### PR TITLE
feat(hermeneus): model fallback + model ID reference

### DIFF
--- a/infrastructure/runtime/src/hermeneus/router.ts
+++ b/infrastructure/runtime/src/hermeneus/router.ts
@@ -1,4 +1,11 @@
 // Provider router — model string to provider, failover, retry with backoff
+//
+// Model ID reference (Anthropic direct API):
+//   claude-opus-4-6              — Opus 4.6 (latest flagship)
+//   claude-sonnet-4-20250514     — Sonnet 4
+//   claude-haiku-4-5-20251001    — Haiku 4.5
+// Config uses "anthropic/" prefix (e.g. "anthropic/claude-opus-4-6") which
+// the router strips before passing to the provider SDK.
 import { readFileSync } from "node:fs";
 import { setTimeout as sleep } from "node:timers/promises";
 import { createLogger } from "../koina/logger.js";
@@ -215,7 +222,7 @@ export class ProviderRouter {
     }
   }
 
-  async *completeStreaming(request: CompletionRequest): AsyncGenerator<StreamingEvent> {
+  async *completeStreaming(request: CompletionRequest, fallbackModels?: string[]): AsyncGenerator<StreamingEvent> {
     const entry = this.resolve(request.model);
     const model = request.model.includes("/") ? request.model.split("/").pop()! : request.model;
     log.debug(`Streaming ${request.model} via ${entry.name} (model=${model})`);
@@ -263,7 +270,7 @@ export class ProviderRouter {
       }
     }
 
-    // Primary exhausted — try backups
+    // Primary exhausted — try backups (same model, different credentials)
     if (lastError instanceof ProviderError && (lastError as ProviderError).recoverable && this.backupProviders.length > 0) {
       for (let i = 0; i < this.backupProviders.length; i++) {
         log.warn(`Primary credential exhausted retries (${(lastError as ProviderError).code}), trying backup ${i + 1}/${this.backupProviders.length}`);
@@ -271,6 +278,22 @@ export class ProviderRouter {
           yield* this.backupProviders[i]!.completeStreaming({ ...request, model });
           return;
         } catch { /* backup also failed — try next */
+          continue;
+        }
+      }
+    }
+
+    // Model fallback — try degraded models (e.g. Sonnet when Opus is overloaded)
+    if (fallbackModels && fallbackModels.length > 0 && lastError instanceof ProviderError && (lastError as ProviderError).recoverable) {
+      for (const fallback of fallbackModels) {
+        const fbModel = fallback.includes("/") ? fallback.split("/").pop()! : fallback;
+        log.warn(`Primary model ${model} exhausted all retries (${(lastError as ProviderError).code}), falling back to ${fbModel}`);
+        try {
+          const fbEntry = this.resolve(fallback);
+          yield* fbEntry.provider.completeStreaming({ ...request, model: fbModel });
+          return;
+        } catch (fbError) {
+          log.warn(`Fallback model ${fbModel} also failed: ${fbError instanceof Error ? fbError.message : fbError}`);
           continue;
         }
       }

--- a/infrastructure/runtime/src/nous/pipeline/stages/execute.ts
+++ b/infrastructure/runtime/src/nous/pipeline/stages/execute.ts
@@ -23,6 +23,7 @@ import type {
 } from "../types.js";
 import { truncateToolResult } from "./truncate.js";
 import { loadPipelineConfig } from "../../pipeline-config.js";
+import { resolveFallbackModels } from "../../../taxis/loader.js";
 
 /** Resolve per-agent maxOutputTokens: agent params → global defaults. */
 function resolveMaxTokens(state: TurnState, services: RuntimeServices): number {
@@ -140,6 +141,7 @@ export async function* executeStreaming(
     const contextManagement = buildContextManagement(contextTokens, useThinking);
 
     const effectiveTemp = resolveTemperature(state);
+    const fallbackModels = resolveFallbackModels(services.config, state.nous);
     for await (const streamEvent of services.router.completeStreaming({
       model,
       system: systemPrompt,
@@ -150,7 +152,7 @@ export async function* executeStreaming(
       ...(abortSignal ? { signal: abortSignal } : {}),
       ...(useThinking ? { thinking: { type: "enabled" as const, budget_tokens: computeThinkingBudget(currentMessages, totalToolCalls, baseThinkingBudget) } } : {}),
       ...(contextManagement ? { contextManagement } : {}),
-    })) {
+    }, fallbackModels)) {
       switch (streamEvent.type) {
         case "text_delta":
           accumulatedText += streamEvent.text;

--- a/infrastructure/runtime/src/taxis/loader.ts
+++ b/infrastructure/runtime/src/taxis/loader.ts
@@ -162,6 +162,13 @@ export function resolveModel(config: AletheiaConfig, nous?: NousConfig): string 
   return config.agents.defaults.model.primary;
 }
 
+export function resolveFallbackModels(config: AletheiaConfig, nous?: NousConfig): string[] {
+  if (nous?.model && typeof nous.model === "object" && nous.model.fallbacks) {
+    return nous.model.fallbacks;
+  }
+  return config.agents.defaults.model.fallbacks ?? [];
+}
+
 export function resolveWorkspace(
   config: AletheiaConfig,
   nous: NousConfig,

--- a/shared/skills/github-issue-triage-and-details-retrieval/SKILL.md
+++ b/shared/skills/github-issue-triage-and-details-retrieval/SKILL.md
@@ -1,0 +1,15 @@
+# GitHub Issue Triage and Details Retrieval
+
+Retrieve and analyze open GitHub issues by fetching a list, then examining specific issue details for context.
+
+## When to Use
+When you need to understand the current state of open issues in a repository, prioritize work items, or investigate specific issues that need attention. Useful for status reviews, bug triage, and planning.
+
+## Steps
+1. Execute a command to list open issues with relevant metadata (number, title, labels, creation date, author)
+2. Filter or identify specific issue numbers of interest from the initial list
+3. Retrieve detailed information for selected issues (title, body, labels) using their issue numbers
+4. Format and display the details for analysis or further action
+
+## Tools Used
+- exec: Used to run GitHub CLI (gh) commands to query issue lists and retrieve detailed issue information


### PR DESCRIPTION
## Summary

Two changes to address the sustained Opus overload incidents on 2026-03-02:

### 1. Model fallback on streaming retry exhaustion

When the primary model (Opus) exhausts all 5 retry attempts, the router now cascades through configured fallback models before giving up:

```
Opus (5 retries) → backup credentials (Opus) → Sonnet → Haiku → error
```

**Files:**
- `router.ts`: `completeStreaming()` accepts optional `fallbackModels` param
- `loader.ts`: `resolveFallbackModels()` extracts fallback list from agent/default config
- `execute.ts`: wires fallback models from config into the streaming call

### 2. Model ID reference comment

Added model ID reference to router.ts header per correction — `claude-opus-4-6` is the real model ID, not an alias.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run src/hermeneus/` — 97 pass (1 pre-existing oauth-refresh env failure)
- [ ] Deploy and verify fallback triggers on next Opus overload

## Related

- #397 — retry budget fix (prerequisite)
- #398 — Rust hermeneus audit
- #399 — prosoche heartbeat cost