### PR TITLE
feat(agora): channel registry and Signal provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,6 +47,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "aletheia-agora"
+version = "0.1.0"
+dependencies = [
+ "aletheia-koina",
+ "aletheia-taxis",
+ "indexmap 2.13.0",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "snafu",
+ "static_assertions",
+ "tokio",
+ "tracing",
+ "uuid",
+ "wiremock",
+]
+
+[[package]]
 name = "aletheia-graph-builder"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 resolver = "2"
 members = [
     "crates/graph-builder",
+    "crates/agora",
     "crates/hermeneus",
     "crates/integration-tests",
     "crates/koina",
@@ -82,6 +83,9 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 
 # Config
 figment = { version = "0.10", features = ["yaml", "json", "env"] }
+
+# IDs
+uuid = { version = "1", features = ["v4"] }
 
 # Types
 compact_str = { version = "0.8", features = ["serde"] }

--- a/crates/agora/Cargo.toml
+++ b/crates/agora/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "aletheia-agora"
+version = "0.1.0"
+description = "Channel registry and provider implementations (Signal, Slack)"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+aletheia-koina = { path = "../koina" }
+aletheia-taxis = { path = "../taxis" }
+indexmap = { workspace = true }
+reqwest = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+snafu = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
+uuid = { workspace = true }
+
+[dev-dependencies]
+static_assertions = { workspace = true }
+tokio = { workspace = true }
+wiremock = { workspace = true }

--- a/crates/agora/src/error.rs
+++ b/crates/agora/src/error.rs
@@ -1,0 +1,43 @@
+//! Error types for the agora crate.
+
+use snafu::Snafu;
+
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub(crate)))]
+#[non_exhaustive]
+pub enum Error {
+    /// Requested channel does not exist in the registry.
+    #[snafu(display("unknown channel: {id}"))]
+    UnknownChannel {
+        id: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    /// A channel with this ID is already registered.
+    #[snafu(display("duplicate channel: {id}"))]
+    DuplicateChannel {
+        id: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    /// Channel send operation failed.
+    #[snafu(display("send failed on channel {channel}: {message}"))]
+    Send {
+        channel: String,
+        message: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    /// Signal-specific error.
+    #[snafu(display("signal error: {source}"))]
+    Signal {
+        source: crate::semeion::error::Error,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+}
+
+pub type Result<T> = std::result::Result<T, Error>;

--- a/crates/agora/src/lib.rs
+++ b/crates/agora/src/lib.rs
@@ -1,0 +1,23 @@
+//! aletheia-agora — channel registry and provider implementations
+//!
+//! Agora (ἀγορά) — "gathering place." The public square where messages flow
+//! between Aletheia and the outside world. Provides the channel abstraction
+//! and registry, with Signal (semeion) as the first provider.
+
+pub mod error;
+pub mod registry;
+pub mod semeion;
+pub mod types;
+
+#[cfg(test)]
+mod assertions {
+    use static_assertions::assert_impl_all;
+
+    use super::registry::ChannelRegistry;
+    use super::semeion::client::SignalClient;
+    use super::semeion::SignalProvider;
+
+    assert_impl_all!(ChannelRegistry: Send, Sync);
+    assert_impl_all!(SignalClient: Send, Sync);
+    assert_impl_all!(SignalProvider: Send, Sync);
+}

--- a/crates/agora/src/registry.rs
+++ b/crates/agora/src/registry.rs
@@ -1,0 +1,306 @@
+//! Channel registry — the single source of truth for available channels.
+
+use std::sync::Arc;
+
+use indexmap::IndexMap;
+use snafu::ensure;
+
+use crate::error::{self, Result};
+use crate::types::{ChannelProvider, ProbeResult, SendParams, SendResult};
+
+/// Registry of available channel providers.
+///
+/// Channels are registered at startup and looked up by ID during send operations.
+/// Uses `IndexMap` to preserve insertion order.
+pub struct ChannelRegistry {
+    providers: IndexMap<String, Arc<dyn ChannelProvider>>,
+}
+
+impl Default for ChannelRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ChannelRegistry {
+    /// Create an empty registry.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            providers: IndexMap::new(),
+        }
+    }
+
+    /// Register a channel provider. Fails if a provider with the same ID exists.
+    pub fn register(
+        &mut self,
+        provider: Arc<dyn ChannelProvider>,
+    ) -> Result<()> {
+        let id = provider.id().to_owned();
+        ensure!(
+            !self.providers.contains_key(&id),
+            error::DuplicateChannelSnafu { id }
+        );
+        self.providers.insert(id, provider);
+        Ok(())
+    }
+
+    /// Look up a provider by channel ID.
+    #[must_use]
+    pub fn get(
+        &self,
+        channel_id: &str,
+    ) -> Option<&Arc<dyn ChannelProvider>> {
+        self.providers.get(channel_id)
+    }
+
+    /// Send a message through a specific channel.
+    ///
+    /// Returns `Err` if the channel is not registered.
+    /// Provider-level failures are captured in [`SendResult::error`].
+    pub async fn send(
+        &self,
+        channel_id: &str,
+        params: &SendParams,
+    ) -> Result<SendResult> {
+        let provider = self.providers.get(channel_id).ok_or_else(|| {
+            error::UnknownChannelSnafu {
+                id: channel_id.to_owned(),
+            }
+            .build()
+        })?;
+        Ok(provider.send(params).await)
+    }
+
+    /// Probe all registered channels for health status.
+    pub async fn probe_all(&self) -> IndexMap<String, ProbeResult> {
+        let mut results = IndexMap::with_capacity(self.providers.len());
+        for (id, provider) in &self.providers {
+            let result = provider.probe().await;
+            results.insert(id.clone(), result);
+        }
+        results
+    }
+
+    /// List all registered channel IDs, in insertion order.
+    #[must_use]
+    pub fn channels(&self) -> Vec<&str> {
+        self.providers.keys().map(String::as_str).collect()
+    }
+
+    /// Number of registered channels.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.providers.len()
+    }
+
+    /// Whether the registry is empty.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.providers.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::future::Future;
+    use std::pin::Pin;
+
+    use crate::types::ChannelCapabilities;
+
+    use super::*;
+
+    static MOCK_CAPS: ChannelCapabilities = ChannelCapabilities {
+        threads: false,
+        reactions: false,
+        typing: false,
+        media: false,
+        streaming: false,
+        rich_formatting: false,
+        max_text_length: 1000,
+    };
+
+    struct MockProvider {
+        channel_id: String,
+        channel_name: String,
+        send_result: SendResult,
+        probe_result: ProbeResult,
+    }
+
+    impl MockProvider {
+        fn new(id: &str) -> Self {
+            Self {
+                channel_id: id.to_owned(),
+                channel_name: format!("Mock {id}"),
+                send_result: SendResult {
+                    sent: true,
+                    error: None,
+                },
+                probe_result: ProbeResult {
+                    ok: true,
+                    latency_ms: Some(42),
+                    error: None,
+                    details: None,
+                },
+            }
+        }
+
+        fn with_send_result(mut self, result: SendResult) -> Self {
+            self.send_result = result;
+            self
+        }
+
+        fn with_probe_result(mut self, result: ProbeResult) -> Self {
+            self.probe_result = result;
+            self
+        }
+    }
+
+    impl ChannelProvider for MockProvider {
+        fn id(&self) -> &str {
+            &self.channel_id
+        }
+
+        fn name(&self) -> &str {
+            &self.channel_name
+        }
+
+        fn capabilities(&self) -> &ChannelCapabilities {
+            &MOCK_CAPS
+        }
+
+        fn send<'a>(
+            &'a self,
+            _params: &'a SendParams,
+        ) -> Pin<Box<dyn Future<Output = SendResult> + Send + 'a>>
+        {
+            Box::pin(async { self.send_result.clone() })
+        }
+
+        fn probe<'a>(
+            &'a self,
+        ) -> Pin<Box<dyn Future<Output = ProbeResult> + Send + 'a>>
+        {
+            Box::pin(async { self.probe_result.clone() })
+        }
+    }
+
+    fn test_params(to: &str) -> SendParams {
+        SendParams {
+            to: to.to_owned(),
+            text: "hello".to_owned(),
+            account_id: None,
+            thread_id: None,
+            attachments: None,
+        }
+    }
+
+    #[test]
+    fn register_and_lookup() {
+        let mut reg = ChannelRegistry::new();
+        let provider = Arc::new(MockProvider::new("signal"));
+        reg.register(provider).expect("register");
+
+        let found = reg.get("signal").expect("found");
+        assert_eq!(found.id(), "signal");
+        assert_eq!(found.name(), "Mock signal");
+    }
+
+    #[test]
+    fn duplicate_registration_fails() {
+        let mut reg = ChannelRegistry::new();
+        reg.register(Arc::new(MockProvider::new("signal")))
+            .expect("first");
+        let err = reg
+            .register(Arc::new(MockProvider::new("signal")))
+            .expect_err("duplicate");
+        assert!(err.to_string().contains("duplicate channel: signal"));
+    }
+
+    #[tokio::test]
+    async fn send_routes_to_correct_provider() {
+        let mut reg = ChannelRegistry::new();
+        reg.register(Arc::new(
+            MockProvider::new("signal").with_send_result(SendResult {
+                sent: true,
+                error: None,
+            }),
+        ))
+        .expect("register signal");
+        reg.register(Arc::new(
+            MockProvider::new("slack").with_send_result(SendResult {
+                sent: false,
+                error: Some("slack down".to_owned()),
+            }),
+        ))
+        .expect("register slack");
+
+        let signal_result =
+            reg.send("signal", &test_params("+1234567890")).await.expect("send");
+        assert!(signal_result.sent);
+
+        let slack_result =
+            reg.send("slack", &test_params("C0123")).await.expect("send");
+        assert!(!slack_result.sent);
+        assert_eq!(slack_result.error.as_deref(), Some("slack down"));
+    }
+
+    #[tokio::test]
+    async fn send_unknown_channel_errors() {
+        let reg = ChannelRegistry::new();
+        let err = reg
+            .send("nonexistent", &test_params("x"))
+            .await
+            .expect_err("unknown");
+        assert!(err.to_string().contains("unknown channel: nonexistent"));
+    }
+
+    #[tokio::test]
+    async fn probe_all_collects_results() {
+        let mut reg = ChannelRegistry::new();
+        reg.register(Arc::new(MockProvider::new("signal")))
+            .expect("register");
+        reg.register(Arc::new(
+            MockProvider::new("slack").with_probe_result(ProbeResult {
+                ok: false,
+                latency_ms: None,
+                error: Some("unreachable".to_owned()),
+                details: None,
+            }),
+        ))
+        .expect("register");
+
+        let results = reg.probe_all().await;
+        assert_eq!(results.len(), 2);
+        assert!(results["signal"].ok);
+        assert!(!results["slack"].ok);
+    }
+
+    #[test]
+    fn channels_lists_registered_ids() {
+        let mut reg = ChannelRegistry::new();
+        reg.register(Arc::new(MockProvider::new("signal")))
+            .expect("register");
+        reg.register(Arc::new(MockProvider::new("slack")))
+            .expect("register");
+        reg.register(Arc::new(MockProvider::new("discord")))
+            .expect("register");
+
+        let channels = reg.channels();
+        assert_eq!(channels, vec!["signal", "slack", "discord"]);
+    }
+
+    #[test]
+    fn empty_registry() {
+        let reg = ChannelRegistry::new();
+        assert!(reg.is_empty());
+        assert_eq!(reg.len(), 0);
+        assert!(reg.channels().is_empty());
+    }
+
+    #[test]
+    fn lookup_missing_returns_none() {
+        let reg = ChannelRegistry::new();
+        assert!(reg.get("nonexistent").is_none());
+    }
+}

