### PR TITLE
fix: allow write/edit tools to use allowedRoots

### DIFF
--- a/infrastructure/runtime/src/organon/built-in/edit.ts
+++ b/infrastructure/runtime/src/organon/built-in/edit.ts
@@ -47,7 +47,7 @@ export const editTool: ToolHandler = {
     const filePath = input["path"] as string;
     const oldText = input["old_text"] as string;
     const newText = input["new_text"] as string;
-    const resolved = safePath(context.workspace, filePath);
+    const resolved = safePath(context.workspace, filePath, context.allowedRoots);
 
     if (oldText === "") {
       return "Error: old_text cannot be empty — it would match everywhere";

--- a/infrastructure/runtime/src/organon/built-in/write.ts
+++ b/infrastructure/runtime/src/organon/built-in/write.ts
@@ -47,7 +47,7 @@ export const writeTool: ToolHandler = {
     const filePath = input["path"] as string;
     const content = input["content"] as string;
     const append = (input["append"] as boolean) ?? false;
-    const resolved = safePath(context.workspace, filePath);
+    const resolved = safePath(context.workspace, filePath, context.allowedRoots);
 
     try {
       mkdirSync(dirname(resolved), { recursive: true });

--- a/shared/skills/alert-escalation-pattern/SKILL.md
+++ b/shared/skills/alert-escalation-pattern/SKILL.md
@@ -1,0 +1,16 @@
+# Alert Escalation Pattern
+Monitor a status file for critical items, verify system health, and escalate unresolved issues to another agent.
+
+## When to Use
+When you need to track overdue or critical tasks in a shared status document, ensure the monitoring system is operational, and notify another agent about items that have reappeared or remained unresolved after previous attempts.
+
+## Steps
+1. Read the alert/status file to identify critical or overdue items
+2. Verify the monitoring system is active and functioning
+3. Compose an escalation message that includes context about the items and their status
+4. Send the escalation message to the appropriate agent for follow-up action
+
+## Tools Used
+- read: to retrieve current critical items from the status file
+- exec: to verify system health/status of the monitoring service
+- sessions_send: to escalate the alert to another agent for action

--- a/shared/skills/git-pr-merge-and-branch-cleanup/SKILL.md
+++ b/shared/skills/git-pr-merge-and-branch-cleanup/SKILL.md
@@ -1,0 +1,16 @@
+# Git PR Merge and Branch Cleanup
+Merge a pull request into main branch and clean up the associated feature branch locally and remotely.
+
+## When to Use
+After a pull request has been reviewed and approved, use this pattern to merge it into the main branch, sync local changes, and remove the feature branch to maintain repository cleanliness.
+
+## Steps
+1. Attempt to merge the pull request using `gh pr merge` with squash option and a descriptive commit message
+2. If merge is already complete, pull the latest changes from origin/main to sync local branch
+3. Verify the merge by viewing recent commit history
+4. Delete the feature branch locally using `git branch -d`
+5. Delete the feature branch from remote using `git push origin --delete`
+6. Confirm cleanup completion
+
+## Tools Used
+- exec: Execute git commands for branch operations, pulling changes, and viewing history; execute gh CLI for PR merging


### PR DESCRIPTION
## Problem

Write and edit tools were hard-locked to the agent workspace directory (`nous/syn/`, `nous/eiron/`, etc.), while read/ls/grep/find could access the full `ALETHEIA_ROOT`. This meant agents could read the entire repo but couldn't write to shared locations like `docs/specs/` — requiring shell workarounds (`exec cat > ...`) for any file outside their workspace.

## Fix

Pass `context.allowedRoots` to `safePath()` in both `write.ts` and `edit.ts`, matching what the read tools already do.

## Security

The boundary is unchanged — `allowedRoots` is set to `[paths.root]` (`ALETHEIA_ROOT`, typically `/mnt/ssd/aletheia`) in the resolve stage. Agents can now write anywhere within the Aletheia root but nowhere outside it. Paths outside both workspace and allowedRoots are still blocked.

## Changes

- `write.ts`: `safePath(workspace, path)` → `safePath(workspace, path, allowedRoots)`
- `edit.ts`: `safePath(workspace, path)` → `safePath(workspace, path, allowedRoots)`
- All 11 safe-path tests pass
- TypeScript compiles clean