### PR TITLE
feat(pylon): webchat compatibility endpoints for Svelte UI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2543,6 +2543,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-range-header"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9171a2ea8a68358193d15dd5d70c1c10a2afc3e7e4c5bc92bc9f025cebd7359c"
+
+[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3395,6 +3401,16 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
 
 [[package]]
 name = "minimal-lexical"
@@ -6113,7 +6129,12 @@ dependencies = [
  "http",
  "http-body",
  "http-body-util",
+ "http-range-header",
+ "httpdate",
  "iri-string",
+ "mime",
+ "mime_guess",
+ "percent-encoding",
  "pin-project-lite",
  "tokio",
  "tokio-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,7 +80,7 @@ axum = "0.8"
 utoipa = { version = "5", features = ["axum_extras"] }
 reqwest = { version = "0.12", features = ["blocking", "json"] }
 tower = "0.5"
-tower-http = { version = "0.6", features = ["cors", "compression-gzip", "trace", "limit", "set-header"] }
+tower-http = { version = "0.6", features = ["cors", "compression-gzip", "trace", "limit", "set-header", "fs"] }
 axum-server = { version = "0.7", features = ["tls-rustls"] }
 
 # Secrets

--- a/crates/pylon/src/extract.rs
+++ b/crates/pylon/src/extract.rs
@@ -10,6 +10,23 @@ use aletheia_symbolon::types::Role;
 use crate::error::ApiError;
 use crate::state::AppState;
 
+/// Optional auth claims — passes through when auth is missing or invalid.
+///
+/// Use on webchat compatibility endpoints that should work with or without JWT.
+#[derive(Debug, Clone)]
+pub struct OptionalClaims(pub Option<Claims>);
+
+impl FromRequestParts<Arc<AppState>> for OptionalClaims {
+    type Rejection = std::convert::Infallible;
+
+    async fn from_request_parts(
+        parts: &mut Parts,
+        state: &Arc<AppState>,
+    ) -> Result<Self, Self::Rejection> {
+        Ok(Self(Claims::from_request_parts(parts, state).await.ok()))
+    }
+}
+
 /// Authenticated user claims extracted from a JWT Bearer token.
 #[derive(Debug, Clone)]
 pub struct Claims {

--- a/crates/pylon/src/handlers/mod.rs
+++ b/crates/pylon/src/handlers/mod.rs
@@ -10,3 +10,5 @@ pub mod metrics;
 pub mod nous;
 /// Session lifecycle, history retrieval, and SSE message streaming.
 pub mod sessions;
+/// Webchat compatibility layer for the Svelte web UI.
+pub mod webchat;

--- a/crates/pylon/src/handlers/webchat.rs
+++ b/crates/pylon/src/handlers/webchat.rs
@@ -1,0 +1,466 @@
+//! Webchat compatibility endpoints for the Svelte web UI.
+
+use std::convert::Infallible;
+use std::sync::Arc;
+use std::time::Duration;
+
+use axum::Json;
+use axum::extract::{Path, Query, State};
+use axum::response::sse::{Event, KeepAlive, Sse};
+use serde::{Deserialize, Serialize};
+use tokio::sync::mpsc;
+use tokio_stream::StreamExt;
+use tokio_stream::wrappers::ReceiverStream;
+use tracing::{instrument, warn};
+
+use crate::error::{ApiError, BadRequestSnafu, NousNotFoundSnafu};
+use crate::extract::OptionalClaims;
+use crate::state::AppState;
+use crate::stream::{WebchatEvent, emit_webchat_events};
+
+// --- POST /api/sessions/stream ---
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StreamRequest {
+    pub agent_id: String,
+    pub message: String,
+    #[serde(default = "default_session_key")]
+    pub session_key: String,
+}
+
+fn default_session_key() -> String {
+    "main".to_owned()
+}
+
+async fn resolve_session(
+    state: &Arc<AppState>,
+    agent_id: &str,
+    session_key: &str,
+    model: Option<&str>,
+) -> Result<String, ApiError> {
+    let id = ulid::Ulid::new().to_string();
+    let state_clone = Arc::clone(state);
+    let id_clone = id.clone();
+    let aid = agent_id.to_owned();
+    let skey = session_key.to_owned();
+    let model_owned = model.map(ToOwned::to_owned);
+
+    let session = tokio::task::spawn_blocking(move || {
+        let store = state_clone.session_store.lock().expect("store lock");
+        store.find_or_create_session(&id_clone, &aid, &skey, model_owned.as_deref(), None)
+    })
+    .await??;
+
+    Ok(session.id)
+}
+
+async fn store_message(
+    state: &Arc<AppState>,
+    session_id: &str,
+    role: aletheia_mneme::types::Role,
+    content: &str,
+    token_estimate: i64,
+) -> Result<i64, ApiError> {
+    let state_clone = Arc::clone(state);
+    let sid = session_id.to_owned();
+    let content = content.to_owned();
+    tokio::task::spawn_blocking(move || {
+        let store = state_clone.session_store.lock().expect("store lock");
+        store.append_message(&sid, role, &content, None, None, token_estimate)
+    })
+    .await?
+    .map_err(ApiError::from)
+}
+
+#[instrument(skip(state, _claims, body), fields(agent_id = %body.agent_id))]
+pub async fn stream(
+    State(state): State<Arc<AppState>>,
+    _claims: OptionalClaims,
+    Json(body): Json<StreamRequest>,
+) -> Result<Sse<impl tokio_stream::Stream<Item = Result<Event, Infallible>>>, ApiError> {
+    let agent_id = body.agent_id;
+    let message = body.message;
+    let session_key = body.session_key;
+
+    if message.is_empty() {
+        return Err(BadRequestSnafu {
+            message: "message must not be empty",
+        }
+        .build());
+    }
+
+    let handle = state
+        .nous_manager
+        .get(&agent_id)
+        .ok_or_else(|| NousNotFoundSnafu { id: agent_id.clone() }.build())?
+        .clone();
+
+    let model = state
+        .nous_manager
+        .get_config(&agent_id)
+        .map(|c| c.model.clone());
+
+    let session_id = resolve_session(
+        &state,
+        &agent_id,
+        &session_key,
+        model.as_deref(),
+    )
+    .await?;
+
+    store_message(&state, &session_id, aletheia_mneme::types::Role::User, &message, 0).await?;
+
+    let turn_id = ulid::Ulid::new().to_string();
+    let (tx, rx) = mpsc::channel::<WebchatEvent>(32);
+
+    let _ = tx
+        .send(WebchatEvent::TurnStart {
+            session_id: session_id.clone(),
+            nous_id: agent_id.clone(),
+            turn_id,
+        })
+        .await;
+
+    let sid = session_id;
+    let aid = agent_id;
+
+    tokio::spawn(async move {
+        match handle.send_turn(&session_key, &message).await {
+            Ok(result) => {
+                emit_webchat_events(&tx, &result, &sid, &aid, model.as_deref()).await;
+                let token_estimate = i64::try_from(result.usage.output_tokens).unwrap_or(0);
+                let _ = store_message(&state, &sid, aletheia_mneme::types::Role::Assistant, &result.content, token_estimate).await;
+            }
+            Err(err) => {
+                warn!(error = %err, "turn failed");
+                let _ = tx
+                    .send(WebchatEvent::Error {
+                        message: err.to_string(),
+                    })
+                    .await;
+            }
+        }
+    });
+
+    let stream = ReceiverStream::new(rx).map(|event| {
+        let data = serde_json::to_string(&event).unwrap_or_default();
+        Ok(Event::default().event(event.event_type()).data(data))
+    });
+
+    Ok(Sse::new(stream).keep_alive(
+        KeepAlive::new()
+            .interval(Duration::from_secs(30))
+            .text("heartbeat"),
+    ))
+}
+
+// --- GET /api/agents ---
+
+#[derive(Debug, Serialize)]
+pub struct AgentsListResponse {
+    pub agents: Vec<AgentInfo>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct AgentInfo {
+    pub id: String,
+    pub name: String,
+    pub workspace: String,
+    pub model: String,
+}
+
+pub async fn agents_list(
+    State(state): State<Arc<AppState>>,
+    _claims: OptionalClaims,
+) -> Json<AgentsListResponse> {
+    let config = state.config.read().await;
+    let defaults = &config.agents.defaults;
+
+    let agents = config
+        .agents
+        .list
+        .iter()
+        .map(|a| {
+            let model = a
+                .model
+                .as_ref()
+                .map_or_else(|| defaults.model.primary.clone(), |m| m.primary.clone());
+            AgentInfo {
+                id: a.id.clone(),
+                name: a.name.clone().unwrap_or_else(|| a.id.clone()),
+                workspace: a.workspace.clone(),
+                model,
+            }
+        })
+        .collect();
+
+    Json(AgentsListResponse { agents })
+}
+
+// --- GET /api/agents/{id}/identity ---
+
+#[derive(Debug, Serialize)]
+pub struct AgentIdentityResponse {
+    pub id: String,
+    pub name: String,
+    pub emoji: Option<String>,
+}
+
+#[instrument(skip(state, _claims))]
+pub async fn agent_identity(
+    State(state): State<Arc<AppState>>,
+    _claims: OptionalClaims,
+    Path(id): Path<String>,
+) -> Result<Json<AgentIdentityResponse>, ApiError> {
+    let config = state.config.read().await;
+    let agent = config
+        .agents
+        .list
+        .iter()
+        .find(|a| a.id == id)
+        .ok_or_else(|| NousNotFoundSnafu { id: id.clone() }.build())?;
+
+    let fallback_name = agent.name.clone().unwrap_or_else(|| id.clone());
+    let workspace = std::path::Path::new(&agent.workspace);
+    let identity_path = workspace.join("IDENTITY.md");
+
+    let (name, emoji) = match tokio::fs::read_to_string(&identity_path).await {
+        Ok(content) => parse_identity(&content, &fallback_name),
+        Err(_) => (fallback_name, None),
+    };
+
+    Ok(Json(AgentIdentityResponse { id, name, emoji }))
+}
+
+fn parse_identity(content: &str, fallback_name: &str) -> (String, Option<String>) {
+    let mut name = fallback_name.to_owned();
+    let mut emoji = None;
+
+    for line in content.lines() {
+        let line = line.trim();
+        if let Some(val) = line.strip_prefix("name:") {
+            let val = val.trim();
+            if !val.is_empty() {
+                val.clone_into(&mut name);
+            }
+        } else if let Some(val) = line.strip_prefix("emoji:") {
+            let val = val.trim();
+            if !val.is_empty() {
+                emoji = Some(val.to_owned());
+            }
+        }
+    }
+
+    (name, emoji)
+}
+
+// --- GET /api/branding ---
+
+#[derive(Debug, Serialize)]
+pub struct BrandingResponse {
+    pub name: &'static str,
+}
+
+pub async fn branding(_claims: OptionalClaims) -> Json<BrandingResponse> {
+    Json(BrandingResponse { name: "Aletheia" })
+}
+
+// --- GET /api/auth/mode ---
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AuthModeResponse {
+    pub mode: &'static str,
+    pub session_auth: bool,
+}
+
+pub async fn auth_mode(_claims: OptionalClaims) -> Json<AuthModeResponse> {
+    Json(AuthModeResponse {
+        mode: "token",
+        session_auth: false,
+    })
+}
+
+// --- GET /api/sessions ---
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionsListQuery {
+    pub nous_id: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct SessionsListResponse {
+    pub sessions: Vec<SessionInfo>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionInfo {
+    pub id: String,
+    pub nous_id: String,
+    pub session_key: String,
+    pub status: String,
+    pub message_count: i64,
+    pub updated_at: String,
+}
+
+#[instrument(skip(state, _claims))]
+pub async fn sessions_list(
+    State(state): State<Arc<AppState>>,
+    _claims: OptionalClaims,
+    Query(params): Query<SessionsListQuery>,
+) -> Result<Json<SessionsListResponse>, ApiError> {
+    let nous_id = params.nous_id;
+
+    let state_clone = Arc::clone(&state);
+    let sessions = tokio::task::spawn_blocking(move || {
+        let store = state_clone.session_store.lock().expect("store lock");
+        store.list_sessions(nous_id.as_deref())
+    })
+    .await??;
+
+    let items = sessions
+        .into_iter()
+        .map(|s| SessionInfo {
+            id: s.id,
+            nous_id: s.nous_id,
+            session_key: s.session_key,
+            status: s.status.as_str().to_owned(),
+            message_count: s.message_count,
+            updated_at: s.updated_at,
+        })
+        .collect();
+
+    Ok(Json(SessionsListResponse { sessions: items }))
+}
+
+// --- GET /api/events ---
+
+pub async fn events_sse(
+    _claims: OptionalClaims,
+) -> Sse<impl tokio_stream::Stream<Item = Result<Event, Infallible>>> {
+    let (tx, rx) = mpsc::channel::<Event>(8);
+
+    // Emit init event
+    let init_data =
+        serde_json::json!({"activeTurns": {}, "pendingDeliveries": 0}).to_string();
+    let _ = tx
+        .send(Event::default().event("init").data(init_data))
+        .await;
+
+    // Ping every 15 seconds
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(Duration::from_secs(15));
+        loop {
+            interval.tick().await;
+            if tx
+                .send(Event::default().event("ping").data("{}"))
+                .await
+                .is_err()
+            {
+                break;
+            }
+        }
+    });
+
+    let stream = ReceiverStream::new(rx).map(Ok);
+
+    Sse::new(stream).keep_alive(
+        KeepAlive::new()
+            .interval(Duration::from_secs(30))
+            .text("heartbeat"),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_identity_extracts_name_and_emoji() {
+        let content = "name: Syn\nemoji: x\nother: ignored\n";
+        let (name, emoji) = parse_identity(content, "fallback");
+        assert_eq!(name, "Syn");
+        assert_eq!(emoji.as_deref(), Some("x"));
+    }
+
+    #[test]
+    fn parse_identity_uses_fallback_when_empty() {
+        let content = "emoji: x\n";
+        let (name, _emoji) = parse_identity(content, "fallback");
+        assert_eq!(name, "fallback");
+    }
+
+    #[test]
+    fn default_session_key_is_main() {
+        assert_eq!(default_session_key(), "main");
+    }
+
+    #[test]
+    fn stream_request_deserializes_with_defaults() {
+        let json = r#"{"agentId": "syn", "message": "hello"}"#;
+        let req: StreamRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req.agent_id, "syn");
+        assert_eq!(req.message, "hello");
+        assert_eq!(req.session_key, "main");
+    }
+
+    #[test]
+    fn stream_request_deserializes_with_session_key() {
+        let json = r#"{"agentId": "syn", "message": "hello", "sessionKey": "debug"}"#;
+        let req: StreamRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req.session_key, "debug");
+    }
+
+    #[test]
+    fn branding_response_shape() {
+        let resp = BrandingResponse { name: "Aletheia" };
+        let json = serde_json::to_value(&resp).unwrap();
+        assert_eq!(json["name"], "Aletheia");
+    }
+
+    #[test]
+    fn auth_mode_response_shape() {
+        let resp = AuthModeResponse {
+            mode: "token",
+            session_auth: false,
+        };
+        let json = serde_json::to_value(&resp).unwrap();
+        assert_eq!(json["mode"], "token");
+        assert_eq!(json["sessionAuth"], false);
+    }
+
+    #[test]
+    fn agents_list_response_serializes() {
+        let resp = AgentsListResponse {
+            agents: vec![AgentInfo {
+                id: "syn".to_owned(),
+                name: "Syn".to_owned(),
+                workspace: "/tmp/syn".to_owned(),
+                model: "anthropic/claude-opus-4-6".to_owned(),
+            }],
+        };
+        let json = serde_json::to_value(&resp).unwrap();
+        assert_eq!(json["agents"][0]["id"], "syn");
+        assert_eq!(json["agents"][0]["model"], "anthropic/claude-opus-4-6");
+    }
+
+    #[test]
+    fn sessions_list_response_uses_camel_case() {
+        let resp = SessionInfo {
+            id: "abc".to_owned(),
+            nous_id: "syn".to_owned(),
+            session_key: "main".to_owned(),
+            status: "active".to_owned(),
+            message_count: 5,
+            updated_at: "2026-01-01T00:00:00Z".to_owned(),
+        };
+        let json = serde_json::to_value(&resp).unwrap();
+        assert!(json.get("nousId").is_some());
+        assert!(json.get("sessionKey").is_some());
+        assert!(json.get("messageCount").is_some());
+        assert!(json.get("updatedAt").is_some());
+    }
+}

--- a/crates/pylon/src/router.rs
+++ b/crates/pylon/src/router.rs
@@ -14,8 +14,10 @@ use tower_http::set_header::SetResponseHeaderLayer;
 use tower_http::trace::TraceLayer;
 use tracing::info_span;
 
+use tower_http::services::{ServeDir, ServeFile};
+
 use crate::error::ApiError;
-use crate::handlers::{config, health, metrics, nous, sessions};
+use crate::handlers::{config, health, metrics, nous, sessions, webchat};
 use crate::middleware::{
     CsrfState, RequestId, enrich_error_response, inject_request_id, record_http_metrics,
     require_csrf_header,
@@ -47,10 +49,40 @@ pub fn build_router(state: Arc<AppState>, security: &SecurityConfig) -> Router {
 
     let mut router = Router::new()
         .nest("/api/v1", v1)
+        // Webchat compatibility endpoints (unversioned)
+        .route("/api/sessions/stream", post(webchat::stream))
+        .route("/api/agents", get(webchat::agents_list))
+        .route("/api/agents/{id}/identity", get(webchat::agent_identity))
+        .route("/api/branding", get(webchat::branding))
+        .route("/api/auth/mode", get(webchat::auth_mode))
+        .route("/api/sessions", get(webchat::sessions_list))
+        .route("/api/events", get(webchat::events_sse))
+        // Infrastructure
         .route("/api/health", get(health::check))
         .route("/api/docs/openapi.json", get(openapi::openapi_json))
-        .route("/metrics", get(metrics::expose))
-        .fallback(fallback_handler);
+        .route("/metrics", get(metrics::expose));
+
+    // Static file serving for the web UI
+    let ui_dist = state
+        .oikos
+        .root()
+        .parent()
+        .map(|repo_root| repo_root.join("ui/dist"));
+
+    if let Some(ref dist_path) = ui_dist {
+        if dist_path.is_dir() {
+            let index = dist_path.join("index.html");
+            router = router.nest_service(
+                "/ui",
+                ServeDir::new(dist_path).fallback(ServeFile::new(index)),
+            );
+            tracing::info!(path = %dist_path.display(), "mounted web UI static files");
+        } else {
+            tracing::debug!(path = %dist_path.display(), "ui/dist not found, skipping static serving");
+        }
+    }
+
+    router = router.fallback(fallback_handler);
 
     // CSRF protection — inject state and apply middleware
     if security.csrf_enabled {
@@ -118,12 +150,13 @@ pub fn build_router(state: Arc<AppState>, security: &SecurityConfig) -> Router {
 
 /// Fallback handler for unmatched routes.
 ///
-/// Detects old unversioned `/api/sessions` and `/api/nous` paths and returns
-/// 410 Gone with a migration hint. All other unknown paths get 404.
+/// Returns 410 Gone with migration hints for old unversioned `/api/nous`
+/// paths. Other unknown paths get 404.
 async fn fallback_handler(uri: axum::http::Uri) -> Response {
     let path = uri.path();
 
-    if path.starts_with("/api/sessions") || path.starts_with("/api/nous") {
+    // `/api/nous/*` has no webchat equivalent; hint at v1
+    if path.starts_with("/api/nous") {
         let suggestion = path.replacen("/api/", "/api/v1/", 1);
         return (
             StatusCode::GONE,

--- a/crates/pylon/src/stream.rs
+++ b/crates/pylon/src/stream.rs
@@ -65,3 +65,131 @@ impl SseEvent {
         }
     }
 }
+
+/// SSE events matching the Svelte web UI's `TurnStreamEvent` contract.
+///
+/// Separate from `SseEvent` to avoid changing the v1 API shape.
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum WebchatEvent {
+    TurnStart {
+        #[serde(rename = "sessionId")]
+        session_id: String,
+        #[serde(rename = "nousId")]
+        nous_id: String,
+        #[serde(rename = "turnId")]
+        turn_id: String,
+    },
+    ThinkingDelta {
+        text: String,
+    },
+    TextDelta {
+        text: String,
+    },
+    ToolStart {
+        #[serde(rename = "toolName")]
+        tool_name: String,
+        #[serde(rename = "toolId")]
+        tool_id: String,
+        input: serde_json::Value,
+    },
+    ToolResult {
+        #[serde(rename = "toolName")]
+        tool_name: String,
+        #[serde(rename = "toolId")]
+        tool_id: String,
+        result: String,
+        #[serde(rename = "isError")]
+        is_error: bool,
+        #[serde(rename = "durationMs")]
+        duration_ms: u64,
+    },
+    TurnComplete {
+        outcome: TurnOutcome,
+    },
+    Error {
+        message: String,
+    },
+}
+
+impl WebchatEvent {
+    pub fn event_type(&self) -> &'static str {
+        match self {
+            Self::TurnStart { .. } => "turn_start",
+            Self::ThinkingDelta { .. } => "thinking_delta",
+            Self::TextDelta { .. } => "text_delta",
+            Self::ToolStart { .. } => "tool_start",
+            Self::ToolResult { .. } => "tool_result",
+            Self::TurnComplete { .. } => "turn_complete",
+            Self::Error { .. } => "error",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TurnOutcome {
+    pub text: String,
+    pub nous_id: String,
+    pub session_id: String,
+    pub model: Option<String>,
+    pub tool_calls: usize,
+    pub input_tokens: u64,
+    pub output_tokens: u64,
+    pub cache_read_tokens: u64,
+    pub cache_write_tokens: u64,
+}
+
+/// Convert a `TurnResult` into the webchat event sequence and send via channel.
+pub async fn emit_webchat_events(
+    tx: &tokio::sync::mpsc::Sender<WebchatEvent>,
+    result: &aletheia_nous::pipeline::TurnResult,
+    session_id: &str,
+    nous_id: &str,
+    model: Option<&str>,
+) {
+    for tc in &result.tool_calls {
+        let _ = tx
+            .send(WebchatEvent::ToolStart {
+                tool_name: tc.name.clone(),
+                tool_id: tc.id.clone(),
+                input: tc.input.clone(),
+            })
+            .await;
+        if let Some(ref result_content) = tc.result {
+            let _ = tx
+                .send(WebchatEvent::ToolResult {
+                    tool_name: tc.name.clone(),
+                    tool_id: tc.id.clone(),
+                    result: result_content.clone(),
+                    is_error: tc.is_error,
+                    duration_ms: tc.duration_ms,
+                })
+                .await;
+        }
+    }
+
+    if !result.content.is_empty() {
+        let _ = tx
+            .send(WebchatEvent::TextDelta {
+                text: result.content.clone(),
+            })
+            .await;
+    }
+
+    let _ = tx
+        .send(WebchatEvent::TurnComplete {
+            outcome: TurnOutcome {
+                text: result.content.clone(),
+                nous_id: nous_id.to_owned(),
+                session_id: session_id.to_owned(),
+                model: model.map(ToOwned::to_owned),
+                tool_calls: result.tool_calls.len(),
+                input_tokens: result.usage.input_tokens,
+                output_tokens: result.usage.output_tokens,
+                cache_read_tokens: result.usage.cache_read_tokens,
+                cache_write_tokens: result.usage.cache_write_tokens,
+            },
+        })
+        .await;
+}

--- a/crates/pylon/src/tests.rs
+++ b/crates/pylon/src/tests.rs
@@ -958,22 +958,16 @@ async fn unknown_route_returns_404() {
 }
 
 #[tokio::test]
-async fn old_api_sessions_path_returns_gone() {
+async fn webchat_sessions_list_returns_200() {
     let (app, _dir) = app().await;
     let resp = app
         .oneshot(authed_get("/api/sessions"))
         .await
         .expect("response");
 
-    assert_eq!(resp.status(), StatusCode::GONE);
+    assert_eq!(resp.status(), StatusCode::OK);
     let body = body_json(resp).await;
-    assert_eq!(body["error"]["code"], "api_version_required");
-    assert!(
-        body["error"]["message"]
-            .as_str()
-            .unwrap()
-            .contains("/api/v1/sessions")
-    );
+    assert!(body["sessions"].is_array());
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- Add 7 unversioned `/api/` endpoints so the Svelte web UI works against the Rust pylon without UI code changes
- `POST /api/sessions/stream` bridges the key mismatch: UI sends `{agentId, message, sessionKey}`, pylon handles find-or-create session + SSE streaming with the `WebchatEvent` format matching `TurnStreamEvent`
- `OptionalClaims` extractor allows webchat routes to work with or without JWT auth
- Static file serving for `ui/dist/` via `tower-http::ServeDir` with SPA fallback
- Existing `/api/v1/` routes, `SseEvent`, and mandatory auth unchanged

## Endpoints added

| Method | Path | Purpose |
|--------|------|---------|
| POST | `/api/sessions/stream` | Chat streaming (SSE) |
| GET | `/api/agents` | Agent list |
| GET | `/api/agents/{id}/identity` | Agent name/emoji from IDENTITY.md |
| GET | `/api/branding` | App branding |
| GET | `/api/auth/mode` | Auth mode indicator |
| GET | `/api/sessions` | Session list |
| GET | `/api/events` | SSE event bus |
| GET | `/ui/*` | Static SPA serving |

## Test plan

- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test -p aletheia-pylon` passes (70 tests, 0 failures)
- [ ] Manual: `curl POST /api/sessions/stream` returns SSE stream
- [ ] Manual: `curl GET /api/agents` returns configured agents
- [ ] Manual: verify existing v1 endpoints still require JWT auth