### PR TITLE
feat(melete): structured distillation — model downshift, sections template, memory flush

### DIFF
--- a/crates/melete/src/distill.rs
+++ b/crates/melete/src/distill.rs
@@ -6,7 +6,82 @@ use snafu::ResultExt;
 use tracing::instrument;
 
 use crate::error::{EmptySummarySnafu, LlmCallSnafu, NoMessagesSnafu, Result};
-use crate::prompt::{self, DISTILLATION_SYSTEM_PROMPT};
+use crate::prompt;
+
+/// Sections that can appear in a distillation summary.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+pub enum DistillSection {
+    Summary,
+    TaskContext,
+    CompletedWork,
+    KeyDecisions,
+    CurrentState,
+    OpenThreads,
+    Corrections,
+    /// Custom section with a name and description.
+    Custom { name: String, description: String },
+}
+
+impl DistillSection {
+    /// Markdown heading for this section.
+    pub fn heading(&self) -> String {
+        match self {
+            Self::Summary => "## Summary".to_owned(),
+            Self::TaskContext => "## Task Context".to_owned(),
+            Self::CompletedWork => "## Completed Work".to_owned(),
+            Self::KeyDecisions => "## Key Decisions".to_owned(),
+            Self::CurrentState => "## Current State".to_owned(),
+            Self::OpenThreads => "## Open Threads".to_owned(),
+            Self::Corrections => "## Corrections".to_owned(),
+            Self::Custom { name, .. } => format!("## {name}"),
+        }
+    }
+
+    /// Description text for this section (used in the system prompt).
+    pub fn description(&self) -> &str {
+        match self {
+            Self::Summary => "One sentence describing what this conversation is about.",
+            Self::TaskContext => {
+                "What was being worked on and why. Include the agent/nous identity if relevant."
+            }
+            Self::CompletedWork => {
+                "- Bullet list of concrete actions taken and their outcomes\n\
+                 - Include file paths, function names, and specific details\n\
+                 - Focus on results, not process"
+            }
+            Self::KeyDecisions => {
+                "- Decisions made with their rationale — these MUST be preserved\n\
+                 - Format: \"Decision: X. Reason: Y.\""
+            }
+            Self::CurrentState => {
+                "Where things stand right now. What is done, what is in progress, what is half-finished."
+            }
+            Self::OpenThreads => {
+                "- Unfinished items, pending questions, next steps\n\
+                 - Items deferred for later"
+            }
+            Self::Corrections => {
+                "- Anything that was wrong and corrected\n\
+                 - Mistakes made and how they were fixed\n\
+                 - These prevent repeating errors"
+            }
+            Self::Custom { description, .. } => description,
+        }
+    }
+
+    /// All standard sections in default order.
+    pub fn all_standard() -> Vec<Self> {
+        vec![
+            Self::Summary,
+            Self::TaskContext,
+            Self::CompletedWork,
+            Self::KeyDecisions,
+            Self::CurrentState,
+            Self::OpenThreads,
+            Self::Corrections,
+        ]
+    }
+}
 
 /// Configuration for a distillation run.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
@@ -19,6 +94,13 @@ pub struct DistillConfig {
     pub min_messages: usize,
     /// Whether to include tool call details in the summary.
     pub include_tool_calls: bool,
+    /// If set, use this model for distillation instead of the primary model.
+    /// Enables cost reduction (e.g., Opus primary -> Sonnet for distillation).
+    pub distillation_model: Option<String>,
+    /// Number of recent messages to preserve verbatim (not summarized).
+    pub verbatim_tail: usize,
+    /// Sections to include in the structured summary.
+    pub sections: Vec<DistillSection>,
 }
 
 impl Default for DistillConfig {
@@ -28,6 +110,9 @@ impl Default for DistillConfig {
             max_output_tokens: 4096,
             min_messages: 6,
             include_tool_calls: true,
+            distillation_model: None,
+            verbatim_tail: 3,
+            sections: DistillSection::all_standard(),
         }
     }
 }
