### PR TITLE
feat(dianoia): Phase 6 observability — decision audit + turn tracking

### DIFF
--- a/infrastructure/runtime/src/dianoia/index.ts
+++ b/infrastructure/runtime/src/dianoia/index.ts
@@ -12,8 +12,8 @@ export type {
   PlanningResearch,
   ProjectContext,
 } from "./types.js";
-export { PLANNING_V20_DDL, PLANNING_V21_MIGRATION, PLANNING_V22_MIGRATION, PLANNING_V23_MIGRATION, PLANNING_V24_MIGRATION, PLANNING_V25_MIGRATION, PLANNING_V26_MIGRATION, PLANNING_V27_MIGRATION } from "./schema.js";
-export type { DiscussionQuestion, DiscussionOption } from "./types.js";
+export { PLANNING_V20_DDL, PLANNING_V21_MIGRATION, PLANNING_V22_MIGRATION, PLANNING_V23_MIGRATION, PLANNING_V24_MIGRATION, PLANNING_V25_MIGRATION, PLANNING_V26_MIGRATION, PLANNING_V27_MIGRATION, PLANNING_V28_MIGRATION } from "./schema.js";
+export type { DiscussionQuestion, DiscussionOption, PlanningDecision, TurnCount } from "./types.js";
 export { ResearchOrchestrator } from "./researcher.js";
 export { createPlanResearchTool } from "./research-tool.js";
 export { transition, VALID_TRANSITIONS } from "./machine.js";

