### PR TITLE
feat(dianoia): v2 Phase 3 — plan_discuss tool

### DIFF
--- a/infrastructure/runtime/src/aletheia.ts
+++ b/infrastructure/runtime/src/aletheia.ts
@@ -52,7 +52,7 @@ import { createWorkspaceIndexTool } from "./organon/built-in/workspace-index.js"
 import { loadCustomCommands, registerCustomCommands } from "./organon/custom-commands.js";
 import { NousManager } from "./nous/manager.js";
 import { DianoiaOrchestrator } from "./dianoia/orchestrator.js";
-import { CheckpointSystem, createPlanCreateTool, createPlanExecuteTool, createPlanRequirementsTool, createPlanResearchTool, createPlanRoadmapTool, createPlanVerifyTool, ExecutionOrchestrator, GoalBackwardVerifier, PlanningStore, RequirementsOrchestrator, ResearchOrchestrator, RoadmapOrchestrator } from "./dianoia/index.js";
+import { CheckpointSystem, createPlanCreateTool, createPlanDiscussTool, createPlanExecuteTool, createPlanRequirementsTool, createPlanResearchTool, createPlanRoadmapTool, createPlanVerifyTool, ExecutionOrchestrator, GoalBackwardVerifier, PlanningStore, RequirementsOrchestrator, ResearchOrchestrator, RoadmapOrchestrator } from "./dianoia/index.js";
 import { McpClientManager } from "./organon/mcp-client.js";
 import { createGateway, type GatewayAuthDeps, setCommandsRef, setCronRef, setMcpRef, setSkillsRef, setWatchdogRef, startGateway } from "./pylon/server.js";
 import { AuthSessionStore } from "./auth/sessions.js";
