### PR TITLE
feat(koina): structured observability — pipeline spans, tool metrics, provider telemetry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -305,6 +305,7 @@ dependencies = [
  "static_assertions",
  "tempfile",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/agora/src/listener.rs
+++ b/crates/agora/src/listener.rs
@@ -4,10 +4,18 @@ use std::future::Future;
 
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
-use tracing::instrument;
+use tracing::{info_span, instrument};
 
 use crate::semeion::SignalProvider;
 use crate::types::InboundMessage;
+
+fn redact_phone(phone: &str) -> String {
+    if phone.len() > 4 {
+        format!("...{}", &phone[phone.len() - 4..])
+    } else {
+        "****".to_owned()
+    }
+}
 
 /// Listens on registered channels, merging inbound messages into a single stream.
 ///
@@ -56,6 +64,11 @@ impl ChannelListener {
     {
         if let Some(ref mut rx) = self.rx {
             while let Some(msg) = rx.recv().await {
+                let span = info_span!("inbound_message",
+                    msg.channel = %msg.channel,
+                    msg.source = %redact_phone(&msg.sender),
+                );
+                let _guard = span.enter();
                 handler(msg).await;
             }
         }
@@ -93,6 +106,26 @@ impl Drop for ChannelListener {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn redact_phone_long_number() {
+        assert_eq!(redact_phone("+1234567890"), "...7890");
+    }
+
+    #[test]
+    fn redact_phone_short_number() {
+        assert_eq!(redact_phone("12"), "****");
+    }
+
+    #[test]
+    fn redact_phone_exactly_four() {
+        assert_eq!(redact_phone("1234"), "****");
+    }
+
+    #[test]
+    fn redact_phone_five_chars() {
+        assert_eq!(redact_phone("12345"), "...2345");
+    }
 
     #[tokio::test]
     async fn listener_receives_messages() {

--- a/crates/agora/src/router.rs
+++ b/crates/agora/src/router.rs
@@ -1,5 +1,7 @@
 //! Message routing — resolves inbound messages to nous targets.
 
+use tracing::debug;
+
 use aletheia_taxis::config::ChannelBinding;
 
 use crate::types::InboundMessage;
@@ -44,6 +46,14 @@ impl MessageRouter {
 
     /// Resolve which nous should handle this message.
     pub fn resolve(&self, msg: &InboundMessage) -> Option<RouteDecision> {
+        let decision = self.match_route(msg);
+        if let Some(ref d) = decision {
+            debug!(nous_id = %d.nous_id, matched_by = ?d.matched_by, "message routed");
+        }
+        decision
+    }
+
+    fn match_route(&self, msg: &InboundMessage) -> Option<RouteDecision> {
         // Priority 1: exact group match (channel + group_id)
         if let Some(group_id) = &msg.group_id {
             for b in &self.bindings {

--- a/crates/hermeneus/src/anthropic/client.rs
+++ b/crates/hermeneus/src/anthropic/client.rs
@@ -1,12 +1,12 @@
 //! Anthropic Messages API provider.
 
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use reqwest::blocking::Client;
 use reqwest::header::{HeaderMap, HeaderValue};
 use secrecy::{ExposeSecret, SecretString};
 use snafu::ResultExt;
-use tracing::instrument;
+use tracing::{info, info_span};
 
 use crate::error::{self, Result};
 use crate::provider::{LlmProvider, ProviderConfig};
@@ -89,12 +89,28 @@ impl AnthropicProvider {
     /// This is an `AnthropicProvider`-specific method. The sync `LlmProvider`
     /// trait only exposes `complete()`. When the trait goes async in M2, this
     /// will become the primary implementation.
-    #[instrument(skip(self, request, on_event), fields(model = %request.model))]
+    #[expect(
+        clippy::too_many_lines,
+        reason = "streaming retry loop with span recording at each exit point"
+    )]
     pub fn complete_streaming(
         &self,
         request: &CompletionRequest,
         mut on_event: impl FnMut(StreamEvent),
     ) -> Result<CompletionResponse> {
+        let span = info_span!("llm_call",
+            llm.provider = "anthropic",
+            llm.model = %request.model,
+            llm.duration_ms = tracing::field::Empty,
+            llm.tokens_in = tracing::field::Empty,
+            llm.tokens_out = tracing::field::Empty,
+            llm.status = tracing::field::Empty,
+            llm.retries = tracing::field::Empty,
+            llm.stream = true,
+        );
+        let _guard = span.enter();
+        let start = Instant::now();
+
         let wire = WireRequest::from_request(request, Some(true));
         let body = serde_json::to_string(&wire).context(error::ParseResponseSnafu)?;
         let headers = self.build_headers();
@@ -131,6 +147,19 @@ impl AnthropicProvider {
                 let err = super::error::map_error_response(response);
                 // Non-retryable HTTP status: 401, 400-level (except 429)
                 if status == 401 || ((400..500).contains(&status) && status != 429) {
+                    #[expect(
+                        clippy::cast_possible_truncation,
+                        reason = "LLM call duration fits in u64"
+                    )]
+                    {
+                        span.record("llm.duration_ms", start.elapsed().as_millis() as u64);
+                    }
+                    span.record("llm.retries", attempt);
+                    if status == 401 {
+                        span.record("llm.status", "auth_failed");
+                    } else {
+                        span.record("llm.status", "error");
+                    }
                     return Err(err);
                 }
                 last_error = Some(err);
@@ -155,12 +184,42 @@ impl AnthropicProvider {
             });
 
             match stream_result {
-                Ok(()) => return Ok(accumulator.finish()),
+                Ok(()) => {
+                    let resp = accumulator.finish();
+                    #[expect(
+                        clippy::cast_possible_truncation,
+                        reason = "LLM call duration fits in u64"
+                    )]
+                    {
+                        span.record("llm.duration_ms", start.elapsed().as_millis() as u64);
+                    }
+                    span.record("llm.tokens_in", resp.usage.input_tokens);
+                    span.record("llm.tokens_out", resp.usage.output_tokens);
+                    span.record("llm.status", "ok");
+                    span.record("llm.retries", attempt);
+                    info!(
+                        model = %request.model,
+                        tokens_in = resp.usage.input_tokens,
+                        tokens_out = resp.usage.output_tokens,
+                        cost = %format!("~${:.4}", estimate_cost(&request.model, resp.usage.input_tokens, resp.usage.output_tokens)),
+                        "LLM call complete"
+                    );
+                    return Ok(resp);
+                }
                 Err(e) => {
                     // If content was already streamed, we can't retry — it would
                     // produce duplicates. Propagate immediately.
                     if content_started {
                         tracing::error!("SSE error after content started streaming — cannot retry");
+                        #[expect(
+                            clippy::cast_possible_truncation,
+                            reason = "LLM call duration fits in u64"
+                        )]
+                        {
+                            span.record("llm.duration_ms", start.elapsed().as_millis() as u64);
+                        }
+                        span.record("llm.retries", attempt);
+                        span.record("llm.status", "error");
                         return Err(e);
                     }
                     // Only retry RateLimited (overloaded/429); other errors are terminal.
@@ -169,10 +228,29 @@ impl AnthropicProvider {
                         last_error = Some(e);
                         continue;
                     }
+                    #[expect(
+                        clippy::cast_possible_truncation,
+                        reason = "LLM call duration fits in u64"
+                    )]
+                    {
+                        span.record("llm.duration_ms", start.elapsed().as_millis() as u64);
+                    }
+                    span.record("llm.retries", attempt);
+                    span.record("llm.status", "error");
                     return Err(e);
                 }
             }
         }
