### PR TITLE
spec 6 phase 1: CONTRIBUTING.md + CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,57 @@
+# CLAUDE.md
+
+Project conventions for AI coding agents working on this codebase.
+
+## Standards
+
+All code must follow [CONTRIBUTING.md](./CONTRIBUTING.md). Key points:
+
+- **Self-documenting code.** No "what" comments. Only "why" comments where non-obvious.
+- **Typed errors.** All errors extend `AletheiaError`. Error codes in `koina/error-codes.ts`. Never throw strings or bare `Error`.
+- **Never empty catch.** Every catch logs, rethrows, or returns a meaningful value.
+- **Test behavior, not implementation.** One assertion per test. Descriptive names.
+
+## Project Structure
+
+- **Runtime:** `infrastructure/runtime/src/` — TypeScript, built with tsup, tested with vitest
+- **UI:** `ui/` — Svelte 5, built with Vite
+- **Memory sidecar:** `infrastructure/memory/sidecar/` — Python FastAPI
+- **Config:** `~/.aletheia/aletheia.json` — validated by Zod schema in `taxis/schema.ts`
+- **Specs:** `docs/specs/` — design documents numbered by implementation order
+
+## Commands
+
+```bash
+# Run all tests
+cd infrastructure/runtime && npx vitest run
+
+# Run specific test file
+cd infrastructure/runtime && npx vitest run src/path/to/file.test.ts
+
+# Build runtime
+cd infrastructure/runtime && npm run build
+
+# Build UI
+cd ui && npm run build
+
+# Validate config
+aletheia doctor
+
+# Lint
+cd infrastructure/runtime && npx eslint src/
+```
+
+## Key Patterns
+
+- **Module naming:** Greek names (koina, taxis, mneme, hermeneus, nous, organon, semeion, pylon, prostheke)
+- **Error handling:** `AletheiaError` hierarchy in `koina/errors.ts`, codes in `koina/error-codes.ts`
+- **Logging:** `createLogger("module-name")` from `koina/logger.ts` — structured with AsyncLocalStorage context
+- **Events:** `eventBus` from `koina/event-bus.ts` — `noun:verb` naming pattern
+- **Config:** Zod schemas in `taxis/schema.ts`, loaded by `taxis/loader.ts`
+
+## Before Submitting
+
+1. Run tests for affected files
+2. Ensure no new empty catch blocks
+3. Check that new errors use typed error classes with codes
+4. Verify import order follows the convention (node → external → internal → local)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing
+# Contributing to Aletheia
 
 ## Getting Started
 
@@ -44,38 +44,208 @@ The hook runs `typecheck` and `lint:check` automatically. Enable it with:
 git config core.hooksPath .githooks
 ```
 
-## Code Style
-
-- **TypeScript strict mode** - all strict flags enabled, `exactOptionalPropertyTypes`, `noUncheckedIndexedAccess`
-- **File headers** - single-line comment describing the file's purpose. No JSDoc, no dates, no author info.
-- **Imports** - use `.js` extensions (NodeNext resolution). Group: node builtins, then local.
-- **Naming** - files: `kebab-case.ts`, classes: `PascalCase`, functions: `camelCase`, constants: `UPPER_SNAKE_CASE`
-- **Index access** - bracket notation for string-keyed records (`record["key"]`, not `record.key`)
-- **Tests** - adjacent to source (`foo.ts` / `foo.test.ts`), vitest with `describe`/`it`
-
-See [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md) for the full style guide and module architecture.
-
 ## Pull Requests
 
-- Keep PRs focused - one feature or fix per PR
+- Keep PRs focused — one feature or fix per PR
 - Include tests for new functionality
 - Ensure `npm run precommit` passes
 - Write a clear description of what changed and why
+- Reference the spec number for spec work
 - Reference related issues with `Fixes #123` or `Closes #123`
 