@@ -388,6 +388,10 @@ export function createRuntime(configPath?: string): AletheiaRuntime {
   roadmapOrchestrator.setWorkspaceRoot(defaultWorkspace);
   const planRoadmapTool = createPlanRoadmapTool(planningOrchestrator, roadmapOrchestrator);
   tools.register(planRoadmapTool);
+
+  // Planning discussion tool — bridges 'discussing' state between roadmap and phase-planning
+  const planDiscussTool = createPlanDiscussTool(planningOrchestrator, store.getDb());
+  tools.register(planDiscussTool);
 
   // Planning execution orchestrator — wired after dispatchTool is available
   const executionOrchestrator = new ExecutionOrchestrator(store.getDb(), dispatchTool);

--- a/infrastructure/runtime/src/dianoia/discuss-tool.test.ts
+++ b/infrastructure/runtime/src/dianoia/discuss-tool.test.ts
@@ -1,0 +1,284 @@
+// Tests for plan_discuss tool (Spec 32 Phase 3)
+import Database from "better-sqlite3";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  PLANNING_V20_DDL,
+  PLANNING_V21_MIGRATION,
+  PLANNING_V22_MIGRATION,
+  PLANNING_V23_MIGRATION,
+  PLANNING_V24_MIGRATION,
+  PLANNING_V25_MIGRATION,
+  PLANNING_V26_MIGRATION,
+} from "./schema.js";
+import { PlanningStore } from "./store.js";
+import { DianoiaOrchestrator } from "./orchestrator.js";
+import { createPlanDiscussTool } from "./discuss-tool.js";
+import type { ToolContext, ToolHandler } from "../organon/registry.js";
+import type { PlanningConfigSchema } from "../taxis/schema.js";
+
+let db: Database.Database;
+let store: PlanningStore;
+let orchestrator: DianoiaOrchestrator;
+let tool: ToolHandler;
+
+const defaultConfig: PlanningConfigSchema = {
+  depth: "standard",
+  parallelization: false,
+  research: true,
+  plan_check: true,
+  verifier: true,
+  mode: "interactive",
+  pause_between_phases: false,
+};
+
+const toolContext = { nousId: "test-nous", sessionId: "test-session" } as ToolContext;
+
+function makeDb(): Database.Database {
+  const d = new Database(":memory:");
+  d.pragma("journal_mode = WAL");
+  d.pragma("foreign_keys = ON");
+  d.exec(PLANNING_V20_DDL);
+  d.exec(PLANNING_V21_MIGRATION);
+  d.exec(PLANNING_V22_MIGRATION);
+  d.exec(PLANNING_V23_MIGRATION);
+  d.exec(PLANNING_V24_MIGRATION);
+  d.exec(PLANNING_V25_MIGRATION);
+  d.exec(PLANNING_V26_MIGRATION);
+  return d;
+}
+
+function createTestProject(): { projectId: string; phaseId: string } {
+  const project = store.createProject({
+    nousId: "test-nous",
+    sessionId: "test-session",
+    goal: "Build auth system",
+    config: defaultConfig,
+  });
+  // Advance to discussing state
+  store.updateProjectState(project.id, "discussing");
+
+  const phase = store.createPhase({
+    projectId: project.id,
+    name: "Authentication",
+    goal: "Implement OAuth2",
+    requirements: ["AUTH-01", "AUTH-02"],
+    successCriteria: ["Users can login via Google", "Sessions persist"],
+    phaseOrder: 0,
+  });
+
+  return { projectId: project.id, phaseId: phase.id };
+}
+
+beforeEach(() => {
+  db = makeDb();
+  store = new PlanningStore(db);
+  orchestrator = new DianoiaOrchestrator(db, defaultConfig);
+  tool = createPlanDiscussTool(orchestrator, db);
+});
+
+afterEach(() => {
+  db.close();
+});
+
+describe("plan_discuss — generate", () => {
+  it("generates questions for a phase", async () => {
+    const { projectId, phaseId } = createTestProject();
+
+    const result = JSON.parse(
+      await tool.execute({ action: "generate", projectId, phaseId }, toolContext),
+    );
+
+    expect(result.generated).toBeGreaterThan(0);
+    expect(result.questions).toBeDefined();
+    expect(result.questions.length).toBeGreaterThan(0);
+    expect(result.questions[0]).toHaveProperty("id");
+    expect(result.questions[0]).toHaveProperty("question");
+    expect(result.questions[0]).toHaveProperty("options");
+  });
+
+  it("returns error without phaseId", async () => {
+    const { projectId } = createTestProject();
+
+    const result = JSON.parse(
+      await tool.execute({ action: "generate", projectId }, toolContext),
+    );
+
+    expect(result.error).toContain("phaseId required");
+  });
+});
+
+describe("plan_discuss — add", () => {
+  it("adds a custom question", async () => {
+    const { projectId, phaseId } = createTestProject();
+
+    const result = JSON.parse(
+      await tool.execute({
+        action: "add",
+        projectId,
+        phaseId,
+        question: "Should we use JWT or session cookies?",
+        options: [
+          { label: "JWT", rationale: "Stateless, works across services" },
+          { label: "Sessions", rationale: "Server-controlled, revocable" },
+        ],
+        recommendation: "JWT",
+      }, toolContext),
+    );
+
+    expect(result.questionId).toBeDefined();
+    expect(result.question).toBe("Should we use JWT or session cookies?");
+    expect(result.options).toHaveLength(2);
+    expect(result.recommendation).toBe("JWT");
+  });
+});
+
+describe("plan_discuss — answer", () => {
+  it("answers a question with decision and note", async () => {
+    const { projectId, phaseId } = createTestProject();
+
+    // Add a question first
+    const addResult = JSON.parse(
+      await tool.execute({
+        action: "add",
+        projectId,
+        phaseId,
+        question: "Test question?",
+        options: [{ label: "A", rationale: "Option A" }],
+      }, toolContext),
+    );
+
+    const result = JSON.parse(
+      await tool.execute({
+        action: "answer",
+        projectId,
+        questionId: addResult.questionId,
+        decision: "A",
+        userNote: "Because of X",
+      }, toolContext),
+    );
+
+    expect(result.answered).toBe(true);
+    expect(result.decision).toBe("A");
+  });
+
+  it("returns error without questionId", async () => {
+    const { projectId } = createTestProject();
+
+    const result = JSON.parse(
+      await tool.execute({ action: "answer", projectId, decision: "A" }, toolContext),
+    );
+
+    expect(result.error).toContain("questionId required");
+  });
+});
+
+describe("plan_discuss — skip", () => {
+  it("skips a question", async () => {
+    const { projectId, phaseId } = createTestProject();
+
+    const addResult = JSON.parse(
+      await tool.execute({
+        action: "add",
+        projectId,
+        phaseId,
+        question: "Skippable question?",
+        options: [],
+      }, toolContext),
+    );
+
+    const result = JSON.parse(
+      await tool.execute({
+        action: "skip",
+        projectId,
+        questionId: addResult.questionId,
+      }, toolContext),
+    );
+
+    expect(result.skipped).toBe(true);
+  });
+});
+
+describe("plan_discuss — list", () => {
+  it("lists questions with status breakdown", async () => {
+    const { projectId, phaseId } = createTestProject();
+
+    // Generate some questions
+    await tool.execute({ action: "generate", projectId, phaseId }, toolContext);
+
+    const result = JSON.parse(
+      await tool.execute({ action: "list", projectId, phaseId }, toolContext),
+    );
+
+    expect(result.total).toBeGreaterThan(0);
+    expect(result.pending).toBe(result.total); // All pending initially
+    expect(result.answered).toBe(0);
+    expect(result.skipped).toBe(0);
+    expect(result.questions).toBeDefined();
+  });
+});
+
+describe("plan_discuss — complete", () => {
+  it("completes discussion when all questions resolved", async () => {
+    const { projectId, phaseId } = createTestProject();
+
+    // Add and answer a question
+    const addResult = JSON.parse(
+      await tool.execute({
+        action: "add",
+        projectId,
+        phaseId,
+        question: "Approach?",
+        options: [{ label: "A", rationale: "Simple" }],
+      }, toolContext),
+    );
+
+    await tool.execute({
+      action: "answer",
+      projectId,
+      questionId: addResult.questionId,
+      decision: "A",
+    }, toolContext);
+
+    const result = JSON.parse(
+      await tool.execute({ action: "complete", projectId, phaseId }, toolContext),
+    );
+
+    expect(result.complete).toBe(true);
+    expect(result.nextState).toBe("phase-planning");
+
+    // Verify state advanced
+    const project = store.getProjectOrThrow(projectId);
+    expect(project.state).toBe("phase-planning");
+  });
+
+  it("blocks completion when pending questions exist", async () => {
+    const { projectId, phaseId } = createTestProject();
+
+    // Add a question but don't answer it
+    await tool.execute({
+      action: "add",
+      projectId,
+      phaseId,
+      question: "Unanswered?",
+      options: [],
+    }, toolContext);
+
+    const result = JSON.parse(
+      await tool.execute({ action: "complete", projectId, phaseId }, toolContext),
+    );
+
+    expect(result.error).toContain("Unresolved questions");
+    expect(result.pendingCount).toBe(1);
+  });
+
+  it("allows completion with no questions (fast-track)", async () => {
+    const { projectId, phaseId } = createTestProject();
+
+    // No questions added — should complete immediately
+    const result = JSON.parse(
+      await tool.execute({ action: "complete", projectId, phaseId }, toolContext),
+    );
+
+    expect(result.complete).toBe(true);
+  });
+});