+
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "LLM call duration fits in u64"
+        )]
+        {
+            span.record("llm.duration_ms", start.elapsed().as_millis() as u64);
+        }
+        span.record("llm.retries", self.max_retries);
+        span.record("llm.status", "error");
 
         Err(last_error.unwrap_or_else(|| {
             error::ApiRequestSnafu {
@@ -198,7 +276,24 @@ impl AnthropicProvider {
         headers
     }
 
+    #[expect(
+        clippy::too_many_lines,
+        reason = "retry loop with span recording at each exit point"
+    )]
     fn execute_with_retry(&self, request: &CompletionRequest) -> Result<CompletionResponse> {
+        let span = info_span!("llm_call",
+            llm.provider = "anthropic",
+            llm.model = %request.model,
+            llm.duration_ms = tracing::field::Empty,
+            llm.tokens_in = tracing::field::Empty,
+            llm.tokens_out = tracing::field::Empty,
+            llm.status = tracing::field::Empty,
+            llm.retries = tracing::field::Empty,
+            llm.stream = false,
+        );
+        let _guard = span.enter();
+        let start = Instant::now();
+
         let wire = WireRequest::from_request(request, None);
         let body = serde_json::to_string(&wire).context(error::ParseResponseSnafu)?;
 
@@ -233,23 +328,69 @@ impl AnthropicProvider {
                     }
                     .build()
                 })?;
-                return super::error::parse_response_body::<super::wire::WireResponse>(&text)
+                let parsed = super::error::parse_response_body::<super::wire::WireResponse>(&text)
                     .and_then(|r| {
                         r.into_response()
                             .map_err(|msg| error::ApiRequestSnafu { message: msg }.build())
                     });
+                if let Ok(ref resp) = parsed {
+                    #[expect(
+                        clippy::cast_possible_truncation,
+                        reason = "LLM call duration fits in u64"
+                    )]
+                    {
+                        span.record("llm.duration_ms", start.elapsed().as_millis() as u64);
+                    }
+                    span.record("llm.tokens_in", resp.usage.input_tokens);
+                    span.record("llm.tokens_out", resp.usage.output_tokens);
+                    span.record("llm.status", "ok");
+                    span.record("llm.retries", attempt);
+                    info!(
+                        model = %request.model,
+                        tokens_in = resp.usage.input_tokens,
+                        tokens_out = resp.usage.output_tokens,
+                        cost = %format!("~${:.4}", estimate_cost(&request.model, resp.usage.input_tokens, resp.usage.output_tokens)),
+                        "LLM call complete"
+                    );
+                }
+                return parsed;
             }
 
             let err = super::error::map_error_response(response);
 
             // Non-retryable: 401, 400-level (except 429).
             if status == 401 || ((400..500).contains(&status) && status != 429) {
+                #[expect(
+                    clippy::cast_possible_truncation,
+                    reason = "LLM call duration fits in u64"
+                )]
+                {
+                    span.record("llm.duration_ms", start.elapsed().as_millis() as u64);
+                }
+                span.record("llm.retries", attempt);
+                if status == 401 {
+                    span.record("llm.status", "auth_failed");
+                } else if status == 429 {
+                    span.record("llm.status", "rate_limited");
+                } else {
+                    span.record("llm.status", "error");
+                }
                 return Err(err);
             }
 
             // Retryable: 429, 5xx, network errors.
             last_error = Some(err);
         }
