### PR TITLE
feat(organon): tool registry + definition types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,15 +16,11 @@ name = "aletheia-hermeneus"
 version = "0.1.0"
 dependencies = [
  "aletheia-koina",
- "reqwest",
- "secrecy",
  "serde",
  "serde_json",
  "snafu",
  "static_assertions",
- "tokio",
  "tracing",
- "wiremock",
 ]
 
 [[package]]
@@ -85,6 +81,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "aletheia-organon"
+version = "0.1.0"
+dependencies = [
+ "aletheia-hermeneus",
+ "aletheia-koina",
+ "indexmap",
+ "serde",
+ "serde_json",
+ "snafu",
+ "static_assertions",
+ "tokio",
+]
+
+[[package]]
 name = "aletheia-taxis"
 version = "0.1.0"
 dependencies = [
@@ -104,16 +114,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
-name = "assert-json-diff"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
-dependencies = [
- "serde",
- "serde_json",
-]
-
-[[package]]
 name = "atomic"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -121,18 +121,6 @@ checksum = "a89cbf775b137e9b968e67227ef7f775587cde3fd31b0d8599dbd0f598a48340"
 dependencies = [
  "bytemuck",
 ]
-
-[[package]]
-name = "atomic-waker"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
-
-[[package]]
-name = "base64"
-version = "0.22.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
@@ -151,12 +139,6 @@ name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
-
-[[package]]
-name = "bytes"
-version = "1.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "castaway"
@@ -199,70 +181,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "core-foundation"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "core-foundation"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "core-foundation-sys"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
-
-[[package]]
-name = "deadpool"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
-dependencies = [
- "deadpool-runtime",
- "lazy_static",
- "num_cpus",
- "tokio",
-]
-
-[[package]]
-name = "deadpool-runtime"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
-
-[[package]]
-name = "displaydoc"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "encoding_rs"
-version = "0.8.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -275,7 +193,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -318,139 +236,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
-name = "fnv"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
-
-[[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
-
-[[package]]
-name = "form_urlencoded"
-version = "1.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
-dependencies = [
- "percent-encoding",
-]
-
-[[package]]
-name = "futures"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-executor",
- "futures-io",
- "futures-sink",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
-name = "futures-channel"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
-dependencies = [
- "futures-core",
- "futures-sink",
-]
-
-[[package]]
-name = "futures-core"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
-
-[[package]]
-name = "futures-executor"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
-dependencies = [
- "futures-core",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
-name = "futures-io"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
-
-[[package]]
-name = "futures-macro"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "futures-sink"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
-
-[[package]]
-name = "futures-task"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
-
-[[package]]
-name = "futures-util"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-io",
- "futures-macro",
- "futures-sink",
- "futures-task",
- "memchr",
- "pin-project-lite",
- "slab",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi",
-]
 
 [[package]]
 name = "getrandom"
@@ -475,25 +264,6 @@ dependencies = [
  "r-efi",
  "wasip2",
  "wasip3",
-]
-
-[[package]]
-name = "h2"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
-dependencies = [
- "atomic-waker",
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "http",
- "indexmap",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
 ]
 
 [[package]]
@@ -527,243 +297,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "hermit-abi"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
-
-[[package]]
-name = "http"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
-dependencies = [
- "bytes",
- "itoa",
-]
-
-[[package]]
-name = "http-body"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
-dependencies = [
- "bytes",
- "http",
-]
-
-[[package]]
-name = "http-body-util"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
-dependencies = [
- "bytes",
- "futures-core",
- "http",
- "http-body",
- "pin-project-lite",
-]
-
-[[package]]
-name = "httparse"
-version = "1.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
-
-[[package]]
-name = "httpdate"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
-
-[[package]]
-name = "hyper"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
-dependencies = [
- "atomic-waker",
- "bytes",
- "futures-channel",
- "futures-core",
- "h2",
- "http",
- "http-body",
- "httparse",
- "httpdate",
- "itoa",
- "pin-project-lite",
- "pin-utils",
- "smallvec",
- "tokio",
- "want",
-]
-
-[[package]]
-name = "hyper-rustls"
-version = "0.27.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
-dependencies = [
- "http",
- "hyper",
- "hyper-util",
- "rustls",
- "rustls-pki-types",
- "tokio",
- "tokio-rustls",
- "tower-service",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
- "tower-service",
-]
-
-[[package]]
-name = "hyper-util"
-version = "0.1.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
-dependencies = [
- "base64",
- "bytes",
- "futures-channel",
- "futures-util",
- "http",
- "http-body",
- "hyper",
- "ipnet",
- "libc",
- "percent-encoding",
- "pin-project-lite",
- "socket2",
- "system-configuration",
- "tokio",
- "tower-service",
- "tracing",
- "windows-registry",
-]
-
-[[package]]
-name = "icu_collections"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
-dependencies = [
- "displaydoc",
- "potential_utf",
- "yoke",
- "zerofrom",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locale_core"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
-dependencies = [
- "displaydoc",
- "litemap",
- "tinystr",
- "writeable",
- "zerovec",
-]
-
-[[package]]
-name = "icu_normalizer"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
-dependencies = [
- "icu_collections",
- "icu_normalizer_data",
- "icu_properties",
- "icu_provider",
- "smallvec",
- "zerovec",
-]
-
-[[package]]
-name = "icu_normalizer_data"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
-
-[[package]]
-name = "icu_properties"
-version = "2.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
-dependencies = [
- "icu_collections",
- "icu_locale_core",
- "icu_properties_data",
- "icu_provider",
- "zerotrie",
- "zerovec",
-]
-
-[[package]]
-name = "icu_properties_data"
-version = "2.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
-
-[[package]]
-name = "icu_provider"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
-dependencies = [
- "displaydoc",
- "icu_locale_core",
- "writeable",
- "yoke",
- "zerofrom",
- "zerotrie",
- "zerovec",
-]
-
-[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
-name = "idna"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
-dependencies = [
- "idna_adapter",
- "smallvec",
- "utf8_iter",
-]
-
-[[package]]
-name = "idna_adapter"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
-dependencies = [
- "icu_normalizer",
- "icu_properties",
-]
 
 [[package]]
 name = "indexmap"
@@ -782,22 +319,6 @@ name = "inlinable_string"
 version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8fae54786f62fb2918dcfae3d568594e50eb9b5c25bf04371af6fe7516452fb"
-
-[[package]]
-name = "ipnet"
-version = "2.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
-
-[[package]]
-name = "iri-string"
-version = "0.7.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
-dependencies = [
- "memchr",
- "serde",
-]
 
 [[package]]
 name = "itoa"
@@ -851,12 +372,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
-name = "litemap"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
-
-[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -878,56 +393,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
-name = "mime"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
-
-[[package]]
-name = "mio"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
-dependencies = [
- "libc",
- "wasi",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "native-tls"
-version = "0.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "num_cpus"
-version = "1.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
-dependencies = [
- "hermit-abi",
- "libc",
+ "windows-sys",
 ]
 
 [[package]]
@@ -935,50 +406,6 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
-
-[[package]]
-name = "openssl"
-version = "0.10.75"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
-dependencies = [
- "bitflags",
- "cfg-if",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "openssl-probe"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.111"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "pear"
@@ -1004,37 +431,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "percent-encoding"
-version = "2.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
-
-[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
-
-[[package]]
-name = "potential_utf"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
-dependencies = [
- "zerovec",
-]
 
 [[package]]
 name = "ppv-lite86"
@@ -1122,18 +528,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex"
-version = "1.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-automata",
- "regex-syntax",
-]
-
-[[package]]
 name = "regex-automata"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1149,62 +543,6 @@ name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
-
-[[package]]
-name = "reqwest"
-version = "0.12.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
-dependencies = [
- "base64",
- "bytes",
- "encoding_rs",
- "futures-channel",
- "futures-core",
- "futures-util",
- "h2",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-rustls",
- "hyper-tls",
- "hyper-util",
- "js-sys",
- "log",
- "mime",
- "native-tls",
- "percent-encoding",
- "pin-project-lite",
- "rustls-pki-types",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper",
- "tokio",
- "tokio-native-tls",
- "tower",
- "tower-http",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
-name = "ring"
-version = "0.17.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
-dependencies = [
- "cc",
- "cfg-if",
- "getrandom 0.2.17",
- "libc",
- "untrusted",
- "windows-sys 0.52.0",
-]
 
 [[package]]
 name = "rusqlite"
@@ -1230,40 +568,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "rustls"
-version = "0.23.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
-dependencies = [
- "once_cell",
- "rustls-pki-types",
- "rustls-webpki",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "rustls-pki-types"
-version = "1.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
-dependencies = [
- "zeroize",
-]
-
-[[package]]
-name = "rustls-webpki"
-version = "0.103.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
-dependencies = [
- "ring",
- "rustls-pki-types",
- "untrusted",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1277,48 +582,6 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
-
-[[package]]
-name = "schannel"
-version = "0.1.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
-dependencies = [
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "secrecy"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
-dependencies = [
- "serde",
- "zeroize",
-]
-
-[[package]]
-name = "security-framework"
-version = "3.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
-dependencies = [
- "bitflags",
- "core-foundation 0.10.1",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework-sys"
-version = "2.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
 
 [[package]]
 name = "semver"
@@ -1370,18 +633,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_urlencoded"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
-dependencies = [
- "form_urlencoded",
- "itoa",
- "ryu",
- "serde",
-]
-
-[[package]]
 name = "serde_yaml"
 version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1408,12 +659,6 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
-
-[[package]]
-name = "slab"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
@@ -1443,32 +688,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "socket2"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
-dependencies = [
- "libc",
- "windows-sys 0.60.2",
-]
-
-[[package]]
-name = "stable_deref_trait"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
-
-[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
-name = "subtle"
-version = "2.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -1482,47 +705,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sync_wrapper"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
-dependencies = [
- "futures-core",
-]
-
-[[package]]
-name = "synstructure"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "system-configuration"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
-dependencies = [
- "bitflags",
- "core-foundation 0.9.4",
- "system-configuration-sys",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
 name = "tempfile"
 version = "3.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1532,7 +714,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1545,28 +727,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "tinystr"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
-dependencies = [
- "displaydoc",
- "zerovec",
-]
-
-[[package]]
 name = "tokio"
 version = "1.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
 dependencies = [
- "bytes",
- "libc",
- "mio",
  "pin-project-lite",
- "socket2",
  "tokio-macros",
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1579,84 +746,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
-]
-
-[[package]]
-name = "tokio-rustls"
-version = "0.26.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
-dependencies = [
- "rustls",
- "tokio",
-]
-
-[[package]]
-name = "tokio-util"
-version = "0.7.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
-dependencies = [
- "bytes",
- "futures-core",
- "futures-sink",
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
-name = "tower"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
-dependencies = [
- "futures-core",
- "futures-util",
- "pin-project-lite",
- "sync_wrapper",
- "tokio",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "tower-http"
-version = "0.6.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
-dependencies = [
- "bitflags",
- "bytes",
- "futures-util",
- "http",
- "http-body",
- "iri-string",
- "pin-project-lite",
- "tower",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "tower-layer"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
-
-[[package]]
-name = "tower-service"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
@@ -1733,12 +822,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "try-lock"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
-
-[[package]]
 name = "ulid"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1777,30 +860,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
-name = "untrusted"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
-
-[[package]]
-name = "url"
-version = "2.5.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
-dependencies = [
- "form_urlencoded",
- "idna",
- "percent-encoding",
- "serde",
-]
-
-[[package]]
-name = "utf8_iter"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
-
-[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1817,21 +876,6 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
-
-[[package]]
-name = "want"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
-dependencies = [
- "try-lock",
-]
-
-[[package]]
-name = "wasi"
-version = "0.11.1+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
@@ -1862,20 +906,6 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-futures"
-version = "0.4.64"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
-dependencies = [
- "cfg-if",
- "futures-util",
- "js-sys",
- "once_cell",
- "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
@@ -1945,16 +975,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "web-sys"
-version = "0.3.91"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "web-time"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1971,211 +991,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
-name = "windows-registry"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
-dependencies = [
- "windows-link",
- "windows-result",
- "windows-strings",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
-dependencies = [
- "windows-link",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
-dependencies = [
- "windows-link",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
-]
-
-[[package]]
 name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
-dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
-]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
-
-[[package]]
-name = "wiremock"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
-dependencies = [
- "assert-json-diff",
- "base64",
- "deadpool",
- "futures",
- "http",
- "http-body-util",
- "hyper",
- "hyper-util",
- "log",
- "once_cell",
- "regex",
- "serde",
- "serde_json",
- "tokio",
- "url",
 ]
 
 [[package]]
@@ -2267,39 +1088,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "writeable"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
-
-[[package]]
 name = "yansi"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
-
-[[package]]
-name = "yoke"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
-dependencies = [
- "stable_deref_trait",
- "yoke-derive",
- "zerofrom",
-]
-
-[[package]]
-name = "yoke-derive"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
-]
 
 [[package]]
 name = "zerocopy"
@@ -2315,66 +1107,6 @@ name = "zerocopy-derive"
 version = "0.8.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f65c489a7071a749c849713807783f70672b28094011623e200cb86dcb835953"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "zerofrom"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
-dependencies = [
- "zerofrom-derive",
-]
-
-[[package]]
-name = "zerofrom-derive"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
-]
-
-[[package]]
-name = "zeroize"
-version = "1.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
-
-[[package]]
-name = "zerotrie"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
-dependencies = [
- "displaydoc",
- "yoke",
- "zerofrom",
-]
-
-[[package]]
-name = "zerovec"
-version = "0.11.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
-dependencies = [
- "yoke",
- "zerofrom",
- "zerovec-derive",
-]
-
-[[package]]
-name = "zerovec-derive"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "crates/koina",
     "crates/mneme",
     "crates/nous",
+    "crates/organon",
     "crates/taxis",
 ]
 exclude = [
@@ -74,7 +75,11 @@ figment = { version = "0.10", features = ["yaml", "json", "env"] }
 
 # Types
 compact_str = { version = "0.8", features = ["serde"] }
+indexmap = { version = "2", features = ["serde"] }
 ulid = { version = "1", features = ["serde"] }
+
+# Async
+tokio = { version = "1", features = ["rt", "macros"] }
 
 # Testing
 static_assertions = "1.1"

--- a/crates/organon/Cargo.toml
+++ b/crates/organon/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "aletheia-organon"
+version = "0.1.0"
+description = "Tool registry, definitions, and built-in tool stubs"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+aletheia-hermeneus = { path = "../hermeneus" }
+aletheia-koina = { path = "../koina" }
+indexmap = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+snafu = { workspace = true }
+
+[dev-dependencies]
+static_assertions = { workspace = true }
+tokio = { workspace = true }

--- a/crates/organon/src/builtins/communication.rs
+++ b/crates/organon/src/builtins/communication.rs
@@ -1,0 +1,122 @@
+//! Communication tool stubs: message, `sessions_ask`.
+
+use std::future::Future;
+use std::pin::Pin;
+
+use aletheia_koina::id::ToolName;
+use indexmap::IndexMap;
+
+use crate::error::Result;
+use crate::registry::{ToolExecutor, ToolRegistry};
+use crate::types::{
+    InputSchema, PropertyDef, PropertyType, ToolCategory, ToolContext, ToolDef, ToolInput,
+    ToolResult,
+};
+
+struct Stub;
+
+impl ToolExecutor for Stub {
+    fn execute<'a>(
+        &'a self,
+        input: &'a ToolInput,
+        _ctx: &'a ToolContext,
+    ) -> Pin<Box<dyn Future<Output = Result<ToolResult>> + Send + 'a>> {
+        Box::pin(async {
+            Ok(ToolResult {
+                content: format!("stub: {} not implemented", input.name),
+                is_error: false,
+            })
+        })
+    }
+}
+
+/// Register communication tool stubs.
+pub fn register(registry: &mut ToolRegistry) -> Result<()> {
+    registry.register(message_def(), Box::new(Stub))?;
+    registry.register(sessions_ask_def(), Box::new(Stub))?;
+    Ok(())
+}
+
+fn message_def() -> ToolDef {
+    ToolDef {
+        name: ToolName::new("message").expect("valid tool name"),
+        description: "Send a message to a user or group via Signal".to_owned(),
+        extended_description: None,
+        input_schema: InputSchema {
+            properties: IndexMap::from([
+                (
+                    "to".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::String,
+                        description: "Recipient: phone (+1234567890), group (group:ID), or username (u:handle)".to_owned(),
+                        enum_values: None,
+                        default: None,
+                    },
+                ),
+                (
+                    "text".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::String,
+                        description: "Message text to send (markdown supported)".to_owned(),
+                        enum_values: None,
+                        default: None,
+                    },
+                ),
+            ]),
+            required: vec!["to".to_owned(), "text".to_owned()],
+        },
+        category: ToolCategory::Communication,
+        auto_activate: false,
+    }
+}
+
+fn sessions_ask_def() -> ToolDef {
+    ToolDef {
+        name: ToolName::new("sessions_ask").expect("valid tool name"),
+        description: "Ask another agent a question and wait for their response".to_owned(),
+        extended_description: None,
+        input_schema: InputSchema {
+            properties: IndexMap::from([
+                (
+                    "agentId".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::String,
+                        description: "Target nous ID (e.g., 'syn', 'eiron', 'arbor')".to_owned(),
+                        enum_values: None,
+                        default: None,
+                    },
+                ),
+                (
+                    "message".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::String,
+                        description: "Question or request to send".to_owned(),
+                        enum_values: None,
+                        default: None,
+                    },
+                ),
+                (
+                    "sessionKey".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::String,
+                        description: "Target session key (default: 'ask:<caller>')".to_owned(),
+                        enum_values: None,
+                        default: None,
+                    },
+                ),
+                (
+                    "timeoutSeconds".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::Number,
+                        description: "Max wait time in seconds (default: 120)".to_owned(),
+                        enum_values: None,
+                        default: Some(serde_json::json!(120)),
+                    },
+                ),
+            ]),
+            required: vec!["agentId".to_owned(), "message".to_owned()],
+        },
+        category: ToolCategory::Communication,
+        auto_activate: false,
+    }
+}

--- a/crates/organon/src/builtins/memory.rs
+++ b/crates/organon/src/builtins/memory.rs
@@ -1,0 +1,178 @@
+//! Memory tool stubs: `mem0_search`, note, blackboard.
+
+use std::future::Future;
+use std::pin::Pin;
+
+use aletheia_koina::id::ToolName;
+use indexmap::IndexMap;
+
+use crate::error::Result;
+use crate::registry::{ToolExecutor, ToolRegistry};
+use crate::types::{
+    InputSchema, PropertyDef, PropertyType, ToolCategory, ToolContext, ToolDef, ToolInput,
+    ToolResult,
+};
+
+struct Stub;
+
+impl ToolExecutor for Stub {
+    fn execute<'a>(
+        &'a self,
+        input: &'a ToolInput,
+        _ctx: &'a ToolContext,
+    ) -> Pin<Box<dyn Future<Output = Result<ToolResult>> + Send + 'a>> {
+        Box::pin(async {
+            Ok(ToolResult {
+                content: format!("stub: {} not implemented", input.name),
+                is_error: false,
+            })
+        })
+    }
+}
+
+/// Register memory tool stubs.
+pub fn register(registry: &mut ToolRegistry) -> Result<()> {
+    registry.register(mem0_search_def(), Box::new(Stub))?;
+    registry.register(note_def(), Box::new(Stub))?;
+    registry.register(blackboard_def(), Box::new(Stub))?;
+    Ok(())
+}
+
+fn mem0_search_def() -> ToolDef {
+    ToolDef {
+        name: ToolName::new("mem0_search").expect("valid tool name"),
+        description: "Search long-term memory for facts, preferences, and relationships"
+            .to_owned(),
+        extended_description: None,
+        input_schema: InputSchema {
+            properties: IndexMap::from([
+                (
+                    "query".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::String,
+                        description: "Semantic search query".to_owned(),
+                        enum_values: None,
+                        default: None,
+                    },
+                ),
+                (
+                    "limit".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::Number,
+                        description: "Max results (default 10)".to_owned(),
+                        enum_values: None,
+                        default: Some(serde_json::json!(10)),
+                    },
+                ),
+            ]),
+            required: vec!["query".to_owned()],
+        },
+        category: ToolCategory::Memory,
+        auto_activate: false,
+    }
+}
+
+fn note_def() -> ToolDef {
+    ToolDef {
+        name: ToolName::new("note").expect("valid tool name"),
+        description: "Write a note to persistent session memory that survives distillation"
+            .to_owned(),
+        extended_description: None,
+        input_schema: InputSchema {
+            properties: IndexMap::from([
+                (
+                    "action".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::String,
+                        description: "Action: 'add', 'list', 'delete'".to_owned(),
+                        enum_values: None,
+                        default: None,
+                    },
+                ),
+                (
+                    "content".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::String,
+                        description: "Note content (required for 'add', max 500 chars)".to_owned(),
+                        enum_values: None,
+                        default: None,
+                    },
+                ),
+                (
+                    "category".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::String,
+                        description:
+                            "Note category: task, decision, preference, correction, context"
+                                .to_owned(),
+                        enum_values: None,
+                        default: Some(serde_json::json!("context")),
+                    },
+                ),
+                (
+                    "id".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::Number,
+                        description: "Note ID (required for 'delete')".to_owned(),
+                        enum_values: None,
+                        default: None,
+                    },
+                ),
+            ]),
+            required: vec!["action".to_owned()],
+        },
+        category: ToolCategory::Memory,
+        auto_activate: false,
+    }
+}
+
+fn blackboard_def() -> ToolDef {
+    ToolDef {
+        name: ToolName::new("blackboard").expect("valid tool name"),
+        description: "Read and write shared state visible to all agents".to_owned(),
+        extended_description: None,
+        input_schema: InputSchema {
+            properties: IndexMap::from([
+                (
+                    "action".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::String,
+                        description: "Action: 'write', 'read', 'list', 'delete'".to_owned(),
+                        enum_values: None,
+                        default: None,
+                    },
+                ),
+                (
+                    "key".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::String,
+                        description: "Blackboard key (required for write/read/delete)".to_owned(),
+                        enum_values: None,
+                        default: None,
+                    },
+                ),
+                (
+                    "value".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::String,
+                        description: "Value to write (required for write action)".to_owned(),
+                        enum_values: None,
+                        default: None,
+                    },
+                ),
+                (
+                    "ttl_seconds".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::Number,
+                        description: "Time-to-live in seconds (default 3600)".to_owned(),
+                        enum_values: None,
+                        default: Some(serde_json::json!(3600)),
+                    },
+                ),
+            ]),
+            required: vec!["action".to_owned()],
+        },
+        category: ToolCategory::Memory,
+        auto_activate: false,
+    }
+}

