### PR TITLE
refactor(tui): decompose app.rs into state/ and update/ modules

### DIFF
--- a/tui/src/app.rs
+++ b/tui/src/app.rs
@@ -15,108 +15,15 @@ use crate::config::Config;
 use crate::events::{Event, StreamEvent};
 use crate::msg::{ErrorToast, Msg, OverlayKind};
 use crate::theme::ThemePalette;
+use crate::update::extract_text_content;
 use crate::view;
 
-// --- Agent state ---
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum AgentStatus {
-    Idle,
-    Working,
-    Streaming,
-    Compacting,
-}
-
-#[derive(Debug, Clone)]
-pub struct AgentState {
-    pub id: String,
-    pub name: String,
-    pub emoji: Option<String>,
-    pub status: AgentStatus,
-    pub active_tool: Option<String>,
-    pub tool_started_at: Option<std::time::Instant>,
-    pub sessions: Vec<Session>,
-    pub compaction_stage: Option<String>,
-    /// Indicates this agent completed a turn while not focused.
-    /// Cleared when the user switches to this agent.
-    pub has_notification: bool,
-}
-
-// --- Tool call info for inline rendering ---
-
-#[derive(Debug, Clone)]
-pub struct ToolCallInfo {
-    pub name: String,
-    pub duration_ms: Option<u64>,
-    pub is_error: bool,
-}
-
-// --- Saved scroll state per agent ---
-
-#[derive(Debug, Clone, Default)]
-struct SavedScrollState {
-    scroll_offset: usize,
-    auto_scroll: bool,
-}
-
-// --- Chat message ---
-
-#[derive(Debug, Clone)]
-pub struct ChatMessage {
-    pub role: String,
-    pub text: String,
-    pub timestamp: Option<String>,
-    pub model: Option<String>,
-    pub is_streaming: bool,
-    pub tool_calls: Vec<ToolCallInfo>,
-}
-
-// --- Input state ---
-
-#[derive(Debug, Default)]
-pub struct InputState {
-    pub text: String,
-    pub cursor: usize,
-    pub history: Vec<String>,
-    pub history_index: Option<usize>,
-}
-
-// --- Overlay state ---
-
-#[derive(Debug)]
-pub enum Overlay {
-    Help,
-    AgentPicker { cursor: usize },
-    SystemStatus,
-    ToolApproval(ToolApprovalOverlay),
-    PlanApproval(PlanApprovalOverlay),
-}
-
-#[derive(Debug)]
-pub struct ToolApprovalOverlay {
-    pub turn_id: String,
-    pub tool_id: String,
-    pub tool_name: String,
-    pub input: serde_json::Value,
-    pub risk: String,
-    pub reason: String,
-}
-
-#[derive(Debug)]
-pub struct PlanApprovalOverlay {
-    pub plan_id: String,
-    pub steps: Vec<PlanStepApproval>,
-    pub total_cost_cents: u32,
-    pub cursor: usize,
-}
-
-#[derive(Debug)]
-pub struct PlanStepApproval {
-    pub id: u32,
-    pub label: String,
-    pub role: String,
-    pub checked: bool,
-}
+#[allow(unused_imports)]
+pub use crate::state::{
+    AgentState, AgentStatus, ChatMessage, InputState, Overlay, PlanApprovalOverlay,
+    PlanStepApproval, TabCompletion, ToolApprovalOverlay, ToolCallInfo,
+};
+use crate::state::SavedScrollState;
 
 // --- App ---
 