@@ -37,7 +122,7 @@ impl Default for DistillConfig {
 pub struct DistillResult {
     /// The distilled summary text.
     pub summary: String,
-    /// Number of messages that were distilled.
+    /// Number of messages that were distilled (excluding verbatim tail).
     pub messages_distilled: usize,
     /// Estimated tokens before distillation.
     pub tokens_before: u64,
@@ -47,6 +132,8 @@ pub struct DistillResult {
     pub distillation_number: u32,
     /// Timestamp of distillation (ISO 8601).
     pub timestamp: String,
+    /// Messages preserved verbatim (not summarized).
+    pub verbatim_messages: Vec<Message>,
 }
 
 /// The distillation engine.
@@ -63,8 +150,9 @@ impl DistillEngine {
 
     /// Check if the given messages warrant distillation.
     ///
-    /// Returns true when message count meets the minimum AND
-    /// the token estimate exceeds the threshold ratio of the context window.
+    /// Returns true when message count meets the minimum (accounting for
+    /// verbatim tail) AND the token estimate exceeds the threshold ratio
+    /// of the context window.
     pub fn should_distill(
         &self,
         message_count: usize,
@@ -72,7 +160,9 @@ impl DistillEngine {
         context_window: u64,
         threshold: f64,
     ) -> bool {
-        if message_count < self.config.min_messages {
+        // Need enough messages to summarize beyond the verbatim tail.
+        let required = self.config.min_messages + self.config.verbatim_tail;
+        if message_count < required {
             return false;
         }
         if context_window == 0 {
@@ -89,6 +179,14 @@ impl DistillEngine {
     /// Build the distillation prompt for the given messages.
     pub fn build_prompt(&self, messages: &[Message], nous_id: &str) -> CompletionRequest {
         let formatted = prompt::format_messages(messages, self.config.include_tool_calls);
+        let system_prompt = prompt::build_system_prompt(&self.config.sections);
+
+        let model = self
+            .config
+            .distillation_model
+            .as_deref()
+            .unwrap_or(&self.config.model)
+            .to_owned();
 
         let user_content = format!(
             "Distill the following conversation from nous \"{nous_id}\" \
@@ -98,8 +196,8 @@ impl DistillEngine {
         );
 
         CompletionRequest {
-            model: self.config.model.clone(),
-            system: Some(DISTILLATION_SYSTEM_PROMPT.to_owned()),
+            model,
+            system: Some(system_prompt),
             messages: vec![Message {
                 role: Role::User,
                 content: Content::Text(user_content),
@@ -113,6 +211,9 @@ impl DistillEngine {
     }
 
     /// Run distillation: call LLM, return the summary.
+    ///
+    /// Splits messages into a summarization group and a verbatim tail.
+    /// Only the summarization group is sent to the LLM.
     #[instrument(skip(self, messages, provider), fields(nous_id, distillation_number))]
     pub async fn distill(
         &self,
@@ -125,8 +226,13 @@ impl DistillEngine {
             return NoMessagesSnafu.fail();
         }
 
+        let tail = self.config.verbatim_tail.min(messages.len());
+        let split_at = messages.len() - tail;
+        let to_summarize = &messages[..split_at];
+        let verbatim = &messages[split_at..];
+
         let tokens_before = estimate_tokens(messages);
-        let request = self.build_prompt(messages, nous_id);
+        let request = self.build_prompt(to_summarize, nous_id);
         let response = provider.complete(&request).context(LlmCallSnafu)?;
 
         let summary = extract_summary_text(&response.content);
@@ -139,11 +245,12 @@ impl DistillEngine {
 
         Ok(DistillResult {
             summary,
-            messages_distilled: messages.len(),
+            messages_distilled: to_summarize.len(),
             tokens_before,
             tokens_after,
             distillation_number,
             timestamp,
+            verbatim_messages: verbatim.to_vec(),
         })
     }
 
@@ -331,6 +438,7 @@ Bug is fixed, test passes.
     #[test]
     fn should_distill_at_threshold_returns_true() {
         let engine = default_engine();
+        // 10 >= min_messages(6) + verbatim_tail(3) = 9, tokens at threshold
         assert!(engine.should_distill(10, 160_000, 200_000, 0.8));
     }
 
@@ -343,7 +451,7 @@ Bug is fixed, test passes.
     #[test]
     fn should_distill_too_few_messages_returns_false() {
         let engine = default_engine();
-        // 5 messages < min_messages (6), even though tokens exceed threshold
+        // 5 < min_messages(6) + verbatim_tail(3) = 9
         assert!(!engine.should_distill(5, 190_000, 200_000, 0.8));
     }
 
@@ -354,10 +462,17 @@ Bug is fixed, test passes.
     }
 
     #[test]
-    fn should_distill_exact_min_messages() {
+    fn should_distill_exact_min_plus_tail() {
         let engine = default_engine();
-        // Exactly 6 messages (min_messages) with tokens above threshold
-        assert!(engine.should_distill(6, 180_000, 200_000, 0.8));
+        // Exactly min_messages(6) + verbatim_tail(3) = 9
+        assert!(engine.should_distill(9, 180_000, 200_000, 0.8));
+    }
+
+    #[test]
+    fn should_distill_below_min_plus_tail_returns_false() {
+        let engine = default_engine();
+        // 8 < min_messages(6) + verbatim_tail(3) = 9
+        assert!(!engine.should_distill(8, 190_000, 200_000, 0.8));
     }
 
     // --- build_prompt tests ---
@@ -438,7 +553,9 @@ Bug is fixed, test passes.
 
         let result = result.unwrap();
         assert!(result.summary.contains("Fixed login bug"));
-        assert_eq!(result.messages_distilled, 6);
+        // 6 messages - 3 verbatim_tail = 3 distilled
+        assert_eq!(result.messages_distilled, 3);
+        assert_eq!(result.verbatim_messages.len(), 3);
         assert_eq!(result.distillation_number, 1);
     }
 
@@ -611,5 +728,118 @@ Bug is fixed, test passes.
         }];
         let text = extract_summary_text(&blocks);
         assert_eq!(text, "summary");
+    }
+
+    // --- new config defaults ---
+
+    #[test]
+    fn config_default_sections() {
+        let config = DistillConfig::default();
+        assert_eq!(config.sections.len(), 7);
+        assert_eq!(config.sections[0], DistillSection::Summary);
+        assert_eq!(config.sections[1], DistillSection::TaskContext);
+        assert_eq!(config.sections[2], DistillSection::CompletedWork);
+        assert_eq!(config.sections[3], DistillSection::KeyDecisions);
+        assert_eq!(config.sections[4], DistillSection::CurrentState);
+        assert_eq!(config.sections[5], DistillSection::OpenThreads);
+        assert_eq!(config.sections[6], DistillSection::Corrections);
+    }
+
+    #[test]
+    fn config_default_verbatim_tail() {
+        let config = DistillConfig::default();
+        assert_eq!(config.verbatim_tail, 3);
+    }
+
+    #[test]
+    fn config_default_distillation_model() {
+        let config = DistillConfig::default();
+        assert!(config.distillation_model.is_none());
+    }
+
+    // --- model downshift ---
+
+    #[test]
+    fn build_prompt_uses_distillation_model_when_set() {
+        let config = DistillConfig {
+            distillation_model: Some("claude-haiku-4-5-20251001".to_owned()),
+            ..DistillConfig::default()
+        };
+        let engine = DistillEngine::new(config);
+        let request = engine.build_prompt(&sample_conversation(), "test");
+        assert_eq!(request.model, "claude-haiku-4-5-20251001");
+    }
+
+    #[test]
+    fn build_prompt_falls_back_to_primary_model() {
+        let config = DistillConfig {
+            distillation_model: None,
+            model: "claude-sonnet-4-20250514".to_owned(),
+            ..DistillConfig::default()
+        };
+        let engine = DistillEngine::new(config);
+        let request = engine.build_prompt(&sample_conversation(), "test");
+        assert_eq!(request.model, "claude-sonnet-4-20250514");
+    }
+
+    #[test]
+    fn build_prompt_uses_dynamic_system_prompt() {
+        let config = DistillConfig {
+            sections: vec![DistillSection::Summary, DistillSection::KeyDecisions],
+            ..DistillConfig::default()
+        };
+        let engine = DistillEngine::new(config);
+        let request = engine.build_prompt(&sample_conversation(), "test");
+        let system = request.system.unwrap();
+        assert!(system.contains("## Summary"));
+        assert!(system.contains("## Key Decisions"));
+        assert!(!system.contains("## Open Threads"));
+    }
+
+    // --- verbatim tail ---
+
+    #[tokio::test]
+    async fn distill_preserves_verbatim_messages() {
+        let config = DistillConfig {
+            verbatim_tail: 2,
+            ..DistillConfig::default()
+        };
+        let engine = DistillEngine::new(config);
+        let messages = sample_conversation(); // 6 messages
+        let provider = MockProvider::success(MOCK_SUMMARY);
+
+        let result = engine
+            .distill(&messages, "test-nous", &provider, 1)
+            .await
+            .unwrap();
+
+        assert_eq!(result.messages_distilled, 4); // 6 - 2
+        assert_eq!(result.verbatim_messages.len(), 2);
+    }
+
+    #[test]
+    fn distill_section_equality() {
+        assert_eq!(DistillSection::Summary, DistillSection::Summary);
+        assert_ne!(DistillSection::Summary, DistillSection::TaskContext);
+        assert_eq!(
+            DistillSection::Custom {
+                name: "Test".to_owned(),
+                description: "desc".to_owned()
+            },
+            DistillSection::Custom {
+                name: "Test".to_owned(),
+                description: "desc".to_owned()
+            }
+        );
+        assert_ne!(
+            DistillSection::Custom {
+                name: "A".to_owned(),
+                description: "desc".to_owned()
+            },
+            DistillSection::Custom {
+                name: "B".to_owned(),
+                description: "desc".to_owned()
+            }
+        );
     }
 }

--- a/crates/melete/src/flush.rs
+++ b/crates/melete/src/flush.rs
@@ -1,0 +1,186 @@
+//! Memory flush types for amnesia prevention across distillation boundaries.
+
+use std::fmt::Write;
+
+/// Items to flush to persistent storage before distillation.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct MemoryFlush {
+    /// Key decisions that must survive distillation.
+    pub decisions: Vec<FlushItem>,
+    /// Corrections that prevent repeating mistakes.
+    pub corrections: Vec<FlushItem>,
+    /// Facts learned in this session.
+    pub facts: Vec<FlushItem>,
+    /// Current task state.
+    pub task_state: Option<String>,
+}
+
+/// A single item to flush to persistent storage.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct FlushItem {
+    pub content: String,
+    pub timestamp: String,
+    pub source: FlushSource,
+}
+
+/// How a flush item was identified.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub enum FlushSource {
+    /// Extracted from conversation by LLM.
+    Extracted,
+    /// Explicitly noted by the agent.
+    AgentNote,
+    /// Detected from tool usage patterns.
+    ToolPattern,
+}
+
+impl FlushSource {
+    fn label(&self) -> &str {
+        match self {
+            Self::Extracted => "extracted",
+            Self::AgentNote => "agent_note",
+            Self::ToolPattern => "tool_pattern",
+        }
+    }
+}
+
+impl MemoryFlush {
+    /// Create an empty flush.
+    pub fn empty() -> Self {
+        Self {
+            decisions: vec![],
+            corrections: vec![],
+            facts: vec![],
+            task_state: None,
+        }
+    }
+
+    /// Check if there's anything to flush.
+    pub fn is_empty(&self) -> bool {
+        self.decisions.is_empty()
+            && self.corrections.is_empty()
+            && self.facts.is_empty()
+            && self.task_state.is_none()
+    }
+
+    /// Render as markdown for writing to a memory file.
+    pub fn to_markdown(&self) -> String {
+        let mut out = String::new();
+
+        write_section(&mut out, "Decisions", &self.decisions);
+        write_section(&mut out, "Corrections", &self.corrections);
+        write_section(&mut out, "Facts", &self.facts);
+
+        if let Some(state) = &self.task_state {
+            let _ = writeln!(out, "## Task State\n{state}\n");
+        }
+
+        out.trim_end().to_owned()
+    }
+}
+
+fn write_section(out: &mut String, heading: &str, items: &[FlushItem]) {
+    if items.is_empty() {
+        return;
+    }
+    let _ = writeln!(out, "## {heading}");
+    for item in items {
+        let _ = writeln!(
+            out,
+            "- [{}] {} (source: {})",
+            item.timestamp,
+            item.content,
+            item.source.label()
+        );
+    }
+    out.push('\n');
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn memory_flush_empty_is_empty() {
+        assert!(MemoryFlush::empty().is_empty());
+    }
+
+    #[test]
+    fn memory_flush_with_items_not_empty() {
+        let flush = MemoryFlush {
+            decisions: vec![FlushItem {
+                content: "Use snafu for errors".to_owned(),
+                timestamp: "2026-03-05T19:00:00Z".to_owned(),
+                source: FlushSource::Extracted,
+            }],
+            corrections: vec![],
+            facts: vec![],
+            task_state: None,
+        };
+        assert!(!flush.is_empty());
+    }
+
+    #[test]
+    fn memory_flush_with_task_state_not_empty() {
+        let flush = MemoryFlush {
+            decisions: vec![],
+            corrections: vec![],
+            facts: vec![],
+            task_state: Some("Working on auth module".to_owned()),
+        };
+        assert!(!flush.is_empty());
+    }
+
+    #[test]
+    fn memory_flush_to_markdown_full() {
+        let flush = MemoryFlush {
+            decisions: vec![FlushItem {
+                content: "Use snafu for errors".to_owned(),
+                timestamp: "2026-03-05T19:00:00Z".to_owned(),
+                source: FlushSource::Extracted,
+            }],
+            corrections: vec![FlushItem {
+                content: "Wrong file path corrected".to_owned(),
+                timestamp: "2026-03-05T19:01:00Z".to_owned(),
+                source: FlushSource::AgentNote,
+            }],
+            facts: vec![FlushItem {
+                content: "Config lives in taxis crate".to_owned(),
+                timestamp: "2026-03-05T19:02:00Z".to_owned(),
+                source: FlushSource::ToolPattern,
+            }],
+            task_state: Some("Implementing distillation pipeline".to_owned()),
+        };
+
+        let md = flush.to_markdown();
+        assert!(md.contains("## Decisions"));
+        assert!(md.contains("Use snafu for errors"));
+        assert!(md.contains("(source: extracted)"));
+        assert!(md.contains("## Corrections"));
+        assert!(md.contains("(source: agent_note)"));
+        assert!(md.contains("## Facts"));
+        assert!(md.contains("(source: tool_pattern)"));
+        assert!(md.contains("## Task State"));
+        assert!(md.contains("Implementing distillation pipeline"));
+    }
+
+    #[test]
+    fn memory_flush_to_markdown_omits_empty_sections() {
+        let flush = MemoryFlush {
+            decisions: vec![FlushItem {
+                content: "Use actor model".to_owned(),
+                timestamp: "2026-03-05T19:00:00Z".to_owned(),
+                source: FlushSource::Extracted,
+            }],
+            corrections: vec![],
+            facts: vec![],
+            task_state: None,
+        };
+
+        let md = flush.to_markdown();
+        assert!(md.contains("## Decisions"));
+        assert!(!md.contains("## Corrections"));
+        assert!(!md.contains("## Facts"));
+        assert!(!md.contains("## Task State"));
+    }
+}

--- a/crates/melete/src/lib.rs
+++ b/crates/melete/src/lib.rs
@@ -9,6 +9,7 @@
 
 pub mod distill;
 pub mod error;
+pub mod flush;
 pub mod prompt;
 pub mod types;
 
@@ -16,9 +17,13 @@ pub mod types;
 mod assertions {
     use static_assertions::assert_impl_all;
 
-    use super::distill::{DistillConfig, DistillEngine, DistillResult};
+    use super::distill::{DistillConfig, DistillEngine, DistillResult, DistillSection};
+    use super::flush::{FlushItem, MemoryFlush};
 
     assert_impl_all!(DistillEngine: Send, Sync);
     assert_impl_all!(DistillResult: Send, Sync);
     assert_impl_all!(DistillConfig: Send, Sync);
+    assert_impl_all!(DistillSection: Send, Sync);
+    assert_impl_all!(MemoryFlush: Send, Sync);
+    assert_impl_all!(FlushItem: Send, Sync);
 }

--- a/crates/melete/src/prompt.rs
+++ b/crates/melete/src/prompt.rs
@@ -4,6 +4,9 @@ use std::fmt::Write;
 
 use aletheia_hermeneus::types::{Content, ContentBlock, Message, Role};
 
+use crate::distill::DistillSection;
+
+#[deprecated(note = "use build_system_prompt() with configured sections")]
 pub const DISTILLATION_SYSTEM_PROMPT: &str = "\
 You are a context distillation engine. Your task is to compress a conversation \
 history into a structured summary that preserves all essential information for \
@@ -45,6 +48,32 @@ Rules:
 - Preserve names, identifiers, and numbers exactly
 - Target 400-600 words total
 - Every fact in the summary must be traceable to the conversation";
+
+/// Generate the distillation system prompt from configured sections.
+pub fn build_system_prompt(sections: &[DistillSection]) -> String {
+    let mut prompt = String::from(
+        "You are a context distillation engine. Your task is to compress a conversation \
+         history into a structured summary that preserves all essential information for \
+         continuing the work.\n\n\
+         Produce a summary with EXACTLY these sections:\n\n",
+    );
+
+    for section in sections {
+        let _ = writeln!(prompt, "{}\n{}\n", section.heading(), section.description());
+    }
+
+    prompt.push_str(
+        "Rules:\n\
+         - Use first person: \"I was...\", \"I decided...\"\n\
+         - Be specific: file paths, line numbers, function names, exact values\n\
+         - Preserve names, identifiers, and numbers exactly\n\
+         - Target 400-600 words total\n\
+         - Every fact in the summary must be traceable to the conversation\n\
+         - If a section has no content, omit it entirely (don't include empty sections)",
+    );
+
+    prompt
+}
 
 /// Format conversation messages into readable text for the distillation LLM.
 pub fn format_messages(messages: &[Message], include_tool_calls: bool) -> String {
@@ -126,7 +155,8 @@ mod tests {
     }
 
     #[test]
-    fn system_prompt_contains_all_sections() {
+    #[expect(deprecated)]
+    fn deprecated_constant_still_exists() {
         let sections = [
             "## Summary",
             "## Task Context",
@@ -142,6 +172,43 @@ mod tests {
                 "missing section: {section}"
             );
         }
+    }
+
+    #[test]
+    fn build_system_prompt_default_sections() {
+        let prompt = build_system_prompt(&DistillSection::all_standard());
+        let expected = [
+            "## Summary",
+            "## Task Context",
+            "## Completed Work",
+            "## Key Decisions",
+            "## Current State",
+            "## Open Threads",
+            "## Corrections",
+        ];
+        for section in expected {
+            assert!(prompt.contains(section), "missing section: {section}");
+        }
+    }
+
+    #[test]
+    fn build_system_prompt_custom_section() {
+        let sections = vec![
+            DistillSection::Summary,
+            DistillSection::Custom {
+                name: "Architecture Notes".to_owned(),
+                description: "Record architectural decisions and their trade-offs.".to_owned(),
+            },
+        ];
+        let prompt = build_system_prompt(&sections);
+        assert!(prompt.contains("## Architecture Notes"));
+        assert!(prompt.contains("Record architectural decisions"));
+    }
+
+    #[test]
+    fn build_system_prompt_contains_omit_rule() {
+        let prompt = build_system_prompt(&DistillSection::all_standard());
+        assert!(prompt.contains("omit it entirely"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Add `DistillSection` enum with 7 standard sections + `Custom` variant for configurable distillation output
- `build_system_prompt()` generates prompts dynamically from configured sections (static constant deprecated)
- Model downshift: `distillation_model` field lets expensive primary models distill with cheaper ones
- Verbatim tail preservation: last N messages kept unsummarized across distillation boundaries
- New `flush` module: `MemoryFlush`/`FlushItem`/`FlushSource` types for amnesia prevention

## Files changed

- `crates/melete/src/distill.rs` — `DistillSection` enum, extended `DistillConfig`/`DistillResult`/`DistillEngine`
- `crates/melete/src/prompt.rs` — `build_system_prompt()`, deprecated static constant
- `crates/melete/src/flush.rs` — NEW memory flush types
- `crates/melete/src/lib.rs` — wire flush module + Send/Sync assertions

## Test plan

- [x] 51 melete tests pass (4 new config, 4 model downshift/dynamic prompt, 2 verbatim tail, 1 section equality, 4 flush)
- [x] `cargo clippy --workspace --exclude aletheia-mneme-engine --all-targets -- -D warnings` — zero warnings
- [x] `cargo test --workspace` — all 849+ tests pass