### PR TITLE
feat(agora): Signal inbound listener and message routing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2426,7 +2426,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2442,9 +2442,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-tzdb"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1283705eb0a21404d2bfd6eef2a7593d240bc42a0bdb39db0ad6fa2ec026524"
+checksum = "68971ebff725b9e2ca27a601c5eb38a4c5d64422c4cbab0c535f248087eda5c2"
 
 [[package]]
 name = "jiff-tzdb-platform"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,7 +97,7 @@ ulid = { version = "1", features = ["serde"] }
 jiff = "0.2"
 
 # Async
-tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "signal", "sync"] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "signal", "sync", "time"] }
 tokio-stream = "0.1"
 
 # Testing

--- a/crates/agora/src/lib.rs
+++ b/crates/agora/src/lib.rs
@@ -5,6 +5,7 @@
 //! and registry, with Signal (semeion) as the first provider.
 
 pub mod error;
+pub mod listener;
 pub mod registry;
 pub mod semeion;
 pub mod types;
@@ -13,11 +14,15 @@ pub mod types;
 mod assertions {
     use static_assertions::assert_impl_all;
 
+    use super::listener::ChannelListener;
     use super::registry::ChannelRegistry;
     use super::semeion::client::SignalClient;
     use super::semeion::SignalProvider;
+    use super::types::InboundMessage;
 
     assert_impl_all!(ChannelRegistry: Send, Sync);
+    assert_impl_all!(ChannelListener: Send);
+    assert_impl_all!(InboundMessage: Send, Sync);
     assert_impl_all!(SignalClient: Send, Sync);
     assert_impl_all!(SignalProvider: Send, Sync);
 }

