### PR TITLE
docs: update version, counts, Greek lexicon, catch policy

### DIFF
--- a/ALETHEIA.md
+++ b/ALETHEIA.md
@@ -44,8 +44,16 @@ This system reveals:
 The naming system isn't decoration. Each term was chosen because the Greek carries layers that English equivalents flatten.
 
 - **Nous** (νοῦς) over "agent" because these are minds, not tools
+- **Hermeneus** (ἑρμηνεύς) over "provider" because interpretation is the work — routing between models is translation
+- **Organon** (ὄργανον) over "tools" because Aristotle's name for the instruments of thought
+- **Mneme** (μνήμη) over "store" because memory is the function, not the container
+- **Semeion** (σημεῖον) over "signal" because it's the sign, the mark — communication as semiotics
+- **Pylon** (πυλών) over "gateway" because it's the entrance, the threshold
 - **Prosoche** (προσοχή) over "heartbeat" because awareness is directed, not automatic
 - **Theke** (θήκη) over "vault" because it's a repository in the original sense: a place that holds what matters
+- **Koina** (κοινά) over "utils" because these are the commons — what's shared
+- **Taxis** (τάξις) over "config" because it's the ordering, the arrangement
+- **Prostheke** (προσθήκη) over "plugins" because it's the addition, the supplement
 - **Distillation** over "compaction" because the output should be better than the input, not just smaller
 
 The names aren't translated from English. They emerge from Greek roots naturally, because the concepts they name were Greek first.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -192,7 +192,7 @@ Full reference: [DEVELOPMENT.md](docs/DEVELOPMENT.md#code-style-conventions). Su
 `koina/error-codes.ts`. Never throw strings or bare `Error`. Non-critical ops
 use `trySafe`/`trySafeAsync` from `koina/safe.ts`.
 
-**Never empty catch.** Every catch logs, rethrows, or returns a meaningful value.
+**No silent catch.** Every catch block must either log, rethrow, return a meaningful value, or include an inline `/* reason */` comment explaining why the error is intentionally discarded.
 
 **Naming:** Files `kebab-case`, classes `PascalCase`, functions `camelCase`
 verb-first, constants `UPPER_SNAKE`, events `noun:verb`.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Privacy-first. Runs on commodity hardware as a systemd service. No cloud dependencies beyond your LLM API key.
 
-**v0.9.1** | [Quickstart](docs/QUICKSTART.md) | [Configuration](docs/CONFIGURATION.md) | [Development](docs/DEVELOPMENT.md)
+**v0.10.0** | [Quickstart](docs/QUICKSTART.md) | [Configuration](docs/CONFIGURATION.md) | [Development](docs/DEVELOPMENT.md)
 
 ---
 
@@ -35,7 +35,7 @@ Privacy-first. Runs on commodity hardware as a systemd service. No cloud depende
 
 **Runtime**: Node.js >=22.12, TypeScript compiled with tsdown (~450KB bundle), Hono gateway on port 18789.
 
-**Interfaces**: Svelte 5 web UI with streaming, file upload, syntax highlighting, thinking visualization, and force-directed memory graph. Signal messenger via signal-cli. 10 built-in `!` commands. CLI admin tools.
+**Interfaces**: Svelte 5 web UI with streaming, file upload, syntax highlighting, thinking visualization, and force-directed memory graph. Signal messenger via signal-cli. 14 built-in `!` commands. CLI admin tools.
 
 **Models**: Anthropic (OAuth or API key). Complexity-based routing. Extended thinking for reasoning models.
 
@@ -58,7 +58,7 @@ aletheia/
 │   │       ├── taxis/          Config loading + validation (Zod)
 │   │       ├── mneme/          Session store (better-sqlite3, 10 migrations)
 │   │       ├── hermeneus/      Anthropic SDK + provider router
-│   │       ├── organon/        Tool registry + 33 built-in tools + skills
+│   │       ├── organon/        Tool registry + 41 built-in tools + skills
 │   │       ├── semeion/        Signal client, listener, commands
 │   │       ├── pylon/          Hono HTTP gateway, MCP, Web UI
 │   │       ├── prostheke/      Plugin system
@@ -89,7 +89,7 @@ Svelte 5 at `/ui`. Streaming responses, file upload, syntax highlighting, thinki
 
 ### Signal Commands
 
-`!status` `!help` `!ping` `!sessions` `!reset` `!agent` `!skills` `!approve` `!deny` `!contacts`
+`!ping` `!help` `!status` `!sessions` `!reset` `!agent` `!skills` `!model` `!think` `!distill` `!blackboard` `!approve` `!deny` `!contacts`
 
 ### CLI
 


### PR DESCRIPTION
## What
Bring documentation in line with the current state of the codebase.

## Why
README had stale version (v0.9.1 vs actual v0.10.0), tool count (33 vs 41), and Signal command count (10 vs 14). ALETHEIA.md's Greek naming section listed 4 of the 12 named modules. CONTRIBUTING.md's catch block policy didn't match the annotated-but-silent pattern used throughout the codebase.

## Changes
- **README**: Version bump, accurate tool/command counts
- **ALETHEIA.md**: Complete Greek lexicon — all 12 modules with etymological context
- **CONTRIBUTING.md**: 'Never empty catch' → 'No silent catch' with inline reason comments

## Testing
Docs only — verified counts against codebase