### PR TITLE
feat(organon): workspace navigation tools

### DIFF
--- a/crates/organon/src/builtins/filesystem.rs
+++ b/crates/organon/src/builtins/filesystem.rs
@@ -1,0 +1,720 @@
+//! Filesystem navigation tools: grep, find, ls.
+
+use std::fmt::Write as _;
+use std::future::Future;
+use std::io::Read as _;
+use std::path::Path;
+use std::pin::Pin;
+use std::process::{Command, Stdio};
+use std::time::SystemTime;
+
+use aletheia_koina::id::ToolName;
+use indexmap::IndexMap;
+
+use crate::error::Result;
+use crate::registry::{ToolExecutor, ToolRegistry};
+use crate::types::{
+    InputSchema, PropertyDef, PropertyType, ToolCategory, ToolContext, ToolDef, ToolInput,
+    ToolResult,
+};
+
+use super::workspace::{extract_opt_bool, extract_opt_u64, extract_str, validate_path};
+
+const MAX_OUTPUT_BYTES: usize = 50 * 1024;
+
+fn extract_opt_str<'a>(args: &'a serde_json::Value, field: &str) -> Option<&'a str> {
+    args.get(field).and_then(serde_json::Value::as_str)
+}
+
+fn truncate_output(mut output: String) -> String {
+    if output.len() > MAX_OUTPUT_BYTES {
+        output.truncate(MAX_OUTPUT_BYTES);
+        output.push_str("\n[output truncated]");
+    }
+    output
+}
+
+fn run_command(cmd: &mut Command) -> std::io::Result<std::process::Output> {
+    let mut child = cmd.stdout(Stdio::piped()).stderr(Stdio::piped()).spawn()?;
+
+    let mut stdout = String::new();
+    if let Some(ref mut pipe) = child.stdout {
+        let _ = pipe.read_to_string(&mut stdout);
+    }
+    let mut stderr = String::new();
+    if let Some(ref mut pipe) = child.stderr {
+        let _ = pipe.read_to_string(&mut stderr);
+    }
+
+    let status = child.wait()?;
+    Ok(std::process::Output {
+        status,
+        stdout: stdout.into_bytes(),
+        stderr: stderr.into_bytes(),
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Grep
+// ---------------------------------------------------------------------------
+
+struct GrepExecutor;
+
+impl ToolExecutor for GrepExecutor {
+    fn execute<'a>(
+        &'a self,
+        input: &'a ToolInput,
+        ctx: &'a ToolContext,
+    ) -> Pin<Box<dyn Future<Output = Result<ToolResult>> + Send + 'a>> {
+        Box::pin(async {
+            let pattern = extract_str(&input.arguments, "pattern", &input.name)?;
+            let max_results = extract_opt_u64(&input.arguments, "maxResults").unwrap_or(50);
+            let case_sensitive = extract_opt_bool(&input.arguments, "caseSensitive").unwrap_or(true);
+            let glob_filter = extract_opt_str(&input.arguments, "glob");
+
+            let path = match extract_opt_str(&input.arguments, "path") {
+                Some(p) => validate_path(p, ctx, &input.name)?,
+                None => ctx.workspace.clone(),
+            };
+
+            let output = try_rg(pattern, &path, max_results, case_sensitive, glob_filter)
+                .or_else(|_| try_grep_fallback(pattern, &path, case_sensitive));
+
+            match output {
+                Ok(out) => {
+                    let code = out.status.code().unwrap_or(-1);
+                    let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
+
+                    if code == 1 && stdout.trim().is_empty() {
+                        return Ok(ToolResult::text("No matches found."));
+                    }
+
+                    let text = truncate_output(stdout);
+                    Ok(ToolResult::text(text))
+                }
+                Err(e) => Ok(ToolResult::error(format!("grep failed: {e}"))),
+            }
+        })
+    }
+}
+
+fn try_rg(
+    pattern: &str,
+    path: &Path,
+    max_results: u64,
+    case_sensitive: bool,
+    glob_filter: Option<&str>,
+) -> std::io::Result<std::process::Output> {
+    let mut cmd = Command::new("rg");
+    cmd.arg("--no-heading")
+        .arg("--line-number")
+        .arg("--max-count")
+        .arg(max_results.to_string());
+
+    if !case_sensitive {
+        cmd.arg("--ignore-case");
+    }
+    if let Some(g) = glob_filter {
+        cmd.arg("--glob").arg(g);
+    }
+
+    cmd.arg(pattern).arg(path);
+    run_command(&mut cmd)
+}
+
+fn try_grep_fallback(
+    pattern: &str,
+    path: &Path,
+    case_sensitive: bool,
+) -> std::io::Result<std::process::Output> {
+    let mut cmd = Command::new("grep");
+    cmd.arg("-rn");
+    if !case_sensitive {
+        cmd.arg("-i");
+    }
+    cmd.arg(pattern).arg(path);
+    run_command(&mut cmd)
+}
+
+// ---------------------------------------------------------------------------
+// Find
+// ---------------------------------------------------------------------------
+
+struct FindExecutor;
+
+impl ToolExecutor for FindExecutor {
+    fn execute<'a>(
+        &'a self,
+        input: &'a ToolInput,
+        ctx: &'a ToolContext,
+    ) -> Pin<Box<dyn Future<Output = Result<ToolResult>> + Send + 'a>> {
+        Box::pin(async {
+            let pattern = extract_str(&input.arguments, "pattern", &input.name)?;
+            let max_results = extract_opt_u64(&input.arguments, "maxResults").unwrap_or(100);
+            let type_filter = extract_opt_str(&input.arguments, "type");
+            let max_depth = extract_opt_u64(&input.arguments, "maxDepth");
+
+            let path = match extract_opt_str(&input.arguments, "path") {
+                Some(p) => validate_path(p, ctx, &input.name)?,
+                None => ctx.workspace.clone(),
+            };
+
+            let output = try_fd(pattern, &path, max_results, type_filter, max_depth)
+                .or_else(|_| try_find_fallback(pattern, &path, type_filter, max_depth));
+
+            match output {
+                Ok(out) => {
+                    let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
+                    if stdout.trim().is_empty() {
+                        return Ok(ToolResult::text("No files found."));
+                    }
+                    let text = truncate_output(stdout);
+                    Ok(ToolResult::text(text))
+                }
+                Err(e) => Ok(ToolResult::error(format!("find failed: {e}"))),
+            }
+        })
+    }
+}
+
+fn try_fd(
+    pattern: &str,
+    path: &Path,
+    max_results: u64,
+    type_filter: Option<&str>,
+    max_depth: Option<u64>,
+) -> std::io::Result<std::process::Output> {
+    let mut cmd = Command::new("fd");
+    cmd.arg(pattern)
+        .arg(path)
+        .arg("--max-results")
+        .arg(max_results.to_string());
+
+    if let Some(t) = type_filter {
+        cmd.arg("--type").arg(t);
+    }
+    if let Some(d) = max_depth {
+        cmd.arg("--max-depth").arg(d.to_string());
+    }
+
+    run_command(&mut cmd)
+}
+
+fn try_find_fallback(
+    pattern: &str,
+    path: &Path,
+    type_filter: Option<&str>,
+    max_depth: Option<u64>,
+) -> std::io::Result<std::process::Output> {
+    let mut cmd = Command::new("find");
+    cmd.arg(path);
+
+    if let Some(d) = max_depth {
+        cmd.arg("-maxdepth").arg(d.to_string());
+    }
+    if let Some(t) = type_filter {
+        cmd.arg("-type").arg(t);
+    }
+
+    cmd.arg("-name").arg(pattern);
+    run_command(&mut cmd)
+}
+
+// ---------------------------------------------------------------------------
+// Ls
+// ---------------------------------------------------------------------------
+
+struct LsExecutor;
+
+impl ToolExecutor for LsExecutor {
+    fn execute<'a>(
+        &'a self,
+        input: &'a ToolInput,
+        ctx: &'a ToolContext,
+    ) -> Pin<Box<dyn Future<Output = Result<ToolResult>> + Send + 'a>> {
+        Box::pin(async {
+            let show_all = extract_opt_bool(&input.arguments, "all").unwrap_or(false);
+
+            let path = match extract_opt_str(&input.arguments, "path") {
+                Some(p) => validate_path(p, ctx, &input.name)?,
+                None => ctx.workspace.clone(),
+            };
+
+            let entries = match std::fs::read_dir(&path) {
+                Ok(rd) => rd,
+                Err(e) => {
+                    return Ok(ToolResult::error(format!(
+                        "cannot read directory {}: {e}",
+                        path.display()
+                    )));
+                }
+            };
+
+            let mut dirs: Vec<(String, u64, SystemTime)> = Vec::new();
+            let mut files: Vec<(String, u64, SystemTime)> = Vec::new();
+
+            for entry in entries.flatten() {
+                let name = entry.file_name().to_string_lossy().into_owned();
+
+                if !show_all && name.starts_with('.') {
+                    continue;
+                }
+
+                let Ok(meta) = entry.metadata() else {
+                    continue;
+                };
+
+                let size = meta.len();
+                let modified = meta.modified().unwrap_or(SystemTime::UNIX_EPOCH);
+
+                if meta.is_dir() {
+                    dirs.push((format!("{name}/"), size, modified));
+                } else {
+                    files.push((name, size, modified));
+                }
+            }
+
+            dirs.sort_by(|a, b| a.0.cmp(&b.0));
+            files.sort_by(|a, b| a.0.cmp(&b.0));
+
+            let mut output = String::new();
+            for (name, size, modified) in dirs.iter().chain(files.iter()) {
+                let modified_str = format_system_time(modified);
+                let _ = writeln!(output, "{name:<40} {size:>10} {modified_str}");
+            }
+
+            if output.is_empty() {
+                return Ok(ToolResult::text("Directory is empty."));
+            }
+
+            Ok(ToolResult::text(output.trim_end().to_owned()))
+        })
+    }
+}
+
+fn format_system_time(time: &SystemTime) -> String {
+    match time.duration_since(SystemTime::UNIX_EPOCH) {
+        Ok(dur) => {
+            let secs = dur.as_secs();
+            // Simple UTC date/time formatting without external deps
+            let days = secs / 86400;
+            let time_of_day = secs % 86400;
+            let hours = time_of_day / 3600;
+            let minutes = (time_of_day % 3600) / 60;
+
+            // Days since epoch to Y-M-D (simplified)
+            let (year, month, day) = days_to_ymd(days);
+            format!("{year:04}-{month:02}-{day:02} {hours:02}:{minutes:02}")
+        }
+        Err(_) => "unknown".to_owned(),
+    }
+}
+
+fn days_to_ymd(days: u64) -> (u64, u64, u64) {
+    // Algorithm from http://howardhinnant.github.io/date_algorithms.html
+    let z = days + 719_468;
+    let era = z / 146_097;
+    let doe = z - era * 146_097;
+    let yoe = (doe - doe / 1460 + doe / 36_524 - doe / 146_096) / 365;
+    let y = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = doy - (153 * mp + 2) / 5 + 1;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 };
+    let y = if m <= 2 { y + 1 } else { y };
+    (y, m, d)
+}
+
+// ---------------------------------------------------------------------------
+// Tool definitions
+// ---------------------------------------------------------------------------
+
+pub fn register(registry: &mut ToolRegistry) -> Result<()> {
+    registry.register(grep_def(), Box::new(GrepExecutor))?;
+    registry.register(find_def(), Box::new(FindExecutor))?;
+    registry.register(ls_def(), Box::new(LsExecutor))?;
+    Ok(())
+}
+
+fn grep_def() -> ToolDef {
+    ToolDef {
+        name: ToolName::new("grep").expect("valid tool name"),
+        description: "Search file contents for a pattern using ripgrep".to_owned(),
+        extended_description: None,
+        input_schema: InputSchema {
+            properties: IndexMap::from([
+                (
+                    "pattern".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::String,
+                        description: "Search pattern (regex supported)".to_owned(),
+                        enum_values: None,
+                        default: None,
+                    },
+                ),
+                (
+                    "path".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::String,
+                        description: "Directory or file to search (default: workspace root)"
+                            .to_owned(),
+                        enum_values: None,
+                        default: None,
+                    },
+                ),
+                (
+                    "glob".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::String,
+                        description: "File glob filter (e.g., '*.ts', '*.md')".to_owned(),
+                        enum_values: None,
+                        default: None,
+                    },
+                ),
+                (
+                    "caseSensitive".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::Boolean,
+                        description: "Case-sensitive search (default: true)".to_owned(),
+                        enum_values: None,
+                        default: Some(serde_json::json!(true)),
+                    },
+                ),
+                (
+                    "maxResults".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::Number,
+                        description: "Maximum matching lines per file (default: 50)".to_owned(),
+                        enum_values: None,
+                        default: Some(serde_json::json!(50)),
+                    },
+                ),
+            ]),
+            required: vec!["pattern".to_owned()],
+        },
+        category: ToolCategory::Workspace,
+        auto_activate: false,
+    }
+}
+
+fn find_def() -> ToolDef {
+    ToolDef {
+        name: ToolName::new("find").expect("valid tool name"),
+        description: "Find files by name pattern using fd".to_owned(),
+        extended_description: None,
+        input_schema: InputSchema {
+            properties: IndexMap::from([
+                (
+                    "pattern".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::String,
+                        description: "File name pattern (glob or regex)".to_owned(),
+                        enum_values: None,
+                        default: None,
+                    },
+                ),
+                (
+                    "path".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::String,
+                        description: "Directory to search (default: workspace root)".to_owned(),
+                        enum_values: None,
+                        default: None,
+                    },
+                ),
+                (
+                    "type".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::String,
+                        description: "Filter: 'f' for files, 'd' for directories".to_owned(),
+                        enum_values: Some(vec!["f".to_owned(), "d".to_owned()]),
+                        default: None,
+                    },
+                ),
+                (
+                    "maxDepth".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::Number,
+                        description: "Maximum directory depth".to_owned(),
+                        enum_values: None,
+                        default: None,
+                    },
+                ),
+                (
+                    "maxResults".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::Number,
+                        description: "Maximum results (default: 100)".to_owned(),
+                        enum_values: None,
+                        default: Some(serde_json::json!(100)),
+                    },
+                ),
+            ]),
+            required: vec!["pattern".to_owned()],
+        },
+        category: ToolCategory::Workspace,
+        auto_activate: false,
+    }
+}
+
+fn ls_def() -> ToolDef {
+    ToolDef {
+        name: ToolName::new("ls").expect("valid tool name"),
+        description: "List directory contents with file sizes and modification times".to_owned(),
+        extended_description: None,
+        input_schema: InputSchema {
+            properties: IndexMap::from([
+                (
+                    "path".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::String,
+                        description: "Directory to list (default: workspace root)".to_owned(),
+                        enum_values: None,
+                        default: None,
+                    },
+                ),
+                (
+                    "all".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::Boolean,
+                        description: "Include hidden files (default: false)".to_owned(),
+                        enum_values: None,
+                        default: Some(serde_json::json!(false)),
+                    },
+                ),
+            ]),
+            required: vec![],
+        },
+        category: ToolCategory::Workspace,
+        auto_activate: false,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use aletheia_koina::id::{NousId, SessionId, ToolName};
+
+    use super::*;
+
+    fn test_ctx(dir: &Path) -> ToolContext {
+        ToolContext {
+            nous_id: NousId::new("test-agent").expect("valid"),
+            session_id: SessionId::new(),
+            workspace: dir.to_path_buf(),
+            allowed_roots: vec![dir.to_path_buf()],
+        }
+    }
+
+    fn tool_input(name: &str, args: serde_json::Value) -> ToolInput {
+        ToolInput {
+            name: ToolName::new(name).expect("valid"),
+            tool_use_id: "toolu_test".to_owned(),
+            arguments: args,
+        }
+    }
+
+    // -- GrepExecutor -------------------------------------------------------
+
+    #[tokio::test]
+    async fn grep_finds_pattern() {
+        let dir = tempfile::tempdir().expect("tmpdir");
+        std::fs::write(dir.path().join("hello.rs"), "fn main() {\n    println!(\"hello\");\n}")
+            .expect("write");
+
+        let ctx = test_ctx(dir.path());
+        let input = tool_input("grep", serde_json::json!({ "pattern": "println" }));
+        let result = GrepExecutor.execute(&input, &ctx).await.expect("exec");
+        assert!(!result.is_error);
+        assert!(result.content.text_summary().contains("println"));
+    }
+
+    #[tokio::test]
+    async fn grep_with_glob_filter() {
+        let dir = tempfile::tempdir().expect("tmpdir");
+        std::fs::write(dir.path().join("code.rs"), "fn rust_func() {}").expect("write");
+        std::fs::write(dir.path().join("code.ts"), "function tsFunc() {}").expect("write");
+
+        let ctx = test_ctx(dir.path());
+        let input = tool_input(
+            "grep",
+            serde_json::json!({ "pattern": "func", "glob": "*.rs" }),
+        );
+        let result = GrepExecutor.execute(&input, &ctx).await.expect("exec");
+        assert!(!result.is_error);
+        let text = result.content.text_summary();
+        assert!(text.contains("rust_func"));
+        assert!(!text.contains("tsFunc"));
+    }
+
+    #[tokio::test]
+    async fn grep_case_insensitive() {
+        let dir = tempfile::tempdir().expect("tmpdir");
+        std::fs::write(dir.path().join("test.txt"), "Hello World\nhello world").expect("write");
+
+        let ctx = test_ctx(dir.path());
+        let input = tool_input(
+            "grep",
+            serde_json::json!({ "pattern": "HELLO", "caseSensitive": false }),
+        );
+        let result = GrepExecutor.execute(&input, &ctx).await.expect("exec");
+        assert!(!result.is_error);
+        let text = result.content.text_summary();
+        assert!(text.contains("Hello"));
+        assert!(text.contains("hello"));
+    }
+
+    #[tokio::test]
+    async fn grep_no_matches_not_error() {
+        let dir = tempfile::tempdir().expect("tmpdir");
+        std::fs::write(dir.path().join("test.txt"), "nothing here").expect("write");
+
+        let ctx = test_ctx(dir.path());
+        let input = tool_input("grep", serde_json::json!({ "pattern": "zzzznotfound" }));
+        let result = GrepExecutor.execute(&input, &ctx).await.expect("exec");
+        assert!(!result.is_error);
+        assert_eq!(result.content.text_summary(), "No matches found.");
+    }
+
+    // -- FindExecutor -------------------------------------------------------
+
+    #[tokio::test]
+    async fn find_locates_files() {
+        let dir = tempfile::tempdir().expect("tmpdir");
+        std::fs::write(dir.path().join("app.rs"), "").expect("write");
+        std::fs::write(dir.path().join("app.ts"), "").expect("write");
+
+        let ctx = test_ctx(dir.path());
+        let input = tool_input("find", serde_json::json!({ "pattern": "app" }));
+        let result = FindExecutor.execute(&input, &ctx).await.expect("exec");
+        assert!(!result.is_error);
+        let text = result.content.text_summary();
+        assert!(text.contains("app"));
+    }
+
+    #[tokio::test]
+    async fn find_type_filter() {
+        let dir = tempfile::tempdir().expect("tmpdir");
+        std::fs::create_dir(dir.path().join("subdir")).expect("mkdir");
+        std::fs::write(dir.path().join("file.txt"), "").expect("write");
+
+        let ctx = test_ctx(dir.path());
+        let input = tool_input("find", serde_json::json!({ "pattern": ".", "type": "d" }));
+        let result = FindExecutor.execute(&input, &ctx).await.expect("exec");
+        assert!(!result.is_error);
+        let text = result.content.text_summary();
+        assert!(text.contains("subdir"));
+    }
+
+    #[tokio::test]
+    async fn find_max_depth() {
+        let dir = tempfile::tempdir().expect("tmpdir");
+        let deep = dir.path().join("a").join("b").join("c");
+        std::fs::create_dir_all(&deep).expect("mkdirs");
+        std::fs::write(deep.join("deep.txt"), "").expect("write");
+        std::fs::write(dir.path().join("shallow.txt"), "").expect("write");
+
+        let ctx = test_ctx(dir.path());
+        let input = tool_input(
+            "find",
+            serde_json::json!({ "pattern": "txt", "maxDepth": 1 }),
+        );
+        let result = FindExecutor.execute(&input, &ctx).await.expect("exec");
+        assert!(!result.is_error);
+        let text = result.content.text_summary();
+        assert!(text.contains("shallow"));
+        assert!(!text.contains("deep"));
+    }
+
+    // -- LsExecutor ---------------------------------------------------------
+
+    #[tokio::test]
+    async fn ls_lists_directory() {
+        let dir = tempfile::tempdir().expect("tmpdir");
+        std::fs::write(dir.path().join("file.txt"), "content").expect("write");
+        std::fs::create_dir(dir.path().join("subdir")).expect("mkdir");
+
+        let ctx = test_ctx(dir.path());
+        let input = tool_input("ls", serde_json::json!({}));
+        let result = LsExecutor.execute(&input, &ctx).await.expect("exec");
+        assert!(!result.is_error);
+        let text = result.content.text_summary();
+        assert!(text.contains("subdir/"));
+        assert!(text.contains("file.txt"));
+    }
+
+    #[tokio::test]
+    async fn ls_hides_dotfiles() {
+        let dir = tempfile::tempdir().expect("tmpdir");
+        std::fs::write(dir.path().join(".hidden"), "secret").expect("write");
+        std::fs::write(dir.path().join("visible.txt"), "public").expect("write");
+
+        let ctx = test_ctx(dir.path());
+        let input = tool_input("ls", serde_json::json!({}));
+        let result = LsExecutor.execute(&input, &ctx).await.expect("exec");
+        assert!(!result.is_error);
+        let text = result.content.text_summary();
+        assert!(!text.contains(".hidden"));
+        assert!(text.contains("visible.txt"));
+    }
+
+    #[tokio::test]
+    async fn ls_shows_dotfiles_with_all() {
+        let dir = tempfile::tempdir().expect("tmpdir");
+        std::fs::write(dir.path().join(".hidden"), "secret").expect("write");
+        std::fs::write(dir.path().join("visible.txt"), "public").expect("write");
+
+        let ctx = test_ctx(dir.path());
+        let input = tool_input("ls", serde_json::json!({ "all": true }));
+        let result = LsExecutor.execute(&input, &ctx).await.expect("exec");
+        assert!(!result.is_error);
+        let text = result.content.text_summary();
+        assert!(text.contains(".hidden"));
+        assert!(text.contains("visible.txt"));
+    }
+
+    #[tokio::test]
+    async fn ls_dirs_sorted_before_files() {
+        let dir = tempfile::tempdir().expect("tmpdir");
+        std::fs::write(dir.path().join("zebra.txt"), "").expect("write");
+        std::fs::create_dir(dir.path().join("alpha")).expect("mkdir");
+
+        let ctx = test_ctx(dir.path());
+        let input = tool_input("ls", serde_json::json!({}));
+        let result = LsExecutor.execute(&input, &ctx).await.expect("exec");
+        let text = result.content.text_summary();
+        let alpha_pos = text.find("alpha/").expect("alpha/ present");
+        let zebra_pos = text.find("zebra.txt").expect("zebra.txt present");
+        assert!(alpha_pos < zebra_pos, "directories should sort before files");
+    }
+
+    // -- Path validation ----------------------------------------------------
+
+    #[tokio::test]
+    async fn path_validation_rejects_outside_roots() {
+        let dir = tempfile::tempdir().expect("tmpdir");
+        let ctx = test_ctx(dir.path());
+        let input = tool_input("grep", serde_json::json!({ "pattern": "x", "path": "/etc" }));
+        let err = GrepExecutor
+            .execute(&input, &ctx)
+            .await
+            .expect_err("should reject outside root");
+        assert!(err.to_string().contains("outside allowed roots"));
+    }
+
+    // -- Registration -------------------------------------------------------
+
+    #[tokio::test]
+    async fn all_tools_registered() {
+        let mut reg = crate::registry::ToolRegistry::new();
+        register(&mut reg).expect("register");
+
+        for name in ["grep", "find", "ls"] {
+            let tn = ToolName::new(name).expect("valid");
+            assert!(reg.get_def(&tn).is_some(), "{name} should be registered");
+        }
+    }
+}

