### PR TITLE
feat(recall): wire embedding provider and scaffold recall pipeline

### DIFF
--- a/crates/aletheia/Cargo.toml
+++ b/crates/aletheia/Cargo.toml
@@ -10,6 +10,13 @@ publish = false
 name = "aletheia"
 path = "src/main.rs"
 
+[features]
+default = []
+# Recall pipeline: enables KnowledgeStore (CozoDB) for vector search.
+# OFF by default — mneme-engine conflicts with rusqlite bundled sqlite3.
+# Phase 2 (prompt 28) wires KnowledgeVectorSearch behind this gate.
+recall = ["aletheia-nous/knowledge-store", "aletheia-mneme/mneme-engine"]
+
 [dependencies]
 aletheia-koina = { path = "../koina" }
 aletheia-taxis = { path = "../taxis" }

--- a/crates/aletheia/src/main.rs
+++ b/crates/aletheia/src/main.rs
@@ -19,6 +19,7 @@ use aletheia_agora::semeion::client::SignalClient;
 use aletheia_agora::types::ChannelProvider;
 use aletheia_hermeneus::anthropic::AnthropicProvider;
 use aletheia_hermeneus::provider::{ProviderConfig, ProviderRegistry};
+use aletheia_mneme::embedding::{EmbeddingConfig, EmbeddingProvider, create_provider};
 use aletheia_mneme::store::SessionStore;
 use aletheia_nous::config::{NousConfig, PipelineConfig};
 use aletheia_nous::manager::NousManager;
