### PR TITLE
feat: agent export — portable AgentFile format (Spec 21 Phase 1)

### DIFF
--- a/docs/specs/21_agent-portability.md
+++ b/docs/specs/21_agent-portability.md
@@ -1,6 +1,6 @@
 # Spec: Agent Portability — Export, Import & Time-Travel
 
-**Status:** Draft
+**Status:** Phase 1 done (feat/agent-export). Phases 2-4 remaining.
 **Author:** Syn
 **Date:** 2026-02-21
 **Source:** Gap Analysis F-15, F-34; Letta Agent File + LangGraph checkpointing

--- a/infrastructure/runtime/src/portability/cli.ts
+++ b/infrastructure/runtime/src/portability/cli.ts
@@ -1,0 +1,136 @@
+// CLI entry point for agent export/import
+//
+// Usage:
+//   npx tsx src/portability/cli.ts export <nous-id> [options]
+//
+// Options:
+//   --output, -o    Output file path (default: <nous-id>-<date>.agent.json)
+//   --memory        Include memory vectors
+//   --graph         Include knowledge graph
+//   --archived      Include archived sessions
+//   --compact       Compact JSON (no pretty-printing)
+//   --sidecar-url   Memory sidecar URL (default: http://localhost:8230)
+
+import { writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { exportAgent, agentFileToJson } from "./export.js";
+import { loadConfig } from "../taxis/loader.js";
+import { SessionStore } from "../mneme/store.js";
+import { paths } from "../taxis/paths.js";
+
+async function main() {
+  const args = process.argv.slice(2);
+
+  if (args.length === 0 || args[0] === "--help" || args[0] === "-h") {
+    console.log(`
+Usage: aletheia-export <nous-id> [options]
+
+Options:
+  --output, -o <file>   Output file (default: <nous-id>-<date>.agent.json)
+  --memory              Include memory vectors from Qdrant
+  --graph               Include knowledge graph from Neo4j
+  --archived            Include archived sessions
+  --compact             Compact JSON output
+  --sidecar-url <url>   Memory sidecar URL (default: http://localhost:8230)
+  --help, -h            Show this help
+`);
+    process.exit(0);
+  }
+
+  const command = args[0];
+  if (command !== "export") {
+    console.error(`Unknown command: ${command}. Currently only 'export' is supported.`);
+    process.exit(1);
+  }
+
+  const nousId = args[1];
+  if (!nousId) {
+    console.error("Error: nous-id is required");
+    process.exit(1);
+  }
+
+  // Parse options
+  let output = "";
+  let includeMemory = false;
+  let includeGraph = false;
+  let includeArchived = false;
+  let compact = false;
+  let sidecarUrl = "http://localhost:8230";
+
+  for (let i = 2; i < args.length; i++) {
+    switch (args[i]) {
+      case "--output":
+      case "-o":
+        output = args[++i] ?? "";
+        break;
+      case "--memory":
+        includeMemory = true;
+        break;
+      case "--graph":
+        includeGraph = true;
+        break;
+      case "--archived":
+        includeArchived = true;
+        break;
+      case "--compact":
+        compact = true;
+        break;
+      case "--sidecar-url":
+        sidecarUrl = args[++i] ?? sidecarUrl;
+        break;
+    }
+  }
+
+  // Default output filename
+  if (!output) {
+    const date = new Date().toISOString().split("T")[0];
+    output = `${nousId}-${date}.agent.json`;
+  }
+
+  // Load config to find the agent
+  const config = loadConfig();
+  const agentDef = config.agents.list.find((a) => a.id === nousId);
+
+  if (!agentDef) {
+    console.error(`Error: Agent '${nousId}' not found in config.`);
+    console.error(`Available agents: ${config.agents.list.map((a) => a.id).join(", ")}`);
+    process.exit(1);
+  }
+
+  // Open session store
+  const store = new SessionStore(paths.sessionsDb());
+
+  try {
+    console.log(`Exporting agent: ${nousId}`);
+
+    const agentFile = await exportAgent(nousId, agentDef as unknown as Record<string, unknown>, store, {
+      includeMemory,
+      includeGraph,
+      includeArchived,
+      sidecarUrl,
+    });
+
+    const json = agentFileToJson(agentFile, !compact);
+    const outputPath = resolve(output);
+    writeFileSync(outputPath, json);
+
+    const sizeMb = (json.length / 1024 / 1024).toFixed(1);
+    console.log(`\nExported to: ${outputPath}`);
+    console.log(`Size: ${sizeMb}MB`);
+    console.log(`Files: ${Object.keys(agentFile.workspace.files).length} text, ${agentFile.workspace.binaryFiles.length} binary`);
+    console.log(`Sessions: ${agentFile.sessions.length}`);
+    if (agentFile.memory?.vectors) {
+      console.log(`Memory vectors: ${agentFile.memory.vectors.length}`);
+    }
+    if (agentFile.memory?.graph) {
+      console.log(`Graph: ${agentFile.memory.graph.nodes.length} nodes, ${agentFile.memory.graph.edges.length} edges`);
+    }
+  } finally {
+    store.close();
+  }
+}
+
+main().catch((err) => {
+  console.error("Export failed:", err);
+  process.exit(1);
+});

--- a/infrastructure/runtime/src/portability/export.test.ts
+++ b/infrastructure/runtime/src/portability/export.test.ts
@@ -1,0 +1,226 @@
+// Agent export tests
+import { describe, expect, it, vi, beforeEach, afterAll } from "vitest";
+import { writeFileSync, mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+
+// Fixed test root — created in beforeEach, cleaned in afterAll
+const TEST_ROOT = "/tmp/aletheia-export-test";
+
+vi.mock("../koina/logger.js", () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+vi.mock("../taxis/paths.js", () => {
+  const { join: pj } = require("node:path");
+  const root = "/tmp/aletheia-export-test";
+  return {
+    paths: {
+      root,
+      nous: pj(root, "nous"),
+      shared: pj(root, "shared"),
+      nousDir: (id: string) => pj(root, "nous", id),
+    },
+  };
+});
+
+import { exportAgent, type AgentFile } from "./export.js";
+
+// --- Mock store ---
+
+function createMockStore(sessions: Array<Record<string, unknown>> = [], messages: Array<Record<string, unknown>> = []) {
+  return {
+    listSessions: vi.fn((nousId?: string) =>
+      sessions.filter((s) => !nousId || s.nousId === nousId),
+    ),
+    getHistory: vi.fn((_sessionId: string, _opts?: { limit?: number }) =>
+      messages,
+    ),
+    getNotes: vi.fn(() => []),
+    findSession: vi.fn(() => null),
+  } as unknown as import("../mneme/store.js").SessionStore;
+}
+
+function makeSession(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: "ses_test_001",
+    nousId: "test-agent",
+    sessionKey: "main",
+    parentSessionId: null,
+    status: "active",
+    model: "claude-opus-4-6",
+    tokenCountEstimate: 5000,
+    messageCount: 10,
+    lastInputTokens: 1000,
+    bootstrapHash: null,
+    distillationCount: 2,
+    sessionType: "primary",
+    lastDistilledAt: "2026-02-21T10:00:00Z",
+    computedContextTokens: 50000,
+    workingState: {
+      currentTask: "Building export",
+      completedSteps: ["Phase 1"],
+      nextSteps: ["Phase 2"],
+      recentDecisions: ["Use JSON format"],
+      openFiles: ["export.ts"],
+      updatedAt: "2026-02-21T10:00:00Z",
+    },
+    distillationPriming: null,
+    createdAt: "2026-02-20T08:00:00Z",
+    updatedAt: "2026-02-21T10:00:00Z",
+    ...overrides,
+  };
+}
+
+function makeMessage(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: 1,
+    sessionId: "ses_test_001",
+    role: "user",
+    content: "Hello, world!",
+    seq: 1,
+    tokenEstimate: 50,
+    isDistilled: false,
+    toolCallId: null,
+    toolName: null,
+    createdAt: "2026-02-21T10:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("exportAgent", () => {
+  let agentWorkspace: string;
+
+  beforeEach(() => {
+    // Clean and recreate test workspace
+    rmSync(TEST_ROOT, { recursive: true, force: true });
+    agentWorkspace = join(TEST_ROOT, "nous", "test-agent");
+    mkdirSync(agentWorkspace, { recursive: true });
+    writeFileSync(join(agentWorkspace, "SOUL.md"), "# Test Agent Soul");
+    writeFileSync(join(agentWorkspace, "MEMORY.md"), "# Memory\n\nSome facts.");
+    mkdirSync(join(agentWorkspace, "memory"), { recursive: true });
+    writeFileSync(join(agentWorkspace, "memory", "2026-02-21.md"), "# Session log");
+  });
+
+  afterAll(() => {
+    rmSync(TEST_ROOT, { recursive: true, force: true });
+  });
+
+  it("exports basic agent with workspace files", async () => {
+    const store = createMockStore([makeSession()], [makeMessage()]);
+    const config = { id: "test-agent", name: "Test Agent", model: "claude-opus-4-6" };
+
+    const result = await exportAgent("test-agent", config, store);
+
+    expect(result.version).toBe(1);
+    expect(result.exportedAt).toBeTruthy();
+    expect(result.generator).toBe("aletheia-export/1.0");
+    expect(result.nous.id).toBe("test-agent");
+    expect(result.nous.name).toBe("Test Agent");
+    expect(result.workspace.files["SOUL.md"]).toBe("# Test Agent Soul");
+    expect(result.workspace.files["MEMORY.md"]).toContain("Some facts");
+    expect(result.workspace.files["memory/2026-02-21.md"]).toBe("# Session log");
+  });
+
+  it("exports sessions with working state", async () => {
+    const session = makeSession();
+    const messages = [
+      makeMessage({ seq: 1, role: "user", content: "What is the system status?" }),
+      makeMessage({ seq: 2, role: "assistant", content: "All systems operational." }),
+    ];
+    const store = createMockStore([session], messages);
+
+    const result = await exportAgent("test-agent", {}, store);
+
+    expect(result.sessions).toHaveLength(1);
+    expect(result.sessions[0]!.sessionKey).toBe("main");
+    expect(result.sessions[0]!.workingState?.currentTask).toBe("Building export");
+    expect(result.sessions[0]!.messages).toHaveLength(2);
+    expect(result.sessions[0]!.messages[0]!.role).toBe("user");
+    expect(result.sessions[0]!.messages[1]!.role).toBe("assistant");
+  });
+
+  it("skips archived sessions by default", async () => {
+    const sessions = [
+      makeSession({ id: "ses_active", status: "active" }),
+      makeSession({ id: "ses_archived", status: "archived" }),
+    ];
+    const store = createMockStore(sessions, []);
+
+    const result = await exportAgent("test-agent", {}, store);
+
+    expect(result.sessions).toHaveLength(1);
+    expect(result.sessions[0]!.id).toBe("ses_active");
+  });
+
+  it("includes archived sessions when requested", async () => {
+    const sessions = [
+      makeSession({ id: "ses_active", status: "active" }),
+      makeSession({ id: "ses_archived", status: "archived" }),
+    ];
+    const store = createMockStore(sessions, []);
+
+    const result = await exportAgent("test-agent", {}, store, {
+      includeArchived: true,
+    });
+
+    expect(result.sessions).toHaveLength(2);
+  });
+
+  it("identifies binary files without including content", async () => {
+    writeFileSync(join(agentWorkspace, "avatar.png"), Buffer.from([0x89, 0x50, 0x4e, 0x47]));
+    writeFileSync(join(agentWorkspace, "data.db"), "sqlite data");
+
+    const store = createMockStore([], []);
+    const result = await exportAgent("test-agent", {}, store);
+
+    expect(result.workspace.binaryFiles).toContain("avatar.png");
+    expect(result.workspace.binaryFiles).toContain("data.db");
+    expect(result.workspace.files["avatar.png"]).toBeUndefined();
+    expect(result.workspace.files["data.db"]).toBeUndefined();
+  });
+
+  it("handles missing workspace gracefully", async () => {
+    const store = createMockStore([], []);
+    const result = await exportAgent("nonexistent-agent", {}, store);
+
+    expect(result.workspace.files).toEqual({});
+    expect(result.workspace.binaryFiles).toEqual([]);
+  });
+
+  it("skips node_modules and .git directories", async () => {
+    mkdirSync(join(agentWorkspace, "node_modules", "dep"), { recursive: true });
+    writeFileSync(join(agentWorkspace, "node_modules", "dep", "index.js"), "module.exports = {}");
+    mkdirSync(join(agentWorkspace, ".git", "objects"), { recursive: true });
+    writeFileSync(join(agentWorkspace, ".git", "HEAD"), "ref: refs/heads/main");
+
+    const store = createMockStore([], []);
+    const result = await exportAgent("test-agent", {}, store);
+
+    expect(Object.keys(result.workspace.files).some((f) => f.includes("node_modules"))).toBe(false);
+    expect(Object.keys(result.workspace.files).some((f) => f.includes(".git"))).toBe(false);
+  });
+
+  it("does not include memory by default", async () => {
+    const store = createMockStore([], []);
+    const result = await exportAgent("test-agent", {}, store);
+
+    expect(result.memory).toBeUndefined();
+  });
+
+  it("produces valid JSON output", async () => {
+    const store = createMockStore([makeSession()], [makeMessage()]);
+    const result = await exportAgent("test-agent", { name: "Test" }, store);
+
+    const json = JSON.stringify(result);
+    const parsed = JSON.parse(json) as AgentFile;
+
+    expect(parsed.version).toBe(1);
+    expect(parsed.nous.id).toBe("test-agent");
+    expect(parsed.sessions).toHaveLength(1);
+  });
+});

--- a/infrastructure/runtime/src/portability/export.ts
+++ b/infrastructure/runtime/src/portability/export.ts
@@ -1,0 +1,393 @@
+// Agent export — produce a portable AgentFile from a running nous
+//
+// Captures: config, workspace files, session history, working state,
+// agent notes, distillation priming, and optionally memory vectors + graph.
+//
+// Design: Spec 21 Phase 1 (Agent Portability)
+
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { join, relative, extname } from "node:path";
+import { createLogger } from "../koina/logger.js";
+import type { SessionStore, Session, WorkingState, DistillationPriming } from "../mneme/store.js";
+import { paths } from "../taxis/paths.js";
+
+const log = createLogger("portability:export");
+
+// --- AgentFile Schema ---
+
+export interface AgentFile {
+  version: 1;
+  exportedAt: string;
+  generator: string;
+  nous: {
+    id: string;
+    name: string | null;
+    model: string | null;
+    config: Record<string, unknown>;
+  };
+  workspace: {
+    files: Record<string, string>;    // path → content (text files only)
+    binaryFiles: string[];            // paths of binary files (not included)
+  };
+  sessions: ExportedSession[];
+  memory?: {
+    vectors?: ExportedVector[];
+    graph?: {
+      nodes: ExportedGraphNode[];
+      edges: ExportedGraphEdge[];
+    };
+  };
+}
+
+export interface ExportedSession {
+  id: string;
+  sessionKey: string;
+  status: Session["status"];
+  sessionType: Session["sessionType"];
+  messageCount: number;
+  tokenCountEstimate: number;
+  distillationCount: number;
+  createdAt: string;
+  updatedAt: string;
+  workingState: WorkingState | null;
+  distillationPriming: DistillationPriming | null;
+  notes: ExportedNote[];
+  messages: ExportedMessage[];
+}
+
+export interface ExportedMessage {
+  role: string;
+  content: string;
+  seq: number;
+  tokenEstimate: number;
+  isDistilled: boolean;
+  createdAt: string;
+}
+
+export interface ExportedNote {
+  category: string;
+  content: string;
+  createdAt: string;
+}
+
+export interface ExportedVector {
+  id: string;
+  text: string;
+  metadata: Record<string, unknown>;
+  // Embeddings omitted — can be regenerated on import
+}
+
+export interface ExportedGraphNode {
+  name: string;
+  labels: string[];
+  properties: Record<string, unknown>;
+}
+
+export interface ExportedGraphEdge {
+  source: string;
+  target: string;
+  relType: string;
+}
+
+// --- Export Options ---
+
+export interface ExportOptions {
+  /** Include memory vectors from Qdrant */
+  includeMemory?: boolean;
+  /** Include knowledge graph from Neo4j */
+  includeGraph?: boolean;
+  /** Max messages per session (0 = all). Default: 500 */
+  maxMessagesPerSession?: number;
+  /** Include archived sessions. Default: false */
+  includeArchived?: boolean;
+  /** Memory sidecar URL for vector/graph export */
+  sidecarUrl?: string;
+}
+
+const DEFAULT_OPTIONS: Required<ExportOptions> = {
+  includeMemory: false,
+  includeGraph: false,
+  maxMessagesPerSession: 500,
+  includeArchived: false,
+  sidecarUrl: "http://localhost:8230",
+};
+
+// --- Text file detection ---
+
+const TEXT_EXTENSIONS = new Set([
+  ".md", ".txt", ".yaml", ".yml", ".json", ".ts", ".js", ".py",
+  ".sh", ".bash", ".zsh", ".css", ".html", ".svelte", ".toml",
+  ".ini", ".cfg", ".conf", ".env", ".log", ".csv", ".xml",
+  ".gitignore", ".editorconfig", ".prettierrc",
+]);
+
+const BINARY_EXTENSIONS = new Set([
+  ".png", ".jpg", ".jpeg", ".gif", ".ico", ".svg", ".webp",
+  ".woff", ".woff2", ".ttf", ".eot",
+  ".zip", ".tar", ".gz", ".bz2", ".xz",
+  ".pdf", ".doc", ".docx", ".xlsx",
+  ".db", ".sqlite", ".sqlite3",
+  ".wasm", ".so", ".dylib",
+]);
+
+function isTextFile(filename: string): boolean {
+  const ext = extname(filename).toLowerCase();
+  if (TEXT_EXTENSIONS.has(ext)) return true;
+  if (BINARY_EXTENSIONS.has(ext)) return false;
+  // No extension or unknown — check if no extension (likely text: Makefile, Dockerfile, etc.)
+  if (!ext) return true;
+  return false; // Default to binary for unknown extensions
+}
+
+// --- Workspace scanning ---
+
+const IGNORE_DIRS = new Set(["node_modules", ".git", "__pycache__", ".cache", "dist"]);
+const MAX_FILE_SIZE = 1024 * 1024; // 1MB — skip files larger than this
+
+function scanWorkspace(
+  workspacePath: string,
+): { files: Record<string, string>; binaryFiles: string[] } {
+  const files: Record<string, string> = {};
+  const binaryFiles: string[] = [];
+
+  function walk(dir: string): void {
+    let entries: string[];
+    try {
+      entries = readdirSync(dir);
+    } catch {
+      return;
+    }
+
+    for (const entry of entries) {
+      if (entry.startsWith(".") && entry !== ".env") continue;
+      if (IGNORE_DIRS.has(entry)) continue;
+
+      const fullPath = join(dir, entry);
+      let stat;
+      try {
+        stat = statSync(fullPath);
+      } catch {
+        continue;
+      }
+
+      if (stat.isDirectory()) {
+        walk(fullPath);
+        continue;
+      }
+
+      if (!stat.isFile()) continue;
+
+      const relPath = relative(workspacePath, fullPath);
+
+      if (stat.size > MAX_FILE_SIZE) {
+        binaryFiles.push(relPath);
+        continue;
+      }
+
+      if (isTextFile(entry)) {
+        try {
+          files[relPath] = readFileSync(fullPath, "utf-8");
+        } catch {
+          binaryFiles.push(relPath);
+        }
+      } else {
+        binaryFiles.push(relPath);
+      }
+    }
+  }
+
+  walk(workspacePath);
+  return { files, binaryFiles };
+}
+
+// --- Session export ---
+
+function exportSession(
+  store: SessionStore,
+  session: Session,
+  _nousId: string,
+  maxMessages: number,
+): ExportedSession {
+  // Get messages — most recent N if limited
+  const limit = maxMessages > 0 ? maxMessages : 0;
+  const messages = store.getHistory(session.id, limit > 0 ? { limit } : {});
+
+  // Get notes for this session
+  const notes = store.getNotes(session.id, { limit: 100 });
+
+  return {
+    id: session.id,
+    sessionKey: session.sessionKey,
+    status: session.status,
+    sessionType: session.sessionType,
+    messageCount: session.messageCount,
+    tokenCountEstimate: session.tokenCountEstimate,
+    distillationCount: session.distillationCount,
+    createdAt: session.createdAt,
+    updatedAt: session.updatedAt,
+    workingState: session.workingState,
+    distillationPriming: session.distillationPriming,
+    notes: notes.map((n) => ({
+      category: n.category,
+      content: n.content,
+      createdAt: n.createdAt,
+    })),
+    messages: messages.map((m) => ({
+      role: m.role,
+      content: m.content,
+      seq: m.seq,
+      tokenEstimate: m.tokenEstimate,
+      isDistilled: m.isDistilled,
+      createdAt: m.createdAt,
+    })),
+  };
+}
+
+// --- Memory export (via sidecar HTTP) ---
+
+async function exportMemoryVectors(
+  sidecarUrl: string,
+  nousId: string,
+): Promise<ExportedVector[]> {
+  try {
+    const response = await fetch(
+      `${sidecarUrl}/memories?agent_id=${encodeURIComponent(nousId)}&limit=10000`,
+    );
+    if (!response.ok) {
+      log.warn(`Memory export failed: ${response.status} ${response.statusText}`);
+      return [];
+    }
+    const data = (await response.json()) as { ok: boolean; memories?: Array<Record<string, unknown>> };
+    if (!data.ok || !data.memories) return [];
+
+    return data.memories.map((m) => ({
+      id: String(m["id"] ?? ""),
+      text: String(m["memory"] ?? m["text"] ?? ""),
+      metadata: (m["metadata"] as Record<string, unknown>) ?? {},
+    }));
+  } catch (err) {
+    log.warn(`Memory sidecar unreachable: ${err instanceof Error ? err.message : err}`);
+    return [];
+  }
+}
+
+async function exportGraph(
+  sidecarUrl: string,
+): Promise<{ nodes: ExportedGraphNode[]; edges: ExportedGraphEdge[] } | null> {
+  try {
+    const response = await fetch(`${sidecarUrl}/graph/export?mode=all`);
+    if (!response.ok) {
+      log.warn(`Graph export failed: ${response.status} ${response.statusText}`);
+      return null;
+    }
+    const data = (await response.json()) as {
+      ok: boolean;
+      nodes?: Array<Record<string, unknown>>;
+      edges?: Array<Record<string, unknown>>;
+    };
+    if (!data.ok) return null;
+
+    const nodes: ExportedGraphNode[] = (data.nodes ?? []).map((n) => ({
+      name: String(n["id"] ?? n["name"] ?? ""),
+      labels: (n["labels"] as string[]) ?? [],
+      properties: {
+        pagerank: n["pagerank"],
+        community: n["community"],
+      },
+    }));
+
+    const edges: ExportedGraphEdge[] = (data.edges ?? []).map((e) => ({
+      source: String(e["source"] ?? ""),
+      target: String(e["target"] ?? ""),
+      relType: String(e["rel_type"] ?? e["relType"] ?? "RELATED_TO"),
+    }));
+
+    return { nodes, edges };
+  } catch (err) {
+    log.warn(`Graph export failed: ${err instanceof Error ? err.message : err}`);
+    return null;
+  }
+}
+
+// --- Main export function ---
+
+export async function exportAgent(
+  nousId: string,
+  nousConfig: Record<string, unknown>,
+  store: SessionStore,
+  opts?: ExportOptions,
+): Promise<AgentFile> {
+  const options = { ...DEFAULT_OPTIONS, ...opts };
+
+  log.info(`Exporting agent ${nousId}...`);
+
+  // 1. Workspace files
+  const workspacePath = paths.nousDir(nousId);
+  let workspace = { files: {} as Record<string, string>, binaryFiles: [] as string[] };
+  if (existsSync(workspacePath)) {
+    workspace = scanWorkspace(workspacePath);
+    log.info(`Workspace: ${Object.keys(workspace.files).length} text files, ${workspace.binaryFiles.length} binary files`);
+  } else {
+    log.warn(`Workspace not found: ${workspacePath}`);
+  }
+
+  // 2. Sessions
+  const allSessions = store.listSessions(nousId);
+  const sessions = options.includeArchived
+    ? allSessions
+    : allSessions.filter((s) => s.status !== "archived");
+
+  const exportedSessions = sessions.map((s) =>
+    exportSession(store, s, nousId, options.maxMessagesPerSession),
+  );
+  log.info(`Sessions: ${exportedSessions.length} (${sessions.length} total, ${allSessions.length - sessions.length} archived skipped)`);
+
+  // 3. Memory (optional)
+  let memory: AgentFile["memory"];
+  if (options.includeMemory || options.includeGraph) {
+    memory = {};
+
+    if (options.includeMemory) {
+      memory.vectors = await exportMemoryVectors(options.sidecarUrl, nousId);
+      log.info(`Memory vectors: ${memory.vectors.length}`);
+    }
+
+    if (options.includeGraph) {
+      const graph = await exportGraph(options.sidecarUrl);
+      if (graph) {
+        memory.graph = graph;
+        log.info(`Graph: ${graph.nodes.length} nodes, ${graph.edges.length} edges`);
+      }
+    }
+  }
+
+  // 4. Build AgentFile
+  const agentFile: AgentFile = {
+    version: 1,
+    exportedAt: new Date().toISOString(),
+    generator: `aletheia-export/1.0`,
+    nous: {
+      id: nousId,
+      name: (nousConfig["name"] as string) ?? null,
+      model: (nousConfig["model"] as string) ?? null,
+      config: nousConfig,
+    },
+    workspace,
+    sessions: exportedSessions,
+  };
+
+  if (memory) {
+    agentFile.memory = memory;
+  }
+
+  const jsonSize = JSON.stringify(agentFile).length;
+  log.info(`Export complete: ${(jsonSize / 1024 / 1024).toFixed(1)}MB`);
+
+  return agentFile;
+}
+
+// --- CLI entry point helper ---
+
+export function agentFileToJson(agentFile: AgentFile, pretty = true): string {
+  return JSON.stringify(agentFile, null, pretty ? 2 : undefined);
+}

--- a/shared/bin/aletheia-export
+++ b/shared/bin/aletheia-export
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# aletheia-export — Export an agent to a portable AgentFile
+#
+# Usage:
+#   aletheia-export <nous-id> [options]
+#   aletheia-export syn --memory --graph -o syn-backup.agent.json
+#
+# Options:
+#   --output, -o    Output file path
+#   --memory        Include memory vectors
+#   --graph         Include knowledge graph
+#   --archived      Include archived sessions
+#   --compact       Compact JSON
+#   --sidecar-url   Memory sidecar URL
+
+set -euo pipefail
+
+ALETHEIA_ROOT="${ALETHEIA_ROOT:-/mnt/ssd/aletheia}"
+RUNTIME="$ALETHEIA_ROOT/infrastructure/runtime"
+
+cd "$RUNTIME"
+exec npx tsx src/portability/cli.ts export "$@"


### PR DESCRIPTION
## What

Structured agent export that produces a single JSON file containing everything needed to reconstruct a nous on a fresh Aletheia instance.

## Why

Spec 21 (Agent Portability) Phase 1. If the server dies, agents die with it. `aletheia-backup` creates tarballs, but there's no structured, portable format for individual agent export/import. This is also the foundation for agent cloning, migration between instances, and time-travel (Phase 4).

## AgentFile Format

```typescript
interface AgentFile {
  version: 1;
  exportedAt: string;
  generator: string;
  nous: { id, name, model, config };
  workspace: { files: Record<path, content>, binaryFiles: string[] };
  sessions: Array<{
    id, sessionKey, status, workingState, distillationPriming,
    notes: Array<{ category, content, createdAt }>,
    messages: Array<{ role, content, seq, tokenEstimate, isDistilled }>,
  }>;
  memory?: {
    vectors?: Array<{ id, text, metadata }>,
    graph?: { nodes: Array<{ name, labels, properties }>, edges: Array<{ source, target, relType }> },
  };
}
```

## Usage

```bash
# Basic export
aletheia-export syn

# Full export with memory + graph
aletheia-export syn --memory --graph -o syn-full.agent.json

# Include archived sessions
aletheia-export demiurge --archived
```

## Architecture

- **`portability/export.ts`** — Core export logic: workspace scanning, session export, optional memory/graph via sidecar HTTP
- **`portability/cli.ts`** — CLI entry point with arg parsing
- **`shared/bin/aletheia-export`** — Shell wrapper

## Key Decisions

- **Text vs binary detection** via extension allowlists (not magic bytes). Known text extensions included inline; binary files listed but not embedded.
- **Embeddings omitted** — can be regenerated on import. Saves significant file size.
- **Session messages limited** to last 500 by default (configurable). Full history available with `--archived`.
- **Memory optional** (`--memory`, `--graph`) because it requires the sidecar and adds significant size.

## Tests

9 passing — workspace scanning (text + binary + skipping), session export with working state, archived filtering, missing workspace handling, directory exclusion, JSON roundtrip.