### PR TITLE
feat(tui): command palette with fuzzy matching

### DIFF
--- a/tui/Cargo.lock
+++ b/tui/Cargo.lock
@@ -27,6 +27,7 @@ dependencies = [
  "crossterm",
  "dirs",
  "futures-util",
+ "fuzzy-matcher",
  "pulldown-cmark",
  "ratatui",
  "reqwest",
@@ -795,6 +796,15 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "fuzzy-matcher"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54614a3312934d066701a80f20f15fa3b56d67ac7722b39eea5b4c9dd1d66c94"
+dependencies = [
+ "thread_local",
 ]
 
 [[package]]

--- a/tui/Cargo.toml
+++ b/tui/Cargo.toml
@@ -49,6 +49,9 @@ futures-util = "0.3"
 syntect = "5"
 arboard = "3"
 
+# Fuzzy matching for command palette
+fuzzy-matcher = "0.3"
+
 [profile.release]
 strip = true
 lto = "thin"

--- a/tui/src/app.rs
+++ b/tui/src/app.rs
@@ -176,6 +176,9 @@ pub struct App {
     // Terminal size for responsive layout
     pub terminal_width: u16,
     pub terminal_height: u16,
+
+    // Command palette (`:` mode)
+    pub command_palette: CommandPaletteState,
 }
 
 #[derive(Debug)]
@@ -184,6 +187,15 @@ pub struct TabCompletion {
     pub candidates: Vec<String>,
     pub index: usize,
     pub insert_start: usize,
+}
+
+#[derive(Debug, Default)]
+pub struct CommandPaletteState {
+    pub input: String,
+    pub cursor: usize,
+    pub suggestions: Vec<crate::command::ScoredCommand>,
+    pub selected: usize,
+    pub active: bool,
 }
 
 impl App {
@@ -225,6 +237,7 @@ impl App {
             tab_completion: None,
             terminal_width: 120,
             terminal_height: 40,
+            command_palette: CommandPaletteState::default(),
         };
 
         // Connect and authenticate
@@ -481,6 +494,11 @@ impl App {
             return self.map_overlay_key(key);
         }
 
+        // Command palette intercepts all keys when active
+        if self.command_palette.active {
+            return self.map_palette_key(key);
+        }
+
         match (key.modifiers, key.code) {
             // Quit
             (KeyModifiers::CONTROL, KeyCode::Char('c'))
@@ -530,6 +548,13 @@ impl App {
             (KeyModifiers::CONTROL, KeyCode::Char('y')) => Some(Msg::CopyLastResponse),
             (KeyModifiers::CONTROL, KeyCode::Char('e')) => Some(Msg::ComposeInEditor),
 
+            // Command palette: `:` when input is empty and no overlay
+            (KeyModifiers::NONE | KeyModifiers::SHIFT, KeyCode::Char(':'))
+                if self.input.text.is_empty() =>
+            {
+                Some(Msg::CommandPaletteOpen)
+            }
+
             // Char input
             (KeyModifiers::NONE | KeyModifiers::SHIFT, KeyCode::Char(c)) => Some(Msg::CharInput(c)),
 
@@ -573,6 +598,24 @@ impl App {
 
     fn is_plan_approval_overlay(&self) -> bool {
         matches!(&self.overlay, Some(Overlay::PlanApproval(_)))
+    }
+
+    fn map_palette_key(&self, key: KeyEvent) -> Option<Msg> {
+        match (key.modifiers, key.code) {
+            (_, KeyCode::Esc) => Some(Msg::CommandPaletteClose),
+            (KeyModifiers::CONTROL, KeyCode::Char('c')) => Some(Msg::CommandPaletteClose),
+            (_, KeyCode::Enter) => Some(Msg::CommandPaletteSelect),
+            (_, KeyCode::Tab) => Some(Msg::CommandPaletteTab),
+            (_, KeyCode::Up) => Some(Msg::CommandPaletteUp),
+            (_, KeyCode::Down) => Some(Msg::CommandPaletteDown),
+            (_, KeyCode::Backspace) => Some(Msg::CommandPaletteBackspace),
+            (KeyModifiers::CONTROL, KeyCode::Char('w')) => Some(Msg::CommandPaletteDeleteWord),
+            (KeyModifiers::CONTROL, KeyCode::Char('u')) => Some(Msg::CommandPaletteClose),
+            (KeyModifiers::NONE | KeyModifiers::SHIFT, KeyCode::Char(c)) => {
+                Some(Msg::CommandPaletteInput(c))
+            }
+            _ => None,
+        }
     }
 
     fn map_sse(&self, event: SseEvent) -> Msg {
@@ -821,6 +864,89 @@ impl App {
                     }
                 }
                 let _ = std::fs::remove_file(&tmpfile);
+            }
+
+            // --- Command Palette ---
+            Msg::CommandPaletteOpen => {
+                self.command_palette.active = true;
+                self.command_palette.input.clear();
+                self.command_palette.cursor = 0;
+                self.command_palette.selected = 0;
+                self.command_palette.suggestions = crate::command::filter_commands("");
+            }
+            Msg::CommandPaletteClose => {
+                self.command_palette.active = false;
+                self.command_palette.input.clear();
+            }
+            Msg::CommandPaletteInput(c) => {
+                self.command_palette
+                    .input
+                    .insert(self.command_palette.cursor, c);
+                self.command_palette.cursor += c.len_utf8();
+                self.command_palette.suggestions =
+                    crate::command::filter_commands(&self.command_palette.input);
+                self.command_palette.selected = 0;
+            }
+            Msg::CommandPaletteBackspace => {
+                if self.command_palette.cursor > 0 {
+                    self.command_palette.cursor -= 1;
+                    self.command_palette.input.remove(self.command_palette.cursor);
+                    self.command_palette.suggestions =
+                        crate::command::filter_commands(&self.command_palette.input);
+                    self.command_palette.selected = 0;
+                } else {
+                    // Backspace on empty input closes palette (vim behavior)
+                    self.command_palette.active = false;
+                }
+            }
+            Msg::CommandPaletteDeleteWord => {
+                let mut pos = self.command_palette.cursor;
+                while pos > 0
+                    && self.command_palette.input.as_bytes().get(pos - 1) == Some(&b' ')
+                {
+                    pos -= 1;
+                }
+                while pos > 0
+                    && self.command_palette.input.as_bytes().get(pos - 1) != Some(&b' ')
+                {
+                    pos -= 1;
+                }
+                self.command_palette.input.drain(pos..self.command_palette.cursor);
+                self.command_palette.cursor = pos;
+                self.command_palette.suggestions =
+                    crate::command::filter_commands(&self.command_palette.input);
+                self.command_palette.selected = 0;
+            }
+            Msg::CommandPaletteUp => {
+                self.command_palette.selected =
+                    self.command_palette.selected.saturating_sub(1);
+            }
+            Msg::CommandPaletteDown => {
+                let max = self.command_palette.suggestions.len().saturating_sub(1);
+                self.command_palette.selected =
+                    (self.command_palette.selected + 1).min(max);
+            }
+            Msg::CommandPaletteTab => {
+                if let Some(scored) = self
+                    .command_palette
+                    .suggestions
+                    .get(self.command_palette.selected)
+                {
+                    let cmd = &crate::command::COMMANDS[scored.index];
+                    let args = self
+                        .command_palette
+                        .input
+                        .split_once(' ')
+                        .map(|(_, a)| format!(" {a}"))
+                        .unwrap_or_default();
+                    self.command_palette.input = format!("{}{}", cmd.name, args);
+                    self.command_palette.cursor = cmd.name.len();
+                    self.command_palette.suggestions =
+                        crate::command::filter_commands(&self.command_palette.input);
+                }
+            }
+            Msg::CommandPaletteSelect => {
+                self.execute_palette_command().await;
             }
 
             // --- Navigation ---
@@ -1447,6 +1573,88 @@ impl App {
             text,
         );
         self.stream_rx = Some(rx);
+    }
+
+    async fn execute_palette_command(&mut self) {
+        let input = self.command_palette.input.trim().to_string();
+        self.command_palette.active = false;
+        self.command_palette.input.clear();
+
+        if input.is_empty() {
+            return;
+        }
+
+        let (cmd_name, args) = match input.split_once(' ') {
+            Some((cmd, rest)) => (cmd, rest.trim()),
+            None => (input.as_str(), ""),
+        };
+
+        match cmd_name {
+            "quit" | "q" => self.should_quit = true,
+            "help" | "?" => {
+                self.overlay = Some(Overlay::Help);
+            }
+            "agents" | "a" | "sessions" | "s" => {
+                self.overlay = Some(Overlay::AgentPicker { cursor: 0 });
+            }
+            "health" | "h" | "cost" | "$" => {
+                self.overlay = Some(Overlay::SystemStatus);
+            }
+            "agent" => {
+                if !args.is_empty() {
+                    let target = args.to_lowercase();
+                    if let Some(agent) = self.agents.iter().find(|a| {
+                        a.id.to_lowercase() == target || a.name.to_lowercase() == target
+                    }) {
+                        let id = agent.id.clone();
+                        self.save_scroll_state();
+                        if let Some(a) = self.agents.iter_mut().find(|a| a.id == id) {
+                            a.has_notification = false;
+                        }
+                        self.focused_agent = Some(id);
+                        self.load_focused_session().await;
+                        self.restore_scroll_state();
+                    } else {
+                        self.error_toast =
+                            Some(ErrorToast::new(format!("Unknown agent: {args}")));
+                    }
+                } else {
+                    self.overlay = Some(Overlay::AgentPicker { cursor: 0 });
+                }
+            }
+            "clear" => {
+                // Reuse NewSession logic
+                let text = String::new();
+                self.messages.clear();
+                self.focused_session_id = None;
+                self.streaming_text.clear();
+                self.streaming_thinking.clear();
+                self.streaming_tool_calls.clear();
+                self.scroll_to_bottom();
+                drop(text);
+            }
+            "compact" => {
+                self.error_toast =
+                    Some(ErrorToast::new("Compact not yet available via TUI".into()));
+            }
+            "recall" | "r" => {
+                if args.is_empty() {
+                    self.error_toast =
+                        Some(ErrorToast::new("Usage: :recall <query>".into()));
+                } else {
+                    self.error_toast =
+                        Some(ErrorToast::new(format!("Recall not yet available: {args}")));
+                }
+            }
+            "model" => {
+                self.error_toast =
+                    Some(ErrorToast::new("Model info not yet available".into()));
+            }
+            _ => {
+                self.error_toast =
+                    Some(ErrorToast::new(format!("Unknown command: {cmd_name}")));
+            }
+        }
     }
 
     fn handle_tab_completion(&mut self) {

--- a/tui/src/command/mod.rs
+++ b/tui/src/command/mod.rs
@@ -1,0 +1,187 @@
+/// Command registry and fuzzy matching for the `:` command palette.
+use fuzzy_matcher::FuzzyMatcher;
+use fuzzy_matcher::skim::SkimMatcherV2;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CommandCategory {
+    Navigation,
+    Action,
+    Query,
+    Agent,
+}
+
+pub struct Command {
+    pub name: &'static str,
+    pub aliases: &'static [&'static str],
+    pub description: &'static str,
+    pub category: CommandCategory,
+}
+
+#[derive(Debug)]
+pub struct ScoredCommand {
+    pub index: usize,
+    pub score: i64,
+}
+
+pub static COMMANDS: &[Command] = &[
+    Command {
+        name: "sessions",
+        aliases: &["s"],
+        description: "List sessions for current agent",
+        category: CommandCategory::Navigation,
+    },
+    Command {
+        name: "agents",
+        aliases: &["a"],
+        description: "Switch agent",
+        category: CommandCategory::Navigation,
+    },
+    Command {
+        name: "agent",
+        aliases: &[],
+        description: "Switch to named agent",
+        category: CommandCategory::Agent,
+    },
+    Command {
+        name: "cost",
+        aliases: &["$"],
+        description: "Show daily cost breakdown",
+        category: CommandCategory::Query,
+    },
+    Command {
+        name: "health",
+        aliases: &["h"],
+        description: "System health status",
+        category: CommandCategory::Query,
+    },
+    Command {
+        name: "compact",
+        aliases: &[],
+        description: "Trigger distillation",
+        category: CommandCategory::Action,
+    },
+    Command {
+        name: "clear",
+        aliases: &[],
+        description: "Clear conversation / new session",
+        category: CommandCategory::Action,
+    },
+    Command {
+        name: "help",
+        aliases: &["?"],
+        description: "Show help",
+        category: CommandCategory::Navigation,
+    },
+    Command {
+        name: "quit",
+        aliases: &["q"],
+        description: "Quit application",
+        category: CommandCategory::Action,
+    },
+    Command {
+        name: "recall",
+        aliases: &["r"],
+        description: "Search memory graph",
+        category: CommandCategory::Query,
+    },
+    Command {
+        name: "model",
+        aliases: &[],
+        description: "Show current model info",
+        category: CommandCategory::Query,
+    },
+];
+
+const MAX_SUGGESTIONS: usize = 8;
+
+/// Filter and rank commands by fuzzy matching against the input.
+///
+/// When input contains a space, only the first word is matched against commands.
+/// Returns up to 8 results sorted by score descending.
+pub fn filter_commands(input: &str) -> Vec<ScoredCommand> {
+    let query = match input.split_once(' ') {
+        Some((cmd, _)) => cmd,
+        None => input,
+    };
+
+    if query.is_empty() {
+        return COMMANDS
+            .iter()
+            .enumerate()
+            .map(|(i, _)| ScoredCommand { index: i, score: 0 })
+            .collect();
+    }
+
+    let matcher = SkimMatcherV2::default();
+    let mut scored: Vec<ScoredCommand> = COMMANDS
+        .iter()
+        .enumerate()
+        .filter_map(|(i, cmd)| {
+            let mut best: Option<i64> = None;
+
+            if let Some(s) = matcher.fuzzy_match(cmd.name, query) {
+                best = Some(s);
+            }
+            for alias in cmd.aliases {
+                if let Some(s) = matcher.fuzzy_match(alias, query) {
+                    best = best.map_or(Some(s), |prev| Some(prev.max(s)));
+                }
+            }
+            if let Some(s) = matcher.fuzzy_match(cmd.description, query) {
+                best = best.map_or(Some(s), |prev| Some(prev.max(s)));
+            }
+
+            best.map(|score| ScoredCommand { index: i, score })
+        })
+        .collect();
+
+    scored.sort_by(|a, b| b.score.cmp(&a.score));
+    scored.truncate(MAX_SUGGESTIONS);
+    scored
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_input_returns_all_commands() {
+        let results = filter_commands("");
+        assert_eq!(results.len(), COMMANDS.len());
+    }
+
+    #[test]
+    fn exact_name_match_ranks_first() {
+        let results = filter_commands("quit");
+        assert!(!results.is_empty());
+        assert_eq!(COMMANDS[results[0].index].name, "quit");
+    }
+
+    #[test]
+    fn alias_match_works() {
+        let results = filter_commands("q");
+        assert!(!results.is_empty());
+        assert!(results.iter().any(|r| COMMANDS[r.index].name == "quit"));
+    }
+
+    #[test]
+    fn fuzzy_match_partial() {
+        let results = filter_commands("sess");
+        assert!(!results.is_empty());
+        assert_eq!(COMMANDS[results[0].index].name, "sessions");
+    }
+
+    #[test]
+    fn max_eight_results() {
+        let results = filter_commands("a");
+        assert!(results.len() <= MAX_SUGGESTIONS);
+    }
+
+    #[test]
+    fn command_with_args_matches_command_only() {
+        let results = filter_commands("agent syn");
+        assert!(!results.is_empty());
+        // "agent" should be in results (args are stripped before matching)
+        assert!(results.iter().any(|r| COMMANDS[r.index].name == "agent"));
+    }
+}

--- a/tui/src/main.rs
+++ b/tui/src/main.rs
@@ -1,6 +1,7 @@
 mod api;
 mod app;
 mod clipboard;
+mod command;
 mod config;
 mod events;
 mod highlight;

--- a/tui/src/msg.rs
+++ b/tui/src/msg.rs
@@ -21,6 +21,17 @@ pub enum Msg {
     ComposeInEditor,  // Ctrl+E — open $EDITOR for multi-line compose
     Quit,             // Ctrl+C or Ctrl+Q
 
+    // --- Command palette ---
+    CommandPaletteOpen,
+    CommandPaletteClose,
+    CommandPaletteInput(char),
+    CommandPaletteBackspace,
+    CommandPaletteDeleteWord,
+    CommandPaletteSelect,
+    CommandPaletteUp,
+    CommandPaletteDown,
+    CommandPaletteTab,
+
     NewSession, // Ctrl+N — start new topic
 
     // --- Navigation ---

--- a/tui/src/view/command_palette.rs
+++ b/tui/src/view/command_palette.rs
@@ -1,0 +1,89 @@
+use ratatui::Frame;
+use ratatui::layout::Rect;
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Paragraph};
+
+use crate::app::App;
+use crate::command::{CommandCategory, COMMANDS};
+use crate::theme::ThemePalette;
+
+pub fn render(app: &App, frame: &mut Frame, area: Rect, theme: &ThemePalette) {
+    if !app.command_palette.active || area.height < 2 {
+        return;
+    }
+
+    let palette = &app.command_palette;
+    let mut lines: Vec<Line> = Vec::new();
+
+    // Input line: `:` prompt + typed text
+    lines.push(Line::from(vec![
+        Span::styled(
+            ":",
+            Style::default()
+                .fg(theme.accent)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(&palette.input, theme.style_fg()),
+    ]));
+
+    // Suggestion lines (max 8)
+    for (i, scored) in palette.suggestions.iter().enumerate().take(8) {
+        let cmd = &COMMANDS[scored.index];
+        let selected = i == palette.selected;
+        let marker = if selected { "▸" } else { " " };
+
+        let name_style = if selected {
+            Style::default()
+                .fg(theme.accent)
+                .add_modifier(Modifier::BOLD)
+        } else {
+            theme.style_fg()
+        };
+
+        let category_color = match cmd.category {
+            CommandCategory::Navigation => theme.accent,
+            CommandCategory::Action => theme.warning,
+            CommandCategory::Query => theme.success,
+            CommandCategory::Agent => theme.streaming,
+        };
+
+        let mut spans = vec![
+            Span::styled(
+                format!(" {} ", marker),
+                if selected {
+                    name_style
+                } else {
+                    theme.style_dim()
+                },
+            ),
+            Span::styled("●", Style::default().fg(category_color)),
+            Span::styled(format!(" {:<12}", cmd.name), name_style),
+            Span::styled(cmd.description, theme.style_muted()),
+        ];
+
+        if !cmd.aliases.is_empty() {
+            let alias_str = cmd
+                .aliases
+                .iter()
+                .map(|a| format!(":{a}"))
+                .collect::<Vec<_>>()
+                .join(" ");
+            spans.push(Span::styled(format!("  {alias_str}"), theme.style_dim()));
+        }
+
+        lines.push(Line::from(spans));
+    }
+
+    let block = Block::default()
+        .borders(Borders::TOP)
+        .border_style(Style::default().fg(theme.separator));
+
+    let paragraph = Paragraph::new(lines).block(block);
+    frame.render_widget(paragraph, area);
+
+    // Position cursor in the input area
+    let cursor_x = area.x + 1 + palette.cursor as u16;
+    let cursor_y = area.y + 1; // +1 for top border
+    frame.set_cursor_position((cursor_x, cursor_y));
+}

--- a/tui/src/view/mod.rs
+++ b/tui/src/view/mod.rs
@@ -1,4 +1,5 @@
 mod chat;
+mod command_palette;
 mod input;
 mod overlay;
 mod sidebar;
@@ -14,40 +15,55 @@ pub fn render(app: &App, frame: &mut Frame) {
     let area = frame.area();
     let theme = &app.theme;
 
-    // Top-level vertical split: title bar | body | status bar | (optional toast)
     let has_toast = app.error_toast.is_some();
+    let palette_active = app.command_palette.active;
+
+    // When palette is active, it replaces the status bar with a variable-height area
+    let bottom_height = if palette_active {
+        let suggestion_lines = app.command_palette.suggestions.len().min(8) as u16;
+        (2 + suggestion_lines).max(3) // input + border + suggestions, min 3
+    } else {
+        1 // status bar
+    };
+
     let vertical = Layout::default()
         .direction(Direction::Vertical)
         .constraints(if has_toast {
             vec![
-                Constraint::Length(1), // title bar
-                Constraint::Min(5),    // body
-                Constraint::Length(1), // status bar
-                Constraint::Length(1), // error toast
+                Constraint::Length(1),            // title bar
+                Constraint::Min(5),               // body
+                Constraint::Length(bottom_height), // status bar or command palette
+                Constraint::Length(1),            // error toast
             ]
         } else {
             vec![
-                Constraint::Length(1), // title bar
-                Constraint::Min(5),    // body
-                Constraint::Length(1), // status bar
+                Constraint::Length(1),            // title bar
+                Constraint::Min(5),               // body
+                Constraint::Length(bottom_height), // status bar or command palette
             ]
         })
         .split(area);
 
     title_bar::render(app, frame, vertical[0], theme);
-    status_bar::render(app, frame, vertical[2], theme);
+
+    // Bottom area: command palette or status bar
+    if palette_active {
+        command_palette::render(app, frame, vertical[2], theme);
+    } else {
+        status_bar::render(app, frame, vertical[2], theme);
+    }
 
     // Error toast at bottom
-    if has_toast {
-        if let Some(ref toast) = app.error_toast {
-            let toast_line = ratatui::text::Line::from(vec![
-                ratatui::text::Span::styled(" ✗ ", theme.style_error_bold()),
-                ratatui::text::Span::styled(&toast.message, theme.style_error()),
-            ]);
-            let toast_widget = ratatui::widgets::Paragraph::new(toast_line)
-                .style(ratatui::style::Style::default().bg(theme.surface_dim));
-            frame.render_widget(toast_widget, vertical[3]);
-        }
+    if has_toast
+        && let Some(ref toast) = app.error_toast
+    {
+        let toast_line = ratatui::text::Line::from(vec![
+            ratatui::text::Span::styled(" ✗ ", theme.style_error_bold()),
+            ratatui::text::Span::styled(&toast.message, theme.style_error()),
+        ]);
+        let toast_widget = ratatui::widgets::Paragraph::new(toast_line)
+            .style(ratatui::style::Style::default().bg(theme.surface_dim));
+        frame.render_widget(toast_widget, vertical[3]);
     }
 
     // Responsive: hide sidebar on narrow terminals (< 60 cols)
@@ -66,9 +82,6 @@ pub fn render(app: &App, frame: &mut Frame) {
         sidebar::render(app, frame, horizontal[0], theme);
         render_chat_area(app, frame, horizontal[1], theme);
 
-        // Store sidebar area for mouse click detection (mutable through interior pattern)
-        // We can't mutate app here since view takes &self, so store in a separate mechanism
-        // Actually we'll update sidebar_area before render in the event loop
         SIDEBAR_RECT.store_rect(horizontal[0]);
     } else {
         SIDEBAR_RECT.store_rect(Rect::ZERO);

--- a/tui/src/view/overlay.rs
+++ b/tui/src/view/overlay.rs
@@ -92,6 +92,7 @@ fn render_help(frame: &mut Frame, area: Rect, theme: &ThemePalette) {
         Line::raw(""),
         help_line("  Enter      ", "Send message", key_style, desc_style),
         help_line("  @agent Tab ", "Mention completion", key_style, desc_style),
+        help_line("  : (empty)  ", "Command palette", key_style, desc_style),
         help_line("  Ctrl+U     ", "Clear input line", key_style, desc_style),
         help_line("  Ctrl+W     ", "Delete word", key_style, desc_style),
         help_line(

--- a/tui/src/view/status_bar.rs
+++ b/tui/src/view/status_bar.rs
@@ -58,7 +58,7 @@ pub fn render(app: &App, frame: &mut Frame, area: Rect, theme: &ThemePalette) {
     }
 
     // Right-align keybinding hints
-    let hints = "^A agents │ ^I status │ ^N new │ ^Q quit";
+    let hints = "^A agents │ ^I status │ ^N new │ : cmd │ ^Q quit";
     let used_width: usize = spans.iter().map(|s| s.content.len()).sum();
     let remaining = area.width as usize - used_width.min(area.width as usize);
     if remaining > hints.len() + 2 {


### PR DESCRIPTION
## Summary
- Add `:` command mode — vim-style universal action launcher with fuzzy matching
- 11 commands: sessions, agents, agent <name>, cost, health, compact, clear, help, quit, recall, model
- `fuzzy-matcher` (SkimMatcherV2) ranks against name + aliases + description, top 8 shown
- Renders at bottom (like vim command line), replaces status bar while active
- Category-colored dots, Tab autocomplete, Esc/Backspace-on-empty to dismiss

## Test plan
- [x] `cargo check` clean
- [x] `cargo clippy` — no new warnings
- [x] `cargo test` — 6/6 passed (fuzzy matching unit tests)
- [ ] Visual: launch TUI → press `:` → type partial commands → verify suggestions → Enter executes → Esc dismisses
- [ ] Verify `:` in non-empty input inserts literal colon