### PR TITLE
feat(dianoia): scaffold planning crate — state machine, workspace model, operating modes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,6 +82,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "aletheia-dianoia"
+version = "0.1.0"
+dependencies = [
+ "aletheia-koina",
+ "jiff",
+ "serde",
+ "serde_json",
+ "snafu",
+ "static_assertions",
+ "tempfile",
+ "tokio",
+ "tracing",
+ "ulid",
+]
+
+[[package]]
 name = "aletheia-graph-builder"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 resolver = "2"
 members = [
     "crates/aletheia",
+    "crates/dianoia",
     "crates/graph-builder",
     "crates/agora",
     "crates/hermeneus",

--- a/crates/dianoia/Cargo.toml
+++ b/crates/dianoia/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "aletheia-dianoia"
+version = "0.1.0"
+description = "Planning and project orchestration — multi-phase state machine with workspace persistence"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+aletheia-koina = { path = "../koina" }
+jiff = { version = "0.2", features = ["serde"] }
+serde = { workspace = true }
+serde_json = { workspace = true }
+snafu = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
+ulid = { workspace = true }
+
+[dev-dependencies]
+static_assertions = { workspace = true }
+tempfile = "3"

--- a/crates/dianoia/src/error.rs
+++ b/crates/dianoia/src/error.rs
@@ -1,0 +1,71 @@
+//! Dianoia-specific errors.
+
+use snafu::Snafu;
+use std::path::PathBuf;
+
+/// Errors from planning and project orchestration.
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub))]
+#[non_exhaustive]
+pub enum Error {
+    #[snafu(display("invalid transition {transition:?} from state {state:?}"))]
+    InvalidTransition {
+        state: crate::state::ProjectState,
+        transition: crate::state::Transition,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("phase not found: {phase_id}"))]
+    PhaseNotFound {
+        phase_id: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("plan not found: {plan_id}"))]
+    PlanNotFound {
+        plan_id: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("plan {plan_id} stuck after {iterations} iterations"))]
+    PlanStuck {
+        plan_id: String,
+        iterations: u32,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("workspace I/O error at {}", path.display()))]
+    WorkspaceIo {
+        path: PathBuf,
+        source: std::io::Error,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("workspace deserialization error"))]
+    WorkspaceDeserialize {
+        source: serde_json::Error,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("workspace serialization error"))]
+    WorkspaceSerialize {
+        source: serde_json::Error,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("project not found in workspace at {}", path.display()))]
+    ProjectNotFound {
+        path: PathBuf,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+}
+
+pub type Result<T> = std::result::Result<T, Error>;

--- a/crates/dianoia/src/lib.rs
+++ b/crates/dianoia/src/lib.rs
@@ -1,0 +1,25 @@
+//! aletheia-dianoia — planning and project orchestration
+//!
+//! Dianoia (διάνοια) — "thinking through." The systematic, step-by-step
+//! reasoning process. Manages multi-phase projects from research through
+//! execution to verification. Three modes: full project, quick task,
+//! autonomous background.
+//!
+//! Depends on: koina
+
+pub mod error;
+pub mod phase;
+pub mod plan;
+pub mod project;
+pub mod state;
+pub mod workspace;
+
+#[cfg(test)]
+mod assertions {
+    use static_assertions::assert_impl_all;
+
+    assert_impl_all!(crate::project::Project: Send, Sync);
+    assert_impl_all!(crate::phase::Phase: Send, Sync);
+    assert_impl_all!(crate::plan::Plan: Send, Sync);
+    assert_impl_all!(crate::workspace::ProjectWorkspace: Send, Sync);
+}

