### PR TITLE
feat(organon): sub-agent spawn and dispatch tools

### DIFF
--- a/crates/aletheia/src/main.rs
+++ b/crates/aletheia/src/main.rs
@@ -504,11 +504,18 @@ async fn serve(cli: Cli) -> Result<()> {
             Some(Arc::new(aletheia_nous::adapters::SessionNoteAdapter(Arc::clone(&session_store))));
         let blackboard_store: Option<Arc<dyn aletheia_organon::types::BlackboardStore>> =
             Some(Arc::new(aletheia_nous::adapters::SessionBlackboardAdapter(Arc::clone(&session_store))));
+        let spawn: Option<Arc<dyn aletheia_organon::types::SpawnService>> =
+            Some(Arc::new(aletheia_nous::spawn_svc::SpawnServiceImpl::new(
+                Arc::clone(&provider_registry),
+                Arc::clone(&tool_registry),
+                Arc::clone(&oikos_arc),
+            )));
         Arc::new(ToolServices {
             cross_nous: Some(cross_nous),
             messenger,
             note_store,
             blackboard_store,
+            spawn,
             http_client: reqwest::Client::new(),
             lazy_tool_catalog: tool_registry.lazy_tool_catalog(),
         })

--- a/crates/nous/src/lib.rs
+++ b/crates/nous/src/lib.rs
@@ -42,6 +42,8 @@ pub mod pipeline;
 pub mod recall;
 /// Session state tracking within a nous actor.
 pub mod session;
+/// Ephemeral sub-agent spawning service.
+pub mod spawn_svc;
 /// Real-time streaming events for the turn pipeline.
 pub mod stream;
 /// User-facing error formatting for display in chat responses.

--- a/crates/nous/src/spawn_svc.rs
+++ b/crates/nous/src/spawn_svc.rs
@@ -1,0 +1,338 @@
+//! Ephemeral sub-agent spawning service.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::time::Duration;
+
+use aletheia_hermeneus::provider::ProviderRegistry;
+use aletheia_organon::registry::ToolRegistry;
+use aletheia_organon::types::{SpawnRequest, SpawnResult, SpawnService};
+use aletheia_taxis::oikos::Oikos;
+use tracing::{Instrument, info, warn};
+
+use crate::actor;
+use crate::config::{NousConfig, PipelineConfig, StageBudget};
+
+const SONNET_MODEL: &str = "claude-sonnet-4-20250514";
+const HAIKU_MODEL: &str = "claude-haiku-4-5-20251001";
+
+fn model_for_role(role: &str) -> &'static str {
+    match role {
+        "explorer" | "runner" => HAIKU_MODEL,
+        _ => SONNET_MODEL,
+    }
+}
+
+/// Concrete [`SpawnService`] that bridges to [`actor::spawn`].
+pub struct SpawnServiceImpl {
+    providers: Arc<ProviderRegistry>,
+    tools: Arc<ToolRegistry>,
+    oikos: Arc<Oikos>,
+}
+
+impl SpawnServiceImpl {
+    #[must_use]
+    pub fn new(
+        providers: Arc<ProviderRegistry>,
+        tools: Arc<ToolRegistry>,
+        oikos: Arc<Oikos>,
+    ) -> Self {
+        Self {
+            providers,
+            tools,
+            oikos,
+        }
+    }
+}
+
+impl SpawnService for SpawnServiceImpl {
+    fn spawn_and_run(
+        &self,
+        request: SpawnRequest,
+        parent_nous_id: &str,
+    ) -> Pin<Box<dyn Future<Output = Result<SpawnResult, String>> + Send + '_>> {
+        let spawn_id = format!("spawn-{}-{}", parent_nous_id, ulid::Ulid::new().to_string().to_lowercase());
+        let model = request
+            .model
+            .clone()
+            .unwrap_or_else(|| model_for_role(&request.role).to_owned());
+        let timeout = Duration::from_secs(request.timeout_secs);
+        let task = request.task.clone();
+        let session_key = format!("spawn:{}", ulid::Ulid::new().to_string().to_lowercase());
+
+        let config = NousConfig {
+            id: spawn_id.clone(),
+            model,
+            context_window: 200_000,
+            max_output_tokens: 16_384,
+            bootstrap_max_tokens: 4_000,
+            thinking_enabled: false,
+            thinking_budget: 0,
+            max_tool_iterations: 25,
+            loop_detection_threshold: 3,
+            domains: Vec::new(),
+        };
+
+        let pipeline_config = PipelineConfig {
+            distillation_threshold: 1.0,
+            include_notes: false,
+            include_working_state: false,
+            max_notes: 0,
+            history_budget_ratio: 0.6,
+            extraction: None,
+            stage_budget: StageBudget::default(),
+        };
+
+        let providers = Arc::clone(&self.providers);
+        let tools = Arc::clone(&self.tools);
+        let oikos = Arc::clone(&self.oikos);
+
+        let span = tracing::info_span!(
+            "spawn_sub_agent",
+            spawn.id = %spawn_id,
+            spawn.role = %request.role,
+        );
+
+        let role_desc = request.role.clone();
+
+        Box::pin(
+            async move {
+                // Create minimal workspace directory for the ephemeral agent
+                let nous_dir = oikos.nous_dir(&spawn_id);
+                if let Err(e) = std::fs::create_dir_all(&nous_dir) {
+                    return Err(format!("failed to create spawn workspace: {e}"));
+                }
+                let soul_path = nous_dir.join("SOUL.md");
+                if let Err(e) = std::fs::write(
+                    &soul_path,
+                    format!("You are an ephemeral {role_desc} sub-agent. Complete the assigned task precisely and concisely."),
+                ) {
+                    return Err(format!("failed to write SOUL.md: {e}"));
+                }
+
+                let (handle, join_handle) = actor::spawn(
+                    config,
+                    pipeline_config,
+                    providers,
+                    tools,
+                    oikos,
+                    None,
+                    None,
+                    None,
+                    None,
+                    Vec::new(),
+                    None,
+                );
+
+                info!(session_key = %session_key, "ephemeral actor started");
+
+                let result =
+                    tokio::time::timeout(timeout, handle.send_turn(&session_key, &task)).await;
+
+                let _ = handle.shutdown().await;
+                let _ = join_handle.await;
+
+                // Clean up ephemeral workspace
+                let _ = std::fs::remove_dir_all(&nous_dir);
+
+                match result {
+                    Ok(Ok(turn)) => Ok(SpawnResult {
+                        content: turn.content,
+                        is_error: false,
+                        input_tokens: turn.usage.input_tokens,
+                        output_tokens: turn.usage.output_tokens,
+                    }),
+                    Ok(Err(e)) => Ok(SpawnResult {
+                        content: format!("Sub-agent error: {e}"),
+                        is_error: true,
+                        input_tokens: 0,
+                        output_tokens: 0,
+                    }),
+                    Err(_elapsed) => {
+                        warn!(timeout_secs = timeout.as_secs(), "sub-agent timed out");
+                        Ok(SpawnResult {
+                            content: format!(
+                                "Sub-agent timed out after {}s",
+                                timeout.as_secs()
+                            ),
+                            is_error: true,
+                            input_tokens: 0,
+                            output_tokens: 0,
+                        })
+                    }
+                }
+            }
+            .instrument(span),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Mutex;
+
+    use aletheia_hermeneus::provider::LlmProvider;
+    use aletheia_hermeneus::types::{
+        CompletionRequest, CompletionResponse, ContentBlock, StopReason, Usage,
+    };
+    use aletheia_taxis::oikos::Oikos;
+
+    use super::*;
+
+    struct MockProvider {
+        response: Mutex<CompletionResponse>,
+    }
+
+    impl LlmProvider for MockProvider {
+        fn complete(
+            &self,
+            _request: &CompletionRequest,
+        ) -> aletheia_hermeneus::error::Result<CompletionResponse> {
+            Ok(self.response.lock().expect("lock").clone())
+        }
+
+        fn supported_models(&self) -> &[&str] {
+            &["claude-sonnet-4-20250514", "claude-haiku-4-5-20251001"]
+        }
+
+        #[expect(clippy::unnecessary_literal_bound, reason = "trait requires &str")]
+        fn name(&self) -> &str {
+            "mock"
+        }
+    }
+
+    fn test_oikos() -> (tempfile::TempDir, Arc<Oikos>) {
+        let dir = tempfile::TempDir::new().expect("tmpdir");
+        let root = dir.path();
+        std::fs::create_dir_all(root.join("shared")).expect("mkdir");
+        std::fs::create_dir_all(root.join("theke")).expect("mkdir");
+        let oikos = Arc::new(Oikos::from_root(root));
+        (dir, oikos)
+    }
+
+    fn test_providers() -> Arc<ProviderRegistry> {
+        let mut providers = ProviderRegistry::new();
+        providers.register(Box::new(MockProvider {
+            response: Mutex::new(CompletionResponse {
+                id: "resp-1".to_owned(),
+                model: "claude-sonnet-4-20250514".to_owned(),
+                stop_reason: StopReason::EndTurn,
+                content: vec![ContentBlock::Text {
+                    text: "Sub-agent result".to_owned(),
+                    citations: None,
+                }],
+                usage: Usage {
+                    input_tokens: 200,
+                    output_tokens: 80,
+                    ..Usage::default()
+                },
+            }),
+        }));
+        Arc::new(providers)
+    }
+
+    fn test_spawn_service(oikos: Arc<Oikos>) -> SpawnServiceImpl {
+        SpawnServiceImpl::new(
+            test_providers(),
+            Arc::new(ToolRegistry::new()),
+            oikos,
+        )
+    }
+
+    #[tokio::test]
+    async fn spawn_runs_single_turn() {
+        let (_dir, oikos) = test_oikos();
+        let svc = test_spawn_service(oikos);
+
+        let result = svc
+            .spawn_and_run(
+                SpawnRequest {
+                    role: "coder".to_owned(),
+                    task: "Write a function".to_owned(),
+                    model: None,
+                    allowed_tools: None,
+                    timeout_secs: 30,
+                },
+                "test-parent",
+            )
+            .await
+            .expect("spawn");
+
+        assert!(!result.is_error, "unexpected error: {}", result.content);
+        assert_eq!(result.content, "Sub-agent result");
+        assert_eq!(result.input_tokens, 200);
+        assert_eq!(result.output_tokens, 80);
+    }
+
+    #[tokio::test]
+    async fn spawn_uses_role_default_model() {
+        assert_eq!(model_for_role("coder"), SONNET_MODEL);
+        assert_eq!(model_for_role("reviewer"), SONNET_MODEL);
+        assert_eq!(model_for_role("researcher"), SONNET_MODEL);
+        assert_eq!(model_for_role("explorer"), HAIKU_MODEL);
+        assert_eq!(model_for_role("runner"), HAIKU_MODEL);
+        assert_eq!(model_for_role("unknown"), SONNET_MODEL);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn spawn_timeout_returns_error() {
+        let (_dir, oikos) = test_oikos();
+
+        // Use a provider that sleeps longer than the timeout
+        let mut providers = ProviderRegistry::new();
+        providers.register(Box::new(SlowProvider));
+        let svc = SpawnServiceImpl::new(
+            Arc::new(providers),
+            Arc::new(ToolRegistry::new()),
+            oikos,
+        );
+
+        let result = svc
+            .spawn_and_run(
+                SpawnRequest {
+                    role: "coder".to_owned(),
+                    task: "Slow task".to_owned(),
+                    model: None,
+                    allowed_tools: None,
+                    timeout_secs: 1,
+                },
+                "test-parent",
+            )
+            .await
+            .expect("spawn");
+
+        assert!(result.is_error);
+        assert!(result.content.contains("timed out"));
+    }
+
+    struct SlowProvider;
+
+    impl LlmProvider for SlowProvider {
+        fn complete(
+            &self,
+            _request: &CompletionRequest,
+        ) -> aletheia_hermeneus::error::Result<CompletionResponse> {
+            std::thread::sleep(std::time::Duration::from_secs(5));
+            Ok(CompletionResponse {
+                id: "slow".to_owned(),
+                model: "claude-sonnet-4-20250514".to_owned(),
+                stop_reason: StopReason::EndTurn,
+                content: vec![ContentBlock::Text {
+                    text: "late".to_owned(),
+                    citations: None,
+                }],
+                usage: Usage::default(),
+            })
+        }
+
+        fn supported_models(&self) -> &[&str] {
+            &["claude-sonnet-4-20250514"]
+        }
+
+        #[expect(clippy::unnecessary_literal_bound, reason = "trait requires &str")]
+        fn name(&self) -> &str {
+            "slow"
+        }
+    }
+}

--- a/crates/organon/Cargo.toml
+++ b/crates/organon/Cargo.toml
@@ -20,6 +20,7 @@ reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 snafu = { workspace = true }
+tokio = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]

--- a/crates/organon/src/builtins/agent.rs
+++ b/crates/organon/src/builtins/agent.rs
@@ -1,0 +1,470 @@
+//! Agent coordination tool executors: sessions_spawn, sessions_dispatch.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use aletheia_koina::id::ToolName;
+use indexmap::IndexMap;
+
+use super::workspace::{extract_opt_u64, extract_str};
+use crate::error::Result;
+use crate::registry::{ToolExecutor, ToolRegistry};
+use crate::types::{
+    InputSchema, PropertyDef, PropertyType, SpawnRequest, ToolCategory, ToolContext, ToolDef,
+    ToolInput, ToolResult,
+};
+
+const DEFAULT_TIMEOUT_SECS: u64 = 300;
+const MAX_DISPATCH_TASKS: usize = 10;
+
+struct SessionsSpawnExecutor;
+
+impl ToolExecutor for SessionsSpawnExecutor {
+    fn execute<'a>(
+        &'a self,
+        input: &'a ToolInput,
+        ctx: &'a ToolContext,
+    ) -> Pin<Box<dyn Future<Output = Result<ToolResult>> + Send + 'a>> {
+        Box::pin(async {
+            let Some(services) = ctx.services.as_ref() else {
+                return Ok(ToolResult::error("spawn service not available"));
+            };
+            let Some(spawn_svc) = services.spawn.as_ref() else {
+                return Ok(ToolResult::error("spawn service not configured"));
+            };
+
+            let role = extract_str(&input.arguments, "role", &input.name)?;
+            let task = extract_str(&input.arguments, "task", &input.name)?;
+            let model = input
+                .arguments
+                .get("model")
+                .and_then(|v| v.as_str())
+                .map(String::from);
+            let timeout = extract_opt_u64(&input.arguments, "timeoutSeconds")
+                .unwrap_or(DEFAULT_TIMEOUT_SECS);
+
+            let request = SpawnRequest {
+                role: role.to_owned(),
+                task: task.to_owned(),
+                model,
+                allowed_tools: None,
+                timeout_secs: timeout,
+            };
+
+            match spawn_svc
+                .spawn_and_run(request, ctx.nous_id.as_str())
+                .await
+            {
+                Ok(result) => {
+                    let json = serde_json::json!({
+                        "content": result.content,
+                        "is_error": result.is_error,
+                        "input_tokens": result.input_tokens,
+                        "output_tokens": result.output_tokens,
+                    });
+                    Ok(ToolResult::text(json.to_string()))
+                }
+                Err(e) => Ok(ToolResult::error(format!("Spawn failed: {e}"))),
+            }
+        })
+    }
+}
+
+struct SessionsDispatchExecutor;
+
+impl ToolExecutor for SessionsDispatchExecutor {
+    fn execute<'a>(
+        &'a self,
+        input: &'a ToolInput,
+        ctx: &'a ToolContext,
+    ) -> Pin<Box<dyn Future<Output = Result<ToolResult>> + Send + 'a>> {
+        Box::pin(async {
+            let Some(services) = ctx.services.as_ref() else {
+                return Ok(ToolResult::error("spawn service not available"));
+            };
+            let Some(spawn_svc) = services.spawn.as_ref() else {
+                return Ok(ToolResult::error("spawn service not configured"));
+            };
+
+            let tasks = input
+                .arguments
+                .get("tasks")
+                .and_then(|v| v.as_array())
+                .ok_or_else(|| {
+                    crate::error::InvalidInputSnafu {
+                        name: input.name.clone(),
+                        reason: "missing or invalid 'tasks' array".to_owned(),
+                    }
+                    .build()
+                })?;
+
+            if tasks.len() > MAX_DISPATCH_TASKS {
+                return Ok(ToolResult::error(format!(
+                    "Too many tasks: {} (max {MAX_DISPATCH_TASKS})",
+                    tasks.len()
+                )));
+            }
+
+            let default_timeout = extract_opt_u64(&input.arguments, "timeoutSeconds")
+                .unwrap_or(DEFAULT_TIMEOUT_SECS);
+            let nous_id = ctx.nous_id.as_str().to_owned();
+
+            let mut join_set = tokio::task::JoinSet::new();
+
+            for task_val in tasks {
+                let role = task_val
+                    .get("role")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("coder")
+                    .to_owned();
+                let task_text = task_val
+                    .get("task")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_owned();
+                let model = task_val
+                    .get("model")
+                    .and_then(|v| v.as_str())
+                    .map(String::from);
+                let timeout = task_val
+                    .get("timeoutSeconds")
+                    .and_then(serde_json::Value::as_u64)
+                    .unwrap_or(default_timeout);
+
+                let request = SpawnRequest {
+                    role,
+                    task: task_text,
+                    model,
+                    allowed_tools: None,
+                    timeout_secs: timeout,
+                };
+
+                let svc = Arc::clone(spawn_svc);
+                let parent = nous_id.clone();
+                join_set.spawn(async move { svc.spawn_and_run(request, &parent).await });
+            }
+
+            let mut results = Vec::with_capacity(join_set.len());
+            while let Some(join_result) = join_set.join_next().await {
+                match join_result {
+                    Ok(Ok(spawn_result)) => results.push(serde_json::json!({
+                        "content": spawn_result.content,
+                        "is_error": spawn_result.is_error,
+                        "input_tokens": spawn_result.input_tokens,
+                        "output_tokens": spawn_result.output_tokens,
+                    })),
+                    Ok(Err(e)) => results.push(serde_json::json!({
+                        "content": format!("Spawn error: {e}"),
+                        "is_error": true,
+                    })),
+                    Err(e) => results.push(serde_json::json!({
+                        "content": format!("Task panicked: {e}"),
+                        "is_error": true,
+                    })),
+                }
+            }
+
+            Ok(ToolResult::text(
+                serde_json::to_string(&results).unwrap_or_else(|_| "[]".to_owned()),
+            ))
+        })
+    }
+}
+
+/// Register agent coordination tools.
+pub fn register(registry: &mut ToolRegistry) -> Result<()> {
+    registry.register(sessions_spawn_def(), Box::new(SessionsSpawnExecutor))?;
+    registry.register(
+        sessions_dispatch_def(),
+        Box::new(SessionsDispatchExecutor),
+    )?;
+    Ok(())
+}
+
+fn sessions_spawn_def() -> ToolDef {
+    ToolDef {
+        name: ToolName::new("sessions_spawn").expect("valid tool name"),
+        description: "Spawn an ephemeral sub-agent to execute a single task".to_owned(),
+        extended_description: Some(
+            "Creates a temporary agent with a role-appropriate model and tool set. \
+             The sub-agent runs one turn against the task prompt and returns its response. \
+             Use for delegating mechanical work: coding, reviewing, researching, exploring, \
+             or running commands."
+                .to_owned(),
+        ),
+        input_schema: InputSchema {
+            properties: IndexMap::from([
+                (
+                    "role".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::String,
+                        description: "Sub-agent role".to_owned(),
+                        enum_values: Some(vec![
+                            "coder".to_owned(),
+                            "reviewer".to_owned(),
+                            "researcher".to_owned(),
+                            "explorer".to_owned(),
+                            "runner".to_owned(),
+                        ]),
+                        default: None,
+                    },
+                ),
+                (
+                    "task".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::String,
+                        description: "Task instruction for the sub-agent".to_owned(),
+                        enum_values: None,
+                        default: None,
+                    },
+                ),
+                (
+                    "model".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::String,
+                        description: "Model override (default: role-based)".to_owned(),
+                        enum_values: None,
+                        default: None,
+                    },
+                ),
+                (
+                    "timeoutSeconds".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::Number,
+                        description: "Max execution time in seconds (default: 300)".to_owned(),
+                        enum_values: None,
+                        default: Some(serde_json::json!(300)),
+                    },
+                ),
+            ]),
+            required: vec!["role".to_owned(), "task".to_owned()],
+        },
+        category: ToolCategory::Agent,
+        auto_activate: false,
+    }
+}
+
+fn sessions_dispatch_def() -> ToolDef {
+    ToolDef {
+        name: ToolName::new("sessions_dispatch").expect("valid tool name"),
+        description: "Spawn multiple sub-agents in parallel and collect their results".to_owned(),
+        extended_description: Some(
+            "Dispatches an array of tasks to ephemeral sub-agents running concurrently. \
+             Each task specifies a role and instruction. Results are returned as an array \
+             in completion order. Maximum 10 concurrent tasks."
+                .to_owned(),
+        ),
+        input_schema: InputSchema {
+            properties: IndexMap::from([
+                (
+                    "tasks".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::Array,
+                        description:
+                            "Array of task objects: {role, task, model?, timeoutSeconds?}"
+                                .to_owned(),
+                        enum_values: None,
+                        default: None,
+                    },
+                ),
+                (
+                    "timeoutSeconds".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::Number,
+                        description: "Default timeout for all tasks (default: 300)".to_owned(),
+                        enum_values: None,
+                        default: Some(serde_json::json!(300)),
+                    },
+                ),
+            ]),
+            required: vec!["tasks".to_owned()],
+        },
+        category: ToolCategory::Agent,
+        auto_activate: false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+    use std::future::Future;
+    use std::path::PathBuf;
+    use std::pin::Pin;
+    use std::sync::{Arc, RwLock};
+
+    use aletheia_koina::id::{NousId, SessionId, ToolName};
+
+    use crate::registry::ToolRegistry;
+    use crate::types::{SpawnRequest, SpawnResult, SpawnService, ToolContext, ToolInput, ToolServices};
+
+    fn test_ctx() -> ToolContext {
+        ToolContext {
+            nous_id: NousId::new("test-agent").expect("valid"),
+            session_id: SessionId::new(),
+            workspace: PathBuf::from("/tmp/test"),
+            allowed_roots: vec![PathBuf::from("/tmp")],
+            services: None,
+            active_tools: Arc::new(RwLock::new(HashSet::new())),
+        }
+    }
+
+    fn test_ctx_with_spawn(spawn: Arc<dyn SpawnService>) -> ToolContext {
+        ToolContext {
+            nous_id: NousId::new("test-agent").expect("valid"),
+            session_id: SessionId::new(),
+            workspace: PathBuf::from("/tmp/test"),
+            allowed_roots: vec![PathBuf::from("/tmp")],
+            services: Some(Arc::new(ToolServices {
+                cross_nous: None,
+                messenger: None,
+                note_store: None,
+                blackboard_store: None,
+                spawn: Some(spawn),
+                lazy_tool_catalog: vec![],
+                http_client: reqwest::Client::new(),
+            })),
+            active_tools: Arc::new(RwLock::new(HashSet::new())),
+        }
+    }
+
+    #[derive(Default)]
+    struct MockSpawnService;
+
+    impl SpawnService for MockSpawnService {
+        fn spawn_and_run(
+            &self,
+            _request: SpawnRequest,
+            _parent_nous_id: &str,
+        ) -> Pin<Box<dyn Future<Output = Result<SpawnResult, String>> + Send + '_>> {
+            Box::pin(async {
+                Ok(SpawnResult {
+                    content: "mock result".to_owned(),
+                    is_error: false,
+                    input_tokens: 100,
+                    output_tokens: 50,
+                })
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn register_agent_tools() {
+        let mut reg = ToolRegistry::new();
+        super::register(&mut reg).expect("register");
+        assert_eq!(reg.definitions().len(), 2);
+    }
+
+    #[tokio::test]
+    async fn spawn_def_requires_role_and_task() {
+        let mut reg = ToolRegistry::new();
+        super::register(&mut reg).expect("register");
+        let name = ToolName::new("sessions_spawn").expect("valid");
+        let def = reg.get_def(&name).expect("found");
+        assert_eq!(def.input_schema.required, vec!["role", "task"]);
+        assert_eq!(def.category, crate::types::ToolCategory::Agent);
+    }
+
+    #[tokio::test]
+    async fn dispatch_def_requires_tasks() {
+        let mut reg = ToolRegistry::new();
+        super::register(&mut reg).expect("register");
+        let name = ToolName::new("sessions_dispatch").expect("valid");
+        let def = reg.get_def(&name).expect("found");
+        assert_eq!(def.input_schema.required, vec!["tasks"]);
+    }
+
+    #[tokio::test]
+    async fn spawn_missing_service_returns_error() {
+        let mut reg = ToolRegistry::new();
+        super::register(&mut reg).expect("register");
+        let input = ToolInput {
+            name: ToolName::new("sessions_spawn").expect("valid"),
+            tool_use_id: "tu_1".to_owned(),
+            arguments: serde_json::json!({"role": "coder", "task": "write code"}),
+        };
+        let result = reg.execute(&input, &test_ctx()).await.expect("execute");
+        assert!(result.is_error);
+        assert!(result.content.text_summary().contains("not available"));
+    }
+
+    #[tokio::test]
+    async fn spawn_returns_json_result() {
+        let spawn = Arc::new(MockSpawnService);
+        let ctx = test_ctx_with_spawn(spawn);
+        let mut reg = ToolRegistry::new();
+        super::register(&mut reg).expect("register");
+
+        let input = ToolInput {
+            name: ToolName::new("sessions_spawn").expect("valid"),
+            tool_use_id: "tu_1".to_owned(),
+            arguments: serde_json::json!({"role": "coder", "task": "write code"}),
+        };
+        let result = reg.execute(&input, &ctx).await.expect("execute");
+        assert!(!result.is_error);
+
+        let json: serde_json::Value =
+            serde_json::from_str(&result.content.text_summary()).expect("json");
+        assert_eq!(json["content"], "mock result");
+        assert_eq!(json["input_tokens"], 100);
+        assert_eq!(json["output_tokens"], 50);
+    }
+
+    #[tokio::test]
+    async fn dispatch_missing_service_returns_error() {
+        let mut reg = ToolRegistry::new();
+        super::register(&mut reg).expect("register");
+        let input = ToolInput {
+            name: ToolName::new("sessions_dispatch").expect("valid"),
+            tool_use_id: "tu_1".to_owned(),
+            arguments: serde_json::json!({"tasks": [{"role": "coder", "task": "write code"}]}),
+        };
+        let result = reg.execute(&input, &test_ctx()).await.expect("execute");
+        assert!(result.is_error);
+    }
+
+    #[tokio::test]
+    async fn dispatch_rejects_too_many_tasks() {
+        let spawn = Arc::new(MockSpawnService);
+        let ctx = test_ctx_with_spawn(spawn);
+        let mut reg = ToolRegistry::new();
+        super::register(&mut reg).expect("register");
+
+        let tasks: Vec<serde_json::Value> = (0..11)
+            .map(|i| serde_json::json!({"role": "coder", "task": format!("task {i}")}))
+            .collect();
+        let input = ToolInput {
+            name: ToolName::new("sessions_dispatch").expect("valid"),
+            tool_use_id: "tu_1".to_owned(),
+            arguments: serde_json::json!({"tasks": tasks}),
+        };
+        let result = reg.execute(&input, &ctx).await.expect("execute");
+        assert!(result.is_error);
+        assert!(result.content.text_summary().contains("Too many tasks"));
+    }
+
+    #[tokio::test]
+    async fn dispatch_collects_results() {
+        let spawn = Arc::new(MockSpawnService);
+        let ctx = test_ctx_with_spawn(spawn);
+        let mut reg = ToolRegistry::new();
+        super::register(&mut reg).expect("register");
+
+        let input = ToolInput {
+            name: ToolName::new("sessions_dispatch").expect("valid"),
+            tool_use_id: "tu_1".to_owned(),
+            arguments: serde_json::json!({
+                "tasks": [
+                    {"role": "coder", "task": "task 1"},
+                    {"role": "reviewer", "task": "task 2"},
+                ]
+            }),
+        };
+        let result = reg.execute(&input, &ctx).await.expect("execute");
+        assert!(!result.is_error);
+
+        let json: Vec<serde_json::Value> =
+            serde_json::from_str(&result.content.text_summary()).expect("json");
+        assert_eq!(json.len(), 2);
+    }
+}

--- a/crates/organon/src/builtins/communication.rs
+++ b/crates/organon/src/builtins/communication.rs
@@ -448,6 +448,7 @@ mod tests {
             cross_nous: None,
             note_store: None,
             blackboard_store: None,
+            spawn: None,
             http_client: reqwest::Client::new(),
             lazy_tool_catalog: vec![],
             messenger: Some(messenger),
@@ -472,6 +473,7 @@ mod tests {
             cross_nous: None,
             note_store: None,
             blackboard_store: None,
+            spawn: None,
             http_client: reqwest::Client::new(),
             lazy_tool_catalog: vec![],
             messenger: Some(messenger),
@@ -503,6 +505,7 @@ mod tests {
             messenger: None,
                     note_store: None,
             blackboard_store: None,
+            spawn: None,
             http_client: reqwest::Client::new(),
             lazy_tool_catalog: vec![],
         });
@@ -534,6 +537,7 @@ mod tests {
             messenger: None,
                     note_store: None,
             blackboard_store: None,
+            spawn: None,
             http_client: reqwest::Client::new(),
             lazy_tool_catalog: vec![],
         });
@@ -560,6 +564,7 @@ mod tests {
             messenger: None,
                     note_store: None,
             blackboard_store: None,
+            spawn: None,
             http_client: reqwest::Client::new(),
             lazy_tool_catalog: vec![],
         });
@@ -584,6 +589,7 @@ mod tests {
             messenger: None,
                     note_store: None,
             blackboard_store: None,
+            spawn: None,
             http_client: reqwest::Client::new(),
             lazy_tool_catalog: vec![],
         });

