### PR TITLE
feat(dianoia): v2 Phase 2 — context packet builder + model selection

### DIFF
--- a/infrastructure/runtime/src/aletheia.ts
+++ b/infrastructure/runtime/src/aletheia.ts
@@ -385,17 +385,20 @@ export function createRuntime(configPath?: string): AletheiaRuntime {
 
   // Planning roadmap orchestrator — wired after dispatchTool is available
   const roadmapOrchestrator = new RoadmapOrchestrator(store.getDb(), dispatchTool);
+  roadmapOrchestrator.setWorkspaceRoot(defaultWorkspace);
   const planRoadmapTool = createPlanRoadmapTool(planningOrchestrator, roadmapOrchestrator);
   tools.register(planRoadmapTool);
 
   // Planning execution orchestrator — wired after dispatchTool is available
   const executionOrchestrator = new ExecutionOrchestrator(store.getDb(), dispatchTool);
+  executionOrchestrator.setWorkspaceRoot(defaultWorkspace);
   const planExecuteTool = createPlanExecuteTool(planningOrchestrator, executionOrchestrator);
   tools.register(planExecuteTool);
   manager.setExecutionOrchestrator(executionOrchestrator);
 
   // Planning verifier and checkpoint system — wired after executionOrchestrator
   const verifierOrchestrator = new GoalBackwardVerifier(store.getDb(), dispatchTool);
+  verifierOrchestrator.setWorkspaceRoot(defaultWorkspace);
   const checkpointSystem = new CheckpointSystem(planningStore, planningConfig);
   const planVerifyTool = createPlanVerifyTool(
     planningOrchestrator,

--- a/infrastructure/runtime/src/dianoia/context-packet.test.ts
+++ b/infrastructure/runtime/src/dianoia/context-packet.test.ts
@@ -1,0 +1,344 @@
+// Tests for ContextPacketBuilder (Spec 32 Phase 2)
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdirSync, writeFileSync, rmSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  buildContextPacket,
+  selectModelForRole,
+  modelTierToRole,
+  type SubAgentRole,
+} from "./context-packet.js";
+import {
+  ensureProjectDir,
+  ensurePhaseDir,
+  writeProjectFile,
+  writeRequirementsFile,
+  writeRoadmapFile,
+  writeDiscussFile,
+  writePlanFile,
+} from "./project-files.js";
+import type { PlanningPhase, PlanningRequirement } from "./types.js";
+
+const TEST_PROJECT_ID = "proj_test123";
+const TEST_PHASE_ID = "phase_test456";
+
+let workspaceRoot: string;
+
+function makePhase(overrides?: Partial<PlanningPhase>): PlanningPhase {
+  return {
+    id: TEST_PHASE_ID,
+    projectId: TEST_PROJECT_ID,
+    name: "Authentication",
+    goal: "Implement OAuth2 login with Google and GitHub providers",
+    requirements: ["AUTH-01", "AUTH-02"],
+    successCriteria: [
+      "Users can log in via Google OAuth",
+      "Users can log in via GitHub OAuth",
+      "Sessions persist across page refreshes",
+    ],
+    plan: { steps: [{ id: "s1", description: "Wire OAuth", subtasks: [], dependsOn: [] }] },
+    status: "pending",
+    phaseOrder: 0,
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function makeRequirement(overrides?: Partial<PlanningRequirement>): PlanningRequirement {
+  return {
+    id: "req_1",
+    projectId: TEST_PROJECT_ID,
+    phaseId: null,
+    reqId: "AUTH-01",
+    description: "OAuth2 login with Google",
+    category: "AUTH",
+    tier: "v1",
+    status: "pending",
+    rationale: null,
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  workspaceRoot = join(tmpdir(), `dianoia-ctx-test-${Date.now()}`);
+  mkdirSync(workspaceRoot, { recursive: true });
+});
+
+afterEach(() => {
+  if (existsSync(workspaceRoot)) {
+    rmSync(workspaceRoot, { recursive: true, force: true });
+  }
+});
+
+describe("buildContextPacket", () => {
+  it("includes phase objective for executor role", () => {
+    const phase = makePhase();
+    const packet = buildContextPacket({
+      workspaceRoot,
+      projectId: TEST_PROJECT_ID,
+      phaseId: TEST_PHASE_ID,
+      role: "executor",
+      phase,
+      projectGoal: "Build a SaaS authentication system",
+    });
+
+    expect(packet).toContain("Phase Objective");
+    expect(packet).toContain("Authentication");
+    expect(packet).toContain("OAuth2 login");
+    expect(packet).toContain("Success Criteria");
+  });
+
+  it("includes project goal for verifier role", () => {
+    const phase = makePhase();
+    const packet = buildContextPacket({
+      workspaceRoot,
+      projectId: TEST_PROJECT_ID,
+      phaseId: TEST_PHASE_ID,
+      role: "verifier",
+      phase,
+      projectGoal: "Build a SaaS authentication system",
+    });
+
+    expect(packet).toContain("Project Goal");
+    expect(packet).toContain("SaaS authentication");
+  });
+
+  it("excludes project context for executor role", () => {
+    // Write a PROJECT.md so there's something to potentially include
+    ensureProjectDir(workspaceRoot, TEST_PROJECT_ID);
+    writeProjectFile(workspaceRoot, {
+      id: TEST_PROJECT_ID,
+      nousId: "test",
+      sessionId: "test",
+      goal: "Big project",
+      state: "executing",
+      config: {} as any,
+      contextHash: "",
+      projectDir: null,
+      createdAt: "2026-01-01",
+      updatedAt: "2026-01-01",
+      projectContext: { goal: "Big project context" },
+    });
+
+    const phase = makePhase();
+    const packet = buildContextPacket({
+      workspaceRoot,
+      projectId: TEST_PROJECT_ID,
+      phaseId: TEST_PHASE_ID,
+      role: "executor",
+      phase,
+      projectGoal: "Big project",
+    });
+
+    // Executor should NOT include full project context
+    expect(packet).not.toContain("Project Context");
+  });
+
+  it("includes discussion decisions for executor role", () => {
+    ensurePhaseDir(workspaceRoot, TEST_PROJECT_ID, TEST_PHASE_ID);
+    writeDiscussFile(workspaceRoot, TEST_PROJECT_ID, TEST_PHASE_ID, [
+      {
+        id: "disc_1",
+        projectId: TEST_PROJECT_ID,
+        phaseId: TEST_PHASE_ID,
+        question: "Should we use PKCE or implicit flow?",
+        options: [
+          { label: "PKCE", rationale: "More secure" },
+          { label: "Implicit", rationale: "Simpler" },
+        ],
+        recommendation: "PKCE",
+        decision: "PKCE",
+        userNote: "Always prefer security",
+        status: "answered",
+        createdAt: "2026-01-01",
+        updatedAt: "2026-01-01",
+      },
+    ]);
+
+    const phase = makePhase();
+    const packet = buildContextPacket({
+      workspaceRoot,
+      projectId: TEST_PROJECT_ID,
+      phaseId: TEST_PHASE_ID,
+      role: "executor",
+      phase,
+    });
+
+    expect(packet).toContain("Design Decisions");
+    expect(packet).toContain("PKCE");
+  });
+
+  it("includes requirements for executor role", () => {
+    const phase = makePhase();
+    const reqs = [
+      makeRequirement({ reqId: "AUTH-01", description: "Google OAuth login" }),
+      makeRequirement({ reqId: "AUTH-02", description: "GitHub OAuth login", id: "req_2" }),
+    ];
+
+    const packet = buildContextPacket({
+      workspaceRoot,
+      projectId: TEST_PROJECT_ID,
+      phaseId: TEST_PHASE_ID,
+      role: "executor",
+      phase,
+      requirements: reqs,
+    });
+
+    expect(packet).toContain("Requirements");
+    expect(packet).toContain("AUTH-01");
+    expect(packet).toContain("AUTH-02");
+    expect(packet).toContain("Google OAuth");
+  });
+
+  it("includes roadmap overview for planner role", () => {
+    const phases = [
+      makePhase({ id: "p1", name: "Auth", phaseOrder: 0 }),
+      makePhase({ id: "p2", name: "API", phaseOrder: 1, goal: "Build REST API" }),
+      makePhase({ id: "p3", name: "UI", phaseOrder: 2, goal: "Build frontend" }),
+    ];
+
+    const packet = buildContextPacket({
+      workspaceRoot,
+      projectId: TEST_PROJECT_ID,
+      phaseId: "p1",
+      role: "planner",
+      phase: phases[0],
+      allPhases: phases,
+      projectGoal: "Full-stack app",
+    });
+
+    expect(packet).toContain("Roadmap Overview");
+    expect(packet).toContain("Auth");
+    expect(packet).toContain("API");
+    expect(packet).toContain("UI");
+  });
+
+  it("excludes roadmap for executor role", () => {
+    const phases = [
+      makePhase({ id: "p1", name: "Auth", phaseOrder: 0 }),
+      makePhase({ id: "p2", name: "API", phaseOrder: 1 }),
+    ];
+
+    const packet = buildContextPacket({
+      workspaceRoot,
+      projectId: TEST_PROJECT_ID,
+      phaseId: "p1",
+      role: "executor",
+      phase: phases[0],
+      allPhases: phases,
+    });
+
+    expect(packet).not.toContain("Roadmap Overview");
+  });
+
+  it("respects token budget and truncates lower-priority sections", () => {
+    const longSupplementary = "x".repeat(5000);
+    const phase = makePhase();
+
+    const packet = buildContextPacket({
+      workspaceRoot,
+      projectId: TEST_PROJECT_ID,
+      phaseId: TEST_PHASE_ID,
+      role: "executor",
+      phase,
+      supplementary: longSupplementary,
+      maxTokens: 500, // Very tight budget: 2000 chars
+    });
+
+    // Should have phase objective (priority 0) but may truncate supplementary
+    expect(packet).toContain("Phase Objective");
+    expect(packet.length).toBeLessThanOrEqual(2100); // ~500 tokens * 4 chars + buffer
+  });
+
+  it("includes supplementary context for executor role", () => {
+    const phase = makePhase();
+    const packet = buildContextPacket({
+      workspaceRoot,
+      projectId: TEST_PROJECT_ID,
+      phaseId: TEST_PHASE_ID,
+      role: "executor",
+      phase,
+      supplementary: "// src/auth/oauth.ts\nexport function authenticate() { ... }",
+    });
+
+    expect(packet).toContain("Reference Material");
+    expect(packet).toContain("oauth.ts");
+  });
+
+  it("returns empty string when no sections match", () => {
+    const packet = buildContextPacket({
+      workspaceRoot,
+      projectId: TEST_PROJECT_ID,
+      phaseId: null,
+      role: "researcher",
+      // No projectGoal, no supplementary, no files
+    });
+
+    expect(packet).toBe("");
+  });
+
+  it("reads from file-backed plan when no in-memory plan", () => {
+    ensurePhaseDir(workspaceRoot, TEST_PROJECT_ID, TEST_PHASE_ID);
+    writePlanFile(workspaceRoot, TEST_PROJECT_ID, TEST_PHASE_ID, {
+      steps: [{ id: "s1", description: "Do the thing" }],
+    });
+
+    const phase = makePhase({ plan: null }); // No in-memory plan
+    const packet = buildContextPacket({
+      workspaceRoot,
+      projectId: TEST_PROJECT_ID,
+      phaseId: TEST_PHASE_ID,
+      role: "executor",
+      phase,
+    });
+
+    expect(packet).toContain("Execution Plan");
+    expect(packet).toContain("Do the thing");
+  });
+
+  it("includes research for planner role", () => {
+    ensureProjectDir(workspaceRoot, TEST_PROJECT_ID);
+    const dir = join(workspaceRoot, ".dianoia", "projects", TEST_PROJECT_ID);
+    writeFileSync(
+      join(dir, "RESEARCH.md"),
+      "# Research\n\n## stack (complete)\n\nUse TypeScript with Fastify.\n",
+      "utf-8",
+    );
+
+    const phase = makePhase();
+    const packet = buildContextPacket({
+      workspaceRoot,
+      projectId: TEST_PROJECT_ID,
+      phaseId: TEST_PHASE_ID,
+      role: "planner",
+      phase,
+      projectGoal: "Build API",
+    });
+
+    expect(packet).toContain("Research Findings");
+    expect(packet).toContain("TypeScript with Fastify");
+  });
+});
+
+describe("selectModelForRole", () => {
+  it("returns sonnet for all current roles", () => {
+    const roles: SubAgentRole[] = ["researcher", "planner", "executor", "reviewer", "verifier"];
+    for (const role of roles) {
+      expect(selectModelForRole(role)).toBe("sonnet");
+    }
+  });
+});
+
+describe("modelTierToRole", () => {
+  it("maps haiku to explorer", () => {
+    expect(modelTierToRole("haiku")).toBe("explorer");
+  });
+
+  it("maps sonnet to coder", () => {
+    expect(modelTierToRole("sonnet")).toBe("coder");
+  });
+});

--- a/infrastructure/runtime/src/dianoia/context-packet.ts
+++ b/infrastructure/runtime/src/dianoia/context-packet.ts
@@ -1,0 +1,383 @@
+// ContextPacketBuilder — assembles scoped context packets for sub-agent dispatches (Spec 32 Phase 2)
+//
+// Problem: Sub-agents currently receive minimal prompts (goal + criteria + raw JSON plan).
+// The orchestrator burns 100k+ tokens synthesizing context that never reaches the executor.
+//
+// Solution: File-backed state from Phase 1 feeds a ContextPacketBuilder that reads only
+// what's relevant per dispatch role, trims to a token budget, and returns a self-contained
+// context string that starts at token 1 with exactly what the sub-agent needs.
+
+import { createLogger } from "../koina/logger.js";
+import {
+  readProjectFile,
+  readRequirementsFile,
+  readRoadmapFile,
+  readResearchFile,
+  readDiscussFile,
+  readPlanFile,
+} from "./project-files.js";
+import type { PlanningPhase, PlanningRequirement } from "./types.js";
+
+const log = createLogger("dianoia:context-packet");
+
+// Rough token estimation: ~4 chars per token for English text
+const CHARS_PER_TOKEN = 4;
+
+export type SubAgentRole =
+  | "researcher"   // Domain research phase
+  | "planner"      // Roadmap generation and phase planning
+  | "executor"     // Phase execution (implementation)
+  | "reviewer"     // Plan checking and verification
+  | "verifier";    // Goal-backward verification
+
+export interface ContextPacketOptions {
+  /** Workspace root for file reads */
+  workspaceRoot: string;
+  /** Project ID */
+  projectId: string;
+  /** Phase ID (null for project-level dispatches like roadmap generation) */
+  phaseId: string | null;
+  /** Role determines which sections are included and prioritized */
+  role: SubAgentRole;
+  /** Maximum tokens for the context packet (default: 8000) */
+  maxTokens?: number;
+  /** Phase object with goal/criteria/plan (avoids re-reading from DB) */
+  phase?: PlanningPhase | null;
+  /** All phases for roadmap context */
+  allPhases?: PlanningPhase[];
+  /** Filtered requirements relevant to this phase */
+  requirements?: PlanningRequirement[];
+  /** Project goal string */
+  projectGoal?: string;
+  /** Additional context to append (e.g., codebase excerpts) */
+  supplementary?: string;
+}
+
+interface ContextSection {
+  /** Header for the section */
+  header: string;
+  /** Content to include */
+  content: string;
+  /** Priority (lower = included first). Sections are included in priority order until budget exhausted. */
+  priority: number;
+}
+
+/** Role-based section inclusion matrix */
+const ROLE_SECTIONS: Record<SubAgentRole, {
+  includeProject: boolean;
+  includeRequirements: boolean;
+  includeRoadmap: boolean;
+  includeResearch: boolean;
+  includeDiscussion: boolean;
+  includePlan: boolean;
+  includePhaseGoal: boolean;
+  includeSupplementary: boolean;
+}> = {
+  researcher: {
+    includeProject: true,
+    includeRequirements: false,
+    includeRoadmap: false,
+    includeResearch: false,    // Previous research — not needed for new research
+    includeDiscussion: false,
+    includePlan: false,
+    includePhaseGoal: false,
+    includeSupplementary: true,
+  },
+  planner: {
+    includeProject: true,
+    includeRequirements: true,
+    includeRoadmap: true,       // Previous phases for dependency awareness
+    includeResearch: true,
+    includeDiscussion: true,
+    includePlan: false,
+    includePhaseGoal: true,
+    includeSupplementary: false,
+  },
+  executor: {
+    includeProject: false,       // Executor doesn't need full project context
+    includeRequirements: true,   // Only phase-scoped requirements
+    includeRoadmap: false,
+    includeResearch: false,
+    includeDiscussion: true,     // Decisions constrain implementation
+    includePlan: true,           // The actual plan to execute
+    includePhaseGoal: true,
+    includeSupplementary: true,  // Codebase excerpts, file contents
+  },
+  reviewer: {
+    includeProject: false,
+    includeRequirements: true,
+    includeRoadmap: false,
+    includeResearch: false,
+    includeDiscussion: true,
+    includePlan: true,
+    includePhaseGoal: true,
+    includeSupplementary: false,
+  },
+  verifier: {
+    includeProject: true,        // Needs full project goal for goal-backward check
+    includeRequirements: true,
+    includeRoadmap: true,        // Needs to see phase in context of whole
+    includeResearch: false,
+    includeDiscussion: true,     // Decisions inform what "met" means
+    includePlan: true,
+    includePhaseGoal: true,
+    includeSupplementary: true,  // Implementation artifacts to verify against
+  },
+};
+
+/**
+ * Build a scoped context packet for a sub-agent dispatch.
+ *
+ * Reads from file-backed state (Phase 1), filters by role, trims to token budget.
+ * The resulting string is self-contained — the sub-agent needs nothing else.
+ */
+export function buildContextPacket(opts: ContextPacketOptions): string {
+  const maxTokens = opts.maxTokens ?? 8000;
+  const maxChars = maxTokens * CHARS_PER_TOKEN;
+  const config = ROLE_SECTIONS[opts.role];
+  const sections: ContextSection[] = [];
+
+  // Priority 0: Phase goal and success criteria (always highest priority when available)
+  if (config.includePhaseGoal && opts.phase) {
+    const lines = [
+      `**Phase:** ${opts.phase.name}`,
+      `**Goal:** ${opts.phase.goal}`,
+    ];
+    if (opts.phase.successCriteria.length > 0) {
+      lines.push("", "**Success Criteria:**");
+      for (const c of opts.phase.successCriteria) {
+        lines.push(`- ${c}`);
+      }
+    }
+    sections.push({ header: "Phase Objective", content: lines.join("\n"), priority: 0 });
+  }
+
+  // Priority 1: Project goal (brief — just the goal, not full PROJECT.md)
+  if (opts.projectGoal) {
+    sections.push({ header: "Project Goal", content: opts.projectGoal, priority: 1 });
+  }
+
+  // Priority 2: Plan (for executor/reviewer/verifier)
+  if (config.includePlan && opts.phaseId) {
+    const plan = readPlanFile(opts.workspaceRoot, opts.projectId, opts.phaseId);
+    if (plan) {
+      sections.push({ header: "Execution Plan", content: plan, priority: 2 });
+    } else if (opts.phase?.plan) {
+      // Fallback to in-memory plan
+      const planStr = typeof opts.phase.plan === "string"
+        ? opts.phase.plan
+        : JSON.stringify(opts.phase.plan, null, 2);
+      sections.push({ header: "Execution Plan", content: planStr, priority: 2 });
+    }
+  }
+
+  // Priority 3: Discussion decisions (constrain what's acceptable)
+  if (config.includeDiscussion && opts.phaseId) {
+    const discuss = readDiscussFile(opts.workspaceRoot, opts.projectId, opts.phaseId);
+    if (discuss) {
+      sections.push({ header: "Design Decisions", content: discuss, priority: 3 });
+    }
+  }
+
+  // Priority 4: Requirements (phase-scoped if available)
+  if (config.includeRequirements) {
+    if (opts.requirements && opts.requirements.length > 0) {
+      const lines = formatRequirements(opts.requirements);
+      sections.push({ header: "Requirements", content: lines, priority: 4 });
+    } else {
+      const reqFile = readRequirementsFile(opts.workspaceRoot, opts.projectId);
+      if (reqFile) {
+        // If we have a phase, filter to relevant requirements
+        const filtered = opts.phase
+          ? filterRequirementsToPhase(reqFile, opts.phase.requirements)
+          : reqFile;
+        sections.push({ header: "Requirements", content: filtered, priority: 4 });
+      }
+    }
+  }
+
+  // Priority 5: Supplementary context (codebase, implementation artifacts)
+  if (config.includeSupplementary && opts.supplementary) {
+    sections.push({ header: "Reference Material", content: opts.supplementary, priority: 5 });
+  }
+
+  // Priority 6: Roadmap (for planners and verifiers — phase ordering context)
+  if (config.includeRoadmap) {
+    if (opts.allPhases && opts.allPhases.length > 0) {
+      const lines = formatRoadmapSummary(opts.allPhases);
+      sections.push({ header: "Roadmap Overview", content: lines, priority: 6 });
+    } else {
+      const roadmap = readRoadmapFile(opts.workspaceRoot, opts.projectId);
+      if (roadmap) {
+        sections.push({ header: "Roadmap Overview", content: roadmap, priority: 6 });
+      }
+    }
+  }
+
+  // Priority 7: Research findings
+  if (config.includeResearch) {
+    const research = readResearchFile(opts.workspaceRoot, opts.projectId);
+    if (research) {
+      sections.push({ header: "Research Findings", content: research, priority: 7 });
+    }
+  }
+
+  // Priority 8: Full project context (lowest priority — only if budget allows)
+  if (config.includeProject) {
+    const projectMd = readProjectFile(opts.workspaceRoot, opts.projectId);
+    if (projectMd) {
+      sections.push({ header: "Project Context", content: projectMd, priority: 8 });
+    }
+  }
+
+  // Assemble sections in priority order, respecting token budget
+  return assembleSections(sections, maxChars);
+}
+
+/**
+ * Assemble sections in priority order, truncating to fit budget.
+ * Final section may be truncated mid-content if budget is tight.
+ */
+function assembleSections(sections: ContextSection[], maxChars: number): string {
+  // Sort by priority (lower = first)
+  const sorted = [...sections].sort((a, b) => a.priority - b.priority);
+
+  const parts: string[] = [];
+  let currentChars = 0;
+
+  for (const section of sorted) {
+    const sectionText = `## ${section.header}\n\n${section.content}\n\n`;
+    const sectionChars = sectionText.length;
+
+    if (currentChars + sectionChars <= maxChars) {
+      // Fits entirely
+      parts.push(sectionText);
+      currentChars += sectionChars;
+    } else {
+      // Partial fit — truncate and add ellipsis
+      const remaining = maxChars - currentChars;
+      if (remaining > 100) {
+        // Only include if we can fit a meaningful chunk
+        const truncated = sectionText.slice(0, remaining - 20) + "\n\n[...truncated]";
+        parts.push(truncated);
+        currentChars = maxChars;
+      }
+      break;
+    }
+  }
+
+  const result = parts.join("").trim();
+  const estimatedTokens = Math.ceil(result.length / CHARS_PER_TOKEN);
+  log.debug(`Context packet assembled: ${sorted.length} sections, ~${estimatedTokens} tokens`, {
+    includedSections: sorted.map((s) => s.header),
+  });
+
+  return result;
+}
+
+/**
+ * Format requirements as a compact table for context packets.
+ */
+function formatRequirements(requirements: PlanningRequirement[]): string {
+  if (requirements.length === 0) return "(none)";
+
+  const lines = ["| ID | Description | Tier |", "|-----|-------------|------|"];
+  for (const req of requirements) {
+    lines.push(`| ${req.reqId} | ${req.description} | ${req.tier} |`);
+  }
+  return lines.join("\n");
+}
+
+/**
+ * Filter a full REQUIREMENTS.md string to only lines containing the given req IDs.
+ * Falls back to full content if filtering would lose everything.
+ */
+function filterRequirementsToPhase(reqMarkdown: string, phaseReqIds: string[]): string {
+  if (phaseReqIds.length === 0) return reqMarkdown;
+
+  const lines = reqMarkdown.split("\n");
+  const filtered: string[] = [];
+  let inHeader = true;
+
+  for (const line of lines) {
+    // Keep headers and table structure
+    if (line.startsWith("# ") || line.startsWith("## ") || line.startsWith("|---")) {
+      filtered.push(line);
+      inHeader = false;
+      continue;
+    }
+    // Keep table header rows
+    if (inHeader || line.startsWith("| ID")) {
+      filtered.push(line);
+      continue;
+    }
+    // Keep rows that contain any of our phase req IDs
+    if (phaseReqIds.some((id) => line.includes(id))) {
+      filtered.push(line);
+    }
+  }
+
+  // If we filtered everything meaningful, return the original
+  const meaningful = filtered.filter((l) => l.startsWith("| ") && !l.startsWith("|---"));
+  if (meaningful.length <= 1) return reqMarkdown; // Only header row left
+
+  return filtered.join("\n");
+}
+
+/**
+ * Format a compact roadmap summary from phase objects.
+ */
+function formatRoadmapSummary(phases: PlanningPhase[]): string {
+  const lines: string[] = [];
+  for (const phase of phases) {
+    const status = phase.status === "complete" ? "✅" :
+      phase.status === "executing" ? "🔄" :
+      phase.status === "failed" ? "❌" :
+      phase.status === "skipped" ? "⏭" : "⬜";
+    lines.push(`${status} **Phase ${phase.phaseOrder + 1}: ${phase.name}** — ${phase.goal}`);
+    if (phase.requirements.length > 0) {
+      lines.push(`  Requirements: ${phase.requirements.join(", ")}`);
+    }
+  }
+  return lines.join("\n");
+}
+
+/**
+ * Select the appropriate model tier for a sub-agent role and task complexity.
+ *
+ * Model selection strategy:
+ * - Haiku: exploration, read-only queries, simple validation (cheap + fast)
+ * - Sonnet: implementation, code generation, plan creation (capable + cost-effective)
+ * - Opus: architecture decisions, complex tradeoffs, judgment calls (never used for sub-agents — that's the orchestrator)
+ */
+export type ModelTier = "haiku" | "sonnet";
+
+export function selectModelForRole(role: SubAgentRole): ModelTier {
+  switch (role) {
+    case "researcher":
+      return "sonnet";     // Research needs reasoning about domain
+    case "planner":
+      return "sonnet";     // Plan generation needs structured thinking
+    case "executor":
+      return "sonnet";     // Code generation needs capability
+    case "reviewer":
+      return "sonnet";     // Review needs judgment
+    case "verifier":
+      return "sonnet";     // Verification needs reasoning
+    default:
+      return "sonnet";
+  }
+}
+
+/**
+ * Maps our model tier to the actual model ID used in dispatch.
+ * Uses the same role strings that sessions_spawn understands.
+ */
+export function modelTierToRole(tier: ModelTier): "coder" | "reviewer" | "researcher" | "explorer" | "runner" {
+  switch (tier) {
+    case "haiku":
+      return "explorer";   // Haiku-backed roles
+    case "sonnet":
+      return "coder";      // Sonnet-backed roles
+  }
+}

--- a/infrastructure/runtime/src/dianoia/execution.ts
+++ b/infrastructure/runtime/src/dianoia/execution.ts
@@ -5,6 +5,7 @@ import type { ToolContext, ToolHandler } from "../organon/registry.js";
 import { PlanningStore } from "./store.js";
 import type { PlanningPhase, SpawnRecord } from "./types.js";
 import type { PhasePlan } from "./roadmap.js";
+import { buildContextPacket, selectModelForRole, modelTierToRole } from "./context-packet.js";
 
 const log = createLogger("dianoia:execution");
 const ZOMBIE_THRESHOLD_SECONDS = 600; // 2x default 300s plan timeout
@@ -70,12 +71,18 @@ export function findResumeWave(records: SpawnRecord[]): number {
 
 export class ExecutionOrchestrator {
   private store: PlanningStore;
+  private workspaceRoot: string | null = null;
 
   constructor(
     db: Database.Database,
     private dispatchTool: ToolHandler,
   ) {
     this.store = new PlanningStore(db);
+  }
+
+  /** Set workspace root for context packet assembly from file-backed state */
+  setWorkspaceRoot(root: string): void {
+    this.workspaceRoot = root;
   }
 
   async executePhase(
@@ -136,11 +143,32 @@ export class ExecutionOrchestrator {
         spawnIds.push(record.id);
       }
 
-      const tasks = activePlans.map((plan) => ({
-        role: "coder" as const,
-        task: buildExecutionPrompt(plan, project.goal),
-        timeoutSeconds: 300,
-      }));
+      const modelTier = selectModelForRole("executor");
+      const role = modelTierToRole(modelTier);
+
+      const tasks = activePlans.map((plan) => {
+        // Build scoped context packet from file-backed state
+        const contextPacket = this.workspaceRoot
+          ? buildContextPacket({
+              workspaceRoot: this.workspaceRoot,
+              projectId,
+              phaseId: plan.id,
+              role: "executor",
+              phase: plan,
+              projectGoal: project.goal,
+              requirements: this.store
+                .listRequirements(projectId)
+                .filter((r) => r.tier === "v1" && plan.requirements.includes(r.reqId)),
+              maxTokens: 12000,
+            })
+          : buildExecutionPrompt(plan, project.goal); // Fallback if no workspace
+
+        return {
+          role: role as "coder",
+          task: contextPacket,
+          timeoutSeconds: 300,
+        };
+      });
 
       let output: {
         results: Array<{ status: string; result?: string; error?: string; durationMs: number }>;

--- a/infrastructure/runtime/src/dianoia/index.ts
+++ b/infrastructure/runtime/src/dianoia/index.ts
@@ -51,3 +51,7 @@ export {
   readDiscussFile,
   readPlanFile,
 } from "./project-files.js";
+
+// Context engineering (Spec 32 Phase 2)
+export { buildContextPacket, selectModelForRole, modelTierToRole } from "./context-packet.js";
+export type { SubAgentRole, ContextPacketOptions, ModelTier } from "./context-packet.js";

--- a/infrastructure/runtime/src/dianoia/roadmap.ts
+++ b/infrastructure/runtime/src/dianoia/roadmap.ts
@@ -6,6 +6,7 @@ import { PlanningError } from "../koina/errors.js";
 import { PlanningStore } from "./store.js";
 import { transition } from "./machine.js";
 import type { PlanningPhase } from "./types.js";
+import { buildContextPacket } from "./context-packet.js";
 
 const log = createLogger("dianoia:roadmap");
 
@@ -46,12 +47,18 @@ interface DispatchOutput {
 
 export class RoadmapOrchestrator {
   private store: PlanningStore;
+  private workspaceRoot: string | null = null;
 
   constructor(
     private db: Database.Database,
     private dispatchTool: ToolHandler,
   ) {
     this.store = new PlanningStore(db);
+  }
+
+  /** Set workspace root for context packet assembly from file-backed state */
+  setWorkspaceRoot(root: string): void {
+    this.workspaceRoot = root;
   }
 
   async generateRoadmap(
@@ -215,7 +222,7 @@ export class RoadmapOrchestrator {
     const depth = project.config.depth ?? "standard";
     const depthInstruction = this.depthToInstruction(depth);
 
-    let plan = await this.generatePlanForPhase(phase, depthInstruction, toolContext);
+    let plan = await this.generatePlanForPhase(phase, depthInstruction, toolContext, projectId, project.goal);
 
     if (config.plan_check === true) {
       for (let attempt = 1; attempt <= MAX_ITERATIONS; attempt++) {
@@ -291,14 +298,37 @@ export class RoadmapOrchestrator {
     phase: PlanningPhase,
     depthInstruction: string,
     toolContext: ToolContext,
+    projectId?: string,
+    projectGoal?: string,
   ): Promise<PhasePlan> {
+    // Build context packet from file-backed state if available
+    let contextSection = "";
+    if (this.workspaceRoot && projectId) {
+      const allPhases = this.store.listPhases(projectId);
+      contextSection = buildContextPacket({
+        workspaceRoot: this.workspaceRoot,
+        projectId,
+        phaseId: phase.id,
+        role: "planner",
+        phase,
+        allPhases,
+        projectGoal: projectGoal ?? "",
+        requirements: this.store
+          .listRequirements(projectId)
+          .filter((r) => r.tier === "v1" && phase.requirements.includes(r.reqId)),
+        maxTokens: 10000,
+      });
+    }
+
     const task = {
       role: "planner",
       task: [
         `Generate an implementation plan for this phase: "${phase.name}"`,
-        `Goal: ${phase.goal}`,
-        `Requirements to cover: ${phase.requirements.join(", ") || "(none)"}`,
-        `Success criteria: ${phase.successCriteria.join("; ") || "(none)"}`,
+        ...(contextSection ? ["", contextSection] : [
+          `Goal: ${phase.goal}`,
+          `Requirements to cover: ${phase.requirements.join(", ") || "(none)"}`,
+          `Success criteria: ${phase.successCriteria.join("; ") || "(none)"}`,
+        ]),
         "",
         depthInstruction,
         "",

--- a/infrastructure/runtime/src/dianoia/verifier.test.ts
+++ b/infrastructure/runtime/src/dianoia/verifier.test.ts
@@ -132,12 +132,12 @@ describe("GoalBackwardVerifier.verify — verifier enabled, phase met", () => {
     expect(result.verifiedAt).toBeDefined();
     expect((mockDispatch as { execute: ReturnType<typeof vi.fn> }).execute).toHaveBeenCalledOnce();
 
-    // Dispatch payload contains phase goal and success criteria
+    // Dispatch payload contains phase goal and success criteria (now in task field via context packet)
     const dispatchCall = (mockDispatch as { execute: ReturnType<typeof vi.fn> }).execute.mock.calls[0]!;
     const dispatchInput = dispatchCall[0] as Record<string, unknown>;
-    const tasks = dispatchInput["tasks"] as Array<{ context: string }>;
-    expect(tasks[0]?.context).toContain("implement authentication");
-    expect(tasks[0]?.context).toContain("Users can login");
+    const tasks = dispatchInput["tasks"] as Array<{ task: string }>;
+    expect(tasks[0]?.task).toContain("implement authentication");
+    expect(tasks[0]?.task).toContain("Users can login");
 
     // Side effect: persisted
     const updated = store.getPhaseOrThrow(phase.id);

--- a/infrastructure/runtime/src/dianoia/verifier.ts
+++ b/infrastructure/runtime/src/dianoia/verifier.ts
@@ -6,6 +6,7 @@ import type { ToolContext, ToolHandler } from "../organon/registry.js";
 import { PlanningStore } from "./store.js";
 import type { PlanningProject, VerificationGap, VerificationResult } from "./types.js";
 import type { PhasePlan } from "./roadmap.js";
+import { buildContextPacket } from "./context-packet.js";
 
 const log = createLogger("dianoia:verifier");
 
@@ -27,12 +28,18 @@ interface DispatchOutput {
 
 export class GoalBackwardVerifier {
   private store: PlanningStore;
+  private workspaceRoot: string | null = null;
 
   constructor(
     db: Database.Database,
     private dispatchTool: ToolHandler,
   ) {
     this.store = new PlanningStore(db);
+  }
+
+  /** Set workspace root for context packet assembly from file-backed state */
+  setWorkspaceRoot(root: string): void {
+    this.workspaceRoot = root;
   }
 
   async verify(
@@ -88,21 +95,41 @@ export class GoalBackwardVerifier {
     toolContext: ToolContext,
   ): Promise<VerificationResult> {
     const phase = this.store.getPhaseOrThrow(phaseId);
+    const allPhases = this.store.listPhases(project.id);
 
-    const contextText = [
-      `Phase goal: ${phase.goal}`,
-      "",
-      `Success criteria:\n${phase.successCriteria.map((c, i) => `${i + 1}. ${c}`).join("\n")}`,
-      "",
-      `Project goal: ${project.goal}`,
-      "",
-      "Gaps must include criterion, found, expected, and proposedFix fields.",
-    ].join("\n");
+    // Build rich context packet from file-backed state
+    const contextPacket = this.workspaceRoot
+      ? buildContextPacket({
+          workspaceRoot: this.workspaceRoot,
+          projectId: project.id,
+          phaseId,
+          role: "verifier",
+          phase,
+          allPhases,
+          projectGoal: project.goal,
+          requirements: this.store
+            .listRequirements(project.id)
+            .filter((r) => r.tier === "v1" && phase.requirements.includes(r.reqId)),
+          maxTokens: 10000,
+        })
+      : [
+          `Phase goal: ${phase.goal}`,
+          "",
+          `Success criteria:\n${phase.successCriteria.map((c, i) => `${i + 1}. ${c}`).join("\n")}`,
+          "",
+          `Project goal: ${project.goal}`,
+        ].join("\n");
 
     const task = {
       role: "reviewer" as const,
-      task: "You are a goal-backward verifier. Given phase goal, success criteria, and artifacts list, report verification status as JSON with fields: status, summary, gaps[]",
-      context: contextText,
+      task: [
+        "You are a goal-backward verifier. Evaluate whether this phase's success criteria are met.",
+        "",
+        contextPacket,
+        "",
+        "Report as JSON: { status: 'met'|'partially-met'|'not-met', summary: string, gaps: Array<{ criterion, status, detail, proposedFix }> }",
+        "Each gap must include criterion (which criterion), status ('met'|'partially-met'|'not-met'), detail (evidence), and proposedFix (concrete next step).",
+      ].join("\n"),
       timeoutSeconds: 120,
     };
 


### PR DESCRIPTION
## Spec 32 — Dianoia v2 Phase 2

### What

Sub-agents were getting anemic context (just goal + criteria + raw JSON). Now every dispatch point builds a scoped context packet from file-backed state, filtered by role, trimmed to token budget.

### ContextPacketBuilder

Role-based section matrix determines what each sub-agent role receives:

| Section | Researcher | Planner | Executor | Reviewer | Verifier |
|---------|-----------|---------|----------|----------|----------|
| Phase objective | ❌ | ✅ | ✅ | ✅ | ✅ |
| Project goal | ✅ | ✅ | ❌ | ❌ | ✅ |
| Execution plan | ❌ | ❌ | ✅ | ✅ | ✅ |
| Design decisions | ❌ | ✅ | ✅ | ✅ | ✅ |
| Requirements | ❌ | ✅ | ✅ | ✅ | ✅ |
| Supplementary | ✅ | ❌ | ✅ | ❌ | ✅ |
| Roadmap | ❌ | ✅ | ❌ | ❌ | ✅ |
| Research | ❌ | ✅ | ❌ | ❌ | ❌ |

Sections are included in priority order (lower = first) until the token budget is exhausted. Phase objective is always priority 0 when present.

### Wiring

- **ExecutionOrchestrator** — executor context packets (12k token budget) replace `buildExecutionPrompt`
- **GoalBackwardVerifier** — verifier context packets (10k) replace minimal phase string
- **RoadmapOrchestrator** — planner context packets (10k) feed `generatePlanForPhase`
- **aletheia.ts** — `setWorkspaceRoot()` called for all three orchestrators

### Model Selection

`selectModelForRole()` + `modelTierToRole()` — currently all roles → Sonnet. Haiku reserved for future exploration/runner tasks.

### Tests

213/213 pass (15 new). Zero type errors.