### PR TITLE
feat: collapsed reasoning in history

### DIFF
--- a/infrastructure/runtime/src/nous/pipeline/stages/execute.ts
+++ b/infrastructure/runtime/src/nous/pipeline/stages/execute.ts
@@ -143,7 +143,10 @@ export async function* executeStreaming(
         trace.addToolCall({ name: "_circuit_breaker", input: { check: "response_quality" }, output: qualityCheck.reason ?? "quality check triggered", durationMs: 0, isError: true });
       }
 
-      services.store.appendMessage(sessionId, "assistant", text, { tokenEstimate: estimateTokens(text) });
+      // Store full ContentBlock[] when thinking blocks present, so history preserves reasoning
+      const hasThinking = streamResult.content.some((b) => b.type === "thinking");
+      const storeContent = hasThinking ? JSON.stringify(streamResult.content) : text;
+      services.store.appendMessage(sessionId, "assistant", storeContent, { tokenEstimate: estimateTokens(storeContent) });
 
       const outcome: TurnOutcome = {
         text, nousId, sessionId, toolCalls: totalToolCalls,

--- a/ui/src/components/chat/ThinkingStatusLine.svelte
+++ b/ui/src/components/chat/ThinkingStatusLine.svelte
@@ -7,7 +7,7 @@
     onclick?: () => void;
   } = $props();
 
-  function extractSummary(text: string): string {
+  function extractLiveSummary(text: string): string {
     if (!text || text.length < 10) return "Thinking...";
 
     const tail = text.slice(-300);
@@ -27,7 +27,22 @@
     return "Thinking...";
   }
 
-  let summary = $derived(extractSummary(thinkingText));
+  function generateCompletedSummary(text: string): string {
+    if (!text || text.length < 10) return "Thought process";
+
+    const sentences = text.match(/[^.!?\n]+[.!?]+/g) ?? [];
+    if (sentences.length === 0) {
+      const firstLine = text.split("\n").filter(Boolean)[0];
+      return firstLine ? firstLine.trim().slice(0, 80) : "Thought process";
+    }
+    if (sentences.length === 1) return sentences[0]!.trim().slice(0, 80);
+
+    const first = sentences[0]!.trim().slice(0, 40);
+    const last = sentences[sentences.length - 1]!.trim().slice(0, 40);
+    return `${first}${first.length >= 40 ? "..." : ""} \u2192 ${last}${last.length >= 40 ? "..." : ""}`;
+  }
+
+  let summary = $derived(isStreaming ? extractLiveSummary(thinkingText) : generateCompletedSummary(thinkingText));
 </script>
 
 <button


### PR DESCRIPTION
## Summary
- Server stores full ContentBlock[] JSON (including thinking blocks) for text-only responses with reasoning, so thinking persists in the database across page refreshes
- Client extracts thinking blocks from history ContentBlock arrays when loading chat history
- ThinkingStatusLine uses two summary modes: live streaming (last sentence) and completed (first sentence -> last sentence)

Implements spec 10 Phase 4 completion: collapsed reasoning survives history reload.

## Test plan
- [ ] Send message to Opus agent (thinking enabled) -> verify thinking pill shows during streaming
- [ ] Refresh page -> verify thinking block appears on the completed message with collapsed summary
- [ ] Click collapsed thinking pill -> verify full thinking text opens in panel
- [ ] Verify Haiku/Sonnet messages without thinking render normally (no empty pill)


🤖 Generated with [Claude Code](https://claude.com/claude-code)