### PR TITLE
refactor: remove redundant contextTokens/maxOutputTokens fallbacks

### DIFF
--- a/infrastructure/runtime/src/nous/audit.ts
+++ b/infrastructure/runtime/src/nous/audit.ts
@@ -17,8 +17,8 @@ export async function auditTokens(agentId: string): Promise<void> {
     maxTokens: config.agents.defaults.bootstrapMaxTokens,
   });
 
-  const contextWindow = config.agents.defaults.contextTokens ?? 200000;
-  const maxOutput = config.agents.defaults.maxOutputTokens ?? 16384;
+  const contextWindow = config.agents.defaults.contextTokens;
+  const maxOutput = config.agents.defaults.maxOutputTokens;
 
   // Build tool defs for token estimation (empty registry — no dispatch context available)
   const tools = new ToolRegistry();

--- a/infrastructure/runtime/src/nous/manager.ts
+++ b/infrastructure/runtime/src/nous/manager.ts
@@ -261,7 +261,7 @@ export class NousManager {
 
   private maybeScheduleDistillation(sessionId: string, nousId: string, lockKey: string): void {
     const compaction = this.config.agents.defaults.compaction;
-    const contextTokens = this.config.agents.defaults.contextTokens ?? 200000;
+    const contextTokens = this.config.agents.defaults.contextTokens;
     const distillThreshold = Math.floor(contextTokens * compaction.maxHistoryShare);
 
     const session = this.store.findSessionById(sessionId);
@@ -344,7 +344,7 @@ export class NousManager {
 
   async triggerDistillation(sessionId: string): Promise<void> {
     const compaction = this.config.agents.defaults.compaction;
-    const contextTokens = this.config.agents.defaults.contextTokens ?? 200000;
+    const contextTokens = this.config.agents.defaults.contextTokens;
     const distillThreshold = Math.floor(contextTokens * compaction.maxHistoryShare);
     const distillModel = compaction.distillationModel;
 

--- a/infrastructure/runtime/src/nous/pipeline/stages/execute.ts
+++ b/infrastructure/runtime/src/nous/pipeline/stages/execute.ts
@@ -125,7 +125,7 @@ export async function* executeStreaming(
     const useThinking = !!(thinkingConfig?.enabled && supportsThinking);
 
     // Build context management — clears old tool results and thinking blocks server-side
-    const contextTokens = services.config.agents.defaults.contextTokens ?? 200000;
+    const contextTokens = services.config.agents.defaults.contextTokens;
     const contextManagement = buildContextManagement(contextTokens, useThinking);
 
     for await (const streamEvent of services.router.completeStreaming({
@@ -503,7 +503,7 @@ export async function executeBuffered(
   const seq = state.seq;
 
   // Context management for buffered path
-  const contextTokens = services.config.agents.defaults.contextTokens ?? 200000;
+  const contextTokens = services.config.agents.defaults.contextTokens;
   const bufferedContextMgmt = buildContextManagement(contextTokens, false);
 
   for (let loop = 0; ; loop++) {


### PR DESCRIPTION
## Problem

`contextTokens ?? 200000` appeared in 5 callsites and `maxOutputTokens ?? 16384` in 1. Both values are already guaranteed by Zod schema defaults in `taxis/schema.ts`:

```ts
contextTokens: z.number().default(200000),
maxOutputTokens: z.number().default(16384),
```

Config is always parsed through Zod before reaching these callsites. The nullish coalescing was redundant and created a second source of truth — if the default changed in the schema, these 6 locations would silently disagree.

## Fix

Remove the `??` fallbacks. Trust validated config. One source of truth in `taxis/schema.ts`.