### PR TITLE
fix(hermeneus): OAuth tokens need Bearer header + beta flag

### DIFF
--- a/crates/hermeneus/src/anthropic/client.rs
+++ b/crates/hermeneus/src/anthropic/client.rs
@@ -380,11 +380,23 @@ impl AnthropicProvider {
         })?;
 
         let mut headers = HeaderMap::new();
-        headers.insert(
-            "x-api-key",
-            HeaderValue::from_str(&credential.secret)
-                .unwrap_or_else(|_| HeaderValue::from_static("")),
-        );
+        match credential.source {
+            CredentialSource::OAuth => {
+                headers.insert(
+                    reqwest::header::AUTHORIZATION,
+                    HeaderValue::from_str(&format!("Bearer {}", credential.secret))
+                        .unwrap_or_else(|_| HeaderValue::from_static("")),
+                );
+                headers.insert("anthropic-beta", HeaderValue::from_static("oauth-2025-04-20"));
+            }
+            _ => {
+                headers.insert(
+                    "x-api-key",
+                    HeaderValue::from_str(&credential.secret)
+                        .unwrap_or_else(|_| HeaderValue::from_static("")),
+                );
+            }
+        }
         headers.insert(
             "anthropic-version",
             HeaderValue::from_str(&self.api_version)


### PR DESCRIPTION
## Summary

The Anthropic API supports OAuth behind `anthropic-beta: oauth-2025-04-20`. The TS runtime used the SDK's `authToken` param which sets both `Authorization: Bearer` and the beta header. The Rust client was missing both.

Branch on `CredentialSource::OAuth` in `build_headers()` to send Bearer + beta flag. API key path unchanged.

## Test plan
- [x] `cargo clippy --workspace` — zero warnings
- [x] All hermeneus tests pass
- [ ] Deploy to worker-node, run eval — conversation tests should pass