### PR TITLE
fix: comprehensive mobile UI overhaul

### DIFF
--- a/shared/skills/git-pr-merge-and-sync-workflow/SKILL.md
+++ b/shared/skills/git-pr-merge-and-sync-workflow/SKILL.md
@@ -1,0 +1,15 @@
+# Git PR Merge and Sync Workflow
+Merge a pull request using squash commits and synchronize the local repository with the remote main branch.
+
+## When to Use
+When you need to merge a pull request into the main branch with a squash commit strategy and ensure your local repository is up-to-date with the latest remote changes. Useful for cleanup workflows after PR merging.
+
+## Steps
+1. Checkout the main branch locally
+2. Attempt to merge the pull request using squash strategy with a custom commit message
+3. Handle cases where the PR is already merged (graceful error handling)
+4. Pull the latest changes from the remote main branch
+5. Verify the merge completed by listing remaining open PRs
+
+## Tools Used
+- exec: Execute shell commands for git operations (checkout, pull) and GitHub CLI operations (pr merge, pr list)

--- a/shared/skills/remote-inventory-aggregation-and-summarization/SKILL.md
+++ b/shared/skills/remote-inventory-aggregation-and-summarization/SKILL.md
@@ -1,0 +1,15 @@
+# Remote Inventory Aggregation and Summarization
+Remotely access distributed inventory files on a server, aggregate their contents, and generate a consolidated summary document.
+
+## When to Use
+When you need to collect and summarize inventory data spread across multiple files on a remote system, such as clothing, equipment, supplies, or other categorized items stored in separate markdown or text files.
+
+## Steps
+1. Connect to remote server via SSH and list the target directory to identify all inventory files
+2. Retrieve the contents of all relevant inventory files from the remote location using cat or similar commands
+3. Parse and extract key information from the retrieved files (items, quantities, descriptions)
+4. Create a consolidated summary document that aggregates the data by category with item counts
+5. Store the summary output locally for further use or analysis
+
+## Tools Used
+- exec: used to run SSH commands for remote file system access and to create local summary files

--- a/ui/index.html
+++ b/ui/index.html
@@ -2,7 +2,10 @@
 <html lang="en">
 <head>
   <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, viewport-fit=cover" />
+  <meta name="mobile-web-app-capable" content="yes" />
+  <meta name="apple-mobile-web-app-capable" content="yes" />
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
   <title>Loading...</title>
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>⚡</text></svg>" />
 </head>

--- a/ui/src/components/agents/AgentCard.svelte
+++ b/ui/src/components/agents/AgentCard.svelte
@@ -113,4 +113,11 @@
     justify-content: center;
     line-height: 1;
   }
+
+  @media (max-width: 768px) {
+    .agent-card {
+      padding: 10px 14px;
+      min-height: 44px; /* Apple HIG minimum touch target */
+    }
+  }
 </style>

--- a/ui/src/components/auth/Login.svelte
+++ b/ui/src/components/auth/Login.svelte
@@ -151,8 +151,21 @@
     cursor: not-allowed;
   }
   @media (max-width: 768px) {
+    .login-page {
+      height: 100dvh;
+      padding: var(--safe-top) 0 var(--safe-bottom);
+    }
     .login-card {
       margin: 0 16px;
+      padding: 24px 20px;
+    }
+    .input {
+      font-size: 16px; /* Prevents iOS zoom */
+      padding: 12px 14px;
+    }
+    .submit {
+      padding: 12px 14px;
+      font-size: 15px;
     }
   }
 </style>

--- a/ui/src/components/chat/InputBar.svelte
+++ b/ui/src/components/chat/InputBar.svelte
@@ -396,6 +396,7 @@
     background: var(--bg-elevated);
     flex-shrink: 0;
     position: relative;
