### PR TITLE
spec 8 phase 2: structured distillation summary

### DIFF
--- a/infrastructure/runtime/src/distillation/chunked-summarize.ts
+++ b/infrastructure/runtime/src/distillation/chunked-summarize.ts
@@ -132,8 +132,9 @@ export async function summarizeInStages(
     model,
     system:
       "Merge these partial summaries of your own conversation into a single cohesive summary. " +
+      "Use these sections (omit any that are empty): ## Task Context, ## Completed Work, ## Key Decisions, ## Current State, ## Open Threads, ## Corrections. " +
       "Preserve all decisions, open items, technical details, and specific facts. " +
-      "Remove redundancies. Write in first person (\"I\"). Keep under 500 words.",
+      "Remove redundancies. Write in first person (\"I\"). Keep under 600 words.",
     messages: [{ role: "user", content: mergeContent }],
     maxTokens: 2048,
   });

--- a/infrastructure/runtime/src/distillation/summarize.ts
+++ b/infrastructure/runtime/src/distillation/summarize.ts
@@ -6,20 +6,33 @@ function buildSummaryPrompt(nousId?: string): string {
   const agentContext = nousId ? ` You are ${nousId}.` : "";
   return `You are summarizing your own conversation for continuity.${agentContext} You will read this summary later to recall what you were doing.
 
-Write a concise first-person narrative summary that captures:
-1. What I was working on and why
-2. Key decisions I made and my rationale
-3. Specific facts from tool results (file contents, command outputs, search results)
-4. Current state of work in progress (be specific about what's done vs pending)
-5. Open questions or blockers I need to resolve
+Write a structured summary using EXACTLY these sections. Include a section ONLY if there is content for it — omit empty sections entirely.
 
-Write in first person ("I was discussing...", "I decided to...").
-Be specific — "I was editing bootstrap.ts to add hash tracking" is better than "I was working on code changes."
-Preserve names, paths, numbers, and technical details exactly.
+## Task Context
+What the user asked for, what I was working on, and the goal. One to three sentences.
 
-If this conversation has already been summarized before (there is a previous summary at the start), focus on what happened AFTER that summary — don't re-summarize.
+## Completed Work
+What was accomplished, with specifics. Not "discussed PRs" but "reviewed and merged PRs #30-32, all clean, squash merged." Include file paths, command outputs, and technical details that matter.
 
-Keep it under 500 words. Focus on what I need to continue effectively.`;
+## Key Decisions
+Decisions made and WHY — the rationale matters as much as the decision. Format: "Decision: X. Reason: Y."
+
+## Current State
+Where we left off. What's in progress. What's half-done. Be specific about what's done vs. pending.
+
+## Open Threads
+Things mentioned but not yet addressed. Questions asked but not answered. Tasks deferred.
+
+## Corrections
+What was tried and didn't work. What was wrong and corrected. Prevents repeating mistakes.
+
+Rules:
+- Write in first person ("I was...", "I decided...").
+- Be specific — "I was editing bootstrap.ts line 42 to add hash tracking" not "I was working on code."
+- Preserve names, paths, numbers, and technical details exactly.
+- If this conversation already has a previous summary, focus on what happened AFTER it.
+- Keep each section concise. Total summary under 600 words.
+- Do NOT include sections that have no content.`;
 }
 
 export async function summarizeMessages(


### PR DESCRIPTION
## What

Replaces the narrative summary prompt with a structured, sectioned format.

## Why

A narrative blob can't simultaneously serve 'what am I doing?', 'what decisions were made?', and 'what failed?'. Agents have to read the whole thing to find what they need. Sectioned summaries let them scan.

## Sections

| Section | Purpose |
|---------|---------|
| Task Context | What and why (1-3 sentences) |
| Completed Work | Specifics with paths, outputs, details |
| Key Decisions | Decision + rationale pairs |
| Current State | Done vs. pending — where we left off |
| Open Threads | Deferred/unanswered items |
| Corrections | What failed — prevents repeating mistakes |

Empty sections are omitted entirely (not rendered with 'None').

## Changes

- `summarize.ts`: New structured prompt with section format, 600 word budget (up from 500)
- `chunked-summarize.ts`: Merge prompt updated to preserve section structure

## Risk

Low. The summary model (Haiku) should follow the section format reliably. If it doesn't, the result is still a readable summary — just less structured. No downstream code depends on the summary format.

Ref: `docs/specs/08_memory-continuity.md` Phase 2