--- a/crates/organon/src/builtins/mod.rs
+++ b/crates/organon/src/builtins/mod.rs
@@ -1,19 +1,25 @@
-//! Built-in tool stubs — prove the registry pattern with real schemas.
+//! Built-in tool executors and stubs.
 
 /// Inter-agent communication tools (send_message, broadcast).
 pub mod communication;
+/// Filesystem navigation tools (grep, find, ls).
+pub mod filesystem;
 /// Knowledge graph and session memory tools (remember, recall).
 pub mod memory;
-/// File and shell workspace tools (read_file, write_file, run_command).
+/// File viewing with multimodal support (images, PDFs, text).
+pub mod view_file;
+/// File and shell workspace tools (read, write, edit, exec).
 pub mod workspace;
 
 use crate::error::Result;
 use crate::registry::ToolRegistry;
 
-/// Register all built-in tool stubs.
+/// Register all built-in tool executors.
 pub fn register_all(registry: &mut ToolRegistry) -> Result<()> {
     workspace::register(registry)?;
     memory::register(registry)?;
     communication::register(registry)?;
+    filesystem::register(registry)?;
+    view_file::register(registry)?;
     Ok(())
 }

--- a/crates/organon/src/builtins/view_file.rs
+++ b/crates/organon/src/builtins/view_file.rs
@@ -76,98 +76,104 @@ impl ToolExecutor for ViewFileExecutor {
                 )));
             }
 
