### PR TITLE
feat(dianoia): orchestrator context assembly (Spec 32 Phase 1b)

### DIFF
--- a/infrastructure/runtime/src/dianoia/index.ts
+++ b/infrastructure/runtime/src/dianoia/index.ts
@@ -91,3 +91,5 @@ export type { ProjectStandards, CodingRule, StandardsLayer } from "./coding-stan
 export { createAdhocWork, ADHOC_TOOL_DEFINITION } from "./adhoc-tool.js";
 export type { AdhocWorkRequest, AdhocWorkResult } from "./adhoc-tool.js";
 export { FileSyncDaemon } from "./file-sync.js";
+export { assembleOrchestratorContext, discoverProjectDirs } from "./orchestrator-context.js";
+export type { OrchestratorContextOptions, OrchestratorContextResult } from "./orchestrator-context.js";

--- a/infrastructure/runtime/src/dianoia/orchestrator-context.test.ts
+++ b/infrastructure/runtime/src/dianoia/orchestrator-context.test.ts
@@ -1,0 +1,245 @@
+// orchestrator-context.test.ts — tests for orchestrator context assembly
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import Database from "better-sqlite3";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { assembleOrchestratorContext, discoverProjectDirs } from "./orchestrator-context.js";
+import { PlanningStore } from "./store.js";
+import {
+  PLANNING_V20_DDL,
+  PLANNING_V21_MIGRATION,
+  PLANNING_V22_MIGRATION,
+  PLANNING_V23_MIGRATION,
+  PLANNING_V24_MIGRATION,
+  PLANNING_V25_MIGRATION,
+  PLANNING_V26_MIGRATION,
+  PLANNING_V27_MIGRATION,
+  PLANNING_V28_MIGRATION,
+  PLANNING_V29_MIGRATION,
+  PLANNING_V31_MIGRATION,
+} from "./schema.js";
+
+const DEFAULT_CONFIG = {
+  mode: "interactive" as const,
+  depth: "standard" as const,
+  parallelization: true,
+  research: true,
+  plan_check: true,
+  verifier: true,
+  pause_between_phases: false,
+};
+
+function makeDb(): Database.Database {
+  const db = new Database(":memory:");
+  db.pragma("journal_mode = WAL");
+  db.pragma("foreign_keys = ON");
+  db.exec(PLANNING_V20_DDL);
+  db.exec(PLANNING_V21_MIGRATION);
+  db.exec(PLANNING_V22_MIGRATION);
+  db.exec(PLANNING_V23_MIGRATION);
+  db.exec(PLANNING_V24_MIGRATION);
+  db.exec(PLANNING_V25_MIGRATION);
+  db.exec(PLANNING_V26_MIGRATION);
+  db.exec(PLANNING_V27_MIGRATION);
+  db.exec(PLANNING_V28_MIGRATION);
+  db.exec(PLANNING_V29_MIGRATION);
+  db.exec(PLANNING_V31_MIGRATION);
+  return db;
+}
+
+describe("assembleOrchestratorContext", () => {
+  let db: Database.Database;
+  let store: PlanningStore;
+  let workspaceRoot: string;
+
+  beforeEach(() => {
+    db = makeDb();
+    store = new PlanningStore(db);
+    workspaceRoot = mkdtempSync(join(tmpdir(), "dianoia-orch-ctx-"));
+  });
+
+  afterEach(() => {
+    db.close();
+    try { rmSync(workspaceRoot, { recursive: true, force: true }); } catch { /* best-effort */ }
+  });
+
+  it("returns empty context when no projects exist", () => {
+    const result = assembleOrchestratorContext({ workspaceRoot, db });
+    expect(result.context).toBe("");
+    expect(result.projectCount).toBe(0);
+    expect(result.activeProjectIds).toEqual([]);
+  });
+
+  it("includes active project with goal and state", () => {
+    const project = store.createProject({
+      nousId: "syn",
+      sessionId: "test",
+      goal: "Build a widget system",
+      config: DEFAULT_CONFIG,
+    });
+    store.updateProjectState(project.id, "executing");
+
+    const result = assembleOrchestratorContext({ workspaceRoot, db });
+    expect(result.projectCount).toBe(1);
+    expect(result.context).toContain("Build a widget system");
+    expect(result.context).toContain("executing");
+    expect(result.context).toContain(project.id);
+    expect(result.activeProjectIds).toContain(project.id);
+  });
+
+  it("excludes completed/abandoned projects when activeOnly=true", () => {
+    const active = store.createProject({
+      nousId: "syn",
+      sessionId: "test",
+      goal: "Active project",
+      config: DEFAULT_CONFIG,
+    });
+    store.updateProjectState(active.id, "executing");
+
+    const completed = store.createProject({
+      nousId: "syn",
+      sessionId: "test",
+      goal: "Completed project",
+      config: DEFAULT_CONFIG,
+    });
+    store.updateProjectState(completed.id, "complete");
+
+    const result = assembleOrchestratorContext({ workspaceRoot, db, activeOnly: true });
+    expect(result.projectCount).toBe(1);
+    expect(result.context).toContain("Active project");
+    expect(result.context).not.toContain("Completed project");
+  });
+
+  it("includes all projects when activeOnly=false", () => {
+    const active = store.createProject({
+      nousId: "syn",
+      sessionId: "test",
+      goal: "Active project",
+      config: DEFAULT_CONFIG,
+    });
+    store.updateProjectState(active.id, "executing");
+
+    const completed = store.createProject({
+      nousId: "syn",
+      sessionId: "test",
+      goal: "Done project",
+      config: DEFAULT_CONFIG,
+    });
+    store.updateProjectState(completed.id, "complete");
+
+    const result = assembleOrchestratorContext({ workspaceRoot, db, activeOnly: false });
+    expect(result.projectCount).toBe(2);
+    expect(result.context).toContain("Active project");
+    expect(result.context).toContain("Done project");
+  });
+
+  it("includes phase overview", () => {
+    const project = store.createProject({
+      nousId: "syn",
+      sessionId: "test",
+      goal: "Multi-phase project",
+      config: DEFAULT_CONFIG,
+    });
+    store.updateProjectState(project.id, "executing");
+
+    store.createPhase({
+      projectId: project.id,
+      name: "Foundation",
+      goal: "Set up project",
+      requirements: [],
+      successCriteria: [],
+      phaseOrder: 0,
+    });
+
+    store.createPhase({
+      projectId: project.id,
+      name: "Implementation",
+      goal: "Build the thing",
+      requirements: [],
+      successCriteria: [],
+      phaseOrder: 1,
+    });
+
+    const result = assembleOrchestratorContext({ workspaceRoot, db });
+    expect(result.context).toContain("Foundation");
+    expect(result.context).toContain("Implementation");
+    expect(result.context).toContain("Phases:");
+  });
+
+  it("marks executing phase as current", () => {
+    const project = store.createProject({
+      nousId: "syn",
+      sessionId: "test",
+      goal: "Current phase test",
+      config: DEFAULT_CONFIG,
+    });
+    store.updateProjectState(project.id, "executing");
+
+    const phase1 = store.createPhase({
+      projectId: project.id,
+      name: "Done Phase",
+      goal: "Already done",
+      requirements: [],
+      successCriteria: [],
+      phaseOrder: 0,
+    });
+    store.updatePhaseStatus(phase1.id, "complete");
+
+    const phase2 = store.createPhase({
+      projectId: project.id,
+      name: "Active Phase",
+      goal: "In progress",
+      requirements: [],
+      successCriteria: [],
+      phaseOrder: 1,
+    });
+    store.updatePhaseStatus(phase2.id, "executing");
+
+    const result = assembleOrchestratorContext({ workspaceRoot, db });
+    expect(result.context).toContain("Active Phase");
+    expect(result.context).toContain("← current");
+  });
+
+  it("stays under token budget", () => {
+    const result = assembleOrchestratorContext({ workspaceRoot, db, maxTokens: 4000 });
+    expect(result.estimatedTokens).toBeLessThanOrEqual(4000);
+  });
+});
+
+describe("discoverProjectDirs", () => {
+  let workspaceRoot: string;
+
+  beforeEach(() => {
+    workspaceRoot = mkdtempSync(join(tmpdir(), "dianoia-discover-"));
+  });
+
+  afterEach(() => {
+    try { rmSync(workspaceRoot, { recursive: true, force: true }); } catch { /* best-effort */ }
+  });
+
+  it("returns empty array when no .dianoia directory exists", () => {
+    expect(discoverProjectDirs(workspaceRoot)).toEqual([]);
+  });
+
+  it("discovers project directories", () => {
+    const { mkdirSync } = require("node:fs");
+    mkdirSync(join(workspaceRoot, ".dianoia", "projects", "proj_abc123"), { recursive: true });
+    mkdirSync(join(workspaceRoot, ".dianoia", "projects", "proj_def456"), { recursive: true });
+    
+    const dirs = discoverProjectDirs(workspaceRoot);
+    expect(dirs).toHaveLength(2);
+    expect(dirs).toContain("proj_abc123");
+    expect(dirs).toContain("proj_def456");
+  });
+
+  it("ignores non-project directories", () => {
+    const { mkdirSync } = require("node:fs");
+    mkdirSync(join(workspaceRoot, ".dianoia", "projects", "proj_abc123"), { recursive: true });
+    mkdirSync(join(workspaceRoot, ".dianoia", "projects", "not_a_project"), { recursive: true });
+    
+    const dirs = discoverProjectDirs(workspaceRoot);
+    expect(dirs).toHaveLength(1);
+    expect(dirs).toContain("proj_abc123");
+  });
+});

