### PR TITLE
feat(tui): context-aware help system

### DIFF
--- a/tui/src/keybindings.rs
+++ b/tui/src/keybindings.rs
@@ -1,5 +1,5 @@
 /// Context-aware keybinding registry — single source of truth for help overlay and status bar hints.
-use crate::app::{App, Overlay};
+use crate::app::{App, Overlay, SelectionContext};
 
 pub struct Keybinding {
     pub keys: &'static str,
@@ -12,6 +12,10 @@ pub struct Keybinding {
 pub enum KeyContext {
     Global,
     Chat,
+    Selection,
+    Filter,
+    CommandPalette,
+    SessionList,
     Input,
     Overlay,
     ToolApproval,
@@ -23,6 +27,10 @@ impl KeyContext {
         match self {
             Self::Global => "Global",
             Self::Chat => "Chat",
+            Self::Selection => "Selection",
+            Self::Filter => "Filter",
+            Self::CommandPalette => "Command Palette",
+            Self::SessionList => "Session List",
             Self::Input => "Input",
             Self::Overlay => "Overlay",
             Self::ToolApproval => "Tool Approval",
@@ -32,7 +40,12 @@ impl KeyContext {
 
     fn display_order(self) -> u8 {
         match self {
-            Self::ToolApproval | Self::PlanApproval => 0,
+            Self::ToolApproval
+            | Self::PlanApproval
+            | Self::Selection
+            | Self::Filter
+            | Self::CommandPalette
+            | Self::SessionList => 0,
             Self::Chat => 1,
             Self::Input => 2,
             Self::Overlay => 3,
@@ -43,56 +56,25 @@ impl KeyContext {
 
 pub fn all_keybindings() -> &'static [Keybinding] {
     &[
-        // --- Global ---
+        // --- Chat (empty-input triggers) ---
         Keybinding {
             keys: "?",
-            description: "Help for current view",
-            contexts: &[KeyContext::Global],
-            show_in_status_bar: false,
+            description: "Help",
+            contexts: &[KeyContext::Chat],
+            show_in_status_bar: true,
         },
         Keybinding {
             keys: ":",
             description: "Command palette",
-            contexts: &[KeyContext::Global],
+            contexts: &[KeyContext::Chat],
             show_in_status_bar: true,
         },
         Keybinding {
-            keys: "Ctrl+A",
-            description: "Switch agent",
-            contexts: &[KeyContext::Global],
+            keys: "/",
+            description: "Filter",
+            contexts: &[KeyContext::Chat],
             show_in_status_bar: true,
         },
-        Keybinding {
-            keys: "Ctrl+F",
-            description: "Toggle sidebar",
-            contexts: &[KeyContext::Global],
-            show_in_status_bar: false,
-        },
-        Keybinding {
-            keys: "Ctrl+T",
-            description: "Toggle thinking",
-            contexts: &[KeyContext::Global],
-            show_in_status_bar: false,
-        },
-        Keybinding {
-            keys: "Ctrl+I",
-            description: "System status",
-            contexts: &[KeyContext::Global],
-            show_in_status_bar: true,
-        },
-        Keybinding {
-            keys: "Ctrl+N",
-            description: "New session",
-            contexts: &[KeyContext::Global],
-            show_in_status_bar: true,
-        },
-        Keybinding {
-            keys: "Ctrl+C/Q",
-            description: "Quit",
-            contexts: &[KeyContext::Global],
-            show_in_status_bar: true,
-        },
-        // --- Chat ---
         Keybinding {
             keys: "Ctrl+Y",
             description: "Copy last response",
@@ -128,6 +110,118 @@ pub fn all_keybindings() -> &'static [Keybinding] {
             description: "Scroll / click agent",
             contexts: &[KeyContext::Chat],
             show_in_status_bar: false,
+        },
+        // --- Selection ---
+        Keybinding {
+            keys: "j / \u{2193}",
+            description: "Next message",
+            contexts: &[KeyContext::Selection],
+            show_in_status_bar: false,
+        },
+        Keybinding {
+            keys: "k / \u{2191}",
+            description: "Previous message",
+            contexts: &[KeyContext::Selection],
+            show_in_status_bar: false,
+        },
+        Keybinding {
+            keys: "c",
+            description: "Copy message",
+            contexts: &[KeyContext::Selection],
+            show_in_status_bar: true,
+        },
+        Keybinding {
+            keys: "y",
+            description: "Yank code block",
+            contexts: &[KeyContext::Selection],
+            show_in_status_bar: true,
+        },
+        Keybinding {
+            keys: "e",
+            description: "Edit and resend",
+            contexts: &[KeyContext::Selection],
+            show_in_status_bar: true,
+        },
+        Keybinding {
+            keys: "d",
+            description: "Delete message",
+            contexts: &[KeyContext::Selection],
+            show_in_status_bar: true,
+        },
+        Keybinding {
+            keys: "o",
+            description: "Open links",
+            contexts: &[KeyContext::Selection],
+            show_in_status_bar: true,
+        },
+        Keybinding {
+            keys: "i",
+            description: "Inspect tool call",
+            contexts: &[KeyContext::Selection],
+            show_in_status_bar: true,
+        },
+        Keybinding {
+            keys: "Esc",
+            description: "Deselect",
+            contexts: &[KeyContext::Selection],
+            show_in_status_bar: true,
+        },
+        // --- Filter ---
+        Keybinding {
+            keys: "Enter",
+            description: "Lock filter",
+            contexts: &[KeyContext::Filter],
+            show_in_status_bar: true,
+        },
+        Keybinding {
+            keys: "Esc",
+            description: "Clear filter",
+            contexts: &[KeyContext::Filter],
+            show_in_status_bar: true,
+        },
+        Keybinding {
+            keys: "n / N",
+            description: "Next / prev match",
+            contexts: &[KeyContext::Filter],
+            show_in_status_bar: true,
+        },
+        // --- Command Palette ---
+        Keybinding {
+            keys: "Enter",
+            description: "Execute command",
+            contexts: &[KeyContext::CommandPalette],
+            show_in_status_bar: false,
+        },
+        Keybinding {
+            keys: "Tab",
+            description: "Autocomplete",
+            contexts: &[KeyContext::CommandPalette],
+            show_in_status_bar: false,
+        },
+        Keybinding {
+            keys: "Esc",
+            description: "Close palette",
+            contexts: &[KeyContext::CommandPalette],
+            show_in_status_bar: false,
+        },
+        // --- Session List ---
+        Keybinding {
+            keys: "Enter",
+            description: "Open session",
+            contexts: &[KeyContext::SessionList],
+            show_in_status_bar: true,
+        },
+        Keybinding {
+            keys: "d",
+            description: "Delete session",
+            contexts: &[KeyContext::SessionList],
+            show_in_status_bar: true,
+        },
+        Keybinding {
+            keys: "n",
+            description: "New session",
+            contexts: &[KeyContext::SessionList],
+            show_in_status_bar: true,
         },
         // --- Input ---
         Keybinding {
@@ -185,6 +279,49 @@ pub fn all_keybindings() -> &'static [Keybinding] {
             contexts: &[KeyContext::Overlay],
             show_in_status_bar: false,
         },
+        // --- Global ---
+        Keybinding {
+            keys: "F1",
+            description: "Help",
+            contexts: &[KeyContext::Global],
+            show_in_status_bar: false,
+        },
+        Keybinding {
+            keys: "Ctrl+A",
+            description: "Switch agent",
+            contexts: &[KeyContext::Global],
+            show_in_status_bar: false,
+        },
+        Keybinding {
+            keys: "Ctrl+F",
+            description: "Toggle sidebar",
+            contexts: &[KeyContext::Global],
+            show_in_status_bar: false,
+        },
+        Keybinding {
+            keys: "Ctrl+T",
+            description: "Toggle thinking",
+            contexts: &[KeyContext::Global],
+            show_in_status_bar: false,
+        },
+        Keybinding {
+            keys: "Ctrl+I",
+            description: "System status",
+            contexts: &[KeyContext::Global],
+            show_in_status_bar: false,
+        },
+        Keybinding {
+            keys: "Ctrl+N",
+            description: "New session",
+            contexts: &[KeyContext::Global],
+            show_in_status_bar: false,
+        },
+        Keybinding {
+            keys: "Ctrl+C/Q",
+            description: "Quit",
+            contexts: &[KeyContext::Global],
+            show_in_status_bar: false,
+        },
         // --- Tool Approval ---
         Keybinding {
             keys: "A",
@@ -220,10 +357,21 @@ pub fn all_keybindings() -> &'static [Keybinding] {
     ]
 }
 
+/// Determine active contexts. Help overlay is transparent — it shows the underlying context.
 pub fn current_contexts(app: &App) -> Vec<KeyContext> {
     let mut contexts = vec![KeyContext::Global];
 
     match &app.overlay {
+        Some(Overlay::Help) | None => {
+            if app.command_palette.active {
+                contexts.push(KeyContext::CommandPalette);
+            } else if app.selection != SelectionContext::None {
+                contexts.push(KeyContext::Selection);
+            } else {
+                contexts.push(KeyContext::Chat);
+                contexts.push(KeyContext::Input);
+            }
+        }
         Some(Overlay::ToolApproval(_)) => {
             contexts.push(KeyContext::ToolApproval);
             contexts.push(KeyContext::Overlay);
@@ -235,19 +383,23 @@ pub fn current_contexts(app: &App) -> Vec<KeyContext> {
         Some(_) => {
             contexts.push(KeyContext::Overlay);
         }
-        None => {
-            contexts.push(KeyContext::Chat);
-            contexts.push(KeyContext::Input);
-        }
     }
 
     contexts
 }
 
-pub fn context_label(overlay: &Option<Overlay>) -> &'static str {
-    match overlay {
-        None => "Chat",
-        Some(Overlay::Help) => "Help",
+/// Label for the help overlay title — reflects the source context, not the overlay itself.
+pub fn context_label(app: &App) -> &'static str {
+    match &app.overlay {
+        Some(Overlay::Help) | None => {
+            if app.command_palette.active {
+                "Command Palette"
+            } else if app.selection != SelectionContext::None {
+                "Selection"
+            } else {
+                "Chat"
+            }
+        }
         Some(Overlay::AgentPicker { .. }) => "Agent Picker",
         Some(Overlay::ToolApproval(_)) => "Tool Approval",
         Some(Overlay::PlanApproval(_)) => "Plan Approval",
@@ -292,13 +444,27 @@ pub fn grouped_keybindings(
     groups
 }
 
+/// Status bar hints: mode-specific bindings first, truncated to fit.
 pub fn status_bar_hints(app: &App) -> Vec<(&'static str, &'static str)> {
     let contexts = current_contexts(app);
 
-    all_keybindings()
+    let mut bindings: Vec<&Keybinding> = all_keybindings()
         .iter()
         .filter(|kb| kb.show_in_status_bar)
         .filter(|kb| kb.contexts.iter().any(|c| contexts.contains(c)))
+        .collect();
+
+    bindings.sort_by_key(|kb| {
+        kb.contexts
+            .iter()
+            .map(|c| c.display_order())
+            .min()
+            .unwrap_or(255)
+    });
+
+    bindings
+        .iter()
         .map(|kb| (kb.keys, kb.description))
+        .take(8)
         .collect()
 }

--- a/tui/src/mapping.rs
+++ b/tui/src/mapping.rs
@@ -136,6 +136,11 @@ impl App {
             (_, KeyCode::Backspace) => Some(Msg::CommandPaletteBackspace),
             (KeyModifiers::CONTROL, KeyCode::Char('w')) => Some(Msg::CommandPaletteDeleteWord),
             (KeyModifiers::CONTROL, KeyCode::Char('u')) => Some(Msg::CommandPaletteClose),
+
+            (KeyModifiers::NONE, KeyCode::Char('?')) if self.command_palette.input.is_empty() => {
+                Some(Msg::OpenOverlay(OverlayKind::Help))
+            }
+
             (KeyModifiers::NONE | KeyModifiers::SHIFT, KeyCode::Char(c)) => {
                 Some(Msg::CommandPaletteInput(c))
             }

--- a/tui/src/view/overlay.rs
+++ b/tui/src/view/overlay.rs
@@ -90,7 +90,7 @@ fn render_help(app: &App, frame: &mut Frame, area: Rect, theme: &ThemePalette) {
 
     lines.push(Line::raw(""));
 
-    let label = keybindings::context_label(&app.overlay);
+    let label = keybindings::context_label(app);
     let title = format!("Help — {label}");
     let block = overlay_block(&title, theme);
     let paragraph = Paragraph::new(lines)

--- a/tui/src/view/status_bar.rs
+++ b/tui/src/view/status_bar.rs
@@ -5,7 +5,8 @@ use ratatui::text::{Line, Span};
 use ratatui::widgets::Paragraph;
 use unicode_width::UnicodeWidthStr;
 
-use crate::app::{App, SelectionContext};
+use crate::app::App;
+use crate::keybindings;
 use crate::theme::ThemePalette;
 
 pub fn render(app: &App, frame: &mut Frame, area: Rect, theme: &ThemePalette) {
@@ -17,19 +18,18 @@ pub fn render(app: &App, frame: &mut Frame, area: Rect, theme: &ThemePalette) {
 }
 
 fn render_keybindings(app: &App, width: u16, theme: &ThemePalette) -> Line<'static> {
-    let hints = match app.selection {
-        SelectionContext::None => ": command │ / filter │ ? help",
-        SelectionContext::UserMessage { .. } => "e edit │ d delete │ c copy",
-        SelectionContext::AgentResponse { .. } => "c copy │ y yank │ o open",
-        SelectionContext::ToolCall { .. } => "a approve │ r reject │ i inspect",
-        SelectionContext::SessionListItem { .. } => "Enter open │ d delete │ n new",
-    };
+    let hints = keybindings::status_bar_hints(app);
+    let hint_str: String = hints
+        .iter()
+        .map(|(key, desc)| format!("{key} {desc}"))
+        .collect::<Vec<_>>()
+        .join(" \u{2502} ");
 
-    let hints_width = hints.width();
+    let hints_width = hint_str.width();
     let pad = (width as usize).saturating_sub(hints_width + 1);
     Line::from(vec![
         Span::raw(" ".repeat(pad)),
-        Span::styled(hints.to_string(), theme.style_dim()),
+        Span::styled(hint_str, theme.style_dim()),
     ])
 }
 


### PR DESCRIPTION
## Summary

- `?` shows keybindings relevant to the current view/mode, replacing static help
- Single keybinding registry (`keybindings.rs`) drives help overlay, status bar hints, and action context
- Help overlay is "transparent" — when opened from command palette via `?`, it shows command palette bindings (not generic overlay bindings)
- Status bar line 1 now pulls from the registry instead of hardcoded `SelectionContext` match
- Added `KeyContext` variants: Selection, Filter, CommandPalette, SessionList with full keybinding sets

## Test plan

- [ ] Normal chat → `?` → help title says "Help — Chat", shows Chat + Input + Global bindings
- [ ] Status bar shows `? Help │ : Command palette │ / Filter` (from registry)
- [ ] `:` → command palette → `?` → help shows "Help — Command Palette" with palette bindings
- [ ] Esc from help → back to command palette (state preserved)
- [ ] F1 works from any state (Global binding, no input guard)
- [ ] `cargo check` passes, no new clippy warnings in changed files