-            let kind = match detect_media_kind(&path) {
-                Some(k) => k,
-                None => {
-                    let ext = path
-                        .extension()
-                        .and_then(|e| e.to_str())
-                        .unwrap_or("unknown");
-                    return Ok(ToolResult::error(format!(
-                        "unsupported file type: {ext}. Supported: png, jpg, gif, webp, pdf, and text files"
-                    )));
-                }
+            let Some(kind) = detect_media_kind(&path) else {
+                let ext = path
+                    .extension()
+                    .and_then(|e| e.to_str())
+                    .unwrap_or("unknown");
+                return Ok(ToolResult::error(format!(
+                    "unsupported file type: {ext}. Supported: png, jpg, gif, webp, pdf, and text files"
+                )));
             };
 
-            match kind {
-                MediaKind::Image(media_type) => {
-                    if metadata.len() > MAX_IMAGE_BYTES {
-                        return Ok(ToolResult::error(format!(
-                            "image too large: {} bytes (max {} MB)",
-                            metadata.len(),
-                            MAX_IMAGE_BYTES / (1024 * 1024)
-                        )));
-                    }
-                    let bytes = match std::fs::read(&path) {
-                        Ok(b) => b,
-                        Err(e) => return Ok(ToolResult::error(format!("read failed: {e}"))),
-                    };
-                    let encoded = base64::engine::general_purpose::STANDARD.encode(&bytes);
-                    Ok(ToolResult::blocks(vec![
-                        ToolResultBlock::Image {
-                            source: ImageSource {
-                                source_type: "base64".to_owned(),
-                                media_type: media_type.to_owned(),
-                                data: encoded,
-                            },
-                        },
-                        ToolResultBlock::Text {
-                            text: format!("{} ({} bytes)", path.display(), bytes.len()),
-                        },
-                    ]))
-                }
-                MediaKind::Pdf => {
-                    if metadata.len() > MAX_PDF_BYTES {
-                        return Ok(ToolResult::error(format!(
-                            "PDF too large: {} bytes (max {} MB)",
-                            metadata.len(),
-                            MAX_PDF_BYTES / (1024 * 1024)
-                        )));
-                    }
-                    let bytes = match std::fs::read(&path) {
-                        Ok(b) => b,
-                        Err(e) => return Ok(ToolResult::error(format!("read failed: {e}"))),
-                    };
-                    let encoded = base64::engine::general_purpose::STANDARD.encode(&bytes);
-                    Ok(ToolResult::blocks(vec![
-                        ToolResultBlock::Document {
-                            source: DocumentSource {
-                                source_type: "base64".to_owned(),
-                                media_type: "application/pdf".to_owned(),
-                                data: encoded,
-                            },
-                        },
-                        ToolResultBlock::Text {
-                            text: format!("{} ({} bytes)", path.display(), bytes.len()),
-                        },
-                    ]))
-                }
-                MediaKind::Text => {
-                    let content = match std::fs::read_to_string(&path) {
-                        Ok(c) => c,
-                        Err(e) if e.kind() == std::io::ErrorKind::InvalidData => {
-                            return Ok(ToolResult::error(format!(
-                                "file is not valid UTF-8 text: {}",
-                                path.display()
-                            )));
-                        }
-                        Err(e) => return Ok(ToolResult::error(format!("read failed: {e}"))),
-                    };
-                    let output = match max_lines {
-                        Some(n) => {
-                            let n = usize::try_from(n).unwrap_or(usize::MAX);
-                            content.lines().take(n).collect::<Vec<_>>().join("\n")
-                        }
-                        None => content,
-                    };
-                    Ok(ToolResult::text(output))
-                }
-            }
+            Ok(execute_by_kind(&kind, &path, &metadata, max_lines))
         })
     }
 }
 
