### PR TITLE
feat(tui): command palette extensions — dynamic agents, shortcuts, live commands

### DIFF
--- a/tui/src/api/client.rs
+++ b/tui/src/api/client.rs
@@ -255,6 +255,38 @@ impl ApiClient {
         Ok((today_cost * 100.0) as u32)
     }
 
+    // --- Distillation ---
+
+    pub async fn compact(&self, session_id: &str) -> Result<()> {
+        self.request(
+            reqwest::Method::POST,
+            &format!("/api/sessions/{session_id}/distill"),
+        )
+        .send()
+        .await
+        .context("failed to trigger distillation")?
+        .error_for_status_ref()
+        .context("distillation request failed")?;
+        Ok(())
+    }
+
+    // --- Memory recall ---
+
+    pub async fn recall(&self, nous_id: &str, query: &str) -> Result<String> {
+        let resp = self
+            .request(
+                reqwest::Method::GET,
+                &format!("/api/nous/{nous_id}/recall"),
+            )
+            .query(&[("q", query)])
+            .send()
+            .await
+            .context("failed to recall memory")?;
+        resp.error_for_status_ref()
+            .context("recall request failed")?;
+        Ok(resp.text().await?)
+    }
+
     // --- Message queue (mid-turn) ---
 
     pub async fn queue_message(&self, session_id: &str, text: &str) -> Result<()> {

--- a/tui/src/app.rs
+++ b/tui/src/app.rs
@@ -185,6 +185,7 @@ impl App {
                 active_tool: None,
                 tool_started_at: None,
                 sessions: Vec::new(),
+                model: a.model,
                 compaction_stage: None,
                 has_notification: false,
             })

--- a/tui/src/command/mod.rs
+++ b/tui/src/command/mod.rs
@@ -2,6 +2,8 @@
 use fuzzy_matcher::FuzzyMatcher;
 use fuzzy_matcher::skim::SkimMatcherV2;
 
+use crate::state::AgentState;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CommandCategory {
     Navigation,
@@ -15,12 +17,18 @@ pub struct Command {
     pub aliases: &'static [&'static str],
     pub description: &'static str,
     pub category: CommandCategory,
+    pub shortcut: Option<&'static str>,
 }
 
 #[derive(Debug)]
-pub struct ScoredCommand {
-    pub index: usize,
+pub struct Suggestion {
+    pub label: String,
+    pub description: String,
+    pub category: CommandCategory,
+    pub aliases: &'static [&'static str],
+    pub shortcut: Option<&'static str>,
     pub score: i64,
+    pub execute_as: String,
 }
 
 pub static COMMANDS: &[Command] = &[
@@ -29,115 +37,193 @@ pub static COMMANDS: &[Command] = &[
         aliases: &["s"],
         description: "List sessions for current agent",
         category: CommandCategory::Navigation,
+        shortcut: None,
     },
     Command {
         name: "agents",
         aliases: &["a"],
         description: "Switch agent",
         category: CommandCategory::Navigation,
+        shortcut: Some("Ctrl+A"),
     },
     Command {
         name: "agent",
         aliases: &[],
         description: "Switch to named agent",
         category: CommandCategory::Agent,
+        shortcut: None,
     },
     Command {
         name: "cost",
         aliases: &["$"],
         description: "Show daily cost breakdown",
         category: CommandCategory::Query,
+        shortcut: Some("Ctrl+I"),
     },
     Command {
         name: "health",
         aliases: &["h"],
         description: "System health status",
         category: CommandCategory::Query,
+        shortcut: Some("Ctrl+I"),
     },
     Command {
         name: "compact",
         aliases: &[],
         description: "Trigger distillation",
         category: CommandCategory::Action,
+        shortcut: None,
     },
     Command {
         name: "clear",
         aliases: &[],
         description: "Clear conversation / new session",
         category: CommandCategory::Action,
+        shortcut: Some("Ctrl+N"),
     },
     Command {
         name: "help",
         aliases: &["?"],
         description: "Show help",
         category: CommandCategory::Navigation,
+        shortcut: Some("F1"),
     },
     Command {
         name: "quit",
         aliases: &["q"],
         description: "Quit application",
         category: CommandCategory::Action,
+        shortcut: Some("Ctrl+C"),
     },
     Command {
         name: "recall",
         aliases: &["r"],
         description: "Search memory graph",
         category: CommandCategory::Query,
+        shortcut: None,
     },
     Command {
         name: "model",
         aliases: &[],
         description: "Show current model info",
         category: CommandCategory::Query,
+        shortcut: None,
     },
 ];
 
 const MAX_SUGGESTIONS: usize = 8;
