### PR TITLE
feat(memory): working state + agent notes — distillation continuity

### DIFF
--- a/infrastructure/runtime/src/aletheia.ts
+++ b/infrastructure/runtime/src/aletheia.ts
@@ -33,6 +33,7 @@ import { createCheckCalibrationTool } from "./organon/built-in/check-calibration
 import { createWhatDoIKnowTool } from "./organon/built-in/what-do-i-know.js";
 import { createRecentCorrectionsTool } from "./organon/built-in/recent-corrections.js";
 import { createBlackboardTool } from "./organon/built-in/blackboard.js";
+import { createNoteTool } from "./organon/built-in/note.js";
 import { createContextCheckTool } from "./organon/built-in/context-check.js";
 import { createStatusReportTool } from "./organon/built-in/status-report.js";
 import { createResearchTool } from "./organon/built-in/research.js";
@@ -222,6 +223,7 @@ export function createRuntime(configPath?: string): AletheiaRuntime {
 
   // Cross-agent blackboard — persistent shared state with auto-expiry
   tools.register(createBlackboardTool(store));
+  tools.register(createNoteTool(store));
 
   // Meta-tools — composed pipelines
   const ctxCheckTool = createContextCheckTool(tools);

--- a/infrastructure/runtime/src/mneme/schema.ts
+++ b/infrastructure/runtime/src/mneme/schema.ts
@@ -227,4 +227,27 @@ export const MIGRATIONS: Array<{ version: number; sql: string }> = [
       CREATE INDEX IF NOT EXISTS idx_sessions_thread ON sessions(thread_id);
     `,
   },
+  {
+    version: 9,
+    sql: `
+      -- Working state: structured task context that survives distillation
+      ALTER TABLE sessions ADD COLUMN working_state TEXT;
+    `,
+  },
+  {
+    version: 10,
+    sql: `
+      -- Agent notes: explicit agent-written context that survives distillation
+      CREATE TABLE IF NOT EXISTS agent_notes (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        session_id TEXT NOT NULL REFERENCES sessions(id),
+        nous_id TEXT NOT NULL,
+        category TEXT NOT NULL DEFAULT 'context' CHECK(category IN ('task', 'decision', 'preference', 'correction', 'context')),
+        content TEXT NOT NULL,
+        created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+      );
+      CREATE INDEX IF NOT EXISTS idx_notes_session ON agent_notes(session_id);
+      CREATE INDEX IF NOT EXISTS idx_notes_nous ON agent_notes(nous_id);
+    `,
+  },
 ];

--- a/infrastructure/runtime/src/nous/pipeline/stages/context.ts
+++ b/infrastructure/runtime/src/nous/pipeline/stages/context.ts
@@ -1,9 +1,10 @@
-// Context stage — bootstrap assembly, recall, broadcasts, working state injection
+// Context stage — bootstrap assembly, recall, broadcasts, working state, notes injection
 import { createLogger, updateTurnContext } from "../../../koina/logger.js";
-import { estimateToolDefTokens } from "../../../hermeneus/token-counter.js";
+import { estimateToolDefTokens, estimateTokens } from "../../../hermeneus/token-counter.js";
 import { assembleBootstrap } from "../../bootstrap.js";
 import { detectBootstrapDiff, logBootstrapDiff } from "../../bootstrap-diff.js";
 import { recallMemories } from "../../recall.js";
+import { formatWorkingState } from "../../working-state.js";
 import { distillSession } from "../../../distillation/pipeline.js";
 import { eventBus } from "../../../koina/event-bus.js";
 import type { TurnState, RuntimeServices, SystemBlock } from "../types.js";
@@ -127,11 +128,43 @@ export async function buildContext(
     systemPrompt.push({ type: "text", text: `## Broadcasts\n\n${broadcastLines}` });
   }
 
-  // Working state injection
+  // Working state injection — semantic task context from post-turn extraction
   const currentSession = services.store.findSessionById(sessionId);
+  const workingState = currentSession?.workingState;
+  if (workingState) {
+    systemPrompt.push({
+      type: "text",
+      text: formatWorkingState(workingState),
+    });
+  }
+
+  // Agent notes injection — explicit notes written by the agent that survive distillation
+  const notes = services.store.getNotes(sessionId, { limit: 20 });
+  if (notes.length > 0) {
+    const NOTE_TOKEN_CAP = 2000;
+    const header = "## Agent Notes\n\nNotes you wrote during this session. These survive context distillation.\n\n";
+    let tokenCount = estimateTokens(header);
+    const noteLines: string[] = [];
+
+    for (const note of notes) {
+      const line = `- [${note.category}] ${note.content}`;
+      const lineTokens = estimateTokens(line + "\n");
+      if (tokenCount + lineTokens > NOTE_TOKEN_CAP) break;
+      noteLines.push(line);
+      tokenCount += lineTokens;
+    }
+
+    if (noteLines.length > 0) {
+      systemPrompt.push({
+        type: "text",
+        text: header + noteLines.join("\n"),
+      });
+    }
+  }
+
+  // Session metrics — injected every 8th turn for self-awareness
   const msgCount = currentSession?.messageCount ?? 0;
   if (msgCount > 0 && msgCount % 8 === 0) {
-    const recentTools = services.store.getRecentToolCalls(sessionId, 6);
     const elapsed = currentSession?.createdAt
       ? Math.round((Date.now() - new Date(currentSession.createdAt).getTime()) / 60000)
       : 0;
@@ -142,8 +175,7 @@ export async function buildContext(
     systemPrompt.push({
       type: "text",
       text:
-        `## Working State — Turn ${msgCount}\n\n` +
-        `Recent tools: ${recentTools.length > 0 ? recentTools.join(", ") : "none"}\n` +
+        `## Session Metrics — Turn ${msgCount}\n\n` +
         `Session duration: ${elapsed} min\n` +
         `Context utilization: ${utilization}%\n` +
         `Distillations: ${currentSession?.distillationCount ?? 0}`,

--- a/infrastructure/runtime/src/nous/working-state.test.ts
+++ b/infrastructure/runtime/src/nous/working-state.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import { formatWorkingState } from "./working-state.js";
+import type { WorkingState } from "../mneme/store.js";
+
+describe("formatWorkingState", () => {
+  it("formats a complete working state", () => {
+    const state: WorkingState = {
+      currentTask: "Reviewing PR #49 for recall performance fix",
+      completedSteps: ["Read recall.ts diff", "Verified test coverage"],
+      nextSteps: ["Merge PR", "Redeploy"],
+      recentDecisions: ["Decision: vector-first search — because graph adds 1.8s latency"],
+      openFiles: ["src/nous/recall.ts", "src/nous/recall.test.ts"],
+      updatedAt: "2026-02-20T17:50:00Z",
+    };
+
+    const result = formatWorkingState(state);
+
+    expect(result).toContain("## Working State");
+    expect(result).toContain("Reviewing PR #49");
+    expect(result).toContain("Read recall.ts diff");
+    expect(result).toContain("Merge PR");
+    expect(result).toContain("vector-first search");
+    expect(result).toContain("src/nous/recall.ts");
+  });
+
+  it("omits empty sections", () => {
+    const state: WorkingState = {
+      currentTask: "Investigating timeout issue",
+      completedSteps: [],
+      nextSteps: [],
+      recentDecisions: [],
+      openFiles: [],
+      updatedAt: "2026-02-20T17:50:00Z",
+    };
+
+    const result = formatWorkingState(state);
+
+    expect(result).toContain("Investigating timeout issue");
+    expect(result).not.toContain("Completed");
+    expect(result).not.toContain("Next");
+    expect(result).not.toContain("Decisions");
+    expect(result).not.toContain("Files");
+  });
+
+  it("handles all fields populated", () => {
+    const state: WorkingState = {
+      currentTask: "Task",
+      completedSteps: ["Step 1"],
+      nextSteps: ["Next 1"],
+      recentDecisions: ["Decision 1"],
+      openFiles: ["file.ts"],
+      updatedAt: "2026-02-20T17:50:00Z",
+    };
+
+    const result = formatWorkingState(state);
+
+    expect(result).toContain("**Current task:**");
+    expect(result).toContain("**Completed:**");
+    expect(result).toContain("**Next:**");
+    expect(result).toContain("**Decisions:**");
+    expect(result).toContain("**Files:**");
+  });
+});

--- a/infrastructure/runtime/src/nous/working-state.ts
+++ b/infrastructure/runtime/src/nous/working-state.ts
@@ -1,0 +1,133 @@
+// Working state extractor — lightweight post-turn extraction of task context
+// Runs on a cheap model after each turn to maintain structured task state
+// that survives distillation.
+import { createLogger } from "../koina/logger.js";
+import type { ProviderRouter } from "../hermeneus/router.js";
+import type { WorkingState } from "../mneme/store.js";
+
+const log = createLogger("working-state");
+
+const EXTRACTION_PROMPT = `You are extracting structured task context from a conversation turn. Output valid JSON only — no markdown, no explanation.
+
+Given the assistant's last response and any tool calls, extract:
+
+{
+  "currentTask": "One-line description of what's being worked on right now",
+  "completedSteps": ["Step that was just completed", "Another completed step"],
+  "nextSteps": ["What needs to happen next"],
+  "recentDecisions": ["Decision: X — because Y"],
+  "openFiles": ["file/paths/mentioned.ts"]
+}
+
+Rules:
+- currentTask: what is actively being worked on RIGHT NOW. Not history.
+- completedSteps: only steps completed in THIS turn (max 5).
+- nextSteps: immediate next actions, not long-term goals (max 3).
+- recentDecisions: decisions made with brief rationale (max 3).
+- openFiles: file paths referenced in tool calls (max 5).
+- If a field has no content, use an empty array [].
+- Keep everything concise — total output under 300 tokens.`;
+
+export async function extractWorkingState(
+  router: ProviderRouter,
+  assistantText: string,
+  toolSummary: string,
+  previousState: WorkingState | null,
+  model: string,
+): Promise<WorkingState | null> {
+  if (!assistantText && !toolSummary) return previousState;
+
+  const input = [
+    previousState
+      ? `Previous working state:\n${JSON.stringify(previousState, null, 2)}\n\n`
+      : "",
+    toolSummary ? `Tool calls this turn:\n${toolSummary}\n\n` : "",
+    `Assistant response:\n${assistantText.slice(0, 2000)}`,
+  ]
+    .filter(Boolean)
+    .join("");
+
+  try {
+    const result = await router.complete({
+      model,
+      system: EXTRACTION_PROMPT,
+      messages: [{ role: "user", content: input }],
+      maxTokens: 512,
+      temperature: 0,
+    });
+
+    const text = result.content
+      .filter((b): b is { type: "text"; text: string } => b.type === "text")
+      .map((b) => b.text)
+      .join("");
+
+    // Parse JSON — strip markdown fences if the model wraps it
+    const cleaned = text
+      .replace(/^```(?:json)?\s*\n?/m, "")
+      .replace(/\n?```\s*$/m, "")
+      .trim();
+
+    const parsed = JSON.parse(cleaned) as Record<string, unknown>;
+
+    const state: WorkingState = {
+      currentTask: typeof parsed["currentTask"] === "string" ? parsed["currentTask"] : "",
+      completedSteps: Array.isArray(parsed["completedSteps"])
+        ? (parsed["completedSteps"] as string[]).slice(0, 5)
+        : [],
+      nextSteps: Array.isArray(parsed["nextSteps"])
+        ? (parsed["nextSteps"] as string[]).slice(0, 3)
+        : [],
+      recentDecisions: Array.isArray(parsed["recentDecisions"])
+        ? (parsed["recentDecisions"] as string[]).slice(0, 3)
+        : [],
+      openFiles: Array.isArray(parsed["openFiles"])
+        ? (parsed["openFiles"] as string[]).slice(0, 5)
+        : [],
+      updatedAt: new Date().toISOString(),
+    };
+
+    // Don't store empty state
+    if (!state.currentTask && state.completedSteps.length === 0 && state.nextSteps.length === 0) {
+      return previousState;
+    }
+
+    return state;
+  } catch (err) {
+    log.debug(
+      `Working state extraction failed (non-fatal): ${err instanceof Error ? err.message : err}`,
+    );
+    return previousState;
+  }
+}
+
+export function formatWorkingState(state: WorkingState): string {
+  const sections: string[] = [];
+
+  if (state.currentTask) {
+    sections.push(`**Current task:** ${state.currentTask}`);
+  }
+
+  if (state.completedSteps.length > 0) {
+    sections.push(
+      `**Completed:** ${state.completedSteps.map((s) => `${s}`).join("; ")}`,
+    );
+  }
+
+  if (state.nextSteps.length > 0) {
+    sections.push(
+      `**Next:** ${state.nextSteps.map((s) => `${s}`).join("; ")}`,
+    );
+  }
+
+  if (state.recentDecisions.length > 0) {
+    sections.push(
+      `**Decisions:** ${state.recentDecisions.map((d) => `${d}`).join("; ")}`,
+    );
+  }
+
+  if (state.openFiles.length > 0) {
+    sections.push(`**Files:** ${state.openFiles.join(", ")}`);
+  }
+
+  return `## Working State\n\n${sections.join("\n")}`;
+}

--- a/infrastructure/runtime/src/organon/built-in/note.test.ts
+++ b/infrastructure/runtime/src/organon/built-in/note.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { SessionStore } from "../../mneme/store.js";
+import { createNoteTool } from "./note.js";
+import type { ToolContext } from "../registry.js";
+
+function makeContext(sessionId: string, nousId = "test-nous"): ToolContext {
+  return {
+    sessionId,
+    nousId,
+    sessionKey: "main",
+    workspace: "/tmp",
+    channel: "test",
+  };
+}
+
+describe("note tool", () => {
+  let tmpDir: string;
+  let store: SessionStore;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "note-test-"));
+    store = new SessionStore(join(tmpDir, "test.db"));
+  });
+
+  afterEach(() => {
+    store.close();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("adds a note", async () => {
+    const session = store.findOrCreateSession("test-nous", "main");
+    const tool = createNoteTool(store);
+    const ctx = makeContext(session.id);
+
+    const result = await tool.execute(
+      { action: "add", content: "Remember: user prefers dark mode", category: "preference" },
+      ctx,
+    );
+
+    expect(result).toContain("saved");
+    expect(result).toContain("preference");
+    expect(result).toContain("dark mode");
+  });
+
+  it("lists notes", async () => {
+    const session = store.findOrCreateSession("test-nous", "main");
+    const tool = createNoteTool(store);
+    const ctx = makeContext(session.id);
+
+    await tool.execute({ action: "add", content: "Note 1", category: "task" }, ctx);
+    await tool.execute({ action: "add", content: "Note 2", category: "decision" }, ctx);
+
+    const result = await tool.execute({ action: "list" }, ctx);
+
+    expect(result).toContain("Notes (2)");
+    expect(result).toContain("Note 1");
+    expect(result).toContain("Note 2");
+    expect(result).toContain("[task]");
+    expect(result).toContain("[decision]");
+  });
+
+  it("lists notes filtered by category", async () => {
+    const session = store.findOrCreateSession("test-nous", "main");
+    const tool = createNoteTool(store);
+    const ctx = makeContext(session.id);
+
+    await tool.execute({ action: "add", content: "Task note", category: "task" }, ctx);
+    await tool.execute({ action: "add", content: "Decision note", category: "decision" }, ctx);
+
+    const result = await tool.execute({ action: "list", category: "task" }, ctx);
+
+    expect(result).toContain("Task note");
+    expect(result).not.toContain("Decision note");
+  });
+
+  it("deletes a note", async () => {
+    const session = store.findOrCreateSession("test-nous", "main");
+    const tool = createNoteTool(store);
+    const ctx = makeContext(session.id);
+
+    await tool.execute({ action: "add", content: "To delete", category: "context" }, ctx);
+    const listBefore = await tool.execute({ action: "list" }, ctx);
+    const idMatch = listBefore.match(/#(\d+)/);
+    const noteId = idMatch ? parseInt(idMatch[1]!, 10) : 0;
+
+    const deleteResult = await tool.execute({ action: "delete", id: noteId }, ctx);
+    expect(deleteResult).toContain("deleted");
+
+    const listAfter = await tool.execute({ action: "list" }, ctx);
+    expect(listAfter).toContain("No notes");
+  });
+
+  it("rejects empty content", async () => {
+    const session = store.findOrCreateSession("test-nous", "main");
+    const tool = createNoteTool(store);
+    const ctx = makeContext(session.id);
+
+    const result = await tool.execute({ action: "add", content: "" }, ctx);
+    expect(result).toContain("Error");
+  });
+
+  it("defaults to context category", async () => {
+    const session = store.findOrCreateSession("test-nous", "main");
+    const tool = createNoteTool(store);
+    const ctx = makeContext(session.id);
+
+    await tool.execute({ action: "add", content: "No category specified" }, ctx);
+    const result = await tool.execute({ action: "list" }, ctx);
+    expect(result).toContain("[context]");
+  });
+
+  it("truncates long content", async () => {
+    const session = store.findOrCreateSession("test-nous", "main");
+    const tool = createNoteTool(store);
+    const ctx = makeContext(session.id);
+
+    const longContent = "x".repeat(1000);
+    await tool.execute({ action: "add", content: longContent }, ctx);
+    const result = await tool.execute({ action: "list" }, ctx);
+    // Content should be truncated to 500 chars
+    expect(result.length).toBeLessThan(longContent.length);
+  });
+
+  it("returns empty list for no notes", async () => {
+    const session = store.findOrCreateSession("test-nous", "main");
+    const tool = createNoteTool(store);
+    const ctx = makeContext(session.id);
+
+    const result = await tool.execute({ action: "list" }, ctx);
+    expect(result).toContain("No notes");
+  });
+});

--- a/infrastructure/runtime/src/organon/built-in/note.ts
+++ b/infrastructure/runtime/src/organon/built-in/note.ts
@@ -1,0 +1,132 @@
+// Agent notes tool — explicit persistent memory that survives distillation
+import type { ToolHandler, ToolContext } from "../registry.js";
+import type { SessionStore } from "../../mneme/store.js";
+
+const VALID_CATEGORIES = ["task", "decision", "preference", "correction", "context"] as const;
+type NoteCategory = (typeof VALID_CATEGORIES)[number];
+const MAX_NOTES_PER_SESSION = 50;
+const MAX_NOTE_LENGTH = 500;
+
+export function createNoteTool(store: SessionStore): ToolHandler {
+  return {
+    definition: {
+      name: "note",
+      description:
+        "Write a note to your persistent session memory. Notes survive context distillation " +
+        "and are automatically included in your system prompt. Use for important context " +
+        "you don't want to lose across distillation boundaries.\n\n" +
+        "USE WHEN:\n" +
+        "- A significant decision is made and you want to remember why\n" +
+        "- The user states a preference or correction\n" +
+        "- You need to track task progress across potential distillations\n" +
+        "- Context that's critical but might be lost in summarization\n\n" +
+        "DO NOT USE WHEN:\n" +
+        "- The information is already in your workspace files (MEMORY.md, etc.)\n" +
+        "- It's a long-term fact better suited for mem0_search\n" +
+        "- The session is short and distillation is unlikely\n\n" +
+        "TIPS:\n" +
+        "- Actions: 'add', 'list', 'delete'\n" +
+        "- Categories: task, decision, preference, correction, context\n" +
+        "- Notes are per-session, ordered by creation time\n" +
+        "- Max 50 notes per session, 500 chars each\n" +
+        "- Notes are injected into your system prompt automatically",
+      input_schema: {
+        type: "object",
+        properties: {
+          action: {
+            type: "string",
+            description: "Action: 'add', 'list', 'delete'",
+          },
+          content: {
+            type: "string",
+            description: "Note content (required for 'add', max 500 chars)",
+          },
+          category: {
+            type: "string",
+            description:
+              "Note category: 'task' (progress tracking), 'decision' (choices made), " +
+              "'preference' (user preferences), 'correction' (things that were wrong), " +
+              "'context' (general important context). Default: 'context'",
+          },
+          id: {
+            type: "number",
+            description: "Note ID (required for 'delete')",
+          },
+        },
+        required: ["action"],
+      },
+    },
+
+    async execute(
+      input: Record<string, unknown>,
+      context: ToolContext,
+    ): Promise<string> {
+      const action = input["action"] as string;
+      const sessionId = context.sessionId;
+      const nousId = context.nousId;
+
+      if (!sessionId || !nousId) {
+        return "Error: note tool requires session and nous context.";
+      }
+
+      switch (action) {
+        case "add": {
+          const content = input["content"] as string | undefined;
+          if (!content?.trim()) {
+            return "Error: 'content' is required for 'add' action.";
+          }
+
+          const trimmed = content.trim().slice(0, MAX_NOTE_LENGTH);
+          const rawCategory = (input["category"] as string) ?? "context";
+          const category = VALID_CATEGORIES.includes(rawCategory as NoteCategory)
+            ? (rawCategory as NoteCategory)
+            : "context";
+
+          // Check note limit
+          const existing = store.getNotes(sessionId, { limit: MAX_NOTES_PER_SESSION + 1 });
+          if (existing.length >= MAX_NOTES_PER_SESSION) {
+            return `Error: Maximum ${MAX_NOTES_PER_SESSION} notes per session reached. Delete old notes first.`;
+          }
+
+          const id = store.addNote(sessionId, nousId, category, trimmed);
+          return `Note #${id} saved (${category}): "${trimmed}"`;
+        }
+
+        case "list": {
+          const filterCategory = input["category"] as string | undefined;
+          const notes = store.getNotes(sessionId, {
+            limit: 50,
+            ...(filterCategory && VALID_CATEGORIES.includes(filterCategory as NoteCategory)
+              ? { category: filterCategory as NoteCategory }
+              : {}),
+          });
+
+          if (notes.length === 0) {
+            return filterCategory
+              ? `No notes with category '${filterCategory}'.`
+              : "No notes in this session.";
+          }
+
+          const lines = notes.map(
+            (n) => `#${n.id} [${n.category}] ${n.content} (${n.createdAt})`,
+          );
+          return `Notes (${notes.length}):\n${lines.join("\n")}`;
+        }
+
+        case "delete": {
+          const noteId = input["id"] as number | undefined;
+          if (noteId === undefined || noteId === null) {
+            return "Error: 'id' is required for 'delete' action.";
+          }
+          const deleted = store.deleteNote(noteId, nousId);
+          return deleted
+            ? `Note #${noteId} deleted.`
+            : `Note #${noteId} not found or not owned by you.`;
+        }
+
+        default:
+          return `Unknown action '${action}'. Use 'add', 'list', or 'delete'.`;
+      }
+    },
+  };
+}


### PR DESCRIPTION
## Problem

After distillation, agents lose track of what they were actively working on. The summary captures *what happened* but not *what's in progress*. Agents also have no mechanism to explicitly flag context as "must survive distillation."

## Solution: Two complementary features

### Working State (Spec 08 Phase 4)
Post-turn extraction of structured task context using Haiku (~$0.003/turn):

```
## Working State

**Current task:** Reviewing PR #49 for recall performance fix
**Completed:** Read recall.ts diff; Verified test coverage
**Next:** Merge PR; Redeploy
**Decisions:** vector-first search — graph adds 1.8s latency
**Files:** src/nous/recall.ts
```

- Extracted after each tool-using turn (not pure conversation)
- Persisted on session row (migration v9)
- Injected into system prompt every turn

### Agent Notes (Spec 08 Phase 5)
Explicit `note` tool for agents to write sticky notes:

```
note add "User prefers squash merge for PRs" --category preference
note add "Tried graph-first approach, too slow" --category correction
note list
note delete 42
```

- Categories: task, decision, preference, correction, context
- Stored in `agent_notes` table (migration v10)
- Injected into system prompt with 2K token cap
- Max 50 notes/session, 500 chars each

### How they differ
| | Working State | Agent Notes |
|---|---|---|
| **Written by** | Automatic (post-turn extraction) | Explicit (agent tool call) |
| **Content** | Current task context | Anything worth remembering |
| **Updates** | Replaced each turn | Accumulated, manually managed |
| **Cost** | ~500 tokens on Haiku/turn | Zero (just DB writes) |

### Changes
- Schema: migrations v9 (working_state) + v10 (agent_notes)
- Store: WorkingState + AgentNote CRUD
- `working-state.ts`: extraction + formatting
- `note.ts`: tool with add/list/delete
- Finalize stage: post-turn extraction hook
- Context stage: injection of both + metrics separated
- Tests: 11/11 passing

Supersedes PR #51 (working state only).

Spec: 08_memory-continuity.md Phases 4-5