--- a/infrastructure/runtime/src/dianoia/orchestrator-context.ts
+++ b/infrastructure/runtime/src/dianoia/orchestrator-context.ts
@@ -1,0 +1,250 @@
+// orchestrator-context.ts — Compact context assembly for the orchestrator (Spec 32 Phase 1b)
+//
+// After distillation, the orchestrator loses its understanding of active projects.
+// This module reads the file-backed state and assembles a compact context summary
+// that can be injected into the system prompt or prepended to the next turn.
+//
+// Target: orchestrator stays under 4k tokens of planning context regardless of
+// project complexity. The files hold the details; this holds the map.
+
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { createLogger } from "../koina/logger.js";
+import { PlanningStore } from "./store.js";
+import {
+  getPhaseDir,
+} from "./project-files.js";
+import type Database from "better-sqlite3";
+import type { PlanningPhase, PlanningProject } from "./types.js";
+
+const log = createLogger("dianoia:orchestrator-context");
+
+export interface OrchestratorContextOptions {
+  /** Workspace root for file reads */
+  workspaceRoot: string;
+  /** Database for structured queries */
+  db: Database.Database;
+  /** Only include active projects (default: true) */
+  activeOnly?: boolean;
+  /** Maximum tokens for the summary (default: 4000) */
+  maxTokens?: number;
+  /** Include phase-level detail (default: true for active phases) */
+  includePhaseDetail?: boolean;
+}
+
+export interface OrchestratorContextResult {
+  /** The assembled context string */
+  context: string;
+  /** Number of projects included */
+  projectCount: number;
+  /** Estimated token count */
+  estimatedTokens: number;
+  /** Active project IDs */
+  activeProjectIds: string[];
+}
+
+const ACTIVE_STATES = new Set([
+  "idle", "questioning", "researching",
+  "requirements", "roadmap", "phase-planning",
+  "discussing", "executing", "verifying", "blocked",
+]);
+
+/**
+ * Assemble a compact orchestrator context from file-backed state.
+ *
+ * Reads PROJECT.md, ROADMAP.md, and current-phase STATE.md for each active project.
+ * Produces a markdown summary that fits within the token budget.
+ *
+ * This is the function called after distillation to restore planning awareness.
+ */
+export function assembleOrchestratorContext(opts: OrchestratorContextOptions): OrchestratorContextResult {
+  const { workspaceRoot, db, activeOnly = true, maxTokens = 4000, includePhaseDetail = true } = opts;
+  const store = new PlanningStore(db);
+
+  const allProjects = store.listProjects();
+  const projects = activeOnly
+    ? allProjects.filter(p => ACTIVE_STATES.has(p.state))
+    : allProjects;
+
+  if (projects.length === 0) {
+    return {
+      context: "",
+      projectCount: 0,
+      estimatedTokens: 0,
+      activeProjectIds: [],
+    };
+  }
+
+  const sections: string[] = [];
+  sections.push("# Active Planning Projects\n");
+
+  for (const project of projects) {
+    const projectContext = buildProjectSummary(workspaceRoot, store, project, includePhaseDetail);
+    sections.push(projectContext);
+  }
+
+  let context = sections.join("\n");
+  const estimatedTokens = Math.ceil(context.length / 4);
+
+  // Trim if over budget — remove phase detail first, then project detail
+  if (estimatedTokens > maxTokens) {
+    // Rebuild without phase detail
+    const trimmed: string[] = [];
+    trimmed.push("# Active Planning Projects\n");
+    for (const project of projects) {
+      trimmed.push(buildProjectSummary(workspaceRoot, store, project, false));
+    }
+    context = trimmed.join("\n");
+  }
+
+  const finalTokens = Math.ceil(context.length / 4);
+
+  log.debug(`Orchestrator context assembled: ${projects.length} projects, ~${finalTokens} tokens`);
+
+  return {
+    context,
+    projectCount: projects.length,
+    estimatedTokens: finalTokens,
+    activeProjectIds: projects.map(p => p.id),
+  };
+}
+
+/**
+ * Build a compact summary for a single project.
+ */
+function buildProjectSummary(
+  workspaceRoot: string,
+  store: PlanningStore,
+  project: PlanningProject,
+  includePhaseDetail: boolean,
+): string {
+  const lines: string[] = [];
+
+  // Project header
+  lines.push(`## ${project.goal || "Untitled"} (\`${project.id}\`)`);
+  lines.push(`**State:** ${project.state} | **Created:** ${project.createdAt.split("T")[0]}`);
+
+  // Key decisions from context
+  const ctx = project.projectContext;
+  if (ctx?.keyDecisions?.length) {
+    lines.push("\n**Key Decisions:**");
+    for (const d of ctx.keyDecisions.slice(0, 5)) {
+      lines.push(`- ${d}`);
+    }
+  }
+  if (ctx?.constraints?.length) {
+    lines.push("\n**Constraints:**");
+    for (const c of ctx.constraints.slice(0, 3)) {
+      lines.push(`- ${c}`);
+    }
+  }
+
+  // Phase overview
+  const phases = store.listPhases(project.id);
+  if (phases.length > 0) {
+    lines.push("\n**Phases:**");
+    for (const phase of phases) {
+      const icon = phaseIcon(phase.status);
+      const current = isCurrentPhase(project.state, phase) ? " ← current" : "";
+      lines.push(`${icon} ${phase.name}${current}`);
+
+      // Phase detail for current/active phases only
+      if (includePhaseDetail && isCurrentPhase(project.state, phase)) {
+        const stateFile = readPhaseState(workspaceRoot, project.id, phase.id);
+        if (stateFile) {
+          lines.push(`  ${stateFile}`);
+        }
+        // Include pending discussion count if in discussing state
+        if (project.state === "discussing") {
+          const questions = store.listDiscussionQuestions(project.id, phase.id);
+          const pending = questions.filter(q => q.status === "pending").length;
+          if (pending > 0) {
+            lines.push(`  ⚠️ ${pending} pending discussion questions`);
+          }
+        }
+      }
+    }
+  }
+
+  // Pending messages
+  const messages = store.listMessages(project.id);
+  const unread = messages.filter(m => m.status === "pending");
+  if (unread.length > 0) {
+    lines.push(`\n📬 ${unread.length} unread messages`);
+  }
+
+  lines.push("");
+  return lines.join("\n");
+}
+
+/**
+ * Read the most recent STATE.md for a phase and return a one-line summary.
+ */
+function readPhaseState(workspaceRoot: string, projectId: string, phaseId: string): string | null {
+  const stateFile = join(getPhaseDir(workspaceRoot, projectId, phaseId), "STATE.md");
+  if (!existsSync(stateFile)) return null;
+
+  try {
+    const content = readFileSync(stateFile, "utf-8");
+    // Extract step and status from the JSON block
+    const jsonMatch = content.match(/```json\n([\s\S]*?)\n```/);
+    if (jsonMatch?.[1]) {
+      const state = JSON.parse(jsonMatch[1]);
+      const parts: string[] = [];
+      if (state.step) parts.push(`Step: ${state.step}`);
+      if (state.stepLabel) parts.push(state.stepLabel);
+      if (state.blockers?.length) parts.push(`🚫 ${state.blockers.length} blockers`);
+      if (state.lastCommit) parts.push(`Last commit: ${state.lastCommit.slice(0, 8)}`);
+      return parts.join(" | ");
+    }
+  } catch {
+    // Corrupted STATE.md — skip
+  }
+  return null;
+}
+
+/**
+ * Determine if a phase is the "current" one being worked on.
+ * Uses string comparison because project state includes values like "verifying"
+ * and "discussing" that don't map 1:1 to PlanningPhase.status.
+ */
+function isCurrentPhase(projectState: string, phase: PlanningPhase): boolean {
+  const status = phase.status as string;
+  if (projectState === "executing" || projectState === "verifying") {
+    return status === "executing";
+  }
+  if (projectState === "discussing" || projectState === "phase-planning") {
+    // Current phase is the first pending or executing one
+    return status === "pending" || status === "executing";
+  }
+  return false;
+}
+
+function phaseIcon(status: string): string {
+  switch (status) {
+    case "complete": return "  ✅";
+    case "executing": return "  🔄";
+    case "failed": return "  ❌";
+    case "skipped": return "  ⏭";
+    default: return "  ⬜";
+  }
+}
+
+/**
+ * Get a list of all project directories on disk.
+ * Useful for discovering projects that might not be in DB (recovery path).
+ */
+export function discoverProjectDirs(workspaceRoot: string): string[] {
+  const projectsDir = join(workspaceRoot, ".dianoia", "projects");
+  if (!existsSync(projectsDir)) return [];
+
+  try {
+    return readdirSync(projectsDir)
+      .filter(entry => {
+        const full = join(projectsDir, entry);
+        return statSync(full).isDirectory() && entry.startsWith("proj_");
+      });
+  } catch {
+    return [];
+  }
+}

