### PR TITLE
feat(melete): context distillation engine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -129,6 +129,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "aletheia-melete"
+version = "0.1.0"
+dependencies = [
+ "aletheia-hermeneus",
+ "aletheia-koina",
+ "jiff",
+ "serde",
+ "serde_json",
+ "snafu",
+ "static_assertions",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "aletheia-mneme"
 version = "0.1.0"
 dependencies = [
@@ -2406,10 +2421,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "819b44bc7c87d9117eb522f14d46e918add69ff12713c475946b0a29363ed1c2"
 dependencies = [
  "jiff-static",
+ "jiff-tzdb-platform",
  "log",
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2421,6 +2438,21 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1283705eb0a21404d2bfd6eef2a7593d240bc42a0bdb39db0ad6fa2ec026524"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
+dependencies = [
+ "jiff-tzdb",
 ]
 
 [[package]]
@@ -4715,6 +4747,7 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
+ "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "crates/integration-tests",
     "crates/koina",
     "crates/mneme",
+    "crates/melete",
     "crates/mneme-engine",
     "crates/nous",
     "crates/organon",
@@ -91,6 +92,9 @@ uuid = { version = "1", features = ["v4"] }
 compact_str = { version = "0.8", features = ["serde"] }
 indexmap = { version = "2", features = ["serde"] }
 ulid = { version = "1", features = ["serde"] }
+
+# Time
+jiff = "0.2"
 
 # Async
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "signal", "sync"] }

--- a/crates/melete/Cargo.toml
+++ b/crates/melete/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "aletheia-melete"
+version = "0.1.0"
+description = "Context distillation engine — compresses conversation history"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+aletheia-koina = { path = "../koina" }
+aletheia-hermeneus = { path = "../hermeneus" }
+serde = { workspace = true }
+serde_json = { workspace = true }
+snafu = { workspace = true }
+tracing = { workspace = true }
+tokio = { workspace = true }
+jiff = { workspace = true }
+
+[dev-dependencies]
+tokio = { version = "1", features = ["full", "test-util"] }
+static_assertions = { workspace = true }

--- a/crates/melete/src/distill.rs
+++ b/crates/melete/src/distill.rs
@@ -1,0 +1,617 @@
+//! Context distillation engine.
+
+use aletheia_hermeneus::provider::LlmProvider;
+use aletheia_hermeneus::types::{CompletionRequest, Content, Message, Role};
+use snafu::ResultExt;
+use tracing::instrument;
+
+use crate::error::{EmptySummarySnafu, LlmCallSnafu, NoMessagesSnafu, Result};
+use crate::prompt::{self, DISTILLATION_SYSTEM_PROMPT};
+
+/// Configuration for a distillation run.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct DistillConfig {
+    /// Model to use for distillation.
+    pub model: String,
+    /// Maximum output tokens for the summary.
+    pub max_output_tokens: u32,
+    /// Minimum messages before distillation is worthwhile.
+    pub min_messages: usize,
+    /// Whether to include tool call details in the summary.
+    pub include_tool_calls: bool,
+}
+
+impl Default for DistillConfig {
+    fn default() -> Self {
+        Self {
+            model: "claude-sonnet-4-20250514".to_owned(),
+            max_output_tokens: 4096,
+            min_messages: 6,
+            include_tool_calls: true,
+        }
+    }
+}
+
+/// Result of a distillation run.
+#[derive(Debug, Clone)]
+pub struct DistillResult {
+    /// The distilled summary text.
+    pub summary: String,
+    /// Number of messages that were distilled.
+    pub messages_distilled: usize,
+    /// Estimated tokens before distillation.
+    pub tokens_before: u64,
+    /// Estimated tokens after distillation.
+    pub tokens_after: u64,
+    /// Which distillation number this is for the session.
+    pub distillation_number: u32,
+    /// Timestamp of distillation (ISO 8601).
+    pub timestamp: String,
+}
+
+/// The distillation engine.
+#[derive(Debug)]
+pub struct DistillEngine {
+    config: DistillConfig,
+}
+
+impl DistillEngine {
+    /// Create a new distillation engine.
+    pub fn new(config: DistillConfig) -> Self {
+        Self { config }
+    }
+
+    /// Check if the given messages warrant distillation.
+    ///
+    /// Returns true when message count meets the minimum AND
+    /// the token estimate exceeds the threshold ratio of the context window.
+    pub fn should_distill(
+        &self,
+        message_count: usize,
+        token_estimate: u64,
+        context_window: u64,
+        threshold: f64,
+    ) -> bool {
+        if message_count < self.config.min_messages {
+            return false;
+        }
+        if context_window == 0 {
+            return false;
+        }
+        #[expect(clippy::cast_precision_loss, reason = "token counts fit in f64 mantissa")]
+        let ratio = token_estimate as f64 / context_window as f64;
+        ratio >= threshold
+    }
+
+    /// Build the distillation prompt for the given messages.
+    pub fn build_prompt(&self, messages: &[Message], nous_id: &str) -> CompletionRequest {
+        let formatted = prompt::format_messages(messages, self.config.include_tool_calls);
+
+        let user_content = format!(
+            "Distill the following conversation from nous \"{nous_id}\" \
+             (distillation context: {msg_count} messages).\n\n\
+             ---\n\n{formatted}",
+            msg_count = messages.len(),
+        );
+
+        CompletionRequest {
+            model: self.config.model.clone(),
+            system: Some(DISTILLATION_SYSTEM_PROMPT.to_owned()),
+            messages: vec![Message {
+                role: Role::User,
+                content: Content::Text(user_content),
+            }],
+            max_tokens: self.config.max_output_tokens,
+            tools: vec![],
+            temperature: Some(0.0),
+            thinking: None,
+            stop_sequences: vec![],
+        }
+    }
+
+    /// Run distillation: call LLM, return the summary.
+    #[instrument(skip(self, messages, provider), fields(nous_id, distillation_number))]
+    pub async fn distill(
+        &self,
+        messages: &[Message],
+        nous_id: &str,
+        provider: &dyn LlmProvider,
+        distillation_number: u32,
+    ) -> Result<DistillResult> {
+        if messages.is_empty() {
+            return NoMessagesSnafu.fail();
+        }
+
+        let tokens_before = estimate_tokens(messages);
+        let request = self.build_prompt(messages, nous_id);
+        let response = provider.complete(&request).context(LlmCallSnafu)?;
+
+        let summary = extract_summary_text(&response.content);
+        if summary.is_empty() {
+            return EmptySummarySnafu.fail();
+        }
+
+        let tokens_after = response.usage.output_tokens;
+        let timestamp = jiff::Timestamp::now().to_string();
+
+        Ok(DistillResult {
+            summary,
+            messages_distilled: messages.len(),
+            tokens_before,
+            tokens_after,
+            distillation_number,
+            timestamp,
+        })
+    }
+
+    /// Access the engine configuration.
+    pub fn config(&self) -> &DistillConfig {
+        &self.config
+    }
+}
+
+/// Estimate token count from messages using chars/4 heuristic.
+fn estimate_tokens(messages: &[Message]) -> u64 {
+    let total_chars: usize = messages
+        .iter()
+        .map(|m| m.content.text().len())
+        .sum();
+    (total_chars as u64).div_ceil(4)
+}
+
+/// Extract plain text from response content blocks.
+fn extract_summary_text(content: &[aletheia_hermeneus::types::ContentBlock]) -> String {
+    content
+        .iter()
+        .filter_map(|block| match block {
+            aletheia_hermeneus::types::ContentBlock::Text { text } => Some(text.as_str()),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+        .trim()
+        .to_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use aletheia_hermeneus::types::{
+        CompletionResponse, ContentBlock, StopReason, Usage,
+    };
+
+    use super::*;
+
+    // --- Mock provider ---
+
+    struct MockProvider {
+        response: std::sync::Mutex<Option<aletheia_hermeneus::error::Result<CompletionResponse>>>,
+    }
+
+    impl MockProvider {
+        fn success(summary: &str) -> Self {
+            Self {
+                response: std::sync::Mutex::new(Some(Ok(CompletionResponse {
+                    id: "msg_distill_1".to_owned(),
+                    model: "claude-sonnet-4-20250514".to_owned(),
+                    stop_reason: StopReason::EndTurn,
+                    content: vec![ContentBlock::Text {
+                        text: summary.to_owned(),
+                    }],
+                    usage: Usage {
+                        input_tokens: 5000,
+                        output_tokens: 200,
+                        cache_read_tokens: 0,
+                        cache_write_tokens: 0,
+                    },
+                }))),
+            }
+        }
+
+        fn empty_response() -> Self {
+            Self {
+                response: std::sync::Mutex::new(Some(Ok(CompletionResponse {
+                    id: "msg_empty".to_owned(),
+                    model: "claude-sonnet-4-20250514".to_owned(),
+                    stop_reason: StopReason::EndTurn,
+                    content: vec![],
+                    usage: Usage::default(),
+                }))),
+            }
+        }
+
+        fn empty_text_blocks() -> Self {
+            Self {
+                response: std::sync::Mutex::new(Some(Ok(CompletionResponse {
+                    id: "msg_empty_text".to_owned(),
+                    model: "claude-sonnet-4-20250514".to_owned(),
+                    stop_reason: StopReason::EndTurn,
+                    content: vec![
+                        ContentBlock::Text {
+                            text: String::new(),
+                        },
+                        ContentBlock::Text {
+                            text: "   ".to_owned(),
+                        },
+                    ],
+                    usage: Usage::default(),
+                }))),
+            }
+        }
+
+        fn failure() -> Self {
+            Self {
+                response: std::sync::Mutex::new(Some(Err(
+                    aletheia_hermeneus::error::ApiRequestSnafu {
+                        message: "network timeout".to_owned(),
+                    }
+                    .build(),
+                ))),
+            }
+        }
+    }
+
+    impl LlmProvider for MockProvider {
+        fn complete(
+            &self,
+            _request: &CompletionRequest,
+        ) -> aletheia_hermeneus::error::Result<CompletionResponse> {
+            self.response
+                .lock()
+                .expect("lock poisoned")
+                .take()
+                .expect("mock provider called more than once")
+        }
+
+        fn supported_models(&self) -> &[&str] {
+            &["claude-sonnet-4-20250514"]
+        }
+
+        #[expect(clippy::unnecessary_literal_bound)]
+        fn name(&self) -> &str {
+            "mock-distill"
+        }
+    }
+
+    // --- Helpers ---
+
+    fn text_msg(role: Role, text: &str) -> Message {
+        Message {
+            role,
+            content: Content::Text(text.to_owned()),
+        }
+    }
+
+    fn sample_conversation() -> Vec<Message> {
+        vec![
+            text_msg(Role::User, "Help me fix the login bug"),
+            text_msg(Role::Assistant, "I'll look at the auth module"),
+            text_msg(Role::User, "It's in src/auth/login.rs"),
+            text_msg(
+                Role::Assistant,
+                "Found the issue — missing null check on line 42",
+            ),
+            text_msg(Role::User, "Great, fix it please"),
+            text_msg(Role::Assistant, "Done. Added the check and a test."),
+        ]
+    }
+
+    fn default_engine() -> DistillEngine {
+        DistillEngine::new(DistillConfig::default())
+    }
+
+    const MOCK_SUMMARY: &str = "\
+## Summary
+Fixed login bug in auth module.
+
+## Task Context
+Working on a null pointer crash in the login flow.
+
+## Completed Work
+- Fixed null check on line 42 of src/auth/login.rs
+- Added regression test
+
+## Key Decisions
+- Decision: Add null check rather than restructure. Reason: Minimal change for the fix.
+
+## Current State
+Bug is fixed, test passes.
+
+## Open Threads
+- None
+
+## Corrections
+- Initially looked at wrong file before finding the issue in login.rs";
+
+    // --- should_distill tests ---
+
+    #[test]
+    fn should_distill_below_threshold_returns_false() {
+        let engine = default_engine();
+        assert!(!engine.should_distill(10, 50_000, 200_000, 0.8));
+    }
+
+    #[test]
+    fn should_distill_at_threshold_returns_true() {
+        let engine = default_engine();
+        assert!(engine.should_distill(10, 160_000, 200_000, 0.8));
+    }
+
+    #[test]
+    fn should_distill_above_threshold_returns_true() {
+        let engine = default_engine();
+        assert!(engine.should_distill(10, 190_000, 200_000, 0.8));
+    }
+
+    #[test]
+    fn should_distill_too_few_messages_returns_false() {
+        let engine = default_engine();
+        // 5 messages < min_messages (6), even though tokens exceed threshold
+        assert!(!engine.should_distill(5, 190_000, 200_000, 0.8));
+    }
+
+    #[test]
+    fn should_distill_zero_context_window_returns_false() {
+        let engine = default_engine();
+        assert!(!engine.should_distill(10, 100, 0, 0.8));
+    }
+
+    #[test]
+    fn should_distill_exact_min_messages() {
+        let engine = default_engine();
+        // Exactly 6 messages (min_messages) with tokens above threshold
+        assert!(engine.should_distill(6, 180_000, 200_000, 0.8));
+    }
+
+    // --- build_prompt tests ---
+
+    #[test]
+    fn build_prompt_has_system_prompt() {
+        let engine = default_engine();
+        let messages = sample_conversation();
+        let request = engine.build_prompt(&messages, "test-nous");
+
+        assert!(request.system.is_some());
+        let system = request.system.unwrap();
+        assert!(system.contains("## Summary"));
+        assert!(system.contains("## Key Decisions"));
+        assert!(system.contains("## Corrections"));
+    }
+
+    #[test]
+    fn build_prompt_includes_nous_id() {
+        let engine = default_engine();
+        let messages = sample_conversation();
+        let request = engine.build_prompt(&messages, "my-agent");
+
+        let user_text = request.messages[0].content.text();
+        assert!(user_text.contains("my-agent"));
+    }
+
+    #[test]
+    fn build_prompt_formats_messages_with_roles() {
+        let engine = default_engine();
+        let messages = sample_conversation();
+        let request = engine.build_prompt(&messages, "test-nous");
+
+        let user_text = request.messages[0].content.text();
+        assert!(user_text.contains("[USER]"));
+        assert!(user_text.contains("[ASSISTANT]"));
+    }
+
+    #[test]
+    fn build_prompt_uses_config_model() {
+        let config = DistillConfig {
+            model: "claude-haiku-4-5-20251001".to_owned(),
+            ..DistillConfig::default()
+        };
+        let engine = DistillEngine::new(config);
+        let request = engine.build_prompt(&sample_conversation(), "test");
+        assert_eq!(request.model, "claude-haiku-4-5-20251001");
+    }
+
+    #[test]
+    fn build_prompt_uses_config_max_tokens() {
+        let config = DistillConfig {
+            max_output_tokens: 2048,
+            ..DistillConfig::default()
+        };
+        let engine = DistillEngine::new(config);
+        let request = engine.build_prompt(&sample_conversation(), "test");
+        assert_eq!(request.max_tokens, 2048);
+    }
+
+    #[test]
+    fn build_prompt_no_tools() {
+        let engine = default_engine();
+        let request = engine.build_prompt(&sample_conversation(), "test");
+        assert!(request.tools.is_empty());
+    }
+
+    // --- distill tests ---
+
+    #[tokio::test]
+    async fn distill_success_returns_result() {
+        let engine = default_engine();
+        let messages = sample_conversation();
+        let provider = MockProvider::success(MOCK_SUMMARY);
+
+        let result = engine.distill(&messages, "test-nous", &provider, 1).await;
+        assert!(result.is_ok());
+
+        let result = result.unwrap();
+        assert!(result.summary.contains("Fixed login bug"));
+        assert_eq!(result.messages_distilled, 6);
+        assert_eq!(result.distillation_number, 1);
+    }
+
+    #[tokio::test]
+    async fn distill_token_estimates_populated() {
+        let engine = default_engine();
+        let messages = sample_conversation();
+        let provider = MockProvider::success(MOCK_SUMMARY);
+
+        let result = engine
+            .distill(&messages, "test-nous", &provider, 1)
+            .await
+            .unwrap();
+
+        assert!(result.tokens_before > 0);
+        assert_eq!(result.tokens_after, 200); // from mock Usage
+    }
+
+    #[tokio::test]
+    async fn distill_distillation_number_passed_through() {
+        let engine = default_engine();
+        let messages = sample_conversation();
+        let provider = MockProvider::success(MOCK_SUMMARY);
+
+        let result = engine
+            .distill(&messages, "test-nous", &provider, 42)
+            .await
+            .unwrap();
+        assert_eq!(result.distillation_number, 42);
+    }
+
+    #[tokio::test]
+    async fn distill_timestamp_is_valid() {
+        let engine = default_engine();
+        let messages = sample_conversation();
+        let provider = MockProvider::success(MOCK_SUMMARY);
+
+        let result = engine
+            .distill(&messages, "test-nous", &provider, 1)
+            .await
+            .unwrap();
+
+        // jiff::Timestamp::to_string() produces RFC 3339 / ISO 8601
+        assert!(
+            result.timestamp.contains('T'),
+            "timestamp should be ISO 8601: {}",
+            result.timestamp
+        );
+    }
+
+    // --- error cases ---
+
+    #[tokio::test]
+    async fn distill_empty_messages_returns_no_messages_error() {
+        let engine = default_engine();
+        let provider = MockProvider::success(MOCK_SUMMARY);
+
+        let result = engine.distill(&[], "test-nous", &provider, 1).await;
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.to_string().contains("no messages"));
+    }
+
+    #[tokio::test]
+    async fn distill_llm_failure_returns_llm_call_error() {
+        let engine = default_engine();
+        let messages = sample_conversation();
+        let provider = MockProvider::failure();
+
+        let result = engine.distill(&messages, "test-nous", &provider, 1).await;
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.to_string().contains("LLM call failed"));
+    }
+
+    #[tokio::test]
+    async fn distill_empty_response_returns_empty_summary_error() {
+        let engine = default_engine();
+        let messages = sample_conversation();
+        let provider = MockProvider::empty_response();
+
+        let result = engine.distill(&messages, "test-nous", &provider, 1).await;
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.to_string().contains("empty summary"));
+    }
+
+    #[tokio::test]
+    async fn distill_whitespace_only_response_returns_empty_summary_error() {
+        let engine = default_engine();
+        let messages = sample_conversation();
+        let provider = MockProvider::empty_text_blocks();
+
+        let result = engine.distill(&messages, "test-nous", &provider, 1).await;
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.to_string().contains("empty summary"));
+    }
+
+    // --- config defaults ---
+
+    #[test]
+    fn config_default_model() {
+        let config = DistillConfig::default();
+        assert_eq!(config.model, "claude-sonnet-4-20250514");
+    }
+
+    #[test]
+    fn config_default_values() {
+        let config = DistillConfig::default();
+        assert_eq!(config.max_output_tokens, 4096);
+        assert_eq!(config.min_messages, 6);
+        assert!(config.include_tool_calls);
+    }
+
+    // --- estimate_tokens ---
+
+    #[test]
+    fn estimate_tokens_chars_div_4() {
+        let messages = vec![text_msg(Role::User, "abcdefgh")]; // 8 chars → 2 tokens
+        assert_eq!(estimate_tokens(&messages), 2);
+    }
+
+    #[test]
+    fn estimate_tokens_rounds_up() {
+        let messages = vec![text_msg(Role::User, "abcde")]; // 5 chars → ceil(5/4) = 2
+        assert_eq!(estimate_tokens(&messages), 2);
+    }
+
+    #[test]
+    fn estimate_tokens_empty_messages() {
+        let messages: Vec<Message> = vec![];
+        assert_eq!(estimate_tokens(&messages), 0);
+    }
+
+    // --- extract_summary_text ---
+
+    #[test]
+    fn extract_summary_from_text_blocks() {
+        let blocks = vec![
+            ContentBlock::Text {
+                text: "Part 1".to_owned(),
+            },
+            ContentBlock::Text {
+                text: "Part 2".to_owned(),
+            },
+        ];
+        let text = extract_summary_text(&blocks);
+        assert_eq!(text, "Part 1\nPart 2");
+    }
+
+    #[test]
+    fn extract_summary_skips_non_text_blocks() {
+        let blocks = vec![
+            ContentBlock::Text {
+                text: "Summary text".to_owned(),
+            },
+            ContentBlock::Thinking {
+                thinking: "internal thought".to_owned(),
+            },
+        ];
+        let text = extract_summary_text(&blocks);
+        assert_eq!(text, "Summary text");
+    }
+
+    #[test]
+    fn extract_summary_trims_whitespace() {
+        let blocks = vec![ContentBlock::Text {
+            text: "  summary  ".to_owned(),
+        }];
+        let text = extract_summary_text(&blocks);
+        assert_eq!(text, "summary");
+    }
+}