@@ -149,7 +56,7 @@ pub struct App {
     pub streaming_text: String,
     pub streaming_thinking: String,
     pub streaming_tool_calls: Vec<ToolCallInfo>,
-    stream_rx: Option<mpsc::Receiver<StreamEvent>>,
+    pub(crate) stream_rx: Option<mpsc::Receiver<StreamEvent>>,
 
     // SSE
     sse: Option<SseConnection>,
@@ -176,14 +83,6 @@ pub struct App {
     // Terminal size for responsive layout
     pub terminal_width: u16,
     pub terminal_height: u16,
-}
-
-#[derive(Debug)]
-pub struct TabCompletion {
-    pub prefix: String,
-    pub candidates: Vec<String>,
-    pub index: usize,
-    pub insert_start: usize,
 }
 
 impl App {
@@ -227,14 +126,12 @@ impl App {
             terminal_height: 40,
         };
 
-        // Connect and authenticate
         app.connect().await?;
 
         Ok(app)
     }
 
     async fn connect(&mut self) -> Result<()> {
-        // Health check
         if !self.client.health().await.unwrap_or(false) {
             anyhow::bail!(
                 "cannot reach gateway at {}. Is it running?",
@@ -242,7 +139,6 @@ impl App {
             );
         }
 
-        // Auth mode detection
         match self.client.auth_mode().await {
             Ok(mode) => match mode.mode.as_str() {
                 "none" => {
@@ -256,12 +152,10 @@ impl App {
                     }
                 }
                 _ => {
-                    // session/password — try login if we have no token
                     if self.client.token().is_none() {
                         anyhow::bail!(
                             "gateway requires authentication. Pass --token or set ALETHEIA_TOKEN"
                         );
-                        // TODO: interactive login prompt (requires raw terminal handling before ratatui init)
                     }
                 }
             },
@@ -270,7 +164,6 @@ impl App {
             }
         }
 
-        // Load agents
         let agents = self.client.agents().await?;
         self.agents = agents
             .into_iter()
@@ -287,30 +180,25 @@ impl App {
             })
             .collect();
 
-        // Focus default agent or first
         self.focused_agent = self
             .config
             .default_agent
             .clone()
             .or_else(|| self.agents.first().map(|a| a.id.clone()));
 
-        // Load sessions for focused agent
         if let Some(ref agent_id) = self.focused_agent {
             if let Ok(sessions) = self.client.sessions(agent_id).await {
                 if let Some(agent) = self.agents.iter_mut().find(|a| a.id == *agent_id) {
                     agent.sessions = sessions;
                 }
             }
-            // Load history for the first/default session
             self.load_focused_session().await;
         }
 
-        // Load daily cost
         if let Ok(cents) = self.client.today_cost_cents().await {
             self.daily_cost_cents = cents;
         }
 
-        // Start SSE connection
         self.sse = Some(SseConnection::connect(
             &self.config.url,
             self.client.token(),
@@ -319,13 +207,12 @@ impl App {
         Ok(())
     }
 
-    async fn load_focused_session(&mut self) {
+    pub(crate) async fn load_focused_session(&mut self) {
         let agent_id = match &self.focused_agent {
             Some(id) => id.clone(),
             None => return,
         };
 
-        // Ensure sessions are loaded for this agent (lazy fetch on first switch)
         {
             let needs_load = self
                 .agents
@@ -348,13 +235,9 @@ impl App {
             None => return,
         };
 
-        // Use explicit session, or find the most recently active primary session
         let session = if let Some(ref key) = self.config.default_session {
             agent.sessions.iter().find(|s| s.key == *key)
         } else {
-            // Pick the most recently updated non-background session.
-            // messageCount is unreliable after distillation (resets to post-compact count),
-            // so updatedAt is the true indicator of the active conversation.
             agent
                 .sessions
                 .iter()
@@ -384,7 +267,6 @@ impl App {
                     self.messages = history
                         .into_iter()
                         .filter_map(|m| {
-                            // Only show user and assistant messages in chat
                             if m.role != "user" && m.role != "assistant" {
                                 return None;
                             }
@@ -444,13 +326,11 @@ impl App {
                 MouseEventKind::ScrollUp => Some(Msg::ScrollUp),
                 MouseEventKind::ScrollDown => Some(Msg::ScrollDown),
                 MouseEventKind::Down(MouseButton::Left) => {
-                    // Check if click is in sidebar area
                     let sidebar = crate::view::SIDEBAR_RECT.load_rect();
                     if sidebar.width > 0
                         && mouse.column < sidebar.x + sidebar.width
                         && mouse.row >= sidebar.y
                     {
-                        // Each agent takes 1-2 rows, starting after 1 row padding
                         let mut y = sidebar.y + 1;
                         for agent in &self.agents {
                             let row_count = if agent.active_tool.is_some()
@@ -476,21 +356,17 @@ impl App {
     }
 
     fn map_key(&self, key: KeyEvent) -> Option<Msg> {
-        // If overlay is open, handle overlay keys
         if self.overlay.is_some() {
             return self.map_overlay_key(key);
         }
 
         match (key.modifiers, key.code) {
-            // Quit
             (KeyModifiers::CONTROL, KeyCode::Char('c'))
             | (KeyModifiers::CONTROL, KeyCode::Char('q')) => Some(Msg::Quit),
 
-            // Layout
             (KeyModifiers::CONTROL, KeyCode::Char('f')) => Some(Msg::ToggleSidebar),
             (KeyModifiers::CONTROL, KeyCode::Char('t')) => Some(Msg::ToggleThinking),
 
-            // Overlays
             (_, KeyCode::F(1)) => Some(Msg::OpenOverlay(OverlayKind::Help)),
             (KeyModifiers::CONTROL, KeyCode::Char('a')) => {
                 Some(Msg::OpenOverlay(OverlayKind::AgentPicker))
@@ -500,22 +376,19 @@ impl App {
             }
             (KeyModifiers::CONTROL, KeyCode::Char('n')) => Some(Msg::NewSession),
 
-            // Tab completion for @mentions
             (_, KeyCode::Tab) => {
                 if self.input.text.contains('@') {
-                    Some(Msg::CharInput('\t')) // Signal tab-complete via special char
+                    Some(Msg::CharInput('\t'))
                 } else {
                     None
                 }
             }
 
-            // Scroll
             (_, KeyCode::PageUp) => Some(Msg::ScrollPageUp),
             (_, KeyCode::PageDown) => Some(Msg::ScrollPageDown),
             (KeyModifiers::SHIFT, KeyCode::Up) => Some(Msg::ScrollUp),
             (KeyModifiers::SHIFT, KeyCode::Down) => Some(Msg::ScrollDown),
 
-            // Input editing
             (_, KeyCode::Enter) => Some(Msg::Submit),
             (_, KeyCode::Backspace) => Some(Msg::Backspace),
             (_, KeyCode::Delete) => Some(Msg::Delete),
@@ -530,8 +403,9 @@ impl App {
             (KeyModifiers::CONTROL, KeyCode::Char('y')) => Some(Msg::CopyLastResponse),
             (KeyModifiers::CONTROL, KeyCode::Char('e')) => Some(Msg::ComposeInEditor),
 
-            // Char input
-            (KeyModifiers::NONE | KeyModifiers::SHIFT, KeyCode::Char(c)) => Some(Msg::CharInput(c)),
+            (KeyModifiers::NONE | KeyModifiers::SHIFT, KeyCode::Char(c)) => {
+                Some(Msg::CharInput(c))
+            }
 
             _ => None,
         }
@@ -544,30 +418,28 @@ impl App {
             (_, KeyCode::Down) => Some(Msg::OverlayDown),
             (_, KeyCode::Enter) => Some(Msg::OverlaySelect),
 
-            // Tool approval shortcuts
             (_, KeyCode::Char('a' | 'A')) if self.is_tool_approval_overlay() => {
-                Some(Msg::OverlaySelect) // Approve
+                Some(Msg::OverlaySelect)
             }
             (_, KeyCode::Char('d' | 'D')) if self.is_tool_approval_overlay() => {
-                Some(Msg::CloseOverlay) // Deny (handled in update)
+                Some(Msg::CloseOverlay)
             }
 
-            // Plan approval shortcuts
             (_, KeyCode::Char(' ')) if self.is_plan_approval_overlay() => {
-                Some(Msg::OverlaySelect) // Toggle step
+                Some(Msg::OverlaySelect)
             }
             (_, KeyCode::Char('a' | 'A')) if self.is_plan_approval_overlay() => {
-                Some(Msg::OverlaySelect) // Approve all
+                Some(Msg::OverlaySelect)
             }
             (_, KeyCode::Char('c' | 'C')) if self.is_plan_approval_overlay() => {
-                Some(Msg::CloseOverlay) // Cancel
+                Some(Msg::CloseOverlay)
             }
 
             _ => None,
         }
     }
 
-    fn is_tool_approval_overlay(&self) -> bool {
+    pub(crate) fn is_tool_approval_overlay(&self) -> bool {
         matches!(&self.overlay, Some(Overlay::ToolApproval(_)))
     }
 
@@ -608,7 +480,9 @@ impl App {
                 tool_name,
                 error,
             },
-            SseEvent::StatusUpdate { nous_id, status } => Msg::SseStatusUpdate { nous_id, status },
+            SseEvent::StatusUpdate { nous_id, status } => {
+                Msg::SseStatusUpdate { nous_id, status }
+            }
             SseEvent::SessionCreated {
                 nous_id,
                 session_id,
@@ -626,7 +500,7 @@ impl App {
             SseEvent::DistillBefore { nous_id } => Msg::SseDistillBefore { nous_id },
             SseEvent::DistillStage { nous_id, stage } => Msg::SseDistillStage { nous_id, stage },
             SseEvent::DistillAfter { nous_id } => Msg::SseDistillAfter { nous_id },
-            SseEvent::Ping => Msg::Tick, // Treat ping as a tick
+            SseEvent::Ping => Msg::Tick,
         }
     }
 
@@ -700,703 +574,17 @@ impl App {
     // --- State update ---
 
     pub async fn update(&mut self, msg: Msg) {
-        match msg {
-            // --- Input ---
-            Msg::CharInput(c) => {
-                if c == '\t' {
-                    // Tab completion for @mentions
-                    self.handle_tab_completion();
-                } else {
-                    // Clear tab completion state on any other input
-                    self.tab_completion = None;
-                    self.input.text.insert(self.input.cursor, c);
-                    self.input.cursor += c.len_utf8();
-                    self.input.history_index = None;
-                }
-            }
-            Msg::Backspace => {
-                if self.input.cursor > 0 {
-                    let prev = self.prev_char_boundary(self.input.cursor);
-                    self.input.text.drain(prev..self.input.cursor);
-                    self.input.cursor = prev;
-                }
-            }
-            Msg::Delete => {
-                if self.input.cursor < self.input.text.len() {
-                    let next = self.next_char_boundary(self.input.cursor);
-                    self.input.text.drain(self.input.cursor..next);
-                }
-            }
-            Msg::CursorLeft => {
-                if self.input.cursor > 0 {
-                    self.input.cursor = self.prev_char_boundary(self.input.cursor);
-                }
-            }
-            Msg::CursorRight => {
-                if self.input.cursor < self.input.text.len() {
-                    self.input.cursor = self.next_char_boundary(self.input.cursor);
-                }
-            }
-            Msg::CursorHome => self.input.cursor = 0,
-            Msg::CursorEnd => self.input.cursor = self.input.text.len(),
-            Msg::DeleteWord => {
-                // Delete back to previous word boundary
-                let mut pos = self.input.cursor;
-                // Skip trailing spaces
-                while pos > 0 && self.input.text.as_bytes().get(pos - 1) == Some(&b' ') {
-                    pos -= 1;
-                }
-                // Skip word chars
-                while pos > 0 && self.input.text.as_bytes().get(pos - 1) != Some(&b' ') {
-                    pos -= 1;
-                }
-                self.input.text.drain(pos..self.input.cursor);
-                self.input.cursor = pos;
-            }
-            Msg::ClearLine => {
-                self.input.text.clear();
-                self.input.cursor = 0;
-            }
-            Msg::HistoryUp => {
-                if !self.input.history.is_empty() {
-                    let idx = match self.input.history_index {
-                        Some(i) if i + 1 < self.input.history.len() => i + 1,
-                        None => 0,
-                        Some(i) => i,
-                    };
-                    self.input.history_index = Some(idx);
-                    self.input.text =
-                        self.input.history[self.input.history.len() - 1 - idx].clone();
-                    self.input.cursor = self.input.text.len();
-                }
-            }
-            Msg::HistoryDown => match self.input.history_index {
-                Some(0) => {
-                    self.input.history_index = None;
-                    self.input.text.clear();
-                    self.input.cursor = 0;
-                }
-                Some(i) => {
-                    let idx = i - 1;
-                    self.input.history_index = Some(idx);
-                    self.input.text =
-                        self.input.history[self.input.history.len() - 1 - idx].clone();
-                    self.input.cursor = self.input.text.len();
-                }
-                None => {}
-            },
-            Msg::Submit => {
-                let text = self.input.text.trim().to_string();
-                if text.is_empty() {
-                    return;
-                }
-                self.input.history.push(text.clone());
-                self.input.text.clear();
-                self.input.cursor = 0;
-                self.input.history_index = None;
-                self.send_message(&text);
-            }
-            Msg::CopyLastResponse => {
-                if let Some(msg) = self.messages.iter().rev().find(|m| m.role == "assistant") {
-                    if let Err(e) = crate::clipboard::copy_to_clipboard(&msg.text) {
-                        tracing::error!("clipboard copy failed: {e}");
-                    }
-                }
-            }
-            Msg::ComposeInEditor => {
-                let editor = std::env::var("EDITOR").unwrap_or_else(|_| "vi".to_string());
-                let tmpfile = std::env::temp_dir().join("aletheia-compose.md");
-                let _ = std::fs::write(&tmpfile, "");
-                ratatui::restore();
-                let status = std::process::Command::new(&editor).arg(&tmpfile).status();
-                let _ = ratatui::init();
-                if let Ok(s) = status {
-                    if s.success() {
-                        if let Ok(text) = std::fs::read_to_string(&tmpfile) {
-                            let text = text.trim().to_string();
-                            if !text.is_empty() {
-                                self.send_message(&text);
-                            }
-                        }
-                    }
-                }
-                let _ = std::fs::remove_file(&tmpfile);
-            }
-
-            // --- Navigation ---
-            Msg::ScrollUp => {
-                self.scroll_offset = self.scroll_offset.saturating_add(3);
-                self.auto_scroll = false;
-            }
-            Msg::ScrollDown => {
-                if self.scroll_offset >= 3 {
-                    self.scroll_offset -= 3;
-                } else {
-                    self.scroll_offset = 0;
-                    self.auto_scroll = true;
-                }
-            }
-            Msg::ScrollPageUp => {
-                self.scroll_offset = self.scroll_offset.saturating_add(20);
-                self.auto_scroll = false;
-            }
-            Msg::ScrollPageDown => {
-                if self.scroll_offset >= 20 {
-                    self.scroll_offset -= 20;
-                } else {
-                    self.scroll_offset = 0;
-                    self.auto_scroll = true;
-                }
-            }
-            Msg::ScrollToBottom => {
-                self.scroll_offset = 0;
-                self.auto_scroll = true;
-            }
-            Msg::FocusAgent(id) => {
-                self.save_scroll_state();
-                // Clear notification on the agent we're switching to
-                if let Some(agent) = self.agents.iter_mut().find(|a| a.id == id) {
-                    agent.has_notification = false;
-                }
-                self.focused_agent = Some(id.clone());
-                self.load_focused_session().await;
-                self.restore_scroll_state();
-            }
-            Msg::NextAgent => {
-                self.save_scroll_state();
-                if let Some(ref current) = self.focused_agent {
-                    if let Some(idx) = self.agents.iter().position(|a| a.id == *current) {
-                        let next = (idx + 1) % self.agents.len();
-                        let id = self.agents[next].id.clone();
-                        self.focused_agent = Some(id);
-                        self.load_focused_session().await;
-                        self.restore_scroll_state();
-                    }
-                }
-            }
-            Msg::PrevAgent => {
-                self.save_scroll_state();
-                if let Some(ref current) = self.focused_agent {
-                    if let Some(idx) = self.agents.iter().position(|a| a.id == *current) {
-                        let prev = if idx == 0 {
-                            self.agents.len() - 1
-                        } else {
-                            idx - 1
-                        };
-                        let id = self.agents[prev].id.clone();
-                        self.focused_agent = Some(id);
-                        self.load_focused_session().await;
-                        self.restore_scroll_state();
-                    }
-                }
-            }
-
-            // --- Layout ---
-            Msg::ToggleSidebar => self.sidebar_visible = !self.sidebar_visible,
-            Msg::ToggleThinking => self.thinking_expanded = !self.thinking_expanded,
-            Msg::OpenOverlay(kind) => {
-                self.overlay = Some(match kind {
-                    OverlayKind::Help => Overlay::Help,
-                    OverlayKind::AgentPicker => Overlay::AgentPicker { cursor: 0 },
-                    OverlayKind::SystemStatus => Overlay::SystemStatus,
-                });
-            }
-            Msg::CloseOverlay => {
-                // If denying a tool approval, send the deny
-                if let Some(Overlay::ToolApproval(ref approval)) = self.overlay {
-                    let turn_id = approval.turn_id.clone();
-                    let tool_id = approval.tool_id.clone();
-                    let client = self.client.clone();
-                    tokio::spawn(async move {
-                        if let Err(e) = client.deny_tool(&turn_id, &tool_id).await {
-                            tracing::error!("failed to deny tool: {e}");
-                        }
-                    });
-                }
-                // If cancelling a plan, send the cancel
-                if let Some(Overlay::PlanApproval(ref plan)) = self.overlay {
-                    let plan_id = plan.plan_id.clone();
-                    let client = self.client.clone();
-                    tokio::spawn(async move {
-                        if let Err(e) = client.cancel_plan(&plan_id).await {
-                            tracing::error!("failed to cancel plan: {e}");
-                        }
-                    });
-                }
-                self.overlay = None;
-            }
-            Msg::Resize(w, h) => {
-                self.terminal_width = w;
-                self.terminal_height = h;
-            }
-
-            // --- Overlay interaction ---
-            Msg::OverlayUp => match &mut self.overlay {
-                Some(Overlay::AgentPicker { cursor }) => {
-                    *cursor = cursor.saturating_sub(1);
-                }
-                Some(Overlay::PlanApproval(plan)) => {
-                    plan.cursor = plan.cursor.saturating_sub(1);
-                }
-                _ => {}
-            },
-            Msg::OverlayDown => match &mut self.overlay {
-                Some(Overlay::AgentPicker { cursor }) => {
-                    let max = self.agents.len().saturating_sub(1);
-                    *cursor = (*cursor + 1).min(max);
-                }
-                Some(Overlay::PlanApproval(plan)) => {
-                    let max = plan.steps.len().saturating_sub(1);
-                    plan.cursor = (plan.cursor + 1).min(max);
-                }
-                _ => {}
-            },
-            Msg::OverlaySelect => {
-                match &self.overlay {
-                    Some(Overlay::AgentPicker { cursor }) => {
-                        if let Some(agent) = self.agents.get_mut(*cursor) {
-                            agent.has_notification = false;
-                            let id = agent.id.clone();
-                            self.focused_agent = Some(id);
-                            self.overlay = None;
-                            self.load_focused_session().await;
-                        }
-                    }
-                    Some(Overlay::ToolApproval(approval)) => {
-                        let turn_id = approval.turn_id.clone();
-                        let tool_id = approval.tool_id.clone();
-                        let client = self.client.clone();
-                        tokio::spawn(async move {
-                            if let Err(e) = client.approve_tool(&turn_id, &tool_id).await {
-                                tracing::error!("failed to approve tool: {e}");
-                            }
-                        });
-                        self.overlay = None;
-                    }
-                    Some(Overlay::PlanApproval(plan)) => {
-                        // Space toggles, A approves
-                        // For now, treat select as approve-all
-                        let plan_id = plan.plan_id.clone();
-                        let client = self.client.clone();
-                        tokio::spawn(async move {
-                            if let Err(e) = client.approve_plan(&plan_id).await {
-                                tracing::error!("failed to approve plan: {e}");
-                            }
-                        });
-                        self.overlay = None;
-                    }
-                    _ => {
-                        self.overlay = None;
-                    }
-                }
-            }
-            Msg::OverlayFilter(_) | Msg::OverlayFilterBackspace => {
-                // TODO: fuzzy filter in Phase 2
-            }
-
-            // --- SSE ---
-            Msg::SseConnected => {
-                let was_disconnected = !self.sse_connected;
-                self.sse_connected = true;
-
-                // On reconnect, reload agent state to sync any missed events
-                if was_disconnected {
-                    tracing::info!("SSE reconnected — reloading agent state");
-                    if let Ok(agents) = self.client.agents().await {
-                        // Preserve notification state across reload
-                        let notifications: HashMap<String, bool> = self
-                            .agents
-                            .iter()
-                            .map(|a| (a.id.clone(), a.has_notification))
-                            .collect();
-
-                        self.agents = agents
-                            .into_iter()
-                            .map(|a| {
-                                let notif = notifications.get(&a.id).copied().unwrap_or(false);
-                                AgentState {
-                                    id: a.id,
-                                    name: a.name,
-                                    emoji: a.emoji,
-                                    status: AgentStatus::Idle,
-                                    active_tool: None,
-                                    tool_started_at: None,
-                                    sessions: Vec::new(),
-                                    compaction_stage: None,
-                                    has_notification: notif,
-                                }
-                            })
-                            .collect();
-                    }
-                    // Reload focused session history
-                    self.load_focused_session().await;
-                }
-            }
-            Msg::SseDisconnected => {
-                self.sse_connected = false;
-            }
-            Msg::SseInit { active_turns } => {
-                for turn in active_turns {
-                    if let Some(agent) = self.agents.iter_mut().find(|a| a.id == turn.nous_id) {
-                        agent.status = AgentStatus::Working;
-                    }
-                }
-            }
-            Msg::SseTurnBefore { nous_id, .. } => {
-                if let Some(agent) = self.agents.iter_mut().find(|a| a.id == nous_id) {
-                    agent.status = AgentStatus::Working;
-                    agent.active_tool = None;
-                }
-            }
-            Msg::SseTurnAfter {
-                nous_id,
-                session_id,
-            } => {
-                let is_focused = self.focused_agent.as_deref() == Some(&nous_id);
-                if let Some(agent) = self.agents.iter_mut().find(|a| a.id == nous_id) {
-                    agent.status = AgentStatus::Idle;
-                    agent.active_tool = None;
-                    agent.tool_started_at = None;
-                    // Set notification if this agent isn't currently focused
-                    if !is_focused {
-                        agent.has_notification = true;
-                    }
-                }
-                // Reload history if this is our focused agent/session
-                if is_focused
-                    && self.focused_session_id.as_deref() == Some(&session_id)
-                    && self.active_turn_id.is_none()
-                {
-                    self.load_focused_session().await;
-                }
-            }
-            Msg::SseToolCalled { nous_id, tool_name } => {
-                if let Some(agent) = self.agents.iter_mut().find(|a| a.id == nous_id) {
-                    agent.active_tool = Some(tool_name);
-                    agent.tool_started_at = Some(std::time::Instant::now());
-                }
-            }
-            Msg::SseToolFailed { nous_id, .. } => {
-                if let Some(agent) = self.agents.iter_mut().find(|a| a.id == nous_id) {
-                    agent.active_tool = None;
-                    agent.tool_started_at = None;
-                }
-            }
-            Msg::SseStatusUpdate { nous_id, status } => {
-                if let Some(agent) = self.agents.iter_mut().find(|a| a.id == nous_id) {
-                    agent.status = match status.as_str() {
-                        "working" => AgentStatus::Working,
-                        "streaming" => AgentStatus::Streaming,
-                        "compacting" => AgentStatus::Compacting,
-                        _ => AgentStatus::Idle,
-                    };
-                }
-            }
-            Msg::SseSessionCreated { nous_id, .. } => {
-                if let Some(agent) = self.agents.iter_mut().find(|a| a.id == nous_id) {
-                    // Reload sessions for this agent
-                    if let Ok(sessions) = self.client.sessions(&nous_id).await {
-                        agent.sessions = sessions;
-                    }
-                }
-            }
-            Msg::SseSessionArchived {
-                nous_id,
-                session_id,
-            } => {
-                if let Some(agent) = self.agents.iter_mut().find(|a| a.id == nous_id) {
-                    agent.sessions.retain(|s| s.id != session_id);
-                }
-            }
-            Msg::SseDistillBefore { nous_id } => {
-                if let Some(agent) = self.agents.iter_mut().find(|a| a.id == nous_id) {
-                    agent.status = AgentStatus::Compacting;
-                    agent.compaction_stage = Some("starting".to_string());
-                }
-            }
-            Msg::SseDistillStage { nous_id, stage } => {
-                if let Some(agent) = self.agents.iter_mut().find(|a| a.id == nous_id) {
-                    agent.compaction_stage = Some(stage);
-                }
-            }
-            Msg::SseDistillAfter { nous_id } => {
-                if let Some(agent) = self.agents.iter_mut().find(|a| a.id == nous_id) {
-                    agent.status = AgentStatus::Idle;
-                    agent.compaction_stage = None;
-                }
-                // Reload history if focused
-                if self.focused_agent.as_deref() == Some(&nous_id) {
-                    self.load_focused_session().await;
-                }
-            }
-
-            // --- Streaming ---
-            Msg::StreamTurnStart {
-                turn_id, nous_id, ..
-            } => {
-                self.active_turn_id = Some(turn_id);
-                self.streaming_text.clear();
-                self.streaming_thinking.clear();
-                self.streaming_tool_calls.clear();
-                self.cached_markdown_text.clear();
-                self.cached_markdown_lines.clear();
-                if let Some(agent) = self.agents.iter_mut().find(|a| a.id == nous_id) {
-                    agent.status = AgentStatus::Streaming;
-                }
-            }
-            Msg::StreamTextDelta(text) => {
-                self.streaming_text.push_str(&text);
-                // Debounced markdown cache: re-parse every 64 chars of new content
-                // or when a newline arrives (likely block boundary).
-                let delta =
-                    self.streaming_text.len() as i64 - self.cached_markdown_text.len() as i64;
-                if delta >= 64 || text.contains('\n') {
-                    let width = 120; // approximate — real width comes from render
-                    self.cached_markdown_lines = crate::markdown::render(
-                        &self.streaming_text,
-                        width,
-                        &self.theme,
-                        &self.highlighter,
-                    );
-                    self.cached_markdown_text = self.streaming_text.clone();
-                }
-                if self.auto_scroll {
-                    self.scroll_offset = 0;
-                }
-            }
-            Msg::StreamThinkingDelta(text) => {
-                self.streaming_thinking.push_str(&text);
-            }
-            Msg::StreamToolStart { tool_name, .. } => {
-                self.streaming_tool_calls.push(ToolCallInfo {
-                    name: tool_name.clone(),
-                    duration_ms: None,
-                    is_error: false,
-                });
-                if let Some(ref agent_id) = self.focused_agent {
-                    if let Some(agent) = self.agents.iter_mut().find(|a| a.id == *agent_id) {
-                        agent.active_tool = Some(tool_name);
-                        agent.tool_started_at = Some(std::time::Instant::now());
-                    }
-                }
-            }
-            Msg::StreamToolResult {
-                tool_name,
-                is_error,
-                duration_ms,
-                ..
-            } => {
-                // Update the most recent matching tool call with result info
-                if let Some(tc) = self
-                    .streaming_tool_calls
-                    .iter_mut()
-                    .rev()
-                    .find(|t| t.name == tool_name)
-                {
-                    tc.duration_ms = Some(duration_ms);
-                    tc.is_error = is_error;
-                }
-                if let Some(ref agent_id) = self.focused_agent {
-                    if let Some(agent) = self.agents.iter_mut().find(|a| a.id == *agent_id) {
-                        agent.active_tool = None;
-                        agent.tool_started_at = None;
-                    }
-                }
-            }
-            Msg::StreamToolApprovalRequired {
-                turn_id,
-                tool_name,
-                tool_id,
-                input,
-                risk,
-                reason,
-            } => {
-                self.overlay = Some(Overlay::ToolApproval(ToolApprovalOverlay {
-                    turn_id,
-                    tool_id,
-                    tool_name,
-                    input,
-                    risk,
-                    reason,
-                }));
-            }
-            Msg::StreamToolApprovalResolved { .. } => {
-                if self.is_tool_approval_overlay() {
-                    self.overlay = None;
-                }
-            }
-            Msg::StreamPlanProposed { plan } => {
-                self.overlay = Some(Overlay::PlanApproval(PlanApprovalOverlay {
-                    plan_id: plan.id,
-                    total_cost_cents: plan.total_estimated_cost_cents,
-                    cursor: 0,
-                    steps: plan
-                        .steps
-                        .into_iter()
-                        .map(|s| PlanStepApproval {
-                            id: s.id,
-                            label: s.label,
-                            role: s.role,
-                            checked: true,
-                        })
-                        .collect(),
-                }));
-            }
-            Msg::StreamPlanStepStart { .. }
-            | Msg::StreamPlanStepComplete { .. }
-            | Msg::StreamPlanComplete { .. } => {
-                // TODO: update plan progress widget
-            }
-            Msg::StreamTurnComplete { outcome } => {
-                // Finalize the streamed message
-                if !self.streaming_text.is_empty() {
-                    self.messages.push(ChatMessage {
-                        role: "assistant".to_string(),
-                        text: self.streaming_text.clone(),
-                        timestamp: None,
-                        model: Some(outcome.model),
-                        is_streaming: false,
-                        tool_calls: std::mem::take(&mut self.streaming_tool_calls),
-                    });
-                }
-                self.streaming_text.clear();
-                self.streaming_thinking.clear();
-                self.streaming_tool_calls.clear();
-                self.cached_markdown_text.clear();
-                self.cached_markdown_lines.clear();
-                self.active_turn_id = None;
-                self.stream_rx = None;
-                if let Some(ref agent_id) = self.focused_agent {
-                    if let Some(agent) = self.agents.iter_mut().find(|a| a.id == *agent_id) {
-                        agent.status = AgentStatus::Idle;
-                        agent.active_tool = None;
-                    }
-                }
-                // Update cost
-                if let Ok(cents) = self.client.today_cost_cents().await {
-                    self.daily_cost_cents = cents;
-                }
-            }
-            Msg::StreamTurnAbort { reason } => {
-                tracing::info!("turn aborted: {reason}");
-                self.streaming_text.clear();
-                self.streaming_thinking.clear();
-                self.active_turn_id = None;
-                self.stream_rx = None;
-            }
-            Msg::StreamError(msg) => {
-                tracing::error!("stream error: {msg}");
-                self.error_toast = Some(ErrorToast::new(msg));
-                self.active_turn_id = None;
-                self.stream_rx = None;
-            }
-
-            // --- API responses ---
-            Msg::AgentsLoaded(agents) => {
-                self.agents = agents
-                    .into_iter()
-                    .map(|a| AgentState {
-                        id: a.id,
-                        name: a.name,
-                        emoji: a.emoji,
-                        status: AgentStatus::Idle,
-                        active_tool: None,
-                        tool_started_at: None,
-                        sessions: Vec::new(),
-                        compaction_stage: None,
-                        has_notification: false,
-                    })
-                    .collect();
-            }
-            Msg::SessionsLoaded { nous_id, sessions } => {
-                if let Some(agent) = self.agents.iter_mut().find(|a| a.id == nous_id) {
-                    agent.sessions = sessions;
-                }
-            }
-            Msg::HistoryLoaded { messages, .. } => {
-                self.messages = messages
-                    .into_iter()
-                    .filter_map(|m| {
-                        if m.role != "user" && m.role != "assistant" {
-                            return None;
-                        }
-                        let text = extract_text_content(&m.content)?;
-                        Some(ChatMessage {
-                            role: m.role,
-                            text,
-                            timestamp: m.created_at,
-                            model: m.model,
-                            is_streaming: false,
-                            tool_calls: Vec::new(),
-                        })
-                    })
-                    .collect();
-                self.scroll_to_bottom();
-            }
-            Msg::CostLoaded { daily_total_cents } => {
-                self.daily_cost_cents = daily_total_cents;
-            }
-            Msg::AuthResult(_) | Msg::ApiError(_) => {}
-
-            // --- New session ---
-            Msg::NewSession => {
-                if let Some(ref agent_id) = self.focused_agent.clone() {
-                    // Create a visual separator in messages
-                    self.messages.clear();
-                    self.scroll_to_bottom();
-
-                    // Create new session via API
-                    let session_key = format!("tui-{}", chrono_compact_now());
-                    let client = self.client.clone();
-                    let agent_id = agent_id.clone();
-                    let key = session_key.clone();
-                    match client.create_session(&agent_id, &key).await {
-                        Ok(session) => {
-                            self.focused_session_id = Some(session.id.clone());
-                            if let Some(agent) = self.agents.iter_mut().find(|a| a.id == agent_id) {
-                                agent.sessions.push(session);
-                            }
-                        }
-                        Err(e) => {
-                            tracing::error!("failed to create session: {e}");
-                            self.error_toast =
-                                Some(ErrorToast::new(format!("New session failed: {e}")));
-                        }
-                    }
-                }
-            }
-
-            // --- Error toasts ---
-            Msg::ShowError(msg) => {
-                self.error_toast = Some(ErrorToast::new(msg));
-            }
-            Msg::DismissError => {
-                self.error_toast = None;
-            }
-
-            // --- Quit ---
-            Msg::Quit => self.should_quit = true,
-
-            // --- Tick ---
-            Msg::Tick => {
-                self.tick_count = self.tick_count.wrapping_add(1);
-                // Auto-dismiss expired error toasts
-                if self.error_toast.as_ref().is_some_and(|t| t.is_expired()) {
-                    self.error_toast = None;
-                }
-            }
-        }
+        crate::update::update(self, msg).await;
     }
 
     // --- Actions ---
 
-    fn send_message(&mut self, text: &str) {
+    pub(crate) fn send_message(&mut self, text: &str) {
         let agent_id = match &self.focused_agent {
             Some(id) => id.clone(),
             None => return,
         };
 
-        // If there's already an active turn, queue the message instead
         if self.active_turn_id.is_some() {
             if let Some(ref session_id) = self.focused_session_id {
                 let client = self.client.clone();
@@ -1411,7 +599,6 @@ impl App {
             return;
         }
 
-        // Add user message to display
         self.messages.push(ChatMessage {
             role: "user".to_string(),
             text: text.to_string(),
@@ -1422,7 +609,6 @@ impl App {
         });
         self.scroll_to_bottom();
 
-        // Determine session key
         let session_key = self
             .focused_agent
             .as_ref()
@@ -1438,7 +624,6 @@ impl App {
             })
             .unwrap_or_else(|| "main".to_string());
 
-        // Start streaming response
         let rx = streaming::stream_message(
             &self.config.url,
             self.client.token(),
@@ -1449,19 +634,16 @@ impl App {
         self.stream_rx = Some(rx);
     }
 
-    fn handle_tab_completion(&mut self) {
-        // Find the @mention prefix before cursor
+    pub(crate) fn handle_tab_completion(&mut self) {
         let text_before_cursor = &self.input.text[..self.input.cursor];
         if let Some(at_pos) = text_before_cursor.rfind('@') {
             let prefix = &text_before_cursor[at_pos + 1..];
 
             if let Some(ref mut tc) = self.tab_completion {
-                // Already completing — cycle to next candidate
                 if tc.prefix == prefix || (!tc.candidates.is_empty() && tc.insert_start == at_pos) {
                     tc.index = (tc.index + 1) % tc.candidates.len();
                     let candidate = &tc.candidates[tc.index];
 
-                    // Replace from @ to cursor with @candidate
                     self.input
                         .text
                         .replace_range(at_pos..self.input.cursor, &format!("@{} ", candidate));
@@ -1470,7 +652,6 @@ impl App {
                 }
             }
 
-            // Build candidate list from agent names
             let candidates: Vec<String> = self
                 .agents
                 .iter()
@@ -1489,7 +670,6 @@ impl App {
                     index: 0,
                     insert_start: at_pos,
                 });
-                // Replace prefix with first match
                 self.input
                     .text
                     .replace_range(at_pos..self.input.cursor, &format!("@{} ", first));
@@ -1498,12 +678,12 @@ impl App {
         }
     }
 
-    fn scroll_to_bottom(&mut self) {
+    pub(crate) fn scroll_to_bottom(&mut self) {
         self.scroll_offset = 0;
         self.auto_scroll = true;
     }
 
-    fn save_scroll_state(&mut self) {
+    pub(crate) fn save_scroll_state(&mut self) {
         if let Some(ref id) = self.focused_agent {
             self.scroll_states.insert(
                 id.clone(),
@@ -1515,7 +695,7 @@ impl App {
         }
     }
 
-    fn restore_scroll_state(&mut self) {
+    pub(crate) fn restore_scroll_state(&mut self) {
         if let Some(ref id) = self.focused_agent {
             if let Some(state) = self.scroll_states.get(id) {
                 self.scroll_offset = state.scroll_offset;
@@ -1526,7 +706,7 @@ impl App {
         }
     }
 
-    fn prev_char_boundary(&self, pos: usize) -> usize {
+    pub(crate) fn prev_char_boundary(&self, pos: usize) -> usize {
         let mut p = pos - 1;
         while p > 0 && !self.input.text.is_char_boundary(p) {
             p -= 1;
@@ -1534,7 +714,7 @@ impl App {
         p
     }
 
-    fn next_char_boundary(&self, pos: usize) -> usize {
+    pub(crate) fn next_char_boundary(&self, pos: usize) -> usize {
         let mut p = pos + 1;
         while p < self.input.text.len() && !self.input.text.is_char_boundary(p) {
             p += 1;
@@ -1547,64 +727,4 @@ impl App {
     pub fn view(&self, frame: &mut Frame) {
         view::render(self, frame);
     }
-}
-
-/// Generate a compact timestamp for session key names (no external dep).
-fn chrono_compact_now() -> String {
-    use std::time::{SystemTime, UNIX_EPOCH};
-    let secs = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_secs();
-    format!("{:x}", secs)
-}
-
-/// Extract only text content from a JSON array of Anthropic content blocks.
-/// Tool_use blocks are silently skipped — if a message is purely tool calls,
-/// this returns None and the message is filtered out of the chat view.
-fn extract_texts_from_array(arr: &[serde_json::Value]) -> Option<String> {
-    let mut texts = Vec::new();
-
-    for block in arr {
-        if block.get("type").and_then(|t| t.as_str()) == Some("text") {
-            if let Some(t) = block.get("text").and_then(|t| t.as_str()) {
-                if !t.is_empty() {
-                    texts.push(t.to_string());
-                }
-            }
-        }
-    }
-
-    if texts.is_empty() {
-        None
-    } else {
-        Some(texts.join("\n"))
-    }
-}
-
-/// Extract displayable text from a history message's content field.
-/// Content can be: a plain string, a stringified JSON array, a JSON array, or null.
-fn extract_text_content(content: &Option<serde_json::Value>) -> Option<String> {
-    let content = content.as_ref()?;
-
-    // Plain string content — but might be a stringified JSON array
-    if let Some(s) = content.as_str() {
-        if s.is_empty() {
-            return None;
-        }
-        // Try parsing as JSON array (double-stringified content from API)
-        if s.starts_with('[') {
-            if let Ok(parsed) = serde_json::from_str::<Vec<serde_json::Value>>(s) {
-                return extract_texts_from_array(&parsed);
-            }
-        }
-        return Some(s.to_string());
-    }
-
-    // Already a JSON array of content blocks
-    if let Some(arr) = content.as_array() {
-        return extract_texts_from_array(arr);
-    }
-
-    None
 }

--- a/tui/src/main.rs
+++ b/tui/src/main.rs
@@ -6,7 +6,9 @@ mod events;
 mod highlight;
 mod markdown;
 mod msg;
+mod state;
 mod theme;
+mod update;
 mod view;
 
 use anyhow::Result;

--- a/tui/src/state/agent.rs
+++ b/tui/src/state/agent.rs
@@ -1,0 +1,24 @@
+use crate::api::types::Session;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AgentStatus {
+    Idle,
+    Working,
+    Streaming,
+    Compacting,
+}
+
+#[derive(Debug, Clone)]
+pub struct AgentState {
+    pub id: String,
+    pub name: String,
+    pub emoji: Option<String>,
+    pub status: AgentStatus,
+    pub active_tool: Option<String>,
+    pub tool_started_at: Option<std::time::Instant>,
+    pub sessions: Vec<Session>,
+    pub compaction_stage: Option<String>,
+    /// Indicates this agent completed a turn while not focused.
+    /// Cleared when the user switches to this agent.
+    pub has_notification: bool,
+}

--- a/tui/src/state/chat.rs
+++ b/tui/src/state/chat.rs
@@ -1,0 +1,22 @@
+#[derive(Debug, Clone)]
+pub struct ToolCallInfo {
+    pub name: String,
+    pub duration_ms: Option<u64>,
+    pub is_error: bool,
+}
+
+#[derive(Debug, Clone, Default)]
+pub(crate) struct SavedScrollState {
+    pub(crate) scroll_offset: usize,
+    pub(crate) auto_scroll: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct ChatMessage {
+    pub role: String,
+    pub text: String,
+    pub timestamp: Option<String>,
+    pub model: Option<String>,
+    pub is_streaming: bool,
+    pub tool_calls: Vec<ToolCallInfo>,
+}

--- a/tui/src/state/input.rs
+++ b/tui/src/state/input.rs
@@ -1,0 +1,15 @@
+#[derive(Debug, Default)]
+pub struct InputState {
+    pub text: String,
+    pub cursor: usize,
+    pub history: Vec<String>,
+    pub history_index: Option<usize>,
+}
+
+#[derive(Debug)]
+pub struct TabCompletion {
+    pub prefix: String,
+    pub candidates: Vec<String>,
+    pub index: usize,
+    pub insert_start: usize,
+}

--- a/tui/src/state/mod.rs
+++ b/tui/src/state/mod.rs
@@ -1,0 +1,10 @@
+mod agent;
+mod chat;
+mod input;
+mod overlay;
+
+pub use agent::{AgentState, AgentStatus};
+pub use chat::{ChatMessage, ToolCallInfo};
+pub(crate) use chat::SavedScrollState;
+pub use input::{InputState, TabCompletion};
+pub use overlay::{Overlay, PlanApprovalOverlay, PlanStepApproval, ToolApprovalOverlay};

--- a/tui/src/state/overlay.rs
+++ b/tui/src/state/overlay.rs
@@ -1,0 +1,34 @@
+#[derive(Debug)]
+pub enum Overlay {
+    Help,
+    AgentPicker { cursor: usize },
+    SystemStatus,
+    ToolApproval(ToolApprovalOverlay),
+    PlanApproval(PlanApprovalOverlay),
+}
+
+#[derive(Debug)]
+pub struct ToolApprovalOverlay {
+    pub turn_id: String,
+    pub tool_id: String,
+    pub tool_name: String,
+    pub input: serde_json::Value,
+    pub risk: String,
+    pub reason: String,
+}
+
+#[derive(Debug)]
+pub struct PlanApprovalOverlay {
+    pub plan_id: String,
+    pub steps: Vec<PlanStepApproval>,
+    pub total_cost_cents: u32,
+    pub cursor: usize,
+}
+
+#[derive(Debug)]
+pub struct PlanStepApproval {
+    pub id: u32,
+    pub label: String,
+    pub role: String,
+    pub checked: bool,
+}

--- a/tui/src/update/api.rs
+++ b/tui/src/update/api.rs
@@ -1,0 +1,142 @@
+use crate::api::types::{Agent, HistoryMessage, Session};
+use crate::app::App;
+use crate::msg::ErrorToast;
+use crate::state::{AgentState, AgentStatus, ChatMessage};
+
+pub(crate) fn handle_agents_loaded(app: &mut App, agents: Vec<Agent>) {
+    app.agents = agents
+        .into_iter()
+        .map(|a| AgentState {
+            id: a.id,
+            name: a.name,
+            emoji: a.emoji,
+            status: AgentStatus::Idle,
+            active_tool: None,
+            tool_started_at: None,
+            sessions: Vec::new(),
+            compaction_stage: None,
+            has_notification: false,
+        })
+        .collect();
+}
+
+pub(crate) fn handle_sessions_loaded(app: &mut App, nous_id: String, sessions: Vec<Session>) {
+    if let Some(agent) = app.agents.iter_mut().find(|a| a.id == nous_id) {
+        agent.sessions = sessions;
+    }
+}
+
+pub(crate) fn handle_history_loaded(app: &mut App, messages: Vec<HistoryMessage>) {
+    app.messages = messages
+        .into_iter()
+        .filter_map(|m| {
+            if m.role != "user" && m.role != "assistant" {
+                return None;
+            }
+            let text = extract_text_content(&m.content)?;
+            Some(ChatMessage {
+                role: m.role,
+                text,
+                timestamp: m.created_at,
+                model: m.model,
+                is_streaming: false,
+                tool_calls: Vec::new(),
+            })
+        })
+        .collect();
+    app.scroll_to_bottom();
+}
+
+pub(crate) fn handle_cost_loaded(app: &mut App, daily_total_cents: u32) {
+    app.daily_cost_cents = daily_total_cents;
+}
+
+pub(crate) async fn handle_new_session(app: &mut App) {
+    if let Some(ref agent_id) = app.focused_agent.clone() {
+        app.messages.clear();
+        app.scroll_to_bottom();
+
+        let session_key = format!("tui-{}", chrono_compact_now());
+        let client = app.client.clone();
+        let agent_id = agent_id.clone();
+        let key = session_key.clone();
+        match client.create_session(&agent_id, &key).await {
+            Ok(session) => {
+                app.focused_session_id = Some(session.id.clone());
+                if let Some(agent) = app.agents.iter_mut().find(|a| a.id == agent_id) {
+                    agent.sessions.push(session);
+                }
+            }
+            Err(e) => {
+                tracing::error!("failed to create session: {e}");
+                app.error_toast = Some(ErrorToast::new(format!("New session failed: {e}")));
+            }
+        }
+    }
+}
+
+pub(crate) fn handle_show_error(app: &mut App, msg: String) {
+    app.error_toast = Some(ErrorToast::new(msg));
+}
+
+pub(crate) fn handle_dismiss_error(app: &mut App) {
+    app.error_toast = None;
+}
+
+pub(crate) fn handle_tick(app: &mut App) {
+    app.tick_count = app.tick_count.wrapping_add(1);
+    if app.error_toast.as_ref().is_some_and(|t| t.is_expired()) {
+        app.error_toast = None;
+    }
+}
+
+fn chrono_compact_now() -> String {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let secs = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    format!("{:x}", secs)
+}
+
+pub(crate) fn extract_text_content(content: &Option<serde_json::Value>) -> Option<String> {
+    let content = content.as_ref()?;
+
+    if let Some(s) = content.as_str() {
+        if s.is_empty() {
+            return None;
+        }
+        if s.starts_with('[') {
+            if let Ok(parsed) = serde_json::from_str::<Vec<serde_json::Value>>(s) {
+                return extract_texts_from_array(&parsed);
+            }
+        }
+        return Some(s.to_string());
+    }
+
+    if let Some(arr) = content.as_array() {
+        return extract_texts_from_array(arr);
+    }
+
+    None
+}
+
+fn extract_texts_from_array(arr: &[serde_json::Value]) -> Option<String> {
+    let mut texts = Vec::new();
+
+    for block in arr {
+        if block.get("type").and_then(|t| t.as_str()) == Some("text") {
+            if let Some(t) = block.get("text").and_then(|t| t.as_str()) {
+                if !t.is_empty() {
+                    texts.push(t.to_string());
+                }
+            }
+        }
+    }
+
+    if texts.is_empty() {
+        None
+    } else {
+        Some(texts.join("\n"))
+    }
+}

--- a/tui/src/update/input.rs
+++ b/tui/src/update/input.rs
@@ -1,0 +1,134 @@
+use crate::app::App;
+
+pub(crate) fn handle_char_input(app: &mut App, c: char) {
+    if c == '\t' {
+        app.handle_tab_completion();
+    } else {
+        app.tab_completion = None;
+        app.input.text.insert(app.input.cursor, c);
+        app.input.cursor += c.len_utf8();
+        app.input.history_index = None;
+    }
+}
+
+pub(crate) fn handle_backspace(app: &mut App) {
+    if app.input.cursor > 0 {
+        let prev = app.prev_char_boundary(app.input.cursor);
+        app.input.text.drain(prev..app.input.cursor);
+        app.input.cursor = prev;
+    }
+}
+
+pub(crate) fn handle_delete(app: &mut App) {
+    if app.input.cursor < app.input.text.len() {
+        let next = app.next_char_boundary(app.input.cursor);
+        app.input.text.drain(app.input.cursor..next);
+    }
+}
+
+pub(crate) fn handle_cursor_left(app: &mut App) {
+    if app.input.cursor > 0 {
+        app.input.cursor = app.prev_char_boundary(app.input.cursor);
+    }
+}
+
+pub(crate) fn handle_cursor_right(app: &mut App) {
+    if app.input.cursor < app.input.text.len() {
+        app.input.cursor = app.next_char_boundary(app.input.cursor);
+    }
+}
+
+pub(crate) fn handle_cursor_home(app: &mut App) {
+    app.input.cursor = 0;
+}
+
+pub(crate) fn handle_cursor_end(app: &mut App) {
+    app.input.cursor = app.input.text.len();
+}
+
+pub(crate) fn handle_delete_word(app: &mut App) {
+    let mut pos = app.input.cursor;
+    while pos > 0 && app.input.text.as_bytes().get(pos - 1) == Some(&b' ') {
+        pos -= 1;
+    }
+    while pos > 0 && app.input.text.as_bytes().get(pos - 1) != Some(&b' ') {
+        pos -= 1;
+    }
+    app.input.text.drain(pos..app.input.cursor);
+    app.input.cursor = pos;
+}
+
+pub(crate) fn handle_clear_line(app: &mut App) {
+    app.input.text.clear();
+    app.input.cursor = 0;
+}
+
+pub(crate) fn handle_history_up(app: &mut App) {
+    if !app.input.history.is_empty() {
+        let idx = match app.input.history_index {
+            Some(i) if i + 1 < app.input.history.len() => i + 1,
+            None => 0,
+            Some(i) => i,
+        };
+        app.input.history_index = Some(idx);
+        app.input.text = app.input.history[app.input.history.len() - 1 - idx].clone();
+        app.input.cursor = app.input.text.len();
+    }
+}
+
+pub(crate) fn handle_history_down(app: &mut App) {
+    match app.input.history_index {
+        Some(0) => {
+            app.input.history_index = None;
+            app.input.text.clear();
+            app.input.cursor = 0;
+        }
+        Some(i) => {
+            let idx = i - 1;
+            app.input.history_index = Some(idx);
+            app.input.text = app.input.history[app.input.history.len() - 1 - idx].clone();
+            app.input.cursor = app.input.text.len();
+        }
+        None => {}
+    }
+}
+
+pub(crate) fn handle_submit(app: &mut App) {
+    let text = app.input.text.trim().to_string();
+    if text.is_empty() {
+        return;
+    }
+    app.input.history.push(text.clone());
+    app.input.text.clear();
+    app.input.cursor = 0;
+    app.input.history_index = None;
+    app.send_message(&text);
+}
+
+pub(crate) fn handle_copy_last_response(app: &mut App) {
+    if let Some(msg) = app.messages.iter().rev().find(|m| m.role == "assistant") {
+        if let Err(e) = crate::clipboard::copy_to_clipboard(&msg.text) {
+            tracing::error!("clipboard copy failed: {e}");
+        }
+    }
+}
+
+pub(crate) fn handle_compose_in_editor(app: &mut App) {
+    let editor = std::env::var("EDITOR").unwrap_or_else(|_| "vi".to_string());
+    let tmpfile = std::env::temp_dir().join("aletheia-compose.md");
+    let _ = std::fs::write(&tmpfile, "");
+    ratatui::restore();
+    let status = std::process::Command::new(&editor).arg(&tmpfile).status();
+    let _ = ratatui::init();
+    if let Ok(s) = status {
+        if s.success() {
+            if let Ok(text) = std::fs::read_to_string(&tmpfile) {
+                let text = text.trim().to_string();
+                if !text.is_empty() {
+                    app.send_message(&text);
+                }
+            }
+        }
+    }
+    let _ = std::fs::remove_file(&tmpfile);
+}

--- a/tui/src/update/mod.rs
+++ b/tui/src/update/mod.rs
@@ -1,0 +1,134 @@
+mod api;
+mod input;
+mod navigation;
+mod overlay;
+mod sse;
+mod streaming;
+
+use crate::app::App;
+use crate::msg::Msg;
+
+pub(crate) use api::extract_text_content;
+
+pub(crate) async fn update(app: &mut App, msg: Msg) {
+    match msg {
+        // --- Input ---
+        Msg::CharInput(c) => input::handle_char_input(app, c),
+        Msg::Backspace => input::handle_backspace(app),
+        Msg::Delete => input::handle_delete(app),
+        Msg::CursorLeft => input::handle_cursor_left(app),
+        Msg::CursorRight => input::handle_cursor_right(app),
+        Msg::CursorHome => input::handle_cursor_home(app),
+        Msg::CursorEnd => input::handle_cursor_end(app),
+        Msg::DeleteWord => input::handle_delete_word(app),
+        Msg::ClearLine => input::handle_clear_line(app),
+        Msg::HistoryUp => input::handle_history_up(app),
+        Msg::HistoryDown => input::handle_history_down(app),
+        Msg::Submit => input::handle_submit(app),
+        Msg::CopyLastResponse => input::handle_copy_last_response(app),
+        Msg::ComposeInEditor => input::handle_compose_in_editor(app),
+
+        // --- Navigation ---
+        Msg::ScrollUp => navigation::handle_scroll_up(app),
+        Msg::ScrollDown => navigation::handle_scroll_down(app),
+        Msg::ScrollPageUp => navigation::handle_scroll_page_up(app),
+        Msg::ScrollPageDown => navigation::handle_scroll_page_down(app),
+        Msg::ScrollToBottom => navigation::handle_scroll_to_bottom(app),
+        Msg::FocusAgent(id) => navigation::handle_focus_agent(app, id).await,
+        Msg::NextAgent => navigation::handle_next_agent(app).await,
+        Msg::PrevAgent => navigation::handle_prev_agent(app).await,
+        Msg::ToggleSidebar => navigation::handle_toggle_sidebar(app),
+        Msg::ToggleThinking => navigation::handle_toggle_thinking(app),
+        Msg::Resize(w, h) => navigation::handle_resize(app, w, h),
+
+        // --- Overlay ---
+        Msg::OpenOverlay(kind) => overlay::handle_open_overlay(app, kind),
+        Msg::CloseOverlay => overlay::handle_close_overlay(app),
+        Msg::OverlayUp => overlay::handle_overlay_up(app),
+        Msg::OverlayDown => overlay::handle_overlay_down(app),
+        Msg::OverlaySelect => overlay::handle_overlay_select(app).await,
+        Msg::OverlayFilter(_) | Msg::OverlayFilterBackspace => {}
+
+        // --- SSE ---
+        Msg::SseConnected => sse::handle_sse_connected(app).await,
+        Msg::SseDisconnected => sse::handle_sse_disconnected(app),
+        Msg::SseInit { active_turns } => sse::handle_sse_init(app, active_turns),
+        Msg::SseTurnBefore { nous_id, .. } => sse::handle_sse_turn_before(app, nous_id),
+        Msg::SseTurnAfter {
+            nous_id,
+            session_id,
+        } => sse::handle_sse_turn_after(app, nous_id, session_id).await,
+        Msg::SseToolCalled {
+            nous_id,
+            tool_name,
+        } => sse::handle_sse_tool_called(app, nous_id, tool_name),
+        Msg::SseToolFailed { nous_id, .. } => sse::handle_sse_tool_failed(app, nous_id),
+        Msg::SseStatusUpdate { nous_id, status } => {
+            sse::handle_sse_status_update(app, nous_id, status)
+        }
+        Msg::SseSessionCreated { nous_id, .. } => {
+            sse::handle_sse_session_created(app, nous_id).await
+        }
+        Msg::SseSessionArchived {
+            nous_id,
+            session_id,
+        } => sse::handle_sse_session_archived(app, nous_id, session_id),
+        Msg::SseDistillBefore { nous_id } => sse::handle_sse_distill_before(app, nous_id),
+        Msg::SseDistillStage { nous_id, stage } => {
+            sse::handle_sse_distill_stage(app, nous_id, stage)
+        }
+        Msg::SseDistillAfter { nous_id } => sse::handle_sse_distill_after(app, nous_id).await,
+
+        // --- Streaming ---
+        Msg::StreamTurnStart {
+            turn_id, nous_id, ..
+        } => streaming::handle_stream_turn_start(app, turn_id, nous_id),
+        Msg::StreamTextDelta(text) => streaming::handle_stream_text_delta(app, text),
+        Msg::StreamThinkingDelta(text) => streaming::handle_stream_thinking_delta(app, text),
+        Msg::StreamToolStart { tool_name, .. } => {
+            streaming::handle_stream_tool_start(app, tool_name)
+        }
+        Msg::StreamToolResult {
+            tool_name,
+            is_error,
+            duration_ms,
+            ..
+        } => streaming::handle_stream_tool_result(app, tool_name, is_error, duration_ms),
+        Msg::StreamToolApprovalRequired {
+            turn_id,
+            tool_name,
+            tool_id,
+            input,
+            risk,
+            reason,
+        } => streaming::handle_stream_tool_approval_required(
+            app, turn_id, tool_name, tool_id, input, risk, reason,
+        ),
+        Msg::StreamToolApprovalResolved { .. } => {
+            streaming::handle_stream_tool_approval_resolved(app)
+        }
+        Msg::StreamPlanProposed { plan } => streaming::handle_stream_plan_proposed(app, plan),
+        Msg::StreamPlanStepStart { .. }
+        | Msg::StreamPlanStepComplete { .. }
+        | Msg::StreamPlanComplete { .. } => {}
+        Msg::StreamTurnComplete { outcome } => {
+            streaming::handle_stream_turn_complete(app, outcome).await
+        }
+        Msg::StreamTurnAbort { reason } => streaming::handle_stream_turn_abort(app, reason),
+        Msg::StreamError(msg) => streaming::handle_stream_error(app, msg),
+
+        // --- API ---
+        Msg::AgentsLoaded(agents) => api::handle_agents_loaded(app, agents),
+        Msg::SessionsLoaded { nous_id, sessions } => {
+            api::handle_sessions_loaded(app, nous_id, sessions)
+        }
+        Msg::HistoryLoaded { messages, .. } => api::handle_history_loaded(app, messages),
+        Msg::CostLoaded { daily_total_cents } => api::handle_cost_loaded(app, daily_total_cents),
+        Msg::AuthResult(_) | Msg::ApiError(_) => {}
+        Msg::NewSession => api::handle_new_session(app).await,
+        Msg::ShowError(msg) => api::handle_show_error(app, msg),
+        Msg::DismissError => api::handle_dismiss_error(app),
+        Msg::Quit => app.should_quit = true,
+        Msg::Tick => api::handle_tick(app),
+    }
+}

--- a/tui/src/update/navigation.rs
+++ b/tui/src/update/navigation.rs
@@ -1,0 +1,87 @@
+use crate::app::App;
+
+pub(crate) fn handle_scroll_up(app: &mut App) {
+    app.scroll_offset = app.scroll_offset.saturating_add(3);
+    app.auto_scroll = false;
+}
+
+pub(crate) fn handle_scroll_down(app: &mut App) {
+    if app.scroll_offset >= 3 {
+        app.scroll_offset -= 3;
+    } else {
+        app.scroll_offset = 0;
+        app.auto_scroll = true;
+    }
+}
+
+pub(crate) fn handle_scroll_page_up(app: &mut App) {
+    app.scroll_offset = app.scroll_offset.saturating_add(20);
+    app.auto_scroll = false;
+}
+
+pub(crate) fn handle_scroll_page_down(app: &mut App) {
+    if app.scroll_offset >= 20 {
+        app.scroll_offset -= 20;
+    } else {
+        app.scroll_offset = 0;
+        app.auto_scroll = true;
+    }
+}
+
+pub(crate) fn handle_scroll_to_bottom(app: &mut App) {
+    app.scroll_offset = 0;
+    app.auto_scroll = true;
+}
+
+pub(crate) async fn handle_focus_agent(app: &mut App, id: String) {
+    app.save_scroll_state();
+    if let Some(agent) = app.agents.iter_mut().find(|a| a.id == id) {
+        agent.has_notification = false;
+    }
+    app.focused_agent = Some(id);
+    app.load_focused_session().await;
+    app.restore_scroll_state();
+}
+
+pub(crate) async fn handle_next_agent(app: &mut App) {
+    app.save_scroll_state();
+    if let Some(ref current) = app.focused_agent {
+        if let Some(idx) = app.agents.iter().position(|a| a.id == *current) {
+            let next = (idx + 1) % app.agents.len();
+            let id = app.agents[next].id.clone();
+            app.focused_agent = Some(id);
+            app.load_focused_session().await;
+            app.restore_scroll_state();
+        }
+    }
+}
+
+pub(crate) async fn handle_prev_agent(app: &mut App) {
+    app.save_scroll_state();
+    if let Some(ref current) = app.focused_agent {
+        if let Some(idx) = app.agents.iter().position(|a| a.id == *current) {
+            let prev = if idx == 0 {
+                app.agents.len() - 1
+            } else {
+                idx - 1
+            };
+            let id = app.agents[prev].id.clone();
+            app.focused_agent = Some(id);
+            app.load_focused_session().await;
+            app.restore_scroll_state();
+        }
+    }
+}
+
+pub(crate) fn handle_toggle_sidebar(app: &mut App) {
+    app.sidebar_visible = !app.sidebar_visible;
+}
+
+pub(crate) fn handle_toggle_thinking(app: &mut App) {
+    app.thinking_expanded = !app.thinking_expanded;
+}
+
+pub(crate) fn handle_resize(app: &mut App, w: u16, h: u16) {
+    app.terminal_width = w;
+    app.terminal_height = h;
+}

--- a/tui/src/update/overlay.rs
+++ b/tui/src/update/overlay.rs
@@ -1,0 +1,98 @@
+use crate::app::App;
+use crate::msg::OverlayKind;
+use crate::state::Overlay;
+
+pub(crate) fn handle_open_overlay(app: &mut App, kind: OverlayKind) {
+    app.overlay = Some(match kind {
+        OverlayKind::Help => Overlay::Help,
+        OverlayKind::AgentPicker => Overlay::AgentPicker { cursor: 0 },
+        OverlayKind::SystemStatus => Overlay::SystemStatus,
+    });
+}
+
+pub(crate) fn handle_close_overlay(app: &mut App) {
+    if let Some(Overlay::ToolApproval(ref approval)) = app.overlay {
+        let turn_id = approval.turn_id.clone();
+        let tool_id = approval.tool_id.clone();
+        let client = app.client.clone();
+        tokio::spawn(async move {
+            if let Err(e) = client.deny_tool(&turn_id, &tool_id).await {
+                tracing::error!("failed to deny tool: {e}");
+            }
+        });
+    }
+    if let Some(Overlay::PlanApproval(ref plan)) = app.overlay {
+        let plan_id = plan.plan_id.clone();
+        let client = app.client.clone();
+        tokio::spawn(async move {
+            if let Err(e) = client.cancel_plan(&plan_id).await {
+                tracing::error!("failed to cancel plan: {e}");
+            }
+        });
+    }
+    app.overlay = None;
+}
+
+pub(crate) fn handle_overlay_up(app: &mut App) {
+    match &mut app.overlay {
+        Some(Overlay::AgentPicker { cursor }) => {
+            *cursor = cursor.saturating_sub(1);
+        }
+        Some(Overlay::PlanApproval(plan)) => {
+            plan.cursor = plan.cursor.saturating_sub(1);
+        }
+        _ => {}
+    }
+}
+
+pub(crate) fn handle_overlay_down(app: &mut App) {
+    match &mut app.overlay {
+        Some(Overlay::AgentPicker { cursor }) => {
+            let max = app.agents.len().saturating_sub(1);
+            *cursor = (*cursor + 1).min(max);
+        }
+        Some(Overlay::PlanApproval(plan)) => {
+            let max = plan.steps.len().saturating_sub(1);
+            plan.cursor = (plan.cursor + 1).min(max);
+        }
+        _ => {}
+    }
+}
+
+pub(crate) async fn handle_overlay_select(app: &mut App) {
+    match &app.overlay {
+        Some(Overlay::AgentPicker { cursor }) => {
+            if let Some(agent) = app.agents.get_mut(*cursor) {
+                agent.has_notification = false;
+                let id = agent.id.clone();
+                app.focused_agent = Some(id);
+                app.overlay = None;
+                app.load_focused_session().await;
+            }
+        }
+        Some(Overlay::ToolApproval(approval)) => {
+            let turn_id = approval.turn_id.clone();
+            let tool_id = approval.tool_id.clone();
+            let client = app.client.clone();
+            tokio::spawn(async move {
+                if let Err(e) = client.approve_tool(&turn_id, &tool_id).await {
+                    tracing::error!("failed to approve tool: {e}");
+                }
+            });
+            app.overlay = None;
+        }
+        Some(Overlay::PlanApproval(plan)) => {
+            let plan_id = plan.plan_id.clone();
+            let client = app.client.clone();
+            tokio::spawn(async move {
+                if let Err(e) = client.approve_plan(&plan_id).await {
+                    tracing::error!("failed to approve plan: {e}");
+                }
+            });
+            app.overlay = None;
+        }
+        _ => {
+            app.overlay = None;
+        }
+    }
+}

--- a/tui/src/update/sse.rs
+++ b/tui/src/update/sse.rs
@@ -1,0 +1,139 @@
+use std::collections::HashMap;
+
+use crate::api::types::ActiveTurn;
+use crate::app::App;
+use crate::state::{AgentState, AgentStatus};
+
+pub(crate) async fn handle_sse_connected(app: &mut App) {
+    let was_disconnected = !app.sse_connected;
+    app.sse_connected = true;
+
+    if was_disconnected {
+        tracing::info!("SSE reconnected — reloading agent state");
+        if let Ok(agents) = app.client.agents().await {
+            let notifications: HashMap<String, bool> = app
+                .agents
+                .iter()
+                .map(|a| (a.id.clone(), a.has_notification))
+                .collect();
+
+            app.agents = agents
+                .into_iter()
+                .map(|a| {
+                    let notif = notifications.get(&a.id).copied().unwrap_or(false);
+                    AgentState {
+                        id: a.id,
+                        name: a.name,
+                        emoji: a.emoji,
+                        status: AgentStatus::Idle,
+                        active_tool: None,
+                        tool_started_at: None,
+                        sessions: Vec::new(),
+                        compaction_stage: None,
+                        has_notification: notif,
+                    }
+                })
+                .collect();
+        }
+        app.load_focused_session().await;
+    }
+}
+
+pub(crate) fn handle_sse_disconnected(app: &mut App) {
+    app.sse_connected = false;
+}
+
+pub(crate) fn handle_sse_init(app: &mut App, active_turns: Vec<ActiveTurn>) {
+    for turn in active_turns {
+        if let Some(agent) = app.agents.iter_mut().find(|a| a.id == turn.nous_id) {
+            agent.status = AgentStatus::Working;
+        }
+    }
+}
+
+pub(crate) fn handle_sse_turn_before(app: &mut App, nous_id: String) {
+    if let Some(agent) = app.agents.iter_mut().find(|a| a.id == nous_id) {
+        agent.status = AgentStatus::Working;
+        agent.active_tool = None;
+    }
+}
+
+pub(crate) async fn handle_sse_turn_after(app: &mut App, nous_id: String, session_id: String) {
+    let is_focused = app.focused_agent.as_deref() == Some(&nous_id);
+    if let Some(agent) = app.agents.iter_mut().find(|a| a.id == nous_id) {
+        agent.status = AgentStatus::Idle;
+        agent.active_tool = None;
+        agent.tool_started_at = None;
+        if !is_focused {
+            agent.has_notification = true;
+        }
+    }
+    if is_focused
+        && app.focused_session_id.as_deref() == Some(&session_id)
+        && app.active_turn_id.is_none()
+    {
+        app.load_focused_session().await;
+    }
+}
+
+pub(crate) fn handle_sse_tool_called(app: &mut App, nous_id: String, tool_name: String) {
+    if let Some(agent) = app.agents.iter_mut().find(|a| a.id == nous_id) {
+        agent.active_tool = Some(tool_name);
+        agent.tool_started_at = Some(std::time::Instant::now());
+    }
+}
+
+pub(crate) fn handle_sse_tool_failed(app: &mut App, nous_id: String) {
+    if let Some(agent) = app.agents.iter_mut().find(|a| a.id == nous_id) {
+        agent.active_tool = None;
+        agent.tool_started_at = None;
+    }
+}
+
+pub(crate) fn handle_sse_status_update(app: &mut App, nous_id: String, status: String) {
+    if let Some(agent) = app.agents.iter_mut().find(|a| a.id == nous_id) {
+        agent.status = match status.as_str() {
+            "working" => AgentStatus::Working,
+            "streaming" => AgentStatus::Streaming,
+            "compacting" => AgentStatus::Compacting,
+            _ => AgentStatus::Idle,
+        };
+    }
+}
+
+pub(crate) async fn handle_sse_session_created(app: &mut App, nous_id: String) {
+    if let Some(agent) = app.agents.iter_mut().find(|a| a.id == nous_id) {
+        if let Ok(sessions) = app.client.sessions(&nous_id).await {
+            agent.sessions = sessions;
+        }
+    }
+}
+
+pub(crate) fn handle_sse_session_archived(app: &mut App, nous_id: String, session_id: String) {
+    if let Some(agent) = app.agents.iter_mut().find(|a| a.id == nous_id) {
+        agent.sessions.retain(|s| s.id != session_id);
+    }
+}
+
+pub(crate) fn handle_sse_distill_before(app: &mut App, nous_id: String) {
+    if let Some(agent) = app.agents.iter_mut().find(|a| a.id == nous_id) {
+        agent.status = AgentStatus::Compacting;
+        agent.compaction_stage = Some("starting".to_string());
+    }
+}
+
+pub(crate) fn handle_sse_distill_stage(app: &mut App, nous_id: String, stage: String) {
+    if let Some(agent) = app.agents.iter_mut().find(|a| a.id == nous_id) {
+        agent.compaction_stage = Some(stage);
+    }
+}
+
+pub(crate) async fn handle_sse_distill_after(app: &mut App, nous_id: String) {
+    if let Some(agent) = app.agents.iter_mut().find(|a| a.id == nous_id) {
+        agent.status = AgentStatus::Idle;
+        agent.compaction_stage = None;
+    }
+    if app.focused_agent.as_deref() == Some(&nous_id) {
+        app.load_focused_session().await;
+    }
+}

--- a/tui/src/update/streaming.rs
+++ b/tui/src/update/streaming.rs
@@ -1,0 +1,165 @@
+use crate::api::types::{Plan, TurnOutcome};
+use crate::app::App;
+use crate::msg::ErrorToast;
+use crate::state::{
+    AgentStatus, ChatMessage, Overlay, PlanApprovalOverlay, PlanStepApproval, ToolApprovalOverlay,
+    ToolCallInfo,
+};
+
+pub(crate) fn handle_stream_turn_start(app: &mut App, turn_id: String, nous_id: String) {
+    app.active_turn_id = Some(turn_id);
+    app.streaming_text.clear();
+    app.streaming_thinking.clear();
+    app.streaming_tool_calls.clear();
+    app.cached_markdown_text.clear();
+    app.cached_markdown_lines.clear();
+    if let Some(agent) = app.agents.iter_mut().find(|a| a.id == nous_id) {
+        agent.status = AgentStatus::Streaming;
+    }
+}
+
+pub(crate) fn handle_stream_text_delta(app: &mut App, text: String) {
+    app.streaming_text.push_str(&text);
+    let delta = app.streaming_text.len() as i64 - app.cached_markdown_text.len() as i64;
+    if delta >= 64 || text.contains('\n') {
+        let width = 120;
+        app.cached_markdown_lines = crate::markdown::render(
+            &app.streaming_text,
+            width,
+            &app.theme,
+            &app.highlighter,
+        );
+        app.cached_markdown_text = app.streaming_text.clone();
+    }
+    if app.auto_scroll {
+        app.scroll_offset = 0;
+    }
+}
+
+pub(crate) fn handle_stream_thinking_delta(app: &mut App, text: String) {
+    app.streaming_thinking.push_str(&text);
+}
+
+pub(crate) fn handle_stream_tool_start(app: &mut App, tool_name: String) {
+    app.streaming_tool_calls.push(ToolCallInfo {
+        name: tool_name.clone(),
+        duration_ms: None,
+        is_error: false,
+    });
+    if let Some(ref agent_id) = app.focused_agent {
+        if let Some(agent) = app.agents.iter_mut().find(|a| a.id == *agent_id) {
+            agent.active_tool = Some(tool_name);
+            agent.tool_started_at = Some(std::time::Instant::now());
+        }
+    }
+}
+
+pub(crate) fn handle_stream_tool_result(
+    app: &mut App,
+    tool_name: String,
+    is_error: bool,
+    duration_ms: u64,
+) {
+    if let Some(tc) = app
+        .streaming_tool_calls
+        .iter_mut()
+        .rev()
+        .find(|t| t.name == tool_name)
+    {
+        tc.duration_ms = Some(duration_ms);
+        tc.is_error = is_error;
+    }
+    if let Some(ref agent_id) = app.focused_agent {
+        if let Some(agent) = app.agents.iter_mut().find(|a| a.id == *agent_id) {
+            agent.active_tool = None;
+            agent.tool_started_at = None;
+        }
+    }
+}
+
+pub(crate) fn handle_stream_tool_approval_required(
+    app: &mut App,
+    turn_id: String,
+    tool_name: String,
+    tool_id: String,
+    input: serde_json::Value,
+    risk: String,
+    reason: String,
+) {
+    app.overlay = Some(Overlay::ToolApproval(ToolApprovalOverlay {
+        turn_id,
+        tool_id,
+        tool_name,
+        input,
+        risk,
+        reason,
+    }));
+}
+
+pub(crate) fn handle_stream_tool_approval_resolved(app: &mut App) {
+    if app.is_tool_approval_overlay() {
+        app.overlay = None;
+    }
+}
+
+pub(crate) fn handle_stream_plan_proposed(app: &mut App, plan: Plan) {
+    app.overlay = Some(Overlay::PlanApproval(PlanApprovalOverlay {
+        plan_id: plan.id,
+        total_cost_cents: plan.total_estimated_cost_cents,
+        cursor: 0,
+        steps: plan
+            .steps
+            .into_iter()
+            .map(|s| PlanStepApproval {
+                id: s.id,
+                label: s.label,
+                role: s.role,
+                checked: true,
+            })
+            .collect(),
+    }));
+}
+
+pub(crate) async fn handle_stream_turn_complete(app: &mut App, outcome: TurnOutcome) {
+    if !app.streaming_text.is_empty() {
+        app.messages.push(ChatMessage {
+            role: "assistant".to_string(),
+            text: app.streaming_text.clone(),
+            timestamp: None,
+            model: Some(outcome.model),
+            is_streaming: false,
+            tool_calls: std::mem::take(&mut app.streaming_tool_calls),
+        });
+    }
+    app.streaming_text.clear();
+    app.streaming_thinking.clear();
+    app.streaming_tool_calls.clear();
+    app.cached_markdown_text.clear();
+    app.cached_markdown_lines.clear();
+    app.active_turn_id = None;
+    app.stream_rx = None;
+    if let Some(ref agent_id) = app.focused_agent {
+        if let Some(agent) = app.agents.iter_mut().find(|a| a.id == *agent_id) {
+            agent.status = AgentStatus::Idle;
+            agent.active_tool = None;
+        }
+    }
+    if let Ok(cents) = app.client.today_cost_cents().await {
+        app.daily_cost_cents = cents;
+    }
+}
+
+pub(crate) fn handle_stream_turn_abort(app: &mut App, reason: String) {
+    tracing::info!("turn aborted: {reason}");
+    app.streaming_text.clear();
+    app.streaming_thinking.clear();
+    app.active_turn_id = None;
+    app.stream_rx = None;
+}
+
+pub(crate) fn handle_stream_error(app: &mut App, msg: String) {
+    tracing::error!("stream error: {msg}");
+    app.error_toast = Some(ErrorToast::new(msg));
+    app.active_turn_id = None;
+    app.stream_rx = None;
+}


### PR DESCRIPTION
## Summary

- Split 1,611-line `app.rs` monolith into `state/` (5 files) and `update/` (7 files) modules
- `app.rs` retains App struct, init/connect, event mapping, and view delegation (730 lines)
- All view imports (`use crate::app::{...}`) continue to work via re-exports
- Pure refactor — zero behavior changes

## Test plan

- [x] `cargo check` passes
- [x] No new clippy warnings (pre-existing theme.rs warnings unchanged)
- [ ] Visual verification: TUI launches and renders correctly against running gateway