### PR TITLE
feat: plan mode fixes + Spec 26 recursive self-improvement

### DIFF
--- a/infrastructure/runtime/src/aletheia.ts
+++ b/infrastructure/runtime/src/aletheia.ts
@@ -20,6 +20,8 @@ import { mem0SearchTool } from "./organon/built-in/mem0-search.js";
 import { factRetractTool } from "./organon/built-in/fact-retract.js";
 import { memoryCorrectTool } from "./organon/built-in/memory-correct.js";
 import { memoryForgetTool } from "./organon/built-in/memory-forget.js";
+import { mem0RetractTool } from "./organon/built-in/mem0-retract.js";
+import { mem0AuditTool } from "./organon/built-in/mem0-audit.js";
 import { browserTool, closeBrowser } from "./organon/built-in/browser.js";
 import { createMessageTool } from "./organon/built-in/message.js";
 import { createVoiceReplyTool } from "./organon/built-in/voice-reply.js";
@@ -34,6 +36,7 @@ import { createPlanTools } from "./organon/built-in/plan.js";
 import { createPlanProposeHandler } from "./organon/built-in/plan-propose.js";
 import { traceLookupTool } from "./organon/built-in/trace-lookup.js";
 import { createCheckCalibrationTool } from "./organon/built-in/check-calibration.js";
+import { createSelfEvaluateTool } from "./organon/built-in/self-evaluate.js";
 import { createWhatDoIKnowTool } from "./organon/built-in/what-do-i-know.js";
 import { createRecentCorrectionsTool } from "./organon/built-in/recent-corrections.js";
 import { createBlackboardTool } from "./organon/built-in/blackboard.js";
