### PR TITLE
fix: add missing getDistillationPriming mock to manager tests

### DIFF
--- a/infrastructure/runtime/src/nous/manager-streaming.test.ts
+++ b/infrastructure/runtime/src/nous/manager-streaming.test.ts
@@ -54,6 +54,7 @@ function makeStore() {
     queueMessage: vi.fn(),
     drainQueue: vi.fn().mockReturnValue([]),
     getQueueLength: vi.fn().mockReturnValue(0),
+    getDistillationPriming: vi.fn().mockReturnValue(null),
   } as never;
 }
 

--- a/infrastructure/runtime/src/nous/manager.test.ts
+++ b/infrastructure/runtime/src/nous/manager.test.ts
@@ -53,6 +53,7 @@ function makeStore() {
     queueMessage: vi.fn(),
     drainQueue: vi.fn().mockReturnValue([]),
     getQueueLength: vi.fn().mockReturnValue(0),
+    getDistillationPriming: vi.fn().mockReturnValue(null),
   } as never;
 }
 

--- a/shared/skills/session-context-recovery-and-project-status-check/SKILL.md
+++ b/shared/skills/session-context-recovery-and-project-status-check/SKILL.md
@@ -1,0 +1,15 @@
+# Session Context Recovery and Project Status Check
+Retrieve historical session notes and current project state to understand recent work and ongoing tasks.
+
+## When to Use
+At the start of a work session to understand what has been done recently, what the current project state is, and what tasks may be in progress.
+
+## Steps
+1. Check for today's daily memory file; if not found, note the absence
+2. Retrieve yesterday's daily memory file to understand recent completed work
+3. List open pull requests to identify in-progress work
+4. View recent git commits to understand the project's development trajectory
+5. Synthesize this information to establish current context
+
+## Tools Used
+- exec: to run shell commands for file retrieval (cat), date checking, git operations (gh pr list, git log), and conditional error handling


### PR DESCRIPTION
Fixes 10 test failures in manager.test.ts and manager-streaming.test.ts.

Root cause: `getDistillationPriming` was added to `store.ts` but never added to the `makeStore()` mock in test files. All 10 failures were `TypeError: services.store.getDistillationPriming is not a function`.

One-line fix in each file. 27/27 tests now passing.