### PR TITLE
feat: per-agent params overrides + operational runbook

### DIFF
--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -1,0 +1,224 @@
+# Aletheia Operational Runbook
+
+Quick reference for starting, stopping, diagnosing, and recovering Aletheia services.
+
+## Service Architecture
+
+```
+aletheia gateway              (port 18789)  — Node.js runtime, web UI, API
+├── signal-cli daemon         (port 8080)   — Signal messaging
+├── prosoche daemon           (background)  — attention/wake system
+├── aletheia-memory sidecar   (port 8230)   — mem0 FastAPI (Python)
+│   ├── qdrant                (port 6333)   — vector store (container)
+│   └── neo4j                 (port 7474/7687) — graph store (container)
+└── cron jobs                 (in-process)  — heartbeats, scheduled tasks
+```
+
+## Quick Health Check
+
+```bash
+aletheia doctor          # connectivity, dependencies, boot persistence
+aletheia status          # agent status, sessions, cron jobs
+```
+
+## Start Procedure
+
+### 1. Verify containers are running
+
+```bash
+podman ps | grep -E "qdrant|neo4j"
+# If not running:
+podman start qdrant neo4j
+```
+
+### 2. Verify memory sidecar
+
+```bash
+curl -s http://localhost:8230/health | python3 -m json.tool
+# Expected: {"status":"ok","qdrant":"ok","neo4j":"ok","embedder":"ok"}
+#
+# If down, check: systemctl --user status aletheia-memory
+# Or start manually:
+cd /mnt/ssd/aletheia/infrastructure/memory/sidecar
+.venv/bin/uvicorn aletheia_memory.app:app --host 0.0.0.0 --port 8230 &
+```
+
+### 3. Check port is free
+
+```bash
+ss -tlnp | grep 18789
+# If occupied: find and kill the stale process
+# fuser -k 18789/tcp
+```
+
+### 4. Start gateway
+
+```bash
+aletheia gateway start
+# Or directly:
+# node /usr/local/bin/aletheia gateway start
+```
+
+### 5. Verify
+
+```bash
+sleep 3
+curl -s http://localhost:18789/api/setup/status | python3 -m json.tool
+```
+
+### 6. Start prosoche (if not running)
+
+```bash
+ps aux | grep prosoche | grep -v grep
+# If not running:
+cd /mnt/ssd/aletheia/infrastructure/prosoche
+.venv/bin/python3 -m prosoche.daemon &
+```
+
+## Stop Procedure
+
+```bash
+# Gateway
+pkill -f "aletheia gateway" || pkill -f "entry.mjs"
+
+# Prosoche
+pkill -f "prosoche.daemon"
+
+# Memory sidecar (optional — usually leave running)
+pkill -f "aletheia_memory"
+
+# Containers (optional — usually leave running)
+podman stop qdrant neo4j
+```
+
+## Deploy / Update
+
+```bash
+cd /mnt/ssd/aletheia
+
+# 1. Pull latest
+git pull origin main
+
+# 2. Build runtime
+cd infrastructure/runtime && npx tsdown
+cd ../..
+
+# 3. Build UI (if UI changes)
+cd ui && npm run build
+cd ..
+
+# 4. Restart gateway
+pkill -f "aletheia gateway"
+sleep 2
+aletheia gateway start
+```
+
+## Common Issues
+
+### EADDRINUSE on port 18789
+
+Port still held by a previous process.
+
+```bash
+fuser 18789/tcp              # find PID
+fuser -k 18789/tcp           # kill it
+sleep 2
+aletheia gateway start
+```
+
+### Memory sidecar unhealthy
+
+```bash
+curl -s http://localhost:8230/health
+# Check individual services:
+curl -s http://localhost:6333/healthz       # Qdrant
+curl -s http://localhost:7474               # Neo4j (browser)
+
+# Restart sidecar (VOYAGE_API_KEY only available in systemd service file):
+systemctl --user restart aletheia-memory
+```
+
+### Signal-cli not receiving messages
+
+```bash
+ps aux | grep signal-cli | grep -v grep
+# If not running, gateway auto-starts it. Restart gateway.
+# If running but not receiving:
+signal-cli -a +15124288605 receive --timeout 5
+```
+
+### Prosoche waking too frequently
+
+Check dedup window and fingerprint:
+
+```bash
+# View current prosoche state
+cat /mnt/ssd/aletheia/nous/syn/PROSOCHE.md
+
+# Check daemon logs
+journalctl --user -u prosoche --since "1 hour ago" 2>/dev/null || \
+  tail -50 /tmp/prosoche.log
+```
+
+### Agent not responding
+
+```bash
+# Check if session exists
+aletheia sessions
+
+# Check agent config
+aletheia doctor
+
+# Verify workspace is readable
+ls -la /mnt/ssd/aletheia/nous/<agent-id>/SOUL.md
+```
+
+### Credential / OAuth token expired
+
+Tokens expire and must be replaced manually. Check:
+
+```bash
+# Look for 401/429 in logs
+journalctl --user -u aletheia --since "1 hour ago" 2>/dev/null | grep -E "401|429|expired|unauthorized"
+
+# Config location for credentials:
+cat ~/.aletheia/aletheia.json | python3 -c "import json,sys; c=json.load(sys.stdin); [print(k) for k in c.get('models',{}).get('providers',{}).keys()]"
+```
+
+Router auto-failover handles 429/5xx across configured providers, but expired OAuth tokens need manual replacement in `~/.aletheia/aletheia.json`.
+
+### NAS SSH refused
+
+```bash
+ping -c 1 192.168.0.120     # Should succeed (NAS is up)
+ssh nas                      # Port 22 refused = SSH service disabled in Synology DSM
+# Fix: Enable SSH in DSM → Control Panel → Terminal & SNMP → Enable SSH
+```
+
+## Log Locations
+
+| Service | Log |
+|---------|-----|
+| Gateway | stdout / `journalctl --user -u aletheia` |
+| Prosoche | `/tmp/prosoche.log` or `journalctl --user -u prosoche` |
+| Memory sidecar | stdout / `journalctl --user -u aletheia-memory` |
+| Qdrant | `podman logs qdrant` |
+| Neo4j | `podman logs neo4j` |
+| Signal-cli | Gateway stdout (subprocess) |
+
+## Key Paths
+
+| Path | Purpose |
+|------|---------|
+| `~/.aletheia/aletheia.json` | Main config |
+| `~/.aletheia/sessions.db` | SQLite session store |
+| `/mnt/ssd/aletheia/` | Monorepo root |
+| `/mnt/ssd/aletheia/nous/<id>/` | Agent workspaces |
+| `/mnt/ssd/aletheia/infrastructure/runtime/` | TypeScript runtime |
+| `/mnt/ssd/aletheia/infrastructure/memory/sidecar/` | Python memory sidecar |
+| `/mnt/ssd/aletheia/infrastructure/prosoche/` | Prosoche daemon |
+| `/mnt/ssd/aletheia/ui/` | Svelte web UI |
+
+## Validation Before Restart
+
+**Always** run `aletheia doctor` before restarting. If it reports failures, fix those first — restarting with broken dependencies just adds confusion.