@@ -119,12 +120,29 @@ async fn serve(cli: Cli) -> Result<()> {
     let tool_registry = Arc::new(build_tool_registry()?);
     let oikos_arc = Arc::new(oikos);
 
+    // Embedding provider — drives recall query embedding
+    let embedding_config = EmbeddingConfig {
+        provider: config.embedding.provider.clone(),
+        model: config.embedding.model.clone(),
+        dimension: Some(config.embedding.dimension),
+        api_key: None,
+    };
+    let embedding_provider: Arc<dyn EmbeddingProvider> = Arc::from(
+        create_provider(&embedding_config).context("failed to create embedding provider")?,
+    );
+    info!(
+        provider = %config.embedding.provider,
+        dim = config.embedding.dimension,
+        "embedding provider created"
+    );
+
     // Spawn nous actors
+    // vector_search is None until Phase 2 (prompt 28) lands KnowledgeVectorSearch
     let mut nous_manager = NousManager::new(
         Arc::clone(&provider_registry),
         Arc::clone(&tool_registry),
         Arc::clone(&oikos_arc),
-        None,
+        Some(embedding_provider),
         None,
         Some(Arc::clone(&session_store)),
     );

--- a/crates/integration-tests/tests/recall_pipeline.rs
+++ b/crates/integration-tests/tests/recall_pipeline.rs
@@ -1,0 +1,76 @@
+//! Integration: recall pipeline end-to-end with mock providers.
+
+use aletheia_mneme::embedding::MockEmbeddingProvider;
+use aletheia_mneme::knowledge::RecallResult as KnowledgeRecallResult;
+use aletheia_nous::recall::{RecallConfig, RecallStage, VectorSearch};
+
+struct MockVectorSearch {
+    results: Vec<KnowledgeRecallResult>,
+}
+
+impl VectorSearch for MockVectorSearch {
+    fn search_vectors(
+        &self,
+        _query_vec: Vec<f32>,
+        _k: usize,
+        _ef: usize,
+    ) -> aletheia_nous::error::Result<Vec<KnowledgeRecallResult>> {
+        Ok(self.results.clone())
+    }
+}
+
+#[test]
+fn recall_with_mock_vectors_end_to_end() {
+    let embedder = MockEmbeddingProvider::new(384);
+    let search = MockVectorSearch {
+        results: vec![
+            KnowledgeRecallResult {
+                content: "Cody lives in Pflugerville".to_owned(),
+                distance: 0.05,
+                source_type: "fact".to_owned(),
+                source_id: "f-1".to_owned(),
+            },
+            KnowledgeRecallResult {
+                content: "Aletheia uses Tokio actors".to_owned(),
+                distance: 0.3,
+                source_type: "fact".to_owned(),
+                source_id: "f-2".to_owned(),
+            },
+        ],
+    };
+
+    let stage = RecallStage::new(RecallConfig {
+        min_score: 0.0,
+        ..RecallConfig::default()
+    });
+
+    let result = stage
+        .run("Where does Cody live?", "syn", &embedder, &search, 10000)
+        .expect("recall should succeed");
+
+    assert!(result.candidates_found >= 1);
+    assert!(result.results_injected >= 1);
+    let section = result.recall_section.expect("should have recall section");
+    assert!(
+        section.contains("Cody lives in Pflugerville"),
+        "section should contain the closest fact"
+    );
+}
+
+#[test]
+fn recall_empty_store_graceful() {
+    let embedder = MockEmbeddingProvider::new(384);
+    let search = MockVectorSearch {
+        results: vec![],
+    };
+
+    let stage = RecallStage::new(RecallConfig::default());
+
+    let result = stage
+        .run("anything", "syn", &embedder, &search, 10000)
+        .expect("recall with empty store should not error");
+
+    assert_eq!(result.candidates_found, 0);
+    assert_eq!(result.results_injected, 0);
+    assert!(result.recall_section.is_none());
+}

--- a/crates/nous/Cargo.toml
+++ b/crates/nous/Cargo.toml
@@ -10,6 +10,9 @@ rust-version.workspace = true
 [lints]
 workspace = true
 
+[features]
+knowledge-store = ["aletheia-mneme/mneme-engine"]
+
 [dependencies]
 aletheia-hermeneus = { path = "../hermeneus" }
 aletheia-koina = { path = "../koina" }

--- a/crates/taxis/src/config.rs
+++ b/crates/taxis/src/config.rs
@@ -13,6 +13,7 @@ pub struct AletheiaConfig {
     pub gateway: GatewayConfig,
     pub channels: ChannelsConfig,
     pub bindings: Vec<ChannelBinding>,
+    pub embedding: EmbeddingSettings,
 }
 
 /// Maps a channel source to a nous agent.
@@ -167,6 +168,29 @@ impl Default for GatewayAuthConfig {
     fn default() -> Self {
         Self {
             mode: "token".to_owned(),
+        }
+    }
+}
+
+/// Embedding provider configuration for recall pipeline.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[serde(default)]
+pub struct EmbeddingSettings {
+    /// Provider type: "mock", "fastembed".
+    pub provider: String,
+    /// Provider-specific model name.
+    pub model: Option<String>,
+    /// Output vector dimension (must match knowledge store HNSW index).
+    pub dimension: usize,
+}
+
+impl Default for EmbeddingSettings {
+    fn default() -> Self {
+        Self {
+            provider: "mock".to_owned(),
+            model: None,
+            dimension: 384,
         }
     }
 }
@@ -341,6 +365,9 @@ mod tests {
         assert!(config.channels.signal.enabled);
         assert!(config.channels.signal.accounts.is_empty());
         assert!(config.bindings.is_empty());
+        assert_eq!(config.embedding.provider, "mock");
+        assert!(config.embedding.model.is_none());
+        assert_eq!(config.embedding.dimension, 384);
     }
 
     #[test]
@@ -351,6 +378,8 @@ mod tests {
         assert_eq!(back.agents.defaults.context_tokens, 200_000);
         assert_eq!(back.gateway.port, 18789);
         assert!(back.channels.signal.enabled);
+        assert_eq!(back.embedding.provider, "mock");
+        assert_eq!(back.embedding.dimension, 384);
     }
 
     #[test]
@@ -487,6 +516,24 @@ mod tests {
         assert_eq!(binding.source, "+1234567890");
         assert_eq!(binding.nous_id, "syn");
         assert_eq!(binding.session_key, "{source}");
+    }
+
+    #[test]
+    fn embedding_override_from_json() {
+        let json = r#"{
+            "embedding": {
+                "provider": "fastembed",
+                "model": "BAAI/bge-small-en-v1.5",
+                "dimension": 512
+            }
+        }"#;
+        let config: AletheiaConfig = serde_json::from_str(json).expect("parse embedding");
+        assert_eq!(config.embedding.provider, "fastembed");
+        assert_eq!(
+            config.embedding.model,
+            Some("BAAI/bge-small-en-v1.5".to_owned())
+        );
+        assert_eq!(config.embedding.dimension, 512);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Add `EmbeddingSettings` to taxis `AletheiaConfig` — provider, model, dimension fields with figment cascade (YAML + env vars)
- Wire `EmbeddingProvider` creation in `main.rs` from config — `NousManager` now receives `Some(embedding_provider)` instead of `None`
- Scaffold `recall` feature gate on binary and `knowledge-store` feature on nous for Phase 2 (prompt 28)
- Add mock-based integration tests for `RecallStage` end-to-end

## What's deferred (prompt 28)

- `KnowledgeVectorSearch` adapter (bridges `KnowledgeStore` → `VectorSearch` trait)
- `KnowledgeStore` initialization behind `#[cfg(feature = "recall")]`
- Vector search wiring: `None` → `Some(vector_search)` in `NousManager`
- The `recall` feature gate resolves the sqlite3/mneme-engine link conflict

## Test plan

- [x] `cargo build -p aletheia` — compiles (recall OFF)
- [x] `cargo clippy --workspace --exclude aletheia-mneme-engine --all-targets -- -D warnings` — zero warnings
- [x] `cargo test --workspace` — all tests pass
- [x] New integration tests: `recall_with_mock_vectors_end_to_end`, `recall_empty_store_graceful`