### PR TITLE
feat: add pathGuard config to disable filesystem containment

### DIFF
--- a/infrastructure/runtime/src/nous/pipeline/stages/resolve.ts
+++ b/infrastructure/runtime/src/nous/pipeline/stages/resolve.ts
@@ -83,12 +83,14 @@ export function resolveStage(
   const globalRoots = services.config.agents.defaults.allowedRoots ?? [];
   const agentRoots = nous.allowedRoots ?? [];
   const allowedRoots = [...new Set([paths.root, ...globalRoots, ...agentRoots])];
+  const pathGuard = services.config.agents.defaults.pathGuard ?? true;
 
   const toolContext: ToolContext = {
     nousId,
     sessionId: session.id,
     workspace,
     allowedRoots,
+    pathGuard,
     depth: msg.depth ?? 0,
     ...(abortSignal ? { signal: abortSignal } : {}),
     sandboxConfig: services.config.sandbox,

--- a/infrastructure/runtime/src/organon/built-in/path-guard.ts
+++ b/infrastructure/runtime/src/organon/built-in/path-guard.ts
@@ -4,10 +4,14 @@ import type { ToolContext } from "../registry.js";
 
 /**
  * Resolve a file path and verify it falls within the workspace or allowedRoots.
- * Throws if the resolved path escapes containment.
+ * When pathGuard is false, resolves only — no containment check.
  */
 export function guardPath(filePath: string, context: ToolContext): string {
   const resolved = normalize(resolve(context.workspace, filePath));
+
+  // When guard is disabled, just resolve the path
+  if (context.pathGuard === false) return resolved;
+
   const workspace = normalize(context.workspace);
   const roots = [workspace, ...(context.allowedRoots ?? [])].map(normalize);
 

--- a/infrastructure/runtime/src/organon/registry.ts
+++ b/infrastructure/runtime/src/organon/registry.ts
@@ -37,6 +37,7 @@ export interface ToolContext {
   sessionId: string;
   workspace: string;
   allowedRoots?: string[];
+  pathGuard?: boolean;
   depth?: number;
   signal?: AbortSignal;
   sandboxConfig?: import("../taxis/schema.js").SandboxSettings;

--- a/infrastructure/runtime/src/taxis/schema.ts
+++ b/infrastructure/runtime/src/taxis/schema.ts
@@ -138,6 +138,7 @@ const AgentDefaults = z.preprocess(
     // Additional filesystem roots the agent may read/write outside its workspace.
     // Each entry is an absolute path. The ALETHEIA_ROOT is always allowed.
     allowedRoots: z.array(z.string()).default([]),
+    pathGuard: z.boolean().default(true),
     model: z
       .object({
         primary: z.string().default("claude-opus-4-6"),


### PR DESCRIPTION
## What

Adds `agents.defaults.pathGuard` config option (boolean, default: `true`). When `false`, the `read`, `write`, and `edit` tools resolve paths normally but skip the containment check against `allowedRoots`.

## Why

Self-hosted single-operator systems don't need filesystem sandboxing. Agents need to read dev clones, config files, system paths, and other directories that aren't under their workspace root. The current guard blocks legitimate access and forces workarounds via `exec cat`.

## Changes

- `path-guard.ts`: Short-circuit when `context.pathGuard === false`
- `registry.ts`: Add `pathGuard?: boolean` to `ToolContext`
- `schema.ts`: Add `pathGuard: z.boolean().default(true)` to `AgentDefaults`
- `resolve.ts`: Thread `pathGuard` from config into `ToolContext`

## Config

```json
{
  "agents": {
    "defaults": {
      "pathGuard": false
    }
  }
}
```

Default is `true` — no behavior change for existing installs.

## Testing

- `tsc --noEmit` clean
- All 18 relevant tests pass (resolve, memory-correct, memory-forget)