### PR TITLE
feat: semantic node cards for graph entity detail (Spec 09 Phase 5)

### DIFF
--- a/docs/specs/09_graph-visualization.md
+++ b/docs/specs/09_graph-visualization.md
@@ -1,6 +1,6 @@
 # Spec: Graph Visualization — From Demo to Tool
 
-**Status:** Phase 1-3 done (PR #56)  
+**Status:** Phase 1-7 done (PRs #56, 7338e93, #90)  
 **Author:** Syn  
 **Date:** 2026-02-19  
 

--- a/infrastructure/memory/sidecar/aletheia_memory/routes.py
+++ b/infrastructure/memory/sidecar/aletheia_memory/routes.py
@@ -1922,15 +1922,22 @@ async def entity_detail(name: str, request: Request):
     memories: list[dict[str, Any]] = []
     try:
         mem = _get_memory(request)
-        raw = await asyncio.to_thread(mem.search, name, user_id="default", limit=5)
+        raw = await asyncio.to_thread(mem.search, name, user_id="default", limit=10)
         results = raw.get("results", raw) if isinstance(raw, dict) else raw
         if isinstance(results, list):
             for r in results:
-                if r.get("score", 0) > 0.5:
+                if r.get("score", 0) > 0.4:
+                    meta = r.get("metadata") or {}
+                    created = r.get("created_at") or meta.get("created_at")
+                    agent_id = meta.get("agent_id")
+                    source = meta.get("source", "inferred")  # "stated" vs "inferred"
                     memories.append({
                         "id": r.get("id"),
-                        "text": r.get("memory", "")[:200],
+                        "text": r.get("memory", "")[:300],
                         "score": round(r.get("score", 0), 3),
+                        "created_at": created,
+                        "agent_id": agent_id,
+                        "source": source,
                     })
     except Exception:
         pass  # Non-fatal — graph data still returned

--- a/ui/src/components/graph/GraphView.svelte
+++ b/ui/src/components/graph/GraphView.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
   import { onMount } from "svelte";
   import Graph2D from "./Graph2D.svelte";
+  import NodeCard from "./NodeCard.svelte";
   import {
     getGraphData, getLoading, getError, getSelectedNodeId,
-    getSelectedNode, getNodeEdges, getConnectedNodes, getCommunityIds,
+    getSelectedNode, getNodeEdges, getCommunityIds,
     getHighlightedCommunity, getSearchQuery, getLoadedMode, getLoadedLimit,
     getTotalNodes, getEntityDetail, getEntityLoading, getCommunityMeta,
     getHiddenEdgeTypes, getEdgeTypes, toggleEdgeType, getFilteredEdges,
@@ -52,8 +53,6 @@
   function handleNodeClick(nodeId: string) {
     focusOnNode(nodeId);
     loadEntityDetail(nodeId);
-    confirmDelete = false;
-    mergeTarget = "";
   }
 
   function handleBackgroundClick() {
@@ -111,11 +110,9 @@
   let graphData = $derived(getGraphData());
   let selectedNode = $derived(getSelectedNode());
   let selectedEdges = $derived(getSelectedNodeId() ? getNodeEdges(getSelectedNodeId()!) : []);
-  let connectedNodes = $derived(getSelectedNodeId() ? getConnectedNodes(getSelectedNodeId()!) : []);
+
   let communityIds = $derived(getCommunityIds());
   let hoverNodeId = $state<string | null>(null);
-  let confirmDelete = $state(false);
-  let mergeTarget = $state("");
   let edgeTypes = $derived(getEdgeTypes());
   let hiddenEdges = $derived(getHiddenEdgeTypes());
   let communityMeta = $derived(getCommunityMeta());
@@ -214,86 +211,18 @@
   </div>
 
   {#if selectedNode}
-    {@const detail = getEntityDetail()}
-    {@const detailLoading = getEntityLoading()}
-    <div class="info-panel">
-      <div class="info-header">
-        <span class="info-dot" style="background: {communityColor(selectedNode.community)}"></span>
-        <strong>{selectedNode.id}</strong>
-        {#if detail}
-          <span class="confidence-dot confidence-{detail.confidence}" title="Confidence: {detail.confidence}"></span>
-        {/if}
-        <span class="info-meta">
-          Community {selectedNode.community >= 0 ? selectedNode.community : "\u2014"} ·
-          PR {selectedNode.pagerank.toFixed(4)}
-        </span>
-        <button class="info-close" onclick={() => { setSelectedNodeId(null); confirmDelete = false; mergeTarget = ""; }}>&times;</button>
-      </div>
-      {#if selectedNode.labels.length > 0}
-        <div class="info-labels">
-          {#each selectedNode.labels as label}
-            <span class="label-tag">{label}</span>
-          {/each}
-        </div>
-      {/if}
-
-      {#if detailLoading}
-        <div class="detail-loading">Loading details...</div>
-      {/if}
-
-      {#if connectedNodes.length > 0}
-        <div class="info-section-title">Relationships ({selectedEdges.length})</div>
-        <div class="info-connections">
-          {#each selectedEdges.slice(0, 20) as edge}
-            <div class="connection-row">
-              <span class="rel-type">{edge.rel_type}</span>
-              <button
-                class="connection-target"
-                onclick={() => { handleNodeClick(edge.source === selectedNode?.id ? edge.target : edge.source); }}
-              >
-                {edge.source === selectedNode?.id ? edge.target : edge.source}
-              </button>
-            </div>
-          {/each}
-          {#if selectedEdges.length > 20}
-            <div class="connection-overflow">+{selectedEdges.length - 20} more</div>
-          {/if}
-        </div>
-      {/if}
-
-      {#if detail?.memories && detail.memories.length > 0}
-        <div class="info-section-title">Memories ({detail.memories.length})</div>
-        <div class="info-memories">
-          {#each detail.memories.slice(0, 5) as mem}
-            <div class="memory-row">
-              <span class="memory-score">{(mem.score * 100).toFixed(0)}%</span>
-              <span class="memory-text">{mem.text}</span>
-            </div>
-          {/each}
-          {#if detail.memories.length > 5}
-            <div class="connection-overflow">+{detail.memories.length - 5} more</div>
-          {/if}
-        </div>
-      {/if}
-
-      <div class="info-actions">
-        {#if confirmDelete}
-          <span class="confirm-label">Delete this entity?</span>
-          <button class="action-btn danger" onclick={async () => { await removeEntity(selectedNode!.id); confirmDelete = false; }}>Confirm</button>
-          <button class="action-btn" onclick={() => { confirmDelete = false; }}>Cancel</button>
-        {:else}
-          <button class="action-btn danger" onclick={() => { confirmDelete = true; }}>Delete</button>
-        {/if}
-        <div class="merge-row">
-          <input class="merge-input" type="text" placeholder="Merge into..." bind:value={mergeTarget} />
-          <button
-            class="action-btn"
-            disabled={!mergeTarget.trim()}
-            onclick={async () => { const ok = await mergeEntityNodes(selectedNode!.id, mergeTarget.trim()); if (ok) mergeTarget = ""; }}
-          >Merge</button>
-        </div>
-      </div>
-    </div>
+    <NodeCard
+      node={selectedNode}
+      detail={getEntityDetail()}
+      detailLoading={getEntityLoading()}
+      communityName={communityLabel(selectedNode.community)}
+      communityColor={communityColor(selectedNode.community)}
+      edges={selectedEdges}
+      onNodeClick={handleNodeClick}
+      onClose={() => { setSelectedNodeId(null); }}
+      onDelete={removeEntity}
+      onMerge={mergeEntityNodes}
+    />
   {/if}
 
   {#if edgeTypes.length > 0}
@@ -456,200 +385,6 @@
     color: var(--red);
   }
 
-  .info-panel {
-    position: absolute;
-    bottom: 12px;
-    left: 12px;
-    width: 320px;
-    max-height: 300px;
-    background: var(--bg-elevated);
-    border: 1px solid var(--border);
-    border-radius: var(--radius);
-    padding: 12px;
-    overflow-y: auto;
-    z-index: 20;
-  }
-
-  .info-header {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    margin-bottom: 8px;
-  }
-  .info-dot {
-    width: 10px;
-    height: 10px;
-    border-radius: 50%;
-    flex-shrink: 0;
-  }
-  .info-header strong {
-    font-size: 14px;
-  }
-  .info-meta {
-    font-size: 11px;
-    color: var(--text-muted);
-  }
-  .info-close {
-    margin-left: auto;
-    background: none;
-    border: none;
-    color: var(--text-muted);
-    font-size: 14px;
-    cursor: pointer;
-    padding: 2px 6px;
-  }
-  .info-close:hover {
-    color: var(--text);
-  }
-
-  .info-labels {
-    display: flex;
-    gap: 4px;
-    margin-bottom: 8px;
-  }
-  .label-tag {
-    background: var(--surface);
-    border: 1px solid var(--border);
-    padding: 1px 6px;
-    border-radius: 4px;
-    font-size: 11px;
-    color: var(--text-secondary);
-  }
-
-  .info-connections {
-    display: flex;
-    flex-direction: column;
-    gap: 3px;
-  }
-  .connection-row {
-    display: flex;
-    align-items: center;
-    gap: 6px;
-    font-size: 12px;
-  }
-  .rel-type {
-    color: var(--text-muted);
-    font-size: 10px;
-    min-width: 80px;
-    font-family: var(--font-mono);
-  }
-  .connection-target {
-    background: none;
-    border: none;
-    color: var(--accent);
-    cursor: pointer;
-    font-size: 12px;
-    padding: 0;
-    text-align: left;
-  }
-  .connection-target:hover {
-    text-decoration: underline;
-  }
-  .connection-overflow {
-    color: var(--text-muted);
-    font-size: 11px;
-    padding-top: 4px;
-  }
-
-  .confidence-dot {
-    width: 8px;
-    height: 8px;
-    border-radius: 50%;
-    flex-shrink: 0;
-  }
-  .confidence-high { background: #3fb950; }
-  .confidence-medium { background: #d29922; }
-  .confidence-low { background: #f85149; }
-
-  .detail-loading {
-    font-size: 11px;
-    color: var(--text-muted);
-    padding: 4px 0;
-  }
-
-  .info-section-title {
-    font-size: 11px;
-    color: var(--text-muted);
-    font-weight: 600;
-    margin-top: 8px;
-    margin-bottom: 4px;
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
-  }
-
-  .info-memories {
-    display: flex;
-    flex-direction: column;
-    gap: 4px;
-  }
-  .memory-row {
-    display: flex;
-    gap: 6px;
-    font-size: 11px;
-    line-height: 1.3;
-  }
-  .memory-score {
-    color: var(--text-muted);
-    font-family: var(--font-mono);
-    font-size: 10px;
-    flex-shrink: 0;
-    min-width: 30px;
-  }
-  .memory-text {
-    color: var(--text-secondary);
-    overflow: hidden;
-    text-overflow: ellipsis;
-    display: -webkit-box;
-    -webkit-line-clamp: 2;
-    -webkit-box-orient: vertical;
-  }
-
-  .info-actions {
-    margin-top: 10px;
-    padding-top: 8px;
-    border-top: 1px solid var(--border);
-    display: flex;
-    flex-wrap: wrap;
-    gap: 6px;
-    align-items: center;
-  }
-  .confirm-label {
-    font-size: 12px;
-    color: var(--red);
-    font-weight: 600;
-  }
-  .action-btn {
-    background: var(--surface);
-    border: 1px solid var(--border);
-    color: var(--text-secondary);
-    padding: 3px 10px;
-    border-radius: var(--radius-sm);
-    font-size: 11px;
-    cursor: pointer;
-  }
-  .action-btn:hover { color: var(--text); border-color: var(--text-muted); }
-  .action-btn:disabled { opacity: 0.4; cursor: default; }
-  .action-btn.danger { border-color: var(--red); color: var(--red); }
-  .action-btn.danger:hover { background: var(--red); color: #fff; }
-
-  .merge-row {
-    display: flex;
-    gap: 4px;
-    width: 100%;
-    margin-top: 4px;
-  }
-  .merge-input {
-    flex: 1;
-    background: var(--surface);
-    border: 1px solid var(--border);
-    border-radius: var(--radius-sm);
-    color: var(--text);
-    padding: 3px 8px;
-    font-size: 11px;
-    font-family: var(--font-sans);
-  }
-  .merge-input:focus { outline: none; border-color: var(--accent); }
-
   .edge-filter-panel {
     position: absolute;
     top: 60px;
@@ -682,11 +417,5 @@
     text-decoration: line-through;
   }
 
-  @media (max-width: 768px) {
-    .info-panel {
-      width: calc(100% - 24px);
-      bottom: 8px;
-      left: 8px;
-    }
-  }
+
 </style>

--- a/ui/src/components/graph/NodeCard.svelte
+++ b/ui/src/components/graph/NodeCard.svelte
@@ -1,0 +1,702 @@
+<script lang="ts">
+  import type { GraphNode, EntityDetail, EntityRelationship, EntityMemory } from "../../lib/types";
+
+  let {
+    node,
+    detail,
+    detailLoading,
+    communityName,
+    communityColor,
+    edges,
+    onNodeClick,
+    onClose,
+    onDelete,
+    onMerge,
+  }: {
+    node: GraphNode;
+    detail: EntityDetail | null;
+    detailLoading: boolean;
+    communityName: string;
+    communityColor: string;
+    edges: Array<{ rel_type: string; source: string; target: string }>;
+    onNodeClick: (id: string) => void;
+    onClose: () => void;
+    onDelete: (name: string) => Promise<boolean>;
+    onMerge: (source: string, target: string) => Promise<boolean>;
+  } = $props();
+
+  let confirmDelete = $state(false);
+  let mergeTarget = $state("");
+  let showAllMemories = $state(false);
+  let showAllConnections = $state(false);
+  let activeTab = $state<"memories" | "connections">("memories");
+
+  // Group relationships by type
+  function groupedRelationships(rels: EntityRelationship[]): Map<string, EntityRelationship[]> {
+    const map = new Map<string, EntityRelationship[]>();
+    for (const r of rels) {
+      const list = map.get(r.type) || [];
+      list.push(r);
+      map.set(r.type, list);
+    }
+    return map;
+  }
+
+  function relativeTime(dateStr: string | null | undefined): string {
+    if (!dateStr) return "";
+    const date = new Date(dateStr);
+    const now = new Date();
+    const diffMs = now.getTime() - date.getTime();
+    const diffMins = Math.floor(diffMs / 60000);
+    if (diffMins < 1) return "just now";
+    if (diffMins < 60) return `${diffMins}m ago`;
+    const diffHrs = Math.floor(diffMins / 60);
+    if (diffHrs < 24) return `${diffHrs}h ago`;
+    const diffDays = Math.floor(diffHrs / 24);
+    if (diffDays < 30) return `${diffDays}d ago`;
+    const diffWeeks = Math.floor(diffDays / 7);
+    if (diffWeeks < 8) return `${diffWeeks}w ago`;
+    const diffMonths = Math.floor(diffDays / 30);
+    return `${diffMonths}mo ago`;
+  }
+
+  function confidenceLabel(c: "high" | "medium" | "low"): string {
+    return c === "high" ? "Strong" : c === "medium" ? "Moderate" : "Weak";
+  }
+
+  function confidenceIcon(c: "high" | "medium" | "low"): string {
+    return c === "high" ? "🟢" : c === "medium" ? "🟡" : "🔴";
+  }
+
+  function sourceIcon(source: string | undefined): string {
+    return source === "stated" ? "▐" : "┊";
+  }
+
+  function sourceLabel(source: string | undefined): string {
+    return source === "stated" ? "Stated" : "Inferred";
+  }
+
+  let displayMemories = $derived(
+    detail?.memories
+      ? showAllMemories ? detail.memories : detail.memories.slice(0, 5)
+      : []
+  );
+
+  let displayEdges = $derived(
+    showAllConnections ? edges : edges.slice(0, 15)
+  );
+
+  let relGroups = $derived(
+    detail?.relationships ? groupedRelationships(detail.relationships) : new Map()
+  );
+</script>
+
+<div class="node-card">
+  <!-- Header -->
+  <div class="card-header">
+    <div class="header-main">
+      <span class="community-dot" style="background: {communityColor}"></span>
+      <h3 class="entity-name">{node.id}</h3>
+      {#if detail}
+        <span class="confidence-badge" title="{confidenceLabel(detail.confidence)} confidence">
+          {confidenceIcon(detail.confidence)}
+        </span>
+      {/if}
+      <button class="close-btn" onclick={onClose}>&times;</button>
+    </div>
+    <div class="header-meta">
+      <span class="meta-community">{communityName}</span>
+      <span class="meta-separator">·</span>
+      <span class="meta-pagerank" title="PageRank">PR {node.pagerank.toFixed(4)}</span>
+      <span class="meta-separator">·</span>
+      <span class="meta-connections">{edges.length} connections</span>
+    </div>
+    {#if node.labels.length > 0}
+      <div class="header-labels">
+        {#each node.labels as label}
+          <span class="label-tag">{label}</span>
+        {/each}
+      </div>
+    {/if}
+  </div>
+
+  {#if detailLoading}
+    <div class="loading-indicator">
+      <span class="loading-dot"></span>
+      Loading entity details...
+    </div>
+  {/if}
+
+  <!-- Tab navigation -->
+  <div class="tab-bar">
+    <button
+      class="tab-btn"
+      class:active={activeTab === "memories"}
+      onclick={() => activeTab = "memories"}
+    >
+      Memories {detail?.memories?.length ? `(${detail.memories.length})` : ""}
+    </button>
+    <button
+      class="tab-btn"
+      class:active={activeTab === "connections"}
+      onclick={() => activeTab = "connections"}
+    >
+      Connections ({edges.length})
+    </button>
+  </div>
+
+  <!-- Memories tab -->
+  {#if activeTab === "memories"}
+    <div class="tab-content">
+      {#if displayMemories.length > 0}
+        <div class="memory-list">
+          {#each displayMemories as mem}
+            <div class="memory-item" class:stated={mem.source === "stated"}>
+              <div class="memory-header">
+                <span class="memory-source" title="{sourceLabel(mem.source)}">
+                  {sourceIcon(mem.source)}
+                </span>
+                <span class="memory-confidence">{(mem.score * 100).toFixed(0)}%</span>
+                {#if mem.created_at}
+                  <span class="memory-age">{relativeTime(mem.created_at)}</span>
+                {/if}
+                {#if mem.agent_id}
+                  <span class="memory-agent">{mem.agent_id}</span>
+                {/if}
+              </div>
+              <p class="memory-text">{mem.text}</p>
+            </div>
+          {/each}
+        </div>
+        {#if detail && detail.memories.length > 5}
+          <button class="show-more-btn" onclick={() => showAllMemories = !showAllMemories}>
+            {showAllMemories ? "Show less" : `Show all ${detail.memories.length}`}
+          </button>
+        {/if}
+      {:else if !detailLoading}
+        <div class="empty-state">No memories found for this entity</div>
+      {/if}
+    </div>
+  {/if}
+
+  <!-- Connections tab -->
+  {#if activeTab === "connections"}
+    <div class="tab-content">
+      {#if detail && relGroups.size > 0}
+        <div class="relationship-groups">
+          {#each [...relGroups.entries()] as [type, rels]}
+            <div class="rel-group">
+              <div class="rel-group-header">
+                <span class="rel-type-badge">{type}</span>
+                <span class="rel-count">{rels.length}</span>
+              </div>
+              <div class="rel-targets">
+                {#each rels.slice(0, showAllConnections ? rels.length : 5) as rel}
+                  <button
+                    class="rel-target"
+                    class:incoming={rel.direction === "in"}
+                    onclick={() => onNodeClick(rel.target)}
+                  >
+                    <span class="rel-arrow">{rel.direction === "out" ? "→" : "←"}</span>
+                    {rel.target}
+                  </button>
+                {/each}
+                {#if rels.length > 5 && !showAllConnections}
+                  <span class="overflow-label">+{rels.length - 5} more</span>
+                {/if}
+              </div>
+            </div>
+          {/each}
+        </div>
+      {:else}
+        <!-- Fallback to edge-based view if detail not loaded -->
+        <div class="connection-list">
+          {#each displayEdges as edge}
+            <div class="connection-row">
+              <span class="edge-type">{edge.rel_type}</span>
+              <button
+                class="connection-target"
+                onclick={() => onNodeClick(edge.source === node.id ? edge.target : edge.source)}
+              >
+                {edge.source === node.id ? edge.target : edge.source}
+              </button>
+            </div>
+          {/each}
+          {#if edges.length > 15 && !showAllConnections}
+            <button class="show-more-btn" onclick={() => showAllConnections = true}>
+              Show all {edges.length}
+            </button>
+          {/if}
+        </div>
+      {/if}
+    </div>
+  {/if}
+
+  <!-- Actions -->
+  <div class="card-actions">
+    {#if confirmDelete}
+      <div class="confirm-row">
+        <span class="confirm-label">Delete "{node.id}"?</span>
+        <button class="action-btn danger" onclick={async () => { await onDelete(node.id); confirmDelete = false; }}>
+          Confirm
+        </button>
+        <button class="action-btn" onclick={() => confirmDelete = false}>Cancel</button>
+      </div>
+    {:else}
+      <button class="action-btn danger-outline" onclick={() => confirmDelete = true}>Delete</button>
+    {/if}
+    <div class="merge-row">
+      <input
+        class="merge-input"
+        type="text"
+        placeholder="Merge into..."
+        bind:value={mergeTarget}
+      />
+      <button
+        class="action-btn primary"
+        disabled={!mergeTarget.trim()}
+        onclick={async () => {
+          const ok = await onMerge(node.id, mergeTarget.trim());
+          if (ok) mergeTarget = "";
+        }}
+      >Merge</button>
+    </div>
+  </div>
+</div>
+
+<style>
+  .node-card {
+    position: absolute;
+    bottom: 12px;
+    left: 12px;
+    width: 360px;
+    max-height: calc(100vh - 120px);
+    background: var(--bg-elevated);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    display: flex;
+    flex-direction: column;
+    z-index: 20;
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+  }
+
+  /* Header */
+  .card-header {
+    padding: 14px 14px 10px;
+    border-bottom: 1px solid var(--border);
+    flex-shrink: 0;
+  }
+
+  .header-main {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+
+  .community-dot {
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    flex-shrink: 0;
+  }
+
+  .entity-name {
+    font-size: 16px;
+    font-weight: 600;
+    margin: 0;
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .confidence-badge {
+    font-size: 12px;
+    flex-shrink: 0;
+  }
+
+  .close-btn {
+    background: none;
+    border: none;
+    color: var(--text-muted);
+    font-size: 18px;
+    cursor: pointer;
+    padding: 0 4px;
+    line-height: 1;
+    flex-shrink: 0;
+  }
+  .close-btn:hover { color: var(--text); }
+
+  .header-meta {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    margin-top: 4px;
+    font-size: 11px;
+    color: var(--text-muted);
+  }
+
+  .meta-separator { opacity: 0.4; }
+
+  .meta-community {
+    color: var(--text-secondary);
+    font-weight: 500;
+  }
+
+  .meta-pagerank {
+    font-family: var(--font-mono);
+    font-size: 10px;
+  }
+
+  .header-labels {
+    display: flex;
+    gap: 4px;
+    margin-top: 6px;
+    flex-wrap: wrap;
+  }
+
+  .label-tag {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    padding: 1px 6px;
+    border-radius: 4px;
+    font-size: 10px;
+    color: var(--text-secondary);
+  }
+
+  /* Loading */
+  .loading-indicator {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 10px 14px;
+    font-size: 11px;
+    color: var(--text-muted);
+  }
+
+  .loading-dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: var(--accent);
+    animation: pulse 1s infinite;
+  }
+
+  @keyframes pulse {
+    0%, 100% { opacity: 0.3; }
+    50% { opacity: 1; }
+  }
+
+  /* Tabs */
+  .tab-bar {
+    display: flex;
+    border-bottom: 1px solid var(--border);
+    flex-shrink: 0;
+  }
+
+  .tab-btn {
+    flex: 1;
+    background: none;
+    border: none;
+    border-bottom: 2px solid transparent;
+    color: var(--text-muted);
+    padding: 8px 12px;
+    font-size: 12px;
+    font-weight: 500;
+    cursor: pointer;
+    transition: all 0.15s;
+  }
+
+  .tab-btn:hover {
+    color: var(--text);
+    background: var(--surface);
+  }
+
+  .tab-btn.active {
+    color: var(--accent);
+    border-bottom-color: var(--accent);
+  }
+
+  /* Tab content */
+  .tab-content {
+    flex: 1;
+    overflow-y: auto;
+    padding: 10px 14px;
+    min-height: 80px;
+    max-height: 300px;
+  }
+
+  /* Memories */
+  .memory-list {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .memory-item {
+    padding: 8px 10px;
+    background: var(--surface);
+    border-radius: var(--radius-sm);
+    border-left: 3px solid var(--border);
+  }
+
+  .memory-item.stated {
+    border-left-color: var(--accent);
+  }
+
+  .memory-header {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    margin-bottom: 4px;
+    font-size: 10px;
+  }
+
+  .memory-source {
+    font-family: var(--font-mono);
+    font-size: 14px;
+    line-height: 1;
+    color: var(--text-muted);
+  }
+
+  .memory-confidence {
+    font-family: var(--font-mono);
+    color: var(--text-muted);
+    font-weight: 600;
+  }
+
+  .memory-age {
+    color: var(--text-muted);
+    margin-left: auto;
+  }
+
+  .memory-agent {
+    background: var(--bg-elevated);
+    border: 1px solid var(--border);
+    padding: 0 4px;
+    border-radius: 3px;
+    font-size: 9px;
+    color: var(--text-secondary);
+    text-transform: uppercase;
+  }
+
+  .memory-text {
+    margin: 0;
+    font-size: 12px;
+    line-height: 1.4;
+    color: var(--text-secondary);
+    overflow: hidden;
+    display: -webkit-box;
+    -webkit-line-clamp: 3;
+    -webkit-box-orient: vertical;
+  }
+
+  /* Relationships */
+  .relationship-groups {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+
+  .rel-group-header {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    margin-bottom: 4px;
+  }
+
+  .rel-type-badge {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    color: var(--text-secondary);
+    background: var(--surface);
+    border: 1px solid var(--border);
+    padding: 1px 6px;
+    border-radius: 4px;
+    font-weight: 600;
+  }
+
+  .rel-count {
+    font-size: 10px;
+    color: var(--text-muted);
+  }
+
+  .rel-targets {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+    padding-left: 4px;
+  }
+
+  .rel-target {
+    background: none;
+    border: none;
+    color: var(--accent);
+    font-size: 12px;
+    cursor: pointer;
+    padding: 2px 4px;
+    border-radius: 3px;
+    transition: background 0.1s;
+  }
+
+  .rel-target:hover {
+    background: var(--surface);
+    text-decoration: underline;
+  }
+
+  .rel-target.incoming {
+    color: var(--text-secondary);
+  }
+
+  .rel-arrow {
+    font-size: 10px;
+    margin-right: 2px;
+    opacity: 0.5;
+  }
+
+  .overflow-label {
+    font-size: 11px;
+    color: var(--text-muted);
+    padding: 2px 4px;
+  }
+
+  /* Fallback connection list */
+  .connection-list {
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+  }
+
+  .connection-row {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 12px;
+  }
+
+  .edge-type {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    color: var(--text-muted);
+    min-width: 80px;
+  }
+
+  .connection-target {
+    background: none;
+    border: none;
+    color: var(--accent);
+    cursor: pointer;
+    font-size: 12px;
+    padding: 0;
+  }
+  .connection-target:hover { text-decoration: underline; }
+
+  /* Empty */
+  .empty-state {
+    text-align: center;
+    color: var(--text-muted);
+    font-size: 12px;
+    padding: 20px 0;
+  }
+
+  /* Show more */
+  .show-more-btn {
+    display: block;
+    width: 100%;
+    background: none;
+    border: none;
+    color: var(--accent);
+    font-size: 11px;
+    cursor: pointer;
+    padding: 6px 0;
+    text-align: center;
+  }
+  .show-more-btn:hover { text-decoration: underline; }
+
+  /* Actions */
+  .card-actions {
+    padding: 10px 14px;
+    border-top: 1px solid var(--border);
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    flex-shrink: 0;
+  }
+
+  .confirm-row {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+  }
+
+  .confirm-label {
+    font-size: 12px;
+    color: var(--red);
+    font-weight: 600;
+    flex: 1;
+  }
+
+  .action-btn {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    color: var(--text-secondary);
+    padding: 4px 12px;
+    border-radius: var(--radius-sm);
+    font-size: 11px;
+    cursor: pointer;
+    transition: all 0.15s;
+  }
+  .action-btn:hover { color: var(--text); border-color: var(--text-muted); }
+  .action-btn:disabled { opacity: 0.4; cursor: default; }
+
+  .action-btn.danger {
+    background: var(--red);
+    border-color: var(--red);
+    color: #fff;
+  }
+
+  .action-btn.danger-outline {
+    border-color: var(--red);
+    color: var(--red);
+    background: none;
+  }
+  .action-btn.danger-outline:hover {
+    background: var(--red);
+    color: #fff;
+  }
+
+  .action-btn.primary {
+    border-color: var(--accent);
+    color: var(--accent);
+  }
+  .action-btn.primary:hover {
+    background: var(--accent);
+    color: #fff;
+  }
+
+  .merge-row {
+    display: flex;
+    gap: 6px;
+  }
+
+  .merge-input {
+    flex: 1;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    color: var(--text);
+    padding: 4px 8px;
+    font-size: 11px;
+    font-family: var(--font-sans);
+  }
+  .merge-input:focus { outline: none; border-color: var(--accent); }
+
+  @media (max-width: 768px) {
+    .node-card {
+      width: calc(100% - 24px);
+      bottom: 8px;
+      left: 8px;
+      max-height: 60vh;
+    }
+  }
+</style>

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -194,8 +194,12 @@ export interface EntityRelationship {
 }
 
 export interface EntityMemory {
+  id?: string;
   text: string;
   score: number;
+  created_at?: string | null;
+  agent_id?: string | null;
+  source?: "stated" | "inferred" | string;
 }
 
 export interface EntityDetail {


### PR DESCRIPTION
Replace the minimal info-panel overlay with a rich NodeCard component.

## Changes

### NodeCard.svelte (new, 702 lines)
- **Tabbed layout**: Memories tab and Connections tab with proper scroll containment
- **Memory items**: confidence %, relative age ("3d ago"), source agent badge, stated vs inferred indicator (solid vs dashed left border)
- **Relationships**: grouped by type (KNOWS, PART_OF, etc.) with directional arrows (→/←) and count per group
- **Confidence badge**: 🟢🟡🔴 in header alongside community name (resolved from meta)
- **Expandable lists**: show more/less toggles for both memories (5 default, expand to all) and connections (15 default)
- **Actions**: delete with confirmation dialog, merge with target input
- **Card design**: shadow box with proper z-index, mobile responsive (full-width on small screens)

### Sidecar (routes.py)
- Entity detail endpoint returns richer memory metadata: `created_at`, `agent_id`, `source`
- Increased memory results from 5 to 10, threshold from 0.5 to 0.4

### GraphView.svelte
- Extracted 290 lines of inline panel markup + styles into NodeCard component
- Removed unused `connectedNodes` dependency
- Clean prop interface: node, detail, communityName, communityColor, edges, callbacks

### Types (types.ts)
- `EntityMemory` extended with `id`, `created_at`, `agent_id`, `source` fields

Completes Spec 09 Phase 5. All foundation phases (1-7) now done.