### PR TITLE
feat: status:update SSE event for live agent pill labels

### DIFF
--- a/infrastructure/runtime/src/aletheia.ts
+++ b/infrastructure/runtime/src/aletheia.ts
@@ -457,7 +457,7 @@ export async function startRuntime(configPath?: string): Promise<void> {
 
   // Wire event bus → SSE push for real-time UI updates
   for (const eventName of [
-    "turn:before", "turn:after", "tool:called", "tool:failed",
+    "turn:before", "turn:after", "tool:called", "tool:failed", "status:update",
     "session:created", "session:archived", "config:reloaded",
   ] as const) {
     eventBus.on(eventName, (payload) => broadcastEvent(eventName, payload));

--- a/infrastructure/runtime/src/koina/event-bus.ts
+++ b/infrastructure/runtime/src/koina/event-bus.ts
@@ -8,6 +8,7 @@ export type EventName =
   | "turn:after"
   | "tool:called"
   | "tool:failed"
+  | "status:update"
   | "distill:before"
   | "distill:stage"
   | "distill:after"

--- a/infrastructure/runtime/src/koina/hooks.ts
+++ b/infrastructure/runtime/src/koina/hooks.ts
@@ -240,7 +240,7 @@ export function loadHookDefinitions(hooksDir: string): HookDefinition[] {
 // Known event names from the event bus
 const VALID_EVENTS: Set<string> = new Set([
   "turn:before", "turn:after",
-  "tool:called", "tool:failed",
+  "tool:called", "tool:failed", "status:update",
   "distill:before", "distill:stage", "distill:after",
   "session:created", "session:archived",
   "memory:added", "memory:retracted",

--- a/infrastructure/runtime/src/nous/pipeline/stages/execute.ts
+++ b/infrastructure/runtime/src/nous/pipeline/stages/execute.ts
@@ -271,6 +271,7 @@ export async function* executeStreaming(
         const toolUse = batch[0]!;
         totalToolCalls++;
         yield { type: "tool_start", toolName: toolUse.name, toolId: toolUse.id, input: toolUse.input as Record<string, unknown> };
+        eventBus.emit("status:update", { nousId, status: toolUse.name });
 
         // Approval gate
         if (services.approvalGate && services.approvalMode && services.approvalMode !== "autonomous") {
@@ -335,6 +336,7 @@ export async function* executeStreaming(
           totalToolCalls++;
           yield { type: "tool_start", toolName: toolUse.name, toolId: toolUse.id, input: toolUse.input as Record<string, unknown> };
         }
+        eventBus.emit("status:update", { nousId, status: `${batch.length} tools` });
 
         const batchStart = Date.now();
         const settled = await Promise.allSettled(

--- a/infrastructure/runtime/src/pylon/routes/events.ts
+++ b/infrastructure/runtime/src/pylon/routes/events.ts
@@ -28,6 +28,7 @@ export function eventRoutes(deps: RouteDeps, _refs: RouteRefs): Hono {
           ["turn:after", forward("turn:after")],
           ["tool:called", forward("tool:called")],
           ["tool:failed", forward("tool:failed")],
+          ["status:update", forward("status:update")],
           ["session:created", forward("session:created")],
           ["session:archived", forward("session:archived")],
           ["distill:before", forward("distill:before")],

--- a/ui/src/components/agents/AgentPill.svelte
+++ b/ui/src/components/agents/AgentPill.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
   import type { Agent } from "../../lib/types";
 
-  let { agent, isActive = false, unreadCount = 0, activeTurns = 0, onclick }: {
+  let { agent, isActive = false, unreadCount = 0, activeTurns = 0, statusLabel = "", onclick }: {
     agent: Agent;
     isActive?: boolean;
     unreadCount?: number;
     activeTurns?: number;
+    statusLabel?: string;
     onclick: () => void;
   } = $props();
 
@@ -13,7 +14,7 @@
     unreadCount > 0
       ? `${unreadCount > 9 ? "9+" : unreadCount} new`
       : activeTurns > 0
-        ? "Working"
+        ? (statusLabel || "Working")
         : "Idle",
   );
 

--- a/ui/src/components/layout/TopBar.svelte
+++ b/ui/src/components/layout/TopBar.svelte
@@ -7,7 +7,7 @@
   import { clearToken } from "../../lib/api";
   import { getMessages } from "../../stores/chat.svelte";
   import { formatCost, calculateMessageCost } from "../../lib/format";
-  import { getActiveTurns } from "../../lib/events.svelte";
+  import { getActiveTurns, getAgentStatus } from "../../lib/events.svelte";
   import { getUnreadCount, markRead } from "../../stores/notifications.svelte";
   import { loadSessions } from "../../stores/sessions.svelte";
   import AgentPill from "../agents/AgentPill.svelte";
@@ -81,6 +81,7 @@
           isActive={a.id === getActiveAgentId()}
           unreadCount={getUnreadCount(a.id)}
           activeTurns={getActiveTurns()[a.id] ?? 0}
+          statusLabel={getAgentStatus(a.id)}
           onclick={() => handleAgentClick(a.id)}
         />
       {/each}

--- a/ui/src/lib/events.svelte.ts
+++ b/ui/src/lib/events.svelte.ts
@@ -10,6 +10,7 @@ const MAX_RECONNECT_DELAY = 30000;
 const HEARTBEAT_TIMEOUT_MS = 45_000; // Server sends pings every ~30s
 const listeners = new Set<EventCallback>();
 let lastActiveTurns = $state<Record<string, number>>({});
+let agentStatuses = $state<Record<string, string>>({});
 
 export function onGlobalEvent(cb: EventCallback): () => void {
   listeners.add(cb);
@@ -97,7 +98,8 @@ function connect() {
   // Forward server event types (only types the server SSE route actually emits)
   const eventTypes = [
     "turn:before", "turn:after",
-    "tool:called", "tool:failed", "session:created", "session:archived",
+    "tool:called", "tool:failed", "status:update",
+    "session:created", "session:archived",
     "distill:before", "distill:stage", "distill:after",
   ];
   for (const type of eventTypes) {
@@ -109,6 +111,12 @@ function connect() {
           lastActiveTurns = { ...lastActiveTurns, [data.nousId]: (lastActiveTurns[data.nousId] ?? 0) + 1 };
         } else if (type === "turn:after" && data.nousId) {
           lastActiveTurns = { ...lastActiveTurns, [data.nousId]: Math.max(0, (lastActiveTurns[data.nousId] ?? 1) - 1) };
+          // Clear status when turn ends
+          if ((lastActiveTurns[data.nousId] ?? 0) <= 0) {
+            agentStatuses = { ...agentStatuses, [data.nousId]: "" };
+          }
+        } else if (type === "status:update" && data.nousId && data.status) {
+          agentStatuses = { ...agentStatuses, [data.nousId]: data.status };
         }
         dispatch(type, data);
       } catch { /* ignore */ }
@@ -130,6 +138,10 @@ function scheduleReconnect() {
 
 export function getActiveTurns(): Record<string, number> {
   return lastActiveTurns;
+}
+
+export function getAgentStatus(agentId: string): string {
+  return agentStatuses[agentId] ?? "";
 }
 
 export function getConnectionStatus(): "connected" | "disconnected" | "connecting" {


### PR DESCRIPTION
## What

When an agent starts a tool, its pill in the topbar now shows the tool name instead of generic 'Working'.

## Flow

```
Agent starts tool 'exec' → execute.ts emits status:update {nousId, status: 'exec'}
→ event-bus → aletheia.ts broadcastEvent → SSE route → UI events.svelte.ts
→ agentStatuses store → AgentPill shows 'exec' instead of 'Working'
→ turn:after clears status back to 'Idle'
```

## Runtime Changes (8 files, +24/-6 lines)

| File | Change |
|------|--------|
| `event-bus.ts` | Add `status:update` to EventName union |
| `hooks.ts` | Add to VALID_EVENTS set |
| `execute.ts` | Emit on tool_start (single: tool name, parallel: 'N tools') |
| `events.ts` (SSE route) | Forward `status:update` to clients |
| `aletheia.ts` | Subscribe to `status:update` for broadcast |

## UI Changes

| File | Change |
|------|--------|
| `events.svelte.ts` | Track `agentStatuses`, clear on turn:after, export `getAgentStatus()` |
| `AgentPill.svelte` | Accept `statusLabel` prop, show instead of 'Working' |
| `TopBar.svelte` | Pass `getAgentStatus()` to each pill |

## Testing

- Runtime build passes, all tests pass
- UI build passes

Completes the deferred item from Spec 29.