--- a/infrastructure/runtime/src/dianoia/observability.test.ts
+++ b/infrastructure/runtime/src/dianoia/observability.test.ts
@@ -1,0 +1,357 @@
+/**
+ * Observability tests — OBS-03 (decision audit trail) and OBS-05 (turn tracking).
+ * Tests store methods + HTTP route endpoints.
+ */
+import Database from "better-sqlite3";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { Hono } from "hono";
+import { mkdirSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import {
+  PLANNING_V20_DDL,
+  PLANNING_V21_MIGRATION,
+  PLANNING_V22_MIGRATION,
+  PLANNING_V23_MIGRATION,
+  PLANNING_V24_MIGRATION,
+  PLANNING_V25_MIGRATION,
+  PLANNING_V26_MIGRATION,
+  PLANNING_V27_MIGRATION,
+  PLANNING_V28_MIGRATION,
+} from "./schema.js";
+import { PlanningStore } from "./store.js";
+import { planningRoutes } from "./routes.js";
+import { DianoiaOrchestrator } from "./orchestrator.js";
+
+let db: Database.Database;
+let store: PlanningStore;
+let app: Hono;
+let tmpDir: string;
+let projectId: string;
+
+const defaultConfig = {
+  depth: "standard" as const,
+  parallelization: false,
+  research: true,
+  plan_check: true,
+  verifier: true,
+  mode: "interactive" as const,
+};
+
+function initDb(): Database.Database {
+  const d = new Database(":memory:");
+  d.pragma("journal_mode = WAL");
+  d.pragma("foreign_keys = ON");
+  d.exec(PLANNING_V20_DDL);
+  d.exec(PLANNING_V21_MIGRATION);
+  d.exec(PLANNING_V22_MIGRATION);
+  d.exec(PLANNING_V23_MIGRATION);
+  d.exec(PLANNING_V24_MIGRATION);
+  d.exec(PLANNING_V25_MIGRATION);
+  d.exec(PLANNING_V26_MIGRATION);
+  d.exec(PLANNING_V27_MIGRATION);
+  d.exec(PLANNING_V28_MIGRATION);
+  return d;
+}
+
+function seedProject(): string {
+  const project = store.createProject({
+    nousId: "test-nous",
+    sessionId: "test-session",
+    goal: "Observability test project",
+    config: defaultConfig,
+  });
+  return project.id;
+}
+
+beforeEach(() => {
+  db = initDb();
+  store = new PlanningStore(db);
+  tmpDir = join(tmpdir(), `dianoia-obs-test-${Date.now()}`);
+  mkdirSync(tmpDir, { recursive: true });
+
+  const orch = new DianoiaOrchestrator(db, {
+    depth: "standard",
+    parallelization: false,
+    research: true,
+    plan_check: true,
+    verifier: true,
+    mode: "interactive",
+  });
+  orch.setWorkspaceRoot(tmpDir);
+
+  const routeApp = planningRoutes(
+    {
+      store: { getDb: () => db } as any,
+      manager: { getActiveTurnDetails: () => [] } as any,
+      planningOrchestrator: orch,
+    } as any,
+    {} as any,
+  );
+  app = new Hono();
+  app.route("/", routeApp);
+  projectId = seedProject();
+});
+
+afterEach(() => {
+  db.close();
+  try { rmSync(tmpDir, { recursive: true, force: true }); } catch {}
+});
+
+// ================================================================
+// OBS-03: Decision Audit Trail — Store
+// ================================================================
+
+describe("Decision audit trail (store)", () => {
+  it("logs a decision and retrieves it by id", () => {
+    const decision = store.logDecision({
+      projectId,
+      source: "user",
+      type: "scope",
+      summary: "Include auth module in v1",
+      rationale: "Security is table stakes",
+    });
+
+    expect(decision.id).toBeTruthy();
+    expect(decision.source).toBe("user");
+    expect(decision.type).toBe("scope");
+    expect(decision.summary).toBe("Include auth module in v1");
+    expect(decision.rationale).toBe("Security is table stakes");
+    expect(decision.createdAt).toBeTruthy();
+
+    const retrieved = store.getDecision(decision.id);
+    expect(retrieved).toEqual(decision);
+  });
+
+  it("logs decisions with different sources", () => {
+    const sources = ["user", "agent", "checkpoint", "system"] as const;
+    for (const source of sources) {
+      store.logDecision({
+        projectId,
+        source,
+        type: "config",
+        summary: `Decision from ${source}`,
+      });
+    }
+
+    const all = store.listDecisions(projectId);
+    expect(all).toHaveLength(4);
+    expect(new Set(all.map((d) => d.source))).toEqual(new Set(sources));
+  });
+
+  it("filters decisions by phase", () => {
+    store.logDecision({
+      projectId,
+      phaseId: "phase-1",
+      source: "agent",
+      type: "architecture",
+      summary: "Use repository pattern",
+    });
+    store.logDecision({
+      projectId,
+      phaseId: "phase-2",
+      source: "agent",
+      type: "architecture",
+      summary: "Use event sourcing",
+    });
+    store.logDecision({
+      projectId,
+      source: "system",
+      type: "transition",
+      summary: "Project state changed",
+    });
+
+    const phase1 = store.listDecisions(projectId, "phase-1");
+    expect(phase1).toHaveLength(1);
+    expect(phase1[0].summary).toBe("Use repository pattern");
+
+    const all = store.listDecisions(projectId);
+    expect(all).toHaveLength(3);
+  });
+
+  it("stores and retrieves context JSON", () => {
+    const context = { requirement: "AUTH-01", tier: "v1", previousTier: "v2" };
+    const decision = store.logDecision({
+      projectId,
+      source: "user",
+      type: "scope-change",
+      summary: "Promoted AUTH-01 to v1",
+      context,
+    });
+
+    const retrieved = store.getDecision(decision.id);
+    expect(retrieved?.context).toEqual(context);
+  });
+
+  it("cascades on project delete", () => {
+    store.logDecision({
+      projectId,
+      source: "user",
+      type: "test",
+      summary: "Will be deleted",
+    });
+    expect(store.listDecisions(projectId)).toHaveLength(1);
+
+    store.deleteProject(projectId);
+    expect(store.listDecisions(projectId)).toHaveLength(0);
+  });
+});
+
+// ================================================================
+// OBS-05: Turn Tracking — Store
+// ================================================================
+
+describe("Turn tracking (store)", () => {
+  it("records and increments turn counts", () => {
+    store.recordTurn(projectId, "phase-1", "syn", 1500);
+    store.recordTurn(projectId, "phase-1", "syn", 2000);
+
+    const counts = store.getTurnCounts(projectId, "phase-1");
+    expect(counts).toHaveLength(1);
+    expect(counts[0].turnCount).toBe(2);
+    expect(counts[0].tokenCount).toBe(3500);
+    expect(counts[0].nousId).toBe("syn");
+  });
+
+  it("tracks multiple agents independently", () => {
+    store.recordTurn(projectId, "phase-1", "syn", 1000);
+    store.recordTurn(projectId, "phase-1", "syn", 1000);
+    store.recordTurn(projectId, "phase-1", "coder-1", 500);
+
+    const counts = store.getTurnCounts(projectId, "phase-1");
+    expect(counts).toHaveLength(2);
+
+    const syn = counts.find((c) => c.nousId === "syn");
+    const coder = counts.find((c) => c.nousId === "coder-1");
+    expect(syn?.turnCount).toBe(2);
+    expect(syn?.tokenCount).toBe(2000);
+    expect(coder?.turnCount).toBe(1);
+    expect(coder?.tokenCount).toBe(500);
+  });
+
+  it("tracks multiple phases independently", () => {
+    store.recordTurn(projectId, "phase-1", "syn", 1000);
+    store.recordTurn(projectId, "phase-2", "syn", 2000);
+
+    const p1 = store.getTurnCounts(projectId, "phase-1");
+    const p2 = store.getTurnCounts(projectId, "phase-2");
+    expect(p1).toHaveLength(1);
+    expect(p2).toHaveLength(1);
+    expect(p1[0].tokenCount).toBe(1000);
+    expect(p2[0].tokenCount).toBe(2000);
+
+    // All phases
+    const all = store.getTurnCounts(projectId);
+    expect(all).toHaveLength(2);
+  });
+
+  it("returns project totals", () => {
+    store.recordTurn(projectId, "phase-1", "syn", 1000);
+    store.recordTurn(projectId, "phase-1", "coder-1", 500);
+    store.recordTurn(projectId, "phase-2", "syn", 2000);
+
+    const totals = store.getProjectTurnTotal(projectId);
+    expect(totals.turns).toBe(3);
+    expect(totals.tokens).toBe(3500);
+  });
+
+  it("returns zeros for empty project", () => {
+    const totals = store.getProjectTurnTotal(projectId);
+    expect(totals.turns).toBe(0);
+    expect(totals.tokens).toBe(0);
+  });
+
+  it("defaults token count to 0", () => {
+    store.recordTurn(projectId, "phase-1", "syn");
+
+    const counts = store.getTurnCounts(projectId, "phase-1");
+    expect(counts[0].turnCount).toBe(1);
+    expect(counts[0].tokenCount).toBe(0);
+  });
+
+  it("cascades on project delete", () => {
+    store.recordTurn(projectId, "phase-1", "syn", 1000);
+    expect(store.getTurnCounts(projectId)).toHaveLength(1);
+
+    store.deleteProject(projectId);
+    expect(store.getTurnCounts(projectId)).toHaveLength(0);
+  });
+});
+
+// ================================================================
+// OBS-03: Decision Audit Trail — Routes
+// ================================================================
+
+describe("GET /api/planning/projects/:id/decisions", () => {
+  it("returns empty list for project with no decisions", async () => {
+    const res = await app.request(`/api/planning/projects/${projectId}/decisions`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.decisions).toEqual([]);
+    expect(body.count).toBe(0);
+    expect(body.projectId).toBe(projectId);
+  });
+
+  it("returns all decisions for project", async () => {
+    store.logDecision({ projectId, source: "user", type: "scope", summary: "Include auth" });
+    store.logDecision({ projectId, source: "agent", type: "design", summary: "Use REST" });
+
+    const res = await app.request(`/api/planning/projects/${projectId}/decisions`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.decisions).toHaveLength(2);
+    expect(body.count).toBe(2);
+  });
+
+  it("filters by phaseId query param", async () => {
+    store.logDecision({ projectId, phaseId: "p1", source: "user", type: "scope", summary: "A" });
+    store.logDecision({ projectId, phaseId: "p2", source: "user", type: "scope", summary: "B" });
+    store.logDecision({ projectId, source: "system", type: "transition", summary: "C" });
+
+    const res = await app.request(`/api/planning/projects/${projectId}/decisions?phaseId=p1`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.decisions).toHaveLength(1);
+    expect(body.decisions[0].summary).toBe("A");
+  });
+});
+
+// ================================================================
+// OBS-05: Turn Tracking — Routes
+// ================================================================
+
+describe("GET /api/planning/projects/:id/usage", () => {
+  it("returns zeros for project with no turns", async () => {
+    const res = await app.request(`/api/planning/projects/${projectId}/usage`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.turnCounts).toEqual([]);
+    expect(body.totals.turns).toBe(0);
+    expect(body.totals.tokens).toBe(0);
+    expect(body.projectId).toBe(projectId);
+  });
+
+  it("returns turn counts and totals", async () => {
+    store.recordTurn(projectId, "p1", "syn", 1000);
+    store.recordTurn(projectId, "p1", "coder-1", 500);
+    store.recordTurn(projectId, "p2", "syn", 2000);
+
+    const res = await app.request(`/api/planning/projects/${projectId}/usage`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.turnCounts).toHaveLength(3);
+    expect(body.totals.turns).toBe(3);
+    expect(body.totals.tokens).toBe(3500);
+  });
+
+  it("filters by phaseId query param", async () => {
+    store.recordTurn(projectId, "p1", "syn", 1000);
+    store.recordTurn(projectId, "p2", "syn", 2000);
+
+    const res = await app.request(`/api/planning/projects/${projectId}/usage?phaseId=p1`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.turnCounts).toHaveLength(1);
+    expect(body.turnCounts[0].phaseId).toBe("p1");
+  });
+});

--- a/infrastructure/runtime/src/dianoia/routes.test.ts
+++ b/infrastructure/runtime/src/dianoia/routes.test.ts
@@ -19,6 +19,7 @@ import {
   PLANNING_V25_MIGRATION,
   PLANNING_V26_MIGRATION,
   PLANNING_V27_MIGRATION,
+  PLANNING_V28_MIGRATION,
 } from "./schema.js";
 import { PlanningStore } from "./store.js";
 import { planningRoutes } from "./routes.js";
@@ -52,6 +53,7 @@ function initDb(): Database.Database {
   d.exec(PLANNING_V25_MIGRATION);
   d.exec(PLANNING_V26_MIGRATION);
   d.exec(PLANNING_V27_MIGRATION);
+  d.exec(PLANNING_V28_MIGRATION);
   return d;
 }
 

--- a/infrastructure/runtime/src/dianoia/routes.ts
+++ b/infrastructure/runtime/src/dianoia/routes.ts
@@ -994,6 +994,51 @@ export function planningRoutes(deps: RouteDeps, _refs: RouteRefs): Hono {
     });
   });
 
