### PR TITLE
feat(tui): enrich SelectionContext and fix context gauge threshold

### DIFF
--- a/tui/src/state/command.rs
+++ b/tui/src/state/command.rs
@@ -10,12 +10,11 @@ pub struct CommandPaletteState {
 
 /// Selection context for context-aware status bar hints.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
-#[expect(dead_code, reason = "variants used when selection tracking is wired")]
 pub enum SelectionContext {
     #[default]
     None,
-    UserMessage,
-    AgentResponse,
-    ToolCall,
-    SessionList,
+    UserMessage { index: usize },
+    AgentResponse { index: usize, has_code: bool, has_links: bool },
+    ToolCall { index: usize, tool_id: String, needs_approval: bool },
+    SessionListItem { index: usize },
 }

--- a/tui/src/view/status_bar.rs
+++ b/tui/src/view/status_bar.rs
@@ -19,10 +19,10 @@ pub fn render(app: &App, frame: &mut Frame, area: Rect, theme: &ThemePalette) {
 fn render_keybindings(app: &App, width: u16, theme: &ThemePalette) -> Line<'static> {
     let hints = match app.selection {
         SelectionContext::None => ": command │ / filter │ ? help",
-        SelectionContext::UserMessage => "e edit │ d delete │ c copy",
-        SelectionContext::AgentResponse => "c copy │ y yank │ o open",
-        SelectionContext::ToolCall => "a approve │ r reject │ i inspect",
-        SelectionContext::SessionList => "Enter open │ d delete │ n new",
+        SelectionContext::UserMessage { .. } => "e edit │ d delete │ c copy",
+        SelectionContext::AgentResponse { .. } => "c copy │ y yank │ o open",
+        SelectionContext::ToolCall { .. } => "a approve │ r reject │ i inspect",
+        SelectionContext::SessionListItem { .. } => "Enter open │ d delete │ n new",
     };
 
     let hints_width = hints.width();
@@ -147,7 +147,7 @@ fn context_gauge_spans(app: &App, theme: &ThemePalette) -> Vec<Span<'static>> {
 
             let color = if pct <= 60 {
                 theme.success
-            } else if pct <= 84 {
+            } else if pct <= 80 {
                 theme.warning
             } else {
                 theme.error


### PR DESCRIPTION
## Summary

- **SelectionContext** variants now carry data fields (`index`, `has_code`, `has_links`, `tool_id`, `needs_approval`) — prepares for row-level actions in prompt 40
- `SessionList` renamed to `SessionListItem` to match spec
- Context gauge yellow threshold corrected from ≤84% to ≤80%

## Test plan

- [x] `cargo check` passes (TUI crate)
- [x] No new clippy warnings introduced
- [ ] Visual: status bar renders correctly with default `SelectionContext::None`