### PR TITLE
feat: credential label pill in topbar

### DIFF
--- a/infrastructure/runtime/src/hermeneus/anthropic.ts
+++ b/infrastructure/runtime/src/hermeneus/anthropic.ts
@@ -59,6 +59,7 @@ export interface TurnResult {
     cacheWriteTokens: number;
   };
   model: string;
+  credentialLabel?: string;
 }
 
 export interface MessageParam {
@@ -106,13 +107,15 @@ export type StreamingEvent =
 export class AnthropicProvider {
   private client: Anthropic;
   private isOAuth: boolean;
+  readonly label: string;
 
-  constructor(opts?: { apiKey?: string; authToken?: string }) {
+  constructor(opts?: { apiKey?: string; authToken?: string; label?: string }) {
     // Support both API key (x-api-key) and OAuth token (Bearer auth)
     // OAuth is used for Max/Pro plan routing
     const authToken = opts?.authToken ?? process.env["ANTHROPIC_AUTH_TOKEN"];
     const apiKey = opts?.apiKey ?? process.env["ANTHROPIC_API_KEY"];
 
+    this.label = opts?.label ?? "default";
     this.isOAuth = !!authToken;
     if (authToken) {
       this.client = new Anthropic({
@@ -221,6 +224,7 @@ export class AnthropicProvider {
             (usage as unknown as Record<string, number>)["cache_creation_input_tokens"] ?? 0,
         },
         model: response.model,
+        credentialLabel: this.label,
       };
     } catch (error) {
       if (error instanceof Anthropic.APIError) {
@@ -398,6 +402,7 @@ export class AnthropicProvider {
         stopReason,
         usage,
         model: responseModel,
+        credentialLabel: this.label,
       },
     };
   }

--- a/infrastructure/runtime/src/hermeneus/router.ts
+++ b/infrastructure/runtime/src/hermeneus/router.ts
@@ -187,7 +187,24 @@ export function createDefaultRouter(config?: RouterConfig): ProviderRouter {
   // (the router's claude-* fallback handles unregistered models)
   const configModels = config?.providers?.["anthropic"]?.models?.map((m) => m.id) ?? [];
 
-  const providerOpts = authToken ? { authToken } : fileApiKey ? { apiKey: fileApiKey } : undefined;
+  // Read credential label from file (default: "primary" for file-based, "default" for env)
+  let primaryLabel = "default";
+  {
+    const home2 = process.env["HOME"] ?? "/tmp";
+    const credPath2 = join(home2, ".aletheia", "credentials", "anthropic.json");
+    try {
+      const raw = JSON.parse(readFileSync(credPath2, "utf-8")) as Record<string, unknown>;
+      if (typeof raw["label"] === "string" && raw["label"].length > 0) {
+        primaryLabel = raw["label"];
+      }
+    } catch { /* use default */ }
+  }
+
+  const providerOpts = authToken
+    ? { authToken, label: primaryLabel }
+    : fileApiKey
+      ? { apiKey: fileApiKey, label: primaryLabel }
+      : { label: primaryLabel };
   const anthropic = new AnthropicProvider(providerOpts);
   router.registerProvider("anthropic", anthropic, configModels);
 
@@ -200,16 +217,18 @@ export function createDefaultRouter(config?: RouterConfig): ProviderRouter {
     const raw = JSON.parse(readFileSync(credPath, "utf-8")) as Record<string, unknown>;
     const backups: AnthropicProvider[] = [];
 
-    // New format: typed backup credentials (oauth tokens + API keys)
+    // New format: typed backup credentials (oauth tokens + API keys) with optional labels
     const backupCreds = raw["backupCredentials"];
     if (Array.isArray(backupCreds)) {
-      for (const cred of backupCreds) {
+      for (let bi = 0; bi < backupCreds.length; bi++) {
+        const cred = backupCreds[bi];
         if (typeof cred !== "object" || cred === null) continue;
         const c = cred as Record<string, unknown>;
+        const label = typeof c["label"] === "string" ? c["label"] : `backup-${bi + 1}`;
         if (c["type"] === "oauth" && typeof c["token"] === "string" && (c["token"] as string).length > 0) {
-          backups.push(new AnthropicProvider({ authToken: c["token"] as string }));
+          backups.push(new AnthropicProvider({ authToken: c["token"] as string, label }));
         } else if (typeof c["apiKey"] === "string" && (c["apiKey"] as string).length > 0) {
-          backups.push(new AnthropicProvider({ apiKey: c["apiKey"] as string }));
+          backups.push(new AnthropicProvider({ apiKey: c["apiKey"] as string, label }));
         }
       }
     }
@@ -217,9 +236,10 @@ export function createDefaultRouter(config?: RouterConfig): ProviderRouter {
     // Legacy format: plain API key strings
     const backupKeys = raw["backupKeys"];
     if (Array.isArray(backupKeys)) {
-      for (const key of backupKeys) {
+      for (let bi = 0; bi < backupKeys.length; bi++) {
+        const key = backupKeys[bi];
         if (typeof key === "string" && key.length > 0) {
-          backups.push(new AnthropicProvider({ apiKey: key }));
+          backups.push(new AnthropicProvider({ apiKey: key, label: `backup-${bi + 1}` }));
         }
       }
     }

--- a/infrastructure/runtime/src/nous/pipeline/stages/execute.ts
+++ b/infrastructure/runtime/src/nous/pipeline/stages/execute.ts
@@ -113,6 +113,9 @@ export async function* executeStreaming(
   const narrationEnabled = services.config.agents.defaults.narrationFilter !== false;
   const narrationFilter = narrationEnabled ? new NarrationFilter() : null;
 
+  // Track which credential was used (updated each loop from streamResult)
+  let lastCredentialLabel: string | undefined;
+
   for (let loop = 0; ; loop++) {
     let accumulatedText = "";
     let streamResult: import("../../../hermeneus/anthropic.js").TurnResult | null = null;
@@ -171,6 +174,7 @@ export async function* executeStreaming(
 
     if (!streamResult) throw new PipelineError("Stream ended without message_complete", { code: "PIPELINE_STREAM_INCOMPLETE" });
 
+    lastCredentialLabel = streamResult.credentialLabel;
     totalInputTokens += streamResult.usage.inputTokens;
     totalOutputTokens += streamResult.usage.outputTokens;
     totalCacheReadTokens += streamResult.usage.cacheReadTokens;
@@ -212,6 +216,7 @@ export async function* executeStreaming(
         text, nousId, sessionId, model, toolCalls: totalToolCalls,
         inputTokens: totalInputTokens, outputTokens: totalOutputTokens,
         cacheReadTokens: totalCacheReadTokens, cacheWriteTokens: totalCacheWriteTokens,
+        ...(lastCredentialLabel ? { credentialLabel: lastCredentialLabel } : {}),
       };
 
       trace.setUsage(totalInputTokens, totalOutputTokens, totalCacheReadTokens, totalCacheWriteTokens);
@@ -428,6 +433,7 @@ export async function* executeStreaming(
             text: planSummary, nousId, sessionId, model, toolCalls: totalToolCalls,
             inputTokens: state.totalInputTokens, outputTokens: state.totalOutputTokens,
             cacheReadTokens: state.totalCacheReadTokens, cacheWriteTokens: state.totalCacheWriteTokens,
+            ...(lastCredentialLabel ? { credentialLabel: lastCredentialLabel } : {}),
           };
           yield { type: "turn_complete", outcome: state.outcome };
           return state;
@@ -577,6 +583,7 @@ export async function executeBuffered(
         text, nousId, sessionId, model, toolCalls: totalToolCalls,
         inputTokens: totalInputTokens, outputTokens: totalOutputTokens,
         cacheReadTokens: totalCacheReadTokens, cacheWriteTokens: totalCacheWriteTokens,
+        ...(result.credentialLabel ? { credentialLabel: result.credentialLabel } : {}),
       };
 
       return state;
@@ -732,6 +739,7 @@ export async function executeBuffered(
             text: planSummary, nousId, sessionId, model, toolCalls: totalToolCalls,
             inputTokens: state.totalInputTokens, outputTokens: state.totalOutputTokens,
             cacheReadTokens: state.totalCacheReadTokens, cacheWriteTokens: state.totalCacheWriteTokens,
+            ...(result.credentialLabel ? { credentialLabel: result.credentialLabel } : {}),
           };
           return state;
         }

--- a/infrastructure/runtime/src/nous/pipeline/types.ts
+++ b/infrastructure/runtime/src/nous/pipeline/types.ts
@@ -75,6 +75,7 @@ export interface TurnOutcome {
   outputTokens: number;
   cacheReadTokens: number;
   cacheWriteTokens: number;
+  credentialLabel?: string;
   error?: string;
 }
 

--- a/infrastructure/runtime/src/pylon/routes/system.ts
+++ b/infrastructure/runtime/src/pylon/routes/system.ts
@@ -1,5 +1,8 @@
 // System routes — health, status, update, config reload
 import { Hono } from "hono";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
 import { createLogger } from "../../koina/logger.js";
 import { tryReloadConfig } from "../../taxis/loader.js";
 import { eventBus } from "../../koina/event-bus.js";
@@ -54,6 +57,33 @@ export function systemRoutes(deps: RouteDeps, _refs: RouteRefs): Hono {
       const msg = err instanceof Error ? err.message : String(err);
       log.warn(`System update failed: ${msg}`);
       return c.json({ error: msg }, 500);
+    }
+  });
+
+  // Credential labels — exposes configured credential names (no secrets)
+  app.get("/api/system/credentials", (c) => {
+    const credPath = join(
+      process.env["ALETHEIA_CONFIG_DIR"] ?? join(homedir(), ".aletheia"),
+      "credentials", "anthropic.json",
+    );
+    try {
+      const raw = JSON.parse(readFileSync(credPath, "utf-8")) as Record<string, unknown>;
+      const primary = typeof raw["label"] === "string" ? raw["label"] : "primary";
+      const authType = typeof raw["token"] === "string" ? "oauth" : typeof raw["apiKey"] === "string" ? "api" : "unknown";
+      const backups: Array<{ label: string; type: string }> = [];
+      const backupCreds = raw["backupCredentials"];
+      if (Array.isArray(backupCreds)) {
+        for (let i = 0; i < backupCreds.length; i++) {
+          const cred = backupCreds[i] as Record<string, unknown> | undefined;
+          if (!cred || typeof cred !== "object") continue;
+          const label = typeof cred["label"] === "string" ? cred["label"] : `backup-${i + 1}`;
+          const type = cred["type"] === "oauth" ? "oauth" : "api";
+          backups.push({ label, type });
+        }
+      }
+      return c.json({ primary: { label: primary, type: authType }, backups });
+    } catch {
+      return c.json({ primary: { label: "default", type: "unknown" }, backups: [] });
     }
   });
 

--- a/shared/skills/credential-based-repository-investigation-and-provider-analysis/SKILL.md
+++ b/shared/skills/credential-based-repository-investigation-and-provider-analysis/SKILL.md
@@ -1,0 +1,19 @@
+# Credential-Based Repository Investigation and Provider Analysis
+
+Investigate a codebase's provider implementations and authentication system by retrieving credentials and analyzing git history and provider-specific code files.
+
+## When to Use
+When you need to understand how a project authenticates with external services (e.g., API providers), understand recent changes to authentication or setup workflows, and examine provider-specific implementation details.
+
+## Steps
+1. Retrieve stored credentials from the local credentials directory
+2. Navigate to the project repository and examine recent git commits to identify relevant changes
+3. Check git diff against the previous commit to see which files were modified
+4. Read the provider router/abstraction layer to understand the provider architecture
+5. Read provider-specific implementation files (e.g., the particular provider being investigated)
+6. Verify current repository status and stash state to understand working directory context
+7. Validate credential access one more time to confirm authentication setup
+
+## Tools Used
+- exec: Navigate to repository, view git history, check git diffs, verify repository status and stash state
+- read: Access provider router and provider-specific implementation files to understand authentication integration

--- a/shared/skills/credential-discovery-and-authentication-system-investigation/SKILL.md
+++ b/shared/skills/credential-discovery-and-authentication-system-investigation/SKILL.md
@@ -1,0 +1,25 @@
+# Credential Discovery and Authentication System Investigation
+Locate and analyze authentication mechanisms, credential storage, and API error handling in a codebase.
+
+## When to Use
+When you need to understand how a system handles credentials, authentication tokens, and API authentication flows, especially to diagnose authentication-related issues or trace error handling paths.
+
+## Steps
+1. Search for authentication-related keywords (oauth, token, credentials, refresh_token) across the codebase
+2. Explore directory structure to locate authentication-related modules
+3. Identify credential storage locations (config files, environment paths)
+4. Read key authentication handler files to understand the auth flow
+5. Locate and examine error handling classes for provider/authentication errors
+6. Search for rate-limit and error-related patterns in router/handler code
+7. Check for credential configuration files in standard locations (~/.aletheia/credentials/)
+8. Trace authentication flows through setup/auth routes
+9. Search UI authentication code for client-side credential handling
+10. Use web search/fetch to understand standard API error response formats if needed
+
+## Tools Used
+- grep: Search for authentication keywords across multiple file types and paths
+- find: Locate TypeScript files in specific directories
+- exec: List directory contents and read credential files
+- read: Examine authentication handler and error class implementations
+- web_search: Query external documentation for API error standards
+- web_fetch: Retrieve official API documentation on error handling

--- a/ui/src/components/layout/TopBar.svelte
+++ b/ui/src/components/layout/TopBar.svelte
@@ -5,11 +5,10 @@
   import { getBrandName } from "../../stores/branding.svelte";
   import { getAccessToken, logout } from "../../lib/auth";
   import { clearToken, getEffectiveToken } from "../../lib/api";
-  import { getMessages } from "../../stores/chat.svelte";
-  import { formatCost, calculateMessageCost } from "../../lib/format";
   import { getActiveTurns, getAgentStatus } from "../../lib/events.svelte";
   import { getUnreadCount, markRead } from "../../stores/notifications.svelte";
   import { loadSessions } from "../../stores/sessions.svelte";
+  import { getActiveCredentialLabel, getCredentialConfig, loadCredentialConfig } from "../../stores/credentials.svelte";
   import AgentPill from "../agents/AgentPill.svelte";
 
   type ViewId = "chat" | "metrics" | "graph" | "files" | "settings";
@@ -25,15 +24,11 @@
   let updateAvailable = $state(false);
   let updateVersion = $state("");
 
-  let sessionCost = $derived(() => {
-    const agentId = getActiveAgentId();
-    if (!agentId) return 0;
-    const msgs = getMessages(agentId);
-    let total = 0;
-    for (const m of msgs) {
-      if (m.turnOutcome) total += calculateMessageCost(m.turnOutcome);
-    }
-    return total;
+  let credLabel = $derived(getActiveCredentialLabel());
+  let credConfig = $derived(getCredentialConfig());
+  let isBackup = $derived(() => {
+    if (!credConfig) return false;
+    return credLabel !== credConfig.primary.label;
   });
 
   function handleAgentClick(id: string) {
@@ -55,6 +50,9 @@
   }
 
   onMount(async () => {
+    // Load credential configuration
+    loadCredentialConfig();
+
     try {
       const token = getEffectiveToken();
       const res = await fetch("/api/system/update-status", {
@@ -88,8 +86,12 @@
       {/each}
       <button class="add-agent-pill" onclick={() => onSetView("settings")} title="Add agent">+</button>
     </div>
-    {#if sessionCost() > 0}
-      <span class="session-cost" title="Running session cost">{formatCost(sessionCost())}</span>
+    {#if credConfig}
+      <span
+        class="credential-pill"
+        class:is-backup={isBackup()}
+        title={isBackup() ? `Using ${credLabel} (failover)` : `Using ${credLabel}`}
+      >{credLabel}</span>
     {/if}
     {#if updateAvailable}
       <span class="update-badge" title="Update available: v{updateVersion}">v{updateVersion}</span>
@@ -239,14 +241,23 @@
     0%, 100% { opacity: 1; }
     50% { opacity: 0.4; }
   }
-  .session-cost {
+  .credential-pill {
     font-size: var(--text-xs);
     font-family: var(--font-mono);
     color: var(--text-muted);
     background: var(--surface);
     border: 1px solid var(--border);
-    border-radius: var(--radius);
-    padding: 1px 6px;
+    border-radius: var(--radius-pill);
+    padding: 2px 8px;
+    text-transform: lowercase;
+    letter-spacing: 0.02em;
+    transition: all var(--transition-quick);
+    flex-shrink: 0;
+  }
+  .credential-pill.is-backup {
+    color: var(--status-warning);
+    background: color-mix(in srgb, var(--status-warning) 12%, transparent);
+    border-color: color-mix(in srgb, var(--status-warning) 30%, transparent);
   }
   .update-badge {
     font-size: var(--text-xs);

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -358,3 +358,15 @@ export async function fetchToolStats(agentId?: string, window = "7d"): Promise<u
   sp.set("window", window);
   return fetchJson(`/api/tool-stats?${sp.toString()}`);
 }
+
+
+// --- Credential Info ---
+
+export interface CredentialInfo {
+  primary: { label: string; type: string };
+  backups: Array<{ label: string; type: string }>;
+}
+
+export async function fetchCredentialInfo(): Promise<CredentialInfo> {
+  return fetchJson("/api/system/credentials");
+}

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -111,6 +111,7 @@ export interface TurnOutcome {
   outputTokens: number;
   cacheReadTokens: number;
   cacheWriteTokens: number;
+  credentialLabel?: string;
 }
 
 export interface MetricsData {

--- a/ui/src/stores/chat.svelte.ts
+++ b/ui/src/stores/chat.svelte.ts
@@ -1,5 +1,6 @@
 import { fetchHistory } from "../lib/api";
 import { streamMessage } from "../lib/stream";
+import { setActiveCredentialLabel } from "./credentials.svelte";
 import type { ChatMessage, ToolCallState, HistoryMessage, MediaItem, PendingApproval, PlanProposal } from "../lib/types";
 
 interface AgentChatState {
@@ -321,6 +322,10 @@ export async function sendMessage(
 
         case "turn_complete": {
           flushStreamBuffer(state);
+          // Update active credential label for topbar pill
+          if (event.outcome.credentialLabel) {
+            setActiveCredentialLabel(event.outcome.credentialLabel);
+          }
           const assistantMsg: ChatMessage = {
             id: `assistant-${Date.now()}`,
             role: "assistant",


### PR DESCRIPTION
Replaces the cost display pill with a credential identity pill that shows which account is handling requests.

## Full Stack Changes

### Backend
- **`AnthropicProvider`** — new `label` property, set from credential file
- **`TurnResult` / `TurnOutcome`** — new `credentialLabel` field threaded through
- **`ProviderRouter`** — reads `label` from credential file, passes to providers
- **Execute stage** — captures `credentialLabel` from stream result, includes in outcome
- **`/api/system/credentials`** — new endpoint returning credential labels (no secrets)

### Frontend
- **`credentials.svelte.ts`** — reactive store tracking active credential from turn_complete events
- **TopBar** — cost pill removed, replaced with credential pill
  - Shows current credential label (e.g. "primary", "backup", "max", "api")
  - Turns amber when failover to backup is active
  - Tooltip shows context

### Credential File Format
```json
{
  "label": "primary",
  "token": "...",
  "backupCredentials": [
    { "type": "oauth", "label": "backup", "token": "..." }
  ]
}
```

Labels are freeform — works for any naming scheme (primary/backup, max/api, work-max/personal, etc).