### PR TITLE
feat(memory): self-configuring LLM backend for memory sidecar

### DIFF
--- a/infrastructure/memory/sidecar/aletheia_memory/config.py
+++ b/infrastructure/memory/sidecar/aletheia_memory/config.py
@@ -1,19 +1,23 @@
-# Mem0 configuration for Aletheia memory sidecar
+"""Mem0 configuration with auto-detecting LLM backend."""
 
+import logging
 import os
 
-ANTHROPIC_API_KEY = os.environ.get("ANTHROPIC_API_KEY", "")
-VOYAGE_API_KEY = os.environ.get("VOYAGE_API_KEY", "")
+from .llm_backend import detect_backend
+
+log = logging.getLogger("aletheia.memory.config")
+
 QDRANT_HOST = os.environ.get("QDRANT_HOST", "localhost")
 QDRANT_PORT = int(os.environ.get("QDRANT_PORT", "6333"))
 NEO4J_URL = os.environ.get("NEO4J_URL", "neo4j://localhost:7687")
 NEO4J_USER = os.environ.get("NEO4J_USER", "neo4j")
-NEO4J_PASSWORD = os.environ.get("NEO4J_PASSWORD", "")
+NEO4J_PASSWORD = os.environ.get("NEO4J_PASSWORD", os.environ.get("NEO4J_PASS", "chiron-memory"))
+VOYAGE_API_KEY = os.environ.get("VOYAGE_API_KEY", "")
 
 FACT_EXTRACTION_PROMPT = """\
 You extract durable personal facts from conversations. Output JSON only.
 
-EXTRACT — lasting facts about the user:
+EXTRACT -- lasting facts about the user:
 - Identity: name, age, location, family, relationships
 - Health: diagnoses, medications, conditions, providers
 - Preferences: tools, workflows, food, communication style
@@ -37,7 +41,7 @@ QUALITY RULES:
 - Use the user's actual name when known, not "the user"
 - Prefer specific over vague ("drives a 2024 4Runner" not "has a vehicle")
 - One fact per entry, no compound sentences
-- Skip if uncertain — fewer quality memories beats many poor ones
+- Skip if uncertain -- fewer quality memories beats many poor ones
 
 Output format:
 {"facts": ["fact one", "fact two"]}
@@ -57,49 +61,79 @@ GRAPH_EXTRACTION_PROMPT = (
     "Use RELATES_TO as fallback when no specific type fits."
 )
 
-MEM0_CONFIG = {
-    "llm": {
-        "provider": "anthropic",
-        "config": {
-            "model": "claude-haiku-4-5-20251001",
-            "temperature": 0.1,
-            "max_tokens": 2000,
-            "api_key": ANTHROPIC_API_KEY,
-        },
-    },
-    "embedder": (
-        {
+# Detect LLM backend at import time
+_backend = detect_backend()
+LLM_BACKEND = _backend
+
+
+def build_mem0_config(backend: dict = None) -> dict:
+    """Build Mem0 config using detected backend."""
+    if backend is None:
+        backend = _backend
+
+    # Embedder: always fastembed by default, Voyage if key available
+    if VOYAGE_API_KEY:
+        embedder_config = {
             "provider": "openai",
             "config": {
                 "model": "voyage-3-large",
                 "api_key": VOYAGE_API_KEY,
                 "openai_base_url": "https://api.voyageai.com/v1",
             },
-        } if VOYAGE_API_KEY else {
+        }
+        embedding_dims = 1024
+    else:
+        embedder_config = {
             "provider": "fastembed",
             "config": {
-                "model": "thenlper/gte-large",
+                "model": "BAAI/bge-small-en-v1.5",  # 67MB, fast
             },
         }
-    ),
-    "vector_store": {
-        "provider": "qdrant",
-        "config": {
-            "collection_name": "aletheia_memories",
-            "host": QDRANT_HOST,
-            "port": QDRANT_PORT,
-            "embedding_model_dims": 1024,
+        embedding_dims = 384  # bge-small-en-v1.5
+
+    config = {
+        "embedder": embedder_config,
+        "vector_store": {
+            "provider": "qdrant",
+            "config": {
+                "collection_name": "aletheia_memories",
+                "host": QDRANT_HOST,
+                "port": QDRANT_PORT,
+                "embedding_model_dims": embedding_dims,
+            },
         },
-    },
-    "graph_store": {
-        "provider": "neo4j",
-        "config": {
-            "url": NEO4J_URL,
-            "username": NEO4J_USER,
-            "password": NEO4J_PASSWORD,
-            "base_label": True,
+        "graph_store": {
+            "provider": "neo4j",
+            "config": {
+                "url": NEO4J_URL,
+                "username": NEO4J_USER,
+                "password": NEO4J_PASSWORD,
+                "base_label": True,
+            },
         },
-    },
-    "custom_prompt": GRAPH_EXTRACTION_PROMPT,
-    "custom_fact_extraction_prompt": FACT_EXTRACTION_PROMPT,
-}
+        "custom_prompt": GRAPH_EXTRACTION_PROMPT,
+        "custom_fact_extraction_prompt": FACT_EXTRACTION_PROMPT,
+    }
+
+    # Add LLM config
+    if backend["config"]:
+        # Tier 1 api-key or Tier 2 ollama: use their native config
+        config["llm"] = backend["config"]
+    elif backend["provider"] == "anthropic-oauth":
+        # OAuth mode: Mem0 needs an LLM config to init, but we'll replace
+        # the LLM instance after creation. Use a placeholder.
+        config["llm"] = {
+            "provider": "anthropic",
+            "config": {
+                "model": backend.get("model", "claude-haiku-4-5-20251001"),
+                "api_key": "oauth-placeholder-replaced-at-runtime",
+                "temperature": 0.1,
+                "max_tokens": 2000,
+            },
+        }
+
+    return config
+
+
+# Build the config for backward compat
+MEM0_CONFIG = build_mem0_config()

--- a/infrastructure/memory/sidecar/aletheia_memory/llm_backend.py
+++ b/infrastructure/memory/sidecar/aletheia_memory/llm_backend.py
@@ -1,0 +1,225 @@
+"""Three-tier LLM backend detection for memory extraction.
+
+Tier 1: Anthropic (OAuth token from gateway, or API key)
+Tier 2: Ollama (local, auto-detect best model)
+Tier 3: None (embedding-only mode, no fact extraction)
+"""
+
+import json
+import logging
+import os
+from pathlib import Path
+from typing import Optional
+
+log = logging.getLogger("aletheia.memory.llm")
+
+OAUTH_CREDS_PATH = Path.home() / ".aletheia" / "credentials" / "anthropic.json"
+OLLAMA_URL = os.environ.get("OLLAMA_URL", "http://localhost:11434")
+
+# Models suitable for structured JSON extraction, in preference order
+OLLAMA_PREFERRED_MODELS = [
+    "qwen2.5:7b",
+    "qwen2.5:3b",
+    "llama3.1:8b",
+    "gemma2:9b",
+    "mistral:7b",
+    "phi3:3.8b",
+]
+
+HAIKU_MODEL = "claude-haiku-4-5-20251001"
+
+
+class OAuthAnthropicLLM:
+    """Anthropic LLM using OAuth token instead of API key.
+
+    Subclasses Mem0's AnthropicLLM at runtime, overriding __init__
+    to use auth_token. This lets Mem0's extraction pipeline work
+    unchanged.
+    """
+
+    @staticmethod
+    def create(auth_token: str, model: str = HAIKU_MODEL):
+        """Create a Mem0-compatible AnthropicLLM using OAuth.
+
+        Returns a patched instance that Mem0 can use directly.
+        """
+        from mem0.llms.anthropic import AnthropicLLM
+        from mem0.configs.llms.anthropic import AnthropicConfig
+        import anthropic as anthropic_sdk
+
+        config = AnthropicConfig(
+            model=model,
+            temperature=0.1,
+            max_tokens=2000,
+            api_key="oauth-placeholder",  # Mem0 validates non-empty
+        )
+
+        instance = AnthropicLLM.__new__(AnthropicLLM)
+        instance.config = config
+
+        # Replace the client with one using auth_token
+        instance.client = anthropic_sdk.Anthropic(
+            auth_token=auth_token,
+            default_headers={"anthropic-beta": "oauth-2025-04-20"},
+        )
+
+        log.info(f"Anthropic OAuth LLM initialized (model={model})")
+        return instance
+
+
+def read_oauth_token() -> Optional[str]:
+    """Read OAuth token from gateway credentials file."""
+    if not OAUTH_CREDS_PATH.exists():
+        return None
+    try:
+        data = json.loads(OAUTH_CREDS_PATH.read_text())
+        token = data.get("token")
+        if token and len(token) > 20:
+            return token
+    except (json.JSONDecodeError, KeyError, OSError) as e:
+        log.warning(f"Failed to read OAuth token: {e}")
+    return None
+
+
+def _check_anthropic_api_key() -> Optional[str]:
+    """Check for ANTHROPIC_API_KEY env var."""
+    key = os.environ.get("ANTHROPIC_API_KEY", "").strip()
+    return key if key else None
+
+
+def _check_ollama() -> Optional[str]:
+    """Check if Ollama is running and find the best available model.
+
+    Returns model name or None.
+    """
+    try:
+        import httpx
+        r = httpx.get(f"{OLLAMA_URL}/api/tags", timeout=3.0)
+        if r.status_code != 200:
+            return None
+        data = r.json()
+        available = {m["name"] for m in data.get("models", [])}
+
+        # Try preferred models first
+        for model in OLLAMA_PREFERRED_MODELS:
+            if model in available:
+                log.info(f"Ollama: found preferred model {model}")
+                return model
+
+        # Fall back to any model with reasonable size
+        for m in data.get("models", []):
+            name = m["name"]
+            size_gb = m.get("size", 0) / (1024**3)
+            if size_gb >= 1.5:  # At least ~3B params
+                log.info(f"Ollama: using available model {name} ({size_gb:.1f}GB)")
+                return name
+
+        log.info("Ollama running but no suitable models found")
+        return None
+    except Exception:
+        return None
+
+
+def detect_backend() -> dict:
+    """Detect the best available LLM backend.
+
+    Returns a dict with:
+        tier: 1, 2, or 3
+        provider: "anthropic-oauth", "anthropic-apikey", "ollama", or "none"
+        model: model name (or None for tier 3)
+        config: partial Mem0 LLM config dict (or None for tier 3)
+        llm_instance: pre-built LLM instance for OAuth (or None)
+    """
+    # Tier 1a: OAuth token
+    token = read_oauth_token()
+    if token:
+        try:
+            llm = OAuthAnthropicLLM.create(token, HAIKU_MODEL)
+            # Quick validation: the client was created, that's enough
+            log.info("Tier 1: Anthropic via OAuth token")
+            return {
+                "tier": 1,
+                "provider": "anthropic-oauth",
+                "model": HAIKU_MODEL,
+                "config": None,  # We'll inject the LLM instance directly
+                "llm_instance": llm,
+                "oauth_token": token,
+            }
+        except Exception as e:
+            log.warning(f"OAuth token found but LLM init failed: {e}")
+
+    # Tier 1b: API key
+    api_key = _check_anthropic_api_key()
+    if api_key:
+        log.info("Tier 1: Anthropic via API key")
+        return {
+            "tier": 1,
+            "provider": "anthropic-apikey",
+            "model": HAIKU_MODEL,
+            "config": {
+                "provider": "anthropic",
+                "config": {
+                    "model": HAIKU_MODEL,
+                    "temperature": 0.1,
+                    "max_tokens": 2000,
+                    "api_key": api_key,
+                },
+            },
+            "llm_instance": None,
+            "oauth_token": None,
+        }
+
+    # Tier 2: Ollama
+    ollama_model = _check_ollama()
+    if ollama_model:
+        log.info(f"Tier 2: Ollama with {ollama_model}")
+        return {
+            "tier": 2,
+            "provider": "ollama",
+            "model": ollama_model,
+            "config": {
+                "provider": "ollama",
+                "config": {
+                    "model": ollama_model,
+                    "temperature": 0.1,
+                    "max_tokens": 2000,
+                    "ollama_base_url": OLLAMA_URL,
+                },
+            },
+            "llm_instance": None,
+            "oauth_token": None,
+        }
+
+    # Tier 3: No LLM
+    log.warning("Tier 3: No LLM available. Embedding-only mode.")
+    return {
+        "tier": 3,
+        "provider": "none",
+        "model": None,
+        "config": None,
+        "llm_instance": None,
+        "oauth_token": None,
+    }
+
+
+def refresh_oauth_token(current_backend: dict) -> dict:
+    """Re-read OAuth token if it changed. Returns updated backend or same."""
+    if current_backend["provider"] != "anthropic-oauth":
+        return current_backend
+
+    new_token = read_oauth_token()
+    if not new_token:
+        log.warning("OAuth token disappeared, falling back to re-detection")
+        return detect_backend()
+
+    if new_token != current_backend.get("oauth_token"):
+        log.info("OAuth token rotated, re-creating Anthropic client")
+        try:
+            llm = OAuthAnthropicLLM.create(new_token, HAIKU_MODEL)
+            current_backend["llm_instance"] = llm
+            current_backend["oauth_token"] = new_token
+        except Exception as e:
+            log.warning(f"Token refresh failed: {e}, falling back")
+            return detect_backend()
+
+    return current_backend

--- a/infrastructure/memory/sidecar/aletheia_memory/reindex.py
+++ b/infrastructure/memory/sidecar/aletheia_memory/reindex.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""Fix zero-vector points in Qdrant by re-computing embeddings.
+
+Run standalone:
+    python -m aletheia_memory.reindex
+
+Or import and call:
+    from aletheia_memory.reindex import reindex_zero_vectors
+    reindex_zero_vectors()
+"""
+
+import logging
+import os
+import sys
+
+from qdrant_client import QdrantClient
+from qdrant_client.models import PointStruct, VectorParams, Distance
+
+log = logging.getLogger("aletheia.memory.reindex")
+
+QDRANT_HOST = os.environ.get("QDRANT_HOST", "localhost")
+QDRANT_PORT = int(os.environ.get("QDRANT_PORT", "6333"))
+COLLECTION = "aletheia_memories"
+
+
+def get_embedder():
+    """Get the configured embedder."""
+    voyage_key = os.environ.get("VOYAGE_API_KEY", "")
+    if voyage_key:
+        from openai import OpenAI
+        client = OpenAI(api_key=voyage_key, base_url="https://api.voyageai.com/v1")
+        def embed(text):
+            r = client.embeddings.create(input=[text.replace("\n", " ")], model="voyage-3-large")
+            return r.data[0].embedding
+        return embed, 1024
+    else:
+        try:
+            from fastembed import TextEmbedding
+            model = TextEmbedding("BAAI/bge-small-en-v1.5")
+            def embed(text):
+                return list(model.embed([text]))[0].tolist()
+            return embed, 384
+        except ImportError:
+            log.error("No embedder available. Install fastembed: pip install fastembed")
+            return None, 0
+
+
+def reindex_zero_vectors(dry_run=False):
+    """Find points with zero/missing vectors and recompute embeddings."""
+    client = QdrantClient(host=QDRANT_HOST, port=QDRANT_PORT)
+
+    # Check collection exists
+    collections = [c.name for c in client.get_collections().collections]
+    if COLLECTION not in collections:
+        log.info(f"Collection {COLLECTION} doesn't exist. Nothing to reindex.")
+        return 0
+
+    info = client.get_collection(COLLECTION)
+    total_points = info.points_count
+    total_vectors = info.indexed_vectors_count or 0
+    log.info(f"Collection: {total_points} points, {total_vectors} vectors")
+
+    if total_vectors >= total_points and total_vectors > 0:
+        log.info("All points have vectors. Nothing to reindex.")
+        return 0
+
+    embed_fn, dims = get_embedder()
+    if not embed_fn:
+        return 0
+
+    # Ensure collection has correct vector config
+    # If vectors_count is 0, the collection may need vector params set
+    if total_vectors == 0 and total_points > 0:
+        log.info(f"Recreating collection with {dims}-dim vectors (preserving points)")
+        # We need to scroll all points, recreate collection, and re-insert
+        # Qdrant doesn't allow adding vector config after creation
+
+        all_points = []
+        offset = None
+        while True:
+            result = client.scroll(
+                collection_name=COLLECTION,
+                limit=100,
+                offset=offset,
+                with_payload=True,
+                with_vectors=False,
+            )
+            points, next_offset = result
+            all_points.extend(points)
+            if next_offset is None:
+                break
+            offset = next_offset
+
+        log.info(f"Scrolled {len(all_points)} points")
+
+        if dry_run:
+            log.info(f"[DRY RUN] Would re-embed {len(all_points)} points")
+            return len(all_points)
+
+        # Recreate collection
+        client.recreate_collection(
+            collection_name=COLLECTION,
+            vectors_config=VectorParams(size=dims, distance=Distance.COSINE),
+        )
+
+        # Re-insert with embeddings
+        batch = []
+        reindexed = 0
+        for point in all_points:
+            payload = point.payload or {}
+            text = payload.get("memory", payload.get("data", payload.get("text", "")))
+            if not text:
+                log.debug(f"Point {point.id}: no text field, skipping")
+                continue
+
+            try:
+                vector = embed_fn(text)
+                batch.append(PointStruct(
+                    id=point.id,
+                    vector=vector,
+                    payload=payload,
+                ))
+                reindexed += 1
+
+                if len(batch) >= 50:
+                    client.upsert(collection_name=COLLECTION, points=batch)
+                    log.info(f"Re-embedded {reindexed}/{len(all_points)} points")
+                    batch = []
+            except Exception as e:
+                log.warning(f"Point {point.id}: embedding failed: {e}")
+
+        if batch:
+            client.upsert(collection_name=COLLECTION, points=batch)
+
+        log.info(f"Reindex complete: {reindexed}/{len(all_points)} points re-embedded")
+        return reindexed
+
+    return 0
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+    dry = "--dry-run" in sys.argv
+    n = reindex_zero_vectors(dry_run=dry)
+    print(f"Reindexed: {n}")


