### PR TITLE
feat(dianoia): v2 Phase 1 — file-backed state + discussion loop

### DIFF
--- a/infrastructure/runtime/src/aletheia.ts
+++ b/infrastructure/runtime/src/aletheia.ts
@@ -271,8 +271,9 @@ export function createRuntime(configPath?: string): AletheiaRuntime {
   };
   const planningStore = new PlanningStore(store.getDb());
   const planningOrchestrator = new DianoiaOrchestrator(store.getDb(), planningConfig);
+  planningOrchestrator.setWorkspaceRoot(defaultWorkspace);
   manager.setPlanningOrchestrator(planningOrchestrator);
-  log.info("Dianoia planning orchestrator initialized");
+  log.info("Dianoia planning orchestrator initialized", { workspace: defaultWorkspace });
 
   const plugins = new PluginRegistry(config);
 

--- a/infrastructure/runtime/src/dianoia/index.ts
+++ b/infrastructure/runtime/src/dianoia/index.ts
@@ -12,7 +12,8 @@ export type {
   PlanningResearch,
   ProjectContext,
 } from "./types.js";
-export { PLANNING_V20_DDL, PLANNING_V21_MIGRATION, PLANNING_V22_MIGRATION, PLANNING_V23_MIGRATION, PLANNING_V24_MIGRATION, PLANNING_V25_MIGRATION } from "./schema.js";
+export { PLANNING_V20_DDL, PLANNING_V21_MIGRATION, PLANNING_V22_MIGRATION, PLANNING_V23_MIGRATION, PLANNING_V24_MIGRATION, PLANNING_V25_MIGRATION, PLANNING_V26_MIGRATION } from "./schema.js";
+export type { DiscussionQuestion, DiscussionOption } from "./types.js";
 export { ResearchOrchestrator } from "./researcher.js";
 export { createPlanResearchTool } from "./research-tool.js";
 export { transition, VALID_TRANSITIONS } from "./machine.js";
@@ -30,3 +31,23 @@ export { GoalBackwardVerifier } from "./verifier.js";
 export { createPlanVerifyTool } from "./verifier-tool.js";
 export { CheckpointSystem } from "./checkpoint.js";
 export { createPlanCreateTool } from "./create-tool.js";
+export {
+  getProjectDir,
+  getPhaseDir,
+  ensureProjectDir,
+  ensurePhaseDir,
+  writeProjectFile,
+  writeRequirementsFile,
+  writeResearchFile,
+  writeRoadmapFile,
+  writeDiscussFile,
+  writePlanFile,
+  writeStateFile,
+  writeVerifyFile,
+  readProjectFile,
+  readRequirementsFile,
+  readRoadmapFile,
+  readResearchFile,
+  readDiscussFile,
+  readPlanFile,
+} from "./project-files.js";

