### PR TITLE
feat(agora): Phase 2 — Slack config schema + CLI onboarding

### DIFF
--- a/infrastructure/runtime/src/agora/cli.test.ts
+++ b/infrastructure/runtime/src/agora/cli.test.ts
@@ -1,0 +1,116 @@
+// Tests for Agora CLI — channel management
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { existsSync, mkdirSync, readFileSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+// Test helpers
+function createTempConfig(channels?: Record<string, unknown>): { dir: string; path: string } {
+  const dir = join(tmpdir(), `agora-cli-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  mkdirSync(dir, { recursive: true });
+  const path = join(dir, "aletheia.json");
+  const config: Record<string, unknown> = {
+    models: { primary: { provider: "anthropic", model: "test" } },
+    agents: { list: [] },
+    bindings: [],
+  };
+  if (channels) config["channels"] = channels;
+  writeFileSync(path, JSON.stringify(config, null, 2));
+  return { dir, path };
+}
+
+function readConfig(path: string): Record<string, unknown> {
+  return JSON.parse(readFileSync(path, "utf-8")) as Record<string, unknown>;
+}
+
+describe("agora/cli", () => {
+  const consoleSpy = { log: vi.fn(), error: vi.fn() };
+  const origLog = console.log;
+  const origError = console.error;
+
+  beforeEach(() => {
+    consoleSpy.log = vi.fn();
+    consoleSpy.error = vi.fn();
+    console.log = consoleSpy.log;
+    console.error = consoleSpy.error;
+  });
+
+  afterEach(() => {
+    console.log = origLog;
+    console.error = origError;
+  });
+
+  describe("channelList", () => {
+    it("shows signal and slack status when both configured", async () => {
+      const { path } = createTempConfig({
+        signal: { enabled: true, accounts: { default: { account: "+1" } } },
+        slack: { enabled: true, mode: "socket", appToken: "xapp-1", botToken: "xoxb-1" },
+      });
+      const { channelList } = await import("./cli.js");
+      channelList(path);
+
+      const output = consoleSpy.log.mock.calls.map((c: unknown[]) => c[0]).join("\n");
+      expect(output).toContain("signal");
+      expect(output).toContain("✓ enabled");
+      expect(output).toContain("slack");
+    });
+
+    it("shows not configured for missing channels", async () => {
+      const { path } = createTempConfig({});
+      const { channelList } = await import("./cli.js");
+      channelList(path);
+
+      const output = consoleSpy.log.mock.calls.map((c: unknown[]) => c[0]).join("\n");
+      expect(output).toContain("slack");
+      expect(output).toContain("not configured");
+    });
+  });
+
+  describe("channelRemove", () => {
+    it("removes slack config from file", async () => {
+      const { path } = createTempConfig({
+        signal: { enabled: true, accounts: {} },
+        slack: { enabled: true },
+      });
+      const { channelRemove } = await import("./cli.js");
+      channelRemove("slack", path);
+
+      const config = readConfig(path);
+      const channels = config["channels"] as Record<string, unknown>;
+      expect(channels["slack"]).toBeUndefined();
+      expect(channels["signal"]).toBeDefined();
+    });
+
+    it("refuses to remove signal", async () => {
+      const { path } = createTempConfig({
+        signal: { enabled: true, accounts: {} },
+      });
+
+      const mockExit = vi.spyOn(process, "exit").mockImplementation(() => { throw new Error("exit"); });
+      const { channelRemove } = await import("./cli.js");
+
+      expect(() => channelRemove("signal", path)).toThrow("exit");
+      mockExit.mockRestore();
+    });
+  });
+
+  describe("isSupportedChannel", () => {
+    it("recognizes slack", async () => {
+      const { isSupportedChannel } = await import("./cli.js");
+      expect(isSupportedChannel("slack")).toBe(true);
+    });
+
+    it("rejects unknown channels", async () => {
+      const { isSupportedChannel } = await import("./cli.js");
+      expect(isSupportedChannel("discord")).toBe(false);
+      expect(isSupportedChannel("signal")).toBe(false); // signal is built-in, not addable
+    });
+  });
+
+  describe("listSupportedChannels", () => {
+    it("returns supported channel list", async () => {
+      const { listSupportedChannels } = await import("./cli.js");
+      expect(listSupportedChannels()).toEqual(["slack"]);
+    });
+  });
+});

--- a/infrastructure/runtime/src/agora/cli.ts
+++ b/infrastructure/runtime/src/agora/cli.ts
@@ -1,0 +1,230 @@
+// Agora CLI — channel management commands (Spec 34)
+//
+// `aletheia channel add slack` — interactive onboarding wizard
+// `aletheia channel list`      — show configured channels and status
+// `aletheia channel remove`    — remove a channel config
+
+import { paths } from "../taxis/paths.js";
+import { readFileSync, writeFileSync, existsSync } from "node:fs";
+import { createInterface } from "node:readline";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function ask(rl: ReturnType<typeof createInterface>, question: string): Promise<string> {
+  return new Promise((resolve) => rl.question(question, resolve));
+}
+
+function loadConfigJson(configPath?: string): Record<string, unknown> {
+  const file = configPath ?? paths.configFile();
+  if (!existsSync(file)) {
+    throw new Error(`Config file not found: ${file}`);
+  }
+  return JSON.parse(readFileSync(file, "utf-8")) as Record<string, unknown>;
+}
+
+function writeConfigJson(config: Record<string, unknown>, configPath?: string): void {
+  const file = configPath ?? paths.configFile();
+  writeFileSync(file, JSON.stringify(config, null, 2) + "\n", "utf-8");
+}
+
+// ---------------------------------------------------------------------------
+// Channel: list
+// ---------------------------------------------------------------------------
+
+export function channelList(configPath?: string): void {
+  const config = loadConfigJson(configPath);
+  const channels = (config["channels"] ?? {}) as Record<string, unknown>;
+
+  console.log("\nConfigured channels:\n");
+
+  // Signal
+  const signal = channels["signal"] as Record<string, unknown> | undefined;
+  if (signal) {
+    const enabled = signal["enabled"] !== false;
+    const accounts = signal["accounts"] as Record<string, unknown> | undefined;
+    const accountCount = accounts ? Object.keys(accounts).length : 0;
+    console.log(`  signal  ${enabled ? "✓ enabled" : "✗ disabled"}  (${accountCount} account${accountCount !== 1 ? "s" : ""})`);
+  } else {
+    console.log("  signal  ✗ not configured");
+  }
+
+  // Slack
+  const slack = channels["slack"] as Record<string, unknown> | undefined;
+  if (slack) {
+    const enabled = slack["enabled"] !== false;
+    const mode = (slack["mode"] as string) ?? "socket";
+    const hasTokens = !!(slack["appToken"] && slack["botToken"]);
+    console.log(`  slack   ${enabled ? "✓ enabled" : "✗ disabled"}  (${mode} mode${hasTokens ? ", tokens set" : ", tokens missing"})`);
+  } else {
+    console.log("  slack   ✗ not configured");
+  }
+
+  console.log();
+}
+
+// ---------------------------------------------------------------------------
+// Channel: remove
+// ---------------------------------------------------------------------------
+
+export function channelRemove(channelId: string, configPath?: string): void {
+  if (channelId === "signal") {
+    console.error("Cannot remove Signal — it is the default channel. Disable it in config instead.");
+    process.exit(1);
+  }
+
+  const config = loadConfigJson(configPath);
+  const channels = (config["channels"] ?? {}) as Record<string, unknown>;
+
+  if (!channels[channelId]) {
+    console.error(`Channel "${channelId}" is not configured.`);
+    process.exit(1);
+  }
+
+  delete channels[channelId];
+  config["channels"] = channels;
+  writeConfigJson(config, configPath);
+
+  console.log(`\n✓ Channel "${channelId}" removed from config.`);
+  console.log("  Restart Aletheia to apply: systemctl restart aletheia\n");
+}
+
+// ---------------------------------------------------------------------------
+// Channel: add slack
+// ---------------------------------------------------------------------------
+
+export async function channelAddSlack(configPath?: string): Promise<void> {
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+
+  try {
+    const config = loadConfigJson(configPath);
+    const channels = (config["channels"] ?? {}) as Record<string, unknown>;
+
+    if (channels["slack"]) {
+      const existing = channels["slack"] as Record<string, unknown>;
+      if (existing["enabled"]) {
+        const overwrite = (await ask(rl, "\nSlack is already configured. Overwrite? (y/N): ")).trim().toLowerCase();
+        if (overwrite !== "y") {
+          console.log("Aborted.");
+          return;
+        }
+      }
+    }
+
+    console.log(`
+  Slack Integration Setup
+  ${"─".repeat(25)}
+
+  Step 1: Create a Slack App
+
+    Visit https://api.slack.com/apps and click "Create New App"
+    Choose "From scratch" and select your workspace
+`);
+
+    console.log(`  Step 2: Enable Socket Mode
+
+    In your app settings, go to "Socket Mode" and enable it
+    Create an App-Level Token with 'connections:write' scope
+    Copy the token (starts with xapp-)
+`);
+
+    const appToken = (await ask(rl, "  ? App Token (xapp-...): ")).trim();
+    if (!appToken.startsWith("xapp-")) {
+      console.error("\n  ✗ App token must start with 'xapp-'. Aborting.\n");
+      return;
+    }
+
+    console.log(`
+  Step 3: Bot Token
+
+    Go to "OAuth & Permissions"
+    Add these Bot Token Scopes:
+      • channels:history    • channels:read
+      • chat:write          • groups:history
+      • groups:read         • im:history
+      • im:read             • reactions:read
+      • reactions:write     • users:read
+      • chat:write.customize (optional — agent identity)
+
+    Install the app to your workspace
+    Copy the Bot User OAuth Token (starts with xoxb-)
+`);
+
+    const botToken = (await ask(rl, "  ? Bot Token (xoxb-...): ")).trim();
+    if (!botToken.startsWith("xoxb-")) {
+      console.error("\n  ✗ Bot token must start with 'xoxb-'. Aborting.\n");
+      return;
+    }
+
+    console.log(`
+  Step 4: Subscribe to Events
+
+    Go to "Event Subscriptions" → "Subscribe to bot events"
+    Add these events:
+      • app_mention         • message.channels
+      • message.groups      • message.im
+      • reaction_added
+`);
+
+    console.log("  Step 5: Configure access\n");
+
+    const dmPolicyInput = (await ask(rl, "  ? DM policy (open/allowlist/disabled) [open]: ")).trim().toLowerCase() || "open";
+    const dmPolicy = ["open", "allowlist", "disabled"].includes(dmPolicyInput) ? dmPolicyInput : "open";
+
+    const groupPolicyInput = (await ask(rl, "  ? Channel policy (open/allowlist/disabled) [allowlist]: ")).trim().toLowerCase() || "allowlist";
+    const groupPolicy = ["open", "allowlist", "disabled"].includes(groupPolicyInput) ? groupPolicyInput : "allowlist";
+
+    const requireMentionInput = (await ask(rl, "  ? Require @mention in channels? (Y/n): ")).trim().toLowerCase();
+    const requireMention = requireMentionInput !== "n";
+
+    // Write config
+    const slackConfig: Record<string, unknown> = {
+      enabled: true,
+      mode: "socket",
+      appToken,
+      botToken,
+      dmPolicy,
+      groupPolicy,
+      allowedChannels: [],
+      allowedUsers: [],
+      requireMention,
+      identity: {
+        useAgentIdentity: true,
+      },
+    };
+
+    channels["slack"] = slackConfig;
+    config["channels"] = channels;
+    writeConfigJson(config, configPath);
+
+    console.log(`
+  ✓ Slack configuration written to config.
+  ✓ Restart Aletheia to activate: systemctl restart aletheia
+
+  To bind an agent to a Slack channel:
+    Edit bindings in config to add:
+    {
+      "agentId": "syn",
+      "match": { "channel": "slack", "peer": { "kind": "channel", "id": "C0123456789" } }
+    }
+`);
+  } finally {
+    rl.close();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Supported channels registry (for validation + help text)
+// ---------------------------------------------------------------------------
+
+const SUPPORTED_CHANNELS = ["slack"] as const;
+type SupportedChannel = (typeof SUPPORTED_CHANNELS)[number];
+
+export function isSupportedChannel(id: string): id is SupportedChannel {
+  return (SUPPORTED_CHANNELS as readonly string[]).includes(id);
+}
+
+export function listSupportedChannels(): string[] {
+  return [...SUPPORTED_CHANNELS];
+}

--- a/infrastructure/runtime/src/agora/config.test.ts
+++ b/infrastructure/runtime/src/agora/config.test.ts
@@ -1,0 +1,118 @@
+// Tests for Slack channel config schema validation (Spec 34)
+import { describe, it, expect } from "vitest";
+
+// We test via the full AletheiaConfig schema to ensure Slack config integrates properly
+import { AletheiaConfigSchema } from "../taxis/schema.js";
+
+function parseConfig(channels: unknown) {
+  return AletheiaConfigSchema.safeParse({
+    models: { primary: { provider: "anthropic", model: "claude-sonnet-4-20250514" } },
+    agents: { list: [] },
+    bindings: [],
+    channels,
+  });
+}
+
+describe("Slack channel config schema", () => {
+  it("accepts minimal slack config", async () => {
+    const result = await parseConfig({
+      signal: { enabled: true, accounts: {} },
+      slack: {
+        enabled: true,
+        appToken: "xapp-1-A0123",
+        botToken: "xoxb-1234",
+      },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const slack = result.data.channels.slack;
+      expect(slack.enabled).toBe(true);
+      expect(slack.mode).toBe("socket"); // default
+      expect(slack.dmPolicy).toBe("open"); // default
+      expect(slack.requireMention).toBe(true); // default
+    }
+  });
+
+  it("accepts full slack config with all fields", async () => {
+    const result = await parseConfig({
+      signal: { enabled: true, accounts: {} },
+      slack: {
+        enabled: true,
+        mode: "socket",
+        appToken: "xapp-1-A0123",
+        botToken: "xoxb-1234",
+        dmPolicy: "allowlist",
+        groupPolicy: "disabled",
+        allowedChannels: ["C0123456789"],
+        allowedUsers: ["U0123456789"],
+        requireMention: false,
+        identity: { useAgentIdentity: false },
+      },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const slack = result.data.channels.slack;
+      expect(slack.dmPolicy).toBe("allowlist");
+      expect(slack.groupPolicy).toBe("disabled");
+      expect(slack.allowedChannels).toEqual(["C0123456789"]);
+      expect(slack.requireMention).toBe(false);
+      expect(slack.identity.useAgentIdentity).toBe(false);
+    }
+  });
+
+  it("omitting slack entirely is valid (optional)", async () => {
+    const result = await parseConfig({
+      signal: { enabled: true, accounts: {} },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.channels.slack).toBeUndefined();
+    }
+  });
+
+  it("rejects invalid mode", async () => {
+    const result = await parseConfig({
+      signal: { enabled: true, accounts: {} },
+      slack: {
+        enabled: true,
+        mode: "websocket", // invalid
+        appToken: "xapp-1",
+        botToken: "xoxb-1",
+      },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects invalid dmPolicy", async () => {
+    const result = await parseConfig({
+      signal: { enabled: true, accounts: {} },
+      slack: {
+        enabled: true,
+        dmPolicy: "everyone", // invalid
+      },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("defaults enabled to false", async () => {
+    const result = await parseConfig({
+      signal: { enabled: true, accounts: {} },
+      slack: {},
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.channels.slack.enabled).toBe(false);
+    }
+  });
+
+  it("defaults allowedChannels to empty array", async () => {
+    const result = await parseConfig({
+      signal: { enabled: true, accounts: {} },
+      slack: { enabled: true },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.channels.slack.allowedChannels).toEqual([]);
+    }
+  });
+});

--- a/infrastructure/runtime/src/agora/index.ts
+++ b/infrastructure/runtime/src/agora/index.ts
@@ -1,5 +1,6 @@
 // Agora — channel abstraction layer (Spec 34)
 export { AgoraRegistry } from "./registry.js";
+export { channelList, channelAddSlack, channelRemove, isSupportedChannel, listSupportedChannels } from "./cli.js";
 export type {
   ChannelCapabilities,
   ChannelContext,

--- a/infrastructure/runtime/src/entry.ts
+++ b/infrastructure/runtime/src/entry.ts
@@ -1254,4 +1254,37 @@ program
     console.log(`\nRestart the gateway to apply: systemctl restart aletheia`);
   });
 
+// --- Channel management (Agora) ---
+const channelCmd = program.command("channel").description("Channel management (Agora)");
+
+channelCmd
+  .command("list")
+  .description("Show configured channels and their status")
+  .action(async () => {
+    const { channelList } = await import("./agora/cli.js");
+    channelList();
+  });
+
+channelCmd
+  .command("add <channel>")
+  .description("Add and configure a channel (e.g., slack)")
+  .action(async (channel: string) => {
+    const { isSupportedChannel, channelAddSlack, listSupportedChannels } = await import("./agora/cli.js");
+    if (!isSupportedChannel(channel)) {
+      console.error(`Unknown channel: "${channel}". Supported: ${listSupportedChannels().join(", ")}`);
+      process.exit(1);
+    }
+    if (channel === "slack") {
+      await channelAddSlack();
+    }
+  });
+
+channelCmd
+  .command("remove <channel>")
+  .description("Remove a channel configuration")
+  .action(async (channel: string) => {
+    const { channelRemove } = await import("./agora/cli.js");
+    channelRemove(channel);
+  });
+
 program.parse();

--- a/infrastructure/runtime/src/taxis/schema.ts
+++ b/infrastructure/runtime/src/taxis/schema.ts
@@ -212,9 +212,27 @@ const SignalConfig = z.preprocess(
   }),
 ).default({ enabled: true, accounts: {} });
 
+// Slack channel config (Spec 34 — Agora)
+const SlackChannelConfig = z.object({
+  enabled: z.boolean().default(false),
+  mode: z.enum(["socket", "http"]).default("socket"),
+  appToken: z.string().optional(),   // xapp-... (Socket Mode)
+  botToken: z.string().optional(),   // xoxb-... (Bot User OAuth)
+  signingSecret: z.string().optional(), // for HTTP mode verification
+  dmPolicy: z.enum(["open", "allowlist", "disabled"]).default("open"),
+  groupPolicy: z.enum(["open", "allowlist", "disabled"]).default("allowlist"),
+  allowedChannels: z.array(z.string()).default([]),
+  allowedUsers: z.array(z.string()).default([]),
+  requireMention: z.boolean().default(true),
+  identity: z.object({
+    useAgentIdentity: z.boolean().default(true),
+  }).default({}),
+});
+
 const ChannelsConfig = z
   .object({
     signal: SignalConfig,
+    slack: SlackChannelConfig.optional(),
   })
   .default({});
 


### PR DESCRIPTION
## Spec 34: Agora — Phase 2

**Config schema and CLI onboarding for Slack.**

### Config Schema (`taxis/schema.ts`)

New `SlackChannelConfig` with Zod validation:

```json
{
  "channels": {
    "slack": {
      "enabled": true,
      "mode": "socket",
      "appToken": "xapp-...",
      "botToken": "xoxb-...",
      "dmPolicy": "open",
      "groupPolicy": "allowlist",
      "allowedChannels": [],
      "allowedUsers": [],
      "requireMention": true,
      "identity": { "useAgentIdentity": true }
    }
  }
}
```

Slack config is **optional** — omitting it entirely is valid. Defaults to disabled.

### CLI Commands

| Command | What |
|---------|------|
| `aletheia channel list` | Show configured channels and status |
| `aletheia channel add slack` | Interactive wizard: token validation, scope guide, policy prompts |
| `aletheia channel remove slack` | Remove Slack config (signal removal blocked) |

### Tests

- **7 config schema tests**: validation, defaults, rejection of invalid values
- **7 CLI tests**: list output, remove behavior, supported channel validation
- **15 registry tests**: unchanged from Phase 1
- **117 semeion tests**: unchanged

Ref: Spec 34 (`docs/specs/34_agora.md`), Phase 2