### PR TITLE
docs: update repo documentation for Rust-first architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,37 @@
 # Aletheia
 
-*Self-hosted multi-agent AI system with a web UI, persistent memory, and Signal messaging.*
+Self-hosted multi-agent AI system with persistent memory, Signal messaging, and a web UI.
 
-Privacy-first. Runs on commodity hardware as a systemd service. No cloud dependencies beyond your LLM API key.
+Privacy-first. Runs on commodity hardware. No cloud dependencies beyond your LLM API key.
 
 **v0.10.0** | [Quickstart](docs/QUICKSTART.md) | [Configuration](docs/CONFIGURATION.md) | [Development](docs/DEVELOPMENT.md)
 
 ---
 
 ## Architecture
+
+Aletheia is being rewritten in Rust. The target is a single static binary that replaces the current Node.js gateway, Python memory sidecar, and all shell scripts with one `scp + systemctl` deployment. The TypeScript runtime still runs production today while the Rust crates reach feature parity.
+
+### Rust Crates (in progress)
+
+```
+aletheia (binary)
+├── koina           shared errors (snafu), tracing, fs utilities
+├── taxis           config loading (figment YAML cascade), path resolution, oikos hierarchy
+├── mneme           unified memory store (sqlite + fastembed + optional CozoDB)
+├── mneme-engine    CozoDB embedded database (vectors, graph, relations, bi-temporal facts)
+├── hermeneus       Anthropic client, model routing, credential management
+├── organon         tool registry, built-in tool definitions
+├── nous            agent pipeline, actor model (tokio), bootstrap, recall, finalize
+├── melete          context distillation, compression strategies, token budgets
+├── agora           channel registry, ChannelProvider trait, Signal provider (semeion)
+├── pylon           Axum HTTP gateway, SSE streaming, static UI serving
+└── symbolon        JWT authentication, session management, RBAC
+```
+
+11 application crates, 718 tests, ~21K lines of Rust. See [PROJECT.md](docs/PROJECT.md) for milestone status and the full roadmap.
+
+### TypeScript Runtime (current production)
 
 ```
          Web UI (Svelte 5)          Signal Messenger
@@ -35,7 +58,7 @@ Privacy-first. Runs on commodity hardware as a systemd service. No cloud depende
 
 **Runtime**: Node.js >=22.12, TypeScript compiled with tsdown (~450KB bundle), Hono gateway on port 18789.
 
-**Interfaces**: Svelte 5 web UI with streaming, file upload, syntax highlighting, thinking visualization, and force-directed memory graph. Signal messenger via signal-cli. 15 built-in `!` commands. CLI admin tools.
+**Interfaces**: Svelte 5 web UI with streaming, file upload, syntax highlighting, and thinking visualization. Signal messenger via signal-cli. 15 built-in `!` commands. CLI admin tools.
 
 **Models**: Anthropic (OAuth or API key). Complexity-based routing. Extended thinking for reasoning models.
 
@@ -49,37 +72,51 @@ Privacy-first. Runs on commodity hardware as a systemd service. No cloud depende
 
 ```
 aletheia/
-├── nous/                   Agent workspaces (SOUL.md, MEMORY.md, etc.)
-│   └── _example/           Template workspace
-├── shared/                 Common scripts, templates, config, skills
+├── crates/                     Rust workspace (the rewrite)
+│   ├── koina/                  Shared errors, tracing, utilities
+│   ├── taxis/                  Config loading, path resolution
+│   ├── mneme/                  Unified memory store
+│   ├── mneme-engine/           CozoDB embedded database
+│   ├── hermeneus/              Anthropic client, model routing
+│   ├── organon/                Tool registry
+│   ├── nous/                   Agent pipeline, actor model
+│   ├── melete/                 Distillation, reflection
+│   ├── agora/                  Channel registry, Signal provider
+│   ├── pylon/                  Axum HTTP gateway
+│   ├── symbolon/               Authentication, RBAC
+│   ├── graph-builder/          Build-time dependency graph visualization
+│   └── integration-tests/      Cross-crate integration tests
+│
+├── nous/                       Agent workspaces (SOUL.md, MEMORY.md, etc.)
+│   └── _example/               Template workspace
+├── shared/                     Common scripts, templates, config, skills
 ├── infrastructure/
-│   ├── runtime/            Gateway (TypeScript/tsdown)
+│   ├── runtime/                Gateway (TypeScript/tsdown) -- current production
 │   │   └── src/
 │   │       ├── taxis/          Config loading + validation (Zod)
 │   │       ├── mneme/          Session store (better-sqlite3, 10 migrations)
 │   │       ├── hermeneus/      Anthropic SDK + provider router
-│   │       ├── organon/        Tool registry + 41 built-in tools + skills
+│   │       ├── organon/        Tool registry + 48 built-in tools + skills
 │   │       ├── semeion/        Signal client, listener, commands
 │   │       ├── pylon/          Hono HTTP gateway, MCP, Web UI
-│   │       ├── prostheke/      Plugin system
 │   │       ├── nous/           Agent bootstrap + turn pipeline
-│   │       ├── melete/         Disciplined practice — distillation, reflection
-│   │       ├── symbolon/       Split-token authentication — JWT, sessions, RBAC
+│   │       ├── melete/         Distillation, reflection, memory flush
+│   │       ├── symbolon/       Split-token authentication
 │   │       ├── dianoia/        Multi-phase planning orchestrator
 │   │       ├── daemon/         Cron, watchdog, update checker
 │   │       └── koina/          Shared utilities
