### PR TITLE
feat(ui): live tool activity feed, subtle abort, message queueing

### DIFF
--- a/ui/src/components/chat/MessageList.svelte
+++ b/ui/src/components/chat/MessageList.svelte
@@ -40,7 +40,6 @@
     }
   }
 
-  // Auto-scroll when new content arrives and user is near bottom
   $effect(() => {
     void messages.length;
     void streamingText;
@@ -51,10 +50,44 @@
     }
   });
 
-  function streamingToolSummary(tools: ToolCallState[]): string {
-    const running = tools.filter((t) => t.status === "running").length;
-    if (running > 0) return `${tools.length} tools (${running} running...)`;
-    return `${tools.length} tool${tools.length === 1 ? "" : "s"} used`;
+  /** Humanize a tool name into a readable activity label */
+  function humanizeTool(tc: ToolCallState): string {
+    const name = tc.name;
+    // Common tool names → human-readable
+    switch (name) {
+      case "exec": return "Running command";
+      case "read": return "Reading file";
+      case "write": return "Writing file";
+      case "edit": return "Editing file";
+      case "grep": return "Searching files";
+      case "find": return "Finding files";
+      case "ls": return "Listing directory";
+      case "web_search": return "Searching web";
+      case "web_fetch": return "Fetching page";
+      case "mem0_search": return "Searching memory";
+      case "blackboard": return "Checking blackboard";
+      case "sessions_send": return "Messaging agent";
+      case "sessions_ask": return "Asking agent";
+      case "sessions_spawn": return "Spawning worker";
+      case "message": return "Sending message";
+      case "enable_tool": return "Enabling tool";
+      default: return name.replace(/_/g, " ");
+    }
+  }
+
+  function toolStatusIcon(status: string): string {
+    switch (status) {
+      case "running": return "◌";
+      case "complete": return "✓";
+      case "error": return "✕";
+      default: return "·";
+    }
+  }
+
+  function formatMs(ms?: number): string {
+    if (ms == null) return "";
+    if (ms < 1000) return `${ms}ms`;
+    return `${(ms / 1000).toFixed(1)}s`;
   }
 </script>
 
@@ -84,14 +117,22 @@
         </div>
         <div class="chat-body">
           {#if activeToolCalls.length > 0}
-            <button
-              class="chat-tool-pill"
-              class:has-error={activeToolCalls.some((t) => t.status === "error")}
-              onclick={() => onToolClick?.(activeToolCalls)}
-            >
-              <span class="chat-tool-icon">⚙</span>
-              {streamingToolSummary(activeToolCalls)}
-            </button>
+            <div class="activity-feed">
+              {#each activeToolCalls as tc (tc.id)}
+                <div class="activity-item" class:running={tc.status === "running"} class:error={tc.status === "error"}>
+                  <span class="activity-status" class:running={tc.status === "running"} class:complete={tc.status === "complete"} class:error={tc.status === "error"}>
+                    {toolStatusIcon(tc.status)}
+                  </span>
+                  <span class="activity-label">{humanizeTool(tc)}</span>
+                  {#if tc.durationMs != null}
+                    <span class="activity-duration">{formatMs(tc.durationMs)}</span>
+                  {/if}
+                  {#if tc.status === "running"}
+                    <span class="activity-spinner"></span>
+                  {/if}
+                </div>
+              {/each}
+            </div>
           {/if}
           {#if streamingText}
             <div class="chat-content">
@@ -152,6 +193,70 @@
     color: #fff;
     letter-spacing: 1px;
   }
+
+  /* Live activity feed during streaming */
+  .activity-feed {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    margin-bottom: 8px;
+    font-size: 12px;
+    font-family: var(--font-mono);
+  }
+  .activity-item {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 2px 0;
+    color: var(--text-secondary);
+    transition: opacity 0.15s;
+  }
+  .activity-item.running {
+    color: var(--text);
+  }
+  .activity-item.error {
+    color: var(--red);
+  }
+  .activity-status {
+    width: 14px;
+    text-align: center;
+    flex-shrink: 0;
+    font-size: 11px;
+  }
+  .activity-status.running {
+    color: var(--accent);
+  }
+  .activity-status.complete {
+    color: var(--green);
+  }
+  .activity-status.error {
+    color: var(--red);
+  }
+  .activity-label {
+    flex: 1;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .activity-duration {
+    color: var(--text-muted);
+    font-size: 11px;
+    flex-shrink: 0;
+  }
+  .activity-spinner {
+    width: 10px;
+    height: 10px;
+    border: 1.5px solid var(--border);
+    border-top-color: var(--accent);
+    border-radius: 50%;
+    animation: spin 0.8s linear infinite;
+    flex-shrink: 0;
+  }
+  @keyframes spin {
+    to { transform: rotate(360deg); }
+  }
+
   .scroll-btn {
     position: sticky;
     bottom: 12px;


### PR DESCRIPTION
## What

Three UX improvements to the streaming experience.

### 1. Live tool activity feed
Replaces the collapsed "3 tools running..." pill with an inline activity stream during streaming:

```
◌ Running command          ⟳
✓ Reading file            0.2s
✓ Writing file            0.1s
◌ Running tests            ⟳
```

Tool names humanized: `exec` → "Running command", `read` → "Reading file", `grep` → "Searching files", etc. Visible by default — no click required. Completed tool pills still collapse after the turn.

### 2. Subtle abort button
The full-width "Stop generating" button that replaced the entire input area is gone. Now a small `■` stop button sits inside the input wrapper. The input textarea is **always available** during streaming.

### 3. Message queueing
Type while the agent is working. Hit Enter/Send (button turns yellow, reads "Queue"). Message queues with a dismissible indicator above input. Auto-sends when the current turn completes.

## Verification
- ✅ Build clean (201KB JS, 22.3KB CSS)
- ✅ 29/29 tests pass
- ✅ svelte-check: 0 errors, 0 warnings
- ✅ oxlint: clean