### PR TITLE
chore: replace synthetic gold with aged brass accent

### DIFF
--- a/ui/src/components/chat/DistillationProgress.svelte
+++ b/ui/src/components/chat/DistillationProgress.svelte
@@ -80,8 +80,8 @@
     gap: 8px;
     padding: 6px 12px;
     margin: 4px 0;
-    background: rgba(201, 168, 76, 0.06);
-    border: 1px solid rgba(201, 168, 76, 0.2);
+    background: rgba(154, 123, 79, 0.06);
+    border: 1px solid rgba(154, 123, 79, 0.2);
     border-radius: 8px;
     font-size: 12px;
     color: var(--text-secondary);

--- a/ui/src/components/chat/InputBar.svelte
+++ b/ui/src/components/chat/InputBar.svelte
@@ -465,7 +465,7 @@
   }
   .attach-btn:hover {
     color: var(--accent);
-    background: rgba(201, 168, 76, 0.1);
+    background: rgba(154, 123, 79, 0.1);
   }
   .stop-btn {
     background: rgba(248, 81, 73, 0.1);
@@ -620,7 +620,7 @@
   .drag-overlay {
     position: absolute;
     inset: 0;
-    background: rgba(201, 168, 76, 0.08);
+    background: rgba(154, 123, 79, 0.08);
     border: 2px dashed var(--accent);
     border-radius: var(--radius);
     display: flex;

--- a/ui/src/components/chat/ToolStatusLine.svelte
+++ b/ui/src/components/chat/ToolStatusLine.svelte
@@ -167,7 +167,7 @@
     color: var(--text);
   }
   .tool-status-line.active {
-    border-color: rgba(201, 168, 76, 0.3);
+    border-color: rgba(154, 123, 79, 0.3);
     color: var(--text);
   }
   .tool-status-line.has-errors {

--- a/ui/src/components/graph/ContextLookup.svelte
+++ b/ui/src/components/graph/ContextLookup.svelte
@@ -180,10 +180,10 @@
     font-size: 12px;
     font-family: var(--font-sans, system-ui);
   }
-  .lookup-input:focus { outline: none; border-color: var(--accent, #c9a84c); }
+  .lookup-input:focus { outline: none; border-color: var(--accent, #9A7B4F); }
 
   .search-btn {
-    background: var(--accent, #c9a84c);
+    background: var(--accent, #9A7B4F);
     border: none;
     color: #0f1114;
     padding: 5px 10px;
@@ -249,7 +249,7 @@
   }
 
   .detail-preview {
-    border-top: 1px solid var(--accent, #c9a84c);
+    border-top: 1px solid var(--accent, #9A7B4F);
     padding: 8px;
     overflow-y: auto;
     max-height: 300px;

--- a/ui/src/components/graph/DriftPanel.svelte
+++ b/ui/src/components/graph/DriftPanel.svelte
@@ -233,7 +233,7 @@
   .section-tab:hover { color: var(--text-secondary, #8b949e); }
   .section-tab.active {
     color: var(--text, #e6edf3);
-    border-bottom-color: var(--accent, #c9a84c);
+    border-bottom-color: var(--accent, #9A7B4F);
   }
 
   .section-content {
@@ -273,7 +273,7 @@
   .entity-link {
     background: none;
     border: none;
-    color: var(--accent, #c9a84c);
+    color: var(--accent, #9A7B4F);
     font-size: 12px;
     cursor: pointer;
     padding: 0;

--- a/ui/src/components/graph/Graph2D.svelte
+++ b/ui/src/components/graph/Graph2D.svelte
@@ -34,7 +34,7 @@
   let staleSet = $derived(new Set(driftData?.stale_entities?.map(e => e.name) ?? []));
 
   const PALETTE = [
-    "#c9a84c", "#3fb950", "#d29922", "#f85149", "#bc8cff",
+    "#9A7B4F", "#3fb950", "#d29922", "#f85149", "#bc8cff",
     "#f778ba", "#79c0ff", "#56d4dd", "#e3b341", "#db6d28",
     "#8b949e", "#7ee787", "#a5d6ff", "#ffa657", "#ff7b72",
     "#d2a8ff", "#ffd8b5", "#89dceb", "#f9e2af", "#a6e3a1",
@@ -57,7 +57,7 @@
     const temporal = ["PRECEDES", "FOLLOWS", "OCCURRED_AT", "MENTIONS"];
 
     if (social.includes(relType)) return "rgba(63, 185, 80, 0.5)";
-    if (structural.includes(relType)) return "rgba(201, 168, 76, 0.5)";
+    if (structural.includes(relType)) return "rgba(154, 123, 79, 0.5)";
     if (temporal.includes(relType)) return "rgba(210, 153, 34, 0.5)";
     return "rgba(139, 148, 158, 0.35)";
   }

--- a/ui/src/components/graph/Graph3D.svelte
+++ b/ui/src/components/graph/Graph3D.svelte
@@ -20,7 +20,7 @@
   } = $props();
 
   const PALETTE = [
-    "#c9a84c", "#3fb950", "#d29922", "#f85149", "#bc8cff",
+    "#9A7B4F", "#3fb950", "#d29922", "#f85149", "#bc8cff",
     "#f778ba", "#79c0ff", "#56d4dd", "#e3b341", "#db6d28",
     "#8b949e", "#7ee787", "#a5d6ff", "#ffa657", "#ff7b72",
     "#d2a8ff", "#ffd8b5", "#89dceb", "#f9e2af", "#a6e3a1",
@@ -43,7 +43,7 @@
     const temporal = ["PRECEDES", "FOLLOWS", "OCCURRED_AT", "MENTIONS"];
 
     if (social.includes(relType)) return "rgba(63, 185, 80, 0.35)";
-    if (structural.includes(relType)) return "rgba(201, 168, 76, 0.35)";
+    if (structural.includes(relType)) return "rgba(154, 123, 79, 0.35)";
     if (temporal.includes(relType)) return "rgba(210, 153, 34, 0.35)";
     return "rgba(139, 148, 158, 0.25)";
   }

--- a/ui/src/components/graph/GraphView.svelte
+++ b/ui/src/components/graph/GraphView.svelte
@@ -35,14 +35,14 @@
   let showEdgeFilter = $state(true);
 
   const PALETTE = [
-    "#c9a84c", "#3fb950", "#d29922", "#f85149", "#bc8cff",
+    "#9A7B4F", "#3fb950", "#d29922", "#f85149", "#bc8cff",
     "#f778ba", "#79c0ff", "#56d4dd", "#e3b341", "#db6d28",
     "#8b949e", "#7ee787", "#a5d6ff", "#ffa657", "#ff7b72",
     "#d2a8ff", "#ffd8b5", "#89dceb", "#f9e2af", "#a6e3a1",
   ];
 
   const AGENT_COLORS: Record<string, string> = {
-    syn: "#c9a84c",
+    syn: "#9A7B4F",
     demiurge: "#d29922",
     syl: "#f778ba",
     akron: "#3fb950",

--- a/ui/src/components/graph/TimelineSlider.svelte
+++ b/ui/src/components/graph/TimelineSlider.svelte
@@ -73,8 +73,8 @@
   }
 
   .timeline-slider.active {
-    background: color-mix(in srgb, var(--accent, #c9a84c) 8%, var(--bg-elevated, #181a1f));
-    border-bottom-color: var(--accent, #c9a84c);
+    background: color-mix(in srgb, var(--accent, #9A7B4F) 8%, var(--bg-elevated, #181a1f));
+    border-bottom-color: var(--accent, #9A7B4F);
   }
 
   .timeline-row {
@@ -107,7 +107,7 @@
   }
   .preset-btn:hover {
     color: var(--text, #e6edf3);
-    border-color: var(--accent, #c9a84c);
+    border-color: var(--accent, #9A7B4F);
   }
 
   .date-inputs {
@@ -128,7 +128,7 @@
   }
   .date-input:focus {
     outline: none;
-    border-color: var(--accent, #c9a84c);
+    border-color: var(--accent, #9A7B4F);
   }
 
   .date-separator {
@@ -137,7 +137,7 @@
   }
 
   .apply-btn {
-    background: var(--accent, #c9a84c);
+    background: var(--accent, #9A7B4F);
     border: none;
     color: #0f1114;
     padding: 2px 10px;

--- a/ui/src/styles/chat-shared.css
+++ b/ui/src/styles/chat-shared.css
@@ -41,8 +41,8 @@
 }
 
 .chat-avatar.agent {
-  background: var(--accent);
-  border-color: var(--accent);
+  background: rgba(154, 123, 79, 0.15);
+  border-color: rgba(154, 123, 79, 0.4);
 }
 
 .chat-avatar-emoji {
@@ -59,7 +59,7 @@
 }
 
 .chat-avatar.agent .chat-avatar-text {
-  color: #0f1114;
+  color: var(--accent);
 }
 
 .chat-body {

--- a/ui/src/styles/global.css
+++ b/ui/src/styles/global.css
@@ -5,16 +5,16 @@
   --surface: #1e2025;
   --surface-hover: #26282e;
   --border: #2e3038;
-  --border-accent: #c9a84c;
+  --border-accent: #9A7B4F;
 
   /* Text — slightly warm white, not blue-tinted */
   --text: #e8e6e3;
   --text-secondary: #9a9590;
   --text-muted: #6b6560;
 
-  /* Accent — warm gold, truth as light */
-  --accent: #c9a84c;
-  --accent-hover: #dbbe65;
+  /* Accent — aged brass, material warmth */
+  --accent: #9A7B4F;
+  --accent-hover: #B08E5E;
   --green: #3fb950;
   --red: #f85149;
   --yellow: #d29922;
@@ -108,7 +108,7 @@ button {
 }
 
 ::selection {
-  background: rgba(201, 168, 76, 0.3);
+  background: rgba(154, 123, 79, 0.3);
 }
 
 @media (max-width: 768px) {


### PR DESCRIPTION
## What

Replace the LED-backlit gold (`#c9a84c`) with aged brass (`#9A7B4F`) — a color grounded in materials, not light.

## Why

The gold read as synthetic/tech ("Tron-like"). Aletheia isn't Ardent, but Ardent is Cody — the sensibility carries. Aged brass is the color of hardware that's been handled, not hardware that's backlit.

## Emoji visibility fix

The solid gold square behind agent emoji in messages made them hard to read against the dark UI. Changed to a subtle tinted surface (`rgba(154, 123, 79, 0.15)`) with a 40% border — the emoji itself becomes the visual element.

## WCAG

| Combination | Ratio | Grade |
|-------------|-------|-------|
| Dark text on brass (buttons) | 4.79:1 | AA ✓ |
| Brass text on dark bg (links) | 4.79:1 | AA ✓ |

## Files (11)

- `global.css` — CSS custom properties (accent, border-accent, selection)
- `chat-shared.css` — Agent avatar background + initials text color
- `InputBar.svelte` — Attachment hover backgrounds
- `ToolStatusLine.svelte` — Tool border accent
- `DistillationProgress.svelte` — Progress indicator
- `GraphView.svelte`, `Graph2D.svelte`, `Graph3D.svelte` — Node/edge colors
- `ContextLookup.svelte`, `DriftPanel.svelte`, `TimelineSlider.svelte` — Graph UI fallbacks

Zero behavioral changes. Build verified.