### PR TITLE
feat: session-based auth wiring (Spec 03 Phases 2a-2e)

### DIFF
--- a/infrastructure/runtime/src/aletheia.ts
+++ b/infrastructure/runtime/src/aletheia.ts
@@ -41,7 +41,10 @@ import { createDeliberateTool } from "./organon/built-in/deliberate.js";
 import { createSelfAuthorTools, loadAuthoredTools } from "./organon/self-author.js";
 import { NousManager } from "./nous/manager.js";
 import { McpClientManager } from "./organon/mcp-client.js";
-import { createGateway, startGateway, setCronRef, setWatchdogRef, setSkillsRef, setMcpRef, setCommandsRef } from "./pylon/server.js";
+import { createGateway, startGateway, setCronRef, setWatchdogRef, setSkillsRef, setMcpRef, setCommandsRef, type GatewayAuthDeps } from "./pylon/server.js";
+import { AuthSessionStore } from "./auth/sessions.js";
+import { AuditLog } from "./auth/audit.js";
+import { generateSecret } from "./auth/tokens.js";
 import { createMcpRoutes } from "./pylon/mcp.js";
 import { createUiRoutes, broadcastEvent } from "./pylon/ui.js";
 import { SignalClient } from "./semeion/client.js";
@@ -65,7 +68,8 @@ import { getVersion } from "./version.js";
 import { CompetenceModel } from "./nous/competence.js";
 import { UncertaintyTracker } from "./nous/uncertainty.js";
 import type { AletheiaConfig } from "./taxis/schema.js";
-import { chmodSync, existsSync } from "node:fs";
+import { chmodSync, existsSync, readFileSync, writeFileSync } from "node:fs";
+import Database from "better-sqlite3";
 import { eventBus } from "./koina/event-bus.js";
 
 const log = createLogger("aletheia");
@@ -284,9 +288,39 @@ export async function startRuntime(configPath?: string): Promise<void> {
     await runtime.plugins.dispatchStart();
   }
 
+  // --- Auth ---
+  let gatewayAuth: GatewayAuthDeps | undefined;
+  {
+    const authDb = new Database(paths.sessionsDb());
+    authDb.pragma("journal_mode = WAL");
+    authDb.pragma("synchronous = NORMAL");
+
+    const auditLog = new AuditLog(authDb);
+    let authSessionStore: AuthSessionStore | null = null;
+    let sessionSecret: string | null = null;
+
+    if (config.gateway.auth.mode === "session") {
+      authSessionStore = new AuthSessionStore(authDb);
+      const secretPath = join(paths.configDir(), "session.key");
+      if (existsSync(secretPath)) {
+        sessionSecret = readFileSync(secretPath, "utf-8").trim();
+      } else {
+        sessionSecret = generateSecret();
+        writeFileSync(secretPath, sessionSecret, { mode: 0o600 });
+        log.info("Generated new session signing key");
+      }
+
+      if (config.gateway.auth.users.length === 0) {
+        log.warn("Auth mode is 'session' but no users configured — run 'aletheia migrate-auth' to create an admin account");
+      }
+    }
+
+    gatewayAuth = { sessionStore: authSessionStore, auditLog, secret: sessionSecret };
+  }
+
   // --- Gateway ---
   const port = config.gateway.port;
-  const app = createGateway(config, runtime.manager, runtime.store);
+  const app = createGateway(config, runtime.manager, runtime.store, gatewayAuth);
 
   // Mount MCP server routes
   const mcpRoutes = createMcpRoutes(config, runtime.manager, runtime.store);

--- a/infrastructure/runtime/src/auth/audit.ts
+++ b/infrastructure/runtime/src/auth/audit.ts
@@ -1,4 +1,3 @@
-// TODO(unused): scaffolded for spec 3 (Auth & Updates) — not yet integrated into gateway
 // Structured audit logging
 import type Database from "better-sqlite3";
 import { createLogger } from "../koina/logger.js";

--- a/infrastructure/runtime/src/auth/middleware.ts
+++ b/infrastructure/runtime/src/auth/middleware.ts
@@ -1,4 +1,3 @@
-// TODO(unused): scaffolded for spec 3 (Auth & Updates) — not yet integrated into gateway
 // Multi-mode auth middleware for Hono
 import type { Context, Next } from "hono";
 import { timingSafeEqual } from "node:crypto";