--- a/infrastructure/runtime/src/nous/pipeline/stages/execute.ts
+++ b/infrastructure/runtime/src/nous/pipeline/stages/execute.ts
@@ -24,6 +24,20 @@ import type {
 import { truncateToolResult } from "./truncate.js";
 import { loadPipelineConfig } from "../../pipeline-config.js";
 
+/** Resolve per-agent maxOutputTokens: agent params → global defaults. */
+function resolveMaxTokens(state: TurnState, services: RuntimeServices): number {
+  const agentMax = state.nous.params?.maxTokens;
+  if (typeof agentMax === "number" && agentMax > 0) return agentMax;
+  return services.config.agents.defaults.maxOutputTokens;
+}
+
+/** Resolve per-agent temperature: agent params → route-selected → undefined. */
+function resolveTemperature(state: TurnState): number | undefined {
+  const agentTemp = state.nous.params?.temperature;
+  if (typeof agentTemp === "number") return agentTemp;
+  return state.temperature;
+}
+
 /** Hard ceiling on tool loops per turn. Prevents infinite loops from exhausting tokens/time. */
 const MAX_TOOL_LOOPS = 200;
 
@@ -115,20 +129,26 @@ export async function* executeStreaming(
       : undefined;
     const supportsThinking = /opus|sonnet-4/i.test(model);
     const useThinking = !!(thinkingConfig?.enabled && supportsThinking);
+    // Per-agent thinking budget override
+    const agentThinkingBudget = state.nous.params?.thinkingBudget;
+    const baseThinkingBudget = (typeof agentThinkingBudget === "number" && agentThinkingBudget > 0)
+      ? agentThinkingBudget
+      : thinkingConfig?.budget ?? 10000;
 
     // Build context management — clears old tool results and thinking blocks server-side
     const contextTokens = services.config.agents.defaults.contextTokens;
     const contextManagement = buildContextManagement(contextTokens, useThinking);
 
+    const effectiveTemp = resolveTemperature(state);
     for await (const streamEvent of services.router.completeStreaming({
       model,
       system: systemPrompt,
       messages: currentMessages,
       ...(toolDefs.length > 0 ? { tools: toolDefs } : {}),
-      maxTokens: services.config.agents.defaults.maxOutputTokens,
-      ...(state.temperature !== undefined ? { temperature: state.temperature } : {}),
+      maxTokens: resolveMaxTokens(state, services),
+      ...(effectiveTemp !== undefined ? { temperature: effectiveTemp } : {}),
       ...(abortSignal ? { signal: abortSignal } : {}),
-      ...(useThinking ? { thinking: { type: "enabled" as const, budget_tokens: computeThinkingBudget(currentMessages, totalToolCalls, thinkingConfig.budget) } } : {}),
+      ...(useThinking ? { thinking: { type: "enabled" as const, budget_tokens: computeThinkingBudget(currentMessages, totalToolCalls, baseThinkingBudget) } } : {}),
       ...(contextManagement ? { contextManagement } : {}),
     })) {
       switch (streamEvent.type) {
@@ -491,13 +511,14 @@ export async function executeBuffered(
       throw new PipelineError(`Turn exceeded ${MAX_TURN_WALL_CLOCK_MS / 60000} minute wall-clock limit — halting`, { code: "PIPELINE_WALL_CLOCK" });
     }
 
+    const bufferedTemp = resolveTemperature(state);
     const llmResult = await services.router.complete({
       model,
       system: systemPrompt,
       messages: currentMessages,
       ...(toolDefs.length > 0 ? { tools: toolDefs } : {}),
-      maxTokens: services.config.agents.defaults.maxOutputTokens,
-      ...(state.temperature !== undefined ? { temperature: state.temperature } : {}),
+      maxTokens: resolveMaxTokens(state, services),
+      ...(bufferedTemp !== undefined ? { temperature: bufferedTemp } : {}),
       ...(bufferedContextMgmt ? { contextManagement: bufferedContextMgmt } : {}),
       ...(abortSignal ? { signal: abortSignal } : {}),
     });

--- a/infrastructure/runtime/src/taxis/loader.ts
+++ b/infrastructure/runtime/src/taxis/loader.ts
@@ -109,7 +109,7 @@ const KNOWN_TOP_KEYS = new Set([
 ]);
 
 const KNOWN_NOUS_KEYS = new Set([
-  "id", "default", "name", "workspace", "model", "subagents",
+  "id", "default", "name", "workspace", "model", "params", "subagents",
   "tools", "heartbeat", "identity",
 ]);
 

--- a/infrastructure/runtime/src/taxis/schema.ts
+++ b/infrastructure/runtime/src/taxis/schema.ts
@@ -84,12 +84,19 @@ const SubagentConfig = z
   })
   .default({});
 
+const NousParams = z.object({
+  maxTokens: z.number().optional(),
+  temperature: z.number().optional(),
+  thinkingBudget: z.number().optional(),
+}).passthrough();  // forward-compat: unknown keys pass through to provider
+
 const NousDefinition = z.object({
   id: z.string(),
   default: z.boolean().default(false),
   name: z.string().optional(),
   workspace: z.string(),
   model: ModelSpec.optional(),
+  params: NousParams.optional(),
   subagents: SubagentConfig.default({}),
   tools: ToolsConfig.default({}),
   heartbeat: HeartbeatConfig.optional(),


### PR DESCRIPTION
Closes #255, closes #288.

## Per-agent params overrides (#255)

Adds optional `params` field to per-agent config:

```json
{
  "id": "syn",
  "params": {
    "maxTokens": 16384,
    "temperature": 0.7,
    "thinkingBudget": 16000
  }
}
```

**Resolution order:** agent `params` → global `agents.defaults` → hardcoded fallback.

- `maxTokens` → overrides `agents.defaults.maxOutputTokens` (default 16384)
- `temperature` → overrides routing-selected temperature
- `thinkingBudget` → overrides session thinking budget for `computeThinkingBudget()`
- Schema uses `.passthrough()` — unknown keys survive for forward-compat with new provider features

Applied at both streaming and buffered execution paths in `execute.ts`.

## Operational runbook (#288)

`docs/RUNBOOK.md` — comprehensive ops reference:
- Service architecture diagram
- Start/stop/deploy procedures
- Common issues: EADDRINUSE, sidecar health, signal-cli, credentials, NAS SSH
- Log locations and key paths

## Also included

Timezone bug fix already merged to main separately (47b44409).