### PR TITLE
fix: narrow gitignore credentials pattern, fix credential-refresh path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,9 @@ projects/
 
 # === Secrets ===
 *.env
-**/credentials*
+**/credentials.json
+**/credentials.yaml
+**/credentials.yml
 !**/credentials.py
 **/secrets*
 **/*.key

--- a/shared/bin/credential-refresh
+++ b/shared/bin/credential-refresh
@@ -35,7 +35,7 @@ _config = {"threshold": 3600, "interval": 300}
 
 # Credential file locations
 ALETHEIA_CRED = Path.home() / ".aletheia" / "credentials" / "anthropic.json"
-CLAUDE_CODE_CRED = Path.home().parent / "ck" / ".claude" / ".credentials.json"
+CLAUDE_CODE_CRED = Path.home() / ".claude" / ".credentials.json"
 
 
 def log(msg: str, level: str = "INFO"):

--- a/ui/src/stores/credentials.svelte.ts
+++ b/ui/src/stores/credentials.svelte.ts
@@ -1,0 +1,34 @@
+// Credential label store — tracks which credential was used on the last turn
+import { fetchCredentialInfo, type CredentialInfo } from "../lib/api";
+
+let activeLabel = $state<string>("primary");
+let credentialConfig = $state<CredentialInfo | null>(null);
+let loaded = $state(false);
+
+export function getActiveCredentialLabel(): string {
+  return activeLabel;
+}
+
+export function setActiveCredentialLabel(label: string): void {
+  activeLabel = label;
+}
+
+export function getCredentialConfig(): CredentialInfo | null {
+  return credentialConfig;
+}
+
+export function isCredentialConfigLoaded(): boolean {
+  return loaded;
+}
+
+export async function loadCredentialConfig(): Promise<void> {
+  try {
+    credentialConfig = await fetchCredentialInfo();
+    // Set initial label to primary
+    activeLabel = credentialConfig.primary.label;
+    loaded = true;
+  } catch {
+    // Fallback — no credential endpoint available
+    loaded = true;
+  }
+}


### PR DESCRIPTION
Recreated from closed PR #192 (branch was ~20 commits behind main).

- **`.gitignore`**: `**/credentials*` was too broad — matched `credentials.svelte.ts` and other non-secret source files. Narrowed to explicit extensions (`.json`, `.yaml`, `.yml`)
- **`shared/bin/credential-refresh`**: `CLAUDE_CODE_CRED` path used `Path.home().parent / 'ck'` which resolves incorrectly; fixed to `Path.home() / '.claude' / '.credentials.json'`
- **`ui/src/stores/credentials.svelte.ts`**: Was untracked due to gitignore pattern despite being imported by TopBar and chat store. Now tracked.