### PR TITLE
fix(mneme): hybrid search correctness bugs (BUG-01..03)

### DIFF
--- a/crates/mneme-engine/src/fixed_rule/utilities/rrf.rs
+++ b/crates/mneme-engine/src/fixed_rule/utilities/rrf.rs
@@ -69,9 +69,9 @@ impl FixedRule for ReciprocalRankFusion {
             out.put(vec![
                 DataValue::Str(id),
                 DataValue::from(rrf_score),
-                DataValue::from(bm25_rank as i64),
-                DataValue::from(vec_rank as i64),
-                DataValue::from(graph_rank as i64),
+                DataValue::from(rank_to_output(bm25_rank)),
+                DataValue::from(rank_to_output(vec_rank)),
+                DataValue::from(rank_to_output(graph_rank)),
             ]);
             poison.check()?;
         }
@@ -113,4 +113,54 @@ fn assign_ranks(
         .enumerate()
         .map(|(rank, (id, _))| ((*id).clone(), rank + 1))
         .collect()
+}
+
+fn rank_to_output(rank: usize) -> i64 {
+    if rank == 0 { -1 } else { rank as i64 }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn signal_contribution_absent_is_zero() {
+        assert_eq!(signal_contribution(0), 0.0);
+    }
+
+    #[test]
+    fn signal_contribution_rank_one() {
+        let expected = 1.0 / (60.0 + 1.0);
+        assert!((signal_contribution(1) - expected).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn assign_ranks_sorted_descending() {
+        let mut scores = FxHashMap::default();
+        scores.insert(SmartString::from("low"), 1.0);
+        scores.insert(SmartString::from("high"), 9.0);
+        scores.insert(SmartString::from("mid"), 5.0);
+
+        let ranks = assign_ranks(&scores);
+        assert_eq!(ranks[&SmartString::from("high")], 1);
+        assert_eq!(ranks[&SmartString::from("mid")], 2);
+        assert_eq!(ranks[&SmartString::from("low")], 3);
+    }
+
+    #[test]
+    fn assign_ranks_empty() {
+        let scores = FxHashMap::default();
+        let ranks = assign_ranks(&scores);
+        assert!(ranks.is_empty());
+    }
+
+    #[test]
+    fn rank_to_output_absent() {
+        assert_eq!(rank_to_output(0), -1);
+    }
+
+    #[test]
+    fn rank_to_output_present() {
+        assert_eq!(rank_to_output(5), 5);
+    }
 }

--- a/crates/mneme/src/knowledge_store.rs
+++ b/crates/mneme/src/knowledge_store.rs
@@ -1084,24 +1084,24 @@ fn rows_to_hybrid_results(
             }
             .build()
         })?)?;
-        let bm25_rank = remap_absent_rank(extract_int(row.get(2).ok_or_else(|| {
+        let bm25_rank = extract_int(row.get(2).ok_or_else(|| {
             crate::error::ConversionSnafu {
                 message: "hybrid row: missing bm25_rank",
             }
             .build()
-        })?)?);
-        let vec_rank = remap_absent_rank(extract_int(row.get(3).ok_or_else(|| {
+        })?)?;
+        let vec_rank = extract_int(row.get(3).ok_or_else(|| {
             crate::error::ConversionSnafu {
                 message: "hybrid row: missing vec_rank",
             }
             .build()
-        })?)?);
-        let graph_rank = remap_absent_rank(extract_int(row.get(4).ok_or_else(|| {
+        })?)?;
+        let graph_rank = extract_int(row.get(4).ok_or_else(|| {
             crate::error::ConversionSnafu {
                 message: "hybrid row: missing graph_rank",
             }
             .build()
-        })?)?);
+        })?)?;
         out.push(HybridResult {
             id,
             rrf_score,
@@ -1118,12 +1118,6 @@ fn rows_to_hybrid_results(
             .unwrap_or(std::cmp::Ordering::Equal)
     });
     Ok(out)
-}
-
-// RRF engine uses 0 for absent signals (1-based ranking); remap to -1 for API clarity.
-#[cfg(feature = "mneme-engine")]
-fn remap_absent_rank(rank: i64) -> i64 {
-    if rank == 0 { -1 } else { rank }
 }
 
 // --- DataValue extraction utilities ---
