### PR TITLE
fix: pass memoryTarget to emergency distillation in context stage

### DIFF
--- a/infrastructure/runtime/src/nous/pipeline/stages/context.ts
+++ b/infrastructure/runtime/src/nous/pipeline/stages/context.ts
@@ -77,6 +77,7 @@ export async function buildContext(
             preserveRecentMaxTokens: compaction.preserveRecentMaxTokens,
             ...(workspace ? { workspace } : {}),
             ...(services.plugins ? { plugins: services.plugins } : {}),
+            ...(services.memoryTarget ? { memoryTarget: services.memoryTarget } : {}),
             ...(thread ? {
               onThreadSummaryUpdate: (summary, keyFacts) => {
                 services.store.updateThreadSummary(thread.id, summary, keyFacts);


### PR DESCRIPTION
## What

One-line fix: pass `services.memoryTarget` to the emergency distillation call in `context.ts`.

## Why

The emergency distillation path (triggered when context hits 90% of the window) was the only distillation call site that didn't pass `memoryTarget`. Extracted facts were written to workspace files but never flushed to the mem0 sidecar, making them invisible to pre-turn recall until the nightly reflection cron ran (~6am next day).

## Changes

- `context.ts`: Added `...(services.memoryTarget ? { memoryTarget: services.memoryTarget } : {})` to the `distillSession()` options

## Audit

All other distillation call sites already pass `memoryTarget`:
- `manager.ts`: 3 calls (scheduled, background, manual) — all ✅
- `reflection-cron.ts`: 1 call — ✅
- `context.ts`: 1 call — was ❌, now ✅

Closes #197