@@ -156,6 +159,8 @@ export function createRuntime(configPath?: string): AletheiaRuntime {
   tools.register({ ...factRetractTool, category: "available" as const });
   tools.register({ ...memoryCorrectTool, category: "available" as const });
   tools.register({ ...memoryForgetTool, category: "available" as const });
+  tools.register({ ...mem0RetractTool, category: "available" as const });
+  tools.register({ ...mem0AuditTool, category: "available" as const });
   tools.register({ ...traceLookupTool, category: "available" as const });
 
   // Browser (requires chromium on host)
@@ -173,7 +178,7 @@ export function createRuntime(configPath?: string): AletheiaRuntime {
   tools.register(sessionStatusTool);
 
   // Planning tools (available on-demand)
-  for (const planTool of createPlanTools()) {
+  for (const planTool of createPlanTools(store)) {
     planTool.category = "available";
     tools.register(planTool);
   }
@@ -275,6 +280,9 @@ export function createRuntime(configPath?: string): AletheiaRuntime {
   const correctionsTool = createRecentCorrectionsTool(store);
   correctionsTool.category = "available";
   tools.register(correctionsTool);
+  const selfEvalTool = createSelfEvaluateTool(store, competence, uncertainty);
+  selfEvalTool.category = "available";
+  tools.register(selfEvalTool);
 
   // Cross-agent blackboard — persistent shared state with auto-expiry
   tools.register(createBlackboardTool(store));

--- a/infrastructure/runtime/src/nous/bootstrap.ts
+++ b/infrastructure/runtime/src/nous/bootstrap.ts
@@ -29,6 +29,7 @@ const WORKSPACE_FILES: Omit<BootstrapFile, "path">[] = [
   { name: "GOALS.md", priority: 4.5, cacheGroup: "semi-static" },
   { name: "TOOLS.md", priority: 5, cacheGroup: "semi-static" },
   { name: "MEMORY.md", priority: 6, cacheGroup: "semi-static" },
+  { name: "STRATEGY.md", priority: 6.3, cacheGroup: "semi-static" },
   { name: "EVAL_FEEDBACK.md", priority: 6.5, cacheGroup: "semi-static" },
   { name: "PROSOCHE.md", priority: 7, cacheGroup: "dynamic" },
   { name: "CONTEXT.md", priority: 8, cacheGroup: "dynamic" },

--- a/infrastructure/runtime/src/nous/interaction-signals.ts
+++ b/infrastructure/runtime/src/nous/interaction-signals.ts
@@ -117,3 +117,30 @@ export function classifyInteraction(
 
   return { signal: "neutral", confidence: 0.4 };
 }
+
+// Domain keyword classification — lightweight regex matching for competence routing
+const DOMAIN_KEYWORDS: [string, RegExp][] = [
+  ["health", /\b(health|symptom|medication|doctor|appointment|diet|exercise|sleep|pain|sick|therapy|weight|blood\s*pressure|heart\s*rate|calories|supplement|prescription|dosage)\b/i],
+  ["scheduling", /\b(schedule|calendar|reminder|meeting|appointment|deadline|timer|alarm|event|booking|reschedule|cancel\s+(meeting|appointment)|availability|time\s*slot)\b/i],
+  ["code", /\b(code|program|function|variable|debug|compile|deploy|commit|merge|branch|refactor|typescript|python|api|endpoint|bug|error|stack\s*trace|lint|test|CI)\b/i],
+  ["writing", /\b(write|draft|essay|blog|article|edit|proofread|paragraph|outline|thesis|narrative|poem|story|copyedit)\b/i],
+  ["research", /\b(research|study|paper|journal|citation|source|evidence|analysis|literature|review|findings|methodology)\b/i],
+  ["finance", /\b(budget|expense|invoice|payment|cost|price|tax|accounting|financial|revenue|savings|investment|receipt)\b/i],
+  ["vehicle", /\b(car|truck|vehicle|engine|tire|oil\s*change|maintenance|mileage|brake|transmission|mechanic)\b/i],
+  ["academic", /\b(coursework|assignment|exam|grade|lecture|syllabus|MBA|class|homework|midterm|final|GPA|professor)\b/i],
+];
+
+export function classifyDomain(text: string): string | undefined {
+  let bestDomain: string | undefined;
+  let bestCount = 0;
+
+  for (const [domain, pattern] of DOMAIN_KEYWORDS) {
+    const matches = text.match(new RegExp(pattern, "gi"));
+    if (matches && matches.length > bestCount) {
+      bestCount = matches.length;
+      bestDomain = domain;
+    }
+  }
+
+  return bestDomain;
+}

--- a/infrastructure/runtime/src/organon/built-in/mem0-audit.test.ts
+++ b/infrastructure/runtime/src/organon/built-in/mem0-audit.test.ts
@@ -1,0 +1,87 @@
+// mem0_audit tool tests
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mem0AuditTool } from "./mem0-audit.js";
+
+const ctx = { nousId: "syn", sessionId: "ses_1", workspace: "/tmp" };
+
+describe("mem0_audit", () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    vi.stubEnv("ALETHEIA_MEMORY_URL", "http://localhost:9999");
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.unstubAllEnvs();
+  });
+
+  it("calls /search when query provided", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ results: [{ id: "m1", memory: "test fact", score: 0.9 }] }),
+    }) as unknown as typeof fetch;
+
+    const result = JSON.parse(await mem0AuditTool.execute({
+      query: "user preferences",
+    }, ctx));
+
+    expect(result.results).toHaveLength(1);
+    expect(result.instructions).toContain("memory_correct");
+
+    const [url, opts] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0]!;
+    expect(url).toBe("http://localhost:9999/search");
+    const body = JSON.parse((opts as RequestInit).body as string);
+    expect(body.query).toBe("user preferences");
+    expect(body.agent_id).toBe("syn");
+  });
+
+  it("calls /memories when no query provided", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ memories: [], count: 0 }),
+    }) as unknown as typeof fetch;
+
+    const result = JSON.parse(await mem0AuditTool.execute({}, ctx));
+
+    expect(result.count).toBe(0);
+    expect(result.instructions).toBeDefined();
+
+    const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0]!;
+    expect(url).toContain("/memories?");
+    expect(url).toContain("agent_id=syn");
+  });
+
+  it("respects limit parameter", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ results: [] }),
+    }) as unknown as typeof fetch;
+
+    await mem0AuditTool.execute({ query: "test", limit: 5 }, ctx);
+
+    const body = JSON.parse(((globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0]![1] as RequestInit).body as string);
+    expect(body.limit).toBe(5);
+  });
+
+  it("returns error on HTTP failure", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 503,
+    }) as unknown as typeof fetch;
+
+    const result = JSON.parse(await mem0AuditTool.execute({
+      query: "test",
+    }, ctx));
+
+    expect(result.error).toContain("HTTP 503");
+  });
+
+  it("returns error on network failure", async () => {
+    globalThis.fetch = vi.fn().mockRejectedValue(new Error("ECONNREFUSED")) as unknown as typeof fetch;
+
+    const result = JSON.parse(await mem0AuditTool.execute({}, ctx));
+
+    expect(result.error).toContain("ECONNREFUSED");
+  });
+});