--- a/crates/melete/src/error.rs
+++ b/crates/melete/src/error.rs
@@ -1,0 +1,33 @@
+//! Melete-specific errors.
+
+use snafu::Snafu;
+
+/// Errors from distillation operations.
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub))]
+#[non_exhaustive]
+pub enum Error {
+    /// LLM call failed during distillation.
+    #[snafu(display("LLM call failed during distillation: {source}"))]
+    LlmCall {
+        source: aletheia_hermeneus::error::Error,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    /// Distillation produced an empty summary.
+    #[snafu(display("distillation produced empty summary"))]
+    EmptySummary {
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    /// Session has no messages to distill.
+    #[snafu(display("session has no messages to distill"))]
+    NoMessages {
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+}
+
+pub type Result<T> = std::result::Result<T, Error>;

--- a/crates/melete/src/lib.rs
+++ b/crates/melete/src/lib.rs
@@ -1,0 +1,24 @@
+//! aletheia-melete — context distillation engine
+//!
+//! Melete (Μελέτη) — "practice, exercise." One of the three original Muses,
+//! representing meditation and the discipline of focused thought. Compresses
+//! conversation history into structured summaries that preserve essential
+//! context across distillation boundaries.
+//!
+//! Depends on `aletheia-koina` (types) and `aletheia-hermeneus` (LLM provider).
+
+pub mod distill;
+pub mod error;
+pub mod prompt;
+pub mod types;
+
+#[cfg(test)]
+mod assertions {
+    use static_assertions::assert_impl_all;
+
+    use super::distill::{DistillConfig, DistillEngine, DistillResult};
+
+    assert_impl_all!(DistillEngine: Send, Sync);
+    assert_impl_all!(DistillResult: Send, Sync);
+    assert_impl_all!(DistillConfig: Send, Sync);
+}

--- a/crates/melete/src/prompt.rs
+++ b/crates/melete/src/prompt.rs
@@ -1,0 +1,211 @@
+//! Distillation prompt construction.
+
+use std::fmt::Write;
+
+use aletheia_hermeneus::types::{Content, ContentBlock, Message, Role};
+
+pub const DISTILLATION_SYSTEM_PROMPT: &str = "\
+You are a context distillation engine. Your task is to compress a conversation \
+history into a structured summary that preserves all essential information for \
+continuing the work.
+
+Produce a summary with EXACTLY these sections. Omit a section only if it has \
+no content.
+
+## Summary
+One sentence describing what this conversation is about.
+
+## Task Context
+What was being worked on and why. Include the agent/nous identity if relevant.
+
+## Completed Work
+- Bullet list of concrete actions taken and their outcomes
+- Include file paths, function names, and specific details
+- Focus on results, not process
+
+## Key Decisions
+- Decisions made with their rationale — these MUST be preserved
+- Format: \"Decision: X. Reason: Y.\"
+
+## Current State
+Where things stand right now. What is done, what is in progress, what is half-finished.
+
+## Open Threads
+- Unfinished items, pending questions, next steps
+- Items deferred for later
+
+## Corrections
+- Anything that was wrong and corrected
+- Mistakes made and how they were fixed
+- These prevent repeating errors
+
+Rules:
+- Use first person: \"I was...\", \"I decided...\"
+- Be specific: file paths, line numbers, function names, exact values
+- Preserve names, identifiers, and numbers exactly
+- Target 400-600 words total
+- Every fact in the summary must be traceable to the conversation";
+
+/// Format conversation messages into readable text for the distillation LLM.
+pub fn format_messages(messages: &[Message], include_tool_calls: bool) -> String {
+    let mut output = String::new();
+
+    for msg in messages {
+        let role_label = match msg.role {
+            Role::System => "SYSTEM",
+            Role::User => "USER",
+            Role::Assistant => "ASSISTANT",
+        };
+
+        match &msg.content {
+            Content::Text(text) => {
+                let _ = writeln!(output, "[{role_label}]\n{text}\n");
+            }
+            Content::Blocks(blocks) => {
+                let mut block_text = String::new();
+                for block in blocks {
+                    match block {
+                        ContentBlock::Text { text } => {
+                            block_text.push_str(text);
+                            block_text.push('\n');
+                        }
+                        ContentBlock::ToolUse { name, input, .. } if include_tool_calls => {
+                            let _ = writeln!(block_text, "[Tool call: {name}({input})]");
+                        }
+                        ContentBlock::ToolResult {
+                            content, is_error, ..
+                        } if include_tool_calls => {
+                            let prefix = if *is_error == Some(true) {
+                                "Tool error"
+                            } else {
+                                "Tool result"
+                            };
+                            let truncated = truncate_tool_result(content);
+                            let _ = writeln!(block_text, "[{prefix}: {truncated}]");
+                        }
+                        ContentBlock::Thinking { thinking } => {
+                            let _ = writeln!(block_text, "[Thinking: {thinking}]");
+                        }
+                        _ => {}
+                    }
+                }
+                if !block_text.is_empty() {
+                    let _ = writeln!(output, "[{role_label}]\n{block_text}");
+                }
+            }
+        }
+    }
+
+    output
+}
+
+/// Truncate long tool results to keep the distillation input manageable.
+fn truncate_tool_result(content: &str) -> &str {
+    const MAX_TOOL_RESULT_LEN: usize = 500;
+    if content.len() <= MAX_TOOL_RESULT_LEN {
+        content
+    } else {
+        // Find a safe UTF-8 boundary near the limit
+        let mut end = MAX_TOOL_RESULT_LEN;
+        while end > 0 && !content.is_char_boundary(end) {
+            end -= 1;
+        }
+        &content[..end]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn text_msg(role: Role, text: &str) -> Message {
+        Message {
+            role,
+            content: Content::Text(text.to_owned()),
+        }
+    }
+
+    #[test]
+    fn system_prompt_contains_all_sections() {
+        let sections = [
+            "## Summary",
+            "## Task Context",
+            "## Completed Work",
+            "## Key Decisions",
+            "## Current State",
+            "## Open Threads",
+            "## Corrections",
+        ];
+        for section in sections {
+            assert!(
+                DISTILLATION_SYSTEM_PROMPT.contains(section),
+                "missing section: {section}"
+            );
+        }
+    }
+
+    #[test]
+    fn format_text_messages() {
+        let messages = vec![
+            text_msg(Role::User, "Hello"),
+            text_msg(Role::Assistant, "Hi there"),
+        ];
+        let formatted = format_messages(&messages, true);
+        assert!(formatted.contains("[USER]"));
+        assert!(formatted.contains("Hello"));
+        assert!(formatted.contains("[ASSISTANT]"));
+        assert!(formatted.contains("Hi there"));
+    }
+
+    #[test]
+    fn format_includes_tool_calls_when_enabled() {
+        let messages = vec![Message {
+            role: Role::Assistant,
+            content: Content::Blocks(vec![
+                ContentBlock::Text {
+                    text: "Let me check.".to_owned(),
+                },
+                ContentBlock::ToolUse {
+                    id: "t1".to_owned(),
+                    name: "read_file".to_owned(),
+                    input: serde_json::json!({"path": "/tmp/test"}),
+                },
+            ]),
+        }];
+        let with_tools = format_messages(&messages, true);
+        assert!(with_tools.contains("[Tool call: read_file"));
+
+        let without_tools = format_messages(&messages, false);
+        assert!(!without_tools.contains("[Tool call:"));
+    }
+
+    #[test]
+    fn format_excludes_tool_results_when_disabled() {
+        let messages = vec![Message {
+            role: Role::User,
+            content: Content::Blocks(vec![ContentBlock::ToolResult {
+                tool_use_id: "t1".to_owned(),
+                content: "file contents here".to_owned(),
+                is_error: Some(false),
+            }]),
+        }];
+        let with_tools = format_messages(&messages, true);
+        assert!(with_tools.contains("[Tool result:"));
+
+        let without_tools = format_messages(&messages, false);
+        assert!(!without_tools.contains("[Tool result:"));
+    }
+
+    #[test]
+    fn truncate_long_tool_result() {
+        let long = "x".repeat(1000);
+        let result = truncate_tool_result(&long);
+        assert!(result.len() <= 500);
+    }
+
+    #[test]
+    fn truncate_short_tool_result_unchanged() {
+        let short = "short result";
+        assert_eq!(truncate_tool_result(short), short);
+    }
+}

--- a/crates/melete/src/types.rs
+++ b/crates/melete/src/types.rs
@@ -1,0 +1,3 @@
+//! Re-exported types from hermeneus for distillation consumers.
+
+pub use aletheia_hermeneus::types::{Content, ContentBlock, Message, Role};


### PR DESCRIPTION
## Summary

New `aletheia-melete` crate — single-pass context distillation engine that compresses conversation history into structured summaries preserving essential context across distillation boundaries.

- `DistillEngine` with threshold detection, prompt construction, LLM call, and result packaging
- 7-section structured summary format (Summary, Task Context, Completed Work, Key Decisions, Current State, Open Threads, Corrections)
- snafu error handling (LlmCall, EmptySummary, NoMessages)
- 34 tests covering threshold logic, prompt construction, mock provider, error cases, config defaults, Send+Sync

## Files

- **New:** `crates/melete/` (Cargo.toml, lib.rs, error.rs, distill.rs, prompt.rs, types.rs)
- **Modified:** `Cargo.toml` (workspace members + jiff dep)

## Validation

- `cargo clippy -p aletheia-melete --all-targets -- -D warnings` — clean
- `cargo test --workspace` — 669 tests pass (34 new in melete)
- `cargo doc --workspace --no-deps` — clean