+
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "LLM call duration fits in u64"
+        )]
+        {
+            span.record("llm.duration_ms", start.elapsed().as_millis() as u64);
+        }
+        span.record("llm.retries", self.max_retries);
+        span.record("llm.status", "error");
 
         Err(last_error.unwrap_or_else(|| {
             error::ApiRequestSnafu {
@@ -261,7 +402,6 @@ impl AnthropicProvider {
 }
 
 impl LlmProvider for AnthropicProvider {
-    #[instrument(skip(self, request), fields(model = %request.model))]
     fn complete(&self, request: &CompletionRequest) -> Result<CompletionResponse> {
         self.execute_with_retry(request)
     }
@@ -277,6 +417,21 @@ impl LlmProvider for AnthropicProvider {
     fn name(&self) -> &str {
         "anthropic"
     }
+}
+
+#[expect(
+    clippy::cast_precision_loss,
+    reason = "token counts are small enough for f64 precision"
+)]
+fn estimate_cost(model: &str, input_tokens: u64, output_tokens: u64) -> f64 {
+    let (in_rate, out_rate) = if model.contains("opus") {
+        (15.0, 75.0)
+    } else if model.contains("haiku") {
+        (0.80, 4.0)
+    } else {
+        (3.0, 15.0)
+    };
+    (input_tokens as f64 * in_rate + output_tokens as f64 * out_rate) / 1_000_000.0
 }
 
 pub(crate) fn backoff_delay(attempt: u32, last_error: Option<&error::Error>) -> Duration {
@@ -554,6 +709,33 @@ mod tests {
             matches!(err, Error::ParseResponse { .. }),
             "expected ParseResponse, got: {err:?}"
         );
+    }
+
+    // --- estimate_cost unit tests ---
+
+    #[test]
+    fn estimate_cost_opus() {
+        let cost = estimate_cost("claude-opus-4-20250514", 1000, 100);
+        assert!((cost - 0.0225).abs() < 0.0001);
+    }
+
+    #[test]
+    fn estimate_cost_sonnet() {
+        let cost = estimate_cost("claude-sonnet-4-20250514", 1000, 100);
+        assert!((cost - 0.0045).abs() < 0.0001);
+    }
+
+    #[test]
+    fn estimate_cost_haiku() {
+        let cost = estimate_cost("claude-haiku-4-5-20251001", 1000, 100);
+        assert!((cost - 0.0012).abs() < 0.0001);
+    }
+
+    #[test]
+    fn estimate_cost_unknown_defaults_to_sonnet() {
+        let cost_unknown = estimate_cost("some-unknown-model", 1000, 100);
+        let cost_sonnet = estimate_cost("claude-sonnet-4-20250514", 1000, 100);
+        assert!((cost_unknown - cost_sonnet).abs() < 0.0001);
     }
 
     // --- backoff_delay unit tests ---

--- a/crates/nous/src/finalize.rs
+++ b/crates/nous/src/finalize.rs
@@ -7,7 +7,7 @@
 //! 4. Records token usage
 
 use snafu::ResultExt;
-use tracing::instrument;
+use tracing::{debug, instrument};
 
 use aletheia_mneme::store::SessionStore;
 use aletheia_mneme::types::{Role, UsageRecord};
@@ -133,6 +133,7 @@ pub fn finalize(
         usage_recorded = true;
     }
 
+    debug!(messages_persisted, usage_recorded, "finalize complete");
     Ok(FinalizeResult {
         messages_persisted,
         usage_recorded,

--- a/crates/nous/src/history.rs
+++ b/crates/nous/src/history.rs
@@ -5,6 +5,7 @@
 //! user message at the end.
 
 use snafu::ResultExt;
+use tracing::debug;
 
 use aletheia_mneme::store::SessionStore;
 use aletheia_mneme::types::Role;
@@ -129,14 +130,18 @@ pub fn load_history(
         token_estimate: current_tokens,
     });
 
-    Ok((
-        messages,
-        HistoryResult {
-            messages_loaded: loaded_count,
-            tokens_consumed,
-            truncated,
-        },
-    ))
+    let result = HistoryResult {
+        messages_loaded: loaded_count,
+        tokens_consumed,
+        truncated,
+    };
+    debug!(
+        messages_loaded = result.messages_loaded,
+        tokens_consumed = result.tokens_consumed,
+        truncated = result.truncated,
+        "history loaded"
+    );
+    Ok((messages, result))
 }
 
 #[cfg(test)]

--- a/crates/nous/src/pipeline.rs
+++ b/crates/nous/src/pipeline.rs
@@ -11,9 +11,10 @@
 
 use std::collections::VecDeque;
 use std::sync::Mutex;
+use std::time::Instant;
 
 use serde::{Deserialize, Serialize};
-use tracing::{debug, error, instrument, warn};
+use tracing::{debug, error, info_span, instrument, warn};
 
 use aletheia_mneme::embedding::EmbeddingProvider;
 use aletheia_mneme::store::SessionStore;
@@ -168,11 +169,7 @@ impl LoopDetector {
         let Some(last) = self.history.back() else {
             return 0;
         };
-        self.history
-            .iter()
-            .rev()
-            .take_while(|s| *s == last)
-            .count()
+        self.history.iter().rev().take_while(|s| *s == last).count()
     }
 }
 
@@ -324,7 +321,6 @@ pub fn check_guard(_session: &SessionState, _config: &NousConfig) -> GuardResult
     clippy::too_many_lines,
     reason = "pipeline orchestrator — sequential stages are clearer inline"
 )]
