### PR TITLE
feat(tui): live filtering with `/` mode

### DIFF
--- a/tui/src/app.rs
+++ b/tui/src/app.rs
@@ -15,7 +15,7 @@ use crate::view;
 
 #[expect(unused_imports, reason = "re-exported for downstream modules that import from crate::app")]
 pub use crate::state::{
-    AgentState, AgentStatus, ChatMessage, CommandPaletteState, InputState, Overlay,
+    AgentState, AgentStatus, ChatMessage, CommandPaletteState, FilterState, InputState, Overlay,
     PlanApprovalOverlay, PlanStepApproval, SelectionContext, TabCompletion,
     ToolApprovalOverlay, ToolCallInfo,
 };
@@ -85,13 +85,15 @@ pub struct App {
 
     // Status bar enhanced fields
     pub session_cost_cents: u32,
-    pub active_filter: Option<String>,
     pub context_usage_pct: Option<u8>,
     pub selection: SelectionContext,
 
     // Message selection (None = auto-scroll mode, Some(index) = message selected)
     pub selected_message: Option<usize>,
     pub tool_expanded: HashSet<String>,
+
+    // Live filter (`/` mode)
+    pub filter: FilterState,
 }
 
 impl App {
@@ -135,11 +137,11 @@ impl App {
             terminal_height: 40,
             command_palette: CommandPaletteState::default(),
             session_cost_cents: 0,
-            active_filter: Option::None,
             context_usage_pct: Option::None,
             selection: SelectionContext::default(),
             selected_message: None,
             tool_expanded: HashSet::new(),
+            filter: FilterState::default(),
         };
 
         app.connect().await?;

--- a/tui/src/keybindings.rs
+++ b/tui/src/keybindings.rs
@@ -383,6 +383,8 @@ pub fn current_contexts(app: &App) -> Vec<KeyContext> {
         Some(Overlay::Help) | None => {
             if app.command_palette.active {
                 contexts.push(KeyContext::CommandPalette);
+            } else if app.filter.active {
+                contexts.push(KeyContext::Filter);
             } else if app.selection != SelectionContext::None {
                 contexts.push(KeyContext::Selection);
             } else {
@@ -412,6 +414,8 @@ pub fn context_label(app: &App) -> &'static str {
         Some(Overlay::Help) | None => {
             if app.command_palette.active {
                 "Command Palette"
+            } else if app.filter.active {
+                "Filter"
             } else if app.selection != SelectionContext::None {
                 "Selection"
             } else {

--- a/tui/src/mapping.rs
+++ b/tui/src/mapping.rs
@@ -64,6 +64,16 @@ impl App {
             return self.map_palette_key(key);
         }
 
+        if self.filter.editing {
+            return self.map_filter_editing_key(key);
+        }
+
+        if self.filter.active
+            && let Some(msg) = self.map_filter_applied_key(key)
+        {
+            return Some(msg);
+        }
+
         // Selection mode — single-letter keys become actions
         if self.selected_message.is_some() {
             return self.map_selection_key(key);
@@ -131,6 +141,10 @@ impl App {
                 Some(Msg::CommandPaletteOpen)
             }
 
+            (KeyModifiers::NONE, KeyCode::Char('/')) if self.input.text.is_empty() => {
+                Some(Msg::FilterOpen)
+            }
+
             (KeyModifiers::NONE | KeyModifiers::SHIFT, KeyCode::Char(c)) => {
                 Some(Msg::CharInput(c))
             }
@@ -196,6 +210,41 @@ impl App {
                 Some(Msg::CharInput(c))
             }
 
+            _ => None,
+        }
+    }
+
+    fn map_filter_editing_key(&self, key: KeyEvent) -> Option<Msg> {
+        match (key.modifiers, key.code) {
+            (KeyModifiers::CONTROL, KeyCode::Char('c')) | (_, KeyCode::Esc) => {
+                Some(Msg::FilterClose)
+            }
+            (_, KeyCode::Enter) => Some(Msg::FilterConfirm),
+            (_, KeyCode::Backspace) => {
+                if self.filter.text.is_empty() {
+                    Some(Msg::FilterClose)
+                } else {
+                    Some(Msg::FilterBackspace)
+                }
+            }
+            (KeyModifiers::CONTROL, KeyCode::Char('u')) => Some(Msg::FilterClear),
+            (KeyModifiers::NONE | KeyModifiers::SHIFT, KeyCode::Char(c)) => {
+                Some(Msg::FilterInput(c))
+            }
+            _ => None,
+        }
+    }
+
+    fn map_filter_applied_key(&self, key: KeyEvent) -> Option<Msg> {
+        match (key.modifiers, key.code) {
+            (_, KeyCode::Esc) => Some(Msg::FilterClose),
+            (KeyModifiers::NONE, KeyCode::Char('/')) if self.input.text.is_empty() => {
+                Some(Msg::FilterOpen)
+            }
+            (KeyModifiers::NONE, KeyCode::Char('n')) if self.input.text.is_empty() => {
+                Some(Msg::FilterNextMatch)
+            }
+            (KeyModifiers::SHIFT, KeyCode::Char('N')) => Some(Msg::FilterPrevMatch),
             _ => None,
         }
     }

--- a/tui/src/msg.rs
+++ b/tui/src/msg.rs
@@ -42,6 +42,16 @@ pub enum Msg {
     SelectLast,                          // G or End in selection mode
     MessageAction(MessageActionKind),    // Action on selected message
 
+    // --- Filter (`/` mode) ---
+    FilterOpen,
+    FilterClose,
+    FilterInput(char),
+    FilterBackspace,
+    FilterClear,     // Ctrl+U — clear text, stay in edit mode
+    FilterConfirm,   // Enter — lock filter, exit edit mode
+    FilterNextMatch, // n — jump to next match
+    FilterPrevMatch, // N — jump to previous match
+
     // --- Navigation ---
     ScrollUp,
     ScrollDown,

--- a/tui/src/state/filter.rs
+++ b/tui/src/state/filter.rs
@@ -1,0 +1,106 @@
+/// Live filter state — `/` mode for real-time content narrowing.
+
+#[derive(Debug, Default, Clone, PartialEq)]
+pub enum FilterScope {
+    #[default]
+    Chat,
+    #[expect(dead_code, reason = "planned for sidebar filtering")]
+    Agents,
+}
+
+#[derive(Debug, Default)]
+pub struct FilterState {
+    /// Whether filter mode is active (editing or applied)
+    pub active: bool,
+    /// Whether the user is currently typing in the filter bar
+    pub editing: bool,
+    /// Current filter text
+    pub text: String,
+    /// Cursor position in filter text (byte offset)
+    pub cursor: usize,
+    /// Which view the filter applies to
+    pub scope: FilterScope,
+    /// Number of matches in current view
+    pub match_count: usize,
+    /// Total items before filtering
+    pub total_count: usize,
+    /// Index of the currently highlighted match (for n/N navigation)
+    pub current_match: usize,
+}
+
+impl FilterState {
+    pub fn open(&mut self) {
+        self.active = true;
+        self.editing = true;
+        self.text.clear();
+        self.cursor = 0;
+        self.match_count = 0;
+        self.total_count = 0;
+        self.current_match = 0;
+        self.scope = FilterScope::Chat;
+    }
+
+    pub fn close(&mut self) {
+        self.active = false;
+        self.editing = false;
+        self.text.clear();
+        self.cursor = 0;
+        self.match_count = 0;
+        self.total_count = 0;
+        self.current_match = 0;
+    }
+
+    pub fn confirm(&mut self) {
+        self.editing = false;
+    }
+
+    pub fn insert_char(&mut self, c: char) {
+        self.text.insert(self.cursor, c);
+        self.cursor += c.len_utf8();
+        self.current_match = 0;
+    }
+
+    pub fn backspace(&mut self) {
+        if self.cursor > 0 {
+            let prev = self.text[..self.cursor]
+                .char_indices()
+                .next_back()
+                .map(|(i, _)| i)
+                .unwrap_or(0);
+            self.text.drain(prev..self.cursor);
+            self.cursor = prev;
+            self.current_match = 0;
+        }
+    }
+
+    pub fn clear_text(&mut self) {
+        self.text.clear();
+        self.cursor = 0;
+        self.match_count = 0;
+        self.current_match = 0;
+    }
+
+    pub fn next_match(&mut self) {
+        if self.match_count > 0 {
+            self.current_match = (self.current_match + 1) % self.match_count;
+        }
+    }
+
+    pub fn prev_match(&mut self) {
+        if self.match_count > 0 {
+            self.current_match = self
+                .current_match
+                .checked_sub(1)
+                .unwrap_or(self.match_count - 1);
+        }
+    }
+
+    /// Returns the effective pattern (without `!` prefix) and whether it's inverted.
+    pub fn pattern(&self) -> (&str, bool) {
+        if let Some(rest) = self.text.strip_prefix('!') {
+            (rest, true)
+        } else {
+            (&self.text, false)
+        }
+    }
+}

--- a/tui/src/state/mod.rs
+++ b/tui/src/state/mod.rs
@@ -1,6 +1,7 @@
 mod agent;
 mod chat;
 mod command;
+mod filter;
 mod input;
 mod overlay;
 
@@ -8,5 +9,6 @@ pub use agent::{AgentState, AgentStatus};
 pub use chat::{ChatMessage, ToolCallInfo};
 pub(crate) use chat::SavedScrollState;
 pub use command::{CommandPaletteState, SelectionContext};
+pub use filter::{FilterScope, FilterState};
 pub use input::{InputState, TabCompletion};
 pub use overlay::{Overlay, PlanApprovalOverlay, PlanStepApproval, ToolApprovalOverlay};

--- a/tui/src/update/filter.rs
+++ b/tui/src/update/filter.rs
@@ -1,0 +1,78 @@
+use crate::app::App;
+
+pub(crate) fn handle_open(app: &mut App) {
+    app.filter.open();
+    update_match_counts(app);
+}
+
+pub(crate) fn handle_close(app: &mut App) {
+    app.filter.close();
+    app.scroll_to_bottom();
+}
+
+pub(crate) fn handle_input(app: &mut App, c: char) {
+    app.filter.insert_char(c);
+    update_match_counts(app);
+    scroll_to_first_match(app);
+}
+
+pub(crate) fn handle_backspace(app: &mut App) {
+    app.filter.backspace();
+    if app.filter.text.is_empty() {
+        app.filter.match_count = 0;
+        app.filter.total_count = app.messages.len();
+    } else {
+        update_match_counts(app);
+    }
+}
+
+pub(crate) fn handle_clear(app: &mut App) {
+    app.filter.clear_text();
+    app.filter.total_count = app.messages.len();
+}
+
+pub(crate) fn handle_confirm(app: &mut App) {
+    if app.filter.text.is_empty() {
+        app.filter.close();
+    } else {
+        app.filter.confirm();
+    }
+}
+
+pub(crate) fn handle_next_match(app: &mut App) {
+    app.filter.next_match();
+}
+
+pub(crate) fn handle_prev_match(app: &mut App) {
+    app.filter.prev_match();
+}
+
+fn update_match_counts(app: &mut App) {
+    let total = app.messages.len();
+    let (pattern, inverted) = app.filter.pattern();
+
+    if pattern.is_empty() {
+        app.filter.match_count = 0;
+        app.filter.total_count = total;
+        return;
+    }
+
+    let pattern_lower = pattern.to_lowercase();
+    let count = app
+        .messages
+        .iter()
+        .filter(|m| {
+            let contains = m.text.to_lowercase().contains(&pattern_lower);
+            if inverted { !contains } else { contains }
+        })
+        .count();
+
+    app.filter.match_count = count;
+    app.filter.total_count = total;
+}
+
+fn scroll_to_first_match(app: &mut App) {
+    app.auto_scroll = false;
+    app.scroll_offset = 0;
+    app.filter.current_match = 0;
+}

--- a/tui/src/update/mod.rs
+++ b/tui/src/update/mod.rs
@@ -1,5 +1,6 @@
 mod api;
 mod command;
+mod filter;
 mod input;
 mod navigation;
 mod overlay;
@@ -43,6 +44,16 @@ pub(crate) async fn update(app: &mut App, msg: Msg) {
         Msg::Submit => input::handle_submit(app),
         Msg::CopyLastResponse => input::handle_copy_last_response(app),
         Msg::ComposeInEditor => input::handle_compose_in_editor(app),
+
+        // --- Filter ---
+        Msg::FilterOpen => filter::handle_open(app),
+        Msg::FilterClose => filter::handle_close(app),
+        Msg::FilterInput(c) => filter::handle_input(app, c),
+        Msg::FilterBackspace => filter::handle_backspace(app),
+        Msg::FilterClear => filter::handle_clear(app),
+        Msg::FilterConfirm => filter::handle_confirm(app),
+        Msg::FilterNextMatch => filter::handle_next_match(app),
+        Msg::FilterPrevMatch => filter::handle_prev_match(app),
 
         // --- Command palette ---
         Msg::CommandPaletteOpen => command::handle_open(app),

--- a/tui/src/view/chat.rs
+++ b/tui/src/view/chat.rs
@@ -6,6 +6,7 @@ use ratatui::widgets::{Block, Borders, Paragraph, Wrap};
 
 use crate::app::{App, ToolCallInfo};
 use crate::markdown;
+use crate::state::FilterScope;
 use crate::theme::{self, ThemePalette};
 
 pub fn render(app: &App, frame: &mut Frame, area: Rect, theme: &ThemePalette) {
@@ -15,10 +16,31 @@ pub fn render(app: &App, frame: &mut Frame, area: Rect, theme: &ThemePalette) {
     // Small top padding
     lines.push(Line::raw(""));
 
-    // Render each message
+    let filter_active = app.filter.active
+        && app.filter.scope == FilterScope::Chat
+        && !app.filter.text.is_empty();
+    let (pattern, inverted) = app.filter.pattern();
+    let pattern_lower = pattern.to_lowercase();
+
+    // Render each message (filtered when active, with selection indicator)
     for (idx, msg) in app.messages.iter().enumerate() {
+        if filter_active {
+            let contains = msg.text.to_lowercase().contains(&pattern_lower);
+            let show = if inverted { !contains } else { contains };
+            if !show {
+                continue;
+            }
+        }
         let selected = app.selected_message == Some(idx);
-        render_message(app, msg, &mut lines, inner_width, theme, selected);
+        let highlight = filter_active.then_some(pattern_lower.as_str());
+        render_message(app, msg, &mut lines, inner_width, theme, selected, highlight);
+    }
+
+    if filter_active && lines.len() <= 1 {
+        lines.push(Line::from(vec![
+            Span::raw(" "),
+            Span::styled("no matches", theme.style_dim()),
+        ]));
     }
 
     // Streaming response (in progress)
@@ -67,6 +89,7 @@ fn render_message(
     inner_width: usize,
     theme: &ThemePalette,
     selected: bool,
+    highlight_pattern: Option<&str>,
 ) {
     let (role_label, role_style) = match msg.role.as_str() {
         "user" => ("you".to_string(), theme.style_user()),
@@ -133,14 +156,64 @@ fn render_message(
     } else {
         Style::default()
     };
+
+    let highlight_bg = Style::default().bg(theme.accent_dim);
+
     for line in rendered {
         let mut padded_spans = vec![Span::styled(content_prefix, prefix_style)];
-        padded_spans.extend(line.spans);
+
+        if let Some(pattern) = highlight_pattern {
+            for span in &line.spans {
+                highlight_span(span, pattern, highlight_bg, &mut padded_spans);
+            }
+        } else {
+            padded_spans.extend(line.spans);
+        }
+
         lines.push(Line::from(padded_spans));
     }
 
     // Breathing room between messages
     lines.push(Line::raw(""));
+}
+
+fn highlight_span(
+    span: &Span<'static>,
+    pattern: &str,
+    highlight_style: Style,
+    out: &mut Vec<Span<'static>>,
+) {
+    let content = &span.content;
+    let content_lower = content.to_lowercase();
+
+    if content_lower.len() != content.len() || pattern.is_empty() {
+        out.push(span.clone());
+        return;
+    }
+
+    let mut last_end = 0;
+    for (start, _) in content_lower.match_indices(pattern) {
+        let end = start + pattern.len();
+        if start > last_end {
+            out.push(Span::styled(
+                content[last_end..start].to_string(),
+                span.style,
+            ));
+        }
+        out.push(Span::styled(
+            content[start..end].to_string(),
+            span.style.patch(highlight_style),
+        ));
+        last_end = end;
+    }
+    if last_end < content.len() {
+        out.push(Span::styled(
+            content[last_end..].to_string(),
+            span.style,
+        ));
+    } else if last_end == 0 {
+        out.push(span.clone());
+    }
 }
 
 /// Render a compact tool call summary line:

--- a/tui/src/view/filter_bar.rs
+++ b/tui/src/view/filter_bar.rs
@@ -1,0 +1,42 @@
+use ratatui::Frame;
+use ratatui::layout::Rect;
+use ratatui::text::{Line, Span};
+use ratatui::widgets::Paragraph;
+use unicode_width::UnicodeWidthStr;
+
+use crate::app::App;
+use crate::theme::ThemePalette;
+
+pub fn render(app: &App, frame: &mut Frame, area: Rect, theme: &ThemePalette) {
+    let width = area.width as usize;
+
+    let cursor_char = if app.tick_count % 6 < 3 { "█" } else { " " };
+    let (before_cursor, after_cursor) = app.filter.text.split_at(app.filter.cursor);
+
+    let mut left_spans = vec![
+        Span::styled("/", theme.style_accent()),
+        Span::styled(before_cursor.to_string(), theme.style_fg()),
+        Span::styled(cursor_char, theme.style_accent()),
+        Span::styled(after_cursor.to_string(), theme.style_fg()),
+    ];
+
+    let right_text = if app.filter.text.is_empty() {
+        String::new()
+    } else {
+        format!("{}/{} matches", app.filter.match_count, app.filter.total_count)
+    };
+
+    let left_width: usize = left_spans.iter().map(|s| s.content.width()).sum();
+    let right_width = right_text.width();
+
+    if !right_text.is_empty() && left_width + right_width + 2 < width {
+        let pad = width.saturating_sub(left_width + right_width + 2);
+        left_spans.push(Span::raw(" ".repeat(pad)));
+        left_spans.push(Span::styled(right_text, theme.style_dim()));
+        left_spans.push(Span::raw(" "));
+    }
+
+    let line = Line::from(left_spans);
+    let bar = Paragraph::new(line).style(theme.style_surface());
+    frame.render_widget(bar, area);
+}

--- a/tui/src/view/mod.rs
+++ b/tui/src/view/mod.rs
@@ -1,5 +1,6 @@
 mod chat;
 mod command_palette;
+mod filter_bar;
 mod input;
 mod overlay;
 mod sidebar;
@@ -142,14 +143,20 @@ fn render_chat_area(app: &App, frame: &mut Frame, area: Rect, theme: &crate::the
     let wrapped_lines = (text_len / content_width) + 1;
     let input_height = (wrapped_lines + 1).clamp(3, 8); // +1 for border, min 3, max 8
 
+    let filter_height: u16 = if app.filter.editing { 1 } else { 0 };
+
     let layout = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
-            Constraint::Min(3),               // messages
-            Constraint::Length(input_height), // input (grows with text)
+            Constraint::Min(3),                  // messages
+            Constraint::Length(filter_height),    // filter bar (when editing)
+            Constraint::Length(input_height),     // input (grows with text)
         ])
         .split(area);
 
     chat::render(app, frame, layout[0], theme);
-    input::render(app, frame, layout[1], theme);
+    if app.filter.editing {
+        filter_bar::render(app, frame, layout[1], theme);
+    }
+    input::render(app, frame, layout[2], theme);
 }

--- a/tui/src/view/status_bar.rs
+++ b/tui/src/view/status_bar.rs
@@ -42,9 +42,13 @@ fn render_info_bar(app: &App, width: u16, theme: &ThemePalette) -> Line<'static>
     left_spans.push(Span::styled(" │ ", theme.style_dim()));
     left_spans.push(connection_indicator_span(app, theme));
 
-    if let Some(ref filter) = app.active_filter {
+    if app.filter.active && !app.filter.editing && !app.filter.text.is_empty() {
         left_spans.push(Span::styled(" │ ", theme.style_dim()));
-        left_spans.push(Span::styled(format!("/{filter}"), theme.style_accent()));
+        left_spans.push(Span::styled(
+            format!("/{}", app.filter.text),
+            theme.style_accent(),
+        ));
+        left_spans.push(Span::styled(" (Esc to clear)", theme.style_dim()));
     }
 
     right_spans.extend(cost_spans(app, theme));


### PR DESCRIPTION
## Summary

- `/` enters filter edit mode — real-time substring matching narrows chat messages as you type
- Enter locks filter (applied mode), Esc clears — two-phase vim-style lifecycle
- `!` prefix inverts filter (show non-matching messages)
- Match highlighting with background color on matched substrings in rendered markdown
- Filter bar shows `/pattern█` with right-aligned match count (`3/47 matches`)
- Status bar shows active filter with `(Esc to clear)` hint in applied mode
- `n`/`N` for next/prev match navigation in applied mode

## Files

- **New:** `state/filter.rs` — `FilterState`, `FilterScope` with cursor editing, match navigation
- **New:** `update/filter.rs` — handlers for open/close/input/backspace/clear/confirm/next/prev
- **New:** `view/filter_bar.rs` — filter bar rendering with blinking cursor and match count
- **Modified:** `msg.rs` — 8 new `Filter*` message variants
- **Modified:** `mapping.rs` — `/` trigger, filter editing key routing, applied mode interception
- **Modified:** `view/chat.rs` — message filtering and inline match highlighting
- **Modified:** `view/mod.rs` — filter bar layout slot in chat area
- **Modified:** `view/status_bar.rs` — applied filter indicator replaces old `active_filter` field
- **Modified:** `keybindings.rs` — Filter context in `current_contexts()` and `context_label()`
- **Modified:** `app.rs` — `FilterState` replaces `active_filter: Option<String>`

## Test plan

- [ ] Launch TUI, press `/` — filter bar appears at bottom of chat area
- [ ] Type `error` — messages without "error" disappear, matches highlighted
- [ ] Press Enter — filter bar closes, filter stays active, status bar shows `/error (Esc to clear)`
- [ ] Press `n`/`N` — cycles through matches
- [ ] Press Esc — filter clears, all messages return
- [ ] Press `/` then type `!error` — inverse: only messages WITHOUT "error" shown
- [ ] Backspace on empty filter text closes filter mode
- [ ] Ctrl+U clears filter text but stays in edit mode
- [ ] `cargo check` and `cargo clippy` pass (no new warnings)