--- a/crates/organon/src/builtins/memory.rs
+++ b/crates/organon/src/builtins/memory.rs
@@ -576,6 +576,7 @@ mod tests {
                 messenger: None,
                 note_store: Some(note_store),
                 blackboard_store: Some(bb_store),
+                spawn: None,
                 http_client: reqwest::Client::new(),
                 lazy_tool_catalog: vec![],
             })),

--- a/crates/organon/src/builtins/mod.rs
+++ b/crates/organon/src/builtins/mod.rs
@@ -1,5 +1,7 @@
 //! Built-in tool executors and stubs.
 
+/// Agent coordination tools (spawn, dispatch).
+pub mod agent;
 /// Inter-agent communication tools (send_message, broadcast).
 pub mod communication;
 /// Dynamic tool activation meta-tool.
@@ -25,6 +27,7 @@ pub fn register_all(registry: &mut ToolRegistry) -> Result<()> {
     communication::register(registry)?;
     filesystem::register(registry)?;
     view_file::register(registry)?;
+    agent::register(registry)?;
     enable_tool::register(registry)?;
     research::register(registry)?;
     Ok(())

--- a/crates/organon/src/types.rs
+++ b/crates/organon/src/types.rs
@@ -290,6 +290,7 @@ pub struct ToolServices {
     pub messenger: Option<Arc<dyn MessageService>>,
     pub note_store: Option<Arc<dyn NoteStore>>,
     pub blackboard_store: Option<Arc<dyn BlackboardStore>>,
+    pub spawn: Option<Arc<dyn SpawnService>>,
     pub http_client: reqwest::Client,
     /// Catalog of lazy tools available for activation via `enable_tool`.
     pub lazy_tool_catalog: Vec<(ToolName, String)>,
@@ -302,6 +303,7 @@ impl std::fmt::Debug for ToolServices {
             .field("messenger", &self.messenger.is_some())
             .field("note_store", &self.note_store.is_some())
             .field("blackboard_store", &self.blackboard_store.is_some())
+            .field("spawn", &self.spawn.is_some())
             .field("lazy_tool_catalog_len", &self.lazy_tool_catalog.len())
             .finish_non_exhaustive()
     }
@@ -387,6 +389,44 @@ pub struct BlackboardEntry {
     pub ttl_seconds: i64,
     pub created_at: String,
     pub expires_at: Option<String>,
+}
+
+/// Request to spawn an ephemeral sub-agent.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SpawnRequest {
+    /// Role identifier (coder, reviewer, researcher, explorer, runner).
+    pub role: String,
+    /// Task prompt sent as the single turn.
+    pub task: String,
+    /// Model override (None = role-based default).
+    pub model: Option<String>,
+    /// Tool name whitelist (None = role-based defaults).
+    pub allowed_tools: Option<Vec<String>>,
+    /// Maximum seconds before the sub-agent is killed.
+    pub timeout_secs: u64,
+}
+
+/// Result from an ephemeral sub-agent's single turn.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SpawnResult {
+    /// The sub-agent's text response.
+    pub content: String,
+    /// Whether the sub-agent encountered an error.
+    pub is_error: bool,
+    /// Input tokens consumed.
+    pub input_tokens: u64,
+    /// Output tokens produced.
+    pub output_tokens: u64,
+}
+
+/// Ephemeral sub-agent spawning for tool executors.
+pub trait SpawnService: Send + Sync {
+    /// Spawn an ephemeral actor, run one turn, collect the result, shut down.
+    fn spawn_and_run(
+        &self,
+        request: SpawnRequest,
+        parent_nous_id: &str,
+    ) -> Pin<Box<dyn Future<Output = Result<SpawnResult, String>> + Send + '_>>;
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

- Add `sessions_spawn` tool: spawn a single ephemeral sub-agent with role-appropriate model (coder/reviewer/researcher use Sonnet, explorer/runner use Haiku)
- Add `sessions_dispatch` tool: spawn up to 10 sub-agents in parallel via JoinSet, collect results
- Add `SpawnService` trait in organon (mirrors `CrossNousService` pattern) with `SpawnServiceImpl` in nous that calls `actor::spawn` directly

## Design

- Sub-agents run one turn and die: no session persistence, no cross-nous registration, no bootstrap
- Recursive spawn prevented: sub-agents get `tool_services: None`
- Ephemeral workspace created with minimal SOUL.md, cleaned up after completion
- Timeout via `tokio::time::timeout` wrapping `handle.send_turn()`

## Files changed

| File | Change |
|------|--------|
| `crates/organon/src/types.rs` | `SpawnService` trait, `SpawnRequest`, `SpawnResult`, `spawn` field on `ToolServices` |
| `crates/organon/src/builtins/agent.rs` | NEW: `sessions_spawn` + `sessions_dispatch` executors + tests |
| `crates/organon/src/builtins/mod.rs` | Register agent module |
| `crates/nous/src/spawn_svc.rs` | NEW: `SpawnServiceImpl` bridging trait to `actor::spawn` + tests |
| `crates/nous/src/lib.rs` | Export `spawn_svc` module |
| `crates/aletheia/src/main.rs` | Wire `SpawnServiceImpl` into `ToolServices` |
| `crates/organon/src/builtins/{communication,memory}.rs` | Add `spawn: None` to test ToolServices |

## Test plan

- [x] `cargo clippy --workspace --all-targets -- -D warnings` (zero errors)
- [x] `cargo test -p aletheia-organon` (82 passed)
- [x] `cargo test -p aletheia-nous` (197 passed, including 3 new spawn_svc tests)
- [x] `cargo test --workspace` (1079 passed, 0 failed)