--- a/crates/organon/src/builtins/mod.rs
+++ b/crates/organon/src/builtins/mod.rs
@@ -1,0 +1,16 @@
+//! Built-in tool stubs — prove the registry pattern with real schemas.
+
+pub mod communication;
+pub mod memory;
+pub mod workspace;
+
+use crate::error::Result;
+use crate::registry::ToolRegistry;
+
+/// Register all built-in tool stubs.
+pub fn register_all(registry: &mut ToolRegistry) -> Result<()> {
+    workspace::register(registry)?;
+    memory::register(registry)?;
+    communication::register(registry)?;
+    Ok(())
+}

--- a/crates/organon/src/builtins/workspace.rs
+++ b/crates/organon/src/builtins/workspace.rs
@@ -1,0 +1,194 @@
+//! Workspace tool stubs: read, write, edit, exec.
+
+use std::future::Future;
+use std::pin::Pin;
+
+use aletheia_koina::id::ToolName;
+use indexmap::IndexMap;
+
+use crate::error::Result;
+use crate::registry::{ToolExecutor, ToolRegistry};
+use crate::types::{
+    InputSchema, PropertyDef, PropertyType, ToolCategory, ToolContext, ToolDef, ToolInput,
+    ToolResult,
+};
+
+struct Stub;
+
+impl ToolExecutor for Stub {
+    fn execute<'a>(
+        &'a self,
+        input: &'a ToolInput,
+        _ctx: &'a ToolContext,
+    ) -> Pin<Box<dyn Future<Output = Result<ToolResult>> + Send + 'a>> {
+        Box::pin(async {
+            Ok(ToolResult {
+                content: format!("stub: {} not implemented", input.name),
+                is_error: false,
+            })
+        })
+    }
+}
+
+/// Register workspace tool stubs.
+pub fn register(registry: &mut ToolRegistry) -> Result<()> {
+    registry.register(read_def(), Box::new(Stub))?;
+    registry.register(write_def(), Box::new(Stub))?;
+    registry.register(edit_def(), Box::new(Stub))?;
+    registry.register(exec_def(), Box::new(Stub))?;
+    Ok(())
+}
+
+fn read_def() -> ToolDef {
+    ToolDef {
+        name: ToolName::new("read").expect("valid tool name"),
+        description: "Read a file's contents as text".to_owned(),
+        extended_description: None,
+        input_schema: InputSchema {
+            properties: IndexMap::from([
+                (
+                    "path".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::String,
+                        description: "File path (absolute or relative to workspace)".to_owned(),
+                        enum_values: None,
+                        default: None,
+                    },
+                ),
+                (
+                    "maxLines".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::Number,
+                        description: "Maximum lines to return (default: all)".to_owned(),
+                        enum_values: None,
+                        default: None,
+                    },
+                ),
+            ]),
+            required: vec!["path".to_owned()],
+        },
+        category: ToolCategory::Workspace,
+        auto_activate: false,
+    }
+}
+
+fn write_def() -> ToolDef {
+    ToolDef {
+        name: ToolName::new("write").expect("valid tool name"),
+        description: "Write content to a file, creating parent directories as needed".to_owned(),
+        extended_description: None,
+        input_schema: InputSchema {
+            properties: IndexMap::from([
+                (
+                    "path".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::String,
+                        description: "File path (absolute or relative to workspace)".to_owned(),
+                        enum_values: None,
+                        default: None,
+                    },
+                ),
+                (
+                    "content".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::String,
+                        description: "Content to write".to_owned(),
+                        enum_values: None,
+                        default: None,
+                    },
+                ),
+                (
+                    "append".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::Boolean,
+                        description: "Append instead of overwrite (default: false)".to_owned(),
+                        enum_values: None,
+                        default: Some(serde_json::json!(false)),
+                    },
+                ),
+            ]),
+            required: vec!["path".to_owned(), "content".to_owned()],
+        },
+        category: ToolCategory::Workspace,
+        auto_activate: false,
+    }
+}
+
+fn edit_def() -> ToolDef {
+    ToolDef {
+        name: ToolName::new("edit").expect("valid tool name"),
+        description: "Replace exact text in a file with new text".to_owned(),
+        extended_description: None,
+        input_schema: InputSchema {
+            properties: IndexMap::from([
+                (
+                    "path".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::String,
+                        description: "File path (absolute or relative to workspace)".to_owned(),
+                        enum_values: None,
+                        default: None,
+                    },
+                ),
+                (
+                    "old_text".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::String,
+                        description: "Exact text to find in the file".to_owned(),
+                        enum_values: None,
+                        default: None,
+                    },
+                ),
+                (
+                    "new_text".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::String,
+                        description: "Replacement text".to_owned(),
+                        enum_values: None,
+                        default: None,
+                    },
+                ),
+            ]),
+            required: vec![
+                "path".to_owned(),
+                "old_text".to_owned(),
+                "new_text".to_owned(),
+            ],
+        },
+        category: ToolCategory::Workspace,
+        auto_activate: false,
+    }
+}
+
+fn exec_def() -> ToolDef {
+    ToolDef {
+        name: ToolName::new("exec").expect("valid tool name"),
+        description: "Execute a shell command in your workspace and return stdout/stderr".to_owned(),
+        extended_description: None,
+        input_schema: InputSchema {
+            properties: IndexMap::from([
+                (
+                    "command".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::String,
+                        description: "The shell command to execute".to_owned(),
+                        enum_values: None,
+                        default: None,
+                    },
+                ),
+                (
+                    "timeout".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::Number,
+                        description: "Timeout in milliseconds (default 30000)".to_owned(),
+                        enum_values: None,
+                        default: Some(serde_json::json!(30000)),
+                    },
+                ),
+            ]),
+            required: vec!["command".to_owned()],
+        },
+        category: ToolCategory::Workspace,
+        auto_activate: false,
+    }
+}

