### PR TITLE
feat: orphan repair + remote turn visibility + mid-turn queue

### DIFF
--- a/infrastructure/runtime/src/mneme/store.ts
+++ b/infrastructure/runtime/src/mneme/store.ts
@@ -429,6 +429,38 @@ export class SessionStore {
     return result;
   }
 
+  repairOrphanedToolUse(sessionId: string): number {
+    const history = this.getHistory(sessionId, { excludeDistilled: true });
+
+    const answeredIds = new Set<string>();
+    for (const m of history) {
+      if (m.role === "tool_result" && m.toolCallId) {
+        answeredIds.add(m.toolCallId);
+      }
+    }
+
+    let repaired = 0;
+    for (const m of history) {
+      if (m.role !== "assistant") continue;
+      try {
+        const parsed = JSON.parse(m.content);
+        if (!Array.isArray(parsed)) continue;
+        for (const block of parsed) {
+          if (block.type !== "tool_use" || !block.id) continue;
+          if (answeredIds.has(block.id)) continue;
+          this.appendMessage(sessionId, "tool_result",
+            `Error: Tool "${block.name ?? "unknown"}" execution interrupted — service restarted mid-turn.`,
+            { toolCallId: block.id, toolName: block.name ?? undefined },
+          );
+          answeredIds.add(block.id);
+          repaired++;
+        }
+      } catch { /* not JSON, skip */ }
+    }
+
+    return repaired;
+  }
+
   getRecentToolCalls(sessionId: string, limit = 10): string[] {
     const rows = this.db
       .prepare(

--- a/infrastructure/runtime/src/nous/pipeline/stages/history.test.ts
+++ b/infrastructure/runtime/src/nous/pipeline/stages/history.test.ts
@@ -34,6 +34,7 @@ function makeServices(): RuntimeServices {
       getUnsurfacedMessages: vi.fn().mockReturnValue([]),
       appendMessage: vi.fn().mockReturnValue(5),
       markMessagesSurfaced: vi.fn(),
+      repairOrphanedToolUse: vi.fn().mockReturnValue(0),
     },
     plugins: null,
   } as unknown as RuntimeServices;

--- a/infrastructure/runtime/src/nous/pipeline/stages/history.ts
+++ b/infrastructure/runtime/src/nous/pipeline/stages/history.ts
@@ -13,6 +13,9 @@ export async function prepareHistory(
   const { nousId, sessionId, msg, nous } = state;
   const historyBudget = (state as TurnState & { _historyBudget?: number })._historyBudget ?? 0;
 
+  const repaired = services.store.repairOrphanedToolUse(sessionId);
+  if (repaired > 0) log.info(`Persisted ${repaired} orphan repair(s) for session ${sessionId}`);
+
   const history = services.store.getHistoryWithBudget(sessionId, historyBudget);
 
   // Surface unsurfaced cross-agent messages

--- a/ui/src/components/chat/ChatView.svelte
+++ b/ui/src/components/chat/ChatView.svelte
@@ -27,6 +27,10 @@
     clearPendingApproval,
     getPendingPlan,
     clearPendingPlan,
+    addRemoteToolCall,
+    setTurnStartedAt,
+    getTurnStartedAt,
+    injectUserMessage,
   } from "../../stores/chat.svelte";
   import type { MediaItem } from "../../lib/types";
   import {
@@ -46,7 +50,7 @@
     loadSessions,
     isSessionsLoading,
   } from "../../stores/sessions.svelte";
-  import { distillSession, fetchCommands, executeCommand } from "../../lib/api";
+  import { distillSession, fetchCommands, executeCommand, queueMessage } from "../../lib/api";
   import type { CommandInfo } from "../../lib/types";
   import { onGlobalEvent } from "../../lib/events.svelte";
   import { onMount, onDestroy, untrack } from "svelte";
@@ -85,6 +89,7 @@
         const turnData = data as { nousId?: string; sessionId?: string; text?: string };
         if (turnData.nousId === agentId) {
           setRemoteStreaming(agentId, false);
+          setTurnStartedAt(agentId, null);
           if (!hasLocalStream(agentId)) {
             const sessionId = getActiveSessionId();
             if (sessionId) {
@@ -109,6 +114,14 @@
         const turnData = data as { nousId?: string };
         if (turnData.nousId === agentId) {
           setRemoteStreaming(agentId, true);
+          setTurnStartedAt(agentId, Date.now());
+        }
+      }
+
+      if (event === "tool:called") {
+        const toolData = data as { nousId?: string; tool?: string; durationMs?: number };
+        if (toolData.nousId === agentId && toolData.tool) {
+          addRemoteToolCall(agentId, toolData.tool, toolData.durationMs);
         }
       }
 
@@ -283,6 +296,17 @@
     });
   }
 
