### PR TITLE
feat(ui): accessibility improvements and micro-interaction polish

### DIFF
--- a/ui/src/components/chat/Message.svelte
+++ b/ui/src/components/chat/Message.svelte
@@ -233,11 +233,12 @@
     border: 1px solid var(--border);
     border-radius: 8px;
     padding: 1px 6px;
-    opacity: 0.7;
     cursor: default;
+    transition: color 0.15s, border-color 0.15s;
   }
   .cost-badge:hover {
-    opacity: 1;
+    color: var(--text-secondary);
+    border-color: var(--text-muted);
   }
 
   /* Media in messages */

--- a/ui/src/components/chat/MessageList.svelte
+++ b/ui/src/components/chat/MessageList.svelte
@@ -110,7 +110,7 @@
   {/if}
 
   {#if !isNearBottom && isStreaming}
-    <button class="scroll-btn" onclick={scrollToBottom}>
+    <button class="scroll-btn" onclick={scrollToBottom} aria-label="Scroll to newest messages">
       New messages below
     </button>
   {/if}

--- a/ui/src/components/chat/ToolPanel.svelte
+++ b/ui/src/components/chat/ToolPanel.svelte
@@ -218,8 +218,8 @@
         <span class="stat time">{formatDuration(totalDuration)}</span>
       {/if}
       <span class="stat-spacer"></span>
-      <button class="toggle-btn" onclick={expandAll} title="Expand all">⊞</button>
-      <button class="toggle-btn" onclick={collapseAll} title="Collapse all">⊟</button>
+      <button class="toggle-btn" onclick={expandAll} title="Expand all" aria-label="Expand all tool calls">⊞</button>
+      <button class="toggle-btn" onclick={collapseAll} title="Collapse all" aria-label="Collapse all tool calls">⊟</button>
     </div>
     {#if categoryStats.length > 1}
       <div class="header-categories">

--- a/ui/src/components/files/FileExplorer.svelte
+++ b/ui/src/components/files/FileExplorer.svelte
@@ -92,7 +92,7 @@
         const agentId = getActiveAgentId();
         loadTree(agentId ?? undefined);
         loadGitStatus(agentId ?? undefined);
-      }} title="Refresh">↻</button>
+      }} title="Refresh" aria-label="Refresh file tree">↻</button>
     </div>
     <div class="filter-row">
       <input
@@ -122,7 +122,7 @@
     {:else if getSelectedPath()}
       <div class="preview-header">
         <span class="preview-path">{getSelectedPath()}</span>
-        <button class="close-btn" onclick={clearFileSelection}>×</button>
+        <button class="close-btn" onclick={clearFileSelection} aria-label="Close file preview">×</button>
       </div>
       <pre class="preview-content">{@html highlightFileContent(getSelectedContent(), getSelectedPath()!)}</pre>
     {:else}

--- a/ui/src/components/settings/SettingsView.svelte
+++ b/ui/src/components/settings/SettingsView.svelte
@@ -128,9 +128,9 @@
       <div class="setting-row">
         <span class="setting-label">Font size</span>
         <div class="font-size-control">
-          <button class="size-btn" onclick={() => setFontSize(Math.max(11, fontSize - 1))}>−</button>
+          <button class="size-btn" onclick={() => setFontSize(Math.max(11, fontSize - 1))} aria-label="Decrease font size">−</button>
           <span class="size-value">{fontSize}px</span>
-          <button class="size-btn" onclick={() => setFontSize(Math.min(20, fontSize + 1))}>+</button>
+          <button class="size-btn" onclick={() => setFontSize(Math.min(20, fontSize + 1))} aria-label="Increase font size">+</button>
         </div>
       </div>
     </section>
@@ -242,7 +242,7 @@
     font-size: 13px;
   }
   .setting-row + .setting-row {
-    border-top: 1px solid rgba(48, 54, 61, 0.4);
+    border-top: 1px solid var(--border);
   }
   .setting-label {
     color: var(--text);

--- a/ui/src/styles/chat-shared.css
+++ b/ui/src/styles/chat-shared.css
@@ -21,8 +21,8 @@
 }
 
 @keyframes chat-fade-in {
-  from { opacity: 0; }
-  to { opacity: 1; }
+  from { opacity: 0; transform: translateY(4px); }
+  to { opacity: 1; transform: translateY(0); }
 }
 
 .chat-avatar {


### PR DESCRIPTION
## What
Add aria-labels to interactive elements missing them, improve micro-interactions.

## Why
The UI had 18 aria-labels across all components — decent for critical elements (close buttons, overlays) but missing on several buttons that use symbols/icons as their only content. Screen readers would announce these as unlabeled buttons.

The cost badge hover used an opacity trick (0.7 → 1.0) which is abrupt and doesn't communicate interactivity. Replaced with a smooth color transition. Message entry animations were opacity-only — added a subtle 4px vertical translate for a more natural entrance.

## Changes
**Accessibility:**
- Scroll-to-bottom button: `aria-label='Scroll to newest messages'`
- Tool panel expand/collapse: labels on ⊞/⊟ buttons  
- File explorer: refresh and close preview buttons
- Settings: font size +/- buttons

**Interactions:**
- Cost badge: opacity → color/border-color transition
- Message entry: opacity-only → opacity + translateY(4px)
- Settings row divider: hardcoded rgba → var(--border)

## Testing
- `npm run build` passes
- Verified transitions are smooth and intentional