--- a/crates/dianoia/src/phase.rs
+++ b/crates/dianoia/src/phase.rs
@@ -1,0 +1,74 @@
+//! Phase types within a project.
+
+use serde::{Deserialize, Serialize};
+use ulid::Ulid;
+
+use crate::plan::{Plan, PlanState};
+
+/// A phase within a project (e.g., "Foundation", "Core Features").
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Phase {
+    pub id: Ulid,
+    pub name: String,
+    pub goal: String,
+    pub requirements: Vec<String>,
+    pub plans: Vec<Plan>,
+    pub state: PhaseState,
+    pub order: u32,
+}
+
+/// Phase lifecycle states.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum PhaseState {
+    Pending,
+    Active,
+    Executing,
+    Verifying,
+    Complete,
+    Failed { can_retry: bool },
+}
+
+impl Phase {
+    #[must_use]
+    pub fn new(name: String, goal: String, order: u32) -> Self {
+        Self {
+            id: Ulid::new(),
+            name,
+            goal,
+            requirements: Vec::new(),
+            plans: Vec::new(),
+            state: PhaseState::Pending,
+            order,
+        }
+    }
+
+    pub fn add_plan(&mut self, plan: Plan) {
+        self.plans.push(plan);
+    }
+
+    #[must_use]
+    pub fn is_complete(&self) -> bool {
+        self.state == PhaseState::Complete
+    }
+
+    /// Percentage of plans in a terminal state (complete, skipped, failed, stuck).
+    #[must_use]
+    pub fn completion_percentage(&self) -> f64 {
+        if self.plans.is_empty() {
+            return 0.0;
+        }
+        let done = self
+            .plans
+            .iter()
+            .filter(|p| {
+                matches!(
+                    p.state,
+                    PlanState::Complete | PlanState::Skipped | PlanState::Failed | PlanState::Stuck
+                )
+            })
+            .count();
+        #[expect(clippy::cast_precision_loss, reason = "plan counts are small")]
+        let pct = done as f64 / self.plans.len() as f64 * 100.0;
+        pct
+    }
+}

