### PR TITLE
feat(agora): Phase 4 — multi-channel message routing

### DIFF
--- a/infrastructure/runtime/src/agora/index.ts
+++ b/infrastructure/runtime/src/agora/index.ts
@@ -2,6 +2,8 @@
 export { AgoraRegistry } from "./registry.js";
 export { channelList, channelAddSlack, channelRemove, isSupportedChannel, listSupportedChannels } from "./cli.js";
 export { SlackChannelProvider } from "./channels/slack/provider.js";
+export { parseTarget, resolveTarget, isRoutingError } from "./routing.js";
+export type { ResolvedTarget, RoutingError, RoutingResult } from "./routing.js";
 export type {
   ChannelCapabilities,
   ChannelContext,

--- a/infrastructure/runtime/src/agora/routing.test.ts
+++ b/infrastructure/runtime/src/agora/routing.test.ts
@@ -1,0 +1,189 @@
+// Agora routing tests (Spec 34, Phase 4)
+import { describe, expect, it } from "vitest";
+import { parseTarget, resolveTarget, isRoutingError } from "./routing.js";
+import { AgoraRegistry } from "./registry.js";
+
+// ---------------------------------------------------------------------------
+// parseTarget — pure parsing, no registry validation
+// ---------------------------------------------------------------------------
+
+describe("parseTarget", () => {
+  describe("explicit channel prefix", () => {
+    it("parses slack:C0123456789", () => {
+      const result = parseTarget("slack:C0123456789");
+      expect(result).toEqual({ channel: "slack", to: "C0123456789" });
+    });
+
+    it("parses slack:@username", () => {
+      const result = parseTarget("slack:@username");
+      expect(result).toEqual({ channel: "slack", to: "@username" });
+    });
+
+    it("parses slack:U0123456789", () => {
+      const result = parseTarget("slack:U0123456789");
+      expect(result).toEqual({ channel: "slack", to: "U0123456789" });
+    });
+
+    it("parses signal:+1234567890", () => {
+      const result = parseTarget("signal:+1234567890");
+      expect(result).toEqual({ channel: "signal", to: "+1234567890" });
+    });
+
+    it("parses discord:123456 (future channel)", () => {
+      const result = parseTarget("discord:123456");
+      expect(result).toEqual({ channel: "discord", to: "123456" });
+    });
+
+    it("parses matrix:@user:matrix.org (future channel)", () => {
+      const result = parseTarget("matrix:@user:matrix.org");
+      expect(result).toEqual({ channel: "matrix", to: "@user:matrix.org" });
+    });
+
+    it("is case-insensitive for channel prefix", () => {
+      const result = parseTarget("Slack:C0123456789");
+      expect(result).toEqual({ channel: "slack", to: "C0123456789" });
+    });
+
+    it("errors on empty address after prefix", () => {
+      const result = parseTarget("slack:");
+      expect(isRoutingError(result)).toBe(true);
+      if (isRoutingError(result)) {
+        expect(result.error).toContain("Missing address");
+      }
+    });
+  });
+
+  describe("legacy Signal formats (unqualified)", () => {
+    it("parses +1234567890 as signal", () => {
+      const result = parseTarget("+1234567890");
+      expect(result).toEqual({ channel: "signal", to: "+1234567890" });
+    });
+
+    it("parses +15125551234 as signal", () => {
+      const result = parseTarget("+15125551234");
+      expect(result).toEqual({ channel: "signal", to: "+15125551234" });
+    });
+
+    it("parses group:ABCDEF as signal", () => {
+      const result = parseTarget("group:ABCDEF");
+      expect(result).toEqual({ channel: "signal", to: "group:ABCDEF" });
+    });
+
+    it("parses u:handle as signal", () => {
+      const result = parseTarget("u:handle");
+      expect(result).toEqual({ channel: "signal", to: "u:handle" });
+    });
+
+    it("parses group:base64/encoded+id== as signal", () => {
+      const result = parseTarget("group:abc123/def+ghi==");
+      expect(result).toEqual({ channel: "signal", to: "group:abc123/def+ghi==" });
+    });
+  });
+
+  describe("edge cases", () => {
+    it("errors on empty string", () => {
+      const result = parseTarget("");
+      expect(isRoutingError(result)).toBe(true);
+      if (isRoutingError(result)) {
+        expect(result.error).toContain("Empty target");
+      }
+    });
+
+    it("errors on whitespace-only", () => {
+      const result = parseTarget("   ");
+      expect(isRoutingError(result)).toBe(true);
+    });
+
+    it("trims whitespace", () => {
+      const result = parseTarget("  +1234567890  ");
+      expect(result).toEqual({ channel: "signal", to: "+1234567890" });
+    });
+
+    it("errors on unknown format", () => {
+      const result = parseTarget("randomtext");
+      expect(isRoutingError(result)).toBe(true);
+      if (isRoutingError(result)) {
+        expect(result.error).toContain("Unknown target format");
+      }
+    });
+
+    it("errors on unknown channel prefix", () => {
+      const result = parseTarget("telegram:12345");
+      expect(isRoutingError(result)).toBe(true);
+      if (isRoutingError(result)) {
+        expect(result.error).toContain("Unknown target format");
+      }
+    });
+
+    it("does not treat short phone numbers as signal", () => {
+      // +12345 is only 5 digits — too short
+      const result = parseTarget("+12345");
+      expect(isRoutingError(result)).toBe(true);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveTarget — parsing + registry validation
+// ---------------------------------------------------------------------------
+
+describe("resolveTarget", () => {
+  function makeRegistry(...channelIds: string[]): AgoraRegistry {
+    const registry = new AgoraRegistry();
+    for (const id of channelIds) {
+      registry.register({
+        id,
+        name: id,
+        capabilities: {
+          threads: false, reactions: false, typing: false,
+          media: false, streaming: false, richFormatting: false,
+          maxTextLength: 4000,
+        },
+        start: async () => {},
+        send: async () => ({ sent: true }),
+        stop: async () => {},
+      });
+    }
+    return registry;
+  }
+
+  it("resolves slack target when slack is registered", () => {
+    const registry = makeRegistry("signal", "slack");
+    const result = resolveTarget("slack:C0123", registry);
+    expect(result).toEqual({ channel: "slack", to: "C0123" });
+  });
+
+  it("resolves signal phone when signal is registered", () => {
+    const registry = makeRegistry("signal");
+    const result = resolveTarget("+1234567890", registry);
+    expect(result).toEqual({ channel: "signal", to: "+1234567890" });
+  });
+
+  it("errors when target channel is not registered", () => {
+    const registry = makeRegistry("signal");
+    const result = resolveTarget("slack:C0123", registry);
+    expect(isRoutingError(result)).toBe(true);
+    if (isRoutingError(result)) {
+      expect(result.error).toContain("not configured");
+      expect(result.error).toContain("signal");
+    }
+  });
+
+  it("errors when no channels are registered", () => {
+    const registry = new AgoraRegistry();
+    const result = resolveTarget("slack:C0123", registry);
+    expect(isRoutingError(result)).toBe(true);
+    if (isRoutingError(result)) {
+      expect(result.error).toContain("No channels configured");
+    }
+  });
+
+  it("passes through parse errors", () => {
+    const registry = makeRegistry("signal");
+    const result = resolveTarget("", registry);
+    expect(isRoutingError(result)).toBe(true);
+    if (isRoutingError(result)) {
+      expect(result.error).toContain("Empty target");
+    }
+  });
+});

--- a/infrastructure/runtime/src/agora/routing.ts
+++ b/infrastructure/runtime/src/agora/routing.ts
@@ -1,0 +1,136 @@
+// Agora routing — target format parsing and channel resolution (Spec 34, Phase 4)
+//
+// Targets arrive as strings from the message tool. This module parses them
+// into a channel ID + channel-specific address, resolving ambiguity.
+//
+// Format rules:
+//   "slack:C0123456789"     → { channel: "slack", to: "C0123456789" }
+//   "slack:@username"       → { channel: "slack", to: "@username" }
+//   "slack:U0123456789"     → { channel: "slack", to: "U0123456789" }
+//   "signal:+1234567890"    → { channel: "signal", to: "+1234567890" }
+//   "+1234567890"           → { channel: "signal", to: "+1234567890" }  (legacy)
+//   "group:ABCDEF"          → { channel: "signal", to: "group:ABCDEF" } (legacy)
+//   "u:handle"              → { channel: "signal", to: "u:handle" }     (legacy)
+//
+// The general pattern: "channel:address" with Signal as the default for
+// unqualified targets that match known Signal formats.
+
+import type { AgoraRegistry } from "./registry.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface ResolvedTarget {
+  /** Which channel to send through */
+  channel: string;
+  /** The channel-specific address (channel ID, phone, group ID, etc.) */
+  to: string;
+}
+
+export interface RoutingError {
+  error: string;
+}
+
+export type RoutingResult = ResolvedTarget | RoutingError;
+
+export function isRoutingError(result: RoutingResult): result is RoutingError {
+  return "error" in result;
+}
+
+// ---------------------------------------------------------------------------
+// Known channel prefixes
+// ---------------------------------------------------------------------------
+
+const CHANNEL_PREFIXES = ["slack", "signal", "discord", "matrix"] as const;
+type ChannelPrefix = (typeof CHANNEL_PREFIXES)[number];
+
+function isChannelPrefix(s: string): s is ChannelPrefix {
+  return (CHANNEL_PREFIXES as readonly string[]).includes(s);
+}
+
+// ---------------------------------------------------------------------------
+// Legacy Signal patterns (unqualified)
+// ---------------------------------------------------------------------------
+
+/** Phone number: starts with + followed by digits */
+const PHONE_RE = /^\+\d{7,15}$/;
+
+/** Signal group: group:BASE64ID */
+const SIGNAL_GROUP_RE = /^group:.+$/;
+
+/** Signal username: u:handle */
+const SIGNAL_USERNAME_RE = /^u:.+$/;
+
+function isLegacySignalTarget(target: string): boolean {
+  return PHONE_RE.test(target) || SIGNAL_GROUP_RE.test(target) || SIGNAL_USERNAME_RE.test(target);
+}
+
+// ---------------------------------------------------------------------------
+// Parse
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse a target string into a channel + address.
+ *
+ * Does NOT verify the channel is registered — that's the caller's job.
+ * This is pure parsing.
+ */
+export function parseTarget(target: string): RoutingResult {
+  const trimmed = target.trim();
+
+  if (!trimmed) {
+    return { error: "Empty target" };
+  }
+
+  // Check for explicit channel prefix: "channel:address"
+  const colonIdx = trimmed.indexOf(":");
+  if (colonIdx > 0) {
+    const prefix = trimmed.slice(0, colonIdx).toLowerCase();
+
+    // Only treat as channel prefix if it's a known channel
+    // This avoids misinterpreting "group:XYZ" or "u:handle" as channel prefixes
+    if (isChannelPrefix(prefix)) {
+      const address = trimmed.slice(colonIdx + 1);
+      if (!address) {
+        return { error: `Missing address after "${prefix}:"` };
+      }
+      return { channel: prefix, to: address };
+    }
+  }
+
+  // Legacy Signal formats (unqualified)
+  if (isLegacySignalTarget(trimmed)) {
+    return { channel: "signal", to: trimmed };
+  }
+
+  return { error: `Unknown target format: "${trimmed}". Use "channel:address" (e.g., slack:C0123, +1234567890)` };
+}
+
+// ---------------------------------------------------------------------------
+// Resolve — parse + validate channel exists
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve a target string to a channel + address, validating the channel is registered.
+ */
+export function resolveTarget(target: string, registry: AgoraRegistry): RoutingResult {
+  const parsed = parseTarget(target);
+
+  if (isRoutingError(parsed)) {
+    return parsed;
+  }
+
+  if (!registry.has(parsed.channel)) {
+    // Give a helpful error — list what IS available
+    const available = registry.list();
+    if (available.length === 0) {
+      return { error: `No channels configured. Cannot send to "${parsed.channel}".` };
+    }
+    return {
+      error: `Channel "${parsed.channel}" is not configured. Available: ${available.join(", ")}`,
+    };
+  }
+
+  return parsed;
+}

--- a/infrastructure/runtime/src/aletheia.ts
+++ b/infrastructure/runtime/src/aletheia.ts
@@ -663,27 +663,25 @@ export async function startRuntime(configPath?: string): Promise<void> {
     get watchdog() { return watchdog; },
   });
 
-  // Wire message + voice tools to agora
-  if (signalProvider.hasClients) {
-    const messageTool = createMessageTool({
-      sender: {
-        send: async (to: string, text: string) => {
-          await agora.send("signal", { to, text });
-        },
-      },
-    });
+  // Wire message tool to agora registry for multi-channel routing (Spec 34, Phase 4)
+  if (agora.size > 0) {
+    const messageTool = createMessageTool({ registry: agora });
     runtime.tools.register(messageTool);
-    log.info("Message tool registered via agora");
+    log.info(`Message tool registered via agora (channels: ${agora.list().join(", ")})`);
+  } else {
+    runtime.tools.register(createMessageTool());
+    log.warn("Message tool registered without channels — sends will fail");
+  }
 
+  // Voice reply tool — Signal-only (requires TTS + audio file delivery)
+  if (signalProvider.hasClients) {
     const voiceTool = createVoiceReplyTool({
       send: async (to: string, text: string, attachments: string[]) => {
         await agora.send("signal", { to, text, attachments });
       },
     });
     runtime.tools.register(voiceTool);
-    log.info("Voice reply tool registered via agora");
-  } else {
-    runtime.tools.register(createMessageTool());
+    log.info("Voice reply tool registered (Signal only)");
   }
 
   // --- Cron ---

--- a/infrastructure/runtime/src/organon/built-in/message.test.ts
+++ b/infrastructure/runtime/src/organon/built-in/message.test.ts
@@ -1,8 +1,39 @@
-// Message tool tests
+// Message tool tests — multi-channel routing via agora (Spec 34, Phase 4)
 import { describe, expect, it, vi } from "vitest";
 import { createMessageTool } from "./message.js";
+import { AgoraRegistry } from "../../agora/registry.js";
+import type { ChannelProvider } from "../../agora/types.js";
 
-describe("createMessageTool", () => {
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function stubProvider(id: string, sendResult = { sent: true }): ChannelProvider {
+  return {
+    id,
+    name: id,
+    capabilities: {
+      threads: false, reactions: false, typing: false,
+      media: false, streaming: false, richFormatting: false,
+      maxTextLength: 4000,
+    },
+    start: vi.fn().mockResolvedValue(undefined),
+    send: vi.fn().mockResolvedValue(sendResult),
+    stop: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+function makeRegistry(...providers: ChannelProvider[]): AgoraRegistry {
+  const registry = new AgoraRegistry();
+  for (const p of providers) registry.register(p);
+  return registry;
+}
+
+// ---------------------------------------------------------------------------
+// Legacy behavior (no registry, direct sender)
+// ---------------------------------------------------------------------------
+
+describe("createMessageTool — legacy sender", () => {
   it("has valid definition", () => {
     const tool = createMessageTool();
     expect(tool.definition.name).toBe("message");
@@ -10,13 +41,13 @@ describe("createMessageTool", () => {
     expect(tool.definition.input_schema.required).toContain("text");
   });
 
-  it("returns error when no sender configured", async () => {
+  it("returns error when no sender or registry configured", async () => {
     const tool = createMessageTool();
     const result = await tool.execute({ to: "+1234567890", text: "hello" });
-    expect(JSON.parse(result).error).toContain("Signal not connected");
+    expect(JSON.parse(result).error).toContain("No channels configured");
   });
 
-  it("sends message via sender", async () => {
+  it("sends message via legacy sender", async () => {
     const sender = { send: vi.fn().mockResolvedValue(undefined) };
     const tool = createMessageTool({ sender });
     const result = await tool.execute({ to: "+1234567890", text: "hello" });
@@ -47,5 +78,173 @@ describe("createMessageTool", () => {
     const result = await tool.execute({ to: "+1234567890", text: "this is a very long message" });
     expect(JSON.parse(result).length).toBe(10);
     expect(sender.send).toHaveBeenCalledWith("+1234567890", "this is a ");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Multi-channel routing via agora registry
+// ---------------------------------------------------------------------------
+
+describe("createMessageTool — agora routing", () => {
+  it("routes +phone to signal provider", async () => {
+    const signal = stubProvider("signal");
+    const registry = makeRegistry(signal);
+    const tool = createMessageTool({ registry });
+
+    const result = await tool.execute({ to: "+1234567890", text: "hello" });
+    const parsed = JSON.parse(result);
+
+    expect(parsed.sent).toBe(true);
+    expect(parsed.channel).toBe("signal");
+    expect(signal.send).toHaveBeenCalledWith(
+      expect.objectContaining({ to: "+1234567890", text: "hello" }),
+    );
+  });
+
+  it("routes group:ID to signal provider", async () => {
+    const signal = stubProvider("signal");
+    const registry = makeRegistry(signal);
+    const tool = createMessageTool({ registry });
+
+    const result = await tool.execute({ to: "group:ABCDEF", text: "hello" });
+    const parsed = JSON.parse(result);
+
+    expect(parsed.sent).toBe(true);
+    expect(parsed.channel).toBe("signal");
+    expect(signal.send).toHaveBeenCalledWith(
+      expect.objectContaining({ to: "group:ABCDEF" }),
+    );
+  });
+
+  it("routes slack:C0123 to slack provider", async () => {
+    const signal = stubProvider("signal");
+    const slack = stubProvider("slack");
+    const registry = makeRegistry(signal, slack);
+    const tool = createMessageTool({ registry });
+
+    const result = await tool.execute({ to: "slack:C0123456789", text: "hello from agora" });
+    const parsed = JSON.parse(result);
+
+    expect(parsed.sent).toBe(true);
+    expect(parsed.channel).toBe("slack");
+    expect(slack.send).toHaveBeenCalledWith(
+      expect.objectContaining({ to: "C0123456789", text: "hello from agora" }),
+    );
+    expect(signal.send).not.toHaveBeenCalled();
+  });
+
+  it("routes slack:@username to slack provider", async () => {
+    const slack = stubProvider("slack");
+    const registry = makeRegistry(slack);
+    const tool = createMessageTool({ registry });
+
+    const result = await tool.execute({ to: "slack:@cody", text: "hey" });
+    const parsed = JSON.parse(result);
+
+    expect(parsed.sent).toBe(true);
+    expect(parsed.channel).toBe("slack");
+    expect(slack.send).toHaveBeenCalledWith(
+      expect.objectContaining({ to: "@cody" }),
+    );
+  });
+
+  it("routes signal:+phone explicitly", async () => {
+    const signal = stubProvider("signal");
+    const slack = stubProvider("slack");
+    const registry = makeRegistry(signal, slack);
+    const tool = createMessageTool({ registry });
+
+    const result = await tool.execute({ to: "signal:+1234567890", text: "explicit" });
+    const parsed = JSON.parse(result);
+
+    expect(parsed.sent).toBe(true);
+    expect(parsed.channel).toBe("signal");
+    expect(signal.send).toHaveBeenCalled();
+    expect(slack.send).not.toHaveBeenCalled();
+  });
+
+  it("errors when target channel is not configured", async () => {
+    const signal = stubProvider("signal");
+    const registry = makeRegistry(signal);
+    const tool = createMessageTool({ registry });
+
+    const result = await tool.execute({ to: "slack:C0123", text: "hello" });
+    const parsed = JSON.parse(result);
+
+    expect(parsed.error).toContain("not configured");
+    expect(parsed.error).toContain("signal"); // shows available channels
+  });
+
+  it("errors on invalid target format", async () => {
+    const signal = stubProvider("signal");
+    const registry = makeRegistry(signal);
+    const tool = createMessageTool({ registry });
+
+    const result = await tool.execute({ to: "randomtext", text: "hello" });
+    const parsed = JSON.parse(result);
+
+    expect(parsed.error).toContain("Unknown target format");
+  });
+
+  it("handles send failure from provider", async () => {
+    const signal = stubProvider("signal", { sent: false, error: "Connection lost" } as any);
+    const registry = makeRegistry(signal);
+    const tool = createMessageTool({ registry });
+
+    const result = await tool.execute({ to: "+1234567890", text: "hello" });
+    const parsed = JSON.parse(result);
+
+    expect(parsed.error).toBe("Connection lost");
+  });
+
+  it("passes identity to send params", async () => {
+    const slack = stubProvider("slack");
+    const registry = makeRegistry(slack);
+    const identity = { name: "Syn", emoji: "🌀" };
+    const tool = createMessageTool({ registry, identity });
+
+    await tool.execute({ to: "slack:C0123", text: "hello" });
+
+    expect(slack.send).toHaveBeenCalledWith(
+      expect.objectContaining({ identity: { name: "Syn", emoji: "🌀" } }),
+    );
+  });
+
+  it("allowlist check runs before routing", async () => {
+    const slack = stubProvider("slack");
+    const registry = makeRegistry(slack);
+    const tool = createMessageTool({ registry, allowedRecipients: ["+9999"] });
+
+    const result = await tool.execute({ to: "slack:C0123", text: "hello" });
+    const parsed = JSON.parse(result);
+
+    expect(parsed.error).toContain("not in allowlist");
+    expect(slack.send).not.toHaveBeenCalled();
+  });
+
+  it("truncates before sending through registry", async () => {
+    const signal = stubProvider("signal");
+    const registry = makeRegistry(signal);
+    const tool = createMessageTool({ registry, maxLength: 5 });
+
+    const result = await tool.execute({ to: "+1234567890", text: "hello world" });
+    const parsed = JSON.parse(result);
+
+    expect(parsed.length).toBe(5);
+    expect(signal.send).toHaveBeenCalledWith(
+      expect.objectContaining({ text: "hello" }),
+    );
+  });
+
+  it("prefers registry over legacy sender", async () => {
+    const signal = stubProvider("signal");
+    const registry = makeRegistry(signal);
+    const legacySender = { send: vi.fn() };
+    const tool = createMessageTool({ registry, sender: legacySender });
+
+    await tool.execute({ to: "+1234567890", text: "hello" });
+
+    expect(signal.send).toHaveBeenCalled();
+    expect(legacySender.send).not.toHaveBeenCalled();
   });
 });

--- a/infrastructure/runtime/src/organon/built-in/message.ts
+++ b/infrastructure/runtime/src/organon/built-in/message.ts
@@ -1,20 +1,49 @@
-// Outbound message tool — sends via Signal
-import type { ToolHandler } from "../registry.js";
+// Outbound message tool — routes through agora channel abstraction (Spec 34, Phase 4)
+//
+// The message tool no longer knows about Signal directly. It parses targets,
+// resolves the channel via agora routing, and dispatches through the registry.
+//
+// Target formats:
+//   slack:C0123456789     → Slack channel
+//   slack:@username       → Slack DM (resolved by Slack provider)
+//   slack:U0123456789     → Slack DM (direct user ID)
+//   signal:+1234567890    → Signal (explicit)
+//   +1234567890           → Signal (legacy, backward compatible)
+//   group:ABCDEF          → Signal group (legacy)
+//   u:handle              → Signal username (legacy)
 
-export interface MessageSender {
-  send(to: string, text: string): Promise<void>;
-}
+import type { ToolHandler } from "../registry.js";
+import type { AgoraRegistry } from "../../agora/registry.js";
+import type { ChannelIdentity } from "../../agora/types.js";
+import { resolveTarget, isRoutingError } from "../../agora/routing.js";
 
 export interface MessageToolOpts {
-  sender?: MessageSender;
+  /** Agora registry for multi-channel routing */
+  registry?: AgoraRegistry;
+  /** Legacy sender — used when no registry is provided (backward compat) */
+  sender?: LegacySender;
+  /** Restrict sending to these recipients only */
   allowedRecipients?: string[];
+  /** Max message length (default 4000) */
   maxLength?: number;
+  /** Default identity for outbound messages */
+  identity?: ChannelIdentity;
+}
+
+export interface LegacySender {
+  send(to: string, text: string): Promise<void>;
 }
 
 const MAX_MESSAGE_LENGTH = 4000;
 
 export function createMessageTool(opts: MessageToolOpts = {}): ToolHandler {
-  const { sender, allowedRecipients, maxLength = MAX_MESSAGE_LENGTH } = opts;
+  const {
+    registry,
+    sender,
+    allowedRecipients,
+    maxLength = MAX_MESSAGE_LENGTH,
+    identity,
+  } = opts;
 
   return {
     definition: {
@@ -34,7 +63,7 @@ export function createMessageTool(opts: MessageToolOpts = {}): ToolHandler {
         "- Messages capped at 4000 chars\n" +
         "- Recipient must be in allowlist if configured",
       input_schema: {
-        type: "object",
+        type: "object" as const,
         properties: {
           to: {
             type: "string",
@@ -53,22 +82,52 @@ export function createMessageTool(opts: MessageToolOpts = {}): ToolHandler {
       const to = input["to"] as string;
       let text = input["text"] as string;
 
-      if (!sender) {
-        return JSON.stringify({ error: "Signal not connected" });
-      }
-
+      // Allowlist check (raw target, before parsing)
       if (allowedRecipients && allowedRecipients.length > 0) {
         if (!allowedRecipients.some((r) => to === r || to.includes(r))) {
           return JSON.stringify({ error: "Recipient not in allowlist" });
         }
       }
 
+      // Truncate
       if (text.length > maxLength) {
         text = text.slice(0, maxLength);
       }
 
-      await sender.send(to, text);
-      return JSON.stringify({ sent: true, to, length: text.length });
+      // Route through agora if registry is available
+      if (registry) {
+        const resolved = resolveTarget(to, registry);
+        if (isRoutingError(resolved)) {
+          return JSON.stringify({ error: resolved.error });
+        }
+
+        const sendParams: import("../../agora/types.js").ChannelSendParams = {
+          to: resolved.to,
+          text,
+        };
+        if (identity) sendParams.identity = identity;
+
+        const result = await registry.send(resolved.channel, sendParams);
+
+        if (!result.sent) {
+          return JSON.stringify({ error: result.error ?? "Send failed" });
+        }
+
+        return JSON.stringify({
+          sent: true,
+          to,
+          channel: resolved.channel,
+          length: text.length,
+        });
+      }
+
+      // Legacy path — direct sender (backward compat)
+      if (sender) {
+        await sender.send(to, text);
+        return JSON.stringify({ sent: true, to, length: text.length });
+      }
+
+      return JSON.stringify({ error: "No channels configured" });
     },
   };
 }


### PR DESCRIPTION
## Spec 34: Agora — Phase 4

**Message tool now routes through agora registry instead of hardcoded Signal.**

### New: `src/agora/routing.ts`

Target format parser + channel resolver:

| Target | Resolves To |
|--------|-------------|
| `slack:C0123456789` | Slack channel |
| `slack:@username` | Slack DM |
| `slack:U0123456789` | Slack DM (direct user ID) |
| `signal:+1234567890` | Signal (explicit) |
| `+1234567890` | Signal (legacy compat) |
| `group:ABCDEF` | Signal group (legacy compat) |
| `u:handle` | Signal username (legacy compat) |

Future-proofed: `discord:` and `matrix:` prefixes recognized in parser.

### Changed: `organon/built-in/message.ts`

- New `registry` option → routes through `resolveTarget() → registry.send()`
- Legacy `sender` preserved for backward compat
- Registry preferred over sender when both present
- Identity passthrough for agent name/emoji on outbound

### Changed: `aletheia.ts` wiring

```
// Before (Phase 3):
createMessageTool({ sender: { send: (to, text) => agora.send('signal', ...) } })

// After (Phase 4):
createMessageTool({ registry: agora })
```

Voice reply remains Signal-only (TTS + audio file delivery).

### Tests

- **24 routing tests** — target parsing, channel resolution, edge cases, registry validation
- **18 message tests** — 6 legacy + 12 agora routing (cross-channel, errors, identity, allowlist, truncation)
- **238 total tests pass** (all agora + semeion + message). Zero TS errors.

Ref: Spec 34, Phase 4