### PR TITLE
refactor(ui): extract shared graph palette to lib/graph-colors.ts

### DIFF
--- a/ui/src/components/graph/Graph2D.svelte
+++ b/ui/src/components/graph/Graph2D.svelte
@@ -2,6 +2,7 @@
   import { onMount } from "svelte";
   import type { GraphData as AppGraphData, GraphNode } from "../../lib/types";
   import { getFilteredEdges } from "../../stores/graph.svelte";
+  import { communityColor } from "../../lib/graph-colors";
 
   import type { AgentOverlayData, DriftData } from "../../lib/api";
 
@@ -32,18 +33,6 @@
   // Build lookup sets for drift visualization
   let orphanedSet = $derived(new Set(driftData?.orphaned_nodes?.map(n => n.name) ?? []));
   let staleSet = $derived(new Set(driftData?.stale_entities?.map(e => e.name) ?? []));
-
-  const PALETTE = [
-    "#7a2838", "#4a3860", "#5C8E63", "#9A7B4F", "#a06e3a",
-    "#b07a8a", "#6b8fa3", "#7a9a8a", "#c49a6a", "#8b6a4a",
-    "#6b7b6b", "#8aad6e", "#a07a5a", "#7a6b8a", "#9a8a6a",
-    "#6a8a7a", "#a08060", "#8a7060", "#7a8a9a", "#6a7a5a",
-  ];
-
-  function communityColor(community: number): string {
-    if (community < 0) return "#302c28";
-    return PALETTE[community % PALETTE.length]!;
-  }
 
   function pagerankSize(pr: number): number {
     const clamped = Math.max(pr, 0.0001);

--- a/ui/src/components/graph/Graph3D.svelte
+++ b/ui/src/components/graph/Graph3D.svelte
@@ -2,6 +2,7 @@
   import { onMount } from "svelte";
   import * as THREE from "three";
   import type { GraphData as AppGraphData } from "../../lib/types";
+  import { communityColor } from "../../lib/graph-colors";
 
   let {
     graphData,
@@ -18,18 +19,6 @@
     onNodeClick?: (nodeId: string) => void;
     onBackgroundClick?: () => void;
   } = $props();
-
-  const PALETTE = [
-    "#7a2838", "#4a3860", "#5C8E63", "#9A7B4F", "#a06e3a",
-    "#b07a8a", "#6b8fa3", "#7a9a8a", "#c49a6a", "#8b6a4a",
-    "#6b7b6b", "#8aad6e", "#a07a5a", "#7a6b8a", "#9a8a6a",
-    "#6a8a7a", "#a08060", "#8a7060", "#7a8a9a", "#6a7a5a",
-  ];
-
-  function communityColor(community: number): string {
-    if (community < 0) return "#302c28";
-    return PALETTE[community % PALETTE.length]!;
-  }
 
   function pagerankSize(pr: number): number {
     const clamped = Math.max(pr, 0.0001);

--- a/ui/src/components/graph/GraphView.svelte
+++ b/ui/src/components/graph/GraphView.svelte
@@ -6,6 +6,7 @@
   import DriftPanel from "./DriftPanel.svelte";
   import TimelineSlider from "./TimelineSlider.svelte";
   import ContextLookup from "./ContextLookup.svelte";
+  import { communityColor, agentColor, AGENT_COLORS } from "../../lib/graph-colors";
   import {
     getGraphData, getLoading, getError, getSelectedNodeId,
     getSelectedNode, getNodeEdges, getCommunityIds,
@@ -33,29 +34,6 @@
   let showContextLookup = $state(false);
   let showTimeline = $state(false);
   let showEdgeFilter = $state(true);
-
-  /* Ardent dye palette leads, earth tones follow */
-  const PALETTE = [
-    "#7a2838", "#4a3860", "#5C8E63", "#9A7B4F", "#a06e3a",
-    "#b07a8a", "#6b8fa3", "#7a9a8a", "#c49a6a", "#8b6a4a",
-    "#6b7b6b", "#8aad6e", "#a07a5a", "#7a6b8a", "#9a8a6a",
-    "#6a8a7a", "#a08060", "#8a7060", "#7a8a9a", "#6a7a5a",
-  ];
-
-  const AGENT_COLORS: Record<string, string> = {
-    syn: "#9A7B4F",      /* aged brass — primary orchestrator */
-    demiurge: "#a06e3a",  /* natural leather — the maker */
-    syl: "#b07a8a",       /* dusty rose */
-    akron: "#5C8E63",     /* aporia green — field work */
-    eiron: "#4a3860",     /* thanatochromia — analysis */
-    arbor: "#6b8fa3",     /* steel blue */
-    unknown: "#6b6560",   /* warm grey */
-  };
-
-  function communityColor(community: number): string {
-    if (community < 0) return "#302c28";
-    return PALETTE[community % PALETTE.length]!;
-  }
 
   // --- Progressive loading ---
   async function initialLoad() {

--- a/ui/src/lib/graph-colors.ts
+++ b/ui/src/lib/graph-colors.ts
@@ -1,0 +1,31 @@
+// Canonical graph color palette — single source of truth for community/agent colors.
+// Ardent dye palette leads (aima, thanatochromia, aporia), earth tones follow.
+
+export const COMMUNITY_PALETTE = [
+  "#7a2838", "#4a3860", "#5C8E63", "#9A7B4F", "#a06e3a",
+  "#b07a8a", "#6b8fa3", "#7a9a8a", "#c49a6a", "#8b6a4a",
+  "#6b7b6b", "#8aad6e", "#a07a5a", "#7a6b8a", "#9a8a6a",
+  "#6a8a7a", "#a08060", "#8a7060", "#7a8a9a", "#6a7a5a",
+] as const;
+
+export const AGENT_COLORS: Record<string, string> = {
+  syn: "#9A7B4F",       /* aged brass — primary orchestrator */
+  demiurge: "#a06e3a",  /* natural leather — the maker */
+  syl: "#b07a8a",       /* dusty rose */
+  akron: "#5C8E63",     /* aporia green — field work */
+  eiron: "#4a3860",     /* thanatochromia — analysis */
+  arbor: "#6b8fa3",     /* steel blue */
+  unknown: "#6b6560",   /* warm grey */
+};
+
+/** Fallback for nodes with no community assignment */
+export const UNASSIGNED_COLOR = "#302c28";
+
+export function communityColor(community: number): string {
+  if (community < 0) return UNASSIGNED_COLOR;
+  return COMMUNITY_PALETTE[community % COMMUNITY_PALETTE.length]!;
+}
+
+export function agentColor(agentId: string): string {
+  return AGENT_COLORS[agentId] ?? AGENT_COLORS["unknown"]!;
+}


### PR DESCRIPTION
3 components (GraphView, Graph2D, Graph3D) each defined the same 20-color palette, agent color map, and communityColor() function independently. Now one source: `lib/graph-colors.ts`.