### PR TITLE
feat: multi-spec batch — sub-agent guards, doctor, graph UI, tool memory, UI polish

### DIFF
--- a/infrastructure/runtime/src/koina/diagnostics.test.ts
+++ b/infrastructure/runtime/src/koina/diagnostics.test.ts
@@ -1,0 +1,95 @@
+// Diagnostics tests
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { applyFixes, formatResults, type DiagnosticResult } from "./diagnostics.js";
+
+describe("formatResults", () => {
+  it("formats ok results with + icon", () => {
+    const results: DiagnosticResult[] = [
+      { name: "test_check", status: "ok", message: "All good" },
+    ];
+    const output = formatResults(results);
+    expect(output).toContain("+ test_check: All good");
+    expect(output).toContain("All checks passed");
+  });
+
+  it("formats error results with X icon", () => {
+    const results: DiagnosticResult[] = [
+      { name: "broken", status: "error", message: "Something failed" },
+    ];
+    const output = formatResults(results);
+    expect(output).toContain("X broken: Something failed");
+    expect(output).toContain("1 error(s)");
+  });
+
+  it("formats warn results with ! icon", () => {
+    const results: DiagnosticResult[] = [
+      { name: "maybe", status: "warn", message: "Something iffy" },
+    ];
+    const output = formatResults(results);
+    expect(output).toContain("! maybe: Something iffy");
+    expect(output).toContain("1 warning(s)");
+  });
+
+  it("shows fixable count", () => {
+    const results: DiagnosticResult[] = [
+      {
+        name: "fixable",
+        status: "warn",
+        message: "Can fix",
+        fix: { description: "Do the thing", action: () => {} },
+      },
+    ];
+    const output = formatResults(results, true);
+    expect(output).toContain("fix: Do the thing");
+    expect(output).toContain("1 fixable");
+  });
+});
+
+describe("applyFixes", () => {
+  it("applies fix actions and counts them", () => {
+    const fn = vi.fn();
+    const results: DiagnosticResult[] = [
+      { name: "ok_check", status: "ok", message: "fine" },
+      {
+        name: "fixable",
+        status: "warn",
+        message: "needs fix",
+        fix: { description: "fix it", action: fn },
+      },
+    ];
+    const { applied, failed } = applyFixes(results);
+    expect(applied).toBe(1);
+    expect(failed).toHaveLength(0);
+    expect(fn).toHaveBeenCalledOnce();
+  });
+
+  it("catches fix errors and reports them", () => {
+    const results: DiagnosticResult[] = [
+      {
+        name: "bad_fix",
+        status: "error",
+        message: "broken",
+        fix: {
+          description: "try fix",
+          action: () => { throw new Error("EACCES"); },
+        },
+      },
+    ];
+    const { applied, failed } = applyFixes(results);
+    expect(applied).toBe(0);
+    expect(failed).toHaveLength(1);
+    expect(failed[0]).toContain("EACCES");
+  });
+
+  it("skips results without fix", () => {
+    const results: DiagnosticResult[] = [
+      { name: "no_fix", status: "error", message: "manual only" },
+    ];
+    const { applied, failed } = applyFixes(results);
+    expect(applied).toBe(0);
+    expect(failed).toHaveLength(0);
+  });
+});