-│   ├── memory/             Mem0 sidecar + docker-compose (Qdrant, Neo4j)
-│   ├── langfuse/           Self-hosted observability
-│   └── prosoche/           Adaptive attention daemon
-├── ui/                     Web UI (Svelte 5)
-└── config/                 Example configuration
+│   ├── memory/                 Mem0 sidecar + docker-compose (Qdrant, Neo4j)
+│   ├── langfuse/               Self-hosted observability
+│   └── prosoche/               Adaptive attention daemon
+├── ui/                         Web UI (Svelte 5)
+└── config/                     Example configuration
 ```
 
 ---
 
 ## Why Greek?
 
-Every name in this system — Aletheia, Dianoia, Prosoche, Symbolon — follows a deliberate naming philosophy. Names unconceal essential natures, not describe implementations. Greek provides the precision: where English has "knowledge," Greek distinguishes between episteme, gnosis, techne, phronesis, and nous — each a fundamentally different stance toward knowing. Where English has "form," Greek has morphe, schema, eidos — each a different structural relationship.
+Every name in this system follows a deliberate naming philosophy. Names unconceal essential natures, not describe implementations. Greek provides the precision: where English has "knowledge," Greek distinguishes between episteme, gnosis, techne, phronesis, and nous, each a fundamentally different stance toward knowing. Where English has "form," Greek has morphe, schema, eidos, each a different structural relationship.
 
 See **[docs/gnomon.md](docs/gnomon.md)** for the full naming system, including the layer test, dimensional resonance, and the process for naming new components.
 
@@ -121,13 +158,13 @@ Svelte 5 at `/ui`. Streaming responses, file upload, syntax highlighting, thinki
 
 Full REST API on port 18789. Key endpoints:
 
-- `/health` — health check
-- `/api/status` — agent list + version
-- `/api/agents` — all agents with model info
-- `/api/sessions/stream` — streaming message (SSE)
-- `/api/costs/summary` — token usage and cost
-- `/api/metrics` — full system metrics
-- `/api/events` — SSE event stream
+- `/health` -- health check
+- `/api/status` -- agent list + version
+- `/api/agents` -- all agents with model info
+- `/api/sessions/stream` -- streaming message (SSE)
+- `/api/costs/summary` -- token usage and cost
+- `/api/metrics` -- full system metrics
+- `/api/events` -- SSE event stream
 
 See [DEVELOPMENT.md](docs/DEVELOPMENT.md) for full endpoint list.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,43 +1,103 @@
 # Architecture
 
-> Module map, initialization order, directed dependency graph, and extension points
-> for all runtime modules. Updated when modules are added or boundaries change.
-> Last updated: 2026-02-25
+> Module map, dependency graph, trait boundaries, and extension points.
+> Covers both the Rust crate workspace (target architecture) and the TypeScript runtime (current production).
+> Last updated: 2026-03-01
 
 ---
 
 ## Naming
 
-Module and subsystem names follow the naming philosophy documented in **[gnomon.md](gnomon.md)**. Names unconceal essential natures — the fundamental character of a thing that persists across implementation changes. Each name should pass the layer test (L1 practical through L4 reflexive) and compose with existing names in the system topology.
+Module and subsystem names follow the naming philosophy documented in **[gnomon.md](gnomon.md)**. Names unconceal essential natures, not describe implementations. Each name should pass the layer test (L1 practical through L4 reflexive) and compose with existing names in the system topology.
 
 When adding a new module, check gnomon.md's process section and anti-patterns before choosing a name.
 
 ---
 
-## Modules
+## Rust Crate Workspace
+
+11 application crates in `crates/`, plus `graph-builder` (build tool), `integration-tests` (test harness), `mneme-bench` (benchmarks, excluded from default build).
+
+### Crates
+
+| Crate | Domain | Depends On |
+|-------|--------|------------|
+| `koina` | Errors (snafu), tracing, fs utilities, safe wrappers | nothing (leaf) |
+| `taxis` | Config loading (figment YAML cascade), path resolution, oikos hierarchy | koina |
+| `mneme-engine` | CozoDB embedded database: vectors, graph, relations, bi-temporal facts | nothing (vendored) |
+| `mneme` | Unified memory store, embedding provider trait, knowledge retrieval | koina, mneme-engine (optional) |
+| `hermeneus` | Anthropic client, model routing, credential management, provider trait | koina |
+| `organon` | Tool registry, tool definitions, built-in tool set | koina, hermeneus |
+| `symbolon` | JWT tokens, password hashing, RBAC policies | nothing (leaf) |
+| `nous` | Agent pipeline, NousActor (tokio), bootstrap, recall, execute, finalize | koina, taxis, mneme, hermeneus, organon |
+| `melete` | Context distillation, compression strategies, token budget management | koina, hermeneus |
+| `agora` | Channel registry, ChannelProvider trait, Signal JSON-RPC client | koina, taxis |
+| `pylon` | Axum HTTP gateway, SSE streaming, static UI serving, auth middleware | koina, taxis, hermeneus, organon, mneme, nous, symbolon |
+
+### Dependency Graph
+
+```
+                        pylon
+                     /  | |  \  \
+                   /    | |   \   \
+                nous  symbolon  |   |
+              / | | \         mneme |
+            /   |  \  \        |    |
+       taxis organon melete    |    |
+          |     |      |       |    |
+        koina  hermeneus    mneme-engine
+                                    agora
+                                   /    \
+                                taxis  koina
+```
+
+Imports are directional. Higher-layer crates may depend on lower layers. Lower-layer crates must not depend on higher layers. `koina` and `symbolon` are true leaf nodes with no internal dependencies.
+
+### Trait Boundaries
+
+These traits define the extension points between crates. Implement the trait, swap the provider.
+
+| Trait | Crate | Purpose | Implementations |
+|-------|-------|---------|-----------------|
+| `EmbeddingProvider` | mneme | Vector embeddings from text | `FastEmbedProvider` (local, default), HTTP API (optional) |
+| `ChannelProvider` | agora | Send/receive on a messaging channel | `SignalProvider` (signal-cli JSON-RPC) |
+| `ModelProvider` | hermeneus | LLM API calls | `AnthropicProvider` |
+
+### Planned Crates (Not Yet Built)
+
+These exist as TypeScript modules in the current runtime. They will become Rust crates as the rewrite progresses.
+
+| Crate | Domain | Milestone |
+|-------|--------|-----------|
+| `daemon` | Per-nous background tasks, cron, prosoche integration | M4 |
+| `dianoia` | Multi-phase planning orchestrator | M4 |
+| `prostheke` | WASM plugin host (wasmtime) | M5 |
+| `autarkeia` | Agent export/import | M5 |
+
+---
+
+## TypeScript Runtime (Current Production)
 
 All 14 modules in `infrastructure/runtime/src/`:
 
 | Module | Domain | Files | Public Surface |
 |--------|--------|-------|----------------|
-| `koina` | Shared utilities — leaf node | 22 | `createLogger`, `AletheiaError` hierarchy, `trySafe`/`trySafeAsync`, `eventBus`, crypto, PII scanner, hooks |
+| `koina` | Shared utilities, leaf node | 22 | `createLogger`, `AletheiaError` hierarchy, `trySafe`/`trySafeAsync`, `eventBus`, crypto, PII scanner, hooks |
 | `taxis` | Config loading, Zod validation, paths | 7 | `loadConfig`, `AletheiaConfigSchema`, `paths`, `resolveNous`, `scaffoldAgent` |
 | `mneme` | Session store, SQLite, migrations | 4 | `SessionStore`, `makeDb`, session/thread/message CRUD |
 | `hermeneus` | Anthropic SDK, provider routing, token counting | 11 | `AnthropicProvider`, `createDefaultRouter`, `ProviderRouter`, token counter, pricing |
 | `organon` | 48 built-in tools, skills registry, MCP client | 30 | `ToolRegistry`, `ToolHandler`, `SkillRegistry`, `McpClientManager` |
 | `nous` | Agent bootstrap, turn pipeline, competence model | 36 | `NousManager`, turn orchestration, `CompetenceModel`, `UncertaintyTracker`, pipeline config |
-| `melete` | Disciplined practice — distillation, reflection, memory flush | 16 | `distillSession`, `reflectOnAgent`, `weeklyReflection`, `MemoryFlushTarget` |
+| `melete` | Distillation, reflection, memory flush | 16 | `distillSession`, `reflectOnAgent`, `weeklyReflection`, `MemoryFlushTarget` |
 | `semeion` | Signal client, TTS, commands, listener | 20 | `SignalClient`, `createDefaultRegistry` (commands), `startListener`, `DaemonHandle` |
 | `pylon` | Hono HTTP gateway, MCP server, Web UI routes | 9 | `createGateway`, `startGateway`, MCP handlers, UI routes |
 | `prostheke` | Plugin system, lifecycle hooks | 5 | `PluginRegistry`, plugin loader, hook dispatch |
 | `daemon` | Cron scheduler, watchdog, update checker, reflection cron | 14 | `CronScheduler`, `Watchdog`, `startUpdateChecker`, reflection/evolution jobs |
 | `dianoia` | Multi-phase planning orchestrator | 34 | `DianoiaOrchestrator`, `PlanningStore`, `ResearchOrchestrator`, `RequirementsOrchestrator`, `RoadmapOrchestrator`, `ExecutionOrchestrator`, `GoalBackwardVerifier`, `CheckpointSystem` |
-| `symbolon` | Split-token authentication — JWT, sessions, RBAC, passwords | 13 | `AuthSessionStore`, `AuditLog`, `createAuthMiddleware`, `createAuthRoutes`, `signToken`, `verifyToken`, `hashPassword`, `rbac` |
+| `symbolon` | Split-token authentication, JWT, sessions, RBAC, passwords | 13 | `AuthSessionStore`, `AuditLog`, `createAuthMiddleware`, `createAuthRoutes`, `signToken`, `verifyToken`, `hashPassword`, `rbac` |
 | `portability` | Agent import/export (AgentFile format) | 5 | `exportAgent`, `importAgent`, `AgentFile`, portability CLI |
 
----
-
-## Initialization Order
+### Initialization Order
 
 Derived from `infrastructure/runtime/src/aletheia.ts`:
 
@@ -49,90 +109,72 @@ taxis → mneme → hermeneus → organon → nous → dianoia → prostheke →
 
 **createRuntime() sequence:**
 
-1. `taxis` — load and validate config (`loadConfig`)
-2. `koina/encryption` — init encryption (depends on config)
-3. `mneme` — open SQLite store (`new SessionStore`)
-4. `hermeneus` — create provider router (`createDefaultRouter`)
-5. `organon` — create tool registry (`new ToolRegistry`), register all built-in tools
-6. `nous` — create manager (`new NousManager`); wires mneme, hermeneus, organon
-7. `dianoia` — create planning store and orchestrators; wired into nous manager
-8. `prostheke` — create plugin registry (`new PluginRegistry`)
-9. `nous/competence` — create competence model and uncertainty tracker; wired into nous manager
+1. `taxis` -- load and validate config (`loadConfig`)
+2. `koina/encryption` -- init encryption (depends on config)
+3. `mneme` -- open SQLite store (`new SessionStore`)
+4. `hermeneus` -- create provider router (`createDefaultRouter`)
+5. `organon` -- create tool registry (`new ToolRegistry`), register all built-in tools
+6. `nous` -- create manager (`new NousManager`); wires mneme, hermeneus, organon
+7. `dianoia` -- create planning store and orchestrators; wired into nous manager
+8. `prostheke` -- create plugin registry (`new PluginRegistry`)
+9. `nous/competence` -- create competence model and uncertainty tracker; wired into nous manager
 
 **startRuntime() continuation (after createRuntime):**
 
-10. `prostheke` — discover and load plugins
-11. `koina/hooks` — register declarative YAML hooks from disk
-12. `semeion` — initialize Signal client, listener, commands (if configured)
-13. `pylon` — create HTTP gateway, mount routes; wires auth, semeion, daemon refs
-14. `daemon` — start cron scheduler, watchdog, update checker
+10. `prostheke` -- discover and load plugins
+11. `koina/hooks` -- register declarative YAML hooks from disk
+12. `semeion` -- initialize Signal client, listener, commands (if configured)
+13. `pylon` -- create HTTP gateway, mount routes; wires auth, semeion, daemon refs
+14. `daemon` -- start cron scheduler, watchdog, update checker
 
-**Auth initialization** — `symbolon` module is stateless utilities. `AuthSessionStore` and `AuditLog` are instantiated in `startGateway` via `pylon/server.ts` using the existing mneme SQLite `Database` handle.
+**Auth initialization** -- `symbolon` module is stateless utilities. `AuthSessionStore` and `AuditLog` are instantiated in `startGateway` via `pylon/server.ts` using the existing mneme SQLite `Database` handle.
 
----
+### Dependency Rules
 
-## Dependency Rules
-
-Imports are directional. Higher-layer modules may import lower layers. Lower-layer modules must not import higher layers (prevents initialization cycles and tight coupling).
-
-All rows verified by reading each module's entry files.
+Imports are directional. Higher-layer modules may import lower layers. Lower-layer modules must not import higher layers.
 
 | Module | May Import | Must Not Import |
 |--------|-----------|-----------------|
-| `koina` | (nothing — leaf node) | Any other module |
-| `taxis` | `koina` | `mneme`, `hermeneus`, `organon`, `nous`, `melete`, `semeion`, `pylon`, `prostheke`, `daemon`, `dianoia`, `symbolon`, `portability` |
-| `mneme` | `koina`, `taxis` | `hermeneus`, `organon`, `nous`, `melete`, `semeion`, `pylon`, `prostheke`, `daemon`, `dianoia`, `symbolon`, `portability` |
-| `hermeneus` | `koina`, `taxis` | `mneme`, `organon`, `nous`, `melete`, `semeion`, `pylon`, `prostheke`, `daemon`, `dianoia`, `symbolon`, `portability` |
-| `organon` | `koina`, `taxis`, `hermeneus` | `nous`, `melete`, `semeion`, `pylon`, `prostheke`, `daemon`, `dianoia`, `symbolon`, `portability` |
-| `nous` | `koina`, `taxis`, `mneme`, `hermeneus`, `organon`, `melete` | `semeion`, `pylon`, `daemon`, `symbolon`, `portability` |
-| `melete` | `koina`, `taxis`, `mneme`, `hermeneus`, `nous` (reflection only) | `semeion`, `pylon`, `prostheke`, `daemon`, `symbolon`, `portability` |
-| `semeion` | `koina`, `taxis`, `mneme`, `nous`, `organon`, `daemon` (watchdog type) | `pylon`, `prostheke`, `symbolon`, `portability` |
-| `pylon` | `koina`, `taxis`, `mneme`, `hermeneus`, `nous`, `organon`, `semeion`, `symbolon`, `daemon`, `dianoia`, `melete` | `prostheke`, `portability` |
-| `prostheke` | `koina`, `taxis`, `organon` | `mneme`, `hermeneus`, `nous`, `melete`, `semeion`, `pylon`, `daemon`, `dianoia`, `symbolon`, `portability` |
-| `daemon` | `koina`, `taxis`, `mneme`, `hermeneus`, `nous`, `melete` | `semeion`, `pylon`, `prostheke`, `symbolon`, `portability` |
-| `dianoia` | `koina`, `taxis`, `mneme`, `organon`, `pylon` (routes type import only) | `hermeneus`, `nous`, `melete`, `semeion`, `prostheke`, `daemon`, `symbolon`, `portability` |
-| `symbolon` | `koina` (node:crypto only — no aletheia module imports) | All aletheia modules |
-| `portability` | `koina`, `taxis`, `mneme` | `hermeneus`, `organon`, `nous`, `melete`, `semeion`, `pylon`, `prostheke`, `daemon`, `dianoia`, `symbolon` |
-
-**Notes:**
-
-- `melete` has a narrow upward reference to `nous/competence.ts` for reflection jobs — this is a known coupling point. The dependency flows through `daemon/reflection-cron.ts` which imports both.
-- `semeion` imports `daemon/watchdog.ts` as a type import for the watchdog alert function injected via commands.
-- `dianoia` has one type import from `pylon/routes/deps.ts` in `dianoia/routes.ts` — the planning routes are mounted by pylon, and the route file is technically in dianoia but wired into pylon at startup. This is an accepted architectural exception.
-- `symbolon` is a stateless utilities module — it imports only from `node:crypto` and `hono`. It has no aletheia module dependencies by design.
+| `koina` | (nothing, leaf node) | Any other module |
+| `taxis` | `koina` | everything else |
+| `mneme` | `koina`, `taxis` | everything else |
+| `hermeneus` | `koina`, `taxis` | everything else |
+| `organon` | `koina`, `taxis`, `hermeneus` | everything else |
+| `nous` | `koina`, `taxis`, `mneme`, `hermeneus`, `organon`, `melete`, `portability` | `semeion`, `pylon`, `prostheke`, `daemon`, `dianoia`, `symbolon` |
+| `melete` | `koina`, `taxis`, `mneme`, `hermeneus` | `organon`, `nous`, `semeion`, `pylon`, `prostheke`, `daemon`, `dianoia`, `symbolon`, `portability` |
+| `symbolon` | `koina` | everything else (stateless utilities) |
+| `dianoia` | `koina`, `taxis`, `mneme`, `hermeneus`, `organon`, `nous` | `semeion`, `pylon`, `prostheke`, `daemon`, `symbolon`, `melete`, `portability` |
+| `semeion` | `koina`, `taxis`, `mneme`, `hermeneus`, `organon`, `nous`, `dianoia` | `pylon`, `prostheke`, `daemon`, `symbolon`, `melete`, `portability` |
+| `pylon` | `koina`, `taxis`, `mneme`, `hermeneus`, `organon`, `nous`, `dianoia`, `semeion`, `symbolon`, `daemon` | `prostheke`, `melete`, `portability` |
+| `prostheke` | `koina`, `organon` | `taxis`, `mneme`, `hermeneus`, `nous`, `melete`, `semeion`, `pylon`, `daemon`, `dianoia`, `symbolon`, `portability` |
+| `daemon` | `koina`, `taxis`, `mneme`, `hermeneus`, `nous`, `melete` | `organon`, `semeion`, `pylon`, `prostheke`, `dianoia`, `symbolon`, `portability` |
+| `portability` | `koina`, `taxis`, `mneme`, `hermeneus`, `organon`, `nous` | `melete`, `semeion`, `pylon`, `prostheke`, `daemon`, `dianoia`, `symbolon` |
 
 ---
 
-## Extension Points
+## Adding Components
 
-### Adding a Tool
+### Adding a Rust Crate
 
-1. Create `infrastructure/runtime/src/organon/built-in/my-tool.ts` implementing `ToolHandler`
-2. Export it as a named constant: `export const myTool: ToolHandler = { definition: {...}, execute: ... }`
-3. Register in `aletheia.ts`: `tools.register(myTool)` (or as factory if it needs deps)
-4. If the tool is synchronous on all branches: use `execute(input): Promise<string>` with `return Promise.resolve(result)` — not `async execute()` with no `await` (triggers `require-await`)
-5. Throw `ToolError` or appropriate `AletheiaError` subclass, never bare `Error`
-6. Categories: `"essential"` (always loaded) or `"available"` (on-demand via `enable_tool`, expires after 5 unused turns)
+1. Create `crates/<name>/` with `Cargo.toml` and `src/lib.rs`
+2. Add to workspace `members` in root `Cargo.toml`
+3. Declare its layer in the dependency graph (what it depends on, who may depend on it)
+4. Update this file: add row to Crates table, verify the dependency graph, note any new traits
+5. All workspace lints apply automatically via `[workspace.lints]`
 
-### Adding a Command (Signal)
+### Adding a TypeScript Module
 
-1. Register in `createDefaultRegistry()` in `src/semeion/commands.ts`
-2. Provide `name`, `aliases`, `description`, `adminOnly`, and `async execute(args, ctx)` returning a response string
-3. `CommandContext` provides: `sender`, `client`, `store`, `config`, `manager`, `watchdog`, `skills`
-
-### Adding a Module
-
-1. Create `infrastructure/runtime/src/my-module/` with a focused domain responsibility
-2. Determine its layer in the dependency graph (what it imports, who may import it)
+1. Create `src/<name>/` with entry file (avoid `index.ts` for leaf modules)
+2. Define its layer in the dependency graph (what it imports, who may import it)
 3. Wire into initialization sequence in `aletheia.ts` (or `startRuntime` for services)
-4. Update this file (ARCHITECTURE.md): add row to Modules table, Dependency Rules table, and update Initialization Order
+4. Update this file: add row to Modules table, Dependency Rules table, and update Initialization Order
 5. The `.claude/rules/architecture.md` agent context automatically informs dispatched agents of the updated boundary rules once this file is updated
 
 ### Adding an Event
 
 1. Follow `noun:verb` format (e.g., `distill:before`, `plugin:loaded`)
 2. Define the event constant in the relevant module's event file or at point of emission
-3. Keep the event name greppable — use the module name as the noun for module lifecycle events
+3. Keep the event name greppable -- use the module name as the noun for module lifecycle events
 4. Document in `docs/STANDARDS.md#rule-event-name-format`
 
 ### Adding a Plugin
