### PR TITLE
feat(nous): NousActor tokio actor with inbox, lifecycle, and message dispatch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -208,11 +208,13 @@ dependencies = [
  "aletheia-mneme",
  "aletheia-organon",
  "aletheia-taxis",
+ "indexmap 2.13.0",
  "serde",
  "serde_json",
  "snafu",
  "static_assertions",
  "tempfile",
+ "tokio",
  "tracing",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,7 +93,7 @@ indexmap = { version = "2", features = ["serde"] }
 ulid = { version = "1", features = ["serde"] }
 
 # Async
-tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "signal"] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "signal", "sync"] }
 tokio-stream = "0.1"
 
 # Testing

--- a/crates/nous/Cargo.toml
+++ b/crates/nous/Cargo.toml
@@ -19,10 +19,10 @@ aletheia-taxis = { path = "../taxis" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 snafu = { workspace = true }
+tokio = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]
 indexmap = { workspace = true }
 static_assertions = { workspace = true }
 tempfile = "3"
-tokio = { workspace = true }

--- a/crates/nous/src/actor.rs
+++ b/crates/nous/src/actor.rs
@@ -1,0 +1,516 @@
+//! Tokio actor for a single nous agent instance.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use tokio::sync::mpsc;
+use tracing::{debug, info, instrument, warn, Instrument};
+
+use aletheia_hermeneus::provider::ProviderRegistry;
+use aletheia_koina::id::{NousId, SessionId};
+use aletheia_organon::registry::ToolRegistry;
+use aletheia_organon::types::ToolContext;
+use aletheia_taxis::oikos::Oikos;
+
+use crate::config::{NousConfig, PipelineConfig};
+use crate::handle::NousHandle;
+use crate::message::{NousLifecycle, NousMessage, NousStatus};
+use crate::pipeline::TurnResult;
+use crate::session::SessionState;
+
+/// Default bounded channel capacity for the actor inbox.
+pub const DEFAULT_INBOX_CAPACITY: usize = 32;
+
+/// A single nous agent running as a Tokio actor.
+///
+/// Each actor owns its mutable state and processes messages sequentially
+/// from a bounded inbox. External code interacts via [`NousHandle`].
+pub struct NousActor {
+    id: String,
+    config: NousConfig,
+    pipeline_config: PipelineConfig,
+    inbox: mpsc::Receiver<NousMessage>,
+    lifecycle: NousLifecycle,
+    sessions: HashMap<String, SessionState>,
+    active_session: Option<String>,
+    providers: Arc<ProviderRegistry>,
+    tools: Arc<ToolRegistry>,
+    oikos: Arc<Oikos>,
+}
+
+impl NousActor {
+    /// Create a new actor. Use [`NousManager::spawn`](crate::manager::NousManager::spawn)
+    /// or [`spawn`] to start it.
+    pub(crate) fn new(
+        id: String,
+        config: NousConfig,
+        pipeline_config: PipelineConfig,
+        inbox: mpsc::Receiver<NousMessage>,
+        providers: Arc<ProviderRegistry>,
+        tools: Arc<ToolRegistry>,
+        oikos: Arc<Oikos>,
+    ) -> Self {
+        Self {
+            id,
+            config,
+            pipeline_config,
+            inbox,
+            lifecycle: NousLifecycle::Idle,
+            sessions: HashMap::new(),
+            active_session: None,
+            providers,
+            tools,
+            oikos,
+        }
+    }
+
+    /// Run the actor loop until shutdown or all handles are dropped.
+    #[instrument(skip(self), fields(nous.id = %self.id))]
+    pub async fn run(mut self) {
+        info!(lifecycle = %self.lifecycle, "actor started");
+
+        while let Some(msg) = self.inbox.recv().await {
+            match msg {
+                NousMessage::Turn {
+                    session_key,
+                    content,
+                    reply,
+                } => {
+                    self.handle_turn(session_key, content, reply).await;
+                }
+                NousMessage::Status { reply } => {
+                    self.handle_status(reply);
+                }
+                NousMessage::Sleep => {
+                    self.handle_sleep();
+                }
+                NousMessage::Wake => {
+                    self.handle_wake();
+                }
+                NousMessage::Shutdown => {
+                    info!("shutdown requested");
+                    break;
+                }
+            }
+        }
+
+        info!(lifecycle = %self.lifecycle, "actor stopped");
+    }
+
+    async fn handle_turn(
+        &mut self,
+        session_key: String,
+        content: String,
+        reply: tokio::sync::oneshot::Sender<crate::error::Result<TurnResult>>,
+    ) {
+        if self.lifecycle == NousLifecycle::Dormant {
+            debug!("auto-waking from dormant for turn");
+            self.lifecycle = NousLifecycle::Idle;
+        }
+
+        self.lifecycle = NousLifecycle::Active;
+        self.active_session = Some(session_key.clone());
+
+        let result = self.execute_turn(&session_key, &content).await;
+
+        self.active_session = None;
+        self.lifecycle = NousLifecycle::Idle;
+
+        // Ignore send error — caller may have dropped the receiver
+        let _ = reply.send(result);
+    }
+
+    async fn execute_turn(
+        &mut self,
+        session_key: &str,
+        content: &str,
+    ) -> crate::error::Result<TurnResult> {
+        let session = self
+            .sessions
+            .entry(session_key.to_owned())
+            .or_insert_with(|| {
+                let id = SessionId::new().to_string();
+                debug!(session_key, session_id = %id, "creating new session");
+                SessionState::new(id, session_key.to_owned(), &self.config)
+            });
+
+        session.next_turn();
+
+        let input = crate::pipeline::PipelineInput {
+            content: content.to_owned(),
+            session: session.clone(),
+            config: self.pipeline_config.clone(),
+        };
+
+        let nous_id = NousId::new(&self.id).map_err(|e| {
+            crate::error::ConfigSnafu {
+                message: format!("invalid nous id: {e}"),
+            }
+            .build()
+        })?;
+
+        let tool_ctx = ToolContext {
+            nous_id,
+            session_id: SessionId::new(),
+            workspace: self.oikos.nous_dir(&self.id),
+            allowed_roots: vec![self.oikos.root().to_path_buf()],
+        };
+
+        crate::pipeline::run_pipeline(
+            input,
+            &self.oikos,
+            &self.config,
+            &self.pipeline_config,
+            &self.providers,
+            &self.tools,
+            &tool_ctx,
+        )
+        .await
+    }
+
+    fn handle_status(&self, reply: tokio::sync::oneshot::Sender<NousStatus>) {
+        let status = NousStatus {
+            id: self.id.clone(),
+            lifecycle: self.lifecycle,
+            session_count: self.sessions.len(),
+            active_session: self.active_session.clone(),
+        };
+        let _ = reply.send(status);
+    }
+
+    fn handle_sleep(&mut self) {
+        match self.lifecycle {
+            NousLifecycle::Idle => {
+                debug!("transitioning to dormant");
+                self.lifecycle = NousLifecycle::Dormant;
+            }
+            NousLifecycle::Active => {
+                warn!("cannot sleep while active, ignoring");
+            }
+            NousLifecycle::Dormant => {
+                debug!("already dormant");
+            }
+        }
+    }
+
+    fn handle_wake(&mut self) {
+        match self.lifecycle {
+            NousLifecycle::Dormant => {
+                debug!("waking from dormant");
+                self.lifecycle = NousLifecycle::Idle;
+            }
+            NousLifecycle::Idle | NousLifecycle::Active => {
+                debug!(lifecycle = %self.lifecycle, "already awake");
+            }
+        }
+    }
+}
+
+/// Spawn a nous actor, returning its handle and join handle.
+///
+/// Creates a bounded channel with [`DEFAULT_INBOX_CAPACITY`], builds the actor,
+/// and starts it on the Tokio runtime.
+pub fn spawn(
+    config: NousConfig,
+    pipeline_config: PipelineConfig,
+    providers: Arc<ProviderRegistry>,
+    tools: Arc<ToolRegistry>,
+    oikos: Arc<Oikos>,
+) -> (NousHandle, tokio::task::JoinHandle<()>) {
+    let (tx, rx) = mpsc::channel(DEFAULT_INBOX_CAPACITY);
+    let id = config.id.clone();
+    let handle = NousHandle::new(id.clone(), tx);
+
+    let actor = NousActor::new(id.clone(), config, pipeline_config, rx, providers, tools, oikos);
+
+    let span = tracing::info_span!("nous_actor", nous.id = %id);
+    let join_handle = tokio::spawn(async move { actor.run().await }.instrument(span));
+
+    (handle, join_handle)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Mutex;
+
+    use aletheia_hermeneus::provider::LlmProvider;
+    use aletheia_hermeneus::types::{
+        CompletionRequest, CompletionResponse, ContentBlock, StopReason, Usage,
+    };
+
+    use super::*;
+
+    // --- Test infrastructure ---
+
+    struct MockProvider {
+        response: Mutex<CompletionResponse>,
+    }
+
+    impl LlmProvider for MockProvider {
+        fn complete(
+            &self,
+            _request: &CompletionRequest,
+        ) -> aletheia_hermeneus::error::Result<CompletionResponse> {
+            Ok(self.response.lock().expect("lock").clone())
+        }
+
+        fn supported_models(&self) -> &[&str] {
+            &["test-model"]
+        }
+
+        #[expect(clippy::unnecessary_literal_bound, reason = "trait requires &str")]
+        fn name(&self) -> &str {
+            "mock"
+        }
+    }
+
+    fn test_config() -> NousConfig {
+        NousConfig {
+            id: "test-agent".to_owned(),
+            model: "test-model".to_owned(),
+            ..NousConfig::default()
+        }
+    }
+
+    fn test_oikos() -> (tempfile::TempDir, Arc<Oikos>) {
+        let dir = tempfile::TempDir::new().expect("tmpdir");
+        let root = dir.path();
+        std::fs::create_dir_all(root.join("nous/test-agent")).expect("mkdir");
+        std::fs::create_dir_all(root.join("shared")).expect("mkdir");
+        std::fs::create_dir_all(root.join("theke")).expect("mkdir");
+        std::fs::write(root.join("nous/test-agent/SOUL.md"), "Test agent.").expect("write");
+        let oikos = Arc::new(Oikos::from_root(root));
+        (dir, oikos)
+    }
+
+    fn test_providers() -> Arc<ProviderRegistry> {
+        let mut providers = ProviderRegistry::new();
+        providers.register(Box::new(MockProvider {
+            response: Mutex::new(CompletionResponse {
+                id: "resp-1".to_owned(),
+                model: "test-model".to_owned(),
+                stop_reason: StopReason::EndTurn,
+                content: vec![ContentBlock::Text {
+                    text: "Hello from actor!".to_owned(),
+                }],
+                usage: Usage {
+                    input_tokens: 100,
+                    output_tokens: 50,
+                    ..Usage::default()
+                },
+            }),
+        }));
+        Arc::new(providers)
+    }
+
+    fn spawn_test_actor() -> (
+        NousHandle,
+        tokio::task::JoinHandle<()>,
+        tempfile::TempDir,
+    ) {
+        let (dir, oikos) = test_oikos();
+        let providers = test_providers();
+        let tools = Arc::new(ToolRegistry::new());
+        let config = test_config();
+        let pipeline_config = PipelineConfig::default();
+
+        let (handle, join) = spawn(config, pipeline_config, providers, tools, oikos);
+        (handle, join, dir)
+    }
+
+    // --- Tests ---
+
+    #[tokio::test]
+    async fn turn_processes_and_returns_result() {
+        let (handle, join, _dir) = spawn_test_actor();
+
+        let result = handle.send_turn("main", "Hello").await.expect("turn");
+        assert_eq!(result.content, "Hello from actor!");
+        assert_eq!(result.usage.llm_calls, 1);
+
+        handle.shutdown().await.expect("shutdown");
+        join.await.expect("join");
+    }
+
+    #[tokio::test]
+    async fn status_returns_snapshot() {
+        let (handle, join, _dir) = spawn_test_actor();
+
+        let status = handle.status().await.expect("status");
+        assert_eq!(status.id, "test-agent");
+        assert_eq!(status.lifecycle, NousLifecycle::Idle);
+        assert_eq!(status.session_count, 0);
+        assert!(status.active_session.is_none());
+
+        handle.shutdown().await.expect("shutdown");
+        join.await.expect("join");
+    }
+
+    #[tokio::test]
+    async fn sleep_transitions_to_dormant() {
+        let (handle, join, _dir) = spawn_test_actor();
+
+        handle.sleep().await.expect("sleep");
+        let status = handle.status().await.expect("status");
+        assert_eq!(status.lifecycle, NousLifecycle::Dormant);
+
+        handle.shutdown().await.expect("shutdown");
+        join.await.expect("join");
+    }
+
+    #[tokio::test]
+    async fn wake_transitions_to_idle() {
+        let (handle, join, _dir) = spawn_test_actor();
+
+        handle.sleep().await.expect("sleep");
+        handle.wake().await.expect("wake");
+        let status = handle.status().await.expect("status");
+        assert_eq!(status.lifecycle, NousLifecycle::Idle);
+
+        handle.shutdown().await.expect("shutdown");
+        join.await.expect("join");
+    }
+
+    #[tokio::test]
+    async fn dormant_auto_wakes_on_turn() {
+        let (handle, join, _dir) = spawn_test_actor();
+
+        handle.sleep().await.expect("sleep");
+        let status = handle.status().await.expect("status");
+        assert_eq!(status.lifecycle, NousLifecycle::Dormant);
+
+        let result = handle.send_turn("main", "Wake up").await.expect("turn");
+        assert_eq!(result.content, "Hello from actor!");
+
+        let status = handle.status().await.expect("status");
+        assert_eq!(status.lifecycle, NousLifecycle::Idle);
+
+        handle.shutdown().await.expect("shutdown");
+        join.await.expect("join");
+    }
+
+    #[tokio::test]
+    async fn shutdown_exits_loop() {
+        let (handle, join, _dir) = spawn_test_actor();
+
+        handle.shutdown().await.expect("shutdown");
+        join.await.expect("join");
+    }
+
+    #[tokio::test]
+    async fn actor_exits_when_all_handles_dropped() {
+        let (handle, join, _dir) = spawn_test_actor();
+        drop(handle);
+        join.await.expect("join");
+    }
+
+    #[tokio::test]
+    async fn multiple_sequential_turns() {
+        let (handle, join, _dir) = spawn_test_actor();
+
+        for i in 0..5 {
+            let result = handle
+                .send_turn("main", format!("Turn {i}"))
+                .await
+                .expect("turn");
+            assert_eq!(result.content, "Hello from actor!");
+        }
+
+        let status = handle.status().await.expect("status");
+        assert_eq!(status.session_count, 1);
+
+        handle.shutdown().await.expect("shutdown");
+        join.await.expect("join");
+    }
+
+    #[tokio::test]
+    async fn turn_creates_session_for_unknown_key() {
+        let (handle, join, _dir) = spawn_test_actor();
+
+        handle.send_turn("session-a", "Hello").await.expect("turn");
+        handle.send_turn("session-b", "World").await.expect("turn");
+
+        let status = handle.status().await.expect("status");
+        assert_eq!(status.session_count, 2);
+
+        handle.shutdown().await.expect("shutdown");
+        join.await.expect("join");
+    }
+
+    #[tokio::test]
+    async fn status_after_turn_shows_idle_and_session() {
+        let (handle, join, _dir) = spawn_test_actor();
+
+        handle.send_turn("main", "Hello").await.expect("turn");
+
+        let status = handle.status().await.expect("status");
+        assert_eq!(status.lifecycle, NousLifecycle::Idle);
+        assert_eq!(status.session_count, 1);
+        assert!(status.active_session.is_none());
+
+        handle.shutdown().await.expect("shutdown");
+        join.await.expect("join");
+    }
+
+    #[tokio::test]
+    async fn sleep_then_sleep_is_idempotent() {
+        let (handle, join, _dir) = spawn_test_actor();
+
+        handle.sleep().await.expect("sleep");
+        handle.sleep().await.expect("sleep again");
+        let status = handle.status().await.expect("status");
+        assert_eq!(status.lifecycle, NousLifecycle::Dormant);
+
+        handle.shutdown().await.expect("shutdown");
+        join.await.expect("join");
+    }
+
+    #[tokio::test]
+    async fn wake_when_idle_is_noop() {
+        let (handle, join, _dir) = spawn_test_actor();
+
+        handle.wake().await.expect("wake");
+        let status = handle.status().await.expect("status");
+        assert_eq!(status.lifecycle, NousLifecycle::Idle);
+
+        handle.shutdown().await.expect("shutdown");
+        join.await.expect("join");
+    }
+
+    #[tokio::test]
+    async fn send_after_shutdown_returns_error() {
+        let (handle, join, _dir) = spawn_test_actor();
+
+        handle.shutdown().await.expect("shutdown");
+        join.await.expect("join");
+
+        let err = handle.send_turn("main", "Hello").await;
+        assert!(err.is_err());
+        assert!(err.unwrap_err().to_string().contains("inbox closed"));
+    }
+
+    #[tokio::test]
+    async fn handle_clone_works() {
+        let (handle, join, _dir) = spawn_test_actor();
+
+        let handle2 = handle.clone();
+        let status = handle2.status().await.expect("status");
+        assert_eq!(status.id, "test-agent");
+
+        handle.shutdown().await.expect("shutdown");
+        join.await.expect("join");
+    }
+
+    #[test]
+    fn send_sync_assertions() {
+        static_assertions::assert_impl_all!(NousHandle: Send, Sync, Clone);
+        static_assertions::assert_impl_all!(NousMessage: Send);
+        static_assertions::assert_impl_all!(NousStatus: Send, Sync);
+        static_assertions::assert_impl_all!(NousLifecycle: Send, Sync, Copy);
+    }
+
+    #[test]
+    fn default_inbox_capacity_is_32() {
+        assert_eq!(DEFAULT_INBOX_CAPACITY, 32);
+    }
+}

