### PR TITLE
feat(pylon): runtime security — TLS, CORS, limits, headers, redaction, CSRF

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,7 +45,6 @@ dependencies = [
  "aletheia-daemon",
  "aletheia-hermeneus",
  "aletheia-koina",
- "aletheia-melete",
  "aletheia-mneme",
  "aletheia-nous",
  "aletheia-organon",
@@ -56,10 +55,10 @@ dependencies = [
  "anyhow",
  "axum",
  "clap",
+ "rcgen",
  "reqwest",
- "secrecy",
- "serde",
  "serde_json",
+ "time",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -112,8 +111,6 @@ dependencies = [
  "snafu",
  "static_assertions",
  "tempfile",
- "tokio",
- "tracing",
  "ulid",
 ]
 
@@ -179,6 +176,7 @@ name = "aletheia-koina"
 version = "0.10.0"
 dependencies = [
  "compact_str 0.8.1",
+ "regex",
  "serde",
  "serde_json",
  "snafu",
@@ -324,6 +322,7 @@ dependencies = [
  "aletheia-symbolon",
  "aletheia-taxis",
  "axum",
+ "axum-server",
  "jsonwebtoken",
  "reqwest",
  "secrecy",
@@ -351,7 +350,6 @@ dependencies = [
  "rusqlite",
  "secrecy",
  "serde",
- "serde_json",
  "snafu",
  "static_assertions",
  "tracing",
@@ -381,7 +379,7 @@ dependencies = [
  "indexmap",
  "serde",
  "serde_json",
- "serde_yml",
+ "serde_yaml",
  "snafu",
  "tempfile",
  "tracing",
@@ -490,6 +488,15 @@ name = "arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+
+[[package]]
+name = "arc-swap"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9f3647c145568cec02c42054e07bdf9a5a698e15b466fb2341bfc393cd24aa5"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "arg_enum_proc_macro"
@@ -643,6 +650,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94bffc006df10ac2a68c83692d734a465f8ee6c5b384d8545a636f81d858f4bf"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4321e568ed89bb5a7d291a7f37997c2c0df89809d7b6d12062c81ddb54aa782e"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
 name = "axum"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -692,6 +721,28 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "axum-server"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1ab4a3ec9ea8a657c72d99a03a824af695bd0fb5ec639ccbd9cd3543b41a5f9"
+dependencies = [
+ "arc-swap",
+ "bytes",
+ "fs-err",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "rustls",
+ "rustls-pemfile",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
 ]
 
 [[package]]
@@ -1003,6 +1054,15 @@ name = "clap_lex"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+
+[[package]]
+name = "cmake"
+version = "0.1.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "color_quant"
@@ -1445,6 +1505,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "ecdsa"
 version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1741,6 +1807,22 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs-err"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73fde052dbfc920003cfd2c8e2c6e6d4cc7c1091538c3a24226cec0665ab08c0"
+dependencies = [
+ "autocfg",
+ "tokio",
+]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
@@ -2654,16 +2736,6 @@ dependencies = [
  "cc",
  "pkg-config",
  "vcpkg",
-]
-
-[[package]]
-name = "libyml"
-version = "0.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3302702afa434ffa30847a83305f0a69d6abd74293b6554c18ec85c7ef30c980"
-dependencies = [
- "anyhow",
- "version_check",
 ]
 
 [[package]]
@@ -3844,6 +3916,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rcgen"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "yasna",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4099,6 +4184,7 @@ version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
+ "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
@@ -4106,6 +4192,15 @@ dependencies = [
  "rustls-webpki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -4123,6 +4218,7 @@ version = "0.103.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -4318,21 +4414,6 @@ dependencies = [
  "ryu",
  "serde",
  "unsafe-libyaml",
-]
-
-[[package]]
-name = "serde_yml"
-version = "0.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59e2dd588bf1597a252c3b920e0143eb99b0f76e4e082f4c92ce34fbc9e71ddd"
-dependencies = [
- "indexmap",
- "itoa",
- "libyml",
- "memchr",
- "ryu",
- "serde",
- "version_check",
 ]
 
 [[package]]
@@ -4889,6 +4970,7 @@ dependencies = [
  "futures-util",
  "http",
  "http-body",
+ "http-body-util",
  "iri-string",
  "pin-project-lite",
  "tokio",
@@ -5832,6 +5914,15 @@ name = "yansi"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
+
+[[package]]
+name = "yasna"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
+dependencies = [
+ "time",
+]
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,7 +80,8 @@ serde_yaml = "0.9"
 axum = "0.8"
 reqwest = { version = "0.12", features = ["blocking", "json"] }
 tower = "0.5"
-tower-http = { version = "0.6", features = ["cors", "compression-gzip", "trace"] }
+tower-http = { version = "0.6", features = ["cors", "compression-gzip", "trace", "limit", "set-header"] }
+axum-server = { version = "0.7", features = ["tls-rustls"] }
 
 # Secrets
 secrecy = { version = "0.10", features = ["serde"] }
@@ -111,6 +112,10 @@ tokio-stream = "0.1"
 
 # Compression
 flate2 = "1"
+
+# TLS / Security
+rcgen = "0.13"
+regex = "1"
 
 # Testing
 proptest = "1"

--- a/crates/aletheia/Cargo.toml
+++ b/crates/aletheia/Cargo.toml
@@ -17,6 +17,7 @@ default = []
 # OFF by default — mneme-engine conflicts with rusqlite bundled sqlite3.
 # Phase 2 (prompt 28) wires KnowledgeVectorSearch behind this gate.
 recall = ["aletheia-nous/knowledge-store", "aletheia-mneme/mneme-engine"]
+tls = ["aletheia-pylon/tls"]
 
 [dependencies]
 aletheia-daemon = { path = "../daemon" }
@@ -40,6 +41,8 @@ reqwest = { workspace = true }
 
 clap = { version = "4", features = ["derive"] }
 anyhow = "1"
+rcgen = { workspace = true }
+time = "0.3"
 
 [lints]
 workspace = true

--- a/crates/aletheia/src/main.rs
+++ b/crates/aletheia/src/main.rs
@@ -3,7 +3,7 @@
 mod daemon_bridge;
 mod dispatch;
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
@@ -94,6 +94,27 @@ enum Command {
         #[command(subcommand)]
         action: MaintenanceAction,
     },
+    /// TLS certificate management
+    Tls {
+        #[command(subcommand)]
+        action: TlsAction,
+    },
+}
+
+#[derive(Debug, Clone, Subcommand)]
+enum TlsAction {
+    /// Generate self-signed certificates for development/LAN use
+    Generate {
+        /// Output directory for cert and key files
+        #[arg(long, default_value = "instance/config/tls")]
+        output_dir: PathBuf,
+        /// Certificate validity in days
+        #[arg(long, default_value_t = 365)]
+        days: u32,
+        /// Subject Alternative Names (hostnames/IPs)
+        #[arg(long, default_values_t = vec!["localhost".to_owned(), "127.0.0.1".to_owned()])]
+        san: Vec<String>,
+    },
 }
 
 #[derive(Debug, Clone, Subcommand)]
@@ -122,6 +143,7 @@ async fn main() -> Result<()> {
         Some(Command::Maintenance { action }) => {
             return run_maintenance(action.clone(), cli.instance_root.as_ref());
         }
+        Some(Command::Tls { action }) => return handle_tls(action),
         None => {}
     }
 
@@ -357,7 +379,7 @@ async fn serve(cli: Cli) -> Result<()> {
     }
 
     // Daemon — background maintenance tasks
-    let (daemon_shutdown_tx, daemon_shutdown_rx) = tokio::sync::watch::channel(false);
+    let (_daemon_shutdown_tx, daemon_shutdown_rx) = tokio::sync::watch::channel(false);
     let maintenance_config = build_maintenance_config(&oikos_arc, &config.maintenance);
     let mut daemon_runner =
         TaskRunner::new("system", daemon_shutdown_rx).with_maintenance(maintenance_config);
@@ -425,7 +447,8 @@ async fn serve(cli: Cli) -> Result<()> {
         start_time: Instant::now(),
     });
 
-    let app = build_router(state.clone());
+    let security = aletheia_pylon::security::SecurityConfig::from_gateway(&config.gateway);
+    let app = build_router(state.clone(), &security);
 
     let bind_addr = format!("{}:{}", cli.bind, cli.port);
     let listener = tokio::net::TcpListener::bind(&bind_addr)
@@ -600,6 +623,56 @@ async fn shutdown_signal() {
         () = ctrl_c => info!("received ctrl+c"),
         () = terminate => info!("received SIGTERM"),
     }
+}
+
+fn handle_tls(action: &TlsAction) -> Result<()> {
+    match action {
+        TlsAction::Generate {
+            output_dir,
+            days,
+            san,
+        } => generate_tls_certs(output_dir, *days, san),
+    }
+}
+
+fn generate_tls_certs(output_dir: &Path, days: u32, sans: &[String]) -> Result<()> {
+    std::fs::create_dir_all(output_dir)
+        .with_context(|| format!("failed to create {}", output_dir.display()))?;
+
+    let subject_alt_names: Vec<String> = sans.to_vec();
+    let key_pair = rcgen::KeyPair::generate().context("failed to generate key pair")?;
+    let mut params = rcgen::CertificateParams::new(subject_alt_names)
+        .context("failed to build certificate params")?;
+    params
+        .distinguished_name
+        .push(rcgen::DnType::CommonName, "Aletheia Dev");
+    params.not_after = rcgen::date_time_ymd(2030, 1, 1);
+
+    // Override validity if days is reasonable
+    if days < 3650 {
+        let now = time::OffsetDateTime::now_utc();
+        let end = now + time::Duration::days(i64::from(days));
+        params.not_before = now;
+        params.not_after = end;
+    }
+
+    let cert = params
+        .self_signed(&key_pair)
+        .context("failed to generate self-signed certificate")?;
+
+    let cert_path = output_dir.join("cert.pem");
+    let key_path = output_dir.join("key.pem");
+
+    std::fs::write(&cert_path, cert.pem())
+        .with_context(|| format!("failed to write {}", cert_path.display()))?;
+    std::fs::write(&key_path, key_pair.serialize_pem())
+        .with_context(|| format!("failed to write {}", key_path.display()))?;
+
+    println!("Certificate: {}", cert_path.display());
+    println!("Private key: {}", key_path.display());
+    println!("Valid for {days} days");
+
+    Ok(())
 }
 
 fn backup(cli: &Cli, list: bool, prune: bool, keep: usize, export_json: bool) -> Result<()> {

--- a/crates/integration-tests/tests/end_to_end.rs
+++ b/crates/integration-tests/tests/end_to_end.rs
@@ -202,7 +202,7 @@ impl TestHarness {
     }
 
     fn router(&self) -> axum::Router {
-        build_router(Arc::clone(&self.state))
+        build_router(Arc::clone(&self.state), &aletheia_pylon::security::SecurityConfig::default())
     }
 
     fn authed_request(

--- a/crates/koina/Cargo.toml
+++ b/crates/koina/Cargo.toml
@@ -12,6 +12,7 @@ workspace = true
 
 [dependencies]
 compact_str = { workspace = true }
+regex = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 snafu = { workspace = true }

--- a/crates/koina/src/lib.rs
+++ b/crates/koina/src/lib.rs
@@ -6,6 +6,7 @@
 
 pub mod error;
 pub mod id;
+pub mod redact;
 pub mod tracing_init;
 
 // --- Static assertions: key types are Send + Sync ---

--- a/crates/koina/src/redact.rs
+++ b/crates/koina/src/redact.rs
@@ -1,0 +1,95 @@
+//! Sensitive value redaction for log output.
+
+use std::sync::LazyLock;
+
+use regex::Regex;
+
+static RE_ANTHROPIC_KEY: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"sk-ant-api03-[A-Za-z0-9_-]+").expect("regex"));
+
+static RE_SK_KEY: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"sk-[A-Za-z0-9_-]{20,}").expect("regex"));
+
+static RE_BEARER: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"Bearer [A-Za-z0-9._-]+").expect("regex"));
+
+static RE_JWT: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+").expect("regex")
+});
+
+static RE_SECRETS: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"(?i)(password|secret|api_key|apikey)\s*[:=]\s*\S+").expect("regex")
+});
+
+/// Redact sensitive values (API keys, JWTs, bearer tokens, passwords) from a string.
+#[must_use]
+pub fn redact_sensitive(value: &str) -> String {
+    let mut result = RE_ANTHROPIC_KEY.replace_all(value, "sk-ant-***").into_owned();
+    result = RE_SK_KEY.replace_all(&result, "sk-***").into_owned();
+    result = RE_BEARER.replace_all(&result, "Bearer ***").into_owned();
+    result = RE_JWT.replace_all(&result, "[JWT REDACTED]").into_owned();
+    result = RE_SECRETS.replace_all(&result, "$1=***").into_owned();
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn redacts_anthropic_api_key() {
+        let input = "using key sk-ant-api03-abcdef123456_789XYZ for requests";
+        let output = redact_sensitive(input);
+        assert_eq!(output, "using key sk-ant-*** for requests");
+    }
+
+    #[test]
+    fn redacts_generic_sk_key() {
+        let input = "key: sk-proj-abcdefghij1234567890abcdef";
+        let output = redact_sensitive(input);
+        assert_eq!(output, "key: sk-***");
+    }
+
+    #[test]
+    fn redacts_bearer_token() {
+        let input = "Authorization: Bearer abc123def456.ghi789";
+        let output = redact_sensitive(input);
+        assert_eq!(output, "Authorization: Bearer ***");
+    }
+
+    #[test]
+    fn redacts_jwt() {
+        let input = "token=eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U";
+        let output = redact_sensitive(input);
+        assert!(output.contains("[JWT REDACTED]"));
+        assert!(!output.contains("dozjgNryP4J3jVmNHl0w5N"));
+    }
+
+    #[test]
+    fn redacts_password_patterns() {
+        assert!(redact_sensitive("password=hunter2").contains("***"));
+        assert!(redact_sensitive("secret: my-secret-value").contains("***"));
+        assert!(redact_sensitive("api_key=sk123abc").contains("***"));
+        assert!(redact_sensitive("APIKEY: tok_live_abc").contains("***"));
+    }
+
+    #[test]
+    fn leaves_safe_strings_unchanged() {
+        let safe = "normal log message with session_id=abc123";
+        assert_eq!(redact_sensitive(safe), safe);
+    }
+
+    #[test]
+    fn handles_empty_input() {
+        assert_eq!(redact_sensitive(""), "");
+    }
+
+    #[test]
+    fn handles_multiple_sensitive_values() {
+        let input = "key=sk-ant-api03-abc123 and password=secret123";
+        let output = redact_sensitive(input);
+        assert!(output.contains("sk-ant-***"));
+        assert!(!output.contains("abc123"));
+        assert!(!output.contains("secret123"));
+    }
+}

