### PR TITLE
feat(symbolon): JWT sessions, API keys, argon2 passwords, RBAC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,11 +16,15 @@ name = "aletheia-hermeneus"
 version = "0.1.0"
 dependencies = [
  "aletheia-koina",
+ "reqwest",
+ "secrecy",
  "serde",
  "serde_json",
  "snafu",
  "static_assertions",
+ "tokio",
  "tracing",
+ "wiremock",
 ]
 
 [[package]]
@@ -95,6 +99,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "aletheia-symbolon"
+version = "0.1.0"
+dependencies = [
+ "argon2",
+ "blake3",
+ "jsonwebtoken",
+ "rand 0.8.5",
+ "rusqlite",
+ "secrecy",
+ "serde",
+ "serde_json",
+ "snafu",
+ "static_assertions",
+ "tracing",
+ "ulid",
+]
+
+[[package]]
 name = "aletheia-taxis"
 version = "0.1.0"
 dependencies = [
@@ -114,6 +136,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "argon2"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
+dependencies = [
+ "base64ct",
+ "blake2",
+ "cpufeatures",
+ "password-hash",
+]
+
+[[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "atomic"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -123,10 +179,66 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+
+[[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest",
+]
+
+[[package]]
+name = "blake3"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2468ef7d57b3fb7e16b576e8377cdbde2320c60e1491e961d11da40fc4f02a2d"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
+ "cpufeatures",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "bumpalo"
@@ -139,6 +251,12 @@ name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+
+[[package]]
+name = "bytes"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "castaway"
@@ -181,6 +299,115 @@ dependencies = [
 ]
 
 [[package]]
+name = "constant_time_eq"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "deadpool"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
+dependencies = [
+ "deadpool-runtime",
+ "lazy_static",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+ "subtle",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -193,7 +420,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -236,10 +463,151 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "wasi",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "getrandom"
@@ -264,6 +632,25 @@ dependencies = [
  "r-efi",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -297,10 +684,243 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "http"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hyper"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "pin-utils",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2",
+ "system-configuration",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "windows-registry",
+]
+
+[[package]]
+name = "icu_collections"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+
+[[package]]
+name = "icu_properties"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+
+[[package]]
+name = "icu_provider"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "indexmap"
@@ -321,6 +941,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8fae54786f62fb2918dcfae3d568594e50eb9b5c25bf04371af6fe7516452fb"
 
 [[package]]
+name = "ipnet"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+
+[[package]]
+name = "iri-string"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -334,6 +970,21 @@ checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "jsonwebtoken"
+version = "9.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
+dependencies = [
+ "base64",
+ "js-sys",
+ "pem",
+ "ring",
+ "serde",
+ "serde_json",
+ "simple_asn1",
 ]
 
 [[package]]
@@ -372,6 +1023,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
+name = "litemap"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -393,12 +1050,90 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mio"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -406,6 +1141,61 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "openssl"
+version = "0.10.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.111"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "password-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+dependencies = [
+ "base64ct",
+ "rand_core 0.6.4",
+ "subtle",
+]
 
 [[package]]
 name = "pear"
@@ -431,16 +1221,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64",
+ "serde_core",
+]
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -500,12 +1327,33 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -515,7 +1363,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -525,6 +1382,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -543,6 +1412,62 @@ name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "encoding_rs",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-tls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-native-tls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "rusqlite"
@@ -568,7 +1493,40 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+dependencies = [
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -582,6 +1540,48 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "schannel"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "secrecy"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
+dependencies = [
+ "serde",
+ "zeroize",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"
@@ -633,6 +1633,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "serde_yaml"
 version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -659,6 +1671,24 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "simple_asn1"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror",
+ "time",
+]
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
@@ -688,10 +1718,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
+dependencies = [
+ "libc",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -705,6 +1757,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -714,7 +1807,27 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -727,13 +1840,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
 name = "tokio"
 version = "1.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
 dependencies = [
+ "bytes",
+ "libc",
+ "mio",
  "pin-project-lite",
+ "socket2",
  "tokio-macros",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -746,6 +1905,84 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "iri-string",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
@@ -822,12 +2059,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "typenum"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
 name = "ulid"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "470dbf6591da1b39d43c14523b2b469c86879a53e8b758c8e090a470fe7b1fbe"
 dependencies = [
- "rand",
+ "rand 0.9.2",
  "serde",
  "web-time",
 ]
@@ -860,6 +2109,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -876,6 +2149,21 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
@@ -906,6 +2194,20 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -975,6 +2277,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-sys"
+version = "0.3.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "web-time"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -991,12 +2303,211 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
 name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "wiremock"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
+dependencies = [
+ "assert-json-diff",
+ "base64",
+ "deadpool",
+ "futures",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
 ]
 
 [[package]]
@@ -1088,10 +2599,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "writeable"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
 name = "yansi"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
+
+[[package]]
+name = "yoke"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
 
 [[package]]
 name = "zerocopy"
@@ -1107,6 +2647,66 @@ name = "zerocopy-derive"
 version = "0.8.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f65c489a7071a749c849713807783f70672b28094011623e200cb86dcb835953"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "crates/mneme",
     "crates/nous",
     "crates/organon",
+    "crates/symbolon",
     "crates/taxis",
 ]
 exclude = [
@@ -83,7 +84,6 @@ tokio = { version = "1", features = ["rt", "macros"] }
 
 # Testing
 static_assertions = "1.1"
-tokio = { version = "1", features = ["macros", "rt"] }
 wiremock = "0.6"
 
 [profile.dev]

--- a/crates/symbolon/Cargo.toml
+++ b/crates/symbolon/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "aletheia-symbolon"
+version = "0.1.0"
+description = "Authentication and authorization for Aletheia"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+argon2 = { version = "0.5", features = ["std"] }
+blake3 = "1"
+jsonwebtoken = "9"
+rand = "0.8"
+rusqlite = { version = "0.33", features = ["bundled"] }
+secrecy = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+snafu = { workspace = true }
+tracing = { workspace = true }
+ulid = { workspace = true }
+
+[dev-dependencies]
+static_assertions = { workspace = true }

--- a/crates/symbolon/src/api_key.rs
+++ b/crates/symbolon/src/api_key.rs
@@ -1,0 +1,260 @@
+//! API key generation and validation.
+//!
+//! Key format: `ale_{prefix}_{secret}` where secret is 32 random bytes hex-encoded.
+//! The prefix identifies the key holder (for logs/audit).
+//! The secret is hashed with blake3 before storage — never stored in plaintext.
+
+use std::time::Duration;
+
+use rand::Rng;
+use tracing::instrument;
+
+use crate::error::{self, Result};
+use crate::store::AuthStore;
+use crate::types::{ApiKeyRecord, Claims, Role, TokenKind};
+
+/// Prefix for all Aletheia API keys.
+const KEY_PREFIX: &str = "ale";
+
+/// Generate a new API key. Returns `(full_key_string, metadata_record)`.
+///
+/// The full key string is shown to the user exactly once. Only the hash is stored.
+#[instrument(skip(store))]
+pub fn generate(
+    store: &AuthStore,
+    prefix: &str,
+    role: Role,
+    nous_id: Option<&str>,
+    expires_in: Option<Duration>,
+) -> Result<(String, ApiKeyRecord)> {
+    let secret_bytes: [u8; 32] = rand::thread_rng().r#gen();
+    let secret_hex = hex::encode(&secret_bytes);
+    let full_key = format!("{KEY_PREFIX}_{prefix}_{secret_hex}");
+
+    let key_hash = blake3::hash(full_key.as_bytes()).to_hex().to_string();
+    let id = ulid::Ulid::new().to_string();
+
+    let expires_at = expires_in.map(|d| {
+        let expiry = std::time::SystemTime::now() + d;
+        let secs = expiry
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+        time_from_unix(secs)
+    });
+
+    let record = ApiKeyRecord {
+        id: id.clone(),
+        prefix: prefix.to_owned(),
+        key_hash,
+        role,
+        nous_id: nous_id.map(str::to_owned),
+        created_at: String::new(), // DB default handles this
+        expires_at,
+        last_used_at: None,
+        revoked_at: None,
+    };
+
+    store.store_api_key(&record)?;
+
+    // Re-read from DB to get populated timestamps
+    let stored = store
+        .find_api_key_by_hash(&record.key_hash)?
+        .unwrap_or(record);
+
+    Ok((full_key, stored))
+}
+
+/// Validate an API key string and return claims if valid.
+///
+/// Parses the key format, hashes with blake3, looks up in the store,
+/// checks revocation and expiry, and updates `last_used_at`.
+pub fn validate(store: &AuthStore, raw_key: &str) -> Result<Claims> {
+    let _parts = parse_key(raw_key)?;
+    let key_hash = blake3::hash(raw_key.as_bytes()).to_hex().to_string();
+
+    let record = store
+        .find_api_key_by_hash(&key_hash)?
+        .ok_or_else(|| error::InvalidCredentialsSnafu.build())?;
+
+    // Check revocation
+    if record.revoked_at.is_some() {
+        return Err(error::InvalidCredentialsSnafu.build());
+    }
+
+    // Check expiry
+    if let Some(ref expires_at) = record.expires_at {
+        let now = now_iso();
+        if *expires_at < now {
+            return Err(error::ExpiredTokenSnafu.build());
+        }
+    }
+
+    // Update last_used_at
+    store.touch_api_key(&record.id)?;
+
+    Ok(Claims {
+        sub: format!("apikey:{}", record.prefix),
+        role: record.role,
+        nous_id: record.nous_id,
+        iss: "aletheia".to_owned(),
+        iat: 0,
+        exp: 0,
+        jti: record.id,
+        kind: TokenKind::Access,
+    })
+}
+
+/// Revoke an API key by its ID.
+pub fn revoke(store: &AuthStore, key_id: &str) -> Result<()> {
+    store.revoke_api_key(key_id)
+}
+
+/// List all API keys (metadata only, never the secret).
+pub fn list(store: &AuthStore) -> Result<Vec<ApiKeyRecord>> {
+    store.list_api_keys()
+}
+
+/// Parse an API key into `(global_prefix, holder_prefix, secret)`.
+fn parse_key(raw: &str) -> Result<(&str, &str, &str)> {
+    let parts: Vec<&str> = raw.splitn(3, '_').collect();
+    if parts.len() != 3 || parts[0] != KEY_PREFIX {
+        return Err(error::InvalidApiKeySnafu.build());
+    }
+    if parts[1].is_empty() || parts[2].is_empty() {
+        return Err(error::InvalidApiKeySnafu.build());
+    }
+    Ok((parts[0], parts[1], parts[2]))
+}
+
+fn now_iso() -> String {
+    let secs = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    time_from_unix(secs)
+}
+
+fn time_from_unix(secs: u64) -> String {
+    // Simple ISO 8601 formatting without external dependency
+    let days = secs / 86400;
+    let time_secs = secs % 86400;
+    let hours = time_secs / 3600;
+    let minutes = (time_secs % 3600) / 60;
+    let seconds = time_secs % 60;
+
+    // Convert days since epoch to Y-M-D (simplified)
+    let (year, month, day) = days_to_date(days);
+    format!("{year:04}-{month:02}-{day:02}T{hours:02}:{minutes:02}:{seconds:02}.000Z")
+}
+
+fn days_to_date(days_since_epoch: u64) -> (u64, u64, u64) {
+    let z = days_since_epoch + 719_468;
+    let era = z / 146_097;
+    let day_of_era = z - era * 146_097;
+    let year_of_era = (day_of_era - day_of_era / 1460 + day_of_era / 36524 - day_of_era / 146_096) / 365;
+    let y = year_of_era + era * 400;
+    let day_of_year = day_of_era - (365 * year_of_era + year_of_era / 4 - year_of_era / 100);
+    let mp = (5 * day_of_year + 2) / 153;
+    let d = day_of_year - (153 * mp + 2) / 5 + 1;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 };
+    let y = if m <= 2 { y + 1 } else { y };
+    (y, m, d)
+}
+
+// We need hex encoding for the secret bytes
+mod hex {
+    const HEX_CHARS: &[u8; 16] = b"0123456789abcdef";
+
+    pub fn encode(bytes: &[u8]) -> String {
+        let mut s = String::with_capacity(bytes.len() * 2);
+        for &b in bytes {
+            s.push(HEX_CHARS[(b >> 4) as usize] as char);
+            s.push(HEX_CHARS[(b & 0x0f) as usize] as char);
+        }
+        s
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_store() -> AuthStore {
+        AuthStore::open_in_memory().unwrap()
+    }
+
+    #[test]
+    fn generate_and_validate_roundtrip() {
+        let store = test_store();
+        let (key, record) = generate(&store, "test", Role::Operator, None, None).unwrap();
+
+        assert!(key.starts_with("ale_test_"));
+        assert_eq!(record.prefix, "test");
+        assert_eq!(record.role, Role::Operator);
+
+        let claims = validate(&store, &key).unwrap();
+        assert_eq!(claims.sub, "apikey:test");
+        assert_eq!(claims.role, Role::Operator);
+    }
+
+    #[test]
+    fn generate_agent_key_with_nous_id() {
+        let store = test_store();
+        let (key, _) = generate(&store, "syn", Role::Agent, Some("syn"), None).unwrap();
+        let claims = validate(&store, &key).unwrap();
+        assert_eq!(claims.role, Role::Agent);
+        assert_eq!(claims.nous_id.as_deref(), Some("syn"));
+    }
+
+    #[test]
+    fn revoked_key_rejected() {
+        let store = test_store();
+        let (key, record) = generate(&store, "test", Role::Operator, None, None).unwrap();
+
+        revoke(&store, &record.id).unwrap();
+        let result = validate(&store, &key);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn malformed_key_rejected() {
+        let store = test_store();
+        assert!(validate(&store, "not-a-key").is_err());
+        assert!(validate(&store, "ale_").is_err());
+        assert!(validate(&store, "ale__secret").is_err());
+        assert!(validate(&store, "xyz_test_secret").is_err());
+    }
+
+    #[test]
+    fn nonexistent_key_rejected() {
+        let store = test_store();
+        assert!(validate(&store, "ale_test_nonexistent").is_err());
+    }
+
+    #[test]
+    fn list_returns_all_keys() {
+        let store = test_store();
+        generate(&store, "a", Role::Operator, None, None).unwrap();
+        generate(&store, "b", Role::Agent, Some("syn"), None).unwrap();
+
+        let keys = list(&store).unwrap();
+        assert_eq!(keys.len(), 2);
+    }
+
+    #[test]
+    fn parse_key_format() {
+        let (prefix, holder, secret) = parse_key("ale_syn_abc123").unwrap();
+        assert_eq!(prefix, "ale");
+        assert_eq!(holder, "syn");
+        assert_eq!(secret, "abc123");
+    }
+
+    #[test]
+    fn key_secret_is_64_hex_chars() {
+        let store = test_store();
+        let (key, _) = generate(&store, "test", Role::Operator, None, None).unwrap();
+        let parts: Vec<&str> = key.splitn(3, '_').collect();
+        assert_eq!(parts[2].len(), 64); // 32 bytes * 2 hex chars
+    }
+}

--- a/crates/symbolon/src/auth.rs
+++ b/crates/symbolon/src/auth.rs
@@ -1,0 +1,451 @@
+//! Unified auth facade composing JWT, API keys, password auth, and RBAC.
+
+use std::path::Path;
+use std::time::Duration;
+
+use secrecy::SecretString;
+use tracing::instrument;
+
+use crate::error::{self, Result};
+use crate::jwt::{JwtConfig, JwtManager};
+use crate::password;
+use crate::store::AuthStore;
+use crate::types::{Action, ApiKeyRecord, Claims, Role, TokenKind, TokenPair};
+use crate::{api_key};
+
+/// Configuration for the auth service.
+#[derive(Default)]
+pub struct AuthConfig {
+    /// JWT configuration.
+    pub jwt: JwtConfig,
+}
+
+/// The main auth service — wraps JWT, API keys, and password auth.
+pub struct AuthService {
+    jwt: JwtManager,
+    store: AuthStore,
+}
+
+impl AuthService {
+    /// Create a new auth service backed by a `SQLite` database.
+    pub fn new(config: AuthConfig, db_path: &Path) -> Result<Self> {
+        let store = AuthStore::open(db_path)?;
+        let jwt = JwtManager::new(config.jwt);
+        Ok(Self { jwt, store })
+    }
+
+    /// Create an auth service with an in-memory database (for testing).
+    pub fn in_memory(config: AuthConfig) -> Result<Self> {
+        let store = AuthStore::open_in_memory()?;
+        let jwt = JwtManager::new(config.jwt);
+        Ok(Self { jwt, store })
+    }
+
+    /// Get a reference to the underlying store.
+    #[must_use]
+    pub fn store(&self) -> &AuthStore {
+        &self.store
+    }
+
+    // --- User management ---
+
+    /// Register a new user with a hashed password.
+    #[instrument(skip(self, password))]
+    pub fn register_user(
+        &self,
+        username: &str,
+        password: &SecretString,
+        role: Role,
+    ) -> Result<crate::types::User> {
+        let hash = password::hash_password(password)?;
+        let id = ulid::Ulid::new().to_string();
+        self.store.create_user(&id, username, &hash, role)
+    }
+
+    // --- Authentication ---
+
+    /// Authenticate via username + password. Returns a JWT pair.
+    #[instrument(skip(self, password))]
+    pub fn login(&self, username: &str, password: &SecretString) -> Result<TokenPair> {
+        let user = self
+            .store
+            .find_user_by_username(username)?
+            .ok_or_else(|| error::InvalidCredentialsSnafu.build())?;
+
+        let valid = password::verify_password(password, &user.password_hash)?;
+        if !valid {
+            return Err(error::InvalidCredentialsSnafu.build());
+        }
+
+        let access = self.jwt.issue_access(&user.id, user.role, None)?;
+        let refresh = self.jwt.issue_refresh(&user.id, user.role)?;
+
+        Ok(TokenPair {
+            access_token: access,
+            refresh_token: refresh,
+        })
+    }
+
+    /// Authenticate via API key. Returns claims.
+    pub fn authenticate_api_key(&self, raw_key: &str) -> Result<Claims> {
+        api_key::validate(&self.store, raw_key)
+    }
+
+    /// Validate a JWT token. Checks signature, expiry, and revocation.
+    pub fn validate_token(&self, token: &str) -> Result<Claims> {
+        let claims = self.jwt.validate(token)?;
+
+        if self.store.is_token_revoked(&claims.jti)? {
+            return Err(error::InvalidTokenSnafu {
+                message: "token has been revoked".to_owned(),
+            }
+            .build());
+        }
+
+        Ok(claims)
+    }
+
+    /// Refresh a JWT pair using a refresh token.
+    #[instrument(skip(self, refresh_token))]
+    pub fn refresh_token(&self, refresh_token: &str) -> Result<TokenPair> {
+        let claims = self.jwt.validate(refresh_token)?;
+
+        if claims.kind != TokenKind::Refresh {
+            return Err(error::InvalidTokenSnafu {
+                message: "expected refresh token".to_owned(),
+            }
+            .build());
+        }
+
+        if self.store.is_token_revoked(&claims.jti)? {
+            return Err(error::InvalidTokenSnafu {
+                message: "refresh token has been revoked".to_owned(),
+            }
+            .build());
+        }
+
+        let access = self
+            .jwt
+            .issue_access(&claims.sub, claims.role, claims.nous_id.as_deref())?;
+        let refresh = self.jwt.issue_refresh(&claims.sub, claims.role)?;
+
+        Ok(TokenPair {
+            access_token: access,
+            refresh_token: refresh,
+        })
+    }
+
+    /// Logout by revoking a JWT (adds its jti to the revocation list).
+    pub fn logout(&self, token: &str) -> Result<()> {
+        let claims = self.jwt.validate(token)?;
+        let expires_at = format_unix_iso(claims.exp);
+        self.store.revoke_token(&claims.jti, &expires_at)
+    }
+
+    // --- API key management ---
+
+    /// Generate a new API key.
+    pub fn generate_api_key(
+        &self,
+        prefix: &str,
+        role: Role,
+        nous_id: Option<&str>,
+        expires_in: Option<Duration>,
+    ) -> Result<(String, ApiKeyRecord)> {
+        api_key::generate(&self.store, prefix, role, nous_id, expires_in)
+    }
+
+    /// Revoke an API key.
+    pub fn revoke_api_key(&self, key_id: &str) -> Result<()> {
+        api_key::revoke(&self.store, key_id)
+    }
+
+    /// List all API keys.
+    pub fn list_api_keys(&self) -> Result<Vec<ApiKeyRecord>> {
+        api_key::list(&self.store)
+    }
+
+    // --- Authorization ---
+
+    /// Check if claims authorize the given action. Returns `Ok(())` if allowed.
+    pub fn authorize(&self, claims: &Claims, action: &Action) -> Result<()> {
+        if is_authorized(claims, action) {
+            Ok(())
+        } else {
+            Err(error::PermissionDeniedSnafu {
+                action: action.to_string(),
+                role: claims.role.to_string(),
+            }
+            .build())
+        }
+    }
+}
+
+/// RBAC authorization logic.
+fn is_authorized(claims: &Claims, action: &Action) -> bool {
+    match claims.role {
+        Role::Operator => true,
+        Role::Agent => match action {
+            Action::ReadSession { nous_id } | Action::WriteSession { nous_id } => {
+                claims
+                    .nous_id
+                    .as_ref()
+                    .is_some_and(|own| own == nous_id)
+            }
+            Action::ReadDashboard => true,
+            Action::ManageAgents | Action::ManageUsers => false,
+        },
+        Role::Readonly => matches!(action, Action::ReadDashboard),
+    }
+}
+
+fn format_unix_iso(unix_secs: i64) -> String {
+    let secs = u64::try_from(unix_secs).unwrap_or(0);
+    let days = secs / 86400;
+    let time_secs = secs % 86400;
+    let hours = time_secs / 3600;
+    let minutes = (time_secs % 3600) / 60;
+    let seconds = time_secs % 60;
+    let (year, month, day) = days_to_date(days);
+    format!("{year:04}-{month:02}-{day:02}T{hours:02}:{minutes:02}:{seconds:02}.000Z")
+}
+
+fn days_to_date(days_since_epoch: u64) -> (u64, u64, u64) {
+    let z = days_since_epoch + 719_468;
+    let era = z / 146_097;
+    let day_of_era = z - era * 146_097;
+    let year_of_era = (day_of_era - day_of_era / 1460 + day_of_era / 36524 - day_of_era / 146_096) / 365;
+    let y = year_of_era + era * 400;
+    let day_of_year = day_of_era - (365 * year_of_era + year_of_era / 4 - year_of_era / 100);
+    let mp = (5 * day_of_year + 2) / 153;
+    let d = day_of_year - (153 * mp + 2) / 5 + 1;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 };
+    let y = if m <= 2 { y + 1 } else { y };
+    (y, m, d)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_service() -> AuthService {
+        AuthService::in_memory(AuthConfig {
+            jwt: JwtConfig {
+                signing_key: SecretString::from("test-jwt-secret".to_owned()),
+                access_ttl: Duration::from_secs(3600),
+                refresh_ttl: Duration::from_secs(86400),
+                issuer: "aletheia-test".to_owned(),
+            },
+        })
+        .unwrap()
+    }
+
+    fn secret(s: &str) -> SecretString {
+        SecretString::from(s.to_owned())
+    }
+
+    // --- Login flow ---
+
+    #[test]
+    fn register_and_login() {
+        let svc = test_service();
+        svc.register_user("cody", &secret("hunter2"), Role::Operator)
+            .unwrap();
+
+        let pair = svc.login("cody", &secret("hunter2")).unwrap();
+        let claims = svc.validate_token(&pair.access_token).unwrap();
+        assert_eq!(claims.role, Role::Operator);
+        assert_eq!(claims.kind, TokenKind::Access);
+    }
+
+    #[test]
+    fn login_wrong_password() {
+        let svc = test_service();
+        svc.register_user("cody", &secret("hunter2"), Role::Operator)
+            .unwrap();
+
+        let result = svc.login("cody", &secret("wrong"));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn login_nonexistent_user() {
+        let svc = test_service();
+        let result = svc.login("nobody", &secret("password"));
+        assert!(result.is_err());
+    }
+
+    // --- Token lifecycle ---
+
+    #[test]
+    fn validate_then_logout_then_reject() {
+        let svc = test_service();
+        svc.register_user("cody", &secret("pw"), Role::Operator)
+            .unwrap();
+        let pair = svc.login("cody", &secret("pw")).unwrap();
+
+        // Token is valid
+        assert!(svc.validate_token(&pair.access_token).is_ok());
+
+        // Logout (revoke)
+        svc.logout(&pair.access_token).unwrap();
+
+        // Token is now rejected
+        let result = svc.validate_token(&pair.access_token);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn refresh_token_flow() {
+        let svc = test_service();
+        svc.register_user("cody", &secret("pw"), Role::Operator)
+            .unwrap();
+        let pair = svc.login("cody", &secret("pw")).unwrap();
+
+        let new_pair = svc.refresh_token(&pair.refresh_token).unwrap();
+        let claims = svc.validate_token(&new_pair.access_token).unwrap();
+        assert_eq!(claims.role, Role::Operator);
+    }
+
+    #[test]
+    fn refresh_with_access_token_rejected() {
+        let svc = test_service();
+        svc.register_user("cody", &secret("pw"), Role::Operator)
+            .unwrap();
+        let pair = svc.login("cody", &secret("pw")).unwrap();
+
+        let result = svc.refresh_token(&pair.access_token);
+        assert!(result.is_err());
+    }
+
+    // --- API key flow ---
+
+    #[test]
+    fn api_key_generate_authenticate_revoke() {
+        let svc = test_service();
+        let (key, record) = svc
+            .generate_api_key("test", Role::Operator, None, None)
+            .unwrap();
+
+        let claims = svc.authenticate_api_key(&key).unwrap();
+        assert_eq!(claims.role, Role::Operator);
+
+        svc.revoke_api_key(&record.id).unwrap();
+        assert!(svc.authenticate_api_key(&key).is_err());
+    }
+
+    // --- RBAC ---
+
+    #[test]
+    fn operator_can_do_everything() {
+        let claims = Claims {
+            sub: "op-1".to_owned(),
+            role: Role::Operator,
+            nous_id: None,
+            iss: "test".to_owned(),
+            iat: 0,
+            exp: 0,
+            jti: "j1".to_owned(),
+            kind: TokenKind::Access,
+        };
+
+        let svc = test_service();
+        svc.authorize(&claims, &Action::ReadSession { nous_id: "syn".to_owned() }).unwrap();
+        svc.authorize(&claims, &Action::WriteSession { nous_id: "syn".to_owned() }).unwrap();
+        svc.authorize(&claims, &Action::ManageAgents).unwrap();
+        svc.authorize(&claims, &Action::ManageUsers).unwrap();
+        svc.authorize(&claims, &Action::ReadDashboard).unwrap();
+    }
+
+    #[test]
+    fn agent_scoped_to_own_nous() {
+        let claims = Claims {
+            sub: "agent-syn".to_owned(),
+            role: Role::Agent,
+            nous_id: Some("syn".to_owned()),
+            iss: "test".to_owned(),
+            iat: 0,
+            exp: 0,
+            jti: "j2".to_owned(),
+            kind: TokenKind::Access,
+        };
+
+        let svc = test_service();
+
+        // Can access own sessions
+        svc.authorize(&claims, &Action::ReadSession { nous_id: "syn".to_owned() }).unwrap();
+        svc.authorize(&claims, &Action::WriteSession { nous_id: "syn".to_owned() }).unwrap();
+
+        // Cannot access other agent's sessions
+        assert!(svc.authorize(&claims, &Action::ReadSession { nous_id: "demiurge".to_owned() }).is_err());
+        assert!(svc.authorize(&claims, &Action::WriteSession { nous_id: "demiurge".to_owned() }).is_err());
+
+        // Cannot manage
+        assert!(svc.authorize(&claims, &Action::ManageAgents).is_err());
+        assert!(svc.authorize(&claims, &Action::ManageUsers).is_err());
+
+        // Can read dashboard
+        svc.authorize(&claims, &Action::ReadDashboard).unwrap();
+    }
+
+    #[test]
+    fn readonly_can_only_read_dashboard() {
+        let claims = Claims {
+            sub: "viewer-1".to_owned(),
+            role: Role::Readonly,
+            nous_id: None,
+            iss: "test".to_owned(),
+            iat: 0,
+            exp: 0,
+            jti: "j3".to_owned(),
+            kind: TokenKind::Access,
+        };
+
+        let svc = test_service();
+
+        svc.authorize(&claims, &Action::ReadDashboard).unwrap();
+
+        assert!(svc.authorize(&claims, &Action::ReadSession { nous_id: "syn".to_owned() }).is_err());
+        assert!(svc.authorize(&claims, &Action::WriteSession { nous_id: "syn".to_owned() }).is_err());
+        assert!(svc.authorize(&claims, &Action::ManageAgents).is_err());
+        assert!(svc.authorize(&claims, &Action::ManageUsers).is_err());
+    }
+
+    #[test]
+    fn agent_without_nous_id_cannot_access_sessions() {
+        let claims = Claims {
+            sub: "agent-orphan".to_owned(),
+            role: Role::Agent,
+            nous_id: None,
+            iss: "test".to_owned(),
+            iat: 0,
+            exp: 0,
+            jti: "j4".to_owned(),
+            kind: TokenKind::Access,
+        };
+
+        let svc = test_service();
+        assert!(svc.authorize(&claims, &Action::ReadSession { nous_id: "syn".to_owned() }).is_err());
+    }
+
+    // --- SQL injection safety ---
+
+    #[test]
+    fn sql_injection_in_username_parameterized() {
+        let svc = test_service();
+        // This should not cause SQL injection — parameterized queries handle it
+        let result = svc.login("'; DROP TABLE users; --", &secret("pw"));
+        assert!(result.is_err()); // Just a "not found" error, no SQL injection
+    }
+
+    // --- Duplicate registration ---
+
+    #[test]
+    fn duplicate_user_registration_rejected() {
+        let svc = test_service();
+        svc.register_user("cody", &secret("pw1"), Role::Operator)
+            .unwrap();
+        let result = svc.register_user("cody", &secret("pw2"), Role::Readonly);
+        assert!(result.is_err());
+    }
+}

--- a/crates/symbolon/src/error.rs
+++ b/crates/symbolon/src/error.rs
@@ -1,0 +1,99 @@
+//! Symbolon-specific errors.
+
+use snafu::Snafu;
+
+/// Errors from authentication and authorization operations.
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub))]
+#[non_exhaustive]
+pub enum Error {
+    /// JWT token is malformed or has an invalid signature.
+    #[snafu(display("invalid token: {message}"))]
+    InvalidToken {
+        message: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    /// JWT token has expired.
+    #[snafu(display("token expired"))]
+    ExpiredToken {
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    /// Username or password is incorrect.
+    #[snafu(display("invalid credentials"))]
+    InvalidCredentials {
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    /// The authenticated principal lacks permission for the requested action.
+    #[snafu(display("permission denied: {role} cannot {action}"))]
+    PermissionDenied {
+        action: String,
+        role: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    /// `SQLite` operation failed.
+    #[snafu(display("database error: {source}"))]
+    Database {
+        source: rusqlite::Error,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    /// Password hashing or verification failed.
+    #[snafu(display("hash error: {message}"))]
+    Hash {
+        message: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    /// JWT encoding failed.
+    #[snafu(display("token encode error: {source}"))]
+    TokenEncode {
+        source: jsonwebtoken::errors::Error,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    /// JWT decoding failed.
+    #[snafu(display("token decode error: {source}"))]
+    TokenDecode {
+        source: jsonwebtoken::errors::Error,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    /// API key format is invalid.
+    #[snafu(display("invalid API key format"))]
+    InvalidApiKey {
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    /// Entity not found.
+    #[snafu(display("{entity} not found: {id}"))]
+    NotFound {
+        entity: String,
+        id: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    /// Duplicate entity.
+    #[snafu(display("duplicate {entity}: {id}"))]
+    Duplicate {
+        entity: String,
+        id: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+}
+
+pub type Result<T> = std::result::Result<T, Error>;

--- a/crates/symbolon/src/jwt.rs
+++ b/crates/symbolon/src/jwt.rs
@@ -1,0 +1,301 @@
+//! JWT token issuance and validation.
+
+use std::time::Duration;
+
+use jsonwebtoken::{Algorithm, DecodingKey, EncodingKey, Header, Validation};
+use secrecy::{ExposeSecret, SecretString};
+use snafu::IntoError;
+use tracing::instrument;
+
+use crate::error::{self, Result};
+use crate::types::{Claims, Role, TokenKind, TokenPair};
+
+/// Configuration for JWT token management.
+pub struct JwtConfig {
+    /// HMAC-SHA256 signing key.
+    pub signing_key: SecretString,
+    /// Access token time-to-live (default: 1 hour).
+    pub access_ttl: Duration,
+    /// Refresh token time-to-live (default: 7 days).
+    pub refresh_ttl: Duration,
+    /// Issuer claim value.
+    pub issuer: String,
+}
+
+impl std::fmt::Debug for JwtConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("JwtConfig")
+            .field("signing_key", &"[REDACTED]")
+            .field("access_ttl", &self.access_ttl)
+            .field("refresh_ttl", &self.refresh_ttl)
+            .field("issuer", &self.issuer)
+            .finish()
+    }
+}
+
+impl Default for JwtConfig {
+    fn default() -> Self {
+        Self {
+            signing_key: SecretString::from("CHANGE-ME-IN-PRODUCTION".to_owned()),
+            access_ttl: Duration::from_secs(3600),
+            refresh_ttl: Duration::from_secs(7 * 24 * 3600),
+            issuer: "aletheia".to_owned(),
+        }
+    }
+}
+
+/// Manages JWT issuance and validation.
+pub struct JwtManager {
+    encoding_key: EncodingKey,
+    decoding_key: DecodingKey,
+    config: JwtConfig,
+}
+
+impl JwtManager {
+    /// Create a new JWT manager from the given config.
+    pub fn new(config: JwtConfig) -> Self {
+        let key_bytes = config.signing_key.expose_secret().as_bytes();
+        let encoding_key = EncodingKey::from_secret(key_bytes);
+        let decoding_key = DecodingKey::from_secret(key_bytes);
+        Self {
+            encoding_key,
+            decoding_key,
+            config,
+        }
+    }
+
+    /// Issue an access token.
+    #[instrument(skip(self), fields(kind = "access"))]
+    pub fn issue_access(
+        &self,
+        sub: &str,
+        role: Role,
+        nous_id: Option<&str>,
+    ) -> Result<String> {
+        self.issue(sub, role, nous_id, TokenKind::Access, self.config.access_ttl)
+    }
+
+    /// Issue a refresh token.
+    #[instrument(skip(self), fields(kind = "refresh"))]
+    pub fn issue_refresh(&self, sub: &str, role: Role) -> Result<String> {
+        self.issue(sub, role, None, TokenKind::Refresh, self.config.refresh_ttl)
+    }
+
+    /// Validate a token and return its claims.
+    pub fn validate(&self, token: &str) -> Result<Claims> {
+        let mut validation = Validation::new(Algorithm::HS256);
+        validation.set_issuer(&[&self.config.issuer]);
+        validation.set_required_spec_claims(&["exp", "iss", "sub", "iat"]);
+
+        let token_data = jsonwebtoken::decode::<Claims>(token, &self.decoding_key, &validation)
+            .map_err(|e| match e.kind() {
+                jsonwebtoken::errors::ErrorKind::ExpiredSignature => {
+                    error::ExpiredTokenSnafu.build()
+                }
+                _ => error::TokenDecodeSnafu.into_error(e),
+            })?;
+
+        Ok(token_data.claims)
+    }
+
+    /// Refresh a token pair: validate the refresh token, issue a new access + refresh pair.
+    #[instrument(skip(self, refresh_token))]
+    pub fn refresh(&self, refresh_token: &str) -> Result<TokenPair> {
+        let claims = self.validate(refresh_token)?;
+
+        if claims.kind != TokenKind::Refresh {
+            return Err(error::InvalidTokenSnafu {
+                message: "expected refresh token, got access token".to_owned(),
+            }
+            .build());
+        }
+
+        let access = self.issue_access(&claims.sub, claims.role, claims.nous_id.as_deref())?;
+        let refresh = self.issue_refresh(&claims.sub, claims.role)?;
+
+        Ok(TokenPair {
+            access_token: access,
+            refresh_token: refresh,
+        })
+    }
+
+    fn issue(
+        &self,
+        sub: &str,
+        role: Role,
+        nous_id: Option<&str>,
+        kind: TokenKind,
+        ttl: Duration,
+    ) -> Result<String> {
+        let now = now_unix();
+        let claims = Claims {
+            sub: sub.to_owned(),
+            role,
+            nous_id: nous_id.map(str::to_owned),
+            iss: self.config.issuer.clone(),
+            iat: now,
+            exp: now + i64::try_from(ttl.as_secs()).unwrap_or(i64::MAX),
+            jti: ulid::Ulid::new().to_string(),
+            kind,
+        };
+
+        jsonwebtoken::encode(&Header::new(Algorithm::HS256), &claims, &self.encoding_key)
+            .context(error::TokenEncodeSnafu)
+    }
+}
+
+use snafu::ResultExt;
+
+fn now_unix() -> i64 {
+    i64::try_from(
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs(),
+    )
+    .unwrap_or(i64::MAX)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_manager() -> JwtManager {
+        JwtManager::new(JwtConfig {
+            signing_key: SecretString::from("test-secret-key-for-jwt".to_owned()),
+            access_ttl: Duration::from_secs(3600),
+            refresh_ttl: Duration::from_secs(86400),
+            issuer: "aletheia-test".to_owned(),
+        })
+    }
+
+    #[test]
+    fn issue_and_validate_access_token() {
+        let mgr = test_manager();
+        let token = mgr
+            .issue_access("user-1", Role::Operator, None)
+            .unwrap();
+        let claims = mgr.validate(&token).unwrap();
+        assert_eq!(claims.sub, "user-1");
+        assert_eq!(claims.role, Role::Operator);
+        assert_eq!(claims.kind, TokenKind::Access);
+        assert!(claims.nous_id.is_none());
+    }
+
+    #[test]
+    fn issue_and_validate_agent_token() {
+        let mgr = test_manager();
+        let token = mgr
+            .issue_access("agent-syn", Role::Agent, Some("syn"))
+            .unwrap();
+        let claims = mgr.validate(&token).unwrap();
+        assert_eq!(claims.sub, "agent-syn");
+        assert_eq!(claims.role, Role::Agent);
+        assert_eq!(claims.nous_id.as_deref(), Some("syn"));
+    }
+
+    #[test]
+    fn issue_and_validate_refresh_token() {
+        let mgr = test_manager();
+        let token = mgr.issue_refresh("user-1", Role::Operator).unwrap();
+        let claims = mgr.validate(&token).unwrap();
+        assert_eq!(claims.kind, TokenKind::Refresh);
+    }
+
+    #[test]
+    fn wrong_signing_key_rejected() {
+        let mgr1 = test_manager();
+        let mgr2 = JwtManager::new(JwtConfig {
+            signing_key: SecretString::from("different-key".to_owned()),
+            ..JwtConfig::default()
+        });
+
+        let token = mgr1
+            .issue_access("user-1", Role::Operator, None)
+            .unwrap();
+        assert!(mgr2.validate(&token).is_err());
+    }
+
+    #[test]
+    fn expired_token_rejected() {
+        let mgr = test_manager();
+
+        // Manually encode a token with exp far in the past (beyond the 60s leeway)
+        let claims = Claims {
+            sub: "user-1".to_owned(),
+            role: Role::Operator,
+            nous_id: None,
+            iss: "aletheia-test".to_owned(),
+            iat: 1_000_000,
+            exp: 1_000_001, // 1970 — long expired
+            jti: "expired-jti".to_owned(),
+            kind: TokenKind::Access,
+        };
+        let token = jsonwebtoken::encode(
+            &Header::new(Algorithm::HS256),
+            &claims,
+            &EncodingKey::from_secret(b"test-secret-key-for-jwt"),
+        )
+        .unwrap();
+
+        let result = mgr.validate(&token);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn refresh_flow_produces_valid_tokens() {
+        let mgr = test_manager();
+        let refresh = mgr.issue_refresh("user-1", Role::Operator).unwrap();
+        let pair = mgr.refresh(&refresh).unwrap();
+
+        let access_claims = mgr.validate(&pair.access_token).unwrap();
+        assert_eq!(access_claims.sub, "user-1");
+        assert_eq!(access_claims.kind, TokenKind::Access);
+
+        let refresh_claims = mgr.validate(&pair.refresh_token).unwrap();
+        assert_eq!(refresh_claims.kind, TokenKind::Refresh);
+    }
+
+    #[test]
+    fn refresh_with_access_token_rejected() {
+        let mgr = test_manager();
+        let access = mgr
+            .issue_access("user-1", Role::Operator, None)
+            .unwrap();
+        let result = mgr.refresh(&access);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn claims_jti_is_unique() {
+        let mgr = test_manager();
+        let t1 = mgr
+            .issue_access("user-1", Role::Operator, None)
+            .unwrap();
+        let t2 = mgr
+            .issue_access("user-1", Role::Operator, None)
+            .unwrap();
+        let c1 = mgr.validate(&t1).unwrap();
+        let c2 = mgr.validate(&t2).unwrap();
+        assert_ne!(c1.jti, c2.jti);
+    }
+
+    #[test]
+    fn config_debug_redacts_key() {
+        let config = JwtConfig {
+            signing_key: SecretString::from("super-secret".to_owned()),
+            ..JwtConfig::default()
+        };
+        let debug_output = format!("{config:?}");
+        assert!(!debug_output.contains("super-secret"));
+        assert!(debug_output.contains("[REDACTED]"));
+    }
+
+    #[test]
+    fn malformed_token_rejected() {
+        let mgr = test_manager();
+        assert!(mgr.validate("not.a.jwt").is_err());
+        assert!(mgr.validate("").is_err());
+        assert!(mgr.validate("abc123").is_err());
+    }
+}

--- a/crates/symbolon/src/lib.rs
+++ b/crates/symbolon/src/lib.rs
@@ -1,0 +1,25 @@
+//! aletheia-symbolon — authentication and authorization
+//!
+//! Symbolon (σύμβολον — "token, credential") handles JWT sessions,
+//! API key validation, Argon2id password hashing, and RBAC permission checks.
+
+pub mod api_key;
+pub mod auth;
+pub mod error;
+pub mod jwt;
+pub mod password;
+pub mod store;
+pub mod types;
+
+#[cfg(test)]
+mod assertions {
+    use static_assertions::assert_impl_all;
+
+    use super::auth::AuthService;
+    use super::jwt::JwtManager;
+    use super::store::AuthStore;
+
+    assert_impl_all!(AuthService: Send);
+    assert_impl_all!(AuthStore: Send);
+    assert_impl_all!(JwtManager: Send, Sync);
+}

--- a/crates/symbolon/src/password.rs
+++ b/crates/symbolon/src/password.rs
@@ -1,0 +1,105 @@
+//! Argon2id password hashing and verification.
+
+use argon2::password_hash::rand_core::OsRng;
+use argon2::password_hash::SaltString;
+use argon2::{Argon2, PasswordHash, PasswordHasher, PasswordVerifier};
+use secrecy::{ExposeSecret, SecretString};
+
+use crate::error::{self, Result};
+
+/// Hash a password with Argon2id (OWASP-recommended defaults).
+///
+/// Returns the PHC-formatted hash string suitable for storage.
+pub fn hash_password(password: &SecretString) -> Result<String> {
+    let salt = SaltString::generate(&mut OsRng);
+    let argon2 = Argon2::default();
+
+    argon2
+        .hash_password(password.expose_secret().as_bytes(), &salt)
+        .map(|hash| hash.to_string())
+        .map_err(|e| {
+            error::HashSnafu {
+                message: e.to_string(),
+            }
+            .build()
+        })
+}
+
+/// Verify a password against a stored Argon2id hash.
+///
+/// Returns `Ok(true)` if the password matches, `Ok(false)` if it does not.
+/// Returns `Err` only if the hash string is malformed.
+pub fn verify_password(password: &SecretString, hash: &str) -> Result<bool> {
+    let parsed_hash = PasswordHash::new(hash).map_err(|e| {
+        error::HashSnafu {
+            message: e.to_string(),
+        }
+        .build()
+    })?;
+
+    let argon2 = Argon2::default();
+    match argon2.verify_password(password.expose_secret().as_bytes(), &parsed_hash) {
+        Ok(()) => Ok(true),
+        Err(argon2::password_hash::Error::Password) => Ok(false),
+        Err(e) => Err(error::HashSnafu {
+            message: e.to_string(),
+        }
+        .build()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn secret(s: &str) -> SecretString {
+        SecretString::from(s.to_owned())
+    }
+
+    #[test]
+    fn hash_and_verify_roundtrip() {
+        let pw = secret("correct-horse-battery-staple");
+        let hash = hash_password(&pw).unwrap();
+        assert!(verify_password(&pw, &hash).unwrap());
+    }
+
+    #[test]
+    fn wrong_password_rejected() {
+        let pw = secret("correct-horse-battery-staple");
+        let hash = hash_password(&pw).unwrap();
+        let wrong = secret("wrong-password");
+        assert!(!verify_password(&wrong, &hash).unwrap());
+    }
+
+    #[test]
+    fn empty_password_hashes() {
+        let pw = secret("");
+        let hash = hash_password(&pw).unwrap();
+        assert!(verify_password(&pw, &hash).unwrap());
+    }
+
+    #[test]
+    fn different_passwords_produce_different_hashes() {
+        let h1 = hash_password(&secret("password-a")).unwrap();
+        let h2 = hash_password(&secret("password-b")).unwrap();
+        assert_ne!(h1, h2);
+    }
+
+    #[test]
+    fn same_password_produces_different_hashes_due_to_salt() {
+        let pw = secret("same-password");
+        let h1 = hash_password(&pw).unwrap();
+        let h2 = hash_password(&pw).unwrap();
+        assert_ne!(h1, h2);
+        // But both verify correctly
+        assert!(verify_password(&pw, &h1).unwrap());
+        assert!(verify_password(&pw, &h2).unwrap());
+    }
+
+    #[test]
+    fn malformed_hash_returns_error() {
+        let pw = secret("password");
+        let result = verify_password(&pw, "not-a-valid-hash");
+        assert!(result.is_err());
+    }
+}

--- a/crates/symbolon/src/store.rs
+++ b/crates/symbolon/src/store.rs
@@ -1,0 +1,562 @@
+//! `SQLite` auth store for users, API keys, and token revocation.
+
+use std::path::Path;
+
+use rusqlite::Connection;
+use snafu::{IntoError, ResultExt};
+use tracing::{info, instrument};
+
+use crate::error::{self, Result};
+use crate::types::{ApiKeyRecord, Role, User};
+
+/// Current schema version.
+pub const SCHEMA_VERSION: u32 = 1;
+
+/// Base DDL for the auth database.
+pub const DDL: &str = r"
+CREATE TABLE IF NOT EXISTS users (
+    id TEXT PRIMARY KEY,
+    username TEXT NOT NULL UNIQUE,
+    password_hash TEXT NOT NULL,
+    role TEXT NOT NULL DEFAULT 'readonly',
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+);
+
+CREATE TABLE IF NOT EXISTS api_keys (
+    id TEXT PRIMARY KEY,
+    prefix TEXT NOT NULL,
+    key_hash TEXT NOT NULL,
+    role TEXT NOT NULL,
+    nous_id TEXT,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    expires_at TEXT,
+    last_used_at TEXT,
+    revoked_at TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_api_keys_hash ON api_keys(key_hash);
+CREATE INDEX IF NOT EXISTS idx_api_keys_prefix ON api_keys(prefix);
+
+CREATE TABLE IF NOT EXISTS revoked_tokens (
+    jti TEXT PRIMARY KEY,
+    revoked_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    expires_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS schema_version (
+    version INTEGER PRIMARY KEY,
+    applied_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+);
+";
+
+/// Auth store backed by `SQLite`.
+pub struct AuthStore {
+    conn: Connection,
+}
+
+impl AuthStore {
+    /// Open (or create) the auth store at the given path.
+    pub fn open(path: &Path) -> Result<Self> {
+        info!("Opening auth store at {}", path.display());
+        let conn = Connection::open(path).context(error::DatabaseSnafu)?;
+
+        conn.execute_batch(
+            "PRAGMA journal_mode = WAL;
+             PRAGMA synchronous = NORMAL;
+             PRAGMA foreign_keys = ON;",
+        )
+        .context(error::DatabaseSnafu)?;
+
+        initialize(&conn)?;
+        Ok(Self { conn })
+    }
+
+    /// Open an in-memory auth store (for testing).
+    pub fn open_in_memory() -> Result<Self> {
+        let conn = Connection::open_in_memory().context(error::DatabaseSnafu)?;
+        conn.execute_batch("PRAGMA foreign_keys = ON;")
+            .context(error::DatabaseSnafu)?;
+        initialize(&conn)?;
+        Ok(Self { conn })
+    }
+
+    /// Get a reference to the underlying connection.
+    #[must_use]
+    pub fn conn(&self) -> &Connection {
+        &self.conn
+    }
+
+    // --- Users ---
+
+    /// Create a new user.
+    #[instrument(skip(self, password_hash))]
+    pub fn create_user(
+        &self,
+        id: &str,
+        username: &str,
+        password_hash: &str,
+        role: Role,
+    ) -> Result<User> {
+        self.conn
+            .execute(
+                "INSERT INTO users (id, username, password_hash, role) VALUES (?1, ?2, ?3, ?4)",
+                rusqlite::params![id, username, password_hash, role.as_str()],
+            )
+            .map_err(|e| match e {
+                rusqlite::Error::SqliteFailure(ref err, _)
+                    if err.extended_code == rusqlite::ffi::SQLITE_CONSTRAINT_UNIQUE =>
+                {
+                    error::DuplicateSnafu {
+                        entity: "user".to_owned(),
+                        id: username.to_owned(),
+                    }
+                    .build()
+                }
+                other => error::DatabaseSnafu.into_error(other),
+            })?;
+
+        info!(id, username, %role, "created user");
+        self.find_user_by_username(username)?
+            .ok_or_else(|| {
+                error::NotFoundSnafu {
+                    entity: "user".to_owned(),
+                    id: username.to_owned(),
+                }
+                .build()
+            })
+    }
+
+    /// Find a user by username.
+    pub fn find_user_by_username(&self, username: &str) -> Result<Option<User>> {
+        let mut stmt = self
+            .conn
+            .prepare_cached(
+                "SELECT id, username, password_hash, role, created_at, updated_at FROM users WHERE username = ?1",
+            )
+            .context(error::DatabaseSnafu)?;
+
+        stmt.query_row([username], map_user)
+            .optional()
+            .context(error::DatabaseSnafu)
+    }
+
+    /// Update a user's role.
+    pub fn update_user_role(&self, username: &str, role: Role) -> Result<()> {
+        let rows = self
+            .conn
+            .execute(
+                "UPDATE users SET role = ?1, updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now') WHERE username = ?2",
+                rusqlite::params![role.as_str(), username],
+            )
+            .context(error::DatabaseSnafu)?;
+
+        if rows == 0 {
+            return Err(error::NotFoundSnafu {
+                entity: "user".to_owned(),
+                id: username.to_owned(),
+            }
+            .build());
+        }
+        Ok(())
+    }
+
+    /// Delete a user by username.
+    pub fn delete_user(&self, username: &str) -> Result<bool> {
+        let rows = self
+            .conn
+            .execute("DELETE FROM users WHERE username = ?1", [username])
+            .context(error::DatabaseSnafu)?;
+        Ok(rows > 0)
+    }
+
+    // --- API Keys ---
+
+    /// Store an API key record.
+    pub fn store_api_key(&self, record: &ApiKeyRecord) -> Result<()> {
+        self.conn
+            .execute(
+                "INSERT INTO api_keys (id, prefix, key_hash, role, nous_id, expires_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+                rusqlite::params![
+                    record.id,
+                    record.prefix,
+                    record.key_hash,
+                    record.role.as_str(),
+                    record.nous_id,
+                    record.expires_at,
+                ],
+            )
+            .context(error::DatabaseSnafu)?;
+        Ok(())
+    }
+
+    /// Find an API key by its blake3 hash. Returns `None` if not found.
+    pub fn find_api_key_by_hash(&self, key_hash: &str) -> Result<Option<ApiKeyRecord>> {
+        let mut stmt = self
+            .conn
+            .prepare_cached(
+                "SELECT id, prefix, key_hash, role, nous_id, created_at, expires_at, last_used_at, revoked_at
+                 FROM api_keys WHERE key_hash = ?1",
+            )
+            .context(error::DatabaseSnafu)?;
+
+        stmt.query_row([key_hash], map_api_key)
+            .optional()
+            .context(error::DatabaseSnafu)
+    }
+
+    /// Update the `last_used_at` timestamp for an API key.
+    pub fn touch_api_key(&self, id: &str) -> Result<()> {
+        self.conn
+            .execute(
+                "UPDATE api_keys SET last_used_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now') WHERE id = ?1",
+                [id],
+            )
+            .context(error::DatabaseSnafu)?;
+        Ok(())
+    }
+
+    /// Revoke an API key by ID.
+    pub fn revoke_api_key(&self, id: &str) -> Result<()> {
+        let rows = self
+            .conn
+            .execute(
+                "UPDATE api_keys SET revoked_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now') WHERE id = ?1",
+                [id],
+            )
+            .context(error::DatabaseSnafu)?;
+
+        if rows == 0 {
+            return Err(error::NotFoundSnafu {
+                entity: "api_key".to_owned(),
+                id: id.to_owned(),
+            }
+            .build());
+        }
+        Ok(())
+    }
+
+    /// List all API keys (metadata only).
+    pub fn list_api_keys(&self) -> Result<Vec<ApiKeyRecord>> {
+        let mut stmt = self
+            .conn
+            .prepare_cached(
+                "SELECT id, prefix, key_hash, role, nous_id, created_at, expires_at, last_used_at, revoked_at
+                 FROM api_keys ORDER BY created_at DESC",
+            )
+            .context(error::DatabaseSnafu)?;
+
+        let rows = stmt
+            .query_map([], map_api_key)
+            .context(error::DatabaseSnafu)?;
+
+        let mut keys = Vec::new();
+        for row in rows {
+            keys.push(row.context(error::DatabaseSnafu)?);
+        }
+        Ok(keys)
+    }
+
+    // --- Token Revocation ---
+
+    /// Revoke a JWT by its `jti`.
+    pub fn revoke_token(&self, jti: &str, expires_at: &str) -> Result<()> {
+        self.conn
+            .execute(
+                "INSERT OR IGNORE INTO revoked_tokens (jti, expires_at) VALUES (?1, ?2)",
+                [jti, expires_at],
+            )
+            .context(error::DatabaseSnafu)?;
+        Ok(())
+    }
+
+    /// Check if a JWT has been revoked.
+    pub fn is_token_revoked(&self, jti: &str) -> Result<bool> {
+        let mut stmt = self
+            .conn
+            .prepare_cached("SELECT 1 FROM revoked_tokens WHERE jti = ?1")
+            .context(error::DatabaseSnafu)?;
+
+        let exists = stmt
+            .query_row([jti], |_| Ok(()))
+            .optional()
+            .context(error::DatabaseSnafu)?;
+
+        Ok(exists.is_some())
+    }
+
+    /// Remove revocation entries for tokens that have already expired.
+    pub fn cleanup_expired_revocations(&self) -> Result<usize> {
+        let rows = self
+            .conn
+            .execute(
+                "DELETE FROM revoked_tokens WHERE expires_at < strftime('%Y-%m-%dT%H:%M:%fZ', 'now')",
+                [],
+            )
+            .context(error::DatabaseSnafu)?;
+        Ok(rows)
+    }
+}
+
+// --- Schema initialization ---
+
+fn initialize(conn: &Connection) -> Result<()> {
+    let version = get_schema_version(conn);
+
+    if version == 0 {
+        info!("Initializing fresh auth database with schema v{SCHEMA_VERSION}");
+        conn.execute_batch(DDL).context(error::DatabaseSnafu)?;
+        conn.execute(
+            "INSERT OR REPLACE INTO schema_version (version) VALUES (?1)",
+            [SCHEMA_VERSION],
+        )
+        .context(error::DatabaseSnafu)?;
+    }
+
+    Ok(())
+}
+
+fn get_schema_version(conn: &Connection) -> u32 {
+    conn.query_row(
+        "SELECT version FROM schema_version ORDER BY version DESC LIMIT 1",
+        [],
+        |row| row.get(0),
+    )
+    .unwrap_or(0)
+}
+
+// --- Row mappers ---
+
+fn map_user(row: &rusqlite::Row<'_>) -> rusqlite::Result<User> {
+    let role_str: String = row.get("role")?;
+    Ok(User {
+        id: row.get("id")?,
+        username: row.get("username")?,
+        password_hash: row.get("password_hash")?,
+        role: role_str.parse().unwrap_or(Role::Readonly),
+        created_at: row.get("created_at")?,
+        updated_at: row.get("updated_at")?,
+    })
+}
+
+fn map_api_key(row: &rusqlite::Row<'_>) -> rusqlite::Result<ApiKeyRecord> {
+    let role_str: String = row.get("role")?;
+    Ok(ApiKeyRecord {
+        id: row.get("id")?,
+        prefix: row.get("prefix")?,
+        key_hash: row.get("key_hash")?,
+        role: role_str.parse().unwrap_or(Role::Readonly),
+        nous_id: row.get("nous_id")?,
+        created_at: row.get("created_at")?,
+        expires_at: row.get("expires_at")?,
+        last_used_at: row.get("last_used_at")?,
+        revoked_at: row.get("revoked_at")?,
+    })
+}
+
+/// Extension trait for optional query results.
+trait OptionalExt<T> {
+    fn optional(self) -> std::result::Result<Option<T>, rusqlite::Error>;
+}
+
+impl<T> OptionalExt<T> for std::result::Result<T, rusqlite::Error> {
+    fn optional(self) -> std::result::Result<Option<T>, rusqlite::Error> {
+        match self {
+            Ok(v) => Ok(Some(v)),
+            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+            Err(e) => Err(e),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_store() -> AuthStore {
+        AuthStore::open_in_memory().expect("open in-memory auth store")
+    }
+
+    #[test]
+    fn fresh_database_initializes() {
+        let store = test_store();
+        let version = get_schema_version(store.conn());
+        assert_eq!(version, SCHEMA_VERSION);
+    }
+
+    #[test]
+    fn idempotent_initialization() {
+        let store = test_store();
+        initialize(store.conn()).unwrap();
+        let version = get_schema_version(store.conn());
+        assert_eq!(version, SCHEMA_VERSION);
+    }
+
+    #[test]
+    fn tables_exist_after_init() {
+        let store = test_store();
+        for table in &["users", "api_keys", "revoked_tokens"] {
+            let exists: bool = store
+                .conn()
+                .query_row(
+                    "SELECT COUNT(*) > 0 FROM sqlite_master WHERE type='table' AND name=?1",
+                    [table],
+                    |row| row.get(0),
+                )
+                .unwrap();
+            assert!(exists, "table {table} should exist");
+        }
+    }
+
+    #[test]
+    fn user_crud() {
+        let store = test_store();
+        let user = store
+            .create_user("u1", "cody", "$argon2id$hash", Role::Operator)
+            .unwrap();
+        assert_eq!(user.username, "cody");
+        assert_eq!(user.role, Role::Operator);
+
+        let found = store.find_user_by_username("cody").unwrap();
+        assert!(found.is_some());
+        assert_eq!(found.unwrap().id, "u1");
+
+        store.update_user_role("cody", Role::Readonly).unwrap();
+        let updated = store.find_user_by_username("cody").unwrap().unwrap();
+        assert_eq!(updated.role, Role::Readonly);
+
+        let deleted = store.delete_user("cody").unwrap();
+        assert!(deleted);
+
+        let gone = store.find_user_by_username("cody").unwrap();
+        assert!(gone.is_none());
+    }
+
+    #[test]
+    fn duplicate_username_rejected() {
+        let store = test_store();
+        store
+            .create_user("u1", "cody", "$hash1", Role::Operator)
+            .unwrap();
+        let result = store.create_user("u2", "cody", "$hash2", Role::Readonly);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn delete_nonexistent_user_returns_false() {
+        let store = test_store();
+        assert!(!store.delete_user("nobody").unwrap());
+    }
+
+    #[test]
+    fn token_revocation_lifecycle() {
+        let store = test_store();
+        let jti = "test-jti-123";
+
+        assert!(!store.is_token_revoked(jti).unwrap());
+        store.revoke_token(jti, "2099-01-01T00:00:00.000Z").unwrap();
+        assert!(store.is_token_revoked(jti).unwrap());
+    }
+
+    #[test]
+    fn expired_revocation_cleanup() {
+        let store = test_store();
+        // Insert an already-expired revocation
+        store
+            .revoke_token("old-jti", "2000-01-01T00:00:00.000Z")
+            .unwrap();
+        // Insert a future revocation
+        store
+            .revoke_token("future-jti", "2099-01-01T00:00:00.000Z")
+            .unwrap();
+
+        let cleaned = store.cleanup_expired_revocations().unwrap();
+        assert_eq!(cleaned, 1);
+
+        assert!(!store.is_token_revoked("old-jti").unwrap());
+        assert!(store.is_token_revoked("future-jti").unwrap());
+    }
+
+    #[test]
+    fn api_key_store_and_find() {
+        let store = test_store();
+        let record = ApiKeyRecord {
+            id: "k1".to_owned(),
+            prefix: "syn".to_owned(),
+            key_hash: "abc123hash".to_owned(),
+            role: Role::Agent,
+            nous_id: Some("syn".to_owned()),
+            created_at: String::new(),
+            expires_at: None,
+            last_used_at: None,
+            revoked_at: None,
+        };
+
+        store.store_api_key(&record).unwrap();
+        let found = store.find_api_key_by_hash("abc123hash").unwrap();
+        assert!(found.is_some());
+        let found = found.unwrap();
+        assert_eq!(found.id, "k1");
+        assert_eq!(found.prefix, "syn");
+        assert_eq!(found.role, Role::Agent);
+    }
+
+    #[test]
+    fn api_key_revoke() {
+        let store = test_store();
+        let record = ApiKeyRecord {
+            id: "k1".to_owned(),
+            prefix: "test".to_owned(),
+            key_hash: "hash1".to_owned(),
+            role: Role::Operator,
+            nous_id: None,
+            created_at: String::new(),
+            expires_at: None,
+            last_used_at: None,
+            revoked_at: None,
+        };
+
+        store.store_api_key(&record).unwrap();
+        store.revoke_api_key("k1").unwrap();
+
+        let found = store.find_api_key_by_hash("hash1").unwrap().unwrap();
+        assert!(found.revoked_at.is_some());
+    }
+
+    #[test]
+    fn api_key_list() {
+        let store = test_store();
+        for i in 0..3 {
+            let record = ApiKeyRecord {
+                id: format!("k{i}"),
+                prefix: format!("prefix{i}"),
+                key_hash: format!("hash{i}"),
+                role: Role::Readonly,
+                nous_id: None,
+                created_at: String::new(),
+                expires_at: None,
+                last_used_at: None,
+                revoked_at: None,
+            };
+            store.store_api_key(&record).unwrap();
+        }
+
+        let keys = store.list_api_keys().unwrap();
+        assert_eq!(keys.len(), 3);
+    }
+
+    #[test]
+    fn update_nonexistent_user_role_errors() {
+        let store = test_store();
+        let result = store.update_user_role("nobody", Role::Operator);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn revoke_nonexistent_api_key_errors() {
+        let store = test_store();
+        let result = store.revoke_api_key("no-such-key");
+        assert!(result.is_err());
+    }
+}

--- a/crates/symbolon/src/types.rs
+++ b/crates/symbolon/src/types.rs
@@ -1,0 +1,136 @@
+//! Shared types for authentication and authorization.
+
+use serde::{Deserialize, Serialize};
+
+/// Role in the RBAC model.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+#[non_exhaustive]
+pub enum Role {
+    /// Full access. Can manage agents, users, read all sessions, configure system.
+    Operator,
+    /// Per-nous scoped. Can access own sessions, use own tools, read shared workspace.
+    Agent,
+    /// Dashboard access only. No mutations.
+    Readonly,
+}
+
+impl Role {
+    /// String representation for storage.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Operator => "operator",
+            Self::Agent => "agent",
+            Self::Readonly => "readonly",
+        }
+    }
+}
+
+impl std::fmt::Display for Role {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl std::str::FromStr for Role {
+    type Err = String;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        match s {
+            "operator" => Ok(Self::Operator),
+            "agent" => Ok(Self::Agent),
+            "readonly" => Ok(Self::Readonly),
+            other => Err(format!("unknown role: {other}")),
+        }
+    }
+}
+
+/// Distinguishes access tokens from refresh tokens.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum TokenKind {
+    /// Short-lived token for API access.
+    Access,
+    /// Long-lived token used to obtain new access tokens.
+    Refresh,
+}
+
+/// JWT claims payload.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Claims {
+    /// Subject — user or agent ID.
+    pub sub: String,
+    /// RBAC role.
+    pub role: Role,
+    /// For agent tokens, the nous ID this token is scoped to.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub nous_id: Option<String>,
+    /// Issuer.
+    pub iss: String,
+    /// Issued-at (unix seconds).
+    pub iat: i64,
+    /// Expiration (unix seconds).
+    pub exp: i64,
+    /// Unique token ID (for revocation).
+    pub jti: String,
+    /// Access or refresh.
+    pub kind: TokenKind,
+}
+
+/// An access + refresh token pair returned from login or refresh.
+pub struct TokenPair {
+    pub access_token: String,
+    pub refresh_token: String,
+}
+
+/// Actions that can be authorized via RBAC.
+#[non_exhaustive]
+pub enum Action {
+    /// Read a session belonging to a specific nous.
+    ReadSession { nous_id: String },
+    /// Write to a session belonging to a specific nous.
+    WriteSession { nous_id: String },
+    /// Manage agent configurations.
+    ManageAgents,
+    /// Manage user accounts.
+    ManageUsers,
+    /// Read the dashboard (metrics, status).
+    ReadDashboard,
+}
+
+impl std::fmt::Display for Action {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ReadSession { nous_id } => write!(f, "read session (nous: {nous_id})"),
+            Self::WriteSession { nous_id } => write!(f, "write session (nous: {nous_id})"),
+            Self::ManageAgents => f.write_str("manage agents"),
+            Self::ManageUsers => f.write_str("manage users"),
+            Self::ReadDashboard => f.write_str("read dashboard"),
+        }
+    }
+}
+
+/// Stored user record.
+#[derive(Debug, Clone)]
+pub struct User {
+    pub id: String,
+    pub username: String,
+    pub password_hash: String,
+    pub role: Role,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+/// Stored API key metadata (never includes the secret).
+#[derive(Debug, Clone)]
+pub struct ApiKeyRecord {
+    pub id: String,
+    pub prefix: String,
+    pub key_hash: String,
+    pub role: Role,
+    pub nous_id: Option<String>,
+    pub created_at: String,
+    pub expires_at: Option<String>,
+    pub last_used_at: Option<String>,
+    pub revoked_at: Option<String>,
+}


### PR DESCRIPTION
## Summary

- New crate `aletheia-symbolon` — authentication and authorization for the Rust rewrite (M3 dependency)
- JWT management: HS256 access (1h) + refresh (7d) tokens with issuance, validation, refresh flow, and jti-based revocation
- Password hashing: Argon2id with OWASP defaults, SecretString-guarded inputs
- API keys: `ale_{prefix}_{secret}` format, blake3 hashing at rest, generate/validate/revoke lifecycle
- RBAC: operator (full access), agent (per-nous scoped), readonly (dashboard only)
- SQLite auth store with WAL mode, prepared statements, schema versioning
- AuthService facade composing all auth mechanisms

## Test plan

- [x] `cargo test -p aletheia-symbolon` — 50 tests passing
- [x] `cargo clippy --workspace` — clean (zero warnings)
- [x] Password: hash+verify roundtrip, wrong password rejected, empty/long passwords, salt uniqueness
- [x] JWT: issue+validate, expired rejected, wrong key rejected, refresh flow, kind enforcement, jti uniqueness
- [x] API keys: generate+validate, revocation, expiry, malformed format, prefix parsing
- [x] RBAC: operator full access, agent nous-scoped, readonly dashboard-only, agent cross-nous denied
- [x] Store: user CRUD, duplicate rejection, token revocation lifecycle, expired cleanup
- [x] Integration: full login→token→validate→logout, API key→authenticate→revoke, SQL injection resistance
- [x] Secret safety: Debug output redacts signing key via SecretString