--- a/crates/nous/src/error.rs
+++ b/crates/nous/src/error.rs
@@ -64,6 +64,22 @@ pub enum Error {
         #[snafu(implicit)]
         location: snafu::Location,
     },
+
+    /// Actor inbox send failed (actor shut down).
+    #[snafu(display("actor send failed: {message}"))]
+    ActorSend {
+        message: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    /// Actor reply receive failed (actor dropped reply channel).
+    #[snafu(display("actor recv failed: {message}"))]
+    ActorRecv {
+        message: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/crates/nous/src/handle.rs
+++ b/crates/nous/src/handle.rs
@@ -1,0 +1,117 @@
+//! Cloneable actor handle for sending messages to a [`NousActor`](crate::actor::NousActor).
+
+use tokio::sync::{mpsc, oneshot};
+
+use crate::error::{self, ActorRecvSnafu, ActorSendSnafu};
+use crate::message::{NousMessage, NousStatus};
+use crate::pipeline::TurnResult;
+
+/// Cloneable handle for communicating with a nous actor.
+///
+/// All external interaction with a [`NousActor`](crate::actor::NousActor) goes through its handle.
+/// The handle is `Clone + Send + Sync` — safe to share across tasks.
+#[derive(Clone)]
+pub struct NousHandle {
+    id: String,
+    sender: mpsc::Sender<NousMessage>,
+}
+
+impl NousHandle {
+    /// Create a new handle from an actor id and sender.
+    pub(crate) fn new(id: String, sender: mpsc::Sender<NousMessage>) -> Self {
+        Self { id, sender }
+    }
+
+    /// Agent identifier.
+    #[must_use]
+    pub fn id(&self) -> &str {
+        &self.id
+    }
+
+    /// Send a turn message and await the result.
+    pub async fn send_turn(
+        &self,
+        session_key: impl Into<String>,
+        content: impl Into<String>,
+    ) -> error::Result<TurnResult> {
+        let (tx, rx) = oneshot::channel();
+        self.sender
+            .send(NousMessage::Turn {
+                session_key: session_key.into(),
+                content: content.into(),
+                reply: tx,
+            })
+            .await
+            .map_err(|_send_err| {
+                ActorSendSnafu {
+                    message: format!("actor '{}' inbox closed", self.id),
+                }
+                .build()
+            })?;
+        rx.await.map_err(|_send_err| {
+            ActorRecvSnafu {
+                message: format!("actor '{}' dropped reply", self.id),
+            }
+            .build()
+        })?
+    }
+
+    /// Query the actor's current status.
+    pub async fn status(&self) -> error::Result<NousStatus> {
+        let (tx, rx) = oneshot::channel();
+        self.sender
+            .send(NousMessage::Status { reply: tx })
+            .await
+            .map_err(|_send_err| {
+                ActorSendSnafu {
+                    message: format!("actor '{}' inbox closed", self.id),
+                }
+                .build()
+            })?;
+        rx.await.map_err(|_send_err| {
+            ActorRecvSnafu {
+                message: format!("actor '{}' dropped reply", self.id),
+            }
+            .build()
+        })
+    }
+
+    /// Transition the actor to dormant state.
+    pub async fn sleep(&self) -> error::Result<()> {
+        self.sender
+            .send(NousMessage::Sleep)
+            .await
+            .map_err(|_send_err| {
+                ActorSendSnafu {
+                    message: format!("actor '{}' inbox closed", self.id),
+                }
+                .build()
+            })
+    }
+
+    /// Wake the actor from dormant state.
+    pub async fn wake(&self) -> error::Result<()> {
+        self.sender
+            .send(NousMessage::Wake)
+            .await
+            .map_err(|_send_err| {
+                ActorSendSnafu {
+                    message: format!("actor '{}' inbox closed", self.id),
+                }
+                .build()
+            })
+    }
+
+    /// Request graceful shutdown.
+    pub async fn shutdown(&self) -> error::Result<()> {
+        self.sender
+            .send(NousMessage::Shutdown)
+            .await
+            .map_err(|_send_err| {
+                ActorSendSnafu {
+                    message: format!("actor '{}' inbox closed", self.id),
+                }
+                .build()
+            })
+    }
+}

--- a/crates/nous/src/lib.rs
+++ b/crates/nous/src/lib.rs
@@ -6,10 +6,14 @@
 //!
 //! Depends on all foundation crates: koina, taxis, mneme, hermeneus.
 
+pub mod actor;
 pub mod bootstrap;
 pub mod budget;
 pub mod config;
 pub mod error;
 pub mod execute;
+pub mod handle;
+pub mod manager;
+pub mod message;
 pub mod pipeline;
 pub mod session;

--- a/crates/nous/src/manager.rs
+++ b/crates/nous/src/manager.rs
@@ -1,0 +1,323 @@
+//! Manages all nous actor instances.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use tokio::task::JoinHandle;
+use tracing::{info, warn};
+
+use aletheia_hermeneus::provider::ProviderRegistry;
+use aletheia_organon::registry::ToolRegistry;
+use aletheia_taxis::oikos::Oikos;
+
+use crate::actor;
+use crate::config::{NousConfig, PipelineConfig};
+use crate::handle::NousHandle;
+use crate::message::NousStatus;
+
+/// Manages the lifecycle of all nous actors.
+pub struct NousManager {
+    actors: HashMap<String, (NousHandle, JoinHandle<()>)>,
+    providers: Arc<ProviderRegistry>,
+    tools: Arc<ToolRegistry>,
+    oikos: Arc<Oikos>,
+}
+
+impl NousManager {
+    /// Create a new manager with shared dependencies.
+    #[must_use]
+    pub fn new(
+        providers: Arc<ProviderRegistry>,
+        tools: Arc<ToolRegistry>,
+        oikos: Arc<Oikos>,
+    ) -> Self {
+        Self {
+            actors: HashMap::new(),
+            providers,
+            tools,
+            oikos,
+        }
+    }
+
+    /// Spawn a new nous actor and return its handle.
+    ///
+    /// If an actor with the same id already exists, the old actor is shut down first.
+    pub async fn spawn(&mut self, config: NousConfig, pipeline_config: PipelineConfig) -> NousHandle {
+        let id = config.id.clone();
+
+        if let Some((old_handle, old_join)) = self.actors.remove(&id) {
+            warn!(nous_id = %id, "replacing existing actor");
+            let _ = old_handle.shutdown().await;
+            let _ = old_join.await;
+        }
+
+        let (handle, join_handle) = actor::spawn(
+            config,
+            pipeline_config,
+            Arc::clone(&self.providers),
+            Arc::clone(&self.tools),
+            Arc::clone(&self.oikos),
+        );
+
+        info!(nous_id = %id, "actor spawned");
+        self.actors.insert(id, (handle.clone(), join_handle));
+        handle
+    }
+
+    /// Look up a handle by nous id.
+    #[must_use]
+    pub fn get(&self, nous_id: &str) -> Option<&NousHandle> {
+        self.actors.get(nous_id).map(|(h, _)| h)
+    }
+
+    /// Query status from all actors.
+    pub async fn list(&self) -> Vec<NousStatus> {
+        let mut statuses = Vec::with_capacity(self.actors.len());
+        for (handle, _) in self.actors.values() {
+            match handle.status().await {
+                Ok(status) => statuses.push(status),
+                Err(_) => {
+                    warn!(nous_id = handle.id(), "failed to query actor status");
+                }
+            }
+        }
+        statuses
+    }
+
+    /// Gracefully shut down all actors.
+    pub async fn shutdown_all(&mut self) {
+        info!(count = self.actors.len(), "shutting down all actors");
+
+        let entries: Vec<(String, NousHandle, JoinHandle<()>)> = self
+            .actors
+            .drain()
+            .map(|(id, (handle, join))| (id, handle, join))
+            .collect();
+
+        for (id, handle, _) in &entries {
+            if let Err(e) = handle.shutdown().await {
+                warn!(nous_id = %id, error = %e, "failed to send shutdown");
+            }
+        }
+
+        for (id, _, join) in entries {
+            if let Err(e) = join.await {
+                warn!(nous_id = %id, error = %e, "actor task panicked");
+            }
+        }
+
+        info!("all actors stopped");
+    }
+
+    /// Number of managed actors.
+    #[must_use]
+    pub fn count(&self) -> usize {
+        self.actors.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Mutex;
+
+    use aletheia_hermeneus::provider::LlmProvider;
+    use aletheia_hermeneus::types::{
+        CompletionRequest, CompletionResponse, ContentBlock, StopReason, Usage,
+    };
+
+    use super::*;
+    use crate::message::NousLifecycle;
+
+    struct MockProvider {
+        response: Mutex<CompletionResponse>,
+    }
+
+    impl LlmProvider for MockProvider {
+        fn complete(
+            &self,
+            _request: &CompletionRequest,
+        ) -> aletheia_hermeneus::error::Result<CompletionResponse> {
+            Ok(self.response.lock().expect("lock").clone())
+        }
+
+        fn supported_models(&self) -> &[&str] {
+            &["test-model"]
+        }
+
+        #[expect(clippy::unnecessary_literal_bound, reason = "trait requires &str")]
+        fn name(&self) -> &str {
+            "mock"
+        }
+    }
+
+    fn test_oikos() -> (tempfile::TempDir, Arc<Oikos>) {
+        let dir = tempfile::TempDir::new().expect("tmpdir");
+        let root = dir.path();
+        std::fs::create_dir_all(root.join("nous/syn")).expect("mkdir");
+        std::fs::create_dir_all(root.join("nous/demiurge")).expect("mkdir");
+        std::fs::create_dir_all(root.join("shared")).expect("mkdir");
+        std::fs::create_dir_all(root.join("theke")).expect("mkdir");
+        std::fs::write(root.join("nous/syn/SOUL.md"), "I am Syn.").expect("write");
+        std::fs::write(root.join("nous/demiurge/SOUL.md"), "I am Demiurge.").expect("write");
+        let oikos = Arc::new(Oikos::from_root(root));
+        (dir, oikos)
+    }
+
+    fn test_providers() -> Arc<ProviderRegistry> {
+        let mut providers = ProviderRegistry::new();
+        providers.register(Box::new(MockProvider {
+            response: Mutex::new(CompletionResponse {
+                id: "resp-1".to_owned(),
+                model: "test-model".to_owned(),
+                stop_reason: StopReason::EndTurn,
+                content: vec![ContentBlock::Text {
+                    text: "Hello!".to_owned(),
+                }],
+                usage: Usage {
+                    input_tokens: 100,
+                    output_tokens: 50,
+                    ..Usage::default()
+                },
+            }),
+        }));
+        Arc::new(providers)
+    }
+
+    fn test_manager(oikos: Arc<Oikos>) -> NousManager {
+        NousManager::new(test_providers(), Arc::new(ToolRegistry::new()), oikos)
+    }
+
+    fn syn_config() -> NousConfig {
+        NousConfig {
+            id: "syn".to_owned(),
+            model: "test-model".to_owned(),
+            ..NousConfig::default()
+        }
+    }
+
+    fn demiurge_config() -> NousConfig {
+        NousConfig {
+            id: "demiurge".to_owned(),
+            model: "test-model".to_owned(),
+            ..NousConfig::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn spawn_returns_handle() {
+        let (_dir, oikos) = test_oikos();
+        let mut mgr = test_manager(oikos);
+
+        let handle = mgr.spawn(syn_config(), PipelineConfig::default()).await;
+        assert_eq!(handle.id(), "syn");
+        assert_eq!(mgr.count(), 1);
+
+        mgr.shutdown_all().await;
+    }
+
+    #[tokio::test]
+    async fn get_finds_spawned_actor() {
+        let (_dir, oikos) = test_oikos();
+        let mut mgr = test_manager(oikos);
+
+        mgr.spawn(syn_config(), PipelineConfig::default()).await;
+
+        let handle = mgr.get("syn").expect("found");
+        assert_eq!(handle.id(), "syn");
+
+        mgr.shutdown_all().await;
+    }
+
+    #[tokio::test]
+    async fn get_returns_none_for_unknown() {
+        let (_dir, oikos) = test_oikos();
+        let mgr = test_manager(oikos);
+        assert!(mgr.get("unknown").is_none());
+    }
+
+    #[tokio::test]
+    async fn list_returns_all_statuses() {
+        let (_dir, oikos) = test_oikos();
+        let mut mgr = test_manager(oikos);
+
+        mgr.spawn(syn_config(), PipelineConfig::default()).await;
+        mgr.spawn(demiurge_config(), PipelineConfig::default()).await;
+
+        let statuses = mgr.list().await;
+        assert_eq!(statuses.len(), 2);
+
+        let ids: Vec<&str> = statuses.iter().map(|s| s.id.as_str()).collect();
+        assert!(ids.contains(&"syn"));
+        assert!(ids.contains(&"demiurge"));
+
+        mgr.shutdown_all().await;
+    }
+
+    #[tokio::test]
+    async fn shutdown_all_stops_all_actors() {
+        let (_dir, oikos) = test_oikos();
+        let mut mgr = test_manager(oikos);
+
+        let handle1 = mgr.spawn(syn_config(), PipelineConfig::default()).await;
+        let handle2 = mgr.spawn(demiurge_config(), PipelineConfig::default()).await;
+
+        mgr.shutdown_all().await;
+
+        assert_eq!(mgr.count(), 0);
+        assert!(handle1.status().await.is_err());
+        assert!(handle2.status().await.is_err());
+    }
+
+    #[tokio::test]
+    async fn spawn_multiple_actors() {
+        let (_dir, oikos) = test_oikos();
+        let mut mgr = test_manager(oikos);
+
+        mgr.spawn(syn_config(), PipelineConfig::default()).await;
+        mgr.spawn(demiurge_config(), PipelineConfig::default()).await;
+
+        assert_eq!(mgr.count(), 2);
+
+        let syn = mgr.get("syn").expect("syn");
+        let dem = mgr.get("demiurge").expect("demiurge");
+
+        let s1 = syn.status().await.expect("status");
+        let s2 = dem.status().await.expect("status");
+        assert_eq!(s1.lifecycle, NousLifecycle::Idle);
+        assert_eq!(s2.lifecycle, NousLifecycle::Idle);
+
+        mgr.shutdown_all().await;
+    }
+
+    #[tokio::test]
+    async fn spawn_replaces_existing_actor() {
+        let (_dir, oikos) = test_oikos();
+        let mut mgr = test_manager(oikos);
+
+        let old_handle = mgr.spawn(syn_config(), PipelineConfig::default()).await;
+        let new_handle = mgr.spawn(syn_config(), PipelineConfig::default()).await;
+
+        assert_eq!(mgr.count(), 1);
+
+        // Old handle should be disconnected
+        assert!(old_handle.status().await.is_err());
+
+        // New handle should work
+        let status = new_handle.status().await.expect("status");
+        assert_eq!(status.id, "syn");
+
+        mgr.shutdown_all().await;
+    }
+
+    #[tokio::test]
+    async fn manager_turn_through_handle() {
+        let (_dir, oikos) = test_oikos();
+        let mut mgr = test_manager(oikos);
+
+        let handle = mgr.spawn(syn_config(), PipelineConfig::default()).await;
+        let result = handle.send_turn("main", "Hello").await.expect("turn");
+        assert_eq!(result.content, "Hello!");
+
+        mgr.shutdown_all().await;
+    }
+}

--- a/crates/nous/src/message.rs
+++ b/crates/nous/src/message.rs
@@ -1,0 +1,95 @@
+//! Actor message types, lifecycle state machine, and status snapshots.
+
+use std::fmt;
+
+use tokio::sync::oneshot;
+
+use crate::error;
+use crate::pipeline::TurnResult;
+
+/// Messages sent to a [`NousActor`](crate::actor::NousActor) via its inbox.
+pub enum NousMessage {
+    /// Process a user message in a session.
+    Turn {
+        session_key: String,
+        content: String,
+        reply: oneshot::Sender<error::Result<TurnResult>>,
+    },
+    /// Query current lifecycle state.
+    Status {
+        reply: oneshot::Sender<NousStatus>,
+    },
+    /// Transition to dormant (sleep).
+    Sleep,
+    /// Wake from dormant.
+    Wake,
+    /// Graceful shutdown.
+    Shutdown,
+}
+
+/// Lifecycle state machine for a nous actor.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NousLifecycle {
+    /// Processing a turn or background task.
+    Active,
+    /// Waiting for messages, no active work.
+    Idle,
+    /// Paused, inbox buffered. Wakes on message or schedule.
+    Dormant,
+}
+
+impl fmt::Display for NousLifecycle {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Active => write!(f, "active"),
+            Self::Idle => write!(f, "idle"),
+            Self::Dormant => write!(f, "dormant"),
+        }
+    }
+}
+
+/// Snapshot of a nous actor's current state.
+#[derive(Debug, Clone)]
+pub struct NousStatus {
+    /// Agent identifier.
+    pub id: String,
+    /// Current lifecycle state.
+    pub lifecycle: NousLifecycle,
+    /// Number of sessions tracked.
+    pub session_count: usize,
+    /// Currently active session key, if any.
+    pub active_session: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lifecycle_display() {
+        assert_eq!(NousLifecycle::Active.to_string(), "active");
+        assert_eq!(NousLifecycle::Idle.to_string(), "idle");
+        assert_eq!(NousLifecycle::Dormant.to_string(), "dormant");
+    }
+
+    #[test]
+    fn lifecycle_equality() {
+        assert_eq!(NousLifecycle::Active, NousLifecycle::Active);
+        assert_ne!(NousLifecycle::Active, NousLifecycle::Idle);
+        assert_ne!(NousLifecycle::Idle, NousLifecycle::Dormant);
+    }
+
+    #[test]
+    fn status_construction() {
+        let status = NousStatus {
+            id: "syn".to_owned(),
+            lifecycle: NousLifecycle::Idle,
+            session_count: 3,
+            active_session: None,
+        };
+        assert_eq!(status.id, "syn");
+        assert_eq!(status.lifecycle, NousLifecycle::Idle);
+        assert_eq!(status.session_count, 3);
+        assert!(status.active_session.is_none());
+    }
+}


### PR DESCRIPTION
## Summary

- Implements the Tokio actor model for nous agents: `NousActor`, `NousHandle`, `NousMessage`, `NousManager`
- Each agent gets its own bounded mpsc inbox (capacity 32), lifecycle state machine (Active/Idle/Dormant), and session tracking
- `NousHandle` is Clone+Send+Sync — all external interaction goes through the handle
- `NousManager` spawns actors, provides lookup, and handles graceful shutdown
- Dormant actors auto-wake on Turn messages
- 27 new tests covering message dispatch, lifecycle transitions, handle methods, manager operations, and Send+Sync assertions

## Files

**New:** `actor.rs`, `handle.rs`, `manager.rs`, `message.rs`
**Modified:** `lib.rs`, `error.rs` (ActorSend/ActorRecv variants), `Cargo.toml` (tokio sync feature)

## Test plan

- [x] `cargo clippy --workspace --all-targets -- -D warnings` (clean, excluding pre-existing mneme-engine issues)
- [x] `cargo test --workspace` — 105 nous tests pass (27 new)
- [x] `cargo doc --workspace --no-deps` — builds (pre-existing budget.rs warning only)
- [x] Turn processing through full pipeline with MockProvider
- [x] Lifecycle state machine: Idle→Active→Idle, Idle→Dormant→Idle, Dormant auto-wake
- [x] Graceful shutdown via message and handle drop
- [x] Manager spawn/get/list/shutdown_all
- [x] static_assertions for Send+Sync+Clone on NousHandle