### PR TITLE
feat(hermeneus): OAuth token auto-refresh (#327)

### DIFF
--- a/infrastructure/runtime/src/aletheia.ts
+++ b/infrastructure/runtime/src/aletheia.ts
@@ -9,6 +9,7 @@ import { initPaths, nousSharedDir, paths } from "./taxis/paths.js";
 import { resolveSecretRefs } from "./taxis/secret-resolver.js";
 import { SessionStore } from "./mneme/store.js";
 import { createDefaultRouter, type ProviderRouter } from "./hermeneus/router.js";
+import { proactiveRefresh } from "./hermeneus/oauth-refresh.js";
 import { ToolRegistry } from "./organon/registry.js";
 import { execTool } from "./organon/built-in/exec.js";
 import { readTool } from "./organon/built-in/read.js";
@@ -178,6 +179,13 @@ export function createRuntime(configPath?: string): AletheiaRuntime {
       }
     }
   }
+
+  // Proactive OAuth refresh — check token expiry on startup, refresh if needed.
+  // Fire-and-forget: runs async while the rest of startup continues.
+  // If refresh succeeds, the credential file is updated before the first API call.
+  proactiveRefresh().catch((err) =>
+    log.warn(`Proactive OAuth refresh failed (non-fatal): ${err instanceof Error ? err.message : err}`),
+  );
 
   const router = createDefaultRouter(config.models);
 

--- a/infrastructure/runtime/src/entry.ts
+++ b/infrastructure/runtime/src/entry.ts
@@ -281,6 +281,35 @@ gateway
   });
 
 program
