### PR TITLE
feat(dianoia): research & standards — codebase mapping, research levels, coding standards

### DIFF
--- a/infrastructure/runtime/src/dianoia/codebase-map.test.ts
+++ b/infrastructure/runtime/src/dianoia/codebase-map.test.ts
@@ -1,0 +1,245 @@
+// Tests for CodebaseMap — structured codebase analysis (ENG-10)
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdirSync, writeFileSync, existsSync, readFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  detectLanguage,
+  extractTsImports,
+  extractTsExports,
+  extractPyImports,
+  extractCsImports,
+  extractImports,
+  extractExports,
+  scanDirectory,
+  groupIntoModules,
+  detectLayers,
+  detectConventions,
+  generateCodebaseMap,
+  writeCodebaseMapFile,
+} from "./codebase-map.js";
+import { ensureProjectDir, getProjectDir } from "./project-files.js";
+import {
+  PLANNING_V20_DDL, PLANNING_V21_MIGRATION, PLANNING_V22_MIGRATION,
+  PLANNING_V23_MIGRATION, PLANNING_V24_MIGRATION, PLANNING_V25_MIGRATION,
+  PLANNING_V26_MIGRATION, PLANNING_V27_MIGRATION,
+} from "./schema.js";
+
+function createTempWorkspace(): string {
+  const dir = join(tmpdir(), `dianoia-codebase-test-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function writeFile(dir: string, path: string, content: string): void {
+  const fullPath = join(dir, path);
+  mkdirSync(join(fullPath, ".."), { recursive: true });
+  writeFileSync(fullPath, content, "utf-8");
+}
+
+describe("CodebaseMap", () => {
+  let workspace: string;
+
+  beforeEach(() => {
+    workspace = createTempWorkspace();
+  });
+
+  afterEach(() => {
+    try { rmSync(workspace, { recursive: true, force: true }); } catch { /* ignore */ }
+  });
+
+  describe("detectLanguage", () => {
+    it("detects TypeScript", () => {
+      expect(detectLanguage("foo.ts")).toBe("typescript");
+      expect(detectLanguage("foo.tsx")).toBe("typescript");
+    });
+    it("detects JavaScript", () => {
+      expect(detectLanguage("foo.js")).toBe("javascript");
+      expect(detectLanguage("foo.mjs")).toBe("javascript");
+    });
+    it("detects Python", () => {
+      expect(detectLanguage("foo.py")).toBe("python");
+    });
+    it("detects C#", () => {
+      expect(detectLanguage("foo.cs")).toBe("csharp");
+    });
+    it("returns unknown for unsupported", () => {
+      expect(detectLanguage("foo.rs")).toBe("unknown");
+      expect(detectLanguage("foo.md")).toBe("unknown");
+    });
+  });
+
+  describe("extractTsImports", () => {
+    it("extracts static imports", () => {
+      const content = `import { foo } from "./foo.js";\nimport bar from "bar";`;
+      const imports = extractTsImports(content);
+      expect(imports).toContain("./foo.js");
+      expect(imports).toContain("bar");
+    });
+    it("extracts type imports", () => {
+      const content = `import type { Foo } from "./types.js";`;
+      const imports = extractTsImports(content);
+      expect(imports).toContain("./types.js");
+    });
+    it("extracts require calls", () => {
+      const content = `const fs = require("node:fs");`;
+      const imports = extractTsImports(content);
+      expect(imports).toContain("node:fs");
+    });
+    it("extracts dynamic imports", () => {
+      const content = `const mod = await import("./dynamic.js");`;
+      const imports = extractTsImports(content);
+      expect(imports).toContain("./dynamic.js");
+    });
+  });
+
+  describe("extractTsExports", () => {
+    it("extracts named exports", () => {
+      const content = `export function foo() {}\nexport class Bar {}\nexport const baz = 1;`;
+      const exports = extractTsExports(content);
+      expect(exports).toContain("foo");
+      expect(exports).toContain("Bar");
+      expect(exports).toContain("baz");
+    });
+    it("extracts re-exports", () => {
+      const content = `export { foo, bar as baz } from "./other.js";`;
+      const exports = extractTsExports(content);
+      expect(exports).toContain("baz");
+    });
+    it("extracts type exports", () => {
+      const content = `export type Foo = string;\nexport interface Bar {}`;
+      const exports = extractTsExports(content);
+      expect(exports).toContain("Foo");
+      expect(exports).toContain("Bar");
+    });
+  });
+
+  describe("extractPyImports", () => {
+    it("extracts simple imports", () => {
+      const imports = extractPyImports("import os\nimport sys");
+      expect(imports).toContain("os");
+      expect(imports).toContain("sys");
+    });
+    it("extracts from imports", () => {
+      const imports = extractPyImports("from pathlib import Path");
+      expect(imports).toContain("pathlib");
+    });
+  });
+
+  describe("extractCsImports", () => {
+    it("extracts using statements", () => {
+      const imports = extractCsImports("using System;\nusing System.Collections.Generic;");
+      expect(imports).toContain("System");
+      expect(imports).toContain("System.Collections.Generic");
+    });
+  });
+
+  describe("scanDirectory", () => {
+    it("finds source files recursively", () => {
+      writeFile(workspace, "src/index.ts", 'export const x = 1;');
+      writeFile(workspace, "src/utils/helper.ts", 'export function help() {}');
+      writeFile(workspace, "README.md", "# Hello"); // Should be skipped
+
+      const files = scanDirectory(workspace);
+      expect(files.length).toBe(2);
+      expect(files.some(f => f.path === "src/index.ts")).toBe(true);
+      expect(files.some(f => f.path === "src/utils/helper.ts")).toBe(true);
+    });
+
+    it("skips node_modules and .git", () => {
+      writeFile(workspace, "src/index.ts", 'export const x = 1;');
+      writeFile(workspace, "node_modules/foo/index.js", 'module.exports = {}');
+      writeFile(workspace, ".git/config", 'stuff');
+
+      const files = scanDirectory(workspace);
+      expect(files.length).toBe(1);
+    });
+
+    it("respects maxFiles limit", () => {
+      for (let i = 0; i < 10; i++) {
+        writeFile(workspace, `src/file${i}.ts`, `export const x${i} = ${i};`);
+      }
+
+      const files = scanDirectory(workspace, { maxFiles: 5 });
+      expect(files.length).toBe(5);
+    });
+
+    it("extracts imports and exports from scanned files", () => {
+      writeFile(workspace, "src/main.ts", 'import { foo } from "./foo.js";\nexport function main() {}');
+
+      const files = scanDirectory(workspace);
+      expect(files[0]!.imports).toContain("./foo.js");
+      expect(files[0]!.exports).toContain("main");
+    });
+  });
+
+  describe("groupIntoModules", () => {
+    it("groups files by directory", () => {
+      writeFile(workspace, "src/a.ts", "export const a = 1;");
+      writeFile(workspace, "src/b.ts", "export const b = 2;");
+      writeFile(workspace, "lib/c.ts", "export const c = 3;");
+
+      const files = scanDirectory(workspace);
+      const modules = groupIntoModules(files, workspace);
+
+      expect(modules.length).toBe(2);
+      const srcMod = modules.find(m => m.path === "src");
+      expect(srcMod).toBeDefined();
+      expect(srcMod!.files.length).toBe(2);
+    });
+  });
+
+  describe("detectLayers", () => {
+    it("detects architectural layers from module names", () => {
+      const modules = [
+        { path: "src/routes", language: "typescript" as const, files: ["a.ts"], totalLines: 100, dependsOn: [], usedBy: [] },
+        { path: "src/services", language: "typescript" as const, files: ["b.ts"], totalLines: 200, dependsOn: [], usedBy: [] },
+        { path: "src/store", language: "typescript" as const, files: ["c.ts"], totalLines: 150, dependsOn: [], usedBy: [] },
+        { path: "src/components", language: "typescript" as const, files: ["d.ts"], totalLines: 300, dependsOn: [], usedBy: [] },
+      ];
+
+      const layers = detectLayers(modules);
+      expect(layers.some(l => l.name === "API/Routes")).toBe(true);
+      expect(layers.some(l => l.name === "Services/Business Logic")).toBe(true);
+      expect(layers.some(l => l.name === "UI/Components")).toBe(true);
+    });
+  });
+
+  describe("generateCodebaseMap", () => {
+    it("generates complete map from workspace", () => {
+      writeFile(workspace, "src/index.ts", 'import { foo } from "./foo.js";\nexport function main() {}');
+      writeFile(workspace, "src/foo.ts", 'export function foo() { return 42; }');
+      writeFile(workspace, "tests/main.test.ts", 'import { main } from "../src/index.js";');
+
+      const map = generateCodebaseMap(workspace);
+
+      expect(map.totalFiles).toBe(3);
+      expect(map.languages.typescript).toBe(3);
+      expect(map.modules.length).toBeGreaterThan(0);
+      expect(map.generatedAt).toBeTruthy();
+    });
+
+    it("returns empty map for empty workspace", () => {
+      const map = generateCodebaseMap(workspace);
+      expect(map.totalFiles).toBe(0);
+    });
+  });
+
+  describe("writeCodebaseMapFile", () => {
+    it("writes CODEBASE.md for a project", () => {
+      writeFile(workspace, "src/index.ts", 'export const x = 1;');
+      const map = generateCodebaseMap(workspace);
+
+      const projectId = "proj_test123";
+      ensureProjectDir(workspace, projectId);
+      writeCodebaseMapFile(workspace, projectId, map);
+
+      const filePath = join(getProjectDir(workspace, projectId), "CODEBASE.md");
+      expect(existsSync(filePath)).toBe(true);
+
+      const content = readFileSync(filePath, "utf-8");
+      expect(content).toContain("# Codebase Map");
+      expect(content).toContain("typescript");
+    });
+  });
+});

--- a/infrastructure/runtime/src/dianoia/codebase-map.ts
+++ b/infrastructure/runtime/src/dianoia/codebase-map.ts
@@ -1,0 +1,599 @@
+// CodebaseMap — structured analysis of stack, architecture, conventions (ENG-10)
+//
+// Consumes workspace index, produces structured documentation about the codebase.
+// Language-aware import/export parsing, architectural relationship extraction.
+// Refreshed on demand. Separate from the indexer (which is file-level).
+//
+// Output feeds into context packets so sub-agents understand the codebase
+// they're working in without re-discovering it every time.
+
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { join, extname, relative, dirname, basename } from "node:path";
+import { createLogger } from "../koina/logger.js";
+import { ensureProjectDir } from "./project-files.js";
+
+// Re-use atomic write
+import { writeFileSync, renameSync, unlinkSync } from "node:fs";
+
+function atomicWriteFile(filePath: string, content: string): void {
+  const tmpPath = `${filePath}.tmp`;
+  try {
+    writeFileSync(tmpPath, content, "utf-8");
+    renameSync(tmpPath, filePath);
+  } catch (error) {
+    try { if (existsSync(tmpPath)) unlinkSync(tmpPath); } catch { /* ignore */ }
+    throw error;
+  }
+}
+
+const log = createLogger("dianoia:codebase-map");
+
+/** Supported languages for import/export parsing */
+export type Language = "typescript" | "javascript" | "python" | "csharp" | "unknown";
+
+export interface FileInfo {
+  path: string;
+  language: Language;
+  size: number;
+  imports: string[];
+  exports: string[];
+}
+
+export interface ModuleInfo {
+  /** Module path (relative to workspace root) */
+  path: string;
+  /** Primary language */
+  language: Language;
+  /** Files in this module */
+  files: string[];
+  /** Total lines of code */
+  totalLines: number;
+  /** Dependencies (other modules this imports from) */
+  dependsOn: string[];
+  /** Dependents (other modules that import from this) */
+  usedBy: string[];
+}
+
+export interface ArchitecturalLayer {
+  name: string;
+  pattern: string;
+  modules: string[];
+}
+
+export interface CodebaseMapResult {
+  /** Workspace root that was analyzed */
+  workspaceRoot: string;
+  /** When the map was generated */
+  generatedAt: string;
+  /** Languages detected with file counts */
+  languages: Record<Language, number>;
+  /** Total files analyzed */
+  totalFiles: number;
+  /** Total lines of code */
+  totalLines: number;
+  /** Module-level view */
+  modules: ModuleInfo[];
+  /** Detected architectural layers */
+  layers: ArchitecturalLayer[];
+  /** Detected conventions */
+  conventions: Convention[];
+  /** Detected concerns/issues */
+  concerns: string[];
+}
+
+export interface Convention {
+  /** What the convention is */
+  name: string;
+  /** How it manifests */
+  description: string;
+  /** Evidence (file patterns, examples) */
+  evidence: string[];
+}
+
+/** File extensions to language mapping */
+const EXT_TO_LANG: Record<string, Language> = {
+  ".ts": "typescript",
+  ".tsx": "typescript",
+  ".js": "javascript",
+  ".jsx": "javascript",
+  ".mjs": "javascript",
+  ".cjs": "javascript",
+  ".py": "python",
+  ".cs": "csharp",
+};
+
+/** Directories to skip */
+const SKIP_DIRS = new Set([
+  "node_modules", ".git", "dist", "build", "coverage", ".next",
+  "__pycache__", ".venv", "venv", "bin", "obj", ".dianoia",
+]);
+
+/**
+ * Detect language from file extension.
+ */
+export function detectLanguage(filePath: string): Language {
+  const ext = extname(filePath).toLowerCase();
+  return EXT_TO_LANG[ext] ?? "unknown";
+}
+
+/**
+ * Extract imports from a TypeScript/JavaScript file.
+ */
+export function extractTsImports(content: string): string[] {
+  const imports: string[] = [];
+
+  // import ... from "..."
+  const staticImports = content.matchAll(/import\s+(?:(?:type\s+)?(?:\{[^}]*\}|[\w*]+(?:\s*,\s*\{[^}]*\})?)\s+from\s+)?['"]([^'"]+)['"]/g);
+  for (const match of staticImports) {
+    if (match[1]) imports.push(match[1]);
+  }
+
+  // require("...")
+  const requires = content.matchAll(/require\s*\(\s*['"]([^'"]+)['"]\s*\)/g);
+  for (const match of requires) {
+    if (match[1]) imports.push(match[1]);
+  }
+
+  // Dynamic import("...")
+  const dynamicImports = content.matchAll(/import\s*\(\s*['"]([^'"]+)['"]\s*\)/g);
+  for (const match of dynamicImports) {
+    if (match[1]) imports.push(match[1]);
+  }
+
+  return imports;
+}
+
+/**
+ * Extract exports from a TypeScript/JavaScript file.
+ */
+export function extractTsExports(content: string): string[] {
+  const exports: string[] = [];
+
+  // export function/class/const/let/var/type/interface/enum
+  const namedExports = content.matchAll(/export\s+(?:default\s+)?(?:async\s+)?(?:function|class|const|let|var|type|interface|enum)\s+(\w+)/g);
+  for (const match of namedExports) {
+    if (match[1]) exports.push(match[1]);
+  }
+
+  // export { ... }
+  const reExports = content.matchAll(/export\s*\{([^}]+)\}/g);
+  for (const match of reExports) {
+    if (match[1]) {
+      const names = match[1].split(",").map((n) => n.trim().split(/\s+as\s+/).pop()?.trim()).filter(Boolean);
+      exports.push(...(names as string[]));
+    }
+  }
+
+  return [...new Set(exports)];
+}
+
+/**
+ * Extract imports from a Python file.
+ */
+export function extractPyImports(content: string): string[] {
+  const imports: string[] = [];
+
+  // import X / import X as Y
+  const simpleImports = content.matchAll(/^import\s+([\w.]+)/gm);
+  for (const match of simpleImports) {
+    if (match[1]) imports.push(match[1]);
+  }
+
+  // from X import ...
+  const fromImports = content.matchAll(/^from\s+([\w.]+)\s+import/gm);
+  for (const match of fromImports) {
+    if (match[1]) imports.push(match[1]);
+  }
+
+  return imports;
+}
+
+/**
+ * Extract imports from a C# file.
+ */
+export function extractCsImports(content: string): string[] {
+  const imports: string[] = [];
+
+  // using X;
+  const usings = content.matchAll(/^using\s+(?:static\s+)?([\w.]+)\s*;/gm);
+  for (const match of usings) {
+    if (match[1]) imports.push(match[1]);
+  }
+
+  return imports;
+}
+
+/**
+ * Extract imports based on language.
+ */
+export function extractImports(content: string, language: Language): string[] {
+  switch (language) {
+    case "typescript":
+    case "javascript":
+      return extractTsImports(content);
+    case "python":
+      return extractPyImports(content);
+    case "csharp":
+      return extractCsImports(content);
+    default:
+      return [];
+  }
+}
+
+/**
+ * Extract exports based on language.
+ */
+export function extractExports(content: string, language: Language): string[] {
+  switch (language) {
+    case "typescript":
+    case "javascript":
+      return extractTsExports(content);
+    default:
+      return [];
+  }
+}
+
+/**
+ * Scan a directory recursively for source files.
+ */
+export function scanDirectory(
+  rootDir: string,
+  opts?: { maxFiles?: number; maxDepth?: number },
+): FileInfo[] {
+  const files: FileInfo[] = [];
+  const maxFiles = opts?.maxFiles ?? 5000;
+  const maxDepth = opts?.maxDepth ?? 20;
+
+  function walk(dir: string, depth: number): void {
+    if (depth > maxDepth || files.length >= maxFiles) return;
+
+    let entries: string[];
+    try {
+      entries = readdirSync(dir);
+    } catch {
+      return;
+    }
+
+    for (const entry of entries) {
+      if (files.length >= maxFiles) break;
+      if (SKIP_DIRS.has(entry)) continue;
+
+      const fullPath = join(dir, entry);
+      let stat;
+      try {
+        stat = statSync(fullPath);
+      } catch {
+        continue;
+      }
+
+      if (stat.isDirectory()) {
+        walk(fullPath, depth + 1);
+      } else if (stat.isFile()) {
+        const language = detectLanguage(fullPath);
+        if (language === "unknown") continue;
+
+        let content: string;
+        try {
+          // Only read first 50KB for import/export extraction
+          const buffer = Buffer.alloc(50_000);
+          const fd = require("node:fs").openSync(fullPath, "r");
+          const bytesRead = require("node:fs").readSync(fd, buffer, 0, 50_000, 0);
+          require("node:fs").closeSync(fd);
+          content = buffer.toString("utf-8", 0, bytesRead);
+        } catch {
+          continue;
+        }
+
+        files.push({
+          path: relative(rootDir, fullPath),
+          language,
+          size: stat.size,
+          imports: extractImports(content, language),
+          exports: extractExports(content, language),
+        });
+      }
+    }
+  }
+
+  walk(rootDir, 0);
+  return files;
+}
+
+/**
+ * Group files into modules (by directory).
+ */
+export function groupIntoModules(files: FileInfo[], rootDir: string): ModuleInfo[] {
+  const moduleMap = new Map<string, FileInfo[]>();
+
+  for (const file of files) {
+    const moduleDir = dirname(file.path) || ".";
+    const list = moduleMap.get(moduleDir) ?? [];
+    list.push(file);
+    moduleMap.set(moduleDir, list);
+  }
+
+  const modules: ModuleInfo[] = [];
+
+  for (const [path, moduleFiles] of moduleMap) {
+    // Detect primary language
+    const langCounts = new Map<Language, number>();
+    for (const f of moduleFiles) {
+      langCounts.set(f.language, (langCounts.get(f.language) ?? 0) + 1);
+    }
+    const primaryLang = [...langCounts.entries()].sort((a, b) => b[1] - a[1])[0]?.[0] ?? "unknown";
+
+    // Count lines
+    let totalLines = 0;
+    for (const f of moduleFiles) {
+      try {
+        const fullPath = join(rootDir, f.path);
+        const content = readFileSync(fullPath, "utf-8");
+        totalLines += content.split("\n").length;
+      } catch {
+        // Estimate from size
+        totalLines += Math.ceil(f.size / 40);
+      }
+    }
+
+    // Collect all imports that reference other modules
+    const allImports = new Set<string>();
+    for (const f of moduleFiles) {
+      for (const imp of f.imports) {
+        // Resolve relative imports to module paths
+        if (imp.startsWith(".")) {
+          const resolved = join(dirname(f.path), imp).replace(/\.\w+$/, "");
+          const resolvedDir = dirname(resolved);
+          if (resolvedDir !== path && moduleMap.has(resolvedDir)) {
+            allImports.add(resolvedDir);
+          }
+        }
+      }
+    }
+
+    modules.push({
+      path,
+      language: primaryLang,
+      files: moduleFiles.map((f) => f.path),
+      totalLines,
+      dependsOn: [...allImports],
+      usedBy: [], // Filled in second pass
+    });
+  }
+
+  // Second pass: compute usedBy (reverse of dependsOn)
+  for (const mod of modules) {
+    for (const dep of mod.dependsOn) {
+      const depMod = modules.find((m) => m.path === dep);
+      if (depMod) {
+        depMod.usedBy.push(mod.path);
+      }
+    }
+  }
+
+  return modules;
+}
+
+/**
+ * Detect architectural layers from module structure.
+ */
+export function detectLayers(modules: ModuleInfo[]): ArchitecturalLayer[] {
+  const layers: ArchitecturalLayer[] = [];
+
+  const layerPatterns: Array<{ name: string; pattern: RegExp }> = [
+    { name: "API/Routes", pattern: /\b(routes?|controllers?|api|endpoints?)\b/i },
+    { name: "Services/Business Logic", pattern: /\b(services?|business|domain|core)\b/i },
+    { name: "Data/Repository", pattern: /\b(data|repository|store|model|schema|migration)\b/i },
+    { name: "Infrastructure", pattern: /\b(infra|infrastructure|config|setup)\b/i },
+    { name: "UI/Components", pattern: /\b(components?|views?|pages?|ui|layout)\b/i },
+    { name: "Tests", pattern: /\b(tests?|spec|__tests__)\b/i },
+    { name: "Utilities", pattern: /\b(utils?|helpers?|lib|common|shared)\b/i },
+  ];
+
+  for (const { name, pattern } of layerPatterns) {
+    const matching = modules.filter((m) => pattern.test(m.path));
+    if (matching.length > 0) {
+      layers.push({
+        name,
+        pattern: pattern.source,
+        modules: matching.map((m) => m.path),
+      });
+    }
+  }
+
+  return layers;
+}
+
+/**
+ * Detect coding conventions from the codebase.
+ */
+export function detectConventions(files: FileInfo[], _modules: ModuleInfo[]): Convention[] {
+  const conventions: Convention[] = [];
+
+  // Check for index files (barrel exports)
+  const indexFiles = files.filter((f) => basename(f.path).match(/^index\.(ts|js|tsx|jsx)$/));
+  if (indexFiles.length > 3) {
+    conventions.push({
+      name: "Barrel exports",
+      description: "Modules use index files to re-export public API",
+      evidence: indexFiles.slice(0, 5).map((f) => f.path),
+    });
+  }
+
+  // Check for test co-location
+  const testFiles = files.filter((f) => f.path.match(/\.(test|spec)\.(ts|js|tsx|jsx)$/));
+  const sourceFiles = files.filter((f) => !f.path.match(/\.(test|spec)\./));
+  if (testFiles.length > 0) {
+    const colocated = testFiles.filter((t) => {
+      const srcPath = t.path.replace(/\.(test|spec)\./, ".");
+      return sourceFiles.some((s) => s.path === srcPath);
+    });
+    if (colocated.length > testFiles.length * 0.5) {
+      conventions.push({
+        name: "Co-located tests",
+        description: "Test files sit next to their source files",
+        evidence: colocated.slice(0, 5).map((f) => f.path),
+      });
+    }
+  }
+
+  // Check for TypeScript strict mode
+  const tsFiles = files.filter((f) => f.language === "typescript");
+  if (tsFiles.length > 0) {
+    conventions.push({
+      name: "TypeScript codebase",
+      description: `${tsFiles.length} TypeScript files detected`,
+      evidence: [`${tsFiles.length} .ts/.tsx files`],
+    });
+  }
+
+  // Check for ESM vs CJS
+  const esmImports = files.filter((f) =>
+    f.imports.some((i) => i.endsWith(".js")) || f.path.endsWith(".mjs"),
+  );
+  if (esmImports.length > files.length * 0.3) {
+    conventions.push({
+      name: "ESM modules",
+      description: "Project uses ES module imports with .js extensions",
+      evidence: esmImports.slice(0, 3).map((f) => f.path),
+    });
+  }
+
+  return conventions;
+}
+
+/**
+ * Generate a full codebase map for a workspace.
+ */
+export function generateCodebaseMap(
+  workspaceRoot: string,
+  opts?: { maxFiles?: number; maxDepth?: number },
+): CodebaseMapResult {
+  const start = Date.now();
+  const files = scanDirectory(workspaceRoot, opts);
+
+  // Language breakdown
+  const languages: Record<Language, number> = {
+    typescript: 0,
+    javascript: 0,
+    python: 0,
+    csharp: 0,
+    unknown: 0,
+  };
+  for (const f of files) {
+    languages[f.language]++;
+  }
+
+  const modules = groupIntoModules(files, workspaceRoot);
+  const layers = detectLayers(modules);
+  const conventions = detectConventions(files, modules);
+
+  // Detect concerns
+  const concerns: string[] = [];
+  const largeMods = modules.filter((m) => m.totalLines > 2000);
+  if (largeMods.length > 0) {
+    concerns.push(`${largeMods.length} large modules (>2000 lines): ${largeMods.map((m) => m.path).join(", ")}`);
+  }
+  const circularDeps = modules.filter((m) => m.dependsOn.some((d) => {
+    const depMod = modules.find((dm) => dm.path === d);
+    return depMod?.dependsOn.includes(m.path);
+  }));
+  if (circularDeps.length > 0) {
+    concerns.push(`Circular dependencies detected: ${circularDeps.map((m) => m.path).join(", ")}`);
+  }
+
+  const totalLines = modules.reduce((sum, m) => sum + m.totalLines, 0);
+  const duration = Date.now() - start;
+  log.info(`Codebase map generated: ${files.length} files, ${modules.length} modules, ${totalLines} lines in ${duration}ms`);
+
+  return {
+    workspaceRoot,
+    generatedAt: new Date().toISOString(),
+    languages,
+    totalFiles: files.length,
+    totalLines,
+    modules,
+    layers,
+    conventions,
+    concerns,
+  };
+}
+
+/**
+ * Write a CODEBASE.md file for a project from a codebase map.
+ */
+export function writeCodebaseMapFile(
+  workspaceRoot: string,
+  projectId: string,
+  map: CodebaseMapResult,
+): void {
+  const dir = ensureProjectDir(workspaceRoot, projectId);
+  const lines: string[] = [];
+
+  lines.push("# Codebase Map", "");
+  lines.push(`*Generated: ${map.generatedAt}*`, "");
+  lines.push(`**Files:** ${map.totalFiles} | **Lines:** ${map.totalLines.toLocaleString()} | **Modules:** ${map.modules.length}`, "");
+
+  // Languages
+  lines.push("## Languages", "");
+  lines.push("| Language | Files |");
+  lines.push("|----------|-------|");
+  for (const [lang, count] of Object.entries(map.languages)) {
+    if (count > 0) {
+      lines.push(`| ${lang} | ${count} |`);
+    }
+  }
+  lines.push("");
+
+  // Architecture
+  if (map.layers.length > 0) {
+    lines.push("## Architecture", "");
+    for (const layer of map.layers) {
+      lines.push(`### ${layer.name}`);
+      for (const mod of layer.modules) {
+        lines.push(`- ${mod}`);
+      }
+      lines.push("");
+    }
+  }
+
+  // Conventions
+  if (map.conventions.length > 0) {
+    lines.push("## Conventions", "");
+    for (const conv of map.conventions) {
+      lines.push(`### ${conv.name}`, "");
+      lines.push(conv.description, "");
+      if (conv.evidence.length > 0) {
+        lines.push("Evidence:");
+        for (const e of conv.evidence) {
+          lines.push(`- \`${e}\``);
+        }
+        lines.push("");
+      }
+    }
+  }
+
+  // Concerns
+  if (map.concerns.length > 0) {
+    lines.push("## Concerns", "");
+    for (const c of map.concerns) {
+      lines.push(`- ⚠️ ${c}`);
+    }
+    lines.push("");
+  }
+
+  // Module detail (top 20 by size)
+  const topModules = [...map.modules].sort((a, b) => b.totalLines - a.totalLines).slice(0, 20);
+  if (topModules.length > 0) {
+    lines.push("## Top Modules (by size)", "");
+    lines.push("| Module | Language | Files | Lines | Deps | Used By |");
+    lines.push("|--------|----------|-------|-------|------|---------|");
+    for (const mod of topModules) {
+      lines.push(`| ${mod.path} | ${mod.language} | ${mod.files.length} | ${mod.totalLines} | ${mod.dependsOn.length} | ${mod.usedBy.length} |`);
+    }
+    lines.push("");
+  }
+
+  const filePath = join(dir, "CODEBASE.md");
+  atomicWriteFile(filePath, lines.join("\n"));
+  log.debug(`Wrote CODEBASE.md for ${projectId}`);
+}