--- a/crates/dianoia/src/plan.rs
+++ b/crates/dianoia/src/plan.rs
@@ -1,0 +1,135 @@
+//! Executable plans within a phase.
+
+use serde::{Deserialize, Serialize};
+use ulid::Ulid;
+
+use crate::error::{self, Result};
+
+const DEFAULT_MAX_ITERATIONS: u32 = 10;
+
+/// An executable plan within a phase.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Plan {
+    pub id: Ulid,
+    pub title: String,
+    pub description: String,
+    pub wave: u32,
+    pub depends_on: Vec<Ulid>,
+    pub state: PlanState,
+    pub max_iterations: u32,
+    pub iterations: u32,
+    pub blockers: Vec<Blocker>,
+    pub achievements: Vec<String>,
+}
+
+/// Plan lifecycle states.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum PlanState {
+    Pending,
+    Ready,
+    Executing,
+    Complete,
+    Failed,
+    Skipped,
+    Stuck,
+}
+
+/// A blocker discovered during plan execution.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Blocker {
+    pub description: String,
+    pub plan_id: Ulid,
+    pub detected_at: jiff::Timestamp,
+}
+
+impl Plan {
+    #[must_use]
+    pub fn new(title: String, description: String, wave: u32) -> Self {
+        Self {
+            id: Ulid::new(),
+            title,
+            description,
+            wave,
+            depends_on: Vec::new(),
+            state: PlanState::Pending,
+            max_iterations: DEFAULT_MAX_ITERATIONS,
+            iterations: 0,
+            blockers: Vec::new(),
+            achievements: Vec::new(),
+        }
+    }
+
+    /// Check if all dependencies are satisfied given completed plan IDs.
+    #[must_use]
+    pub fn is_ready(&self, completed: &[Ulid]) -> bool {
+        self.depends_on.iter().all(|dep| completed.contains(dep))
+    }
+
+    /// Record an iteration. Returns `Err` if `max_iterations` exceeded.
+    pub fn record_iteration(&mut self) -> Result<()> {
+        self.iterations += 1;
+        if self.iterations > self.max_iterations {
+            self.state = PlanState::Stuck;
+            return error::PlanStuckSnafu {
+                plan_id: self.id.to_string(),
+                iterations: self.iterations,
+            }
+            .fail();
+        }
+        Ok(())
+    }
+
+    /// Mark as stuck with a blocker.
+    pub fn mark_stuck(&mut self, blocker: Blocker) {
+        self.state = PlanState::Stuck;
+        self.blockers.push(blocker);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dependency_check() {
+        let dep1 = Ulid::new();
+        let dep2 = Ulid::new();
+        let mut plan = Plan::new("task".into(), "do a thing".into(), 1);
+        plan.depends_on = vec![dep1, dep2];
+
+        assert!(!plan.is_ready(&[]));
+        assert!(!plan.is_ready(&[dep1]));
+        assert!(plan.is_ready(&[dep1, dep2]));
+        assert!(plan.is_ready(&[dep2, dep1, Ulid::new()]));
+    }
+
+    #[test]
+    fn iteration_tracking_and_stuck() {
+        let mut plan = Plan::new("task".into(), "desc".into(), 1);
+        plan.max_iterations = 3;
+
+        plan.record_iteration().unwrap(); // 1
+        plan.record_iteration().unwrap(); // 2
+        plan.record_iteration().unwrap(); // 3
+        let result = plan.record_iteration(); // 4 > 3
+        assert!(result.is_err());
+        assert_eq!(plan.state, PlanState::Stuck);
+    }
+
+    #[test]
+    fn wave_ordering() {
+        let first = Plan::new("first".into(), "wave 1".into(), 1);
+        let second = Plan::new("second".into(), "wave 1".into(), 1);
+        let mut dependent = Plan::new("dependent".into(), "wave 2".into(), 2);
+        dependent.depends_on = vec![first.id, second.id];
+
+        // Wave 1 plans have no deps — always ready
+        assert!(first.is_ready(&[]));
+        assert!(second.is_ready(&[]));
+
+        // Wave 2 not ready until wave 1 complete
+        assert!(!dependent.is_ready(&[]));
+        assert!(!dependent.is_ready(&[first.id]));
+        assert!(dependent.is_ready(&[first.id, second.id]));
+    }
+}

--- a/crates/dianoia/src/project.rs
+++ b/crates/dianoia/src/project.rs
@@ -1,0 +1,138 @@
+//! Project types and lifecycle management.
+
+use serde::{Deserialize, Serialize};
+use ulid::Ulid;
+
+use crate::error::Result;
+use crate::phase::Phase;
+use crate::state::{ProjectState, Transition};
+
+/// A planning project.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Project {
+    pub id: Ulid,
+    pub name: String,
+    pub description: String,
+    pub scope: Option<String>,
+    pub state: ProjectState,
+    pub mode: ProjectMode,
+    pub phases: Vec<Phase>,
+    pub created_at: jiff::Timestamp,
+    pub updated_at: jiff::Timestamp,
+    pub owner: String,
+}
+
+/// Operating modes for planning.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ProjectMode {
+    Full,
+    Quick { appetite_minutes: u32 },
+    Background,
+}
+
+impl Project {
+    #[must_use]
+    pub fn new(name: String, description: String, mode: ProjectMode, owner: String) -> Self {
+        let now = jiff::Timestamp::now();
+        Self {
+            id: Ulid::new(),
+            name,
+            description,
+            scope: None,
+            state: ProjectState::Created,
+            mode,
+            phases: Vec::new(),
+            created_at: now,
+            updated_at: now,
+            owner,
+        }
+    }
+
+    /// Advance project state via a transition.
+    pub fn advance(&mut self, transition: Transition) -> Result<()> {
+        let current = self.state.clone();
+        self.state = current.transition(transition)?;
+        self.updated_at = jiff::Timestamp::now();
+        Ok(())
+    }
+
+    pub fn add_phase(&mut self, phase: Phase) {
+        self.phases.push(phase);
+        self.updated_at = jiff::Timestamp::now();
+    }
+
+    /// Get the current active phase (first non-complete phase).
+    #[must_use]
+    pub fn active_phase(&self) -> Option<&Phase> {
+        self.phases
+            .iter()
+            .find(|p| !p.is_complete())
+    }
+
+    /// Get a mutable reference to the current active phase.
+    pub fn active_phase_mut(&mut self) -> Option<&mut Phase> {
+        self.phases
+            .iter_mut()
+            .find(|p| !p.is_complete())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::phase::{Phase, PhaseState};
+
+    #[test]
+    fn create_project_defaults() {
+        let project = Project::new(
+            "test".into(),
+            "a test project".into(),
+            ProjectMode::Full,
+            "syn".into(),
+        );
+        assert_eq!(project.name, "test");
+        assert_eq!(project.state, ProjectState::Created);
+        assert_eq!(project.mode, ProjectMode::Full);
+        assert!(project.phases.is_empty());
+        assert!(project.scope.is_none());
+        assert_eq!(project.owner, "syn");
+    }
+
+    #[test]
+    fn advance_updates_timestamp() {
+        let mut project = Project::new(
+            "test".into(),
+            "desc".into(),
+            ProjectMode::Full,
+            "syn".into(),
+        );
+        let before = project.updated_at;
+        // Small sleep to ensure timestamp differs
+        std::thread::sleep(std::time::Duration::from_millis(2));
+        project.advance(Transition::StartQuestioning).unwrap();
+        assert_eq!(project.state, ProjectState::Questioning);
+        assert!(project.updated_at >= before);
+    }
+
+    #[test]
+    fn active_phase_tracking() {
+        let mut project = Project::new(
+            "test".into(),
+            "desc".into(),
+            ProjectMode::Full,
+            "syn".into(),
+        );
+
+        assert!(project.active_phase().is_none());
+
+        let mut phase1 = Phase::new("Phase 1".into(), "First phase".into(), 1);
+        phase1.state = PhaseState::Complete;
+        project.add_phase(phase1);
+
+        let phase2 = Phase::new("Phase 2".into(), "Second phase".into(), 2);
+        project.add_phase(phase2);
+
+        let active = project.active_phase().unwrap();
+        assert_eq!(active.name, "Phase 2");
+    }
+}

--- a/crates/dianoia/src/state.rs
+++ b/crates/dianoia/src/state.rs
@@ -1,0 +1,345 @@
+//! Project lifecycle state machine.
+
+use serde::{Deserialize, Serialize};
+use snafu::ensure;
+
+use crate::error::{self, Result};
+
+/// Project lifecycle states.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum ProjectState {
+    Created,
+    Questioning,
+    Researching,
+    Scoping,
+    Planning,
+    Discussing,
+    Executing,
+    Verifying,
+    Complete,
+    Abandoned,
+    Paused {
+        previous: Box<ProjectState>,
+    },
+}
+
+/// Valid transitions between project states.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Transition {
+    StartQuestioning,
+    SkipToResearch,
+    StartResearch,
+    SkipResearch,
+    StartScoping,
+    StartPlanning,
+    StartDiscussion,
+    StartExecution,
+    StartVerification,
+    Complete,
+    Abandon,
+    Pause,
+    Resume,
+    Revert { to: ProjectState },
+}
+
+impl ProjectState {
+    /// Attempt a state transition. Returns the new state or an error
+    /// if the transition is invalid from the current state.
+    pub fn transition(self, t: Transition) -> Result<Self> {
+        match (&self, &t) {
+            // Unique forward transitions
+            (Self::Created, Transition::StartQuestioning) => Ok(Self::Questioning),
+            (Self::Questioning, Transition::StartResearch) => Ok(Self::Researching),
+            (Self::Scoping, Transition::StartPlanning) => Ok(Self::Planning),
+            (Self::Planning, Transition::StartDiscussion) => Ok(Self::Discussing),
+            (Self::Executing, Transition::StartVerification) => Ok(Self::Verifying),
+            (Self::Verifying, Transition::Complete) => Ok(Self::Complete),
+
+            // Multiple paths to Scoping
+            (Self::Created, Transition::SkipToResearch)
+            | (Self::Questioning, Transition::SkipResearch)
+            | (Self::Researching, Transition::StartScoping) => Ok(Self::Scoping),
+
+            // Multiple paths to Executing
+            (Self::Planning | Self::Discussing, Transition::StartExecution) => Ok(Self::Executing),
+
+            // Revert from verification to an earlier phase
+            (
+                Self::Verifying,
+                Transition::Revert {
+                    to: to @ (Self::Scoping | Self::Planning | Self::Executing),
+                },
+            ) => Ok(to.clone()),
+
+            // Pause from any pausable state
+            (
+                Self::Researching
+                | Self::Scoping
+                | Self::Planning
+                | Self::Discussing
+                | Self::Executing,
+                Transition::Pause,
+            ) => Ok(Self::Paused {
+                previous: Box::new(self),
+            }),
+
+            // Resume returns to the state before pause
+            (Self::Paused { previous }, Transition::Resume) => Ok(*previous.clone()),
+
+            // Abandon from any non-terminal state
+            (
+                Self::Created
+                | Self::Questioning
+                | Self::Researching
+                | Self::Scoping
+                | Self::Planning
+                | Self::Discussing
+                | Self::Executing
+                | Self::Verifying
+                | Self::Paused { .. },
+                Transition::Abandon,
+            ) => Ok(Self::Abandoned),
+
+            // Terminal states and all invalid transitions
+            _ => {
+                ensure!(
+                    false,
+                    error::InvalidTransitionSnafu {
+                        state: self,
+                        transition: t,
+                    }
+                );
+                unreachable!()
+            }
+        }
+    }
+
+    /// List valid transitions from this state.
+    #[must_use]
+    pub fn valid_transitions(&self) -> Vec<Transition> {
+        match self {
+            Self::Created => vec![
+                Transition::StartQuestioning,
+                Transition::SkipToResearch,
+                Transition::Abandon,
+            ],
+            Self::Questioning => vec![
+                Transition::StartResearch,
+                Transition::SkipResearch,
+                Transition::Abandon,
+            ],
+            Self::Researching => vec![
+                Transition::StartScoping,
+                Transition::Abandon,
+                Transition::Pause,
+            ],
+            Self::Scoping => vec![
+                Transition::StartPlanning,
+                Transition::Abandon,
+                Transition::Pause,
+            ],
+            Self::Planning => vec![
+                Transition::StartDiscussion,
+                Transition::StartExecution,
+                Transition::Abandon,
+                Transition::Pause,
+            ],
+            Self::Discussing => vec![
+                Transition::StartExecution,
+                Transition::Abandon,
+                Transition::Pause,
+            ],
+            Self::Executing => vec![
+                Transition::StartVerification,
+                Transition::Abandon,
+                Transition::Pause,
+            ],
+            Self::Verifying => vec![
+                Transition::Complete,
+                Transition::Abandon,
+            ],
+            Self::Complete | Self::Abandoned => vec![],
+            Self::Paused { .. } => vec![
+                Transition::Resume,
+                Transition::Abandon,
+            ],
+        }
+    }
+
+    /// Whether this state represents a terminal condition.
+    #[must_use]
+    pub fn is_terminal(&self) -> bool {
+        matches!(self, Self::Complete | Self::Abandoned)
+    }
+
+    /// Whether work can happen in this state.
+    #[must_use]
+    pub fn is_active(&self) -> bool {
+        !self.is_terminal() && !matches!(self, Self::Paused { .. })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn happy_path_full_lifecycle() {
+        let state = ProjectState::Created;
+        let state = state.transition(Transition::StartQuestioning).unwrap();
+        assert_eq!(state, ProjectState::Questioning);
+        let state = state.transition(Transition::StartResearch).unwrap();
+        assert_eq!(state, ProjectState::Researching);
+        let state = state.transition(Transition::StartScoping).unwrap();
+        assert_eq!(state, ProjectState::Scoping);
+        let state = state.transition(Transition::StartPlanning).unwrap();
+        assert_eq!(state, ProjectState::Planning);
+        let state = state.transition(Transition::StartDiscussion).unwrap();
+        assert_eq!(state, ProjectState::Discussing);
+        let state = state.transition(Transition::StartExecution).unwrap();
+        assert_eq!(state, ProjectState::Executing);
+        let state = state.transition(Transition::StartVerification).unwrap();
+        assert_eq!(state, ProjectState::Verifying);
+        let state = state.transition(Transition::Complete).unwrap();
+        assert_eq!(state, ProjectState::Complete);
+    }
+
+    #[test]
+    fn skip_research() {
+        let state = ProjectState::Created;
+        let state = state.transition(Transition::SkipToResearch).unwrap();
+        assert_eq!(state, ProjectState::Scoping);
+    }
+
+    #[test]
+    fn skip_discussion() {
+        let state = ProjectState::Planning;
+        let state = state.transition(Transition::StartExecution).unwrap();
+        assert_eq!(state, ProjectState::Executing);
+    }
+
+    #[test]
+    fn invalid_transition_returns_error() {
+        let state = ProjectState::Executing;
+        let result = state.transition(Transition::StartQuestioning);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn pause_and_resume() {
+        let state = ProjectState::Executing;
+        let state = state.transition(Transition::Pause).unwrap();
+        assert!(matches!(state, ProjectState::Paused { .. }));
+        let state = state.transition(Transition::Resume).unwrap();
+        assert_eq!(state, ProjectState::Executing);
+    }
+
+    #[test]
+    fn pause_preserves_previous_state() {
+        let state = ProjectState::Scoping;
+        let state = state.transition(Transition::Pause).unwrap();
+        assert_eq!(
+            state,
+            ProjectState::Paused {
+                previous: Box::new(ProjectState::Scoping)
+            }
+        );
+    }
+
+    #[test]
+    fn abandon_from_various_states() {
+        for start in [
+            ProjectState::Created,
+            ProjectState::Researching,
+            ProjectState::Executing,
+        ] {
+            let state = start.transition(Transition::Abandon).unwrap();
+            assert_eq!(state, ProjectState::Abandoned);
+        }
+    }
+
+    #[test]
+    fn terminal_states_reject_all_transitions() {
+        for terminal in [ProjectState::Complete, ProjectState::Abandoned] {
+            assert!(terminal
+                .clone()
+                .transition(Transition::StartQuestioning)
+                .is_err());
+            assert!(terminal
+                .clone()
+                .transition(Transition::Abandon)
+                .is_err());
+            assert!(terminal.transition(Transition::Pause).is_err());
+        }
+    }
+
+    #[test]
+    fn valid_transitions_per_state() {
+        let created = ProjectState::Created;
+        let transitions = created.valid_transitions();
+        assert_eq!(transitions.len(), 3);
+        assert!(transitions.contains(&Transition::StartQuestioning));
+        assert!(transitions.contains(&Transition::SkipToResearch));
+        assert!(transitions.contains(&Transition::Abandon));
+
+        assert!(ProjectState::Complete.valid_transitions().is_empty());
+        assert!(ProjectState::Abandoned.valid_transitions().is_empty());
+
+        let paused = ProjectState::Paused {
+            previous: Box::new(ProjectState::Executing),
+        };
+        let transitions = paused.valid_transitions();
+        assert_eq!(transitions.len(), 2);
+        assert!(transitions.contains(&Transition::Resume));
+        assert!(transitions.contains(&Transition::Abandon));
+    }
+
+    #[test]
+    fn revert_from_verifying() {
+        let state = ProjectState::Verifying;
+        let state = state
+            .transition(Transition::Revert {
+                to: ProjectState::Executing,
+            })
+            .unwrap();
+        assert_eq!(state, ProjectState::Executing);
+
+        let state = ProjectState::Verifying;
+        let state = state
+            .transition(Transition::Revert {
+                to: ProjectState::Planning,
+            })
+            .unwrap();
+        assert_eq!(state, ProjectState::Planning);
+
+        let state = ProjectState::Verifying;
+        let state = state
+            .transition(Transition::Revert {
+                to: ProjectState::Scoping,
+            })
+            .unwrap();
+        assert_eq!(state, ProjectState::Scoping);
+    }
+
+    #[test]
+    fn is_terminal() {
+        assert!(ProjectState::Complete.is_terminal());
+        assert!(ProjectState::Abandoned.is_terminal());
+        assert!(!ProjectState::Executing.is_terminal());
+        assert!(!ProjectState::Created.is_terminal());
+    }
+
+    #[test]
+    fn is_active() {
+        assert!(ProjectState::Created.is_active());
+        assert!(ProjectState::Executing.is_active());
+        assert!(!ProjectState::Complete.is_active());
+        assert!(!ProjectState::Abandoned.is_active());
+        assert!(
+            !ProjectState::Paused {
+                previous: Box::new(ProjectState::Executing)
+            }
+            .is_active()
+        );
+    }
+}

--- a/crates/dianoia/src/workspace.rs
+++ b/crates/dianoia/src/workspace.rs
@@ -1,0 +1,203 @@
+//! On-disk workspace persistence for projects.
+
+use std::path::{Path, PathBuf};
+
+use snafu::ResultExt;
+
+use crate::error::{self, Result};
+use crate::plan::Blocker;
+use crate::project::Project;
+
+/// Manages the on-disk workspace for a project.
+pub struct ProjectWorkspace {
+    root: PathBuf,
+}
+
+/// Standard directories in a project workspace.
+pub struct WorkspaceLayout {
+    pub root: PathBuf,
+    pub project_file: PathBuf,
+    pub phases_dir: PathBuf,
+    pub blockers_dir: PathBuf,
+    pub artifacts_dir: PathBuf,
+}
+
+impl ProjectWorkspace {
+    /// Create a new workspace at the given path.
+    pub fn create(root: impl Into<PathBuf>) -> Result<Self> {
+        let root = root.into();
+        let layout = Self::build_layout(&root);
+
+        for dir in [&layout.phases_dir, &layout.blockers_dir, &layout.artifacts_dir] {
+            std::fs::create_dir_all(dir).context(error::WorkspaceIoSnafu {
+                path: dir.clone(),
+            })?;
+        }
+
+        Ok(Self { root })
+    }
+
+    /// Open an existing workspace.
+    pub fn open(root: impl Into<PathBuf>) -> Result<Self> {
+        let root = root.into();
+        if !root.exists() {
+            return error::ProjectNotFoundSnafu { path: root }.fail();
+        }
+        Ok(Self { root })
+    }
+
+    /// Save project state to disk.
+    pub fn save_project(&self, project: &Project) -> Result<()> {
+        let layout = self.layout();
+        let json = serde_json::to_string_pretty(project).context(error::WorkspaceSerializeSnafu)?;
+        std::fs::write(&layout.project_file, json).context(error::WorkspaceIoSnafu {
+            path: &layout.project_file,
+        })?;
+        Ok(())
+    }
+
+    /// Load project state from disk.
+    pub fn load_project(&self) -> Result<Project> {
+        let layout = self.layout();
+        if !layout.project_file.exists() {
+            return error::ProjectNotFoundSnafu {
+                path: layout.project_file,
+            }
+            .fail();
+        }
+        let contents =
+            std::fs::read_to_string(&layout.project_file).context(error::WorkspaceIoSnafu {
+                path: &layout.project_file,
+            })?;
+        let project: Project =
+            serde_json::from_str(&contents).context(error::WorkspaceDeserializeSnafu)?;
+        Ok(project)
+    }
+
+    /// Write a blocker file for stuck detection integration.
+    pub fn write_blocker(&self, phase_id: &str, blocker: &Blocker) -> Result<()> {
+        let layout = self.layout();
+        let phase_blockers = layout.blockers_dir.join(phase_id);
+        std::fs::create_dir_all(&phase_blockers).context(error::WorkspaceIoSnafu {
+            path: &phase_blockers,
+        })?;
+
+        let filename = format!("{}.md", blocker.plan_id);
+        let path = phase_blockers.join(&filename);
+        let content = format!(
+            "# Blocker: {}\n\nPlan: {}\nDetected: {}\n\n{}\n",
+            blocker.plan_id, blocker.plan_id, blocker.detected_at, blocker.description
+        );
+        std::fs::write(&path, content).context(error::WorkspaceIoSnafu { path })?;
+        Ok(())
+    }
+
+    /// Read all blockers for a phase.
+    pub fn read_blockers(&self, phase_id: &str) -> Result<Vec<Blocker>> {
+        let layout = self.layout();
+        let phase_blockers = layout.blockers_dir.join(phase_id);
+
+        if !phase_blockers.exists() {
+            return Ok(Vec::new());
+        }
+
+        let mut blockers = Vec::new();
+        let entries =
+            std::fs::read_dir(&phase_blockers).context(error::WorkspaceIoSnafu {
+                path: &phase_blockers,
+            })?;
+
+        for entry in entries {
+            let entry = entry.context(error::WorkspaceIoSnafu {
+                path: &phase_blockers,
+            })?;
+            let path = entry.path();
+            if path.extension().is_some_and(|ext| ext == "md") {
+                let content =
+                    std::fs::read_to_string(&path).context(error::WorkspaceIoSnafu {
+                        path: &path,
+                    })?;
+                let plan_id_str = path
+                    .file_stem()
+                    .unwrap_or_default()
+                    .to_string_lossy();
+
+                blockers.push(Blocker {
+                    description: content,
+                    plan_id: plan_id_str
+                        .parse::<ulid::Ulid>()
+                        .unwrap_or_else(|_| ulid::Ulid::new()),
+                    detected_at: jiff::Timestamp::now(),
+                });
+            }
+        }
+
+        Ok(blockers)
+    }
+
+    /// Get the workspace directory layout.
+    #[must_use]
+    pub fn layout(&self) -> WorkspaceLayout {
+        Self::build_layout(&self.root)
+    }
+
+    fn build_layout(root: &Path) -> WorkspaceLayout {
+        WorkspaceLayout {
+            root: root.to_path_buf(),
+            project_file: root.join("PROJECT.json"),
+            phases_dir: root.join("phases"),
+            blockers_dir: root.join(".dianoia").join("blockers"),
+            artifacts_dir: root.join("artifacts"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::project::ProjectMode;
+
+    #[test]
+    fn save_and_load_roundtrip() {
+        let dir = tempfile::tempdir().unwrap();
+        let ws = ProjectWorkspace::create(dir.path().join("project")).unwrap();
+
+        let project = Project::new(
+            "roundtrip-test".into(),
+            "testing persistence".into(),
+            ProjectMode::Full,
+            "syn".into(),
+        );
+        ws.save_project(&project).unwrap();
+
+        let loaded = ws.load_project().unwrap();
+        assert_eq!(loaded.id, project.id);
+        assert_eq!(loaded.name, project.name);
+        assert_eq!(loaded.description, project.description);
+        assert_eq!(loaded.owner, project.owner);
+    }
+
+    #[test]
+    fn blocker_write_and_read() {
+        let dir = tempfile::tempdir().unwrap();
+        let ws = ProjectWorkspace::create(dir.path().join("project")).unwrap();
+
+        let plan_id = ulid::Ulid::new();
+        let blocker = Blocker {
+            description: "blocked on API design".into(),
+            plan_id,
+            detected_at: jiff::Timestamp::now(),
+        };
+
+        ws.write_blocker("phase-1", &blocker).unwrap();
+        let blockers = ws.read_blockers("phase-1").unwrap();
+        assert_eq!(blockers.len(), 1);
+        assert!(blockers[0].description.contains("blocked on API design"));
+    }
+
+    #[test]
+    fn open_nonexistent_returns_error() {
+        let result = ProjectWorkspace::open("/nonexistent/workspace/path");
+        assert!(result.is_err());
+    }
+}


### PR DESCRIPTION
## Summary

Scaffolds `aletheia-dianoia`, the planning and project orchestration crate.

- **State machine** (`state.rs`) — `ProjectState` enum with exhaustive `match` on all (state, transition) pairs. Supports pause/resume, skip phases, and revert from verification.
- **Project types** (`project.rs`) — `Project` struct with three operating modes: Full lifecycle, Quick (time-boxed), Background (autonomous).
- **Phase & Plan types** (`phase.rs`, `plan.rs`) — wave-based parallel execution, dependency tracking, iteration caps with stuck detection, blocker recording.
- **Workspace persistence** (`workspace.rs`) — `ProjectWorkspace` reads/writes project state as JSON, manages blocker files on disk.
- **Error types** (`error.rs`) — snafu enum with implicit `Location` tracking, consistent with all other crates.

## Test plan

- [x] 21 unit tests covering state transitions, pause/resume, skip paths, terminal rejection, round-trip persistence, blocker I/O, and stuck detection
- [x] `cargo clippy --workspace --exclude aletheia-mneme-engine --all-targets -- -D warnings` — zero warnings
- [x] `cargo test --workspace` — all 870 tests pass (21 new + 849 existing)
- [x] No modifications to any existing crate