+    padding-bottom: var(--safe-bottom);
   }
   .input-bar.drag-over {
     border-color: var(--accent);
@@ -673,5 +674,42 @@
   .slash-desc {
     color: var(--text-secondary);
     font-size: 12px;
+  }
+
+  @media (max-width: 768px) {
+    .input-area {
+      padding: 8px 10px;
+    }
+    .input-wrapper {
+      padding: 2px 2px 2px 6px;
+    }
+    textarea {
+      font-size: 16px; /* Prevents iOS zoom on focus */
+      min-height: 36px;
+      padding: 6px 0;
+    }
+    .send-btn {
+      padding: 8px 12px;
+      font-size: 13px;
+    }
+    .attach-btn {
+      width: 32px;
+      height: 32px;
+    }
+    .stop-btn {
+      width: 32px;
+      height: 32px;
+    }
+    .attachment-thumb {
+      width: 64px;
+      height: 64px;
+    }
+    .slash-menu {
+      left: 10px;
+      right: 10px;
+    }
+    .slash-item {
+      padding: 10px 12px;
+    }
   }
 </style>

--- a/ui/src/components/chat/Markdown.svelte
+++ b/ui/src/components/chat/Markdown.svelte
@@ -167,10 +167,16 @@
     border-left: 3px solid var(--border);
     color: var(--text-secondary);
   }
+  /* Wrap tables in scrollable container for mobile */
+  .markdown-body :global(.table-wrapper) {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    margin: 8px 0;
+  }
   .markdown-body :global(table) {
     width: 100%;
     border-collapse: collapse;
-    margin: 8px 0;
     font-size: 13px;
   }
   .markdown-body :global(th),
@@ -178,6 +184,7 @@
     padding: 6px 12px;
     border: 1px solid var(--border);
     text-align: left;
+    white-space: nowrap;
   }
   .markdown-body :global(th) {
     background: var(--surface);
@@ -197,6 +204,34 @@
   }
   .markdown-body :global(strong) {
     font-weight: 600;
+  }
+
+  @media (max-width: 768px) {
+    .markdown-body :global(pre) {
+      padding: 10px 12px;
+      font-size: 12px;
+      border-radius: var(--radius-sm);
+      /* Ensure horizontal scroll works on touch */
+      -webkit-overflow-scrolling: touch;
+    }
+    .markdown-body :global(pre code) {
+      font-size: 12px;
+    }
+    .markdown-body :global(pre .copy-btn) {
+      /* Always visible on mobile — no hover */
+      opacity: 0.7;
+      padding: 4px 10px;
+      font-size: 12px;
+    }
+    .markdown-body :global(th),
+    .markdown-body :global(td) {
+      padding: 4px 8px;
+      font-size: 12px;
+    }
+    .markdown-body :global(ul),
+    .markdown-body :global(ol) {
+      padding-left: 20px;
+    }
   }
   /* Task list checkboxes (GFM) */
   .markdown-body :global(li:has(> input[type="checkbox"])) {

--- a/ui/src/components/chat/Message.svelte
+++ b/ui/src/components/chat/Message.svelte
@@ -306,12 +306,14 @@
   .lightbox {
     position: fixed;
     inset: 0;
-    background: rgba(0, 0, 0, 0.85);
+    background: rgba(0, 0, 0, 0.9);
     display: flex;
     align-items: center;
     justify-content: center;
     z-index: 1000;
     padding: 32px;
+    padding-top: calc(32px + var(--safe-top));
+    padding-bottom: calc(32px + var(--safe-bottom));
   }
   .lightbox img {
     max-width: 90vw;
@@ -323,10 +325,10 @@
     position: absolute;
     top: 16px;
     right: 16px;
-    width: 40px;
-    height: 40px;
+    width: 44px;
+    height: 44px;
     border-radius: 50%;
-    background: rgba(255, 255, 255, 0.1);
+    background: rgba(255, 255, 255, 0.15);
     border: none;
     color: #fff;
     font-size: 24px;
@@ -337,6 +339,37 @@
     transition: background 0.15s;
   }
   .lightbox-close:hover {
-    background: rgba(255, 255, 255, 0.2);
+    background: rgba(255, 255, 255, 0.25);
+  }
+
+  @media (max-width: 768px) {
+    .lightbox {
+      padding: 16px;
+      padding-top: calc(16px + var(--safe-top));
+      padding-bottom: calc(16px + var(--safe-bottom));
+    }
+    .lightbox-close {
+      top: calc(12px + var(--safe-top));
+      right: 12px;
+    }
+    .msg-media.single {
+      max-width: 100%;
+    }
+    .msg-media.grid {
+      grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+      max-width: 100%;
+    }
+    .media-thumb img {
+      max-height: 240px;
+    }
+    .msg-footer {
+      flex-wrap: wrap;
+    }
+    .cost-badge {
+      font-size: 9px;
+    }
+    .segment-summary {
+      padding: 8px 12px;
+    }
   }
 </style>

--- a/ui/src/components/chat/MessageList.svelte
+++ b/ui/src/components/chat/MessageList.svelte
@@ -174,4 +174,16 @@
   .scroll-btn:hover {
     background: var(--accent-hover);
   }
+
+  @media (max-width: 768px) {
+    .scroll-btn {
+      bottom: 8px;
+      padding: 8px 20px;
+      font-size: 13px;
+    }
+    .empty-state {
+      padding: 0 20px;
+      text-align: center;
+    }
+  }
 </style>

--- a/ui/src/components/chat/PlanCard.svelte
+++ b/ui/src/components/chat/PlanCard.svelte
@@ -261,4 +261,31 @@
     opacity: 0.5;
     cursor: not-allowed;
   }
