### PR TITLE
docs: audit and fix staleness across core docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,8 +4,9 @@ Project conventions for AI coding agents working on this codebase.
 
 ## Standards
 
-Follow [CONTRIBUTING.md](./CONTRIBUTING.md). Key points: self-documenting code, typed errors (`AletheiaError`), never empty catch, test behavior not implementation.
+Follow [CONTRIBUTING.md](./CONTRIBUTING.md). Key points: self-documenting code, typed errors, never empty catch, test behavior not implementation.
 
+@.claude/rules/rust.md
 @.claude/rules/typescript.md
 @.claude/rules/svelte.md
 @.claude/rules/python.md
@@ -13,36 +14,103 @@ Follow [CONTRIBUTING.md](./CONTRIBUTING.md). Key points: self-documenting code, 
 
 ## Structure
 
+### Rust Crate Workspace (target architecture)
+
+11 application crates in `crates/`, plus 4 support crates:
+
+| Crate | Purpose |
+|-------|---------|
+| `koina` | Errors (snafu), tracing, fs utilities, safe wrappers — leaf node |
+| `taxis` | Config loading (figment YAML cascade), path resolution, oikos hierarchy |
+| `mneme` | Unified memory store, embedding provider trait, knowledge retrieval |
+| `mneme-engine` | CozoDB embedded database: vectors, graph, relations (vendored, ~42K lines) |
+| `hermeneus` | Anthropic client, model routing, credentials, streaming retry, provider trait |
+| `organon` | Tool registry, tool definitions, built-in tool set |
+| `symbolon` | JWT tokens, password hashing, RBAC policies — leaf node |
+| `nous` | Agent pipeline, NousActor (tokio), bootstrap, recall, execute, finalize |
+| `melete` | Context distillation, compression strategies, token budget management |
+| `agora` | Channel registry, ChannelProvider trait, Signal JSON-RPC client |
+| `pylon` | Axum HTTP gateway, SSE streaming, static UI serving, auth middleware |
+| `aletheia` | Binary entrypoint (Clap CLI) — wires all crates together |
+| `graph-builder` | CSR graph construction/traversal (build tool) |
+| `integration-tests` | Cross-crate integration tests |
+| `mneme-bench` | CozoDB validation benchmarks (excluded from default build) |
+
+### TypeScript Runtime (current production)
+
 - **Runtime:** `infrastructure/runtime/src/` — TypeScript, tsdown, vitest
 - **UI:** `ui/` — Svelte 5, Vite
 - **Memory sidecar:** `infrastructure/memory/sidecar/` — Python FastAPI
-- **Config:** `~/.aletheia/aletheia.json` — validated by Zod in `taxis/schema.ts`
+
+### Config
+
+- **TS runtime:** `~/.aletheia/aletheia.json` — validated by Zod in `taxis/schema.ts`
+- **Rust crates:** `instance/config/aletheia.yaml` — figment cascade (defaults → YAML → env vars)
+
+### Other
+
 - **Specs:** `docs/specs/` — design documents numbered by implementation order
+- **Decisions:** `docs/decisions/` — Architecture Decision Records
 
 ## Commands
 
+### Rust
+
+```bash
+cargo build                            # Debug build
+cargo build --release                  # Release (LTO, stripped)
+cargo test --workspace                 # All tests (747 across 14 crates)
+cargo test -p aletheia-hermeneus       # Single crate
+cargo clippy --workspace               # Lint (zero warnings policy)
+```
+
+### TypeScript
+
 ```bash
 cd infrastructure/runtime
-npx vitest run                        # All tests
-npx vitest run src/path/file.test.ts  # Specific test
-npx tsdown                            # Build runtime
-npx tsc --noEmit                      # Type check
-npx oxlint src/                       # Lint
-cd ../../ui && npm run build          # Build UI
-aletheia doctor                       # Validate config
+npx vitest run                         # All tests
+npx vitest run src/path/file.test.ts   # Specific test
+npx tsdown                             # Build runtime
+npx tsc --noEmit                       # Type check
+npx oxlint src/                        # Lint
+cd ../../ui && npm run build           # Build UI
+aletheia doctor                        # Validate config
 ```
 
 ## Patterns
 