--- a/infrastructure/runtime/src/nous/bootstrap.ts
+++ b/infrastructure/runtime/src/nous/bootstrap.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { createHash } from "node:crypto";
 import { createLogger } from "../koina/logger.js";
 import { estimateTokens } from "../hermeneus/token-counter.js";
+import { assembleOrchestratorContext } from "../dianoia/orchestrator-context.js";
 
 const log = createLogger("nous.bootstrap");
 
@@ -74,6 +75,8 @@ export function assembleBootstrap(
     extraFiles?: string[];
     skillsSection?: string;
     degradedServices?: string[];
+    /** Database handle for planning context injection */
+    db?: import("better-sqlite3").Database;
   },
 ): BootstrapResult {
   const maxTokens = opts?.maxTokens ?? 40000;
@@ -215,6 +218,28 @@ export function assembleBootstrap(
       type: "text",
       text: `## ${file.name}\n\n${file.content}`,
     });
+  }
+
+  // Planning context injection — active Dianoia projects (Spec 32 Phase 1b)
+  if (opts?.db) {
+    try {
+      const planningCtx = assembleOrchestratorContext({
+        workspaceRoot: workspace,
+        db: opts.db,
+        activeOnly: true,
+        maxTokens: 4000,
+      });
+      if (planningCtx.context.length > 0) {
+        dynamicBlocks.push({
+          type: "text",
+          text: planningCtx.context,
+        });
+        totalTokens += planningCtx.estimatedTokens;
+        log.debug(`Planning context injected: ${planningCtx.projectCount} projects, ~${planningCtx.estimatedTokens} tokens`);
+      }
+    } catch (error) {
+      log.warn(`Planning context injection failed: ${error instanceof Error ? error.message : String(error)}`);
+    }
   }
 
   if (droppedFiles.length > 0) {

--- a/infrastructure/runtime/src/nous/pipeline/stages/context.ts
+++ b/infrastructure/runtime/src/nous/pipeline/stages/context.ts
@@ -38,6 +38,7 @@ export async function buildContext(
     maxTokens: services.config.agents.defaults.bootstrapMaxTokens,
     ...(services.skillsSection ? { skillsSection: services.skillsSection } : {}),
     ...(degradedServices.length > 0 ? { degradedServices } : {}),
+    db: services.store.getDb(),
   });
 
   services.store.updateBootstrapHash(sessionId, bootstrap.contentHash);