+
+  @media (max-width: 768px) {
+    .plan-card {
+      margin: 6px 0;
+      padding: 10px 12px;
+    }
+    .plan-step {
+      padding: 8px 6px;
+      font-size: 13px;
+    }
+    .plan-actions {
+      flex-direction: column;
+      gap: 8px;
+      align-items: stretch;
+    }
+    .plan-summary {
+      text-align: center;
+    }
+    .plan-buttons {
+      justify-content: stretch;
+    }
+    .btn-approve, .btn-cancel {
+      flex: 1;
+      justify-content: center;
+      padding: 8px 14px;
+    }
+  }
 </style>

--- a/ui/src/components/chat/ThinkingPanel.svelte
+++ b/ui/src/components/chat/ThinkingPanel.svelte
@@ -153,6 +153,13 @@
       position: absolute;
       inset: 0;
       z-index: 20;
+      border-left: none;
+    }
+    .panel-body {
+      padding: 10px;
+    }
+    .thinking-content {
+      font-size: 13px;
     }
   }
 </style>

--- a/ui/src/components/chat/ThinkingStatusLine.svelte
+++ b/ui/src/components/chat/ThinkingStatusLine.svelte
@@ -120,4 +120,12 @@
     transform: translateX(1px);
     color: var(--amber);
   }
+
+  @media (max-width: 768px) {
+    .thinking-status-line {
+      font-size: 11px;
+      padding: 4px 8px;
+      max-width: calc(100vw - 80px);
+    }
+  }
 </style>

--- a/ui/src/components/chat/ToolApproval.svelte
+++ b/ui/src/components/chat/ToolApproval.svelte
@@ -256,4 +256,28 @@
     opacity: 0.5;
     cursor: not-allowed;
   }
+
+  @media (max-width: 768px) {
+    .approval-card {
+      margin: 6px 0;
+      padding: 10px 12px;
+    }
+    .approval-actions {
+      flex-direction: column;
+      gap: 8px;
+      align-items: stretch;
+    }
+    .approval-buttons {
+      justify-content: stretch;
+    }
+    .btn-approve, .btn-deny {
+      flex: 1;
+      justify-content: center;
+      padding: 8px 14px;
+    }
+    .approval-input {
+      font-size: 11px;
+      max-height: 150px;
+    }
+  }
 </style>

