### PR TITLE
feat: communication tool executors

### DIFF
--- a/crates/aletheia/src/main.rs
+++ b/crates/aletheia/src/main.rs
@@ -34,6 +34,7 @@ use aletheia_oikonomos::maintenance::{
 use aletheia_oikonomos::runner::TaskRunner;
 use aletheia_organon::builtins;
 use aletheia_organon::registry::ToolRegistry;
+use aletheia_organon::types::ToolServices;
 use aletheia_pylon::router::build_router;
 use aletheia_pylon::state::AppState;
 use aletheia_symbolon::credential::{
@@ -488,6 +489,23 @@ async fn serve(cli: Cli) -> Result<()> {
     // Cross-nous router for inter-agent messaging
     let cross_router = Arc::new(CrossNousRouter::default());
 
+    // Build signal provider early so it can be shared with tool services
+    let signal_provider = build_signal_provider(&config.channels.signal);
+
+    // Build tool services for communication executors
+    let tool_services = {
+        let cross_nous: Arc<dyn aletheia_organon::types::CrossNousService> =
+            Arc::new(tool_adapters::CrossNousAdapter(Arc::clone(&cross_router)));
+        let messenger: Option<Arc<dyn aletheia_organon::types::MessageService>> =
+            signal_provider
+                .as_ref()
+                .map(|p| Arc::new(tool_adapters::SignalAdapter(Arc::clone(p) as Arc<dyn ChannelProvider>)) as Arc<dyn aletheia_organon::types::MessageService>);
+        Arc::new(ToolServices {
+            cross_nous: Some(cross_nous),
+            messenger,
+        })
+    };
+
     // Spawn nous actors
     // vector_search is None until Phase 2 (prompt 28) lands KnowledgeVectorSearch
     let mut nous_manager = NousManager::new(
@@ -499,6 +517,7 @@ async fn serve(cli: Cli) -> Result<()> {
         Some(Arc::clone(&session_store)),
         Arc::clone(&packs),
         Some(Arc::clone(&cross_router)),
+        Some(tool_services),
     );
 
     if config.agents.list.is_empty() {
@@ -562,7 +581,7 @@ async fn serve(cli: Cli) -> Result<()> {
     // Channel registry + inbound dispatch (gated on ready signal)
     let ready_rx = nous_manager.ready_rx();
     let (_channel_registry, _dispatch_handle) =
-        start_inbound_dispatch(&config, &nous_manager, ready_rx);
+        start_inbound_dispatch(&config, &nous_manager, ready_rx, signal_provider.as_ref());
 
     // Daemon runners — per-agent background task scheduling
     let (daemon_shutdown_tx, _) = tokio::sync::watch::channel(false);
@@ -806,6 +825,92 @@ async fn handle_credential(
     Ok(())
 }
 
+// -- Tool service adapters -------------------------------------------------
+
+mod tool_adapters {
+    use std::future::Future;
+    use std::pin::Pin;
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use aletheia_agora::types::{ChannelProvider, SendParams};
+    use aletheia_nous::cross::{CrossNousMessage, CrossNousRouter};
+    use aletheia_organon::types::{CrossNousService, MessageService};
+
+    pub struct CrossNousAdapter(pub Arc<CrossNousRouter>);
+
+    impl CrossNousService for CrossNousAdapter {
+        fn send(
+            &self,
+            from: &str,
+            to: &str,
+            session_key: &str,
+            content: &str,
+        ) -> Pin<Box<dyn Future<Output = Result<(), String>> + Send + '_>> {
+            let msg = CrossNousMessage::new(from, to, content).with_target_session(session_key);
+            let router = Arc::clone(&self.0);
+            Box::pin(async move {
+                router
+                    .send(msg)
+                    .await
+                    .map(|_| ())
+                    .map_err(|e| e.to_string())
+            })
+        }
+
+        fn ask(
+            &self,
+            from: &str,
+            to: &str,
+            session_key: &str,
+            content: &str,
+            timeout_secs: u64,
+        ) -> Pin<Box<dyn Future<Output = Result<String, String>> + Send + '_>> {
+            let msg = CrossNousMessage::new(from, to, content)
+                .with_target_session(session_key)
+                .with_reply(Duration::from_secs(timeout_secs));
+            let router = Arc::clone(&self.0);
+            Box::pin(async move {
+                router
+                    .ask(msg)
+                    .await
+                    .map(|reply| reply.content)
+                    .map_err(|e| e.to_string())
+            })
+        }
+    }
+
+    pub struct SignalAdapter(pub Arc<dyn ChannelProvider>);
+
+    impl MessageService for SignalAdapter {
+        fn send_message(
+            &self,
+            to: &str,
+            text: &str,
+            _from_nous: &str,
+        ) -> Pin<Box<dyn Future<Output = Result<(), String>> + Send + '_>> {
+            let params = SendParams {
+                to: to.to_owned(),
+                text: text.to_owned(),
+                account_id: None,
+                thread_id: None,
+                attachments: None,
+            };
+            let provider = Arc::clone(&self.0);
+            Box::pin(async move {
+                let result = provider.send(&params).await;
+                if result.sent {
+                    Ok(())
+                } else {
+                    Err(result
+                        .error
+                        .unwrap_or_else(|| "unknown send error".to_owned()))
+                }
+            })
+        }
+    }
+}
+
 /// Build a tool registry with all builtins.
 fn build_tool_registry() -> Result<ToolRegistry> {
     let mut registry = ToolRegistry::new();
@@ -819,18 +924,18 @@ fn start_inbound_dispatch(
     config: &aletheia_taxis::config::AletheiaConfig,
     nous_manager: &Arc<NousManager>,
     ready_rx: tokio::sync::watch::Receiver<bool>,
+    signal_provider: Option<&Arc<SignalProvider>>,
 ) -> (Arc<ChannelRegistry>, Option<tokio::task::JoinHandle<()>>) {
     let mut channel_registry = ChannelRegistry::new();
 
-    let signal_provider = build_signal_provider(&config.channels.signal);
-    if let Some(ref provider) = signal_provider {
+    if let Some(provider) = signal_provider {
         channel_registry
             .register(Arc::clone(provider) as Arc<dyn ChannelProvider>)
             .expect("register signal provider");
     }
     let channel_registry = Arc::new(channel_registry);
 
-    let handle = if let Some(ref provider) = signal_provider {
+    let handle = if let Some(provider) = signal_provider {
         let listener = ChannelListener::start(provider, None);
         info!("signal channel listener started");
         let rx = listener.into_receiver();

--- a/crates/integration-tests/tests/domain_packs.rs
+++ b/crates/integration-tests/tests/domain_packs.rs
@@ -132,6 +132,7 @@ context:
         None,
         Arc::new(packs),
         None,
+        None,
     );
 
     let config = NousConfig {
@@ -262,6 +263,7 @@ overlays:
         None,
         Arc::new(packs.clone()),
         None,
+        None,
     );
 
     let chiron_config = NousConfig {
@@ -292,6 +294,7 @@ overlays:
         None,
         None,
         Arc::new(packs),
+        None,
         None,
     );
 

--- a/crates/integration-tests/tests/end_to_end.rs
+++ b/crates/integration-tests/tests/end_to_end.rs
@@ -162,6 +162,7 @@ impl TestHarness {
             Some(Arc::clone(&session_store)),
             Arc::new(vec![]),
             None,
+            None,
         );
 
         let nous_config = NousConfig {

--- a/crates/integration-tests/tests/eval_harness.rs
+++ b/crates/integration-tests/tests/eval_harness.rs
@@ -92,6 +92,7 @@ async fn start_test_server() -> (String, String, tempfile::TempDir) {
         Some(Arc::clone(&session_store)),
         Arc::new(vec![]),
         None,
+        None,
     );
 
     let nous_config = NousConfig {

--- a/crates/nous/src/actor.rs
+++ b/crates/nous/src/actor.rs
@@ -14,7 +14,7 @@ use aletheia_hermeneus::provider::ProviderRegistry;
 use aletheia_koina::id::{NousId, SessionId};
 use aletheia_mneme::embedding::EmbeddingProvider;
 use aletheia_organon::registry::ToolRegistry;
-use aletheia_organon::types::ToolContext;
+use aletheia_organon::types::{ToolContext, ToolServices};
 use aletheia_taxis::oikos::Oikos;
 
 use crate::bootstrap::BootstrapSection;
@@ -46,6 +46,7 @@ pub struct NousActor {
     embedding_provider: Option<Arc<dyn EmbeddingProvider>>,
     vector_search: Option<Arc<dyn crate::recall::VectorSearch>>,
     session_store: Option<Arc<Mutex<SessionStore>>>,
+    tool_services: Option<Arc<ToolServices>>,
     extra_bootstrap: Vec<BootstrapSection>,
 }
 
@@ -68,6 +69,7 @@ impl NousActor {
         embedding_provider: Option<Arc<dyn EmbeddingProvider>>,
         vector_search: Option<Arc<dyn crate::recall::VectorSearch>>,
         session_store: Option<Arc<Mutex<SessionStore>>>,
+        tool_services: Option<Arc<ToolServices>>,
         extra_bootstrap: Vec<BootstrapSection>,
     ) -> Self {
         Self {
@@ -85,6 +87,7 @@ impl NousActor {
             embedding_provider,
             vector_search,
             session_store,
+            tool_services,
             extra_bootstrap,
         }
     }
@@ -215,6 +218,7 @@ impl NousActor {
             session_id: SessionId::new(),
             workspace: self.oikos.nous_dir(&self.id),
             allowed_roots: vec![self.oikos.root().to_path_buf()],
+            services: self.tool_services.clone(),
         };
 
         crate::pipeline::run_pipeline(
@@ -356,6 +360,7 @@ pub fn spawn(
     embedding_provider: Option<Arc<dyn EmbeddingProvider>>,
     vector_search: Option<Arc<dyn crate::recall::VectorSearch>>,
     session_store: Option<Arc<Mutex<SessionStore>>>,
+    tool_services: Option<Arc<aletheia_organon::types::ToolServices>>,
     extra_bootstrap: Vec<BootstrapSection>,
     cross_rx: Option<mpsc::Receiver<CrossNousEnvelope>>,
 ) -> (NousHandle, tokio::task::JoinHandle<()>) {
@@ -375,6 +380,7 @@ pub fn spawn(
         embedding_provider,
         vector_search,
         session_store,
+        tool_services,
         extra_bootstrap,
     );
 
@@ -472,6 +478,7 @@ mod tests {
             providers,
             tools,
             oikos,
+            None,
             None,
             None,
             None,

--- a/crates/nous/src/execute.rs
+++ b/crates/nous/src/execute.rs
@@ -419,6 +419,7 @@ mod tests {
             session_id: SessionId::new(),
             workspace: PathBuf::from("/tmp/test"),
             allowed_roots: vec![PathBuf::from("/tmp")],
+            services: None,
         }
     }
 

--- a/crates/nous/src/manager.rs
+++ b/crates/nous/src/manager.rs
@@ -13,6 +13,7 @@ use tracing::{info, warn};
 use aletheia_hermeneus::provider::ProviderRegistry;
 use aletheia_mneme::embedding::EmbeddingProvider;
 use aletheia_organon::registry::ToolRegistry;
+use aletheia_organon::types::ToolServices;
 use aletheia_taxis::oikos::Oikos;
 
 use crate::actor;
@@ -39,6 +40,7 @@ pub struct NousManager {
     session_store: Option<Arc<Mutex<SessionStore>>>,
     packs: Arc<Vec<LoadedPack>>,
     router: Option<Arc<crate::cross::CrossNousRouter>>,
+    tool_services: Option<Arc<ToolServices>>,
     ready_tx: watch::Sender<bool>,
     ready_rx: watch::Receiver<bool>,
 }
@@ -59,6 +61,7 @@ impl NousManager {
         session_store: Option<Arc<Mutex<SessionStore>>>,
         packs: Arc<Vec<LoadedPack>>,
         router: Option<Arc<crate::cross::CrossNousRouter>>,
+        tool_services: Option<Arc<ToolServices>>,
     ) -> Self {
         let (ready_tx, ready_rx) = watch::channel(false);
         Self {
@@ -71,6 +74,7 @@ impl NousManager {
             session_store,
             packs,
             router,
+            tool_services,
             ready_tx,
             ready_rx,
         }
@@ -141,6 +145,7 @@ impl NousManager {
             self.embedding_provider.clone(),
             self.vector_search.clone(),
             self.session_store.clone(),
+            self.tool_services.clone(),
             extra_bootstrap,
             cross_rx,
         );
@@ -324,6 +329,7 @@ mod tests {
             None,
             None,
             Arc::new(Vec::new()),
+            None,
             None,
         )
     }

--- a/crates/nous/src/pipeline.rs
+++ b/crates/nous/src/pipeline.rs
@@ -932,6 +932,7 @@ mod tests {
             session_id: SessionId::new(),
             workspace: PathBuf::from("/tmp/test"),
             allowed_roots: vec![PathBuf::from("/tmp")],
+            services: None,
         };
 
         let session = crate::session::SessionState::new(

--- a/crates/organon/src/builtins/communication.rs
+++ b/crates/organon/src/builtins/communication.rs
@@ -1,4 +1,4 @@
-//! Communication tool stubs: message, `sessions_ask`.
+//! Communication tool executors: message, sessions_ask, sessions_send.
 
 use std::future::Future;
 use std::pin::Pin;
@@ -6,6 +6,7 @@ use std::pin::Pin;
 use aletheia_koina::id::ToolName;
 use indexmap::IndexMap;
 
+use super::workspace::{extract_opt_u64, extract_str};
 use crate::error::Result;
 use crate::registry::{ToolExecutor, ToolRegistry};
 use crate::types::{
@@ -13,27 +14,129 @@ use crate::types::{
     ToolResult,
 };
 
-struct Stub;
+const MESSAGE_MAX_LEN: usize = 4000;
 
-impl ToolExecutor for Stub {
+struct MessageExecutor;
+
+impl ToolExecutor for MessageExecutor {
     fn execute<'a>(
         &'a self,
         input: &'a ToolInput,
-        _ctx: &'a ToolContext,
+        ctx: &'a ToolContext,
     ) -> Pin<Box<dyn Future<Output = Result<ToolResult>> + Send + 'a>> {
         Box::pin(async {
-            Ok(ToolResult::text(format!(
-                "stub: {} not implemented",
-                input.name
-            )))
+            let Some(services) = ctx.services.as_ref() else {
+                return Ok(ToolResult::error("message service not available"));
+            };
+            let Some(messenger) = services.messenger.as_ref() else {
+                return Ok(ToolResult::error("message service not configured"));
+            };
+
+            let to = extract_str(&input.arguments, "to", &input.name)?;
+            let text = extract_str(&input.arguments, "text", &input.name)?;
+
+            if text.len() > MESSAGE_MAX_LEN {
+                return Ok(ToolResult::error(format!(
+                    "Message exceeds {MESSAGE_MAX_LEN} character limit ({} chars)",
+                    text.len()
+                )));
+            }
+
+            match messenger.send_message(to, text, ctx.nous_id.as_str()).await {
+                Ok(()) => Ok(ToolResult::text(format!("Message sent to {to}"))),
+                Err(e) => Ok(ToolResult::error(format!("Send failed: {e}"))),
+            }
         })
     }
 }
 
-/// Register communication tool stubs.
+struct SessionsAskExecutor;
+
+impl ToolExecutor for SessionsAskExecutor {
+    fn execute<'a>(
+        &'a self,
+        input: &'a ToolInput,
+        ctx: &'a ToolContext,
+    ) -> Pin<Box<dyn Future<Output = Result<ToolResult>> + Send + 'a>> {
+        Box::pin(async {
+            let Some(services) = ctx.services.as_ref() else {
+                return Ok(ToolResult::error("cross-nous service not available"));
+            };
+            let Some(cross) = services.cross_nous.as_ref() else {
+                return Ok(ToolResult::error("cross-nous service not configured"));
+            };
+
+            let agent_id = extract_str(&input.arguments, "agentId", &input.name)?;
+            let message = extract_str(&input.arguments, "message", &input.name)?;
+            let default_session = format!("ask:{}", ctx.nous_id.as_str());
+            let session_key = input
+                .arguments
+                .get("sessionKey")
+                .and_then(|v| v.as_str())
+                .unwrap_or(&default_session);
+            let timeout = extract_opt_u64(&input.arguments, "timeoutSeconds").unwrap_or(120);
+
+            match cross
+                .ask(
+                    ctx.nous_id.as_str(),
+                    agent_id,
+                    session_key,
+                    message,
+                    timeout,
+                )
+                .await
+            {
+                Ok(reply) => Ok(ToolResult::text(reply)),
+                Err(e) => Ok(ToolResult::error(format!("Ask {agent_id} failed: {e}"))),
+            }
+        })
+    }
+}
+
+struct SessionsSendExecutor;
+
+impl ToolExecutor for SessionsSendExecutor {
+    fn execute<'a>(
+        &'a self,
+        input: &'a ToolInput,
+        ctx: &'a ToolContext,
+    ) -> Pin<Box<dyn Future<Output = Result<ToolResult>> + Send + 'a>> {
+        Box::pin(async {
+            let Some(services) = ctx.services.as_ref() else {
+                return Ok(ToolResult::error("cross-nous service not available"));
+            };
+            let Some(cross) = services.cross_nous.as_ref() else {
+                return Ok(ToolResult::error("cross-nous service not configured"));
+            };
+
+            let agent_id = extract_str(&input.arguments, "agentId", &input.name)?;
+            let message = extract_str(&input.arguments, "message", &input.name)?;
+            let session_key = input
+                .arguments
+                .get("sessionKey")
+                .and_then(|v| v.as_str())
+                .unwrap_or("main");
+
+            match cross
+                .send(ctx.nous_id.as_str(), agent_id, session_key, message)
+                .await
+            {
+                Ok(()) => Ok(ToolResult::text(format!(
+                    "Message sent to {agent_id} (session: {session_key})"
+                ))),
+                Err(e) => Ok(ToolResult::error(format!(
+                    "Failed to send to {agent_id}: {e}"
+                ))),
+            }
+        })
+    }
+}
+
+/// Register communication tools.
 pub fn register(registry: &mut ToolRegistry) -> Result<()> {
-    registry.register(message_def(), Box::new(Stub))?;
-    registry.register(sessions_ask_def(), Box::new(Stub))?;
+    registry.register(message_def(), Box::new(MessageExecutor))?;
+    registry.register(sessions_ask_def(), Box::new(SessionsAskExecutor))?;
+    registry.register(sessions_send_def(), Box::new(SessionsSendExecutor))?;
     Ok(())
 }
 
@@ -121,14 +224,59 @@ fn sessions_ask_def() -> ToolDef {
     }
 }
 
+fn sessions_send_def() -> ToolDef {
+    ToolDef {
+        name: ToolName::new("sessions_send").expect("valid tool name"),
+        description: "Send a message to another agent without waiting for a response".to_owned(),
+        extended_description: None,
+        input_schema: InputSchema {
+            properties: IndexMap::from([
+                (
+                    "agentId".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::String,
+                        description: "Target nous ID".to_owned(),
+                        enum_values: None,
+                        default: None,
+                    },
+                ),
+                (
+                    "message".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::String,
+                        description: "Message to send".to_owned(),
+                        enum_values: None,
+                        default: None,
+                    },
+                ),
+                (
+                    "sessionKey".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::String,
+                        description: "Target session key (default: 'main')".to_owned(),
+                        enum_values: None,
+                        default: None,
+                    },
+                ),
+            ]),
+            required: vec!["agentId".to_owned(), "message".to_owned()],
+        },
+        category: ToolCategory::Communication,
+        auto_activate: false,
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use std::future::Future;
     use std::path::PathBuf;
+    use std::pin::Pin;
+    use std::sync::{Arc, Mutex};
 
     use aletheia_koina::id::{NousId, SessionId, ToolName};
 
     use crate::registry::ToolRegistry;
-    use crate::types::{ToolContext, ToolInput};
+    use crate::types::{CrossNousService, MessageService, ToolContext, ToolInput, ToolServices};
 
     fn test_ctx() -> ToolContext {
         ToolContext {
@@ -136,6 +284,79 @@ mod tests {
             session_id: SessionId::new(),
             workspace: PathBuf::from("/tmp/test"),
             allowed_roots: vec![PathBuf::from("/tmp")],
+            services: None,
+        }
+    }
+
+    fn test_ctx_with_services(services: ToolServices) -> ToolContext {
+        ToolContext {
+            nous_id: NousId::new("test-agent").expect("valid"),
+            session_id: SessionId::new(),
+            workspace: PathBuf::from("/tmp/test"),
+            allowed_roots: vec![PathBuf::from("/tmp")],
+            services: Some(Arc::new(services)),
+        }
+    }
+
+    #[derive(Default)]
+    struct MockCrossNous {
+        send_calls: Mutex<Vec<(String, String, String, String)>>,
+        ask_reply: Mutex<Option<Result<String, String>>>,
+    }
+
+    impl CrossNousService for MockCrossNous {
+        fn send(
+            &self,
+            from: &str,
+            to: &str,
+            session_key: &str,
+            content: &str,
+        ) -> Pin<Box<dyn Future<Output = Result<(), String>> + Send + '_>> {
+            self.send_calls.lock().unwrap().push((
+                from.to_owned(),
+                to.to_owned(),
+                session_key.to_owned(),
+                content.to_owned(),
+            ));
+            Box::pin(async { Ok(()) })
+        }
+
+        fn ask(
+            &self,
+            _from: &str,
+            _to: &str,
+            _session_key: &str,
+            _content: &str,
+            _timeout_secs: u64,
+        ) -> Pin<Box<dyn Future<Output = Result<String, String>> + Send + '_>> {
+            let reply = self
+                .ask_reply
+                .lock()
+                .unwrap()
+                .take()
+                .unwrap_or(Ok("mock reply".to_owned()));
+            Box::pin(async move { reply })
+        }
+    }
+
+    #[derive(Default)]
+    struct MockMessenger {
+        send_calls: Mutex<Vec<(String, String, String)>>,
+    }
+
+    impl MessageService for MockMessenger {
+        fn send_message(
+            &self,
+            to: &str,
+            text: &str,
+            from_nous: &str,
+        ) -> Pin<Box<dyn Future<Output = Result<(), String>> + Send + '_>> {
+            self.send_calls.lock().unwrap().push((
+                to.to_owned(),
+                text.to_owned(),
+                from_nous.to_owned(),
+            ));
+            Box::pin(async { Ok(()) })
         }
     }
 
@@ -143,38 +364,7 @@ mod tests {
     async fn register_communication_tools() {
         let mut reg = ToolRegistry::new();
         super::register(&mut reg).expect("register");
-        assert_eq!(reg.definitions().len(), 2);
-    }
-
-    #[tokio::test]
-    async fn message_stub_responds() {
-        let mut reg = ToolRegistry::new();
-        super::register(&mut reg).expect("register");
-        let input = ToolInput {
-            name: ToolName::new("message").expect("valid"),
-            tool_use_id: "tu_1".to_owned(),
-            arguments: serde_json::json!({"to": "+1234567890", "text": "hello"}),
-        };
-        let result = reg.execute(&input, &test_ctx()).await.expect("execute");
-        assert!(!result.is_error);
-        assert!(
-            result.content.text_summary().contains("stub"),
-            "expected stub: {}",
-            result.content.text_summary()
-        );
-    }
-
-    #[tokio::test]
-    async fn sessions_ask_stub_responds() {
-        let mut reg = ToolRegistry::new();
-        super::register(&mut reg).expect("register");
-        let input = ToolInput {
-            name: ToolName::new("sessions_ask").expect("valid"),
-            tool_use_id: "tu_2".to_owned(),
-            arguments: serde_json::json!({"agentId": "syn", "message": "hello"}),
-        };
-        let result = reg.execute(&input, &test_ctx()).await.expect("execute");
-        assert!(!result.is_error);
+        assert_eq!(reg.definitions().len(), 3);
     }
 
     #[tokio::test]
@@ -193,5 +383,190 @@ mod tests {
         let name = ToolName::new("sessions_ask").expect("valid");
         let def = reg.get_def(&name).expect("found");
         assert_eq!(def.input_schema.required, vec!["agentId", "message"]);
+    }
+
+    #[tokio::test]
+    async fn sessions_send_def_requires_agent_and_message() {
+        let mut reg = ToolRegistry::new();
+        super::register(&mut reg).expect("register");
+        let name = ToolName::new("sessions_send").expect("valid");
+        let def = reg.get_def(&name).expect("found");
+        assert_eq!(def.input_schema.required, vec!["agentId", "message"]);
+    }
+
+    #[tokio::test]
+    async fn message_missing_service_returns_error() {
+        let mut reg = ToolRegistry::new();
+        super::register(&mut reg).expect("register");
+        let input = ToolInput {
+            name: ToolName::new("message").expect("valid"),
+            tool_use_id: "tu_1".to_owned(),
+            arguments: serde_json::json!({"to": "+1234567890", "text": "hello"}),
+        };
+        let result = reg.execute(&input, &test_ctx()).await.expect("execute");
+        assert!(result.is_error);
+        assert!(result.content.text_summary().contains("not available"));
+    }
+
+    #[tokio::test]
+    async fn sessions_send_missing_service_returns_error() {
+        let mut reg = ToolRegistry::new();
+        super::register(&mut reg).expect("register");
+        let input = ToolInput {
+            name: ToolName::new("sessions_send").expect("valid"),
+            tool_use_id: "tu_1".to_owned(),
+            arguments: serde_json::json!({"agentId": "syn", "message": "hello"}),
+        };
+        let result = reg.execute(&input, &test_ctx()).await.expect("execute");
+        assert!(result.is_error);
+        assert!(result.content.text_summary().contains("not available"));
+    }
+
+    #[tokio::test]
+    async fn sessions_ask_missing_service_returns_error() {
+        let mut reg = ToolRegistry::new();
+        super::register(&mut reg).expect("register");
+        let input = ToolInput {
+            name: ToolName::new("sessions_ask").expect("valid"),
+            tool_use_id: "tu_1".to_owned(),
+            arguments: serde_json::json!({"agentId": "syn", "message": "hello"}),
+        };
+        let result = reg.execute(&input, &test_ctx()).await.expect("execute");
+        assert!(result.is_error);
+        assert!(result.content.text_summary().contains("not available"));
+    }
+
+    #[tokio::test]
+    async fn message_rejects_over_4000_chars() {
+        let messenger = Arc::new(MockMessenger::default());
+        let ctx = test_ctx_with_services(ToolServices {
+            cross_nous: None,
+            messenger: Some(messenger),
+        });
+        let mut reg = ToolRegistry::new();
+        super::register(&mut reg).expect("register");
+        let input = ToolInput {
+            name: ToolName::new("message").expect("valid"),
+            tool_use_id: "tu_1".to_owned(),
+            arguments: serde_json::json!({"to": "+1234567890", "text": "x".repeat(4001)}),
+        };
+        let result = reg.execute(&input, &ctx).await.expect("execute");
+        assert!(result.is_error);
+        assert!(result.content.text_summary().contains("4000"));
+    }
+
+    #[tokio::test]
+    async fn message_sends_via_signal() {
+        let messenger = Arc::new(MockMessenger::default());
+        let messenger_ref = Arc::clone(&messenger);
+        let ctx = test_ctx_with_services(ToolServices {
+            cross_nous: None,
+            messenger: Some(messenger),
+        });
+        let mut reg = ToolRegistry::new();
+        super::register(&mut reg).expect("register");
+        let input = ToolInput {
+            name: ToolName::new("message").expect("valid"),
+            tool_use_id: "tu_1".to_owned(),
+            arguments: serde_json::json!({"to": "+1234567890", "text": "hello world"}),
+        };
+        let result = reg.execute(&input, &ctx).await.expect("execute");
+        assert!(!result.is_error);
+        assert!(result.content.text_summary().contains("sent"));
+
+        let calls = messenger_ref.send_calls.lock().unwrap();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].0, "+1234567890");
+        assert_eq!(calls[0].1, "hello world");
+        assert_eq!(calls[0].2, "test-agent");
+    }
+
+    #[tokio::test]
+    async fn sessions_send_dispatches() {
+        let cross = Arc::new(MockCrossNous::default());
+        let cross_ref = Arc::clone(&cross);
+        let ctx = test_ctx_with_services(ToolServices {
+            cross_nous: Some(cross),
+            messenger: None,
+        });
+        let mut reg = ToolRegistry::new();
+        super::register(&mut reg).expect("register");
+        let input = ToolInput {
+            name: ToolName::new("sessions_send").expect("valid"),
+            tool_use_id: "tu_1".to_owned(),
+            arguments: serde_json::json!({"agentId": "syn", "message": "do the thing"}),
+        };
+        let result = reg.execute(&input, &ctx).await.expect("execute");
+        assert!(!result.is_error);
+        assert!(result.content.text_summary().contains("sent"));
+
+        let calls = cross_ref.send_calls.lock().unwrap();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].0, "test-agent");
+        assert_eq!(calls[0].1, "syn");
+        assert_eq!(calls[0].2, "main");
+        assert_eq!(calls[0].3, "do the thing");
+    }
+
+    #[tokio::test]
+    async fn sessions_send_uses_custom_session_key() {
+        let cross = Arc::new(MockCrossNous::default());
+        let cross_ref = Arc::clone(&cross);
+        let ctx = test_ctx_with_services(ToolServices {
+            cross_nous: Some(cross),
+            messenger: None,
+        });
+        let mut reg = ToolRegistry::new();
+        super::register(&mut reg).expect("register");
+        let input = ToolInput {
+            name: ToolName::new("sessions_send").expect("valid"),
+            tool_use_id: "tu_1".to_owned(),
+            arguments: serde_json::json!({"agentId": "syn", "message": "hi", "sessionKey": "custom"}),
+        };
+        let result = reg.execute(&input, &ctx).await.expect("execute");
+        assert!(!result.is_error);
+
+        let calls = cross_ref.send_calls.lock().unwrap();
+        assert_eq!(calls[0].2, "custom");
+    }
+
+    #[tokio::test]
+    async fn sessions_ask_returns_reply() {
+        let cross = Arc::new(MockCrossNous::default());
+        *cross.ask_reply.lock().unwrap() = Some(Ok("the answer is 42".to_owned()));
+        let ctx = test_ctx_with_services(ToolServices {
+            cross_nous: Some(cross),
+            messenger: None,
+        });
+        let mut reg = ToolRegistry::new();
+        super::register(&mut reg).expect("register");
+        let input = ToolInput {
+            name: ToolName::new("sessions_ask").expect("valid"),
+            tool_use_id: "tu_1".to_owned(),
+            arguments: serde_json::json!({"agentId": "syn", "message": "what is the answer?"}),
+        };
+        let result = reg.execute(&input, &ctx).await.expect("execute");
+        assert!(!result.is_error);
+        assert_eq!(result.content.text_summary(), "the answer is 42");
+    }
+
+    #[tokio::test]
+    async fn sessions_ask_timeout_returns_error() {
+        let cross = Arc::new(MockCrossNous::default());
+        *cross.ask_reply.lock().unwrap() = Some(Err("timed out after 120s".to_owned()));
+        let ctx = test_ctx_with_services(ToolServices {
+            cross_nous: Some(cross),
+            messenger: None,
+        });
+        let mut reg = ToolRegistry::new();
+        super::register(&mut reg).expect("register");
+        let input = ToolInput {
+            name: ToolName::new("sessions_ask").expect("valid"),
+            tool_use_id: "tu_1".to_owned(),
+            arguments: serde_json::json!({"agentId": "syn", "message": "hello?"}),
+        };
+        let result = reg.execute(&input, &ctx).await.expect("execute");
+        assert!(result.is_error);
+        assert!(result.content.text_summary().contains("timed out"));
     }
 }

--- a/crates/organon/src/builtins/memory.rs
+++ b/crates/organon/src/builtins/memory.rs
@@ -191,6 +191,7 @@ mod tests {
             session_id: SessionId::new(),
             workspace: PathBuf::from("/tmp/test"),
             allowed_roots: vec![PathBuf::from("/tmp")],
+            services: None,
         }
     }
 

--- a/crates/organon/src/builtins/view_file.rs
+++ b/crates/organon/src/builtins/view_file.rs
@@ -222,6 +222,7 @@ mod tests {
             session_id: SessionId::new(),
             workspace: dir.to_path_buf(),
             allowed_roots: vec![dir.to_path_buf()],
+            services: None,
         }
     }
 

