### PR TITLE
fix: SSE init event sends active turn details for TUI status

### DIFF
--- a/infrastructure/runtime/src/pylon/routes/events.ts
+++ b/infrastructure/runtime/src/pylon/routes/events.ts
@@ -13,7 +13,7 @@ export function eventRoutes(deps: RouteDeps, _refs: RouteRefs): Hono {
 
     const stream = new ReadableStream({
       start(controller) {
-        const activeTurns = manager.getActiveTurnsByNous();
+        const activeTurns = manager.getActiveTurnDetails();
         controller.enqueue(encoder.encode(`event: init\ndata: ${JSON.stringify({ activeTurns })}\n\n`));
 
         const forward = (eventName: string) => (data: unknown) => {


### PR DESCRIPTION
**Bug:** When the TUI connects to the SSE stream, the `init` event sends `activeTurns` from `getActiveTurnsByNous()` which returns a map (`{nousId: count}`). The TUI expects an array of `ActiveTurn` structs (`{nousId, sessionId, turnId}`). Deserialization silently fails, so agents already mid-turn when the TUI starts never show as 'working'.

**Fix:** Use `getActiveTurnDetails()` which returns the array format matching the TUI's expected schema.

One-line change.