### PR TITLE
fix(hermeneus): expired OAuth token falls through to backup credentials

### DIFF
--- a/infrastructure/runtime/src/hermeneus/anthropic.test.ts
+++ b/infrastructure/runtime/src/hermeneus/anthropic.test.ts
@@ -108,4 +108,46 @@ describe("AnthropicProvider", () => {
       messages: [{ role: "user", content: "hi" }],
     })).rejects.toThrow("Network failure");
   });
+
+  it("maps expired OAuth 401 to PROVIDER_TOKEN_EXPIRED (recoverable: true)", async () => {
+    const Anthropic = (await import("@anthropic-ai/sdk")).default;
+    const provider = new AnthropicProvider({ authToken: "sk-ant-oat01-test" });
+
+    const expiredErr = new (Anthropic as unknown as { APIError: new (s: number, m: string) => Error }).APIError(
+      401,
+      "OAuth token has expired. Please obtain a new token or refresh your existing token.",
+    );
+    (provider as unknown as { client: { messages: { create: ReturnType<typeof vi.fn> } } })
+      .client.messages.create = vi.fn().mockRejectedValue(expiredErr);
+
+    const err = await provider.complete({
+      model: "claude-sonnet-4-6",
+      system: "test",
+      messages: [{ role: "user", content: "hi" }],
+    }).catch((e) => e);
+
+    expect(err.code).toBe("PROVIDER_TOKEN_EXPIRED");
+    expect(err.recoverable).toBe(true);
+  });
+
+  it("maps invalid-key 401 to PROVIDER_AUTH_FAILED (recoverable: false)", async () => {
+    const Anthropic = (await import("@anthropic-ai/sdk")).default;
+    const provider = new AnthropicProvider({ apiKey: "sk-bad-key" });
+
+    const authErr = new (Anthropic as unknown as { APIError: new (s: number, m: string) => Error }).APIError(
+      401,
+      "Invalid API key",
+    );
+    (provider as unknown as { client: { messages: { create: ReturnType<typeof vi.fn> } } })
+      .client.messages.create = vi.fn().mockRejectedValue(authErr);
+
+    const err = await provider.complete({
+      model: "claude-sonnet-4-6",
+      system: "test",
+      messages: [{ role: "user", content: "hi" }],
+    }).catch((e) => e);
+
+    expect(err.code).toBe("PROVIDER_AUTH_FAILED");
+    expect(err.recoverable).toBe(false);
+  });
 });

