### PR TITLE
chore(specs): align specs and issues — deduplicate, promote, reindex

### DIFF
--- a/docs/specs/34_agora.md
+++ b/docs/specs/34_agora.md
@@ -1,6 +1,6 @@
 # Spec 34: Agora — Channel Abstraction and Slack Integration
 
-**Status:** In Progress (Phase 6)
+**Status:** Implemented (Phases 1–6 complete)
 **Author:** Syn
 **Date:** 2026-02-27
 **Spec:** 34

--- a/docs/specs/35_context-engineering.md
+++ b/docs/specs/35_context-engineering.md
@@ -1,4 +1,4 @@
-# Spec 31: Context Engineering
+# Spec 35: Context Engineering
 
 **Status:** Draft
 **Author:** Cody

--- a/docs/specs/36_config-taxis.md
+++ b/docs/specs/36_config-taxis.md
@@ -1,0 +1,67 @@
+# Spec 36: Config Taxis — 4-Layer Workspace Architecture + SecretRef Credential Storage
+
+**Status:** Draft
+**Origin:** Issue #267
+**Module:** `taxis`
+
+---
+
+## Problem
+
+Deployment config is scattered across 4+ locations: `~/.aletheia/`, `~/.aletheia/credentials/`, workspace directories, and tool configs. No single place to manage a deployment. Credentials are stored as plaintext files with no resolution pattern.
+
+## Design
+
+### 4-Layer Architecture
+
+Clean separation into four layers:
+
+| Layer | Location | Contains |
+|-------|----------|----------|
+| Framework | `ergon/` | Runtime, shared tools, `_example/` template |
+| Identity + workspace | `nous/` | Agent files, memory, scratch space |
+| Team work | `ergon_tools/` | DDLs, dashboards, knowledge, standards |
+| Deployment config | `deploy/` | Credentials, tool config, prosoche, bootstrap |
+
+### Agent Scratch Space
+
+```
+nous/{agent}/workspace/
+├── scripts/     # Investigation SQL, one-off queries (tracked)
+├── data/        # Sample exports, debug output (.gitignored)
+└── drafts/      # WIP before promotion to ergon_tools (tracked)
+```
+
+### Deploy Consolidation
+
+```
+deploy/
+├── aletheia.json           # Main config (from ~/.aletheia/)
+├── credentials/            # All secrets (from scattered locations)
+├── prosoche.yaml           # Attention config
+├── tools.yaml              # Tool overlay
+├── contracts/              # Agent contracts
+└── bootstrap.sh            # Replaces install.sh
+```
+
+`~/.aletheia/` becomes purely runtime state (sessions.db, logs, socket).
+
+Config resolution via `ALETHEIA_CONFIG_DIR` env var in `start.sh`.
+
+### SecretRef Credential Storage
+
+Credentials referenced by name, resolved at runtime. No plaintext secrets in main config.
+
+### Workspace Indexing
+
+`workspace-index` updated to include `workspace/` so scratch scripts surface in pre-turn recall.
+
+## Open Questions
+
+- Migration path from current scattered layout
+- Whether `deploy/` should be a separate repo or directory within monorepo
+- SecretRef resolver implementation (env vars, Vault, file-based)
+
+## Phases
+
+TBD — needs design review.

