### PR TITLE
feat: zero-config onboarding wizard

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -1,0 +1,35 @@
+# Quick Start
+
+```bash
+git clone https://github.com/forkwright/aletheia
+cd aletheia
+./setup.sh
+```
+
+Your browser will open automatically. Follow the setup wizard — it takes about two minutes.
+
+## What setup.sh does
+
+1. Checks Node.js 20+ is present
+2. Builds the runtime and UI
+3. Creates a minimal config at `~/.aletheia/aletheia.json` if one doesn't exist
+4. Starts the gateway on port 18789
+5. Opens your browser
+
+## Credential detection
+
+The wizard will attempt to auto-detect your Anthropic API key from Claude Code's config (`~/.claude.json`). If you don't have Claude Code installed, enter an API key manually at `https://console.anthropic.com/keys`.
+
+## After setup
+
+Your agent's workspace lives at `<repo>/nous/<agent-id>/`. It starts with an onboarding SOUL.md — your first conversation calibrates the agent to your domain and style.
+
+## Manual start (after first run)
+
+```bash
+ALETHEIA_ROOT=$(pwd) node infrastructure/runtime/dist/entry.mjs
+```
+
+## Advanced configuration
+
+See `docs/` for full configuration reference, multi-agent setup, and deployment guides.

--- a/config/services/aletheia.service
+++ b/config/services/aletheia.service
@@ -1,0 +1,58 @@
+[Unit]
+Description=Aletheia AI Gateway
+After=network.target
+
+[Service]
+Type=simple
+User=%i
+EnvironmentFile=%h/.aletheia/env
+ExecStart=/usr/bin/node %h/aletheia/infrastructure/runtime/dist/entry.mjs
+Restart=on-failure
+RestartSec=5
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=default.target
+
+# Usage:
+#   cp aletheia.service ~/.config/systemd/user/aletheia.service
+#   systemctl --user daemon-reload
+#   systemctl --user enable --now aletheia
+#
+# Create ~/.aletheia/env with:
+#   ALETHEIA_ROOT=/home/<user>/aletheia
+
+# =============================================================================
+# macOS launchd equivalent (~/.config/aletheia/com.aletheia.plist):
+# =============================================================================
+#
+# <?xml version="1.0" encoding="UTF-8"?>
+# <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+#   "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+# <plist version="1.0">
+# <dict>
+#   <key>Label</key>
+#   <string>com.aletheia</string>
+#   <key>ProgramArguments</key>
+#   <array>
+#     <string>/usr/local/bin/node</string>
+#     <string>/Users/<user>/aletheia/infrastructure/runtime/dist/entry.mjs</string>
+#   </array>
+#   <key>EnvironmentVariables</key>
+#   <dict>
+#     <key>ALETHEIA_ROOT</key>
+#     <string>/Users/<user>/aletheia</string>
+#   </dict>
+#   <key>RunAtLoad</key>
+#   <true/>
+#   <key>KeepAlive</key>
+#   <true/>
+#   <key>StandardOutPath</key>
+#   <string>/tmp/aletheia.log</string>
+#   <key>StandardErrorPath</key>
+#   <string>/tmp/aletheia.log</string>
+# </dict>
+# </plist>
+#
+# launchctl load ~/Library/LaunchAgents/com.aletheia.plist

