### PR TITLE
feat: turn safety — error propagation, distillation guards, orphan diagnostics

### DIFF
--- a/infrastructure/runtime/src/koina/event-bus.ts
+++ b/infrastructure/runtime/src/koina/event-bus.ts
@@ -16,7 +16,9 @@ export type EventName =
   | "memory:retracted"
   | "signal:received"
   | "boot:start"
-  | "boot:ready";
+  | "boot:ready"
+  | "pipeline:error"
+  | "history:orphan_repair";
 
 export type EventPayload = Record<string, unknown>;
 export type EventHandler = (payload: EventPayload) => void | Promise<void>;

--- a/infrastructure/runtime/src/nous/pipeline/runner.test.ts
+++ b/infrastructure/runtime/src/nous/pipeline/runner.test.ts
@@ -1,0 +1,176 @@
+// Pipeline runner tests — error boundaries, stage identification
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { runBufferedPipeline, runStreamingPipeline } from "./runner.js";
+
+vi.mock("./stages/resolve.js", () => ({
+  resolveStage: vi.fn(),
+  resolveNousId: vi.fn().mockReturnValue("syn"),
+}));
+
+vi.mock("./stages/guard.js", () => ({
+  checkGuards: vi.fn().mockReturnValue(null),
+}));
+
+vi.mock("./stages/context.js", () => ({
+  buildContext: vi.fn(),
+}));
+
+vi.mock("./stages/history.js", () => ({
+  prepareHistory: vi.fn(),
+}));
+
+vi.mock("./stages/execute.js", () => ({
+  executeBuffered: vi.fn(),
+  executeStreaming: vi.fn(),
+}));
+
+vi.mock("./stages/finalize.js", () => ({
+  finalize: vi.fn(),
+}));
+
+vi.mock("../../koina/event-bus.js", () => ({
+  eventBus: { emit: vi.fn(), on: vi.fn(), off: vi.fn() },
+}));
+
+function makeState(overrides: Record<string, unknown> = {}) {
+  return {
+    nousId: "syn",
+    sessionId: "ses_1",
+    sessionKey: "main",
+    model: "claude-sonnet",
+    nous: { id: "syn", name: "Syn" },
+    workspace: "/tmp/syn",
+    seq: 1,
+    systemPrompt: [{ type: "text", text: "system" }],
+    messages: [],
+    toolDefs: [],
+    toolContext: {},
+    trace: { addStage: vi.fn(), finalize: vi.fn() },
+    totalToolCalls: 0,
+    totalInputTokens: 100,
+    totalOutputTokens: 50,
+    totalCacheReadTokens: 0,
+    totalCacheWriteTokens: 0,
+    currentMessages: [],
+    turnToolCalls: [],
+    loopDetector: { check: vi.fn() },
+    msg: { text: "hello" },
+    ...overrides,
+  };
+}
+
+const services = {} as never;
+
+describe("runBufferedPipeline", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns error outcome when context stage throws", async () => {
+    const { resolveStage } = await import("./stages/resolve.js");
+    const { buildContext } = await import("./stages/context.js");
+
+    const state = makeState({ systemPrompt: undefined });
+    (resolveStage as ReturnType<typeof vi.fn>).mockReturnValue(state);
+    (buildContext as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("context boom"));
+
+    const outcome = await runBufferedPipeline({ text: "hi", nousId: "syn" }, services);
+
+    expect(outcome.error).toBe("context boom");
+    expect(outcome.nousId).toBe("syn");
+    expect(outcome.sessionId).toBe("ses_1");
+    expect(outcome.text).toBe("");
+  });
+
+  it("returns error outcome when history stage throws", async () => {
+    const { resolveStage } = await import("./stages/resolve.js");
+    const { buildContext } = await import("./stages/context.js");
+    const { prepareHistory } = await import("./stages/history.js");
+
+    const state = makeState();
+    (resolveStage as ReturnType<typeof vi.fn>).mockReturnValue(state);
+    (buildContext as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
+    (prepareHistory as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("history boom"));
+
+    const outcome = await runBufferedPipeline({ text: "hi", nousId: "syn" }, services);
+
+    expect(outcome.error).toBe("history boom");
+    expect(outcome.text).toBe("");
+  });
+
+  it("emits pipeline:error event on failure", async () => {
+    const { resolveStage } = await import("./stages/resolve.js");
+    const { buildContext } = await import("./stages/context.js");
+    const { eventBus } = await import("../../koina/event-bus.js");
+
+    const state = makeState({ systemPrompt: undefined });
+    (resolveStage as ReturnType<typeof vi.fn>).mockReturnValue(state);
+    (buildContext as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("fail"));
+
+    await runBufferedPipeline({ text: "hi", nousId: "syn" }, services);
+
+    expect(eventBus.emit).toHaveBeenCalledWith("pipeline:error", expect.objectContaining({
+      nousId: "syn",
+      stage: "context",
+      error: "fail",
+    }));
+  });
+
+  it("returns normal outcome on success", async () => {
+    const { resolveStage } = await import("./stages/resolve.js");
+    const { buildContext } = await import("./stages/context.js");
+    const { prepareHistory } = await import("./stages/history.js");
+    const { executeBuffered } = await import("./stages/execute.js");
+    const { finalize } = await import("./stages/finalize.js");
+
+    const outcome = {
+      text: "response",
+      nousId: "syn",
+      sessionId: "ses_1",
+      toolCalls: 0,
+      inputTokens: 100,
+      outputTokens: 50,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
+    };
+    const state = makeState({ outcome });
+    (resolveStage as ReturnType<typeof vi.fn>).mockReturnValue(state);
+    (buildContext as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
+    (prepareHistory as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
+    (executeBuffered as ReturnType<typeof vi.fn>).mockResolvedValue(state);
+    (finalize as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
+
+    const result = await runBufferedPipeline({ text: "hi", nousId: "syn" }, services);
+
+    expect(result.text).toBe("response");
+    expect(result.error).toBeUndefined();
+  });
+
+  it("throws on unknown nous (resolve returns null)", async () => {
+    const { resolveStage } = await import("./stages/resolve.js");
+    (resolveStage as ReturnType<typeof vi.fn>).mockReturnValue(null);
+
+    await expect(runBufferedPipeline({ text: "hi", nousId: "bad" }, services))
+      .rejects.toThrow("Unknown nous");
+  });
+});
+
+describe("runStreamingPipeline", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("yields error event when context stage throws", async () => {
+    const { resolveStage } = await import("./stages/resolve.js");
+    const { buildContext } = await import("./stages/context.js");
+
+    const state = makeState({ systemPrompt: undefined });
+    (resolveStage as ReturnType<typeof vi.fn>).mockReturnValue(state);
+    (buildContext as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("context boom"));
+
+    const events: unknown[] = [];
+    for await (const event of runStreamingPipeline({ text: "hi", nousId: "syn" }, services)) {
+      events.push(event);
+    }
+
+    const errorEvent = events.find((e: any) => e.type === "error");
+    expect(errorEvent).toBeDefined();
+    expect((errorEvent as any).message).toContain("context boom");
+  });
+});

--- a/infrastructure/runtime/src/nous/pipeline/types.ts
+++ b/infrastructure/runtime/src/nous/pipeline/types.ts
@@ -49,6 +49,7 @@ export interface TurnOutcome {
   outputTokens: number;
   cacheReadTokens: number;
   cacheWriteTokens: number;
+  error?: string;
 }
 
 export type TurnStreamEvent =

--- a/infrastructure/runtime/src/pylon/server.ts
+++ b/infrastructure/runtime/src/pylon/server.ts
@@ -207,6 +207,7 @@ export function createGateway(
         response: result.text,
         sessionId: result.sessionId,
         toolCalls: result.toolCalls,
+        ...(result.error ? { error: result.error } : {}),
         usage: {
           inputTokens: result.inputTokens,
           outputTokens: result.outputTokens,

--- a/infrastructure/runtime/src/semeion/listener.ts
+++ b/infrastructure/runtime/src/semeion/listener.ts
@@ -497,6 +497,12 @@ async function processTurn(
   try {
     const outcome = await manager.handleMessage(msg);
 
+    if (outcome.error) {
+      log.error(`Turn completed with error: ${outcome.error}`, { nousId: outcome.nousId, sessionId: outcome.sessionId });
+      await sendMessage(client, target, "I encountered an error processing that. Please try again.", { markdown: false });
+      return;
+    }
+
     sendTyping(client, target, true).catch(() => {});
 
     if (outcome.text) {


### PR DESCRIPTION
## Summary

Implements `docs/specs/01_turn-safety.md` — eliminates silent turn failures, prevents distillation on dirty history, and improves orphan repair diagnostics.

- **Pipeline error boundaries**: runner.ts catches stage failures and returns structured `TurnOutcome` with `error` field instead of throwing into the session lock chain
- **Session lock fix**: `.then(fn, fn)` replaced with explicit resolve/reject handlers that log previous-turn errors
- **Deferred distillation**: auto-distillation moved from finalize stage to NousManager, runs after session lock release — prevents blocking subsequent turns and eliminates the distill-during-turn race
- **Distillation validation**: rejects sessions with orphaned tool_use blocks before distilling
- **Orphan repair improvements**: logs tool names/IDs, emits `history:orphan_repair` events, includes tool name in synthetic error content
- **Error visibility**: Signal listener and API server surface error outcomes to users instead of silence
- **Test fixes**: fixes pre-existing `triggerDistillation` test failure (missing `getThreadForSession` mock)

## Files changed (10 modified, 1 new)

| File | Change |
|------|--------|
| `pipeline/runner.ts` | try/catch around stages 3-6, `identifyFailedStage()`, `pipeline:error` events |
| `pipeline/types.ts` | `error?: string` on `TurnOutcome` |
| `manager.ts` | Session lock fix, `maybeScheduleDistillation()` deferred scheduling |
| `stages/finalize.ts` | Remove auto-distillation block (moved to manager) |
| `distillation/pipeline.ts` | Orphaned tool_use validation guard |
| `build-messages.ts` | Enhanced orphan logging, event emission, tool names in error content |
| `event-bus.ts` | New events: `pipeline:error`, `history:orphan_repair` |
| `listener.ts` | Handle `outcome.error` in Signal `processTurn` |
| `server.ts` | Include `error` field in `/api/sessions/send` response |
| `runner.test.ts` | **New** — 6 tests for pipeline error boundaries |
| `manager.test.ts` | 2 new tests + fix pre-existing failure |

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `runner.test.ts` — 6/6 pass (error outcomes, event emission, stage identification)
- [x] `manager.test.ts` — 17/17 pass (error recovery, sequential turn resilience, pre-existing fix)
- [ ] CI full suite
- [ ] Manual: Signal message during error → user receives error message (not silence)
- [ ] Manual: session at distillation threshold → deferred distillation fires after lock release

Spec: `docs/specs/01_turn-safety.md`