### PR TITLE
feat(ui): credential management in settings + metrics status card

### DIFF
--- a/infrastructure/runtime/src/pylon/routes/system.ts
+++ b/infrastructure/runtime/src/pylon/routes/system.ts
@@ -1,6 +1,6 @@
 // System routes — health, status, update, config reload
 import { Hono } from "hono";
-import { readFileSync } from "node:fs";
+import { readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { homedir } from "node:os";
 import { createLogger } from "../../koina/logger.js";
@@ -98,6 +98,91 @@ export function systemRoutes(deps: RouteDeps, _refs: RouteRefs): Hono {
       });
     } catch {
       return c.json({ primary: { label: "default", type: "unknown" }, backups: [] });
+    }
+  });
+
+  // Update primary credential
+  app.put("/api/system/credentials/primary", async (c) => {
+    const credPath = join(
+      process.env["ALETHEIA_CONFIG_DIR"] ?? join(homedir(), ".aletheia"),
+      "credentials", "anthropic.json",
+    );
+    const body = await c.req.json<{ type: "oauth" | "api"; value: string; label?: string }>();
+    if (!body.value || typeof body.value !== "string") {
+      return c.json({ error: "value is required" }, 400);
+    }
+    const credType = body.type === "oauth" ? "oauth" : "api";
+    try {
+      let existing: Record<string, unknown> = {};
+      try { existing = JSON.parse(readFileSync(credPath, "utf-8")) as Record<string, unknown>; } catch { /* new file */ }
+      const updated: Record<string, unknown> = {
+        ...existing,
+        label: typeof body.label === "string" && body.label ? body.label : (existing["label"] ?? "primary"),
+      };
+      if (credType === "oauth") {
+        updated["token"] = body.value;
+        delete updated["apiKey"];
+      } else {
+        updated["apiKey"] = body.value;
+        delete updated["token"];
+        delete updated["expiresAt"];
+      }
+      writeFileSync(credPath, JSON.stringify(updated), "utf-8");
+      log.info("Primary credential updated", { type: credType });
+      return c.json({ ok: true });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      log.warn("Failed to update primary credential", { err: msg });
+      return c.json({ error: msg }, 500);
+    }
+  });
+
+  // Add a backup credential
+  app.post("/api/system/credentials/backups", async (c) => {
+    const credPath = join(
+      process.env["ALETHEIA_CONFIG_DIR"] ?? join(homedir(), ".aletheia"),
+      "credentials", "anthropic.json",
+    );
+    const body = await c.req.json<{ type: "oauth" | "api"; value: string; label: string }>();
+    if (!body.value || !body.label) return c.json({ error: "value and label are required" }, 400);
+    const credType = body.type === "oauth" ? "oauth" : "api";
+    try {
+      let existing: Record<string, unknown> = {};
+      try { existing = JSON.parse(readFileSync(credPath, "utf-8")) as Record<string, unknown>; } catch { /* new file */ }
+      const backups = Array.isArray(existing["backupCredentials"])
+        ? (existing["backupCredentials"] as Array<Record<string, unknown>>).filter(b => b["label"] !== body.label)
+        : [];
+      const entry: Record<string, string> = { label: body.label, type: credType };
+      if (credType === "oauth") entry["token"] = body.value;
+      else entry["apiKey"] = body.value;
+      backups.push(entry);
+      writeFileSync(credPath, JSON.stringify({ ...existing, backupCredentials: backups }), "utf-8");
+      log.info("Backup credential added", { label: body.label, type: credType });
+      return c.json({ ok: true });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return c.json({ error: msg }, 500);
+    }
+  });
+
+  // Remove a backup credential by label
+  app.delete("/api/system/credentials/backups/:label", (c) => {
+    const credPath = join(
+      process.env["ALETHEIA_CONFIG_DIR"] ?? join(homedir(), ".aletheia"),
+      "credentials", "anthropic.json",
+    );
+    const label = c.req.param("label");
+    try {
+      const existing = JSON.parse(readFileSync(credPath, "utf-8")) as Record<string, unknown>;
+      const backups = Array.isArray(existing["backupCredentials"])
+        ? (existing["backupCredentials"] as Array<Record<string, unknown>>).filter(b => b["label"] !== label)
+        : [];
+      writeFileSync(credPath, JSON.stringify({ ...existing, backupCredentials: backups }), "utf-8");
+      log.info("Backup credential removed", { label });
+      return c.json({ ok: true });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return c.json({ error: msg }, 500);
     }
   });
 