@@ -147,10 +189,14 @@ Plugins live outside the runtime at `~/.aletheia/plugins/<id>/`. They integrate 
 
 ## Key Structural Properties
 
-**koina is a true leaf node.** It has no `index.ts` by design — all imports must reference the specific file (e.g., `../koina/logger.js`, not `../koina/index.js`). This prevents circular dependencies and ensures only the needed symbols are loaded.
+**koina is a true leaf node** in both Rust and TypeScript. In TS, it has no `index.ts` by design. All imports must reference the specific file (e.g., `../koina/logger.js`). This prevents circular dependencies and ensures only the needed symbols are loaded.
 
-**symbolon is a zero-dependency utilities module.** `symbolon/tokens.ts`, `symbolon/passwords.ts`, `symbolon/rbac.ts` import only from `node:crypto` and `hono`. `symbolon/sessions.ts` and `symbolon/audit.ts` take `Database.Database` as a constructor argument. This design allows symbolon to be tested and used independently of the runtime.
+**symbolon is a zero-dependency utilities module** in both stacks. TS version: `symbolon/tokens.ts`, `symbolon/passwords.ts`, `symbolon/rbac.ts` import only from `node:crypto` and `hono`. `symbolon/sessions.ts` and `symbolon/audit.ts` take `Database.Database` as a constructor argument. Rust version: standalone crate with no workspace dependencies.
 
