### PR TITLE
spec 02: webchat UX — notifications, resilience, file editor

### DIFF
--- a/infrastructure/runtime/src/nous/pipeline/stages/finalize.ts
+++ b/infrastructure/runtime/src/nous/pipeline/stages/finalize.ts
@@ -41,6 +41,7 @@ export async function finalize(
   eventBus.emit("turn:after", {
     nousId, sessionId, toolCalls: totalToolCalls,
     inputTokens: totalInputTokens, outputTokens: totalOutputTokens,
+    text: outcome.text.slice(0, 120),
   });
 
   // Interaction signal classification

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -8,7 +8,16 @@
       "name": "aletheia-ui",
       "version": "0.1.0",
       "dependencies": {
+        "@codemirror/lang-css": "^6.3.1",
+        "@codemirror/lang-html": "^6.4.11",
+        "@codemirror/lang-javascript": "^6.2.4",
+        "@codemirror/lang-json": "^6.0.2",
+        "@codemirror/lang-markdown": "^6.5.0",
+        "@codemirror/lang-python": "^6.2.1",
+        "@codemirror/lang-yaml": "^6.1.2",
+        "@codemirror/theme-one-dark": "^6.1.3",
         "3d-force-graph": "^1.79.1",
+        "codemirror": "^6.0.2",
         "dompurify": "^3.2.0",
         "highlight.js": "^11.11.0",
         "marked": "^15.0.0",
@@ -72,6 +81,197 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@codemirror/autocomplete": {
+      "version": "6.20.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.20.0.tgz",
+      "integrity": "sha512-bOwvTOIJcG5FVo5gUUupiwYh8MioPLQ4UcqbcRf7UQ98X90tCa9E1kZ3Z7tqwpZxYyOvh1YTYbmZE9RTfTp5hg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/commands": {
+      "version": "6.10.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.10.2.tgz",
+      "integrity": "sha512-vvX1fsih9HledO1c9zdotZYUZnE4xV0m6i3m25s5DIfXofuprk6cRcLUZvSk3CASUbwjQX21tOGbkY2BH8TpnQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.4.0",
+        "@codemirror/view": "^6.27.0",
+        "@lezer/common": "^1.1.0"
+      }
+    },
+    "node_modules/@codemirror/lang-css": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-css/-/lang-css-6.3.1.tgz",
+      "integrity": "sha512-kr5fwBGiGtmz6l0LSJIbno9QrifNMUusivHbnA1H6Dmqy4HZFte3UAICix1VuKo0lMPKQr2rqB+0BkKi/S3Ejg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.0.2",
+        "@lezer/css": "^1.1.7"
+      }
+    },
+    "node_modules/@codemirror/lang-html": {
+      "version": "6.4.11",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-html/-/lang-html-6.4.11.tgz",
+      "integrity": "sha512-9NsXp7Nwp891pQchI7gPdTwBuSuT3K65NGTHWHNJ55HjYcHLllr0rbIZNdOzas9ztc1EUVBlHou85FFZS4BNnw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/lang-css": "^6.0.0",
+        "@codemirror/lang-javascript": "^6.0.0",
+        "@codemirror/language": "^6.4.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/css": "^1.1.0",
+        "@lezer/html": "^1.3.12"
+      }
+    },
+    "node_modules/@codemirror/lang-javascript": {
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-javascript/-/lang-javascript-6.2.4.tgz",
+      "integrity": "sha512-0WVmhp1QOqZ4Rt6GlVGwKJN3KW7Xh4H2q8ZZNGZaP6lRdxXJzmjm4FqvmOojVj6khWJHIb9sp7U/72W7xQgqAA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.6.0",
+        "@codemirror/lint": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/javascript": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-json": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-json/-/lang-json-6.0.2.tgz",
+      "integrity": "sha512-x2OtO+AvwEHrEwR0FyyPtfDUiloG3rnVTSZV1W8UteaLL8/MajQd8DpvUb2YVzC+/T18aSDv0H9mu+xw0EStoQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@lezer/json": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-markdown": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-markdown/-/lang-markdown-6.5.0.tgz",
+      "integrity": "sha512-0K40bZ35jpHya6FriukbgaleaqzBLZfOh7HuzqbMxBXkbYMJDxfF39c23xOgxFezR+3G+tR2/Mup+Xk865OMvw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.7.1",
+        "@codemirror/lang-html": "^6.0.0",
+        "@codemirror/language": "^6.3.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/common": "^1.2.1",
+        "@lezer/markdown": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-python": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-python/-/lang-python-6.2.1.tgz",
+      "integrity": "sha512-IRjC8RUBhn9mGR9ywecNhB51yePWCGgvHfY1lWN/Mrp3cKuHr0isDKia+9HnvhiWNnMpbGhWrkhuWOc09exRyw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.3.2",
+        "@codemirror/language": "^6.8.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.2.1",
+        "@lezer/python": "^1.1.4"
+      }
+    },
+    "node_modules/@codemirror/lang-yaml": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-yaml/-/lang-yaml-6.1.2.tgz",
+      "integrity": "sha512-dxrfG8w5Ce/QbT7YID7mWZFKhdhsaTNOYjOkSIMt1qmC4VQnXSDSYVHHHn8k6kJUfIhtLo8t1JJgltlxWdsITw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.2.0",
+        "@lezer/lr": "^1.0.0",
+        "@lezer/yaml": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/language": {
+      "version": "6.12.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.12.1.tgz",
+      "integrity": "sha512-Fa6xkSiuGKc8XC8Cn96T+TQHYj4ZZ7RdFmXA3i9xe/3hLHfwPZdM+dqfX0Cp0zQklBKhVD8Yzc8LS45rkqcwpQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.23.0",
+        "@lezer/common": "^1.5.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0",
+        "style-mod": "^4.0.0"
+      }
+    },
+    "node_modules/@codemirror/lint": {
+      "version": "6.9.4",
+      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.9.4.tgz",
+      "integrity": "sha512-ABc9vJ8DEmvOWuH26P3i8FpMWPQkduD9Rvba5iwb6O3hxASgclm3T3krGo8NASXkHCidz6b++LWlzWIUfEPSWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.35.0",
+        "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/search": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.6.0.tgz",
+      "integrity": "sha512-koFuNXcDvyyotWcgOnZGmY7LZqEOXZaaxD/j6n18TCLx2/9HieZJ5H6hs1g8FiRxBD0DNfs0nXn17g872RmYdw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.37.0",
+        "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/state": {
+      "version": "6.5.4",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.5.4.tgz",
+      "integrity": "sha512-8y7xqG/hpB53l25CIoit9/ngxdfoG+fx+V3SHBrinnhOtLvKHRyAJJuHzkWrR4YXXLX8eXBsejgAAxHUOdW1yw==",
+      "license": "MIT",
+      "dependencies": {
+        "@marijn/find-cluster-break": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/theme-one-dark": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/theme-one-dark/-/theme-one-dark-6.1.3.tgz",
+      "integrity": "sha512-NzBdIvEJmx6fjeremiGp3t/okrLPYT0d9orIc7AFun8oZcRk58aejkqhv6spnz4MLAevrKNPMQYXEWMg4s+sKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/highlight": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/view": {
+      "version": "6.39.14",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.39.14.tgz",
+      "integrity": "sha512-WJcvgHm/6Q7dvGT0YFv/6PSkoc36QlR0VCESS6x9tGsnF1lWLmmYxOgX3HH6v8fo6AvSLgpcs+H0Olre6MKXlg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.5.0",
+        "crelt": "^1.0.6",
+        "style-mod": "^4.1.0",
+        "w3c-keyname": "^2.2.4"
       }
     },
     "node_modules/@csstools/color-helpers": {
@@ -680,6 +880,112 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@lezer/common": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.5.1.tgz",
+      "integrity": "sha512-6YRVG9vBkaY7p1IVxL4s44n5nUnaNnGM2/AckNgYOnxTG2kWh1vR8BMxPseWPjRNpb5VtXnMpeYAEAADoRV1Iw==",
+      "license": "MIT"
+    },
+    "node_modules/@lezer/css": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@lezer/css/-/css-1.3.1.tgz",
+      "integrity": "sha512-PYAKeUVBo3HFThruRyp/iK91SwiZJnzXh8QzkQlwijB5y+N5iB28+iLk78o2zmKqqV0uolNhCwFqB8LA7b0Svg==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/highlight": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.3.tgz",
+      "integrity": "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/html": {
+      "version": "1.3.13",
+      "resolved": "https://registry.npmjs.org/@lezer/html/-/html-1.3.13.tgz",
+      "integrity": "sha512-oI7n6NJml729m7pjm9lvLvmXbdoMoi2f+1pwSDJkl9d68zGr7a9Btz8NdHTGQZtW2DA25ybeuv/SyDb9D5tseg==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/javascript": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@lezer/javascript/-/javascript-1.5.4.tgz",
+      "integrity": "sha512-vvYx3MhWqeZtGPwDStM2dwgljd5smolYD2lR2UyFcHfxbBQebqx8yjmFmxtJ/E6nN6u1D9srOiVWm3Rb4tmcUA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.1.3",
+        "@lezer/lr": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/json": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@lezer/json/-/json-1.0.3.tgz",
+      "integrity": "sha512-BP9KzdF9Y35PDpv04r0VeSTKDeox5vVr3efE7eBbx3r4s3oNLfunchejZhjArmeieBH+nVOpgIiBJpEAv8ilqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/lr": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.8.tgz",
+      "integrity": "sha512-bPWa0Pgx69ylNlMlPvBPryqeLYQjyJjqPx+Aupm5zydLIF3NE+6MMLT8Yi23Bd9cif9VS00aUebn+6fDIGBcDA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/markdown": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@lezer/markdown/-/markdown-1.6.3.tgz",
+      "integrity": "sha512-jpGm5Ps+XErS+xA4urw7ogEGkeZOahVQF21Z6oECF0sj+2liwZopd2+I8uH5I/vZsRuuze3OxBREIANLf6KKUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.5.0",
+        "@lezer/highlight": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/python": {
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/@lezer/python/-/python-1.1.18.tgz",
+      "integrity": "sha512-31FiUrU7z9+d/ElGQLJFXl+dKOdx0jALlP3KEOsGTex8mvj+SoE1FgItcHWK/axkxCHGUSpqIHt6JAWfWu9Rhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/yaml": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@lezer/yaml/-/yaml-1.0.4.tgz",
+      "integrity": "sha512-2lrrHqxalACEbxIbsjhqGpSW8kWpUKuY6RHgnSAFZa6qK62wvnPxA8hGOwOoDbwHcOFs5M4o27mjGu+P7TvBmw==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.4.0"
+      }
+    },
+    "node_modules/@marijn/find-cluster-break": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
+      "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
+      "license": "MIT"
     },
     "node_modules/@oxlint/binding-android-arm-eabi": {
       "version": "1.48.0",
@@ -1798,6 +2104,27 @@
         "node": ">=6"
       }
     },
