### PR TITLE
fix(dianoia): execution timeout and dispatch reliability

### DIFF
--- a/infrastructure/runtime/src/dianoia/execution.ts
+++ b/infrastructure/runtime/src/dianoia/execution.ts
@@ -9,7 +9,7 @@ import { buildContextPacket } from "./context-packet.js";
 import { parseDispatchResponse, selectRoleForTask } from "./structured-extraction.js";
 
 const log = createLogger("dianoia:execution");
-const ZOMBIE_THRESHOLD_SECONDS = 600; // 2x default 300s plan timeout
+const ZOMBIE_THRESHOLD_SECONDS = 600; // Conservative threshold; execution timeouts are per-task, zombies are per-record
 
 export function computeWaves(phases: PlanningPhase[]): PlanningPhase[][] {
   // Unit of parallelism is the PlanningPhase (plan).
@@ -134,10 +134,12 @@ export class ExecutionOrchestrator {
       }
 
       const wave = waves[waveIndex]!;
+      // Re-read records each wave (reapZombies may have mutated earlier records)
+      const currentRecords = this.store.listSpawnRecords(projectId);
       const activePlans = wave.filter(
         (p) =>
           !skippedIds.has(p.id) &&
-          !existingRecords.some((r) => r.phaseId === p.id && r.status === "done"),
+          !currentRecords.some((r) => r.phaseId === p.id && (r.status === "done" || r.status === "running")),
       );
 
       if (activePlans.length === 0) continue;
@@ -185,7 +187,7 @@ export class ExecutionOrchestrator {
         return {
           role: selectedRole,
           task: contextPacket,
-          timeoutSeconds: 300,
+          timeoutSeconds: 900, // 15 min — phases need multiple turns with tool calls
         };
       });
 

--- a/infrastructure/runtime/src/organon/built-in/sessions-dispatch.ts
+++ b/infrastructure/runtime/src/organon/built-in/sessions-dispatch.ts
@@ -114,7 +114,19 @@ export function createSessionsDispatchTool(
         return JSON.stringify({ error: "Agent dispatch not available" });
       }
 
-      const tasks = input["tasks"] as DispatchTask[];
+      // Defensive: parse tasks if delivered as JSON string (model/framework serialization)
+      let tasks: DispatchTask[];
+      const raw = input["tasks"];
+      if (typeof raw === "string") {
+        try {
+          tasks = JSON.parse(raw);
+        } catch {
+          return JSON.stringify({ error: "tasks: invalid JSON string" });
+        }
+      } else {
+        tasks = raw as DispatchTask[];
+      }
+
       if (!tasks || !Array.isArray(tasks) || tasks.length === 0) {
         return JSON.stringify({ error: "tasks array is required and must not be empty" });
       }

--- a/infrastructure/runtime/src/organon/timeout.ts
+++ b/infrastructure/runtime/src/organon/timeout.ts
@@ -14,6 +14,8 @@ export const DEFAULT_TOOL_TIMEOUTS: ToolTimeoutConfig = {
     sessions_ask: 0,   // sessions_ask has its own timeout
     sessions_spawn: 0, // long-running by design
     sessions_dispatch: 0, // long-running, handles own timeouts per task
+    plan_execute: 0,      // execution phases are long-running; internal dispatch handles timeouts
+    plan_research: 0,     // research spawns sub-agents with own timeouts
     browser: 180_000,
     web_fetch: 60_000,
     web_search: 60_000,


### PR DESCRIPTION
## Root Cause Analysis

Phase execution was failing with all 4 phases timing out. Investigation revealed a cascade of issues:

### What Happened
1. `plan_execute start` dispatched 4 sub-agents in parallel
2. Pipeline's 120s tool timeout fired before dispatch could complete (sub-agents needed 10-15 min)
3. Pipeline returned `[TIMEOUT]` to the model, which retried the tool call
4. **Three cohorts of 4 sub-agents** (12 total) were all competing for API rate limits
5. Each cohort's dispatch also timed out at 300s (internal timeout)
6. Sub-agents kept running as zombies after their dispatch timed out

Evidence from journal logs:
- `Tool timeout: plan_execute after 120000ms` — 3 times within 11 seconds
- `Wave 1/1: dispatching 4 plans` — 3 separate wave starts
- Sub-agents had 84-208 messages and ran distillation cycles (real work)
- No 429s or API errors — just insufficient time

### Fixes

| Fix | File | Impact |
|-----|------|--------|
| Tool timeout override | `timeout.ts` | `plan_execute` and `plan_research` get unlimited framework timeout (they manage their own via dispatch) |
| Execution timeout 300→900s | `execution.ts` | Sub-agents get 15 min per phase instead of 5 |
| Idempotency guard | `execution.ts` | Skip dispatching phases with existing `running` spawn records |
| Defensive JSON parsing | `sessions-dispatch.ts` | Handle tasks arriving as JSON string from model tool calls |

### Tests
17/18 pass (1 pre-existing `isPaused` failure). Zero type errors.