### PR TITLE
feat: distillation preservation, export API, streaming recovery

### DIFF
--- a/infrastructure/runtime/src/pylon/ui.test.ts
+++ b/infrastructure/runtime/src/pylon/ui.test.ts
@@ -28,18 +28,16 @@ describe("createUiRoutes", () => {
     expect(app.fetch).toBeDefined();
   });
 
-  it("/ui returns HTML dashboard", async () => {
+  it("/ui returns HTML", async () => {
     const app = createUiRoutes(makeConfig(), null, makeStore());
     const res = await app.request("/ui");
     expect(res.status).toBe(200);
     const html = await res.text();
     expect(html).toContain("<!DOCTYPE html>");
     expect(html).toContain("Aletheia");
-    expect(html).toContain("Syn");
-    expect(html).toContain("Eiron");
   });
 
-  it("/ui/* returns same dashboard HTML", async () => {
+  it("/ui/* serves SPA (fallback to index.html)", async () => {
     const app = createUiRoutes(makeConfig(), null, makeStore());
     const res = await app.request("/ui/agents/syn");
     expect(res.status).toBe(200);
@@ -54,35 +52,11 @@ describe("createUiRoutes", () => {
     expect(res.headers.get("Content-Type")).toBe("text/event-stream");
     expect(res.headers.get("Cache-Control")).toBe("no-cache");
   });
-
-  it("fallback dashboard contains agent names", async () => {
-    const app = createUiRoutes(makeConfig(), null, makeStore());
-    const res = await app.request("/ui");
-    const html = await res.text();
-    expect(html).toContain("Syn");
-    expect(html).toContain("Eiron");
-  });
-
-  it("fallback dashboard includes CSS styles", async () => {
-    const app = createUiRoutes(makeConfig(), null, makeStore());
-    const res = await app.request("/ui");
-    const html = await res.text();
-    expect(html).toContain("<style>");
-    expect(html).toContain("--bg:");
-  });
-
-  it("fallback dashboard shows build instructions", async () => {
-    const app = createUiRoutes(makeConfig(), null, makeStore());
-    const res = await app.request("/ui");
-    const html = await res.text();
-    expect(html).toContain("npm run build");
-  });
 });
 
 describe("broadcastEvent", () => {
   it("is exported and callable", () => {
     expect(typeof broadcastEvent).toBe("function");
-    // Should not throw even when no clients connected
     broadcastEvent("test", { hello: "world" });
   });
 });

--- a/infrastructure/runtime/src/pylon/ui.ts
+++ b/infrastructure/runtime/src/pylon/ui.ts
@@ -39,9 +39,13 @@ const MIME_TYPES: Record<string, string> = {
   ".map": "application/json",
 };
 
+interface ManagerLike {
+  getActiveTurnsByNous(): Record<string, number>;
+}
+
 export function createUiRoutes(
   config: AletheiaConfig,
-  _manager: unknown,
+  manager: ManagerLike | null,
   store: SessionStore,
 ): Hono {
   const app = new Hono();
@@ -72,6 +76,7 @@ export function createUiRoutes(
           })),
           uptime: Math.round(process.uptime()),
           usage: metrics.usage,
+          activeTurns: manager?.getActiveTurnsByNous() ?? {},
         };
         controller.enqueue(
           new TextEncoder().encode(`event: init\ndata: ${JSON.stringify(initData)}\n\n`),

--- a/infrastructure/runtime/src/taxis/schema.ts
+++ b/infrastructure/runtime/src/taxis/schema.ts
@@ -47,6 +47,8 @@ const CompactionConfig = z
     reserveTokensFloor: z.number().default(8000),
     maxHistoryShare: z.number().default(0.7),
     distillationModel: z.string().default("claude-haiku-4-5-20251001"),
+    preserveRecentMessages: z.number().default(4),
+    preserveRecentMaxTokens: z.number().default(4000),
     memoryFlush: z
       .object({
         enabled: z.boolean().default(true),

--- a/shared/competence/model.json
+++ b/shared/competence/model.json
@@ -28,5 +28,27 @@
       }
     },
     "overallScore": 0.5033333333333335
+  },
+  "chiron": {
+    "nousId": "chiron",
+    "domains": {
+      "web": {
+        "domain": "web",
+        "score": 0.6400000000000001,
+        "corrections": 0,
+        "successes": 7,
+        "disagreements": 0,
+        "lastUpdated": "2026-02-18T14:26:47.003Z"
+      },
+      "test-deploy": {
+        "domain": "test-deploy",
+        "score": 0.6200000000000001,
+        "corrections": 0,
+        "successes": 6,
+        "disagreements": 0,
+        "lastUpdated": "2026-02-18T15:14:21.241Z"
+      }
+    },
+    "overallScore": 0.6300000000000001
   }
 }

--- a/ui/src/components/graph/GraphView.svelte
+++ b/ui/src/components/graph/GraphView.svelte
@@ -196,6 +196,12 @@
         >{cid}</button>
       {/each}
     </div>
+    <button
+      class="pill refresh-btn"
+      onclick={() => loadGraph()}
+      disabled={getLoading()}
+      title="Reload graph data"
+    >{getLoading() ? "..." : "Refresh"}</button>
     <span class="graph-stats">
       {getGraphData().nodes.length} nodes · {getGraphData().edges.length} edges
     </span>

--- a/ui/src/components/layout/Sidebar.svelte
+++ b/ui/src/components/layout/Sidebar.svelte
@@ -27,6 +27,7 @@
 </script>
 
 <aside class="sidebar" class:collapsed>
+  <div class="section-header">Agents</div>
   <div class="agent-list">
     {#each getAgents() as agent}
       <AgentCard
@@ -56,6 +57,17 @@
     opacity: 0;
     border-right: none;
     pointer-events: none;
+  }
+  .section-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 4px 12px 8px;
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    color: var(--text-muted);
   }
   .agent-list {
     display: flex;

--- a/ui/src/stores/chat.svelte.ts
+++ b/ui/src/stores/chat.svelte.ts
@@ -5,6 +5,7 @@ import type { ChatMessage, ToolCallState, HistoryMessage, MediaItem } from "../l
 interface AgentChatState {
   messages: ChatMessage[];
   isStreaming: boolean;
+  remoteStreaming: boolean;
   streamingText: string;
   activeToolCalls: ToolCallState[];
   error: string | null;
@@ -16,6 +17,7 @@ let states = $state<Record<string, AgentChatState>>({});
 const EMPTY: AgentChatState = {
   messages: [],
   isStreaming: false,
+  remoteStreaming: false,
   streamingText: "",
   activeToolCalls: [],
   error: null,
@@ -33,6 +35,7 @@ function writeState(agentId: string): AgentChatState {
     states[agentId] = {
       messages: [],
       isStreaming: false,
+      remoteStreaming: false,
       streamingText: "",
       activeToolCalls: [],
       error: null,
@@ -47,7 +50,12 @@ export function getMessages(agentId: string): ChatMessage[] {
 }
 
 export function getIsStreaming(agentId: string): boolean {
-  return readState(agentId).isStreaming;
+  const s = readState(agentId);
+  return s.isStreaming || s.remoteStreaming;
+}
+
+export function setRemoteStreaming(agentId: string, active: boolean): void {
+  writeState(agentId).remoteStreaming = active;
 }
 
 export function getStreamingText(agentId: string): string {


### PR DESCRIPTION
## Summary
- **Distillation preservation window**: Last N messages survive distillation as raw context (default 4 messages, 4000 token cap). Zero changes to retrieval path — preserved messages keep `is_distilled=0`.
- **Export/analytics API**: Three new endpoints for conversation mining — `GET /api/export/stats` (aggregate analytics), `GET /api/export/sessions` (filtered listing), `GET /api/export/sessions/:id` (full session as JSONL).
- **Streaming state recovery**: Browser refresh during active turn now shows "thinking" indicator. `activeTurns` per-agent included in SSE init event; `turn:before`/`turn:after` events drive UI state.
- **Credential file apiKey support**: `~/.aletheia/credentials/anthropic.json` now accepts `apiKey` field (not just OAuth `token`).
- **UI polish**: Refresh button on memory graph, "Agents" section header in sidebar, fixed ui.test.ts for built UI.

## Test plan
- [x] 798 runtime tests passing (81 test files)
- [x] 29 UI tests passing
- [x] Builds clean (runtime + UI)
- [x] Export stats endpoint verified live (688 messages, 5 distillations)
- [x] SSE init event includes `activeTurns: {}` field
- [ ] Manual: trigger distillation, verify last 4 messages preserved as raw context
- [ ] Manual: refresh during active turn, verify streaming indicator recovers