-#[instrument(skip_all, fields(nous_id = %config.id))]
 pub async fn run_pipeline(
     input: PipelineInput,
     oikos: &Oikos,
@@ -338,118 +334,270 @@ pub async fn run_pipeline(
     session_store: Option<&Mutex<SessionStore>>,
     extra_bootstrap: Vec<BootstrapSection>,
 ) -> error::Result<TurnResult> {
+    let pipeline_start = Instant::now();
+    let pipeline_span = info_span!("pipeline",
+        nous_id = %config.id,
+        session_id = %input.session.id,
+        pipeline.total_duration_ms = tracing::field::Empty,
+        pipeline.stages_completed = tracing::field::Empty,
+        pipeline.tool_calls = tracing::field::Empty,
+        pipeline.model = %config.model,
+    );
+    let _pipeline_guard = pipeline_span.enter();
+    let mut stages_completed: u32 = 0;
+
     // Stage 1: Context (with domain pack sections if any)
     let mut ctx = PipelineContext::default();
-    assemble_context_with_extra(oikos, config, pipeline_config, &mut ctx, extra_bootstrap)?;
+    {
+        let span = info_span!(
+            "pipeline_stage",
+            stage = "context",
+            duration_ms = tracing::field::Empty,
+            status = tracing::field::Empty
+        );
+        let _guard = span.enter();
+        let start = Instant::now();
+        assemble_context_with_extra(oikos, config, pipeline_config, &mut ctx, extra_bootstrap)?;
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "stage duration fits in u64"
+        )]
+        {
+            span.record("duration_ms", start.elapsed().as_millis() as u64);
+        }
+        span.record("status", "ok");
+        stages_completed += 1;
+    }
 
     // Stage 1.5: Recall
