### PR TITLE
feat(ui): light theme with warm parchment palette (Spec 29 Phase 4)

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -21,6 +21,15 @@
     if(typeof GPUBufferUsage==="undefined")globalThis.GPUBufferUsage={MAP_READ:1,MAP_WRITE:2,COPY_SRC:4,COPY_DST:8,INDEX:16,VERTEX:32,UNIFORM:64,STORAGE:128,INDIRECT:256,QUERY_RESOLVE:512};
     if(typeof GPUMapMode==="undefined")globalThis.GPUMapMode={READ:1,WRITE:2};
   </script>
+  <script>
+    // Apply saved theme + font size before first paint to prevent flash
+    (function(){
+      var t=localStorage.getItem("aletheia_theme");
+      if(t)document.documentElement.setAttribute("data-theme",t);
+      var f=localStorage.getItem("aletheia_font_size");
+      if(f)document.documentElement.style.fontSize=f+"px";
+    })();
+  </script>
   <div id="app"></div>
   <script type="module" src="./src/main.ts"></script>
 </body>

--- a/ui/src/styles/chat-shared.css
+++ b/ui/src/styles/chat-shared.css
@@ -9,11 +9,11 @@
 }
 
 .chat-msg:hover {
-  background: rgba(255, 255, 255, 0.02);
+  background: var(--chat-msg-hover, rgba(255, 255, 255, 0.02));
 }
 
 .chat-msg.assistant {
-  background: rgba(255, 255, 255, 0.01);
+  background: var(--chat-msg-assistant, rgba(255, 255, 255, 0.01));
 }
 
 .chat-msg.streaming {

--- a/ui/src/styles/global.css
+++ b/ui/src/styles/global.css
@@ -128,6 +128,86 @@
   --safe-right: env(safe-area-inset-right, 0px);
 }
 
+/* === LIGHT THEME === */
+/* Warm parchment — same material family as Ardent Leatherworks (#F7F3E8) */
+[data-theme="light"] {
+  /* Backgrounds — warm parchment, not clinical white */
+  --bg: #F7F3E8;
+  --bg-elevated: #FFFFFF;
+  --surface: #EDE8DC;
+  --surface-hover: #E5DFD2;
+
+  /* Borders — visible but soft */
+  --border: #D4CEBD;
+  --border-accent: #9A7B4F;
+
+  /* Text — warm dark, not pure black */
+  --text: #2A2725;
+  --text-secondary: #6B6560;
+  --text-muted: #9A9590;
+
+  /* Accent — same brass, slightly deeper for light-bg contrast */
+  --accent: #8A6B3F;
+  --accent-hover: #7A5B2F;
+  --accent-muted: rgba(138, 107, 63, 0.12);
+  --accent-border: rgba(138, 107, 63, 0.35);
+
+  /* Dye palette — same hues, adjusted for light background */
+  --aima: #581523;
+  --aima-light: #6E1D2F;
+  --thanatochromia: #2C1B3A;
+  --thanatochromia-light: #3A2550;
+  --aporia: #4A7A52;
+  --aporia-muted: #5C8E63;
+  --natural: #8B5A2B;
+  --natural-light: #7A4E24;
+
+  /* Status — same hues, darker for light-bg contrast */
+  --status-success: #3A8A4B;
+  --status-error: #B74440;
+  --status-warning: #A8821F;
+  --status-info: #7A6EA8;
+  --status-active: #B48A2A;
+
+  /* Syntax — adjusted for light background */
+  --syntax-keyword: #A8654A;
+  --syntax-string: #5A8D3E;
+  --syntax-number: #4A7EA7;
+  --syntax-comment: #9A9590;
+  --syntax-function: #A48A4A;
+  --syntax-type: #7A6EA8;
+  --syntax-literal: #4A7EA7;
+  --syntax-tag: #5A8D3E;
+  --syntax-attr: #A8654A;
+  --syntax-property: #8A7A5A;
+  --syntax-meta: #5A7F93;
+  --syntax-builtin: #A48A4A;
+  --syntax-deleted: #B74440;
+  --syntax-inserted: #3A8A4B;
+
+  /* Shadows — lighter, warm-tinted */
+  --shadow-sm: 0 2px 8px rgba(42, 39, 37, 0.08);
+  --shadow-md: 0 4px 12px rgba(42, 39, 37, 0.12);
+  --shadow-lg: 0 8px 24px rgba(42, 39, 37, 0.16);
+
+  /* Chat message backgrounds — dark uses white overlay, light uses dark overlay */
+  --chat-msg-hover: rgba(0, 0, 0, 0.02);
+  --chat-msg-assistant: rgba(0, 0, 0, 0.015);
+
+  color-scheme: light;
+}
+
+[data-theme="light"] ::-webkit-scrollbar-thumb {
+  background: #D4CEBD;
+}
+[data-theme="light"] ::-webkit-scrollbar-thumb:hover {
+  background: #9A9590;
+}
+
+[data-theme="light"] ::selection {
+  background: rgba(138, 107, 63, 0.2);
+}
+
 *, *::before, *::after {
   box-sizing: border-box;
   margin: 0;


### PR DESCRIPTION
## What

Adds a complete light theme that matches the Ardent Leatherworks visual identity.

## The Palette

| Variable | Dark | Light |
|----------|------|-------|
| `--bg` | `#12110f` | `#F7F3E8` (parchment) |
| `--bg-elevated` | `#1a1816` | `#FFFFFF` |
| `--text` | `#e8e6e3` | `#2A2725` (warm dark) |
| `--accent` | `#9A7B4F` | `#8A6B3F` (deeper brass) |
| `--border` | `#302c28` | `#D4CEBD` |

All syntax highlighting, status colors, dye palette, and shadow variables have light-mode equivalents.

## Theme Persistence

Inline `<script>` in index.html applies saved theme + font size before first paint. No flash of wrong theme on reload.

## Chat Message Fix

`chat-shared.css` had hardcoded `rgba(255,255,255,...)` for message hover/assistant backgrounds. Now uses CSS custom properties that invert for light mode.

## Files Changed

- `global.css` — 75-line `[data-theme='light']` block + scrollbar/selection overrides
- `chat-shared.css` — CSS variable fallback pattern for message backgrounds
- `index.html` — inline theme/font-size restore script

Spec 29 Phase 4.