### PR TITLE
feat: unified slash commands, stop button fix, thinking mode

### DIFF
--- a/infrastructure/runtime/src/aletheia.ts
+++ b/infrastructure/runtime/src/aletheia.ts
@@ -40,7 +40,7 @@ import { createDeliberateTool } from "./organon/built-in/deliberate.js";
 import { createSelfAuthorTools, loadAuthoredTools } from "./organon/self-author.js";
 import { NousManager } from "./nous/manager.js";
 import { McpClientManager } from "./organon/mcp-client.js";
-import { createGateway, startGateway, setCronRef, setWatchdogRef, setSkillsRef, setMcpRef } from "./pylon/server.js";
+import { createGateway, startGateway, setCronRef, setWatchdogRef, setSkillsRef, setMcpRef, setCommandsRef } from "./pylon/server.js";
 import { createMcpRoutes } from "./pylon/mcp.js";
 import { createUiRoutes, broadcastEvent } from "./pylon/ui.js";
 import { SignalClient } from "./semeion/client.js";
@@ -312,6 +312,7 @@ export async function startRuntime(configPath?: string): Promise<void> {
 
   // --- Command Registry ---
   const commandRegistry = createDefaultRegistry();
+  setCommandsRef(commandRegistry);
 
   // --- Signal ---
   let watchdog: Watchdog | null = null;

--- a/infrastructure/runtime/src/mneme/schema.ts
+++ b/infrastructure/runtime/src/mneme/schema.ts
@@ -181,4 +181,11 @@ export const MIGRATIONS: Array<{ version: number; sql: string }> = [
       CREATE INDEX IF NOT EXISTS idx_blackboard_expires ON blackboard(expires_at);
     `,
   },
+  {
+    version: 7,
+    sql: `
+      ALTER TABLE sessions ADD COLUMN thinking_enabled INTEGER DEFAULT 0;
+      ALTER TABLE sessions ADD COLUMN thinking_budget INTEGER DEFAULT 10000;
+    `,
+  },
 ];

--- a/infrastructure/runtime/src/mneme/store.ts
+++ b/infrastructure/runtime/src/mneme/store.ts
@@ -407,6 +407,32 @@ export class SessionStore {
     return row?.distillation_count ?? 0;
   }
 
+  updateSessionModel(sessionId: string, model: string): void {
+    this.db
+      .prepare(
+        `UPDATE sessions SET model = ?, updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now') WHERE id = ?`,
+      )
+      .run(model, sessionId);
+  }
+
+  getThinkingConfig(sessionId: string): { enabled: boolean; budget: number } {
+    const row = this.db
+      .prepare("SELECT thinking_enabled, thinking_budget FROM sessions WHERE id = ?")
+      .get(sessionId) as { thinking_enabled: number; thinking_budget: number } | undefined;
+    return {
+      enabled: (row?.thinking_enabled ?? 0) === 1,
+      budget: row?.thinking_budget ?? 10_000,
+    };
+  }
+
+  setThinkingConfig(sessionId: string, enabled: boolean, budget: number): void {
+    this.db
+      .prepare(
+        `UPDATE sessions SET thinking_enabled = ?, thinking_budget = ?, updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now') WHERE id = ?`,
+      )
+      .run(enabled ? 1 : 0, budget, sessionId);
+  }
+
   getLastBootstrapHash(nousId: string): string | null {
     const row = this.db
       .prepare(

--- a/infrastructure/runtime/src/nous/pipeline/types.ts
+++ b/infrastructure/runtime/src/nous/pipeline/types.ts
@@ -50,6 +50,7 @@ export interface TurnOutcome {
 export type TurnStreamEvent =
   | { type: "turn_start"; sessionId: string; nousId: string; turnId: string }
   | { type: "text_delta"; text: string }
+  | { type: "thinking_delta"; text: string }
   | { type: "tool_start"; toolName: string; toolId: string }
   | { type: "tool_result"; toolName: string; toolId: string; result: string; isError: boolean; durationMs: number }
   | { type: "tool_approval_required"; turnId: string; toolName: string; toolId: string; input: unknown; risk: string; reason: string }

--- a/infrastructure/runtime/src/semeion/commands-full.test.ts
+++ b/infrastructure/runtime/src/semeion/commands-full.test.ts
@@ -63,6 +63,13 @@ describe("command execution", () => {
     const match = registry.match("!help");
     const result = await match!.handler.execute("", makeCtx());
     expect(result).toContain("Available commands");
+    expect(result).toContain("/ping");
+    expect(result).toContain("/status");
+  });
+
+  it("help uses ! prefix in group context", async () => {
+    const match = registry.match("!help");
+    const result = await match!.handler.execute("", makeCtx({ target: { account: "+1", groupId: "grp1" } }));
     expect(result).toContain("!ping");
     expect(result).toContain("!status");
   });

--- a/infrastructure/runtime/src/semeion/commands.test.ts
+++ b/infrastructure/runtime/src/semeion/commands.test.ts
@@ -38,6 +38,30 @@ describe("CommandRegistry", () => {
     expect(reg.match("!Ping")).not.toBeNull();
   });
 
+  it("matches / prefix (slash commands)", () => {
+    const reg = new CommandRegistry();
+    reg.register({
+      name: "test",
+      description: "Test",
+      execute: async () => "done",
+    });
+    const match = reg.match("/test");
+    expect(match).not.toBeNull();
+    expect(match!.handler.name).toBe("test");
+  });
+
+  it("matches / prefix with arguments", () => {
+    const reg = new CommandRegistry();
+    reg.register({
+      name: "model",
+      description: "Switch model",
+      execute: async () => "done",
+    });
+    const match = reg.match("/model sonnet");
+    expect(match).not.toBeNull();
+    expect(match!.args).toBe("sonnet");
+  });
+
   it("returns null for non-command text", () => {
     const reg = new CommandRegistry();
     expect(reg.match("hello")).toBeNull();
@@ -80,7 +104,7 @@ describe("createDefaultRegistry", () => {
   it("returns a registry with default commands", () => {
     const reg = createDefaultRegistry();
     const all = reg.listAll();
-    expect(all.length).toBeGreaterThanOrEqual(10);
+    expect(all.length).toBeGreaterThanOrEqual(14);
     const names = all.map((c) => c.name);
     expect(names).toContain("ping");
     expect(names).toContain("help");
@@ -89,6 +113,10 @@ describe("createDefaultRegistry", () => {
     expect(names).toContain("reset");
     expect(names).toContain("agent");
     expect(names).toContain("skills");
+    expect(names).toContain("model");
+    expect(names).toContain("think");
+    expect(names).toContain("distill");
+    expect(names).toContain("blackboard");
     expect(names).toContain("approve");
     expect(names).toContain("deny");
     expect(names).toContain("contacts");

--- a/ui/src/components/chat/Message.svelte
+++ b/ui/src/components/chat/Message.svelte
@@ -67,6 +67,12 @@
         {/each}
       </div>
     {/if}
+    {#if message.thinking}
+      <details class="thinking-block">
+        <summary class="thinking-summary">Thought process</summary>
+        <div class="thinking-content">{message.thinking}</div>
+      </details>
+    {/if}
     {#if message.content}
       <div class="chat-content">
         {#if isUser}
@@ -88,6 +94,35 @@
 {/if}
 
 <style>
+  .thinking-block {
+    margin-bottom: 8px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    overflow: hidden;
+  }
+  .thinking-summary {
+    padding: 6px 10px;
+    font-size: 12px;
+    color: var(--text-muted);
+    cursor: pointer;
+    user-select: none;
+    background: var(--surface);
+  }
+  .thinking-summary:hover {
+    color: var(--text-secondary);
+  }
+  .thinking-content {
+    padding: 8px 10px;
+    font-size: 12px;
+    color: var(--text-muted);
+    white-space: pre-wrap;
+    word-break: break-word;
+    max-height: 300px;
+    overflow-y: auto;
+    border-top: 1px solid var(--border);
+    font-family: var(--font-mono);
+    line-height: 1.5;
+  }
   .user-text {
     white-space: pre-wrap;
     word-break: break-word;

--- a/ui/src/components/chat/MessageList.svelte
+++ b/ui/src/components/chat/MessageList.svelte
@@ -8,6 +8,7 @@
   let {
     messages,
     streamingText,
+    thinkingText = "",
     activeToolCalls,
     isStreaming,
     agentName,
@@ -16,6 +17,7 @@
   }: {
     messages: ChatMessage[];
     streamingText: string;
+    thinkingText?: string;
     activeToolCalls: ToolCallState[];
     isStreaming: boolean;
     agentName?: string | null;
@@ -44,6 +46,7 @@
   $effect(() => {
     void messages.length;
     void streamingText;
+    void thinkingText;
     void activeToolCalls.length;
 
     if (isNearBottom) {
@@ -77,6 +80,12 @@
           {/if}
         </div>
         <div class="chat-body">
+          {#if thinkingText}
+            <details class="thinking-stream" open>
+              <summary class="thinking-summary">Thinking...</summary>
+              <div class="thinking-content">{thinkingText}</div>
+            </details>
+          {/if}
           {#if activeToolCalls.length > 0}
             <ToolStatusLine
               tools={activeToolCalls}
@@ -87,7 +96,7 @@
             <div class="chat-content">
               <Markdown content={streamingText} />
             </div>
-          {:else if activeToolCalls.length === 0}
+          {:else if activeToolCalls.length === 0 && !thinkingText}
             <StreamingIndicator />
           {/if}
         </div>
@@ -141,6 +150,38 @@
     background: var(--accent);
     color: #fff;
     letter-spacing: 1px;
+  }
+
+  .thinking-stream {
+    margin-bottom: 8px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    overflow: hidden;
+  }
+  .thinking-summary {
+    padding: 6px 10px;
+    font-size: 12px;
+    color: var(--text-muted);
+    cursor: pointer;
+    user-select: none;
+    background: var(--surface);
+    animation: pulse 2s ease-in-out infinite;
+  }
+  @keyframes pulse {
+    0%, 100% { opacity: 0.6; }
+    50% { opacity: 1; }
+  }
+  .thinking-content {
+    padding: 8px 10px;
+    font-size: 12px;
+    color: var(--text-muted);
+    white-space: pre-wrap;
+    word-break: break-word;
+    max-height: 200px;
+    overflow-y: auto;
+    border-top: 1px solid var(--border);
+    font-family: var(--font-mono);
+    line-height: 1.5;
   }
 
   .scroll-btn {

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -1,4 +1,4 @@
-import type { Agent, Session, HistoryMessage, MetricsData, CostSummary, GraphData, FileTreeEntry, GitFileStatus } from "./types";
+import type { Agent, Session, HistoryMessage, MetricsData, CostSummary, GraphData, FileTreeEntry, GitFileStatus, CommandInfo } from "./types";
 
 const TOKEN_KEY = "aletheia_token";
 
@@ -112,6 +112,19 @@ export async function fetchGraphExport(params?: GraphExportParams): Promise<Grap
     community_meta: data.community_meta ?? [],
     total_nodes: data.total_nodes ?? data.nodes.length,
   };
+}
+
+export async function fetchCommands(): Promise<CommandInfo[]> {
+  const data = await fetchJson<{ commands: CommandInfo[] }>("/api/commands");
+  return data.commands;
+}
+
+export async function executeCommand(command: string, sessionId?: string): Promise<string> {
+  const data = await fetchJson<{ ok: boolean; result: string }>("/api/command", {
+    method: "POST",
+    body: JSON.stringify({ command, sessionId }),
+  });
+  return data.result;
 }
 
 export async function approveToolCall(turnId: string, toolId: string, alwaysAllow = false): Promise<void> {

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -41,6 +41,7 @@ export interface ChatMessage {
   toolCalls?: ToolCallState[];
   isStreaming?: boolean;
   media?: MediaItem[];
+  thinking?: string;
 }
 
 export interface ToolCallState {
@@ -54,11 +55,13 @@ export interface ToolCallState {
 export type TurnStreamEvent =
   | { type: "turn_start"; sessionId: string; nousId: string; turnId?: string }
   | { type: "text_delta"; text: string }
+  | { type: "thinking_delta"; text: string }
   | { type: "tool_start"; toolName: string; toolId: string }
   | { type: "tool_result"; toolName: string; toolId: string; result: string; isError: boolean; durationMs: number }
   | { type: "tool_approval_required"; turnId: string; toolName: string; toolId: string; input: unknown; risk: string; reason: string }
   | { type: "tool_approval_resolved"; toolId: string; decision: string }
   | { type: "turn_complete"; outcome: TurnOutcome }
+  | { type: "turn_abort"; reason: string }
   | { type: "error"; message: string };
 
 export interface PendingApproval {
@@ -154,6 +157,12 @@ export interface GraphData {
   communities: number;
   community_meta: CommunityMeta[];
   total_nodes: number;
+}
+
+export interface CommandInfo {
+  name: string;
+  description: string;
+  aliases: string[];
 }
 
 export interface FileTreeEntry {


### PR DESCRIPTION
## Summary
- **Stop button fix**: `remoteStreaming` now clears on abort, `turn_abort` SSE event handled, `AbortSignal` passed through to Anthropic SDK so LLM calls actually cancel
- **Unified slash commands**: `CommandRegistry.match()` accepts both `!` and `/` prefixes. New commands: `/model`, `/think`, `/distill`, `/blackboard`. WebUI discovers and executes server commands via `GET /api/commands` and `POST /api/command`
- **Extended thinking**: Per-session toggle via `/think on|off`, migration v7 adds `thinking_enabled`/`thinking_budget` columns, thinking blocks stream to UI with collapsible rendering

## Test plan
- [ ] Click stop during tool use → UI returns to input-ready state without hard refresh
- [ ] Type `/` in WebUI → autocomplete shows all commands (client + server)
- [ ] `/model` shows current model; `/model sonnet` switches
- [ ] `/think on` enables thinking; send message → collapsible thinking block renders above response
- [ ] `!model` via Signal → same behavior as `/model` in WebUI
- [ ] `npx vitest run` passes for commands, commands-full, anthropic, store test files

🤖 Generated with [Claude Code](https://claude.com/claude-code)