### PR TITLE
spec 8 phase 1: expand preserved tail (4→10 messages, 4K→12K tokens)

### DIFF
--- a/infrastructure/runtime/src/taxis/loader.test.ts
+++ b/infrastructure/runtime/src/taxis/loader.test.ts
@@ -79,6 +79,30 @@ describe("loadConfig", () => {
     expect(config.agents.defaults.bootstrapMaxTokens).toBe(40000);
   });
 
+  it("defaults compaction preserveRecentMessages to 10 and preserveRecentMaxTokens to 12000", () => {
+    mockReadJson.mockReturnValue(minimalConfig());
+    const config = loadConfig();
+    expect(config.agents.defaults.compaction.preserveRecentMessages).toBe(10);
+    expect(config.agents.defaults.compaction.preserveRecentMaxTokens).toBe(12000);
+  });
+
+  it("allows overriding compaction preservation settings", () => {
+    mockReadJson.mockReturnValue({
+      agents: {
+        defaults: {
+          compaction: {
+            preserveRecentMessages: 6,
+            preserveRecentMaxTokens: 8000,
+          },
+        },
+        list: [{ id: "syn", workspace: "/nous/syn" }],
+      },
+    });
+    const config = loadConfig();
+    expect(config.agents.defaults.compaction.preserveRecentMessages).toBe(6);
+    expect(config.agents.defaults.compaction.preserveRecentMaxTokens).toBe(8000);
+  });
+
   it("uses provided configPath over default", () => {
     mockReadJson.mockReturnValue(minimalConfig());
     loadConfig("/custom/path.json");

--- a/infrastructure/runtime/src/taxis/schema.ts
+++ b/infrastructure/runtime/src/taxis/schema.ts
@@ -47,8 +47,8 @@ const CompactionConfig = z
     reserveTokensFloor: z.number().default(8000),
     maxHistoryShare: z.number().default(0.7),
     distillationModel: z.string().default("claude-haiku-4-5-20251001"),
-    preserveRecentMessages: z.number().default(4),
-    preserveRecentMaxTokens: z.number().default(4000),
+    preserveRecentMessages: z.number().default(10),
+    preserveRecentMaxTokens: z.number().default(12000),
     memoryFlush: z
       .object({
         enabled: z.boolean().default(true),


### PR DESCRIPTION
## What

Increases the distillation preserved tail from 4 messages / 4K tokens to **10 messages / 12K tokens**.

## Why

After distillation, agents wake up with a summary + the last few raw messages. With only 4 messages (~2 turns), the agent loses the context that gives those messages meaning. 10 messages (~5 turns) captures the current exchange plus the context-setting exchanges before it.

**Token budget:** 12K tokens is ~6% of the 200K context window. Post-distillation context totals ~32K tokens, leaving 84% headroom for new conversation.

## What changed

- `taxis/schema.ts`: Default `preserveRecentMessages` 4→10, `preserveRecentMaxTokens` 4000→12000
- `taxis/loader.test.ts`: Tests for new defaults + override behavior
- `distillation/pipeline.test.ts`: Tests for preservation with new values + token budget limiting

## Risk

**Minimal.** The pipeline already handled arbitrary preserve values — this changes defaults only. Configs that explicitly set these values (like our live config's compaction block) are unaffected unless they omit these fields.

## Ref

`docs/specs/08_memory-continuity.md` — Phase 1: "Do it immediately."