--- a/docs/specs/37_metadata-architecture.md
+++ b/docs/specs/37_metadata-architecture.md
@@ -1,0 +1,61 @@
+# Spec 37: Declarative Metadata-Driven Architecture
+
+**Status:** Draft
+**Origin:** Issue #285
+**Module:** Cross-cutting
+
+---
+
+## Goal
+
+Aletheia should be versatile with minimal maintenance friction. The mechanism: everything that *can* be config or parameter *is* config or parameter. New capabilities are added by dropping in config entries or files — not by modifying core code.
+
+## Core Principle: Declarative over Imperative
+
+**Declarative:** Describe *what* you want. The system interprets it.
+**Imperative:** Describe *how* to do it. The code executes it.
+
+Push as much behavior as possible into the declarative layer. Adding a new agent role, tool, channel, or skill should be a config entry — not a code change. Every `if (agentId === "chiron")` in core code is a failure of this principle.
+
+### Current State
+
+- ✅ Skills: convention-based loading from `shared/skills/`
+- ✅ Tool access: allow/deny config per agent
+- ✅ Config schema: Zod in `taxis/`
+- ✅ Workspace files: convention-based loading by name
+- ❌ Roles: TypeScript objects in `nous/roles/index.ts` — adding a role requires editing code
+- ❌ Providers: hardcoded in `hermeneus/` — adding a provider requires editing code
+- ❌ Sub-agent routing: conditional logic, not policy evaluation
+- ❌ Competence-based dispatch: not yet config-driven
+
+## Architectural Patterns
+
+### 1. Configuration Cascade
+
+Behavior defined at the highest applicable level, overridden only where it differs:
+
+```
+Global defaults (taxis schema defaults)
+  → Agent-level config (aletheia.json per agent)
+    → Session-level overrides (per-session params)
+      → Message-level overrides (per-turn toolFilter, model, etc.)
+```
+
+### 2. Convention-Based Discovery
+
+File presence = feature enabled. No registration step.
+
+### 3. Schema-First Validation
+
+Every config surface validated by Zod schema. Invalid config fails fast at boot.
+
+## Scope
+
+- Role definitions → ROLE.md convention files
+- Provider adapters → plugin interface (see Spec 38)
+- Sub-agent routing → policy evaluation engine
+- Competence dispatch → config-driven threshold routing
+
+## Phases
+
+TBD — needs design review. Depends on Spec 36 (Config Taxis) and Spec 38 (Provider Adapters).

--- a/docs/specs/38_provider-adapters.md
+++ b/docs/specs/38_provider-adapters.md
@@ -1,0 +1,76 @@
+# Spec 38: Provider Adapter Interface
+
+**Status:** Draft
+**Origin:** Issue #298
+**Module:** `hermeneus`
+
+---
+
+## Problem
+
+`hermeneus/router.ts` currently has Anthropic hard-wired. Adding a second provider (OpenAI, Gemini, Mistral, local Ollama) requires modifying the router directly — there is no adapter interface. This creates coupling between routing logic and provider implementation, and makes it impossible to test routing decisions without making real API calls.
+
+## Prerequisites
+
+- Provider fallback (use OpenAI if Anthropic is rate-limited)
+- Per-agent model overrides (agent A uses Claude Opus, agent B uses local Llama)
+- Cost optimization routing (use cheaper model for simple tasks)
+- Offline/local operation (Ollama for air-gapped environments)
+
+## Proposed Interface
+
+### `LLMProvider` Adapter
+
+```typescript
+export interface LLMMessage {
+  role: "user" | "assistant" | "tool_result";
+  content: string | ContentBlock[];
+}
+
+export interface LLMRequest {
+  model: string;
+  messages: LLMMessage[];
+  systemPrompt?: string;
+  tools?: ToolDefinition[];
+  maxTokens?: number;
+  temperature?: number;
+  thinkingBudget?: number;
+  stream?: boolean;
+}
+
+export interface LLMUsage {
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens?: number;
+  cacheWriteTokens?: number;
+}
+
+export interface LLMProvider {
+  name: string;
+  supportsStreaming: boolean;
+  supportsThinking: boolean;
+  supportedModels: string[];
+
+  complete(request: LLMRequest): Promise<LLMResponse>;
+  stream(request: LLMRequest): AsyncIterable<LLMStreamEvent>;
+}
+```
+
+### Provider Registry
+
+Convention-based discovery: `hermeneus/providers/{name}.ts` exports a factory function. Config maps model IDs to providers.
+
+## Phases
+
+1. Define `LLMProvider` interface + types
+2. Extract current Anthropic logic into `AnthropicProvider`
+3. Router refactor: provider resolution from config, not hardcoded
+4. OpenAI adapter (GPT-4o, o1)
+5. Ollama adapter (local models)
+6. Provider fallback chain (retry on 429/5xx with next provider)
+
+## Open Questions
+
+- Thinking budget normalization across providers (only Anthropic supports it natively)
+- Tool schema translation (Anthropic vs OpenAI function calling formats differ)
+- Streaming event normalization

