### PR TITLE
feat(tui): context-aware help system

### DIFF
--- a/tui/src/app.rs
+++ b/tui/src/app.rs
@@ -530,6 +530,11 @@ impl App {
             (KeyModifiers::CONTROL, KeyCode::Char('y')) => Some(Msg::CopyLastResponse),
             (KeyModifiers::CONTROL, KeyCode::Char('e')) => Some(Msg::ComposeInEditor),
 
+            // Context-aware help (only when input is empty)
+            (KeyModifiers::NONE, KeyCode::Char('?')) if self.input.text.is_empty() => {
+                Some(Msg::OpenOverlay(OverlayKind::Help))
+            }
+
             // Char input
             (KeyModifiers::NONE | KeyModifiers::SHIFT, KeyCode::Char(c)) => Some(Msg::CharInput(c)),
 

--- a/tui/src/keybindings.rs
+++ b/tui/src/keybindings.rs
@@ -1,0 +1,298 @@
+/// Context-aware keybinding registry — single source of truth for help overlay and status bar hints.
+use crate::app::{App, Overlay};
+
+pub struct Keybinding {
+    pub keys: &'static str,
+    pub description: &'static str,
+    pub contexts: &'static [KeyContext],
+    pub show_in_status_bar: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum KeyContext {
+    Global,
+    Chat,
+    Input,
+    Overlay,
+    ToolApproval,
+    PlanApproval,
+}
+
+impl KeyContext {
+    pub fn section_label(self) -> &'static str {
+        match self {
+            Self::Global => "Global",
+            Self::Chat => "Chat",
+            Self::Input => "Input",
+            Self::Overlay => "Overlay",
+            Self::ToolApproval => "Tool Approval",
+            Self::PlanApproval => "Plan Approval",
+        }
+    }
+
+    fn display_order(self) -> u8 {
+        match self {
+            Self::ToolApproval | Self::PlanApproval => 0,
+            Self::Chat => 1,
+            Self::Input => 2,
+            Self::Overlay => 3,
+            Self::Global => 4,
+        }
+    }
+}
+
+pub fn all_keybindings() -> &'static [Keybinding] {
+    &[
+        // --- Global ---
+        Keybinding {
+            keys: "?",
+            description: "Help for current view",
+            contexts: &[KeyContext::Global],
+            show_in_status_bar: false,
+        },
+        Keybinding {
+            keys: "Ctrl+A",
+            description: "Switch agent",
+            contexts: &[KeyContext::Global],
+            show_in_status_bar: true,
+        },
+        Keybinding {
+            keys: "Ctrl+F",
+            description: "Toggle sidebar",
+            contexts: &[KeyContext::Global],
+            show_in_status_bar: false,
+        },
+        Keybinding {
+            keys: "Ctrl+T",
+            description: "Toggle thinking",
+            contexts: &[KeyContext::Global],
+            show_in_status_bar: false,
+        },
+        Keybinding {
+            keys: "Ctrl+I",
+            description: "System status",
+            contexts: &[KeyContext::Global],
+            show_in_status_bar: true,
+        },
+        Keybinding {
+            keys: "Ctrl+N",
+            description: "New session",
+            contexts: &[KeyContext::Global],
+            show_in_status_bar: true,
+        },
+        Keybinding {
+            keys: "Ctrl+C/Q",
+            description: "Quit",
+            contexts: &[KeyContext::Global],
+            show_in_status_bar: true,
+        },
+        // --- Chat ---
+        Keybinding {
+            keys: "Ctrl+Y",
+            description: "Copy last response",
+            contexts: &[KeyContext::Chat],
+            show_in_status_bar: false,
+        },
+        Keybinding {
+            keys: "Shift+Up",
+            description: "Scroll up",
+            contexts: &[KeyContext::Chat],
+            show_in_status_bar: false,
+        },
+        Keybinding {
+            keys: "Shift+Down",
+            description: "Scroll down",
+            contexts: &[KeyContext::Chat],
+            show_in_status_bar: false,
+        },
+        Keybinding {
+            keys: "PgUp/PgDn",
+            description: "Page scroll",
+            contexts: &[KeyContext::Chat],
+            show_in_status_bar: false,
+        },
+        Keybinding {
+            keys: "End",
+            description: "Scroll to bottom",
+            contexts: &[KeyContext::Chat],
+            show_in_status_bar: false,
+        },
+        Keybinding {
+            keys: "Mouse",
+            description: "Scroll / click agent",
+            contexts: &[KeyContext::Chat],
+            show_in_status_bar: false,
+        },
+        // --- Input ---
+        Keybinding {
+            keys: "Enter",
+            description: "Send message",
+            contexts: &[KeyContext::Input],
+            show_in_status_bar: false,
+        },
+        Keybinding {
+            keys: "@agent Tab",
+            description: "Mention completion",
+            contexts: &[KeyContext::Input],
+            show_in_status_bar: false,
+        },
+        Keybinding {
+            keys: "Ctrl+U",
+            description: "Clear input line",
+            contexts: &[KeyContext::Input],
+            show_in_status_bar: false,
+        },
+        Keybinding {
+            keys: "Ctrl+W",
+            description: "Delete word",
+            contexts: &[KeyContext::Input],
+            show_in_status_bar: false,
+        },
+        Keybinding {
+            keys: "Ctrl+E",
+            description: "Open $EDITOR",
+            contexts: &[KeyContext::Input],
+            show_in_status_bar: false,
+        },
+        Keybinding {
+            keys: "Up/Down",
+            description: "Input history",
+            contexts: &[KeyContext::Input],
+            show_in_status_bar: false,
+        },
+        // --- Overlay (generic) ---
+        Keybinding {
+            keys: "Esc",
+            description: "Close",
+            contexts: &[KeyContext::Overlay],
+            show_in_status_bar: true,
+        },
+        Keybinding {
+            keys: "Up/Down",
+            description: "Navigate",
+            contexts: &[KeyContext::Overlay],
+            show_in_status_bar: false,
+        },
+        Keybinding {
+            keys: "Enter",
+            description: "Select",
+            contexts: &[KeyContext::Overlay],
+            show_in_status_bar: false,
+        },
+        // --- Tool Approval ---
+        Keybinding {
+            keys: "A",
+            description: "Approve tool",
+            contexts: &[KeyContext::ToolApproval],
+            show_in_status_bar: true,
+        },
+        Keybinding {
+            keys: "D",
+            description: "Deny tool",
+            contexts: &[KeyContext::ToolApproval],
+            show_in_status_bar: true,
+        },
+        // --- Plan Approval ---
+        Keybinding {
+            keys: "Space",
+            description: "Toggle step",
+            contexts: &[KeyContext::PlanApproval],
+            show_in_status_bar: true,
+        },
+        Keybinding {
+            keys: "A",
+            description: "Approve all",
+            contexts: &[KeyContext::PlanApproval],
+            show_in_status_bar: true,
+        },
+        Keybinding {
+            keys: "C",
+            description: "Cancel plan",
+            contexts: &[KeyContext::PlanApproval],
+            show_in_status_bar: true,
+        },
+    ]
+}
+
+pub fn current_contexts(app: &App) -> Vec<KeyContext> {
+    let mut contexts = vec![KeyContext::Global];
+
+    match &app.overlay {
+        Some(Overlay::ToolApproval(_)) => {
+            contexts.push(KeyContext::ToolApproval);
+            contexts.push(KeyContext::Overlay);
+        }
+        Some(Overlay::PlanApproval(_)) => {
+            contexts.push(KeyContext::PlanApproval);
+            contexts.push(KeyContext::Overlay);
+        }
+        Some(_) => {
+            contexts.push(KeyContext::Overlay);
+        }
+        None => {
+            contexts.push(KeyContext::Chat);
+            contexts.push(KeyContext::Input);
+        }
+    }
+
+    contexts
+}
+
+pub fn context_label(overlay: &Option<Overlay>) -> &'static str {
+    match overlay {
+        None => "Chat",
+        Some(Overlay::Help) => "Help",
+        Some(Overlay::AgentPicker { .. }) => "Agent Picker",
+        Some(Overlay::ToolApproval(_)) => "Tool Approval",
+        Some(Overlay::PlanApproval(_)) => "Plan Approval",
+        Some(Overlay::SystemStatus) => "System Status",
+    }
+}
+
+/// Groups keybindings by their primary context, ordered for display.
+pub fn grouped_keybindings(
+    contexts: &[KeyContext],
+) -> Vec<(&'static str, Vec<&'static Keybinding>)> {
+    let mut context_order: Vec<KeyContext> = contexts.to_vec();
+    context_order.sort_by_key(|c| c.display_order());
+
+    let mut groups: Vec<(&'static str, Vec<&'static Keybinding>)> = Vec::new();
+    let mut seen_keys: Vec<&'static str> = Vec::new();
+
+    for ctx in &context_order {
+        let label = ctx.section_label();
+        if groups.iter().any(|(l, _)| *l == label) {
+            continue;
+        }
+
+        let bindings: Vec<&'static Keybinding> = all_keybindings()
+            .iter()
+            .filter(|kb| kb.contexts.contains(ctx))
+            .filter(|kb| {
+                if seen_keys.contains(&kb.keys) {
+                    false
+                } else {
+                    seen_keys.push(kb.keys);
+                    true
+                }
+            })
+            .collect();
+
+        if !bindings.is_empty() {
+            groups.push((label, bindings));
+        }
+    }
+
+    groups
+}
+
+pub fn status_bar_hints(app: &App) -> Vec<(&'static str, &'static str)> {
+    let contexts = current_contexts(app);
+
+    all_keybindings()
+        .iter()
+        .filter(|kb| kb.show_in_status_bar)
+        .filter(|kb| kb.contexts.iter().any(|c| contexts.contains(c)))
+        .map(|kb| (kb.keys, kb.description))
+        .collect()
+}

