### PR TITLE
feat(daemon): scaffold daemon crate — cron scheduling, task runner, prosoche attention

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,6 +82,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "aletheia-daemon"
+version = "0.1.0"
+dependencies = [
+ "aletheia-koina",
+ "chrono",
+ "cron",
+ "jiff",
+ "serde",
+ "serde_json",
+ "snafu",
+ "static_assertions",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "aletheia-dianoia"
 version = "0.1.0"
 dependencies = [
@@ -1100,6 +1116,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "cron"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5877d3fbf742507b66bc2a1945106bd30dd8504019d596901ddd012a4dd01740"
+dependencies = [
+ "chrono",
+ "once_cell",
+ "winnow",
+]
+
+[[package]]
 name = "crossbeam"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1816,19 +1843,19 @@ checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
 ]
@@ -2371,9 +2398,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.11.0"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "iri-string"
@@ -3620,6 +3647,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4546,7 +4579,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
 dependencies = [
  "fastrand",
- "getrandom 0.4.1",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -4706,9 +4739,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.49.0"
+version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
+checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
 dependencies = [
  "bytes",
  "libc",
@@ -4723,9 +4756,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5118,7 +5151,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b672338555252d43fd2240c714dc444b8c6fb0a5c5335e65a07bba7742735ddb"
 dependencies = [
  "atomic 0.6.1",
- "getrandom 0.4.1",
+ "getrandom 0.4.2",
  "js-sys",
  "serde_core",
  "wasm-bindgen",
@@ -5610,6 +5643,15 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "0.6.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e90edd2ac1aa278a5c4599b1d89cf03074b610800f866d4026dc199d7929a28"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wiremock"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "crates/dianoia",
     "crates/graph-builder",
     "crates/agora",
+    "crates/daemon",
     "crates/hermeneus",
     "crates/integration-tests",
     "crates/koina",
@@ -97,6 +98,8 @@ indexmap = { version = "2", features = ["serde"] }
 ulid = { version = "1", features = ["serde"] }
 
 # Time
+chrono = "0.4"
+cron = "0.15"
 jiff = "0.2"
 
 # Async

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "aletheia-daemon"
+version = "0.1.0"
+description = "Per-nous background task runner — cron scheduling, prosoche attention"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+aletheia-koina = { path = "../koina" }
+chrono = { workspace = true }
+cron = { workspace = true }
+jiff = { workspace = true, features = ["serde"] }
+serde = { workspace = true }
+serde_json = { workspace = true }
+snafu = { workspace = true }
+tokio = { workspace = true, features = ["process"] }
+tracing = { workspace = true }
+
+[dev-dependencies]
+static_assertions = { workspace = true }
+tokio = { workspace = true, features = ["test-util"] }

--- a/crates/daemon/src/error.rs
+++ b/crates/daemon/src/error.rs
@@ -1,0 +1,53 @@
+//! Daemon-specific errors.
+
+use snafu::Snafu;
+
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub))]
+#[non_exhaustive]
+pub enum Error {
+    /// Invalid cron expression.
+    #[snafu(display("invalid cron expression: {expression}"))]
+    InvalidCron {
+        expression: String,
+        source: cron::error::Error,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    /// Task execution failed.
+    #[snafu(display("task execution failed for {task_id}: {reason}"))]
+    TaskFailed {
+        task_id: String,
+        reason: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    /// Shell command execution failed.
+    #[snafu(display("command execution failed: {command}"))]
+    CommandFailed {
+        command: String,
+        source: std::io::Error,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    /// Task disabled after consecutive failures.
+    #[snafu(display("task {task_id} disabled after {failures} consecutive failures"))]
+    TaskDisabled {
+        task_id: String,
+        failures: u32,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    /// Shutdown signal received.
+    #[snafu(display("shutdown signal received"))]
+    Shutdown {
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+}
+
+pub type Result<T> = std::result::Result<T, Error>;

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -1,0 +1,19 @@
+//! aletheia-daemon — per-nous background task runner
+//!
+//! Daemon (δαίμων) — "attendant spirit." The quiet persistent presence that
+//! keeps things running in the background. Manages scheduled tasks, periodic
+//! attention checks (prosoche), and maintenance cycles for each nous.
+
+pub mod error;
+pub mod prosoche;
+pub mod runner;
+pub mod schedule;
+
+#[cfg(test)]
+mod assertions {
+    use static_assertions::assert_impl_all;
+
+    assert_impl_all!(super::runner::TaskRunner: Send);
+    assert_impl_all!(super::prosoche::ProsocheCheck: Send, Sync);
+    assert_impl_all!(super::schedule::TaskDef: Send, Sync);
+}

--- a/crates/daemon/src/prosoche.rs
+++ b/crates/daemon/src/prosoche.rs
@@ -1,0 +1,78 @@
+//! Prosoche (προσοχή) — "directed attention." Periodic check-in that monitors
+//! calendar, tasks, and system health for a nous.
+
+use serde::{Deserialize, Serialize};
+
+/// Prosoche attention check runner.
+#[derive(Debug, Clone)]
+pub struct ProsocheCheck {
+    nous_id: String,
+}
+
+/// Result of a prosoche check.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProsocheResult {
+    pub items: Vec<AttentionItem>,
+    pub checked_at: String,
+}
+
+/// A single item requiring attention.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AttentionItem {
+    pub category: AttentionCategory,
+    pub summary: String,
+    pub urgency: Urgency,
+}
+
+/// Categories of attention items.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum AttentionCategory {
+    Calendar,
+    Task,
+    SystemHealth,
+    Custom(String),
+}
+
+/// Urgency level for attention items.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Urgency {
+    Low,
+    Medium,
+    High,
+    Critical,
+}
+
+impl ProsocheCheck {
+    pub fn new(nous_id: impl Into<String>) -> Self {
+        Self {
+            nous_id: nous_id.into(),
+        }
+    }
+
+    /// Run the attention check. Returns items needing attention.
+    ///
+    /// Currently returns an empty result — actual checks (gcal, taskwarrior,
+    /// system health) require tool execution which will be wired when daemon
+    /// integrates with the nous pipeline.
+    #[expect(clippy::unused_async, reason = "will perform async I/O once wired to nous pipeline")]
+    pub async fn run(&self) -> crate::error::Result<ProsocheResult> {
+        tracing::info!(nous_id = %self.nous_id, "prosoche check completed");
+        Ok(ProsocheResult {
+            items: Vec::new(),
+            checked_at: jiff::Timestamp::now().to_string(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn prosoche_returns_empty_result() {
+        let check = ProsocheCheck::new("test-nous");
+        let result = check.run().await.expect("should succeed");
+        assert!(result.items.is_empty());
+        assert!(!result.checked_at.is_empty());
+    }
+}

--- a/crates/daemon/src/runner.rs
+++ b/crates/daemon/src/runner.rs
@@ -1,0 +1,405 @@
+//! Per-nous background task runner with cron scheduling, failure tracking, and graceful shutdown.
+
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+use snafu::ResultExt;
+use tokio::sync::watch;
+
+use crate::error::{self, Result};
+use crate::prosoche::ProsocheCheck;
+use crate::schedule::{BuiltinTask, Schedule, TaskAction, TaskDef, TaskStatus};
+
+/// Per-nous background task runner.
+pub struct TaskRunner {
+    nous_id: String,
+    tasks: Vec<RegisteredTask>,
+    shutdown: watch::Receiver<bool>,
+}
+
+struct RegisteredTask {
+    def: TaskDef,
+    next_run: Option<jiff::Timestamp>,
+    last_run: Option<jiff::Timestamp>,
+    run_count: u64,
+    consecutive_failures: u32,
+}
+
+/// Outcome of executing a single task action.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExecutionResult {
+    pub success: bool,
+    pub output: Option<String>,
+}
+
+impl TaskRunner {
+    pub fn new(nous_id: impl Into<String>, shutdown: watch::Receiver<bool>) -> Self {
+        Self {
+            nous_id: nous_id.into(),
+            tasks: Vec::new(),
+            shutdown,
+        }
+    }
+
+    /// Register a task. Startup tasks are marked for immediate execution.
+    pub fn register(&mut self, task: TaskDef) {
+        let next_run = match &task.schedule {
+            Schedule::Startup => Some(jiff::Timestamp::now()),
+            other => other.next_run().unwrap_or(None),
+        };
+
+        tracing::info!(
+            nous_id = %self.nous_id,
+            task_id = %task.id,
+            task_name = %task.name,
+            "registered task"
+        );
+
+        self.tasks.push(RegisteredTask {
+            def: task,
+            next_run,
+            last_run: None,
+            run_count: 0,
+            consecutive_failures: 0,
+        });
+    }
+
+    /// Run the event loop. Checks for due tasks every second, executes them.
+    /// Returns when shutdown signal is received.
+    pub async fn run(&mut self) {
+        tracing::info!(nous_id = %self.nous_id, tasks = self.tasks.len(), "daemon started");
+
+        let mut interval = tokio::time::interval(Duration::from_secs(1));
+
+        loop {
+            tokio::select! {
+                _ = interval.tick() => {
+                    self.tick().await;
+                }
+                result = self.shutdown.changed() => {
+                    if result.is_err() || *self.shutdown.borrow() {
+                        tracing::info!(nous_id = %self.nous_id, "daemon shutting down");
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    /// Get status of all registered tasks.
+    pub fn status(&self) -> Vec<TaskStatus> {
+        self.tasks
+            .iter()
+            .map(|t| TaskStatus {
+                id: t.def.id.clone(),
+                name: t.def.name.clone(),
+                enabled: t.def.enabled,
+                next_run: t.next_run.map(|ts| ts.to_string()),
+                last_run: t.last_run.map(|ts| ts.to_string()),
+                run_count: t.run_count,
+                consecutive_failures: t.consecutive_failures,
+            })
+            .collect()
+    }
+
+    async fn tick(&mut self) {
+        let now = jiff::Timestamp::now();
+
+        for task in &mut self.tasks {
+            if !task.def.enabled {
+                continue;
+            }
+
+            let Some(next) = task.next_run else {
+                continue;
+            };
+
+            if next > now {
+                continue;
+            }
+
+            if !Schedule::in_window(task.def.active_window) {
+                continue;
+            }
+
+            let result = execute_action(&task.def.action, &task.def.nous_id).await;
+            task.last_run = Some(now);
+
+            match result {
+                Ok(_) => {
+                    task.run_count += 1;
+                    task.consecutive_failures = 0;
+                    task.next_run = task.def.schedule.next_run().unwrap_or(None);
+                    tracing::debug!(
+                        task_id = %task.def.id,
+                        run_count = task.run_count,
+                        "task completed"
+                    );
+                }
+                Err(e) => {
+                    task.consecutive_failures += 1;
+                    tracing::warn!(
+                        task_id = %task.def.id,
+                        failures = task.consecutive_failures,
+                        error = %e,
+                        "task failed"
+                    );
+
+                    if task.consecutive_failures >= 3 {
+                        task.def.enabled = false;
+                        tracing::warn!(
+                            task_id = %task.def.id,
+                            failures = task.consecutive_failures,
+                            "task disabled after consecutive failures"
+                        );
+                    } else {
+                        task.next_run = task.def.schedule.next_run().unwrap_or(None);
+                    }
+                }
+            }
+        }
+    }
+}
+
+async fn execute_action(action: &TaskAction, nous_id: &str) -> Result<ExecutionResult> {
+    match action {
+        TaskAction::Command(cmd) => execute_command(cmd).await,
+        TaskAction::Tool { name, .. } => {
+            tracing::info!(
+                nous_id = %nous_id,
+                tool = %name,
+                "tool execution not yet wired — requires organon integration"
+            );
+            Ok(ExecutionResult {
+                success: true,
+                output: None,
+            })
+        }
+        TaskAction::Prompt(prompt) => {
+            tracing::info!(
+                nous_id = %nous_id,
+                prompt_len = prompt.len(),
+                "prompt injection not yet wired — requires nous pipeline access"
+            );
+            Ok(ExecutionResult {
+                success: true,
+                output: None,
+            })
+        }
+        TaskAction::Builtin(builtin) => execute_builtin(builtin, nous_id).await,
+    }
+}
+
+async fn execute_command(cmd: &str) -> Result<ExecutionResult> {
+    let output = tokio::process::Command::new("sh")
+        .args(["-c", cmd])
+        .output()
+        .await
+        .context(error::CommandFailedSnafu {
+            command: cmd.to_owned(),
+        })?;
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    if output.status.success() {
+        tracing::debug!(cmd = %cmd, stdout = %stdout, "command succeeded");
+        Ok(ExecutionResult {
+            success: true,
+            output: Some(stdout.into_owned()),
+        })
+    } else {
+        let reason = if stderr.is_empty() {
+            format!("exit code: {}", output.status)
+        } else {
+            stderr.into_owned()
+        };
+
+        error::TaskFailedSnafu {
+            task_id: cmd.to_owned(),
+            reason,
+        }
+        .fail()
+    }
+}
+
+async fn execute_builtin(builtin: &BuiltinTask, nous_id: &str) -> Result<ExecutionResult> {
+    match builtin {
+        BuiltinTask::Prosoche => {
+            let check = ProsocheCheck::new(nous_id);
+            let result = check.run().await?;
+            Ok(ExecutionResult {
+                success: true,
+                output: Some(format!("{} items", result.items.len())),
+            })
+        }
+        BuiltinTask::GraphMaintenance => {
+            tracing::info!(
+                nous_id = %nous_id,
+                "graph maintenance not yet implemented — requires mneme integration"
+            );
+            Ok(ExecutionResult {
+                success: true,
+                output: None,
+            })
+        }
+        BuiltinTask::MemoryConsolidation => {
+            tracing::info!(
+                nous_id = %nous_id,
+                "memory consolidation not yet implemented — requires melete integration"
+            );
+            Ok(ExecutionResult {
+                success: true,
+                output: None,
+            })
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_echo_task(id: &str) -> TaskDef {
+        TaskDef {
+            id: id.to_owned(),
+            name: format!("Test task {id}"),
+            nous_id: "test-nous".to_owned(),
+            schedule: Schedule::Interval(Duration::from_secs(60)),
+            action: TaskAction::Command("echo hello".to_owned()),
+            enabled: true,
+            active_window: None,
+        }
+    }
+
+    #[test]
+    fn register_shows_in_status() {
+        let (_tx, rx) = watch::channel(false);
+        let mut runner = TaskRunner::new("test-nous", rx);
+        runner.register(make_echo_task("task-1"));
+        runner.register(make_echo_task("task-2"));
+
+        let statuses = runner.status();
+        assert_eq!(statuses.len(), 2);
+        assert_eq!(statuses[0].id, "task-1");
+        assert_eq!(statuses[1].id, "task-2");
+        assert!(statuses[0].enabled);
+    }
+
+    #[tokio::test]
+    async fn shutdown_exits_run_loop() {
+        let (tx, rx) = watch::channel(false);
+        let mut runner = TaskRunner::new("test-nous", rx);
+
+        let handle = tokio::spawn(async move {
+            runner.run().await;
+        });
+
+        // Signal shutdown
+        tx.send(true).expect("send shutdown");
+
+        // Verify it exits within a reasonable time
+        let result = tokio::time::timeout(Duration::from_secs(5), handle).await;
+        assert!(result.is_ok(), "runner should exit on shutdown signal");
+    }
+
+    #[tokio::test]
+    async fn task_disabled_after_consecutive_failures() {
+        tokio::time::pause();
+
+        let (_tx, rx) = watch::channel(false);
+        let mut runner = TaskRunner::new("test-nous", rx);
+
+        // Register a task that will fail (nonexistent command)
+        let task = TaskDef {
+            id: "failing-task".to_owned(),
+            name: "Failing task".to_owned(),
+            nous_id: "test-nous".to_owned(),
+            schedule: Schedule::Interval(Duration::from_millis(10)),
+            action: TaskAction::Command(
+                "exit 1".to_owned(),
+            ),
+            enabled: true,
+            active_window: None,
+        };
+        runner.register(task);
+
+        // Force next_run to now so it fires immediately
+        runner.tasks[0].next_run = Some(jiff::Timestamp::now());
+
+        // Run 3 ticks — each should fail and increment consecutive_failures
+        for _ in 0..3 {
+            runner.tasks[0].next_run = Some(
+                jiff::Timestamp::now()
+                    .checked_add(jiff::SignedDuration::from_secs(-1))
+                    .unwrap(),
+            );
+            runner.tick().await;
+        }
+
+        let statuses = runner.status();
+        assert!(!statuses[0].enabled, "task should be disabled after 3 failures");
+        assert_eq!(statuses[0].consecutive_failures, 3);
+    }
+
+    #[tokio::test]
+    async fn successful_command_resets_failures() {
+        let (_tx, rx) = watch::channel(false);
+        let mut runner = TaskRunner::new("test-nous", rx);
+
+        let task = TaskDef {
+            id: "echo-task".to_owned(),
+            name: "Echo task".to_owned(),
+            nous_id: "test-nous".to_owned(),
+            schedule: Schedule::Interval(Duration::from_secs(60)),
+            action: TaskAction::Command("echo ok".to_owned()),
+            enabled: true,
+            active_window: None,
+        };
+        runner.register(task);
+
+        // Set up as if it had 2 prior failures
+        runner.tasks[0].consecutive_failures = 2;
+        runner.tasks[0].next_run = Some(
+            jiff::Timestamp::now()
+                .checked_add(jiff::SignedDuration::from_secs(-1))
+                .unwrap(),
+        );
+
+        runner.tick().await;
+
+        let statuses = runner.status();
+        assert_eq!(statuses[0].consecutive_failures, 0);
+        assert_eq!(statuses[0].run_count, 1);
+        assert!(statuses[0].enabled);
+    }
+
+    #[tokio::test]
+    async fn builtin_prosoche_executes() {
+        let (_tx, rx) = watch::channel(false);
+        let mut runner = TaskRunner::new("test-nous", rx);
+
+        let task = TaskDef {
+            id: "prosoche".to_owned(),
+            name: "Prosoche check".to_owned(),
+            nous_id: "test-nous".to_owned(),
+            schedule: Schedule::Interval(Duration::from_secs(60)),
+            action: TaskAction::Builtin(BuiltinTask::Prosoche),
+            enabled: true,
+            active_window: None,
+        };
+        runner.register(task);
+
+        runner.tasks[0].next_run = Some(
+            jiff::Timestamp::now()
+                .checked_add(jiff::SignedDuration::from_secs(-1))
+                .unwrap(),
+        );
+
+        runner.tick().await;
+
+        let statuses = runner.status();
+        assert_eq!(statuses[0].run_count, 1);
+        assert_eq!(statuses[0].consecutive_failures, 0);
+    }
+}

--- a/crates/daemon/src/schedule.rs
+++ b/crates/daemon/src/schedule.rs
@@ -1,0 +1,217 @@
+//! Scheduling primitives for background tasks.
+
+use std::str::FromStr;
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+use snafu::ResultExt;
+
+use crate::error::{self, Result};
+
+/// When a task should run.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum Schedule {
+    /// Cron expression (e.g., `"0 */45 8-23 * * *"` for every 45min 8am-11pm).
+    Cron(String),
+    /// Fixed interval.
+    Interval(Duration),
+    /// Run once at a specific time.
+    Once(jiff::Timestamp),
+    /// Run once at startup.
+    Startup,
+}
+
+/// A registered background task definition.
+#[derive(Debug, Clone)]
+pub struct TaskDef {
+    /// Unique task identifier.
+    pub id: String,
+    /// Human-readable name.
+    pub name: String,
+    /// Which nous this task belongs to.
+    pub nous_id: String,
+    /// When to run.
+    pub schedule: Schedule,
+    /// What to run.
+    pub action: TaskAction,
+    /// Whether the task is currently enabled.
+    pub enabled: bool,
+    /// Active time window (optional): `(start_hour, end_hour)` in local time.
+    pub active_window: Option<(u8, u8)>,
+}
+
+/// What a background task does.
+#[derive(Debug, Clone)]
+pub enum TaskAction {
+    /// Execute a shell command.
+    Command(String),
+    /// Call a tool by name with JSON arguments.
+    Tool {
+        name: String,
+        args: serde_json::Value,
+    },
+    /// Send a prompt to the nous for processing.
+    Prompt(String),
+    /// Run a built-in maintenance function.
+    Builtin(BuiltinTask),
+}
+
+/// Built-in maintenance tasks.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum BuiltinTask {
+    /// Prosoche attention check.
+    Prosoche,
+    /// Knowledge graph maintenance (dedup, orphan purge).
+    GraphMaintenance,
+    /// Memory consolidation.
+    MemoryConsolidation,
+}
+
+impl Schedule {
+    /// Calculate the next run time from now.
+    ///
+    /// Returns `None` for `Startup` (already ran) or `Once` with a past timestamp.
+    pub fn next_run(&self) -> Result<Option<jiff::Timestamp>> {
+        match self {
+            Self::Cron(expr) => {
+                let schedule = cron::Schedule::from_str(expr).context(
+                    error::InvalidCronSnafu {
+                        expression: expr.clone(),
+                    },
+                )?;
+                let next = schedule.upcoming(chrono::Utc).next();
+                Ok(next.map(|dt| {
+                    jiff::Timestamp::from_second(dt.timestamp())
+                        .expect("chrono timestamp in valid range")
+                }))
+            }
+            Self::Interval(duration) => {
+                let span = jiff::SignedDuration::from_nanos(
+                    i64::try_from(duration.as_nanos())
+                        .expect("interval fits in i64 nanos"),
+                );
+                let next = jiff::Timestamp::now().checked_add(span).expect("interval addition overflow");
+                Ok(Some(next))
+            }
+            Self::Once(ts) => {
+                if *ts > jiff::Timestamp::now() {
+                    Ok(Some(*ts))
+                } else {
+                    Ok(None)
+                }
+            }
+            Self::Startup => Ok(None),
+        }
+    }
+
+    /// Check if the current time is within the active window.
+    ///
+    /// `None` window means always active. Handles overnight windows (e.g., 22-06).
+    pub fn in_window(window: Option<(u8, u8)>) -> bool {
+        let Some((start, end)) = window else {
+            return true;
+        };
+
+        let now = jiff::Zoned::now();
+        let hour = u8::try_from(now.hour()).expect("hour in u8 range");
+
+        if start <= end {
+            // Normal window: e.g., 9-17
+            hour >= start && hour < end
+        } else {
+            // Overnight window: e.g., 22-06
+            hour >= start || hour < end
+        }
+    }
+}
+
+/// Status snapshot of a registered task.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TaskStatus {
+    pub id: String,
+    pub name: String,
+    pub enabled: bool,
+    pub next_run: Option<String>,
+    pub last_run: Option<String>,
+    pub run_count: u64,
+    pub consecutive_failures: u32,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn interval_next_run_returns_future() {
+        let schedule = Schedule::Interval(Duration::from_secs(10));
+        let next = schedule.next_run().expect("no error").expect("should have next");
+        assert!(next > jiff::Timestamp::now());
+    }
+
+    #[test]
+    fn once_future_returns_some() {
+        let future = jiff::Timestamp::now()
+            .checked_add(jiff::SignedDuration::from_secs(3600))
+            .unwrap();
+        let schedule = Schedule::Once(future);
+        let next = schedule.next_run().expect("no error").expect("should have next");
+        assert_eq!(next, future);
+    }
+
+    #[test]
+    fn once_past_returns_none() {
+        let past = jiff::Timestamp::now()
+            .checked_add(jiff::SignedDuration::from_secs(-3600))
+            .unwrap();
+        let schedule = Schedule::Once(past);
+        assert!(schedule.next_run().expect("no error").is_none());
+    }
+
+    #[test]
+    fn startup_returns_none() {
+        let schedule = Schedule::Startup;
+        assert!(schedule.next_run().expect("no error").is_none());
+    }
+
+    #[test]
+    fn cron_valid_expression_parses() {
+        let schedule = Schedule::Cron("0 0 * * * *".to_owned());
+        let next = schedule.next_run().expect("no error");
+        assert!(next.is_some(), "valid cron should produce a next run time");
+    }
+
+    #[test]
+    fn cron_invalid_expression_errors() {
+        let schedule = Schedule::Cron("not a cron expression".to_owned());
+        assert!(schedule.next_run().is_err());
+    }
+
+    #[test]
+    fn in_window_none_always_active() {
+        assert!(Schedule::in_window(None));
+    }
+
+    #[test]
+    fn in_window_full_day() {
+        // 0-24 should always be active (every hour is >= 0 and < 24)
+        assert!(Schedule::in_window(Some((0, 24))));
+    }
+
+    #[test]
+    fn in_window_overnight_covers_late_or_early() {
+        // Overnight window 22-06: hour >= 22 OR hour < 6
+        let now_hour = u8::try_from(jiff::Zoned::now().hour()).unwrap();
+        let result = Schedule::in_window(Some((22, 6)));
+        let expected = !(6..22).contains(&now_hour);
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn in_window_daytime_range() {
+        // Daytime window 9-17: hour >= 9 AND hour < 17
+        let now_hour = u8::try_from(jiff::Zoned::now().hour()).unwrap();
+        let result = Schedule::in_window(Some((9, 17)));
+        let expected = (9..17).contains(&now_hour);
+        assert_eq!(result, expected);
+    }
+}


### PR DESCRIPTION
## Summary

- New `aletheia-daemon` crate: per-nous background task runner bringing scheduled operations into the binary
- Schedule types: `Cron` (via `cron` crate), `Interval`, `Once`, `Startup` with `next_run()` calculation and active time window support (including overnight windows)
- `TaskRunner`: 1-second tick loop with automatic failure tracking (disables task after 3 consecutive failures), graceful shutdown via `watch` channel
- `TaskAction` variants: `Command` (shell exec via `tokio::process`), `Tool`/`Prompt` (stubbed for future organon/nous wiring), `Builtin` (Prosoche, GraphMaintenance, MemoryConsolidation)
- `ProsocheCheck`: attention check stub returning empty result until nous pipeline integration
- 16 tests covering schedule parsing, window logic, runner lifecycle, failure tracking, and prosoche stub

## Scope

M4 Phase 4.2 foundational work. Creates the crate skeleton and core scheduling/execution primitives. Does NOT wire daemon into `main.rs` or `NousManager` — that's future work.

## New dependencies

- `cron = "0.15"` — cron expression parsing
- `chrono = "0.4"` — required by `cron` crate, used at boundary for timestamp conversion to jiff

## Test plan

- [x] `cargo clippy --workspace --exclude aletheia-mneme-engine --all-targets -- -D warnings` (zero warnings)
- [x] `cargo test -p aletheia-daemon` (16 tests pass)
- [x] `cargo test --workspace` (all tests pass)
- [x] `git diff --stat` confirms only daemon crate + workspace root Cargo.toml/Cargo.lock modified