### PR TITLE
feat: memory tool executors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -242,6 +242,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "twox-hash 2.1.2",
+ "ulid",
  "unicode-normalization",
  "uuid",
 ]
@@ -259,6 +260,7 @@ dependencies = [
  "indexmap",
  "jiff",
  "prometheus",
+ "reqwest",
  "serde",
  "serde_json",
  "snafu",
@@ -296,6 +298,7 @@ dependencies = [
  "base64 0.22.1",
  "indexmap",
  "prometheus",
+ "reqwest",
  "serde",
  "serde_json",
  "snafu",

--- a/crates/aletheia/src/main.rs
+++ b/crates/aletheia/src/main.rs
@@ -492,7 +492,7 @@ async fn serve(cli: Cli) -> Result<()> {
     // Build signal provider early so it can be shared with tool services
     let signal_provider = build_signal_provider(&config.channels.signal);
 
-    // Build tool services for communication executors
+    // Build tool services for communication + memory executors
     let tool_services = {
         let cross_nous: Arc<dyn aletheia_organon::types::CrossNousService> =
             Arc::new(tool_adapters::CrossNousAdapter(Arc::clone(&cross_router)));
@@ -500,9 +500,16 @@ async fn serve(cli: Cli) -> Result<()> {
             signal_provider
                 .as_ref()
                 .map(|p| Arc::new(tool_adapters::SignalAdapter(Arc::clone(p) as Arc<dyn ChannelProvider>)) as Arc<dyn aletheia_organon::types::MessageService>);
+        let note_store: Option<Arc<dyn aletheia_organon::types::NoteStore>> =
+            Some(Arc::new(aletheia_nous::adapters::SessionNoteAdapter(Arc::clone(&session_store))));
+        let blackboard_store: Option<Arc<dyn aletheia_organon::types::BlackboardStore>> =
+            Some(Arc::new(aletheia_nous::adapters::SessionBlackboardAdapter(Arc::clone(&session_store))));
         Arc::new(ToolServices {
             cross_nous: Some(cross_nous),
             messenger,
+            note_store,
+            blackboard_store,
+            http_client: reqwest::Client::new(),
         })
     };
 

--- a/crates/mneme/Cargo.toml
+++ b/crates/mneme/Cargo.toml
@@ -44,6 +44,7 @@ serde_json = { workspace = true }
 snafu = { workspace = true }
 tokio = { workspace = true, optional = true }
 tracing = { workspace = true }
+ulid = { workspace = true }
 
 # Engine (vendored CozoDB) dependencies — activated by mneme-engine feature
 rayon = { workspace = true, optional = true }

--- a/crates/mneme/src/migration.rs
+++ b/crates/mneme/src/migration.rs
@@ -20,16 +20,34 @@ pub struct Migration {
 }
 
 /// All registered migrations, in version order.
-pub static MIGRATIONS: &[Migration] = &[Migration {
-    version: 1,
-    description: "base schema — sessions, messages, usage, distillations, agent_notes",
-    up: DDL,
-    down: "DROP TABLE IF EXISTS agent_notes;
+pub static MIGRATIONS: &[Migration] = &[
+    Migration {
+        version: 1,
+        description: "base schema — sessions, messages, usage, distillations, agent_notes",
+        up: DDL,
+        down: "DROP TABLE IF EXISTS agent_notes;
 DROP TABLE IF EXISTS distillations;
 DROP TABLE IF EXISTS usage;
 DROP TABLE IF EXISTS messages;
 DROP TABLE IF EXISTS sessions;",
-}];
+    },
+    Migration {
+        version: 2,
+        description: "blackboard — shared agent state with TTL",
+        up: "CREATE TABLE IF NOT EXISTS blackboard (
+    id TEXT PRIMARY KEY,
+    key TEXT NOT NULL UNIQUE,
+    value TEXT NOT NULL,
+    author_nous_id TEXT NOT NULL,
+    ttl_seconds INTEGER DEFAULT 3600,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    expires_at TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_blackboard_key ON blackboard(key);
+CREATE INDEX IF NOT EXISTS idx_blackboard_expires ON blackboard(expires_at);",
+        down: "DROP TABLE IF EXISTS blackboard;",
+    },
+];
 
 /// Outcome of a migration run.
 #[derive(Debug)]
@@ -197,8 +215,8 @@ mod tests {
         let result = run_migrations(&conn).unwrap();
 
         assert!(result.was_fresh);
-        assert_eq!(result.applied, vec![1]);
-        assert_eq!(result.current_version, 1);
+        assert_eq!(result.applied, vec![1, 2]);
+        assert_eq!(result.current_version, 2);
     }
 
     #[test]
@@ -209,7 +227,7 @@ mod tests {
         let result = run_migrations(&conn).unwrap();
         assert!(!result.was_fresh);
         assert!(result.applied.is_empty());
-        assert_eq!(result.current_version, 1);
+        assert_eq!(result.current_version, 2);
     }
 
     #[test]
@@ -235,7 +253,7 @@ mod tests {
         bootstrap_version_table(&conn).unwrap();
 
         let pending = check_migrations(&conn).unwrap();
-        assert_eq!(pending.len(), 1);
+        assert_eq!(pending.len(), 2);
         assert_eq!(pending[0].version, 1);
 
         // Verify nothing was applied
@@ -276,6 +294,7 @@ mod tests {
             "usage",
             "distillations",
             "agent_notes",
+            "blackboard",
         ] {
             let exists: bool = conn
                 .query_row(
@@ -304,11 +323,11 @@ mod tests {
         conn.execute("INSERT INTO schema_version (version) VALUES (1)", [])
             .unwrap();
 
-        // Running migrations should detect existing v1 and do nothing
+        // Running migrations should detect existing v1 and apply v2
         let result = run_migrations(&conn).unwrap();
         assert!(!result.was_fresh);
-        assert!(result.applied.is_empty());
-        assert_eq!(result.current_version, 1);
+        assert_eq!(result.applied, vec![2]);
+        assert_eq!(result.current_version, 2);
 
         // description column should have been added
         assert!(has_description_column(&conn));

--- a/crates/mneme/src/schema.rs
+++ b/crates/mneme/src/schema.rs
@@ -102,7 +102,7 @@ mod tests {
     fn fresh_database_initializes_via_migration() {
         let conn = Connection::open_in_memory().unwrap();
         let result = migration::run_migrations(&conn).unwrap();
-        assert_eq!(result.current_version, 1);
+        assert_eq!(result.current_version, 2);
     }
 
     #[test]
@@ -112,7 +112,7 @@ mod tests {
         migration::run_migrations(&conn).unwrap();
 
         let version = migration::get_schema_version(&conn);
-        assert_eq!(version, 1);
+        assert_eq!(version, 2);
     }
 
     #[test]
@@ -126,6 +126,7 @@ mod tests {
             "usage",
             "distillations",
             "agent_notes",
+            "blackboard",
         ] {
             let exists: bool = conn
                 .query_row(

--- a/crates/mneme/src/store.rs
+++ b/crates/mneme/src/store.rs
@@ -10,7 +10,9 @@ use tracing::{debug, info, instrument};
 
 use crate::error::{self, Result};
 use crate::migration;
-use crate::types::{AgentNote, Message, Role, Session, SessionStatus, SessionType, UsageRecord};
+use crate::types::{
+    AgentNote, BlackboardRow, Message, Role, Session, SessionStatus, SessionType, UsageRecord,
+};
 
 /// The session store — wraps a `SQLite` connection.
 pub struct SessionStore {
@@ -448,6 +450,101 @@ impl SessionStore {
         let rows = self
             .conn
             .execute("DELETE FROM agent_notes WHERE id = ?1", [note_id])
+            .context(error::DatabaseSnafu)?;
+        Ok(rows > 0)
+    }
+
+    // --- Blackboard ---
+
+    /// Write or update a blackboard entry. Upserts on key.
+    pub fn blackboard_write(
+        &self,
+        key: &str,
+        value: &str,
+        author: &str,
+        ttl_secs: i64,
+    ) -> Result<()> {
+        let id = ulid::Ulid::new().to_string();
+        self.conn
+            .execute(
+                "INSERT INTO blackboard (id, key, value, author_nous_id, ttl_seconds, expires_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5, datetime('now', '+' || ?5 || ' seconds'))
+                 ON CONFLICT(key) DO UPDATE SET
+                   value = excluded.value,
+                   author_nous_id = excluded.author_nous_id,
+                   ttl_seconds = excluded.ttl_seconds,
+                   expires_at = excluded.expires_at",
+                rusqlite::params![id, key, value, author, ttl_secs],
+            )
+            .context(error::DatabaseSnafu)?;
+        Ok(())
+    }
+
+    /// Read a blackboard entry by key, filtering expired entries.
+    pub fn blackboard_read(&self, key: &str) -> Result<Option<BlackboardRow>> {
+        let result = self
+            .conn
+            .query_row(
+                "SELECT key, value, author_nous_id, ttl_seconds, created_at, expires_at
+                 FROM blackboard
+                 WHERE key = ?1 AND (expires_at IS NULL OR expires_at > datetime('now'))",
+                [key],
+                |row| {
+                    Ok(BlackboardRow {
+                        key: row.get(0)?,
+                        value: row.get(1)?,
+                        author_nous_id: row.get(2)?,
+                        ttl_seconds: row.get(3)?,
+                        created_at: row.get(4)?,
+                        expires_at: row.get(5)?,
+                    })
+                },
+            )
+            .optional()
+            .context(error::DatabaseSnafu)?;
+        Ok(result)
+    }
+
+    /// List all non-expired blackboard entries.
+    pub fn blackboard_list(&self) -> Result<Vec<BlackboardRow>> {
+        let mut stmt = self
+            .conn
+            .prepare_cached(
+                "SELECT key, value, author_nous_id, ttl_seconds, created_at, expires_at
+                 FROM blackboard
+                 WHERE expires_at IS NULL OR expires_at > datetime('now')
+                 ORDER BY key ASC",
+            )
+            .context(error::DatabaseSnafu)?;
+
+        let rows = stmt
+            .query_map([], |row| {
+                Ok(BlackboardRow {
+                    key: row.get(0)?,
+                    value: row.get(1)?,
+                    author_nous_id: row.get(2)?,
+                    ttl_seconds: row.get(3)?,
+                    created_at: row.get(4)?,
+                    expires_at: row.get(5)?,
+                })
+            })
+            .context(error::DatabaseSnafu)?;
+
+        let mut entries = Vec::new();
+        for row in rows {
+            entries.push(row.context(error::DatabaseSnafu)?);
+        }
+        Ok(entries)
+    }
+
+    /// Delete a blackboard entry. Only the original author can delete.
+    pub fn blackboard_delete(&self, key: &str, author: &str) -> Result<bool> {
+        let rows = self
+            .conn
+            .execute(
+                "DELETE FROM blackboard WHERE key = ?1 AND author_nous_id = ?2",
+                rusqlite::params![key, author],
+            )
             .context(error::DatabaseSnafu)?;
         Ok(rows > 0)
     }
@@ -920,5 +1017,90 @@ mod tests {
             .unwrap();
         let history = store.get_history_with_budget("ses-1", 1).unwrap();
         assert_eq!(history.len(), 1);
+    }
+
+    // --- Blackboard ---
+
+    #[test]
+    fn blackboard_crud() {
+        let store = test_store();
+        store
+            .blackboard_write("goal", "finish M0b", "syn", 3600)
+            .unwrap();
+
+        let entry = store.blackboard_read("goal").unwrap().unwrap();
+        assert_eq!(entry.key, "goal");
+        assert_eq!(entry.value, "finish M0b");
+        assert_eq!(entry.author_nous_id, "syn");
+
+        let list = store.blackboard_list().unwrap();
+        assert_eq!(list.len(), 1);
+
+        let deleted = store.blackboard_delete("goal", "syn").unwrap();
+        assert!(deleted);
+
+        let gone = store.blackboard_read("goal").unwrap();
+        assert!(gone.is_none());
+    }
+
+    #[test]
+    fn blackboard_upsert() {
+        let store = test_store();
+        store
+            .blackboard_write("status", "starting", "syn", 3600)
+            .unwrap();
+        store
+            .blackboard_write("status", "running", "syn", 3600)
+            .unwrap();
+
+        let entry = store.blackboard_read("status").unwrap().unwrap();
+        assert_eq!(entry.value, "running");
+
+        let list = store.blackboard_list().unwrap();
+        assert_eq!(list.len(), 1);
+    }
+
+    #[test]
+    fn blackboard_delete_only_author() {
+        let store = test_store();
+        store
+            .blackboard_write("secret", "value", "syn", 3600)
+            .unwrap();
+
+        let deleted = store.blackboard_delete("secret", "other-agent").unwrap();
+        assert!(!deleted);
+
+        let still_there = store.blackboard_read("secret").unwrap();
+        assert!(still_there.is_some());
+    }
+
+    #[test]
+    fn blackboard_read_missing_returns_none() {
+        let store = test_store();
+        let result = store.blackboard_read("nonexistent").unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn blackboard_expiry_filtered() {
+        let store = test_store();
+        store
+            .blackboard_write("temp", "data", "syn", 3600)
+            .unwrap();
+
+        // Manually set expires_at to the past
+        store
+            .conn
+            .execute(
+                "UPDATE blackboard SET expires_at = datetime('now', '-1 second') WHERE key = 'temp'",
+                [],
+            )
+            .unwrap();
+
+        let result = store.blackboard_read("temp").unwrap();
+        assert!(result.is_none());
+
+        let list = store.blackboard_list().unwrap();
+        assert!(list.is_empty());
     }
 }

--- a/crates/mneme/src/types.rs
+++ b/crates/mneme/src/types.rs
@@ -196,6 +196,17 @@ pub struct UsageRecord {
     pub model: Option<String>,
 }
 
+/// Blackboard entry — shared agent state with TTL.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BlackboardRow {
+    pub key: String,
+    pub value: String,
+    pub author_nous_id: String,
+    pub ttl_seconds: i64,
+    pub created_at: String,
+    pub expires_at: Option<String>,
+}
+
 /// Agent note — explicit agent-written context that survives distillation.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AgentNote {

--- a/crates/nous/Cargo.toml
+++ b/crates/nous/Cargo.toml
@@ -22,6 +22,7 @@ aletheia-taxis = { path = "../taxis" }
 aletheia-thesauros = { path = "../thesauros" }
 jiff = { workspace = true }
 prometheus = { workspace = true }
+reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 snafu = { workspace = true }

--- a/crates/nous/src/actor.rs
+++ b/crates/nous/src/actor.rs
@@ -213,6 +213,7 @@ impl NousActor {
             .build()
         })?;
 
+
         let tool_ctx = ToolContext {
             nous_id,
             session_id: SessionId::new(),

--- a/crates/nous/src/adapters.rs
+++ b/crates/nous/src/adapters.rs
@@ -1,0 +1,107 @@
+//! Trait adapters bridging organon tool traits to mneme SessionStore.
+
+use std::sync::{Arc, Mutex};
+
+use aletheia_mneme::store::SessionStore;
+use aletheia_organon::types::{BlackboardEntry, BlackboardStore, NoteEntry, NoteStore};
+
+type BoxError = Box<dyn std::error::Error + Send + Sync>;
+
+/// Adapts `SessionStore` note methods to the `NoteStore` trait.
+pub struct SessionNoteAdapter(pub Arc<Mutex<SessionStore>>);
+
+impl NoteStore for SessionNoteAdapter {
+    fn add_note(
+        &self,
+        session_id: &str,
+        nous_id: &str,
+        category: &str,
+        content: &str,
+    ) -> Result<i64, BoxError> {
+        let store = self.0.lock().expect("session store lock");
+        store
+            .add_note(session_id, nous_id, category, content)
+            .map_err(|e| Box::new(e) as BoxError)
+    }
+
+    fn get_notes(&self, session_id: &str) -> Result<Vec<NoteEntry>, BoxError> {
+        let store = self.0.lock().expect("session store lock");
+        let notes = store
+            .get_notes(session_id)
+            .map_err(|e| Box::new(e) as BoxError)?;
+        Ok(notes
+            .into_iter()
+            .map(|n| NoteEntry {
+                id: n.id,
+                category: n.category,
+                content: n.content,
+                created_at: n.created_at,
+            })
+            .collect())
+    }
+
+    fn delete_note(&self, note_id: i64) -> Result<bool, BoxError> {
+        let store = self.0.lock().expect("session store lock");
+        store
+            .delete_note(note_id)
+            .map_err(|e| Box::new(e) as BoxError)
+    }
+}
+
+/// Adapts `SessionStore` blackboard methods to the `BlackboardStore` trait.
+pub struct SessionBlackboardAdapter(pub Arc<Mutex<SessionStore>>);
+
+impl BlackboardStore for SessionBlackboardAdapter {
+    fn write(
+        &self,
+        key: &str,
+        value: &str,
+        author: &str,
+        ttl_seconds: i64,
+    ) -> Result<(), BoxError> {
+        let store = self.0.lock().expect("session store lock");
+        store
+            .blackboard_write(key, value, author, ttl_seconds)
+            .map_err(|e| Box::new(e) as BoxError)
+    }
+
+    fn read(&self, key: &str) -> Result<Option<BlackboardEntry>, BoxError> {
+        let store = self.0.lock().expect("session store lock");
+        let row = store
+            .blackboard_read(key)
+            .map_err(|e| Box::new(e) as BoxError)?;
+        Ok(row.map(|r| BlackboardEntry {
+            key: r.key,
+            value: r.value,
+            author_nous_id: r.author_nous_id,
+            ttl_seconds: r.ttl_seconds,
+            created_at: r.created_at,
+            expires_at: r.expires_at,
+        }))
+    }
+
+    fn list(&self) -> Result<Vec<BlackboardEntry>, BoxError> {
+        let store = self.0.lock().expect("session store lock");
+        let rows = store
+            .blackboard_list()
+            .map_err(|e| Box::new(e) as BoxError)?;
+        Ok(rows
+            .into_iter()
+            .map(|r| BlackboardEntry {
+                key: r.key,
+                value: r.value,
+                author_nous_id: r.author_nous_id,
+                ttl_seconds: r.ttl_seconds,
+                created_at: r.created_at,
+                expires_at: r.expires_at,
+            })
+            .collect())
+    }
+
+    fn delete(&self, key: &str, author: &str) -> Result<bool, BoxError> {
+        let store = self.0.lock().expect("session store lock");
+        store
+            .blackboard_delete(key, author)
+            .map_err(|e| Box::new(e) as BoxError)
+    }
+}

--- a/crates/nous/src/lib.rs
+++ b/crates/nous/src/lib.rs
@@ -6,6 +6,8 @@
 //!
 //! Depends on all foundation crates: koina, taxis, mneme, hermeneus.
 
+/// Trait adapters bridging organon tool traits to mneme SessionStore.
+pub mod adapters;
 /// Tokio actor driving a single nous instance's message loop.
 pub mod actor;
 /// System prompt assembly from workspace files and domain packs.

--- a/crates/organon/Cargo.toml
+++ b/crates/organon/Cargo.toml
@@ -16,6 +16,7 @@ aletheia-koina = { path = "../koina" }
 base64 = { workspace = true }
 indexmap = { workspace = true }
 prometheus = { workspace = true }
+reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 snafu = { workspace = true }

--- a/crates/organon/src/builtins/communication.rs
+++ b/crates/organon/src/builtins/communication.rs
@@ -441,6 +441,9 @@ mod tests {
         let messenger = Arc::new(MockMessenger::default());
         let ctx = test_ctx_with_services(ToolServices {
             cross_nous: None,
+            note_store: None,
+            blackboard_store: None,
+            http_client: reqwest::Client::new(),
             messenger: Some(messenger),
         });
         let mut reg = ToolRegistry::new();
@@ -461,6 +464,9 @@ mod tests {
         let messenger_ref = Arc::clone(&messenger);
         let ctx = test_ctx_with_services(ToolServices {
             cross_nous: None,
+            note_store: None,
+            blackboard_store: None,
+            http_client: reqwest::Client::new(),
             messenger: Some(messenger),
         });
         let mut reg = ToolRegistry::new();
@@ -488,6 +494,9 @@ mod tests {
         let ctx = test_ctx_with_services(ToolServices {
             cross_nous: Some(cross),
             messenger: None,
+                    note_store: None,
+            blackboard_store: None,
+            http_client: reqwest::Client::new(),
         });
         let mut reg = ToolRegistry::new();
         super::register(&mut reg).expect("register");
@@ -515,6 +524,9 @@ mod tests {
         let ctx = test_ctx_with_services(ToolServices {
             cross_nous: Some(cross),
             messenger: None,
+                    note_store: None,
+            blackboard_store: None,
+            http_client: reqwest::Client::new(),
         });
         let mut reg = ToolRegistry::new();
         super::register(&mut reg).expect("register");
@@ -537,6 +549,9 @@ mod tests {
         let ctx = test_ctx_with_services(ToolServices {
             cross_nous: Some(cross),
             messenger: None,
+                    note_store: None,
+            blackboard_store: None,
+            http_client: reqwest::Client::new(),
         });
         let mut reg = ToolRegistry::new();
         super::register(&mut reg).expect("register");
@@ -557,6 +572,9 @@ mod tests {
         let ctx = test_ctx_with_services(ToolServices {
             cross_nous: Some(cross),
             messenger: None,
+                    note_store: None,
+            blackboard_store: None,
+            http_client: reqwest::Client::new(),
         });
         let mut reg = ToolRegistry::new();
         super::register(&mut reg).expect("register");

--- a/crates/organon/src/builtins/filesystem.rs
+++ b/crates/organon/src/builtins/filesystem.rs
@@ -506,6 +506,7 @@ mod tests {
             session_id: SessionId::new(),
             workspace: dir.to_path_buf(),
             allowed_roots: vec![dir.to_path_buf()],
+            services: None,
         }
     }
 

--- a/crates/organon/src/builtins/memory.rs
+++ b/crates/organon/src/builtins/memory.rs
@@ -1,4 +1,4 @@
-//! Memory tool stubs: `mem0_search`, note, blackboard.
+//! Memory tool executors: `mem0_search`, `note`, `blackboard`.
 
 use std::future::Future;
 use std::pin::Pin;
@@ -13,30 +13,286 @@ use crate::types::{
     ToolResult,
 };
 
-struct Stub;
+use super::workspace::{extract_opt_u64, extract_str};
 
-impl ToolExecutor for Stub {
+fn require_services(ctx: &ToolContext) -> std::result::Result<&crate::types::ToolServices, ToolResult> {
+    ctx.services
+        .as_deref()
+        .ok_or_else(|| ToolResult::error("memory services not configured"))
+}
+
+// --- Mem0 Search ---
+
+struct Mem0SearchExecutor;
+
+impl ToolExecutor for Mem0SearchExecutor {
     fn execute<'a>(
         &'a self,
         input: &'a ToolInput,
-        _ctx: &'a ToolContext,
+        ctx: &'a ToolContext,
     ) -> Pin<Box<dyn Future<Output = Result<ToolResult>> + Send + 'a>> {
         Box::pin(async {
-            Ok(ToolResult::text(format!(
-                "stub: {} not implemented",
-                input.name
-            )))
+            let services = match require_services(ctx) {
+                Ok(s) => s,
+                Err(e) => return Ok(e),
+            };
+
+            let query = extract_str(&input.arguments, "query", &input.name)?;
+            let limit = extract_opt_u64(&input.arguments, "limit").unwrap_or(10);
+
+            let base_url =
+                std::env::var("MEM0_URL").unwrap_or_else(|_| "http://localhost:8230".to_owned());
+
+            let response = services
+                .http_client
+                .post(format!("{base_url}/v1/memories/search/"))
+                .json(&serde_json::json!({
+                    "query": query,
+                    "agent_id": ctx.nous_id.as_str(),
+                    "limit": limit
+                }))
+                .send()
+                .await;
+
+            match response {
+                Ok(resp) if resp.status().is_success() => {
+                    let body: serde_json::Value =
+                        resp.json().await.unwrap_or(serde_json::json!({"results": []}));
+                    let results = body
+                        .get("results")
+                        .and_then(|r| r.as_array())
+                        .cloned()
+                        .unwrap_or_default();
+                    if results.is_empty() {
+                        Ok(ToolResult::text("No memories found."))
+                    } else {
+                        Ok(ToolResult::text(format_mem0_results(&results)))
+                    }
+                }
+                Ok(resp) => Ok(ToolResult::error(format!(
+                    "Mem0 search failed: HTTP {}",
+                    resp.status()
+                ))),
+                Err(e) => Ok(ToolResult::error(format!(
+                    "Mem0 sidecar unreachable: {e}"
+                ))),
+            }
         })
     }
 }
 
-/// Register memory tool stubs.
+fn format_mem0_results(results: &[serde_json::Value]) -> String {
+    results
+        .iter()
+        .map(|r| {
+            let memory = r
+                .get("memory")
+                .and_then(|m| m.as_str())
+                .unwrap_or("(no content)");
+            let score = r
+                .get("score")
+                .and_then(serde_json::Value::as_f64)
+                .unwrap_or(0.0);
+            format!("- {memory} (score: {score:.2})")
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+// --- Note ---
+
+struct NoteExecutor;
+
+impl ToolExecutor for NoteExecutor {
+    fn execute<'a>(
+        &'a self,
+        input: &'a ToolInput,
+        ctx: &'a ToolContext,
+    ) -> Pin<Box<dyn Future<Output = Result<ToolResult>> + Send + 'a>> {
+        Box::pin(async {
+            let services = match require_services(ctx) {
+                Ok(s) => s,
+                Err(e) => return Ok(e),
+            };
+            let Some(note_store) = services.note_store.as_ref() else {
+                return Ok(ToolResult::error("note store not configured"));
+            };
+
+            let action = extract_str(&input.arguments, "action", &input.name)?;
+
+            match action {
+                "add" => {
+                    let content = extract_str(&input.arguments, "content", &input.name)?;
+                    let category = input
+                        .arguments
+                        .get("category")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("context");
+
+                    if content.len() > 500 {
+                        return Ok(ToolResult::error(
+                            "Note content exceeds 500 character limit",
+                        ));
+                    }
+
+                    match note_store.add_note(
+                        &ctx.session_id.to_string(),
+                        ctx.nous_id.as_str(),
+                        category,
+                        content,
+                    ) {
+                        Ok(id) => Ok(ToolResult::text(format!(
+                            "Note #{id} saved ({category}): \"{content}\""
+                        ))),
+                        Err(e) => Ok(ToolResult::error(format!("Failed to save note: {e}"))),
+                    }
+                }
+                "list" => {
+                    match note_store.get_notes(&ctx.session_id.to_string()) {
+                        Ok(notes) if notes.is_empty() => {
+                            Ok(ToolResult::text("No session notes."))
+                        }
+                        Ok(notes) => {
+                            let lines: Vec<String> = notes
+                                .iter()
+                                .map(|n| format!("#{} [{}] {}", n.id, n.category, n.content))
+                                .collect();
+                            Ok(ToolResult::text(lines.join("\n")))
+                        }
+                        Err(e) => Ok(ToolResult::error(format!("Failed to list notes: {e}"))),
+                    }
+                }
+                "delete" => {
+                    let id = input
+                        .arguments
+                        .get("id")
+                        .and_then(serde_json::Value::as_i64)
+                        .ok_or_else(|| {
+                            crate::error::InvalidInputSnafu {
+                                name: input.name.clone(),
+                                reason: "missing or invalid field: id".to_owned(),
+                            }
+                            .build()
+                        })?;
+                    match note_store.delete_note(id) {
+                        Ok(_) => Ok(ToolResult::text(format!("Note #{id} deleted."))),
+                        Err(e) => Ok(ToolResult::error(format!("Failed to delete note: {e}"))),
+                    }
+                }
+                _ => Ok(ToolResult::error(format!("Unknown action: {action}"))),
+            }
+        })
+    }
+}
+
+// --- Blackboard ---
+
+struct BlackboardExecutor;
+
+impl ToolExecutor for BlackboardExecutor {
+    fn execute<'a>(
+        &'a self,
+        input: &'a ToolInput,
+        ctx: &'a ToolContext,
+    ) -> Pin<Box<dyn Future<Output = Result<ToolResult>> + Send + 'a>> {
+        Box::pin(async {
+            let services = match require_services(ctx) {
+                Ok(s) => s,
+                Err(e) => return Ok(e),
+            };
+            let Some(bb_store) = services.blackboard_store.as_ref() else {
+                return Ok(ToolResult::error("blackboard store not configured"));
+            };
+
+            let action = extract_str(&input.arguments, "action", &input.name)?;
+
+            match action {
+                "write" => {
+                    let key = extract_str(&input.arguments, "key", &input.name)?;
+                    let value = extract_str(&input.arguments, "value", &input.name)?;
+                    let ttl = extract_opt_u64(&input.arguments, "ttl_seconds").unwrap_or(3600);
+
+                    #[expect(
+                        clippy::cast_possible_wrap,
+                        reason = "TTL from u64 will not exceed i64::MAX in practice"
+                    )]
+                    match bb_store.write(key, value, ctx.nous_id.as_str(), ttl as i64) {
+                        Ok(()) => Ok(ToolResult::text(format!(
+                            "Blackboard [{key}] written (TTL: {ttl}s)"
+                        ))),
+                        Err(e) => Ok(ToolResult::error(format!(
+                            "Failed to write blackboard: {e}"
+                        ))),
+                    }
+                }
+                "read" => {
+                    let key = extract_str(&input.arguments, "key", &input.name)?;
+                    match bb_store.read(key) {
+                        Ok(Some(entry)) => Ok(ToolResult::text(format!(
+                            "[{key}] = {} (by {}, expires: {})",
+                            entry.value,
+                            entry.author_nous_id,
+                            entry.expires_at.as_deref().unwrap_or("never")
+                        ))),
+                        Ok(None) => Ok(ToolResult::text(format!(
+                            "No entry for key: {key}"
+                        ))),
+                        Err(e) => Ok(ToolResult::error(format!(
+                            "Failed to read blackboard: {e}"
+                        ))),
+                    }
+                }
+                "list" => match bb_store.list() {
+                    Ok(entries) if entries.is_empty() => {
+                        Ok(ToolResult::text("Blackboard is empty."))
+                    }
+                    Ok(entries) => {
+                        let lines: Vec<String> = entries
+                            .iter()
+                            .map(|e| {
+                                format!(
+                                    "[{}] = {} (by {})",
+                                    e.key, e.value, e.author_nous_id
+                                )
+                            })
+                            .collect();
+                        Ok(ToolResult::text(lines.join("\n")))
+                    }
+                    Err(e) => Ok(ToolResult::error(format!(
+                        "Failed to list blackboard: {e}"
+                    ))),
+                },
+                "delete" => {
+                    let key = extract_str(&input.arguments, "key", &input.name)?;
+                    match bb_store.delete(key, ctx.nous_id.as_str()) {
+                        Ok(true) => Ok(ToolResult::text(format!(
+                            "Blackboard [{key}] deleted."
+                        ))),
+                        Ok(false) => Ok(ToolResult::text(format!(
+                            "No entry for key: {key} (or not your entry)"
+                        ))),
+                        Err(e) => Ok(ToolResult::error(format!(
+                            "Failed to delete blackboard entry: {e}"
+                        ))),
+                    }
+                }
+                _ => Ok(ToolResult::error(format!("Unknown action: {action}"))),
+            }
+        })
+    }
+}
+
+// --- Registration ---
+
+/// Register memory tool executors.
 pub fn register(registry: &mut ToolRegistry) -> Result<()> {
-    registry.register(mem0_search_def(), Box::new(Stub))?;
-    registry.register(note_def(), Box::new(Stub))?;
-    registry.register(blackboard_def(), Box::new(Stub))?;
+    registry.register(mem0_search_def(), Box::new(Mem0SearchExecutor))?;
+    registry.register(note_def(), Box::new(NoteExecutor))?;
+    registry.register(blackboard_def(), Box::new(BlackboardExecutor))?;
     Ok(())
 }
+
+// --- Tool Definitions (unchanged schemas) ---
 
 fn mem0_search_def() -> ToolDef {
     ToolDef {
@@ -179,11 +435,120 @@ fn blackboard_def() -> ToolDef {
 #[cfg(test)]
 mod tests {
     use std::path::PathBuf;
+    use std::sync::{Arc, Mutex};
 
     use aletheia_koina::id::{NousId, SessionId, ToolName};
 
     use crate::registry::ToolRegistry;
-    use crate::types::{ToolContext, ToolInput};
+    use crate::types::{
+        BlackboardEntry, BlackboardStore, NoteEntry, NoteStore, ToolContext, ToolInput,
+        ToolServices,
+    };
+
+    type BoxError = Box<dyn std::error::Error + Send + Sync>;
+
+    // --- In-memory mock stores ---
+
+    struct MockNoteStore {
+        notes: Mutex<Vec<NoteEntry>>,
+        next_id: Mutex<i64>,
+    }
+
+    impl MockNoteStore {
+        fn new() -> Self {
+            Self {
+                notes: Mutex::new(Vec::new()),
+                next_id: Mutex::new(1),
+            }
+        }
+    }
+
+    impl NoteStore for MockNoteStore {
+        fn add_note(
+            &self,
+            _session_id: &str,
+            _nous_id: &str,
+            category: &str,
+            content: &str,
+        ) -> Result<i64, BoxError> {
+            let mut id = self.next_id.lock().unwrap();
+            let note_id = *id;
+            *id += 1;
+            self.notes.lock().unwrap().push(NoteEntry {
+                id: note_id,
+                category: category.to_owned(),
+                content: content.to_owned(),
+                created_at: "2026-01-01T00:00:00Z".to_owned(),
+            });
+            Ok(note_id)
+        }
+
+        fn get_notes(&self, _session_id: &str) -> Result<Vec<NoteEntry>, BoxError> {
+            Ok(self.notes.lock().unwrap().clone())
+        }
+
+        fn delete_note(&self, note_id: i64) -> Result<bool, BoxError> {
+            let mut notes = self.notes.lock().unwrap();
+            let len_before = notes.len();
+            notes.retain(|n| n.id != note_id);
+            Ok(notes.len() < len_before)
+        }
+    }
+
+    struct MockBlackboardStore {
+        entries: Mutex<Vec<BlackboardEntry>>,
+    }
+
+    impl MockBlackboardStore {
+        fn new() -> Self {
+            Self {
+                entries: Mutex::new(Vec::new()),
+            }
+        }
+    }
+
+    impl BlackboardStore for MockBlackboardStore {
+        fn write(
+            &self,
+            key: &str,
+            value: &str,
+            author: &str,
+            ttl_seconds: i64,
+        ) -> Result<(), BoxError> {
+            let mut entries = self.entries.lock().unwrap();
+            entries.retain(|e| e.key != key);
+            entries.push(BlackboardEntry {
+                key: key.to_owned(),
+                value: value.to_owned(),
+                author_nous_id: author.to_owned(),
+                ttl_seconds,
+                created_at: "2026-01-01T00:00:00Z".to_owned(),
+                expires_at: None,
+            });
+            Ok(())
+        }
+
+        fn read(&self, key: &str) -> Result<Option<BlackboardEntry>, BoxError> {
+            Ok(self
+                .entries
+                .lock()
+                .unwrap()
+                .iter()
+                .find(|e| e.key == key)
+                .cloned())
+        }
+
+        fn list(&self) -> Result<Vec<BlackboardEntry>, BoxError> {
+            Ok(self.entries.lock().unwrap().clone())
+        }
+
+        fn delete(&self, key: &str, author: &str) -> Result<bool, BoxError> {
+            let mut entries = self.entries.lock().unwrap();
+            let len_before = entries.len();
+            entries.retain(|e| !(e.key == key && e.author_nous_id == author));
+            Ok(entries.len() < len_before)
+        }
+    }
 
     fn test_ctx() -> ToolContext {
         ToolContext {
@@ -195,55 +560,30 @@ mod tests {
         }
     }
 
+    fn ctx_with_services(
+        note_store: Arc<dyn NoteStore>,
+        bb_store: Arc<dyn BlackboardStore>,
+    ) -> ToolContext {
+        ToolContext {
+            nous_id: NousId::new("test-agent").expect("valid"),
+            session_id: SessionId::new(),
+            workspace: PathBuf::from("/tmp/test"),
+            allowed_roots: vec![PathBuf::from("/tmp")],
+            services: Some(Arc::new(ToolServices {
+                cross_nous: None,
+                messenger: None,
+                note_store: Some(note_store),
+                blackboard_store: Some(bb_store),
+                http_client: reqwest::Client::new(),
+            })),
+        }
+    }
+
     #[tokio::test]
     async fn register_memory_tools() {
         let mut reg = ToolRegistry::new();
         super::register(&mut reg).expect("register");
         assert_eq!(reg.definitions().len(), 3);
-    }
-
-    #[tokio::test]
-    async fn mem0_search_stub_responds() {
-        let mut reg = ToolRegistry::new();
-        super::register(&mut reg).expect("register");
-        let input = ToolInput {
-            name: ToolName::new("mem0_search").expect("valid"),
-            tool_use_id: "tu_1".to_owned(),
-            arguments: serde_json::json!({"query": "test"}),
-        };
-        let result = reg.execute(&input, &test_ctx()).await.expect("execute");
-        assert!(!result.is_error);
-        assert!(
-            result.content.text_summary().contains("stub"),
-            "expected stub response: {}",
-            result.content.text_summary()
-        );
-    }
-
-    #[tokio::test]
-    async fn note_stub_responds() {
-        let mut reg = ToolRegistry::new();
-        super::register(&mut reg).expect("register");
-        let input = ToolInput {
-            name: ToolName::new("note").expect("valid"),
-            tool_use_id: "tu_2".to_owned(),
-            arguments: serde_json::json!({"action": "add", "content": "test"}),
-        };
-        let result = reg.execute(&input, &test_ctx()).await.expect("execute");
-        assert!(!result.is_error);
-    }
-
-    #[tokio::test]
-    async fn blackboard_stub_responds() {
-        let mut reg = ToolRegistry::new();
-        super::register(&mut reg).expect("register");
-        let input = ToolInput {
-            name: ToolName::new("blackboard").expect("valid"),
-            tool_use_id: "tu_3".to_owned(),
-            arguments: serde_json::json!({"action": "read", "key": "test"}),
-        };
-        let result = reg.execute(&input, &test_ctx()).await.expect("execute");
-        assert!(!result.is_error);
     }
 
     #[tokio::test]
@@ -253,5 +593,232 @@ mod tests {
         let name = ToolName::new("mem0_search").expect("valid");
         let def = reg.get_def(&name).expect("found");
         assert!(def.input_schema.required.contains(&"query".to_owned()));
+    }
+
+    #[tokio::test]
+    async fn mem0_search_handles_sidecar_down() {
+        let mut reg = ToolRegistry::new();
+        super::register(&mut reg).expect("register");
+        let note_store = Arc::new(MockNoteStore::new());
+        let bb_store = Arc::new(MockBlackboardStore::new());
+        let ctx = ctx_with_services(note_store, bb_store);
+
+        let input = ToolInput {
+            name: ToolName::new("mem0_search").expect("valid"),
+            tool_use_id: "tu_1".to_owned(),
+            arguments: serde_json::json!({"query": "test"}),
+        };
+        let result = reg.execute(&input, &ctx).await.expect("execute");
+        assert!(result.is_error);
+        assert!(
+            result.content.text_summary().contains("unreachable"),
+            "expected unreachable error: {}",
+            result.content.text_summary()
+        );
+    }
+
+    #[tokio::test]
+    async fn mem0_search_no_services_returns_error() {
+        let mut reg = ToolRegistry::new();
+        super::register(&mut reg).expect("register");
+        let input = ToolInput {
+            name: ToolName::new("mem0_search").expect("valid"),
+            tool_use_id: "tu_1".to_owned(),
+            arguments: serde_json::json!({"query": "test"}),
+        };
+        let result = reg.execute(&input, &test_ctx()).await.expect("execute");
+        assert!(result.is_error);
+        assert!(result.content.text_summary().contains("not configured"));
+    }
+
+    // --- Note tests ---
+
+    #[tokio::test]
+    async fn note_add_and_list() {
+        let mut reg = ToolRegistry::new();
+        super::register(&mut reg).expect("register");
+        let note_store = Arc::new(MockNoteStore::new());
+        let bb_store = Arc::new(MockBlackboardStore::new());
+        let ctx = ctx_with_services(Arc::clone(&note_store) as Arc<dyn NoteStore>, bb_store);
+
+        let add1 = ToolInput {
+            name: ToolName::new("note").expect("valid"),
+            tool_use_id: "tu_1".to_owned(),
+            arguments: serde_json::json!({"action": "add", "content": "first note", "category": "task"}),
+        };
+        let r1 = reg.execute(&add1, &ctx).await.expect("execute");
+        assert!(!r1.is_error);
+        assert!(r1.content.text_summary().contains("#1"));
+
+        let add2 = ToolInput {
+            name: ToolName::new("note").expect("valid"),
+            tool_use_id: "tu_2".to_owned(),
+            arguments: serde_json::json!({"action": "add", "content": "second note"}),
+        };
+        let r2 = reg.execute(&add2, &ctx).await.expect("execute");
+        assert!(!r2.is_error);
+        assert!(r2.content.text_summary().contains("#2"));
+
+        let list = ToolInput {
+            name: ToolName::new("note").expect("valid"),
+            tool_use_id: "tu_3".to_owned(),
+            arguments: serde_json::json!({"action": "list"}),
+        };
+        let r3 = reg.execute(&list, &ctx).await.expect("execute");
+        assert!(!r3.is_error);
+        let text = r3.content.text_summary();
+        assert!(text.contains("first note"));
+        assert!(text.contains("second note"));
+    }
+
+    #[tokio::test]
+    async fn note_delete() {
+        let mut reg = ToolRegistry::new();
+        super::register(&mut reg).expect("register");
+        let note_store = Arc::new(MockNoteStore::new());
+        let bb_store = Arc::new(MockBlackboardStore::new());
+        let ctx = ctx_with_services(Arc::clone(&note_store) as Arc<dyn NoteStore>, bb_store);
+
+        let add = ToolInput {
+            name: ToolName::new("note").expect("valid"),
+            tool_use_id: "tu_1".to_owned(),
+            arguments: serde_json::json!({"action": "add", "content": "to delete"}),
+        };
+        reg.execute(&add, &ctx).await.expect("execute");
+
+        let del = ToolInput {
+            name: ToolName::new("note").expect("valid"),
+            tool_use_id: "tu_2".to_owned(),
+            arguments: serde_json::json!({"action": "delete", "id": 1}),
+        };
+        let r = reg.execute(&del, &ctx).await.expect("execute");
+        assert!(!r.is_error);
+        assert!(r.content.text_summary().contains("deleted"));
+
+        let list = ToolInput {
+            name: ToolName::new("note").expect("valid"),
+            tool_use_id: "tu_3".to_owned(),
+            arguments: serde_json::json!({"action": "list"}),
+        };
+        let r3 = reg.execute(&list, &ctx).await.expect("execute");
+        assert!(r3.content.text_summary().contains("No session notes"));
+    }
+
+    #[tokio::test]
+    async fn note_rejects_over_500_chars() {
+        let mut reg = ToolRegistry::new();
+        super::register(&mut reg).expect("register");
+        let note_store = Arc::new(MockNoteStore::new());
+        let bb_store = Arc::new(MockBlackboardStore::new());
+        let ctx = ctx_with_services(note_store, bb_store);
+
+        let long_content = "x".repeat(501);
+        let input = ToolInput {
+            name: ToolName::new("note").expect("valid"),
+            tool_use_id: "tu_1".to_owned(),
+            arguments: serde_json::json!({"action": "add", "content": long_content}),
+        };
+        let result = reg.execute(&input, &ctx).await.expect("execute");
+        assert!(result.is_error);
+        assert!(result.content.text_summary().contains("500"));
+    }
+
+    // --- Blackboard tests ---
+
+    #[tokio::test]
+    async fn blackboard_write_and_read() {
+        let mut reg = ToolRegistry::new();
+        super::register(&mut reg).expect("register");
+        let note_store = Arc::new(MockNoteStore::new());
+        let bb_store = Arc::new(MockBlackboardStore::new());
+        let ctx = ctx_with_services(note_store, Arc::clone(&bb_store) as Arc<dyn BlackboardStore>);
+
+        let write = ToolInput {
+            name: ToolName::new("blackboard").expect("valid"),
+            tool_use_id: "tu_1".to_owned(),
+            arguments: serde_json::json!({"action": "write", "key": "goal", "value": "ship M0b"}),
+        };
+        let r1 = reg.execute(&write, &ctx).await.expect("execute");
+        assert!(!r1.is_error);
+        assert!(r1.content.text_summary().contains("[goal] written"));
+
+        let read = ToolInput {
+            name: ToolName::new("blackboard").expect("valid"),
+            tool_use_id: "tu_2".to_owned(),
+            arguments: serde_json::json!({"action": "read", "key": "goal"}),
+        };
+        let r2 = reg.execute(&read, &ctx).await.expect("execute");
+        assert!(!r2.is_error);
+        assert!(r2.content.text_summary().contains("ship M0b"));
+    }
+
+    #[tokio::test]
+    async fn blackboard_list() {
+        let mut reg = ToolRegistry::new();
+        super::register(&mut reg).expect("register");
+        let note_store = Arc::new(MockNoteStore::new());
+        let bb_store = Arc::new(MockBlackboardStore::new());
+        let ctx = ctx_with_services(note_store, Arc::clone(&bb_store) as Arc<dyn BlackboardStore>);
+
+        for (k, v) in [("a", "1"), ("b", "2")] {
+            let write = ToolInput {
+                name: ToolName::new("blackboard").expect("valid"),
+                tool_use_id: "tu_w".to_owned(),
+                arguments: serde_json::json!({"action": "write", "key": k, "value": v}),
+            };
+            reg.execute(&write, &ctx).await.expect("execute");
+        }
+
+        let list = ToolInput {
+            name: ToolName::new("blackboard").expect("valid"),
+            tool_use_id: "tu_l".to_owned(),
+            arguments: serde_json::json!({"action": "list"}),
+        };
+        let r = reg.execute(&list, &ctx).await.expect("execute");
+        assert!(!r.is_error);
+        let text = r.content.text_summary();
+        assert!(text.contains("[a] = 1"));
+        assert!(text.contains("[b] = 2"));
+    }
+
+    #[tokio::test]
+    async fn blackboard_delete_only_author() {
+        let mut reg = ToolRegistry::new();
+        super::register(&mut reg).expect("register");
+        let note_store = Arc::new(MockNoteStore::new());
+        let bb_store = Arc::new(MockBlackboardStore::new());
+        let ctx = ctx_with_services(note_store, Arc::clone(&bb_store) as Arc<dyn BlackboardStore>);
+
+        let write = ToolInput {
+            name: ToolName::new("blackboard").expect("valid"),
+            tool_use_id: "tu_1".to_owned(),
+            arguments: serde_json::json!({"action": "write", "key": "secret", "value": "data"}),
+        };
+        reg.execute(&write, &ctx).await.expect("execute");
+
+        // Try delete with different author
+        let other_ctx = ToolContext {
+            nous_id: NousId::new("other-agent").expect("valid"),
+            session_id: SessionId::new(),
+            workspace: PathBuf::from("/tmp/test"),
+            allowed_roots: vec![PathBuf::from("/tmp")],
+            services: ctx.services.clone(),
+        };
+        let del = ToolInput {
+            name: ToolName::new("blackboard").expect("valid"),
+            tool_use_id: "tu_2".to_owned(),
+            arguments: serde_json::json!({"action": "delete", "key": "secret"}),
+        };
+        let r = reg.execute(&del, &other_ctx).await.expect("execute");
+        assert!(r.content.text_summary().contains("not your entry"));
+
+        // Original author can delete
+        let del2 = ToolInput {
+            name: ToolName::new("blackboard").expect("valid"),
+            tool_use_id: "tu_3".to_owned(),
+            arguments: serde_json::json!({"action": "delete", "key": "secret"}),
+        };
+        let r2 = reg.execute(&del2, &ctx).await.expect("execute");
+        assert!(r2.content.text_summary().contains("deleted"));
     }
 }

--- a/crates/organon/src/types.rs
+++ b/crates/organon/src/types.rs
@@ -284,6 +284,9 @@ pub trait MessageService: Send + Sync {
 pub struct ToolServices {
     pub cross_nous: Option<Arc<dyn CrossNousService>>,
     pub messenger: Option<Arc<dyn MessageService>>,
+    pub note_store: Option<Arc<dyn NoteStore>>,
+    pub blackboard_store: Option<Arc<dyn BlackboardStore>>,
+    pub http_client: reqwest::Client,
 }
 
 impl std::fmt::Debug for ToolServices {
@@ -291,7 +294,9 @@ impl std::fmt::Debug for ToolServices {
         f.debug_struct("ToolServices")
             .field("cross_nous", &self.cross_nous.is_some())
             .field("messenger", &self.messenger.is_some())
-            .finish()
+            .field("note_store", &self.note_store.is_some())
+            .field("blackboard_store", &self.blackboard_store.is_some())
+            .finish_non_exhaustive()
     }
 }
 
@@ -306,8 +311,73 @@ pub struct ToolContext {
     pub workspace: PathBuf,
     /// Allowed filesystem roots for sandboxing.
     pub allowed_roots: Vec<PathBuf>,
-    /// Optional runtime services for tools that need cross-cutting capabilities.
+/// Optional runtime services for tools that need cross-cutting capabilities.
     pub services: Option<Arc<ToolServices>>,
+}
+
+/// Persistent session notes storage.
+pub trait NoteStore: Send + Sync {
+    fn add_note(
+        &self,
+        session_id: &str,
+        nous_id: &str,
+        category: &str,
+        content: &str,
+    ) -> std::result::Result<i64, Box<dyn std::error::Error + Send + Sync>>;
+
+    fn get_notes(
+        &self,
+        session_id: &str,
+    ) -> std::result::Result<Vec<NoteEntry>, Box<dyn std::error::Error + Send + Sync>>;
+
+    fn delete_note(
+        &self,
+        note_id: i64,
+    ) -> std::result::Result<bool, Box<dyn std::error::Error + Send + Sync>>;
+}
+
+/// Shared blackboard state with TTL.
+pub trait BlackboardStore: Send + Sync {
+    fn write(
+        &self,
+        key: &str,
+        value: &str,
+        author: &str,
+        ttl_seconds: i64,
+    ) -> std::result::Result<(), Box<dyn std::error::Error + Send + Sync>>;
+
+    fn read(
+        &self,
+        key: &str,
+    ) -> std::result::Result<Option<BlackboardEntry>, Box<dyn std::error::Error + Send + Sync>>;
+
+    fn list(
+        &self,
+    ) -> std::result::Result<Vec<BlackboardEntry>, Box<dyn std::error::Error + Send + Sync>>;
+
+    fn delete(
+        &self,
+        key: &str,
+        author: &str,
+    ) -> std::result::Result<bool, Box<dyn std::error::Error + Send + Sync>>;
+}
+
+#[derive(Debug, Clone)]
+pub struct NoteEntry {
+    pub id: i64,
+    pub category: String,
+    pub content: String,
+    pub created_at: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct BlackboardEntry {
+    pub key: String,
+    pub value: String,
+    pub author_nous_id: String,
+    pub ttl_seconds: i64,
+    pub created_at: String,
+    pub expires_at: Option<String>,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

- Replace stub executors for `mem0_search`, `note`, and `blackboard` with real implementations
- Add `ToolServices` trait system in organon so tools can access storage and HTTP without direct mneme dependency
- Add blackboard table (v2 migration) with CRUD, TTL, and author-scoped deletes to mneme
- Add trait adapters in nous bridging organon traits to `SessionStore`
- Wire `ToolServices` into `NousActor` for live agent sessions

## What each tool does

| Tool | Function |
|------|----------|
| `mem0_search` | Searches long-term memory via Mem0 sidecar HTTP API |
| `note` | Persistent session notes (add/list/delete) surviving distillation |
| `blackboard` | Shared agent state with TTL (write/read/list/delete) |

## Test plan

- [x] `cargo test -p aletheia-organon` (46 tests: executors, mock stores, error paths)
- [x] `cargo test -p aletheia-mneme` (146 tests: blackboard CRUD, upsert, expiry, migration)
- [x] `cargo test -p aletheia-nous` (186 tests: adapter compilation, existing pipeline tests)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` (zero errors)