--- a/infrastructure/runtime/src/dianoia/discuss-tool.ts
+++ b/infrastructure/runtime/src/dianoia/discuss-tool.ts
@@ -1,0 +1,288 @@
+// plan_discuss tool — manage per-phase discussion: generate, present, answer, skip, complete
+// This bridges the 'discussing' FSM state between roadmap and phase-planning.
+import { createLogger } from "../koina/logger.js";
+import type { ToolContext, ToolHandler } from "../organon/registry.js";
+import type { DianoiaOrchestrator } from "./orchestrator.js";
+import { PlanningStore } from "./store.js";
+import type Database from "better-sqlite3";
+
+const log = createLogger("dianoia:discuss-tool");
+
+export function createPlanDiscussTool(
+  orchestrator: DianoiaOrchestrator,
+  db: Database.Database,
+): ToolHandler {
+  const store = new PlanningStore(db);
+
+  return {
+    definition: {
+      name: "plan_discuss",
+      description:
+        "Manage the per-phase discussion flow. Generate gray-area questions, present them for decisions, " +
+        "collect answers, and complete the discussion to advance to phase planning.\n\n" +
+        "Actions:\n" +
+        "- generate: Auto-generate discussion questions for a phase based on requirements and context\n" +
+        "- list: Show all discussion questions for a phase\n" +
+        "- add: Manually add a discussion question\n" +
+        "- answer: Answer a specific question with a decision\n" +
+        "- skip: Skip a question (agent uses its recommendation)\n" +
+        "- complete: Finalize discussion and advance to phase planning",
+      input_schema: {
+        type: "object",
+        properties: {
+          action: {
+            type: "string",
+            enum: ["generate", "list", "add", "answer", "skip", "complete"],
+            description: "Action to perform",
+          },
+          projectId: {
+            type: "string",
+            description: "Active planning project ID",
+          },
+          phaseId: {
+            type: "string",
+            description: "Phase ID for the discussion",
+          },
+          questionId: {
+            type: "string",
+            description: "Discussion question ID (for answer/skip actions)",
+          },
+          question: {
+            type: "string",
+            description: "Question text (for add action)",
+          },
+          options: {
+            type: "array",
+            description: "Options for the question (for add action)",
+            items: {
+              type: "object",
+              properties: {
+                label: { type: "string" },
+                rationale: { type: "string" },
+              },
+              required: ["label", "rationale"],
+            },
+          },
+          recommendation: {
+            type: "string",
+            description: "Recommended option (for add action)",
+          },
+          decision: {
+            type: "string",
+            description: "Decision text (for answer action)",
+          },
+          userNote: {
+            type: "string",
+            description: "Optional note explaining the decision (for answer action)",
+          },
+        },
+        required: ["action", "projectId"],
+      },
+    },
+    async execute(input: Record<string, unknown>, context: ToolContext): Promise<string> {
+      const action = input["action"] as string;
+      const projectId = input["projectId"] as string;
+      const phaseId = input["phaseId"] as string | undefined;
+
+      try {
+        switch (action) {
+          case "generate": {
+            if (!phaseId) return JSON.stringify({ error: "phaseId required for generate" });
+            return handleGenerate(orchestrator, store, projectId, phaseId, context);
+          }
+
+          case "list": {
+            if (!phaseId) return JSON.stringify({ error: "phaseId required for list" });
+            return handleList(orchestrator, projectId, phaseId);
+          }
+
+          case "add": {
+            if (!phaseId) return JSON.stringify({ error: "phaseId required for add" });
+            const question = input["question"] as string;
+            if (!question) return JSON.stringify({ error: "question required for add" });
+            const options = (input["options"] as Array<{ label: string; rationale: string }>) ?? [];
+            const recommendation = (input["recommendation"] as string) ?? null;
+
+            const q = orchestrator.addDiscussionQuestion(projectId, phaseId, question, options, recommendation);
+            log.info(`Added discussion question ${q.id} for phase ${phaseId}`);
+            return JSON.stringify({
+              questionId: q.id,
+              question: q.question,
+              options: q.options,
+              recommendation: q.recommendation,
+              status: q.status,
+            });
+          }
+
+          case "answer": {
+            const questionId = input["questionId"] as string;
+            if (!questionId) return JSON.stringify({ error: "questionId required for answer" });
+            const decision = input["decision"] as string;
+            if (!decision) return JSON.stringify({ error: "decision required for answer" });
+            const userNote = (input["userNote"] as string) ?? null;
+
+            orchestrator.answerDiscussion(questionId, decision, userNote);
+            log.info(`Answered discussion question ${questionId}: ${decision}`);
+            return JSON.stringify({ answered: true, questionId, decision });
+          }
+
+          case "skip": {
+            const questionId = input["questionId"] as string;
+            if (!questionId) return JSON.stringify({ error: "questionId required for skip" });
+
+            orchestrator.skipDiscussion(questionId);
+            log.info(`Skipped discussion question ${questionId}`);
+            return JSON.stringify({ skipped: true, questionId });
+          }
+
+          case "complete": {
+            if (!phaseId) return JSON.stringify({ error: "phaseId required for complete" });
+
+            // Check all questions are resolved
+            const pending = orchestrator.getPendingDiscussions(projectId, phaseId);
+            if (pending.length > 0) {
+              return JSON.stringify({
+                error: "Unresolved questions remain",
+                pendingCount: pending.length,
+                pendingQuestions: pending.map((q) => ({ id: q.id, question: q.question })),
+                message: "Answer or skip all pending questions before completing discussion.",
+              });
+            }
+
+            const result = orchestrator.completeDiscussion(projectId, phaseId, context.nousId, context.sessionId);
+            log.info(`Discussion completed for phase ${phaseId}`);
+            return JSON.stringify({
+              complete: true,
+              message: result,
+              nextState: "phase-planning",
+            });
+          }
+
+          default:
+            return JSON.stringify({ error: `Unknown action: ${action}` });
+        }
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        log.error(`plan_discuss [${action}] failed: ${message}`);
+        return JSON.stringify({ error: message });
+      }
+    },
+  };
+}
+
+/** Generate discussion questions for a phase by analyzing requirements and context */
+async function handleGenerate(
+  orchestrator: DianoiaOrchestrator,
+  store: PlanningStore,
+  projectId: string,
+  phaseId: string,
+  _context: ToolContext,
+): Promise<string> {
+  store.getProjectOrThrow(projectId); // Validate project exists
+  const phase = store.getPhaseOrThrow(phaseId);
+  const allReqs = store.listRequirements(projectId);
+  const phaseReqs = allReqs.filter((r) => phase.requirements.includes(r.reqId));
+
+  // Build questions from phase analysis (deterministic, no LLM needed)
+  const questions: Array<{
+    question: string;
+    options: Array<{ label: string; rationale: string }>;
+    recommendation: string | null;
+  }> = [];
+
+  // 1. Implementation approach question (if phase has multiple requirements)
+  if (phaseReqs.length >= 2) {
+    questions.push({
+      question: `For "${phase.name}": should requirements be implemented sequentially or in parallel?`,
+      options: [
+        { label: "Sequential", rationale: "Simpler dependency management, easier to review" },
+        { label: "Parallel", rationale: "Faster overall delivery, but more complex integration" },
+      ],
+      recommendation: phaseReqs.length > 4 ? "Sequential" : "Parallel",
+    });
+  }
+
+  // 2. Testing strategy question
+  questions.push({
+    question: `Testing strategy for "${phase.name}": what level of test coverage?`,
+    options: [
+      { label: "Unit tests only", rationale: "Fast, focused, catches regressions" },
+      { label: "Unit + integration", rationale: "Covers interactions between components" },
+      { label: "Full: unit + integration + e2e", rationale: "Comprehensive but slower to write" },
+    ],
+    recommendation: "Unit + integration",
+  });
+
+  // 3. Error handling approach
+  questions.push({
+    question: `Error handling for "${phase.name}": fail-fast or graceful degradation?`,
+    options: [
+      { label: "Fail-fast", rationale: "Clear error signals, simpler logic, easier debugging" },
+      { label: "Graceful degradation", rationale: "Better UX, handles partial failures, more complex" },
+    ],
+    recommendation: "Fail-fast",
+  });
+
+  // 4. Phase-specific: if phase has success criteria with ambiguity
+  for (const criterion of phase.successCriteria) {
+    if (criterion.includes("or") || criterion.includes("configurable") || criterion.includes("optional")) {
+      questions.push({
+        question: `Success criterion "${criterion}" has flexibility — which interpretation should guide implementation?`,
+        options: [
+          { label: "Minimal viable", rationale: "Implement the simplest valid interpretation" },
+          { label: "Comprehensive", rationale: "Cover all interpretations of this criterion" },
+        ],
+        recommendation: "Minimal viable",
+      });
+    }
+  }
+
+  // Persist all generated questions
+  const created = [];
+  for (const q of questions) {
+    const disc = orchestrator.addDiscussionQuestion(
+      projectId, phaseId, q.question, q.options, q.recommendation,
+    );
+    created.push({
+      id: disc.id,
+      question: disc.question,
+      options: disc.options,
+      recommendation: disc.recommendation,
+    });
+  }
+
+  log.info(`Generated ${created.length} discussion questions for phase ${phaseId}`);
+  return JSON.stringify({
+    generated: created.length,
+    questions: created,
+    message: `${created.length} questions generated. Answer with action=answer or skip with action=skip, then action=complete to advance.`,
+  });
+}
+
+/** List all discussion questions for a phase with status */
+function handleList(
+  orchestrator: DianoiaOrchestrator,
+  projectId: string,
+  phaseId: string,
+): string {
+  const all = orchestrator.getPhaseDiscussions(projectId, phaseId);
+  const pending = orchestrator.getPendingDiscussions(projectId, phaseId);
+
+  const formatted = all.map((q) => ({
+    id: q.id,
+    question: q.question,
+    options: q.options,
+    recommendation: q.recommendation,
+    status: q.status,
+    decision: q.decision,
+    userNote: q.userNote,
+  }));
+
+  return JSON.stringify({
+    total: all.length,
+    pending: pending.length,
+    answered: all.filter((q) => q.status === "answered").length,
+    skipped: all.filter((q) => q.status === "skipped").length,
+    questions: formatted,
+  });
+}