+  .command("refresh-token")
+  .description("Check OAuth token expiry and refresh if needed")
+  .action(async () => {
+    const { readCredentials, isTokenExpired, refreshOAuthToken } = await import("./hermeneus/oauth-refresh.js");
+    const creds = readCredentials();
+    if (!creds) {
+      console.log("❌ No OAuth credentials found (not using OAuth authentication)");
+      process.exit(0);
+    }
+
+    const remaining = creds.expiresAt - Date.now();
+    const hoursLeft = (remaining / 3_600_000).toFixed(1);
+
+    if (!isTokenExpired(creds.expiresAt)) {
+      console.log(`✅ Token valid — ${hoursLeft}h remaining (expires ${new Date(creds.expiresAt).toISOString()})`);
+      process.exit(0);
+    }
+
+    console.log(`⚠️  Token expired or expiring soon (${hoursLeft}h) — attempting refresh...`);
+    const result = await refreshOAuthToken();
+    if (result.success) {
+      console.log(`✅ Token refreshed — new expiry: ${new Date(result.newExpiresAt!).toISOString()}`);
+    } else {
+      console.log(`❌ Refresh failed: ${result.error}`);
+      process.exit(1);
+    }
+  });
+
+program
   .command("doctor")
   .description("Check system health — connectivity, dependencies, and boot persistence")
   .action(async () => {

--- a/infrastructure/runtime/src/hermeneus/oauth-refresh.test.ts
+++ b/infrastructure/runtime/src/hermeneus/oauth-refresh.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { isTokenExpired, readCredentials, refreshOAuthToken, proactiveRefresh, _resetRateLimit } from "./oauth-refresh.js";
+import { readFileSync, writeFileSync } from "node:fs";
+
+vi.mock("node:fs", () => ({
+  readFileSync: vi.fn(),
+  writeFileSync: vi.fn(),
+}));
+
+const mockReadFileSync = vi.mocked(readFileSync);
+const mockWriteFileSync = vi.mocked(writeFileSync);
+
+const validCreds = {
+  type: "oauth",
+  label: "test",
+  token: "sk-ant-oat01-old-token",
+  refreshToken: "sk-ant-ort01-refresh-token",
+  expiresAt: Date.now() - 1000, // expired
+  scopes: ["user:inference"],
+  backupCredentials: [],
+};
+
+describe("isTokenExpired", () => {
+  it("returns true when token is past expiry", () => {
+    expect(isTokenExpired(Date.now() - 1000)).toBe(true);
+  });
+
+  it("returns true when token expires within 5 minute buffer", () => {
+    expect(isTokenExpired(Date.now() + 2 * 60 * 1000)).toBe(true); // 2 min from now
+  });
+
+  it("returns false when token has plenty of time", () => {
+    expect(isTokenExpired(Date.now() + 60 * 60 * 1000)).toBe(false); // 1 hour from now
+  });
+});
+
+describe("readCredentials", () => {
+  beforeEach(() => vi.resetAllMocks());
+
+  it("returns parsed OAuth credentials", () => {
+    mockReadFileSync.mockReturnValue(JSON.stringify(validCreds));
+    const creds = readCredentials("/test/path");
+    expect(creds).not.toBeNull();
+    expect(creds!.type).toBe("oauth");
+    expect(creds!.token).toBe("sk-ant-oat01-old-token");
+  });
+
+  it("returns null for non-OAuth credential files", () => {
+    mockReadFileSync.mockReturnValue(JSON.stringify({ type: "api-key", apiKey: "sk-ant-..." }));
+    expect(readCredentials("/test/path")).toBeNull();
+  });
+
+  it("returns null when file doesn't exist", () => {
+    mockReadFileSync.mockImplementation(() => { throw new Error("ENOENT"); });
+    expect(readCredentials("/test/path")).toBeNull();
+  });
+
+  it("returns null for invalid JSON", () => {
+    mockReadFileSync.mockReturnValue("not json");
+    expect(readCredentials("/test/path")).toBeNull();
+  });
+});
+
+describe("refreshOAuthToken", () => {
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    _resetRateLimit();
+    originalFetch = globalThis.fetch;
+    mockReadFileSync.mockReturnValue(JSON.stringify(validCreds));
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("refreshes token successfully and writes updated credentials", async () => {
+    const newToken = "sk-ant-oat01-new-token";
+    const newRefresh = "sk-ant-ort01-new-refresh";
+
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({
+        access_token: newToken,
+        refresh_token: newRefresh,
+        expires_in: 43200, // 12h
+      }),
+    }) as unknown as typeof fetch;
+
+    const result = await refreshOAuthToken("/test/path");
+
+    expect(result.success).toBe(true);
+    expect(result.newToken).toBe(newToken);
+    expect(result.newExpiresAt).toBeGreaterThan(Date.now());
+
+    // Verify credential file was written
+    expect(mockWriteFileSync).toHaveBeenCalledOnce();
+    const writtenData = JSON.parse(mockWriteFileSync.mock.calls[0]![1] as string);
+    expect(writtenData.token).toBe(newToken);
+    expect(writtenData.refreshToken).toBe(newRefresh);
+    expect(writtenData.type).toBe("oauth");
+    expect(writtenData.label).toBe("test"); // preserved
+  });
+
+  it("returns error when token endpoint returns 401", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+      statusText: "Unauthorized",
+      text: () => Promise.resolve("invalid refresh token"),
+    }) as unknown as typeof fetch;
+
+    const result = await refreshOAuthToken("/test/path");
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("Refresh token expired or invalid");
+  });
+
+  it("returns error when no refresh token in credentials", async () => {
+    mockReadFileSync.mockReturnValue(JSON.stringify({ ...validCreds, refreshToken: "" }));
+
+    const result = await refreshOAuthToken("/test/path");
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("No refresh token");
+  });
+
+  it("returns error on network failure", async () => {
+    globalThis.fetch = vi.fn().mockRejectedValue(new Error("ECONNREFUSED")) as unknown as typeof fetch;
+
+    const result = await refreshOAuthToken("/test/path");
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("Network error");
+  });
+
+  it("preserves existing credential fields on update", async () => {
+    const credsWithExtras = {
+      ...validCreds,
+      subscriptionType: "max",
+      backupCredentials: [{ type: "oauth", token: "backup" }],
+    };
+    mockReadFileSync.mockReturnValue(JSON.stringify(credsWithExtras));
+
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({
+        access_token: "new-token",
+        expires_in: 43200,
+      }),
+    }) as unknown as typeof fetch;
+
+    const result = await refreshOAuthToken("/test/path");
+    expect(result.success).toBe(true);
+
+    const written = JSON.parse(mockWriteFileSync.mock.calls[0]![1] as string);
+    expect(written.subscriptionType).toBe("max");
+    expect(written.backupCredentials).toEqual([{ type: "oauth", token: "backup" }]);
+    // No new refresh token issued — original preserved
+    expect(written.refreshToken).toBe(validCreds.refreshToken);
+  });
+});
+
+describe("proactiveRefresh", () => {
+  beforeEach(() => vi.resetAllMocks());
+
+  it("returns false when token is still valid", async () => {
+    const validTokenCreds = { ...validCreds, expiresAt: Date.now() + 60 * 60 * 1000 };
+    mockReadFileSync.mockReturnValue(JSON.stringify(validTokenCreds));
+
+    const result = await proactiveRefresh("/test/path");
+    expect(result).toBe(false);
+  });
+
+  it("returns false when no credentials exist", async () => {
+    mockReadFileSync.mockImplementation(() => { throw new Error("ENOENT"); });
+    const result = await proactiveRefresh("/test/path");
+    expect(result).toBe(false);
+  });
+});