-**dianoia routes are a seam.** `dianoia/routes.ts` imports a type from `pylon/routes/deps.ts` to satisfy the Hono route handler signature. The route file is owned by dianoia but mounted by pylon. If this coupling becomes a problem, the route file can move to `pylon/routes/plans.ts` with no behavioral change.
+**dianoia routes are a seam** (TS only). `dianoia/routes.ts` imports a type from `pylon/routes/deps.ts` to satisfy the Hono route handler signature. The route file is owned by dianoia but mounted by pylon. If this coupling becomes a problem, the route file can move to `pylon/routes/plans.ts` with no behavioral change.
 
-**daemon imports nous and melete.** The cron and reflection jobs need `NousManager` (to dispatch messages to agents) and melete functions (to run reflection cycles). This makes daemon a high-layer module despite its name suggesting infrastructure. Daemon must not be imported by other modules — it is a leaf in the upward direction.
+**daemon imports nous and melete** (TS only). The cron and reflection jobs need `NousManager` (to dispatch messages to agents) and melete functions (to run reflection cycles). This makes daemon a high-layer module despite its name suggesting infrastructure. Daemon must not be imported by other modules.
+
+**mneme-engine is vendored.** The CozoDB database engine is absorbed into the workspace as a vendored crate. It has no workspace dependencies and is an optional dependency of `mneme` (behind the `mneme-engine` feature flag).
+
+**Trait boundaries are the extension points.** `EmbeddingProvider`, `ChannelProvider`, and `ModelProvider` define where the system can be extended without modifying existing crates. New providers implement the trait and register at startup.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1,8 +1,22 @@
 # Aletheia Configuration Reference
 