@@ -1383,7 +1377,8 @@ mod tests {
         let store =
             KnowledgeStore::open_mem_with_config(KnowledgeConfig { dim }).expect("open_mem");
 
-        let fact = Fact {
+        // f1: reachable from 3 seed entities
+        let f1 = Fact {
             id: "f1".to_owned(),
             nous_id: "test".to_owned(),
             content: "Rust systems programming".to_owned(),
@@ -1395,21 +1390,47 @@ mod tests {
             source_session_id: None,
             recorded_at: "2026-03-01T00:00:00Z".to_owned(),
         };
-        store.insert_fact(&fact).expect("insert fact");
+        store.insert_fact(&f1).expect("insert f1");
+        store
+            .insert_embedding(&EmbeddedChunk {
+                id: "f1".to_owned(),
+                content: "Rust systems programming".to_owned(),
+                source_type: "fact".to_owned(),
+                source_id: "f1".to_owned(),
+                nous_id: "test".to_owned(),
+                embedding: vec![0.9, 0.1, 0.1, 0.1],
+                created_at: "2026-03-01T00:00:00Z".to_owned(),
+            })
+            .expect("insert f1 embedding");
 
-        let chunk = EmbeddedChunk {
-            id: "f1".to_owned(),
-            content: "Rust systems programming".to_owned(),
-            source_type: "fact".to_owned(),
-            source_id: "f1".to_owned(),
+        // f2: reachable from only 1 seed entity
+        let f2 = Fact {
+            id: "f2".to_owned(),
             nous_id: "test".to_owned(),
-            embedding: vec![0.9, 0.1, 0.1, 0.1],
-            created_at: "2026-03-01T00:00:00Z".to_owned(),
+            content: "Rust memory safety".to_owned(),
+            confidence: 0.9,
+            tier: EpistemicTier::Inferred,
+            valid_from: "2026-01-01".to_owned(),
+            valid_to: "9999-12-31".to_owned(),
+            superseded_by: None,
+            source_session_id: None,
+            recorded_at: "2026-03-01T00:00:00Z".to_owned(),
         };
-        store.insert_embedding(&chunk).expect("insert embedding");
+        store.insert_fact(&f2).expect("insert f2");
+        store
+            .insert_embedding(&EmbeddedChunk {
+                id: "f2".to_owned(),
+                content: "Rust memory safety".to_owned(),
+                source_type: "fact".to_owned(),
+                source_id: "f2".to_owned(),
+                nous_id: "test".to_owned(),
+                embedding: vec![0.8, 0.2, 0.1, 0.1],
+                created_at: "2026-03-01T00:00:00Z".to_owned(),
+            })
+            .expect("insert f2 embedding");
 
-        // Two seed entities, both connected to f1
-        for (id, name) in [("s1", "Seed1"), ("s2", "Seed2")] {
+        // Three seed entities: all point to f1, only s1 points to f2
+        for (id, name) in [("s1", "Seed1"), ("s2", "Seed2"), ("s3", "Seed3")] {
             store
                 .insert_entity(&Entity {
                     id: id.to_owned(),
@@ -1428,20 +1449,29 @@ mod tests {
                     weight: 0.7,
                     created_at: "2026-03-01T00:00:00Z".to_owned(),
                 })
-                .expect("insert relationship");
+                .expect("insert relationship to f1");
         }
+        store
+            .insert_relationship(&Relationship {
+                src: "s1".to_owned(),
+                dst: "f2".to_owned(),
+                relation: "describes".to_owned(),
+                weight: 0.7,
+                created_at: "2026-03-01T00:00:00Z".to_owned(),
+            })
+            .expect("insert relationship to f2");
 
         let results = store
             .search_hybrid(&HybridQuery {
                 text: "Rust programming".to_owned(),
                 embedding: vec![0.9, 0.1, 0.1, 0.1],
-                seed_entities: vec!["s1".to_owned(), "s2".to_owned()],
-                limit: 5,
+                seed_entities: vec!["s1".to_owned(), "s2".to_owned(), "s3".to_owned()],
+                limit: 10,
                 ef: 20,
             })
-            .expect("hybrid search with two seeds");
+            .expect("hybrid search with three seeds");
 
-        // f1 must appear exactly once (aggregated, not duplicated)
+        // f1 must appear exactly once (aggregated from 3 paths)
         let f1_hits: Vec<_> = results.iter().filter(|r| r.id == "f1").collect();
         assert_eq!(
             f1_hits.len(),
@@ -1451,6 +1481,95 @@ mod tests {
         assert!(
             f1_hits[0].graph_rank > 0,
             "f1 must have a positive graph rank"
+        );
+
+        // f2 must appear exactly once (from 1 path)
+        let f2_hits: Vec<_> = results.iter().filter(|r| r.id == "f2").collect();
+        assert_eq!(f2_hits.len(), 1, "f2 must appear once");
+        assert!(
+            f2_hits[0].graph_rank > 0,
+            "f2 must have a positive graph rank"
+        );
+
+        // f1 (3 paths) should have a higher RRF score than f2 (1 path)
+        assert!(
+            f1_hits[0].rrf_score > f2_hits[0].rrf_score,
+            "3-path entity must score higher than 1-path entity: f1={} vs f2={}",
+            f1_hits[0].rrf_score,
+            f2_hits[0].rrf_score,
+        );
+    }
+
+    #[cfg(feature = "mneme-engine")]
+    #[test]
+    fn hybrid_search_two_signal_no_graph() {
+        use crate::knowledge::{EmbeddedChunk, Entity, EpistemicTier, Fact};
+
+        let dim = 4;
+        let store =
+            KnowledgeStore::open_mem_with_config(KnowledgeConfig { dim }).expect("open_mem");
+
+        let fact = Fact {
+            id: "f-twosig".to_owned(),
+            nous_id: "test".to_owned(),
+            content: "unique harpsichord melody testing".to_owned(),
+            confidence: 0.9,
+            tier: EpistemicTier::Inferred,
+            valid_from: "2026-01-01".to_owned(),
+            valid_to: "9999-12-31".to_owned(),
+            superseded_by: None,
+            source_session_id: None,
+            recorded_at: "2026-03-01T00:00:00Z".to_owned(),
+        };
+        store.insert_fact(&fact).expect("insert fact");
+
+        store
+            .insert_embedding(&EmbeddedChunk {
+                id: "f-twosig".to_owned(),
+                content: "unique harpsichord melody testing".to_owned(),
+                source_type: "fact".to_owned(),
+                source_id: "f-twosig".to_owned(),
+                nous_id: "test".to_owned(),
+                embedding: vec![0.7, 0.3, 0.2, 0.1],
+                created_at: "2026-03-01T00:00:00Z".to_owned(),
+            })
+            .expect("insert embedding");
+
+        // Insert an unrelated seed entity so the graph signal is structurally present but yields
+        // no matches for f-twosig
+        store
+            .insert_entity(&Entity {
+                id: "e-unrelated".to_owned(),
+                name: "Unrelated".to_owned(),
+                entity_type: "concept".to_owned(),
+                aliases: vec![],
+                created_at: "2026-03-01T00:00:00Z".to_owned(),
+                updated_at: "2026-03-01T00:00:00Z".to_owned(),
+            })
+            .expect("insert entity");
+
+        let results = store
+            .search_hybrid(&HybridQuery {
+                text: "harpsichord melody".to_owned(),
+                embedding: vec![0.7, 0.3, 0.2, 0.1],
+                seed_entities: vec!["e-unrelated".to_owned()],
+                limit: 5,
+                ef: 20,
+            })
+            .expect("hybrid search two signals");
+
+        let hit = results.iter().find(|r| r.id == "f-twosig");
+        assert!(hit.is_some(), "BM25+vector fact must appear in results");
+        let hit = hit.unwrap();
+        assert!(hit.bm25_rank > 0, "must have positive BM25 rank");
+        assert!(hit.vec_rank > 0, "must have positive vector rank");
+        assert_eq!(
+            hit.graph_rank, -1,
+            "absent from graph signal must be -1"
+        );
+        assert!(
+            hit.rrf_score > 0.0,
+            "RRF score must be positive from two signals"
         );
     }
 


### PR DESCRIPTION
## Summary

- RRF engine now outputs `-1` (not `0`) for absent signal ranks, removing the consumer-side `remap_absent_rank()` band-aid
- Added `rank_to_output()` helper in `rrf.rs` and 6 unit tests for core RRF functions
- Strengthened graph aggregation test from 2-path to 3-path with comparative score assertion
- Added two-signal RRF test (BM25+vector with structurally empty graph signal)

## Changes

**`crates/mneme-engine/src/fixed_rule/utilities/rrf.rs`**
- New `rank_to_output(rank: usize) -> i64`: maps rank 0 (absent) to -1, passes through positive ranks
- Output tuple now uses `rank_to_output()` instead of bare `as i64` cast
- 6 new unit tests: `signal_contribution_absent_is_zero`, `signal_contribution_rank_one`, `assign_ranks_sorted_descending`, `assign_ranks_empty`, `rank_to_output_absent`, `rank_to_output_present`

**`crates/mneme/src/knowledge_store.rs`**
- Removed `remap_absent_rank()` function and its 3 call sites in `rows_to_hybrid_results()`
- `hybrid_search_graph_aggregation`: now tests 3 seed paths (was 2), adds second fact with 1 path, asserts 3-path entity scores higher
- New `hybrid_search_two_signal_no_graph`: validates RRF with BM25+vector signals when graph signal is structurally present but yields no matches

## Test plan

- [x] `cargo test -p aletheia-mneme-engine -- rrf` — 6 new RRF unit tests pass
- [x] `cargo test -p aletheia-mneme --no-default-features --features mneme-engine -- hybrid` — all 6 hybrid tests pass (3 existing + 1 strengthened + 1 new)
- [x] `cargo clippy --workspace --exclude aletheia-mneme-engine --all-targets -- -D warnings` — zero warnings
- [x] `cargo test --workspace` — all 745 tests pass