### PR TITLE
feat(pylon): Axum HTTP gateway — session CRUD, SSE streaming, health check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -100,6 +106,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "aletheia-pylon"
+version = "0.1.0"
+dependencies = [
+ "aletheia-hermeneus",
+ "aletheia-koina",
+ "aletheia-mneme",
+ "aletheia-nous",
+ "aletheia-organon",
+ "aletheia-taxis",
+ "axum",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "snafu",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tower-http",
+ "tracing",
+ "tracing-subscriber",
+ "ulid",
+]
+
+[[package]]
 name = "aletheia-symbolon"
 version = "0.1.0"
 dependencies = [
@@ -171,6 +201,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-compression"
+version = "0.4.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0f9ee0f6e02ffd7ad5816e9464499fba7b3effd01123b515c41d1697c43dad1"
+dependencies = [
+ "compression-codecs",
+ "compression-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "atomic"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -190,6 +232,58 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "axum"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
 
 [[package]]
 name = "base64"
@@ -300,6 +394,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "compression-codecs"
+version = "0.4.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb7b51a7d9c967fc26773061ba86150f19c50c0d65c887cb1fbe295fd16619b7"
+dependencies = [
+ "compression-core",
+ "flate2",
+ "memchr",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75984efb6ed102a0d42db99afb6c1948f0380d1d91808d5529916e6c08b49d8d"
+
+[[package]]
 name = "constant_time_eq"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -338,6 +449,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -462,6 +582,16 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fnv"
@@ -1045,6 +1175,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1055,6 +1191,16 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
 
 [[package]]
 name = "mio"
@@ -1634,6 +1780,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1672,6 +1829,22 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
 name = "simple_asn1"
@@ -1891,6 +2064,7 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
@@ -1928,6 +2102,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1953,6 +2138,7 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1961,16 +2147,21 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
+ "async-compression",
  "bitflags",
  "bytes",
+ "futures-core",
  "futures-util",
  "http",
  "http-body",
  "iri-string",
  "pin-project-lite",
+ "tokio",
+ "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1991,6 +2182,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "crates/mneme",
     "crates/nous",
     "crates/organon",
+    "crates/pylon",
     "crates/symbolon",
     "crates/taxis",
 ]
@@ -62,7 +63,10 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 
 # HTTP
+axum = "0.8"
 reqwest = { version = "0.12", features = ["blocking", "json"] }
+tower = "0.5"
+tower-http = { version = "0.6", features = ["cors", "compression-gzip", "trace"] }
 
 # Secrets
 secrecy = { version = "0.10", features = ["serde"] }
@@ -80,7 +84,8 @@ indexmap = { version = "2", features = ["serde"] }
 ulid = { version = "1", features = ["serde"] }
 
 # Async
-tokio = { version = "1", features = ["rt", "macros"] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "signal"] }
+tokio-stream = "0.1"
 
 # Testing
 static_assertions = "1.1"

--- a/crates/pylon/Cargo.toml
+++ b/crates/pylon/Cargo.toml
@@ -1,0 +1,47 @@
+[package]
+name = "aletheia-pylon"
+version = "0.1.0"
+description = "Axum HTTP gateway for Aletheia"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+# HTTP framework
+axum = { workspace = true }
+tower = { workspace = true }
+tower-http = { workspace = true }
+
+# Async
+tokio = { workspace = true }
+tokio-stream = { workspace = true }
+
+# Serialization
+serde = { workspace = true }
+serde_json = { workspace = true }
+
+# Error handling
+snafu = { workspace = true }
+
+# Observability
+tracing = { workspace = true }
+
+# Types
+ulid = { workspace = true }
+
+# Internal crates
+aletheia-koina = { path = "../koina" }
+aletheia-taxis = { path = "../taxis" }
+aletheia-hermeneus = { path = "../hermeneus" }
+aletheia-organon = { path = "../organon" }
+aletheia-mneme = { path = "../mneme", features = ["sqlite"] }
+aletheia-nous = { path = "../nous" }
+
+[dev-dependencies]
+reqwest = { workspace = true }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "signal", "test-util"] }
+tracing-subscriber = { workspace = true }

--- a/crates/pylon/src/error.rs
+++ b/crates/pylon/src/error.rs
@@ -1,0 +1,70 @@
+//! API error types with Axum response integration.
+
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use axum::Json;
+use snafu::Snafu;
+
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub))]
+pub enum ApiError {
+    #[snafu(display("session not found: {id}"))]
+    SessionNotFound { id: String },
+
+    #[snafu(display("nous not found: {id}"))]
+    NousNotFound { id: String },
+
+    #[snafu(display("bad request: {message}"))]
+    BadRequest { message: String },
+
+    #[snafu(display("internal error: {message}"))]
+    Internal { message: String },
+
+    #[snafu(display("unauthorized"))]
+    Unauthorized,
+}
+
+impl IntoResponse for ApiError {
+    fn into_response(self) -> Response {
+        let (status, code) = match &self {
+            Self::SessionNotFound { .. } => (StatusCode::NOT_FOUND, "session_not_found"),
+            Self::NousNotFound { .. } => (StatusCode::NOT_FOUND, "nous_not_found"),
+            Self::BadRequest { .. } => (StatusCode::BAD_REQUEST, "bad_request"),
+            Self::Internal { .. } => (StatusCode::INTERNAL_SERVER_ERROR, "internal_error"),
+            Self::Unauthorized => (StatusCode::UNAUTHORIZED, "unauthorized"),
+        };
+
+        let body = serde_json::json!({
+            "error": {
+                "code": code,
+                "message": self.to_string(),
+            }
+        });
+
+        (status, Json(body)).into_response()
+    }
+}
+
+impl From<aletheia_mneme::error::Error> for ApiError {
+    fn from(err: aletheia_mneme::error::Error) -> Self {
+        Self::Internal {
+            message: err.to_string(),
+        }
+    }
+}
+
+impl From<aletheia_hermeneus::error::Error> for ApiError {
+    fn from(err: aletheia_hermeneus::error::Error) -> Self {
+        Self::Internal {
+            message: err.to_string(),
+        }
+    }
+}
+
+impl From<tokio::task::JoinError> for ApiError {
+    fn from(err: tokio::task::JoinError) -> Self {
+        Self::Internal {
+            message: format!("task join failed: {err}"),
+        }
+    }
+}

