### PR TITLE
feat(dianoia): API & sync — file co-primary, category workflow, batch ops

### DIFF
--- a/infrastructure/runtime/src/dianoia/routes.test.ts
+++ b/infrastructure/runtime/src/dianoia/routes.test.ts
@@ -1,0 +1,705 @@
+/**
+ * Planning routes test — ORCH-01 through ORCH-06, SYNC-01 through SYNC-04.
+ * Tests CRUD endpoints, file sync, category workflow, batch ops, and SSE events.
+ *
+ * Uses in-memory SQLite + real Hono app (no HTTP, direct handler calls).
+ */
+import Database from "better-sqlite3";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Hono } from "hono";
+import { existsSync, mkdirSync, readFileSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import {
+  PLANNING_V20_DDL,
+  PLANNING_V21_MIGRATION,
+  PLANNING_V22_MIGRATION,
+  PLANNING_V23_MIGRATION,
+  PLANNING_V24_MIGRATION,
+  PLANNING_V25_MIGRATION,
+  PLANNING_V26_MIGRATION,
+  PLANNING_V27_MIGRATION,
+} from "./schema.js";
+import { PlanningStore } from "./store.js";
+import { planningRoutes } from "./routes.js";
+import { DianoiaOrchestrator } from "./orchestrator.js";
+import { eventBus } from "../koina/event-bus.js";
+
+let db: Database.Database;
+let store: PlanningStore;
+let app: Hono;
+let tmpDir: string;
+let projectId: string;
+
+const defaultConfig = {
+  depth: "standard" as const,
+  parallelization: false,
+  research: true,
+  plan_check: true,
+  verifier: true,
+  mode: "interactive" as const,
+};
+
+function initDb(): Database.Database {
+  const d = new Database(":memory:");
+  d.pragma("journal_mode = WAL");
+  d.pragma("foreign_keys = ON");
+  d.exec(PLANNING_V20_DDL);
+  d.exec(PLANNING_V21_MIGRATION);
+  d.exec(PLANNING_V22_MIGRATION);
+  d.exec(PLANNING_V23_MIGRATION);
+  d.exec(PLANNING_V24_MIGRATION);
+  d.exec(PLANNING_V25_MIGRATION);
+  d.exec(PLANNING_V26_MIGRATION);
+  d.exec(PLANNING_V27_MIGRATION);
+  return d;
+}
+
+function seedProject(): string {
+  const project = store.createProject({
+    nousId: "test-nous",
+    sessionId: "test-session",
+    goal: "Test project",
+    config: defaultConfig,
+  });
+  return project.id;
+}
+
+beforeEach(() => {
+  db = initDb();
+  store = new PlanningStore(db);
+  tmpDir = join(tmpdir(), `dianoia-routes-test-${Date.now()}`);
+  mkdirSync(tmpDir, { recursive: true });
+
+  // Create orchestrator with workspace root for file sync
+  const orch = new DianoiaOrchestrator(db, {
+    depth: "standard",
+    parallelization: false,
+    research: true,
+    plan_check: true,
+    verifier: true,
+    mode: "interactive",
+  });
+  orch.setWorkspaceRoot(tmpDir);
+
+  // Build Hono app from routes
+  const routeApp = planningRoutes(
+    {
+      store: { getDb: () => db } as any,
+      manager: { getActiveTurnDetails: () => [] } as any,
+      planningOrchestrator: orch,
+    } as any,
+    {} as any,
+  );
+  app = new Hono();
+  app.route("/", routeApp);
+
+  projectId = seedProject();
+});
+
+afterEach(() => {
+  db.close();
+  try { rmSync(tmpDir, { recursive: true, force: true }); } catch { /* ok */ }
+});
+
+// ─── Helpers ───────────────────────────────────────────────
+
+async function req(method: string, path: string, body?: unknown) {
+  const init: RequestInit = { method, headers: { "Content-Type": "application/json" } };
+  if (body) init.body = JSON.stringify(body);
+  return app.request(path, init);
+}
+
+async function json(res: Response) {
+  return res.json();
+}
+
+// ─── ORCH-01: Requirement CRUD ─────────────────────────────
+
+describe("ORCH-01: Requirement CRUD", () => {
+  it("creates a requirement and syncs to file", async () => {
+    const res = await req("POST", `/api/planning/projects/${projectId}/requirements`, {
+      description: "User can log in",
+      category: "AUTH",
+      tier: "v1",
+    });
+    expect(res.status).toBe(201);
+    const data = await json(res);
+    expect(data.reqId).toMatch(/^AUTH-/);
+    expect(data.tier).toBe("v1");
+
+    // Verify file sync
+    const reqFile = join(tmpDir, ".dianoia", "projects", projectId, "REQUIREMENTS.md");
+    expect(existsSync(reqFile)).toBe(true);
+    const content = readFileSync(reqFile, "utf-8");
+    expect(content).toContain("AUTH");
+    expect(content).toContain("User can log in");
+  });
+
+  it("updates a requirement by reqId", async () => {
+    // Create first
+    await req("POST", `/api/planning/projects/${projectId}/requirements`, {
+      description: "User can log in",
+      category: "AUTH",
+      tier: "v1",
+    });
+
+    const res = await req("PATCH", `/api/planning/projects/${projectId}/requirements/AUTH-01`, {
+      tier: "v2",
+      rationale: "Defer to v2",
+    });
+    expect(res.status).toBe(200);
+    const data = await json(res);
+    expect(data.tier).toBe("v2");
+    expect(data.rationale).toBe("Defer to v2");
+  });
+
+  it("deletes a requirement and syncs file", async () => {
+    const createRes = await req("POST", `/api/planning/projects/${projectId}/requirements`, {
+      description: "User can log in",
+      category: "AUTH",
+      tier: "v1",
+    });
+    const created = await json(createRes);
+
+    const res = await req("DELETE", `/api/planning/projects/${projectId}/requirements/${created.reqId}`);
+    expect(res.status).toBe(200);
+    const data = await json(res);
+    expect(data.success).toBe(true);
+
+    // File should be updated (empty requirements)
+    const reqFile = join(tmpDir, ".dianoia", "projects", projectId, "REQUIREMENTS.md");
+    if (existsSync(reqFile)) {
+      const content = readFileSync(reqFile, "utf-8");
+      expect(content).not.toContain("User can log in");
+    }
+  });
+
+  it("returns 404 for non-existent requirement", async () => {
+    const res = await req("PATCH", `/api/planning/projects/${projectId}/requirements/NOPE-01`, {
+      tier: "v2",
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it("auto-generates reqId with incrementing sequence", async () => {
+    await req("POST", `/api/planning/projects/${projectId}/requirements`, {
+      description: "First", category: "UI",
+    });
+    const res = await req("POST", `/api/planning/projects/${projectId}/requirements`, {
+      description: "Second", category: "UI",
+    });
+    const data = await json(res);
+    expect(data.reqId).toBe("UI-02");
+  });
+});
+
+// ─── ORCH-02: Phase CRUD ───────────────────────────────────
+
+describe("ORCH-02: Phase CRUD", () => {
+  let phaseId: string;
+
+  beforeEach(() => {
+    const phase = store.createPhase({
+      projectId,
+      name: "Foundation",
+      goal: "Build the base",
+      requirements: ["AUTH-01"],
+      successCriteria: ["Tests pass"],
+      dependencies: [],
+      phaseOrder: 0,
+    });
+    phaseId = phase.id;
+  });
+
+  it("updates phase name and goal with file sync", async () => {
+    const res = await req("PATCH", `/api/planning/projects/${projectId}/phases/${phaseId}`, {
+      name: "Core Foundation",
+      goal: "Build the core base layer",
+    });
+    expect(res.status).toBe(200);
+    const data = await json(res);
+    expect(data.name).toBe("Core Foundation");
+    expect(data.goal).toBe("Build the core base layer");
+
+    // Verify ROADMAP.md updated
+    const roadmapFile = join(tmpDir, ".dianoia", "projects", projectId, "ROADMAP.md");
+    expect(existsSync(roadmapFile)).toBe(true);
+    const content = readFileSync(roadmapFile, "utf-8");
+    expect(content).toContain("Core Foundation");
+  });
+
+  it("deletes a phase with file sync", async () => {
+    const res = await req("DELETE", `/api/planning/projects/${projectId}/phases/${phaseId}`);
+    expect(res.status).toBe(200);
+    const data = await json(res);
+    expect(data.success).toBe(true);
+
+    // Roadmap should not contain the phase
+    const roadmapFile = join(tmpDir, ".dianoia", "projects", projectId, "ROADMAP.md");
+    if (existsSync(roadmapFile)) {
+      const content = readFileSync(roadmapFile, "utf-8");
+      expect(content).not.toContain("Foundation");
+    }
+  });
+
+  it("reorders phases with file sync", async () => {
+    // Create a second phase
+    store.createPhase({
+      projectId,
+      name: "UI Layer",
+      goal: "Build the UI",
+      requirements: ["UI-01"],
+      successCriteria: ["Components render"],
+      dependencies: [],
+      phaseOrder: 1,
+    });
+
+    const res = await req("POST", `/api/planning/projects/${projectId}/phases/${phaseId}/reorder`, {
+      newOrder: 1,
+    });
+    expect(res.status).toBe(200);
+    const data = await json(res);
+    expect(data.phases.length).toBe(2);
+  });
+
+  it("returns 404 for non-existent phase", async () => {
+    const res = await req("PATCH", `/api/planning/projects/${projectId}/phases/fake-phase-id`, {
+      name: "Nope",
+    });
+    expect(res.status).toBe(404);
+  });
+});
+
+// ─── ORCH-03: Category Workflow ────────────────────────────
+
+describe("ORCH-03: Category Workflow", () => {
+  const authCategory = {
+    category: "AUTH",
+    categoryName: "Authentication",
+    tableStakes: [
+      { name: "Login", description: "User can log in", isTableStakes: true, proposedTier: "v1" as const },
+      { name: "Logout", description: "User can log out", isTableStakes: true, proposedTier: "v1" as const },
+    ],
+    differentiators: [
+      { name: "SSO", description: "Single sign-on via OIDC", isTableStakes: false, proposedTier: "v2" as const },
+    ],
+  };
+
+  it("presents a category and returns formatted text", async () => {
+    const res = await req("POST", `/api/planning/projects/${projectId}/categories/present`, authCategory);
+    expect(res.status).toBe(200);
+    const data = await json(res);
+    expect(data.formatted).toContain("Authentication");
+    expect(data.formatted).toContain("Login");
+    expect(data.formatted).toContain("SSO");
+    expect(data.tableStakesCount).toBe(2);
+    expect(data.differentiatorCount).toBe(1);
+  });
+
+  it("persists category decisions as requirements", async () => {
+    const res = await req("POST", `/api/planning/projects/${projectId}/categories/persist`, {
+      category: authCategory,
+      decisions: [
+        { name: "Login", tier: "v1" },
+        { name: "Logout", tier: "v1" },
+        { name: "SSO", tier: "v2", rationale: "Nice to have later" },
+      ],
+    });
+    expect(res.status).toBe(201);
+    const data = await json(res);
+    expect(data.persisted).toBe(3);
+    expect(data.totalRequirements).toBe(3);
+
+    // Verify requirements exist in DB
+    const reqs = store.listRequirements(projectId);
+    expect(reqs.length).toBe(3);
+    expect(reqs.find(r => r.reqId === "AUTH-01")?.tier).toBe("v1");
+    expect(reqs.find(r => r.reqId === "AUTH-03")?.tier).toBe("v2");
+
+    // Verify REQUIREMENTS.md
+    const reqFile = join(tmpDir, ".dianoia", "projects", projectId, "REQUIREMENTS.md");
+    expect(existsSync(reqFile)).toBe(true);
+    const content = readFileSync(reqFile, "utf-8");
+    expect(content).toContain("AUTH-01");
+    expect(content).toContain("AUTH-03");
+  });
+
+  it("adjusts category requirements by reqId", async () => {
+    // First persist some requirements
+    await req("POST", `/api/planning/projects/${projectId}/categories/persist`, {
+      category: authCategory,
+      decisions: [
+        { name: "Login", tier: "v1" },
+        { name: "Logout", tier: "v1" },
+        { name: "SSO", tier: "v2" },
+      ],
+    });
+
+    // Now adjust
+    const res = await req("PATCH", `/api/planning/projects/${projectId}/categories/AUTH`, {
+      adjustments: [
+        { reqId: "AUTH-03", tier: "v1", rationale: "Actually need SSO for launch" },
+      ],
+    });
+    expect(res.status).toBe(200);
+    const data = await json(res);
+    expect(data.updatedCount).toBe(1);
+    expect(data.results[0].updated).toBe(true);
+
+    // Verify in DB
+    const reqs = store.listRequirements(projectId);
+    expect(reqs.find(r => r.reqId === "AUTH-03")?.tier).toBe("v1");
+  });
+
+  it("rejects table-stakes out-of-scope without rationale", async () => {
+    const res = await req("POST", `/api/planning/projects/${projectId}/categories/persist`, {
+      category: authCategory,
+      decisions: [
+        { name: "Login", tier: "out-of-scope" }, // table-stakes without rationale
+      ],
+    });
+    expect(res.status).toBe(400);
+    const data = await json(res);
+    expect(data.error.toLowerCase()).toContain("table-stakes");
+  });
+
+  it("rejects adjustment for wrong category", async () => {
+    await req("POST", `/api/planning/projects/${projectId}/categories/persist`, {
+      category: authCategory,
+      decisions: [{ name: "Login", tier: "v1" }],
+    });
+
+    const res = await req("PATCH", `/api/planning/projects/${projectId}/categories/UI`, {
+      adjustments: [{ reqId: "AUTH-01", tier: "v2" }],
+    });
+    const data = await json(res);
+    expect(data.results[0].updated).toBe(false);
+    expect(data.results[0].error).toContain("belongs to AUTH");
+  });
+});
+
+// ─── ORCH-04: Discussion Answer/Skip ───────────────────────
+
+describe("ORCH-04: Discussion Answer/Skip", () => {
+  let phaseId: string;
+  let questionId: string;
+
+  beforeEach(() => {
+    const phase = store.createPhase({
+      projectId,
+      name: "Test Phase",
+      goal: "Test",
+      requirements: [],
+      successCriteria: [],
+      dependencies: [],
+      phaseOrder: 0,
+    });
+    phaseId = phase.id;
+    const q = store.createDiscussionQuestion({
+      projectId,
+      phaseId,
+      question: "Should we use REST or GraphQL?",
+      options: JSON.stringify([
+        { label: "REST", rationale: "Simpler" },
+        { label: "GraphQL", rationale: "Flexible" },
+      ]),
+      recommendation: "REST",
+    });
+    questionId = q.id;
+  });
+
+  it("answers a discussion question via dedicated endpoint", async () => {
+    const res = await req("POST", `/api/planning/projects/${projectId}/discuss/answer`, {
+      questionId,
+      decision: "REST",
+      userNote: "Keep it simple",
+    });
+    expect(res.status).toBe(200);
+    const data = await json(res);
+    expect(data.success).toBe(true);
+
+    // Verify in DB
+    const q = store.getDiscussionQuestion(questionId);
+    expect(q?.decision).toBe("REST");
+  });
+
+  it("skips a discussion question", async () => {
+    const res = await req("POST", `/api/planning/projects/${projectId}/discuss/skip`, {
+      questionId,
+    });
+    expect(res.status).toBe(200);
+
+    const q = store.getDiscussionQuestion(questionId);
+    expect(q?.decision).toContain("skipped");
+  });
+
+  it("lists discussion questions for a phase", async () => {
+    const res = await req("GET", `/api/planning/projects/${projectId}/discuss?phaseId=${phaseId}`);
+    expect(res.status).toBe(200);
+    const data = await json(res);
+    expect(data.questions.length).toBe(1);
+    expect(data.questions[0].question).toBe("Should we use REST or GraphQL?");
+  });
+});
+
+// ─── ORCH-05: SSE Events ───────────────────────────────────
+
+describe("ORCH-05: SSE Events on mutations", () => {
+  it("emits requirement-changed on create", async () => {
+    const events: unknown[] = [];
+    const handler = (data: unknown) => events.push(data);
+    eventBus.on("planning:requirement-changed", handler);
+
+    await req("POST", `/api/planning/projects/${projectId}/requirements`, {
+      description: "Test req", category: "TST",
+    });
+
+    eventBus.off("planning:requirement-changed", handler);
+    expect(events.length).toBe(1);
+    expect((events[0] as any).action).toBe("created");
+  });
+
+  it("emits phase-changed on update", async () => {
+    const phase = store.createPhase({
+      projectId, name: "P1", goal: "G1",
+      requirements: [], successCriteria: [], dependencies: [], phaseOrder: 0,
+    });
+
+    const events: unknown[] = [];
+    const handler = (data: unknown) => events.push(data);
+    eventBus.on("planning:phase-changed", handler);
+
+    await req("PATCH", `/api/planning/projects/${projectId}/phases/${phase.id}`, {
+      name: "P1 Updated",
+    });
+
+    eventBus.off("planning:phase-changed", handler);
+    expect(events.length).toBe(1);
+    expect((events[0] as any).action).toBe("updated");
+  });
+
+  it("emits discussion-answered on answer", async () => {
+    const phase = store.createPhase({
+      projectId, name: "P1", goal: "G1",
+      requirements: [], successCriteria: [], dependencies: [], phaseOrder: 0,
+    });
+    const q = store.createDiscussionQuestion({
+      projectId, phaseId: phase.id,
+      question: "Test?", options: "[]", recommendation: "Yes",
+    });
+
+    const events: unknown[] = [];
+    const handler = (data: unknown) => events.push(data);
+    eventBus.on("planning:discussion-answered", handler);
+
+    await req("POST", `/api/planning/projects/${projectId}/discuss/answer`, {
+      questionId: q.id, decision: "Yes",
+    });
+
+    eventBus.off("planning:discussion-answered", handler);
+    expect(events.length).toBe(1);
+    expect((events[0] as any).decision).toBe("Yes");
+  });
+
+  it("emits on category persist", async () => {
+    const events: unknown[] = [];
+    const handler = (data: unknown) => events.push(data);
+    eventBus.on("planning:requirement-changed", handler);
+
+    await req("POST", `/api/planning/projects/${projectId}/categories/persist`, {
+      category: {
+        category: "UI",
+        categoryName: "User Interface",
+        tableStakes: [{ name: "Buttons", description: "Clickable", isTableStakes: true, proposedTier: "v1" }],
+        differentiators: [],
+      },
+      decisions: [{ name: "Buttons", tier: "v1" }],
+    });
+
+    eventBus.off("planning:requirement-changed", handler);
+    expect(events.length).toBe(1);
+    expect((events[0] as any).action).toBe("category-persisted");
+  });
+});
+
+// ─── ORCH-06: Batch Operations ─────────────────────────────
+
+describe("ORCH-06: Batch Operations", () => {
+  it("applies multiple requirement updates in one call", async () => {
+    store.createRequirement({ projectId, reqId: "A-01", description: "One", category: "A", tier: "v1", rationale: null });
+    store.createRequirement({ projectId, reqId: "A-02", description: "Two", category: "A", tier: "v1", rationale: null });
+
+    const r1 = store.getRequirementByReqId(projectId, "A-01")!;
+    const r2 = store.getRequirementByReqId(projectId, "A-02")!;
+
+    const res = await req("POST", `/api/planning/projects/${projectId}/batch`, {
+      operations: [
+        { type: "update-requirement", id: r1.id, data: { tier: "v2" } },
+        { type: "update-requirement", id: r2.id, data: { tier: "out-of-scope" } },
+      ],
+    });
+    expect(res.status).toBe(200);
+    const data = await json(res);
+    expect(data.successCount).toBe(2);
+    expect(data.failureCount).toBe(0);
+
+    // Verify DB
+    expect(store.getRequirement(r1.id)?.tier).toBe("v2");
+    expect(store.getRequirement(r2.id)?.tier).toBe("out-of-scope");
+
+    // Verify file synced
+    const reqFile = join(tmpDir, ".dianoia", "projects", projectId, "REQUIREMENTS.md");
+    expect(existsSync(reqFile)).toBe(true);
+  });
+
+  it("handles mixed success/failure in batch", async () => {
+    store.createRequirement({ projectId, reqId: "B-01", description: "One", category: "B", tier: "v1", rationale: null });
+    const r1 = store.getRequirementByReqId(projectId, "B-01")!;
+
+    const res = await req("POST", `/api/planning/projects/${projectId}/batch`, {
+      operations: [
+        { type: "update-requirement", id: r1.id, data: { tier: "v2" } },
+        { type: "delete-requirement", id: "nonexistent-id" },
+      ],
+    });
+    expect(res.status).toBe(200);
+    const data = await json(res);
+    expect(data.successCount).toBe(1);
+    expect(data.failureCount).toBe(1);
+    expect(data.results[1].error).toBeDefined();
+  });
+
+  it("rejects batches over 50 operations", async () => {
+    const ops = Array.from({ length: 51 }, (_, i) => ({
+      type: "update-requirement" as const,
+      id: `fake-${i}`,
+      data: { tier: "v2" },
+    }));
+    const res = await req("POST", `/api/planning/projects/${projectId}/batch`, { operations: ops });
+    expect(res.status).toBe(400);
+  });
+
+  it("batch deletes phases and syncs roadmap", async () => {
+    const p1 = store.createPhase({
+      projectId, name: "P1", goal: "G1",
+      requirements: [], successCriteria: [], dependencies: [], phaseOrder: 0,
+    });
+    const p2 = store.createPhase({
+      projectId, name: "P2", goal: "G2",
+      requirements: [], successCriteria: [], dependencies: [], phaseOrder: 0,
+    });
+
+    const res = await req("POST", `/api/planning/projects/${projectId}/batch`, {
+      operations: [
+        { type: "delete-phase", id: p1.id },
+        { type: "delete-phase", id: p2.id },
+      ],
+    });
+    expect(res.status).toBe(200);
+    const data = await json(res);
+    expect(data.successCount).toBe(2);
+
+    // Verify phases gone
+    expect(store.listPhases(projectId).length).toBe(0);
+  });
+});
+
+// ─── SYNC: File Co-Primary Verification ───────────────────
+
+describe("SYNC: File co-primary (ENG-01 compliance)", () => {
+  it("every requirement mutation writes REQUIREMENTS.md", async () => {
+    const reqFile = () => {
+      const p = join(tmpDir, ".dianoia", "projects", projectId, "REQUIREMENTS.md");
+      return existsSync(p) ? readFileSync(p, "utf-8") : "";
+    };
+
+    // Create
+    await req("POST", `/api/planning/projects/${projectId}/requirements`, {
+      description: "Feature A", category: "FEAT",
+    });
+    expect(reqFile()).toContain("Feature A");
+
+    // Update
+    await req("PATCH", `/api/planning/projects/${projectId}/requirements/FEAT-01`, {
+      description: "Feature A (updated)",
+    });
+    expect(reqFile()).toContain("Feature A (updated)");
+
+    // Delete
+    await req("DELETE", `/api/planning/projects/${projectId}/requirements/FEAT-01`);
+    expect(reqFile()).not.toContain("Feature A");
+  });
+
+  it("every phase mutation writes ROADMAP.md", async () => {
+    const roadmapFile = () => {
+      const p = join(tmpDir, ".dianoia", "projects", projectId, "ROADMAP.md");
+      return existsSync(p) ? readFileSync(p, "utf-8") : "";
+    };
+
+    const phase = store.createPhase({
+      projectId, name: "Alpha", goal: "Build alpha",
+      requirements: [], successCriteria: [], dependencies: [], phaseOrder: 0,
+    });
+
+    // Update
+    await req("PATCH", `/api/planning/projects/${projectId}/phases/${phase.id}`, {
+      name: "Alpha v2",
+    });
+    expect(roadmapFile()).toContain("Alpha v2");
+
+    // Delete
+    await req("DELETE", `/api/planning/projects/${projectId}/phases/${phase.id}`);
+    expect(roadmapFile()).not.toContain("Alpha v2");
+  });
+});
+
+// ─── Read Endpoints ────────────────────────────────────────
+
+describe("Read endpoints", () => {
+  it("GET /projects lists all projects", async () => {
+    const res = await req("GET", "/api/planning/projects");
+    expect(res.status).toBe(200);
+    const data = await json(res);
+    expect(data.projects.length).toBe(1);
+  });
+
+  it("GET /projects/:id returns project detail", async () => {
+    const res = await req("GET", `/api/planning/projects/${projectId}`);
+    expect(res.status).toBe(200);
+    const data = await json(res);
+    expect(data.id).toBe(projectId);
+    expect(data.goal).toBe("Test project");
+  });
+
+  it("GET /projects/:id/requirements lists requirements", async () => {
+    store.createRequirement({ projectId, reqId: "X-01", description: "Test", category: "X", tier: "v1", rationale: null });
+    const res = await req("GET", `/api/planning/projects/${projectId}/requirements`);
+    expect(res.status).toBe(200);
+    const data = await json(res);
+    expect(data.requirements.length).toBe(1);
+  });
+
+  it("GET /projects/:id/phases lists phases", async () => {
+    store.createPhase({
+      projectId, name: "P1", goal: "G1",
+      requirements: [], successCriteria: [], dependencies: [], phaseOrder: 0,
+    });
+    const res = await req("GET", `/api/planning/projects/${projectId}/phases`);
+    expect(res.status).toBe(200);
+    const data = await json(res);
+    expect(data.phases.length).toBe(1);
+  });
+
+  it("GET /projects/:id/timeline returns milestones", async () => {
+    const res = await req("GET", `/api/planning/projects/${projectId}/timeline`);
+    expect(res.status).toBe(200);
+    const data = await json(res);
+    expect(data.milestones.length).toBeGreaterThanOrEqual(2); // Research + Requirements at minimum
+  });
+
+  it("returns 404 for non-existent project", async () => {
+    const res = await req("GET", "/api/planning/projects/fake-id");
+    expect(res.status).toBe(404);
+  });
+});

--- a/infrastructure/runtime/src/dianoia/routes.ts
+++ b/infrastructure/runtime/src/dianoia/routes.ts
@@ -1,11 +1,47 @@
 // Planning API routes — /api/planning/projects and /api/planning/projects/:id
+//
+// Phase 4 (ORCH-01 through ORCH-05, SYNC-01 through SYNC-04):
+// - Full CRUD for requirements, phases, categories, discussions
+// - Bidirectional file sync: every mutation writes SQLite AND markdown
+// - SSE events emitted on every state change for real-time UI push
 import { Hono } from "hono";
 import { createLogger } from "../koina/logger.js";
 import { eventBus } from "../koina/event-bus.js";
 import type { RouteDeps, RouteRefs } from "../pylon/routes/deps.js";
 import { PlanningStore } from "./store.js";
+import { RequirementsOrchestrator } from "./requirements.js";
+import type { CategoryProposal, ScopingDecision } from "./requirements.js";
+import { writeRequirementsFile, writeRoadmapFile } from "./project-files.js";
 
 const log = createLogger("pylon:planning");
+
+/**
+ * Sync requirements from SQLite to REQUIREMENTS.md.
+ * Called after every requirement mutation so file stays co-primary with DB.
+ */
+function syncRequirementsFile(store: PlanningStore, projectId: string, workspaceRoot: string | null): void {
+  if (!workspaceRoot) return;
+  try {
+    const reqs = store.listRequirements(projectId);
+    writeRequirementsFile(workspaceRoot, projectId, reqs);
+  } catch (err) {
+    log.warn(`Failed to sync REQUIREMENTS.md for ${projectId}`, { error: err });
+  }
+}
+
+/**
+ * Sync phases from SQLite to ROADMAP.md.
+ * Called after every phase mutation.
+ */
+function syncRoadmapFile(store: PlanningStore, projectId: string, workspaceRoot: string | null): void {
+  if (!workspaceRoot) return;
+  try {
+    const phases = store.listPhases(projectId);
+    writeRoadmapFile(workspaceRoot, projectId, phases);
+  } catch (err) {
+    log.warn(`Failed to sync ROADMAP.md for ${projectId}`, { error: err });
+  }
+}
 
 export function planningRoutes(deps: RouteDeps, _refs: RouteRefs): Hono {
   const app = new Hono();
@@ -15,6 +51,15 @@ export function planningRoutes(deps: RouteDeps, _refs: RouteRefs): Hono {
   const getStore = (): PlanningStore | null => {
     try {
       return deps.store ? new PlanningStore(deps.store.getDb()) : null;
+    } catch {
+      return null;
+    }
+  };
+
+  // Get workspace root from orchestrator for file sync
+  const getWorkspaceRoot = (): string | null => {
+    try {
+      return orch?.getWorkspaceOrThrow() ?? null;
     } catch {
       return null;
     }
@@ -475,6 +520,7 @@ export function planningRoutes(deps: RouteDeps, _refs: RouteRefs): Hono {
         rationale: body.rationale ?? null,
         phaseId: body.phaseId ?? null,
       });
+      syncRequirementsFile(store, projectId, getWorkspaceRoot());
       eventBus.emit("planning:requirement-changed", {
         projectId, action: "created", requirementId: req.id, reqId: req.reqId,
       });
@@ -513,6 +559,7 @@ export function planningRoutes(deps: RouteDeps, _refs: RouteRefs): Hono {
       }
 
       const updated = store.updateRequirement(req.id, body);
+      syncRequirementsFile(store, projectId, getWorkspaceRoot());
       eventBus.emit("planning:requirement-changed", {
         projectId, action: "updated", requirementId: req.id, reqId: updated.reqId, changes: Object.keys(body),
       });
@@ -541,6 +588,7 @@ export function planningRoutes(deps: RouteDeps, _refs: RouteRefs): Hono {
       }
 
       store.deleteRequirement(req.id);
+      syncRequirementsFile(store, projectId, getWorkspaceRoot());
       eventBus.emit("planning:requirement-changed", {
         projectId, action: "deleted", requirementId: req.id, reqId: req.reqId,
       });
@@ -576,6 +624,7 @@ export function planningRoutes(deps: RouteDeps, _refs: RouteRefs): Hono {
       }
 
       const updated = store.updatePhase(phaseId, body);
+      syncRoadmapFile(store, projectId, getWorkspaceRoot());
       eventBus.emit("planning:phase-changed", {
         projectId, action: "updated", phaseId, changes: Object.keys(body),
       });
@@ -612,6 +661,7 @@ export function planningRoutes(deps: RouteDeps, _refs: RouteRefs): Hono {
       }
 
       store.deletePhase(phaseId);
+      syncRoadmapFile(store, projectId, getWorkspaceRoot());
       eventBus.emit("planning:phase-changed", {
         projectId, action: "deleted", phaseId, phaseName: phase.name,
       });
@@ -638,6 +688,7 @@ export function planningRoutes(deps: RouteDeps, _refs: RouteRefs): Hono {
     try {
       store.reorderPhase(projectId, phaseId, body.newOrder);
       const phases = store.listPhases(projectId);
+      syncRoadmapFile(store, projectId, getWorkspaceRoot());
       eventBus.emit("planning:phase-changed", {
         projectId, action: "reordered", phaseId, newOrder: body.newOrder,
       });
@@ -717,6 +768,230 @@ export function planningRoutes(deps: RouteDeps, _refs: RouteRefs): Hono {
       log.error("Failed to skip discussion", { projectId, error });
       return c.json({ error: "Failed to skip discussion" }, 500);
     }
+  });
+
+  // ============================================================
+  // Category Proposal Workflow (ORCH-03)
+  // ============================================================
+
+  // Present a category proposal — returns formatted text for UI display
+  app.post("/api/planning/projects/:id/categories/present", async (c) => {
+    const store = getStore();
+    if (!store) return c.json({ error: "Database not available" }, 503);
+
+    const projectId = c.req.param("id");
+    const body = await c.req.json() as CategoryProposal;
+
+    if (!body.category || !body.categoryName) {
+      return c.json({ error: "category and categoryName are required" }, 400);
+    }
+
+    try {
+      const reqOrch = new RequirementsOrchestrator(store["db"], getWorkspaceRoot() ?? undefined);
+      const formatted = reqOrch.formatCategoryPresentation(body);
+      eventBus.emit("planning:requirement-changed", {
+        projectId, action: "category-presented", category: body.category,
+      });
+      return c.json({
+        projectId,
+        category: body.category,
+        categoryName: body.categoryName,
+        formatted,
+        tableStakesCount: body.tableStakes.length,
+        differentiatorCount: body.differentiators.length,
+      });
+    } catch (error) {
+      log.error("Failed to present category", { projectId, error });
+      return c.json({ error: "Failed to present category" }, 500);
+    }
+  });
+
+  // Persist category decisions — creates requirements from approved features
+  app.post("/api/planning/projects/:id/categories/persist", async (c) => {
+    const store = getStore();
+    if (!store) return c.json({ error: "Database not available" }, 503);
+
+    const projectId = c.req.param("id");
+    const body = await c.req.json() as {
+      category: CategoryProposal;
+      decisions: ScopingDecision[];
+    };
+
+    if (!body.category || !body.decisions?.length) {
+      return c.json({ error: "category and decisions[] are required" }, 400);
+    }
+
+    try {
+      const reqOrch = new RequirementsOrchestrator(store["db"], getWorkspaceRoot() ?? undefined);
+      reqOrch.persistCategory(projectId, body.category, body.decisions);
+      // File sync is already handled by RequirementsOrchestrator.persistCategory()
+      // but let's ensure it happens even if workspace was null during construction
+      syncRequirementsFile(store, projectId, getWorkspaceRoot());
+      eventBus.emit("planning:requirement-changed", {
+        projectId, action: "category-persisted", category: body.category.category,
+        count: body.decisions.length,
+      });
+      const reqs = store.listRequirements(projectId);
+      return c.json({
+        projectId,
+        category: body.category.category,
+        persisted: body.decisions.length,
+        totalRequirements: reqs.length,
+      }, 201);
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      const code = (error as any)?.code ?? "";
+      log.error("Failed to persist category", { projectId, error });
+      if (msg.includes("Table-stakes") || msg.includes("TABLE_STAKES") || code.includes("TABLE_STAKES") ||
+          msg.includes("DUPLICATE") || code.includes("DUPLICATE")) {
+        return c.json({ error: msg }, 400);
+      }
+      return c.json({ error: "Failed to persist category" }, 500);
+    }
+  });
+
+  // Adjust a category's requirements — bulk update tiers/rationale
+  app.patch("/api/planning/projects/:id/categories/:categoryCode", async (c) => {
+    const store = getStore();
+    if (!store) return c.json({ error: "Database not available" }, 503);
+
+    const projectId = c.req.param("id");
+    const categoryCode = c.req.param("categoryCode");
+    const body = await c.req.json() as {
+      adjustments: Array<{
+        reqId: string;
+        tier?: "v1" | "v2" | "out-of-scope";
+        rationale?: string | null;
+      }>;
+    };
+
+    if (!body.adjustments?.length) {
+      return c.json({ error: "adjustments[] is required" }, 400);
+    }
+
+    try {
+      const results: Array<{ reqId: string; updated: boolean; error?: string }> = [];
+      for (const adj of body.adjustments) {
+        try {
+          const req = store.getRequirementByReqId(projectId, adj.reqId);
+          if (!req) {
+            results.push({ reqId: adj.reqId, updated: false, error: "not found" });
+            continue;
+          }
+          if (req.category !== categoryCode) {
+            results.push({ reqId: adj.reqId, updated: false, error: `belongs to ${req.category}, not ${categoryCode}` });
+            continue;
+          }
+          const updates: Record<string, unknown> = {};
+          if (adj.tier !== undefined) updates["tier"] = adj.tier;
+          if (adj.rationale !== undefined) updates["rationale"] = adj.rationale;
+          store.updateRequirement(req.id, updates as { tier?: "v1" | "v2" | "out-of-scope"; rationale?: string | null });
+          results.push({ reqId: adj.reqId, updated: true });
+        } catch (err) {
+          results.push({ reqId: adj.reqId, updated: false, error: err instanceof Error ? err.message : String(err) });
+        }
+      }
+
+      syncRequirementsFile(store, projectId, getWorkspaceRoot());
+      const updatedCount = results.filter(r => r.updated).length;
+      eventBus.emit("planning:requirement-changed", {
+        projectId, action: "category-adjusted", category: categoryCode, updatedCount,
+      });
+      return c.json({ projectId, category: categoryCode, results, updatedCount });
+    } catch (error) {
+      log.error("Failed to adjust category", { projectId, categoryCode, error });
+      return c.json({ error: "Failed to adjust category" }, 500);
+    }
+  });
+
+  // ============================================================
+  // Batch Operations (ORCH-06) — v2 but useful now
+  // ============================================================
+
+  app.post("/api/planning/projects/:id/batch", async (c) => {
+    const store = getStore();
+    if (!store) return c.json({ error: "Database not available" }, 503);
+
+    const projectId = c.req.param("id");
+    const project = orch?.getProject(projectId);
+    if (!project) return c.json({ error: "Project not found" }, 404);
+
+    const body = await c.req.json() as {
+      operations: Array<{
+        type: "update-requirement" | "update-phase" | "delete-requirement" | "delete-phase";
+        id: string;
+        data?: Record<string, unknown>;
+      }>;
+    };
+
+    if (!body.operations?.length) {
+      return c.json({ error: "operations[] is required" }, 400);
+    }
+
+    if (body.operations.length > 50) {
+      return c.json({ error: "Maximum 50 operations per batch" }, 400);
+    }
+
+    const results: Array<{ index: number; type: string; id: string; success: boolean; error?: string }> = [];
+    let reqsChanged = false;
+    let phasesChanged = false;
+
+    for (let i = 0; i < body.operations.length; i++) {
+      const op = body.operations[i]!;
+      try {
+        switch (op.type) {
+          case "update-requirement": {
+            const req = store.getRequirement(op.id) ?? store.getRequirementByReqId(projectId, op.id);
+            if (!req) throw new Error("Not found");
+            store.updateRequirement(req.id, op.data as { tier?: "v1" | "v2" | "out-of-scope"; rationale?: string | null });
+            reqsChanged = true;
+            results.push({ index: i, type: op.type, id: op.id, success: true });
+            break;
+          }
+          case "delete-requirement": {
+            const req = store.getRequirement(op.id) ?? store.getRequirementByReqId(projectId, op.id);
+            if (!req) throw new Error("Not found");
+            store.deleteRequirement(req.id);
+            reqsChanged = true;
+            results.push({ index: i, type: op.type, id: op.id, success: true });
+            break;
+          }
+          case "update-phase": {
+            store.updatePhase(op.id, op.data as { name?: string; goal?: string });
+            phasesChanged = true;
+            results.push({ index: i, type: op.type, id: op.id, success: true });
+            break;
+          }
+          case "delete-phase": {
+            store.deletePhase(op.id);
+            phasesChanged = true;
+            results.push({ index: i, type: op.type, id: op.id, success: true });
+            break;
+          }
+          default:
+            results.push({ index: i, type: op.type, id: op.id, success: false, error: `Unknown type: ${op.type}` });
+        }
+      } catch (err) {
+        results.push({ index: i, type: op.type, id: op.id, success: false, error: err instanceof Error ? err.message : String(err) });
+      }
+    }
+
+    const wsRoot = getWorkspaceRoot();
+    if (reqsChanged) syncRequirementsFile(store, projectId, wsRoot);
+    if (phasesChanged) syncRoadmapFile(store, projectId, wsRoot);
+
+    const successCount = results.filter(r => r.success).length;
+    eventBus.emit("planning:phase-changed", {
+      projectId, action: "batch", operationCount: body.operations.length, successCount,
+    });
+
+    return c.json({
+      projectId,
+      totalOperations: body.operations.length,
+      successCount,
+      failureCount: body.operations.length - successCount,
+      results,
+    });
   });
 
   log.debug("planning routes mounted");


### PR DESCRIPTION
## Phase 4: API & Sync Layer

Implements ORCH-01 through ORCH-06, SYNC-01 through SYNC-04 from the Dianoia Collaborative Workspace roadmap.

### File Co-Primary Sync (SYNC-01/02)

Every mutation route now writes **both** SQLite and markdown files, maintaining the co-primary architecture from ENG-01. Previously, CRUD routes only touched SQLite — file sync was limited to agent tool calls.

| Mutation | File Synced |
|----------|------------|
| Create/update/delete requirement | REQUIREMENTS.md |
| Update/delete/reorder phase | ROADMAP.md |
| Category persist | REQUIREMENTS.md |
| Batch operations | Both (once per type) |

### Category Workflow (ORCH-03)

Three new endpoints for the full category proposal flow:

| Endpoint | Purpose |
|----------|---------|
| `POST /categories/present` | Format category for UI display |
| `POST /categories/persist` | Create requirements from approved features |
| `PATCH /categories/:code` | Bulk-adjust requirements within a category |

Enforcement:
- Table-stakes features cannot be out-of-scope without explicit rationale
- Adjustments validate category ownership (can't modify AUTH reqs via UI category)

### Batch Operations (ORCH-06)

`POST /batch` applies multiple operations atomically:
- 4 operation types: update-requirement, delete-requirement, update-phase, delete-phase
- Partial success: each op succeeds/fails independently
- File sync runs once per file type, not per operation
- Hard limit: 50 ops per batch

### SSE Events (ORCH-05 / SYNC-03)

All mutations emit events through the existing event bus → SSE pipeline. New action payloads:
- `category-presented`, `category-persisted`, `category-adjusted`, `batch`

### Test Coverage

| Section | Tests |
|---------|-------|
| ORCH-01: Requirement CRUD | 5 |
| ORCH-02: Phase CRUD | 4 |
| ORCH-03: Category Workflow | 5 |
| ORCH-04: Discussion Answer/Skip | 3 |
| ORCH-05: SSE Events | 4 |
| ORCH-06: Batch Operations | 4 |
| SYNC: File co-primary | 2 |
| Read endpoints | 6 |
| **Total** | **33** |

607 total tests passing, 0 TypeScript errors.