### PR TITLE
fix(prosoche): remove stale AGENT_ID_MAP causing wake delivery failures

### DIFF
--- a/infrastructure/prosoche/prosoche/wake.py
+++ b/infrastructure/prosoche/prosoche/wake.py
@@ -11,10 +11,6 @@ from loguru import logger
 
 from .scoring import NousScore
 
-# Prosoche config uses "syn" but runtime config uses "main" for Syn (legacy)
-AGENT_ID_MAP = {"syn": "main"}
-
-
 def _signal_fingerprint(signals: list) -> str:
     """Create a hash of the urgent signal summaries to detect duplicates."""
     key = "|".join(sorted(s.summary for s in signals))
@@ -94,7 +90,7 @@ async def trigger_wake(score: NousScore, config: dict) -> bool:
         text_parts.append("Staged context available — check PROSOCHE.md for details.")
 
     event_text = "\n".join(text_parts)
-    agent_id = AGENT_ID_MAP.get(score.nous_id, score.nous_id)
+    agent_id = score.nous_id
 
     payload = json.dumps({
         "agentId": agent_id,


### PR DESCRIPTION
## Problem

Every prosoche wake delivery to Syn fails with HTTP 500:

```
ERROR [pipeline:resolve] Unknown nous: main
ERROR [pylon] Session send failed: Unknown nous: main
```

## Root Cause

`wake.py` had an `AGENT_ID_MAP` that mapped `syn → main`, based on a stale assumption that the runtime used `main` as Syn's agent ID. The runtime actually registers agents by their config IDs — `syn`, `akron`, `demiurge`, `syl` — so sending `agentId: 'main'` hits the unknown-nous error path.

## Fix

Removed `AGENT_ID_MAP` entirely. Agent IDs now pass through unchanged from the prosoche config (`score.nous_id`), which already uses the correct runtime IDs.

## Impact

Prosoche wake delivery to Syn will actually work now. The dedup mechanism was correctly preventing retry spam from this failure, but the underlying wake was never reaching the agent.