--- a/crates/organon/src/error.rs
+++ b/crates/organon/src/error.rs
@@ -1,0 +1,55 @@
+//! Error types for the organon crate.
+
+use aletheia_koina::id::ToolName;
+use snafu::Snafu;
+
+/// Errors from tool registry operations.
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub(crate)))]
+#[non_exhaustive]
+pub enum Error {
+    /// Requested tool does not exist in the registry.
+    #[snafu(display("tool not found: {name}"))]
+    ToolNotFound {
+        name: ToolName,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    /// A tool with this name is already registered.
+    #[snafu(display("duplicate tool: {name}"))]
+    DuplicateTool {
+        name: ToolName,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    /// Tool input failed validation.
+    #[snafu(display("invalid input for tool {name}: {reason}"))]
+    InvalidInput {
+        name: ToolName,
+        reason: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    /// Tool execution returned an error.
+    #[snafu(display("tool execution failed: {name}"))]
+    ExecutionFailed {
+        name: ToolName,
+        source: Box<dyn std::error::Error + Send + Sync>,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    /// Failed to serialize an input schema to JSON.
+    #[snafu(display("schema serialization failed"))]
+    SchemaSerialization {
+        source: serde_json::Error,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+}
+
+/// Convenience alias.
+pub type Result<T> = std::result::Result<T, Error>;

--- a/crates/organon/src/lib.rs
+++ b/crates/organon/src/lib.rs
@@ -1,0 +1,21 @@
+//! aletheia-organon — tool registry, definitions, and built-in tool stubs
+//!
+//! Organon (ὄργανον) — "instrument." The formal instruments through which
+//! agent capability expresses. Provides the tool registry, definition types,
+//! and stub implementations for built-in tools.
+//!
+//! Depends on `aletheia-koina` (types) and `aletheia-hermeneus` (LLM wire format).
+
+pub mod builtins;
+pub mod error;
+pub mod registry;
+pub mod types;
+
+#[cfg(test)]
+mod assertions {
+    use static_assertions::assert_impl_all;
+
+    use super::registry::ToolRegistry;
+
+    assert_impl_all!(ToolRegistry: Send, Sync);
+}

--- a/crates/organon/src/registry.rs
+++ b/crates/organon/src/registry.rs
@@ -1,0 +1,354 @@
+//! Tool registry — the single source of truth for available tools.
+
+use std::future::Future;
+use std::pin::Pin;
+
+use aletheia_koina::id::ToolName;
+use indexmap::IndexMap;
+use snafu::ensure;
+
+use crate::error::{self, Result};
+use crate::types::{ToolCategory, ToolContext, ToolDef, ToolInput, ToolResult};
+
+/// The trait tool implementations must satisfy.
+///
+/// Uses `Pin<Box<dyn Future>>` for object-safety with async dispatch.
+pub trait ToolExecutor: Send + Sync {
+    /// Execute the tool with the given input and context.
+    fn execute<'a>(
+        &'a self,
+        input: &'a ToolInput,
+        ctx: &'a ToolContext,
+    ) -> Pin<Box<dyn Future<Output = Result<ToolResult>> + Send + 'a>>;
+}
+
+struct RegisteredTool {
+    def: ToolDef,
+    executor: Box<dyn ToolExecutor>,
+}
+
+/// Registry of available tools.
+///
+/// Tools are registered at startup and looked up by name during execution.
+/// The registry is the single source of truth for what tools an agent can use.
+pub struct ToolRegistry {
+    tools: IndexMap<ToolName, RegisteredTool>,
+}
+
+impl Default for ToolRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ToolRegistry {
+    /// Create an empty registry.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            tools: IndexMap::new(),
+        }
+    }
+
+    /// Register a tool. Fails if a tool with the same name already exists.
+    pub fn register(
+        &mut self,
+        def: ToolDef,
+        executor: Box<dyn ToolExecutor>,
+    ) -> Result<()> {
+        ensure!(
+            !self.tools.contains_key(&def.name),
+            error::DuplicateToolSnafu {
+                name: def.name.clone()
+            }
+        );
+        self.tools.insert(def.name.clone(), RegisteredTool { def, executor });
+        Ok(())
+    }
+
+    /// Look up a tool definition by name.
+    #[must_use]
+    pub fn get_def(&self, name: &ToolName) -> Option<&ToolDef> {
+        self.tools.get(name).map(|t| &t.def)
+    }
+
+    /// Execute a tool by name.
+    pub async fn execute(
+        &self,
+        input: &ToolInput,
+        ctx: &ToolContext,
+    ) -> Result<ToolResult> {
+        let tool = self.tools.get(&input.name).ok_or_else(|| {
+            error::ToolNotFoundSnafu {
+                name: input.name.clone(),
+            }
+            .build()
+        })?;
+        tool.executor.execute(input, ctx).await
+    }
+
+    /// All registered tool definitions, in insertion order.
+    #[must_use]
+    pub fn definitions(&self) -> Vec<&ToolDef> {
+        self.tools.values().map(|t| &t.def).collect()
+    }
+
+    /// Tool definitions filtered by category.
+    #[must_use]
+    pub fn definitions_for_category(&self, category: ToolCategory) -> Vec<&ToolDef> {
+        self.tools
+            .values()
+            .filter(|t| t.def.category == category)
+            .map(|t| &t.def)
+            .collect()
+    }
+
+    /// Convert registered tools to the LLM wire format.
+    ///
+    /// Produces `ToolDefinition` structs suitable for `CompletionRequest::tools`.
+    pub fn to_hermeneus_tools(&self) -> Vec<aletheia_hermeneus::types::ToolDefinition> {
+        self.tools
+            .values()
+            .map(|t| aletheia_hermeneus::types::ToolDefinition {
+                name: t.def.name.as_str().to_owned(),
+                description: t.def.description.clone(),
+                input_schema: t.def.input_schema.to_json_schema(),
+            })
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use aletheia_koina::id::{NousId, SessionId};
+
+    use super::*;
+    use crate::types::{InputSchema, PropertyDef, PropertyType};
+
+    /// Mock executor that captures calls for verification.
+    struct MockExecutor {
+        calls: Arc<Mutex<Vec<ToolName>>>,
+        response: String,
+    }
+
+    impl ToolExecutor for MockExecutor {
+        fn execute<'a>(
+            &'a self,
+            input: &'a ToolInput,
+            _ctx: &'a ToolContext,
+        ) -> Pin<Box<dyn Future<Output = Result<ToolResult>> + Send + 'a>> {
+            Box::pin(async {
+                self.calls.lock().expect("lock").push(input.name.clone());
+                Ok(ToolResult {
+                    content: self.response.clone(),
+                    is_error: false,
+                })
+            })
+        }
+    }
+
+    fn test_ctx() -> ToolContext {
+        ToolContext {
+            nous_id: NousId::new("test-agent").expect("valid"),
+            session_id: SessionId::new(),
+            workspace: std::path::PathBuf::from("/tmp/test"),
+            allowed_roots: vec![std::path::PathBuf::from("/tmp")],
+        }
+    }
+
+    fn test_def(name: &str, category: ToolCategory) -> ToolDef {
+        ToolDef {
+            name: ToolName::new(name).expect("valid"),
+            description: format!("Test tool: {name}"),
+            extended_description: None,
+            input_schema: InputSchema {
+                properties: IndexMap::new(),
+                required: vec![],
+            },
+            category,
+            auto_activate: false,
+        }
+    }
+
+    fn mock_executor(response: &str) -> (Box<dyn ToolExecutor>, Arc<Mutex<Vec<ToolName>>>) {
+        let calls = Arc::new(Mutex::new(Vec::new()));
+        let executor = Box::new(MockExecutor {
+            calls: Arc::clone(&calls),
+            response: response.to_owned(),
+        });
+        (executor, calls)
+    }
+
+    #[test]
+    fn register_and_lookup() {
+        let mut reg = ToolRegistry::new();
+        let (exec, _) = mock_executor("ok");
+        reg.register(test_def("read", ToolCategory::Workspace), exec)
+            .expect("register");
+
+        let name = ToolName::new("read").expect("valid");
+        let def = reg.get_def(&name).expect("found");
+        assert_eq!(def.name.as_str(), "read");
+    }
+
+    #[test]
+    fn duplicate_rejection() {
+        let mut reg = ToolRegistry::new();
+        let (exec1, _) = mock_executor("ok");
+        let (exec2, _) = mock_executor("ok");
+        reg.register(test_def("read", ToolCategory::Workspace), exec1)
+            .expect("first register");
+        let err = reg
+            .register(test_def("read", ToolCategory::Workspace), exec2)
+            .expect_err("duplicate");
+        assert!(err.to_string().contains("duplicate tool: read"));
+    }
+
+    #[test]
+    fn lookup_missing() {
+        let reg = ToolRegistry::new();
+        let name = ToolName::new("nonexistent").expect("valid");
+        assert!(reg.get_def(&name).is_none());
+    }
+
+    #[tokio::test]
+    async fn execute_dispatches_correctly() {
+        let mut reg = ToolRegistry::new();
+        let (exec, calls) = mock_executor("hello");
+        reg.register(test_def("greet", ToolCategory::System), exec)
+            .expect("register");
+
+        let input = ToolInput {
+            name: ToolName::new("greet").expect("valid"),
+            tool_use_id: "toolu_1".to_owned(),
+            arguments: serde_json::json!({}),
+        };
+        let result = reg.execute(&input, &test_ctx()).await.expect("execute");
+        assert_eq!(result.content, "hello");
+        assert!(!result.is_error);
+        assert_eq!(calls.lock().expect("lock").len(), 1);
+    }
+
+    #[tokio::test]
+    async fn execute_not_found() {
+        let reg = ToolRegistry::new();
+        let input = ToolInput {
+            name: ToolName::new("missing").expect("valid"),
+            tool_use_id: "toolu_1".to_owned(),
+            arguments: serde_json::json!({}),
+        };
+        let err = reg.execute(&input, &test_ctx()).await.expect_err("missing");
+        assert!(err.to_string().contains("tool not found: missing"));
+    }
+
+    #[test]
+    fn category_filtering() {
+        let mut reg = ToolRegistry::new();
+        let (e1, _) = mock_executor("ok");
+        let (e2, _) = mock_executor("ok");
+        let (e3, _) = mock_executor("ok");
+        reg.register(test_def("read", ToolCategory::Workspace), e1)
+            .expect("register");
+        reg.register(test_def("write", ToolCategory::Workspace), e2)
+            .expect("register");
+        reg.register(test_def("note", ToolCategory::Memory), e3)
+            .expect("register");
+
+        let ws = reg.definitions_for_category(ToolCategory::Workspace);
+        assert_eq!(ws.len(), 2);
+        let mem = reg.definitions_for_category(ToolCategory::Memory);
+        assert_eq!(mem.len(), 1);
+        let comm = reg.definitions_for_category(ToolCategory::Communication);
+        assert!(comm.is_empty());
+    }
+
+    #[test]
+    fn definitions_returns_all() {
+        let mut reg = ToolRegistry::new();
+        let (e1, _) = mock_executor("ok");
+        let (e2, _) = mock_executor("ok");
+        reg.register(test_def("a", ToolCategory::Workspace), e1)
+            .expect("register");
+        reg.register(test_def("b", ToolCategory::Memory), e2)
+            .expect("register");
+        assert_eq!(reg.definitions().len(), 2);
+    }
+
+    #[test]
+    fn to_hermeneus_tools_produces_valid_definitions() {
+        let mut reg = ToolRegistry::new();
+        let (exec, _) = mock_executor("ok");
+        let def = ToolDef {
+            name: ToolName::new("read").expect("valid"),
+            description: "Read a file".to_owned(),
+            extended_description: None,
+            input_schema: InputSchema {
+                properties: IndexMap::from([(
+                    "path".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::String,
+                        description: "File path".to_owned(),
+                        enum_values: None,
+                        default: None,
+                    },
+                )]),
+                required: vec!["path".to_owned()],
+            },
+            category: ToolCategory::Workspace,
+            auto_activate: false,
+        };
+        reg.register(def, exec).expect("register");
+
+        let tools = reg.to_hermeneus_tools();
+        assert_eq!(tools.len(), 1);
+        assert_eq!(tools[0].name, "read");
+        assert_eq!(tools[0].description, "Read a file");
+        assert_eq!(tools[0].input_schema["type"], "object");
+        assert_eq!(tools[0].input_schema["properties"]["path"]["type"], "string");
+    }
+
+    #[tokio::test]
+    async fn context_passed_to_executor() {
+        struct CtxCapture {
+            captured_nous_id: Arc<Mutex<Option<String>>>,
+        }
+        impl ToolExecutor for CtxCapture {
+            fn execute<'a>(
+                &'a self,
+                _input: &'a ToolInput,
+                ctx: &'a ToolContext,
+            ) -> Pin<Box<dyn Future<Output = Result<ToolResult>> + Send + 'a>> {
+                let nous_id = ctx.nous_id.as_str().to_owned();
+                let captured = Arc::clone(&self.captured_nous_id);
+                Box::pin(async move {
+                    *captured.lock().expect("lock") = Some(nous_id);
+                    Ok(ToolResult {
+                        content: "ok".to_owned(),
+                        is_error: false,
+                    })
+                })
+            }
+        }
+
+        let captured = Arc::new(Mutex::new(None));
+        let executor = Box::new(CtxCapture {
+            captured_nous_id: Arc::clone(&captured),
+        });
+
+        let mut reg = ToolRegistry::new();
+        reg.register(test_def("ctx-test", ToolCategory::System), executor)
+            .expect("register");
+
+        let input = ToolInput {
+            name: ToolName::new("ctx-test").expect("valid"),
+            tool_use_id: "toolu_1".to_owned(),
+            arguments: serde_json::json!({}),
+        };
+        reg.execute(&input, &test_ctx()).await.expect("execute");
+
+        let id = captured.lock().expect("lock").clone();
+        assert_eq!(id.as_deref(), Some("test-agent"));
+    }
+}