--- a/infrastructure/runtime/src/koina/diagnostics.ts
+++ b/infrastructure/runtime/src/koina/diagnostics.ts
@@ -1,0 +1,334 @@
+// Diagnostic checks for `aletheia doctor`
+import { existsSync, mkdirSync, readFileSync, statSync, unlinkSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { paths } from "../taxis/paths.js";
+import { loadConfig } from "../taxis/loader.js";
+import type { AletheiaConfig } from "../taxis/schema.js";
+
+export interface DiagnosticResult {
+  name: string;
+  status: "ok" | "warn" | "error";
+  message: string;
+  fix?: {
+    description: string;
+    action: () => void;
+  };
+}
+
+type DiagnosticCheck = (config: AletheiaConfig | null) => DiagnosticResult;
+
+const checks: DiagnosticCheck[] = [
+  checkConfigValid,
+  checkWorkspacesExist,
+  checkSharedDirs,
+  checkSessionsDb,
+  checkPluginPaths,
+  checkStalePid,
+  checkBootstrapFiles,
+  checkSignalConfig,
+  checkCredentialsDir,
+];
+
+function checkConfigValid(_config: AletheiaConfig | null): DiagnosticResult {
+  try {
+    loadConfig();
+    return { name: "config_valid", status: "ok", message: "Config parses and validates" };
+  } catch (err) {
+    return {
+      name: "config_valid",
+      status: "error",
+      message: `Config invalid: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+}
+
+function checkWorkspacesExist(config: AletheiaConfig | null): DiagnosticResult {
+  if (!config) return { name: "workspaces_exist", status: "warn", message: "Skipped (no config)" };
+
+  const missing: string[] = [];
+  for (const nous of config.agents.list) {
+    const ws = nous.workspace.startsWith("/")
+      ? nous.workspace
+      : join(paths.root, nous.workspace);
+    if (!existsSync(ws)) missing.push(`${nous.id}: ${ws}`);
+  }
+
+  if (missing.length === 0) {
+    return { name: "workspaces_exist", status: "ok", message: `All ${config.agents.list.length} workspaces exist` };
+  }
+
+  return {
+    name: "workspaces_exist",
+    status: "error",
+    message: `Missing workspaces: ${missing.join(", ")}`,
+    fix: {
+      description: `Create ${missing.length} workspace directories`,
+      action: () => {
+        for (const nous of config.agents.list) {
+          const ws = nous.workspace.startsWith("/")
+            ? nous.workspace
+            : join(paths.root, nous.workspace);
+          if (!existsSync(ws)) mkdirSync(ws, { recursive: true });
+        }
+      },
+    },
+  };
+}
+
+function checkSharedDirs(_config: AletheiaConfig | null): DiagnosticResult {
+  const required = [
+    join(paths.shared, "skills"),
+    join(paths.shared, "tools", "authored"),
+    join(paths.shared, "competence"),
+    join(paths.shared, "calibration"),
+  ];
+
+  const missing = required.filter((d) => !existsSync(d));
+  if (missing.length === 0) {
+    return { name: "shared_dirs", status: "ok", message: "All shared directories exist" };
+  }
+
+  return {
+    name: "shared_dirs",
+    status: "warn",
+    message: `Missing: ${missing.map((d) => d.replace(paths.root + "/", "")).join(", ")}`,
+    fix: {
+      description: `Create ${missing.length} shared directories`,
+      action: () => {
+        for (const d of missing) mkdirSync(d, { recursive: true });
+      },
+    },
+  };
+}
+
+function checkSessionsDb(_config: AletheiaConfig | null): DiagnosticResult {
+  const dbPath = paths.sessionsDb();
+  if (existsSync(dbPath)) {
+    try {
+      const stat = statSync(dbPath);
+      if (stat.size === 0) {
+        return { name: "sessions_db", status: "warn", message: "Sessions DB exists but is empty (will be initialized on start)" };
+      }
+      return { name: "sessions_db", status: "ok", message: `Sessions DB exists (${Math.round(stat.size / 1024)}KB)` };
+    } catch {
+      return { name: "sessions_db", status: "error", message: "Sessions DB exists but is not readable" };
+    }
+  }
+
+  return {
+    name: "sessions_db",
+    status: "warn",
+    message: "Sessions DB does not exist (will be created on first start)",
+    fix: {
+      description: "Create config directory for sessions DB",
+      action: () => {
+        const dir = paths.configDir();
+        if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+      },
+    },
+  };
+}
+
+function checkPluginPaths(config: AletheiaConfig | null): DiagnosticResult {
+  if (!config) return { name: "plugin_paths", status: "warn", message: "Skipped (no config)" };
+
+  const loadPaths = config.plugins.load.paths;
+  if (loadPaths.length === 0) {
+    return { name: "plugin_paths", status: "ok", message: "No plugin paths configured" };
+  }
+
+  const missing = loadPaths.filter((p) => !existsSync(p));
+  if (missing.length === 0) {
+    return { name: "plugin_paths", status: "ok", message: `All ${loadPaths.length} plugin paths exist` };
+  }
+
+  return {
+    name: "plugin_paths",
+    status: "warn",
+    message: `Missing plugin paths: ${missing.join(", ")}`,
+    fix: {
+      description: `Create ${missing.length} plugin directories`,
+      action: () => {
+        for (const p of missing) mkdirSync(p, { recursive: true });
+      },
+    },
+  };
+}
+
+function checkStalePid(_config: AletheiaConfig | null): DiagnosticResult {
+  const pidPath = join(paths.configDir(), "aletheia.pid");
+  if (!existsSync(pidPath)) {
+    return { name: "stale_pid", status: "ok", message: "No PID file" };
+  }
+
+  try {
+    const pid = parseInt(readFileSync(pidPath, "utf-8").trim(), 10);
+    if (isNaN(pid)) {
+      return {
+        name: "stale_pid",
+        status: "warn",
+        message: "PID file contains invalid data",
+        fix: {
+          description: "Remove invalid PID file",
+          action: () => unlinkSync(pidPath),
+        },
+      };
+    }
+
+    try {
+      process.kill(pid, 0); // Signal 0 = check if alive
+      return { name: "stale_pid", status: "ok", message: `Process ${pid} is running` };
+    } catch {
+      return {
+        name: "stale_pid",
+        status: "warn",
+        message: `Stale PID file (process ${pid} not running)`,
+        fix: {
+          description: "Remove stale PID file",
+          action: () => unlinkSync(pidPath),
+        },
+      };
+    }
+  } catch {
+    return { name: "stale_pid", status: "ok", message: "No PID file" };
+  }
+}
+
+function checkBootstrapFiles(config: AletheiaConfig | null): DiagnosticResult {
+  if (!config) return { name: "bootstrap_files", status: "warn", message: "Skipped (no config)" };
+
+  const missing: string[] = [];
+  for (const nous of config.agents.list) {
+    const ws = nous.workspace.startsWith("/")
+      ? nous.workspace
+      : join(paths.root, nous.workspace);
+    if (!existsSync(ws)) continue; // workspace doesn't exist, caught by other check
+    const soul = join(ws, "SOUL.md");
+    if (!existsSync(soul)) missing.push(`${nous.id}/SOUL.md`);
+  }
+
+  if (missing.length === 0) {
+    return { name: "bootstrap_files", status: "ok", message: "All agents have SOUL.md" };
+  }
+
+  return {
+    name: "bootstrap_files",
+    status: "warn",
+    message: `Missing: ${missing.join(", ")}`,
+    fix: {
+      description: `Create ${missing.length} minimal SOUL.md files`,
+      action: () => {
+        for (const nous of config.agents.list) {
+          const ws = nous.workspace.startsWith("/")
+            ? nous.workspace
+            : join(paths.root, nous.workspace);
+          if (!existsSync(ws)) continue;
+          const soul = join(ws, "SOUL.md");
+          if (!existsSync(soul)) {
+            const name = nous.identity?.name ?? nous.name ?? nous.id;
+            writeFileSync(soul, `# ${name}\n\nYou are ${name}, an Aletheia agent.\n`, "utf-8");
+          }
+        }
+      },
+    },
+  };
+}
+
+function checkSignalConfig(config: AletheiaConfig | null): DiagnosticResult {
+  if (!config) return { name: "signal_config", status: "warn", message: "Skipped (no config)" };
+
+  if (!config.channels.signal.enabled) {
+    return { name: "signal_config", status: "ok", message: "Signal disabled" };
+  }
+
+  const accounts = Object.entries(config.channels.signal.accounts);
+  if (accounts.length === 0) {
+    return { name: "signal_config", status: "warn", message: "Signal enabled but no accounts configured" };
+  }
+
+  const noAccount = accounts.filter(([, acct]) => !acct.account);
+  if (noAccount.length > 0) {
+    return {
+      name: "signal_config",
+      status: "warn",
+      message: `Signal accounts without phone number: ${noAccount.map(([k]) => k).join(", ")}`,
+    };
+  }
+
+  return { name: "signal_config", status: "ok", message: `${accounts.length} Signal account(s) configured` };
+}
+
+function checkCredentialsDir(_config: AletheiaConfig | null): DiagnosticResult {
+  const credDir = join(paths.configDir(), "credentials");
+  if (!existsSync(credDir)) {
+    return {
+      name: "credentials_dir",
+      status: "warn",
+      message: "Credentials directory missing",
+      fix: {
+        description: "Create credentials directory",
+        action: () => mkdirSync(credDir, { recursive: true }),
+      },
+    };
+  }
+  return { name: "credentials_dir", status: "ok", message: "Credentials directory exists" };
+}
+
+export function runDiagnostics(): { results: DiagnosticResult[]; config: AletheiaConfig | null } {
+  let config: AletheiaConfig | null = null;
+  try {
+    config = loadConfig();
+  } catch {
+    // Config check itself will report the error
+  }
+
+  const results = checks.map((check) => check(config));
+  return { results, config };
+}
+
+export function applyFixes(results: DiagnosticResult[]): { applied: number; failed: string[] } {
+  let applied = 0;
+  const failed: string[] = [];
+
+  for (const r of results) {
+    if (!r.fix) continue;
+    try {
+      r.fix.action();
+      applied++;
+    } catch (err) {
+      failed.push(`${r.name}: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+
+  return { applied, failed };
+}
+
+export function formatResults(results: DiagnosticResult[], showFixes = false): string {
+  const lines: string[] = [];
+  const icons = { ok: "+", warn: "!", error: "X" };
+
+  for (const r of results) {
+    const icon = icons[r.status];
+    lines.push(`  ${icon} ${r.name}: ${r.message}`);
+    if (showFixes && r.fix) {
+      lines.push(`    fix: ${r.fix.description}`);
+    }
+  }
+
+  const errors = results.filter((r) => r.status === "error").length;
+  const warns = results.filter((r) => r.status === "warn").length;
+  const fixable = results.filter((r) => r.fix).length;
+
+  lines.push("");
+  if (errors === 0 && warns === 0) {
+    lines.push("All checks passed.");
+  } else {
+    const parts: string[] = [];
+    if (errors > 0) parts.push(`${errors} error(s)`);
+    if (warns > 0) parts.push(`${warns} warning(s)`);
+    if (fixable > 0) parts.push(`${fixable} fixable (run with --fix)`);
+    lines.push(parts.join(", "));
+  }
+
+  return lines.join("\n");
+}

--- a/infrastructure/runtime/src/mneme/schema.ts
+++ b/infrastructure/runtime/src/mneme/schema.ts
@@ -360,4 +360,24 @@ export const MIGRATIONS: Array<{ version: number; sql: string }> = [
       ALTER TABLE sessions ADD COLUMN distillation_priming TEXT;
     `,
   },
+  {
+    version: 17,
+    sql: `
+      -- Content hash for cross-agent message idempotency
+      ALTER TABLE cross_agent_messages ADD COLUMN content_hash TEXT;
+      CREATE INDEX IF NOT EXISTS idx_xagent_hash ON cross_agent_messages(content_hash, created_at);
+
+      -- Tool usage stats for memory/analytics
+      CREATE TABLE IF NOT EXISTS tool_stats (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        nous_id TEXT NOT NULL,
+        tool_name TEXT NOT NULL,
+        success INTEGER NOT NULL DEFAULT 1,
+        error_message TEXT,
+        duration_ms INTEGER,
+        created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+      );
+      CREATE INDEX IF NOT EXISTS idx_tool_stats_lookup ON tool_stats(nous_id, tool_name, created_at);
+    `,
+  },
 ];

--- a/infrastructure/runtime/src/nous/pipeline/stages/context.ts
+++ b/infrastructure/runtime/src/nous/pipeline/stages/context.ts
@@ -230,6 +230,7 @@ export async function buildContext(
     sessionId,
     ...(nous.tools.allow.length > 0 ? { allow: nous.tools.allow } : {}),
     ...(nous.tools.deny.length > 0 ? { deny: nous.tools.deny } : {}),
+    ...(msg.toolFilter?.length ? { toolFilter: msg.toolFilter } : {}),
   });
 
   state.systemPrompt = systemPrompt;

--- a/infrastructure/runtime/src/nous/pipeline/types.ts
+++ b/infrastructure/runtime/src/nous/pipeline/types.ts
@@ -39,6 +39,7 @@ export interface InboundMessage {
   threadId?: string;
   bindingId?: string;
   lockKey?: string;
+  toolFilter?: string[];
 }
 
 export interface TurnOutcome {

--- a/ui/src/components/chat/Markdown.svelte
+++ b/ui/src/components/chat/Markdown.svelte
@@ -198,4 +198,35 @@
   .markdown-body :global(strong) {
     font-weight: 600;
   }
+  /* Task list checkboxes (GFM) */
+  .markdown-body :global(li:has(> input[type="checkbox"])) {
+    list-style: none;
+    margin-left: -20px;
+  }
+  .markdown-body :global(input[type="checkbox"]) {
+    appearance: none;
+    width: 14px;
+    height: 14px;
+    border: 1.5px solid var(--text-muted);
+    border-radius: 3px;
+    background: transparent;
+    vertical-align: middle;
+    margin-right: 6px;
+    position: relative;
+    top: -1px;
+    cursor: default;
+  }
+  .markdown-body :global(input[type="checkbox"]:checked) {
+    background: var(--accent);
+    border-color: var(--accent);
+  }
+  .markdown-body :global(input[type="checkbox"]:checked::after) {
+    content: "\2713";
+    display: block;
+    color: #fff;
+    font-size: 10px;
+    font-weight: 700;
+    text-align: center;
+    line-height: 14px;
+  }
 </style>

--- a/ui/src/components/chat/ToolStatusLine.svelte
+++ b/ui/src/components/chat/ToolStatusLine.svelte
@@ -100,12 +100,36 @@
     }
   }
 
