### PR TITLE
feat: session classification, lightweight distillation, ephemeral cleanup

### DIFF
--- a/infrastructure/runtime/src/daemon/retention.ts
+++ b/infrastructure/runtime/src/daemon/retention.ts
@@ -9,6 +9,7 @@ export interface RetentionResult {
   distilledMessagesDeleted: number;
   archivedMessagesDeleted: number;
   toolResultsTruncated: number;
+  ephemeralSessionsDeleted: number;
 }
 
 /**
@@ -24,6 +25,7 @@ export function runRetention(
     distilledMessagesDeleted: 0,
     archivedMessagesDeleted: 0,
     toolResultsTruncated: 0,
+    ephemeralSessionsDeleted: 0,
   };
 
   try {
@@ -50,15 +52,23 @@ export function runRetention(
     log.error(`Retention: tool result truncation failed: ${err instanceof Error ? err.message : err}`);
   }
 
+  try {
+    result.ephemeralSessionsDeleted = store.deleteEphemeralSessions();
+  } catch (err) {
+    log.error(`Retention: ephemeral cleanup failed: ${err instanceof Error ? err.message : err}`);
+  }
+
   const total =
     result.distilledMessagesDeleted +
     result.archivedMessagesDeleted +
-    result.toolResultsTruncated;
+    result.toolResultsTruncated +
+    result.ephemeralSessionsDeleted;
   if (total > 0) {
     log.info(
       `Retention cycle complete: ${result.distilledMessagesDeleted} distilled msgs deleted, ` +
       `${result.archivedMessagesDeleted} archived msgs deleted, ` +
-      `${result.toolResultsTruncated} tool results truncated`,
+      `${result.toolResultsTruncated} tool results truncated, ` +
+      `${result.ephemeralSessionsDeleted} ephemeral sessions deleted`,
     );
   }
 

--- a/infrastructure/runtime/src/pylon/server.ts
+++ b/infrastructure/runtime/src/pylon/server.ts
@@ -1,7 +1,7 @@
 // Hono HTTP gateway
 import { Hono } from "hono";
 import { serve } from "@hono/node-server";
-import { createCipheriv, randomBytes, scryptSync, timingSafeEqual } from "node:crypto";
+import { createCipheriv, randomBytes, scryptSync } from "node:crypto";
 import { createLogger, withTurnAsync } from "../koina/logger.js";
 import type { NousManager } from "../nous/manager.js";
 import type { SessionStore } from "../mneme/store.js";


### PR DESCRIPTION
## Summary
- Migration v12: `session_type` (primary/background/ephemeral), `last_distilled_at`, `computed_context_tokens` columns with backfill
- Auto-classify sessions on creation by key pattern (prosoche→background, spawn/ask/ephemeral→ephemeral)
- Background sessions distill at 50 msgs / 10K tokens with lightweight mode (skip extraction, single-sentence summary)
- Ephemeral sessions hard-deleted after 24h via retention daemon
- New store methods: `updateSessionType`, `updateLastDistilledAt`, `updateComputedContextTokens`, `deleteEphemeralSessions`

## Test plan
- [x] Session classification auto-assigns by key pattern (10 tests)
- [x] Ephemeral deletion cascades to messages/usage/notes (4 tests)
- [x] Lightweight distillation skips extraction and uses router.complete (1 test)
- [ ] CI passes full suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)