-    if let (Some(ep), Some(vs)) = (embedding_provider, vector_search) {
-        let recall_config = crate::recall::RecallConfig::default();
-        let recall_stage = crate::recall::RecallStage::new(recall_config);
-        #[expect(
-            clippy::cast_sign_loss,
-            reason = "remaining_tokens is positive after context assembly"
-        )]
-        let budget = ctx.remaining_tokens.max(0) as u64;
-        match recall_stage.run(&input.content, &config.id, ep, vs, budget) {
-            Ok(recall_result) => {
-                if let Some(ref section) = recall_result.recall_section {
-                    if let Some(ref mut prompt) = ctx.system_prompt {
-                        prompt.push_str("\n\n");
-                        prompt.push_str(section);
+    {
+        let span = info_span!(
+            "pipeline_stage",
+            stage = "recall",
+            duration_ms = tracing::field::Empty,
+            status = tracing::field::Empty
+        );
+        let _guard = span.enter();
+        let start = Instant::now();
+        if let (Some(ep), Some(vs)) = (embedding_provider, vector_search) {
+            let recall_config = crate::recall::RecallConfig::default();
+            let recall_stage = crate::recall::RecallStage::new(recall_config);
+            #[expect(
+                clippy::cast_sign_loss,
+                reason = "remaining_tokens is positive after context assembly"
+            )]
+            let budget = ctx.remaining_tokens.max(0) as u64;
+            match recall_stage.run(&input.content, &config.id, ep, vs, budget) {
+                Ok(recall_result) => {
+                    if let Some(ref section) = recall_result.recall_section {
+                        if let Some(ref mut prompt) = ctx.system_prompt {
+                            prompt.push_str("\n\n");
+                            prompt.push_str(section);
+                        }
+                        #[expect(clippy::cast_possible_wrap, reason = "recall tokens fit in i64")]
+                        {
+                            ctx.remaining_tokens -= recall_result.tokens_consumed as i64;
+                        }
                     }
-                    #[expect(clippy::cast_possible_wrap, reason = "recall tokens fit in i64")]
-                    {
-                        ctx.remaining_tokens -= recall_result.tokens_consumed as i64;
-                    }
+                    ctx.recall_result = Some(recall_result);
+                    span.record("status", "ok");
                 }
-                ctx.recall_result = Some(recall_result);
+                Err(e) => {
+                    warn!(error = %e, "recall stage failed, continuing without recalled knowledge");
+                    span.record("status", "error");
+                }
             }
-            Err(e) => {
-                warn!(error = %e, "recall stage failed, continuing without recalled knowledge");
-            }
+        } else {
+            debug!("recall skipped: embedding provider or vector search not configured");
+            span.record("status", "skipped");
         }
-    } else {
-        debug!("recall skipped: embedding provider or vector search not configured");
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "stage duration fits in u64"
+        )]
+        {
+            span.record("duration_ms", start.elapsed().as_millis() as u64);
+        }
+        stages_completed += 1;
     }
 
     // Stage 2: History
-    let history_config = HistoryConfig::default();
-    if let Some(store_mutex) = session_store {
-        let store = store_mutex.lock().expect("session store lock");
-        let (messages, hist_result) = history::load_history(
-            &store,
-            &input.session.id,
-            ctx.history_budget,
-            &history_config,
-            &input.content,
-        )?;
-        ctx.messages = messages;
-        ctx.history_budget -= hist_result.tokens_consumed;
-        ctx.history_result = Some(hist_result);
-    } else {
-        #[expect(clippy::cast_possible_wrap, reason = "message length fits in i64")]
-        let token_estimate = input.content.len() as i64 / 4;
-        ctx.messages.push(PipelineMessage {
-            role: "user".to_owned(),
-            content: input.content.clone(),
-            token_estimate,
-        });
+    {
+        let span = info_span!(
+            "pipeline_stage",
+            stage = "history",
+            duration_ms = tracing::field::Empty,
+            status = tracing::field::Empty
+        );
+        let _guard = span.enter();
+        let start = Instant::now();
+        let history_config = HistoryConfig::default();
+        if let Some(store_mutex) = session_store {
+            let store = store_mutex.lock().expect("session store lock");
+            let (messages, hist_result) = history::load_history(
+                &store,
+                &input.session.id,
+                ctx.history_budget,
+                &history_config,
+                &input.content,
+            )?;
+            ctx.messages = messages;
+            ctx.history_budget -= hist_result.tokens_consumed;
+            ctx.history_result = Some(hist_result);
+        } else {
+            #[expect(clippy::cast_possible_wrap, reason = "message length fits in i64")]
+            let token_estimate = input.content.len() as i64 / 4;
+            ctx.messages.push(PipelineMessage {
+                role: "user".to_owned(),
+                content: input.content.clone(),
+                token_estimate,
+            });
+        }
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "stage duration fits in u64"
+        )]
+        {
+            span.record("duration_ms", start.elapsed().as_millis() as u64);
+        }
+        span.record("status", "ok");
+        stages_completed += 1;
     }
 
     // Stage 3: Guard