--- a/infrastructure/runtime/src/hermeneus/anthropic.ts
+++ b/infrastructure/runtime/src/hermeneus/anthropic.ts
@@ -231,12 +231,16 @@ export class AnthropicProvider {
         const status = error.status;
         log.error(`Anthropic API ${status}: ${error.message}`);
 
+        const isExpiredToken = status === 401
+          && error.message.includes("OAuth token has expired");
+
         const code = status === 429 ? "PROVIDER_RATE_LIMITED" as const
           : status === 529 ? "PROVIDER_OVERLOADED" as const
+          : isExpiredToken ? "PROVIDER_TOKEN_EXPIRED" as const
           : (status === 401 || status === 403) ? "PROVIDER_AUTH_FAILED" as const
           : "PROVIDER_INVALID_RESPONSE" as const;
 
-        const recoverable = status === 429 || status === 529 || status >= 500;
+        const recoverable = status === 429 || status === 529 || status >= 500 || isExpiredToken;
         throw new ProviderError(
           `Anthropic API error: ${status} ${error.message}`,
           {
@@ -286,11 +290,15 @@ export class AnthropicProvider {
       if (error instanceof Anthropic.APIError) {
         const status = error.status;
         log.error(`Anthropic API ${status}: ${error.message}`);
+        const isExpiredToken = status === 401
+          && error.message.includes("OAuth token has expired");
+
         const code = status === 429 ? "PROVIDER_RATE_LIMITED" as const
           : status === 529 ? "PROVIDER_OVERLOADED" as const
+          : isExpiredToken ? "PROVIDER_TOKEN_EXPIRED" as const
           : (status === 401 || status === 403) ? "PROVIDER_AUTH_FAILED" as const
           : "PROVIDER_INVALID_RESPONSE" as const;
-        const recoverable = status === 429 || status === 529 || status >= 500;
+        const recoverable = status === 429 || status === 529 || status >= 500 || isExpiredToken;
         throw new ProviderError(`Anthropic API error: ${status} ${error.message}`, {
           cause: error, code, recoverable,
           ...(status === 429 ? { retryAfterMs: 60_000 } : status === 529 ? { retryAfterMs: 30_000 } : {}),

--- a/infrastructure/runtime/src/koina/error-codes.ts
+++ b/infrastructure/runtime/src/koina/error-codes.ts
@@ -7,6 +7,7 @@ export const ERROR_CODES = {
   PROVIDER_TIMEOUT: "API call timed out",
   PROVIDER_RATE_LIMITED: "Rate limited by provider",
   PROVIDER_AUTH_FAILED: "Authentication failed",
+  PROVIDER_TOKEN_EXPIRED: "OAuth token expired — falling through to backup credential",
   PROVIDER_INVALID_RESPONSE: "Provider returned unexpected response format",
   PROVIDER_NOT_FOUND: "No provider registered for requested model",
   PROVIDER_OVERLOADED: "Provider returned 529 overloaded",

--- a/infrastructure/runtime/src/pylon/routes/system.ts
+++ b/infrastructure/runtime/src/pylon/routes/system.ts
@@ -81,7 +81,21 @@ export function systemRoutes(deps: RouteDeps, _refs: RouteRefs): Hono {
           backups.push({ label, type });
         }
       }
-      return c.json({ primary: { label: primary, type: authType }, backups });
+      const expiresAtMs = typeof raw["expiresAt"] === "number" ? raw["expiresAt"] as number : undefined;
+      const expiresAt = expiresAtMs !== undefined ? new Date(expiresAtMs).toISOString() : undefined;
+      const now = Date.now();
+      return c.json({
+        primary: {
+          label: primary,
+          type: authType,
+          ...(expiresAt !== undefined ? {
+            expiresAt,
+            isExpired: expiresAtMs! < now,
+            expiresInMs: expiresAtMs! - now,
+          } : {}),
+        },
+        backups,
+      });
     } catch {
       return c.json({ primary: { label: "default", type: "unknown" }, backups: [] });
     }

--- a/shared/bin/credential-refresh
+++ b/shared/bin/credential-refresh
@@ -28,14 +28,14 @@ import urllib.error
 
 # Claude Code production OAuth client ID (from cli.js)
 CLIENT_ID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e"
-TOKEN_URL = "https://console.anthropic.com/v1/oauth/token"
+TOKEN_URL = "https://platform.claude.com/v1/oauth/token"
 
 # Refresh when token has less than this many seconds left
 _config = {"threshold": 3600, "interval": 300}
 
 # Credential file locations
 ALETHEIA_CRED = Path.home() / ".aletheia" / "credentials" / "anthropic.json"
-CLAUDE_CODE_CRED = Path.home().parent / "ck" / ".claude" / ".credentials.json"
+CLAUDE_CODE_CRED = Path.home() / ".claude" / ".credentials.json"
 
 
 def log(msg: str, level: str = "INFO"):

--- a/shared/bin/start.sh
+++ b/shared/bin/start.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# start.sh — Template for ~/.aletheia/start.sh
+# Copy to ~/.aletheia/start.sh and make executable.
+# Run `claude setup-token` first to get a 1-year OAuth token, then this script
+# uses credential-refresh to keep it renewed automatically on every startup.
+set -euo pipefail
+
+ALETHEIA_CREDS="$HOME/.aletheia/credentials/anthropic.json"
+CLAUDE_JSON="$HOME/.claude.json"
+
+# Attempt OAuth token refresh if a token is already stored
+if command -v credential-refresh &>/dev/null && [[ -f "$ALETHEIA_CREDS" ]]; then
+  has_token=$(python3 -c "
+import json, sys
+try:
+    d = json.load(open('$ALETHEIA_CREDS'))
+    print('yes' if d.get('token','').startswith('sk-ant-oat') else 'no')
+except Exception:
+    print('no')
+" 2>/dev/null || echo "no")
+  if [[ "$has_token" == "yes" ]]; then
+    credential-refresh || echo "warn: credential-refresh failed — proceeding with existing token" >&2
+  fi
+fi
+
+# Fall back to API key sync from Claude Code config if no OAuth token present
+if [[ -f "$CLAUDE_JSON" ]]; then
+  api_key=$(python3 -c "
+import json
+print(json.load(open('$CLAUDE_JSON')).get('primaryApiKey', ''))
+" 2>/dev/null || true)
+  if [[ -n "$api_key" && "${api_key:0:11}" == "sk-ant-api0" ]]; then
+    mkdir -p "$(dirname "$ALETHEIA_CREDS")"
+    python3 -c "
+import json
+path = '$ALETHEIA_CREDS'
+try:
+    existing = json.load(open(path))
+except Exception:
+    existing = {}
+if not existing.get('token','').startswith('sk-ant-oat'):
+    existing.pop('token', None)
+    existing['apiKey'] = '$api_key'
+    existing.setdefault('backupKeys', [])
+    json.dump(existing, open(path, 'w'), indent=2)
+" 2>/dev/null
+    chmod 600 "$ALETHEIA_CREDS"
+    echo "API key synced from Claude Code config"
+  fi
+fi
+
+if [[ ! -f "$ALETHEIA_CREDS" ]]; then
+  echo "error: No credentials found. Run: claude setup-token" >&2
+  exit 1
+fi
+
+export ALETHEIA_ROOT="${ALETHEIA_ROOT:-$HOME/summus/ergon}"
+export ALETHEIA_MEMORY_USER="${ALETHEIA_MEMORY_USER:-$(whoami)}"
+exec node "$ALETHEIA_ROOT/dist/entry.mjs" gateway start \
+  --config "$HOME/.aletheia/aletheia.json" "$@"


### PR DESCRIPTION
## Summary

- Expired OAuth tokens (`sk-ant-oat01-*`) now produce `PROVIDER_TOKEN_EXPIRED` (`recoverable: true`) instead of `PROVIDER_AUTH_FAILED` (`recoverable: false`) — the router's existing backup failover then tries backup API keys automatically, no router changes needed
- Fix two bugs in `credential-refresh`: wrong `TOKEN_URL` (`console.anthropic.com` → `platform.claude.com`) and hardcoded username in `CLAUDE_CODE_CRED` path
- Add `shared/bin/start.sh` template: runs `credential-refresh` on startup if an OAuth token is present, falls back to API key sync from Claude Code config
- `GET /api/system/credentials` now includes `expiresAt`, `isExpired`, `expiresInMs` when expiry is stored in the credential file

## What this enables

`claude setup-token` generates a **1-year OAuth token**. With this PR:
1. Run `claude setup-token` once — writes long-lived token to aletheia credentials
2. `start.sh` calls `credential-refresh` on every restart to proactively renew
3. If the token still expires (refresh token also expired), backup API keys are tried before failing

## Notes

- Detection uses `error.message.includes("OAuth token has expired")` — degrades gracefully if the string changes (falls back to non-recoverable `PROVIDER_AUTH_FAILED`, same as today)
- Hot-reload of credentials without restart is deferred — a restart is still required after `credential-refresh` writes a new token
- `start.sh` is a template; copy to `~/.aletheia/start.sh` on deployment

## Test plan

- [ ] `npx vitest run src/hermeneus/anthropic.test.ts` — 9 tests pass (2 new: expired OAuth → `PROVIDER_TOKEN_EXPIRED`, invalid key → `PROVIDER_AUTH_FAILED`)
- [ ] `npx tsc --noEmit` — clean
- [ ] Manual: set expired token in credentials, send a turn, confirm backup API key is tried
- [ ] `credential-refresh --status` shows correct token state

Closes #207