### PR TITLE
feat(hermeneus): Anthropic API parity — caching, counting, tool_choice, citations, batch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,6 +56,7 @@ dependencies = [
  "anyhow",
  "axum",
  "clap",
+ "jiff",
  "owo-colors",
  "rcgen",
  "reqwest",
@@ -66,6 +67,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "ulid",
 ]
 
 [[package]]
@@ -138,6 +140,7 @@ dependencies = [
 name = "aletheia-integration-tests"
 version = "0.10.0"
 dependencies = [
+ "aletheia-dokimion",
  "aletheia-hermeneus",
  "aletheia-koina",
  "aletheia-mneme",

--- a/crates/agora/src/semeion/connection.rs
+++ b/crates/agora/src/semeion/connection.rs
@@ -68,10 +68,7 @@ impl AccountState {
 
     /// Drain all buffered messages in FIFO order.
     pub fn drain_all(&mut self) -> Vec<client::SendParams> {
-        self.buffer
-            .drain(..)
-            .map(|bm| bm.params)
-            .collect()
+        self.buffer.drain(..).map(|bm| bm.params).collect()
     }
 
     /// Number of messages currently buffered.

--- a/crates/agora/src/semeion/mod.rs
+++ b/crates/agora/src/semeion/mod.rs
@@ -164,10 +164,7 @@ impl SignalProvider {
             .map(|(k, v)| (k.as_str(), v))
     }
 
-    fn build_send_params(
-        account: &str,
-        params: &ChannelSendParams,
-    ) -> client::SendParams {
+    fn build_send_params(account: &str, params: &ChannelSendParams) -> client::SendParams {
         let target = parse_target(&params.to);
         match target {
             SignalTarget::Phone(ref phone) => client::SendParams {
@@ -305,8 +302,7 @@ impl ChannelProvider for SignalProvider {
                     );
                 }
 
-                account_results
-                    .insert(account_id.clone(), serde_json::Value::Object(detail));
+                account_results.insert(account_id.clone(), serde_json::Value::Object(detail));
             }
 
             ProbeResult {

--- a/crates/aletheia/src/daemon_bridge.rs
+++ b/crates/aletheia/src/daemon_bridge.rs
@@ -4,9 +4,9 @@ use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
 
+use aletheia_nous::manager::NousManager;
 use aletheia_oikonomos::bridge::DaemonBridge;
 use aletheia_oikonomos::runner::ExecutionResult;
-use aletheia_nous::manager::NousManager;
 
 pub(crate) struct NousDaemonBridge {
     nous_manager: Arc<NousManager>,

--- a/crates/aletheia/src/main.rs
+++ b/crates/aletheia/src/main.rs
@@ -241,7 +241,16 @@ async fn main() -> Result<()> {
             archived,
             max_messages,
             compact,
-        }) => return export_agent_cmd(&cli, nous_id, output.as_ref(), *archived, *max_messages, *compact),
+        }) => {
+            return export_agent_cmd(
+                &cli,
+                nous_id,
+                output.as_ref(),
+                *archived,
+                *max_messages,
+                *compact,
+            );
+        }
         Some(Command::Import {
             file,
             target_id,
@@ -249,7 +258,17 @@ async fn main() -> Result<()> {
             skip_workspace,
             force,
             dry_run,
-        }) => return import_agent_cmd(&cli, file, target_id.as_deref(), *skip_sessions, *skip_workspace, *force, *dry_run),
+        }) => {
+            return import_agent_cmd(
+                &cli,
+                file,
+                target_id.as_deref(),
+                *skip_sessions,
+                *skip_workspace,
+                *force,
+                *dry_run,
+            );
+        }
         None => {}
     }
 
@@ -1118,7 +1137,11 @@ fn import_agent_cmd(
 
     if dry_run {
         println!("Dry run — no changes will be made\n");
-        println!("Agent: {} ({})", nous_id, agent_file.nous.name.as_deref().unwrap_or("unnamed"));
+        println!(
+            "Agent: {} ({})",
+            nous_id,
+            agent_file.nous.name.as_deref().unwrap_or("unnamed")
+        );
         println!("Generator: {}", agent_file.generator);
         println!("Exported at: {}", agent_file.exported_at);
         println!(
@@ -1163,14 +1186,9 @@ fn import_agent_cmd(
         force,
     };
     let id_gen = || ulid::Ulid::new().to_string();
-    let result = aletheia_mneme::import::import_agent(
-        &agent_file,
-        &store,
-        &workspace_path,
-        &id_gen,
-        &opts,
-    )
-    .context("import failed")?;
+    let result =
+        aletheia_mneme::import::import_agent(&agent_file, &store, &workspace_path, &id_gen, &opts)
+            .context("import failed")?;
 
     println!("Imported agent: {}", result.nous_id);
     println!("Files restored: {}", result.files_restored);
@@ -1282,7 +1300,10 @@ mod tests {
                 assert_eq!(timeout, 60);
             }
             _ => panic!("expected Eval command"),
+        }
+    }
 
+    #[test]
     fn export_subcommand_parses() {
         let cli = Cli::parse_from(["aletheia", "export", "syn", "--archived", "--compact"]);
         match cli.command {

--- a/crates/aletheia/src/status.rs
+++ b/crates/aletheia/src/status.rs
@@ -75,17 +75,13 @@ struct NousInfo {
 
 async fn fetch_health(url: &str) -> Result<HealthResponse> {
     let endpoint = format!("{url}/api/health");
-    let resp = reqwest::get(&endpoint)
-        .await
-        .context("failed to connect")?;
+    let resp = reqwest::get(&endpoint).await.context("failed to connect")?;
     resp.json().await.context("failed to parse health response")
 }
 
 async fn fetch_nous(url: &str) -> Result<Vec<NousInfo>> {
     let endpoint = format!("{url}/api/v1/nous");
-    let resp = reqwest::get(&endpoint)
-        .await
-        .context("failed to connect")?;
+    let resp = reqwest::get(&endpoint).await.context("failed to connect")?;
     resp.json().await.context("failed to parse nous response")
 }
 
@@ -263,7 +259,10 @@ pub fn format_bytes(bytes: u64) -> String {
         return "0 B".to_owned();
     }
     let units = ["B", "KB", "MB", "GB", "TB"];
-    #[expect(clippy::cast_precision_loss, reason = "file sizes fit comfortably in f64 mantissa")]
+    #[expect(
+        clippy::cast_precision_loss,
+        reason = "file sizes fit comfortably in f64 mantissa"
+    )]
     let mut size = bytes as f64;
     let mut unit_idx = 0;
     while size >= 1024.0 && unit_idx < units.len() - 1 {

--- a/crates/hermeneus/src/anthropic/batch.rs
+++ b/crates/hermeneus/src/anthropic/batch.rs
@@ -1,0 +1,130 @@
+//! Batch API types for the Anthropic Messages Batches endpoint.
+
+use serde::{Deserialize, Serialize};
+
+/// A batch request — multiple messages requests submitted together.
+#[derive(Debug, Clone, Serialize)]
+pub struct BatchRequest {
+    pub requests: Vec<BatchItem>,
+}
+
+/// A single item in a batch request.
+#[derive(Debug, Clone, Serialize)]
+pub struct BatchItem {
+    pub custom_id: String,
+    /// Pre-serialized request body (`WireRequest` borrows and can't be stored).
+    pub params: serde_json::Value,
+}
+
+/// Response from batch creation.
+#[derive(Debug, Clone, Deserialize)]
+pub struct BatchResponse {
+    pub id: String,
+    pub processing_status: String,
+    pub request_counts: BatchRequestCounts,
+    pub results_url: Option<String>,
+}
+
+/// Counts of requests in various states.
+#[derive(Debug, Clone, Deserialize)]
+pub struct BatchRequestCounts {
+    pub processing: u32,
+    pub succeeded: u32,
+    pub errored: u32,
+    pub canceled: u32,
+    pub expired: u32,
+}
+
+/// A single result from a completed batch.
+#[derive(Debug, Clone, Deserialize)]
+pub struct BatchResult {
+    pub custom_id: String,
+    pub result: BatchResultType,
+}
+
+/// Result type for a batch item.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(tag = "type")]
+pub enum BatchResultType {
+    #[serde(rename = "succeeded")]
+    Succeeded { message: serde_json::Value },
+    #[serde(rename = "errored")]
+    Errored { error: BatchError },
+}
+
+/// Error detail for a failed batch item.
+#[derive(Debug, Clone, Deserialize)]
+pub struct BatchError {
+    #[serde(rename = "type")]
+    pub error_type: String,
+    pub message: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn batch_request_serializes() {
+        let req = BatchRequest {
+            requests: vec![BatchItem {
+                custom_id: "req-1".to_owned(),
+                params: serde_json::json!({"model": "claude-opus-4-20250514", "max_tokens": 100}),
+            }],
+        };
+        let json = serde_json::to_value(&req).unwrap();
+        assert_eq!(json["requests"][0]["custom_id"], "req-1");
+    }
+
+    #[test]
+    fn batch_response_deserializes() {
+        let json = r#"{
+            "id": "batch_123",
+            "processing_status": "in_progress",
+            "request_counts": {
+                "processing": 5,
+                "succeeded": 3,
+                "errored": 1,
+                "canceled": 0,
+                "expired": 0
+            },
+            "results_url": null
+        }"#;
+        let resp: BatchResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.id, "batch_123");
+        assert_eq!(resp.request_counts.succeeded, 3);
+    }
+
+    #[test]
+    fn batch_result_succeeded_deserializes() {
+        let json = r#"{
+            "custom_id": "req-1",
+            "result": {
+                "type": "succeeded",
+                "message": {"id": "msg_1", "content": []}
+            }
+        }"#;
+        let result: BatchResult = serde_json::from_str(json).unwrap();
+        assert_eq!(result.custom_id, "req-1");
+        assert!(matches!(result.result, BatchResultType::Succeeded { .. }));
+    }
+
+    #[test]
+    fn batch_result_errored_deserializes() {
+        let json = r#"{
+            "custom_id": "req-2",
+            "result": {
+                "type": "errored",
+                "error": {"type": "invalid_request_error", "message": "bad input"}
+            }
+        }"#;
+        let result: BatchResult = serde_json::from_str(json).unwrap();
+        assert_eq!(result.custom_id, "req-2");
+        match result.result {
+            BatchResultType::Errored { error } => {
+                assert_eq!(error.message, "bad input");
+            }
+            BatchResultType::Succeeded { .. } => panic!("expected Errored"),
+        }
+    }
+}

--- a/crates/hermeneus/src/anthropic/client.rs
+++ b/crates/hermeneus/src/anthropic/client.rs
@@ -13,7 +13,7 @@ use std::collections::HashMap;
 
 use crate::error::{self, Result};
 use crate::provider::{LlmProvider, ModelPricing, ProviderConfig};
-use crate::types::{CompletionRequest, CompletionResponse};
+use crate::types::{CompletionRequest, CompletionResponse, TokenCount};
 use aletheia_koina::credential::{CredentialProvider, CredentialSource};
 
 use super::stream::{StreamAccumulator, StreamEvent, parse_sse_stream};
@@ -329,6 +329,48 @@ impl AnthropicProvider {
         }))
     }
 