+  // ============================================================
+  // Decision Audit Trail (OBS-03)
+  // ============================================================
+
+  app.get("/api/planning/projects/:id/decisions", (c) => {
+    const store = getStore();
+    if (!store) return c.json({ error: "Database not available" }, 503);
+
+    const projectId = c.req.param("id");
+    const phaseId = c.req.query("phaseId");
+
+    try {
+      const decisions = store.listDecisions(projectId, phaseId || undefined);
+      return c.json({ projectId, decisions, count: decisions.length });
+    } catch (error) {
+      log.error("Failed to list decisions", { projectId, error });
+      return c.json({ error: "Failed to list decisions" }, 500);
+    }
+  });
+
+  // ============================================================
+  // Turn Tracking (OBS-05)
+  // ============================================================
+
+  app.get("/api/planning/projects/:id/usage", (c) => {
+    const store = getStore();
+    if (!store) return c.json({ error: "Database not available" }, 503);
+
+    const projectId = c.req.param("id");
+    const phaseId = c.req.query("phaseId");
+
+    try {
+      const turnCounts = store.getTurnCounts(projectId, phaseId || undefined);
+      const totals = store.getProjectTurnTotal(projectId);
+      return c.json({
+        projectId,
+        turnCounts,
+        totals,
+      });
+    } catch (error) {
+      log.error("Failed to get usage", { projectId, error });
+      return c.json({ error: "Failed to get usage" }, 500);
+    }
+  });
+
   log.debug("planning routes mounted");
   return app;
 }

