### PR TITLE
chore: release engineering — versioning, changelog, SBOM, binary builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Release Build Verification
+name: Release
 
 on:
   push:
@@ -8,31 +8,91 @@ permissions:
   contents: write
 
 jobs:
-  verify:
+  test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-
-      - name: Build (release)
-        run: cargo build --workspace --release
-
       - name: Test
         run: cargo test --workspace
 
-  sbom:
-    runs-on: ubuntu-latest
-    needs: verify
+  build:
+    needs: [test]
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+            artifact: aletheia-linux-amd64
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
+            artifact: aletheia-linux-arm64
+            cross: true
+          - target: x86_64-apple-darwin
+            os: macos-latest
+            artifact: aletheia-macos-amd64
+          - target: aarch64-apple-darwin
+            os: macos-latest
+            artifact: aletheia-macos-arm64
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.target }}
+
+      - name: Install cross
+        if: matrix.cross
+        run: cargo install cross --locked
+
+      - name: Build (native)
+        if: ${{ !matrix.cross }}
+        run: cargo build --release --target ${{ matrix.target }}
+
+      - name: Build (cross)
+        if: ${{ matrix.cross }}
+        run: cross build --release --target ${{ matrix.target }}
+
+      - name: Rename binary
+        run: cp target/${{ matrix.target }}/release/aletheia ${{ matrix.artifact }}
+
+      - name: Generate checksum (Linux)
+        if: runner.os == 'Linux'
+        run: sha256sum ${{ matrix.artifact }} > ${{ matrix.artifact }}.sha256
+
+      - name: Generate checksum (macOS)
+        if: runner.os == 'macOS'
+        run: shasum -a 256 ${{ matrix.artifact }} > ${{ matrix.artifact }}.sha256
+
+      - name: Upload binary and checksum
+        run: |
+          gh release upload "${GITHUB_REF#refs/tags/}" \
+            ${{ matrix.artifact }} \
+            ${{ matrix.artifact }}.sha256 \
+            --clobber
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  sbom:
+    needs: [test]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
       - uses: anchore/sbom-action@v0
         with:
           artifact-name: aletheia-sbom.spdx.json
           output-file: aletheia-sbom.spdx.json
+
       - name: Attach SBOM to release
         run: gh release upload "${GITHUB_REF#refs/tags/}" aletheia-sbom.spdx.json --clobber
         env:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -23,6 +23,12 @@ jobs:
       - name: Audit Rust dependencies
         run: cargo audit
 
+  cargo-deny:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: EmbarkStudios/cargo-deny-action@v2
+
   npm-audit:
     runs-on: ubuntu-latest
     steps:
@@ -54,6 +60,6 @@ jobs:
         with:
           fetch-depth: 0
       - name: TruffleHog secret scan
