### PR TITLE
docs: policy documents — SECURITY.md + 5 policy specs (#286, #287, #289, #292, #293, #295)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,57 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported |
+|---------|-----------|
+| 0.x (latest minor) | ✓ |
+| 0.x (previous minor) | Bug fixes only |
+| < current - 2 minors | ✗ |
+
+## Reporting a Vulnerability
+
+**Do not open a public GitHub issue for security vulnerabilities.**
+
+Report privately via GitHub's built-in security advisory system:
+→ https://github.com/forkwright/aletheia/security/advisories/new
+
+Or email: cody.kickertz@pm.me
+
+Include:
+- Description of the vulnerability
+- Steps to reproduce
+- Potential impact
+- Any suggested fix
+
+## Response SLA
+
+| Severity | Acknowledgment | Fix Target |
+|----------|---------------|------------|
+| Critical (CVSS ≥ 9.0) | 24 hours | 7 days |
+| High (CVSS 7.0–8.9) | 48 hours | 14 days |
+| Medium (CVSS 4.0–6.9) | 5 days | 30 days |
+| Low (CVSS < 4.0) | 10 days | 90 days |
+
+## Scope
+
+**In scope:**
+- Authentication and session token handling (`symbolon/`)
+- Credential exposure in logs or API responses
+- Path traversal in plugin loader (`prostheke/`) or export (`portability/`)
+- SSRF via agent tool calls
+- Prompt injection leading to tool abuse
+- Memory data leakage between agent namespaces
+
+**Out of scope:**
+- Social engineering
+- Physical access attacks
+- Issues in dependencies (report to upstream; we'll patch promptly)
+
+## Disclosure Policy
+
+After a fix is released, we will publish a GitHub Security Advisory with:
+- CVE (requested if warranted)
+- Description
+- Affected versions
+- Fixed version
+- Credit to reporter (if desired)

--- a/docs/policy/agent-contribution.md
+++ b/docs/policy/agent-contribution.md
@@ -1,0 +1,47 @@
+# Agent Contribution Policy
+
+## Rule 1: All automated agent commits go through PRs
+
+No agent — including the GSD agent — pushes directly to main. Every automated commit opens a PR and must pass CI before merging.
+
+**Exceptions:** None. Branch protection enforces this.
+
+## Rule 2: Commit scope limits
+
+| Agent Role | Max files per commit | Max LOC per commit |
+|-----------|---------------------|-------------------|
+| Coder (sub-agent) | 10 | 500 |
+| Reviewer | 0 (review only) | 0 |
+| Orchestrator (Syn) | 20 | 1000 |
+| Dependabot | Unlimited (deps only) | Unlimited |
+
+Commits exceeding scope limits are split into multiple PRs.
+
+## Rule 3: Quality gates
+
+All agent PRs must pass:
+- [ ] TypeScript type check (`npm run typecheck`)
+- [ ] Lint (`npm run lint:check`)
+- [ ] Commit message format (`commitlint`)
+- [ ] No secrets in diff (`trufflehog`)
+
+## Rule 4: Review requirements
+
+| Change Type | Review Required |
+|-------------|----------------|
+| Runtime source | Human approval |
+| UI source | Human approval |
+| Documentation | Auto-merge after CI |
+| Dependency updates | Auto-merge if patch, human if minor/major |
+| Config/tooling | Human approval |
+
+## Rule 5: Attribution
+
+All commits use the operator's identity (`Cody Kickertz <cody.kickertz@pm.me>`). No `Co-authored-by: Claude` or agent attribution in public history. Agents are tools, not authors.
+
+## Rule 6: Branching
+
+- **Branch naming:** `<type>/<description>` (e.g., `feat/memory-pipeline`, `fix/auth-token`)
+- **One concern per branch** — no mixing features
+- **Always squash merge** — no merge commits
+- **Delete branch after merge**

--- a/docs/policy/fork-upstream.md
+++ b/docs/policy/fork-upstream.md
@@ -1,0 +1,47 @@
+# Fork/Upstream Relationship
+
+**forkwright/aletheia** (public, framework) → **CKickertz/ergon** (private, operator deployment)
+
+## Boundary
+
+### Always upstream (forkwright/aletheia)
+- Runtime source (`infrastructure/runtime/src/`)
+- UI source (`ui/src/`)
+- Memory sidecar source (`infrastructure/memory/`)
+- Shared tooling (`infrastructure/shared/`)
+- Documentation (`docs/`)
+- CI/CD workflows (`.github/`)
+- Schema definitions and migrations
+
+### Always downstream (CKickertz/ergon)
+- Agent workspaces (`nous/*/`) — SOUL.md, MEMORY.md, config overrides
+- Operator config (`aletheia.json` values — credentials, bindings, agent list)
+- Custom commands (`shared/commands/`)
+- Custom hooks (`shared/hooks/`)
+- Data directories (`data/`)
+- Deployment scripts specific to the operator's infrastructure
+
+### Gray zone — case by case
+- Plugin manifests — upstream if reusable, downstream if operator-specific
+- Spec documents — upstream (design rationale benefits all operators)
+- Test fixtures with real data — downstream (privacy)
+
+## Sync Policy
+
+1. **Downstream merges upstream regularly** (at least per minor release)
+2. **Downstream never force-pushes upstream changes** — cherry-pick or merge only
+3. **Upstream never contains operator-specific config** — use `.gitignore` patterns and config overlays
+4. **Conflicts in gray zone**: upstream wins unless operator has a documented reason
+
+## When to Upstream
+
+A change belongs upstream when:
+- It fixes a bug any operator would hit
+- It adds a capability with no operator-specific assumptions
+- It improves documentation or developer experience
+- It's a refactor with no behavioral change
+
+A change stays downstream when:
+- It references specific credentials, endpoints, or personal data
+- It's a workflow or automation specific to one operator's setup
+- It customizes agent personality or domain behavior

--- a/docs/policy/git-history.md
+++ b/docs/policy/git-history.md
@@ -1,0 +1,55 @@
+# Git History Cleanup
+
+**Status:** Plan — execute before forking to CKickertz/ergon
+
+## Problem
+
+350+ commits accumulated across multiple phases, GSD agent runs, Dependabot updates, and direct-to-main pushes. History reads like a work log, not a project narrative. Must be cleaned before the fork — all SHAs change, so this is a one-time destructive operation.
+
+## Squash Strategy
+
+Group by milestone/capability, not by date or agent.
+
+### Target Structure
+
+```
+feat: initialize aletheia runtime — Hono gateway, session store, tool registry
+feat: turn pipeline — 6-stage composable processing, error boundaries, distillation
+feat: memory system — Mem0 sidecar, distillation persistence, knowledge graph
+feat: agent architecture — sub-agents, model routing, skill learning
+feat: security — symbolon auth, token management, path validation
+feat: webchat UI — Svelte 5, markdown rendering, thinking panels
+feat: TUI — Ratatui terminal client, sessions, system overlay
+feat: Signal integration — semeion daemon, command registry, contact pairing
+feat: Slack integration — agora channel abstraction, provider pattern
+feat: planning system — dianoia FSM, file-backed state, discussion flow
+feat: IDE integration — CodeMirror editor, file tree, agent edit notifications
+feat: context engineering — cache-group bootstrap, interaction signals
+chore: CI/CD — GitHub Actions, branch protection, commitlint
+chore: documentation — specs, architecture docs, contributing guide
+```
+
+### Commit Standards Post-Cleanup
+
+- **Format:** `<type>(<scope>): <description>` — conventional commits
+- **Types:** feat, fix, refactor, chore, docs, test, perf, ci
+- **Scope:** module name (pylon, dianoia, semeion, agora, mneme, organon, etc.)
+- **Body:** What and why, not how. Reference issue/spec numbers.
+- **Each commit compiles and passes tests** — no broken intermediate states
+
+## Execution
+
+1. Create a backup branch: `git branch backup/pre-squash`
+2. Interactive rebase from root: `git rebase -i --root`
+3. Group commits by milestone, squash within groups
+4. Write professional commit messages per group
+5. Force push to main (coordinated — all operators must re-clone)
+6. Tag the result: `v0.1.0` (first clean release)
+
+## Acceptance Criteria
+
+- [ ] `git log --oneline` reads as a coherent project narrative
+- [ ] Each commit compiles independently
+- [ ] No Dependabot noise, no "fix typo" orphans
+- [ ] Backup branch preserved for archaeology
+- [ ] All operators notified and re-synced

--- a/docs/policy/staging.md
+++ b/docs/policy/staging.md
@@ -1,0 +1,54 @@
+# Staging Environment
+
+## Problem
+
+No staging environment exists. All testing happens in CI (unit/integration) or directly in production. Breaking changes to the runtime, sidecar, or UI are validated only by looking at the live agent.
+
+## Design: Single-Machine Isolation
+
+Use a second set of ports and config files on the same machine.
+
+| Resource | Production | Staging |
+|----------|-----------|---------|
+| Gateway port | 18789 | 18799 |
+| Memory sidecar port | 8230 | 8231 |
+| SQLite database | `data/aletheia.db` | `data/staging.db` |
+| Qdrant collection | `aletheia` | `aletheia_staging` |
+| Neo4j database | `neo4j` | `neo4j` (separate namespace) |
+| Config file | `aletheia.json` | `aletheia.staging.json` |
+| Workspace root | `nous/` | `nous-staging/` |
+
+## What Staging Enables
+
+- Deploy and smoke-test PRs before they touch the production agent
+- Run destructive experiments (schema migrations, memory resets) without risking live data
+- Validate the deploy checklist automatically
+- Let agents verify their own work end-to-end before requesting merge
+
+## Deployment Flow
+
+```
+PR merged to main
+  → CI passes
+  → Auto-deploy to staging (systemd unit: aletheia-staging)
+  → Smoke tests run against staging endpoints
+  → Human verifies (or auto-promote after N minutes with no errors)
+  → Deploy to production
+```
+
+## Smoke Tests
+
+Minimum staging validation before promotion:
+1. Gateway responds on `/api/health`
+2. At least one agent session can be created
+3. A turn completes successfully (tool call + response)
+4. Memory sidecar responds on `/health`
+5. No error-level log entries in first 60 seconds
+
+## Implementation
+
+1. Create `aletheia.staging.json` with staging ports/paths
+2. Create `aletheia-staging.service` systemd unit
+3. Add `npm run deploy:staging` script
+4. Add smoke test script (`scripts/smoke-test.sh`)
+5. Wire into CI as post-merge step

--- a/docs/policy/versioning.md
+++ b/docs/policy/versioning.md
@@ -1,0 +1,64 @@
+# Versioning and Breaking Change Policy
+
+## Version Scheme
+
+Semantic versioning with pre-1.0 interpretation:
+
+| Version | Meaning |
+|---------|---------|
+| `0.MINOR.PATCH` | Pre-stable. Breaking changes allowed in MINOR bumps with documented migration |
+| `1.0.0` | Stable public API. Breaking changes require MAJOR bump |
+
+**Current:** `0.1.0` (pre-stable)
+
+## What Constitutes a Breaking Change
+
+### Breaking (requires MINOR bump)
+- Removing or renaming a config key in `aletheia.json`
+- Changing database schema without automatic migration
+- Removing or renaming a tool available to agents
+- Changing API endpoint signatures (request/response shape)
+- Removing or renaming a CLI command
+- Changing the plugin/hook interface contract
+
+### Non-breaking (PATCH bump)
+- Adding new config keys with defaults
+- Adding new API endpoints
+- Adding new tools
+- Adding new database columns with defaults
+- Bug fixes
+- Performance improvements
+- Documentation changes
+
+## Migration Path
+
+Every breaking change includes:
+1. **Migration guide** in the release notes
+2. **Automated migration** where possible (schema migrations, config transformers)
+3. **Deprecation period** of at least one minor release for removals (add deprecation warning in N, remove in N+1)
+
+## Release Process
+
+1. Bump version in `package.json`
+2. Update `CHANGELOG.md` with categorized changes
+3. Tag: `git tag v0.MINOR.PATCH`
+4. GitHub Release with migration notes if breaking
+5. Notify downstream operators (ergon fork) if breaking
+
+## Changelog Format
+
+```markdown
+## [0.2.0] — 2026-MM-DD
+
+### Breaking
+- Renamed `agents.list[].pipeline` to `agents.list[].config` — run `npx aletheia migrate`
+
+### Added
+- New tool: `plan_discuss` for phase-level discussion flow
+
+### Fixed
+- Memory recall diversity regression from v0.1.3
+
+### Changed
+- Default context window reduced from 200k to 128k for cost optimization
+```


### PR DESCRIPTION
## Phase 1 Quick Wins — Policy Documents

Six policy/ops documents drafted from the issue proposals:

### SECURITY.md (repo root) — #295
GitHub auto-surfaces in Security tab. Covers: supported versions, private disclosure via GitHub advisories, response SLAs by CVSS severity, scope (symbolon auth, path traversal, SSRF, prompt injection, memory isolation).

### Fork/Upstream Policy — #286
Defines boundary between forkwright/aletheia (public framework) and CKickertz/ergon (private operator deployment). What belongs upstream vs downstream, sync policy, gray zone rules.

### Git History Cleanup — #287
Plan for squashing 350+ commits into coherent milestone-grouped history before forking. Target structure, commit standards, execution steps. Destructive operation — must happen before fork.

### Agent Contribution Policy — #289
PR requirements, commit scope limits per agent role, quality gates, review requirements by change type, attribution policy, branching conventions.

### Versioning Policy — #293
Semver with pre-1.0 interpretation. Defines what constitutes breaking vs non-breaking changes. Migration path requirements, release process, changelog format.

### Staging Environment — #292
Single-machine port isolation design. Staging ports, deployment flow, smoke test criteria, implementation steps.

---

All are first drafts based on the issue proposals. Cody reviews and adjusts before merge.

Closes #286, closes #287, closes #289, closes #292, closes #293, closes #295