### PR TITLE
chore: security hardening v1 — gitleaks, CODEOWNERS, commit signing

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -57,3 +57,16 @@ jobs:
         run: cargo test --workspace
       - name: Doc tests
         run: cargo test --workspace --doc
+
+  secrets:
+    name: Secret Scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Gitleaks
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_CONFIG: .gitleaks.toml

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -57,3 +57,15 @@ jobs:
         uses: trufflesecurity/trufflehog@main
         with:
           extra_args: --only-verified
+
+  gitleaks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Gitleaks scan
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_CONFIG: .gitleaks.toml

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,41 @@
+title = "Aletheia gitleaks config"
+
+# Extend the default ruleset
+[extend]
+useDefault = true
+
+# Custom rules for Aletheia-specific patterns
+[[rules]]
+id = "anthropic-api-key"
+description = "Anthropic API key"
+regex = '''sk-ant-[a-zA-Z0-9_-]{90,}'''
+tags = ["key", "anthropic"]
+
+[[rules]]
+id = "signal-cli-password"
+description = "Signal CLI registration password"
+regex = '''signal-cli.*password["\s:=]+[^\s"]{8,}'''
+tags = ["password", "signal"]
+
+[[rules]]
+id = "phone-number"
+description = "Phone number (US format)"
+regex = '''\+1[0-9]{10}'''
+tags = ["pii", "phone"]
+
+[[rules]]
+id = "jwt-secret"
+description = "JWT secret or token"
+regex = '''eyJ[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}'''
+tags = ["token", "jwt"]
+
+# Allowlisted paths — instance/ is gitignored so shouldn't appear,
+# but be defensive
+[allowlist]
+paths = [
+  '''vendor/''',
+  '''crates/mneme-engine/''',
+  '''\.gitleaks\.toml''',
+  '''docs/SECURITY\.md''',
+  '''SECURITY\.md''',
+]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.21.2
+    hooks:
+      - id: gitleaks

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,26 @@
+# Aletheia CODEOWNERS
+# Require review for security-sensitive and configuration paths.
+#
+# Syntax: path  @owner
+# See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Global default — forkwright reviews everything
+*                                    @forkwright
+
+# Security-critical
+SECURITY.md                          @forkwright
+crates/symbolon/                     @forkwright
+.github/workflows/security.yml       @forkwright
+.github/workflows/release.yml        @forkwright
+.gitleaks.toml                       @forkwright
+
+# Configuration and deployment
+release-please-config.json           @forkwright
+.release-please-manifest.json        @forkwright
+deny.toml                            @forkwright
+
+# CI workflows
+.github/workflows/                   @forkwright
+
+# Documentation
+docs/                                @forkwright

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -1,0 +1,104 @@
+# Developer Security Guide
+
+Security practices for contributors working on Aletheia. For vulnerability reporting, see the root [SECURITY.md](../SECURITY.md).
+
+## Pre-commit Setup
+
+Install pre-commit and gitleaks to catch secrets and PII before they enter git history:
+
+```bash
+# Install pre-commit (Python)
+pip install pre-commit
+# OR via Homebrew
+brew install pre-commit
+
+# Install gitleaks
+brew install gitleaks
+# OR download from https://github.com/gitleaks/gitleaks/releases
+
+# Activate hooks
+pre-commit install
+```
+
+The `.gitleaks.toml` config at the repo root defines custom rules for Anthropic API keys, Signal CLI passwords, phone numbers, and JWT tokens in addition to the default gitleaks ruleset.
+
+To run a manual scan:
+
+```bash
+gitleaks detect --config .gitleaks.toml --no-git --source . -v
+```
+
+## Commit Signing
+
+All commits to `main` should be signed. GitHub shows a "Verified" badge on signed commits.
+
+### SSH Signing (recommended)
+
+```bash
+# Generate an SSH key if you don't have one
+ssh-keygen -t ed25519 -C "your-email@example.com"
+
+# Configure git to use SSH signing
+git config --global gpg.format ssh
+git config --global user.signingkey ~/.ssh/id_ed25519.pub
+git config --global commit.gpgsign true
+
+# Add the public key to GitHub:
+# Settings -> SSH and GPG keys -> New SSH key -> Key type: Signing Key
+```
+
+### GPG Signing (alternative)
+
+```bash
+# Generate a GPG key
+gpg --full-generate-key
+
+# Get the key ID
+gpg --list-secret-keys --keyid-format=long
+
+# Configure git
+git config --global user.signingkey YOUR_KEY_ID
+git config --global commit.gpgsign true
+
+# Add the public key to GitHub:
+# Settings -> SSH and GPG keys -> New GPG key
+```
+
+Enforcement via branch protection (requiring signed commits) is deferred to SEC-07 — it needs contributor onboarding first.
+
+## Secrets Handling
+
+- Never commit API keys, passwords, or tokens to tracked files
+- Use environment variables or `instance/config/credentials/` (gitignored) for runtime secrets
+- Anthropic key: `ANTHROPIC_API_KEY` environment variable
+- JWT secret: generated at runtime, never persisted in config files
+- If you accidentally commit a secret, rotate it immediately and use `git filter-repo` or BFG Repo-Cleaner to scrub history
+
+## PII Handling
+
+- Phone numbers, names, and addresses must never appear in tracked files
+- The `instance/` directory is gitignored — all personal data stays there
+- Log redaction: never log full phone numbers or message content
+- Test data must use synthetic identities (alice, bob, acme.corp, 192.168.1.100)
+- The CI PII scanner (`.github/pii-patterns.txt`) rejects commits containing personal data patterns
+
+## Dependency Policy
+
+- `cargo audit` runs in CI on every PR and weekly — flags known vulnerabilities in Rust dependencies
+- `cargo deny` enforces license compatibility and bans specific crates
+- `npm audit` checks UI dependencies (high severity, production only)
+- `pip-audit` checks memory sidecar Python dependencies
+- Dependabot creates PRs for vulnerable dependencies automatically
+
+## Branch Protection
+
+Current recommended settings for the `main` branch:
+
+- **Require pull request before merging** — no direct pushes to main
+- **Require status checks to pass** — CI (Rust, Security workflows) must be green
+- **Require review from Code Owners** — CODEOWNERS file enforces review routing
+- **Require signed commits** — deferred (SEC-07), document only for now
+- **Do not allow force pushes** — protect git history integrity
+- **Do not allow deletions** — prevent accidental branch deletion
+
+To enable CODEOWNERS enforcement: Repository Settings -> Branches -> Branch protection rule -> check "Require review from Code Owners".


