### PR TITLE
feat: batch — efficiency, memory intelligence, sub-agent dispatch, UI polish

### DIFF
--- a/infrastructure/runtime/package.json
+++ b/infrastructure/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aletheia",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "license": "AGPL-3.0-only",
   "type": "module",
   "private": true,

--- a/infrastructure/runtime/src/entry.ts
+++ b/infrastructure/runtime/src/entry.ts
@@ -422,6 +422,17 @@ program
     },
   );
 
+// --- Token Audit ---
+
+program
+  .command("audit-tokens [agent-id]")
+  .description("Show per-section bootstrap token breakdown for an agent")
+  .action(async (agentId: string | undefined) => {
+    const { auditTokens } = await import("./nous/audit.js");
+    const id = agentId ?? "main";
+    await auditTokens(id);
+  });
+
 // --- Auth Migration ---
 
 program

--- a/infrastructure/runtime/src/koina/event-bus.ts
+++ b/infrastructure/runtime/src/koina/event-bus.ts
@@ -9,6 +9,7 @@ export type EventName =
   | "tool:called"
   | "tool:failed"
   | "distill:before"
+  | "distill:stage"
   | "distill:after"
   | "session:created"
   | "session:archived"

--- a/infrastructure/runtime/src/nous/audit.ts
+++ b/infrastructure/runtime/src/nous/audit.ts
@@ -1,0 +1,67 @@
+// Bootstrap token audit — measures per-section token usage for a nous
+import { loadConfig, resolveNous, resolveWorkspace } from "../taxis/loader.js";
+import { assembleBootstrap } from "./bootstrap.js";
+import { estimateTokens, estimateToolDefTokens } from "../hermeneus/token-counter.js";
+import { ToolRegistry } from "../organon/registry.js";
+
+export async function auditTokens(agentId: string): Promise<void> {
+  const config = loadConfig();
+  const nous = resolveNous(config, agentId);
+  if (!nous) {
+    console.error(`Agent "${agentId}" not found in config.`);
+    process.exit(1);
+  }
+
+  const workspace = resolveWorkspace(config, nous);
+  const bootstrap = assembleBootstrap(workspace, {
+    maxTokens: config.agents.defaults.bootstrapMaxTokens,
+  });
+
+  const contextWindow = config.agents.defaults.contextTokens ?? 200000;
+  const maxOutput = config.agents.defaults.maxOutputTokens ?? 16384;
+
+  // Build tool defs for token estimation (empty registry — no dispatch context available)
+  const tools = new ToolRegistry();
+  const toolDefs = tools.getDefinitions({});
+  const toolDefTokens = estimateToolDefTokens(toolDefs);
+
+  // Parse bootstrap blocks for per-file breakdown
+  const allBlocks = [...bootstrap.staticBlocks, ...bootstrap.dynamicBlocks];
+  const blockDetails: Array<{ label: string; tokens: number; cache: string }> = [];
+
+  for (const block of allBlocks) {
+    const text = block.text;
+    const tokens = estimateTokens(text);
+    const firstLine = text.split("\n")[0]?.trim() ?? "(empty)";
+    const label = firstLine.startsWith("# ") ? firstLine.slice(2) : firstLine.slice(0, 60);
+    const cache = block.cache_control ? "cached" : "dynamic";
+    blockDetails.push({ label, tokens, cache });
+  }
+
+  const totalBootstrap = bootstrap.totalTokens;
+  const historyBudget = Math.max(0, contextWindow - totalBootstrap - toolDefTokens - maxOutput);
+  const usedPct = ((totalBootstrap + toolDefTokens) / contextWindow * 100).toFixed(1);
+
+  console.log(`\n  Bootstrap Token Audit — ${nous.name} (${agentId})\n`);
+  console.log(`  ${"Section".padEnd(40)} ${"Tokens".padStart(8)}  ${"Cache".padStart(8)}`);
+  console.log(`  ${"─".repeat(40)} ${"─".repeat(8)}  ${"─".repeat(8)}`);
+
+  for (const d of blockDetails) {
+    console.log(`  ${d.label.padEnd(40)} ${String(d.tokens).padStart(8)}  ${d.cache.padStart(8)}`);
+  }
+
+  console.log(`  ${"─".repeat(40)} ${"─".repeat(8)}  ${"─".repeat(8)}`);
+  console.log(`  ${"Bootstrap subtotal".padEnd(40)} ${String(totalBootstrap).padStart(8)}`);
+  console.log(`  ${"Tool definitions (" + toolDefs.length + " tools)".padEnd(40)} ${String(toolDefTokens).padStart(8)}`);
+  console.log(`  ${"Max output".padEnd(40)} ${String(maxOutput).padStart(8)}`);
+  console.log(`  ${"─".repeat(40)} ${"─".repeat(8)}`);
+  console.log(`  ${"Available for history".padEnd(40)} ${String(historyBudget).padStart(8)}`);
+  console.log(`  ${"Context window".padEnd(40)} ${String(contextWindow).padStart(8)}`);
+  console.log(`\n  Overhead: ${usedPct}% of context window used by bootstrap + tools`);
+
+  if (bootstrap.droppedFiles.length > 0) {
+    console.log(`\n  Dropped files (exceeded budget): ${bootstrap.droppedFiles.join(", ")}`);
+  }
+
+  console.log();
+}

