### PR TITLE
fix: recover streaming indicator after page refresh

### DIFF
--- a/ui/src/components/chat/ChatView.svelte
+++ b/ui/src/components/chat/ChatView.svelte
@@ -47,7 +47,7 @@
   } from "../../stores/sessions.svelte";
   import { distillSession, fetchCommands, executeCommand } from "../../lib/api";
   import type { CommandInfo } from "../../lib/types";
-  import { onGlobalEvent } from "../../lib/events";
+  import { onGlobalEvent, getActiveTurns } from "../../lib/events";
   import { onMount, onDestroy } from "svelte";
   import { addNotification } from "../../stores/notifications.svelte";
   import { showToast } from "../../stores/toast.svelte";
@@ -145,6 +145,16 @@
     } else if (!sessionId && prevSessionId) {
       prevSessionId = null;
       if (currentAgentId) clearMessages(currentAgentId);
+    }
+  });
+
+  // Recover remote streaming state when agent becomes available
+  $effect(() => {
+    const agentId = getActiveAgentId();
+    if (!agentId) return;
+    const activeTurns = getActiveTurns();
+    if (activeTurns[agentId] && activeTurns[agentId] > 0) {
+      setRemoteStreaming(agentId, true);
     }
   });
 


### PR DESCRIPTION
## Summary

- **Root cause**: SSE `init` event (carrying `activeTurns` map) arrived before the sidebar finished loading agents. `getActiveAgentId()` returned `null`, so the streaming state recovery silently failed. On second refresh, the turn had usually completed so messages appeared but the spinner was gone.

- **Fix**: Cache `activeTurns` in `events.ts` and add a Svelte `$effect` in `ChatView.svelte` that rechecks the cache whenever `getActiveAgentId()` changes. Also keeps the cache in sync via `turn:before`/`turn:after` events so it stays accurate between SSE reconnections.

## Test plan
- [x] UI builds cleanly (`npm run build`)
- [ ] Manual: start a long-running agent turn, refresh mid-turn, verify spinner shows immediately
- [ ] Manual: verify spinner clears when turn completes