### PR TITLE
feat: configurable instance branding

### DIFF
--- a/infrastructure/runtime/src/pylon/ui.test.ts
+++ b/infrastructure/runtime/src/pylon/ui.test.ts
@@ -34,7 +34,7 @@ describe("createUiRoutes", () => {
     expect(res.status).toBe(200);
     const html = await res.text();
     expect(html).toContain("<!DOCTYPE html>");
-    expect(html).toContain("Aletheia");
+    expect(html).toContain("<title>");
   });
 
   it("/ui/* serves SPA (fallback to index.html)", async () => {

--- a/infrastructure/runtime/src/taxis/loader.ts
+++ b/infrastructure/runtime/src/taxis/loader.ts
@@ -103,7 +103,7 @@ export function applyEnv(config: AletheiaConfig): number {
 
 const KNOWN_TOP_KEYS = new Set([
   "agents", "bindings", "channels", "gateway", "plugins",
-  "session", "cron", "models", "env", "watchdog",
+  "session", "cron", "models", "env", "watchdog", "branding",
 ]);
 
 const KNOWN_NOUS_KEYS = new Set([

--- a/infrastructure/runtime/src/taxis/schema.ts
+++ b/infrastructure/runtime/src/taxis/schema.ts
@@ -359,6 +359,14 @@ const WatchdogConfig = z
   })
   .default({});
 
+const BrandingConfig = z
+  .object({
+    name: z.string().default("Aletheia"),
+    tagline: z.string().optional(),
+    favicon: z.string().optional(),
+  })
+  .default({});
+
 // passthrough() preserves unknown top-level fields (meta, wizard, browser, tools, etc.)
 // so they survive round-tripping without silent data loss
 export const AletheiaConfigSchema = z.object({
@@ -372,6 +380,7 @@ export const AletheiaConfigSchema = z.object({
   models: ModelsConfig.default({}),
   env: EnvConfig.default({}),
   watchdog: WatchdogConfig.default({}),
+  branding: BrandingConfig,
 }).passthrough();
 
 export type AletheiaConfig = z.infer<typeof AletheiaConfigSchema>;

--- a/ui/index.html
+++ b/ui/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Aletheia</title>
+  <title>Loading...</title>
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>⚡</text></svg>" />
 </head>
 <body>

--- a/ui/src/App.svelte
+++ b/ui/src/App.svelte
@@ -2,10 +2,12 @@
   import Layout from "./components/layout/Layout.svelte";
   import { initConnection } from "./stores/connection.svelte";
   import { loadAgents } from "./stores/agents.svelte";
+  import { loadBranding } from "./stores/branding.svelte";
   import { getToken } from "./lib/api";
 
   $effect(() => {
     if (getToken()) {
+      loadBranding();
       loadAgents();
       initConnection();
     }

--- a/ui/src/components/layout/Layout.svelte
+++ b/ui/src/components/layout/Layout.svelte
@@ -5,12 +5,16 @@
   import MetricsView from "../metrics/MetricsView.svelte";
   import GraphView from "../graph/GraphView.svelte";
   import { getToken, setToken } from "../../lib/api";
+  import { getBrandName, loadBranding } from "../../stores/branding.svelte";
 
   type ViewId = "chat" | "metrics" | "graph";
 
   const SIDEBAR_KEY = "aletheia_sidebar_collapsed";
 
   let activeView = $state<ViewId>("chat");
+  // Load branding before auth so login screen shows the right name
+  loadBranding();
+
   let hasToken = $state(!!getToken());
   let tokenValue = $state("");
   let sidebarCollapsed = $state(localStorage.getItem(SIDEBAR_KEY) === "true");
@@ -40,7 +44,7 @@
 {#if !hasToken}
   <div class="token-setup">
     <div class="token-card">
-      <h1>Aletheia</h1>
+      <h1>{getBrandName()}</h1>
       <p>Enter your gateway authentication token to get started.</p>
       <form onsubmit={handleTokenSubmit}>
         <input

--- a/ui/src/components/layout/TopBar.svelte
+++ b/ui/src/components/layout/TopBar.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { getConnectionStatus } from "../../stores/connection.svelte";
   import { getActiveAgent } from "../../stores/agents.svelte";
+  import { getBrandName } from "../../stores/branding.svelte";
   import { getToken, setToken, clearToken } from "../../lib/api";
 
   type ViewId = "chat" | "metrics" | "graph";
@@ -45,7 +46,7 @@
         <line x1="6.5" y1="2" x2="6.5" y2="16" stroke="currentColor" stroke-width="1.5"/>
       </svg>
     </button>
-    <h1 class="title">Aletheia</h1>
+    <h1 class="title">{getBrandName()}</h1>
     <span class="status-dot" class:connected={getConnectionStatus() === "connected"} class:connecting={getConnectionStatus() === "connecting"}></span>
     {#if agent}
       <span class="active-agent">

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -38,6 +38,16 @@ async function fetchJson<T>(path: string, opts?: RequestInit): Promise<T> {
   return res.json();
 }
 
+export interface Branding {
+  name: string;
+  tagline?: string;
+  favicon?: string;
+}
+
+export async function fetchBranding(): Promise<Branding> {
+  return fetchJson("/api/branding");
+}
+
 export async function fetchAgents(): Promise<Agent[]> {
   const data = await fetchJson<{ agents: Agent[] }>("/api/agents");
   return data.agents;

--- a/ui/src/stores/branding.svelte.ts
+++ b/ui/src/stores/branding.svelte.ts
@@ -1,0 +1,29 @@
+import { fetchBranding, type Branding } from "../lib/api";
+
+const DEFAULT: Branding = { name: "Aletheia" };
+
+let branding = $state<Branding>({ ...DEFAULT });
+let loaded = $state(false);
+
+export function getBranding(): Branding {
+  return branding;
+}
+
+export function getBrandName(): string {
+  return branding.name;
+}
+
+export async function loadBranding(): Promise<void> {
+  if (loaded) return;
+  try {
+    branding = await fetchBranding();
+    document.title = branding.name;
+    if (branding.favicon) {
+      const link = document.querySelector("link[rel='icon']") as HTMLLinkElement | null;
+      if (link) link.href = branding.favicon;
+    }
+  } catch {
+    // API unavailable — keep defaults
+  }
+  loaded = true;
+}


### PR DESCRIPTION
## Summary

- Adds `branding` config section with `name`, `tagline`, and `favicon` fields (defaults to "Aletheia")
- UI reads branding from `GET /api/branding` (public endpoint, no auth) and dynamically sets page title, top bar header, and login screen heading
- Fixes identity endpoint fallback: when `IDENTITY.md` is missing from workspace, falls back to `config.identity.emoji` instead of returning `null`
- Basic auth realm now uses configured brand name

Anyone who forks/deploys can set their instance name in config without touching source:
```json
{ "branding": { "name": "MyInstance" } }
```

## Files changed

| Area | File | Change |
|------|------|--------|
| Schema | `taxis/schema.ts` | Add `BrandingConfig` |
| Schema | `taxis/loader.ts` | Add "branding" to known keys |
| Server | `pylon/server.ts` | `/api/branding` endpoint (public), identity fallback fix, auth realm |
| UI | `stores/branding.svelte.ts` | New reactive branding store |
| UI | `lib/api.ts` | `fetchBranding()` |
| UI | `App.svelte`, `Layout.svelte`, `TopBar.svelte` | Replace hardcoded "Aletheia" with dynamic brand name |
| UI | `index.html` | Generic title (JS sets it dynamically) |

## Test plan

- [x] 831/831 tests pass
- [x] Runtime builds clean
- [x] UI builds clean
- [x] Default behavior unchanged (no `branding` config = "Aletheia")
- [ ] Set `branding.name` in config, verify login screen + top bar show custom name
- [ ] Verify page title updates dynamically