+    /// Count tokens for a request via the Anthropic `count_tokens` endpoint.
+    pub fn count_tokens_request(&self, request: &CompletionRequest) -> Result<TokenCount> {
+        #[derive(serde::Deserialize)]
+        struct CountResponse {
+            input_tokens: u64,
+        }
+
+        let wire = WireRequest::from_request(request, None);
+        let body = serde_json::to_string(&wire).context(error::ParseResponseSnafu)?;
+        let headers = self.build_headers()?;
+
+        let response = self
+            .client
+            .post(format!("{}/v1/messages/count_tokens", self.base_url))
+            .headers(headers)
+            .body(body)
+            .send()
+            .map_err(|e| {
+                error::ApiRequestSnafu {
+                    message: format!("count_tokens request failed: {e}"),
+                }
+                .build()
+            })?;
+
+        if !response.status().is_success() {
+            return Err(super::error::map_error_response(response));
+        }
+
+        let text = response.text().map_err(|e| {
+            error::ApiRequestSnafu {
+                message: format!("failed to read count_tokens response: {e}"),
+            }
+            .build()
+        })?;
+
+        let parsed: CountResponse =
+            serde_json::from_str(&text).context(error::ParseResponseSnafu)?;
+        Ok(TokenCount {
+            input_tokens: parsed.input_tokens,
+        })
+    }
+
     fn build_headers(&self) -> Result<HeaderMap> {
         let credential = self.credential_provider.get_credential().ok_or_else(|| {
             error::AuthFailedSnafu {
@@ -508,6 +550,18 @@ impl LlmProvider for AnthropicProvider {
     fn name(&self) -> &str {
         "anthropic"
     }
+
+    fn count_tokens(&self, request: &CompletionRequest) -> Result<Option<TokenCount>> {
+        self.count_tokens_request(request).map(Some)
+    }
+
+    fn supports_caching(&self) -> bool {
+        true
+    }
+
+    fn supports_citations(&self) -> bool {
+        true
+    }
 }
 
 /// Estimate cost using config-based pricing, falling back to hardcoded defaults.
@@ -616,6 +670,7 @@ mod tests {
             temperature: None,
             thinking: None,
             stop_sequences: vec![],
+            ..Default::default()
         }
     }
 

--- a/crates/hermeneus/src/anthropic/mod.rs
+++ b/crates/hermeneus/src/anthropic/mod.rs
@@ -4,6 +4,7 @@
 //! and error classification. Re-exports `AnthropicProvider` and `StreamEvent`
 //! as the public surface.
 
+pub mod batch;
 mod client;
 pub(crate) mod error;
 pub(crate) mod stream;

--- a/crates/hermeneus/src/anthropic/stream.rs
+++ b/crates/hermeneus/src/anthropic/stream.rs
@@ -67,7 +67,10 @@ enum BlockBuilder {
         name: String,
         input_json: String,
     },
-    Thinking(String),
+    Thinking {
+        text: String,
+        signature: String,
+    },
 }
 
 impl StreamAccumulator {
@@ -86,6 +89,7 @@ impl StreamAccumulator {
 
     /// Process an SSE event, emitting `StreamEvent`s via the callback.
     /// Returns `Err` if the stream contains an error event.
+    #[expect(clippy::too_many_lines, reason = "SSE event dispatch is inherently branchy")]
     pub(crate) fn process_event(
         &mut self,
         event: WireStreamEvent,
@@ -122,9 +126,10 @@ impl StreamAccumulator {
                         name,
                         input_json: String::new(),
                     },
-                    WireContentBlockStart::Thinking { thinking } => {
-                        BlockBuilder::Thinking(thinking)
-                    }
+                    WireContentBlockStart::Thinking { thinking } => BlockBuilder::Thinking {
+                        text: thinking,
+                        signature: String::new(),
+                    },
                 };
                 // Ensure the blocks vec is large enough.
                 let idx = index as usize;
@@ -153,10 +158,22 @@ impl StreamAccumulator {
                             on_event(StreamEvent::InputJsonDelta { partial_json });
                         }
                         WireDelta::ThinkingDelta { thinking } => {
-                            if let BlockBuilder::Thinking(ref mut buf) = self.blocks[idx] {
+                            if let BlockBuilder::Thinking {
+                                text: ref mut buf, ..
+                            } = self.blocks[idx]
+                            {
                                 buf.push_str(&thinking);
                             }
                             on_event(StreamEvent::ThinkingDelta { thinking });
+                        }
+                        WireDelta::SignatureDelta { signature } => {
+                            if let BlockBuilder::Thinking {
+                                signature: ref mut buf,
+                                ..
+                            } = self.blocks[idx]
+                            {
+                                buf.push_str(&signature);
+                            }
                         }
                     }
                 }
@@ -194,7 +211,10 @@ impl StreamAccumulator {
             .blocks
             .into_iter()
             .map(|b| match b {
-                BlockBuilder::Text(text) => ContentBlock::Text { text },
+                BlockBuilder::Text(text) => ContentBlock::Text {
+                    text,
+                    citations: None,
+                },
                 BlockBuilder::ToolUse {
                     id,
                     name,
@@ -203,7 +223,14 @@ impl StreamAccumulator {
                     let input = serde_json::from_str(&input_json).unwrap_or_default();
                     ContentBlock::ToolUse { id, name, input }
                 }
-                BlockBuilder::Thinking(thinking) => ContentBlock::Thinking { thinking },
+                BlockBuilder::Thinking { text, signature } => ContentBlock::Thinking {
+                    thinking: text,
+                    signature: if signature.is_empty() {
+                        None
+                    } else {
+                        Some(signature)
+                    },
+                },
             })
             .collect();
 
@@ -338,7 +365,7 @@ data: {\"type\":\"message_stop\"}\n\
         assert_eq!(response.stop_reason, StopReason::EndTurn);
         assert_eq!(response.content.len(), 1);
         match &response.content[0] {
-            ContentBlock::Text { text } => assert_eq!(text, "Hello world"),
+            ContentBlock::Text { text, .. } => assert_eq!(text, "Hello world"),
             _ => panic!("expected Text block"),
         }
     }
@@ -416,13 +443,13 @@ data: {\"type\":\"message_stop\"}\n\
 
         assert_eq!(response.content.len(), 2);
         match &response.content[0] {
-            ContentBlock::Thinking { thinking } => {
+            ContentBlock::Thinking { thinking, .. } => {
                 assert_eq!(thinking, "Let me think about this.");
             }
             _ => panic!("expected Thinking block"),
         }
         match &response.content[1] {
-            ContentBlock::Text { text } => assert_eq!(text, "The answer is 42."),
+            ContentBlock::Text { text, .. } => assert_eq!(text, "The answer is 42."),
             _ => panic!("expected Text block"),
         }
     }

--- a/crates/hermeneus/src/anthropic/wire.rs
+++ b/crates/hermeneus/src/anthropic/wire.rs
@@ -3,8 +3,8 @@
 use serde::{Deserialize, Serialize};
 
 use crate::types::{
-    CompletionRequest, CompletionResponse, Content, ContentBlock, Role, StopReason, ThinkingConfig,
-    Usage,
+    CacheControl, CompletionRequest, CompletionResponse, Content, ContentBlock, Role, StopReason,
+    ThinkingConfig, ToolChoice, Usage,
 };
 
 // ---------------------------------------------------------------------------
@@ -17,7 +17,7 @@ pub(crate) struct WireRequest<'a> {
     pub max_tokens: u32,
     pub messages: Vec<WireMessage<'a>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub system: Option<String>,
+    pub system: Option<serde_json::Value>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub tools: Vec<WireTool<'a>>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -28,6 +28,12 @@ pub(crate) struct WireRequest<'a> {
     pub thinking: Option<WireThinkingConfig>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub stream: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_choice: Option<&'a ToolChoice>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<&'a crate::types::RequestMetadata>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub citations: Option<&'a crate::types::CitationConfig>,
 }
 
 #[derive(Debug, Serialize)]
@@ -41,6 +47,8 @@ pub(crate) struct WireTool<'a> {
     pub name: &'a str,
     pub description: &'a str,
     pub input_schema: &'a serde_json::Value,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cache_control: Option<CacheControl>,
 }
 
 #[derive(Debug, Serialize)]
@@ -81,7 +89,11 @@ pub(crate) struct WireUsage {
 #[serde(tag = "type")]
 pub(crate) enum WireContentBlock {
     #[serde(rename = "text")]
-    Text { text: String },
+    Text {
+        text: String,
+        #[serde(default)]
+        citations: Option<Vec<crate::types::Citation>>,
+    },
     #[serde(rename = "tool_use")]
     ToolUse {
         id: String,
@@ -89,14 +101,7 @@ pub(crate) enum WireContentBlock {
         input: serde_json::Value,
     },
     #[serde(rename = "thinking")]
-    Thinking {
-        thinking: String,
-        #[expect(
-            dead_code,
-            reason = "captured from API but not exposed in public types until M2"
-        )]
-        signature: String,
-    },
+    Thinking { thinking: String, signature: String },
 }
 
 // ---------------------------------------------------------------------------
@@ -122,7 +127,7 @@ pub(crate) struct WireErrorDetail {
 impl<'a> WireRequest<'a> {
     pub(crate) fn from_request(req: &'a CompletionRequest, stream: Option<bool>) -> Self {
         // Extract system prompt from messages (Anthropic wants it as a top-level field).
-        let system = req.system.clone().or_else(|| {
+        let system_text = req.system.clone().or_else(|| {
             let system_texts: Vec<&str> = req
                 .messages
                 .iter()
@@ -140,6 +145,19 @@ impl<'a> WireRequest<'a> {
             }
         });
 
+        // When caching, serialize system as array with cache_control on last block.
+        let system = system_text.map(|text| {
+            if req.cache_system {
+                serde_json::json!([{
+                    "type": "text",
+                    "text": text,
+                    "cache_control": {"type": "ephemeral"}
+                }])
+            } else {
+                serde_json::Value::String(text)
+            }
+        });
+
         let messages: Vec<WireMessage<'a>> = req
             .messages
             .iter()
@@ -150,13 +168,23 @@ impl<'a> WireRequest<'a> {
             })
             .collect();
 
+        let tool_count = req.tools.len();
         let tools: Vec<WireTool<'a>> = req
             .tools
             .iter()
-            .map(|t| WireTool {
-                name: &t.name,
-                description: &t.description,
-                input_schema: &t.input_schema,
+            .enumerate()
+            .map(|(i, t)| {
+                let cache_control = if req.cache_tools && i == tool_count - 1 {
+                    Some(CacheControl::ephemeral())
+                } else {
+                    None
+                };
+                WireTool {
+                    name: &t.name,
+                    description: &t.description,
+                    input_schema: &t.input_schema,
+                    cache_control,
+                }
             })
             .collect();
 
@@ -180,6 +208,9 @@ impl<'a> WireRequest<'a> {
             stop_sequences,
             thinking,
             stream,
+            tool_choice: req.tool_choice.as_ref(),
+            metadata: req.metadata.as_ref(),
+            citations: req.citations.as_ref(),
         }
     }
 }
@@ -216,12 +247,15 @@ impl WireResponse {
 impl WireContentBlock {
     fn into_content_block(self) -> ContentBlock {
         match self {
-            Self::Text { text } => ContentBlock::Text { text },
+            Self::Text { text, citations } => ContentBlock::Text { text, citations },
             Self::ToolUse { id, name, input } => ContentBlock::ToolUse { id, name, input },
             Self::Thinking {
                 thinking,
-                signature: _,
-            } => ContentBlock::Thinking { thinking },
+                signature,
+            } => ContentBlock::Thinking {
+                thinking,
+                signature: Some(signature),
+            },
         }
     }
 }
@@ -309,6 +343,8 @@ pub(crate) enum WireDelta {
     InputJsonDelta { partial_json: String },
     #[serde(rename = "thinking_delta")]
     ThinkingDelta { thinking: String },
+    #[serde(rename = "signature_delta")]
+    SignatureDelta { signature: String },
 }
 
 #[derive(Debug, Deserialize)]
@@ -386,7 +422,7 @@ mod tests {
         let block: WireContentBlock = serde_json::from_str(json).unwrap();
         let converted = block.into_content_block();
         match converted {
-            ContentBlock::Thinking { thinking } => {
+            ContentBlock::Thinking { thinking, .. } => {
                 assert_eq!(thinking, "let me think");
             }
             _ => panic!("expected Thinking"),
@@ -417,9 +453,13 @@ mod tests {
             temperature: None,
             thinking: None,
             stop_sequences: vec![],
+            ..Default::default()
         };
         let wire = WireRequest::from_request(&req, None);
-        assert_eq!(wire.system.as_deref(), Some("You are helpful."));
+        assert_eq!(
+            wire.system,
+            Some(serde_json::Value::String("You are helpful.".to_owned()))
+        );
         assert_eq!(wire.messages.len(), 1);
         assert_eq!(wire.messages[0].role, "user");
     }
@@ -444,9 +484,13 @@ mod tests {
             temperature: None,
             thinking: None,
             stop_sequences: vec![],
+            ..Default::default()
         };
         let wire = WireRequest::from_request(&req, None);
-        assert_eq!(wire.system.as_deref(), Some("Be concise."));
+        assert_eq!(
+            wire.system,
+            Some(serde_json::Value::String("Be concise.".to_owned()))
+        );
         // System messages must not appear in the messages array
         assert_eq!(wire.messages.len(), 1);
     }
@@ -468,6 +512,7 @@ mod tests {
                 budget_tokens: 8192,
             }),
             stop_sequences: vec![],
+            ..Default::default()
         };
         let wire = WireRequest::from_request(&req, None);
         let json = serde_json::to_value(&wire).unwrap();
@@ -500,6 +545,7 @@ mod tests {
             temperature: None,
             thinking: None,
             stop_sequences: vec![],
+            ..Default::default()
         };
         let wire = WireRequest::from_request(&req, None);
         let json = serde_json::to_value(&wire).unwrap();
@@ -549,5 +595,214 @@ mod tests {
             StopReason::StopSequence
         );
         assert!(parse_stop_reason("unknown").is_err());
+    }
+
+    #[test]
+    fn wire_request_cache_system_serializes_as_array() {
+        let req = CompletionRequest {
+            model: "claude-opus-4-20250514".to_owned(),
+            system: Some("You are helpful.".to_owned()),
+            messages: vec![Message {
+                role: Role::User,
+                content: Content::Text("hello".to_owned()),
+            }],
+            max_tokens: 1024,
+            cache_system: true,
+            ..Default::default()
+        };
+        let wire = WireRequest::from_request(&req, None);
+        let json = serde_json::to_value(&wire).unwrap();
+        let system = json["system"].as_array().unwrap();
+        assert_eq!(system.len(), 1);
+        assert_eq!(system[0]["type"], "text");
+        assert_eq!(system[0]["text"], "You are helpful.");
+        assert_eq!(system[0]["cache_control"]["type"], "ephemeral");
+    }
+
+    #[test]
+    fn wire_request_cache_tools_on_last_tool() {
+        let req = CompletionRequest {
+            model: "claude-opus-4-20250514".to_owned(),
+            messages: vec![Message {
+                role: Role::User,
+                content: Content::Text("run".to_owned()),
+            }],
+            max_tokens: 1024,
+            tools: vec![
+                ToolDefinition {
+                    name: "a".to_owned(),
+                    description: "first".to_owned(),
+                    input_schema: serde_json::json!({}),
+                },
+                ToolDefinition {
+                    name: "b".to_owned(),
+                    description: "second".to_owned(),
+                    input_schema: serde_json::json!({}),
+                },
+            ],
+            cache_tools: true,
+            ..Default::default()
+        };
+        let wire = WireRequest::from_request(&req, None);
+        let json = serde_json::to_value(&wire).unwrap();
+        let tools = json["tools"].as_array().unwrap();
+        assert!(tools[0].get("cache_control").is_none());
+        assert_eq!(tools[1]["cache_control"]["type"], "ephemeral");
+    }
+
+    #[test]
+    fn wire_request_tool_choice_auto() {
+        let req = CompletionRequest {
+            model: "claude-opus-4-20250514".to_owned(),
+            messages: vec![Message {
+                role: Role::User,
+                content: Content::Text("hi".to_owned()),
+            }],
+            max_tokens: 1024,
+            tool_choice: Some(crate::types::ToolChoice::Auto),
+            ..Default::default()
+        };
+        let wire = WireRequest::from_request(&req, None);
+        let json = serde_json::to_value(&wire).unwrap();
+        assert_eq!(json["tool_choice"]["type"], "auto");
+    }
+
+    #[test]
+    fn wire_request_tool_choice_specific_tool() {
+        let req = CompletionRequest {
+            model: "claude-opus-4-20250514".to_owned(),
+            messages: vec![Message {
+                role: Role::User,
+                content: Content::Text("hi".to_owned()),
+            }],
+            max_tokens: 1024,
+            tool_choice: Some(crate::types::ToolChoice::Tool {
+                name: "exec".to_owned(),
+            }),
+            ..Default::default()
+        };
+        let wire = WireRequest::from_request(&req, None);
+        let json = serde_json::to_value(&wire).unwrap();
+        assert_eq!(json["tool_choice"]["type"], "tool");
+        assert_eq!(json["tool_choice"]["name"], "exec");
+    }
+
+    #[test]
+    fn wire_request_tool_choice_none_omitted() {
+        let req = CompletionRequest {
+            model: "claude-opus-4-20250514".to_owned(),
+            messages: vec![Message {
+                role: Role::User,
+                content: Content::Text("hi".to_owned()),
+            }],
+            max_tokens: 1024,
+            ..Default::default()
+        };
+        let wire = WireRequest::from_request(&req, None);
+        let json = serde_json::to_value(&wire).unwrap();
+        assert!(json.get("tool_choice").is_none());
+    }
+
+    #[test]
+    fn wire_request_metadata_serialized() {
+        let req = CompletionRequest {
+            model: "claude-opus-4-20250514".to_owned(),
+            messages: vec![Message {
+                role: Role::User,
+                content: Content::Text("hi".to_owned()),
+            }],
+            max_tokens: 1024,
+            metadata: Some(crate::types::RequestMetadata {
+                user_id: Some("nous:syn:main".to_owned()),
+            }),
+            ..Default::default()
+        };
+        let wire = WireRequest::from_request(&req, None);
+        let json = serde_json::to_value(&wire).unwrap();
+        assert_eq!(json["metadata"]["user_id"], "nous:syn:main");
+    }
+
+    #[test]
+    fn wire_request_citations_serialized() {
+        let req = CompletionRequest {
+            model: "claude-opus-4-20250514".to_owned(),
+            messages: vec![Message {
+                role: Role::User,
+                content: Content::Text("hi".to_owned()),
+            }],
+            max_tokens: 1024,
+            citations: Some(crate::types::CitationConfig { enabled: true }),
+            ..Default::default()
+        };
+        let wire = WireRequest::from_request(&req, None);
+        let json = serde_json::to_value(&wire).unwrap();
+        assert_eq!(json["citations"]["enabled"], true);
+    }
+
+    #[test]
+    fn wire_response_text_with_citations() {
+        let json = r#"{
+            "id": "msg_cit",
+            "type": "message",
+            "role": "assistant",
+            "content": [{
+                "type": "text",
+                "text": "According to the doc...",
+                "citations": [{
+                    "type": "char_location",
+                    "document_index": 0,
+                    "start_char_index": 0,
+                    "end_char_index": 150,
+                    "cited_text": "source text"
+                }]
+            }],
+            "model": "claude-opus-4-20250514",
+            "stop_reason": "end_turn",
+            "usage": {"input_tokens": 10, "output_tokens": 5}
+        }"#;
+        let resp: WireResponse = serde_json::from_str(json).unwrap();
+        let converted = resp.into_response().unwrap();
+        match &converted.content[0] {
+            ContentBlock::Text { citations, .. } => {
+                let cits = citations.as_ref().unwrap();
+                assert_eq!(cits.len(), 1);
+            }
+            _ => panic!("expected Text block"),
+        }
+    }
+
+    #[test]
+    fn wire_thinking_signature_passes_through() {
+        let json = r#"{"type":"thinking","thinking":"let me think","signature":"sig_abc"}"#;
+        let block: WireContentBlock = serde_json::from_str(json).unwrap();
+        let converted = block.into_content_block();
+        match converted {
+            ContentBlock::Thinking {
+                thinking,
+                signature,
+            } => {
+                assert_eq!(thinking, "let me think");
+                assert_eq!(signature.as_deref(), Some("sig_abc"));
+            }
+            _ => panic!("expected Thinking"),
+        }
+    }
+
+    #[test]
+    fn wire_request_no_cache_system_is_string() {
+        let req = CompletionRequest {
+            model: "claude-opus-4-20250514".to_owned(),
+            system: Some("test".to_owned()),
+            messages: vec![Message {
+                role: Role::User,
+                content: Content::Text("hi".to_owned()),
+            }],
+            max_tokens: 1024,
+            ..Default::default()
+        };
+        let wire = WireRequest::from_request(&req, None);
+        let json = serde_json::to_value(&wire).unwrap();
+        assert!(json["system"].is_string());
+        assert_eq!(json["system"], "test");
     }
 }

--- a/crates/hermeneus/src/health.rs
+++ b/crates/hermeneus/src/health.rs
@@ -100,7 +100,11 @@ impl ProviderHealthTracker {
     /// Current health state.
     #[must_use]
     pub fn health(&self) -> ProviderHealth {
-        self.inner.lock().expect("health lock poisoned").health.clone()
+        self.inner
+            .lock()
+            .expect("health lock poisoned")
+            .health
+            .clone()
     }
 
     /// Check if the provider can accept a request.
@@ -177,7 +181,10 @@ impl ProviderHealthTracker {
                     },
                 };
             }
-            Error::ApiRequest { .. } | Error::ApiError { status: 500..=599, .. } => {
+            Error::ApiRequest { .. }
+            | Error::ApiError {
+                status: 500..=599, ..
+            } => {
                 let now = Timestamp::now();
                 match &inner.health {
                     ProviderHealth::Up => {
@@ -229,10 +236,7 @@ mod tests {
     use snafu::IntoError;
 
     fn api_request_error() -> Error {
-        crate::error::ApiRequestSnafu {
-            message: "timeout",
-        }
-        .build()
+        crate::error::ApiRequestSnafu { message: "timeout" }.build()
     }
 
     fn server_error() -> Error {
@@ -251,10 +255,7 @@ mod tests {
     }
 
     fn rate_limit_error(ms: u64) -> Error {
-        crate::error::RateLimitedSnafu {
-            retry_after_ms: ms,
-        }
-        .build()
+        crate::error::RateLimitedSnafu { retry_after_ms: ms }.build()
     }
 
     fn parse_error() -> Error {
@@ -353,7 +354,12 @@ mod tests {
         t.record_error(&rate_limit_error(5000));
         match t.health() {
             ProviderHealth::Down { reason, .. } => {
-                assert_eq!(reason, DownReason::RateLimited { retry_after_ms: 5000 });
+                assert_eq!(
+                    reason,
+                    DownReason::RateLimited {
+                        retry_after_ms: 5000
+                    }
+                );
             }
             other => panic!("expected Down(RateLimited), got {other:?}"),
         }

--- a/crates/hermeneus/src/lib.rs
+++ b/crates/hermeneus/src/lib.rs
@@ -1,8 +1,8 @@
-//! aletheia-hermeneus — LLM provider abstraction
+//! aletheia-hermeneus — Anthropic-native LLM provider
 //!
-//! Hermeneus (Ἑρμηνεύς) — "interpreter." Provides a provider-agnostic interface
-//! for LLM interaction. Anthropic as the primary provider, with the trait
-//! designed for future OpenAI/Ollama backends.
+//! Hermeneus (Ἑρμηνεύς) — "interpreter." Anthropic-native types and client
+//! for LLM interaction. Other providers implement adapters that map to/from
+//! the Anthropic type system.
 //!
 //! Depends only on `aletheia-koina`.
 
@@ -15,5 +15,5 @@ pub mod health;
 pub mod metrics;
 /// [`LlmProvider`](provider::LlmProvider), [`ProviderConfig`](provider::ProviderConfig), and [`ProviderRegistry`](provider::ProviderRegistry).
 pub mod provider;
-/// Provider-agnostic types for LLM requests and responses ([`CompletionRequest`](types::CompletionRequest), [`CompletionResponse`](types::CompletionResponse)).
+/// Anthropic-native types for LLM requests and responses ([`CompletionRequest`](types::CompletionRequest), [`CompletionResponse`](types::CompletionResponse)).
 pub mod types;

--- a/crates/hermeneus/src/metrics.rs
+++ b/crates/hermeneus/src/metrics.rs
@@ -2,10 +2,7 @@
 
 use std::sync::LazyLock;
 
-use prometheus::{
-    CounterVec, IntCounterVec, Opts,
-    register_counter_vec, register_int_counter_vec,
-};
+use prometheus::{CounterVec, IntCounterVec, Opts, register_counter_vec, register_int_counter_vec};
 
 static LLM_TOKENS_TOTAL: LazyLock<IntCounterVec> = LazyLock::new(|| {
     register_int_counter_vec!(

--- a/crates/hermeneus/src/provider.rs
+++ b/crates/hermeneus/src/provider.rs
@@ -1,14 +1,13 @@
-//! LLM provider trait.
+//! LLM provider trait — Anthropic-native with adapter support.
 //!
-//! Defines the interface that all providers (Anthropic, `OpenAI`, Ollama)
-//! must implement. Designed for the current sync-first approach with
-//! async streaming planned for M2.
+//! Defines the interface all providers must implement. Types are modeled
+//! on the Anthropic Messages API; other providers adapt to this surface.
 
 use std::collections::HashMap;
 
 use crate::error::{self, Result};
 use crate::health::{HealthConfig, ProviderHealth, ProviderHealthTracker};
-use crate::types::{CompletionRequest, CompletionResponse};
+use crate::types::{CompletionRequest, CompletionResponse, TokenCount};
 
 /// Trait for LLM providers.
 ///
@@ -42,6 +41,22 @@ pub trait LlmProvider: Send + Sync {
     /// support local tokenization should override this.
     fn estimate_tokens(&self, _text: &str) -> Option<u64> {
         None
+    }
+
+    /// Count tokens for a request via the provider's API.
+    /// Returns None if the provider doesn't support server-side counting.
+    fn count_tokens(&self, _request: &CompletionRequest) -> Result<Option<TokenCount>> {
+        Ok(None)
+    }
+
+    /// Whether this provider supports prompt caching.
+    fn supports_caching(&self) -> bool {
+        false
+    }
+
+    /// Whether this provider supports citation tracking.
+    fn supports_citations(&self) -> bool {
+        false
     }
 }
 
@@ -190,6 +205,7 @@ mod tests {
                 stop_reason: StopReason::EndTurn,
                 content: vec![ContentBlock::Text {
                     text: "mock response".to_owned(),
+                    citations: None,
                 }],
                 usage: Usage {
                     input_tokens: 100,
@@ -203,7 +219,10 @@ mod tests {
             &self.models
         }
 
-        #[expect(clippy::unnecessary_literal_bound, reason = "trait requires &str return")]
+        #[expect(
+            clippy::unnecessary_literal_bound,
+            reason = "trait requires &str return"
+        )]
         fn name(&self) -> &str {
             "mock"
         }
@@ -224,6 +243,7 @@ mod tests {
             temperature: None,
             thinking: None,
             stop_sequences: vec![],
+            ..Default::default()
         };
 
         let response = provider.complete(&request).unwrap();
@@ -277,10 +297,7 @@ mod tests {
         let mut registry = ProviderRegistry::new();
         registry.register(Box::new(MockProvider::new()));
 
-        assert_eq!(
-            registry.provider_health("mock"),
-            Some(ProviderHealth::Up)
-        );
+        assert_eq!(registry.provider_health("mock"), Some(ProviderHealth::Up));
     }
 
     #[test]
@@ -294,14 +311,13 @@ mod tests {
         let mut registry = ProviderRegistry::new();
         registry.register(Box::new(MockProvider::new()));
 
-        let err: crate::error::Error = crate::error::ApiRequestSnafu {
-            message: "timeout",
-        }
-        .build();
+        let err: crate::error::Error = crate::error::ApiRequestSnafu { message: "timeout" }.build();
         registry.record_error("mock", &err);
 
         match registry.provider_health("mock") {
-            Some(ProviderHealth::Degraded { consecutive_errors, .. }) => {
+            Some(ProviderHealth::Degraded {
+                consecutive_errors, ..
+            }) => {
                 assert_eq!(consecutive_errors, 1);
             }
             other => panic!("expected Degraded, got {other:?}"),
@@ -313,17 +329,11 @@ mod tests {
         let mut registry = ProviderRegistry::new();
         registry.register(Box::new(MockProvider::new()));
 
-        let err: crate::error::Error = crate::error::ApiRequestSnafu {
-            message: "timeout",
-        }
-        .build();
+        let err: crate::error::Error = crate::error::ApiRequestSnafu { message: "timeout" }.build();
         registry.record_error("mock", &err);
         registry.record_success("mock");
 
-        assert_eq!(
-            registry.provider_health("mock"),
-            Some(ProviderHealth::Up)
-        );
+        assert_eq!(registry.provider_health("mock"), Some(ProviderHealth::Up));
     }
 
     #[test]
@@ -332,10 +342,7 @@ mod tests {
         registry.register(Box::new(MockProvider::new()));
         // Should not panic
         registry.record_success("nonexistent");
-        let err: crate::error::Error = crate::error::ApiRequestSnafu {
-            message: "timeout",
-        }
-        .build();
+        let err: crate::error::Error = crate::error::ApiRequestSnafu { message: "timeout" }.build();
         registry.record_error("nonexistent", &err);
     }
 }

--- a/crates/hermeneus/src/types.rs
+++ b/crates/hermeneus/src/types.rs
@@ -63,8 +63,8 @@ impl Content {
             Self::Blocks(blocks) => blocks
                 .iter()
                 .filter_map(|b| match b {
-                    ContentBlock::Text { text } => Some(text.as_str()),
-                    ContentBlock::Thinking { thinking } => Some(thinking.as_str()),
+                    ContentBlock::Text { text, .. } => Some(text.as_str()),
+                    ContentBlock::Thinking { thinking, .. } => Some(thinking.as_str()),
                     _ => None,
                 })
                 .collect::<Vec<_>>()
@@ -80,7 +80,11 @@ impl Content {
 pub enum ContentBlock {
     /// Text content.
     #[serde(rename = "text")]
-    Text { text: String },
+    Text {
+        text: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        citations: Option<Vec<Citation>>,
+    },
 
     /// Tool use request from assistant.
     #[serde(rename = "tool_use")]
@@ -107,7 +111,11 @@ pub enum ContentBlock {
 
     /// Extended thinking content.
     #[serde(rename = "thinking")]
-    Thinking { thinking: String },
+    Thinking {
+        thinking: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        signature: Option<String>,
+    },
 }
 
 /// Tool result content — simple text or rich content blocks.
@@ -208,6 +216,80 @@ pub struct ToolDefinition {
     pub input_schema: serde_json::Value,
 }
 
+/// Cache control directive for prompt caching.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CacheControl {
+    #[serde(rename = "type")]
+    pub control_type: String,
+}
+
+impl CacheControl {
+    #[must_use]
+    pub fn ephemeral() -> Self {
+        Self {
+            control_type: "ephemeral".to_owned(),
+        }
+    }
+}
+
+/// Control tool use behavior.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum ToolChoice {
+    #[serde(rename = "auto")]
+    Auto,
+    #[serde(rename = "any")]
+    Any,
+    #[serde(rename = "tool")]
+    Tool { name: String },
+}
+
+/// Optional request metadata for tracking.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RequestMetadata {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub user_id: Option<String>,
+}
+
+/// Citation configuration for requests.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CitationConfig {
+    pub enabled: bool,
+}
+
+/// A source citation in a response.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type")]
+#[non_exhaustive]
+pub enum Citation {
+    #[serde(rename = "char_location")]
+    CharLocation {
+        document_index: u32,
+        start_char_index: u32,
+        end_char_index: u32,
+        cited_text: String,
+    },
+    #[serde(rename = "page_location")]
+    PageLocation {
+        document_index: u32,
+        start_page: u32,
+        end_page: u32,
+        cited_text: String,
+    },
+    #[serde(rename = "web_search_result_location")]
+    WebSearchResultLocation {
+        url: String,
+        title: Option<String>,
+        cited_text: String,
+    },
+}
+
+/// Token count result from the `count_tokens` endpoint.
+#[derive(Debug, Clone)]
+pub struct TokenCount {
+    pub input_tokens: u64,
+}
+
 /// Request to the LLM provider.
 #[derive(Debug, Clone)]
 pub struct CompletionRequest {
@@ -227,6 +309,36 @@ pub struct CompletionRequest {
     pub thinking: Option<ThinkingConfig>,
     /// Stop sequences.
     pub stop_sequences: Vec<String>,
+    /// When true, system prompt gets `cache_control: ephemeral`.
+    pub cache_system: bool,
+    /// When true, last tool definition gets `cache_control: ephemeral`.
+    pub cache_tools: bool,
+    /// Control tool use behavior (auto/any/specific tool).
+    pub tool_choice: Option<ToolChoice>,
+    /// Request metadata for tracking.
+    pub metadata: Option<RequestMetadata>,
+    /// Enable citation tracking in responses.
+    pub citations: Option<CitationConfig>,
+}
+
+impl Default for CompletionRequest {
+    fn default() -> Self {
+        Self {
+            model: String::new(),
+            system: None,
+            messages: Vec::new(),
+            max_tokens: 4096,
+            tools: Vec::new(),
+            temperature: None,
+            thinking: None,
+            stop_sequences: Vec::new(),
+            cache_system: false,
+            cache_tools: false,
+            tool_choice: None,
+            metadata: None,
+            citations: None,
+        }
+    }
 }
 
 /// Configuration for extended thinking.
@@ -343,9 +455,11 @@ mod tests {
         let blocks = Content::Blocks(vec![
             ContentBlock::Thinking {
                 thinking: "let me think".to_owned(),
+                signature: None,
             },
             ContentBlock::Text {
                 text: "the answer is 42".to_owned(),
+                citations: None,
             },
         ]);
         assert!(blocks.text().contains("let me think"));
@@ -405,7 +519,10 @@ mod tests {
         };
         let json = serde_json::to_string(&block).unwrap();
         let v: serde_json::Value = serde_json::from_str(&json).unwrap();
-        assert!(v["content"].is_string(), "Text should serialize as bare string");
+        assert!(
+            v["content"].is_string(),
+            "Text should serialize as bare string"
+        );
         assert_eq!(v["content"], "hello");
     }
 
@@ -505,6 +622,114 @@ mod tests {
     }
 
     #[test]
+    fn citation_char_location_serde() {
+        let citation = Citation::CharLocation {
+            document_index: 0,
+            start_char_index: 10,
+            end_char_index: 50,
+            cited_text: "some text".to_owned(),
+        };
+        let json = serde_json::to_string(&citation).unwrap();
+        let back: Citation = serde_json::from_str(&json).unwrap();
+        match back {
+            Citation::CharLocation {
+                document_index,
+                start_char_index,
+                ..
+            } => {
+                assert_eq!(document_index, 0);
+                assert_eq!(start_char_index, 10);
+            }
+            _ => panic!("expected CharLocation"),
+        }
+    }
+
+    #[test]
+    fn thinking_signature_roundtrip() {
+        let block = ContentBlock::Thinking {
+            thinking: "deep thoughts".to_owned(),
+            signature: Some("sig_xyz".to_owned()),
+        };
+        let json = serde_json::to_string(&block).unwrap();
+        let back: ContentBlock = serde_json::from_str(&json).unwrap();
+        match back {
+            ContentBlock::Thinking {
+                thinking,
+                signature,
+            } => {
+                assert_eq!(thinking, "deep thoughts");
+                assert_eq!(signature.as_deref(), Some("sig_xyz"));
+            }
+            _ => panic!("expected Thinking"),
+        }
+    }
+
+    #[test]
+    fn thinking_no_signature_roundtrip() {
+        let block = ContentBlock::Thinking {
+            thinking: "brief".to_owned(),
+            signature: None,
+        };
+        let json = serde_json::to_string(&block).unwrap();
+        let back: ContentBlock = serde_json::from_str(&json).unwrap();
+        match back {
+            ContentBlock::Thinking { signature, .. } => {
+                assert!(signature.is_none());
+            }
+            _ => panic!("expected Thinking"),
+        }
+    }
+
+    #[test]
+    fn completion_request_default() {
+        let req = CompletionRequest::default();
+        assert!(req.model.is_empty());
+        assert!(req.system.is_none());
+        assert!(req.messages.is_empty());
+        assert_eq!(req.max_tokens, 4096);
+        assert!(!req.cache_system);
+        assert!(!req.cache_tools);
+        assert!(req.tool_choice.is_none());
+        assert!(req.metadata.is_none());
+        assert!(req.citations.is_none());
+    }
+
+    #[test]
+    fn tool_choice_serde() {
+        let auto = ToolChoice::Auto;
+        let json = serde_json::to_string(&auto).unwrap();
+        assert!(json.contains("\"type\":\"auto\""));
+
+        let tool = ToolChoice::Tool {
+            name: "exec".to_owned(),
+        };
+        let json = serde_json::to_string(&tool).unwrap();
+        assert!(json.contains("\"type\":\"tool\""));
+        assert!(json.contains("\"name\":\"exec\""));
+    }
+
+    #[test]
+    fn text_block_with_citations_serde() {
+        let block = ContentBlock::Text {
+            text: "cited text".to_owned(),
+            citations: Some(vec![Citation::CharLocation {
+                document_index: 0,
+                start_char_index: 0,
+                end_char_index: 10,
+                cited_text: "source".to_owned(),
+            }]),
+        };
+        let json = serde_json::to_string(&block).unwrap();
+        let back: ContentBlock = serde_json::from_str(&json).unwrap();
+        match back {
+            ContentBlock::Text { citations, .. } => {
+                assert_eq!(citations.unwrap().len(), 1);
+            }
+            _ => panic!("expected Text"),
+        }
+    }
+
+    #[test]
     fn completion_response_serde() {
         let response = CompletionResponse {
             id: "msg_123".to_owned(),
@@ -512,6 +737,7 @@ mod tests {
             stop_reason: StopReason::EndTurn,
             content: vec![ContentBlock::Text {
                 text: "Hello!".to_owned(),
+                citations: None,
             }],
             usage: Usage {
                 input_tokens: 100,

--- a/crates/integration-tests/tests/domain_packs.rs
+++ b/crates/integration-tests/tests/domain_packs.rs
@@ -32,6 +32,7 @@ impl CapturingMockProvider {
                 stop_reason: StopReason::EndTurn,
                 content: vec![ContentBlock::Text {
                     text: "Hello from mock!".to_owned(),
+                    citations: None,
                 }],
                 usage: Usage {
                     input_tokens: 10,

--- a/crates/integration-tests/tests/end_to_end.rs
+++ b/crates/integration-tests/tests/end_to_end.rs
@@ -36,6 +36,7 @@ impl MockProvider {
                 stop_reason: StopReason::EndTurn,
                 content: vec![ContentBlock::Text {
                     text: "Hello from mock!".to_owned(),
+                    citations: None,
                 }],
                 usage: Usage {
                     input_tokens: 10,
@@ -79,6 +80,7 @@ impl CapturingMockProvider {
                 stop_reason: StopReason::EndTurn,
                 content: vec![ContentBlock::Text {
                     text: "Hello from mock!".to_owned(),
+                    citations: None,
                 }],
                 usage: Usage {
                     input_tokens: 10,
@@ -202,7 +204,10 @@ impl TestHarness {
     }
 
     fn router(&self) -> axum::Router {
-        build_router(Arc::clone(&self.state), &aletheia_pylon::security::SecurityConfig::default())
+        build_router(
+            Arc::clone(&self.state),
+            &aletheia_pylon::security::SecurityConfig::default(),
+        )
     }
 
     fn authed_request(

--- a/crates/integration-tests/tests/eval_harness.rs
+++ b/crates/integration-tests/tests/eval_harness.rs
@@ -33,6 +33,7 @@ impl MockProvider {
                 stop_reason: StopReason::EndTurn,
                 content: vec![ContentBlock::Text {
                     text: "Hello from eval harness!".to_owned(),
+                    citations: None,
                 }],
                 usage: Usage {
                     input_tokens: 10,
@@ -216,7 +217,10 @@ async fn eval_session_scenarios_pass() {
     let report = runner.run().await;
 
     assert_eq!(report.failed, 0, "session scenarios should all pass");
-    assert!(report.passed > 0, "at least one session scenario should run");
+    assert!(
+        report.passed > 0,
+        "at least one session scenario should run"
+    );
 }
 
 #[tokio::test]
@@ -258,7 +262,13 @@ async fn eval_full_run_with_json_output() {
     let runner = ScenarioRunner::new(config);
     let report = runner.run().await;
 
-    assert_eq!(report.failed, 0, "all scenarios should pass against test harness");
+    assert_eq!(
+        report.failed, 0,
+        "all scenarios should pass against test harness"
+    );
     assert!(report.passed >= 10, "expect at least 10 passing scenarios");
-    assert_eq!(report.skipped, 0, "no scenarios should skip with full auth + nous");
+    assert_eq!(
+        report.skipped, 0,
+        "no scenarios should skip with full auth + nous"
+    );
 }

--- a/crates/integration-tests/tests/hermeneus_from_mneme.rs
+++ b/crates/integration-tests/tests/hermeneus_from_mneme.rs
@@ -58,6 +58,7 @@ fn build_completion_request_from_mneme_history() {
         temperature: None,
         thinking: None,
         stop_sequences: vec![],
+        ..Default::default()
     };
 
     assert_eq!(request.messages.len(), 2);

--- a/crates/koina/src/redact.rs
+++ b/crates/koina/src/redact.rs
@@ -27,7 +27,9 @@ static RE_SECRETS: LazyLock<Regex> = LazyLock::new(|| {
 /// Redact sensitive values (API keys, JWTs, bearer tokens, passwords) from a string.
 #[must_use]
 pub fn redact_sensitive(value: &str) -> String {
-    let mut result = RE_ANTHROPIC_KEY.replace_all(value, "sk-ant-***").into_owned();
+    let mut result = RE_ANTHROPIC_KEY
+        .replace_all(value, "sk-ant-***")
+        .into_owned();
     result = RE_SK_KEY.replace_all(&result, "sk-***").into_owned();
     result = RE_BEARER.replace_all(&result, "Bearer ***").into_owned();
     result = RE_JWT.replace_all(&result, "[JWT REDACTED]").into_owned();

--- a/crates/melete/src/distill.rs
+++ b/crates/melete/src/distill.rs
@@ -26,10 +26,7 @@ pub enum DistillSection {
     /// Mistakes discovered and corrected to prevent repetition.
     Corrections,
     /// Custom section with a name and description.
-    Custom {
-        name: String,
-        description: String,
-    },
+    Custom { name: String, description: String },
 }
 
 impl DistillSection {
@@ -217,6 +214,7 @@ impl DistillEngine {
             temperature: Some(0.0),
             thinking: None,
             stop_sequences: vec![],
+            ..Default::default()
         }
     }
 
@@ -281,7 +279,7 @@ fn extract_summary_text(content: &[aletheia_hermeneus::types::ContentBlock]) -> 
     content
         .iter()
         .filter_map(|block| match block {
-            aletheia_hermeneus::types::ContentBlock::Text { text } => Some(text.as_str()),
+            aletheia_hermeneus::types::ContentBlock::Text { text, .. } => Some(text.as_str()),
             _ => None,
         })
         .collect::<Vec<_>>()
@@ -311,6 +309,7 @@ mod tests {
                     stop_reason: StopReason::EndTurn,
                     content: vec![ContentBlock::Text {
                         text: summary.to_owned(),
+                        citations: None,
                     }],
                     usage: Usage {
                         input_tokens: 5000,
@@ -343,9 +342,11 @@ mod tests {
                     content: vec![
                         ContentBlock::Text {
                             text: String::new(),
+                            citations: None,
                         },
                         ContentBlock::Text {
                             text: "   ".to_owned(),
+                            citations: None,
                         },
                     ],
                     usage: Usage::default(),
@@ -708,9 +709,11 @@ Bug is fixed, test passes.
         let blocks = vec![
             ContentBlock::Text {
                 text: "Part 1".to_owned(),
+                citations: None,
             },
             ContentBlock::Text {
                 text: "Part 2".to_owned(),
+                citations: None,
             },
         ];
         let text = extract_summary_text(&blocks);
@@ -722,9 +725,11 @@ Bug is fixed, test passes.
         let blocks = vec![
             ContentBlock::Text {
                 text: "Summary text".to_owned(),
+                citations: None,
             },
             ContentBlock::Thinking {
                 thinking: "internal thought".to_owned(),
+                signature: None,
             },
         ];
         let text = extract_summary_text(&blocks);
@@ -735,6 +740,7 @@ Bug is fixed, test passes.
     fn extract_summary_trims_whitespace() {
         let blocks = vec![ContentBlock::Text {
             text: "  summary  ".to_owned(),
+            citations: None,
         }];
         let text = extract_summary_text(&blocks);
         assert_eq!(text, "summary");

--- a/crates/melete/src/prompt.rs
+++ b/crates/melete/src/prompt.rs
@@ -95,7 +95,7 @@ pub fn format_messages(messages: &[Message], include_tool_calls: bool) -> String
                 let mut block_text = String::new();
                 for block in blocks {
                     match block {
-                        ContentBlock::Text { text } => {
+                        ContentBlock::Text { text, .. } => {
                             block_text.push_str(text);
                             block_text.push('\n');
                         }
@@ -114,7 +114,7 @@ pub fn format_messages(messages: &[Message], include_tool_calls: bool) -> String
                             let truncated = truncate_tool_result(&summary);
                             let _ = writeln!(block_text, "[{prefix}: {truncated}]");
                         }
-                        ContentBlock::Thinking { thinking } => {
+                        ContentBlock::Thinking { thinking, .. } => {
                             let _ = writeln!(block_text, "[Thinking: {thinking}]");
                         }
                         _ => {}
@@ -233,6 +233,7 @@ mod tests {
             content: Content::Blocks(vec![
                 ContentBlock::Text {
                     text: "Let me check.".to_owned(),
+                    citations: None,
                 },
                 ContentBlock::ToolUse {
                     id: "t1".to_owned(),

--- a/crates/nous/src/actor.rs
+++ b/crates/nous/src/actor.rs
@@ -447,6 +447,7 @@ mod tests {
                 stop_reason: StopReason::EndTurn,
                 content: vec![ContentBlock::Text {
                     text: "Hello from actor!".to_owned(),
+                    citations: None,
                 }],
                 usage: Usage {
                     input_tokens: 100,

--- a/crates/nous/src/budget.rs
+++ b/crates/nous/src/budget.rs
@@ -128,8 +128,8 @@ impl TokenBudget {
 
 // --- Time budget (complementary to token budget) ---
 
-use std::time::{Duration, Instant};
 use crate::config::StageBudget;
+use std::time::{Duration, Instant};
 
 /// Tracks wall-clock time per pipeline stage and enforces limits.
 pub struct TimeBudget {
@@ -179,7 +179,8 @@ impl TimeBudget {
         if self.stage_budgets.total_secs == 0 {
             return false;
         }
-        self.pipeline_start.elapsed() >= Duration::from_secs(u64::from(self.stage_budgets.total_secs))
+        self.pipeline_start.elapsed()
+            >= Duration::from_secs(u64::from(self.stage_budgets.total_secs))
     }
 
     /// Wall-clock time remaining before the total pipeline budget expires.
@@ -362,7 +363,10 @@ mod tests {
 
     #[test]
     fn time_budget_unlimited_when_zero() {
-        let tb = TimeBudget::new(StageBudget { total_secs: 0, ..StageBudget::default() });
+        let tb = TimeBudget::new(StageBudget {
+            total_secs: 0,
+            ..StageBudget::default()
+        });
         assert!(!tb.total_exceeded());
         assert!(tb.total_remaining() > Duration::from_secs(1_000_000));
     }
@@ -370,7 +374,9 @@ mod tests {
     #[test]
     fn stage_limit_none_when_both_zero() {
         let tb = TimeBudget::new(StageBudget {
-            execute_secs: 0, total_secs: 0, ..StageBudget::default()
+            execute_secs: 0,
+            total_secs: 0,
+            ..StageBudget::default()
         });
         // execute has 0 stage limit and total is 0
         assert!(tb.stage_limit("execute").is_none());
@@ -379,7 +385,9 @@ mod tests {
     #[test]
     fn stage_limit_capped_by_total() {
         let tb = TimeBudget::new(StageBudget {
-            recall_secs: 999, total_secs: 10, ..StageBudget::default()
+            recall_secs: 999,
+            total_secs: 10,
+            ..StageBudget::default()
         });
         let limit = tb.stage_limit("recall").unwrap();
         assert!(limit <= Duration::from_secs(10));

--- a/crates/nous/src/execute.rs
+++ b/crates/nous/src/execute.rs
@@ -162,7 +162,10 @@ async fn dispatch_tools(
 /// 3. Processes `tool_use` blocks by dispatching to the `ToolRegistry`
 /// 4. Feeds tool results back and re-calls the LLM
 /// 5. Repeats until `EndTurn`, `MaxTokens`, or iteration limit
-#[expect(clippy::too_many_lines, reason = "health check additions keep the loop cohesive")]
+#[expect(
+    clippy::too_many_lines,
+    reason = "health check additions keep the loop cohesive"
+)]
 #[instrument(skip_all, fields(nous_id = %session.nous_id, session_id = %session.id))]
 pub async fn execute(
     ctx: &PipelineContext,
@@ -226,6 +229,7 @@ pub async fn execute(
             temperature: None,
             thinking: thinking.clone(),
             stop_sequences: vec![],
+            ..Default::default()
         };
 
         let response = match provider.complete(&request) {
@@ -250,11 +254,11 @@ pub async fn execute(
 
         for block in &response.content {
             match block {
-                ContentBlock::Text { text } => text_parts.push(text.clone()),
+                ContentBlock::Text { text, .. } => text_parts.push(text.clone()),
                 ContentBlock::ToolUse { id, name, input } => {
                     tool_uses.push((id.clone(), name.clone(), input.clone()));
                 }
-                ContentBlock::Thinking { thinking } => {
+                ContentBlock::Thinking { thinking, .. } => {
                     debug!(len = thinking.len(), "thinking block received");
                 }
                 _ => {}
@@ -361,7 +365,10 @@ mod tests {
             &["test-model"]
         }
 
-        #[expect(clippy::unnecessary_literal_bound, reason = "trait requires &str return")]
+        #[expect(
+            clippy::unnecessary_literal_bound,
+            reason = "trait requires &str return"
+        )]
         fn name(&self) -> &str {
             "mock"
         }
@@ -439,6 +446,7 @@ mod tests {
             stop_reason: StopReason::EndTurn,
             content: vec![ContentBlock::Text {
                 text: text.to_owned(),
+                citations: None,
             }],
             usage: Usage {
                 input_tokens: 100,

--- a/crates/nous/src/extraction.rs
+++ b/crates/nous/src/extraction.rs
@@ -36,6 +36,7 @@ impl ExtractionProvider for HermeneusExtractionProvider {
             temperature: None,
             thinking: None,
             stop_sequences: Vec::new(),
+            ..Default::default()
         };
 
         let provider = self.providers.find_provider(&self.model).ok_or_else(|| {
@@ -56,7 +57,7 @@ impl ExtractionProvider for HermeneusExtractionProvider {
             .content
             .iter()
             .find_map(|block| match block {
-                ContentBlock::Text { text } => Some(text.clone()),
+                ContentBlock::Text { text, .. } => Some(text.clone()),
                 _ => None,
             })
             .context(LlmCallSnafu {

--- a/crates/nous/src/manager.rs
+++ b/crates/nous/src/manager.rs
@@ -303,6 +303,7 @@ mod tests {
                 stop_reason: StopReason::EndTurn,
                 content: vec![ContentBlock::Text {
                     text: "Hello!".to_owned(),
+                    citations: None,
                 }],
                 usage: Usage {
                     input_tokens: 100,

--- a/crates/nous/src/metrics.rs
+++ b/crates/nous/src/metrics.rs
@@ -3,13 +3,16 @@
 use std::sync::LazyLock;
 
 use prometheus::{
-    HistogramOpts, HistogramVec, IntCounterVec, Opts,
-    register_histogram_vec, register_int_counter_vec,
+    HistogramOpts, HistogramVec, IntCounterVec, Opts, register_histogram_vec,
+    register_int_counter_vec,
 };
 
 static PIPELINE_TURNS_TOTAL: LazyLock<IntCounterVec> = LazyLock::new(|| {
     register_int_counter_vec!(
-        Opts::new("aletheia_pipeline_turns_total", "Total pipeline turns processed"),
+        Opts::new(
+            "aletheia_pipeline_turns_total",
+            "Total pipeline turns processed"
+        ),
         &["nous_id"]
     )
     .expect("metric registration")
@@ -21,7 +24,9 @@ static PIPELINE_STAGE_DURATION_SECONDS: LazyLock<HistogramVec> = LazyLock::new(|
             "aletheia_pipeline_stage_duration_seconds",
             "Pipeline stage duration in seconds"
         )
-        .buckets(vec![0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1.0, 5.0, 30.0, 60.0]),
+        .buckets(vec![
+            0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1.0, 5.0, 30.0, 60.0
+        ]),
         &["nous_id", "stage"]
     )
     .expect("metric registration")

--- a/crates/nous/src/pipeline.rs
+++ b/crates/nous/src/pipeline.rs
@@ -884,7 +884,10 @@ mod tests {
             fn supported_models(&self) -> &[&str] {
                 &["test-model"]
             }
-            #[expect(clippy::unnecessary_literal_bound, reason = "trait requires &str return")]
+            #[expect(
+                clippy::unnecessary_literal_bound,
+                reason = "trait requires &str return"
+            )]
             fn name(&self) -> &str {
                 "mock"
             }
@@ -913,6 +916,7 @@ mod tests {
                 stop_reason: StopReason::EndTurn,
                 content: vec![ContentBlock::Text {
                     text: "Hello from pipeline!".to_owned(),
+                    citations: None,
                 }],
                 usage: Usage {
                     input_tokens: 100,

--- a/crates/nous/src/session.rs
+++ b/crates/nous/src/session.rs
@@ -56,7 +56,10 @@ impl SessionState {
     /// Check if context is nearing capacity.
     #[must_use]
     pub fn needs_distillation(&self, threshold_ratio: f64, context_window: u32) -> bool {
-        #[expect(clippy::cast_possible_truncation, reason = "threshold product fits in i64")]
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "threshold product fits in i64"
+        )]
         let threshold = (f64::from(context_window) * threshold_ratio) as i64;
         self.token_estimate >= threshold
     }

--- a/crates/nous/src/user_error.rs
+++ b/crates/nous/src/user_error.rs
@@ -17,10 +17,7 @@ pub enum UserFacingError {
     /// The conversation exceeded the model's context window.
     ContextOverflow { limit_tokens: u64 },
     /// A tool execution failed.
-    ToolExecutionFailed {
-        tool_name: String,
-        message: String,
-    },
+    ToolExecutionFailed { tool_name: String, message: String },
     /// The session has expired or is invalid.
     SessionExpired { session_id: String },
     /// Rate limited by the provider.
@@ -79,8 +76,8 @@ impl fmt::Display for UserFacingError {
 ///
 /// Returns `None` for internal errors that should not be shown to users.
 pub fn to_user_facing(error: &crate::error::Error) -> Option<UserFacingError> {
-    use aletheia_hermeneus::error::Error as HError;
     use crate::error::Error;
+    use aletheia_hermeneus::error::Error as HError;
 
     match error {
         Error::Llm { source, .. } => match source {
@@ -89,9 +86,7 @@ pub fn to_user_facing(error: &crate::error::Error) -> Option<UserFacingError> {
                 suggestion: "This may be a configuration issue. Please check the API key."
                     .to_owned(),
             }),
-            HError::RateLimited {
-                retry_after_ms, ..
-            } => Some(UserFacingError::RateLimited {
+            HError::RateLimited { retry_after_ms, .. } => Some(UserFacingError::RateLimited {
                 retry_after_secs: Some(retry_after_ms / 1000),
             }),
             HError::ApiError { status, .. } if *status >= 500 => {
@@ -178,10 +173,7 @@ mod tests {
     #[test]
     fn convert_llm_auth_error() {
         let err = crate::error::Error::Llm {
-            source: aletheia_hermeneus::error::AuthFailedSnafu {
-                message: "bad key",
-            }
-            .build(),
+            source: aletheia_hermeneus::error::AuthFailedSnafu { message: "bad key" }.build(),
             location: snafu::Location::new("test", 1, 1),
         };
         let uf = to_user_facing(&err).expect("should convert");

--- a/crates/organon/src/metrics.rs
+++ b/crates/organon/src/metrics.rs
@@ -3,8 +3,8 @@
 use std::sync::LazyLock;
 
 use prometheus::{
-    HistogramOpts, HistogramVec, IntCounterVec, Opts,
-    register_histogram_vec, register_int_counter_vec,
+    HistogramOpts, HistogramVec, IntCounterVec, Opts, register_histogram_vec,
+    register_int_counter_vec,
 };
 
 static TOOL_INVOCATIONS_TOTAL: LazyLock<IntCounterVec> = LazyLock::new(|| {
@@ -21,7 +21,9 @@ static TOOL_DURATION_SECONDS: LazyLock<HistogramVec> = LazyLock::new(|| {
             "aletheia_tool_duration_seconds",
             "Tool execution duration in seconds"
         )
-        .buckets(vec![0.01, 0.05, 0.1, 0.5, 1.0, 5.0, 10.0, 30.0, 60.0, 120.0]),
+        .buckets(vec![
+            0.01, 0.05, 0.1, 0.5, 1.0, 5.0, 10.0, 30.0, 60.0, 120.0
+        ]),
         &["tool_name"]
     )
     .expect("metric registration")

--- a/crates/pylon/src/error.rs
+++ b/crates/pylon/src/error.rs
@@ -103,18 +103,16 @@ impl From<aletheia_hermeneus::error::Error> for ApiError {
     fn from(err: aletheia_hermeneus::error::Error) -> Self {
         use aletheia_hermeneus::error::Error;
         match err {
-            Error::RateLimited { retry_after_ms, .. } => {
-                Self::RateLimited { retry_after_ms }
-            }
+            Error::RateLimited { retry_after_ms, .. } => Self::RateLimited { retry_after_ms },
             Error::AuthFailed { message, .. } => Self::ServiceUnavailable {
                 message: format!("provider auth failed: {message}"),
             },
-            Error::ApiError { status: 429, .. } => Self::RateLimited {
-                retry_after_ms: 0,
-            },
-            Error::ApiError { status: 503, message, .. } => {
-                Self::ServiceUnavailable { message }
-            }
+            Error::ApiError { status: 429, .. } => Self::RateLimited { retry_after_ms: 0 },
+            Error::ApiError {
+                status: 503,
+                message,
+                ..
+            } => Self::ServiceUnavailable { message },
             _ => Self::Internal {
                 message: err.to_string(),
             },

--- a/crates/pylon/src/handlers/sessions.rs
+++ b/crates/pylon/src/handlers/sessions.rs
@@ -20,7 +20,8 @@ use aletheia_mneme::types::SessionStatus;
 use aletheia_nous::pipeline::TurnResult;
 
 use crate::error::{
-    ApiError, BadRequestSnafu, ErrorResponse, InternalSnafu, NousNotFoundSnafu, SessionNotFoundSnafu,
+    ApiError, BadRequestSnafu, ErrorResponse, InternalSnafu, NousNotFoundSnafu,
+    SessionNotFoundSnafu,
 };
 use crate::extract::Claims;
 use crate::state::AppState;

--- a/crates/pylon/src/metrics.rs
+++ b/crates/pylon/src/metrics.rs
@@ -3,8 +3,8 @@
 use std::sync::LazyLock;
 
 use prometheus::{
-    Gauge, HistogramOpts, HistogramVec, IntCounterVec, IntGauge, Opts,
-    register_gauge, register_histogram_vec, register_int_counter_vec, register_int_gauge,
+    Gauge, HistogramOpts, HistogramVec, IntCounterVec, IntGauge, Opts, register_gauge,
+    register_histogram_vec, register_int_counter_vec, register_int_gauge,
 };
 
 static HTTP_REQUESTS_TOTAL: LazyLock<IntCounterVec> = LazyLock::new(|| {
@@ -21,7 +21,9 @@ static HTTP_REQUEST_DURATION_SECONDS: LazyLock<HistogramVec> = LazyLock::new(|| 
             "aletheia_http_request_duration_seconds",
             "HTTP request duration in seconds"
         )
-        .buckets(vec![0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0]),
+        .buckets(vec![
+            0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0
+        ]),
         &["method", "path"]
     )
     .expect("metric registration")

--- a/crates/pylon/src/middleware.rs
+++ b/crates/pylon/src/middleware.rs
@@ -71,10 +71,7 @@ pub async fn inject_request_id(mut request: Request, next: Next) -> Response {
 ///
 /// Must be placed inside the compression layer so the body is uncompressed.
 pub async fn enrich_error_response(request: Request, next: Next) -> Response {
-    let request_id = request
-        .extensions()
-        .get::<RequestId>()
-        .map(|r| r.0.clone());
+    let request_id = request.extensions().get::<RequestId>().map(|r| r.0.clone());
 
     let response = next.run(request).await;
 
@@ -106,10 +103,7 @@ pub async fn enrich_error_response(request: Request, next: Next) -> Response {
     };
 
     if let Some(error) = json.get_mut("error").and_then(|e| e.as_object_mut()) {
-        error.insert(
-            "request_id".to_owned(),
-            serde_json::Value::String(rid),
-        );
+        error.insert("request_id".to_owned(), serde_json::Value::String(rid));
         let new_bytes = serde_json::to_vec(&json).unwrap_or_default();
         return Response::from_parts(parts, Body::from(new_bytes));
     }

--- a/crates/pylon/src/router.rs
+++ b/crates/pylon/src/router.rs
@@ -3,10 +3,10 @@
 use std::sync::Arc;
 use std::time::Duration;
 
+use axum::Router;
 use axum::extract::DefaultBodyLimit;
 use axum::http::{HeaderName, HeaderValue, Method, StatusCode};
 use axum::response::{IntoResponse, Response};
-use axum::Router;
 use axum::routing::{get, post};
 use tower_http::compression::CompressionLayer;
 use tower_http::cors::{AllowOrigin, CorsLayer};
@@ -16,8 +16,11 @@ use tracing::info_span;
 
 use crate::error::ApiError;
 use crate::handlers::{health, metrics, nous, sessions};
+use crate::middleware::{
+    CsrfState, RequestId, enrich_error_response, inject_request_id, record_http_metrics,
+    require_csrf_header,
+};
 use crate::openapi;
-use crate::middleware::{CsrfState, RequestId, enrich_error_response, inject_request_id, record_http_metrics, require_csrf_header};
 use crate::security::SecurityConfig;
 use crate::state::AppState;
 
@@ -83,14 +86,9 @@ pub fn build_router(state: Arc<AppState>, security: &SecurityConfig) -> Router {
                 )
             })
             .on_response(
-                |response: &axum::http::Response<_>,
-                 latency: Duration,
-                 span: &tracing::Span| {
+                |response: &axum::http::Response<_>, latency: Duration, span: &tracing::Span| {
                     span.record("http.status_code", response.status().as_u16());
-                    #[expect(
-                        clippy::cast_possible_truncation,
-                        reason = "HTTP latency fits in u64"
-                    )]
+                    #[expect(clippy::cast_possible_truncation, reason = "HTTP latency fits in u64")]
                     let duration_ms = latency.as_millis() as u64;
                     tracing::debug!(
                         duration_ms,
@@ -142,8 +140,8 @@ async fn fallback_handler(uri: axum::http::Uri) -> Response {
 
 /// Build a CORS layer from security configuration.
 fn build_cors_layer(security: &SecurityConfig) -> CorsLayer {
-    let is_permissive = security.allowed_origins.is_empty()
-        || security.allowed_origins.iter().any(|o| o == "*");
+    let is_permissive =
+        security.allowed_origins.is_empty() || security.allowed_origins.iter().any(|o| o == "*");
 
     if is_permissive {
         return CorsLayer::permissive();
@@ -166,7 +164,10 @@ fn build_cors_layer(security: &SecurityConfig) -> CorsLayer {
 }
 
 /// Apply standard security response headers.
-fn apply_security_headers(router: Router<Arc<AppState>>, security: &SecurityConfig) -> Router<Arc<AppState>> {
+fn apply_security_headers(
+    router: Router<Arc<AppState>>,
+    security: &SecurityConfig,
+) -> Router<Arc<AppState>> {
     let mut r = router
         .layer(SetResponseHeaderLayer::overriding(
             HeaderName::from_static("x-frame-options"),

--- a/crates/pylon/src/server.rs
+++ b/crates/pylon/src/server.rs
@@ -110,11 +110,9 @@ pub async fn run(config: ServerConfig) -> Result<(), ServerError> {
 }
 
 async fn serve_plain(app: axum::Router, bind_addr: &str) -> Result<(), ServerError> {
-    let listener = TcpListener::bind(bind_addr)
-        .await
-        .context(BindSnafu {
-            addr: bind_addr.to_owned(),
-        })?;
+    let listener = TcpListener::bind(bind_addr).await.context(BindSnafu {
+        addr: bind_addr.to_owned(),
+    })?;
 
     info!(addr = %bind_addr, tls = false, "pylon listening");
 

--- a/crates/pylon/src/tests.rs
+++ b/crates/pylon/src/tests.rs
@@ -36,6 +36,7 @@ impl MockProvider {
                 stop_reason: StopReason::EndTurn,
                 content: vec![ContentBlock::Text {
                     text: "Hello from mock!".to_owned(),
+                    citations: None,
                 }],
                 usage: Usage {
                     input_tokens: 10,
@@ -531,7 +532,9 @@ async fn history_with_limit() {
 
     let resp = router
         .clone()
-        .oneshot(authed_get(&format!("/api/v1/sessions/{id}/history?limit=3")))
+        .oneshot(authed_get(&format!(
+            "/api/v1/sessions/{id}/history?limit=3"
+        )))
         .await
         .unwrap();
 
@@ -671,7 +674,10 @@ async fn error_response_has_consistent_structure() {
     assert!(body["error"].is_object());
     assert!(body["error"]["code"].is_string());
     assert!(body["error"]["message"].is_string());
-    assert!(body["error"]["request_id"].is_string(), "error response must include request_id");
+    assert!(
+        body["error"]["request_id"].is_string(),
+        "error response must include request_id"
+    );
 }
 
 #[tokio::test]
@@ -958,7 +964,12 @@ async fn old_api_sessions_path_returns_gone() {
     assert_eq!(resp.status(), StatusCode::GONE);
     let body = body_json(resp).await;
     assert_eq!(body["error"]["code"], "api_version_required");
-    assert!(body["error"]["message"].as_str().unwrap().contains("/api/v1/sessions"));
+    assert!(
+        body["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("/api/v1/sessions")
+    );
 }
 
 #[tokio::test]
@@ -972,21 +983,35 @@ async fn old_api_nous_path_returns_gone() {
     assert_eq!(resp.status(), StatusCode::GONE);
     let body = body_json(resp).await;
     assert_eq!(body["error"]["code"], "api_version_required");
-    assert!(body["error"]["message"].as_str().unwrap().contains("/api/v1/nous"));
+    assert!(
+        body["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("/api/v1/nous")
+    );
 }
 
 #[tokio::test]
 async fn fallback_404_returns_json_error() {
     let (app, _dir) = app().await;
     let resp = app
-        .oneshot(Request::get("/totally/unknown/path").body(Body::empty()).unwrap())
+        .oneshot(
+            Request::get("/totally/unknown/path")
+                .body(Body::empty())
+                .unwrap(),
+        )
         .await
         .expect("response");
 
     assert_eq!(resp.status(), StatusCode::NOT_FOUND);
     let body = body_json(resp).await;
     assert_eq!(body["error"]["code"], "not_found");
-    assert!(body["error"]["message"].as_str().unwrap().contains("/totally/unknown/path"));
+    assert!(
+        body["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("/totally/unknown/path")
+    );
     assert!(body["error"]["request_id"].is_string());
 }
 
@@ -1017,18 +1042,12 @@ async fn security_headers_present_on_response() {
         .unwrap();
 
     assert_eq!(resp.status(), StatusCode::OK);
-    assert_eq!(
-        resp.headers().get("x-frame-options").unwrap(),
-        "DENY"
-    );
+    assert_eq!(resp.headers().get("x-frame-options").unwrap(), "DENY");
     assert_eq!(
         resp.headers().get("x-content-type-options").unwrap(),
         "nosniff"
     );
-    assert_eq!(
-        resp.headers().get("x-xss-protection").unwrap(),
-        "0"
-    );
+    assert_eq!(resp.headers().get("x-xss-protection").unwrap(), "0");
     assert_eq!(
         resp.headers().get("referrer-policy").unwrap(),
         "strict-origin-when-cross-origin"
@@ -1044,7 +1063,10 @@ async fn security_headers_present_on_response() {
 #[tokio::test]
 async fn hsts_header_present_when_tls_enabled() {
     let (state, _dir) = test_state().await;
-    let security = SecurityConfig { tls_enabled: true, ..SecurityConfig::default() };
+    let security = SecurityConfig {
+        tls_enabled: true,
+        ..SecurityConfig::default()
+    };
     let router = build_router(state, &security);
 
     let resp = router
@@ -1063,7 +1085,10 @@ async fn hsts_header_present_when_tls_enabled() {
 #[tokio::test]
 async fn oversized_body_returns_413() {
     let (state, _dir) = test_state().await;
-    let security = SecurityConfig { body_limit_bytes: 100, ..SecurityConfig::default() };
+    let security = SecurityConfig {
+        body_limit_bytes: 100,
+        ..SecurityConfig::default()
+    };
     let router = build_router(state, &security);
 
     let big_body = "x".repeat(200);
@@ -1085,7 +1110,10 @@ async fn oversized_body_returns_413() {
 #[tokio::test]
 async fn csrf_rejects_post_without_header() {
     let (state, _dir) = test_state().await;
-    let security = SecurityConfig { csrf_enabled: true, ..SecurityConfig::default() };
+    let security = SecurityConfig {
+        csrf_enabled: true,
+        ..SecurityConfig::default()
+    };
     let router = build_router(state, &security);
 
     let req = authed_request(
@@ -1104,7 +1132,10 @@ async fn csrf_rejects_post_without_header() {
 #[tokio::test]
 async fn csrf_allows_post_with_correct_header() {
     let (state, _dir) = test_state().await;
-    let security = SecurityConfig { csrf_enabled: true, ..SecurityConfig::default() };
+    let security = SecurityConfig {
+        csrf_enabled: true,
+        ..SecurityConfig::default()
+    };
     let router = build_router(state, &security);
 
     let token = default_token();
@@ -1130,13 +1161,13 @@ async fn csrf_allows_post_with_correct_header() {
 #[tokio::test]
 async fn csrf_allows_get_without_header() {
     let (state, _dir) = test_state().await;
-    let security = SecurityConfig { csrf_enabled: true, ..SecurityConfig::default() };
+    let security = SecurityConfig {
+        csrf_enabled: true,
+        ..SecurityConfig::default()
+    };
     let router = build_router(state, &security);
 
-    let resp = router
-        .oneshot(authed_get("/api/v1/nous"))
-        .await
-        .unwrap();
+    let resp = router.oneshot(authed_get("/api/v1/nous")).await.unwrap();
 
     assert_eq!(resp.status(), StatusCode::OK);
 }
@@ -1147,21 +1178,32 @@ async fn csrf_allows_get_without_header() {
 async fn openapi_spec_returns_valid_json() {
     let (app, _dir) = app().await;
     let resp = app
-        .oneshot(Request::get("/api/docs/openapi.json").body(Body::empty()).unwrap())
+        .oneshot(
+            Request::get("/api/docs/openapi.json")
+                .body(Body::empty())
+                .unwrap(),
+        )
         .await
         .unwrap();
 
     assert_eq!(resp.status(), StatusCode::OK);
     let body = body_json(resp).await;
     let version = body["openapi"].as_str().unwrap();
-    assert!(version.starts_with("3."), "expected OpenAPI 3.x, got {version}");
+    assert!(
+        version.starts_with("3."),
+        "expected OpenAPI 3.x, got {version}"
+    );
 }
 
 #[tokio::test]
 async fn openapi_spec_has_all_paths() {
     let (app, _dir) = app().await;
     let resp = app
-        .oneshot(Request::get("/api/docs/openapi.json").body(Body::empty()).unwrap())
+        .oneshot(
+            Request::get("/api/docs/openapi.json")
+                .body(Body::empty())
+                .unwrap(),
+        )
         .await
         .unwrap();
 
@@ -1181,7 +1223,11 @@ async fn openapi_spec_has_all_paths() {
 async fn openapi_docs_no_auth_required() {
     let (app, _dir) = app().await;
     let resp = app
-        .oneshot(Request::get("/api/docs/openapi.json").body(Body::empty()).unwrap())
+        .oneshot(
+            Request::get("/api/docs/openapi.json")
+                .body(Body::empty())
+                .unwrap(),
+        )
         .await
         .unwrap();
 
@@ -1192,7 +1238,11 @@ async fn openapi_docs_no_auth_required() {
 async fn openapi_spec_has_schemas() {
     let (app, _dir) = app().await;
     let resp = app
-        .oneshot(Request::get("/api/docs/openapi.json").body(Body::empty()).unwrap())
+        .oneshot(
+            Request::get("/api/docs/openapi.json")
+                .body(Body::empty())
+                .unwrap(),
+        )
         .await
         .unwrap();
 
@@ -1316,7 +1366,10 @@ async fn cors_permissive_when_no_origins_configured() {
 #[tokio::test]
 async fn cors_rejects_unlisted_origin() {
     let (state, _dir) = test_state().await;
-    let security = SecurityConfig { allowed_origins: vec!["http://localhost:3000".to_owned()], ..SecurityConfig::default() };
+    let security = SecurityConfig {
+        allowed_origins: vec!["http://localhost:3000".to_owned()],
+        ..SecurityConfig::default()
+    };
     let router = build_router(state, &security);
 
     let req = Request::builder()
@@ -1330,8 +1383,5 @@ async fn cors_rejects_unlisted_origin() {
     let resp = router.oneshot(req).await.unwrap();
     // Should not have the evil origin in access-control-allow-origin
     let allow_origin = resp.headers().get("access-control-allow-origin");
-    assert!(
-        allow_origin.is_none()
-            || allow_origin.unwrap() != "http://evil.example.com"
-    );
+    assert!(allow_origin.is_none() || allow_origin.unwrap() != "http://evil.example.com");
 }

--- a/crates/symbolon/src/lib.rs
+++ b/crates/symbolon/src/lib.rs
@@ -5,10 +5,10 @@
 
 /// API key generation, validation, and revocation.
 pub mod api_key;
-/// Credential provider implementations for LLM API key resolution.
-pub mod credential;
 /// Unified auth facade composing JWT, API keys, passwords, and RBAC.
 pub mod auth;
+/// Credential provider implementations for LLM API key resolution.
+pub mod credential;
 /// Symbolon-specific error types and result alias.
 pub mod error;
 /// JWT token issuance, validation, and refresh.


### PR DESCRIPTION
## Summary

Brings hermeneus to full Anthropic Messages API surface coverage:

- **Prompt caching** — `cache_system`/`cache_tools` fields on `CompletionRequest`; system prompt serialized as JSON array with `cache_control` when enabled; last tool definition gets ephemeral cache marker
- **Token counting** — `count_tokens()` on `LlmProvider` trait with `TokenCount` return type; `AnthropicProvider` hits `/v1/messages/count_tokens`
- **Tool choice** — `ToolChoice` enum (`Auto`/`Any`/`Tool{name}`) with proper wire serialization
- **Request metadata** — `RequestMetadata` with `user_id` pass-through for abuse tracking
- **Citations** — `CitationConfig` on requests; `Citation` enum (`CharLocation`/`PageLocation`/`WebSearchResultLocation`) on `ContentBlock::Text`
- **Extended thinking signatures** — `signature` field on `ContentBlock::Thinking` and streaming `SignatureDelta` accumulator
- **Batch API types** — `BatchRequest`, `BatchItem`, `BatchResponse`, `BatchResult`, `BatchError` with `serde_json::Value` params
- **Provider trait** — `supports_caching()`, `supports_citations()` capability queries
- **CompletionRequest** — `Default` impl for backward-compatible field additions
- **Module docs** — "Anthropic-native" framing replaces "provider-agnostic"

All call sites updated across nous, melete, pylon, and integration-tests for new `ContentBlock`/`CompletionRequest` shapes.

## Test plan

- [x] `cargo test -p aletheia-hermeneus` — 102 tests pass (17 new)
- [x] `cargo test --workspace` — 985 tests pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — zero warnings
- [x] `cargo doc --workspace --no-deps` — builds clean
- [x] `cargo fmt --check -p aletheia-hermeneus` — formatted