### PR TITLE
fix: rename Syn agent ID from "main" to "syn"

### DIFF
--- a/config/aletheia.example.json
+++ b/config/aletheia.example.json
@@ -21,7 +21,7 @@
           "complex": "claude-opus-4-6"
         },
         "agentOverrides": {
-          "main": "complex",
+          "syn": "complex",
           "creative": "complex",
           "technical": "complex"
         }
@@ -32,7 +32,7 @@
     },
     "list": [
       {
-        "id": "main",
+        "id": "syn",
         "name": "Atlas",
         "default": true,
         "workspace": "/path/to/aletheia/nous/atlas",
@@ -58,7 +58,7 @@
   },
   "bindings": [
     {
-      "agentId": "main",
+      "agentId": "syn",
       "match": {
         "channel": "signal",
         "peer": {

--- a/infrastructure/runtime/src/entry.ts
+++ b/infrastructure/runtime/src/entry.ts
@@ -749,7 +749,7 @@ program
   .description("Show per-section bootstrap token breakdown for an agent")
   .action(async (agentId: string | undefined) => {
     const { auditTokens } = await import("./nous/audit.js");
-    const id = agentId ?? "main";
+    const id = agentId ?? "syn";
     await auditTokens(id);
   });
 

--- a/infrastructure/runtime/src/mneme/schema.ts
+++ b/infrastructure/runtime/src/mneme/schema.ts
@@ -398,4 +398,23 @@ export const MIGRATIONS: Array<{ version: number; sql: string }> = [
       CREATE INDEX IF NOT EXISTS idx_plans_session ON plans(session_id, status);
     `,
   },
+  {
+    version: 19,
+    sql: `
+      -- Rename Syn's agent ID from "main" (OpenClaw legacy) to "syn"
+      UPDATE sessions SET nous_id = 'syn' WHERE nous_id = 'main';
+      UPDATE cross_agent_messages SET source_nous_id = 'syn' WHERE source_nous_id = 'main';
+      UPDATE cross_agent_messages SET target_nous_id = 'syn' WHERE target_nous_id = 'main';
+      UPDATE routing_cache SET nous_id = 'syn' WHERE nous_id = 'main';
+      UPDATE interaction_signals SET nous_id = 'syn' WHERE nous_id = 'main';
+      UPDATE blackboard SET author_nous_id = 'syn' WHERE author_nous_id = 'main';
+      UPDATE threads SET nous_id = 'syn' WHERE nous_id = 'main';
+      UPDATE agent_notes SET nous_id = 'syn' WHERE nous_id = 'main';
+      UPDATE distillation_log SET nous_id = 'syn' WHERE nous_id = 'main';
+      UPDATE sub_agent_log SET parent_nous_id = 'syn' WHERE parent_nous_id = 'main';
+      UPDATE reflection_log SET nous_id = 'syn' WHERE nous_id = 'main';
+      UPDATE tool_stats SET nous_id = 'syn' WHERE nous_id = 'main';
+      UPDATE plans SET nous_id = 'syn' WHERE nous_id = 'main';
+    `,
+  },
 ];

--- a/infrastructure/runtime/src/nous/pipeline/stages/guard.test.ts
+++ b/infrastructure/runtime/src/nous/pipeline/stages/guard.test.ts
@@ -15,7 +15,7 @@ const mocked = vi.mocked(checkInputCircuitBreakers);
 
 function makeState(text = "hello") {
   return {
-    nousId: "main",
+    nousId: "syn",
     sessionId: "ses_1",
     msg: { text, senderId: "u1" },
   } as never;
@@ -44,7 +44,7 @@ describe("checkGuards", () => {
     expect(result!.outcome.toolCalls).toBe(0);
     expect(result!.outcome.inputTokens).toBe(0);
     expect(result!.outcome.outputTokens).toBe(0);
-    expect(result!.outcome.nousId).toBe("main");
+    expect(result!.outcome.nousId).toBe("syn");
     expect(result!.outcome.sessionId).toBe("ses_1");
   });
 

--- a/infrastructure/runtime/src/organon/docker-exec.test.ts
+++ b/infrastructure/runtime/src/organon/docker-exec.test.ts
@@ -66,7 +66,7 @@ describe("execInDocker", () => {
     const result = await execInDocker({
       command: "ls -la",
       workspace: "/mnt/ssd/aletheia/nous/syn",
-      nousId: "main",
+      nousId: "syn",
       timeout: 30000,
       config: defaultConfig,
     });

--- a/infrastructure/runtime/src/semeion/commands.ts
+++ b/infrastructure/runtime/src/semeion/commands.ts
@@ -73,7 +73,7 @@ export function createDefaultRegistry(): CommandRegistry {
   function findSession(ctx: CommandContext, nousId?: string): ReturnType<SessionStore["findSessionById"]> {
     if (ctx.sessionId) return ctx.store.findSessionById(ctx.sessionId);
     const sessionKey = `signal:${ctx.isGroup ? ctx.target.groupId : ctx.sender}`;
-    return ctx.store.findSession(nousId ?? ctx.config.agents.list[0]?.id ?? "main", sessionKey);
+    return ctx.store.findSession(nousId ?? ctx.config.agents.list[0]?.id ?? "syn", sessionKey);
   }
 
   function findSessionsByCtx(ctx: CommandContext): ReturnType<SessionStore["findSessionsByKey"]> {


### PR DESCRIPTION
## Summary

- **Migration v19**: Renames `nous_id = 'main'` → `'syn'` across all 12 tables (13 UPDATE statements — `cross_agent_messages` has two columns)
- **Code fallbacks**: `entry.ts` (CLI audit-tokens), `commands.ts` (Signal session lookup) — both changed from `"main"` to `"syn"`
- **Example config**: Agent ID, routing override key, and Signal binding all updated
- **Tests**: `guard.test.ts` and `docker-exec.test.ts` updated to use `nousId: "syn"`

Session key `"main"` (default session name for all agents) is intentionally **unchanged** — it's a separate concept from agent ID.

## Deploy notes

**Order matters** — update server config BEFORE restarting the service:

1. Pull + build on server (no restart)
2. Edit `/home/syn/.aletheia/aletheia.json`: change `id: "main"` → `"syn"`, `agentId: "main"` → `"syn"` in bindings, and `agentOverrides` key
3. Restart service — migration v19 runs with config already correct

## Test plan

- [x] `npx tsc --noEmit` — types clean
- [x] `vitest run src/nous/pipeline/stages/guard.test.ts` — 3/3 pass
- [x] `vitest run src/organon/docker-exec.test.ts` — 6/6 pass
- [x] `vitest run src/mneme/` — 81/81 pass (migration v19 applies cleanly)
- [ ] Post-deploy: verify `SELECT COUNT(*) FROM sessions WHERE nous_id = 'main'` returns 0
- [ ] Post-deploy: verify Syn sessions exist under `nous_id = 'syn'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)