### PR TITLE
feat: onboarding system for fresh installs

### DIFF
--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -3,68 +3,70 @@
 ## Prerequisites
 
 - Node.js >= 22.12
-- Docker and Docker Compose
-- signal-cli ([install guide](https://github.com/AsamK/signal-cli))
-- A registered Signal phone number
+- An Anthropic API key
 
-## 1. Build
+## 1. Clone and Build
 
 ```bash
 git clone https://github.com/forkwright/aletheia.git && cd aletheia
 cd infrastructure/runtime && npm install && npx tsdown && cd ../..
+cd ui && npm install && npm run build && cd ..
 ```
 
-## 2. Configure
+## 2. Initialize
 
 ```bash
-cp .env.example shared/config/aletheia.env
-# Edit: ANTHROPIC_API_KEY, ALETHEIA_ROOT
-
-mkdir -p ~/.aletheia/credentials
-cp config/aletheia.example.json ~/.aletheia/aletheia.json
-# Edit: agent workspace paths, Signal number, bindings
+npx infrastructure/runtime/aletheia.mjs init
 ```
 
-See [CONFIGURATION.md](CONFIGURATION.md) for full reference.
+The wizard will prompt for:
+- Anthropic API key
+- Gateway port (default: 18789)
+- Auth mode (default: none for local use)
+- Aletheia root directory
+- First agent name and emoji
 
-## 3. Memory Infrastructure (optional)
+## 3. Start
+
+```bash
+npx infrastructure/runtime/aletheia.mjs gateway start
+```
+
+Or if installed globally:
+
+```bash
+aletheia gateway start
+```
+
+## 4. Open the UI
+
+```
+http://localhost:18789/ui
+```
+
+Your first agent will guide you through onboarding — it asks about your preferences, communication style, and what you need help with, then writes its own identity files.
+
+## 5. Verify
+
+```bash
+aletheia doctor                         # Validate config
+aletheia status                         # Check running gateway
+curl http://localhost:18789/health      # Health check
+```
+
+## Optional: Memory Infrastructure
+
+For long-term memory with vector search and knowledge graphs:
 
 ```bash
 cd infrastructure/memory && docker compose up -d    # Qdrant + Neo4j
 ```
 
-For the Mem0 sidecar, see [DEPLOYMENT.md](DEPLOYMENT.md#memory-sidecar).
+See [DEPLOYMENT.md](DEPLOYMENT.md#memory-sidecar) for the Mem0 sidecar setup.
 
-## 4. Create an Agent
+## Optional: Signal Integration
 
-```bash
-cp -r nous/_example nous/atlas
-# Edit: SOUL.md (identity), USER.md (operator), IDENTITY.md (name + emoji)
-```
-
-See [WORKSPACE_FILES.md](WORKSPACE_FILES.md) for file reference.
-
-## 5. Build Web UI (optional)
-
-```bash
-cd ui && npm install && npm run build && cd ..
-```
-
-## 6. Run
-
-```bash
-node infrastructure/runtime/aletheia.mjs gateway
-```
-
-## 7. Verify
-
-```bash
-curl http://localhost:18789/health       # Gateway
-open http://localhost:18789/ui           # Web UI
-aletheia send -a atlas -m "Hello"       # Test message
-```
-
-Signal: send a message to the registered number. Use `!help` for commands.
+Requires [signal-cli](https://github.com/AsamK/signal-cli) and a registered phone number. See [CONFIGURATION.md](CONFIGURATION.md#signal) for setup.
 
 ## Next Steps
 

--- a/infrastructure/runtime/src/entry.ts
+++ b/infrastructure/runtime/src/entry.ts
@@ -31,7 +31,9 @@ program
   .description("First-run setup wizard — configure credentials, create first agent")
   .action(async () => {
     const { existsSync, mkdirSync, writeFileSync } = await import("node:fs");
-    const { join } = await import("node:path");
+    const { join, dirname } = await import("node:path");
+    const { fileURLToPath } = await import("node:url");
+    const { randomBytes } = await import("node:crypto");
     const { paths } = await import("./taxis/paths.js");
     const { writeJson } = await import("./koina/fs.js");
     const { scaffoldAgent } = await import("./taxis/scaffold.js");
@@ -67,6 +69,23 @@ program
         return;
       }
 
+      // Auth mode
+      const authInput = (await ask("Auth mode — none (local only), token (API key), session (multi-user) [none]: ")).trim().toLowerCase();
+      const authMode = (authInput === "token" || authInput === "session") ? authInput : "none";
+      const authBlock: Record<string, unknown> = { mode: authMode };
+      if (authMode === "token") {
+        const token = randomBytes(24).toString("hex");
+        authBlock["token"] = token;
+        console.log(`\n  Auth token: ${token}`);
+        console.log(`  Save this — you'll need it to access the UI and API.\n`);
+      }
+
+      // Aletheia root detection
+      const scriptDir = dirname(fileURLToPath(import.meta.url));
+      const detectedRoot = join(scriptDir, "..", "..");
+      const rootInput = (await ask(`Aletheia root [${detectedRoot}]: `)).trim();
+      const aletheiaRoot = rootInput || detectedRoot;
+
       // First agent
       const agentName = (await ask("First agent name (e.g. Atlas): ")).trim();
       if (!agentName) {
@@ -81,19 +100,24 @@ program
       mkdirSync(credDir, { recursive: true });
       const credPath = join(credDir, "anthropic.json");
       writeFileSync(credPath, JSON.stringify({ apiKey }, null, 2) + "\n", { mode: 0o600 });
-      console.log(`  Credentials: ${credPath}`);
 
       // Write base config (scaffoldAgent will append agent + binding)
       mkdirSync(paths.configDir(), { recursive: true });
       writeJson(configPath, {
         agents: { defaults: {}, list: [] },
         bindings: [],
-        gateway: { port },
+        gateway: { port, auth: authBlock },
+        env: { ALETHEIA_ROOT: aletheiaRoot },
       });
 
-      // Scaffold agent
-      mkdirSync(paths.nous, { recursive: true });
-      const templateDir = join(paths.nous, "_example");
+      // Write env file for systemd compatibility
+      const envPath = join(paths.configDir(), "aletheia.env");
+      writeFileSync(envPath, `ALETHEIA_ROOT=${aletheiaRoot}\n`, "utf-8");
+
+      // Scaffold agent using detected root
+      const nousDir = join(aletheiaRoot, "nous");
+      mkdirSync(nousDir, { recursive: true });
+      const templateDir = join(nousDir, "_example");
       if (!existsSync(templateDir)) {
         mkdirSync(templateDir, { recursive: true });
       }
@@ -102,18 +126,31 @@ program
         id: agentId,
         name: agentName,
         emoji: agentEmoji,
-        nousDir: paths.nous,
+        nousDir,
         configPath,
         templateDir,
       });
 
+      const authLabel = authMode === "none"
+        ? "none (no token required)"
+        : authMode === "token"
+          ? "token (saved to config)"
+          : "session (configure users with migrate-auth)";
+
       console.log(`\nSetup complete.`);
-      console.log(`  Config: ${configPath}`);
-      console.log(`  Agent: ${agentName} (${agentId}) → ${result.workspace}`);
+      console.log(`  Config:  ${configPath}`);
+      console.log(`  Agent:   ${agentName} (${agentId}) → ${result.workspace}`);
+      console.log(`  Auth:    ${authLabel}`);
+      console.log(`  Root:    ${aletheiaRoot}`);
       console.log(`\nStart the gateway:`);
       console.log(`  aletheia gateway start`);
       console.log(`\nThen open:`);
       console.log(`  http://localhost:${port}/ui`);
+      console.log(`\nYour agent has onboarding instructions — it will learn your`);
+      console.log(`preferences through conversation.`);
+      console.log(`\nUseful commands:`);
+      console.log(`  aletheia doctor        Validate setup`);
+      console.log(`  aletheia agent create  Add another agent`);
     } finally {
       rl.close();
     }

--- a/ui/src/components/layout/Layout.svelte
+++ b/ui/src/components/layout/Layout.svelte
@@ -8,7 +8,8 @@
   import { getToken, setToken } from "../../lib/api";
   import { fetchAuthMode, getAccessToken, refresh, setAuthFailureHandler, logout } from "../../lib/auth";
   import { getBrandName, loadBranding } from "../../stores/branding.svelte";
-  import { getActiveAgentId } from "../../stores/agents.svelte";
+  import { getActiveAgentId, isFirstRun, loadAgents } from "../../stores/agents.svelte";
+  import Welcome from "../onboarding/Welcome.svelte";
   import Toast from "../shared/Toast.svelte";
 
   type ViewId = "chat" | "metrics" | "graph" | "settings";
@@ -126,6 +127,9 @@
     </div>
   </div>
 {:else}
+  {#if isFirstRun()}
+    <Welcome onComplete={() => { loadAgents(); }} />
+  {:else}
   <TopBar
     onSetView={handleSetView}
     activeView={filePanelOpen ? "files" : activeView}
@@ -141,7 +145,7 @@
           <div style="padding:2rem;color:var(--text-secondary)">Failed to load graph view</div>
         {/await}
       {:else if activeView === "settings"}
-        <SettingsView />
+        <SettingsView onNavigate={handleSetView} />
       {:else}
         <div class="chat-pane">
           {#key getActiveAgentId()}
@@ -164,6 +168,7 @@
     </div>
   </div>
   <Toast />
+  {/if}
 {/if}
 
 <style>

--- a/ui/src/components/onboarding/Welcome.svelte
+++ b/ui/src/components/onboarding/Welcome.svelte
@@ -1,0 +1,188 @@
+<script lang="ts">
+  import { createAgent } from "../../lib/api";
+  import { getBrandName } from "../../stores/branding.svelte";
+
+  let { onComplete }: { onComplete: () => void } = $props();
+
+  let formName = $state("");
+  let formId = $state("");
+  let formEmoji = $state("");
+  let formError = $state("");
+  let creating = $state(false);
+
+  function deriveId(name: string): string {
+    return name.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "").slice(0, 30);
+  }
+
+  function handleNameInput() {
+    formId = deriveId(formName);
+  }
+
+  async function handleCreate() {
+    if (!formName.trim() || !formId.trim()) return;
+    creating = true;
+    formError = "";
+    try {
+      await createAgent(formId, formName.trim(), formEmoji.trim() || undefined);
+      onComplete();
+    } catch (err) {
+      formError = err instanceof Error ? err.message : String(err);
+    } finally {
+      creating = false;
+    }
+  }
+
+  function handleKeydown(e: KeyboardEvent) {
+    if (e.key === "Enter" && formName.trim() && formId.trim() && !creating) {
+      handleCreate();
+    }
+  }
+</script>
+
+<div class="welcome">
+  <div class="welcome-card">
+    <h1 class="welcome-title">{getBrandName()}</h1>
+    <p class="welcome-subtitle">Create your first agent to get started.</p>
+
+    <div class="create-form" onkeydown={handleKeydown}>
+      <label class="field">
+        <span class="field-label">Name</span>
+        <input
+          type="text"
+          class="field-input"
+          placeholder="e.g. Atlas"
+          bind:value={formName}
+          oninput={handleNameInput}
+          disabled={creating}
+        />
+      </label>
+      <label class="field">
+        <span class="field-label">ID</span>
+        <input
+          type="text"
+          class="field-input mono"
+          placeholder="auto-derived"
+          bind:value={formId}
+          disabled={creating}
+        />
+      </label>
+      <label class="field">
+        <span class="field-label">Emoji</span>
+        <input
+          type="text"
+          class="field-input"
+          placeholder="optional"
+          bind:value={formEmoji}
+          disabled={creating}
+        />
+      </label>
+      {#if formError}
+        <div class="form-error">{formError}</div>
+      {/if}
+      <button
+        class="btn-create"
+        onclick={handleCreate}
+        disabled={creating || !formName.trim()}
+      >
+        {creating ? "Creating..." : "Create Agent"}
+      </button>
+    </div>
+
+    <p class="welcome-hint">Your agent will guide you through onboarding via conversation.</p>
+  </div>
+</div>
+
+<style>
+  .welcome {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 100vh;
+    background: var(--bg);
+  }
+  .welcome-card {
+    background: var(--bg-elevated);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 40px 32px;
+    max-width: 420px;
+    width: 100%;
+    text-align: center;
+  }
+  .welcome-title {
+    font-size: var(--text-2xl);
+    font-family: var(--font-display);
+    margin-bottom: 8px;
+  }
+  .welcome-subtitle {
+    color: var(--text-secondary);
+    font-size: var(--text-base);
+    margin-bottom: 24px;
+  }
+  .create-form {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    text-align: left;
+  }
+  .field {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+  .field-label {
+    font-size: var(--text-xs);
+    font-weight: 600;
+    color: var(--text-secondary);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+  .field-input {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    color: var(--text);
+    padding: 10px 12px;
+    font-size: var(--text-base);
+    width: 100%;
+  }
+  .field-input.mono {
+    font-family: var(--font-mono);
+    font-size: var(--text-sm);
+  }
+  .field-input:focus {
+    outline: none;
+    border-color: var(--accent);
+  }
+  .form-error {
+    color: var(--status-error);
+    font-size: var(--text-sm);
+  }
+  .btn-create {
+    margin-top: 4px;
+    background: var(--accent);
+    border: none;
+    color: var(--bg);
+    padding: 12px 14px;
+    border-radius: var(--radius-sm);
+    font-size: var(--text-base);
+    font-weight: 500;
+  }
+  .btn-create:hover:not(:disabled) {
+    background: var(--accent-hover);
+  }
+  .btn-create:disabled {
+    opacity: 0.5;
+  }
+  .welcome-hint {
+    margin-top: 20px;
+    color: var(--text-muted);
+    font-size: var(--text-sm);
+  }
+  @media (max-width: 768px) {
+    .welcome-card {
+      margin: 0 16px;
+      padding: 32px 20px;
+    }
+  }
+</style>

--- a/ui/src/components/settings/SettingsView.svelte
+++ b/ui/src/components/settings/SettingsView.svelte
@@ -1,10 +1,13 @@
 <script lang="ts">
-  import { getToken, setToken, clearToken } from "../../lib/api";
-  import { getAgents } from "../../stores/agents.svelte";
+  import { getToken, setToken, clearToken, createAgent } from "../../lib/api";
+  import { getAgents, loadAgents, setActiveAgent } from "../../stores/agents.svelte";
+  import { loadSessions } from "../../stores/sessions.svelte";
   import { onMount } from "svelte";
   import type { Agent } from "../../lib/types";
   import SessionManager from "./SessionManager.svelte";
   import { fetchAuthMode, getAccessToken, logout as sessionLogout } from "../../lib/auth";
+
+  let { onNavigate }: { onNavigate?: (view: string) => void } = $props();
 
   const THEME_KEY = "aletheia_theme";
   const FONT_SIZE_KEY = "aletheia_font_size";
@@ -18,6 +21,42 @@
   let fontSize = $state<number>(
     parseInt(localStorage.getItem(FONT_SIZE_KEY) ?? "14", 10),
   );
+
+  let showCreateForm = $state(false);
+  let formName = $state("");
+  let formId = $state("");
+  let formEmoji = $state("");
+  let formError = $state("");
+  let creating = $state(false);
+
+  function deriveId(name: string): string {
+    return name.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "").slice(0, 30);
+  }
+
+  function handleNameInput() {
+    formId = deriveId(formName);
+  }
+
+  async function handleCreate() {
+    if (!formName.trim() || !formId.trim()) return;
+    creating = true;
+    formError = "";
+    try {
+      await createAgent(formId, formName.trim(), formEmoji.trim() || undefined);
+      await loadAgents();
+      setActiveAgent(formId);
+      loadSessions(formId);
+      showCreateForm = false;
+      formName = "";
+      formId = "";
+      formEmoji = "";
+      onNavigate?.("chat");
+    } catch (err) {
+      formError = err instanceof Error ? err.message : String(err);
+    } finally {
+      creating = false;
+    }
+  }
 
   onMount(async () => {
     agents = getAgents();
@@ -76,6 +115,45 @@
         <div class="setting-row">
           <span class="setting-label muted">No agents configured</span>
         </div>
+      {/if}
+      {#if showCreateForm}
+        <div class="create-form">
+          <input
+            type="text"
+            class="settings-input"
+            placeholder="Agent name"
+            bind:value={formName}
+            oninput={handleNameInput}
+            disabled={creating}
+          />
+          <input
+            type="text"
+            class="settings-input"
+            placeholder="ID (auto-derived)"
+            bind:value={formId}
+            disabled={creating}
+          />
+          <input
+            type="text"
+            class="settings-input"
+            placeholder="Emoji (optional)"
+            bind:value={formEmoji}
+            disabled={creating}
+          />
+          {#if formError}
+            <div class="form-error">{formError}</div>
+          {/if}
+          <div class="form-actions">
+            <button class="btn-primary" onclick={handleCreate} disabled={creating || !formName.trim()}>
+              {creating ? "Creating..." : "Create"}
+            </button>
+            <button class="btn-cancel" onclick={() => { showCreateForm = false; formError = ""; }}>
+              Cancel
+            </button>
+          </div>
+        </div>
+      {:else}
+        <button class="btn-add" onclick={() => { showCreateForm = true; }}>+ New Agent</button>
       {/if}
     </section>
 
@@ -298,5 +376,47 @@
   }
   .btn-danger:hover {
     background: rgba(248, 81, 73, 0.1);
+  }
+  .btn-add {
+    width: 100%;
+    margin-top: 8px;
+    padding: 8px;
+    border: 1px dashed var(--border);
+    border-radius: var(--radius-sm);
+    background: transparent;
+    color: var(--text-secondary);
+    font-size: var(--text-sm);
+    transition: all var(--transition-quick);
+  }
+  .btn-add:hover {
+    border-color: var(--accent);
+    color: var(--accent);
+  }
+  .create-form {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    margin-top: 12px;
+    padding-top: 12px;
+    border-top: 1px solid var(--border);
+  }
+  .form-error {
+    color: var(--status-error);
+    font-size: var(--text-xs);
+  }
+  .form-actions {
+    display: flex;
+    gap: 8px;
+  }
+  .btn-cancel {
+    padding: 8px 16px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    background: transparent;
+    color: var(--text-secondary);
+    font-size: var(--text-sm);
+  }
+  .btn-cancel:hover {
+    color: var(--text);
   }
 </style>

--- a/ui/src/stores/agents.svelte.ts
+++ b/ui/src/stores/agents.svelte.ts
@@ -22,6 +22,10 @@ export function isLoading(): boolean {
   return loading;
 }
 
+export function isFirstRun(): boolean {
+  return agents.length === 0 && !loading;
+}
+
 export async function loadAgents(): Promise<void> {
   loading = true;
   try {


### PR DESCRIPTION
## Summary
- Fix critical auth bug in `aletheia init` — Zod defaulted to `mode: "token"` with no token value, instant 401 lockout for new users
- Add auth mode prompt (default: none), ALETHEIA_ROOT detection, token generation, better completion output
- First-run Welcome screen with inline agent creation when no agents exist
- Agent creation form in Settings view (makes the `+` button in TopBar functional)
- Update QUICKSTART.md to use CLI wizard flow instead of manual `cp -r` workflow

## Test plan
- [ ] Delete `~/.aletheia/` → run `aletheia init` → verify config has `auth.mode: "none"` and `env.ALETHEIA_ROOT`
- [ ] Start gateway → open UI → Welcome screen appears with agent creation form
- [ ] Create agent → auto-redirects to chat → onboarding SOUL.md conversation starts
- [ ] Click `+` in TopBar → Settings → "New Agent" form works
- [ ] Fresh clone with `auth: "none"` → no 401 errors, UI loads directly

🤖 Generated with [Claude Code](https://claude.com/claude-code)