+  function handleQueue(text: string) {
+    if (!currentAgentId) return;
+    injectUserMessage(currentAgentId, text);
+    const sessionId = getActiveSessionId();
+    if (sessionId) {
+      queueMessage(sessionId, text).catch((err) => {
+        injectLocalMessage(currentAgentId!, `*Queue failed: ${err instanceof Error ? err.message : String(err)}*`);
+      });
+    }
+  }
+
   let agent = $derived(getActiveAgent());
   let currentAgentId = $derived(getActiveAgentId());
   let emoji = $derived(currentAgentId ? getAgentEmoji(currentAgentId) : null);
@@ -294,6 +318,8 @@
     const contextWindow = 200_000;
     return Math.min(100, Math.round((tokens / contextWindow) * 100));
   });
+
+  let turnStartedAt = $derived(currentAgentId ? getTurnStartedAt(currentAgentId) : null);
 
   // Pending tool approval
   let pendingApproval = $derived(currentAgentId ? getPendingApproval(currentAgentId) : null);
@@ -381,6 +407,7 @@
       thinkingText={currentAgentId ? getThinkingText(currentAgentId) : ""}
       activeToolCalls={currentAgentId ? getActiveToolCalls(currentAgentId) : []}
       isStreaming={currentAgentId ? getIsStreaming(currentAgentId) : false}
+      {turnStartedAt}
       agentName={agent?.name}
       agentEmoji={emoji}
       onToolClick={handleToolClick}
@@ -408,6 +435,7 @@
     isStreaming={currentAgentId ? getIsStreaming(currentAgentId) : false}
     onSend={handleSend}
     onAbort={handleAbort}
+    onQueue={handleQueue}
     contextPercent={contextPercent()}
     slashCommands={getSlashCommands()}
   />

--- a/ui/src/components/chat/InputBar.svelte
+++ b/ui/src/components/chat/InputBar.svelte
@@ -5,12 +5,14 @@
     isStreaming,
     onSend,
     onAbort,
+    onQueue,
     contextPercent = 0,
     slashCommands = [],
   }: {
     isStreaming: boolean;
     onSend: (text: string, media?: MediaItem[]) => void;
     onAbort: () => void;
+    onQueue?: (text: string) => void;
     contextPercent?: number;
     slashCommands?: Array<{ command: string; description: string }>;
   } = $props();
@@ -230,9 +232,15 @@
 
     if (isStreaming) {
       if (trimmed) {
-        queued = trimmed;
-        text = "";
-        if (textarea) textarea.style.height = "40px";
+        if (onQueue) {
+          onQueue(trimmed);
+          text = "";
+          if (textarea) textarea.style.height = "40px";
+        } else {
+          queued = trimmed;
+          text = "";
+          if (textarea) textarea.style.height = "40px";
+        }
       }
       return;
     }
@@ -369,9 +377,9 @@
         class="send-btn"
         onclick={submit}
         disabled={!hasContent}
-        class:queuing={isStreaming && text.trim().length > 0}
+        class:queuing={isStreaming && !onQueue && text.trim().length > 0}
       >