### PR DESCRIPTION
## Summary

Establishes repository-level security controls for Aletheia:

- **Gitleaks pre-commit hook** (`.gitleaks.toml` + `.pre-commit-config.yaml`): Pattern-based secret/PII scanning with custom rules for Anthropic API keys, Signal CLI passwords, phone numbers, and JWTs. Complements existing TruffleHog verified-only scanning.
- **CI secret scanning**: Gitleaks job added to both `security.yml` (dedicated security workflow) and `rust.yml` (PR workflow) so every PR gets pattern-based scanning.
- **CODEOWNERS**: `@forkwright` as global default with explicit entries for security-critical paths (symbolon/, workflows, .gitleaks.toml), config/deployment files, and docs.
- **Developer security guide** (`docs/SECURITY.md`): Pre-commit setup, commit signing (SSH + GPG), secrets handling, PII policy, dependency audit pipeline, and branch protection recommendations.

## Changes

| File | Action |
|------|--------|
| `.gitleaks.toml` | NEW — gitleaks config with custom rules + allowlist |
| `.pre-commit-config.yaml` | NEW — pre-commit hook for gitleaks |
| `CODEOWNERS` | NEW — code ownership enforcement |
| `.github/workflows/security.yml` | Added `gitleaks` job |
| `.github/workflows/rust.yml` | Added `secrets` job |
| `docs/SECURITY.md` | NEW — developer security practices guide |

No source code changes. TruffleHog retained in `security.yml` (catches different things — verified active secrets vs pattern matches).

## Notes

- Gitleaks not installed locally — CI will validate the config on first run
- CODEOWNERS requires "Require review from Code Owners" branch protection rule to be active
- Commit signing enforcement deferred to SEC-07 (needs contributor onboarding)

## Test plan

- [ ] CI `gitleaks` job runs successfully (no false positives on current codebase)
- [ ] CI `secrets` job in rust.yml runs on this PR
- [ ] YAML syntax valid (verified locally via Python yaml parser)
- [ ] `docs/SECURITY.md` renders correctly on GitHub
- [ ] Existing CI jobs (cargo audit, TruffleHog, clippy, tests) unaffected