### PR TITLE
fix: standalone issues #341 #344 #345 #346

### DIFF
--- a/infrastructure/memory/sidecar/aletheia_memory/app.py
+++ b/infrastructure/memory/sidecar/aletheia_memory/app.py
@@ -12,12 +12,16 @@ from fastapi.responses import JSONResponse
 from mem0 import Memory
 from starlette.responses import Response
 
-from .config import LLM_BACKEND, build_mem0_config
+from neo4j import GraphDatabase
+from qdrant_client import QdrantClient
+
+from .config import LLM_BACKEND, NEO4J_PASSWORD, NEO4J_URL, NEO4J_USER, QDRANT_HOST, QDRANT_PORT, build_mem0_config
 from .discovery import discovery_router
 from .evolution import evolution_router
+from .graph import set_shared_driver
 from .graph_extraction import init_pipeline
 from .llm_backend import refresh_oauth_token
-from .routes import foresight_router, router
+from .routes import foresight_router, router, set_shared_qdrant
 from .temporal import ensure_temporal_schema, temporal_router
 
 log = logging.getLogger("aletheia.memory")
@@ -172,14 +176,26 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         if provider == "anthropic-oauth":
             _inject_oauth_llm(memory, _active_backend)
 
+    # Create shared database clients — reused across all requests (#341)
+    neo4j_drv = GraphDatabase.driver(NEO4J_URL, auth=(NEO4J_USER, NEO4J_PASSWORD)) if NEO4J_PASSWORD else None
+    set_shared_driver(neo4j_drv)
+    qdrant_cl = QdrantClient(host=QDRANT_HOST, port=QDRANT_PORT)
+    set_shared_qdrant(qdrant_cl)
+
     app.state.memory = memory
     app.state.backend = _active_backend
     app.state.graph_pipeline = init_pipeline(_active_backend)
+    app.state.neo4j_driver = neo4j_drv
+    app.state.qdrant_client = qdrant_cl
     await ensure_temporal_schema()
 
     log.info("Memory sidecar ready")
     yield
 
+    # Cleanup
+    if neo4j_drv:
+        neo4j_drv.close()
+    qdrant_cl.close()
     memory = None
 
 

--- a/infrastructure/memory/sidecar/aletheia_memory/graph.py
+++ b/infrastructure/memory/sidecar/aletheia_memory/graph.py
@@ -1,4 +1,4 @@
-# Neo4j driver factory and cached availability check
+# Neo4j driver management and cached availability check
 import logging
 import threading
 import time
@@ -15,11 +15,22 @@ _neo4j_checked_at: float = 0.0
 _check_lock = threading.Lock()
 _CHECK_INTERVAL = 30.0  # seconds
 
+# Shared driver instance, set from app lifespan
+_shared_driver: neo4j.Driver | None = None
+
+
+def set_shared_driver(driver: neo4j.Driver | None) -> None:
+    """Set the shared Neo4j driver (called from app lifespan)."""
+    global _shared_driver
+    _shared_driver = driver
+
 
 def neo4j_driver() -> neo4j.Driver:
-    """Create a fresh Neo4j driver instance."""
+    """Return the shared Neo4j driver, or create a fresh one if not set."""
+    if _shared_driver is not None:
+        return _shared_driver
     from neo4j import GraphDatabase
-    driver: neo4j.Driver = GraphDatabase.driver(NEO4J_URL, auth=(NEO4J_USER, NEO4J_PASSWORD))  # pyright: ignore[reportUnknownMemberType] — neo4j stubs use **config: Unknown
+    driver: neo4j.Driver = GraphDatabase.driver(NEO4J_URL, auth=(NEO4J_USER, NEO4J_PASSWORD))  # pyright: ignore[reportUnknownMemberType]
     return driver
 
 
@@ -41,8 +52,7 @@ def neo4j_available() -> bool:
 
         try:
             driver = neo4j_driver()
-            driver.verify_connectivity()  # pyright: ignore[reportUnknownMemberType] — neo4j stubs use **config: Unknown
-            driver.close()
+            driver.verify_connectivity()  # pyright: ignore[reportUnknownMemberType]
             _neo4j_ok = True
         except Exception:
             _neo4j_ok = False

--- a/infrastructure/memory/sidecar/aletheia_memory/routes.py
+++ b/infrastructure/memory/sidecar/aletheia_memory/routes.py
@@ -44,6 +44,22 @@ def _extract_entities_for_episode(text: str) -> list[str]:
 logger = logging.getLogger("aletheia_memory")
 router = APIRouter()
 
+# Shared Qdrant client — set from app lifespan, avoids per-request instantiation (#341)
+_shared_qdrant: QdrantClient | None = None
+
+
+def set_shared_qdrant(client: QdrantClient) -> None:
+    """Set the shared Qdrant client (called from app lifespan)."""
+    global _shared_qdrant
+    _shared_qdrant = client
+
+
+def _qdrant() -> QdrantClient:
+    """Return the shared Qdrant client."""
+    if _shared_qdrant is None:
+        raise RuntimeError("Qdrant client not initialized — app lifespan not started")
+    return _shared_qdrant
+
 
 def _extract_results(raw: Any, key: str = "results") -> Any:
     """Unwrap Mem0 response: if dict with key, return that value; else return raw."""