-        {isStreaming && text.trim().length > 0 ? "Queue" : "Send"}
+        {isStreaming && text.trim().length > 0 ? (onQueue ? "Send" : "Queue") : "Send"}
       </button>
     </div>
     <input

--- a/ui/src/components/chat/MessageList.svelte
+++ b/ui/src/components/chat/MessageList.svelte
@@ -12,6 +12,7 @@
     thinkingText = "",
     activeToolCalls,
     isStreaming,
+    turnStartedAt = null,
     agentName,
     agentEmoji,
     onToolClick,
@@ -22,6 +23,7 @@
     thinkingText?: string;
     activeToolCalls: ToolCallState[];
     isStreaming: boolean;
+    turnStartedAt?: number | null;
     agentName?: string | null;
     agentEmoji?: string | null;
     onToolClick?: (tools: ToolCallState[]) => void;
@@ -102,7 +104,7 @@
               <Markdown content={streamingText} />
             </div>
           {:else if activeToolCalls.length === 0 && !thinkingText}
-            <StreamingIndicator />
+            <StreamingIndicator startedAt={turnStartedAt} />
           {/if}
         </div>
       </div>

--- a/ui/src/components/chat/StreamingIndicator.svelte
+++ b/ui/src/components/chat/StreamingIndicator.svelte
@@ -1,18 +1,48 @@
 <script lang="ts">
+  import { onDestroy } from "svelte";
+
+  let { startedAt = null }: { startedAt?: number | null } = $props();
+
+  let elapsed = $state(0);
+  let timer: ReturnType<typeof setInterval> | null = null;
+
+  $effect(() => {
+    if (timer) { clearInterval(timer); timer = null; }
+    if (startedAt) {
+      elapsed = Math.floor((Date.now() - startedAt) / 1000);
+      timer = setInterval(() => {
+        elapsed = Math.floor((Date.now() - startedAt!) / 1000);
+      }, 1000);
+    } else {
+      elapsed = 0;
+    }
+  });
+
+  onDestroy(() => { if (timer) clearInterval(timer); });
 </script>
 
-<span class="dots">
-  <span class="dot"></span>
-  <span class="dot"></span>
-  <span class="dot"></span>
+<span class="indicator">
+  <span class="dots">
+    <span class="dot"></span>
+    <span class="dot"></span>
+    <span class="dot"></span>
+  </span>
+  {#if startedAt && elapsed > 0}
+    <span class="elapsed">Working... {elapsed}s</span>
+  {/if}
 </span>
 
 <style>
+  .indicator {
+    display: inline-flex;
+    gap: 8px;
+    align-items: center;
+    padding: 4px 0;
+  }
   .dots {
     display: inline-flex;
     gap: 4px;
     align-items: center;
-    padding: 4px 0;
   }
   .dot {
     width: 6px;
@@ -23,6 +53,11 @@
   }
   .dot:nth-child(2) { animation-delay: 0.2s; }
   .dot:nth-child(3) { animation-delay: 0.4s; }
+  .elapsed {
+    font-size: var(--text-xs);
+    color: var(--text-muted);
+    font-variant-numeric: tabular-nums;
+  }
 
   @keyframes bounce {
     0%, 60%, 100% { transform: translateY(0); opacity: 0.4; }

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -105,6 +105,13 @@ export async function distillSession(sessionId: string): Promise<void> {
   });
 }
 
