### PR TITLE
feat: oxlint coding standards enforcement

### DIFF
--- a/infrastructure/runtime/.oxlintrc.json
+++ b/infrastructure/runtime/.oxlintrc.json
@@ -1,18 +1,35 @@
 {
   "$schema": "./node_modules/oxlint/configuration_schema.json",
-  "plugins": ["typescript"],
+  "plugins": ["typescript", "import"],
   "categories": {
     "correctness": "error"
   },
   "rules": {
     "no-unused-vars": "warn",
-    "no-empty": "warn",
+    "no-empty": "error",
     "no-empty-function": "warn",
     "eqeqeq": "error",
     "require-await": "warn",
+    "sort-imports": [
+      "warn",
+      {
+        "ignoreDeclarationSort": true,
+        "ignoreCase": true,
+        "allowSeparatedGroups": true
+      }
+    ],
     "typescript/no-explicit-any": "warn",
     "typescript/no-floating-promises": "error",
-    "typescript/no-misused-promises": "error"
+    "typescript/no-misused-promises": "error",
+    "typescript/consistent-type-imports": [
+      "error",
+      {
+        "prefer": "type-imports",
+        "fixStyle": "separate-type-imports",
+        "disallowTypeAnnotations": false
+      }
+    ],
+    "import/no-duplicates": "error"
   },
   "settings": {},
   "ignorePatterns": ["dist/", "coverage/", "test-results/", "node_modules/"]

--- a/infrastructure/runtime/src/aletheia.ts
+++ b/infrastructure/runtime/src/aletheia.ts
@@ -1,7 +1,7 @@
 // Main orchestration — wire all modules
 import { join } from "node:path";
 import { createLogger } from "./koina/logger.js";
-import { loadConfig, applyEnv } from "./taxis/loader.js";
+import { applyEnv, loadConfig } from "./taxis/loader.js";
 import { paths } from "./taxis/paths.js";
 import { SessionStore } from "./mneme/store.js";
 import { createDefaultRouter, type ProviderRouter } from "./hermeneus/router.js";
@@ -41,25 +41,25 @@ import { createDeliberateTool } from "./organon/built-in/deliberate.js";
 import { createSelfAuthorTools, loadAuthoredTools } from "./organon/self-author.js";
 import { NousManager } from "./nous/manager.js";
 import { McpClientManager } from "./organon/mcp-client.js";
-import { createGateway, startGateway, setCronRef, setWatchdogRef, setSkillsRef, setMcpRef, setCommandsRef } from "./pylon/server.js";
+import { createGateway, setCommandsRef, setCronRef, setMcpRef, setSkillsRef, setWatchdogRef, startGateway } from "./pylon/server.js";
 import { createMcpRoutes } from "./pylon/mcp.js";
-import { createUiRoutes, broadcastEvent } from "./pylon/ui.js";
+import { broadcastEvent, createUiRoutes } from "./pylon/ui.js";
 import { SignalClient } from "./semeion/client.js";
 import {
+  type DaemonHandle,
+  daemonOptsFromConfig,
   spawnDaemon,
   waitForReady,
-  daemonOptsFromConfig,
-  type DaemonHandle,
 } from "./semeion/daemon.js";
 import { startListener } from "./semeion/listener.js";
-import { sendMessage, parseTarget } from "./semeion/sender.js";
+import { parseTarget, sendMessage } from "./semeion/sender.js";
 import { createDefaultRegistry } from "./semeion/commands.js";
 import { SkillRegistry } from "./organon/skills.js";
 import { loadPlugins } from "./prostheke/loader.js";
 import { PluginRegistry } from "./prostheke/registry.js";
 import { CronScheduler } from "./daemon/cron.js";
 import { runRetention } from "./daemon/retention.js";
-import { Watchdog, type ServiceProbe } from "./daemon/watchdog.js";
+import { type ServiceProbe, Watchdog } from "./daemon/watchdog.js";
 import { startUpdateChecker } from "./daemon/update-check.js";
 import { getVersion } from "./version.js";
 import { CompetenceModel } from "./nous/competence.js";

--- a/infrastructure/runtime/src/auth/middleware.ts
+++ b/infrastructure/runtime/src/auth/middleware.ts
@@ -2,9 +2,9 @@
 // Multi-mode auth middleware for Hono
 import type { Context, Next } from "hono";
 import { timingSafeEqual } from "node:crypto";
-import { verifyToken, signToken } from "./tokens.js";
+import { signToken, verifyToken } from "./tokens.js";
 import { verifyPassword } from "./passwords.js";
-import { AuthSessionStore } from "./sessions.js";
+import type { AuthSessionStore } from "./sessions.js";
 import type { AuditLog } from "./audit.js";
 import { getRequiredPermission, hasPermission } from "./rbac.js";
 

--- a/infrastructure/runtime/src/auth/passwords.ts
+++ b/infrastructure/runtime/src/auth/passwords.ts
@@ -1,6 +1,6 @@
 // TODO(unused): scaffolded for spec 3 (Auth & Updates) — not yet integrated into gateway
 // Password hashing — scrypt (node:crypto built-in, zero deps)
-import { scryptSync, randomBytes, timingSafeEqual } from "node:crypto";
+import { randomBytes, scryptSync, timingSafeEqual } from "node:crypto";
 
 const SALT_LENGTH = 32;
 const KEY_LENGTH = 64;

--- a/infrastructure/runtime/src/auth/sessions.ts
+++ b/infrastructure/runtime/src/auth/sessions.ts
@@ -2,7 +2,7 @@
 // Auth session CRUD — SQLite-backed
 import type Database from "better-sqlite3";
 import { createHash } from "node:crypto";
-import { generateSessionId, generateRefreshToken } from "./tokens.js";
+import { generateRefreshToken, generateSessionId } from "./tokens.js";
 
 export interface AuthSession {
   id: string;

--- a/infrastructure/runtime/src/auth/tls.ts
+++ b/infrastructure/runtime/src/auth/tls.ts
@@ -1,7 +1,7 @@
 // TODO(unused): scaffolded for spec 3 (Auth & Updates) — not yet integrated into gateway
 // TLS certificate generation and server setup
 import { generateKeyPairSync } from "node:crypto";
-import { readFileSync, writeFileSync, mkdirSync, mkdtempSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { createServer as createHttpsServer } from "node:https";

--- a/infrastructure/runtime/src/auth/tokens.ts
+++ b/infrastructure/runtime/src/auth/tokens.ts
@@ -1,6 +1,6 @@
 // TODO(unused): scaffolded for spec 3 (Auth & Updates) — not yet integrated into gateway
 // JWT signing/verification — HMAC-SHA256, zero external deps
-import { createHmac, timingSafeEqual, randomBytes } from "node:crypto";
+import { createHmac, randomBytes, timingSafeEqual } from "node:crypto";
 
 export interface AccessTokenPayload {
   sub: string; // username

--- a/infrastructure/runtime/src/daemon/cron-full.test.ts
+++ b/infrastructure/runtime/src/daemon/cron-full.test.ts
@@ -1,5 +1,5 @@
 // Extended cron tests — schedule parsing, tick execution, command jobs
-import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { CronScheduler } from "./cron.js";
 
 // We need to access computeNextRun indirectly through the scheduler

--- a/infrastructure/runtime/src/daemon/cron.test.ts
+++ b/infrastructure/runtime/src/daemon/cron.test.ts
@@ -1,5 +1,5 @@
 // Cron scheduler tests
-import { describe, it, expect, vi, afterEach } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { CronScheduler } from "./cron.js";
 
 function makeConfig(jobs: Array<Record<string, unknown>> = []) {

--- a/infrastructure/runtime/src/daemon/update-check.test.ts
+++ b/infrastructure/runtime/src/daemon/update-check.test.ts
@@ -1,5 +1,5 @@
 // Update check daemon tests
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // Extract isNewer for testing by re-implementing the logic
 // (the actual function is private, so we test via the module's behavior)

--- a/infrastructure/runtime/src/daemon/watchdog-full.test.ts
+++ b/infrastructure/runtime/src/daemon/watchdog-full.test.ts
@@ -1,5 +1,5 @@
 // Extended watchdog tests — health check logic, alerts, state transitions
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Watchdog } from "./watchdog.js";
 
 describe("Watchdog health checks", () => {

--- a/infrastructure/runtime/src/daemon/watchdog.test.ts
+++ b/infrastructure/runtime/src/daemon/watchdog.test.ts
@@ -1,5 +1,5 @@
 // Watchdog tests
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { Watchdog } from "./watchdog.js";
 
 describe("Watchdog", () => {

--- a/infrastructure/runtime/src/distillation/chunked-summarize.test.ts
+++ b/infrastructure/runtime/src/distillation/chunked-summarize.test.ts
@@ -1,5 +1,5 @@
 // Chunked summarization tests
-import { describe, it, expect, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { sanitizeToolResults, summarizeInStages } from "./chunked-summarize.js";
 
 describe("sanitizeToolResults", () => {

--- a/infrastructure/runtime/src/distillation/extract.test.ts
+++ b/infrastructure/runtime/src/distillation/extract.test.ts
@@ -1,5 +1,5 @@
 // Distillation extraction tests
-import { describe, it, expect, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { extractFromMessages, extractJson, findBalancedBraces, repairJson } from "./extract.js";
 
 function mockRouter(responseText: string) {

--- a/infrastructure/runtime/src/distillation/hooks.test.ts
+++ b/infrastructure/runtime/src/distillation/hooks.test.ts
@@ -1,5 +1,5 @@
 // Distillation hooks tests
-import { describe, it, expect, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { flushToMemory, type MemoryFlushTarget } from "./hooks.js";
 
 function makeTarget(addResult = { added: 5, errors: 0 }): MemoryFlushTarget {

--- a/infrastructure/runtime/src/distillation/pipeline.test.ts
+++ b/infrastructure/runtime/src/distillation/pipeline.test.ts
@@ -1,9 +1,9 @@
 // Distillation pipeline tests
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { mkdtempSync, rmSync, existsSync, readFileSync } from "node:fs";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { shouldDistill, distillSession } from "./pipeline.js";
+import { distillSession, shouldDistill } from "./pipeline.js";
 
 // Mock extraction
 vi.mock("./extract.js", () => ({

--- a/infrastructure/runtime/src/distillation/summarize.test.ts
+++ b/infrastructure/runtime/src/distillation/summarize.test.ts
@@ -1,5 +1,5 @@
 // Distillation summarization tests
-import { describe, it, expect, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { summarizeMessages } from "./summarize.js";
 
 function mockRouter(text: string) {

--- a/infrastructure/runtime/src/distillation/workspace-flush.test.ts
+++ b/infrastructure/runtime/src/distillation/workspace-flush.test.ts
@@ -1,6 +1,6 @@
 // Workspace flush tests — distillation memory file writer
-import { describe, it, expect, afterEach } from "vitest";
-import { mkdtempSync, rmSync, readFileSync, existsSync, writeFileSync, mkdirSync } from "node:fs";
+import { afterEach, describe, expect, it } from "vitest";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { flushToWorkspace } from "./workspace-flush.js";

--- a/infrastructure/runtime/src/distillation/workspace-flush.ts
+++ b/infrastructure/runtime/src/distillation/workspace-flush.ts
@@ -1,6 +1,6 @@
 // Distillation workspace flush — write summary + extraction to agent memory file
 import { join } from "node:path";
-import { existsSync, mkdirSync, appendFileSync } from "node:fs";
+import { appendFileSync, existsSync, mkdirSync } from "node:fs";
 import { createLogger } from "../koina/logger.js";
 import type { ExtractionResult } from "./extract.js";
 

--- a/infrastructure/runtime/src/hermeneus/anthropic.test.ts
+++ b/infrastructure/runtime/src/hermeneus/anthropic.test.ts
@@ -1,5 +1,5 @@
 // Anthropic provider tests
-import { describe, it, expect, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { AnthropicProvider } from "./anthropic.js";
 
 // Mock the Anthropic SDK

--- a/infrastructure/runtime/src/hermeneus/complexity.test.ts
+++ b/infrastructure/runtime/src/hermeneus/complexity.test.ts
@@ -1,5 +1,5 @@
 // Complexity scoring tests
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 import { scoreComplexity, selectModel, selectTemperature } from "./complexity.js";
 
 const base = { messageText: "Hello", messageCount: 5, depth: 0 };

--- a/infrastructure/runtime/src/hermeneus/pricing.test.ts
+++ b/infrastructure/runtime/src/hermeneus/pricing.test.ts
@@ -1,6 +1,6 @@
 // Pricing module tests
-import { describe, it, expect } from "vitest";
-import { calculateTurnCost, calculateCostBreakdown } from "./pricing.js";
+import { describe, expect, it } from "vitest";
+import { calculateCostBreakdown, calculateTurnCost } from "./pricing.js";
 
 const baseUsage = {
   inputTokens: 1_000_000,

--- a/infrastructure/runtime/src/hermeneus/router-full.test.ts
+++ b/infrastructure/runtime/src/hermeneus/router-full.test.ts
@@ -1,5 +1,5 @@
 // Extended router tests — createDefaultRouter credential loading
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createDefaultRouter } from "./router.js";
 
 // Mock the AnthropicProvider constructor to avoid real SDK usage

--- a/infrastructure/runtime/src/hermeneus/router.test.ts
+++ b/infrastructure/runtime/src/hermeneus/router.test.ts
@@ -1,5 +1,5 @@
 // Provider router tests
-import { describe, it, expect, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { ProviderRouter } from "./router.js";
 
 function mockProvider(result = { content: [{ type: "text" as const, text: "ok" }], stopReason: "end_turn", usage: { inputTokens: 10, outputTokens: 5, cacheReadTokens: 0, cacheWriteTokens: 0 }, model: "test" }) {

--- a/infrastructure/runtime/src/hermeneus/router.ts
+++ b/infrastructure/runtime/src/hermeneus/router.ts
@@ -6,8 +6,8 @@ import { ProviderError } from "../koina/errors.js";
 import {
   AnthropicProvider,
   type CompletionRequest,
-  type TurnResult,
   type StreamingEvent,
+  type TurnResult,
 } from "./anthropic.js";
 
 const log = createLogger("hermeneus.router");

--- a/infrastructure/runtime/src/hermeneus/token-counter.test.ts
+++ b/infrastructure/runtime/src/hermeneus/token-counter.test.ts
@@ -1,9 +1,9 @@
 // Token counter tests
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 import {
+  estimateMessageTokens,
   estimateTokens,
   estimateTokensSafe,
-  estimateMessageTokens,
   estimateToolDefTokens,
   SAFETY_MARGIN,
 } from "./token-counter.js";

--- a/infrastructure/runtime/src/koina/crypto.test.ts
+++ b/infrastructure/runtime/src/koina/crypto.test.ts
@@ -1,5 +1,5 @@
 // Crypto utilities tests
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 import { generateId, generateSessionKey } from "./crypto.js";
 
 describe("generateId", () => {

--- a/infrastructure/runtime/src/koina/errors.test.ts
+++ b/infrastructure/runtime/src/koina/errors.test.ts
@@ -1,10 +1,10 @@
 // Error hierarchy unit tests
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 import {
   AletheiaError,
   ConfigError,
-  SessionError,
   ProviderError,
+  SessionError,
   ToolError,
 } from "./errors.js";
 import { ERROR_CODES, type ErrorCode } from "./error-codes.js";

--- a/infrastructure/runtime/src/koina/event-bus.test.ts
+++ b/infrastructure/runtime/src/koina/event-bus.test.ts
@@ -1,6 +1,6 @@
 // Event bus tests
-import { describe, it, expect, vi } from "vitest";
-import { eventBus, type EventName, type EventHandler } from "./event-bus.js";
+import { describe, expect, it, vi } from "vitest";
+import { eventBus, type EventHandler, type EventName } from "./event-bus.js";
 
 vi.mock("./logger.js", () => ({
   createLogger: () => ({

--- a/infrastructure/runtime/src/koina/fs.test.ts
+++ b/infrastructure/runtime/src/koina/fs.test.ts
@@ -1,6 +1,6 @@
 // Filesystem utility tests
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { readText, readJson, writeText, writeJson, exists } from "./fs.js";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { exists, readJson, readText, writeJson, writeText } from "./fs.js";
 import { mkdtempSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";

--- a/infrastructure/runtime/src/koina/fs.ts
+++ b/infrastructure/runtime/src/koina/fs.ts
@@ -1,5 +1,5 @@
 // Filesystem utilities
-import { readFileSync, existsSync, writeFileSync, mkdirSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname } from "node:path";
 
 export function readText(path: string): string | null {

--- a/infrastructure/runtime/src/koina/logger.test.ts
+++ b/infrastructure/runtime/src/koina/logger.test.ts
@@ -1,11 +1,11 @@
-import { describe, it, expect, afterEach, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  createLogger,
+  getTurnContext,
+  type TurnContext,
+  updateTurnContext,
   withTurn,
   withTurnAsync,
-  getTurnContext,
-  updateTurnContext,
-  createLogger,
-  type TurnContext,
 } from "./logger.js";
 
 describe("TurnContext via AsyncLocalStorage", () => {

--- a/infrastructure/runtime/src/koina/safe.test.ts
+++ b/infrastructure/runtime/src/koina/safe.test.ts
@@ -1,5 +1,5 @@
 // trySafe / trySafeAsync tests
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 import { trySafe, trySafeAsync } from "./safe.js";
 
 describe("trySafe", () => {

--- a/infrastructure/runtime/src/mneme/queue.test.ts
+++ b/infrastructure/runtime/src/mneme/queue.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { mkdtempSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";

--- a/infrastructure/runtime/src/mneme/store.test.ts
+++ b/infrastructure/runtime/src/mneme/store.test.ts
@@ -1,5 +1,5 @@
 // Session store unit tests — uses :memory: SQLite
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { SessionStore } from "./store.js";
 
 let store: SessionStore;

--- a/infrastructure/runtime/src/mneme/store.ts
+++ b/infrastructure/runtime/src/mneme/store.ts
@@ -3,7 +3,7 @@ import Database from "better-sqlite3";
 import { createLogger } from "../koina/logger.js";
 import { SessionError } from "../koina/errors.js";
 import { generateId, generateSessionKey } from "../koina/crypto.js";
-import { DDL, SCHEMA_VERSION, MIGRATIONS } from "./schema.js";
+import { DDL, MIGRATIONS, SCHEMA_VERSION } from "./schema.js";
 
 const log = createLogger("mneme");
 

--- a/infrastructure/runtime/src/nous/async-channel.test.ts
+++ b/infrastructure/runtime/src/nous/async-channel.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 import { AsyncChannel } from "./async-channel.js";
 
 describe("AsyncChannel", () => {

--- a/infrastructure/runtime/src/nous/bootstrap-diff.test.ts
+++ b/infrastructure/runtime/src/nous/bootstrap-diff.test.ts
@@ -1,7 +1,7 @@
 // Bootstrap diff detection tests
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { detectBootstrapDiff, logBootstrapDiff } from "./bootstrap-diff.js";
-import { mkdtempSync, rmSync, mkdirSync, existsSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 

--- a/infrastructure/runtime/src/nous/bootstrap-diff.ts
+++ b/infrastructure/runtime/src/nous/bootstrap-diff.ts
@@ -1,6 +1,6 @@
 // Bootstrap diff detection — file-level change tracking across sessions
-import { readFileSync, writeFileSync, appendFileSync, mkdirSync } from "node:fs";
-import { join, dirname } from "node:path";
+import { appendFileSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
 import { createLogger } from "../koina/logger.js";
 
 const log = createLogger("nous.bootstrap-diff");

--- a/infrastructure/runtime/src/nous/bootstrap.test.ts
+++ b/infrastructure/runtime/src/nous/bootstrap.test.ts
@@ -1,7 +1,7 @@
 // Bootstrap assembly tests
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { assembleBootstrap } from "./bootstrap.js";
-import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 

--- a/infrastructure/runtime/src/nous/bootstrap.ts
+++ b/infrastructure/runtime/src/nous/bootstrap.ts
@@ -1,5 +1,5 @@
 // Token-aware context assembly with cache boundary optimization
-import { readFileSync, existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { createHash } from "node:crypto";
 import { createLogger } from "../koina/logger.js";

--- a/infrastructure/runtime/src/nous/circuit-breaker.test.ts
+++ b/infrastructure/runtime/src/nous/circuit-breaker.test.ts
@@ -1,5 +1,5 @@
 // Circuit breaker tests
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 import { checkInputCircuitBreakers, checkResponseQuality } from "./circuit-breaker.js";
 
 describe("checkInputCircuitBreakers", () => {

--- a/infrastructure/runtime/src/nous/competence.test.ts
+++ b/infrastructure/runtime/src/nous/competence.test.ts
@@ -1,5 +1,5 @@
 // Competence model tests
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { CompetenceModel } from "./competence.js";
 import { mkdtempSync, rmSync } from "node:fs";
 import { join } from "node:path";

--- a/infrastructure/runtime/src/nous/competence.ts
+++ b/infrastructure/runtime/src/nous/competence.ts
@@ -1,5 +1,5 @@
 // Competence model — per-agent per-domain confidence tracking
-import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { createLogger } from "../koina/logger.js";
 

--- a/infrastructure/runtime/src/nous/ephemeral.test.ts
+++ b/infrastructure/runtime/src/nous/ephemeral.test.ts
@@ -1,14 +1,14 @@
 // Ephemeral agent tests
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
-  spawnEphemeral,
-  recordEphemeralTurn,
-  teardownEphemeral,
   getEphemeral,
-  listEphemerals,
   harvestOutput,
+  listEphemerals,
+  recordEphemeralTurn,
+  spawnEphemeral,
+  teardownEphemeral,
 } from "./ephemeral.js";
-import { mkdtempSync, rmSync, existsSync } from "node:fs";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 

--- a/infrastructure/runtime/src/nous/ephemeral.ts
+++ b/infrastructure/runtime/src/nous/ephemeral.ts
@@ -1,5 +1,5 @@
 // Ephemeral agent spawning — Syn creates temporary specialists with bounded lifecycles
-import { mkdirSync, writeFileSync, existsSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { randomBytes } from "node:crypto";
 import { createLogger } from "../koina/logger.js";

--- a/infrastructure/runtime/src/nous/loop-detector.test.ts
+++ b/infrastructure/runtime/src/nous/loop-detector.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 import { LoopDetector } from "./loop-detector.js";
 
 describe("LoopDetector", () => {

--- a/infrastructure/runtime/src/nous/manager-streaming.test.ts
+++ b/infrastructure/runtime/src/nous/manager-streaming.test.ts
@@ -1,5 +1,5 @@
 // Tests for handleMessageStreaming — real-time event delivery via AsyncChannel
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { NousManager } from "./manager.js";
 import type { StreamingEvent } from "../hermeneus/anthropic.js";
 

--- a/infrastructure/runtime/src/nous/manager.test.ts
+++ b/infrastructure/runtime/src/nous/manager.test.ts
@@ -1,5 +1,5 @@
 // NousManager tests — orchestration, routing, turn execution
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { NousManager } from "./manager.js";
 
 function makeConfig(overrides: Record<string, unknown> = {}) {

--- a/infrastructure/runtime/src/nous/manager.ts
+++ b/infrastructure/runtime/src/nous/manager.ts
@@ -15,8 +15,8 @@ import { ApprovalGate } from "../organon/approval.js";
 import type { ApprovalMode } from "../organon/approval.js";
 import { AsyncChannel } from "./async-channel.js";
 import { resolveNousId } from "./pipeline/stages/resolve.js";
-import { runStreamingPipeline, runBufferedPipeline } from "./pipeline/runner.js";
-import type { RuntimeServices, InboundMessage, TurnStreamEvent, TurnOutcome } from "./pipeline/types.js";
+import { runBufferedPipeline, runStreamingPipeline } from "./pipeline/runner.js";
+import type { InboundMessage, RuntimeServices, TurnOutcome, TurnStreamEvent } from "./pipeline/types.js";
 
 export type { InboundMessage, TurnOutcome, TurnStreamEvent, MediaAttachment } from "./pipeline/types.js";
 

--- a/infrastructure/runtime/src/nous/pipeline/runner.test.ts
+++ b/infrastructure/runtime/src/nous/pipeline/runner.test.ts
@@ -1,5 +1,5 @@
 // Pipeline runner tests — error boundaries, stage identification
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { runBufferedPipeline, runStreamingPipeline } from "./runner.js";
 
 vi.mock("./stages/resolve.js", () => ({

--- a/infrastructure/runtime/src/nous/pipeline/runner.ts
+++ b/infrastructure/runtime/src/nous/pipeline/runner.ts
@@ -6,14 +6,14 @@ import { resolveStage } from "./stages/resolve.js";
 import { checkGuards } from "./stages/guard.js";
 import { buildContext } from "./stages/context.js";
 import { prepareHistory } from "./stages/history.js";
-import { executeStreaming, executeBuffered } from "./stages/execute.js";
+import { executeBuffered, executeStreaming } from "./stages/execute.js";
 import { finalize } from "./stages/finalize.js";
 import type {
   InboundMessage,
+  RuntimeServices,
   TurnOutcome,
   TurnState,
   TurnStreamEvent,
-  RuntimeServices,
 } from "./types.js";
 
 const log = createLogger("pipeline:runner");

--- a/infrastructure/runtime/src/nous/pipeline/stages/context.ts
+++ b/infrastructure/runtime/src/nous/pipeline/stages/context.ts
@@ -1,13 +1,13 @@
 // Context stage — bootstrap assembly, recall, broadcasts, working state, notes injection
 import { createLogger, updateTurnContext } from "../../../koina/logger.js";
-import { estimateToolDefTokens, estimateTokens } from "../../../hermeneus/token-counter.js";
+import { estimateTokens, estimateToolDefTokens } from "../../../hermeneus/token-counter.js";
 import { assembleBootstrap } from "../../bootstrap.js";
 import { detectBootstrapDiff, logBootstrapDiff } from "../../bootstrap-diff.js";
 import { recallMemories } from "../../recall.js";
 import { formatWorkingState } from "../../working-state.js";
 import { distillSession } from "../../../distillation/pipeline.js";
 import { eventBus } from "../../../koina/event-bus.js";
-import type { TurnState, RuntimeServices, SystemBlock } from "../types.js";
+import type { RuntimeServices, SystemBlock, TurnState } from "../types.js";
 
 const log = createLogger("pipeline:context");
 

--- a/infrastructure/runtime/src/nous/pipeline/stages/execute.ts
+++ b/infrastructure/runtime/src/nous/pipeline/stages/execute.ts
@@ -14,10 +14,10 @@ import type {
   UserContentBlock,
 } from "../../../hermeneus/anthropic.js";
 import type {
+  RuntimeServices,
+  TurnOutcome,
   TurnState,
   TurnStreamEvent,
-  TurnOutcome,
-  RuntimeServices,
 } from "../types.js";
 
 const log = createLogger("pipeline:execute");

--- a/infrastructure/runtime/src/nous/pipeline/stages/finalize.ts
+++ b/infrastructure/runtime/src/nous/pipeline/stages/finalize.ts
@@ -7,7 +7,7 @@ import { extractWorkingState } from "../../working-state.js";
 import { resolveWorkspace } from "../../../taxis/loader.js";
 import { eventBus } from "../../../koina/event-bus.js";
 import { createLogger } from "../../../koina/logger.js";
-import type { TurnState, RuntimeServices } from "../types.js";
+import type { RuntimeServices, TurnState } from "../types.js";
 
 const log = createLogger("finalize");
 

--- a/infrastructure/runtime/src/nous/pipeline/stages/guard.ts
+++ b/infrastructure/runtime/src/nous/pipeline/stages/guard.ts
@@ -2,7 +2,7 @@
 import { createLogger } from "../../../koina/logger.js";
 import { estimateTokens } from "../../../hermeneus/token-counter.js";
 import { checkInputCircuitBreakers } from "../../circuit-breaker.js";
-import type { TurnState, RuntimeServices, TurnOutcome } from "../types.js";
+import type { RuntimeServices, TurnOutcome, TurnState } from "../types.js";
 
 const log = createLogger("pipeline:guard");
 

--- a/infrastructure/runtime/src/nous/pipeline/stages/history.ts
+++ b/infrastructure/runtime/src/nous/pipeline/stages/history.ts
@@ -2,7 +2,7 @@
 import { createLogger } from "../../../koina/logger.js";
 import { estimateTokens } from "../../../hermeneus/token-counter.js";
 import { buildMessages } from "../utils/build-messages.js";
-import type { TurnState, RuntimeServices } from "../types.js";
+import type { RuntimeServices, TurnState } from "../types.js";
 
 const log = createLogger("pipeline:history");
 

--- a/infrastructure/runtime/src/nous/pipeline/stages/resolve.ts
+++ b/infrastructure/runtime/src/nous/pipeline/stages/resolve.ts
@@ -1,20 +1,20 @@
 // Resolve stage — route to nous, create/find session, select model
 import { createLogger } from "../../../koina/logger.js";
 import {
-  resolveNous,
-  resolveModel,
-  resolveWorkspace,
   resolveDefaultNous,
+  resolveModel,
+  resolveNous,
+  resolveWorkspace,
 } from "../../../taxis/loader.js";
 import {
+  type ComplexityTier,
   scoreComplexity,
   selectModel,
   selectTemperature,
-  type ComplexityTier,
 } from "../../../hermeneus/complexity.js";
 import { paths } from "../../../taxis/paths.js";
 import type { ToolContext } from "../../../organon/registry.js";
-import type { InboundMessage, RuntimeServices, TurnState, SystemBlock } from "../types.js";
+import type { InboundMessage, RuntimeServices, SystemBlock, TurnState } from "../types.js";
 import { TraceBuilder } from "../../trace.js";
 import { LoopDetector } from "../../loop-detector.js";
 

--- a/infrastructure/runtime/src/nous/pipeline/types.ts
+++ b/infrastructure/runtime/src/nous/pipeline/types.ts
@@ -2,7 +2,7 @@
 import type { AletheiaConfig, NousConfig } from "../../taxis/schema.js";
 import type { SessionStore } from "../../mneme/store.js";
 import type { ProviderRouter } from "../../hermeneus/router.js";
-import type { ToolRegistry, ToolContext } from "../../organon/registry.js";
+import type { ToolContext, ToolRegistry } from "../../organon/registry.js";
 import type { PluginRegistry } from "../../prostheke/registry.js";
 import type { Watchdog } from "../../daemon/watchdog.js";
 import type { CompetenceModel } from "../competence.js";

--- a/infrastructure/runtime/src/nous/pipeline/utils/build-messages.test.ts
+++ b/infrastructure/runtime/src/nous/pipeline/utils/build-messages.test.ts
@@ -1,5 +1,5 @@
 // build-messages tests — thinking block handling, orphan repair, message construction
-import { describe, it, expect, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { buildMessages } from "./build-messages.js";
 
 vi.mock("../../../koina/event-bus.js", () => ({

--- a/infrastructure/runtime/src/nous/recall.test.ts
+++ b/infrastructure/runtime/src/nous/recall.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { recallMemories } from "./recall.js";
 
 const mockFetch = vi.fn();

--- a/infrastructure/runtime/src/nous/trace.test.ts
+++ b/infrastructure/runtime/src/nous/trace.test.ts
@@ -1,5 +1,5 @@
 // Causal tracing tests
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { TraceBuilder } from "./trace.js";
 
 describe("TraceBuilder", () => {

--- a/infrastructure/runtime/src/nous/trace.ts
+++ b/infrastructure/runtime/src/nous/trace.ts
@@ -1,5 +1,5 @@
 // Causal tracing — records provenance for each turn
-import { appendFileSync, mkdirSync, existsSync } from "node:fs";
+import { appendFileSync, existsSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
 import { createLogger } from "../koina/logger.js";
 

--- a/infrastructure/runtime/src/nous/uncertainty.test.ts
+++ b/infrastructure/runtime/src/nous/uncertainty.test.ts
@@ -1,5 +1,5 @@
 // Uncertainty tracker tests
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { UncertaintyTracker } from "./uncertainty.js";
 import { mkdtempSync, rmSync } from "node:fs";
 import { join } from "node:path";

--- a/infrastructure/runtime/src/nous/uncertainty.ts
+++ b/infrastructure/runtime/src/nous/uncertainty.ts
@@ -1,5 +1,5 @@
 // Uncertainty quantification — track calibration of agent confidence estimates
-import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 interface CalibrationPoint {

--- a/infrastructure/runtime/src/nous/working-state.test.ts
+++ b/infrastructure/runtime/src/nous/working-state.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 import { formatWorkingState } from "./working-state.js";
 import type { WorkingState } from "../mneme/store.js";
 

--- a/infrastructure/runtime/src/organon/approval.test.ts
+++ b/infrastructure/runtime/src/organon/approval.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from "vitest";
-import { requiresApproval, ApprovalGate } from "./approval.js";
+import { describe, expect, it } from "vitest";
+import { ApprovalGate, requiresApproval } from "./approval.js";
 
 describe("requiresApproval", () => {
   it("autonomous mode never requires approval", () => {

--- a/infrastructure/runtime/src/organon/built-in/blackboard.test.ts
+++ b/infrastructure/runtime/src/organon/built-in/blackboard.test.ts
@@ -1,5 +1,5 @@
 // Blackboard tool tests
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { mkdtempSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";

--- a/infrastructure/runtime/src/organon/built-in/blackboard.ts
+++ b/infrastructure/runtime/src/organon/built-in/blackboard.ts
@@ -1,5 +1,5 @@
 // Cross-agent blackboard — persistent shared state with auto-expiry
-import type { ToolHandler, ToolContext } from "../registry.js";
+import type { ToolContext, ToolHandler } from "../registry.js";
 import type { SessionStore } from "../../mneme/store.js";
 
 export function createBlackboardTool(store: SessionStore): ToolHandler {

--- a/infrastructure/runtime/src/organon/built-in/brave-search.test.ts
+++ b/infrastructure/runtime/src/organon/built-in/brave-search.test.ts
@@ -1,5 +1,5 @@
 // Brave search tool tests
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { braveSearchTool } from "./brave-search.js";
 
 describe("braveSearchTool", () => {

--- a/infrastructure/runtime/src/organon/built-in/browser.test.ts
+++ b/infrastructure/runtime/src/organon/built-in/browser.test.ts
@@ -1,5 +1,5 @@
 // Browser tool tests — definition and error handling
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { browserTool, closeBrowser } from "./browser.js";
 
 // Mock SSRF guard

--- a/infrastructure/runtime/src/organon/built-in/check-calibration.test.ts
+++ b/infrastructure/runtime/src/organon/built-in/check-calibration.test.ts
@@ -1,5 +1,5 @@
 // Check calibration tool tests
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 import { createCheckCalibrationTool } from "./check-calibration.js";
 import type { ToolContext } from "../registry.js";
 

--- a/infrastructure/runtime/src/organon/built-in/check-calibration.ts
+++ b/infrastructure/runtime/src/organon/built-in/check-calibration.ts
@@ -1,5 +1,5 @@
 // Self-observation tool — calibration and competence snapshot
-import type { ToolHandler, ToolContext } from "../registry.js";
+import type { ToolContext, ToolHandler } from "../registry.js";
 import type { CompetenceModel } from "../../nous/competence.js";
 import type { UncertaintyTracker } from "../../nous/uncertainty.js";
 

--- a/infrastructure/runtime/src/organon/built-in/config-read.test.ts
+++ b/infrastructure/runtime/src/organon/built-in/config-read.test.ts
@@ -1,5 +1,5 @@
 // Config read tool tests
-import { describe, it, expect, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { createConfigReadTool } from "./config-read.js";
 
 function makeConfig() {

--- a/infrastructure/runtime/src/organon/built-in/config-read.ts
+++ b/infrastructure/runtime/src/organon/built-in/config-read.ts
@@ -1,5 +1,5 @@
 // Config inspection tool — agents can read their own scoped config
-import type { ToolHandler, ToolContext } from "../registry.js";
+import type { ToolContext, ToolHandler } from "../registry.js";
 import type { AletheiaConfig } from "../../taxis/schema.js";
 import { resolveNous } from "../../taxis/loader.js";
 

--- a/infrastructure/runtime/src/organon/built-in/context-check.test.ts
+++ b/infrastructure/runtime/src/organon/built-in/context-check.test.ts
@@ -1,5 +1,5 @@
 // Context check meta-tool tests
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 import { createContextCheckTool } from "./context-check.js";
 import { ToolRegistry } from "../registry.js";
 import type { ToolContext } from "../registry.js";

--- a/infrastructure/runtime/src/organon/built-in/context-check.ts
+++ b/infrastructure/runtime/src/organon/built-in/context-check.ts
@@ -1,6 +1,5 @@
 // Meta-tool — context snapshot: session + competence + memory status
-import type { ToolHandler, ToolContext } from "../registry.js";
-import type { ToolRegistry } from "../registry.js";
+import type { ToolContext, ToolHandler, ToolRegistry } from "../registry.js";
 
 export function createContextCheckTool(registry: ToolRegistry): ToolHandler {
   return {

--- a/infrastructure/runtime/src/organon/built-in/deliberate.test.ts
+++ b/infrastructure/runtime/src/organon/built-in/deliberate.test.ts
@@ -1,5 +1,5 @@
 // Cross-agent deliberation protocol tests
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 import { createDeliberateTool } from "./deliberate.js";
 import type { InboundMessage, TurnOutcome } from "../../nous/manager.js";
 

--- a/infrastructure/runtime/src/organon/built-in/deliberate.ts
+++ b/infrastructure/runtime/src/organon/built-in/deliberate.ts
@@ -1,6 +1,6 @@
 // Cross-agent deliberation — structured multi-turn dialectic protocol
 import { createLogger } from "../../koina/logger.js";
-import type { ToolHandler, ToolContext } from "../registry.js";
+import type { ToolContext, ToolHandler } from "../registry.js";
 import type { InboundMessage, TurnOutcome } from "../../nous/manager.js";
 import type { SessionStore } from "../../mneme/store.js";
 

--- a/infrastructure/runtime/src/organon/built-in/edit.ts
+++ b/infrastructure/runtime/src/organon/built-in/edit.ts
@@ -1,6 +1,6 @@
 // File edit tool — find and replace
 import { readFileSync, writeFileSync } from "node:fs";
-import type { ToolHandler, ToolContext } from "../registry.js";
+import type { ToolContext, ToolHandler } from "../registry.js";
 import { safePath } from "./safe-path.js";
 import { commitWorkspaceChange } from "../workspace-git.js";
 import { trySafe } from "../../koina/safe.js";

--- a/infrastructure/runtime/src/organon/built-in/exec.ts
+++ b/infrastructure/runtime/src/organon/built-in/exec.ts
@@ -1,7 +1,7 @@
 // Shell execution tool
 import { exec } from "node:child_process";
 import { promisify } from "node:util";
-import type { ToolHandler, ToolContext } from "../registry.js";
+import type { ToolContext, ToolHandler } from "../registry.js";
 
 const execAsync = promisify(exec);
 

--- a/infrastructure/runtime/src/organon/built-in/fact-retract.test.ts
+++ b/infrastructure/runtime/src/organon/built-in/fact-retract.test.ts
@@ -1,5 +1,5 @@
 // Fact retract tool tests
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { factRetractTool } from "./fact-retract.js";
 
 const ctx = { nousId: "syn", sessionId: "ses_1", workspace: "/tmp" };

--- a/infrastructure/runtime/src/organon/built-in/fact-retract.ts
+++ b/infrastructure/runtime/src/organon/built-in/fact-retract.ts
@@ -1,6 +1,6 @@
 // Memory retraction tool — agents can request fact removal
 import { createLogger } from "../../koina/logger.js";
-import type { ToolHandler, ToolContext } from "../registry.js";
+import type { ToolContext, ToolHandler } from "../registry.js";
 
 const log = createLogger("organon.fact-retract");
 const SIDECAR_URL = process.env["ALETHEIA_MEMORY_URL"] ?? "http://127.0.0.1:8230";

--- a/infrastructure/runtime/src/organon/built-in/find.ts
+++ b/infrastructure/runtime/src/organon/built-in/find.ts
@@ -1,7 +1,7 @@
 // File search tool — find files by name pattern
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
-import type { ToolHandler, ToolContext } from "../registry.js";
+import type { ToolContext, ToolHandler } from "../registry.js";
 import { safePath } from "./safe-path.js";
 
 const execFileAsync = promisify(execFile);

--- a/infrastructure/runtime/src/organon/built-in/grep.ts
+++ b/infrastructure/runtime/src/organon/built-in/grep.ts
@@ -1,7 +1,7 @@
 // Content search tool — grep through files
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
-import type { ToolHandler, ToolContext } from "../registry.js";
+import type { ToolContext, ToolHandler } from "../registry.js";
 import { safePath } from "./safe-path.js";
 
 const execFileAsync = promisify(execFile);

--- a/infrastructure/runtime/src/organon/built-in/ls.ts
+++ b/infrastructure/runtime/src/organon/built-in/ls.ts
@@ -1,7 +1,7 @@
 // Directory listing tool
 import { readdirSync, statSync } from "node:fs";
 import { join } from "node:path";
-import type { ToolHandler, ToolContext } from "../registry.js";
+import type { ToolContext, ToolHandler } from "../registry.js";
 import { safePath } from "./safe-path.js";
 
 export const lsTool: ToolHandler = {

--- a/infrastructure/runtime/src/organon/built-in/mem0-search.test.ts
+++ b/infrastructure/runtime/src/organon/built-in/mem0-search.test.ts
@@ -1,5 +1,5 @@
 // Mem0 search tool tests
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { mem0SearchTool } from "./mem0-search.js";
 
 const ctx = { nousId: "syn", sessionId: "ses_1", workspace: "/tmp" };

--- a/infrastructure/runtime/src/organon/built-in/mem0-search.ts
+++ b/infrastructure/runtime/src/organon/built-in/mem0-search.ts
@@ -1,5 +1,5 @@
 // Mem0 memory search tool — query long-term extracted memories
-import type { ToolHandler, ToolContext } from "../registry.js";
+import type { ToolContext, ToolHandler } from "../registry.js";
 import { createLogger } from "../../koina/logger.js";
 
 const log = createLogger("tool:mem0-search");

--- a/infrastructure/runtime/src/organon/built-in/message.test.ts
+++ b/infrastructure/runtime/src/organon/built-in/message.test.ts
@@ -1,5 +1,5 @@
 // Message tool tests
-import { describe, it, expect, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { createMessageTool } from "./message.js";
 
 describe("createMessageTool", () => {

--- a/infrastructure/runtime/src/organon/built-in/note.test.ts
+++ b/infrastructure/runtime/src/organon/built-in/note.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { mkdtempSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";

--- a/infrastructure/runtime/src/organon/built-in/note.ts
+++ b/infrastructure/runtime/src/organon/built-in/note.ts
@@ -1,5 +1,5 @@
 // Agent notes tool — explicit persistent memory that survives distillation
-import type { ToolHandler, ToolContext } from "../registry.js";
+import type { ToolContext, ToolHandler } from "../registry.js";
 import type { SessionStore } from "../../mneme/store.js";
 
 const VALID_CATEGORIES = ["task", "decision", "preference", "correction", "context"] as const;

--- a/infrastructure/runtime/src/organon/built-in/plan.test.ts
+++ b/infrastructure/runtime/src/organon/built-in/plan.test.ts
@@ -1,6 +1,6 @@
 // Plan tool tests — create, status, step complete, step fail
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdirSync, rmSync, existsSync } from "node:fs";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { existsSync, mkdirSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { createPlanTools } from "./plan.js";
 

--- a/infrastructure/runtime/src/organon/built-in/plan.ts
+++ b/infrastructure/runtime/src/organon/built-in/plan.ts
@@ -1,8 +1,8 @@
 // Structured planning with verification loops
-import { readFileSync, writeFileSync, mkdirSync, existsSync } from "node:fs";
-import { join, dirname } from "node:path";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
 import { createLogger } from "../../koina/logger.js";
-import type { ToolHandler, ToolContext } from "../registry.js";
+import type { ToolContext, ToolHandler } from "../registry.js";
 
 const log = createLogger("organon.plan");
 

--- a/infrastructure/runtime/src/organon/built-in/read.ts
+++ b/infrastructure/runtime/src/organon/built-in/read.ts
@@ -1,6 +1,6 @@
 // File read tool
 import { readFileSync } from "node:fs";
-import type { ToolHandler, ToolContext } from "../registry.js";
+import type { ToolContext, ToolHandler } from "../registry.js";
 import { safePath } from "./safe-path.js";
 
 export const readTool: ToolHandler = {

--- a/infrastructure/runtime/src/organon/built-in/recent-corrections.test.ts
+++ b/infrastructure/runtime/src/organon/built-in/recent-corrections.test.ts
@@ -1,5 +1,5 @@
 // Recent corrections tool tests
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 import { createRecentCorrectionsTool } from "./recent-corrections.js";
 import type { ToolContext } from "../registry.js";
 

--- a/infrastructure/runtime/src/organon/built-in/recent-corrections.ts
+++ b/infrastructure/runtime/src/organon/built-in/recent-corrections.ts
@@ -1,5 +1,5 @@
 // Self-observation tool — recent correction patterns
-import type { ToolHandler, ToolContext } from "../registry.js";
+import type { ToolContext, ToolHandler } from "../registry.js";
 import type { SessionStore } from "../../mneme/store.js";
 
 export function createRecentCorrectionsTool(store?: SessionStore): ToolHandler {

--- a/infrastructure/runtime/src/organon/built-in/research.test.ts
+++ b/infrastructure/runtime/src/organon/built-in/research.test.ts
@@ -1,5 +1,5 @@
 // Research meta-tool tests
-import { describe, it, expect, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { createResearchTool } from "./research.js";
 import { ToolRegistry } from "../registry.js";
 

--- a/infrastructure/runtime/src/organon/built-in/research.ts
+++ b/infrastructure/runtime/src/organon/built-in/research.ts
@@ -1,6 +1,5 @@
 // Meta-tool — research pipeline: memory → web → synthesize
-import type { ToolHandler, ToolContext } from "../registry.js";
-import type { ToolRegistry } from "../registry.js";
+import type { ToolContext, ToolHandler, ToolRegistry } from "../registry.js";
 
 export function createResearchTool(registry: ToolRegistry): ToolHandler {
   return {

--- a/infrastructure/runtime/src/organon/built-in/safe-path.test.ts
+++ b/infrastructure/runtime/src/organon/built-in/safe-path.test.ts
@@ -1,5 +1,5 @@
 // Path resolution tests
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 import { safePath } from "./safe-path.js";
 
 describe("safePath", () => {

--- a/infrastructure/runtime/src/organon/built-in/session-status.test.ts
+++ b/infrastructure/runtime/src/organon/built-in/session-status.test.ts
@@ -1,5 +1,5 @@
 // Session status tool tests
-import { describe, it, expect, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { createSessionStatusTool } from "./session-status.js";
 
 const ctx = { nousId: "syn", sessionId: "ses_1", workspace: "/tmp" };

--- a/infrastructure/runtime/src/organon/built-in/session-status.ts
+++ b/infrastructure/runtime/src/organon/built-in/session-status.ts
@@ -1,5 +1,5 @@
 // Session status tool — usage and model info
-import type { ToolHandler, ToolContext } from "../registry.js";
+import type { ToolContext, ToolHandler } from "../registry.js";
 import type { SessionStore } from "../../mneme/store.js";
 
 export function createSessionStatusTool(store?: SessionStore): ToolHandler {

--- a/infrastructure/runtime/src/organon/built-in/sessions-ask.test.ts
+++ b/infrastructure/runtime/src/organon/built-in/sessions-ask.test.ts
@@ -1,5 +1,5 @@
 // Sessions ask tool tests
-import { describe, it, expect, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { createSessionsAskTool } from "./sessions-ask.js";
 
 const ctx = { nousId: "syn", sessionId: "ses_1", workspace: "/tmp" };

--- a/infrastructure/runtime/src/organon/built-in/sessions-ask.ts
+++ b/infrastructure/runtime/src/organon/built-in/sessions-ask.ts
@@ -1,6 +1,6 @@
 // Synchronous cross-agent messaging — waits for response
 import { createLogger } from "../../koina/logger.js";
-import type { ToolHandler, ToolContext } from "../registry.js";
+import type { ToolContext, ToolHandler } from "../registry.js";
 import type { InboundMessage, TurnOutcome } from "../../nous/manager.js";
 import type { SessionStore } from "../../mneme/store.js";
 

--- a/infrastructure/runtime/src/organon/built-in/sessions-send.test.ts
+++ b/infrastructure/runtime/src/organon/built-in/sessions-send.test.ts
@@ -1,5 +1,5 @@
 // Sessions send tool tests
-import { describe, it, expect, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { createSessionsSendTool } from "./sessions-send.js";
 
 const ctx = { nousId: "syn", sessionId: "ses_1", workspace: "/tmp" };

--- a/infrastructure/runtime/src/organon/built-in/sessions-send.ts
+++ b/infrastructure/runtime/src/organon/built-in/sessions-send.ts
@@ -1,6 +1,6 @@
 // Cross-agent fire-and-forget messaging
 import { createLogger } from "../../koina/logger.js";
-import type { ToolHandler, ToolContext } from "../registry.js";
+import type { ToolContext, ToolHandler } from "../registry.js";
 import type { InboundMessage, TurnOutcome } from "../../nous/manager.js";
 import type { SessionStore } from "../../mneme/store.js";
 

--- a/infrastructure/runtime/src/organon/built-in/sessions-spawn.test.ts
+++ b/infrastructure/runtime/src/organon/built-in/sessions-spawn.test.ts
@@ -1,6 +1,6 @@
 // Sessions spawn tool tests
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { mkdtempSync, rmSync, mkdirSync } from "node:fs";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { createSessionsSpawnTool } from "./sessions-spawn.js";

--- a/infrastructure/runtime/src/organon/built-in/sessions-spawn.ts
+++ b/infrastructure/runtime/src/organon/built-in/sessions-spawn.ts
@@ -1,12 +1,12 @@
 // Sub-nous spawning — run a scoped task on a temporary agent (supports ephemeral specialists)
-import type { ToolHandler, ToolContext } from "../registry.js";
+import type { ToolContext, ToolHandler } from "../registry.js";
 import type { InboundMessage, TurnOutcome } from "../../nous/manager.js";
 import type { SessionStore } from "../../mneme/store.js";
 import {
-  spawnEphemeral,
-  recordEphemeralTurn,
-  teardownEphemeral,
   harvestOutput,
+  recordEphemeralTurn,
+  spawnEphemeral,
+  teardownEphemeral,
 } from "../../nous/ephemeral.js";
 import { createLogger } from "../../koina/logger.js";
 

--- a/infrastructure/runtime/src/organon/built-in/ssrf-guard.test.ts
+++ b/infrastructure/runtime/src/organon/built-in/ssrf-guard.test.ts
@@ -1,5 +1,5 @@
 // SSRF guard tests
-import { describe, it, expect, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 vi.mock("node:dns/promises", () => ({
   lookup: vi.fn(),

--- a/infrastructure/runtime/src/organon/built-in/status-report.test.ts
+++ b/infrastructure/runtime/src/organon/built-in/status-report.test.ts
@@ -1,5 +1,5 @@
 // Status report meta-tool tests
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { mkdtempSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";

--- a/infrastructure/runtime/src/organon/built-in/status-report.ts
+++ b/infrastructure/runtime/src/organon/built-in/status-report.ts
@@ -1,5 +1,5 @@
 // Meta-tool — status report: agent metrics + blackboard + recent activity
-import type { ToolHandler, ToolContext } from "../registry.js";
+import type { ToolContext, ToolHandler } from "../registry.js";
 import type { SessionStore } from "../../mneme/store.js";
 import type { CompetenceModel } from "../../nous/competence.js";
 

--- a/infrastructure/runtime/src/organon/built-in/tools.test.ts
+++ b/infrastructure/runtime/src/organon/built-in/tools.test.ts
@@ -1,6 +1,6 @@
 // Built-in tool tests — tests tool definitions and execute functions using temp workspace
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdtempSync, writeFileSync, mkdirSync, rmSync, readFileSync } from "node:fs";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import type { ToolContext } from "../registry.js";

--- a/infrastructure/runtime/src/organon/built-in/trace-lookup.test.ts
+++ b/infrastructure/runtime/src/organon/built-in/trace-lookup.test.ts
@@ -1,6 +1,6 @@
 // Trace lookup tool tests
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { traceLookupTool } from "./trace-lookup.js";

--- a/infrastructure/runtime/src/organon/built-in/trace-lookup.ts
+++ b/infrastructure/runtime/src/organon/built-in/trace-lookup.ts
@@ -1,7 +1,7 @@
 // Introspective debugging — agents inspect their own reasoning provenance
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
-import type { ToolHandler, ToolContext } from "../registry.js";
+import type { ToolContext, ToolHandler } from "../registry.js";
 
 export const traceLookupTool: ToolHandler = {
   definition: {

--- a/infrastructure/runtime/src/organon/built-in/voice-reply.test.ts
+++ b/infrastructure/runtime/src/organon/built-in/voice-reply.test.ts
@@ -1,5 +1,5 @@
 // Voice reply tool tests
-import { describe, it, expect, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { createVoiceReplyTool } from "./voice-reply.js";
 
 // Mock TTS to avoid actual synthesis

--- a/infrastructure/runtime/src/organon/built-in/voice-reply.ts
+++ b/infrastructure/runtime/src/organon/built-in/voice-reply.ts
@@ -1,7 +1,7 @@
 // Voice reply tool — synthesize speech and send as audio attachment via Signal
 import { createLogger } from "../../koina/logger.js";
 import { synthesize, type TtsOptions } from "../../semeion/tts.js";
-import type { ToolHandler, ToolContext } from "../registry.js";
+import type { ToolContext, ToolHandler } from "../registry.js";
 
 const log = createLogger("organon.voice-reply");
 

--- a/infrastructure/runtime/src/organon/built-in/web-fetch.test.ts
+++ b/infrastructure/runtime/src/organon/built-in/web-fetch.test.ts
@@ -1,5 +1,5 @@
 // Web fetch tool tests
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { webFetchTool } from "./web-fetch.js";
 
 // Mock SSRF guard to allow all URLs in tests

--- a/infrastructure/runtime/src/organon/built-in/web-search.test.ts
+++ b/infrastructure/runtime/src/organon/built-in/web-search.test.ts
@@ -1,5 +1,5 @@
 // Web search tool tests
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { webSearchTool } from "./web-search.js";
 
 describe("webSearchTool", () => {

--- a/infrastructure/runtime/src/organon/built-in/what-do-i-know.test.ts
+++ b/infrastructure/runtime/src/organon/built-in/what-do-i-know.test.ts
@@ -1,5 +1,5 @@
 // What do I know tool tests
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 import { createWhatDoIKnowTool } from "./what-do-i-know.js";
 import type { ToolContext } from "../registry.js";
 

--- a/infrastructure/runtime/src/organon/built-in/what-do-i-know.ts
+++ b/infrastructure/runtime/src/organon/built-in/what-do-i-know.ts
@@ -1,5 +1,5 @@
 // Self-observation tool — knowledge domain inventory
-import type { ToolHandler, ToolContext } from "../registry.js";
+import type { ToolContext, ToolHandler } from "../registry.js";
 import type { CompetenceModel } from "../../nous/competence.js";
 import type { SessionStore } from "../../mneme/store.js";
 

--- a/infrastructure/runtime/src/organon/built-in/write.ts
+++ b/infrastructure/runtime/src/organon/built-in/write.ts
@@ -1,7 +1,7 @@
 // File write tool
-import { writeFileSync, mkdirSync } from "node:fs";
+import { mkdirSync, writeFileSync } from "node:fs";
 import { dirname } from "node:path";
-import type { ToolHandler, ToolContext } from "../registry.js";
+import type { ToolContext, ToolHandler } from "../registry.js";
 import { safePath } from "./safe-path.js";
 import { trySafe } from "../../koina/safe.js";
 import { commitWorkspaceChange } from "../workspace-git.js";

--- a/infrastructure/runtime/src/organon/mcp-client.ts
+++ b/infrastructure/runtime/src/organon/mcp-client.ts
@@ -6,7 +6,7 @@ import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js"
 import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
-import type { ToolRegistry, ToolHandler, ToolContext } from "./registry.js";
+import type { ToolContext, ToolHandler, ToolRegistry } from "./registry.js";
 import { createLogger } from "../koina/logger.js";
 import { getVersion } from "../version.js";
 

--- a/infrastructure/runtime/src/organon/registry.test.ts
+++ b/infrastructure/runtime/src/organon/registry.test.ts
@@ -1,6 +1,6 @@
 // Tool registry tests
-import { describe, it, expect } from "vitest";
-import { ToolRegistry, type ToolHandler, type ToolContext } from "./registry.js";
+import { describe, expect, it } from "vitest";
+import { type ToolContext, type ToolHandler, ToolRegistry } from "./registry.js";
 
 function makeHandler(name: string, result = "ok"): ToolHandler {
   return {

--- a/infrastructure/runtime/src/organon/reversibility.test.ts
+++ b/infrastructure/runtime/src/organon/reversibility.test.ts
@@ -1,6 +1,6 @@
 // Reversibility module tests
-import { describe, it, expect } from "vitest";
-import { getReversibility, requiresSimulation, buildSimulationPrompt } from "./reversibility.js";
+import { describe, expect, it } from "vitest";
+import { buildSimulationPrompt, getReversibility, requiresSimulation } from "./reversibility.js";
 
 describe("getReversibility", () => {
   it("returns reversible for read-only tools", () => {

--- a/infrastructure/runtime/src/organon/self-author.test.ts
+++ b/infrastructure/runtime/src/organon/self-author.test.ts
@@ -1,10 +1,10 @@
 // Self-authoring tool tests
-import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { mkdtempSync, rmSync, writeFileSync, mkdirSync, readFileSync, existsSync } from "node:fs";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { loadAuthoredTools, createSelfAuthorTools } from "./self-author.js";
-import type { ToolRegistry, ToolHandler } from "./registry.js";
+import { createSelfAuthorTools, loadAuthoredTools } from "./self-author.js";
+import type { ToolHandler, ToolRegistry } from "./registry.js";
 
 let tmpDir: string;
 let workspace: string;

--- a/infrastructure/runtime/src/organon/self-author.ts
+++ b/infrastructure/runtime/src/organon/self-author.ts
@@ -1,9 +1,9 @@
 // Self-authoring tools — agents create, test, and register custom tools at runtime
-import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
-import { join, basename } from "node:path";
+import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { basename, join } from "node:path";
 import { execSync } from "node:child_process";
 import { createLogger } from "../koina/logger.js";
-import type { ToolHandler, ToolContext, ToolRegistry } from "./registry.js";
+import type { ToolContext, ToolHandler, ToolRegistry } from "./registry.js";
 
 const log = createLogger("organon.self-author");
 

--- a/infrastructure/runtime/src/organon/skills.test.ts
+++ b/infrastructure/runtime/src/organon/skills.test.ts
@@ -1,7 +1,7 @@
 // Skills registry tests
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { SkillRegistry } from "./skills.js";
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 

--- a/infrastructure/runtime/src/organon/skills.ts
+++ b/infrastructure/runtime/src/organon/skills.ts
@@ -1,5 +1,5 @@
 // Skills directory — loads SKILL.md files and exposes them for bootstrap/commands
-import { readdirSync, readFileSync, existsSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { createLogger } from "../koina/logger.js";
 

--- a/infrastructure/runtime/src/organon/timeout.test.ts
+++ b/infrastructure/runtime/src/organon/timeout.test.ts
@@ -1,10 +1,10 @@
 // Timeout wrapper tests
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 import {
+  DEFAULT_TOOL_TIMEOUTS,
   executeWithTimeout,
   resolveTimeout,
   ToolTimeoutError,
-  DEFAULT_TOOL_TIMEOUTS,
 } from "./timeout.js";
 
 describe("resolveTimeout", () => {

--- a/infrastructure/runtime/src/organon/truncate.test.ts
+++ b/infrastructure/runtime/src/organon/truncate.test.ts
@@ -1,5 +1,5 @@
 // Tool result truncation tests
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 import { truncateToolResult } from "./truncate.js";
 
 describe("truncateToolResult", () => {

--- a/infrastructure/runtime/src/organon/workspace-git.ts
+++ b/infrastructure/runtime/src/organon/workspace-git.ts
@@ -1,7 +1,7 @@
 // Workspace git tracking — auto-commit file changes for history and rollback
 import { execFileSync } from "node:child_process";
 import { existsSync } from "node:fs";
-import { join, relative, basename } from "node:path";
+import { basename, join, relative } from "node:path";
 import { createLogger } from "../koina/logger.js";
 
 const log = createLogger("organon.workspace-git");

--- a/infrastructure/runtime/src/prostheke/loader.test.ts
+++ b/infrastructure/runtime/src/prostheke/loader.test.ts
@@ -1,6 +1,6 @@
 // Plugin loader tests
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { loadPlugins } from "./loader.js";

--- a/infrastructure/runtime/src/prostheke/registry.test.ts
+++ b/infrastructure/runtime/src/prostheke/registry.test.ts
@@ -1,7 +1,7 @@
 // Plugin registry tests
-import { describe, it, expect, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { PluginRegistry } from "./registry.js";
-import type { PluginDefinition, PluginApi } from "./types.js";
+import type { PluginApi, PluginDefinition } from "./types.js";
 
 function makeConfig(): never {
   return { agents: { list: [] }, gateway: { port: 18789, auth: { mode: "none" } } } as never;

--- a/infrastructure/runtime/src/prostheke/registry.ts
+++ b/infrastructure/runtime/src/prostheke/registry.ts
@@ -3,13 +3,13 @@ import { createLogger } from "../koina/logger.js";
 import type { ToolRegistry } from "../organon/registry.js";
 import type { AletheiaConfig } from "../taxis/schema.js";
 import type {
-  PluginDefinition,
-  PluginApi,
-  HookName,
-  TurnContext,
-  TurnResult,
   DistillContext,
   DistillResult,
+  HookName,
+  PluginApi,
+  PluginDefinition,
+  TurnContext,
+  TurnResult,
 } from "./types.js";
 
 const log = createLogger("prostheke");

--- a/infrastructure/runtime/src/pylon/mcp.test.ts
+++ b/infrastructure/runtime/src/pylon/mcp.test.ts
@@ -1,6 +1,6 @@
 // MCP routes tests — JSON-RPC handling, auth, scope enforcement, tool listing, tool execution
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { createMcpRoutes, validateMcpToken, loadMcpTokens } from "./mcp.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createMcpRoutes, loadMcpTokens, validateMcpToken } from "./mcp.js";
 
 function makeConfig(overrides: Record<string, unknown> = {}) {
   return {

--- a/infrastructure/runtime/src/pylon/mcp.ts
+++ b/infrastructure/runtime/src/pylon/mcp.ts
@@ -1,6 +1,6 @@
 // MCP (Model Context Protocol) server — exposes Aletheia agents as MCP tools
 import { Hono } from "hono";
-import { readFileSync, existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { randomBytes, timingSafeEqual } from "node:crypto";
 import { createLogger } from "../koina/logger.js";
 import type { AletheiaConfig } from "../taxis/schema.js";

--- a/infrastructure/runtime/src/pylon/server-full.test.ts
+++ b/infrastructure/runtime/src/pylon/server-full.test.ts
@@ -1,6 +1,6 @@
 // Extended server tests — admin endpoints, costs, auth modes
-import { describe, it, expect, vi } from "vitest";
-import { createGateway, setCronRef, setWatchdogRef, setSkillsRef } from "./server.js";
+import { describe, expect, it, vi } from "vitest";
+import { createGateway, setCronRef, setSkillsRef, setWatchdogRef } from "./server.js";
 
 function makeConfig(overrides: Record<string, unknown> = {}) {
   return {

--- a/infrastructure/runtime/src/pylon/server-stream.test.ts
+++ b/infrastructure/runtime/src/pylon/server-stream.test.ts
@@ -1,5 +1,5 @@
 // Streaming endpoint tests
-import { describe, it, expect, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { createGateway } from "./server.js";
 
 function makeConfig() {

--- a/infrastructure/runtime/src/pylon/server.test.ts
+++ b/infrastructure/runtime/src/pylon/server.test.ts
@@ -1,5 +1,5 @@
 // Pylon server tests
-import { describe, it, expect, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { createGateway, setCronRef, setWatchdogRef } from "./server.js";
 
 function makeConfig() {

--- a/infrastructure/runtime/src/pylon/server.ts
+++ b/infrastructure/runtime/src/pylon/server.ts
@@ -1,7 +1,7 @@
 // Hono HTTP gateway
 import { Hono } from "hono";
 import { serve } from "@hono/node-server";
-import { timingSafeEqual, randomBytes, scryptSync, createCipheriv } from "node:crypto";
+import { createCipheriv, randomBytes, scryptSync, timingSafeEqual } from "node:crypto";
 import { createLogger, withTurnAsync } from "../koina/logger.js";
 import type { NousManager } from "../nous/manager.js";
 import type { SessionStore } from "../mneme/store.js";
@@ -11,7 +11,7 @@ import type { Watchdog } from "../daemon/watchdog.js";
 import type { SkillRegistry } from "../organon/skills.js";
 import type { McpClientManager } from "../organon/mcp-client.js";
 import { calculateCostBreakdown } from "../hermeneus/pricing.js";
-import { readFileSync, writeFileSync, readdirSync, statSync, existsSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
 import { eventBus, type EventName } from "../koina/event-bus.js";
 import { join, resolve } from "node:path";
 import { execSync } from "node:child_process";

--- a/infrastructure/runtime/src/pylon/ui.test.ts
+++ b/infrastructure/runtime/src/pylon/ui.test.ts
@@ -1,6 +1,6 @@
 // Web UI route tests
-import { describe, it, expect, vi } from "vitest";
-import { createUiRoutes, broadcastEvent } from "./ui.js";
+import { describe, expect, it, vi } from "vitest";
+import { broadcastEvent, createUiRoutes } from "./ui.js";
 
 function makeConfig() {
   return {

--- a/infrastructure/runtime/src/pylon/ui.ts
+++ b/infrastructure/runtime/src/pylon/ui.ts
@@ -1,6 +1,6 @@
 // Web UI — Svelte SPA served at /ui, SSE events at /api/events
 import { existsSync, readFileSync } from "node:fs";
-import { join, extname } from "node:path";
+import { extname, join } from "node:path";
 import { Hono } from "hono";
 import type { SessionStore } from "../mneme/store.js";
 import type { AletheiaConfig } from "../taxis/schema.js";

--- a/infrastructure/runtime/src/semeion/client-full.test.ts
+++ b/infrastructure/runtime/src/semeion/client-full.test.ts
@@ -1,5 +1,5 @@
 // Extended Signal client tests — sendTyping, sendReceipt, sendReaction, getAttachment, retry edge cases
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { SignalClient } from "./client.js";
 
 describe("SignalClient extended", () => {

--- a/infrastructure/runtime/src/semeion/client.test.ts
+++ b/infrastructure/runtime/src/semeion/client.test.ts
@@ -1,5 +1,5 @@
 // Signal client tests
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { SignalClient } from "./client.js";
 
 describe("SignalClient", () => {

--- a/infrastructure/runtime/src/semeion/commands-full.test.ts
+++ b/infrastructure/runtime/src/semeion/commands-full.test.ts
@@ -1,5 +1,5 @@
 // Full command execution tests — covers !status, !help, !sessions, !reset, etc.
-import { describe, it, expect, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { createDefaultRegistry } from "./commands.js";
 
 function makeCtx(overrides: Record<string, unknown> = {}) {

--- a/infrastructure/runtime/src/semeion/commands.test.ts
+++ b/infrastructure/runtime/src/semeion/commands.test.ts
@@ -1,5 +1,5 @@
 // Command registry tests
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 import { CommandRegistry, createDefaultRegistry } from "./commands.js";
 
 describe("CommandRegistry", () => {

--- a/infrastructure/runtime/src/semeion/daemon.test.ts
+++ b/infrastructure/runtime/src/semeion/daemon.test.ts
@@ -1,5 +1,5 @@
 // Signal daemon tests — config extraction, lifecycle
-import { describe, it, expect, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { daemonOptsFromConfig } from "./daemon.js";
 
 describe("daemonOptsFromConfig", () => {

--- a/infrastructure/runtime/src/semeion/format.test.ts
+++ b/infrastructure/runtime/src/semeion/format.test.ts
@@ -1,5 +1,5 @@
 // Signal text formatting tests
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 import { formatForSignal, stylesToSignalParam } from "./format.js";
 
 describe("formatForSignal", () => {

--- a/infrastructure/runtime/src/semeion/listener.test.ts
+++ b/infrastructure/runtime/src/semeion/listener.test.ts
@@ -1,5 +1,5 @@
 // Signal listener tests — envelope handling, access control, mention hydration
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // We can't easily test startListener (SSE consumer) without a real stream,
 // but we can test the helper functions by importing them indirectly.

--- a/infrastructure/runtime/src/semeion/listener.ts
+++ b/infrastructure/runtime/src/semeion/listener.ts
@@ -1,12 +1,12 @@
 // SSE event stream consumer — dispatches Signal messages to NousManager
 import { createLogger, withTurnAsync } from "../koina/logger.js";
 import { TransportError } from "../koina/errors.js";
-import type { NousManager, InboundMessage, MediaAttachment } from "../nous/manager.js";
-import { SignalClient } from "./client.js";
-import { sendMessage, sendTyping, sendReadReceipt, type SendTarget } from "./sender.js";
-import type { SignalAccount, AletheiaConfig } from "../taxis/schema.js";
+import type { InboundMessage, MediaAttachment, NousManager } from "../nous/manager.js";
+import type { SignalClient } from "./client.js";
+import { sendMessage, sendReadReceipt, type SendTarget, sendTyping } from "./sender.js";
+import type { AletheiaConfig, SignalAccount } from "../taxis/schema.js";
 import type { SessionStore } from "../mneme/store.js";
-import type { CommandRegistry, CommandContext } from "./commands.js";
+import type { CommandContext, CommandRegistry } from "./commands.js";
 import type { Watchdog } from "../daemon/watchdog.js";
 import type { SkillRegistry } from "../organon/skills.js";
 import { preprocessLinks } from "./preprocess.js";

--- a/infrastructure/runtime/src/semeion/preprocess.test.ts
+++ b/infrastructure/runtime/src/semeion/preprocess.test.ts
@@ -1,5 +1,5 @@
 // Link preprocessing tests
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("../organon/built-in/ssrf-guard.js", () => ({
   validateUrl: vi.fn().mockResolvedValue(undefined),

--- a/infrastructure/runtime/src/semeion/sender.test.ts
+++ b/infrastructure/runtime/src/semeion/sender.test.ts
@@ -1,5 +1,5 @@
 // Sender utility tests
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 import { parseTarget } from "./sender.js";
 
 describe("parseTarget", () => {

--- a/infrastructure/runtime/src/semeion/sender.ts
+++ b/infrastructure/runtime/src/semeion/sender.ts
@@ -1,6 +1,6 @@
 // Outbound message sending via signal-cli
 import { createLogger } from "../koina/logger.js";
-import { SignalClient } from "./client.js";
+import type { SignalClient } from "./client.js";
 import { formatForSignal, stylesToSignalParam } from "./format.js";
 
 const log = createLogger("semeion:send");

--- a/infrastructure/runtime/src/semeion/transcribe.test.ts
+++ b/infrastructure/runtime/src/semeion/transcribe.test.ts
@@ -1,6 +1,6 @@
 // Transcription module tests
-import { describe, it, expect } from "vitest";
-import { transcribeAudio, isWhisperAvailable } from "./transcribe.js";
+import { describe, expect, it } from "vitest";
+import { isWhisperAvailable, transcribeAudio } from "./transcribe.js";
 
 describe("transcribe", () => {
   it("isWhisperAvailable returns false without WHISPER_MODEL_PATH", () => {

--- a/infrastructure/runtime/src/semeion/transcribe.ts
+++ b/infrastructure/runtime/src/semeion/transcribe.ts
@@ -1,6 +1,6 @@
 // Audio transcription via whisper.cpp
 import { execFile } from "node:child_process";
-import { writeFileSync, unlinkSync, existsSync, mkdtempSync } from "node:fs";
+import { existsSync, mkdtempSync, unlinkSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { createLogger } from "../koina/logger.js";

--- a/infrastructure/runtime/src/semeion/tts.test.ts
+++ b/infrastructure/runtime/src/semeion/tts.test.ts
@@ -1,5 +1,5 @@
 // TTS tests — synthesize, cleanupTtsFiles
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 describe("synthesize", () => {
   beforeEach(() => {

--- a/infrastructure/runtime/src/semeion/tts.ts
+++ b/infrastructure/runtime/src/semeion/tts.ts
@@ -1,5 +1,5 @@
 // Text-to-speech synthesis — OpenAI TTS primary, Piper local fallback
-import { writeFileSync, mkdirSync, unlinkSync, existsSync } from "node:fs";
+import { existsSync, mkdirSync, unlinkSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { execFileSync } from "node:child_process";
 import { randomBytes } from "node:crypto";

--- a/infrastructure/runtime/src/taxis/loader.test.ts
+++ b/infrastructure/runtime/src/taxis/loader.test.ts
@@ -1,6 +1,6 @@
 // Config loading unit tests
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { loadConfig, resolveNous, resolveModel, resolveWorkspace, resolveDefaultNous, allNousIds, applyEnv } from "./loader.js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { allNousIds, applyEnv, loadConfig, resolveDefaultNous, resolveModel, resolveNous, resolveWorkspace } from "./loader.js";
 import { ConfigError } from "../koina/errors.js";
 import type { AletheiaConfig, NousConfig } from "./schema.js";
 

--- a/infrastructure/runtime/src/taxis/loader.ts
+++ b/infrastructure/runtime/src/taxis/loader.ts
@@ -4,8 +4,8 @@ import { ConfigError } from "../koina/errors.js";
 import { createLogger } from "../koina/logger.js";
 import { paths } from "./paths.js";
 import {
-  AletheiaConfigSchema,
   type AletheiaConfig,
+  AletheiaConfigSchema,
   type NousConfig,
 } from "./schema.js";
 

--- a/infrastructure/runtime/src/taxis/paths.test.ts
+++ b/infrastructure/runtime/src/taxis/paths.test.ts
@@ -1,5 +1,5 @@
 // Paths module tests
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 describe("paths", () => {
   const originalEnv = { ...process.env };

--- a/infrastructure/runtime/src/version.test.ts
+++ b/infrastructure/runtime/src/version.test.ts
@@ -1,5 +1,5 @@
 // Version module tests
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 import { getVersion } from "./version.js";
 
 describe("getVersion", () => {


### PR DESCRIPTION
## Summary
- Enable `import` plugin alongside existing `typescript` plugin
- Add `typescript/consistent-type-imports` (error) — enforces `import type` for type-only imports, with autofix
- Add `sort-imports` (warn) — alphabetical member sorting within imports, declaration order left alone
- Add `import/no-duplicates` (error) — prevents duplicate import statements from same module
- Upgrade `no-empty` from warn to error — zero tolerance for empty blocks
- Autofix all 160 source files for consistent type imports and sorted import members

Implements spec 06 Phase 7: encode coding standards in linter tooling.

## Test plan
- [ ] `npx oxlint src/` reports 0 errors (129 pre-existing warnings remain)
- [ ] `npx tsc --noEmit` clean
- [ ] `npx tsdown` builds successfully
- [ ] Pre-commit hook passes


🤖 Generated with [Claude Code](https://claude.com/claude-code)