### PR TITLE
feat(agora): Phase 1 — channel abstraction + Signal refactor

### DIFF
--- a/infrastructure/runtime/src/agora/index.ts
+++ b/infrastructure/runtime/src/agora/index.ts
@@ -1,0 +1,11 @@
+// Agora — channel abstraction layer (Spec 34)
+export { AgoraRegistry } from "./registry.js";
+export type {
+  ChannelCapabilities,
+  ChannelContext,
+  ChannelIdentity,
+  ChannelProbeResult,
+  ChannelProvider,
+  ChannelSendParams,
+  ChannelSendResult,
+} from "./types.js";

--- a/infrastructure/runtime/src/agora/registry.test.ts
+++ b/infrastructure/runtime/src/agora/registry.test.ts
@@ -1,0 +1,205 @@
+// Tests for AgoraRegistry — channel provider lifecycle and routing
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { AgoraRegistry } from "./registry.js";
+import type { ChannelContext, ChannelProvider, ChannelSendResult } from "./types.js";
+
+function mockProvider(id: string, overrides?: Partial<ChannelProvider>): ChannelProvider {
+  return {
+    id,
+    name: id.charAt(0).toUpperCase() + id.slice(1),
+    capabilities: {
+      threads: false,
+      reactions: false,
+      typing: false,
+      media: false,
+      streaming: false,
+      richFormatting: false,
+      maxTextLength: 2000,
+    },
+    start: vi.fn().mockResolvedValue(undefined),
+    send: vi.fn().mockResolvedValue({ sent: true } satisfies ChannelSendResult),
+    stop: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
+function mockContext(): ChannelContext {
+  return {
+    dispatch: vi.fn().mockResolvedValue({ text: "ok" }),
+    config: {} as ChannelContext["config"],
+    store: {} as ChannelContext["store"],
+    manager: {} as ChannelContext["manager"],
+    abortSignal: new AbortController().signal,
+  };
+}
+
+describe("AgoraRegistry", () => {
+  let registry: AgoraRegistry;
+
+  beforeEach(() => {
+    registry = new AgoraRegistry();
+  });
+
+  describe("register", () => {
+    it("registers a provider", () => {
+      const p = mockProvider("signal");
+      registry.register(p);
+      expect(registry.has("signal")).toBe(true);
+      expect(registry.get("signal")).toBe(p);
+      expect(registry.size).toBe(1);
+    });
+
+    it("throws on duplicate registration", () => {
+      registry.register(mockProvider("signal"));
+      expect(() => registry.register(mockProvider("signal"))).toThrow(
+        'Channel provider "signal" already registered',
+      );
+    });
+
+    it("lists all registered provider IDs", () => {
+      registry.register(mockProvider("signal"));
+      registry.register(mockProvider("slack"));
+      expect(registry.list()).toEqual(["signal", "slack"]);
+    });
+  });
+
+  describe("startAll", () => {
+    it("calls start on all providers", async () => {
+      const p1 = mockProvider("signal");
+      const p2 = mockProvider("slack");
+      registry.register(p1);
+      registry.register(p2);
+
+      const ctx = mockContext();
+      await registry.startAll(ctx);
+
+      expect(p1.start).toHaveBeenCalledWith(ctx);
+      expect(p2.start).toHaveBeenCalledWith(ctx);
+    });
+
+    it("does not throw if one provider fails to start", async () => {
+      const good = mockProvider("signal");
+      const bad = mockProvider("slack", {
+        start: vi.fn().mockRejectedValue(new Error("boom")),
+      });
+      registry.register(good);
+      registry.register(bad);
+
+      // Should not throw — bad channel logs error but doesn't block
+      await registry.startAll(mockContext());
+      expect(good.start).toHaveBeenCalled();
+    });
+
+    it("ignores second call", async () => {
+      const p = mockProvider("signal");
+      registry.register(p);
+      const ctx = mockContext();
+
+      await registry.startAll(ctx);
+      await registry.startAll(ctx); // Second call — should be no-op
+
+      expect(p.start).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("stopAll", () => {
+    it("calls stop on all providers", async () => {
+      const p1 = mockProvider("signal");
+      const p2 = mockProvider("slack");
+      registry.register(p1);
+      registry.register(p2);
+
+      await registry.startAll(mockContext());
+      await registry.stopAll();
+
+      expect(p1.stop).toHaveBeenCalled();
+      expect(p2.stop).toHaveBeenCalled();
+    });
+  });
+
+  describe("send", () => {
+    it("routes to the correct provider", async () => {
+      const signal = mockProvider("signal");
+      const slack = mockProvider("slack");
+      registry.register(signal);
+      registry.register(slack);
+
+      const result = await registry.send("signal", { to: "+1234", text: "hello" });
+      expect(result.sent).toBe(true);
+      expect(signal.send).toHaveBeenCalledWith({ to: "+1234", text: "hello" });
+      expect(slack.send).not.toHaveBeenCalled();
+    });
+
+    it("returns error for unknown channel", async () => {
+      const result = await registry.send("discord", { to: "foo", text: "bar" });
+      expect(result.sent).toBe(false);
+      expect(result.error).toContain("discord");
+    });
+  });
+
+  describe("probeAll", () => {
+    it("probes all providers with probe()", async () => {
+      const signal = mockProvider("signal", {
+        probe: vi.fn().mockResolvedValue({ ok: true, latencyMs: 10 }),
+      });
+      const slack = mockProvider("slack", {
+        probe: vi.fn().mockResolvedValue({ ok: false, error: "disconnected" }),
+      });
+      registry.register(signal);
+      registry.register(slack);
+
+      const results = await registry.probeAll();
+      expect(results.get("signal")).toEqual({ ok: true, latencyMs: 10 });
+      expect(results.get("slack")).toEqual({ ok: false, error: "disconnected" });
+    });
+
+    it("assumes OK for providers without probe()", async () => {
+      const p = mockProvider("signal"); // no probe method
+      registry.register(p);
+
+      const results = await registry.probeAll();
+      expect(results.get("signal")).toEqual({ ok: true });
+    });
+
+    it("handles probe errors gracefully", async () => {
+      const p = mockProvider("signal", {
+        probe: vi.fn().mockRejectedValue(new Error("timeout")),
+      });
+      registry.register(p);
+
+      const results = await registry.probeAll();
+      expect(results.get("signal")?.ok).toBe(false);
+      expect(results.get("signal")?.error).toContain("timeout");
+    });
+  });
+
+  describe("getFirst", () => {
+    it("returns first provider without predicate", () => {
+      registry.register(mockProvider("signal"));
+      registry.register(mockProvider("slack"));
+      expect(registry.getFirst()?.id).toBe("signal");
+    });
+
+    it("returns first matching provider with predicate", () => {
+      registry.register(mockProvider("signal"));
+      registry.register(mockProvider("slack", {
+        capabilities: {
+          threads: true,
+          reactions: true,
+          typing: false,
+          media: true,
+          streaming: true,
+          richFormatting: true,
+          maxTextLength: 4000,
+        },
+      }));
+      const result = registry.getFirst((p) => p.capabilities.threads);
+      expect(result?.id).toBe("slack");
+    });
+
+    it("returns undefined when nothing matches", () => {
+      registry.register(mockProvider("signal"));
+      expect(registry.getFirst((p) => p.id === "discord")).toBeUndefined();
+    });
+  });
+});

--- a/infrastructure/runtime/src/agora/registry.ts
+++ b/infrastructure/runtime/src/agora/registry.ts
@@ -1,0 +1,144 @@
+// Agora Registry — manages channel providers (Spec 34)
+//
+// The registry is the central coordination point for all channels.
+// It handles lifecycle (start/stop), send routing, and health probes.
+
+import { createLogger } from "../koina/logger.js";
+import type {
+  ChannelContext,
+  ChannelProbeResult,
+  ChannelProvider,
+  ChannelSendParams,
+  ChannelSendResult,
+} from "./types.js";
+
+const log = createLogger("agora");
+
+export class AgoraRegistry {
+  private providers = new Map<string, ChannelProvider>();
+  private started = false;
+
+  /** Register a channel provider. Must be called before startAll(). */
+  register(provider: ChannelProvider): void {
+    if (this.providers.has(provider.id)) {
+      throw new Error(`Channel provider "${provider.id}" already registered`);
+    }
+    this.providers.set(provider.id, provider);
+    log.info(`Registered channel: ${provider.id} (${provider.name})`);
+  }
+
+  /** Get a provider by channel ID */
+  get(channelId: string): ChannelProvider | undefined {
+    return this.providers.get(channelId);
+  }
+
+  /** Check if a channel is registered */
+  has(channelId: string): boolean {
+    return this.providers.has(channelId);
+  }
+
+  /** List all registered provider IDs */
+  list(): string[] {
+    return [...this.providers.keys()];
+  }
+
+  /** Number of registered channels */
+  get size(): number {
+    return this.providers.size;
+  }
+
+  /**
+   * Start all registered channels.
+   * Each channel receives the shared context and begins listening for inbound messages.
+   * A channel that fails to start logs a warning but doesn't block other channels.
+   */
+  async startAll(ctx: ChannelContext): Promise<void> {
+    if (this.started) {
+      log.warn("AgoraRegistry.startAll() called more than once — ignoring");
+      return;
+    }
+    this.started = true;
+
+    const results = await Promise.allSettled(
+      [...this.providers.values()].map(async (provider) => {
+        try {
+          await provider.start(ctx);
+          log.info(`Channel started: ${provider.id}`);
+        } catch (error) {
+          log.error(
+            `Channel ${provider.id} failed to start: ${error instanceof Error ? error.message : error}`,
+          );
+          throw error;
+        }
+      }),
+    );
+
+    const succeeded = results.filter((r) => r.status === "fulfilled").length;
+    const failed = results.filter((r) => r.status === "rejected").length;
+
+    if (failed > 0) {
+      log.warn(`Agora: ${succeeded} channels started, ${failed} failed`);
+    } else {
+      log.info(`Agora: ${succeeded} channel(s) started`);
+    }
+  }
+
+  /** Stop all channels gracefully */
+  async stopAll(): Promise<void> {
+    const results = await Promise.allSettled(
+      [...this.providers.values()].map(async (provider) => {
+        try {
+          await provider.stop();
+          log.debug(`Channel stopped: ${provider.id}`);
+        } catch (error) {
+          log.warn(
+            `Channel ${provider.id} failed to stop cleanly: ${error instanceof Error ? error.message : error}`,
+          );
+        }
+      }),
+    );
+    this.started = false;
+    log.info(`Agora: ${results.length} channel(s) stopped`);
+  }
+
+  /**
+   * Send a message through a specific channel.
+   * Returns error result if channel is not found.
+   */
+  async send(channelId: string, params: ChannelSendParams): Promise<ChannelSendResult> {
+    const provider = this.providers.get(channelId);
+    if (!provider) {
+      return { sent: false, error: `Channel "${channelId}" not registered` };
+    }
+    return provider.send(params);
+  }
+
+  /** Probe all channels for health status */
+  async probeAll(): Promise<Map<string, ChannelProbeResult>> {
+    const results = new Map<string, ChannelProbeResult>();
+    for (const [id, provider] of this.providers) {
+      if (provider.probe) {
+        try {
+          results.set(id, await provider.probe());
+        } catch (error) {
+          results.set(id, { ok: false, error: error instanceof Error ? error.message : String(error) });
+        }
+      } else {
+        // No probe = assume OK if registered
+        results.set(id, { ok: true });
+      }
+    }
+    return results;
+  }
+
+  /**
+   * Get the first registered provider that matches a predicate.
+   * Useful for legacy code that needs "any available Signal client."
+   */
+  getFirst(predicate?: (p: ChannelProvider) => boolean): ChannelProvider | undefined {
+    for (const provider of this.providers.values()) {
+      if (!predicate || predicate(provider)) return provider;
+    }
+    return undefined;
+  }
+}

--- a/infrastructure/runtime/src/agora/types.ts
+++ b/infrastructure/runtime/src/agora/types.ts
@@ -1,0 +1,141 @@
+// Agora — channel abstraction types (Spec 34)
+//
+// ChannelProvider is the contract every channel (Signal, Slack, etc.) implements.
+// The agora doesn't know about Signal or Slack — it knows about ChannelProviders.
+
+import type { InboundMessage, TurnOutcome, TurnStreamEvent } from "../nous/pipeline/types.js";
+import type { AletheiaConfig } from "../taxis/schema.js";
+import type { SessionStore } from "../mneme/store.js";
+import type { CommandRegistry } from "../semeion/commands.js";
+import type { NousManager } from "../nous/manager.js";
+
+// ---------------------------------------------------------------------------
+// Capabilities — what a channel can and can't do
+// ---------------------------------------------------------------------------
+
+export interface ChannelCapabilities {
+  /** Supports threading (Slack threads, Signal quotes) */
+  threads: boolean;
+  /** Supports emoji reactions */
+  reactions: boolean;
+  /** Supports typing indicators */
+  typing: boolean;
+  /** Supports file/media attachments */
+  media: boolean;
+  /** Supports native streaming/progressive updates */
+  streaming: boolean;
+  /** Supports rich formatting beyond markdown (blocks, embeds) */
+  richFormatting: boolean;
+  /** Max text length per message (0 = unlimited) */
+  maxTextLength: number;
+}
+
+// ---------------------------------------------------------------------------
+// Context — what agora provides to each channel on start
+// ---------------------------------------------------------------------------
+
+export interface ChannelContext {
+  /** Dispatch an inbound message through the nous pipeline */
+  dispatch: (msg: InboundMessage) => Promise<TurnOutcome>;
+  /** Stream an inbound message through the nous pipeline */
+  dispatchStream?: (msg: InboundMessage) => AsyncIterable<TurnStreamEvent>;
+  /** The full runtime config */
+  config: AletheiaConfig;
+  /** Session store for thread/session lookups */
+  store: SessionStore;
+  /** NousManager — for manager-level operations (thread resolution, etc.) */
+  manager: NousManager;
+  /** Abort signal for graceful shutdown */
+  abortSignal: AbortSignal;
+  /** Command registry for slash-command handling */
+  commands?: CommandRegistry;
+  /** Watchdog ref (may be set after start) */
+  watchdog?: import("../daemon/watchdog.js").Watchdog | null;
+}
+
+// ---------------------------------------------------------------------------
+// Send parameters — what the caller provides to send outbound
+// ---------------------------------------------------------------------------
+
+export interface ChannelSendParams {
+  /** Target identifier (channel-specific format) */
+  to: string;
+  /** Message text (markdown) */
+  text: string;
+  /** Account ID within the channel (for multi-account setups) */
+  accountId?: string;
+  /** Thread/reply context */
+  threadId?: string;
+  /** File attachments (paths) */
+  attachments?: string[];
+  /** Sender identity override (agent name, emoji) */
+  identity?: ChannelIdentity;
+  /** Disable markdown formatting */
+  markdown?: boolean;
+}
+
+export interface ChannelSendResult {
+  /** Whether the message was sent successfully */
+  sent: boolean;
+  /** Error message if send failed */
+  error?: string;
+}
+
+export interface ChannelIdentity {
+  name?: string;
+  emoji?: string;
+  avatarUrl?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Probe — health check
+// ---------------------------------------------------------------------------
+
+export interface ChannelProbeResult {
+  ok: boolean;
+  latencyMs?: number;
+  error?: string;
+  details?: Record<string, unknown>;
+}
+
+// ---------------------------------------------------------------------------
+// The provider contract
+// ---------------------------------------------------------------------------
+
+export interface ChannelProvider {
+  /** Unique channel identifier — used in config, bindings, routing */
+  readonly id: string;
+
+  /** Human-readable name */
+  readonly name: string;
+
+  /** What this channel supports */
+  readonly capabilities: ChannelCapabilities;
+
+  /**
+   * Start listening for inbound messages.
+   * Called during runtime startup if the channel is configured and enabled.
+   */
+  start(ctx: ChannelContext): Promise<void>;
+
+  /**
+   * Send a message outbound through this channel.
+   * Called by the agora registry when routing determines this channel.
+   */
+  send(params: ChannelSendParams): Promise<ChannelSendResult>;
+
+  /**
+   * Send a typing indicator (if supported).
+   */
+  sendTyping?(to: string, accountId?: string, stop?: boolean): Promise<void>;
+
+  /**
+   * Gracefully stop the channel.
+   */
+  stop(): Promise<void>;
+
+  /**
+   * Health probe — is this channel connected and functional?
+   */
+  probe?(): Promise<ChannelProbeResult>;
+}

--- a/infrastructure/runtime/src/aletheia.ts
+++ b/infrastructure/runtime/src/aletheia.ts
@@ -61,15 +61,9 @@ import { AuditLog } from "./symbolon/audit.js";
 import { generateSecret } from "./symbolon/tokens.js";
 import { createMcpRoutes } from "./pylon/mcp.js";
 import { broadcastEvent, createUiRoutes } from "./pylon/ui.js";
-import { SignalClient } from "./semeion/client.js";
-import {
-  type DaemonHandle,
-  daemonOptsFromConfig,
-  spawnDaemon,
-  waitForReady,
-} from "./semeion/daemon.js";
-import { startListener } from "./semeion/listener.js";
-import { initSenderPii, parseTarget, sendMessage } from "./semeion/sender.js";
+import { AgoraRegistry } from "./agora/registry.js";
+import { SignalChannelProvider } from "./semeion/provider.js";
+import { sendMessage } from "./semeion/sender.js";
 import { createDefaultRegistry } from "./semeion/commands.js";
 import { SkillRegistry } from "./organon/skills.js";
 import { discoverPlugins, loadPlugins } from "./prostheke/loader.js";
@@ -634,101 +628,53 @@ export async function startRuntime(configPath?: string): Promise<void> {
     log.debug("Registered /plan command");
   }
 
-  // --- Signal ---
+  // --- Channels (Agora) ---
   let watchdog: Watchdog | null = null;
   const abortController = new AbortController();
-  const daemons: DaemonHandle[] = [];
-  const clients = new Map<string, SignalClient>();
+  const agora = new AgoraRegistry();
 
-  // Collect bound group IDs from bindings so the listener can allow them
-  const boundGroupIds = new Set<string>();
-  for (const binding of config.bindings) {
-    if (binding.match.peer?.kind === "group" && binding.match.peer.id) {
-      boundGroupIds.add(binding.match.peer.id);
-    }
-  }
+  // Signal channel provider
+  const signalProvider = new SignalChannelProvider({
+    config,
+    commands: commandRegistry,
+    skills,
+    onStatusRequest: async (client, target) => {
+      const status = formatStatusMessage(runtime.store, config, watchdog);
+      await sendMessage(client, target, status, { markdown: false });
+    },
+  });
+  agora.register(signalProvider);
 
-  initSenderPii(config.privacy?.pii);
+  // Start all registered channels
+  await agora.startAll({
+    dispatch: (msg) => runtime.manager.handleMessage(msg),
+    config,
+    store: runtime.store,
+    manager: runtime.manager,
+    abortSignal: abortController.signal,
+    commands: commandRegistry,
+    get watchdog() { return watchdog; },
+  });
 
-  if (config.channels.signal.enabled) {
-    for (const [accountId, account] of Object.entries(
-      config.channels.signal.accounts,
-    )) {
-      if (!account.enabled) continue;
-
-      const httpUrl =
-        account.httpUrl ??
-        `http://${account.httpHost}:${account.httpPort}`;
-
-      if (account.autoStart) {
-        const daemonOpts = daemonOptsFromConfig(accountId, account);
-        const handle = spawnDaemon(daemonOpts);
-        daemons.push(handle);
-
-        try {
-          await waitForReady(handle.baseUrl);
-        } catch (error) {
-          log.error(
-            `Signal daemon for ${accountId} failed to start: ${error instanceof Error ? error.message : error}`,
-          );
-          continue;
-        }
-      }
-
-      const client = new SignalClient(httpUrl);
-      clients.set(accountId, client);
-
-      startListener({
-        accountId,
-        account,
-        manager: runtime.manager,
-        client,
-        baseUrl: httpUrl,
-        abortSignal: abortController.signal,
-        boundGroupIds,
-        commands: commandRegistry,
-        store: runtime.store,
-        config,
-        get watchdog() { return watchdog; },
-        skills,
-        onStatusRequest: async (target) => {
-          const status = formatStatusMessage(runtime.store, config, watchdog);
-          await sendMessage(client, target, status, { markdown: false });
+  // Wire message + voice tools to agora
+  if (signalProvider.hasClients) {
+    const messageTool = createMessageTool({
+      sender: {
+        send: async (to: string, text: string) => {
+          await agora.send("signal", { to, text });
         },
-      });
+      },
+    });
+    runtime.tools.register(messageTool);
+    log.info("Message tool registered via agora");
 
-      log.info(`Signal account ${accountId} active at ${httpUrl}`);
-    }
-
-    if (clients.size > 0) {
-      const firstClient = clients.values().next().value!;
-      const firstAccountId = clients.keys().next().value!;
-      const firstAccount =
-        config.channels.signal.accounts[firstAccountId];
-      const defaultAccount = firstAccount?.account ?? firstAccountId;
-
-      const messageTool = createMessageTool({
-        sender: {
-          send: async (to: string, text: string) => {
-            const target = parseTarget(to, defaultAccount);
-            await sendMessage(firstClient, target, text);
-          },
-        },
-      });
-      runtime.tools.register(messageTool);
-      log.info("Message tool registered with Signal sender");
-
-      const voiceTool = createVoiceReplyTool({
-        send: async (to: string, text: string, attachments: string[]) => {
-          const target = parseTarget(to, defaultAccount);
-          await sendMessage(firstClient, target, text, { attachments });
-        },
-      });
-      runtime.tools.register(voiceTool);
-      log.info("Voice reply tool registered");
-    } else {
-      runtime.tools.register(createMessageTool());
-    }
+    const voiceTool = createVoiceReplyTool({
+      send: async (to: string, text: string, attachments: string[]) => {
+        await agora.send("signal", { to, text, attachments });
+      },
+    });
+    runtime.tools.register(voiceTool);
+    log.info("Voice reply tool registered via agora");
   } else {
     runtime.tools.register(createMessageTool());
   }
@@ -812,14 +758,10 @@ export async function startRuntime(configPath?: string): Promise<void> {
   // Evolutionary config search — mutate pipeline configs, benchmark, promote winners
   cron.registerCommand("evolution:nightly", async () => {
     const opts: Parameters<typeof runEvolutionCycle>[3] = {};
-    if (clients.size > 0 && config.watchdog?.alertRecipient) {
+    if (signalProvider.hasClients && config.watchdog?.alertRecipient) {
       const alertRecipient = config.watchdog.alertRecipient;
-      const client = clients.values().next().value!;
-      const accountId = clients.keys().next().value!;
-      const account = config.channels.signal.accounts[accountId]!;
-      const accountPhone = account.account ?? accountId;
       opts.sendNotification = async (_nousId, message) => {
-        await sendMessage(client, { account: accountPhone, recipient: alertRecipient }, message, { markdown: false });
+        await agora.send("signal", { to: alertRecipient, text: message, markdown: false });
       };
     }
     const result = await runEvolutionCycle(runtime.store, runtime.router, config, opts);
@@ -846,16 +788,9 @@ export async function startRuntime(configPath?: string): Promise<void> {
 
     // Wire alert function only when Signal + alertRecipient are configured
     let alertFn: ((message: string) => Promise<void>) | undefined;
-    if (wdConfig.alertRecipient && clients.size > 0) {
-      const alertClient = clients.values().next().value!;
-      const alertAccountId = clients.keys().next().value!;
-      const alertAccount = config.channels.signal.accounts[alertAccountId]!;
-      const alertAccountPhone = alertAccount.account ?? alertAccountId;
+    if (wdConfig.alertRecipient && signalProvider.hasClients) {
       alertFn = async (message) => {
-        await sendMessage(alertClient, {
-          account: alertAccountPhone,
-          recipient: wdConfig.alertRecipient!,
-        }, message, { markdown: false });
+        await agora.send("signal", { to: wdConfig.alertRecipient!, text: message, markdown: false });
       };
     }
 
@@ -863,7 +798,7 @@ export async function startRuntime(configPath?: string): Promise<void> {
     watchdog.start();
     setWatchdogRef(watchdog);
     runtime.manager.setWatchdog(watchdog);
-    log.info(`Watchdog started: ${services.length} services${alertFn ? ", alerts → Signal" : ", no alert channel"}`);
+    log.info(`Watchdog started: ${services.length} services${alertFn ? ", alerts via agora" : ", no alert channel"}`);
   }
 
   // Spawn session cleanup — archive stale spawn sessions every hour
@@ -923,9 +858,7 @@ export async function startRuntime(configPath?: string): Promise<void> {
 
     if (mcpManager) await mcpManager.disconnectAll().catch(() => { /* disconnect errors suppressed on shutdown */ });
     abortController.abort();
-    for (const daemon of daemons) {
-      daemon.stop();
-    }
+    await agora.stopAll().catch(() => { /* channel stop errors suppressed on shutdown */ });
     await closeBrowser().catch(() => { /* browser close errors suppressed on shutdown */ });
     await runtime.plugins.dispatchShutdown();
     hookRegistry.teardown();

--- a/infrastructure/runtime/src/semeion/provider.ts
+++ b/infrastructure/runtime/src/semeion/provider.ts
@@ -1,0 +1,283 @@
+// Signal channel provider — wraps semeion into the agora ChannelProvider interface (Spec 34)
+//
+// This is a thin adapter. All real Signal logic stays in semeion's existing files.
+// The provider owns the lifecycle (daemon, client, listener) and exposes send/probe.
+
+import { createLogger } from "../koina/logger.js";
+import type {
+  ChannelCapabilities,
+  ChannelContext,
+  ChannelProbeResult,
+  ChannelProvider,
+  ChannelSendParams,
+  ChannelSendResult,
+} from "../agora/types.js";
+import { SignalClient } from "./client.js";
+import {
+  type DaemonHandle,
+  daemonOptsFromConfig,
+  spawnDaemon,
+  waitForReady,
+} from "./daemon.js";
+import { startListener, type ListenerOpts } from "./listener.js";
+import { initSenderPii, parseTarget, sendMessage, type SendTarget } from "./sender.js";
+import type { AletheiaConfig } from "../taxis/schema.js";
+import type { SkillRegistry } from "../organon/skills.js";
+import type { CommandRegistry } from "./commands.js";
+
+const log = createLogger("semeion:provider");
+
+export interface SignalProviderOpts {
+  config: AletheiaConfig;
+  commands?: CommandRegistry;
+  skills?: SkillRegistry | null;
+  onStatusRequest?: (client: SignalClient, target: SendTarget) => Promise<void>;
+}
+
+/**
+ * SignalChannelProvider — adapts semeion to ChannelProvider.
+ *
+ * On start():
+ *   - Spawns signal-cli daemons for each configured account
+ *   - Creates SignalClient instances
+ *   - Starts SSE listeners that dispatch to the nous pipeline via ctx.dispatch()
+ *
+ * On send():
+ *   - Parses the target format and routes to the correct SignalClient
+ *
+ * On stop():
+ *   - Aborts the SSE listeners
+ *   - Stops signal-cli daemons
+ */
+export class SignalChannelProvider implements ChannelProvider {
+  readonly id = "signal";
+  readonly name = "Signal";
+  readonly capabilities: ChannelCapabilities = {
+    threads: false,
+    reactions: true,
+    typing: true,
+    media: true,
+    streaming: false,
+    richFormatting: false,
+    maxTextLength: 2000,
+  };
+
+  private readonly config: AletheiaConfig;
+  private commandRegistryLocal: CommandRegistry | undefined;
+  private skillsLocal: SkillRegistry | null | undefined;
+  private onStatusRequestFn: ((client: SignalClient, target: SendTarget) => Promise<void>) | undefined;
+
+  private daemons: DaemonHandle[] = [];
+  private clients = new Map<string, SignalClient>();
+  private abortController: AbortController | undefined;
+  private defaultAccountPhone: string | undefined;
+  private defaultClient: SignalClient | undefined;
+
+  constructor(opts: SignalProviderOpts) {
+    this.config = opts.config;
+    this.commandRegistryLocal = opts.commands;
+    this.skillsLocal = opts.skills;
+    this.onStatusRequestFn = opts.onStatusRequest;
+  }
+
+  async start(ctx: ChannelContext): Promise<void> {
+    if (!this.config.channels.signal.enabled) {
+      log.info("Signal channel disabled in config");
+      return;
+    }
+
+    this.abortController = new AbortController();
+
+    // Chain to the parent abort signal
+    ctx.abortSignal.addEventListener("abort", () => this.abortController?.abort(), { once: true });
+
+    initSenderPii(this.config.privacy?.pii);
+
+    // Collect bound group IDs from bindings so the listener can allow them
+    const boundGroupIds = new Set<string>();
+    for (const binding of this.config.bindings) {
+      if (binding.match.peer?.kind === "group" && binding.match.peer.id) {
+        boundGroupIds.add(binding.match.peer.id);
+      }
+    }
+
+    const commands = this.commandRegistryLocal ?? ctx.commands;
+    const skills = this.skillsLocal ?? null;
+
+    for (const [accountId, account] of Object.entries(
+      this.config.channels.signal.accounts,
+    )) {
+      if (!account.enabled) continue;
+
+      const httpUrl =
+        account.httpUrl ??
+        `http://${account.httpHost}:${account.httpPort}`;
+
+      // Spawn daemon if auto-start enabled
+      if (account.autoStart) {
+        const daemonOpts = daemonOptsFromConfig(accountId, account);
+        const handle = spawnDaemon(daemonOpts);
+        this.daemons.push(handle);
+
+        try {
+          await waitForReady(handle.baseUrl);
+        } catch (error) {
+          log.error(
+            `Signal daemon for ${accountId} failed to start: ${error instanceof Error ? error.message : error}`,
+          );
+          continue;
+        }
+      }
+
+      const client = new SignalClient(httpUrl);
+      this.clients.set(accountId, client);
+
+      // Track default (first) account for outbound
+      if (!this.defaultClient) {
+        this.defaultClient = client;
+        this.defaultAccountPhone = account.account ?? accountId;
+      }
+
+      // Start SSE listener — dispatches to nous via ctx.manager.handleMessage
+      const listenerOpts: ListenerOpts = {
+        accountId,
+        account,
+        manager: ctx.manager,
+        client,
+        baseUrl: httpUrl,
+        abortSignal: this.abortController.signal,
+        boundGroupIds,
+        store: ctx.store,
+        config: this.config,
+        get watchdog() { return ctx.watchdog ?? null; },
+      };
+
+      // Conditionally assign optional fields to avoid exactOptionalPropertyTypes issues
+      if (commands) listenerOpts.commands = commands;
+      if (skills) listenerOpts.skills = skills;
+
+      if (this.onStatusRequestFn) {
+        const statusHandler = this.onStatusRequestFn;
+        listenerOpts.onStatusRequest = async (target) => {
+          await statusHandler(client, target);
+        };
+      }
+
+      // startListener is fire-and-forget (it loops internally with reconnect)
+      startListener(listenerOpts);
+
+      log.info(`Signal account ${accountId} active at ${httpUrl}`);
+    }
+
+    log.info(`Signal provider started: ${this.clients.size} account(s)`);
+  }
+
+  async send(params: ChannelSendParams): Promise<ChannelSendResult> {
+    const client = this.resolveClient(params.accountId);
+    if (!client) {
+      return { sent: false, error: "No Signal client available" };
+    }
+
+    const account = this.resolveAccountPhone(params.accountId);
+    const target = parseTarget(params.to, account);
+
+    try {
+      const sendOpts: { markdown?: boolean; attachments?: string[] } = {};
+      if (params.markdown !== undefined) sendOpts.markdown = params.markdown;
+      if (params.attachments) sendOpts.attachments = params.attachments;
+
+      await sendMessage(client, target, params.text, sendOpts);
+      return { sent: true };
+    } catch (error) {
+      return {
+        sent: false,
+        error: `Signal send failed: ${error instanceof Error ? error.message : error}`,
+      };
+    }
+  }
+
+  async sendTyping(to: string, accountId?: string, stop = false): Promise<void> {
+    const client = this.resolveClient(accountId);
+    if (!client) return;
+
+    const account = this.resolveAccountPhone(accountId);
+    const target = parseTarget(to, account);
+
+    const { sendTyping: sendTypingFn } = await import("./sender.js");
+    await sendTypingFn(client, target, stop);
+  }
+
+  async stop(): Promise<void> {
+    this.abortController?.abort();
+    for (const daemon of this.daemons) {
+      daemon.stop();
+    }
+    this.daemons = [];
+    this.clients.clear();
+    this.defaultClient = undefined;
+    this.defaultAccountPhone = undefined;
+    log.info("Signal provider stopped");
+  }
+
+  async probe(): Promise<ChannelProbeResult> {
+    if (this.clients.size === 0) {
+      return { ok: false, error: "No Signal clients configured" };
+    }
+
+    // Probe each client via health endpoint
+    const accountResults: Record<string, boolean> = {};
+    let anyOk = false;
+
+    for (const [accountId, client] of this.clients) {
+      try {
+        const ok = await client.health();
+        accountResults[accountId] = ok;
+        if (ok) anyOk = true;
+      } catch {
+        accountResults[accountId] = false;
+      }
+    }
+
+    return {
+      ok: anyOk,
+      details: { accounts: accountResults },
+    };
+  }
+
+  // --- Accessors for legacy code that needs raw client/account ---
+
+  /** Get the default SignalClient (first configured account) */
+  getDefaultClient(): SignalClient | undefined {
+    return this.defaultClient;
+  }
+
+  /** Get the default account phone number */
+  getDefaultAccountPhone(): string | undefined {
+    return this.defaultAccountPhone;
+  }
+
+  /** Get a specific SignalClient by account ID */
+  getClient(accountId: string): SignalClient | undefined {
+    return this.clients.get(accountId);
+  }
+
+  /** Check if any Signal clients are available */
+  get hasClients(): boolean {
+    return this.clients.size > 0;
+  }
+
+  // --- Internal ---
+
+  private resolveClient(accountId?: string): SignalClient | undefined {
+    if (accountId) return this.clients.get(accountId);
+    return this.defaultClient;
+  }
+
+  private resolveAccountPhone(accountId?: string): string {
+    if (accountId) {
+      const account = this.config.channels.signal.accounts[accountId];
+      return account?.account ?? accountId;
+    }
+    return this.defaultAccountPhone ?? "";
+  }
+}

--- a/shared/skills/codebase-guided-specification-writing/SKILL.md
+++ b/shared/skills/codebase-guided-specification-writing/SKILL.md
@@ -1,0 +1,21 @@
+# Codebase-Guided Specification Writing
+Write a new technical specification by researching related code, documentation, and architectural decisions in the codebase first.
+
+## When to Use
+When you need to author a new technical specification (RFC/ADR) that must be consistent with existing system design, naming conventions, and architectural patterns. Use this when the spec proposes changes that touch multiple modules or require understanding current implementation details.
+
+## Steps
+1. Search codebase for related terms, existing specs, and architectural documentation
+2. Read foundational design documents (e.g., ARCHITECTURE.md, naming philosophy docs)
+3. Examine the most recent related specs to understand current status and progression
+4. Inspect actual source code in relevant modules to understand current implementation
+5. Trace imports and cross-references between modules to understand dependencies
+6. Write the specification document with proper structure (status, problem, solution, implementation details)
+7. Commit the spec to version control with descriptive message
+8. Update or create related tracking issue with spec summary and phase breakdown
+9. Record the work in task notes with spec number, commit hash, and phase outline
+
+## Tools Used
+- exec: for grepping documentation/code, reading files, checking directory structure, running git commands, and GitHub CLI updates
+- write: for creating the specification document file
+- note: for recording completion and phase breakdown in task tracking

--- a/shared/skills/github-issue-investigation-and-analysis/SKILL.md
+++ b/shared/skills/github-issue-investigation-and-analysis/SKILL.md
@@ -1,0 +1,19 @@
+# GitHub Issue Investigation and Analysis
+Systematically retrieve and analyze multiple GitHub issues to understand project problems, bugs, and feature requests.
+
+## When to Use
+When you need to investigate a repository's issue backlog to understand recurring problems, prioritize bugs, gather context about multiple related issues, or extract information from issue discussions for analysis or reporting.
+
+## Steps
+1. List all open issues with key metadata (number, title, labels, state) to get an overview
+2. Identify specific issue numbers of interest from the list
+3. Retrieve full body content of selected issues using issue view commands
+4. Extract and examine the first ~20 lines of issue descriptions to understand context
+5. Batch retrieve multiple related issues in a loop to efficiently gather information on several topics
+6. Parse JSON output with jq to extract structured data (body text, labels, etc.)
+
+## Tools Used
+- exec: Execute shell commands to run GitHub CLI (gh) commands for querying issues
+- gh issue list: Retrieve multiple issues with filtered metadata
+- gh issue view: Get detailed information for specific issue numbers
+- jq: Parse and filter JSON output to extract relevant fields


### PR DESCRIPTION
## Spec 34: Agora — Phase 1

**Channel abstraction layer with Signal as first provider.**

### What changed

**New modules:**
- `src/agora/types.ts` — `ChannelProvider` interface, capabilities, context, send params
- `src/agora/registry.ts` — `AgoraRegistry` (register, start, stop, send, probe)
- `src/semeion/provider.ts` — `SignalChannelProvider` implementing `ChannelProvider`

**Refactored `aletheia.ts`:**
- Replaced all direct semeion wiring with `AgoraRegistry` + `SignalChannelProvider`
- Message tool routes through `agora.send('signal', ...)`
- Watchdog alerts route through `agora.send('signal', ...)`
- Evolution cron notifications route through `agora.send('signal', ...)`
- Shutdown calls `agora.stopAll()`
- **-67 net lines** in aletheia.ts (moved into focused modules)

### Zero behavioral change

Signal works exactly as before — same SSE listener, same daemon management, same send path. The difference is architectural: semeion is now a plugin that implements an interface, not a hardwired subsystem.

### Tests

- All **117 existing semeion tests** pass unchanged
- **15 new tests** in `agora/registry.test.ts`: registration, lifecycle, send routing, probes, getFirst

### Why this matters

After this PR, adding Slack (Phase 3) means implementing `SlackChannelProvider`, registering it with agora, and adding config. No changes to the nous pipeline, no changes to the routing system, no changes to the message tool. The abstraction layer handles it.

Ref: Spec 34 (`docs/specs/34_agora.md`), Issue #210