### PR TITLE
fix: cutover follow-ups — signal receive, port binding, example config

### DIFF
--- a/crates/agora/src/semeion/mod.rs
+++ b/crates/agora/src/semeion/mod.rs
@@ -132,7 +132,7 @@ impl SignalProvider {
             );
 
             let handle = tokio::spawn(
-                poll_loop(signal_client, account_id, tx, interval, state).instrument(span),
+                poll_loop(signal_client, tx, interval, state).instrument(span),
             );
             handles.push(handle);
         }
@@ -332,14 +332,13 @@ impl std::fmt::Debug for SignalProvider {
 
 async fn poll_loop(
     signal_client: client::SignalClient,
-    account_id: String,
     tx: mpsc::Sender<InboundMessage>,
     interval: Duration,
     state: Arc<Mutex<AccountState>>,
 ) {
     tracing::info!("polling started");
     loop {
-        match signal_client.receive(Some(&account_id)).await {
+        match signal_client.receive(None).await {
             Ok(envelopes) => {
                 // Restore connection if we were reconnecting
                 {
@@ -526,7 +525,6 @@ mod tests {
 
         let handle = tokio::spawn(super::poll_loop(
             signal_client,
-            "+0000000000".to_owned(),
             tx,
             Duration::from_millis(50),
             account_state,

--- a/crates/aletheia/src/main.rs
+++ b/crates/aletheia/src/main.rs
@@ -60,9 +60,9 @@ struct Cli {
     #[arg(long, default_value = "127.0.0.1")]
     bind: String,
 
-    /// Port
-    #[arg(short, long, default_value_t = 18789)]
-    port: u16,
+    /// Port (overrides config gateway.port when set)
+    #[arg(short, long)]
+    port: Option<u16>,
 
     /// Emit JSON-structured logs
     #[arg(long)]
@@ -578,7 +578,8 @@ async fn serve(cli: Cli) -> Result<()> {
     let security = aletheia_pylon::security::SecurityConfig::from_gateway(&config.gateway);
     let app = build_router(state.clone(), &security);
 
-    let bind_addr = format!("{}:{}", cli.bind, cli.port);
+    let port = cli.port.unwrap_or(config.gateway.port);
+    let bind_addr = format!("{}:{}", cli.bind, port);
     let listener = tokio::net::TcpListener::bind(&bind_addr)
         .await
         .with_context(|| format!("failed to bind to {bind_addr}"))?;
@@ -1217,7 +1218,7 @@ mod tests {
     #[test]
     fn cli_defaults() {
         let cli = Cli::parse_from(["aletheia"]);
-        assert_eq!(cli.port, 18789);
+        assert!(cli.port.is_none());
         assert_eq!(cli.bind, "127.0.0.1");
         assert_eq!(cli.log_level, "info");
         assert!(!cli.json_logs);

--- a/instance.example/config/aletheia.yaml.example
+++ b/instance.example/config/aletheia.yaml.example
@@ -13,10 +13,10 @@ gateway:
     mode: token          # token | none
   # tls:
   #   enabled: true
-  #   cert_path: config/tls/cert.pem
-  #   key_path: config/tls/key.pem
+  #   certPath: config/tls/cert.pem
+  #   keyPath: config/tls/key.pem
   # cors:
-  #   allowed_origins: ["https://my-dashboard.local"]
+  #   allowedOrigins: ["https://my-dashboard.local"]
   # csrf:
   #   enabled: true
 
@@ -25,12 +25,12 @@ agents:
   defaults:
     model:
       primary: claude-sonnet-4-6
-    context_tokens: 200000
-    # thinking_enabled: false
-    # thinking_budget: 10000
-    # max_tool_iterations: 50
-    # tool_timeouts:
-    #   default_ms: 120000
+    contextTokens: 200000
+    # thinkingEnabled: false
+    # thinkingBudget: 10000
+    # maxToolIterations: 50
+    # toolTimeouts:
+    #   defaultMs: 120000
 
   list:
     - id: main
@@ -44,14 +44,14 @@ agents:
 #     accounts:
 #       default:
 #         account: "+1XXXXXXXXXX"
-#         http_host: localhost
-#         http_port: 8080
+#         httpHost: localhost
+#         httpPort: 8080
 
 # --- Bindings (route messages to agents) ---
 # bindings:
 #   - channel: signal
 #     source: "*"
-#     nous_id: main
+#     nousId: main
 
 # --- Embedding (for recall/knowledge search) ---
 # embedding:
@@ -61,18 +61,18 @@ agents:
 # --- Data retention ---
 # data:
 #   retention:
-#     session_max_age_days: 90
-#     archive_before_delete: true
+#     sessionMaxAgeDays: 90
+#     archiveBeforeDelete: true
 
 # --- Maintenance ---
 # maintenance:
-#   trace_rotation:
-#     max_age_days: 14
-#   db_monitoring:
-#     warn_threshold_mb: 100
+#   traceRotation:
+#     maxAgeDays: 14
+#   dbMonitoring:
+#     warnThresholdMb: 100
 
 # --- Cost tracking ---
 # pricing:
 #   claude-sonnet-4-6:
-#     input_cost_per_mtok: 3.0
-#     output_cost_per_mtok: 15.0
+#     inputCostPerMtok: 3.0
+#     outputCostPerMtok: 15.0


### PR DESCRIPTION
## Summary

Three fixes discovered during the Node→Rust production cutover:

- **Signal receive RPC**: Remove `account` parameter from `receive()` call — signal-cli 0.13.23 only accepts `maxMessages` and `timeout`, causing "Unrecognized field account" errors
- **CLI port binding**: Make `--port` optional so `config.gateway.port` from YAML is respected when the flag isn't explicitly passed (previously the clap default always won)
- **Example config**: Fix `aletheia.yaml.example` to use camelCase field names matching `#[serde(rename_all = "camelCase")]` on all taxis structs (snake_case was silently ignored)

## Test plan

- [x] `cargo clippy --workspace --all-targets -- -D warnings` — zero warnings
- [x] `cargo test -p aletheia-agora -p aletheia -p aletheia-taxis` — 60 tests pass
- [x] `cli_defaults` test updated for `Option<u16>` port
- [ ] Verify on worker-node: signal polling works, port from config respected

Generated with [Claude Code](https://claude.com/claude-code)