### PR TITLE
feat(organon): implement workspace tool executors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,6 +102,7 @@ dependencies = [
  "serde_json",
  "snafu",
  "static_assertions",
+ "tempfile",
  "tokio",
 ]
 

--- a/crates/organon/Cargo.toml
+++ b/crates/organon/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aletheia-organon"
 version = "0.1.0"
-description = "Tool registry, definitions, and built-in tool stubs"
+description = "Tool registry, definitions, and built-in tool executors"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -20,4 +20,5 @@ snafu = { workspace = true }
 
 [dev-dependencies]
 static_assertions = { workspace = true }
+tempfile = "3"
 tokio = { workspace = true }

--- a/crates/organon/src/builtins/workspace.rs
+++ b/crates/organon/src/builtins/workspace.rs
@@ -1,41 +1,329 @@
-//! Workspace tool stubs: read, write, edit, exec.
+//! Workspace tool executors: read, write, edit, exec.
 
 use std::future::Future;
+use std::io::Read as _;
+use std::path::{Component, Path, PathBuf};
 use std::pin::Pin;
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
 
 use aletheia_koina::id::ToolName;
 use indexmap::IndexMap;
 
-use crate::error::Result;
+use crate::error::{self, Result};
 use crate::registry::{ToolExecutor, ToolRegistry};
 use crate::types::{
     InputSchema, PropertyDef, PropertyType, ToolCategory, ToolContext, ToolDef, ToolInput,
     ToolResult,
 };
 
-struct Stub;
+const MAX_OUTPUT_BYTES: usize = 50 * 1024;
 
-impl ToolExecutor for Stub {
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn validate_path(raw: &str, ctx: &ToolContext, tool_name: &ToolName) -> Result<PathBuf> {
+    if raw.is_empty() {
+        return Err(error::InvalidInputSnafu {
+            name: tool_name.clone(),
+            reason: "path must not be empty".to_owned(),
+        }
+        .build());
+    }
+
+    let resolved = if Path::new(raw).is_absolute() {
+        PathBuf::from(raw)
+    } else {
+        ctx.workspace.join(raw)
+    };
+
+    let normalized = normalize(&resolved);
+
+    let allowed = ctx
+        .allowed_roots
+        .iter()
+        .any(|root| normalized.starts_with(root));
+
+    if !allowed {
+        return Err(error::InvalidInputSnafu {
+            name: tool_name.clone(),
+            reason: format!("path outside allowed roots: {raw}"),
+        }
+        .build());
+    }
+
+    Ok(normalized)
+}
+
+fn normalize(path: &Path) -> PathBuf {
+    let mut result = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::ParentDir => {
+                result.pop();
+            }
+            Component::CurDir => {}
+            other => result.push(other),
+        }
+    }
+    result
+}
+
+fn extract_str<'a>(
+    args: &'a serde_json::Value,
+    field: &str,
+    tool_name: &ToolName,
+) -> Result<&'a str> {
+    args.get(field)
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| {
+            error::InvalidInputSnafu {
+                name: tool_name.clone(),
+                reason: format!("missing or invalid field: {field}"),
+            }
+            .build()
+        })
+}
+
+fn extract_opt_u64(args: &serde_json::Value, field: &str) -> Option<u64> {
+    args.get(field).and_then(serde_json::Value::as_u64)
+}
+
+fn extract_opt_bool(args: &serde_json::Value, field: &str) -> Option<bool> {
+    args.get(field).and_then(serde_json::Value::as_bool)
+}
+
+fn err_result(msg: String) -> ToolResult {
+    ToolResult {
+        content: msg,
+        is_error: true,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Executors
+// ---------------------------------------------------------------------------
+
+struct ReadExecutor;
+
+impl ToolExecutor for ReadExecutor {
     fn execute<'a>(
         &'a self,
         input: &'a ToolInput,
-        _ctx: &'a ToolContext,
+        ctx: &'a ToolContext,
     ) -> Pin<Box<dyn Future<Output = Result<ToolResult>> + Send + 'a>> {
         Box::pin(async {
+            let path_str = extract_str(&input.arguments, "path", &input.name)?;
+            let max_lines = extract_opt_u64(&input.arguments, "maxLines");
+            let path = validate_path(path_str, ctx, &input.name)?;
+
+            let content = match std::fs::read_to_string(&path) {
+                Ok(c) => c,
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                    return Ok(err_result(format!("file not found: {}", path.display())));
+                }
+                Err(e) => {
+                    return Ok(err_result(format!("read failed: {e}")));
+                }
+            };
+
+            let output = match max_lines {
+                Some(n) => {
+                    let n = usize::try_from(n).unwrap_or(usize::MAX);
+                    content.lines().take(n).collect::<Vec<_>>().join("\n")
+                }
+                None => content,
+            };
+
             Ok(ToolResult {
-                content: format!("stub: {} not implemented", input.name),
+                content: output,
                 is_error: false,
             })
         })
     }
 }
 
