### PR TITLE
feat(memory): semantic working state — task continuity across distillation

### DIFF
--- a/infrastructure/runtime/src/mneme/schema.ts
+++ b/infrastructure/runtime/src/mneme/schema.ts
@@ -227,4 +227,11 @@ export const MIGRATIONS: Array<{ version: number; sql: string }> = [
       CREATE INDEX IF NOT EXISTS idx_sessions_thread ON sessions(thread_id);
     `,
   },
+  {
+    version: 9,
+    sql: `
+      -- Working state: structured task context that survives distillation
+      ALTER TABLE sessions ADD COLUMN working_state TEXT;
+    `,
+  },
 ];

--- a/infrastructure/runtime/src/nous/working-state.test.ts
+++ b/infrastructure/runtime/src/nous/working-state.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import { formatWorkingState } from "./working-state.js";
+import type { WorkingState } from "../mneme/store.js";
+
+describe("formatWorkingState", () => {
+  it("formats a complete working state", () => {
+    const state: WorkingState = {
+      currentTask: "Reviewing PR #49 for recall performance fix",
+      completedSteps: ["Read recall.ts diff", "Verified test coverage"],
+      nextSteps: ["Merge PR", "Redeploy"],
+      recentDecisions: ["Decision: vector-first search — because graph adds 1.8s latency"],
+      openFiles: ["src/nous/recall.ts", "src/nous/recall.test.ts"],
+      updatedAt: "2026-02-20T17:50:00Z",
+    };
+
+    const result = formatWorkingState(state);
+
+    expect(result).toContain("## Working State");
+    expect(result).toContain("Reviewing PR #49");
+    expect(result).toContain("Read recall.ts diff");
+    expect(result).toContain("Merge PR");
+    expect(result).toContain("vector-first search");
+    expect(result).toContain("src/nous/recall.ts");
+  });
+
+  it("omits empty sections", () => {
+    const state: WorkingState = {
+      currentTask: "Investigating timeout issue",
+      completedSteps: [],
+      nextSteps: [],
+      recentDecisions: [],
+      openFiles: [],
+      updatedAt: "2026-02-20T17:50:00Z",
+    };
+
+    const result = formatWorkingState(state);
+
+    expect(result).toContain("Investigating timeout issue");
+    expect(result).not.toContain("Completed");
+    expect(result).not.toContain("Next");
+    expect(result).not.toContain("Decisions");
+    expect(result).not.toContain("Files");
+  });
+
+  it("handles all fields populated", () => {
+    const state: WorkingState = {
+      currentTask: "Task",
+      completedSteps: ["Step 1"],
+      nextSteps: ["Next 1"],
+      recentDecisions: ["Decision 1"],
+      openFiles: ["file.ts"],
+      updatedAt: "2026-02-20T17:50:00Z",
+    };
+
+    const result = formatWorkingState(state);
+
+    expect(result).toContain("**Current task:**");
+    expect(result).toContain("**Completed:**");
+    expect(result).toContain("**Next:**");
+    expect(result).toContain("**Decisions:**");
+    expect(result).toContain("**Files:**");
+  });
+});

--- a/infrastructure/runtime/src/nous/working-state.ts
+++ b/infrastructure/runtime/src/nous/working-state.ts
@@ -1,0 +1,133 @@
+// Working state extractor — lightweight post-turn extraction of task context
+// Runs on a cheap model after each turn to maintain structured task state
+// that survives distillation.
+import { createLogger } from "../koina/logger.js";
+import type { ProviderRouter } from "../hermeneus/router.js";
+import type { WorkingState } from "../mneme/store.js";
+
+const log = createLogger("working-state");
+
+const EXTRACTION_PROMPT = `You are extracting structured task context from a conversation turn. Output valid JSON only — no markdown, no explanation.
+
+Given the assistant's last response and any tool calls, extract:
+
+{
+  "currentTask": "One-line description of what's being worked on right now",
+  "completedSteps": ["Step that was just completed", "Another completed step"],
+  "nextSteps": ["What needs to happen next"],
+  "recentDecisions": ["Decision: X — because Y"],
+  "openFiles": ["file/paths/mentioned.ts"]
+}
+
+Rules:
+- currentTask: what is actively being worked on RIGHT NOW. Not history.
+- completedSteps: only steps completed in THIS turn (max 5).
+- nextSteps: immediate next actions, not long-term goals (max 3).
+- recentDecisions: decisions made with brief rationale (max 3).
+- openFiles: file paths referenced in tool calls (max 5).
+- If a field has no content, use an empty array [].
+- Keep everything concise — total output under 300 tokens.`;
+
+export async function extractWorkingState(
+  router: ProviderRouter,
+  assistantText: string,
+  toolSummary: string,
+  previousState: WorkingState | null,
+  model: string,
+): Promise<WorkingState | null> {
+  if (!assistantText && !toolSummary) return previousState;
+
+  const input = [
+    previousState
+      ? `Previous working state:\n${JSON.stringify(previousState, null, 2)}\n\n`
+      : "",
+    toolSummary ? `Tool calls this turn:\n${toolSummary}\n\n` : "",
+    `Assistant response:\n${assistantText.slice(0, 2000)}`,
+  ]
+    .filter(Boolean)
+    .join("");
+
+  try {
+    const result = await router.complete({
+      model,
+      system: EXTRACTION_PROMPT,
+      messages: [{ role: "user", content: input }],
+      maxTokens: 512,
+      temperature: 0,
+    });
+
+    const text = result.content
+      .filter((b): b is { type: "text"; text: string } => b.type === "text")
+      .map((b) => b.text)
+      .join("");
+
+    // Parse JSON — strip markdown fences if the model wraps it
+    const cleaned = text
+      .replace(/^```(?:json)?\s*\n?/m, "")
+      .replace(/\n?```\s*$/m, "")
+      .trim();
+
+    const parsed = JSON.parse(cleaned) as Record<string, unknown>;
+
+    const state: WorkingState = {
+      currentTask: typeof parsed["currentTask"] === "string" ? parsed["currentTask"] : "",
+      completedSteps: Array.isArray(parsed["completedSteps"])
+        ? (parsed["completedSteps"] as string[]).slice(0, 5)
+        : [],
+      nextSteps: Array.isArray(parsed["nextSteps"])
+        ? (parsed["nextSteps"] as string[]).slice(0, 3)
+        : [],
+      recentDecisions: Array.isArray(parsed["recentDecisions"])
+        ? (parsed["recentDecisions"] as string[]).slice(0, 3)
+        : [],
+      openFiles: Array.isArray(parsed["openFiles"])
+        ? (parsed["openFiles"] as string[]).slice(0, 5)
+        : [],
+      updatedAt: new Date().toISOString(),
+    };
+
+    // Don't store empty state
+    if (!state.currentTask && state.completedSteps.length === 0 && state.nextSteps.length === 0) {
+      return previousState;
+    }
+
+    return state;
+  } catch (err) {
+    log.debug(
+      `Working state extraction failed (non-fatal): ${err instanceof Error ? err.message : err}`,
+    );
+    return previousState;
+  }
+}
+
+export function formatWorkingState(state: WorkingState): string {
+  const sections: string[] = [];
+
+  if (state.currentTask) {
+    sections.push(`**Current task:** ${state.currentTask}`);
+  }
+
+  if (state.completedSteps.length > 0) {
+    sections.push(
+      `**Completed:** ${state.completedSteps.map((s) => `${s}`).join("; ")}`,
+    );
+  }
+
+  if (state.nextSteps.length > 0) {
+    sections.push(
+      `**Next:** ${state.nextSteps.map((s) => `${s}`).join("; ")}`,
+    );
+  }
+
+  if (state.recentDecisions.length > 0) {
+    sections.push(
+      `**Decisions:** ${state.recentDecisions.map((d) => `${d}`).join("; ")}`,
+    );
+  }
+
+  if (state.openFiles.length > 0) {
+    sections.push(`**Files:** ${state.openFiles.join(", ")}`);
+  }
+
+  return `## Working State\n\n${sections.join("\n")}`;
+}