+    "node_modules/codemirror": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-6.0.2.tgz",
+      "integrity": "sha512-VhydHotNW5w1UGK0Qj96BwSk/Zqbp9WbnyK2W/eVMv4QyF41INRGpjUhFJY7/uDNuudSc33a/PKr4iDqRduvHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/commands": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/lint": "^6.0.0",
+        "@codemirror/search": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0"
+      }
+    },
+    "node_modules/crelt": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
+      "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
+      "license": "MIT"
+    },
     "node_modules/cssstyle": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
@@ -2847,6 +3174,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/style-mod": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
+      "integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
+      "license": "MIT"
+    },
     "node_modules/svelte": {
       "version": "5.53.0",
       "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.53.0.tgz",
@@ -3272,6 +3605,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/w3c-keyname": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+      "license": "MIT"
     },
     "node_modules/w3c-xmlserializer": {
       "version": "5.0.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -26,7 +26,16 @@
     "vitest": "^3.0.0"
   },
   "dependencies": {
+    "@codemirror/lang-css": "^6.3.1",
+    "@codemirror/lang-html": "^6.4.11",
+    "@codemirror/lang-javascript": "^6.2.4",
+    "@codemirror/lang-json": "^6.0.2",
+    "@codemirror/lang-markdown": "^6.5.0",
+    "@codemirror/lang-python": "^6.2.1",
+    "@codemirror/lang-yaml": "^6.1.2",
+    "@codemirror/theme-one-dark": "^6.1.3",
     "3d-force-graph": "^1.79.1",
+    "codemirror": "^6.0.2",
     "dompurify": "^3.2.0",
     "highlight.js": "^11.11.0",
     "marked": "^15.0.0",

--- a/ui/src/components/agents/AgentCard.svelte
+++ b/ui/src/components/agents/AgentCard.svelte
@@ -2,11 +2,12 @@
   import type { Agent } from "../../lib/types";
   import { formatTimeSince } from "../../lib/format";
 
-  let { agent, isActive = false, lastActivity, onclick }: {
+  let { agent, isActive = false, lastActivity, onclick, unreadCount = 0 }: {
     agent: Agent;
     isActive?: boolean;
     lastActivity?: string | null;
     onclick: () => void;
+    unreadCount?: number;
   } = $props();
 </script>
 
@@ -24,6 +25,9 @@
       <span class="activity">{formatTimeSince(lastActivity)}</span>
     {/if}
   </span>
+  {#if unreadCount > 0}
+    <span class="unread-badge">{unreadCount > 9 ? "9+" : unreadCount}</span>
+  {/if}
 </button>
 
 <style>
@@ -93,5 +97,20 @@
   .activity {
     font-size: 11px;
     color: var(--text-muted);
+  }
+  .unread-badge {
+    flex-shrink: 0;
+    min-width: 18px;
+    height: 18px;
+    padding: 0 5px;
+    border-radius: 9px;
+    background: var(--accent);
+    color: #fff;
+    font-size: 10px;
+    font-weight: 700;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    line-height: 1;
   }
 </style>

--- a/ui/src/components/files/FileEditor.svelte
+++ b/ui/src/components/files/FileEditor.svelte
@@ -1,0 +1,526 @@
+<script lang="ts">
+  import { onMount, onDestroy } from "svelte";
+  import type { FileTreeEntry } from "../../lib/types";
+  import { saveWorkspaceFile, fetchWorkspaceFile } from "../../lib/api";
+  import {
+    getTreeEntries,
+    isLoading,
+    isExpanded,
+    toggleDir,
+    loadTree,
+    loadGitStatus,
+    getGitStatus,
+  } from "../../stores/files.svelte";
+  import { getActiveAgentId } from "../../stores/agents.svelte";
+  import Spinner from "../shared/Spinner.svelte";
+  import { EditorView, basicSetup } from "codemirror";
+  import { EditorState, type Extension } from "@codemirror/state";
+  import { keymap } from "@codemirror/view";
+  import { javascript } from "@codemirror/lang-javascript";
+  import { markdown } from "@codemirror/lang-markdown";
+  import { json } from "@codemirror/lang-json";
+  import { css } from "@codemirror/lang-css";
+  import { html } from "@codemirror/lang-html";
+  import { python } from "@codemirror/lang-python";
+  import { yaml } from "@codemirror/lang-yaml";
+  import { oneDark } from "@codemirror/theme-one-dark";
+
+  let { onClose }: { onClose: () => void } = $props();
+
+  let currentPath = $state<string | null>(null);
+  let isDirty = $state(false);
+  let saving = $state(false);
+  let fileLoading = $state(false);
+  let saveError = $state<string | null>(null);
+  let treeVisible = $state(true);
+  let filterText = $state("");
+  let showPreview = $state(false);
+  let previewHtml = $state("");
+
+  let editorContainer: HTMLDivElement;
+  let editorView: EditorView | null = null;
+  let originalContent = "";
+
+  onMount(() => {
+    const agentId = getActiveAgentId();
+    loadTree(agentId ?? undefined);
+    loadGitStatus(agentId ?? undefined);
+
+    const handler = (e: BeforeUnloadEvent) => {
+      if (isDirty) {
+        e.preventDefault();
+        e.returnValue = "";
+      }
+    };
+    window.addEventListener("beforeunload", handler);
+    return () => window.removeEventListener("beforeunload", handler);
+  });
+
+  onDestroy(() => {
+    editorView?.destroy();
+  });
+
+  function resolveLanguage(path: string): Extension {
+    const ext = path.split(".").pop()?.toLowerCase();
+    switch (ext) {
+      case "ts": case "tsx": return javascript({ typescript: true, jsx: ext.endsWith("x") });
+      case "js": case "jsx": case "mjs": return javascript({ jsx: ext.endsWith("x") });
+      case "md": return markdown();
+      case "json": return json();
+      case "yaml": case "yml": return yaml();
+      case "py": return python();
+      case "css": return css();
+      case "html": case "svelte": return html();
+      default: return [];
+    }
+  }
+
+  function initEditor(content: string, path: string) {
+    editorView?.destroy();
+    isDirty = false;
+    saveError = null;
+
+    const lang = resolveLanguage(path);
+    const extensions: Extension[] = [
+      basicSetup,
+      lang,
+      oneDark,
+      EditorView.updateListener.of((update) => {
+        if (update.docChanged) {
+          isDirty = true;
+          if (showPreview && isMarkdown(path)) {
+            updatePreview();
+          }
+        }
+      }),
+      keymap.of([{
+        key: "Mod-s",
+        run: () => { save(); return true; },
+      }]),
+      EditorView.theme({
+        "&": { height: "100%", fontSize: "13px" },
+        ".cm-scroller": { overflow: "auto", fontFamily: "var(--font-mono)" },
+        ".cm-content": { padding: "8px 0" },
+      }),
+    ];
+
+    const state = EditorState.create({ doc: content, extensions });
+    editorView = new EditorView({ state, parent: editorContainer });
+  }
+
+  function isMarkdown(path: string): boolean {
+    return path.endsWith(".md");
+  }
+
+  function updatePreview() {
+    if (!editorView) return;
+    const text = editorView.state.doc.toString();
+    // Simple markdown → HTML (basic rendering for preview)
+    previewHtml = text
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/^### (.+)$/gm, "<h3>$1</h3>")
+      .replace(/^## (.+)$/gm, "<h2>$1</h2>")
+      .replace(/^# (.+)$/gm, "<h1>$1</h1>")
+      .replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>")
+      .replace(/\*(.+?)\*/g, "<em>$1</em>")
+      .replace(/`(.+?)`/g, "<code>$1</code>")
+      .replace(/^- (.+)$/gm, "<li>$1</li>")
+      .replace(/\n\n/g, "<br><br>")
+      .replace(/\n/g, "<br>");
+  }
+
+  async function openFile(path: string) {
+    if (isDirty && !confirm("Discard unsaved changes?")) return;
+
+    fileLoading = true;
+    currentPath = path;
+    showPreview = false;
+    try {
+      const agentId = getActiveAgentId();
+      const data = await fetchWorkspaceFile(path, agentId ?? undefined);
+      originalContent = data.content;
+      if (editorContainer) {
+        initEditor(data.content, path);
+      }
+    } catch (err) {
+      saveError = `Failed to load: ${err instanceof Error ? err.message : String(err)}`;
+    } finally {
+      fileLoading = false;
+    }
+  }
+
+  async function save() {
+    if (!currentPath || !editorView || saving) return;
+    saving = true;
+    saveError = null;
+    try {
+      const content = editorView.state.doc.toString();
+      const agentId = getActiveAgentId();
+      await saveWorkspaceFile(currentPath, content, agentId ?? undefined);
+      originalContent = content;
+      isDirty = false;
+    } catch (err) {
+      saveError = err instanceof Error ? err.message : String(err);
+    } finally {
+      saving = false;
+    }
+  }
+
+  function fileIcon(name: string): string {
+    if (name.endsWith(".ts") || name.endsWith(".tsx")) return "TS";
+    if (name.endsWith(".js") || name.endsWith(".jsx")) return "JS";
+    if (name.endsWith(".svelte")) return "Sv";
+    if (name.endsWith(".css")) return "Cs";
+    if (name.endsWith(".json")) return "{}";
+    if (name.endsWith(".md")) return "Md";
+    if (name.endsWith(".py")) return "Py";
+    if (name.endsWith(".yaml") || name.endsWith(".yml")) return "Ym";
+    return "··";
+  }
+
+  function matchesFilter(entry: FileTreeEntry, path: string): boolean {
+    if (!filterText) return true;
+    const lower = filterText.toLowerCase();
+    if (entry.name.toLowerCase().includes(lower)) return true;
+    if (path.toLowerCase().includes(lower)) return true;
+    if (entry.type === "directory" && entry.children) {
+      return entry.children.some((child) => matchesFilter(child, `${path}/${child.name}`));
+    }
+    return false;
+  }
+
+  function gitStatusClass(status: string): string {
+    if (status.includes("M")) return "modified";
+    if (status.includes("A") || status === "??") return "added";
+    if (status.includes("D")) return "deleted";
+    return "";
+  }
+</script>
+
+<div class="file-editor">
+  {#if treeVisible}
+    <div class="editor-tree">
+      <div class="tree-header">
+        <span class="tree-title">Files</span>
+        <button class="icon-btn" onclick={() => {
+          const agentId = getActiveAgentId();
+          loadTree(agentId ?? undefined);
+          loadGitStatus(agentId ?? undefined);
+        }} title="Refresh">↻</button>
+        <button class="icon-btn" onclick={() => treeVisible = false} title="Hide tree">◀</button>
+      </div>
+      <div class="tree-filter">
+        <input type="text" placeholder="Filter..." bind:value={filterText} />
+      </div>
+      <div class="tree-list">
+        {#if isLoading()}
+          <div class="tree-msg"><Spinner size={14} /> Loading...</div>
+        {:else if getTreeEntries().length === 0}
+          <div class="tree-msg">No files</div>
+        {:else}
+          {#each getTreeEntries() as entry (entry.name)}
+            {#if matchesFilter(entry, entry.name)}
+              {@render treeNode(entry, entry.name, 0)}
+            {/if}
+          {/each}
+        {/if}
+      </div>
+    </div>
+  {/if}
+  <div class="editor-main">
+    <div class="editor-toolbar">
+      {#if !treeVisible}
+        <button class="icon-btn" onclick={() => treeVisible = true} title="Show tree">▶</button>
+      {/if}
+      {#if currentPath}
+        <span class="file-path">{currentPath}</span>
+        {#if isDirty}
+          <span class="dirty-dot" title="Unsaved changes"></span>
+        {/if}
+        {#if isMarkdown(currentPath)}
+          <button
+            class="toolbar-btn"
+            class:active={showPreview}
+            onclick={() => { showPreview = !showPreview; if (showPreview) updatePreview(); }}
+          >Preview</button>
+        {/if}
+        <button class="toolbar-btn save-btn" onclick={save} disabled={!isDirty || saving}>
+          {saving ? "Saving..." : "Save"}
+        </button>
+      {:else}
+        <span class="file-path placeholder">No file open</span>
+      {/if}
+      <button class="icon-btn close-btn" onclick={onClose} title="Close editor">×</button>
+    </div>
+    {#if saveError}
+      <div class="save-error">{saveError}</div>
+    {/if}
+    <div class="editor-content">
+      {#if fileLoading}
+        <div class="editor-loading"><Spinner size={16} /> Loading...</div>
+      {:else if showPreview && currentPath && isMarkdown(currentPath)}
+        <div class="preview-pane">{@html previewHtml}</div>
+      {:else if currentPath}
+        <div class="cm-wrapper" bind:this={editorContainer}></div>
+      {:else}
+        <div class="editor-empty">Select a file from the tree to edit</div>
+      {/if}
+    </div>
+  </div>
+</div>
+
+{#snippet treeNode(entry: FileTreeEntry, path: string, depth: number)}
+  {#if entry.type === "directory"}
+    <button
+      class="tree-item dir"
+      style="padding-left: {8 + depth * 14}px"
+      onclick={() => toggleDir(path)}
+    >
+      <span class="tree-chevron">{isExpanded(path) ? "▾" : "▸"}</span>
+      <span class="tree-name">{entry.name}</span>
+    </button>
+    {#if isExpanded(path) && entry.children}
+      {#each entry.children as child (child.name)}
+        {#if matchesFilter(child, `${path}/${child.name}`)}
+          {@render treeNode(child, `${path}/${child.name}`, depth + 1)}
+        {/if}
+      {/each}
+    {/if}
+  {:else}
+    {@const gs = getGitStatus(path)}
+    <button
+      class="tree-item file"
+      class:active={currentPath === path}
+      class:modified={gs ? gitStatusClass(gs) === "modified" : false}
+      class:added={gs ? gitStatusClass(gs) === "added" : false}
+      style="padding-left: {8 + depth * 14}px"
+      onclick={() => openFile(path)}
+    >
+      <span class="tree-ficon">{fileIcon(entry.name)}</span>
+      <span class="tree-name">{entry.name}</span>
+    </button>
+  {/if}
+{/snippet}
+
+<style>
+  .file-editor {
+    display: flex;
+    height: 100%;
+    min-height: 0;
+    overflow: hidden;
+    background: var(--bg);
+  }
+
+  /* Tree panel */
+  .editor-tree {
+    width: 200px;
+    min-width: 160px;
+    display: flex;
+    flex-direction: column;
+    border-right: 1px solid var(--border);
+    background: var(--bg-elevated);
+  }
+  .tree-header {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    padding: 6px 8px;
+    border-bottom: 1px solid var(--border);
+  }
+  .tree-title {
+    font-size: 12px;
+    font-weight: 600;
+    flex: 1;
+  }
+  .tree-filter {
+    padding: 4px 6px;
+    border-bottom: 1px solid var(--border);
+  }
+  .tree-filter input {
+    width: 100%;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 3px;
+    color: var(--text);
+    padding: 3px 6px;
+    font-size: 11px;
+    font-family: var(--font-sans);
+  }
+  .tree-filter input:focus {
+    outline: none;
+    border-color: var(--accent);
+  }
+  .tree-list {
+    flex: 1;
+    overflow-y: auto;
+    padding: 2px 0;
+  }
+  .tree-msg {
+    padding: 12px;
+    color: var(--text-muted);
+    font-size: 11px;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+  }
+  .tree-item {
+    display: flex;
+    align-items: center;
+    gap: 3px;
+    width: 100%;
+    padding: 2px 8px;
+    background: none;
+    border: none;
+    color: var(--text);
+    font-size: 11px;
+    text-align: left;
+    cursor: pointer;
+    white-space: nowrap;
+    overflow: hidden;
+  }
+  .tree-item:hover { background: var(--surface-hover); }
+  .tree-item.active { background: var(--surface); color: var(--accent); }
+  .tree-item.modified .tree-name { color: var(--yellow); }
+  .tree-item.added .tree-name { color: var(--green); }
+  .tree-chevron {
+    width: 10px;
+    font-size: 9px;
+    color: var(--text-muted);
+    flex-shrink: 0;
+  }
+  .tree-ficon {
+    width: 16px;
+    font-size: 8px;
+    font-family: var(--font-mono);
+    color: var(--text-muted);
+    flex-shrink: 0;
+    text-align: center;
+  }
+  .tree-name {
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  .tree-item.dir .tree-name { font-weight: 500; }
+
+  /* Main editor area */
+  .editor-main {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+  }
+  .editor-toolbar {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 8px;
+    border-bottom: 1px solid var(--border);
+    background: var(--bg-elevated);
+    min-height: 32px;
+  }
+  .file-path {
+    font-family: var(--font-mono);
+    font-size: 12px;
+    color: var(--text-secondary);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    flex: 1;
+  }
+  .file-path.placeholder { color: var(--text-muted); }
+  .dirty-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: var(--yellow);
+    flex-shrink: 0;
+  }
+  .icon-btn {
+    background: none;
+    border: none;
+    color: var(--text-muted);
+    font-size: 14px;
+    padding: 2px 4px;
+    border-radius: 3px;
+    cursor: pointer;
+    line-height: 1;
+  }
+  .icon-btn:hover { color: var(--text); background: var(--surface-hover); }
+  .close-btn { margin-left: auto; font-size: 18px; }
+  .toolbar-btn {
+    background: none;
+    border: 1px solid var(--border);
+    color: var(--text-secondary);
+    padding: 2px 8px;
+    border-radius: 3px;
+    font-size: 11px;
+    cursor: pointer;
+  }
+  .toolbar-btn:hover { color: var(--text); background: var(--surface); }
+  .toolbar-btn.active { color: var(--accent); border-color: var(--accent); }
+  .toolbar-btn:disabled { opacity: 0.4; cursor: default; }
+  .save-btn:not(:disabled) {
+    border-color: var(--accent);
+    color: var(--accent);
+  }
+  .save-btn:not(:disabled):hover {
+    background: var(--accent);
+    color: #fff;
+  }
+  .save-error {
+    padding: 4px 8px;
+    background: rgba(248, 81, 73, 0.1);
+    border-bottom: 1px solid var(--red);
+    color: var(--red);
+    font-size: 12px;
+  }
+  .editor-content {
+    flex: 1;
+    min-height: 0;
+    overflow: hidden;
+    display: flex;
+  }
+  .editor-loading, .editor-empty {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    width: 100%;
+    height: 100%;
+    color: var(--text-muted);
+    font-size: 13px;
+  }
+  .cm-wrapper {
+    width: 100%;
+    height: 100%;
+    overflow: hidden;
+  }
+  .cm-wrapper :global(.cm-editor) {
+    height: 100%;
+  }
+  .preview-pane {
+    flex: 1;
+    overflow: auto;
+    padding: 16px 24px;
+    font-size: 14px;
+    line-height: 1.6;
+    color: var(--text);
+  }
+  .preview-pane :global(h1) { font-size: 24px; margin: 16px 0 8px; }
+  .preview-pane :global(h2) { font-size: 20px; margin: 14px 0 6px; }
+  .preview-pane :global(h3) { font-size: 16px; margin: 12px 0 4px; }
+  .preview-pane :global(code) {
+    background: var(--surface);
+    padding: 1px 4px;
+    border-radius: 3px;
+    font-family: var(--font-mono);
+    font-size: 12px;
+  }
+  .preview-pane :global(strong) { color: var(--text); }
+  .preview-pane :global(li) {
+    margin-left: 20px;
+    list-style: disc;
+  }
+</style>

--- a/ui/src/components/layout/Sidebar.svelte
+++ b/ui/src/components/layout/Sidebar.svelte
@@ -6,6 +6,7 @@
     setActiveAgent,
   } from "../../stores/agents.svelte";
   import { loadSessions } from "../../stores/sessions.svelte";
+  import { getUnreadCount, markRead } from "../../stores/notifications.svelte";
 
   let { collapsed = false, onAgentSelect }: {
     collapsed?: boolean;
@@ -15,6 +16,7 @@
   function handleAgentClick(id: string) {
     setActiveAgent(id);
     loadSessions(id);
+    markRead(id);
     onAgentSelect?.();
   }
 
@@ -32,6 +34,7 @@
       <AgentCard
         {agent}
         isActive={agent.id === getActiveAgentId()}
+        unreadCount={getUnreadCount(agent.id)}
         onclick={() => handleAgentClick(agent.id)}
       />
     {/each}

--- a/ui/src/components/shared/Toast.svelte
+++ b/ui/src/components/shared/Toast.svelte
@@ -1,0 +1,105 @@
+<script lang="ts">
+  import { getToasts, dismissToast } from "../../stores/toast.svelte";
+  import { setActiveAgent } from "../../stores/agents.svelte";
+  import { loadSessions } from "../../stores/sessions.svelte";
+
+  function handleClick(agentId?: string, toastId?: string) {
+    if (agentId) {
+      setActiveAgent(agentId);
+      loadSessions(agentId);
+    }
+    if (toastId) dismissToast(toastId);
+  }
+</script>
+
+{#if getToasts().length > 0}
+  <div class="toast-container">
+    {#each getToasts() as toast (toast.id)}
+      <div
+        class="toast"
+        role="button"
+        tabindex="0"
+        onclick={() => handleClick(toast.agentId, toast.id)}
+        onkeydown={(e: KeyboardEvent) => { if (e.key === "Enter") handleClick(toast.agentId, toast.id); }}
+      >
+        <span class="toast-header">
+          {#if toast.emoji}<span class="toast-emoji">{toast.emoji}</span>{/if}
+          <span class="toast-agent">{toast.agentName}</span>
+          <span
+            class="toast-dismiss"
+            role="button"
+            tabindex="0"
+            onclick={(e: MouseEvent) => { e.stopPropagation(); dismissToast(toast.id); }}
+            onkeydown={(e: KeyboardEvent) => { if (e.key === "Enter") { e.stopPropagation(); dismissToast(toast.id); } }}
+          >×</span>
+        </span>
+        <span class="toast-preview">{toast.preview}</span>
+      </div>
+    {/each}
+  </div>
+{/if}
+
+<style>
+  .toast-container {
+    position: fixed;
+    bottom: 16px;
+    right: 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    z-index: 1000;
+    max-width: 340px;
+  }
+  .toast {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    padding: 10px 14px;
+    background: var(--bg-elevated);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    color: var(--text);
+    font-size: 13px;
+    text-align: left;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+    animation: slide-in 0.2s ease-out;
+    cursor: pointer;
+    width: 100%;
+  }
+  .toast:hover {
+    border-color: var(--accent);
+  }
+  .toast-header {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+  }
+  .toast-emoji {
+    font-size: 14px;
+  }
+  .toast-agent {
+    font-weight: 600;
+    flex: 1;
+  }
+  .toast-dismiss {
+    color: var(--text-muted);
+    font-size: 16px;
+    padding: 0 2px;
+    line-height: 1;
+    cursor: pointer;
+  }
+  .toast-dismiss:hover {
+    color: var(--text);
+  }
+  .toast-preview {
+    color: var(--text-secondary);
+    font-size: 12px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  @keyframes slide-in {
+    from { transform: translateX(100%); opacity: 0; }
+    to { transform: translateX(0); opacity: 1; }
+  }
+</style>

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -188,6 +188,17 @@ export async function fetchWorkspaceFile(
   return fetchJson(`/api/workspace/file?${sp.toString()}`);
 }
 
+export async function saveWorkspaceFile(
+  path: string,
+  content: string,
+  agentId?: string,
+): Promise<void> {
+  await fetchJson("/api/workspace/file", {
+    method: "PUT",
+    body: JSON.stringify({ path, content, ...(agentId ? { agentId } : {}) }),
+  });
+}
+
 export async function fetchGitStatus(
   agentId?: string,
 ): Promise<{ files: GitFileStatus[] }> {

--- a/ui/src/stores/chat.svelte.ts
+++ b/ui/src/stores/chat.svelte.ts
@@ -150,8 +150,6 @@ export async function sendMessage(
   state.activeToolCalls = [];
   state.abortController = new AbortController();
 
-  let needsTextSeparator = false;
-
   try {
     for await (const event of streamMessage(agentId, text, sessionKey, state.abortController!.signal, media)) {
       switch (event.type) {
@@ -160,11 +158,6 @@ export async function sendMessage(
           break;
 
         case "text_delta":
-          // Insert separator when text follows tool results (new content block)
-          if (needsTextSeparator && state.streamingText) {
-            state.streamingText += "\n\n";
-            needsTextSeparator = false;
-          }
           state.streamingText += event.text;
           break;
 
@@ -186,7 +179,6 @@ export async function sendMessage(
                 }
               : tc,
           );
-          needsTextSeparator = true;
           break;
 
         case "tool_approval_required":
@@ -218,7 +210,6 @@ export async function sendMessage(
           state.thinkingText = "";
           state.activeToolCalls = [];
           state.isStreaming = false;
-          needsTextSeparator = false;
           break;
         }
 

--- a/ui/src/stores/notifications.svelte.ts
+++ b/ui/src/stores/notifications.svelte.ts
@@ -1,0 +1,37 @@
+// Cross-agent notification state — unread badges + notification history
+interface Notification {
+  id: string;
+  agentId: string;
+  agentName: string;
+  preview: string;
+  timestamp: number;
+  read: boolean;
+}
+
+let notifications = $state<Notification[]>([]);
+
+export function addNotification(agentId: string, agentName: string, preview: string): void {
+  const id = `notif-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
+  notifications = [
+    { id, agentId, agentName, preview, timestamp: Date.now(), read: false },
+    ...notifications,
+  ].slice(0, 50);
+}
+
+export function getUnreadCount(agentId: string): number {
+  return notifications.filter((n) => n.agentId === agentId && !n.read).length;
+}
+
+export function getTotalUnreadCount(): number {
+  return notifications.filter((n) => !n.read).length;
+}
+
+export function markRead(agentId: string): void {
+  notifications = notifications.map((n) =>
+    n.agentId === agentId && !n.read ? { ...n, read: true } : n,
+  );
+}
+
+export function getNotifications(): Notification[] {
+  return notifications;
+}

--- a/ui/src/stores/toast.svelte.ts
+++ b/ui/src/stores/toast.svelte.ts
@@ -1,0 +1,31 @@
+// Toast notification queue — auto-dismiss after 5s
+interface ToastItem {
+  id: string;
+  agentName: string;
+  emoji?: string | null;
+  preview: string;
+  agentId?: string;
+}
+
+let toasts = $state<ToastItem[]>([]);
+
+export function showToast(
+  agentName: string,
+  emoji: string | null | undefined,
+  preview: string,
+  agentId?: string,
+): void {
+  const id = `toast-${Date.now()}`;
+  toasts = [...toasts, { id, agentName, emoji, preview, agentId }];
+  setTimeout(() => {
+    toasts = toasts.filter((t) => t.id !== id);
+  }, 5000);
+}
+
+export function getToasts(): ToastItem[] {
+  return toasts;
+}
+
+export function dismissToast(id: string): void {
+  toasts = toasts.filter((t) => t.id !== id);
+}


### PR DESCRIPTION
## Summary

Implements [spec 02](docs/specs/02_webchat-ux.md) — four webchat UX problems resolved:

- **Cross-agent notifications**: SSE endpoint (`GET /api/events`) bridges eventBus to clients. Unread badges on agent cards, toast popups with click-to-switch, auto-dismiss after 5s
- **Refresh resilience**: Streaming turns survive page refresh — server no longer aborts on client disconnect. Poll fallback (30s) when SSE drops, immediate history reload on reconnect
- **Tool output fix**: Removed `needsTextSeparator` that was inserting `\n\n` between tool_result and next text_delta, breaking mid-word output
- **File editor**: Split pane layout with resizable divider. CodeMirror 6 editor with syntax highlighting (TS/JS/Python/JSON/YAML/CSS/HTML/Markdown), Cmd+S save, dirty indicator, unsaved changes guard, markdown preview toggle

### Server changes
- `GET /api/events` — persistent SSE, init snapshot, keepalive ping, cleanup on disconnect
- `PUT /api/workspace/file` — save with path traversal protection
- Streaming: removed abort-on-disconnect, graceful client disconnect handling
- `turn:after` event enriched with text preview for notifications

### Client changes (14 files, 4 new)
- Notification store + toast store + Toast component
- AgentCard unread badge, Sidebar markRead wiring
- ChatView: notification triggers for non-active agents, poll fallback
- Layout: split pane with resize handle, file panel toggle
- FileEditor: CodeMirror 6, tree browser, save, preview

## Test plan
- [x] Runtime typecheck clean (`npx tsc --noEmit`)
- [x] `build-messages.test.ts` — 4 tests pass
- [x] UI builds clean (`npm run build`)
- [ ] Manual: verify SSE connects (network tab `/api/events`)
- [ ] Manual: send Signal message to agent A while viewing B → badge + toast
- [ ] Manual: start long tool loop, refresh → turn continues, result appears
- [ ] Manual: multi-tool turn → no split lines after tool calls
- [ ] Manual: toggle file panel → side-by-side with chat, edit + Cmd+S save

🤖 Generated with [Claude Code](https://claude.com/claude-code)