-/// Register workspace tool stubs.
+struct WriteExecutor;
+
+impl ToolExecutor for WriteExecutor {
+    fn execute<'a>(
+        &'a self,
+        input: &'a ToolInput,
+        ctx: &'a ToolContext,
+    ) -> Pin<Box<dyn Future<Output = Result<ToolResult>> + Send + 'a>> {
+        Box::pin(async {
+            let path_str = extract_str(&input.arguments, "path", &input.name)?;
+            let content = extract_str(&input.arguments, "content", &input.name)?;
+            let append = extract_opt_bool(&input.arguments, "append").unwrap_or(false);
+            let path = validate_path(path_str, ctx, &input.name)?;
+
+            if let Some(parent) = path.parent() {
+                if let Err(e) = std::fs::create_dir_all(parent) {
+                    return Ok(err_result(format!("failed to create directories: {e}")));
+                }
+            }
+
+            let write_result = if append {
+                std::fs::OpenOptions::new()
+                    .create(true)
+                    .append(true)
+                    .open(&path)
+                    .and_then(|mut f| {
+                        use std::io::Write;
+                        f.write_all(content.as_bytes())
+                    })
+            } else {
+                std::fs::write(&path, content)
+            };
+
+            match write_result {
+                Ok(()) => Ok(ToolResult {
+                    content: format!("wrote {} bytes to {}", content.len(), path.display()),
+                    is_error: false,
+                }),
+                Err(e) => Ok(err_result(format!("write failed: {e}"))),
+            }
+        })
+    }
+}
+
+struct EditExecutor;
+
+impl ToolExecutor for EditExecutor {
+    fn execute<'a>(
+        &'a self,
+        input: &'a ToolInput,
+        ctx: &'a ToolContext,
+    ) -> Pin<Box<dyn Future<Output = Result<ToolResult>> + Send + 'a>> {
+        Box::pin(async {
+            let path_str = extract_str(&input.arguments, "path", &input.name)?;
+            let old_text = extract_str(&input.arguments, "old_text", &input.name)?;
+            let new_text = extract_str(&input.arguments, "new_text", &input.name)?;
+            let path = validate_path(path_str, ctx, &input.name)?;
+
+            let content = match std::fs::read_to_string(&path) {
+                Ok(c) => c,
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                    return Ok(err_result(format!("file not found: {}", path.display())));
+                }
+                Err(e) => {
+                    return Ok(err_result(format!("read failed: {e}")));
+                }
+            };
+
+            let count = content.matches(old_text).count();
+            if count == 0 {
+                return Ok(err_result(format!(
+                    "old_text not found in {}",
+                    path.display()
+                )));
+            }
+            if count > 1 {
+                return Ok(err_result(format!(
+                    "old_text found {count} times in {} \u{2014} must be unique",
+                    path.display()
+                )));
+            }
+
+            let new_content = content.replacen(old_text, new_text, 1);
+            if let Err(e) = std::fs::write(&path, &new_content) {
+                return Ok(err_result(format!("write failed: {e}")));
+            }
+
+            Ok(ToolResult {
+                content: format!(
+                    "edited {}: replaced {} chars with {} chars",
+                    path.display(),
+                    old_text.len(),
+                    new_text.len()
+                ),
+                is_error: false,
+            })
+        })
+    }
+}
+
+struct ExecExecutor;
+
+impl ToolExecutor for ExecExecutor {
+    fn execute<'a>(
+        &'a self,
+        input: &'a ToolInput,
+        ctx: &'a ToolContext,
+    ) -> Pin<Box<dyn Future<Output = Result<ToolResult>> + Send + 'a>> {
+        Box::pin(async {
+            let command = extract_str(&input.arguments, "command", &input.name)?;
+            let timeout_ms = extract_opt_u64(&input.arguments, "timeout").unwrap_or(30_000);
+
+            let mut child = match Command::new("sh")
+                .arg("-c")
+                .arg(command)
+                .current_dir(&ctx.workspace)
+                .stdout(Stdio::piped())
+                .stderr(Stdio::piped())
+                .spawn()
+            {
+                Ok(c) => c,
+                Err(e) => {
+                    return Ok(err_result(format!("spawn failed: {e}")));
+                }
+            };
+
+            let deadline = Instant::now() + Duration::from_millis(timeout_ms);
+            let status = loop {
+                match child.try_wait() {
+                    Ok(Some(s)) => break s,
+                    Ok(None) => {
+                        if Instant::now() >= deadline {
+                            let _ = child.kill();
+                            let _ = child.wait();
+                            return Ok(err_result(format!(
+                                "command timed out after {timeout_ms}ms"
+                            )));
+                        }
+                        std::thread::sleep(Duration::from_millis(50));
+                    }
+                    Err(e) => {
+                        return Ok(err_result(format!("wait failed: {e}")));
+                    }
+                }
+            };
+
+            let mut stdout = String::new();
+            if let Some(ref mut pipe) = child.stdout {
+                let _ = pipe.read_to_string(&mut stdout);
+            }
+            let mut stderr = String::new();
+            if let Some(ref mut pipe) = child.stderr {
+                let _ = pipe.read_to_string(&mut stderr);
+            }
+
+            let code = status.code().unwrap_or(-1);
+            let mut output = format!("exit={code}\n{stdout}\n{stderr}");
+            if output.len() > MAX_OUTPUT_BYTES {
+                output.truncate(MAX_OUTPUT_BYTES);
+                output.push_str("\n[output truncated]");
+            }
+
+            Ok(ToolResult {
+                content: output,
+                is_error: false,
+            })
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tool definitions (schemas unchanged)
+// ---------------------------------------------------------------------------
+
+/// Register workspace tool executors.
 pub fn register(registry: &mut ToolRegistry) -> Result<()> {
-    registry.register(read_def(), Box::new(Stub))?;
-    registry.register(write_def(), Box::new(Stub))?;
-    registry.register(edit_def(), Box::new(Stub))?;
-    registry.register(exec_def(), Box::new(Stub))?;
+    registry.register(read_def(), Box::new(ReadExecutor))?;
+    registry.register(write_def(), Box::new(WriteExecutor))?;
+    registry.register(edit_def(), Box::new(EditExecutor))?;
+    registry.register(exec_def(), Box::new(ExecExecutor))?;
     Ok(())
 }
 
@@ -190,5 +478,224 @@ fn exec_def() -> ToolDef {
         },
         category: ToolCategory::Workspace,
         auto_activate: false,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use aletheia_koina::id::{NousId, SessionId};
+
+    use super::*;
+
+    fn test_ctx(dir: &Path) -> ToolContext {
+        ToolContext {
+            nous_id: NousId::new("test-agent").expect("valid"),
+            session_id: SessionId::new(),
+            workspace: dir.to_path_buf(),
+            allowed_roots: vec![dir.to_path_buf()],
+        }
+    }
+
+    fn tool_input(name: &str, args: serde_json::Value) -> ToolInput {
+        ToolInput {
+            name: ToolName::new(name).expect("valid"),
+            tool_use_id: "toolu_test".to_owned(),
+            arguments: args,
+        }
+    }
+
+    // -- ReadExecutor -------------------------------------------------------
+
+    #[tokio::test]
+    async fn read_existing_file() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        std::fs::write(dir.path().join("hello.txt"), "hello world").expect("write");
+
+        let ctx = test_ctx(dir.path());
+        let input = tool_input("read", serde_json::json!({ "path": "hello.txt" }));
+        let result = ReadExecutor.execute(&input, &ctx).await.expect("execute");
+        assert_eq!(result.content, "hello world");
+        assert!(!result.is_error);
+    }
+
+    #[tokio::test]
+    async fn read_with_max_lines() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        std::fs::write(dir.path().join("lines.txt"), "a\nb\nc\nd\ne\n").expect("write");
+
+        let ctx = test_ctx(dir.path());
+        let input = tool_input(
+            "read",
+            serde_json::json!({ "path": "lines.txt", "maxLines": 2 }),
+        );
+        let result = ReadExecutor.execute(&input, &ctx).await.expect("execute");
+        assert_eq!(result.content, "a\nb");
+        assert!(!result.is_error);
+    }
+
+    #[tokio::test]
+    async fn read_missing_file() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let ctx = test_ctx(dir.path());
+        let input = tool_input("read", serde_json::json!({ "path": "nope.txt" }));
+        let result = ReadExecutor.execute(&input, &ctx).await.expect("execute");
+        assert!(result.is_error);
+        assert!(result.content.contains("file not found"));
+    }
+
+    // -- WriteExecutor ------------------------------------------------------
+
+    #[tokio::test]
+    async fn write_creates_file() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let ctx = test_ctx(dir.path());
+        let input = tool_input(
+            "write",
+            serde_json::json!({ "path": "out.txt", "content": "data" }),
+        );
+        let result = WriteExecutor.execute(&input, &ctx).await.expect("execute");
+        assert!(!result.is_error);
+        assert!(result.content.contains("wrote 4 bytes"));
+        let on_disk = std::fs::read_to_string(dir.path().join("out.txt")).expect("read");
+        assert_eq!(on_disk, "data");
+    }
+
+    #[tokio::test]
+    async fn write_creates_parent_dirs() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let ctx = test_ctx(dir.path());
+        let input = tool_input(
+            "write",
+            serde_json::json!({ "path": "sub/deep/file.txt", "content": "nested" }),
+        );
+        let result = WriteExecutor.execute(&input, &ctx).await.expect("execute");
+        assert!(!result.is_error);
+        let on_disk =
+            std::fs::read_to_string(dir.path().join("sub/deep/file.txt")).expect("read");
+        assert_eq!(on_disk, "nested");
+    }
+
+    #[tokio::test]
+    async fn write_append_mode() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        std::fs::write(dir.path().join("log.txt"), "first\n").expect("write");
+
+        let ctx = test_ctx(dir.path());
+        let input = tool_input(
+            "write",
+            serde_json::json!({ "path": "log.txt", "content": "second\n", "append": true }),
+        );
+        let result = WriteExecutor.execute(&input, &ctx).await.expect("execute");
+        assert!(!result.is_error);
+        let on_disk = std::fs::read_to_string(dir.path().join("log.txt")).expect("read");
+        assert_eq!(on_disk, "first\nsecond\n");
+    }
+
+    // -- EditExecutor -------------------------------------------------------
+
+    #[tokio::test]
+    async fn edit_single_match() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        std::fs::write(dir.path().join("code.rs"), "fn old_name() {}").expect("write");
+
+        let ctx = test_ctx(dir.path());
+        let input = tool_input(
+            "edit",
+            serde_json::json!({
+                "path": "code.rs",
+                "old_text": "old_name",
+                "new_text": "new_name"
+            }),
+        );
+        let result = EditExecutor.execute(&input, &ctx).await.expect("execute");
+        assert!(!result.is_error);
+        assert!(result.content.contains("edited"));
+        let on_disk = std::fs::read_to_string(dir.path().join("code.rs")).expect("read");
+        assert_eq!(on_disk, "fn new_name() {}");
+    }
+
+    #[tokio::test]
+    async fn edit_not_found() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        std::fs::write(dir.path().join("code.rs"), "fn hello() {}").expect("write");
+
+        let ctx = test_ctx(dir.path());
+        let input = tool_input(
+            "edit",
+            serde_json::json!({
+                "path": "code.rs",
+                "old_text": "nonexistent",
+                "new_text": "whatever"
+            }),
+        );
+        let result = EditExecutor.execute(&input, &ctx).await.expect("execute");
+        assert!(result.is_error);
+        assert!(result.content.contains("old_text not found"));
+    }
+
+    #[tokio::test]
+    async fn edit_multiple_matches() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        std::fs::write(dir.path().join("dup.txt"), "aaa bbb aaa").expect("write");
+
+        let ctx = test_ctx(dir.path());
+        let input = tool_input(
+            "edit",
+            serde_json::json!({
+                "path": "dup.txt",
+                "old_text": "aaa",
+                "new_text": "ccc"
+            }),
+        );
+        let result = EditExecutor.execute(&input, &ctx).await.expect("execute");
+        assert!(result.is_error);
+        assert!(result.content.contains("2 times"));
+    }
+
+    // -- ExecExecutor -------------------------------------------------------
+
+    #[tokio::test]
+    async fn exec_simple_command() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let ctx = test_ctx(dir.path());
+        let input = tool_input("exec", serde_json::json!({ "command": "echo hello" }));
+        let result = ExecExecutor.execute(&input, &ctx).await.expect("execute");
+        assert!(!result.is_error);
+        assert!(result.content.contains("hello"));
+        assert!(result.content.contains("exit=0"));
+    }
+
+    #[tokio::test]
+    async fn exec_timeout() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let ctx = test_ctx(dir.path());
+        let input = tool_input(
+            "exec",
+            serde_json::json!({ "command": "sleep 60", "timeout": 200 }),
+        );
+        let result = ExecExecutor.execute(&input, &ctx).await.expect("execute");
+        assert!(result.is_error);
+        assert!(result.content.contains("timed out"));
+    }
+
+    // -- Path traversal -----------------------------------------------------
+
+    #[tokio::test]
+    async fn path_traversal_blocked() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let ctx = test_ctx(dir.path());
+        let input = tool_input(
+            "read",
+            serde_json::json!({ "path": "../../etc/passwd" }),
+        );
+        let err = ReadExecutor
+            .execute(&input, &ctx)
+            .await
+            .expect_err("should reject traversal");
+        assert!(err.to_string().contains("outside allowed roots"));
     }
 }