--- a/infrastructure/runtime/src/dianoia/schema.ts
+++ b/infrastructure/runtime/src/dianoia/schema.ts
@@ -149,3 +149,31 @@ CREATE TABLE IF NOT EXISTS planning_discussions (
 CREATE INDEX IF NOT EXISTS idx_planning_discussions_project ON planning_discussions(project_id);
 CREATE INDEX IF NOT EXISTS idx_planning_discussions_phase ON planning_discussions(phase_id);
 `;
+
+// Phase 6: Observability — Decision audit trail (OBS-03) + Turn tracking (OBS-05)
+export const PLANNING_V28_MIGRATION = `
+CREATE TABLE IF NOT EXISTS planning_decisions (
+  id TEXT PRIMARY KEY,
+  project_id TEXT NOT NULL REFERENCES planning_projects(id) ON DELETE CASCADE,
+  phase_id TEXT,
+  source TEXT NOT NULL CHECK(source IN ('user', 'agent', 'checkpoint', 'system')),
+  type TEXT NOT NULL,
+  summary TEXT NOT NULL,
+  rationale TEXT,
+  context TEXT NOT NULL DEFAULT '{}',
+  created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_planning_decisions_project ON planning_decisions(project_id);
+CREATE INDEX IF NOT EXISTS idx_planning_decisions_phase ON planning_decisions(phase_id);
+
+CREATE TABLE IF NOT EXISTS planning_turn_counts (
+  project_id TEXT NOT NULL REFERENCES planning_projects(id) ON DELETE CASCADE,
+  phase_id TEXT NOT NULL,
+  nous_id TEXT NOT NULL,
+  turn_count INTEGER NOT NULL DEFAULT 0,
+  token_count INTEGER NOT NULL DEFAULT 0,
+  updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+  PRIMARY KEY (project_id, phase_id, nous_id)
+);
+`;

--- a/infrastructure/runtime/src/dianoia/standalone/orchestration-demo.ts
+++ b/infrastructure/runtime/src/dianoia/standalone/orchestration-demo.ts
@@ -2,7 +2,7 @@
 // This script demonstrates all ORCH requirements working together in a realistic scenario
 
 import Database from "better-sqlite3";
-import { PLANNING_V20_DDL, PLANNING_V21_MIGRATION, PLANNING_V22_MIGRATION, PLANNING_V23_MIGRATION, PLANNING_V24_MIGRATION, PLANNING_V25_MIGRATION, PLANNING_V26_MIGRATION, PLANNING_V27_MIGRATION } from "./schema.js";
+import { PLANNING_V20_DDL, PLANNING_V21_MIGRATION, PLANNING_V22_MIGRATION, PLANNING_V23_MIGRATION, PLANNING_V24_MIGRATION, PLANNING_V25_MIGRATION, PLANNING_V26_MIGRATION, PLANNING_V27_MIGRATION, PLANNING_V28_MIGRATION } from "./schema.js";
 import { OrchestrationCore } from "./orchestration-core.js";
 import { PlanningStore } from "./store.js";
 import type { VerificationResult } from "./types.js";
@@ -23,6 +23,7 @@ function createDemoDatabase(): Database.Database {
   db.exec(PLANNING_V25_MIGRATION);
   db.exec(PLANNING_V26_MIGRATION);
   db.exec(PLANNING_V27_MIGRATION);
+  db.exec(PLANNING_V28_MIGRATION);
   
   return db;
 }

--- a/infrastructure/runtime/src/dianoia/standalone/simple-demo.ts
+++ b/infrastructure/runtime/src/dianoia/standalone/simple-demo.ts
@@ -2,7 +2,7 @@
 // This script demonstrates all ORCH requirements working together
 
 import Database from "better-sqlite3";
-import { PLANNING_V20_DDL, PLANNING_V21_MIGRATION, PLANNING_V22_MIGRATION, PLANNING_V23_MIGRATION, PLANNING_V24_MIGRATION, PLANNING_V25_MIGRATION, PLANNING_V26_MIGRATION, PLANNING_V27_MIGRATION } from "./schema.js";
+import { PLANNING_V20_DDL, PLANNING_V21_MIGRATION, PLANNING_V22_MIGRATION, PLANNING_V23_MIGRATION, PLANNING_V24_MIGRATION, PLANNING_V25_MIGRATION, PLANNING_V26_MIGRATION, PLANNING_V27_MIGRATION, PLANNING_V28_MIGRATION } from "./schema.js";
 import { PlanningStore } from "./store.js";
 import type { VerificationResult } from "./types.js";
 import type { PhasePlan } from "./roadmap.js";
@@ -21,6 +21,7 @@ function createDemoDatabase(): Database.Database {
   db.exec(PLANNING_V25_MIGRATION);
   db.exec(PLANNING_V26_MIGRATION);
   db.exec(PLANNING_V27_MIGRATION);
+  db.exec(PLANNING_V28_MIGRATION);
   
   return db;
 }

--- a/infrastructure/runtime/src/dianoia/store.ts
+++ b/infrastructure/runtime/src/dianoia/store.ts
@@ -10,12 +10,14 @@ import type {
   DiscussionQuestion,
   PlanningCheckpoint,
   PlanningConfig,
+  PlanningDecision,
   PlanningPhase,
   PlanningProject,
   PlanningRequirement,
   PlanningResearch,
   ProjectContext,
   SpawnRecord,
+  TurnCount,
   VerificationResult,
 } from "./types.js";
 
@@ -920,6 +922,102 @@ export class PlanningStore {
       completedAt: (row["completed_at"] as string | null) ?? null,
       errorMessage: (row["error_message"] as string | null) ?? null,
       createdAt: row["created_at"] as string,
+      updatedAt: row["updated_at"] as string,
+    };
+  }
+
+  // ─── Decision Audit Trail (OBS-03) ────────────────────────
+
+  logDecision(opts: {
+    projectId: string;
+    phaseId?: string | null;
+    source: "user" | "agent" | "checkpoint" | "system";
+    type: string;
+    summary: string;
+    rationale?: string | null;
+    context?: Record<string, unknown>;
+  }): PlanningDecision {
+    const id = generateId("dec");
+    this.db.prepare(
+      `INSERT INTO planning_decisions (id, project_id, phase_id, source, type, summary, rationale, context)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+    ).run(
+      id,
+      opts.projectId,
+      opts.phaseId ?? null,
+      opts.source,
+      opts.type,
+      opts.summary,
+      opts.rationale ?? null,
+      JSON.stringify(opts.context ?? {}),
+    );
+    return this.getDecision(id)!;
+  }
+
+  getDecision(id: string): PlanningDecision | undefined {
+    const row = this.db.prepare("SELECT * FROM planning_decisions WHERE id = ?").get(id) as Record<string, unknown> | undefined;
+    return row ? this.mapDecision(row) : undefined;
+  }
+
+  listDecisions(projectId: string, phaseId?: string): PlanningDecision[] {
+    if (phaseId) {
+      return (this.db.prepare("SELECT * FROM planning_decisions WHERE project_id = ? AND phase_id = ? ORDER BY created_at ASC")
+        .all(projectId, phaseId) as Record<string, unknown>[]).map(r => this.mapDecision(r));
+    }
+    return (this.db.prepare("SELECT * FROM planning_decisions WHERE project_id = ? ORDER BY created_at ASC")
+      .all(projectId) as Record<string, unknown>[]).map(r => this.mapDecision(r));
+  }
+
+  private mapDecision(row: Record<string, unknown>): PlanningDecision {
+    return {
+      id: row["id"] as string,
+      projectId: row["project_id"] as string,
+      phaseId: (row["phase_id"] as string | null) ?? null,
+      source: row["source"] as PlanningDecision["source"],
+      type: row["type"] as string,
+      summary: row["summary"] as string,
+      rationale: (row["rationale"] as string | null) ?? null,
+      context: JSON.parse((row["context"] as string) || "{}"),
+      createdAt: row["created_at"] as string,
+    };
+  }
+
+  // ─── Turn Tracking (OBS-05) ───────────────────────────────
+
+  recordTurn(projectId: string, phaseId: string, nousId: string, tokenCount = 0): void {
+    this.db.prepare(
+      `INSERT INTO planning_turn_counts (project_id, phase_id, nous_id, turn_count, token_count, updated_at)
+       VALUES (?, ?, ?, 1, ?, strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+       ON CONFLICT (project_id, phase_id, nous_id) DO UPDATE SET
+         turn_count = turn_count + 1,
+         token_count = token_count + excluded.token_count,
+         updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')`
+    ).run(projectId, phaseId, nousId, tokenCount);
+  }
+
+  getTurnCounts(projectId: string, phaseId?: string): TurnCount[] {
+    if (phaseId) {
+      return (this.db.prepare("SELECT * FROM planning_turn_counts WHERE project_id = ? AND phase_id = ? ORDER BY turn_count DESC")
+        .all(projectId, phaseId) as Record<string, unknown>[]).map(r => this.mapTurnCount(r));
+    }
+    return (this.db.prepare("SELECT * FROM planning_turn_counts WHERE project_id = ? ORDER BY phase_id, turn_count DESC")
+      .all(projectId) as Record<string, unknown>[]).map(r => this.mapTurnCount(r));
+  }
+
+  getProjectTurnTotal(projectId: string): { turns: number; tokens: number } {
+    const row = this.db.prepare(
+      "SELECT COALESCE(SUM(turn_count), 0) as turns, COALESCE(SUM(token_count), 0) as tokens FROM planning_turn_counts WHERE project_id = ?"
+    ).get(projectId) as { turns: number; tokens: number };
+    return row;
+  }
+
+  private mapTurnCount(row: Record<string, unknown>): TurnCount {
+    return {
+      projectId: row["project_id"] as string,
+      phaseId: row["phase_id"] as string,
+      nousId: row["nous_id"] as string,
+      turnCount: row["turn_count"] as number,
+      tokenCount: row["token_count"] as number,
       updatedAt: row["updated_at"] as string,
     };
   }

