### PR TITLE
fix: test performance — tiered testing and worker limits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  VITEST_MAX_FORKS: 4
+
 jobs:
   typecheck:
     runs-on: ubuntu-latest
@@ -35,7 +38,25 @@ jobs:
       - run: cd infrastructure/runtime && npm ci
       - run: cd infrastructure/runtime && npm run lint:check
 
-  test-unit:
+  # Fast tests — lightweight unit tests, quick PR feedback
+  test-fast:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: infrastructure/runtime/package-lock.json
+      - name: Install system tools
+        run: |
+          sudo apt-get install -y ripgrep fd-find
+          sudo ln -sf "$(which fdfind)" /usr/local/bin/fd
+      - run: cd infrastructure/runtime && npm ci
+      - run: cd infrastructure/runtime && npm run test:fast
+
+  # Full test suite with coverage
+  test-full:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/infrastructure/runtime/package.json
+++ b/infrastructure/runtime/package.json
@@ -15,7 +15,10 @@
     "lint:check": "oxlint src/",
     "typecheck": "tsc --noEmit",
     "check": "npm run typecheck && npm run lint:check && npm run test",
-    "precommit": "npm run typecheck && npm run lint:check && npm run test -- --reporter=dot"
+    "precommit": "npm run typecheck && npm run lint:check && npm run test:fast",
+    "test:fast": "vitest run -c vitest.fast.config.ts",
+    "test:affected": "vitest run --changed HEAD~1",
+    "test:file": "vitest run"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.39.0",

--- a/infrastructure/runtime/scripts/test-module.sh
+++ b/infrastructure/runtime/scripts/test-module.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Run tests for a specific module or set of changed files
+# Usage: ./scripts/test-module.sh [module-path-pattern]
+# Examples:
+#   ./scripts/test-module.sh organon/built-in   # all built-in tool tests
+#   ./scripts/test-module.sh nous/pipeline       # pipeline tests
+#   ./scripts/test-module.sh                     # tests for files changed since HEAD~1
+
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+if [ $# -eq 0 ]; then
+  echo "Running tests for changed files (vs HEAD~1)..."
+  npx vitest run --changed HEAD~1 --reporter dot 2>&1
+else
+  pattern="$1"
+  echo "Running tests matching: $pattern"
+  npx vitest run --reporter dot "$pattern" 2>&1
+fi

--- a/infrastructure/runtime/vitest.config.ts
+++ b/infrastructure/runtime/vitest.config.ts
@@ -26,5 +26,11 @@ export default defineConfig({
     testTimeout: 10000,
     hookTimeout: 10000,
     pool: "forks",
+    poolOptions: {
+      forks: {
+        // CI overrides via VITEST_MAX_FORKS env var; local default is conservative
+        maxForks: parseInt(process.env["VITEST_MAX_FORKS"] ?? "2", 10),
+      },
+    },
   },
 });

--- a/infrastructure/runtime/vitest.fast.config.ts
+++ b/infrastructure/runtime/vitest.fast.config.ts
@@ -1,0 +1,30 @@
+// Fast test config — excludes heavy test files for local dev and agent use
+// Use: npm run test:fast
+// CI runs full suite via npm run test:coverage
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    root: "src",
+    include: ["**/*.test.ts"],
+    exclude: [
+      "**/*.integration.test.ts",
+      // Heavy tests: full-suite variants, manager (real pipeline), store (real SQLite)
+      "**/*-full.test.ts",
+      "**/manager.test.ts",
+      "**/manager-streaming.test.ts",
+      "**/store.test.ts",
+      "**/server-stream.test.ts",
+    ],
+    reporters: ["dot"],
+    passWithNoTests: false,
+    testTimeout: 5000,
+    hookTimeout: 5000,
+    pool: "forks",
+    poolOptions: {
+      forks: {
+        maxForks: parseInt(process.env["VITEST_MAX_FORKS"] ?? "2", 10),
+      },
+    },
+  },
+});

--- a/shared/skills/cross-codebase-api-contract-alignment/SKILL.md
+++ b/shared/skills/cross-codebase-api-contract-alignment/SKILL.md
@@ -1,0 +1,24 @@
+# Cross-codebase API Contract Alignment
+Identify and propagate API parameter changes across dependent modules and tools.
+
+## When to Use
+When a core utility or interface expands its parameters (e.g., adding an optional parameter), and you need to find all call sites that should be updated to use the new capability for consistency and feature completeness.
+
+## Steps
+1. Read the utility/module definition to understand the new parameter and its purpose
+2. Grep for all usages of that utility across the codebase to identify call sites
+3. Grep for related configuration or context definitions that might provide the new parameter value
+4. Read related files to understand how the parameter is initialized in different contexts
+5. Read dependent tool implementations to see current usage patterns
+6. Create a feature branch for the changes
+7. Update each call site to pass the new parameter from its context
+8. Run existing test suite for the modified utilities to verify compatibility
+9. Run type checker to catch any contract violations
+10. Commit changes with clear explanation of why the parameter is now being propagated
+11. Create a PR documenting the fix
+
+## Tools Used
+- read: inspect utility definitions and call sites
+- grep: locate all usages of a function/parameter across codebase
+- exec: run sed for bulk replacements, execute tests, run type checker, manage git
+- Git workflow: branch, diff, commit, and PR creation for tracking changes


### PR DESCRIPTION
## Problem

Full test suite (83 files) spawns up to 8 vitest workers via `pool: forks`, starving the host where runtime + signal-cli + agents run concurrently. Tests take 10+ minutes locally and frequently crash agent sessions mid-turn.

## Solution: Tiered Testing

### Local / Agent use
- **`npm run test:fast`** — excludes heavy tests (`*-full.test.ts`, manager, store, server-stream), 5s timeouts, dot reporter. Target: <60s, safe alongside live runtime.
- **`npm run test:affected`** — only tests related to files changed since HEAD~1.
- **`npm run test:file <path>`** — run specific test file(s).
- Worker forks capped at 2 locally (configurable via `VITEST_MAX_FORKS` env).

### CI (GitHub Actions)
- **`test-fast`** job — quick feedback, runs lightweight suite.
- **`test-full`** job — full coverage suite, runs in parallel.
- Both use `VITEST_MAX_FORKS=4` (GH runners aren't resource-constrained).

### Heavy tests excluded from fast suite
| File | Why heavy |
|------|-----------|
| `*-full.test.ts` (6 files) | Extended test variants with deeper mocking |
| `manager.test.ts` | Full pipeline with mocked provider, 3s recall timeout |
| `manager-streaming.test.ts` | Streaming pipeline with async generators |
| `store.test.ts` | Real SQLite, 44 tests with migrations |
| `server-stream.test.ts` | SSE streaming with Hono test client |

## Files
- `vitest.config.ts` — worker cap via `VITEST_MAX_FORKS` (default 2)
- `vitest.fast.config.ts` — new fast config
- `package.json` — new scripts, precommit uses test:fast
- `.github/workflows/ci.yml` — split into test-fast + test-full jobs
- `scripts/test-module.sh` — helper for targeted module testing