--- a/crates/pylon/src/extract.rs
+++ b/crates/pylon/src/extract.rs
@@ -1,0 +1,28 @@
+//! Placeholder auth extractor — always returns test claims.
+//! Real auth middleware (symbolon) will be wired in a future PR.
+
+use axum::extract::FromRequestParts;
+use axum::http::request::Parts;
+
+use crate::error::ApiError;
+
+/// Authenticated user claims.
+#[derive(Debug, Clone)]
+pub struct Claims {
+    pub sub: String,
+}
+
+impl<S: Send + Sync> FromRequestParts<S> for Claims {
+    type Rejection = ApiError;
+
+    async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
+        let sub = parts
+            .headers
+            .get("x-user-id")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("anonymous")
+            .to_owned();
+
+        Ok(Self { sub })
+    }
+}

--- a/crates/pylon/src/handlers/health.rs
+++ b/crates/pylon/src/handlers/health.rs
@@ -1,0 +1,72 @@
+//! Health check endpoint.
+
+use std::sync::Arc;
+
+use axum::extract::State;
+use axum::Json;
+use serde::Serialize;
+
+use crate::state::AppState;
+
+/// GET /api/health — liveness + readiness check.
+pub async fn check(State(state): State<Arc<AppState>>) -> Json<HealthResponse> {
+    let uptime = state.start_time.elapsed().as_secs();
+
+    let mut checks = Vec::new();
+
+    // Check session store connectivity
+    let store_ok = state.session_store.lock().is_ok_and(|store| {
+        store.list_sessions(None).is_ok()
+    });
+    checks.push(HealthCheck {
+        name: "session_store",
+        status: if store_ok { "pass" } else { "fail" },
+        message: if store_ok {
+            None
+        } else {
+            Some("session store unavailable".to_owned())
+        },
+    });
+
+    // Check provider registry has at least one provider
+    let has_providers = !state.provider_registry.providers().is_empty();
+    checks.push(HealthCheck {
+        name: "providers",
+        status: if has_providers { "pass" } else { "warn" },
+        message: if has_providers {
+            None
+        } else {
+            Some("no LLM providers registered".to_owned())
+        },
+    });
+
+    let status = if checks.iter().any(|c| c.status == "fail") {
+        "unhealthy"
+    } else if checks.iter().any(|c| c.status == "warn") {
+        "degraded"
+    } else {
+        "healthy"
+    };
+
+    Json(HealthResponse {
+        status,
+        version: env!("CARGO_PKG_VERSION"),
+        uptime_seconds: uptime,
+        checks,
+    })
+}
+
+#[derive(Debug, Serialize)]
+pub struct HealthResponse {
+    pub status: &'static str,
+    pub version: &'static str,
+    pub uptime_seconds: u64,
+    pub checks: Vec<HealthCheck>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct HealthCheck {
+    pub name: &'static str,
+    pub status: &'static str,
+    pub message: Option<String>,
+}

--- a/crates/pylon/src/handlers/mod.rs
+++ b/crates/pylon/src/handlers/mod.rs
@@ -1,0 +1,5 @@
+//! HTTP request handlers.
+
+pub mod health;
+pub mod nous;
+pub mod sessions;

--- a/crates/pylon/src/handlers/nous.rs
+++ b/crates/pylon/src/handlers/nous.rs
@@ -1,0 +1,106 @@
+//! Nous (agent) information endpoints.
+
+use std::sync::Arc;
+
+use axum::extract::{Path, State};
+use axum::Json;
+use serde::Serialize;
+
+use crate::error::{ApiError, NousNotFoundSnafu};
+use crate::state::AppState;
+
+/// GET /api/nous — list registered nous agents.
+pub async fn list(State(state): State<Arc<AppState>>) -> Json<NousListResponse> {
+    let config = state.session_manager.config();
+    // Currently single-nous — return the configured agent
+    Json(NousListResponse {
+        nous: vec![NousSummary {
+            id: config.id.clone(),
+            model: config.model.clone(),
+            status: "active".to_owned(),
+        }],
+    })
+}
+
+/// GET /api/nous/{id} — get nous status.
+pub async fn get_status(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<String>,
+) -> Result<Json<NousStatus>, ApiError> {
+    let config = state.session_manager.config();
+    if config.id != id {
+        return Err(NousNotFoundSnafu { id }.build());
+    }
+
+    Ok(Json(NousStatus {
+        id: config.id.clone(),
+        model: config.model.clone(),
+        context_window: config.context_window,
+        max_output_tokens: config.max_output_tokens,
+        thinking_enabled: config.thinking_enabled,
+        thinking_budget: config.thinking_budget,
+        max_tool_iterations: config.max_tool_iterations,
+        status: "active".to_owned(),
+    }))
+}
+
+/// GET /api/nous/{id}/tools — list tools available to a nous.
+pub async fn tools(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<String>,
+) -> Result<Json<ToolsResponse>, ApiError> {
+    let config = state.session_manager.config();
+    if config.id != id {
+        return Err(NousNotFoundSnafu { id }.build());
+    }
+
+    let defs = state.tool_registry.definitions();
+    let tools = defs
+        .into_iter()
+        .map(|d| ToolSummary {
+            name: d.name.as_str().to_owned(),
+            description: d.description.clone(),
+            category: format!("{:?}", d.category),
+        })
+        .collect();
+
+    Ok(Json(ToolsResponse { tools }))
+}
+
+// --- Response types ---
+
+#[derive(Debug, Serialize)]
+pub struct NousListResponse {
+    pub nous: Vec<NousSummary>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct NousSummary {
+    pub id: String,
+    pub model: String,
+    pub status: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct NousStatus {
+    pub id: String,
+    pub model: String,
+    pub context_window: u32,
+    pub max_output_tokens: u32,
+    pub thinking_enabled: bool,
+    pub thinking_budget: u32,
+    pub max_tool_iterations: u32,
+    pub status: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ToolsResponse {
+    pub tools: Vec<ToolSummary>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ToolSummary {
+    pub name: String,
+    pub description: String,
+    pub category: String,
+}

--- a/crates/pylon/src/handlers/sessions.rs
+++ b/crates/pylon/src/handlers/sessions.rs
@@ -1,0 +1,408 @@
+//! Session management and message streaming handlers.
+
+use std::convert::Infallible;
+use std::sync::Arc;
+use std::time::Duration;
+
+use axum::extract::{Path, Query, State};
+use axum::http::StatusCode;
+use axum::response::sse::{Event, KeepAlive, Sse};
+use axum::response::IntoResponse;
+use axum::Json;
+use serde::{Deserialize, Serialize};
+use tokio::sync::mpsc;
+use tokio_stream::wrappers::ReceiverStream;
+use tokio_stream::StreamExt;
+use tracing::{info, instrument, warn};
+
+use aletheia_hermeneus::types::{
+    CompletionRequest, Content, ContentBlock, Message as LlmMessage, Role as LlmRole,
+};
+use aletheia_mneme::types::SessionStatus;
+
+use crate::error::{ApiError, BadRequestSnafu, InternalSnafu, SessionNotFoundSnafu};
+use crate::state::AppState;
+use crate::stream::{SseEvent, UsageData};
+
+/// POST /api/sessions — create a new session.
+#[instrument(skip(state, body))]
+pub async fn create(
+    State(state): State<Arc<AppState>>,
+    Json(body): Json<CreateSessionRequest>,
+) -> Result<impl IntoResponse, ApiError> {
+    let nous_id = body.nous_id;
+    let session_key = body.session_key;
+
+    let manager = &state.session_manager;
+    let session_state = manager.create_session(&ulid::Ulid::new().to_string(), &session_key);
+
+    let state_clone = Arc::clone(&state);
+    let id = session_state.id.clone();
+    let nid = session_state.nous_id.clone();
+    let skey = session_key.clone();
+    let model = session_state.model.clone();
+
+    let session = tokio::task::spawn_blocking(move || {
+        let store = state_clone.session_store.lock().expect("store lock");
+        store.find_or_create_session(&id, &nid, &skey, Some(&model), None)
+    })
+    .await??;
+
+    info!(session_id = %session.id, nous_id, "session created");
+
+    Ok((StatusCode::CREATED, Json(SessionResponse::from_mneme(&session))))
+}
+
+/// GET /api/sessions/{id} — get session state.
+#[instrument(skip(state))]
+pub async fn get_session(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<String>,
+) -> Result<Json<SessionResponse>, ApiError> {
+    let session = find_session(&state, &id).await?;
+    Ok(Json(SessionResponse::from_mneme(&session)))
+}
+
+/// DELETE /api/sessions/{id} — close (archive) a session.
+#[instrument(skip(state))]
+pub async fn close(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<String>,
+) -> Result<StatusCode, ApiError> {
+    let _ = find_session(&state, &id).await?;
+
+    let state_clone = Arc::clone(&state);
+    let id_clone = id.clone();
+    tokio::task::spawn_blocking(move || {
+        let store = state_clone.session_store.lock().expect("store lock");
+        store.update_session_status(&id_clone, SessionStatus::Archived)
+    })
+    .await??;
+
+    info!(session_id = %id, "session closed");
+    Ok(StatusCode::NO_CONTENT)
+}
+
+/// GET /api/sessions/{id}/history — get conversation history.
+#[instrument(skip(state))]
+pub async fn history(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<String>,
+    Query(params): Query<HistoryParams>,
+) -> Result<Json<HistoryResponse>, ApiError> {
+    let _ = find_session(&state, &id).await?;
+
+    let state_clone = Arc::clone(&state);
+    let id_clone = id.clone();
+    let limit = params.limit;
+    let messages = tokio::task::spawn_blocking(move || {
+        let store = state_clone.session_store.lock().expect("store lock");
+        store.get_history(&id_clone, limit.map(|l| l as usize))
+    })
+    .await??;
+
+    let mut items: Vec<HistoryMessage> = messages
+        .into_iter()
+        .map(|m| HistoryMessage {
+            id: m.id,
+            seq: m.seq,
+            role: m.role.as_str().to_owned(),
+            content: m.content,
+            tool_call_id: m.tool_call_id,
+            tool_name: m.tool_name,
+            created_at: m.created_at,
+        })
+        .collect();
+
+    if let Some(before) = params.before {
+        items.retain(|m| m.seq < before);
+    }
+
+    Ok(Json(HistoryResponse { messages: items }))
+}
+
+/// POST /api/sessions/{id}/messages — send a message and stream the response via SSE.
+pub async fn send_message(
+    State(state): State<Arc<AppState>>,
+    Path(session_id): Path<String>,
+    Json(body): Json<SendMessageRequest>,
+) -> Result<Sse<impl tokio_stream::Stream<Item = Result<Event, Infallible>>>, ApiError> {
+    let session = find_session(&state, &session_id).await?;
+    let content = body.content;
+
+    if content.is_empty() {
+        return Err(BadRequestSnafu {
+            message: "content must not be empty",
+        }
+        .build());
+    }
+
+    // Store the user message
+    store_message(&state, &session_id, aletheia_mneme::types::Role::User, &content, 0).await?;
+
+    let model = session
+        .model
+        .clone()
+        .unwrap_or_else(|| "claude-opus-4-20250514".to_owned());
+
+    let request = build_completion_request(&state, &session_id, &model).await?;
+
+    if state.provider_registry.find_provider(&model).is_none() {
+        return Err(InternalSnafu {
+            message: format!("no provider for model {model}"),
+        }
+        .build());
+    }
+
+    let (tx, rx) = mpsc::channel::<SseEvent>(32);
+    let state_clone = Arc::clone(&state);
+    let sid = session_id.clone();
+
+    tokio::task::spawn_blocking(move || {
+        run_completion(&state_clone, &model, &request, &tx, &sid);
+    });
+
+    let stream = ReceiverStream::new(rx).map(|event| {
+        let data = serde_json::to_string(&event).unwrap_or_default();
+        Ok(Event::default().event(event.event_type()).data(data))
+    });
+
+    Ok(Sse::new(stream).keep_alive(
+        KeepAlive::new()
+            .interval(Duration::from_secs(15))
+            .text("ping"),
+    ))
+}
+
+async fn store_message(
+    state: &Arc<AppState>,
+    session_id: &str,
+    role: aletheia_mneme::types::Role,
+    content: &str,
+    token_estimate: i64,
+) -> Result<i64, ApiError> {
+    let state_clone = Arc::clone(state);
+    let sid = session_id.to_owned();
+    let content = content.to_owned();
+    tokio::task::spawn_blocking(move || {
+        let store = state_clone.session_store.lock().expect("store lock");
+        store.append_message(&sid, role, &content, None, None, token_estimate)
+    })
+    .await?
+    .map_err(ApiError::from)
+}
+
+async fn build_completion_request(
+    state: &Arc<AppState>,
+    session_id: &str,
+    model: &str,
+) -> Result<CompletionRequest, ApiError> {
+    let state_clone = Arc::clone(state);
+    let sid = session_id.to_owned();
+    let history = tokio::task::spawn_blocking(move || {
+        let store = state_clone.session_store.lock().expect("store lock");
+        store.get_history(&sid, Some(50))
+    })
+    .await??;
+
+    let messages: Vec<LlmMessage> = history
+        .iter()
+        .filter_map(|m| {
+            let role = match m.role {
+                aletheia_mneme::types::Role::User => LlmRole::User,
+                aletheia_mneme::types::Role::Assistant => LlmRole::Assistant,
+                _ => return None,
+            };
+            Some(LlmMessage {
+                role,
+                content: Content::Text(m.content.clone()),
+            })
+        })
+        .collect();
+
+    Ok(CompletionRequest {
+        model: model.to_owned(),
+        system: None,
+        messages,
+        max_tokens: 4096,
+        tools: state.tool_registry.to_hermeneus_tools(),
+        temperature: None,
+        thinking: None,
+        stop_sequences: vec![],
+    })
+}
+
+fn run_completion(
+    state: &AppState,
+    model: &str,
+    request: &CompletionRequest,
+    tx: &mpsc::Sender<SseEvent>,
+    session_id: &str,
+) {
+    let Some(provider) = state.provider_registry.find_provider(model) else {
+        let _ = tx.blocking_send(SseEvent::Error {
+            code: "no_provider".to_owned(),
+            message: format!("no provider for model {model}"),
+        });
+        return;
+    };
+
+    match provider.complete(request) {
+        Ok(response) => {
+            emit_response_events(tx, &response);
+
+            let full_text: String = response
+                .content
+                .iter()
+                .filter_map(|b| match b {
+                    ContentBlock::Text { text } => Some(text.as_str()),
+                    _ => None,
+                })
+                .collect::<Vec<_>>()
+                .join("");
+
+            if let Ok(store) = state.session_store.lock() {
+                let _ = store.append_message(
+                    session_id,
+                    aletheia_mneme::types::Role::Assistant,
+                    &full_text,
+                    None,
+                    None,
+                    i64::try_from(response.usage.output_tokens).unwrap_or(0),
+                );
+            }
+        }
+        Err(err) => {
+            warn!(error = %err, "completion failed");
+            let _ = tx.blocking_send(SseEvent::Error {
+                code: "completion_failed".to_owned(),
+                message: err.to_string(),
+            });
+        }
+    }
+}
+
+fn emit_response_events(
+    tx: &mpsc::Sender<SseEvent>,
+    response: &aletheia_hermeneus::types::CompletionResponse,
+) {
+    for block in &response.content {
+        let event = match block {
+            ContentBlock::Text { text } => SseEvent::TextDelta {
+                text: text.clone(),
+            },
+            ContentBlock::Thinking { thinking } => SseEvent::ThinkingDelta {
+                thinking: thinking.clone(),
+            },
+            ContentBlock::ToolUse { id, name, input } => SseEvent::ToolUse {
+                id: id.clone(),
+                name: name.clone(),
+                input: input.clone(),
+            },
+            ContentBlock::ToolResult {
+                tool_use_id,
+                content,
+                is_error,
+            } => SseEvent::ToolResult {
+                tool_use_id: tool_use_id.clone(),
+                content: content.clone(),
+                is_error: is_error.unwrap_or(false),
+            },
+            _ => continue,
+        };
+        let _ = tx.blocking_send(event);
+    }
+
+    let _ = tx.blocking_send(SseEvent::MessageComplete {
+        stop_reason: format!("{:?}", response.stop_reason),
+        usage: UsageData {
+            input_tokens: response.usage.input_tokens,
+            output_tokens: response.usage.output_tokens,
+        },
+    });
+}
+
+async fn find_session(
+    state: &Arc<AppState>,
+    id: &str,
+) -> Result<aletheia_mneme::types::Session, ApiError> {
+    let state_clone = Arc::clone(state);
+    let id_owned = id.to_owned();
+    let id_for_error = id.to_owned();
+    let session = tokio::task::spawn_blocking(move || {
+        let store = state_clone.session_store.lock().expect("store lock");
+        store.find_session_by_id(&id_owned)
+    })
+    .await??;
+
+    session.ok_or_else(|| {
+        SessionNotFoundSnafu {
+            id: id_for_error,
+        }
+        .build()
+    })
+}
+
+// --- Request/Response types ---
+
+#[derive(Debug, Deserialize)]
+pub struct CreateSessionRequest {
+    pub nous_id: String,
+    pub session_key: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct SendMessageRequest {
+    pub content: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct HistoryParams {
+    pub limit: Option<u32>,
+    pub before: Option<i64>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct SessionResponse {
+    pub id: String,
+    pub nous_id: String,
+    pub session_key: String,
+    pub status: String,
+    pub model: Option<String>,
+    pub message_count: i64,
+    pub token_count_estimate: i64,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+impl SessionResponse {
+    fn from_mneme(s: &aletheia_mneme::types::Session) -> Self {
+        Self {
+            id: s.id.clone(),
+            nous_id: s.nous_id.clone(),
+            session_key: s.session_key.clone(),
+            status: s.status.as_str().to_owned(),
+            model: s.model.clone(),
+            message_count: s.message_count,
+            token_count_estimate: s.token_count_estimate,
+            created_at: s.created_at.clone(),
+            updated_at: s.updated_at.clone(),
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct HistoryResponse {
+    pub messages: Vec<HistoryMessage>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct HistoryMessage {
+    pub id: i64,
+    pub seq: i64,
+    pub role: String,
+    pub content: String,
+    pub tool_call_id: Option<String>,
+    pub tool_name: Option<String>,
+    pub created_at: String,
+}

--- a/crates/pylon/src/lib.rs
+++ b/crates/pylon/src/lib.rs
@@ -1,0 +1,12 @@
+//! Axum HTTP gateway for Aletheia.
+
+pub mod error;
+pub mod extract;
+pub mod handlers;
+pub mod router;
+pub mod server;
+pub mod state;
+pub mod stream;
+
+#[cfg(test)]
+mod tests;

--- a/crates/pylon/src/router.rs
+++ b/crates/pylon/src/router.rs
@@ -1,0 +1,35 @@
+//! HTTP router construction with middleware layers.
+
+use std::sync::Arc;
+
+use axum::routing::{get, post};
+use axum::Router;
+use tower_http::compression::CompressionLayer;
+use tower_http::cors::CorsLayer;
+use tower_http::trace::TraceLayer;
+
+use crate::handlers::{health, nous, sessions};
+use crate::state::AppState;
+
+/// Build the Axum router with all routes and middleware.
+pub fn build_router(state: Arc<AppState>) -> Router {
+    Router::new()
+        .route("/api/health", get(health::check))
+        .route("/api/sessions", post(sessions::create))
+        .route(
+            "/api/sessions/{id}",
+            get(sessions::get_session).delete(sessions::close),
+        )
+        .route(
+            "/api/sessions/{id}/messages",
+            post(sessions::send_message),
+        )
+        .route("/api/sessions/{id}/history", get(sessions::history))
+        .route("/api/nous", get(nous::list))
+        .route("/api/nous/{id}", get(nous::get_status))
+        .route("/api/nous/{id}/tools", get(nous::tools))
+        .layer(CompressionLayer::new())
+        .layer(TraceLayer::new_for_http())
+        .layer(CorsLayer::permissive())
+        .with_state(state)
+}

--- a/crates/pylon/src/server.rs
+++ b/crates/pylon/src/server.rs
@@ -1,0 +1,107 @@
+//! Server entry point with graceful shutdown.
+
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+use std::time::Instant;
+
+use snafu::{ResultExt, Snafu};
+use tokio::net::TcpListener;
+use tracing::info;
+
+use aletheia_hermeneus::provider::ProviderRegistry;
+use aletheia_mneme::store::SessionStore;
+use aletheia_nous::config::NousConfig;
+use aletheia_nous::session::SessionManager;
+use aletheia_organon::registry::ToolRegistry;
+use aletheia_taxis::oikos::Oikos;
+
+use crate::router::build_router;
+use crate::state::AppState;
+
+/// Server configuration.
+#[derive(Debug, Clone)]
+pub struct ServerConfig {
+    /// Address to bind, e.g. `"0.0.0.0:3000"`.
+    pub bind_addr: String,
+    /// Path to the Aletheia instance directory.
+    pub instance_path: PathBuf,
+}
+
+#[derive(Debug, Snafu)]
+pub enum ServerError {
+    #[snafu(display("failed to open session store: {source}"))]
+    SessionStore { source: aletheia_mneme::error::Error },
+
+    #[snafu(display("failed to bind to {addr}: {source}"))]
+    Bind {
+        addr: String,
+        source: std::io::Error,
+    },
+
+    #[snafu(display("server error: {source}"))]
+    Serve { source: std::io::Error },
+}
+
+/// Start the HTTP gateway and block until shutdown.
+pub async fn run(config: ServerConfig) -> Result<(), ServerError> {
+    let oikos = Oikos::from_root(&config.instance_path);
+
+    let session_store =
+        SessionStore::open(&oikos.sessions_db()).context(SessionStoreSnafu)?;
+
+    let nous_config = NousConfig::default();
+    let session_manager = SessionManager::new(nous_config);
+    let provider_registry = ProviderRegistry::new();
+    let tool_registry = ToolRegistry::new();
+
+    let state = Arc::new(AppState {
+        session_store: Mutex::new(session_store),
+        provider_registry,
+        session_manager,
+        tool_registry,
+        oikos,
+        start_time: Instant::now(),
+    });
+
+    let app = build_router(state);
+
+    let listener = TcpListener::bind(&config.bind_addr)
+        .await
+        .context(BindSnafu {
+            addr: config.bind_addr.clone(),
+        })?;
+
+    info!(addr = %config.bind_addr, "pylon listening");
+
+    axum::serve(listener, app)
+        .with_graceful_shutdown(shutdown_signal())
+        .await
+        .context(ServeSnafu)?;
+
+    info!("pylon shutdown complete");
+    Ok(())
+}
+
+async fn shutdown_signal() {
+    let ctrl_c = async {
+        tokio::signal::ctrl_c()
+            .await
+            .expect("failed to install ctrl+c handler");
+    };
+
+    #[cfg(unix)]
+    let terminate = async {
+        tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+            .expect("failed to install SIGTERM handler")
+            .recv()
+            .await;
+    };
+
+    #[cfg(not(unix))]
+    let terminate = std::future::pending::<()>();
+
+    tokio::select! {
+        () = ctrl_c => info!("received ctrl+c"),
+        () = terminate => info!("received SIGTERM"),
+    }
+}

--- a/crates/pylon/src/state.rs
+++ b/crates/pylon/src/state.rs
@@ -1,0 +1,20 @@
+//! Shared application state accessible in all Axum handlers.
+
+use std::sync::Mutex;
+use std::time::Instant;
+
+use aletheia_hermeneus::provider::ProviderRegistry;
+use aletheia_mneme::store::SessionStore;
+use aletheia_nous::session::SessionManager;
+use aletheia_organon::registry::ToolRegistry;
+use aletheia_taxis::oikos::Oikos;
+
+/// Shared state for all Axum handlers, held behind `Arc` in the router.
+pub struct AppState {
+    pub session_store: Mutex<SessionStore>,
+    pub session_manager: SessionManager,
+    pub provider_registry: ProviderRegistry,
+    pub tool_registry: ToolRegistry,
+    pub oikos: Oikos,
+    pub start_time: Instant,
+}

--- a/crates/pylon/src/stream.rs
+++ b/crates/pylon/src/stream.rs
@@ -1,0 +1,59 @@
+//! SSE event types and hermeneus→SSE bridge.
+
+use serde::Serialize;
+
+/// SSE event emitted to the client during message streaming.
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "type")]
+pub enum SseEvent {
+    #[serde(rename = "text_delta")]
+    TextDelta { text: String },
+
+    #[serde(rename = "thinking_delta")]
+    ThinkingDelta { thinking: String },
+
+    #[serde(rename = "tool_use")]
+    ToolUse {
+        id: String,
+        name: String,
+        input: serde_json::Value,
+    },
+
+    #[serde(rename = "tool_result")]
+    ToolResult {
+        tool_use_id: String,
+        content: String,
+        is_error: bool,
+    },
+
+    #[serde(rename = "message_complete")]
+    MessageComplete {
+        stop_reason: String,
+        usage: UsageData,
+    },
+
+    #[serde(rename = "error")]
+    Error { code: String, message: String },
+}
+
+/// Token usage summary sent with `message_complete`.
+#[derive(Debug, Clone, Serialize)]
+pub struct UsageData {
+    pub input_tokens: u64,
+    pub output_tokens: u64,
+}
+
+impl SseEvent {
+    /// SSE event name for the `event:` field.
+    pub fn event_type(&self) -> &'static str {
+        match self {
+            Self::TextDelta { .. } => "text_delta",
+            Self::ThinkingDelta { .. } => "thinking_delta",
+            Self::ToolUse { .. } => "tool_use",
+            Self::ToolResult { .. } => "tool_result",
+            Self::MessageComplete { .. } => "message_complete",
+            Self::Error { .. } => "error",
+        }
+    }
+}
+

--- a/crates/pylon/src/tests.rs
+++ b/crates/pylon/src/tests.rs
@@ -1,0 +1,669 @@
+//! Integration tests for the pylon HTTP gateway.
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+    use std::time::Instant;
+
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use tower::ServiceExt;
+
+    use aletheia_hermeneus::provider::{LlmProvider, ProviderConfig, ProviderRegistry};
+    use aletheia_hermeneus::types::*;
+    use aletheia_mneme::store::SessionStore;
+    use aletheia_nous::config::NousConfig;
+    use aletheia_nous::session::SessionManager;
+    use aletheia_organon::registry::ToolRegistry;
+    use aletheia_taxis::oikos::Oikos;
+
+    use crate::router::build_router;
+    use crate::state::AppState;
+
+    // --- Mock Provider ---
+
+    struct MockProvider {
+        response: CompletionResponse,
+    }
+
+    impl MockProvider {
+        fn new() -> Self {
+            Self {
+                response: CompletionResponse {
+                    id: "msg_test".to_owned(),
+                    model: "mock-model".to_owned(),
+                    stop_reason: StopReason::EndTurn,
+                    content: vec![ContentBlock::Text {
+                        text: "Hello from mock!".to_owned(),
+                    }],
+                    usage: Usage {
+                        input_tokens: 10,
+                        output_tokens: 5,
+                        ..Usage::default()
+                    },
+                },
+            }
+        }
+
+        fn with_thinking() -> Self {
+            Self {
+                response: CompletionResponse {
+                    id: "msg_think".to_owned(),
+                    model: "mock-model".to_owned(),
+                    stop_reason: StopReason::EndTurn,
+                    content: vec![
+                        ContentBlock::Thinking {
+                            thinking: "Let me think...".to_owned(),
+                        },
+                        ContentBlock::Text {
+                            text: "The answer is 42.".to_owned(),
+                        },
+                    ],
+                    usage: Usage {
+                        input_tokens: 20,
+                        output_tokens: 10,
+                        ..Usage::default()
+                    },
+                },
+            }
+        }
+    }
+
+    impl LlmProvider for MockProvider {
+        fn complete(&self, _request: &CompletionRequest) -> aletheia_hermeneus::error::Result<CompletionResponse> {
+            Ok(self.response.clone())
+        }
+
+        fn supported_models(&self) -> &[&str] {
+            &["mock-model", "claude-opus-4-20250514"]
+        }
+
+        #[expect(clippy::unnecessary_literal_bound, reason = "trait requires &str")]
+        fn name(&self) -> &str {
+            "mock"
+        }
+    }
+
+    // --- Test Helpers ---
+
+    fn test_state() -> Arc<AppState> {
+        test_state_with_provider(true)
+    }
+
+    fn test_state_with_provider(with_provider: bool) -> Arc<AppState> {
+        let store = SessionStore::open_in_memory().expect("in-memory store");
+        let nous_config = NousConfig {
+            id: "syn".to_owned(),
+            ..NousConfig::default()
+        };
+        let session_manager = SessionManager::new(nous_config);
+
+        let mut provider_registry = ProviderRegistry::new();
+        if with_provider {
+            provider_registry.register(Box::new(MockProvider::new()));
+        }
+
+        let tool_registry = ToolRegistry::new();
+        let oikos = Oikos::from_root("/tmp/aletheia-test");
+
+        Arc::new(AppState {
+            session_store: Mutex::new(store),
+            session_manager,
+            provider_registry,
+            tool_registry,
+            oikos,
+            start_time: Instant::now(),
+        })
+    }
+
+    fn app() -> axum::Router {
+        build_router(test_state())
+    }
+
+    fn app_no_providers() -> axum::Router {
+        build_router(test_state_with_provider(false))
+    }
+
+    fn json_request(method: &str, uri: &str, body: Option<serde_json::Value>) -> Request<Body> {
+        let builder = Request::builder()
+            .method(method)
+            .uri(uri)
+            .header("content-type", "application/json");
+
+        match body {
+            Some(b) => builder
+                .body(Body::from(serde_json::to_vec(&b).unwrap()))
+                .unwrap(),
+            None => builder.body(Body::empty()).unwrap(),
+        }
+    }
+
+    async fn body_json(response: axum::response::Response) -> serde_json::Value {
+        let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        serde_json::from_slice(&bytes).unwrap()
+    }
+
+    async fn body_string(response: axum::response::Response) -> String {
+        let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        String::from_utf8(bytes.to_vec()).unwrap()
+    }
+
+    async fn create_test_session(app: &axum::Router) -> serde_json::Value {
+        let req = json_request(
+            "POST",
+            "/api/sessions",
+            Some(serde_json::json!({
+                "nous_id": "syn",
+                "session_key": "test-session"
+            })),
+        );
+        let resp = app.clone().oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::CREATED);
+        body_json(resp).await
+    }
+
+    // --- Health Tests ---
+
+    #[tokio::test]
+    async fn health_returns_200() {
+        let resp = app()
+            .oneshot(Request::get("/api/health").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_json(resp).await;
+        assert_eq!(body["status"], "healthy");
+        assert!(body["version"].is_string());
+        assert!(body["uptime_seconds"].is_number());
+        assert!(body["checks"].is_array());
+    }
+
+    #[tokio::test]
+    async fn health_degraded_without_providers() {
+        let resp = app_no_providers()
+            .oneshot(Request::get("/api/health").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+
+        let body = body_json(resp).await;
+        assert_eq!(body["status"], "degraded");
+    }
+
+    // --- Session CRUD Tests ---
+
+    #[tokio::test]
+    async fn create_session_returns_201() {
+        let session = create_test_session(&app()).await;
+        assert!(session["id"].is_string());
+        assert_eq!(session["nous_id"], "syn");
+        assert_eq!(session["session_key"], "test-session");
+        assert_eq!(session["status"], "active");
+    }
+
+    #[tokio::test]
+    async fn get_session_returns_created_session() {
+        let router = app();
+        let created = create_test_session(&router).await;
+        let id = created["id"].as_str().unwrap();
+
+        let resp = router
+            .clone()
+            .oneshot(
+                Request::get(&format!("/api/sessions/{id}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_json(resp).await;
+        assert_eq!(body["id"], id);
+        assert_eq!(body["nous_id"], "syn");
+    }
+
+    #[tokio::test]
+    async fn get_unknown_session_returns_404() {
+        let resp = app()
+            .oneshot(
+                Request::get("/api/sessions/nonexistent")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+        let body = body_json(resp).await;
+        assert_eq!(body["error"]["code"], "session_not_found");
+    }
+
+    #[tokio::test]
+    async fn close_session_returns_204() {
+        let router = app();
+        let created = create_test_session(&router).await;
+        let id = created["id"].as_str().unwrap();
+
+        let resp = router
+            .clone()
+            .oneshot(
+                Request::delete(&format!("/api/sessions/{id}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+    }
+
+    #[tokio::test]
+    async fn get_closed_session_shows_archived() {
+        let router = app();
+        let created = create_test_session(&router).await;
+        let id = created["id"].as_str().unwrap();
+
+        // Close
+        router
+            .clone()
+            .oneshot(
+                Request::delete(&format!("/api/sessions/{id}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        // Get again
+        let resp = router
+            .clone()
+            .oneshot(
+                Request::get(&format!("/api/sessions/{id}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_json(resp).await;
+        assert_eq!(body["status"], "archived");
+    }
+
+    #[tokio::test]
+    async fn close_unknown_session_returns_404() {
+        let resp = app()
+            .oneshot(
+                Request::delete("/api/sessions/nonexistent")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    // --- History Tests ---
+
+    #[tokio::test]
+    async fn history_empty_for_new_session() {
+        let router = app();
+        let created = create_test_session(&router).await;
+        let id = created["id"].as_str().unwrap();
+
+        let resp = router
+            .clone()
+            .oneshot(
+                Request::get(&format!("/api/sessions/{id}/history"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_json(resp).await;
+        assert!(body["messages"].as_array().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn history_unknown_session_returns_404() {
+        let resp = app()
+            .oneshot(
+                Request::get("/api/sessions/nonexistent/history")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn history_with_limit() {
+        let state = test_state();
+        let router = build_router(Arc::clone(&state));
+
+        let created = create_test_session(&router).await;
+        let id = created["id"].as_str().unwrap();
+
+        // Directly insert messages
+        {
+            let store = state.session_store.lock().unwrap();
+            for i in 1..=5 {
+                store
+                    .append_message(
+                        id,
+                        aletheia_mneme::types::Role::User,
+                        &format!("message {i}"),
+                        None,
+                        None,
+                        10,
+                    )
+                    .unwrap();
+            }
+        }
+
+        let resp = router
+            .clone()
+            .oneshot(
+                Request::get(&format!("/api/sessions/{id}/history?limit=3"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        let body = body_json(resp).await;
+        assert_eq!(body["messages"].as_array().unwrap().len(), 3);
+    }
+
+    // --- SSE Message Tests ---
+
+    #[tokio::test]
+    async fn send_message_returns_sse_content_type() {
+        let state = test_state();
+        let router = build_router(Arc::clone(&state));
+        let created = create_test_session(&router).await;
+        let id = created["id"].as_str().unwrap();
+
+        let req = json_request(
+            "POST",
+            &format!("/api/sessions/{id}/messages"),
+            Some(serde_json::json!({ "content": "Hello!" })),
+        );
+
+        let resp = router.clone().oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let content_type = resp
+            .headers()
+            .get("content-type")
+            .unwrap()
+            .to_str()
+            .unwrap();
+        assert!(content_type.contains("text/event-stream"));
+    }
+
+    #[tokio::test]
+    async fn send_message_stream_contains_events() {
+        let state = test_state();
+        let router = build_router(Arc::clone(&state));
+        let created = create_test_session(&router).await;
+        let id = created["id"].as_str().unwrap();
+
+        let req = json_request(
+            "POST",
+            &format!("/api/sessions/{id}/messages"),
+            Some(serde_json::json!({ "content": "Hello!" })),
+        );
+
+        let resp = router.clone().oneshot(req).await.unwrap();
+        let body = body_string(resp).await;
+
+        assert!(body.contains("event: text_delta"), "should contain text_delta event");
+        assert!(body.contains("Hello from mock!"), "should contain mock response text");
+        assert!(body.contains("event: message_complete"), "should contain message_complete event");
+    }
+
+    #[tokio::test]
+    async fn send_message_unknown_session_returns_404() {
+        let req = json_request(
+            "POST",
+            "/api/sessions/nonexistent/messages",
+            Some(serde_json::json!({ "content": "Hello!" })),
+        );
+
+        let resp = app().oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn send_empty_message_returns_400() {
+        let router = app();
+        let created = create_test_session(&router).await;
+        let id = created["id"].as_str().unwrap();
+
+        let req = json_request(
+            "POST",
+            &format!("/api/sessions/{id}/messages"),
+            Some(serde_json::json!({ "content": "" })),
+        );
+
+        let resp = router.clone().oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn send_message_stores_in_history() {
+        let state = test_state();
+        let router = build_router(Arc::clone(&state));
+        let created = create_test_session(&router).await;
+        let id = created["id"].as_str().unwrap();
+
+        // Send a message
+        let req = json_request(
+            "POST",
+            &format!("/api/sessions/{id}/messages"),
+            Some(serde_json::json!({ "content": "Hello!" })),
+        );
+        let resp = router.clone().oneshot(req).await.unwrap();
+        // Consume the SSE body to ensure the blocking task completes
+        let _ = body_string(resp).await;
+
+        // Check history
+        let resp = router
+            .clone()
+            .oneshot(
+                Request::get(&format!("/api/sessions/{id}/history"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        let body = body_json(resp).await;
+        let messages = body["messages"].as_array().unwrap();
+        assert!(messages.len() >= 2, "should have user + assistant messages");
+
+        assert_eq!(messages[0]["role"], "user");
+        assert_eq!(messages[0]["content"], "Hello!");
+    }
+
+    // --- Error Format Tests ---
+
+    #[tokio::test]
+    async fn error_response_has_consistent_structure() {
+        let resp = app()
+            .oneshot(
+                Request::get("/api/sessions/nonexistent")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        let body = body_json(resp).await;
+        assert!(body["error"].is_object());
+        assert!(body["error"]["code"].is_string());
+        assert!(body["error"]["message"].is_string());
+    }
+
+    #[tokio::test]
+    async fn malformed_create_body_returns_400() {
+        let req = Request::builder()
+            .method("POST")
+            .uri("/api/sessions")
+            .header("content-type", "application/json")
+            .body(Body::from(r#"{"invalid": true}"#))
+            .unwrap();
+
+        let resp = app().oneshot(req).await.unwrap();
+        // Axum returns 422 for deserialization failures
+        assert!(
+            resp.status() == StatusCode::BAD_REQUEST
+                || resp.status() == StatusCode::UNPROCESSABLE_ENTITY
+        );
+    }
+
+    #[tokio::test]
+    async fn malformed_send_body_returns_error() {
+        let router = app();
+        let created = create_test_session(&router).await;
+        let id = created["id"].as_str().unwrap();
+
+        let req = Request::builder()
+            .method("POST")
+            .uri(&format!("/api/sessions/{id}/messages"))
+            .header("content-type", "application/json")
+            .body(Body::from(r#"{"wrong_field": "abc"}"#))
+            .unwrap();
+
+        let resp = router.clone().oneshot(req).await.unwrap();
+        assert!(
+            resp.status() == StatusCode::BAD_REQUEST
+                || resp.status() == StatusCode::UNPROCESSABLE_ENTITY
+        );
+    }
+
+    // --- Nous Tests ---
+
+    #[tokio::test]
+    async fn list_nous_returns_agents() {
+        let resp = app()
+            .oneshot(
+                Request::get("/api/nous").body(Body::empty()).unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_json(resp).await;
+        let agents = body["nous"].as_array().unwrap();
+        assert_eq!(agents.len(), 1);
+        assert_eq!(agents[0]["id"], "syn");
+    }
+
+    #[tokio::test]
+    async fn get_nous_status() {
+        let resp = app()
+            .oneshot(
+                Request::get("/api/nous/syn").body(Body::empty()).unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_json(resp).await;
+        assert_eq!(body["id"], "syn");
+        assert!(body["context_window"].is_number());
+        assert!(body["max_output_tokens"].is_number());
+    }
+
+    #[tokio::test]
+    async fn get_unknown_nous_returns_404() {
+        let resp = app()
+            .oneshot(
+                Request::get("/api/nous/nonexistent")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+        let body = body_json(resp).await;
+        assert_eq!(body["error"]["code"], "nous_not_found");
+    }
+
+    #[tokio::test]
+    async fn get_nous_tools() {
+        let resp = app()
+            .oneshot(
+                Request::get("/api/nous/syn/tools")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_json(resp).await;
+        assert!(body["tools"].is_array());
+    }
+
+    // --- Concurrent access ---
+
+    #[tokio::test]
+    async fn concurrent_session_creation() {
+        let state = test_state();
+        let mut handles = Vec::new();
+
+        for i in 0..5 {
+            let router = build_router(Arc::clone(&state));
+            handles.push(tokio::spawn(async move {
+                let req = json_request(
+                    "POST",
+                    "/api/sessions",
+                    Some(serde_json::json!({
+                        "nous_id": "syn",
+                        "session_key": format!("concurrent-{i}")
+                    })),
+                );
+                let resp = router.oneshot(req).await.unwrap();
+                resp.status()
+            }));
+        }
+
+        for handle in handles {
+            let status = handle.await.unwrap();
+            assert_eq!(status, StatusCode::CREATED);
+        }
+    }
+
+    // --- SSE with no provider ---
+
+    #[tokio::test]
+    async fn send_message_no_provider_returns_error() {
+        let state = test_state_with_provider(false);
+        let router = build_router(Arc::clone(&state));
+        let created = create_test_session(&router).await;
+        let id = created["id"].as_str().unwrap();
+
+        let req = json_request(
+            "POST",
+            &format!("/api/sessions/{id}/messages"),
+            Some(serde_json::json!({ "content": "Hello!" })),
+        );
+
+        let resp = router.clone().oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `crates/pylon/` — Axum HTTP gateway wiring nous, hermeneus, organon, mneme, taxis, koina
- Session CRUD (create/get/close), message history with pagination, SSE streaming
- Health check with component-level status (store connectivity, provider availability)
- Nous info endpoints (list agents, status, tools)
- Placeholder auth extractor (symbolon wiring deferred)
- 25 integration tests, clippy clean

## Architecture
- `spawn_blocking` + mpsc channel bridges sync hermeneus/mneme into async Axum handlers
- `std::sync::Mutex` for SessionStore (short critical sections, dropped before `.await`)
- Consistent JSON error responses via `ApiError` snafu enum with `IntoResponse`

## Test plan
- [x] `cargo test -p aletheia-pylon` — 25 tests pass
- [x] `cargo clippy -p aletheia-pylon -- -D warnings` — clean
- [x] Health, session CRUD, SSE streaming, nous endpoints, error format, concurrent access

🤖 Generated with [Claude Code](https://claude.com/claude-code)