### PR TITLE
feat(nous): context bootstrap — oikos cascade assembly, token budget, tool tiers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,6 +75,7 @@ dependencies = [
  "aletheia-hermeneus",
  "aletheia-koina",
  "aletheia-mneme",
+ "aletheia-organon",
  "aletheia-taxis",
  "serde",
  "serde_json",

--- a/crates/nous/Cargo.toml
+++ b/crates/nous/Cargo.toml
@@ -14,6 +14,7 @@ workspace = true
 aletheia-hermeneus = { path = "../hermeneus" }
 aletheia-koina = { path = "../koina" }
 aletheia-mneme = { path = "../mneme" }
+aletheia-organon = { path = "../organon" }
 aletheia-taxis = { path = "../taxis" }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/nous/src/bootstrap/mod.rs
+++ b/crates/nous/src/bootstrap/mod.rs
@@ -1,0 +1,617 @@
+//! Context bootstrap assembly.
+//!
+//! Reads workspace files through the taxis cascade, estimates tokens,
+//! and packs sections in priority order within the token budget.
+
+pub mod tools;
+
+use tracing::{debug, info, warn};
+
+use aletheia_taxis::cascade;
+use aletheia_taxis::oikos::Oikos;
+
+use crate::budget::{CharEstimator, TokenBudget, TokenEstimator};
+use crate::error::{self, Result};
+
+/// Priority level for bootstrap sections.
+///
+/// Determines inclusion order and drop/truncation behavior under budget pressure.
+/// Derives `Ord` so sections sort Required-first.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum SectionPriority {
+    /// Must be included. Missing = error.
+    Required = 0,
+    /// Should be included if present. Missing = skip silently.
+    Important = 1,
+    /// Can be truncated (oldest content removed first).
+    Flexible = 2,
+    /// Dropped first under budget pressure.
+    Optional = 3,
+}
+
+/// A section of the bootstrap system prompt.
+#[derive(Debug, Clone)]
+pub struct BootstrapSection {
+    /// Section name (e.g. "SOUL.md", "tools-summary").
+    pub name: String,
+    /// Priority level.
+    pub priority: SectionPriority,
+    /// The text content.
+    pub content: String,
+    /// Estimated token count.
+    pub tokens: u64,
+    /// Whether this section can be truncated (vs dropped entirely).
+    pub truncatable: bool,
+}
+
+/// Result of bootstrap assembly.
+#[derive(Debug, Clone)]
+pub struct BootstrapResult {
+    /// The assembled system prompt text.
+    pub system_prompt: String,
+    /// Section names that were included (in order).
+    pub sections_included: Vec<String>,
+    /// Section names that were truncated.
+    pub sections_truncated: Vec<String>,
+    /// Section names that were dropped entirely.
+    pub sections_dropped: Vec<String>,
+    /// Total estimated tokens consumed by the system prompt.
+    pub total_tokens: u64,
+}
+
+/// Workspace file specification for cascade resolution.
+struct WorkspaceFileSpec {
+    filename: &'static str,
+    priority: SectionPriority,
+    truncatable: bool,
+}
+
+/// Ordered list of workspace files resolved through the oikos cascade.
+///
+/// Priority ordering:
+/// - SOUL.md: Required (core identity)
+/// - USER.md: Important (operator profile, typically in theke/)
+/// - TELOS.md: Important (active goals)
+/// - AGENTS.md: Important (team topology, typically in theke/)
+/// - MNEME.md: Flexible + truncatable (operational memory, oldest entries dropped first)
+const WORKSPACE_FILES: &[WorkspaceFileSpec] = &[
+    WorkspaceFileSpec {
+        filename: "SOUL.md",
+        priority: SectionPriority::Required,
+        truncatable: false,
+    },
+    WorkspaceFileSpec {
+        filename: "USER.md",
+        priority: SectionPriority::Important,
+        truncatable: false,
+    },
+    WorkspaceFileSpec {
+        filename: "TELOS.md",
+        priority: SectionPriority::Important,
+        truncatable: false,
+    },
+    WorkspaceFileSpec {
+        filename: "AGENTS.md",
+        priority: SectionPriority::Important,
+        truncatable: false,
+    },
+    WorkspaceFileSpec {
+        filename: "MNEME.md",
+        priority: SectionPriority::Flexible,
+        truncatable: true,
+    },
+];
+
+/// Minimum tokens remaining before attempting truncation (below this, just drop).
+const MIN_TRUNCATION_BUDGET: u64 = 200;
+
+/// Assembles the bootstrap system prompt from oikos workspace files.
+///
+/// Resolves files through the three-tier cascade (`nous/{id}/` → `shared/` → `theke/`),
+/// reads contents, estimates tokens, and packs sections in priority order.
+pub struct BootstrapAssembler<'a, E: TokenEstimator = CharEstimator> {
+    oikos: &'a Oikos,
+    estimator: E,
+}
+
+impl<'a> BootstrapAssembler<'a, CharEstimator> {
+    /// Create an assembler with the default character-based estimator.
+    #[must_use]
+    pub fn new(oikos: &'a Oikos) -> Self {
+        Self {
+            oikos,
+            estimator: CharEstimator,
+        }
+    }
+}
+
+impl<'a, E: TokenEstimator> BootstrapAssembler<'a, E> {
+    /// Create an assembler with a custom token estimator.
+    #[must_use]
+    pub fn with_estimator(oikos: &'a Oikos, estimator: E) -> Self {
+        Self { oikos, estimator }
+    }
+
+    /// Assemble the bootstrap system prompt for the given nous.
+    ///
+    /// Resolves workspace files through the cascade, packs them in priority order
+    /// within the token budget, truncates flexible sections, and drops optional
+    /// sections if budget is exhausted.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`error::Error::ContextAssembly`] if a Required file (SOUL.md) is
+    /// missing or unreadable.
+    pub fn assemble(&self, nous_id: &str, budget: &mut TokenBudget) -> Result<BootstrapResult> {
+        let mut sections = self.resolve_workspace_files(nous_id)?;
+
+        // Stable sort preserves declaration order within same priority
+        sections.sort_by_key(|s| s.priority);
+
+        let mut included: Vec<BootstrapSection> = Vec::new();
+        let mut truncated_names: Vec<String> = Vec::new();
+        let mut dropped_names: Vec<String> = Vec::new();
+
+        for section in sections {
+            if budget.can_fit(section.tokens) {
+                budget.consume(section.tokens);
+                included.push(section);
+            } else if section.truncatable && budget.remaining() > MIN_TRUNCATION_BUDGET {
+                let truncated = self.truncate_section(&section, budget.remaining());
+                budget.consume(truncated.tokens);
+                warn!(
+                    section = section.name,
+                    original_tokens = section.tokens,
+                    truncated_tokens = truncated.tokens,
+                    "section truncated for token budget"
+                );
+                truncated_names.push(truncated.name.clone());
+                included.push(truncated);
+            } else {
+                warn!(
+                    section = section.name,
+                    tokens = section.tokens,
+                    remaining = budget.remaining(),
+                    "section dropped — budget exhausted"
+                );
+                dropped_names.push(section.name);
+            }
+        }
+
+        let system_prompt = included
+            .iter()
+            .map(|s| format!("## {}\n\n{}", s.name, s.content))
+            .collect::<Vec<_>>()
+            .join("\n\n---\n\n");
+
+        let section_names: Vec<String> = included.iter().map(|s| s.name.clone()).collect();
+        let total_tokens = budget.consumed();
+
+        info!(
+            nous_id,
+            sections = section_names.len(),
+            total_tokens,
+            truncated = truncated_names.len(),
+            dropped = dropped_names.len(),
+            "bootstrap assembled"
+        );
+
+        Ok(BootstrapResult {
+            system_prompt,
+            sections_included: section_names,
+            sections_truncated: truncated_names,
+            sections_dropped: dropped_names,
+            total_tokens,
+        })
+    }
+
+    /// Resolve workspace files through the cascade and read their contents.
+    fn resolve_workspace_files(&self, nous_id: &str) -> Result<Vec<BootstrapSection>> {
+        let mut sections = Vec::new();
+
+        for spec in WORKSPACE_FILES {
+            let Some(p) = cascade::resolve(self.oikos, nous_id, spec.filename, None) else {
+                if spec.priority == SectionPriority::Required {
+                    return Err(error::ContextAssemblySnafu {
+                        message: format!(
+                            "required file {} not found in cascade",
+                            spec.filename
+                        ),
+                    }
+                    .build());
+                }
+                debug!(file = spec.filename, "not found in cascade, skipping");
+                continue;
+            };
+
+            match std::fs::read_to_string(&p) {
+                Ok(content) => {
+                    let content = content.trim().to_owned();
+                    if content.is_empty() {
+                        debug!(file = spec.filename, "skipping empty file");
+                        continue;
+                    }
+                    let tokens = self.estimator.estimate(&content);
+                    sections.push(BootstrapSection {
+                        name: spec.filename.to_owned(),
+                        priority: spec.priority,
+                        content,
+                        tokens,
+                        truncatable: spec.truncatable,
+                    });
+                }
+                Err(e) => {
+                    if spec.priority == SectionPriority::Required {
+                        return Err(error::ContextAssemblySnafu {
+                            message: format!(
+                                "required file {} unreadable: {e}",
+                                spec.filename
+                            ),
+                        }
+                        .build());
+                    }
+                    warn!(
+                        file = spec.filename,
+                        path = %p.display(),
+                        error = %e,
+                        "failed to read workspace file, skipping"
+                    );
+                }
+            }
+        }
+
+        Ok(sections)
+    }
+
+    /// Truncate a section to fit within the given token limit.
+    ///
+    /// Strategy: split on `## ` markdown headers, include complete subsections
+    /// until budget is reached. Falls back to line-by-line truncation if no
+    /// headers are found.
+    fn truncate_section(&self, section: &BootstrapSection, max_tokens: u64) -> BootstrapSection {
+        let parts: Vec<&str> = section.content.split("\n## ").collect();
+
+        if parts.len() <= 1 {
+            return self.truncate_by_lines(section, max_tokens);
+        }
+
+        let mut result = String::new();
+        let mut tokens: u64 = 0;
+
+        for (i, part) in parts.iter().enumerate() {
+            let text = if i == 0 {
+                (*part).to_owned()
+            } else {
+                format!("\n## {part}")
+            };
+            let part_tokens = self.estimator.estimate(&text);
+
+            if tokens + part_tokens > max_tokens {
+                if result.is_empty() {
+                    return self.truncate_by_lines(section, max_tokens);
+                }
+                result.push_str("\n\n... [truncated for token budget] ...");
+                break;
+            }
+            result.push_str(&text);
+            tokens += part_tokens;
+        }
+
+        let final_tokens = self.estimator.estimate(&result);
+        BootstrapSection {
+            name: section.name.clone(),
+            priority: section.priority,
+            content: result,
+            tokens: final_tokens,
+            truncatable: section.truncatable,
+        }
+    }
+
+    /// Line-by-line truncation fallback.
+    fn truncate_by_lines(&self, section: &BootstrapSection, max_tokens: u64) -> BootstrapSection {
+        let mut result = String::new();
+        let mut tokens: u64 = 0;
+
+        for line in section.content.lines() {
+            let line_with_newline = format!("{line}\n");
+            let line_tokens = self.estimator.estimate(&line_with_newline);
+
+            if tokens + line_tokens > max_tokens {
+                result.push_str("\n... [truncated for token budget] ...");
+                break;
+            }
+            result.push_str(&line_with_newline);
+            tokens += line_tokens;
+        }
+
+        let final_tokens = self.estimator.estimate(&result);
+        BootstrapSection {
+            name: section.name.clone(),
+            priority: section.priority,
+            content: result,
+            tokens: final_tokens,
+            truncatable: section.truncatable,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::budget::TokenBudget;
+    use std::fs;
+    use tempfile::TempDir;
+
+    /// Create an oikos directory structure with the given files.
+    /// Files are placed in `nous/{nous_id}/` unless the filename starts with `theke:`.
+    fn setup_oikos(nous_id: &str, files: &[(&str, &str)]) -> (TempDir, Oikos) {
+        let dir = TempDir::new().unwrap();
+        let root = dir.path();
+
+        // Create tier directories
+        fs::create_dir_all(root.join(format!("nous/{nous_id}"))).unwrap();
+        fs::create_dir_all(root.join("shared")).unwrap();
+        fs::create_dir_all(root.join("theke")).unwrap();
+
+        for (name, content) in files {
+            if let Some(stripped) = name.strip_prefix("theke:") {
+                fs::write(root.join("theke").join(stripped), content).unwrap();
+            } else {
+                fs::write(
+                    root.join(format!("nous/{nous_id}")).join(name),
+                    content,
+                )
+                .unwrap();
+            }
+        }
+
+        let oikos = Oikos::from_root(root);
+        (dir, oikos)
+    }
+
+    fn default_budget() -> TokenBudget {
+        TokenBudget::new(200_000, 0.6, 16_384, 40_000)
+    }
+
+    // --- Assembly tests ---
+
+    #[test]
+    fn assemble_with_required_only() {
+        let (_dir, oikos) = setup_oikos("test", &[("SOUL.md", "I am a test agent.")]);
+        let assembler = BootstrapAssembler::new(&oikos);
+        let mut budget = default_budget();
+
+        let result = assembler.assemble("test", &mut budget).unwrap();
+        assert!(result.system_prompt.contains("I am a test agent."));
+        assert_eq!(result.sections_included, vec!["SOUL.md"]);
+        assert!(result.sections_dropped.is_empty());
+    }
+
+    #[test]
+    fn assemble_missing_required_errors() {
+        let (_dir, oikos) = setup_oikos("test", &[("USER.md", "some user info")]);
+        let assembler = BootstrapAssembler::new(&oikos);
+        let mut budget = default_budget();
+
+        let err = assembler.assemble("test", &mut budget).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("SOUL.md"), "error should mention SOUL.md: {msg}");
+    }
+
+    #[test]
+    fn assemble_missing_optional_skips() {
+        let (_dir, oikos) = setup_oikos("test", &[("SOUL.md", "identity")]);
+        let assembler = BootstrapAssembler::new(&oikos);
+        let mut budget = default_budget();
+
+        let result = assembler.assemble("test", &mut budget).unwrap();
+        // Only SOUL.md included, others silently skipped
+        assert_eq!(result.sections_included, vec!["SOUL.md"]);
+        assert!(result.sections_dropped.is_empty());
+    }
+
+    #[test]
+    fn assemble_priority_ordering() {
+        let (_dir, oikos) = setup_oikos(
+            "test",
+            &[
+                ("SOUL.md", "identity"),
+                ("MNEME.md", "memory notes"),
+                ("TELOS.md", "goals"),
+            ],
+        );
+        let assembler = BootstrapAssembler::new(&oikos);
+        let mut budget = default_budget();
+
+        let result = assembler.assemble("test", &mut budget).unwrap();
+        // Required (SOUL) before Important (TELOS) before Flexible (MNEME)
+        let soul_pos = result
+            .sections_included
+            .iter()
+            .position(|s| s == "SOUL.md")
+            .unwrap();
+        let telos_pos = result
+            .sections_included
+            .iter()
+            .position(|s| s == "TELOS.md")
+            .unwrap();
+        let mneme_pos = result
+            .sections_included
+            .iter()
+            .position(|s| s == "MNEME.md")
+            .unwrap();
+        assert!(soul_pos < telos_pos);
+        assert!(telos_pos < mneme_pos);
+    }
+
+    #[test]
+    fn assemble_all_files_present() {
+        let (_dir, oikos) = setup_oikos(
+            "test",
+            &[
+                ("SOUL.md", "identity"),
+                ("USER.md", "user info"),
+                ("TELOS.md", "goals"),
+                ("AGENTS.md", "team topology"),
+                ("MNEME.md", "memory"),
+            ],
+        );
+        let assembler = BootstrapAssembler::new(&oikos);
+        let mut budget = default_budget();
+
+        let result = assembler.assemble("test", &mut budget).unwrap();
+        assert_eq!(result.sections_included.len(), 5);
+        assert!(result.total_tokens > 0);
+    }
+
+    #[test]
+    fn assemble_empty_file_skipped() {
+        let (_dir, oikos) = setup_oikos(
+            "test",
+            &[
+                ("SOUL.md", "identity"),
+                ("AGENTS.md", ""),
+                ("TELOS.md", "   \n  \n  "), // whitespace-only
+            ],
+        );
+        let assembler = BootstrapAssembler::new(&oikos);
+        let mut budget = default_budget();
+
+        let result = assembler.assemble("test", &mut budget).unwrap();
+        assert_eq!(result.sections_included, vec!["SOUL.md"]);
+    }
+
+    #[test]
+    fn assemble_mneme_truncated() {
+        // Create a large MNEME.md that exceeds a small budget
+        let large_mneme = "## Recent\nNew stuff here.\n## Old\nOld stuff here that is much longer and should be truncated when the budget is tight. ".repeat(50);
+        let (_dir, oikos) = setup_oikos(
+            "test",
+            &[("SOUL.md", "identity"), ("MNEME.md", &large_mneme)],
+        );
+        let assembler = BootstrapAssembler::new(&oikos);
+        // Small budget: enough for SOUL.md but not full MNEME.md
+        let mut budget = TokenBudget::new(100_000, 0.0, 0, 500);
+
+        let result = assembler.assemble("test", &mut budget).unwrap();
+        assert!(result.sections_included.contains(&"MNEME.md".to_owned()));
+        assert!(result.sections_truncated.contains(&"MNEME.md".to_owned()));
+        assert!(result.system_prompt.contains("[truncated for token budget]"));
+    }
+
+    #[test]
+    fn assemble_optional_dropped() {
+        // SOUL.md fills the entire budget, MNEME.md gets dropped
+        let large_soul = "x".repeat(2000); // ~500 tokens at 4 chars/token
+        let (_dir, oikos) = setup_oikos(
+            "test",
+            &[("SOUL.md", &large_soul), ("MNEME.md", "memory notes")],
+        );
+        let assembler = BootstrapAssembler::new(&oikos);
+        let mut budget = TokenBudget::new(100_000, 0.0, 0, 500);
+
+        let result = assembler.assemble("test", &mut budget).unwrap();
+        assert!(result.sections_included.contains(&"SOUL.md".to_owned()));
+        assert!(result.sections_dropped.contains(&"MNEME.md".to_owned()));
+    }
+
+    #[test]
+    fn assemble_budget_consumed_correctly() {
+        let (_dir, oikos) = setup_oikos(
+            "test",
+            &[("SOUL.md", "identity"), ("USER.md", "user info")],
+        );
+        let assembler = BootstrapAssembler::new(&oikos);
+        let mut budget = default_budget();
+
+        let result = assembler.assemble("test", &mut budget).unwrap();
+        assert_eq!(budget.consumed(), result.total_tokens);
+        assert!(result.total_tokens > 0);
+    }
+
+    #[test]
+    fn assemble_cascade_nous_tier() {
+        // File only in nous tier
+        let (_dir, oikos) = setup_oikos("syn", &[("SOUL.md", "I am Syn.")]);
+        let assembler = BootstrapAssembler::new(&oikos);
+        let mut budget = default_budget();
+
+        let result = assembler.assemble("syn", &mut budget).unwrap();
+        assert!(result.system_prompt.contains("I am Syn."));
+    }
+
+    #[test]
+    fn assemble_cascade_theke_fallback() {
+        // USER.md only in theke (common pattern)
+        let (_dir, oikos) = setup_oikos(
+            "syn",
+            &[("SOUL.md", "identity"), ("theke:USER.md", "Chris K.")],
+        );
+        let assembler = BootstrapAssembler::new(&oikos);
+        let mut budget = default_budget();
+
+        let result = assembler.assemble("syn", &mut budget).unwrap();
+        assert!(result.system_prompt.contains("Chris K."));
+        assert!(result.sections_included.contains(&"USER.md".to_owned()));
+    }
+
+    #[test]
+    fn assemble_nous_overrides_theke() {
+        // SOUL.md in both tiers — nous wins
+        let dir = TempDir::new().unwrap();
+        let root = dir.path();
+        fs::create_dir_all(root.join("nous/syn")).unwrap();
+        fs::create_dir_all(root.join("shared")).unwrap();
+        fs::create_dir_all(root.join("theke")).unwrap();
+        fs::write(root.join("nous/syn/SOUL.md"), "nous-specific soul").unwrap();
+        fs::write(root.join("theke/SOUL.md"), "theke soul").unwrap();
+
+        let oikos = Oikos::from_root(root);
+        let assembler = BootstrapAssembler::new(&oikos);
+        let mut budget = default_budget();
+
+        let result = assembler.assemble("syn", &mut budget).unwrap();
+        assert!(result.system_prompt.contains("nous-specific soul"));
+        assert!(!result.system_prompt.contains("theke soul"));
+    }
+
+    // --- Truncation tests ---
+
+    #[test]
+    fn truncate_section_aware() {
+        let oikos = Oikos::from_root("/tmp/unused");
+        let assembler = BootstrapAssembler::new(&oikos);
+
+        let section = BootstrapSection {
+            name: "MNEME.md".to_owned(),
+            priority: SectionPriority::Flexible,
+            content: "## Section A\nContent A.\n## Section B\nContent B.\n## Section C\nContent C.".to_owned(),
+            tokens: 100,
+            truncatable: true,
+        };
+
+        // Budget enough for first section only
+        let truncated = assembler.truncate_section(&section, 10);
+        assert!(truncated.content.contains("Section A"));
+        assert!(truncated.content.contains("[truncated for token budget]"));
+    }
+
+    #[test]
+    fn truncate_falls_back_to_lines() {
+        let oikos = Oikos::from_root("/tmp/unused");
+        let assembler = BootstrapAssembler::new(&oikos);
+
+        let section = BootstrapSection {
+            name: "MNEME.md".to_owned(),
+            priority: SectionPriority::Flexible,
+            content: "Line one\nLine two\nLine three\nLine four\nLine five".to_owned(),
+            tokens: 100,
+            truncatable: true,
+        };
+
+        // Budget enough for ~2 lines
+        let truncated = assembler.truncate_by_lines(&section, 5);
+        assert!(truncated.content.contains("Line one"));
+        assert!(truncated.content.contains("[truncated for token budget]"));
+    }
+}

--- a/crates/nous/src/bootstrap/tools.rs
+++ b/crates/nous/src/bootstrap/tools.rs
@@ -1,0 +1,157 @@
+//! Tool description tiers for token-efficient tool injection.
+//!
+//! Two tiers:
+//! - **Summary**: name + one-liner, included in bootstrap for all tools
+//! - **Expanded**: full description + parameters, loaded on demand
+
+use aletheia_organon::registry::ToolRegistry;
+use aletheia_organon::types::ToolDef;
+
+/// Compact tool summary for bootstrap inclusion.
+///
+/// One-liner is the first sentence of the tool description, capped at 80 characters.
+#[derive(Debug, Clone)]
+pub struct ToolSummary {
+    /// Tool name.
+    pub name: String,
+    /// One-line description (max 80 chars).
+    pub one_liner: String,
+}
+
+/// Expanded tool description for on-demand loading.
+#[derive(Debug, Clone)]
+pub struct ToolExpanded {
+    /// Tool name.
+    pub name: String,
+    /// Full description text.
+    pub description: String,
+    /// Parameter names and their descriptions.
+    pub parameters: Vec<(String, String)>,
+}
+
+/// Generate compact summaries for all registered tools.
+#[must_use]
+pub fn summarize_tools(registry: &ToolRegistry) -> Vec<ToolSummary> {
+    registry
+        .definitions()
+        .iter()
+        .map(|def| ToolSummary {
+            name: def.name.as_str().to_owned(),
+            one_liner: extract_one_liner(&def.description),
+        })
+        .collect()
+}
+
+/// Generate expanded descriptions for selected tool definitions.
+#[must_use]
+pub fn expand_tools(defs: &[&ToolDef]) -> Vec<ToolExpanded> {
+    defs.iter()
+        .map(|def| ToolExpanded {
+            name: def.name.as_str().to_owned(),
+            description: def
+                .extended_description
+                .as_deref()
+                .unwrap_or(&def.description)
+                .to_owned(),
+            parameters: def
+                .input_schema
+                .properties
+                .iter()
+                .map(|(name, prop)| (name.clone(), prop.description.clone()))
+                .collect(),
+        })
+        .collect()
+}
+
+/// Format tool summaries as a markdown section for the system prompt.
+#[must_use]
+pub fn format_tool_summary_section(summaries: &[ToolSummary]) -> String {
+    if summaries.is_empty() {
+        return String::new();
+    }
+
+    let mut lines = Vec::with_capacity(summaries.len() + 2);
+    lines.push("## Available Tools\n".to_owned());
+    for summary in summaries {
+        lines.push(format!("- **{}**: {}", summary.name, summary.one_liner));
+    }
+    lines.join("\n")
+}
+
+/// Extract a one-line summary from a description string.
+///
+/// Takes the first sentence (up to first `. ` or newline), capped at 80 characters.
+fn extract_one_liner(description: &str) -> String {
+    let first_line = description.lines().next().unwrap_or(description);
+
+    // Find first sentence boundary
+    let end = first_line
+        .find(". ")
+        .map_or(first_line.len(), |i| i + 1);
+
+    let sentence = &first_line[..end];
+
+    if sentence.len() <= 80 {
+        sentence.to_owned()
+    } else {
+        let truncated = &sentence[..80];
+        match truncated.rfind(' ') {
+            Some(i) if i > 40 => format!("{}...", &truncated[..i]),
+            _ => format!("{truncated}..."),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extract_one_liner_short_description() {
+        assert_eq!(extract_one_liner("Read a file."), "Read a file.");
+    }
+
+    #[test]
+    fn extract_one_liner_truncated() {
+        let long = "This is a very long tool description that goes on and on and explains every detail about what the tool does in excruciating detail.";
+        let result = extract_one_liner(long);
+        assert!(result.len() <= 83); // 80 + "..."
+        assert!(result.ends_with("..."));
+    }
+
+    #[test]
+    fn extract_one_liner_sentence_boundary() {
+        let desc = "Read a file from disk. Supports all text encodings and binary files.";
+        assert_eq!(extract_one_liner(desc), "Read a file from disk.");
+    }
+
+    #[test]
+    fn summarize_empty_registry() {
+        let registry = ToolRegistry::new();
+        let summaries = summarize_tools(&registry);
+        assert!(summaries.is_empty());
+    }
+
+    #[test]
+    fn format_produces_markdown() {
+        let summaries = vec![
+            ToolSummary {
+                name: "read".to_owned(),
+                one_liner: "Read a file from disk.".to_owned(),
+            },
+            ToolSummary {
+                name: "write".to_owned(),
+                one_liner: "Write content to a file.".to_owned(),
+            },
+        ];
+        let section = format_tool_summary_section(&summaries);
+        assert!(section.contains("## Available Tools"));
+        assert!(section.contains("- **read**: Read a file from disk."));
+        assert!(section.contains("- **write**: Write content to a file."));
+    }
+
+    #[test]
+    fn format_empty_summaries() {
+        assert_eq!(format_tool_summary_section(&[]), "");
+    }
+}

--- a/crates/nous/src/budget.rs
+++ b/crates/nous/src/budget.rs
@@ -1,0 +1,234 @@
+//! Token estimation and budget management.
+
+/// Estimate token count from text.
+///
+/// Implementations must be `Send + Sync` for use across async boundaries.
+/// The default [`CharEstimator`] uses a character-based heuristic.
+/// Future implementations can wrap tiktoken or the Anthropic token counting API.
+pub trait TokenEstimator: Send + Sync {
+    /// Estimate the number of tokens in the given text.
+    fn estimate(&self, text: &str) -> u64;
+}
+
+/// Character-based token estimator: 1 token ≈ 4 characters (ceiling division).
+///
+/// Conservative estimate suitable for budget planning. Actual token counts
+/// from the Anthropic API will be lower, giving natural headroom.
+pub struct CharEstimator;
+
+impl TokenEstimator for CharEstimator {
+    fn estimate(&self, text: &str) -> u64 {
+        (text.len() as u64).div_ceil(4)
+    }
+}
+
+/// Token budget for a single turn's system prompt assembly.
+///
+/// Partitions the model's context window into three zones:
+/// - **System budget**: for bootstrap content (SOUL.md, USER.md, etc.)
+/// - **History budget**: for conversation history
+/// - **Turn reserve**: for output tokens and extended thinking
+///
+/// The system budget is capped at `bootstrap_cap` (from [`NousConfig::bootstrap_max_tokens`]).
+#[derive(Debug, Clone)]
+pub struct TokenBudget {
+    context_window: u64,
+    reserved_for_turn: u64,
+    reserved_for_history: u64,
+    system_budget: u64,
+    consumed: u64,
+}
+
+impl TokenBudget {
+    /// Create a new token budget.
+    ///
+    /// - `context_window`: total context window tokens (e.g. 200,000)
+    /// - `history_ratio`: fraction of window reserved for history (e.g. 0.6)
+    /// - `turn_reserve`: tokens reserved for output + thinking
+    /// - `bootstrap_cap`: hard cap from `NousConfig::bootstrap_max_tokens`
+    #[must_use]
+    pub fn new(
+        context_window: u64,
+        history_ratio: f64,
+        turn_reserve: u64,
+        bootstrap_cap: u64,
+    ) -> Self {
+        #[expect(
+            clippy::cast_possible_truncation,
+            clippy::cast_sign_loss,
+            clippy::cast_precision_loss,
+            reason = "context_window fits in f64 mantissa for practical model sizes"
+        )]
+        let reserved_for_history = (context_window as f64 * history_ratio) as u64;
+        let computed = context_window
+            .saturating_sub(turn_reserve)
+            .saturating_sub(reserved_for_history);
+        let system_budget = computed.min(bootstrap_cap);
+
+        Self {
+            context_window,
+            reserved_for_turn: turn_reserve,
+            reserved_for_history,
+            system_budget,
+            consumed: 0,
+        }
+    }
+
+    /// Remaining tokens available for bootstrap content.
+    #[must_use]
+    pub fn remaining(&self) -> u64 {
+        self.system_budget.saturating_sub(self.consumed)
+    }
+
+    /// Try to consume tokens. Returns `false` if budget would be exceeded.
+    pub fn consume(&mut self, tokens: u64) -> bool {
+        if self.consumed + tokens > self.system_budget {
+            return false;
+        }
+        self.consumed += tokens;
+        true
+    }
+
+    /// Check if the given number of tokens fits in the remaining budget.
+    #[must_use]
+    pub fn can_fit(&self, tokens: u64) -> bool {
+        self.consumed + tokens <= self.system_budget
+    }
+
+    /// Total tokens consumed so far.
+    #[must_use]
+    pub fn consumed(&self) -> u64 {
+        self.consumed
+    }
+
+    /// The system budget cap (maximum tokens for bootstrap).
+    #[must_use]
+    pub fn system_budget(&self) -> u64 {
+        self.system_budget
+    }
+
+    /// Tokens reserved for conversation history.
+    #[must_use]
+    pub fn history_budget(&self) -> u64 {
+        self.reserved_for_history
+    }
+
+    /// Total context window size.
+    #[must_use]
+    pub fn context_window(&self) -> u64 {
+        self.context_window
+    }
+
+    /// Tokens reserved for turn output.
+    #[must_use]
+    pub fn turn_reserve(&self) -> u64 {
+        self.reserved_for_turn
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- CharEstimator ---
+
+    #[test]
+    fn char_estimator_empty_string() {
+        assert_eq!(CharEstimator.estimate(""), 0);
+    }
+
+    #[test]
+    fn char_estimator_exact_multiple() {
+        // 8 chars / 4 = 2 tokens
+        assert_eq!(CharEstimator.estimate("abcdefgh"), 2);
+    }
+
+    #[test]
+    fn char_estimator_rounds_up() {
+        // 5 chars -> ceil(5/4) = 2
+        assert_eq!(CharEstimator.estimate("hello"), 2);
+        // 1 char -> ceil(1/4) = 1
+        assert_eq!(CharEstimator.estimate("a"), 1);
+        // 3 chars -> ceil(3/4) = 1
+        assert_eq!(CharEstimator.estimate("abc"), 1);
+    }
+
+    #[test]
+    fn char_estimator_single_char() {
+        assert_eq!(CharEstimator.estimate("x"), 1);
+    }
+
+    // --- TokenBudget ---
+
+    #[test]
+    fn budget_computes_system_budget() {
+        // 200k window, 0.6 history ratio (120k), 16k turn reserve
+        // computed = 200k - 16k - 120k = 64k
+        // cap = 40k -> system_budget = 40k
+        let budget = TokenBudget::new(200_000, 0.6, 16_384, 40_000);
+        assert_eq!(budget.system_budget(), 40_000);
+        assert_eq!(budget.remaining(), 40_000);
+        assert_eq!(budget.consumed(), 0);
+    }
+
+    #[test]
+    fn budget_remaining_decreases() {
+        let mut budget = TokenBudget::new(200_000, 0.6, 16_384, 40_000);
+        assert!(budget.consume(10_000));
+        assert_eq!(budget.remaining(), 30_000);
+        assert_eq!(budget.consumed(), 10_000);
+    }
+
+    #[test]
+    fn budget_consume_returns_false_on_overflow() {
+        let mut budget = TokenBudget::new(200_000, 0.6, 16_384, 40_000);
+        assert!(budget.consume(35_000));
+        // Try to consume 10k more when only 5k remaining
+        assert!(!budget.consume(10_000));
+        // Budget unchanged after failed consume
+        assert_eq!(budget.consumed(), 35_000);
+        assert_eq!(budget.remaining(), 5_000);
+    }
+
+    #[test]
+    fn budget_can_fit_boundary() {
+        let mut budget = TokenBudget::new(100_000, 0.0, 0, 50_000);
+        assert!(budget.consume(49_999));
+        // Exactly 1 token remaining
+        assert!(budget.can_fit(1));
+        assert!(!budget.can_fit(2));
+    }
+
+    #[test]
+    fn budget_saturating_sub_prevents_underflow() {
+        // turn_reserve larger than context_window
+        let budget = TokenBudget::new(1000, 0.5, 2000, 500);
+        assert_eq!(budget.system_budget(), 0);
+        assert_eq!(budget.remaining(), 0);
+    }
+
+    #[test]
+    fn budget_cap_limits_system_budget() {
+        // computed = 100k - 0 - 0 = 100k, but cap = 5000
+        let budget = TokenBudget::new(100_000, 0.0, 0, 5_000);
+        assert_eq!(budget.system_budget(), 5_000);
+    }
+
+    #[test]
+    fn budget_consumed_tracks_total() {
+        let mut budget = TokenBudget::new(100_000, 0.0, 0, 50_000);
+        assert!(budget.consume(1000));
+        assert!(budget.consume(2000));
+        assert!(budget.consume(3000));
+        assert_eq!(budget.consumed(), 6000);
+        assert_eq!(budget.remaining(), 44_000);
+    }
+
+    // --- Static assertions ---
+
+    #[test]
+    fn char_estimator_is_send_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<CharEstimator>();
+    }
+}

--- a/crates/nous/src/lib.rs
+++ b/crates/nous/src/lib.rs
@@ -6,6 +6,8 @@
 //!
 //! Depends on all foundation crates: koina, taxis, mneme, hermeneus.
 
+pub mod bootstrap;
+pub mod budget;
 pub mod config;
 pub mod error;
 pub mod pipeline;

--- a/crates/nous/src/pipeline.rs
+++ b/crates/nous/src/pipeline.rs
@@ -9,11 +9,13 @@
 //! 6. **Finalize** — persist messages, update counts, extract facts
 
 use serde::{Deserialize, Serialize};
-// tracing will be used when pipeline stages are implemented
-#[expect(unused_imports, reason = "will be used when pipeline stages are implemented")]
 use tracing::instrument;
 
-use crate::config::PipelineConfig;
+use aletheia_taxis::oikos::Oikos;
+
+use crate::bootstrap::BootstrapAssembler;
+use crate::budget::TokenBudget;
+use crate::config::{NousConfig, PipelineConfig};
 use crate::session::SessionState;
 
 /// Input to the pipeline — an inbound message.
@@ -203,6 +205,43 @@ impl TurnUsage {
     pub fn total_tokens(&self) -> u64 {
         self.input_tokens + self.output_tokens
     }
+}
+
+/// Assemble bootstrap context and populate the pipeline context.
+///
+/// This is the "context" stage of the pipeline. It:
+/// 1. Creates a token budget from the nous config
+/// 2. Runs the bootstrap assembler against oikos workspace files
+/// 3. Sets [`PipelineContext::system_prompt`] and [`PipelineContext::remaining_tokens`]
+///
+/// # Errors
+///
+/// Returns [`crate::error::Error::ContextAssembly`] if required workspace files
+/// (e.g. SOUL.md) are missing.
+#[instrument(skip_all, fields(nous_id = %nous_config.id))]
+pub fn assemble_context(
+    oikos: &Oikos,
+    nous_config: &NousConfig,
+    pipeline_config: &PipelineConfig,
+    ctx: &mut PipelineContext,
+) -> crate::error::Result<()> {
+    let mut budget = TokenBudget::new(
+        u64::from(nous_config.context_window),
+        pipeline_config.history_budget_ratio,
+        u64::from(nous_config.max_output_tokens),
+        u64::from(nous_config.bootstrap_max_tokens),
+    );
+
+    let assembler = BootstrapAssembler::new(oikos);
+    let result = assembler.assemble(&nous_config.id, &mut budget)?;
+
+    ctx.system_prompt = Some(result.system_prompt);
+    #[expect(clippy::cast_possible_wrap, reason = "budget fits in i64 for practical context windows")]
+    {
+        ctx.remaining_tokens = budget.remaining() as i64;
+    }
+
+    Ok(())
 }
 
 #[cfg(test)]
@@ -407,5 +446,39 @@ mod tests {
         let json = serde_json::to_string(&usage).unwrap();
         let back: TurnUsage = serde_json::from_str(&json).unwrap();
         assert_eq!(usage.total_tokens(), back.total_tokens());
+    }
+
+    // --- Context assembly ---
+
+    #[test]
+    fn assemble_context_populates_pipeline() {
+        use crate::config::{NousConfig, PipelineConfig};
+        use aletheia_taxis::oikos::Oikos;
+        use std::fs;
+        use tempfile::TempDir;
+
+        let dir = TempDir::new().unwrap();
+        let root = dir.path();
+        fs::create_dir_all(root.join("nous/test-agent")).unwrap();
+        fs::create_dir_all(root.join("shared")).unwrap();
+        fs::create_dir_all(root.join("theke")).unwrap();
+        fs::write(root.join("nous/test-agent/SOUL.md"), "I am a test agent.").unwrap();
+        fs::write(root.join("theke/USER.md"), "Test user.").unwrap();
+
+        let oikos = Oikos::from_root(root);
+        let nous_config = NousConfig {
+            id: "test-agent".to_owned(),
+            ..NousConfig::default()
+        };
+        let pipeline_config = PipelineConfig::default();
+        let mut ctx = PipelineContext::default();
+
+        assemble_context(&oikos, &nous_config, &pipeline_config, &mut ctx).unwrap();
+
+        assert!(ctx.system_prompt.is_some());
+        let prompt = ctx.system_prompt.unwrap();
+        assert!(prompt.contains("I am a test agent."));
+        assert!(prompt.contains("Test user."));
+        assert!(ctx.remaining_tokens > 0);
     }
 }