--- a/crates/organon/src/types.rs
+++ b/crates/organon/src/types.rs
@@ -1,0 +1,279 @@
+//! Core types for tool definitions, input/output, and execution context.
+
+use std::path::PathBuf;
+
+use aletheia_koina::id::{NousId, SessionId, ToolName};
+use indexmap::IndexMap;
+use serde::{Deserialize, Serialize};
+
+/// Tool definition — the rich metadata that organon tracks internally.
+///
+/// Converted to `hermeneus::types::ToolDefinition` (the lean LLM wire format)
+/// via `ToolRegistry::to_hermeneus_tools`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ToolDef {
+    /// Validated tool name.
+    pub name: ToolName,
+    /// Short description sent to the LLM (token-budget friendly).
+    pub description: String,
+    /// Detailed description for extended-thinking mode.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extended_description: Option<String>,
+    /// JSON Schema for the tool's input parameters.
+    pub input_schema: InputSchema,
+    /// Semantic category.
+    pub category: ToolCategory,
+    /// Whether the tool activates automatically by domain without explicit config.
+    pub auto_activate: bool,
+}
+
+/// JSON Schema for tool input parameters.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InputSchema {
+    /// Property definitions, insertion-ordered.
+    pub properties: IndexMap<String, PropertyDef>,
+    /// Names of required properties.
+    pub required: Vec<String>,
+}
+
+impl InputSchema {
+    /// Serialize to a JSON Schema `{"type": "object", ...}` value
+    /// suitable for `hermeneus::types::ToolDefinition::input_schema`.
+    pub fn to_json_schema(&self) -> serde_json::Value {
+        let mut props = serde_json::Map::new();
+        for (name, def) in &self.properties {
+            let mut prop = serde_json::Map::new();
+            prop.insert(
+                "type".to_owned(),
+                serde_json::to_value(def.property_type)
+                    .unwrap_or(serde_json::Value::String("string".to_owned())),
+            );
+            prop.insert(
+                "description".to_owned(),
+                serde_json::Value::String(def.description.clone()),
+            );
+            if let Some(ref enum_vals) = def.enum_values {
+                prop.insert(
+                    "enum".to_owned(),
+                    serde_json::Value::Array(
+                        enum_vals
+                            .iter()
+                            .map(|v| serde_json::Value::String(v.clone()))
+                            .collect(),
+                    ),
+                );
+            }
+            if let Some(ref default) = def.default {
+                prop.insert("default".to_owned(), default.clone());
+            }
+            props.insert(name.clone(), serde_json::Value::Object(prop));
+        }
+
+        serde_json::json!({
+            "type": "object",
+            "properties": props,
+            "required": self.required,
+        })
+    }
+}
+
+/// A single property in the input schema.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PropertyDef {
+    /// The JSON Schema type.
+    #[serde(rename = "type")]
+    pub property_type: PropertyType,
+    /// Human-readable description.
+    pub description: String,
+    /// Allowed enum values, if constrained.
+    #[serde(rename = "enum", skip_serializing_if = "Option::is_none")]
+    pub enum_values: Option<Vec<String>>,
+    /// Default value.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub default: Option<serde_json::Value>,
+}
+
+/// JSON Schema primitive types.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+#[non_exhaustive]
+pub enum PropertyType {
+    String,
+    Number,
+    Integer,
+    Boolean,
+    Array,
+    Object,
+}
+
+impl std::fmt::Display for PropertyType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::String => f.write_str("string"),
+            Self::Number => f.write_str("number"),
+            Self::Integer => f.write_str("integer"),
+            Self::Boolean => f.write_str("boolean"),
+            Self::Array => f.write_str("array"),
+            Self::Object => f.write_str("object"),
+        }
+    }
+}
+
+/// Semantic tool category — classifies tool purpose.
+///
+/// This is a semantic classification, not a loading strategy.
+/// The loading strategy (essential vs available) is orthogonal.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum ToolCategory {
+    /// Filesystem operations.
+    Workspace,
+    /// Memory operations.
+    Memory,
+    /// Messaging and cross-agent communication.
+    Communication,
+    /// Planning and deliberation.
+    Planning,
+    /// System and configuration.
+    System,
+    /// Agent coordination and spawning.
+    Agent,
+}
+
+impl std::fmt::Display for ToolCategory {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Workspace => f.write_str("workspace"),
+            Self::Memory => f.write_str("memory"),
+            Self::Communication => f.write_str("communication"),
+            Self::Planning => f.write_str("planning"),
+            Self::System => f.write_str("system"),
+            Self::Agent => f.write_str("agent"),
+        }
+    }
+}
+
+/// What the tool executor returns.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ToolResult {
+    /// Result content (text or JSON string).
+    pub content: String,
+    /// Whether this result represents an error.
+    pub is_error: bool,
+}
+
+/// Input to a tool execution (from the LLM's `tool_use` block).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ToolInput {
+    /// Which tool to invoke.
+    pub name: ToolName,
+    /// The `tool_use` block ID from the LLM response.
+    pub tool_use_id: String,
+    /// The arguments the LLM provided.
+    pub arguments: serde_json::Value,
+}
+
+/// Execution context passed to every tool invocation.
+#[derive(Debug, Clone)]
+pub struct ToolContext {
+    /// The agent executing this tool.
+    pub nous_id: NousId,
+    /// Current session.
+    pub session_id: SessionId,
+    /// Agent workspace root.
+    pub workspace: PathBuf,
+    /// Allowed filesystem roots for sandboxing.
+    pub allowed_roots: Vec<PathBuf>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tool_def_serde_roundtrip() {
+        let def = ToolDef {
+            name: ToolName::new("test_tool").expect("valid"),
+            description: "A test tool".to_owned(),
+            extended_description: Some("Detailed description".to_owned()),
+            input_schema: InputSchema {
+                properties: IndexMap::from([(
+                    "path".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::String,
+                        description: "File path".to_owned(),
+                        enum_values: None,
+                        default: None,
+                    },
+                )]),
+                required: vec!["path".to_owned()],
+            },
+            category: ToolCategory::Workspace,
+            auto_activate: false,
+        };
+        let json = serde_json::to_string(&def).expect("serialize");
+        let back: ToolDef = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back.name.as_str(), "test_tool");
+        assert_eq!(back.category, ToolCategory::Workspace);
+    }
+
+    #[test]
+    fn input_schema_to_json_schema() {
+        let schema = InputSchema {
+            properties: IndexMap::from([
+                (
+                    "path".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::String,
+                        description: "File path".to_owned(),
+                        enum_values: None,
+                        default: None,
+                    },
+                ),
+                (
+                    "max_lines".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::Number,
+                        description: "Maximum lines".to_owned(),
+                        enum_values: None,
+                        default: Some(serde_json::json!(100)),
+                    },
+                ),
+            ]),
+            required: vec!["path".to_owned()],
+        };
+        let json_schema = schema.to_json_schema();
+        assert_eq!(json_schema["type"], "object");
+        assert_eq!(json_schema["properties"]["path"]["type"], "string");
+        assert_eq!(json_schema["properties"]["max_lines"]["default"], 100);
+        assert_eq!(json_schema["required"][0], "path");
+    }
+
+    #[test]
+    fn property_type_serde() {
+        let json = serde_json::to_string(&PropertyType::Integer).expect("serialize");
+        assert_eq!(json, "\"integer\"");
+        let back: PropertyType = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back, PropertyType::Integer);
+    }
+
+    #[test]
+    fn tool_category_display() {
+        assert_eq!(ToolCategory::Workspace.to_string(), "workspace");
+        assert_eq!(ToolCategory::Communication.to_string(), "communication");
+    }
+
+    #[test]
+    fn tool_input_serde_roundtrip() {
+        let input = ToolInput {
+            name: ToolName::new("read").expect("valid"),
+            tool_use_id: "toolu_123".to_owned(),
+            arguments: serde_json::json!({"path": "/tmp/test.txt"}),
+        };
+        let json = serde_json::to_string(&input).expect("serialize");
+        let back: ToolInput = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back.name.as_str(), "read");
+        assert_eq!(back.tool_use_id, "toolu_123");
+    }
+}


