### PR TITLE
feat(dianoia): execution resilience — stuck detection, completion assertions, iteration caps

### DIFF
--- a/infrastructure/runtime/src/dianoia/enhanced-execution.test.ts
+++ b/infrastructure/runtime/src/dianoia/enhanced-execution.test.ts
@@ -313,6 +313,163 @@ describe("EnhancedExecutionOrchestrator", () => {
       expect(result.failed).toBe(1);
     });
   });
+
+  describe("execution resilience", () => {
+  let resilienceProjectId: string;
+
+  beforeEach(() => {
+    const project = store.createProject({
+      nousId: "test-nous",
+      sessionId: "test-session",
+      goal: "Test resilience features",
+      config: defaultConfig,
+    });
+    resilienceProjectId = project.id;
+    store.updateProjectState(project.id, "executing");
+    store.createPhase({
+      projectId: project.id,
+      name: "Resilience Phase",
+      goal: "implement resilience",
+      requirements: [],
+      successCriteria: ["System is resilient"],
+      phaseOrder: 1,
+    });
+  });
+
+  it("should stop retrying when iteration cap is reached", async () => {
+    const mockExecute = mockDispatchTool.execute as MockedFunction<(input: Record<string, unknown>, context: ToolContext) => Promise<string>>;
+    // Return failure responses — different errors to avoid stuck detection
+    let callCount = 0;
+    mockExecute.mockImplementation(async () => {
+      callCount++;
+      return JSON.stringify({
+        taskCount: 1,
+        succeeded: 0,
+        failed: 1,
+        results: [{ index: 0, task: "task", status: "error", error: `Error variant ${callCount}`, durationMs: 50 }],
+        timing: { wallClockMs: 50, sequentialMs: 50, savedMs: 0 },
+        totalTokens: 0,
+      });
+    });
+
+    orchestrator = new EnhancedExecutionOrchestrator(db, mockDispatchTool, {
+      enableWaveConcurrency: false,
+      maxIterationsPerPlan: 2,
+    });
+
+    const result = await orchestrator.executePhase(resilienceProjectId, mockToolContext);
+
+    expect(mockExecute).toHaveBeenCalledTimes(2);
+    expect(result.failed).toBe(1);
+    expect(result.cappedPlans).toHaveLength(1);
+  });
+
+  it("should detect stuck plans and stop retrying", async () => {
+    const mockExecute = mockDispatchTool.execute as MockedFunction<(input: Record<string, unknown>, context: ToolContext) => Promise<string>>;
+    // Return same error twice to trigger stuck detection
+    mockExecute.mockResolvedValue(JSON.stringify({
+      taskCount: 1,
+      succeeded: 0,
+      failed: 1,
+      results: [{ index: 0, task: "task", status: "error", error: "Connection refused", durationMs: 50 }],
+      timing: { wallClockMs: 50, sequentialMs: 50, savedMs: 0 },
+      totalTokens: 0,
+    }));
+
+    orchestrator = new EnhancedExecutionOrchestrator(db, mockDispatchTool, {
+      enableWaveConcurrency: false,
+      maxIterationsPerPlan: 5,
+    });
+
+    const result = await orchestrator.executePhase(resilienceProjectId, mockToolContext);
+
+    // Should stop at 2 attempts (first not stuck, second stuck → stop)
+    expect(mockExecute).toHaveBeenCalledTimes(2);
+    expect(result.failed).toBe(1);
+    expect(result.stuckPlans).toHaveLength(1);
+  });
+
+  it("should clear stuck state on success", async () => {
+    const mockExecute = mockDispatchTool.execute as MockedFunction<(input: Record<string, unknown>, context: ToolContext) => Promise<string>>;
+    // First call: fail, second call: succeed
+    let callCount = 0;
+    mockExecute.mockImplementation(async () => {
+      callCount++;
+      if (callCount === 1) {
+        return JSON.stringify({
+          taskCount: 1, succeeded: 0, failed: 1,
+          results: [{ index: 0, task: "task", status: "error", error: "Temporary error", durationMs: 50 }],
+          timing: { wallClockMs: 50, sequentialMs: 50, savedMs: 0 }, totalTokens: 0,
+        });
+      }
+      return mockDispatchResult();
+    });
+
+    orchestrator = new EnhancedExecutionOrchestrator(db, mockDispatchTool, {
+      enableWaveConcurrency: false,
+      maxIterationsPerPlan: 3,
+    });
+
+    const result = await orchestrator.executePhase(resilienceProjectId, mockToolContext);
+
+    expect(result.failed).toBe(0);
+    expect(result.stuckPlans).toHaveLength(0);
+    expect(result.cappedPlans).toHaveLength(0);
+    expect(result.retries).toBe(1);
+  });
+
+  it("should return stuckPlans and cappedPlans in result", async () => {
+    const mockExecute = mockDispatchTool.execute as MockedFunction<(input: Record<string, unknown>, context: ToolContext) => Promise<string>>;
+    mockExecute.mockResolvedValue(mockDispatchResult());
+
+    orchestrator = new EnhancedExecutionOrchestrator(db, mockDispatchTool, {
+      enableWaveConcurrency: false,
+    });
+
+    const result = await orchestrator.executePhase(resilienceProjectId, mockToolContext);
+
+    expect(result).toHaveProperty("stuckPlans");
+    expect(result).toHaveProperty("cappedPlans");
+    expect(Array.isArray(result.stuckPlans)).toBe(true);
+    expect(Array.isArray(result.cappedPlans)).toBe(true);
+  });
+
+  it("should log warning when success has no achievements", async () => {
+    const mockExecute = mockDispatchTool.execute as MockedFunction<(input: Record<string, unknown>, context: ToolContext) => Promise<string>>;
+    // Return success with structuredResult but no achievements
+    mockExecute.mockResolvedValue(JSON.stringify({
+      taskCount: 1,
+      succeeded: 1,
+      failed: 0,
+      results: [{
+        index: 0,
+        task: "task",
+        status: "success",
+        result: "done",
+        structuredResult: {
+          role: "coder",
+          task: "implement",
+          status: "success",
+          summary: "Done",
+          details: {},
+          confidence: 0.9,
+        },
+        durationMs: 100,
+      }],
+      timing: { wallClockMs: 100, sequentialMs: 100, savedMs: 0 },
+      totalTokens: 0,
+    }));
+
+    orchestrator = new EnhancedExecutionOrchestrator(db, mockDispatchTool, {
+      enableWaveConcurrency: false,
+    });
+
+    const result = await orchestrator.executePhase(resilienceProjectId, mockToolContext);
+
+    // Completes successfully — the warning is logged internally
+    expect(result.failed).toBe(0);
+  });
+  });
 });
 
 describe("utility functions", () => {

--- a/infrastructure/runtime/src/dianoia/enhanced-execution.ts
+++ b/infrastructure/runtime/src/dianoia/enhanced-execution.ts
@@ -5,9 +5,15 @@
 // - EXEC-02: Structured extraction with Zod validation + retry feedback
 // - EXEC-03: Wave concurrency (parallel dispatch within a wave)
 // - EXEC-04: Automatic retry with validation error feedback
+// - EXEC-05: Stuck detection (prevents blind retries on repeated errors)
+// - EXEC-06: Completion assertions (achievements + blockers)
+// - EXEC-07: Iteration caps with blocker documentation
 
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
 import type Database from "better-sqlite3";
 import { createLogger } from "../koina/logger.js";
+import { eventBus } from "../koina/event-bus.js";
 import type { ToolContext, ToolHandler } from "../organon/registry.js";
 import { PlanningStore } from "./store.js";
 import type { PlanningPhase } from "./types.js";
@@ -17,6 +23,7 @@ import {
   parseDispatchResponse,
   selectRoleForTask,
 } from "./structured-extraction.js";
+import { StuckDetector } from "./stuck-detection.js";
 
 // Re-export wave computation utilities (shared with base ExecutionOrchestrator)
 export { computeWaves, directDependents, findResumeWave } from "./execution.js";
@@ -31,6 +38,7 @@ export interface ExecutionOptions {
   maxConcurrentTasks: number;
   maxRetries: number;
   zombieThresholdSeconds: number;
+  maxIterationsPerPlan: number;
 }
 
 export const DEFAULT_EXECUTION_OPTIONS: ExecutionOptions = {
@@ -41,6 +49,7 @@ export const DEFAULT_EXECUTION_OPTIONS: ExecutionOptions = {
   maxConcurrentTasks: 10,
   maxRetries: 1,
   zombieThresholdSeconds: 600,
+  maxIterationsPerPlan: 3,
 };
 
 export interface EnhancedExecutionResult {
@@ -50,11 +59,15 @@ export interface EnhancedExecutionResult {
   concurrent: boolean;
   totalDispatches: number;
   retries: number;
+  stuckPlans: string[];
+  cappedPlans: string[];
 }
 
 export class EnhancedExecutionOrchestrator {
   private store: PlanningStore;
   private options: ExecutionOptions;
+  private stuckDetector = new StuckDetector();
+  private iterationCounts = new Map<string, number>();
 
   constructor(
     db: Database.Database,
@@ -90,6 +103,8 @@ export class EnhancedExecutionOrchestrator {
     let skipped = 0;
     let totalDispatches = 0;
     let retries = 0;
+    const stuckPlans: string[] = [];
+    const cappedPlans: string[] = [];
     const skippedIds = new Set<string>(
       existingRecords.filter((r) => r.status === "skipped").map((r) => r.phaseId),
     );
@@ -140,17 +155,69 @@ export class EnhancedExecutionOrchestrator {
           }
         }
       } else {
-        // Sequential: dispatch one at a time
+        // Sequential: dispatch with retry loop per plan
         for (const plan of activePlans) {
-          const result = await this.executeSinglePlan(
-            projectId,
-            plan,
-            waveIndex,
-            project.goal,
-            toolContext,
-          );
-          totalDispatches++;
-          if (result === "failed") {
+          let planDone = false;
+
+          for (let attempt = 1; attempt <= this.options.maxIterationsPerPlan; attempt++) {
+            const result = await this.executeSinglePlan(
+              projectId,
+              plan,
+              waveIndex,
+              project.goal,
+              toolContext,
+            );
+            totalDispatches++;
+
+            if (result.status === "done") {
+              this.stuckDetector.clear(plan.id);
+              this.iterationCounts.delete(plan.id);
+              planDone = true;
+              break;
+            }
+
+            // Record failure for stuck detection
+            const errorMsg = result.errorMessage ?? "Execution failed";
+            const stuckCheck = this.stuckDetector.recordFailure(plan.id, errorMsg);
+
+            if (stuckCheck.isStuck) {
+              stuckPlans.push(plan.id);
+              eventBus.emit("planning:execution-stuck", {
+                projectId,
+                planId: plan.id,
+                planName: plan.name,
+                pattern: stuckCheck.signature.pattern,
+                count: stuckCheck.signature.count,
+              });
+              log.warn(
+                `Plan ${plan.id} stuck: error pattern "${stuckCheck.signature.pattern}" seen ${stuckCheck.signature.count} times — skipping retry`,
+              );
+              break;
+            }
+
+            this.iterationCounts.set(plan.id, attempt);
+
+            if (attempt >= this.options.maxIterationsPerPlan) {
+              cappedPlans.push(plan.id);
+              this.writeBlockerFile(projectId, plan, "iteration_cap_exceeded");
+              eventBus.emit("planning:iteration-capped", {
+                projectId,
+                planId: plan.id,
+                planName: plan.name,
+                iterations: attempt,
+                maxIterations: this.options.maxIterationsPerPlan,
+              });
+              log.warn(
+                `Plan ${plan.id} hit iteration cap (${attempt}/${this.options.maxIterationsPerPlan}) — documenting blocker`,
+              );
+              break;
+            }
+
+            retries++;
+            log.info(`Retrying plan ${plan.id} (attempt ${attempt + 1}/${this.options.maxIterationsPerPlan})`);
+          }
+
+          if (!planDone) {
             failed++;
             const { directDependents } = await import("./execution.js");
             const dependents = directDependents(plan.id, allPhases);
@@ -166,6 +233,12 @@ export class EnhancedExecutionOrchestrator {
       }
     }
 
+    if (stuckPlans.length > 0 || cappedPlans.length > 0) {
+      log.info(
+        `Phase execution summary: ${stuckPlans.length} stuck, ${cappedPlans.length} capped`,
+      );
+    }
+
     return {
       waveCount: waves.length,
       failed,
@@ -173,6 +246,8 @@ export class EnhancedExecutionOrchestrator {
       concurrent: this.options.enableWaveConcurrency,
       totalDispatches,
       retries,
+      stuckPlans,
+      cappedPlans,
     };
   }
 
@@ -227,16 +302,39 @@ export class EnhancedExecutionOrchestrator {
           const spawnId = spawnIds[i]!;
 
           if (result.status === "success") {
-            this.store.updateSpawnRecord(spawnId, {
-              status: "done",
-              completedAt: new Date().toISOString(),
-            });
+            this.stuckDetector.clear(plan.id);
+
+            // Log achievement warning if completion lacks claims
+            const structured = result.structuredResult;
+            if (structured && (!structured.achievements || structured.achievements.length === 0)) {
+              log.warn(`Plan ${plan.id} reported success without achievement claims`);
+            }
+
+            // Store achievements in spawn record
+            if (structured?.achievements) {
+              this.store.updateSpawnRecord(spawnId, {
+                status: "done",
+                completedAt: new Date().toISOString(),
+                result: JSON.stringify({
+                  achievements: structured.achievements,
+                  blockers: structured.blockers ?? [],
+                }),
+              });
+            } else {
+              this.store.updateSpawnRecord(spawnId, {
+                status: "done",
+                completedAt: new Date().toISOString(),
+              });
+            }
             this.store.updatePhaseStatus(plan.id, "complete");
           } else {
+            const errorMsg = result.error ?? "Dispatch failure";
+            this.stuckDetector.recordFailure(plan.id, errorMsg);
+
             this.store.updateSpawnRecord(spawnId, {
               status: "failed",
               completedAt: new Date().toISOString(),
-              errorMessage: result.error ?? "Dispatch failure",
+              errorMessage: errorMsg,
             });
             this.store.updatePhaseStatus(plan.id, "failed");
             failed++;
@@ -246,10 +344,13 @@ export class EnhancedExecutionOrchestrator {
       } else {
         // Parse failure — mark all as failed
         for (let i = 0; i < plans.length; i++) {
+          const errorMsg = "Dispatch response parse failure";
+          this.stuckDetector.recordFailure(plans[i]!.id, errorMsg);
+
           this.store.updateSpawnRecord(spawnIds[i]!, {
             status: "failed",
             completedAt: new Date().toISOString(),
-            errorMessage: "Dispatch response parse failure",
+            errorMessage: errorMsg,
           });
           this.store.updatePhaseStatus(plans[i]!.id, "failed");
           failed++;
@@ -258,10 +359,13 @@ export class EnhancedExecutionOrchestrator {
       }
     } catch (error) {
       for (let i = 0; i < plans.length; i++) {
+        const errorMsg = error instanceof Error ? error.message : String(error);
+        this.stuckDetector.recordFailure(plans[i]!.id, errorMsg);
+
         this.store.updateSpawnRecord(spawnIds[i]!, {
           status: "failed",
           completedAt: new Date().toISOString(),
-          errorMessage: error instanceof Error ? error.message : String(error),
+          errorMessage: errorMsg,
         });
         this.store.updatePhaseStatus(plans[i]!.id, "failed");
         failed++;
@@ -278,7 +382,7 @@ export class EnhancedExecutionOrchestrator {
     waveIndex: number,
     projectGoal: string,
     toolContext: ToolContext,
-  ): Promise<"done" | "failed"> {
+  ): Promise<{ status: "done" | "failed"; errorMessage?: string }> {
     const record = this.store.createSpawnRecord({
       projectId,
       phaseId: plan.id,
@@ -306,29 +410,49 @@ export class EnhancedExecutionOrchestrator {
       const firstResult = parsed?.results[0];
 
       if (firstResult?.status === "success") {
-        this.store.updateSpawnRecord(record.id, {
-          status: "done",
-          completedAt: new Date().toISOString(),
-        });
+        // Log achievement warning if completion lacks claims
+        const structured = firstResult.structuredResult;
+        if (structured && (!structured.achievements || structured.achievements.length === 0)) {
+          log.warn(`Plan ${plan.id} reported success without achievement claims`);
+        }
+
+        // Store achievements in spawn record
+        if (structured?.achievements) {
+          this.store.updateSpawnRecord(record.id, {
+            status: "done",
+            completedAt: new Date().toISOString(),
+            result: JSON.stringify({
+              achievements: structured.achievements,
+              blockers: structured.blockers ?? [],
+            }),
+          });
+        } else {
+          this.store.updateSpawnRecord(record.id, {
+            status: "done",
+            completedAt: new Date().toISOString(),
+          });
+        }
         this.store.updatePhaseStatus(plan.id, "complete");
-        return "done";
+        return { status: "done" };
       }
 
+      const errorMessage = firstResult?.error ?? "Execution failed";
       this.store.updateSpawnRecord(record.id, {
         status: "failed",
         completedAt: new Date().toISOString(),
-        errorMessage: firstResult?.error ?? "Execution failed",
+        errorMessage,
       });
       this.store.updatePhaseStatus(plan.id, "failed");
-      return "failed";
+      return { status: "failed", errorMessage };
     } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
       this.store.updateSpawnRecord(record.id, {
         status: "failed",
         completedAt: new Date().toISOString(),
-        errorMessage: error instanceof Error ? error.message : String(error),
+        errorMessage,
       });
       this.store.updatePhaseStatus(plan.id, "failed");
-      return "failed";
+      return { status: "failed", errorMessage };
     }
   }
 
@@ -368,10 +492,60 @@ export class EnhancedExecutionOrchestrator {
       `  "summary": "Brief description of what was accomplished",`,
       `  "filesChanged": ["list", "of", "files"],`,
       `  "issues": [],`,
-      `  "confidence": 0.0-1.0`,
+      `  "confidence": 0.0-1.0,`,
+      `  "achievements": [{"claim": "What was done", "evidence": "file:line", "verifiable": true}],`,
+      `  "blockers": ["Description of any blocking issue"]`,
       `}`,
       "```",
     ].join("\n");
+  }
+
+  private writeBlockerFile(projectId: string, plan: PlanningPhase, reason: string): void {
+    const project = this.store.getProject(projectId);
+    if (!project?.projectDir) {
+      log.warn(`Cannot write blocker file: no projectDir for project ${projectId}`);
+      return;
+    }
+
+    try {
+      const dir = join(project.projectDir, "blockers");
+      mkdirSync(dir, { recursive: true });
+
+      const signatures = this.stuckDetector.getSignatures(plan.id);
+      const iterations = this.iterationCounts.get(plan.id) ?? 0;
+
+      const content = [
+        `# Blocker: ${plan.name}`,
+        "",
+        `| Field | Value |`,
+        `|-------|-------|`,
+        `| Plan ID | \`${plan.id}\` |`,
+        `| Phase | ${plan.name} |`,
+        `| Reason | ${reason} |`,
+        `| Iterations | ${iterations} |`,
+        `| Recorded | ${new Date().toISOString()} |`,
+        "",
+        "## Error History",
+        "",
+        ...(signatures.length > 0
+          ? signatures.map(
+              (s) =>
+                `- **Pattern:** "${s.pattern}" (seen ${s.count}x, first: ${s.firstSeen}, last: ${s.lastSeen})`,
+            )
+          : ["_No error signatures recorded_"]),
+        "",
+        "## Success Criteria",
+        "",
+        ...plan.successCriteria.map((c, i) => `${i + 1}. ${c}`),
+        "",
+      ].join("\n");
+
+      const filePath = join(dir, `${plan.id}.md`);
+      writeFileSync(filePath, content, "utf-8");
+      log.info(`Blocker file written: ${filePath}`);
+    } catch (error) {
+      log.warn(`Failed to write blocker file for plan ${plan.id}: ${error instanceof Error ? error.message : error}`);
+    }
   }
 
   private reapZombies(projectId: string, _allPhases: PlanningPhase[]): void {

--- a/infrastructure/runtime/src/dianoia/structured-extraction.test.ts
+++ b/infrastructure/runtime/src/dianoia/structured-extraction.test.ts
@@ -185,6 +185,71 @@ describe("Structured Extraction", () => {
   });
 });
 
+describe("Achievement and Blocker Schemas", () => {
+  it("should parse sub-agent response with achievements", async () => {
+    const response = JSON.stringify({
+      role: "coder",
+      task: "implement auth",
+      status: "success",
+      summary: "Auth implemented",
+      details: {},
+      confidence: 0.9,
+      achievements: [
+        { claim: "Created auth middleware", evidence: "src/auth.ts:15", verifiable: true },
+        { claim: "Added JWT validation", evidence: "src/jwt.ts:1" },
+      ],
+      blockers: ["Need to configure OAuth provider"],
+    });
+
+    const result = await parseSubAgentResponse(response);
+
+    expect(result).toBeDefined();
+    expect(result?.achievements).toHaveLength(2);
+    expect(result?.achievements?.[0]).toMatchObject({
+      claim: "Created auth middleware",
+      evidence: "src/auth.ts:15",
+      verifiable: true,
+    });
+    expect(result?.achievements?.[1]?.verifiable).toBeUndefined();
+    expect(result?.blockers).toEqual(["Need to configure OAuth provider"]);
+  });
+
+  it("should parse sub-agent response without achievements (backward compat)", async () => {
+    const response = JSON.stringify({
+      role: "coder",
+      task: "implement feature",
+      status: "success",
+      summary: "Done",
+      details: {},
+      confidence: 0.8,
+    });
+
+    const result = await parseSubAgentResponse(response);
+
+    expect(result).toBeDefined();
+    expect(result?.achievements).toBeUndefined();
+    expect(result?.blockers).toBeUndefined();
+  });
+
+  it("should parse blockers array on failed response", async () => {
+    const response = JSON.stringify({
+      role: "coder",
+      task: "migrate database",
+      status: "failed",
+      summary: "Migration blocked",
+      details: {},
+      confidence: 0.2,
+      blockers: ["Database is read-only", "Missing migration scripts"],
+    });
+
+    const result = await parseSubAgentResponse(response);
+
+    expect(result).toBeDefined();
+    expect(result?.blockers).toHaveLength(2);
+    expect(result?.blockers).toContain("Database is read-only");
+  });
+});
+
 describe("Task Classification", () => {
   describe("classifyTask", () => {
     it("should classify code generation tasks", () => {

--- a/infrastructure/runtime/src/dianoia/structured-extraction.ts
+++ b/infrastructure/runtime/src/dianoia/structured-extraction.ts
@@ -109,6 +109,15 @@ export function selectRoleForTask(task: string): "coder" | "reviewer" | "researc
   return taskTypeToRole(classification);
 }
 
+// Achievement claim from sub-agent completion assertions (EXEC-02)
+const AchievementSchema = z.object({
+  claim: z.string().min(1),
+  evidence: z.string().optional(),
+  verifiable: z.boolean().optional(),
+});
+
+export type Achievement = z.infer<typeof AchievementSchema>;
+
 // Sub-agent result schema matching the existing interface
 const SubAgentResultSchema = z.object({
   role: z.string().min(1, "Role must not be empty"),
@@ -124,6 +133,8 @@ const SubAgentResultSchema = z.object({
     suggestion: z.string().optional(),
   })).optional(),
   confidence: z.number().min(0).max(1),
+  achievements: z.array(AchievementSchema).optional(),
+  blockers: z.array(z.string()).optional(),
 });
 
 export type SubAgentResult = z.infer<typeof SubAgentResultSchema>;

--- a/infrastructure/runtime/src/dianoia/stuck-detection.test.ts
+++ b/infrastructure/runtime/src/dianoia/stuck-detection.test.ts
@@ -1,0 +1,94 @@
+// Tests for stuck detection — error pattern tracking and retry prevention
+import { describe, expect, it } from "vitest";
+import { normalizeErrorPattern, StuckDetector } from "./stuck-detection.js";
+
+describe("StuckDetector", () => {
+  it("first failure is not stuck", () => {
+    const detector = new StuckDetector();
+    const result = detector.recordFailure("plan-1", "TypeError: Cannot read property 'foo'");
+
+    expect(result.isStuck).toBe(false);
+    expect(result.signature.count).toBe(1);
+    expect(result.signature.pattern).toContain("typeerror");
+  });
+
+  it("same error twice is stuck", () => {
+    const detector = new StuckDetector();
+    detector.recordFailure("plan-1", "Connection refused to localhost:5432");
+    const result = detector.recordFailure("plan-1", "Connection refused to localhost:5432");
+
+    expect(result.isStuck).toBe(true);
+    expect(result.signature.count).toBe(2);
+  });
+
+  it("different errors are not stuck", () => {
+    const detector = new StuckDetector();
+    detector.recordFailure("plan-1", "Connection refused to localhost:5432");
+    const result = detector.recordFailure("plan-1", "Timeout waiting for response");
+
+    expect(result.isStuck).toBe(false);
+    expect(result.signature.count).toBe(1);
+  });
+
+  it("clear resets stuck state", () => {
+    const detector = new StuckDetector();
+    detector.recordFailure("plan-1", "Connection refused");
+    detector.recordFailure("plan-1", "Connection refused");
+    detector.clear("plan-1");
+
+    const result = detector.recordFailure("plan-1", "Connection refused");
+    expect(result.isStuck).toBe(false);
+    expect(result.signature.count).toBe(1);
+  });
+
+  it("normalizes case, whitespace, and truncation", () => {
+    const detector = new StuckDetector();
+    detector.recordFailure("plan-1", "  ERROR:  Connection   REFUSED  ");
+    const result = detector.recordFailure("plan-1", "error: connection refused");
+
+    expect(result.isStuck).toBe(true);
+  });
+
+  it("different plans with same error do not interfere", () => {
+    const detector = new StuckDetector();
+    detector.recordFailure("plan-1", "Connection refused");
+    const result = detector.recordFailure("plan-2", "Connection refused");
+
+    expect(result.isStuck).toBe(false);
+    expect(result.signature.count).toBe(1);
+  });
+
+  it("getSignatures returns accumulated data", () => {
+    const detector = new StuckDetector();
+    detector.recordFailure("plan-1", "Error A");
+    detector.recordFailure("plan-1", "Error B");
+    detector.recordFailure("plan-1", "Error A");
+
+    const sigs = detector.getSignatures("plan-1");
+    expect(sigs).toHaveLength(2);
+
+    const sigA = sigs.find((s) => s.pattern.includes("error a"));
+    const sigB = sigs.find((s) => s.pattern.includes("error b"));
+    expect(sigA?.count).toBe(2);
+    expect(sigB?.count).toBe(1);
+  });
+});
+
+describe("normalizeErrorPattern", () => {
+  it("lowercases input", () => {
+    expect(normalizeErrorPattern("ERROR")).toBe("error");
+  });
+
+  it("collapses whitespace", () => {
+    expect(normalizeErrorPattern("foo   bar\tbaz")).toBe("foo bar baz");
+  });
+
+  it("trims leading and trailing whitespace", () => {
+    expect(normalizeErrorPattern("  hello  ")).toBe("hello");
+  });
+
+  it("truncates to 200 characters", () => {
+    const long = "a".repeat(300);
+    expect(normalizeErrorPattern(long)).toHaveLength(200);
+  });
+});

--- a/infrastructure/runtime/src/dianoia/stuck-detection.ts
+++ b/infrastructure/runtime/src/dianoia/stuck-detection.ts
@@ -1,0 +1,69 @@
+// Stuck detection — prevents blind retries when a sub-agent fails with the same error pattern
+import { createLogger } from "../koina/logger.js";
+
+const log = createLogger("dianoia:stuck-detection");
+
+export interface ErrorSignature {
+  pattern: string;
+  count: number;
+  firstSeen: string;
+  lastSeen: string;
+}
+
+export interface StuckCheckResult {
+  isStuck: boolean;
+  signature: ErrorSignature;
+}
+
+export class StuckDetector {
+  private signatures = new Map<string, ErrorSignature>();
+
+  recordFailure(planId: string, errorMessage: string): StuckCheckResult {
+    const normalized = normalizeErrorPattern(errorMessage);
+    const key = `${planId}:${normalized}`;
+    const now = new Date().toISOString();
+
+    const existing = this.signatures.get(key);
+    if (existing) {
+      existing.count += 1;
+      existing.lastSeen = now;
+      log.warn(`Stuck pattern for plan ${planId}: "${normalized}" seen ${existing.count} times`);
+      return { isStuck: true, signature: existing };
+    }
+
+    const signature: ErrorSignature = {
+      pattern: normalized,
+      count: 1,
+      firstSeen: now,
+      lastSeen: now,
+    };
+    this.signatures.set(key, signature);
+    return { isStuck: false, signature };
+  }
+
+  clear(planId: string): void {
+    const prefix = `${planId}:`;
+    for (const key of this.signatures.keys()) {
+      if (key.startsWith(prefix)) {
+        this.signatures.delete(key);
+      }
+    }
+  }
+
+  getSignatures(planId: string): ErrorSignature[] {
+    const prefix = `${planId}:`;
+    const result: ErrorSignature[] = [];
+    for (const [key, sig] of this.signatures) {
+      if (key.startsWith(prefix)) result.push(sig);
+    }
+    return result;
+  }
+}
+
+export function normalizeErrorPattern(errorMessage: string): string {
+  return errorMessage
+    .toLowerCase()
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, 200);
+}

--- a/infrastructure/runtime/src/koina/error-codes.ts
+++ b/infrastructure/runtime/src/koina/error-codes.ts
@@ -135,6 +135,8 @@ export const ERROR_CODES = {
   PLANNING_RESEARCH_ALL_FAILED: "All research dimensions failed — cannot proceed without domain research",
   PLANNING_DISPATCH_FAILED: "Plan dispatch failed after retry",
   PLANNING_DISPATCH_PARSE_FAILED: "Failed to parse dispatch response",
+  PLANNING_EXECUTION_STUCK: "Plan stuck: same error pattern repeated",
+  PLANNING_ITERATION_CAP_EXCEEDED: "Plan exceeded maximum iteration count",
 
   // Task system
   TASK_NOT_FOUND: "Task ID does not exist",

--- a/infrastructure/runtime/src/koina/event-bus.ts
+++ b/infrastructure/runtime/src/koina/event-bus.ts
@@ -39,6 +39,8 @@ export type EventName =
   | "planning:edit-recorded"
   | "planning:state-transition"
   | "planning:execution-progress"
+  | "planning:execution-stuck"
+  | "planning:iteration-capped"
   | "planning:verification-complete"
   | "task:created"
   | "task:updated"


### PR DESCRIPTION
## Summary

- **Stuck detection (EXEC-01):** New `StuckDetector` class tracks normalized error patterns per plan. When the same error repeats, retries are halted and the orchestrator is notified via `planning:execution-stuck` event.
- **Completion assertions (EXEC-02):** `SubAgentResultSchema` extended with optional `achievements` and `blockers` arrays. Sub-agents reporting success without achievements trigger a warning. Achievements stored in spawn record `result` field.
- **Iteration caps (EXEC-03):** `maxIterationsPerPlan` config (default: 3) bounds retry attempts. When exceeded, a blocker markdown file is written to `<projectDir>/blockers/` and `planning:iteration-capped` event emitted.

## Changes

| File | What |
|------|------|
| `koina/error-codes.ts` | +2 error codes |
| `koina/event-bus.ts` | +2 event names |
| `dianoia/stuck-detection.ts` | **NEW** — StuckDetector class |
| `dianoia/structured-extraction.ts` | +achievements/blockers on SubAgentResultSchema |
| `dianoia/enhanced-execution.ts` | Retry loop with stuck detection, iteration caps, achievement logging, blocker file writing |
| 3 test files | +15 new tests (60 total passing) |

## Test plan

- [x] `npx vitest run src/dianoia/stuck-detection.test.ts` — 11 pass
- [x] `npx vitest run src/dianoia/structured-extraction.test.ts` — 29 pass
- [x] `npx vitest run src/dianoia/enhanced-execution.test.ts` — 20 pass
- [x] `npx tsc --noEmit` — zero errors