### PR DESCRIPTION
## What

The memory sidecar currently requires `ANTHROPIC_API_KEY` to function. If the key is missing, the sidecar starts but all memory operations fail silently (Qdrant points get stored with zero vectors).

This PR makes the sidecar self-configuring: it detects what's available at startup and adapts.

## Three-tier LLM detection

| Tier | Provider | Detection | Capabilities |
|------|----------|-----------|-------------|
| 1a | Anthropic OAuth | Reads `~/.aletheia/credentials/anthropic.json` | Full: extraction + embedding + graph |
| 1b | Anthropic API key | `ANTHROPIC_API_KEY` env var | Full: extraction + embedding + graph |
| 2 | Ollama | Probes `localhost:11434`, picks best model | Full: extraction + embedding + graph |
| 3 | None | No LLM found | Embedding-only: vector search works, no fact extraction |

## Key changes

- **`llm_backend.py`** (new): Three-tier detection logic, `OAuthAnthropicLLM` subclass that uses `auth_token` instead of API key
- **`config.py`**: Dynamic config via `build_mem0_config()` instead of static dict. Switches embedder to `bge-small-en-v1.5` (67MB, fast) when Voyage isn't available
- **`app.py`**: Backend-aware startup — conditional patching, OAuth LLM injection into Mem0 instance, tier-3 graceful degradation
- **`routes.py`**: Tier-3 embedding-only path in `/add`, LLM backend info in `/health`
- **`reindex.py`** (new): Fix zero-vector points by re-computing embeddings with current config

## Why OAuth matters

Aletheia's gateway authenticates via Anthropic OAuth tokens (stored in `~/.aletheia/credentials/`). The sidecar previously couldn't use these — it only accepted `ANTHROPIC_API_KEY`. Since most deployments use the gateway's OAuth flow, the sidecar was effectively broken out of the box.

The `OAuthAnthropicLLM` class wraps Mem0's `AnthropicLLM`, replacing the client with one using `auth_token`. Token rotation is handled on health checks.

## Tested

- Sidecar starts with tier-1 OAuth, all health checks pass
- Re-indexed 379 existing zero-vector points to full 384-dim vectors
- Semantic search returns relevant results with good scores
- `/health` reports backend tier, provider, model, and extraction status