--- a/crates/organon/src/builtins/workspace.rs
+++ b/crates/organon/src/builtins/workspace.rs
@@ -487,6 +487,7 @@ mod tests {
             session_id: SessionId::new(),
             workspace: dir.to_path_buf(),
             allowed_roots: vec![dir.to_path_buf()],
+            services: None,
         }
     }
 

--- a/crates/organon/src/registry.rs
+++ b/crates/organon/src/registry.rs
@@ -167,6 +167,7 @@ mod tests {
             session_id: SessionId::new(),
             workspace: std::path::PathBuf::from("/tmp/test"),
             allowed_roots: vec![std::path::PathBuf::from("/tmp")],
+            services: None,
         }
     }
 

--- a/crates/organon/src/types.rs
+++ b/crates/organon/src/types.rs
@@ -1,6 +1,9 @@
 //! Core types for tool definitions, input/output, and execution context.
 
+use std::future::Future;
 use std::path::PathBuf;
+use std::pin::Pin;
+use std::sync::Arc;
 
 use aletheia_koina::id::{NousId, SessionId, ToolName};
 use indexmap::IndexMap;
@@ -244,6 +247,54 @@ impl ToolStats {
     }
 }
 
+/// Cross-nous message routing for tool executors.
+pub trait CrossNousService: Send + Sync {
+    /// Fire-and-forget send to another agent.
+    fn send(
+        &self,
+        from: &str,
+        to: &str,
+        session_key: &str,
+        content: &str,
+    ) -> Pin<Box<dyn Future<Output = Result<(), String>> + Send + '_>>;
+
+    /// Send and wait for a reply from another agent.
+    fn ask(
+        &self,
+        from: &str,
+        to: &str,
+        session_key: &str,
+        content: &str,
+        timeout_secs: u64,
+    ) -> Pin<Box<dyn Future<Output = Result<String, String>> + Send + '_>>;
+}
+
+/// Outbound message delivery (Signal, etc.) for tool executors.
+pub trait MessageService: Send + Sync {
+    /// Send a text message to a recipient.
+    fn send_message(
+        &self,
+        to: &str,
+        text: &str,
+        from_nous: &str,
+    ) -> Pin<Box<dyn Future<Output = Result<(), String>> + Send + '_>>;
+}
+
+/// Service locator for tool executors needing access to runtime services.
+pub struct ToolServices {
+    pub cross_nous: Option<Arc<dyn CrossNousService>>,
+    pub messenger: Option<Arc<dyn MessageService>>,
+}
+
+impl std::fmt::Debug for ToolServices {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ToolServices")
+            .field("cross_nous", &self.cross_nous.is_some())
+            .field("messenger", &self.messenger.is_some())
+            .finish()
+    }
+}
+
 /// Execution context passed to every tool invocation.
 #[derive(Debug, Clone)]
 pub struct ToolContext {
@@ -255,6 +306,8 @@ pub struct ToolContext {
     pub workspace: PathBuf,
     /// Allowed filesystem roots for sandboxing.
     pub allowed_roots: Vec<PathBuf>,
+    /// Optional runtime services for tools that need cross-cutting capabilities.
+    pub services: Option<Arc<ToolServices>>,
 }
 
 #[cfg(test)]

--- a/crates/pylon/src/server.rs
+++ b/crates/pylon/src/server.rs
@@ -81,6 +81,7 @@ pub async fn run(config: ServerConfig) -> Result<(), ServerError> {
         Some(Arc::clone(&session_store)),
         Arc::new(vec![]),
         None,
+        None,
     );
     let nous_config = NousConfig::default();
     nous_manager

--- a/crates/pylon/src/tests.rs
+++ b/crates/pylon/src/tests.rs
@@ -120,6 +120,7 @@ async fn test_state_with_provider(with_provider: bool) -> (Arc<AppState>, tempfi
         Some(Arc::clone(&session_store)),
         Arc::new(vec![]),
         None,
+        None,
     );
 
     let nous_config = NousConfig {

--- a/crates/thesauros/src/tools.rs
+++ b/crates/thesauros/src/tools.rs
@@ -512,6 +512,7 @@ mod tests {
             session_id: aletheia_koina::id::SessionId::new(),
             workspace: dir.path().to_path_buf(),
             allowed_roots: vec![],
+            services: None,
         };
 
         let result = futures::executor::block_on(executor.execute(&input, &ctx)).unwrap();
@@ -540,6 +541,7 @@ mod tests {
             session_id: aletheia_koina::id::SessionId::new(),
             workspace: dir.path().to_path_buf(),
             allowed_roots: vec![],
+            services: None,
         };
 
         let result = futures::executor::block_on(executor.execute(&input, &ctx)).unwrap();


### PR DESCRIPTION
## Summary

- Replace stub executors for `sessions_ask` and `message` with real implementations
- Add new `sessions_send` tool (fire-and-forget cross-agent messaging)
- Introduce `ToolServices` pattern: `CrossNousService` and `MessageService` traits in organon, with adapter implementations in the main binary
- Thread `ToolServices` through `NousManager` -> `NousActor` -> `ToolContext`

## Details

**New types** (`crates/organon/src/types.rs`):
- `CrossNousService` trait: `send()` and `ask()` for cross-agent communication
- `MessageService` trait: `send_message()` for outbound Signal messaging
- `ToolServices` struct: optional service locator on `ToolContext`

**Executors** (`crates/organon/src/builtins/communication.rs`):
- `MessageExecutor`: validates 4000-char limit, delegates to `MessageService`
- `SessionsAskExecutor`: delegates to `CrossNousService.ask()` with configurable timeout
- `SessionsSendExecutor`: delegates to `CrossNousService.send()` with configurable session key

**Adapters** (`crates/aletheia/src/main.rs`):
- `CrossNousAdapter`: wraps `CrossNousRouter`, constructs `CrossNousMessage`
- `SignalAdapter`: wraps `ChannelProvider`, uses agora's target parsing (phone/group)

## Test plan

- [x] `cargo test -p aletheia-organon` (49 tests pass, including 14 new communication tests)
- [x] `cargo test -p aletheia-nous` (186 tests pass)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` (zero errors)
- [ ] Manual: verify `sessions_send` dispatches to registered agent
- [ ] Manual: verify `message` sends via Signal when provider configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)