-    let guard = check_guard(&input.session, config);
-    match guard {
-        GuardResult::Allow => {}
-        GuardResult::RateLimited { retry_after_ms } => {
-            return Err(error::GuardRejectedSnafu {
-                reason: format!("rate limited, retry after {retry_after_ms}ms"),
-            }
-            .build());
+    {
+        let span = info_span!(
+            "pipeline_stage",
+            stage = "guard",
+            duration_ms = tracing::field::Empty,
+            status = tracing::field::Empty
+        );
+        let _guard = span.enter();
+        let start = Instant::now();
+        let guard = check_guard(&input.session, config);
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "stage duration fits in u64"
+        )]
+        {
+            span.record("duration_ms", start.elapsed().as_millis() as u64);
         }
-        GuardResult::LoopDetected { pattern } => {
-            return Err(error::LoopDetectedSnafu {
-                iterations: 0u32,
-                pattern,
+        match guard {
+            GuardResult::Allow => {
+                span.record("status", "ok");
+                stages_completed += 1;
             }
-            .build());
-        }
-        GuardResult::Rejected { reason } => {
-            return Err(error::GuardRejectedSnafu { reason }.build());
+            GuardResult::RateLimited { retry_after_ms } => {
+                span.record("status", "error");
+                return Err(error::GuardRejectedSnafu {
+                    reason: format!("rate limited, retry after {retry_after_ms}ms"),
+                }
+                .build());
+            }
+            GuardResult::LoopDetected { pattern } => {
+                span.record("status", "error");
+                return Err(error::LoopDetectedSnafu {
+                    iterations: 0u32,
+                    pattern,
+                }
+                .build());
+            }
+            GuardResult::Rejected { reason } => {
+                span.record("status", "error");
+                return Err(error::GuardRejectedSnafu { reason }.build());
+            }
         }
     }
 
     // Stage 4: Resolve (stub)
 
     // Stage 5: Execute
-    let result =
-        crate::execute::execute(&ctx, &input.session, config, providers, tools, tool_ctx).await?;
+    let result;
+    {
+        let span = info_span!(
+            "pipeline_stage",
+            stage = "execute",
+            duration_ms = tracing::field::Empty,
+            status = tracing::field::Empty,
+            tokens_in = tracing::field::Empty,
+            tokens_out = tracing::field::Empty,
+        );
+        let _guard = span.enter();
+        let start = Instant::now();
+        result = crate::execute::execute(&ctx, &input.session, config, providers, tools, tool_ctx)
+            .await?;
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "stage duration fits in u64"
+        )]
+        {
+            span.record("duration_ms", start.elapsed().as_millis() as u64);
+        }
+        span.record("tokens_in", result.usage.input_tokens);
+        span.record("tokens_out", result.usage.output_tokens);
+        span.record("status", "ok");
+        stages_completed += 1;
+    }
 
     // Stage 6: Finalize
-    if let Some(store_mutex) = session_store {
-        let store = store_mutex.lock().expect("session store lock");
-        let finalize_config = crate::finalize::FinalizeConfig::default();
-        match crate::finalize::finalize(
-            &store,
-            &input.session,
-            &input.content,
-            &result,
-            &finalize_config,
-        ) {
-            Ok(fr) => {
-                debug!(
-                    messages = fr.messages_persisted,
-                    usage = fr.usage_recorded,
-                    "finalize complete"
-                );
+    {
+        let span = info_span!(
+            "pipeline_stage",
+            stage = "finalize",
+            duration_ms = tracing::field::Empty,
+            status = tracing::field::Empty
+        );
+        let _guard = span.enter();
+        let start = Instant::now();
+        if let Some(store_mutex) = session_store {
+            let store = store_mutex.lock().expect("session store lock");
+            let finalize_config = crate::finalize::FinalizeConfig::default();
+            match crate::finalize::finalize(
+                &store,
+                &input.session,
+                &input.content,
+                &result,
+                &finalize_config,
+            ) {
+                Ok(fr) => {
+                    debug!(
+                        messages = fr.messages_persisted,
+                        usage = fr.usage_recorded,
+                        "finalize complete"
+                    );
+                    span.record("status", "ok");
+                }
+                Err(e) => {
+                    error!(error = %e, "finalize failed, returning result without persistence");
+                    span.record("status", "error");
+                }
             }
-            Err(e) => {
-                error!(error = %e, "finalize failed, returning result without persistence");
-            }
+        } else {
+            debug!("no session store, skipping finalize");
+            span.record("status", "skipped");
         }
-    } else {
-        debug!("no session store, skipping finalize");
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "stage duration fits in u64"
+        )]
+        {
+            span.record("duration_ms", start.elapsed().as_millis() as u64);
+        }
+        stages_completed += 1;
     }
+
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "pipeline duration fits in u64"
+    )]
+    {
+        pipeline_span.record(
+            "pipeline.total_duration_ms",
+            pipeline_start.elapsed().as_millis() as u64,
+        );
+    }
+    pipeline_span.record("pipeline.stages_completed", stages_completed);
+    pipeline_span.record("pipeline.tool_calls", result.tool_calls.len() as u64);
 
     Ok(result)
 }
