### PR TITLE
feat(dianoia): v2 Phase 4 — retrospective system

### DIFF
--- a/infrastructure/runtime/src/dianoia/index.ts
+++ b/infrastructure/runtime/src/dianoia/index.ts
@@ -52,6 +52,10 @@ export {
   readPlanFile,
 } from "./project-files.js";
 
+// Retrospective (Spec 32 Phase 4)
+export { RetrospectiveGenerator } from "./retrospective.js";
+export type { RetrospectiveEntry, PhaseRetrospective, Pattern } from "./retrospective.js";
+
 // Discussion tool (Spec 32 Phase 3)
 export { createPlanDiscussTool } from "./discuss-tool.js";
 

--- a/infrastructure/runtime/src/dianoia/orchestrator.ts
+++ b/infrastructure/runtime/src/dianoia/orchestrator.ts
@@ -16,6 +16,7 @@ import {
 import type Database from "better-sqlite3";
 import type { PlanningConfigSchema } from "../taxis/schema.js";
 import type { DiscussionOption, DiscussionQuestion, PlanningProject, ProjectContext } from "./types.js";
+import { RetrospectiveGenerator } from "./retrospective.js";
 
 const log = createLogger("dianoia:orchestrator");
 
@@ -27,10 +28,12 @@ const ACTIVE_STATES = new Set([
 
 export class DianoiaOrchestrator {
   private store: PlanningStore;
+  private retroGenerator: RetrospectiveGenerator;
   private workspaceRoot: string | null = null;
 
   constructor(db: Database.Database, private defaultConfig: PlanningConfigSchema) {
     this.store = new PlanningStore(db);
+    this.retroGenerator = new RetrospectiveGenerator(db);
   }
 
   /** Set the workspace root for file-backed state. Must be called before file writes work. */
@@ -103,6 +106,10 @@ export class DianoiaOrchestrator {
   abandon(projectId: string): void {
     const project = this.store.getProjectOrThrow(projectId);
     this.store.updateProjectState(projectId, transition(project.state, "ABANDON"));
+
+    // Generate retrospective even on abandon — failure patterns are valuable
+    this.generateRetro(projectId);
+
     log.info(`Abandoned planning project ${projectId}`);
   }
 
@@ -238,12 +245,20 @@ export class DianoiaOrchestrator {
       projectId,
       transition(project.state, "ALL_PHASES_COMPLETE"),
     );
+
+    // Generate retrospective on project completion
+    this.generateRetro(projectId);
+
     eventBus.emit("planning:complete", { projectId, nousId, sessionId });
     log.info(`Project complete: ${projectId}`);
   }
 
   completeAllPhases(projectId: string, nousId: string, sessionId: string): void {
     this.store.updateProjectState(projectId, transition("verifying", "ALL_PHASES_COMPLETE"));
+
+    // Generate retrospective on project completion
+    this.generateRetro(projectId);
+
     eventBus.emit("planning:complete", { projectId, nousId, sessionId });
     log.info("All phases complete", { projectId });
   }
@@ -320,6 +335,28 @@ export class DianoiaOrchestrator {
 
   updateContext(projectId: string, context: ProjectContext): void {
     this.store.updateProjectContext(projectId, context);
+  }
+
+  // --- Retrospective (Spec 32 Phase 4) ---
+
+  /** Generate and persist retrospective for a project */
+  private generateRetro(projectId: string): void {
+    try {
+      const retro = this.retroGenerator.generate(projectId);
+      if (this.workspaceRoot) {
+        this.retroGenerator.writeRetroFile(this.workspaceRoot, retro);
+        this.retroGenerator.writeRetroJson(this.workspaceRoot, retro);
+      }
+      log.info(`Retrospective generated for project ${projectId}: ${retro.patterns.length} patterns`);
+    } catch (err) {
+      // Don't let retro failure block project state transitions
+      log.warn(`Failed to generate retrospective for ${projectId}`, { err });
+    }
+  }
+
+  /** Explicitly generate retrospective (e.g., for mid-project review) */
+  generateRetrospective(projectId: string): import("./retrospective.js").RetrospectiveEntry {
+    return this.retroGenerator.generate(projectId);
   }
 
   // --- Discussion flow (Spec 32) ---

--- a/infrastructure/runtime/src/dianoia/retrospective.test.ts
+++ b/infrastructure/runtime/src/dianoia/retrospective.test.ts
@@ -1,0 +1,247 @@
+// Tests for RetrospectiveGenerator (Spec 32 Phase 4)
+import Database from "better-sqlite3";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { existsSync, readFileSync, rmSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  PLANNING_V20_DDL,
+  PLANNING_V21_MIGRATION,
+  PLANNING_V22_MIGRATION,
+  PLANNING_V23_MIGRATION,
+  PLANNING_V24_MIGRATION,
+  PLANNING_V25_MIGRATION,
+  PLANNING_V26_MIGRATION,
+} from "./schema.js";
+import { PlanningStore } from "./store.js";
+import { RetrospectiveGenerator } from "./retrospective.js";
+
+let db: Database.Database;
+let store: PlanningStore;
+let retro: RetrospectiveGenerator;
+let workspaceRoot: string;
+
+const defaultConfig = {
+  depth: "standard" as const,
+  parallelization: false,
+  research: true,
+  plan_check: true,
+  verifier: true,
+  mode: "interactive" as const,
+  pause_between_phases: false,
+};
+
+function makeDb(): Database.Database {
+  const d = new Database(":memory:");
+  d.pragma("journal_mode = WAL");
+  d.pragma("foreign_keys = ON");
+  d.exec(PLANNING_V20_DDL);
+  d.exec(PLANNING_V21_MIGRATION);
+  d.exec(PLANNING_V22_MIGRATION);
+  d.exec(PLANNING_V23_MIGRATION);
+  d.exec(PLANNING_V24_MIGRATION);
+  d.exec(PLANNING_V25_MIGRATION);
+  d.exec(PLANNING_V26_MIGRATION);
+  return d;
+}
+
+beforeEach(() => {
+  db = makeDb();
+  store = new PlanningStore(db);
+  retro = new RetrospectiveGenerator(db);
+  workspaceRoot = join(tmpdir(), `dianoia-retro-test-${Date.now()}`);
+  mkdirSync(workspaceRoot, { recursive: true });
+});
+
+afterEach(() => {
+  db.close();
+  if (existsSync(workspaceRoot)) {
+    rmSync(workspaceRoot, { recursive: true, force: true });
+  }
+});
+
+describe("RetrospectiveGenerator.generate", () => {
+  it("generates retrospective for a completed project", () => {
+    const project = store.createProject({
+      nousId: "test",
+      sessionId: "test",
+      goal: "Build auth system",
+      config: defaultConfig,
+    });
+    store.updateProjectState(project.id, "complete");
+
+    const phase = store.createPhase({
+      projectId: project.id,
+      name: "Auth",
+      goal: "Implement OAuth",
+      requirements: ["AUTH-01"],
+      successCriteria: ["Users can login"],
+      phaseOrder: 0,
+    });
+    store.updatePhaseStatus(phase.id, "complete");
+    store.updatePhaseVerificationResult(phase.id, {
+      status: "met",
+      summary: "All good",
+      gaps: [],
+      verifiedAt: new Date().toISOString(),
+    });
+
+    const result = retro.generate(project.id);
+
+    expect(result.projectId).toBe(project.id);
+    expect(result.goal).toBe("Build auth system");
+    expect(result.outcome).toBe("complete");
+    expect(result.phases).toHaveLength(1);
+    expect(result.phases[0]!.name).toBe("Auth");
+    expect(result.phases[0]!.status).toBe("complete");
+    expect(result.phases[0]!.verificationStatus).toBe("met");
+    expect(result.patterns.length).toBeGreaterThan(0);
+    expect(result.patterns.some((p) => p.type === "success")).toBe(true);
+  });
+
+  it("marks abandoned projects correctly", () => {
+    const project = store.createProject({
+      nousId: "test",
+      sessionId: "test",
+      goal: "Abandoned project",
+      config: defaultConfig,
+    });
+    store.updateProjectState(project.id, "abandoned");
+
+    const result = retro.generate(project.id);
+    expect(result.outcome).toBe("abandoned");
+  });
+
+  it("detects failure patterns", () => {
+    const project = store.createProject({
+      nousId: "test",
+      sessionId: "test",
+      goal: "Failing project",
+      config: defaultConfig,
+    });
+    store.updateProjectState(project.id, "blocked");
+
+    const phase = store.createPhase({
+      projectId: project.id,
+      name: "Data Layer",
+      goal: "Build data",
+      requirements: [],
+      successCriteria: [],
+      phaseOrder: 0,
+    });
+    store.updatePhaseStatus(phase.id, "failed");
+
+    const result = retro.generate(project.id);
+    expect(result.outcome).toBe("partial");
+    expect(result.patterns.some((p) => p.type === "failure")).toBe(true);
+  });
+
+  it("detects cascade skip antipattern", () => {
+    const project = store.createProject({
+      nousId: "test",
+      sessionId: "test",
+      goal: "Cascade project",
+      config: defaultConfig,
+    });
+    store.updateProjectState(project.id, "complete");
+
+    const p1 = store.createPhase({
+      projectId: project.id,
+      name: "Phase 1",
+      goal: "First",
+      requirements: [],
+      successCriteria: [],
+      phaseOrder: 0,
+    });
+    store.updatePhaseStatus(p1.id, "failed");
+
+    const p2 = store.createPhase({
+      projectId: project.id,
+      name: "Phase 2",
+      goal: "Second",
+      requirements: [],
+      successCriteria: [],
+      phaseOrder: 1,
+    });
+    store.updatePhaseStatus(p2.id, "skipped");
+
+    const result = retro.generate(project.id);
+    expect(result.patterns.some((p) => p.type === "antipattern" && p.summary.includes("Cascade"))).toBe(true);
+  });
+
+  it("includes discussion counts per phase", () => {
+    const project = store.createProject({
+      nousId: "test",
+      sessionId: "test",
+      goal: "Discussed project",
+      config: defaultConfig,
+    });
+    store.updateProjectState(project.id, "complete");
+
+    const phase = store.createPhase({
+      projectId: project.id,
+      name: "Auth",
+      goal: "Implement OAuth",
+      requirements: [],
+      successCriteria: [],
+      phaseOrder: 0,
+    });
+    store.updatePhaseStatus(phase.id, "complete");
+
+    // Add discussions
+    store.createDiscussionQuestion({
+      projectId: project.id,
+      phaseId: phase.id,
+      question: "Q1?",
+      options: [],
+    });
+    store.createDiscussionQuestion({
+      projectId: project.id,
+      phaseId: phase.id,
+      question: "Q2?",
+      options: [],
+    });
+
+    const result = retro.generate(project.id);
+    expect(result.phases[0]!.discussionCount).toBe(2);
+  });
+});
+
+describe("RetrospectiveGenerator file output", () => {
+  it("writes RETRO.md and retro.json", () => {
+    const project = store.createProject({
+      nousId: "test",
+      sessionId: "test",
+      goal: "File output test",
+      config: defaultConfig,
+    });
+    store.updateProjectState(project.id, "complete");
+
+    store.createPhase({
+      projectId: project.id,
+      name: "Phase 1",
+      goal: "Goal 1",
+      requirements: [],
+      successCriteria: [],
+      phaseOrder: 0,
+    });
+
+    const result = retro.generate(project.id);
+    retro.writeRetroFile(workspaceRoot, result);
+    retro.writeRetroJson(workspaceRoot, result);
+
+    const retroMdPath = join(workspaceRoot, ".dianoia", "projects", project.id, "RETRO.md");
+    const retroJsonPath = join(workspaceRoot, ".dianoia", "projects", project.id, "retro.json");
+
+    expect(existsSync(retroMdPath)).toBe(true);
+    expect(existsSync(retroJsonPath)).toBe(true);
+
+    const md = readFileSync(retroMdPath, "utf-8");
+    expect(md).toContain("Retrospective:");
+    expect(md).toContain("File output test");
+
+    const json = JSON.parse(readFileSync(retroJsonPath, "utf-8"));
+    expect(json.projectId).toBe(project.id);
+    expect(json.outcome).toBe("complete");
+  });
+});

--- a/infrastructure/runtime/src/dianoia/retrospective.ts
+++ b/infrastructure/runtime/src/dianoia/retrospective.ts
@@ -1,0 +1,272 @@
+// Retrospective — project learning system (Spec 32 Phase 4)
+//
+// After a project completes (or is abandoned), extract patterns:
+// - What phases succeeded/failed and why
+// - Discussion decisions that proved correct/incorrect
+// - Verification gaps that recurred
+// - Execution timing data
+//
+// Persisted as RETRO.md in the project directory and available for
+// future projects via context packet assembly.
+
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { createLogger } from "../koina/logger.js";
+import { PlanningStore } from "./store.js";
+import { ensureProjectDir, getProjectDir } from "./project-files.js";
+import type Database from "better-sqlite3";
+import type { PlanningPhase, VerificationResult } from "./types.js";
+
+const log = createLogger("dianoia:retrospective");
+
+export interface RetrospectiveEntry {
+  projectId: string;
+  goal: string;
+  outcome: "complete" | "abandoned" | "partial";
+  phases: PhaseRetrospective[];
+  patterns: Pattern[];
+  generatedAt: string;
+}
+
+export interface PhaseRetrospective {
+  name: string;
+  goal: string;
+  status: string;
+  discussionCount: number;
+  verificationStatus: string | null;
+  gapCount: number;
+  duration: string | null; // ISO duration or null
+}
+
+export interface Pattern {
+  type: "success" | "failure" | "antipattern" | "lesson";
+  summary: string;
+  context: string;
+}
+
+export class RetrospectiveGenerator {
+  private store: PlanningStore;
+
+  constructor(db: Database.Database) {
+    this.store = new PlanningStore(db);
+  }
+
+  /**
+   * Generate a retrospective for a completed/abandoned project.
+   * Analyzes phases, discussions, verification results, and spawn records
+   * to extract patterns and lessons.
+   */
+  generate(projectId: string): RetrospectiveEntry {
+    const project = this.store.getProjectOrThrow(projectId);
+    const phases = this.store.listPhases(projectId);
+    const spawnRecords = this.store.listSpawnRecords(projectId);
+
+    const outcome: RetrospectiveEntry["outcome"] =
+      project.state === "complete" ? "complete" :
+      project.state === "abandoned" ? "abandoned" : "partial";
+
+    const phaseRetros = phases.map((phase): PhaseRetrospective => {
+      const discussions = this.store.listDiscussionQuestions(projectId, phase.id);
+      const verification = phase.verificationResult as VerificationResult | null;
+      const phaseSpawns = spawnRecords.filter((r) => r.phaseId === phase.id);
+
+      // Calculate duration from spawn records
+      let duration: string | null = null;
+      if (phaseSpawns.length > 0) {
+        const start = phaseSpawns[0]?.startedAt;
+        const end = phaseSpawns[phaseSpawns.length - 1]?.completedAt;
+        if (start && end) {
+          const ms = new Date(end).getTime() - new Date(start).getTime();
+          duration = `${Math.round(ms / 1000)}s`;
+        }
+      }
+
+      return {
+        name: phase.name,
+        goal: phase.goal,
+        status: phase.status,
+        discussionCount: discussions.length,
+        verificationStatus: verification?.status ?? null,
+        gapCount: verification?.gaps?.length ?? 0,
+        duration,
+      };
+    });
+
+    const patterns = this.extractPatterns(phases, phaseRetros, spawnRecords);
+
+    const retro: RetrospectiveEntry = {
+      projectId,
+      goal: project.goal,
+      outcome,
+      phases: phaseRetros,
+      patterns,
+      generatedAt: new Date().toISOString(),
+    };
+
+    log.info(`Generated retrospective for project ${projectId}: ${patterns.length} patterns extracted`);
+    return retro;
+  }
+
+  /**
+   * Write RETRO.md to the project directory.
+   */
+  writeRetroFile(workspaceRoot: string, retro: RetrospectiveEntry): void {
+    const dir = ensureProjectDir(workspaceRoot, retro.projectId);
+    const lines = [
+      `# Retrospective: ${retro.goal}`,
+      "",
+      `| Field | Value |`,
+      `|-------|-------|`,
+      `| Outcome | ${retro.outcome} |`,
+      `| Phases | ${retro.phases.length} |`,
+      `| Patterns | ${retro.patterns.length} |`,
+      `| Generated | ${retro.generatedAt} |`,
+      "",
+      "## Phases",
+      "",
+    ];
+
+    for (const phase of retro.phases) {
+      const icon = phase.status === "complete" ? "✅" :
+        phase.status === "failed" ? "❌" :
+        phase.status === "skipped" ? "⏭" : "⬜";
+      lines.push(`### ${icon} ${phase.name}`);
+      lines.push(`- **Goal:** ${phase.goal}`);
+      lines.push(`- **Status:** ${phase.status}`);
+      if (phase.duration) lines.push(`- **Duration:** ${phase.duration}`);
+      if (phase.discussionCount > 0) lines.push(`- **Discussions:** ${phase.discussionCount}`);
+      if (phase.verificationStatus) lines.push(`- **Verification:** ${phase.verificationStatus}`);
+      if (phase.gapCount > 0) lines.push(`- **Gaps found:** ${phase.gapCount}`);
+      lines.push("");
+    }
+
+    if (retro.patterns.length > 0) {
+      lines.push("## Patterns", "");
+      for (const pattern of retro.patterns) {
+        const icon = pattern.type === "success" ? "✅" :
+          pattern.type === "failure" ? "❌" :
+          pattern.type === "antipattern" ? "⚠️" : "💡";
+        lines.push(`### ${icon} ${pattern.summary}`);
+        lines.push(`**Type:** ${pattern.type}`);
+        lines.push(`${pattern.context}`);
+        lines.push("");
+      }
+    }
+
+    writeFileSync(join(dir, "RETRO.md"), lines.join("\n"), "utf-8");
+    log.debug(`Wrote RETRO.md for ${retro.projectId}`);
+  }
+
+  /**
+   * Read all retrospectives from past projects (for feeding into new project context).
+   */
+  readPastRetros(workspaceRoot: string): RetrospectiveEntry[] {
+    const projectsDir = join(workspaceRoot, ".dianoia", "projects");
+    if (!existsSync(projectsDir)) return [];
+
+    const retros: RetrospectiveEntry[] = [];
+    const { readdirSync } = require("node:fs") as typeof import("node:fs");
+    try {
+      const dirs = readdirSync(projectsDir);
+      for (const dir of dirs) {
+        const retroPath = join(projectsDir, dir, "RETRO.md");
+        if (existsSync(retroPath)) {
+          // We store structured data too for quick access
+          const jsonPath = join(projectsDir, dir, "retro.json");
+          if (existsSync(jsonPath)) {
+            try {
+              const data = JSON.parse(readFileSync(jsonPath, "utf-8")) as RetrospectiveEntry;
+              retros.push(data);
+            } catch {
+              // Skip corrupt entries
+            }
+          }
+        }
+      }
+    } catch {
+      // Projects dir not readable
+    }
+
+    return retros;
+  }
+
+  /**
+   * Write structured JSON alongside RETRO.md for programmatic access.
+   */
+  writeRetroJson(workspaceRoot: string, retro: RetrospectiveEntry): void {
+    const dir = getProjectDir(workspaceRoot, retro.projectId);
+    writeFileSync(join(dir, "retro.json"), JSON.stringify(retro, null, 2), "utf-8");
+  }
+
+  // --- Pattern extraction ---
+
+  private extractPatterns(
+    _phases: PlanningPhase[],
+    phaseRetros: PhaseRetrospective[],
+    spawnRecords: Array<{ status: string; phaseId: string }>,
+  ): Pattern[] {
+    const patterns: Pattern[] = [];
+
+    // Pattern: All phases succeeded
+    const allComplete = phaseRetros.every((p) => p.status === "complete");
+    if (allComplete && phaseRetros.length > 0) {
+      patterns.push({
+        type: "success",
+        summary: "All phases completed successfully",
+        context: `${phaseRetros.length} phases executed without failures.`,
+      });
+    }
+
+    // Pattern: Failed phases
+    const failedPhases = phaseRetros.filter((p) => p.status === "failed");
+    for (const fp of failedPhases) {
+      patterns.push({
+        type: "failure",
+        summary: `Phase "${fp.name}" failed`,
+        context: `Goal: ${fp.goal}. Verification: ${fp.verificationStatus ?? "not run"}. Gaps: ${fp.gapCount}.`,
+      });
+    }
+
+    // Pattern: Phases with verification gaps that were eventually resolved
+    const gapPhases = phaseRetros.filter((p) => p.gapCount > 0 && p.status === "complete");
+    if (gapPhases.length > 0) {
+      patterns.push({
+        type: "lesson",
+        summary: "Verification gaps were recoverable",
+        context: `${gapPhases.length} phase(s) had verification gaps but completed after gap closure: ${gapPhases.map((p) => p.name).join(", ")}.`,
+      });
+    }
+
+    // Pattern: Skipped phases (cascade from failures)
+    const skippedPhases = phaseRetros.filter((p) => p.status === "skipped");
+    if (skippedPhases.length > 0) {
+      patterns.push({
+        type: "antipattern",
+        summary: "Cascade skip from dependency failure",
+        context: `${skippedPhases.length} phase(s) were skipped due to upstream failures: ${skippedPhases.map((p) => p.name).join(", ")}.`,
+      });
+    }
+
+    // Pattern: Phases with no discussion (fast-tracked)
+    const noDiscussion = phaseRetros.filter((p) => p.discussionCount === 0);
+    if (noDiscussion.length > 0 && noDiscussion.some((p) => p.status === "failed")) {
+      patterns.push({
+        type: "antipattern",
+        summary: "Phases without discussion had higher failure rate",
+        context: `${noDiscussion.filter((p) => p.status === "failed").length}/${noDiscussion.length} undiscussed phases failed vs ${failedPhases.length}/${phaseRetros.length} overall.`,
+      });
+    }
+
+    // Pattern: Zombie detection
+    const zombieCount = spawnRecords.filter((r) => r.status === "zombie").length;
+    if (zombieCount > 0) {
+      patterns.push({
+        type: "antipattern",
+        summary: "Zombie spawn records detected",
+        context: `${zombieCount} sub-agent spawn(s) timed out and were reaped as zombies. Consider increasing timeout or reducing task scope.`,
+      });
+    }
+
+    return patterns;
+  }
+}


### PR DESCRIPTION
## Spec 32 — Dianoia v2 Phase 4

### What

Projects now generate retrospectives on completion/abandonment. Pattern extraction turns project history into learnable insights.

### Pattern Detection

| Pattern | Type | Trigger |
|---------|------|---------|
| All phases succeeded | success | Every phase status = complete |
| Phase X failed | failure | Any phase status = failed |
| Cascade skip | antipattern | Phases skipped due to upstream failure |
| Verification gaps recoverable | lesson | Phases with gaps that still completed |
| No discussion → higher failure | antipattern | Failed phases had 0 discussions |
| Zombie spawns | antipattern | Spawn records reaped as zombies |

### Output

- **RETRO.md** — Human-readable markdown with phase outcomes and patterns
- **retro.json** — Structured JSON for programmatic access and future context injection
- Auto-generated on `completeProject()`, `completeAllPhases()`, and `abandon()`
- Non-blocking: retro failure doesn't prevent state transitions

### Tests

229/229 pass (6 new). Zero type errors.