--- a/crates/pylon/Cargo.toml
+++ b/crates/pylon/Cargo.toml
@@ -10,11 +10,16 @@ rust-version.workspace = true
 [lints]
 workspace = true
 
+[features]
+default = []
+tls = ["dep:axum-server"]
+
 [dependencies]
 # HTTP framework
 axum = { workspace = true }
 tower = { workspace = true }
 tower-http = { workspace = true }
+axum-server = { workspace = true, optional = true }
 
 # Async
 tokio = { workspace = true }

--- a/crates/pylon/src/lib.rs
+++ b/crates/pylon/src/lib.rs
@@ -5,7 +5,9 @@
 pub mod error;
 pub mod extract;
 pub mod handlers;
+pub mod middleware;
 pub mod router;
+pub mod security;
 pub mod server;
 pub mod state;
 pub mod stream;

--- a/crates/pylon/src/middleware.rs
+++ b/crates/pylon/src/middleware.rs
@@ -1,0 +1,54 @@
+//! Custom middleware layers for pylon.
+
+use axum::extract::Request;
+use axum::http::{Method, StatusCode};
+use axum::middleware::Next;
+use axum::response::{IntoResponse, Response};
+
+/// CSRF protection state stored as a router extension.
+#[derive(Debug, Clone)]
+pub struct CsrfState {
+    pub header_name: String,
+    pub header_value: String,
+}
+
+/// Middleware that requires a custom header on state-changing requests.
+///
+/// GET, HEAD, and OPTIONS are exempt. POST, PUT, DELETE, and PATCH must
+/// include the configured header with the expected value.
+pub async fn require_csrf_header(request: Request, next: Next) -> Response {
+    let is_safe = matches!(
+        *request.method(),
+        Method::GET | Method::HEAD | Method::OPTIONS
+    );
+
+    if is_safe {
+        return next.run(request).await;
+    }
+
+    let csrf = request.extensions().get::<CsrfState>().cloned();
+
+    if let Some(csrf) = csrf {
+        let header_value = request
+            .headers()
+            .get(&csrf.header_name)
+            .and_then(|v| v.to_str().ok());
+
+        match header_value {
+            Some(v) if v == csrf.header_value => next.run(request).await,
+            _ => (
+                StatusCode::FORBIDDEN,
+                serde_json::json!({
+                    "error": {
+                        "code": "csrf_rejected",
+                        "message": "missing or invalid CSRF header"
+                    }
+                })
+                .to_string(),
+            )
+                .into_response(),
+        }
+    } else {
+        next.run(request).await
+    }
+}

