### PR TITLE
fix: tool stats payload key mismatch + sidecar systemd dependency

### DIFF
--- a/infrastructure/runtime/src/aletheia.ts
+++ b/infrastructure/runtime/src/aletheia.ts
@@ -391,7 +391,7 @@ export async function startRuntime(configPath?: string): Promise<void> {
         const durMs = payload["durationMs"] as number | undefined;
         runtime.store.recordToolStat({
           nousId: (payload["nousId"] as string) ?? "unknown",
-          toolName: (payload["name"] as string) ?? "unknown",
+          toolName: (payload["tool"] as string) ?? "unknown",
           success: eventName === "tool:called",
           ...(errMsg ? { errorMessage: errMsg } : {}),
           ...(durMs != null ? { durationMs: durMs } : {}),


### PR DESCRIPTION
## What

Two small fixes:

1. **Tool stats recording `toolName: 'unknown'`** — The event bus emits `{ tool: toolUse.name }` but `recordToolStat` in `aletheia.ts` was reading `payload['name']`. One-character fix: `'name'` → `'tool'`.

2. **Memory sidecar not restarting with main service** — Added `PartOf=aletheia.service` and `After=aletheia.service` to `aletheia-memory.service` so the sidecar restarts automatically when the main service restarts. Applied directly to systemd (not in repo).

## Impact
- Tool stats will now correctly attribute calls to their tool names
- Future deploys won't leave the sidecar running stale code