--- a/crates/agora/src/listener.rs
+++ b/crates/agora/src/listener.rs
@@ -1,0 +1,204 @@
+//! Unified channel listener — merges inbound messages from all providers.
+
+use std::future::Future;
+
+use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
+use tracing::instrument;
+
+use crate::semeion::SignalProvider;
+use crate::types::InboundMessage;
+
+/// Listens on registered channels, merging inbound messages into a single stream.
+///
+/// Dropping the listener aborts all background polling tasks unless
+/// [`into_receiver`](Self::into_receiver) was called first.
+pub struct ChannelListener {
+    rx: Option<mpsc::Receiver<InboundMessage>>,
+    handles: Vec<JoinHandle<()>>,
+}
+
+impl ChannelListener {
+    /// Start listening on a Signal provider.
+    ///
+    /// Spawns polling tasks for all accounts registered on the provider
+    /// and merges their messages into a single receiver.
+    pub fn start(
+        signal_provider: &SignalProvider,
+        poll_interval: Option<std::time::Duration>,
+    ) -> Self {
+        let (rx, handles) = signal_provider.listen(poll_interval);
+        Self {
+            rx: Some(rx),
+            handles,
+        }
+    }
+
+    /// Create from pre-built parts.
+    ///
+    /// Use when the caller assembles provider-specific listeners
+    /// independently (e.g., merging Signal + future Slack receivers).
+    pub fn from_parts(
+        rx: mpsc::Receiver<InboundMessage>,
+        handles: Vec<JoinHandle<()>>,
+    ) -> Self {
+        Self {
+            rx: Some(rx),
+            handles,
+        }
+    }
+
+    /// Run the listener loop, dispatching each message to the handler.
+    ///
+    /// Returns when all senders are dropped (all polling tasks have stopped).
+    #[instrument(skip_all)]
+    pub async fn run<F, Fut>(mut self, handler: F)
+    where
+        F: Fn(InboundMessage) -> Fut + Send + 'static,
+        Fut: Future<Output = ()> + Send,
+    {
+        if let Some(ref mut rx) = self.rx {
+            while let Some(msg) = rx.recv().await {
+                handler(msg).await;
+            }
+        }
+        tracing::info!("all channels closed, listener stopping");
+    }
+
+    /// Unwrap into the raw receiver for manual control.
+    ///
+    /// The background polling handles are kept alive — they stop
+    /// naturally when the receiver is dropped (closed channel).
+    pub fn into_receiver(mut self) -> mpsc::Receiver<InboundMessage> {
+        let rx = self
+            .rx
+            .take()
+            .expect("into_receiver called on consumed listener");
+        // Clear handles so Drop doesn't abort them
+        self.handles.clear();
+        rx
+    }
+
+    /// Stop all polling tasks.
+    pub fn stop(self) {
+        drop(self);
+    }
+}
+
+impl Drop for ChannelListener {
+    fn drop(&mut self) {
+        for handle in &self.handles {
+            handle.abort();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn listener_receives_messages() {
+        let (tx, rx) = mpsc::channel(16);
+        let listener = ChannelListener::from_parts(rx, vec![]);
+
+        let msg = InboundMessage {
+            channel: "signal".to_owned(),
+            sender: "+1234567890".to_owned(),
+            sender_name: None,
+            group_id: None,
+            text: "hello".to_owned(),
+            timestamp: 100,
+            attachments: vec![],
+            raw: None,
+        };
+
+        tx.send(msg.clone()).await.expect("send");
+        drop(tx);
+
+        let mut rx = listener.into_receiver();
+        let received = rx.recv().await.expect("recv");
+        assert_eq!(received.text, "hello");
+        assert_eq!(received.sender, "+1234567890");
+        assert!(rx.recv().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn listener_run_dispatches_to_handler() {
+        let (tx, rx) = mpsc::channel(16);
+        let listener = ChannelListener::from_parts(rx, vec![]);
+
+        let count = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count_clone = count.clone();
+
+        for i in 0_u64..3 {
+            tx.send(InboundMessage {
+                channel: "signal".to_owned(),
+                sender: format!("+{i}"),
+                sender_name: None,
+                group_id: None,
+                text: format!("msg-{i}"),
+                timestamp: i,
+                attachments: vec![],
+                raw: None,
+            })
+            .await
+            .expect("send");
+        }
+        drop(tx);
+
+        listener
+            .run(move |_msg| {
+                let c = count_clone.clone();
+                async move {
+                    c.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                }
+            })
+            .await;
+
+        assert_eq!(count.load(std::sync::atomic::Ordering::Relaxed), 3);
+    }
+
+    #[tokio::test]
+    async fn listener_stop_aborts_tasks() {
+        let (_tx, rx) = mpsc::channel::<InboundMessage>(16);
+
+        let handle = tokio::spawn(async {
+            // Simulate a long-running task
+            tokio::time::sleep(std::time::Duration::from_secs(300)).await;
+        });
+
+        let listener = ChannelListener::from_parts(rx, vec![handle]);
+        listener.stop();
+
+        // If we get here, the tasks were aborted successfully
+    }
+
+    #[tokio::test]
+    async fn listener_drop_aborts_tasks() {
+        let task_finished =
+            std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let finished_clone = task_finished.clone();
+
+        let (_tx, rx) = mpsc::channel::<InboundMessage>(16);
+
+        let handle = tokio::spawn(async move {
+            tokio::time::sleep(std::time::Duration::from_secs(300)).await;
+            finished_clone
+                .store(true, std::sync::atomic::Ordering::Relaxed);
+        });
+
+        {
+            let _listener = ChannelListener::from_parts(rx, vec![handle]);
+            // listener drops here
+        }
+
+        // Give the runtime a moment to process the abort
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        assert!(
+            !task_finished.load(std::sync::atomic::Ordering::Relaxed),
+            "task should have been aborted, not completed"
+        );
+    }
+}

--- a/crates/agora/src/semeion/client.rs
+++ b/crates/agora/src/semeion/client.rs
@@ -7,10 +7,12 @@ use snafu::ResultExt;
 use tracing::instrument;
 use uuid::Uuid;
 
+use super::envelope::SignalEnvelope;
 use super::error::{self, Result};
 
 const RPC_TIMEOUT: Duration = Duration::from_secs(10);
 const HEALTH_TIMEOUT: Duration = Duration::from_secs(2);
+const RECEIVE_TIMEOUT: Duration = Duration::from_secs(15);
 
 #[derive(Debug, Serialize)]
 struct RpcRequest<'a> {
@@ -37,6 +39,7 @@ struct RpcError {
 }
 
 /// Async JSON-RPC client for a single signal-cli HTTP daemon instance.
+#[derive(Clone)]
 pub struct SignalClient {
     client: reqwest::Client,
     rpc_url: String,
@@ -155,6 +158,85 @@ impl SignalClient {
             .send()
             .await;
         matches!(result, Ok(r) if r.status().is_success())
+    }
+
+    /// Poll for accumulated inbound messages.
+    ///
+    /// Calls the signal-cli `receive` RPC method, which returns all messages
+    /// that have accumulated since the last call. Uses a longer timeout than
+    /// standard RPC calls since receive may block briefly.
+    #[instrument(skip(self))]
+    pub async fn receive(
+        &self,
+        account: Option<&str>,
+    ) -> Result<Vec<SignalEnvelope>> {
+        let mut params = serde_json::Map::new();
+        if let Some(acct) = account {
+            params.insert(
+                "account".to_owned(),
+                serde_json::Value::String(acct.to_owned()),
+            );
+        }
+
+        let id = Uuid::new_v4().to_string();
+        let request = RpcRequest {
+            jsonrpc: "2.0",
+            method: "receive",
+            params: serde_json::Value::Object(params),
+            id,
+        };
+
+        let body =
+            serde_json::to_string(&request).context(error::JsonSnafu)?;
+
+        let response = self
+            .client
+            .post(&self.rpc_url)
+            .header("content-type", "application/json")
+            .timeout(RECEIVE_TIMEOUT)
+            .body(body)
+            .send()
+            .await
+            .context(error::HttpSnafu)?;
+
+        if response.status().as_u16() == 201 {
+            return Ok(Vec::new());
+        }
+
+        let rpc_response: RpcResponse =
+            response.json().await.context(error::HttpSnafu)?;
+
+        if let Some(err) = rpc_response.error {
+            return Err(error::RpcSnafu {
+                code: err.code,
+                message: err.message,
+            }
+            .build());
+        }
+
+        match rpc_response.result {
+            Some(serde_json::Value::Array(items)) => {
+                let mut envelopes = Vec::with_capacity(items.len());
+                for item in items {
+                    let env_value = item
+                        .get("envelope")
+                        .cloned()
+                        .unwrap_or(item.clone());
+
+                    match serde_json::from_value::<SignalEnvelope>(env_value) {
+                        Ok(env) => envelopes.push(env),
+                        Err(e) => {
+                            tracing::debug!(
+                                error = %e,
+                                "skipping unparseable envelope"
+                            );
+                        }
+                    }
+                }
+                Ok(envelopes)
+            }
+            Some(_) | None => Ok(Vec::new()),
+        }
     }
 
     /// The base RPC URL this client targets.
@@ -311,5 +393,152 @@ mod tests {
     fn client_creation() {
         let client = SignalClient::new("localhost:8080").expect("create client");
         assert_eq!(client.rpc_url(), "http://localhost:8080/api/v1/rpc");
+    }
+
+    #[tokio::test]
+    async fn receive_returns_envelopes() {
+        let server = wiremock::MockServer::start().await;
+
+        let rpc_response = serde_json::json!({
+            "jsonrpc": "2.0",
+            "result": [
+                {
+                    "envelope": {
+                        "sourceNumber": "+1234567890",
+                        "sourceName": "Alice",
+                        "timestamp": 1_709_312_345_678_u64,
+                        "dataMessage": {
+                            "timestamp": 1_709_312_345_678_u64,
+                            "message": "hello"
+                        }
+                    },
+                    "account": "+0000000000"
+                }
+            ],
+            "id": "test"
+        });
+
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .and(wiremock::matchers::path("/api/v1/rpc"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200)
+                    .set_body_json(&rpc_response),
+            )
+            .mount(&server)
+            .await;
+
+        let client = SignalClient::new(&server.uri()).expect("create client");
+        let envelopes = client.receive(None).await.expect("receive");
+
+        assert_eq!(envelopes.len(), 1);
+        assert_eq!(
+            envelopes[0].source_number.as_deref(),
+            Some("+1234567890")
+        );
+        assert_eq!(
+            envelopes[0]
+                .data_message
+                .as_ref()
+                .and_then(|d| d.message.as_deref()),
+            Some("hello")
+        );
+    }
+
+    #[tokio::test]
+    async fn receive_empty_result() {
+        let server = wiremock::MockServer::start().await;
+
+        let rpc_response = serde_json::json!({
+            "jsonrpc": "2.0",
+            "result": [],
+            "id": "test"
+        });
+
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .and(wiremock::matchers::path("/api/v1/rpc"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200)
+                    .set_body_json(&rpc_response),
+            )
+            .mount(&server)
+            .await;
+
+        let client = SignalClient::new(&server.uri()).expect("create client");
+        let envelopes = client.receive(None).await.expect("receive");
+        assert!(envelopes.is_empty());
+    }
+
+    #[tokio::test]
+    async fn receive_rpc_error() {
+        let server = wiremock::MockServer::start().await;
+
+        let rpc_response = serde_json::json!({
+            "jsonrpc": "2.0",
+            "error": {"code": -32601, "message": "method not found"},
+            "id": "test"
+        });
+
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .and(wiremock::matchers::path("/api/v1/rpc"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200)
+                    .set_body_json(&rpc_response),
+            )
+            .mount(&server)
+            .await;
+
+        let client = SignalClient::new(&server.uri()).expect("create client");
+        let err = client.receive(None).await.expect_err("should fail");
+        let msg = err.to_string();
+        assert!(msg.contains("method not found"), "got: {msg}");
+    }
+
+    #[tokio::test]
+    async fn receive_skips_malformed_envelopes() {
+        let server = wiremock::MockServer::start().await;
+
+        let rpc_response = serde_json::json!({
+            "jsonrpc": "2.0",
+            "result": [
+                {
+                    "envelope": {
+                        "sourceNumber": "+1111111111",
+                        "dataMessage": {"message": "good"}
+                    }
+                },
+                {
+                    "envelope": "not-an-object"
+                },
+                {
+                    "envelope": {
+                        "sourceNumber": "+2222222222",
+                        "dataMessage": {"message": "also good"}
+                    }
+                }
+            ],
+            "id": "test"
+        });
+
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .and(wiremock::matchers::path("/api/v1/rpc"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200)
+                    .set_body_json(&rpc_response),
+            )
+            .mount(&server)
+            .await;
+
+        let client = SignalClient::new(&server.uri()).expect("create client");
+        let envelopes = client.receive(None).await.expect("receive");
+
+        assert_eq!(envelopes.len(), 2);
+        assert_eq!(
+            envelopes[0].source_number.as_deref(),
+            Some("+1111111111")
+        );
+        assert_eq!(
+            envelopes[1].source_number.as_deref(),
+            Some("+2222222222")
+        );
     }
 }

--- a/crates/agora/src/semeion/envelope.rs
+++ b/crates/agora/src/semeion/envelope.rs
@@ -1,0 +1,297 @@
+//! Signal envelope deserialization and inbound message extraction.
+
+use serde::{Deserialize, Serialize};
+
+use crate::types::InboundMessage;
+
+/// A signal-cli envelope from the `receive` RPC response.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SignalEnvelope {
+    pub source_number: Option<String>,
+    pub source_uuid: Option<String>,
+    pub source_name: Option<String>,
+    pub timestamp: Option<u64>,
+    #[serde(default)]
+    pub data_message: Option<DataMessage>,
+    #[serde(default)]
+    pub sync_message: Option<serde_json::Value>,
+    #[serde(default)]
+    pub receipt_message: Option<serde_json::Value>,
+    #[serde(default)]
+    pub typing_message: Option<serde_json::Value>,
+}
+
+/// The data payload of an inbound Signal message.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DataMessage {
+    pub timestamp: Option<u64>,
+    pub message: Option<String>,
+    #[serde(default)]
+    pub group_info: Option<GroupInfo>,
+    #[serde(default)]
+    pub attachments: Option<Vec<Attachment>>,
+}
+
+/// Group metadata attached to a data message.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GroupInfo {
+    pub group_id: Option<String>,
+}
+
+/// A file attachment on a Signal message.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Attachment {
+    pub id: Option<String>,
+    pub content_type: Option<String>,
+    pub filename: Option<String>,
+    pub size: Option<u64>,
+}
+
+/// Extract an [`InboundMessage`] from a signal envelope, if it contains usable content.
+///
+/// Returns `None` for sync messages, receipt messages, typing indicators,
+/// data messages with no text, and messages with no identifiable sender.
+pub fn extract_message(envelope: &SignalEnvelope) -> Option<InboundMessage> {
+    let data = envelope.data_message.as_ref()?;
+
+    let text = data.message.as_deref()?;
+    if text.is_empty() {
+        return None;
+    }
+
+    let sender = envelope
+        .source_number
+        .as_deref()
+        .or(envelope.source_uuid.as_deref())?;
+
+    let group_id = data
+        .group_info
+        .as_ref()
+        .and_then(|g| g.group_id.clone());
+
+    let attachments = data
+        .attachments
+        .as_ref()
+        .map(|atts| {
+            atts.iter()
+                .filter_map(|a| {
+                    a.filename
+                        .clone()
+                        .or_else(|| a.id.clone())
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let raw_value = serde_json::to_value(envelope).ok();
+
+    Some(InboundMessage {
+        channel: "signal".to_owned(),
+        sender: sender.to_owned(),
+        sender_name: envelope.source_name.clone(),
+        group_id,
+        text: text.to_owned(),
+        timestamp: envelope.timestamp.or(data.timestamp).unwrap_or(0),
+        attachments,
+        raw: raw_value,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn dm_envelope() -> serde_json::Value {
+        serde_json::json!({
+            "sourceNumber": "+1234567890",
+            "sourceUuid": "uuid-abc",
+            "sourceName": "Alice",
+            "timestamp": 1_709_312_345_678_u64,
+            "dataMessage": {
+                "timestamp": 1_709_312_345_678_u64,
+                "message": "hello",
+                "groupInfo": null
+            }
+        })
+    }
+
+    fn group_envelope() -> serde_json::Value {
+        serde_json::json!({
+            "sourceNumber": "+1234567890",
+            "sourceName": "Bob",
+            "timestamp": 1_709_312_345_000_u64,
+            "dataMessage": {
+                "timestamp": 1_709_312_345_000_u64,
+                "message": "group hello",
+                "groupInfo": {
+                    "groupId": "YWJjMTIz"
+                }
+            }
+        })
+    }
+
+    #[test]
+    fn extract_dm_with_text() {
+        let env: SignalEnvelope = serde_json::from_value(dm_envelope()).unwrap();
+        let msg = extract_message(&env).unwrap();
+
+        assert_eq!(msg.channel, "signal");
+        assert_eq!(msg.sender, "+1234567890");
+        assert_eq!(msg.sender_name.as_deref(), Some("Alice"));
+        assert_eq!(msg.text, "hello");
+        assert!(msg.group_id.is_none());
+        assert_eq!(msg.timestamp, 1_709_312_345_678);
+        assert!(msg.attachments.is_empty());
+        assert!(msg.raw.is_some());
+    }
+
+    #[test]
+    fn extract_group_message() {
+        let env: SignalEnvelope = serde_json::from_value(group_envelope()).unwrap();
+        let msg = extract_message(&env).unwrap();
+
+        assert_eq!(msg.sender, "+1234567890");
+        assert_eq!(msg.text, "group hello");
+        assert_eq!(msg.group_id.as_deref(), Some("YWJjMTIz"));
+    }
+
+    #[test]
+    fn extract_skips_sync_message() {
+        let json = serde_json::json!({
+            "sourceNumber": "+1234567890",
+            "timestamp": 100,
+            "syncMessage": {"sentMessage": {}}
+        });
+        let env: SignalEnvelope = serde_json::from_value(json).unwrap();
+        assert!(extract_message(&env).is_none());
+    }
+
+    #[test]
+    fn extract_skips_receipt_message() {
+        let json = serde_json::json!({
+            "sourceNumber": "+1234567890",
+            "timestamp": 100,
+            "receiptMessage": {"type": "DELIVERY"}
+        });
+        let env: SignalEnvelope = serde_json::from_value(json).unwrap();
+        assert!(extract_message(&env).is_none());
+    }
+
+    #[test]
+    fn extract_skips_typing_indicator() {
+        let json = serde_json::json!({
+            "sourceNumber": "+1234567890",
+            "timestamp": 100,
+            "typingMessage": {"action": "STARTED"}
+        });
+        let env: SignalEnvelope = serde_json::from_value(json).unwrap();
+        assert!(extract_message(&env).is_none());
+    }
+
+    #[test]
+    fn extract_skips_empty_data_message() {
+        let json = serde_json::json!({
+            "sourceNumber": "+1234567890",
+            "timestamp": 100,
+            "dataMessage": {
+                "timestamp": 100
+            }
+        });
+        let env: SignalEnvelope = serde_json::from_value(json).unwrap();
+        assert!(extract_message(&env).is_none());
+    }
+
+    #[test]
+    fn extract_uses_attachment_filenames() {
+        let json = serde_json::json!({
+            "sourceNumber": "+1234567890",
+            "timestamp": 100,
+            "dataMessage": {
+                "timestamp": 100,
+                "message": "see attached",
+                "attachments": [
+                    {"id": "att-1", "filename": "photo.jpg", "contentType": "image/jpeg", "size": 1024},
+                    {"id": "att-2", "contentType": "application/pdf", "size": 2048}
+                ]
+            }
+        });
+        let env: SignalEnvelope = serde_json::from_value(json).unwrap();
+        let msg = extract_message(&env).unwrap();
+
+        assert_eq!(msg.attachments.len(), 2);
+        assert_eq!(msg.attachments[0], "photo.jpg");
+        assert_eq!(msg.attachments[1], "att-2"); // falls back to id
+    }
+
+    #[test]
+    fn extract_no_sender_returns_none() {
+        let json = serde_json::json!({
+            "timestamp": 100,
+            "dataMessage": {
+                "timestamp": 100,
+                "message": "ghost message"
+            }
+        });
+        let env: SignalEnvelope = serde_json::from_value(json).unwrap();
+        assert!(extract_message(&env).is_none());
+    }
+
+    #[test]
+    fn envelope_deserialize_full() {
+        let json = serde_json::json!({
+            "sourceNumber": "+1234567890",
+            "sourceUuid": "abc-def",
+            "sourceName": "Test User",
+            "timestamp": 1_709_312_345_678_u64,
+            "dataMessage": {
+                "timestamp": 1_709_312_345_678_u64,
+                "message": "full message",
+                "groupInfo": {
+                    "groupId": "grp123"
+                },
+                "attachments": [
+                    {"id": "a1", "filename": "doc.pdf", "contentType": "application/pdf", "size": 999}
+                ]
+            }
+        });
+        let env: SignalEnvelope = serde_json::from_value(json).unwrap();
+
+        assert_eq!(env.source_number.as_deref(), Some("+1234567890"));
+        assert_eq!(env.source_uuid.as_deref(), Some("abc-def"));
+        assert_eq!(env.source_name.as_deref(), Some("Test User"));
+        assert_eq!(env.timestamp, Some(1_709_312_345_678));
+
+        let data = env.data_message.as_ref().unwrap();
+        assert_eq!(data.message.as_deref(), Some("full message"));
+        assert_eq!(
+            data.group_info.as_ref().unwrap().group_id.as_deref(),
+            Some("grp123")
+        );
+        assert_eq!(data.attachments.as_ref().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn envelope_deserialize_minimal() {
+        let json = serde_json::json!({
+            "sourceNumber": "+5555555555",
+            "dataMessage": {
+                "message": "hi"
+            }
+        });
+        let env: SignalEnvelope = serde_json::from_value(json).unwrap();
+
+        assert_eq!(env.source_number.as_deref(), Some("+5555555555"));
+        assert!(env.source_uuid.is_none());
+        assert!(env.source_name.is_none());
+        assert!(env.timestamp.is_none());
+        assert!(env.sync_message.is_none());
+
+        let msg = extract_message(&env).unwrap();
+        assert_eq!(msg.text, "hi");
+        assert_eq!(msg.timestamp, 0); // no timestamp available
+    }
+}

--- a/crates/agora/src/semeion/mod.rs
+++ b/crates/agora/src/semeion/mod.rs
@@ -1,16 +1,24 @@
 //! Signal channel provider — wraps signal-cli JSON-RPC.
 
 pub mod client;
+pub mod envelope;
 pub mod error;
 
 use std::collections::HashMap;
 use std::future::Future;
 use std::pin::Pin;
+use std::time::Duration;
+
+use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
+use tracing::{Instrument, instrument};
 
 use crate::types::{
-    ChannelCapabilities, ChannelProvider, ProbeResult,
+    ChannelCapabilities, ChannelProvider, InboundMessage, ProbeResult,
     SendParams as ChannelSendParams, SendResult,
 };
+
+const DEFAULT_POLL_INTERVAL: Duration = Duration::from_secs(2);
 
 /// Parsed Signal message target.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -74,6 +82,39 @@ impl SignalProvider {
             self.default_account = Some(account_id.clone());
         }
         self.clients.insert(account_id, client);
+    }
+
+    /// Start listening for inbound messages on all registered accounts.
+    ///
+    /// Spawns a polling task per account. Messages from all accounts merge
+    /// into the returned receiver. Dropping the receiver stops all tasks
+    /// (the send half detects the closed channel).
+    #[instrument(skip(self))]
+    pub fn listen(
+        &self,
+        poll_interval: Option<Duration>,
+    ) -> (mpsc::Receiver<InboundMessage>, Vec<JoinHandle<()>>) {
+        let interval = poll_interval.unwrap_or(DEFAULT_POLL_INTERVAL);
+        let (tx, rx) = mpsc::channel(64);
+        let mut handles = Vec::with_capacity(self.clients.len());
+
+        for (account_id, signal_client) in &self.clients {
+            let tx = tx.clone();
+            let account_id = account_id.clone();
+            let signal_client = signal_client.clone();
+            let span = tracing::info_span!(
+                "signal_poll",
+                account = %account_id
+            );
+
+            let handle = tokio::spawn(
+                poll_loop(signal_client, account_id, tx, interval)
+                    .instrument(span),
+            );
+            handles.push(handle);
+        }
+
+        (rx, handles)
     }
 
     fn resolve_client(
@@ -209,6 +250,39 @@ impl std::fmt::Debug for SignalProvider {
     }
 }
 
+async fn poll_loop(
+    signal_client: client::SignalClient,
+    account_id: String,
+    tx: mpsc::Sender<InboundMessage>,
+    interval: Duration,
+) {
+    tracing::info!("polling started");
+    loop {
+        match signal_client.receive(Some(&account_id)).await {
+            Ok(envelopes) => {
+                for env in &envelopes {
+                    if let Some(msg) =
+                        envelope::extract_message(env)
+                    {
+                        if tx.send(msg).await.is_err() {
+                            tracing::info!(
+                                "receiver dropped, stopping poll"
+                            );
+                            return;
+                        }
+                    } else {
+                        tracing::debug!("skipping non-message envelope");
+                    }
+                }
+            }
+            Err(e) => {
+                tracing::warn!(error = %e, "receive poll failed");
+            }
+        }
+        tokio::time::sleep(interval).await;
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -260,5 +334,111 @@ mod tests {
         let provider = SignalProvider::new();
         let caps = provider.capabilities();
         assert_eq!(caps.max_text_length, 2000);
+    }
+
+    #[test]
+    fn listen_empty_provider_returns_empty() {
+        // Create a runtime manually to avoid #[tokio::test] overhead
+        // when we just need to verify the return shape.
+        let provider = SignalProvider::new();
+        let (rx, handles) = provider.listen(None);
+        assert!(handles.is_empty());
+        drop(rx);
+    }
+
+    #[tokio::test]
+    async fn listen_returns_receiver_and_handles() {
+        let server = wiremock::MockServer::start().await;
+
+        // Return empty result so the poll loop has something to do
+        let rpc_response = serde_json::json!({
+            "jsonrpc": "2.0",
+            "result": [],
+            "id": "test"
+        });
+
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .and(wiremock::matchers::path("/api/v1/rpc"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200)
+                    .set_body_json(&rpc_response),
+            )
+            .mount(&server)
+            .await;
+
+        let mut provider = SignalProvider::new();
+        let signal_client =
+            client::SignalClient::new(&server.uri()).expect("client");
+        provider.add_account("+1111111111".to_owned(), signal_client);
+
+        let (rx, handles) = provider.listen(Some(Duration::from_secs(60)));
+        assert_eq!(handles.len(), 1);
+
+        // Drop receiver to stop the poll tasks
+        drop(rx);
+
+        // Wait for task to finish (it should detect closed channel)
+        for h in handles {
+            // Use a timeout so the test doesn't hang
+            let _ = tokio::time::timeout(Duration::from_secs(5), h).await;
+        }
+    }
+
+    #[tokio::test]
+    async fn poll_loop_stops_on_receiver_drop() {
+        let server = wiremock::MockServer::start().await;
+
+        let rpc_response = serde_json::json!({
+            "jsonrpc": "2.0",
+            "result": [
+                {
+                    "envelope": {
+                        "sourceNumber": "+9999999999",
+                        "timestamp": 100,
+                        "dataMessage": {
+                            "timestamp": 100,
+                            "message": "test msg"
+                        }
+                    }
+                }
+            ],
+            "id": "test"
+        });
+
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .and(wiremock::matchers::path("/api/v1/rpc"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200)
+                    .set_body_json(&rpc_response),
+            )
+            .mount(&server)
+            .await;
+
+        let signal_client =
+            client::SignalClient::new(&server.uri()).expect("client");
+        let (tx, mut rx) = mpsc::channel(16);
+
+        let handle = tokio::spawn(super::poll_loop(
+            signal_client,
+            "+0000000000".to_owned(),
+            tx,
+            Duration::from_millis(50),
+        ));
+
+        // Receive one message
+        let msg = tokio::time::timeout(Duration::from_secs(5), rx.recv())
+            .await
+            .expect("timeout")
+            .expect("message");
+        assert_eq!(msg.text, "test msg");
+
+        // Drop receiver — poll loop should stop
+        drop(rx);
+        let result =
+            tokio::time::timeout(Duration::from_secs(5), handle).await;
+        assert!(
+            result.is_ok(),
+            "poll loop should stop when receiver is dropped"
+        );
     }
 }

--- a/crates/agora/src/types.rs
+++ b/crates/agora/src/types.rs
@@ -57,6 +57,27 @@ pub struct ProbeResult {
     pub details: Option<HashMap<String, serde_json::Value>>,
 }
 
+/// A normalized inbound message received from any channel.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InboundMessage {
+    /// Channel this message came from (e.g., "signal").
+    pub channel: String,
+    /// Sender identifier (phone number, user ID, etc.).
+    pub sender: String,
+    /// Display name if known.
+    pub sender_name: Option<String>,
+    /// Group/conversation identifier (None for DM).
+    pub group_id: Option<String>,
+    /// Message text content.
+    pub text: String,
+    /// Unix timestamp in milliseconds.
+    pub timestamp: u64,
+    /// Attachment file paths or identifiers.
+    pub attachments: Vec<String>,
+    /// Raw channel-specific payload for extensions.
+    pub raw: Option<serde_json::Value>,
+}
+
 /// The contract every channel provider must implement.
 ///
 /// Object-safe via `Pin<Box<dyn Future>>` (matches `ToolExecutor` in organon).
@@ -81,4 +102,36 @@ pub trait ChannelProvider: Send + Sync {
     fn probe<'a>(
         &'a self,
     ) -> Pin<Box<dyn Future<Output = ProbeResult> + Send + 'a>>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn inbound_message_serde_roundtrip() {
+        let msg = InboundMessage {
+            channel: "signal".to_owned(),
+            sender: "+1234567890".to_owned(),
+            sender_name: Some("Alice".to_owned()),
+            group_id: Some("grp123".to_owned()),
+            text: "hello world".to_owned(),
+            timestamp: 1_709_312_345_678,
+            attachments: vec!["photo.jpg".to_owned()],
+            raw: Some(serde_json::json!({"extra": "data"})),
+        };
+
+        let json = serde_json::to_string(&msg).expect("serialize");
+        let back: InboundMessage =
+            serde_json::from_str(&json).expect("deserialize");
+
+        assert_eq!(back.channel, msg.channel);
+        assert_eq!(back.sender, msg.sender);
+        assert_eq!(back.sender_name, msg.sender_name);
+        assert_eq!(back.group_id, msg.group_id);
+        assert_eq!(back.text, msg.text);
+        assert_eq!(back.timestamp, msg.timestamp);
+        assert_eq!(back.attachments, msg.attachments);
+        assert_eq!(back.raw, msg.raw);
+    }
 }


### PR DESCRIPTION
## Summary

- Add `InboundMessage` struct for normalized cross-channel inbound messages
- Add `SignalEnvelope` deserialization with `extract_message()` that filters receipts/typing/sync
- Add `SignalClient::receive()` — polls signal-cli `receive` RPC endpoint
- Add `SignalProvider::listen()` — spawns per-account polling tasks, merges into single mpsc channel
- Add `ChannelListener` — aggregates provider streams, dispatches via `run(handler)`, graceful shutdown via `Drop`
- 22 new tests (41 total for agora), all passing
- All types `Send + Sync` verified via `static_assertions`

## Design note

The prompt assumed subprocess stdin/stdout, but `SignalClient` uses HTTP JSON-RPC via `reqwest`. Adapted to poll the `receive` RPC method with configurable interval (default 2s).

`listen()` is on `SignalProvider` directly rather than on the `ChannelProvider` trait — listening is a different lifecycle (spawns tasks, returns receivers) that doesn't fit the object-safe `Pin<Box<dyn Future>>` pattern.

## Test plan

- [x] `cargo clippy -p aletheia-agora --all-targets -- -D warnings` — zero warnings
- [x] `cargo test -p aletheia-agora` — 41 tests pass
- [x] `cargo test --workspace --exclude aletheia-mneme-engine --exclude aletheia-integration-tests` — all pass
- [x] Envelope parsing: DM, group, sync/receipt/typing skip, attachments, no-sender, roundtrip
- [x] Client receive: wiremock mocks for success, empty, RPC error, malformed envelope skip
- [x] Provider listen: receiver+handles shape, empty provider, poll stop on receiver drop
- [x] Listener: message dispatch, run handler, stop/drop abort tasks