### PR TITLE
feat(tui): complete Phase 2-3

### DIFF
--- a/docs/specs/28_tui.md
+++ b/docs/specs/28_tui.md
@@ -1,7 +1,7 @@
 # Spec 28 — Aletheia TUI
 
-**Status:** Phase 1 — Complete ✅  
-**Component:** `tui/` — Rust terminal client (4,431 LOC as of 2026-02-23)  
+**Status:** Phase 2 — Complete ✅ (Phase 3 substantially complete)  
+**Component:** `tui/` — Rust terminal client (4,853 LOC as of 2026-02-23)  
 **Interface:** Primary working interface alongside Signal (mobile)  
 **Gateway dependency:** Hono REST API + SSE on `:18789` — zero gateway changes  
 **Design target:** Level 2 dashboard — multi-agent visibility with split panes  
@@ -1024,7 +1024,7 @@ tui/
 - [x] Exponential backoff reconnect (1s → 30s max, reset on successful connection)
 - [x] On `turn:after` for focused agent → reload history automatically
 
-### Phase 2: Rich Rendering + Overlays (~75% complete)
+### Phase 2: Rich Rendering + Overlays ✅ Complete
 
 **Milestone:** Code highlighting, thinking blocks, tables, all modal overlays, compose mode.
 
@@ -1034,34 +1034,34 @@ tui/
 - [x] `view/overlay.rs`: Modal overlay system (centered floating block over main view)
 - [x] Agent picker overlay (`Ctrl+A`)
 - [x] Help overlay (`F1`) — Navigation, Input, Scroll, During Turns sections
-- [ ] Token summary overlay (`F2`) — nice-to-have, not priority
-- [ ] System status overlay (`Ctrl+I`)
-- [ ] Fuzzy filtering in overlays (`/` to search, arrow keys to navigate)
+- [ ] Token summary overlay (`F2`) — deferred, nice-to-have
+- [x] System status overlay (`Ctrl+I`) — connection, agents, sessions, cost
+- [ ] Fuzzy filtering in overlays (`/` to search) — deferred
 - [x] `clipboard.rs`: Copy last response (`Ctrl+Y`) — arboard native with OSC52 fallback
 - [x] `Ctrl+E` compose mode: suspend TUI, spawn `$EDITOR`, send on save+quit
-- [ ] New session / topic boundary (`Ctrl+N`)
+- [x] New session / topic boundary (`Ctrl+N`)
 - [x] Tool approval overlay: render on `tool_approval_required`, A/D to approve/deny
 - [x] Plan approval overlay: render on `plan_proposed`, toggle steps, approve/cancel
-- [ ] Plan execution progress: persistent mini-widget during plan execution
-- [ ] OSC 8 hyperlinks for URLs
-- [ ] `markdown.rs`: Links as OSC 8 clickable hyperlinks
+- [ ] Plan execution progress: persistent mini-widget — deferred
+- [ ] OSC 8 hyperlinks for URLs — deferred
+- [ ] `markdown.rs`: Links as OSC 8 clickable hyperlinks — deferred
 
-### Phase 3: Polish + Production Hardening (3-4 days)
+### Phase 3: Polish + Production Hardening ✅ Substantially Complete
 
 **Milestone:** Daily-driver quality. Handles every edge case gracefully.
 
-- [ ] Reconnection resilience: network drops, gateway restarts, laptop sleep/wake
-- [ ] State recovery on reconnect: reload history for stale agents, restore streaming state
-- [ ] `@agent` mention completion in input (Tab to cycle)
+- [x] Reconnection resilience: SSE reconnect triggers full agent state reload + history refresh
+- [x] State recovery on reconnect: reload agents, preserve notifications, refresh focused session
+- [x] `@agent` mention completion in input (Tab to cycle through matching agents)
 - [x] Mouse support: scroll wheel in chat
-- [ ] Mouse support: click agent in sidebar to switch
-- [ ] Error display: inline toast with auto-dismiss after 5s, persistent errors in status bar
-- [ ] Responsive layout: graceful degradation for small terminals (hide sidebar < 60 cols)
+- [x] Mouse support: click agent in sidebar to switch (via static SIDEBAR_RECT tracking)
+- [x] Error display: inline toast bar at bottom with 5-second auto-dismiss
+- [x] Responsive layout: sidebar auto-hides below 60 columns
 - [x] Tracing to file via tracing-appender
-- [ ] Log rotation configuration
-- [ ] `aletheia logout` subcommand
+- [ ] Log rotation configuration — tracing-appender handles daily rotation already
+- [x] `aletheia logout` subcommand (via `--logout` CLI flag)
 - [ ] Comprehensive tests: state transitions, markdown rendering snapshots, API type round-trips
