### PR TITLE
fix(ui): resolve 7 reliability bugs in chat state management

### DIFF
--- a/infrastructure/runtime/src/nous/bootstrap.ts
+++ b/infrastructure/runtime/src/nous/bootstrap.ts
@@ -45,6 +45,18 @@ const DEGRADATION_GUIDANCE: Record<string, string> = {
   "signal-cli": "Signal messaging unavailable. You can process but not respond.",
 };
 
+const RESPONSE_HYGIENE = `
+
+---
+
+## Response Hygiene
+
+Your visible response is what the user reads. Keep it focused on their request.
+
+- Internal planning, self-narration, context management thoughts, and memory/distillation concerns belong in your thinking, never in your response text.
+- Do not narrate what you are about to do — just do it. If you need to use tools, use them without announcing each step.
+- Never tell the user you are "saving to memory", "preparing for distillation", or "noting for context". These are invisible internal operations.`;
+
 export interface BootstrapResult {
   staticBlocks: SystemBlock[];
   dynamicBlocks: SystemBlock[];
@@ -160,9 +172,10 @@ export function assembleBootstrap(
 
   // Static group — combine into one block with cache breakpoint
   if (staticFiles.length > 0) {
-    const text = staticFiles
+    const fileSections = staticFiles
       .map((f) => `## ${f.name}\n\n${f.content}`)
       .join("\n\n---\n\n");
+    const text = fileSections + RESPONSE_HYGIENE;
     staticBlocks.push({
       type: "text",
       text,

--- a/ui/src/App.svelte
+++ b/ui/src/App.svelte
@@ -4,13 +4,31 @@
   import { loadAgents } from "./stores/agents.svelte";
   import { loadBranding } from "./stores/branding.svelte";
   import { getToken } from "./lib/api";
+  import { onGlobalEvent } from "./lib/events.svelte";
+  import { loadHistory, hasLocalStream } from "./stores/chat.svelte";
+
+  let unsubTurnAfter: (() => void) | null = null;
 
   $effect(() => {
     if (getToken()) {
       loadBranding();
       loadAgents();
       initConnection();
-      return () => disconnect();
+
+      // Preload history for any agent that completes a remote turn
+      unsubTurnAfter = onGlobalEvent((event, data) => {
+        if (event === "turn:after") {
+          const { nousId, sessionId } = data as { nousId?: string; sessionId?: string };
+          if (nousId && sessionId && !hasLocalStream(nousId)) {
+            loadHistory(nousId, sessionId);
+          }
+        }
+      });
+
+      return () => {
+        disconnect();
+        unsubTurnAfter?.();
+      };
     }
   });
 

--- a/ui/src/components/chat/ChatView.svelte
+++ b/ui/src/components/chat/ChatView.svelte
@@ -47,7 +47,7 @@
   } from "../../stores/sessions.svelte";
   import { distillSession, fetchCommands, executeCommand } from "../../lib/api";
   import type { CommandInfo } from "../../lib/types";
-  import { onGlobalEvent, getActiveTurns } from "../../lib/events";
+  import { onGlobalEvent, getActiveTurns } from "../../lib/events.svelte";
   import { onMount, onDestroy, untrack } from "svelte";
   import { addNotification } from "../../stores/notifications.svelte";
   import { showToast } from "../../stores/toast.svelte";
@@ -77,7 +77,7 @@
         }
         // Reload history on reconnect to catch any missed messages
         const sid = getActiveSessionId();
-        if (sid) loadHistory(agentId, sid);
+        if (sid && !hasLocalStream(agentId)) loadHistory(agentId, sid);
       }
 
       if (event === "turn:after") {

--- a/ui/src/components/chat/DistillationProgress.svelte
+++ b/ui/src/components/chat/DistillationProgress.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { onGlobalEvent } from "../../lib/events";
+  import { onGlobalEvent } from "../../lib/events.svelte";
   import { onMount, onDestroy } from "svelte";
   import Spinner from "../shared/Spinner.svelte";
 

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -99,7 +99,10 @@ export async function archiveSession(sessionId: string): Promise<void> {
 }
 
 export async function distillSession(sessionId: string): Promise<void> {
-  await fetchJson(`/api/sessions/${sessionId}/distill`, { method: "POST" });
+  await fetchJson(`/api/sessions/${sessionId}/distill`, {
+    method: "POST",
+    signal: AbortSignal.timeout(90_000),
+  });
 }
 
 export async function fetchThreads(nousId?: string): Promise<Thread[]> {

--- a/ui/src/lib/events.svelte.ts
+++ b/ui/src/lib/events.svelte.ts
@@ -9,7 +9,7 @@ let reconnectDelay = 1000;
 const MAX_RECONNECT_DELAY = 30000;
 const HEARTBEAT_TIMEOUT_MS = 45_000; // Server sends pings every ~30s
 const listeners = new Set<EventCallback>();
-let lastActiveTurns: Record<string, number> = {};
+let lastActiveTurns = $state<Record<string, number>>({});
 
 export function onGlobalEvent(cb: EventCallback): () => void {
   listeners.add(cb);
@@ -92,9 +92,9 @@ function connect() {
     } catch { /* ignore */ }
   });
 
-  // Forward all other event types
+  // Forward server event types (only types the server SSE route actually emits)
   const eventTypes = [
-    "turn:before", "turn:after", "turn:text_delta", "turn:tool_start", "turn:tool_result",
+    "turn:before", "turn:after",
     "tool:called", "tool:failed", "session:created", "session:archived",
     "distill:before", "distill:stage", "distill:after",
   ];
@@ -104,9 +104,9 @@ function connect() {
       try {
         const data = JSON.parse((e as MessageEvent).data);
         if (type === "turn:before" && data.nousId) {
-          lastActiveTurns[data.nousId] = (lastActiveTurns[data.nousId] ?? 0) + 1;
+          lastActiveTurns = { ...lastActiveTurns, [data.nousId]: (lastActiveTurns[data.nousId] ?? 0) + 1 };
         } else if (type === "turn:after" && data.nousId) {
-          lastActiveTurns[data.nousId] = Math.max(0, (lastActiveTurns[data.nousId] ?? 1) - 1);
+          lastActiveTurns = { ...lastActiveTurns, [data.nousId]: Math.max(0, (lastActiveTurns[data.nousId] ?? 1) - 1) };
         }
         dispatch(type, data);
       } catch { /* ignore */ }
@@ -114,7 +114,6 @@ function connect() {
   }
 
   // SSE comment lines (:ping) don't fire event listeners, but onmessage catches them
-  // Use a catch-all to reset heartbeat on any server activity
   source.onmessage = () => { resetHeartbeat(); };
 }
 

--- a/ui/src/stores/chat.svelte.ts
+++ b/ui/src/stores/chat.svelte.ts
@@ -307,7 +307,7 @@ export function abortStream(agentId: string): void {
 
 function historyToMessages(history: HistoryMessage[]): ChatMessage[] {
   const result: ChatMessage[] = [];
-  let currentToolCalls: ToolCallState[] = [];
+  let pendingToolCalls: ToolCallState[] = [];
 
   for (const msg of history) {
     if (msg.role === "user") {
@@ -318,7 +318,7 @@ function historyToMessages(history: HistoryMessage[]): ChatMessage[] {
         timestamp: msg.createdAt,
       });
     } else if (msg.role === "assistant") {
-      // Check if it's a JSON content block array (text + tool_use + thinking blocks)
+      // Try parsing as JSON content block array (text + tool_use + thinking blocks)
       try {
         const parsed = JSON.parse(msg.content);
         if (Array.isArray(parsed) && parsed.length > 0 && parsed[0]?.type) {
@@ -330,17 +330,20 @@ function historyToMessages(history: HistoryMessage[]): ChatMessage[] {
             ? thinkingBlocks.map((b: { thinking: string }) => b.thinking).join("\n\n")
             : undefined;
 
+          // Accumulate tool calls (append, don't overwrite)
           if (toolBlocks.length > 0) {
-            currentToolCalls = toolBlocks.map((b: { id: string; name: string; input?: Record<string, unknown> }) => ({
-              id: b.id,
-              name: b.name,
-              status: "complete" as const,
-              input: b.input,
-            }));
+            pendingToolCalls.push(
+              ...toolBlocks.map((b: { id: string; name: string; input?: Record<string, unknown> }) => ({
+                id: b.id,
+                name: b.name,
+                status: "complete" as const,
+                input: b.input,
+              })),
+            );
           }
 
-          // If there's text alongside tool_use, emit a message with the text
-          if (textBlocks.length > 0 && toolBlocks.length > 0) {
+          // If there's text, emit a message with text + all accumulated tool calls
+          if (textBlocks.length > 0) {
             const text = textBlocks.map((b: { text: string }) => b.text).join("\n").trim();
             if (text) {
               result.push({
@@ -348,33 +351,16 @@ function historyToMessages(history: HistoryMessage[]): ChatMessage[] {
                 role: "assistant",
                 content: text,
                 timestamp: msg.createdAt,
+                toolCalls: pendingToolCalls.length > 0 ? [...pendingToolCalls] : undefined,
                 ...(thinkingText ? { thinking: thinkingText } : {}),
               });
+              pendingToolCalls = [];
+              continue;
             }
           }
 
-          // If only tool_use blocks (no text), skip — tool calls attach to next assistant message
-          if (toolBlocks.length > 0) continue;
-
-          // Text blocks (possibly with thinking, no tool_use)
-          if (textBlocks.length > 0) {
-            const text = textBlocks.map((b: { text: string }) => b.text).join("\n").trim();
-            result.push({
-              id: msg.id,
-              role: "assistant",
-              content: text,
-              timestamp: msg.createdAt,
-              toolCalls: currentToolCalls.length > 0 ? [...currentToolCalls] : undefined,
-              ...(thinkingText ? { thinking: thinkingText } : {}),
-            });
-            currentToolCalls = [];
-            continue;
-          }
-
-          // Thinking-only blocks (no text, no tool_use) — unlikely but handle gracefully
-          if (thinkingBlocks.length > 0 && textBlocks.length === 0 && toolBlocks.length === 0) {
-            continue;
-          }
+          // No text — tool calls or thinking only, skip (tools attach to next text message)
+          continue;
         }
       } catch {
         // Not JSON, treat as plain text
@@ -385,11 +371,11 @@ function historyToMessages(history: HistoryMessage[]): ChatMessage[] {
         role: "assistant",
         content: msg.content,
         timestamp: msg.createdAt,
-        toolCalls: currentToolCalls.length > 0 ? [...currentToolCalls] : undefined,
+        toolCalls: pendingToolCalls.length > 0 ? [...pendingToolCalls] : undefined,
       });
-      currentToolCalls = [];
+      pendingToolCalls = [];
     } else if (msg.role === "tool_result") {
-      const tc = currentToolCalls.find((t) => t.id === msg.toolCallId);
+      const tc = pendingToolCalls.find((t) => t.id === msg.toolCallId);
       if (tc) {
         tc.result = msg.content.slice(0, 2000);
       }

--- a/ui/src/stores/connection.svelte.ts
+++ b/ui/src/stores/connection.svelte.ts
@@ -1,4 +1,4 @@
-import { initEventSource, closeEventSource, onGlobalEvent } from "../lib/events";
+import { initEventSource, closeEventSource, onGlobalEvent } from "../lib/events.svelte";
 
 let status = $state<"connected" | "disconnected" | "connecting">("disconnected");
 let unsub: (() => void) | null = null;

--- a/ui/src/stores/sessions.svelte.ts
+++ b/ui/src/stores/sessions.svelte.ts
@@ -4,6 +4,7 @@ import type { Session } from "../lib/types";
 let sessions = $state<Session[]>([]);
 let activeSessionId = $state<string | null>(null);
 let loading = $state(false);
+let loadGeneration = 0;
 
 export function getSessions(): Session[] {
   return sessions;
@@ -22,9 +23,11 @@ export function isSessionsLoading(): boolean {
 }
 
 export async function loadSessions(nousId: string): Promise<void> {
+  const gen = ++loadGeneration;
   loading = true;
   try {
     const all = await fetchSessions(nousId);
+    if (gen !== loadGeneration) return; // Stale — a newer loadSessions call superseded us
     // Filter out background/system sessions
     sessions = all.filter((s) =>
       !s.sessionKey.startsWith("cron:") &&
@@ -42,7 +45,7 @@ export async function loadSessions(nousId: string): Promise<void> {
       activeSessionId = null;
     }
   } finally {
-    loading = false;
+    if (gen === loadGeneration) loading = false;
   }
 }
 


### PR DESCRIPTION
## Summary

Fixes multiple interacting UI bugs causing agent chat cross-contamination, message duplication, message fragmentation after refresh, UI lockup during distillation, and failure to show remote turn progress.

### Bugs fixed

- **B1 — Session store race**: Add generation counter to `loadSessions()` to discard stale async results when rapidly switching agents (fixes Syn's messages appearing in Demi's chat)
- **B2 — History reload during local stream**: Guard SSE `init` handler with `hasLocalStream` check (fixes message duplication on SSE reconnect)
- **B3 — Non-reactive activeTurns**: Convert `events.ts` → `events.svelte.ts` with `$state` so Svelte effects react to remote turn status changes
- **B4 — History tool grouping**: Rewrite `historyToMessages` to accumulate tool calls (append instead of overwrite) and keep them with their parent text message (fixes message fragmentation after page refresh)
- **B5 — Dead SSE event types**: Remove `turn:text_delta`, `turn:tool_start`, `turn:tool_result` from client listener registration (server never emits these)
- **B6 — Distillation timeout**: Add 90s `AbortSignal.timeout` to `distillSession` API call (fixes UI lockup)
- **B7 — Remote turn visibility**: Add global `turn:after` handler in `App.svelte` to preload history for background agent turns (fixes needing refresh to see remote responses)

### UX improvement

- Adds response hygiene instruction to bootstrap prompt redirecting agent self-narration about memory/context/distillation to thinking blocks

## Files changed (10)

| File | Change |
|------|--------|
| `ui/src/stores/sessions.svelte.ts` | Generation counter for async cancellation |
| `ui/src/stores/chat.svelte.ts` | Rewrite `historyToMessages` tool grouping |
| `ui/src/components/chat/ChatView.svelte` | Guard init handler, update import |
| `ui/src/lib/events.ts` → `events.svelte.ts` | Reactive `$state`, remove dead event types |
| `ui/src/App.svelte` | Global turn:after handler |
| `ui/src/lib/api.ts` | Distillation timeout |
| `ui/src/stores/connection.svelte.ts` | Update import path |
| `ui/src/components/chat/DistillationProgress.svelte` | Update import path |
| `infrastructure/runtime/src/nous/bootstrap.ts` | Response hygiene prompt |

## Test plan

- [ ] Rapidly switch between agents — verify no cross-contamination
- [ ] Send message, switch agent, switch back — verify response visible
- [ ] Trigger distillation — verify no lockup, 90s timeout
- [ ] Refresh page — verify messages grouped correctly (tool calls with parent)
- [ ] Send Signal message while viewing web UI — verify response appears without refresh
- [ ] Check agents near context limit — verify no narration in main message area