+## Current Runtime (TypeScript)
+
 Config file location: `~/.aletheia/aletheia.json`
 
 Validated at startup against the Zod schema in `src/taxis/schema.ts`. Unknown top-level fields are preserved (passthrough) for forward compatibility.
+
+## Rust Crates
+
+Config file location: `instance/config/aletheia.yaml` (or `~/.aletheia/aletheia.yaml`)
+
+Loaded by the `taxis` crate using figment with a three-layer cascade: compiled defaults, YAML file, environment variables (prefix `ALETHEIA_`). Environment variables override YAML, YAML overrides defaults. The Rust config uses `AletheiaConfig` structs validated at deserialization time, not a separate validation pass.
+
+Key differences from the JSON config:
+- YAML format instead of JSON
+- Figment cascade (defaults, file, env) instead of single-file loading
+- camelCase field names still work (compat layer), but snake_case is canonical
+- Secret values use `SecretString` from the `secrecy` crate, never logged or serialized to debug output
 
 ---
 
@@ -96,6 +110,7 @@ Each entry defines a nous (agent).
 
 Extra fields are preserved (passthrough).
 
+**JSON example (current runtime):**
 ```json
 {
   "id": "research",
@@ -104,6 +119,19 @@ Extra fields are preserved (passthrough).
   "model": "claude-sonnet-4-5-20250929",
   "identity": { "name": "Scholar", "emoji": "📚" }
 }
+```
+
+**YAML example (Rust):**
+```yaml
+agents:
+  list:
+    - id: research
+      name: Scholar
+      workspace: /path/to/aletheia/instance/nous/scholar
+      model: claude-sonnet-4-5-20250929
+      identity:
+        name: Scholar
+        emoji: "📚"
 ```
 
 ---
