### PR TITLE
feat: graph visualization with community clouds and progressive loading

### DIFF
--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -90,8 +90,26 @@ export async function fetchSessionCosts(sessionId: string): Promise<unknown> {
   return fetchJson(`/api/costs/session/${sessionId}`);
 }
 
-export async function fetchGraphExport(community?: number): Promise<GraphData> {
-  const params = community !== undefined ? `?community=${community}` : "";
-  const data = await fetchJson<{ ok: boolean } & GraphData>(`/api/memory/graph/export${params}`);
-  return { nodes: data.nodes, edges: data.edges, communities: data.communities };
+export interface GraphExportParams {
+  mode?: "top" | "community" | "all";
+  limit?: number;
+  community?: number;
+}
+
+export async function fetchGraphExport(params?: GraphExportParams): Promise<GraphData> {
+  const sp = new URLSearchParams();
+  if (params?.mode) sp.set("mode", params.mode);
+  if (params?.limit) sp.set("limit", String(params.limit));
+  if (params?.community !== undefined) sp.set("community", String(params.community));
+  const qs = sp.toString();
+  const data = await fetchJson<{ ok: boolean } & GraphData>(
+    `/api/memory/graph/export${qs ? `?${qs}` : ""}`,
+  );
+  return {
+    nodes: data.nodes,
+    edges: data.edges,
+    communities: data.communities,
+    community_meta: data.community_meta ?? [],
+    total_nodes: data.total_nodes ?? data.nodes.length,
+  };
 }

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -131,10 +131,18 @@ export interface GraphEdge {
   rel_type: string;
 }
 
+export interface CommunityMeta {
+  id: number;
+  size: number;
+  centroid_node: string;
+}
+
 export interface GraphData {
   nodes: GraphNode[];
   edges: GraphEdge[];
   communities: number;
+  community_meta: CommunityMeta[];
+  total_nodes: number;
 }
 
 export interface CostSummary {

--- a/ui/src/stores/graph.svelte.ts
+++ b/ui/src/stores/graph.svelte.ts
@@ -1,8 +1,8 @@
 // Graph visualization store
-import { fetchGraphExport } from "../lib/api";
-import type { GraphData, GraphNode, GraphEdge } from "../lib/types";
+import { fetchGraphExport, type GraphExportParams } from "../lib/api";
+import type { GraphData, GraphNode, GraphEdge, CommunityMeta } from "../lib/types";
 
-const EMPTY: GraphData = { nodes: [], edges: [], communities: 0 };
+const EMPTY: GraphData = { nodes: [], edges: [], communities: 0, community_meta: [], total_nodes: 0 };
 
 let graphData = $state<GraphData>(EMPTY);
 let loading = $state(false);
@@ -10,6 +10,8 @@ let error = $state<string | null>(null);
 let selectedNodeId = $state<string | null>(null);
 let highlightedCommunity = $state<number | null>(null);
 let searchQuery = $state("");
+let loadedMode = $state<"top" | "community" | "all">("top");
+let loadedLimit = $state(200);
 
 export function getGraphData(): GraphData {
   return graphData;
@@ -73,11 +75,29 @@ export function getCommunityIds(): number[] {
   return [...ids].sort((a, b) => a - b);
 }
 
-export async function loadGraph(community?: number): Promise<void> {
+export function getLoadedMode(): string {
+  return loadedMode;
+}
+
+export function getLoadedLimit(): number {
+  return loadedLimit;
+}
+
+export function getTotalNodes(): number {
+  return graphData.total_nodes;
+}
+
+export function getCommunityMeta(): CommunityMeta[] {
+  return graphData.community_meta;
+}
+
+export async function loadGraph(params?: GraphExportParams): Promise<void> {
   loading = true;
   error = null;
   try {
-    graphData = await fetchGraphExport(community);
+    graphData = await fetchGraphExport(params);
+    loadedMode = params?.mode ?? "top";
+    loadedLimit = params?.limit ?? 200;
   } catch (e) {
     error = e instanceof Error ? e.message : String(e);
     graphData = EMPTY;


### PR DESCRIPTION
## Summary

- **Backend (routes.py)**: Fix `analyze_graph` to store pagerank/community scores for ALL nodes using UNWIND batching (was only top-k). Add `mode` param to `graph_export` (top/community/all), return `community_meta` and `total_nodes`. Optimize edge query by pushing node filter to Cypher when set < 5000.
- **Frontend**: Translucent 3D cloud spheres around community clusters using three.js (BackSide rendering, depthWrite:false). Floating label sprites above each cloud. Progressive loading controls (mode select, "Load more", "X of Y nodes" counter). Community drill-down on pill click. Proper three.js resource cleanup on teardown.

## Test plan

- [ ] Run `POST /graph/analyze` with `store_scores: true` — verify ALL nodes get pagerank/community (not just top 20)
- [ ] `GET /graph/export?mode=top&limit=50` returns 50 nodes with `community_meta` and `total_nodes`
- [ ] `GET /graph/export?mode=community&community=0` returns only community 0 nodes
- [ ] UI builds: `cd ui && npm run build`
- [ ] Graph loads ~200 nodes by default, translucent colored spheres surround clusters
- [ ] Clicking community pill drills into that community
- [ ] "Load more" increments by 100. Mode select switches between top/all
- [ ] "X of Y nodes" counter accurate
- [ ] Navigate away and back — no orphaned three.js objects