-        uses: trufflesecurity/trufflehog@main
+        uses: trufflesecurity/trufflehog@v3.93.6
         with:
           extra_args: --only-verified

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 All notable changes to Aletheia are documented here.
+Future entries are generated automatically by [release-please](https://github.com/googleapis/release-please) from conventional commits.
 
 ---
 
@@ -94,6 +95,8 @@ All notable changes to Aletheia are documented here.
 ---
 
 ## [0.10.0] - 2026-02-20
+
+Rust rewrite milestone: 18 crates, 973+ tests, ~33K lines. Key capabilities: agent pipeline, session store, tool execution, Signal integration, knowledge extraction, domain packs, distillation, web UI, plugin system, self-improvement, agent portability.
 
 ### Added
 - **Session continuity hardening** (Spec 12) — pre-compaction memory flush with distillation log, background session aggressive distillation (50 msg / 10K token triggers), ephemeral session cleanup (nightly purge), post-distillation verification checks

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,7 +39,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia"
-version = "0.1.0"
+version = "0.10.0"
 dependencies = [
  "aletheia-agora",
  "aletheia-hermeneus",
@@ -66,7 +66,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-agora"
-version = "0.1.0"
+version = "0.10.0"
 dependencies = [
  "aletheia-koina",
  "aletheia-taxis",
@@ -84,7 +84,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-daemon"
-version = "0.1.0"
+version = "0.10.0"
 dependencies = [
  "aletheia-koina",
  "chrono",
@@ -100,7 +100,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-dianoia"
-version = "0.1.0"
+version = "0.10.0"
 dependencies = [
  "aletheia-koina",
  "jiff",
@@ -116,7 +116,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-graph-builder"
-version = "0.1.0"
+version = "0.10.0"
 dependencies = [
  "atoi",
  "atomic 0.5.3",
@@ -136,7 +136,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-hermeneus"
-version = "0.1.0"
+version = "0.10.0"
 dependencies = [
  "aletheia-koina",
  "reqwest",
@@ -152,7 +152,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-integration-tests"
-version = "0.0.0"
+version = "0.10.0"
 dependencies = [
  "aletheia-hermeneus",
  "aletheia-koina",
@@ -173,7 +173,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-koina"
-version = "0.1.0"
+version = "0.10.0"
 dependencies = [
  "compact_str 0.8.1",
  "serde",
@@ -187,7 +187,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-melete"
-version = "0.1.0"
+version = "0.10.0"
 dependencies = [
  "aletheia-hermeneus",
  "aletheia-koina",
@@ -202,7 +202,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-mneme"
-version = "0.1.0"
+version = "0.10.0"
 dependencies = [
  "aletheia-koina",
  "aletheia-mneme-engine",
@@ -221,7 +221,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-mneme-engine"
-version = "0.1.0"
+version = "0.10.0"
 dependencies = [
  "aho-corasick",
  "approx",
@@ -272,7 +272,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-nous"
-version = "0.1.0"
+version = "0.10.0"
 dependencies = [
  "aletheia-hermeneus",
  "aletheia-koina",
@@ -294,7 +294,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-organon"
-version = "0.1.0"
+version = "0.10.0"
 dependencies = [
  "aletheia-hermeneus",
  "aletheia-koina",
@@ -309,7 +309,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-pylon"
-version = "0.1.0"
+version = "0.10.0"
 dependencies = [
  "aletheia-hermeneus",
  "aletheia-koina",
@@ -337,7 +337,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-symbolon"
-version = "0.1.0"
+version = "0.10.0"
 dependencies = [
  "argon2",
  "blake3",
@@ -355,7 +355,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-taxis"
-version = "0.1.0"
+version = "0.10.0"
 dependencies = [
  "aletheia-koina",
  "figment",
@@ -368,7 +368,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-thesauros"
-version = "0.1.0"
+version = "0.10.0"
 dependencies = [
  "aletheia-koina",
  "aletheia-organon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ exclude = [
 ]
 
 [workspace.package]
+version = "0.10.0"
 edition = "2024"
 license = "AGPL-3.0-or-later"
 repository = "https://github.com/forkwright/aletheia"

--- a/crates/agora/Cargo.toml
+++ b/crates/agora/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aletheia-agora"
-version = "0.1.0"
+version.workspace = true
 description = "Channel registry and provider implementations (Signal, Slack)"
 edition.workspace = true
 license.workspace = true

--- a/crates/aletheia/Cargo.toml
+++ b/crates/aletheia/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "aletheia"
-version = "0.1.0"
+version.workspace = true
 edition.workspace = true
+license.workspace = true
 rust-version.workspace = true
 description = "Aletheia cognitive agent runtime"
 publish = false

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aletheia-daemon"
-version = "0.1.0"
+version.workspace = true
 description = "Per-nous background task runner — cron scheduling, prosoche attention"
 edition.workspace = true
 license.workspace = true

--- a/crates/dianoia/Cargo.toml
+++ b/crates/dianoia/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aletheia-dianoia"
-version = "0.1.0"
+version.workspace = true
 description = "Planning and project orchestration — multi-phase state machine with workspace persistence"
 edition.workspace = true
 license.workspace = true

--- a/crates/graph-builder/Cargo.toml
+++ b/crates/graph-builder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aletheia-graph-builder"
-version = "0.1.0"
+version.workspace = true
 description = "CSR graph construction and traversal for Aletheia graph algorithms (graph_builder 0.4.1 absorbed)"
 edition.workspace = true
 license = "MIT"

--- a/crates/hermeneus/Cargo.toml
+++ b/crates/hermeneus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aletheia-hermeneus"
-version = "0.1.0"
+version.workspace = true
 description = "LLM provider abstraction and Anthropic streaming client"
 edition.workspace = true
 license.workspace = true

--- a/crates/integration-tests/Cargo.toml
+++ b/crates/integration-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aletheia-integration-tests"
-version = "0.0.0"
+version.workspace = true
 publish = false
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/koina/Cargo.toml
+++ b/crates/koina/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aletheia-koina"
-version = "0.1.0"
+version.workspace = true
 description = "Core types, errors, and tracing for Aletheia"
 edition.workspace = true
 license.workspace = true

--- a/crates/melete/Cargo.toml
+++ b/crates/melete/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aletheia-melete"
-version = "0.1.0"
+version.workspace = true
 description = "Context distillation engine — compresses conversation history"
 edition.workspace = true
 license.workspace = true

--- a/crates/mneme-engine/Cargo.toml
+++ b/crates/mneme-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aletheia-mneme-engine"
-version = "0.1.0"
+version.workspace = true
 description = "Embedded Datalog + HNSW + graph engine for Aletheia (absorbed from CozoDB 0.7.6)"
 edition.workspace = true
 license = "MPL-2.0"

--- a/crates/mneme/Cargo.toml
+++ b/crates/mneme/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aletheia-mneme"
-version = "0.1.0"
+version.workspace = true
 description = "Session store and memory engine for Aletheia"
 edition.workspace = true
 license.workspace = true

--- a/crates/nous/Cargo.toml
+++ b/crates/nous/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aletheia-nous"
-version = "0.1.0"
+version.workspace = true
 description = "Agent session pipeline — bootstrap, routing, tool execution"
 edition.workspace = true
 license.workspace = true

--- a/crates/organon/Cargo.toml
+++ b/crates/organon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aletheia-organon"
-version = "0.1.0"
+version.workspace = true
 description = "Tool registry, definitions, and built-in tool executors"
 edition.workspace = true
 license.workspace = true

--- a/crates/pylon/Cargo.toml
+++ b/crates/pylon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aletheia-pylon"
-version = "0.1.0"
+version.workspace = true
 description = "Axum HTTP gateway for Aletheia"
 edition.workspace = true
 license.workspace = true

--- a/crates/symbolon/Cargo.toml
+++ b/crates/symbolon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aletheia-symbolon"
-version = "0.1.0"
+version.workspace = true
 description = "Authentication and authorization for Aletheia"
 edition.workspace = true
 license.workspace = true

--- a/crates/taxis/Cargo.toml
+++ b/crates/taxis/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aletheia-taxis"
-version = "0.1.0"
+version.workspace = true
 description = "Configuration cascade and path resolution for Aletheia"
 edition.workspace = true
 license.workspace = true

--- a/crates/thesauros/Cargo.toml
+++ b/crates/thesauros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aletheia-thesauros"
-version = "0.1.0"
+version.workspace = true
 description = "Domain pack loader — external knowledge, tools, and config overlays"
 edition.workspace = true
 license.workspace = true

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,37 @@
+# cargo-deny configuration
+# https://embarkstudios.github.io/cargo-deny/
+
+[graph]
+# Exclude vendored CozoDB engine and test-only crate from all checks
+exclude = ["aletheia-mneme-engine", "aletheia-integration-tests"]
+
+[advisories]
+ignore = [
+    { id = "RUSTSEC-2023-0071", reason = "rsa timing side-channel via jsonwebtoken — no safe upgrade, local-only use" },
+    { id = "RUSTSEC-2025-0057", reason = "fxhash unmaintained — transitive via graph_builder, no safe upgrade" },
+]
+
+[licenses]
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "AGPL-3.0-or-later",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "ISC",
+    "Zlib",
+    "Unicode-3.0",
+    "BSL-1.0",
+    "CC0-1.0",
+    "0BSD",
+]
+confidence-threshold = 0.8
+
+[bans]
+multiple-versions = "warn"
+wildcards = "allow"
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-git = []

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,92 @@
+# Releasing Aletheia
+
+## Version Scheme
+
+Semantic Versioning. Pre-1.0, MINOR bumps may include breaking changes with
+documented migration. PATCH bumps are backwards-compatible.
+
+The canonical version lives in `Cargo.toml` at `[workspace.package].version`.
+All crates inherit it via `version.workspace = true`.
+
+## Automated Release Process
+
+1. Merge conventional-commit-formatted PRs to `main`
+2. [release-please](https://github.com/googleapis/release-please) opens a
+   version-bump PR that updates `CHANGELOG.md`, `.release-please-manifest.json`,
+   and `Cargo.toml`
+3. Review and merge the release PR
+4. release-please creates a git tag (`vX.Y.Z`) and GitHub Release
+5. The tag triggers `.github/workflows/release.yml`:
+   - Runs the full test suite
+   - Builds cross-platform binaries (4 targets)
+   - Generates SHA256 checksums per binary
+   - Generates and attaches an SBOM (SPDX)
+   - Uploads everything to the GitHub Release
+
+## Supported Platforms
+
+| Target | Runner | Method |
+|--------|--------|--------|
+| `x86_64-unknown-linux-gnu` | `ubuntu-latest` | Native cargo build |
+| `aarch64-unknown-linux-gnu` | `ubuntu-latest` | `cross` (Docker) |
+| `x86_64-apple-darwin` | `macos-latest` | Native cross-compile |
+| `aarch64-apple-darwin` | `macos-latest` | Native cargo build |
+
+## Manual Release
+
+If release-please fails or you need an out-of-band release:
+
+```bash
+# Bump the version
+scripts/bump-version.sh 0.11.0
+
+# Update CHANGELOG.md manually
+
+# Commit and tag
+git add -A
+git commit -m "chore: release 0.11.0"
+git tag v0.11.0
+git push origin main --tags
+```
+
+The tag push triggers the release workflow.
+
+## Hotfix Process
+
+```bash
+# Branch from the release tag
+git checkout -b hotfix/0.10.1 v0.10.0
+
+# Apply fix, commit
+git commit -m "fix(scope): description"
+
+# Tag and push
+git tag v0.10.1
+git push origin hotfix/0.10.1 --tags
+```
+
+The tag push builds binaries the same way. Merge the hotfix branch back to
+`main` afterwards.
+
+## Binary Verification
+
+Each binary has a companion `.sha256` file attached to the GitHub Release.
+
+```bash
+# Download binary and checksum
+gh release download v0.10.0 -p 'aletheia-linux-amd64*'
+
+# Verify
+sha256sum -c aletheia-linux-amd64.sha256
+```
+
+The SBOM (`aletheia-sbom.spdx.json`) is also attached to each release and
+lists all Cargo dependencies with versions.
+
+## Supply Chain
+
+- `cargo-audit` and `cargo-deny` run on every PR (`.github/workflows/security.yml`)
+- `deny.toml` enforces license policy and advisory checks
+- `Cargo.lock` is committed and pinned
+- All GitHub Actions are pinned to version tags (no `@main` references)
+- Anchore SBOM generated on every release

--- a/docs/policy/versioning.md
+++ b/docs/policy/versioning.md
@@ -9,7 +9,11 @@ Semantic versioning with pre-1.0 interpretation:
 | `0.MINOR.PATCH` | Pre-stable. Breaking changes allowed in MINOR bumps with documented migration |
 | `1.0.0` | Stable public API. Breaking changes require MAJOR bump |
 
-**Current:** `0.1.0` (pre-stable)
+**Current:** `0.10.0` (pre-stable)
+
+The canonical version lives in `Cargo.toml` under `[workspace.package].version`.
+All crates inherit it via `version.workspace = true`. The release-please manifest
+(`.release-please-manifest.json`) tracks the same value.
 
 ## What Constitutes a Breaking Change
 
@@ -39,25 +43,29 @@ Every breaking change includes:
 
 ## Release Process
 
-1. Bump version in `package.json`
-2. Update `CHANGELOG.md` with categorized changes
-3. Tag: `git tag v0.MINOR.PATCH`
-4. GitHub Release with migration notes if breaking
-5. Notify downstream operators (your fork) if breaking
+1. Merge to `main` with conventional commit messages
+2. release-please opens a version-bump PR (updates `CHANGELOG.md`, manifest, `Cargo.toml`)
+3. Merge the release PR to create a git tag
+4. CI builds cross-platform binaries and attaches them to the GitHub Release
+5. Notify downstream operators if breaking
+
+Manual fallback: `scripts/bump-version.sh <version>`, then tag and push.
+
+See `docs/RELEASING.md` for the full process.
 
 ## Changelog Format
 
 ```markdown
-## [0.2.0] — 2026-MM-DD
+## [0.11.0] — 2026-MM-DD
 
 ### Breaking
-- Renamed `agents.list[].pipeline` to `agents.list[].config` — run `npx aletheia migrate`
+- Renamed `agents.list[].pipeline` to `agents.list[].config` — run `aletheia migrate`
 
 ### Added
 - New tool: `plan_discuss` for phase-level discussion flow
 
 ### Fixed
-- Memory recall diversity regression from v0.1.3
+- Memory recall diversity regression from v0.10.3
 
 ### Changed
 - Default context window reduced from 200k to 128k for cost optimization

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,6 +4,17 @@
   "include-component-in-tag": false,
   "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": true,
+  "changelog-sections": [
+    {"type": "feat", "section": "Features"},
+    {"type": "fix", "section": "Bug Fixes"},
+    {"type": "perf", "section": "Performance"},
+    {"type": "chore", "section": "Maintenance", "hidden": true},
+    {"type": "docs", "hidden": true},
+    {"type": "test", "hidden": true},
+    {"type": "refactor", "hidden": true},
+    {"type": "ci", "hidden": true},
+    {"type": "style", "hidden": true}
+  ],
   "packages": {
     ".": {
       "changelog-path": "CHANGELOG.md",
@@ -12,6 +23,11 @@
           "type": "json",
           "path": "infrastructure/runtime/package.json",
           "jsonpath": "$.version"
+        },
+        {
+          "type": "toml",
+          "path": "Cargo.toml",
+          "jsonpath": "$.workspace.package.version"
         }
       ]
     }

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Bump the workspace version in Cargo.toml and the release-please manifest.
+# Fallback for when release-please TOML updater doesn't handle Cargo.toml.
+#
+# Usage: scripts/bump-version.sh 0.11.0
+
+set -euo pipefail
+
+VERSION="${1:?Usage: $0 <version>}"
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+sed -i "s/^version = \"[0-9]*\.[0-9]*\.[0-9]*\"/version = \"${VERSION}\"/" \
+  "${REPO_ROOT}/Cargo.toml"
+
+MANIFEST="${REPO_ROOT}/.release-please-manifest.json"
+if [[ -f "$MANIFEST" ]]; then
+  sed -i "s/\"\\.: \"[0-9]*\\.[0-9]*\\.[0-9]*\"/\".\": \"${VERSION}\"/" \
+    "$MANIFEST"
+fi
+
+echo "Bumped workspace version to ${VERSION}"
+echo "Verify: cargo metadata --format-version 1 | jq '.packages[] | select(.name | startswith(\"aletheia\")) | .version'"


### PR DESCRIPTION
## Summary

- **Workspace version alignment**: All 17 crates inherit `version = "0.10.0"` from `[workspace.package]` instead of hardcoding `0.1.0`
- **Changelog automation**: Added `changelog-sections` to release-please config — feat/fix/perf visible, chore/docs/test/refactor/ci hidden
- **Binary distribution**: Restructured `release.yml` with 4-target build matrix (Linux x86_64/arm64, macOS x86_64/arm64), per-binary SHA256 checksums
- **Supply chain hardening**: Created `deny.toml` with license policy, added `cargo-deny` job to security.yml, pinned TruffleHog from `@main` to `@v3.93.6`
- **Release docs**: Created `docs/RELEASING.md` covering automated + manual release process, hotfix flow, binary verification, supported platforms
- **Version bump script**: `scripts/bump-version.sh` as manual fallback if release-please TOML updater doesn't work

## Test plan

- [x] `cargo build --workspace` — succeeds with workspace version inheritance
- [x] `cargo test --workspace` — all pass
- [x] `cargo metadata` — all 17 crates show `0.10.0`
- [x] `cargo deny check` — advisories, licenses, bans, sources all pass
- [ ] Verify CI workflows pass on this PR
- [ ] Verify release-please still opens version-bump PRs correctly