--- a/crates/pylon/src/tests.rs
+++ b/crates/pylon/src/tests.rs
@@ -1,669 +1,655 @@
 //! Integration tests for the pylon HTTP gateway.
 
-#[cfg(test)]
-mod tests {
-    use std::sync::{Arc, Mutex};
-    use std::time::Instant;
+use std::sync::{Arc, Mutex};
+use std::time::Instant;
 
-    use axum::body::Body;
-    use axum::http::{Request, StatusCode};
-    use tower::ServiceExt;
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use tower::ServiceExt;
 
-    use aletheia_hermeneus::provider::{LlmProvider, ProviderConfig, ProviderRegistry};
-    use aletheia_hermeneus::types::*;
-    use aletheia_mneme::store::SessionStore;
-    use aletheia_nous::config::NousConfig;
-    use aletheia_nous::session::SessionManager;
-    use aletheia_organon::registry::ToolRegistry;
-    use aletheia_taxis::oikos::Oikos;
+use aletheia_hermeneus::provider::{LlmProvider, ProviderRegistry};
+use aletheia_hermeneus::types::*;
+use aletheia_mneme::store::SessionStore;
+use aletheia_nous::config::NousConfig;
+use aletheia_nous::session::SessionManager;
+use aletheia_organon::registry::ToolRegistry;
+use aletheia_taxis::oikos::Oikos;
 
-    use crate::router::build_router;
-    use crate::state::AppState;
+use crate::router::build_router;
+use crate::state::AppState;
 
-    // --- Mock Provider ---
+// --- Mock Provider ---
 
-    struct MockProvider {
-        response: CompletionResponse,
-    }
+struct MockProvider {
+    response: CompletionResponse,
+}
 
-    impl MockProvider {
-        fn new() -> Self {
-            Self {
-                response: CompletionResponse {
-                    id: "msg_test".to_owned(),
-                    model: "mock-model".to_owned(),
-                    stop_reason: StopReason::EndTurn,
-                    content: vec![ContentBlock::Text {
-                        text: "Hello from mock!".to_owned(),
-                    }],
-                    usage: Usage {
-                        input_tokens: 10,
-                        output_tokens: 5,
-                        ..Usage::default()
-                    },
+impl MockProvider {
+    fn new() -> Self {
+        Self {
+            response: CompletionResponse {
+                id: "msg_test".to_owned(),
+                model: "mock-model".to_owned(),
+                stop_reason: StopReason::EndTurn,
+                content: vec![ContentBlock::Text {
+                    text: "Hello from mock!".to_owned(),
+                }],
+                usage: Usage {
+                    input_tokens: 10,
+                    output_tokens: 5,
+                    ..Usage::default()
                 },
-            }
-        }
-
-        fn with_thinking() -> Self {
-            Self {
-                response: CompletionResponse {
-                    id: "msg_think".to_owned(),
-                    model: "mock-model".to_owned(),
-                    stop_reason: StopReason::EndTurn,
-                    content: vec![
-                        ContentBlock::Thinking {
-                            thinking: "Let me think...".to_owned(),
-                        },
-                        ContentBlock::Text {
-                            text: "The answer is 42.".to_owned(),
-                        },
-                    ],
-                    usage: Usage {
-                        input_tokens: 20,
-                        output_tokens: 10,
-                        ..Usage::default()
-                    },
-                },
-            }
+            },
         }
     }
+}
 
-    impl LlmProvider for MockProvider {
-        fn complete(&self, _request: &CompletionRequest) -> aletheia_hermeneus::error::Result<CompletionResponse> {
-            Ok(self.response.clone())
-        }
-
-        fn supported_models(&self) -> &[&str] {
-            &["mock-model", "claude-opus-4-20250514"]
-        }
-
-        #[expect(clippy::unnecessary_literal_bound, reason = "trait requires &str")]
-        fn name(&self) -> &str {
-            "mock"
-        }
+impl LlmProvider for MockProvider {
+    fn complete(
+        &self,
+        _request: &CompletionRequest,
+    ) -> aletheia_hermeneus::error::Result<CompletionResponse> {
+        Ok(self.response.clone())
     }
 
-    // --- Test Helpers ---
-
-    fn test_state() -> Arc<AppState> {
-        test_state_with_provider(true)
+    fn supported_models(&self) -> &[&str] {
+        &["mock-model", "claude-opus-4-20250514"]
     }
 
-    fn test_state_with_provider(with_provider: bool) -> Arc<AppState> {
-        let store = SessionStore::open_in_memory().expect("in-memory store");
-        let nous_config = NousConfig {
-            id: "syn".to_owned(),
-            ..NousConfig::default()
-        };
-        let session_manager = SessionManager::new(nous_config);
+    #[expect(clippy::unnecessary_literal_bound, reason = "trait requires &str")]
+    fn name(&self) -> &str {
+        "mock"
+    }
+}
 
-        let mut provider_registry = ProviderRegistry::new();
-        if with_provider {
-            provider_registry.register(Box::new(MockProvider::new()));
-        }
+// --- Test Helpers ---
 
-        let tool_registry = ToolRegistry::new();
-        let oikos = Oikos::from_root("/tmp/aletheia-test");
+fn test_state() -> Arc<AppState> {
+    test_state_with_provider(true)
+}
 
-        Arc::new(AppState {
-            session_store: Mutex::new(store),
-            session_manager,
-            provider_registry,
-            tool_registry,
-            oikos,
-            start_time: Instant::now(),
-        })
+fn test_state_with_provider(with_provider: bool) -> Arc<AppState> {
+    let store = SessionStore::open_in_memory().expect("in-memory store");
+    let nous_config = NousConfig {
+        id: "syn".to_owned(),
+        ..NousConfig::default()
+    };
+    let session_manager = SessionManager::new(nous_config);
+
+    let mut provider_registry = ProviderRegistry::new();
+    if with_provider {
+        provider_registry.register(Box::new(MockProvider::new()));
     }
 
-    fn app() -> axum::Router {
-        build_router(test_state())
+    let tool_registry = ToolRegistry::new();
+    let oikos = Oikos::from_root("/tmp/aletheia-test");
+
+    Arc::new(AppState {
+        session_store: Mutex::new(store),
+        session_manager,
+        provider_registry,
+        tool_registry,
+        oikos,
+        start_time: Instant::now(),
+    })
+}
+
+fn app() -> axum::Router {
+    build_router(test_state())
+}
+
+fn app_no_providers() -> axum::Router {
+    build_router(test_state_with_provider(false))
+}
+
+fn json_request(method: &str, uri: &str, body: Option<serde_json::Value>) -> Request<Body> {
+    let builder = Request::builder()
+        .method(method)
+        .uri(uri)
+        .header("content-type", "application/json");
+
+    match body {
+        Some(b) => builder
+            .body(Body::from(serde_json::to_vec(&b).unwrap()))
+            .unwrap(),
+        None => builder.body(Body::empty()).unwrap(),
     }
+}
 
-    fn app_no_providers() -> axum::Router {
-        build_router(test_state_with_provider(false))
-    }
+async fn body_json(response: axum::response::Response) -> serde_json::Value {
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    serde_json::from_slice(&bytes).unwrap()
+}
 
-    fn json_request(method: &str, uri: &str, body: Option<serde_json::Value>) -> Request<Body> {
-        let builder = Request::builder()
-            .method(method)
-            .uri(uri)
-            .header("content-type", "application/json");
+async fn body_string(response: axum::response::Response) -> String {
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    String::from_utf8(bytes.to_vec()).unwrap()
+}
 
-        match body {
-            Some(b) => builder
-                .body(Body::from(serde_json::to_vec(&b).unwrap()))
+async fn create_test_session(app: &axum::Router) -> serde_json::Value {
+    let req = json_request(
+        "POST",
+        "/api/sessions",
+        Some(serde_json::json!({
+            "nous_id": "syn",
+            "session_key": "test-session"
+        })),
+    );
+    let resp = app.clone().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::CREATED);
+    body_json(resp).await
+}
+
+// --- Health Tests ---
+
+#[tokio::test]
+async fn health_returns_200() {
+    let resp = app()
+        .oneshot(Request::get("/api/health").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = body_json(resp).await;
+    assert_eq!(body["status"], "healthy");
+    assert!(body["version"].is_string());
+    assert!(body["uptime_seconds"].is_number());
+    assert!(body["checks"].is_array());
+}
+
+#[tokio::test]
+async fn health_degraded_without_providers() {
+    let resp = app_no_providers()
+        .oneshot(Request::get("/api/health").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+
+    let body = body_json(resp).await;
+    assert_eq!(body["status"], "degraded");
+}
+
+// --- Session CRUD Tests ---
+
+#[tokio::test]
+async fn create_session_returns_201() {
+    let session = create_test_session(&app()).await;
+    assert!(session["id"].is_string());
+    assert_eq!(session["nous_id"], "syn");
+    assert_eq!(session["session_key"], "test-session");
+    assert_eq!(session["status"], "active");
+}
+
+#[tokio::test]
+async fn get_session_returns_created_session() {
+    let router = app();
+    let created = create_test_session(&router).await;
+    let id = created["id"].as_str().unwrap();
+
+    let resp = router
+        .clone()
+        .oneshot(
+            Request::get(format!("/api/sessions/{id}"))
+                .body(Body::empty())
                 .unwrap(),
-            None => builder.body(Body::empty()).unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = body_json(resp).await;
+    assert_eq!(body["id"], id);
+    assert_eq!(body["nous_id"], "syn");
+}
+
+#[tokio::test]
+async fn get_unknown_session_returns_404() {
+    let resp = app()
+        .oneshot(
+            Request::get("/api/sessions/nonexistent")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    let body = body_json(resp).await;
+    assert_eq!(body["error"]["code"], "session_not_found");
+}
+
+#[tokio::test]
+async fn close_session_returns_204() {
+    let router = app();
+    let created = create_test_session(&router).await;
+    let id = created["id"].as_str().unwrap();
+
+    let resp = router
+        .clone()
+        .oneshot(
+            Request::delete(format!("/api/sessions/{id}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+}
+
+#[tokio::test]
+async fn get_closed_session_shows_archived() {
+    let router = app();
+    let created = create_test_session(&router).await;
+    let id = created["id"].as_str().unwrap();
+
+    // Close
+    router
+        .clone()
+        .oneshot(
+            Request::delete(format!("/api/sessions/{id}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    // Get again
+    let resp = router
+        .clone()
+        .oneshot(
+            Request::get(format!("/api/sessions/{id}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = body_json(resp).await;
+    assert_eq!(body["status"], "archived");
+}
+
+#[tokio::test]
+async fn close_unknown_session_returns_404() {
+    let resp = app()
+        .oneshot(
+            Request::delete("/api/sessions/nonexistent")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+// --- History Tests ---
+
+#[tokio::test]
+async fn history_empty_for_new_session() {
+    let router = app();
+    let created = create_test_session(&router).await;
+    let id = created["id"].as_str().unwrap();
+
+    let resp = router
+        .clone()
+        .oneshot(
+            Request::get(format!("/api/sessions/{id}/history"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = body_json(resp).await;
+    assert!(body["messages"].as_array().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn history_unknown_session_returns_404() {
+    let resp = app()
+        .oneshot(
+            Request::get("/api/sessions/nonexistent/history")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn history_with_limit() {
+    let state = test_state();
+    let router = build_router(Arc::clone(&state));
+
+    let created = create_test_session(&router).await;
+    let id = created["id"].as_str().unwrap();
+
+    // Directly insert messages
+    {
+        let store = state.session_store.lock().unwrap();
+        for i in 1..=5 {
+            store
+                .append_message(
+                    id,
+                    aletheia_mneme::types::Role::User,
+                    &format!("message {i}"),
+                    None,
+                    None,
+                    10,
+                )
+                .unwrap();
         }
     }
 
-    async fn body_json(response: axum::response::Response) -> serde_json::Value {
-        let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
-            .await
-            .unwrap();
-        serde_json::from_slice(&bytes).unwrap()
-    }
+    let resp = router
+        .clone()
+        .oneshot(
+            Request::get(format!("/api/sessions/{id}/history?limit=3"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
 
-    async fn body_string(response: axum::response::Response) -> String {
-        let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
-            .await
-            .unwrap();
-        String::from_utf8(bytes.to_vec()).unwrap()
-    }
+    let body = body_json(resp).await;
+    assert_eq!(body["messages"].as_array().unwrap().len(), 3);
+}
 
-    async fn create_test_session(app: &axum::Router) -> serde_json::Value {
-        let req = json_request(
-            "POST",
-            "/api/sessions",
-            Some(serde_json::json!({
-                "nous_id": "syn",
-                "session_key": "test-session"
-            })),
-        );
-        let resp = app.clone().oneshot(req).await.unwrap();
-        assert_eq!(resp.status(), StatusCode::CREATED);
-        body_json(resp).await
-    }
+// --- SSE Message Tests ---
 
-    // --- Health Tests ---
+#[tokio::test]
+async fn send_message_returns_sse_content_type() {
+    let state = test_state();
+    let router = build_router(Arc::clone(&state));
+    let created = create_test_session(&router).await;
+    let id = created["id"].as_str().unwrap();
 
-    #[tokio::test]
-    async fn health_returns_200() {
-        let resp = app()
-            .oneshot(Request::get("/api/health").body(Body::empty()).unwrap())
-            .await
-            .unwrap();
+    let req = json_request(
+        "POST",
+        &format!("/api/sessions/{id}/messages"),
+        Some(serde_json::json!({ "content": "Hello!" })),
+    );
 
-        assert_eq!(resp.status(), StatusCode::OK);
-        let body = body_json(resp).await;
-        assert_eq!(body["status"], "healthy");
-        assert!(body["version"].is_string());
-        assert!(body["uptime_seconds"].is_number());
-        assert!(body["checks"].is_array());
-    }
+    let resp = router.clone().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
 
-    #[tokio::test]
-    async fn health_degraded_without_providers() {
-        let resp = app_no_providers()
-            .oneshot(Request::get("/api/health").body(Body::empty()).unwrap())
-            .await
-            .unwrap();
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .unwrap()
+        .to_str()
+        .unwrap();
+    assert!(content_type.contains("text/event-stream"));
+}
 
-        let body = body_json(resp).await;
-        assert_eq!(body["status"], "degraded");
-    }
+#[tokio::test]
+async fn send_message_stream_contains_events() {
+    let state = test_state();
+    let router = build_router(Arc::clone(&state));
+    let created = create_test_session(&router).await;
+    let id = created["id"].as_str().unwrap();
 
-    // --- Session CRUD Tests ---
+    let req = json_request(
+        "POST",
+        &format!("/api/sessions/{id}/messages"),
+        Some(serde_json::json!({ "content": "Hello!" })),
+    );
 
-    #[tokio::test]
-    async fn create_session_returns_201() {
-        let session = create_test_session(&app()).await;
-        assert!(session["id"].is_string());
-        assert_eq!(session["nous_id"], "syn");
-        assert_eq!(session["session_key"], "test-session");
-        assert_eq!(session["status"], "active");
-    }
+    let resp = router.clone().oneshot(req).await.unwrap();
+    let body = body_string(resp).await;
 
-    #[tokio::test]
-    async fn get_session_returns_created_session() {
-        let router = app();
-        let created = create_test_session(&router).await;
-        let id = created["id"].as_str().unwrap();
+    assert!(
+        body.contains("event: text_delta"),
+        "should contain text_delta event"
+    );
+    assert!(
+        body.contains("Hello from mock!"),
+        "should contain mock response text"
+    );
+    assert!(
+        body.contains("event: message_complete"),
+        "should contain message_complete event"
+    );
+}
 
-        let resp = router
-            .clone()
-            .oneshot(
-                Request::get(&format!("/api/sessions/{id}"))
-                    .body(Body::empty())
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
+#[tokio::test]
+async fn send_message_unknown_session_returns_404() {
+    let req = json_request(
+        "POST",
+        "/api/sessions/nonexistent/messages",
+        Some(serde_json::json!({ "content": "Hello!" })),
+    );
 
-        assert_eq!(resp.status(), StatusCode::OK);
-        let body = body_json(resp).await;
-        assert_eq!(body["id"], id);
-        assert_eq!(body["nous_id"], "syn");
-    }
+    let resp = app().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
 
-    #[tokio::test]
-    async fn get_unknown_session_returns_404() {
-        let resp = app()
-            .oneshot(
-                Request::get("/api/sessions/nonexistent")
-                    .body(Body::empty())
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
+#[tokio::test]
+async fn send_empty_message_returns_400() {
+    let router = app();
+    let created = create_test_session(&router).await;
+    let id = created["id"].as_str().unwrap();
 
-        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
-        let body = body_json(resp).await;
-        assert_eq!(body["error"]["code"], "session_not_found");
-    }
+    let req = json_request(
+        "POST",
+        &format!("/api/sessions/{id}/messages"),
+        Some(serde_json::json!({ "content": "" })),
+    );
 
-    #[tokio::test]
-    async fn close_session_returns_204() {
-        let router = app();
-        let created = create_test_session(&router).await;
-        let id = created["id"].as_str().unwrap();
+    let resp = router.clone().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
 
-        let resp = router
-            .clone()
-            .oneshot(
-                Request::delete(&format!("/api/sessions/{id}"))
-                    .body(Body::empty())
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
+#[tokio::test]
+async fn send_message_stores_in_history() {
+    let state = test_state();
+    let router = build_router(Arc::clone(&state));
+    let created = create_test_session(&router).await;
+    let id = created["id"].as_str().unwrap();
 
-        assert_eq!(resp.status(), StatusCode::NO_CONTENT);
-    }
+    // Send a message
+    let req = json_request(
+        "POST",
+        &format!("/api/sessions/{id}/messages"),
+        Some(serde_json::json!({ "content": "Hello!" })),
+    );
+    let resp = router.clone().oneshot(req).await.unwrap();
+    // Consume the SSE body to ensure the blocking task completes
+    let _ = body_string(resp).await;
 
-    #[tokio::test]
-    async fn get_closed_session_shows_archived() {
-        let router = app();
-        let created = create_test_session(&router).await;
-        let id = created["id"].as_str().unwrap();
+    // Check history
+    let resp = router
+        .clone()
+        .oneshot(
+            Request::get(format!("/api/sessions/{id}/history"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
 
-        // Close
-        router
-            .clone()
-            .oneshot(
-                Request::delete(&format!("/api/sessions/{id}"))
-                    .body(Body::empty())
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
+    let body = body_json(resp).await;
+    let messages = body["messages"].as_array().unwrap();
+    assert!(messages.len() >= 2, "should have user + assistant messages");
 
-        // Get again
-        let resp = router
-            .clone()
-            .oneshot(
-                Request::get(&format!("/api/sessions/{id}"))
-                    .body(Body::empty())
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
+    assert_eq!(messages[0]["role"], "user");
+    assert_eq!(messages[0]["content"], "Hello!");
+}
 
-        assert_eq!(resp.status(), StatusCode::OK);
-        let body = body_json(resp).await;
-        assert_eq!(body["status"], "archived");
-    }
+// --- Error Format Tests ---
 
-    #[tokio::test]
-    async fn close_unknown_session_returns_404() {
-        let resp = app()
-            .oneshot(
-                Request::delete("/api/sessions/nonexistent")
-                    .body(Body::empty())
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
+#[tokio::test]
+async fn error_response_has_consistent_structure() {
+    let resp = app()
+        .oneshot(
+            Request::get("/api/sessions/nonexistent")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
 
-        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
-    }
+    let body = body_json(resp).await;
+    assert!(body["error"].is_object());
+    assert!(body["error"]["code"].is_string());
+    assert!(body["error"]["message"].is_string());
+}
 
-    // --- History Tests ---
+#[tokio::test]
+async fn malformed_create_body_returns_400() {
+    let req = Request::builder()
+        .method("POST")
+        .uri("/api/sessions")
+        .header("content-type", "application/json")
+        .body(Body::from(r#"{"invalid": true}"#))
+        .unwrap();
 
-    #[tokio::test]
-    async fn history_empty_for_new_session() {
-        let router = app();
-        let created = create_test_session(&router).await;
-        let id = created["id"].as_str().unwrap();
+    let resp = app().oneshot(req).await.unwrap();
+    // Axum returns 422 for deserialization failures
+    assert!(
+        resp.status() == StatusCode::BAD_REQUEST
+            || resp.status() == StatusCode::UNPROCESSABLE_ENTITY
+    );
+}
 
-        let resp = router
-            .clone()
-            .oneshot(
-                Request::get(&format!("/api/sessions/{id}/history"))
-                    .body(Body::empty())
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
+#[tokio::test]
+async fn malformed_send_body_returns_error() {
+    let router = app();
+    let created = create_test_session(&router).await;
+    let id = created["id"].as_str().unwrap();
 
-        assert_eq!(resp.status(), StatusCode::OK);
-        let body = body_json(resp).await;
-        assert!(body["messages"].as_array().unwrap().is_empty());
-    }
+    let req = Request::builder()
+        .method("POST")
+        .uri(format!("/api/sessions/{id}/messages"))
+        .header("content-type", "application/json")
+        .body(Body::from(r#"{"wrong_field": "abc"}"#))
+        .unwrap();
 
-    #[tokio::test]
-    async fn history_unknown_session_returns_404() {
-        let resp = app()
-            .oneshot(
-                Request::get("/api/sessions/nonexistent/history")
-                    .body(Body::empty())
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
+    let resp = router.clone().oneshot(req).await.unwrap();
+    assert!(
+        resp.status() == StatusCode::BAD_REQUEST
+            || resp.status() == StatusCode::UNPROCESSABLE_ENTITY
+    );
+}
 
-        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
-    }
+// --- Nous Tests ---
 
-    #[tokio::test]
-    async fn history_with_limit() {
-        let state = test_state();
+#[tokio::test]
+async fn list_nous_returns_agents() {
+    let resp = app()
+        .oneshot(Request::get("/api/nous").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = body_json(resp).await;
+    let agents = body["nous"].as_array().unwrap();
+    assert_eq!(agents.len(), 1);
+    assert_eq!(agents[0]["id"], "syn");
+}
+
+#[tokio::test]
+async fn get_nous_status() {
+    let resp = app()
+        .oneshot(
+            Request::get("/api/nous/syn")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = body_json(resp).await;
+    assert_eq!(body["id"], "syn");
+    assert!(body["context_window"].is_number());
+    assert!(body["max_output_tokens"].is_number());
+}
+
+#[tokio::test]
+async fn get_unknown_nous_returns_404() {
+    let resp = app()
+        .oneshot(
+            Request::get("/api/nous/nonexistent")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    let body = body_json(resp).await;
+    assert_eq!(body["error"]["code"], "nous_not_found");
+}
+
+#[tokio::test]
+async fn get_nous_tools() {
+    let resp = app()
+        .oneshot(
+            Request::get("/api/nous/syn/tools")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = body_json(resp).await;
+    assert!(body["tools"].is_array());
+}
+
+// --- Concurrent access ---
+
+#[tokio::test]
+async fn concurrent_session_creation() {
+    let state = test_state();
+    let mut handles = Vec::new();
+
+    for i in 0..5 {
         let router = build_router(Arc::clone(&state));
-
-        let created = create_test_session(&router).await;
-        let id = created["id"].as_str().unwrap();
-
-        // Directly insert messages
-        {
-            let store = state.session_store.lock().unwrap();
-            for i in 1..=5 {
-                store
-                    .append_message(
-                        id,
-                        aletheia_mneme::types::Role::User,
-                        &format!("message {i}"),
-                        None,
-                        None,
-                        10,
-                    )
-                    .unwrap();
-            }
-        }
-
-        let resp = router
-            .clone()
-            .oneshot(
-                Request::get(&format!("/api/sessions/{id}/history?limit=3"))
-                    .body(Body::empty())
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
-
-        let body = body_json(resp).await;
-        assert_eq!(body["messages"].as_array().unwrap().len(), 3);
+        handles.push(tokio::spawn(async move {
+            let req = json_request(
+                "POST",
+                "/api/sessions",
+                Some(serde_json::json!({
+                    "nous_id": "syn",
+                    "session_key": format!("concurrent-{i}")
+                })),
+            );
+            let resp = router.oneshot(req).await.unwrap();
+            resp.status()
+        }));
     }
 
-    // --- SSE Message Tests ---
-
-    #[tokio::test]
-    async fn send_message_returns_sse_content_type() {
-        let state = test_state();
-        let router = build_router(Arc::clone(&state));
-        let created = create_test_session(&router).await;
-        let id = created["id"].as_str().unwrap();
-
-        let req = json_request(
-            "POST",
-            &format!("/api/sessions/{id}/messages"),
-            Some(serde_json::json!({ "content": "Hello!" })),
-        );
-
-        let resp = router.clone().oneshot(req).await.unwrap();
-        assert_eq!(resp.status(), StatusCode::OK);
-
-        let content_type = resp
-            .headers()
-            .get("content-type")
-            .unwrap()
-            .to_str()
-            .unwrap();
-        assert!(content_type.contains("text/event-stream"));
+    for handle in handles {
+        let status = handle.await.unwrap();
+        assert_eq!(status, StatusCode::CREATED);
     }
+}
 
-    #[tokio::test]
-    async fn send_message_stream_contains_events() {
-        let state = test_state();
-        let router = build_router(Arc::clone(&state));
-        let created = create_test_session(&router).await;
-        let id = created["id"].as_str().unwrap();
+// --- SSE with no provider ---
 
-        let req = json_request(
-            "POST",
-            &format!("/api/sessions/{id}/messages"),
-            Some(serde_json::json!({ "content": "Hello!" })),
-        );
+#[tokio::test]
+async fn send_message_no_provider_returns_error() {
+    let state = test_state_with_provider(false);
+    let router = build_router(Arc::clone(&state));
+    let created = create_test_session(&router).await;
+    let id = created["id"].as_str().unwrap();
 
-        let resp = router.clone().oneshot(req).await.unwrap();
-        let body = body_string(resp).await;
+    let req = json_request(
+        "POST",
+        &format!("/api/sessions/{id}/messages"),
+        Some(serde_json::json!({ "content": "Hello!" })),
+    );
 
-        assert!(body.contains("event: text_delta"), "should contain text_delta event");
-        assert!(body.contains("Hello from mock!"), "should contain mock response text");
-        assert!(body.contains("event: message_complete"), "should contain message_complete event");
-    }
-
-    #[tokio::test]
-    async fn send_message_unknown_session_returns_404() {
-        let req = json_request(
-            "POST",
-            "/api/sessions/nonexistent/messages",
-            Some(serde_json::json!({ "content": "Hello!" })),
-        );
-
-        let resp = app().oneshot(req).await.unwrap();
-        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
-    }
-
-    #[tokio::test]
-    async fn send_empty_message_returns_400() {
-        let router = app();
-        let created = create_test_session(&router).await;
-        let id = created["id"].as_str().unwrap();
-
-        let req = json_request(
-            "POST",
-            &format!("/api/sessions/{id}/messages"),
-            Some(serde_json::json!({ "content": "" })),
-        );
-
-        let resp = router.clone().oneshot(req).await.unwrap();
-        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
-    }
-
-    #[tokio::test]
-    async fn send_message_stores_in_history() {
-        let state = test_state();
-        let router = build_router(Arc::clone(&state));
-        let created = create_test_session(&router).await;
-        let id = created["id"].as_str().unwrap();
-
-        // Send a message
-        let req = json_request(
-            "POST",
-            &format!("/api/sessions/{id}/messages"),
-            Some(serde_json::json!({ "content": "Hello!" })),
-        );
-        let resp = router.clone().oneshot(req).await.unwrap();
-        // Consume the SSE body to ensure the blocking task completes
-        let _ = body_string(resp).await;
-
-        // Check history
-        let resp = router
-            .clone()
-            .oneshot(
-                Request::get(&format!("/api/sessions/{id}/history"))
-                    .body(Body::empty())
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
-
-        let body = body_json(resp).await;
-        let messages = body["messages"].as_array().unwrap();
-        assert!(messages.len() >= 2, "should have user + assistant messages");
-
-        assert_eq!(messages[0]["role"], "user");
-        assert_eq!(messages[0]["content"], "Hello!");
-    }
-
-    // --- Error Format Tests ---
-
-    #[tokio::test]
-    async fn error_response_has_consistent_structure() {
-        let resp = app()
-            .oneshot(
-                Request::get("/api/sessions/nonexistent")
-                    .body(Body::empty())
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
-
-        let body = body_json(resp).await;
-        assert!(body["error"].is_object());
-        assert!(body["error"]["code"].is_string());
-        assert!(body["error"]["message"].is_string());
-    }
-
-    #[tokio::test]
-    async fn malformed_create_body_returns_400() {
-        let req = Request::builder()
-            .method("POST")
-            .uri("/api/sessions")
-            .header("content-type", "application/json")
-            .body(Body::from(r#"{"invalid": true}"#))
-            .unwrap();
-
-        let resp = app().oneshot(req).await.unwrap();
-        // Axum returns 422 for deserialization failures
-        assert!(
-            resp.status() == StatusCode::BAD_REQUEST
-                || resp.status() == StatusCode::UNPROCESSABLE_ENTITY
-        );
-    }
-
-    #[tokio::test]
-    async fn malformed_send_body_returns_error() {
-        let router = app();
-        let created = create_test_session(&router).await;
-        let id = created["id"].as_str().unwrap();
-
-        let req = Request::builder()
-            .method("POST")
-            .uri(&format!("/api/sessions/{id}/messages"))
-            .header("content-type", "application/json")
-            .body(Body::from(r#"{"wrong_field": "abc"}"#))
-            .unwrap();
-
-        let resp = router.clone().oneshot(req).await.unwrap();
-        assert!(
-            resp.status() == StatusCode::BAD_REQUEST
-                || resp.status() == StatusCode::UNPROCESSABLE_ENTITY
-        );
-    }
-
-    // --- Nous Tests ---
-
-    #[tokio::test]
-    async fn list_nous_returns_agents() {
-        let resp = app()
-            .oneshot(
-                Request::get("/api/nous").body(Body::empty()).unwrap(),
-            )
-            .await
-            .unwrap();
-
-        assert_eq!(resp.status(), StatusCode::OK);
-        let body = body_json(resp).await;
-        let agents = body["nous"].as_array().unwrap();
-        assert_eq!(agents.len(), 1);
-        assert_eq!(agents[0]["id"], "syn");
-    }
-
-    #[tokio::test]
-    async fn get_nous_status() {
-        let resp = app()
-            .oneshot(
-                Request::get("/api/nous/syn").body(Body::empty()).unwrap(),
-            )
-            .await
-            .unwrap();
-
-        assert_eq!(resp.status(), StatusCode::OK);
-        let body = body_json(resp).await;
-        assert_eq!(body["id"], "syn");
-        assert!(body["context_window"].is_number());
-        assert!(body["max_output_tokens"].is_number());
-    }
-
-    #[tokio::test]
-    async fn get_unknown_nous_returns_404() {
-        let resp = app()
-            .oneshot(
-                Request::get("/api/nous/nonexistent")
-                    .body(Body::empty())
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
-
-        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
-        let body = body_json(resp).await;
-        assert_eq!(body["error"]["code"], "nous_not_found");
-    }
-
-    #[tokio::test]
-    async fn get_nous_tools() {
-        let resp = app()
-            .oneshot(
-                Request::get("/api/nous/syn/tools")
-                    .body(Body::empty())
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
-
-        assert_eq!(resp.status(), StatusCode::OK);
-        let body = body_json(resp).await;
-        assert!(body["tools"].is_array());
-    }
-
-    // --- Concurrent access ---
-
-    #[tokio::test]
-    async fn concurrent_session_creation() {
-        let state = test_state();
-        let mut handles = Vec::new();
-
-        for i in 0..5 {
-            let router = build_router(Arc::clone(&state));
-            handles.push(tokio::spawn(async move {
-                let req = json_request(
-                    "POST",
-                    "/api/sessions",
-                    Some(serde_json::json!({
-                        "nous_id": "syn",
-                        "session_key": format!("concurrent-{i}")
-                    })),
-                );
-                let resp = router.oneshot(req).await.unwrap();
-                resp.status()
-            }));
-        }
-
-        for handle in handles {
-            let status = handle.await.unwrap();
-            assert_eq!(status, StatusCode::CREATED);
-        }
-    }
-
-    // --- SSE with no provider ---
-
-    #[tokio::test]
-    async fn send_message_no_provider_returns_error() {
-        let state = test_state_with_provider(false);
-        let router = build_router(Arc::clone(&state));
-        let created = create_test_session(&router).await;
-        let id = created["id"].as_str().unwrap();
-
-        let req = json_request(
-            "POST",
-            &format!("/api/sessions/{id}/messages"),
-            Some(serde_json::json!({ "content": "Hello!" })),
-        );
-
-        let resp = router.clone().oneshot(req).await.unwrap();
-        assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
-    }
+    let resp = router.clone().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
 }


### PR DESCRIPTION
## Summary

- Replace `Stub` struct with four real workspace tool executors: `ReadExecutor`, `WriteExecutor`, `EditExecutor`, `ExecExecutor`
- Add path validation helper that normalizes `..`/`.` components and checks against `allowed_roots` to prevent directory traversal
- Fix pre-existing clippy warnings in pylon tests (module inception, unused import, dead code, needless borrows)

### Executors

| Executor | Key behaviors |
|----------|--------------|
| **ReadExecutor** | UTF-8 file read, optional `maxLines` truncation |
| **WriteExecutor** | Creates parent dirs, supports append mode |
| **EditExecutor** | Requires unique `old_text` match, rejects 0 or 2+ matches |
| **ExecExecutor** | Shell via `sh -c`, configurable timeout, 50KB output cap |

### Tests added (12)

`read_existing_file`, `read_with_max_lines`, `read_missing_file`, `write_creates_file`, `write_creates_parent_dirs`, `write_append_mode`, `edit_single_match`, `edit_not_found`, `edit_multiple_matches`, `exec_simple_command`, `exec_timeout`, `path_traversal_blocked`

## Test plan

- [x] `cargo clippy --workspace --all-targets -- -D warnings` — zero warnings
- [x] `cargo test -p aletheia-organon` — 26/26 pass (14 existing + 12 new)
- [x] `cargo doc --workspace --no-deps` — clean
- [ ] Note: `aletheia-symbolon` has 12 pre-existing test failures from the jsonwebtoken 9→10 migration (#371), unrelated to this PR