--- a/crates/pylon/src/router.rs
+++ b/crates/pylon/src/router.rs
@@ -3,19 +3,24 @@
 use std::sync::Arc;
 use std::time::Duration;
 
+use axum::extract::DefaultBodyLimit;
+use axum::http::{HeaderName, HeaderValue, Method};
 use axum::Router;
 use axum::routing::{get, post};
 use tower_http::compression::CompressionLayer;
-use tower_http::cors::CorsLayer;
+use tower_http::cors::{AllowOrigin, CorsLayer};
+use tower_http::set_header::SetResponseHeaderLayer;
 use tower_http::trace::TraceLayer;
 use tracing::info_span;
 
 use crate::handlers::{health, nous, sessions};
+use crate::middleware::{CsrfState, require_csrf_header};
+use crate::security::SecurityConfig;
 use crate::state::AppState;
 
 /// Build the Axum router with all routes and middleware.
-pub fn build_router(state: Arc<AppState>) -> Router {
-    Router::new()
+pub fn build_router(state: Arc<AppState>, security: &SecurityConfig) -> Router {
+    let mut router = Router::new()
         .route("/api/health", get(health::check))
         .route("/api/sessions", post(sessions::create))
         .route(
@@ -26,37 +31,120 @@ pub fn build_router(state: Arc<AppState>) -> Router {
         .route("/api/sessions/{id}/history", get(sessions::history))
         .route("/api/nous", get(nous::list))
         .route("/api/nous/{id}", get(nous::get_status))
-        .route("/api/nous/{id}/tools", get(nous::tools))
-        .layer(CompressionLayer::new())
-        .layer(
-            TraceLayer::new_for_http()
-                .make_span_with(|request: &axum::http::Request<_>| {
-                    let request_id = ulid::Ulid::new().to_string();
-                    info_span!("http_request",
-                        http.method = %request.method(),
-                        http.path = %request.uri().path(),
-                        http.request_id = %request_id,
-                        http.status_code = tracing::field::Empty,
-                    )
-                })
-                .on_response(
-                    |response: &axum::http::Response<_>,
-                     latency: Duration,
-                     span: &tracing::Span| {
-                        span.record("http.status_code", response.status().as_u16());
-                        #[expect(
-                            clippy::cast_possible_truncation,
-                            reason = "HTTP latency fits in u64"
-                        )]
-                        let duration_ms = latency.as_millis() as u64;
-                        tracing::debug!(
-                            duration_ms,
-                            status = response.status().as_u16(),
-                            "request complete"
-                        );
-                    },
-                ),
-        )
-        .layer(CorsLayer::permissive())
-        .with_state(state)
+        .route("/api/nous/{id}/tools", get(nous::tools));
+
+    // CSRF protection — inject state and apply middleware
+    if security.csrf_enabled {
+        let csrf_state = CsrfState {
+            header_name: security.csrf_header_name.clone(),
+            header_value: security.csrf_header_value.clone(),
+        };
+        router = router
+            .layer(axum::middleware::from_fn(require_csrf_header))
+            .layer(axum::Extension(csrf_state));
+    }
+
+    // Body size limit
+    router = router.layer(DefaultBodyLimit::max(security.body_limit_bytes));
+
+    // Compression
+    router = router.layer(CompressionLayer::new());
+
+    // Request tracing
+    router = router.layer(
+        TraceLayer::new_for_http()
+            .make_span_with(|request: &axum::http::Request<_>| {
+                let request_id = ulid::Ulid::new().to_string();
+                info_span!("http_request",
+                    http.method = %request.method(),
+                    http.path = %request.uri().path(),
+                    http.request_id = %request_id,
+                    http.status_code = tracing::field::Empty,
+                )
+            })
+            .on_response(
+                |response: &axum::http::Response<_>,
+                 latency: Duration,
+                 span: &tracing::Span| {
+                    span.record("http.status_code", response.status().as_u16());
+                    #[expect(
+                        clippy::cast_possible_truncation,
+                        reason = "HTTP latency fits in u64"
+                    )]
+                    let duration_ms = latency.as_millis() as u64;
+                    tracing::debug!(
+                        duration_ms,
+                        status = response.status().as_u16(),
+                        "request complete"
+                    );
+                },
+            ),
+    );
+
+    // CORS
+    router = router.layer(build_cors_layer(security));
+
+    // Security response headers (outermost — applied to every response)
+    router = apply_security_headers(router, security);
+
+    router.with_state(state)
+}
+
+/// Build a CORS layer from security configuration.
+fn build_cors_layer(security: &SecurityConfig) -> CorsLayer {
+    let is_permissive = security.allowed_origins.is_empty()
+        || security.allowed_origins.iter().any(|o| o == "*");
+
+    if is_permissive {
+        return CorsLayer::permissive();
+    }
+
+    let origins: Vec<HeaderValue> = security
+        .allowed_origins
+        .iter()
+        .filter_map(|o| o.parse().ok())
+        .collect();
+
+    CorsLayer::new()
+        .allow_origin(AllowOrigin::list(origins))
+        .allow_methods([Method::GET, Method::POST, Method::DELETE, Method::OPTIONS])
+        .allow_headers([
+            HeaderName::from_static("content-type"),
+            HeaderName::from_static("authorization"),
+        ])
+        .max_age(Duration::from_secs(security.cors_max_age_secs))
+}
+
+/// Apply standard security response headers.
+fn apply_security_headers(router: Router<Arc<AppState>>, security: &SecurityConfig) -> Router<Arc<AppState>> {
+    let mut r = router
+        .layer(SetResponseHeaderLayer::overriding(
+            HeaderName::from_static("x-frame-options"),
+            HeaderValue::from_static("DENY"),
+        ))
+        .layer(SetResponseHeaderLayer::overriding(
+            HeaderName::from_static("x-content-type-options"),
+            HeaderValue::from_static("nosniff"),
+        ))
+        .layer(SetResponseHeaderLayer::overriding(
+            HeaderName::from_static("x-xss-protection"),
+            HeaderValue::from_static("0"),
+        ))
+        .layer(SetResponseHeaderLayer::overriding(
+            HeaderName::from_static("referrer-policy"),
+            HeaderValue::from_static("strict-origin-when-cross-origin"),
+        ))
+        .layer(SetResponseHeaderLayer::overriding(
+            HeaderName::from_static("content-security-policy"),
+            HeaderValue::from_static("default-src 'self'"),
+        ));
+
+    if security.tls_enabled {
+        r = r.layer(SetResponseHeaderLayer::overriding(
+            HeaderName::from_static("strict-transport-security"),
+            HeaderValue::from_static("max-age=31536000; includeSubDomains"),
+        ));
+    }
+
+    r
 }

