### PR TITLE
feat(ui): collapsible sidebar, slash commands, copy code blocks

### DIFF
--- a/ui/src/components/layout/Sidebar.svelte
+++ b/ui/src/components/layout/Sidebar.svelte
@@ -12,6 +12,15 @@
     onAgentSelect?: () => void;
   } = $props();
 
+  // Persist collapse state (desktop only — mobile uses the Layout-controlled collapsed prop)
+  const COLLAPSE_KEY = "aletheia_sidebar_agents_collapsed";
+  let agentsCollapsed = $state(localStorage.getItem(COLLAPSE_KEY) === "true");
+
+  function toggleAgents() {
+    agentsCollapsed = !agentsCollapsed;
+    localStorage.setItem(COLLAPSE_KEY, String(agentsCollapsed));
+  }
+
   function handleAgentClick(id: string) {
     setActiveAgent(id);
     loadSessions(id);
@@ -28,15 +37,22 @@
 
 <aside class="sidebar" class:collapsed>
   <div class="section">
-    <div class="section-list">
-      {#each getAgents() as agent}
-        <AgentCard
-          {agent}
-          isActive={agent.id === getActiveAgentId()}
-          onclick={() => handleAgentClick(agent.id)}
-        />
-      {/each}
-    </div>
+    <button class="section-header" onclick={toggleAgents}>
+      <span class="chevron" class:open={!agentsCollapsed}>›</span>
+      <span class="section-title">Agents</span>
+      <span class="agent-count">{getAgents().length}</span>
+    </button>
+    {#if !agentsCollapsed}
+      <div class="section-list">
+        {#each getAgents() as agent}
+          <AgentCard
+            {agent}
+            isActive={agent.id === getActiveAgentId()}
+            onclick={() => handleAgentClick(agent.id)}
+          />
+        {/each}
+      </div>
+    {/if}
   </div>
 </aside>
 
@@ -55,10 +71,52 @@
   .section {
     padding: 8px;
   }
+  .section-header {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    width: 100%;
+    padding: 4px 12px 8px;
+    background: none;
+    border: none;
+    color: var(--text-muted);
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    text-align: left;
+    transition: color 0.15s;
+  }
+  .section-header:hover {
+    color: var(--text-secondary);
+  }
+  .chevron {
+    font-size: 12px;
+    transition: transform 0.15s ease;
+    flex-shrink: 0;
+  }
+  .chevron.open {
+    transform: rotate(90deg);
+  }
+  .section-title {
+    flex: 1;
+  }
+  .agent-count {
+    font-size: 10px;
+    color: var(--text-muted);
+    background: var(--surface);
+    padding: 1px 6px;
+    border-radius: 8px;
+  }
   .section-list {
     display: flex;
     flex-direction: column;
     gap: 2px;
+    animation: section-open 0.15s ease;
+  }
+  @keyframes section-open {
+    from { opacity: 0; transform: translateY(-4px); }
+    to { opacity: 1; transform: translateY(0); }
   }
 
   @media (max-width: 768px) {

--- a/ui/src/stores/chat.svelte.ts
+++ b/ui/src/stores/chat.svelte.ts
@@ -49,6 +49,17 @@ export function clearMessages(): void {
   error = null;
 }
 
+/** Inject a local-only message (not sent to any agent) */
+export function injectLocalMessage(content: string): void {
+  const msg: ChatMessage = {
+    id: `system-${Date.now()}`,
+    role: "assistant",
+    content,
+    timestamp: new Date().toISOString(),
+  };
+  messages = [...messages, msg];
+}
+
 export async function sendMessage(
   agentId: string,
   text: string,


### PR DESCRIPTION
## Changes

### Collapsible agent list
- Chevron toggle (›/▾) with smooth open/close animation
- Agent count badge shown when collapsed
- State persisted in localStorage
- Brings back the 'Agents' header that was removed, but as an interactive collapsible

### More slash commands
- `/switch <name>` — change active agent from input (matches name or id, case-insensitive)
- `/help` — renders all available commands as a local message in chat (no server round-trip)

### Copy button on code blocks
- Appears on hover over any `<pre>` block
- Uses Clipboard API for one-click copy
- 'Copied!' feedback with green highlight for 2 seconds

### Other
- `injectLocalMessage()` in chat store for UI-only messages
- `loadAgents()` re-parallelized with `Promise.allSettled` (lost in prior merge)

## Verification
- ✅ Build: 203KB JS, 23.7KB CSS
- ✅ 29/29 tests pass
- ✅ svelte-check: 0 errors
- ✅ oxlint: clean