### PR TITLE
feat(ui): warm gold theme, proper favicon, refined empty state

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -6,8 +6,8 @@
   <meta name="mobile-web-app-capable" content="yes" />
   <meta name="apple-mobile-web-app-capable" content="yes" />
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
-  <title>Loading...</title>
-  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>⚡</text></svg>" />
+  <title>Aletheia</title>
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>ἀ</text></svg>" />
 </head>
 <body>
   <script>

--- a/ui/src/components/agents/AgentCard.svelte
+++ b/ui/src/components/agents/AgentCard.svelte
@@ -79,7 +79,7 @@
     justify-content: center;
     border-radius: var(--radius-sm);
     background: var(--accent);
-    color: #fff;
+    color: #0f1114;
     letter-spacing: 0.5px;
   }
   .info {
@@ -105,7 +105,7 @@
     padding: 0 5px;
     border-radius: 9px;
     background: var(--accent);
-    color: #fff;
+    color: #0f1114;
     font-size: 10px;
     font-weight: 700;
     display: flex;

--- a/ui/src/components/auth/Login.svelte
+++ b/ui/src/components/auth/Login.svelte
@@ -135,7 +135,7 @@
   .submit {
     background: var(--accent);
     border: none;
-    color: #fff;
+    color: #0f1114;
     padding: 10px 14px;
     border-radius: var(--radius-sm);
     font-size: 14px;

--- a/ui/src/components/chat/DistillationProgress.svelte
+++ b/ui/src/components/chat/DistillationProgress.svelte
@@ -80,8 +80,8 @@
     gap: 8px;
     padding: 6px 12px;
     margin: 4px 0;
-    background: rgba(88, 166, 255, 0.06);
-    border: 1px solid rgba(88, 166, 255, 0.2);
+    background: rgba(201, 168, 76, 0.06);
+    border: 1px solid rgba(201, 168, 76, 0.2);
     border-radius: 8px;
     font-size: 12px;
     color: var(--text-secondary);

--- a/ui/src/components/chat/InputBar.svelte
+++ b/ui/src/components/chat/InputBar.svelte
@@ -465,7 +465,7 @@
   }
   .attach-btn:hover {
     color: var(--accent);
-    background: rgba(88, 166, 255, 0.1);
+    background: rgba(201, 168, 76, 0.1);
   }
   .stop-btn {
     background: rgba(248, 81, 73, 0.1);
@@ -492,7 +492,7 @@
   .send-btn {
     background: var(--accent);
     border: none;
-    color: #fff;
+    color: #0f1114;
     padding: 8px 16px;
     border-radius: var(--radius-sm);
     font-size: 13px;
@@ -620,7 +620,7 @@
   .drag-overlay {
     position: absolute;
     inset: 0;
-    background: rgba(88, 166, 255, 0.08);
+    background: rgba(201, 168, 76, 0.08);
     border: 2px dashed var(--accent);
     border-radius: var(--radius);
     display: flex;

--- a/ui/src/components/chat/Markdown.svelte
+++ b/ui/src/components/chat/Markdown.svelte
@@ -259,7 +259,7 @@
   .markdown-body :global(input[type="checkbox"]:checked::after) {
     content: "\2713";
     display: block;
-    color: #fff;
+    color: #0f1114;
     font-size: 10px;
     font-weight: 700;
     text-align: center;

--- a/ui/src/components/chat/MessageList.svelte
+++ b/ui/src/components/chat/MessageList.svelte
@@ -66,7 +66,8 @@
       {:else}
         <div class="empty-initials">{initials}</div>
       {/if}
-      <p>Send a message to start a conversation.</p>
+      <p class="empty-name">{agentName ?? "Agent"}</p>
+      <p class="empty-hint">Ready when you are.</p>
     </div>
   {:else}
     {#each messages as message (message.id)}
@@ -131,7 +132,17 @@
     height: 100%;
     color: var(--text-muted);
     font-size: 14px;
-    gap: 12px;
+    gap: 8px;
+  }
+  .empty-name {
+    font-size: 16px;
+    font-weight: 600;
+    color: var(--text-secondary);
+    margin-top: 4px;
+  }
+  .empty-hint {
+    font-size: 13px;
+    color: var(--text-muted);
   }
   .empty-emoji {
     font-size: 48px;
@@ -152,7 +163,7 @@
     justify-content: center;
     border-radius: var(--radius);
     background: var(--accent);
-    color: #fff;
+    color: #0f1114;
     letter-spacing: 1px;
   }
 
@@ -162,7 +173,7 @@
     left: 50%;
     transform: translateX(-50%);
     background: var(--accent);
-    color: #fff;
+    color: #0f1114;
     border: none;
     padding: 6px 16px;
     border-radius: 16px;

--- a/ui/src/components/chat/PlanCard.svelte
+++ b/ui/src/components/chat/PlanCard.svelte
@@ -132,7 +132,7 @@
     padding: 12px 16px;
     background: var(--bg-elevated);
     border: 1px solid var(--border);
-    border-left: 3px solid var(--blue, #58a6ff);
+    border-left: 3px solid var(--accent);
     border-radius: var(--radius-sm);
     animation: fade-in 0.2s ease;
   }

--- a/ui/src/components/chat/ToolStatusLine.svelte
+++ b/ui/src/components/chat/ToolStatusLine.svelte
@@ -167,7 +167,7 @@
     color: var(--text);
   }
   .tool-status-line.active {
-    border-color: rgba(88, 166, 255, 0.3);
+    border-color: rgba(201, 168, 76, 0.3);
     color: var(--text);
   }
   .tool-status-line.has-errors {

--- a/ui/src/components/files/FileEditor.svelte
+++ b/ui/src/components/files/FileEditor.svelte
@@ -470,7 +470,7 @@
   }
   .save-btn:not(:disabled):hover {
     background: var(--accent);
-    color: #fff;
+    color: #0f1114;
   }
   .save-error {
     padding: 4px 8px;

--- a/ui/src/components/graph/ContextLookup.svelte
+++ b/ui/src/components/graph/ContextLookup.svelte
@@ -180,12 +180,12 @@
     font-size: 12px;
     font-family: var(--font-sans, system-ui);
   }
-  .lookup-input:focus { outline: none; border-color: var(--accent, #58a6ff); }
+  .lookup-input:focus { outline: none; border-color: var(--accent, #c9a84c); }
 
   .search-btn {
-    background: var(--accent, #58a6ff);
+    background: var(--accent, #c9a84c);
     border: none;
-    color: #fff;
+    color: #0f1114;
     padding: 5px 10px;
     border-radius: 4px;
     font-size: 12px;
@@ -249,7 +249,7 @@
   }
 
   .detail-preview {
-    border-top: 1px solid var(--accent, #58a6ff);
+    border-top: 1px solid var(--accent, #c9a84c);
     padding: 8px;
     overflow-y: auto;
     max-height: 300px;

--- a/ui/src/components/graph/DriftPanel.svelte
+++ b/ui/src/components/graph/DriftPanel.svelte
@@ -233,7 +233,7 @@
   .section-tab:hover { color: var(--text-secondary, #8b949e); }
   .section-tab.active {
     color: var(--text, #e6edf3);
-    border-bottom-color: var(--accent, #58a6ff);
+    border-bottom-color: var(--accent, #c9a84c);
   }
 
   .section-content {
@@ -273,7 +273,7 @@
   .entity-link {
     background: none;
     border: none;
-    color: var(--accent, #58a6ff);
+    color: var(--accent, #c9a84c);
     font-size: 12px;
     cursor: pointer;
     padding: 0;

--- a/ui/src/components/graph/Graph2D.svelte
+++ b/ui/src/components/graph/Graph2D.svelte
@@ -34,7 +34,7 @@
   let staleSet = $derived(new Set(driftData?.stale_entities?.map(e => e.name) ?? []));
 
   const PALETTE = [
-    "#58a6ff", "#3fb950", "#d29922", "#f85149", "#bc8cff",
+    "#c9a84c", "#3fb950", "#d29922", "#f85149", "#bc8cff",
     "#f778ba", "#79c0ff", "#56d4dd", "#e3b341", "#db6d28",
     "#8b949e", "#7ee787", "#a5d6ff", "#ffa657", "#ff7b72",
     "#d2a8ff", "#ffd8b5", "#89dceb", "#f9e2af", "#a6e3a1",
@@ -57,7 +57,7 @@
     const temporal = ["PRECEDES", "FOLLOWS", "OCCURRED_AT", "MENTIONS"];
 
     if (social.includes(relType)) return "rgba(63, 185, 80, 0.5)";
-    if (structural.includes(relType)) return "rgba(88, 166, 255, 0.5)";
+    if (structural.includes(relType)) return "rgba(201, 168, 76, 0.5)";
     if (temporal.includes(relType)) return "rgba(210, 153, 34, 0.5)";
     return "rgba(139, 148, 158, 0.35)";
   }

--- a/ui/src/components/graph/Graph3D.svelte
+++ b/ui/src/components/graph/Graph3D.svelte
@@ -20,7 +20,7 @@
   } = $props();
 
   const PALETTE = [
-    "#58a6ff", "#3fb950", "#d29922", "#f85149", "#bc8cff",
+    "#c9a84c", "#3fb950", "#d29922", "#f85149", "#bc8cff",
     "#f778ba", "#79c0ff", "#56d4dd", "#e3b341", "#db6d28",
     "#8b949e", "#7ee787", "#a5d6ff", "#ffa657", "#ff7b72",
     "#d2a8ff", "#ffd8b5", "#89dceb", "#f9e2af", "#a6e3a1",
@@ -43,7 +43,7 @@
     const temporal = ["PRECEDES", "FOLLOWS", "OCCURRED_AT", "MENTIONS"];
 
     if (social.includes(relType)) return "rgba(63, 185, 80, 0.35)";
-    if (structural.includes(relType)) return "rgba(88, 166, 255, 0.35)";
+    if (structural.includes(relType)) return "rgba(201, 168, 76, 0.35)";
     if (temporal.includes(relType)) return "rgba(210, 153, 34, 0.35)";
     return "rgba(139, 148, 158, 0.25)";
   }

--- a/ui/src/components/graph/GraphView.svelte
+++ b/ui/src/components/graph/GraphView.svelte
@@ -35,14 +35,14 @@
   let showEdgeFilter = $state(true);
 
   const PALETTE = [
-    "#58a6ff", "#3fb950", "#d29922", "#f85149", "#bc8cff",
+    "#c9a84c", "#3fb950", "#d29922", "#f85149", "#bc8cff",
     "#f778ba", "#79c0ff", "#56d4dd", "#e3b341", "#db6d28",
     "#8b949e", "#7ee787", "#a5d6ff", "#ffa657", "#ff7b72",
     "#d2a8ff", "#ffd8b5", "#89dceb", "#f9e2af", "#a6e3a1",
   ];
 
   const AGENT_COLORS: Record<string, string> = {
-    syn: "#58a6ff",
+    syn: "#c9a84c",
     demiurge: "#d29922",
     syl: "#f778ba",
     akron: "#3fb950",
@@ -483,7 +483,7 @@
   .toggle-btn:hover { color: var(--text); }
   .toggle-btn.active {
     background: var(--accent);
-    color: #fff;
+    color: #0f1114;
   }
 
   /* Overlay toggles */

--- a/ui/src/components/graph/NodeCard.svelte
+++ b/ui/src/components/graph/NodeCard.svelte
@@ -692,7 +692,7 @@
   }
   .action-btn.primary:hover {
     background: var(--accent);
-    color: #fff;
+    color: #0f1114;
   }
 
   .merge-row {

--- a/ui/src/components/graph/TimelineSlider.svelte
+++ b/ui/src/components/graph/TimelineSlider.svelte
@@ -68,13 +68,13 @@
 <style>
   .timeline-slider {
     padding: 4px 12px;
-    background: var(--bg-elevated, #161b22);
+    background: var(--bg-elevated, #181a1f);
     border-bottom: 1px solid var(--border, #30363d);
   }
 
   .timeline-slider.active {
-    background: color-mix(in srgb, var(--accent, #58a6ff) 8%, var(--bg-elevated, #161b22));
-    border-bottom-color: var(--accent, #58a6ff);
+    background: color-mix(in srgb, var(--accent, #c9a84c) 8%, var(--bg-elevated, #181a1f));
+    border-bottom-color: var(--accent, #c9a84c);
   }
 
   .timeline-row {
@@ -107,7 +107,7 @@
   }
   .preset-btn:hover {
     color: var(--text, #e6edf3);
-    border-color: var(--accent, #58a6ff);
+    border-color: var(--accent, #c9a84c);
   }
 
   .date-inputs {
@@ -128,7 +128,7 @@
   }
   .date-input:focus {
     outline: none;
-    border-color: var(--accent, #58a6ff);
+    border-color: var(--accent, #c9a84c);
   }
 
   .date-separator {
@@ -137,9 +137,9 @@
   }
 
   .apply-btn {
-    background: var(--accent, #58a6ff);
+    background: var(--accent, #c9a84c);
     border: none;
-    color: #fff;
+    color: #0f1114;
     padding: 2px 10px;
     border-radius: 4px;
     font-size: 11px;

--- a/ui/src/components/layout/Layout.svelte
+++ b/ui/src/components/layout/Layout.svelte
@@ -279,7 +279,7 @@
   .token-submit {
     background: var(--accent);
     border: none;
-    color: #fff;
+    color: #0f1114;
     padding: 10px 14px;
     border-radius: var(--radius-sm);
     font-size: 14px;

--- a/ui/src/components/settings/SessionManager.svelte
+++ b/ui/src/components/settings/SessionManager.svelte
@@ -153,7 +153,7 @@
   }
   .session-current {
     background: var(--accent);
-    color: #fff;
+    color: #0f1114;
     font-size: 10px;
     padding: 1px 6px;
     border-radius: 8px;

--- a/ui/src/components/settings/SettingsView.svelte
+++ b/ui/src/components/settings/SettingsView.svelte
@@ -287,7 +287,7 @@
   }
   .toggle-btn.active {
     background: var(--accent);
-    color: #fff;
+    color: #0f1114;
   }
   .toggle-btn:not(.active):hover {
     color: var(--text);
@@ -352,7 +352,7 @@
   .btn-primary {
     background: var(--accent);
     border: none;
-    color: #fff;
+    color: #0f1114;
     padding: 8px 16px;
     border-radius: var(--radius-sm);
     font-size: 13px;

--- a/ui/src/styles/chat-shared.css
+++ b/ui/src/styles/chat-shared.css
@@ -59,7 +59,7 @@
 }
 
 .chat-avatar.agent .chat-avatar-text {
-  color: #fff;
+  color: #0f1114;
 }
 
 .chat-body {

--- a/ui/src/styles/global.css
+++ b/ui/src/styles/global.css
@@ -1,17 +1,20 @@
 :root {
-  --bg: #0d1117;
-  --bg-elevated: #161b22;
-  --surface: #1c2128;
-  --surface-hover: #242b35;
-  --border: #30363d;
-  --border-accent: #58a6ff;
+  /* Backgrounds — warm dark, not cold blue-black */
+  --bg: #0f1114;
+  --bg-elevated: #181a1f;
+  --surface: #1e2025;
+  --surface-hover: #26282e;
+  --border: #2e3038;
+  --border-accent: #c9a84c;
 
-  --text: #e6edf3;
-  --text-secondary: #8b949e;
-  --text-muted: #656d76;
+  /* Text — slightly warm white, not blue-tinted */
+  --text: #e8e6e3;
+  --text-secondary: #9a9590;
+  --text-muted: #6b6560;
 
-  --accent: #58a6ff;
-  --accent-hover: #79c0ff;
+  /* Accent — warm gold, truth as light */
+  --accent: #c9a84c;
+  --accent-hover: #dbbe65;
   --green: #3fb950;
   --red: #f85149;
   --yellow: #d29922;
@@ -105,7 +108,7 @@ button {
 }
 
 ::selection {
-  background: rgba(88, 166, 255, 0.3);
+  background: rgba(201, 168, 76, 0.3);
 }
 
 @media (max-width: 768px) {


### PR DESCRIPTION
## What
Replace the cold GitHub-blue accent with warm gold (#c9a84c) and give Aletheia its own visual identity.

## Why
The UI was a GitHub-dark clone — cold blue accent, generic ⚡ favicon, 'Loading...' as the HTML title. Aletheia is a philosophical system rooted in Greek thought. Its visual identity should reflect that: warmth, authority, intention.

## Changes
- **Favicon**: ἀ (Greek alpha with rough breathing) — the first character of ἀλήθεια
- **Title**: 'Aletheia' instead of 'Loading...'
- **Accent**: #58a6ff → #c9a84c (warm gold) — updated across 22 files
- **Backgrounds**: subtle warm shift (#0d1117 → #0f1114)
- **Text**: slightly warm white (#e6edf3 → #e8e6e3)
- **Contrast**: all white-on-accent text → dark (#0f1114) for gold legibility
- **Empty state**: agent name + 'Ready when you are.' replaces generic prompt
- **Graph**: community palette, structural edges, timeline controls updated

## Testing
- `npm run build` passes (ui/)
- All components render with consistent theme
- Verified contrast ratios remain accessible (gold on dark bg, dark text on gold)