### PR TITLE
fix: credentials store, gitignore scope, credential-refresh path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,9 @@ projects/
 
 # === Secrets ===
 *.env
-**/credentials*
+**/credentials.json
+**/credentials.yaml
+**/credentials.yml
 !**/credentials.py
 **/secrets*
 **/*.key

--- a/shared/bin/credential-refresh
+++ b/shared/bin/credential-refresh
@@ -35,7 +35,7 @@ _config = {"threshold": 3600, "interval": 300}
 
 # Credential file locations
 ALETHEIA_CRED = Path.home() / ".aletheia" / "credentials" / "anthropic.json"
-CLAUDE_CODE_CRED = Path.home().parent / "ck" / ".claude" / ".credentials.json"
+CLAUDE_CODE_CRED = Path.home() / ".claude" / ".credentials.json"
 
 
 def log(msg: str, level: str = "INFO"):

--- a/ui/src/stores/credentials.svelte.ts
+++ b/ui/src/stores/credentials.svelte.ts
@@ -1,0 +1,44 @@
+// Credential config store — tracks active credential label and config for topbar pill
+import { getEffectiveToken } from "../lib/api";
+
+interface CredentialEntry {
+  label: string;
+  type: "oauth" | "api" | "unknown";
+}
+
+interface CredentialConfig {
+  primary: CredentialEntry;
+  backups: CredentialEntry[];
+}
+
+let credentialConfig = $state<CredentialConfig | null>(null);
+let activeCredentialLabel = $state<string>("");
+
+export function getCredentialConfig(): CredentialConfig | null {
+  return credentialConfig;
+}
+
+export function getActiveCredentialLabel(): string {
+  return activeCredentialLabel || credentialConfig?.primary.label || "";
+}
+
+export function setActiveCredentialLabel(label: string): void {
+  activeCredentialLabel = label;
+}
+
+export async function loadCredentialConfig(): Promise<void> {
+  try {
+    const token = getEffectiveToken();
+    const res = await fetch("/api/system/credentials", {
+      headers: token ? { Authorization: `Bearer ${token}` } : {},
+    });
+    if (res.ok) {
+      credentialConfig = await res.json() as CredentialConfig;
+      if (!activeCredentialLabel) {
+        activeCredentialLabel = credentialConfig.primary.label;
+      }
+    }
+  } catch {
+    // Non-fatal — pill simply won't render
+  }
+}


### PR DESCRIPTION
## Summary

- **`ui/src/stores/credentials.svelte.ts`** — Missing file: TopBar imported `getActiveCredentialLabel`, `getCredentialConfig`, `loadCredentialConfig`, and `setActiveCredentialLabel` from this store but it was never created, breaking the UI build
- **`.gitignore`** — `**/credentials*` pattern was too broad, matching `credentials.svelte.ts` and any other non-secret files named `credentials.*`. Narrowed to explicit extensions (`.json`, `.yaml`, `.yml`)
- **`shared/bin/credential-refresh`** — `CLAUDE_CODE_CRED` path was hardcoded as `Path.home().parent / "ck" / ".claude/.credentials.json"` which resolves incorrectly; changed to `Path.home() / ".claude" / ".credentials.json"`

## Test plan

- [ ] `cd ui && npm run build` succeeds without missing module error
- [ ] `credential-refresh --status` correctly locates Claude Code credentials
- [ ] `git check-ignore ui/src/stores/credentials.svelte.ts` returns no match