### PR TITLE
feat(agora): inbound message routing with binding resolution

### DIFF
--- a/crates/agora/src/lib.rs
+++ b/crates/agora/src/lib.rs
@@ -7,6 +7,7 @@
 pub mod error;
 pub mod listener;
 pub mod registry;
+pub mod router;
 pub mod semeion;
 pub mod types;
 
@@ -16,6 +17,7 @@ mod assertions {
 
     use super::listener::ChannelListener;
     use super::registry::ChannelRegistry;
+    use super::router::MessageRouter;
     use super::semeion::client::SignalClient;
     use super::semeion::SignalProvider;
     use super::types::InboundMessage;
@@ -23,6 +25,7 @@ mod assertions {
     assert_impl_all!(ChannelRegistry: Send, Sync);
     assert_impl_all!(ChannelListener: Send);
     assert_impl_all!(InboundMessage: Send, Sync);
+    assert_impl_all!(MessageRouter: Send, Sync);
     assert_impl_all!(SignalClient: Send, Sync);
     assert_impl_all!(SignalProvider: Send, Sync);
 }

--- a/crates/agora/src/router.rs
+++ b/crates/agora/src/router.rs
@@ -1,0 +1,285 @@
+//! Message routing — resolves inbound messages to nous targets.
+
+use aletheia_taxis::config::ChannelBinding;
+
+use crate::types::InboundMessage;
+
+/// A resolved routing decision.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RouteDecision {
+    pub nous_id: String,
+    pub session_key: String,
+    pub matched_by: MatchReason,
+}
+
+/// How the routing decision was made.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MatchReason {
+    GroupBinding,
+    SourceBinding,
+    ChannelDefault,
+    GlobalDefault,
+}
+
+/// Routes inbound channel messages to the appropriate nous agent.
+///
+/// Resolution order:
+/// 1. Exact group match: channel + `group_id` → `nous_id`
+/// 2. Exact source match: channel + source → `nous_id`
+/// 3. Default for channel: channel + `"*"` → `nous_id`
+/// 4. Global default: the nous with `default: true`
+/// 5. No match → `None`
+pub struct MessageRouter {
+    bindings: Vec<ChannelBinding>,
+    default_nous: Option<String>,
+}
+
+impl MessageRouter {
+    pub fn new(bindings: Vec<ChannelBinding>, default_nous: Option<String>) -> Self {
+        Self {
+            bindings,
+            default_nous,
+        }
+    }
+
+    /// Resolve which nous should handle this message.
+    pub fn resolve(&self, msg: &InboundMessage) -> Option<RouteDecision> {
+        // Priority 1: exact group match (channel + group_id)
+        if let Some(group_id) = &msg.group_id {
+            for b in &self.bindings {
+                if b.channel == msg.channel && b.source == *group_id {
+                    return Some(RouteDecision {
+                        nous_id: b.nous_id.clone(),
+                        session_key: expand_session_key(&b.session_key, msg),
+                        matched_by: MatchReason::GroupBinding,
+                    });
+                }
+            }
+        }
+
+        // Priority 2: exact source match (channel + sender)
+        for b in &self.bindings {
+            if b.channel == msg.channel && b.source == msg.sender {
+                return Some(RouteDecision {
+                    nous_id: b.nous_id.clone(),
+                    session_key: expand_session_key(&b.session_key, msg),
+                    matched_by: MatchReason::SourceBinding,
+                });
+            }
+        }
+
+        // Priority 3: channel default (source = "*")
+        for b in &self.bindings {
+            if b.channel == msg.channel && b.source == "*" {
+                return Some(RouteDecision {
+                    nous_id: b.nous_id.clone(),
+                    session_key: expand_session_key(&b.session_key, msg),
+                    matched_by: MatchReason::ChannelDefault,
+                });
+            }
+        }
+
+        // Priority 4: global default
+        self.default_nous.as_ref().map(|id| RouteDecision {
+            nous_id: id.clone(),
+            session_key: expand_session_key("{source}", msg),
+            matched_by: MatchReason::GlobalDefault,
+        })
+    }
+}
+
+/// Expand session key template placeholders.
+fn expand_session_key(template: &str, msg: &InboundMessage) -> String {
+    template
+        .replace("{source}", &msg.sender)
+        .replace("{group}", msg.group_id.as_deref().unwrap_or("dm"))
+}
+
+/// Determine reply target for outbound response.
+///
+/// Group messages reply to the group. DMs reply to the sender.
+pub fn reply_target(msg: &InboundMessage) -> String {
+    match &msg.group_id {
+        Some(group) => format!("group:{group}"),
+        None => msg.sender.clone(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn dm_message(sender: &str) -> InboundMessage {
+        InboundMessage {
+            channel: "signal".to_owned(),
+            sender: sender.to_owned(),
+            sender_name: None,
+            group_id: None,
+            text: "hello".to_owned(),
+            timestamp: 100,
+            attachments: vec![],
+            raw: None,
+        }
+    }
+
+    fn group_message(sender: &str, group_id: &str) -> InboundMessage {
+        InboundMessage {
+            channel: "signal".to_owned(),
+            sender: sender.to_owned(),
+            sender_name: None,
+            group_id: Some(group_id.to_owned()),
+            text: "hello".to_owned(),
+            timestamp: 100,
+            attachments: vec![],
+            raw: None,
+        }
+    }
+
+    fn binding(channel: &str, source: &str, nous_id: &str) -> ChannelBinding {
+        ChannelBinding {
+            channel: channel.to_owned(),
+            source: source.to_owned(),
+            nous_id: nous_id.to_owned(),
+            session_key: "{source}".to_owned(),
+        }
+    }
+
+    #[test]
+    fn exact_group_binding_matches() {
+        let router = MessageRouter::new(
+            vec![binding("signal", "group-abc", "syn")],
+            None,
+        );
+        let msg = group_message("+1234567890", "group-abc");
+        let decision = router.resolve(&msg).expect("should match");
+        assert_eq!(decision.nous_id, "syn");
+        assert_eq!(decision.matched_by, MatchReason::GroupBinding);
+    }
+
+    #[test]
+    fn exact_source_binding_matches() {
+        let router = MessageRouter::new(
+            vec![binding("signal", "+1234567890", "cody")],
+            None,
+        );
+        let msg = dm_message("+1234567890");
+        let decision = router.resolve(&msg).expect("should match");
+        assert_eq!(decision.nous_id, "cody");
+        assert_eq!(decision.matched_by, MatchReason::SourceBinding);
+    }
+
+    #[test]
+    fn channel_default_matches() {
+        let router = MessageRouter::new(
+            vec![binding("signal", "*", "default-nous")],
+            None,
+        );
+        let msg = dm_message("+9999999999");
+        let decision = router.resolve(&msg).expect("should match");
+        assert_eq!(decision.nous_id, "default-nous");
+        assert_eq!(decision.matched_by, MatchReason::ChannelDefault);
+    }
+
+    #[test]
+    fn global_default_fallback() {
+        let router = MessageRouter::new(vec![], Some("global-nous".to_owned()));
+        let msg = dm_message("+1234567890");
+        let decision = router.resolve(&msg).expect("should match");
+        assert_eq!(decision.nous_id, "global-nous");
+        assert_eq!(decision.matched_by, MatchReason::GlobalDefault);
+    }
+
+    #[test]
+    fn no_match_returns_none() {
+        let router = MessageRouter::new(vec![], None);
+        let msg = dm_message("+1234567890");
+        assert!(router.resolve(&msg).is_none());
+    }
+
+    #[test]
+    fn group_binding_takes_priority_over_source() {
+        let router = MessageRouter::new(
+            vec![
+                binding("signal", "+1234567890", "source-nous"),
+                binding("signal", "group-abc", "group-nous"),
+            ],
+            None,
+        );
+        let msg = group_message("+1234567890", "group-abc");
+        let decision = router.resolve(&msg).expect("should match");
+        assert_eq!(decision.nous_id, "group-nous");
+        assert_eq!(decision.matched_by, MatchReason::GroupBinding);
+    }
+
+    #[test]
+    fn session_key_source_interpolation() {
+        let mut b = binding("signal", "*", "syn");
+        b.session_key = "signal:{source}".to_owned();
+        let router = MessageRouter::new(vec![b], None);
+        let msg = dm_message("+1234567890");
+        let decision = router.resolve(&msg).expect("should match");
+        assert_eq!(decision.session_key, "signal:+1234567890");
+    }
+
+    #[test]
+    fn session_key_group_interpolation() {
+        let mut b = binding("signal", "group-abc", "syn");
+        b.session_key = "signal:group:{group}".to_owned();
+        let router = MessageRouter::new(vec![b], None);
+        let msg = group_message("+1234567890", "group-abc");
+        let decision = router.resolve(&msg).expect("should match");
+        assert_eq!(decision.session_key, "signal:group:group-abc");
+    }
+
+    #[test]
+    fn dm_session_key_format() {
+        let mut b = binding("signal", "+1234567890", "syn");
+        b.session_key = "signal:{source}".to_owned();
+        let router = MessageRouter::new(vec![b], None);
+        let msg = dm_message("+1234567890");
+        let decision = router.resolve(&msg).expect("should match");
+        assert_eq!(decision.session_key, "signal:+1234567890");
+    }
+
+    #[test]
+    fn group_session_key_format() {
+        let mut b = binding("signal", "group-xyz", "syn");
+        b.session_key = "signal:group:{group}".to_owned();
+        let router = MessageRouter::new(vec![b], None);
+        let msg = group_message("+9999999999", "group-xyz");
+        let decision = router.resolve(&msg).expect("should match");
+        assert_eq!(decision.session_key, "signal:group:group-xyz");
+    }
+
+    #[test]
+    fn group_placeholder_defaults_to_dm() {
+        let mut b = binding("signal", "+1234567890", "syn");
+        b.session_key = "{source}:{group}".to_owned();
+        let router = MessageRouter::new(vec![b], None);
+        let msg = dm_message("+1234567890");
+        let decision = router.resolve(&msg).expect("should match");
+        assert_eq!(decision.session_key, "+1234567890:dm");
+    }
+
+    #[test]
+    fn wrong_channel_does_not_match() {
+        let router = MessageRouter::new(
+            vec![binding("slack", "+1234567890", "syn")],
+            None,
+        );
+        let msg = dm_message("+1234567890");
+        assert!(router.resolve(&msg).is_none());
+    }
+
+    #[test]
+    fn reply_target_dm() {
+        let msg = dm_message("+1234567890");
+        assert_eq!(reply_target(&msg), "+1234567890");
+    }
+
+    #[test]
+    fn reply_target_group() {
+        let msg = group_message("+1234567890", "group-abc");
+        assert_eq!(reply_target(&msg), "group:group-abc");
+    }
+}

--- a/crates/aletheia/src/dispatch.rs
+++ b/crates/aletheia/src/dispatch.rs
@@ -1,0 +1,104 @@
+//! Background dispatch loop — routes inbound messages to nous actors.
+
+use std::sync::Arc;
+
+use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
+use tracing::{info, warn, Instrument};
+
+use aletheia_agora::registry::ChannelRegistry;
+use aletheia_agora::router::{reply_target, MessageRouter};
+use aletheia_agora::types::{InboundMessage, SendParams};
+use aletheia_nous::manager::NousManager;
+
+/// Spawn a background task that dispatches inbound messages to nous actors.
+///
+/// Runs until the receiver channel closes (all senders dropped).
+pub fn spawn_dispatcher(
+    mut rx: mpsc::Receiver<InboundMessage>,
+    router: Arc<MessageRouter>,
+    nous_manager: Arc<NousManager>,
+    channel_registry: Arc<ChannelRegistry>,
+) -> JoinHandle<()> {
+    let span = tracing::info_span!("message_dispatcher");
+    tokio::spawn(
+        async move {
+            info!("dispatch loop started");
+            while let Some(msg) = rx.recv().await {
+                let router = Arc::clone(&router);
+                let nous_mgr = Arc::clone(&nous_manager);
+                let channels = Arc::clone(&channel_registry);
+                let msg_span = tracing::info_span!(
+                    "dispatch",
+                    channel = %msg.channel,
+                    sender = %msg.sender,
+                );
+                tokio::spawn(dispatch_one(msg, router, nous_mgr, channels).instrument(msg_span));
+            }
+            info!("dispatch loop stopped — all senders dropped");
+        }
+        .instrument(span),
+    )
+}
+
+async fn dispatch_one(
+    msg: InboundMessage,
+    router: Arc<MessageRouter>,
+    nous_manager: Arc<NousManager>,
+    channel_registry: Arc<ChannelRegistry>,
+) {
+    let Some(decision) = router.resolve(&msg) else {
+        warn!(
+            channel = %msg.channel,
+            sender = %msg.sender,
+            "no route for inbound message, dropping"
+        );
+        return;
+    };
+
+    let Some(handle) = nous_manager.get(&decision.nous_id).cloned() else {
+        warn!(
+            nous_id = %decision.nous_id,
+            "routed to unknown nous actor, dropping"
+        );
+        return;
+    };
+
+    info!(
+        nous_id = %decision.nous_id,
+        session_key = %decision.session_key,
+        matched_by = ?decision.matched_by,
+        "dispatching turn"
+    );
+
+    let turn_result = match handle.send_turn(&decision.session_key, &msg.text).await {
+        Ok(result) => result,
+        Err(e) => {
+            warn!(error = %e, nous_id = %decision.nous_id, "turn failed");
+            return;
+        }
+    };
+
+    let to = reply_target(&msg);
+    let params = SendParams {
+        to,
+        text: turn_result.content,
+        account_id: None,
+        thread_id: None,
+        attachments: None,
+    };
+
+    match channel_registry.send(&msg.channel, &params).await {
+        Ok(result) => {
+            if !result.sent {
+                warn!(
+                    error = result.error.as_deref().unwrap_or("unknown"),
+                    "failed to send reply"
+                );
+            }
+        }
+        Err(e) => {
+            warn!(error = %e, "channel send error");
+        }
+    }
+}

--- a/crates/aletheia/src/main.rs
+++ b/crates/aletheia/src/main.rs
@@ -1,5 +1,7 @@
 //! Aletheia cognitive agent runtime — binary entrypoint.
 
+mod dispatch;
+
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
@@ -10,8 +12,11 @@ use tracing::{info, warn};
 use tracing_subscriber::{fmt, EnvFilter};
 
 use aletheia_agora::listener::ChannelListener;
+use aletheia_agora::registry::ChannelRegistry;
+use aletheia_agora::router::MessageRouter;
 use aletheia_agora::semeion::client::SignalClient;
 use aletheia_agora::semeion::SignalProvider;
+use aletheia_agora::types::ChannelProvider;
 use aletheia_hermeneus::anthropic::AnthropicProvider;
 use aletheia_hermeneus::provider::{ProviderConfig, ProviderRegistry};
 use aletheia_mneme::store::SessionStore;
@@ -147,13 +152,17 @@ async fn serve(cli: Cli) -> Result<()> {
         info!(count = nous_manager.count(), "nous actors spawned");
     }
 
-    // Signal channel listener (optional)
-    let _listener = start_signal_listener(&config.channels.signal);
+    // Wrap in Arc — shared between dispatcher and AppState
+    let nous_manager = Arc::new(nous_manager);
 
-    // Pylon HTTP gateway — shares registries with NousManager, owns the manager
+    // Channel registry + inbound dispatch
+    let (_channel_registry, _dispatch_handle) =
+        start_inbound_dispatch(&config, &nous_manager);
+
+    // Pylon HTTP gateway — shares registries with NousManager
     let state = Arc::new(AppState {
         session_store,
-        nous_manager,
+        nous_manager: Arc::clone(&nous_manager),
         provider_registry,
         tool_registry,
         oikos: oikos_arc,
@@ -214,9 +223,54 @@ fn build_tool_registry() -> Result<ToolRegistry> {
     Ok(registry)
 }
 
-fn start_signal_listener(
+/// Build channel registry, start inbound listener, and spawn dispatch loop.
+fn start_inbound_dispatch(
+    config: &aletheia_taxis::config::AletheiaConfig,
+    nous_manager: &Arc<NousManager>,
+) -> (Arc<ChannelRegistry>, Option<tokio::task::JoinHandle<()>>) {
+    let mut channel_registry = ChannelRegistry::new();
+
+    let signal_provider = build_signal_provider(&config.channels.signal);
+    if let Some(ref provider) = signal_provider {
+        channel_registry
+            .register(Arc::clone(provider) as Arc<dyn ChannelProvider>)
+            .expect("register signal provider");
+    }
+    let channel_registry = Arc::new(channel_registry);
+
+    let handle = if let Some(ref provider) = signal_provider {
+        let listener = ChannelListener::start(provider, None);
+        info!("signal channel listener started");
+        let rx = listener.into_receiver();
+
+        let default_nous_id = config
+            .agents
+            .list
+            .iter()
+            .find(|a| a.default)
+            .or_else(|| config.agents.list.first())
+            .map(|a| a.id.clone());
+        let router = Arc::new(MessageRouter::new(
+            config.bindings.clone(),
+            default_nous_id,
+        ));
+
+        Some(dispatch::spawn_dispatcher(
+            rx,
+            router,
+            Arc::clone(nous_manager),
+            Arc::clone(&channel_registry),
+        ))
+    } else {
+        None
+    };
+
+    (channel_registry, handle)
+}
+
+fn build_signal_provider(
     signal_config: &aletheia_taxis::config::SignalConfig,
-) -> Option<ChannelListener> {
+) -> Option<Arc<SignalProvider>> {
     if !signal_config.enabled {
         info!("signal channel disabled");
         return None;
@@ -247,9 +301,7 @@ fn start_signal_listener(
         }
     }
 
-    let listener = ChannelListener::start(&provider, None);
-    info!("signal channel listener started");
-    Some(listener)
+    Some(Arc::new(provider))
 }
 
 fn init_tracing(log_level: &str, json: bool) {

--- a/crates/pylon/src/server.rs
+++ b/crates/pylon/src/server.rs
@@ -67,7 +67,7 @@ pub async fn run(config: ServerConfig) -> Result<(), ServerError> {
 
     let state = Arc::new(AppState {
         session_store: Arc::new(Mutex::new(session_store)),
-        nous_manager,
+        nous_manager: Arc::new(nous_manager),
         provider_registry,
         tool_registry,
         oikos,

--- a/crates/pylon/src/state.rs
+++ b/crates/pylon/src/state.rs
@@ -13,7 +13,7 @@ use aletheia_taxis::oikos::Oikos;
 /// Shared state for all Axum handlers, held behind `Arc` in the router.
 pub struct AppState {
     pub session_store: Arc<Mutex<SessionStore>>,
-    pub nous_manager: NousManager,
+    pub nous_manager: Arc<NousManager>,
     pub provider_registry: Arc<ProviderRegistry>,
     pub tool_registry: Arc<ToolRegistry>,
     pub oikos: Arc<Oikos>,

--- a/crates/pylon/src/tests.rs
+++ b/crates/pylon/src/tests.rs
@@ -124,7 +124,7 @@ async fn test_state_with_provider(with_provider: bool) -> (Arc<AppState>, tempfi
 
     let state = Arc::new(AppState {
         session_store: Arc::new(Mutex::new(store)),
-        nous_manager,
+        nous_manager: Arc::new(nous_manager),
         provider_registry,
         tool_registry,
         oikos,

--- a/crates/taxis/src/config.rs
+++ b/crates/taxis/src/config.rs
@@ -12,6 +12,26 @@ pub struct AletheiaConfig {
     pub agents: AgentsConfig,
     pub gateway: GatewayConfig,
     pub channels: ChannelsConfig,
+    pub bindings: Vec<ChannelBinding>,
+}
+
+/// Maps a channel source to a nous agent.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ChannelBinding {
+    /// Channel type (e.g., "signal").
+    pub channel: String,
+    /// Source pattern — phone number, group ID, or "*" for default.
+    pub source: String,
+    /// Nous ID to route to.
+    pub nous_id: String,
+    /// Session key pattern. Supports `{source}` and `{group}` placeholders.
+    #[serde(default = "default_session_pattern")]
+    pub session_key: String,
+}
+
+fn default_session_pattern() -> String {
+    "{source}".to_owned()
 }
 
 /// Agent configuration: shared defaults and per-agent definitions.
@@ -317,6 +337,7 @@ mod tests {
         assert_eq!(config.gateway.auth.mode, "token");
         assert!(config.channels.signal.enabled);
         assert!(config.channels.signal.accounts.is_empty());
+        assert!(config.bindings.is_empty());
     }
 
     #[test]
@@ -449,5 +470,25 @@ mod tests {
         assert!(account.require_mention);
         assert!(account.send_read_receipts);
         assert_eq!(account.text_chunk_limit, 2000);
+    }
+
+    #[test]
+    fn channel_binding_serde_roundtrip() {
+        let json = r#"{
+            "channel": "signal",
+            "source": "+1234567890",
+            "nousId": "syn"
+        }"#;
+        let binding: ChannelBinding = serde_json::from_str(json).expect("parse binding");
+        assert_eq!(binding.channel, "signal");
+        assert_eq!(binding.source, "+1234567890");
+        assert_eq!(binding.nous_id, "syn");
+        assert_eq!(binding.session_key, "{source}");
+    }
+
+    #[test]
+    fn bindings_in_config_default_empty() {
+        let config = AletheiaConfig::default();
+        assert!(config.bindings.is_empty());
     }
 }


### PR DESCRIPTION
## Summary

- **ChannelBinding** config type in taxis — maps channel+source patterns to nous agents with session key templates (`{source}`, `{group}` placeholders)
- **MessageRouter** in agora — 4-level priority resolution: group binding → source binding → channel default → global default
- **MessageDispatcher** in binary crate — background Tokio task connecting ChannelListener → MessageRouter → NousHandle → ChannelRegistry reply
- **NousManager wrapped in Arc** — shared between HTTP handlers (AppState) and dispatch loop
- **SignalProvider refactored** — built as `Arc<SignalProvider>`, registered in ChannelRegistry for outbound replies, shared with ChannelListener for inbound polling

## Files changed

| File | Change |
|------|--------|
| `crates/taxis/src/config.rs` | `ChannelBinding` struct, `bindings` field on `AletheiaConfig` |
| `crates/agora/src/router.rs` | **New** — `MessageRouter`, `RouteDecision`, `MatchReason`, `reply_target()` |
| `crates/agora/src/lib.rs` | Register `router` module, add `Send+Sync` assertion |
| `crates/aletheia/src/dispatch.rs` | **New** — `spawn_dispatcher`, per-message dispatch with tracing spans |
| `crates/aletheia/src/main.rs` | Extract `start_inbound_dispatch`, `build_signal_provider`, Arc wiring |
| `crates/pylon/src/state.rs` | `nous_manager: NousManager` → `Arc<NousManager>` |
| `crates/pylon/src/server.rs` | Arc wrapping for NousManager |
| `crates/pylon/src/tests.rs` | Arc wrapping in test helpers |

## Test plan

- [x] 14 unit tests on routing logic (group/source/channel/global priority, session key interpolation, reply targets)
- [x] 2 new config tests (binding serde roundtrip, default empty bindings)
- [x] All 33 pylon tests pass (Arc<NousManager> backward-compatible)
- [x] `cargo clippy -p aletheia-taxis -p aletheia-agora -p aletheia-pylon -p aletheia -- -D warnings` — zero warnings