### PR TITLE
feat(pylon): route message handling through NousActor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -266,6 +266,7 @@ dependencies = [
  "serde",
  "serde_json",
  "snafu",
+ "tempfile",
  "tokio",
  "tokio-stream",
  "tower",

--- a/crates/nous/src/manager.rs
+++ b/crates/nous/src/manager.rs
@@ -15,9 +15,15 @@ use crate::config::{NousConfig, PipelineConfig};
 use crate::handle::NousHandle;
 use crate::message::NousStatus;
 
+struct ActorEntry {
+    handle: NousHandle,
+    join: JoinHandle<()>,
+    config: NousConfig,
+}
+
 /// Manages the lifecycle of all nous actors.
 pub struct NousManager {
-    actors: HashMap<String, (NousHandle, JoinHandle<()>)>,
+    actors: HashMap<String, ActorEntry>,
     providers: Arc<ProviderRegistry>,
     tools: Arc<ToolRegistry>,
     oikos: Arc<Oikos>,
@@ -45,14 +51,14 @@ impl NousManager {
     pub async fn spawn(&mut self, config: NousConfig, pipeline_config: PipelineConfig) -> NousHandle {
         let id = config.id.clone();
 
-        if let Some((old_handle, old_join)) = self.actors.remove(&id) {
+        if let Some(old) = self.actors.remove(&id) {
             warn!(nous_id = %id, "replacing existing actor");
-            let _ = old_handle.shutdown().await;
-            let _ = old_join.await;
+            let _ = old.handle.shutdown().await;
+            let _ = old.join.await;
         }
 
         let (handle, join_handle) = actor::spawn(
-            config,
+            config.clone(),
             pipeline_config,
             Arc::clone(&self.providers),
             Arc::clone(&self.tools),
@@ -60,24 +66,40 @@ impl NousManager {
         );
 
         info!(nous_id = %id, "actor spawned");
-        self.actors.insert(id, (handle.clone(), join_handle));
+        self.actors.insert(id, ActorEntry {
+            handle: handle.clone(),
+            join: join_handle,
+            config,
+        });
         handle
     }
 
     /// Look up a handle by nous id.
     #[must_use]
     pub fn get(&self, nous_id: &str) -> Option<&NousHandle> {
-        self.actors.get(nous_id).map(|(h, _)| h)
+        self.actors.get(nous_id).map(|e| &e.handle)
+    }
+
+    /// Look up a config by nous id.
+    #[must_use]
+    pub fn get_config(&self, nous_id: &str) -> Option<&NousConfig> {
+        self.actors.get(nous_id).map(|e| &e.config)
+    }
+
+    /// All stored configs.
+    #[must_use]
+    pub fn configs(&self) -> Vec<&NousConfig> {
+        self.actors.values().map(|e| &e.config).collect()
     }
 
     /// Query status from all actors.
     pub async fn list(&self) -> Vec<NousStatus> {
         let mut statuses = Vec::with_capacity(self.actors.len());
-        for (handle, _) in self.actors.values() {
-            match handle.status().await {
+        for entry in self.actors.values() {
+            match entry.handle.status().await {
                 Ok(status) => statuses.push(status),
                 Err(_) => {
-                    warn!(nous_id = handle.id(), "failed to query actor status");
+                    warn!(nous_id = entry.handle.id(), "failed to query actor status");
                 }
             }
         }
@@ -91,7 +113,7 @@ impl NousManager {
         let entries: Vec<(String, NousHandle, JoinHandle<()>)> = self
             .actors
             .drain()
-            .map(|(id, (handle, join))| (id, handle, join))
+            .map(|(id, e)| (id, e.handle, e.join))
             .collect();
 
         for (id, handle, _) in &entries {
@@ -107,6 +129,19 @@ impl NousManager {
         }
 
         info!("all actors stopped");
+    }
+
+    /// Send shutdown to all actors without requiring `&mut self`.
+    ///
+    /// Used when the manager is behind `Arc` and mutable access is unavailable.
+    /// Does not drain the entries — cleanup happens when the `Arc` drops.
+    pub async fn shutdown_readonly(&self) {
+        info!(count = self.actors.len(), "shutting down all actors");
+        for entry in self.actors.values() {
+            if let Err(e) = entry.handle.shutdown().await {
+                warn!(nous_id = entry.handle.id(), error = %e, "failed to send shutdown");
+            }
+        }
     }
 
     /// Number of managed actors.
@@ -233,6 +268,45 @@ mod tests {
         let (_dir, oikos) = test_oikos();
         let mgr = test_manager(oikos);
         assert!(mgr.get("unknown").is_none());
+    }
+
+    #[tokio::test]
+    async fn get_config_returns_stored_config() {
+        let (_dir, oikos) = test_oikos();
+        let mut mgr = test_manager(oikos);
+
+        mgr.spawn(syn_config(), PipelineConfig::default()).await;
+
+        let config = mgr.get_config("syn").expect("config");
+        assert_eq!(config.id, "syn");
+        assert_eq!(config.model, "test-model");
+
+        mgr.shutdown_all().await;
+    }
+
+    #[tokio::test]
+    async fn get_config_returns_none_for_unknown() {
+        let (_dir, oikos) = test_oikos();
+        let mgr = test_manager(oikos);
+        assert!(mgr.get_config("unknown").is_none());
+    }
+
+    #[tokio::test]
+    async fn configs_returns_all() {
+        let (_dir, oikos) = test_oikos();
+        let mut mgr = test_manager(oikos);
+
+        mgr.spawn(syn_config(), PipelineConfig::default()).await;
+        mgr.spawn(demiurge_config(), PipelineConfig::default()).await;
+
+        let configs = mgr.configs();
+        assert_eq!(configs.len(), 2);
+
+        let ids: Vec<&str> = configs.iter().map(|c| c.id.as_str()).collect();
+        assert!(ids.contains(&"syn"));
+        assert!(ids.contains(&"demiurge"));
+
+        mgr.shutdown_all().await;
     }
 
     #[tokio::test]

--- a/crates/pylon/Cargo.toml
+++ b/crates/pylon/Cargo.toml
@@ -46,5 +46,6 @@ aletheia-symbolon = { path = "../symbolon" }
 jsonwebtoken = { version = "10", features = ["rust_crypto"] }
 reqwest = { workspace = true }
 secrecy = { workspace = true }
+tempfile = "3"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "signal", "test-util"] }
 tracing-subscriber = { workspace = true }

--- a/crates/pylon/src/error.rs
+++ b/crates/pylon/src/error.rs
@@ -61,6 +61,14 @@ impl From<aletheia_hermeneus::error::Error> for ApiError {
     }
 }
 
+impl From<aletheia_nous::error::Error> for ApiError {
+    fn from(err: aletheia_nous::error::Error) -> Self {
+        Self::Internal {
+            message: err.to_string(),
+        }
+    }
+}
+
 impl From<tokio::task::JoinError> for ApiError {
     fn from(err: tokio::task::JoinError) -> Self {
         Self::Internal {

--- a/crates/pylon/src/handlers/nous.rs
+++ b/crates/pylon/src/handlers/nous.rs
@@ -12,15 +12,17 @@ use crate::state::AppState;
 
 /// GET /api/nous — list registered nous agents.
 pub async fn list(State(state): State<Arc<AppState>>, _claims: Claims) -> Json<NousListResponse> {
-    let config = state.session_manager.config();
-    // Currently single-nous — return the configured agent
-    Json(NousListResponse {
-        nous: vec![NousSummary {
-            id: config.id.clone(),
-            model: config.model.clone(),
+    let nous: Vec<NousSummary> = state
+        .nous_manager
+        .configs()
+        .into_iter()
+        .map(|c| NousSummary {
+            id: c.id.clone(),
+            model: c.model.clone(),
             status: "active".to_owned(),
-        }],
-    })
+        })
+        .collect();
+    Json(NousListResponse { nous })
 }
 
 /// GET /api/nous/{id} — get nous status.
@@ -29,10 +31,18 @@ pub async fn get_status(
     _claims: Claims,
     Path(id): Path<String>,
 ) -> Result<Json<NousStatus>, ApiError> {
-    let config = state.session_manager.config();
-    if config.id != id {
-        return Err(NousNotFoundSnafu { id }.build());
-    }
+    let config = state
+        .nous_manager
+        .get_config(&id)
+        .ok_or_else(|| NousNotFoundSnafu { id: id.clone() }.build())?;
+
+    let status = match state.nous_manager.get(&id) {
+        Some(handle) => handle
+            .status()
+            .await
+            .map_or_else(|_| "unknown".to_owned(), |s| s.lifecycle.to_string()),
+        None => "unknown".to_owned(),
+    };
 
     Ok(Json(NousStatus {
         id: config.id.clone(),
@@ -42,7 +52,7 @@ pub async fn get_status(
         thinking_enabled: config.thinking_enabled,
         thinking_budget: config.thinking_budget,
         max_tool_iterations: config.max_tool_iterations,
-        status: "active".to_owned(),
+        status,
     }))
 }
 
@@ -52,8 +62,7 @@ pub async fn tools(
     _claims: Claims,
     Path(id): Path<String>,
 ) -> Result<Json<ToolsResponse>, ApiError> {
-    let config = state.session_manager.config();
-    if config.id != id {
+    if state.nous_manager.get_config(&id).is_none() {
         return Err(NousNotFoundSnafu { id }.build());
     }
 

--- a/crates/pylon/src/handlers/sessions.rs
+++ b/crates/pylon/src/handlers/sessions.rs
@@ -15,12 +15,10 @@ use tokio_stream::wrappers::ReceiverStream;
 use tokio_stream::StreamExt;
 use tracing::{info, instrument, warn};
 
-use aletheia_hermeneus::types::{
-    CompletionRequest, Content, ContentBlock, Message as LlmMessage, Role as LlmRole,
-};
 use aletheia_mneme::types::SessionStatus;
+use aletheia_nous::pipeline::TurnResult;
 
-use crate::error::{ApiError, BadRequestSnafu, InternalSnafu, SessionNotFoundSnafu};
+use crate::error::{ApiError, BadRequestSnafu, InternalSnafu, NousNotFoundSnafu, SessionNotFoundSnafu};
 use crate::extract::Claims;
 use crate::state::AppState;
 use crate::stream::{SseEvent, UsageData};
@@ -35,18 +33,20 @@ pub async fn create(
     let nous_id = body.nous_id;
     let session_key = body.session_key;
 
-    let manager = &state.session_manager;
-    let session_state = manager.create_session(&ulid::Ulid::new().to_string(), &session_key);
+    let config = state.nous_manager.get_config(&nous_id)
+        .ok_or_else(|| NousNotFoundSnafu { id: nous_id.clone() }.build())?;
+
+    let id = ulid::Ulid::new().to_string();
+    let model = config.model.clone();
 
     let state_clone = Arc::clone(&state);
-    let id = session_state.id.clone();
-    let nid = session_state.nous_id.clone();
+    let id_clone = id.clone();
+    let nid = nous_id.clone();
     let skey = session_key.clone();
-    let model = session_state.model.clone();
 
     let session = tokio::task::spawn_blocking(move || {
         let store = state_clone.session_store.lock().expect("store lock");
-        store.find_or_create_session(&id, &nid, &skey, Some(&model), None)
+        store.find_or_create_session(&id_clone, &nid, &skey, Some(&model), None)
     })
     .await??;
 
@@ -146,26 +146,60 @@ pub async fn send_message(
     // Store the user message
     store_message(&state, &session_id, aletheia_mneme::types::Role::User, &content, 0).await?;
 
-    let model = session
-        .model
-        .clone()
-        .unwrap_or_else(|| "claude-opus-4-20250514".to_owned());
+    // Resolve the nous actor
+    let nous_id = &session.nous_id;
+    let handle = state
+        .nous_manager
+        .get(nous_id)
+        .ok_or_else(|| {
+            InternalSnafu {
+                message: format!("no actor for nous {nous_id}"),
+            }
+            .build()
+        })?
+        .clone();
 
-    let request = build_completion_request(&state, &session_id, &model).await?;
-
-    if state.provider_registry.find_provider(&model).is_none() {
-        return Err(InternalSnafu {
-            message: format!("no provider for model {model}"),
+    // Pre-flight: verify provider exists for the model
+    if let Some(config) = state.nous_manager.get_config(nous_id) {
+        if state.provider_registry.find_provider(&config.model).is_none() {
+            return Err(InternalSnafu {
+                message: format!("no provider for model {}", config.model),
+            }
+            .build());
         }
-        .build());
     }
 
+    let session_key = session.session_key.clone();
     let (tx, rx) = mpsc::channel::<SseEvent>(32);
     let state_clone = Arc::clone(&state);
     let sid = session_id.clone();
 
-    tokio::task::spawn_blocking(move || {
-        run_completion(&state_clone, &model, &request, &tx, &sid);
+    tokio::spawn(async move {
+        match handle.send_turn(&session_key, &content).await {
+            Ok(result) => {
+                emit_turn_result_events(&tx, &result).await;
+
+                // Store assistant response
+                let token_estimate = i64::try_from(result.usage.output_tokens).unwrap_or(0);
+                let _ = store_message(
+                    &state_clone,
+                    &sid,
+                    aletheia_mneme::types::Role::Assistant,
+                    &result.content,
+                    token_estimate,
+                )
+                .await;
+            }
+            Err(err) => {
+                warn!(error = %err, "turn failed");
+                let _ = tx
+                    .send(SseEvent::Error {
+                        code: "turn_failed".to_owned(),
+                        message: err.to_string(),
+                    })
+                    .await;
+            }
+        }
     });
 
     let stream = ReceiverStream::new(rx).map(|event| {
@@ -178,6 +212,45 @@ pub async fn send_message(
             .interval(Duration::from_secs(15))
             .text("ping"),
     ))
+}
+
+async fn emit_turn_result_events(tx: &mpsc::Sender<SseEvent>, result: &TurnResult) {
+    if !result.content.is_empty() {
+        let _ = tx
+            .send(SseEvent::TextDelta {
+                text: result.content.clone(),
+            })
+            .await;
+    }
+
+    for tc in &result.tool_calls {
+        let _ = tx
+            .send(SseEvent::ToolUse {
+                id: tc.id.clone(),
+                name: tc.name.clone(),
+                input: tc.input.clone(),
+            })
+            .await;
+        if let Some(ref result_content) = tc.result {
+            let _ = tx
+                .send(SseEvent::ToolResult {
+                    tool_use_id: tc.id.clone(),
+                    content: result_content.clone(),
+                    is_error: tc.is_error,
+                })
+                .await;
+        }
+    }
+
+    let _ = tx
+        .send(SseEvent::MessageComplete {
+            stop_reason: result.stop_reason.clone(),
+            usage: UsageData {
+                input_tokens: result.usage.input_tokens,
+                output_tokens: result.usage.output_tokens,
+            },
+        })
+        .await;
 }
 
 async fn store_message(
@@ -196,136 +269,6 @@ async fn store_message(
     })
     .await?
     .map_err(ApiError::from)
-}
-
-async fn build_completion_request(
-    state: &Arc<AppState>,
-    session_id: &str,
-    model: &str,
-) -> Result<CompletionRequest, ApiError> {
-    let state_clone = Arc::clone(state);
-    let sid = session_id.to_owned();
-    let history = tokio::task::spawn_blocking(move || {
-        let store = state_clone.session_store.lock().expect("store lock");
-        store.get_history(&sid, Some(50))
-    })
-    .await??;
-
-    let messages: Vec<LlmMessage> = history
-        .iter()
-        .filter_map(|m| {
-            let role = match m.role {
-                aletheia_mneme::types::Role::User => LlmRole::User,
-                aletheia_mneme::types::Role::Assistant => LlmRole::Assistant,
-                _ => return None,
-            };
-            Some(LlmMessage {
-                role,
-                content: Content::Text(m.content.clone()),
-            })
-        })
-        .collect();
-
-    Ok(CompletionRequest {
-        model: model.to_owned(),
-        system: None,
-        messages,
-        max_tokens: 4096,
-        tools: state.tool_registry.to_hermeneus_tools(),
-        temperature: None,
-        thinking: None,
-        stop_sequences: vec![],
-    })
-}
-
-fn run_completion(
-    state: &AppState,
-    model: &str,
-    request: &CompletionRequest,
-    tx: &mpsc::Sender<SseEvent>,
-    session_id: &str,
-) {
-    let Some(provider) = state.provider_registry.find_provider(model) else {
-        let _ = tx.blocking_send(SseEvent::Error {
-            code: "no_provider".to_owned(),
-            message: format!("no provider for model {model}"),
-        });
-        return;
-    };
-
-    match provider.complete(request) {
-        Ok(response) => {
-            emit_response_events(tx, &response);
-
-            let full_text: String = response
-                .content
-                .iter()
-                .filter_map(|b| match b {
-                    ContentBlock::Text { text } => Some(text.as_str()),
-                    _ => None,
-                })
-                .collect::<Vec<_>>()
-                .join("");
-
-            if let Ok(store) = state.session_store.lock() {
-                let _ = store.append_message(
-                    session_id,
-                    aletheia_mneme::types::Role::Assistant,
-                    &full_text,
-                    None,
-                    None,
-                    i64::try_from(response.usage.output_tokens).unwrap_or(0),
-                );
-            }
-        }
-        Err(err) => {
-            warn!(error = %err, "completion failed");
-            let _ = tx.blocking_send(SseEvent::Error {
-                code: "completion_failed".to_owned(),
-                message: err.to_string(),
-            });
-        }
-    }
-}
-
-fn emit_response_events(
-    tx: &mpsc::Sender<SseEvent>,
-    response: &aletheia_hermeneus::types::CompletionResponse,
-) {
-    for block in &response.content {
-        let event = match block {
-            ContentBlock::Text { text } => SseEvent::TextDelta {
-                text: text.clone(),
-            },
-            ContentBlock::Thinking { thinking } => SseEvent::ThinkingDelta {
-                thinking: thinking.clone(),
-            },
-            ContentBlock::ToolUse { id, name, input } => SseEvent::ToolUse {
-                id: id.clone(),
-                name: name.clone(),
-                input: input.clone(),
-            },
-            ContentBlock::ToolResult {
-                tool_use_id,
-                content,
-                is_error,
-            } => SseEvent::ToolResult {
-                tool_use_id: tool_use_id.clone(),
-                content: content.clone(),
-                is_error: is_error.unwrap_or(false),
-            },
-            _ => continue,
-        };
-        let _ = tx.blocking_send(event);
-    }
-
-    let _ = tx.blocking_send(SseEvent::MessageComplete {
-        stop_reason: format!("{:?}", response.stop_reason),
-        usage: UsageData {
-            input_tokens: response.usage.input_tokens,
-            output_tokens: response.usage.output_tokens,
-        },
-    });
 }
 
 async fn find_session(

--- a/crates/pylon/src/server.rs
+++ b/crates/pylon/src/server.rs
@@ -10,8 +10,8 @@ use tracing::info;
 
 use aletheia_hermeneus::provider::ProviderRegistry;
 use aletheia_mneme::store::SessionStore;
-use aletheia_nous::config::NousConfig;
-use aletheia_nous::session::SessionManager;
+use aletheia_nous::config::{NousConfig, PipelineConfig};
+use aletheia_nous::manager::NousManager;
 use aletheia_organon::registry::ToolRegistry;
 use aletheia_symbolon::jwt::{JwtConfig, JwtManager};
 use aletheia_taxis::oikos::Oikos;
@@ -45,28 +45,34 @@ pub enum ServerError {
 
 /// Start the HTTP gateway and block until shutdown.
 pub async fn run(config: ServerConfig) -> Result<(), ServerError> {
-    let oikos = Oikos::from_root(&config.instance_path);
+    let oikos = Arc::new(Oikos::from_root(&config.instance_path));
 
     let session_store =
         SessionStore::open(&oikos.sessions_db()).context(SessionStoreSnafu)?;
 
-    let nous_config = NousConfig::default();
-    let session_manager = SessionManager::new(nous_config);
-    let provider_registry = ProviderRegistry::new();
-    let tool_registry = ToolRegistry::new();
+    let provider_registry = Arc::new(ProviderRegistry::new());
+    let tool_registry = Arc::new(ToolRegistry::new());
     let jwt_manager = Arc::new(JwtManager::new(JwtConfig::default()));
+
+    let mut nous_manager = NousManager::new(
+        Arc::clone(&provider_registry),
+        Arc::clone(&tool_registry),
+        Arc::clone(&oikos),
+    );
+    let nous_config = NousConfig::default();
+    nous_manager.spawn(nous_config, PipelineConfig::default()).await;
 
     let state = Arc::new(AppState {
         session_store: Mutex::new(session_store),
+        nous_manager,
         provider_registry,
-        session_manager,
         tool_registry,
         oikos,
         jwt_manager,
         start_time: Instant::now(),
     });
 
-    let app = build_router(state);
+    let app = build_router(state.clone());
 
     let listener = TcpListener::bind(&config.bind_addr)
         .await
@@ -80,6 +86,8 @@ pub async fn run(config: ServerConfig) -> Result<(), ServerError> {
         .with_graceful_shutdown(shutdown_signal())
         .await
         .context(ServeSnafu)?;
+
+    state.nous_manager.shutdown_readonly().await;
 
     info!("pylon shutdown complete");
     Ok(())

--- a/crates/pylon/src/state.rs
+++ b/crates/pylon/src/state.rs
@@ -5,7 +5,7 @@ use std::time::Instant;
 
 use aletheia_hermeneus::provider::ProviderRegistry;
 use aletheia_mneme::store::SessionStore;
-use aletheia_nous::session::SessionManager;
+use aletheia_nous::manager::NousManager;
 use aletheia_organon::registry::ToolRegistry;
 use aletheia_symbolon::jwt::JwtManager;
 use aletheia_taxis::oikos::Oikos;
@@ -13,10 +13,10 @@ use aletheia_taxis::oikos::Oikos;
 /// Shared state for all Axum handlers, held behind `Arc` in the router.
 pub struct AppState {
     pub session_store: Mutex<SessionStore>,
-    pub session_manager: SessionManager,
-    pub provider_registry: ProviderRegistry,
-    pub tool_registry: ToolRegistry,
-    pub oikos: Oikos,
+    pub nous_manager: NousManager,
+    pub provider_registry: Arc<ProviderRegistry>,
+    pub tool_registry: Arc<ToolRegistry>,
+    pub oikos: Arc<Oikos>,
     pub jwt_manager: Arc<JwtManager>,
     pub start_time: Instant,
 }

--- a/crates/pylon/src/tests.rs
+++ b/crates/pylon/src/tests.rs
@@ -11,8 +11,8 @@ use tower::ServiceExt;
 use aletheia_hermeneus::provider::{LlmProvider, ProviderRegistry};
 use aletheia_hermeneus::types::*;
 use aletheia_mneme::store::SessionStore;
-use aletheia_nous::config::NousConfig;
-use aletheia_nous::session::SessionManager;
+use aletheia_nous::config::{NousConfig, PipelineConfig};
+use aletheia_nous::manager::NousManager;
 use aletheia_organon::registry::ToolRegistry;
 use aletheia_symbolon::jwt::{JwtConfig, JwtManager};
 use aletheia_taxis::oikos::Oikos;
@@ -44,7 +44,6 @@ impl MockProvider {
             },
         }
     }
-
 }
 
 impl LlmProvider for MockProvider {
@@ -81,44 +80,66 @@ fn default_token() -> String {
 
 // --- Test Helpers ---
 
-fn test_state() -> Arc<AppState> {
-    test_state_with_provider(true)
+async fn test_state() -> (Arc<AppState>, tempfile::TempDir) {
+    test_state_with_provider(true).await
 }
 
-fn test_state_with_provider(with_provider: bool) -> Arc<AppState> {
+async fn test_state_with_provider(with_provider: bool) -> (Arc<AppState>, tempfile::TempDir) {
+    let dir = tempfile::TempDir::new().expect("tmpdir");
+    let root = dir.path();
+
+    // Create oikos directory structure required by the actor pipeline
+    std::fs::create_dir_all(root.join("nous/syn")).expect("mkdir nous/syn");
+    std::fs::create_dir_all(root.join("shared")).expect("mkdir shared");
+    std::fs::create_dir_all(root.join("theke")).expect("mkdir theke");
+    std::fs::write(root.join("nous/syn/SOUL.md"), "I am Syn, a test agent.").expect("write SOUL.md");
+
     let store = SessionStore::open_in_memory().expect("in-memory store");
-    let nous_config = NousConfig {
-        id: "syn".to_owned(),
-        ..NousConfig::default()
-    };
-    let session_manager = SessionManager::new(nous_config);
+    let oikos = Arc::new(Oikos::from_root(root));
 
     let mut provider_registry = ProviderRegistry::new();
     if with_provider {
         provider_registry.register(Box::new(MockProvider::new()));
     }
+    let provider_registry = Arc::new(provider_registry);
+    let tool_registry = Arc::new(ToolRegistry::new());
 
-    let tool_registry = ToolRegistry::new();
-    let oikos = Oikos::from_root("/tmp/aletheia-test");
+    let mut nous_manager = NousManager::new(
+        Arc::clone(&provider_registry),
+        Arc::clone(&tool_registry),
+        Arc::clone(&oikos),
+    );
+
+    let nous_config = NousConfig {
+        id: "syn".to_owned(),
+        model: "mock-model".to_owned(),
+        ..NousConfig::default()
+    };
+    nous_manager.spawn(nous_config, PipelineConfig::default()).await;
+
     let jwt_manager = test_jwt_manager();
 
-    Arc::new(AppState {
+    let state = Arc::new(AppState {
         session_store: Mutex::new(store),
-        session_manager,
+        nous_manager,
         provider_registry,
         tool_registry,
         oikos,
         jwt_manager,
         start_time: Instant::now(),
-    })
+    });
+
+    (state, dir)
 }
 
-fn app() -> axum::Router {
-    build_router(test_state())
+async fn app() -> (axum::Router, tempfile::TempDir) {
+    let (state, dir) = test_state().await;
+    (build_router(state), dir)
 }
 
-fn app_no_providers() -> axum::Router {
-    build_router(test_state_with_provider(false))
+async fn app_no_providers() -> (axum::Router, tempfile::TempDir) {
+    let (state, dir) = test_state_with_provider(false).await;
+    (build_router(state), dir)
 }
 
 fn json_request(method: &str, uri: &str, body: Option<serde_json::Value>) -> Request<Body> {
@@ -199,7 +220,8 @@ async fn create_test_session(app: &axum::Router) -> serde_json::Value {
 
 #[tokio::test]
 async fn health_no_auth_required() {
-    let resp = app()
+    let (app, _dir) = app().await;
+    let resp = app
         .oneshot(Request::get("/api/health").body(Body::empty()).unwrap())
         .await
         .unwrap();
@@ -211,6 +233,7 @@ async fn health_no_auth_required() {
 
 #[tokio::test]
 async fn sessions_require_auth() {
+    let (app, _dir) = app().await;
     let req = json_request(
         "POST",
         "/api/sessions",
@@ -220,13 +243,14 @@ async fn sessions_require_auth() {
         })),
     );
 
-    let resp = app().oneshot(req).await.unwrap();
+    let resp = app.oneshot(req).await.unwrap();
     assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
 }
 
 #[tokio::test]
 async fn valid_token_passes() {
-    let session = create_test_session(&app()).await;
+    let (app, _dir) = app().await;
+    let session = create_test_session(&app).await;
     assert!(session["id"].is_string());
     assert_eq!(session["nous_id"], "syn");
 }
@@ -236,14 +260,15 @@ async fn expired_token_rejected() {
     use aletheia_symbolon::types::{Claims, Role, TokenKind};
     use jsonwebtoken::{Algorithm, EncodingKey, Header};
 
-    // Manually encode a token with exp far in the past (beyond 60s leeway)
+    let (app, _dir) = app().await;
+
     let claims = Claims {
         sub: "test-user".to_owned(),
         role: Role::Operator,
         nous_id: None,
         iss: "aletheia-test".to_owned(),
         iat: 1_000_000,
-        exp: 1_000_001, // 1970 — long expired
+        exp: 1_000_001,
         jti: "expired-jti".to_owned(),
         kind: TokenKind::Access,
     };
@@ -268,12 +293,13 @@ async fn expired_token_rejected() {
         ))
         .unwrap();
 
-    let resp = app().oneshot(req).await.unwrap();
+    let resp = app.oneshot(req).await.unwrap();
     assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
 }
 
 #[tokio::test]
 async fn malformed_token_rejected() {
+    let (app, _dir) = app().await;
     let req = Request::builder()
         .method("POST")
         .uri("/api/sessions")
@@ -288,12 +314,13 @@ async fn malformed_token_rejected() {
         ))
         .unwrap();
 
-    let resp = app().oneshot(req).await.unwrap();
+    let resp = app.oneshot(req).await.unwrap();
     assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
 }
 
 #[tokio::test]
 async fn missing_bearer_prefix() {
+    let (app, _dir) = app().await;
     let token = default_token();
     let req = Request::builder()
         .method("POST")
@@ -309,7 +336,7 @@ async fn missing_bearer_prefix() {
         ))
         .unwrap();
 
-    let resp = app().oneshot(req).await.unwrap();
+    let resp = app.oneshot(req).await.unwrap();
     assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
 }
 
@@ -317,7 +344,8 @@ async fn missing_bearer_prefix() {
 
 #[tokio::test]
 async fn health_returns_200() {
-    let resp = app()
+    let (app, _dir) = app().await;
+    let resp = app
         .oneshot(Request::get("/api/health").body(Body::empty()).unwrap())
         .await
         .unwrap();
@@ -332,7 +360,8 @@ async fn health_returns_200() {
 
 #[tokio::test]
 async fn health_degraded_without_providers() {
-    let resp = app_no_providers()
+    let (app, _dir) = app_no_providers().await;
+    let resp = app
         .oneshot(Request::get("/api/health").body(Body::empty()).unwrap())
         .await
         .unwrap();
@@ -345,7 +374,8 @@ async fn health_degraded_without_providers() {
 
 #[tokio::test]
 async fn create_session_returns_201() {
-    let session = create_test_session(&app()).await;
+    let (app, _dir) = app().await;
+    let session = create_test_session(&app).await;
     assert!(session["id"].is_string());
     assert_eq!(session["nous_id"], "syn");
     assert_eq!(session["session_key"], "test-session");
@@ -354,7 +384,7 @@ async fn create_session_returns_201() {
 
 #[tokio::test]
 async fn get_session_returns_created_session() {
-    let router = app();
+    let (router, _dir) = app().await;
     let created = create_test_session(&router).await;
     let id = created["id"].as_str().unwrap();
 
@@ -372,7 +402,8 @@ async fn get_session_returns_created_session() {
 
 #[tokio::test]
 async fn get_unknown_session_returns_404() {
-    let resp = app()
+    let (app, _dir) = app().await;
+    let resp = app
         .oneshot(authed_get("/api/sessions/nonexistent"))
         .await
         .unwrap();
@@ -384,7 +415,7 @@ async fn get_unknown_session_returns_404() {
 
 #[tokio::test]
 async fn close_session_returns_204() {
-    let router = app();
+    let (router, _dir) = app().await;
     let created = create_test_session(&router).await;
     let id = created["id"].as_str().unwrap();
 
@@ -399,18 +430,16 @@ async fn close_session_returns_204() {
 
 #[tokio::test]
 async fn get_closed_session_shows_archived() {
-    let router = app();
+    let (router, _dir) = app().await;
     let created = create_test_session(&router).await;
     let id = created["id"].as_str().unwrap();
 
-    // Close
     router
         .clone()
         .oneshot(authed_delete(&format!("/api/sessions/{id}")))
         .await
         .unwrap();
 
-    // Get again
     let resp = router
         .clone()
         .oneshot(authed_get(&format!("/api/sessions/{id}")))
@@ -424,7 +453,8 @@ async fn get_closed_session_shows_archived() {
 
 #[tokio::test]
 async fn close_unknown_session_returns_404() {
-    let resp = app()
+    let (app, _dir) = app().await;
+    let resp = app
         .oneshot(authed_delete("/api/sessions/nonexistent"))
         .await
         .unwrap();
@@ -436,7 +466,7 @@ async fn close_unknown_session_returns_404() {
 
 #[tokio::test]
 async fn history_empty_for_new_session() {
-    let router = app();
+    let (router, _dir) = app().await;
     let created = create_test_session(&router).await;
     let id = created["id"].as_str().unwrap();
 
@@ -453,7 +483,8 @@ async fn history_empty_for_new_session() {
 
 #[tokio::test]
 async fn history_unknown_session_returns_404() {
-    let resp = app()
+    let (app, _dir) = app().await;
+    let resp = app
         .oneshot(authed_get("/api/sessions/nonexistent/history"))
         .await
         .unwrap();
@@ -463,13 +494,12 @@ async fn history_unknown_session_returns_404() {
 
 #[tokio::test]
 async fn history_with_limit() {
-    let state = test_state();
+    let (state, _dir) = test_state().await;
     let router = build_router(Arc::clone(&state));
 
     let created = create_test_session(&router).await;
     let id = created["id"].as_str().unwrap();
 
-    // Directly insert messages
     {
         let store = state.session_store.lock().unwrap();
         for i in 1..=5 {
@@ -500,7 +530,7 @@ async fn history_with_limit() {
 
 #[tokio::test]
 async fn send_message_returns_sse_content_type() {
-    let state = test_state();
+    let (state, _dir) = test_state().await;
     let router = build_router(Arc::clone(&state));
     let created = create_test_session(&router).await;
     let id = created["id"].as_str().unwrap();
@@ -525,7 +555,7 @@ async fn send_message_returns_sse_content_type() {
 
 #[tokio::test]
 async fn send_message_stream_contains_events() {
-    let state = test_state();
+    let (state, _dir) = test_state().await;
     let router = build_router(Arc::clone(&state));
     let created = create_test_session(&router).await;
     let id = created["id"].as_str().unwrap();
@@ -546,19 +576,20 @@ async fn send_message_stream_contains_events() {
 
 #[tokio::test]
 async fn send_message_unknown_session_returns_404() {
+    let (app, _dir) = app().await;
     let req = authed_request(
         "POST",
         "/api/sessions/nonexistent/messages",
         Some(serde_json::json!({ "content": "Hello!" })),
     );
 
-    let resp = app().oneshot(req).await.unwrap();
+    let resp = app.oneshot(req).await.unwrap();
     assert_eq!(resp.status(), StatusCode::NOT_FOUND);
 }
 
 #[tokio::test]
 async fn send_empty_message_returns_400() {
-    let router = app();
+    let (router, _dir) = app().await;
     let created = create_test_session(&router).await;
     let id = created["id"].as_str().unwrap();
 
@@ -574,22 +605,19 @@ async fn send_empty_message_returns_400() {
 
 #[tokio::test]
 async fn send_message_stores_in_history() {
-    let state = test_state();
+    let (state, _dir) = test_state().await;
     let router = build_router(Arc::clone(&state));
     let created = create_test_session(&router).await;
     let id = created["id"].as_str().unwrap();
 
-    // Send a message
     let req = authed_request(
         "POST",
         &format!("/api/sessions/{id}/messages"),
         Some(serde_json::json!({ "content": "Hello!" })),
     );
     let resp = router.clone().oneshot(req).await.unwrap();
-    // Consume the SSE body to ensure the blocking task completes
     let _ = body_string(resp).await;
 
-    // Check history
     let resp = router
         .clone()
         .oneshot(authed_get(&format!("/api/sessions/{id}/history")))
@@ -608,7 +636,8 @@ async fn send_message_stores_in_history() {
 
 #[tokio::test]
 async fn error_response_has_consistent_structure() {
-    let resp = app()
+    let (app, _dir) = app().await;
+    let resp = app
         .oneshot(authed_get("/api/sessions/nonexistent"))
         .await
         .unwrap();
@@ -621,6 +650,7 @@ async fn error_response_has_consistent_structure() {
 
 #[tokio::test]
 async fn malformed_create_body_returns_400() {
+    let (app, _dir) = app().await;
     let token = default_token();
     let req = Request::builder()
         .method("POST")
@@ -630,8 +660,7 @@ async fn malformed_create_body_returns_400() {
         .body(Body::from(r#"{"invalid": true}"#))
         .unwrap();
 
-    let resp = app().oneshot(req).await.unwrap();
-    // Axum returns 422 for deserialization failures
+    let resp = app.oneshot(req).await.unwrap();
     assert!(
         resp.status() == StatusCode::BAD_REQUEST
             || resp.status() == StatusCode::UNPROCESSABLE_ENTITY
@@ -640,7 +669,7 @@ async fn malformed_create_body_returns_400() {
 
 #[tokio::test]
 async fn malformed_send_body_returns_error() {
-    let router = app();
+    let (router, _dir) = app().await;
     let created = create_test_session(&router).await;
     let id = created["id"].as_str().unwrap();
 
@@ -664,7 +693,8 @@ async fn malformed_send_body_returns_error() {
 
 #[tokio::test]
 async fn list_nous_returns_agents() {
-    let resp = app()
+    let (app, _dir) = app().await;
+    let resp = app
         .oneshot(authed_get("/api/nous"))
         .await
         .unwrap();
@@ -678,7 +708,8 @@ async fn list_nous_returns_agents() {
 
 #[tokio::test]
 async fn get_nous_status() {
-    let resp = app()
+    let (app, _dir) = app().await;
+    let resp = app
         .oneshot(authed_get("/api/nous/syn"))
         .await
         .unwrap();
@@ -692,7 +723,8 @@ async fn get_nous_status() {
 
 #[tokio::test]
 async fn get_unknown_nous_returns_404() {
-    let resp = app()
+    let (app, _dir) = app().await;
+    let resp = app
         .oneshot(authed_get("/api/nous/nonexistent"))
         .await
         .unwrap();
@@ -704,7 +736,8 @@ async fn get_unknown_nous_returns_404() {
 
 #[tokio::test]
 async fn get_nous_tools() {
-    let resp = app()
+    let (app, _dir) = app().await;
+    let resp = app
         .oneshot(authed_get("/api/nous/syn/tools"))
         .await
         .unwrap();
@@ -718,7 +751,7 @@ async fn get_nous_tools() {
 
 #[tokio::test]
 async fn concurrent_session_creation() {
-    let state = test_state();
+    let (state, _dir) = test_state().await;
     let mut handles = Vec::new();
 
     for i in 0..5 {
@@ -747,7 +780,7 @@ async fn concurrent_session_creation() {
 
 #[tokio::test]
 async fn send_message_no_provider_returns_error() {
-    let state = test_state_with_provider(false);
+    let (state, _dir) = test_state_with_provider(false).await;
     let router = build_router(Arc::clone(&state));
     let created = create_test_session(&router).await;
     let id = created["id"].as_str().unwrap();
@@ -760,4 +793,48 @@ async fn send_message_no_provider_returns_error() {
 
     let resp = router.clone().oneshot(req).await.unwrap();
     assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+}
+
+// --- Actor-routed tests ---
+
+#[tokio::test]
+async fn send_message_routes_through_actor() {
+    let (state, _dir) = test_state().await;
+    let router = build_router(Arc::clone(&state));
+    let created = create_test_session(&router).await;
+    let id = created["id"].as_str().unwrap();
+
+    let req = authed_request(
+        "POST",
+        &format!("/api/sessions/{id}/messages"),
+        Some(serde_json::json!({ "content": "Test routing" })),
+    );
+
+    let resp = router.clone().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = body_string(resp).await;
+
+    assert!(body.contains("event: text_delta"), "should have text_delta");
+    assert!(body.contains("Hello from mock!"), "should contain mock response");
+    assert!(body.contains("event: message_complete"), "should have message_complete");
+    assert!(body.contains("end_turn"), "stop_reason should be end_turn");
+}
+
+#[tokio::test]
+async fn nous_list_from_manager() {
+    let (state, _dir) = test_state().await;
+    let router = build_router(Arc::clone(&state));
+
+    let resp = router
+        .oneshot(authed_get("/api/nous"))
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = body_json(resp).await;
+    let agents = body["nous"].as_array().unwrap();
+    assert_eq!(agents.len(), 1);
+    assert_eq!(agents[0]["id"], "syn");
+    assert_eq!(agents[0]["model"], "mock-model");
+    assert_eq!(agents[0]["status"], "active");
 }


### PR DESCRIPTION
## Summary

- Route `POST /api/sessions/{id}/messages` through `NousHandle::send_turn()` instead of direct `provider.complete()` calls
- Rewrite nous handlers (`list`, `get_status`, `tools`) to query live actor state from `NousManager`
- Remove `SessionManager` from `AppState`, replace with `NousManager`
- Add config storage (`get_config`, `configs`) and `shutdown_readonly` to `NousManager`
- Arc-wrap `ProviderRegistry`/`ToolRegistry`/`Oikos` for shared ownership with actors
- Map `TurnResult` → SSE events preserving existing event format
- Async test infrastructure with TempDir-backed oikos and spawned actors

## Test plan

- [x] `cargo clippy --workspace --all-targets -- -D warnings` — zero warnings
- [x] `cargo test --workspace` — all tests pass (718+)
- [x] `send_message_routes_through_actor` — verifies actor pipeline produces expected SSE events
- [x] `nous_list_from_manager` — verifies list endpoint reads from NousManager
- [x] All existing pylon tests updated and passing