### PR TITLE
fix: rich command formatting, /model bug, word wrapping

### DIFF
--- a/infrastructure/runtime/src/pylon/server.ts
+++ b/infrastructure/runtime/src/pylon/server.ts
@@ -403,6 +403,7 @@ export function createGateway(
     if (!commandsRef) return c.json({ error: "Commands not available" }, 503);
     const body = await c.req.json() as Record<string, unknown>;
     const command = body["command"] as string;
+    const sessionId = body["sessionId"] as string | undefined;
     if (!command || typeof command !== "string") {
       return c.json({ error: "Missing command" }, 400);
     }
@@ -421,6 +422,7 @@ export function createGateway(
         manager,
         watchdog: watchdogRef,
         skills: skillsRef,
+        sessionId,
       };
       const result = await match.handler.execute(match.args, ctx);
       return c.json({ ok: true, result });

--- a/infrastructure/runtime/src/semeion/commands.test.ts
+++ b/infrastructure/runtime/src/semeion/commands.test.ts
@@ -122,11 +122,12 @@ describe("createDefaultRegistry", () => {
     expect(names).toContain("contacts");
   });
 
-  it("ping command returns pong", async () => {
+  it("ping command returns status indicator", async () => {
     const reg = createDefaultRegistry();
     const match = reg.match("!ping");
     const result = await match!.handler.execute("", {} as never);
-    expect(result).toBe("pong");
+    expect(result).toContain("**pong**");
+    expect(result).toContain("uptime");
   });
 
   it("help alias works", () => {

--- a/ui/src/lib/markdown.ts
+++ b/ui/src/lib/markdown.ts
@@ -40,7 +40,7 @@ export function highlightCode(code: string, language?: string): string {
 }
 
 const marked = new Marked({
-  breaks: true,
+  breaks: false,
   gfm: true,
   renderer: {
     code({ text, lang }: { text: string; lang?: string }) {


### PR DESCRIPTION
## Summary
- **Fix `/model` bug**: Was showing `[object Object]` because `config.agents.defaults.model` is `{ primary, fallbacks }` not a string. Now uses `.primary`.
- **Fix WebUI session context**: `POST /api/command` now passes `sessionId` from request body so commands like `/model` and `/think` can find the active session.
- **Rich markdown formatting**: All 14 command responses reformatted with tables, headers, bold labels, inline code for values, and Unicode status indicators (✓/✗). `/ping` shows uptime, `/status` uses tables for services and nous, `/skills` and `/help` rendered as tables.
- **Fix word wrapping**: Changed `breaks: true` to `breaks: false` in marked config. Single newlines now treated as spaces (standard GFM) instead of `<br>`, fixing orphaned single words on their own line.

## Test plan
- [ ] `/model` shows `**Model:** \`claude-opus-4-6\`` (not `[object Object]`)
- [ ] `/ping` shows bold "pong" with uptime
- [ ] `/status` renders with service table and nous table
- [ ] `/skills` renders as table
- [ ] `/help` renders as table with all commands
- [ ] LLM responses with mid-paragraph newlines flow as prose (no orphaned words)
- [ ] 34 command tests pass: `npx vitest run src/semeion/commands.test.ts src/semeion/commands-full.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)