### PR TITLE
fix: memory sidecar env var race + set slicing crash

### DIFF
--- a/infrastructure/memory/sidecar/aletheia_memory/routes.py
+++ b/infrastructure/memory/sidecar/aletheia_memory/routes.py
@@ -592,7 +592,7 @@ async def graph_enhanced_search(req: GraphEnhancedSearchRequest, request: Reques
     # Step 3: If graph found neighbors, do a supplementary vector search with expanded terms
     graph_results: list[dict[str, Any]] = []
     if graph_neighbors:
-        expanded_query = req.query + " " + " ".join(set(graph_neighbors)[:5])
+        expanded_query = req.query + " " + " ".join(list(set(graph_neighbors))[:5])
         try:
             raw2 = await asyncio.to_thread(mem.search, expanded_query, **kwargs)
             graph_results = raw2.get("results", raw2) if isinstance(raw2, dict) else raw2

--- a/infrastructure/runtime/src/nous/recall.ts
+++ b/infrastructure/runtime/src/nous/recall.ts
@@ -4,8 +4,9 @@ import { estimateTokens } from "../hermeneus/token-counter.js";
 
 const log = createLogger("recall");
 
-const SIDECAR_URL = process.env["ALETHEIA_MEMORY_URL"] ?? "http://127.0.0.1:8230";
-const USER_ID = process.env["ALETHEIA_MEMORY_USER"] ?? "default";
+// Lazy reads — env vars may be set by taxis config after module import
+const getSidecarUrl = () => process.env["ALETHEIA_MEMORY_URL"] ?? "http://127.0.0.1:8230";
+const getUserId = () => process.env["ALETHEIA_MEMORY_USER"] ?? "default";
 
 export interface RecallResult {
   block: { type: "text"; text: string } | null;
@@ -160,12 +161,12 @@ async function fetchGraphEnhanced(
   limit: number,
   signal: AbortSignal,
 ): Promise<MemoryHit[]> {
-  const res = await fetch(`${SIDECAR_URL}/graph_enhanced_search`, {
+  const res = await fetch(`${getSidecarUrl()}/graph_enhanced_search`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({
       query,
-      user_id: USER_ID,
+      user_id: getUserId(),
       agent_id: nousId,
       limit,
       graph_weight: 0.3,
@@ -185,12 +186,12 @@ async function fetchBasicSearch(
   signal: AbortSignal,
   domains?: string[],
 ): Promise<MemoryHit[]> {
-  const res = await fetch(`${SIDECAR_URL}/search`, {
+  const res = await fetch(`${getSidecarUrl()}/search`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({
       query,
-      user_id: USER_ID,
+      user_id: getUserId(),
       agent_id: nousId,
       limit,
       ...(domains && domains.length > 0 ? { domains } : {}),

--- a/infrastructure/runtime/src/organon/built-in/fact-retract.ts
+++ b/infrastructure/runtime/src/organon/built-in/fact-retract.ts
@@ -3,8 +3,9 @@ import { createLogger } from "../../koina/logger.js";
 import type { ToolContext, ToolHandler } from "../registry.js";
 
 const log = createLogger("organon.fact-retract");
-const SIDECAR_URL = process.env["ALETHEIA_MEMORY_URL"] ?? "http://127.0.0.1:8230";
-const USER_ID = process.env["ALETHEIA_MEMORY_USER"] ?? "default";
+// Lazy reads — env vars may be set by taxis config after module import
+const getSidecarUrl = () => process.env["ALETHEIA_MEMORY_URL"] ?? "http://127.0.0.1:8230";
+const getUserId = () => process.env["ALETHEIA_MEMORY_USER"] ?? "default";
 
 export const factRetractTool: ToolHandler = {
   definition: {
@@ -58,12 +59,12 @@ export const factRetractTool: ToolHandler = {
     log.info(`Retraction requested by ${context.nousId}: "${query}" (reason: ${reason}, dry_run: ${dryRun})`);
 
     try {
-      const res = await fetch(`${SIDECAR_URL}/retract`, {
+      const res = await fetch(`${getSidecarUrl()}/retract`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           query,
-          user_id: USER_ID,
+          user_id: getUserId(),
           cascade,
           dry_run: dryRun,
           reason: `[${context.nousId}] ${reason}`,

--- a/infrastructure/runtime/src/organon/built-in/mem0-search.ts
+++ b/infrastructure/runtime/src/organon/built-in/mem0-search.ts
@@ -4,8 +4,9 @@ import { createLogger } from "../../koina/logger.js";
 
 const log = createLogger("tool:mem0-search");
 
-const SIDECAR_URL = process.env["ALETHEIA_MEMORY_URL"] ?? "http://127.0.0.1:8230";
-const USER_ID = process.env["ALETHEIA_MEMORY_USER"] ?? "default";
+// Lazy reads — env vars may be set by taxis config after module import
+const getSidecarUrl = () => process.env["ALETHEIA_MEMORY_URL"] ?? "http://127.0.0.1:8230";
+const getUserId = () => process.env["ALETHEIA_MEMORY_USER"] ?? "default";
 
 export const mem0SearchTool: ToolHandler = {
   definition: {
@@ -62,12 +63,12 @@ export const mem0SearchTool: ToolHandler = {
 
       // Tier 1: Enhanced search with query rewriting + alias resolution
       try {
-        const enhancedRes = await fetch(`${SIDECAR_URL}/search_enhanced`, {
+        const enhancedRes = await fetch(`${getSidecarUrl()}/search_enhanced`, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
             query,
-            user_id: USER_ID,
+            user_id: getUserId(),
             agent_id: context.nousId,
             limit: limit * 2,
             rewrite: true,
@@ -84,12 +85,12 @@ export const mem0SearchTool: ToolHandler = {
       // Tier 2: Graph-enhanced search (vector + graph neighbor expansion)
       if (results.length === 0) {
         try {
-          const graphRes = await fetch(`${SIDECAR_URL}/graph_enhanced_search`, {
+          const graphRes = await fetch(`${getSidecarUrl()}/graph_enhanced_search`, {
             method: "POST",
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify({
               query,
-              user_id: USER_ID,
+              user_id: getUserId(),
               agent_id: context.nousId,
               limit: limit * 2,
               graph_weight: 0.3,
@@ -110,19 +111,19 @@ export const mem0SearchTool: ToolHandler = {
         const searchBody = (agentId?: string) =>
           JSON.stringify({
             query,
-            user_id: USER_ID,
+            user_id: getUserId(),
             ...(agentId ? { agent_id: agentId } : {}),
             limit,
           });
         try {
           const [aRes, gRes] = await Promise.all([
-            fetch(`${SIDECAR_URL}/search`, {
+            fetch(`${getSidecarUrl()}/search`, {
               method: "POST",
               headers: { "Content-Type": "application/json" },
               body: searchBody(context.nousId),
               signal: controller.signal,
             }),
-            fetch(`${SIDECAR_URL}/search`, {
+            fetch(`${getSidecarUrl()}/search`, {
               method: "POST",
               headers: { "Content-Type": "application/json" },
               body: searchBody(),


### PR DESCRIPTION
Fixes #81

## Bug 1 (High): env var race in memory tool consumers

`ALETHEIA_MEMORY_USER` and `ALETHEIA_MEMORY_URL` were captured in module-level `const` declarations evaluated at import time — **before** the taxis config system sets them from `aletheia.json`. Result: `user_id` was always `"default"`, causing all memory searches to return empty when the real user ID was config-driven.

**Fix:** Replace module-level consts with lazy getter functions that read env at call time. Applied to all three consumers:
- `src/nous/recall.ts`
- `src/organon/built-in/mem0-search.ts`
- `src/organon/built-in/fact-retract.ts`

## Bug 2 (Medium): Python set slicing crash in graph_enhanced_search

`routes.py` line 595 used `set(graph_neighbors)[:5]` — sets aren't subscriptable in Python. Fixed to `list(set(...))[:5]`, matching the pattern already correctly used on line 628 of the same file.

## Not addressed

The Mem0 1.0.4 `PointStruct` validation bug on `event: NONE` is upstream — documented in the issue as informational. The direct Qdrant backfill pattern is a usage recommendation, not a code change.