--- a/infrastructure/runtime/src/auth/middleware.ts
+++ b/infrastructure/runtime/src/auth/middleware.ts
@@ -60,6 +60,9 @@ export function createAuthMiddleware(
     "/api/auth/login",
     "/api/auth/refresh",
     "/api/auth/mode",
+    "/api/setup/status",
+    "/api/setup/credentials",
+    "/api/setup/complete",
   ]);
 
   return async (c: Context, next: Next) => {

--- a/infrastructure/runtime/src/pylon/routes/setup.ts
+++ b/infrastructure/runtime/src/pylon/routes/setup.ts
@@ -1,0 +1,92 @@
+// Setup routes — pre-auth endpoints for initial onboarding wizard
+import { Hono } from "hono";
+import { existsSync, writeFileSync, readFileSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+import { createLogger } from "../../koina/logger.js";
+import type { RouteDeps, RouteRefs } from "./deps.js";
+
+const log = createLogger("pylon.setup");
+
+const configDir = (): string => process.env["ALETHEIA_CONFIG_DIR"] ?? join(homedir(), ".aletheia");
+const setupFlagFile = (): string => join(configDir(), ".setup-complete");
+const credentialFile = (): string => join(configDir(), "credentials", "anthropic.json");
+const claudeJsonPath = (): string => join(homedir(), ".claude.json");
+
+export function setupRoutes(deps: RouteDeps, _refs: RouteRefs): Hono {
+  const app = new Hono();
+  const { config } = deps;
+
+  app.get("/api/setup/status", (c) => {
+    return c.json({
+      credentialFound: existsSync(credentialFile()),
+      agentCount: config.agents.list.length,
+      setupComplete: existsSync(setupFlagFile()),
+    });
+  });
+
+  app.post("/api/setup/credentials", async (c) => {
+    let apiKey: string | undefined;
+
+    // Check request body first
+    try {
+      const body = await c.req.json() as Record<string, unknown>;
+      if (typeof body["apiKey"] === "string" && body["apiKey"].trim().length > 0) {
+        apiKey = body["apiKey"].trim();
+      }
+    } catch { /* no body or not JSON */ }
+
+    // Auto-detect from Claude Code's credential store
+    if (!apiKey) {
+      try {
+        const raw = JSON.parse(readFileSync(claudeJsonPath(), "utf-8")) as Record<string, unknown>;
+        const pk = raw["primaryApiKey"];
+        if (typeof pk === "string" && pk.length > 0) {
+          apiKey = pk;
+          log.info("Auto-detected API key from ~/.claude.json");
+        }
+      } catch {
+        log.debug("~/.claude.json not found or unreadable");
+      }
+    }
+
+    if (!apiKey) {
+      return c.json({ success: false, error: "No API key found. Provide one manually or sign in to Claude Code first." }, 400);
+    }
+
+    if (!apiKey.startsWith("sk-ant-")) {
+      return c.json({ success: false, error: "Invalid key format — expected sk-ant-..." }, 400);
+    }
+
+    try {
+      const credDir = join(configDir(), "credentials");
+      mkdirSync(credDir, { recursive: true });
+
+      // Preserve existing backupKeys if the file already exists
+      let existing: Record<string, unknown> = {};
+      try {
+        existing = JSON.parse(readFileSync(credentialFile(), "utf-8")) as Record<string, unknown>;
+      } catch { /* no existing file */ }
+
+      writeFileSync(credentialFile(), JSON.stringify({ ...existing, apiKey }, null, 2), { mode: 0o600 });
+      return c.json({ success: true });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      log.error(`Failed to write credentials: ${msg}`);
+      return c.json({ success: false, error: msg }, 500);
+    }
+  });
+
+  app.post("/api/setup/complete", (c) => {
+    try {
+      writeFileSync(setupFlagFile(), new Date().toISOString(), "utf-8");
+      return c.json({ success: true });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      log.error(`Failed to write setup flag: ${msg}`);
+      return c.json({ success: false, error: msg }, 500);
+    }
+  });
+
+  return app;
+}

--- a/infrastructure/runtime/src/pylon/server.ts
+++ b/infrastructure/runtime/src/pylon/server.ts
@@ -34,6 +34,7 @@ import { memoryRoutes } from "./routes/memory.js";
 import { exportRoutes } from "./routes/export.js";
 import { blackboardRoutes } from "./routes/blackboard.js";
 import { workspaceRoutes } from "./routes/workspace.js";
+import { setupRoutes } from "./routes/setup.js";
 
 const log = createLogger("pylon");
 
@@ -180,6 +181,7 @@ export function createGateway(
 
   // Mount all route modules
   const modules = [
+    setupRoutes,
     systemRoutes,
     authRoutes,
     auditRoutes,

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# First-run setup: build, configure, start, open browser
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PORT="${ALETHEIA_PORT:-18789}"
+
+echo "[1/5] Checking prerequisites..."
+if ! command -v node &>/dev/null; then
+  echo "Error: Node.js not found. Install from https://nodejs.org (v20+)"
+  exit 1
+fi
+NODE_MAJOR=$(node -e "process.stdout.write(process.version.slice(1).split('.')[0])")
+if [ "$NODE_MAJOR" -lt 20 ]; then
+  echo "Error: Node.js 20+ required (found $(node --version))"
+  exit 1
+fi
+if ! command -v npm &>/dev/null; then
+  echo "Error: npm not found."
+  exit 1
+fi
+
+echo "[2/5] Building runtime..."
+cd "$REPO_DIR/infrastructure/runtime"
+npm install --silent
+npx tsdown --silent
+
+echo "[3/5] Building UI..."
+cd "$REPO_DIR/ui"
+npm install --silent
+npm run build --silent
+
+echo "[4/5] Writing default config..."
+CONFIG_DIR="${ALETHEIA_CONFIG_DIR:-$HOME/.aletheia}"
+CONFIG_FILE="$CONFIG_DIR/aletheia.json"
+mkdir -p "$CONFIG_DIR"
+if [ ! -f "$CONFIG_FILE" ]; then
+  cat > "$CONFIG_FILE" <<EOF
+{
+  "gateway": {
+    "port": $PORT,
+    "auth": { "mode": "none" }
+  },
+  "agents": { "list": [] }
+}
+EOF
+  echo "   Created $CONFIG_FILE"
+fi
+
+echo "[5/5] Starting Aletheia..."
+ENTRY="$REPO_DIR/infrastructure/runtime/dist/entry.mjs"
+if [ ! -f "$ENTRY" ]; then
+  echo "Error: Build output not found at $ENTRY — build may have failed"
+  exit 1
+fi
+
+# Stop any existing process
+if pgrep -f "entry.mjs" &>/dev/null; then
+  echo "   Stopping existing gateway..."
+  pkill -f "entry.mjs" 2>/dev/null || true
+  sleep 1
+fi
+
+ALETHEIA_ROOT="$REPO_DIR" ALETHEIA_CONFIG_DIR="$CONFIG_DIR" \
+  node "$ENTRY" >> /tmp/aletheia-setup.log 2>&1 &
+GATEWAY_PID=$!
+echo "   Gateway PID $GATEWAY_PID — logs: /tmp/aletheia-setup.log"
+sleep 2
+
+# Verify it started
+if ! kill -0 "$GATEWAY_PID" 2>/dev/null; then
+  echo "Error: Gateway failed to start. Check /tmp/aletheia-setup.log"
+  exit 1
+fi
+
+URL="http://localhost:$PORT"
+echo ""
+echo "Aletheia is running at $URL"
+echo "Opening browser..."
+
+if command -v xdg-open &>/dev/null; then
+  xdg-open "$URL" 2>/dev/null &
+elif command -v open &>/dev/null; then
+  open "$URL" 2>/dev/null &
+else
+  echo "   (Could not auto-open browser — visit $URL manually)"
+fi

--- a/tui/README.md
+++ b/tui/README.md
@@ -1,0 +1,49 @@
+# Aletheia TUI
+
+Terminal interface for Aletheia, built with Rust/Ratatui.
+
+## Setup
+
+The TUI connects to a running Aletheia gateway. Start the gateway first:
+
+```bash
+cd ..
+./setup.sh        # first run: builds everything, starts gateway
+# or manually:
+ALETHEIA_ROOT=$(pwd) node infrastructure/runtime/dist/entry.mjs
+```
+
+## Build
+
+```bash
+cargo build --release
+```
+
+## Run
+
+```bash
+./target/release/aletheia-tui
+# or during development:
+cargo run
+```
+
+Configuration is read from `~/.aletheia/aletheia.json`. The TUI connects to the gateway URL defined in that file (default `http://localhost:18789`).
+
+## Configuration
+
+The TUI respects the same `ALETHEIA_CONFIG_DIR` environment variable as the gateway:
+
+```bash
+ALETHEIA_CONFIG_DIR=~/.aletheia cargo run
+```
+
+## Credential setup
+
+Credentials are shared with the gateway — if you've run `./setup.sh` and completed the web wizard, the TUI will work automatically. To set up credentials manually:
+
+```bash
+# Create the credentials directory and file:
+mkdir -p ~/.aletheia/credentials
+echo '{"apiKey": "sk-ant-..."}' > ~/.aletheia/credentials/anthropic.json
+chmod 600 ~/.aletheia/credentials/anthropic.json
+```

--- a/ui/src/components/layout/Layout.svelte
+++ b/ui/src/components/layout/Layout.svelte
@@ -10,10 +10,11 @@
   import { getBrandName, loadBranding } from "../../stores/branding.svelte";
   import { getActiveAgentId, isFirstRun, loadAgents } from "../../stores/agents.svelte";
   import Welcome from "../onboarding/Welcome.svelte";
+  import SetupWizard from "../onboarding/SetupWizard.svelte";
   import Toast from "../shared/Toast.svelte";
 
   type ViewId = "chat" | "metrics" | "graph" | "settings";
-  type AuthState = "loading" | "login" | "token-setup" | "authenticated";
+  type AuthState = "loading" | "needs-setup" | "login" | "token-setup" | "authenticated";
 
   const FILE_PANEL_WIDTH_KEY = "aletheia_file_panel_width";
 
@@ -37,6 +38,16 @@
   // Determine auth mode on mount
   (async () => {
     try {
+      // Check setup state before auth — wizard runs before any auth concerns
+      const setupStatus = await fetch("/api/setup/status")
+        .then((r) => r.json() as Promise<{ setupComplete: boolean }>)
+        .catch(() => ({ setupComplete: true }));
+
+      if (!setupStatus.setupComplete) {
+        authState = "needs-setup";
+        return;
+      }
+
       const mode = await fetchAuthMode();
       if (mode.sessionAuth) {
         // Try refreshing an existing session (httpOnly cookie may be valid)
@@ -53,6 +64,25 @@
       authState = getToken() ? "authenticated" : "token-setup";
     }
   })();
+
+  async function handleSetupComplete() {
+    // Re-run auth determination now that setup is done
+    authState = "loading";
+    try {
+      const mode = await fetchAuthMode();
+      if (mode.sessionAuth) {
+        const ok = await refresh();
+        authState = ok ? "authenticated" : "login";
+      } else if (mode.mode === "none") {
+        authState = "authenticated";
+      } else {
+        authState = getToken() ? "authenticated" : "token-setup";
+      }
+    } catch {
+      authState = getToken() ? "authenticated" : "token-setup";
+    }
+    await loadAgents();
+  }
 
   // Handle session expiry — redirect to login
   setAuthFailureHandler(() => {
@@ -118,6 +148,8 @@
       <p style="color: var(--text-muted)">Connecting...</p>
     </div>
   </div>
+{:else if authState === "needs-setup"}
+  <SetupWizard onComplete={handleSetupComplete} />
 {:else if authState === "login"}
   <Login onSuccess={handleLoginSuccess} />
 {:else if authState === "token-setup"}

--- a/ui/src/components/onboarding/SetupWizard.svelte
+++ b/ui/src/components/onboarding/SetupWizard.svelte
@@ -1,0 +1,383 @@
+<script lang="ts">
+  import { createAgent } from "../../lib/api";
+  import { getBrandName } from "../../stores/branding.svelte";
+
+  let { onComplete }: { onComplete: () => void } = $props();
+
+  type Step = "credentials" | "agent" | "ready";
+
+  let step = $state<Step>("credentials");
+  let credError = $state("");
+  let credChecking = $state(false);
+  let credFound = $state(false);
+  let manualKey = $state("");
+  let showManual = $state(false);
+
+  let agentName = $state("");
+  let agentEmoji = $state("");
+  let agentCreating = $state(false);
+  let agentError = $state("");
+  let createdName = $state("");
+  let createdEmoji = $state("🤖");
+
+  function deriveId(name: string): string {
+    return name.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "").slice(0, 30);
+  }
+
+  async function autoDetectCredentials() {
+    credChecking = true;
+    credError = "";
+    try {
+      const res = await fetch("/api/setup/credentials", { method: "POST" });
+      const data = await res.json() as { success: boolean; error?: string };
+      if (data.success) {
+        credFound = true;
+        step = "agent";
+      } else {
+        credError = data.error ?? "Auto-detect failed";
+        showManual = true;
+      }
+    } catch {
+      credError = "Could not reach server";
+      showManual = true;
+    } finally {
+      credChecking = false;
+    }
+  }
+
+  async function submitManualKey() {
+    if (!manualKey.trim()) return;
+    credChecking = true;
+    credError = "";
+    try {
+      const res = await fetch("/api/setup/credentials", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ apiKey: manualKey.trim() }),
+      });
+      const data = await res.json() as { success: boolean; error?: string };
+      if (data.success) {
+        credFound = true;
+        step = "agent";
+      } else {
+        credError = data.error ?? "Invalid key";
+      }
+    } catch {
+      credError = "Could not reach server";
+    } finally {
+      credChecking = false;
+    }
+  }
+
+  async function createMyAgent() {
+    if (!agentName.trim()) return;
+    agentCreating = true;
+    agentError = "";
+    const id = deriveId(agentName);
+    const emoji = agentEmoji.trim() || "🤖";
+    try {
+      await createAgent(id, agentName.trim(), emoji);
+      await fetch("/api/setup/complete", { method: "POST" });
+      createdName = agentName.trim();
+      createdEmoji = emoji;
+      step = "ready";
+    } catch (err) {
+      agentError = err instanceof Error ? err.message : String(err);
+    } finally {
+      agentCreating = false;
+    }
+  }
+
+  function handleAgentKeydown(e: KeyboardEvent) {
+    if (e.key === "Enter" && agentName.trim() && !agentCreating) createMyAgent();
+  }
+
+  function handleManualKeydown(e: KeyboardEvent) {
+    if (e.key === "Enter" && manualKey.trim() && !credChecking) submitManualKey();
+  }
+</script>
+
+<div class="wizard">
+  <div class="wizard-card">
+    <div class="progress">
+      {#each (["credentials", "agent", "ready"] as Step[]) as s, i}
+        <div class="dot" class:active={step === s} class:done={
+          (step === "agent" && i === 0) ||
+          (step === "ready" && i < 2)
+        }></div>
+      {/each}
+    </div>
+
+    {#if step === "credentials"}
+      <h1 class="title">{getBrandName()}</h1>
+      <p class="subtitle">Connect your Anthropic account to get started.</p>
+
+      <button class="btn-primary" onclick={autoDetectCredentials} disabled={credChecking}>
+        {credChecking ? "Detecting..." : "Auto-detect from Claude Code"}
+      </button>
+
+      {#if credError && !showManual}
+        <p class="error">{credError}</p>
+      {/if}
+
+      {#if showManual}
+        <div class="manual-section">
+          <p class="manual-label">Enter your API key manually:</p>
+          <div class="key-row" onkeydown={handleManualKeydown} role="group">
+            <input
+              type="password"
+              class="key-input"
+              placeholder="sk-ant-..."
+              bind:value={manualKey}
+              disabled={credChecking}
+            />
+            <button class="btn-secondary" onclick={submitManualKey} disabled={credChecking || !manualKey.trim()}>
+              {credChecking ? "..." : "Use key"}
+            </button>
+          </div>
+          {#if credError}
+            <p class="error">{credError}</p>
+          {/if}
+        </div>
+      {:else if !credChecking}
+        <button class="btn-link" onclick={() => { showManual = true; credError = ""; }}>
+          Enter API key manually
+        </button>
+      {/if}
+
+      <a
+        class="key-link"
+        href="https://console.anthropic.com/keys"
+        target="_blank"
+        rel="noopener noreferrer"
+      >Get an API key →</a>
+
+    {:else if step === "agent"}
+      <h1 class="title">Name your agent</h1>
+      <p class="subtitle">Claude will calibrate to your domain and style in your first conversation.</p>
+
+      <div class="agent-form" onkeydown={handleAgentKeydown} role="group">
+        <label class="field">
+          <span class="field-label">Name</span>
+          <input
+            type="text"
+            class="field-input"
+            placeholder="e.g. Chiron"
+            bind:value={agentName}
+            disabled={agentCreating}
+            autofocus
+          />
+        </label>
+        <label class="field">
+          <span class="field-label">Emoji (optional)</span>
+          <input
+            type="text"
+            class="field-input emoji-input"
+            placeholder="🤖"
+            bind:value={agentEmoji}
+            disabled={agentCreating}
+          />
+        </label>
+        {#if agentError}
+          <p class="error">{agentError}</p>
+        {/if}
+        <button
+          class="btn-primary"
+          onclick={createMyAgent}
+          disabled={agentCreating || !agentName.trim()}
+        >
+          {agentCreating ? "Creating..." : "Create agent"}
+        </button>
+      </div>
+
+    {:else}
+      <div class="ready-emoji">{createdEmoji}</div>
+      <h1 class="title">{createdName} is ready</h1>
+      <p class="subtitle">Your first conversation will calibrate {createdName} to how you work.</p>
+      <button class="btn-primary" onclick={onComplete}>Start your first conversation</button>
+    {/if}
+  </div>
+</div>
+
+<style>
+  .wizard {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 100vh;
+    background: var(--bg);
+  }
+  .wizard-card {
+    background: var(--bg-elevated);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 40px 32px;
+    max-width: 480px;
+    width: 100%;
+    text-align: center;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 16px;
+  }
+  .progress {
+    display: flex;
+    gap: 8px;
+    margin-bottom: 8px;
+  }
+  .dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: var(--border);
+    transition: background var(--transition-quick);
+  }
+  .dot.active {
+    background: var(--accent);
+  }
+  .dot.done {
+    background: var(--status-success);
+  }
+  .title {
+    font-size: var(--text-2xl);
+    font-family: var(--font-display);
+    margin: 0;
+  }
+  .subtitle {
+    color: var(--text-secondary);
+    font-size: var(--text-base);
+    margin: 0;
+    max-width: 340px;
+  }
+  .btn-primary {
+    background: var(--accent);
+    border: none;
+    color: var(--bg);
+    padding: 12px 24px;
+    border-radius: var(--radius-sm);
+    font-size: var(--text-base);
+    font-weight: 500;
+    width: 100%;
+    cursor: pointer;
+  }
+  .btn-primary:hover:not(:disabled) {
+    background: var(--accent-hover);
+  }
+  .btn-primary:disabled {
+    opacity: 0.5;
+    cursor: default;
+  }
+  .btn-secondary {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    color: var(--text);
+    padding: 10px 16px;
+    border-radius: var(--radius-sm);
+    font-size: var(--text-base);
+    white-space: nowrap;
+    cursor: pointer;
+  }
+  .btn-secondary:disabled {
+    opacity: 0.5;
+    cursor: default;
+  }
+  .btn-link {
+    background: none;
+    border: none;
+    color: var(--text-secondary);
+    font-size: var(--text-sm);
+    cursor: pointer;
+    text-decoration: underline;
+    padding: 0;
+  }
+  .error {
+    color: var(--status-error);
+    font-size: var(--text-sm);
+    margin: 0;
+  }
+  .manual-section {
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    text-align: left;
+  }
+  .manual-label {
+    font-size: var(--text-sm);
+    color: var(--text-secondary);
+    margin: 0;
+  }
+  .key-row {
+    display: flex;
+    gap: 8px;
+  }
+  .key-input {
+    flex: 1;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    color: var(--text);
+    padding: 10px 12px;
+    font-size: var(--text-sm);
+    font-family: var(--font-mono);
+    min-width: 0;
+  }
+  .key-input:focus {
+    outline: none;
+    border-color: var(--accent);
+  }
+  .key-link {
+    color: var(--text-muted);
+    font-size: var(--text-sm);
+    text-decoration: none;
+  }
+  .key-link:hover {
+    color: var(--accent);
+  }
+  .agent-form {
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    text-align: left;
+  }
+  .field {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+  .field-label {
+    font-size: var(--text-xs);
+    font-weight: 600;
+    color: var(--text-secondary);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+  .field-input {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    color: var(--text);
+    padding: 10px 12px;
+    font-size: var(--text-base);
+    width: 100%;
+  }
+  .field-input:focus {
+    outline: none;
+    border-color: var(--accent);
+  }
+  .emoji-input {
+    font-size: var(--text-xl);
+    max-width: 80px;
+  }
+  .ready-emoji {
+    font-size: 48px;
+    line-height: 1;
+  }
+  @media (max-width: 768px) {
+    .wizard-card {
+      margin: 0 16px;
+      padding: 32px 20px;
+    }
+  }
+</style>


### PR DESCRIPTION
## Summary

- **`setup.sh`** — single entry point after clone: checks Node 20+, builds runtime + UI, writes minimal `~/.aletheia/aletheia.json` if missing, starts gateway, opens browser
- **`/api/setup/*` endpoints** — three pre-auth endpoints; auto-detects `primaryApiKey` from `~/.claude.json` (Claude Code), falls back to manual entry
- **`SetupWizard.svelte`** — 3-step wizard for fresh installs: credentials → agent name/emoji → ready
- **`Layout.svelte`** — new `"needs-setup"` auth state checked before all auth logic; flag file `~/.aletheia/.setup-complete` gates the wizard
- **Docs** — `QUICKSTART.md` (3 commands), `tui/README.md`, `config/services/aletheia.service` (systemd + launchd reference)

Onboarding conversation (domain calibration → SOUL.md/USER.md) is driven by the existing `scaffoldAgent` mechanism — no changes needed there.

## Test plan

- [ ] `rm -rf ~/.aletheia && ./setup.sh` — builds, starts, browser opens to wizard
- [ ] Step 1 auto-detect — reads key from `~/.claude.json`, advances to step 2
- [ ] Step 1 fallback — rename `~/.claude.json`, manual key input shown and accepted
- [ ] Step 2 — enter agent name → "Create agent" → step 3 renders
- [ ] Step 3 — "Start first conversation" → chat loads
- [ ] First turn → agent asks onboarding question (from scaffold SOUL.md)
- [ ] Subsequent load with flag present — wizard skipped, normal auth flow
- [ ] `cd ui && npm run build` clean; `npx tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)