### PR TITLE
feat(nous): history pipeline stage — load conversation context

### DIFF
--- a/crates/aletheia/src/main.rs
+++ b/crates/aletheia/src/main.rs
@@ -100,8 +100,10 @@ async fn serve(cli: Cli) -> Result<()> {
         std::fs::create_dir_all(parent)
             .with_context(|| format!("failed to create data dir {}", parent.display()))?;
     }
-    let session_store = SessionStore::open(&db_path)
-        .with_context(|| format!("failed to open session store at {}", db_path.display()))?;
+    let session_store = Arc::new(Mutex::new(
+        SessionStore::open(&db_path)
+            .with_context(|| format!("failed to open session store at {}", db_path.display()))?,
+    ));
     info!(path = %db_path.display(), "session store opened");
 
     // JWT manager
@@ -119,6 +121,7 @@ async fn serve(cli: Cli) -> Result<()> {
         Arc::clone(&oikos_arc),
         None,
         None,
+        Some(Arc::clone(&session_store)),
     );
 
     if config.agents.list.is_empty() {
@@ -149,7 +152,7 @@ async fn serve(cli: Cli) -> Result<()> {
 
     // Pylon HTTP gateway — shares registries with NousManager, owns the manager
     let state = Arc::new(AppState {
-        session_store: Mutex::new(session_store),
+        session_store,
         nous_manager,
         provider_registry,
         tool_registry,

--- a/crates/nous/src/actor.rs
+++ b/crates/nous/src/actor.rs
@@ -1,7 +1,9 @@
 //! Tokio actor for a single nous agent instance.
 
 use std::collections::HashMap;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
+
+use aletheia_mneme::store::SessionStore;
 
 use tokio::sync::mpsc;
 use tracing::{debug, info, instrument, warn, Instrument};
@@ -39,6 +41,7 @@ pub struct NousActor {
     oikos: Arc<Oikos>,
     embedding_provider: Option<Arc<dyn EmbeddingProvider>>,
     vector_search: Option<Arc<dyn crate::recall::VectorSearch>>,
+    session_store: Option<Arc<Mutex<SessionStore>>>,
 }
 
 impl NousActor {
@@ -55,6 +58,7 @@ impl NousActor {
         oikos: Arc<Oikos>,
         embedding_provider: Option<Arc<dyn EmbeddingProvider>>,
         vector_search: Option<Arc<dyn crate::recall::VectorSearch>>,
+        session_store: Option<Arc<Mutex<SessionStore>>>,
     ) -> Self {
         Self {
             id,
@@ -69,6 +73,7 @@ impl NousActor {
             oikos,
             embedding_provider,
             vector_search,
+            session_store,
         }
     }
 
@@ -174,6 +179,7 @@ impl NousActor {
             &tool_ctx,
             self.embedding_provider.as_deref(),
             self.vector_search.as_deref(),
+            self.session_store.as_deref(),
         )
         .await
     }
@@ -220,6 +226,7 @@ impl NousActor {
 ///
 /// Creates a bounded channel with [`DEFAULT_INBOX_CAPACITY`], builds the actor,
 /// and starts it on the Tokio runtime.
+#[expect(clippy::too_many_arguments, reason = "actor spawn requires all runtime dependencies")]
 pub fn spawn(
     config: NousConfig,
     pipeline_config: PipelineConfig,
@@ -228,12 +235,13 @@ pub fn spawn(
     oikos: Arc<Oikos>,
     embedding_provider: Option<Arc<dyn EmbeddingProvider>>,
     vector_search: Option<Arc<dyn crate::recall::VectorSearch>>,
+    session_store: Option<Arc<Mutex<SessionStore>>>,
 ) -> (NousHandle, tokio::task::JoinHandle<()>) {
     let (tx, rx) = mpsc::channel(DEFAULT_INBOX_CAPACITY);
     let id = config.id.clone();
     let handle = NousHandle::new(id.clone(), tx);
 
-    let actor = NousActor::new(id.clone(), config, pipeline_config, rx, providers, tools, oikos, embedding_provider, vector_search);
+    let actor = NousActor::new(id.clone(), config, pipeline_config, rx, providers, tools, oikos, embedding_provider, vector_search, session_store);
 
     let span = tracing::info_span!("nous_actor", nous.id = %id);
     let join_handle = tokio::spawn(async move { actor.run().await }.instrument(span));
@@ -326,7 +334,7 @@ mod tests {
         let config = test_config();
         let pipeline_config = PipelineConfig::default();
 
-        let (handle, join) = spawn(config, pipeline_config, providers, tools, oikos, None, None);
+        let (handle, join) = spawn(config, pipeline_config, providers, tools, oikos, None, None, None);
         (handle, join, dir)
     }
 

--- a/crates/nous/src/history.rs
+++ b/crates/nous/src/history.rs
@@ -1,0 +1,309 @@
+//! History stage — loads conversation context from the session store.
+//!
+//! Retrieves the most recent messages that fit within the remaining token
+//! budget, converts them to pipeline messages, and appends the current
+//! user message at the end.
+
+use snafu::ResultExt;
+
+use aletheia_mneme::store::SessionStore;
+use aletheia_mneme::types::Role;
+
+use crate::error;
+use crate::pipeline::PipelineMessage;
+
+/// Configuration for the history stage.
+#[derive(Debug, Clone)]
+pub struct HistoryConfig {
+    /// Maximum number of history messages to load.
+    pub max_messages: usize,
+    /// Reserve tokens for the user's current message.
+    pub reserve_for_current: i64,
+    /// Whether to include tool-result messages.
+    pub include_tool_messages: bool,
+}
+
+impl Default for HistoryConfig {
+    fn default() -> Self {
+        Self {
+            max_messages: 50,
+            reserve_for_current: 4000,
+            include_tool_messages: true,
+        }
+    }
+}
+
+/// Result of the history stage.
+#[derive(Debug, Clone)]
+pub struct HistoryResult {
+    /// Number of messages loaded from store.
+    pub messages_loaded: usize,
+    /// Total tokens consumed by loaded history.
+    pub tokens_consumed: i64,
+    /// Whether history was truncated to fit budget.
+    pub truncated: bool,
+}
+
+/// Load conversation history and append the current user message.
+///
+/// Retrieves the most recent messages from the session store that fit within
+/// the given token budget, converts them to [`PipelineMessage`]s, and appends
+/// the current user message at the end.
+///
+/// System-role messages are always skipped (they're in the system prompt).
+/// Tool-result messages are included or skipped based on `config.include_tool_messages`.
+#[expect(clippy::cast_possible_wrap, reason = "message length fits in i64")]
+pub fn load_history(
+    store: &SessionStore,
+    session_id: &str,
+    budget: i64,
+    config: &HistoryConfig,
+    current_message: &str,
+) -> error::Result<(Vec<PipelineMessage>, HistoryResult)> {
+    let current_tokens = current_message.len() as i64 / 4;
+    let available = budget - config.reserve_for_current - current_tokens;
+
+    if available <= 0 {
+        let messages = vec![PipelineMessage {
+            role: "user".to_owned(),
+            content: current_message.to_owned(),
+            token_estimate: current_tokens,
+        }];
+        return Ok((
+            messages,
+            HistoryResult {
+                messages_loaded: 0,
+                tokens_consumed: 0,
+                truncated: false,
+            },
+        ));
+    }
+
+    let budget_messages = store
+        .get_history_with_budget(session_id, available)
+        .context(error::StoreSnafu)?;
+    let all_messages = store
+        .get_history(session_id, None)
+        .context(error::StoreSnafu)?;
+
+    let total_in_store = all_messages
+        .iter()
+        .filter(|m| m.role != Role::System)
+        .count();
+
+    let mut messages = Vec::new();
+    let mut tokens_consumed: i64 = 0;
+    let mut loaded_count: usize = 0;
+
+    for msg in &budget_messages {
+        if loaded_count >= config.max_messages {
+            break;
+        }
+
+        match msg.role {
+            Role::System => continue,
+            Role::ToolResult if !config.include_tool_messages => continue,
+            _ => {}
+        }
+
+        let role = match msg.role {
+            Role::User => "user",
+            Role::Assistant => "assistant",
+            Role::ToolResult => "tool_result",
+            Role::System => unreachable!(),
+        };
+
+        messages.push(PipelineMessage {
+            role: role.to_owned(),
+            content: msg.content.clone(),
+            token_estimate: msg.token_estimate,
+        });
+        tokens_consumed += msg.token_estimate;
+        loaded_count += 1;
+    }
+
+    let truncated = total_in_store > loaded_count;
+
+    messages.push(PipelineMessage {
+        role: "user".to_owned(),
+        content: current_message.to_owned(),
+        token_estimate: current_tokens,
+    });
+
+    Ok((
+        messages,
+        HistoryResult {
+            messages_loaded: loaded_count,
+            tokens_consumed,
+            truncated,
+        },
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aletheia_mneme::types::Role;
+
+    fn setup_store() -> SessionStore {
+        let store = SessionStore::open_in_memory().expect("open in-memory store");
+        store
+            .create_session("ses-1", "test-agent", "main", None, Some("test-model"))
+            .expect("create session");
+        store
+    }
+
+    fn append(store: &SessionStore, role: Role, content: &str, tokens: i64) {
+        store
+            .append_message("ses-1", role, content, None, None, tokens)
+            .expect("append");
+    }
+
+    #[test]
+    fn empty_history_returns_just_current_message() {
+        let store = setup_store();
+        let config = HistoryConfig::default();
+
+        let (messages, result) =
+            load_history(&store, "ses-1", 100_000, &config, "Hello").expect("load");
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].role, "user");
+        assert_eq!(messages[0].content, "Hello");
+        assert_eq!(result.messages_loaded, 0);
+        assert_eq!(result.tokens_consumed, 0);
+        assert!(!result.truncated);
+    }
+
+    #[test]
+    fn history_respects_budget() {
+        let store = setup_store();
+        // Each message ~200 tokens, budget will only fit some
+        append(&store, Role::User, "old message 1", 200);
+        append(&store, Role::Assistant, "reply 1", 200);
+        append(&store, Role::User, "old message 2", 200);
+        append(&store, Role::Assistant, "reply 2", 200);
+        append(&store, Role::User, "old message 3", 200);
+        append(&store, Role::Assistant, "reply 3", 200);
+
+        let config = HistoryConfig {
+            reserve_for_current: 100,
+            ..HistoryConfig::default()
+        };
+
+        // Budget 600 - 100 reserve - current tokens = ~499 available
+        // Should fit only ~2 messages (400 tokens)
+        let (messages, result) =
+            load_history(&store, "ses-1", 600, &config, "new message").expect("load");
+
+        // Budget-limited: fewer messages loaded than total in store
+        assert!(result.messages_loaded < 6);
+        assert!(result.tokens_consumed <= 500);
+        assert!(result.truncated);
+        // Current message is always last
+        assert_eq!(messages.last().unwrap().role, "user");
+        assert_eq!(messages.last().unwrap().content, "new message");
+    }
+
+    #[test]
+    fn history_filters_tool_messages() {
+        let store = setup_store();
+        append(&store, Role::User, "use a tool", 50);
+        append(&store, Role::Assistant, "calling tool", 50);
+        append(&store, Role::ToolResult, "tool output", 50);
+        append(&store, Role::Assistant, "here's the result", 50);
+
+        let config = HistoryConfig {
+            include_tool_messages: false,
+            ..HistoryConfig::default()
+        };
+
+        let (messages, result) =
+            load_history(&store, "ses-1", 100_000, &config, "next").expect("load");
+
+        let roles: Vec<&str> = messages.iter().map(|m| m.role.as_str()).collect();
+        assert!(!roles.contains(&"tool_result"));
+        // 3 messages loaded (user, assistant, assistant) — tool_result skipped
+        assert_eq!(result.messages_loaded, 3);
+    }
+
+    #[test]
+    fn history_skips_system_messages() {
+        let store = setup_store();
+        append(&store, Role::System, "system instruction", 100);
+        append(&store, Role::User, "hello", 50);
+        append(&store, Role::Assistant, "hi there", 50);
+
+        let config = HistoryConfig::default();
+        let (messages, result) =
+            load_history(&store, "ses-1", 100_000, &config, "next").expect("load");
+
+        let roles: Vec<&str> = messages.iter().map(|m| m.role.as_str()).collect();
+        assert!(!roles.contains(&"system"));
+        // Only user + assistant loaded from history (system skipped)
+        assert_eq!(result.messages_loaded, 2);
+    }
+
+    #[test]
+    fn history_preserves_order() {
+        let store = setup_store();
+        append(&store, Role::User, "first", 50);
+        append(&store, Role::Assistant, "second", 50);
+        append(&store, Role::User, "third", 50);
+        append(&store, Role::Assistant, "fourth", 50);
+
+        let config = HistoryConfig::default();
+        let (messages, _) =
+            load_history(&store, "ses-1", 100_000, &config, "fifth").expect("load");
+
+        assert_eq!(messages[0].content, "first");
+        assert_eq!(messages[1].content, "second");
+        assert_eq!(messages[2].content, "third");
+        assert_eq!(messages[3].content, "fourth");
+        assert_eq!(messages[4].content, "fifth");
+    }
+
+    #[test]
+    fn history_truncated_flag() {
+        let store = setup_store();
+        for i in 0..10 {
+            append(&store, Role::User, &format!("msg {i}"), 100);
+        }
+
+        let config = HistoryConfig {
+            reserve_for_current: 100,
+            ..HistoryConfig::default()
+        };
+
+        // Tight budget: only fits a few of 10 messages
+        let (_, result) =
+            load_history(&store, "ses-1", 500, &config, "current").expect("load");
+
+        assert!(result.truncated);
+        assert!(result.messages_loaded < 10);
+
+        // Large budget: fits all
+        let (_, result_full) =
+            load_history(&store, "ses-1", 100_000, &config, "current").expect("load");
+
+        assert!(!result_full.truncated);
+        assert_eq!(result_full.messages_loaded, 10);
+    }
+
+    #[test]
+    fn zero_budget_returns_current_only() {
+        let store = setup_store();
+        append(&store, Role::User, "old", 50);
+        append(&store, Role::Assistant, "reply", 50);
+
+        let config = HistoryConfig::default();
+        let (messages, result) =
+            load_history(&store, "ses-1", 0, &config, "current").expect("load");
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].content, "current");
+        assert_eq!(result.messages_loaded, 0);
+        assert_eq!(result.tokens_consumed, 0);
+        assert!(!result.truncated);
+    }
+}

--- a/crates/nous/src/lib.rs
+++ b/crates/nous/src/lib.rs
@@ -13,6 +13,7 @@ pub mod config;
 pub mod error;
 pub mod execute;
 pub mod handle;
+pub mod history;
 pub mod manager;
 pub mod message;
 pub mod pipeline;

--- a/crates/nous/src/manager.rs
+++ b/crates/nous/src/manager.rs
@@ -1,7 +1,9 @@
 //! Manages all nous actor instances.
 
 use std::collections::HashMap;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
+
+use aletheia_mneme::store::SessionStore;
 
 use tokio::task::JoinHandle;
 use tracing::{info, warn};
@@ -30,6 +32,7 @@ pub struct NousManager {
     oikos: Arc<Oikos>,
     embedding_provider: Option<Arc<dyn EmbeddingProvider>>,
     vector_search: Option<Arc<dyn crate::recall::VectorSearch>>,
+    session_store: Option<Arc<Mutex<SessionStore>>>,
 }
 
 impl NousManager {
@@ -41,6 +44,7 @@ impl NousManager {
         oikos: Arc<Oikos>,
         embedding_provider: Option<Arc<dyn EmbeddingProvider>>,
         vector_search: Option<Arc<dyn crate::recall::VectorSearch>>,
+        session_store: Option<Arc<Mutex<SessionStore>>>,
     ) -> Self {
         Self {
             actors: HashMap::new(),
@@ -49,6 +53,7 @@ impl NousManager {
             oikos,
             embedding_provider,
             vector_search,
+            session_store,
         }
     }
 
@@ -72,6 +77,7 @@ impl NousManager {
             Arc::clone(&self.oikos),
             self.embedding_provider.clone(),
             self.vector_search.clone(),
+            self.session_store.clone(),
         );
 
         info!(nous_id = %id, "actor spawned");
@@ -228,7 +234,7 @@ mod tests {
     }
 
     fn test_manager(oikos: Arc<Oikos>) -> NousManager {
-        NousManager::new(test_providers(), Arc::new(ToolRegistry::new()), oikos, None, None)
+        NousManager::new(test_providers(), Arc::new(ToolRegistry::new()), oikos, None, None, None)
     }
 
     fn syn_config() -> NousConfig {

--- a/crates/nous/src/pipeline.rs
+++ b/crates/nous/src/pipeline.rs
@@ -9,10 +9,13 @@
 //! 5. **Execute** — call LLM, process tool use, iterate
 //! 6. **Finalize** — persist messages, update counts, extract facts
 
+use std::sync::Mutex;
+
 use serde::{Deserialize, Serialize};
 use tracing::{debug, instrument, warn};
 
 use aletheia_mneme::embedding::EmbeddingProvider;
+use aletheia_mneme::store::SessionStore;
 
 use aletheia_hermeneus::provider::ProviderRegistry;
 use aletheia_organon::registry::ToolRegistry;
@@ -23,6 +26,7 @@ use crate::bootstrap::BootstrapAssembler;
 use crate::budget::TokenBudget;
 use crate::config::{NousConfig, PipelineConfig};
 use crate::error;
+use crate::history::{self, HistoryConfig, HistoryResult};
 use crate::session::SessionState;
 
 /// Input to the pipeline — an inbound message.
@@ -45,14 +49,18 @@ pub struct PipelineContext {
     pub messages: Vec<PipelineMessage>,
     /// Available tools for this turn.
     pub tools: Vec<String>,
-    /// Token budget remaining after bootstrap + history.
+    /// Token budget remaining after bootstrap (system prompt space).
     pub remaining_tokens: i64,
+    /// Token budget allocated for conversation history.
+    pub history_budget: i64,
     /// Whether distillation is needed before this turn.
     pub needs_distillation: bool,
     /// Guard decision.
     pub guard_result: GuardResult,
     /// Recall stage output, if recall was run.
     pub recall_result: Option<crate::recall::RecallStageResult>,
+    /// History stage output, if history was loaded.
+    pub history_result: Option<HistoryResult>,
 }
 
 impl Default for PipelineContext {
@@ -62,9 +70,11 @@ impl Default for PipelineContext {
             messages: Vec::new(),
             tools: Vec::new(),
             remaining_tokens: 0,
+            history_budget: 0,
             needs_distillation: false,
             guard_result: GuardResult::Allow,
             recall_result: None,
+            history_result: None,
         }
     }
 }
@@ -249,6 +259,7 @@ pub fn assemble_context(
     #[expect(clippy::cast_possible_wrap, reason = "budget fits in i64 for practical context windows")]
     {
         ctx.remaining_tokens = budget.remaining() as i64;
+        ctx.history_budget = budget.history_budget() as i64;
     }
 
     Ok(())
@@ -264,7 +275,7 @@ pub fn check_guard(_session: &SessionState, _config: &NousConfig) -> GuardResult
 
 /// Run the full pipeline for one turn.
 ///
-/// Stages: context → history (stub) → guard → execute.
+/// Stages: context → recall → history → guard → execute.
 /// Resolve (stage 4) and finalize (stage 6) are future work.
 #[expect(clippy::too_many_arguments, reason = "pipeline threading requires all dependencies until config struct refactor")]
 #[instrument(skip_all, fields(nous_id = %config.id))]
@@ -278,6 +289,7 @@ pub async fn run_pipeline(
     tool_ctx: &ToolContext,
     embedding_provider: Option<&dyn EmbeddingProvider>,
     vector_search: Option<&dyn crate::recall::VectorSearch>,
+    session_store: Option<&Mutex<SessionStore>>,
 ) -> error::Result<TurnResult> {
     // Stage 1: Context
     let mut ctx = PipelineContext::default();
@@ -309,14 +321,29 @@ pub async fn run_pipeline(
         debug!("recall skipped: embedding provider or vector search not configured");
     }
 
-    // Stage 2: History (stub — just add the user message)
-    #[expect(clippy::cast_possible_wrap, reason = "message length fits in i64")]
-    let token_estimate = input.content.len() as i64 / 4;
-    ctx.messages.push(PipelineMessage {
-        role: "user".to_owned(),
-        content: input.content.clone(),
-        token_estimate,
-    });
+    // Stage 2: History
+    let history_config = HistoryConfig::default();
+    if let Some(store_mutex) = session_store {
+        let store = store_mutex.lock().expect("session store lock");
+        let (messages, hist_result) = history::load_history(
+            &store,
+            &input.session.id,
+            ctx.history_budget,
+            &history_config,
+            &input.content,
+        )?;
+        ctx.messages = messages;
+        ctx.history_budget -= hist_result.tokens_consumed;
+        ctx.history_result = Some(hist_result);
+    } else {
+        #[expect(clippy::cast_possible_wrap, reason = "message length fits in i64")]
+        let token_estimate = input.content.len() as i64 / 4;
+        ctx.messages.push(PipelineMessage {
+            role: "user".to_owned(),
+            content: input.content.clone(),
+            token_estimate,
+        });
+    }
 
     // Stage 3: Guard
     let guard = check_guard(&input.session, config);
@@ -680,6 +707,7 @@ mod tests {
             &providers,
             &tools,
             &tool_ctx,
+            None,
             None,
             None,
         )

--- a/crates/pylon/src/server.rs
+++ b/crates/pylon/src/server.rs
@@ -60,12 +60,13 @@ pub async fn run(config: ServerConfig) -> Result<(), ServerError> {
         Arc::clone(&oikos),
         None,
         None,
+        None,
     );
     let nous_config = NousConfig::default();
     nous_manager.spawn(nous_config, PipelineConfig::default()).await;
 
     let state = Arc::new(AppState {
-        session_store: Mutex::new(session_store),
+        session_store: Arc::new(Mutex::new(session_store)),
         nous_manager,
         provider_registry,
         tool_registry,

--- a/crates/pylon/src/state.rs
+++ b/crates/pylon/src/state.rs
@@ -12,7 +12,7 @@ use aletheia_taxis::oikos::Oikos;
 
 /// Shared state for all Axum handlers, held behind `Arc` in the router.
 pub struct AppState {
-    pub session_store: Mutex<SessionStore>,
+    pub session_store: Arc<Mutex<SessionStore>>,
     pub nous_manager: NousManager,
     pub provider_registry: Arc<ProviderRegistry>,
     pub tool_registry: Arc<ToolRegistry>,

--- a/crates/pylon/src/tests.rs
+++ b/crates/pylon/src/tests.rs
@@ -110,6 +110,7 @@ async fn test_state_with_provider(with_provider: bool) -> (Arc<AppState>, tempfi
         Arc::clone(&oikos),
         None,
         None,
+        None,
     );
 
     let nous_config = NousConfig {
@@ -122,7 +123,7 @@ async fn test_state_with_provider(with_provider: bool) -> (Arc<AppState>, tempfi
     let jwt_manager = test_jwt_manager();
 
     let state = Arc::new(AppState {
-        session_store: Mutex::new(store),
+        session_store: Arc::new(Mutex::new(store)),
         nous_manager,
         provider_registry,
         tool_registry,


### PR DESCRIPTION
## Summary

- Replace Stage 2 stub in nous pipeline with real history loading from `SessionStore`
- Add `crates/nous/src/history.rs` with `HistoryConfig`, `HistoryResult`, and `load_history()`
- Surface dedicated `history_budget` from `TokenBudget` through `PipelineContext` (uses the 120k history allocation, not the 30k leftover system prompt space)
- Wire `Arc<Mutex<SessionStore>>` through `NousManager` → `NousActor` → `run_pipeline`
- Change `AppState.session_store` from `Mutex<SessionStore>` to `Arc<Mutex<SessionStore>>` for sharing between pylon handlers and nous actors
- Graceful fallback to current-message-only when no `SessionStore` is provided

## Test plan

- [x] 7 unit tests in `history.rs`: empty history, budget respect, tool filtering, system skip, order preservation, truncation flag, zero budget
- [x] All existing tests pass (33 tests across nous, pylon, aletheia)
- [x] `cargo clippy -p aletheia-nous -p aletheia-pylon -p aletheia --all-targets -- -D warnings` — zero warnings