### PR TITLE
feat: syntax highlighting, collapsible tool results, /compact command

### DIFF
--- a/ui/src/components/chat/Markdown.svelte
+++ b/ui/src/components/chat/Markdown.svelte
@@ -81,12 +81,50 @@
     overflow-x: auto;
     position: relative;
   }
+  .markdown-body :global(pre .code-lang) {
+    position: absolute;
+    top: 4px;
+    left: 12px;
+    font-size: 10px;
+    font-family: var(--font-sans);
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    pointer-events: none;
+    opacity: 0.6;
+  }
   .markdown-body :global(pre code) {
     padding: 0;
     background: none;
     font-size: 13px;
     line-height: 1.5;
   }
+  /* highlight.js token colors — dark theme */
+  .markdown-body :global(.hljs-keyword) { color: #ff7b72; }
+  .markdown-body :global(.hljs-string),
+  .markdown-body :global(.hljs-regexp) { color: #a5d6ff; }
+  .markdown-body :global(.hljs-number),
+  .markdown-body :global(.hljs-literal) { color: #79c0ff; }
+  .markdown-body :global(.hljs-comment) { color: #8b949e; font-style: italic; }
+  .markdown-body :global(.hljs-function),
+  .markdown-body :global(.hljs-title) { color: #d2a8ff; }
+  .markdown-body :global(.hljs-built_in) { color: #ffa657; }
+  .markdown-body :global(.hljs-type),
+  .markdown-body :global(.hljs-class) { color: #ffa657; }
+  .markdown-body :global(.hljs-attr),
+  .markdown-body :global(.hljs-attribute) { color: #79c0ff; }
+  .markdown-body :global(.hljs-variable),
+  .markdown-body :global(.hljs-template-variable) { color: #ffa657; }
+  .markdown-body :global(.hljs-property) { color: #79c0ff; }
+  .markdown-body :global(.hljs-tag) { color: #7ee787; }
+  .markdown-body :global(.hljs-name) { color: #7ee787; }
+  .markdown-body :global(.hljs-selector-class),
+  .markdown-body :global(.hljs-selector-id),
+  .markdown-body :global(.hljs-selector-tag) { color: #7ee787; }
+  .markdown-body :global(.hljs-meta) { color: #79c0ff; }
+  .markdown-body :global(.hljs-addition) { color: #aff5b4; background: rgba(63, 185, 80, 0.15); }
+  .markdown-body :global(.hljs-deletion) { color: #ffdcd7; background: rgba(248, 81, 73, 0.15); }
+  .markdown-body :global(.hljs-punctuation) { color: #c9d1d9; }
   .markdown-body :global(pre .copy-btn) {
     position: absolute;
     top: 6px;

--- a/ui/src/lib/markdown.ts
+++ b/ui/src/lib/markdown.ts
@@ -1,11 +1,6 @@
 import { Marked } from "marked";
 import DOMPurify from "dompurify";
 
-const marked = new Marked({
-  breaks: true,
-  gfm: true,
-});
-
 // Selective highlight.js — only the languages we actually need (~90% smaller)
 import hljs from "highlight.js/lib/core";
 import typescript from "highlight.js/lib/languages/typescript";
@@ -37,13 +32,6 @@ hljs.registerLanguage("css", css);
 hljs.registerLanguage("ts", typescript);
 hljs.registerLanguage("js", javascript);
 
-export function renderMarkdown(text: string): string {
-  const raw = marked.parse(text, { async: false }) as string;
-  return DOMPurify.sanitize(raw, {
-    ADD_ATTR: ["class"],
-  });
-}
-
 export function highlightCode(code: string, language?: string): string {
   if (language && hljs.getLanguage(language)) {
     return hljs.highlight(code, { language }).value;
@@ -51,9 +39,43 @@ export function highlightCode(code: string, language?: string): string {
   return hljs.highlightAuto(code).value;
 }
 
-export function highlightCodeSync(code: string, language?: string): string {
-  if (language && hljs.getLanguage(language)) {
-    return hljs.highlight(code, { language }).value;
-  }
-  return hljs.highlightAuto(code).value;
+const marked = new Marked({
+  breaks: true,
+  gfm: true,
+  renderer: {
+    code({ text, lang }: { text: string; lang?: string }) {
+      const language = lang?.split(/\s/)[0] ?? "";
+      const highlighted = highlightCode(text, language || undefined);
+      const label = language ? `<span class="code-lang">${language}</span>` : "";
+      return `<pre class="code-block">${label}<code class="hljs">${highlighted}</code></pre>`;
+    },
+  },
+});
+
+export function renderMarkdown(text: string): string {
+  const raw = marked.parse(text, { async: false }) as string;
+  return DOMPurify.sanitize(raw, {
+    ADD_ATTR: ["class"],
+  });
+}
+
+/** Infer a highlight.js language from a file path or tool name */
+export function inferLanguage(toolName: string, input?: string): string | undefined {
+  if (toolName === "exec") return "bash";
+  if (toolName === "web_fetch") return "html";
+  if (toolName === "web_search" || toolName === "ls") return undefined;
+
+  // For file tools, try to infer from the file path in the input
+  const path = typeof input === "string" ? input : "";
+  const ext = path.match(/\.(\w+)$/)?.[1]?.toLowerCase();
+  if (!ext) return undefined;
+
+  const extMap: Record<string, string> = {
+    ts: "typescript", tsx: "typescript", js: "javascript", jsx: "javascript",
+    py: "python", sh: "bash", bash: "bash", fish: "bash",
+    json: "json", yaml: "yaml", yml: "yaml", toml: "yaml",
+    sql: "sql", md: "markdown", html: "html", xml: "xml",
+    css: "css", svelte: "html",
+  };
+  return extMap[ext];
 }


### PR DESCRIPTION
## Summary

- **Code highlighting in chat**: Wire highlight.js into marked renderer with custom `code` handler. Fenced code blocks now render with GitHub-dark token colors. Language label shows in top-left corner of code blocks.
- **Syntax highlighting in ToolPanel**: Infer language from tool name/input (exec→bash, read→file extension, web_fetch→html). Apply highlight.js + DOMPurify before rendering. Tool results now show colored syntax.
- **Collapsible long results**: Tool results over 20 lines collapse to 10 lines with a CSS mask fade gradient. "Show all N lines" / "Show less" toggle.
- **`/compact` slash command**: Triggers `POST /api/sessions/:id/distill` from chat. Shows progress and success/failure as injected messages. Reloads history after compaction.

## Test plan

- [ ] Send a message asking for code in Python, TypeScript, SQL — verify syntax colors render
- [ ] Check that inline \`code\` still works (not just fenced blocks)
- [ ] Open ToolPanel after a turn with file reads — verify syntax coloring
- [ ] Trigger a tool that returns 50+ lines — verify it collapses with fade
- [ ] Click "Show all N lines" — verify it expands, click "Show less" — verify it collapses
- [ ] Type `/compact` in chat — verify distillation runs and reports success
- [ ] `npm run build` succeeds, all 29 tests pass