### PR TITLE
feat: plug-and-play agent onboarding (spec 5, phases 1-4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to Aletheia are documented here.
 
 ---
 
+## [0.10.4] - 2026-02-22
+
+### Added
+- **`aletheia agent create`** (Spec 5 P1-P3) — CLI command scaffolds a new agent workspace from `_example/` template with onboarding SOUL.md. Supports `--id`, `--name`, `--emoji` flags or interactive prompts. Automatically updates `aletheia.json` with agent entry and web binding.
+- **Onboarding SOUL.md** (Spec 5 P4) — Scaffolded agents get an onboarding prompt as their initial SOUL.md. The agent interviews its operator to learn name, domain, working style, and boundaries, then writes its own `SOUL.md`, `USER.md`, and `MEMORY.md`. Zero runtime changes — the agent naturally transitions out of onboarding by overwriting SOUL.md via the write tool.
+
+---
+
 ## [0.10.3] - 2026-02-22
 
 ### Added

--- a/docs/specs/05_plug-and-play-onboarding.md
+++ b/docs/specs/05_plug-and-play-onboarding.md
@@ -1,6 +1,6 @@
 # Spec: Plug-and-Play Onboarding
 
-**Status:** Draft (rewritten 2026-02-20)
+**Status:** In Progress — Phases 1-4 done (PR #131)
 **Author:** Syn
 **Date:** 2026-02-19, revised 2026-02-20
 

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -8,11 +8,16 @@ that evolve with the system.
 
 ## Active Specs
 
+### In Progress
+
+| # | Spec | Status | Scope | Notes |
+|---|------|--------|-------|-------|
+| 5 | [Plug-and-Play Onboarding](05_plug-and-play-onboarding.md) | 4/6 phases | Agent scaffolding, CLI, onboarding | Needed for public adoption |
+
 ### Draft
 
 | # | Spec | Status | Scope | Notes |
 |---|------|--------|-------|-------|
-| 5 | [Plug-and-Play Onboarding](05_plug-and-play-onboarding.md) | Draft | Agent scaffolding, CLI, wizard | Needed for public adoption |
 | 25 | [Integrated IDE](25_integrated-ide.md) | Draft | File editor in web UI | Nice-to-have |
 | 27 | [Embedding Space Intelligence](27_embedding-space-intelligence.md) | Draft | Semantic space analysis, concept drift | Research-grade |
 | 22 | [Interop & Workflows](22_interop-and-workflows.md) | Draft | A2A protocol, workflow engine | A2A premature per Cody |
@@ -27,8 +32,7 @@ that evolve with the system.
 ### Priority Order
 
 **Draft:**
-1. **5** Onboarding — needed for public adoption
-2. **25** Integrated IDE
+1. **25** Integrated IDE
 3. **27** Embedding Space Intelligence
 4. **22** Interop & Workflows
 5. **24** Aletheia Linux — long-term
@@ -64,7 +68,7 @@ that evolve with the system.
 | [Tool Call Governance](archive/spec-tool-call-governance.md) | PR #22 | Approval gates, timeouts, LoopDetector |
 | [Distillation Persistence](archive/spec-distillation-memory-persistence.md) | Hooks | Workspace flush on distillation |
 
-**Score: 26 archived, 0 in progress, 5 draft/skeleton.**
+**Score: 26 archived, 1 in progress, 4 draft/skeleton.**
 
 ## Conventions
 

--- a/infrastructure/runtime/src/taxis/scaffold.test.ts
+++ b/infrastructure/runtime/src/taxis/scaffold.test.ts
@@ -1,0 +1,141 @@
+// Tests for agent workspace scaffolding
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdirSync, writeFileSync, readFileSync, existsSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { validateAgentId, scaffoldAgent } from "./scaffold.js";
+
+const TEST_ROOT = `/tmp/scaffold-test-${Date.now()}`;
+
+function setupFixture() {
+  const nousDir = join(TEST_ROOT, "nous");
+  const templateDir = join(nousDir, "_example");
+  const configPath = join(TEST_ROOT, "aletheia.json");
+
+  mkdirSync(templateDir, { recursive: true });
+
+  for (const file of ["AGENTS.md", "GOALS.md", "MEMORY.md", "TOOLS.md", "CONTEXT.md", "PROSOCHE.md"]) {
+    writeFileSync(join(templateDir, file), `# ${file}\nTemplate content.\n`);
+  }
+  writeFileSync(join(templateDir, "SOUL.md"), "# Example Soul\nTemplate.\n");
+  writeFileSync(join(templateDir, "IDENTITY.md"), "name: Atlas\nemoji: 🗺️\n");
+  writeFileSync(join(templateDir, "USER.md"), "# User\nTemplate.\n");
+
+  const config = {
+    agents: { defaults: {}, list: [{ id: "syn", workspace: join(nousDir, "syn") }] },
+    bindings: [{ agentId: "syn", match: { channel: "signal" } }],
+  };
+  writeFileSync(configPath, JSON.stringify(config, null, 2));
+
+  return { nousDir, templateDir, configPath };
+}
+
+describe("validateAgentId", () => {
+  it("accepts valid IDs", () => {
+    expect(validateAgentId("atlas").valid).toBe(true);
+    expect(validateAgentId("my-agent").valid).toBe(true);
+    expect(validateAgentId("a1").valid).toBe(true);
+    expect(validateAgentId("test-agent-99").valid).toBe(true);
+  });
+
+  it("rejects empty ID", () => {
+    const result = validateAgentId("");
+    expect(result.valid).toBe(false);
+    expect(result.reason).toContain("empty");
+  });
+
+  it("rejects uppercase", () => {
+    expect(validateAgentId("Atlas").valid).toBe(false);
+  });
+
+  it("rejects spaces", () => {
+    expect(validateAgentId("my agent").valid).toBe(false);
+  });
+
+  it("rejects reserved names", () => {
+    expect(validateAgentId("_example").valid).toBe(false);
+    expect(validateAgentId("_onboarding").valid).toBe(false);
+  });
+
+  it("rejects too long", () => {
+    expect(validateAgentId("a".repeat(31)).valid).toBe(false);
+  });
+
+  it("rejects trailing hyphen", () => {
+    expect(validateAgentId("test-").valid).toBe(false);
+  });
+});
+
+describe("scaffoldAgent", () => {
+  let fixture: ReturnType<typeof setupFixture>;
+
+  beforeEach(() => { fixture = setupFixture(); });
+  afterEach(() => { rmSync(TEST_ROOT, { recursive: true, force: true }); });
+
+  it("creates workspace with all expected files", () => {
+    const result = scaffoldAgent({
+      id: "atlas",
+      name: "Atlas",
+      emoji: "🗺️",
+      ...fixture,
+    });
+
+    expect(result.workspace).toBe(join(fixture.nousDir, "atlas"));
+    expect(existsSync(result.workspace)).toBe(true);
+    expect(result.filesCreated).toContain("AGENTS.md");
+    expect(result.filesCreated).toContain("SOUL.md");
+    expect(result.filesCreated).toContain("IDENTITY.md");
+    expect(result.filesCreated).toContain("USER.md");
+    expect(result.filesCreated).toContain("MEMORY.md");
+    expect(result.filesCreated.length).toBeGreaterThanOrEqual(9);
+  });
+
+  it("writes correct IDENTITY.md", () => {
+    scaffoldAgent({ id: "atlas", name: "Atlas", emoji: "🗺️", ...fixture });
+    const content = readFileSync(join(fixture.nousDir, "atlas", "IDENTITY.md"), "utf-8");
+    expect(content).toContain("name: Atlas");
+    expect(content).toContain("emoji: 🗺️");
+  });
+
+  it("writes onboarding SOUL.md, not template", () => {
+    scaffoldAgent({ id: "atlas", name: "Atlas", ...fixture });
+    const soul = readFileSync(join(fixture.nousDir, "atlas", "SOUL.md"), "utf-8");
+    expect(soul).toContain("Onboarding");
+    expect(soul).toContain("first conversation");
+    expect(soul).toContain("Atlas");
+    expect(soul).not.toContain("Example Soul");
+  });
+
+  it("updates config with agent entry and web binding", () => {
+    scaffoldAgent({ id: "atlas", name: "Atlas", ...fixture });
+    const config = JSON.parse(readFileSync(fixture.configPath, "utf-8"));
+    const agent = config.agents.list.find((a: { id: string }) => a.id === "atlas");
+    expect(agent).toBeDefined();
+    expect(agent.name).toBe("Atlas");
+    expect(agent.identity.emoji).toBe("🤖");
+    const binding = config.bindings.find((b: { agentId: string }) => b.agentId === "atlas");
+    expect(binding).toBeDefined();
+    expect(binding.match.channel).toBe("web");
+  });
+
+  it("rejects duplicate agent ID", () => {
+    expect(() => scaffoldAgent({ id: "syn", name: "Syn Dupe", ...fixture }))
+      .toThrow("already exists in config");
+  });
+
+  it("rejects if workspace already exists", () => {
+    mkdirSync(join(fixture.nousDir, "taken"), { recursive: true });
+    expect(() => scaffoldAgent({ id: "taken", name: "Taken", ...fixture }))
+      .toThrow("Workspace already exists");
+  });
+
+  it("uses default emoji when none provided", () => {
+    scaffoldAgent({ id: "helper", name: "Helper", ...fixture });
+    const identity = readFileSync(join(fixture.nousDir, "helper", "IDENTITY.md"), "utf-8");
+    expect(identity).toContain("emoji: 🤖");
+  });
+
+  it("rejects invalid ID", () => {
+    expect(() => scaffoldAgent({ id: "Bad Name", name: "Bad", ...fixture }))
+      .toThrow("Invalid agent ID");
+  });
+});

--- a/infrastructure/runtime/src/taxis/scaffold.ts
+++ b/infrastructure/runtime/src/taxis/scaffold.ts
@@ -1,0 +1,135 @@
+// Agent workspace scaffolding with onboarding SOUL.md
+import { copyFileSync, existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { readJson, writeJson } from "../koina/fs.js";
+import type { AletheiaConfig } from "./schema.js";
+
+export interface ScaffoldOpts {
+  id: string;
+  name: string;
+  emoji?: string;
+  nousDir: string;
+  configPath: string;
+  templateDir: string;
+}
+
+export interface ScaffoldResult {
+  workspace: string;
+  configUpdated: boolean;
+  filesCreated: string[];
+}
+
+const ID_PATTERN = /^[a-z][a-z0-9-]*$/;
+const RESERVED_IDS = new Set(["_example", "_onboarding", "_template"]);
+const MIN_ID_LEN = 2;
+const MAX_ID_LEN = 30;
+
+const TEMPLATE_FILES = [
+  "AGENTS.md", "GOALS.md", "MEMORY.md", "TOOLS.md", "CONTEXT.md", "PROSOCHE.md",
+];
+
+export function validateAgentId(id: string): { valid: boolean; reason?: string } {
+  if (!id) return { valid: false, reason: "ID cannot be empty" };
+  if (id.length < MIN_ID_LEN) return { valid: false, reason: `ID must be at least ${MIN_ID_LEN} characters` };
+  if (id.length > MAX_ID_LEN) return { valid: false, reason: `ID must be at most ${MAX_ID_LEN} characters` };
+  if (RESERVED_IDS.has(id)) return { valid: false, reason: `"${id}" is reserved` };
+  if (!ID_PATTERN.test(id)) return { valid: false, reason: "ID must be lowercase alphanumeric with hyphens, starting with a letter" };
+  if (id.endsWith("-")) return { valid: false, reason: "ID cannot end with a hyphen" };
+  return { valid: true };
+}
+
+function onboardingSoul(name: string): string {
+  return `# Onboarding
+
+You are **${name}**. This is your first conversation with your operator.
+
+Your goal is to learn enough about your operator and your role to write your own identity files. Until you do, these onboarding instructions will be your system prompt on every turn.
+
+## What to Learn
+
+Work through these topics one at a time. Don't rush — ask one question, listen, reflect back, then move on.
+
+1. **Operator** — name, how they prefer to be addressed, communication style preferences
+2. **Your domain** — what area(s) you'll focus on, what tasks you'll handle
+3. **Working style** — formality level, verbosity, proactivity, when to ask vs act
+4. **Boundaries** — what you should never do, what requires confirmation, uncertainty handling
+
+## Guidelines
+
+- One topic at a time. Reflect back what you heard before moving on.
+- Reference AGENTS.md for operational defaults — don't re-ask what's already documented.
+- Demonstrate calibration live: match the style they describe as you go.
+
+## When You're Ready
+
+After covering all topics, summarize what you've learned and ask the operator to confirm. Once confirmed, use the write tool to create these files in your workspace:
+
+1. **SOUL.md** — your identity, voice, values, working style (this replaces this onboarding file)
+2. **USER.md** — operator profile, preferences, communication style
+3. **MEMORY.md** — initial knowledge base from the conversation
+
+After writing these files, naturally transition to your first real task. Your first responses after onboarding should demonstrate the calibrated style your operator described.
+`;
+}
+
+export function scaffoldAgent(opts: ScaffoldOpts): ScaffoldResult {
+  const validation = validateAgentId(opts.id);
+  if (!validation.valid) {
+    throw new Error(`Invalid agent ID: ${validation.reason}`);
+  }
+
+  const workspace = join(opts.nousDir, opts.id);
+  if (existsSync(workspace)) {
+    throw new Error(`Workspace already exists: ${workspace}`);
+  }
+
+  const config = readJson<AletheiaConfig>(opts.configPath);
+  if (!config) {
+    throw new Error(`Cannot read config: ${opts.configPath}`);
+  }
+
+  const agents = config.agents?.list ?? [];
+  if (agents.some((a: { id: string }) => a.id === opts.id)) {
+    throw new Error(`Agent ID "${opts.id}" already exists in config`);
+  }
+
+  mkdirSync(workspace, { recursive: true });
+  const filesCreated: string[] = [];
+
+  for (const file of TEMPLATE_FILES) {
+    const src = join(opts.templateDir, file);
+    if (existsSync(src)) {
+      copyFileSync(src, join(workspace, file));
+      filesCreated.push(file);
+    }
+  }
+
+  const identityContent = `name: ${opts.name}\nemoji: ${opts.emoji ?? "🤖"}\n`;
+  writeFileSync(join(workspace, "IDENTITY.md"), identityContent, "utf-8");
+  filesCreated.push("IDENTITY.md");
+
+  writeFileSync(join(workspace, "SOUL.md"), onboardingSoul(opts.name), "utf-8");
+  filesCreated.push("SOUL.md");
+
+  writeFileSync(join(workspace, "USER.md"), "# Operator\n\n*To be written during onboarding.*\n", "utf-8");
+  filesCreated.push("USER.md");
+
+  agents.push({
+    id: opts.id,
+    workspace,
+    name: opts.name,
+    identity: { name: opts.name, emoji: opts.emoji ?? "🤖" },
+  } as AletheiaConfig["agents"]["list"][number]);
+
+  const bindings = config.bindings ?? [];
+  bindings.push({
+    agentId: opts.id,
+    match: { channel: "web" },
+  } as AletheiaConfig["bindings"][number]);
+
+  config.agents.list = agents;
+  config.bindings = bindings;
+  writeJson(opts.configPath, config);
+
+  return { workspace, configUpdated: true, filesCreated };
+}


### PR DESCRIPTION
## Summary
- Add `aletheia agent create` CLI command that scaffolds a new agent workspace from `_example/` template
- Scaffolded agents get an **onboarding SOUL.md** — the agent interviews its operator and writes its own identity files
- Zero runtime changes: SOUL.md is priority 1 in bootstrap, so the onboarding prompt is the system prompt until the agent overwrites it
- 15 tests, typecheck clean, lint clean

## Files
- **New:** `src/taxis/scaffold.ts` — `scaffoldAgent()`, `validateAgentId()`, onboarding template
- **New:** `src/taxis/scaffold.test.ts` — 15 tests (ID validation + workspace scaffolding)
- **Edit:** `src/entry.ts` — `aletheia agent create` command with interactive prompts
- **Edit:** spec 5 status, README, CHANGELOG

## How it works
```
CLI creates workspace → SOUL.md = onboarding prompt
Agent's 1st session  → reads onboarding SOUL.md, interviews operator
Agent writes files    → SOUL.md overwritten with real identity
Agent's 2nd session   → reads real SOUL.md, fully calibrated
```

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run src/taxis/scaffold.test.ts` — 15/15 passing
- [x] `npx oxlint src/` — no new warnings
- [x] `npx tsdown` — builds successfully
- [ ] Manual: `aletheia agent create --id test-agent --name "Test Agent"` on server
- [ ] Manual: verify onboarding conversation works in web UI