### PR TITLE
fix: structural env injection via typed applyEnv()

### DIFF
--- a/infrastructure/runtime/src/aletheia.ts
+++ b/infrastructure/runtime/src/aletheia.ts
@@ -1,7 +1,7 @@
 // Main orchestration — wire all modules
 import { join } from "node:path";
 import { createLogger } from "./koina/logger.js";
-import { loadConfig } from "./taxis/loader.js";
+import { loadConfig, applyEnv } from "./taxis/loader.js";
 import { paths } from "./taxis/paths.js";
 import { SessionStore } from "./mneme/store.js";
 import { createDefaultRouter, type ProviderRouter } from "./hermeneus/router.js";
@@ -80,15 +80,7 @@ export function createRuntime(configPath?: string): AletheiaRuntime {
 
   const config = loadConfig(configPath);
 
-  // Apply env vars from config before anything reads process.env
-  const configEnv = (config as Record<string, unknown>)["env"];
-  if (configEnv && typeof configEnv === "object") {
-    for (const [key, value] of Object.entries(configEnv as Record<string, string>)) {
-      if (typeof value === "string" && !process.env[key]) {
-        process.env[key] = value;
-      }
-    }
-  }
+  applyEnv(config);
 
   const store = new SessionStore(paths.sessionsDb());
   const router = createDefaultRouter(config.models);


### PR DESCRIPTION
## Summary

- Config env vars (e.g. `ANTHROPIC_API_KEY`) defined in `aletheia.json` were silently not applied to `process.env`, causing auth failures
- Root cause: Zod's `EnvConfig` preprocess wraps flat `{"KEY": "val"}` into `{ vars: {"KEY": "val"} }`. The inline injection code iterated `config.env` directly, found key `"vars"` with an object value, failed `typeof === "string"`, and skipped it
- Moved to a typed `applyEnv()` function in `taxis/loader.ts` that reads `config.env.vars` correctly
- Added 4 tests covering flat format, structured format, no-overwrite, and empty config

## Test plan

- [x] 835/835 tests pass (`npm run build && npx vitest run`)
- [x] Gateway logs `env: set ANTHROPIC_API_KEY from config (sk-a...TgAA)` at startup
- [x] Router logs `Using ANTHROPIC_API_KEY from environment` (no more credential ERROR)
- [x] Chiron authenticates successfully