### PR TITLE
feat(nous): history pipeline stage — load conversation context

### DIFF
--- a/crates/nous/src/history.rs
+++ b/crates/nous/src/history.rs
@@ -107,9 +107,8 @@ pub fn load_history(
         }
 
         let role = match msg.role {
-            Role::User => "user",
+            Role::User | Role::ToolResult => "user",
             Role::Assistant => "assistant",
-            Role::ToolResult => "tool_result",
             Role::System => unreachable!(),
         };
 
@@ -288,6 +287,35 @@ mod tests {
 
         assert!(!result_full.truncated);
         assert_eq!(result_full.messages_loaded, 10);
+    }
+
+    #[test]
+    fn tool_result_mapped_to_user_role() {
+        let store = setup_store();
+        append(&store, Role::ToolResult, "file contents", 100);
+
+        let config = HistoryConfig::default();
+        let (messages, result) =
+            load_history(&store, "ses-1", 100_000, &config, "next").expect("load");
+
+        assert_eq!(result.messages_loaded, 1);
+        assert_eq!(messages[0].role, "user");
+        assert_eq!(messages[0].content, "file contents");
+    }
+
+    #[test]
+    fn token_estimates_preserved() {
+        let store = setup_store();
+        append(&store, Role::User, "q", 42);
+        append(&store, Role::Assistant, "a", 99);
+
+        let config = HistoryConfig::default();
+        let (messages, result) =
+            load_history(&store, "ses-1", 100_000, &config, "next").expect("load");
+
+        assert_eq!(result.tokens_consumed, 141);
+        assert_eq!(messages[0].token_estimate, 42);
+        assert_eq!(messages[1].token_estimate, 99);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Fix `Role::ToolResult` mapping from `"tool_result"` to `"user"` per Anthropic API convention (tool results are sent as user messages)
- Add 2 missing unit tests (`tool_result_mapped_to_user_role`, `token_estimates_preserved`) bringing history stage to 9 tests total

The history stage implementation, wiring through actor/manager/pipeline, `Arc<Mutex<SessionStore>>` sharing, and finalize stage were already on main. This PR completes the acceptance criteria.

## Test plan

- [x] `cargo clippy --workspace --exclude aletheia-mneme-engine --all-targets -- -D warnings` — zero warnings
- [x] `cargo test -p aletheia-nous` — 131 tests pass (9 history tests)
- [x] ToolResult role correctly maps to `"user"` 
- [x] Token estimates preserved through conversion
- [x] System messages skipped, tool messages filterable, budget respected, truncation detected

🤖 Generated with [Claude Code](https://claude.com/claude-code)