--- a/crates/pylon/src/security.rs
+++ b/crates/pylon/src/security.rs
@@ -1,0 +1,53 @@
+//! Security configuration for the pylon HTTP gateway.
+
+use std::path::PathBuf;
+
+use aletheia_taxis::config::GatewayConfig;
+
+/// Middleware security settings derived from gateway configuration.
+#[derive(Debug, Clone)]
+pub struct SecurityConfig {
+    pub allowed_origins: Vec<String>,
+    pub cors_max_age_secs: u64,
+    pub body_limit_bytes: usize,
+    pub csrf_enabled: bool,
+    pub csrf_header_name: String,
+    pub csrf_header_value: String,
+    pub tls_enabled: bool,
+    pub tls_cert_path: Option<PathBuf>,
+    pub tls_key_path: Option<PathBuf>,
+}
+
+impl SecurityConfig {
+    /// Build security config from the gateway configuration section.
+    #[must_use]
+    pub fn from_gateway(gateway: &GatewayConfig) -> Self {
+        Self {
+            allowed_origins: gateway.cors.allowed_origins.clone(),
+            cors_max_age_secs: gateway.cors.max_age_secs,
+            body_limit_bytes: gateway.body_limit.max_bytes,
+            csrf_enabled: gateway.csrf.enabled,
+            csrf_header_name: gateway.csrf.header_name.clone(),
+            csrf_header_value: gateway.csrf.header_value.clone(),
+            tls_enabled: gateway.tls.enabled,
+            tls_cert_path: gateway.tls.cert_path.as_ref().map(PathBuf::from),
+            tls_key_path: gateway.tls.key_path.as_ref().map(PathBuf::from),
+        }
+    }
+}
+
+impl Default for SecurityConfig {
+    fn default() -> Self {
+        Self {
+            allowed_origins: Vec::new(),
+            cors_max_age_secs: 3600,
+            body_limit_bytes: 1_048_576,
+            csrf_enabled: false,
+            csrf_header_name: "x-requested-with".to_owned(),
+            csrf_header_value: "aletheia".to_owned(),
+            tls_enabled: false,
+            tls_cert_path: None,
+            tls_key_path: None,
+        }
+    }
+}