-## Adding Tools
+---
+
+## Code Standards
+
+### Self-Documenting Code Over Comments
+
+**File headers:** Each file gets one header comment — a single line explaining what the module is:
+
+```typescript
+// Pipeline runner — composes stages for streaming and non-streaming turn execution
+```
+
+**Inline comments:** Only where the *why* is non-obvious. Never comment *what* the code does.
+
+Good:
+```typescript
+// SQLCipher 4 format — must be set before any other pragma
+this.db.pragma(`key = '${encryptionKey}'`);
+```
+
+Bad:
+```typescript
+// Get the session
+const session = store.findSessionById(sessionId);
+```
+
+If the code needs a "what" comment to be understood, rename the variables and functions until it doesn't.
+
+### Naming
+
+| Thing | Convention | Example |
+|-------|-----------|---------|
+| Files | kebab-case | `build-messages.ts`, `session-store.ts` |
+| Classes | PascalCase | `SessionStore`, `ToolRegistry` |
+| Functions | camelCase, verb-first | `resolveThread`, `buildContext`, `parseConfig` |
+| Constants | UPPER_SNAKE | `MAX_CONCURRENT_TURNS`, `SIDECAR_URL` |
+| Types/Interfaces | PascalCase | `TurnState`, `DistillationOpts` |
+| Booleans | `is`/`has`/`should` prefix | `isStreaming`, `hasToken`, `shouldDistill` |
+| Event names | `noun:verb` or `noun:adjective` | `turn:before`, `distill:after`, `tool:called` |
+
+### TypeScript
+
+- **Strict mode** — all strict flags enabled, `exactOptionalPropertyTypes`, `noUncheckedIndexedAccess`
+- **Imports** — use `.js` extensions (NodeNext resolution)
+- **Index access** — bracket notation for string-keyed records (`record["key"]`, not `record.key`)
+
+### Function Design
+
+- **Single responsibility.** If a function needs a comment explaining its sections, split it.
+- **Early returns over nested ifs.** Guard clauses at the top, happy path below.
+- **Explicit over clever.** The next person reading this code is a tired engineer at 2am.
+- **Right tool for the job.** Don't use `reduce` when a `for` loop is clearer. Don't use a class when a function suffices. Don't use generics when the type is always the same.
+
+### Import Order
+
+```typescript
+// 1. Node built-ins
+import { join } from "node:path";
+import { readFileSync } from "node:fs";
+
+// 2. External packages
+import { Hono } from "hono";
+
+// 3. Internal absolute imports (by module)
+import { createLogger } from "../koina/logger.js";
+import type { SessionStore } from "../mneme/store.js";
+
+// 4. Local relative imports
+import { buildMessages } from "./utils/build-messages.js";
+import type { TurnState } from "./types.js";
+```
+
+---
+
+## Error Handling
+
+### Never Empty Catch
+
+Every `catch` block either logs, rethrows, or returns a meaningful value. No exceptions.
+
+```typescript
+// ❌ Never
+try { doThing(); } catch {}
+promise.catch(() => {});
+
+// ✅ Always
+try { doThing(); } catch (err) {
+  log.warn(`doThing failed (non-fatal): ${err instanceof Error ? err.message : err}`);
+}
+```
+
+### Use Typed Errors
+
+All errors extend `AletheiaError` from `koina/errors.ts`. Error codes are defined in `koina/error-codes.ts`.
+
+```typescript
+import { PipelineError } from "../koina/errors.js";
+
+throw new PipelineError("Stage failed", {
+  code: "PIPELINE_STAGE_FAILED",
+  context: { stage: "context", sessionId },
+  recoverable: true,
+});
+```
+
+Never throw strings. Never throw bare `Error`.
+
+### Error Boundaries for Non-Critical Operations
+
+Optional operations (skill learning, interaction signals, workspace flush) use `trySafe` / `trySafeAsync`:
+
+```typescript
+import { trySafe, trySafeAsync } from "../koina/safe.js";
+
+// Sync
+const result = trySafe("skill extraction", () => extractSkill(data), null);
+
+// Async
+const mem = await trySafeAsync("memory flush", () => flushToMemory(target), { errors: 0 });
+```
+
+The intent is explicit: "this operation is optional and must not crash the caller."
+
+### Log at the Boundary
+
+The function that catches the error logs it. Inner functions let errors propagate.
+
+---
+
+## Testing
+
+- **Test behavior, not implementation.** Tests break when the contract changes, not when internals refactor.
+- **One assertion per test** where practical. Name describes the assertion.
+- **Test names:** `it("returns null when session not found")` — not `it("test 1")`.
+- **No internal state access.** If you need `(store as any).db.prepare(...)`, the store needs a method for that.
+- **Test files:** Same directory as the module, named `module.test.ts` (vitest with `describe`/`it`).
+
+---
+
+## Module Architecture
+
+The runtime is organized by Greek-named subsystems:
+
+| Module | Domain | Examples |
+|--------|--------|---------|
+| `koina` | Shared infrastructure | Logger, errors, event bus, crypto, filesystem |
+| `taxis` | Configuration | Schema, loader, paths |
+| `mneme` | Memory/storage | Session store, message persistence |
+| `hermeneus` | LLM providers | Anthropic client, router, pricing, complexity |
+| `nous` | Agent management | Bootstrap, pipeline, manager |
+| `organon` | Tools | Built-in tools, tool registry |
+| `semeion` | Signal transport | Listener, sender, TTS |
+| `pylon` | Gateway/HTTP | Server, routes, middleware |
+| `prostheke` | Plugins | Loader, registry, hooks |
+| `distillation` | Context compression | Pipeline, extraction, summarization |
+| `daemon` | Background tasks | Cron, watchdog, retention |
+| `auth` | Authentication | JWT, RBAC, sessions (partially wired) |
+
+New code goes in the appropriate subsystem. If none fits, it probably belongs in `koina` (shared) or needs a new subsystem.
+
+### Adding Tools
 
 Tools live in `src/organon/built-in/`. See [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md#adding-new-tools) for the full guide.
 
-## Adding Commands
+### Adding Commands
 
 Signal commands (`!command`) are registered in `src/semeion/commands.ts`. See [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md#adding-new-built-in-commands).
 
+---
+
+## Architecture Principles
+
+1. **Pipeline stages are composable.** Each stage gets TurnState in, returns TurnState out. Side effects are explicit.
+2. **Config is the source of truth.** Runtime behavior comes from `aletheia.json` via Zod-validated schema. No magic environment variables for core config.
+3. **Events over callbacks.** Use the `eventBus` for cross-cutting concerns. Don't pass callback chains through 5 layers.
+4. **Errors carry context.** Every error has a code, a module, and enough context to debug without reading the source.
+5. **Agents are independent.** Each nous has its own workspace, identity, and config. Shared state goes through the store or event bus.
+
+---
+
+## Git Conventions
+
+- **Commits:** Descriptive, present tense. `fix: prevent orphan messages on pipeline error`
+- **Branches:** `spec<N>-<description>` for spec work, `fix/<description>` for bugs
+- **Always push after commit.** `git commit && git push` — never leave commits local.
+
+---
+
 ## Reporting Issues
 
-- **Bugs** - use the [bug report template](.github/ISSUE_TEMPLATE/bug_report.md)
-- **Features** - use the [feature request template](.github/ISSUE_TEMPLATE/feature_request.md)
-- **Security** - see [SECURITY.md](.github/SECURITY.md). Do not open public issues for vulnerabilities.
+- **Bugs** — use the [bug report template](.github/ISSUE_TEMPLATE/bug_report.md)
+- **Features** — use the [feature request template](.github/ISSUE_TEMPLATE/feature_request.md)
+- **Security** — see [SECURITY.md](.github/SECURITY.md). Do not open public issues for vulnerabilities.
 
 ## License
 


### PR DESCRIPTION
## What

Adds `CONTRIBUTING.md` (coding standards) and `CLAUDE.md` (AI agent quick-reference).

## Why

No documented agreement on how code should be written. The result is inconsistency across modules — different error handling patterns, comment styles, naming conventions. These docs set the baseline.

**CONTRIBUTING.md** covers:
- Self-documenting code (no 'what' comments, only 'why' comments)
- Naming conventions (files, classes, functions, constants, booleans, events)
- Function design (single responsibility, early returns, explicit over clever)
- Import order
- Error handling rules (never empty catch, typed errors via AletheiaError, error boundaries)
- Testing standards
- Module organization reference
- Git conventions

**CLAUDE.md** is the AI agent quick-reference:
- Points to CONTRIBUTING.md
- Project structure
- Common commands
- Key patterns

## Risk

None. Documentation only.

## Ref

`docs/specs/06_code-quality.md` — Phase 1: "Sets expectations."