@@ -856,6 +1004,9 @@ mod tests {
         // Now trigger a loop within the window
         assert!(det.record("exec", "same").is_none());
         assert!(det.record("exec", "same").is_none());
-        assert!(det.record("exec", "same").is_some(), "should detect loop even after window eviction");
+        assert!(
+            det.record("exec", "same").is_some(),
+            "should detect loop even after window eviction"
+        );
     }
 }

--- a/crates/organon/Cargo.toml
+++ b/crates/organon/Cargo.toml
@@ -17,6 +17,7 @@ indexmap = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 snafu = { workspace = true }
+tracing = { workspace = true }
 
 [dev-dependencies]
 static_assertions = { workspace = true }

--- a/crates/organon/src/registry.rs
+++ b/crates/organon/src/registry.rs
@@ -2,10 +2,12 @@
 
 use std::future::Future;
 use std::pin::Pin;
+use std::time::Instant;
 
 use aletheia_koina::id::ToolName;
 use indexmap::IndexMap;
 use snafu::ensure;
+use tracing::info_span;
 
 use crate::error::{self, Result};
 use crate::types::{ToolCategory, ToolContext, ToolDef, ToolInput, ToolResult};
@@ -77,7 +79,22 @@ impl ToolRegistry {
             }
             .build()
         })?;
-        tool.executor.execute(input, ctx).await
+        let span = info_span!("tool_execute",
+            tool.name = %input.name,
+            tool.duration_ms = tracing::field::Empty,
+            tool.status = tracing::field::Empty,
+        );
+        let _guard = span.enter();
+        let start = Instant::now();
+        let result = tool.executor.execute(input, ctx).await;
+        #[expect(clippy::cast_possible_truncation, reason = "tool duration fits in u64")]
+        let duration_ms = start.elapsed().as_millis() as u64;
+        span.record("tool.duration_ms", duration_ms);
+        match &result {
+            Ok(r) if !r.is_error => span.record("tool.status", "ok"),
+            _ => span.record("tool.status", "error"),
+        };
+        result
     }
 
     /// All registered tool definitions, in insertion order.

--- a/crates/organon/src/types.rs
+++ b/crates/organon/src/types.rs
@@ -177,6 +177,40 @@ pub struct ToolInput {
     pub arguments: serde_json::Value,
 }
 