--- a/crates/pylon/src/server.rs
+++ b/crates/pylon/src/server.rs
@@ -17,6 +17,7 @@ use aletheia_symbolon::jwt::{JwtConfig, JwtManager};
 use aletheia_taxis::oikos::Oikos;
 
 use crate::router::build_router;
+use crate::security::SecurityConfig;
 use crate::state::AppState;
 
 /// Server configuration.
@@ -26,6 +27,8 @@ pub struct ServerConfig {
     pub bind_addr: String,
     /// Path to the Aletheia instance directory.
     pub instance_path: PathBuf,
+    /// Security configuration for middleware layers.
+    pub security: SecurityConfig,
 }
 
 #[derive(Debug, Snafu)]
@@ -43,6 +46,12 @@ pub enum ServerError {
 
     #[snafu(display("server error: {source}"))]
     Serve { source: std::io::Error },
+
+    #[snafu(display("TLS configuration error: {source}"))]
+    TlsConfig { source: std::io::Error },
+
+    #[snafu(display("TLS support not compiled — rebuild with --features tls"))]
+    TlsNotCompiled,
 }
 
 /// Start the HTTP gateway and block until shutdown.
@@ -81,25 +90,85 @@ pub async fn run(config: ServerConfig) -> Result<(), ServerError> {
         start_time: Instant::now(),
     });
 
-    let app = build_router(state.clone());
+    let app = build_router(state.clone(), &config.security);
 
-    let listener = TcpListener::bind(&config.bind_addr)
+    if config.security.tls_enabled {
+        serve_tls(app, &config).await?;
+    } else {
+        serve_plain(app, &config.bind_addr).await?;
+    }
+
+    state.nous_manager.shutdown_readonly().await;
+    info!("pylon shutdown complete");
+    Ok(())
+}
+
+async fn serve_plain(app: axum::Router, bind_addr: &str) -> Result<(), ServerError> {
+    let listener = TcpListener::bind(bind_addr)
         .await
         .context(BindSnafu {
-            addr: config.bind_addr.clone(),
+            addr: bind_addr.to_owned(),
         })?;
 
-    info!(addr = %config.bind_addr, "pylon listening");
+    info!(addr = %bind_addr, tls = false, "pylon listening");
 
     axum::serve(listener, app)
         .with_graceful_shutdown(shutdown_signal())
         .await
-        .context(ServeSnafu)?;
+        .context(ServeSnafu)
+}
 
