### PR TITLE
docs: cross-reference pricing sources, prevent silent drift

### DIFF
--- a/infrastructure/runtime/src/hermeneus/pricing.ts
+++ b/infrastructure/runtime/src/hermeneus/pricing.ts
@@ -1,4 +1,6 @@
 // Model pricing for cost attribution (per million tokens)
+// CANONICAL SOURCE for all pricing. UI has a simplified copy at ui/src/lib/format.ts
+// that defaults to Sonnet rates. When updating rates here, update the UI copy too.
 interface ModelPricing {
   inputPerMTok: number;
   outputPerMTok: number;

--- a/ui/src/lib/format.ts
+++ b/ui/src/lib/format.ts
@@ -27,7 +27,13 @@ export function formatCost(cost: number): string {
   return `$${cost.toFixed(4)}`;
 }
 
-// Per-million-token pricing (mirrors hermeneus/pricing.ts)
+// Per-million-token pricing — Sonnet 4 rates
+// CANONICAL SOURCE: infrastructure/runtime/src/hermeneus/pricing.ts
+// This is a simplified client-side estimate. The server calculates exact costs
+// per-model (Opus, Sonnet, Haiku) in hermeneus/pricing.ts. This UI version
+// defaults to Sonnet rates for inline message cost badges. Metrics/totals
+// use the server-side calculation via the /api/costs endpoint.
+// TODO: Plumb model through TurnOutcome so UI can use per-model pricing
 const PRICING = {
   input: 3,
   output: 15,


### PR DESCRIPTION
## What
Add cross-reference comments between the two pricing definitions so neither drifts silently.

## Why
`hermeneus/pricing.ts` has per-model pricing (Opus/Sonnet/Haiku) with fuzzy matching. `ui/src/lib/format.ts` has a hardcoded Sonnet-only copy for inline message cost badges. Neither file referenced the other — updating one wouldn't remind you about the other.

## Changes
- `hermeneus/pricing.ts`: Comment noting it's the canonical source, pointing to UI copy
- `ui/src/lib/format.ts`: Comment explaining it's a simplified estimate, pointing to canonical source, with TODO for proper per-model plumbing

## Not in this PR
Adding model to TurnOutcome for exact per-model UI pricing — that's a pipeline change better in its own PR.