--- a/crates/agora/src/semeion/client.rs
+++ b/crates/agora/src/semeion/client.rs
@@ -1,0 +1,315 @@
+//! JSON-RPC client for the signal-cli HTTP daemon.
+
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+use snafu::ResultExt;
+use tracing::instrument;
+use uuid::Uuid;
+
+use super::error::{self, Result};
+
+const RPC_TIMEOUT: Duration = Duration::from_secs(10);
+const HEALTH_TIMEOUT: Duration = Duration::from_secs(2);
+
+#[derive(Debug, Serialize)]
+struct RpcRequest<'a> {
+    jsonrpc: &'static str,
+    method: &'a str,
+    params: serde_json::Value,
+    id: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct RpcResponse {
+    #[expect(dead_code, reason = "present in wire format, validated implicitly")]
+    jsonrpc: String,
+    result: Option<serde_json::Value>,
+    error: Option<RpcError>,
+    #[expect(dead_code, reason = "present in wire format, used for correlation")]
+    id: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RpcError {
+    code: i64,
+    message: String,
+}
+
+/// Async JSON-RPC client for a single signal-cli HTTP daemon instance.
+pub struct SignalClient {
+    client: reqwest::Client,
+    rpc_url: String,
+    health_url: String,
+}
+
+impl SignalClient {
+    /// Create a new client targeting the given base URL.
+    ///
+    /// Normalizes the URL: strips trailing slashes, prepends `http://` if missing.
+    pub fn new(base_url: &str) -> Result<Self> {
+        let base = normalize_url(base_url);
+
+        let client = reqwest::Client::builder()
+            .timeout(RPC_TIMEOUT)
+            .build()
+            .context(error::HttpSnafu)?;
+
+        Ok(Self {
+            client,
+            rpc_url: format!("{base}/api/v1/rpc"),
+            health_url: format!("{base}/api/v1/check"),
+        })
+    }
+
+    /// Low-level JSON-RPC call.
+    #[instrument(skip(self, params), fields(method))]
+    pub async fn rpc(
+        &self,
+        method: &str,
+        params: serde_json::Value,
+    ) -> Result<Option<serde_json::Value>> {
+        let id = Uuid::new_v4().to_string();
+        let request = RpcRequest {
+            jsonrpc: "2.0",
+            method,
+            params,
+            id,
+        };
+
+        let body = serde_json::to_string(&request).context(error::JsonSnafu)?;
+
+        let response = self
+            .client
+            .post(&self.rpc_url)
+            .header("content-type", "application/json")
+            .body(body)
+            .send()
+            .await
+            .context(error::HttpSnafu)?;
+
+        // 201 = accepted, no body (signal-cli convention for fire-and-forget)
+        if response.status().as_u16() == 201 {
+            return Ok(None);
+        }
+
+        let rpc_response: RpcResponse =
+            response.json().await.context(error::HttpSnafu)?;
+
+        if let Some(err) = rpc_response.error {
+            return Err(error::RpcSnafu {
+                code: err.code,
+                message: err.message,
+            }
+            .build());
+        }
+
+        Ok(rpc_response.result)
+    }
+
+    /// Send a message with retry on transient failures.
+    ///
+    /// Retries up to 2 times with 500ms, 1000ms backoff.
+    /// Does NOT retry JSON-RPC application errors (only transport failures).
+    #[instrument(skip(self, params))]
+    pub async fn send_message(
+        &self,
+        params: &SendParams,
+    ) -> Result<Option<serde_json::Value>> {
+        let rpc_params = params.to_rpc_value();
+        let backoffs = [500u64, 1000];
+        let mut last_err = None;
+
+        for attempt in 0..=backoffs.len() {
+            match self.rpc("send", rpc_params.clone()).await {
+                Ok(result) => return Ok(result),
+                Err(e) => {
+                    if matches!(e, super::error::Error::Rpc { .. }) {
+                        return Err(e);
+                    }
+                    last_err = Some(e);
+                    if attempt < backoffs.len() {
+                        tracing::warn!(
+                            attempt = attempt + 1,
+                            backoff_ms = backoffs[attempt],
+                            "signal send attempt failed, retrying"
+                        );
+                        tokio::time::sleep(Duration::from_millis(
+                            backoffs[attempt],
+                        ))
+                        .await;
+                    }
+                }
+            }
+        }
+
+        Err(last_err.expect("at least one attempt was made"))
+    }
+
+    /// Health check — hits the signal-cli check endpoint.
+    pub async fn health(&self) -> bool {
+        let result = self
+            .client
+            .get(&self.health_url)
+            .timeout(HEALTH_TIMEOUT)
+            .send()
+            .await;
+        matches!(result, Ok(r) if r.status().is_success())
+    }
+
+    /// The base RPC URL this client targets.
+    pub fn rpc_url(&self) -> &str {
+        &self.rpc_url
+    }
+}
+
+impl std::fmt::Debug for SignalClient {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SignalClient")
+            .field("rpc_url", &self.rpc_url)
+            .finish_non_exhaustive()
+    }
+}
+
+/// Parameters for the signal-cli `send` RPC method.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SendParams {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub recipient: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub group_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub account: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub attachments: Option<Vec<String>>,
+}
+
+impl SendParams {
+    /// Convert to the JSON-RPC wire format expected by signal-cli.
+    ///
+    /// Key transformations:
+    /// - `recipient` is wrapped in an array (signal-cli convention)
+    /// - `group_id` becomes `groupId` (camelCase)
+    pub fn to_rpc_value(&self) -> serde_json::Value {
+        let mut map = serde_json::Map::new();
+
+        if let Some(ref msg) = self.message {
+            map.insert(
+                "message".to_owned(),
+                serde_json::Value::String(msg.clone()),
+            );
+        }
+        if let Some(ref r) = self.recipient {
+            // signal-cli expects recipient as an array
+            map.insert(
+                "recipient".to_owned(),
+                serde_json::Value::Array(vec![serde_json::Value::String(
+                    r.clone(),
+                )]),
+            );
+        }
+        if let Some(ref g) = self.group_id {
+            map.insert(
+                "groupId".to_owned(),
+                serde_json::Value::String(g.clone()),
+            );
+        }
+        if let Some(ref a) = self.account {
+            map.insert(
+                "account".to_owned(),
+                serde_json::Value::String(a.clone()),
+            );
+        }
+        if let Some(ref att) = self.attachments {
+            map.insert(
+                "attachments".to_owned(),
+                serde_json::Value::Array(
+                    att.iter()
+                        .map(|a| serde_json::Value::String(a.clone()))
+                        .collect(),
+                ),
+            );
+        }
+
+        serde_json::Value::Object(map)
+    }
+}
+
+fn normalize_url(url: &str) -> String {
+    let trimmed = url.trim_end_matches('/');
+    if trimmed.starts_with("http://") || trimmed.starts_with("https://") {
+        trimmed.to_owned()
+    } else {
+        format!("http://{trimmed}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn url_normalization() {
+        assert_eq!(normalize_url("localhost:8080/"), "http://localhost:8080");
+        assert_eq!(
+            normalize_url("http://localhost:8080/"),
+            "http://localhost:8080"
+        );
+        assert_eq!(
+            normalize_url("https://signal.example.com///"),
+            "https://signal.example.com"
+        );
+        assert_eq!(normalize_url("127.0.0.1:9000"), "http://127.0.0.1:9000");
+    }
+
+    #[test]
+    fn send_params_serialization_phone() {
+        let params = SendParams {
+            message: Some("hello".to_owned()),
+            recipient: Some("+1234567890".to_owned()),
+            group_id: None,
+            account: Some("+0987654321".to_owned()),
+            attachments: None,
+        };
+
+        let value = params.to_rpc_value();
+        assert_eq!(value["message"], "hello");
+        // recipient is wrapped in an array
+        assert_eq!(
+            value["recipient"],
+            serde_json::json!(["+1234567890"])
+        );
+        assert_eq!(value["account"], "+0987654321");
+        assert!(value.get("groupId").is_none());
+        assert!(value.get("attachments").is_none());
+    }
+
+    #[test]
+    fn send_params_serialization_group() {
+        let params = SendParams {
+            message: Some("group msg".to_owned()),
+            recipient: None,
+            group_id: Some("YWJjMTIz".to_owned()),
+            account: Some("+1111111111".to_owned()),
+            attachments: Some(vec!["/tmp/photo.jpg".to_owned()]),
+        };
+
+        let value = params.to_rpc_value();
+        assert_eq!(value["message"], "group msg");
+        assert!(value.get("recipient").is_none());
+        // group_id mapped to camelCase groupId
+        assert_eq!(value["groupId"], "YWJjMTIz");
+        assert_eq!(
+            value["attachments"],
+            serde_json::json!(["/tmp/photo.jpg"])
+        );
+    }
+
+    #[test]
+    fn client_creation() {
+        let client = SignalClient::new("localhost:8080").expect("create client");
+        assert_eq!(client.rpc_url(), "http://localhost:8080/api/v1/rpc");
+    }
+}

--- a/crates/agora/src/semeion/error.rs
+++ b/crates/agora/src/semeion/error.rs
@@ -1,0 +1,43 @@
+//! Signal-specific error types.
+
+use snafu::Snafu;
+
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub(crate)))]
+#[non_exhaustive]
+pub enum Error {
+    /// JSON-RPC returned an error response.
+    #[snafu(display("signal RPC error {code}: {message}"))]
+    Rpc {
+        code: i64,
+        message: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    /// HTTP transport error communicating with signal-cli daemon.
+    #[snafu(display("signal HTTP error: {source}"))]
+    Http {
+        source: reqwest::Error,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    /// No Signal account configured for the requested operation.
+    #[snafu(display("no signal account: {account_id}"))]
+    NoAccount {
+        account_id: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    /// JSON serialization/deserialization failure.
+    #[snafu(display("signal JSON error: {source}"))]
+    Json {
+        source: serde_json::Error,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+}
+
+pub type Result<T> = std::result::Result<T, Error>;

--- a/crates/agora/src/semeion/mod.rs
+++ b/crates/agora/src/semeion/mod.rs
@@ -1,0 +1,264 @@
+//! Signal channel provider — wraps signal-cli JSON-RPC.
+
+pub mod client;
+pub mod error;
+
+use std::collections::HashMap;
+use std::future::Future;
+use std::pin::Pin;
+
+use crate::types::{
+    ChannelCapabilities, ChannelProvider, ProbeResult,
+    SendParams as ChannelSendParams, SendResult,
+};
+
+/// Parsed Signal message target.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SignalTarget {
+    Phone(String),
+    Group(String),
+}
+
+/// Parse a target string into a `SignalTarget`.
+///
+/// - `"group:<base64id>"` → `Group`
+/// - anything else (e.g., `"+1234567890"`) → `Phone`
+#[must_use]
+pub fn parse_target(to: &str) -> SignalTarget {
+    if let Some(group_id) = to.strip_prefix("group:") {
+        SignalTarget::Group(group_id.to_owned())
+    } else {
+        SignalTarget::Phone(to.to_owned())
+    }
+}
+
+static SIGNAL_CAPABILITIES: ChannelCapabilities = ChannelCapabilities {
+    threads: false,
+    reactions: true,
+    typing: true,
+    media: true,
+    streaming: false,
+    rich_formatting: false,
+    max_text_length: 2000,
+};
+
+/// Signal channel provider implementing `ChannelProvider`.
+///
+/// Manages multiple Signal accounts, each backed by a `SignalClient`.
+/// The first registered account becomes the default for sends without
+/// an explicit `account_id`.
+pub struct SignalProvider {
+    clients: HashMap<String, client::SignalClient>,
+    default_account: Option<String>,
+}
+
+impl SignalProvider {
+    /// Create an empty provider. Add accounts with [`add_account`](Self::add_account).
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            clients: HashMap::new(),
+            default_account: None,
+        }
+    }
+
+    /// Register a Signal account backed by a client.
+    ///
+    /// The first account added becomes the default.
+    pub fn add_account(
+        &mut self,
+        account_id: String,
+        client: client::SignalClient,
+    ) {
+        if self.default_account.is_none() {
+            self.default_account = Some(account_id.clone());
+        }
+        self.clients.insert(account_id, client);
+    }
+
+    fn resolve_client(
+        &self,
+        account_id: Option<&str>,
+    ) -> Option<(&str, &client::SignalClient)> {
+        let key = account_id.or(self.default_account.as_deref())?;
+        self.clients
+            .get_key_value(key)
+            .map(|(k, v)| (k.as_str(), v))
+    }
+}
+
+impl Default for SignalProvider {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ChannelProvider for SignalProvider {
+    #[expect(clippy::unnecessary_literal_bound, reason = "trait signature requires &str")]
+    fn id(&self) -> &str {
+        "signal"
+    }
+
+    #[expect(clippy::unnecessary_literal_bound, reason = "trait signature requires &str")]
+    fn name(&self) -> &str {
+        "Signal"
+    }
+
+    fn capabilities(&self) -> &ChannelCapabilities {
+        &SIGNAL_CAPABILITIES
+    }
+
+    fn send<'a>(
+        &'a self,
+        params: &'a ChannelSendParams,
+    ) -> Pin<Box<dyn Future<Output = SendResult> + Send + 'a>> {
+        Box::pin(async move {
+            let Some((account, client)) =
+                self.resolve_client(params.account_id.as_deref())
+            else {
+                return SendResult {
+                    sent: false,
+                    error: Some("no Signal client available".to_owned()),
+                };
+            };
+
+            let target = parse_target(&params.to);
+
+            let send_params = match target {
+                SignalTarget::Phone(ref phone) => client::SendParams {
+                    message: Some(params.text.clone()),
+                    recipient: Some(phone.clone()),
+                    group_id: None,
+                    account: Some(account.to_owned()),
+                    attachments: params.attachments.clone(),
+                },
+                SignalTarget::Group(ref group_id) => client::SendParams {
+                    message: Some(params.text.clone()),
+                    recipient: None,
+                    group_id: Some(group_id.clone()),
+                    account: Some(account.to_owned()),
+                    attachments: params.attachments.clone(),
+                },
+            };
+
+            match client.send_message(&send_params).await {
+                Ok(_) => SendResult {
+                    sent: true,
+                    error: None,
+                },
+                Err(e) => SendResult {
+                    sent: false,
+                    error: Some(format!("{e}")),
+                },
+            }
+        })
+    }
+
+    fn probe<'a>(
+        &'a self,
+    ) -> Pin<Box<dyn Future<Output = ProbeResult> + Send + 'a>> {
+        Box::pin(async move {
+            if self.clients.is_empty() {
+                return ProbeResult {
+                    ok: false,
+                    latency_ms: None,
+                    error: Some(
+                        "no Signal clients configured".to_owned(),
+                    ),
+                    details: None,
+                };
+            }
+
+            let mut account_results = HashMap::new();
+            let mut any_ok = false;
+
+            for (account_id, client) in &self.clients {
+                let ok = client.health().await;
+                if ok {
+                    any_ok = true;
+                }
+                account_results.insert(
+                    account_id.clone(),
+                    serde_json::Value::Bool(ok),
+                );
+            }
+
+            ProbeResult {
+                ok: any_ok,
+                latency_ms: None,
+                error: if any_ok {
+                    None
+                } else {
+                    Some("all Signal accounts unreachable".to_owned())
+                },
+                details: Some(account_results),
+            }
+        })
+    }
+}
+
+impl std::fmt::Debug for SignalProvider {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SignalProvider")
+            .field(
+                "accounts",
+                &self.clients.keys().collect::<Vec<_>>(),
+            )
+            .field("default_account", &self.default_account)
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_target_phone() {
+        let target = parse_target("+1234567890");
+        assert_eq!(target, SignalTarget::Phone("+1234567890".to_owned()));
+    }
+
+    #[test]
+    fn parse_target_group() {
+        let target = parse_target("group:YWJjMTIz");
+        assert_eq!(target, SignalTarget::Group("YWJjMTIz".to_owned()));
+    }
+
+    #[test]
+    fn parse_target_group_empty_id() {
+        let target = parse_target("group:");
+        assert_eq!(target, SignalTarget::Group(String::new()));
+    }
+
+    #[test]
+    fn parse_target_plain_text() {
+        let target = parse_target("someuser");
+        assert_eq!(target, SignalTarget::Phone("someuser".to_owned()));
+    }
+
+    #[test]
+    fn signal_capabilities() {
+        assert!(!SIGNAL_CAPABILITIES.threads);
+        assert!(SIGNAL_CAPABILITIES.reactions);
+        assert!(SIGNAL_CAPABILITIES.typing);
+        assert!(SIGNAL_CAPABILITIES.media);
+        assert!(!SIGNAL_CAPABILITIES.streaming);
+        assert!(!SIGNAL_CAPABILITIES.rich_formatting);
+        assert_eq!(SIGNAL_CAPABILITIES.max_text_length, 2000);
+    }
+
+    #[test]
+    fn provider_id_and_name() {
+        let provider = SignalProvider::new();
+        assert_eq!(ChannelProvider::id(&provider), "signal");
+        assert_eq!(ChannelProvider::name(&provider), "Signal");
+    }
+
+    #[test]
+    fn provider_capabilities_ref() {
+        let provider = SignalProvider::new();
+        let caps = provider.capabilities();
+        assert_eq!(caps.max_text_length, 2000);
+    }
+}