-- **Modules:** Greek names — koina, taxis, mneme, hermeneus, nous, organon, melete, symbolon, dianoia, semeion, pylon, prostheke, portability
+### Rust
+
+- **Errors:** `snafu` enums per crate with `.context()` propagation and `Location` tracking. See `.claude/rules/rust.md`.
+- **IDs:** Newtypes for all domain IDs (`AgentId`, `SessionId`, `NousId`, etc.)
+- **Time:** `jiff` for time, `ulid` for IDs, `compact_str` for small strings
+- **Async:** Tokio actor model (`NousActor` pattern)
+- **Config:** figment YAML cascade in `taxis`
+
+### TypeScript
+
+- **Modules:** Greek names — koina, taxis, mneme, hermeneus, nous, organon, melete, symbolon, dianoia, semeion, pylon, prostheke
 - **Errors:** `AletheiaError` hierarchy in `koina/errors.ts`, codes in `koina/error-codes.ts`, `trySafe`/`trySafeAsync` in `koina/safe.ts`
 - **Logging:** `createLogger("module-name")` — structured with AsyncLocalStorage context
 - **Events:** `eventBus` — `noun:verb` naming (e.g., `turn:before`, `tool:called`)
 - **Config:** Zod schemas in `taxis/schema.ts`
 - **Imports:** `.js` extensions, order: node → external → internal → local
 
+### Both Stacks
+
+- **Naming:** Greek names per [gnomon.md](docs/gnomon.md). Names identify modes of attention, not implementations.
+- **No barrel files** — import from the file that owns the symbol
+- **Module imports flow downward** — higher layers may depend on lower, never the reverse
+
 ## Before Submitting
 
+### Rust
+1. `cargo test -p <affected-crate>` passes
+2. `cargo clippy --workspace` — zero warnings
+3. No `unwrap()` in library code
+4. New errors use snafu with context
+
+### TypeScript
 1. Tests pass for affected files
 2. No new empty catch blocks
 3. New errors use typed error classes

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -2,7 +2,7 @@
 
 > Module map, dependency graph, trait boundaries, and extension points.
 > Covers both the Rust crate workspace (target architecture) and the TypeScript runtime (current production).
-> Last updated: 2026-03-01
+> Last updated: 2026-03-02
 
 ---
 
@@ -16,7 +16,7 @@ When adding a new module, check gnomon.md's process section and anti-patterns be
 
 ## Rust Crate Workspace
 
-11 application crates in `crates/`, plus `graph-builder` (build tool), `integration-tests` (test harness), `mneme-bench` (benchmarks, excluded from default build).
+11 application crates in `crates/`, plus `aletheia` (binary entrypoint), `graph-builder` (build tool), `integration-tests` (test harness), `mneme-bench` (benchmarks, excluded from default build). 15 crate directories total, 14 in the default workspace build.
 
 ### Crates
 
@@ -33,25 +33,34 @@ When adding a new module, check gnomon.md's process section and anti-patterns be
 | `melete` | Context distillation, compression strategies, token budget management | koina, hermeneus |
 | `agora` | Channel registry, ChannelProvider trait, Signal JSON-RPC client | koina, taxis |
 | `pylon` | Axum HTTP gateway, SSE streaming, static UI serving, auth middleware | koina, taxis, hermeneus, organon, mneme, nous, symbolon |
+| `aletheia` | Binary entrypoint (Clap CLI) — wires all crates together | all application crates |
 
 ### Dependency Graph
 
 ```
-                        pylon
-                     /  | |  \  \
-                   /    | |   \   \
-                nous  symbolon  |   |
-              / | | \         mneme |
-            /   |  \  \        |    |
-       taxis organon melete    |    |
-          |     |      |       |    |
-        koina  hermeneus    mneme-engine
-                                    agora
-                                   /    \
-                                taxis  koina
+                        aletheia (binary)
+                    /   /   |   \   \   \
+                  /   /     |    \    \    \
+              pylon nous  agora melete organon ...
+              / | \   |\   / \     |      |
+             /  |  \  | \ /   \    |      |
+      symbolon  |  mneme taxis  hermeneus  koina
+                |    |     |       |
+              organon |   koina   koina
+                |   mneme-engine
+              hermeneus
+                |
+              koina
 ```
 