@@ -57,6 +56,7 @@ export function createAuthMiddleware(
   const skipPaths = new Set([
     "/health",
     "/api/branding",
+    "/api/commands",
     "/api/auth/login",
     "/api/auth/refresh",
     "/api/auth/mode",

--- a/infrastructure/runtime/src/auth/passwords.ts
+++ b/infrastructure/runtime/src/auth/passwords.ts
@@ -1,4 +1,3 @@
-// TODO(unused): scaffolded for spec 3 (Auth & Updates) — not yet integrated into gateway
 // Password hashing — scrypt (node:crypto built-in, zero deps)
 import { scryptSync, randomBytes, timingSafeEqual } from "node:crypto";
 

--- a/infrastructure/runtime/src/auth/rbac.ts
+++ b/infrastructure/runtime/src/auth/rbac.ts
@@ -1,4 +1,3 @@
-// TODO(unused): scaffolded for spec 3 (Auth & Updates) — not yet integrated into gateway
 // Role-based access control
 const ROUTE_PERMISSIONS: Record<string, string> = {
   // Chat

--- a/infrastructure/runtime/src/auth/sessions.ts
+++ b/infrastructure/runtime/src/auth/sessions.ts
@@ -1,4 +1,3 @@
-// TODO(unused): scaffolded for spec 3 (Auth & Updates) — not yet integrated into gateway
 // Auth session CRUD — SQLite-backed
 import type Database from "better-sqlite3";
 import { createHash } from "node:crypto";

--- a/infrastructure/runtime/src/auth/tokens.ts
+++ b/infrastructure/runtime/src/auth/tokens.ts
@@ -1,4 +1,3 @@
-// TODO(unused): scaffolded for spec 3 (Auth & Updates) — not yet integrated into gateway
 // JWT signing/verification — HMAC-SHA256, zero external deps
 import { createHmac, timingSafeEqual, randomBytes } from "node:crypto";
 

--- a/infrastructure/runtime/src/taxis/schema.ts
+++ b/infrastructure/runtime/src/taxis/schema.ts
@@ -224,8 +224,25 @@ const GatewayConfig = z
       .default("lan"),
     auth: z
       .object({
-        mode: z.enum(["token", "password"]).default("token"),
+        mode: z.enum(["none", "token", "password", "session"]).default("token"),
         token: z.string().optional(),
+        users: z
+          .array(
+            z.object({
+              username: z.string(),
+              passwordHash: z.string(),
+              role: z.enum(["admin", "user", "readonly"]).default("admin"),
+            }),
+          )
+          .default([]),
+        session: z
+          .object({
+            accessTokenTtl: z.number().default(900),
+            refreshTokenTtl: z.number().default(2_592_000),
+            maxSessionsPerUser: z.number().default(10),
+            secureCookies: z.boolean().default(true),
+          })
+          .default({}),
       })
       .default({}),
     controlUi: z

--- a/ui/src/components/auth/Login.svelte
+++ b/ui/src/components/auth/Login.svelte
@@ -1,0 +1,158 @@
+<script lang="ts">
+  import { login } from "../../lib/auth";
+  import { getBrandName } from "../../stores/branding.svelte";
+
+  let { onSuccess }: { onSuccess: () => void } = $props();
+
+  let username = $state("");
+  let password = $state("");
+  let rememberMe = $state(true);
+  let error = $state<string | null>(null);
+  let loading = $state(false);
+
+  async function handleSubmit(e: Event) {
+    e.preventDefault();
+    if (!username.trim() || !password) return;
+
+    loading = true;
+    error = null;
+
+    const result = await login(username.trim(), password, rememberMe);
+    loading = false;
+
+    if (result.ok) {
+      onSuccess();
+    } else {
+      error = result.error ?? "Login failed";
+    }
+  }
+</script>
+
+<div class="login-page">
+  <div class="login-card">
+    <h1>{getBrandName()}</h1>
+    <p>Sign in to continue</p>
+    <form onsubmit={handleSubmit}>
+      <input
+        type="text"
+        class="input"
+        placeholder="Username"
+        autocomplete="username"
+        bind:value={username}
+        disabled={loading}
+      />
+      <input
+        type="password"
+        class="input"
+        placeholder="Password"
+        autocomplete="current-password"
+        bind:value={password}
+        disabled={loading}
+      />
+      <label class="remember">
+        <input type="checkbox" bind:checked={rememberMe} />
+        <span>Remember me</span>
+      </label>
+      {#if error}
+        <div class="error">{error}</div>
+      {/if}
+      <button type="submit" class="submit" disabled={loading}>
+        {loading ? "Signing in..." : "Sign in"}
+      </button>
+    </form>
+  </div>
+</div>
+
+<style>
+  .login-page {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 100vh;
+    background: var(--bg);
+  }
+  .login-card {
+    background: var(--bg-elevated);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 32px;
+    max-width: 380px;
+    width: 100%;
+    text-align: center;
+  }
+  .login-card h1 {
+    font-size: 24px;
+    margin-bottom: 4px;
+  }
+  .login-card p {
+    color: var(--text-secondary);
+    font-size: 14px;
+    margin-bottom: 20px;
+  }
+  .login-card form {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+  .input {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    color: var(--text);
+    padding: 10px 14px;
+    font-size: 14px;
+    font-family: var(--font-sans);
+    width: 100%;
+  }
+  .input:focus {
+    outline: none;
+    border-color: var(--accent);
+  }
+  .input:disabled {
+    opacity: 0.6;
+  }
+  .remember {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 13px;
+    color: var(--text-secondary);
+    cursor: pointer;
+    user-select: none;
+  }
+  .remember input[type="checkbox"] {
+    accent-color: var(--accent);
+  }
+  .error {
+    background: rgba(248, 81, 73, 0.1);
+    border: 1px solid var(--red);
+    border-radius: var(--radius-sm);
+    color: var(--red);
+    font-size: 13px;
+    padding: 8px 12px;
+    text-align: left;
+  }
+  .submit {
+    background: var(--accent);
+    border: none;
+    color: #fff;
+    padding: 10px 14px;
+    border-radius: var(--radius-sm);
+    font-size: 14px;
+    font-weight: 500;
+    cursor: pointer;
+    margin-top: 4px;
+  }
+  .submit:hover:not(:disabled) {
+    background: var(--accent-hover);
+  }
+  .submit:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+  @media (max-width: 768px) {
+    .login-card {
+      margin: 0 16px;
+    }
+  }
+</style>

--- a/ui/src/lib/auth.ts
+++ b/ui/src/lib/auth.ts
@@ -29,11 +29,12 @@ export async function fetchAuthMode(): Promise<AuthMode> {
 export async function login(
   username: string,
   password: string,
+  rememberMe = true,
 ): Promise<{ ok: boolean; error?: string; role?: string }> {
   const res = await fetch("/api/auth/login", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ username, password }),
+    body: JSON.stringify({ username, password, rememberMe }),
     credentials: "include",
   });
 

--- a/ui/src/lib/events.ts
+++ b/ui/src/lib/events.ts
@@ -1,4 +1,4 @@
-import { getToken } from "./api";
+import { getEffectiveToken } from "./api";
 
 type EventCallback = (event: string, data: unknown) => void;
 
@@ -33,7 +33,7 @@ export function closeEventSource(): void {
 }
 
 function connect() {
-  const token = getToken();
+  const token = getEffectiveToken();
   const base = import.meta.env.DEV ? "" : window.location.origin;
   const url = `${base}/api/events${token ? `?token=${encodeURIComponent(token)}` : ""}`;
 

--- a/ui/src/lib/stream.ts
+++ b/ui/src/lib/stream.ts
@@ -1,4 +1,4 @@
-import { getToken } from "./api";
+import { getEffectiveToken } from "./api";
 import type { TurnStreamEvent, MediaItem } from "./types";
 
 export async function* streamMessage(
@@ -9,7 +9,7 @@ export async function* streamMessage(
   media?: MediaItem[],
 ): AsyncGenerator<TurnStreamEvent> {
   const base = import.meta.env.DEV ? "" : window.location.origin;
-  const token = getToken();
+  const token = getEffectiveToken();
 
   const res = await fetch(`${base}/api/sessions/stream`, {
     method: "POST",


### PR DESCRIPTION
## Summary
- Expand auth schema to support `none | token | password | session` modes with user accounts, scrypt password hashing, and JWT session config
- Wire auth modules (middleware, sessions, tokens, passwords, RBAC, audit) into the gateway — replaces inline token check with multi-mode middleware
- Add auth API routes: login, refresh (token rotation), logout, session management, audit log query
- Add Login component with auth state machine in Layout (loading → login → token-setup → authenticated)
- Add `migrate-auth` CLI command for migrating from token to session auth
- Update SSE events and streaming to use effective token (session or static)

16 files changed, +566/-53 lines across runtime and UI.

## Test plan
- [ ] `tsc --noEmit` clean
- [ ] `npx tsdown` builds (491KB)
- [ ] UI builds clean
- [ ] Token mode still works (backwards compatible)
- [ ] Session mode: login → access token → refresh rotation → logout
- [ ] migrate-auth CLI creates user and switches mode
- [ ] SSE reconnects with session token after refresh
- [ ] 401 → auto-refresh → retry in API client

🤖 Generated with [Claude Code](https://claude.com/claude-code)