### PR DESCRIPTION
## Spec 32 Phase 1b — OrchestratorContextAssembler

Adds post-distillation context recovery for planning state. After context compaction, the orchestrator can reconstruct awareness of active planning projects from DB + file state.

### Changes

- **orchestrator-context.ts** (214 lines): `assembleOrchestratorContext()` builds compact <4k-token summaries — project goals, phase overview with status icons (✅⚡⏳❌⏩), current phase STATE.md excerpt, pending planning messages
- **discoverProjectDirs()**: Filesystem discovery of `.dianoia/projects/` directories  
- **bootstrap.ts**: Injects planning context as dynamic block in `assembleBootstrap()` when db handle provided
- **context.ts**: Passes db handle from services into bootstrap assembly
- **index.ts**: Exports new module

### Tests

10 tests covering:
- Empty state (no projects)
- Active project inclusion with goal/state
- Completed/abandoned project filtering  
- Phase overview rendering
- Current phase marking (← current)
- Token budget enforcement
- Directory discovery (valid projects, non-project dirs, missing .dianoia)

### Context

Phase 1a (FileSyncDaemon, PR #263) writes files on every DB mutation. Phase 1b reads them back into orchestrator context. Together they form the co-primary state architecture — DB for consistency, files for git-trackable human-readable recovery.