--- a/infrastructure/runtime/src/nous/pipeline/stages/truncate.test.ts
+++ b/infrastructure/runtime/src/nous/pipeline/stages/truncate.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { truncateToolResult } from "./truncate.js";
+
+describe("truncateToolResult", () => {
+  it("returns short results unchanged", () => {
+    expect(truncateToolResult("exec", "hello")).toBe("hello");
+  });
+
+  it("truncates exec results at 8K", () => {
+    const long = "x".repeat(20000);
+    const result = truncateToolResult("exec", long);
+    expect(result.length).toBeLessThanOrEqual(8200); // limit + gap notice
+    expect(result).toContain("chars omitted");
+  });
+
+  it("truncates read results at 10K", () => {
+    const long = "x".repeat(20000);
+    const result = truncateToolResult("read", long);
+    expect(result.length).toBeLessThanOrEqual(10200);
+    expect(result).toContain("chars omitted");
+  });
+
+  it("uses default 5K for unknown tools", () => {
+    const long = "x".repeat(10000);
+    const result = truncateToolResult("unknown_tool", long);
+    expect(result.length).toBeLessThanOrEqual(5200);
+    expect(result).toContain("chars omitted");
+  });
+
+  it("preserves head 70% and tail 30%", () => {
+    const input = "HEAD".repeat(2000) + "TAIL".repeat(2000);
+    const result = truncateToolResult("exec", input);
+    expect(result.startsWith("HEAD")).toBe(true);
+    expect(result.endsWith("TAIL")).toBe(true);
+  });
+});

--- a/infrastructure/runtime/src/nous/pipeline/stages/truncate.ts
+++ b/infrastructure/runtime/src/nous/pipeline/stages/truncate.ts
@@ -1,0 +1,23 @@
+// Per-tool-type result truncation for storage — preserves head + tail with gap notice
+const TOOL_RESULT_LIMITS: Record<string, number> = {
+  exec: 8000,
+  read: 10000,
+  grep: 5000,
+  find: 3000,
+  ls: 2000,
+  web_fetch: 8000,
+  web_search: 4000,
+};
+
+const DEFAULT_LIMIT = 5000;
+
+export function truncateToolResult(toolName: string, result: string): string {
+  const limit = TOOL_RESULT_LIMITS[toolName] ?? DEFAULT_LIMIT;
+  if (result.length <= limit) return result;
+
+  const headSize = Math.floor(limit * 0.7);
+  const tailSize = limit - headSize;
+  const omitted = result.length - headSize - tailSize;
+
+  return `${result.slice(0, headSize)}\n\n[... ${omitted} chars omitted ...]\n\n${result.slice(-tailSize)}`;
+}

