### PR TITLE
feat(ui): thinking UI pills + detail panel

### DIFF
--- a/ui/src/components/chat/ChatView.svelte
+++ b/ui/src/components/chat/ChatView.svelte
@@ -2,6 +2,7 @@
   import MessageList from "./MessageList.svelte";
   import InputBar from "./InputBar.svelte";
   import ToolPanel from "./ToolPanel.svelte";
+  import ThinkingPanel from "./ThinkingPanel.svelte";
   import ToolApproval from "./ToolApproval.svelte";
   import ErrorBanner from "../shared/ErrorBanner.svelte";
   import type { ToolCallState } from "../../lib/types";
@@ -283,6 +284,25 @@
     selectedTools = null;
   }
 
+  // Thinking panel state
+  let selectedThinking = $state<string | null>(null);
+  let thinkingIsLive = $state(false);
+
+  function handleThinkingClick(thinking?: string) {
+    if (thinking) {
+      selectedThinking = thinking;
+      thinkingIsLive = false;
+    } else {
+      selectedThinking = currentAgentId ? getThinkingText(currentAgentId) : "";
+      thinkingIsLive = true;
+    }
+  }
+
+  function closeThinkingPanel() {
+    selectedThinking = null;
+    thinkingIsLive = false;
+  }
+
   function handleAbort() {
     const id = getActiveAgentId();
     if (id) abortStream(id);
@@ -315,9 +335,17 @@
       agentName={agent?.name}
       agentEmoji={emoji}
       onToolClick={handleToolClick}
+      onThinkingClick={(thinking) => handleThinkingClick(thinking)}
     />
     {#if selectedTools}
       <ToolPanel tools={selectedTools} onClose={closeToolPanel} />
+    {/if}
+    {#if selectedThinking !== null}
+      <ThinkingPanel
+        thinkingText={thinkingIsLive && currentAgentId ? getThinkingText(currentAgentId) : selectedThinking}
+        isStreaming={thinkingIsLive && (currentAgentId ? getIsStreaming(currentAgentId) : false)}
+        onClose={closeThinkingPanel}
+      />
     {/if}
   </div>
   {#if pendingApproval}

--- a/ui/src/components/chat/Message.svelte
+++ b/ui/src/components/chat/Message.svelte
@@ -3,12 +3,14 @@
   import { formatTimestamp, formatDuration } from "../../lib/format";
   import Markdown from "./Markdown.svelte";
   import ToolStatusLine from "./ToolStatusLine.svelte";
+  import ThinkingStatusLine from "./ThinkingStatusLine.svelte";
 
-  let { message, agentName, agentEmoji, onToolClick }: {
+  let { message, agentName, agentEmoji, onToolClick, onThinkingClick }: {
     message: ChatMessage;
     agentName?: string | null;
     agentEmoji?: string | null;
     onToolClick?: (tools: ToolCallState[]) => void;
+    onThinkingClick?: (thinking: string) => void;
   } = $props();
 
   let isUser = $derived(message.role === "user");
@@ -105,10 +107,10 @@
       </div>
     {/if}
     {#if message.thinking}
-      <details class="thinking-block">
-        <summary class="thinking-summary">Thought process</summary>
-        <div class="thinking-content">{message.thinking}</div>
-      </details>
+      <ThinkingStatusLine
+        thinkingText={message.thinking}
+        onclick={() => onThinkingClick?.(message.thinking!)}
+      />
     {/if}
     {#if message.content}
       <div class="chat-content">
@@ -191,35 +193,6 @@
     border: 1px solid var(--border);
   }
 
-  .thinking-block {
-    margin-bottom: 8px;
-    border: 1px solid var(--border);
-    border-radius: var(--radius-sm);
-    overflow: hidden;
-  }
-  .thinking-summary {
-    padding: 6px 10px;
-    font-size: 12px;
-    color: var(--text-muted);
-    cursor: pointer;
-    user-select: none;
-    background: var(--surface);
-  }
-  .thinking-summary:hover {
-    color: var(--text-secondary);
-  }
-  .thinking-content {
-    padding: 8px 10px;
-    font-size: 12px;
-    color: var(--text-muted);
-    white-space: pre-wrap;
-    word-break: break-word;
-    max-height: 300px;
-    overflow-y: auto;
-    border-top: 1px solid var(--border);
-    font-family: var(--font-mono);
-    line-height: 1.5;
-  }
   .user-text {
     white-space: pre-wrap;
     word-break: break-word;

--- a/ui/src/components/chat/MessageList.svelte
+++ b/ui/src/components/chat/MessageList.svelte
@@ -4,6 +4,7 @@
   import Markdown from "./Markdown.svelte";
   import StreamingIndicator from "./StreamingIndicator.svelte";
   import ToolStatusLine from "./ToolStatusLine.svelte";
+  import ThinkingStatusLine from "./ThinkingStatusLine.svelte";
 
   let {
     messages,
@@ -14,6 +15,7 @@
     agentName,
     agentEmoji,
     onToolClick,
+    onThinkingClick,
   }: {
     messages: ChatMessage[];
     streamingText: string;
@@ -23,6 +25,7 @@
     agentName?: string | null;
     agentEmoji?: string | null;
     onToolClick?: (tools: ToolCallState[]) => void;
+    onThinkingClick?: (thinking?: string) => void;
   } = $props();
 
   let initials = $derived(agentName ? agentName.slice(0, 2).toUpperCase() : "AI");
@@ -67,7 +70,7 @@
     </div>
   {:else}
     {#each messages as message (message.id)}
-      <Message {message} {agentName} {agentEmoji} {onToolClick} />
+      <Message {message} {agentName} {agentEmoji} {onToolClick} onThinkingClick={(thinking) => onThinkingClick?.(thinking)} />
     {/each}
 
     {#if isStreaming}
@@ -81,10 +84,11 @@
         </div>
         <div class="chat-body">
           {#if thinkingText}
-            <details class="thinking-stream" open>
-              <summary class="thinking-summary">Thinking...</summary>
-              <div class="thinking-content">{thinkingText}</div>
-            </details>
+            <ThinkingStatusLine
+              {thinkingText}
+              isStreaming={true}
+              onclick={() => onThinkingClick?.()}
+            />
           {/if}
           {#if activeToolCalls.length > 0}
             <ToolStatusLine
@@ -150,38 +154,6 @@
     background: var(--accent);
     color: #fff;
     letter-spacing: 1px;
-  }
-
-  .thinking-stream {
-    margin-bottom: 8px;
-    border: 1px solid var(--border);
-    border-radius: var(--radius-sm);
-    overflow: hidden;
-  }
-  .thinking-summary {
-    padding: 6px 10px;
-    font-size: 12px;
-    color: var(--text-muted);
-    cursor: pointer;
-    user-select: none;
-    background: var(--surface);
-    animation: pulse 2s ease-in-out infinite;
-  }
-  @keyframes pulse {
-    0%, 100% { opacity: 0.6; }
-    50% { opacity: 1; }
-  }
-  .thinking-content {
-    padding: 8px 10px;
-    font-size: 12px;
-    color: var(--text-muted);
-    white-space: pre-wrap;
-    word-break: break-word;
-    max-height: 200px;
-    overflow-y: auto;
-    border-top: 1px solid var(--border);
-    font-family: var(--font-mono);
-    line-height: 1.5;
   }
 
   .scroll-btn {

--- a/ui/src/components/chat/ThinkingPanel.svelte
+++ b/ui/src/components/chat/ThinkingPanel.svelte
@@ -1,0 +1,149 @@
+<script lang="ts">
+  let { thinkingText, isStreaming = false, onClose }: {
+    thinkingText: string;
+    isStreaming?: boolean;
+    onClose: () => void;
+  } = $props();
+
+  let scrollContainer = $state<HTMLDivElement | null>(null);
+  let autoScroll = $state(true);
+
+  function checkScroll() {
+    if (!scrollContainer) return;
+    const threshold = 40;
+    autoScroll =
+      scrollContainer.scrollHeight - scrollContainer.scrollTop - scrollContainer.clientHeight < threshold;
+  }
+
+  $effect(() => {
+    void thinkingText;
+    if (autoScroll && scrollContainer) {
+      requestAnimationFrame(() => {
+        if (scrollContainer) scrollContainer.scrollTop = scrollContainer.scrollHeight;
+      });
+    }
+  });
+</script>
+
+<div class="thinking-panel">
+  <div class="panel-header">
+    <div class="header-top">
+      <span class="panel-title">Thinking</span>
+      {#if isStreaming}
+        <span class="live-badge">Live</span>
+      {/if}
+      <button class="close-btn" onclick={onClose} aria-label="Close">&times;</button>
+    </div>
+  </div>
+  <div
+    class="panel-body"
+    bind:this={scrollContainer}
+    onscroll={checkScroll}
+  >
+    {#if thinkingText}
+      <pre class="thinking-text">{thinkingText}</pre>
+    {:else}
+      <div class="empty-thinking">No thinking content yet.</div>
+    {/if}
+  </div>
+</div>
+
+<style>
+  .thinking-panel {
+    width: 380px;
+    max-width: 100%;
+    flex-shrink: 0;
+    display: flex;
+    flex-direction: column;
+    background: var(--bg-elevated);
+    border-left: 1px solid var(--border);
+    animation: slide-in 0.15s ease;
+    overflow: hidden;
+  }
+  @keyframes slide-in {
+    from { transform: translateX(16px); opacity: 0; }
+    to { transform: translateX(0); opacity: 1; }
+  }
+  .panel-header {
+    padding: 10px 12px;
+    border-bottom: 1px solid var(--border);
+    flex-shrink: 0;
+  }
+  .header-top {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+  .panel-title {
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--text);
+    flex: 1;
+  }
+  .live-badge {
+    font-size: 10px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--amber);
+    background: rgba(232, 169, 42, 0.1);
+    padding: 2px 6px;
+    border-radius: 8px;
+    border: 1px solid rgba(232, 169, 42, 0.2);
+    animation: pulse 2s ease-in-out infinite;
+  }
+  @keyframes pulse {
+    0%, 100% { opacity: 0.7; }
+    50% { opacity: 1; }
+  }
+  .close-btn {
+    width: 24px;
+    height: 24px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border: none;
+    background: none;
+    color: var(--text-muted);
+    font-size: 16px;
+    cursor: pointer;
+    border-radius: var(--radius-sm);
+    transition: background 0.15s, color 0.15s;
+    flex-shrink: 0;
+  }
+  .close-btn:hover {
+    background: var(--surface-hover);
+    color: var(--text);
+  }
+  .panel-body {
+    flex: 1;
+    overflow-y: auto;
+    overflow-x: hidden;
+    padding: 12px;
+    min-height: 0;
+  }
+  .thinking-text {
+    font-family: var(--font-mono);
+    font-size: 12px;
+    color: var(--text-secondary);
+    white-space: pre-wrap;
+    word-break: break-word;
+    line-height: 1.6;
+    margin: 0;
+  }
+  .empty-thinking {
+    color: var(--text-muted);
+    font-size: 13px;
+    text-align: center;
+    padding: 24px;
+  }
+
+  @media (max-width: 768px) {
+    .thinking-panel {
+      width: 100%;
+      position: absolute;
+      inset: 0;
+      z-index: 20;
+    }
+  }
+</style>

--- a/ui/src/components/chat/ThinkingStatusLine.svelte
+++ b/ui/src/components/chat/ThinkingStatusLine.svelte
@@ -1,0 +1,108 @@
+<script lang="ts">
+  import Spinner from "../shared/Spinner.svelte";
+
+  let { thinkingText, isStreaming = false, onclick }: {
+    thinkingText: string;
+    isStreaming?: boolean;
+    onclick?: () => void;
+  } = $props();
+
+  function extractSummary(text: string): string {
+    if (!text || text.length < 10) return "Thinking...";
+
+    const tail = text.slice(-300);
+
+    // Try to find last complete sentence
+    const sentenceMatch = tail.match(/[.!?]\s+([^.!?]+[.!?])\s*$/);
+    if (sentenceMatch) return sentenceMatch[1]!.trim().slice(0, 80);
+
+    // Fallback: last non-empty line
+    const lines = tail.split("\n").filter(Boolean);
+    const last = lines[lines.length - 1];
+    if (last && last.length > 10) {
+      const trimmed = last.trim();
+      return trimmed.length > 80 ? trimmed.slice(0, 77) + "..." : trimmed;
+    }
+
+    return "Thinking...";
+  }
+
+  let summary = $derived(extractSummary(thinkingText));
+</script>
+
+<button
+  class="thinking-status-line"
+  class:active={isStreaming}
+  onclick={() => onclick?.()}
+  title="Click to view full thinking"
+>
+  <span class="status-indicator">
+    {#if isStreaming}
+      <Spinner size={12} />
+    {:else}
+      <span class="icon-done">&#x2713;</span>
+    {/if}
+  </span>
+  <span class="status-text">{summary}</span>
+  <span class="chevron">&rsaquo;</span>
+</button>
+
+<style>
+  .thinking-status-line {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 10px;
+    margin-bottom: 6px;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-left: 3px solid var(--amber);
+    border-radius: 14px;
+    color: var(--text-secondary);
+    font-size: 12px;
+    font-family: var(--font-sans);
+    cursor: pointer;
+    transition: background 0.15s, border-color 0.15s, color 0.15s;
+    max-width: 100%;
+    white-space: nowrap;
+    overflow: hidden;
+  }
+  .thinking-status-line:hover {
+    background: var(--surface-hover);
+    border-color: var(--amber);
+    color: var(--text);
+  }
+  .thinking-status-line.active {
+    border-color: var(--amber);
+    color: var(--text);
+  }
+  .status-indicator {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 14px;
+    height: 14px;
+    flex-shrink: 0;
+  }
+  .icon-done {
+    color: var(--amber);
+    font-size: 11px;
+    font-weight: 700;
+  }
+  .status-text {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    min-width: 0;
+  }
+  .chevron {
+    color: var(--text-muted);
+    font-size: 14px;
+    flex-shrink: 0;
+    transition: transform 0.15s;
+  }
+  .thinking-status-line:hover .chevron {
+    transform: translateX(1px);
+    color: var(--amber);
+  }
+</style>

--- a/ui/src/styles/global.css
+++ b/ui/src/styles/global.css
@@ -15,6 +15,7 @@
   --green: #3fb950;
   --red: #f85149;
   --yellow: #d29922;
+  --amber: #e8a92a;
   --purple: #bc8cff;
 
   --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;


### PR DESCRIPTION
## Summary
- Replace raw `<details>` thinking blocks with styled amber pills matching tool status line pattern
- Live summary extraction shows the most recent thought during streaming
- Click pill to open right-side detail panel with full thinking text and auto-scroll
- Completed messages show collapsed pill with first/last sentence summary

## Changes
- **ThinkingStatusLine.svelte** (new) — amber-accented pill with sentence extraction from streaming text
- **ThinkingPanel.svelte** (new) — 380px right panel, auto-scroll, "Live" badge during stream
- **MessageList.svelte** — replaced `<details class="thinking-stream">` with ThinkingStatusLine
- **Message.svelte** — replaced `<details class="thinking-block">` with ThinkingStatusLine
- **ChatView.svelte** — wired thinking panel state alongside existing tool panel
- **global.css** — added `--amber` CSS variable

## Spec
Implements Phases 2-4 of `docs/specs/10_thinking-ui.md`

## Test plan
- [ ] Verify thinking pill renders with amber accent during streaming (when extended thinking enabled)
- [ ] Verify pill summary updates live with extracted sentence
- [ ] Click thinking pill → detail panel opens with full text and auto-scroll
- [ ] Completed messages show collapsed thinking pill (not raw `<details>`)
- [ ] Click completed pill → panel shows full thinking text
- [ ] No thinking = no pill (no empty amber pill visible)
- [ ] Tool pills and thinking pills coexist during interleaved turns
- [ ] UI builds clean (`npm run build` passes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)