### PR TITLE
feat(tui): row-level message selection with context-sensitive actions

### DIFF
--- a/tui/Cargo.lock
+++ b/tui/Cargo.lock
@@ -28,6 +28,7 @@ dependencies = [
  "dirs",
  "futures-util",
  "fuzzy-matcher",
+ "open",
  "pulldown-cmark",
  "ratatui",
  "reqwest",
@@ -1198,6 +1199,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-docker"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "is-wsl"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
+dependencies = [
+ "is-docker",
+ "once_cell",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1595,6 +1615,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "open"
+version = "5.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43bb73a7fa3799b198970490a51174027ba0d4ec504b03cd08caf513d40024bc"
+dependencies = [
+ "is-wsl",
+ "libc",
+ "pathdiff",
+]
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1631,6 +1662,12 @@ dependencies = [
  "smallvec",
  "windows-link",
 ]
+
+[[package]]
+name = "pathdiff"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "percent-encoding"

--- a/tui/Cargo.toml
+++ b/tui/Cargo.toml
@@ -52,6 +52,9 @@ arboard = "3"
 # Fuzzy matching for command palette
 fuzzy-matcher = "0.3"
 
+# Cross-platform URL/file opening
+open = "5"
+
 [profile.release]
 strip = true
 lto = "thin"

--- a/tui/src/app.rs
+++ b/tui/src/app.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use anyhow::Result;
 use ratatui::Frame;
@@ -88,6 +88,10 @@ pub struct App {
     pub active_filter: Option<String>,
     pub context_usage_pct: Option<u8>,
     pub selection: SelectionContext,
+
+    // Message selection (None = auto-scroll mode, Some(index) = message selected)
+    pub selected_message: Option<usize>,
+    pub tool_expanded: HashSet<String>,
 }
 
 impl App {
@@ -134,6 +138,8 @@ impl App {
             active_filter: Option::None,
             context_usage_pct: Option::None,
             selection: SelectionContext::default(),
+            selected_message: None,
+            tool_expanded: HashSet::new(),
         };
 
         app.connect().await?;

--- a/tui/src/keybindings.rs
+++ b/tui/src/keybindings.rs
@@ -111,6 +111,12 @@ pub fn all_keybindings() -> &'static [Keybinding] {
             contexts: &[KeyContext::Chat],
             show_in_status_bar: false,
         },
+        Keybinding {
+            keys: "\u{2191}/\u{2193}",
+            description: "Select message",
+            contexts: &[KeyContext::Chat],
+            show_in_status_bar: true,
+        },
         // --- Selection ---
         Keybinding {
             keys: "j / \u{2193}",
@@ -159,6 +165,18 @@ pub fn all_keybindings() -> &'static [Keybinding] {
             description: "Inspect tool call",
             contexts: &[KeyContext::Selection],
             show_in_status_bar: true,
+        },
+        Keybinding {
+            keys: "G / End",
+            description: "Jump to newest",
+            contexts: &[KeyContext::Selection],
+            show_in_status_bar: false,
+        },
+        Keybinding {
+            keys: "Home",
+            description: "Jump to oldest",
+            contexts: &[KeyContext::Selection],
+            show_in_status_bar: false,
         },
         Keybinding {
             keys: "Esc",

--- a/tui/src/mapping.rs
+++ b/tui/src/mapping.rs
@@ -6,7 +6,7 @@ use crossterm::event::{
 use crate::api::types::SseEvent;
 use crate::app::App;
 use crate::events::{Event, StreamEvent};
-use crate::msg::{Msg, OverlayKind};
+use crate::msg::{MessageActionKind, Msg, OverlayKind};
 use crate::state::Overlay;
 
 impl App {
@@ -64,6 +64,11 @@ impl App {
             return self.map_palette_key(key);
         }
 
+        // Selection mode — single-letter keys become actions
+        if self.selected_message.is_some() {
+            return self.map_selection_key(key);
+        }
+
         match (key.modifiers, key.code) {
             (KeyModifiers::CONTROL, KeyCode::Char('c'))
             | (KeyModifiers::CONTROL, KeyCode::Char('q')) => Some(Msg::Quit),
@@ -100,8 +105,17 @@ impl App {
             (_, KeyCode::Right) => Some(Msg::CursorRight),
             (_, KeyCode::Home) => Some(Msg::CursorHome),
             (_, KeyCode::End) => Some(Msg::CursorEnd),
+
+            // Up/Down with empty input enters selection mode; otherwise history nav
+            (_, KeyCode::Up) if self.input.text.is_empty() && !self.messages.is_empty() => {
+                Some(Msg::SelectPrev)
+            }
+            (_, KeyCode::Down) if self.input.text.is_empty() && !self.messages.is_empty() => {
+                Some(Msg::SelectNext)
+            }
             (_, KeyCode::Up) => Some(Msg::HistoryUp),
             (_, KeyCode::Down) => Some(Msg::HistoryDown),
+
             (KeyModifiers::CONTROL, KeyCode::Char('w')) => Some(Msg::DeleteWord),
             (KeyModifiers::CONTROL, KeyCode::Char('u')) => Some(Msg::ClearLine),
             (KeyModifiers::CONTROL, KeyCode::Char('y')) => Some(Msg::CopyLastResponse),
@@ -117,6 +131,67 @@ impl App {
                 Some(Msg::CommandPaletteOpen)
             }
 
+            (KeyModifiers::NONE | KeyModifiers::SHIFT, KeyCode::Char(c)) => {
+                Some(Msg::CharInput(c))
+            }
+
+            _ => None,
+        }
+    }
+
+    fn map_selection_key(&self, key: KeyEvent) -> Option<Msg> {
+        match (key.modifiers, key.code) {
+            // Ctrl combos pass through to global handlers
+            (KeyModifiers::CONTROL, KeyCode::Char('c'))
+            | (KeyModifiers::CONTROL, KeyCode::Char('q')) => Some(Msg::Quit),
+            (KeyModifiers::CONTROL, KeyCode::Char('f')) => Some(Msg::ToggleSidebar),
+            (KeyModifiers::CONTROL, KeyCode::Char('t')) => Some(Msg::ToggleThinking),
+            (KeyModifiers::CONTROL, KeyCode::Char('a')) => {
+                Some(Msg::OpenOverlay(OverlayKind::AgentPicker))
+            }
+            (KeyModifiers::CONTROL, KeyCode::Char('i')) => {
+                Some(Msg::OpenOverlay(OverlayKind::SystemStatus))
+            }
+            (KeyModifiers::CONTROL, KeyCode::Char('n')) => Some(Msg::NewSession),
+
+            // Shift+Up/Down scroll (before bare Up/Down)
+            (KeyModifiers::SHIFT, KeyCode::Up) => Some(Msg::ScrollUp),
+            (KeyModifiers::SHIFT, KeyCode::Down) => Some(Msg::ScrollDown),
+
+            // Navigation
+            (_, KeyCode::Char('j')) | (_, KeyCode::Down) => Some(Msg::SelectNext),
+            (_, KeyCode::Char('k')) | (_, KeyCode::Up) => Some(Msg::SelectPrev),
+            (_, KeyCode::Esc) => Some(Msg::DeselectMessage),
+            (_, KeyCode::Home) => Some(Msg::SelectFirst),
+            (_, KeyCode::End) | (KeyModifiers::SHIFT, KeyCode::Char('G')) => {
+                Some(Msg::SelectLast)
+            }
+
+            // Actions
+            (KeyModifiers::NONE, KeyCode::Char('c')) => {
+                Some(Msg::MessageAction(MessageActionKind::Copy))
+            }
+            (KeyModifiers::NONE, KeyCode::Char('y')) => {
+                Some(Msg::MessageAction(MessageActionKind::YankCodeBlock))
+            }
+            (KeyModifiers::NONE, KeyCode::Char('e')) => {
+                Some(Msg::MessageAction(MessageActionKind::Edit))
+            }
+            (KeyModifiers::NONE, KeyCode::Char('d')) => {
+                Some(Msg::MessageAction(MessageActionKind::Delete))
+            }
+            (KeyModifiers::NONE, KeyCode::Char('o')) => {
+                Some(Msg::MessageAction(MessageActionKind::OpenLinks))
+            }
+            (KeyModifiers::NONE, KeyCode::Char('i')) => {
+                Some(Msg::MessageAction(MessageActionKind::Inspect))
+            }
+
+            (_, KeyCode::PageUp) => Some(Msg::ScrollPageUp),
+            (_, KeyCode::PageDown) => Some(Msg::ScrollPageDown),
+            (_, KeyCode::F(1)) => Some(Msg::OpenOverlay(OverlayKind::Help)),
+
+            // Any other character deselects and inserts into input
             (KeyModifiers::NONE | KeyModifiers::SHIFT, KeyCode::Char(c)) => {
                 Some(Msg::CharInput(c))
             }

--- a/tui/src/msg.rs
+++ b/tui/src/msg.rs
@@ -34,6 +34,14 @@ pub enum Msg {
 
     NewSession, // Ctrl+N — start new topic
 
+    // --- Message selection ---
+    SelectPrev,                          // k or Up in selection mode
+    SelectNext,                          // j or Down in selection mode
+    DeselectMessage,                     // Esc — return to auto-scroll
+    SelectFirst,                         // Home in selection mode
+    SelectLast,                          // G or End in selection mode
+    MessageAction(MessageActionKind),    // Action on selected message
+
     // --- Navigation ---
     ScrollUp,
     ScrollDown,
@@ -181,6 +189,16 @@ pub enum Msg {
 
     // --- Timer ---
     Tick,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MessageActionKind {
+    Copy,
+    YankCodeBlock,
+    Edit,
+    Delete,
+    OpenLinks,
+    Inspect,
 }
 
 #[derive(Debug, Clone)]

--- a/tui/src/update/mod.rs
+++ b/tui/src/update/mod.rs
@@ -3,6 +3,7 @@ mod command;
 mod input;
 mod navigation;
 mod overlay;
+pub(crate) mod selection;
 mod sse;
 mod streaming;
 
@@ -13,8 +14,22 @@ pub(crate) use api::extract_text_content;
 
 pub(crate) async fn update(app: &mut App, msg: Msg) {
     match msg {
+        // --- Message selection ---
+        Msg::SelectPrev => selection::handle_select_prev(app),
+        Msg::SelectNext => selection::handle_select_next(app),
+        Msg::DeselectMessage => selection::handle_deselect(app),
+        Msg::SelectFirst => selection::handle_select_first(app),
+        Msg::SelectLast => selection::handle_select_last(app),
+        Msg::MessageAction(action) => selection::handle_message_action(app, action),
+
         // --- Input ---
-        Msg::CharInput(c) => input::handle_char_input(app, c),
+        Msg::CharInput(c) => {
+            // If a message is selected and a non-action char arrives, deselect first
+            if app.selected_message.is_some() {
+                selection::handle_deselect(app);
+            }
+            input::handle_char_input(app, c);
+        }
         Msg::Backspace => input::handle_backspace(app),
         Msg::Delete => input::handle_delete(app),
         Msg::CursorLeft => input::handle_cursor_left(app),

--- a/tui/src/update/selection.rs
+++ b/tui/src/update/selection.rs
@@ -1,0 +1,253 @@
+/// Message selection handlers — navigation, actions, and SelectionContext sync.
+use crate::app::App;
+use crate::msg::{ErrorToast, MessageActionKind};
+use crate::state::SelectionContext;
+
+pub(crate) fn handle_select_prev(app: &mut App) {
+    let count = app.messages.len();
+    if count == 0 {
+        return;
+    }
+    match app.selected_message {
+        None => {
+            // Enter selection mode on last message
+            let idx = count - 1;
+            app.selected_message = Some(idx);
+            app.auto_scroll = false;
+        }
+        Some(idx) => {
+            if idx > 0 {
+                app.selected_message = Some(idx - 1);
+            }
+        }
+    }
+    sync_selection_context(app);
+}
+
+pub(crate) fn handle_select_next(app: &mut App) {
+    let count = app.messages.len();
+    if count == 0 {
+        return;
+    }
+    match app.selected_message {
+        None => {
+            // Enter selection mode on last message
+            let idx = count - 1;
+            app.selected_message = Some(idx);
+            app.auto_scroll = false;
+        }
+        Some(idx) => {
+            if idx + 1 < count {
+                app.selected_message = Some(idx + 1);
+            }
+        }
+    }
+    sync_selection_context(app);
+}
+
+pub(crate) fn handle_deselect(app: &mut App) {
+    app.selected_message = None;
+    app.selection = SelectionContext::None;
+    app.scroll_to_bottom();
+}
+
+pub(crate) fn handle_select_first(app: &mut App) {
+    if app.messages.is_empty() {
+        return;
+    }
+    app.selected_message = Some(0);
+    app.auto_scroll = false;
+    sync_selection_context(app);
+}
+
+pub(crate) fn handle_select_last(app: &mut App) {
+    if app.messages.is_empty() {
+        return;
+    }
+    app.selected_message = Some(app.messages.len() - 1);
+    app.auto_scroll = false;
+    sync_selection_context(app);
+}
+
+pub(crate) fn handle_message_action(app: &mut App, action: MessageActionKind) {
+    let idx = match app.selected_message {
+        Some(i) if i < app.messages.len() => i,
+        _ => return,
+    };
+
+    match action {
+        MessageActionKind::Copy => action_copy(app, idx),
+        MessageActionKind::YankCodeBlock => action_yank_code_block(app, idx),
+        MessageActionKind::Edit => action_edit(app, idx),
+        MessageActionKind::Delete => action_delete(app, idx),
+        MessageActionKind::OpenLinks => action_open_links(app, idx),
+        MessageActionKind::Inspect => action_inspect(app, idx),
+    }
+}
+
+fn action_copy(app: &mut App, idx: usize) {
+    let text = &app.messages[idx].text;
+    match crate::clipboard::copy_to_clipboard(text) {
+        Ok(()) => show_toast(app, "Copied to clipboard"),
+        Err(e) => {
+            tracing::error!("clipboard copy failed: {e}");
+            show_toast(app, "Clipboard copy failed");
+        }
+    }
+}
+
+fn action_yank_code_block(app: &mut App, idx: usize) {
+    let text = &app.messages[idx].text;
+    if let Some(code) = extract_first_code_block(text) {
+        match crate::clipboard::copy_to_clipboard(&code) {
+            Ok(()) => show_toast(app, "Code block copied"),
+            Err(e) => {
+                tracing::error!("clipboard copy failed: {e}");
+                show_toast(app, "Clipboard copy failed");
+            }
+        }
+    } else {
+        // No code block — copy full message
+        match crate::clipboard::copy_to_clipboard(text) {
+            Ok(()) => show_toast(app, "No code block found — copied full message"),
+            Err(e) => {
+                tracing::error!("clipboard copy failed: {e}");
+                show_toast(app, "Clipboard copy failed");
+            }
+        }
+    }
+}
+
+fn action_edit(app: &mut App, idx: usize) {
+    if app.messages[idx].role != "user" {
+        show_toast(app, "Can only edit user messages");
+        return;
+    }
+    let text = app.messages[idx].text.clone();
+    app.messages.remove(idx);
+    app.selected_message = None;
+    app.selection = SelectionContext::None;
+    app.input.text = text;
+    app.input.cursor = app.input.text.len();
+}
+
+fn action_delete(app: &mut App, idx: usize) {
+    if app.messages[idx].role != "user" {
+        show_toast(app, "Can only delete user messages");
+        return;
+    }
+    app.messages.remove(idx);
+    // Fix selection index after removal
+    let count = app.messages.len();
+    if count == 0 {
+        app.selected_message = None;
+        app.selection = SelectionContext::None;
+    } else if idx >= count {
+        app.selected_message = Some(count - 1);
+        sync_selection_context(app);
+    } else {
+        sync_selection_context(app);
+    }
+    show_toast(app, "Message deleted");
+}
+
+fn action_open_links(app: &mut App, idx: usize) {
+    let text = &app.messages[idx].text;
+    let urls = extract_urls(text);
+    match urls.len() {
+        0 => show_toast(app, "No links found"),
+        1 => {
+            if let Err(e) = open::that(&urls[0]) {
+                tracing::error!("failed to open URL: {e}");
+                show_toast(app, "Failed to open link");
+            }
+        }
+        n => {
+            // Open the first link and notify about the rest
+            if let Err(e) = open::that(&urls[0]) {
+                tracing::error!("failed to open URL: {e}");
+                show_toast(app, "Failed to open link");
+            } else {
+                show_toast(app, &format!("Opened 1 of {} links", n));
+            }
+        }
+    }
+}
+
+fn action_inspect(app: &mut App, idx: usize) {
+    let msg = &app.messages[idx];
+    if msg.tool_calls.is_empty() {
+        show_toast(app, "No tool calls to inspect");
+        return;
+    }
+    // Toggle expanded state for all tool calls on this message
+    let key = format!("msg:{idx}");
+    if app.tool_expanded.contains(&key) {
+        app.tool_expanded.remove(&key);
+    } else {
+        app.tool_expanded.insert(key);
+    }
+}
+
+fn sync_selection_context(app: &mut App) {
+    app.selection = match app.selected_message {
+        Some(idx) if idx < app.messages.len() => {
+            let msg = &app.messages[idx];
+            match msg.role.as_str() {
+                "user" => SelectionContext::UserMessage { index: idx },
+                "assistant" => SelectionContext::AgentResponse {
+                    index: idx,
+                    has_code: msg.text.contains("```"),
+                    has_links: msg.text.contains("http"),
+                },
+                _ => SelectionContext::None,
+            }
+        }
+        _ => SelectionContext::None,
+    };
+}
+
+fn extract_first_code_block(text: &str) -> Option<String> {
+    let mut lines = text.lines();
+    let mut in_block = false;
+    let mut code = String::new();
+
+    for line in &mut lines {
+        if !in_block {
+            if line.trim_start().starts_with("```") {
+                in_block = true;
+                continue;
+            }
+        } else if line.trim_start().starts_with("```") {
+            return Some(code);
+        } else {
+            if !code.is_empty() {
+                code.push('\n');
+            }
+            code.push_str(line);
+        }
+    }
+    None
+}
+
+fn extract_urls(text: &str) -> Vec<String> {
+    let mut urls = Vec::new();
+    for word in text.split_whitespace() {
+        // Handle URLs that may be wrapped in markdown link syntax
+        let candidate = word
+            .trim_start_matches('(')
+            .trim_start_matches('[')
+            .trim_end_matches(')')
+            .trim_end_matches(']')
+            .trim_end_matches(',')
+            .trim_end_matches('.');
+        if candidate.starts_with("http://") || candidate.starts_with("https://") {
+            urls.push(candidate.to_string());
+        }
+    }
+    urls
+}
+
+fn show_toast(app: &mut App, message: &str) {
+    app.error_toast = Some(ErrorToast::new(message.to_string()));
+}

--- a/tui/src/view/chat.rs
+++ b/tui/src/view/chat.rs
@@ -16,8 +16,9 @@ pub fn render(app: &App, frame: &mut Frame, area: Rect, theme: &ThemePalette) {
     lines.push(Line::raw(""));
 
     // Render each message
-    for msg in &app.messages {
-        render_message(app, msg, &mut lines, inner_width, theme);
+    for (idx, msg) in app.messages.iter().enumerate() {
+        let selected = app.selected_message == Some(idx);
+        render_message(app, msg, &mut lines, inner_width, theme, selected);
     }
 
     // Streaming response (in progress)
@@ -65,6 +66,7 @@ fn render_message(
     lines: &mut Vec<Line<'static>>,
     inner_width: usize,
     theme: &ThemePalette,
+    selected: bool,
 ) {
     let (role_label, role_style) = match msg.role.as_str() {
         "user" => ("you".to_string(), theme.style_user()),
@@ -80,8 +82,19 @@ fn render_message(
         _ => ("system".to_string(), theme.style_muted()),
     };
 
-    // Header: role name + optional model (dim) + timestamp
-    let mut header_spans = vec![Span::styled(format!(" {}", role_label), role_style)];
+    // Selection indicator prefix
+    let marker = if selected { "▸" } else { " " };
+    let marker_style = if selected {
+        Style::default().fg(theme.selected)
+    } else {
+        Style::default()
+    };
+
+    // Header: selection marker + role name + optional model (dim) + timestamp
+    let mut header_spans = vec![
+        Span::styled(marker, marker_style),
+        Span::styled(format!(" {}", role_label), role_style),
+    ];
 
     if let Some(ref model) = msg.model {
         let short_model = model.split('/').next_back().unwrap_or(model);
@@ -114,8 +127,14 @@ fn render_message(
         theme,
         &app.highlighter,
     );
+    let content_prefix = if selected { "│" } else { " " };
+    let prefix_style = if selected {
+        Style::default().fg(theme.selected)
+    } else {
+        Style::default()
+    };
     for line in rendered {
-        let mut padded_spans = vec![Span::raw(" ")];
+        let mut padded_spans = vec![Span::styled(content_prefix, prefix_style)];
         padded_spans.extend(line.spans);
         lines.push(Line::from(padded_spans));
     }


### PR DESCRIPTION
## Summary

- Vim-style `j`/`k` cursor navigation on chat messages with `▸`/`│` visual indicator
- Context-sensitive single-letter actions: `c` copy, `y` yank code block, `e` edit, `d` delete (user msgs), `o` open links, `i` inspect tool calls
- Arrow keys with empty input enter selection mode; `Esc` exits back to auto-scroll
- `G`/`End` jump to newest, `Home` to oldest message
- SelectionContext synced to status bar for contextual keybinding hints
- New `open` crate dependency for cross-platform URL opening

## Test plan

- [ ] Launch TUI with messages, press `↓` — first message highlights with `▸`
- [ ] `j`/`k` navigates between messages, `│` bar shows on content lines
- [ ] `c` copies message text to clipboard (toast confirms)
- [ ] `y` yanks first code block (or full message if none)
- [ ] `e` on user message loads text into input field
- [ ] `d` on user message deletes it (toast confirms)
- [ ] `o` on message with URL opens in browser
- [ ] `Esc` clears selection, returns to auto-scroll
- [ ] Typing any non-action character deselects and inserts into input
- [ ] Status bar hints update to show selection actions when in selection mode