### PR TITLE
feat: declarative hook system (Spec 18 Phase 1)

### DIFF
--- a/docs/specs/18_extensibility.md
+++ b/docs/specs/18_extensibility.md
@@ -1,6 +1,6 @@
 # Spec: Extensibility — Hooks, Commands & Plugins
 
-**Status:** Draft
+**Status:** Phase 1 done (feat/hook-system). Phases 2-6 remaining.
 **Author:** Syn
 **Date:** 2026-02-21
 **Source:** Gap Analysis F-2, F-12, F-24, F-25, F-27, F-37

--- a/infrastructure/runtime/src/koina/hooks.test.ts
+++ b/infrastructure/runtime/src/koina/hooks.test.ts
@@ -1,0 +1,558 @@
+// Hook system tests
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  substituteTemplateVars,
+  parseSimpleYaml,
+  loadHookDefinitions,
+  executeShellHook,
+  registerHooks,
+  type HookDefinition,
+} from "./hooks.js";
+
+vi.mock("./logger.js", () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+// --- Template substitution ---
+
+describe("substituteTemplateVars", () => {
+  it("replaces simple variables", () => {
+    const result = substituteTemplateVars(
+      "Session {{sessionId}} for {{nousId}}",
+      { sessionId: "ses_123", nousId: "syn" },
+    );
+    expect(result).toBe("Session ses_123 for syn");
+  });
+
+  it("replaces nested dot-notation variables", () => {
+    const result = substituteTemplateVars(
+      "{{session.id}} at {{session.timestamp}}",
+      { session: { id: "ses_42", timestamp: "2026-02-22" } },
+    );
+    expect(result).toBe("ses_42 at 2026-02-22");
+  });
+
+  it("replaces missing variables with empty string", () => {
+    const result = substituteTemplateVars(
+      "Hello {{name}}, your {{missing}} is ready",
+      { name: "Cody" },
+    );
+    expect(result).toBe("Hello Cody, your  is ready");
+  });
+
+  it("serializes object values as JSON", () => {
+    const result = substituteTemplateVars(
+      "Data: {{payload}}",
+      { payload: { a: 1, b: 2 } },
+    );
+    expect(result).toBe('Data: {"a":1,"b":2}');
+  });
+
+  it("handles numeric values", () => {
+    const result = substituteTemplateVars(
+      "Tokens: {{tokens}}",
+      { tokens: 1500 },
+    );
+    expect(result).toBe("Tokens: 1500");
+  });
+
+  it("handles boolean values", () => {
+    const result = substituteTemplateVars(
+      "Active: {{active}}",
+      { active: true },
+    );
+    expect(result).toBe("Active: true");
+  });
+
+  it("returns input unchanged when no template vars present", () => {
+    const result = substituteTemplateVars("no vars here", { foo: "bar" });
+    expect(result).toBe("no vars here");
+  });
+
+  it("handles null/undefined in nested path gracefully", () => {
+    const result = substituteTemplateVars(
+      "Value: {{deep.nested.path}}",
+      { deep: null },
+    );
+    expect(result).toBe("Value: ");
+  });
+});
+
+// --- Simple YAML parser ---
+
+describe("parseSimpleYaml", () => {
+  it("parses flat key-value pairs", () => {
+    const yaml = `
+name: my-hook
+event: turn:after
+enabled: true
+`;
+    const result = parseSimpleYaml(yaml);
+    expect(result).toEqual({
+      name: "my-hook",
+      event: "turn:after",
+      enabled: true,
+    });
+  });
+
+  it("parses nested objects", () => {
+    const yaml = `
+name: test-hook
+event: distill:after
+handler:
+  type: shell
+  command: /usr/bin/echo
+  timeout: 10s
+  failAction: warn
+`;
+    const result = parseSimpleYaml(yaml);
+    expect(result).toEqual({
+      name: "test-hook",
+      event: "distill:after",
+      handler: {
+        type: "shell",
+        command: "/usr/bin/echo",
+        timeout: "10s",
+        failAction: "warn",
+      },
+    });
+  });
+
+  it("parses inline arrays", () => {
+    const yaml = `
+name: filtered-hook
+nousFilter: [syn, demiurge]
+`;
+    const result = parseSimpleYaml(yaml);
+    expect(result).toEqual({
+      name: "filtered-hook",
+      nousFilter: ["syn", "demiurge"],
+    });
+  });
+
+  it("parses inline arrays with quoted strings", () => {
+    const yaml = `
+name: args-hook
+handler:
+  command: /bin/test
+  args: ["{{sessionId}}", "{{nousId}}"]
+`;
+    const result = parseSimpleYaml(yaml);
+    expect(result?.handler).toEqual({
+      command: "/bin/test",
+      args: ["{{sessionId}}", "{{nousId}}"],
+    });
+  });
+
+  it("strips comments", () => {
+    const yaml = `
+name: commented  # this is a comment
+event: boot:ready  # another comment
+`;
+    const result = parseSimpleYaml(yaml);
+    expect(result).toEqual({
+      name: "commented",
+      event: "boot:ready",
+    });
+  });
+
+  it("handles numbers and booleans", () => {
+    const yaml = `
+count: 42
+ratio: 3.14
+active: true
+disabled: false
+`;
+    const result = parseSimpleYaml(yaml);
+    expect(result).toEqual({
+      count: 42,
+      ratio: 3.14,
+      active: true,
+      disabled: false,
+    });
+  });
+
+  it("handles quoted strings", () => {
+    const yaml = `
+name: "my hook"
+path: '/usr/local/bin'
+`;
+    const result = parseSimpleYaml(yaml);
+    expect(result).toEqual({
+      name: "my hook",
+      path: "/usr/local/bin",
+    });
+  });
+
+  it("returns null for empty content", () => {
+    expect(parseSimpleYaml("")).toBeNull();
+    expect(parseSimpleYaml("  \n  \n")).toBeNull();
+    expect(parseSimpleYaml("# just comments")).toBeNull();
+  });
+});
+
+// --- Shell execution ---
+
+describe("executeShellHook", () => {
+  it("executes a simple command and captures output", async () => {
+    const hook: HookDefinition = {
+      name: "test-echo",
+      event: "boot:ready",
+      handler: {
+        type: "shell",
+        command: "/bin/echo",
+        args: ["hello", "world"],
+        timeout: "5s",
+        failAction: "warn",
+        env: {},
+      },
+      enabled: true,
+    };
+
+    const result = await executeShellHook(hook, { timestamp: Date.now() });
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe("hello world");
+    expect(result.timedOut).toBe(false);
+    expect(result.durationMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it("captures non-zero exit codes", async () => {
+    const hook: HookDefinition = {
+      name: "test-fail",
+      event: "boot:ready",
+      handler: {
+        type: "shell",
+        command: "/bin/sh",
+        args: ["-c", "exit 2"],
+        timeout: "5s",
+        failAction: "warn",
+        env: {},
+      },
+      enabled: true,
+    };
+
+    const result = await executeShellHook(hook, {});
+    expect(result.exitCode).toBe(2);
+    expect(result.timedOut).toBe(false);
+  });
+
+  it("substitutes template variables in args", async () => {
+    const hook: HookDefinition = {
+      name: "test-vars",
+      event: "turn:after",
+      handler: {
+        type: "shell",
+        command: "/bin/echo",
+        args: ["{{nousId}}", "{{sessionId}}"],
+        timeout: "5s",
+        failAction: "warn",
+        env: {},
+      },
+      enabled: true,
+    };
+
+    const result = await executeShellHook(hook, {
+      nousId: "syn",
+      sessionId: "ses_42",
+    });
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe("syn ses_42");
+  });
+
+  it("passes event payload as JSON on stdin", async () => {
+    const hook: HookDefinition = {
+      name: "test-stdin",
+      event: "turn:after",
+      handler: {
+        type: "shell",
+        command: "/bin/cat",
+        args: [],
+        timeout: "5s",
+        failAction: "warn",
+        env: {},
+      },
+      enabled: true,
+    };
+
+    const payload = { nousId: "syn", tokens: 1500 };
+    const result = await executeShellHook(hook, payload);
+    expect(result.exitCode).toBe(0);
+    expect(JSON.parse(result.stdout)).toEqual(payload);
+  });
+
+  it("sets ALETHEIA_HOOK_NAME and ALETHEIA_HOOK_EVENT env vars", async () => {
+    const hook: HookDefinition = {
+      name: "test-env",
+      event: "distill:after",
+      handler: {
+        type: "shell",
+        command: "/bin/sh",
+        args: ["-c", "echo $ALETHEIA_HOOK_NAME:$ALETHEIA_HOOK_EVENT"],
+        timeout: "5s",
+        failAction: "warn",
+        env: {},
+      },
+      enabled: true,
+    };
+
+    const result = await executeShellHook(hook, {});
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe("test-env:distill:after");
+  });
+
+  it("passes custom env vars", async () => {
+    const hook: HookDefinition = {
+      name: "test-custom-env",
+      event: "boot:ready",
+      handler: {
+        type: "shell",
+        command: "/bin/sh",
+        args: ["-c", "echo $MY_VAR"],
+        timeout: "5s",
+        failAction: "warn",
+        env: { MY_VAR: "hello" },
+      },
+      enabled: true,
+    };
+
+    const result = await executeShellHook(hook, {});
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe("hello");
+  });
+
+  it("times out long-running commands", async () => {
+    const hook: HookDefinition = {
+      name: "test-timeout",
+      event: "boot:ready",
+      handler: {
+        type: "shell",
+        command: "/bin/sleep",
+        args: ["10"],
+        timeout: "100ms",
+        failAction: "warn",
+        env: {},
+      },
+      enabled: true,
+    };
+
+    const result = await executeShellHook(hook, {});
+    expect(result.timedOut).toBe(true);
+    expect(result.exitCode).toBeNull();
+  });
+
+  it("captures stderr on failure", async () => {
+    const hook: HookDefinition = {
+      name: "test-stderr",
+      event: "boot:ready",
+      handler: {
+        type: "shell",
+        command: "/bin/sh",
+        args: ["-c", "echo 'error msg' >&2; exit 1"],
+        timeout: "5s",
+        failAction: "warn",
+        env: {},
+      },
+      enabled: true,
+    };
+
+    const result = await executeShellHook(hook, {});
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toBe("error msg");
+  });
+});
+
+// --- YAML loading from directory ---
+
+describe("loadHookDefinitions", () => {
+  it("returns empty array for non-existent directory", () => {
+    const hooks = loadHookDefinitions("/nonexistent/path/hooks");
+    expect(hooks).toEqual([]);
+  });
+
+  it("loads valid hook YAML from a real directory", () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), "hooks-test-"));
+    try {
+      writeFileSync(
+        join(tmpDir, "test-hook.yaml"),
+        `name: test-hook
+event: turn:after
+handler:
+  type: shell
+  command: /bin/echo
+  args: ["hello"]
+  timeout: 5s
+  failAction: warn
+`,
+      );
+
+      const hooks = loadHookDefinitions(tmpDir);
+      expect(hooks).toHaveLength(1);
+      expect(hooks[0]!.name).toBe("test-hook");
+      expect(hooks[0]!.event).toBe("turn:after");
+      expect(hooks[0]!.handler.command).toBe("/bin/echo");
+    } finally {
+      rmSync(tmpDir, { recursive: true });
+    }
+  });
+
+  it("skips disabled hooks", () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), "hooks-test-"));
+    try {
+      writeFileSync(
+        join(tmpDir, "disabled.yaml"),
+        `name: disabled-hook
+event: boot:ready
+enabled: false
+handler:
+  type: shell
+  command: /bin/echo
+`,
+      );
+
+      const hooks = loadHookDefinitions(tmpDir);
+      expect(hooks).toHaveLength(0);
+    } finally {
+      rmSync(tmpDir, { recursive: true });
+    }
+  });
+
+  it("skips hooks with invalid event names", () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), "hooks-test-"));
+    try {
+      writeFileSync(
+        join(tmpDir, "bad-event.yaml"),
+        `name: bad-event-hook
+event: nonexistent:event
+handler:
+  type: shell
+  command: /bin/echo
+`,
+      );
+
+      const hooks = loadHookDefinitions(tmpDir);
+      expect(hooks).toHaveLength(0);
+    } finally {
+      rmSync(tmpDir, { recursive: true });
+    }
+  });
+
+  it("skips hooks with disallowed command extensions", () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), "hooks-test-"));
+    try {
+      writeFileSync(
+        join(tmpDir, "bad-ext.yaml"),
+        `name: bad-ext-hook
+event: boot:ready
+handler:
+  type: shell
+  command: /tmp/evil.exe
+`,
+      );
+
+      const hooks = loadHookDefinitions(tmpDir);
+      expect(hooks).toHaveLength(0);
+    } finally {
+      rmSync(tmpDir, { recursive: true });
+    }
+  });
+
+  it("loads multiple hooks from multiple files", () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), "hooks-test-"));
+    try {
+      writeFileSync(
+        join(tmpDir, "hook-a.yaml"),
+        `name: hook-a
+event: turn:before
+handler:
+  type: shell
+  command: /bin/echo
+`,
+      );
+      writeFileSync(
+        join(tmpDir, "hook-b.yml"),
+        `name: hook-b
+event: distill:after
+handler:
+  type: shell
+  command: /bin/echo
+`,
+      );
+
+      const hooks = loadHookDefinitions(tmpDir);
+      expect(hooks).toHaveLength(2);
+      const names = hooks.map((h) => h.name).sort();
+      expect(names).toEqual(["hook-a", "hook-b"]);
+    } finally {
+      rmSync(tmpDir, { recursive: true });
+    }
+  });
+
+  it("ignores non-yaml files", () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), "hooks-test-"));
+    try {
+      writeFileSync(join(tmpDir, "README.md"), "# not a hook");
+      writeFileSync(join(tmpDir, "notes.txt"), "not a hook either");
+      writeFileSync(
+        join(tmpDir, "real.yaml"),
+        `name: real-hook
+event: boot:ready
+handler:
+  type: shell
+  command: /bin/echo
+`,
+      );
+
+      const hooks = loadHookDefinitions(tmpDir);
+      expect(hooks).toHaveLength(1);
+      expect(hooks[0]!.name).toBe("real-hook");
+    } finally {
+      rmSync(tmpDir, { recursive: true });
+    }
+  });
+});
+
+// --- Hook registration ---
+
+describe("registerHooks", () => {
+  it("returns empty hooks array for non-existent directory", () => {
+    const registry = registerHooks("/nonexistent/path/hooks");
+    expect(registry.hooks).toEqual([]);
+    registry.teardown();
+  });
+
+  it("registers hooks onto event bus and teardown removes them", async () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), "hooks-test-"));
+    try {
+      writeFileSync(
+        join(tmpDir, "test.yaml"),
+        `name: bus-test
+event: boot:ready
+handler:
+  type: shell
+  command: /bin/echo
+  args: ["test"]
+`,
+      );
+
+      const { eventBus: bus } = await import("./event-bus.js");
+      const countBefore = bus.listenerCount("boot:ready");
+
+      const registry = registerHooks(tmpDir);
+      expect(registry.hooks).toHaveLength(1);
+      expect(bus.listenerCount("boot:ready")).toBe(countBefore + 1);
+
+      registry.teardown();
+      expect(bus.listenerCount("boot:ready")).toBe(countBefore);
+    } finally {
+      rmSync(tmpDir, { recursive: true });
+    }
+  });
+});