--- a/infrastructure/runtime/src/dianoia/types.ts
+++ b/infrastructure/runtime/src/dianoia/types.ts
@@ -174,3 +174,29 @@ export interface RollbackPlan {
   estimatedEffort: "low" | "medium" | "high";
   createdAt: string;
 }
+
+
+// ─── Decision Audit Trail (OBS-03) ──────────────────────────
+
+export interface PlanningDecision {
+  id: string;
+  projectId: string;
+  phaseId: string | null;
+  source: "user" | "agent" | "checkpoint" | "system";
+  type: string;
+  summary: string;
+  rationale: string | null;
+  context: Record<string, unknown>;
+  createdAt: string;
+}
+
+// ─── Turn Tracking (OBS-05) ─────────────────────────────────
+
+export interface TurnCount {
+  projectId: string;
+  phaseId: string;
+  nousId: string;
+  turnCount: number;
+  tokenCount: number;
+  updatedAt: string;
+}

--- a/infrastructure/runtime/src/mneme/schema.ts
+++ b/infrastructure/runtime/src/mneme/schema.ts
@@ -1,5 +1,5 @@
 // SQLite DDL — embedded as string constants for migrations
-import { PLANNING_V20_DDL, PLANNING_V21_MIGRATION, PLANNING_V22_MIGRATION, PLANNING_V23_MIGRATION, PLANNING_V24_MIGRATION, PLANNING_V25_MIGRATION, PLANNING_V26_MIGRATION, PLANNING_V27_MIGRATION } from "../dianoia/schema.js";
+import { PLANNING_V20_DDL, PLANNING_V21_MIGRATION, PLANNING_V22_MIGRATION, PLANNING_V23_MIGRATION, PLANNING_V24_MIGRATION, PLANNING_V25_MIGRATION, PLANNING_V26_MIGRATION, PLANNING_V27_MIGRATION, PLANNING_V28_MIGRATION } from "../dianoia/schema.js";
 
 export const SCHEMA_VERSION = 1;
 
