### PR TITLE
fix: SSE connection resilience and stuck streaming state

### DIFF
--- a/ui/src/components/chat/ChatView.svelte
+++ b/ui/src/components/chat/ChatView.svelte
@@ -69,9 +69,15 @@
       if (event === "init") {
         const initData = data as { activeTurns?: Record<string, number> };
         const activeTurns = initData.activeTurns ?? {};
+        // Set or clear remote streaming based on server's authoritative state
         if (activeTurns[agentId] && activeTurns[agentId] > 0) {
           setRemoteStreaming(agentId, true);
+        } else {
+          setRemoteStreaming(agentId, false);
         }
+        // Reload history on reconnect to catch any missed messages
+        const sid = getActiveSessionId();
+        if (sid) loadHistory(agentId, sid);
       }
 
       if (event === "turn:after") {
@@ -107,18 +113,18 @@
 
       if (event === "connection") {
         const { status } = data as { status: string };
-        if (status === "disconnected" && !pollInterval) {
-          pollInterval = setInterval(() => {
-            const id = getActiveAgentId();
-            const sid = getActiveSessionId();
-            if (id && sid) loadHistory(id, sid);
-          }, 30_000);
-        } else if (status === "connected" && pollInterval) {
-          clearInterval(pollInterval);
-          pollInterval = null;
-          const id = getActiveAgentId();
-          const sid = getActiveSessionId();
-          if (id && sid) loadHistory(id, sid);
+        if (status === "disconnected") {
+          // Clear remote streaming — we can't trust it without SSE
+          setRemoteStreaming(agentId, false);
+          if (!pollInterval) {
+            pollInterval = setInterval(() => {
+              const id = getActiveAgentId();
+              const sid = getActiveSessionId();
+              if (id && sid) loadHistory(id, sid);
+            }, 5_000); // Poll every 5s while disconnected
+          }
+        } else if (status === "connected") {
+          if (pollInterval) { clearInterval(pollInterval); pollInterval = null; }
         }
       }
     });
@@ -148,14 +154,13 @@
     }
   });
 
-  // Recover remote streaming state when agent becomes available
+  // Sync remote streaming state from SSE activeTurns
   $effect(() => {
     const agentId = getActiveAgentId();
     if (!agentId) return;
     const activeTurns = getActiveTurns();
-    if (activeTurns[agentId] && activeTurns[agentId] > 0) {
-      setRemoteStreaming(agentId, true);
-    }
+    const active = activeTurns[agentId] && activeTurns[agentId] > 0;
+    setRemoteStreaming(agentId, !!active);
   });
 
   // Slash command registry

--- a/ui/src/lib/events.ts
+++ b/ui/src/lib/events.ts
@@ -4,8 +4,10 @@ type EventCallback = (event: string, data: unknown) => void;
 
 let source: EventSource | null = null;
 let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+let heartbeatTimer: ReturnType<typeof setTimeout> | null = null;
 let reconnectDelay = 1000;
 const MAX_RECONNECT_DELAY = 30000;
+const HEARTBEAT_TIMEOUT_MS = 45_000; // Server sends pings every ~30s
 const listeners = new Set<EventCallback>();
 let lastActiveTurns: Record<string, number> = {};
 
@@ -26,14 +28,34 @@ export function initEventSource(): void {
 }
 
 export function closeEventSource(): void {
-  if (reconnectTimer) clearTimeout(reconnectTimer);
+  if (reconnectTimer) { clearTimeout(reconnectTimer); reconnectTimer = null; }
+  if (heartbeatTimer) { clearTimeout(heartbeatTimer); heartbeatTimer = null; }
   if (source) {
     source.close();
     source = null;
   }
 }
 