--- a/crates/agora/src/types.rs
+++ b/crates/agora/src/types.rs
@@ -1,0 +1,84 @@
+//! Core types for the channel abstraction layer.
+
+use std::collections::HashMap;
+use std::future::Future;
+use std::pin::Pin;
+
+use serde::{Deserialize, Serialize};
+
+/// What a channel supports.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[expect(clippy::struct_excessive_bools, reason = "capability flags are inherently boolean")]
+pub struct ChannelCapabilities {
+    pub threads: bool,
+    pub reactions: bool,
+    pub typing: bool,
+    pub media: bool,
+    pub streaming: bool,
+    pub rich_formatting: bool,
+    pub max_text_length: usize,
+}
+
+/// Parameters for sending a message through a channel.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SendParams {
+    /// Target identifier (channel-specific: phone number, group ID, etc.)
+    pub to: String,
+    /// Message text (markdown).
+    pub text: String,
+    /// Account ID within the channel (for multi-account setups).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub account_id: Option<String>,
+    /// Thread/reply context identifier.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub thread_id: Option<String>,
+    /// File attachment paths.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub attachments: Option<Vec<String>>,
+}
+
+/// Result of a send operation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SendResult {
+    pub sent: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+/// Health probe result.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProbeResult {
+    pub ok: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub latency_ms: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub details: Option<HashMap<String, serde_json::Value>>,
+}
+
+/// The contract every channel provider must implement.
+///
+/// Object-safe via `Pin<Box<dyn Future>>` (matches `ToolExecutor` in organon).
+/// Implementations are stored as `Arc<dyn ChannelProvider>` in the registry.
+pub trait ChannelProvider: Send + Sync {
+    /// Unique channel identifier (e.g., `"signal"`, `"slack"`).
+    fn id(&self) -> &str;
+
+    /// Human-readable display name.
+    fn name(&self) -> &str;
+
+    /// What this channel supports.
+    fn capabilities(&self) -> &ChannelCapabilities;
+
+    /// Send a message outbound through this channel.
+    fn send<'a>(
+        &'a self,
+        params: &'a SendParams,
+    ) -> Pin<Box<dyn Future<Output = SendResult> + Send + 'a>>;
+
+    /// Health probe for this channel.
+    fn probe<'a>(
+        &'a self,
+    ) -> Pin<Box<dyn Future<Output = ProbeResult> + Send + 'a>>;
+}