--- a/docs/specs/39_autonomy-gradient.md
+++ b/docs/specs/39_autonomy-gradient.md
@@ -1,0 +1,58 @@
+# Spec 39: Dianoia Autonomy Gradient — Confidence-Gated Step Execution
+
+**Status:** Draft
+**Origin:** Issue #302
+**Module:** `dianoia`
+
+---
+
+## Problem
+
+Every Dianoia FSM transition currently requires an explicit tool call. There is no auto-advancement, no confidence threshold, no "skip confirmation on routine steps" logic. For straightforward tasks this creates unnecessary friction — the user must approve each step even when the plan is obvious.
+
+The goal is not full autonomy. It is a gradient: confirm at the right granularity based on task novelty and operator-configured trust level.
+
+## Current Behavior
+
+```
+idle → questioning   (explicit: START_QUESTIONING tool call)
+questioning → research  (explicit: confirmSynthesis tool call)
+research → roadmap   (explicit: completeRequirements tool call)
+roadmap → executing  (explicit: advanceToExecution tool call)
+executing → verifying  (explicit: advanceToVerification tool call)
+verifying → next_phase  (explicit: every phase verified individually)
+```
+
+Every arrow requires a conscious agent action. On a 10-phase project, that's 10+ explicit checkpoints.
+
+## Proposed Gradient
+
+Four autonomy levels, configurable per agent in `aletheia.json`:
+
+| Level | Name | Behavior |
+|-------|------|---------|
+| 0 | `confirm-all` | Current behavior. Every transition requires explicit confirmation. |
+| 1 | `confirm-destructive` | Auto-advance read-only phases (research, requirements, roadmap). Confirm before writing files or executing code. |
+| 2 | `confirm-novel` | Auto-advance when task type matches a previously successful pattern. Confirm when confidence < threshold. |
+| 3 | `confirm-never` | Fully autonomous. Confirm only on explicit BLOCK or error. |
+
+Default: `confirm-destructive` (level 1).
+
+## Dependencies
+
+- Competence model integration (Spec 42) for level 2 confidence scoring
+- Provider adapters (Spec 38) for cost-aware auto-advancement decisions
+
+## Phases
+
+1. Config schema: add `autonomyLevel` to agent config
+2. FSM auto-advance logic for level 1 (read-only phases skip confirmation)
+3. Competence integration for level 2 (confidence-gated)
+4. Level 3 implementation with audit trail
+5. Per-project autonomy overrides
+
+## Open Questions
+
+- Should autonomy level be per-agent, per-project, or both?
+- Rollback mechanism if auto-advanced step produces bad output
+- Notification strategy: silent auto-advance vs. "auto-approved" status messages

--- a/docs/specs/40_testing-strategy.md
+++ b/docs/specs/40_testing-strategy.md
@@ -1,0 +1,65 @@
+# Spec 40: Testing Strategy — Coverage Targets, Integration Patterns, Contract Tests
+
+**Status:** Draft
+**Origin:** Issue #297
+**Module:** Cross-cutting
+
+---
+
+## Problem
+
+Testing exists (vitest for runtime, pytest for sidecar) but there is no documented strategy: no coverage targets, no integration test patterns, no definition of what a "complete" test suite looks like. Agents writing tests have no guidance on what to test or how much is enough.
+
+## Current State
+
+| Layer | Framework | Coverage | Integration | E2E |
+|-------|-----------|----------|-------------|-----|
+| Runtime (TypeScript) | vitest | ~65% lines (est) | Some (CI job) | None |
+| UI (Svelte) | vitest + @testing-library | ~20% (est) | None | None |
+| Memory sidecar (Python) | pytest | ~40% (est) | None | None |
+| TUI (Rust) | cargo test | ~0% | None | None |
+
+## Coverage Targets (CI-enforced)
+
+| Layer | Line Coverage | Branch Coverage |
+|-------|--------------|-----------------|
+| Runtime (core modules) | ≥ 80% | ≥ 70% |
+| Runtime (overall) | ≥ 70% | ≥ 60% |
+| Memory sidecar | ≥ 75% | — |
+| UI | ≥ 50% | — |
+
+Core modules: koina, mneme, hermeneus, organon, symbolon.
+
+## Unit Test Patterns
+
+Test behavior, not implementation:
+
+```typescript
+// Good: tests observable behavior
+it("rejects expired tokens", async () => {
+  const token = createExpiredToken();
+  const result = await auth.verify(token);
+  expect(result.ok).toBe(false);
+  expect(result.error.code).toBe("TOKEN_EXPIRED");
+});
+```
+
+## Integration Test Patterns
+
+- Contract tests between runtime ↔ sidecar API
+- Session lifecycle tests (create → message → distill → resume)
+- Tool execution round-trip tests
+
+## Phases
+
+1. Baseline measurement: actual coverage numbers across all layers
+2. CI enforcement: coverage gates in GitHub Actions
+3. Integration test harness: shared fixtures, test containers
+4. Contract tests: runtime ↔ sidecar API boundary
+5. E2E smoke tests: session lifecycle through API
+
+## Open Questions
+
+- Mutation testing (Stryker) — see #280, worth the CI time?
+- Snapshot testing for UI components vs. behavioral tests
+- Test data management strategy