+function resetHeartbeat() {
+  if (heartbeatTimer) clearTimeout(heartbeatTimer);
+  heartbeatTimer = setTimeout(() => {
+    // No activity for 45s — connection is likely dead
+    if (source) {
+      source.close();
+      source = null;
+      dispatch("connection", { status: "disconnected" });
+      scheduleReconnect();
+    }
+  }, HEARTBEAT_TIMEOUT_MS);
+}
+
 function connect() {
+  // Clean up any existing connection
+  if (source) {
+    source.close();
+    source = null;
+  }
+
   const token = getEffectiveToken();
   const base = import.meta.env.DEV ? "" : window.location.origin;
   const url = `${base}/api/events${token ? `?token=${encodeURIComponent(token)}` : ""}`;
@@ -42,21 +64,31 @@ function connect() {
 
   source.onopen = () => {
     reconnectDelay = 1000;
+    resetHeartbeat();
     dispatch("connection", { status: "connected" });
   };
 
   source.onerror = () => {
     dispatch("connection", { status: "disconnected" });
+    if (heartbeatTimer) { clearTimeout(heartbeatTimer); heartbeatTimer = null; }
     source?.close();
     source = null;
     scheduleReconnect();
   };
 
   source.addEventListener("init", (e) => {
+    resetHeartbeat();
     try {
       const data = JSON.parse((e as MessageEvent).data);
-      if (data.activeTurns) lastActiveTurns = data.activeTurns;
-      dispatch("init", data);
+      const newActiveTurns: Record<string, number> = data.activeTurns ?? {};
+      // Clear stale entries: if an agent was "active" before but isn't now, zero it
+      for (const agentId of Object.keys(lastActiveTurns)) {
+        if (!(agentId in newActiveTurns)) {
+          newActiveTurns[agentId] = 0;
+        }
+      }
+      lastActiveTurns = newActiveTurns;
+      dispatch("init", { ...data, activeTurns: lastActiveTurns });
     } catch { /* ignore */ }
   });
 
@@ -68,9 +100,9 @@ function connect() {
   ];
   for (const type of eventTypes) {
     source.addEventListener(type, (e) => {
+      resetHeartbeat();
       try {
         const data = JSON.parse((e as MessageEvent).data);
-        // Keep activeTurns cache in sync
         if (type === "turn:before" && data.nousId) {
           lastActiveTurns[data.nousId] = (lastActiveTurns[data.nousId] ?? 0) + 1;
         } else if (type === "turn:after" && data.nousId) {
@@ -80,6 +112,10 @@ function connect() {
       } catch { /* ignore */ }
     });
   }
+
+  // SSE comment lines (:ping) don't fire event listeners, but onmessage catches them
+  // Use a catch-all to reset heartbeat on any server activity
+  source.onmessage = () => { resetHeartbeat(); };
 }
 
 function scheduleReconnect() {

--- a/ui/src/lib/stream.ts
+++ b/ui/src/lib/stream.ts
@@ -1,6 +1,22 @@
 import { getEffectiveToken } from "./api";
 import type { TurnStreamEvent, MediaItem } from "./types";
 
+const READ_TIMEOUT_MS = 120_000; // 2 min — abort if no data for this long
+
+function readWithTimeout<T>(reader: ReadableStreamDefaultReader<T>, timeoutMs: number): Promise<ReadableStreamReadResult<T>> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reader.cancel("Read timeout").catch(() => {});
+      reject(new Error("Stream read timed out — server may be unreachable"));
+    }, timeoutMs);
+
+    reader.read().then(
+      (result) => { clearTimeout(timer); resolve(result); },
+      (err) => { clearTimeout(timer); reject(err); },
+    );
+  });
+}
+
 export async function* streamMessage(
   agentId: string,
   message: string,
@@ -43,7 +59,7 @@ export async function* streamMessage(
 
   try {
     while (true) {
-      const { done, value } = await reader.read();
+      const { done, value } = await readWithTimeout(reader, READ_TIMEOUT_MS);
       if (done) break;
 
       buffer += decoder.decode(value, { stream: true });


### PR DESCRIPTION
## Summary
Fixes the "UI stops responding, have to keep refreshing" bug.

**Root causes identified:**
1. `remoteStreaming` stuck true when SSE drops mid-turn (`turn:after` never arrives)
2. `init` event only sets `remoteStreaming=true`, never clears it for inactive agents
3. Disconnect handler only polls history (30s), never clears streaming state
4. Fetch reader can hang forever on network drop (no timeout)

**Fixes:**
- `init` event now **clears** `remoteStreaming` for agents not in `activeTurns` (was set-only)
- `$effect` syncs both directions from `activeTurns` cache
- Disconnect event immediately clears `remoteStreaming`
- Poll interval reduced from 30s to 5s while disconnected
- History reloaded on SSE reconnect to catch missed messages
- Heartbeat timer (45s) detects silently dead connections
- Fetch stream reader has 2-minute timeout (was infinite)
- Clean up existing EventSource before creating new one in `connect()`

## Files
- `ui/src/lib/events.ts` — heartbeat timer, clean reconnect, stale activeTurns clearing
- `ui/src/lib/stream.ts` — `readWithTimeout()` wrapper, 2min timeout
- `ui/src/components/chat/ChatView.svelte` — init clears stale state, disconnect clears streaming, $effect bidirectional

## Test plan
- [x] UI builds cleanly
- [ ] Manual: network drop mid-stream → UI recovers within seconds, not stuck
- [ ] Manual: page refresh during streaming → shows current state, input enabled
- [ ] Manual: idle disconnect/reconnect → no stale "streaming" indicator