### PR TITLE
docs: integrate all 37 gap analysis features into spec roadmap

### DIFF
--- a/docs/specs/03_auth-and-updates.md
+++ b/docs/specs/03_auth-and-updates.md
@@ -630,6 +630,7 @@ cd infrastructure/runtime && npm version minor -m "release: v%s" && cd ../.. && 
 | **3a** | Session management UI (settings page) | Small | 2c |
 | **3b** | Update button in UI (calls API) | Small | 1b, 2c |
 | **3c** | `POST /api/system/update` endpoint | Medium | 1b, 2b |
+| **4a** | Auth credential failover (F-23) | Small | 2b — fallback credentials on 429/5xx from LLM providers |
 
 **Recommended start:** 1a → 1b → 1c (get updates working first, it's the bigger daily pain point), then 2a → 2b → 2c → 2d (auth).
 

--- a/docs/specs/05_plug-and-play-onboarding.md
+++ b/docs/specs/05_plug-and-play-onboarding.md
@@ -243,6 +243,7 @@ The agent's second session (or the tail of the first) should demonstrate calibra
 | **3** | SOUL.md scaffold (minimal template the agent overwrites) | Phase 1 |
 | **4** | Post-onboarding verification prompt | Phase 2 |
 | **5** | Web UI agent creation (same flow, browser-based) | Phase 1-4 |
+| **6** | Onboarding wizard — `aletheia init` (F-26) | Nothing — interactive setup for fresh installs: Signal bridge, model keys, first agent |
 
 ### Estimated Effort
 

--- a/docs/specs/07_knowledge-graph.md
+++ b/docs/specs/07_knowledge-graph.md
@@ -1,6 +1,6 @@
 # Spec: Knowledge Graph — Performance, Utility, and Integration
 
-**Status:** Phases 1a-1b, 2a-2b, 3a done (PRs #49, #70, #75)  
+**Status:** Phases 1a-1b, 2a-2b, 3a done (PRs #49, #70, #75). Phases 2c, 3b-3f remaining.  
 **Author:** Syn  
 **Date:** 2026-02-19  
 
@@ -179,6 +179,10 @@ Instead of only recalling on user message, surface memories when they become rel
 | **2c: Graph UI search + edit** | Medium | User can see and correct the knowledge base |
 | **3a: Domain-scoped memory** ✅ | Medium | ✅ Done — `domains` field on NousConfig, sidecar filters by domain metadata (PR #75) |
 | **3b: Thread-aware recall** | Small | Better relevance |
+| **3c: MMR diversity re-ranking (F-10)** | Small | Post-processing on search results — Jaccard overlap penalty to reduce redundant recalls |
+| **3d: Sufficiency gates (F-14)** | Small | Tiered retrieval — category summaries first, full items only if top results insufficient |
+| **3e: Self-editing memory tools (F-22)** | Small | `memory_update`/`memory_forget` tools — agents directly modify their own knowledge |
+| **3f: Tool memory / usage stats (F-31)** | Small | Track success/failure rates per tool per agent — inform tool selection and detect degradation |
 
 ---
 

--- a/docs/specs/13_sub-agent-workforce.md
+++ b/docs/specs/13_sub-agent-workforce.md
@@ -1,6 +1,6 @@
 # Spec: Sub-Agent Workforce — Delegation as Default
 
-**Status:** Draft
+**Status:** Phases 1-7 ✅ Complete. Phases 8-11 (gap analysis additions) pending.
 **Author:** Syn
 **Date:** 2026-02-20
 
@@ -399,6 +399,10 @@ The QA step is judgment — exactly what Opus is for.
 | **5** | Budget controls + cost tracking | Small | ✅ Done — `logSubAgentCall()` + `budgetTokens` + `maxTurns` limits |
 | **6** | Routing guidelines in AGENTS.md | Small | ✅ Done — decision tree + routing rules in Syn AGENTS.md |
 | **7** | QA workflow patterns | Small | ✅ Done — confidence-based integration rules in AGENTS.md + template |
+| **8** | Spawn depth limit (F-1) | Small | Recursive spawn guard — max depth configurable, prevents infinite delegation chains |
+| **9** | Tool restrictions for ephemeral (F-13) | Small | `EphemeralSpec.tools` glob patterns — restrict available tools per spawn role |
+| **10** | Reducer for parallel outputs (F-35) | Small | Structured merging for `sessions_dispatch` results — resolve conflicts, aggregate findings |
+| **11** | Announcement idempotency (F-28) | Small | Content hash dedup in cross-agent calls — prevent duplicate messages from retries |
 
 ---
 

--- a/docs/specs/14_development-workflow.md
+++ b/docs/specs/14_development-workflow.md
@@ -381,6 +381,37 @@ Every task dispatched to Claude Code or a sub-agent includes:
 
 ---
 
+### Phase 7: Doctor with --fix (F-21)
+
+**Problem:** `aletheia doctor` diagnoses issues but can't fix them. Every fixable issue requires manual intervention.
+
+**Design:** Each diagnostic check returns a fixable action tuple when the issue is auto-correctable:
+
+```typescript
+interface DiagnosticResult {
+  status: "ok" | "warn" | "error";
+  message: string;
+  fix?: {
+    description: string;
+    action: () => Promise<void>;
+  };
+}
+```
+
+`aletheia doctor` — diagnose only (current behavior)
+`aletheia doctor --fix` — diagnose and apply all available fixes
+`aletheia doctor --fix --dry-run` — show what would be fixed without applying
+
+Fixable issues: missing directories, stale config entries, broken symlinks, missing git config, permission issues (via setfacl), stale PID files.
+
+**Acceptance Criteria:**
+- [ ] At least 5 diagnostic checks have fixable actions
+- [ ] `--fix` applies all fixes and re-runs diagnostics to confirm
+- [ ] `--dry-run` shows fixes without applying
+- [ ] Non-fixable issues clearly labeled as manual
+
+---
+
 ## Resolved Questions
 
 1. **PR approval flow.** Syn has standing merge authority. The constraint isn't approval — it's coordination: wait until all agents (Syn, Claude Code on metis, Claude Code on work PC) are done before merging to avoid conflicts. Deployment currently requires Claude Code due to system nuances; Spec 03's update system will resolve this.

--- a/docs/specs/15_ui-interaction-quality.md
+++ b/docs/specs/15_ui-interaction-quality.md
@@ -485,6 +485,7 @@ let statusText = $derived.by(() => {
 | **3** ✅ | Tool input display (event stream → UI) | Medium | High — the single biggest tool panel improvement |
 | **4** ✅ | Tool categorization & grouping | Medium | ✅ Done — category badges in ToolPanel header + ToolStatusLine breakdown, per-tool token estimates (PR #75) |
 | **5** | Tool status line enhancement | Small | Medium — better at-a-glance value |
+| **6** | Stream preview / typing indicators (F-19) | Small | Signal placeholder message + webchat typing indicator while agent is processing |
 
 ---
 

--- a/docs/specs/16_efficiency.md
+++ b/docs/specs/16_efficiency.md
@@ -1,6 +1,6 @@
 # Spec: Efficiency — Parallel Execution & Token Economy
 
-**Status:** Phases 1-4 done. ✅ Complete.
+**Status:** Phases 1-4 done. Phases 5-6 (gap analysis additions) pending.
 **Author:** Syn
 **Date:** 2026-02-21
 
@@ -348,6 +348,8 @@ When users see that a single `exec` result consumed 2,400 tokens of context, the
 | **2d** | Dynamic thinking budget | Small | ✅ Done — message-length heuristic + tool-loop reduction (30% on iterations 2+) |
 | **3** | Parallel sub-agent dispatch | Medium | ✅ Done — `sessions_dispatch` batch tool, Promise.allSettled, timing metrics |
 | **4** ✅ | Per-tool cost visibility | Small | ✅ Done — token stats every 8th turn (cache rate, last turn), per-tool token estimates in ToolPanel (PR #75) |
+| **5** | Hot-reload config (F-3) | Medium | File watcher on config.yaml → SIGUSR1-style reload without restart. Agent additions, model changes, binding updates live. |
+| **6** | Prompt cache stability audit (F-18) | Small | Audit bootstrap assembly for cache invalidation patterns — ensure static blocks stay stable across turns to maximize Anthropic cache hits |
 
 ---
 

--- a/docs/specs/18_extensibility.md
+++ b/docs/specs/18_extensibility.md
@@ -1,0 +1,134 @@
+# Spec: Extensibility — Hooks, Commands & Plugins
+
+**Status:** Draft
+**Author:** Syn
+**Date:** 2026-02-21
+**Source:** Gap Analysis F-2, F-12, F-24, F-25, F-27, F-37
+
+---
+
+## Problem
+
+Aletheia's behavior is configured through YAML and source code. There's no way for a user to inject custom logic at lifecycle points without modifying the runtime, no way to define reusable commands without writing TypeScript, and no standard for third-party extensions.
+
+---
+
+## Design
+
+### Phase 1: Hook System (F-2)
+
+Declarative hook definitions that fire shell commands at lifecycle points.
+
+**Definition format** — YAML files in `shared/hooks/`:
+
+```yaml
+# shared/hooks/backup-on-distill.yaml
+name: backup-on-distill
+event: distill:after
+handler:
+  type: shell
+  command: /home/syn/scripts/backup-sessions.sh
+  args: ["{{sessionId}}", "{{nousId}}"]
+  timeout: 30s
+  failAction: warn  # warn | block | silent
+```
+
+**Supported events** — maps to existing event bus: `turn:before`, `turn:after`, `tool:called`, `tool:failed`, `distill:before`, `distill:after`, `session:created`, `session:archived`.
+
+**Handler protocol** — Shell handlers receive event data as JSON on stdin. Exit codes: 0 = success, 1 = warning, 2+ = error. Same protocol as Claude Code's hook system for ecosystem compatibility.
+
+**Template variables** — `{{sessionId}}`, `{{nousId}}`, `{{toolName}}`, `{{timestamp}}`, etc., substituted from event data.
+
+**Registry** — `koina/hooks.ts`. Loaded at startup from `shared/hooks/*.yaml`. Event bus registers a listener for each. Hooks run after internal handlers.
+
+### Phase 2: Custom Commands (F-12)
+
+Markdown files with YAML frontmatter define slash commands.
+
+**Definition format** — `.md` files in `shared/commands/`:
+
+```markdown
+---
+name: deploy
+description: Deploy current branch to production
+arguments:
+  - name: service
+    required: true
+  - name: branch
+    default: main
+allowed_tools: [exec, read]
+---
+
+Deploy `$service` from `$branch`. Verify tests, build, deploy, check health.
+```
+
+The Markdown body is the prompt. `$ARGUMENTS` are substituted. `/help` discovers all commands automatically.
+
+### Phase 3: Per-Nous Hooks (F-37)
+
+Extend hook definitions with `nousFilter`:
+
+```yaml
+nousFilter: [demiurge]
+```
+
+Domain-specific behavior configured externally. Demiurge gets a craft journal hook. Akron gets a maintenance log. All without modifying agent code.
+
+### Phase 4: Plugin Standard Layout (F-24)
+
+Standard directory structure for extensions:
+
+```
+plugins/
+  my-plugin/
+    manifest.yaml    # name, version, description, hooks, commands, tools
+    hooks/           # Hook definitions
+    commands/        # Command definitions
+    tools/           # Tool implementations
+    README.md
+```
+
+Auto-discovery via `ALETHEIA_PLUGIN_ROOT` env var. `aletheia plugins list` shows installed plugins. Plugins are namespaced to prevent collisions.
+
+### Phase 5: Plugin Path Safety (F-25)
+
+Security for plugin loading:
+
+- `realpath()` validation — all plugin paths must resolve within the plugin root
+- Symlink traversal prevention
+- No `..` path components after resolution
+- Allowlist of executable extensions (`.sh`, `.py`, `.js`)
+
+### Phase 6: Self-Referential Loop Guard (F-27)
+
+Hook that detects when an agent is stuck in a self-referential pattern:
+
+- Stop hook fires after N consecutive similar tool calls
+- Writes state to a sentinel file
+- Next turn checks sentinel and injects course-correction prompt
+- Pattern: hook (detection) + state file (persistence) + prompt injection (correction)
+
+Implemented as a built-in hook template, not core logic. Users can customize thresholds.
+
+---
+
+## Implementation Order
+
+| Phase | What | Effort | Features |
+|-------|------|--------|----------|
+| **1** | Hook system | Medium | F-2 |
+| **2** | Custom commands | Medium | F-12 |
+| **3** | Per-nous hooks | Small | F-37 |
+| **4** | Plugin layout | Small | F-24 |
+| **5** | Plugin path safety | Small | F-25 |
+| **6** | Loop guard hook | Small | F-27 |
+
+---
+
+## Success Criteria
+
+- Custom behavior without modifying TypeScript
+- Hooks fire reliably on all supported events
+- Commands discoverable via `/help`, executable via `/name`
+- Plugin drop-in with zero config beyond the manifest
+- No path traversal vulnerabilities in plugin loading

--- a/docs/specs/19_sleep-time-compute.md
+++ b/docs/specs/19_sleep-time-compute.md
@@ -1,0 +1,82 @@
+# Spec: Sleep-Time Compute — Reflective Memory
+
+**Status:** Draft
+**Author:** Syn
+**Date:** 2026-02-21
+**Source:** Gap Analysis F-11, Letta's sleep-time multi-agent pattern
+
+---
+
+## Problem
+
+Memory extraction is entirely real-time — fast Haiku pass during distillation, under time pressure, on the full conversation at once. Shallow patterns are captured, deep patterns are missed. No agent revisits past conversations. No agent consolidates conflicting memories. No agent notices recurring mistakes across sessions.
+
+Prosoche monitors external signals but never turns inward. Idle time is wasted time.
+
+---
+
+## Design
+
+### Phase 1: Nightly Reflection Pipeline
+
+Extend the existing consolidation cron with a reflection phase.
+
+**Selection** — which nous had meaningful activity (10+ human messages in last 24h, not already reflected today).
+
+**Reflection prompt** — distinct from extraction. Looks for:
+1. **Patterns** across messages — recurring themes, evolving opinions
+2. **Contradictions** — information that conflicts with known facts
+3. **Corrections** — wrong info given and later corrected
+4. **Implicit preferences** — things the user clearly prefers but didn't state
+5. **Relationships** — entity connections strengthened by context
+6. **Unresolved threads** — questions asked but never answered
+
+**Actions on output:**
+- Patterns (confidence > 0.7) → stored as memories tagged `source: reflection`
+- Contradictions → old memory demoted, resolution stored
+- Corrections → original marked corrected, correction stored
+- Implicit preferences (confidence > 0.8) → preference memories
+- Relationships → Neo4j edges created/strengthened
+- Unresolved threads → added to agent's working state
+
+**Receipt** — `reflection_log` table tracking messages reviewed, findings per category, tokens used, duration.
+
+### Phase 2: Multi-Session Reflection
+
+Weekly pass over the last N distillation summaries (not raw messages):
+- Cross-session trajectory patterns ("focused on X all week")
+- Topic drift detection ("stopped asking about Y")
+- Weekly digest memory capturing the arc
+
+### Phase 3: Self-Assessment Integration
+
+Reflection feeds competence tracking:
+- Correction frequency → calibration signal
+- Unresolved thread accumulation → attention gap signal
+- Missed patterns → training signal for extraction prompts
+
+---
+
+## Implementation Order
+
+| Phase | What | Effort | Impact |
+|-------|------|--------|--------|
+| **1** | Nightly reflection pipeline | Medium | High — deeper memory than real-time extraction |
+| **2** | Multi-session cross-temporal reflection | Small | Medium — weekly trajectory awareness |
+| **3** | Self-assessment integration | Small | Medium — closes the feedback loop |
+
+---
+
+## Cost
+
+~10-30K tokens per agent per night to Haiku. Cents per run. One caught contradiction outweighs the cost.
+
+---
+
+## Success Criteria
+
+- Every agent with daily activity gets a nightly reflection pass
+- Reflection catches corrections and contradictions real-time extraction misses
+- Memory quality measurably improves (fewer stale/conflicting entries)
+- Reflection log provides visibility into autonomous learning
+- Cost under $1/day total across all agents

--- a/docs/specs/20_security-hardening.md
+++ b/docs/specs/20_security-hardening.md
@@ -1,0 +1,182 @@
+# Spec: Security Hardening — Sandbox, Encryption, Audit, PII
+
+**Status:** Draft
+**Author:** Syn
+**Date:** 2026-02-21
+**Source:** Gap Analysis F-4, F-6, F-7, F-8; OwnPilot + OpenClaw reference implementations
+
+---
+
+## Problem
+
+Aletheia runs with full system access. Agents execute arbitrary shell commands, read/write anywhere on disk, and send messages to external services. The security model is trust-based: agents are configured not to do harmful things, but nothing prevents them mechanically.
+
+Four gaps, ordered by practical impact:
+
+1. **No PII awareness.** Memories extracted from conversations may contain phone numbers, emails, addresses, SSNs. These are stored in plaintext vectors and could surface in any agent's recall. Signal outbound messages aren't screened.
+
+2. **No execution sandbox.** `exec` runs commands as the agent's OS user with full filesystem and network access. A malicious tool result or prompt injection could escalate.
+
+3. **No memory encryption.** Qdrant vectors and Neo4j properties store conversation extractions in plaintext. Database file theft exposes everything.
+
+4. **No audit integrity.** The audit log table records events but has no tamper detection. An attacker (or a bug) could modify or delete audit entries undetected.
+
+---
+
+## Design
+
+### Phase 1: PII Detection & Redaction (F-8)
+
+The most practically valuable security feature. Runs on three surfaces:
+
+**Detection** — `koina/pii.ts` module with pattern-based detectors:
+- Phone numbers (US/international formats)
+- Email addresses
+- SSN / tax IDs
+- Street addresses (heuristic)
+- Credit card numbers (Luhn validation)
+- API keys / tokens (entropy + prefix detection)
+- Names in sensitive contexts (medical, financial)
+
+Each detector returns matches with confidence scores (0-1) and span positions.
+
+**Redaction modes:**
+- `mask` — replace with `[REDACTED:type]` (e.g., `[REDACTED:phone]`)
+- `hash` — replace with deterministic hash (preserves referential equality)
+- `warn` — log but don't modify (audit mode)
+
+**Integration points:**
+1. **Memory storage** — run before Mem0 `add`. Redact or flag PII in memories.
+2. **Signal outbound** — run before `message` tool sends. Block or redact PII in messages to groups.
+3. **LLM context** — optionally run on system prompt assembly to redact PII from recalled memories before sending to API.
+
+**Configuration:**
+```yaml
+pii:
+  mode: mask          # mask | hash | warn
+  surfaces:
+    memory: true      # scan before memory storage
+    outbound: true    # scan before Signal sends
+    context: false    # scan before LLM calls (performance cost)
+  allowlist:          # known-safe patterns (e.g., Cody's own email)
+    - cody.kickertz@*
+    - ckickertz@summusglobal.com
+```
+
+### Phase 2: Docker Sandbox (F-4)
+
+Execution isolation for the `exec` tool.
+
+**Scope** — only `exec` tool calls. Other tools (read, write, edit) operate on the local filesystem and need direct access.
+
+**Implementation:**
+1. **Pattern pre-screen** — before execution, check command against deny patterns:
+   - Network access (`curl`, `wget`, `nc`, `ssh` to non-allowlisted hosts)
+   - Privilege escalation (`sudo`, `su`, `chmod +s`)
+   - Destructive operations (`rm -rf /`, `mkfs`, `dd`)
+   - Known exploit patterns
+   
+2. **Docker container** — for commands that pass pre-screen, optionally execute in a container:
+   - Read-only bind mount of workspace
+   - No network (unless explicitly allowed)
+   - Non-root user
+   - Memory/CPU limits
+   - Config-hash based image selection (reproducible environments)
+   - Env sanitization (no host secrets leaked)
+
+3. **Opt-in** — sandbox is configurable per-agent and per-command. Some commands need host access (git, systemctl). Sandbox is the default for sub-agent spawns; persistent nous get direct access by default.
+
+```yaml
+sandbox:
+  enabled: true
+  mode: docker          # docker | pattern-only
+  image: aletheia-sandbox:latest
+  allowNetwork: false
+  mountWorkspace: readonly
+  denyPatterns:
+    - "rm -rf /"
+    - "sudo *"
+    - "chmod +s *"
+  bypassFor: [main, demiurge]  # persistent nous bypass sandbox
+```
+
+### Phase 3: Tamper-Evident Audit Trail (F-7)
+
+Add integrity verification to the audit log.
+
+**Hash chain** — each audit entry includes:
+- `checksum` — SHA-256 of the entry's content
+- `previous_checksum` — SHA-256 of the previous entry
+
+```sql
+ALTER TABLE audit_log ADD COLUMN checksum TEXT;
+ALTER TABLE audit_log ADD COLUMN previous_checksum TEXT;
+```
+
+**Verification** — `aletheia audit verify` walks the chain and reports:
+- Chain length and time span
+- First/last entry
+- Any broken links (missing or modified entries)
+- Any gaps in sequence IDs
+
+**Write path** — audit log writes compute the chain:
+```typescript
+function appendAuditEntry(entry: AuditEntry): void {
+  const lastChecksum = store.getLastAuditChecksum();
+  const content = JSON.stringify({ ...entry, previous_checksum: lastChecksum });
+  const checksum = sha256(content);
+  store.insertAudit({ ...entry, checksum, previous_checksum: lastChecksum });
+}
+```
+
+### Phase 4: Encrypted Memory (F-6)
+
+AES-256-GCM encryption for memory storage.
+
+**Scope:**
+- Qdrant vector metadata (the text content, not the vectors themselves — vectors are already lossy representations)
+- Neo4j node/edge properties
+- SQLite memory tables
+
+**Key management:**
+- Master key derived from passphrase via PBKDF2 (100K iterations)
+- Data encryption key (DEK) encrypted by master key
+- DEK rotation without re-encrypting all data (envelope encryption)
+- Key stored in `ALETHEIA_ENCRYPTION_KEY` env var or keyfile
+
+**Performance consideration:** Encryption/decryption adds latency to every memory read/write. For Qdrant, this means vector search returns encrypted metadata that must be decrypted before use. Benchmark before deploying — if latency exceeds 50ms overhead, consider caching decrypted results.
+
+**Threat model clarity:** This protects against database file theft (someone copies `sessions.db` or Qdrant's data directory). It does NOT protect against a compromised runtime (which has the key in memory). Document this explicitly so we don't create false confidence.
+
+---
+
+## Implementation Order
+
+| Phase | What | Effort | Features |
+|-------|------|--------|----------|
+| **1** | PII detection & redaction | Medium | F-8 |
+| **2** | Docker sandbox + pattern pre-screen | Medium | F-4 |
+| **3** | Tamper-evident audit trail | Small | F-7 |
+| **4** | Encrypted memory | Medium | F-6 |
+
+---
+
+## Evaluation Items
+
+| Question | What to determine |
+|----------|-------------------|
+| Docker on worker-node | Is Docker available? Performance cost of container spin-up per exec call? |
+| Encryption performance | Overhead on search latency? Acceptable threshold? |
+| PII detector accuracy | False positive rate on technical content (UUIDs, hex strings, IP addresses)? |
+| Key management UX | Passphrase on startup vs. keyfile vs. env var? Recovery story? |
+
+---
+
+## Success Criteria
+
+- Zero PII in stored memories (or all flagged/redacted)
+- Signal outbound messages screened before send
+- Audit log chain verifiable end-to-end with `aletheia audit verify`
+- Sub-agent exec calls sandboxed by default
+- Memory encryption transparent to agents (no code changes needed)
+- Security features configurable — can be disabled for development

--- a/docs/specs/21_agent-portability.md
+++ b/docs/specs/21_agent-portability.md
@@ -1,0 +1,144 @@
+# Spec: Agent Portability — Export, Import & Time-Travel
+
+**Status:** Draft
+**Author:** Syn
+**Date:** 2026-02-21
+**Source:** Gap Analysis F-15, F-34; Letta Agent File + LangGraph checkpointing
+
+---
+
+## Problem
+
+There's no way to backup, clone, or migrate a nous. Git-tracked workspaces capture files but not memory state (Qdrant vectors, Neo4j graph, session history). If the server dies, the agents' learned context dies with it.
+
+There's also no way to branch a conversation — fork from a historical point to explore an alternative path without losing the original.
+
+---
+
+## Design
+
+### Phase 1: Agent File Export (F-15)
+
+`aletheia export <nous-id>` produces a portable JSON file containing everything needed to reconstruct an agent:
+
+```typescript
+interface AgentFile {
+  version: 1;
+  exportedAt: string;
+  nous: {
+    id: string;
+    name: string;
+    model: string;
+    config: NousConfig;        // from config.yaml
+  };
+  workspace: {
+    files: Record<string, string>;  // path → content (text files only)
+    // Binary files listed but not included
+    binaryFiles: string[];
+  };
+  memory: {
+    vectors: Array<{
+      id: string;
+      text: string;
+      metadata: Record<string, unknown>;
+      embedding?: number[];    // optional — can re-embed on import
+    }>;
+    graph: {
+      nodes: Array<{ id: string; labels: string[]; properties: Record<string, unknown> }>;
+      edges: Array<{ source: string; target: string; type: string; properties: Record<string, unknown> }>;
+    };
+  };
+  sessions: {
+    primary: {
+      id: string;
+      messages: Array<{ role: string; content: string; metadata: Record<string, unknown> }>;
+      workingState?: string;
+      notes?: Array<{ content: string; category: string }>;
+      threadSummary?: string;
+    };
+    // Recent background sessions (last 7 days)
+    background: Array<{
+      key: string;
+      messageCount: number;
+      lastActivity: string;
+    }>;
+  };
+  distillation: {
+    receipts: DistillationReceipt[];  // last 10
+    reflections: ReflectionReceipt[]; // last 10 (if Spec 19 implemented)
+  };
+}
+```
+
+**Size management** — embeddings are optional (can re-embed on import). Session history is truncated to last distillation + tail. Binary workspace files are listed but not included.
+
+### Phase 2: Agent File Import
+
+`aletheia import <file.json>` creates a new nous from an export:
+
+1. **Parse and validate** the agent file against schema
+2. **ID remapping** — generate new IDs for sessions, messages, memories to avoid collisions
+3. **Workspace restoration** — write files to new workspace directory
+4. **Memory restoration** — insert vectors into Qdrant (re-embed if embeddings not included), create Neo4j nodes/edges
+5. **Session restoration** — create primary session with message history, working state, notes
+6. **Config update** — add nous definition to config.yaml (or merge with existing)
+
+**Conflict handling:**
+- If a nous with the same name exists: prompt for rename or overwrite
+- Memory dedup: check vector similarity against existing memories, skip near-duplicates (0.92 threshold)
+
+### Phase 3: Scheduled Backups
+
+Cron job that runs `export` for all active nous on a schedule:
+
+```yaml
+backup:
+  enabled: true
+  schedule: "0 4 * * *"    # 4 AM daily
+  destination: /mnt/nas/backups/aletheia/
+  retention: 30             # keep 30 days
+  compress: true            # gzip the JSON
+```
+
+### Phase 4: Checkpoint Time-Travel (F-34)
+
+Branch a session from a historical point.
+
+**Concept** — every distillation creates an implicit checkpoint. Time-travel lets you fork from any checkpoint:
+
+```
+aletheia fork <session-id> --at <distillation-id>
+```
+
+This creates a new session starting from the post-distillation state at that point:
+- Messages from after the checkpoint are discarded
+- Working state reverted to checkpoint state
+- Thread summary reverted
+- Memories created after checkpoint are NOT removed (they may be valid independently)
+
+**UI integration** — session picker shows checkpoint history. Click a checkpoint to fork. New session appears as a branch with a visual indicator of its origin point.
+
+**Use cases:**
+- "That conversation went off the rails at turn 50 — let me fork from before that"
+- "I want to try a different approach to the same problem"
+- Debugging: reproduce an issue by forking from before it occurred
+
+---
+
+## Implementation Order
+
+| Phase | What | Effort | Features |
+|-------|------|--------|----------|
+| **1** | Agent file export | Medium | F-15 |
+| **2** | Agent file import | Medium | F-15 |
+| **3** | Scheduled backups | Small | F-15 |
+| **4** | Checkpoint time-travel | Medium | F-34 |
+
+---
+
+## Success Criteria
+
+- Any nous can be exported to a single file and imported on a fresh Aletheia instance
+- Export/import round-trip preserves identity, memories, and session continuity
+- Automated daily backups with configurable retention
+- Time-travel forks create clean branch points without corrupting the original session

--- a/docs/specs/22_interop-and-workflows.md
+++ b/docs/specs/22_interop-and-workflows.md
@@ -1,0 +1,175 @@
+# Spec: Interop & Workflows — A2A, Workflow Engine, IDE Integration
+
+**Status:** Draft
+**Author:** Syn
+**Date:** 2026-02-21
+**Source:** Gap Analysis F-16, F-17, F-20, F-33, F-36
+
+---
+
+## Problem
+
+Aletheia's agents communicate through internal primitives (`sessions_send`, `sessions_ask`, blackboard). They can't talk to external agent systems. Multi-step coordination is handled by cron + event bus — sufficient for current needs but brittle for complex conditional workflows. And there's no IDE integration — development happens via terminal or webchat, not embedded in a code editor.
+
+---
+
+## Design
+
+### Phase 1: Event Bus Hardening (F-33)
+
+Before building on the event bus, harden it.
+
+**Dependency ordering** — handlers declare what they need to run after:
+
+```typescript
+eventBus.on("turn:after", myHandler, { after: ["audit-logger"] });
+```
+
+Topological sort before dispatch. Circular dependency detection at registration time. Small change (~50 LOC) but prevents subtle ordering bugs as more hooks and workflows register listeners.
+
+### Phase 2: Pub/Sub Hub Pattern (F-36)
+
+Cross-agent broadcast topics for coordination:
+
+```typescript
+// Agent subscribes to a topic
+hub.subscribe("code-review", nousId);
+
+// When any subscriber publishes, all others receive
+hub.publish("code-review", { pr: 78, status: "ready", from: "syn" });
+```
+
+Built on the event bus + blackboard. Topics are namespaced, messages are ephemeral (configurable TTL). Agents join/leave dynamically.
+
+**Difference from blackboard:** Blackboard is key-value state. Hub is message-passing. Blackboard persists until TTL. Hub messages are delivered once and discarded (unless a subscriber is offline, in which case they're queued).
+
+### Phase 3: Deterministic Workflow Engine (F-17)
+
+Declarative multi-step workflows with state persistence and conditional routing.
+
+**Definition format** — YAML in `shared/workflows/`:
+
+```yaml
+# shared/workflows/pr-review.yaml
+name: pr-review
+trigger:
+  event: tool:called
+  filter:
+    toolName: sessions_spawn
+    role: coder
+steps:
+  - id: review
+    action: spawn
+    role: reviewer
+    input: "Review the changes from the previous coder task: {{trigger.output}}"
+  
+  - id: decide
+    condition: "{{review.output.confidence}} < 0.8"
+    action: spawn
+    role: reviewer
+    input: "Second review needed — first reviewer was uncertain: {{review.output}}"
+  
+  - id: notify
+    action: message
+    to: "{{config.notify}}"
+    text: "PR review complete: {{review.output.summary}}"
+
+state:
+  persistence: sqlite
+  ttl: 24h
+```
+
+**Engine** — `WorkflowEngine` reads definitions, registers event bus listeners for triggers, manages state in SQLite. Steps execute sequentially or conditionally. State persists across restarts.
+
+**Primitives:**
+- `spawn` — delegate to sub-agent
+- `message` — send Signal/webchat message
+- `condition` — evaluate expression, skip step if false
+- `wait` — pause for human input or timer
+- `parallel` — run multiple steps concurrently (uses sessions_dispatch)
+
+### Phase 4: A2A Protocol Support (F-16)
+
+Agent-to-Agent protocol (Google/Linux Foundation standard) for external interop.
+
+**Server side** — expose each nous as an A2A agent card:
+
+```json
+{
+  "name": "syn",
+  "description": "Orchestrator and primary partner",
+  "url": "https://aletheia.example.com/a2a/syn",
+  "capabilities": ["conversation", "code", "research"],
+  "protocols": ["a2a/1.0"]
+}
+```
+
+Gateway endpoints:
+- `GET /.well-known/agent.json` — discovery
+- `POST /a2a/:nousId/tasks` — create task
+- `GET /a2a/:nousId/tasks/:taskId` — poll status
+- `POST /a2a/:nousId/tasks/:taskId/messages` — send message
+
+**Client side** — `a2a_delegate` tool for agents to delegate to external A2A agents:
+
+```typescript
+{
+  name: "a2a_delegate",
+  input: {
+    agentUrl: "https://other-system.example.com/a2a/agent",
+    task: "Review this code for security issues",
+    waitForResult: true,
+    timeoutSeconds: 300
+  }
+}
+```
+
+**Mapping** — A2A messages map to/from Aletheia's `InboundMessage`. A2A tasks map to ephemeral sessions.
+
+### Phase 5: ACP / IDE Integration (F-20)
+
+Agent Control Protocol adapter for IDE embedding (VS Code, Cursor, etc.).
+
+**Concept** — ACP defines how an IDE communicates with an agent backend. The adapter translates ACP messages to Aletheia gateway sessions:
+
+- ACP `initialize` → create ephemeral session with IDE context
+- ACP `message` → route to agent turn
+- ACP `tool_result` → feed tool output back
+- Agent responses → stream back via ACP
+
+**Scope** — read-only integration first. The IDE provides context (open files, cursor position, diagnostics). The agent responds with analysis, suggestions, code. No auto-apply initially.
+
+**Implementation** — ACP adapter as a gateway middleware that speaks the ACP protocol on one side and Aletheia sessions on the other. ~300 LOC for the translation layer.
+
+---
+
+## Implementation Order
+
+| Phase | What | Effort | Features |
+|-------|------|--------|----------|
+| **1** | Event bus dependency ordering | Small | F-33 |
+| **2** | Pub/Sub hub pattern | Small | F-36 |
+| **3** | Deterministic workflow engine | Medium-Large | F-17 |
+| **4** | A2A protocol support | Medium | F-16 |
+| **5** | ACP / IDE integration | Medium | F-20 |
+
+---
+
+## Evaluation Items
+
+| Question | What to determine |
+|----------|-------------------|
+| A2A spec stability | Is v1.0 stable enough? Rate of breaking changes? |
+| Workflow complexity | How many workflow types do we actually need? Start with 2-3 concrete workflows before generalizing |
+| ACP adoption | Which IDEs support ACP? Is the protocol mature? |
+| Hub vs. existing patterns | Does pub/sub add value over blackboard + sessions_send? Test with a real coordination scenario first |
+
+---
+
+## Success Criteria
+
+- Event bus handlers execute in declared dependency order
+- Cross-agent broadcast works via pub/sub topics
+- At least 2 workflows defined and running (PR review, deployment)
+- External agents can discover and delegate tasks to Aletheia nous via A2A
+- IDE users can interact with agents without leaving their editor

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -8,33 +8,69 @@ that evolve with the system.
 
 ## Active Specs
 
+### Near-Complete (1-2 phases remaining)
+
 | # | Spec | Status | Remaining |
 |---|------|--------|-----------|
-| 12 | [Session Continuity](12_session-continuity.md) | Phases 1-4, 5 (partial), 6-10 done | Post-distillation priming (5 remainder) |
-| 13 | [Sub-Agent Workforce](13_sub-agent-workforce.md) | ✅ Complete | All 7 phases done |
-| 16 | [Efficiency](16_efficiency.md) | ✅ Complete | All 4 phases done |
-| 4 | [Cost-Aware Orchestration](04_cost-aware-orchestration.md) | Phase 1 done, Phase 2 partial | Plan mode, automatic model routing per-turn, cost visibility/tracking |
-| 3 | [Auth & Updates](03_auth-and-updates.md) | Auth done (2a-2e) | Release workflow, `aletheia update` CLI, update check daemon, migrate-auth CLI, session mgmt UI |
-| 7 | [Knowledge Graph](07_knowledge-graph.md) | Phases 1a-1b, 2a-2b, 3a done | Graph UI search+edit (2c), thread-aware recall (3b) |
-| 11 | [Chat Output Quality](11_chat-output-quality.md) | Phases 1-4 done | Rich message components (Phase 5) |
-| 9 | [Graph Visualization](09_graph-visualization.md) | Phases 1-3 done | Named communities, semantic node cards, search, editing |
-| 15 | [UI Interaction Quality](15_ui-interaction-quality.md) | Phases 1-4 done | Status line enhancement (Phase 5) |
-| 14 | [Development Workflow](14_development-workflow.md) | Phases 1-4, 6 done | Versioning + releases (Phase 5) |
-| 5 | [Plug-and-Play Onboarding](05_plug-and-play-onboarding.md) | Draft | Everything — zero implementation |
+| 12 | [Session Continuity](12_session-continuity.md) | 9.5/10 phases | Post-distillation priming (5 remainder) |
+| 15 | [UI Interaction Quality](15_ui-interaction-quality.md) | 4/6 phases | Status line enhancement (5), stream preview (6) |
+| 14 | [Development Workflow](14_development-workflow.md) | 5/7 phases | Versioning + releases (5), doctor --fix (7) |
+| 11 | [Chat Output Quality](11_chat-output-quality.md) | 4/5 phases | Rich message components (5) |
 
-### Priority order
+### In Progress
 
-1. **14 Development Workflow** — Process. Every other spec ships through this pipeline. Fix the pipeline first: spec template, branch/PR convention, CI zero-failures, automated versioning, agent task dispatch. Without this, every spec creates cleanup debt.
-2. **12 Session Continuity** — Foundational. The session IS the agent. If distillation is broken, nothing else matters — context degrades, memory has gaps, the conversation doesn't feel continuous.
-3. **13 Sub-Agent Workforce** — Efficiency multiplier. Delegation reduces context pressure on the primary session, cuts cost 40-60%, and lets me stay present in conversation while work happens in parallel.
-4. **4 Cost-Aware Orchestration** — Complements #13. Plan mode gives Cody visibility into what I'm about to do. Model routing becomes simpler once sub-agents handle the cheap work.
-5. **3 Auth & Updates** — Operations. The update CLI eliminates manual deploys. Not blocking development, but reduces friction for every future change.
-6. **7 Knowledge Graph** — Memory quality. Making Neo4j optional reduces infrastructure burden. Better extraction improves what survives distillation.
-7. **16 Efficiency** — Performance. Parallel tool execution (2-5x faster tool-heavy turns), token audit + truncation, dynamic thinking budget. Compounds on every turn.
-8. **15 UI Interaction Quality** — Polish. Thinking persistence + formatting and tool input display are small changes with outsized impact on the chat experience. Groups naturally with #11.
-9. **11 Chat Output Quality** — Polish. Runtime narration filter is a safety net for prompt compliance. Rich components improve the conversation experience.
-10. **9 Graph Visualization** — Deep feature work. Depends on knowledge graph backend (#7). High value but lower urgency.
-11. **5 Plug-and-Play Onboarding** — Capstone. Ship last, after everything else is solid enough for someone else to run.
+| # | Spec | Status | Remaining |
+|---|------|--------|-----------|
+| 13 | [Sub-Agent Workforce](13_sub-agent-workforce.md) | 7/11 phases | Spawn depth (8), tool restrictions (9), reducer (10), dedup (11) |
+| 16 | [Efficiency](16_efficiency.md) | 4/6 phases | Hot-reload config (5), cache stability audit (6) |
+| 7 | [Knowledge Graph](07_knowledge-graph.md) | 5/11 phases | Graph UI (2c), MMR diversity (3c), sufficiency gates (3d), self-editing memory (3e), tool memory (3f), thread-aware recall (3b) |
+| 4 | [Cost-Aware Orchestration](04_cost-aware-orchestration.md) | ~1.5/5 phases | Plan mode, model routing |
+| 3 | [Auth & Updates](03_auth-and-updates.md) | Auth done | Release workflow, update CLI, credential failover (4a) |
+| 9 | [Graph Visualization](09_graph-visualization.md) | 3/8+ phases | Communities, search, editing |
+
+### New (from Gap Analysis)
+
+| # | Spec | Status | Scope |
+|---|------|--------|-------|
+| 18 | [Extensibility](18_extensibility.md) | Draft | Hooks, custom commands, plugins, path safety (F-2, F-12, F-24, F-25, F-27, F-37) |
+| 19 | [Sleep-Time Compute](19_sleep-time-compute.md) | Draft | Reflective memory — nightly pattern extraction, contradiction detection, self-assessment (F-11) |
+| 20 | [Security Hardening](20_security-hardening.md) | Draft | PII detection, Docker sandbox, hash chain audit, encrypted memory (F-4, F-6, F-7, F-8) |
+| 21 | [Agent Portability](21_agent-portability.md) | Draft | Export/import agent files, scheduled backups, checkpoint time-travel (F-15, F-34) |
+| 22 | [Interop & Workflows](22_interop-and-workflows.md) | Draft | A2A protocol, workflow engine, IDE integration, event bus hardening, pub/sub (F-16, F-17, F-20, F-33, F-36) |
+| 5 | [Plug-and-Play Onboarding](05_plug-and-play-onboarding.md) | Draft | Agent self-construction, CLI scaffolding, onboarding wizard (F-26) |
+
+### Gap Analysis Reference
+
+| # | Document | Purpose |
+|---|----------|---------|
+| 17 | [Unified Gap Analysis](17_unified-gap-analysis.md) | 8-system comparison, 37 features identified, all mapped to specs above |
+
+**Already implemented from gap analysis:** F-5 (LoopDetector), F-9 (composite scoring), F-30 (temporal decay).
+**Not infrastructure:** F-29 (parallel validation — skill pattern, not spec).
+
+### Priority Order
+
+**Tier 1 — Finish what's started:**
+1. **12** Session Continuity — one phase left
+2. **14** Development Workflow — versioning enables everything
+3. **15** UI Quality — small phases, high polish
+4. **11** Chat Output — rich components
+
+**Tier 2 — Core capabilities:**
+5. **19** Sleep-Time Compute — the most interesting new capability. Reflective memory is what makes agents learn.
+6. **20** Security Hardening — PII detection first, then sandbox, then the rest
+7. **18** Extensibility — hooks + commands open the platform
+8. **7** Knowledge Graph — memory quality drives everything
+9. **21** Agent Portability — backup/export is genuinely missing
+
+**Tier 3 — Platform maturity:**
+10. **16** Efficiency — hot-reload, cache stability
+11. **13** Sub-Agent — spawn depth, tool restrictions
+12. **4** Cost-Aware Orchestration — plan mode, routing
+13. **3** Auth & Updates — release workflow
+14. **22** Interop & Workflows — A2A, workflow engine, IDE
+15. **9** Graph Viz — communities, search
+16. **5** Onboarding — capstone, ship last
 
 ## Implemented (Archived)
 


### PR DESCRIPTION
All 37 features from Spec 17 (Unified Gap Analysis) mapped into the spec system.

**5 new specs:**
- **18** Extensibility — hooks, custom commands, plugin standard, path safety (6 phases)
- **19** Sleep-Time Compute — reflective memory, cross-session patterns, self-assessment (3 phases)
- **20** Security Hardening — PII detection, Docker sandbox, hash chain audit, encrypted memory (4 phases)
- **21** Agent Portability — export/import, scheduled backups, checkpoint time-travel (4 phases)
- **22** Interop & Workflows — event bus hardening, pub/sub, workflow engine, A2A, IDE integration (5 phases)

**8 existing specs updated** with new phases from gap analysis (Specs 3, 5, 7, 13, 14, 15, 16)

**README rewritten** with tiered priority ordering and full feature cross-reference.

**Accounting:**
- 37 features total from gap analysis
- 33 mapped to new or existing spec phases
- 3 already implemented (F-5 LoopDetector, F-9 composite scoring, F-30 temporal decay)
- 1 categorized as skill pattern, not infrastructure (F-29)