### PR TITLE
feat(nous): wire cross-nous, daemon bridge, extraction into runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,6 +42,7 @@ name = "aletheia"
 version = "0.1.0"
 dependencies = [
  "aletheia-agora",
+ "aletheia-daemon",
  "aletheia-hermeneus",
  "aletheia-koina",
  "aletheia-melete",

--- a/crates/aletheia/Cargo.toml
+++ b/crates/aletheia/Cargo.toml
@@ -29,6 +29,7 @@ aletheia-pylon = { path = "../pylon" }
 aletheia-agora = { path = "../agora" }
 aletheia-melete = { path = "../melete" }
 aletheia-thesauros = { path = "../thesauros" }
+aletheia-daemon = { path = "../daemon" }
 
 tokio = { workspace = true }
 axum = { workspace = true }

--- a/crates/aletheia/src/daemon_bridge.rs
+++ b/crates/aletheia/src/daemon_bridge.rs
@@ -1,0 +1,68 @@
+//! Bridge from daemon tasks to nous actors.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use aletheia_daemon::bridge::DaemonBridge;
+use aletheia_daemon::runner::ExecutionResult;
+use aletheia_nous::manager::NousManager;
+
+pub(crate) struct NousDaemonBridge {
+    nous_manager: Arc<NousManager>,
+}
+
+impl NousDaemonBridge {
+    pub(crate) fn new(nous_manager: Arc<NousManager>) -> Self {
+        Self { nous_manager }
+    }
+}
+
+impl DaemonBridge for NousDaemonBridge {
+    fn send_prompt(
+        &self,
+        nous_id: &str,
+        session_key: &str,
+        prompt: &str,
+    ) -> Pin<Box<dyn Future<Output = aletheia_daemon::error::Result<ExecutionResult>> + Send + '_>>
+    {
+        let nous_id = nous_id.to_owned();
+        let session_key = session_key.to_owned();
+        let prompt = prompt.to_owned();
+
+        Box::pin(async move {
+            let Some(handle) = self.nous_manager.get(&nous_id).cloned() else {
+                tracing::warn!(nous_id = %nous_id, "daemon bridge: nous actor not found");
+                return Ok(ExecutionResult {
+                    success: false,
+                    output: Some(format!("nous actor {nous_id} not found")),
+                });
+            };
+
+            match handle.send_turn(&session_key, &prompt).await {
+                Ok(result) => {
+                    tracing::debug!(
+                        nous_id = %nous_id,
+                        content_len = result.content.len(),
+                        "daemon bridge: prompt delivered"
+                    );
+                    Ok(ExecutionResult {
+                        success: true,
+                        output: Some(result.content),
+                    })
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        nous_id = %nous_id,
+                        error = %e,
+                        "daemon bridge: turn failed"
+                    );
+                    Ok(ExecutionResult {
+                        success: false,
+                        output: Some(format!("turn failed: {e}")),
+                    })
+                }
+            }
+        })
+    }
+}

--- a/crates/aletheia/src/dispatch.rs
+++ b/crates/aletheia/src/dispatch.rs
@@ -2,7 +2,7 @@
 
 use std::sync::Arc;
 
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, watch};
 use tokio::task::JoinHandle;
 use tracing::{Instrument, info, warn};
 