--- a/infrastructure/runtime/src/dianoia/index.ts
+++ b/infrastructure/runtime/src/dianoia/index.ts
@@ -52,6 +52,9 @@ export {
   readPlanFile,
 } from "./project-files.js";
 
+// Discussion tool (Spec 32 Phase 3)
+export { createPlanDiscussTool } from "./discuss-tool.js";
+
 // Context engineering (Spec 32 Phase 2)
 export { buildContextPacket, selectModelForRole, modelTierToRole } from "./context-packet.js";
 export type { SubAgentRole, ContextPacketOptions, ModelTier } from "./context-packet.js";


### PR DESCRIPTION
## Spec 32 — Dianoia v2 Phase 3

### What

The `plan_discuss` tool that bridges the `discussing` FSM state. Before sub-agents execute a phase, gray areas and trade-offs are surfaced as structured questions, decisions are captured, and DISCUSS.md constrains implementation.

### Actions

| Action | Purpose |
|--------|---------|
| `generate` | Auto-create questions from phase analysis |
| `add` | Manually add a question with options |
| `answer` | Record a decision |
| `skip` | Use agent recommendation |
| `list` | Show all questions with status |
| `complete` | Validate + advance to phase-planning |

### Flow

```
roadmap → ROADMAP_COMPLETE → discussing
                              ↓
                     plan_discuss generate
                     plan_discuss answer/skip (×N)
                     plan_discuss complete
                              ↓
                        phase-planning
```

### Tests

223/223 pass (10 new). Zero type errors.