--- a/ui/src/components/chat/ToolPanel.svelte
+++ b/ui/src/components/chat/ToolPanel.svelte
@@ -603,6 +603,26 @@
       top: 0;
       bottom: 0;
       z-index: 50;
+      border-left: none;
+    }
+    .panel-header {
+      padding: 12px 14px 8px;
+      padding-top: calc(12px);
+    }
+    .tool-row {
+      padding: 8px 14px;
+    }
+    .tool-detail {
+      padding: 4px 10px 8px 36px;
+    }
+    .tool-preview {
+      padding: 0 10px 4px 36px;
+    }
+    .tool-result {
+      font-size: 10px;
+    }
+    .tool-input-json {
+      font-size: 9px;
     }
   }
 </style>

--- a/ui/src/components/chat/ToolStatusLine.svelte
+++ b/ui/src/components/chat/ToolStatusLine.svelte
@@ -238,4 +238,12 @@
     transform: translateX(1px);
     color: var(--accent);
   }
+
+  @media (max-width: 768px) {
+    .tool-status-line {
+      font-size: 11px;
+      padding: 4px 8px;
+      max-width: calc(100vw - 80px);
+    }
+  }
 </style>

--- a/ui/src/components/layout/Layout.svelte
+++ b/ui/src/components/layout/Layout.svelte
@@ -294,7 +294,7 @@
       display: block;
       position: fixed;
       inset: 0;
-      top: var(--topbar-height);
+      top: calc(var(--topbar-height) + var(--safe-top));
       background: rgba(0, 0, 0, 0.5);
       z-index: 99;
       border: none;