-/// Register the view_file tool.
+fn execute_by_kind(
+    kind: &MediaKind,
+    path: &std::path::Path,
+    metadata: &std::fs::Metadata,
+    max_lines: Option<u64>,
+) -> ToolResult {
+    match kind {
+        MediaKind::Image(media_type) => {
+            if metadata.len() > MAX_IMAGE_BYTES {
+                return ToolResult::error(format!(
+                    "image too large: {} bytes (max {} MB)",
+                    metadata.len(),
+                    MAX_IMAGE_BYTES / (1024 * 1024)
+                ));
+            }
+            let bytes = match std::fs::read(path) {
+                Ok(b) => b,
+                Err(e) => return ToolResult::error(format!("read failed: {e}")),
+            };
+            let encoded = base64::engine::general_purpose::STANDARD.encode(&bytes);
+            ToolResult::blocks(vec![
+                ToolResultBlock::Image {
+                    source: ImageSource {
+                        source_type: "base64".to_owned(),
+                        media_type: (*media_type).to_owned(),
+                        data: encoded,
+                    },
+                },
+                ToolResultBlock::Text {
+                    text: format!("{} ({} bytes)", path.display(), bytes.len()),
+                },
+            ])
+        }
+        MediaKind::Pdf => {
+            if metadata.len() > MAX_PDF_BYTES {
+                return ToolResult::error(format!(
+                    "PDF too large: {} bytes (max {} MB)",
+                    metadata.len(),
+                    MAX_PDF_BYTES / (1024 * 1024)
+                ));
+            }
+            let bytes = match std::fs::read(path) {
+                Ok(b) => b,
+                Err(e) => return ToolResult::error(format!("read failed: {e}")),
+            };
+            let encoded = base64::engine::general_purpose::STANDARD.encode(&bytes);
+            ToolResult::blocks(vec![
+                ToolResultBlock::Document {
+                    source: DocumentSource {
+                        source_type: "base64".to_owned(),
+                        media_type: "application/pdf".to_owned(),
+                        data: encoded,
+                    },
+                },
+                ToolResultBlock::Text {
+                    text: format!("{} ({} bytes)", path.display(), bytes.len()),
+                },
+            ])
+        }
+        MediaKind::Text => {
+            let content = match std::fs::read_to_string(path) {
+                Ok(c) => c,
+                Err(e) if e.kind() == std::io::ErrorKind::InvalidData => {
+                    return ToolResult::error(format!(
+                        "file is not valid UTF-8 text: {}",
+                        path.display()
+                    ));
+                }
+                Err(e) => return ToolResult::error(format!("read failed: {e}")),
+            };
+            let output = match max_lines {
+                Some(n) => {
+                    let n = usize::try_from(n).unwrap_or(usize::MAX);
+                    content.lines().take(n).collect::<Vec<_>>().join("\n")
+                }
+                None => content,
+            };
+            ToolResult::text(output)
+        }
+    }
+}
+
+/// Register the `view_file` tool.
 pub fn register(registry: &mut ToolRegistry) -> Result<()> {
     registry.register(view_file_def(), Box::new(ViewFileExecutor))?;
     Ok(())
@@ -209,8 +215,6 @@ fn view_file_def() -> crate::types::ToolDef {
 
 #[cfg(test)]
 mod tests {
-    use std::path::PathBuf;
-
     use aletheia_koina::id::{NousId, SessionId, ToolName};
 
     use super::*;
@@ -283,10 +287,10 @@ mod tests {
                         assert_eq!(source.source_type, "base64");
                         assert!(!source.data.is_empty());
                     }
-                    _ => panic!("expected Image block"),
+                    other => panic!("expected Image block, got {other:?}"),
                 }
             }
-            _ => panic!("expected Blocks"),
+            other @ ToolResultContent::Text(_) => panic!("expected Blocks, got {other:?}"),
         }
     }
 