--- a/infrastructure/runtime/src/koina/hooks.ts
+++ b/infrastructure/runtime/src/koina/hooks.ts
@@ -1,0 +1,481 @@
+// Declarative hook system — YAML-defined shell hooks wired to the event bus
+//
+// Hook definitions live in shared/hooks/*.yaml. Each hook specifies:
+//   - event: which EventName to listen on
+//   - handler.command: shell command to execute
+//   - handler.args: template variables substituted from event payload
+//   - handler.timeout: max execution time (default 30s)
+//   - handler.failAction: warn | block | silent (default: warn)
+//   - nousFilter: optional list of nous IDs to restrict to
+//
+// Shell handlers receive the full event payload as JSON on stdin.
+// Exit codes: 0 = success, 1 = warning, 2+ = error.
+// Same protocol as Claude Code's hook system for ecosystem compatibility.
+
+import { execFile } from "node:child_process";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { join, extname } from "node:path";
+import { z } from "zod";
+import { createLogger } from "./logger.js";
+import { eventBus, type EventName, type EventPayload } from "./event-bus.js";
+
+const log = createLogger("hooks");
+
+// --- Schema ---
+
+const ALLOWED_EXTENSIONS = new Set([".sh", ".py", ".js", ".ts", ".rb", ".pl"]);
+
+const HandlerSchema = z.object({
+  type: z.literal("shell").default("shell"),
+  command: z.string().min(1),
+  args: z.array(z.string()).default([]),
+  timeout: z.string().default("30s"),
+  failAction: z.enum(["warn", "block", "silent"]).default("warn"),
+  env: z.record(z.string(), z.string()).default({}),
+  cwd: z.string().optional(),
+});
+
+const HookDefinitionSchema = z.object({
+  name: z.string().min(1),
+  event: z.string().min(1),
+  handler: HandlerSchema,
+  nousFilter: z.array(z.string()).optional(),
+  enabled: z.boolean().default(true),
+  description: z.string().optional(),
+});
+
+export type HookDefinition = z.infer<typeof HookDefinitionSchema>;
+
+// --- Template substitution ---
+
+/**
+ * Replace {{variable}} placeholders with values from the event payload.
+ * Nested access via dot notation: {{session.id}} → payload.session.id
+ * Missing variables resolve to empty string.
+ */
+export function substituteTemplateVars(
+  template: string,
+  payload: EventPayload,
+): string {
+  return template.replace(/\{\{(\w+(?:\.\w+)*)\}\}/g, (_match, path: string) => {
+    const parts = path.split(".");
+    let value: unknown = payload;
+    for (const part of parts) {
+      if (value == null || typeof value !== "object") return "";
+      value = (value as Record<string, unknown>)[part];
+    }
+    if (value == null) return "";
+    if (typeof value === "object") return JSON.stringify(value);
+    return String(value);
+  });
+}
+
+// --- Timeout parsing ---
+
+function parseTimeout(timeout: string): number {
+  const match = timeout.match(/^(\d+)(ms|s|m)?$/);
+  if (!match) return 30_000;
+  const value = parseInt(match[1]!, 10);
+  const unit = match[2] ?? "s";
+  switch (unit) {
+    case "ms": return value;
+    case "s":  return value * 1000;
+    case "m":  return value * 60_000;
+    default:   return value * 1000;
+  }
+}
+
+// --- Shell execution ---
+
+export interface HookResult {
+  hookName: string;
+  exitCode: number | null;
+  stdout: string;
+  stderr: string;
+  timedOut: boolean;
+  durationMs: number;
+}
+
+/**
+ * Execute a shell hook. The command receives event data as JSON on stdin.
+ * Returns a structured result regardless of success/failure.
+ */
+export async function executeShellHook(
+  hook: HookDefinition,
+  payload: EventPayload,
+): Promise<HookResult> {
+  const timeoutMs = parseTimeout(hook.handler.timeout);
+  const args = hook.handler.args.map((arg) =>
+    substituteTemplateVars(arg, payload),
+  );
+
+  const command = substituteTemplateVars(hook.handler.command, payload);
+  const stdinData = JSON.stringify(payload);
+  const start = Date.now();
+
+  return new Promise<HookResult>((resolveResult) => {
+    const child = execFile(
+      command,
+      args,
+      {
+        timeout: timeoutMs,
+        maxBuffer: 1024 * 1024, // 1MB
+        env: {
+          ...process.env,
+          ...hook.handler.env,
+          ALETHEIA_HOOK_NAME: hook.name,
+          ALETHEIA_HOOK_EVENT: hook.event,
+        },
+        cwd: hook.handler.cwd,
+      },
+      (error, stdout, stderr) => {
+        const durationMs = Date.now() - start;
+
+        // Node's execFile sets `killed: true` and `signal: 'SIGTERM'` on timeout
+        const errAny = error as NodeJS.ErrnoException & { killed?: boolean; signal?: string } | null;
+        const timedOut = errAny?.killed === true || errAny?.signal === "SIGTERM";
+
+        // exitCode: null if killed/timed out, otherwise from error or 0
+        let exitCode: number | null = null;
+        if (timedOut) {
+          exitCode = null;
+        } else if (error && "code" in error && typeof error.code === "number") {
+          exitCode = error.code;
+        } else if (!error) {
+          exitCode = 0;
+        }
+
+        resolveResult({
+          hookName: hook.name,
+          exitCode,
+          stdout: stdout.trim(),
+          stderr: stderr.trim(),
+          timedOut,
+          durationMs,
+        });
+      },
+    );
+
+    // Pipe event payload as JSON to stdin — ignore EPIPE if command doesn't read stdin
+    if (child.stdin) {
+      child.stdin.on("error", () => { /* EPIPE is expected for commands that don't read stdin */ });
+      child.stdin.write(stdinData);
+      child.stdin.end();
+    }
+  });
+}
+
+// --- YAML loading ---
+
+/**
+ * Load hook definitions from a directory of YAML files.
+ * Invalid files are logged and skipped, never crash boot.
+ */
+export function loadHookDefinitions(hooksDir: string): HookDefinition[] {
+  if (!existsSync(hooksDir)) {
+    log.debug(`Hooks directory not found: ${hooksDir}`);
+    return [];
+  }
+
+  const hooks: HookDefinition[] = [];
+  let files: string[];
+
+  try {
+    files = readdirSync(hooksDir).filter(
+      (f) => f.endsWith(".yaml") || f.endsWith(".yml"),
+    );
+  } catch (err) {
+    log.warn(`Cannot read hooks directory ${hooksDir}: ${err instanceof Error ? err.message : err}`);
+    return [];
+  }
+
+  for (const file of files) {
+    const filePath = join(hooksDir, file);
+    try {
+      const content = readFileSync(filePath, "utf-8");
+      // Simple YAML parsing — we use a minimal approach to avoid adding js-yaml dependency.
+      // Hook YAML is structured enough for JSON-compatible parsing after YAML→JSON conversion.
+      const parsed = parseSimpleYaml(content);
+      if (!parsed) {
+        log.warn(`Empty or unparseable hook file: ${file}`);
+        continue;
+      }
+
+      const result = HookDefinitionSchema.safeParse(parsed);
+      if (!result.success) {
+        log.warn(`Invalid hook definition in ${file}: ${result.error.message}`);
+        continue;
+      }
+
+      const hook = result.data;
+
+      // Validate command extension
+      const cmdExt = extname(hook.handler.command);
+      if (cmdExt && !ALLOWED_EXTENSIONS.has(cmdExt)) {
+        log.warn(`Hook ${hook.name}: command extension ${cmdExt} not in allowlist, skipping`);
+        continue;
+      }
+
+      // Validate event name is a known event
+      if (!isValidEventName(hook.event)) {
+        log.warn(`Hook ${hook.name}: unknown event '${hook.event}', skipping`);
+        continue;
+      }
+
+      if (!hook.enabled) {
+        log.info(`Hook ${hook.name}: disabled, skipping`);
+        continue;
+      }
+
+      hooks.push(hook);
+      log.info(`Loaded hook: ${hook.name} → ${hook.event}`);
+    } catch (err) {
+      log.warn(`Error loading hook file ${file}: ${err instanceof Error ? err.message : err}`);
+    }
+  }
+
+  return hooks;
+}
+
+// Known event names from the event bus
+const VALID_EVENTS: Set<string> = new Set([
+  "turn:before", "turn:after",
+  "tool:called", "tool:failed",
+  "distill:before", "distill:stage", "distill:after",
+  "session:created", "session:archived",
+  "memory:added", "memory:retracted",
+  "signal:received",
+  "boot:start", "boot:ready",
+  "config:reloaded",
+  "exec:denied",
+  "pipeline:error",
+  "history:orphan_repair",
+]);
+
+function isValidEventName(event: string): event is EventName {
+  return VALID_EVENTS.has(event);
+}
+
+// --- Minimal YAML parser ---
+// Handles the flat structure of hook definitions without requiring js-yaml.
+// Supports: scalars, arrays (inline and block), nested objects (one level),
+// and comments. NOT a full YAML parser — just enough for hook definitions.
+
+export function parseSimpleYaml(content: string): Record<string, unknown> | null {
+  const lines = content.split("\n");
+  const result: Record<string, unknown> = {};
+  let currentIndent = 0;
+  let nestedObj: Record<string, unknown> | null = null;
+  let nestedKey: string | null = null;
+  let arrayKey: string | null = null;
+  let arrayItems: Array<string | number | boolean> | null = null;
+
+  for (const rawLine of lines) {
+    const line = rawLine.replace(/#.*$/, ""); // strip comments
+    if (line.trim() === "") continue;
+
+    const indent = line.length - line.trimStart().length;
+    const trimmed = line.trim();
+
+    // Flush pending array if indent returns to base level
+    if (arrayKey && indent <= currentIndent && !trimmed.startsWith("-")) {
+      if (nestedObj && nestedKey) {
+        nestedObj[arrayKey] = arrayItems;
+      } else {
+        result[arrayKey] = arrayItems;
+      }
+      arrayKey = null;
+      arrayItems = null;
+    }
+
+    // Array item (block style)
+    if (trimmed.startsWith("- ") && arrayKey) {
+      arrayItems!.push(parseYamlValue(trimmed.slice(2).trim()));
+      continue;
+    }
+
+    // key: value pair
+    const kvMatch = trimmed.match(/^(\w+)\s*:\s*(.*)$/);
+    if (!kvMatch) continue;
+
+    const key = kvMatch[1]!;
+    const rawValue = kvMatch[2]!.trim();
+
+    // Nested object detection: key with no value, next lines indented
+    if (rawValue === "" || rawValue === "|" || rawValue === ">") {
+      // Close any pending nested object at same or lower indent
+      if (nestedObj && nestedKey && indent <= currentIndent) {
+        result[nestedKey] = nestedObj;
+        nestedObj = null;
+        nestedKey = null;
+      }
+
+      if (indent === 0) {
+        // Top-level nested object
+        nestedKey = key;
+        nestedObj = {};
+        currentIndent = indent;
+      }
+      continue;
+    }
+
+    // Inline array: [a, b, c]
+    if (rawValue.startsWith("[") && rawValue.endsWith("]")) {
+      const items = rawValue
+        .slice(1, -1)
+        .split(",")
+        .map((s) => parseYamlValue(s.trim()))
+        .filter((s) => s !== "");
+
+      if (nestedObj && indent > 0) {
+        nestedObj[key] = items;
+      } else {
+        if (nestedObj && nestedKey) {
+          result[nestedKey] = nestedObj;
+          nestedObj = null;
+          nestedKey = null;
+        }
+        result[key] = items;
+      }
+      continue;
+    }
+
+    // Block array start: key followed by - items on next lines
+    // We'll detect this when we see a "- " on the next iteration
+
+    // Regular value
+    const parsedValue = parseYamlValue(rawValue);
+
+    if (nestedObj && indent > 0) {
+      nestedObj[key] = parsedValue;
+    } else {
+      // Close nested object if returning to top level
+      if (nestedObj && nestedKey) {
+        result[nestedKey] = nestedObj;
+        nestedObj = null;
+        nestedKey = null;
+      }
+      result[key] = parsedValue;
+      currentIndent = indent;
+    }
+  }
+
+  // Flush any pending nested object or array
+  if (arrayKey) {
+    if (nestedObj && nestedKey) {
+      nestedObj[arrayKey] = arrayItems;
+    } else {
+      result[arrayKey] = arrayItems;
+    }
+  }
+  if (nestedObj && nestedKey) {
+    result[nestedKey] = nestedObj;
+  }
+
+  return Object.keys(result).length > 0 ? result : null;
+}
+
+function parseYamlValue(raw: string): string | number | boolean {
+  // Remove surrounding quotes
+  if ((raw.startsWith('"') && raw.endsWith('"')) || (raw.startsWith("'") && raw.endsWith("'"))) {
+    return raw.slice(1, -1);
+  }
+  if (raw === "true") return true;
+  if (raw === "false") return false;
+  if (/^-?\d+$/.test(raw)) return parseInt(raw, 10);
+  if (/^-?\d+\.\d+$/.test(raw)) return parseFloat(raw);
+  return raw;
+}
+
+// --- Registry ---
+
+export interface HookRegistry {
+  hooks: HookDefinition[];
+  teardown: () => void;
+}
+
+/**
+ * Register all hooks from a directory onto the event bus.
+ * Returns a teardown function to remove all listeners.
+ */
+export function registerHooks(hooksDir: string): HookRegistry {
+  const hooks = loadHookDefinitions(hooksDir);
+  const teardowns: Array<() => void> = [];
+
+  for (const hook of hooks) {
+    const handler = createHookHandler(hook);
+    const eventName = hook.event as EventName;
+    eventBus.on(eventName, handler);
+    teardowns.push(() => eventBus.off(eventName, handler));
+  }
+
+  if (hooks.length > 0) {
+    log.info(`Registered ${hooks.length} hook(s) from ${hooksDir}`);
+  }
+
+  return {
+    hooks,
+    teardown: () => {
+      for (const fn of teardowns) fn();
+      log.info("All hooks unregistered");
+    },
+  };
+}
+
+/**
+ * Create an event handler function for a hook definition.
+ * Handles nous filtering, execution, and error handling per failAction.
+ */
+function createHookHandler(hook: HookDefinition): (payload: EventPayload) => void {
+  return (payload: EventPayload) => {
+    // Nous filter — skip if payload.nousId doesn't match
+    if (hook.nousFilter && hook.nousFilter.length > 0) {
+      const nousId = payload["nousId"] as string | undefined;
+      if (nousId && !hook.nousFilter.includes(nousId)) {
+        return;
+      }
+    }
+
+    // Fire-and-forget — don't block the event bus
+    executeShellHook(hook, payload)
+      .then((result) => {
+        if (result.timedOut) {
+          if (hook.handler.failAction !== "silent") {
+            log.warn(`Hook ${hook.name} timed out after ${result.durationMs}ms`);
+          }
+          return;
+        }
+
+        if (result.exitCode === 0) {
+          log.debug(`Hook ${hook.name} completed in ${result.durationMs}ms`);
+          if (result.stdout) {
+            log.debug(`Hook ${hook.name} stdout: ${result.stdout.slice(0, 500)}`);
+          }
+          return;
+        }
+
+        // Non-zero exit
+        switch (hook.handler.failAction) {
+          case "silent":
+            break;
+          case "warn":
+            log.warn(
+              `Hook ${hook.name} exited ${result.exitCode}: ${result.stderr || result.stdout}`.slice(0, 500),
+            );
+            break;
+          case "block":
+            // In fire-and-forget mode, block can only log — blocking requires sync execution
+            // which the spec notes as a future enhancement. For now, treat as warn + error level.
+            log.error(
+              `Hook ${hook.name} BLOCKED (exit ${result.exitCode}): ${result.stderr || result.stdout}`.slice(0, 500),
+            );
+            break;
+        }
+      })
+      .catch((err) => {
+        if (hook.handler.failAction !== "silent") {
+          log.warn(`Hook ${hook.name} execution error: ${err instanceof Error ? err.message : err}`);
+        }
+      });
+  };
+}

--- a/shared/hooks/README.md
+++ b/shared/hooks/README.md
@@ -1,0 +1,108 @@
+# Hooks
+
+Declarative shell hooks that fire at runtime lifecycle events.
+
+## How It Works
+
+Drop a `.yaml` file in this directory. Each file defines a hook that runs a shell command when an event fires on the internal event bus. No TypeScript required.
+
+## Hook Definition Format
+
+```yaml
+name: my-hook              # unique identifier
+event: turn:after           # which event to listen on
+description: Log every turn # optional description
+enabled: true               # default: true. Set false to disable without deleting.
+
+handler:
+  type: shell               # currently only "shell" supported
+  command: /path/to/script  # absolute path to executable
+  args: ["{{sessionId}}", "{{nousId}}"]  # template variables from event payload
+  timeout: 30s              # max execution time (ms, s, m). Default: 30s
+  failAction: warn          # warn | block | silent. Default: warn
+  env:                      # optional extra environment variables
+    MY_VAR: my-value
+  cwd: /some/dir            # optional working directory
+
+# Optional: restrict to specific agents
+nousFilter: [demiurge, akron]
+```
+
+## Supported Events
+
+| Event | Payload Fields | When |
+|-------|---------------|------|
+| `turn:before` | nousId, sessionId, sessionKey, channel | Before API call |
+| `turn:after` | nousId, sessionId, inputTokens, outputTokens, toolCalls | After API response |
+| `tool:called` | nousId, sessionId, toolName, durationMs | Tool executed successfully |
+| `tool:failed` | nousId, sessionId, toolName, error, durationMs | Tool execution failed |
+| `distill:before` | sessionId, nousId, distillationNumber | Before context distillation |
+| `distill:after` | sessionId, nousId, distillationNumber, tokensBefore, tokensAfter, factsExtracted | After distillation |
+| `session:created` | sessionId, nousId | New session created |
+| `session:archived` | sessionId | Session archived |
+| `memory:added` | nousId, count | Facts extracted and stored |
+| `boot:start` | — | Runtime starting |
+| `boot:ready` | port, tools, plugins | Runtime ready |
+| `config:reloaded` | added, removed | Config hot-reloaded |
+
+## Handler Protocol
+
+Shell handlers receive the full event payload as JSON on **stdin**. This means your script can read structured data:
+
+```bash
+#!/bin/bash
+# Read event payload from stdin
+PAYLOAD=$(cat)
+SESSION_ID=$(echo "$PAYLOAD" | jq -r '.sessionId')
+echo "Processing session: $SESSION_ID"
+```
+
+**Environment variables** are always set:
+- `ALETHEIA_HOOK_NAME` — the hook's name
+- `ALETHEIA_HOOK_EVENT` — the event that triggered it
+- Plus any custom env vars from the `env:` field
+
+**Exit codes:**
+- `0` — success
+- `1` — warning (logged if failAction is not "silent")
+- `2+` — error (always logged unless "silent")
+
+## Template Variables
+
+Args and the command itself support `{{variable}}` substitution from the event payload:
+
+- `{{sessionId}}` — session ID
+- `{{nousId}}` — agent ID
+- `{{toolName}}` — tool name (tool events only)
+- `{{timestamp}}` — event timestamp
+- Nested: `{{session.id}}` for nested objects
+
+Missing variables resolve to empty string.
+
+## Per-Agent Hooks
+
+Hooks in `shared/hooks/` apply globally. For agent-specific hooks, create a `hooks/` directory in the agent's workspace:
+
+```
+nous/demiurge/hooks/craft-journal.yaml
+nous/akron/hooks/maintenance-log.yaml
+```
+
+Or use `nousFilter` in a global hook to restrict which agents trigger it.
+
+## Allowed Script Extensions
+
+For security, only these file extensions are allowed as hook commands:
+`.sh`, `.py`, `.js`, `.ts`, `.rb`, `.pl`
+
+Commands without extensions (e.g., `/usr/bin/curl`) are also allowed.
+
+## Fail Actions
+
+- **warn** (default) — log a warning on non-zero exit, don't affect the event
+- **silent** — swallow all errors silently
+- **block** — log an error (future: may block the triggering operation)
+
+## Examples
+
+See `_examples/` in this directory for starter hooks.

--- a/shared/hooks/_examples/backup-on-distill.yaml
+++ b/shared/hooks/_examples/backup-on-distill.yaml
@@ -1,0 +1,13 @@
+# Example: Run a backup script after every distillation
+# Copy to shared/hooks/ to activate
+
+name: backup-on-distill
+event: distill:after
+description: Back up session data after distillation completes
+
+handler:
+  type: shell
+  command: /bin/sh
+  args: ["-c", "cp /root/.aletheia/sessions.db /root/.aletheia/sessions.db.bak-$(date +%Y%m%d%H%M)"]
+  timeout: 30s
+  failAction: warn

--- a/shared/hooks/_examples/craft-journal.yaml
+++ b/shared/hooks/_examples/craft-journal.yaml
@@ -1,0 +1,14 @@
+# Example: Per-agent hook — only fires for Demiurge
+# Copy to shared/hooks/ or nous/demiurge/hooks/ to activate
+
+name: craft-journal
+event: turn:after
+description: Append craft session notes for Demiurge's domain
+nousFilter: [demiurge]
+
+handler:
+  type: shell
+  command: /bin/sh
+  args: ["-c", "echo \"$(date -Iseconds) session={{sessionId}} tools={{toolCalls}}\" >> /mnt/ssd/aletheia/nous/demiurge/craft-journal.log"]
+  timeout: 5s
+  failAction: silent

--- a/shared/hooks/_examples/log-turns.yaml
+++ b/shared/hooks/_examples/log-turns.yaml
@@ -1,0 +1,13 @@
+# Example: Log every turn completion to a file
+# Copy to shared/hooks/ to activate
+
+name: log-turns
+event: turn:after
+description: Append turn metadata to a daily log file
+
+handler:
+  type: shell
+  command: /bin/sh
+  args: ["-c", "echo \"$(date -Iseconds) {{nousId}} {{sessionId}} tokens_in={{inputTokens}} tokens_out={{outputTokens}} tools={{toolCalls}}\" >> /tmp/aletheia-turns.log"]
+  timeout: 5s
+  failAction: silent

--- a/shared/hooks/_examples/notify-boot.yaml
+++ b/shared/hooks/_examples/notify-boot.yaml
@@ -1,0 +1,13 @@
+# Example: Send a notification when Aletheia boots
+# Copy to shared/hooks/ to activate
+
+name: notify-boot
+event: boot:ready
+description: Log boot completion with tool and plugin counts
+
+handler:
+  type: shell
+  command: /bin/sh
+  args: ["-c", "echo \"Aletheia ready on port {{port}} with {{tools}} tools and {{plugins}} plugins\" | logger -t aletheia"]
+  timeout: 5s
+  failAction: silent

--- a/shared/skills/find-product-specific-configuration-settings/SKILL.md
+++ b/shared/skills/find-product-specific-configuration-settings/SKILL.md
@@ -1,0 +1,16 @@
+# Find Product-Specific Configuration Settings
+Locate optimal configuration settings for a specific product model by searching for and fetching relevant documentation.
+
+## When to Use
+When you need to find specific settings, specifications, or configuration recommendations for a particular product model (e.g., grinder settings, temperature ranges, size charts).
+
+## Steps
+1. Enable web_search tool
+2. Construct a specific search query combining the product model name with the setting/specification type needed
+3. Enable web_fetch tool
+4. Fetch relevant result URLs that appear to contain product documentation or guides
+5. If initial source is incomplete, fetch alternative sources (official product pages, review sites, guides)
+
+## Tools Used
+- web_search: to locate pages containing product-specific settings and documentation
+- web_fetch: to retrieve and extract the actual configuration details from identified sources

--- a/shared/skills/project-status-specification-assessment/SKILL.md
+++ b/shared/skills/project-status-specification-assessment/SKILL.md
@@ -1,0 +1,15 @@
+# Project Status & Specification Assessment
+Quickly gather repository state, identify active specs, and locate priority tasks to understand project context and workload.
+
+## When to Use
+When you need to rapidly assess the current state of a project, understand which specifications are in progress vs. draft status, identify assigned tasks, and prioritize next steps based on project documentation and attention logs.
+
+## Steps
+1. Navigate to project root and retrieve recent git history and PR status to understand recent activity
+2. List key specification documents and read their headers to identify status, authors, and phases
+3. Cross-reference multiple related specs to understand dependencies and completion status
+4. Check priority/attention logs (e.g., PROSOCHE.md) to identify high-priority items and blockers
+5. Synthesize findings into a picture of what's in progress, what's blocked, and what needs attention
+
+## Tools Used
+- exec: Execute git commands for history and PR status, read specification files with cat and head, grep for specific status information, check attention/priority logs


### PR DESCRIPTION
## What

Declarative YAML-based hook system that fires shell commands at runtime lifecycle events. Drop a `.yaml` file in `shared/hooks/` — no TypeScript required.

## Why

Spec 18 (Extensibility) Phase 1. Users need to inject custom logic at lifecycle points without modifying the runtime. This is the foundation for commands (Phase 2), per-nous hooks (Phase 3), and the full plugin standard (Phase 4-6).

## How

### Hook Definition Format

```yaml
name: backup-on-distill
event: distill:after
handler:
  type: shell
  command: /home/syn/scripts/backup-sessions.sh
  args: ["{{sessionId}}", "{{nousId}}"]
  timeout: 30s
  failAction: warn  # warn | block | silent
```

### Architecture

- **`koina/hooks.ts`** — Hook registry: YAML loading, Zod validation, template substitution, shell execution, event bus wiring
- **Boot integration** — Hooks loaded after plugins, before gateway. Both global (`shared/hooks/`) and per-nous (`nous/<id>/hooks/`) directories scanned
- **Shell protocol** — Event payload as JSON on stdin, exit codes for status, `ALETHEIA_HOOK_NAME`/`ALETHEIA_HOOK_EVENT` env vars. Compatible with Claude Code hook protocol.
- **Minimal YAML parser** — No `js-yaml` dependency; handles the structured YAML hook definitions natively
- **Clean shutdown** — All listeners torn down on SIGTERM/SIGINT

### Supported Events

`turn:before`, `turn:after`, `tool:called`, `tool:failed`, `distill:before`, `distill:after`, `session:created`, `session:archived`, `memory:added`, `boot:start`, `boot:ready`, `config:reloaded`, and more.

### Security

- Allowed extensions whitelist (`.sh`, `.py`, `.js`, `.ts`, `.rb`, `.pl`)
- Event name validation against known bus events
- Per-hook timeout enforcement
- `nousFilter` for agent-scoped hooks

## Tests

33 passing — template variables, YAML parsing, shell execution (success, failure, timeout, stdin, env vars, stderr), filesystem loading (valid, disabled, bad event, bad extension, multiple files, non-yaml filtering), event bus registration/teardown.

## Docs

`shared/hooks/README.md` — full reference with handler protocol, event table, template variables, per-agent hooks, fail actions. 4 example hooks included.