@@ -19,10 +19,18 @@ pub fn spawn_dispatcher(
     router: Arc<MessageRouter>,
     nous_manager: Arc<NousManager>,
     channel_registry: Arc<ChannelRegistry>,
+    mut ready_rx: watch::Receiver<bool>,
 ) -> JoinHandle<()> {
     let span = tracing::info_span!("message_dispatcher");
     tokio::spawn(
         async move {
+            // Wait for ready signal before processing messages
+            while !*ready_rx.borrow_and_update() {
+                if ready_rx.changed().await.is_err() {
+                    warn!("ready channel dropped before ready signal");
+                    return;
+                }
+            }
             info!("dispatch loop started");
             while let Some(msg) = rx.recv().await {
                 let router = Arc::clone(&router);

--- a/crates/aletheia/src/main.rs
+++ b/crates/aletheia/src/main.rs
@@ -1,5 +1,6 @@
 //! Aletheia cognitive agent runtime — binary entrypoint.
 
+mod daemon_bridge;
 mod dispatch;
 
 use std::path::PathBuf;
@@ -8,7 +9,7 @@ use std::time::Instant;
 
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
-use tracing::{info, warn};
+use tracing::{Instrument, info, warn};
 use tracing_subscriber::{EnvFilter, fmt};
 
 use aletheia_agora::listener::ChannelListener;
@@ -22,6 +23,7 @@ use aletheia_hermeneus::provider::{ProviderConfig, ProviderRegistry};
 use aletheia_mneme::embedding::{EmbeddingConfig, EmbeddingProvider, create_provider};
 use aletheia_mneme::store::SessionStore;
 use aletheia_nous::config::{NousConfig, PipelineConfig};
+use aletheia_nous::cross::CrossNousRouter;
 use aletheia_nous::manager::NousManager;
 use aletheia_organon::builtins;
 use aletheia_organon::registry::ToolRegistry;
@@ -80,7 +82,10 @@ async fn main() -> Result<()> {
     serve(cli).await
 }
 
-#[expect(clippy::too_many_lines, reason = "binary entrypoint — sequential init steps")]
+#[expect(
+    clippy::too_many_lines,
+    reason = "binary entrypoint — sequential init steps"
+)]
 async fn serve(cli: Cli) -> Result<()> {
     init_tracing(&cli.log_level, cli.json_logs);
 
@@ -149,6 +154,9 @@ async fn serve(cli: Cli) -> Result<()> {
         "embedding provider created"
     );
 
+    // Cross-nous router for inter-agent messaging
+    let cross_router = Arc::new(CrossNousRouter::default());
+
     // Spawn nous actors
     // vector_search is None until Phase 2 (prompt 28) lands KnowledgeVectorSearch
     let mut nous_manager = NousManager::new(
@@ -159,6 +167,7 @@ async fn serve(cli: Cli) -> Result<()> {
         None,
         Some(Arc::clone(&session_store)),
         Arc::clone(&packs),
+        Some(Arc::clone(&cross_router)),
     );
 
     if config.agents.list.is_empty() {
@@ -190,7 +199,13 @@ async fn serve(cli: Cli) -> Result<()> {
                 domains,
             };
             nous_manager
-                .spawn(nous_config, PipelineConfig::default())
+                .spawn(
+                    nous_config,
+                    PipelineConfig {
+                        extraction: Some(aletheia_mneme::extract::ExtractionConfig::default()),
+                        ..PipelineConfig::default()
+                    },
+                )
                 .await;
         }
         info!(count = nous_manager.count(), "nous actors spawned");
@@ -199,8 +214,49 @@ async fn serve(cli: Cli) -> Result<()> {
     // Wrap in Arc — shared between dispatcher and AppState
     let nous_manager = Arc::new(nous_manager);
 
-    // Channel registry + inbound dispatch
-    let (_channel_registry, _dispatch_handle) = start_inbound_dispatch(&config, &nous_manager);
+    // Signal ready — all actors spawned, safe to accept inbound messages
+    nous_manager.ready();
+
+    // Channel registry + inbound dispatch (gated on ready signal)
+    let ready_rx = nous_manager.ready_rx();
+    let (_channel_registry, _dispatch_handle) =
+        start_inbound_dispatch(&config, &nous_manager, ready_rx);
+
+    // Daemon runners — per-agent background task scheduling
+    let (daemon_shutdown_tx, _) = tokio::sync::watch::channel(false);
+    let daemon_bridge = Arc::new(daemon_bridge::NousDaemonBridge::new(Arc::clone(
+        &nous_manager,
+    )));
+    for agent_def in &config.agents.list {
+        let mut runner = aletheia_daemon::runner::TaskRunner::with_bridge(
+            agent_def.id.clone(),
+            daemon_shutdown_tx.subscribe(),
+            daemon_bridge.clone(),
+        );
+        runner.register(aletheia_daemon::schedule::TaskDef {
+            id: format!("{}-prosoche", agent_def.id),
+            name: "Prosoche attention check".to_owned(),
+            nous_id: agent_def.id.clone(),
+            schedule: aletheia_daemon::schedule::Schedule::Interval(
+                std::time::Duration::from_secs(45 * 60),
+            ),
+            action: aletheia_daemon::schedule::TaskAction::Builtin(
+                aletheia_daemon::schedule::BuiltinTask::Prosoche,
+            ),
+            enabled: true,
+            active_window: Some((8, 23)),
+        });
+        let span = tracing::info_span!("daemon", nous.id = %agent_def.id);
+        tokio::spawn(
+            async move {
+                runner.run().await;
+            }
+            .instrument(span),
+        );
+    }
+    if !config.agents.list.is_empty() {
+        info!(count = config.agents.list.len(), "daemon runners spawned");
+    }
 
     // Pylon HTTP gateway — shares registries with NousManager
     let state = Arc::new(AppState {
@@ -228,6 +284,7 @@ async fn serve(cli: Cli) -> Result<()> {
         .context("server error")?;
 
     info!("shutting down");
+    let _ = daemon_shutdown_tx.send(true);
     state.nous_manager.shutdown_readonly().await;
     info!("shutdown complete");
 
@@ -270,6 +327,7 @@ fn build_tool_registry() -> Result<ToolRegistry> {
 fn start_inbound_dispatch(
     config: &aletheia_taxis::config::AletheiaConfig,
     nous_manager: &Arc<NousManager>,
+    ready_rx: tokio::sync::watch::Receiver<bool>,
 ) -> (Arc<ChannelRegistry>, Option<tokio::task::JoinHandle<()>>) {
     let mut channel_registry = ChannelRegistry::new();
 
@@ -300,6 +358,7 @@ fn start_inbound_dispatch(
             router,
             Arc::clone(nous_manager),
             Arc::clone(&channel_registry),
+            ready_rx,
         ))
     } else {
         None

--- a/crates/daemon/src/bridge.rs
+++ b/crates/daemon/src/bridge.rs
@@ -1,0 +1,53 @@
+//! Bridge trait for daemon → nous communication.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use crate::runner::ExecutionResult;
+
+/// Allows daemon tasks to send prompts to a nous actor without the daemon
+/// crate depending on nous directly.
+///
+/// Implemented in the binary crate where both daemon and nous are available.
+/// Uses boxed futures for object safety (`Arc<dyn DaemonBridge>`).
+pub trait DaemonBridge: Send + Sync {
+    fn send_prompt(
+        &self,
+        nous_id: &str,
+        session_key: &str,
+        prompt: &str,
+    ) -> Pin<Box<dyn Future<Output = crate::error::Result<ExecutionResult>> + Send + '_>>;
+}
+
+/// No-op bridge for tests and configurations without nous integration.
+pub struct NoopBridge;
+
+impl DaemonBridge for NoopBridge {
+    fn send_prompt(
+        &self,
+        _nous_id: &str,
+        _session_key: &str,
+        _prompt: &str,
+    ) -> Pin<Box<dyn Future<Output = crate::error::Result<ExecutionResult>> + Send + '_>> {
+        Box::pin(async {
+            tracing::warn!("no daemon bridge configured — prompt not sent");
+            Ok(ExecutionResult {
+                success: false,
+                output: Some("no bridge configured".to_owned()),
+            })
+        })
+    }
+}
+
+/// Wrap an `Arc<dyn DaemonBridge>` to forward to the inner trait.
+impl DaemonBridge for Arc<dyn DaemonBridge> {
+    fn send_prompt(
+        &self,
+        nous_id: &str,
+        session_key: &str,
+        prompt: &str,
+    ) -> Pin<Box<dyn Future<Output = crate::error::Result<ExecutionResult>> + Send + '_>> {
+        (**self).send_prompt(nous_id, session_key, prompt)
+    }
+}

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -4,6 +4,7 @@
 //! keeps things running in the background. Manages scheduled tasks, periodic
 //! attention checks (prosoche), and maintenance cycles for each nous.
 
+pub mod bridge;
 pub mod error;
 pub mod prosoche;
 pub mod runner;

--- a/crates/daemon/src/prosoche.rs
+++ b/crates/daemon/src/prosoche.rs
@@ -42,6 +42,17 @@ pub enum Urgency {
     Critical,
 }
 
+impl AttentionItem {
+    pub fn category_label(&self) -> &str {
+        match &self.category {
+            AttentionCategory::Calendar => "calendar",
+            AttentionCategory::Task => "task",
+            AttentionCategory::SystemHealth => "health",
+            AttentionCategory::Custom(s) => s,
+        }
+    }
+}
+
 impl ProsocheCheck {
     pub fn new(nous_id: impl Into<String>) -> Self {
         Self {
@@ -54,7 +65,10 @@ impl ProsocheCheck {
     /// Currently returns an empty result — actual checks (gcal, taskwarrior,
     /// system health) require tool execution which will be wired when daemon
     /// integrates with the nous pipeline.
-    #[expect(clippy::unused_async, reason = "will perform async I/O once wired to nous pipeline")]
+    #[expect(
+        clippy::unused_async,
+        reason = "will perform async I/O once wired to nous pipeline"
+    )]
     pub async fn run(&self) -> crate::error::Result<ProsocheResult> {
         tracing::info!(nous_id = %self.nous_id, "prosoche check completed");
         Ok(ProsocheResult {

--- a/crates/daemon/src/runner.rs
+++ b/crates/daemon/src/runner.rs
@@ -1,11 +1,13 @@
 //! Per-nous background task runner with cron scheduling, failure tracking, and graceful shutdown.
 
+use std::sync::Arc;
 use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
 use snafu::ResultExt;
 use tokio::sync::watch;
 
+use crate::bridge::DaemonBridge;
 use crate::error::{self, Result};
 use crate::prosoche::ProsocheCheck;
 use crate::schedule::{BuiltinTask, Schedule, TaskAction, TaskDef, TaskStatus};
@@ -15,6 +17,7 @@ pub struct TaskRunner {
     nous_id: String,
     tasks: Vec<RegisteredTask>,
     shutdown: watch::Receiver<bool>,
+    bridge: Option<Arc<dyn DaemonBridge>>,
 }
 
 struct RegisteredTask {
@@ -38,6 +41,21 @@ impl TaskRunner {
             nous_id: nous_id.into(),
             tasks: Vec::new(),
             shutdown,
+            bridge: None,
+        }
+    }
+
+    /// Create a runner with a bridge for nous communication.
+    pub fn with_bridge(
+        nous_id: impl Into<String>,
+        shutdown: watch::Receiver<bool>,
+        bridge: Arc<dyn DaemonBridge>,
+    ) -> Self {
+        Self {
+            nous_id: nous_id.into(),
+            tasks: Vec::new(),
+            shutdown,
+            bridge: Some(bridge),
         }
     }
 
@@ -122,7 +140,8 @@ impl TaskRunner {
                 continue;
             }
 
-            let result = execute_action(&task.def.action, &task.def.nous_id).await;
+            let result =
+                execute_action(&task.def.action, &task.def.nous_id, self.bridge.as_ref()).await;
             task.last_run = Some(now);
 
             match result {
@@ -161,7 +180,11 @@ impl TaskRunner {
     }
 }
 
-async fn execute_action(action: &TaskAction, nous_id: &str) -> Result<ExecutionResult> {
+async fn execute_action(
+    action: &TaskAction,
+    nous_id: &str,
+    bridge: Option<&Arc<dyn DaemonBridge>>,
+) -> Result<ExecutionResult> {
     match action {
         TaskAction::Command(cmd) => execute_command(cmd).await,
         TaskAction::Tool { name, .. } => {
@@ -176,17 +199,20 @@ async fn execute_action(action: &TaskAction, nous_id: &str) -> Result<ExecutionR
             })
         }
         TaskAction::Prompt(prompt) => {
-            tracing::info!(
-                nous_id = %nous_id,
-                prompt_len = prompt.len(),
-                "prompt injection not yet wired — requires nous pipeline access"
-            );
-            Ok(ExecutionResult {
-                success: true,
-                output: None,
-            })
+            if let Some(bridge) = bridge {
+                bridge.send_prompt(nous_id, "daemon:prompt", prompt).await
+            } else {
+                tracing::warn!(
+                    nous_id = %nous_id,
+                    "prompt action skipped — no daemon bridge configured"
+                );
+                Ok(ExecutionResult {
+                    success: false,
+                    output: Some("no bridge configured".to_owned()),
+                })
+            }
         }
-        TaskAction::Builtin(builtin) => execute_builtin(builtin, nous_id).await,
+        TaskAction::Builtin(builtin) => execute_builtin(builtin, nous_id, bridge).await,
     }
 }
 
@@ -223,11 +249,30 @@ async fn execute_command(cmd: &str) -> Result<ExecutionResult> {
     }
 }
 
-async fn execute_builtin(builtin: &BuiltinTask, nous_id: &str) -> Result<ExecutionResult> {
+async fn execute_builtin(
+    builtin: &BuiltinTask,
+    nous_id: &str,
+    bridge: Option<&Arc<dyn DaemonBridge>>,
+) -> Result<ExecutionResult> {
     match builtin {
         BuiltinTask::Prosoche => {
             let check = ProsocheCheck::new(nous_id);
             let result = check.run().await?;
+
+            if !result.items.is_empty() {
+                if let Some(bridge) = bridge {
+                    let summary: Vec<String> = result
+                        .items
+                        .iter()
+                        .map(|item| format!("- [{}] {}", item.category_label(), item.summary))
+                        .collect();
+                    let prompt = format!("Prosoche attention check:\n{}", summary.join("\n"));
+                    let _ = bridge
+                        .send_prompt(nous_id, "daemon:prosoche", &prompt)
+                        .await;
+                }
+            }
+
             Ok(ExecutionResult {
                 success: true,
                 output: Some(format!("{} items", result.items.len())),
@@ -316,9 +361,7 @@ mod tests {
             name: "Failing task".to_owned(),
             nous_id: "test-nous".to_owned(),
             schedule: Schedule::Interval(Duration::from_millis(10)),
-            action: TaskAction::Command(
-                "exit 1".to_owned(),
-            ),
+            action: TaskAction::Command("exit 1".to_owned()),
             enabled: true,
             active_window: None,
         };
@@ -338,7 +381,10 @@ mod tests {
         }
 
         let statuses = runner.status();
-        assert!(!statuses[0].enabled, "task should be disabled after 3 failures");
+        assert!(
+            !statuses[0].enabled,
+            "task should be disabled after 3 failures"
+        );
         assert_eq!(statuses[0].consecutive_failures, 3);
     }
 

--- a/crates/daemon/src/schedule.rs
+++ b/crates/daemon/src/schedule.rs
@@ -74,11 +74,9 @@ impl Schedule {
     pub fn next_run(&self) -> Result<Option<jiff::Timestamp>> {
         match self {
             Self::Cron(expr) => {
-                let schedule = cron::Schedule::from_str(expr).context(
-                    error::InvalidCronSnafu {
-                        expression: expr.clone(),
-                    },
-                )?;
+                let schedule = cron::Schedule::from_str(expr).context(error::InvalidCronSnafu {
+                    expression: expr.clone(),
+                })?;
                 let next = schedule.upcoming(chrono::Utc).next();
                 Ok(next.map(|dt| {
                     jiff::Timestamp::from_second(dt.timestamp())
@@ -87,10 +85,11 @@ impl Schedule {
             }
             Self::Interval(duration) => {
                 let span = jiff::SignedDuration::from_nanos(
-                    i64::try_from(duration.as_nanos())
-                        .expect("interval fits in i64 nanos"),
+                    i64::try_from(duration.as_nanos()).expect("interval fits in i64 nanos"),
                 );
-                let next = jiff::Timestamp::now().checked_add(span).expect("interval addition overflow");
+                let next = jiff::Timestamp::now()
+                    .checked_add(span)
+                    .expect("interval addition overflow");
                 Ok(Some(next))
             }
             Self::Once(ts) => {
@@ -144,7 +143,10 @@ mod tests {
     #[test]
     fn interval_next_run_returns_future() {
         let schedule = Schedule::Interval(Duration::from_secs(10));
-        let next = schedule.next_run().expect("no error").expect("should have next");
+        let next = schedule
+            .next_run()
+            .expect("no error")
+            .expect("should have next");
         assert!(next > jiff::Timestamp::now());
     }
 
@@ -154,7 +156,10 @@ mod tests {
             .checked_add(jiff::SignedDuration::from_secs(3600))
             .unwrap();
         let schedule = Schedule::Once(future);
-        let next = schedule.next_run().expect("no error").expect("should have next");
+        let next = schedule
+            .next_run()
+            .expect("no error")
+            .expect("should have next");
         assert_eq!(next, future);
     }
 

--- a/crates/dianoia/src/project.rs
+++ b/crates/dianoia/src/project.rs
@@ -64,16 +64,12 @@ impl Project {
     /// Get the current active phase (first non-complete phase).
     #[must_use]
     pub fn active_phase(&self) -> Option<&Phase> {
-        self.phases
-            .iter()
-            .find(|p| !p.is_complete())
+        self.phases.iter().find(|p| !p.is_complete())
     }
 
     /// Get a mutable reference to the current active phase.
     pub fn active_phase_mut(&mut self) -> Option<&mut Phase> {
-        self.phases
-            .iter_mut()
-            .find(|p| !p.is_complete())
+        self.phases.iter_mut().find(|p| !p.is_complete())
     }
 }
 

--- a/crates/dianoia/src/state.rs
+++ b/crates/dianoia/src/state.rs
@@ -18,9 +18,7 @@ pub enum ProjectState {
     Verifying,
     Complete,
     Abandoned,
-    Paused {
-        previous: Box<ProjectState>,
-    },
+    Paused { previous: Box<ProjectState> },
 }
 
 /// Valid transitions between project states.
@@ -154,15 +152,9 @@ impl ProjectState {
                 Transition::Abandon,
                 Transition::Pause,
             ],
-            Self::Verifying => vec![
-                Transition::Complete,
-                Transition::Abandon,
-            ],
+            Self::Verifying => vec![Transition::Complete, Transition::Abandon],
             Self::Complete | Self::Abandoned => vec![],
-            Self::Paused { .. } => vec![
-                Transition::Resume,
-                Transition::Abandon,
-            ],
+            Self::Paused { .. } => vec![Transition::Resume, Transition::Abandon],
         }
     }
 
@@ -261,14 +253,13 @@ mod tests {
     #[test]
     fn terminal_states_reject_all_transitions() {
         for terminal in [ProjectState::Complete, ProjectState::Abandoned] {
-            assert!(terminal
-                .clone()
-                .transition(Transition::StartQuestioning)
-                .is_err());
-            assert!(terminal
-                .clone()
-                .transition(Transition::Abandon)
-                .is_err());
+            assert!(
+                terminal
+                    .clone()
+                    .transition(Transition::StartQuestioning)
+                    .is_err()
+            );
+            assert!(terminal.clone().transition(Transition::Abandon).is_err());
             assert!(terminal.transition(Transition::Pause).is_err());
         }
     }

--- a/crates/dianoia/src/workspace.rs
+++ b/crates/dianoia/src/workspace.rs
@@ -28,10 +28,12 @@ impl ProjectWorkspace {
         let root = root.into();
         let layout = Self::build_layout(&root);
 
-        for dir in [&layout.phases_dir, &layout.blockers_dir, &layout.artifacts_dir] {
-            std::fs::create_dir_all(dir).context(error::WorkspaceIoSnafu {
-                path: dir.clone(),
-            })?;
+        for dir in [
+            &layout.phases_dir,
+            &layout.blockers_dir,
+            &layout.artifacts_dir,
+        ] {
+            std::fs::create_dir_all(dir).context(error::WorkspaceIoSnafu { path: dir.clone() })?;
         }
 
         Ok(Self { root })
@@ -102,10 +104,9 @@ impl ProjectWorkspace {
         }
 
         let mut blockers = Vec::new();
-        let entries =
-            std::fs::read_dir(&phase_blockers).context(error::WorkspaceIoSnafu {
-                path: &phase_blockers,
-            })?;
+        let entries = std::fs::read_dir(&phase_blockers).context(error::WorkspaceIoSnafu {
+            path: &phase_blockers,
+        })?;
 
         for entry in entries {
             let entry = entry.context(error::WorkspaceIoSnafu {
@@ -113,14 +114,9 @@ impl ProjectWorkspace {
             })?;
             let path = entry.path();
             if path.extension().is_some_and(|ext| ext == "md") {
-                let content =
-                    std::fs::read_to_string(&path).context(error::WorkspaceIoSnafu {
-                        path: &path,
-                    })?;
-                let plan_id_str = path
-                    .file_stem()
-                    .unwrap_or_default()
-                    .to_string_lossy();
+                let content = std::fs::read_to_string(&path)
+                    .context(error::WorkspaceIoSnafu { path: &path })?;
+                let plan_id_str = path.file_stem().unwrap_or_default().to_string_lossy();
 
                 blockers.push(Blocker {
                     description: content,

--- a/crates/integration-tests/tests/domain_packs.rs
+++ b/crates/integration-tests/tests/domain_packs.rs
@@ -7,9 +7,9 @@ use aletheia_hermeneus::provider::{LlmProvider, ProviderRegistry};
 use aletheia_hermeneus::types::{
     CompletionRequest, CompletionResponse, ContentBlock, StopReason, Usage,
 };
+use aletheia_koina::id::ToolName;
 use aletheia_nous::config::{NousConfig, PipelineConfig};
 use aletheia_nous::manager::NousManager;
-use aletheia_koina::id::ToolName;
 use aletheia_organon::registry::ToolRegistry;
 use aletheia_organon::types::ToolCategory;
 use aletheia_taxis::oikos::Oikos;
@@ -110,7 +110,10 @@ context:
   - path: context/DOMAIN_KNOWLEDGE.md
     priority: important
 "#,
-        &[("context/DOMAIN_KNOWLEDGE.md", "Engagements flow into cases which flow into journeys.")],
+        &[(
+            "context/DOMAIN_KNOWLEDGE.md",
+            "Engagements flow into cases which flow into journeys.",
+        )],
     );
 
     let packs = load_packs(&[pack_dir.path().to_path_buf()]);
@@ -127,6 +130,7 @@ context:
         None,
         None,
         Arc::new(packs),
+        None,
     );
 
     let config = NousConfig {
@@ -196,7 +200,10 @@ tools:
 }
 
 #[tokio::test]
-#[expect(clippy::too_many_lines, reason = "integration test requires two full agent setups")]
+#[expect(
+    clippy::too_many_lines,
+    reason = "integration test requires two full agent setups"
+)]
 async fn domain_tagged_sections_reach_correct_agents() {
     let oikos_dir = tempfile::TempDir::new().expect("tmpdir");
     let pack_dir = tempfile::TempDir::new().expect("tmpdir");
@@ -226,7 +233,10 @@ overlays:
 "#,
         &[
             ("context/GENERAL.md", "General knowledge for all agents."),
-            ("context/HEALTHCARE.md", "HIPAA compliance requires encryption at rest."),
+            (
+                "context/HEALTHCARE.md",
+                "HIPAA compliance requires encryption at rest.",
+            ),
         ],
     );
 
@@ -250,6 +260,7 @@ overlays:
         None,
         None,
         Arc::new(packs.clone()),
+        None,
     );
 
     let chiron_config = NousConfig {
@@ -280,6 +291,7 @@ overlays:
         None,
         None,
         Arc::new(packs),
+        None,
     );
 
     let hermes_config = NousConfig {
@@ -348,8 +360,11 @@ fn missing_pack_warns_not_crashes() {
 #[test]
 fn invalid_manifest_skips_gracefully() {
     let bad_dir = tempfile::TempDir::new().expect("tmpdir");
-    std::fs::write(bad_dir.path().join("pack.yaml"), "this: [is: not: valid: yaml: {{}}")
-        .expect("write bad yaml");
+    std::fs::write(
+        bad_dir.path().join("pack.yaml"),
+        "this: [is: not: valid: yaml: {{}}",
+    )
+    .expect("write bad yaml");
 
     let packs = load_packs(&[bad_dir.path().to_path_buf()]);
     assert!(packs.is_empty());

--- a/crates/integration-tests/tests/end_to_end.rs
+++ b/crates/integration-tests/tests/end_to_end.rs
@@ -159,6 +159,7 @@ impl TestHarness {
             None,
             Some(Arc::clone(&session_store)),
             Arc::new(vec![]),
+            None,
         );
 
         let nous_config = NousConfig {

--- a/crates/integration-tests/tests/recall_pipeline.rs
+++ b/crates/integration-tests/tests/recall_pipeline.rs
@@ -60,9 +60,7 @@ fn recall_with_mock_vectors_end_to_end() {
 #[test]
 fn recall_empty_store_graceful() {
     let embedder = MockEmbeddingProvider::new(384);
-    let search = MockVectorSearch {
-        results: vec![],
-    };
+    let search = MockVectorSearch { results: vec![] };
 
     let stage = RecallStage::new(RecallConfig::default());
 

--- a/crates/melete/src/distill.rs
+++ b/crates/melete/src/distill.rs
@@ -19,7 +19,10 @@ pub enum DistillSection {
     OpenThreads,
     Corrections,
     /// Custom section with a name and description.
-    Custom { name: String, description: String },
+    Custom {
+        name: String,
+        description: String,
+    },
 }
 
 impl DistillSection {

--- a/crates/mneme/src/extract.rs
+++ b/crates/mneme/src/extract.rs
@@ -8,6 +8,7 @@ use snafu::{ResultExt, Snafu};
 // ---------------------------------------------------------------------------
 
 #[derive(Debug, Snafu)]
+#[snafu(visibility(pub))]
 pub enum ExtractionError {
     #[snafu(display("failed to parse extraction response"))]
     ParseResponse {
@@ -104,11 +105,7 @@ impl Default for ExtractionConfig {
 /// Keeps mneme independent of hermeneus. The nous layer bridges this trait
 /// to the full `LlmProvider` + `CompletionRequest` API.
 pub trait ExtractionProvider: Send + Sync {
-    fn complete(
-        &self,
-        system: &str,
-        user_message: &str,
-    ) -> Result<String, ExtractionError>;
+    fn complete(&self, system: &str, user_message: &str) -> Result<String, ExtractionError>;
 }
 
 // ---------------------------------------------------------------------------
@@ -280,9 +277,12 @@ Rules:
         }
 
         for (i, fact) in extraction.facts.iter().enumerate() {
-            let content =
-                format!("{} {} {}", fact.subject, fact.predicate, fact.object);
-            let id = format!("{}-{}-{i}", slugify(&fact.subject), slugify(&fact.predicate));
+            let content = format!("{} {} {}", fact.subject, fact.predicate, fact.object);
+            let id = format!(
+                "{}-{}-{i}",
+                slugify(&fact.subject),
+                slugify(&fact.predicate)
+            );
             let f = Fact {
                 id,
                 nous_id: nous_id.to_owned(),
@@ -374,8 +374,7 @@ fn epoch_days_to_ymd(days: i64) -> (i64, u32, u32) {
     let z = days + 719_468;
     let era = z.div_euclid(146_097);
     let doe = z.rem_euclid(146_097) as u32;
-    let yoe =
-        (doe - doe / 1460 + doe / 36524 - doe / 146_096) / 365;
+    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146_096) / 365;
     let y = (yoe as i64) + era * 400;
     let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
     let mp = (5 * doy + 2) / 153;
@@ -532,12 +531,22 @@ mod tests {
 
     #[test]
     fn strip_code_fences_works() {
-        assert_eq!(strip_code_fences(r#"```json
+        assert_eq!(
+            strip_code_fences(
+                r#"```json
 {"a":1}
-```"#), r#"{"a":1}"#);
-        assert_eq!(strip_code_fences(r#"```
+```"#
+            ),
+            r#"{"a":1}"#
+        );
+        assert_eq!(
+            strip_code_fences(
+                r#"```
 {"a":1}
-```"#), r#"{"a":1}"#);
+```"#
+            ),
+            r#"{"a":1}"#
+        );
         assert_eq!(strip_code_fences(r#"{"a":1}"#), r#"{"a":1}"#);
     }
 
@@ -590,7 +599,9 @@ mod tests {
 
         // query_facts filters: valid_from <= now AND valid_to > now
         // Use a future time that's after valid_from but before valid_to.
-        let facts = store.query_facts("syn", "9999-01-01T00:00:00Z", 100).unwrap();
+        let facts = store
+            .query_facts("syn", "9999-01-01T00:00:00Z", 100)
+            .unwrap();
         assert!(
             facts.iter().any(|f| f.content.contains("CozoDB")),
             "persisted fact should be retrievable"

--- a/crates/mneme/src/knowledge_store.rs
+++ b/crates/mneme/src/knowledge_store.rs
@@ -1442,10 +1442,7 @@ mod tests {
         let hit = hit.unwrap();
         assert!(hit.bm25_rank > 0, "must have positive BM25 rank");
         assert!(hit.vec_rank > 0, "must have positive vector rank");
-        assert_eq!(
-            hit.graph_rank, -1,
-            "absent from graph signal must be -1"
-        );
+        assert_eq!(hit.graph_rank, -1, "absent from graph signal must be -1");
         assert!(
             hit.rrf_score > 0.0,
             "RRF score must be positive from two signals"

--- a/crates/mneme/src/query.rs
+++ b/crates/mneme/src/query.rs
@@ -243,7 +243,8 @@ impl PutBuilder {
     /// literal like `"\"9999-12-31\""`, etc. Required for multi-row puts where
     /// different rows bind different params (e.g. `SUPERSEDE_FACT`).
     pub fn row(mut self, exprs: &[&str]) -> Self {
-        self.rows.push(exprs.iter().map(|s| (*s).to_owned()).collect());
+        self.rows
+            .push(exprs.iter().map(|s| (*s).to_owned()).collect());
         self
     }
 
@@ -253,11 +254,7 @@ impl PutBuilder {
     /// names (convention: `$field_name` for each field).
     pub fn done(mut self) -> QueryBuilder {
         if self.rows.is_empty() {
-            let auto_row: Vec<String> = self
-                .all_fields
-                .iter()
-                .map(|f| format!("${f}"))
-                .collect();
+            let auto_row: Vec<String> = self.all_fields.iter().map(|f| format!("${f}")).collect();
             self.rows.push(auto_row);
         }
 
@@ -274,7 +271,11 @@ impl PutBuilder {
         let value_fields: Vec<&str> = self.all_fields[self.key_count..].to_vec();
 
         let put_clause = if value_fields.is_empty() {
-            format!(":put {} {{{}}}", self.relation.name(), key_fields.join(", "))
+            format!(
+                ":put {} {{{}}}",
+                self.relation.name(),
+                key_fields.join(", ")
+            )
         } else {
             format!(
                 ":put {} {{{} => {}}}",
@@ -701,7 +702,10 @@ mod tests {
             .build();
 
         assert!(script.contains("$val"), "script must reference $val");
-        assert!(!script.contains("42"), "script must not contain literal value");
+        assert!(
+            !script.contains("42"),
+            "script must not contain literal value"
+        );
         assert!(params.contains_key("val"));
     }
 
@@ -713,7 +717,10 @@ mod tests {
             .param("id", DataValue::Str("evil}; :rm facts".into()))
             .build();
 
-        assert!(!script.contains("evil}"), "injection payload must not appear in script");
+        assert!(
+            !script.contains("evil}"),
+            "injection payload must not appear in script"
+        );
         assert!(params.contains_key("id"));
     }
 
@@ -774,7 +781,14 @@ mod tests {
         assert_eq!(facts_ddl_fields.as_slice(), facts_enum_fields.as_slice());
 
         // Entities DDL fields
-        let entities_ddl = ["id", "name", "entity_type", "aliases", "created_at", "updated_at"];
+        let entities_ddl = [
+            "id",
+            "name",
+            "entity_type",
+            "aliases",
+            "created_at",
+            "updated_at",
+        ];
         let entities_enum: Vec<&str> = [
             EntitiesField::Id,
             EntitiesField::Name,

--- a/crates/nous/src/actor.rs
+++ b/crates/nous/src/actor.rs
@@ -8,6 +8,8 @@ use aletheia_mneme::store::SessionStore;
 use tokio::sync::mpsc;
 use tracing::{Instrument, debug, info, instrument, warn};
 
+use crate::cross::CrossNousEnvelope;
+
 use aletheia_hermeneus::provider::ProviderRegistry;
 use aletheia_koina::id::{NousId, SessionId};
 use aletheia_mneme::embedding::EmbeddingProvider;
@@ -34,6 +36,7 @@ pub struct NousActor {
     config: NousConfig,
     pipeline_config: PipelineConfig,
     inbox: mpsc::Receiver<NousMessage>,
+    cross_rx: Option<mpsc::Receiver<CrossNousEnvelope>>,
     lifecycle: NousLifecycle,
     sessions: HashMap<String, SessionState>,
     active_session: Option<String>,
@@ -58,6 +61,7 @@ impl NousActor {
         config: NousConfig,
         pipeline_config: PipelineConfig,
         inbox: mpsc::Receiver<NousMessage>,
+        cross_rx: Option<mpsc::Receiver<CrossNousEnvelope>>,
         providers: Arc<ProviderRegistry>,
         tools: Arc<ToolRegistry>,
         oikos: Arc<Oikos>,
@@ -71,6 +75,7 @@ impl NousActor {
             config,
             pipeline_config,
             inbox,
+            cross_rx,
             lifecycle: NousLifecycle::Idle,
             sessions: HashMap::new(),
             active_session: None,
@@ -89,32 +94,64 @@ impl NousActor {
     pub async fn run(mut self) {
         info!(lifecycle = %self.lifecycle, "actor started");
 
-        while let Some(msg) = self.inbox.recv().await {
-            match msg {
-                NousMessage::Turn {
-                    session_key,
-                    content,
-                    reply,
+        loop {
+            tokio::select! {
+                msg = self.inbox.recv() => {
+                    let Some(msg) = msg else { break };
+                    match msg {
+                        NousMessage::Turn {
+                            session_key,
+                            content,
+                            reply,
+                        } => {
+                            self.handle_turn(session_key, content, reply).await;
+                        }
+                        NousMessage::Status { reply } => {
+                            self.handle_status(reply);
+                        }
+                        NousMessage::Sleep => {
+                            self.handle_sleep();
+                        }
+                        NousMessage::Wake => {
+                            self.handle_wake();
+                        }
+                        NousMessage::Shutdown => {
+                            info!("shutdown requested");
+                            break;
+                        }
+                    }
+                }
+                envelope = async {
+                    match self.cross_rx.as_mut() {
+                        Some(rx) => rx.recv().await,
+                        None => std::future::pending().await,
+                    }
                 } => {
-                    self.handle_turn(session_key, content, reply).await;
-                }
-                NousMessage::Status { reply } => {
-                    self.handle_status(reply);
-                }
-                NousMessage::Sleep => {
-                    self.handle_sleep();
-                }
-                NousMessage::Wake => {
-                    self.handle_wake();
-                }
-                NousMessage::Shutdown => {
-                    info!("shutdown requested");
-                    break;
+                    if let Some(envelope) = envelope {
+                        self.handle_cross_message(envelope).await;
+                    }
                 }
             }
         }
 
         info!(lifecycle = %self.lifecycle, "actor stopped");
+    }
+
+    async fn handle_cross_message(&mut self, envelope: CrossNousEnvelope) {
+        let from = &envelope.message.from;
+        let session_key = format!("cross:{from}");
+        let content = envelope.message.content.clone();
+
+        debug!(from = %from, session_key = %session_key, "processing cross-nous message");
+
+        match self.execute_turn(&session_key, &content).await {
+            Ok(result) => {
+                debug!(from = %from, content_len = result.content.len(), "cross-nous turn completed");
+            }
+            Err(e) => {
+                warn!(from = %from, error = %e, "cross-nous turn failed");
+            }
+        }
     }
 
     async fn handle_turn(
@@ -132,6 +169,10 @@ impl NousActor {
         self.active_session = Some(session_key.clone());
 
         let result = self.execute_turn(&session_key, &content).await;
+
+        if let Ok(ref turn_result) = result {
+            self.maybe_spawn_extraction(&content, &turn_result.content);
+        }
 
         self.active_session = None;
         self.lifecycle = NousLifecycle::Idle;
@@ -202,6 +243,34 @@ impl NousActor {
         let _ = reply.send(status);
     }
 
+    fn maybe_spawn_extraction(&self, user_content: &str, assistant_content: &str) {
+        let Some(ref extraction_config) = self.pipeline_config.extraction else {
+            return;
+        };
+        if !extraction_config.enabled {
+            return;
+        }
+
+        let content_len = user_content.len() + assistant_content.len();
+        if content_len < extraction_config.min_message_length {
+            return;
+        }
+
+        let config = extraction_config.clone();
+        let providers = Arc::clone(&self.providers);
+        let nous_id = self.id.clone();
+        let user = user_content.to_owned();
+        let assistant = assistant_content.to_owned();
+        let span = tracing::info_span!("extraction", nous.id = %nous_id);
+
+        tokio::spawn(
+            async move {
+                run_extraction(&config, providers, &nous_id, &user, &assistant);
+            }
+            .instrument(span),
+        );
+    }
+
     fn handle_sleep(&mut self) {
         match self.lifecycle {
             NousLifecycle::Idle => {
@@ -230,6 +299,46 @@ impl NousActor {
     }
 }
 
+/// Run extraction as a background task. Logs results, never panics.
+fn run_extraction(
+    config: &aletheia_mneme::extract::ExtractionConfig,
+    providers: Arc<ProviderRegistry>,
+    nous_id: &str,
+    user_content: &str,
+    assistant_content: &str,
+) {
+    use aletheia_mneme::extract::{ConversationMessage, ExtractionEngine};
+
+    let engine = ExtractionEngine::new(config.clone());
+    let provider = crate::extraction::HermeneusExtractionProvider::new(providers, &config.model);
+
+    let messages = vec![
+        ConversationMessage {
+            role: "user".to_owned(),
+            content: user_content.to_owned(),
+        },
+        ConversationMessage {
+            role: "assistant".to_owned(),
+            content: assistant_content.to_owned(),
+        },
+    ];
+
+    match engine.extract(&messages, &provider) {
+        Ok(extraction) => {
+            info!(
+                nous_id = %nous_id,
+                entities = extraction.entities.len(),
+                relationships = extraction.relationships.len(),
+                facts = extraction.facts.len(),
+                "extraction completed"
+            );
+        }
+        Err(e) => {
+            warn!(nous_id = %nous_id, error = %e, "extraction failed");
+        }
+    }
+}
+
 /// Spawn a nous actor, returning its handle and join handle.
 ///
 /// Creates a bounded channel with [`DEFAULT_INBOX_CAPACITY`], builds the actor,
@@ -248,6 +357,7 @@ pub fn spawn(
     vector_search: Option<Arc<dyn crate::recall::VectorSearch>>,
     session_store: Option<Arc<Mutex<SessionStore>>>,
     extra_bootstrap: Vec<BootstrapSection>,
+    cross_rx: Option<mpsc::Receiver<CrossNousEnvelope>>,
 ) -> (NousHandle, tokio::task::JoinHandle<()>) {
     let (tx, rx) = mpsc::channel(DEFAULT_INBOX_CAPACITY);
     let id = config.id.clone();
@@ -258,6 +368,7 @@ pub fn spawn(
         config,
         pipeline_config,
         rx,
+        cross_rx,
         providers,
         tools,
         oikos,
@@ -364,6 +475,7 @@ mod tests {
             None,
             None,
             Vec::new(),
+            None,
         );
         (handle, join, dir)
     }

--- a/crates/nous/src/bootstrap/mod.rs
+++ b/crates/nous/src/bootstrap/mod.rs
@@ -732,9 +732,11 @@ mod tests {
             .assemble_with_extra("test", &mut budget, extra)
             .unwrap();
         assert!(result.system_prompt.contains("Domain logic from pack."));
-        assert!(result
-            .sections_included
-            .contains(&"[pack] LOGIC.md".to_owned()));
+        assert!(
+            result
+                .sections_included
+                .contains(&"[pack] LOGIC.md".to_owned())
+        );
         assert_eq!(result.sections_included.len(), 2);
     }
 

--- a/crates/nous/src/config.rs
+++ b/crates/nous/src/config.rs
@@ -58,6 +58,9 @@ pub struct PipelineConfig {
     pub max_notes: usize,
     /// Token budget for history (remaining after bootstrap).
     pub history_budget_ratio: f64,
+    /// Knowledge extraction configuration (None = disabled).
+    #[serde(default)]
+    pub extraction: Option<aletheia_mneme::extract::ExtractionConfig>,
 }
 
 impl Default for PipelineConfig {
@@ -68,6 +71,7 @@ impl Default for PipelineConfig {
             include_working_state: true,
             max_notes: 50,
             history_budget_ratio: 0.6,
+            extraction: None,
         }
     }
 }

--- a/crates/nous/src/cross.rs
+++ b/crates/nous/src/cross.rs
@@ -4,11 +4,13 @@ use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;
 use std::time::Duration;
 
-use tokio::sync::{mpsc, oneshot, RwLock};
+use tokio::sync::{RwLock, mpsc, oneshot};
 use tracing::{instrument, warn};
 use ulid::Ulid;
 
-use crate::error::{self, AskTimeoutSnafu, DeliveryFailedSnafu, NousNotFoundSnafu, ReplyNotFoundSnafu};
+use crate::error::{
+    self, AskTimeoutSnafu, DeliveryFailedSnafu, NousNotFoundSnafu, ReplyNotFoundSnafu,
+};
 
 const DEFAULT_REPLY_TIMEOUT: Duration = Duration::from_secs(30);
 const DEFAULT_MAX_LOG_ENTRIES: usize = 1000;
@@ -41,11 +43,7 @@ pub struct CrossNousMessage {
 
 impl CrossNousMessage {
     #[must_use]
-    pub fn new(
-        from: impl Into<String>,
-        to: impl Into<String>,
-        content: impl Into<String>,
-    ) -> Self {
+    pub fn new(from: impl Into<String>, to: impl Into<String>, content: impl Into<String>) -> Self {
         Self {
             id: Ulid::new(),
             from: from.into(),
@@ -146,9 +144,12 @@ impl CrossNousRouter {
         let routes = self.routes.read().await;
         let Some(sender) = routes.get(&to).cloned() else {
             drop(routes);
-            self.log_delivery(&message, &DeliveryState::Failed {
-                reason: format!("nous '{to}' not registered"),
-            })
+            self.log_delivery(
+                &message,
+                &DeliveryState::Failed {
+                    reason: format!("nous '{to}' not registered"),
+                },
+            )
             .await;
             return NousNotFoundSnafu { nous_id: to }.fail();
         };
@@ -161,8 +162,7 @@ impl CrossNousRouter {
 
         match sender.send(envelope).await {
             Ok(()) => {
-                self.log_delivery_state(&to, DeliveryState::Delivered)
-                    .await;
+                self.log_delivery_state(&to, DeliveryState::Delivered).await;
                 Ok(DeliveryState::Delivered)
             }
             Err(send_err) => {
@@ -185,9 +185,12 @@ impl CrossNousRouter {
         let routes = self.routes.read().await;
         let Some(sender) = routes.get(&to).cloned() else {
             drop(routes);
-            self.log_delivery(&message, &DeliveryState::Failed {
-                reason: format!("nous '{to}' not registered"),
-            })
+            self.log_delivery(
+                &message,
+                &DeliveryState::Failed {
+                    reason: format!("nous '{to}' not registered"),
+                },
+            )
             .await;
             return NousNotFoundSnafu { nous_id: to }.fail();
         };
@@ -196,10 +199,7 @@ impl CrossNousRouter {
         let (reply_tx, reply_rx) = oneshot::channel();
         let msg_id = message.id;
 
-        self.pending_replies
-            .write()
-            .await
-            .insert(msg_id, reply_tx);
+        self.pending_replies.write().await.insert(msg_id, reply_tx);
 
         let envelope = CrossNousEnvelope {
             message: message.clone(),
@@ -208,15 +208,17 @@ impl CrossNousRouter {
 
         if sender.send(envelope).await.is_err() {
             self.pending_replies.write().await.remove(&msg_id);
-            self.log_delivery(&message, &DeliveryState::Failed {
-                reason: "inbox closed".to_owned(),
-            })
+            self.log_delivery(
+                &message,
+                &DeliveryState::Failed {
+                    reason: "inbox closed".to_owned(),
+                },
+            )
             .await;
             return DeliveryFailedSnafu { nous_id: to }.fail();
         }
 
-        self.log_delivery(&message, &DeliveryState::Delivered)
-            .await;
+        self.log_delivery(&message, &DeliveryState::Delivered).await;
 
         tokio::select! {
             result = reply_rx => {

--- a/crates/nous/src/extraction.rs
+++ b/crates/nous/src/extraction.rs
@@ -1,0 +1,66 @@
+//! Bridge from nous to mneme's extraction pipeline via hermeneus providers.
+
+use std::sync::Arc;
+
+use aletheia_hermeneus::provider::ProviderRegistry;
+use aletheia_hermeneus::types::{CompletionRequest, Content, ContentBlock, Message, Role};
+use aletheia_mneme::extract::{ExtractionError, ExtractionProvider, LlmCallSnafu};
+use snafu::OptionExt;
+
+/// Bridges hermeneus `ProviderRegistry` to mneme's `ExtractionProvider` trait.
+pub(crate) struct HermeneusExtractionProvider {
+    providers: Arc<ProviderRegistry>,
+    model: String,
+}
+
+impl HermeneusExtractionProvider {
+    pub(crate) fn new(providers: Arc<ProviderRegistry>, model: &str) -> Self {
+        Self {
+            providers,
+            model: model.to_owned(),
+        }
+    }
+}
+
+impl ExtractionProvider for HermeneusExtractionProvider {
+    fn complete(&self, system: &str, user_message: &str) -> Result<String, ExtractionError> {
+        let request = CompletionRequest {
+            model: self.model.clone(),
+            system: Some(system.to_owned()),
+            messages: vec![Message {
+                role: Role::User,
+                content: Content::Text(user_message.to_owned()),
+            }],
+            max_tokens: 4096,
+            tools: Vec::new(),
+            temperature: None,
+            thinking: None,
+            stop_sequences: Vec::new(),
+        };
+
+        let provider = self.providers.find_provider(&self.model).ok_or_else(|| {
+            LlmCallSnafu {
+                message: format!("no provider for model {}", self.model),
+            }
+            .build()
+        })?;
+
+        let response = provider.complete(&request).map_err(|e| {
+            LlmCallSnafu {
+                message: e.to_string(),
+            }
+            .build()
+        })?;
+
+        response
+            .content
+            .iter()
+            .find_map(|block| match block {
+                ContentBlock::Text { text } => Some(text.clone()),
+                _ => None,
+            })
+            .context(LlmCallSnafu {
+                message: "no text content in extraction response",
+            })
+    }
+}

--- a/crates/nous/src/lib.rs
+++ b/crates/nous/src/lib.rs
@@ -13,6 +13,7 @@ pub mod config;
 pub mod cross;
 pub mod error;
 pub mod execute;
+pub(crate) mod extraction;
 pub mod finalize;
 pub mod handle;
 pub mod history;

--- a/crates/nous/src/manager.rs
+++ b/crates/nous/src/manager.rs
@@ -6,6 +6,7 @@ use std::sync::{Arc, Mutex};
 use aletheia_mneme::store::SessionStore;
 use aletheia_thesauros::loader::LoadedPack;
 
+use tokio::sync::watch;
 use tokio::task::JoinHandle;
 use tracing::{info, warn};
 
@@ -37,11 +38,18 @@ pub struct NousManager {
     vector_search: Option<Arc<dyn crate::recall::VectorSearch>>,
     session_store: Option<Arc<Mutex<SessionStore>>>,
     packs: Arc<Vec<LoadedPack>>,
+    router: Option<Arc<crate::cross::CrossNousRouter>>,
+    ready_tx: watch::Sender<bool>,
+    ready_rx: watch::Receiver<bool>,
 }
 
 impl NousManager {
     /// Create a new manager with shared dependencies.
     #[must_use]
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "runtime init requires all shared dependencies"
+    )]
     pub fn new(
         providers: Arc<ProviderRegistry>,
         tools: Arc<ToolRegistry>,
@@ -50,7 +58,9 @@ impl NousManager {
         vector_search: Option<Arc<dyn crate::recall::VectorSearch>>,
         session_store: Option<Arc<Mutex<SessionStore>>>,
         packs: Arc<Vec<LoadedPack>>,
+        router: Option<Arc<crate::cross::CrossNousRouter>>,
     ) -> Self {
+        let (ready_tx, ready_rx) = watch::channel(false);
         Self {
             actors: HashMap::new(),
             providers,
@@ -60,7 +70,28 @@ impl NousManager {
             vector_search,
             session_store,
             packs,
+            router,
+            ready_tx,
+            ready_rx,
         }
+    }
+
+    /// Signal that all actors are spawned and the system is ready for inbound messages.
+    pub fn ready(&self) {
+        let _ = self.ready_tx.send(true);
+        info!(count = self.actors.len(), "system ready");
+    }
+
+    /// Subscribe to the ready signal.
+    #[must_use]
+    pub fn ready_rx(&self) -> watch::Receiver<bool> {
+        self.ready_rx.clone()
+    }
+
+    /// Access the cross-nous router, if configured.
+    #[must_use]
+    pub fn router(&self) -> Option<&Arc<crate::cross::CrossNousRouter>> {
+        self.router.as_ref()
     }
 
     /// Spawn a new nous actor and return its handle.
@@ -84,14 +115,21 @@ impl NousManager {
             let estimator = CharEstimator;
             let mut sections = Vec::new();
             for pack in self.packs.iter() {
-                let agent_sections =
-                    pack.sections_for_agent_or_domains(&id, &config.domains);
+                let agent_sections = pack.sections_for_agent_or_domains(&id, &config.domains);
                 sections.extend(pack_sections_to_bootstrap(&agent_sections, &estimator));
             }
             if !sections.is_empty() {
                 info!(nous_id = %id, sections = sections.len(), "domain pack sections resolved");
             }
             sections
+        };
+
+        let cross_rx = if let Some(ref router) = self.router {
+            let (cross_tx, cross_rx) = tokio::sync::mpsc::channel(32);
+            router.register(&id, cross_tx).await;
+            Some(cross_rx)
+        } else {
+            None
         };
 
         let (handle, join_handle) = actor::spawn(
@@ -104,6 +142,7 @@ impl NousManager {
             self.vector_search.clone(),
             self.session_store.clone(),
             extra_bootstrap,
+            cross_rx,
         );
 
         info!(nous_id = %id, "actor spawned");
@@ -154,6 +193,12 @@ impl NousManager {
     pub async fn shutdown_all(&mut self) {
         info!(count = self.actors.len(), "shutting down all actors");
 
+        if let Some(ref router) = self.router {
+            for id in self.actors.keys() {
+                router.unregister(id).await;
+            }
+        }
+
         let entries: Vec<(String, NousHandle, JoinHandle<()>)> = self
             .actors
             .drain()
@@ -181,6 +226,13 @@ impl NousManager {
     /// Does not drain the entries — cleanup happens when the `Arc` drops.
     pub async fn shutdown_readonly(&self) {
         info!(count = self.actors.len(), "shutting down all actors");
+
+        if let Some(ref router) = self.router {
+            for id in self.actors.keys() {
+                router.unregister(id).await;
+            }
+        }
+
         for entry in self.actors.values() {
             if let Err(e) = entry.handle.shutdown().await {
                 warn!(nous_id = entry.handle.id(), error = %e, "failed to send shutdown");
@@ -271,6 +323,7 @@ mod tests {
             None,
             None,
             Arc::new(Vec::new()),
+            None,
         )
     }
 

--- a/crates/nous/src/pipeline.rs
+++ b/crates/nous/src/pipeline.rs
@@ -168,11 +168,7 @@ impl LoopDetector {
         let Some(last) = self.history.back() else {
             return 0;
         };
-        self.history
-            .iter()
-            .rev()
-            .take_while(|s| *s == last)
-            .count()
+        self.history.iter().rev().take_while(|s| *s == last).count()
     }
 }
 
@@ -856,6 +852,9 @@ mod tests {
         // Now trigger a loop within the window
         assert!(det.record("exec", "same").is_none());
         assert!(det.record("exec", "same").is_none());
-        assert!(det.record("exec", "same").is_some(), "should detect loop even after window eviction");
+        assert!(
+            det.record("exec", "same").is_some(),
+            "should detect loop even after window eviction"
+        );
     }
 }

--- a/crates/nous/src/recall.rs
+++ b/crates/nous/src/recall.rs
@@ -58,7 +58,12 @@ impl VectorSearch for KnowledgeVectorSearch {
         let ef_i64 = i64::try_from(ef).unwrap_or(i64::MAX);
         self.store
             .search_vectors(query_vec, k_i64, ef_i64)
-            .map_err(|e| error::RecallSearchSnafu { message: e.to_string() }.build())
+            .map_err(|e| {
+                error::RecallSearchSnafu {
+                    message: e.to_string(),
+                }
+                .build()
+            })
     }
 }
 
@@ -154,9 +159,21 @@ impl RecallStage {
         }
 
         if self.config.iterative && self.config.max_cycles > 1 {
-            self.run_iterative(query, nous_id, embedding_provider, vector_search, remaining_budget)
+            self.run_iterative(
+                query,
+                nous_id,
+                embedding_provider,
+                vector_search,
+                remaining_budget,
+            )
         } else {
-            self.run_single(query, nous_id, embedding_provider, vector_search, remaining_budget)
+            self.run_single(
+                query,
+                nous_id,
+                embedding_provider,
+                vector_search,
+                remaining_budget,
+            )
         }
     }
 
@@ -249,7 +266,10 @@ impl RecallStage {
             }
         }
 
-        debug!(unique_candidates = merged.len(), "merged results from 2 cycles");
+        debug!(
+            unique_candidates = merged.len(),
+            "merged results from 2 cycles"
+        );
 
         let candidates = self.build_candidates(merged, nous_id);
         let ranked = self.engine.rank(candidates);
@@ -286,7 +306,11 @@ impl RecallStage {
             candidates_found,
             results_injected,
             tokens_consumed: tokens,
-            recall_section: if section.is_empty() { None } else { Some(section) },
+            recall_section: if section.is_empty() {
+                None
+            } else {
+                Some(section)
+            },
         }
     }
 
@@ -365,37 +389,144 @@ fn search(
     query_vec: Vec<f32>,
     k: usize,
 ) -> error::Result<Vec<KnowledgeRecallResult>> {
-    vector_search
-        .search_vectors(query_vec, k, 50)
-        .map_err(|e| {
-            error::RecallSearchSnafu {
-                message: e.to_string(),
-            }
-            .build()
-        })
+    vector_search.search_vectors(query_vec, k, 50).map_err(|e| {
+        error::RecallSearchSnafu {
+            message: e.to_string(),
+        }
+        .build()
+    })
 }
 
 // --- Stopword list ---
 
 static STOPWORDS: LazyLock<HashSet<&str>> = LazyLock::new(|| {
     HashSet::from([
-        "a", "an", "the", "and", "but", "or", "nor", "for", "yet", "so",
-        "in", "on", "at", "to", "from", "by", "with", "about", "into",
-        "through", "during", "before", "after", "above", "below", "between",
-        "out", "off", "over", "under", "again", "further", "then", "once",
-        "is", "am", "are", "was", "were", "be", "been", "being",
-        "have", "has", "had", "having", "do", "does", "did", "doing",
-        "will", "would", "shall", "should", "may", "might", "must", "can",
-        "could", "need", "dare", "ought", "used",
-        "i", "me", "my", "myself", "we", "our", "ours", "ourselves",
-        "you", "your", "yours", "yourself", "yourselves",
-        "he", "him", "his", "himself", "she", "her", "hers", "herself",
-        "it", "its", "itself", "they", "them", "their", "theirs", "themselves",
-        "what", "which", "who", "whom", "this", "that", "these", "those",
-        "here", "there", "when", "where", "why", "how",
-        "all", "each", "every", "both", "few", "more", "most", "other",
-        "some", "such", "only", "own", "same", "than",
-        "too", "very", "just", "also", "not", "no",
+        "a",
+        "an",
+        "the",
+        "and",
+        "but",
+        "or",
+        "nor",
+        "for",
+        "yet",
+        "so",
+        "in",
+        "on",
+        "at",
+        "to",
+        "from",
+        "by",
+        "with",
+        "about",
+        "into",
+        "through",
+        "during",
+        "before",
+        "after",
+        "above",
+        "below",
+        "between",
+        "out",
+        "off",
+        "over",
+        "under",
+        "again",
+        "further",
+        "then",
+        "once",
+        "is",
+        "am",
+        "are",
+        "was",
+        "were",
+        "be",
+        "been",
+        "being",
+        "have",
+        "has",
+        "had",
+        "having",
+        "do",
+        "does",
+        "did",
+        "doing",
+        "will",
+        "would",
+        "shall",
+        "should",
+        "may",
+        "might",
+        "must",
+        "can",
+        "could",
+        "need",
+        "dare",
+        "ought",
+        "used",
+        "i",
+        "me",
+        "my",
+        "myself",
+        "we",
+        "our",
+        "ours",
+        "ourselves",
+        "you",
+        "your",
+        "yours",
+        "yourself",
+        "yourselves",
+        "he",
+        "him",
+        "his",
+        "himself",
+        "she",
+        "her",
+        "hers",
+        "herself",
+        "it",
+        "its",
+        "itself",
+        "they",
+        "them",
+        "their",
+        "theirs",
+        "themselves",
+        "what",
+        "which",
+        "who",
+        "whom",
+        "this",
+        "that",
+        "these",
+        "those",
+        "here",
+        "there",
+        "when",
+        "where",
+        "why",
+        "how",
+        "all",
+        "each",
+        "every",
+        "both",
+        "few",
+        "more",
+        "most",
+        "other",
+        "some",
+        "such",
+        "only",
+        "own",
+        "same",
+        "than",
+        "too",
+        "very",
+        "just",
+        "also",
+        "not",
+        "no",
     ])
 });
 
@@ -422,10 +553,7 @@ fn discover_terminology(results: &[ScoredResult], original_query: &str) -> Vec<S
             let cleaned = word
                 .trim_matches(|c: char| !c.is_alphanumeric())
                 .to_lowercase();
-            if cleaned.len() > 3
-                && !query_words.contains(&cleaned)
-                && !is_stopword(&cleaned)
-            {
+            if cleaned.len() > 3 && !query_words.contains(&cleaned) && !is_stopword(&cleaned) {
                 *term_freq.entry(cleaned).or_default() += 1;
             }
         }
@@ -767,7 +895,6 @@ mod tests {
         fn _assert_object_safe(_: &dyn VectorSearch) {}
     }
 
-
     #[cfg(feature = "knowledge-store")]
     mod knowledge_bridge_tests {
         use aletheia_mneme::knowledge::EmbeddedChunk;
@@ -939,7 +1066,8 @@ mod tests {
 
         let gaps = detect_gaps(&results);
         assert!(
-            gaps.iter().any(|g| g == "Machine Learning" || g == "Research"),
+            gaps.iter()
+                .any(|g| g == "Machine Learning" || g == "Research"),
             "should detect capitalized phrases: got {gaps:?}"
         );
     }
@@ -1008,7 +1136,10 @@ mod tests {
             .unwrap();
 
         // fact-b should appear only once in the merged set
-        assert_eq!(result.candidates_found, 3, "should have 3 unique candidates");
+        assert_eq!(
+            result.candidates_found, 3,
+            "should have 3 unique candidates"
+        );
         assert_eq!(search.call_count(), 2, "should have searched twice");
     }
 

--- a/crates/pylon/src/server.rs
+++ b/crates/pylon/src/server.rs
@@ -64,6 +64,7 @@ pub async fn run(config: ServerConfig) -> Result<(), ServerError> {
         None,
         Some(Arc::clone(&session_store)),
         Arc::new(vec![]),
+        None,
     );
     let nous_config = NousConfig::default();
     nous_manager

--- a/crates/pylon/src/tests.rs
+++ b/crates/pylon/src/tests.rs
@@ -117,6 +117,7 @@ async fn test_state_with_provider(with_provider: bool) -> (Arc<AppState>, tempfi
         None,
         Some(Arc::clone(&session_store)),
         Arc::new(vec![]),
+        None,
     );
 
     let nous_config = NousConfig {

--- a/crates/thesauros/src/error.rs
+++ b/crates/thesauros/src/error.rs
@@ -105,10 +105,9 @@ mod tests {
 
     #[test]
     fn read_file_chains_source() {
-        let result: Result<Vec<u8>> =
-            std::fs::read("/nonexistent/path").context(ReadFileSnafu {
-                path: PathBuf::from("/nonexistent/path"),
-            });
+        let result: Result<Vec<u8>> = std::fs::read("/nonexistent/path").context(ReadFileSnafu {
+            path: PathBuf::from("/nonexistent/path"),
+        });
         let err = result.unwrap_err();
         assert!(std::error::Error::source(&err).is_some());
     }

--- a/crates/thesauros/src/loader.rs
+++ b/crates/thesauros/src/loader.rs
@@ -107,11 +107,7 @@ pub fn load_packs(paths: &[PathBuf]) -> Vec<LoadedPack> {
 
     if !packs.is_empty() {
         let total_sections: usize = packs.iter().map(|p| p.sections.len()).sum();
-        info!(
-            packs = packs.len(),
-            total_sections,
-            "domain packs loaded"
-        );
+        info!(packs = packs.len(), total_sections, "domain packs loaded");
     }
 
     packs
@@ -236,11 +232,17 @@ overlays:
     #[test]
     fn load_packs_multiple() {
         let dir1 = setup_pack(&[
-            ("pack.yaml", "name: pack-a\nversion: \"1.0\"\ncontext:\n  - path: a.md\n"),
+            (
+                "pack.yaml",
+                "name: pack-a\nversion: \"1.0\"\ncontext:\n  - path: a.md\n",
+            ),
             ("a.md", "Content A"),
         ]);
         let dir2 = setup_pack(&[
-            ("pack.yaml", "name: pack-b\nversion: \"1.0\"\ncontext:\n  - path: b.md\n"),
+            (
+                "pack.yaml",
+                "name: pack-b\nversion: \"1.0\"\ncontext:\n  - path: b.md\n",
+            ),
             ("b.md", "Content B"),
         ]);
 
@@ -252,9 +254,7 @@ overlays:
 
     #[test]
     fn load_packs_skips_invalid() {
-        let good = setup_pack(&[
-            ("pack.yaml", "name: good\nversion: \"1.0\"\n"),
-        ]);
+        let good = setup_pack(&[("pack.yaml", "name: good\nversion: \"1.0\"\n")]);
 
         let packs = load_packs(&[
             PathBuf::from("/nonexistent/pack"),
@@ -327,10 +327,7 @@ context:
         let pack = load_single_pack(dir.path()).unwrap();
 
         // hermes has no agent match but has healthcare domain
-        let sections = pack.sections_for_agent_or_domains(
-            "hermes",
-            &["healthcare".to_owned()],
-        );
+        let sections = pack.sections_for_agent_or_domains("hermes", &["healthcare".to_owned()]);
         assert_eq!(sections.len(), 2); // general + healthcare
         let names: Vec<&str> = sections.iter().map(|s| s.name.as_str()).collect();
         assert!(names.contains(&"general.md"));
@@ -356,10 +353,7 @@ context:
         let pack = load_single_pack(dir.path()).unwrap();
 
         // unknown agent, no matching domains: only general (no filter) section
-        let sections = pack.sections_for_agent_or_domains(
-            "unknown",
-            &["analytics".to_owned()],
-        );
+        let sections = pack.sections_for_agent_or_domains("unknown", &["analytics".to_owned()]);
         assert_eq!(sections.len(), 1);
         assert_eq!(sections[0].name, "general.md");
     }
@@ -380,10 +374,7 @@ context:
     #[test]
     fn missing_context_file_skipped_gracefully() {
         let yaml = "name: partial\nversion: \"1.0\"\ncontext:\n  - path: exists.md\n  - path: missing.md\n";
-        let dir = setup_pack(&[
-            ("pack.yaml", yaml),
-            ("exists.md", "content"),
-        ]);
+        let dir = setup_pack(&[("pack.yaml", yaml), ("exists.md", "content")]);
 
         let pack = load_single_pack(dir.path()).unwrap();
         assert_eq!(pack.sections.len(), 1);
@@ -393,7 +384,10 @@ context:
     #[test]
     fn content_is_trimmed() {
         let dir = setup_pack(&[
-            ("pack.yaml", "name: trim-test\nversion: \"1.0\"\ncontext:\n  - path: padded.md\n"),
+            (
+                "pack.yaml",
+                "name: trim-test\nversion: \"1.0\"\ncontext:\n  - path: padded.md\n",
+            ),
             ("padded.md", "\n\n  Content with whitespace.  \n\n"),
         ]);
 

--- a/crates/thesauros/src/manifest.rs
+++ b/crates/thesauros/src/manifest.rs
@@ -142,10 +142,9 @@ pub fn load_manifest(pack_root: &Path) -> Result<PackManifest> {
         }
     );
 
-    let contents =
-        std::fs::read_to_string(&manifest_path).context(error::ReadFileSnafu {
-            path: manifest_path.clone(),
-        })?;
+    let contents = std::fs::read_to_string(&manifest_path).context(error::ReadFileSnafu {
+        path: manifest_path.clone(),
+    })?;
 
     let manifest: PackManifest =
         serde_yml::from_str(&contents).map_err(|e| error::Error::ParseManifest {

--- a/crates/thesauros/src/tools.rs
+++ b/crates/thesauros/src/tools.rs
@@ -72,10 +72,7 @@ impl ToolExecutor for ShellToolExecutor {
                             let _ = child.kill();
                             let _ = child.wait();
                             return Ok(ToolResult {
-                                content: format!(
-                                    "command timed out after {}ms",
-                                    self.timeout_ms
-                                ),
+                                content: format!("command timed out after {}ms", self.timeout_ms),
                                 is_error: true,
                             });
                         }
@@ -125,10 +122,7 @@ impl ToolExecutor for ShellToolExecutor {
 ///
 /// Validates each tool's command path and schema, then registers it.
 /// Invalid tools are skipped with warnings; errors are collected and returned.
-pub fn register_pack_tools(
-    packs: &[LoadedPack],
-    registry: &mut ToolRegistry,
-) -> Vec<error::Error> {
+pub fn register_pack_tools(packs: &[LoadedPack], registry: &mut ToolRegistry) -> Vec<error::Error> {
     let mut errors = Vec::new();
 
     for pack in packs {
@@ -426,7 +420,10 @@ mod tests {
             result.properties["limit"].property_type,
             PropertyType::Integer
         );
-        assert_eq!(result.properties["limit"].default, Some(serde_json::json!(100)));
+        assert_eq!(
+            result.properties["limit"].default,
+            Some(serde_json::json!(100))
+        );
         assert_eq!(result.required, vec!["sql"]);
     }
 


### PR DESCRIPTION
## Summary

- Wire `CrossNousRouter` into `NousManager` — actors register/deregister cross-nous channels, `NousActor` handles inter-agent messages via `tokio::select!` with session key `cross:{from}`
- Add ready gate (`watch::channel<bool>`) so dispatch waits for all actors to spawn before processing inbound messages
- Create `DaemonBridge` trait (object-safe, boxed futures) in daemon crate with `NousDaemonBridge` impl in binary — wires `Prompt` actions and `Prosoche` results to nous actors
- Add `HermeneusExtractionProvider` bridging `ProviderRegistry` to mneme's `ExtractionProvider` trait — actor spawns fire-and-forget extraction after successful turns

## Test plan

- [x] All 166 targeted tests pass (nous, daemon, aletheia)
- [x] Full workspace tests pass (exit code 0)
- [x] `cargo clippy --workspace --exclude aletheia-mneme-engine --all-targets -- -D warnings` clean
- [x] Integration tests updated for new `NousManager::new()` signature

Generated with [Claude Code](https://claude.com/claude-code)