### PR TITLE
refactor(taxis): remove remaining _shared/ references for oikos

### DIFF
--- a/infrastructure/runtime/src/aletheia.ts
+++ b/infrastructure/runtime/src/aletheia.ts
@@ -621,7 +621,7 @@ export async function startRuntime(configPath?: string): Promise<void> {
   eventBus.emit("boot:ready", { port, tools: runtime.tools.size, plugins: runtime.plugins.size });
   log.info(`Aletheia gateway listening on port ${port}`);
 
-  // INDX-01: Live file watcher — rebuilds shared index when _shared/ files change
+  // INDX-01: Live file watcher — rebuilds shared index when theke/ files change
   {
     if (existsSync(paths.theke)) {
       let debounceTimer: ReturnType<typeof setTimeout> | null = null;

--- a/infrastructure/runtime/src/dianoia/migration.ts
+++ b/infrastructure/runtime/src/dianoia/migration.ts
@@ -41,7 +41,7 @@ export function generateMigrationPrompt(projects: LegacyProject[]): string {
 
   return [
     "The following in-flight planning projects are stored at old-style paths and can be migrated",
-    "to the new shared workspace location (_shared/workspace/plans/{slug}/):",
+    "to the new shared workspace location (shared/workspace/plans/{slug}/):",
     "",
     list,
     "",

--- a/infrastructure/runtime/src/dianoia/orchestrator.ts
+++ b/infrastructure/runtime/src/dianoia/orchestrator.ts
@@ -194,7 +194,7 @@ export class DianoiaOrchestrator {
         "Migration complete:",
         ...results,
         "",
-        "Projects now stored at _shared/workspace/plans/{slug}/.",
+        "Projects now stored at shared/workspace/plans/{slug}/.",
       ].join("\n");
     }
 
@@ -273,7 +273,7 @@ export class DianoiaOrchestrator {
 
     eventBus.emit("planning:project-created", { projectId: project.id, nousId, sessionId });
     log.info(`Created planning project ${project.id} for nous ${nousId}`, { slug, dir });
-    return `Project "${displayName}" (slug: ${slug}) created. Artifacts will be stored in _shared/workspace/plans/${slug}/\n\nFirst: what are you building?`;
+    return `Project "${displayName}" (slug: ${slug}) created. Artifacts will be stored in shared/workspace/plans/${slug}/\n\nFirst: what are you building?`;
   }
 
   confirmResume(projectId: string, nousId: string, sessionId: string, answer: string): string {

--- a/infrastructure/runtime/src/koina/error-codes.ts
+++ b/infrastructure/runtime/src/koina/error-codes.ts
@@ -65,7 +65,7 @@ export const ERROR_CODES = {
   CONFIG_VALIDATION_FAILED: "Configuration failed schema validation",
   CONFIG_MISSING_REQUIRED: "Required configuration field is missing",
   CONFIG_ANCHOR_NOT_FOUND: "Bootstrap anchor not found — run 'aletheia init' to configure",
-  CONFIG_ANCHOR_INVALID: "Bootstrap anchor.json failed schema validation",
+  CONFIG_INSTANCE_INVALID: "Instance directory structure validation failed",
   CONFIG_SECRET_UNRESOLVED: "SecretRef could not be resolved — env var not set, file not readable, or file is empty",
   CONFIG_SECRET_VAULT_UNSUPPORTED: "Vault SecretRef source is not yet implemented — a plugin interface is planned for future versions",
 

--- a/infrastructure/runtime/src/nous/pipeline/stages/context.ts
+++ b/infrastructure/runtime/src/nous/pipeline/stages/context.ts
@@ -18,7 +18,7 @@ import type { RuntimeServices, SystemBlock, TurnState } from "../types.js";
 
 const log = createLogger("pipeline:context");
 
-const SHARED_INJECTION_SCORE_THRESHOLD = 2; // minimum token matches for _shared/ content to be injected
+const SHARED_INJECTION_SCORE_THRESHOLD = 2; // minimum token matches for shared/ content to be injected
 const SHARED_TOKEN_BUDGET = 600;
 const SHARED_MAX_RESULTS = 3;
 
@@ -211,7 +211,7 @@ export async function buildContext(
     }
   }
 
-  // _shared/ workspace excerpt injection — surfaces shared workspace content per turn (INDX-04)
+  // Shared workspace excerpt injection — surfaces shared workspace content per turn (INDX-04)
   // Injection is silent when no matches exceed threshold or when index is still building.
   {
     const sharedIndex = getSharedIndex();

--- a/infrastructure/runtime/src/taxis/nous-scaffold.test.ts
+++ b/infrastructure/runtime/src/taxis/nous-scaffold.test.ts
@@ -15,21 +15,21 @@ afterEach(() => {
 });
 
 describe("scaffoldNousShared", () => {
-  it("creates four subdirectories under _shared/workspace/", () => {
+  it("creates four subdirectories under workspace/", () => {
     scaffoldNousShared(tmpDir);
-    expect(existsSync(join(tmpDir, "_shared", "workspace", "plans"))).toBe(true);
-    expect(existsSync(join(tmpDir, "_shared", "workspace", "specs"))).toBe(true);
-    expect(existsSync(join(tmpDir, "_shared", "workspace", "standards"))).toBe(true);
-    expect(existsSync(join(tmpDir, "_shared", "workspace", "references"))).toBe(true);
+    expect(existsSync(join(tmpDir, "workspace", "plans"))).toBe(true);
+    expect(existsSync(join(tmpDir, "workspace", "specs"))).toBe(true);
+    expect(existsSync(join(tmpDir, "workspace", "standards"))).toBe(true);
+    expect(existsSync(join(tmpDir, "workspace", "references"))).toBe(true);
   });
 
   it("returns created paths as segment strings", () => {
     const created = scaffoldNousShared(tmpDir);
     expect(created).toEqual([
-      "_shared/workspace/plans",
-      "_shared/workspace/specs",
-      "_shared/workspace/standards",
-      "_shared/workspace/references",
+      "workspace/plans",
+      "workspace/specs",
+      "workspace/standards",
+      "workspace/references",
     ]);
   });
 

--- a/infrastructure/runtime/src/taxis/nous-scaffold.ts
+++ b/infrastructure/runtime/src/taxis/nous-scaffold.ts
@@ -7,22 +7,22 @@ import { createLogger } from "../koina/logger.js";
 const log = createLogger("taxis:nous-scaffold");
 
 const SHARED_WORKSPACE_DIRS = [
-  ["_shared", "workspace", "plans"],
-  ["_shared", "workspace", "specs"],
-  ["_shared", "workspace", "standards"],
-  ["_shared", "workspace", "references"],
+  ["workspace", "plans"],
+  ["workspace", "specs"],
+  ["workspace", "standards"],
+  ["workspace", "references"],
 ] as const;
 
-export function scaffoldNousShared(nousDir: string): string[] {
+export function scaffoldNousShared(sharedDir: string): string[] {
   const created: string[] = [];
   for (const segments of SHARED_WORKSPACE_DIRS) {
-    const dir = join(nousDir, ...segments);
+    const dir = join(sharedDir, ...segments);
     if (!existsSync(dir)) {
       mkdirSync(dir, { recursive: true });
       created.push(segments.join("/"));
     }
   }
-  log.debug("scaffoldNousShared complete", { nousDir, created });
+  log.debug("scaffoldNousShared complete", { sharedDir, created });
   return created;
 }
 


### PR DESCRIPTION
## Summary
- Follows up on #359 (oikos path migration) to remove all remaining `_shared/` directory references
- Updates `nous-scaffold` to create workspace dirs directly under `shared/` instead of `_shared/workspace/`
- Updates user-facing messages in dianoia to reference `shared/` paths
- Renames `CONFIG_ANCHOR_INVALID` error code to `CONFIG_INSTANCE_INVALID`

## Files changed (7)
- `taxis/nous-scaffold.ts` + test — remove `_shared` prefix from scaffold dirs
- `dianoia/orchestrator.ts`, `dianoia/migration.ts` — update user-facing path strings
- `nous/pipeline/stages/context.ts`, `aletheia.ts` — comment updates
- `koina/error-codes.ts` — rename stale error code

## Verification
- 92/92 taxis tests pass
- Zero remaining references to: `nousSharedDir`, `initPaths`, `bootstrap-loader`, `_shared/`, `anchor.json`
- `homedir()` only remains in legitimate uses (tilde expansion, `~/.claude.json`)

## Test plan
- [x] `npx vitest run src/taxis/` — 92 tests pass
- [x] `npx tsc --noEmit` — no new errors
- [x] Grep verification for stale patterns — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)