### PR TITLE
chore: clean dead config keys and fix MCP access

### DIFF
--- a/infrastructure/runtime/src/aletheia.ts
+++ b/infrastructure/runtime/src/aletheia.ts
@@ -298,11 +298,10 @@ export async function startRuntime(configPath?: string): Promise<void> {
 
   // --- MCP Client ---
   let mcpManager: McpClientManager | null = null;
-  const mcpConfig = (config as Record<string, unknown>)["mcp"] as { enabled?: boolean; servers?: Record<string, unknown> } | undefined;
-  if (mcpConfig?.enabled && mcpConfig.servers && Object.keys(mcpConfig.servers).length > 0) {
+  if (config.mcp.enabled && Object.keys(config.mcp.servers).length > 0) {
     mcpManager = new McpClientManager(runtime.tools);
     try {
-      await mcpManager.connectAll(mcpConfig.servers as Record<string, import("./organon/mcp-client.js").McpServerConfig>);
+      await mcpManager.connectAll(config.mcp.servers as Record<string, import("./organon/mcp-client.js").McpServerConfig>);
       log.info(`MCP client: ${mcpManager.getToolCount()} tools from ${mcpManager.getStatus().filter(s => s.status === "connected").length} server(s)`);
     } catch (err) {
       log.error(`MCP client initialization error: ${err instanceof Error ? err.message : err}`);

--- a/infrastructure/runtime/src/nous/manager-streaming.test.ts
+++ b/infrastructure/runtime/src/nous/manager-streaming.test.ts
@@ -15,7 +15,6 @@ function makeConfig(overrides: Record<string, unknown> = {}) {
         contextTokens: 200000,
         maxOutputTokens: 4096,
         bootstrapMaxTokens: 30000,
-        maxToolLoops: 40,
         routing: { enabled: false, tiers: {}, agentOverrides: {} },
         compaction: { maxHistoryShare: 0.7, distillationModel: "claude-haiku" },
       },

--- a/infrastructure/runtime/src/taxis/loader.ts
+++ b/infrastructure/runtime/src/taxis/loader.ts
@@ -104,6 +104,7 @@ export function applyEnv(config: AletheiaConfig): number {
 const KNOWN_TOP_KEYS = new Set([
   "agents", "bindings", "channels", "gateway", "plugins",
   "session", "cron", "models", "env", "watchdog", "branding",
+  "mcp",
 ]);
 
 const KNOWN_NOUS_KEYS = new Set([

--- a/infrastructure/runtime/src/taxis/schema.ts
+++ b/infrastructure/runtime/src/taxis/schema.ts
@@ -125,7 +125,6 @@ const AgentDefaults = z.preprocess(
     userTimezone: z.string().default("UTC"),
     contextTokens: z.number().default(200000),
     maxOutputTokens: z.number().default(16384),
-    maxToolLoops: z.number().default(100), // Deprecated — loop detector handles this now
     compaction: CompactionConfig.default({}),
     routing: RoutingConfig.default({}),
     heartbeat: HeartbeatConfig.optional(),


### PR DESCRIPTION
## Summary
- Add `mcp` to `KNOWN_TOP_KEYS` in loader.ts — was missing, would warn despite being schema-defined
- Fix MCP config access in aletheia.ts — replace unsafe type cast with direct `config.mcp` property access
- Remove deprecated `maxToolLoops` from schema (loop detector handles this)

Also cleaned server config directly (not in this PR):
- Removed 7 dead OpenClaw legacy keys: meta, wizard, browser, tools, messages, commands, skills
- Removed dead `sandbox` key from main agent definition
- `aletheia doctor` now shows zero warnings

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run src/taxis/` — 31 tests pass
- [x] `aletheia doctor` — zero warnings on server
- [x] `systemctl restart aletheia` — starts clean, all 4 nous load

🤖 Generated with [Claude Code](https://claude.com/claude-code)