+/// Cumulative tool execution statistics for a pipeline turn.
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct ToolStats {
+    pub total_calls: u32,
+    pub total_duration_ms: u64,
+    pub error_count: u32,
+    pub calls_by_tool: IndexMap<String, u32>,
+}
+
+impl ToolStats {
+    /// Record a tool execution.
+    pub fn record(&mut self, name: &str, duration_ms: u64, is_error: bool) {
+        self.total_calls += 1;
+        self.total_duration_ms += duration_ms;
+        if is_error {
+            self.error_count += 1;
+        }
+        *self.calls_by_tool.entry(name.to_owned()).or_insert(0) += 1;
+    }
+
+    /// Top N tools by call count.
+    #[must_use]
+    pub fn top_tools(&self, n: usize) -> Vec<(&str, u32)> {
+        let mut sorted: Vec<_> = self
+            .calls_by_tool
+            .iter()
+            .map(|(k, v)| (k.as_str(), *v))
+            .collect();
+        sorted.sort_by(|a, b| b.1.cmp(&a.1));
+        sorted.truncate(n);
+        sorted
+    }
+}
+
 /// Execution context passed to every tool invocation.
 #[derive(Debug, Clone)]
 pub struct ToolContext {
@@ -265,6 +299,34 @@ mod tests {
     fn tool_category_display() {
         assert_eq!(ToolCategory::Workspace.to_string(), "workspace");
         assert_eq!(ToolCategory::Communication.to_string(), "communication");
+    }
+
+    #[test]
+    fn tool_stats_record_accumulates() {
+        let mut stats = ToolStats::default();
+        stats.record("read", 10, false);
+        stats.record("write", 20, false);
+        stats.record("read", 15, true);
+        assert_eq!(stats.total_calls, 3);
+        assert_eq!(stats.total_duration_ms, 45);
+        assert_eq!(stats.error_count, 1);
+        assert_eq!(stats.calls_by_tool["read"], 2);
+        assert_eq!(stats.calls_by_tool["write"], 1);
+    }
+
+    #[test]
+    fn tool_stats_top_tools() {
+        let mut stats = ToolStats::default();
+        stats.record("a", 1, false);
+        stats.record("b", 1, false);
+        stats.record("b", 1, false);
+        stats.record("c", 1, false);
+        stats.record("c", 1, false);
+        stats.record("c", 1, false);
+        let top = stats.top_tools(2);
+        assert_eq!(top.len(), 2);
+        assert_eq!(top[0], ("c", 3));
+        assert_eq!(top[1], ("b", 2));
     }
 
     #[test]

--- a/crates/pylon/src/router.rs
+++ b/crates/pylon/src/router.rs
@@ -1,12 +1,14 @@
 //! HTTP router construction with middleware layers.
 
 use std::sync::Arc;
+use std::time::Duration;
 
 use axum::Router;
 use axum::routing::{get, post};
 use tower_http::compression::CompressionLayer;
 use tower_http::cors::CorsLayer;
 use tower_http::trace::TraceLayer;
+use tracing::info_span;
 
 use crate::handlers::{health, nous, sessions};
 use crate::state::AppState;
@@ -26,7 +28,35 @@ pub fn build_router(state: Arc<AppState>) -> Router {
         .route("/api/nous/{id}", get(nous::get_status))
         .route("/api/nous/{id}/tools", get(nous::tools))
         .layer(CompressionLayer::new())
-        .layer(TraceLayer::new_for_http())
+        .layer(
+            TraceLayer::new_for_http()
+                .make_span_with(|request: &axum::http::Request<_>| {
+                    let request_id = ulid::Ulid::new().to_string();
+                    info_span!("http_request",
+                        http.method = %request.method(),
+                        http.path = %request.uri().path(),
+                        http.request_id = %request_id,
+                        http.status_code = tracing::field::Empty,
+                    )
+                })
+                .on_response(
+                    |response: &axum::http::Response<_>,
+                     latency: Duration,
+                     span: &tracing::Span| {
+                        span.record("http.status_code", response.status().as_u16());
+                        #[expect(
+                            clippy::cast_possible_truncation,
+                            reason = "HTTP latency fits in u64"
+                        )]
+                        let duration_ms = latency.as_millis() as u64;
+                        tracing::debug!(
+                            duration_ms,
+                            status = response.status().as_u16(),
+                            "request complete"
+                        );
+                    },
+                ),
+        )
         .layer(CorsLayer::permissive())
         .with_state(state)
 }


### PR DESCRIPTION
## Summary

- **Pipeline stage spans (nous):** Parent `pipeline` span with per-stage `pipeline_stage` spans tracking timing, status, token counts across context/recall/history/guard/execute/finalize stages
- **Tool execution metrics (organon):** `tool_execute` span with duration/status tracking + `ToolStats` accumulator with `record()` and `top_tools()` methods
- **Provider call telemetry (hermeneus):** `llm_call` spans on both `execute_with_retry()` and `complete_streaming()` with model, tokens, cost estimate, retry count, and status fields
- **HTTP request tracing (pylon):** Custom `TraceLayer` with ULID-based `http.request_id`, method, path, status code, and duration
- **Channel message tracing (agora):** `inbound_message` spans with `redact_phone()` helper for PII-safe logging + debug routing info in `resolve()`

All spans use consistent `namespace.field` naming (`pipeline.*`, `tool.*`, `llm.*`, `http.*`, `msg.*`).

## Test plan

- [x] `cargo clippy --workspace --exclude aletheia-mneme-engine --all-targets -- -D warnings` — zero warnings
- [x] `cargo test --workspace` — all pass
- [x] New unit tests: `ToolStats` accumulation + top_tools, `estimate_cost` for opus/sonnet/haiku/unknown, `redact_phone` edge cases
- [x] Audit: no message content, full phone numbers, or API keys in span fields