### PR TITLE
feat(tui): command palette, context-aware help, status bar upgrade

### DIFF
--- a/tui/Cargo.lock
+++ b/tui/Cargo.lock
@@ -27,6 +27,7 @@ dependencies = [
  "crossterm",
  "dirs",
  "futures-util",
+ "fuzzy-matcher",
  "pulldown-cmark",
  "ratatui",
  "reqwest",
@@ -795,6 +796,15 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "fuzzy-matcher"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54614a3312934d066701a80f20f15fa3b56d67ac7722b39eea5b4c9dd1d66c94"
+dependencies = [
+ "thread_local",
 ]
 
 [[package]]

--- a/tui/Cargo.toml
+++ b/tui/Cargo.toml
@@ -49,6 +49,9 @@ futures-util = "0.3"
 syntect = "5"
 arboard = "3"
 
+# Fuzzy matching for command palette
+fuzzy-matcher = "0.3"
+
 [profile.release]
 strip = true
 lto = "thin"

--- a/tui/src/app.rs
+++ b/tui/src/app.rs
@@ -20,8 +20,9 @@ use crate::view;
 
 #[allow(unused_imports)]
 pub use crate::state::{
-    AgentState, AgentStatus, ChatMessage, InputState, Overlay, PlanApprovalOverlay,
-    PlanStepApproval, TabCompletion, ToolApprovalOverlay, ToolCallInfo,
+    AgentState, AgentStatus, ChatMessage, CommandPaletteState, InputState, Overlay,
+    PlanApprovalOverlay, PlanStepApproval, SelectionContext, TabCompletion,
+    ToolApprovalOverlay, ToolCallInfo,
 };
 use crate::state::SavedScrollState;
 
@@ -83,6 +84,15 @@ pub struct App {
     // Terminal size for responsive layout
     pub terminal_width: u16,
     pub terminal_height: u16,
+
+    // Command palette (`:` mode)
+    pub command_palette: CommandPaletteState,
+
+    // Status bar enhanced fields
+    pub session_cost_cents: u32,
+    pub active_filter: Option<String>,
+    pub context_usage_pct: Option<u8>,
+    pub selection: SelectionContext,
 }
 
 impl App {
@@ -124,6 +134,11 @@ impl App {
             tab_completion: None,
             terminal_width: 120,
             terminal_height: 40,
+            command_palette: CommandPaletteState::default(),
+            session_cost_cents: 0,
+            active_filter: Option::None,
+            context_usage_pct: Option::None,
+            selection: SelectionContext::default(),
         };
 
         app.connect().await?;
@@ -360,6 +375,11 @@ impl App {
             return self.map_overlay_key(key);
         }
 
+        // Command palette intercepts all keys when active
+        if self.command_palette.active {
+            return self.map_palette_key(key);
+        }
+
         match (key.modifiers, key.code) {
             (KeyModifiers::CONTROL, KeyCode::Char('c'))
             | (KeyModifiers::CONTROL, KeyCode::Char('q')) => Some(Msg::Quit),
@@ -403,10 +423,40 @@ impl App {
             (KeyModifiers::CONTROL, KeyCode::Char('y')) => Some(Msg::CopyLastResponse),
             (KeyModifiers::CONTROL, KeyCode::Char('e')) => Some(Msg::ComposeInEditor),
 
+            // Context-aware help (only when input is empty)
+            (KeyModifiers::NONE, KeyCode::Char('?')) if self.input.text.is_empty() => {
+                Some(Msg::OpenOverlay(OverlayKind::Help))
+            }
+
+            // Command palette:  when input is empty and no overlay
+            (KeyModifiers::NONE | KeyModifiers::SHIFT, KeyCode::Char(':'))
+                if self.input.text.is_empty() =>
+            {
+                Some(Msg::CommandPaletteOpen)
+            }
+
             (KeyModifiers::NONE | KeyModifiers::SHIFT, KeyCode::Char(c)) => {
                 Some(Msg::CharInput(c))
             }
 
+            _ => None,
+        }
+    }
+
+    fn map_palette_key(&self, key: KeyEvent) -> Option<Msg> {
+        match (key.modifiers, key.code) {
+            (_, KeyCode::Esc) => Some(Msg::CommandPaletteClose),
+            (KeyModifiers::CONTROL, KeyCode::Char('c')) => Some(Msg::CommandPaletteClose),
+            (_, KeyCode::Enter) => Some(Msg::CommandPaletteSelect),
+            (_, KeyCode::Tab) => Some(Msg::CommandPaletteTab),
+            (_, KeyCode::Up) => Some(Msg::CommandPaletteUp),
+            (_, KeyCode::Down) => Some(Msg::CommandPaletteDown),
+            (_, KeyCode::Backspace) => Some(Msg::CommandPaletteBackspace),
+            (KeyModifiers::CONTROL, KeyCode::Char('w')) => Some(Msg::CommandPaletteDeleteWord),
+            (KeyModifiers::CONTROL, KeyCode::Char('u')) => Some(Msg::CommandPaletteClose),
+            (KeyModifiers::NONE | KeyModifiers::SHIFT, KeyCode::Char(c)) => {
+                Some(Msg::CommandPaletteInput(c))
+            }
             _ => None,
         }
     }

--- a/tui/src/command/mod.rs
+++ b/tui/src/command/mod.rs
@@ -1,0 +1,186 @@
+/// Command registry and fuzzy matching for the `:` command palette.
+use fuzzy_matcher::FuzzyMatcher;
+use fuzzy_matcher::skim::SkimMatcherV2;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CommandCategory {
+    Navigation,
+    Action,
+    Query,
+    Agent,
+}
+
+pub struct Command {
+    pub name: &'static str,
+    pub aliases: &'static [&'static str],
+    pub description: &'static str,
+    pub category: CommandCategory,
+}
+
+#[derive(Debug)]
+pub struct ScoredCommand {
+    pub index: usize,
+    pub score: i64,
+}
+
+pub static COMMANDS: &[Command] = &[
+    Command {
+        name: "sessions",
+        aliases: &["s"],
+        description: "List sessions for current agent",
+        category: CommandCategory::Navigation,
+    },
+    Command {
+        name: "agents",
+        aliases: &["a"],
+        description: "Switch agent",
+        category: CommandCategory::Navigation,
+    },
+    Command {
+        name: "agent",
+        aliases: &[],
+        description: "Switch to named agent",
+        category: CommandCategory::Agent,
+    },
+    Command {
+        name: "cost",
+        aliases: &["$"],
+        description: "Show daily cost breakdown",
+        category: CommandCategory::Query,
+    },
+    Command {
+        name: "health",
+        aliases: &["h"],
+        description: "System health status",
+        category: CommandCategory::Query,
+    },
+    Command {
+        name: "compact",
+        aliases: &[],
+        description: "Trigger distillation",
+        category: CommandCategory::Action,
+    },
+    Command {
+        name: "clear",
+        aliases: &[],
+        description: "Clear conversation / new session",
+        category: CommandCategory::Action,
+    },
+    Command {
+        name: "help",
+        aliases: &["?"],
+        description: "Show help",
+        category: CommandCategory::Navigation,
+    },
+    Command {
+        name: "quit",
+        aliases: &["q"],
+        description: "Quit application",
+        category: CommandCategory::Action,
+    },
+    Command {
+        name: "recall",
+        aliases: &["r"],
+        description: "Search memory graph",
+        category: CommandCategory::Query,
+    },
+    Command {
+        name: "model",
+        aliases: &[],
+        description: "Show current model info",
+        category: CommandCategory::Query,
+    },
+];
+
+const MAX_SUGGESTIONS: usize = 8;
+
+/// Filter and rank commands by fuzzy matching against the input.
+///
+/// When input contains a space, only the first word is matched against commands.
+/// Returns up to 8 results sorted by score descending.
+pub fn filter_commands(input: &str) -> Vec<ScoredCommand> {
+    let query = match input.split_once(' ') {
+        Some((cmd, _)) => cmd,
+        None => input,
+    };
+
+    if query.is_empty() {
+        return COMMANDS
+            .iter()
+            .enumerate()
+            .map(|(i, _)| ScoredCommand { index: i, score: 0 })
+            .collect();
+    }
+
+    let matcher = SkimMatcherV2::default();
+    let mut scored: Vec<ScoredCommand> = COMMANDS
+        .iter()
+        .enumerate()
+        .filter_map(|(i, cmd)| {
+            let mut best: Option<i64> = None;
+
+            if let Some(s) = matcher.fuzzy_match(cmd.name, query) {
+                best = Some(s);
+            }
+            for alias in cmd.aliases {
+                if let Some(s) = matcher.fuzzy_match(alias, query) {
+                    best = best.map_or(Some(s), |prev| Some(prev.max(s)));
+                }
+            }
+            if let Some(s) = matcher.fuzzy_match(cmd.description, query) {
+                best = best.map_or(Some(s), |prev| Some(prev.max(s)));
+            }
+
+            best.map(|score| ScoredCommand { index: i, score })
+        })
+        .collect();
+
+    scored.sort_by(|a, b| b.score.cmp(&a.score));
+    scored.truncate(MAX_SUGGESTIONS);
+    scored
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_input_returns_all_commands() {
+        let results = filter_commands("");
+        assert_eq!(results.len(), COMMANDS.len());
+    }
+
+    #[test]
+    fn exact_name_match_ranks_first() {
+        let results = filter_commands("quit");
+        assert!(!results.is_empty());
+        assert_eq!(COMMANDS[results[0].index].name, "quit");
+    }
+
+    #[test]
+    fn alias_match_works() {
+        let results = filter_commands("q");
+        assert!(!results.is_empty());
+        assert!(results.iter().any(|r| COMMANDS[r.index].name == "quit"));
+    }
+
+    #[test]
+    fn fuzzy_match_partial() {
+        let results = filter_commands("sess");
+        assert!(!results.is_empty());
+        assert_eq!(COMMANDS[results[0].index].name, "sessions");
+    }
+
+    #[test]
+    fn max_eight_results() {
+        let results = filter_commands("a");
+        assert!(results.len() <= MAX_SUGGESTIONS);
+    }
+
+    #[test]
+    fn command_with_args_matches_command_only() {
+        let results = filter_commands("agent syn");
+        assert!(!results.is_empty());
+        assert!(results.iter().any(|r| COMMANDS[r.index].name == "agent"));
+    }
+}

--- a/tui/src/keybindings.rs
+++ b/tui/src/keybindings.rs
@@ -1,0 +1,304 @@
+/// Context-aware keybinding registry — single source of truth for help overlay and status bar hints.
+use crate::app::{App, Overlay};
+
+pub struct Keybinding {
+    pub keys: &'static str,
+    pub description: &'static str,
+    pub contexts: &'static [KeyContext],
+    pub show_in_status_bar: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum KeyContext {
+    Global,
+    Chat,
+    Input,
+    Overlay,
+    ToolApproval,
+    PlanApproval,
+}
+
+impl KeyContext {
+    pub fn section_label(self) -> &'static str {
+        match self {
+            Self::Global => "Global",
+            Self::Chat => "Chat",
+            Self::Input => "Input",
+            Self::Overlay => "Overlay",
+            Self::ToolApproval => "Tool Approval",
+            Self::PlanApproval => "Plan Approval",
+        }
+    }
+
+    fn display_order(self) -> u8 {
+        match self {
+            Self::ToolApproval | Self::PlanApproval => 0,
+            Self::Chat => 1,
+            Self::Input => 2,
+            Self::Overlay => 3,
+            Self::Global => 4,
+        }
+    }
+}
+
+pub fn all_keybindings() -> &'static [Keybinding] {
+    &[
+        // --- Global ---
+        Keybinding {
+            keys: "?",
+            description: "Help for current view",
+            contexts: &[KeyContext::Global],
+            show_in_status_bar: false,
+        },
+        Keybinding {
+            keys: ":",
+            description: "Command palette",
+            contexts: &[KeyContext::Global],
+            show_in_status_bar: true,
+        },
+        Keybinding {
+            keys: "Ctrl+A",
+            description: "Switch agent",
+            contexts: &[KeyContext::Global],
+            show_in_status_bar: true,
+        },
+        Keybinding {
+            keys: "Ctrl+F",
+            description: "Toggle sidebar",
+            contexts: &[KeyContext::Global],
+            show_in_status_bar: false,
+        },
+        Keybinding {
+            keys: "Ctrl+T",
+            description: "Toggle thinking",
+            contexts: &[KeyContext::Global],
+            show_in_status_bar: false,
+        },
+        Keybinding {
+            keys: "Ctrl+I",
+            description: "System status",
+            contexts: &[KeyContext::Global],
+            show_in_status_bar: true,
+        },
+        Keybinding {
+            keys: "Ctrl+N",
+            description: "New session",
+            contexts: &[KeyContext::Global],
+            show_in_status_bar: true,
+        },
+        Keybinding {
+            keys: "Ctrl+C/Q",
+            description: "Quit",
+            contexts: &[KeyContext::Global],
+            show_in_status_bar: true,
+        },
+        // --- Chat ---
+        Keybinding {
+            keys: "Ctrl+Y",
+            description: "Copy last response",
+            contexts: &[KeyContext::Chat],
+            show_in_status_bar: false,
+        },
+        Keybinding {
+            keys: "Shift+Up",
+            description: "Scroll up",
+            contexts: &[KeyContext::Chat],
+            show_in_status_bar: false,
+        },
+        Keybinding {
+            keys: "Shift+Down",
+            description: "Scroll down",
+            contexts: &[KeyContext::Chat],
+            show_in_status_bar: false,
+        },
+        Keybinding {
+            keys: "PgUp/PgDn",
+            description: "Page scroll",
+            contexts: &[KeyContext::Chat],
+            show_in_status_bar: false,
+        },
+        Keybinding {
+            keys: "End",
+            description: "Scroll to bottom",
+            contexts: &[KeyContext::Chat],
+            show_in_status_bar: false,
+        },
+        Keybinding {
+            keys: "Mouse",
+            description: "Scroll / click agent",
+            contexts: &[KeyContext::Chat],
+            show_in_status_bar: false,
+        },
+        // --- Input ---
+        Keybinding {
+            keys: "Enter",
+            description: "Send message",
+            contexts: &[KeyContext::Input],
+            show_in_status_bar: false,
+        },
+        Keybinding {
+            keys: "@agent Tab",
+            description: "Mention completion",
+            contexts: &[KeyContext::Input],
+            show_in_status_bar: false,
+        },
+        Keybinding {
+            keys: "Ctrl+U",
+            description: "Clear input line",
+            contexts: &[KeyContext::Input],
+            show_in_status_bar: false,
+        },
+        Keybinding {
+            keys: "Ctrl+W",
+            description: "Delete word",
+            contexts: &[KeyContext::Input],
+            show_in_status_bar: false,
+        },
+        Keybinding {
+            keys: "Ctrl+E",
+            description: "Open $EDITOR",
+            contexts: &[KeyContext::Input],
+            show_in_status_bar: false,
+        },
+        Keybinding {
+            keys: "Up/Down",
+            description: "Input history",
+            contexts: &[KeyContext::Input],
+            show_in_status_bar: false,
+        },
+        // --- Overlay (generic) ---
+        Keybinding {
+            keys: "Esc",
+            description: "Close",
+            contexts: &[KeyContext::Overlay],
+            show_in_status_bar: true,
+        },
+        Keybinding {
+            keys: "Up/Down",
+            description: "Navigate",
+            contexts: &[KeyContext::Overlay],
+            show_in_status_bar: false,
+        },
+        Keybinding {
+            keys: "Enter",
+            description: "Select",
+            contexts: &[KeyContext::Overlay],
+            show_in_status_bar: false,
+        },
+        // --- Tool Approval ---
+        Keybinding {
+            keys: "A",
+            description: "Approve tool",
+            contexts: &[KeyContext::ToolApproval],
+            show_in_status_bar: true,
+        },
+        Keybinding {
+            keys: "D",
+            description: "Deny tool",
+            contexts: &[KeyContext::ToolApproval],
+            show_in_status_bar: true,
+        },
+        // --- Plan Approval ---
+        Keybinding {
+            keys: "Space",
+            description: "Toggle step",
+            contexts: &[KeyContext::PlanApproval],
+            show_in_status_bar: true,
+        },
+        Keybinding {
+            keys: "A",
+            description: "Approve all",
+            contexts: &[KeyContext::PlanApproval],
+            show_in_status_bar: true,
+        },
+        Keybinding {
+            keys: "C",
+            description: "Cancel plan",
+            contexts: &[KeyContext::PlanApproval],
+            show_in_status_bar: true,
+        },
+    ]
+}
+
+pub fn current_contexts(app: &App) -> Vec<KeyContext> {
+    let mut contexts = vec![KeyContext::Global];
+
+    match &app.overlay {
+        Some(Overlay::ToolApproval(_)) => {
+            contexts.push(KeyContext::ToolApproval);
+            contexts.push(KeyContext::Overlay);
+        }
+        Some(Overlay::PlanApproval(_)) => {
+            contexts.push(KeyContext::PlanApproval);
+            contexts.push(KeyContext::Overlay);
+        }
+        Some(_) => {
+            contexts.push(KeyContext::Overlay);
+        }
+        None => {
+            contexts.push(KeyContext::Chat);
+            contexts.push(KeyContext::Input);
+        }
+    }
+
+    contexts
+}
+
+pub fn context_label(overlay: &Option<Overlay>) -> &'static str {
+    match overlay {
+        None => "Chat",
+        Some(Overlay::Help) => "Help",
+        Some(Overlay::AgentPicker { .. }) => "Agent Picker",
+        Some(Overlay::ToolApproval(_)) => "Tool Approval",
+        Some(Overlay::PlanApproval(_)) => "Plan Approval",
+        Some(Overlay::SystemStatus) => "System Status",
+    }
+}
+
+/// Groups keybindings by their primary context, ordered for display.
+pub fn grouped_keybindings(
+    contexts: &[KeyContext],
+) -> Vec<(&'static str, Vec<&'static Keybinding>)> {
+    let mut context_order: Vec<KeyContext> = contexts.to_vec();
+    context_order.sort_by_key(|c| c.display_order());
+
+    let mut groups: Vec<(&'static str, Vec<&'static Keybinding>)> = Vec::new();
+    let mut seen_keys: Vec<&'static str> = Vec::new();
+
+    for ctx in &context_order {
+        let label = ctx.section_label();
+        if groups.iter().any(|(l, _)| *l == label) {
+            continue;
+        }
+
+        let bindings: Vec<&'static Keybinding> = all_keybindings()
+            .iter()
+            .filter(|kb| kb.contexts.contains(ctx))
+            .filter(|kb| {
+                if seen_keys.contains(&kb.keys) {
+                    false
+                } else {
+                    seen_keys.push(kb.keys);
+                    true
+                }
+            })
+            .collect();
+
+        if !bindings.is_empty() {
+            groups.push((label, bindings));
+        }
+    }
+
+    groups
+}
+
+pub fn status_bar_hints(app: &App) -> Vec<(&'static str, &'static str)> {
+    let contexts = current_contexts(app);
+
+    all_keybindings()
+        .iter()
+        .filter(|kb| kb.show_in_status_bar)
+        .filter(|kb| kb.contexts.iter().any(|c| contexts.contains(c)))
+        .map(|kb| (kb.keys, kb.description))
+        .collect()
+}