--- a/infrastructure/runtime/src/nous/pipeline/types.ts
+++ b/infrastructure/runtime/src/nous/pipeline/types.ts
@@ -57,7 +57,7 @@ export type TurnStreamEvent =
   | { type: "text_delta"; text: string }
   | { type: "thinking_delta"; text: string }
   | { type: "tool_start"; toolName: string; toolId: string; input?: Record<string, unknown> }
-  | { type: "tool_result"; toolName: string; toolId: string; result: string; isError: boolean; durationMs: number }
+  | { type: "tool_result"; toolName: string; toolId: string; result: string; isError: boolean; durationMs: number; tokenEstimate?: number }
   | { type: "tool_approval_required"; turnId: string; toolName: string; toolId: string; input: unknown; risk: string; reason: string }
   | { type: "tool_approval_resolved"; toolId: string; decision: string }
   | { type: "turn_complete"; outcome: TurnOutcome }

--- a/infrastructure/runtime/src/nous/recall.ts
+++ b/infrastructure/runtime/src/nous/recall.ts
@@ -36,6 +36,7 @@ export async function recallMemories(
     maxTokens?: number;
     timeoutMs?: number;
     minScore?: number;
+    domains?: string[];
   },
 ): Promise<RecallResult> {
   const limit = opts?.limit ?? 8;
@@ -52,7 +53,7 @@ export async function recallMemories(
 
   try {
     // Primary path: vector-only search (fast, ~200-500ms)
-    hits = await fetchBasicSearch(query, nousId, limit, controller.signal);
+    hits = await fetchBasicSearch(query, nousId, limit, controller.signal, opts?.domains);
 
     // If vector search returned results above threshold, skip graph enrichment.
     // Only fall back to graph-enhanced search if vector search found nothing
@@ -182,6 +183,7 @@ async function fetchBasicSearch(
   nousId: string,
   limit: number,
   signal: AbortSignal,
+  domains?: string[],
 ): Promise<MemoryHit[]> {
   const res = await fetch(`${SIDECAR_URL}/search`, {
     method: "POST",
@@ -191,6 +193,7 @@ async function fetchBasicSearch(
       user_id: USER_ID,
       agent_id: nousId,
       limit,
+      ...(domains && domains.length > 0 ? { domains } : {}),
     }),
     signal,
   });

--- a/infrastructure/runtime/src/pylon/server.ts
+++ b/infrastructure/runtime/src/pylon/server.ts
@@ -365,6 +365,9 @@ export function createGateway(
           ["tool:failed", forward("tool:failed")],
           ["session:created", forward("session:created")],
           ["session:archived", forward("session:archived")],
+          ["distill:before", forward("distill:before")],
+          ["distill:stage", forward("distill:stage")],
+          ["distill:after", forward("distill:after")],
         ];
 
         for (const [event, handler] of handlers) {

--- a/infrastructure/runtime/src/taxis/schema.ts
+++ b/infrastructure/runtime/src/taxis/schema.ts
@@ -100,6 +100,7 @@ const NousDefinition = z.object({
       emoji: z.string().optional(),
     })
     .optional(),
+  domains: z.array(z.string()).optional(),
 }).passthrough();
 
 const AgentDefaults = z.preprocess(

--- a/ui/src/components/chat/ChatView.svelte
+++ b/ui/src/components/chat/ChatView.svelte
@@ -4,6 +4,7 @@
   import ToolPanel from "./ToolPanel.svelte";
   import ThinkingPanel from "./ThinkingPanel.svelte";
   import ToolApproval from "./ToolApproval.svelte";
+  import DistillationProgress from "./DistillationProgress.svelte";
   import ErrorBanner from "../shared/ErrorBanner.svelte";
   import type { ToolCallState } from "../../lib/types";
   import {
@@ -372,6 +373,7 @@
   {#if pendingApproval}
     <ToolApproval approval={pendingApproval} onResolved={handleApprovalResolved} />
   {/if}
+  <DistillationProgress />
   <InputBar
     isStreaming={currentAgentId ? getIsStreaming(currentAgentId) : false}
     onSend={handleSend}

--- a/ui/src/components/chat/DistillationProgress.svelte
+++ b/ui/src/components/chat/DistillationProgress.svelte
@@ -1,0 +1,141 @@
+<script lang="ts">
+  import { onGlobalEvent } from "../../lib/events";
+  import { onMount, onDestroy } from "svelte";
+  import Spinner from "../shared/Spinner.svelte";
+
+  const STAGE_LABELS: Record<string, string> = {
+    sanitize: "Sanitizing messages",
+    extract: "Extracting facts",
+    summarize: "Summarizing context",
+    flush: "Flushing to memory",
+    verify: "Verifying integrity",
+  };
+
+  let active = $state(false);
+  let stage = $state("");
+  let progress = $state(0);
+  let total = $state(6);
+  let nousId = $state("");
+  let cleanup: (() => void) | undefined;
+  let dismissTimer: ReturnType<typeof setTimeout> | undefined;
+
+  onMount(() => {
+    cleanup = onGlobalEvent((event, data) => {
+      const d = data as Record<string, unknown>;
+      if (event === "distill:before") {
+        active = true;
+        stage = "preparing";
+        progress = 0;
+        nousId = (d.nousId as string) ?? "";
+        if (dismissTimer) clearTimeout(dismissTimer);
+      } else if (event === "distill:stage") {
+        active = true;
+        stage = (d.stage as string) ?? "";
+        progress = (d.progress as number) ?? 0;
+        total = (d.total as number) ?? 6;
+      } else if (event === "distill:after") {
+        stage = "complete";
+        progress = total;
+        dismissTimer = setTimeout(() => { active = false; }, 3000);
+      }
+    });
+  });
+
+  onDestroy(() => {
+    cleanup?.();
+    if (dismissTimer) clearTimeout(dismissTimer);
+  });
+
+  let pct = $derived(total > 0 ? Math.round((progress / total) * 100) : 0);
+  let label = $derived(STAGE_LABELS[stage] ?? stage);
+</script>
+
+{#if active}
+  <div class="distill-bar" class:complete={stage === "complete"}>
+    <div class="distill-icon">
+      {#if stage === "complete"}
+        <span class="done-icon">✓</span>
+      {:else}
+        <Spinner size={12} />
+      {/if}
+    </div>
+    <div class="distill-info">
+      <span class="distill-label">
+        {stage === "complete" ? "Context compressed" : label}
+        {#if nousId}
+          <span class="distill-agent">({nousId})</span>
+        {/if}
+      </span>
+      <div class="distill-track">
+        <div class="distill-fill" style="width: {pct}%"></div>
+      </div>
+    </div>
+  </div>
+{/if}
+
+<style>
+  .distill-bar {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 12px;
+    margin: 4px 0;
+    background: rgba(88, 166, 255, 0.06);
+    border: 1px solid rgba(88, 166, 255, 0.2);
+    border-radius: 8px;
+    font-size: 12px;
+    color: var(--text-secondary);
+    animation: fade-in 0.2s ease;
+  }
+  .distill-bar.complete {
+    border-color: rgba(63, 185, 80, 0.3);
+    background: rgba(63, 185, 80, 0.06);
+  }
+  @keyframes fade-in {
+    from { opacity: 0; transform: translateY(-4px); }
+    to { opacity: 1; transform: translateY(0); }
+  }
+  .distill-icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 16px;
+    height: 16px;
+    flex-shrink: 0;
+  }
+  .done-icon {
+    color: var(--green);
+    font-size: 12px;
+    font-weight: 700;
+  }
+  .distill-info {
+    flex: 1;
+    min-width: 0;
+  }
+  .distill-label {
+    display: block;
+    margin-bottom: 3px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  .distill-agent {
+    color: var(--text-muted);
+    font-size: 10px;
+  }
+  .distill-track {
+    height: 3px;
+    background: var(--surface);
+    border-radius: 2px;
+    overflow: hidden;
+  }
+  .distill-fill {
+    height: 100%;
+    background: var(--accent);
+    border-radius: 2px;
+    transition: width 0.4s ease;
+  }
+  .distill-bar.complete .distill-fill {
+    background: var(--green);
+  }
+</style>

--- a/ui/src/components/chat/ToolPanel.svelte
+++ b/ui/src/components/chat/ToolPanel.svelte
@@ -42,6 +42,37 @@
     tools.reduce((sum, t) => sum + (t.durationMs ?? 0), 0)
   );
 
+  const TOOL_CATEGORIES: Record<string, { icon: string; label: string }> = {
+    read: { icon: "\u{1F4C1}", label: "fs" },
+    write: { icon: "\u{1F4C1}", label: "fs" },
+    edit: { icon: "\u{1F4C1}", label: "fs" },
+    ls: { icon: "\u{1F4C1}", label: "fs" },
+    find: { icon: "\u{1F50D}", label: "search" },
+    grep: { icon: "\u{1F50D}", label: "search" },
+    web_search: { icon: "\u{1F50D}", label: "search" },
+    mem0_search: { icon: "\u{1F50D}", label: "search" },
+    exec: { icon: "\u26A1", label: "exec" },
+    sessions_send: { icon: "\u{1F4AC}", label: "comms" },
+    sessions_ask: { icon: "\u{1F4AC}", label: "comms" },
+    sessions_spawn: { icon: "\u{1F4AC}", label: "comms" },
+    message: { icon: "\u{1F4AC}", label: "comms" },
+    blackboard: { icon: "\u{1F9E0}", label: "system" },
+    note: { icon: "\u{1F9E0}", label: "system" },
+    enable_tool: { icon: "\u{1F9E0}", label: "system" },
+    web_fetch: { icon: "\u{1F310}", label: "web" },
+  };
+
+  let categoryStats = $derived.by(() => {
+    const counts = new Map<string, { icon: string; count: number }>();
+    for (const t of tools) {
+      const entry = TOOL_CATEGORIES[t.name] ?? { icon: "\u2699", label: "other" };
+      const existing = counts.get(entry.label);
+      if (existing) existing.count++;
+      else counts.set(entry.label, { icon: entry.icon, count: 1 });
+    }
+    return [...counts.values()];
+  });
+
   /** Humanize a tool name */
   function humanize(name: string): string {
     switch (name) {
@@ -209,6 +240,13 @@
       <button class="toggle-btn" onclick={expandAll} title="Expand all">⊞</button>
       <button class="toggle-btn" onclick={collapseAll} title="Collapse all">⊟</button>
     </div>
+    {#if categoryStats.length > 1}
+      <div class="header-categories">
+        {#each categoryStats as cat}
+          <span class="cat-badge">{cat.icon}{cat.count}</span>
+        {/each}
+      </div>
+    {/if}
   </div>
   <div class="panel-body">
     {#each tools as tool, i (tool.id)}
@@ -237,6 +275,9 @@
           </span>
           {#if tool.durationMs != null}
             <span class="tool-time">{formatDuration(tool.durationMs)}</span>
+          {/if}
+          {#if tool.tokenEstimate}
+            <span class="tool-tokens">~{tool.tokenEstimate > 999 ? `${(tool.tokenEstimate / 1000).toFixed(1)}k` : tool.tokenEstimate} tok</span>
           {/if}
           <span class="tool-chevron">{expandedIds.has(tool.id) ? "−" : "+"}</span>
         </button>
@@ -325,6 +366,17 @@
   .stat.running { color: var(--accent); }
   .stat.time { color: var(--text-muted); font-family: var(--font-mono); }
   .stat-spacer { flex: 1; }
+  .header-categories {
+    display: flex;
+    gap: 6px;
+    padding: 4px 0 0;
+    flex-wrap: wrap;
+  }
+  .cat-badge {
+    font-size: 11px;
+    color: var(--text-muted);
+    letter-spacing: -0.5px;
+  }
   .toggle-btn {
     background: transparent;
     border: none;
@@ -429,6 +481,13 @@
     font-size: 10px;
     font-family: var(--font-mono);
     flex-shrink: 0;
+  }
+  .tool-tokens {
+    color: var(--text-muted);
+    font-size: 9px;
+    font-family: var(--font-mono);
+    flex-shrink: 0;
+    opacity: 0.7;
   }
   .tool-chevron {
     color: var(--text-muted);

--- a/ui/src/components/chat/ToolStatusLine.svelte
+++ b/ui/src/components/chat/ToolStatusLine.svelte
@@ -7,10 +7,47 @@
     onclick?: () => void;
   } = $props();
 
+  const TOOL_CATEGORIES: Record<string, { icon: string; label: string }> = {
+    read: { icon: "\u{1F4C1}", label: "fs" },
+    write: { icon: "\u{1F4C1}", label: "fs" },
+    edit: { icon: "\u{1F4C1}", label: "fs" },
+    ls: { icon: "\u{1F4C1}", label: "fs" },
+    find: { icon: "\u{1F50D}", label: "search" },
+    grep: { icon: "\u{1F50D}", label: "search" },
+    web_search: { icon: "\u{1F50D}", label: "search" },
+    mem0_search: { icon: "\u{1F50D}", label: "search" },
+    exec: { icon: "\u26A1", label: "exec" },
+    sessions_send: { icon: "\u{1F4AC}", label: "comms" },
+    sessions_ask: { icon: "\u{1F4AC}", label: "comms" },
+    sessions_spawn: { icon: "\u{1F4AC}", label: "comms" },
+    message: { icon: "\u{1F4AC}", label: "comms" },
+    blackboard: { icon: "\u{1F9E0}", label: "system" },
+    note: { icon: "\u{1F9E0}", label: "system" },
+    enable_tool: { icon: "\u{1F9E0}", label: "system" },
+    web_fetch: { icon: "\u{1F310}", label: "web" },
+  };
+
+  function getCategory(name: string): string {
+    return TOOL_CATEGORIES[name]?.label ?? "other";
+  }
+
   let running = $derived(tools.filter(t => t.status === "running"));
   let completed = $derived(tools.filter(t => t.status !== "running").length);
   let errors = $derived(tools.filter(t => t.status === "error").length);
   let total = $derived(tools.length);
+
+  let categoryBreakdown = $derived.by(() => {
+    if (running.length > 0 || total < 2) return "";
+    const counts = new Map<string, { icon: string; count: number }>();
+    for (const t of tools) {
+      const cat = getCategory(t.name);
+      const entry = TOOL_CATEGORIES[t.name] ?? { icon: "\u2699", label: "other" };
+      const existing = counts.get(cat);
+      if (existing) existing.count++;
+      else counts.set(cat, { icon: entry.icon, count: 1 });
+    }
+    return [...counts.values()].map(c => `${c.icon}${c.count}`).join(" ");
+  });
 
   /** Humanize a tool name into a readable activity label */
   function humanizeTool(name: string): string {
@@ -72,6 +109,9 @@
     }
     if (errors > 0) {
       return `${total} tool${total === 1 ? '' : 's'} · ${errors} failed`;
+    }
+    if (categoryBreakdown) {
+      return categoryBreakdown;
     }
     return `${total} tool${total === 1 ? '' : 's'} completed`;
   });

--- a/ui/src/components/layout/Layout.svelte
+++ b/ui/src/components/layout/Layout.svelte
@@ -22,6 +22,7 @@
 
   let authState = $state<AuthState>("loading");
   let tokenValue = $state("");
+  let hasToken = $state(!!getToken());
 
   // Determine auth mode on mount
   (async () => {

--- a/ui/src/lib/auth.ts
+++ b/ui/src/lib/auth.ts
@@ -4,7 +4,7 @@ let refreshTimer: ReturnType<typeof setTimeout> | null = null;
 let onAuthFailure: (() => void) | null = null;
 
 export interface AuthMode {
-  mode: "token" | "session";
+  mode: "none" | "token" | "session";
   sessionAuth: boolean;
 }
 

--- a/ui/src/lib/events.ts
+++ b/ui/src/lib/events.ts
@@ -61,6 +61,7 @@ function connect() {
   const eventTypes = [
     "turn:before", "turn:after", "turn:text_delta", "turn:tool_start", "turn:tool_result",
     "tool:called", "tool:failed", "session:created", "session:archived",
+    "distill:before", "distill:stage", "distill:after",
   ];
   for (const type of eventTypes) {
     source.addEventListener(type, (e) => {

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -51,6 +51,7 @@ export interface ToolCallState {
   input?: Record<string, unknown>;
   result?: string;
   durationMs?: number;
+  tokenEstimate?: number;
 }
 
 export type TurnStreamEvent =
@@ -58,7 +59,7 @@ export type TurnStreamEvent =
   | { type: "text_delta"; text: string }
   | { type: "thinking_delta"; text: string }
   | { type: "tool_start"; toolName: string; toolId: string; input?: Record<string, unknown> }
-  | { type: "tool_result"; toolName: string; toolId: string; result: string; isError: boolean; durationMs: number }
+  | { type: "tool_result"; toolName: string; toolId: string; result: string; isError: boolean; durationMs: number; tokenEstimate?: number }
   | { type: "tool_approval_required"; turnId: string; toolName: string; toolId: string; input: unknown; risk: string; reason: string }
   | { type: "tool_approval_resolved"; toolId: string; decision: string }
   | { type: "turn_complete"; outcome: TurnOutcome }

--- a/ui/src/stores/chat.svelte.ts
+++ b/ui/src/stores/chat.svelte.ts
@@ -181,6 +181,7 @@ export async function sendMessage(
                   status: event.isError ? "error" as const : "complete" as const,
                   result: event.result,
                   durationMs: event.durationMs,
+                  tokenEstimate: event.tokenEstimate,
                 }
               : tc,
           );


### PR DESCRIPTION
## Summary

- **Parallel sub-agent dispatch**: `tasks[]` array in sessions_spawn, up to 3 concurrent via Promise.allSettled
- **Domain-scoped memory**: `domains` field on NousConfig, filters recall to agent-relevant memories
- **Memory confidence scoring**: Neo4j access/decay data weights search results (boost accessed, penalize decayed)
- **Recency-boosted recall**: Memories <24h get up to +0.15 score boost with linear decay
- **Cost visibility**: Token usage summary injected every 8th turn (cache rate, last turn stats)
- **Dynamic thinking budget**: Scales 2K–16K based on message complexity + tool count
- **Tool result truncation**: Per-tool-type limits at storage time (head 70% + tail 30%)
- **Bootstrap token audit**: `aletheia audit-tokens [agent-id]` CLI command
- **Distillation progress**: `distill:stage` events at 6 pipeline steps, forwarded via SSE
- **Tool categorization UI**: Category badges in ToolPanel header + ToolStatusLine breakdown
- **Per-tool token estimates**: Displayed in ToolPanel per tool call
- **DistillationProgress component**: Live progress bar during context compression
- **Layout.svelte auth fix**: Added "none" auth mode, declared missing hasToken variable

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx tsdown` — runtime builds (337KB)
- [x] `npm run build` (UI) — builds successfully
- [x] `svelte-check` — 1 pre-existing error (missing @types/three)
- [x] Truncation tests pass (5/5)
- [ ] Deploy to server and smoke test

🤖 Generated with [Claude Code](https://claude.com/claude-code)