### PR TITLE
fix: prevent cross-agent chat contamination on notifications

### DIFF
--- a/ui/src/components/shared/Toast.svelte
+++ b/ui/src/components/shared/Toast.svelte
@@ -3,37 +3,33 @@
   import { setActiveAgent } from "../../stores/agents.svelte";
   import { loadSessions } from "../../stores/sessions.svelte";
 
-  function handleClick(agentId?: string, toastId?: string) {
-    if (agentId) {
-      setActiveAgent(agentId);
-      loadSessions(agentId);
-    }
-    if (toastId) dismissToast(toastId);
+  function handleNavigate(agentId: string, toastId: string) {
+    setActiveAgent(agentId);
+    loadSessions(agentId);
+    dismissToast(toastId);
   }
 </script>
 
 {#if getToasts().length > 0}
   <div class="toast-container">
     {#each getToasts() as toast (toast.id)}
-      <div
-        class="toast"
-        role="button"
-        tabindex="0"
-        onclick={() => handleClick(toast.agentId, toast.id)}
-        onkeydown={(e: KeyboardEvent) => { if (e.key === "Enter") handleClick(toast.agentId, toast.id); }}
-      >
+      <div class="toast" role="status" aria-live="polite">
         <span class="toast-header">
           {#if toast.emoji}<span class="toast-emoji">{toast.emoji}</span>{/if}
           <span class="toast-agent">{toast.agentName}</span>
-          <span
+          <button
             class="toast-dismiss"
-            role="button"
-            tabindex="0"
             onclick={(e: MouseEvent) => { e.stopPropagation(); dismissToast(toast.id); }}
-            onkeydown={(e: KeyboardEvent) => { if (e.key === "Enter") { e.stopPropagation(); dismissToast(toast.id); } }}
-          >×</span>
+            aria-label="Dismiss notification"
+          >×</button>
         </span>
         <span class="toast-preview">{toast.preview}</span>
+        {#if toast.agentId}
+          <button
+            class="toast-action"
+            onclick={() => handleNavigate(toast.agentId!, toast.id)}
+          >View</button>
+        {/if}
       </div>
     {/each}
   </div>
@@ -42,13 +38,14 @@
 <style>
   .toast-container {
     position: fixed;
-    bottom: 16px;
+    bottom: 80px;
     right: 16px;
     display: flex;
     flex-direction: column;
     gap: 8px;
     z-index: 1000;
     max-width: 340px;
+    pointer-events: none;
   }
   .toast {
     display: flex;
@@ -63,11 +60,8 @@
     text-align: left;
     box-shadow: var(--shadow-md);
     animation: slide-in 0.2s ease-out;
-    cursor: pointer;
     width: 100%;
-  }
-  .toast:hover {
-    border-color: var(--accent);
+    pointer-events: auto;
   }
   .toast-header {
     display: flex;
@@ -84,9 +78,11 @@
   .toast-dismiss {
     color: var(--text-muted);
     font-size: var(--text-lg);
-    padding: 0 2px;
+    padding: 0 4px;
     line-height: 1;
     cursor: pointer;
+    background: none;
+    border: none;
   }
   .toast-dismiss:hover {
     color: var(--text);
@@ -98,8 +94,34 @@
     text-overflow: ellipsis;
     white-space: nowrap;
   }
+  .toast-action {
+    align-self: flex-end;
+    background: none;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    color: var(--accent);
+    font-size: var(--text-xs);
+    font-weight: 600;
+    padding: 3px 10px;
+    cursor: pointer;
+    margin-top: 2px;
+    transition: background var(--transition-quick), border-color var(--transition-quick);
+  }
+  .toast-action:hover {
+    background: var(--surface-hover);
+    border-color: var(--accent);
+  }
   @keyframes slide-in {
     from { transform: translateX(100%); opacity: 0; }
     to { transform: translateX(0); opacity: 1; }
+  }
+
+  @media (max-width: 768px) {
+    .toast-container {
+      bottom: 100px;
+      right: 8px;
+      left: 8px;
+      max-width: none;
+    }
   }
 </style>

--- a/ui/src/stores/sessions.svelte.ts
+++ b/ui/src/stores/sessions.svelte.ts
@@ -22,28 +22,43 @@ export function isSessionsLoading(): boolean {
   return loading;
 }
 
+/**
+ * Full session load — clears active selection and re-selects.
+ * Used on agent switch and initial load.
+ */
 export async function loadSessions(nousId: string): Promise<void> {
   const gen = ++loadGeneration;
   activeSessionId = null; // Clear immediately to prevent stale session reads during fetch
   loading = true;
   try {
-    const all = await fetchSessions(nousId);
+    const fetched = await fetchSessions(nousId);
     if (gen !== loadGeneration) return; // Stale — a newer loadSessions call superseded us
-    // Filter out background/system sessions
-    sessions = all.filter((s) =>
-      !s.sessionKey.startsWith("cron:") &&
-      !s.sessionKey.startsWith("agent:") &&
-      !s.sessionKey.startsWith("prosoche"),
-    );
-    // Auto-select: prefer the Signal session for continuity (shared with phone), then most recent
-    if (sessions.length > 0) {
-      const current = sessions.find((s) => s.id === activeSessionId);
-      if (!current) {
-        const signal = sessions.find((s) => s.sessionKey.startsWith("signal:") && s.nousId === nousId);
-        activeSessionId = signal?.id ?? sessions[0]!.id;
-      }
+    sessions = filterUserSessions(fetched);
+    autoSelect(nousId);
+  } finally {
+    if (gen === loadGeneration) loading = false;
+  }
+}
+
+/**
+ * Refresh session list without disrupting the active selection.
+ * Used after turn completion to pick up new sessions without switching.
+ * Preserves activeSessionId if it still exists in the refreshed list.
+ */
+export async function refreshSessions(nousId: string): Promise<void> {
+  const gen = ++loadGeneration;
+  const previousActiveId = activeSessionId; // Capture before async gap
+  loading = true;
+  try {
+    const fetched = await fetchSessions(nousId);
+    if (gen !== loadGeneration) return; // Stale — a newer call superseded us
+    sessions = filterUserSessions(fetched);
+    // Keep current selection if it's still in the list
+    if (previousActiveId && sessions.some((s) => s.id === previousActiveId)) {
+      activeSessionId = previousActiveId;
     } else {
-      activeSessionId = null;
+      // Current session gone (archived/deleted) — re-select
+      autoSelect(nousId);
     }
   } finally {
     if (gen === loadGeneration) loading = false;
@@ -68,6 +83,21 @@ export function createNewSession(_nousId: string): string {
   return key;
 }
 
-export function refreshSessions(nousId: string): void {
-  loadSessions(nousId);
+// --- Internal helpers ---
+
+function filterUserSessions(all: Session[]): Session[] {
+  return all.filter((s) =>
+    !s.sessionKey.startsWith("cron:") &&
+    !s.sessionKey.startsWith("agent:") &&
+    !s.sessionKey.startsWith("prosoche"),
+  );
+}
+
+function autoSelect(nousId: string): void {
+  if (sessions.length > 0) {
+    const signal = sessions.find((s) => s.sessionKey.startsWith("signal:") && s.nousId === nousId);
+    activeSessionId = signal?.id ?? sessions[0]!.id;
+  } else {
+    activeSessionId = null;
+  }
 }


### PR DESCRIPTION
## Problem

When viewing Agent A's chat and Agent B completes a turn, Agent B's chat content replaces Agent A's in the active tab. Refreshing fixes it.

## Root Causes

**1. Toast click-to-navigate** — The entire toast body was a clickable button that called `setActiveAgent(B) + loadSessions(B)`. On mobile especially, the toast (positioned at `bottom: 16px`) overlapped with the input area, making accidental taps likely. Even on desktop, clicking anywhere on the toast to dismiss navigated instead.

**2. `refreshSessions` nulled active session** — `refreshSessions()` was just an alias for `loadSessions()`, which unconditionally set `activeSessionId = null` before the async fetch. During the gap, Svelte $effects could fire on the null state. After the fetch, auto-select might pick a different session than what the user was viewing.

## Changes

### Toast (`Toast.svelte`)
- Removed full-body `onclick` handler — toast is no longer a button
- Added explicit **View** action button for intentional navigation
- Changed `role="button"` → `role="status"` with `aria-live="polite"`
- Moved container up (`bottom: 80px`) to clear the input bar
- Dismiss × is now a proper `<button>` element
- Added mobile responsive layout (full-width, higher position)
- Container uses `pointer-events: none` with toasts opting back in

### Sessions Store (`sessions.svelte.ts`)
- Split into two distinct functions:
  - **`loadSessions()`** — full reset, clears selection, auto-selects. Used on agent switch.
  - **`refreshSessions()`** — preserves `activeSessionId` across the async gap. Only re-selects if the current session was archived/deleted. Used after turn completion.
- Extracted `filterUserSessions()` and `autoSelect()` helpers

## Testing
- `npm run build` passes cleanly
- `svelte-check` shows 0 new errors (3 pre-existing unrelated)