@@ -460,5 +460,9 @@ export const MIGRATIONS: Array<{ version: number; sql: string }> = [
         locked_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
       );
     `,
+  },
+  {
+    version: 29,
+    sql: PLANNING_V28_MIGRATION,
   },
 ];

--- a/shared/skills/feature-development-code-review-workflow/SKILL.md
+++ b/shared/skills/feature-development-code-review-workflow/SKILL.md
@@ -1,0 +1,34 @@
+# Feature Development & Code Review Workflow
+
+Orchestrate a complete feature development cycle: merge prior work, investigate requirements, create feature branch, implement multi-file changes, test, fix compilation errors, commit, push, and create pull request.
+
+## When to Use
+When developing a new feature that requires:
+- Multiple related source files and corresponding test files
+- Investigation of existing codebase patterns and requirements
+- TypeScript compilation and test validation
+- Git workflow management (branch creation, commits, pushes, PR creation)
+- Coordination across several interdependent modules
+
+## Steps
+1. Merge completed prior work via pull request
+2. Query requirements/specifications to understand scope
+3. Create feature branch for new work
+4. Analyze existing related code (line counts, patterns, key exports)
+5. Search codebase for relevant patterns and existing implementations
+6. Create source implementation files with full content
+7. Create corresponding test files
+8. Document progress in notes and state files
+9. Update index/export files to expose new modules
+10. Run TypeScript compiler to catch type errors
+11. Identify and fix unused imports and parameters
+12. Verify compilation succeeds
+13. Stage all changes with git add
+14. Commit with descriptive message
+15. Push feature branch and create pull request via GitHub CLI
+
+## Tools Used
+- exec: run git commands, grep searches, TypeScript compilation, test execution
+- write: create new implementation and test files, update documentation
+- edit: fix compilation errors, update exports
+- note: track progress and phase completion

--- a/shared/skills/feature-development-workflow-test-validate-commit-and-create-pr/SKILL.md
+++ b/shared/skills/feature-development-workflow-test-validate-commit-and-create-pr/SKILL.md
@@ -1,0 +1,25 @@
+# Feature Development Workflow: Test, Validate, Commit, and Create PR
+
+Complete workflow for developing a feature: run tests, update exports, validate TypeScript, commit changes, and create a pull request.
+
+## When to Use
+When implementing a feature in a TypeScript/Node.js codebase that requires:
+- Running test suites to verify functionality
+- Updating module exports
+- Type-checking the codebase
+- Committing changes to git
+- Creating a pull request on GitHub
+
+## Steps
+1. Run the specific test file for the feature to verify it passes
+2. Update the index/export file to expose new functionality
+3. Run TypeScript type checker to catch compilation errors
+4. Run related test suites to ensure no regressions
+5. Stage and commit the changes with a descriptive commit message
+6. Push the feature branch to origin
+7. Create a pull request with a clear title and description
+
+## Tools Used
+- exec: Running test suites (vitest), TypeScript compiler (tsc), and git commands (add, commit, push)
+- edit: Updating module exports and index files
+- GitHub CLI (gh): Creating pull requests programmatically


### PR DESCRIPTION
## Phase 6: Interjection & Observability (OBS-03, OBS-05)

### Decision Audit Trail (OBS-03)
- `planning_decisions` table with source attribution (user/agent/checkpoint/system)
- Store methods: `logDecision()`, `getDecision()`, `listDecisions()`
- Route: `GET /api/planning/projects/:id/decisions?phaseId=`

### Turn Tracking (OBS-05)
- `planning_turn_counts` table with composite PK (project, phase, agent)
- Upsert pattern: each `recordTurn()` increments count + accumulates tokens
- Store methods: `recordTurn()`, `getTurnCounts()`, `getProjectTurnTotal()`
- Route: `GET /api/planning/projects/:id/usage?phaseId=`

### Infrastructure
- V28 migration (registered as V29 in mneme chain)
- PlanningDecision + TurnCount types exported from index
- Standalone demos updated

### Tests
- 18 new tests (observability.test.ts)
- 33 existing route tests unaffected
- 0 TypeScript errors