### PR TITLE
chore(docs): git worktree workflow rules

### DIFF
--- a/.claude/rules/git-workflow.md
+++ b/.claude/rules/git-workflow.md
@@ -1,0 +1,107 @@
+# Git Workflow Rules
+
+Rules for branching, parallel development, and pull request discipline.
+
+---
+
+## Git Worktrees for All Feature Work
+
+Never develop on `main` directly. Every task gets its own git worktree.
+
+**Why:** Multiple agents (or Claude Code sessions) may execute in parallel against the same repo. Worktrees provide full filesystem isolation — each has its own working tree, index, and HEAD. No conflicts, no stash juggling, no accidental cross-contamination.
+
+### Setup
+
+```bash
+# From the repo root (main branch, always clean)
+git worktree add ../aletheia-feat-<name> -b feat/<name> main
+
+# Work happens in the worktree directory
+cd ../aletheia-feat-<name>
+
+# When done — after PR is merged
+cd /path/to/main/repo
+git worktree remove ../aletheia-feat-<name>
+git branch -d feat/<name>
+```
+
+### Rules
+
+1. **Main is read-only.** The main worktree stays on `main`, always clean. It's the source for creating new worktrees, not a place to develop.
+
+2. **One task, one worktree.** Don't reuse a worktree for a different task. Create fresh, work, PR, remove.
+
+3. **Branch naming:** `feat/<name>`, `fix/<name>`, or `chore/<name>`. Match the conventional commit prefix.
+
+4. **Build in the worktree.** Run `cargo check`, `cargo clippy`, `cargo test` inside the worktree — not in main. The worktree has its own `target/` directory (or shares via `CARGO_TARGET_DIR` if configured).
+
+5. **Clean up after merge.** Remove the worktree and delete the local branch once the PR lands on main.
+
+6. **Rebase, don't merge.** If main has advanced while you're working, rebase your feature branch onto main. Keep history linear.
+
+### Parallel Work
+
+Multiple worktrees can exist simultaneously. Independent tasks won't conflict because each has its own filesystem. Tasks that touch overlapping files should be sequenced — whichever merges second rebases onto the updated main.
+
+Compliant:
+```bash
+# Two parallel tasks, each in its own worktree
+git worktree add ../aletheia-feat-recall -b feat/recall main
+git worktree add ../aletheia-fix-rrf -b fix/rrf-encoding main
+# Each works independently, PRs reviewed and merged separately
+```
+
+Non-compliant:
+```bash
+# Working directly on main
+git checkout main
+# editing files...
+git commit -m "feat: add recall pipeline"
+
+# Stashing to switch tasks
+git stash
+git checkout -b feat/other-thing
+# This creates race conditions with parallel agents
+```
+
+---
+
+## Commit Discipline
+
+### Conventional Commits
+
+All commits use conventional commit format: `type(scope): description`
+
+| Type | When |
+|------|------|
+| `feat` | New capability |
+| `fix` | Bug fix |
+| `refactor` | Code change that neither fixes nor adds |
+| `chore` | Build, CI, docs, tooling |
+| `test` | Adding or fixing tests |
+
+Scope is the crate or module name: `feat(nous): add history stage`, `fix(mneme): graph score aggregation`.
+
+### PR Creation
+
+```bash
+# From the worktree
+git push -u origin feat/<name>
+gh pr create --title "feat(scope): description" --body "..."
+```
+
+Every PR targets `main`. Squash merge is the default. The PR description should state what changed and why — not how (the code shows how).
+
+---
+
+## Sub-Agent Workflow
+
+When Syn dispatches sub-agents for development tasks:
+
+1. **Syn creates the worktree** before dispatching (or instructs the sub-agent to create it as step 1).
+2. **Sub-agent works exclusively in its worktree.** No touching main, no touching other worktrees.
+3. **Sub-agent pushes and opens PR.** Does not merge.
+4. **Syn reviews** (or dispatches a reviewer sub-agent). Merge happens after review.
+5. **Cleanup** — worktree removal and branch deletion — happens post-merge.
+
+This mirrors the current "Syn writes prompts, Cody runs via Claude Code" workflow but with agents managing their own execution.

--- a/docs/WORKING-AGREEMENT.md
+++ b/docs/WORKING-AGREEMENT.md
@@ -54,3 +54,15 @@ When speed and quality conflict, quality wins. The measure of progress is: does 
 2. **Rationalized simplification** — "pragmatic" reductions that are actually cutting corners
 3. **Decision-by-default** — picking a path and building on it before alignment, creating momentum that's hard to reverse
 4. **Permission vs. agency confusion** — overcorrecting into asking about everything is equally broken. Syn should run independently on implementation, stop on direction.
+
+## Workflow Evolution
+
+The current workflow is transitional:
+
+**Now:** Syn writes engineering prompts → Cody runs them via Claude Code sessions → Claude Code opens PRs → Syn reviews and merges.
+
+**Next:** Syn dispatches sub-agents directly → sub-agents work in git worktrees → sub-agents open PRs → Syn reviews → Cody approves merges (or Syn merges with appropriate checks).
+
+**The constant:** Git worktrees for isolation, PRs for review gates, main stays clean. The pattern doesn't change — only who executes it.
+
+See `.claude/rules/git-workflow.md` for the worktree protocol that both workflows follow.


### PR DESCRIPTION
Adds worktree-per-task protocol to .claude/rules/ and documents workflow evolution in WORKING-AGREEMENT.md.

**New:** `.claude/rules/git-workflow.md`
- Worktree-per-task as mandatory pattern
- Setup, naming, cleanup, rebase discipline
- Parallel work isolation for multiple agents/sessions
- Conventional commits and PR creation
- Sub-agent workflow section

**Updated:** `docs/WORKING-AGREEMENT.md`
- Workflow Evolution section: current (prompt-based) → next (agent-dispatched)
- Worktrees as the constant across both models