### PR TITLE
fix: error handling sweep (spec 06 phase 5)

### DIFF
--- a/docs/specs/06_code-quality.md
+++ b/docs/specs/06_code-quality.md
@@ -1,6 +1,6 @@
 # Spec: Code Quality — Error Handling, Dead Code Audit, and Coding Standards
 
-**Status:** Phase 1-4 done (PRs #37, #45)  
+**Status:** Phase 1-5 done (PRs #37, #45, #52)
 **Author:** Syn  
 **Date:** 2026-02-19  
 

--- a/infrastructure/runtime/src/koina/safe.test.ts
+++ b/infrastructure/runtime/src/koina/safe.test.ts
@@ -1,0 +1,27 @@
+// trySafe / trySafeAsync tests
+import { describe, it, expect } from "vitest";
+import { trySafe, trySafeAsync } from "./safe.js";
+
+describe("trySafe", () => {
+  it("returns function result on success", () => {
+    expect(trySafe("test", () => 42, 0)).toBe(42);
+  });
+
+  it("returns fallback on throw", () => {
+    expect(trySafe("test", () => { throw new Error("boom"); }, "default")).toBe("default");
+  });
+
+  it("returns null fallback", () => {
+    expect(trySafe("test", () => { throw new Error("boom"); }, null)).toBeNull();
+  });
+});
+
+describe("trySafeAsync", () => {
+  it("returns promise result on success", async () => {
+    expect(await trySafeAsync("test", async () => 42, 0)).toBe(42);
+  });
+
+  it("returns fallback on rejection", async () => {
+    expect(await trySafeAsync("test", async () => { throw new Error("boom"); }, "default")).toBe("default");
+  });
+});

--- a/infrastructure/runtime/src/koina/safe.ts
+++ b/infrastructure/runtime/src/koina/safe.ts
@@ -1,0 +1,22 @@
+// Safe execution wrappers — explicit error boundaries for non-critical operations
+import { createLogger } from "./logger.js";
+
+const log = createLogger("safe");
+
+export function trySafe<T>(label: string, fn: () => T, fallback: T): T {
+  try {
+    return fn();
+  } catch (err) {
+    log.warn(`${label} failed (non-fatal): ${err instanceof Error ? err.message : err}`);
+    return fallback;
+  }
+}
+
+export async function trySafeAsync<T>(label: string, fn: () => Promise<T>, fallback: T): Promise<T> {
+  try {
+    return await fn();
+  } catch (err) {
+    log.warn(`${label} failed (non-fatal): ${err instanceof Error ? err.message : err}`);
+    return fallback;
+  }
+}

--- a/infrastructure/runtime/src/mneme/store.ts
+++ b/infrastructure/runtime/src/mneme/store.ts
@@ -1324,7 +1324,7 @@ export class SessionStore {
       .get(threadId) as Record<string, unknown> | undefined;
     if (!row) return null;
     let keyFacts: string[] = [];
-    try { keyFacts = JSON.parse(row["key_facts"] as string) as string[]; } catch { /* empty */ }
+    try { keyFacts = JSON.parse(row["key_facts"] as string) as string[]; } catch { /* malformed JSON in key_facts column */ }
     return {
       threadId: row["thread_id"] as string,
       summary: row["summary"] as string,

--- a/infrastructure/runtime/src/nous/pipeline/stages/finalize.ts
+++ b/infrastructure/runtime/src/nous/pipeline/stages/finalize.ts
@@ -5,7 +5,10 @@ import { classifyInteraction } from "../../interaction-signals.js";
 import { extractSkillCandidate, saveLearnedSkill } from "../../../organon/skill-learner.js";
 import { resolveWorkspace } from "../../../taxis/loader.js";
 import { eventBus } from "../../../koina/event-bus.js";
+import { createLogger } from "../../../koina/logger.js";
 import type { TurnState, RuntimeServices } from "../types.js";
+
+const log = createLogger("finalize");
 
 export async function finalize(
   state: TurnState,
@@ -67,7 +70,7 @@ export async function finalize(
     const skillsDir = join(resolveWorkspace(services.config, nous)!, "..", "..", "shared", "skills");
     extractSkillCandidate(services.router, turnToolCalls, skillModel, sessionId, seq, nousId)
       .then((candidate) => { if (candidate) saveLearnedSkill(candidate, skillsDir); })
-      .catch(() => {});
+      .catch((err) => { log.debug(`Skill extraction failed (non-fatal): ${err instanceof Error ? err.message : err}`); });
   }
 
   // Note: auto-distillation scheduling moved to NousManager (runs after session lock release)

--- a/infrastructure/runtime/src/organon/built-in/browser.ts
+++ b/infrastructure/runtime/src/organon/built-in/browser.ts
@@ -49,7 +49,7 @@ async function withPage<T>(fn: (page: Page) => Promise<T>): Promise<T> {
     if (!cleaned) {
       cleaned = true;
       pageCount--;
-      page.close().catch(() => {});
+      page.close().catch(() => { /* page cleanup */ });
     }
   };
 

--- a/infrastructure/runtime/src/organon/built-in/edit.ts
+++ b/infrastructure/runtime/src/organon/built-in/edit.ts
@@ -68,7 +68,7 @@ export const editTool: ToolHandler = {
       const updated = content.slice(0, idx) + newText + content.slice(idx + oldText.length);
       writeFileSync(resolved, updated, "utf-8");
 
-      try { commitWorkspaceChange(context.workspace, resolved, "edit"); } catch {}
+      try { commitWorkspaceChange(context.workspace, resolved, "edit"); } catch { /* git sync, non-critical */ }
       return `Edited ${filePath}: replaced ${oldText.length} chars with ${newText.length} chars`;
     } catch (error) {
       const msg = error instanceof Error ? error.message : String(error);

--- a/infrastructure/runtime/src/organon/built-in/mem0-search.ts
+++ b/infrastructure/runtime/src/organon/built-in/mem0-search.ts
@@ -1,5 +1,8 @@
 // Mem0 memory search tool — query long-term extracted memories
 import type { ToolHandler, ToolContext } from "../registry.js";
+import { createLogger } from "../../koina/logger.js";
+
+const log = createLogger("tool:mem0-search");
 
 const SIDECAR_URL = process.env["ALETHEIA_MEMORY_URL"] ?? "http://127.0.0.1:8230";
 const USER_ID = process.env["ALETHEIA_MEMORY_USER"] ?? "default";
@@ -74,8 +77,8 @@ export const mem0SearchTool: ToolHandler = {
         if (enhancedRes.ok) {
           results = await extract(enhancedRes);
         }
-      } catch {
-        // Fall through to tier 2
+      } catch (err) {
+        log.debug(`Tier 1 (enhanced) failed: ${err instanceof Error ? err.message : err}`);
       }
 
       // Tier 2: Graph-enhanced search (vector + graph neighbor expansion)
@@ -97,8 +100,8 @@ export const mem0SearchTool: ToolHandler = {
           if (graphRes.ok) {
             results = await extract(graphRes);
           }
-        } catch {
-          // Fall through to tier 3
+        } catch (err) {
+          log.debug(`Tier 2 (graph-enhanced) failed: ${err instanceof Error ? err.message : err}`);
         }
       }
 
@@ -129,8 +132,8 @@ export const mem0SearchTool: ToolHandler = {
           const agentResults = await extract(aRes);
           const globalResults = await extract(gRes);
           results = [...agentResults, ...globalResults];
-        } catch {
-          // All tiers failed
+        } catch (err) {
+          log.debug(`Tier 3 (basic) failed: ${err instanceof Error ? err.message : err}`);
         }
       }
 

--- a/infrastructure/runtime/src/organon/built-in/write.ts
+++ b/infrastructure/runtime/src/organon/built-in/write.ts
@@ -56,7 +56,7 @@ export const writeTool: ToolHandler = {
         flag: append ? "a" : "w",
         encoding: "utf-8",
       });
-      try { commitWorkspaceChange(context.workspace, resolved, append ? "append" : "write"); } catch {}
+      try { commitWorkspaceChange(context.workspace, resolved, append ? "append" : "write"); } catch { /* git sync, non-critical */ }
       return `Written to ${filePath}`;
     } catch (error) {
       const msg =

--- a/infrastructure/runtime/src/prostheke/loader.ts
+++ b/infrastructure/runtime/src/prostheke/loader.ts
@@ -89,7 +89,7 @@ function findManifest(pluginPath: string): string | null {
     const files = readdirSync(pluginPath);
     const pluginJson = files.find((f) => f.endsWith(".plugin.json"));
     if (pluginJson) return join(pluginPath, pluginJson);
-  } catch {}
+  } catch { /* directory may not exist */ }
 
   return null;
 }

--- a/infrastructure/runtime/src/semeion/listener.ts
+++ b/infrastructure/runtime/src/semeion/listener.ts
@@ -503,7 +503,7 @@ async function processTurn(
       return;
     }
 
-    sendTyping(client, target, true).catch(() => {});
+    sendTyping(client, target, true).catch(() => { /* typing indicator, non-critical */ });
 
     if (outcome.text) {
       await sendMessage(client, target, outcome.text);
@@ -513,7 +513,7 @@ async function processTurn(
       `Turn complete: ${outcome.nousId} session=${outcome.sessionId} tools=${outcome.toolCalls} in=${outcome.inputTokens} out=${outcome.outputTokens}`,
     );
   } catch (err) {
-    sendTyping(client, target, true).catch(() => {});
+    sendTyping(client, target, true).catch(() => { /* typing indicator, non-critical */ });
     log.error(`Turn failed: ${err instanceof Error ? err.message : err}`);
     if (err instanceof Error && err.stack) log.error(err.stack);
 

--- a/infrastructure/runtime/src/semeion/tts.ts
+++ b/infrastructure/runtime/src/semeion/tts.ts
@@ -81,7 +81,7 @@ async function synthesizeOpenAI(text: string, id: string, opts?: TtsOptions): Pr
   return {
     path: outPath,
     engine: "openai",
-    cleanup: () => { try { unlinkSync(outPath); } catch {} },
+    cleanup: () => { try { unlinkSync(outPath); } catch { /* file cleanup */ } },
   };
 }
 
@@ -107,7 +107,7 @@ function synthesizePiper(text: string, id: string, opts?: TtsOptions): TtsResult
   return {
     path: outPath,
     engine: "piper",
-    cleanup: () => { try { unlinkSync(outPath); } catch {} },
+    cleanup: () => { try { unlinkSync(outPath); } catch { /* file cleanup */ } },
   };
 }
 
@@ -124,7 +124,7 @@ export function cleanupTtsFiles(): void {
         if (now - st.mtimeMs > 3600_000) {
           unlinkSync(p);
         }
-      } catch {}
+      } catch { /* file may be locked or already removed */ }
     }
-  } catch {}
+  } catch { /* TTS dir may not exist yet */ }
 }


### PR DESCRIPTION
## Summary
- Add `koina/safe.ts` with `trySafe`/`trySafeAsync` error boundary wrappers for non-critical operations
- Add debug logging to mem0-search tiered fallback catches (3 tiers now observable)
- Add debug logging to skill extraction catch in finalize.ts
- Annotate all truly empty catch blocks with intent comments explaining why the error is suppressed
- Every catch block in the codebase now either logs, has an intent comment, or returns a meaningful value

## Audit findings
The codebase was already well-structured — no `throw "string"`, no bare empty catches in main request paths. Changes were primarily observability improvements (debug logging on fallback paths) and documentation (intent comments on cleanup catches).

## Test plan
- [x] TypeScript typecheck clean
- [x] 5 new tests pass (trySafe/trySafeAsync)
- [x] All existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)