### PR TITLE
fix(metrics): remove cost estimates, fix cache hit rate, daily token chart

### DIFF
--- a/infrastructure/runtime/src/pylon/routes/metrics.ts
+++ b/infrastructure/runtime/src/pylon/routes/metrics.ts
@@ -100,10 +100,10 @@ export function metricRoutes(deps: RouteDeps, refs: RouteRefs): Hono {
     });
 
     const cacheHitRate =
-      metrics.usage.totalInputTokens > 0
+      (metrics.usage.totalInputTokens + metrics.usage.totalCacheReadTokens) > 0
         ? Math.round(
             (metrics.usage.totalCacheReadTokens /
-              metrics.usage.totalInputTokens) *
+              (metrics.usage.totalInputTokens + metrics.usage.totalCacheReadTokens)) *
               100,
           )
         : 0;

--- a/ui/src/components/metrics/MetricsView.svelte
+++ b/ui/src/components/metrics/MetricsView.svelte
@@ -1,13 +1,12 @@
 <script lang="ts">
-  import { fetchMetrics, fetchCostSummary, fetchCredentialInfo } from "../../lib/api";
+  import { fetchMetrics, fetchCredentialInfo } from "../../lib/api";
   import type { CredentialInfo } from "../../lib/api";
-  import { formatTokens, formatUptime, formatCost, formatTimeSince } from "../../lib/format";
+  import { formatTokens, formatUptime, formatTimeSince } from "../../lib/format";
   import Badge from "../shared/Badge.svelte";
   import UsageChart from "./UsageChart.svelte";
-  import type { MetricsData, CostSummary } from "../../lib/types";
+  import type { MetricsData } from "../../lib/types";
 
   let metrics = $state<MetricsData | null>(null);
-  let costs = $state<CostSummary | null>(null);
   let creds = $state<CredentialInfo | null>(null);
   let error = $state<string | null>(null);
 
@@ -20,9 +19,8 @@
 
   async function load() {
     try {
-      const [m, c, cr] = await Promise.all([fetchMetrics(), fetchCostSummary(), fetchCredentialInfo()]);
+      const [m, cr] = await Promise.all([fetchMetrics(), fetchCredentialInfo()]);
       metrics = m;
-      costs = c;
       creds = cr;
     } catch (err) {
       error = err instanceof Error ? err.message : String(err);
@@ -55,18 +53,12 @@
       <div class="card">
         <div class="card-label">Cache Hit Rate</div>
         <div class="card-value">{metrics.usage.cacheHitRate}%</div>
-        <div class="card-sub">{formatTokens(metrics.usage.totalCacheReadTokens)} cached</div>
+        <div class="card-sub">{formatTokens(metrics.usage.totalCacheReadTokens)} from cache</div>
       </div>
       <div class="card">
         <div class="card-label">Turns</div>
         <div class="card-value">{metrics.usage.turnCount}</div>
       </div>
-      {#if costs}
-        <div class="card">
-          <div class="card-label">Total Cost</div>
-          <div class="card-value">{formatCost(costs.totalCost)}</div>
-        </div>
-      {/if}
       <div class="card">
         <div class="card-label">Services</div>
         <div class="card-value">
@@ -117,14 +109,10 @@
             <th>Last Activity</th>
             <th>Tokens In</th>
             <th>Turns</th>
-            {#if costs}
-              <th>Cost</th>
-            {/if}
           </tr>
         </thead>
         <tbody>
           {#each metrics.nous as agent}
-            {@const agentCost = costs?.agents.find(a => a.agentId === agent.id)}
             <tr>
               <td class="agent-name">{agent.name}</td>
               <td>{agent.activeSessions}</td>
@@ -132,9 +120,6 @@
               <td class="muted">{formatTimeSince(agent.lastActivity)}</td>
               <td>{agent.tokens ? formatTokens(agent.tokens.input) : "-"}</td>
               <td>{agent.tokens?.turns ?? "-"}</td>
-              {#if costs}
-                <td>{agentCost ? formatCost(agentCost.totalCost || agentCost.cost) : "-"}</td>
-              {/if}
             </tr>
           {/each}
         </tbody>

--- a/ui/src/components/metrics/UsageChart.svelte
+++ b/ui/src/components/metrics/UsageChart.svelte
@@ -1,13 +1,13 @@
 <script lang="ts">
   import { fetchDailyCosts } from "../../lib/api";
-  import { formatCost } from "../../lib/format";
+  import { formatTokens } from "../../lib/format";
   import type { DailyCost } from "../../lib/types";
   import { onMount } from "svelte";
 
   let data = $state<DailyCost[]>([]);
   let loading = $state(true);
   let error = $state<string | null>(null);
-  let maxCost = $derived(Math.max(...data.map((d) => d.cost), 0.001));
+  let maxTokens = $derived(Math.max(...data.map((d) => d.tokens), 1));
 
   onMount(async () => {
     try {
@@ -21,7 +21,7 @@
 </script>
 
 <div class="usage-chart">
-  <h3>Daily Cost (30d)</h3>
+  <h3>Daily Usage (30d)</h3>
   {#if loading}
     <div class="chart-empty">Loading...</div>
   {:else if error}
@@ -32,8 +32,8 @@
     <div class="chart-container">
       <div class="chart-bars">
         {#each data as day}
-          {@const pct = (day.cost / maxCost) * 100}
-          <div class="bar-col" title="{day.date}: {formatCost(day.cost)} · {day.turns} turns">
+          {@const pct = (day.tokens / maxTokens) * 100}
+          <div class="bar-col" title="{day.date}: {formatTokens(day.tokens)} · {day.turns} turns">
             <div class="bar" style="height: {Math.max(pct, 2)}%"></div>
           </div>
         {/each}
@@ -43,7 +43,7 @@
         <span>{data[data.length - 1]?.date.slice(5)}</span>
       </div>
       <div class="chart-summary">
-        Total: {formatCost(data.reduce((s, d) => s + d.cost, 0))} · {data.reduce((s, d) => s + d.turns, 0)} turns
+        Total: {formatTokens(data.reduce((s, d) => s + d.tokens, 0))} · {data.reduce((s, d) => s + d.turns, 0)} turns
       </div>
     </div>
   {/if}


### PR DESCRIPTION
Cherry-picked from #218 — clean metrics-only changes without the unrelated tooling/dianoia/planning commits that were on that branch.

- Cache hit rate formula fixed (was >100%, now 0-100%)
- Cost estimates removed (meaningless on OAuth seat)  
- Daily chart shows token volume instead of cost