--- a/infrastructure/runtime/src/dianoia/machine.test.ts
+++ b/infrastructure/runtime/src/dianoia/machine.test.ts
@@ -9,6 +9,7 @@ const ALL_EVENTS: PlanningEvent[] = [
   "RESEARCH_COMPLETE",
   "REQUIREMENTS_COMPLETE",
   "ROADMAP_COMPLETE",
+  "DISCUSSION_COMPLETE",
   "PLAN_READY",
   "VERIFY",
   "NEXT_PHASE",
@@ -65,8 +66,16 @@ describe("DianoiaFSM — valid transitions", () => {
     expect(transition("requirements", "ABANDON")).toBe("abandoned");
   });
 
-  it("roadmap + ROADMAP_COMPLETE -> phase-planning", () => {
-    expect(transition("roadmap", "ROADMAP_COMPLETE")).toBe("phase-planning");
+  it("roadmap + ROADMAP_COMPLETE -> discussing", () => {
+    expect(transition("roadmap", "ROADMAP_COMPLETE")).toBe("discussing");
+  });
+
+  it("discussing + DISCUSSION_COMPLETE -> phase-planning", () => {
+    expect(transition("discussing", "DISCUSSION_COMPLETE")).toBe("phase-planning");
+  });
+
+  it("discussing + ABANDON -> abandoned", () => {
+    expect(transition("discussing", "ABANDON")).toBe("abandoned");
   });
 
   it("roadmap + ABANDON -> abandoned", () => {
@@ -93,8 +102,8 @@ describe("DianoiaFSM — valid transitions", () => {
     expect(transition("executing", "ABANDON")).toBe("abandoned");
   });
 
-  it("verifying + NEXT_PHASE -> phase-planning", () => {
-    expect(transition("verifying", "NEXT_PHASE")).toBe("phase-planning");
+  it("verifying + NEXT_PHASE -> discussing", () => {
+    expect(transition("verifying", "NEXT_PHASE")).toBe("discussing");
   });
 
   it("verifying + ALL_PHASES_COMPLETE -> complete", () => {
@@ -145,8 +154,8 @@ describe("DianoiaFSM — invalid transitions", () => {
 });
 
 describe("DianoiaFSM — VALID_TRANSITIONS completeness", () => {
-  it("covers all 11 states", () => {
-    expect(Object.keys(VALID_TRANSITIONS).length).toBe(11);
+  it("covers all 12 states", () => {
+    expect(Object.keys(VALID_TRANSITIONS).length).toBe(12);
   });
 
   it("complete state has no valid transitions", () => {
@@ -157,13 +166,14 @@ describe("DianoiaFSM — VALID_TRANSITIONS completeness", () => {
     expect(VALID_TRANSITIONS["abandoned"].length).toBe(0);
   });
 
-  it("all 11 DianoiaState values are present as keys", () => {
+  it("all 12 DianoiaState values are present as keys", () => {
     const expected: DianoiaState[] = [
       "idle",
       "questioning",
       "researching",
       "requirements",
       "roadmap",
+      "discussing",
       "phase-planning",
       "executing",
       "verifying",
@@ -189,6 +199,8 @@ describe("DianoiaFSM — state reachability (sequential scenarios)", () => {
     s = transition(s, "REQUIREMENTS_COMPLETE");
     expect(s).toBe("roadmap");
     s = transition(s, "ROADMAP_COMPLETE");
+    expect(s).toBe("discussing");
+    s = transition(s, "DISCUSSION_COMPLETE");
     expect(s).toBe("phase-planning");
     s = transition(s, "PLAN_READY");
     expect(s).toBe("executing");
@@ -204,9 +216,11 @@ describe("DianoiaFSM — state reachability (sequential scenarios)", () => {
     expect(s).toBe("executing");
   });
 
-  it("traces multi-phase loop: verifying -> phase-planning (NEXT_PHASE)", () => {
+  it("traces multi-phase loop: verifying -> discussing -> phase-planning (NEXT_PHASE)", () => {
     let s: DianoiaState = "verifying";
     s = transition(s, "NEXT_PHASE");
+    expect(s).toBe("discussing");
+    s = transition(s, "DISCUSSION_COMPLETE");
     expect(s).toBe("phase-planning");
     s = transition(s, "PLAN_READY");
     expect(s).toBe("executing");

--- a/infrastructure/runtime/src/dianoia/machine.ts
+++ b/infrastructure/runtime/src/dianoia/machine.ts
@@ -9,6 +9,7 @@ export type PlanningEvent =
   | "RESEARCH_COMPLETE"
   | "REQUIREMENTS_COMPLETE"
   | "ROADMAP_COMPLETE"
+  | "DISCUSSION_COMPLETE"
   | "PLAN_READY"
   | "VERIFY"
   | "NEXT_PHASE"
@@ -24,6 +25,7 @@ export const VALID_TRANSITIONS: Record<DianoiaState, ReadonlyArray<PlanningEvent
   researching: ["RESEARCH_COMPLETE", "BLOCK", "ABANDON"],
   requirements: ["REQUIREMENTS_COMPLETE", "ABANDON"],
   roadmap: ["ROADMAP_COMPLETE", "ABANDON"],
+  discussing: ["DISCUSSION_COMPLETE", "ABANDON"],
   "phase-planning": ["PLAN_READY", "ABANDON"],
   executing: ["VERIFY", "BLOCK", "ABANDON"],
   verifying: ["NEXT_PHASE", "ALL_PHASES_COMPLETE", "PHASE_FAILED", "ABANDON"],
@@ -37,11 +39,12 @@ const TRANSITION_RESULT: Partial<Record<DianoiaState, Partial<Record<PlanningEve
   questioning: { START_RESEARCH: "researching", ABANDON: "abandoned" },
   researching: { RESEARCH_COMPLETE: "requirements", BLOCK: "blocked", ABANDON: "abandoned" },
   requirements: { REQUIREMENTS_COMPLETE: "roadmap", ABANDON: "abandoned" },
-  roadmap: { ROADMAP_COMPLETE: "phase-planning", ABANDON: "abandoned" },
+  roadmap: { ROADMAP_COMPLETE: "discussing", ABANDON: "abandoned" },
+  discussing: { DISCUSSION_COMPLETE: "phase-planning", ABANDON: "abandoned" },
   "phase-planning": { PLAN_READY: "executing", ABANDON: "abandoned" },
   executing: { VERIFY: "verifying", BLOCK: "blocked", ABANDON: "abandoned" },
   verifying: {
-    NEXT_PHASE: "phase-planning",
+    NEXT_PHASE: "discussing",
     ALL_PHASES_COMPLETE: "complete",
     PHASE_FAILED: "blocked",
     ABANDON: "abandoned",

--- a/infrastructure/runtime/src/dianoia/orchestrator.ts
+++ b/infrastructure/runtime/src/dianoia/orchestrator.ts
@@ -3,9 +3,19 @@ import { createLogger } from "../koina/logger.js";
 import { eventBus } from "../koina/event-bus.js";
 import { PlanningStore } from "./store.js";
 import { transition } from "./machine.js";
+import {
+  ensureProjectDir,
+  writeProjectFile,
+  writeRequirementsFile,
+  writeResearchFile,
+  writeRoadmapFile,
+  writeDiscussFile,
+  writePlanFile,
+  writeVerifyFile,
+} from "./project-files.js";
 import type Database from "better-sqlite3";
 import type { PlanningConfigSchema } from "../taxis/schema.js";
-import type { PlanningProject, ProjectContext } from "./types.js";
+import type { DiscussionOption, DiscussionQuestion, PlanningProject, ProjectContext } from "./types.js";
 
 const log = createLogger("dianoia:orchestrator");
 
@@ -17,9 +27,22 @@ const ACTIVE_STATES = new Set([
 
 export class DianoiaOrchestrator {
   private store: PlanningStore;
+  private workspaceRoot: string | null = null;
 
   constructor(db: Database.Database, private defaultConfig: PlanningConfigSchema) {
     this.store = new PlanningStore(db);
+  }
+
+  /** Set the workspace root for file-backed state. Must be called before file writes work. */
+  setWorkspaceRoot(root: string): void {
+    this.workspaceRoot = root;
+  }
+
+  getWorkspaceOrThrow(): string {
+    if (!this.workspaceRoot) {
+      throw new Error("DianoiaOrchestrator: workspaceRoot not set — call setWorkspaceRoot() first");
+    }
+    return this.workspaceRoot;
   }
 
   handle(nousId: string, sessionId: string): string {
@@ -41,6 +64,13 @@ export class DianoiaOrchestrator {
       config: this.defaultConfig,
     });
     this.store.updateProjectState(project.id, transition("idle", "START_QUESTIONING"));
+
+    // Set up file-backed state directory
+    if (this.workspaceRoot) {
+      const dir = ensureProjectDir(this.workspaceRoot, project.id);
+      this.store.updateProjectDir(project.id, dir);
+    }
+
     eventBus.emit("planning:project-created", { projectId: project.id, nousId, sessionId });
     log.info(`Created planning project ${project.id} for nous ${nousId}`);
     return "Starting a Dianoia planning project. First: what are you building?";
@@ -143,6 +173,12 @@ export class DianoiaOrchestrator {
     // Transition FSM: questioning -> researching (event: START_RESEARCH)
     this.store.updateProjectState(projectId, transition("questioning", "START_RESEARCH"));
 
+    // Write PROJECT.md with confirmed context
+    if (this.workspaceRoot) {
+      const updated = this.store.getProjectOrThrow(projectId);
+      writeProjectFile(this.workspaceRoot, updated, merged);
+    }
+
     eventBus.emit("planning:phase-started", {
       projectId,
       nousId,
@@ -165,6 +201,13 @@ export class DianoiaOrchestrator {
 
   skipResearch(projectId: string, nousId: string, sessionId: string): string {
     this.store.updateProjectState(projectId, transition("researching", "RESEARCH_COMPLETE"));
+
+    // Write RESEARCH.md even if skipped (records what was available)
+    if (this.workspaceRoot) {
+      const research = this.store.listResearch(projectId);
+      if (research.length > 0) writeResearchFile(this.workspaceRoot, projectId, research);
+    }
+
     eventBus.emit("planning:phase-complete", { projectId, nousId, sessionId, phase: "research" });
     log.info(`Research skipped for project ${projectId}; advancing to requirements`);
     return "Research skipped. Proceeding to requirements definition.";
@@ -172,6 +215,13 @@ export class DianoiaOrchestrator {
 
   completeRequirements(projectId: string, nousId: string, sessionId: string): string {
     this.store.updateProjectState(projectId, transition("requirements", "REQUIREMENTS_COMPLETE"));
+
+    // Write REQUIREMENTS.md
+    if (this.workspaceRoot) {
+      const reqs = this.store.listRequirements(projectId);
+      writeRequirementsFile(this.workspaceRoot, projectId, reqs);
+    }
+
     eventBus.emit("planning:phase-complete", { projectId, nousId, sessionId, phase: "requirements" });
     log.info(`Requirements complete for project ${projectId}; advancing to roadmap`);
     return "Requirements confirmed. Advancing to roadmap generation.";
@@ -203,9 +253,16 @@ export class DianoiaOrchestrator {
   completeRoadmap(projectId: string, nousId: string, sessionId: string): string {
     const project = this.store.getProjectOrThrow(projectId);
     this.store.updateProjectState(projectId, transition(project.state, "ROADMAP_COMPLETE"));
+
+    // Write ROADMAP.md
+    if (this.workspaceRoot) {
+      const phases = this.store.listPhases(projectId);
+      writeRoadmapFile(this.workspaceRoot, projectId, phases);
+    }
+
     eventBus.emit("planning:phase-complete", { projectId, nousId, sessionId, phase: "roadmap" });
-    log.info(`Roadmap complete for project ${projectId}`);
-    return "Roadmap complete. Moving to phase planning.";
+    log.info(`Roadmap complete for project ${projectId}; advancing to discussion`);
+    return "Roadmap complete. Moving to phase discussion.";
   }
 
   advanceToExecution(projectId: string, nousId: string, sessionId: string): string {
@@ -263,5 +320,90 @@ export class DianoiaOrchestrator {
 
   updateContext(projectId: string, context: ProjectContext): void {
     this.store.updateProjectContext(projectId, context);
+  }
+
+  // --- Discussion flow (Spec 32) ---
+
+  /** Create a discussion question for a phase */
+  addDiscussionQuestion(
+    projectId: string,
+    phaseId: string,
+    question: string,
+    options: DiscussionOption[],
+    recommendation?: string | null,
+  ): DiscussionQuestion {
+    return this.store.createDiscussionQuestion({
+      projectId,
+      phaseId,
+      question,
+      options,
+      recommendation: recommendation ?? null,
+    });
+  }
+
+  /** Answer a discussion question */
+  answerDiscussion(questionId: string, decision: string, userNote?: string | null): void {
+    this.store.answerDiscussionQuestion(questionId, decision, userNote);
+  }
+
+  /** Skip a discussion question (agent uses its recommendation) */
+  skipDiscussion(questionId: string): void {
+    this.store.skipDiscussionQuestion(questionId);
+  }
+
+  /** Get pending questions for a phase */
+  getPendingDiscussions(projectId: string, phaseId: string): DiscussionQuestion[] {
+    return this.store.getPendingDiscussionQuestions(projectId, phaseId);
+  }
+
+  /** Get all discussion questions for a phase */
+  getPhaseDiscussions(projectId: string, phaseId: string): DiscussionQuestion[] {
+    return this.store.listDiscussionQuestions(projectId, phaseId);
+  }
+
+  /** Complete discussion phase — writes DISCUSS.md and advances to planning */
+  completeDiscussion(projectId: string, phaseId: string, nousId: string, sessionId: string): string {
+    const project = this.store.getProjectOrThrow(projectId);
+    this.store.updateProjectState(projectId, transition(project.state, "DISCUSSION_COMPLETE"));
+
+    // Write DISCUSS.md with all questions and decisions
+    if (this.workspaceRoot) {
+      const questions = this.store.listDiscussionQuestions(projectId, phaseId);
+      writeDiscussFile(this.workspaceRoot, projectId, phaseId, questions);
+    }
+
+    eventBus.emit("planning:phase-complete", { projectId, nousId, sessionId, phase: "discussing" });
+    log.info(`Discussion complete for phase ${phaseId} in project ${projectId}; advancing to planning`);
+    return "Discussion complete. Advancing to phase planning.";
+  }
+
+  /** Advance to next phase — now goes to discussing instead of phase-planning */
+  advanceToNextPhaseDiscussion(projectId: string, nousId: string, sessionId: string): string {
+    const project = this.store.getProjectOrThrow(projectId);
+    this.store.updateProjectState(projectId, transition(project.state, "NEXT_PHASE"));
+    eventBus.emit("planning:phase-started", { projectId, nousId, sessionId });
+    log.info(`Next phase discussion started for project ${projectId}`);
+    return "Moving to discussion for next phase.";
+  }
+
+  // --- File sync helpers ---
+
+  /** Write/update the PROJECT.md file with current state */
+  syncProjectFile(projectId: string): void {
+    if (!this.workspaceRoot) return;
+    const project = this.store.getProjectOrThrow(projectId);
+    writeProjectFile(this.workspaceRoot, project);
+  }
+
+  /** Write execution plan file for a phase */
+  syncPlanFile(projectId: string, phaseId: string, plan: unknown): void {
+    if (!this.workspaceRoot) return;
+    writePlanFile(this.workspaceRoot, projectId, phaseId, plan);
+  }
+
+  /** Write verification results for a phase */
+  syncVerifyFile(projectId: string, phaseId: string, verification: Record<string, unknown>): void {
+    if (!this.workspaceRoot) return;
+    writeVerifyFile(this.workspaceRoot, projectId, phaseId, verification);
   }
 }

--- a/infrastructure/runtime/src/dianoia/project-files.ts
+++ b/infrastructure/runtime/src/dianoia/project-files.ts
@@ -1,0 +1,299 @@
+// Project file generators — markdown files as source of truth for Dianoia projects (Spec 32)
+import { mkdirSync, writeFileSync, existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { createLogger } from "../koina/logger.js";
+import type {
+  PlanningProject,
+  PlanningPhase,
+  PlanningRequirement,
+  PlanningResearch,
+  ProjectContext,
+  DiscussionQuestion,
+} from "./types.js";
+
+const log = createLogger("dianoia:files");
+
+// --- Directory management ---
+
+export function getProjectDir(workspaceRoot: string, projectId: string): string {
+  return join(workspaceRoot, ".dianoia", "projects", projectId);
+}
+
+export function getPhaseDir(workspaceRoot: string, projectId: string, phaseId: string): string {
+  return join(getProjectDir(workspaceRoot, projectId), "phases", phaseId);
+}
+
+export function ensureProjectDir(workspaceRoot: string, projectId: string): string {
+  const dir = getProjectDir(workspaceRoot, projectId);
+  mkdirSync(dir, { recursive: true });
+  mkdirSync(join(dir, "phases"), { recursive: true });
+  return dir;
+}
+
+export function ensurePhaseDir(workspaceRoot: string, projectId: string, phaseId: string): string {
+  const dir = getPhaseDir(workspaceRoot, projectId, phaseId);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+// --- File writers ---
+
+export function writeProjectFile(
+  workspaceRoot: string,
+  project: PlanningProject,
+  context?: ProjectContext | null,
+): void {
+  const dir = ensureProjectDir(workspaceRoot, project.id);
+  const ctx = context ?? project.projectContext;
+
+  const lines = [
+    `# ${project.goal || "Untitled Project"}`,
+    "",
+    `| Field | Value |`,
+    `|-------|-------|`,
+    `| ID | \`${project.id}\` |`,
+    `| State | ${project.state} |`,
+    `| Created | ${project.createdAt} |`,
+    `| Updated | ${project.updatedAt} |`,
+    "",
+  ];
+
+  if (ctx) {
+    lines.push("## Context", "");
+    if (ctx.goal) lines.push(`**Goal:** ${ctx.goal}`, "");
+    if (ctx.coreValue) lines.push(`**Core Value:** ${ctx.coreValue}`, "");
+    if (ctx.constraints?.length) {
+      lines.push("**Constraints:**");
+      for (const c of ctx.constraints) lines.push(`- ${c}`);
+      lines.push("");
+    }
+    if (ctx.keyDecisions?.length) {
+      lines.push("**Key Decisions:**");
+      for (const d of ctx.keyDecisions) lines.push(`- ${d}`);
+      lines.push("");
+    }
+    if (ctx.rawTranscript?.length) {
+      lines.push("## Discovery Transcript", "");
+      for (const t of ctx.rawTranscript) {
+        lines.push(`**Q${t.turn}:** ${t.text}`, "");
+      }
+    }
+  }
+
+  const filePath = join(dir, "PROJECT.md");
+  writeFileSync(filePath, lines.join("\n"), "utf-8");
+  log.debug(`Wrote PROJECT.md for ${project.id}`);
+}
+
+export function writeRequirementsFile(
+  workspaceRoot: string,
+  projectId: string,
+  requirements: PlanningRequirement[],
+): void {
+  const dir = ensureProjectDir(workspaceRoot, projectId);
+  const lines = ["# Requirements", ""];
+
+  // Group by category
+  const byCategory = new Map<string, PlanningRequirement[]>();
+  for (const req of requirements) {
+    const list = byCategory.get(req.category) ?? [];
+    list.push(req);
+    byCategory.set(req.category, list);
+  }
+
+  // Group by tier within each category
+  for (const [category, reqs] of byCategory) {
+    lines.push(`## ${category}`, "");
+    lines.push("| ID | Description | Tier | Status | Rationale |");
+    lines.push("|-----|-------------|------|--------|-----------|");
+    for (const req of reqs) {
+      lines.push(
+        `| ${req.reqId} | ${req.description} | ${req.tier} | ${req.status} | ${req.rationale ?? "—"} |`,
+      );
+    }
+    lines.push("");
+  }
+
+  writeFileSync(join(dir, "REQUIREMENTS.md"), lines.join("\n"), "utf-8");
+  log.debug(`Wrote REQUIREMENTS.md for ${projectId}`);
+}
+
+export function writeResearchFile(
+  workspaceRoot: string,
+  projectId: string,
+  research: PlanningResearch[],
+): void {
+  const dir = ensureProjectDir(workspaceRoot, projectId);
+  const lines = ["# Research", ""];
+
+  for (const r of research) {
+    lines.push(`## ${r.dimension} (${r.status})`, "");
+    lines.push(r.content, "");
+  }
+
+  writeFileSync(join(dir, "RESEARCH.md"), lines.join("\n"), "utf-8");
+  log.debug(`Wrote RESEARCH.md for ${projectId}`);
+}
+
+export function writeRoadmapFile(
+  workspaceRoot: string,
+  projectId: string,
+  phases: PlanningPhase[],
+): void {
+  const dir = ensureProjectDir(workspaceRoot, projectId);
+  const lines = ["# Roadmap", ""];
+
+  for (const phase of phases) {
+    const status = phase.status === "complete" ? "✅" :
+      phase.status === "executing" ? "🔄" :
+      phase.status === "failed" ? "❌" :
+      phase.status === "skipped" ? "⏭" : "⬜";
+    lines.push(`## ${status} Phase ${phase.phaseOrder + 1}: ${phase.name}`, "");
+    lines.push(`**Goal:** ${phase.goal}`, "");
+    if (phase.requirements.length > 0) {
+      lines.push("**Requirements:**");
+      for (const r of phase.requirements) lines.push(`- ${r}`);
+      lines.push("");
+    }
+    if (phase.successCriteria.length > 0) {
+      lines.push("**Success Criteria:**");
+      for (const c of phase.successCriteria) lines.push(`- ${c}`);
+      lines.push("");
+    }
+  }
+
+  writeFileSync(join(dir, "ROADMAP.md"), lines.join("\n"), "utf-8");
+  log.debug(`Wrote ROADMAP.md for ${projectId}`);
+}
+
+export function writeDiscussFile(
+  workspaceRoot: string,
+  projectId: string,
+  phaseId: string,
+  questions: DiscussionQuestion[],
+): void {
+  const dir = ensurePhaseDir(workspaceRoot, projectId, phaseId);
+  const lines = ["# Phase Discussion", ""];
+
+  for (const q of questions) {
+    const statusIcon = q.status === "answered" ? "✅" :
+      q.status === "skipped" ? "⏭" : "❓";
+    lines.push(`## ${statusIcon} ${q.question}`, "");
+
+    if (q.options.length > 0) {
+      lines.push("**Options:**");
+      for (const opt of q.options) {
+        const selected = q.decision === opt.label ? " ← **selected**" : "";
+        lines.push(`- **${opt.label}:** ${opt.rationale}${selected}`);
+      }
+      lines.push("");
+    }
+
+    if (q.recommendation) {
+      lines.push(`**Recommended:** ${q.recommendation}`, "");
+    }
+
+    if (q.decision) {
+      lines.push(`**Decision:** ${q.decision}`, "");
+    }
+
+    if (q.userNote) {
+      lines.push(`**Note:** ${q.userNote}`, "");
+    }
+  }
+
+  writeFileSync(join(dir, "DISCUSS.md"), lines.join("\n"), "utf-8");
+  log.debug(`Wrote DISCUSS.md for phase ${phaseId}`);
+}
+
+export function writePlanFile(
+  workspaceRoot: string,
+  projectId: string,
+  phaseId: string,
+  plan: unknown,
+): void {
+  const dir = ensurePhaseDir(workspaceRoot, projectId, phaseId);
+  const content = typeof plan === "string" ? plan : JSON.stringify(plan, null, 2);
+  writeFileSync(join(dir, "PLAN.md"), `# Execution Plan\n\n\`\`\`json\n${content}\n\`\`\`\n`, "utf-8");
+  log.debug(`Wrote PLAN.md for phase ${phaseId}`);
+}
+
+export function writeStateFile(
+  workspaceRoot: string,
+  projectId: string,
+  phaseId: string,
+  state: Record<string, unknown>,
+): void {
+  const dir = ensurePhaseDir(workspaceRoot, projectId, phaseId);
+  writeFileSync(
+    join(dir, "STATE.md"),
+    `# Phase State\n\n\`\`\`json\n${JSON.stringify(state, null, 2)}\n\`\`\`\n`,
+    "utf-8",
+  );
+}
+
+export function writeVerifyFile(
+  workspaceRoot: string,
+  projectId: string,
+  phaseId: string,
+  verification: Record<string, unknown>,
+): void {
+  const dir = ensurePhaseDir(workspaceRoot, projectId, phaseId);
+  const v = verification;
+  const lines = [
+    "# Verification Results",
+    "",
+    `**Status:** ${v["overallStatus"] ?? v["status"] ?? "unknown"}`,
+    `**Verified:** ${v["verifiedAt"] ?? "—"}`,
+    "",
+  ];
+
+  if (v["summary"]) {
+    lines.push("## Summary", "", v["summary"] as string, "");
+  }
+
+  const gaps = v["gaps"] as Array<Record<string, unknown>> | undefined;
+  if (gaps?.length) {
+    lines.push("## Gaps", "");
+    for (const gap of gaps) {
+      lines.push(`- **${gap["status"]}:** ${gap["detail"] ?? gap["criterion"] ?? gap["requirement"]}`);
+      if (gap["proposedFix"]) lines.push(`  - Fix: ${gap["proposedFix"]}`);
+    }
+    lines.push("");
+  }
+
+  writeFileSync(join(dir, "VERIFY.md"), lines.join("\n"), "utf-8");
+  log.debug(`Wrote VERIFY.md for phase ${phaseId}`);
+}
+
+// --- File readers (for context packets) ---
+
+export function readProjectFile(workspaceRoot: string, projectId: string): string | null {
+  const path = join(getProjectDir(workspaceRoot, projectId), "PROJECT.md");
+  return existsSync(path) ? readFileSync(path, "utf-8") : null;
+}
+
+export function readRequirementsFile(workspaceRoot: string, projectId: string): string | null {
+  const path = join(getProjectDir(workspaceRoot, projectId), "REQUIREMENTS.md");
+  return existsSync(path) ? readFileSync(path, "utf-8") : null;
+}
+
+export function readRoadmapFile(workspaceRoot: string, projectId: string): string | null {
+  const path = join(getProjectDir(workspaceRoot, projectId), "ROADMAP.md");
+  return existsSync(path) ? readFileSync(path, "utf-8") : null;
+}
+
+export function readResearchFile(workspaceRoot: string, projectId: string): string | null {
+  const path = join(getProjectDir(workspaceRoot, projectId), "RESEARCH.md");
+  return existsSync(path) ? readFileSync(path, "utf-8") : null;
+}
+
+export function readDiscussFile(workspaceRoot: string, projectId: string, phaseId: string): string | null {
+  const path = join(getPhaseDir(workspaceRoot, projectId, phaseId), "DISCUSS.md");
+  return existsSync(path) ? readFileSync(path, "utf-8") : null;
+}
+
+export function readPlanFile(workspaceRoot: string, projectId: string, phaseId: string): string | null {
+  const path = join(getPhaseDir(workspaceRoot, projectId, phaseId), "PLAN.md");
+  return existsSync(path) ? readFileSync(path, "utf-8") : null;
+}

--- a/infrastructure/runtime/src/dianoia/schema.ts
+++ b/infrastructure/runtime/src/dianoia/schema.ts
@@ -98,3 +98,47 @@ CREATE TABLE IF NOT EXISTS planning_spawn_records (
 CREATE INDEX IF NOT EXISTS idx_planning_spawn_records_project ON planning_spawn_records(project_id);
 CREATE INDEX IF NOT EXISTS idx_planning_spawn_records_phase ON planning_spawn_records(phase_id);
 `;
+
+// Spec 32 — Dianoia v2 Phase 1: file-backed state + discussion loop
+// SQLite CHECK constraints can't be ALTERed, so we recreate the projects table
+// to add 'discussing' state and project_dir column.
+export const PLANNING_V26_MIGRATION = `
+CREATE TABLE planning_projects_v26 (
+  id TEXT PRIMARY KEY,
+  nous_id TEXT NOT NULL,
+  session_id TEXT NOT NULL,
+  goal TEXT NOT NULL,
+  state TEXT NOT NULL DEFAULT 'idle' CHECK(state IN ('idle', 'questioning', 'researching', 'requirements', 'roadmap', 'discussing', 'phase-planning', 'executing', 'verifying', 'complete', 'blocked', 'abandoned')),
+  config TEXT NOT NULL DEFAULT '{}',
+  context_hash TEXT NOT NULL,
+  project_context TEXT,
+  project_dir TEXT,
+  created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+  updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+);
+
+INSERT INTO planning_projects_v26 (id, nous_id, session_id, goal, state, config, context_hash, project_context, created_at, updated_at)
+  SELECT id, nous_id, session_id, goal, state, config, context_hash, project_context, created_at, updated_at
+  FROM planning_projects;
+
+DROP TABLE planning_projects;
+ALTER TABLE planning_projects_v26 RENAME TO planning_projects;
+CREATE INDEX IF NOT EXISTS idx_planning_projects_nous ON planning_projects(nous_id);
+
+CREATE TABLE IF NOT EXISTS planning_discussions (
+  id TEXT PRIMARY KEY,
+  project_id TEXT NOT NULL REFERENCES planning_projects(id) ON DELETE CASCADE,
+  phase_id TEXT NOT NULL,
+  question TEXT NOT NULL,
+  options TEXT NOT NULL DEFAULT '[]',
+  recommendation TEXT,
+  decision TEXT,
+  user_note TEXT,
+  status TEXT NOT NULL DEFAULT 'pending' CHECK(status IN ('pending', 'answered', 'skipped')),
+  created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+  updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_planning_discussions_project ON planning_discussions(project_id);
+CREATE INDEX IF NOT EXISTS idx_planning_discussions_phase ON planning_discussions(phase_id);
+`;

--- a/infrastructure/runtime/src/dianoia/store.ts
+++ b/infrastructure/runtime/src/dianoia/store.ts
@@ -6,6 +6,8 @@ import { PlanningError } from "../koina/errors.js";
 import { createLogger } from "../koina/logger.js";
 import type {
   DianoiaState,
+  DiscussionOption,
+  DiscussionQuestion,
   PlanningCheckpoint,
   PlanningConfig,
   PlanningPhase,
@@ -474,6 +476,119 @@ export class PlanningStore {
       .run(JSON.stringify(result), id);
   }
 
+  // --- Project Directory ---
+
+  updateProjectDir(id: string, projectDir: string): void {
+    const result = this.db
+      .prepare(
+        `UPDATE planning_projects SET project_dir = ?, updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now') WHERE id = ?`,
+      )
+      .run(projectDir, id);
+    if (result.changes === 0) {
+      throw new PlanningError(`Planning project not found: ${id}`, {
+        code: "PLANNING_PROJECT_NOT_FOUND",
+        context: { id },
+      });
+    }
+  }
+
+  // --- Discussions (Spec 32) ---
+
+  createDiscussionQuestion(opts: {
+    projectId: string;
+    phaseId: string;
+    question: string;
+    options: DiscussionOption[];
+    recommendation?: string | null;
+  }): DiscussionQuestion {
+    const id = generateId("disc");
+    const now = new Date().toISOString();
+
+    this.db
+      .prepare(
+        `INSERT INTO planning_discussions (id, project_id, phase_id, question, options, recommendation, status, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, 'pending', ?, ?)`,
+      )
+      .run(
+        id,
+        opts.projectId,
+        opts.phaseId,
+        opts.question,
+        JSON.stringify(opts.options),
+        opts.recommendation ?? null,
+        now,
+        now,
+      );
+
+    return this.getDiscussionQuestionOrThrow(id);
+  }
+
+  answerDiscussionQuestion(id: string, decision: string, userNote?: string | null): void {
+    const result = this.db
+      .prepare(
+        `UPDATE planning_discussions SET decision = ?, user_note = ?, status = 'answered', updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now') WHERE id = ?`,
+      )
+      .run(decision, userNote ?? null, id);
+    if (result.changes === 0) {
+      throw new PlanningError(`Discussion question not found: ${id}`, {
+        code: "PLANNING_DISCUSSION_NOT_FOUND",
+        context: { id },
+      });
+    }
+  }
+
+  skipDiscussionQuestion(id: string): void {
+    const result = this.db
+      .prepare(
+        `UPDATE planning_discussions SET status = 'skipped', updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now') WHERE id = ?`,
+      )
+      .run(id);
+    if (result.changes === 0) {
+      throw new PlanningError(`Discussion question not found: ${id}`, {
+        code: "PLANNING_DISCUSSION_NOT_FOUND",
+        context: { id },
+      });
+    }
+  }
+
+  listDiscussionQuestions(projectId: string, phaseId?: string): DiscussionQuestion[] {
+    const rows = phaseId
+      ? (this.db
+          .prepare("SELECT * FROM planning_discussions WHERE project_id = ? AND phase_id = ? ORDER BY created_at ASC")
+          .all(projectId, phaseId) as Array<Record<string, unknown>>)
+      : (this.db
+          .prepare("SELECT * FROM planning_discussions WHERE project_id = ? ORDER BY created_at ASC")
+          .all(projectId) as Array<Record<string, unknown>>);
+    return rows.map((r) => this.mapDiscussionQuestion(r));
+  }
+
+  getPendingDiscussionQuestions(projectId: string, phaseId: string): DiscussionQuestion[] {
+    const rows = this.db
+      .prepare(
+        "SELECT * FROM planning_discussions WHERE project_id = ? AND phase_id = ? AND status = 'pending' ORDER BY created_at ASC",
+      )
+      .all(projectId, phaseId) as Array<Record<string, unknown>>;
+    return rows.map((r) => this.mapDiscussionQuestion(r));
+  }
+
+  getDiscussionQuestion(id: string): DiscussionQuestion | undefined {
+    const row = this.db
+      .prepare("SELECT * FROM planning_discussions WHERE id = ?")
+      .get(id) as Record<string, unknown> | undefined;
+    return row ? this.mapDiscussionQuestion(row) : undefined;
+  }
+
+  getDiscussionQuestionOrThrow(id: string): DiscussionQuestion {
+    const q = this.getDiscussionQuestion(id);
+    if (!q) {
+      throw new PlanningError(`Discussion question not found: ${id}`, {
+        code: "PLANNING_DISCUSSION_NOT_FOUND",
+        context: { id },
+      });
+    }
+    return q;
+  }
+
   // --- Private mappers ---
 
   private mapProject(row: Record<string, unknown>): PlanningProject {
@@ -503,6 +618,7 @@ export class PlanningStore {
       state: row["state"] as DianoiaState,
       config,
       contextHash: row["context_hash"] as string,
+      projectDir: (row["project_dir"] as string | null) ?? null,
       createdAt: row["created_at"] as string,
       updatedAt: row["updated_at"] as string,
       projectContext,
@@ -589,6 +705,28 @@ export class PlanningStore {
       content: row["content"] as string,
       status: (row["status"] as "complete" | "partial" | "failed") ?? "complete",
       createdAt: row["created_at"] as string,
+    };
+  }
+
+  private mapDiscussionQuestion(row: Record<string, unknown>): DiscussionQuestion {
+    let options: DiscussionOption[];
+    try {
+      options = JSON.parse(row["options"] as string) as DiscussionOption[];
+    } catch {
+      options = [];
+    }
+    return {
+      id: row["id"] as string,
+      projectId: row["project_id"] as string,
+      phaseId: row["phase_id"] as string,
+      question: row["question"] as string,
+      options,
+      recommendation: (row["recommendation"] as string | null) ?? null,
+      decision: (row["decision"] as string | null) ?? null,
+      userNote: (row["user_note"] as string | null) ?? null,
+      status: row["status"] as DiscussionQuestion["status"],
+      createdAt: row["created_at"] as string,
+      updatedAt: row["updated_at"] as string,
     };
   }
 

--- a/infrastructure/runtime/src/dianoia/types.ts
+++ b/infrastructure/runtime/src/dianoia/types.ts
@@ -17,6 +17,7 @@ export type DianoiaState =
   | "researching"
   | "requirements"
   | "roadmap"
+  | "discussing"
   | "phase-planning"
   | "executing"
   | "verifying"
@@ -32,6 +33,7 @@ export interface PlanningProject {
   state: DianoiaState;
   config: PlanningConfig;
   contextHash: string;
+  projectDir: string | null;
   createdAt: string;
   updatedAt: string;
   projectContext: ProjectContext | null;
@@ -86,6 +88,29 @@ export interface PlanningResearch {
   status: "complete" | "partial" | "failed";
   createdAt: string;
 }
+
+// --- Discussion types (Spec 32 — discuss-per-phase) ---
+
+export interface DiscussionOption {
+  label: string;
+  rationale: string;
+}
+
+export interface DiscussionQuestion {
+  id: string;
+  projectId: string;
+  phaseId: string;
+  question: string;
+  options: DiscussionOption[];
+  recommendation: string | null;
+  decision: string | null;
+  userNote: string | null;
+  status: "pending" | "answered" | "skipped";
+  createdAt: string;
+  updatedAt: string;
+}
+
+// --- Spawn / Verification types ---
 
 // Phase 6+ stubs — populated when execution/verification phases are complete
 export interface SpawnRecord {

--- a/infrastructure/runtime/src/koina/error-codes.ts
+++ b/infrastructure/runtime/src/koina/error-codes.ts
@@ -93,6 +93,7 @@ export const ERROR_CODES = {
   PLANNING_CONSTRAINT_VIOLATION: "Planning operation violates a database constraint",
   PLANNING_INVALID_TRANSITION: "FSM transition is not valid from the current state",
   PLANNING_SPAWN_NOT_FOUND: "Spawn record ID does not exist",
+  PLANNING_DISCUSSION_NOT_FOUND: "Discussion question ID does not exist",
 } as const;
 
 export type ErrorCode = keyof typeof ERROR_CODES;

--- a/infrastructure/runtime/src/mneme/schema.ts
+++ b/infrastructure/runtime/src/mneme/schema.ts
@@ -1,5 +1,5 @@
 // SQLite DDL — embedded as string constants for migrations
-import { PLANNING_V20_DDL, PLANNING_V21_MIGRATION, PLANNING_V22_MIGRATION, PLANNING_V23_MIGRATION, PLANNING_V24_MIGRATION, PLANNING_V25_MIGRATION } from "../dianoia/schema.js";
+import { PLANNING_V20_DDL, PLANNING_V21_MIGRATION, PLANNING_V22_MIGRATION, PLANNING_V23_MIGRATION, PLANNING_V24_MIGRATION, PLANNING_V25_MIGRATION, PLANNING_V26_MIGRATION } from "../dianoia/schema.js";
 
 export const SCHEMA_VERSION = 1;
 
@@ -442,5 +442,9 @@ export const MIGRATIONS: Array<{ version: number; sql: string }> = [
   {
     version: 25,
     sql: PLANNING_V25_MIGRATION,
+  },
+  {
+    version: 26,
+    sql: PLANNING_V26_MIGRATION,
   },
 ];


### PR DESCRIPTION
## Spec 32 — Dianoia v2 Phase 1

### What

File-backed project state and discussion-per-phase flow. Projects now survive restarts, distillation, and session switches because the source of truth lives in markdown files on disk.

### Changes

**State machine** — Added `discussing` state. Roadmap completion now enters discussion before phase planning. Multi-phase loops go through discussion on each iteration. 12 states, 16 transitions.

**File-backed state** — New `project-files.ts` module generates PROJECT.md, REQUIREMENTS.md, ROADMAP.md, RESEARCH.md, DISCUSS.md, PLAN.md, STATE.md, VERIFY.md at appropriate state transitions. Readers for context packet assembly.

**Discussion system** — `planning_discussions` table with structured questions (options, recommendations, decisions). Full CRUD in store, orchestrator methods for the complete discussion flow. DISCUSS.md captures all decisions per phase.

**Schema migration v26** — Recreates `planning_projects` table (adds `discussing` to CHECK constraint + `project_dir` column). Creates `planning_discussions` table.

### Tests

198 dianoia tests pass (was 193 — added 5 for discussing state). Zero type errors.

### What's Next

- Phase 2: Sub-agent context engineering (ContextPacketBuilder, model selection, orchestrator stays under 40k tokens)
- Phase 3: Planning UI (milestone timeline, decision cards, mode shift)
- Phase 4: Verification + learning