### PR TITLE
fix: remove hardcoded paths, add portability fallbacks

### DIFF
--- a/infrastructure/langfuse/docker-compose.yml
+++ b/infrastructure/langfuse/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   langfuse-server:
-    image: langfuse/langfuse:2
+    image: docker.io/langfuse/langfuse:2
     container_name: langfuse
     restart: unless-stopped
     depends_on:
@@ -19,7 +19,7 @@ services:
     mem_limit: 512m
 
   langfuse-db:
-    image: postgres:15-alpine
+    image: docker.io/library/postgres:15-alpine
     container_name: langfuse-db
     restart: unless-stopped
     environment:

--- a/infrastructure/memory/sidecar/aletheia_memory/config.py
+++ b/infrastructure/memory/sidecar/aletheia_memory/config.py
@@ -68,14 +68,21 @@ MEM0_CONFIG = {
             "api_key": ANTHROPIC_API_KEY,
         },
     },
-    "embedder": {
-        "provider": "openai",
-        "config": {
-            "model": "voyage-3-large",
-            "api_key": VOYAGE_API_KEY,
-            "openai_base_url": "https://api.voyageai.com/v1",
-        },
-    },
+    "embedder": (
+        {
+            "provider": "openai",
+            "config": {
+                "model": "voyage-3-large",
+                "api_key": VOYAGE_API_KEY,
+                "openai_base_url": "https://api.voyageai.com/v1",
+            },
+        } if VOYAGE_API_KEY else {
+            "provider": "huggingface",
+            "config": {
+                "model": "BAAI/bge-large-en-v1.5",
+            },
+        }
+    ),
     "vector_store": {
         "provider": "qdrant",
         "config": {

--- a/infrastructure/prosoche/prosoche/daemon.py
+++ b/infrastructure/prosoche/prosoche/daemon.py
@@ -2,6 +2,7 @@
 # Prosoche daemon — adaptive attention engine for Aletheia
 from __future__ import annotations
 
+import os
 import signal
 import sys
 import time
@@ -35,7 +36,7 @@ COLLECTORS = {
 
 
 class ProsocheDaemon:
-    def __init__(self, config_path: str | Path):
+    def __init__(self, config_path: str | Path | None = None):
         self.config = load_config(config_path)
         self.nous_root = Path(self.config["nous_root"])
         self.nous_ids = get_nous_ids(self.config)
@@ -50,7 +51,8 @@ class ProsocheDaemon:
             cooldown_seconds=budget_cfg.get("cooldown_after_wake_seconds", 300),
         )
 
-        data_dir = Path(self.config.get("data_dir", "/mnt/ssd/aletheia/shared/prosoche"))
+        fallback = os.environ.get("ALETHEIA_ROOT", str(Path(__file__).resolve().parents[3]))
+        data_dir = Path(self.config.get("data_dir", f"{fallback}/shared/prosoche"))
         self.activity_model = ActivityModel(data_dir)
 
     async def run(self) -> None:
@@ -165,7 +167,7 @@ class ProsocheDaemon:
 
 
 def main() -> None:
-    config_path = sys.argv[1] if len(sys.argv) > 1 else "/mnt/ssd/aletheia/infrastructure/prosoche/config.yaml"
+    config_path = sys.argv[1] if len(sys.argv) > 1 else None
 
     daemon = ProsocheDaemon(config_path)
 


### PR DESCRIPTION
## Summary

- **Prosoche config**: expand `${VAR}` references in config.yaml values via `_expand_env()`. Resolve default config path from `ALETHEIA_ROOT` env var or `Path(__file__)` relative traversal instead of hardcoded `/mnt/ssd/aletheia/`
- **Mem0 sidecar**: fall back to HuggingFace `BAAI/bge-large-en-v1.5` embeddings when `VOYAGE_API_KEY` is not set, so the sidecar starts without a paid API key
- **Langfuse compose**: fully qualify Docker Hub image refs (`docker.io/langfuse/langfuse:2`, `docker.io/library/postgres:15-alpine`) for podman compatibility

## Motivation

The prosoche daemon and its config loader had `/mnt/ssd/aletheia/` hardcoded in three places, making it unusable on any other machine. The mem0 sidecar required a Voyage API key with no fallback. The langfuse compose file used short image names that fail on podman with `short-name resolution enforced`.

## Test plan

- [ ] `cd infrastructure/prosoche && python -c "from prosoche.config import load_config; load_config()"` resolves config without explicit path
- [ ] Config values with `${ALETHEIA_ROOT}` expand correctly
- [ ] Mem0 sidecar starts with `VOYAGE_API_KEY=""` using HuggingFace embeddings
- [ ] `podman compose up -d` in `infrastructure/langfuse/` pulls images without short-name errors