### PR TITLE
feat: backup script + hot-reload routing + Spec 16 close-out

### DIFF
--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -12,7 +12,6 @@ that evolve with the system.
 
 | # | Spec | Status | Remaining |
 |---|------|--------|-----------|
-| 16 | [Efficiency](16_efficiency.md) | 5/6 phases | Hot-reload config (5) |
 | 4 | [Cost-Aware Orchestration](04_cost-aware-orchestration.md) | 4/5 phases | Cost visibility UI (5) |
 
 ### In Progress
@@ -26,7 +25,7 @@ that evolve with the system.
 
 | # | Spec | Status | Scope | Value |
 |---|------|--------|-------|-------|
-| 21 | [Agent Portability](21_agent-portability.md) | Draft | Export/import, backups, time-travel | **High** — no backup story exists |
+| 21 | [Agent Portability](21_agent-portability.md) | Draft | Export/import, backups, time-travel | **High** — basic `aletheia-backup` script exists, needs structured export/import |
 | 18 | [Extensibility](18_extensibility.md) | Draft | Hooks, custom commands, plugins | **High** — opens the platform |
 | 5 | [Plug-and-Play Onboarding](05_plug-and-play-onboarding.md) | Draft | Agent scaffolding, CLI, wizard | **Medium** — needed for public adoption |
 
@@ -48,30 +47,30 @@ that evolve with the system.
 
 ### Priority Order
 
-**Tier 1 — Close out (1 phase each):**
-1. **16** Efficiency — hot-reload config
-2. **4** Cost-Aware Orchestration — cost visibility UI
+**Tier 1 — Close out (1 phase):**
+1. **4** Cost-Aware Orchestration — cost visibility UI
 
 **Tier 2 — Active work:**
-3. **3** Auth & Updates — release workflow, auth wiring, login UI
-4. **20** Security Hardening — sandbox, audit trail, encryption
+2. **3** Auth & Updates — release workflow, auth wiring, login UI
+3. **20** Security Hardening — sandbox, audit trail, encryption
 
 **Tier 3 — Next up:**
-5. **21** Agent Portability — backup/export is genuinely missing
-6. **18** Extensibility — hooks + commands open the platform
-7. **5** Onboarding — needed for public adoption
+4. **21** Agent Portability — structured export/import (basic backup exists)
+5. **18** Extensibility — hooks + commands open the platform
+6. **5** Onboarding — needed for public adoption
 
 **Tier 4 — Future / research:**
-8. **25** Integrated IDE
-9. **26** Recursive Self-Improvement
-10. **27** Embedding Space Intelligence
-11. **22** Interop & Workflows — A2A premature per Cody
-12. **24** Aletheia Linux — long-term
+7. **25** Integrated IDE
+8. **26** Recursive Self-Improvement
+9. **27** Embedding Space Intelligence
+10. **22** Interop & Workflows — A2A premature per Cody
+11. **24** Aletheia Linux — long-term
 
 ## Implemented (Archived)
 
 | Spec | Implemented | Summary |
 |------|-------------|---------|
+| [Efficiency](archive/16_efficiency.md) | PRs #75, #94 | Parallel tools, token audit, truncation, dynamic thinking, hot-reload config, prompt cache stability |
 | [Graph Visualization](archive/09_graph-visualization.md) | PRs #56, #90, #91 | 2D/3D graph, node cards, communities, search, health audit, drift detection, context lookup |
 | [Knowledge Graph](archive/07_knowledge-graph.md) | PRs #61, #85, #86 | Vector recall, Neo4j degradation, sufficiency gates, entity CRUD, tool memory |
 | [Chat Output Quality](archive/11_chat-output-quality.md) | PR #86 | Narration filter, cost badge, GFM checkboxes, rich components |
@@ -92,7 +91,7 @@ that evolve with the system.
 | [Tool Call Governance](archive/spec-tool-call-governance.md) | PR #22 | Approval gates, timeouts, LoopDetector |
 | [Distillation Persistence](archive/spec-distillation-memory-persistence.md) | Hooks | Workspace flush on distillation |
 
-**Score: 19 archived, 4 in progress, 8 draft/skeleton.**
+**Score: 20 archived, 3 in progress, 8 draft/skeleton.**
 
 ## Conventions
 

--- a/docs/specs/archive/16_efficiency.md
+++ b/docs/specs/archive/16_efficiency.md
@@ -1,6 +1,6 @@
 # Spec: Efficiency — Parallel Execution & Token Economy
 
-**Status:** Phases 1-4, 6 done. Phase 5 (hot-reload config) remaining.
+**Status:** All phases complete. Archived.
 **Author:** Syn
 **Date:** 2026-02-21
 