--- a/infrastructure/runtime/src/organon/built-in/mem0-audit.ts
+++ b/infrastructure/runtime/src/organon/built-in/mem0-audit.ts
@@ -1,0 +1,88 @@
+// Memory audit tool — agents can review and assess their own memories
+import { createLogger } from "../../koina/logger.js";
+import type { ToolContext, ToolHandler } from "../registry.js";
+
+const log = createLogger("organon.mem0-audit");
+const getSidecarUrl = () => process.env["ALETHEIA_MEMORY_URL"] ?? "http://127.0.0.1:8230";
+const getUserId = () => process.env["ALETHEIA_MEMORY_USER"] ?? "default";
+
+export const mem0AuditTool: ToolHandler = {
+  definition: {
+    name: "mem0_audit",
+    description:
+      "Review memories stored about a topic or list all memories for self-curation.\n\n" +
+      "USE WHEN:\n" +
+      "- Checking what you know about a topic before acting on it\n" +
+      "- Periodically auditing memory quality during self-evaluation\n" +
+      "- Before retracting — verify what exists first\n\n" +
+      "DO NOT USE WHEN:\n" +
+      "- You need to recall memories for a task (use mem0_search instead)\n" +
+      "- You want to add a memory (use the normal memory pipeline)\n\n" +
+      "TIPS:\n" +
+      "- With query: returns semantically similar memories (scored)\n" +
+      "- Without query: returns recent memories for inventory\n" +
+      "- Follow up with memory_correct, memory_forget, or mem0_retract as needed",
+    input_schema: {
+      type: "object",
+      properties: {
+        query: {
+          type: "string",
+          description: "Optional topic to audit — returns semantically similar memories. Omit for full inventory.",
+        },
+        limit: {
+          type: "number",
+          description: "Maximum memories to return (default 20)",
+        },
+      },
+    },
+  },
+  async execute(
+    input: Record<string, unknown>,
+    context: ToolContext,
+  ): Promise<string> {
+    const query = input["query"] as string | undefined;
+    const limit = (input["limit"] as number) ?? 20;
+
+    log.info(`Audit requested by ${context.nousId}: query="${query ?? "(inventory)"}", limit=${limit}`);
+
+    try {
+      let data: Record<string, unknown>;
+
+      if (query) {
+        const res = await fetch(`${getSidecarUrl()}/search`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            query,
+            user_id: getUserId(),
+            agent_id: context.nousId,
+            limit,
+          }),
+          signal: AbortSignal.timeout(15000),
+        });
+        if (!res.ok) return JSON.stringify({ error: `Audit search failed: HTTP ${res.status}` });
+        data = (await res.json()) as Record<string, unknown>;
+      } else {
+        const params = new URLSearchParams({
+          user_id: getUserId(),
+          agent_id: context.nousId,
+          limit: String(limit),
+        });
+        const res = await fetch(`${getSidecarUrl()}/memories?${params}`, {
+          signal: AbortSignal.timeout(15000),
+        });
+        if (!res.ok) return JSON.stringify({ error: `Audit list failed: HTTP ${res.status}` });
+        data = (await res.json()) as Record<string, unknown>;
+      }
+
+      return JSON.stringify({
+        ...data,
+        instructions: "Review each memory for accuracy. Use memory_correct to fix errors, memory_forget to soft-delete, or mem0_retract for full removal including graph nodes.",
+      });
+    } catch (err) {
+      return JSON.stringify({
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  },
+};

--- a/infrastructure/runtime/src/organon/built-in/mem0-retract.test.ts
+++ b/infrastructure/runtime/src/organon/built-in/mem0-retract.test.ts
@@ -1,0 +1,84 @@
+// mem0_retract tool tests
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mem0RetractTool } from "./mem0-retract.js";
+
+const ctx = { nousId: "syn", sessionId: "ses_1", workspace: "/tmp" };
+
+describe("mem0_retract", () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    vi.stubEnv("ALETHEIA_MEMORY_URL", "http://localhost:9999");
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.unstubAllEnvs();
+  });
+
+  it("calls sidecar /retract with correct payload", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ retracted: 2, dry_run: false }),
+    }) as unknown as typeof fetch;
+
+    const result = JSON.parse(await mem0RetractTool.execute({
+      query: "old address",
+      reason: "moved to new house",
+    }, ctx));
+
+    expect(result.retracted).toBe(2);
+    expect(globalThis.fetch).toHaveBeenCalledOnce();
+
+    const [url, opts] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0]!;
+    expect(url).toBe("http://localhost:9999/retract");
+    const body = JSON.parse((opts as RequestInit).body as string);
+    expect(body.query).toBe("old address");
+    expect(body.reason).toContain("[syn]");
+    expect(body.cascade).toBe(false);
+    expect(body.dry_run).toBe(false);
+  });
+
+  it("passes cascade and dry_run flags", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ retracted: 0, dry_run: true, preview: [] }),
+    }) as unknown as typeof fetch;
+
+    await mem0RetractTool.execute({
+      query: "test",
+      reason: "audit",
+      cascade: true,
+      dry_run: true,
+    }, ctx);
+
+    const body = JSON.parse(((globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0]![1] as RequestInit).body as string);
+    expect(body.cascade).toBe(true);
+    expect(body.dry_run).toBe(true);
+  });
+
+  it("returns error on HTTP failure", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+    }) as unknown as typeof fetch;
+
+    const result = JSON.parse(await mem0RetractTool.execute({
+      query: "test",
+      reason: "test",
+    }, ctx));
+
+    expect(result.error).toContain("HTTP 500");
+  });
+
+  it("returns error on network failure", async () => {
+    globalThis.fetch = vi.fn().mockRejectedValue(new Error("Connection refused")) as unknown as typeof fetch;
+
+    const result = JSON.parse(await mem0RetractTool.execute({
+      query: "test",
+      reason: "test",
+    }, ctx));
+
+    expect(result.error).toContain("Connection refused");
+  });
+});

