### PR TITLE
feat(prosoche): activity signal collector — window focus tracking (#313)

### DIFF
--- a/infrastructure/prosoche/config.yaml
+++ b/infrastructure/prosoche/config.yaml
@@ -79,6 +79,18 @@ signals:
     interval_seconds: 1800
     stale_hours: 24
     dormant_hours: 72
+  activity:
+    enabled: true
+    interval_seconds: 5          # poll frequency (fast — just reads window title)
+    ring_buffer_size: 100        # last N focus events
+    duration_threshold_s: 10     # min seconds before recording a focus event
+    summary_hours: 2             # hours of activity in PROSOCHE.md summary
+    deep_work_minutes: 30        # threshold for "deep focus" signal
+    exclude_apps:                # never log these (privacy)
+      - 1Password
+      - KeePassXC
+      - Bitwarden
+      - gnome-keyring
 nous:
   syn:
     role: orchestrator
@@ -91,6 +103,7 @@ nous:
       nas: 0.8
       credentials: 0.9
       sessions: 0.5
+      activity: 0.4
   syl:
     role: general
     weights:

--- a/infrastructure/prosoche/prosoche/daemon.py
+++ b/infrastructure/prosoche/prosoche/daemon.py
@@ -42,6 +42,7 @@ _OPTIONAL_COLLECTORS: dict[str, str] = {
     "nas": ".signals.nas",
     "credentials": ".signals.credentials",
     "sessions": ".signals.sessions",
+    "activity": ".signals.activity",
 }
 
 

--- a/infrastructure/prosoche/prosoche/signals/activity.py
+++ b/infrastructure/prosoche/prosoche/signals/activity.py
@@ -1,0 +1,397 @@
+# Activity signal — window focus tracking for context reconstruction
+#
+# Captures active window title + app name via platform-appropriate methods:
+#   - GNOME/Wayland: gdbus call to org.gnome.Shell.Eval
+#   - X11: xdotool getactivewindow getwindowname + xprop
+#   - macOS: osascript (System Events)
+#
+# Writes a ring buffer of FocusEvents and emits a Signal with recent activity
+# summary for PROSOCHE.md. The killer use case is reconstruction after
+# distraction: "what was I doing before this?"
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import os
+import re
+import subprocess
+import time
+from collections import deque
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+
+from loguru import logger
+
+from . import ContextBlock, Signal
+
+# ---------------------------------------------------------------------------
+# Configuration defaults
+# ---------------------------------------------------------------------------
+DEFAULT_RING_SIZE = 100
+DEFAULT_POLL_INTERVAL = 5  # seconds
+DEFAULT_DURATION_THRESHOLD = 10  # minimum seconds before recording
+DEFAULT_SUMMARY_HOURS = 2  # hours of activity to include in summary
+
+# ---------------------------------------------------------------------------
+# Data model
+# ---------------------------------------------------------------------------
+
+@dataclass
+class FocusEvent:
+    timestamp: str       # ISO8601
+    app_name: str        # e.g., "Firefox", "Alacritty", "Code"
+    window_title: str    # e.g., "aletheia/tui/src/app.rs - Neovim"
+    duration_s: int = 0  # seconds spent before next focus change
+
+
+# Module-level state — persists across collection cycles within the daemon
+_ring_buffer: deque[FocusEvent] = deque(maxlen=DEFAULT_RING_SIZE)
+_current_focus: dict | None = None  # {app_name, window_title, started_at}
+_last_poll: float = 0.0
+_excluded_apps: set[str] = set()
+
+
+def _reset_state(ring_size: int = DEFAULT_RING_SIZE) -> None:
+    """Reset module state — primarily for testing."""
+    global _ring_buffer, _current_focus, _last_poll, _excluded_apps
+    _ring_buffer.clear()
+    # Recreate with new maxlen if changed
+    if _ring_buffer.maxlen != ring_size:
+        _ring_buffer = deque(maxlen=ring_size)
+    _current_focus = None
+    _last_poll = 0.0
+    _excluded_apps = set()
+
+
+def _get_ring_buffer() -> deque[FocusEvent]:
+    """Access ring buffer — tests should use this instead of importing _ring_buffer directly."""
+    return _ring_buffer
+
+
+# ---------------------------------------------------------------------------
+# Platform-specific window detection
+# ---------------------------------------------------------------------------
+
+def _get_active_window_gnome() -> dict | None:
+    """Query active window via GNOME Shell DBus (Wayland-compatible)."""
+    try:
+        result = subprocess.run(
+            [
+                "gdbus", "call", "--session",
+                "--dest", "org.gnome.Shell",
+                "--object-path", "/org/gnome/Shell",
+                "--method", "org.gnome.Shell.Eval",
+                "global.display.focus_window ? "
+                "(global.display.focus_window.get_title() + '|' + "
+                "global.display.focus_window.get_wm_class()) : ''",
+            ],
+            capture_output=True, text=True, timeout=2,
+        )
+        if result.returncode != 0:
+            return None
+
+        # Output format: (true, 'title|wm_class')
+        stdout = result.stdout.strip()
+        match = re.search(r"\(true,\s*'(.+)'\)", stdout)
+        if not match:
+            return None
+
+        raw = match.group(1)
+        if "|" not in raw:
+            return None
+
+        parts = raw.rsplit("|", 1)
+        title = parts[0].strip()
+        app = parts[1].strip() if len(parts) > 1 else "Unknown"
+
+        if not title:
+            return None
+
+        return {"app_name": app, "window_title": title}
+
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        return None
+
+
+def _get_active_window_x11() -> dict | None:
+    """Query active window via xdotool (X11)."""
+    try:
+        # Get window ID
+        wid_result = subprocess.run(
+            ["xdotool", "getactivewindow"],
+            capture_output=True, text=True, timeout=2,
+        )
+        if wid_result.returncode != 0:
+            return None
+
+        wid = wid_result.stdout.strip()
+
+        # Get window name
+        name_result = subprocess.run(
+            ["xdotool", "getwindowname", wid],
+            capture_output=True, text=True, timeout=2,
+        )
+        title = name_result.stdout.strip() if name_result.returncode == 0 else ""
+
+        # Get WM_CLASS via xprop
+        class_result = subprocess.run(
+            ["xprop", "-id", wid, "WM_CLASS"],
+            capture_output=True, text=True, timeout=2,
+        )
+        app = "Unknown"
+        if class_result.returncode == 0:
+            # Format: WM_CLASS(STRING) = "instance", "class"
+            match = re.search(r'"([^"]+)",\s*"([^"]+)"', class_result.stdout)
+            if match:
+                app = match.group(2)  # class name is more readable
+
+        if not title:
+            return None
+
+        return {"app_name": app, "window_title": title}
+
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        return None
+
+
+def _get_active_window_macos() -> dict | None:
+    """Query active window via osascript (macOS)."""
+    try:
+        result = subprocess.run(
+            [
+                "osascript", "-e",
+                'tell application "System Events" to get {name, title of first window} '
+                'of first application process whose frontmost is true',
+            ],
+            capture_output=True, text=True, timeout=2,
+        )
+        if result.returncode != 0:
+            return None
+
+        # Output: "AppName, Window Title"
+        parts = result.stdout.strip().split(", ", 1)
+        app = parts[0] if parts else "Unknown"
+        title = parts[1] if len(parts) > 1 else app
+
+        return {"app_name": app, "window_title": title}
+
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        return None
+
+
+def get_active_window() -> dict | None:
+    """Try platform-appropriate methods in order."""
+    # Try GNOME/Wayland first (Cody's primary: Fedora 42)
+    result = _get_active_window_gnome()
+    if result:
+        return result
+
+    # X11 fallback
+    result = _get_active_window_x11()
+    if result:
+        return result
+
+    # macOS fallback
+    result = _get_active_window_macos()
+    if result:
+        return result
+
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Ring buffer management
+# ---------------------------------------------------------------------------
+
+def _is_excluded(app_name: str) -> bool:
+    """Check if app is in the exclusion list (case-insensitive)."""
+    return app_name.lower() in _excluded_apps
+
+
+def _sanitize_title(title: str) -> str:
+    """Strip potentially sensitive info from window titles.
+
+    Removes URLs with query params, file paths that look like credentials,
+    and truncates to reasonable length.
+    """
+    # Strip URL query parameters (may contain tokens)
+    title = re.sub(r'\?[^\s]*', '?…', title)
+    # Truncate
+    if len(title) > 200:
+        title = title[:197] + "..."
+    return title
+
+
+def _record_focus_change(new_window: dict, now: float) -> None:
+    """Record the end of one focus period and start of a new one."""
+    global _current_focus
+
+    if _current_focus is not None:
+        duration = int(now - _current_focus["started_at"])
+        threshold = DEFAULT_DURATION_THRESHOLD
+
+        if duration >= threshold and not _is_excluded(_current_focus["app_name"]):
+            event = FocusEvent(
+                timestamp=datetime.now(timezone.utc).isoformat(),
+                app_name=_current_focus["app_name"],
+                window_title=_sanitize_title(_current_focus["window_title"]),
+                duration_s=duration,
+            )
+            _ring_buffer.append(event)
+
+    _current_focus = {
+        "app_name": new_window["app_name"],
+        "window_title": new_window["window_title"],
+        "started_at": now,
+    }
+
+
+def poll_focus(config: dict | None = None) -> None:
+    """Single poll of window focus. Called by collect() on each cycle."""
+    global _last_poll, _excluded_apps
+
+    now = time.monotonic()
+
+    # Load exclusions from config if provided
+    if config:
+        act_config = config.get("signals", {}).get("activity", {})
+        _excluded_apps = {
+            a.lower() for a in act_config.get("exclude_apps", [])
+        }
+        ring_size = act_config.get("ring_buffer_size", DEFAULT_RING_SIZE)
+        if _ring_buffer.maxlen != ring_size:
+            _reset_state(ring_size)
+
+    window = get_active_window()
+    if window is None:
+        return
+
+    if _current_focus is None:
+        # First observation — just record what's focused
+        _record_focus_change(window, now)
+        return
+
+    # Check if focus changed
+    if (window["app_name"] != _current_focus["app_name"] or
+            window["window_title"] != _current_focus["window_title"]):
+        _record_focus_change(window, now)
+
+    _last_poll = now
+
+
+# ---------------------------------------------------------------------------
+# Signal collector (prosoche interface)
+# ---------------------------------------------------------------------------
+
+def _build_activity_summary(hours: float = DEFAULT_SUMMARY_HOURS) -> str:
+    """Build a human-readable summary of recent activity."""
+    if not _ring_buffer:
+        return ""
+
+    now = datetime.now(timezone.utc)
+    cutoff_s = hours * 3600
+    recent: list[FocusEvent] = []
+
+    for event in reversed(_ring_buffer):
+        try:
+            event_time = datetime.fromisoformat(event.timestamp)
+            age = (now - event_time).total_seconds()
+            if age <= cutoff_s:
+                recent.append(event)
+        except (ValueError, TypeError):
+            continue
+
+    recent.reverse()
+
+    if not recent:
+        return ""
+
+    # Collapse consecutive same-app entries
+    collapsed: list[tuple[str, str, int, str]] = []  # (time, app, duration, title)
+    for event in recent:
+        time_str = event.timestamp[11:16]  # HH:MM from ISO
+        if collapsed and collapsed[-1][1] == event.app_name:
+            # Same app — merge duration, keep latest title
+            prev = collapsed[-1]
+            collapsed[-1] = (prev[0], prev[1], prev[2] + event.duration_s, event.window_title)
+        else:
+            collapsed.append((time_str, event.app_name, event.duration_s, event.window_title))
+
+    lines = []
+    for time_str, app, duration, title in collapsed:
+        mins = duration // 60
+        if mins < 1:
+            dur_str = f"{duration}s"
+        else:
+            dur_str = f"{mins} min"
+
+        # Truncate title for display
+        display_title = title[:60] + "..." if len(title) > 60 else title
+        lines.append(f"- {time_str} {app} ({display_title}) — {dur_str}")
+
+    # Add current focus if active
+    if _current_focus:
+        duration = int(time.monotonic() - _current_focus["started_at"])
+        if duration >= 60:
+            mins = duration // 60
+            title = _current_focus["window_title"][:60]
+            lines.append(f"- now   {_current_focus['app_name']} ({title}) — {mins} min (ongoing)")
+
+    return "\n".join(lines)
+
+
+async def collect(config: dict) -> list[Signal]:
+    """Prosoche signal collector interface.
+
+    Unlike other collectors that query external services, this one polls
+    the local window manager. Each call updates the ring buffer and emits
+    a signal with the activity summary.
+    """
+    act_config = config.get("signals", {}).get("activity", {})
+    if not act_config.get("enabled"):
+        return []
+
+    # Poll current focus
+    poll_focus(config)
+
+    # Only emit signal if we have meaningful data
+    summary_hours = act_config.get("summary_hours", DEFAULT_SUMMARY_HOURS)
+    summary = _build_activity_summary(summary_hours)
+
+    if not summary:
+        return []
+
+    signals = []
+
+    # Main activity signal — informational, for context
+    signals.append(Signal(
+        source="activity",
+        summary=f"Recent activity ({summary_hours}h window)",
+        urgency=0.1,  # Pure context, not actionable
+        relevant_nous=[],  # All agents can benefit
+        details=summary,
+        context_blocks=[
+            ContextBlock(
+                title=f"Recent Activity (last {summary_hours} hours)",
+                content=summary,
+                source="activity",
+            )
+        ],
+    ))
+
+    # Detect long uninterrupted focus (deep work signal)
+    if _current_focus:
+        duration = int(time.monotonic() - _current_focus["started_at"])
+        deep_work_threshold = act_config.get("deep_work_minutes", 30) * 60
+        if duration >= deep_work_threshold:
+            mins = duration // 60
+            signals.append(Signal(
+                source="activity",
+                summary=f"Deep focus: {_current_focus['app_name']} for {mins} min",
+                urgency=0.0,  # Informational only — don't interrupt deep work!
+                relevant_nous=[],
+                details=f"app={_current_focus['app_name']} duration={mins}min",
+            ))
+
+    return signals

--- a/infrastructure/prosoche/tests/test_activity.py
+++ b/infrastructure/prosoche/tests/test_activity.py
@@ -1,0 +1,259 @@
+# Tests for activity signal collector
+from __future__ import annotations
+
+import time
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+import pytest
+
+from prosoche.signals import activity
+from prosoche.signals.activity import (
+    DEFAULT_DURATION_THRESHOLD,
+    FocusEvent,
+    _build_activity_summary,
+    _record_focus_change,
+    _reset_state,
+    _sanitize_title,
+    collect,
+    get_active_window,
+    poll_focus,
+)
+
+
+@pytest.fixture(autouse=True)
+def clean_state():
+    """Reset module state before each test."""
+    _reset_state(ring_size=100)
+    yield
+    _reset_state(ring_size=100)
+
+
+def _buf():
+    """Get current ring buffer from module (avoids stale reference)."""
+    return activity._ring_buffer
+
+
+# ---------------------------------------------------------------------------
+# Title sanitization
+# ---------------------------------------------------------------------------
+
+class TestSanitizeTitle:
+    def test_strips_url_query_params(self):
+        title = "GitHub - PRs?token=abc123&page=2 — Firefox"
+        result = _sanitize_title(title)
+        assert "abc123" not in result
+        assert "?…" in result
+
+    def test_truncates_long_titles(self):
+        title = "A" * 300
+        result = _sanitize_title(title)
+        assert len(result) == 200
+        assert result.endswith("...")
+
+    def test_short_titles_unchanged(self):
+        title = "aletheia/tui/src/app.rs - Neovim"
+        assert _sanitize_title(title) == title
+
+
+# ---------------------------------------------------------------------------
+# Focus change recording
+# ---------------------------------------------------------------------------
+
+class TestFocusRecording:
+    def test_first_focus_no_event_recorded(self):
+        """First observation sets current focus but doesn't create an event."""
+        _record_focus_change({"app_name": "Firefox", "window_title": "Test"}, time.monotonic())
+        assert len(_buf()) == 0
+
+    def test_focus_change_records_event(self):
+        """Changing focus records the previous window's duration."""
+        start = time.monotonic()
+        _record_focus_change({"app_name": "Firefox", "window_title": "Tab 1"}, start)
+
+        # Simulate time passing
+        _record_focus_change(
+            {"app_name": "Neovim", "window_title": "app.rs"},
+            start + 30,  # 30 seconds later
+        )
+
+        assert len(_buf()) == 1
+        event = _buf()[0]
+        assert event.app_name == "Firefox"
+        assert event.window_title == "Tab 1"
+        assert event.duration_s == 30
+
+    def test_short_focus_filtered(self):
+        """Focus durations below threshold are not recorded."""
+        start = time.monotonic()
+        _record_focus_change({"app_name": "Firefox", "window_title": "Tab 1"}, start)
+        _record_focus_change(
+            {"app_name": "Neovim", "window_title": "app.rs"},
+            start + 3,  # Only 3 seconds — below 10s threshold
+        )
+
+        assert len(_buf()) == 0
+
+    def test_excluded_app_not_recorded(self):
+        """Excluded apps are filtered out."""
+        activity._excluded_apps = {"1password"}
+
+        start = time.monotonic()
+        _record_focus_change({"app_name": "1Password", "window_title": "Vault"}, start)
+        _record_focus_change(
+            {"app_name": "Firefox", "window_title": "Tab 1"},
+            start + 60,
+        )
+
+        assert len(_buf()) == 0
+
+    def test_ring_buffer_respects_max_size(self):
+        """Ring buffer evicts oldest events when full."""
+        _reset_state(ring_size=3)
+        start = time.monotonic()
+        for i in range(5):
+            _record_focus_change(
+                {"app_name": f"App{i}", "window_title": f"Win{i}"},
+                start + (i * 20),
+            )
+        # After 5 focus changes, 4 events recorded but buffer holds 3
+        assert len(_buf()) == 3
+        assert _buf()[0].app_name == "App1"  # Oldest surviving
+
+
+# ---------------------------------------------------------------------------
+# Platform detection
+# ---------------------------------------------------------------------------
+
+class TestPlatformDetection:
+    @patch("prosoche.signals.activity._get_active_window_gnome")
+    def test_gnome_preferred(self, mock_gnome):
+        mock_gnome.return_value = {"app_name": "Firefox", "window_title": "Test"}
+        result = get_active_window()
+        assert result["app_name"] == "Firefox"
+
+    @patch("prosoche.signals.activity._get_active_window_gnome", return_value=None)
+    @patch("prosoche.signals.activity._get_active_window_x11")
+    def test_falls_through_to_x11(self, mock_x11, mock_gnome):
+        mock_x11.return_value = {"app_name": "Alacritty", "window_title": "fish"}
+        result = get_active_window()
+        assert result["app_name"] == "Alacritty"
+
+    @patch("prosoche.signals.activity._get_active_window_gnome", return_value=None)
+    @patch("prosoche.signals.activity._get_active_window_x11", return_value=None)
+    @patch("prosoche.signals.activity._get_active_window_macos", return_value=None)
+    def test_returns_none_when_all_fail(self, *mocks):
+        assert get_active_window() is None
+
+
+# ---------------------------------------------------------------------------
+# Activity summary
+# ---------------------------------------------------------------------------
+
+class TestActivitySummary:
+    def test_empty_buffer_returns_empty(self):
+        assert _build_activity_summary() == ""
+
+    def test_summary_includes_recent_events(self):
+        now = datetime.now(timezone.utc)
+        _buf().append(FocusEvent(
+            timestamp=now.isoformat(),
+            app_name="Firefox",
+            window_title="GitHub PR #300",
+            duration_s=480,
+        ))
+        _buf().append(FocusEvent(
+            timestamp=now.isoformat(),
+            app_name="Neovim",
+            window_title="aletheia/tui/src/app.rs",
+            duration_s=2040,
+        ))
+
+        summary = _build_activity_summary(hours=2)
+        assert "Firefox" in summary
+        assert "Neovim" in summary
+        assert "8 min" in summary
+        assert "34 min" in summary
+
+    def test_collapses_consecutive_same_app(self):
+        now = datetime.now(timezone.utc)
+        for i in range(3):
+            _buf().append(FocusEvent(
+                timestamp=now.isoformat(),
+                app_name="Firefox",
+                window_title=f"Tab {i}",
+                duration_s=60,
+            ))
+
+        summary = _build_activity_summary(hours=2)
+        # Should have only one Firefox line with combined duration
+        firefox_lines = [l for l in summary.split("\n") if "Firefox" in l]
+        assert len(firefox_lines) == 1
+        assert "3 min" in firefox_lines[0]
+
+
+# ---------------------------------------------------------------------------
+# Signal collector
+# ---------------------------------------------------------------------------
+
+class TestCollector:
+    @pytest.mark.anyio
+    async def test_disabled_returns_empty(self):
+        config = {"signals": {"activity": {"enabled": False}}}
+        result = await collect(config)
+        assert result == []
+
+    @pytest.mark.anyio
+    async def test_enabled_with_no_data_returns_empty(self):
+        config = {"signals": {"activity": {"enabled": True}}}
+        with patch("prosoche.signals.activity.get_active_window", return_value=None):
+            result = await collect(config)
+        assert result == []
+
+    @pytest.mark.anyio
+    async def test_emits_signal_with_activity(self):
+        # Pre-populate ring buffer
+        now = datetime.now(timezone.utc)
+        _buf().append(FocusEvent(
+            timestamp=now.isoformat(),
+            app_name="Neovim",
+            window_title="test.py",
+            duration_s=600,
+        ))
+
+        config = {"signals": {"activity": {"enabled": True, "summary_hours": 2}}}
+        with patch("prosoche.signals.activity.get_active_window", return_value=None):
+            result = await collect(config)
+
+        assert len(result) >= 1
+        assert result[0].source == "activity"
+        assert result[0].urgency == 0.1  # Informational
+        assert result[0].context_blocks  # Has staged context
+
+    @pytest.mark.anyio
+    async def test_deep_focus_signal(self):
+        """Long uninterrupted focus emits a deep work signal."""
+        # Simulate being focused for 45 minutes
+        now = time.monotonic()
+        activity._current_focus = {
+            "app_name": "Neovim",
+            "window_title": "app.rs",
+            "started_at": now - (45 * 60),  # 45 min ago
+        }
+        # Add something to ring buffer so summary isn't empty
+        _buf().append(FocusEvent(
+            timestamp=datetime.now(timezone.utc).isoformat(),
+            app_name="Firefox",
+            window_title="docs",
+            duration_s=60,
+        ))
+
+        config = {"signals": {"activity": {"enabled": True, "deep_work_minutes": 30}}}
+        with patch("prosoche.signals.activity.get_active_window", return_value={
+            "app_name": "Neovim", "window_title": "app.rs"
+        }):
+            result = await collect(config)
+
+        deep_signals = [s for s in result if "Deep focus" in s.summary]
+        assert len(deep_signals) == 1
+        assert deep_signals[0].urgency == 0.0  # Never interrupt deep work


### PR DESCRIPTION
## Activity Signal Collector

Tracks window focus events for context reconstruction after distraction — the AuDHD core loop: *started something, got interrupted, lost the thread. What was I doing?*

### How it works

1. Polls active window (title + app name) every 5 seconds
2. On focus change, records previous window's duration to a ring buffer (last 100 events)
3. Emits a `ContextBlock` with formatted recent activity for PROSOCHE.md
4. Detects deep work (uninterrupted focus >30min) as a separate signal

### Platform support

| Platform | Method | Status |
|----------|--------|--------|
| GNOME/Wayland (Fedora 42) | `gdbus call org.gnome.Shell.Eval` | Primary |
| X11 | `xdotool` + `xprop` | Fallback |
| macOS | `osascript` (System Events) | Fallback |
| Headless (worker-node) | Graceful skip | ✅ |

### Privacy

- `exclude_apps` config list (default: 1Password, KeePassXC, Bitwarden, gnome-keyring)
- URL query parameters stripped from titles (may contain tokens)
- Title truncated to 200 chars
- Duration threshold (10s) filters accidental focus switches

### PROSOCHE.md output (via Staged Context)

```
### Recent Activity (last 2 hours)
- 14:23 Neovim (aletheia/tui/src/app.rs) — 34 min
- 14:57 Firefox (GitHub PR #300) — 8 min
- 15:05 Alacritty (fish shell) — 12 min
- 15:17 Neovim (ergon/nous/akron/TELOS.md) — ongoing
```

### Tests

18 passing: sanitization, focus recording, platform fallback, ring buffer limits, summary generation, collector interface, deep focus detection.

Partially closes #313 (activity tracking portion — HEARTBEAT_OK and Summus signals are separate items)