@@ -266,9 +282,6 @@ async def add_memory(req: AddRequest, request: Request) -> dict[str, Any]:
             # Use Mem0's vector store directly for embedding-only storage
             try:
                 import uuid as _uuid
-
-                from qdrant_client import QdrantClient
-                from qdrant_client.models import PointStruct
                 embedder: Any = mem.embedding_model
                 vector: Any = await asyncio.to_thread(embedder.embed, req.text)
                 point_id = str(_uuid.uuid4())
@@ -280,7 +293,7 @@ async def add_memory(req: AddRequest, request: Request) -> dict[str, Any]:
                     "created_at": datetime.now(UTC).isoformat(),
                     **(req.metadata or {}),
                 }
-                qclient = QdrantClient(host=QDRANT_HOST, port=QDRANT_PORT)
+                qclient = _qdrant()
                 qclient.upsert(
                     collection_name="aletheia_memories",
                     points=[PointStruct(id=point_id, vector=vector, payload=payload)],
@@ -368,7 +381,6 @@ def _apply_confidence_weight(results: list[dict[str, Any]]) -> list[dict[str, An
                 "RETURN mid, m.access_count AS accesses, m.last_accessed AS last_accessed",
                 ids=memory_ids,
             ).data()
-        driver.close()
         mark_neo4j_ok()
         now = datetime.now(UTC)
         access_map: dict[str, tuple[int, str | None]] = {}
@@ -548,7 +560,7 @@ async def add_batch(req: AddBatchRequest, request: Request) -> dict[str, Any]:
         return {"ok": True, "added": 0, "skipped": 0, "errors": 0}
 
     try:
-        client = QdrantClient(host=QDRANT_HOST, port=QDRANT_PORT)
+        client = _qdrant()
         now = datetime.now(UTC).isoformat()
 
         # Content hash dedup — batch check existing hashes
@@ -823,7 +835,7 @@ async def _collect_qdrant_metrics(
     if not qdrant_ok:
         return {"orphan_count": None, "entries_by_agent": None, "total_entries": None}
     try:
-        client = QdrantClient(host=QDRANT_HOST, port=QDRANT_PORT)
+        client = _qdrant()
 
         # Orphan count — entries missing agent_id (unattributed memories)
         orphan_result = client.count(
@@ -880,7 +892,7 @@ async def _collect_noise_rate(qdrant_ok: bool) -> float | None:
     if not qdrant_ok:
         return None
     try:
-        client = QdrantClient(host=QDRANT_HOST, port=QDRANT_PORT)
+        client = _qdrant()
         scroll_result = client.scroll(
             collection_name=COLLECTION_NAME,
             limit=500,
@@ -918,7 +930,6 @@ async def _collect_neo4j_metrics(neo4j_ok: bool) -> dict[str, Any]:
             total_rels: int = total_single["c"] if total_single else 0
             relates_single = session.run("MATCH ()-[r:RELATES_TO]->() RETURN count(r) AS c").single()
             relates_count: int = relates_single["c"] if relates_single else 0
-        driver.close()
         mark_neo4j_ok()
         relates_to_rate = relates_count / total_rels if total_rels > 0 else None
         return {"relates_to_rate": relates_to_rate, "total_relationships": total_rels}
@@ -1103,7 +1114,6 @@ async def graph_stats() -> dict[str, Any]:
                 "MATCH ()-[r]->() WITH type(r) AS t, count(*) AS c WHERE c = 1 RETURN count(t) AS c"
             ).single()
             singleton_types: int = singleton_single["c"] if singleton_single else 0
-        driver.close()
         mark_neo4j_ok()
 
         return {
@@ -1253,7 +1263,6 @@ async def graph_export(
                     "top_nodes": top_names,
                 })
 
-        driver.close()
 
         return {
             "ok": True,
@@ -1331,7 +1340,6 @@ async def graph_search(
                 else:
                     results.append(node)
 
-        driver.close()
         return {"ok": True, "results": results, "total": len(results)}
     except Exception as e:
         mark_neo4j_down()
@@ -1413,7 +1421,6 @@ def _neo4j_expand_sync(query: str, user_id: str, graph_depth: int = 1) -> list[s
                     name = record["name"]
                     if name:
                         neighbors.append(name)
-        driver.close()
         mark_neo4j_ok()
     except Exception as e:
         mark_neo4j_down()
@@ -1459,7 +1466,7 @@ def _qdrant_search_direct(
     try:
         embedder: Any = mem.embedding_model
         vector: list[float] = embedder.embed(query)
-        client = QdrantClient(host=QDRANT_HOST, port=QDRANT_PORT)
+        client = _qdrant()
         results = client.query_points(
             collection_name=COLLECTION_NAME,
             query=vector,
@@ -1774,7 +1781,6 @@ async def retract_memory(req: RetractRequest, request: Request) -> dict[str, Any
                         if record and record["deleted"] > 0:
                             neo4j_removed.extend(record["affected"])
                             logger.info("Retract cascade: removed %d rels for entity '%s'", record['deleted'], entity)
-            driver.close()
             mark_neo4j_ok()
         except Exception:
             mark_neo4j_down()
@@ -1870,7 +1876,6 @@ async def _record_episode(text: str, agent_id: str, metadata: dict[str, Any] | N
                     """,
                     name=entity_name, ep_id=episode_id, now=now,
                 )
-        driver.close()
         mark_neo4j_ok()
         logger.debug("Episode %s: %d entities linked", episode_id, len(entities))
     except Exception:
@@ -1919,7 +1924,6 @@ async def add_foresight(req: ForesightAddRequest) -> dict[str, Any]:
                 expiry=req.expiry,
                 weight=req.weight,
             )
-        driver.close()
         mark_neo4j_ok()
         return {"ok": True, "entity": req.entity, "signal": req.signal}
     except Exception as e:
@@ -1958,7 +1962,6 @@ async def active_foresight() -> dict[str, Any]:
                 }
                 for r in result
             ]
-        driver.close()
         mark_neo4j_ok()
         return {"ok": True, "signals": signals}
     except Exception as e:
@@ -1998,7 +2001,6 @@ async def decay_foresight() -> dict[str, Any]:
             )
             delete_single = delete_result.single()
             deleted: int = delete_single["deleted"] if delete_single else 0
-        driver.close()
         mark_neo4j_ok()
         return {"ok": True, "decayed": decayed, "deleted": deleted}
     except Exception as e:
@@ -2110,7 +2112,6 @@ async def _generate_links(mem: Any, new_text: str, user_id: str) -> list[dict[st
                         description=link["description"],
                         score=link["score"],
                     )
-            driver.close()
             mark_neo4j_ok()
             logger.info("Generated %d memory links for new memory", len(links))
         except Exception:
@@ -2158,7 +2159,6 @@ async def analyze_graph(req: GraphAnalyzeRequest) -> dict[str, Any]:
 
         node_count: int = graph.number_of_nodes()
         if node_count == 0:
-            driver.close()
             return {"ok": True, "nodes": 0, "message": "Empty graph"}
 
         # PageRank
@@ -2228,7 +2228,6 @@ async def analyze_graph(req: GraphAnalyzeRequest) -> dict[str, Any]:
                     scores_stored += len(chunk)
 
         edge_count: int = graph.number_of_edges()
-        driver.close()
 
         return {
             "ok": True,
@@ -2294,7 +2293,6 @@ async def search_enhanced(req: EnhancedSearchRequest, request: Request) -> dict[
                     record = result.single()
                     if record and record["canonical"] != entity:
                         canonical_names[entity] = record["canonical"]
-            driver.close()
             mark_neo4j_ok()
         except Exception:
             mark_neo4j_down()
@@ -2495,7 +2493,6 @@ async def entity_detail(name: str, request: Request) -> dict[str, Any]:
                     **({"props": rel["props"]} if rel["props"] else {}),
                 })
 
-        driver.close()
         mark_neo4j_ok()
     except HTTPException:
         raise
@@ -2561,7 +2558,6 @@ async def delete_entity(name: str) -> dict[str, Any]:
                 "RETURN rels",
                 name=name,
             ).single()
-        driver.close()
         mark_neo4j_ok()
 
         if result is None:
@@ -2599,7 +2595,6 @@ async def flag_entity(name: str, request: Request) -> dict[str, Any]:
                 name=name,
                 flagged=flagged,
             ).single()
-        driver.close()
         mark_neo4j_ok()
 
         if result is None:
@@ -2662,7 +2657,6 @@ async def merge_entities(req: EntityMergeRequest) -> dict[str, Any]:
             # Delete source node
             session.run("MATCH (n {name: $name}) DETACH DELETE n", name=req.source)
 
-        driver.close()
         mark_neo4j_ok()
         logger.info("Merged entity '%s' → '%s' (%d relationships redirected)", req.source, req.target, redirected)
         return {"ok": True, "source": req.source, "target": req.target, "relationships_redirected": redirected}
@@ -2676,7 +2670,6 @@ async def merge_entities(req: EntityMergeRequest) -> dict[str, Any]:
                 driver = neo4j_driver()
                 with _neo4j_session(driver) as session:
                     session.run("MATCH (n {name: $name}) DETACH DELETE n", name=req.source)
-                driver.close()
                 mark_neo4j_ok()
                 logger.info("Merged (fallback, rels lost) entity '%s' → '%s'", req.source, req.target)
                 return {"ok": True, "source": req.source, "target": req.target,
@@ -2808,7 +2801,7 @@ async def add_direct_v2(req: AddDirectRequest, request: Request) -> dict[str, An
 
     try:
         content_hash = _content_hash(text)
-        client = QdrantClient(host=QDRANT_HOST, port=QDRANT_PORT)
+        client = _qdrant()
 
         # Content hash dedup (exact match)
         existing = client.scroll(
@@ -2906,7 +2899,7 @@ async def correct_memory(req: CorrectMemoryRequest, request: Request) -> dict[st
         return {"ok": False, "error": "empty corrected_text"}
 
     try:
-        client = QdrantClient(host=QDRANT_HOST, port=QDRANT_PORT)
+        client = _qdrant()
 
         # Find the memory to correct via semantic search
         query_vector = (await _embed_texts(mem, [req.query]))[0]
@@ -2989,7 +2982,7 @@ async def forget_memory(req: ForgetMemoryRequest, request: Request) -> dict[str,
     mem = _get_memory(request)
 
     try:
-        client = QdrantClient(host=QDRANT_HOST, port=QDRANT_PORT)
+        client = _qdrant()
 
         # Search for matching memories
         query_vector = (await _embed_texts(mem, [req.query]))[0]
@@ -3057,7 +3050,7 @@ async def memory_health(request: Request, user_id: str = "default") -> dict[str,
     mem = _get_memory(request)
 
     try:
-        client = QdrantClient(host=QDRANT_HOST, port=QDRANT_PORT)
+        client = _qdrant()
         # Get collection info for total count
         collection = client.get_collection(COLLECTION_NAME)
         total: int = collection.points_count or 0
@@ -3178,7 +3171,6 @@ async def graph_timeline(
                 limit=limit,
             )
             rows: list[dict[str, Any]] = result.data()
-        driver.close()
         mark_neo4j_ok()
     except Exception as e:
         mark_neo4j_down()
@@ -3327,7 +3319,6 @@ async def graph_drift(request: Request, user_id: str = "default", stale_days: in
             ).single()
             total_count = total["total"] if total else 0
 
-        driver.close()
         mark_neo4j_ok()
     except Exception as e:
         mark_neo4j_down()

--- a/infrastructure/runtime/src/aletheia.ts
+++ b/infrastructure/runtime/src/aletheia.ts
@@ -86,9 +86,8 @@ import { getVersion } from "./version.js";
 import { CompetenceModel } from "./nous/competence.js";
 import { UncertaintyTracker } from "./nous/uncertainty.js";
 import type { AletheiaConfig } from "./taxis/schema.js";
-import { chmodSync, existsSync, readFileSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, readFileSync, readdirSync, statSync, unlinkSync, writeFileSync } from "node:fs";
 import { getKeySalt, initEncryption } from "./koina/encryption.js";
-import Database from "better-sqlite3";
 import { eventBus } from "./koina/event-bus.js";
 import { type HookRegistry, registerHooks } from "./koina/hooks.js";
 import { getSidecarUrl, getUserId } from "./koina/memory-client.js";
@@ -525,9 +524,9 @@ export async function startRuntime(configPath?: string): Promise<void> {
   // --- Auth ---
   let gatewayAuth: GatewayAuthDeps | undefined;
   {
-    const authDb = new Database(paths.sessionsDb());
-    authDb.pragma("journal_mode = WAL");
-    authDb.pragma("synchronous = NORMAL");
+    // Reuse the SessionStore's database connection — both operate on disjoint
+    // tables in sessions.db, so sharing avoids a redundant WAL reader (#346).
+    const authDb = runtime.store.getDb();
 
     const auditLog = new AuditLog(authDb);
     let authSessionStore: AuthSessionStore | null = null;
@@ -766,10 +765,9 @@ export async function startRuntime(configPath?: string): Promise<void> {
 
   // Backup cron command — exports all agents to JSON files with retention
   cron.registerCommand("backup:all-agents", async () => {
-    const { mkdirSync: mkdirBackup, readdirSync: readdirBackup, unlinkSync: unlinkBackup } = await import("node:fs");
     const { exportAgent, agentFileToJson } = await import("./portability/export.js");
     const dest = config.backup.destination;
-    mkdirBackup(dest, { recursive: true });
+    mkdirSync(dest, { recursive: true });
 
     const date = new Date().toISOString().split("T")[0];
     let count = 0;
@@ -778,9 +776,7 @@ export async function startRuntime(configPath?: string): Promise<void> {
       try {
         const agentFile = await exportAgent(agent.id, agent as unknown as Record<string, unknown>, runtime.store);
         const filename = `${agent.id}-${date}.agent.json`;
-        const { writeFileSync: writeBackup } = await import("node:fs");
-        const { join: joinPath } = await import("node:path");
-        writeBackup(joinPath(dest, filename), agentFileToJson(agentFile, false));
+        writeFileSync(join(dest, filename), agentFileToJson(agentFile, false));
         count++;
       } catch (error) {
         log.warn(`Backup failed for ${agent.id}: ${error instanceof Error ? error.message : error}`);
@@ -790,14 +786,12 @@ export async function startRuntime(configPath?: string): Promise<void> {
     // Retention — delete old .agent.json files
     const cutoff = Date.now() - config.backup.retentionDays * 24 * 60 * 60 * 1000;
     try {
-      const { statSync: statBackup } = await import("node:fs");
-      const { join: joinPath } = await import("node:path");
-      for (const file of readdirBackup(dest)) {
+      for (const file of readdirSync(dest)) {
         if (!file.endsWith(".agent.json")) continue;
-        const filePath = joinPath(dest, file);
-        const stat = statBackup(filePath);
+        const filePath = join(dest, file);
+        const stat = statSync(filePath);
         if (stat.mtimeMs < cutoff) {
-          unlinkBackup(filePath);
+          unlinkSync(filePath);
           log.debug(`Deleted old backup: ${file}`);
         }
       }

--- a/infrastructure/runtime/src/daemon/cron.test.ts
+++ b/infrastructure/runtime/src/daemon/cron.test.ts
@@ -5,6 +5,7 @@ import { CronScheduler } from "./cron.js";
 function makeConfig(jobs: Array<Record<string, unknown>> = []) {
   return {
     cron: { jobs },
+    agents: { defaults: { userTimezone: "UTC" } },
   } as never;
 }
 

--- a/infrastructure/runtime/src/daemon/cron.ts
+++ b/infrastructure/runtime/src/daemon/cron.ts
@@ -1,5 +1,8 @@
 // Cron scheduler — dispatch timed messages to agents or run shell commands
-import { execSync } from "node:child_process";
+import { exec as execCb } from "node:child_process";
+import { promisify } from "node:util";
+
+const execAsync = promisify(execCb);
 import { createLogger } from "../koina/logger.js";
 import type { NousManager } from "../nous/manager.js";
 import type { AletheiaConfig } from "../taxis/schema.js";
@@ -25,11 +28,14 @@ export class CronScheduler {
   private running = false;
   private ticking = false;
   private builtInCommands = new Map<string, () => Promise<string>>();
+  private timezone: string;
 
   constructor(
     private config: AletheiaConfig,
     private manager: NousManager,
-  ) {}
+  ) {
+    this.timezone = config.agents.defaults.userTimezone ?? "UTC";
+  }
 
   /**
    * Register a built-in command that can be referenced from cron jobs.
@@ -55,7 +61,7 @@ export class CronScheduler {
         command: j.command,
         schedule: j.schedule,
         timeoutSeconds: j.timeoutSeconds,
-        nextRun: computeNextRun(j.schedule),
+        nextRun: computeNextRun(j.schedule, undefined, this.timezone),
       }));
 
     if (this.entries.length === 0) {
@@ -119,7 +125,7 @@ export class CronScheduler {
 
     for (const entry of dueEntries) {
       entry.lastRun = now;
-      entry.nextRun = computeNextRun(entry.schedule, now);
+      entry.nextRun = computeNextRun(entry.schedule, now, this.timezone);
     }
 
     const results = await Promise.allSettled(
@@ -142,18 +148,13 @@ export class CronScheduler {
             ]);
           }
 
-          return new Promise<{ type: "command"; stdout: string }>((resolve, reject) => {
-            try {
-              const stdout = execSync(entry.command!, {
-                timeout: timeoutMs,
-                encoding: "utf-8",
-                stdio: ["ignore", "pipe", "pipe"],
-              });
-              log.info(`Cron command ${entry.id} completed: ${stdout.slice(0, 200)}`);
-              resolve({ type: "command", stdout: stdout.slice(0, 2000) });
-            } catch (error) {
-              reject(error instanceof Error ? error : new Error(String(error)));
-            }
+          return execAsync(entry.command!, {
+            timeout: timeoutMs,
+            encoding: "utf-8",
+          }).then(({ stdout }) => {
+            const out = String(stdout);
+            log.info(`Cron command ${entry.id} completed: ${out.slice(0, 200)}`);
+            return { type: "command" as const, stdout: out.slice(0, 2000) };
           });
         }
 
@@ -190,7 +191,30 @@ export class CronScheduler {
   }
 }
 
-function computeNextRun(schedule: string, from?: number): number {
+/** Get date/time components in the specified timezone using Intl API. */
+function tzParts(epochMs: number, tz: string): { year: number; month: number; day: number; dow: number; hour: number; minute: number } {
+  const d = new Date(epochMs);
+  // Intl.DateTimeFormat with hourCycle: "h23" gives 0-23 hours
+  const fmt = new Intl.DateTimeFormat("en-US", {
+    timeZone: tz,
+    year: "numeric", month: "numeric", day: "numeric",
+    hour: "numeric", minute: "numeric",
+    weekday: "short",
+    hourCycle: "h23",
+  });
+  const parts = Object.fromEntries(fmt.formatToParts(d).map(p => [p.type, p.value]));
+  const dowMap: Record<string, number> = { Sun: 0, Mon: 1, Tue: 2, Wed: 3, Thu: 4, Fri: 5, Sat: 6 };
+  return {
+    year: parseInt(parts["year"]!, 10),
+    month: parseInt(parts["month"]!, 10),
+    day: parseInt(parts["day"]!, 10),
+    dow: dowMap[parts["weekday"]!] ?? 0,
+    hour: parseInt(parts["hour"]!, 10),
+    minute: parseInt(parts["minute"]!, 10),
+  };
+}
+
+function computeNextRun(schedule: string, from?: number, tz = "UTC"): number {
   const now = from ?? Date.now();
 
   const intervalMatch = schedule.match(/^every\s+(\d+)\s*(m|h|min|hour|s|sec)/i);
@@ -208,19 +232,15 @@ function computeNextRun(schedule: string, from?: number): number {
 
   const timeMatch = schedule.match(/^at\s+(\d{1,2}):(\d{2})/i);
   if (timeMatch) {
-    const hour = parseInt(timeMatch[1]!, 10);
-    const minute = parseInt(timeMatch[2]!, 10);
-    const date = new Date(now);
-    date.setHours(hour, minute, 0, 0);
-    if (date.getTime() <= now) {
-      date.setDate(date.getDate() + 1);
-    }
-    return date.getTime();
+    const targetHour = parseInt(timeMatch[1]!, 10);
+    const targetMinute = parseInt(timeMatch[2]!, 10);
+    // Delegate to cron expression parser which handles timezone correctly
+    return computeFromCronExpr([String(targetMinute), String(targetHour), "*", "*", "*"], now, tz);
   }
 
   const cronParts = schedule.split(/\s+/);
   if (cronParts.length === 5) {
-    return computeFromCronExpr(cronParts, now);
+    return computeFromCronExpr(cronParts, now, tz);
   }
 
   log.warn(`Unknown cron schedule format: ${schedule}, defaulting to 1h`);
@@ -254,7 +274,7 @@ function fieldMatches(field: Set<number> | null, value: number): boolean {
   return field === null || field.has(value);
 }
 
-function computeFromCronExpr(parts: string[], from: number): number {
+function computeFromCronExpr(parts: string[], from: number, tz = "UTC"): number {
   const [minStr, hourStr, domStr, monStr, dowStr] = parts;
   const minutes = parseCronField(minStr!, 0, 59);
   const hours = parseCronField(hourStr!, 0, 23);
@@ -262,26 +282,22 @@ function computeFromCronExpr(parts: string[], from: number): number {
   const months = parseCronField(monStr!, 1, 12);
   const dows = parseCronField(dowStr!, 0, 7); // 0=Sun, 7=Sun
 
-  const candidate = new Date(from);
-  candidate.setSeconds(0, 0);
-  candidate.setMilliseconds(0);
-
-  // Scan forward up to 400 days to find next matching time
+  // Scan forward in 1-minute increments using timezone-aware field extraction.
+  // Start from next minute boundary.
+  let candidate = from - (from % 60000) + 60000; // next minute boundary
   const limit = from + 400 * 24 * 60 * 60 * 1000;
-  // Start from next minute
-  candidate.setMinutes(candidate.getMinutes() + 1);
 
-  while (candidate.getTime() < limit) {
-    const mo = candidate.getMonth() + 1;
-    const dom = candidate.getDate();
-    const dow = candidate.getDay(); // 0=Sun
-    const hr = candidate.getHours();
-    const mn = candidate.getMinutes();
+  while (candidate < limit) {
+    const p = tzParts(candidate, tz);
+    const mo = p.month;
+    const dom = p.day;
+    const dow = p.dow;
+    const hr = p.hour;
+    const mn = p.minute;
 
     if (!fieldMatches(months, mo)) {
-      // Jump to first day of next month
-      candidate.setMonth(candidate.getMonth() + 1, 1);
-      candidate.setHours(0, 0, 0, 0);
+      // Skip forward ~1 day at a time to avoid minute-by-minute scan through wrong months
+      candidate += 24 * 60 * 60 * 1000;
       continue;
     }
 
@@ -293,22 +309,25 @@ function computeFromCronExpr(parts: string[], from: number): number {
       : domMatch && dowMatch;
 
     if (!dayOk) {
-      candidate.setDate(candidate.getDate() + 1);
-      candidate.setHours(0, 0, 0, 0);
+      // Skip to next day: advance by enough minutes to reach next midnight in tz
+      // Approximate: skip forward by (24 - hr) hours - mn minutes
+      const minutesToMidnight = (24 - hr) * 60 - mn;
+      candidate += minutesToMidnight * 60000;
       continue;
     }
 
     if (!fieldMatches(hours, hr)) {
-      candidate.setHours(candidate.getHours() + 1, 0, 0, 0);
+      // Skip to next hour
+      candidate += (60 - mn) * 60000;
       continue;
     }
 
     if (!fieldMatches(minutes, mn)) {
-      candidate.setMinutes(candidate.getMinutes() + 1, 0, 0);
+      candidate += 60000; // next minute
       continue;
     }
 
-    return candidate.getTime();
+    return candidate;
   }
 
   // Fallback if no match found within scan window

--- a/infrastructure/runtime/src/koina/logger.ts
+++ b/infrastructure/runtime/src/koina/logger.ts
@@ -1,7 +1,7 @@
 // Structured logging with request tracing via AsyncLocalStorage
 import { Logger } from "tslog";
 import { AsyncLocalStorage } from "node:async_hooks";
-import { appendFileSync } from "node:fs";
+import { createWriteStream, type WriteStream } from "node:fs";
 
 // --- Turn context (propagated via AsyncLocalStorage) ---
 
@@ -100,7 +100,11 @@ export const log = new Logger({
 
 // Attach JSON transport for structured output to file/pipe
 const jsonLogPath = process.env["ALETHEIA_LOG_JSON"];
+let jsonLogStream: WriteStream | null = null;
 if (jsonLogPath) {
+  jsonLogStream = createWriteStream(jsonLogPath, { flags: "a" });
+  jsonLogStream.on("error", () => { /* log write failed — cannot recurse */ });
+
   log.attachTransport((logObj) => {
     const ctx = turnStore.getStore();
     const entry: Record<string, unknown> = {
@@ -124,11 +128,7 @@ if (jsonLogPath) {
       entry["msg"] = parts[0];
       if (parts.length > 1) entry["data"] = parts.slice(1);
     }
-    try {
-      appendFileSync(jsonLogPath, JSON.stringify(entry) + "\n");
-    } catch { /* log write failed — cannot recurse */
-      // Don't recurse on log failure
-    }
+    jsonLogStream!.write(JSON.stringify(entry) + "\n");
   });
 }
 

--- a/infrastructure/runtime/src/nous/competence.test.ts
+++ b/infrastructure/runtime/src/nous/competence.test.ts
@@ -91,9 +91,10 @@ describe("CompetenceModel", () => {
     expect(agent.overallScore).toBeCloseTo((0.52 + 0.45) / 2);
   });
 
-  it("persists and reloads from file", () => {
+  it("persists and reloads from file", async () => {
     model.recordSuccess("syn", "health");
     model.recordSuccess("syn", "health");
+    await model.waitForFlush();
 
     const model2 = new CompetenceModel(tmpDir);
     expect(model2.getScore("syn", "health")).toBeCloseTo(0.54);

--- a/infrastructure/runtime/src/nous/competence.ts
+++ b/infrastructure/runtime/src/nous/competence.ts
@@ -1,5 +1,6 @@
 // Competence model — per-agent per-domain confidence tracking
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync } from "node:fs";
+import { writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { createLogger } from "../koina/logger.js";
 
@@ -27,6 +28,8 @@ const DISAGREEMENT_PENALTY = 0.01;
 export class CompetenceModel {
   private data: Record<string, AgentCompetence> = {};
   private filePath: string;
+  private dirty = false;
+  private flushScheduled = false;
 
   constructor(sharedRoot: string) {
     const dir = join(sharedRoot, "shared", "competence");
@@ -46,8 +49,30 @@ export class CompetenceModel {
     }
   }
 
+  /** Mark data as dirty and schedule an async flush on next microtask. */
   private save(): void {
-    writeFileSync(this.filePath, JSON.stringify(this.data, null, 2));
+    this.dirty = true;
+    if (!this.flushScheduled) {
+      this.flushScheduled = true;
+      setImmediate(() => this.flush());
+    }
+  }
+
+  private flush(): void {
+    this.flushScheduled = false;
+    if (!this.dirty) return;
+    this.dirty = false;
+    this.flushPromise = writeFile(this.filePath, JSON.stringify(this.data, null, 2)).catch((err) => {
+      log.warn(`Competence save failed: ${err instanceof Error ? err.message : err}`);
+    });
+  }
+
+  private flushPromise: Promise<void> = Promise.resolve();
+
+  /** Wait for any pending async writes to complete. Useful for tests. */
+  async waitForFlush(): Promise<void> {
+    if (this.dirty) this.flush();
+    await this.flushPromise;
   }
 
   private ensureAgent(nousId: string): AgentCompetence {

--- a/infrastructure/runtime/src/nous/uncertainty.test.ts
+++ b/infrastructure/runtime/src/nous/uncertainty.test.ts
@@ -85,8 +85,9 @@ describe("UncertaintyTracker", () => {
     expect(tracker.getSummary().totalPoints).toBe(2);
   });
 
-  it("persists and reloads data", () => {
+  it("persists and reloads data", async () => {
     tracker.record("syn", "d", 0.7, true);
+    await tracker.waitForFlush();
     const tracker2 = new UncertaintyTracker(tmpDir);
     expect(tracker2.getSummary("syn").totalPoints).toBe(1);
   });

--- a/infrastructure/runtime/src/nous/uncertainty.ts
+++ b/infrastructure/runtime/src/nous/uncertainty.ts
@@ -1,5 +1,6 @@
 // Uncertainty quantification — track calibration of agent confidence estimates
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync } from "node:fs";
+import { writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { createLogger } from "../koina/logger.js";
 
@@ -23,6 +24,8 @@ interface CalibrationBin {
 export class UncertaintyTracker {
   private points: CalibrationPoint[] = [];
   private filePath: string;
+  private dirty = false;
+  private flushScheduled = false;
 
   constructor(sharedRoot: string) {
     const dir = join(sharedRoot, "shared", "calibration");
@@ -42,12 +45,34 @@ export class UncertaintyTracker {
     }
   }
 
+  /** Mark data as dirty and schedule an async flush on next microtask. */
   private save(): void {
     // Keep last 1000 points
     if (this.points.length > 1000) {
       this.points = this.points.slice(-1000);
     }
-    writeFileSync(this.filePath, JSON.stringify(this.points, null, 2));
+    this.dirty = true;
+    if (!this.flushScheduled) {
+      this.flushScheduled = true;
+      setImmediate(() => this.flush());
+    }
+  }
+
+  private flush(): void {
+    this.flushScheduled = false;
+    if (!this.dirty) return;
+    this.dirty = false;
+    this.flushPromise = writeFile(this.filePath, JSON.stringify(this.points, null, 2)).catch((err) => {
+      log.warn(`Calibration save failed: ${err instanceof Error ? err.message : err}`);
+    });
+  }
+
+  private flushPromise: Promise<void> = Promise.resolve();
+
+  /** Wait for any pending async writes to complete. Useful for tests. */
+  async waitForFlush(): Promise<void> {
+    if (this.dirty) this.flush();
+    await this.flushPromise;
   }
 
   record(

--- a/shared/skills/git-repository-change-analysis/SKILL.md
+++ b/shared/skills/git-repository-change-analysis/SKILL.md
@@ -1,0 +1,16 @@
+# Git Repository Change Analysis
+Analyze recent changes to a specific file in a git repository by pulling latest commits and examining diffs.
+
+## When to Use
+When you need to understand what changed in a particular file across recent commits, especially to track modifications to configuration, code patterns, or command definitions.
+
+## Steps
+1. Navigate to the repository directory and pull the latest changes from origin
+2. View recent commit history to identify relevant commits
+3. Use git diff between two commits to see changes to the target file
+4. Use grep to locate specific patterns or command definitions in the file
+5. Cross-reference with configuration files if needed to understand the context
+
+## Tools Used
+- exec: Used to run git commands (pull, log, diff) and grep for pattern searching in files
+- file reading: Used to examine configuration files that provide context (anchor.json, etc.)


### PR DESCRIPTION
Fixes four standalone implementation issues that didn't need spec coverage.

## #341 — Sidecar client singletons (performance)
Neo4j driver and Qdrant client were created per-request (~30 call sites). Now created once in FastAPI lifespan and shared via module-level accessors.
- Removed 22 `driver.close()` calls (shared driver lifecycle managed by lifespan)
- Removed 9 per-request `QdrantClient()` instantiations
- `graph.py`: `set_shared_driver()` + fallback to fresh driver if not set
- `routes.py`: `set_shared_qdrant()` + `_qdrant()` accessor

## #344 — Cron timezone support (bug fix)
Cron scheduler used `date.getHours()` etc. (local system time) instead of the configured `userTimezone`.
- Added `tzParts()` using `Intl.DateTimeFormat` for timezone-aware field extraction
- `computeNextRun` and `computeFromCronExpr` now accept a `tz` parameter
- `CronScheduler` reads `config.agents.defaults.userTimezone`
- `at HH:MM` schedules delegate to cron expression parser for correctness

## #345 — Async I/O (event loop unblocking)
Four sources of synchronous I/O on the event loop replaced with async alternatives:
- `competence.ts`: `writeFileSync` → `writeFile` with dirty flag + `setImmediate` flush
- `uncertainty.ts`: same pattern
- `logger.ts`: `appendFileSync` → `createWriteStream` (buffered async writes)
- `cron.ts`: `execSync` → `promisify(exec)` for shell command fallback
- Added `waitForFlush()` on both models for test determinism

## #346 — SQLite + dynamic import cleanup
- Reuse `SessionStore.getDb()` for `AuthSessionStore` (was opening a second connection to the same WAL-mode file)
- Removed unused `better-sqlite3` import
- Replaced 4 dynamic `await import('node:fs'/'node:path')` in backup cron with static imports

## Verification
- TypeScript: `tsc --noEmit` clean
- Tests: 42/42 passing (cron, competence, uncertainty, logger)
- Python: AST parse validates all 3 sidecar files

Closes #341, closes #344, closes #345, closes #346