--- a/ui/src/components/metrics/MetricsView.svelte
+++ b/ui/src/components/metrics/MetricsView.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { fetchMetrics, fetchCostSummary } from "../../lib/api";
+  import { fetchMetrics, fetchCostSummary, fetchCredentialInfo } from "../../lib/api";
+  import type { CredentialInfo } from "../../lib/api";
   import { formatTokens, formatUptime, formatCost, formatTimeSince } from "../../lib/format";
   import Badge from "../shared/Badge.svelte";
   import UsageChart from "./UsageChart.svelte";
@@ -7,13 +8,22 @@
 
   let metrics = $state<MetricsData | null>(null);
   let costs = $state<CostSummary | null>(null);
+  let creds = $state<CredentialInfo | null>(null);
   let error = $state<string | null>(null);
+
+  function credStatus(c: CredentialInfo): { label: string; variant: "success" | "warning" | "error" } {
+    if (c.primary.isExpired) return { label: "expired", variant: "error" };
+    if (c.primary.expiresInMs !== undefined && c.primary.expiresInMs < 86_400_000) return { label: "expiring", variant: "warning" };
+    if (c.backups.length === 0) return { label: "no backup", variant: "warning" };
+    return { label: "ok", variant: "success" };
+  }
 
   async function load() {
     try {
-      const [m, c] = await Promise.all([fetchMetrics(), fetchCostSummary()]);
+      const [m, c, cr] = await Promise.all([fetchMetrics(), fetchCostSummary(), fetchCredentialInfo()]);
       metrics = m;
       costs = c;
+      creds = cr;
     } catch (err) {
       error = err instanceof Error ? err.message : String(err);
     }
@@ -72,6 +82,24 @@
           {/each}
         </div>
       </div>
+      {#if creds}
+        {@const status = credStatus(creds)}
+        <div class="card">
+          <div class="card-label">Credentials</div>
+          <div class="card-value card-value-sm">
+            <span class="mono">{creds.primary.label}</span>
+          </div>
+          <div class="card-sub">
+            <Badge text={creds.primary.type} variant="default" />
+            <Badge text={status.label} variant={status.variant} />
+          </div>
+          {#if creds.backups.length > 0}
+            <div class="card-sub" style="margin-top: 4px">
+              {creds.backups.length} backup{creds.backups.length > 1 ? "s" : ""}
+            </div>
+          {/if}
+        </div>
+      {/if}
     </div>
 
     <div class="section">
@@ -165,6 +193,9 @@
   .card-value {
     font-size: var(--text-3xl);
     font-weight: 700;
+  }
+  .card-value-sm {
+    font-size: var(--text-lg);
   }
   .card-sub {
     font-size: var(--text-sm);

--- a/ui/src/components/settings/SettingsView.svelte
+++ b/ui/src/components/settings/SettingsView.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { getToken, setToken, clearToken, createAgent } from "../../lib/api";
+  import { getToken, setToken, clearToken, createAgent, fetchCredentialInfo, updatePrimaryCredential, addBackupCredential, deleteBackupCredential } from "../../lib/api";
+  import type { CredentialInfo } from "../../lib/api";
   import { getAgents, loadAgents, setActiveAgent } from "../../stores/agents.svelte";
   import { loadSessions } from "../../stores/sessions.svelte";
   import { onMount } from "svelte";
@@ -21,6 +22,80 @@
   let fontSize = $state<number>(
     parseInt(localStorage.getItem(FONT_SIZE_KEY) ?? "14", 10),
   );
+
+  let credInfo = $state<CredentialInfo | null>(null);
+  let credLoading = $state(false);
+  let credError = $state("");
+
+  let primaryType = $state<"oauth" | "api">("api");
+  let primaryValue = $state("");
+  let primaryLabel = $state("");
+  let primarySaving = $state(false);
+  let primarySaved = $state(false);
+
+  let backupType = $state<"oauth" | "api">("api");
+  let backupValue = $state("");
+  let backupLabel = $state("");
+  let backupSaving = $state(false);
+  let showAddBackup = $state(false);
+
+  async function loadCredentials() {
+    credLoading = true;
+    credError = "";
+    try {
+      credInfo = await fetchCredentialInfo();
+      primaryLabel = credInfo.primary.label;
+      primaryType = credInfo.primary.type === "oauth" ? "oauth" : "api";
+    } catch (err) {
+      credError = err instanceof Error ? err.message : String(err);
+    } finally {
+      credLoading = false;
+    }
+  }
+
+  async function savePrimary() {
+    if (!primaryValue.trim()) return;
+    primarySaving = true;
+    credError = "";
+    try {
+      await updatePrimaryCredential(primaryType, primaryValue.trim(), primaryLabel.trim() || undefined);
+      primaryValue = "";
+      primarySaved = true;
+      setTimeout(() => { primarySaved = false; }, 3000);
+      await loadCredentials();
+    } catch (err) {
+      credError = err instanceof Error ? err.message : String(err);
+    } finally {
+      primarySaving = false;
+    }
+  }
+
+  async function saveBackup() {
+    if (!backupValue.trim() || !backupLabel.trim()) return;
+    backupSaving = true;
+    credError = "";
+    try {
+      await addBackupCredential(backupType, backupValue.trim(), backupLabel.trim());
+      backupValue = "";
+      backupLabel = "";
+      showAddBackup = false;
+      await loadCredentials();
+    } catch (err) {
+      credError = err instanceof Error ? err.message : String(err);
+    } finally {
+      backupSaving = false;
+    }
+  }
+
+  async function removeBackup(label: string) {
+    credError = "";
+    try {
+      await deleteBackupCredential(label);
+      await loadCredentials();
+    } catch (err) {
+      credError = err instanceof Error ? err.message : String(err);
+    }
+  }
 
   let showCreateForm = $state(false);
   let formName = $state("");
@@ -66,6 +141,7 @@
     } catch {
       // auth mode unavailable
     }
+    await loadCredentials();
   });
 
   function saveToken() {
@@ -210,6 +286,146 @@
       {/if}
     </section>
 
+    <section class="settings-section">
+      <h3 class="section-title">Credentials</h3>
+
+      {#if credError}
+        <div class="form-error" style="margin-bottom: 8px">{credError}</div>
+      {/if}
+
+      <div class="cred-subsection-label">Primary</div>
+      {#if credInfo}
+        <div class="setting-row">
+          <span class="setting-label">Current</span>
+          <span class="setting-value">
+            <span class="cred-label mono">{credInfo.primary.label}</span>
+            <span class="cred-type-badge cred-type-{credInfo.primary.type}">{credInfo.primary.type}</span>
+            {#if credInfo.primary.isExpired}
+              <span class="cred-type-badge cred-expired">expired</span>
+            {:else if credInfo.primary.expiresInMs !== undefined && credInfo.primary.expiresInMs < 86_400_000}
+              <span class="cred-type-badge cred-expiring">expires soon</span>
+            {/if}
+          </span>
+        </div>
+      {/if}
+
+      <div class="cred-how-to">
+        <div class="how-to-tabs">
+          <button
+            class="how-to-tab"
+            class:active={primaryType === "api"}
+            onclick={() => { primaryType = "api"; }}
+          >API Key</button>
+          <button
+            class="how-to-tab"
+            class:active={primaryType === "oauth"}
+            onclick={() => { primaryType = "oauth"; }}
+          >OAuth Token</button>
+        </div>
+        {#if primaryType === "api"}
+          <p class="how-to-text">
+            Get an API key from <strong>console.anthropic.com</strong> → API Keys.
+            Use this for direct API access or a team billing seat (e.g. a Summus API account).
+            Keys start with <code>sk-ant-api03-</code>.
+          </p>
+        {:else}
+          <p class="how-to-text">
+            Run <code>claude setup-token</code> in your terminal and paste the result.
+            This generates a one-year OAuth token tied to your Claude.ai Max account.
+            Tokens start with <code>sk-ant-oat01-</code>.
+          </p>
+        {/if}
+      </div>
+
+      <div class="cred-update-form">
+        <div class="cred-row">
+          <input
+            type="text"
+            class="settings-input cred-label-input"
+            placeholder="Label (e.g. max-5x)"
+            bind:value={primaryLabel}
+            disabled={primarySaving}
+          />
+          <input
+            type="password"
+            class="settings-input cred-value-input"
+            placeholder={primaryType === "oauth" ? "sk-ant-oat01-…" : "sk-ant-api03-…"}
+            bind:value={primaryValue}
+            disabled={primarySaving}
+          />
+          <button
+            class="btn-primary"
+            onclick={savePrimary}
+            disabled={primarySaving || !primaryValue.trim()}
+          >
+            {#if primarySaved}Saved{:else if primarySaving}Saving…{:else}Update{/if}
+          </button>
+        </div>
+      </div>
+
+      <div class="cred-divider"></div>
+
+      <div class="cred-subsection-label">Backups <span class="cred-hint">— used when primary fails or expires</span></div>
+
+      {#if credInfo && credInfo.backups.length > 0}
+        {#each credInfo.backups as backup (backup.label)}
+          <div class="setting-row">
+            <span class="setting-label">
+              <span class="mono">{backup.label}</span>
+              <span class="cred-type-badge cred-type-{backup.type}">{backup.type}</span>
+            </span>
+            <button class="btn-remove" onclick={() => removeBackup(backup.label)} aria-label="Remove {backup.label}">Remove</button>
+          </div>
+        {/each}
+      {:else if !credLoading}
+        <div class="setting-row">
+          <span class="setting-label muted">No backup credentials</span>
+        </div>
+      {/if}
+
+      {#if showAddBackup}
+        <div class="create-form">
+          <div class="how-to-tabs">
+            <button
+              class="how-to-tab"
+              class:active={backupType === "api"}
+              onclick={() => { backupType = "api"; }}
+            >API Key</button>
+            <button
+              class="how-to-tab"
+              class:active={backupType === "oauth"}
+              onclick={() => { backupType = "oauth"; }}
+            >OAuth Token</button>
+          </div>
+          <div class="cred-row">
+            <input
+              type="text"
+              class="settings-input cred-label-input"
+              placeholder="Label (e.g. api-backup)"
+              bind:value={backupLabel}
+              disabled={backupSaving}
+            />
+            <input
+              type="password"
+              class="settings-input cred-value-input"
+              placeholder={backupType === "oauth" ? "sk-ant-oat01-…" : "sk-ant-api03-…"}
+              bind:value={backupValue}
+              disabled={backupSaving}
+            />
+          </div>
+          <div class="form-actions">
+            <button
+              class="btn-primary"
+              onclick={saveBackup}
+              disabled={backupSaving || !backupValue.trim() || !backupLabel.trim()}
+            >{backupSaving ? "Saving…" : "Add Backup"}</button>
+            <button class="btn-cancel" onclick={() => { showAddBackup = false; backupValue = ""; backupLabel = ""; }}>Cancel</button>
+          </div>
+        </div>
+      {:else}
+        <button class="btn-add" onclick={() => { showAddBackup = true; }}>+ Add Backup</button>
+      {/if}
+    </section>
 
   </div>
 </div>
@@ -418,5 +634,99 @@
   }
   .btn-cancel:hover {
     color: var(--text);
+  }
+  .cred-subsection-label {
+    font-size: var(--text-xs);
+    font-weight: 600;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    margin: 4px 0 8px;
+  }
+  .cred-hint {
+    font-weight: 400;
+    text-transform: none;
+    letter-spacing: 0;
+    color: var(--text-muted);
+    opacity: 0.7;
+  }
+  .cred-type-badge {
+    font-size: var(--text-xs);
+    padding: 1px 6px;
+    border-radius: var(--radius-pill);
+    font-weight: 600;
+    margin-left: 6px;
+  }
+  .cred-type-oauth { background: var(--status-info-bg, rgba(59,130,246,0.15)); color: var(--status-info, #60a5fa); }
+  .cred-type-api   { background: var(--surface); color: var(--text-secondary); border: 1px solid var(--border); }
+  .cred-expired    { background: var(--status-error-bg); color: var(--status-error); }
+  .cred-expiring   { background: var(--status-warning-bg); color: var(--status-warning); }
+  .cred-how-to {
+    margin: 10px 0 8px;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    padding: 10px 12px;
+  }
+  .how-to-tabs {
+    display: flex;
+    gap: 2px;
+    margin-bottom: 8px;
+  }
+  .how-to-tab {
+    background: none;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    color: var(--text-secondary);
+    padding: 3px 10px;
+    font-size: var(--text-xs);
+    font-weight: 600;
+    transition: all var(--transition-quick);
+  }
+  .how-to-tab.active {
+    background: var(--accent);
+    border-color: var(--accent);
+    color: var(--bg);
+  }
+  .how-to-text {
+    font-size: var(--text-xs);
+    color: var(--text-secondary);
+    line-height: 1.5;
+    margin: 0;
+  }
+  .how-to-text code {
+    font-family: var(--font-mono);
+    background: var(--bg-elevated);
+    border: 1px solid var(--border);
+    border-radius: 3px;
+    padding: 0 4px;
+  }
+  .cred-update-form {
+    margin-top: 8px;
+  }
+  .cred-row {
+    display: flex;
+    gap: 6px;
+    align-items: center;
+  }
+  .cred-label-input { flex: 0 0 140px; }
+  .cred-value-input { flex: 1; }
+  .cred-divider {
+    height: 1px;
+    background: var(--border);
+    margin: 14px 0;
+  }
+  .btn-remove {
+    background: none;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    color: var(--text-secondary);
+    padding: 3px 10px;
+    font-size: var(--text-xs);
+    transition: all var(--transition-quick);
+  }
+  .btn-remove:hover {
+    border-color: var(--status-error);
+    color: var(--status-error);
   }
 </style>

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -363,10 +363,46 @@ export async function fetchToolStats(agentId?: string, window = "7d"): Promise<u
 // --- Credential Info ---
 
 export interface CredentialInfo {
-  primary: { label: string; type: string };
+  primary: {
+    label: string;
+    type: string;
+    expiresAt?: string;
+    isExpired?: boolean;
+    expiresInMs?: number;
+  };
   backups: Array<{ label: string; type: string }>;
 }
 
 export async function fetchCredentialInfo(): Promise<CredentialInfo> {
   return fetchJson("/api/system/credentials");
+}
+
+export async function updatePrimaryCredential(
+  type: "oauth" | "api",
+  value: string,
+  label?: string,
+): Promise<void> {
+  await fetchJson("/api/system/credentials/primary", {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ type, value, label }),
+  });
+}
+
+export async function addBackupCredential(
+  type: "oauth" | "api",
+  value: string,
+  label: string,
+): Promise<void> {
+  await fetchJson("/api/system/credentials/backups", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ type, value, label }),
+  });
+}
+
+export async function deleteBackupCredential(label: string): Promise<void> {
+  await fetchJson(`/api/system/credentials/backups/${encodeURIComponent(label)}`, {
+    method: "DELETE",
+  });
 }


### PR DESCRIPTION
## Summary

- **Settings → Credentials section**: manage primary and backup credentials directly from the UI without touching the filesystem
- **Metrics → Credentials card**: at-a-glance status alongside uptime/tokens/services

## Settings: Credentials Section

**Primary credential:**
- Shows current label, type badge (oauth/api), and expiry warnings (expired / expiring soon)
- Tab toggle to switch between API Key and OAuth Token mode — each tab shows concise instructions on how to get that credential type
- Label + value inputs, Update button

**Backup credentials:**
- List of configured backups with type badges and per-item Remove button  
- Add Backup form (same tab toggle + instructions)
- Displayed with "used when primary fails or expires" note

**How-to instructions (inline, not docs):**
- API Key tab: `console.anthropic.com → API Keys`, keys start with `sk-ant-api03-`
- OAuth tab: `claude setup-token` in terminal, tokens start with `sk-ant-oat01-`

## Metrics: Credentials Card

New card in the status grid showing:
- Primary label (mono)
- Type badge + status badge (`ok` / `expiring` / `expired` / `no backup`)
- Backup count

## Backend (3 new routes)

| Method | Path | Purpose |
|--------|------|---------|
| `PUT` | `/api/system/credentials/primary` | Set/update primary token or key |
| `POST` | `/api/system/credentials/backups` | Add a backup credential |
| `DELETE` | `/api/system/credentials/backups/:label` | Remove a backup by label |

Writes are atomic JSON file updates to `~/.aletheia/credentials/anthropic.json`. No secrets are ever read back to the client.

## Test plan

- [ ] Settings → Credentials section renders with current primary label/type
- [ ] Switch to OAuth tab → instructions update, placeholder changes
- [ ] Paste API key, click Update → credential file updates, current row refreshes
- [ ] Add backup → appears in list; Remove → disappears
- [ ] Metrics card shows correct label, type, and status badge
- [ ] Expired OAuth primary → "expired" badge in both Settings and Metrics