-    state.nous_manager.shutdown_readonly().await;
+#[cfg(feature = "tls")]
+async fn serve_tls(app: axum::Router, config: &ServerConfig) -> Result<(), ServerError> {
+    use std::time::Duration;
 
-    info!("pylon shutdown complete");
-    Ok(())
+    use axum_server::tls_rustls::RustlsConfig;
+
+    let cert_path = config
+        .security
+        .tls_cert_path
+        .as_deref()
+        .unwrap_or(Path::new("instance/config/tls/cert.pem"));
+    let key_path = config
+        .security
+        .tls_key_path
+        .as_deref()
+        .unwrap_or(Path::new("instance/config/tls/key.pem"));
+
+    let tls_config = RustlsConfig::from_pem_file(cert_path, key_path)
+        .await
+        .context(TlsConfigSnafu)?;
+
+    let addr: std::net::SocketAddr = config
+        .bind_addr
+        .parse()
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidInput, e))
+        .context(BindSnafu {
+            addr: config.bind_addr.clone(),
+        })?;
+
+    let handle = axum_server::Handle::new();
+    let shutdown_handle = handle.clone();
+    tokio::spawn(async move {
+        shutdown_signal().await;
+        shutdown_handle.graceful_shutdown(Some(Duration::from_secs(30)));
+    });
+
+    info!(addr = %config.bind_addr, tls = true, "pylon listening (TLS)");
+
+    axum_server::bind_rustls(addr, tls_config)
+        .handle(handle)
+        .serve(app.into_make_service())
+        .await
+        .context(ServeSnafu)
+}
+
+#[cfg(not(feature = "tls"))]
+fn serve_tls(
+    _app: axum::Router,
+    _config: &ServerConfig,
+) -> impl std::future::Future<Output = Result<(), ServerError>> {
+    std::future::ready(TlsNotCompiledSnafu.fail())
 }
 
 async fn shutdown_signal() {

--- a/crates/pylon/src/tests.rs
+++ b/crates/pylon/src/tests.rs
@@ -18,6 +18,7 @@ use aletheia_symbolon::jwt::{JwtConfig, JwtManager};
 use aletheia_taxis::oikos::Oikos;
 
 use crate::router::build_router;
+use crate::security::SecurityConfig;
 use crate::state::AppState;
 
 // --- Mock Provider ---
@@ -146,12 +147,12 @@ async fn test_state_with_provider(with_provider: bool) -> (Arc<AppState>, tempfi
 
 async fn app() -> (axum::Router, tempfile::TempDir) {
     let (state, dir) = test_state().await;
-    (build_router(state), dir)
+    (build_router(state, &SecurityConfig::default()), dir)
 }
 
 async fn app_no_providers() -> (axum::Router, tempfile::TempDir) {
     let (state, dir) = test_state_with_provider(false).await;
-    (build_router(state), dir)
+    (build_router(state, &SecurityConfig::default()), dir)
 }
 
 fn json_request(method: &str, uri: &str, body: Option<serde_json::Value>) -> Request<Body> {
@@ -507,7 +508,7 @@ async fn history_unknown_session_returns_404() {
 #[tokio::test]
 async fn history_with_limit() {
     let (state, _dir) = test_state().await;
-    let router = build_router(Arc::clone(&state));
+    let router = build_router(Arc::clone(&state), &SecurityConfig::default());
 
     let created = create_test_session(&router).await;
     let id = created["id"].as_str().unwrap();
@@ -543,7 +544,7 @@ async fn history_with_limit() {
 #[tokio::test]
 async fn send_message_returns_sse_content_type() {
     let (state, _dir) = test_state().await;
-    let router = build_router(Arc::clone(&state));
+    let router = build_router(Arc::clone(&state), &SecurityConfig::default());
     let created = create_test_session(&router).await;
     let id = created["id"].as_str().unwrap();
 
@@ -568,7 +569,7 @@ async fn send_message_returns_sse_content_type() {
 #[tokio::test]
 async fn send_message_stream_contains_events() {
     let (state, _dir) = test_state().await;
-    let router = build_router(Arc::clone(&state));
+    let router = build_router(Arc::clone(&state), &SecurityConfig::default());
     let created = create_test_session(&router).await;
     let id = created["id"].as_str().unwrap();
 
@@ -627,7 +628,7 @@ async fn send_empty_message_returns_400() {
 #[tokio::test]
 async fn send_message_stores_in_history() {
     let (state, _dir) = test_state().await;
-    let router = build_router(Arc::clone(&state));
+    let router = build_router(Arc::clone(&state), &SecurityConfig::default());
     let created = create_test_session(&router).await;
     let id = created["id"].as_str().unwrap();
 
@@ -773,7 +774,7 @@ async fn concurrent_session_creation() {
     let mut handles = Vec::new();
 
     for i in 0..5 {
-        let router = build_router(Arc::clone(&state));
+        let router = build_router(Arc::clone(&state), &SecurityConfig::default());
         handles.push(tokio::spawn(async move {
             let req = authed_request(
                 "POST",
@@ -799,7 +800,7 @@ async fn concurrent_session_creation() {
 #[tokio::test]
 async fn send_message_no_provider_returns_error() {
     let (state, _dir) = test_state_with_provider(false).await;
-    let router = build_router(Arc::clone(&state));
+    let router = build_router(Arc::clone(&state), &SecurityConfig::default());
     let created = create_test_session(&router).await;
     let id = created["id"].as_str().unwrap();
 
@@ -818,7 +819,7 @@ async fn send_message_no_provider_returns_error() {
 #[tokio::test]
 async fn send_message_routes_through_actor() {
     let (state, _dir) = test_state().await;
-    let router = build_router(Arc::clone(&state));
+    let router = build_router(Arc::clone(&state), &SecurityConfig::default());
     let created = create_test_session(&router).await;
     let id = created["id"].as_str().unwrap();
 
@@ -847,7 +848,7 @@ async fn send_message_routes_through_actor() {
 #[tokio::test]
 async fn nous_list_from_manager() {
     let (state, _dir) = test_state().await;
-    let router = build_router(Arc::clone(&state));
+    let router = build_router(Arc::clone(&state), &SecurityConfig::default());
 
     let resp = router.oneshot(authed_get("/api/nous")).await.unwrap();
 
@@ -956,4 +957,183 @@ async fn missing_auth_header_returns_401() {
 
     let resp = app.oneshot(req).await.expect("response");
     assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+// --- Security Header Tests ---
+
+#[tokio::test]
+async fn security_headers_present_on_response() {
+    let (app, _dir) = app().await;
+    let resp = app
+        .oneshot(Request::get("/api/health").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert_eq!(
+        resp.headers().get("x-frame-options").unwrap(),
+        "DENY"
+    );
+    assert_eq!(
+        resp.headers().get("x-content-type-options").unwrap(),
+        "nosniff"
+    );
+    assert_eq!(
+        resp.headers().get("x-xss-protection").unwrap(),
+        "0"
+    );
+    assert_eq!(
+        resp.headers().get("referrer-policy").unwrap(),
+        "strict-origin-when-cross-origin"
+    );
+    assert_eq!(
+        resp.headers().get("content-security-policy").unwrap(),
+        "default-src 'self'"
+    );
+    // HSTS should NOT be present when TLS is disabled
+    assert!(resp.headers().get("strict-transport-security").is_none());
+}
+
+#[tokio::test]
+async fn hsts_header_present_when_tls_enabled() {
+    let (state, _dir) = test_state().await;
+    let security = SecurityConfig { tls_enabled: true, ..SecurityConfig::default() };
+    let router = build_router(state, &security);
+
+    let resp = router
+        .oneshot(Request::get("/api/health").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+
+    assert_eq!(
+        resp.headers().get("strict-transport-security").unwrap(),
+        "max-age=31536000; includeSubDomains"
+    );
+}
+
+// --- Body Limit Tests ---
+
+#[tokio::test]
+async fn oversized_body_returns_413() {
+    let (state, _dir) = test_state().await;
+    let security = SecurityConfig { body_limit_bytes: 100, ..SecurityConfig::default() };
+    let router = build_router(state, &security);
+
+    let big_body = "x".repeat(200);
+    let token = default_token();
+    let req = Request::builder()
+        .method("POST")
+        .uri("/api/sessions")
+        .header("content-type", "application/json")
+        .header("authorization", format!("Bearer {token}"))
+        .body(Body::from(big_body))
+        .unwrap();
+
+    let resp = router.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::PAYLOAD_TOO_LARGE);
+}
+
+// --- CSRF Tests ---
+
+#[tokio::test]
+async fn csrf_rejects_post_without_header() {
+    let (state, _dir) = test_state().await;
+    let security = SecurityConfig { csrf_enabled: true, ..SecurityConfig::default() };
+    let router = build_router(state, &security);
+
+    let req = authed_request(
+        "POST",
+        "/api/sessions",
+        Some(serde_json::json!({
+            "nous_id": "syn",
+            "session_key": "csrf-test"
+        })),
+    );
+
+    let resp = router.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn csrf_allows_post_with_correct_header() {
+    let (state, _dir) = test_state().await;
+    let security = SecurityConfig { csrf_enabled: true, ..SecurityConfig::default() };
+    let router = build_router(state, &security);
+
+    let token = default_token();
+    let req = Request::builder()
+        .method("POST")
+        .uri("/api/sessions")
+        .header("content-type", "application/json")
+        .header("authorization", format!("Bearer {token}"))
+        .header("x-requested-with", "aletheia")
+        .body(Body::from(
+            serde_json::to_vec(&serde_json::json!({
+                "nous_id": "syn",
+                "session_key": "csrf-test"
+            }))
+            .unwrap(),
+        ))
+        .unwrap();
+
+    let resp = router.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::CREATED);
+}
+
+#[tokio::test]
+async fn csrf_allows_get_without_header() {
+    let (state, _dir) = test_state().await;
+    let security = SecurityConfig { csrf_enabled: true, ..SecurityConfig::default() };
+    let router = build_router(state, &security);
+
+    let resp = router
+        .oneshot(authed_get("/api/nous"))
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+}
+
+// --- CORS Tests ---
+
+#[tokio::test]
+async fn cors_permissive_when_no_origins_configured() {
+    let (state, _dir) = test_state().await;
+    let security = SecurityConfig::default(); // empty origins = permissive
+    let router = build_router(state, &security);
+
+    let req = Request::builder()
+        .method("OPTIONS")
+        .uri("/api/health")
+        .header("origin", "http://evil.example.com")
+        .header("access-control-request-method", "GET")
+        .body(Body::empty())
+        .unwrap();
+
+    let resp = router.oneshot(req).await.unwrap();
+    // Permissive CORS should allow any origin
+    assert!(resp.status().is_success() || resp.status() == StatusCode::NO_CONTENT);
+}
+
+#[tokio::test]
+async fn cors_rejects_unlisted_origin() {
+    let (state, _dir) = test_state().await;
+    let security = SecurityConfig { allowed_origins: vec!["http://localhost:3000".to_owned()], ..SecurityConfig::default() };
+    let router = build_router(state, &security);
+
+    let req = Request::builder()
+        .method("OPTIONS")
+        .uri("/api/health")
+        .header("origin", "http://evil.example.com")
+        .header("access-control-request-method", "GET")
+        .body(Body::empty())
+        .unwrap();
+
+    let resp = router.oneshot(req).await.unwrap();
+    // Should not have the evil origin in access-control-allow-origin
+    let allow_origin = resp.headers().get("access-control-allow-origin");
+    assert!(
+        allow_origin.is_none()
+            || allow_origin.unwrap() != "http://evil.example.com"
+    );
 }

--- a/crates/taxis/src/config.rs
+++ b/crates/taxis/src/config.rs
@@ -149,6 +149,10 @@ pub struct GatewayConfig {
     pub port: u16,
     pub bind: String,
     pub auth: GatewayAuthConfig,
+    pub tls: TlsConfig,
+    pub cors: CorsConfig,
+    pub body_limit: BodyLimitConfig,
+    pub csrf: CsrfConfig,
 }
 
 impl Default for GatewayConfig {
@@ -157,6 +161,10 @@ impl Default for GatewayConfig {
             port: 18789,
             bind: "lan".to_owned(),
             auth: GatewayAuthConfig::default(),
+            tls: TlsConfig::default(),
+            cors: CorsConfig::default(),
+            body_limit: BodyLimitConfig::default(),
+            csrf: CsrfConfig::default(),
         }
     }
 }
@@ -173,6 +181,73 @@ impl Default for GatewayAuthConfig {
     fn default() -> Self {
         Self {
             mode: "token".to_owned(),
+        }
+    }
+}
+
+/// TLS termination configuration.
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[serde(default)]
+pub struct TlsConfig {
+    pub enabled: bool,
+    pub cert_path: Option<String>,
+    pub key_path: Option<String>,
+}
+
+/// CORS origin allowlist configuration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[serde(default)]
+pub struct CorsConfig {
+    /// Allowed origins. Empty or `["*"]` means permissive (dev mode).
+    pub allowed_origins: Vec<String>,
+    /// Preflight cache duration in seconds.
+    pub max_age_secs: u64,
+}
+
+impl Default for CorsConfig {
+    fn default() -> Self {
+        Self {
+            allowed_origins: Vec::new(),
+            max_age_secs: 3600,
+        }
+    }
+}
+
+/// Request body size limit configuration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[serde(default)]
+pub struct BodyLimitConfig {
+    /// Maximum request body size in bytes.
+    pub max_bytes: usize,
+}
+
+impl Default for BodyLimitConfig {
+    fn default() -> Self {
+        Self {
+            max_bytes: 1_048_576,
+        }
+    }
+}
+
+/// CSRF protection configuration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[serde(default)]
+pub struct CsrfConfig {
+    pub enabled: bool,
+    pub header_name: String,
+    pub header_value: String,
+}
+
+impl Default for CsrfConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            header_name: "x-requested-with".to_owned(),
+            header_value: "aletheia".to_owned(),
         }
     }
 }
@@ -489,6 +564,15 @@ mod tests {
         assert_eq!(config.gateway.port, 18789);
         assert_eq!(config.gateway.bind, "lan");
         assert_eq!(config.gateway.auth.mode, "token");
+        // Security config defaults
+        assert!(!config.gateway.tls.enabled);
+        assert!(config.gateway.tls.cert_path.is_none());
+        assert!(config.gateway.cors.allowed_origins.is_empty());
+        assert_eq!(config.gateway.cors.max_age_secs, 3600);
+        assert_eq!(config.gateway.body_limit.max_bytes, 1_048_576);
+        assert!(!config.gateway.csrf.enabled);
+        assert_eq!(config.gateway.csrf.header_name, "x-requested-with");
+        assert_eq!(config.gateway.csrf.header_value, "aletheia");
         assert!(config.channels.signal.enabled);
         assert!(config.channels.signal.accounts.is_empty());
         assert!(config.bindings.is_empty());


### PR DESCRIPTION
## Summary

- **RSEC-01**: TLS termination with rustls behind `pylon/tls` feature flag, `aletheia tls generate` CLI subcommand using rcgen
- **RSEC-02**: CORS lockdown — configurable origin allowlist replaces `CorsLayer::permissive()`
- **RSEC-03**: Request body limits via `DefaultBodyLimit` (default 1MB, configurable)
- **RSEC-04**: Security response headers on all responses (X-Frame-Options, X-Content-Type-Options, CSP, Referrer-Policy, HSTS when TLS)
- **RSEC-05**: Log redaction in koina — `redact_sensitive()` masks API keys, JWTs, bearer tokens, passwords
- **RSEC-06**: CSRF protection via custom header requirement on state-changing endpoints

All 6 features configurable through taxis `GatewayConfig` with sensible defaults. `SecurityConfig` in pylon bridges config to middleware layers. Zero clippy warnings, all workspace tests pass (46 pylon tests including 8 new security tests).

## Test plan

- [x] `cargo clippy --workspace --exclude aletheia-mneme-engine --all-targets -- -D warnings` — zero warnings
- [x] `cargo test --workspace --exclude aletheia-mneme-engine` — all pass
- [x] Security headers verified on health endpoint response
- [x] HSTS present only when TLS enabled
- [x] Oversized body returns 413
- [x] CSRF rejects POST without header, allows with correct header, allows GET
- [x] CORS rejects unlisted origins when configured
- [x] Redaction masks sk-ant keys, JWTs, Bearer tokens, password patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)