@@ -348,7 +348,7 @@ When users see that a single `exec` result consumed 2,400 tokens of context, the
 | **2d** | Dynamic thinking budget | Small | ✅ Done — message-length heuristic + tool-loop reduction (30% on iterations 2+) |
 | **3** | Parallel sub-agent dispatch | Medium | ✅ Done — `sessions_dispatch` batch tool, Promise.allSettled, timing metrics |
 | **4** ✅ | Per-tool cost visibility | Small | ✅ Done — token stats every 8th turn (cache rate, last turn), per-tool token estimates in ToolPanel (PR #75) |
-| **5** | Hot-reload config (F-3) | Medium | File watcher on config.yaml → SIGUSR1-style reload without restart. Agent additions, model changes, binding updates live. |
+| **5** ✅ | Hot-reload config (F-3) | Medium | ✅ Done — File watcher + reload endpoint + routing cache rebuild + event bus broadcast to UI. Agent additions, model changes, binding updates all live without restart. |
 | **6** | Prompt cache stability audit (F-18) | Small | Audit bootstrap assembly for cache invalidation patterns — ensure static blocks stay stable across turns to maximize Anthropic cache hits |
 
 ---

--- a/shared/bin/aletheia-backup
+++ b/shared/bin/aletheia-backup
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# aletheia-backup — Create a timestamped backup of all Aletheia state.
+#
+# Backs up: config, sessions DB, agent workspaces, shared config/bin.
+# Optionally includes Qdrant and Neo4j data (--full).
+#
+# Usage:
+#   aletheia-backup              # Core backup (~50MB)
+#   aletheia-backup --full       # Core + vector/graph data (~600MB)
+#   aletheia-backup --dest /path # Custom destination
+#   aletheia-backup --list       # List existing backups
+
+set -euo pipefail
+
+ALETHEIA_ROOT="${ALETHEIA_ROOT:-/mnt/ssd/aletheia}"
+CONFIG_DIR="${ALETHEIA_CONFIG_DIR:-$HOME/.aletheia}"
+BACKUP_DIR="${ALETHEIA_BACKUP_DIR:-$ALETHEIA_ROOT/backups}"
+TIMESTAMP=$(date +%Y%m%d-%H%M%S)
+FULL=false
+
+# --- Parse args ---
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --full)  FULL=true; shift ;;
+    --dest)  BACKUP_DIR="$2"; shift 2 ;;
+    --list)
+      if [[ -d "$BACKUP_DIR" ]]; then
+        echo "Backups in $BACKUP_DIR:"
+        ls -lh "$BACKUP_DIR"/*.tar.gz 2>/dev/null || echo "  (none)"
+      else
+        echo "No backup directory at $BACKUP_DIR"
+      fi
+      exit 0
+      ;;
+    -h|--help)
+      echo "Usage: aletheia-backup [--full] [--dest DIR] [--list]"
+      echo ""
+      echo "Options:"
+      echo "  --full   Include Qdrant + Neo4j data (~600MB vs ~50MB)"
+      echo "  --dest   Custom backup destination (default: $ALETHEIA_ROOT/backups)"
+      echo "  --list   List existing backups"
+      exit 0
+      ;;
+    *) echo "Unknown option: $1"; exit 1 ;;
+  esac
+done
+
+mkdir -p "$BACKUP_DIR"
+
+BACKUP_NAME="aletheia-${TIMESTAMP}"
+if $FULL; then
+  BACKUP_NAME="aletheia-full-${TIMESTAMP}"
+fi
+BACKUP_FILE="$BACKUP_DIR/${BACKUP_NAME}.tar.gz"
+
+echo "=== Aletheia Backup ==="
+echo "Timestamp: $TIMESTAMP"
+echo "Mode:      $($FULL && echo 'full (core + data)' || echo 'core')"
+echo "Dest:      $BACKUP_FILE"
+echo ""
+
+# --- Safely copy SQLite (checkpoint WAL first) ---
+TEMP_DIR=$(mktemp -d)
+trap 'rm -rf "$TEMP_DIR"' EXIT
+
+DB_FILE="$CONFIG_DIR/sessions.db"
+if [[ -f "$DB_FILE" ]]; then
+  echo "→ Checkpointing SQLite WAL..."
+  sqlite3 "$DB_FILE" "PRAGMA wal_checkpoint(TRUNCATE);" 2>/dev/null || true
+  cp "$DB_FILE" "$TEMP_DIR/sessions.db"
+  echo "  sessions.db: $(du -h "$TEMP_DIR/sessions.db" | cut -f1)"
+else
+  echo "⚠ sessions.db not found at $DB_FILE"
+fi
+
+# --- Stage files into a clean tree ---
+STAGE_DIR=$(mktemp -d)
+trap 'rm -rf "$TEMP_DIR" "$STAGE_DIR"' EXIT
+
+# Config files
+mkdir -p "$STAGE_DIR/config"
+if [[ -f "$CONFIG_DIR/aletheia.json" ]]; then
+  cp "$CONFIG_DIR/aletheia.json" "$STAGE_DIR/config/"
+  echo "→ Config: aletheia.json"
+fi
+if [[ -f "$TEMP_DIR/sessions.db" ]]; then
+  cp "$TEMP_DIR/sessions.db" "$STAGE_DIR/config/"
+fi
+for f in aletheia.env tools.yaml; do
+  [[ -f "$CONFIG_DIR/$f" ]] && cp "$CONFIG_DIR/$f" "$STAGE_DIR/config/"
+done
+if [[ -d "$CONFIG_DIR/credentials" ]]; then
+  cp -r "$CONFIG_DIR/credentials" "$STAGE_DIR/config/"
+  echo "→ Credentials"
+fi
+
+# Agent workspaces (symlink to avoid copy)
+if [[ -d "$ALETHEIA_ROOT/nous" ]]; then
+  SIZE=$(du -sh "$ALETHEIA_ROOT/nous" | cut -f1)
+  echo "→ Agent workspaces: $SIZE"
+  ln -s "$ALETHEIA_ROOT/nous" "$STAGE_DIR/nous"
+fi
+
+# Shared config + bin
+if [[ -d "$ALETHEIA_ROOT/shared" ]]; then
+  SIZE=$(du -sh "$ALETHEIA_ROOT/shared" | cut -f1)
+  echo "→ Shared (config/bin): $SIZE"
+  ln -s "$ALETHEIA_ROOT/shared" "$STAGE_DIR/shared"
+fi
+
+# Full mode: vector + graph data
+if $FULL; then
+  mkdir -p "$STAGE_DIR/data"
+  if [[ -d "$ALETHEIA_ROOT/data/qdrant" ]]; then
+    SIZE=$(du -sh "$ALETHEIA_ROOT/data/qdrant" | cut -f1)
+    echo "→ Qdrant data: $SIZE"
+    ln -s "$ALETHEIA_ROOT/data/qdrant" "$STAGE_DIR/data/qdrant"
+  fi
+  if [[ -d "$ALETHEIA_ROOT/data/neo4j" ]]; then
+    SIZE=$(du -sh "$ALETHEIA_ROOT/data/neo4j" | cut -f1)
+    echo "→ Neo4j data: $SIZE"
+    ln -s "$ALETHEIA_ROOT/data/neo4j" "$STAGE_DIR/data/neo4j"
+  fi
+fi
+
+echo ""
+echo "→ Creating archive..."
+tar czf "$BACKUP_FILE" -C "$STAGE_DIR" --dereference .
+
+SIZE=$(du -h "$BACKUP_FILE" | cut -f1)
+echo ""
+echo "✓ Backup complete: $BACKUP_FILE ($SIZE)"
+
+# --- Retention: keep last 10 backups ---
+BACKUP_COUNT=$(ls -1 "$BACKUP_DIR"/aletheia*.tar.gz 2>/dev/null | wc -l)
+if [[ $BACKUP_COUNT -gt 10 ]]; then
+  EXCESS=$((BACKUP_COUNT - 10))
+  echo ""
+  echo "→ Pruning $EXCESS old backup(s) (keeping last 10)..."
+  ls -1t "$BACKUP_DIR"/aletheia*.tar.gz | tail -n "$EXCESS" | xargs rm -f
+fi
+
+echo ""
+echo "Restore with:"
+echo "  tar xzf $BACKUP_FILE -C /mnt/ssd/aletheia"
+echo "  cp /mnt/ssd/aletheia/config/sessions.db ~/.aletheia/"
+echo "  cp /mnt/ssd/aletheia/config/aletheia.json ~/.aletheia/"


### PR DESCRIPTION
Three quick wins:

**1. `aletheia-backup` script**
- Core mode: config + sqlite (WAL checkpoint) + agent workspaces + shared = ~8MB
- Full mode (`--full`): adds Qdrant + Neo4j data = ~600MB
- 10-backup retention with auto-prune
- `--list` to see existing backups
- Restore instructions printed after each run

**2. Config hot-reload routing fix**
- `rebuildRoutingCache()` now runs on config reload (was startup-only)
- Both file watcher and `POST /api/config/reload` paths covered
- `config:reloaded` event broadcast to UI via SSE
- Extracted `extractBindings()` helper to deduplicate 3 copies

**3. Spec 16 archived**
- All 6 phases complete (parallel tools, token audit, truncation, thinking budget, hot-reload, cache stability)
- Score: 20 archived, 3 in progress, 8 draft

Also cleaned up BACKLOG.md (local, not in repo) — removed stale Letta/Eiron/Arbor/6-agent references.