### PR TITLE
docs: restore trimmed gnomon.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,7 +69,7 @@ aletheia doctor                        # Validate config
 
 ### Both Stacks
 
-- **Naming:** Greek names that reflect purpose (nous = mind, mneme = memory, hermeneus = interpreter)
+- **Naming:** Greek names per the gnomon convention in STANDARDS.md
 - **No barrel files** - import from the file that owns the symbol
 - **Module imports flow downward** - higher layers depend on lower, never reverse
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ aletheia start    # from next time on
 
 ## Why Greek?
 
-Every name follows a deliberate naming philosophy. Greek provides precision where English flattens: *nous* over "agent" because these are minds, not tools. *Mneme* over "store" because memory is the function, not the container. Module and crate names use Greek terms reflecting their purpose (nous = mind, mneme = memory, hermeneus = interpreter). See [ALETHEIA.md](ALETHEIA.md) for philosophical grounding.
+Every name follows a deliberate naming philosophy. Greek provides precision where English flattens: *nous* over "agent" because these are minds, not tools. *Mneme* over "store" because memory is the function, not the container. See [ALETHEIA.md](ALETHEIA.md) for the manifesto, [gnomon.md](docs/gnomon.md) for the naming system.
 
 ---
 

--- a/docs/STANDARDS.md
+++ b/docs/STANDARDS.md
@@ -24,7 +24,7 @@ These apply regardless of language.
 
 #### Gnomon System (Persistent Names)
 
-Module directories, agent identities, subsystems, and major features use Greek naming. Greek naming - modules and crates use Greek terms reflecting their purpose (nous = mind, mneme = memory, hermeneus = interpreter). Names identify modes of attention, not implementations. Pass the layer test (L1-L4). If no Greek word fits naturally, the mode of attention isn't clear yet - wait.
+Module directories, agent identities, subsystems, and major features follow the gnomon naming convention. Names identify essential natures, not implementations. Pass the layer test (L1-L4). If no Greek word fits naturally, the essential nature isn't clear yet - wait.
 
 Applies to: modules, agents, subsystems, features that persist.
 Does not apply to: variables, functions, test fixtures, temporary branches.
@@ -908,9 +908,9 @@ except Exception:  # swallowed
 
 ### Rule: Gnomon Naming Convention
 
-**What:** Persistent names for modules, subsystems, agents, and major components use Greek terms reflecting their purpose (nous = mind, mneme = memory, hermeneus = interpreter). Names identify modes of attention, pass the layer test (L1-L4), and compose with the existing name topology. See ALETHEIA.md for philosophical grounding.
+**What:** Persistent names for modules, subsystems, agents, and major components follow the gnomon naming convention. Names unconceal essential natures, pass the layer test (L1-L4), and compose with the existing name topology.
 
-**Why:** The naming system is not decoration. Names that identify the right mode of attention survive refactors, communicate architectural intent, and resist drift toward generic labels. A well-chosen name teaches you something about what it names.
+**Why:** The naming system is not decoration. Names that identify the right essential nature survive refactors, communicate architectural intent, and resist drift toward generic labels. A well-chosen name teaches you something about what it names.
 
 **Applies to:** Module directories, agent identities, subsystem names, major persistent features. Does *not* apply to: utility functions, variable names, temporary branches, test fixtures.
 

