### PR TITLE
refactor: extract koina/memory-client.ts — single source for sidecar URL/user ID

### DIFF
--- a/infrastructure/runtime/src/aletheia.ts
+++ b/infrastructure/runtime/src/aletheia.ts
@@ -85,6 +85,7 @@ import { getKeySalt, initEncryption } from "./koina/encryption.js";
 import Database from "better-sqlite3";
 import { eventBus } from "./koina/event-bus.js";
 import { type HookRegistry, registerHooks } from "./koina/hooks.js";
+import { getSidecarUrl, getUserId } from "./koina/memory-client.js";
 
 const log = createLogger("aletheia");
 
@@ -260,17 +261,15 @@ export function createRuntime(configPath?: string): AletheiaRuntime {
   const plugins = new PluginRegistry(config);
 
   // Memory flush target — connects distillation/reflection extraction to memory sidecar
-  const sidecarUrl = process.env["ALETHEIA_MEMORY_URL"] ?? "http://127.0.0.1:8230";
-  const memoryUserId = process.env["ALETHEIA_MEMORY_USER"] ?? "default";
   const memoryTarget: import("./distillation/hooks.js").MemoryFlushTarget = {
     async addMemories(agentId: string, memories: string[]): Promise<{ added: number; errors: number }> {
       try {
-        const res = await fetch(`${sidecarUrl}/add_batch`, {
+        const res = await fetch(`${getSidecarUrl()}/add_batch`, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
             texts: memories,
-            user_id: memoryUserId,
+            user_id: getUserId(),
             agent_id: agentId,
             source: "distillation",
             confidence: 0.8,

--- a/infrastructure/runtime/src/koina/memory-client.ts
+++ b/infrastructure/runtime/src/koina/memory-client.ts
@@ -1,0 +1,9 @@
+// Canonical sidecar URL and user ID for memory service access.
+// Single source of truth — every module that talks to the memory sidecar imports from here.
+// Lazy reads: env vars may be set by taxis config after module import.
+
+export const getSidecarUrl = (): string =>
+  process.env["ALETHEIA_MEMORY_URL"] ?? "http://127.0.0.1:8230";
+
+export const getUserId = (): string =>
+  process.env["ALETHEIA_MEMORY_USER"] ?? "default";

--- a/infrastructure/runtime/src/nous/pipeline/stages/finalize.ts
+++ b/infrastructure/runtime/src/nous/pipeline/stages/finalize.ts
@@ -8,6 +8,7 @@ import { extractTurnFacts } from "../../turn-facts.js";
 import { resolveWorkspace } from "../../../taxis/loader.js";
 import { eventBus } from "../../../koina/event-bus.js";
 import { createLogger } from "../../../koina/logger.js";
+import { getSidecarUrl, getUserId } from "../../../koina/memory-client.js";
 import type { RuntimeServices, TurnState } from "../types.js";
 
 const log = createLogger("finalize");
@@ -102,15 +103,13 @@ export async function finalize(
     extractTurnFacts(services.router, outcome.text, toolSummary, factModel)
       .then(async (result) => {
         if (result.facts.length > 0) {
-          const sidecarUrl = process.env["ALETHEIA_MEMORY_URL"] ?? "http://127.0.0.1:8230";
-          const userId = process.env["ALETHEIA_MEMORY_USER"] ?? "default";
           try {
-            const res = await fetch(`${sidecarUrl}/add_batch`, {
+            const res = await fetch(`${getSidecarUrl()}/add_batch`, {
               method: "POST",
               headers: { "Content-Type": "application/json" },
               body: JSON.stringify({
                 texts: result.facts,
-                user_id: userId,
+                user_id: getUserId(),
                 agent_id: nousId,
                 source: "turn",
                 session_id: sessionId,

--- a/infrastructure/runtime/src/nous/recall.ts
+++ b/infrastructure/runtime/src/nous/recall.ts
@@ -1,12 +1,9 @@
 // Pre-turn memory recall — surfaces relevant memories before LLM reasoning
 import { createLogger } from "../koina/logger.js";
 import { estimateTokens } from "../hermeneus/token-counter.js";
+import { getSidecarUrl, getUserId } from "../koina/memory-client.js";
 
 const log = createLogger("recall");
-
-// Lazy reads — env vars may be set by taxis config after module import
-const getSidecarUrl = () => process.env["ALETHEIA_MEMORY_URL"] ?? "http://127.0.0.1:8230";
-const getUserId = () => process.env["ALETHEIA_MEMORY_USER"] ?? "default";
 
 export interface RecallResult {
   block: { type: "text"; text: string } | null;

--- a/infrastructure/runtime/src/organon/built-in/fact-retract.ts
+++ b/infrastructure/runtime/src/organon/built-in/fact-retract.ts
@@ -1,11 +1,9 @@
 // Memory retraction tool — agents can request fact removal
 import { createLogger } from "../../koina/logger.js";
+import { getSidecarUrl, getUserId } from "../../koina/memory-client.js";
 import type { ToolContext, ToolHandler } from "../registry.js";
 
 const log = createLogger("organon.fact-retract");
-// Lazy reads — env vars may be set by taxis config after module import
-const getSidecarUrl = () => process.env["ALETHEIA_MEMORY_URL"] ?? "http://127.0.0.1:8230";
-const getUserId = () => process.env["ALETHEIA_MEMORY_USER"] ?? "default";
 
 export const factRetractTool: ToolHandler = {
   definition: {

--- a/infrastructure/runtime/src/organon/built-in/mem0-audit.ts
+++ b/infrastructure/runtime/src/organon/built-in/mem0-audit.ts
@@ -1,10 +1,9 @@
 // Memory audit tool — agents can review and assess their own memories
 import { createLogger } from "../../koina/logger.js";
+import { getSidecarUrl, getUserId } from "../../koina/memory-client.js";
 import type { ToolContext, ToolHandler } from "../registry.js";
 
 const log = createLogger("organon.mem0-audit");
-const getSidecarUrl = () => process.env["ALETHEIA_MEMORY_URL"] ?? "http://127.0.0.1:8230";
-const getUserId = () => process.env["ALETHEIA_MEMORY_USER"] ?? "default";
 
 export const mem0AuditTool: ToolHandler = {
   definition: {

--- a/infrastructure/runtime/src/organon/built-in/mem0-retract.ts
+++ b/infrastructure/runtime/src/organon/built-in/mem0-retract.ts
@@ -1,10 +1,9 @@
 // Memory retraction tool — agents can retract incorrect/stale memories
 import { createLogger } from "../../koina/logger.js";
+import { getSidecarUrl, getUserId } from "../../koina/memory-client.js";
 import type { ToolContext, ToolHandler } from "../registry.js";
 
 const log = createLogger("organon.mem0-retract");
-const getSidecarUrl = () => process.env["ALETHEIA_MEMORY_URL"] ?? "http://127.0.0.1:8230";
-const getUserId = () => process.env["ALETHEIA_MEMORY_USER"] ?? "default";
 
 export const mem0RetractTool: ToolHandler = {
   definition: {

--- a/infrastructure/runtime/src/organon/built-in/mem0-search.ts
+++ b/infrastructure/runtime/src/organon/built-in/mem0-search.ts
@@ -1,12 +1,9 @@
 // Mem0 memory search tool — query long-term extracted memories
 import type { ToolContext, ToolHandler } from "../registry.js";
 import { createLogger } from "../../koina/logger.js";
+import { getSidecarUrl, getUserId } from "../../koina/memory-client.js";
 
 const log = createLogger("tool:mem0-search");
-
-// Lazy reads — env vars may be set by taxis config after module import
-const getSidecarUrl = () => process.env["ALETHEIA_MEMORY_URL"] ?? "http://127.0.0.1:8230";
-const getUserId = () => process.env["ALETHEIA_MEMORY_USER"] ?? "default";
 
 export const mem0SearchTool: ToolHandler = {
   definition: {

--- a/infrastructure/runtime/src/organon/built-in/memory-correct.ts
+++ b/infrastructure/runtime/src/organon/built-in/memory-correct.ts
@@ -1,10 +1,9 @@
 // Memory correction tool — agents can correct existing memories
 import { createLogger } from "../../koina/logger.js";
+import { getSidecarUrl, getUserId } from "../../koina/memory-client.js";
 import type { ToolContext, ToolHandler } from "../registry.js";
 
 const log = createLogger("organon.memory-correct");
-const getSidecarUrl = () => process.env["ALETHEIA_MEMORY_URL"] ?? "http://127.0.0.1:8230";
-const getUserId = () => process.env["ALETHEIA_MEMORY_USER"] ?? "default";
 
 export const memoryCorrectTool: ToolHandler = {
   definition: {

--- a/infrastructure/runtime/src/organon/built-in/memory-forget.ts
+++ b/infrastructure/runtime/src/organon/built-in/memory-forget.ts
@@ -1,10 +1,9 @@
 // Memory forget tool — agents can soft-delete memories
 import { createLogger } from "../../koina/logger.js";
+import { getSidecarUrl, getUserId } from "../../koina/memory-client.js";
 import type { ToolContext, ToolHandler } from "../registry.js";
 
 const log = createLogger("organon.memory-forget");
-const getSidecarUrl = () => process.env["ALETHEIA_MEMORY_URL"] ?? "http://127.0.0.1:8230";
-const getUserId = () => process.env["ALETHEIA_MEMORY_USER"] ?? "default";
 
 export const memoryForgetTool: ToolHandler = {
   definition: {

--- a/shared/skills/remote-repository-build-test-validation/SKILL.md
+++ b/shared/skills/remote-repository-build-test-validation/SKILL.md
@@ -1,0 +1,19 @@
+# Remote Repository Build & Test Validation
+Diagnose, clone, build, and systematically test a remote .NET repository to identify root causes of failures.
+
+## When to Use
+When you need to verify a remote project's build status and test suite health, especially when the repository location is unknown or the project hasn't been cloned yet. Useful for pre-deployment verification, CI/CD diagnostics, or assessing code quality before integration.
+
+## Steps
+1. SSH into the remote host and attempt to locate the repository in common directories (/tmp, /home/*)
+2. If not found, clone the repository from source control into a working directory
+3. Run dependency restore and full build, capturing output to identify compilation errors
+4. Execute the test suite with minimal verbosity to get a high-level pass/fail summary
+5. Document findings (build status, test counts, failure patterns) in a persistent note
+6. Run targeted test subsets (by namespace/category) to isolate root causes of failures
+7. Record session results and error analysis in a dated memory/log file
+
+## Tools Used
+- exec: SSH remote command execution with timeout and output tail filtering
+- note: Documenting build/test status and identified issues for task tracking
+- write: Recording detailed session findings and error patterns to a dated log file

--- a/shared/skills/repository-reconnaissance-feature-audit/SKILL.md
+++ b/shared/skills/repository-reconnaissance-feature-audit/SKILL.md
@@ -1,0 +1,24 @@
+# Repository Reconnaissance & Feature Audit
+Systematically discover project structure, recent changes, active specs, and in-flight work across a codebase.
+
+## When to Use
+When you need to quickly understand a repository's current state, ongoing development priorities, architectural layout, and what features are being built—especially useful for onboarding to a new project, assessing scope before making contributions, or tracking project momentum.
+
+## Steps
+1. Locate the repository (check local paths and remote servers via SSH)
+2. Extract recent commit history with messages to understand latest work
+3. Review ROADMAP and spec files to identify active priorities and phases
+4. List directory structure (pages, components, stores, services) to understand architecture
+5. Examine recent commits in detail (--stat) to see which files changed
+6. Sample key source files (entry points, test files) to understand tech stack
+7. Query open/merged pull requests to see in-flight features and recent completions
+8. Review PR bodies to understand feature scope and spec alignment
+9. Check package.json and build configs (Cargo.toml, etc.) for dependencies and metadata
+10. Verify local state is current (git pull)
+11. Collect final inventory of all major directories and line counts
+
+## Tools Used
+- exec: Running shell commands to navigate filesystem, execute git queries, list directories, read file contents, and query GitHub CLI for PR/issue data
+- git log: Extracting commit history, diffs, and change statistics
+- gh (GitHub CLI): Querying pull request state, metadata, and bodies
+- cat/head: Sampling source code and documentation files


### PR DESCRIPTION
## Problem

`getSidecarUrl()` and `getUserId()` were independently defined in 8 files, each reading `ALETHEIA_MEMORY_URL` and `ALETHEIA_MEMORY_USER` with identical fallback defaults. Change the port? Chase it across 8 files.

## Fix

One canonical module: `koina/memory-client.ts`. All 8 consumers now import from one source.

### Files updated
- `organon/built-in/`: mem0-search, mem0-retract, mem0-audit, memory-correct, memory-forget, fact-retract
- `nous/recall.ts`
- `nous/pipeline/stages/finalize.ts`
- `aletheia.ts`

Same lazy-read semantics preserved — env vars still evaluated at call time, not import time.