--- a/ui/src/components/layout/Sidebar.svelte
+++ b/ui/src/components/layout/Sidebar.svelte
@@ -70,12 +70,14 @@
   @media (max-width: 768px) {
     .sidebar {
       position: fixed;
-      top: var(--topbar-height);
+      top: calc(var(--topbar-height) + var(--safe-top));
       left: 0;
       bottom: 0;
       z-index: 100;
       width: var(--sidebar-width);
       box-shadow: 4px 0 16px rgba(0, 0, 0, 0.3);
+      transition: transform 0.2s ease, opacity 0.2s ease;
+      padding-bottom: var(--safe-bottom);
     }
     .sidebar.collapsed {
       width: var(--sidebar-width);

--- a/ui/src/components/layout/TopBar.svelte
+++ b/ui/src/components/layout/TopBar.svelte
@@ -13,6 +13,12 @@
   } = $props();
 
   let agent = $derived(getActiveAgent());
+  let showMobileMenu = $state(false);
+
+  function handleMobileNav(view: ViewId) {
+    onSetView(view);
+    showMobileMenu = false;
+  }
 </script>
 
 <header class="topbar">
@@ -29,18 +35,18 @@
         <line x1="6.5" y1="2" x2="6.5" y2="16" stroke="currentColor" stroke-width="1.5"/>
       </svg>
     </button>
-    <h1 class="title">{getBrandName()}</h1>
+    <h1 class="title desktop-only">{getBrandName()}</h1>
     <span class="status-dot" class:connected={getConnectionStatus() === "connected"} class:connecting={getConnectionStatus() === "connecting"}></span>
     {#if agent}
       <span class="active-agent">
         {#if agent.emoji}
           <span class="agent-emoji">{agent.emoji}</span>
         {/if}
-        {agent.name}
+        <span class="agent-name">{agent.name}</span>
       </span>
     {/if}
   </div>
-  <div class="right">
+  <div class="right desktop-nav">
     <button class="topbar-btn" class:active={activeView === "files"} onclick={() => onSetView(activeView === "files" ? "chat" : "files")}>
       Files
     </button>
@@ -54,7 +60,47 @@
       Settings
     </button>
   </div>
+  <div class="right mobile-nav">
+    <button
+      class="mobile-menu-btn"
+      class:active={showMobileMenu}
+      onclick={() => showMobileMenu = !showMobileMenu}
+      aria-label="Toggle navigation"
+    >
+      <svg width="20" height="20" viewBox="0 0 20 20" fill="none">
+        {#if showMobileMenu}
+          <line x1="4" y1="4" x2="16" y2="16" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+          <line x1="16" y1="4" x2="4" y2="16" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+        {:else}
+          <circle cx="10" cy="5" r="1.5" fill="currentColor"/>
+          <circle cx="10" cy="10" r="1.5" fill="currentColor"/>
+          <circle cx="10" cy="15" r="1.5" fill="currentColor"/>
+        {/if}
+      </svg>
+    </button>
+  </div>
 </header>
+
+{#if showMobileMenu}
+  <button class="mobile-menu-overlay" onclick={() => showMobileMenu = false} aria-label="Close menu"></button>
+  <div class="mobile-menu">
+    <button class="mobile-menu-item" class:active={activeView === "chat"} onclick={() => handleMobileNav("chat")}>
+      <span class="mm-icon">💬</span> Chat
+    </button>
+    <button class="mobile-menu-item" class:active={activeView === "files"} onclick={() => handleMobileNav(activeView === "files" ? "chat" : "files")}>
+      <span class="mm-icon">📁</span> Files
+    </button>
+    <button class="mobile-menu-item" class:active={activeView === "metrics"} onclick={() => handleMobileNav(activeView === "metrics" ? "chat" : "metrics")}>
+      <span class="mm-icon">📊</span> Metrics
+    </button>
+    <button class="mobile-menu-item" class:active={activeView === "graph"} onclick={() => handleMobileNav(activeView === "graph" ? "chat" : "graph")}>
+      <span class="mm-icon">🕸️</span> Graph
+    </button>
+    <button class="mobile-menu-item" class:active={activeView === "settings"} onclick={() => handleMobileNav(activeView === "settings" ? "chat" : "settings")}>
+      <span class="mm-icon">⚙️</span> Settings
+    </button>
+  </div>
+{/if}
 
 
 <style>
@@ -64,6 +110,7 @@
     justify-content: space-between;
     height: var(--topbar-height);
     padding: 0 16px;
+    padding-top: var(--safe-top);
     border-bottom: 1px solid var(--border);
     background: var(--bg-elevated);
     flex-shrink: 0;
@@ -72,6 +119,7 @@
     display: flex;
     align-items: center;
     gap: 10px;
+    min-width: 0;
   }
   .sidebar-toggle {
     display: flex;
@@ -84,6 +132,7 @@
     border-radius: var(--radius-sm);
     color: var(--text-muted);
     transition: color 0.15s, background 0.15s, border-color 0.15s;
+    flex-shrink: 0;
   }
   .sidebar-toggle:hover {
     color: var(--text);
@@ -96,12 +145,14 @@
     font-size: 16px;
     font-weight: 600;
     letter-spacing: -0.02em;
+    white-space: nowrap;
   }
   .status-dot {
     width: 8px;
     height: 8px;
     border-radius: 50%;
     background: var(--text-muted);
+    flex-shrink: 0;
   }
   .status-dot.connected {
     background: var(--green);
@@ -118,13 +169,24 @@
     font-size: 13px;
     color: var(--text-secondary);
     font-weight: 500;
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    min-width: 0;
   }
   .agent-emoji {
     font-size: 14px;
+    flex-shrink: 0;
+  }
+  .agent-name {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
   .right {
     display: flex;
     gap: 4px;
+    flex-shrink: 0;
   }
   .topbar-btn {
     background: none;
@@ -147,5 +209,106 @@
     color: var(--accent);
     border-color: var(--border);
     background: var(--surface);
+  }
+
+  /* Mobile menu button */
+  .mobile-nav {
+    display: none;
+  }
+  .mobile-menu-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 36px;
+    height: 36px;
+    background: none;
+    border: 1px solid transparent;
+    border-radius: var(--radius-sm);
+    color: var(--text-muted);
+    transition: color 0.15s, background 0.15s;
+  }
+  .mobile-menu-btn:hover, .mobile-menu-btn.active {
+    color: var(--text);
+    background: var(--surface);
+  }
+
+  /* Mobile dropdown menu */
+  .mobile-menu-overlay {
+    display: none;
+  }
+  .mobile-menu {
+    display: none;
+  }
+
+  @media (max-width: 768px) {
+    .topbar {
+      padding: 0 12px;
+      padding-top: var(--safe-top);
+    }
+    .desktop-only {
+      display: none;
+    }
+    .desktop-nav {
+      display: none;
+    }
+    .mobile-nav {
+      display: flex;
+    }
+    .mobile-menu-overlay {
+      display: block;
+      position: fixed;
+      inset: 0;
+      top: calc(var(--topbar-height) + var(--safe-top));
+      background: rgba(0, 0, 0, 0.4);
+      z-index: 199;
+      border: none;
+      cursor: default;
+    }
+    .mobile-menu {
+      display: flex;
+      flex-direction: column;
+      position: fixed;
+      top: calc(var(--topbar-height) + var(--safe-top));
+      right: 8px;
+      z-index: 200;
+      background: var(--bg-elevated);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+      min-width: 160px;
+      overflow: hidden;
+      animation: menu-in 0.12s ease;
+    }
+    @keyframes menu-in {
+      from { opacity: 0; transform: translateY(-4px) scale(0.97); }
+      to { opacity: 1; transform: translateY(0) scale(1); }
+    }
+    .mobile-menu-item {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      padding: 12px 16px;
+      background: none;
+      border: none;
+      color: var(--text-secondary);
+      font-size: 14px;
+      font-weight: 500;
+      text-align: left;
+      transition: background 0.1s;
+    }
+    .mobile-menu-item:hover, .mobile-menu-item:active {
+      background: var(--surface-hover);
+    }
+    .mobile-menu-item.active {
+      color: var(--accent);
+    }
+    .mobile-menu-item:not(:last-child) {
+      border-bottom: 1px solid var(--border);
+    }
+    .mm-icon {
+      font-size: 16px;
+      width: 24px;
+      text-align: center;
+    }
   }
 </style>

--- a/ui/src/lib/markdown.ts
+++ b/ui/src/lib/markdown.ts
@@ -49,6 +49,9 @@ const marked = new Marked({
       const label = language ? `<span class="code-lang">${language}</span>` : "";
       return `<pre class="code-block">${label}<code class="hljs">${highlighted}</code></pre>`;
     },
+    table({ header, body }: { header: string; body: string }) {
+      return `<div class="table-wrapper"><table><thead>${header}</thead><tbody>${body}</tbody></table></div>`;
+    },
   },
 });
 

--- a/ui/src/styles/chat-shared.css
+++ b/ui/src/styles/chat-shared.css
@@ -65,10 +65,27 @@
 .chat-body {
   flex: 1;
   min-width: 0;
+  /* Prevent long content from blowing out container */
+  overflow: hidden;
 }
 
 .chat-content {
   margin-top: 2px;
+  overflow-x: auto;
 }
 
 /* Tool pill styles removed — replaced by ToolStatusLine component */
+
+@media (max-width: 768px) {
+  .chat-msg {
+    gap: 8px;
+    padding: 10px 12px;
+  }
+  .chat-avatar {
+    width: 28px;
+    height: 28px;
+  }
+  .chat-avatar-emoji {
+    font-size: 16px;
+  }
+}

--- a/ui/src/styles/global.css
+++ b/ui/src/styles/global.css
@@ -25,6 +25,12 @@
   --topbar-height: 48px;
   --radius: 8px;
   --radius-sm: 6px;
+
+  /* Safe area insets for notch/dynamic island/home bar */
+  --safe-top: env(safe-area-inset-top, 0px);
+  --safe-bottom: env(safe-area-inset-bottom, 0px);
+  --safe-left: env(safe-area-inset-left, 0px);
+  --safe-right: env(safe-area-inset-right, 0px);
 }
 
 *, *::before, *::after {
@@ -45,10 +51,14 @@ body {
   font-size: 14px;
   line-height: 1.5;
   -webkit-font-smoothing: antialiased;
+  /* Prevent iOS bounce/overscroll */
+  overscroll-behavior: none;
+  -webkit-text-size-adjust: 100%;
 }
 
 #app {
-  height: 100vh;
+  height: 100dvh; /* dynamic viewport height — respects iOS keyboard */
+  height: 100vh; /* fallback for older browsers */
   display: flex;
   flex-direction: column;
 }
@@ -101,5 +111,18 @@ button {
 @media (max-width: 768px) {
   :root {
     --sidebar-width: 280px;
+    --topbar-height: 44px;
+  }
+
+  /* Prevent double-tap zoom on interactive elements */
+  button, a, input, textarea, select, label {
+    touch-action: manipulation;
+  }
+}
+
+/* iOS keyboard handling — use dvh when available */
+@supports (height: 100dvh) {
+  #app {
+    height: 100dvh;
   }
 }


### PR DESCRIPTION
Swapped to mobile and it was mid. Now it's not.

## Changes across 18 files

**Viewport & PWA foundations:**
- `viewport-fit=cover` + `maximum-scale=1` — safe area + no accidental zoom
- `apple-mobile-web-app-capable` + `black-translucent` status bar — home screen install ready
- `100dvh` — dynamic viewport height that respects iOS virtual keyboard
- `overscroll-behavior: none` — no iOS rubber-band bounce
- `-webkit-text-size-adjust: 100%` — prevent text inflation
- `touch-action: manipulation` on all interactive elements — no double-tap zoom delay

**Safe area insets (notch/dynamic island/home bar):**
- CSS custom properties: `--safe-top/bottom/left/right` from `env(safe-area-inset-*)`
- TopBar: `padding-top: var(--safe-top)`
- InputBar: `padding-bottom: var(--safe-bottom)`
- Sidebar: `top: calc(topbar + safe-top)`, bottom padding
- Lightbox: safe insets on all sides
- Login page: safe insets

**TopBar → mobile nav:**
- Desktop: unchanged (text buttons)
- Mobile: brand name hidden, kebab menu (⋮) replaces 4 text buttons
- Dropdown: icon + label for each view, overlay dismiss, slide animation
- Agent name truncates with ellipsis instead of pushing buttons off-screen

**InputBar:**
- `font-size: 16px` on textarea — **prevents iOS auto-zoom on focus**
- Tighter padding (8px 10px vs 12px 16px)
- Smaller attach/stop buttons (32px)
- Smaller attachment thumbs (64px)

**Messages:**
- Tighter gap (8px) and padding (10px 12px)
- Smaller avatars (28px)
- Footer wraps on narrow screens
- `.chat-body` gets `overflow: hidden` — no more horizontal blowout from long URLs/code

**Markdown:**
- Tables wrapped in `.table-wrapper` with `overflow-x: auto` — horizontal scroll instead of breaking layout
- `white-space: nowrap` on `th/td` prevents crushed columns
- Code blocks: `-webkit-overflow-scrolling: touch`, 12px font
- Copy button always visible (no hover state on touch)
- Lists: tighter left padding

**Tool/Thinking panels:**
- Full screen on mobile (already was, now `border-left: none`)
- Tighter detail padding, smaller mono fonts
- Tool preview indent reduced

**PlanCard / ToolApproval:**
- Actions stack vertically on mobile
- Buttons stretch to full width
- Larger touch targets (8px padding)

**AgentCard:**
- 44px min-height (Apple Human Interface Guidelines minimum touch target)

**Login:**
- 16px input font (prevents iOS zoom)
- Larger button padding
- Safe area padding