### PR TITLE
test: end-to-end integration tests for pipeline and HTTP stack

### DIFF
--- a/crates/integration-tests/tests/end_to_end.rs
+++ b/crates/integration-tests/tests/end_to_end.rs
@@ -486,3 +486,60 @@ async fn unauthenticated_request_rejected() {
     let resp = router.oneshot(req).await.expect("unauthenticated request");
     assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
 }
+
+#[tokio::test]
+async fn close_session_archives_it() {
+    let harness = TestHarness::build().await;
+    let router = harness.router();
+
+    let session = harness.create_session(&router).await;
+    let id = session["id"].as_str().expect("session id");
+
+    let token = harness.auth_token();
+    let req = Request::delete(format!("/api/sessions/{id}"))
+        .header("authorization", format!("Bearer {token}"))
+        .body(Body::empty())
+        .expect("request");
+    let resp = router.clone().oneshot(req).await.expect("close session");
+    assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+
+    let resp = router
+        .clone()
+        .oneshot(harness.authed_get(&format!("/api/sessions/{id}")))
+        .await
+        .expect("get archived session");
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = body_json(resp).await;
+    assert_eq!(body["status"], "archived");
+}
+
+#[tokio::test]
+async fn send_message_stores_both_roles_in_history() {
+    let harness = TestHarness::build().await;
+    let router = harness.router();
+
+    let session = harness.create_session(&router).await;
+    let id = session["id"].as_str().expect("session id");
+
+    let req = harness.authed_request(
+        "POST",
+        &format!("/api/sessions/{id}/messages"),
+        Some(serde_json::json!({ "content": "test message" })),
+    );
+    let resp = router.clone().oneshot(req).await.expect("send message");
+    let _ = body_string(resp).await;
+
+    let resp = router
+        .clone()
+        .oneshot(harness.authed_get(&format!("/api/sessions/{id}/history")))
+        .await
+        .expect("get history");
+    let history = body_json(resp).await;
+    let messages = history["messages"].as_array().expect("messages array");
+
+    assert_eq!(messages.len(), 2, "should have exactly user + assistant");
+    assert_eq!(messages[0]["role"], "user");
+    assert_eq!(messages[0]["content"], "test message");
+    assert_eq!(messages[1]["role"], "assistant");
+    assert_eq!(messages[1]["content"], "Hello from mock!");
+}


### PR DESCRIPTION
## Summary

- Adds 2 additional e2e integration test cases to `crates/integration-tests/tests/end_to_end.rs`:
  - `close_session_archives_it` — verifies DELETE archives session and subsequent GET reflects "archived" status
  - `send_message_stores_both_roles_in_history` — explicitly validates both user and assistant messages appear in history with correct role and content after a turn

Builds on the existing 7 e2e tests (HTTP round trip, multi-turn persistence, nous status, bootstrap assembly, 404 handling, health check, auth enforcement) bringing the total to 9.

## Test plan

- [x] `cargo test -p aletheia-integration-tests --test end_to_end` — all 9 tests pass
- [x] `cargo clippy -p aletheia-integration-tests --all-targets -- -D warnings` — zero warnings
- [x] `cargo test --workspace --exclude aletheia-mneme-engine --exclude aletheia-mneme-bench --exclude aletheia-graph-builder` — all workspace tests pass
- [x] Only `end_to_end.rs` modified — pure test addition, no production code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)