### PR TITLE
fix(dianoia): smoke test bugs — coverage gate, rationale, timeouts, UI wiring

### DIFF
--- a/infrastructure/runtime/src/dianoia/requirements.test.ts
+++ b/infrastructure/runtime/src/dianoia/requirements.test.ts
@@ -215,7 +215,7 @@ describe("RequirementsOrchestrator.validateCoverage()", () => {
   });
 
   // CTX-03 enhancements
-  it("returns false when fewer than minimum categories presented (default 2)", () => {
+  it("returns false when fewer than minimum categories presented (explicit minimum=2)", () => {
     const db = makeDb();
     const projectId = makeProject(db);
     const orch = new RequirementsOrchestrator(db);
@@ -225,11 +225,11 @@ describe("RequirementsOrchestrator.validateCoverage()", () => {
     ];
     orch.persistCategory(projectId, AUTH_CATEGORY, decisions);
 
-    // Only 1 category, should fail minimum gate
-    expect(orch.validateCoverage(projectId, ["AUTH"])).toBe(false);
+    // Only 1 category, should fail when minimum is explicitly 2
+    expect(orch.validateCoverage(projectId, ["AUTH"], 2)).toBe(false);
   });
 
-  it("passes with custom minimum category count", () => {
+  it("passes with single category (default minimum=1)", () => {
     const db = makeDb();
     const projectId = makeProject(db);
     const orch = new RequirementsOrchestrator(db);
@@ -239,54 +239,38 @@ describe("RequirementsOrchestrator.validateCoverage()", () => {
     ];
     orch.persistCategory(projectId, AUTH_CATEGORY, decisions);
 
-    // Allow single category with minimumCategories=1
-    expect(orch.validateCoverage(projectId, ["AUTH"], 1)).toBe(true);
+    // Default minimum is 1, single category should pass
+    expect(orch.validateCoverage(projectId, ["AUTH"])).toBe(true);
   });
 });
 
 describe("RequirementsOrchestrator.persistCategory() - CTX-03 enhancements", () => {
-  it("throws on duplicate reqId", () => {
+  it("throws on duplicate reqId from cross-category collision", () => {
     const db = makeDb();
     const projectId = makeProject(db);
     const orch = new RequirementsOrchestrator(db);
 
-    // First persist
-    const decisions1: ScopingDecision[] = [
-      { name: "Login with email/password", tier: "v1" },
-    ];
-    orch.persistCategory(projectId, AUTH_CATEGORY, decisions1);
-
-    // Create another category that would generate the same reqId
-    const conflictCategory: CategoryProposal = {
-      category: "AUTH",
-      categoryName: "Authentication Conflict",
-      tableStakes: [{
-        name: "Different feature",
-        description: "different description",
-        isTableStakes: true,
-        proposedTier: "v1",
-      }],
-      differentiators: [],
-    };
-
-    // This should generate AUTH-01 again, which should conflict
+    // Manually insert a requirement with reqId AUTH-01 under a different category
+    // This simulates a cross-category collision where another category happened
+    // to produce the same reqId prefix
     const store = new PlanningStore(db);
-    // Manually create a req with AUTH-01 to simulate conflict
     store.createRequirement({
       projectId,
       reqId: "AUTH-01",
-      description: "Existing AUTH-01",
+      description: "Existing AUTH-01 from another source",
       category: "OTHER",
       tier: "v1",
       rationale: null,
     });
 
-    const decisions2: ScopingDecision[] = [
-      { name: "Different feature", tier: "v1" },
+    // Now persist AUTH category — nextNum will be 1 (no existing AUTH reqs),
+    // generating AUTH-01 which conflicts with the cross-category entry
+    const decisions: ScopingDecision[] = [
+      { name: "Login with email/password", tier: "v1" },
     ];
 
     expect(() => {
-      orch.persistCategory(projectId, conflictCategory, decisions2);
+      orch.persistCategory(projectId, AUTH_CATEGORY, decisions);
     }).toThrow("Duplicate requirement ID: AUTH-01");
   });
 

--- a/infrastructure/runtime/src/dianoia/requirements.ts
+++ b/infrastructure/runtime/src/dianoia/requirements.ts
@@ -126,7 +126,7 @@ export class RequirementsOrchestrator {
         description,
         category: category.category,
         tier: decision.tier,
-        rationale: decision.tier === "out-of-scope" ? (decision.rationale ?? null) : null,
+        rationale: decision.rationale ?? null,
       });
 
       nextNum++;
@@ -157,7 +157,7 @@ export class RequirementsOrchestrator {
     this.store.updateRequirement(row.id, updates);
   }
 
-  validateCoverage(projectId: string, presentedCategories: string[], minimumCategories = 2): boolean {
+  validateCoverage(projectId: string, presentedCategories: string[], minimumCategories = 1): boolean {
     const reqs = this.store.listRequirements(projectId);
 
     // Minimum category count gate

--- a/infrastructure/runtime/src/dianoia/roadmap.ts
+++ b/infrastructure/runtime/src/dianoia/roadmap.ts
@@ -461,7 +461,7 @@ export class RoadmapOrchestrator {
         return { pass: true, issues: [] };
       }
 
-      const parsed = JSON.parse(result.result) as { pass: boolean; issues: string[] };
+      const parsed = this.extractCheckResult(result.result);
       return { pass: parsed.pass, issues: parsed.issues ?? [] };
     } catch (cause) {
       log.warn("Plan checker parse error — treating as pass (best-effort)", { cause, phaseId: phase.id, attempt });
@@ -556,5 +556,36 @@ export class RoadmapOrchestrator {
     }
 
     return JSON.parse(jsonMatch[1]) as PhasePlan;
+  }
+
+  /** Extract JSON check result from sub-agent response that may include prose wrapping */
+  private extractCheckResult(raw: string): { pass: boolean; issues: string[] } {
+    // Try direct parse first
+    try {
+      return JSON.parse(raw) as { pass: boolean; issues: string[] };
+    } catch {
+      // Try extracting JSON from code block
+      const codeBlockMatch = /```(?:json)?\s*([\s\S]*?)```/.exec(raw);
+      if (codeBlockMatch?.[1]) {
+        try {
+          return JSON.parse(codeBlockMatch[1]) as { pass: boolean; issues: string[] };
+        } catch { /* fall through */ }
+      }
+
+      // Try extracting JSON object from prose
+      const jsonMatch = /\{[\s\S]*?"pass"\s*:[\s\S]*?\}/.exec(raw);
+      if (jsonMatch) {
+        try {
+          return JSON.parse(jsonMatch[0]) as { pass: boolean; issues: string[] };
+        } catch { /* fall through */ }
+      }
+
+      // If raw contains "pass" keyword heuristically
+      if (/\bpass\b/i.test(raw) && !/\bfail\b/i.test(raw) && !/\bissue/i.test(raw)) {
+        return { pass: true, issues: [] };
+      }
+
+      throw new Error(`Cannot extract check result from: ${raw.slice(0, 200)}`);
+    }
   }
 }

--- a/infrastructure/runtime/src/dianoia/routes.ts
+++ b/infrastructure/runtime/src/dianoia/routes.ts
@@ -231,7 +231,7 @@ export function planningRoutes(deps: RouteDeps, _refs: RouteRefs): Hono {
         id: phase.id,
         name: phase.name,
         goal: phase.goal,
-        dependencies: [],
+        dependencies: phase.dependencies ?? [],
         requirements: phase.requirements,
         state: phase.status,
         order: phase.phaseOrder,

--- a/infrastructure/runtime/src/organon/timeout.ts
+++ b/infrastructure/runtime/src/organon/timeout.ts
@@ -16,6 +16,7 @@ export const DEFAULT_TOOL_TIMEOUTS: ToolTimeoutConfig = {
     sessions_dispatch: 0, // long-running, handles own timeouts per task
     plan_execute: 0,      // execution phases are long-running; internal dispatch handles timeouts
     plan_research: 0,     // research spawns sub-agents with own timeouts
+    plan_roadmap: 0,      // plan_phases action dispatches sub-agents for plan generation + checking
     browser: 180_000,
     web_fetch: 60_000,
     web_search: 60_000,

--- a/shared/skills/module-discovery-and-api-integration-pattern/SKILL.md
+++ b/shared/skills/module-discovery-and-api-integration-pattern/SKILL.md
@@ -1,0 +1,22 @@
+# Module Discovery and API Integration Pattern
+Locate a specific module within a large codebase, understand its structure and public API, then verify its integration points with the rest of the system.
+
+## When to Use
+When you need to understand how a particular module (e.g., a feature module, domain service, or library) is implemented and integrated into a larger system, especially in a monorepo with multiple layers (UI, runtime, infrastructure).
+
+## Steps
+1. Use find commands with path filters to locate all TypeScript files related to the target module, excluding common exclusions (node_modules, build artifacts)
+2. Search for test files associated with the module to understand expected behavior and API surface
+3. Use grep to search for key exported functions, types, or patterns across the codebase
+4. Read the module's type definitions to understand the public interface
+5. Read the module's store/data layer implementation to understand internal structure
+6. Read unit tests to see usage patterns and expected behavior
+7. Grep for specific method/function names to locate their implementation
+8. Use sed/exec to extract specific line ranges for detailed examination
+9. Search for where the module is imported/used in other parts of the system (e.g., server integration points)
+10. Grep for references to the module's exported functions in orchestrators or route handlers
+
+## Tools Used
+- exec: Find files by path pattern and exclusions; extract specific line ranges; search for import statements
+- grep: Search for function names, patterns, and module references; locate integration points
+- read: Examine type definitions, store implementations, test files, and configuration

--- a/ui/src/components/planning/DiscussionPanel.svelte
+++ b/ui/src/components/planning/DiscussionPanel.svelte
@@ -18,7 +18,7 @@
     answeredAt?: string;
   }
 
-  let { projectId }: { projectId: string } = $props();
+  let { projectId, phaseId }: { projectId: string; phaseId?: string } = $props();
 
   let questions = $state<DiscussionQuestion[]>([]);
   let loading = $state(true);
@@ -34,45 +34,39 @@
 
       // In a real implementation, this would call the API endpoint defined in Spec 32
       // For now, we'll mock some sample questions
-      const res = await fetch(`/api/planning/projects/${projectId}/discuss`);
+      const url = phaseId 
+        ? `/api/planning/projects/${projectId}/discuss?phaseId=${encodeURIComponent(phaseId)}`
+        : `/api/planning/projects/${projectId}/discuss`;
+      const res = await fetch(url);
       
       if (!res.ok) {
-        // Mock data for demonstration
-        questions = [
-          {
-            id: "q1",
-            question: "How should user authentication be handled?",
-            description: "The MVP could use simple token-based auth, but enterprise customers may need SSO integration.",
-            options: [
-              { label: "JWT tokens only", rationale: "Simple, fast to implement, covers basic use cases" },
-              { label: "JWT + OAuth providers", rationale: "Moderate complexity, handles Google/GitHub login" },
-              { label: "Full SSO suite", rationale: "Enterprise-ready but significant development time" }
-            ],
-            recommendation: "JWT + OAuth providers",
-            answered: false
-          },
-          {
-            id: "q2",
-            question: "What level of real-time collaboration is needed?",
-            description: "Project sharing could be read-only, comment-based, or full collaborative editing.",
-            options: [
-              { label: "Read-only sharing", rationale: "Minimal complexity, covers basic sharing needs" },
-              { label: "Comment system", rationale: "Enables feedback without edit conflicts" },
-              { label: "Live collaborative editing", rationale: "Full Google Docs experience but complex to implement" }
-            ],
-            recommendation: "Comment system",
-            answered: true,
-            decision: "Comment system",
-            userNote: "Focus on feedback workflow first",
-            answeredAt: new Date().toISOString()
-          }
-        ];
-        loading = false;
+        const errData = await res.json().catch(() => ({})) as { error?: string };
+        error = errData.error || `Failed to load questions (${res.status})`;
         return;
       }
 
-      const data = await res.json();
-      questions = data.questions || [];
+      const data = await res.json() as { questions?: Array<{
+        id: string;
+        question: string;
+        description?: string;
+        options: DiscussionOption[];
+        recommendation?: string;
+        status: string;
+        decision?: string | null;
+        userNote?: string | null;
+        updatedAt?: string;
+      }> };
+      questions = (data.questions ?? []).map(q => ({
+        id: q.id,
+        question: q.question,
+        description: q.description,
+        options: q.options,
+        recommendation: q.recommendation,
+        answered: q.status === "answered" || q.status === "skipped",
+        decision: q.decision ?? undefined,
+        userNote: q.userNote ?? undefined,
+        answeredAt: q.status !== "pending" ? q.updatedAt : undefined,
+      }));
     } catch (err) {
       error = err instanceof Error ? err.message : String(err);
     } finally {
@@ -86,7 +80,10 @@
     try {
       submitting[questionId] = true;
       
-      const res = await fetch(`/api/planning/projects/${projectId}/discuss`, {
+      const postUrl = phaseId
+        ? `/api/planning/projects/${projectId}/discuss?phaseId=${encodeURIComponent(phaseId)}`
+        : `/api/planning/projects/${projectId}/discuss`;
+      const res = await fetch(postUrl, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({

--- a/ui/src/components/planning/PlanningDashboard.svelte
+++ b/ui/src/components/planning/PlanningDashboard.svelte
@@ -261,9 +261,12 @@
 
         <!-- Discussion Panel (visible during discussing + phase-planning states) -->
         {#if (project.state === "discussing" || project.state === "phase-planning") && project.id}
-          <div class="dashboard-section full-width">
-            <DiscussionPanel projectId={project.id} />
-          </div>
+          {@const activePhase = phases.find(p => p.state === "active" || p.status === "pending") ?? phases[0]}
+          {#if activePhase}
+            <div class="dashboard-section full-width">
+              <DiscussionPanel projectId={project.id} phaseId={activePhase.id} />
+            </div>
+          {/if}
         {/if}
       </div>
     </div>


### PR DESCRIPTION
7 bugs found by running the full planning loop end-to-end (create → research → requirements → roadmap → discuss → plan_phases → execute).

### Requirements
- **Coverage gate default 2→1**: Small projects with a single category couldn't pass `validateCoverage`. Default `minimumCategories` lowered from 2 to 1.
- **Rationale always saved**: Was hardcoded to `null` for non-out-of-scope tiers. Now saves rationale for all decisions.
- **Fixed duplicate reqId test**: Test was asserting wrong scenario (same-category re-persist, not cross-category collision). Corrected to test actual duplicate ID detection.

### Roadmap
- **plan_roadmap timeout**: Added `0` override (no framework timeout) like plan_execute and plan_research. `plan_phases` action dispatches sub-agents that collectively take >120s, hitting the default timeout.
- **Plan checker JSON extraction**: Sub-agents frequently return prose-wrapped JSON. New `extractCheckResult()` handles code blocks, inline JSON objects, and heuristic pass detection before falling back to parse error.
- **Dependencies in /roadmap API**: V27 migration added `dependencies` column but the route was hardcoding `[]`. Now reads from schema.

### UI
- **DiscussionPanel phaseId**: Component now accepts `phaseId` prop and passes it to GET/POST discuss endpoints (previously missing, causing 400 errors)
- **DiscussionPanel status mapping**: Maps API `status` field (`pending/answered/skipped`) to component's `answered` boolean
- **Removed mock data**: DiscussionPanel was falling back to hardcoded demo questions on API error. Now shows actual error message.
- **Dashboard → DiscussionPanel wiring**: PlanningDashboard now passes the active phase ID to DiscussionPanel

### Tests
34/34 pass (requirements + roadmap). UI builds clean.