### PR TITLE
fix(auth): resilient session refresh — visibility-aware, retry, dedup

### DIFF
--- a/infrastructure/runtime/src/pylon/routes/auth.ts
+++ b/infrastructure/runtime/src/pylon/routes/auth.ts
@@ -38,10 +38,30 @@ function clearRefreshCookie(c: import("hono").Context, secureCookies: boolean): 
   c.header("Set-Cookie", parts.join("; "));
 }
 
+/**
+ * Determine whether the Secure flag should be set on cookies.
+ * When behind a TLS-terminating reverse proxy (Caddy, nginx), the backend
+ * sees plain HTTP but the browser sees HTTPS.  In that case the configured
+ * `secureCookies` should be false — but if the user forgets, we auto-detect
+ * by checking for X-Forwarded-Proto / X-Real-IP headers that proxies inject.
+ */
+function resolveSecureCookies(
+  c: import("hono").Context,
+  configured: boolean,
+): boolean {
+  if (!configured) return false;
+  // If the proxy tells us the original request was HTTPS, Secure is safe
+  const proto = c.req.header("X-Forwarded-Proto");
+  if (proto === "https") return true;
+  // If we see proxy headers but no proto, assume TLS termination → don't set Secure
+  if (c.req.header("X-Forwarded-For") || c.req.header("X-Real-IP")) return false;
+  return configured;
+}
+
 export function authRoutes(deps: RouteDeps, _refs: RouteRefs): Hono {
   const app = new Hono();
   const { authConfig, authSessionStore, authRoutes: auth } = deps;
-  const secureCookies = authConfig.session?.secureCookies ?? true;
+  const configuredSecureCookies = authConfig.session?.secureCookies ?? true;
 
   app.get("/api/auth/mode", (c) => {
     return c.json(auth.mode());
@@ -77,7 +97,8 @@ export function authRoutes(deps: RouteDeps, _refs: RouteRefs): Hono {
     const maxAge = rememberMe
       ? authConfig.session?.refreshTokenTtl
       : undefined;
-    setRefreshCookie(c, result.refreshToken, secureCookies, maxAge);
+    const secure = resolveSecureCookies(c, configuredSecureCookies);
+    setRefreshCookie(c, result.refreshToken, secure, maxAge);
 
     return c.json({
       accessToken: result.accessToken,
@@ -94,12 +115,13 @@ export function authRoutes(deps: RouteDeps, _refs: RouteRefs): Hono {
     }
 
     const result = await auth.refresh(refreshToken);
+    const secure = resolveSecureCookies(c, configuredSecureCookies);
     if (!result) {
-      clearRefreshCookie(c, secureCookies);
+      clearRefreshCookie(c, secure);
       return c.json({ error: "Invalid or expired refresh token" }, 401);
     }
 
-    setRefreshCookie(c, result.refreshToken, secureCookies, authConfig.session?.refreshTokenTtl);
+    setRefreshCookie(c, result.refreshToken, secure, authConfig.session?.refreshTokenTtl);
 
     return c.json({
       accessToken: result.accessToken,
@@ -112,7 +134,8 @@ export function authRoutes(deps: RouteDeps, _refs: RouteRefs): Hono {
     if (user?.sessionId) {
       auth.logout(user.sessionId);
     }
-    clearRefreshCookie(c, secureCookies);
+    const secure = resolveSecureCookies(c, configuredSecureCookies);
+    clearRefreshCookie(c, secure);
     return c.json({ ok: true });
   });
 

--- a/ui/src/lib/auth.test.ts
+++ b/ui/src/lib/auth.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// We test the module's exported behavior by mocking fetch
+// and verifying refresh dedup, retry, and visibility-aware patterns.
+
+describe("auth", () => {
+  let auth: typeof import("./auth");
+
+  beforeEach(async () => {
+    vi.stubGlobal("fetch", vi.fn());
+    // Provide minimal DOM stubs for visibility listener
+    vi.stubGlobal("document", {
+      addEventListener: vi.fn(),
+      visibilityState: "visible",
+    });
+    vi.stubGlobal("window", {
+      addEventListener: vi.fn(),
+    });
+    // Fresh module for each test (module-level state resets)
+    vi.resetModules();
+    auth = await import("./auth");
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("login sets access token and schedules refresh", async () => {
+    const mockFetch = vi.mocked(fetch);
+    mockFetch.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          accessToken: "tok-123",
+          expiresIn: 900,
+          username: "cody",
+          role: "admin",
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+
+    const result = await auth.login("cody", "pass");
+    expect(result.ok).toBe(true);
+    expect(auth.getAccessToken()).toBe("tok-123");
+  });
+
+  it("refresh retries once on network error before failing", async () => {
+    const mockFetch = vi.mocked(fetch);
+    const failureHandler = vi.fn();
+    auth.setAuthFailureHandler(failureHandler);
+
+    // First attempt: network error
+    mockFetch.mockRejectedValueOnce(new Error("Network error"));
+    // Second attempt: also fails
+    mockFetch.mockRejectedValueOnce(new Error("Network error"));
+
+    const result = await auth.refresh();
+    expect(result).toBe(false);
+    expect(failureHandler).toHaveBeenCalledOnce();
+    // 2 fetch calls = 1 original + 1 retry
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("refresh retries once on server error then succeeds", async () => {
+    const mockFetch = vi.mocked(fetch);
+
+    // First attempt: 500
+    mockFetch.mockResolvedValueOnce(
+      new Response("Internal Server Error", { status: 500 }),
+    );
+    // Second attempt: success
+    mockFetch.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({ accessToken: "tok-456", expiresIn: 900 }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+
+    const result = await auth.refresh();
+    expect(result).toBe(true);
+    expect(auth.getAccessToken()).toBe("tok-456");
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("refresh does NOT retry on 401 (token truly invalid)", async () => {
+    const mockFetch = vi.mocked(fetch);
+    const failureHandler = vi.fn();
+    auth.setAuthFailureHandler(failureHandler);
+
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: "Invalid refresh token" }), {
+        status: 401,
+      }),
+    );
+
+    const result = await auth.refresh();
+    expect(result).toBe(false);
+    expect(failureHandler).toHaveBeenCalledOnce();
+    // Only 1 call — no retry on 401
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("deduplicates concurrent refresh calls", async () => {
+    const mockFetch = vi.mocked(fetch);
+
+    // Single successful response — should only be called once
+    mockFetch.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({ accessToken: "tok-dedup", expiresIn: 900 }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+
+    // Fire 3 concurrent refreshes
+    const [r1, r2, r3] = await Promise.all([
+      auth.refresh(),
+      auth.refresh(),
+      auth.refresh(),
+    ]);
+
+    expect(r1).toBe(true);
+    expect(r2).toBe(true);
+    expect(r3).toBe(true);
+    // Only 1 actual fetch — the other 2 piggybacked
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(auth.getAccessToken()).toBe("tok-dedup");
+  });
+
+  it("logout clears token", async () => {
+    const mockFetch = vi.mocked(fetch);
+
+    // Login first
+    mockFetch.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          accessToken: "tok-bye",
+          expiresIn: 900,
+          username: "cody",
+          role: "admin",
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    await auth.login("cody", "pass");
+    expect(auth.getAccessToken()).toBe("tok-bye");
+
+    // Logout
+    mockFetch.mockResolvedValueOnce(new Response("{}", { status: 200 }));
+    await auth.logout();
+    expect(auth.getAccessToken()).toBeNull();
+  });
+});

--- a/ui/src/lib/auth.ts
+++ b/ui/src/lib/auth.ts
@@ -1,7 +1,10 @@
 // Session auth — access token in memory, refresh token in httpOnly cookie
 let accessToken: string | null = null;
+let tokenExpiresAt: number | null = null; // unix ms when access token expires
 let refreshTimer: ReturnType<typeof setTimeout> | null = null;
 let onAuthFailure: (() => void) | null = null;
+let refreshInFlight: Promise<boolean> | null = null;
+let visibilityListenerAttached = false;
 
 export interface AuthMode {
   mode: "none" | "token" | "session";
@@ -46,35 +49,70 @@ export async function login(
   const data = await res.json();
   accessToken = data.accessToken;
   scheduleRefresh(data.expiresIn);
+  attachVisibilityListener();
   return { ok: true, role: data.role };
 }
 
+/**
+ * Refresh the access token using the httpOnly refresh cookie.
+ * Deduplicates concurrent calls — if a refresh is already in flight,
+ * callers share the same promise.
+ */
 export async function refresh(): Promise<boolean> {
+  // Deduplicate: if a refresh is already running, piggyback on it
+  if (refreshInFlight) return refreshInFlight;
+
+  refreshInFlight = doRefresh();
   try {
-    const res = await fetch("/api/auth/refresh", {
-      method: "POST",
-      credentials: "include",
-    });
-
-    if (!res.ok) {
-      accessToken = null;
-      onAuthFailure?.();
-      return false;
-    }
-
-    const data = await res.json();
-    accessToken = data.accessToken;
-    scheduleRefresh(data.expiresIn);
-    return true;
-  } catch {
-    accessToken = null;
-    onAuthFailure?.();
-    return false;
+    return await refreshInFlight;
+  } finally {
+    refreshInFlight = null;
   }
 }
 
+async function doRefresh(): Promise<boolean> {
+  // Retry once with a short delay before giving up
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      const res = await fetch("/api/auth/refresh", {
+        method: "POST",
+        credentials: "include",
+      });
+
+      if (res.ok) {
+        const data = await res.json();
+        accessToken = data.accessToken;
+        scheduleRefresh(data.expiresIn);
+        attachVisibilityListener();
+        return true;
+      }
+
+      // 401 = refresh token invalid/expired — no point retrying
+      if (res.status === 401) break;
+
+      // Server error — retry once after short delay
+      if (attempt === 0) {
+        await sleep(1000);
+        continue;
+      }
+    } catch {
+      // Network error — retry once
+      if (attempt === 0) {
+        await sleep(1000);
+        continue;
+      }
+    }
+  }
+
+  // All attempts failed
+  accessToken = null;
+  tokenExpiresAt = null;
+  onAuthFailure?.();
+  return false;
+}
+
 export async function logout(): Promise<void> {
-  if (refreshTimer) clearTimeout(refreshTimer);
+  teardownRefresh();
   try {
     await fetch("/api/auth/logout", {
       method: "POST",
@@ -87,12 +125,66 @@ export async function logout(): Promise<void> {
     // best-effort
   }
   accessToken = null;
+  tokenExpiresAt = null;
+}
+
+/**
+ * Check if the access token is expired or about to expire.
+ * If so, trigger a refresh proactively.
+ * Called on visibility change (tab focus) and window focus.
+ */
+function checkAndRefreshIfNeeded(): void {
+  if (!tokenExpiresAt) return;
+
+  const now = Date.now();
+  const margin = 60_000; // 60s before expiry
+
+  if (now >= tokenExpiresAt - margin) {
+    // Token expired or about to — refresh immediately
+    refresh();
+  }
 }
 
 function scheduleRefresh(expiresInSeconds: number): void {
   if (refreshTimer) clearTimeout(refreshTimer);
+
+  // Track absolute expiry time so visibility checks work after sleep
+  tokenExpiresAt = Date.now() + expiresInSeconds * 1000;
+
+  // Schedule a timer as the primary refresh mechanism.
+  // The visibility listener is the safety net for sleep/suspend.
   const ms = Math.max(0, (expiresInSeconds - 60) * 1000);
   refreshTimer = setTimeout(() => {
     refresh();
   }, ms);
+}
+
+/**
+ * Attach visibility/focus listeners that catch token expiry after sleep.
+ * setTimeout pauses when the OS suspends — these events fire on wake.
+ */
+function attachVisibilityListener(): void {
+  if (visibilityListenerAttached) return;
+  visibilityListenerAttached = true;
+
+  document.addEventListener("visibilitychange", () => {
+    if (document.visibilityState === "visible") {
+      checkAndRefreshIfNeeded();
+    }
+  });
+
+  window.addEventListener("focus", () => {
+    checkAndRefreshIfNeeded();
+  });
+}
+
+function teardownRefresh(): void {
+  if (refreshTimer) {
+    clearTimeout(refreshTimer);
+    refreshTimer = null;
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }


### PR DESCRIPTION
## Problem

Login screen appears randomly, especially after laptop sleep/suspend or brief network interruptions.

## Root Cause

Three bugs conspiring:

### 1. `setTimeout` dies on OS suspend
The refresh timer (`scheduleRefresh`) uses `setTimeout` set to fire 60s before the 15-minute access token expires. When the laptop sleeps, the timer **pauses** — but the token expiry clock doesn't. Wake up after 30 minutes: token expired, timer hasn't fired, next API call gets 401 → login screen.

### 2. `onAuthFailure` is a one-shot nuke
Any single failed `refresh()` immediately sets `authState = 'login'`. No retry, no grace period. A transient network blip during the refresh window = login screen.

### 3. `secureCookies: true` behind TLS-terminating proxy
Caddy terminates TLS at `:8443` and proxies to Hono at `:18789` over plain HTTP. The `Secure` cookie flag could cause the refresh cookie to not be sent depending on proxy header configuration.

## Fix

### Client (`ui/src/lib/auth.ts`)
- **Visibility-aware refresh**: Track absolute token expiry time. On `visibilitychange` (tab becomes visible) and `window.focus` (window regains focus), check if token is expired/expiring and refresh immediately. These events fire on laptop wake — `setTimeout` doesn't.
- **Retry with backoff**: `doRefresh()` retries once with 1s delay on network/server errors. 401 (truly invalid token) breaks immediately.
- **Refresh deduplication**: Concurrent callers share a single in-flight refresh promise instead of racing.

### Server (`infrastructure/runtime/src/pylon/routes/auth.ts`)
- **`resolveSecureCookies()`**: Auto-detects reverse proxy via `X-Forwarded-Proto`, `X-Forwarded-For`, `X-Real-IP` headers. Sets `Secure` flag only when appropriate, regardless of config value.

### Tests (`ui/src/lib/auth.test.ts`)
- 6 new tests: login, retry on network error, retry on server error then succeed, no retry on 401, concurrent refresh deduplication, logout.

## Files Changed
- `ui/src/lib/auth.ts` — Rewritten refresh lifecycle
- `ui/src/lib/auth.test.ts` — New test suite (6 tests)
- `infrastructure/runtime/src/pylon/routes/auth.ts` — Dynamic secure cookie resolution