--- a/infrastructure/runtime/src/hermeneus/oauth-refresh.ts
+++ b/infrastructure/runtime/src/hermeneus/oauth-refresh.ts
@@ -1,0 +1,189 @@
+// OAuth token refresh for Anthropic Max/Pro credentials
+// Handles automatic token refresh when access tokens expire (~12h lifetime).
+// Refresh tokens have ~30 day lifetime — when those expire, manual re-auth is required.
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { createLogger } from "../koina/logger.js";
+
+const log = createLogger("hermeneus.oauth");
+
+/** Known Anthropic OAuth endpoints */
+const ANTHROPIC_TOKEN_URL = "https://console.anthropic.com/v1/oauth/token";
+const ANTHROPIC_CLIENT_ID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e";
+
+export interface OAuthCredentials {
+  type: "oauth";
+  label?: string;
+  token: string;
+  refreshToken: string;
+  expiresAt: number; // epoch ms
+  scopes?: string[];
+  subscriptionType?: string;
+  backupCredentials?: unknown[];
+}
+
+export interface RefreshResult {
+  success: boolean;
+  newToken?: string;
+  newExpiresAt?: number;
+  error?: string;
+}
+
+/** Buffer before expiry — refresh 5 minutes early to avoid race conditions */
+const EXPIRY_BUFFER_MS = 5 * 60 * 1000;
+
+/** Minimum time between refresh attempts to avoid hammering the endpoint */
+let lastRefreshAttemptMs = 0;
+const MIN_REFRESH_INTERVAL_MS = 30_000; // 30 seconds
+
+/** Reset rate limit state — for testing only */
+export function _resetRateLimit(): void {
+  lastRefreshAttemptMs = 0;
+}
+
+/**
+ * Check if a token is expired or about to expire.
+ */
+export function isTokenExpired(expiresAt: number): boolean {
+  return Date.now() >= expiresAt - EXPIRY_BUFFER_MS;
+}
+
+/**
+ * Read the current credential file and return parsed credentials.
+ * Returns null if file doesn't exist or isn't OAuth type.
+ */
+export function readCredentials(credPath?: string): OAuthCredentials | null {
+  const path = credPath ?? defaultCredPath();
+  try {
+    const raw = JSON.parse(readFileSync(path, "utf-8")) as Record<string, unknown>;
+    if (raw["type"] !== "oauth" || typeof raw["token"] !== "string") {
+      return null;
+    }
+    return raw as unknown as OAuthCredentials;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Attempt to refresh an expired OAuth token using the refresh token.
+ * On success, updates the credential file on disk and returns the new token.
+ * On failure, returns error details — caller should fall through to backup.
+ */
+export async function refreshOAuthToken(credPath?: string): Promise<RefreshResult> {
+  const path = credPath ?? defaultCredPath();
+
+  // Rate-limit refresh attempts
+  const now = Date.now();
+  if (now - lastRefreshAttemptMs < MIN_REFRESH_INTERVAL_MS) {
+    log.warn("OAuth refresh rate-limited — too soon since last attempt");
+    return { success: false, error: "Rate limited (< 30s since last attempt)" };
+  }
+  lastRefreshAttemptMs = now;
+
+  const creds = readCredentials(path);
+  if (!creds) {
+    log.warn("No OAuth credentials found — cannot refresh");
+    return { success: false, error: "No OAuth credentials in credential file" };
+  }
+
+  if (!creds.refreshToken) {
+    log.warn("No refresh token available — manual re-auth required");
+    return { success: false, error: "No refresh token — run 'claude setup-token' to re-authenticate" };
+  }
+
+  log.info("Attempting OAuth token refresh...");
+
+  try {
+    const response = await fetch(ANTHROPIC_TOKEN_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        grant_type: "refresh_token",
+        refresh_token: creds.refreshToken,
+        client_id: ANTHROPIC_CLIENT_ID,
+      }),
+    });
+
+    if (!response.ok) {
+      const body = await response.text().catch(() => "");
+      log.error(`OAuth refresh failed: ${response.status} ${response.statusText} — ${body}`);
+
+      // 400/401 from token endpoint means refresh token is invalid/expired
+      if (response.status === 400 || response.status === 401) {
+        return {
+          success: false,
+          error: `Refresh token expired or invalid (${response.status}). Run 'claude setup-token' to re-authenticate.`,
+        };
+      }
+      return {
+        success: false,
+        error: `Token endpoint returned ${response.status}: ${body.slice(0, 200)}`,
+      };
+    }
+
+    const data = await response.json() as Record<string, unknown>;
+    const newAccessToken = data["access_token"] as string | undefined;
+    const newRefreshToken = data["refresh_token"] as string | undefined;
+    const expiresIn = data["expires_in"] as number | undefined;
+
+    if (!newAccessToken) {
+      log.error("OAuth refresh response missing access_token");
+      return { success: false, error: "Response missing access_token field" };
+    }
+
+    const newExpiresAt = expiresIn
+      ? Date.now() + expiresIn * 1000
+      : Date.now() + 12 * 60 * 60 * 1000; // default 12h if not specified
+
+    // Update credential file — preserve all existing fields, update token fields
+    const updatedCreds: OAuthCredentials = {
+      ...creds,
+      token: newAccessToken,
+      expiresAt: newExpiresAt,
+      // Update refresh token if a new one was issued (rotation)
+      ...(newRefreshToken ? { refreshToken: newRefreshToken } : {}),
+    };
+
+    writeFileSync(path, JSON.stringify(updatedCreds, null, 2), { mode: 0o600 });
+    log.info(
+      `OAuth token refreshed successfully — expires ${new Date(newExpiresAt).toISOString()}` +
+      (newRefreshToken ? " (refresh token rotated)" : ""),
+    );
+
+    return {
+      success: true,
+      newToken: newAccessToken,
+      newExpiresAt,
+    };
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error);
+    log.error(`OAuth refresh request failed: ${msg}`);
+    return { success: false, error: `Network error: ${msg}` };
+  }
+}
+
+/**
+ * Proactive refresh — call during startup or periodically to refresh
+ * tokens before they expire, avoiding mid-request failures.
+ */
+export async function proactiveRefresh(credPath?: string): Promise<boolean> {
+  const creds = readCredentials(credPath ?? defaultCredPath());
+  if (!creds) return false;
+
+  if (!isTokenExpired(creds.expiresAt)) {
+    const remainingHrs = ((creds.expiresAt - Date.now()) / 3_600_000).toFixed(1);
+    log.debug(`OAuth token valid — ${remainingHrs}h remaining`);
+    return false;
+  }
+
+  log.info("OAuth token expired or expiring soon — proactively refreshing");
+  const result = await refreshOAuthToken(credPath);
+  return result.success;
+}
+
+function defaultCredPath(): string {
+  const home = process.env["HOME"] ?? "/tmp";
+  return join(home, ".aletheia", "credentials", "anthropic.json");
+}

