### PR TITLE
refactor(ui): extract TOOL_CATEGORIES to shared lib/tools.ts

### DIFF
--- a/ui/src/components/chat/ToolPanel.svelte
+++ b/ui/src/components/chat/ToolPanel.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import type { ToolCallState } from "../../lib/types";
   import { formatDuration } from "../../lib/format";
+  import { getToolCategory } from "../../lib/tools";
   import { highlightCode, inferLanguage } from "../../lib/markdown";
   import DOMPurify from "dompurify";
   import Spinner from "../shared/Spinner.svelte";
@@ -42,33 +43,13 @@
     tools.reduce((sum, t) => sum + (t.durationMs ?? 0), 0)
   );
 
-  const TOOL_CATEGORIES: Record<string, { icon: string; label: string }> = {
-    read: { icon: "\u{1F4C1}", label: "fs" },
-    write: { icon: "\u{1F4C1}", label: "fs" },
-    edit: { icon: "\u{1F4C1}", label: "fs" },
-    ls: { icon: "\u{1F4C1}", label: "fs" },
-    find: { icon: "\u{1F50D}", label: "search" },
-    grep: { icon: "\u{1F50D}", label: "search" },
-    web_search: { icon: "\u{1F50D}", label: "search" },
-    mem0_search: { icon: "\u{1F50D}", label: "search" },
-    exec: { icon: "\u26A1", label: "exec" },
-    sessions_send: { icon: "\u{1F4AC}", label: "comms" },
-    sessions_ask: { icon: "\u{1F4AC}", label: "comms" },
-    sessions_spawn: { icon: "\u{1F4AC}", label: "comms" },
-    message: { icon: "\u{1F4AC}", label: "comms" },
-    blackboard: { icon: "\u{1F9E0}", label: "system" },
-    note: { icon: "\u{1F9E0}", label: "system" },
-    enable_tool: { icon: "\u{1F9E0}", label: "system" },
-    web_fetch: { icon: "\u{1F310}", label: "web" },
-  };
-
   let categoryStats = $derived.by(() => {
     const counts = new Map<string, { icon: string; count: number }>();
     for (const t of tools) {
-      const entry = TOOL_CATEGORIES[t.name] ?? { icon: "\u2699", label: "other" };
-      const existing = counts.get(entry.label);
+      const cat = getToolCategory(t.name);
+      const existing = counts.get(cat.label);
       if (existing) existing.count++;
-      else counts.set(entry.label, { icon: entry.icon, count: 1 });
+      else counts.set(cat.label, { icon: cat.icon, count: 1 });
     }
     return [...counts.values()];
   });

--- a/ui/src/components/chat/ToolStatusLine.svelte
+++ b/ui/src/components/chat/ToolStatusLine.svelte
@@ -1,35 +1,12 @@
 <script lang="ts">
   import type { ToolCallState } from "../../lib/types";
+  import { getToolCategory } from "../../lib/tools";
   import Spinner from "../shared/Spinner.svelte";
 
   let { tools, onclick }: {
     tools: ToolCallState[];
     onclick?: () => void;
   } = $props();
-
-  const TOOL_CATEGORIES: Record<string, { icon: string; label: string }> = {
-    read: { icon: "\u{1F4C1}", label: "fs" },
-    write: { icon: "\u{1F4C1}", label: "fs" },
-    edit: { icon: "\u{1F4C1}", label: "fs" },
-    ls: { icon: "\u{1F4C1}", label: "fs" },
-    find: { icon: "\u{1F50D}", label: "search" },
-    grep: { icon: "\u{1F50D}", label: "search" },
-    web_search: { icon: "\u{1F50D}", label: "search" },
-    mem0_search: { icon: "\u{1F50D}", label: "search" },
-    exec: { icon: "\u26A1", label: "exec" },
-    sessions_send: { icon: "\u{1F4AC}", label: "comms" },
-    sessions_ask: { icon: "\u{1F4AC}", label: "comms" },
-    sessions_spawn: { icon: "\u{1F4AC}", label: "comms" },
-    message: { icon: "\u{1F4AC}", label: "comms" },
-    blackboard: { icon: "\u{1F9E0}", label: "system" },
-    note: { icon: "\u{1F9E0}", label: "system" },
-    enable_tool: { icon: "\u{1F9E0}", label: "system" },
-    web_fetch: { icon: "\u{1F310}", label: "web" },
-  };
-
-  function getCategory(name: string): string {
-    return TOOL_CATEGORIES[name]?.label ?? "other";
-  }
 
   let running = $derived(tools.filter(t => t.status === "running"));
   let completed = $derived(tools.filter(t => t.status !== "running").length);