-- [ ] README with screenshots and install instructions
+- [x] README with keybindings, install instructions, architecture, terminal support matrix
 
 ---
 

--- a/tui/README.md
+++ b/tui/README.md
@@ -1,49 +1,138 @@
 # Aletheia TUI
 
-Terminal interface for Aletheia, built with Rust/Ratatui.
+Terminal dashboard for [Aletheia](https://github.com/forkwright/aletheia) — a multi-agent orchestration system.
 
-## Setup
+The TUI is the primary working interface alongside Signal (mobile). It connects to the Aletheia gateway over HTTP/SSE and provides a real-time multi-agent dashboard.
 
-The TUI connects to a running Aletheia gateway. Start the gateway first:
+## Features
+
+- **Multi-agent dashboard** — see all agents' status (idle/working/streaming/compacting) simultaneously
+- **Real-time SSE streaming** — live tool calls, thinking blocks, markdown rendering
+- **Syntax-highlighted code blocks** — via syntect (base16-ocean.dark)
+- **Markdown rendering** — bold, italic, code, headings, lists, tables, blockquotes, rules
+- **Tool approval/denial** — inline overlay when a tool requires human approval
+- **Plan approval** — toggle individual steps, approve or cancel proposed plans
+- **Message queuing** — send messages while an agent is mid-turn (yellow "queued ›" prompt)
+- **@mention completion** — type `@` then Tab to cycle through agent names
+- **Clipboard** — `Ctrl+Y` copies last response (native + OSC52 fallback for SSH)
+- **Compose mode** — `Ctrl+E` opens `$EDITOR` for multi-line input
+- **Mouse support** — scroll wheel in chat, click agents in sidebar
+- **Responsive** — sidebar auto-hides below 60 columns
+- **Theme system** — true color (24-bit), 256-color, and 16-color ANSI with auto-detection
+- **Reconnection resilience** — exponential backoff SSE reconnect with state recovery
+- **Error toasts** — transient error display with 5-second auto-dismiss
+
+## Requirements
+
+- Rust 1.85+ (edition 2024)
+- A running Aletheia gateway (default: `http://localhost:18789`)
+
+## Install
 
 ```bash
-cd ..
-./setup.sh        # first run: builds everything, starts gateway
-# or manually:
-ALETHEIA_ROOT=$(pwd) node infrastructure/runtime/dist/entry.mjs
-```
+# From the repository root
+cd tui
+cargo install --path .
 
-## Build
-
-```bash
+# Or build without installing
 cargo build --release
+# Binary at tui/target/release/aletheia-tui
 ```
-
-## Run
-
-```bash
-./target/release/aletheia-tui
-# or during development:
-cargo run
-```
-
-Configuration is read from `~/.aletheia/aletheia.json`. The TUI connects to the gateway URL defined in that file (default `http://localhost:18789`).
 
 ## Configuration
 
-The TUI respects the same `ALETHEIA_CONFIG_DIR` environment variable as the gateway:
+Config file: `~/.config/aletheia/tui.toml`
 
-```bash
-ALETHEIA_CONFIG_DIR=~/.aletheia cargo run
+```toml
+url = "http://localhost:18789"
+token = "your-bearer-token"
+default_agent = "syn"
 ```
 
-## Credential setup
-
-Credentials are shared with the gateway — if you've run `./setup.sh` and completed the web wizard, the TUI will work automatically. To set up credentials manually:
+All values can be overridden via CLI flags or environment variables:
 
 ```bash
-# Create the credentials directory and file:
-mkdir -p ~/.aletheia/credentials
-echo '{"apiKey": "sk-ant-..."}' > ~/.aletheia/credentials/anthropic.json
-chmod 600 ~/.aletheia/credentials/anthropic.json
+aletheia-tui --url http://host:18789 --token $ALETHEIA_TOKEN --agent syn
 ```
+
+Environment variables: `ALETHEIA_URL`, `ALETHEIA_TOKEN`
+
+## Keybindings
+
+### Navigation
+| Key | Action |
+|-----|--------|
+| `Ctrl+A` | Switch agent (overlay) |
+| `Ctrl+F` | Toggle sidebar |
+| `Ctrl+T` | Toggle thinking blocks |
+| `Ctrl+I` | System status overlay |
+| `Ctrl+N` | New session / topic |
+| `F1` | Help overlay |
+
+### Input
+| Key | Action |
+|-----|--------|
+| `Enter` | Send message |
+| `@agent Tab` | Mention completion |
+| `Ctrl+E` | Open $EDITOR |
+| `Ctrl+Y` | Copy last response |
+| `Ctrl+U` | Clear input |
+| `Ctrl+W` | Delete word |
+| `Up/Down` | Input history |
+
+### Scroll
+| Key | Action |
+|-----|--------|
+| `Shift+Up/Down` | Scroll line |
+| `PgUp/PgDn` | Scroll page |
+| `Mouse wheel` | Scroll chat |
+| `Click sidebar` | Switch agent |
+
+### During Turns
+| Key | Action |
+|-----|--------|
+| `A` | Approve tool/plan |
+| `D` | Deny tool call |
+| `Space` | Toggle plan step |
+
+### General
+| Key | Action |
+|-----|--------|
+| `Ctrl+C` / `Ctrl+Q` | Quit |
+| `Esc` | Close overlay |
+
+## Architecture
+
+Built on the [Elm Architecture](https://guide.elm-lang.org/architecture/) (TEA):
+
+- **Model** — `App` struct holds all state
+- **Message** — `Msg` enum for every possible event
+- **Update** — `async fn update(&mut self, msg: Msg)` — state transitions
+- **View** — `fn view(&self, frame: &mut Frame)` — pure rendering
+
+Three multiplexed event sources via `tokio::select!`:
+1. Terminal events (crossterm `EventStream`)
+2. SSE global stream (agent status, turns, tools, distillation)
+3. Tick timer (30fps for animations)
+
+## Terminal Support
+
+| Terminal | Color | Clipboard |
+|----------|-------|-----------|
+| GNOME Terminal | True color | OSC52 |
+| iTerm2 | True color | Native + OSC52 |
+| Kitty | True color | OSC52 |
+| WezTerm | True color | OSC52 |
+| Alacritty | True color | OSC52 |
+| Ghostty | True color | OSC52 |
+| Terminal.app | 256 color | Native |
+| tmux | 256+ color | OSC52 passthrough |
+| SSH | Depends on client | OSC52 |
+
+## Logging
+
+Logs to `~/.local/share/aletheia/tui.log` (daily rotation). Set `RUST_LOG=debug` for verbose output.
+
+## License
+
+Same as Aletheia — AGPL-3.0 (infrastructure) / Apache-2.0 (templates and tools).

--- a/tui/src/api/client.rs
+++ b/tui/src/api/client.rs
@@ -140,6 +140,22 @@ impl ApiClient {
         Ok(wrapper.messages)
     }
 
+    pub async fn create_session(&self, nous_id: &str, session_key: &str) -> Result<Session> {
+        let resp = self
+            .request(reqwest::Method::POST, "/api/sessions")
+            .json(&serde_json::json!({
+                "nousId": nous_id,
+                "sessionKey": session_key,
+            }))
+            .send()
+            .await
+            .context("failed to create session")?;
+        Self::check_auth(&resp)?;
+        resp.error_for_status_ref()
+            .context("create session request failed")?;
+        Ok(resp.json().await?)
+    }
+
     pub async fn archive_session(&self, session_id: &str) -> Result<()> {
         self.request(
             reqwest::Method::POST,

--- a/tui/src/app.rs
+++ b/tui/src/app.rs
@@ -1,7 +1,9 @@
 use std::collections::HashMap;
 
 use anyhow::Result;
-use crossterm::event::{Event as TermEvent, KeyCode, KeyEvent, KeyModifiers, MouseEventKind};
+use crossterm::event::{
+    Event as TermEvent, KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEventKind,
+};
 use ratatui::Frame;
 use tokio::sync::mpsc;
 
@@ -11,7 +13,7 @@ use crate::api::streaming;
 use crate::api::types::*;
 use crate::config::Config;
 use crate::events::{Event, StreamEvent};
-use crate::msg::{Msg, OverlayKind};
+use crate::msg::{ErrorToast, Msg, OverlayKind};
 use crate::theme::ThemePalette;
 use crate::view;
 
@@ -164,6 +166,24 @@ pub struct App {
 
     // Tick counter for spinner animation
     pub tick_count: u64,
+
+    // Error toast (auto-dismiss after 5s)
+    pub error_toast: Option<ErrorToast>,
+
+    // @mention tab completion state
+    pub tab_completion: Option<TabCompletion>,
+
+    // Terminal size for responsive layout
+    pub terminal_width: u16,
+    pub terminal_height: u16,
+}
+
+#[derive(Debug)]
+pub struct TabCompletion {
+    pub prefix: String,
+    pub candidates: Vec<String>,
+    pub index: usize,
+    pub insert_start: usize,
 }
 
 impl App {
@@ -201,6 +221,10 @@ impl App {
             cached_markdown_text: String::new(),
             cached_markdown_lines: Vec::new(),
             tick_count: 0,
+            error_toast: None,
+            tab_completion: None,
+            terminal_width: 120,
+            terminal_height: 40,
         };
 
         // Connect and authenticate
@@ -419,6 +443,31 @@ impl App {
             TermEvent::Mouse(mouse) => match mouse.kind {
                 MouseEventKind::ScrollUp => Some(Msg::ScrollUp),
                 MouseEventKind::ScrollDown => Some(Msg::ScrollDown),
+                MouseEventKind::Down(MouseButton::Left) => {
+                    // Check if click is in sidebar area
+                    let sidebar = crate::view::SIDEBAR_RECT.load_rect();
+                    if sidebar.width > 0
+                        && mouse.column < sidebar.x + sidebar.width
+                        && mouse.row >= sidebar.y
+                    {
+                        // Each agent takes 1-2 rows, starting after 1 row padding
+                        let mut y = sidebar.y + 1;
+                        for agent in &self.agents {
+                            let row_count = if agent.active_tool.is_some()
+                                || agent.compaction_stage.is_some()
+                            {
+                                2u16
+                            } else {
+                                1
+                            };
+                            if mouse.row >= y && mouse.row < y + row_count {
+                                return Some(Msg::FocusAgent(agent.id.clone()));
+                            }
+                            y += row_count;
+                        }
+                    }
+                    None
+                }
                 _ => None,
             },
             TermEvent::Resize(w, h) => Some(Msg::Resize(w, h)),
@@ -445,6 +494,19 @@ impl App {
             (_, KeyCode::F(1)) => Some(Msg::OpenOverlay(OverlayKind::Help)),
             (KeyModifiers::CONTROL, KeyCode::Char('a')) => {
                 Some(Msg::OpenOverlay(OverlayKind::AgentPicker))
+            }
+            (KeyModifiers::CONTROL, KeyCode::Char('i')) => {
+                Some(Msg::OpenOverlay(OverlayKind::SystemStatus))
+            }
+            (KeyModifiers::CONTROL, KeyCode::Char('n')) => Some(Msg::NewSession),
+
+            // Tab completion for @mentions
+            (_, KeyCode::Tab) => {
+                if self.input.text.contains('@') {
+                    Some(Msg::CharInput('\t')) // Signal tab-complete via special char
+                } else {
+                    None
+                }
             }
 
             // Scroll
@@ -641,9 +703,16 @@ impl App {
         match msg {
             // --- Input ---
             Msg::CharInput(c) => {
-                self.input.text.insert(self.input.cursor, c);
-                self.input.cursor += c.len_utf8();
-                self.input.history_index = None;
+                if c == '\t' {
+                    // Tab completion for @mentions
+                    self.handle_tab_completion();
+                } else {
+                    // Clear tab completion state on any other input
+                    self.tab_completion = None;
+                    self.input.text.insert(self.input.cursor, c);
+                    self.input.cursor += c.len_utf8();
+                    self.input.history_index = None;
+                }
             }
             Msg::Backspace => {
                 if self.input.cursor > 0 {
@@ -856,7 +925,10 @@ impl App {
                 }
                 self.overlay = None;
             }
-            Msg::Resize(_, _) => {} // ratatui handles this
+            Msg::Resize(w, h) => {
+                self.terminal_width = w;
+                self.terminal_height = h;
+            }
 
             // --- Overlay interaction ---
             Msg::OverlayUp => match &mut self.overlay {
@@ -924,7 +996,41 @@ impl App {
 
             // --- SSE ---
             Msg::SseConnected => {
+                let was_disconnected = !self.sse_connected;
                 self.sse_connected = true;
+
+                // On reconnect, reload agent state to sync any missed events
+                if was_disconnected {
+                    tracing::info!("SSE reconnected — reloading agent state");
+                    if let Ok(agents) = self.client.agents().await {
+                        // Preserve notification state across reload
+                        let notifications: HashMap<String, bool> = self
+                            .agents
+                            .iter()
+                            .map(|a| (a.id.clone(), a.has_notification))
+                            .collect();
+
+                        self.agents = agents
+                            .into_iter()
+                            .map(|a| {
+                                let notif = notifications.get(&a.id).copied().unwrap_or(false);
+                                AgentState {
+                                    id: a.id,
+                                    name: a.name,
+                                    emoji: a.emoji,
+                                    status: AgentStatus::Idle,
+                                    active_tool: None,
+                                    tool_started_at: None,
+                                    sessions: Vec::new(),
+                                    compaction_stage: None,
+                                    has_notification: notif,
+                                }
+                            })
+                            .collect();
+                    }
+                    // Reload focused session history
+                    self.load_focused_session().await;
+                }
             }
             Msg::SseDisconnected => {
                 self.sse_connected = false;
@@ -1180,6 +1286,7 @@ impl App {
             }
             Msg::StreamError(msg) => {
                 tracing::error!("stream error: {msg}");
+                self.error_toast = Some(ErrorToast::new(msg));
                 self.active_turn_id = None;
                 self.stream_rx = None;
             }
@@ -1231,12 +1338,52 @@ impl App {
             }
             Msg::AuthResult(_) | Msg::ApiError(_) => {}
 
+            // --- New session ---
+            Msg::NewSession => {
+                if let Some(ref agent_id) = self.focused_agent.clone() {
+                    // Create a visual separator in messages
+                    self.messages.clear();
+                    self.scroll_to_bottom();
+
+                    // Create new session via API
+                    let session_key = format!("tui-{}", chrono_compact_now());
+                    let client = self.client.clone();
+                    let agent_id = agent_id.clone();
+                    let key = session_key.clone();
+                    match client.create_session(&agent_id, &key).await {
+                        Ok(session) => {
+                            self.focused_session_id = Some(session.id.clone());
+                            if let Some(agent) = self.agents.iter_mut().find(|a| a.id == agent_id) {
+                                agent.sessions.push(session);
+                            }
+                        }
+                        Err(e) => {
+                            tracing::error!("failed to create session: {e}");
+                            self.error_toast =
+                                Some(ErrorToast::new(format!("New session failed: {e}")));
+                        }
+                    }
+                }
+            }
+
+            // --- Error toasts ---
+            Msg::ShowError(msg) => {
+                self.error_toast = Some(ErrorToast::new(msg));
+            }
+            Msg::DismissError => {
+                self.error_toast = None;
+            }
+
             // --- Quit ---
             Msg::Quit => self.should_quit = true,
 
             // --- Tick ---
             Msg::Tick => {
                 self.tick_count = self.tick_count.wrapping_add(1);
+                // Auto-dismiss expired error toasts
+                if self.error_toast.as_ref().is_some_and(|t| t.is_expired()) {
+                    self.error_toast = None;
+                }
             }
         }
     }
@@ -1302,6 +1449,55 @@ impl App {
         self.stream_rx = Some(rx);
     }
 
+    fn handle_tab_completion(&mut self) {
+        // Find the @mention prefix before cursor
+        let text_before_cursor = &self.input.text[..self.input.cursor];
+        if let Some(at_pos) = text_before_cursor.rfind('@') {
+            let prefix = &text_before_cursor[at_pos + 1..];
+
+            if let Some(ref mut tc) = self.tab_completion {
+                // Already completing — cycle to next candidate
+                if tc.prefix == prefix || (!tc.candidates.is_empty() && tc.insert_start == at_pos) {
+                    tc.index = (tc.index + 1) % tc.candidates.len();
+                    let candidate = &tc.candidates[tc.index];
+
+                    // Replace from @ to cursor with @candidate
+                    self.input
+                        .text
+                        .replace_range(at_pos..self.input.cursor, &format!("@{} ", candidate));
+                    self.input.cursor = at_pos + 1 + candidate.len() + 1;
+                    return;
+                }
+            }
+
+            // Build candidate list from agent names
+            let candidates: Vec<String> = self
+                .agents
+                .iter()
+                .filter(|a| {
+                    a.id.starts_with(prefix)
+                        || a.name.to_lowercase().starts_with(&prefix.to_lowercase())
+                })
+                .map(|a| a.id.clone())
+                .collect();
+
+            if !candidates.is_empty() {
+                let first = candidates[0].clone();
+                self.tab_completion = Some(TabCompletion {
+                    prefix: prefix.to_string(),
+                    candidates,
+                    index: 0,
+                    insert_start: at_pos,
+                });
+                // Replace prefix with first match
+                self.input
+                    .text
+                    .replace_range(at_pos..self.input.cursor, &format!("@{} ", first));
+                self.input.cursor = at_pos + 1 + first.len() + 1;
+            }
+        }
+    }
+
     fn scroll_to_bottom(&mut self) {
         self.scroll_offset = 0;
         self.auto_scroll = true;
@@ -1351,6 +1547,16 @@ impl App {
     pub fn view(&self, frame: &mut Frame) {
         view::render(self, frame);
     }
+}
+
+/// Generate a compact timestamp for session key names (no external dep).
+fn chrono_compact_now() -> String {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let secs = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    format!("{:x}", secs)
 }
 
 /// Extract only text content from a JSON array of Anthropic content blocks.

--- a/tui/src/msg.rs
+++ b/tui/src/msg.rs
@@ -21,6 +21,8 @@ pub enum Msg {
     ComposeInEditor,  // Ctrl+E — open $EDITOR for multi-line compose
     Quit,             // Ctrl+C or Ctrl+Q
 
+    NewSession, // Ctrl+N — start new topic
+
     // --- Navigation ---
     ScrollUp,
     ScrollDown,
@@ -162,6 +164,10 @@ pub enum Msg {
     AuthResult(AuthOutcome),
     ApiError(String),
 
+    // --- Errors / toasts ---
+    ShowError(String),
+    DismissError,
+
     // --- Timer ---
     Tick,
 }
@@ -171,6 +177,27 @@ pub enum OverlayKind {
     Help,
     AgentPicker,
     SystemStatus,
+}
+
+/// Transient error toast that auto-dismisses.
+#[derive(Debug, Clone)]
+pub struct ErrorToast {
+    pub message: String,
+    pub created_at: std::time::Instant,
+}
+
+impl ErrorToast {
+    pub fn new(message: String) -> Self {
+        Self {
+            message,
+            created_at: std::time::Instant::now(),
+        }
+    }
+
+    /// Returns true if this toast has been visible long enough (5s).
+    pub fn is_expired(&self) -> bool {
+        self.created_at.elapsed() > std::time::Duration::from_secs(5)
+    }
 }
 
 #[derive(Debug)]

--- a/tui/src/view/mod.rs
+++ b/tui/src/view/mod.rs
@@ -14,21 +14,47 @@ pub fn render(app: &App, frame: &mut Frame) {
     let area = frame.area();
     let theme = &app.theme;
 
-    // Top-level vertical split: title bar | body | status bar
+    // Top-level vertical split: title bar | body | status bar | (optional toast)
+    let has_toast = app.error_toast.is_some();
     let vertical = Layout::default()
         .direction(Direction::Vertical)
-        .constraints([
-            Constraint::Length(1), // title bar
-            Constraint::Min(5),    // body
-            Constraint::Length(1), // status bar
-        ])
+        .constraints(if has_toast {
+            vec![
+                Constraint::Length(1), // title bar
+                Constraint::Min(5),    // body
+                Constraint::Length(1), // status bar
+                Constraint::Length(1), // error toast
+            ]
+        } else {
+            vec![
+                Constraint::Length(1), // title bar
+                Constraint::Min(5),    // body
+                Constraint::Length(1), // status bar
+            ]
+        })
         .split(area);
 
     title_bar::render(app, frame, vertical[0], theme);
     status_bar::render(app, frame, vertical[2], theme);
 
+    // Error toast at bottom
+    if has_toast {
+        if let Some(ref toast) = app.error_toast {
+            let toast_line = ratatui::text::Line::from(vec![
+                ratatui::text::Span::styled(" ✗ ", theme.style_error_bold()),
+                ratatui::text::Span::styled(&toast.message, theme.style_error()),
+            ]);
+            let toast_widget = ratatui::widgets::Paragraph::new(toast_line)
+                .style(ratatui::style::Style::default().bg(theme.surface_dim));
+            frame.render_widget(toast_widget, vertical[3]);
+        }
+    }
+
+    // Responsive: hide sidebar on narrow terminals (< 60 cols)
+    let show_sidebar = app.sidebar_visible && area.width >= 60;
+
     // Body: sidebar | chat area
-    if app.sidebar_visible {
+    if show_sidebar {
         let horizontal = Layout::default()
             .direction(Direction::Horizontal)
             .constraints([
@@ -39,7 +65,13 @@ pub fn render(app: &App, frame: &mut Frame) {
 
         sidebar::render(app, frame, horizontal[0], theme);
         render_chat_area(app, frame, horizontal[1], theme);
+
+        // Store sidebar area for mouse click detection (mutable through interior pattern)
+        // We can't mutate app here since view takes &self, so store in a separate mechanism
+        // Actually we'll update sidebar_area before render in the event loop
+        SIDEBAR_RECT.store_rect(horizontal[0]);
     } else {
+        SIDEBAR_RECT.store_rect(Rect::ZERO);
         render_chat_area(app, frame, vertical[1], theme);
     }
 
@@ -48,6 +80,46 @@ pub fn render(app: &App, frame: &mut Frame) {
         overlay::render(app, frame, area, theme);
     }
 }
+
+/// Thread-safe sidebar rect storage for mouse click detection.
+/// Updated each frame by render(), read by App::map_terminal().
+pub struct SidebarRect {
+    x: std::sync::atomic::AtomicU16,
+    y: std::sync::atomic::AtomicU16,
+    w: std::sync::atomic::AtomicU16,
+    h: std::sync::atomic::AtomicU16,
+}
+
+impl SidebarRect {
+    const fn new() -> Self {
+        Self {
+            x: std::sync::atomic::AtomicU16::new(0),
+            y: std::sync::atomic::AtomicU16::new(0),
+            w: std::sync::atomic::AtomicU16::new(0),
+            h: std::sync::atomic::AtomicU16::new(0),
+        }
+    }
+
+    fn store_rect(&self, r: Rect) {
+        use std::sync::atomic::Ordering::Relaxed;
+        self.x.store(r.x, Relaxed);
+        self.y.store(r.y, Relaxed);
+        self.w.store(r.width, Relaxed);
+        self.h.store(r.height, Relaxed);
+    }
+
+    pub fn load_rect(&self) -> Rect {
+        use std::sync::atomic::Ordering::Relaxed;
+        Rect::new(
+            self.x.load(Relaxed),
+            self.y.load(Relaxed),
+            self.w.load(Relaxed),
+            self.h.load(Relaxed),
+        )
+    }
+}
+
+pub static SIDEBAR_RECT: SidebarRect = SidebarRect::new();
 
 fn render_chat_area(app: &App, frame: &mut Frame, area: Rect, theme: &crate::theme::ThemePalette) {
     // Dynamically size input area based on text length (wrapping)

--- a/tui/src/view/overlay.rs
+++ b/tui/src/view/overlay.rs
@@ -5,7 +5,7 @@ use ratatui::symbols;
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Clear, Paragraph, Wrap};
 
-use crate::app::{App, Overlay};
+use crate::app::{AgentStatus, App, Overlay};
 use crate::theme::ThemePalette;
 
 pub fn render(app: &App, frame: &mut Frame, area: Rect, theme: &ThemePalette) {
@@ -26,10 +26,7 @@ pub fn render(app: &App, frame: &mut Frame, area: Rect, theme: &ThemePalette) {
         }
         Overlay::ToolApproval(approval) => render_tool_approval(frame, popup_area, approval, theme),
         Overlay::PlanApproval(plan) => render_plan_approval(frame, popup_area, plan, theme),
-        _ => {
-            let block = overlay_block(" TODO ", theme);
-            frame.render_widget(block, popup_area);
-        }
+        Overlay::SystemStatus => render_system_status(app, frame, popup_area, theme),
     }
 }
 
@@ -82,11 +79,19 @@ fn render_help(frame: &mut Frame, area: Rect, theme: &ThemePalette) {
             key_style,
             desc_style,
         ),
+        help_line("  Ctrl+I     ", "System status", key_style, desc_style),
+        help_line(
+            "  Ctrl+N     ",
+            "New session / topic",
+            key_style,
+            desc_style,
+        ),
         help_line("  F1         ", "This help screen", key_style, desc_style),
         Line::raw(""),
         Line::from(Span::styled("  Input", section_style)),
         Line::raw(""),
         help_line("  Enter      ", "Send message", key_style, desc_style),
+        help_line("  @agent Tab ", "Mention completion", key_style, desc_style),
         help_line("  Ctrl+U     ", "Clear input line", key_style, desc_style),
         help_line("  Ctrl+W     ", "Delete word", key_style, desc_style),
         help_line(
@@ -104,6 +109,12 @@ fn render_help(frame: &mut Frame, area: Rect, theme: &ThemePalette) {
         help_line("  Shift+Down ", "Scroll down", key_style, desc_style),
         help_line("  PgUp/PgDn  ", "Page scroll", key_style, desc_style),
         help_line("  End        ", "Scroll to bottom", key_style, desc_style),
+        help_line(
+            "  Mouse      ",
+            "Scroll / click agent",
+            key_style,
+            desc_style,
+        ),
         Line::raw(""),
         Line::from(Span::styled("  During Turns", section_style)),
         Line::raw(""),
@@ -317,6 +328,96 @@ fn render_plan_approval(
 
     let block = overlay_block_accent(&title, theme.accent, theme);
     let paragraph = Paragraph::new(lines).block(block);
+    frame.render_widget(paragraph, area);
+}
+
+fn render_system_status(app: &App, frame: &mut Frame, area: Rect, theme: &ThemePalette) {
+    let mut lines = vec![Line::raw("")];
+    let section_style = Style::default().fg(theme.fg).add_modifier(Modifier::BOLD);
+
+    // Connection status
+    lines.push(Line::from(Span::styled("  Connection", section_style)));
+    lines.push(Line::raw(""));
+    let sse_status = if app.sse_connected {
+        Span::styled("  SSE: connected ●", Style::default().fg(theme.success))
+    } else {
+        Span::styled("  SSE: disconnected ○", Style::default().fg(theme.error))
+    };
+    lines.push(Line::from(sse_status));
+    lines.push(Line::from(Span::styled(
+        format!("  Gateway: {}", app.config.url),
+        theme.style_muted(),
+    )));
+    lines.push(Line::from(Span::styled(
+        format!("  Terminal: {}×{}", app.terminal_width, app.terminal_height),
+        theme.style_muted(),
+    )));
+    lines.push(Line::raw(""));
+
+    // Agents
+    lines.push(Line::from(Span::styled("  Agents", section_style)));
+    lines.push(Line::raw(""));
+
+    for agent in &app.agents {
+        let status_str = match agent.status {
+            AgentStatus::Idle => Span::styled("idle", theme.style_dim()),
+            AgentStatus::Working => Span::styled("working", Style::default().fg(theme.spinner)),
+            AgentStatus::Streaming => {
+                Span::styled("streaming", Style::default().fg(theme.streaming))
+            }
+            AgentStatus::Compacting => {
+                let stage = agent.compaction_stage.as_deref().unwrap_or("...");
+                Span::styled(
+                    format!("compacting ({})", stage),
+                    Style::default().fg(theme.compacting),
+                )
+            }
+        };
+
+        let emoji = agent.emoji.as_deref().unwrap_or("");
+        let session_count = agent.sessions.len();
+
+        lines.push(Line::from(vec![
+            Span::styled(
+                format!("  {} {} ", emoji, agent.name),
+                theme.style_accent_bold(),
+            ),
+            Span::styled(format!("({}) ", agent.id), theme.style_dim()),
+            status_str,
+        ]));
+        lines.push(Line::from(Span::styled(
+            format!("     {} sessions", session_count),
+            theme.style_dim(),
+        )));
+    }
+
+    lines.push(Line::raw(""));
+
+    // Cost
+    let cost = app.daily_cost_cents as f64 / 100.0;
+    lines.push(Line::from(Span::styled("  Today", section_style)));
+    lines.push(Line::raw(""));
+    lines.push(Line::from(Span::styled(
+        format!("  Cost: ${:.2}", cost),
+        theme.style_muted(),
+    )));
+
+    lines.push(Line::raw(""));
+    lines.push(Line::from(vec![
+        Span::raw("  "),
+        Span::styled(
+            "Esc",
+            Style::default()
+                .fg(theme.fg_dim)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(" close", theme.style_muted()),
+    ]));
+
+    let block = overlay_block("System Status — Ctrl+I", theme);
+    let paragraph = Paragraph::new(lines)
+        .block(block)
+        .wrap(Wrap { trim: false });
     frame.render_widget(paragraph, area);
 }
 

--- a/tui/src/view/status_bar.rs
+++ b/tui/src/view/status_bar.rs
@@ -58,7 +58,7 @@ pub fn render(app: &App, frame: &mut Frame, area: Rect, theme: &ThemePalette) {
     }
 
     // Right-align keybinding hints
-    let hints = "^A agents │ ^F sidebar │ ^Q quit";
+    let hints = "^A agents │ ^I status │ ^N new │ ^Q quit";
     let used_width: usize = spans.iter().map(|s| s.content.len()).sum();
     let remaining = area.width as usize - used_width.min(area.width as usize);
     if remaining > hints.len() + 2 {


### PR DESCRIPTION
Finishes the TUI spec (28). Phase 2 complete, Phase 3 substantially complete.

## Phase 2 Additions
- **System status overlay** (`Ctrl+I`) — shows SSE connection, gateway URL, terminal size, per-agent status/sessions, daily cost
- **New session** (`Ctrl+N`) — creates fresh topic via `POST /api/sessions`, clears chat
- **Help overlay** updated with all new keybindings (`Ctrl+I`, `Ctrl+N`, `@agent Tab`, mouse click)

## Phase 3 Additions
- **Mouse click in sidebar** — click an agent name to switch focus. Uses static atomic `SIDEBAR_RECT` tracking (updated each frame by view, read by event mapper)
- **`@agent` Tab completion** — type `@` then Tab to cycle through matching agent IDs. Subsequent Tabs cycle candidates.
- **Reconnection resilience** — when SSE reconnects after disconnect, reloads full agent list (preserving notification state) and refreshes focused session history
- **Error toasts** — transient error bar at bottom of screen, auto-dismisses after 5 seconds. Stream errors and failed API calls surface here.
- **Responsive layout** — sidebar auto-hides when terminal width < 60 columns
- **`create_session`** API client method for `Ctrl+N`

## Also
- Comprehensive README: keybindings table, install instructions, architecture overview, terminal support matrix
- Spec 28 updated: Phase 2 ✅, Phase 3 ✅ (substantially)
- 4,853 LOC across 18 source files

## Remaining (deferred)
- Token summary overlay (`F2`) — nice-to-have
- Fuzzy filtering in overlays — nice-to-have  
- OSC 8 hyperlinks — nice-to-have
- Plan execution progress widget — low frequency use
- Comprehensive test suite — ongoing