### PR TITLE
feat(taxis): auto-migrate legacy ~/.aletheia/ state files

### DIFF
--- a/infrastructure/runtime/src/aletheia.ts
+++ b/infrastructure/runtime/src/aletheia.ts
@@ -6,6 +6,7 @@ import { applyEnv, loadConfig, watchConfig } from "./taxis/loader.js";
 import { mergeGitignore, scaffoldNousShared } from "./taxis/nous-scaffold.js";
 import { paths } from "./taxis/paths.js";
 import { resolveSecretRefs } from "./taxis/secret-resolver.js";
+import { migrateLegacyPaths } from "./taxis/migrate-legacy.js";
 import { SessionStore } from "./mneme/store.js";
 import { createDefaultRouter, type ProviderRouter } from "./hermeneus/router.js";
 import { proactiveRefresh } from "./hermeneus/oauth-refresh.js";
@@ -150,6 +151,8 @@ export function createRuntime(configPath?: string): AletheiaRuntime {
   eventBus.emit("boot:start", {});
   log.info("Initializing Aletheia runtime");
 
+  // Migrate legacy ~/.aletheia/ state files to oikos layout (safe no-op if already done)
+  migrateLegacyPaths();
   const config = loadConfig(configPath);
 
   applyEnv(config);

--- a/infrastructure/runtime/src/taxis/migrate-legacy.test.ts
+++ b/infrastructure/runtime/src/taxis/migrate-legacy.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync, existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+// These must be hoisted-safe: vi.mock factories can't reference outer variables
+vi.mock("node:os", async () => {
+  const actual = await vi.importActual<typeof import("node:os")>("node:os");
+  return {
+    ...actual,
+    homedir: () => (globalThis as Record<string, string>).__TEST_HOME ?? actual.homedir(),
+  };
+});
+
+vi.mock("./paths.js", () => ({
+  paths: {
+    get root() { return (globalThis as Record<string, string>).__TEST_ROOT ?? "/tmp/fallback"; },
+  },
+}));
+
+import { migrateLegacyPaths } from "./migrate-legacy.js";
+
+describe("migrateLegacyPaths", () => {
+  let testRoot: string;
+  let testHome: string;
+
+  beforeEach(() => {
+    testRoot = mkdtempSync(join(tmpdir(), "migrate-root-"));
+    testHome = mkdtempSync(join(tmpdir(), "migrate-home-"));
+    (globalThis as Record<string, string>).__TEST_ROOT = testRoot;
+    (globalThis as Record<string, string>).__TEST_HOME = testHome;
+  });
+
+  afterEach(() => {
+    try { rmSync(testRoot, { recursive: true, force: true }); } catch {}
+    try { rmSync(testHome, { recursive: true, force: true }); } catch {}
+    delete (globalThis as Record<string, string>).__TEST_ROOT;
+    delete (globalThis as Record<string, string>).__TEST_HOME;
+  });
+
+  it("no-ops when ~/.aletheia does not exist", () => {
+    expect(() => migrateLegacyPaths()).not.toThrow();
+  });
+
+  it("copies .setup-complete to config/", () => {
+    mkdirSync(join(testHome, ".aletheia"), { recursive: true });
+    writeFileSync(join(testHome, ".aletheia", ".setup-complete"), "1");
+
+    migrateLegacyPaths();
+
+    expect(existsSync(join(testRoot, "config", ".setup-complete"))).toBe(true);
+    expect(readFileSync(join(testRoot, "config", ".setup-complete"), "utf-8")).toBe("1");
+  });
+
+  it("copies session.key to config/", () => {
+    mkdirSync(join(testHome, ".aletheia"), { recursive: true });
+    writeFileSync(join(testHome, ".aletheia", "session.key"), "secret-key");
+
+    migrateLegacyPaths();
+
+    expect(readFileSync(join(testRoot, "config", "session.key"), "utf-8")).toBe("secret-key");
+  });
+
+  it("copies credentials directory", () => {
+    mkdirSync(join(testHome, ".aletheia", "credentials"), { recursive: true });
+    writeFileSync(join(testHome, ".aletheia", "credentials", "anthropic.json"), '{"key":"sk-test"}');
+
+    migrateLegacyPaths();
+
+    expect(readFileSync(join(testRoot, "config", "credentials", "anthropic.json"), "utf-8")).toBe('{"key":"sk-test"}');
+  });
+
+  it("does not overwrite existing files", () => {
+    mkdirSync(join(testHome, ".aletheia"), { recursive: true });
+    writeFileSync(join(testHome, ".aletheia", "session.key"), "old");
+
+    mkdirSync(join(testRoot, "config"), { recursive: true });
+    writeFileSync(join(testRoot, "config", "session.key"), "new");
+
+    migrateLegacyPaths();
+
+    expect(readFileSync(join(testRoot, "config", "session.key"), "utf-8")).toBe("new");
+  });
+
+  it("copies sessions.db to data/", () => {
+    mkdirSync(join(testHome, ".aletheia"), { recursive: true });
+    writeFileSync(join(testHome, ".aletheia", "sessions.db"), "db-content");
+
+    migrateLegacyPaths();
+
+    expect(readFileSync(join(testRoot, "data", "sessions.db"), "utf-8")).toBe("db-content");
+  });
+});

--- a/infrastructure/runtime/src/taxis/migrate-legacy.ts
+++ b/infrastructure/runtime/src/taxis/migrate-legacy.ts
@@ -1,0 +1,81 @@
+// One-time migration from ~/.aletheia/ to oikos instance layout ($ALETHEIA_ROOT)
+// Copies state files that existed before PR #373 migrated path resolution.
+// See: https://github.com/forkwright/aletheia/issues/392
+import { copyFileSync, existsSync, mkdirSync, readdirSync, statSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { createLogger } from "../koina/logger.js";
+import { paths } from "./paths.js";
+
+const log = createLogger("taxis:migrate-legacy");
+
+interface MigrationEntry {
+  /** Source path relative to ~/.aletheia/ */
+  src: string;
+  /** Destination path relative to $ALETHEIA_ROOT/ */
+  dest: string;
+  /** If true, copy entire directory contents */
+  dir?: boolean;
+}
+
+const MIGRATIONS: MigrationEntry[] = [
+  { src: ".setup-complete", dest: "config/.setup-complete" },
+  { src: "session.key", dest: "config/session.key" },
+  { src: "sessions.db", dest: "data/sessions.db" },
+  { src: "credentials", dest: "config/credentials", dir: true },
+];
+
+function copyDir(src: string, dest: string): number {
+  mkdirSync(dest, { recursive: true });
+  let count = 0;
+  for (const entry of readdirSync(src)) {
+    const srcPath = join(src, entry);
+    const destPath = join(dest, entry);
+    if (statSync(srcPath).isFile() && !existsSync(destPath)) {
+      copyFileSync(srcPath, destPath);
+      count++;
+    }
+  }
+  return count;
+}
+
+/**
+ * Check for legacy ~/.aletheia/ state files and copy them to the oikos
+ * instance layout if the destination doesn't already have them.
+ *
+ * Safe to call on every startup — skips if legacy dir doesn't exist
+ * or all files are already present at the destination.
+ */
+export function migrateLegacyPaths(): void {
+  const legacyRoot = join(homedir(), ".aletheia");
+  if (!existsSync(legacyRoot)) return; // no legacy install
+
+  const instanceRoot = paths.root;
+  let migrated = 0;
+
+  for (const entry of MIGRATIONS) {
+    const srcPath = join(legacyRoot, entry.src);
+    const destPath = join(instanceRoot, entry.dest);
+
+    if (!existsSync(srcPath)) continue;
+    if (existsSync(destPath)) continue; // already migrated or created fresh
+
+    if (entry.dir) {
+      if (!statSync(srcPath).isDirectory()) continue;
+      const count = copyDir(srcPath, destPath);
+      if (count > 0) {
+        log.info(`Migrated ${count} files from ${srcPath} → ${destPath}`);
+        migrated += count;
+      }
+    } else {
+      mkdirSync(join(destPath, ".."), { recursive: true });
+      copyFileSync(srcPath, destPath);
+      log.info(`Migrated ${srcPath} → ${destPath}`);
+      migrated++;
+    }
+  }
+
+  if (migrated > 0) {
+    log.info(`Legacy migration complete: ${migrated} file(s) copied from ~/.aletheia/ to ${instanceRoot}`);
+  }
+}


### PR DESCRIPTION
## Problem

PR #373 migrated config resolution to oikos instance layout (`$ALETHEIA_ROOT/`), but existing deployments have state files at `~/.aletheia/` that don't get copied over. This causes:

- Onboarding wizard reappears (`.setup-complete` missing)
- API calls fail (credentials not found)
- Session history lost (`sessions.db` at old path)

## Solution

`taxis/migrate-legacy.ts` runs at startup before `loadConfig`:
1. Checks if `~/.aletheia/` exists
2. For each known state file, copies to oikos path if destination doesn't exist
3. Logs what was migrated
4. No-ops on subsequent startups (files already present)

## Files migrated

| Source | Destination |
|--------|-------------|
| `~/.aletheia/.setup-complete` | `$ALETHEIA_ROOT/config/.setup-complete` |
| `~/.aletheia/session.key` | `$ALETHEIA_ROOT/config/session.key` |
| `~/.aletheia/sessions.db` | `$ALETHEIA_ROOT/data/sessions.db` |
| `~/.aletheia/credentials/*` | `$ALETHEIA_ROOT/config/credentials/*` |

## Tests

6 tests covering: no-op when missing, each file type, directory copy, no-overwrite guard.

Closes #392