@@ -459,7 +487,7 @@ Used in `agents.defaults.heartbeat` or per-agent `heartbeat`. Sends periodic che
 
 ## Minimal Config
 
-The smallest working configuration:
+### JSON (current runtime)
 
 ```json
 {
@@ -476,6 +504,19 @@ The smallest working configuration:
     ]
   }
 }
+```
+
+### YAML (Rust)
+
+```yaml
+agents:
+  defaults:
+    model:
+      primary: claude-sonnet-4-5-20250929
+  list:
+    - id: main
+      default: true
+      workspace: /path/to/instance/nous/main
 ```
 
 Everything else has sensible defaults. Add sections as needed.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -2,6 +2,16 @@
 
 ## Prerequisites
 
+### Rust (crate workspace)
+
+| Tool | Version | Purpose |
+|------|---------|---------|
+| Rust | 1.85+ (2024 edition) | Compiler |
+| cargo | (bundled) | Build system, package manager |
+| clippy | (bundled) | Linting (zero warnings policy) |
+
+### TypeScript (current runtime)
+
 | Tool | Version | Purpose |
 |------|---------|---------|
 | Node.js | >= 22.12 | Runtime |
@@ -15,6 +25,20 @@ Optional: Docker (Qdrant, Neo4j, Langfuse), signal-cli, Chromium (browser tool).
 
 ## Building
 