--- a/infrastructure/runtime/src/organon/built-in/mem0-retract.ts
+++ b/infrastructure/runtime/src/organon/built-in/mem0-retract.ts
@@ -1,0 +1,85 @@
+// Memory retraction tool — agents can retract incorrect/stale memories
+import { createLogger } from "../../koina/logger.js";
+import type { ToolContext, ToolHandler } from "../registry.js";
+
+const log = createLogger("organon.mem0-retract");
+const getSidecarUrl = () => process.env["ALETHEIA_MEMORY_URL"] ?? "http://127.0.0.1:8230";
+const getUserId = () => process.env["ALETHEIA_MEMORY_USER"] ?? "default";
+
+export const mem0RetractTool: ToolHandler = {
+  definition: {
+    name: "mem0_retract",
+    description:
+      "Retract memories matching a semantic query — removes from both vector store and knowledge graph.\n\n" +
+      "USE WHEN:\n" +
+      "- A stored memory is factually wrong and should be fully removed\n" +
+      "- Outdated information keeps surfacing in recall\n" +
+      "- You've verified via mem0_audit that specific memories need deletion\n\n" +
+      "DO NOT USE WHEN:\n" +
+      "- A fact needs correction but not deletion (use memory_correct instead)\n" +
+      "- You're unsure what to retract — use mem0_audit first to review\n\n" +
+      "TIPS:\n" +
+      "- Use dry_run=true first to preview what would be retracted\n" +
+      "- cascade=true removes related Neo4j graph nodes\n" +
+      "- Only memories scoring >0.75 similarity are matched",
+    input_schema: {
+      type: "object",
+      properties: {
+        query: {
+          type: "string",
+          description: "Semantic description of the memory/memories to retract",
+        },
+        reason: {
+          type: "string",
+          description: "Why these memories should be retracted (audit trail)",
+        },
+        cascade: {
+          type: "boolean",
+          description: "Also remove related graph nodes in Neo4j (default false)",
+        },
+        dry_run: {
+          type: "boolean",
+          description: "Preview what would be retracted without actually doing it (default false)",
+        },
+      },
+      required: ["query", "reason"],
+    },
+  },
+  async execute(
+    input: Record<string, unknown>,
+    context: ToolContext,
+  ): Promise<string> {
+    const query = input["query"] as string;
+    const reason = input["reason"] as string;
+    const cascade = (input["cascade"] as boolean) ?? false;
+    const dryRun = (input["dry_run"] as boolean) ?? false;
+
+    log.info(`Retract requested by ${context.nousId}: "${query}" (reason: ${reason}, dry_run: ${dryRun}, cascade: ${cascade})`);
+
+    try {
+      const res = await fetch(`${getSidecarUrl()}/retract`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          query,
+          reason: `[${context.nousId}] ${reason}`,
+          user_id: getUserId(),
+          cascade,
+          dry_run: dryRun,
+        }),
+        signal: AbortSignal.timeout(15000),
+      });
+
+      if (!res.ok) {
+        return JSON.stringify({ error: `Retract failed: HTTP ${res.status}` });
+      }
+
+      const data = (await res.json()) as Record<string, unknown>;
+      return JSON.stringify(data);
+    } catch (err) {
+      return JSON.stringify({
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  },
+};

--- a/infrastructure/runtime/src/organon/built-in/self-evaluate.test.ts
+++ b/infrastructure/runtime/src/organon/built-in/self-evaluate.test.ts
@@ -1,0 +1,90 @@
+// self_evaluate tool tests
+import { beforeEach, describe, expect, it } from "vitest";
+import { SessionStore } from "../../mneme/store.js";
+import { CompetenceModel } from "../../nous/competence.js";
+import { createSelfEvaluateTool } from "./self-evaluate.js";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+const ctx = { nousId: "syn", sessionId: "ses_1", workspace: "/tmp" };
+
+describe("self_evaluate", () => {
+  let store: SessionStore;
+  let tmpDir: string;
+
+  beforeEach(() => {
+    store = new SessionStore(":memory:");
+    tmpDir = mkdtempSync(join(tmpdir(), "aletheia-eval-"));
+  });
+
+  it("returns evaluation without competence model", async () => {
+    const tool = createSelfEvaluateTool(store);
+    const result = JSON.parse(await tool.execute({}, ctx));
+
+    expect(result.nousId).toBe("syn");
+    expect(result.competence.note).toContain("not available");
+    expect(result.calibration.note).toContain("not available");
+    expect(result.recentActivity).toBeDefined();
+    expect(result.recommendations).toBeDefined();
+  });
+
+  it("returns competence data when model has data", async () => {
+    const competence = new CompetenceModel(tmpDir);
+    competence.recordSuccess("syn", "code");
+    competence.recordSuccess("syn", "code");
+
+    const tool = createSelfEvaluateTool(store, competence);
+    const result = JSON.parse(await tool.execute({}, ctx));
+
+    expect(result.overallScore).toBeGreaterThan(0);
+    expect(result.domains.code).toBeDefined();
+    expect(result.domains.code.successes).toBe(2);
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("generates recommendation for low-scoring domain", async () => {
+    const competence = new CompetenceModel(tmpDir);
+    // Drive score below 0.35 with corrections
+    for (let i = 0; i < 5; i++) competence.recordCorrection("syn", "health");
+
+    const tool = createSelfEvaluateTool(store, competence);
+    const result = JSON.parse(await tool.execute({}, ctx));
+
+    const healthRec = result.recommendations.find((r: string) => r.includes("health"));
+    expect(healthRec).toContain("delegating");
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("generates recommendation when corrections exceed successes", async () => {
+    const competence = new CompetenceModel(tmpDir);
+    competence.recordCorrection("syn", "scheduling");
+    competence.recordCorrection("syn", "scheduling");
+    competence.recordCorrection("syn", "scheduling");
+    competence.recordSuccess("syn", "scheduling");
+
+    const tool = createSelfEvaluateTool(store, competence);
+    const result = JSON.parse(await tool.execute({}, ctx));
+
+    const schedRec = result.recommendations.find((r: string) => r.includes("scheduling"));
+    expect(schedRec).toContain("corrections");
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("counts recent sessions within period", async () => {
+    store.createSession("syn", "recent-test");
+    const tool = createSelfEvaluateTool(store);
+    const result = JSON.parse(await tool.execute({ days: 1 }, ctx));
+
+    expect(result.recentActivity.recentSessions).toBeGreaterThanOrEqual(1);
+  });
+
+  it("reports no activity for inactive agent", async () => {
+    const tool = createSelfEvaluateTool(store);
+    const result = JSON.parse(await tool.execute({ days: 0 }, ctx));
+
+    expect(result.recommendations).toContainEqual(
+      expect.stringContaining("No recent activity"),
+    );
+  });
+});

--- a/infrastructure/runtime/src/organon/built-in/self-evaluate.ts
+++ b/infrastructure/runtime/src/organon/built-in/self-evaluate.ts
@@ -1,0 +1,112 @@
+// Self-evaluation tool — structured performance assessment
+import type { ToolContext, ToolHandler } from "../registry.js";
+import type { CompetenceModel } from "../../nous/competence.js";
+import type { UncertaintyTracker } from "../../nous/uncertainty.js";
+import type { SessionStore } from "../../mneme/store.js";
+
+export function createSelfEvaluateTool(
+  store: SessionStore,
+  competence?: CompetenceModel,
+  uncertainty?: UncertaintyTracker,
+): ToolHandler {
+  return {
+    definition: {
+      name: "self_evaluate",
+      description:
+        "Run a structured self-evaluation of your recent performance.\n\n" +
+        "Returns competence scores, calibration metrics, recent activity stats, and actionable recommendations.\n\n" +
+        "USE WHEN:\n" +
+        "- During periodic self-reflection (daily/weekly)\n" +
+        "- Before writing or updating STRATEGY.md\n" +
+        "- After receiving multiple corrections in a session\n\n" +
+        "DO NOT USE WHEN:\n" +
+        "- You just need a quick calibration check (use check_calibration instead)\n\n" +
+        "TIPS:\n" +
+        "- Use the output to update your STRATEGY.md with adjusted approaches\n" +
+        "- Low domain scores (<0.35) suggest delegating that domain\n" +
+        "- High correction-to-success ratio suggests reviewing your approach",
+      input_schema: {
+        type: "object",
+        properties: {
+          days: {
+            type: "number",
+            description: "Number of days to look back for activity (default 7)",
+          },
+        },
+      },
+    },
+    async execute(
+      input: Record<string, unknown>,
+      context: ToolContext,
+    ): Promise<string> {
+      const days = (input["days"] as number) ?? 7;
+      const cutoff = new Date(Date.now() - days * 86400000).toISOString();
+
+      const result: Record<string, unknown> = { nousId: context.nousId, evaluationPeriodDays: days };
+
+      // Competence snapshot
+      if (competence) {
+        const agent = competence.getAgentCompetence(context.nousId);
+        if (agent) {
+          result["overallScore"] = agent.overallScore;
+          result["domains"] = Object.fromEntries(
+            Object.entries(agent.domains).map(([k, v]) => [
+              k, { score: v.score, corrections: v.corrections, successes: v.successes },
+            ]),
+          );
+        } else {
+          result["competence"] = { note: "No competence data recorded yet" };
+        }
+      } else {
+        result["competence"] = { note: "Competence model not available" };
+      }
+
+      // Calibration data
+      if (uncertainty) {
+        result["calibration"] = uncertainty.getSummary(context.nousId);
+      } else {
+        result["calibration"] = { note: "Uncertainty tracker not available" };
+      }
+
+      // Recent activity
+      const sessions = store.listSessions(context.nousId);
+      const recentSessions = sessions.filter((s) => s.updatedAt >= cutoff);
+      result["recentActivity"] = {
+        totalSessions: sessions.length,
+        recentSessions: recentSessions.length,
+        periodStart: cutoff,
+      };
+
+      // Recommendations
+      const recommendations: string[] = [];
+
+      if (competence) {
+        const agent = competence.getAgentCompetence(context.nousId);
+        if (agent) {
+          for (const [domain, data] of Object.entries(agent.domains)) {
+            if (data.score < 0.35) {
+              recommendations.push(
+                `Domain "${domain}" score is ${data.score.toFixed(2)} — consider delegating tasks in this area via sessions_ask`,
+              );
+            }
+            if (data.corrections > data.successes && data.corrections > 2) {
+              recommendations.push(
+                `Domain "${domain}" has more corrections (${data.corrections}) than successes (${data.successes}) — review your approach`,
+              );
+            }
+          }
+        }
+      }
+
+      if (recentSessions.length === 0) {
+        recommendations.push("No recent activity — consider checking if there are pending tasks or messages");
+      }
+
+      result["recommendations"] = recommendations.length > 0
+        ? recommendations
+        : ["No issues detected — performance is within normal parameters"];
+
+      return JSON.stringify(result);
+    },
+  };
+}


### PR DESCRIPTION
## Summary

- **Fix #101**: Plan approval signal — lockKey used sessionId instead of sessionKey
- **Fix #102**: Plan persistence — rewrote JSONL → SQLite
- **Spec 26 Phase 1**: Self-evaluation loop (STRATEGY.md, self_evaluate tool, EVAL_FEEDBACK.md)
- **Spec 26 Phase 2**: Calibration-driven delegation (domain classification, competence suggestions)
- **Spec 26 Phase 3**: Memory self-curation (mem0_retract, mem0_audit tools)

Rebased clean from #104.