### PR DESCRIPTION
## Summary

- Implement M2.2 context bootstrap: first stage of the nous pipeline assembling system prompts from oikos workspace files
- `budget.rs`: `TokenEstimator` trait + `CharEstimator` (1 token ≈ 4 chars), `TokenBudget` with system/history/turn partitioning capped at `bootstrap_max_tokens`
- `bootstrap/mod.rs`: `BootstrapAssembler` resolves SOUL.md, USER.md, TELOS.md, AGENTS.md, MNEME.md via `taxis::cascade::resolve()`, packs by priority (Required → Important → Flexible → Optional), truncates MNEME.md oldest-first, drops optional sections under budget pressure
- `bootstrap/tools.rs`: Two-tier tool descriptions — `ToolSummary` (compact, ≤80 char one-liner) and `ToolExpanded` (full description + parameters)
- `assemble_context()` wires bootstrap into `PipelineContext` (system_prompt + remaining_tokens)
- Fixes pre-existing duplicate `tokio` key in workspace Cargo.toml

## Test plan

- [x] 33 new tests (66 total in nous crate)
- [x] `cargo clippy --workspace` clean
- [x] `cargo test --workspace` all green
- [x] Token budget: consume, overflow, boundary, cap, saturating arithmetic
- [x] Bootstrap assembly: required missing → error, optional missing → skip, priority ordering, truncation, cascade resolution (nous overrides theke)
- [x] Tool summaries: one-liner extraction, sentence boundary, empty registry, markdown formatting
- [x] Pipeline integration: `assemble_context` populates system_prompt and remaining_tokens

🤖 Generated with [Claude Code](https://claude.com/claude-code)