+### Rust
+
+```bash
+cargo build                     # debug build
+cargo build --release           # release build (LTO, stripped)
+cargo clippy --workspace        # lint (must be zero warnings)
+```
+
+The workspace uses pedantic clippy lints with select allows (`missing_errors_doc`, `module_name_repetitions`, `must_use_candidate`). `dbg!`, `todo!`, and `unimplemented!` are denied. `unsafe` is denied workspace-wide.
+
+Release profile: thin LTO, single codegen unit, symbols stripped.
+
+### TypeScript
+
 ```bash
 cd infrastructure/runtime && npm install && npx tsdown
 ```
@@ -27,7 +51,28 @@ For dev without building: `npm run dev` (tsx).
 
 ## Module Architecture
 
-Initialization order: `taxis → mneme → hermeneus → organon → nous → dianoia → prostheke → daemon` (semeion + pylon wired at runtime start)
+### Rust Crate Dependency Graph
+
+```
+                        pylon
+                     /  | |  \  \
+                   /    | |   \   \
+                nous  symbolon  |   |
+              / | | \         mneme |
+            /   |  \  \        |    |
+       taxis organon melete    |    |
+          |     |      |       |    |
+        koina  hermeneus    mneme-engine
+                                    agora
+                                   /    \
+                                taxis  koina
+```
+
+See [ARCHITECTURE.md](ARCHITECTURE.md) for the full dependency rules and trait boundaries.
+
+### TypeScript Initialization Order
+
+`taxis -> mneme -> hermeneus -> organon -> nous -> dianoia -> prostheke -> daemon` (semeion + pylon wired at runtime start)
 
 | Module | Domain | Key Files |
 |--------|--------|-----------|