### PR DESCRIPTION
## Summary

M2.1 — `aletheia-organon` crate (1,282 lines):

- **Core types:** `ToolDef`, `InputSchema`, `PropertyDef`, `PropertyType`, `ToolCategory`, `ToolResult`, `ToolInput`, `ToolContext`
- **Registry:** `ToolRegistry` with register/execute/definitions/category filtering/`to_hermeneus_tools()`
- **Async executor trait:** `ToolExecutor` with `Pin<Box<dyn Future>>` for dyn dispatch (no async-trait crate)
- **9 built-in stubs:** workspace (read/write/edit/exec), memory (mem0_search/note/blackboard), communication (message/sessions_ask)
- **Error hierarchy:** snafu with `Location` tracking — `ToolNotFound`, `DuplicateTool`, `InvalidInput`, `ExecutionFailed`, `SchemaSerialization`

### Key design decisions

- Uses `ToolName` newtype from koina (validated, not bare String)
- Converts to `hermeneus::types::ToolDefinition` for LLM wire format
- Full `ToolContext` (NousId, SessionId, workspace, allowed_roots) passed to every executor
- `#[non_exhaustive]` on `ToolCategory` and `PropertyType`
- `IndexMap` for insertion-ordered tool storage

### Checks

- 14 new tests, 149 total workspace tests pass
- Zero clippy warnings
- Docs build clean