-Imports are directional. Higher-layer crates may depend on lower layers. Lower-layer crates must not depend on higher layers. `koina` and `symbolon` are true leaf nodes with no internal dependencies.
+Layer rules:
+- **Leaf nodes** (no workspace deps): `koina`, `symbolon`, `mneme-engine`
+- **Low layer** (leaf deps only): `taxis`, `hermeneus`, `melete`, `organon`, `agora`, `mneme`
+- **Mid layer**: `nous` (taxis, mneme, hermeneus, organon)
+- **High layer**: `pylon` (nous, mneme, hermeneus, organon, taxis, symbolon)
+- **Top**: `aletheia` binary (all application crates)
+
+Imports are directional. Higher-layer crates depend on lower layers. Lower-layer crates must not depend on higher layers.
 
 ### Trait Boundaries
 

--- a/docs/PROJECT.md
+++ b/docs/PROJECT.md
@@ -2,7 +2,7 @@
 
 > Roadmap and current status for Aletheia's evolution from TypeScript prototype to Rust production system.
 > For decisions see `docs/decisions/`, for standards see `docs/STANDARDS.md`, for triage see `docs/DISPOSITION.md`.
-> Last updated: 2026-03-01 — M0a/M0b/M1 complete, M2 core + M3 complete. 718 tests across 14 crates, ~21K lines Rust.
+> Last updated: 2026-03-02 — M0a/M0b/M1 complete, M2 core + M3 complete. 747 tests across 14 crates, ~21K lines Rust (+42K vendored mneme-engine).
 
 ---
 
@@ -529,7 +529,7 @@ Last updated: 2026-03-01
 | M5 | Not started | Plugins, portability, cutover |
 | M6 | Backlog | Independent items, work anytime after M5 |
 
-**Totals:** 14 Rust crates (+ integration-tests + mneme-bench + graph-builder), 718 workspace tests, ~21K lines of Rust (+ 42K absorbed CozoDB in mneme-engine).
+**Totals:** 15 crate directories (11 application + `aletheia` binary + `graph-builder` + `integration-tests` + `mneme-bench`), 747 tests (`#[test]` + `#[tokio::test]`), ~21K lines of Rust (+42K vendored CozoDB in mneme-engine).
 
 ---
 


### PR DESCRIPTION
## Problem

Three core docs were stale relative to current codebase state.

## Changes

### CLAUDE.md (biggest change)
Was TS-only. Now dual-stack:
- Full Rust crate table (all 15 crates)
- `@.claude/rules/rust.md` reference (was missing — agents didn't get Rust rules)
- Rust commands (`cargo build/test/clippy`)
- Rust patterns (snafu, newtypes, jiff, tokio actor model)
- Split config: TS (`aletheia.json`) vs Rust (`aletheia.yaml`)
- Split submission checklist into Rust and TS sections
- Shared patterns section (gnomon naming, no barrel files, downward imports)

### ARCHITECTURE.md
- Crate count: was "11" with no mention of `aletheia` binary — now acknowledges 15 directories (11 app + 4 support)
- Added `aletheia` binary entrypoint to crates table
- Dependency graph: `agora` was disconnected/floating — replaced with layered graph showing actual dependency structure from `aletheia` (top) through leaf nodes
- Added explicit layer classification (leaf → low → mid → high → top)

### PROJECT.md
- Test count: 718 → **747** (was missing `#[tokio::test]` annotations, only counted `#[test]`)
- Crate count: 14 → **15** directories (missing `aletheia` binary crate)
- Line count clarification: ~21K app + ~42K vendored mneme-engine