### PR TITLE
fix(hermeneus): Rust streaming retry + SSE error typing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -125,3 +125,6 @@ tui/target/
 vendor/cozo/target/
 vendor/graph_builder/target/
 crates/mneme-bench/target/
+-e 
+# Cargo build output
+/target/

--- a/crates/hermeneus/src/anthropic/client.rs
+++ b/crates/hermeneus/src/anthropic/client.rs
@@ -24,6 +24,7 @@ const BACKOFF_FACTOR: u64 = 2;
 const BACKOFF_MAX_MS: u64 = 30_000;
 
 static SUPPORTED_MODELS: &[&str] = &[
+    "claude-opus-4-6",
     "claude-opus-4-20250514",
     "claude-sonnet-4-20250514",
     "claude-haiku-4-5-20251001",
@@ -80,6 +81,11 @@ impl AnthropicProvider {
     /// Streaming completion — accumulates into a final `CompletionResponse`
     /// while emitting deltas to the callback.
     ///
+    /// Retries on transient errors (overloaded, rate-limited) with exponential
+    /// backoff, but **only if no content has been emitted** to the callback yet.
+    /// Once deltas have been streamed, a retry would produce duplicate/corrupt
+    /// output, so mid-content errors propagate immediately.
+    ///
     /// This is an `AnthropicProvider`-specific method. The sync `LlmProvider`
     /// trait only exposes `complete()`. When the trait goes async in M2, this
     /// will become the primary implementation.
@@ -91,24 +97,91 @@ impl AnthropicProvider {
     ) -> Result<CompletionResponse> {
         let wire = WireRequest::from_request(request, Some(true));
         let body = serde_json::to_string(&wire).context(error::ParseResponseSnafu)?;
+        let headers = self.build_headers();
 
-        let response = self
-            .client
-            .post(format!("{}/v1/messages", self.base_url))
-            .headers(self.build_headers())
-            .body(body)
-            .send()
-            .map_err(|e| super::error::map_request_error(&e))?;
+        let mut last_error = None;
 
-        if !response.status().is_success() {
-            return Err(super::error::map_error_response(response));
+        for attempt in 0..=self.max_retries {
+            if attempt > 0 {
+                tracing::warn!(
+                    attempt,
+                    max = self.max_retries,
+                    "retrying streaming request after transient error"
+                );
+                std::thread::sleep(backoff_delay(attempt, last_error.as_ref()));
+            }
+
+            // HTTP-level errors (connection, non-200 status)
+            let response = match self
+                .client
+                .post(format!("{}/v1/messages", self.base_url))
+                .headers(headers.clone())
+                .body(body.clone())
+                .send()
+            {
+                Ok(r) => r,
+                Err(e) => {
+                    last_error = Some(super::error::map_request_error(&e));
+                    continue;
+                }
+            };
+
+            if !response.status().is_success() {
+                let status = response.status().as_u16();
+                let err = super::error::map_error_response(response);
+                // Non-retryable HTTP status: 401, 400-level (except 429)
+                if status == 401 || ((400..500).contains(&status) && status != 429) {
+                    return Err(err);
+                }
+                last_error = Some(err);
+                continue;
+            }
+
+            // SSE stream — track whether content has been emitted
+            let reader = std::io::BufReader::new(response);
+            let mut accumulator = StreamAccumulator::new();
+            let mut content_started = false;
+
+            let stream_result = parse_sse_stream(reader, &mut accumulator, &mut |event| {
+                if matches!(
+                    event,
+                    StreamEvent::TextDelta { .. }
+                        | StreamEvent::ThinkingDelta { .. }
+                        | StreamEvent::InputJsonDelta { .. }
+                ) {
+                    content_started = true;
+                }
+                on_event(event);
+            });
+
+            match stream_result {
+                Ok(()) => return Ok(accumulator.finish()),
+                Err(e) => {
+                    // If content was already streamed, we can't retry — it would
+                    // produce duplicates. Propagate immediately.
+                    if content_started {
+                        tracing::error!(
+                            "SSE error after content started streaming — cannot retry"
+                        );
+                        return Err(e);
+                    }
+                    // Only retry RateLimited (overloaded/429); other errors are terminal.
+                    if matches!(e, error::Error::RateLimited { .. }) {
+                        tracing::warn!("SSE stream returned retryable error before content");
+                        last_error = Some(e);
+                        continue;
+                    }
+                    return Err(e);
+                }
+            }
         }
 
-        let reader = std::io::BufReader::new(response);
-        let mut accumulator = StreamAccumulator::new();
-        parse_sse_stream(reader, &mut accumulator, &mut on_event)?;
-
-        Ok(accumulator.finish())
+        Err(last_error.unwrap_or_else(|| {
+            error::ApiRequestSnafu {
+                message: "streaming request failed after all retries".to_owned(),
+            }
+            .build()
+        }))
     }
 
     fn build_headers(&self) -> HeaderMap {

--- a/crates/hermeneus/src/anthropic/error.rs
+++ b/crates/hermeneus/src/anthropic/error.rs
@@ -53,3 +53,68 @@ fn extract_retry_after(response: &Response) -> Option<u64> {
         .and_then(|v| v.parse::<u64>().ok())
         .map(|secs| secs * 1000)
 }
+
+/// Default backoff for SSE overload/rate-limit errors (no retry-after header available).
+const SSE_DEFAULT_RETRY_MS: u64 = 1000;
+
+/// Map an SSE stream error event to a hermeneus error.
+///
+/// Unlike HTTP errors, SSE errors arrive inside a 200 response body.
+/// The error type string determines retryability:
+/// - `overloaded_error` / `rate_limit_error` → `RateLimited` (retryable)
+/// - Everything else → `ApiError` (not retried)
+pub(crate) fn map_sse_error(detail: super::wire::WireErrorDetail) -> crate::error::Error {
+    match detail.error_type.as_str() {
+        "overloaded_error" | "rate_limit_error" => crate::error::RateLimitedSnafu {
+            retry_after_ms: SSE_DEFAULT_RETRY_MS,
+        }
+        .build(),
+        _ => crate::error::ApiSnafu {
+            status: 0_u16,
+            message: detail.message,
+        }
+        .build(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::error::Error;
+
+    #[test]
+    fn overloaded_error_maps_to_rate_limited() {
+        let detail = super::super::wire::WireErrorDetail {
+            error_type: "overloaded_error".to_owned(),
+            message: "Overloaded".to_owned(),
+        };
+        let err = map_sse_error(detail);
+        assert!(
+            matches!(err, Error::RateLimited { retry_after_ms: 1000, .. }),
+            "expected RateLimited, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn rate_limit_error_maps_to_rate_limited() {
+        let detail = super::super::wire::WireErrorDetail {
+            error_type: "rate_limit_error".to_owned(),
+            message: "Rate limited".to_owned(),
+        };
+        let err = map_sse_error(detail);
+        assert!(matches!(err, Error::RateLimited { .. }));
+    }
+
+    #[test]
+    fn unknown_error_maps_to_api_error() {
+        let detail = super::super::wire::WireErrorDetail {
+            error_type: "invalid_request_error".to_owned(),
+            message: "bad input".to_owned(),
+        };
+        let err = map_sse_error(detail);
+        assert!(
+            matches!(err, Error::ApiError { status: 0, .. }),
+            "expected ApiError, got: {err:?}"
+        );
+    }
+}

--- a/crates/hermeneus/src/anthropic/stream.rs
+++ b/crates/hermeneus/src/anthropic/stream.rs
@@ -168,11 +168,7 @@ impl StreamAccumulator {
                 // Final event or keepalive — nothing to accumulate.
             }
             WireStreamEvent::Error { error } => {
-                return Err(error::ApiSnafu {
-                    status: 0_u16,
-                    message: error.message,
-                }
-                .build());
+                return Err(super::error::map_sse_error(error));
             }
         }
         Ok(())
@@ -451,4 +447,24 @@ data: {\"type\":\"error\",\"error\":{\"type\":\"overloaded_error\",\"message\":\
         let result = parse_sse_stream(reader, &mut acc, &mut |_| {});
         assert!(result.is_err());
     }
+
+    #[test]
+    fn overloaded_sse_error_is_rate_limited() {
+        use crate::error::Error;
+
+        let sse = "\
+event: error\n\
+data: {\"type\":\"error\",\"error\":{\"type\":\"overloaded_error\",\"message\":\"Overloaded\"}}\n\
+\n";
+
+        let reader = std::io::Cursor::new(sse);
+        let mut acc = StreamAccumulator::new();
+        let result = parse_sse_stream(reader, &mut acc, &mut |_| {});
+        let err = result.unwrap_err();
+        assert!(
+            matches!(err, Error::RateLimited { .. }),
+            "expected RateLimited, got: {err:?}"
+        );
+    }
 }
+

--- a/crates/hermeneus/src/anthropic/wire.rs
+++ b/crates/hermeneus/src/anthropic/wire.rs
@@ -105,7 +105,7 @@ pub(crate) struct WireErrorResponse {
 #[derive(Debug, Deserialize)]
 pub(crate) struct WireErrorDetail {
     #[serde(rename = "type")]
-    pub _error_type: String,
+    pub error_type: String,
     pub message: String,
 }
 


### PR DESCRIPTION
## Problem

The Rust hermeneus crate had three gaps compared to the TS fixes in PR #397, all related to mid-stream error handling during SSE streaming.

## Gaps and Fixes

### 1. No retry loop in `complete_streaming`

The non-streaming `execute_with_retry` had proper retry logic, but `complete_streaming` was single-attempt. Now retries with exponential backoff up to `max_retries`.

**Critical safety guard:** Only retries if **no content has been emitted** to the callback yet. Once text/thinking/tool deltas have streamed, retrying would produce duplicate output. This is actually stricter than the TS version.

### 2. SSE `overloaded_error` typed as `ApiError` (not retryable)

SSE error events arrive inside a 200 response. The stream parser was mapping all of them to `ApiError { status: 0 }` — unrecognized as retryable.

New `map_sse_error()` dispatches on the error type string:
- `overloaded_error` / `rate_limit_error` → `RateLimited` (retryable)
- Everything else → `ApiError` (terminal)

### 3. `WireErrorDetail._error_type` was dead code

Renamed from `_error_type` to `error_type` and wired into the dispatch.

## Also

- Added `claude-opus-4-6` to `SUPPORTED_MODELS`
- Added `/target/` to root `.gitignore`

## Test plan

- [x] `cargo test -p aletheia-hermeneus` — 34 pass (+4 new)
- New tests: `overloaded_error_maps_to_rate_limited`, `rate_limit_error_maps_to_rate_limited`, `unknown_error_maps_to_api_error`, `overloaded_sse_error_is_rate_limited`

## Design notes

Confirmed via [Anthropic docs](https://docs.anthropic.com/en/api/errors): SSE error payloads have no `retry-after` field. HTTP 529 (`overloaded_error`) and 429 (`rate_limit_error`) only carry that hint in HTTP headers, which aren't available mid-stream. We use a 1s default backoff.

Closes #398