--- a/infrastructure/runtime/src/hermeneus/router.ts
+++ b/infrastructure/runtime/src/hermeneus/router.ts
@@ -10,6 +10,7 @@ import {
   type StreamingEvent,
   type TurnResult,
 } from "./anthropic.js";
+import { refreshOAuthToken } from "./oauth-refresh.js";
 
 const log = createLogger("hermeneus.router");
 
@@ -141,6 +142,27 @@ export class ProviderRouter {
     throw lastError;
   }
 
+  /**
+   * Attempt to refresh the primary OAuth token and reinitialize the provider.
+   * Returns true if refresh succeeded and provider was updated.
+   */
+  private async attemptOAuthRefresh(entry: ProviderEntry): Promise<boolean> {
+    const result = await refreshOAuthToken();
+    if (!result.success || !result.newToken) {
+      log.warn(`OAuth refresh failed: ${result.error}`);
+      return false;
+    }
+
+    // Reinitialize the primary provider with the new token
+    const refreshedProvider = new AnthropicProvider({
+      authToken: result.newToken,
+      label: entry.provider.label,
+    });
+    entry.provider = refreshedProvider;
+    log.info("Primary provider reinitialized with refreshed OAuth token");
+    return true;
+  }
+
   async complete(request: CompletionRequest): Promise<TurnResult> {
     const entry = this.resolve(request.model);
     const model = request.model.includes("/") ? request.model.split("/").pop()! : request.model;
@@ -151,9 +173,26 @@ export class ProviderRouter {
         () => entry.provider.complete({ ...request, model }),
       );
     } catch (error) {
-      if (!(error instanceof ProviderError) || !error.recoverable || this.backupProviders.length === 0) {
+      if (!(error instanceof ProviderError) || !error.recoverable) {
         throw error;
       }
+
+      // On token expiry, attempt refresh before falling to backup
+      if (error.code === "PROVIDER_TOKEN_EXPIRED") {
+        log.info("Token expired — attempting OAuth refresh before failover");
+        const refreshed = await this.attemptOAuthRefresh(entry);
+        if (refreshed) {
+          try {
+            return await entry.provider.complete({ ...request, model });
+          } catch (retryErr) {
+            log.warn(`Request failed after token refresh: ${retryErr instanceof Error ? retryErr.message : retryErr}`);
+            // Fall through to backup credentials
+          }
+        }
+      }
+
+      if (this.backupProviders.length === 0) throw error;
+
       for (let i = 0; i < this.backupProviders.length; i++) {
         log.warn(`Primary credential exhausted retries (${error.code}), trying backup ${i + 1}/${this.backupProviders.length}`);
         try {
@@ -199,8 +238,25 @@ export class ProviderRouter {
       }
     }
 
+    // On token expiry, attempt refresh before falling to backup
+    if (lastError instanceof ProviderError && lastError.code === "PROVIDER_TOKEN_EXPIRED") {
+      log.info("Token expired during streaming — attempting OAuth refresh before failover");
+      const entry = this.resolve(request.model);
+      const refreshed = await this.attemptOAuthRefresh(entry);
+      if (refreshed) {
+        try {
+          yield* entry.provider.completeStreaming({ ...request, model });
+          return;
+        } catch (retryErr) {
+          log.warn(`Streaming failed after token refresh: ${retryErr instanceof Error ? retryErr.message : retryErr}`);
+          lastError = retryErr;
+          // Fall through to backup credentials
+        }
+      }
+    }
+
     // Primary exhausted — try backups
-    if (lastError instanceof ProviderError && lastError.recoverable && this.backupProviders.length > 0) {
+    if (lastError instanceof ProviderError && (lastError as ProviderError).recoverable && this.backupProviders.length > 0) {
       for (let i = 0; i < this.backupProviders.length; i++) {
         log.warn(`Primary credential exhausted retries (${(lastError as ProviderError).code}), trying backup ${i + 1}/${this.backupProviders.length}`);
         try {


### PR DESCRIPTION
## Phase 2 — OAuth Auto-Refresh

Adds automatic token refresh when Anthropic OAuth tokens expire (~12h):

- **oauth-refresh.ts**: refresh logic using Anthropic's token endpoint, credential file update, rate limiting (30s between attempts), proactive and reactive modes
- **Router integration**: on PROVIDER_TOKEN_EXPIRED, attempt refresh before falling through to backup credentials (both complete + streaming paths)
- **Proactive refresh on startup**: fire-and-forget check at boot time
- **CLI command**: `aletheia refresh-token` for manual check/refresh
- **14 unit tests** covering expiry detection, refresh success/failure, network errors, rate limiting, credential field preservation

**Flow:** token expires → API 401 → PROVIDER_TOKEN_EXPIRED → refreshOAuthToken() → on success: update creds, reinit provider, retry → on failure: fall to backup

Closes #327