+export async function queueMessage(sessionId: string, text: string): Promise<void> {
+  await fetchJson(`/api/sessions/${sessionId}/queue`, {
+    method: "POST",
+    body: JSON.stringify({ text, sender: "webchat" }),
+  });
+}
+
 export async function fetchThreads(nousId?: string): Promise<Thread[]> {
   const qs = nousId ? `?nousId=${nousId}` : "";
   const data = await fetchJson<{ threads: Thread[] }>(`/api/threads${qs}`);

--- a/ui/src/stores/chat.svelte.ts
+++ b/ui/src/stores/chat.svelte.ts
@@ -13,6 +13,7 @@ interface AgentChatState {
   abortController: AbortController | null;
   pendingApproval: PendingApproval | null;
   pendingPlan: PlanProposal | null;
+  turnStartedAt: number | null;
   // Debounce buffers — accumulate deltas, flush to reactive state on timer
   _textBuffer: string;
   _thinkingBuffer: string;
@@ -35,6 +36,7 @@ const EMPTY: AgentChatState = {
   abortController: null,
   pendingApproval: null,
   pendingPlan: null,
+  turnStartedAt: null,
   _textBuffer: "",
   _thinkingBuffer: "",
   _flushTimer: null,
@@ -59,6 +61,7 @@ function writeState(agentId: string): AgentChatState {
       abortController: null,
       pendingApproval: null,
       pendingPlan: null,
+      turnStartedAt: null,
       _textBuffer: "",
       _thinkingBuffer: "",
       _flushTimer: null,
@@ -120,6 +123,36 @@ export function clearError(agentId: string): void {
   writeState(agentId).error = null;
 }
 
+export function getTurnStartedAt(agentId: string): number | null {
+  return readState(agentId).turnStartedAt;
+}
+
+export function setTurnStartedAt(agentId: string, ts: number | null): void {
+  writeState(agentId).turnStartedAt = ts;
+}
+
+export function addRemoteToolCall(agentId: string, toolName: string, durationMs?: number): void {
+  const state = writeState(agentId);
+  const tc: ToolCallState = {
+    id: `remote-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`,
+    name: toolName,
+    status: "complete",
+    durationMs,
+  };
+  state.activeToolCalls = [...state.activeToolCalls, tc];
+}
+
+export function injectUserMessage(agentId: string, content: string): void {
+  const state = writeState(agentId);
+  const msg: ChatMessage = {
+    id: `user-${Date.now()}`,
+    role: "user",
+    content,
+    timestamp: new Date().toISOString(),
+  };
+  state.messages = [...state.messages, msg];
+}
+
 export async function loadHistory(agentId: string, sessionId: string): Promise<void> {
   const gen = (historyGeneration[agentId] ?? 0) + 1;
   historyGeneration[agentId] = gen;
@@ -146,6 +179,7 @@ export function clearMessages(agentId: string): void {
   state.activeToolCalls = [];
   state.error = null;
   state.pendingApproval = null;
+  state.turnStartedAt = null;
 }
 
 /** Inject a local-only message (not sent to any agent) */
@@ -356,6 +390,7 @@ export async function sendMessage(
     state.activeToolCalls = [];
     state.abortController = null;
     state.pendingApproval = null;
+    state.turnStartedAt = null;
   }
   return resolvedSessionId;
 }


### PR DESCRIPTION
## Summary

- **Persist orphan tool_use repair**: `store.repairOrphanedToolUse()` writes synthetic `tool_result` rows to DB on first encounter. Stops recurring repair warnings every turn and unblocks distillation (which refuses to run when orphaned blocks exist).
- **Remote turn progress**: Wires `tool:called` SSE events into the UI chat store so completed tools appear during server-side turns. `StreamingIndicator` shows live elapsed timer ("Working... 12s") instead of bare bouncing dots.
- **Mid-turn message queue**: When agent is busy with a remote turn, user messages POST to `/api/sessions/:id/queue` (drained mid-turn by execute stage) instead of being held client-side until the turn ends. Agent sees and responds to queued messages within the same turn.

## Test plan

- [x] `npx tsc --noEmit` clean (runtime)
- [x] `vitest run src/mneme/` — 81 tests pass (store including new method)
- [x] `vitest run src/nous/pipeline/stages/history.test.ts` — 4 tests pass
- [x] `npm run build` — UI builds clean
- [ ] Deploy → first Syn turn should log "Persisted N orphan repair(s)", subsequent turns should have no repair warnings
- [ ] While agent processes Signal message, web UI shows elapsed timer + completed tools
- [ ] Send message during remote turn → agent receives it mid-turn and responds