--- a/tui/src/main.rs
+++ b/tui/src/main.rs
@@ -1,9 +1,11 @@
 mod api;
 mod app;
 mod clipboard;
+mod command;
 mod config;
 mod events;
 mod highlight;
+mod keybindings;
 mod markdown;
 mod msg;
 mod state;

--- a/tui/src/msg.rs
+++ b/tui/src/msg.rs
@@ -21,6 +21,17 @@ pub enum Msg {
     ComposeInEditor,  // Ctrl+E — open $EDITOR for multi-line compose
     Quit,             // Ctrl+C or Ctrl+Q
 
+    // --- Command palette ---
+    CommandPaletteOpen,
+    CommandPaletteClose,
+    CommandPaletteInput(char),
+    CommandPaletteBackspace,
+    CommandPaletteDeleteWord,
+    CommandPaletteSelect,
+    CommandPaletteUp,
+    CommandPaletteDown,
+    CommandPaletteTab,
+
     NewSession, // Ctrl+N — start new topic
 
     // --- Navigation ---

--- a/tui/src/state/command.rs
+++ b/tui/src/state/command.rs
@@ -1,0 +1,21 @@
+/// Command palette state.
+#[derive(Debug, Default)]
+pub struct CommandPaletteState {
+    pub input: String,
+    pub cursor: usize,
+    pub suggestions: Vec<crate::command::ScoredCommand>,
+    pub selected: usize,
+    pub active: bool,
+}
+
+/// Selection context for context-aware status bar hints.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[expect(dead_code, reason = "variants used when selection tracking is wired")]
+pub enum SelectionContext {
+    #[default]
+    None,
+    UserMessage,
+    AgentResponse,
+    ToolCall,
+    SessionList,
+}

--- a/tui/src/state/mod.rs
+++ b/tui/src/state/mod.rs
@@ -1,10 +1,12 @@
 mod agent;
 mod chat;
+mod command;
 mod input;
 mod overlay;
 
 pub use agent::{AgentState, AgentStatus};
 pub use chat::{ChatMessage, ToolCallInfo};
 pub(crate) use chat::SavedScrollState;
+pub use command::{CommandPaletteState, SelectionContext};
 pub use input::{InputState, TabCompletion};
 pub use overlay::{Overlay, PlanApprovalOverlay, PlanStepApproval, ToolApprovalOverlay};

--- a/tui/src/update/command.rs
+++ b/tui/src/update/command.rs
@@ -1,0 +1,166 @@
+use crate::app::App;
+use crate::msg::ErrorToast;
+use crate::state::Overlay;
+
+pub fn handle_open(app: &mut App) {
+    app.command_palette.active = true;
+    app.command_palette.input.clear();
+    app.command_palette.cursor = 0;
+    app.command_palette.selected = 0;
+    app.command_palette.suggestions = crate::command::filter_commands("");
+}
+
+pub fn handle_close(app: &mut App) {
+    app.command_palette.active = false;
+    app.command_palette.input.clear();
+}
+
+pub fn handle_input(app: &mut App, c: char) {
+    app.command_palette
+        .input
+        .insert(app.command_palette.cursor, c);
+    app.command_palette.cursor += c.len_utf8();
+    app.command_palette.suggestions =
+        crate::command::filter_commands(&app.command_palette.input);
+    app.command_palette.selected = 0;
+}
+
+pub fn handle_backspace(app: &mut App) {
+    if app.command_palette.cursor > 0 {
+        app.command_palette.cursor -= 1;
+        app.command_palette.input.remove(app.command_palette.cursor);
+        app.command_palette.suggestions =
+            crate::command::filter_commands(&app.command_palette.input);
+        app.command_palette.selected = 0;
+    } else {
+        // Backspace on empty input closes palette (vim behavior)
+        app.command_palette.active = false;
+    }
+}
+
+pub fn handle_delete_word(app: &mut App) {
+    let mut pos = app.command_palette.cursor;
+    while pos > 0 && app.command_palette.input.as_bytes().get(pos - 1) == Some(&b' ') {
+        pos -= 1;
+    }
+    while pos > 0 && app.command_palette.input.as_bytes().get(pos - 1) != Some(&b' ') {
+        pos -= 1;
+    }
+    app.command_palette.input.drain(pos..app.command_palette.cursor);
+    app.command_palette.cursor = pos;
+    app.command_palette.suggestions =
+        crate::command::filter_commands(&app.command_palette.input);
+    app.command_palette.selected = 0;
+}
+
+pub fn handle_up(app: &mut App) {
+    app.command_palette.selected = app.command_palette.selected.saturating_sub(1);
+}
+
+pub fn handle_down(app: &mut App) {
+    let max = app.command_palette.suggestions.len().saturating_sub(1);
+    app.command_palette.selected = (app.command_palette.selected + 1).min(max);
+}
+
+pub fn handle_tab(app: &mut App) {
+    if let Some(scored) = app
+        .command_palette
+        .suggestions
+        .get(app.command_palette.selected)
+    {
+        let cmd = &crate::command::COMMANDS[scored.index];
+        let args = app
+            .command_palette
+            .input
+            .split_once(' ')
+            .map(|(_, a)| format!(" {a}"))
+            .unwrap_or_default();
+        app.command_palette.input = format!("{}{}", cmd.name, args);
+        app.command_palette.cursor = cmd.name.len();
+        app.command_palette.suggestions =
+            crate::command::filter_commands(&app.command_palette.input);
+    }
+}
+
+pub async fn handle_select(app: &mut App) {
+    execute_command(app).await;
+}
+
+async fn execute_command(app: &mut App) {
+    let input = app.command_palette.input.trim().to_string();
+    app.command_palette.active = false;
+    app.command_palette.input.clear();
+
+    if input.is_empty() {
+        return;
+    }
+
+    let (cmd_name, args) = match input.split_once(' ') {
+        Some((cmd, rest)) => (cmd, rest.trim()),
+        None => (input.as_str(), ""),
+    };
+
+    match cmd_name {
+        "quit" | "q" => app.should_quit = true,
+        "help" | "?" => {
+            app.overlay = Some(Overlay::Help);
+        }
+        "agents" | "a" | "sessions" | "s" => {
+            app.overlay = Some(Overlay::AgentPicker { cursor: 0 });
+        }
+        "health" | "h" | "cost" | "$" => {
+            app.overlay = Some(Overlay::SystemStatus);
+        }
+        "agent" => {
+            if !args.is_empty() {
+                let target = args.to_lowercase();
+                if let Some(agent) = app.agents.iter().find(|a| {
+                    a.id.to_lowercase() == target || a.name.to_lowercase() == target
+                }) {
+                    let id = agent.id.clone();
+                    app.save_scroll_state();
+                    if let Some(a) = app.agents.iter_mut().find(|a| a.id == id) {
+                        a.has_notification = false;
+                    }
+                    app.focused_agent = Some(id);
+                    app.load_focused_session().await;
+                    app.restore_scroll_state();
+                } else {
+                    app.error_toast =
+                        Some(ErrorToast::new(format!("Unknown agent: {args}")));
+                }
+            } else {
+                app.overlay = Some(Overlay::AgentPicker { cursor: 0 });
+            }
+        }
+        "clear" => {
+            app.messages.clear();
+            app.focused_session_id = None;
+            app.streaming_text.clear();
+            app.streaming_thinking.clear();
+            app.streaming_tool_calls.clear();
+            app.scroll_to_bottom();
+        }
+        "compact" => {
+            app.error_toast =
+                Some(ErrorToast::new("Compact not yet available via TUI".into()));
+        }
+        "recall" | "r" => {
+            if args.is_empty() {
+                app.error_toast =
+                    Some(ErrorToast::new("Usage: :recall <query>".into()));
+            } else {
+                app.error_toast =
+                    Some(ErrorToast::new(format!("Recall not yet available: {args}")));
+            }
+        }
+        "model" => {
+            app.error_toast =
+                Some(ErrorToast::new("Model info not yet available".into()));
+        }
+        _ => {
+            app.error_toast =
+                Some(ErrorToast::new(format!("Unknown command: {cmd_name}")));
+        }
+    }
+}

--- a/tui/src/update/mod.rs
+++ b/tui/src/update/mod.rs
@@ -1,4 +1,5 @@
 mod api;
+mod command;
 mod input;
 mod navigation;
 mod overlay;
@@ -27,6 +28,17 @@ pub(crate) async fn update(app: &mut App, msg: Msg) {
         Msg::Submit => input::handle_submit(app),
         Msg::CopyLastResponse => input::handle_copy_last_response(app),
         Msg::ComposeInEditor => input::handle_compose_in_editor(app),
+
+        // --- Command palette ---
+        Msg::CommandPaletteOpen => command::handle_open(app),
+        Msg::CommandPaletteClose => command::handle_close(app),
+        Msg::CommandPaletteInput(c) => command::handle_input(app, c),
+        Msg::CommandPaletteBackspace => command::handle_backspace(app),
+        Msg::CommandPaletteDeleteWord => command::handle_delete_word(app),
+        Msg::CommandPaletteSelect => command::handle_select(app).await,
+        Msg::CommandPaletteUp => command::handle_up(app),
+        Msg::CommandPaletteDown => command::handle_down(app),
+        Msg::CommandPaletteTab => command::handle_tab(app),
 
         // --- Navigation ---
         Msg::ScrollUp => navigation::handle_scroll_up(app),

--- a/tui/src/view/command_palette.rs
+++ b/tui/src/view/command_palette.rs
@@ -1,0 +1,89 @@
+use ratatui::Frame;
+use ratatui::layout::Rect;
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Paragraph};
+
+use crate::app::App;
+use crate::command::{CommandCategory, COMMANDS};
+use crate::theme::ThemePalette;
+
+pub fn render(app: &App, frame: &mut Frame, area: Rect, theme: &ThemePalette) {
+    if !app.command_palette.active || area.height < 2 {
+        return;
+    }
+
+    let palette = &app.command_palette;
+    let mut lines: Vec<Line> = Vec::new();
+
+    // Input line: `:` prompt + typed text
+    lines.push(Line::from(vec![
+        Span::styled(
+            ":",
+            Style::default()
+                .fg(theme.accent)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(&palette.input, theme.style_fg()),
+    ]));
+
+    // Suggestion lines (max 8)
+    for (i, scored) in palette.suggestions.iter().enumerate().take(8) {
+        let cmd = &COMMANDS[scored.index];
+        let selected = i == palette.selected;
+        let marker = if selected { "▸" } else { " " };
+
+        let name_style = if selected {
+            Style::default()
+                .fg(theme.accent)
+                .add_modifier(Modifier::BOLD)
+        } else {
+            theme.style_fg()
+        };
+
+        let category_color = match cmd.category {
+            CommandCategory::Navigation => theme.accent,
+            CommandCategory::Action => theme.warning,
+            CommandCategory::Query => theme.success,
+            CommandCategory::Agent => theme.streaming,
+        };
+
+        let mut spans = vec![
+            Span::styled(
+                format!(" {} ", marker),
+                if selected {
+                    name_style
+                } else {
+                    theme.style_dim()
+                },
+            ),
+            Span::styled("●", Style::default().fg(category_color)),
+            Span::styled(format!(" {:<12}", cmd.name), name_style),
+            Span::styled(cmd.description, theme.style_muted()),
+        ];
+
+        if !cmd.aliases.is_empty() {
+            let alias_str = cmd
+                .aliases
+                .iter()
+                .map(|a| format!(":{a}"))
+                .collect::<Vec<_>>()
+                .join(" ");
+            spans.push(Span::styled(format!("  {alias_str}"), theme.style_dim()));
+        }
+
+        lines.push(Line::from(spans));
+    }
+
+    let block = Block::default()
+        .borders(Borders::TOP)
+        .border_style(Style::default().fg(theme.separator));
+
+    let paragraph = Paragraph::new(lines).block(block);
+    frame.render_widget(paragraph, area);
+
+    // Position cursor in the input area
+    let cursor_x = area.x + 1 + palette.cursor as u16;
+    let cursor_y = area.y + 1; // +1 for top border
+    frame.set_cursor_position((cursor_x, cursor_y));
+}

--- a/tui/src/view/mod.rs
+++ b/tui/src/view/mod.rs
@@ -1,4 +1,5 @@
 mod chat;
+mod command_palette;
 mod input;
 mod overlay;
 mod sidebar;
@@ -14,40 +15,55 @@ pub fn render(app: &App, frame: &mut Frame) {
     let area = frame.area();
     let theme = &app.theme;
 
-    // Top-level vertical split: title bar | body | status bar | (optional toast)
     let has_toast = app.error_toast.is_some();
+    let palette_active = app.command_palette.active;
+
+    // When palette is active, it replaces the status bar with a variable-height area
+    let bottom_height = if palette_active {
+        let suggestion_lines = app.command_palette.suggestions.len().min(8) as u16;
+        (2 + suggestion_lines).max(3) // input + border + suggestions, min 3
+    } else {
+        2 // 2-line status bar
+    };
+
     let vertical = Layout::default()
         .direction(Direction::Vertical)
         .constraints(if has_toast {
             vec![
-                Constraint::Length(1), // title bar
-                Constraint::Min(5),    // body
-                Constraint::Length(1), // status bar
-                Constraint::Length(1), // error toast
+                Constraint::Length(1),            // title bar
+                Constraint::Min(5),               // body
+                Constraint::Length(bottom_height), // status bar or command palette
+                Constraint::Length(1),            // error toast
             ]
         } else {
             vec![
-                Constraint::Length(1), // title bar
-                Constraint::Min(5),    // body
-                Constraint::Length(1), // status bar
+                Constraint::Length(1),            // title bar
+                Constraint::Min(5),               // body
+                Constraint::Length(bottom_height), // status bar or command palette
             ]
         })
         .split(area);
 
     title_bar::render(app, frame, vertical[0], theme);
-    status_bar::render(app, frame, vertical[2], theme);
+
+    // Bottom area: command palette or status bar
+    if palette_active {
+        command_palette::render(app, frame, vertical[2], theme);
+    } else {
+        status_bar::render(app, frame, vertical[2], theme);
+    }
 
     // Error toast at bottom
-    if has_toast {
-        if let Some(ref toast) = app.error_toast {
-            let toast_line = ratatui::text::Line::from(vec![
-                ratatui::text::Span::styled(" ✗ ", theme.style_error_bold()),
-                ratatui::text::Span::styled(&toast.message, theme.style_error()),
-            ]);
-            let toast_widget = ratatui::widgets::Paragraph::new(toast_line)
-                .style(ratatui::style::Style::default().bg(theme.surface_dim));
-            frame.render_widget(toast_widget, vertical[3]);
-        }
+    if has_toast
+        && let Some(ref toast) = app.error_toast
+    {
+        let toast_line = ratatui::text::Line::from(vec![
+            ratatui::text::Span::styled(" ✗ ", theme.style_error_bold()),
+            ratatui::text::Span::styled(&toast.message, theme.style_error()),
+        ]);
+        let toast_widget = ratatui::widgets::Paragraph::new(toast_line)
+            .style(ratatui::style::Style::default().bg(theme.surface_dim));
+        frame.render_widget(toast_widget, vertical[3]);
     }
 
     // Responsive: hide sidebar on narrow terminals (< 60 cols)
@@ -66,9 +82,6 @@ pub fn render(app: &App, frame: &mut Frame) {
         sidebar::render(app, frame, horizontal[0], theme);
         render_chat_area(app, frame, horizontal[1], theme);
 
-        // Store sidebar area for mouse click detection (mutable through interior pattern)
-        // We can't mutate app here since view takes &self, so store in a separate mechanism
-        // Actually we'll update sidebar_area before render in the event loop
         SIDEBAR_RECT.store_rect(horizontal[0]);
     } else {
         SIDEBAR_RECT.store_rect(Rect::ZERO);

--- a/tui/src/view/overlay.rs
+++ b/tui/src/view/overlay.rs
@@ -6,6 +6,7 @@ use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Clear, Paragraph, Wrap};
 
 use crate::app::{AgentStatus, App, Overlay};
+use crate::keybindings;
 use crate::theme::ThemePalette;
 
 pub fn render(app: &App, frame: &mut Frame, area: Rect, theme: &ThemePalette) {
@@ -20,7 +21,7 @@ pub fn render(app: &App, frame: &mut Frame, area: Rect, theme: &ThemePalette) {
     frame.render_widget(Clear, popup_area);
 
     match overlay {
-        Overlay::Help => render_help(frame, popup_area, theme),
+        Overlay::Help => render_help(app, frame, popup_area, theme),
         Overlay::AgentPicker { cursor } => {
             render_agent_picker(app, frame, popup_area, *cursor, theme)
         }
@@ -60,94 +61,42 @@ fn overlay_block_accent(
         .style(Style::default().bg(theme.surface))
 }
 
-fn render_help(frame: &mut Frame, area: Rect, theme: &ThemePalette) {
+fn render_help(app: &App, frame: &mut Frame, area: Rect, theme: &ThemePalette) {
     let key_style = Style::default()
         .fg(theme.accent)
         .add_modifier(Modifier::BOLD);
     let desc_style = theme.style_fg();
     let section_style = Style::default().fg(theme.fg).add_modifier(Modifier::BOLD);
 
-    let lines = vec![
-        Line::raw(""),
-        Line::from(Span::styled("  Navigation", section_style)),
-        Line::raw(""),
-        help_line("  Ctrl+A     ", "Switch agent", key_style, desc_style),
-        help_line("  Ctrl+F     ", "Toggle sidebar", key_style, desc_style),
-        help_line(
-            "  Ctrl+T     ",
-            "Toggle thinking blocks",
-            key_style,
-            desc_style,
-        ),
-        help_line("  Ctrl+I     ", "System status", key_style, desc_style),
-        help_line(
-            "  Ctrl+N     ",
-            "New session / topic",
-            key_style,
-            desc_style,
-        ),
-        help_line("  F1         ", "This help screen", key_style, desc_style),
-        Line::raw(""),
-        Line::from(Span::styled("  Input", section_style)),
-        Line::raw(""),
-        help_line("  Enter      ", "Send message", key_style, desc_style),
-        help_line("  @agent Tab ", "Mention completion", key_style, desc_style),
-        help_line("  Ctrl+U     ", "Clear input line", key_style, desc_style),
-        help_line("  Ctrl+W     ", "Delete word", key_style, desc_style),
-        help_line(
-            "  Ctrl+E     ",
-            "Open $EDITOR for compose",
-            key_style,
-            desc_style,
-        ),
-        help_line("  Ctrl+Y     ", "Copy last response", key_style, desc_style),
-        help_line("  Up/Down    ", "Input history", key_style, desc_style),
-        Line::raw(""),
-        Line::from(Span::styled("  Scroll", section_style)),
-        Line::raw(""),
-        help_line("  Shift+Up   ", "Scroll up", key_style, desc_style),
-        help_line("  Shift+Down ", "Scroll down", key_style, desc_style),
-        help_line("  PgUp/PgDn  ", "Page scroll", key_style, desc_style),
-        help_line("  End        ", "Scroll to bottom", key_style, desc_style),
-        help_line(
-            "  Mouse      ",
-            "Scroll / click agent",
-            key_style,
-            desc_style,
-        ),
-        Line::raw(""),
-        Line::from(Span::styled("  During Turns", section_style)),
-        Line::raw(""),
-        help_line(
-            "  A          ",
-            "Approve tool / plan",
-            key_style,
-            desc_style,
-        ),
-        help_line("  D          ", "Deny tool call", key_style, desc_style),
-        help_line("  Space      ", "Toggle plan step", key_style, desc_style),
-        Line::raw(""),
-        help_line("  Ctrl+C/Q   ", "Quit", key_style, desc_style),
-        help_line(
-            "  Esc        ",
-            "Close overlay / cancel",
-            key_style,
-            desc_style,
-        ),
-    ];
+    let contexts = keybindings::current_contexts(app);
+    let groups = keybindings::grouped_keybindings(&contexts);
 
-    let block = overlay_block("Help — F1", theme);
+    let mut lines: Vec<Line> = Vec::new();
+
+    for (section_label, bindings) in &groups {
+        lines.push(Line::raw(""));
+        lines.push(Line::from(Span::styled(
+            format!("  {section_label}"),
+            section_style,
+        )));
+        lines.push(Line::raw(""));
+        for kb in bindings {
+            lines.push(Line::from(vec![
+                Span::styled(format!("  {:<13}", kb.keys), key_style),
+                Span::styled(kb.description, desc_style),
+            ]));
+        }
+    }
+
+    lines.push(Line::raw(""));
+
+    let label = keybindings::context_label(&app.overlay);
+    let title = format!("Help — {label}");
+    let block = overlay_block(&title, theme);
     let paragraph = Paragraph::new(lines)
         .block(block)
         .wrap(Wrap { trim: false });
     frame.render_widget(paragraph, area);
-}
-
-fn help_line<'a>(key: &'a str, desc: &'a str, key_style: Style, desc_style: Style) -> Line<'a> {
-    Line::from(vec![
-        Span::styled(key, key_style),
-        Span::styled(desc, desc_style),
-    ])
 }
 
 fn render_agent_picker(

--- a/tui/src/view/status_bar.rs
+++ b/tui/src/view/status_bar.rs
@@ -3,69 +3,165 @@ use ratatui::layout::Rect;
 use ratatui::style::Style;
 use ratatui::text::{Line, Span};
 use ratatui::widgets::Paragraph;
+use unicode_width::UnicodeWidthStr;
 
-use crate::app::{AgentStatus, App};
-use crate::theme::{self, ThemePalette};
+use crate::app::{App, SelectionContext};
+use crate::theme::ThemePalette;
 
 pub fn render(app: &App, frame: &mut Frame, area: Rect, theme: &ThemePalette) {
-    let mut spans: Vec<Span> = vec![Span::raw(" ")];
+    let line1 = render_keybindings(app, area.width, theme);
+    let line2 = render_info_bar(app, area.width, theme);
 
-    let working_agents: Vec<_> = app
-        .agents
-        .iter()
-        .filter(|a| a.status != AgentStatus::Idle)
-        .collect();
-
-    if working_agents.is_empty() {
-        spans.push(Span::styled("idle", theme.style_dim()));
-    } else {
-        for (i, agent) in working_agents.iter().enumerate() {
-            if i > 0 {
-                spans.push(Span::styled(" │ ", theme.style_dim()));
-            }
-
-            let ch = theme::spinner_frame(app.tick_count);
-
-            let status_str = match agent.status {
-                AgentStatus::Working => {
-                    if let Some(ref tool) = agent.active_tool {
-                        let elapsed = agent
-                            .tool_started_at
-                            .map(|t| format!("{:.1}s", t.elapsed().as_secs_f32()))
-                            .unwrap_or_default();
-                        format!("{} {}: {} ({})", ch, agent.name, tool, elapsed)
-                    } else {
-                        format!("{} {}: working", ch, agent.name)
-                    }
-                }
-                AgentStatus::Streaming => format!("● {}: streaming", agent.name),
-                AgentStatus::Compacting => {
-                    let stage = agent.compaction_stage.as_deref().unwrap_or("...");
-                    format!("{} {}: compacting ({})", ch, agent.name, stage)
-                }
-                AgentStatus::Idle => unreachable!(),
-            };
-
-            let color = match agent.status {
-                AgentStatus::Working => theme.spinner,
-                AgentStatus::Streaming => theme.streaming,
-                AgentStatus::Compacting => theme.compacting,
-                AgentStatus::Idle => unreachable!(),
-            };
-
-            spans.push(Span::styled(status_str, Style::default().fg(color)));
-        }
-    }
-
-    // Right-align keybinding hints
-    let hints = "^A agents │ ^I status │ ^N new │ ^Q quit";
-    let used_width: usize = spans.iter().map(|s| s.content.len()).sum();
-    let remaining = area.width as usize - used_width.min(area.width as usize);
-    if remaining > hints.len() + 2 {
-        spans.push(Span::raw(" ".repeat(remaining - hints.len() - 1)));
-        spans.push(Span::styled(hints, theme.style_dim()));
-    }
-
-    let bar = Paragraph::new(Line::from(spans)).style(theme.style_surface());
+    let bar = Paragraph::new(vec![line1, line2]).style(theme.style_surface());
     frame.render_widget(bar, area);
+}
+
+fn render_keybindings(app: &App, width: u16, theme: &ThemePalette) -> Line<'static> {
+    let hints = match app.selection {
+        SelectionContext::None => ": command │ / filter │ ? help",
+        SelectionContext::UserMessage => "e edit │ d delete │ c copy",
+        SelectionContext::AgentResponse => "c copy │ y yank │ o open",
+        SelectionContext::ToolCall => "a approve │ r reject │ i inspect",
+        SelectionContext::SessionList => "Enter open │ d delete │ n new",
+    };
+
+    let hints_width = hints.width();
+    let pad = (width as usize).saturating_sub(hints_width + 1);
+    Line::from(vec![
+        Span::raw(" ".repeat(pad)),
+        Span::styled(hints.to_string(), theme.style_dim()),
+    ])
+}
+
+fn render_info_bar(app: &App, width: u16, theme: &ThemePalette) -> Line<'static> {
+    let mut left_spans = Vec::new();
+    let mut right_spans = Vec::new();
+
+    left_spans.extend(agent_identity_spans(app, theme));
+
+    left_spans.push(Span::styled(" │ ", theme.style_dim()));
+    left_spans.push(connection_indicator_span(app, theme));
+
+    if let Some(ref filter) = app.active_filter {
+        left_spans.push(Span::styled(" │ ", theme.style_dim()));
+        left_spans.push(Span::styled(format!("/{filter}"), theme.style_accent()));
+    }
+
+    right_spans.extend(cost_spans(app, theme));
+    right_spans.push(Span::styled(" │ ", theme.style_dim()));
+    right_spans.extend(context_gauge_spans(app, theme));
+    right_spans.push(Span::raw(" "));
+
+    let left_width: usize = left_spans.iter().map(|s| s.content.width()).sum();
+    let right_width: usize = right_spans.iter().map(|s| s.content.width()).sum();
+    let total = width as usize;
+
+    let mut spans = vec![Span::raw(" ")];
+    spans.extend(left_spans);
+
+    if left_width + right_width + 2 < total {
+        let pad = total - left_width - right_width - 2;
+        spans.push(Span::raw(" ".repeat(pad)));
+        spans.extend(right_spans);
+    }
+
+    Line::from(spans)
+}
+
+fn agent_identity_spans(app: &App, theme: &ThemePalette) -> Vec<Span<'static>> {
+    let agent = app
+        .focused_agent
+        .as_ref()
+        .and_then(|id| app.agents.iter().find(|a| a.id == *id));
+
+    let (emoji, name) = agent
+        .map(|a| (a.emoji.clone().unwrap_or_default(), a.name.clone()))
+        .unwrap_or_else(|| (String::new(), "no agent".to_string()));
+
+    let session_key = agent
+        .and_then(|a| {
+            app.focused_session_id.as_ref().and_then(|sid| {
+                a.sessions
+                    .iter()
+                    .find(|s| s.id == *sid)
+                    .map(|s| s.key.clone())
+            })
+        })
+        .unwrap_or_else(|| "—".to_string());
+
+    let mut spans = Vec::new();
+    if !emoji.is_empty() {
+        spans.push(Span::styled(format!("{emoji} "), theme.style_fg()));
+    }
+    spans.push(Span::styled(name, theme.style_accent()));
+    spans.push(Span::styled(" · ", theme.style_dim()));
+    spans.push(Span::styled(session_key, theme.style_muted()));
+    spans
+}
+
+fn connection_indicator_span(app: &App, theme: &ThemePalette) -> Span<'static> {
+    if app.sse_connected {
+        Span::styled("●", theme.style_success())
+    } else {
+        Span::styled("○", theme.style_error())
+    }
+}
+
+fn cost_spans(app: &App, theme: &ThemePalette) -> Vec<Span<'static>> {
+    let mut spans = Vec::new();
+
+    if app.session_cost_cents > 0 {
+        spans.push(Span::styled(
+            format_cost(app.session_cost_cents),
+            theme.style_fg(),
+        ));
+    } else {
+        spans.push(Span::styled("$—", theme.style_dim()));
+    }
+
+    spans.push(Span::styled(" · ", theme.style_dim()));
+
+    if app.daily_cost_cents > 0 {
+        spans.push(Span::styled(
+            format!("{}/day", format_cost(app.daily_cost_cents)),
+            theme.style_fg(),
+        ));
+    } else {
+        spans.push(Span::styled("$0.00/day", theme.style_dim()));
+    }
+
+    spans
+}
+
+fn format_cost(cents: u32) -> String {
+    format!("${:.2}", cents as f64 / 100.0)
+}
+
+fn context_gauge_spans(app: &App, theme: &ThemePalette) -> Vec<Span<'static>> {
+    const GAUGE_WIDTH: usize = 6;
+
+    match app.context_usage_pct {
+        Some(pct) => {
+            let filled = (pct as usize * GAUGE_WIDTH) / 100;
+            let empty = GAUGE_WIDTH.saturating_sub(filled);
+
+            let color = if pct <= 60 {
+                theme.success
+            } else if pct <= 84 {
+                theme.warning
+            } else {
+                theme.error
+            };
+
+            vec![
+                Span::styled("█".repeat(filled), Style::default().fg(color)),
+                Span::styled("░".repeat(empty), theme.style_dim()),
+                Span::styled(format!(" {pct}%"), Style::default().fg(color)),
+            ]
+        }
+        None => vec![
+            Span::styled("░".repeat(GAUGE_WIDTH), theme.style_dim()),
+            Span::styled(" —%", theme.style_dim()),
+        ],
+    }
 }


### PR DESCRIPTION
Integrates TUI Wave 1 features (prompts 43, 44, 47) onto the decomposed app.rs codebase from prompt 42.

## Command Palette (`:` mode) — Prompt 43
- Fuzzy matching via skim against name, aliases, description
- 11 commands: quit, help, agents, agent <name>, cost, health, clear, compact, recall, model, sessions
- Tab completion, Ctrl+W word delete, backspace-to-close
- Category color dots, selected highlight, alias display
- Replaces status bar area when active (variable height)
- 6 unit tests for fuzzy matching

## Context-Aware Help System — Prompt 47
- Keybinding registry (`keybindings.rs`) — single source of truth
- `KeyContext` enum: Global, Chat, Input, Overlay, ToolApproval, PlanApproval
- Help overlay auto-generates from registry (was hardcoded)
- `?` opens help when input empty (in addition to F1)

## Status Bar Upgrade — Prompt 44
- 2-line layout: keybinding hints (line 1) + info bar (line 2)
- Agent identity with emoji + session key
- Connection indicator (green dot / red circle)
- Session cost + daily cost display
- Context window gauge (6-char bar, green/yellow/red thresholds)
- Active filter display
- `SelectionContext` enum for context-aware hints

## Integration Notes
PRs #460, #461, #462 were all written against pre-decomposition app.rs. This PR manually integrates all three onto the post-prompt-42 modular structure, with command palette handlers properly in `update/command.rs` and state types in `state/command.rs`.

**New files:** command/mod.rs, keybindings.rs, state/command.rs, update/command.rs, view/command_palette.rs
**New dependency:** fuzzy-matcher 0.3
**Tests:** 6 pass, zero new warnings

Supersedes #460, #461, #462