### PR TITLE
feat: parallel tools, full narration filter, UI thinking+input

### DIFF
--- a/docs/specs/11_chat-output-quality.md
+++ b/docs/specs/11_chat-output-quality.md
@@ -1,6 +1,6 @@
 # Spec: Chat Output Quality — Signal Over Noise
 
-**Status:** Phase 1-3 done (PR #70). Phase 4 next.
+**Status:** Phase 1-4 done. Phase 5 next.
 **Author:** Syn
 **Date:** 2026-02-20
 
@@ -61,7 +61,7 @@ Not content filtering — reclassification. Information moves to thinking pane, 
 
 During tool-heavy turns (28 tool calls), the user sees a wall of process narration streaming in the text pane. After the turn completes, the thinking pane collapses and only the final clean summary remains — but during the work, the experience is noisy.
 
-### Phase 4: Full-Response Narration Suppression (Runtime)
+### Phase 4: Full-Response Narration Suppression (Runtime) ✅
 
 Extend the `NarrationFilter` to classify narration throughout the entire response, not just at the start.
 
@@ -112,7 +112,7 @@ Status cards, diff views, progress checklists, cost badges. Pattern-match on com
 | **1** ✅ | Prompt — thinking vs chat routing | Small | High |
 | **2** ✅ | Prompt — formatting standards | Small | Medium |
 | **3** ✅ | Runtime narration filter (response start) | Medium | Medium (safety net) |
-| **4** | Runtime narration filter (full response) | Small | High — eliminates mid-response process noise |
+| **4** ✅ | Runtime narration filter (full response) | Small | High — eliminates mid-response process noise |
 | **5** | Rich UI components | Large | High |
 
 ---

--- a/docs/specs/12_session-continuity.md
+++ b/docs/specs/12_session-continuity.md
@@ -1,6 +1,6 @@
 # Spec: Session Continuity — The Never-Ending Conversation
 
-**Status:** Draft
+**Status:** Phase 1-3 done. Phase 4 next.
 **Author:** Syn
 **Date:** 2026-02-20
 
@@ -59,7 +59,7 @@ For the conversation to feel continuous:
 
 ## Design
 
-### Session Classification
+### Session Classification ✅
 
 Introduce a `session_type` field that determines lifecycle behavior:
 
@@ -88,7 +88,7 @@ UPDATE sessions SET session_type = 'background' WHERE session_key LIKE '%prosoch
 UPDATE sessions SET session_type = 'ephemeral' WHERE session_key LIKE 'ask:%' OR session_key LIKE 'spawn:%';
 ```
 
-### Smart Distillation Triggers
+### Smart Distillation Triggers ✅
 
 Replace the single `last_input_tokens >= 140,000` check with a multi-signal trigger:
 
@@ -152,7 +152,7 @@ ALTER TABLE sessions ADD COLUMN message_count INTEGER DEFAULT 0;
 
 Update `message_count` on every message insert (atomic increment). Update `computed_context_tokens` before each turn. Update `last_distilled_at` after each distillation.
 
-### Distillation Pipeline Hardening
+### Distillation Pipeline Hardening ✅
 
 The pipeline itself (Spec 08) is mostly sound. What's broken is reliability:
 
@@ -312,9 +312,9 @@ Cross-agent asks and sub-agent spawns create sessions that are used once and nev
 
 | Phase | What | Effort | Impact |
 |-------|------|--------|--------|
-| **1** | Session classification schema + backfill | Small | Foundation for everything else |
-| **2** | Smart triggers (multi-signal) + context size computation | Medium | Fixes the "never fires" problem |
-| **3** | Distillation receipts + logging | Small | Auditability — know when distillation happens and what it produces |
+| **1** ✅ | Session classification schema + backfill | Small | Foundation for everything else |
+| **2** ✅ | Smart triggers (multi-signal) + context size computation | Medium | Fixes the "never fires" problem |
+| **3** ✅ | Distillation receipts + logging | Small | Auditability — know when distillation happens and what it produces |
 | **4** | Pre-compaction flush hardening | Small | Ensures daily memory files actually get written |
 | **5** | Recency-boosted recall + post-distillation priming | Medium | Bridges the extraction→recall gap |
 | **6** | Primary session enforcement | Medium | One session per agent, all channels route to it |

--- a/docs/specs/15_ui-interaction-quality.md
+++ b/docs/specs/15_ui-interaction-quality.md
@@ -1,6 +1,6 @@
 # Spec: UI Interaction Quality — Thinking Persistence & Tool Detail
 
-**Status:** Draft
+**Status:** Phase 1-3 done. Phase 4 next.
 **Author:** Syn
 **Date:** 2026-02-21
 
@@ -51,7 +51,7 @@ What it doesn't show:
 
 ## Design
 
-### Phase 1: Thinking Panel Persistence
+### Phase 1: Thinking Panel Persistence ✅
 
 **Goal:** Thinking panel stays open across the streaming→completed transition, content preserved seamlessly.
 
@@ -105,7 +105,7 @@ $effect(() => {
 
 **Recommendation:** Option A. It's a 15-line change in `ChatView.svelte` with no store changes. Option B is cleaner architecturally but touches the store contract.
 
-### Phase 2: Thinking Panel Rendering
+### Phase 2: Thinking Panel Rendering ✅
 
 **Goal:** Thinking content renders with Markdown formatting instead of raw `<pre>`.
 
@@ -173,7 +173,7 @@ The `Markdown` component already handles code blocks, lists, headers, emphasis, 
 
 **Fallback:** If the thinking content is genuinely unstructured (no markdown markers), the Markdown component renders it as plain paragraphs — still better than `<pre>` because it wraps properly and respects paragraph breaks.
 
-### Phase 3: Tool Input Display
+### Phase 3: Tool Input Display ✅
 
 **Goal:** Show what each tool was called with, not just what it returned. The input IS the context.
 
@@ -480,9 +480,9 @@ let statusText = $derived.by(() => {
 
 | Phase | What | Effort | Impact |
 |-------|------|--------|--------|
-| **1** | Thinking panel persistence across turn completion | Small | High — eliminates jarring panel close |
-| **2** | Thinking panel Markdown rendering | Small | Medium — makes thinking content actually readable |
-| **3** | Tool input display (event stream → UI) | Medium | High — the single biggest tool panel improvement |
+| **1** ✅ | Thinking panel persistence across turn completion | Small | High — eliminates jarring panel close |
+| **2** ✅ | Thinking panel Markdown rendering | Small | Medium — makes thinking content actually readable |
+| **3** ✅ | Tool input display (event stream → UI) | Medium | High — the single biggest tool panel improvement |
 | **4** | Tool categorization & grouping | Medium | Medium — scales tool-heavy turns |
 | **5** | Tool status line enhancement | Small | Medium — better at-a-glance value |
 

--- a/docs/specs/16_efficiency.md
+++ b/docs/specs/16_efficiency.md
@@ -1,6 +1,6 @@
 # Spec: Efficiency — Parallel Execution & Token Economy
 
-**Status:** Draft
+**Status:** Phase 1 done. Phase 2 next.
 **Author:** Syn
 **Date:** 2026-02-21
 
@@ -65,7 +65,7 @@ Spec 13 (Sub-Agent Workforce) defines delegation to sub-agents. Currently, sub-a
 
 ## Design
 
-### Phase 1: Parallel Tool Execution
+### Phase 1: Parallel Tool Execution ✅
 
 **Goal:** Execute independent tool calls concurrently when the model returns multiple `tool_use` blocks.
 
@@ -341,7 +341,7 @@ When users see that a single `exec` result consumed 2,400 tokens of context, the
 
 | Phase | What | Effort | Impact |
 |-------|------|--------|--------|
-| **1** | Parallel tool execution | Medium | High — 2-5x faster tool-heavy turns |
+| **1** ✅ | Parallel tool execution | Medium | High — 2-5x faster tool-heavy turns |
 | **2a** | Token audit tooling | Small | Foundation — measurement before optimization |
 | **2b** | Bootstrap density audit | Small-Medium | Medium — trim redundant prompt content |
 | **2c** | Tool result truncation | Small | Medium — reduces context bloat over time |

--- a/infrastructure/runtime/src/nous/narration-filter.test.ts
+++ b/infrastructure/runtime/src/nous/narration-filter.test.ts
@@ -19,6 +19,16 @@ describe("isNarration", () => {
     "I want to examine the logs more closely.",
     "I will update the configuration.",
     "Verifying the test results now.",
+    // New Phase 4 patterns
+    "Good call. Let me check the spec.",
+    "Good point, I'll read the config.",
+    "Now I need to verify the output.",
+    "Now I should check the database.",
+    "Let me also check the tests.",
+    "Let me quickly verify the build.",
+    "Time to check the deployment.",
+    "Going to read the error logs.",
+    "About to scan the directory.",
   ];
 
   const negatives = [
@@ -32,6 +42,8 @@ describe("isNarration", () => {
     "I recommend using TypeScript for this project.",
     "Based on my analysis, the root cause is...",
     "",
+    "Good call on both counts.",
+    "Now we have a working solution.",
   ];
 
   for (const s of positives) {
@@ -50,10 +62,7 @@ describe("isNarration", () => {
 describe("NarrationFilter", () => {
   it("suppresses narration at start of response", () => {
     const filter = new NarrationFilter();
-    // Sentence boundary requires trailing whitespace — "Here are the results." stays buffered
     const events = filter.feed("Let me check the logs. Here are the results. ");
-    // First sentence is narration → thinking_delta
-    // Second sentence is not → text_delta (+ rest)
     expect(events).toHaveLength(2);
     expect(events[0]!.type).toBe("thinking_delta");
     expect(events[0]!.text).toContain("Let me check the logs.");
@@ -63,34 +72,42 @@ describe("NarrationFilter", () => {
 
   it("passes through non-narration from the start", () => {
     const filter = new NarrationFilter();
-    const events = filter.feed("The error is in line 42. Let me check the logs.");
-    // First sentence is not narration → text_delta with rest of buffer
-    expect(events).toHaveLength(1);
+    const events = filter.feed("The error is in line 42. Here are the details. ");
+    expect(events).toHaveLength(2);
     expect(events[0]!.type).toBe("text_delta");
     expect(events[0]!.text).toContain("The error is in line 42.");
-    expect(events[0]!.text).toContain("Let me check the logs.");
+    expect(events[1]!.type).toBe("text_delta");
+    expect(events[1]!.text).toContain("Here are the details.");
   });
 
   it("buffers incomplete sentences", () => {
     const filter = new NarrationFilter();
-    // "Let me check" — no sentence boundary yet
     const events1 = filter.feed("Let me check");
     expect(events1).toHaveLength(0);
 
-    // Complete the sentence + start a new one (need trailing space for boundary)
     const events2 = filter.feed(" the logs. Here are the results. ");
     expect(events2).toHaveLength(2);
     expect(events2[0]!.type).toBe("thinking_delta");
     expect(events2[1]!.type).toBe("text_delta");
   });
 
-  it("stops filtering after first non-narration sentence", () => {
+  it("catches narration AFTER non-narration sentences", () => {
     const filter = new NarrationFilter();
-    filter.feed("The answer is 42. ");
-    // Now everything should pass through
-    const events = filter.feed("Let me check more stuff.");
-    expect(events).toHaveLength(1);
+    const events = filter.feed("The answer is 42. Let me check the details. ");
+    expect(events).toHaveLength(2);
     expect(events[0]!.type).toBe("text_delta");
+    expect(events[0]!.text).toContain("The answer is 42.");
+    expect(events[1]!.type).toBe("thinking_delta");
+    expect(events[1]!.text).toContain("Let me check the details.");
+  });
+
+  it("catches narration sandwiched between non-narration", () => {
+    const filter = new NarrationFilter();
+    const events = filter.feed("Good news. Let me check the logs. The fix is simple. ");
+    expect(events).toHaveLength(3);
+    expect(events[0]!.type).toBe("text_delta");
+    expect(events[1]!.type).toBe("thinking_delta");
+    expect(events[2]!.type).toBe("text_delta");
   });
 
   it("handles flush of narration buffer", () => {
@@ -128,21 +145,48 @@ describe("NarrationFilter", () => {
     const filter = new NarrationFilter();
     const allEvents: Array<{ type: string; text: string }> = [];
 
-    // Simulate streaming: "Let me check the logs. The error is clear."
     for (const chunk of ["Let ", "me ch", "eck the lo", "gs. ", "The er", "ror is cl", "ear."]) {
       allEvents.push(...filter.feed(chunk));
     }
     allEvents.push(...filter.flush());
 
-    // Should have narration suppressed, then text passed through
     const thinkingEvents = allEvents.filter((e) => e.type === "thinking_delta");
     const textEvents = allEvents.filter((e) => e.type === "text_delta");
     expect(thinkingEvents.length).toBeGreaterThan(0);
     expect(textEvents.length).toBeGreaterThan(0);
 
-    // Reconstruct: all text should be present
     const allText = allEvents.map((e) => e.text).join("");
     expect(allText).toContain("Let me check the logs.");
     expect(allText).toContain("The error is clear.");
+  });
+
+  it("classifies new Phase 4 patterns mid-response", () => {
+    const filter = new NarrationFilter();
+    const events = filter.feed("Good call. Let me check the spec. Here is what I found. ");
+    expect(events).toHaveLength(3);
+    expect(events[0]!.type).toBe("text_delta");
+    expect(events[1]!.type).toBe("thinking_delta");
+    expect(events[2]!.type).toBe("text_delta");
+  });
+
+  it("handles interleaved narration and substantive content", () => {
+    const filter = new NarrationFilter();
+    const allEvents: Array<{ type: string; text: string }> = [];
+
+    allEvents.push(...filter.feed("The config looks correct. "));
+    allEvents.push(...filter.feed("Let me verify the build. "));
+    allEvents.push(...filter.feed("Build succeeded with no errors. "));
+    allEvents.push(...filter.feed("Now let me check the tests. "));
+    allEvents.push(...filter.feed("All 42 tests pass. "));
+    allEvents.push(...filter.flush());
+
+    const types = allEvents.map((e) => e.type);
+    expect(types).toEqual([
+      "text_delta",      // The config looks correct.
+      "thinking_delta",  // Let me verify the build.
+      "text_delta",      // Build succeeded with no errors.
+      "thinking_delta",  // Now let me check the tests.
+      "text_delta",      // All 42 tests pass.
+    ]);
   });
 });

--- a/infrastructure/runtime/src/nous/pipeline/types.ts
+++ b/infrastructure/runtime/src/nous/pipeline/types.ts
@@ -56,7 +56,7 @@ export type TurnStreamEvent =
   | { type: "turn_start"; sessionId: string; nousId: string; turnId: string }
   | { type: "text_delta"; text: string }
   | { type: "thinking_delta"; text: string }
-  | { type: "tool_start"; toolName: string; toolId: string }
+  | { type: "tool_start"; toolName: string; toolId: string; input?: Record<string, unknown> }
   | { type: "tool_result"; toolName: string; toolId: string; result: string; isError: boolean; durationMs: number }
   | { type: "tool_approval_required"; turnId: string; toolName: string; toolId: string; input: unknown; risk: string; reason: string }
   | { type: "tool_approval_resolved"; toolId: string; decision: string }

--- a/infrastructure/runtime/src/organon/parallel.test.ts
+++ b/infrastructure/runtime/src/organon/parallel.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect } from "vitest";
+import { groupForParallelExecution } from "./parallel.js";
+import type { ToolUseBlock } from "../hermeneus/anthropic.js";
+
+function tool(name: string, input: Record<string, unknown> = {}): ToolUseBlock {
+  return { type: "tool_use", id: `tool-${name}-${Math.random().toString(36).slice(2, 6)}`, name, input };
+}
+
+describe("groupForParallelExecution", () => {
+  it("returns empty array for no tools", () => {
+    expect(groupForParallelExecution([])).toEqual([]);
+  });
+
+  it("returns single batch for one tool", () => {
+    const tools = [tool("read", { path: "/foo" })];
+    const groups = groupForParallelExecution(tools);
+    expect(groups).toHaveLength(1);
+    expect(groups[0]).toHaveLength(1);
+  });
+
+  it("groups all read-only tools into one batch", () => {
+    const tools = [
+      tool("grep", { pattern: "foo", path: "/a" }),
+      tool("read", { path: "/b" }),
+      tool("find", { pattern: "*.ts", path: "/c" }),
+      tool("ls", { path: "/d" }),
+      tool("mem0_search", { query: "test" }),
+    ];
+    const groups = groupForParallelExecution(tools);
+    expect(groups).toHaveLength(1);
+    expect(groups[0]).toHaveLength(5);
+  });
+
+  it("splits at exec (never-parallel) tool", () => {
+    const tools = [
+      tool("grep", { pattern: "foo" }),
+      tool("read", { path: "/a" }),
+      tool("exec", { command: "npm test" }),
+      tool("read", { path: "/b" }),
+      tool("grep", { pattern: "bar" }),
+    ];
+    const groups = groupForParallelExecution(tools);
+    expect(groups).toHaveLength(3);
+    expect(groups[0]).toHaveLength(2); // grep + read
+    expect(groups[1]).toHaveLength(1); // exec alone
+    expect(groups[2]).toHaveLength(2); // read + grep
+  });
+
+  it("splits edits to the same file into separate batches", () => {
+    const tools = [
+      tool("edit", { path: "/foo.ts" }),
+      tool("edit", { path: "/foo.ts" }),
+    ];
+    const groups = groupForParallelExecution(tools);
+    expect(groups).toHaveLength(2);
+    expect(groups[0]).toHaveLength(1);
+    expect(groups[1]).toHaveLength(1);
+  });
+
+  it("keeps edits to different files in same batch", () => {
+    const tools = [
+      tool("edit", { path: "/foo.ts" }),
+      tool("edit", { path: "/bar.ts" }),
+    ];
+    const groups = groupForParallelExecution(tools);
+    expect(groups).toHaveLength(1);
+    expect(groups[0]).toHaveLength(2);
+  });
+
+  it("handles mixed always, conditional, and never tools", () => {
+    const tools = [
+      tool("grep", { pattern: "a" }),
+      tool("grep", { pattern: "b" }),
+      tool("grep", { pattern: "c" }),
+      tool("exec", { command: "build" }),
+      tool("read", { path: "/x" }),
+      tool("edit", { path: "/x" }),
+      tool("message", { to: "user", text: "done" }),
+      tool("read", { path: "/y" }),
+    ];
+    const groups = groupForParallelExecution(tools);
+    expect(groups).toHaveLength(5);
+    expect(groups[0]).toHaveLength(3); // 3x grep
+    expect(groups[1]).toHaveLength(1); // exec (never)
+    expect(groups[2]).toHaveLength(2); // read + edit (no conflict — first touch of /x)
+    expect(groups[3]).toHaveLength(1); // message (never)
+    expect(groups[4]).toHaveLength(1); // read /y
+  });
+
+  it("treats unknown tools as never-parallel", () => {
+    const tools = [
+      tool("read", { path: "/a" }),
+      tool("some_custom_tool", {}),
+      tool("read", { path: "/b" }),
+    ];
+    const groups = groupForParallelExecution(tools);
+    expect(groups).toHaveLength(3);
+    expect(groups[1]).toHaveLength(1);
+    expect(groups[1]![0]!.name).toBe("some_custom_tool");
+  });
+
+  it("handles consecutive never-parallel tools", () => {
+    const tools = [
+      tool("exec", { command: "a" }),
+      tool("exec", { command: "b" }),
+      tool("message", { to: "user" }),
+    ];
+    const groups = groupForParallelExecution(tools);
+    expect(groups).toHaveLength(3);
+    expect(groups[0]).toHaveLength(1);
+    expect(groups[1]).toHaveLength(1);
+    expect(groups[2]).toHaveLength(1);
+  });
+
+  it("handles blackboard conditional on same key", () => {
+    const tools = [
+      tool("blackboard", { action: "write", key: "status" }),
+      tool("blackboard", { action: "write", key: "status" }),
+    ];
+    const groups = groupForParallelExecution(tools);
+    expect(groups).toHaveLength(2);
+  });
+
+  it("handles blackboard conditional on different keys", () => {
+    const tools = [
+      tool("blackboard", { action: "write", key: "status" }),
+      tool("blackboard", { action: "read", key: "other" }),
+    ];
+    const groups = groupForParallelExecution(tools);
+    expect(groups).toHaveLength(1);
+    expect(groups[0]).toHaveLength(2);
+  });
+});

--- a/infrastructure/runtime/src/organon/parallel.ts
+++ b/infrastructure/runtime/src/organon/parallel.ts
@@ -1,0 +1,74 @@
+// Parallel tool execution — batch grouping by safety model
+import type { ToolUseBlock } from "../hermeneus/anthropic.js";
+
+type ToolParallelism = "always" | "never" | "conditional";
+
+const TOOL_PARALLELISM: Record<string, ToolParallelism> = {
+  read: "always",
+  grep: "always",
+  find: "always",
+  ls: "always",
+  mem0_search: "always",
+  web_search: "always",
+  web_fetch: "always",
+  brave_search: "always",
+  note: "always",
+  enable_tool: "always",
+  sessions_send: "always",
+  sessions_ask: "always",
+  sessions_spawn: "always",
+  check_calibration: "always",
+  what_do_i_know: "always",
+  recent_corrections: "always",
+  context_check: "always",
+  status_report: "always",
+  blackboard: "conditional",
+  write: "conditional",
+  edit: "conditional",
+  exec: "never",
+  message: "never",
+  voice_reply: "never",
+};
+
+function extractPath(tool: ToolUseBlock): string | undefined {
+  const input = tool.input as Record<string, unknown>;
+  if (typeof input["path"] === "string") return input["path"];
+  if (typeof input["file"] === "string") return input["file"];
+  if (tool.name === "blackboard" && typeof input["key"] === "string") return input["key"];
+  return undefined;
+}
+
+export function groupForParallelExecution(tools: ToolUseBlock[]): ToolUseBlock[][] {
+  if (tools.length <= 1) return tools.length === 1 ? [tools] : [];
+
+  const groups: ToolUseBlock[][] = [];
+  let batch: ToolUseBlock[] = [];
+  const touchedPaths = new Set<string>();
+
+  for (const tool of tools) {
+    const parallelism = TOOL_PARALLELISM[tool.name] ?? "never";
+
+    if (parallelism === "never") {
+      if (batch.length > 0) groups.push(batch);
+      batch = [];
+      touchedPaths.clear();
+      groups.push([tool]);
+      continue;
+    }
+
+    if (parallelism === "conditional") {
+      const path = extractPath(tool);
+      if (path && touchedPaths.has(path)) {
+        if (batch.length > 0) groups.push(batch);
+        batch = [];
+        touchedPaths.clear();
+      }
+      if (path) touchedPaths.add(path);
+    }
+
+    batch.push(tool);
+  }
+
+  if (batch.length > 0) groups.push(batch);
+  return groups;
+}

--- a/ui/src/components/chat/ChatView.svelte
+++ b/ui/src/components/chat/ChatView.svelte
@@ -303,6 +303,21 @@
     thinkingIsLive = false;
   }
 
+  // Thinking panel persistence — capture thinking content when turn completes
+  let previouslyLive = false;
+  $effect(() => {
+    const isLive = thinkingIsLive && currentAgentId ? getIsStreaming(currentAgentId) : false;
+    if (previouslyLive && !isLive && currentAgentId) {
+      const msgs = getMessages(currentAgentId);
+      const lastMsg = msgs[msgs.length - 1];
+      if (lastMsg?.thinking) {
+        selectedThinking = lastMsg.thinking;
+      }
+      thinkingIsLive = false;
+    }
+    previouslyLive = isLive;
+  });
+
   function handleAbort() {
     const id = getActiveAgentId();
     if (id) abortStream(id);

--- a/ui/src/components/chat/ThinkingPanel.svelte
+++ b/ui/src/components/chat/ThinkingPanel.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import Markdown from "./Markdown.svelte";
+
   let { thinkingText, isStreaming = false, onClose }: {
     thinkingText: string;
     isStreaming?: boolean;
@@ -41,7 +43,9 @@
     onscroll={checkScroll}
   >
     {#if thinkingText}
-      <pre class="thinking-text">{thinkingText}</pre>
+      <div class="thinking-content">
+        <Markdown content={thinkingText} />
+      </div>
     {:else}
       <div class="empty-thinking">No thinking content yet.</div>
     {/if}
@@ -122,14 +126,19 @@
     padding: 12px;
     min-height: 0;
   }
-  .thinking-text {
-    font-family: var(--font-mono);
-    font-size: 12px;
+  .thinking-content {
+    font-size: 13px;
     color: var(--text-secondary);
-    white-space: pre-wrap;
-    word-break: break-word;
-    line-height: 1.6;
-    margin: 0;
+    line-height: 1.5;
+  }
+  .thinking-content :global(.markdown-body) {
+    font-size: 13px;
+  }
+  .thinking-content :global(p) {
+    margin: 0 0 6px;
+  }
+  .thinking-content :global(pre) {
+    font-size: 12px;
   }
   .empty-thinking {
     color: var(--text-muted);

--- a/ui/src/components/chat/ToolStatusLine.svelte
+++ b/ui/src/components/chat/ToolStatusLine.svelte
@@ -36,9 +36,39 @@
     }
   }
 
+  /** Get a short input summary for a running tool */
+  function inputHint(tool: ToolCallState): string {
+    if (!tool.input) return "";
+    const inp = tool.input;
+    switch (tool.name) {
+      case "exec": {
+        const cmd = String(inp.command ?? "");
+        return cmd.length > 40 ? cmd.slice(0, 37) + "..." : cmd;
+      }
+      case "read":
+      case "write":
+      case "edit":
+      case "ls": {
+        const p = String(inp.path ?? inp.file ?? "");
+        const parts = p.split("/");
+        return parts.length > 1 ? parts.slice(-2).join("/") : p;
+      }
+      case "grep":
+        return `/${inp.pattern ?? ""}/`;
+      case "web_search":
+      case "mem0_search":
+        return String(inp.query ?? "").slice(0, 40);
+      default:
+        return "";
+    }
+  }
+
   let statusText = $derived.by(() => {
     if (running.length > 0) {
-      return humanizeTool(running[running.length - 1]!.name);
+      const current = running[running.length - 1]!;
+      const hint = inputHint(current);
+      const label = humanizeTool(current.name);
+      return hint ? `${label}: ${hint}` : label;
     }
     if (errors > 0) {
       return `${total} tool${total === 1 ? '' : 's'} · ${errors} failed`;

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -48,6 +48,7 @@ export interface ToolCallState {
   id: string;
   name: string;
   status: "running" | "complete" | "error";
+  input?: Record<string, unknown>;
   result?: string;
   durationMs?: number;
 }
@@ -56,7 +57,7 @@ export type TurnStreamEvent =
   | { type: "turn_start"; sessionId: string; nousId: string; turnId?: string }
   | { type: "text_delta"; text: string }
   | { type: "thinking_delta"; text: string }
-  | { type: "tool_start"; toolName: string; toolId: string }
+  | { type: "tool_start"; toolName: string; toolId: string; input?: Record<string, unknown> }
   | { type: "tool_result"; toolName: string; toolId: string; result: string; isError: boolean; durationMs: number }
   | { type: "tool_approval_required"; turnId: string; toolName: string; toolId: string; input: unknown; risk: string; reason: string }
   | { type: "tool_approval_resolved"; toolId: string; decision: string }

--- a/ui/src/stores/chat.svelte.ts
+++ b/ui/src/stores/chat.svelte.ts
@@ -164,7 +164,7 @@ export async function sendMessage(
         case "tool_start":
           state.activeToolCalls = [
             ...state.activeToolCalls,
-            { id: event.toolId, name: event.toolName, status: "running" },
+            { id: event.toolId, name: event.toolName, status: "running", input: event.input },
           ];
           break;
 
@@ -300,10 +300,11 @@ function historyToMessages(history: HistoryMessage[]): ChatMessage[] {
             : undefined;
 
           if (toolBlocks.length > 0) {
-            currentToolCalls = toolBlocks.map((b: { id: string; name: string }) => ({
+            currentToolCalls = toolBlocks.map((b: { id: string; name: string; input?: Record<string, unknown> }) => ({
               id: b.id,
               name: b.name,
               status: "complete" as const,
+              input: b.input,
             }));
           }
 


### PR DESCRIPTION
## Summary

- **Spec 11 Phase 4**: NarrationFilter evaluates every sentence regardless of position — narration after substantive text is now caught and reclassified as thinking_delta. Removed early-exit flag, added 4 new regex patterns.
- **Spec 16 Phase 1**: Parallel tool execution — tools grouped into batches by safety model (always/never/conditional). Read-only tools run via `Promise.allSettled`; conditional tools check path conflicts; `exec`/`message` always run alone. Both streaming and buffered paths.
- **Spec 15 Phases 1-3**: Thinking panel persists across turn completion (captures content on live→completed transition). ThinkingPanel renders markdown instead of raw `<pre>`. `tool_start` events now carry input — shown as inline summary in ToolStatusLine/ToolPanel, with full JSON in expanded detail.
- **Spec 12 Phases 1-3**: Already implemented in prior commits (no changes needed).

## Files changed

| Area | Files | Change |
|------|-------|--------|
| Runtime | `organon/parallel.ts` | NEW — safety model + batch grouping |
| Runtime | `organon/parallel.test.ts` | NEW — 11 tests |
| Runtime | `nous/narration-filter.ts` | Remove early exit, add patterns |
| Runtime | `nous/narration-filter.test.ts` | 49 tests (was 37) |
| Runtime | `nous/pipeline/stages/execute.ts` | Batch tool execution loop |
| Runtime | `nous/pipeline/types.ts` | `input?` on tool_start |
| UI | `ChatView.svelte` | Thinking persistence $effect |
| UI | `ThinkingPanel.svelte` | Markdown rendering |
| UI | `ToolPanel.svelte` | Input summary + full JSON |
| UI | `ToolStatusLine.svelte` | Input hint for running tools |
| UI | `types.ts`, `chat.svelte.ts` | input field plumbing |
| Docs | `specs/11,12,15,16` | Status updates |

## Test plan

- [x] 60 targeted tests pass (11 parallel + 49 narration)
- [x] `tsc --noEmit` clean
- [x] `npx tsdown` builds (537KB)
- [x] `npm run build` (UI) clean
- [ ] Manual: send message triggering multiple tools, verify parallel execution in logs
- [ ] Manual: open thinking panel during streaming, verify it persists after turn completes
- [ ] Manual: verify tool input summaries in ToolStatusLine and ToolPanel