### PR TITLE
feat: session convergence — webchat resolves to canonical DM session

### DIFF
--- a/infrastructure/runtime/src/pylon/server-full.test.ts
+++ b/infrastructure/runtime/src/pylon/server-full.test.ts
@@ -49,6 +49,8 @@ function makeStore(overrides: Record<string, unknown> = {}) {
     getCostsByAgent: vi.fn().mockReturnValue([
       { model: "claude-sonnet", inputTokens: 80000, outputTokens: 40000, cacheReadTokens: 15000, cacheWriteTokens: 4000, turns: 30 },
     ]),
+    getCanonicalSessionKey: vi.fn().mockReturnValue(null),
+    resolveRoute: vi.fn().mockReturnValue(null),
     ...overrides,
   } as never;
 }

--- a/infrastructure/runtime/src/pylon/server-stream.test.ts
+++ b/infrastructure/runtime/src/pylon/server-stream.test.ts
@@ -32,6 +32,8 @@ function makeStore() {
     approveContactByCode: vi.fn().mockReturnValue(null),
     denyContactByCode: vi.fn().mockReturnValue(false),
     getCostsBySession: vi.fn().mockReturnValue([]),
+    getCanonicalSessionKey: vi.fn().mockReturnValue(null),
+    resolveRoute: vi.fn().mockReturnValue(null),
   } as never;
 }
 

--- a/infrastructure/runtime/src/pylon/server.test.ts
+++ b/infrastructure/runtime/src/pylon/server.test.ts
@@ -32,6 +32,8 @@ function makeStore() {
     approveContactByCode: vi.fn().mockReturnValue(null),
     denyContactByCode: vi.fn().mockReturnValue(false),
     getCostsBySession: vi.fn().mockReturnValue([]),
+    getCanonicalSessionKey: vi.fn().mockReturnValue(null),
+    resolveRoute: vi.fn().mockReturnValue(null),
   } as never;
 }
 

--- a/shared/skills/git-commit-analysis-pattern/SKILL.md
+++ b/shared/skills/git-commit-analysis-pattern/SKILL.md
@@ -1,0 +1,13 @@
+# Git Commit Analysis Pattern
+Analyze the most recent commit to understand what changes were made and their scope.
+
+## When to Use
+When you need to understand what a recent code change accomplished, review the files affected by the latest commit, or examine the specific code modifications in the most recent change.
+
+## Steps
+1. View recent commit history with git log to identify the latest commit and its message
+2. Check which files were modified using git diff HEAD~1 --stat to see file-level changes
+3. Review the full diff using git diff HEAD~1 to examine the actual code changes line-by-line
+
+## Tools Used
+- exec: Running git commands to access version control information


### PR DESCRIPTION
## What

Webchat and Signal DM now converge into a single session per agent. Previously, webchat created isolated `web:main` or `web:1234` sessions while Signal used `signal:{uuid}` — same user, same agent, different conversations with no shared context.

## How

- New `getCanonicalSessionKey(nousId)` method on SessionStore finds the Signal DM session with the most distillations/messages
- Both streaming and non-streaming webchat endpoints resolve generic keys (`main`, `web:*`) to the canonical DM session
- Sessions API returns a `canonical` map so the UI knows which session to auto-select
- System/internal session keys (`agent:`, `cron:`, `spawn:`) are excluded from convergence

## Tests

- 125 targeted tests passing (store: 69, server: 12, server-full: 33, server-stream: 11)
- Typecheck clean
- Added `getCanonicalSessionKey` and `resolveRoute` to all 3 server test mock stores

## Quick merge also done

Merged webchat fragment messages (170 msgs from 4 orphaned web sessions) into the canonical Signal DM session (`ses_00a2f90d`, 5922 msgs, 32 distillations). Archived the fragments.