+const MAX_SUGGESTIONS_INITIAL: usize = 16;
 
-/// Filter and rank commands by fuzzy matching against the input.
-///
-/// When input contains a space, only the first word is matched against commands.
-/// Returns up to 8 results sorted by score descending.
-pub fn filter_commands(input: &str) -> Vec<ScoredCommand> {
+/// Build suggestions from static commands + dynamic agent entries.
+pub fn build_suggestions(input: &str, agents: &[AgentState]) -> Vec<Suggestion> {
     let query = match input.split_once(' ') {
         Some((cmd, _)) => cmd,
         None => input,
     };
 
-    if query.is_empty() {
-        return COMMANDS
-            .iter()
-            .enumerate()
-            .map(|(i, _)| ScoredCommand { index: i, score: 0 })
-            .collect();
-    }
-
     let matcher = SkimMatcherV2::default();
-    let mut scored: Vec<ScoredCommand> = COMMANDS
-        .iter()
-        .enumerate()
-        .filter_map(|(i, cmd)| {
-            let mut best: Option<i64> = None;
+    let mut suggestions: Vec<Suggestion> = Vec::new();
 
-            if let Some(s) = matcher.fuzzy_match(cmd.name, query) {
+    if query.is_empty() {
+        // Show all static commands + agent entries
+        for cmd in COMMANDS {
+            suggestions.push(Suggestion {
+                label: cmd.name.to_string(),
+                description: cmd.description.to_string(),
+                category: cmd.category,
+                aliases: cmd.aliases,
+                shortcut: cmd.shortcut,
+                score: 0,
+                execute_as: cmd.name.to_string(),
+            });
+        }
+        for agent in agents {
+            suggestions.push(agent_suggestion(agent, 0));
+        }
+    } else {
+        // Fuzzy match static commands
+        for cmd in COMMANDS {
+            if let Some(score) = best_match(&matcher, cmd, query) {
+                suggestions.push(Suggestion {
+                    label: cmd.name.to_string(),
+                    description: cmd.description.to_string(),
+                    category: cmd.category,
+                    aliases: cmd.aliases,
+                    shortcut: cmd.shortcut,
+                    score,
+                    execute_as: cmd.name.to_string(),
+                });
+            }
+        }
+
+        // Inject dynamic agent suggestions
+        for agent in agents {
+            let mut best: Option<i64> = None;
+            if let Some(s) = matcher.fuzzy_match(&agent.name, query) {
                 best = Some(s);
             }
-            for alias in cmd.aliases {
-                if let Some(s) = matcher.fuzzy_match(alias, query) {
-                    best = best.map_or(Some(s), |prev| Some(prev.max(s)));
-                }
-            }
-            if let Some(s) = matcher.fuzzy_match(cmd.description, query) {
+            if let Some(s) = matcher.fuzzy_match(&agent.id, query) {
                 best = best.map_or(Some(s), |prev| Some(prev.max(s)));
             }
+            // Also match "agent <name>" as a compound
+            let compound = format!("agent {}", agent.name);
+            if let Some(s) = matcher.fuzzy_match(&compound, query) {
+                best = best.map_or(Some(s), |prev| Some(prev.max(s)));
+            }
+            if let Some(score) = best {
+                suggestions.push(agent_suggestion(agent, score));
+            }
+        }
+    }
 
-            best.map(|score| ScoredCommand { index: i, score })
-        })
-        .collect();
+    suggestions.sort_by(|a, b| b.score.cmp(&a.score));
+    // Show more on empty input (initial palette open), but still cap for display
+    let limit = if query.is_empty() {
+        MAX_SUGGESTIONS_INITIAL
+    } else {
+        MAX_SUGGESTIONS
+    };
+    suggestions.truncate(limit);
+    suggestions
+}
 
-    scored.sort_by(|a, b| b.score.cmp(&a.score));
-    scored.truncate(MAX_SUGGESTIONS);
-    scored
+fn agent_suggestion(agent: &AgentState, score: i64) -> Suggestion {
+    let desc = match &agent.emoji {
+        Some(emoji) => format!("{emoji} Switch to {}", agent.name),
+        None => format!("Switch to {}", agent.name),
+    };
+    Suggestion {
+        label: format!("agent {}", agent.id),
+        description: desc,
+        category: CommandCategory::Agent,
+        aliases: &[],
+        shortcut: None,
+        score,
+        execute_as: format!("agent {}", agent.id),
+    }
+}
+
+fn best_match(matcher: &SkimMatcherV2, cmd: &Command, query: &str) -> Option<i64> {
+    let mut best: Option<i64> = None;
+
+    if let Some(s) = matcher.fuzzy_match(cmd.name, query) {
+        best = Some(s);
+    }
+    for alias in cmd.aliases {
+        if let Some(s) = matcher.fuzzy_match(alias, query) {
+            best = best.map_or(Some(s), |prev| Some(prev.max(s)));
+        }
+    }
+    if let Some(s) = matcher.fuzzy_match(cmd.description, query) {
+        best = best.map_or(Some(s), |prev| Some(prev.max(s)));
+    }
+
+    best
+}
+
+#[cfg(test)]
+fn filter_commands(input: &str) -> Vec<Suggestion> {
+    build_suggestions(input, &[])
 }
 
 #[cfg(test)]
@@ -147,28 +233,28 @@ mod tests {
     #[test]
     fn empty_input_returns_all_commands() {
         let results = filter_commands("");
-        assert_eq!(results.len(), COMMANDS.len());
+        assert!(results.len() >= COMMANDS.len());
     }
 
     #[test]
     fn exact_name_match_ranks_first() {
         let results = filter_commands("quit");
         assert!(!results.is_empty());
-        assert_eq!(COMMANDS[results[0].index].name, "quit");
+        assert_eq!(results[0].label, "quit");
     }
 
     #[test]
     fn alias_match_works() {
         let results = filter_commands("q");
         assert!(!results.is_empty());
-        assert!(results.iter().any(|r| COMMANDS[r.index].name == "quit"));
+        assert!(results.iter().any(|r| r.label == "quit"));
     }
 
     #[test]
     fn fuzzy_match_partial() {
         let results = filter_commands("sess");
         assert!(!results.is_empty());
-        assert_eq!(COMMANDS[results[0].index].name, "sessions");
+        assert_eq!(results[0].label, "sessions");
     }
 
     #[test]
@@ -181,6 +267,31 @@ mod tests {
     fn command_with_args_matches_command_only() {
         let results = filter_commands("agent syn");
         assert!(!results.is_empty());
-        assert!(results.iter().any(|r| COMMANDS[r.index].name == "agent"));
+        assert!(results.iter().any(|r| r.label == "agent"));
+    }
+
+    #[test]
+    fn dynamic_agents_appear_in_suggestions() {
+        let agents = vec![AgentState {
+            id: "syn".into(),
+            name: "Syn".into(),
+            emoji: Some("🧠".into()),
+            status: crate::state::AgentStatus::Idle,
+            active_tool: None,
+            tool_started_at: None,
+            sessions: Vec::new(),
+            model: Some("claude-opus-4-6".into()),
+            compaction_stage: None,
+            has_notification: false,
+        }];
+        let results = build_suggestions("syn", &agents);
+        assert!(results.iter().any(|r| r.execute_as == "agent syn"));
+    }
+
+    #[test]
+    fn shortcut_present_on_help() {
+        let results = filter_commands("help");
+        let help = results.iter().find(|r| r.label == "help").unwrap();
+        assert_eq!(help.shortcut, Some("F1"));
     }
 }

--- a/tui/src/state/agent.rs
+++ b/tui/src/state/agent.rs
@@ -17,6 +17,7 @@ pub struct AgentState {
     pub active_tool: Option<String>,
     pub tool_started_at: Option<std::time::Instant>,
     pub sessions: Vec<Session>,
+    pub model: Option<String>,
     pub compaction_stage: Option<String>,
     /// Indicates this agent completed a turn while not focused.
     /// Cleared when the user switches to this agent.

--- a/tui/src/state/command.rs
+++ b/tui/src/state/command.rs
@@ -3,7 +3,7 @@
 pub struct CommandPaletteState {
     pub input: String,
     pub cursor: usize,
-    pub suggestions: Vec<crate::command::ScoredCommand>,
+    pub suggestions: Vec<crate::command::Suggestion>,
     pub selected: usize,
     pub active: bool,
 }

--- a/tui/src/update/api.rs
+++ b/tui/src/update/api.rs
@@ -14,6 +14,7 @@ pub(crate) fn handle_agents_loaded(app: &mut App, agents: Vec<Agent>) {
             active_tool: None,
             tool_started_at: None,
             sessions: Vec::new(),
+            model: a.model,
             compaction_stage: None,
             has_notification: false,
         })

--- a/tui/src/update/command.rs
+++ b/tui/src/update/command.rs
@@ -1,4 +1,5 @@
 use crate::app::App;
+use crate::command::build_suggestions;
 use crate::msg::ErrorToast;
 use crate::state::Overlay;
 
@@ -7,7 +8,7 @@ pub fn handle_open(app: &mut App) {
     app.command_palette.input.clear();
     app.command_palette.cursor = 0;
     app.command_palette.selected = 0;
-    app.command_palette.suggestions = crate::command::filter_commands("");
+    app.command_palette.suggestions = build_suggestions("", &app.agents);
 }
 
 pub fn handle_close(app: &mut App) {
@@ -20,8 +21,7 @@ pub fn handle_input(app: &mut App, c: char) {
         .input
         .insert(app.command_palette.cursor, c);
     app.command_palette.cursor += c.len_utf8();
-    app.command_palette.suggestions =
-        crate::command::filter_commands(&app.command_palette.input);
+    refresh_suggestions(app);
     app.command_palette.selected = 0;
 }
 
@@ -29,8 +29,7 @@ pub fn handle_backspace(app: &mut App) {
     if app.command_palette.cursor > 0 {
         app.command_palette.cursor -= 1;
         app.command_palette.input.remove(app.command_palette.cursor);
-        app.command_palette.suggestions =
-            crate::command::filter_commands(&app.command_palette.input);
+        refresh_suggestions(app);
         app.command_palette.selected = 0;
     } else {
         // Backspace on empty input closes palette (vim behavior)
@@ -48,8 +47,7 @@ pub fn handle_delete_word(app: &mut App) {
     }
     app.command_palette.input.drain(pos..app.command_palette.cursor);
     app.command_palette.cursor = pos;
-    app.command_palette.suggestions =
-        crate::command::filter_commands(&app.command_palette.input);
+    refresh_suggestions(app);
     app.command_palette.selected = 0;
 }
 
@@ -63,27 +61,57 @@ pub fn handle_down(app: &mut App) {
 }
 
 pub fn handle_tab(app: &mut App) {
-    if let Some(scored) = app
+    if let Some(suggestion) = app
         .command_palette
         .suggestions
         .get(app.command_palette.selected)
     {
-        let cmd = &crate::command::COMMANDS[scored.index];
+        let base = suggestion.execute_as.clone();
         let args = app
             .command_palette
             .input
             .split_once(' ')
             .map(|(_, a)| format!(" {a}"))
             .unwrap_or_default();
-        app.command_palette.input = format!("{}{}", cmd.name, args);
-        app.command_palette.cursor = cmd.name.len();
-        app.command_palette.suggestions =
-            crate::command::filter_commands(&app.command_palette.input);
+        app.command_palette.input = format!("{base}{args}");
+        app.command_palette.cursor = base.len();
+        refresh_suggestions(app);
     }
 }
 
 pub async fn handle_select(app: &mut App) {
+    // Resolve to the selected suggestion before executing
+    if let Some(suggestion) = app
+        .command_palette
+        .suggestions
+        .get(app.command_palette.selected)
+    {
+        let execute_as = suggestion.execute_as.clone();
+        let extra_args = app
+            .command_palette
+            .input
+            .split_once(' ')
+            .map(|(_, a)| a.trim().to_string())
+            .unwrap_or_default();
+
+        if extra_args.is_empty() {
+            app.command_palette.input = execute_as;
+        } else {
+            // Preserve typed args (e.g., user typed "agent sy" but suggestion is "agent")
+            let suggestion_has_args = execute_as.contains(' ');
+            if suggestion_has_args {
+                app.command_palette.input = execute_as;
+            } else {
+                app.command_palette.input = format!("{execute_as} {extra_args}");
+            }
+        }
+    }
     execute_command(app).await;
+}
+
+fn refresh_suggestions(app: &mut App) {
+    app.command_palette.suggestions =
+        build_suggestions(&app.command_palette.input, &app.agents);
 }
 
 async fn execute_command(app: &mut App) {
@@ -142,25 +170,85 @@ async fn execute_command(app: &mut App) {
             app.scroll_to_bottom();
         }
         "compact" => {
-            app.error_toast =
-                Some(ErrorToast::new("Compact not yet available via TUI".into()));
+            execute_compact(app).await;
         }
         "recall" | "r" => {
             if args.is_empty() {
                 app.error_toast =
                     Some(ErrorToast::new("Usage: :recall <query>".into()));
             } else {
-                app.error_toast =
-                    Some(ErrorToast::new(format!("Recall not yet available: {args}")));
+                execute_recall(app, args).await;
             }
         }
         "model" => {
-            app.error_toast =
-                Some(ErrorToast::new("Model info not yet available".into()));
+            execute_model(app);
         }
         _ => {
             app.error_toast =
                 Some(ErrorToast::new(format!("Unknown command: {cmd_name}")));
+        }
+    }
+}
+
+fn execute_model(app: &mut App) {
+    let agent = app.focused_agent.as_ref().and_then(|id| {
+        app.agents.iter().find(|a| &a.id == id)
+    });
+
+    match agent {
+        Some(agent) => {
+            let model = agent.model.as_deref().unwrap_or("unknown");
+            let name = &agent.name;
+            app.error_toast = Some(ErrorToast::new(format!("{name}: {model}")));
+        }
+        None => {
+            app.error_toast = Some(ErrorToast::new("No agent focused".into()));
+        }
+    }
+}
+
+async fn execute_compact(app: &mut App) {
+    let session_id = match &app.focused_session_id {
+        Some(id) => id.clone(),
+        None => {
+            app.error_toast = Some(ErrorToast::new("No active session to compact".into()));
+            return;
+        }
+    };
+
+    let client = app.client.clone();
+    match client.compact(&session_id).await {
+        Ok(()) => {
+            app.error_toast = Some(ErrorToast::new("Distillation triggered".into()));
+        }
+        Err(e) => {
+            app.error_toast = Some(ErrorToast::new(format!("Compact failed: {e}")));
+        }
+    }
+}
+
+async fn execute_recall(app: &mut App, query: &str) {
+    let nous_id = match &app.focused_agent {
+        Some(id) => id.clone(),
+        None => {
+            app.error_toast = Some(ErrorToast::new("No agent focused for recall".into()));
+            return;
+        }
+    };
+
+    let client = app.client.clone();
+    let query = query.to_string();
+    match client.recall(&nous_id, &query).await {
+        Ok(result) => {
+            let display = if result.len() > 200 {
+                format!("{}...", &result[..200])
+            } else {
+                result
+            };
+            app.error_toast = Some(ErrorToast::new(display));
+        }
+        Err(e) => {
+            app.error_toast = Some(ErrorToast::new(format!("Recall failed: {e}")));
         }
     }
 }

--- a/tui/src/update/sse.rs
+++ b/tui/src/update/sse.rs
@@ -29,6 +29,7 @@ pub(crate) async fn handle_sse_connected(app: &mut App) {
                         active_tool: None,
                         tool_started_at: None,
                         sessions: Vec::new(),
+                        model: a.model,
                         compaction_stage: None,
                         has_notification: notif,
                     }

--- a/tui/src/view/command_palette.rs
+++ b/tui/src/view/command_palette.rs
@@ -5,7 +5,7 @@ use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Paragraph};
 
 use crate::app::App;
-use crate::command::{CommandCategory, COMMANDS};
+use crate::command::CommandCategory;
 use crate::theme::ThemePalette;
 
 pub fn render(app: &App, frame: &mut Frame, area: Rect, theme: &ThemePalette) {
@@ -28,8 +28,7 @@ pub fn render(app: &App, frame: &mut Frame, area: Rect, theme: &ThemePalette) {
     ]));
 
     // Suggestion lines (max 8)
-    for (i, scored) in palette.suggestions.iter().enumerate().take(8) {
-        let cmd = &COMMANDS[scored.index];
+    for (i, suggestion) in palette.suggestions.iter().enumerate() {
         let selected = i == palette.selected;
         let marker = if selected { "▸" } else { " " };
 
@@ -41,7 +40,7 @@ pub fn render(app: &App, frame: &mut Frame, area: Rect, theme: &ThemePalette) {
             theme.style_fg()
         };
 
-        let category_color = match cmd.category {
+        let category_color = match suggestion.category {
             CommandCategory::Navigation => theme.accent,
             CommandCategory::Action => theme.warning,
             CommandCategory::Query => theme.success,
@@ -58,12 +57,16 @@ pub fn render(app: &App, frame: &mut Frame, area: Rect, theme: &ThemePalette) {
                 },
             ),
             Span::styled("●", Style::default().fg(category_color)),
-            Span::styled(format!(" {:<12}", cmd.name), name_style),
-            Span::styled(cmd.description, theme.style_muted()),
+            Span::styled(format!(" {:<12}", suggestion.label), name_style),
+            Span::styled(&suggestion.description, theme.style_muted()),
         ];
 
-        if !cmd.aliases.is_empty() {
-            let alias_str = cmd
+        if let Some(shortcut) = suggestion.shortcut {
+            spans.push(Span::styled(format!("  [{shortcut}]"), theme.style_dim()));
+        }
+
+        if !suggestion.aliases.is_empty() {
+            let alias_str = suggestion
                 .aliases
                 .iter()
                 .map(|a| format!(":{a}"))

--- a/tui/src/view/mod.rs
+++ b/tui/src/view/mod.rs
@@ -20,7 +20,7 @@ pub fn render(app: &App, frame: &mut Frame) {
 
     // When palette is active, it replaces the status bar with a variable-height area
     let bottom_height = if palette_active {
-        let suggestion_lines = app.command_palette.suggestions.len().min(8) as u16;
+        let suggestion_lines = app.command_palette.suggestions.len().min(12) as u16;
         (2 + suggestion_lines).max(3) // input + border + suggestions, min 3
     } else {
         2 // 2-line status bar


### PR DESCRIPTION
## Summary

- **Dynamic agent commands**: typing partial agent names in `:` palette now shows per-agent suggestions (`agent syn`, `agent demiurge`) injected from the live agent list with emoji-prefixed descriptions
- **Keyboard shortcut hints**: commands with keybindings show `[F1]`, `[Ctrl+A]`, etc. in dim brackets beside each suggestion
- **Live command wiring**: `:model` shows focused agent's model, `:compact` triggers distillation via API, `:recall <query>` searches memory graph via API
- **Enter-executes-selection fix**: Enter now executes the selected suggestion (not raw partial input), so typing `sess` + Enter correctly runs `sessions`

## Changes

| File | What |
|------|------|
| `command/mod.rs` | `Suggestion` type replaces `ScoredCommand`, `build_suggestions()` merges static + dynamic agents |
| `state/command.rs` | Type update for suggestions field |
| `state/agent.rs` | Add `model: Option<String>` field |
| `update/command.rs` | All handlers use `build_suggestions`, implement `:model`/`:compact`/`:recall` |
| `view/command_palette.rs` | Render from Suggestion fields, show shortcut hints |
| `api/client.rs` | Add `compact()` and `recall()` API methods |
| `app.rs`, `update/api.rs`, `update/sse.rs` | Wire `model` field through AgentState constructors |

## Test plan

- [x] `cargo check` — compiles clean
- [x] `cargo test` — 8 tests pass (including 2 new: `dynamic_agents_appear_in_suggestions`, `shortcut_present_on_help`)
- [ ] Visual: launch TUI, press `:`, verify agent names appear, shortcut hints show, Enter on partial match works