--- a/docs/gnomon.md
+++ b/docs/gnomon.md
@@ -1,0 +1,105 @@
+# Gnomon
+
+*γνώμων - that which reveals by indicating*
+
+A sundial's gnomon doesn't contain time. It casts a shadow that makes time legible. The best names work the same way - they don't describe what something is. They reveal what was already there.
+
+---
+
+## Why Greek
+
+Ancient Greek was engineered across centuries for a single purpose - distinguishing between closely related things that matter. Where English has "knowledge," Greek has episteme (systematic knowledge), gnosis (direct acquaintance), techne (craft knowledge), phronesis (practical wisdom), and nous (direct apprehension). These aren't synonyms. They're fundamentally different stances toward the world.
+
+This precision extends beyond epistemics. Where English has "form," Greek has morphe (the form that makes a thing *this kind* of thing), schema (the shape or figure), eidos (the visible form), and typos (the impression left by a blow). The language is equally precise about *what things are* as it is about *how you know them*.
+
+When you name a module *Dianoia*, you're not saying "thinking" - you're saying *discursive reasoning that works through problems step by step*, as distinct from noesis (immediate insight) or episteme (systematic knowledge). When you name a module *Taxis*, you're not saying "organization" - you're saying *the specific arrangement that makes a collection coherent rather than merely grouped*. The Greek carries the distinction natively. English requires a paragraph.
+
+Greek also offers:
+
+- **Productive compounding.** Roots, prefixes, and suffixes combine systematically. The grammar builds meaning.
+- **Defamiliarization.** An unfamiliar word resists assumption. You have to ask what it means, which means you have to think about what the thing *does*.
+- **Density.** Meaning compressed into sound. Aletheia is four syllables carrying an entire ontology - truth as *unconcealment*, the negation of forgetting.
+
+The goal is not erudition. The goal is precision tools for a system that distinguishes between many closely related things.
+
+---
+
+## The Layer Test
+
+Every name must work at multiple levels of abstraction simultaneously. This is the primary quality test.
+
+| Layer | What it answers | Failure mode |
+|-------|----------------|--------------|
+| **L1 - Practical** | What does this do? | Too abstract to use |
+| **L2 - Structural** | How does this relate to other things? | Isolated, doesn't compose |
+| **L3 - Philosophical** | What essential nature does this name unconceal? | Decorative, not meaningful |
+| **L4 - Reflexive** | Does the name exhibit what it describes? | Inert, doesn't reward reflection |
+
+A name that works at L1 but not L3 is a label. A name that works at L3 but not L1 is pretension.
+
+**Example - Aletheia:**
+
+| Layer | Reading |
+|-------|---------|
+| L1 | A software system - agent ecosystem, memory, orchestration |
+| L2 | The substrate that makes the other systems possible |
+| L3 | Truth as unconcealment - the negation of forgetting. Not truth as correspondence but truth as *revealing what was hidden* |
+| L4 | The system itself practices unconcealment - surfacing latent knowledge, making hidden patterns legible, refusing to let things stay forgotten |
+
+**Example - Dianoia:**
+
+| Layer | Reading |
+|-------|---------|
+| L1 | The planning system - project decomposition, phased execution |
+| L2 | The structured thinking that connects vision to implementation |
+| L3 | Discursive reasoning - thinking *through* problems step by step. Plato's divided line: dianoia is the mode between opinion and pure understanding |
+| L4 | A planning system named for step-by-step reasoning that itself works by stepping through phases |
+
+---
+
+## Topology
+
+Names in a system are not independent. They compose.
+
+The relationships between names carry meaning. **Noesis** and **Dianoia** are the two sides of Plato's divided line - one sees the whole immediately, the other works through it step by step. Placing them in the same system asserts that both modes are necessary.
+
+**Prosoche** (sustained attention) is the *practice* that makes **Aletheia** (unconcealment) possible. You can't reveal what's hidden without attending carefully. The names encode this dependency.
+
+**Mneme** (memory) and **Melete** (disciplined practice) compose as process: mneme holds what was experienced, melete refines it into wisdom.
+
+Topological coherence means:
+- **Containment is meaningful.** Aletheia contains Dianoia, Prosoche, the agents. This is the claim that truth-as-unconcealment requires both structured reasoning and sustained attention.
+- **Adjacency is meaningful.** Names at the same level should share a register. Module names all unconceal what the module *essentially is*.
+- **Absence is meaningful.** What you don't name stays unconstituted.
+
+When you add a new name, it must compose with what exists. A name that fits locally but creates dissonance in the topology has identified the right essential nature in isolation but the wrong one in context.
+
+---
+
+## The Gnomon Principle
+
+A gnomon doesn't contain time. It doesn't measure time. It casts a shadow, and the shadow makes time legible.
+
+The best names are gnomons. They indicate without containing. The name Aletheia doesn't *make* the system true. It reveals that the system was already an act of unconcealment. The name Dianoia doesn't *make* the planner reason discursively. It reveals that phased planning always was discursive reasoning.
+
+A name succeeds as a gnomon when someone encounters it, learns what it means, and feels that the thing has become more itself - not differently described but more clearly *seen*.
+
+A name fails as a gnomon when the name draws attention to itself rather than to what it names. If you're explaining the name, it's decoration. If the name is explaining the thing, it's a gnomon.
+
+---
+
+## When Naming
+
+1. **Wait.** Let the thing reveal its nature before fixing the name. Premature naming produces labels.
+2. **Identify what needs unconcealing.** Not what the thing *does technically* but what it *essentially is*.
+3. **Construct the name.** Greek roots are verbs and processes, not static nouns. Let the grammar do work.
+4. **Run the layer test.** L1 through L4. If any layer strains, go back to step 2.
+5. **Check the topology.** Does this name compose with what exists?
+6. **Listen for recognition.** The right name feels discovered, not invented. If you're arguing for why it fits, it doesn't.
+
+### Anti-Patterns
+
+- **Naming the implementation.** You named what it does technically, not what it essentially is. "Tracker" is an implementation. Prosoche is the essential nature that tracking serves.
+- **Forcing the Greek.** If you have to work through three dictionaries to justify the connection, the name is wrong. The right Greek word should feel like it was waiting.
+- **Naming for audience.** If the name exists to impress rather than to indicate, it's pretension.
+- **Ignoring topology.** A name that sounds right in isolation but conflicts with adjacent names disrupts the system.

--- a/llms.txt
+++ b/llms.txt
@@ -4,7 +4,7 @@
 
 Privacy-first distributed cognition. N agents + 1 human operator. Each agent has character, memory, and domain expertise. They persist understanding across sessions, coordinate through shared infrastructure, and evolve through use. Runs on commodity hardware with no cloud dependencies beyond your LLM API key.
 
-Dual-stack: Rust crates (target architecture) and TypeScript runtime (current production). Greek naming - modules and crates use Greek terms reflecting their purpose (nous = mind, mneme = memory, hermeneus = interpreter).
+Dual-stack: Rust crates (target architecture) and TypeScript runtime (current production).
 
 ## Getting Started
 


### PR DESCRIPTION
Restores gnomon.md with philosophy, layer test, topology, and practice. Drops pronunciation table, root/prefix/suffix tables, and exhaustive roster.

Removes inline Greek naming explainers (`nous = mind, mneme = memory, hermeneus = interpreter`) from CLAUDE.md, STANDARDS.md, llms.txt, and README.md. Single link to gnomon.md from README.md only. STANDARDS.md and CLAUDE.md reference the convention by name.