### PR DESCRIPTION
## Problem

After distillation, the agent loses track of what it was actively working on. The summary narrative captures *what happened* but not *what's in progress right now*. The existing "Working State" injection was just session metrics (tool count, duration, context %).

## Solution

Post-turn extraction of structured task context using a cheap model (Haiku), persisted on the session, injected into the system prompt every turn.

### Working State Structure
```json
{
  "currentTask": "Reviewing PR #49 for recall performance fix",
  "completedSteps": ["Read recall.ts diff", "Verified test coverage"],
  "nextSteps": ["Merge PR", "Redeploy"],
  "recentDecisions": ["Decision: vector-first search — because graph adds 1.8s latency"],
  "openFiles": ["src/nous/recall.ts"]
}
```

### How it works
1. **After each tool-using turn:** Haiku extracts structured state from the assistant response + tool calls (~300 tokens, <1s)
2. **Stored on session:** JSON in `working_state` column (migration v9)
3. **Injected into system prompt:** Every turn, formatted as a `## Working State` block
4. **Survives distillation:** The state is on the session row, not in message history

### What's injected
```
## Working State

**Current task:** Reviewing PR #49 for recall performance fix
**Completed:** Read recall.ts diff; Verified test coverage
**Next:** Merge PR; Redeploy
**Decisions:** Decision: vector-first search — because graph adds 1.8s latency
**Files:** src/nous/recall.ts
```

### Changes
- Schema migration v9: `working_state TEXT` on sessions
- `working-state.ts`: extraction prompt, JSON parser, formatter
- Finalize stage: post-turn extraction hook (async, non-blocking — never fails the turn)
- Context stage: inject working state; session metrics moved to separate block
- Tests: 3/3 passing

### Cost
~500 tokens per extraction on Haiku = ~$0.003/turn. Only runs on tool-using turns (not pure conversation).

### Note
Pre-existing test failures in manager.test.ts and manager-streaming.test.ts (missing `getThinkingConfig` mock) — not introduced by this PR.

Spec: 08_memory-continuity.md Phase 4