### PR TITLE
feat: automatic distillation for session management

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -253,6 +253,7 @@ version = "0.10.0"
 dependencies = [
  "aletheia-hermeneus",
  "aletheia-koina",
+ "aletheia-melete",
  "aletheia-mneme",
  "aletheia-organon",
  "aletheia-taxis",

--- a/crates/daemon/src/runner.rs
+++ b/crates/daemon/src/runner.rs
@@ -12,7 +12,6 @@ use crate::error::{self, Result};
 use crate::maintenance::{
     DbMonitor, DriftDetector, MaintenanceConfig, RetentionExecutor, TraceRotator,
 };
-use crate::prosoche::ProsocheCheck;
 use crate::schedule::{BuiltinTask, Schedule, TaskAction, TaskDef, TaskStatus};
 
 /// Per-nous background task runner.
@@ -343,27 +342,21 @@ impl TaskRunner {
     ) -> Result<ExecutionResult> {
         match builtin {
             BuiltinTask::Prosoche => {
-                let check = ProsocheCheck::new(nous_id);
-                let result = check.run().await?;
-
-                if !result.items.is_empty() {
-                    if let Some(bridge) = &self.bridge {
-                        let summary: Vec<String> = result
-                            .items
-                            .iter()
-                            .map(|item| format!("- [{}] {}", item.category_label(), item.summary))
-                            .collect();
-                        let prompt = format!("Prosoche attention check:\n{}", summary.join("\n"));
-                        let _ = bridge
-                            .send_prompt(nous_id, "daemon:prosoche", &prompt)
-                            .await;
-                    }
+                if let Some(bridge) = &self.bridge {
+                    let prompt = "Run your prosoche heartbeat check per PROSOCHE.md.";
+                    let _ = bridge
+                        .send_prompt(nous_id, "daemon:prosoche", prompt)
+                        .await;
+                    Ok(ExecutionResult {
+                        success: true,
+                        output: Some("dispatched".to_owned()),
+                    })
+                } else {
+                    Ok(ExecutionResult {
+                        success: false,
+                        output: Some("no bridge configured".to_owned()),
+                    })
                 }
-
-                Ok(ExecutionResult {
-                    success: true,
-                    output: Some(format!("{} items", result.items.len())),
-                })
             }
             BuiltinTask::GraphMaintenance => {
                 tracing::info!(

--- a/crates/mneme/src/store.rs
+++ b/crates/mneme/src/store.rs
@@ -373,6 +373,101 @@ impl SessionStore {
         Ok(())
     }
 
+    // --- Distillation ---
+
+    /// Insert a distillation summary as a system message, then remove distilled messages.
+    ///
+    /// In a single transaction:
+    /// 1. Shift seq numbers of undistilled messages up by 1
+    /// 2. Insert summary at seq 0
+    /// 3. Delete all messages marked `is_distilled = 1`
+    #[instrument(skip(self, content))]
+    pub fn insert_distillation_summary(&self, session_id: &str, content: &str) -> Result<()> {
+        let tx = self
+            .conn
+            .unchecked_transaction()
+            .context(error::DatabaseSnafu)?;
+
+        // Shift existing undistilled messages up by 1
+        tx.execute(
+            "UPDATE messages SET seq = seq + 1 WHERE session_id = ?1 AND is_distilled = 0",
+            [session_id],
+        )
+        .context(error::DatabaseSnafu)?;
+
+        // Insert summary at seq 0
+        #[expect(clippy::cast_possible_wrap, reason = "summary length fits in i64")]
+        let token_estimate = content.len() as i64 / 4;
+        tx.execute(
+            "INSERT INTO messages (session_id, seq, role, content, is_distilled, token_estimate, created_at)
+             VALUES (?1, 0, 'system', ?2, 0, ?3, strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))",
+            rusqlite::params![session_id, content, token_estimate],
+        )
+        .context(error::DatabaseSnafu)?;
+
+        // Delete distilled messages
+        tx.execute(
+            "DELETE FROM messages WHERE session_id = ?1 AND is_distilled = 1",
+            [session_id],
+        )
+        .context(error::DatabaseSnafu)?;
+
+        // Recalculate session counts
+        let (total_tokens, msg_count): (i64, i64) = tx
+            .query_row(
+                "SELECT COALESCE(SUM(token_estimate), 0), COUNT(*) FROM messages WHERE session_id = ?1 AND is_distilled = 0",
+                [session_id],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .context(error::DatabaseSnafu)?;
+
+        tx.execute(
+            "UPDATE sessions SET token_count_estimate = ?1, message_count = ?2, updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now') WHERE id = ?3",
+            rusqlite::params![total_tokens, msg_count, session_id],
+        )
+        .context(error::DatabaseSnafu)?;
+
+        tx.commit().context(error::DatabaseSnafu)?;
+
+        info!(session_id, msg_count, total_tokens, "inserted distillation summary");
+        Ok(())
+    }
+
+    /// Record a distillation event: insert into distillations table, update session counters.
+    #[instrument(skip(self))]
+    pub fn record_distillation(
+        &self,
+        session_id: &str,
+        messages_before: i64,
+        messages_after: i64,
+        tokens_before: i64,
+        tokens_after: i64,
+        model: Option<&str>,
+    ) -> Result<()> {
+        let tx = self
+            .conn
+            .unchecked_transaction()
+            .context(error::DatabaseSnafu)?;
+
+        tx.execute(
+            "INSERT INTO distillations (session_id, messages_before, messages_after, tokens_before, tokens_after, model)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+            rusqlite::params![session_id, messages_before, messages_after, tokens_before, tokens_after, model],
+        )
+        .context(error::DatabaseSnafu)?;
+
+        tx.execute(
+            "UPDATE sessions SET distillation_count = distillation_count + 1, last_distilled_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now'), updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now') WHERE id = ?1",
+            [session_id],
+        )
+        .context(error::DatabaseSnafu)?;
+
+        tx.commit().context(error::DatabaseSnafu)?;
+
+        info!(session_id, messages_before, messages_after, tokens_before, tokens_after, "recorded distillation");
+        Ok(())
+    }
+
     // --- Usage ---
 
     /// Record token usage for a turn.
@@ -1102,5 +1197,70 @@ mod tests {
 
         let list = store.blackboard_list().unwrap();
         assert!(list.is_empty());
+    }
+
+    #[test]
+    fn record_distillation_increments_count() {
+        let store = test_store();
+        store
+            .create_session("ses-1", "syn", "main", None, None)
+            .unwrap();
+
+        let session = store.find_session_by_id("ses-1").unwrap().unwrap();
+        assert_eq!(session.distillation_count, 0);
+        assert!(session.last_distilled_at.is_none());
+
+        store
+            .record_distillation("ses-1", 20, 5, 50000, 2000, Some("sonnet"))
+            .unwrap();
+
+        let session = store.find_session_by_id("ses-1").unwrap().unwrap();
+        assert_eq!(session.distillation_count, 1);
+        assert!(session.last_distilled_at.is_some());
+
+        store
+            .record_distillation("ses-1", 15, 3, 30000, 1500, None)
+            .unwrap();
+
+        let session = store.find_session_by_id("ses-1").unwrap().unwrap();
+        assert_eq!(session.distillation_count, 2);
+    }
+
+    #[test]
+    fn insert_distillation_summary_and_cleanup() {
+        let store = test_store();
+        store
+            .create_session("ses-1", "syn", "main", None, None)
+            .unwrap();
+
+        // Add some messages
+        store
+            .append_message("ses-1", Role::User, "msg1", None, None, 100)
+            .unwrap();
+        store
+            .append_message("ses-1", Role::Assistant, "msg2", None, None, 200)
+            .unwrap();
+        store
+            .append_message("ses-1", Role::User, "msg3", None, None, 50)
+            .unwrap();
+
+        // Mark first two as distilled
+        store.mark_messages_distilled("ses-1", &[1, 2]).unwrap();
+
+        // Insert summary (should also delete distilled messages)
+        store
+            .insert_distillation_summary("ses-1", "[Distillation #1]\n\nSummary text")
+            .unwrap();
+
+        let history = store.get_history("ses-1", None).unwrap();
+        // Should have: summary (seq 0) + undistilled msg3 (seq shifted)
+        assert_eq!(history.len(), 2);
+        assert_eq!(history[0].role, Role::System);
+        assert!(history[0].content.contains("Distillation #1"));
+        assert_eq!(history[1].content, "msg3");
+
+        // Session counts should reflect new state
+        let session = store.find_session_by_id("ses-1").unwrap().unwrap();
+        assert_eq!(session.message_count, 2);
     }
 }

--- a/crates/nous/Cargo.toml
+++ b/crates/nous/Cargo.toml
@@ -16,6 +16,7 @@ knowledge-store = ["aletheia-mneme/mneme-engine"]
 [dependencies]
 aletheia-hermeneus = { path = "../hermeneus" }
 aletheia-koina = { path = "../koina" }
+aletheia-melete = { path = "../melete" }
 aletheia-mneme = { path = "../mneme" }
 aletheia-organon = { path = "../organon" }
 aletheia-taxis = { path = "../taxis" }

--- a/crates/nous/src/actor.rs
+++ b/crates/nous/src/actor.rs
@@ -175,6 +175,7 @@ impl NousActor {
 
         if let Ok(ref turn_result) = result {
             self.maybe_spawn_extraction(&content, &turn_result.content);
+            self.maybe_spawn_distillation(&session_key);
         }
 
         self.active_session = None;
@@ -276,6 +277,51 @@ impl NousActor {
         );
     }
 
+    fn maybe_spawn_distillation(&self, session_key: &str) {
+        let Some(ref store_arc) = self.session_store else {
+            return;
+        };
+        let Some(session_state) = self.sessions.get(session_key) else {
+            return;
+        };
+        let session_id = session_state.id.clone();
+
+        // Quick trigger check under the lock
+        let should_distill = {
+            let store = store_arc.lock().expect("session store lock");
+            let Ok(Some(session)) = store.find_session_by_id(&session_id) else {
+                return;
+            };
+            let config = crate::distillation::DistillTriggerConfig::default();
+            crate::distillation::should_trigger_distillation(
+                &session,
+                u64::from(self.config.context_window),
+                &config,
+            )
+            .is_some()
+        };
+
+        if !should_distill {
+            return;
+        }
+
+        let config = crate::distillation::DistillTriggerConfig::default();
+        if self.providers.find_provider(&config.model).is_none() {
+            warn!(model = %config.model, "no provider for distillation model");
+            return;
+        }
+
+        let store = Arc::clone(store_arc);
+        let providers = Arc::clone(&self.providers);
+        let nous_id = self.id.clone();
+        let span = tracing::info_span!("distillation", nous.id = %nous_id, session.id = %session_id);
+
+        tokio::spawn(
+            run_background_distillation(store, providers, session_id, nous_id, config)
+                .instrument(span),
+        );
+    }
+
     fn handle_sleep(&mut self) {
         match self.lifecycle {
             NousLifecycle::Idle => {
@@ -342,6 +388,76 @@ fn run_extraction(
             warn!(nous_id = %nous_id, error = %e, "extraction failed");
         }
     }
+}
+
+/// Run distillation as a background task. Loads history, calls LLM, applies results.
+async fn run_background_distillation(
+    store: Arc<Mutex<SessionStore>>,
+    providers: Arc<ProviderRegistry>,
+    session_id: String,
+    nous_id: String,
+    config: crate::distillation::DistillTriggerConfig,
+) {
+    let Some(provider) = providers.find_provider(&config.model) else {
+        return;
+    };
+
+    // Load history under the lock, then release before async work
+    let (history, session) = {
+        let s = store.lock().expect("session store lock");
+        let Ok(Some(session)) = s.find_session_by_id(&session_id) else {
+            return;
+        };
+        match s.get_history(&session_id, None) {
+            Ok(h) if !h.is_empty() => (h, session),
+            Ok(_) => return,
+            Err(e) => {
+                warn!(error = %e, "failed to load history for distillation");
+                return;
+            }
+        }
+    };
+
+    let messages = crate::distillation::convert_to_hermeneus_messages(&history);
+    let engine = aletheia_melete::distill::DistillEngine::new(
+        aletheia_melete::distill::DistillConfig {
+            model: config.model.clone(),
+            verbatim_tail: config.verbatim_tail,
+            ..Default::default()
+        },
+    );
+
+    #[expect(
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss,
+        reason = "distillation count is small non-negative"
+    )]
+    let distill_count = session.distillation_count as u32;
+    let result = match engine
+        .distill(&messages, &nous_id, provider, distill_count + 1)
+        .await
+    {
+        Ok(r) => r,
+        Err(e) => {
+            warn!(error = %e, "distillation LLM call failed");
+            return;
+        }
+    };
+
+    // Apply results under the lock
+    let s = store.lock().expect("session store lock");
+    if let Err(e) =
+        crate::distillation::apply_distillation(&s, &session_id, &result, &history)
+    {
+        warn!(error = %e, "failed to apply distillation");
+        return;
+    }
+
+    info!(
+        session_id = %session_id,
+        messages_distilled = result.messages_distilled,
+        "background distillation complete"
+    );
 }
 
 /// Spawn a nous actor, returning its handle and join handle.

--- a/crates/nous/src/distillation.rs
+++ b/crates/nous/src/distillation.rs
@@ -1,0 +1,401 @@
+//! Distillation wiring: trigger logic and orchestration.
+
+use snafu::ResultExt;
+use tracing::{info, instrument};
+
+use aletheia_hermeneus::provider::LlmProvider;
+use aletheia_hermeneus::types::{Content, Message as HermeneusMessage, Role as HermeneusRole};
+use aletheia_melete::distill::{DistillConfig, DistillEngine, DistillResult};
+use aletheia_mneme::store::SessionStore;
+use aletheia_mneme::types::{Role as MnemeRole, Session};
+
+use crate::error;
+
+/// Configuration for distillation triggers.
+#[derive(Debug, Clone)]
+pub struct DistillTriggerConfig {
+    /// Fraction of context window that triggers legacy threshold (default 0.7).
+    pub max_history_share: f64,
+    /// Model to use for distillation.
+    pub model: String,
+    /// Messages to preserve verbatim at the tail (default 3).
+    pub verbatim_tail: usize,
+}
+
+impl Default for DistillTriggerConfig {
+    fn default() -> Self {
+        Self {
+            max_history_share: 0.7,
+            model: "claude-sonnet-4-20250514".to_owned(),
+            verbatim_tail: 3,
+        }
+    }
+}
+
+/// Check if a session needs distillation. Returns the trigger reason if so.
+#[must_use]
+pub fn should_trigger_distillation(
+    session: &Session,
+    context_window: u64,
+    config: &DistillTriggerConfig,
+) -> Option<String> {
+    // Never distill on the first turn
+    if session.message_count <= 0 {
+        return None;
+    }
+
+    // Prefer actual context from last input; fall back to estimate
+    let actual_context = if session.last_input_tokens > 0 {
+        session.last_input_tokens
+    } else {
+        session.token_count_estimate
+    };
+
+    #[expect(
+        clippy::cast_sign_loss,
+        reason = "token counts are non-negative in practice"
+    )]
+    let actual_context_u64 = actual_context as u64;
+
+    // Signal 1: Absolute context threshold (120K+)
+    if actual_context_u64 >= 120_000 {
+        return Some(format!("context={actual_context} >= 120K"));
+    }
+
+    // Signal 2: High message count (150+)
+    if session.message_count >= 150 {
+        return Some(format!("message_count={} >= 150", session.message_count));
+    }
+
+    // Signal 3: Stale + messages (7 days since last distill + 20 msgs)
+    if let Some(ref last) = session.last_distilled_at {
+        if let Ok(last_ts) = last.parse::<jiff::Timestamp>() {
+            let age = jiff::Timestamp::now().duration_since(last_ts);
+            let days = age.as_secs() / 86_400;
+            if days >= 7 && session.message_count >= 20 {
+                return Some(format!(
+                    "stale ({days}d) + {} msgs",
+                    session.message_count
+                ));
+            }
+        }
+    }
+
+    // Signal 4: Never distilled + enough messages (30+)
+    if session.distillation_count == 0 && session.message_count >= 30 {
+        return Some(format!(
+            "never distilled + {} msgs",
+            session.message_count
+        ));
+    }
+
+    // Signal 5: Legacy threshold (configurable ratio of context window)
+    #[expect(
+        clippy::cast_precision_loss,
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss,
+        reason = "context_window * ratio is a rough threshold; precision/truncation acceptable"
+    )]
+    let threshold = (context_window as f64 * config.max_history_share) as u64;
+    if actual_context_u64 >= threshold && session.message_count >= 10 {
+        return Some(format!(
+            "legacy threshold ({actual_context} >= {threshold})"
+        ));
+    }
+
+    None
+}
+
+/// Check if session needs distillation, run it if so.
+///
+/// Returns `Some(result)` if distillation ran, `None` if not needed.
+#[instrument(skip(session_store, provider, config))]
+pub async fn maybe_distill(
+    session_store: &SessionStore,
+    provider: &dyn LlmProvider,
+    session_id: &str,
+    nous_id: &str,
+    context_window: u64,
+    config: &DistillTriggerConfig,
+) -> error::Result<Option<DistillResult>> {
+    let Some(session) = session_store
+        .find_session_by_id(session_id)
+        .context(error::StoreSnafu)?
+    else {
+        return Ok(None);
+    };
+
+    let Some(trigger) = should_trigger_distillation(&session, context_window, config) else {
+        return Ok(None);
+    };
+
+    info!(%session_id, %nous_id, %trigger, "triggering distillation");
+
+    let history = session_store
+        .get_history(session_id, None)
+        .context(error::StoreSnafu)?;
+
+    if history.is_empty() {
+        return Ok(None);
+    }
+
+    let messages = convert_to_hermeneus_messages(&history);
+
+    let engine = DistillEngine::new(DistillConfig {
+        model: config.model.clone(),
+        verbatim_tail: config.verbatim_tail,
+        ..Default::default()
+    });
+
+    #[expect(
+        clippy::cast_sign_loss,
+        clippy::cast_possible_truncation,
+        reason = "distillation_count is small non-negative"
+    )]
+    let distill_count = session.distillation_count as u32;
+    let result = engine
+        .distill(&messages, nous_id, provider, distill_count + 1)
+        .await
+        .context(error::DistillationSnafu)?;
+
+    apply_distillation(session_store, session_id, &result, &history)?;
+
+    info!(
+        %session_id,
+        messages_distilled = result.messages_distilled,
+        tokens_before = result.tokens_before,
+        tokens_after = result.tokens_after,
+        "distillation complete"
+    );
+
+    Ok(Some(result))
+}
+
+/// Apply distillation result to the session store.
+pub fn apply_distillation(
+    store: &SessionStore,
+    session_id: &str,
+    result: &DistillResult,
+    history: &[aletheia_mneme::types::Message],
+) -> error::Result<()> {
+    // Collect seq numbers of messages that were distilled (all except verbatim tail)
+    let distill_count = result.messages_distilled.min(history.len());
+    let seqs: Vec<i64> = history[..distill_count].iter().map(|m| m.seq).collect();
+
+    // Mark messages as distilled first
+    store
+        .mark_messages_distilled(session_id, &seqs)
+        .context(error::StoreSnafu)?;
+
+    // Insert summary and clean up distilled messages
+    let summary_content = format!(
+        "[Distillation #{}]\n\n{}",
+        result.distillation_number, result.summary
+    );
+    store
+        .insert_distillation_summary(session_id, &summary_content)
+        .context(error::StoreSnafu)?;
+
+    // Record distillation metadata
+    #[expect(clippy::cast_possible_wrap, reason = "token/message counts fit in i64")]
+    store
+        .record_distillation(
+            session_id,
+            distill_count as i64,
+            (history.len() - distill_count) as i64,
+            result.tokens_before as i64,
+            result.tokens_after as i64,
+            None,
+        )
+        .context(error::StoreSnafu)?;
+
+    Ok(())
+}
+
+/// Convert mneme messages to hermeneus messages for the distillation engine.
+pub fn convert_to_hermeneus_messages(
+    history: &[aletheia_mneme::types::Message],
+) -> Vec<HermeneusMessage> {
+    history
+        .iter()
+        .map(|msg| {
+            let role = match msg.role {
+                MnemeRole::System => HermeneusRole::System,
+                MnemeRole::User | MnemeRole::ToolResult => HermeneusRole::User,
+                MnemeRole::Assistant => HermeneusRole::Assistant,
+            };
+            HermeneusMessage {
+                role,
+                content: Content::Text(msg.content.clone()),
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_session(overrides: impl FnOnce(&mut Session)) -> Session {
+        let mut session = Session {
+            id: "ses-1".to_owned(),
+            nous_id: "test-nous".to_owned(),
+            session_key: "main".to_owned(),
+            parent_session_id: None,
+            status: aletheia_mneme::types::SessionStatus::Active,
+            model: Some("test-model".to_owned()),
+            token_count_estimate: 1000,
+            message_count: 10,
+            last_input_tokens: 0,
+            bootstrap_hash: None,
+            distillation_count: 0,
+            session_type: aletheia_mneme::types::SessionType::Primary,
+            last_distilled_at: None,
+            computed_context_tokens: 0,
+            thread_id: None,
+            transport: None,
+            created_at: String::new(),
+            updated_at: String::new(),
+        };
+        overrides(&mut session);
+        session
+    }
+
+    #[test]
+    fn trigger_on_high_context() {
+        let session = test_session(|s| {
+            s.last_input_tokens = 130_000;
+        });
+        let config = DistillTriggerConfig::default();
+        let result = should_trigger_distillation(&session, 200_000, &config);
+        assert!(result.is_some());
+        assert!(result.unwrap().contains("120K"));
+    }
+
+    #[test]
+    fn trigger_on_message_count() {
+        let session = test_session(|s| {
+            s.message_count = 160;
+        });
+        let config = DistillTriggerConfig::default();
+        let result = should_trigger_distillation(&session, 200_000, &config);
+        assert!(result.is_some());
+        assert!(result.unwrap().contains("150"));
+    }
+
+    #[test]
+    fn trigger_on_never_distilled() {
+        let session = test_session(|s| {
+            s.message_count = 35;
+            s.distillation_count = 0;
+        });
+        let config = DistillTriggerConfig::default();
+        let result = should_trigger_distillation(&session, 200_000, &config);
+        assert!(result.is_some());
+        assert!(result.unwrap().contains("never distilled"));
+    }
+
+    #[test]
+    fn trigger_on_stale_session() {
+        let eight_days_ago = jiff::Timestamp::now()
+            .checked_sub(jiff::SignedDuration::from_hours(8 * 24))
+            .expect("valid timestamp");
+        let session = test_session(|s| {
+            s.message_count = 25;
+            s.distillation_count = 1;
+            s.last_distilled_at = Some(eight_days_ago.to_string());
+        });
+        let config = DistillTriggerConfig::default();
+        let result = should_trigger_distillation(&session, 200_000, &config);
+        assert!(result.is_some());
+        assert!(result.unwrap().contains("stale"));
+    }
+
+    #[test]
+    fn no_trigger_below_thresholds() {
+        let session = test_session(|s| {
+            s.message_count = 5;
+            s.token_count_estimate = 1000;
+            s.distillation_count = 0;
+        });
+        let config = DistillTriggerConfig::default();
+        let result = should_trigger_distillation(&session, 200_000, &config);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn no_trigger_first_turn() {
+        let session = test_session(|s| {
+            s.message_count = 0;
+            s.token_count_estimate = 200_000;
+            s.last_input_tokens = 200_000;
+        });
+        let config = DistillTriggerConfig::default();
+        let result = should_trigger_distillation(&session, 200_000, &config);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn trigger_on_legacy_threshold() {
+        let session = test_session(|s| {
+            s.message_count = 15;
+            s.token_count_estimate = 100_000;
+            s.distillation_count = 1;
+        });
+        let config = DistillTriggerConfig {
+            max_history_share: 0.7,
+            ..DistillTriggerConfig::default()
+        };
+        // context_window=140_000 * 0.7 = 98_000, actual=100_000 >= 98_000
+        let result = should_trigger_distillation(&session, 140_000, &config);
+        assert!(result.is_some());
+        assert!(result.unwrap().contains("legacy threshold"));
+    }
+
+    #[test]
+    fn message_conversion_maps_roles() {
+        let messages = vec![
+            aletheia_mneme::types::Message {
+                id: 1,
+                session_id: "s".to_owned(),
+                seq: 1,
+                role: MnemeRole::System,
+                content: "system".to_owned(),
+                tool_call_id: None,
+                tool_name: None,
+                token_estimate: 0,
+                is_distilled: false,
+                created_at: String::new(),
+            },
+            aletheia_mneme::types::Message {
+                id: 2,
+                session_id: "s".to_owned(),
+                seq: 2,
+                role: MnemeRole::User,
+                content: "user".to_owned(),
+                tool_call_id: None,
+                tool_name: None,
+                token_estimate: 0,
+                is_distilled: false,
+                created_at: String::new(),
+            },
+            aletheia_mneme::types::Message {
+                id: 3,
+                session_id: "s".to_owned(),
+                seq: 3,
+                role: MnemeRole::ToolResult,
+                content: "tool output".to_owned(),
+                tool_call_id: Some("tc-1".to_owned()),
+                tool_name: Some("read".to_owned()),
+                token_estimate: 0,
+                is_distilled: false,
+                created_at: String::new(),
+            },
+        ];
+        let converted = convert_to_hermeneus_messages(&messages);
+        assert_eq!(converted.len(), 3);
+        assert_eq!(converted[0].role, HermeneusRole::System);
+        assert_eq!(converted[1].role, HermeneusRole::User);
+        assert_eq!(converted[2].role, HermeneusRole::User);
+    }
+}

--- a/crates/nous/src/error.rs
+++ b/crates/nous/src/error.rs
@@ -129,6 +129,14 @@ pub enum Error {
         #[snafu(implicit)]
         location: snafu::Location,
     },
+
+    /// Distillation failed.
+    #[snafu(display("distillation failed: {source}"))]
+    Distillation {
+        source: aletheia_melete::error::Error,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
 }
 
 /// Convenience alias for results with [`Error`].

--- a/crates/nous/src/lib.rs
+++ b/crates/nous/src/lib.rs
@@ -18,6 +18,8 @@ pub mod budget;
 pub mod config;
 /// Inter-agent messaging — fire-and-forget, request-response, and delivery audit.
 pub mod cross;
+/// Distillation trigger logic and orchestration.
+pub mod distillation;
 /// Nous-specific error types.
 pub mod error;
 /// LLM execution stage — sends the assembled prompt to the provider.


### PR DESCRIPTION
## Summary

- Wire melete distillation engine into the nous pipeline so sessions get automatically compressed when they grow too large
- Add 5 trigger signals ported from TS multi-signal logic (context threshold, message count, stale session, never-distilled, legacy ratio)
- Background distillation runs after each turn without blocking the response
- Fix prosoche dispatch to unconditionally send prompt to agent instead of running stub check

## Changes

| File | What |
|------|------|
| `crates/nous/src/distillation.rs` | **New** - trigger logic, orchestration, message conversion |
| `crates/nous/src/actor.rs` | Spawn background distillation after turns |
| `crates/mneme/src/store.rs` | `insert_distillation_summary()`, `record_distillation()` |
| `crates/daemon/src/runner.rs` | Simplify prosoche to unconditional dispatch |

## Design decisions

- **Background task, not inline**: distillation spawns via `tokio::spawn` after pipeline returns, same pattern as extraction
- **Lock discipline**: store lock held only for reads/writes, released before the LLM call to avoid blocking other turns
- **Seq-based marking**: uses existing `mark_messages_distilled(&[i64])` API rather than count-based, for explicit control
- **Gateway tool deferred**: manual distillation via tool requires service wiring through `ToolContext`, separate PR

## Test plan

- [x] 8 trigger logic unit tests (high context, message count, stale, never-distilled, legacy, first turn, below threshold)
- [x] 2 store integration tests (record_distillation, insert_distillation_summary)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test -p aletheia-nous -p aletheia-mneme -p aletheia-oikonomos` all passing