### PR TITLE
feat(hermeneus): Anthropic API provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,11 +16,15 @@ name = "aletheia-hermeneus"
 version = "0.1.0"
 dependencies = [
  "aletheia-koina",
+ "reqwest",
+ "secrecy",
  "serde",
  "serde_json",
  "snafu",
  "static_assertions",
+ "tokio",
  "tracing",
+ "wiremock",
 ]
 
 [[package]]
@@ -100,6 +104,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "atomic"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -107,6 +121,18 @@ checksum = "a89cbf775b137e9b968e67227ef7f775587cde3fd31b0d8599dbd0f598a48340"
 dependencies = [
  "bytemuck",
 ]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
@@ -125,6 +151,12 @@ name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+
+[[package]]
+name = "bytes"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "castaway"
@@ -167,6 +199,70 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "deadpool"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
+dependencies = [
+ "deadpool-runtime",
+ "lazy_static",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+
+[[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -179,7 +275,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -222,10 +318,139 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
 
 [[package]]
 name = "getrandom"
@@ -250,6 +475,25 @@ dependencies = [
  "r-efi",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -283,10 +527,243 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "http"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hyper"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "pin-utils",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2",
+ "system-configuration",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "windows-registry",
+]
+
+[[package]]
+name = "icu_collections"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+
+[[package]]
+name = "icu_properties"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+
+[[package]]
+name = "icu_provider"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "indexmap"
@@ -305,6 +782,22 @@ name = "inlinable_string"
 version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8fae54786f62fb2918dcfae3d568594e50eb9b5c25bf04371af6fe7516452fb"
+
+[[package]]
+name = "ipnet"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+
+[[package]]
+name = "iri-string"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
+dependencies = [
+ "memchr",
+ "serde",
+]
 
 [[package]]
 name = "itoa"
@@ -358,6 +851,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
+name = "litemap"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -379,12 +878,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mio"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -392,6 +935,50 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "openssl"
+version = "0.10.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.111"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "pear"
@@ -417,16 +1004,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+dependencies = [
+ "zerovec",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -514,6 +1122,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "regex-automata"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -529,6 +1149,62 @@ name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "encoding_rs",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-tls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-native-tls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "rusqlite"
@@ -554,7 +1230,40 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+dependencies = [
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -568,6 +1277,48 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "schannel"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "secrecy"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
+dependencies = [
+ "serde",
+ "zeroize",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"
@@ -619,6 +1370,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "serde_yaml"
 version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -645,6 +1408,12 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
@@ -674,10 +1443,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
+dependencies = [
+ "libc",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -691,6 +1482,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -700,7 +1532,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -711,6 +1543,120 @@ checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "tinystr"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
+name = "tokio"
+version = "1.49.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
+dependencies = [
+ "bytes",
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "socket2",
+ "tokio-macros",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "iri-string",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
@@ -787,6 +1733,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "ulid"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -825,6 +1777,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -841,6 +1817,21 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
@@ -871,6 +1862,20 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -940,6 +1945,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-sys"
+version = "0.3.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "web-time"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -956,12 +1971,211 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
 name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "wiremock"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
+dependencies = [
+ "assert-json-diff",
+ "base64",
+ "deadpool",
+ "futures",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
 ]
 
 [[package]]
@@ -1053,10 +2267,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "writeable"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
 name = "yansi"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
+
+[[package]]
+name = "yoke"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
 
 [[package]]
 name = "zerocopy"
@@ -1072,6 +2315,66 @@ name = "zerocopy-derive"
 version = "0.8.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f65c489a7071a749c849713807783f70672b28094011623e200cb86dcb835953"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,12 @@ snafu = "0.8"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 
+# HTTP
+reqwest = { version = "0.12", features = ["blocking", "json"] }
+
+# Secrets
+secrecy = { version = "0.10", features = ["serde"] }
+
 # Tracing
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
@@ -72,6 +78,8 @@ ulid = { version = "1", features = ["serde"] }
 
 # Testing
 static_assertions = "1.1"
+tokio = { version = "1", features = ["macros", "rt"] }
+wiremock = "0.6"
 
 [profile.dev]
 opt-level = 1

--- a/crates/hermeneus/Cargo.toml
+++ b/crates/hermeneus/Cargo.toml
@@ -12,6 +12,8 @@ workspace = true
 
 [dependencies]
 aletheia-koina = { path = "../koina" }
+reqwest = { workspace = true }
+secrecy = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 snafu = { workspace = true }
@@ -19,3 +21,5 @@ tracing = { workspace = true }
 
 [dev-dependencies]
 static_assertions = { workspace = true }
+tokio = { workspace = true }
+wiremock = { workspace = true }

--- a/crates/hermeneus/src/anthropic/client.rs
+++ b/crates/hermeneus/src/anthropic/client.rs
@@ -1,0 +1,242 @@
+//! Anthropic Messages API provider.
+
+use std::time::Duration;
+
+use reqwest::blocking::Client;
+use reqwest::header::{HeaderMap, HeaderValue};
+use secrecy::{ExposeSecret, SecretString};
+use snafu::ResultExt;
+use tracing::instrument;
+
+use crate::error::{self, Result};
+use crate::provider::{LlmProvider, ProviderConfig};
+use crate::types::{CompletionRequest, CompletionResponse};
+
+use super::stream::{parse_sse_stream, StreamAccumulator, StreamEvent};
+use super::wire::WireRequest;
+
+const DEFAULT_BASE_URL: &str = "https://api.anthropic.com";
+const DEFAULT_API_VERSION: &str = "2023-06-01";
+const DEFAULT_MAX_RETRIES: u32 = 3;
+
+const BACKOFF_BASE_MS: u64 = 1000;
+const BACKOFF_FACTOR: u64 = 2;
+const BACKOFF_MAX_MS: u64 = 30_000;
+
+static SUPPORTED_MODELS: &[&str] = &[
+    "claude-opus-4-20250514",
+    "claude-sonnet-4-20250514",
+    "claude-haiku-4-5-20251001",
+];
+
+/// Anthropic Messages API provider.
+pub struct AnthropicProvider {
+    client: Client,
+    api_key: SecretString,
+    base_url: String,
+    api_version: String,
+    max_retries: u32,
+}
+
+impl AnthropicProvider {
+    /// Create a provider from configuration.
+    ///
+    /// # Errors
+    /// Returns `ProviderInit` if `api_key` is missing.
+    pub fn from_config(config: &ProviderConfig) -> Result<Self> {
+        let api_key = config
+            .api_key
+            .as_ref()
+            .filter(|k| !k.is_empty())
+            .ok_or_else(|| {
+                error::ProviderInitSnafu {
+                    message: "api_key is required for Anthropic provider".to_owned(),
+                }
+                .build()
+            })?;
+
+        let client = Client::builder()
+            .timeout(Duration::from_secs(120))
+            .build()
+            .map_err(|e| {
+                error::ProviderInitSnafu {
+                    message: format!("failed to build HTTP client: {e}"),
+                }
+                .build()
+            })?;
+
+        Ok(Self {
+            client,
+            api_key: SecretString::from(api_key.clone()),
+            base_url: config
+                .base_url
+                .clone()
+                .unwrap_or_else(|| DEFAULT_BASE_URL.to_owned()),
+            api_version: DEFAULT_API_VERSION.to_owned(),
+            max_retries: config.max_retries.unwrap_or(DEFAULT_MAX_RETRIES),
+        })
+    }
+
+    /// Streaming completion — accumulates into a final `CompletionResponse`
+    /// while emitting deltas to the callback.
+    ///
+    /// This is an `AnthropicProvider`-specific method. The sync `LlmProvider`
+    /// trait only exposes `complete()`. When the trait goes async in M2, this
+    /// will become the primary implementation.
+    #[instrument(skip(self, request, on_event), fields(model = %request.model))]
+    pub fn complete_streaming(
+        &self,
+        request: &CompletionRequest,
+        mut on_event: impl FnMut(StreamEvent),
+    ) -> Result<CompletionResponse> {
+        let wire = WireRequest::from_request(request, Some(true));
+        let body = serde_json::to_string(&wire).context(error::ParseResponseSnafu)?;
+
+        let response = self
+            .client
+            .post(format!("{}/v1/messages", self.base_url))
+            .headers(self.build_headers())
+            .body(body)
+            .send()
+            .map_err(|e| super::error::map_request_error(&e))?;
+
+        if !response.status().is_success() {
+            return Err(super::error::map_error_response(response));
+        }
+
+        let reader = std::io::BufReader::new(response);
+        let mut accumulator = StreamAccumulator::new();
+        parse_sse_stream(reader, &mut accumulator, &mut on_event)?;
+
+        Ok(accumulator.finish())
+    }
+
+    fn build_headers(&self) -> HeaderMap {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "x-api-key",
+            HeaderValue::from_str(self.api_key.expose_secret())
+                .unwrap_or_else(|_| HeaderValue::from_static("")),
+        );
+        headers.insert(
+            "anthropic-version",
+            HeaderValue::from_str(&self.api_version)
+                .unwrap_or_else(|_| HeaderValue::from_static(DEFAULT_API_VERSION)),
+        );
+        headers.insert("content-type", HeaderValue::from_static("application/json"));
+        headers
+    }
+
+    fn execute_with_retry(&self, request: &CompletionRequest) -> Result<CompletionResponse> {
+        let wire = WireRequest::from_request(request, None);
+        let body = serde_json::to_string(&wire).context(error::ParseResponseSnafu)?;
+
+        let mut last_error = None;
+        let headers = self.build_headers();
+
+        for attempt in 0..=self.max_retries {
+            if attempt > 0 {
+                std::thread::sleep(backoff_delay(attempt, last_error.as_ref()));
+            }
+
+            let response = match self
+                .client
+                .post(format!("{}/v1/messages", self.base_url))
+                .headers(headers.clone())
+                .body(body.clone())
+                .send()
+            {
+                Ok(r) => r,
+                Err(e) => {
+                    last_error = Some(super::error::map_request_error(&e));
+                    continue;
+                }
+            };
+
+            let status = response.status().as_u16();
+
+            if response.status().is_success() {
+                let text = response.text().map_err(|e| {
+                    error::ApiRequestSnafu {
+                        message: format!("failed to read response body: {e}"),
+                    }
+                    .build()
+                })?;
+                return super::error::parse_response_body::<super::wire::WireResponse>(&text)
+                    .and_then(|r| {
+                        r.into_response()
+                            .map_err(|msg| error::ApiRequestSnafu { message: msg }.build())
+                    });
+            }
+
+            let err = super::error::map_error_response(response);
+
+            // Non-retryable: 401, 400-level (except 429).
+            if status == 401 || ((400..500).contains(&status) && status != 429) {
+                return Err(err);
+            }
+
+            // Retryable: 429, 5xx, network errors.
+            last_error = Some(err);
+        }
+
+        Err(last_error.unwrap_or_else(|| {
+            error::ApiRequestSnafu {
+                message: "request failed after all retries".to_owned(),
+            }
+            .build()
+        }))
+    }
+}
+
+impl LlmProvider for AnthropicProvider {
+    #[instrument(skip(self, request), fields(model = %request.model))]
+    fn complete(&self, request: &CompletionRequest) -> Result<CompletionResponse> {
+        self.execute_with_retry(request)
+    }
+
+    fn supported_models(&self) -> &[&str] {
+        SUPPORTED_MODELS
+    }
+
+    #[expect(
+        clippy::unnecessary_literal_bound,
+        reason = "trait requires &str return, static string is fine"
+    )]
+    fn name(&self) -> &str {
+        "anthropic"
+    }
+}
+
+fn backoff_delay(attempt: u32, last_error: Option<&error::Error>) -> Duration {
+    if let Some(error::Error::RateLimited {
+        retry_after_ms, ..
+    }) = last_error
+    {
+        return Duration::from_millis(*retry_after_ms);
+    }
+
+    let base = BACKOFF_BASE_MS * BACKOFF_FACTOR.pow(attempt.saturating_sub(1));
+    let capped = base.min(BACKOFF_MAX_MS);
+
+    // ±25% jitter via integer math: range = capped / 4
+    let jitter_range = capped / 4;
+    let delay = if jitter_range > 0 {
+        let offset = (u64::from(attempt) * 7 + 13) % (jitter_range * 2);
+        capped - jitter_range + offset
+    } else {
+        capped
+    };
+
+    Duration::from_millis(delay.max(100))
+}
+
+impl std::fmt::Debug for AnthropicProvider {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AnthropicProvider")
+            .field("base_url", &self.base_url)
+            .field("api_version", &self.api_version)
+            .field("max_retries", &self.max_retries)
+            .finish_non_exhaustive()
+    }
+}

--- a/crates/hermeneus/src/anthropic/error.rs
+++ b/crates/hermeneus/src/anthropic/error.rs
@@ -1,0 +1,55 @@
+//! Anthropic API error mapping to hermeneus error variants.
+
+use reqwest::blocking::Response;
+use snafu::ResultExt;
+
+use super::wire::WireErrorResponse;
+use crate::error::{self, Result};
+
+/// Map an HTTP response with a non-success status to a hermeneus error.
+///
+/// Consumes the response body to extract the Anthropic error detail.
+pub(crate) fn map_error_response(response: Response) -> error::Error {
+    let status = response.status().as_u16();
+    let retry_after_ms = extract_retry_after(&response);
+
+    let detail = response
+        .text()
+        .ok()
+        .and_then(|body| serde_json::from_str::<WireErrorResponse>(&body).ok())
+        .map(|e| e.error.message);
+
+    let message = detail.unwrap_or_else(|| format!("HTTP {status}"));
+
+    match status {
+        401 => error::AuthFailedSnafu { message }.build(),
+        429 => error::RateLimitedSnafu {
+            retry_after_ms: retry_after_ms.unwrap_or(1000),
+        }
+        .build(),
+        _ => error::ApiSnafu { status, message }.build(),
+    }
+}
+
+/// Map a reqwest transport error to a hermeneus error.
+pub(crate) fn map_request_error(err: &reqwest::Error) -> error::Error {
+    error::ApiRequestSnafu {
+        message: err.to_string(),
+    }
+    .build()
+}
+
+/// Parse a response body as JSON, mapping parse failures to `ParseResponse`.
+pub(crate) fn parse_response_body<T: serde::de::DeserializeOwned>(body: &str) -> Result<T> {
+    serde_json::from_str(body).context(error::ParseResponseSnafu)
+}
+
+/// Extract `retry-after` header value as milliseconds.
+fn extract_retry_after(response: &Response) -> Option<u64> {
+    response
+        .headers()
+        .get("retry-after")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.parse::<u64>().ok())
+        .map(|secs| secs * 1000)
+}

--- a/crates/hermeneus/src/anthropic/mod.rs
+++ b/crates/hermeneus/src/anthropic/mod.rs
@@ -1,0 +1,9 @@
+//! Anthropic Messages API provider implementation.
+
+mod client;
+pub(crate) mod error;
+pub(crate) mod stream;
+pub(crate) mod wire;
+
+pub use client::AnthropicProvider;
+pub use stream::StreamEvent;

--- a/crates/hermeneus/src/anthropic/stream.rs
+++ b/crates/hermeneus/src/anthropic/stream.rs
@@ -1,0 +1,454 @@
+//! SSE streaming parser for the Anthropic Messages API.
+
+use std::io::BufRead;
+
+use crate::error::{self, Result};
+use crate::types::{CompletionResponse, ContentBlock, StopReason, Usage};
+
+use super::wire::{
+    WireContentBlockStart, WireDelta, WireStreamEvent, WireUsage,
+};
+
+/// Event emitted during streaming completion.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub enum StreamEvent {
+    /// Incremental text content.
+    TextDelta { text: String },
+    /// Incremental thinking content.
+    ThinkingDelta { thinking: String },
+    /// Incremental tool input JSON.
+    InputJsonDelta { partial_json: String },
+    /// A content block has started.
+    ContentBlockStart { index: u32, block_type: String },
+    /// A content block has finished.
+    ContentBlockStop { index: u32 },
+    /// Message started with initial usage.
+    MessageStart { usage: Usage },
+    /// Message finished with final stop reason and usage.
+    MessageStop {
+        stop_reason: StopReason,
+        usage: Usage,
+    },
+}
+
+/// Accumulator state for building a `CompletionResponse` from SSE events.
+pub(crate) struct StreamAccumulator {
+    id: String,
+    model: String,
+    stop_reason: Option<StopReason>,
+    blocks: Vec<BlockBuilder>,
+    input_tokens: u64,
+    output_tokens: u64,
+    cache_write_tokens: u64,
+    cache_read_tokens: u64,
+}
+
+/// Builder for a single content block being streamed.
+enum BlockBuilder {
+    Text(String),
+    ToolUse {
+        id: String,
+        name: String,
+        input_json: String,
+    },
+    Thinking(String),
+}
+
+impl StreamAccumulator {
+    pub(crate) fn new() -> Self {
+        Self {
+            id: String::new(),
+            model: String::new(),
+            stop_reason: None,
+            blocks: Vec::new(),
+            input_tokens: 0,
+            output_tokens: 0,
+            cache_write_tokens: 0,
+            cache_read_tokens: 0,
+        }
+    }
+
+    /// Process an SSE event, emitting `StreamEvent`s via the callback.
+    /// Returns `Err` if the stream contains an error event.
+    pub(crate) fn process_event(
+        &mut self,
+        event: WireStreamEvent,
+        on_event: &mut impl FnMut(StreamEvent),
+    ) -> Result<()> {
+        match event {
+            WireStreamEvent::MessageStart { message } => {
+                self.id.clone_from(&message.id);
+                self.model.clone_from(&message.model);
+                let usage = convert_wire_usage(&message.usage);
+                self.input_tokens = usage.input_tokens;
+                self.cache_write_tokens = usage.cache_write_tokens;
+                self.cache_read_tokens = usage.cache_read_tokens;
+                on_event(StreamEvent::MessageStart { usage });
+            }
+            WireStreamEvent::ContentBlockStart {
+                index,
+                content_block,
+            } => {
+                let block_type = match &content_block {
+                    WireContentBlockStart::Text { .. } => "text",
+                    WireContentBlockStart::ToolUse { .. } => "tool_use",
+                    WireContentBlockStart::Thinking { .. } => "thinking",
+                };
+                on_event(StreamEvent::ContentBlockStart {
+                    index,
+                    block_type: block_type.to_owned(),
+                });
+
+                let builder = match content_block {
+                    WireContentBlockStart::Text { text } => BlockBuilder::Text(text),
+                    WireContentBlockStart::ToolUse { id, name } => BlockBuilder::ToolUse {
+                        id,
+                        name,
+                        input_json: String::new(),
+                    },
+                    WireContentBlockStart::Thinking { thinking } => {
+                        BlockBuilder::Thinking(thinking)
+                    }
+                };
+                // Ensure the blocks vec is large enough.
+                let idx = index as usize;
+                while self.blocks.len() <= idx {
+                    self.blocks.push(BlockBuilder::Text(String::new()));
+                }
+                self.blocks[idx] = builder;
+            }
+            WireStreamEvent::ContentBlockDelta { index, delta } => {
+                let idx = index as usize;
+                if idx < self.blocks.len() {
+                    match delta {
+                        WireDelta::TextDelta { text } => {
+                            if let BlockBuilder::Text(ref mut buf) = self.blocks[idx] {
+                                buf.push_str(&text);
+                            }
+                            on_event(StreamEvent::TextDelta { text });
+                        }
+                        WireDelta::InputJsonDelta { partial_json } => {
+                            if let BlockBuilder::ToolUse {
+                                ref mut input_json,
+                                ..
+                            } = self.blocks[idx]
+                            {
+                                input_json.push_str(&partial_json);
+                            }
+                            on_event(StreamEvent::InputJsonDelta { partial_json });
+                        }
+                        WireDelta::ThinkingDelta { thinking } => {
+                            if let BlockBuilder::Thinking(ref mut buf) = self.blocks[idx] {
+                                buf.push_str(&thinking);
+                            }
+                            on_event(StreamEvent::ThinkingDelta { thinking });
+                        }
+                    }
+                }
+            }
+            WireStreamEvent::ContentBlockStop { index } => {
+                on_event(StreamEvent::ContentBlockStop { index });
+            }
+            WireStreamEvent::MessageDelta { delta, usage } => {
+                self.output_tokens = usage.output_tokens;
+                let stop_reason = parse_stop_reason_lenient(&delta.stop_reason);
+                self.stop_reason = Some(stop_reason);
+                on_event(StreamEvent::MessageStop {
+                    stop_reason,
+                    usage: Usage {
+                        input_tokens: self.input_tokens,
+                        output_tokens: self.output_tokens,
+                        cache_write_tokens: self.cache_write_tokens,
+                        cache_read_tokens: self.cache_read_tokens,
+                    },
+                });
+            }
+            WireStreamEvent::MessageStop {} | WireStreamEvent::Ping {} => {
+                // Final event or keepalive — nothing to accumulate.
+            }
+            WireStreamEvent::Error { error } => {
+                return Err(error::ApiSnafu {
+                    status: 0_u16,
+                    message: error.message,
+                }
+                .build());
+            }
+        }
+        Ok(())
+    }
+
+    /// Build the final `CompletionResponse` from accumulated state.
+    pub(crate) fn finish(self) -> CompletionResponse {
+        let content = self
+            .blocks
+            .into_iter()
+            .map(|b| match b {
+                BlockBuilder::Text(text) => ContentBlock::Text { text },
+                BlockBuilder::ToolUse {
+                    id,
+                    name,
+                    input_json,
+                } => {
+                    let input = serde_json::from_str(&input_json).unwrap_or_default();
+                    ContentBlock::ToolUse { id, name, input }
+                }
+                BlockBuilder::Thinking(thinking) => ContentBlock::Thinking { thinking },
+            })
+            .collect();
+
+        CompletionResponse {
+            id: self.id,
+            model: self.model,
+            stop_reason: self.stop_reason.unwrap_or(StopReason::EndTurn),
+            content,
+            usage: Usage {
+                input_tokens: self.input_tokens,
+                output_tokens: self.output_tokens,
+                cache_write_tokens: self.cache_write_tokens,
+                cache_read_tokens: self.cache_read_tokens,
+            },
+        }
+    }
+}
+
+/// Parse SSE lines from a reader, dispatching events to the accumulator.
+pub(crate) fn parse_sse_stream(
+    reader: impl BufRead,
+    accumulator: &mut StreamAccumulator,
+    on_event: &mut impl FnMut(StreamEvent),
+) -> Result<()> {
+    let mut current_event_type = String::new();
+    let mut current_data = String::new();
+
+    for line in reader.lines() {
+        let line = line.map_err(|e| {
+            error::ApiRequestSnafu {
+                message: format!("stream read error: {e}"),
+            }
+            .build()
+        })?;
+
+        if line.is_empty() {
+            // Empty line = end of event. Dispatch if we have data.
+            if !current_data.is_empty() && current_event_type != "ping" {
+                let event: WireStreamEvent = serde_json::from_str(&current_data)
+                    .map_err(|e| {
+                        error::ApiRequestSnafu {
+                            message: format!("stream parse error: {e}"),
+                        }
+                        .build()
+                    })?;
+                accumulator.process_event(event, on_event)?;
+            }
+            current_event_type.clear();
+            current_data.clear();
+            continue;
+        }
+
+        if let Some(event_type) = line.strip_prefix("event: ") {
+            event_type.clone_into(&mut current_event_type);
+        } else if let Some(data) = line.strip_prefix("data: ") {
+            data.clone_into(&mut current_data);
+        }
+        // Ignore other lines (comments, etc.)
+    }
+
+    Ok(())
+}
+
+fn convert_wire_usage(wire: &WireUsage) -> Usage {
+    Usage {
+        input_tokens: wire.input_tokens,
+        output_tokens: wire.output_tokens,
+        cache_write_tokens: wire.cache_creation_input_tokens,
+        cache_read_tokens: wire.cache_read_input_tokens,
+    }
+}
+
+fn parse_stop_reason_lenient(s: &str) -> StopReason {
+    match s {
+        "tool_use" => StopReason::ToolUse,
+        "max_tokens" => StopReason::MaxTokens,
+        "stop_sequence" => StopReason::StopSequence,
+        _ => StopReason::EndTurn,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn collect_events(sse_text: &str) -> (Vec<StreamEvent>, CompletionResponse) {
+        let reader = std::io::Cursor::new(sse_text);
+        let mut acc = StreamAccumulator::new();
+        let mut events = Vec::new();
+        parse_sse_stream(reader, &mut acc, &mut |e| events.push(e)).unwrap();
+        let response = acc.finish();
+        (events, response)
+    }
+
+    #[test]
+    fn parses_simple_text_stream() {
+        let sse = "\
+event: message_start\n\
+data: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_1\",\"model\":\"claude-opus-4-20250514\",\"usage\":{\"input_tokens\":10,\"output_tokens\":0}}}\n\
+\n\
+event: content_block_start\n\
+data: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n\
+\n\
+event: content_block_delta\n\
+data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"Hello\"}}\n\
+\n\
+event: content_block_delta\n\
+data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" world\"}}\n\
+\n\
+event: content_block_stop\n\
+data: {\"type\":\"content_block_stop\",\"index\":0}\n\
+\n\
+event: message_delta\n\
+data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"output_tokens\":5}}\n\
+\n\
+event: message_stop\n\
+data: {\"type\":\"message_stop\"}\n\
+\n";
+
+        let (events, response) = collect_events(sse);
+
+        assert!(events.iter().any(|e| matches!(e, StreamEvent::TextDelta { text } if text == "Hello")));
+        assert!(events.iter().any(|e| matches!(e, StreamEvent::TextDelta { text } if text == " world")));
+        assert_eq!(response.id, "msg_1");
+        assert_eq!(response.stop_reason, StopReason::EndTurn);
+        assert_eq!(response.content.len(), 1);
+        match &response.content[0] {
+            ContentBlock::Text { text } => assert_eq!(text, "Hello world"),
+            _ => panic!("expected Text block"),
+        }
+    }
+
+    #[test]
+    fn parses_tool_use_stream() {
+        let sse = "\
+event: message_start\n\
+data: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_2\",\"model\":\"claude-opus-4-20250514\",\"usage\":{\"input_tokens\":20,\"output_tokens\":0}}}\n\
+\n\
+event: content_block_start\n\
+data: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"tool_use\",\"id\":\"toolu_1\",\"name\":\"exec\"}}\n\
+\n\
+event: content_block_delta\n\
+data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"{\\\"cmd\\\"\"}}\n\
+\n\
+event: content_block_delta\n\
+data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\": \\\"ls\\\"}\"}}\n\
+\n\
+event: content_block_stop\n\
+data: {\"type\":\"content_block_stop\",\"index\":0}\n\
+\n\
+event: message_delta\n\
+data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"tool_use\"},\"usage\":{\"output_tokens\":15}}\n\
+\n\
+event: message_stop\n\
+data: {\"type\":\"message_stop\"}\n\
+\n";
+
+        let (_, response) = collect_events(sse);
+
+        assert_eq!(response.stop_reason, StopReason::ToolUse);
+        match &response.content[0] {
+            ContentBlock::ToolUse { id, name, input } => {
+                assert_eq!(id, "toolu_1");
+                assert_eq!(name, "exec");
+                assert_eq!(input["cmd"], "ls");
+            }
+            _ => panic!("expected ToolUse block"),
+        }
+    }
+
+    #[test]
+    fn parses_thinking_stream() {
+        let sse = "\
+event: message_start\n\
+data: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_3\",\"model\":\"claude-opus-4-20250514\",\"usage\":{\"input_tokens\":30,\"output_tokens\":0}}}\n\
+\n\
+event: content_block_start\n\
+data: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"thinking\",\"thinking\":\"\"}}\n\
+\n\
+event: content_block_delta\n\
+data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"Let me think about this.\"}}\n\
+\n\
+event: content_block_stop\n\
+data: {\"type\":\"content_block_stop\",\"index\":0}\n\
+\n\
+event: content_block_start\n\
+data: {\"type\":\"content_block_start\",\"index\":1,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n\
+\n\
+event: content_block_delta\n\
+data: {\"type\":\"content_block_delta\",\"index\":1,\"delta\":{\"type\":\"text_delta\",\"text\":\"The answer is 42.\"}}\n\
+\n\
+event: content_block_stop\n\
+data: {\"type\":\"content_block_stop\",\"index\":1}\n\
+\n\
+event: message_delta\n\
+data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"output_tokens\":25}}\n\
+\n\
+event: message_stop\n\
+data: {\"type\":\"message_stop\"}\n\
+\n";
+
+        let (_, response) = collect_events(sse);
+
+        assert_eq!(response.content.len(), 2);
+        match &response.content[0] {
+            ContentBlock::Thinking { thinking } => {
+                assert_eq!(thinking, "Let me think about this.");
+            }
+            _ => panic!("expected Thinking block"),
+        }
+        match &response.content[1] {
+            ContentBlock::Text { text } => assert_eq!(text, "The answer is 42."),
+            _ => panic!("expected Text block"),
+        }
+    }
+
+    #[test]
+    fn handles_ping_events() {
+        let sse = "\
+event: ping\n\
+data: {\"type\":\"ping\"}\n\
+\n\
+event: message_start\n\
+data: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_4\",\"model\":\"claude-opus-4-20250514\",\"usage\":{\"input_tokens\":5,\"output_tokens\":0}}}\n\
+\n\
+event: content_block_start\n\
+data: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n\
+\n\
+event: content_block_delta\n\
+data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"Hi\"}}\n\
+\n\
+event: content_block_stop\n\
+data: {\"type\":\"content_block_stop\",\"index\":0}\n\
+\n\
+event: message_delta\n\
+data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"output_tokens\":1}}\n\
+\n\
+event: message_stop\n\
+data: {\"type\":\"message_stop\"}\n\
+\n";
+
+        let (_, response) = collect_events(sse);
+        assert_eq!(response.id, "msg_4");
+    }
+
+    #[test]
+    fn stream_error_event_returns_err() {
+        let sse = "\
+event: error\n\
+data: {\"type\":\"error\",\"error\":{\"type\":\"overloaded_error\",\"message\":\"Overloaded\"}}\n\
+\n";
+
+        let reader = std::io::Cursor::new(sse);
+        let mut acc = StreamAccumulator::new();
+        let result = parse_sse_stream(reader, &mut acc, &mut |_| {});
+        assert!(result.is_err());
+    }
+}

--- a/crates/hermeneus/src/anthropic/wire.rs
+++ b/crates/hermeneus/src/anthropic/wire.rs
@@ -1,0 +1,547 @@
+//! Wire types matching the Anthropic Messages API format.
+
+use serde::{Deserialize, Serialize};
+
+use crate::types::{
+    CompletionRequest, CompletionResponse, Content, ContentBlock, Role, StopReason, ThinkingConfig,
+    Usage,
+};
+
+// ---------------------------------------------------------------------------
+// Request
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Serialize)]
+pub(crate) struct WireRequest<'a> {
+    pub model: &'a str,
+    pub max_tokens: u32,
+    pub messages: Vec<WireMessage<'a>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub system: Option<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub tools: Vec<WireTool<'a>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub temperature: Option<f32>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub stop_sequences: Vec<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub thinking: Option<WireThinkingConfig>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stream: Option<bool>,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct WireMessage<'a> {
+    pub role: &'a str,
+    pub content: &'a Content,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct WireTool<'a> {
+    pub name: &'a str,
+    pub description: &'a str,
+    pub input_schema: &'a serde_json::Value,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct WireThinkingConfig {
+    #[serde(rename = "type")]
+    pub config_type: &'static str,
+    pub budget_tokens: u32,
+}
+
+// ---------------------------------------------------------------------------
+// Response
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct WireResponse {
+    pub id: String,
+    pub content: Vec<WireContentBlock>,
+    pub model: String,
+    pub stop_reason: String,
+    pub usage: WireUsage,
+}
+
+#[derive(Debug, Deserialize)]
+#[expect(clippy::struct_field_names, reason = "field names match Anthropic API wire format")]
+pub(crate) struct WireUsage {
+    pub input_tokens: u64,
+    pub output_tokens: u64,
+    #[serde(default)]
+    pub cache_creation_input_tokens: u64,
+    #[serde(default)]
+    pub cache_read_input_tokens: u64,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "type")]
+pub(crate) enum WireContentBlock {
+    #[serde(rename = "text")]
+    Text { text: String },
+    #[serde(rename = "tool_use")]
+    ToolUse {
+        id: String,
+        name: String,
+        input: serde_json::Value,
+    },
+    #[serde(rename = "thinking")]
+    Thinking {
+        thinking: String,
+        #[expect(dead_code, reason = "captured from API but not exposed in public types until M2")]
+        signature: String,
+    },
+}
+
+// ---------------------------------------------------------------------------
+// Error response
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct WireErrorResponse {
+    pub error: WireErrorDetail,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct WireErrorDetail {
+    #[serde(rename = "type")]
+    pub _error_type: String,
+    pub message: String,
+}
+
+// ---------------------------------------------------------------------------
+// Conversions
+// ---------------------------------------------------------------------------
+
+impl<'a> WireRequest<'a> {
+    pub(crate) fn from_request(req: &'a CompletionRequest, stream: Option<bool>) -> Self {
+        // Extract system prompt from messages (Anthropic wants it as a top-level field).
+        let system = req
+            .system
+            .clone()
+            .or_else(|| {
+                let system_texts: Vec<&str> = req
+                    .messages
+                    .iter()
+                    .filter(|m| m.role == Role::System)
+                    .map(|m| match &m.content {
+                        Content::Text(s) => s.as_str(),
+                        Content::Blocks(_) => "",
+                    })
+                    .filter(|s| !s.is_empty())
+                    .collect();
+                if system_texts.is_empty() {
+                    None
+                } else {
+                    Some(system_texts.join("\n\n"))
+                }
+            });
+
+        let messages: Vec<WireMessage<'a>> = req
+            .messages
+            .iter()
+            .filter(|m| m.role != Role::System)
+            .map(|m| WireMessage {
+                role: m.role.as_str(),
+                content: &m.content,
+            })
+            .collect();
+
+        let tools: Vec<WireTool<'a>> = req
+            .tools
+            .iter()
+            .map(|t| WireTool {
+                name: &t.name,
+                description: &t.description,
+                input_schema: &t.input_schema,
+            })
+            .collect();
+
+        let thinking = req.thinking.as_ref().and_then(|tc| {
+            if tc.enabled {
+                Some(WireThinkingConfig::from_config(tc))
+            } else {
+                None
+            }
+        });
+
+        let stop_sequences: Vec<&str> = req.stop_sequences.iter().map(String::as_str).collect();
+
+        Self {
+            model: &req.model,
+            max_tokens: req.max_tokens,
+            messages,
+            system,
+            tools,
+            temperature: req.temperature,
+            stop_sequences,
+            thinking,
+            stream,
+        }
+    }
+}
+
+impl WireThinkingConfig {
+    fn from_config(config: &ThinkingConfig) -> Self {
+        Self {
+            config_type: "enabled",
+            budget_tokens: config.budget_tokens,
+        }
+    }
+}
+
+impl WireResponse {
+    pub(crate) fn into_response(self) -> Result<CompletionResponse, String> {
+        let stop_reason = parse_stop_reason(&self.stop_reason)?;
+
+        let content = self
+            .content
+            .into_iter()
+            .map(WireContentBlock::into_content_block)
+            .collect();
+
+        Ok(CompletionResponse {
+            id: self.id,
+            model: self.model,
+            stop_reason,
+            content,
+            usage: self.usage.into_usage(),
+        })
+    }
+}
+
+impl WireContentBlock {
+    fn into_content_block(self) -> ContentBlock {
+        match self {
+            Self::Text { text } => ContentBlock::Text { text },
+            Self::ToolUse { id, name, input } => ContentBlock::ToolUse { id, name, input },
+            Self::Thinking {
+                thinking,
+                signature: _,
+            } => ContentBlock::Thinking { thinking },
+        }
+    }
+}
+
+impl WireUsage {
+    fn into_usage(self) -> Usage {
+        Usage {
+            input_tokens: self.input_tokens,
+            output_tokens: self.output_tokens,
+            cache_write_tokens: self.cache_creation_input_tokens,
+            cache_read_tokens: self.cache_read_input_tokens,
+        }
+    }
+}
+
+fn parse_stop_reason(s: &str) -> Result<StopReason, String> {
+    match s {
+        "end_turn" => Ok(StopReason::EndTurn),
+        "tool_use" => Ok(StopReason::ToolUse),
+        "max_tokens" => Ok(StopReason::MaxTokens),
+        "stop_sequence" => Ok(StopReason::StopSequence),
+        other => Err(format!("unknown stop_reason: {other}")),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Streaming wire types
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "type")]
+pub(crate) enum WireStreamEvent {
+    #[serde(rename = "message_start")]
+    MessageStart { message: WireMessageStart },
+    #[serde(rename = "content_block_start")]
+    ContentBlockStart {
+        index: u32,
+        content_block: WireContentBlockStart,
+    },
+    #[serde(rename = "content_block_delta")]
+    ContentBlockDelta { index: u32, delta: WireDelta },
+    #[serde(rename = "content_block_stop")]
+    ContentBlockStop { index: u32 },
+    #[serde(rename = "message_delta")]
+    MessageDelta {
+        delta: WireMessageDeltaBody,
+        usage: WireMessageDeltaUsage,
+    },
+    #[serde(rename = "message_stop")]
+    MessageStop {},
+    #[serde(rename = "ping")]
+    Ping {},
+    #[serde(rename = "error")]
+    Error { error: WireErrorDetail },
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct WireMessageStart {
+    pub id: String,
+    pub model: String,
+    pub usage: WireUsage,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "type")]
+pub(crate) enum WireContentBlockStart {
+    #[serde(rename = "text")]
+    Text { text: String },
+    #[serde(rename = "tool_use")]
+    ToolUse { id: String, name: String },
+    #[serde(rename = "thinking")]
+    Thinking { thinking: String },
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "type")]
+#[expect(clippy::enum_variant_names, reason = "variant names match Anthropic SSE delta types")]
+pub(crate) enum WireDelta {
+    #[serde(rename = "text_delta")]
+    TextDelta { text: String },
+    #[serde(rename = "input_json_delta")]
+    InputJsonDelta { partial_json: String },
+    #[serde(rename = "thinking_delta")]
+    ThinkingDelta { thinking: String },
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct WireMessageDeltaBody {
+    pub stop_reason: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct WireMessageDeltaUsage {
+    pub output_tokens: u64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{Message, ToolDefinition};
+
+    #[test]
+    fn wire_response_deserializes() {
+        let json = r#"{
+            "id": "msg_123",
+            "type": "message",
+            "role": "assistant",
+            "content": [{"type": "text", "text": "Hello"}],
+            "model": "claude-opus-4-20250514",
+            "stop_reason": "end_turn",
+            "usage": {"input_tokens": 10, "output_tokens": 5}
+        }"#;
+        let resp: WireResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.id, "msg_123");
+        assert_eq!(resp.stop_reason, "end_turn");
+        assert_eq!(resp.usage.input_tokens, 10);
+        assert_eq!(resp.usage.cache_creation_input_tokens, 0);
+    }
+
+    #[test]
+    fn wire_response_with_cache_tokens() {
+        let json = r#"{
+            "id": "msg_456",
+            "type": "message",
+            "role": "assistant",
+            "content": [{"type": "text", "text": "Hi"}],
+            "model": "claude-opus-4-20250514",
+            "stop_reason": "end_turn",
+            "usage": {
+                "input_tokens": 100,
+                "output_tokens": 50,
+                "cache_creation_input_tokens": 200,
+                "cache_read_input_tokens": 80
+            }
+        }"#;
+        let resp: WireResponse = serde_json::from_str(json).unwrap();
+        let converted = resp.into_response().unwrap();
+        assert_eq!(converted.usage.cache_write_tokens, 200);
+        assert_eq!(converted.usage.cache_read_tokens, 80);
+    }
+
+    #[test]
+    fn wire_content_block_tool_use() {
+        let json = r#"{"type":"tool_use","id":"toolu_1","name":"exec","input":{"cmd":"ls"}}"#;
+        let block: WireContentBlock = serde_json::from_str(json).unwrap();
+        let converted = block.into_content_block();
+        match converted {
+            ContentBlock::ToolUse { id, name, .. } => {
+                assert_eq!(id, "toolu_1");
+                assert_eq!(name, "exec");
+            }
+            _ => panic!("expected ToolUse"),
+        }
+    }
+
+    #[test]
+    fn wire_content_block_thinking() {
+        let json = r#"{"type":"thinking","thinking":"let me think","signature":"sig_abc"}"#;
+        let block: WireContentBlock = serde_json::from_str(json).unwrap();
+        let converted = block.into_content_block();
+        match converted {
+            ContentBlock::Thinking { thinking } => {
+                assert_eq!(thinking, "let me think");
+            }
+            _ => panic!("expected Thinking"),
+        }
+    }
+
+    #[test]
+    fn wire_error_response_deserializes() {
+        let json = r#"{
+            "type": "error",
+            "error": {"type": "invalid_request_error", "message": "bad input"}
+        }"#;
+        let err: WireErrorResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(err.error.message, "bad input");
+    }
+
+    #[test]
+    fn wire_request_extracts_system_prompt() {
+        let req = CompletionRequest {
+            model: "claude-opus-4-20250514".to_owned(),
+            system: Some("You are helpful.".to_owned()),
+            messages: vec![Message {
+                role: Role::User,
+                content: Content::Text("hello".to_owned()),
+            }],
+            max_tokens: 1024,
+            tools: vec![],
+            temperature: None,
+            thinking: None,
+            stop_sequences: vec![],
+        };
+        let wire = WireRequest::from_request(&req, None);
+        assert_eq!(wire.system.as_deref(), Some("You are helpful."));
+        assert_eq!(wire.messages.len(), 1);
+        assert_eq!(wire.messages[0].role, "user");
+    }
+
+    #[test]
+    fn wire_request_extracts_system_from_messages() {
+        let req = CompletionRequest {
+            model: "claude-opus-4-20250514".to_owned(),
+            system: None,
+            messages: vec![
+                Message {
+                    role: Role::System,
+                    content: Content::Text("Be concise.".to_owned()),
+                },
+                Message {
+                    role: Role::User,
+                    content: Content::Text("hello".to_owned()),
+                },
+            ],
+            max_tokens: 1024,
+            tools: vec![],
+            temperature: None,
+            thinking: None,
+            stop_sequences: vec![],
+        };
+        let wire = WireRequest::from_request(&req, None);
+        assert_eq!(wire.system.as_deref(), Some("Be concise."));
+        // System messages must not appear in the messages array
+        assert_eq!(wire.messages.len(), 1);
+    }
+
+    #[test]
+    fn wire_request_serializes_thinking_config() {
+        let req = CompletionRequest {
+            model: "claude-opus-4-20250514".to_owned(),
+            system: None,
+            messages: vec![Message {
+                role: Role::User,
+                content: Content::Text("think hard".to_owned()),
+            }],
+            max_tokens: 16384,
+            tools: vec![],
+            temperature: None,
+            thinking: Some(ThinkingConfig {
+                enabled: true,
+                budget_tokens: 8192,
+            }),
+            stop_sequences: vec![],
+        };
+        let wire = WireRequest::from_request(&req, None);
+        let json = serde_json::to_value(&wire).unwrap();
+        let thinking = json.get("thinking").unwrap();
+        assert_eq!(thinking["type"], "enabled");
+        assert_eq!(thinking["budget_tokens"], 8192);
+    }
+
+    #[test]
+    fn wire_request_serializes_tools() {
+        let req = CompletionRequest {
+            model: "claude-opus-4-20250514".to_owned(),
+            system: None,
+            messages: vec![Message {
+                role: Role::User,
+                content: Content::Text("run ls".to_owned()),
+            }],
+            max_tokens: 1024,
+            tools: vec![ToolDefinition {
+                name: "exec".to_owned(),
+                description: "Execute a command".to_owned(),
+                input_schema: serde_json::json!({
+                    "type": "object",
+                    "properties": {
+                        "command": {"type": "string"}
+                    },
+                    "required": ["command"]
+                }),
+            }],
+            temperature: None,
+            thinking: None,
+            stop_sequences: vec![],
+        };
+        let wire = WireRequest::from_request(&req, None);
+        let json = serde_json::to_value(&wire).unwrap();
+        let tools = json["tools"].as_array().unwrap();
+        assert_eq!(tools.len(), 1);
+        assert_eq!(tools[0]["name"], "exec");
+    }
+
+    #[test]
+    fn wire_stream_event_deserializes() {
+        let json = r#"{"type":"message_start","message":{"id":"msg_1","model":"claude-opus-4-20250514","usage":{"input_tokens":10,"output_tokens":0}}}"#;
+        let event: WireStreamEvent = serde_json::from_str(json).unwrap();
+        match event {
+            WireStreamEvent::MessageStart { message } => {
+                assert_eq!(message.id, "msg_1");
+            }
+            _ => panic!("expected MessageStart"),
+        }
+    }
+
+    #[test]
+    fn wire_stream_delta_deserializes() {
+        let json = r#"{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello"}}"#;
+        let event: WireStreamEvent = serde_json::from_str(json).unwrap();
+        match event {
+            WireStreamEvent::ContentBlockDelta { index, delta } => {
+                assert_eq!(index, 0);
+                match delta {
+                    WireDelta::TextDelta { text } => assert_eq!(text, "Hello"),
+                    _ => panic!("expected TextDelta"),
+                }
+            }
+            _ => panic!("expected ContentBlockDelta"),
+        }
+    }
+
+    #[test]
+    fn parse_stop_reason_all_variants() {
+        assert_eq!(parse_stop_reason("end_turn").unwrap(), StopReason::EndTurn);
+        assert_eq!(parse_stop_reason("tool_use").unwrap(), StopReason::ToolUse);
+        assert_eq!(
+            parse_stop_reason("max_tokens").unwrap(),
+            StopReason::MaxTokens
+        );
+        assert_eq!(
+            parse_stop_reason("stop_sequence").unwrap(),
+            StopReason::StopSequence
+        );
+        assert!(parse_stop_reason("unknown").is_err());
+    }
+}

--- a/crates/hermeneus/src/lib.rs
+++ b/crates/hermeneus/src/lib.rs
@@ -6,6 +6,7 @@
 //!
 //! Depends only on `aletheia-koina`.
 
+pub mod anthropic;
 pub mod error;
 pub mod provider;
 pub mod types;


### PR DESCRIPTION
## Summary

- Anthropic Messages API provider implementing `LlmProvider` trait with `reqwest::blocking` client
- Wire types for request/response translation (system prompt extraction, thinking signature, cache token mapping)
- SSE streaming parser with `StreamEvent` callback + accumulator for `complete_streaming()`
- Exponential backoff with jitter, error mapping to hermeneus error variants
- `SecretString` for API key handling via `secrecy` crate
- 30 tests covering wire serialization, streaming parsing, and type conversions

## Test plan

- [x] `cargo clippy --workspace --all-targets -- -D warnings` — zero warnings
- [x] `cargo test --workspace` — 30 new tests, all passing
- [ ] Manual review of wire type mapping against Anthropic API docs
- [ ] Verify no modifications to existing types.rs, provider.rs, error.rs

🤖 Generated with [Claude Code](https://claude.com/claude-code)