### PR TITLE
fix: decouple watchdog probing from alerting

### DIFF
--- a/infrastructure/runtime/src/daemon/watchdog.ts
+++ b/infrastructure/runtime/src/daemon/watchdog.ts
@@ -12,7 +12,7 @@ export interface ServiceProbe {
 export interface WatchdogOpts {
   services: ServiceProbe[];
   intervalMs: number;
-  alertFn: (message: string) => Promise<void>;
+  alertFn?: (message: string) => Promise<void>;
 }
 
 const MAX_CONSECUTIVE_FAILURES = 100;
@@ -118,7 +118,7 @@ export class Watchdog {
       }
     }
 
-    if (alerts.length > 0) {
+    if (alerts.length > 0 && this.opts.alertFn) {
       const message = `Watchdog Alert\n${alerts.join("\n")}`;
       try {
         await this.opts.alertFn(message);


### PR DESCRIPTION
## Summary

- Watchdog now always starts when `watchdog.enabled = true`, regardless of Signal/alertRecipient config
- `alertFn` is optional in `WatchdogOpts` — only wired when Signal clients exist and `alertRecipient` is set
- Startup log now indicates whether alerts are active: `"Watchdog started: N services, alerts → Signal"` vs `"no alert channel"`

Fixes the dashboard showing `-` for service health on deployments without Signal configured.

## Test plan
- [ ] Confirm existing 4 watchdog tests still pass
- [ ] Start without Signal configured: watchdog probes all services, status visible in metrics
- [ ] Verify no alert errors logged when services go down without Signal
- [ ] Start with Signal configured: alert behavior unchanged