### PR TITLE
feat: complete spec 5 (phases 5-6) + TUI spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to Aletheia are documented here.
 
 ---
 
+## [0.10.5] - 2026-02-22
+
+### Added
+- **Web UI agent creation** (Spec 5 P5) — "+" button in sidebar opens inline form to create agents. Calls `POST /api/agents` which scaffolds workspace, updates config, and hot-reloads the runtime. New agent is auto-selected for immediate onboarding.
+- **`aletheia init` wizard** (Spec 5 P6) — First-run setup: prompts for Anthropic API key, gateway port, and first agent. Writes credentials, config, and scaffolds workspace in one flow.
+
+### Specs Completed
+- **Spec 5** Plug-and-Play Onboarding — 6/6 phases
+
+---
+
 ## [0.10.4] - 2026-02-22
 
 ### Added

--- a/docs/specs/05_plug-and-play-onboarding.md
+++ b/docs/specs/05_plug-and-play-onboarding.md
@@ -1,6 +1,6 @@
 # Spec: Plug-and-Play Onboarding
 
-**Status:** In Progress — Phases 1-4 done (PR #131)
+**Status:** All 6 phases complete (PRs #137, #138)
 **Author:** Syn
 **Date:** 2026-02-19, revised 2026-02-20
 

--- a/docs/specs/28_tui.md
+++ b/docs/specs/28_tui.md
@@ -1,0 +1,361 @@
+# Aletheia TUI
+
+**Status:** Draft
+**Component**: `tui/` — Terminal User Interface Client
+**Target**: Ratatui + Crossterm (Rust)
+**Interface**: Third client alongside Web UI and Signal
+**Gateway Dependency**: Existing Hono REST API + SSE on `:18789`
+**Scope**: Conversational interface with agent management — not a web UI replacement
+
+---
+
+## 1. Design Principles
+
+The TUI is a **thin client**. It owns no business logic, no memory management, no agent routing. It consumes the same gateway API that the Svelte UI and Signal client already use. This means zero gateway changes are required.
+
+**In scope**: Message send/receive, SSE streaming, agent switching, session management, cost display, thinking block visualization, basic markdown rendering.
+
+**Out of scope**: File upload, force-directed memory graph, full syntax highlighting (basic only), image rendering. These stay in the web UI.
+
+---
+
+## 2. Architecture
+
+```
+┌─────────────────────────────────────┐
+│            Aletheia TUI             │
+│                                     │
+│  ┌───────────┐  ┌────────────────┐  │
+│  │  App State │  │  Event Loop    │  │
+│  │            │◄─┤  (crossterm +  │  │
+│  │  messages  │  │   tokio select)│  │
+│  │  agents    │  │                │  │
+│  │  sessions  │  └────────────────┘  │
+│  │  input buf │          │           │
+│  └─────┬──────┘          │           │
+│        │           ┌─────▼────────┐  │
+│        │           │   Renderer   │  │
+│        │           │  (ratatui)   │  │
+│        │           └──────────────┘  │
+│  ┌─────▼──────────────────────────┐  │
+│  │       API Client (reqwest)     │  │
+│  │  REST calls + SSE streaming    │  │
+│  └────────────────────────────────┘  │
+└──────────────────┬──────────────────┘
+                   │ HTTP/SSE
+                   ▼
+            Gateway (:18789)
+```
+
+### Core Loop
+
+Standard Ratatui event loop with `tokio::select!` multiplexing three event sources:
+
+1. **Terminal events** — keystrokes, resize (via `crossterm::event`)
+2. **SSE stream** — assistant response chunks (via `reqwest` + `eventsource-stream`)
+3. **Tick timer** — UI refresh at 30fps for spinner animations, streaming cursor
+
+---
+
+## 3. Dependencies
+
+```toml
+[package]
+name = "aletheia-tui"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+ratatui = "0.29"
+crossterm = "0.28"
+tokio = { version = "1", features = ["full"] }
+reqwest = { version = "0.12", features = ["stream", "json"] }
+eventsource-stream = "0.2"
+futures-util = "0.3"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+clap = { version = "4", features = ["derive"] }
+dirs = "6"
+toml = "0.8"
+textwrap = "0.16"
+syntect = "5"
+pulldown-cmark = "0.12"
+unicode-width = "0.2"
+arboard = "3"
+```
+
+Estimated binary size: ~8-12MB (static link, release build with `strip = true`).
+
+---
+
+## 4. Layout
+
+### Primary View — Chat
+
+```
+┌─ Aletheia ─────────────────────── agent: curator ─── session: 3f8a ──┐
+│                                                                       │
+│  ╭─ You ──────────────────────────────────────────────────────────╮   │
+│  │ whats the term for text based images                          │   │
+│  ╰────────────────────────────────────────────────────────────────╯   │
+│                                                                       │
+│  ╭─ curator ──────────────────────────────────────────────────────╮   │
+│  │ You're thinking of **ASCII art** — images composed of text    │   │
+│  │ characters from the ASCII character set.                      │   │
+│  ╰────────────────────────────────────────────────────────────────╯   │
+│                                                                       │
+│  ╭─ You ──────────────────────────────────────────────────────────╮   │
+│  │ then whats the rust tui library                               │   │
+│  ╰────────────────────────────────────────────────────────────────╯   │
+│                                                                       │
+│  ╭─ curator ──────────────────────────────────────────────────────╮   │
+│  │ ▌ Ratatui — it's the most popular Rust library for building   │   │
+│  │ terminal user interfaces...                                   │   │
+│  ╰────────────────────────────────────────────────────────────────╯   │
+│                                                                       │
+├───────────────────────────────────────────────────────────────────────┤
+│ > _                                                                   │
+│                                                            Ctrl+? help│
+└───────────────────────────────────────────────────────────────────────┘
+```
+
+### Layout Breakdown
+
+| Region           | Widget         | Height    |
+|------------------|----------------|-----------|
+| Title bar        | `Block` title  | 1 row     |
+| Message area     | Scrollable `List` / custom widget | flex fill |
+| Divider          | `Block` border | 1 row     |
+| Input area       | `Paragraph` (editable) | 1-5 rows (auto-expand) |
+| Status bar       | `Paragraph`    | 1 row     |
+
+### Secondary Views (Modal Overlays)
+
+| View             | Trigger       | Content |
+|------------------|---------------|---------|
+| Agent picker     | `Ctrl+A`      | List of agents with model info, arrow-key select |
+| Session browser  | `Ctrl+S`      | Table of sessions with timestamps, agent, preview |
+| Help             | `Ctrl+?`      | Keybinding reference |
+| Cost summary     | `Ctrl+$`      | Token usage from `/api/costs/summary` |
+| System status    | `Ctrl+I`      | From `/api/status` — version, uptime, services |
+
+Modals render as centered floating `Block` widgets over the chat view.
+
+---
+
+## 5. Keybindings
+
+### Normal Mode (input focused)
+
+| Key              | Action |
+|------------------|--------|
+| `Enter`          | Send message (or newline with `Shift+Enter` / `Alt+Enter`) |
+| `Ctrl+C`         | Cancel streaming response / exit if idle |
+| `Ctrl+D`         | Exit |
+| `Ctrl+A`         | Agent picker |
+| `Ctrl+S`         | Session browser |
+| `Ctrl+N`         | New session |
+| `Ctrl+R`         | Reset current session |
+| `Ctrl+?` / `F1`  | Help overlay |
+| `Ctrl+$`         | Cost summary |
+| `Ctrl+I`         | System status |
+| `Ctrl+T`         | Toggle thinking block visibility |
+| `Ctrl+Y`         | Copy last response to clipboard |
+| `Ctrl+U`         | Clear input line |
+| `PageUp/Down`    | Scroll message history |
+| `Esc`            | Close overlay / cancel current action |
+
+### Overlay Mode
+
+| Key              | Action |
+|------------------|--------|
+| `↑/↓` or `j/k`  | Navigate list |
+| `Enter`          | Select |
+| `Esc`            | Close |
+| `/`              | Filter/search within overlay |
+
+---
+
+## 6. API Integration
+
+All calls target `http://{host}:{port}` where defaults are `localhost:18789`, configurable via CLI args or config file.
+
+### Endpoints Used
+
+| Endpoint                        | Method | Purpose |
+|---------------------------------|--------|---------|
+| `/health`                       | GET    | Startup connectivity check |
+| `/api/status`                   | GET    | Version, agents, uptime |
+| `/api/agents`                   | GET    | Agent list with model info |
+| `/api/sessions/stream`          | POST   | Send message, receive SSE stream |
+| `/api/sessions`                 | GET    | List sessions (for browser) |
+| `/api/costs/summary`            | GET    | Token/cost data |
+| `/api/metrics`                  | GET    | System metrics |
+| `/api/events`                   | GET    | Global SSE event stream |
+
+### SSE Streaming
+
+```rust
+// Pseudocode
+async fn stream_response(client: &Client, message: &str, agent: &str) {
+    let response = client
+        .post(format!("{}/api/sessions/stream", base_url))
+        .json(&json!({
+            "message": message,
+            "agent": agent,
+            "session_id": current_session
+        }))
+        .send()
+        .await?;
+
+    let mut stream = response.bytes_stream().eventsource();
+
+    while let Some(event) = stream.next().await {
+        match event.event.as_str() {
+            "content_block_delta" => { /* append text delta */ }
+            "thinking" => { /* append to thinking block */ }
+            "message_stop" => { break; }
+            "error" => { break; }
+            _ => {}
+        }
+    }
+}
+```
+
+---
+
+## 7. State Model
+
+```rust
+pub struct App {
+    pub mode: AppMode,
+    pub gateway_url: String,
+    pub messages: Vec<ChatMessage>,
+    pub input_buffer: String,
+    pub input_cursor: usize,
+    pub scroll_offset: usize,
+    pub streaming_buffer: Option<StreamingMessage>,
+    pub agents: Vec<Agent>,
+    pub current_agent: String,
+    pub current_session: Option<String>,
+    pub sessions: Vec<SessionSummary>,
+    pub show_thinking: bool,
+    pub overlay: Option<OverlayState>,
+    pub terminal_size: (u16, u16),
+    pub status_message: Option<(String, Instant)>,
+}
+
+pub struct ChatMessage {
+    pub role: Role,
+    pub content: String,
+    pub thinking: Option<String>,
+    pub timestamp: DateTime<Utc>,
+    pub token_count: Option<u32>,
+}
+
+pub enum AppMode { Normal, Streaming, Overlay(OverlayKind) }
+pub enum OverlayKind { AgentPicker, SessionBrowser, Help, CostSummary, SystemStatus }
+```
+
+---
+
+## 8. Message Rendering
+
+### Markdown Subset
+
+| Element           | Rendering |
+|-------------------|-----------|
+| `**bold**`        | `Style::new().bold()` |
+| `*italic*`        | `Style::new().italic()` |
+| `` `inline code` `` | `Style::new().fg(Color::Yellow).bg(Color::DarkGray)` |
+| ```` ```code blocks``` ```` | Bordered block with `syntect` highlighting (top 10 languages) |
+| `# Headings`      | Bold + underline |
+| `- lists`         | Indented with bullet prefix |
+| `> blockquote`    | Dim + left border character |
+| Links             | Underlined, URL in parentheses |
+
+Use `pulldown-cmark` to parse, then map events to `ratatui::text::Line` / `Span` sequences.
+
+### Thinking Blocks
+
+Collapsible. Collapsed: `▶ thinking (42 tokens)`. Expanded (`Ctrl+T`): full content in dim/italic with left border.
+
+### Streaming
+
+Append chunks to `StreamingMessage` buffer. Render with blinking cursor `▌`. Re-parse markdown debounced (every 100ms max).
+
+---
+
+## 9. Configuration
+
+```toml
+# ~/.config/aletheia/tui.toml
+
+[gateway]
+url = "http://localhost:18789"
+
+[defaults]
+agent = "curator"
+show_thinking = false
+
+[theme]
+# Terminal-native — respects terminal colorscheme by default
+```
+
+CLI overrides:
+
+```bash
+aletheia-tui
+aletheia-tui --url http://10.0.0.5:18789
+aletheia-tui --agent researcher
+aletheia-tui --session <id>
+```
+
+---
+
+## 10. Directory Structure
+
+```
+tui/
+├── Cargo.toml
+├── Cargo.lock
+├── src/
+│   ├── main.rs
+│   ├── app.rs
+│   ├── event.rs
+│   ├── ui/
+│   │   ├── mod.rs
+│   │   ├── chat.rs
+│   │   ├── input.rs
+│   │   ├── status_bar.rs
+│   │   ├── overlay.rs
+│   │   └── markdown.rs
+│   ├── api/
+│   │   ├── mod.rs
+│   │   ├── client.rs
+│   │   ├── streaming.rs
+│   │   └── types.rs
+│   ├── config.rs
+│   └── clipboard.rs
+└── README.md
+```
+
+---
+
+## 11. Implementation Phases
+
+| Phase | What | Milestone |
+|-------|------|-----------|
+| 1 | Core chat: event loop, `/health` check, input, SSE streaming, message display | Send message, see streamed response |
+| 2 | Agent & session management: picker overlay, session browser, new/reset session | Switch agents, browse sessions |
+| 3 | Rich rendering: markdown subset, code highlighting, thinking blocks, scroll | Formatted responses with code |
+| 4 | Polish: cost/status overlays, clipboard, config file, error handling, tests | Feature-complete for daily use |
+
+---
+
+## 12. Open Questions
+
+1. **Authentication** — TUI needs bearer token path (not session cookies). Config file or env var.
+2. **Multi-line input** — `Alt+Enter` more portable than `Shift+Enter`. Consider compose mode toggle.
+3. **Live notifications** — Should the `/api/events` SSE stream update the TUI when other interfaces send messages?
+4. **Binary distribution** — `cargo-dist` or cross-compilation, or build from source for now?

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -8,16 +8,11 @@ that evolve with the system.
 
 ## Active Specs
 
-### In Progress
-
-| # | Spec | Status | Scope | Notes |
-|---|------|--------|-------|-------|
-| 5 | [Plug-and-Play Onboarding](05_plug-and-play-onboarding.md) | 4/6 phases | Agent scaffolding, CLI, onboarding | Needed for public adoption |
-
 ### Draft
 
 | # | Spec | Status | Scope | Notes |
 |---|------|--------|-------|-------|
+| 28 | [TUI](28_tui.md) | Draft | Ratatui terminal client | Thin client, SSE streaming, agent switching |
 | 25 | [Integrated IDE](25_integrated-ide.md) | Draft | File editor in web UI | Nice-to-have |
 | 27 | [Embedding Space Intelligence](27_embedding-space-intelligence.md) | Draft | Semantic space analysis, concept drift | Research-grade |
 | 22 | [Interop & Workflows](22_interop-and-workflows.md) | Draft | A2A protocol, workflow engine | A2A premature per Cody |
@@ -32,7 +27,8 @@ that evolve with the system.
 ### Priority Order
 
 **Draft:**
-1. **25** Integrated IDE
+1. **28** TUI — terminal client
+2. **25** Integrated IDE
 3. **27** Embedding Space Intelligence
 4. **22** Interop & Workflows
 5. **24** Aletheia Linux — long-term
@@ -41,6 +37,7 @@ that evolve with the system.
 
 | Spec | Implemented | Summary |
 |------|-------------|---------|
+| [Plug-and-Play Onboarding](05_plug-and-play-onboarding.md) | PRs #137, #138 | CLI scaffolding, onboarding SOUL.md, web UI agent creation, `aletheia init` wizard |
 | [Recursive Self-Improvement](26_recursive-self-improvement.md) | PRs #106, #107, #128 | Self-authored tools, skill learning, competence model, code patching, evolutionary config search |
 | [Agent Portability](21_agent-portability.md) | PRs #100, #124, #128 | Agent file export/import, scheduled backups, checkpoint time-travel (session forking) |
 | [Auth & Updates](03_auth-and-updates.md) | PRs #50, #70, #99, #126 | OAuth login, session mgmt, update daemon, release workflow, credential failover, update notification UI |
@@ -68,7 +65,7 @@ that evolve with the system.
 | [Tool Call Governance](archive/spec-tool-call-governance.md) | PR #22 | Approval gates, timeouts, LoopDetector |
 | [Distillation Persistence](archive/spec-distillation-memory-persistence.md) | Hooks | Workspace flush on distillation |
 
-**Score: 26 archived, 1 in progress, 4 draft/skeleton.**
+**Score: 27 archived, 0 in progress, 5 draft/skeleton.**
 
 ## Conventions
 
@@ -80,7 +77,7 @@ that evolve with the system.
 
 ## Adding a Spec
 
-1. Create `NN_<topic>.md` in this directory (next available number: 28)
+1. Create `NN_<topic>.md` in this directory (next available number: 29)
 2. Add it to the index above
 3. Start with Draft status
 4. PR for review when ready

--- a/ui/src/components/layout/Sidebar.svelte
+++ b/ui/src/components/layout/Sidebar.svelte
@@ -3,15 +3,53 @@
   import {
     getAgents,
     getActiveAgentId,
+    loadAgents,
     setActiveAgent,
   } from "../../stores/agents.svelte";
   import { loadSessions } from "../../stores/sessions.svelte";
   import { getUnreadCount, markRead } from "../../stores/notifications.svelte";
+  import { createAgent } from "../../lib/api";
 
   let { collapsed = false, onAgentSelect }: {
     collapsed?: boolean;
     onAgentSelect?: () => void;
   } = $props();
+
+  let showForm = $state(false);
+  let formName = $state("");
+  let formId = $state("");
+  let formEmoji = $state("");
+  let formError = $state("");
+  let creating = $state(false);
+
+  function deriveId(name: string): string {
+    return name.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "").slice(0, 30);
+  }
+
+  function handleNameInput() {
+    formId = deriveId(formName);
+  }
+
+  async function handleCreate() {
+    if (!formName.trim() || !formId.trim()) return;
+    creating = true;
+    formError = "";
+    try {
+      await createAgent(formId, formName.trim(), formEmoji.trim() || undefined);
+      await loadAgents();
+      setActiveAgent(formId);
+      loadSessions(formId);
+      showForm = false;
+      formName = "";
+      formId = "";
+      formEmoji = "";
+      onAgentSelect?.();
+    } catch (err) {
+      formError = err instanceof Error ? err.message : String(err);
+    } finally {
+      creating = false;
+    }
+  }
 
   function handleAgentClick(id: string) {
     setActiveAgent(id);
@@ -39,6 +77,45 @@
       />
     {/each}
   </div>
+
+  {#if showForm}
+    <div class="create-form">
+      <input
+        type="text"
+        placeholder="Agent name"
+        bind:value={formName}
+        oninput={handleNameInput}
+        disabled={creating}
+      />
+      <input
+        type="text"
+        placeholder="ID (auto)"
+        bind:value={formId}
+        disabled={creating}
+      />
+      <input
+        type="text"
+        placeholder="Emoji (optional)"
+        bind:value={formEmoji}
+        disabled={creating}
+      />
+      {#if formError}
+        <div class="form-error">{formError}</div>
+      {/if}
+      <div class="form-actions">
+        <button class="btn-create" onclick={handleCreate} disabled={creating || !formName.trim()}>
+          {creating ? "Creating..." : "Create"}
+        </button>
+        <button class="btn-cancel" onclick={() => { showForm = false; formError = ""; }}>
+          Cancel
+        </button>
+      </div>
+    </div>
+  {:else}
+    <button class="add-agent" onclick={() => { showForm = true; }} title="Create new agent">
+      +
+    </button>
+  {/if}
 </aside>
 
 <style>
@@ -65,6 +142,76 @@
     flex-direction: column;
     gap: 2px;
     padding: 8px;
+  }
+  .add-agent {
+    margin: 4px 8px 8px;
+    padding: 6px;
+    border: 1px dashed var(--border);
+    border-radius: 8px;
+    background: transparent;
+    color: var(--text-secondary);
+    font-size: 18px;
+    cursor: pointer;
+    transition: all 0.15s ease;
+  }
+  .add-agent:hover {
+    border-color: var(--accent);
+    color: var(--accent);
+    background: var(--bg-secondary);
+  }
+  .create-form {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    padding: 8px;
+    margin: 4px 8px 8px;
+    background: var(--bg-secondary);
+    border-radius: 8px;
+    border: 1px solid var(--border);
+  }
+  .create-form input {
+    padding: 6px 8px;
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    background: var(--bg-primary);
+    color: var(--text-primary);
+    font-size: 13px;
+  }
+  .create-form input:focus {
+    outline: none;
+    border-color: var(--accent);
+  }
+  .form-error {
+    color: var(--error);
+    font-size: 12px;
+    padding: 0 2px;
+  }
+  .form-actions {
+    display: flex;
+    gap: 6px;
+  }
+  .btn-create {
+    flex: 1;
+    padding: 6px;
+    border: none;
+    border-radius: 4px;
+    background: var(--accent);
+    color: var(--bg-primary);
+    font-size: 13px;
+    cursor: pointer;
+  }
+  .btn-create:disabled {
+    opacity: 0.5;
+    cursor: default;
+  }
+  .btn-cancel {
+    padding: 6px 10px;
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    background: transparent;
+    color: var(--text-secondary);
+    font-size: 13px;
+    cursor: pointer;
   }
 
   @media (max-width: 768px) {

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -70,6 +70,13 @@ export async function fetchAgents(): Promise<Agent[]> {
   return data.agents;
 }
 
+export async function createAgent(id: string, name: string, emoji?: string): Promise<{ ok: boolean; id: string }> {
+  return fetchJson("/api/agents", {
+    method: "POST",
+    body: JSON.stringify({ id, name, ...(emoji ? { emoji } : {}) }),
+  });
+}
+
 export async function fetchAgentIdentity(id: string): Promise<{ name: string; emoji: string | null }> {
   return fetchJson(`/api/agents/${id}/identity`);
 }


### PR DESCRIPTION
## Summary
- **Phase 5**: `POST /api/agents` endpoint with config hot-reload + "+" button in sidebar with inline creation form. New agent auto-selected for immediate onboarding.
- **Phase 6**: `aletheia init` first-run wizard — prompts for API key, gateway port, first agent. One command from clone to running.
- **Spec 28**: TUI design document (Ratatui + Crossterm thin client)

## Files
- **Edit:** `src/pylon/server.ts` — `POST /api/agents` endpoint, scaffold + hot-reload
- **Edit:** `src/entry.ts` — `aletheia init` wizard (~80 LOC)
- **Edit:** `ui/src/lib/api.ts` — `createAgent()` function
- **Edit:** `ui/src/components/layout/Sidebar.svelte` — "+" button + inline form
- **New:** `docs/specs/28_tui.md` — TUI specification
- **Edit:** spec 5 status, README, CHANGELOG

## Spec 5 status
All 6 phases complete. Spec moved to archived.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run src/taxis/scaffold.test.ts` — 15/15 passing
- [x] `npx oxlint src/` — no new warnings
- [x] `npx tsdown` — builds
- [x] `npm run build` (UI) — builds
- [ ] Manual: click "+" in sidebar, create agent, verify onboarding starts
- [ ] Manual: `aletheia init` on fresh config dir