### PR DESCRIPTION
## Summary

Implements the `aletheia-agora` crate (M3.2) — the channel abstraction layer for routing messages between Aletheia and external messaging platforms.

### What's included

- **`ChannelProvider` trait** — object-safe async trait (Pin<Box<dyn Future>> pattern matching ToolExecutor) with `send()`, `probe()`, `id()`, `name()`, `capabilities()`
- **`ChannelRegistry`** — IndexMap-backed provider registry with duplicate detection, send routing, and probe aggregation
- **Signal `SignalClient`** — JSON-RPC client for signal-cli HTTP daemon with URL normalization, 10s timeout, retry on transport errors (500ms/1000ms backoff)
- **`SignalProvider`** — ChannelProvider implementation with multi-account support, target parsing (phone/group), health probing
- **Error hierarchy** — crate-level errors (UnknownChannel, DuplicateChannel, Send, Signal) + Signal-specific errors (Rpc, Http, NoAccount, Json), all snafu with Location tracking

### Out of scope (separate PRs)

- SSE listener (inbound message stream)
- signal-cli daemon spawning
- Slack provider
- Message bindings (agent → channel routing)
- Pylon route wiring

### Validation

- `cargo clippy --workspace --all-targets -- -D warnings` — zero warnings
- `cargo test --workspace` — 397 tests pass (19 new in agora)
- `cargo doc -p aletheia-agora --no-deps` — clean
- All public types verified Send + Sync via static_assertions
- No unwrap() in non-test code

### Files

```
crates/agora/
├── Cargo.toml
└── src/
    ├── lib.rs           # Module declarations, Send+Sync assertions
    ├── error.rs         # Crate-level errors
    ├── types.rs         # ChannelProvider trait, capabilities, params, results
    ├── registry.rs      # ChannelRegistry + 8 tests
    └── semeion/
        ├── mod.rs       # SignalProvider + 7 tests
        ├── client.rs    # SignalClient JSON-RPC + 4 tests
        └── error.rs     # Signal-specific errors
```