@@ -40,11 +17,10 @@
     if (running.length > 0 || total < 2) return "";
     const counts = new Map<string, { icon: string; count: number }>();
     for (const t of tools) {
-      const cat = getCategory(t.name);
-      const entry = TOOL_CATEGORIES[t.name] ?? { icon: "\u2699", label: "other" };
-      const existing = counts.get(cat);
+      const cat = getToolCategory(t.name);
+      const existing = counts.get(cat.label);
       if (existing) existing.count++;
-      else counts.set(cat, { icon: entry.icon, count: 1 });
+      else counts.set(cat.label, { icon: cat.icon, count: 1 });
     }
     return [...counts.values()].map(c => `${c.icon}${c.count}`).join(" ");
   });

--- a/ui/src/lib/tools.ts
+++ b/ui/src/lib/tools.ts
@@ -1,0 +1,42 @@
+// Canonical tool-to-category mapping — single source of truth for UI display
+export interface ToolCategory {
+  icon: string;
+  label: string;
+}
+
+export const TOOL_CATEGORIES: Record<string, ToolCategory> = {
+  // Filesystem
+  read: { icon: "\u{1F4C1}", label: "fs" },
+  write: { icon: "\u{1F4C1}", label: "fs" },
+  edit: { icon: "\u{1F4C1}", label: "fs" },
+  ls: { icon: "\u{1F4C1}", label: "fs" },
+
+  // Search
+  find: { icon: "\u{1F50D}", label: "search" },
+  grep: { icon: "\u{1F50D}", label: "search" },
+  web_search: { icon: "\u{1F50D}", label: "search" },
+  mem0_search: { icon: "\u{1F50D}", label: "search" },
+
+  // Execution
+  exec: { icon: "\u26A1", label: "exec" },
+
+  // Communication
+  sessions_send: { icon: "\u{1F4AC}", label: "comms" },
+  sessions_ask: { icon: "\u{1F4AC}", label: "comms" },
+  sessions_spawn: { icon: "\u{1F4AC}", label: "comms" },
+  message: { icon: "\u{1F4AC}", label: "comms" },
+
+  // System
+  blackboard: { icon: "\u{1F9E0}", label: "system" },
+  note: { icon: "\u{1F9E0}", label: "system" },
+  enable_tool: { icon: "\u{1F9E0}", label: "system" },
+
+  // Web
+  web_fetch: { icon: "\u{1F310}", label: "web" },
+};
+
+const DEFAULT_CATEGORY: ToolCategory = { icon: "\u2699", label: "other" };
+
+export function getToolCategory(name: string): ToolCategory {
+  return TOOL_CATEGORIES[name] ?? DEFAULT_CATEGORY;
+}


### PR DESCRIPTION
## What
Extract duplicated TOOL_CATEGORIES constant into a single shared module.

## Why
The identical 17-entry tool category map was copy-pasted in both ToolPanel.svelte and ToolStatusLine.svelte. Adding a new tool category required editing two files identically — a guaranteed drift source.

## Changes
- **New**: `ui/src/lib/tools.ts` — canonical mapping + `getToolCategory()` helper
- **Updated**: ToolStatusLine.svelte — imports from shared module
- **Updated**: ToolPanel.svelte — imports from shared module
- **Removed**: ~50 lines of duplicated definitions

## Testing
- `npm run build` passes