### PR TITLE
feat: persist distillation summaries to agent workspace memory files

### DIFF
--- a/infrastructure/runtime/src/distillation/workspace-flush.test.ts
+++ b/infrastructure/runtime/src/distillation/workspace-flush.test.ts
@@ -1,0 +1,240 @@
+// Workspace flush tests — distillation memory file writer
+import { describe, it, expect, afterEach } from "vitest";
+import { mkdtempSync, rmSync, readFileSync, existsSync, writeFileSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { flushToWorkspace } from "./workspace-flush.js";
+import type { ExtractionResult } from "./extract.js";
+
+const EMPTY_EXTRACTION: ExtractionResult = {
+  facts: [],
+  decisions: [],
+  openItems: [],
+  keyEntities: [],
+  contradictions: [],
+};
+
+function makeExtraction(overrides: Partial<ExtractionResult> = {}): ExtractionResult {
+  return { ...EMPTY_EXTRACTION, ...overrides };
+}
+
+const dirs: string[] = [];
+
+function tmpDir(): string {
+  const d = mkdtempSync(join(tmpdir(), "workspace-flush-test-"));
+  dirs.push(d);
+  return d;
+}
+
+afterEach(() => {
+  for (const d of dirs.splice(0)) {
+    try { rmSync(d, { recursive: true }); } catch { /* ignore */ }
+  }
+});
+
+describe("flushToWorkspace", () => {
+  it("creates memory directory if missing", () => {
+    const workspace = tmpDir();
+    const result = flushToWorkspace({
+      workspace,
+      nousId: "syn",
+      sessionId: "ses_abc123",
+      distillationNumber: 1,
+      summary: "Did some work today.",
+      extraction: EMPTY_EXTRACTION,
+    });
+
+    expect(result.written).toBe(true);
+    expect(existsSync(join(workspace, "memory"))).toBe(true);
+    expect(existsSync(result.path)).toBe(true);
+  });
+
+  it("writes file header and summary on first write", () => {
+    const workspace = tmpDir();
+    flushToWorkspace({
+      workspace,
+      nousId: "syn",
+      sessionId: "ses_abc123",
+      distillationNumber: 1,
+      summary: "First summary.",
+      extraction: EMPTY_EXTRACTION,
+    });
+
+    const dateStr = new Date().toISOString().slice(0, 10);
+    const content = readFileSync(join(workspace, "memory", `${dateStr}.md`), "utf-8");
+    expect(content).toContain(`# Memory — ${dateStr}`);
+    expect(content).toContain("First summary.");
+    expect(content).toContain("Distillation #1");
+  });
+
+  it("appends to existing file without duplicating header", () => {
+    const workspace = tmpDir();
+
+    flushToWorkspace({
+      workspace,
+      nousId: "syn",
+      sessionId: "ses_abc123",
+      distillationNumber: 1,
+      summary: "First summary.",
+      extraction: EMPTY_EXTRACTION,
+    });
+
+    flushToWorkspace({
+      workspace,
+      nousId: "syn",
+      sessionId: "ses_abc123",
+      distillationNumber: 2,
+      summary: "Second summary.",
+      extraction: EMPTY_EXTRACTION,
+    });
+
+    const dateStr = new Date().toISOString().slice(0, 10);
+    const content = readFileSync(join(workspace, "memory", `${dateStr}.md`), "utf-8");
+
+    expect(content).toContain("First summary.");
+    expect(content).toContain("Second summary.");
+    expect(content).toContain("Distillation #1");
+    expect(content).toContain("Distillation #2");
+
+    // Header appears exactly once
+    const headerCount = (content.match(/^# Memory/gm) ?? []).length;
+    expect(headerCount).toBe(1);
+  });
+
+  it("writes extraction sections when data present", () => {
+    const workspace = tmpDir();
+    flushToWorkspace({
+      workspace,
+      nousId: "syn",
+      sessionId: "ses_abc123",
+      distillationNumber: 1,
+      summary: "Summary with extraction.",
+      extraction: makeExtraction({
+        facts: ["fact one", "fact two"],
+        decisions: ["use TypeScript"],
+        openItems: ["write tests"],
+      }),
+    });
+
+    const dateStr = new Date().toISOString().slice(0, 10);
+    const content = readFileSync(join(workspace, "memory", `${dateStr}.md`), "utf-8");
+    expect(content).toContain("**Facts:** 2");
+    expect(content).toContain("**Decisions:** 1");
+    expect(content).toContain("**Open Items:** 1");
+    expect(content).toContain("- fact one");
+    expect(content).toContain("#### Key Facts");
+    expect(content).toContain("#### Decisions");
+    expect(content).toContain("#### Open Items");
+  });
+
+  it("omits extraction sections when all arrays are empty", () => {
+    const workspace = tmpDir();
+    flushToWorkspace({
+      workspace,
+      nousId: "syn",
+      sessionId: "ses_abc123",
+      distillationNumber: 1,
+      summary: "Just a summary.",
+      extraction: EMPTY_EXTRACTION,
+    });
+
+    const dateStr = new Date().toISOString().slice(0, 10);
+    const content = readFileSync(join(workspace, "memory", `${dateStr}.md`), "utf-8");
+    expect(content).not.toContain("### Extracted");
+    expect(content).not.toContain("#### Key Facts");
+  });
+
+  it("caps facts at 20 and adds overflow note", () => {
+    const workspace = tmpDir();
+    const facts = Array.from({ length: 25 }, (_, i) => `fact ${i + 1}`);
+    flushToWorkspace({
+      workspace,
+      nousId: "syn",
+      sessionId: "ses_abc123",
+      distillationNumber: 1,
+      summary: "Many facts.",
+      extraction: makeExtraction({ facts }),
+    });
+
+    const dateStr = new Date().toISOString().slice(0, 10);
+    const content = readFileSync(join(workspace, "memory", `${dateStr}.md`), "utf-8");
+    expect(content).toContain("- fact 20");
+    expect(content).not.toContain("- fact 21");
+    expect(content).toContain("... and 5 more");
+  });
+
+  it("returns error result when write fails (bad path)", () => {
+    // Use a path where memory dir cannot be created
+    const result = flushToWorkspace({
+      workspace: "/proc/nonexistent-for-test",
+      nousId: "syn",
+      sessionId: "ses_abc123",
+      distillationNumber: 1,
+      summary: "will fail",
+      extraction: EMPTY_EXTRACTION,
+    });
+
+    expect(result.written).toBe(false);
+    expect(result.error).toBeDefined();
+  });
+
+  it("includes contradictions section when present", () => {
+    const workspace = tmpDir();
+    flushToWorkspace({
+      workspace,
+      nousId: "syn",
+      sessionId: "ses_abc123",
+      distillationNumber: 1,
+      summary: "Contradictory session.",
+      extraction: makeExtraction({
+        facts: ["fact"],
+        contradictions: ["previously X, now Y"],
+      }),
+    });
+
+    const dateStr = new Date().toISOString().slice(0, 10);
+    const content = readFileSync(join(workspace, "memory", `${dateStr}.md`), "utf-8");
+    expect(content).toContain("**Contradictions:** 1");
+    expect(content).toContain("#### Contradictions");
+    expect(content).toContain("- previously X, now Y");
+  });
+
+  it("uses existing memory dir without error", () => {
+    const workspace = tmpDir();
+    mkdirSync(join(workspace, "memory"), { recursive: true });
+
+    const result = flushToWorkspace({
+      workspace,
+      nousId: "syn",
+      sessionId: "ses_abc123",
+      distillationNumber: 1,
+      summary: "Dir already exists.",
+      extraction: EMPTY_EXTRACTION,
+    });
+
+    expect(result.written).toBe(true);
+  });
+
+  it("pre-populates file before second flush to verify no duplicate header", () => {
+    const workspace = tmpDir();
+    const dateStr = new Date().toISOString().slice(0, 10);
+    const memDir = join(workspace, "memory");
+    mkdirSync(memDir, { recursive: true });
+    writeFileSync(join(memDir, `${dateStr}.md`), `# Memory — ${dateStr}\n\nexisting content\n`);
+
+    flushToWorkspace({
+      workspace,
+      nousId: "syn",
+      sessionId: "ses_abc123",
+      distillationNumber: 3,
+      summary: "Appended to existing.",
+      extraction: EMPTY_EXTRACTION,
+    });
+
+    const content = readFileSync(join(memDir, `${dateStr}.md`), "utf-8");
+    expect(content).toContain("existing content");
+    expect(content).toContain("Appended to existing.");
+    const headerCount = (content.match(/^# Memory/gm) ?? []).length;
+    expect(headerCount).toBe(1);
+  });
+});

--- a/infrastructure/runtime/src/distillation/workspace-flush.ts
+++ b/infrastructure/runtime/src/distillation/workspace-flush.ts
@@ -1,0 +1,122 @@
+// Distillation workspace flush — write summary + extraction to agent memory file
+import { join } from "node:path";
+import { existsSync, mkdirSync, appendFileSync } from "node:fs";
+import { createLogger } from "../koina/logger.js";
+import type { ExtractionResult } from "./extract.js";
+
+const log = createLogger("distillation:workspace");
+
+export interface WorkspaceFlushOpts {
+  workspace: string;
+  nousId: string;
+  sessionId: string;
+  distillationNumber: number;
+  summary: string;
+  extraction: ExtractionResult;
+}
+
+export interface WorkspaceFlushResult {
+  written: boolean;
+  path: string;
+  error?: string;
+}
+
+export function flushToWorkspace(opts: WorkspaceFlushOpts): WorkspaceFlushResult {
+  const now = new Date();
+  const dateStr = now.toISOString().slice(0, 10);
+  const timeStr = now.toLocaleTimeString("en-US", {
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+    timeZone: process.env["TZ"] ?? "UTC",
+  });
+
+  const memoryDir = join(opts.workspace, "memory");
+  const filePath = join(memoryDir, `${dateStr}.md`);
+
+  try {
+    if (!existsSync(memoryDir)) {
+      mkdirSync(memoryDir, { recursive: true });
+    }
+
+    const sections: string[] = [];
+
+    if (!existsSync(filePath)) {
+      sections.push(`# Memory — ${dateStr}\n`);
+    }
+
+    sections.push(`\n---\n`);
+    sections.push(
+      `## Distillation #${opts.distillationNumber} — ${timeStr} (session: ${opts.sessionId.slice(0, 12)})\n`,
+    );
+
+    sections.push(`### Summary\n`);
+    sections.push(opts.summary.trim());
+    sections.push(``);
+
+    const ext = opts.extraction;
+    const hasFacts = ext.facts.length > 0;
+    const hasDecisions = ext.decisions.length > 0;
+    const hasOpen = ext.openItems.length > 0;
+    const hasContradictions = ext.contradictions.length > 0;
+
+    if (hasFacts || hasDecisions || hasOpen) {
+      sections.push(`### Extracted`);
+      sections.push(`- **Facts:** ${ext.facts.length}`);
+      sections.push(`- **Decisions:** ${ext.decisions.length}`);
+      sections.push(`- **Open Items:** ${ext.openItems.length}`);
+      if (hasContradictions) {
+        sections.push(`- **Contradictions:** ${ext.contradictions.length}`);
+      }
+      sections.push(``);
+    }
+
+    if (hasFacts) {
+      sections.push(`#### Key Facts`);
+      const capped = ext.facts.slice(0, 20);
+      for (const fact of capped) {
+        sections.push(`- ${fact}`);
+      }
+      if (ext.facts.length > 20) {
+        sections.push(`- ... and ${ext.facts.length - 20} more`);
+      }
+      sections.push(``);
+    }
+
+    if (hasDecisions) {
+      sections.push(`#### Decisions`);
+      for (const d of ext.decisions) {
+        sections.push(`- ${d}`);
+      }
+      sections.push(``);
+    }
+
+    if (hasOpen) {
+      sections.push(`#### Open Items`);
+      for (const item of ext.openItems) {
+        sections.push(`- ${item}`);
+      }
+      sections.push(``);
+    }
+
+    if (hasContradictions) {
+      sections.push(`#### Contradictions`);
+      for (const c of ext.contradictions) {
+        sections.push(`- ${c}`);
+      }
+      sections.push(``);
+    }
+
+    const content = sections.join("\n") + "\n";
+    appendFileSync(filePath, content, "utf-8");
+
+    log.info(
+      `Workspace memory written: ${filePath} (distillation #${opts.distillationNumber})`,
+    );
+    return { written: true, path: filePath };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    log.error(`Workspace memory flush failed for ${opts.nousId}: ${msg}`);
+    return { written: false, path: filePath, error: msg };
+  }
+}

--- a/infrastructure/runtime/src/nous/manager.ts
+++ b/infrastructure/runtime/src/nous/manager.ts
@@ -513,6 +513,7 @@ export class NousManager {
               extractionModel: distillModel, summaryModel: distillModel,
               preserveRecentMessages: compaction.preserveRecentMessages,
               preserveRecentMaxTokens: compaction.preserveRecentMaxTokens,
+              ...(workspace ? { workspace } : {}),
               ...(this.plugins ? { plugins: this.plugins } : {}),
             });
           }
@@ -1033,6 +1034,7 @@ export class NousManager {
               summaryModel: distillModel,
               preserveRecentMessages: compaction.preserveRecentMessages,
               preserveRecentMaxTokens: compaction.preserveRecentMaxTokens,
+              ...(workspace ? { workspace } : {}),
               ...(this.plugins ? { plugins: this.plugins } : {}),
             });
           }
@@ -1362,6 +1364,9 @@ export class NousManager {
     const session = this.store.findSessionById(sessionId);
     if (!session) throw new Error(`Session ${sessionId} not found`);
 
+    const nous = resolveNous(this.config, session.nousId);
+    const workspace = nous ? resolveWorkspace(this.config, nous) : undefined;
+
     log.info(`Manual distillation triggered for session ${sessionId}`);
     await distillSession(this.store, this.router, sessionId, session.nousId, {
       triggerThreshold: distillThreshold,
@@ -1370,6 +1375,7 @@ export class NousManager {
       summaryModel: distillModel,
       preserveRecentMessages: compaction.preserveRecentMessages,
       preserveRecentMaxTokens: compaction.preserveRecentMaxTokens,
+      ...(workspace ? { workspace } : {}),
       ...(this.plugins ? { plugins: this.plugins } : {}),
     });
   }


### PR DESCRIPTION
## Summary

Implements the distillation memory persistence spec from `docs/spec-distillation-memory-persistence.md` (authored by Syn).

- **New `distillation/workspace-flush.ts`**: Pure function that appends distillation output to `{workspace}/memory/YYYY-MM-DD.md` — append-only, creates dir if missing, non-throwing (returns error result rather than raising)
- **`distillation/pipeline.ts`**: New optional `workspace` field on `DistillationOpts`; calls `flushToWorkspace` after `recordDistillation`, before event bus emit
- **`nous/manager.ts`**: All 3 `distillSession` call sites now pass `workspace` — both auto-distill paths and `triggerDistillation()`
- **Tests**: 9 new tests in `workspace-flush.test.ts` + 2 integration tests in `pipeline.test.ts`

## Behaviour

Every auto-triggered and manually-triggered distillation now produces a dated markdown file in the agent's workspace:
```
nous/syn/memory/2026-02-19.md
```
Multiple distillations in a day append to the same file. The file is human-readable with summary + extracted facts/decisions/open items per cycle. File writes never fail the distillation pipeline.

## Test plan

- [ ] CI passes (typecheck, lint, test-unit, build)
- [ ] `workspace-flush.test.ts` — 9 cases: dir creation, append, empty extraction, 20-fact cap, error handling, header dedup, contradictions
- [ ] `pipeline.test.ts` — workspace flush integration: file written when workspace provided, pipeline succeeds when flush fails
- [ ] All 3 manager.ts call sites pass workspace (streaming, non-streaming, manual trigger)