@@ -37,8 +82,8 @@ Initialization order: `taxis → mneme → hermeneus → organon → nous → di
 | `hermeneus` | Anthropic SDK, provider router, token counting | `anthropic.ts`, `router.ts`, `complexity.ts`, `pricing.ts` |
 | `organon` | 48 built-in tools, skills, self-authoring | `registry.ts`, `skills.ts`, `built-in/*.ts` |
 | `nous` | Agent bootstrap, turn pipeline, working state | `manager.ts`, `bootstrap.ts`, `working-state.ts`, `pipeline/` |
-| `melete` | Disciplined practice — distillation, reflection | `pipeline.ts`, `extract.ts`, `reflect.ts`, `summarize.ts` |
-| `symbolon` | Split-token authentication — JWT, sessions, RBAC | `tokens.ts`, `passwords.ts`, `sessions.ts`, `rbac.ts` |
+| `melete` | Distillation, reflection, memory flush | `pipeline.ts`, `extract.ts`, `reflect.ts`, `summarize.ts` |
+| `symbolon` | Split-token authentication, JWT, sessions, RBAC | `tokens.ts`, `passwords.ts`, `sessions.ts`, `rbac.ts` |
 | `dianoia` | Multi-phase planning orchestrator | `orchestrator.ts`, `store.ts`, `execution.ts`, `verifier.ts` |
 | `semeion` | Signal client, listener, commands, TTS | `client.ts`, `listener.ts`, `commands.ts` |
 | `pylon` | Hono HTTP gateway, MCP, Web UI | `server.ts`, `mcp.ts`, `ui.ts` |
@@ -50,11 +95,24 @@ Initialization order: `taxis → mneme → hermeneus → organon → nous → di
 
 ## Testing
 
+### Rust
+
 ```bash
-npm test                    # Unit tests
-npm run test:watch          # Watch mode
-npm run test:coverage       # Coverage (thresholds enforced)
-npm run test:integration    # Integration (30s timeout)
+cargo test --workspace                          # all tests
+cargo test -p aletheia-nous                     # single crate
+cargo test -p aletheia-nous -- actor            # filter by name
+cargo test -p aletheia-integration-tests        # cross-crate integration tests
+```
+
+Tests live alongside source in `#[cfg(test)] mod tests` blocks. Integration tests are in `crates/integration-tests/`.
+
+### TypeScript
+
+```bash
+npm test                    # unit tests
+npm run test:watch          # watch mode
+npm run test:coverage       # coverage (thresholds enforced)
+npm run test:integration    # integration (30s timeout)
 ```
 
 Tests live alongside source as `*.test.ts`. Integration tests use `.integration.test.ts`.
@@ -65,17 +123,39 @@ Coverage thresholds: 80% statements, 78% branches, 90% functions, 80% lines.
 
 ## Code Style
 
-Full conventions in [CONTRIBUTING.md](../CONTRIBUTING.md#code-standards). Key rules:
+Full conventions in [STANDARDS.md](STANDARDS.md). Key rules by language:
+
+### Rust
+
+- Edition 2024, `unsafe` denied, pedantic clippy
+- Errors via `snafu` with context selectors, not `anyhow`
+- `pub(crate)` by default, minimize public surface
+- `expect("invariant description")` over bare `unwrap()`
+- File headers: `//!` module doc, one line
+- Property-based testing with `proptest` where applicable
 
 ### TypeScript
 
 Strict mode with `exactOptionalPropertyTypes`, `noUncheckedIndexedAccess`, `noPropertyAccessFromIndexSignature`. Bracket notation for index access: `record["key"]`.
 
-### File Headers
+### Both Languages
 
-One-line comment per file: `// Pipeline runner — composes stages for streaming and non-streaming turn execution`
+- File headers: one-line comment describing purpose
+- No inline comments except genuinely non-obvious *why* explanations
+- No creation dates, author info, or AI generation indicators
+- Conventional commits: `feat(crate):`, `fix(crate):`, `chore(crate):`
 
-### Import Order
+### File and Code Naming
+
+| Context | Convention | Example |
+|---------|-----------|---------|
+| Files | `kebab-case` | `session-store.rs`, `event-bus.ts` |
+| Types / Traits | `PascalCase` | `SessionStore`, `EmbeddingProvider` |
+| Functions | `camelCase` (TS) / `snake_case` (Rust) | `loadConfig` / `load_config` |
+| Constants | `UPPER_SNAKE` | `MAX_TURNS`, `DEFAULT_PORT` |
+| Events | `noun:verb` | `turn:before`, `tool:called` |
+
+### Import Order (TypeScript)
 
 ```typescript
 import { join } from "node:path";           // 1. Node builtins
@@ -84,7 +164,7 @@ import { createLogger } from "../koina/logger.js";  // 3. Internal
 import type { TurnState } from "./types.js";        // 4. Local
 ```
 
-### Error Handling
+### Error Handling (TypeScript)
 
 ```typescript
 // Typed errors
@@ -93,10 +173,6 @@ throw new PipelineError("Stage failed", { code: "PIPELINE_STAGE_FAILED", context
 // Non-critical operations
 const result = trySafe("skill extraction", () => extractSkill(data), null);
 ```
-
-### Naming
-
-Files `kebab-case`, classes `PascalCase`, functions `camelCase` verb-first, constants `UPPER_SNAKE`, events `noun:verb`, booleans `is`/`has`/`should` prefix.
 
 ---
 

--- a/docs/PROJECT.md
+++ b/docs/PROJECT.md
@@ -2,7 +2,7 @@
 
 > Roadmap and current status for Aletheia's evolution from TypeScript prototype to Rust production system.
 > For decisions see `docs/decisions/`, for standards see `docs/STANDARDS.md`, for triage see `docs/DISPOSITION.md`.
-> Last updated: 2026-03-04 — M0a/M0b/M1 complete, M2 core + M3 complete. 718 tests across 14 crates, ~21K lines Rust.
+> Last updated: 2026-03-01 — M0a/M0b/M1 complete, M2 core + M3 complete. 718 tests across 14 crates, ~21K lines Rust.
 
 ---
 
@@ -497,7 +497,7 @@ Progress updates go here as milestones complete. Daily work tracked in `memory/Y
 
 ### Current Status
 
-Last updated: 2026-03-04
+Last updated: 2026-03-01
 
 | Milestone | Status | Notes |
 |-----------|--------|-------|


### PR DESCRIPTION
Updates 5 documents to present the Rust crate workspace as Aletheia's primary architecture, with the TypeScript runtime clearly framed as current production (transitional).

**Changes:**

- **README.md** -- Leads with Rust crate map. Shows both stacks in directory structure. Crate descriptions up front, TS runtime diagram below with "current production" label.
- **docs/ARCHITECTURE.md** -- Full rewrite. Rust crate dependency graph with trait boundaries (EmbeddingProvider, ChannelProvider, ModelProvider). TS module table and init order preserved as "Current Production" section. Planned crates listed separately from built crates.
- **docs/DEVELOPMENT.md** -- Rust toolchain (1.85+, cargo, clippy) as primary prerequisites. Cargo build/test commands. TS section retained. Both code style guides.
- **docs/CONFIGURATION.md** -- Adds figment YAML cascade documentation. YAML examples alongside existing JSON examples. Notes on SecretString, snake_case canonical names, env var override.
- **docs/PROJECT.md** -- Date fix (2026-03-04 -> 2026-03-01).

No code changes. No em dashes.