--- a/docs/specs/41_observability.md
+++ b/docs/specs/41_observability.md
@@ -1,0 +1,60 @@
+# Spec 41: Observability — Logs, Metrics, Traces, Alerts
+
+**Status:** Draft
+**Origin:** Issue #296
+**Module:** Cross-cutting
+
+---
+
+## Problem
+
+Currently: structured logs exist (tracing to file), no metrics, no distributed traces, no alerting. No way to answer "why was that turn slow?" or "which agent is failing most?" without manual log grep.
+
+## Three Pillars
+
+### 1. Logs (exists, needs structure)
+
+Current: `createLogger("module")` emits structured JSON to file.
+
+Gaps:
+- No log aggregation — logs live on filesystem, no cross-time search
+- No log retention policy — files grow unbounded
+- No alert on ERROR/WARN patterns
+
+Target: consistent structured fields on every log event (sessionId, turnId, agentId, model, tokens, duration, toolsUsed). Log rotation with maxSize/maxFiles.
+
+### 2. Metrics (new)
+
+Key metrics to instrument:
+- Turn latency (p50, p95, p99) by agent and model
+- Token usage by agent, model, session
+- Tool execution count and duration
+- Memory recall latency and hit rate
+- Provider error rates (429s, 5xx, timeouts)
+- Active sessions and message throughput
+
+### 3. Traces (new)
+
+Distributed tracing across turn lifecycle:
+- Pre-turn (context assembly, recall) → LLM call → tool execution → post-turn (memory, distill)
+- Langfuse SDK integration (see #277) as the trace backend
+- Span hierarchy matching the actual execution flow
+
+## Alerting
+
+- Provider error rate > threshold → credential failover notification
+- Turn latency > 60s → investigation signal
+- Memory sidecar unreachable → prosoche escalation
+
+## Phases
+
+1. Structured log standardization + rotation
+2. Langfuse SDK integration (#277)
+3. Metrics instrumentation (key counters and histograms)
+4. Alert rules and notification routing
+5. Dashboard (Langfuse UI or custom)
+
+## Dependencies
+
+- Langfuse instance deployment (self-hosted or cloud)
+- Provider adapter interface (Spec 38) for provider-level metrics

--- a/docs/specs/42_nous-team.md
+++ b/docs/specs/42_nous-team.md
@@ -1,0 +1,55 @@
+# Spec 42: Nous Team — Closing the Loop Between Primitives and Autonomous Operation
+
+**Status:** Draft
+**Origin:** Issue #260
+**Module:** Cross-cutting (dianoia, competence, mneme, reflection)
+
+---
+
+## Problem
+
+Aletheia's stated goal is a domain-specific Nous team that reduces cognitive overhead for both operator and agent, with recursive self-improvement as a measurable KPI. The infrastructure exists — sub-agent roles, melete distillation, prosoche signals, competence model, dianoia FSM, Neo4j graph, tiered recall — but these primitives are not connected into a system that operates autonomously. Every non-trivial task still requires operator direction at each handoff.
+
+## Gap 1: No Closed Feedback Loop
+
+**Current:** Competence scores exist but influence nothing at runtime. Reflection findings sit in workspace files that no system reads automatically. The loop is open.
+
+**Target:**
+- Routing uses competence: dianoia reads `competence/model.json` and weights sub-agent selection
+- Kritikos flags write back: rejection increments `corrections` for the relevant domain automatically
+- Reflection findings trigger actions: stable patterns promoted to MNEME.md automatically
+
+**Scope:** ~300 lines across 4 files, connecting things that already exist.
+
+## Gap 2: No Cross-Agent Task Handoff
+
+**Current:** Agents can message each other but there's no structured task protocol. Handoffs are informal, untracked, and lossy.
+
+**Target:**
+- `task-create` / `task-send` as first-class primitives
+- Task state machine: created → assigned → in-progress → review → done
+- Task context travels with the handoff (not reconstructed from memory)
+
+## Gap 3: No Autonomous Prioritization
+
+**Current:** Prosoche scores signals but doesn't act on them. An agent must be woken, read PROSOCHE.md, and decide what to do. No automatic "this is urgent, start now."
+
+**Target:**
+- Prosoche triggers can auto-create dianoia projects for high-urgency signals
+- Priority queue: agents process highest-scored signal first when idle
+- Operator notification for signals above threshold (not just agent wake)
+
+## Dependencies
+
+- Autonomy gradient (Spec 39) for confidence-gated auto-execution
+- Provider adapters (Spec 38) for cost-aware task routing
+- Config taxis (Spec 36) for per-agent autonomy config
+
+## Phases
+
+1. Competence-aware routing in dianoia sub-agent selection
+2. Kritikos → competence model feedback loop
+3. Reflection → MNEME.md auto-promotion
+4. Structured task handoff protocol
+5. Prosoche → dianoia auto-project creation
+6. Priority queue for idle agents

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -8,31 +8,58 @@ that evolve with the system.
 
 ## Active Specs
 
-### Draft
+### Implemented
 
-| # | Spec | Status | Scope | Notes |
-|---|------|--------|-------|-------|
-| 29 | [UI Layout & Theming](29_ui-layout-and-theming.md) | Draft | Layout overhaul, light theme | Sidebar → tab bar, agent status |
-| 30 | [Homepage Dashboard](30_homepage-dashboard.md) | Skeleton | Shared task board, overview | Cross-agent visibility |
-| 28 | [TUI](28_tui.md) | Draft | Ratatui terminal client | Thin client, SSE streaming, agent switching |
-| 25 | [Integrated IDE](25_integrated-ide.md) | Draft | File editor in web UI | Nice-to-have |
-| 27 | [Embedding Space Intelligence](27_embedding-space-intelligence.md) | Draft | Semantic space analysis, concept drift | Research-grade |
-| 22 | [Interop & Workflows](22_interop-and-workflows.md) | Draft | A2A protocol, workflow engine | A2A premature per Cody |
-| 24 | [Aletheia Linux](24_aletheia-linux.md) | Skeleton | OS + network integration | Long-term vision |
+| # | Spec | Status | Notes |
+|---|------|--------|-------|
+| 28 | [TUI](28_tui.md) | ✅ Complete | Ratatui terminal client |
+| 34 | [Agora](34_agora.md) | ✅ Phases 1–6 | Channel abstraction + Slack integration |
 
-### Priority Order
+### In Progress
 
-1. **29** UI Layout & Theming
-2. **30** Homepage Dashboard
-3. **28** TUI — terminal client
-4. **25** Integrated IDE
-5. **27** Embedding Space Intelligence
-6. **22** Interop & Workflows
-7. **24** Aletheia Linux — long-term
+| # | Spec | Status | Notes |
+|---|------|--------|-------|
+| 31 | [Dianoia](31_dianoia.md) | In Progress | Persistent multi-phase planning runtime |
+| 32 | [Dianoia v2](32_dianoia-v2.md) | In Progress | Context-engineered planning, sub-agent isolation |
+| 33 | [Gnomon Alignment](33_gnomon-alignment.md) | Draft | Module identity and naming infrastructure |
+
+### Draft — Architecture
+
+| # | Spec | Status | Notes |
+|---|------|--------|-------|
+| 35 | [Context Engineering](35_context-engineering.md) | Draft | Context window optimization |
+| 36 | [Config Taxis](36_config-taxis.md) | Draft | 4-layer workspace + SecretRef credentials |
+| 37 | [Metadata Architecture](37_metadata-architecture.md) | Draft | Declarative config-first design |
+| 38 | [Provider Adapters](38_provider-adapters.md) | Draft | Multi-provider hermeneus interface |
+| 42 | [Nous Team](42_nous-team.md) | Draft | Closing feedback loops for autonomous operation |
+
+### Draft — Execution & Quality
+
+| # | Spec | Status | Notes |
+|---|------|--------|-------|
+| 39 | [Autonomy Gradient](39_autonomy-gradient.md) | Draft | Confidence-gated dianoia step execution |
+| 40 | [Testing Strategy](40_testing-strategy.md) | Draft | Coverage targets, integration patterns |
+| 41 | [Observability](41_observability.md) | Draft | Logs, metrics, traces, alerts |
+
+### Draft — UI & Platform
+
+| # | Spec | Status | Notes |
+|---|------|--------|-------|
+| 29 | [UI Layout & Theming](29_ui-layout-and-theming.md) | Draft | Layout overhaul, light theme |
+| 30 | [Homepage Dashboard](30_homepage-dashboard.md) | Skeleton | Shared task board, overview |
+| 25 | [Integrated IDE](25_integrated-ide.md) | Draft | File editor in web UI |
+
+### Draft — Future
+
+| # | Spec | Status | Notes |
+|---|------|--------|-------|
+| 22 | [Interop & Workflows](22_interop-and-workflows.md) | Draft | A2A protocol, workflow engine |
+| 24 | [Aletheia Linux](24_aletheia-linux.md) | Skeleton | OS + network integration |
+| 27 | [Embedding Space Intelligence](27_embedding-space-intelligence.md) | Draft | JEPA principles for agents |
 
 ## Implemented (Archived)
 
-28 implemented specs consolidated into **[archive/DECISIONS.md](archive/DECISIONS.md)** (~350 lines). Organized by domain (Foundation, Turn Pipeline, Memory, Agents, Security, UI, Extensibility), preserving key decisions, rejected alternatives, and patterns that constrain future work. Code is the source of truth — the archive captures the *why*.
+28 implemented specs (01–23, 26) consolidated into **[archive/DECISIONS.md](archive/DECISIONS.md)** (~350 lines). Organized by domain (Foundation, Turn Pipeline, Memory, Agents, Security, UI, Extensibility), preserving key decisions, rejected alternatives, and patterns that constrain future work.
 
 ## Conventions
 
@@ -41,10 +68,10 @@ that evolve with the system.
 - **Format:** Problem statement → Design → Constraints → Open questions
 - Specs describe *intent and design*, not implementation. Code is the source of truth.
 - Implemented specs move to `archive/` with a note on which PR delivered them.
+- **Next available number: 43**
 
-## Adding a Spec
+## Related
 
-1. Create `NN_<topic>.md` in this directory (next available number: 33)
-2. Add it to the index above
-3. Start with Draft status
-4. PR for review when ready
+- **Open issues:** `gh issue list` — scoped implementation tasks, policy/ops docs
+- **Policy/ops issues** are labeled `policy/ops` — not specs, not feature code
+- Spec-worthy issues get promoted to spec files; the issue is closed with a link


### PR DESCRIPTION
## Spec/Issue Alignment

### Closed as duplicates (absorbed into existing specs)
- #210 → Spec 34 (Agora) — feature complete
- #233 → Spec 32 (Dianoia v2) — bugs resolved during development
- #227, #226 → Spec 33 (Gnomon Alignment) — rename work is Phase 1
- #282 → Spec 29 (UI Layout) — file browser issues addressed during overhaul

### Promoted to specs (closed issues, content preserved in spec files)
| Issue | Spec | Title |
|-------|------|-------|
| #267 | 36 | Config Taxis — 4-layer workspace + SecretRef |
| #285 | 37 | Metadata Architecture — declarative config-first |
| #298 | 38 | Provider Adapters — multi-provider hermeneus |
| #302 | 39 | Autonomy Gradient — confidence-gated dianoia |
| #297 | 40 | Testing Strategy — coverage targets + patterns |
| #296 | 41 | Observability — logs, metrics, traces, alerts |
| #260 | 42 | Nous Team — closing the feedback loop |

### Other changes
- Fixed duplicate Spec 31 numbering (Context Engineering → Spec 35)
- Updated Spec 34 status to Implemented (Phases 1–6)
- Labeled 8 policy/ops issues with new `policy/ops` label
- Rewrote specs README with full current inventory
- Next available spec number: 43