--- a/infrastructure/runtime/src/dianoia/coding-standards.test.ts
+++ b/infrastructure/runtime/src/dianoia/coding-standards.test.ts
@@ -1,0 +1,179 @@
+// Tests for CodingStandards — layered coding standard system (ENG-15)
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdirSync, existsSync, readFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  getLanguageRules,
+  buildStandards,
+  writeStandardsFile,
+  readStandardsFile,
+  createUserPreferenceRule,
+} from "./coding-standards.js";
+import { ensureProjectDir, getProjectDir } from "./project-files.js";
+
+function createTempWorkspace(): string {
+  const dir = join(tmpdir(), `dianoia-standards-test-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+describe("CodingStandards", () => {
+  let workspace: string;
+
+  beforeEach(() => { workspace = createTempWorkspace(); });
+  afterEach(() => { try { rmSync(workspace, { recursive: true, force: true }); } catch { /* */ } });
+
+  describe("getLanguageRules", () => {
+    it("returns TypeScript rules", () => {
+      const rules = getLanguageRules("typescript");
+      expect(rules.length).toBeGreaterThan(0);
+      expect(rules.every(r => r.level === 1)).toBe(true);
+      expect(rules.some(r => r.id.includes("TS"))).toBe(true);
+    });
+
+    it("returns Python rules", () => {
+      const rules = getLanguageRules("python");
+      expect(rules.length).toBeGreaterThan(0);
+      expect(rules.some(r => r.id.includes("PY"))).toBe(true);
+    });
+
+    it("returns C# rules", () => {
+      const rules = getLanguageRules("csharp");
+      expect(rules.length).toBeGreaterThan(0);
+      expect(rules.some(r => r.id.includes("CS"))).toBe(true);
+    });
+
+    it("returns empty for unknown language", () => {
+      const rules = getLanguageRules("brainfuck");
+      expect(rules).toHaveLength(0);
+    });
+  });
+
+  describe("buildStandards", () => {
+    it("builds 4-layer standards stack", () => {
+      const standards = buildStandards({ primaryLanguage: "typescript" });
+      expect(standards.layers).toHaveLength(4);
+      expect(standards.layers[0]!.level).toBe(0);
+      expect(standards.layers[1]!.level).toBe(1);
+      expect(standards.layers[2]!.level).toBe(2);
+      expect(standards.layers[3]!.level).toBe(3);
+    });
+
+    it("L0 has universal rules", () => {
+      const standards = buildStandards({ primaryLanguage: "typescript" });
+      const l0 = standards.layers[0]!;
+      expect(l0.rules.length).toBeGreaterThan(0);
+      expect(l0.rules.every(r => r.level === 0)).toBe(true);
+    });
+
+    it("L1 has language-specific rules", () => {
+      const standards = buildStandards({ primaryLanguage: "typescript" });
+      const l1 = standards.layers[1]!;
+      expect(l1.rules.length).toBeGreaterThan(0);
+      expect(l1.name).toContain("typescript");
+    });
+
+    it("effective rules include L0 + L1", () => {
+      const standards = buildStandards({ primaryLanguage: "typescript" });
+      const l0Count = standards.layers[0]!.rules.length;
+      const l1Count = standards.layers[1]!.rules.length;
+      expect(standards.effectiveRules.length).toBe(l0Count + l1Count);
+    });
+
+    it("includes custom L2 project rules", () => {
+      const projectRules = [{
+        id: "L2-PROJ-001", level: 2 as const, name: "Custom rule",
+        description: "Test", check: "review" as const, severity: "warn" as const,
+        enabled: true,
+      }];
+
+      const standards = buildStandards({
+        primaryLanguage: "typescript",
+        projectRules,
+      });
+
+      expect(standards.effectiveRules.some(r => r.id === "L2-PROJ-001")).toBe(true);
+    });
+
+    it("includes L3 user preference rules", () => {
+      const userRules = [createUserPreferenceRule("Always use early returns")];
+
+      const standards = buildStandards({
+        primaryLanguage: "typescript",
+        userRules,
+      });
+
+      expect(standards.effectiveRules.some(r => r.level === 3)).toBe(true);
+    });
+
+    it("sets updatedAt timestamp", () => {
+      const standards = buildStandards({ primaryLanguage: "typescript" });
+      expect(standards.updatedAt).toBeTruthy();
+    });
+  });
+
+  describe("writeStandardsFile / readStandardsFile", () => {
+    it("writes and reads STANDARDS.md", () => {
+      const projectId = "proj_test123";
+      ensureProjectDir(workspace, projectId);
+
+      const standards = buildStandards({ primaryLanguage: "typescript", projectId });
+      writeStandardsFile(workspace, projectId, standards);
+
+      const filePath = join(getProjectDir(workspace, projectId), "STANDARDS.md");
+      expect(existsSync(filePath)).toBe(true);
+
+      const content = readFileSync(filePath, "utf-8");
+      expect(content).toContain("# Coding Standards");
+      expect(content).toContain("L0: Universal");
+      expect(content).toContain("L1: Language: typescript");
+    });
+
+    it("round-trips effective rules through JSON trailer", () => {
+      const projectId = "proj_roundtrip";
+      ensureProjectDir(workspace, projectId);
+
+      const standards = buildStandards({ primaryLanguage: "python", projectId });
+      writeStandardsFile(workspace, projectId, standards);
+
+      const result = readStandardsFile(workspace, projectId);
+      expect(result).not.toBeNull();
+      expect(result!.effectiveRules.length).toBe(standards.effectiveRules.length);
+      expect(result!.effectiveRules[0]!.id).toBeTruthy();
+    });
+
+    it("returns null when file doesn't exist", () => {
+      const result = readStandardsFile(workspace, "proj_nonexistent");
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("createUserPreferenceRule", () => {
+    it("creates L3 rule from correction text", () => {
+      const rule = createUserPreferenceRule("Always validate input at function boundary");
+      expect(rule.level).toBe(3);
+      expect(rule.id).toMatch(/^L3-USR-/);
+      expect(rule.description).toContain("validate input");
+      expect(rule.enabled).toBe(true);
+      expect(rule.severity).toBe("warn"); // default
+    });
+
+    it("respects severity override", () => {
+      const rule = createUserPreferenceRule("Never use any", { severity: "error" });
+      expect(rule.severity).toBe("error");
+    });
+
+    it("respects check override", () => {
+      const rule = createUserPreferenceRule("Run lint", { check: "lint" });
+      expect(rule.check).toBe("lint");
+    });
+
+    it("truncates long names to 80 chars", () => {
+      const longText = "A".repeat(200);
+      const rule = createUserPreferenceRule(longText);
+      expect(rule.name.length).toBe(80);
+      expect(rule.description.length).toBe(200); // Full text in description
+    });
+  });
+});

--- a/infrastructure/runtime/src/dianoia/coding-standards.ts
+++ b/infrastructure/runtime/src/dianoia/coding-standards.ts
@@ -1,0 +1,368 @@
+// CodingStandards — layered coding standard system (ENG-15)
+//
+// 4 layers of coding standards, each inheriting from the layer above:
+// L0: Universal — self-documenting, no dead code, consistent formatting
+// L1: Language/domain — TypeScript strict mode, Python PEP 8, C# naming
+// L2: Project-specific — this project's patterns, file structure, conventions
+// L3: User preferences — learned over time from corrections and code reviews
+//
+// Machine-readable (JSON), inheritable (L2 includes L1 includes L0),
+// template-backed (defaults per language).
+
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { createLogger } from "../koina/logger.js";
+import { getProjectDir, ensureProjectDir } from "./project-files.js";
+
+// Re-use atomic write
+import { writeFileSync, renameSync, unlinkSync } from "node:fs";
+
+function atomicWriteFile(filePath: string, content: string): void {
+  const tmpPath = `${filePath}.tmp`;
+  try {
+    writeFileSync(tmpPath, content, "utf-8");
+    renameSync(tmpPath, filePath);
+  } catch (error) {
+    try { if (existsSync(tmpPath)) unlinkSync(tmpPath); } catch { /* ignore */ }
+    throw error;
+  }
+}
+
+const log = createLogger("dianoia:standards");
+
+export type StandardLevel = 0 | 1 | 2 | 3;
+
+export interface CodingRule {
+  /** Unique rule ID (e.g., "L0-001", "L1-TS-003") */
+  id: string;
+  /** Which layer this rule belongs to */
+  level: StandardLevel;
+  /** Human-readable name */
+  name: string;
+  /** Description of the rule */
+  description: string;
+  /** How to check compliance (can be automated or manual) */
+  check: "lint" | "type-check" | "review" | "manual";
+  /** Severity: error blocks merge, warn is advisory */
+  severity: "error" | "warn" | "info";
+  /** Example of correct usage */
+  goodExample?: string;
+  /** Example of incorrect usage */
+  badExample?: string;
+  /** Whether this rule is enabled */
+  enabled: boolean;
+}
+
+export interface StandardsLayer {
+  level: StandardLevel;
+  name: string;
+  description: string;
+  rules: CodingRule[];
+}
+
+export interface ProjectStandards {
+  /** Project these standards apply to */
+  projectId: string | null;
+  /** All 4 layers */
+  layers: StandardsLayer[];
+  /** Computed: all enabled rules across all layers (L0 → L3) */
+  effectiveRules: CodingRule[];
+  /** When standards were last updated */
+  updatedAt: string;
+}
+
+// --- L0: Universal standards (apply to all code) ---
+
+const L0_RULES: CodingRule[] = [
+  {
+    id: "L0-001", level: 0, name: "Self-documenting names",
+    description: "Variables, functions, and types should be named clearly enough that comments are rarely needed",
+    check: "review", severity: "warn", enabled: true,
+  },
+  {
+    id: "L0-002", level: 0, name: "No dead code",
+    description: "Remove commented-out code, unused imports, unreachable branches",
+    check: "lint", severity: "error", enabled: true,
+  },
+  {
+    id: "L0-003", level: 0, name: "Consistent formatting",
+    description: "Use project formatter (prettier, black, dotnet-format). No manual formatting debates.",
+    check: "lint", severity: "error", enabled: true,
+  },
+  {
+    id: "L0-004", level: 0, name: "Error handling",
+    description: "No swallowed errors. Catch blocks must log, rethrow, or return meaningful error.",
+    check: "review", severity: "error", enabled: true,
+  },
+  {
+    id: "L0-005", level: 0, name: "Single responsibility",
+    description: "Functions do one thing. Files have one purpose. Modules have clear boundaries.",
+    check: "review", severity: "warn", enabled: true,
+  },
+  {
+    id: "L0-006", level: 0, name: "Atomic commits",
+    description: "Each commit does one logical thing. Conventional commit messages.",
+    check: "manual", severity: "warn", enabled: true,
+  },
+  {
+    id: "L0-007", level: 0, name: "No magic numbers/strings",
+    description: "Named constants for non-obvious values. Config over hardcoding.",
+    check: "review", severity: "warn", enabled: true,
+  },
+  {
+    id: "L0-008", level: 0, name: "Fail fast",
+    description: "Validate inputs early. Return errors before doing work.",
+    check: "review", severity: "warn", enabled: true,
+  },
+];
+
+// --- L1: Language-specific templates ---
+
+const L1_TYPESCRIPT_RULES: CodingRule[] = [
+  {
+    id: "L1-TS-001", level: 1, name: "Strict TypeScript",
+    description: "strict: true in tsconfig. No any unless explicitly justified.",
+    check: "type-check", severity: "error", enabled: true,
+  },
+  {
+    id: "L1-TS-002", level: 1, name: "Explicit return types",
+    description: "Public functions and methods should have explicit return types",
+    check: "lint", severity: "warn", enabled: true,
+  },
+  {
+    id: "L1-TS-003", level: 1, name: "Prefer type imports",
+    description: "Use 'import type' for type-only imports to improve tree-shaking",
+    check: "lint", severity: "info", enabled: true,
+  },
+  {
+    id: "L1-TS-004", level: 1, name: "ESM imports with .js extension",
+    description: "Import paths end in .js for ESM compatibility (TypeScript resolves .ts → .js)",
+    check: "type-check", severity: "error", enabled: true,
+  },
+  {
+    id: "L1-TS-005", level: 1, name: "Zod for runtime validation",
+    description: "Use Zod schemas for external data validation (API input, file parsing, config)",
+    check: "review", severity: "warn", enabled: true,
+  },
+  {
+    id: "L1-TS-006", level: 1, name: "Readonly by default",
+    description: "Prefer const, readonly, and ReadonlyArray. Mutate only when necessary.",
+    check: "review", severity: "info", enabled: true,
+  },
+];
+
+const L1_PYTHON_RULES: CodingRule[] = [
+  {
+    id: "L1-PY-001", level: 1, name: "Type hints",
+    description: "All function signatures should have type hints (PEP 484)",
+    check: "lint", severity: "warn", enabled: true,
+  },
+  {
+    id: "L1-PY-002", level: 1, name: "PEP 8 formatting",
+    description: "Use black or ruff for consistent formatting",
+    check: "lint", severity: "error", enabled: true,
+  },
+  {
+    id: "L1-PY-003", level: 1, name: "Docstrings",
+    description: "Public functions and classes should have docstrings (Google style)",
+    check: "lint", severity: "warn", enabled: true,
+  },
+  {
+    id: "L1-PY-004", level: 1, name: "No bare except",
+    description: "Always catch specific exceptions. No 'except:' or 'except Exception:'.",
+    check: "lint", severity: "error", enabled: true,
+  },
+];
+
+const L1_CSHARP_RULES: CodingRule[] = [
+  {
+    id: "L1-CS-001", level: 1, name: "PascalCase public members",
+    description: "Public methods, properties, and classes use PascalCase",
+    check: "lint", severity: "error", enabled: true,
+  },
+  {
+    id: "L1-CS-002", level: 1, name: "Nullable reference types",
+    description: "Enable nullable reference types. Explicit null checks.",
+    check: "type-check", severity: "error", enabled: true,
+  },
+  {
+    id: "L1-CS-003", level: 1, name: "Async all the way",
+    description: "Don't mix sync/async. Use async/await consistently.",
+    check: "review", severity: "warn", enabled: true,
+  },
+];
+
+/** Language templates */
+const LANGUAGE_TEMPLATES: Record<string, CodingRule[]> = {
+  typescript: L1_TYPESCRIPT_RULES,
+  javascript: L1_TYPESCRIPT_RULES.filter((r) => !r.id.includes("TS-001")), // No strict TS for JS
+  python: L1_PYTHON_RULES,
+  csharp: L1_CSHARP_RULES,
+};
+
+/**
+ * Get L1 rules for a specific language.
+ */
+export function getLanguageRules(language: string): CodingRule[] {
+  return LANGUAGE_TEMPLATES[language.toLowerCase()] ?? [];
+}
+
+/**
+ * Build the complete standards stack for a project.
+ *
+ * @param primaryLanguage - The main language of the project (for L1 template)
+ * @param projectRules - Custom L2 rules specific to this project
+ * @param userRules - L3 rules learned from user corrections
+ */
+export function buildStandards(opts: {
+  projectId?: string;
+  primaryLanguage: string;
+  projectRules?: CodingRule[];
+  userRules?: CodingRule[];
+}): ProjectStandards {
+  const l0: StandardsLayer = {
+    level: 0,
+    name: "Universal",
+    description: "Apply to all code regardless of language or project",
+    rules: L0_RULES,
+  };
+
+  const l1Rules = getLanguageRules(opts.primaryLanguage);
+  const l1: StandardsLayer = {
+    level: 1,
+    name: `Language: ${opts.primaryLanguage}`,
+    description: `${opts.primaryLanguage}-specific rules and conventions`,
+    rules: l1Rules,
+  };
+
+  const l2: StandardsLayer = {
+    level: 2,
+    name: "Project",
+    description: "Project-specific patterns and conventions",
+    rules: opts.projectRules ?? [],
+  };
+
+  const l3: StandardsLayer = {
+    level: 3,
+    name: "User Preferences",
+    description: "Rules learned from corrections and code reviews over time",
+    rules: opts.userRules ?? [],
+  };
+
+  // Compute effective rules: all enabled rules from L0 → L3
+  // Higher layers can override lower layers (same rule ID = higher layer wins)
+  const ruleMap = new Map<string, CodingRule>();
+  for (const layer of [l0, l1, l2, l3]) {
+    for (const rule of layer.rules) {
+      if (rule.enabled) {
+        ruleMap.set(rule.id, rule);
+      }
+    }
+  }
+
+  return {
+    projectId: opts.projectId ?? null,
+    layers: [l0, l1, l2, l3],
+    effectiveRules: [...ruleMap.values()],
+    updatedAt: new Date().toISOString(),
+  };
+}
+
+/**
+ * Write STANDARDS.md file for a project.
+ */
+export function writeStandardsFile(
+  workspaceRoot: string,
+  projectId: string,
+  standards: ProjectStandards,
+): void {
+  const dir = ensureProjectDir(workspaceRoot, projectId);
+  const lines: string[] = [];
+
+  lines.push("# Coding Standards", "");
+  lines.push(`*Updated: ${standards.updatedAt}*`, "");
+
+  for (const layer of standards.layers) {
+    lines.push(`## L${layer.level}: ${layer.name}`, "");
+    lines.push(`*${layer.description}*`, "");
+
+    if (layer.rules.length === 0) {
+      lines.push("*No rules defined at this layer.*", "");
+      continue;
+    }
+
+    lines.push("| ID | Rule | Check | Severity |");
+    lines.push("|----|------|-------|----------|");
+    for (const rule of layer.rules) {
+      const severityIcon = rule.severity === "error" ? "🔴" : rule.severity === "warn" ? "🟡" : "🔵";
+      const enabledMark = rule.enabled ? "" : " *(disabled)*";
+      lines.push(`| ${rule.id} | ${rule.name}${enabledMark} | ${rule.check} | ${severityIcon} ${rule.severity} |`);
+    }
+    lines.push("");
+  }
+
+  // Summary
+  lines.push("## Summary", "");
+  const errorCount = standards.effectiveRules.filter((r) => r.severity === "error").length;
+  const warnCount = standards.effectiveRules.filter((r) => r.severity === "warn").length;
+  const infoCount = standards.effectiveRules.filter((r) => r.severity === "info").length;
+  lines.push(`**${standards.effectiveRules.length} active rules:** ${errorCount} errors, ${warnCount} warnings, ${infoCount} info`, "");
+
+  // JSON trailer for machine reading
+  lines.push("---", "");
+  lines.push("```json");
+  lines.push(JSON.stringify({
+    effectiveRules: standards.effectiveRules.map((r) => ({
+      id: r.id, level: r.level, name: r.name, check: r.check, severity: r.severity, enabled: r.enabled,
+    })),
+  }, null, 2));
+  lines.push("```");
+
+  const filePath = join(dir, "STANDARDS.md");
+  atomicWriteFile(filePath, lines.join("\n"));
+  log.debug(`Wrote STANDARDS.md for ${projectId}`);
+}
+
+/**
+ * Read standards from a STANDARDS.md file.
+ */
+export function readStandardsFile(
+  workspaceRoot: string,
+  projectId: string,
+): { effectiveRules: Array<{ id: string; level: number; name: string; check: string; severity: string; enabled: boolean }> } | null {
+  const dir = getProjectDir(workspaceRoot, projectId);
+  const filePath = join(dir, "STANDARDS.md");
+
+  if (!existsSync(filePath)) return null;
+
+  try {
+    const content = readFileSync(filePath, "utf-8");
+    const jsonMatch = content.match(/```json\n([\s\S]+?)\n```/);
+    if (!jsonMatch?.[1]) return null;
+    return JSON.parse(jsonMatch[1]);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Create a user preference rule from a code review correction.
+ * This is how L3 standards get populated over time.
+ */
+export function createUserPreferenceRule(
+  correction: string,
+  opts?: { severity?: "error" | "warn" | "info"; check?: CodingRule["check"] },
+): CodingRule {
+  // Generate an incrementing ID
+  const id = `L3-USR-${Date.now().toString(36).toUpperCase()}`;
+
+  return {
+    id,
+    level: 3,
+    name: correction.slice(0, 80),
+    description: correction,
+    check: opts?.check ?? "review",
+    severity: opts?.severity ?? "warn",
+    enabled: true,
+  };
+}

--- a/infrastructure/runtime/src/dianoia/index.ts
+++ b/infrastructure/runtime/src/dianoia/index.ts
@@ -77,3 +77,11 @@ export { calculateBudgetAllocation, buildOrchestratorContext, checkBudget, DEFAU
 export type { BudgetAllocation } from "./context-budget.js";
 export { writeStructuredDiscussFile, readStructuredDiscussFile, extractDecisionsFromQuestions, createEmptyArtifact, acquireDiscussionLock, releaseDiscussionLock, isDiscussionLocked } from "./discussion-artifacts.js";
 export type { DiscussionArtifact, BoundaryItem, ImplementationDecision, DiscretionItem, DeferredIdea } from "./discussion-artifacts.js";
+
+// Research & Standards (ENG-10/11/15)
+export { generateCodebaseMap, scanDirectory, writeCodebaseMapFile, detectLanguage, extractImports, extractExports, groupIntoModules, detectLayers, detectConventions } from "./codebase-map.js";
+export type { CodebaseMapResult, ModuleInfo, ArchitecturalLayer, Convention, FileInfo } from "./codebase-map.js";
+export { RESEARCH_LEVELS, extractComplexitySignals, selectResearchLevel, getResearchConfig, determineResearchLevel } from "./research-levels.js";
+export type { ResearchLevel, ResearchLevelConfig } from "./research-levels.js";
+export { getLanguageRules, buildStandards, writeStandardsFile, readStandardsFile, createUserPreferenceRule } from "./coding-standards.js";
+export type { ProjectStandards, CodingRule, StandardsLayer } from "./coding-standards.js";

--- a/infrastructure/runtime/src/dianoia/research-levels.test.ts
+++ b/infrastructure/runtime/src/dianoia/research-levels.test.ts
@@ -1,0 +1,231 @@
+// Tests for ResearchLevels — right-sized research per phase (ENG-11)
+import { describe, it, expect } from "vitest";
+import {
+  extractComplexitySignals,
+  selectResearchLevel,
+  getResearchConfig,
+  determineResearchLevel,
+  RESEARCH_LEVELS,
+} from "./research-levels.js";
+import type { PlanningPhase, PlanningRequirement } from "./types.js";
+
+function makePhase(overrides?: Partial<PlanningPhase>): PlanningPhase {
+  return {
+    id: "phase_test",
+    projectId: "proj_test",
+    name: "Test Phase",
+    goal: "Do something",
+    requirements: [],
+    successCriteria: [],
+    dependencies: [],
+    plan: null,
+    status: "pending",
+    phaseOrder: 0,
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function makeReq(description: string): PlanningRequirement {
+  return {
+    id: "req_test",
+    projectId: "proj_test",
+    phaseId: null,
+    reqId: "REQ-01",
+    description,
+    category: "Test",
+    tier: "v1",
+    status: "pending",
+    rationale: null,
+    dependsOn: [],
+    blockedBy: [],
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+  };
+}
+
+describe("ResearchLevels", () => {
+  describe("RESEARCH_LEVELS", () => {
+    it("has 4 levels (0-3)", () => {
+      expect(Object.keys(RESEARCH_LEVELS)).toHaveLength(4);
+      expect(RESEARCH_LEVELS[0].name).toBe("Skip");
+      expect(RESEARCH_LEVELS[1].name).toBe("Quick");
+      expect(RESEARCH_LEVELS[2].name).toBe("Standard");
+      expect(RESEARCH_LEVELS[3].name).toBe("Deep Dive");
+    });
+
+    it("L0 has no dimensions", () => {
+      expect(RESEARCH_LEVELS[0].dimensions).toHaveLength(0);
+      expect(RESEARCH_LEVELS[0].researcherCount).toBe(0);
+    });
+
+    it("L1 has 1 dimension (pitfalls)", () => {
+      expect(RESEARCH_LEVELS[1].dimensions).toEqual(["pitfalls"]);
+      expect(RESEARCH_LEVELS[1].researcherCount).toBe(1);
+    });
+
+    it("L2 and L3 have 4 dimensions", () => {
+      expect(RESEARCH_LEVELS[2].dimensions).toHaveLength(4);
+      expect(RESEARCH_LEVELS[3].dimensions).toHaveLength(4);
+    });
+
+    it("L2 and L3 need synthesis", () => {
+      expect(RESEARCH_LEVELS[2].needsSynthesis).toBe(true);
+      expect(RESEARCH_LEVELS[3].needsSynthesis).toBe(true);
+    });
+  });
+
+  describe("extractComplexitySignals", () => {
+    it("detects novel technology keywords", () => {
+      const phase = makePhase({ goal: "Migrate to a new framework" });
+      const signals = extractComplexitySignals(phase, []);
+      expect(signals.hasNovelTechnology).toBe(true);
+    });
+
+    it("detects security concerns", () => {
+      const phase = makePhase({ goal: "Implement user authentication" });
+      const signals = extractComplexitySignals(phase, []);
+      expect(signals.hasSecurityConcerns).toBe(true);
+    });
+
+    it("detects data migration", () => {
+      const reqs = [makeReq("Database schema migration for users table")];
+      const signals = extractComplexitySignals(makePhase(), reqs);
+      expect(signals.hasDataMigration).toBe(true);
+    });
+
+    it("detects external integrations", () => {
+      const reqs = [makeReq("Integrate with third-party payment SDK")];
+      const signals = extractComplexitySignals(makePhase(), reqs);
+      expect(signals.hasExternalIntegrations).toBe(true);
+    });
+
+    it("detects architectural decisions", () => {
+      const phase = makePhase({ goal: "Design the distributed message queue architecture" });
+      const signals = extractComplexitySignals(phase, []);
+      expect(signals.hasArchitecturalDecisions).toBe(true);
+    });
+
+    it("counts requirements", () => {
+      const reqs = Array.from({ length: 8 }, (_, i) => makeReq(`Req ${i}`));
+      const signals = extractComplexitySignals(makePhase(), reqs);
+      expect(signals.requirementCount).toBe(8);
+    });
+
+    it("respects user override", () => {
+      const signals = extractComplexitySignals(makePhase(), [], { userOverride: 3 });
+      expect(signals.userOverride).toBe(3);
+    });
+
+    it("respects existing patterns flag", () => {
+      const signals = extractComplexitySignals(makePhase(), [], { existingPatterns: true });
+      expect(signals.hasExistingPatterns).toBe(true);
+    });
+  });
+
+  describe("selectResearchLevel", () => {
+    it("returns L0 for simple phase with existing patterns", () => {
+      const level = selectResearchLevel({
+        requirementCount: 1,
+        hasNovelTechnology: false,
+        hasSecurityConcerns: false,
+        hasDataMigration: false,
+        hasExternalIntegrations: false,
+        hasArchitecturalDecisions: false,
+        hasExistingPatterns: true,
+        userOverride: null,
+      });
+      expect(level).toBe(0);
+    });
+
+    it("returns L1 for few requirements, no special signals", () => {
+      const level = selectResearchLevel({
+        requirementCount: 3,
+        hasNovelTechnology: false,
+        hasSecurityConcerns: false,
+        hasDataMigration: false,
+        hasExternalIntegrations: false,
+        hasArchitecturalDecisions: false,
+        hasExistingPatterns: false,
+        userOverride: null,
+      });
+      expect(level).toBe(1);
+    });
+
+    it("returns L2 for moderate complexity", () => {
+      const level = selectResearchLevel({
+        requirementCount: 5,
+        hasNovelTechnology: false,
+        hasSecurityConcerns: true,
+        hasDataMigration: false,
+        hasExternalIntegrations: false,
+        hasArchitecturalDecisions: false,
+        hasExistingPatterns: false,
+        userOverride: null,
+      });
+      expect(level).toBe(2);
+    });
+
+    it("returns L3 for high complexity", () => {
+      const level = selectResearchLevel({
+        requirementCount: 12,
+        hasNovelTechnology: true,
+        hasSecurityConcerns: true,
+        hasDataMigration: true,
+        hasExternalIntegrations: false,
+        hasArchitecturalDecisions: true,
+        hasExistingPatterns: false,
+        userOverride: null,
+      });
+      expect(level).toBe(3);
+    });
+
+    it("respects user override regardless of signals", () => {
+      const level = selectResearchLevel({
+        requirementCount: 1,
+        hasNovelTechnology: false,
+        hasSecurityConcerns: false,
+        hasDataMigration: false,
+        hasExternalIntegrations: false,
+        hasArchitecturalDecisions: false,
+        hasExistingPatterns: true,
+        userOverride: 3,
+      });
+      expect(level).toBe(3);
+    });
+  });
+
+  describe("getResearchConfig", () => {
+    it("returns config for each level", () => {
+      for (const level of [0, 1, 2, 3] as const) {
+        const config = getResearchConfig(level);
+        expect(config.level).toBe(level);
+        expect(config.name).toBeTruthy();
+      }
+    });
+  });
+
+  describe("determineResearchLevel", () => {
+    it("combines extraction and selection", () => {
+      const phase = makePhase({ goal: "Implement OAuth authentication with external provider" });
+      const reqs = [
+        makeReq("OIDC integration"),
+        makeReq("Token refresh"),
+        makeReq("Permission model"),
+      ];
+
+      const result = determineResearchLevel(phase, reqs);
+
+      expect(result.level).toBeGreaterThanOrEqual(1);
+      expect(result.config).toBeDefined();
+      expect(result.signals.hasSecurityConcerns).toBe(true);
+    });
+
+    it("returns L0 for trivial phase", () => {
+      const phase = makePhase({ goal: "Add a readme file" });
+      const result = determineResearchLevel(phase, [], { existingPatterns: true });
+      expect(result.level).toBe(0);
+    });
+  });
+});

--- a/infrastructure/runtime/src/dianoia/research-levels.ts
+++ b/infrastructure/runtime/src/dianoia/research-levels.ts
@@ -1,0 +1,227 @@
+// ResearchLevels — right-sized research per phase (ENG-11)
+//
+// Not every phase needs 30 minutes of research. A CRUD endpoint phase
+// needs L0 (skip). A new auth system needs L2 (standard). A novel
+// architecture needs L3 (deep dive).
+//
+// Research level selection is based on:
+// 1. Phase requirements complexity
+// 2. Novelty (does the codebase already have similar code?)
+// 3. Risk (what breaks if we get this wrong?)
+// 4. User override (explicit level in planning config)
+
+import { createLogger } from "../koina/logger.js";
+import type { PlanningPhase, PlanningRequirement } from "./types.js";
+
+const log = createLogger("dianoia:research-levels");
+
+export type ResearchLevel = 0 | 1 | 2 | 3;
+
+export interface ResearchLevelConfig {
+  /** Research level (0-3) */
+  level: ResearchLevel;
+  /** Human-readable name */
+  name: string;
+  /** Description */
+  description: string;
+  /** Expected duration range */
+  durationRange: string;
+  /** Dimensions to research */
+  dimensions: string[];
+  /** Number of researchers to dispatch */
+  researcherCount: number;
+  /** Context budget per researcher */
+  contextBudgetPerResearcher: number;
+  /** Whether synthesis is needed */
+  needsSynthesis: boolean;
+}
+
+/** Research level definitions */
+export const RESEARCH_LEVELS: Record<ResearchLevel, ResearchLevelConfig> = {
+  0: {
+    level: 0,
+    name: "Skip",
+    description: "Well-understood domain, existing patterns. No research needed.",
+    durationRange: "0 min",
+    dimensions: [],
+    researcherCount: 0,
+    contextBudgetPerResearcher: 0,
+    needsSynthesis: false,
+  },
+  1: {
+    level: 1,
+    name: "Quick",
+    description: "Mostly understood with a few unknowns. Quick validation.",
+    durationRange: "2-5 min",
+    dimensions: ["pitfalls"],
+    researcherCount: 1,
+    contextBudgetPerResearcher: 4000,
+    needsSynthesis: false,
+  },
+  2: {
+    level: 2,
+    name: "Standard",
+    description: "New domain or significant complexity. Full 4-dimension research.",
+    durationRange: "15-30 min",
+    dimensions: ["stack", "features", "architecture", "pitfalls"],
+    researcherCount: 4,
+    contextBudgetPerResearcher: 6000,
+    needsSynthesis: true,
+  },
+  3: {
+    level: 3,
+    name: "Deep Dive",
+    description: "Novel architecture, high risk, or unfamiliar domain. Extended research with validation.",
+    durationRange: "1+ hour",
+    dimensions: ["stack", "features", "architecture", "pitfalls"],
+    researcherCount: 4,
+    contextBudgetPerResearcher: 10000,
+    needsSynthesis: true,
+  },
+};
+
+/** Signals that suggest higher research levels */
+interface ComplexitySignals {
+  /** Number of requirements in the phase */
+  requirementCount: number;
+  /** Whether requirements mention unfamiliar technologies */
+  hasNovelTechnology: boolean;
+  /** Whether requirements mention security/auth */
+  hasSecurityConcerns: boolean;
+  /** Whether requirements mention data migration */
+  hasDataMigration: boolean;
+  /** Whether requirements mention external integrations */
+  hasExternalIntegrations: boolean;
+  /** Whether the phase goal mentions architectural decisions */
+  hasArchitecturalDecisions: boolean;
+  /** Whether similar code exists in the codebase */
+  hasExistingPatterns: boolean;
+  /** Explicit user override (null = auto-detect) */
+  userOverride: ResearchLevel | null;
+}
+
+/** Keywords that signal novel/unfamiliar technology */
+const NOVEL_TECH_KEYWORDS = [
+  "new framework", "migrate to", "replace", "novel", "unfamiliar",
+  "first time", "proof of concept", "prototype", "experimental",
+  "custom protocol", "from scratch",
+];
+
+/** Keywords that signal security concerns */
+const SECURITY_KEYWORDS = [
+  "auth", "authentication", "authorization", "oauth", "oidc", "jwt",
+  "encryption", "certificate", "tls", "ssl", "permission", "rbac",
+  "credential", "secret", "token", "password", "sanitize", "xss", "csrf",
+];
+
+/** Keywords that signal data migration */
+const MIGRATION_KEYWORDS = [
+  "migration", "migrate", "schema change", "data conversion",
+  "backward compat", "breaking change", "database upgrade",
+];
+
+/** Keywords that signal external integrations */
+const INTEGRATION_KEYWORDS = [
+  "api integration", "third-party", "external service", "webhook",
+  "sdk", "provider", "vendor", "saas", "cloud service",
+];
+
+/** Keywords that signal architectural decisions */
+const ARCHITECTURE_KEYWORDS = [
+  "architecture", "design pattern", "system design", "scalab",
+  "distributed", "microservice", "monolith", "event-driven",
+  "message queue", "caching strategy", "load balanc",
+];
+
+/**
+ * Extract complexity signals from a phase and its requirements.
+ */
+export function extractComplexitySignals(
+  phase: PlanningPhase,
+  requirements: PlanningRequirement[],
+  opts?: { userOverride?: ResearchLevel | null; existingPatterns?: boolean },
+): ComplexitySignals {
+  const text = [
+    phase.goal,
+    phase.name,
+    ...phase.successCriteria,
+    ...requirements.map((r) => r.description),
+  ].join(" ").toLowerCase();
+
+  return {
+    requirementCount: requirements.length,
+    hasNovelTechnology: NOVEL_TECH_KEYWORDS.some((kw) => text.includes(kw)),
+    hasSecurityConcerns: SECURITY_KEYWORDS.some((kw) => text.includes(kw)),
+    hasDataMigration: MIGRATION_KEYWORDS.some((kw) => text.includes(kw)),
+    hasExternalIntegrations: INTEGRATION_KEYWORDS.some((kw) => text.includes(kw)),
+    hasArchitecturalDecisions: ARCHITECTURE_KEYWORDS.some((kw) => text.includes(kw)),
+    hasExistingPatterns: opts?.existingPatterns ?? false,
+    userOverride: opts?.userOverride ?? null,
+  };
+}
+
+/**
+ * Select the appropriate research level for a phase.
+ */
+export function selectResearchLevel(signals: ComplexitySignals): ResearchLevel {
+  // User override takes priority
+  if (signals.userOverride !== null) {
+    log.info(`Using user-overridden research level: L${signals.userOverride}`);
+    return signals.userOverride;
+  }
+
+  let score = 0;
+
+  // Requirement count
+  if (signals.requirementCount <= 2) score += 0;
+  else if (signals.requirementCount <= 5) score += 1;
+  else if (signals.requirementCount <= 10) score += 2;
+  else score += 3;
+
+  // Novelty and risk signals
+  if (signals.hasNovelTechnology) score += 3;
+  if (signals.hasSecurityConcerns) score += 2;
+  if (signals.hasDataMigration) score += 2;
+  if (signals.hasExternalIntegrations) score += 2;
+  if (signals.hasArchitecturalDecisions) score += 2;
+
+  // Existing patterns reduce need
+  if (signals.hasExistingPatterns) score -= 2;
+
+  // Map score to level
+  if (score <= 0) return 0;      // Skip
+  if (score <= 2) return 1;      // Quick
+  if (score <= 6) return 2;      // Standard
+  return 3;                       // Deep Dive
+}
+
+/**
+ * Get the research config for a level.
+ */
+export function getResearchConfig(level: ResearchLevel): ResearchLevelConfig {
+  return RESEARCH_LEVELS[level];
+}
+
+/**
+ * Determine research level for a phase automatically.
+ * Combines signal extraction and level selection in one call.
+ */
+export function determineResearchLevel(
+  phase: PlanningPhase,
+  requirements: PlanningRequirement[],
+  opts?: { userOverride?: ResearchLevel | null; existingPatterns?: boolean },
+): { level: ResearchLevel; config: ResearchLevelConfig; signals: ComplexitySignals } {
+  const signals = extractComplexitySignals(phase, requirements, opts);
+  const level = selectResearchLevel(signals);
+  const config = getResearchConfig(level);
+
+  log.info(
+    `Research level for "${phase.name}": L${level} (${config.name}) — ` +
+    `${signals.requirementCount} reqs, ` +
+    `novel=${signals.hasNovelTechnology}, ` +
+    `security=${signals.hasSecurityConcerns}, ` +
+    `migration=${signals.hasDataMigration}`,
+  );
+
+  return { level, config, signals };
+}


### PR DESCRIPTION
## Phase 7 of Dianoia Collaborative Workspace

Implements the Research & Standards layer (ENG-10, ENG-11, ENG-15).

### CodebaseMap (ENG-10) — 24 tests

Language-aware codebase analysis that feeds into context packets.

- **Import/export parsing:** TypeScript (static/dynamic/require), JavaScript, Python, C#
- **Module grouping:** Directory-based with cross-module dependency tracking
- **Layer detection:** Routes, services, data, UI, tests, utilities
- **Convention detection:** Barrel exports, co-located tests, ESM modules, TypeScript usage
- **Concern detection:** Large modules (>2000 lines), circular dependencies
- **Output:** CODEBASE.md file per project with tables and structured data

### ResearchLevels (ENG-11) — 22 tests

Right-sized research for each phase.

| Level | Name | Duration | Researchers | Dimensions |
|-------|------|----------|-------------|------------|
| L0 | Skip | 0 | 0 | none |
| L1 | Quick | 2-5 min | 1 | pitfalls only |
| L2 | Standard | 15-30 min | 4 | stack, features, architecture, pitfalls |
| L3 | Deep Dive | 1+ hour | 4 | all dimensions, extended budget |

- **Signal extraction:** Keyword-based complexity detection from phase goals and requirements
- **Automatic selection:** Score-based mapping from signals to level
- **User override:** Explicit level in planning config overrides auto-detection
- **Signals:** Novel technology, security, migration, external integrations, architecture

### CodingStandards (ENG-15) — 17 tests

4-layer inheritable coding standard system.

| Layer | Name | Rules | Source |
|-------|------|-------|--------|
| L0 | Universal | 8 | Built-in (naming, dead code, formatting, errors, SRP, commits, magic values, fail-fast) |
| L1 | Language | 6 TS / 4 PY / 3 C# | Template per language |
| L2 | Project | Custom | Detected or manual |
| L3 | User | Custom | Learned from corrections |

- Higher layers override lower layers (same rule ID)
- Machine-readable JSON trailer in STANDARDS.md
- `createUserPreferenceRule()` converts corrections into L3 rules
- `buildStandards()` computes effective ruleset with inheritance

### Test Coverage

| File | Tests |
|------|-------|
| codebase-map.test.ts | 24 |
| research-levels.test.ts | 22 |
| coding-standards.test.ts | 17 |
| **Total** | **63** |

0 TypeScript errors.