+  let elapsed = $state(0);
+  let runStart = $state(0);
+
+  $effect(() => {
+    if (running.length > 0) {
+      if (!runStart) runStart = Date.now();
+      elapsed = Math.floor((Date.now() - runStart) / 1000);
+      const iv = setInterval(() => {
+        elapsed = Math.floor((Date.now() - runStart) / 1000);
+      }, 1000);
+      return () => clearInterval(iv);
+    } else {
+      runStart = 0;
+      elapsed = 0;
+    }
+  });
+
+  function formatElapsed(s: number): string {
+    if (s < 60) return `${s}s`;
+    return `${Math.floor(s / 60)}m${s % 60}s`;
+  }
+
   let statusText = $derived.by(() => {
     if (running.length > 0) {
       const current = running[running.length - 1]!;
+      const icon = TOOL_CATEGORIES[current.name]?.icon ?? "\u2699";
       const hint = inputHint(current);
       const label = humanizeTool(current.name);
-      return hint ? `${label}: ${hint}` : label;
+      const time = elapsed > 0 ? ` (${formatElapsed(elapsed)})` : "";
+      return hint ? `${icon} ${label}: ${hint}${time}` : `${icon} ${label}${time}`;
     }
     if (errors > 0) {
       return `${total} tool${total === 1 ? '' : 's'} · ${errors} failed`;

--- a/ui/src/components/graph/GraphView.svelte
+++ b/ui/src/components/graph/GraphView.svelte
@@ -5,9 +5,9 @@
     getGraphData, getLoading, getError, getSelectedNodeId,
     getSelectedNode, getNodeEdges, getConnectedNodes, getCommunityIds,
     getHighlightedCommunity, getSearchQuery, getLoadedMode, getLoadedLimit,
-    getTotalNodes,
+    getTotalNodes, getEntityDetail, getEntityLoading,
     setSelectedNodeId, setHighlightedCommunity, setSearchQuery,
-    loadGraph,
+    loadGraph, loadEntityDetail, removeEntity, mergeEntityNodes,
   } from "../../stores/graph.svelte";
 
   type ViewMode = "2d" | "3d";
@@ -49,6 +49,9 @@
 
   function handleNodeClick(nodeId: string) {
     focusOnNode(nodeId);
+    loadEntityDetail(nodeId);
+    confirmDelete = false;
+    mergeTarget = "";
   }
 
   function handleBackgroundClick() {
@@ -109,6 +112,8 @@
   let connectedNodes = $derived(getSelectedNodeId() ? getConnectedNodes(getSelectedNodeId()!) : []);
   let communityIds = $derived(getCommunityIds());
   let hoverNodeId = $state<string | null>(null);
+  let confirmDelete = $state(false);
+  let mergeTarget = $state("");
 </script>
 
 <div class="graph-view">
@@ -198,15 +203,20 @@
   </div>
 
   {#if selectedNode}
+    {@const detail = getEntityDetail()}
+    {@const detailLoading = getEntityLoading()}
     <div class="info-panel">
       <div class="info-header">
         <span class="info-dot" style="background: {communityColor(selectedNode.community)}"></span>
         <strong>{selectedNode.id}</strong>
+        {#if detail}
+          <span class="confidence-dot confidence-{detail.confidence}" title="Confidence: {detail.confidence}"></span>
+        {/if}
         <span class="info-meta">
           Community {selectedNode.community >= 0 ? selectedNode.community : "\u2014"} ·
           PR {selectedNode.pagerank.toFixed(4)}
         </span>
-        <button class="info-close" onclick={() => setSelectedNodeId(null)}>&times;</button>
+        <button class="info-close" onclick={() => { setSelectedNodeId(null); confirmDelete = false; mergeTarget = ""; }}>&times;</button>
       </div>
       {#if selectedNode.labels.length > 0}
         <div class="info-labels">
@@ -215,14 +225,20 @@
           {/each}
         </div>
       {/if}
+
+      {#if detailLoading}
+        <div class="detail-loading">Loading details...</div>
+      {/if}
+
       {#if connectedNodes.length > 0}
+        <div class="info-section-title">Relationships ({selectedEdges.length})</div>
         <div class="info-connections">
           {#each selectedEdges.slice(0, 20) as edge}
             <div class="connection-row">
               <span class="rel-type">{edge.rel_type}</span>
               <button
                 class="connection-target"
-                onclick={() => focusOnNode(edge.source === selectedNode?.id ? edge.target : edge.source)}
+                onclick={() => { handleNodeClick(edge.source === selectedNode?.id ? edge.target : edge.source); }}
               >
                 {edge.source === selectedNode?.id ? edge.target : edge.source}
               </button>
@@ -233,6 +249,39 @@
           {/if}
         </div>
       {/if}
+
+      {#if detail?.memories && detail.memories.length > 0}
+        <div class="info-section-title">Memories ({detail.memories.length})</div>
+        <div class="info-memories">
+          {#each detail.memories.slice(0, 5) as mem}
+            <div class="memory-row">
+              <span class="memory-score">{(mem.score * 100).toFixed(0)}%</span>
+              <span class="memory-text">{mem.text}</span>
+            </div>
+          {/each}
+          {#if detail.memories.length > 5}
+            <div class="connection-overflow">+{detail.memories.length - 5} more</div>
+          {/if}
+        </div>
+      {/if}
+
+      <div class="info-actions">
+        {#if confirmDelete}
+          <span class="confirm-label">Delete this entity?</span>
+          <button class="action-btn danger" onclick={async () => { await removeEntity(selectedNode!.id); confirmDelete = false; }}>Confirm</button>
+          <button class="action-btn" onclick={() => { confirmDelete = false; }}>Cancel</button>
+        {:else}
+          <button class="action-btn danger" onclick={() => { confirmDelete = true; }}>Delete</button>
+        {/if}
+        <div class="merge-row">
+          <input class="merge-input" type="text" placeholder="Merge into..." bind:value={mergeTarget} />
+          <button
+            class="action-btn"
+            disabled={!mergeTarget.trim()}
+            onclick={async () => { const ok = await mergeEntityNodes(selectedNode!.id, mergeTarget.trim()); if (ok) mergeTarget = ""; }}
+          >Merge</button>
+        </div>
+      </div>
     </div>
   {/if}
 </div>
@@ -477,6 +526,105 @@
     font-size: 11px;
     padding-top: 4px;
   }
+
+  .confidence-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    flex-shrink: 0;
+  }
+  .confidence-high { background: #3fb950; }
+  .confidence-medium { background: #d29922; }
+  .confidence-low { background: #f85149; }
+
+  .detail-loading {
+    font-size: 11px;
+    color: var(--text-muted);
+    padding: 4px 0;
+  }
+
+  .info-section-title {
+    font-size: 11px;
+    color: var(--text-muted);
+    font-weight: 600;
+    margin-top: 8px;
+    margin-bottom: 4px;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+  }
+
+  .info-memories {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+  .memory-row {
+    display: flex;
+    gap: 6px;
+    font-size: 11px;
+    line-height: 1.3;
+  }
+  .memory-score {
+    color: var(--text-muted);
+    font-family: var(--font-mono);
+    font-size: 10px;
+    flex-shrink: 0;
+    min-width: 30px;
+  }
+  .memory-text {
+    color: var(--text-secondary);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+  }
+
+  .info-actions {
+    margin-top: 10px;
+    padding-top: 8px;
+    border-top: 1px solid var(--border);
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    align-items: center;
+  }
+  .confirm-label {
+    font-size: 12px;
+    color: var(--red);
+    font-weight: 600;
+  }
+  .action-btn {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    color: var(--text-secondary);
+    padding: 3px 10px;
+    border-radius: var(--radius-sm);
+    font-size: 11px;
+    cursor: pointer;
+  }
+  .action-btn:hover { color: var(--text); border-color: var(--text-muted); }
+  .action-btn:disabled { opacity: 0.4; cursor: default; }
+  .action-btn.danger { border-color: var(--red); color: var(--red); }
+  .action-btn.danger:hover { background: var(--red); color: #fff; }
+
+  .merge-row {
+    display: flex;
+    gap: 4px;
+    width: 100%;
+    margin-top: 4px;
+  }
+  .merge-input {
+    flex: 1;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    color: var(--text);
+    padding: 3px 8px;
+    font-size: 11px;
+    font-family: var(--font-sans);
+  }
+  .merge-input:focus { outline: none; border-color: var(--accent); }
 
   @media (max-width: 768px) {
     .info-panel {

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -1,4 +1,4 @@
-import type { Agent, Session, HistoryMessage, MetricsData, CostSummary, GraphData, FileTreeEntry, GitFileStatus, CommandInfo, Thread, ThreadMessage } from "./types";
+import type { Agent, Session, HistoryMessage, MetricsData, CostSummary, GraphData, FileTreeEntry, GitFileStatus, CommandInfo, Thread, ThreadMessage, EntityDetail } from "./types";
 import { getAccessToken, refresh } from "./auth";
 
 const TOKEN_KEY = "aletheia_token";
@@ -222,4 +222,30 @@ export async function fetchGitStatus(
   const sp = new URLSearchParams();
   if (agentId) sp.set("agentId", agentId);
   return fetchJson(`/api/workspace/git-status?${sp.toString()}`);
+}
+
+// --- Graph Entity Management ---
+
+export async function fetchEntityDetail(name: string): Promise<EntityDetail> {
+  return fetchJson(`/api/memory/entity/${encodeURIComponent(name)}`);
+}
+
+export async function deleteEntity(name: string): Promise<{ deleted: boolean; relationships_removed: number }> {
+  return fetchJson(`/api/memory/entity/${encodeURIComponent(name)}`, { method: "DELETE" });
+}
+
+export async function mergeEntities(source: string, target: string): Promise<{ merged: boolean; message: string }> {
+  return fetchJson("/api/memory/entity/merge", {
+    method: "POST",
+    body: JSON.stringify({ source, target }),
+  });
+}
+
+// --- Tool Stats ---
+
+export async function fetchToolStats(agentId?: string, window = "7d"): Promise<unknown> {
+  const sp = new URLSearchParams();
+  if (agentId) sp.set("agentId", agentId);
+  sp.set("window", window);
+  return fetchJson(`/api/tool-stats?${sp.toString()}`);
 }

--- a/ui/src/lib/markdown.ts
+++ b/ui/src/lib/markdown.ts
@@ -55,7 +55,8 @@ const marked = new Marked({
 export function renderMarkdown(text: string): string {
   const raw = marked.parse(text, { async: false }) as string;
   return DOMPurify.sanitize(raw, {
-    ADD_ATTR: ["class"],
+    ADD_ATTR: ["class", "type", "checked", "disabled"],
+    ADD_TAGS: ["input"],
   });
 }
 

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -42,6 +42,7 @@ export interface ChatMessage {
   isStreaming?: boolean;
   media?: MediaItem[];
   thinking?: string;
+  turnOutcome?: TurnOutcome;
 }
 
 export interface ToolCallState {
@@ -159,6 +160,27 @@ export interface GraphData {
   communities: number;
   community_meta: CommunityMeta[];
   total_nodes: number;
+}
+
+export interface EntityRelationship {
+  type: string;
+  target: string;
+  direction: "out" | "in";
+}
+
+export interface EntityMemory {
+  text: string;
+  score: number;
+}
+
+export interface EntityDetail {
+  name: string;
+  properties: Record<string, unknown>;
+  relationships: EntityRelationship[];
+  memories: EntityMemory[];
+  confidence: "high" | "medium" | "low";
+  relationship_count: number;
+  pagerank: number;
 }
 
 export interface CommandInfo {

--- a/ui/src/stores/chat.svelte.ts
+++ b/ui/src/stores/chat.svelte.ts
@@ -210,6 +210,7 @@ export async function sendMessage(
             timestamp: new Date().toISOString(),
             toolCalls: state.activeToolCalls.length > 0 ? [...state.activeToolCalls] : undefined,
             ...(state.thinkingText ? { thinking: state.thinkingText } : {}),
+            turnOutcome: event.outcome,
           };
           state.messages = [...state.messages, assistantMsg];
           state.streamingText = "";


### PR DESCRIPTION
## Summary

- **Spec 13 Phases 9-11**: Sub-agent tool filtering (glob patterns on spawn), dispatch reducer (concat/dedup/merge), cross-agent message idempotency (content hash dedup, 5-min window)
- **Spec 14 Phase 7**: `aletheia doctor --fix` with 9 diagnostic checks (config, workspaces, shared dirs, sessions DB, stale PIDs, bootstrap files, signal config, credentials) and auto-remediation
- **Spec 7 Phase 2c**: Entity detail panel in graph UI — confidence indicator, memory mentions from Qdrant, delete/merge actions. Sidecar CRUD endpoints + gateway proxy
- **Spec 7 Phase 3f**: `tool_stats` table (migration v16), event bus recording (`tool:called`/`tool:failed`), `GET /api/tool-stats` endpoint with windowed aggregation
- **Spec 15 Phase 5**: ToolStatusLine — category icon on running tool, elapsed timer
- **Spec 11 Phase 5**: Cost badge on assistant messages (token counts from TurnOutcome), GFM checkbox styling, DOMPurify input tag allowlist

24 files changed, ~1400 lines added. Runtime builds to 628KB. UI builds clean. 115 tests passing.

## Test plan

- [ ] `npx vitest run src/organon/registry.test.ts` — tool filter glob matching
- [ ] `npx vitest run src/organon/built-in/sessions-spawn.test.ts` — spawn tool filter passthrough
- [ ] `npx vitest run src/organon/built-in/sessions-dispatch.test.ts` — reducer strategies
- [ ] `npx vitest run src/mneme/store.test.ts` — content hash idempotency + tool stats
- [ ] `npx vitest run src/koina/diagnostics.test.ts` — diagnostic checks and fix application
- [ ] `npx tsc --noEmit` clean (runtime + UI)
- [ ] `npx tsdown` builds successfully
- [ ] `npm run build` (UI) builds successfully
- [ ] Visual: graph entity panel shows confidence dot, memories, delete/merge
- [ ] Visual: cost badge appears on assistant messages
- [ ] Visual: GFM checkboxes render with styled appearance