### PR TITLE
test: coverage tooling, failure injection, and property tests

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,35 @@
+name: Rust
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "crates/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - ".github/workflows/rust.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "crates/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - ".github/workflows/rust.yml"
+
+env:
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: -D warnings
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+      - name: Test
+        run: cargo test --workspace
+      - name: Clippy
+        run: cargo clippy --workspace -- -D warnings

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -207,6 +207,7 @@ dependencies = [
  "pest",
  "pest_derive",
  "priority-queue",
+ "proptest",
  "quadrature",
  "rand 0.8.5",
  "rayon",
@@ -699,6 +700,21 @@ dependencies = [
  "shlex",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bit_field"
@@ -2290,7 +2306,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
 dependencies = [
  "byteorder-lite",
- "quick-error",
+ "quick-error 2.0.1",
 ]
 
 [[package]]
@@ -3554,6 +3570,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37566cb3fdacef14c0737f9546df7cfeadbfbc9fef10991038bf5015d0c80532"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "num-traits",
+ "rand 0.9.2",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
 name = "pxfm"
 version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3573,6 +3608,12 @@ name = "quadrature"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2054ccb02f454fcb2bc81e343aa0a171636a6331003fd5ec24c47a10966634b7"
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-error"
@@ -3655,6 +3696,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rav1e"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3698,7 +3748,7 @@ dependencies = [
  "avif-serialize",
  "imgref",
  "loop9",
- "quick-error",
+ "quick-error 2.0.1",
  "rav1e",
  "rayon",
  "rgb",
@@ -4029,6 +4079,18 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error 1.2.3",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "ryu"
@@ -4551,7 +4613,7 @@ dependencies = [
  "fax",
  "flate2",
  "half",
- "quick-error",
+ "quick-error 2.0.1",
  "weezl",
  "zune-jpeg 0.4.21",
 ]
@@ -4884,6 +4946,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "uncased"
 version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5043,6 +5111,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "want"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,6 +102,7 @@ tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "signal
 tokio-stream = "0.1"
 
 # Testing
+proptest = "1"
 static_assertions = "1.1"
 wiremock = "0.6"
 

--- a/crates/hermeneus/src/anthropic/client.rs
+++ b/crates/hermeneus/src/anthropic/client.rs
@@ -281,7 +281,7 @@ impl LlmProvider for AnthropicProvider {
     }
 }
 
-fn backoff_delay(attempt: u32, last_error: Option<&error::Error>) -> Duration {
+pub(crate) fn backoff_delay(attempt: u32, last_error: Option<&error::Error>) -> Duration {
     if let Some(error::Error::RateLimited {
         retry_after_ms, ..
     }) = last_error
@@ -311,5 +311,280 @@ impl std::fmt::Debug for AnthropicProvider {
             .field("api_version", &self.api_version)
             .field("max_retries", &self.max_retries)
             .finish_non_exhaustive()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    use super::*;
+    use crate::error::Error;
+    use crate::provider::{LlmProvider, ProviderConfig};
+    use crate::types::{CompletionRequest, CompletionResponse, Content, Message, Role};
+
+    /// Build a provider and call complete() on a blocking thread.
+    ///
+    /// reqwest::blocking::Client panics if constructed or used inside a tokio
+    /// async context, so wiremock tests dispatch everything to spawn_blocking.
+    async fn complete_on_blocking_thread(
+        config: ProviderConfig,
+        request: CompletionRequest,
+    ) -> crate::error::Result<CompletionResponse> {
+        tokio::task::spawn_blocking(move || {
+            let provider = AnthropicProvider::from_config(&config)?;
+            provider.complete(&request)
+        })
+        .await
+        .expect("spawn_blocking join")
+    }
+
+    fn test_config_with(base_url: &str) -> ProviderConfig {
+        ProviderConfig {
+            provider_type: "anthropic".to_owned(),
+            api_key: Some("test-key".to_owned()),
+            base_url: Some(base_url.to_owned()),
+            default_model: None,
+            max_retries: Some(0),
+        }
+    }
+
+    fn test_request() -> CompletionRequest {
+        CompletionRequest {
+            model: "claude-opus-4-20250514".to_owned(),
+            system: None,
+            messages: vec![Message {
+                role: Role::User,
+                content: Content::Text("hello".to_owned()),
+            }],
+            max_tokens: 128,
+            tools: vec![],
+            temperature: None,
+            thinking: None,
+            stop_sequences: vec![],
+        }
+    }
+
+    fn valid_wire_response_json() -> serde_json::Value {
+        serde_json::json!({
+            "id": "msg_test",
+            "type": "message",
+            "role": "assistant",
+            "content": [{"type": "text", "text": "Hello from test"}],
+            "model": "claude-opus-4-20250514",
+            "stop_reason": "end_turn",
+            "usage": {"input_tokens": 10, "output_tokens": 5}
+        })
+    }
+
+    // --- from_config tests ---
+
+    #[test]
+    fn from_config_missing_api_key() {
+        let config = ProviderConfig {
+            api_key: None,
+            ..ProviderConfig::default()
+        };
+        let err = AnthropicProvider::from_config(&config).expect_err("should fail without key");
+        assert!(
+            matches!(err, Error::ProviderInit { .. }),
+            "expected ProviderInit, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn from_config_empty_api_key() {
+        let config = ProviderConfig {
+            api_key: Some(String::new()),
+            ..ProviderConfig::default()
+        };
+        let err = AnthropicProvider::from_config(&config).expect_err("should fail with empty key");
+        assert!(
+            matches!(err, Error::ProviderInit { .. }),
+            "expected ProviderInit, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn from_config_valid() {
+        let config = ProviderConfig {
+            api_key: Some("sk-test-123".to_owned()),
+            base_url: Some("https://custom.api.example.com".to_owned()),
+            ..ProviderConfig::default()
+        };
+        let provider = AnthropicProvider::from_config(&config).expect("valid config");
+        let debug = format!("{provider:?}");
+        assert!(
+            debug.contains("custom.api.example.com"),
+            "debug should show base_url: {debug}"
+        );
+    }
+
+    // --- wiremock integration tests ---
+
+    #[tokio::test]
+    async fn complete_success() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/v1/messages"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(valid_wire_response_json()),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let config = test_config_with(&server.uri());
+        let response = complete_on_blocking_thread(config, test_request())
+            .await
+            .expect("complete");
+        assert_eq!(response.id, "msg_test");
+        assert_eq!(response.stop_reason, crate::types::StopReason::EndTurn);
+        assert_eq!(response.usage.input_tokens, 10);
+    }
+
+    #[tokio::test]
+    async fn complete_auth_failure_not_retried() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/v1/messages"))
+            .respond_with(ResponseTemplate::new(401).set_body_json(serde_json::json!({
+                "type": "error",
+                "error": {"type": "authentication_error", "message": "invalid api key"}
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let mut config = test_config_with(&server.uri());
+        config.max_retries = Some(2);
+        let err = complete_on_blocking_thread(config, test_request())
+            .await
+            .expect_err("should fail");
+        assert!(
+            matches!(err, Error::AuthFailed { .. }),
+            "expected AuthFailed, got: {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn complete_bad_request_not_retried() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/v1/messages"))
+            .respond_with(ResponseTemplate::new(400).set_body_json(serde_json::json!({
+                "type": "error",
+                "error": {"type": "invalid_request_error", "message": "bad input"}
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let mut config = test_config_with(&server.uri());
+        config.max_retries = Some(2);
+        let err = complete_on_blocking_thread(config, test_request())
+            .await
+            .expect_err("should fail");
+        assert!(
+            matches!(err, Error::ApiError { status: 400, .. }),
+            "expected ApiError 400, got: {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn complete_rate_limited_no_retry() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/v1/messages"))
+            .respond_with(ResponseTemplate::new(429).set_body_json(serde_json::json!({
+                "type": "error",
+                "error": {"type": "rate_limit_error", "message": "rate limited"}
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let config = test_config_with(&server.uri());
+        let err = complete_on_blocking_thread(config, test_request())
+            .await
+            .expect_err("should fail");
+        assert!(
+            matches!(err, Error::RateLimited { .. }),
+            "expected RateLimited, got: {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn complete_server_error_no_retry() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/v1/messages"))
+            .respond_with(ResponseTemplate::new(500).set_body_string("internal server error"))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let config = test_config_with(&server.uri());
+        let err = complete_on_blocking_thread(config, test_request())
+            .await
+            .expect_err("should fail");
+        assert!(
+            matches!(err, Error::ApiError { status: 500, .. }),
+            "expected ApiError 500, got: {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn complete_malformed_body() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/v1/messages"))
+            .respond_with(ResponseTemplate::new(200).set_body_string("not json at all"))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let config = test_config_with(&server.uri());
+        let err = complete_on_blocking_thread(config, test_request())
+            .await
+            .expect_err("should fail");
+        assert!(
+            matches!(err, Error::ParseResponse { .. }),
+            "expected ParseResponse, got: {err:?}"
+        );
+    }
+
+    // --- backoff_delay unit tests ---
+
+    #[test]
+    fn backoff_delay_respects_retry_after() {
+        let err = error::RateLimitedSnafu {
+            retry_after_ms: 5000_u64,
+        }
+        .build();
+        let delay = backoff_delay(1, Some(&err));
+        assert_eq!(delay, Duration::from_millis(5000));
+    }
+
+    #[test]
+    fn backoff_delay_exponential_growth() {
+        let d1 = backoff_delay(1, None);
+        let d2 = backoff_delay(2, None);
+        let d3 = backoff_delay(3, None);
+        assert!(d1 < d2, "attempt 2 should be longer than attempt 1");
+        assert!(d2 < d3, "attempt 3 should be longer than attempt 2");
+        assert!(
+            d3 <= Duration::from_millis(BACKOFF_MAX_MS + BACKOFF_MAX_MS / 4),
+            "delay should be capped near BACKOFF_MAX_MS"
+        );
     }
 }

--- a/crates/hermeneus/src/anthropic/stream.rs
+++ b/crates/hermeneus/src/anthropic/stream.rs
@@ -466,5 +466,44 @@ data: {\"type\":\"error\",\"error\":{\"type\":\"overloaded_error\",\"message\":\
             "expected RateLimited, got: {err:?}"
         );
     }
+
+    #[test]
+    fn malformed_json_data_returns_error() {
+        let sse = "\
+event: message_start\n\
+data: this is not valid json\n\
+\n";
+
+        let reader = std::io::Cursor::new(sse);
+        let mut acc = StreamAccumulator::new();
+        let result = parse_sse_stream(reader, &mut acc, &mut |_| {});
+        assert!(result.is_err(), "malformed JSON data should produce an error");
+    }
+
+    #[test]
+    fn non_retryable_sse_error_is_api_error() {
+        use crate::error::Error;
+
+        let sse = "\
+event: error\n\
+data: {\"type\":\"error\",\"error\":{\"type\":\"invalid_request_error\",\"message\":\"bad input\"}}\n\
+\n";
+
+        let reader = std::io::Cursor::new(sse);
+        let mut acc = StreamAccumulator::new();
+        let err = parse_sse_stream(reader, &mut acc, &mut |_| {}).expect_err("should error");
+        assert!(
+            matches!(err, Error::ApiError { status: 0, .. }),
+            "expected ApiError, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn empty_stream_returns_ok_with_defaults() {
+        let (events, response) = collect_events("");
+        assert!(events.is_empty(), "no events from empty stream");
+        assert_eq!(response.stop_reason, StopReason::EndTurn);
+        assert!(response.content.is_empty());
+    }
 }
 

--- a/crates/mneme-engine/Cargo.toml
+++ b/crates/mneme-engine/Cargo.toml
@@ -115,6 +115,7 @@ bytemuck = "1.25"
 rocksdb = { version = "0.22.0", optional = true }
 
 [dev-dependencies]
+proptest = { workspace = true }
 tempfile = "3"
 static_assertions = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/crates/mneme-engine/src/data/tests/mod.rs
+++ b/crates/mneme-engine/src/data/tests/mod.rs
@@ -13,3 +13,4 @@ mod json;
 mod memcmp;
 mod validity;
 mod values;
+mod properties;

--- a/crates/mneme-engine/src/data/tests/properties.rs
+++ b/crates/mneme-engine/src/data/tests/properties.rs
@@ -1,0 +1,96 @@
+use proptest::prelude::*;
+
+use crate::data::memcmp::MemCmpEncoder;
+use crate::data::value::{DataValue, Num};
+
+fn scalar_strategy() -> impl Strategy<Value = DataValue> {
+    prop_oneof![
+        Just(DataValue::Null),
+        any::<bool>().prop_map(DataValue::Bool),
+        any::<i64>().prop_map(|n| DataValue::Num(Num::Int(n))),
+        "[a-zA-Z0-9 ]{0,50}".prop_map(|s: String| DataValue::Str(s.into())),
+        proptest::collection::vec(any::<u8>(), 0..50).prop_map(DataValue::Bytes),
+    ]
+}
+
+proptest! {
+    #[test]
+    fn null_roundtrips(_x in Just(DataValue::Null)) {
+        let mut enc = vec![];
+        enc.encode_datavalue(&DataValue::Null);
+        let (decoded, rest) = DataValue::decode_from_key(&enc);
+        prop_assert!(rest.is_empty());
+        prop_assert_eq!(decoded, DataValue::Null);
+    }
+
+    #[test]
+    fn bool_roundtrips(b in any::<bool>()) {
+        let v = DataValue::Bool(b);
+        let mut enc = vec![];
+        enc.encode_datavalue(&v);
+        let (decoded, rest) = DataValue::decode_from_key(&enc);
+        prop_assert!(rest.is_empty());
+        prop_assert_eq!(decoded, v);
+    }
+
+    #[test]
+    fn int_roundtrips(n in any::<i64>()) {
+        let v = DataValue::Num(Num::Int(n));
+        let mut enc = vec![];
+        enc.encode_datavalue(&v);
+        let (decoded, rest) = DataValue::decode_from_key(&enc);
+        prop_assert!(rest.is_empty());
+        prop_assert_eq!(decoded, v);
+    }
+
+    #[test]
+    fn string_roundtrips(s in "[a-zA-Z0-9 ]{0,50}") {
+        let v = DataValue::Str(s.into());
+        let mut enc = vec![];
+        enc.encode_datavalue(&v);
+        let (decoded, rest) = DataValue::decode_from_key(&enc);
+        prop_assert!(rest.is_empty());
+        prop_assert_eq!(decoded, v);
+    }
+
+    #[test]
+    fn bytes_roundtrips(bs in proptest::collection::vec(any::<u8>(), 0..50)) {
+        let v = DataValue::Bytes(bs);
+        let mut enc = vec![];
+        enc.encode_datavalue(&v);
+        let (decoded, rest) = DataValue::decode_from_key(&enc);
+        prop_assert!(rest.is_empty());
+        prop_assert_eq!(decoded, v);
+    }
+
+    #[test]
+    fn int_encoding_preserves_order(a in any::<i64>(), b in any::<i64>()) {
+        let mut enc_a = vec![];
+        enc_a.encode_datavalue(&DataValue::Num(Num::Int(a)));
+        let mut enc_b = vec![];
+        enc_b.encode_datavalue(&DataValue::Num(Num::Int(b)));
+        prop_assert_eq!(enc_a.cmp(&enc_b), a.cmp(&b));
+    }
+
+    #[test]
+    fn list_of_scalars_roundtrips(items in proptest::collection::vec(scalar_strategy(), 0..5)) {
+        let v = DataValue::List(items);
+        let mut enc = vec![];
+        enc.encode_datavalue(&v);
+        let (decoded, rest) = DataValue::decode_from_key(&enc);
+        prop_assert!(rest.is_empty());
+        prop_assert_eq!(decoded, v);
+    }
+
+    #[test]
+    fn concatenated_values_decode_correctly(a in scalar_strategy(), b in scalar_strategy()) {
+        let mut enc = vec![];
+        enc.encode_datavalue(&a);
+        enc.encode_datavalue(&b);
+        let (decoded_a, rest) = DataValue::decode_from_key(&enc);
+        let (decoded_b, remaining) = DataValue::decode_from_key(rest);
+        prop_assert!(remaining.is_empty());
+        prop_assert_eq!(decoded_a, a);
+        prop_assert_eq!(decoded_b, b);
+    }
+}

--- a/crates/nous/src/execute.rs
+++ b/crates/nous/src/execute.rs
@@ -725,4 +725,112 @@ mod tests {
         assert_eq!(result.usage.llm_calls, 2);
         assert_eq!(result.usage.total_tokens(), 260);
     }
+
+    #[tokio::test]
+    async fn tool_error_captured_not_propagated() {
+        let mut providers = ProviderRegistry::new();
+        providers.register(Box::new(MockProvider::with_responses(vec![
+            make_tool_response("fail_tool", "tu_1", serde_json::json!({})),
+            make_text_response("recovered"),
+        ])));
+
+        let tools = make_registry_with("fail_tool", Box::new(ErrorExecutor));
+        let result = execute(
+            &test_pipeline_ctx(),
+            &test_session(),
+            &test_config(),
+            &providers,
+            &tools,
+            &test_tool_ctx(),
+        )
+        .await
+        .expect("pipeline should complete despite tool error");
+
+        assert!(
+            result.tool_calls.iter().any(|tc| tc.is_error),
+            "should capture the tool error in tool_calls"
+        );
+    }
+
+    #[tokio::test]
+    async fn max_iterations_stops_loop() {
+        let mut providers = ProviderRegistry::new();
+        // Provider always returns tool use — would loop forever without max_iterations.
+        // Supply enough unique-id responses to feed several iterations.
+        let responses: Vec<_> = (0..10)
+            .map(|i| make_tool_response("echo", &format!("tu_{i}"), serde_json::json!({"i": i})))
+            .collect();
+        providers.register(Box::new(MockProvider::with_responses(responses)));
+
+        let tools = make_registry_with("echo", Box::new(EchoExecutor));
+        let mut config = test_config();
+        config.max_tool_iterations = 2;
+        config.loop_detection_threshold = 100;
+        let result = execute(
+            &test_pipeline_ctx(),
+            &test_session(),
+            &config,
+            &providers,
+            &tools,
+            &test_tool_ctx(),
+        )
+        .await
+        .expect("should complete after hitting max iterations");
+
+        assert!(
+            result.usage.llm_calls <= 3,
+            "should have stopped after ~2 iterations, got {} llm_calls",
+            result.usage.llm_calls
+        );
+    }
+
+    #[tokio::test]
+    async fn text_response_no_tools() {
+        let mut providers = ProviderRegistry::new();
+        providers.register(Box::new(MockProvider::with_responses(vec![
+            make_text_response("just text"),
+        ])));
+
+        let tools = ToolRegistry::new();
+        let result = execute(
+            &test_pipeline_ctx(),
+            &test_session(),
+            &test_config(),
+            &providers,
+            &tools,
+            &test_tool_ctx(),
+        )
+        .await
+        .expect("execute");
+
+        assert!(result.tool_calls.is_empty(), "no tool calls expected");
+        assert_eq!(result.content, "just text");
+    }
+
+    #[test]
+    fn classify_signals_conversation_when_no_tools() {
+        let signals = classify_signals(&[], "some text");
+        assert_eq!(signals, vec![InteractionSignal::Conversation]);
+    }
+
+    #[test]
+    fn classify_signals_includes_error_recovery() {
+        let calls = vec![ToolCall {
+            id: "1".to_owned(),
+            name: "test".to_owned(),
+            input: serde_json::json!({}),
+            result: Some("failed".to_owned()),
+            is_error: true,
+            duration_ms: 5,
+        }];
+        let signals = classify_signals(&calls, "");
+        assert!(
+            signals.contains(&InteractionSignal::ToolExecution),
+            "should have ToolExecution"
+        );
+        assert!(
+            signals.contains(&InteractionSignal::ErrorRecovery),
+            "should have ErrorRecovery"
+        );
+    }
 }

--- a/crates/organon/src/builtins/communication.rs
+++ b/crates/organon/src/builtins/communication.rs
@@ -120,3 +120,74 @@ fn sessions_ask_def() -> ToolDef {
         auto_activate: false,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use aletheia_koina::id::{NousId, SessionId, ToolName};
+
+    use crate::registry::ToolRegistry;
+    use crate::types::{ToolContext, ToolInput};
+
+    fn test_ctx() -> ToolContext {
+        ToolContext {
+            nous_id: NousId::new("test-agent").expect("valid"),
+            session_id: SessionId::new(),
+            workspace: PathBuf::from("/tmp/test"),
+            allowed_roots: vec![PathBuf::from("/tmp")],
+        }
+    }
+
+    #[tokio::test]
+    async fn register_communication_tools() {
+        let mut reg = ToolRegistry::new();
+        super::register(&mut reg).expect("register");
+        assert_eq!(reg.definitions().len(), 2);
+    }
+
+    #[tokio::test]
+    async fn message_stub_responds() {
+        let mut reg = ToolRegistry::new();
+        super::register(&mut reg).expect("register");
+        let input = ToolInput {
+            name: ToolName::new("message").expect("valid"),
+            tool_use_id: "tu_1".to_owned(),
+            arguments: serde_json::json!({"to": "+1234567890", "text": "hello"}),
+        };
+        let result = reg.execute(&input, &test_ctx()).await.expect("execute");
+        assert!(!result.is_error);
+        assert!(result.content.contains("stub"), "expected stub: {}", result.content);
+    }
+
+    #[tokio::test]
+    async fn sessions_ask_stub_responds() {
+        let mut reg = ToolRegistry::new();
+        super::register(&mut reg).expect("register");
+        let input = ToolInput {
+            name: ToolName::new("sessions_ask").expect("valid"),
+            tool_use_id: "tu_2".to_owned(),
+            arguments: serde_json::json!({"agentId": "syn", "message": "hello"}),
+        };
+        let result = reg.execute(&input, &test_ctx()).await.expect("execute");
+        assert!(!result.is_error);
+    }
+
+    #[tokio::test]
+    async fn message_def_requires_to_and_text() {
+        let mut reg = ToolRegistry::new();
+        super::register(&mut reg).expect("register");
+        let name = ToolName::new("message").expect("valid");
+        let def = reg.get_def(&name).expect("found");
+        assert_eq!(def.input_schema.required, vec!["to", "text"]);
+    }
+
+    #[tokio::test]
+    async fn sessions_ask_def_requires_agent_and_message() {
+        let mut reg = ToolRegistry::new();
+        super::register(&mut reg).expect("register");
+        let name = ToolName::new("sessions_ask").expect("valid");
+        let def = reg.get_def(&name).expect("found");
+        assert_eq!(def.input_schema.required, vec!["agentId", "message"]);
+    }
+}

--- a/crates/organon/src/builtins/memory.rs
+++ b/crates/organon/src/builtins/memory.rs
@@ -176,3 +176,78 @@ fn blackboard_def() -> ToolDef {
         auto_activate: false,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use aletheia_koina::id::{NousId, SessionId, ToolName};
+
+    use crate::registry::ToolRegistry;
+    use crate::types::{ToolContext, ToolInput};
+
+    fn test_ctx() -> ToolContext {
+        ToolContext {
+            nous_id: NousId::new("test-agent").expect("valid"),
+            session_id: SessionId::new(),
+            workspace: PathBuf::from("/tmp/test"),
+            allowed_roots: vec![PathBuf::from("/tmp")],
+        }
+    }
+
+    #[tokio::test]
+    async fn register_memory_tools() {
+        let mut reg = ToolRegistry::new();
+        super::register(&mut reg).expect("register");
+        assert_eq!(reg.definitions().len(), 3);
+    }
+
+    #[tokio::test]
+    async fn mem0_search_stub_responds() {
+        let mut reg = ToolRegistry::new();
+        super::register(&mut reg).expect("register");
+        let input = ToolInput {
+            name: ToolName::new("mem0_search").expect("valid"),
+            tool_use_id: "tu_1".to_owned(),
+            arguments: serde_json::json!({"query": "test"}),
+        };
+        let result = reg.execute(&input, &test_ctx()).await.expect("execute");
+        assert!(!result.is_error);
+        assert!(result.content.contains("stub"), "expected stub response: {}", result.content);
+    }
+
+    #[tokio::test]
+    async fn note_stub_responds() {
+        let mut reg = ToolRegistry::new();
+        super::register(&mut reg).expect("register");
+        let input = ToolInput {
+            name: ToolName::new("note").expect("valid"),
+            tool_use_id: "tu_2".to_owned(),
+            arguments: serde_json::json!({"action": "add", "content": "test"}),
+        };
+        let result = reg.execute(&input, &test_ctx()).await.expect("execute");
+        assert!(!result.is_error);
+    }
+
+    #[tokio::test]
+    async fn blackboard_stub_responds() {
+        let mut reg = ToolRegistry::new();
+        super::register(&mut reg).expect("register");
+        let input = ToolInput {
+            name: ToolName::new("blackboard").expect("valid"),
+            tool_use_id: "tu_3".to_owned(),
+            arguments: serde_json::json!({"action": "read", "key": "test"}),
+        };
+        let result = reg.execute(&input, &test_ctx()).await.expect("execute");
+        assert!(!result.is_error);
+    }
+
+    #[tokio::test]
+    async fn mem0_search_def_requires_query() {
+        let mut reg = ToolRegistry::new();
+        super::register(&mut reg).expect("register");
+        let name = ToolName::new("mem0_search").expect("valid");
+        let def = reg.get_def(&name).expect("found");
+        assert!(def.input_schema.required.contains(&"query".to_owned()));
+    }
+}

--- a/crates/pylon/src/tests.rs
+++ b/crates/pylon/src/tests.rs
@@ -841,3 +841,101 @@ async fn nous_list_from_manager() {
     assert_eq!(agents[0]["model"], "mock-model");
     assert_eq!(agents[0]["status"], "active");
 }
+
+#[tokio::test]
+async fn empty_json_body_send_message_returns_400() {
+    let (router, _dir) = app().await;
+    let created = create_test_session(&router).await;
+    let id = created["id"].as_str().expect("session id");
+
+    let req = authed_request(
+        "POST",
+        &format!("/api/sessions/{id}/messages"),
+        Some(serde_json::json!({})),
+    );
+
+    let resp = router.clone().oneshot(req).await.expect("response");
+    assert!(
+        resp.status() == StatusCode::BAD_REQUEST
+            || resp.status() == StatusCode::UNPROCESSABLE_ENTITY,
+        "expected 400 or 422, got {}",
+        resp.status()
+    );
+}
+
+#[tokio::test]
+async fn double_close_session_is_idempotent() {
+    let (router, _dir) = app().await;
+    let created = create_test_session(&router).await;
+    let id = created["id"].as_str().expect("session id");
+
+    let first = router
+        .clone()
+        .oneshot(authed_delete(&format!("/api/sessions/{id}")))
+        .await
+        .expect("first close");
+    assert_eq!(first.status(), StatusCode::NO_CONTENT);
+
+    let second = router
+        .clone()
+        .oneshot(authed_delete(&format!("/api/sessions/{id}")))
+        .await
+        .expect("second close");
+    assert_eq!(second.status(), StatusCode::NO_CONTENT);
+
+    // Session should still be accessible as archived after both closes
+    let resp = router
+        .clone()
+        .oneshot(authed_get(&format!("/api/sessions/{id}")))
+        .await
+        .expect("get after double close");
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = body_json(resp).await;
+    assert_eq!(body["status"], "archived");
+}
+
+#[tokio::test]
+async fn get_session_after_create_reflects_state() {
+    let (router, _dir) = app().await;
+    let created = create_test_session(&router).await;
+    let id = created["id"].as_str().expect("session id");
+
+    let resp = router
+        .clone()
+        .oneshot(authed_get(&format!("/api/sessions/{id}")))
+        .await
+        .expect("response");
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = body_json(resp).await;
+    assert_eq!(body["id"], id);
+    assert_eq!(body["status"], "active");
+    assert_eq!(body["nous_id"], "syn");
+}
+
+#[tokio::test]
+async fn unknown_route_returns_404() {
+    let (app, _dir) = app().await;
+    let resp = app
+        .oneshot(authed_get("/api/nonexistent"))
+        .await
+        .expect("response");
+
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn missing_auth_header_returns_401() {
+    let (app, _dir) = app().await;
+    let req = json_request(
+        "POST",
+        "/api/sessions",
+        Some(serde_json::json!({
+            "nous_id": "syn",
+            "session_key": "no-auth-test"
+        })),
+    );
+
+    let resp = app.oneshot(req).await.expect("response");
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Baseline: TBD% line coverage (run and record after initial setup)
+#
+# Generates HTML + LCOV coverage reports for the Aletheia Rust workspace.
+# Excludes vendored mneme-engine and benchmark crate from metrics.
+#
+# Prerequisites: cargo install cargo-llvm-cov
+set -euo pipefail
+
+cargo llvm-cov \
+    --workspace \
+    --exclude aletheia-mneme-engine \
+    --exclude aletheia-mneme-bench \
+    --html \
+    --output-dir target/coverage \
+    "$@"
+
+cargo llvm-cov \
+    --workspace \
+    --exclude aletheia-mneme-engine \
+    --exclude aletheia-mneme-bench \
+    --lcov \
+    --output-path target/coverage/lcov.info \
+    "$@"
+
+echo "HTML report: target/coverage/index.html"
+echo "LCOV:        target/coverage/lcov.info"


### PR DESCRIPTION
## Summary
- Add `scripts/coverage.sh` (cargo-llvm-cov) and `.github/workflows/rust.yml` (Rust CI: test + clippy)
- 10 wiremock failure injection tests for `hermeneus/client.rs` (previously zero tests on 315 LOC)
- 3 additional streaming edge case tests for `hermeneus/stream.rs`
- 10 stub registration/execution tests for `organon/builtins/{memory,communication}.rs`
- 5 failure injection tests for `nous/execute.rs` (tool errors, max iterations, signal classification)
- 5 HTTP edge case tests for `pylon/tests.rs`
- 8 proptest property tests for `mneme-engine` DataValue memcmp encoding roundtrips
- `proptest = "1"` added as workspace dev-dependency

## Test plan
- [x] `cargo test -p aletheia-hermeneus` — 48 passed
- [x] `cargo test -p aletheia-organon` — 36 passed
- [x] `cargo test -p aletheia-nous` — 121 passed
- [x] `cargo test -p aletheia-pylon` — 38 passed
- [x] `cargo test -p aletheia-mneme-engine` — 181 passed
- [x] `cargo clippy` on all modified crates — zero warnings
- [x] No `unwrap()` in new test code

🤖 Generated with [Claude Code](https://claude.com/claude-code)