--- a/crates/organon/src/builtins/workspace.rs
+++ b/crates/organon/src/builtins/workspace.rs
@@ -90,7 +90,7 @@ pub(crate) fn extract_opt_u64(args: &serde_json::Value, field: &str) -> Option<u
     args.get(field).and_then(serde_json::Value::as_u64)
 }
 
-fn extract_opt_bool(args: &serde_json::Value, field: &str) -> Option<bool> {
+pub(crate) fn extract_opt_bool(args: &serde_json::Value, field: &str) -> Option<bool> {
     args.get(field).and_then(serde_json::Value::as_bool)
 }
 


### PR DESCRIPTION
## Summary

- Add `grep`, `find`, `ls` tool executors to `crates/organon/src/builtins/filesystem.rs`
- Register existing `view_file` executor in `register_all()` (was implemented but not wired up)
- Make `extract_opt_bool` helper `pub(crate)` for cross-module use
- Fix pre-existing clippy warnings in `view_file.rs` (too-many-lines, manual-let-else, match patterns)

### New tools

| Tool | Backend | Fallback | Params |
|------|---------|----------|--------|
| `grep` | `rg` (ripgrep) | `grep -rn` | pattern, path, glob, caseSensitive, maxResults |
| `find` | `fd` | `find` | pattern, path, type, maxDepth, maxResults |
| `ls` | `std::fs::read_dir` | n/a | path, all |

All tools validate paths against `ToolContext.allowed_roots` for sandbox enforcement. `grep`/`find` cap output at 50KB.

## Test plan

- [x] `cargo test -p aletheia-organon` (61 tests pass)
- [x] `cargo clippy -p aletheia-organon -- -D warnings` (clean)
- [ ] Verify grep finds patterns in real workspace
- [ ] Verify find locates files with type/depth filters
- [ ] Verify ls shows sorted directory listing with dotfile filtering
- [ ] Verify path traversal outside allowed_roots is rejected