--- a/tui/src/main.rs
+++ b/tui/src/main.rs
@@ -4,6 +4,7 @@ mod clipboard;
 mod config;
 mod events;
 mod highlight;
+mod keybindings;
 mod markdown;
 mod msg;
 mod theme;

--- a/tui/src/view/overlay.rs
+++ b/tui/src/view/overlay.rs
@@ -6,6 +6,7 @@ use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Clear, Paragraph, Wrap};
 
 use crate::app::{AgentStatus, App, Overlay};
+use crate::keybindings;
 use crate::theme::ThemePalette;
 
 pub fn render(app: &App, frame: &mut Frame, area: Rect, theme: &ThemePalette) {
@@ -20,7 +21,7 @@ pub fn render(app: &App, frame: &mut Frame, area: Rect, theme: &ThemePalette) {
     frame.render_widget(Clear, popup_area);
 
     match overlay {
-        Overlay::Help => render_help(frame, popup_area, theme),
+        Overlay::Help => render_help(app, frame, popup_area, theme),
         Overlay::AgentPicker { cursor } => {
             render_agent_picker(app, frame, popup_area, *cursor, theme)
         }
@@ -60,94 +61,42 @@ fn overlay_block_accent(
         .style(Style::default().bg(theme.surface))
 }
 
-fn render_help(frame: &mut Frame, area: Rect, theme: &ThemePalette) {
+fn render_help(app: &App, frame: &mut Frame, area: Rect, theme: &ThemePalette) {
     let key_style = Style::default()
         .fg(theme.accent)
         .add_modifier(Modifier::BOLD);
     let desc_style = theme.style_fg();
     let section_style = Style::default().fg(theme.fg).add_modifier(Modifier::BOLD);
 
-    let lines = vec![
-        Line::raw(""),
-        Line::from(Span::styled("  Navigation", section_style)),
-        Line::raw(""),
-        help_line("  Ctrl+A     ", "Switch agent", key_style, desc_style),
-        help_line("  Ctrl+F     ", "Toggle sidebar", key_style, desc_style),
-        help_line(
-            "  Ctrl+T     ",
-            "Toggle thinking blocks",
-            key_style,
-            desc_style,
-        ),
-        help_line("  Ctrl+I     ", "System status", key_style, desc_style),
-        help_line(
-            "  Ctrl+N     ",
-            "New session / topic",
-            key_style,
-            desc_style,
-        ),
-        help_line("  F1         ", "This help screen", key_style, desc_style),
-        Line::raw(""),
-        Line::from(Span::styled("  Input", section_style)),
-        Line::raw(""),
-        help_line("  Enter      ", "Send message", key_style, desc_style),
-        help_line("  @agent Tab ", "Mention completion", key_style, desc_style),
-        help_line("  Ctrl+U     ", "Clear input line", key_style, desc_style),
-        help_line("  Ctrl+W     ", "Delete word", key_style, desc_style),
-        help_line(
-            "  Ctrl+E     ",
-            "Open $EDITOR for compose",
-            key_style,
-            desc_style,
-        ),
-        help_line("  Ctrl+Y     ", "Copy last response", key_style, desc_style),
-        help_line("  Up/Down    ", "Input history", key_style, desc_style),
-        Line::raw(""),
-        Line::from(Span::styled("  Scroll", section_style)),
-        Line::raw(""),
-        help_line("  Shift+Up   ", "Scroll up", key_style, desc_style),
-        help_line("  Shift+Down ", "Scroll down", key_style, desc_style),
-        help_line("  PgUp/PgDn  ", "Page scroll", key_style, desc_style),
-        help_line("  End        ", "Scroll to bottom", key_style, desc_style),
-        help_line(
-            "  Mouse      ",
-            "Scroll / click agent",
-            key_style,
-            desc_style,
-        ),
-        Line::raw(""),
-        Line::from(Span::styled("  During Turns", section_style)),
-        Line::raw(""),
-        help_line(
-            "  A          ",
-            "Approve tool / plan",
-            key_style,
-            desc_style,
-        ),
-        help_line("  D          ", "Deny tool call", key_style, desc_style),
-        help_line("  Space      ", "Toggle plan step", key_style, desc_style),
-        Line::raw(""),
-        help_line("  Ctrl+C/Q   ", "Quit", key_style, desc_style),
-        help_line(
-            "  Esc        ",
-            "Close overlay / cancel",
-            key_style,
-            desc_style,
-        ),
-    ];
+    let contexts = keybindings::current_contexts(app);
+    let groups = keybindings::grouped_keybindings(&contexts);
 
-    let block = overlay_block("Help — F1", theme);
+    let mut lines: Vec<Line> = Vec::new();
+
+    for (section_label, bindings) in &groups {
+        lines.push(Line::raw(""));
+        lines.push(Line::from(Span::styled(
+            format!("  {section_label}"),
+            section_style,
+        )));
+        lines.push(Line::raw(""));
+        for kb in bindings {
+            lines.push(Line::from(vec![
+                Span::styled(format!("  {:<13}", kb.keys), key_style),
+                Span::styled(kb.description, desc_style),
+            ]));
+        }
+    }
+
+    lines.push(Line::raw(""));
+
+    let label = keybindings::context_label(&app.overlay);
+    let title = format!("Help — {label}");
+    let block = overlay_block(&title, theme);
     let paragraph = Paragraph::new(lines)
         .block(block)
         .wrap(Wrap { trim: false });
     frame.render_widget(paragraph, area);
-}
-
-fn help_line<'a>(key: &'a str, desc: &'a str, key_style: Style, desc_style: Style) -> Line<'a> {
-    Line::from(vec![
-        Span::styled(key, key_style),
-        Span::styled(desc, desc_style),
-    ])
 }
 
 fn render_agent_picker(

--- a/tui/src/view/status_bar.rs
+++ b/tui/src/view/status_bar.rs
@@ -5,6 +5,7 @@ use ratatui::text::{Line, Span};
 use ratatui::widgets::Paragraph;
 
 use crate::app::{AgentStatus, App};
+use crate::keybindings;
 use crate::theme::{self, ThemePalette};
 
 pub fn render(app: &App, frame: &mut Frame, area: Rect, theme: &ThemePalette) {
@@ -57,8 +58,13 @@ pub fn render(app: &App, frame: &mut Frame, area: Rect, theme: &ThemePalette) {
         }
     }
 
-    // Right-align keybinding hints
-    let hints = "^A agents │ ^I status │ ^N new │ ^Q quit";
+    // Right-align context-aware keybinding hints
+    let hint_pairs = keybindings::status_bar_hints(app);
+    let hints: String = hint_pairs
+        .iter()
+        .map(|(k, d)| format!("{k} {d}"))
+        .collect::<Vec<_>>()
+        .join(" │ ");
     let used_width: usize = spans.iter().map(|s| s.content.len()).sum();
     let remaining = area.width as usize - used_width.min(area.width as usize);
     if remaining > hints.len() + 2 {


### PR DESCRIPTION
## Summary
- Add `keybindings.rs` — single keybinding registry with `KeyContext` enum, context detection, grouped display, and status bar hint generation
- `?` opens help overlay when input is empty (F1 still works unconditionally)
- Help overlay dynamically shows keybindings relevant to current context (Chat, Tool Approval, Plan Approval, Overlay, etc.) with adaptive title
- Status bar hints now context-aware — shows approval keys during tool/plan approval, standard navigation otherwise

## Test plan
- [ ] `?` with empty input → opens help showing Chat + Input + Global bindings, title "Help — Chat"
- [ ] `?` with text in input → inserts `?` character
- [ ] F1 → still opens help unconditionally
- [ ] During tool approval overlay → help shows Tool Approval + Overlay + Global bindings
- [ ] During plan approval overlay → help shows Plan Approval keys
- [ ] Status bar shows `A Approve tool │ D Deny tool │ Esc Close` during tool approval
- [ ] Status bar shows standard `Ctrl+A Switch agent │ ...` in normal chat mode
- [ ] `cargo check` passes