### PR TITLE
feat(organon): dianoia planning tool executors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,6 +42,7 @@ name = "aletheia"
 version = "0.10.0"
 dependencies = [
  "aletheia-agora",
+ "aletheia-dianoia",
  "aletheia-dokimion",
  "aletheia-hermeneus",
  "aletheia-koina",
@@ -64,6 +65,7 @@ dependencies = [
  "serde",
  "serde_json",
  "supports-color",
+ "tempfile",
  "time",
  "tokio",
  "tracing",

--- a/crates/aletheia/Cargo.toml
+++ b/crates/aletheia/Cargo.toml
@@ -21,6 +21,7 @@ tls = ["aletheia-pylon/tls"]
 tui = ["dep:aletheia-tui"]
 
 [dependencies]
+aletheia-dianoia = { path = "../dianoia" }
 aletheia-oikonomos = { path = "../daemon" }
 aletheia-koina = { path = "../koina" }
 aletheia-taxis = { path = "../taxis" }
@@ -52,6 +53,9 @@ rcgen = { workspace = true }
 time = "0.3"
 owo-colors = "4"
 supports-color = "3"
+
+[dev-dependencies]
+tempfile = "3"
 
 [lints]
 workspace = true

--- a/crates/aletheia/src/main.rs
+++ b/crates/aletheia/src/main.rs
@@ -2,6 +2,7 @@
 
 mod daemon_bridge;
 mod dispatch;
+mod planning_adapter;
 mod status;
 
 use std::path::{Path, PathBuf};
@@ -510,12 +511,16 @@ async fn serve(cli: Cli) -> Result<()> {
                 Arc::clone(&tool_registry),
                 Arc::clone(&oikos_arc),
             )));
+        let planning_root = oikos_arc.data().join("planning");
+        let planning: Option<Arc<dyn aletheia_organon::types::PlanningService>> =
+            Some(Arc::new(planning_adapter::FilesystemPlanningService::new(planning_root)));
         Arc::new(ToolServices {
             cross_nous: Some(cross_nous),
             messenger,
             note_store,
             blackboard_store,
             spawn,
+            planning,
             http_client: reqwest::Client::new(),
             lazy_tool_catalog: tool_registry.lazy_tool_catalog(),
         })

--- a/crates/aletheia/src/planning_adapter.rs
+++ b/crates/aletheia/src/planning_adapter.rs
@@ -1,0 +1,406 @@
+//! Filesystem-backed adapter for the `PlanningService` trait.
+
+use std::future::Future;
+use std::path::{Path, PathBuf};
+use std::pin::Pin;
+
+use aletheia_dianoia::phase::Phase;
+use aletheia_dianoia::plan::PlanState;
+use aletheia_dianoia::project::{Project, ProjectMode};
+use aletheia_dianoia::state::{ProjectState, Transition};
+use aletheia_dianoia::workspace::ProjectWorkspace;
+use aletheia_organon::types::PlanningService;
+
+pub struct FilesystemPlanningService {
+    projects_root: PathBuf,
+}
+
+impl FilesystemPlanningService {
+    pub fn new(projects_root: PathBuf) -> Self {
+        Self { projects_root }
+    }
+}
+
+impl PlanningService for FilesystemPlanningService {
+    fn create_project(
+        &self,
+        name: &str,
+        description: &str,
+        scope: Option<&str>,
+        mode: &str,
+        appetite_minutes: Option<u32>,
+        owner: &str,
+    ) -> Pin<Box<dyn Future<Output = Result<String, String>> + Send + '_>> {
+        let root = self.projects_root.clone();
+        let name = name.to_owned();
+        let description = description.to_owned();
+        let scope = scope.map(str::to_owned);
+        let mode_str = mode.to_owned();
+        let owner = owner.to_owned();
+        Box::pin(async move {
+            tokio::task::spawn_blocking(move || {
+                let mode = parse_mode(&mode_str, appetite_minutes)?;
+                let mut project = Project::new(name, description, mode, owner);
+                if let Some(s) = scope {
+                    project.scope = Some(s);
+                }
+                let ws_path = root.join(project.id.to_string());
+                let ws = ProjectWorkspace::create(&ws_path).map_err(|e| e.to_string())?;
+                ws.save_project(&project).map_err(|e| e.to_string())?;
+                serde_json::to_string_pretty(&project).map_err(|e| e.to_string())
+            })
+            .await
+            .map_err(|e| e.to_string())?
+        })
+    }
+
+    fn load_project(
+        &self,
+        project_id: &str,
+    ) -> Pin<Box<dyn Future<Output = Result<String, String>> + Send + '_>> {
+        let root = self.projects_root.clone();
+        let project_id = project_id.to_owned();
+        Box::pin(async move {
+            tokio::task::spawn_blocking(move || {
+                let ws_path = root.join(&project_id);
+                let ws = ProjectWorkspace::open(&ws_path).map_err(|e| e.to_string())?;
+                let project = ws.load_project().map_err(|e| e.to_string())?;
+                serde_json::to_string_pretty(&project).map_err(|e| e.to_string())
+            })
+            .await
+            .map_err(|e| e.to_string())?
+        })
+    }
+
+    fn transition_project(
+        &self,
+        project_id: &str,
+        transition: &str,
+    ) -> Pin<Box<dyn Future<Output = Result<String, String>> + Send + '_>> {
+        let root = self.projects_root.clone();
+        let project_id = project_id.to_owned();
+        let transition_str = transition.to_owned();
+        Box::pin(async move {
+            tokio::task::spawn_blocking(move || {
+                let ws_path = root.join(&project_id);
+                let ws = ProjectWorkspace::open(&ws_path).map_err(|e| e.to_string())?;
+                let mut project = ws.load_project().map_err(|e| e.to_string())?;
+                let transition =
+                    parse_transition(&transition_str).ok_or_else(|| {
+                        format!("unknown transition: {transition_str}")
+                    })?;
+                project.advance(transition).map_err(|e| e.to_string())?;
+                ws.save_project(&project).map_err(|e| e.to_string())?;
+                serde_json::to_string_pretty(&project).map_err(|e| e.to_string())
+            })
+            .await
+            .map_err(|e| e.to_string())?
+        })
+    }
+
+    fn add_phase(
+        &self,
+        project_id: &str,
+        name: &str,
+        goal: &str,
+    ) -> Pin<Box<dyn Future<Output = Result<String, String>> + Send + '_>> {
+        let root = self.projects_root.clone();
+        let project_id = project_id.to_owned();
+        let name = name.to_owned();
+        let goal = goal.to_owned();
+        Box::pin(async move {
+            tokio::task::spawn_blocking(move || {
+                let ws_path = root.join(&project_id);
+                let ws = ProjectWorkspace::open(&ws_path).map_err(|e| e.to_string())?;
+                let mut project = ws.load_project().map_err(|e| e.to_string())?;
+                #[expect(clippy::cast_possible_truncation, reason = "phase count fits in u32")]
+                let order = project.phases.len() as u32 + 1;
+                let phase = Phase::new(name, goal, order);
+                project.add_phase(phase);
+                ws.save_project(&project).map_err(|e| e.to_string())?;
+                serde_json::to_string_pretty(&project).map_err(|e| e.to_string())
+            })
+            .await
+            .map_err(|e| e.to_string())?
+        })
+    }
+
+    fn complete_plan(
+        &self,
+        project_id: &str,
+        phase_id: &str,
+        plan_id: &str,
+        achievement: Option<&str>,
+    ) -> Pin<Box<dyn Future<Output = Result<String, String>> + Send + '_>> {
+        let root = self.projects_root.clone();
+        let project_id = project_id.to_owned();
+        let phase_id = phase_id.to_owned();
+        let plan_id = plan_id.to_owned();
+        let achievement = achievement.map(str::to_owned);
+        Box::pin(async move {
+            tokio::task::spawn_blocking(move || {
+                let ws_path = root.join(&project_id);
+                let ws = ProjectWorkspace::open(&ws_path).map_err(|e| e.to_string())?;
+                let mut project = ws.load_project().map_err(|e| e.to_string())?;
+                let plan = find_plan_mut(&mut project, &phase_id, &plan_id)?;
+                plan.state = PlanState::Complete;
+                if let Some(a) = achievement {
+                    plan.achievements.push(a);
+                }
+                ws.save_project(&project).map_err(|e| e.to_string())?;
+                serde_json::to_string_pretty(&project).map_err(|e| e.to_string())
+            })
+            .await
+            .map_err(|e| e.to_string())?
+        })
+    }
+
+    fn fail_plan(
+        &self,
+        project_id: &str,
+        phase_id: &str,
+        plan_id: &str,
+        reason: &str,
+    ) -> Pin<Box<dyn Future<Output = Result<String, String>> + Send + '_>> {
+        let root = self.projects_root.clone();
+        let project_id = project_id.to_owned();
+        let phase_id = phase_id.to_owned();
+        let plan_id = plan_id.to_owned();
+        let reason = reason.to_owned();
+        Box::pin(async move {
+            tokio::task::spawn_blocking(move || {
+                let ws_path = root.join(&project_id);
+                let ws = ProjectWorkspace::open(&ws_path).map_err(|e| e.to_string())?;
+                let mut project = ws.load_project().map_err(|e| e.to_string())?;
+                let plan = find_plan_mut(&mut project, &phase_id, &plan_id)?;
+                plan.state = PlanState::Failed;
+                plan.blockers.push(aletheia_dianoia::plan::Blocker {
+                    description: reason,
+                    plan_id: plan.id,
+                    detected_at: jiff::Timestamp::now(),
+                });
+                ws.save_project(&project).map_err(|e| e.to_string())?;
+                serde_json::to_string_pretty(&project).map_err(|e| e.to_string())
+            })
+            .await
+            .map_err(|e| e.to_string())?
+        })
+    }
+
+    fn list_projects(
+        &self,
+    ) -> Pin<Box<dyn Future<Output = Result<String, String>> + Send + '_>> {
+        let root = self.projects_root.clone();
+        Box::pin(async move {
+            tokio::task::spawn_blocking(move || list_projects_sync(&root))
+                .await
+                .map_err(|e| e.to_string())?
+        })
+    }
+}
+
+fn parse_mode(mode: &str, appetite_minutes: Option<u32>) -> Result<ProjectMode, String> {
+    match mode {
+        "full" => Ok(ProjectMode::Full),
+        "quick" => {
+            let minutes = appetite_minutes.unwrap_or(30);
+            Ok(ProjectMode::Quick {
+                appetite_minutes: minutes,
+            })
+        }
+        "background" => Ok(ProjectMode::Background),
+        other => Err(format!("unknown mode: {other}")),
+    }
+}
+
+fn parse_transition(s: &str) -> Option<Transition> {
+    Some(match s {
+        "start_questioning" => Transition::StartQuestioning,
+        "start_research" => Transition::StartResearch,
+        "skip_research" => Transition::SkipResearch,
+        "skip_to_research" => Transition::SkipToResearch,
+        "start_scoping" => Transition::StartScoping,
+        "start_planning" => Transition::StartPlanning,
+        "start_discussion" => Transition::StartDiscussion,
+        "start_execution" => Transition::StartExecution,
+        "start_verification" => Transition::StartVerification,
+        "complete" => Transition::Complete,
+        "abandon" => Transition::Abandon,
+        "pause" => Transition::Pause,
+        "resume" => Transition::Resume,
+        "revert_to_scoping" => Transition::Revert {
+            to: ProjectState::Scoping,
+        },
+        "revert_to_planning" => Transition::Revert {
+            to: ProjectState::Planning,
+        },
+        "revert_to_executing" => Transition::Revert {
+            to: ProjectState::Executing,
+        },
+        _ => return None,
+    })
+}
+
+fn find_plan_mut<'a>(
+    project: &'a mut Project,
+    phase_id: &str,
+    plan_id: &str,
+) -> Result<&'a mut aletheia_dianoia::plan::Plan, String> {
+    let phase_ulid: ulid::Ulid = phase_id.parse().map_err(|e| format!("invalid phase_id: {e}"))?;
+    let plan_ulid: ulid::Ulid = plan_id.parse().map_err(|e| format!("invalid plan_id: {e}"))?;
+
+    let phase = project
+        .phases
+        .iter_mut()
+        .find(|p| p.id == phase_ulid)
+        .ok_or_else(|| format!("phase not found: {phase_id}"))?;
+
+    phase
+        .plans
+        .iter_mut()
+        .find(|p| p.id == plan_ulid)
+        .ok_or_else(|| format!("plan not found: {plan_id}"))
+}
+
+fn list_projects_sync(root: &Path) -> Result<String, String> {
+    if !root.exists() {
+        return Ok("[]".to_owned());
+    }
+
+    let entries = std::fs::read_dir(root).map_err(|e| e.to_string())?;
+    let mut summaries = Vec::new();
+
+    for entry in entries {
+        let entry = entry.map_err(|e| e.to_string())?;
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+        let project_file = path.join("PROJECT.json");
+        if !project_file.exists() {
+            continue;
+        }
+        let contents = std::fs::read_to_string(&project_file).map_err(|e| e.to_string())?;
+        let project: Project = match serde_json::from_str(&contents) {
+            Ok(p) => p,
+            Err(_) => continue,
+        };
+        summaries.push(serde_json::json!({
+            "id": project.id.to_string(),
+            "name": project.name,
+            "state": format!("{:?}", project.state),
+            "mode": format!("{:?}", project.mode),
+            "owner": project.owner,
+            "phase_count": project.phases.len(),
+            "updated_at": project.updated_at.to_string(),
+        }));
+    }
+
+    serde_json::to_string_pretty(&summaries).map_err(|e| e.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn create_and_load_roundtrip() {
+        let dir = tempfile::tempdir().unwrap();
+        let service = FilesystemPlanningService::new(dir.path().to_path_buf());
+
+        let json = service
+            .create_project("test-project", "a test", None, "full", None, "syn")
+            .await
+            .expect("create");
+
+        let project: serde_json::Value = serde_json::from_str(&json).unwrap();
+        let project_id = project["id"].as_str().unwrap();
+
+        let loaded_json = service
+            .load_project(project_id)
+            .await
+            .expect("load");
+
+        let loaded: serde_json::Value = serde_json::from_str(&loaded_json).unwrap();
+        assert_eq!(loaded["name"], "test-project");
+        assert_eq!(loaded["state"], "Created");
+    }
+
+    #[tokio::test]
+    async fn transition_advances_state() {
+        let dir = tempfile::tempdir().unwrap();
+        let service = FilesystemPlanningService::new(dir.path().to_path_buf());
+
+        let json = service
+            .create_project("test", "desc", None, "full", None, "syn")
+            .await
+            .unwrap();
+        let project: serde_json::Value = serde_json::from_str(&json).unwrap();
+        let id = project["id"].as_str().unwrap();
+
+        let json = service
+            .transition_project(id, "start_questioning")
+            .await
+            .unwrap();
+        let project: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(project["state"], "Questioning");
+    }
+
+    #[tokio::test]
+    async fn invalid_transition_returns_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let service = FilesystemPlanningService::new(dir.path().to_path_buf());
+
+        let json = service
+            .create_project("test", "desc", None, "full", None, "syn")
+            .await
+            .unwrap();
+        let project: serde_json::Value = serde_json::from_str(&json).unwrap();
+        let id = project["id"].as_str().unwrap();
+
+        let result = service
+            .transition_project(id, "start_verification")
+            .await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn add_phase_appends() {
+        let dir = tempfile::tempdir().unwrap();
+        let service = FilesystemPlanningService::new(dir.path().to_path_buf());
+
+        let json = service
+            .create_project("test", "desc", None, "full", None, "syn")
+            .await
+            .unwrap();
+        let project: serde_json::Value = serde_json::from_str(&json).unwrap();
+        let id = project["id"].as_str().unwrap();
+
+        let json = service
+            .add_phase(id, "Foundation", "Set up core")
+            .await
+            .unwrap();
+        let project: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(project["phases"].as_array().unwrap().len(), 1);
+        assert_eq!(project["phases"][0]["name"], "Foundation");
+    }
+
+    #[tokio::test]
+    async fn list_projects_returns_summaries() {
+        let dir = tempfile::tempdir().unwrap();
+        let service = FilesystemPlanningService::new(dir.path().to_path_buf());
+
+        service
+            .create_project("proj1", "first", None, "full", None, "syn")
+            .await
+            .unwrap();
+        service
+            .create_project("proj2", "second", None, "quick", Some(15), "syn")
+            .await
+            .unwrap();
+
+        let json = service.list_projects().await.unwrap();
+        let list: Vec<serde_json::Value> = serde_json::from_str(&json).unwrap();
+        assert_eq!(list.len(), 2);
+    }
+}

--- a/crates/organon/src/builtins/communication.rs
+++ b/crates/organon/src/builtins/communication.rs
@@ -449,6 +449,7 @@ mod tests {
             note_store: None,
             blackboard_store: None,
             spawn: None,
+            planning: None,
             http_client: reqwest::Client::new(),
             lazy_tool_catalog: vec![],
             messenger: Some(messenger),
@@ -474,6 +475,7 @@ mod tests {
             note_store: None,
             blackboard_store: None,
             spawn: None,
+            planning: None,
             http_client: reqwest::Client::new(),
             lazy_tool_catalog: vec![],
             messenger: Some(messenger),
@@ -503,9 +505,10 @@ mod tests {
         let ctx = test_ctx_with_services(ToolServices {
             cross_nous: Some(cross),
             messenger: None,
-                    note_store: None,
+            note_store: None,
             blackboard_store: None,
             spawn: None,
+            planning: None,
             http_client: reqwest::Client::new(),
             lazy_tool_catalog: vec![],
         });
@@ -535,9 +538,10 @@ mod tests {
         let ctx = test_ctx_with_services(ToolServices {
             cross_nous: Some(cross),
             messenger: None,
-                    note_store: None,
+            note_store: None,
             blackboard_store: None,
             spawn: None,
+            planning: None,
             http_client: reqwest::Client::new(),
             lazy_tool_catalog: vec![],
         });
@@ -562,9 +566,10 @@ mod tests {
         let ctx = test_ctx_with_services(ToolServices {
             cross_nous: Some(cross),
             messenger: None,
-                    note_store: None,
+            note_store: None,
             blackboard_store: None,
             spawn: None,
+            planning: None,
             http_client: reqwest::Client::new(),
             lazy_tool_catalog: vec![],
         });
@@ -587,9 +592,10 @@ mod tests {
         let ctx = test_ctx_with_services(ToolServices {
             cross_nous: Some(cross),
             messenger: None,
-                    note_store: None,
+            note_store: None,
             blackboard_store: None,
             spawn: None,
+            planning: None,
             http_client: reqwest::Client::new(),
             lazy_tool_catalog: vec![],
         });

--- a/crates/organon/src/builtins/memory.rs
+++ b/crates/organon/src/builtins/memory.rs
@@ -577,6 +577,7 @@ mod tests {
                 note_store: Some(note_store),
                 blackboard_store: Some(bb_store),
                 spawn: None,
+                planning: None,
                 http_client: reqwest::Client::new(),
                 lazy_tool_catalog: vec![],
             })),

--- a/crates/organon/src/builtins/mod.rs
+++ b/crates/organon/src/builtins/mod.rs
@@ -10,6 +10,8 @@ pub mod enable_tool;
 pub mod filesystem;
 /// Knowledge graph and session memory tools (remember, recall).
 pub mod memory;
+/// Planning project management tools (create, status, execute, verify).
+pub mod planning;
 /// Web research tools (web_search, web_fetch).
 pub mod research;
 /// File viewing with multimodal support (images, PDFs, text).
@@ -29,6 +31,7 @@ pub fn register_all(registry: &mut ToolRegistry) -> Result<()> {
     view_file::register(registry)?;
     agent::register(registry)?;
     enable_tool::register(registry)?;
+    planning::register(registry)?;
     research::register(registry)?;
     Ok(())
 }

--- a/crates/organon/src/builtins/planning.rs
+++ b/crates/organon/src/builtins/planning.rs
@@ -1,0 +1,1266 @@
+//! Planning tool executors for dianoia project management.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use aletheia_koina::id::ToolName;
+use indexmap::IndexMap;
+
+use super::workspace::{extract_opt_bool, extract_opt_u64, extract_str};
+use crate::error::Result;
+use crate::registry::{ToolExecutor, ToolRegistry};
+use crate::types::{
+    InputSchema, PlanningService, PropertyDef, PropertyType, ToolCategory, ToolContext, ToolDef,
+    ToolInput, ToolResult,
+};
+
+fn require_planning(
+    ctx: &ToolContext,
+) -> std::result::Result<&Arc<dyn PlanningService>, ToolResult> {
+    ctx.services
+        .as_deref()
+        .and_then(|s| s.planning.as_ref())
+        .ok_or_else(|| ToolResult::error("planning service not configured"))
+}
+
+// --- Executors ---
+
+struct PlanCreateExecutor;
+
+impl ToolExecutor for PlanCreateExecutor {
+    fn execute<'a>(
+        &'a self,
+        input: &'a ToolInput,
+        ctx: &'a ToolContext,
+    ) -> Pin<Box<dyn Future<Output = Result<ToolResult>> + Send + 'a>> {
+        Box::pin(async {
+            let planning = match require_planning(ctx) {
+                Ok(p) => p,
+                Err(r) => return Ok(r),
+            };
+            let name = extract_str(&input.arguments, "name", &input.name)?;
+            let description = extract_str(&input.arguments, "description", &input.name)?;
+            let scope = input.arguments.get("scope").and_then(|v| v.as_str());
+            let mode = input
+                .arguments
+                .get("mode")
+                .and_then(|v| v.as_str())
+                .unwrap_or("full");
+            #[expect(clippy::cast_possible_truncation, reason = "appetite_minutes fits in u32")]
+            let appetite_minutes = extract_opt_u64(&input.arguments, "appetite_minutes")
+                .map(|v| v as u32);
+
+            match planning
+                .create_project(name, description, scope, mode, appetite_minutes, ctx.nous_id.as_str())
+                .await
+            {
+                Ok(json) => Ok(ToolResult::text(json)),
+                Err(e) => Ok(ToolResult::error(e)),
+            }
+        })
+    }
+}
+
+struct PlanResearchExecutor;
+
+impl ToolExecutor for PlanResearchExecutor {
+    fn execute<'a>(
+        &'a self,
+        input: &'a ToolInput,
+        ctx: &'a ToolContext,
+    ) -> Pin<Box<dyn Future<Output = Result<ToolResult>> + Send + 'a>> {
+        Box::pin(async {
+            let planning = match require_planning(ctx) {
+                Ok(p) => p,
+                Err(r) => return Ok(r),
+            };
+            let project_id = extract_str(&input.arguments, "project_id", &input.name)?;
+            let skip = extract_opt_bool(&input.arguments, "skip").unwrap_or(false);
+
+            let transition = if skip { "skip_research" } else { "start_research" };
+            match planning.transition_project(project_id, transition).await {
+                Ok(json) => Ok(ToolResult::text(json)),
+                Err(e) => Ok(ToolResult::error(e)),
+            }
+        })
+    }
+}
+
+struct PlanRequirementsExecutor;
+
+impl ToolExecutor for PlanRequirementsExecutor {
+    fn execute<'a>(
+        &'a self,
+        input: &'a ToolInput,
+        ctx: &'a ToolContext,
+    ) -> Pin<Box<dyn Future<Output = Result<ToolResult>> + Send + 'a>> {
+        Box::pin(async {
+            let planning = match require_planning(ctx) {
+                Ok(p) => p,
+                Err(r) => return Ok(r),
+            };
+            let project_id = extract_str(&input.arguments, "project_id", &input.name)?;
+            let action = extract_str(&input.arguments, "action", &input.name)?;
+
+            let transition = match action {
+                "start_scoping" => "start_scoping",
+                "complete" => "start_planning",
+                other => return Ok(ToolResult::error(format!("unknown action: {other}"))),
+            };
+            match planning.transition_project(project_id, transition).await {
+                Ok(json) => Ok(ToolResult::text(json)),
+                Err(e) => Ok(ToolResult::error(e)),
+            }
+        })
+    }
+}
+
+struct PlanRoadmapExecutor;
+
+impl ToolExecutor for PlanRoadmapExecutor {
+    fn execute<'a>(
+        &'a self,
+        input: &'a ToolInput,
+        ctx: &'a ToolContext,
+    ) -> Pin<Box<dyn Future<Output = Result<ToolResult>> + Send + 'a>> {
+        Box::pin(async {
+            let planning = match require_planning(ctx) {
+                Ok(p) => p,
+                Err(r) => return Ok(r),
+            };
+            let project_id = extract_str(&input.arguments, "project_id", &input.name)?;
+            let action = extract_str(&input.arguments, "action", &input.name)?;
+
+            match action {
+                "add_phase" => {
+                    let phase_name =
+                        extract_str(&input.arguments, "phase_name", &input.name)?;
+                    let phase_goal =
+                        extract_str(&input.arguments, "phase_goal", &input.name)?;
+                    match planning.add_phase(project_id, phase_name, phase_goal).await {
+                        Ok(json) => Ok(ToolResult::text(json)),
+                        Err(e) => Ok(ToolResult::error(e)),
+                    }
+                }
+                "start_discussion" => {
+                    match planning
+                        .transition_project(project_id, "start_discussion")
+                        .await
+                    {
+                        Ok(json) => Ok(ToolResult::text(json)),
+                        Err(e) => Ok(ToolResult::error(e)),
+                    }
+                }
+                "start_execution" => {
+                    match planning
+                        .transition_project(project_id, "start_execution")
+                        .await
+                    {
+                        Ok(json) => Ok(ToolResult::text(json)),
+                        Err(e) => Ok(ToolResult::error(e)),
+                    }
+                }
+                other => Ok(ToolResult::error(format!("unknown action: {other}"))),
+            }
+        })
+    }
+}
+
+struct PlanDiscussExecutor;
+
+impl ToolExecutor for PlanDiscussExecutor {
+    fn execute<'a>(
+        &'a self,
+        input: &'a ToolInput,
+        ctx: &'a ToolContext,
+    ) -> Pin<Box<dyn Future<Output = Result<ToolResult>> + Send + 'a>> {
+        Box::pin(async {
+            let planning = match require_planning(ctx) {
+                Ok(p) => p,
+                Err(r) => return Ok(r),
+            };
+            let project_id = extract_str(&input.arguments, "project_id", &input.name)?;
+            let action = extract_str(&input.arguments, "action", &input.name)?;
+
+            let transition = match action {
+                "complete" => "start_execution",
+                other => return Ok(ToolResult::error(format!("unknown action: {other}"))),
+            };
+            match planning.transition_project(project_id, transition).await {
+                Ok(json) => Ok(ToolResult::text(json)),
+                Err(e) => Ok(ToolResult::error(e)),
+            }
+        })
+    }
+}
+
+struct PlanExecuteExecutor;
+
+impl ToolExecutor for PlanExecuteExecutor {
+    fn execute<'a>(
+        &'a self,
+        input: &'a ToolInput,
+        ctx: &'a ToolContext,
+    ) -> Pin<Box<dyn Future<Output = Result<ToolResult>> + Send + 'a>> {
+        Box::pin(async {
+            let planning = match require_planning(ctx) {
+                Ok(p) => p,
+                Err(r) => return Ok(r),
+            };
+            let project_id = extract_str(&input.arguments, "project_id", &input.name)?;
+            let action = extract_str(&input.arguments, "action", &input.name)?;
+
+            let transition = match action {
+                "start" => "start_execution",
+                "pause" => "pause",
+                "resume" => "resume",
+                "abandon" => "abandon",
+                "start_verification" => "start_verification",
+                other => return Ok(ToolResult::error(format!("unknown action: {other}"))),
+            };
+            match planning.transition_project(project_id, transition).await {
+                Ok(json) => Ok(ToolResult::text(json)),
+                Err(e) => Ok(ToolResult::error(e)),
+            }
+        })
+    }
+}
+
+struct PlanVerifyExecutor;
+
+impl ToolExecutor for PlanVerifyExecutor {
+    fn execute<'a>(
+        &'a self,
+        input: &'a ToolInput,
+        ctx: &'a ToolContext,
+    ) -> Pin<Box<dyn Future<Output = Result<ToolResult>> + Send + 'a>> {
+        Box::pin(async {
+            let planning = match require_planning(ctx) {
+                Ok(p) => p,
+                Err(r) => return Ok(r),
+            };
+            let project_id = extract_str(&input.arguments, "project_id", &input.name)?;
+            let action = extract_str(&input.arguments, "action", &input.name)?;
+
+            let transition = match action {
+                "complete" => "complete",
+                "revert" => {
+                    let revert_to =
+                        extract_str(&input.arguments, "revert_to", &input.name)?;
+                    match revert_to {
+                        "scoping" => "revert_to_scoping",
+                        "planning" => "revert_to_planning",
+                        "executing" => "revert_to_executing",
+                        other => {
+                            return Ok(ToolResult::error(format!(
+                                "invalid revert target: {other}"
+                            )))
+                        }
+                    }
+                }
+                other => return Ok(ToolResult::error(format!("unknown action: {other}"))),
+            };
+            match planning.transition_project(project_id, transition).await {
+                Ok(json) => Ok(ToolResult::text(json)),
+                Err(e) => Ok(ToolResult::error(e)),
+            }
+        })
+    }
+}
+
+struct PlanStatusExecutor;
+
+impl ToolExecutor for PlanStatusExecutor {
+    fn execute<'a>(
+        &'a self,
+        input: &'a ToolInput,
+        ctx: &'a ToolContext,
+    ) -> Pin<Box<dyn Future<Output = Result<ToolResult>> + Send + 'a>> {
+        Box::pin(async {
+            let planning = match require_planning(ctx) {
+                Ok(p) => p,
+                Err(r) => return Ok(r),
+            };
+            let project_id = extract_str(&input.arguments, "project_id", &input.name)?;
+
+            match planning.load_project(project_id).await {
+                Ok(json) => Ok(ToolResult::text(json)),
+                Err(e) => Ok(ToolResult::error(e)),
+            }
+        })
+    }
+}
+
+struct PlanStepCompleteExecutor;
+
+impl ToolExecutor for PlanStepCompleteExecutor {
+    fn execute<'a>(
+        &'a self,
+        input: &'a ToolInput,
+        ctx: &'a ToolContext,
+    ) -> Pin<Box<dyn Future<Output = Result<ToolResult>> + Send + 'a>> {
+        Box::pin(async {
+            let planning = match require_planning(ctx) {
+                Ok(p) => p,
+                Err(r) => return Ok(r),
+            };
+            let project_id = extract_str(&input.arguments, "project_id", &input.name)?;
+            let phase_id = extract_str(&input.arguments, "phase_id", &input.name)?;
+            let plan_id = extract_str(&input.arguments, "plan_id", &input.name)?;
+            let achievement = input
+                .arguments
+                .get("achievement")
+                .and_then(|v| v.as_str());
+
+            match planning
+                .complete_plan(project_id, phase_id, plan_id, achievement)
+                .await
+            {
+                Ok(json) => Ok(ToolResult::text(json)),
+                Err(e) => Ok(ToolResult::error(e)),
+            }
+        })
+    }
+}
+
+struct PlanStepFailExecutor;
+
+impl ToolExecutor for PlanStepFailExecutor {
+    fn execute<'a>(
+        &'a self,
+        input: &'a ToolInput,
+        ctx: &'a ToolContext,
+    ) -> Pin<Box<dyn Future<Output = Result<ToolResult>> + Send + 'a>> {
+        Box::pin(async {
+            let planning = match require_planning(ctx) {
+                Ok(p) => p,
+                Err(r) => return Ok(r),
+            };
+            let project_id = extract_str(&input.arguments, "project_id", &input.name)?;
+            let phase_id = extract_str(&input.arguments, "phase_id", &input.name)?;
+            let plan_id = extract_str(&input.arguments, "plan_id", &input.name)?;
+            let reason = extract_str(&input.arguments, "reason", &input.name)?;
+
+            match planning
+                .fail_plan(project_id, phase_id, plan_id, reason)
+                .await
+            {
+                Ok(json) => Ok(ToolResult::text(json)),
+                Err(e) => Ok(ToolResult::error(e)),
+            }
+        })
+    }
+}
+
+// --- Tool Definitions ---
+
+fn plan_create_def() -> ToolDef {
+    ToolDef {
+        name: ToolName::new("plan_create").expect("valid tool name"),
+        description: "Create a new planning project with phases and plans".to_owned(),
+        extended_description: Some(
+            "Creates a multi-phase planning project. Modes: 'full' (research through verification), \
+             'quick' (time-boxed task with appetite_minutes), 'background' (autonomous processing)."
+                .to_owned(),
+        ),
+        input_schema: InputSchema {
+            properties: IndexMap::from([
+                (
+                    "name".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::String,
+                        description: "Project name".to_owned(),
+                        enum_values: None,
+                        default: None,
+                    },
+                ),
+                (
+                    "description".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::String,
+                        description: "What this project aims to accomplish".to_owned(),
+                        enum_values: None,
+                        default: None,
+                    },
+                ),
+                (
+                    "scope".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::String,
+                        description: "Optional scope constraint (e.g., 'crate X only')".to_owned(),
+                        enum_values: None,
+                        default: None,
+                    },
+                ),
+                (
+                    "mode".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::String,
+                        description: "Planning mode".to_owned(),
+                        enum_values: Some(vec![
+                            "full".to_owned(),
+                            "quick".to_owned(),
+                            "background".to_owned(),
+                        ]),
+                        default: Some(serde_json::json!("full")),
+                    },
+                ),
+                (
+                    "appetite_minutes".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::Number,
+                        description: "Time budget in minutes (only for 'quick' mode)".to_owned(),
+                        enum_values: None,
+                        default: None,
+                    },
+                ),
+            ]),
+            required: vec!["name".to_owned(), "description".to_owned()],
+        },
+        category: ToolCategory::Planning,
+        auto_activate: false,
+    }
+}
+
+fn plan_research_def() -> ToolDef {
+    ToolDef {
+        name: ToolName::new("plan_research").expect("valid tool name"),
+        description: "Advance project to research phase or skip research".to_owned(),
+        extended_description: None,
+        input_schema: InputSchema {
+            properties: IndexMap::from([
+                (
+                    "project_id".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::String,
+                        description: "Project ID".to_owned(),
+                        enum_values: None,
+                        default: None,
+                    },
+                ),
+                (
+                    "skip".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::Boolean,
+                        description: "Skip research and go directly to scoping".to_owned(),
+                        enum_values: None,
+                        default: Some(serde_json::json!(false)),
+                    },
+                ),
+            ]),
+            required: vec!["project_id".to_owned()],
+        },
+        category: ToolCategory::Planning,
+        auto_activate: false,
+    }
+}
+
+fn plan_requirements_def() -> ToolDef {
+    ToolDef {
+        name: ToolName::new("plan_requirements").expect("valid tool name"),
+        description: "Manage requirements scoping phase".to_owned(),
+        extended_description: None,
+        input_schema: InputSchema {
+            properties: IndexMap::from([
+                (
+                    "project_id".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::String,
+                        description: "Project ID".to_owned(),
+                        enum_values: None,
+                        default: None,
+                    },
+                ),
+                (
+                    "action".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::String,
+                        description: "Action to perform".to_owned(),
+                        enum_values: Some(vec![
+                            "start_scoping".to_owned(),
+                            "complete".to_owned(),
+                        ]),
+                        default: None,
+                    },
+                ),
+            ]),
+            required: vec!["project_id".to_owned(), "action".to_owned()],
+        },
+        category: ToolCategory::Planning,
+        auto_activate: false,
+    }
+}
+
+fn plan_roadmap_def() -> ToolDef {
+    ToolDef {
+        name: ToolName::new("plan_roadmap").expect("valid tool name"),
+        description: "Manage project roadmap: add phases, start discussion or execution".to_owned(),
+        extended_description: None,
+        input_schema: InputSchema {
+            properties: IndexMap::from([
+                (
+                    "project_id".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::String,
+                        description: "Project ID".to_owned(),
+                        enum_values: None,
+                        default: None,
+                    },
+                ),
+                (
+                    "action".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::String,
+                        description: "Action to perform".to_owned(),
+                        enum_values: Some(vec![
+                            "add_phase".to_owned(),
+                            "start_discussion".to_owned(),
+                            "start_execution".to_owned(),
+                        ]),
+                        default: None,
+                    },
+                ),
+                (
+                    "phase_name".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::String,
+                        description: "Phase name (required for add_phase)".to_owned(),
+                        enum_values: None,
+                        default: None,
+                    },
+                ),
+                (
+                    "phase_goal".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::String,
+                        description: "Phase goal (required for add_phase)".to_owned(),
+                        enum_values: None,
+                        default: None,
+                    },
+                ),
+            ]),
+            required: vec!["project_id".to_owned(), "action".to_owned()],
+        },
+        category: ToolCategory::Planning,
+        auto_activate: false,
+    }
+}
+
+fn plan_discuss_def() -> ToolDef {
+    ToolDef {
+        name: ToolName::new("plan_discuss").expect("valid tool name"),
+        description: "Complete discussion phase and advance to execution".to_owned(),
+        extended_description: None,
+        input_schema: InputSchema {
+            properties: IndexMap::from([
+                (
+                    "project_id".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::String,
+                        description: "Project ID".to_owned(),
+                        enum_values: None,
+                        default: None,
+                    },
+                ),
+                (
+                    "action".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::String,
+                        description: "Action to perform".to_owned(),
+                        enum_values: Some(vec!["complete".to_owned()]),
+                        default: None,
+                    },
+                ),
+            ]),
+            required: vec!["project_id".to_owned(), "action".to_owned()],
+        },
+        category: ToolCategory::Planning,
+        auto_activate: false,
+    }
+}
+
+fn plan_execute_def() -> ToolDef {
+    ToolDef {
+        name: ToolName::new("plan_execute").expect("valid tool name"),
+        description: "Manage plan execution: start, pause, resume, abandon, or verify".to_owned(),
+        extended_description: None,
+        input_schema: InputSchema {
+            properties: IndexMap::from([
+                (
+                    "project_id".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::String,
+                        description: "Project ID".to_owned(),
+                        enum_values: None,
+                        default: None,
+                    },
+                ),
+                (
+                    "action".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::String,
+                        description: "Action to perform".to_owned(),
+                        enum_values: Some(vec![
+                            "start".to_owned(),
+                            "pause".to_owned(),
+                            "resume".to_owned(),
+                            "abandon".to_owned(),
+                            "start_verification".to_owned(),
+                        ]),
+                        default: None,
+                    },
+                ),
+            ]),
+            required: vec!["project_id".to_owned(), "action".to_owned()],
+        },
+        category: ToolCategory::Planning,
+        auto_activate: false,
+    }
+}
+
+fn plan_verify_def() -> ToolDef {
+    ToolDef {
+        name: ToolName::new("plan_verify").expect("valid tool name"),
+        description: "Complete verification or revert to an earlier phase".to_owned(),
+        extended_description: None,
+        input_schema: InputSchema {
+            properties: IndexMap::from([
+                (
+                    "project_id".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::String,
+                        description: "Project ID".to_owned(),
+                        enum_values: None,
+                        default: None,
+                    },
+                ),
+                (
+                    "action".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::String,
+                        description: "Action to perform".to_owned(),
+                        enum_values: Some(vec!["complete".to_owned(), "revert".to_owned()]),
+                        default: None,
+                    },
+                ),
+                (
+                    "revert_to".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::String,
+                        description: "Target state for revert (required when action is 'revert')"
+                            .to_owned(),
+                        enum_values: Some(vec![
+                            "scoping".to_owned(),
+                            "planning".to_owned(),
+                            "executing".to_owned(),
+                        ]),
+                        default: None,
+                    },
+                ),
+            ]),
+            required: vec!["project_id".to_owned(), "action".to_owned()],
+        },
+        category: ToolCategory::Planning,
+        auto_activate: false,
+    }
+}
+
+fn plan_status_def() -> ToolDef {
+    ToolDef {
+        name: ToolName::new("plan_status").expect("valid tool name"),
+        description: "Get current project status including phases and completion".to_owned(),
+        extended_description: None,
+        input_schema: InputSchema {
+            properties: IndexMap::from([(
+                "project_id".to_owned(),
+                PropertyDef {
+                    property_type: PropertyType::String,
+                    description: "Project ID".to_owned(),
+                    enum_values: None,
+                    default: None,
+                },
+            )]),
+            required: vec!["project_id".to_owned()],
+        },
+        category: ToolCategory::Planning,
+        auto_activate: false,
+    }
+}
+
+fn plan_step_complete_def() -> ToolDef {
+    ToolDef {
+        name: ToolName::new("plan_step_complete").expect("valid tool name"),
+        description: "Mark a plan step as successfully completed".to_owned(),
+        extended_description: None,
+        input_schema: InputSchema {
+            properties: IndexMap::from([
+                (
+                    "project_id".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::String,
+                        description: "Project ID".to_owned(),
+                        enum_values: None,
+                        default: None,
+                    },
+                ),
+                (
+                    "phase_id".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::String,
+                        description: "Phase ID containing the plan".to_owned(),
+                        enum_values: None,
+                        default: None,
+                    },
+                ),
+                (
+                    "plan_id".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::String,
+                        description: "Plan ID to mark complete".to_owned(),
+                        enum_values: None,
+                        default: None,
+                    },
+                ),
+                (
+                    "achievement".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::String,
+                        description: "Description of what was accomplished".to_owned(),
+                        enum_values: None,
+                        default: None,
+                    },
+                ),
+            ]),
+            required: vec![
+                "project_id".to_owned(),
+                "phase_id".to_owned(),
+                "plan_id".to_owned(),
+            ],
+        },
+        category: ToolCategory::Planning,
+        auto_activate: false,
+    }
+}
+
+fn plan_step_fail_def() -> ToolDef {
+    ToolDef {
+        name: ToolName::new("plan_step_fail").expect("valid tool name"),
+        description: "Mark a plan step as failed with a reason".to_owned(),
+        extended_description: None,
+        input_schema: InputSchema {
+            properties: IndexMap::from([
+                (
+                    "project_id".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::String,
+                        description: "Project ID".to_owned(),
+                        enum_values: None,
+                        default: None,
+                    },
+                ),
+                (
+                    "phase_id".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::String,
+                        description: "Phase ID containing the plan".to_owned(),
+                        enum_values: None,
+                        default: None,
+                    },
+                ),
+                (
+                    "plan_id".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::String,
+                        description: "Plan ID to mark failed".to_owned(),
+                        enum_values: None,
+                        default: None,
+                    },
+                ),
+                (
+                    "reason".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::String,
+                        description: "Why the plan failed".to_owned(),
+                        enum_values: None,
+                        default: None,
+                    },
+                ),
+            ]),
+            required: vec![
+                "project_id".to_owned(),
+                "phase_id".to_owned(),
+                "plan_id".to_owned(),
+                "reason".to_owned(),
+            ],
+        },
+        category: ToolCategory::Planning,
+        auto_activate: false,
+    }
+}
+
+// --- Registration ---
+
+pub fn register(registry: &mut ToolRegistry) -> Result<()> {
+    registry.register(plan_create_def(), Box::new(PlanCreateExecutor))?;
+    registry.register(plan_research_def(), Box::new(PlanResearchExecutor))?;
+    registry.register(plan_requirements_def(), Box::new(PlanRequirementsExecutor))?;
+    registry.register(plan_roadmap_def(), Box::new(PlanRoadmapExecutor))?;
+    registry.register(plan_discuss_def(), Box::new(PlanDiscussExecutor))?;
+    registry.register(plan_execute_def(), Box::new(PlanExecuteExecutor))?;
+    registry.register(plan_verify_def(), Box::new(PlanVerifyExecutor))?;
+    registry.register(plan_status_def(), Box::new(PlanStatusExecutor))?;
+    registry.register(plan_step_complete_def(), Box::new(PlanStepCompleteExecutor))?;
+    registry.register(plan_step_fail_def(), Box::new(PlanStepFailExecutor))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+    use std::future::Future;
+    use std::path::PathBuf;
+    use std::pin::Pin;
+    use std::sync::{Arc, Mutex, RwLock};
+
+    use aletheia_koina::id::{NousId, SessionId, ToolName};
+
+    use crate::registry::ToolRegistry;
+    use crate::types::{PlanningService, ToolCategory, ToolContext, ToolInput, ToolServices};
+
+    fn test_ctx() -> ToolContext {
+        ToolContext {
+            nous_id: NousId::new("test-agent").expect("valid"),
+            session_id: SessionId::new(),
+            workspace: PathBuf::from("/tmp/test"),
+            allowed_roots: vec![PathBuf::from("/tmp")],
+            services: None,
+            active_tools: Arc::new(RwLock::new(HashSet::new())),
+        }
+    }
+
+    fn test_ctx_with_planning(planning: Arc<dyn PlanningService>) -> ToolContext {
+        ToolContext {
+            nous_id: NousId::new("test-agent").expect("valid"),
+            session_id: SessionId::new(),
+            workspace: PathBuf::from("/tmp/test"),
+            allowed_roots: vec![PathBuf::from("/tmp")],
+            services: Some(Arc::new(ToolServices {
+                cross_nous: None,
+                messenger: None,
+                note_store: None,
+                blackboard_store: None,
+                spawn: None,
+                planning: Some(planning),
+                http_client: reqwest::Client::new(),
+                lazy_tool_catalog: vec![],
+            })),
+            active_tools: Arc::new(RwLock::new(HashSet::new())),
+        }
+    }
+
+    #[derive(Default)]
+    struct MockPlanning {
+        create_result: Mutex<Option<Result<String, String>>>,
+        load_result: Mutex<Option<Result<String, String>>>,
+        transition_calls: Mutex<Vec<(String, String)>>,
+        transition_result: Mutex<Option<Result<String, String>>>,
+        add_phase_calls: Mutex<Vec<(String, String, String)>>,
+        add_phase_result: Mutex<Option<Result<String, String>>>,
+        complete_plan_calls: Mutex<Vec<(String, String, String)>>,
+        complete_plan_result: Mutex<Option<Result<String, String>>>,
+        fail_plan_calls: Mutex<Vec<(String, String, String, String)>>,
+        fail_plan_result: Mutex<Option<Result<String, String>>>,
+    }
+
+    impl PlanningService for MockPlanning {
+        fn create_project(
+            &self,
+            _name: &str,
+            _description: &str,
+            _scope: Option<&str>,
+            _mode: &str,
+            _appetite_minutes: Option<u32>,
+            _owner: &str,
+        ) -> Pin<Box<dyn Future<Output = Result<String, String>> + Send + '_>> {
+            let result = self
+                .create_result
+                .lock()
+                .unwrap()
+                .take()
+                .unwrap_or(Ok(r#"{"id":"01J0000000000000000000000","name":"test","state":"Created"}"#.to_owned()));
+            Box::pin(async move { result })
+        }
+
+        fn load_project(
+            &self,
+            _project_id: &str,
+        ) -> Pin<Box<dyn Future<Output = Result<String, String>> + Send + '_>> {
+            let result = self
+                .load_result
+                .lock()
+                .unwrap()
+                .take()
+                .unwrap_or(Ok(r#"{"id":"01J0000000000000000000000","state":"Created"}"#.to_owned()));
+            Box::pin(async move { result })
+        }
+
+        fn transition_project(
+            &self,
+            project_id: &str,
+            transition: &str,
+        ) -> Pin<Box<dyn Future<Output = Result<String, String>> + Send + '_>> {
+            self.transition_calls
+                .lock()
+                .unwrap()
+                .push((project_id.to_owned(), transition.to_owned()));
+            let result = self
+                .transition_result
+                .lock()
+                .unwrap()
+                .take()
+                .unwrap_or(Ok(r#"{"id":"01J0000000000000000000000","state":"Researching"}"#.to_owned()));
+            Box::pin(async move { result })
+        }
+
+        fn add_phase(
+            &self,
+            project_id: &str,
+            name: &str,
+            goal: &str,
+        ) -> Pin<Box<dyn Future<Output = Result<String, String>> + Send + '_>> {
+            self.add_phase_calls
+                .lock()
+                .unwrap()
+                .push((project_id.to_owned(), name.to_owned(), goal.to_owned()));
+            let result = self
+                .add_phase_result
+                .lock()
+                .unwrap()
+                .take()
+                .unwrap_or(Ok(r#"{"id":"01J0000000000000000000000","phases":[{"name":"Phase 1"}]}"#.to_owned()));
+            Box::pin(async move { result })
+        }
+
+        fn complete_plan(
+            &self,
+            project_id: &str,
+            phase_id: &str,
+            plan_id: &str,
+            _achievement: Option<&str>,
+        ) -> Pin<Box<dyn Future<Output = Result<String, String>> + Send + '_>> {
+            self.complete_plan_calls
+                .lock()
+                .unwrap()
+                .push((project_id.to_owned(), phase_id.to_owned(), plan_id.to_owned()));
+            let result = self
+                .complete_plan_result
+                .lock()
+                .unwrap()
+                .take()
+                .unwrap_or(Ok(r#"{"status":"plan completed"}"#.to_owned()));
+            Box::pin(async move { result })
+        }
+
+        fn fail_plan(
+            &self,
+            project_id: &str,
+            phase_id: &str,
+            plan_id: &str,
+            reason: &str,
+        ) -> Pin<Box<dyn Future<Output = Result<String, String>> + Send + '_>> {
+            self.fail_plan_calls.lock().unwrap().push((
+                project_id.to_owned(),
+                phase_id.to_owned(),
+                plan_id.to_owned(),
+                reason.to_owned(),
+            ));
+            let result = self
+                .fail_plan_result
+                .lock()
+                .unwrap()
+                .take()
+                .unwrap_or(Ok(r#"{"status":"plan failed"}"#.to_owned()));
+            Box::pin(async move { result })
+        }
+
+        fn list_projects(
+            &self,
+        ) -> Pin<Box<dyn Future<Output = Result<String, String>> + Send + '_>> {
+            Box::pin(async { Ok("[]".to_owned()) })
+        }
+    }
+
+    #[tokio::test]
+    async fn register_planning_tools() {
+        let mut reg = ToolRegistry::new();
+        super::register(&mut reg).expect("register");
+        let planning_tools = reg.definitions_for_category(ToolCategory::Planning);
+        assert_eq!(planning_tools.len(), 10);
+    }
+
+    #[tokio::test]
+    async fn all_tools_are_lazy() {
+        let mut reg = ToolRegistry::new();
+        super::register(&mut reg).expect("register");
+        for def in reg.definitions_for_category(ToolCategory::Planning) {
+            assert!(!def.auto_activate, "{} should be lazy", def.name.as_str());
+        }
+    }
+
+    #[tokio::test]
+    async fn plan_create_missing_service_returns_error() {
+        let mut reg = ToolRegistry::new();
+        super::register(&mut reg).expect("register");
+        let input = ToolInput {
+            name: ToolName::new("plan_create").expect("valid"),
+            tool_use_id: "tu_1".to_owned(),
+            arguments: serde_json::json!({"name": "test", "description": "test project"}),
+        };
+        let result = reg.execute(&input, &test_ctx()).await.expect("execute");
+        assert!(result.is_error);
+        assert!(result.content.text_summary().contains("not configured"));
+    }
+
+    #[tokio::test]
+    async fn plan_create_success() {
+        let mock = Arc::new(MockPlanning::default());
+        let ctx = test_ctx_with_planning(mock);
+        let mut reg = ToolRegistry::new();
+        super::register(&mut reg).expect("register");
+        let input = ToolInput {
+            name: ToolName::new("plan_create").expect("valid"),
+            tool_use_id: "tu_1".to_owned(),
+            arguments: serde_json::json!({"name": "my project", "description": "build a thing"}),
+        };
+        let result = reg.execute(&input, &ctx).await.expect("execute");
+        assert!(!result.is_error);
+        assert!(result.content.text_summary().contains("Created"));
+    }
+
+    #[tokio::test]
+    async fn plan_create_error_propagates() {
+        let mock = Arc::new(MockPlanning::default());
+        *mock.create_result.lock().unwrap() = Some(Err("project already exists".to_owned()));
+        let ctx = test_ctx_with_planning(mock);
+        let mut reg = ToolRegistry::new();
+        super::register(&mut reg).expect("register");
+        let input = ToolInput {
+            name: ToolName::new("plan_create").expect("valid"),
+            tool_use_id: "tu_1".to_owned(),
+            arguments: serde_json::json!({"name": "test", "description": "test"}),
+        };
+        let result = reg.execute(&input, &ctx).await.expect("execute");
+        assert!(result.is_error);
+        assert!(result.content.text_summary().contains("already exists"));
+    }
+
+    #[tokio::test]
+    async fn plan_research_skip_dispatches_correctly() {
+        let mock = Arc::new(MockPlanning::default());
+        let mock_ref = Arc::clone(&mock);
+        let ctx = test_ctx_with_planning(mock);
+        let mut reg = ToolRegistry::new();
+        super::register(&mut reg).expect("register");
+        let input = ToolInput {
+            name: ToolName::new("plan_research").expect("valid"),
+            tool_use_id: "tu_1".to_owned(),
+            arguments: serde_json::json!({"project_id": "01J0000000000000000000000", "skip": true}),
+        };
+        let result = reg.execute(&input, &ctx).await.expect("execute");
+        assert!(!result.is_error);
+
+        let calls = mock_ref.transition_calls.lock().unwrap();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].1, "skip_research");
+    }
+
+    #[tokio::test]
+    async fn plan_research_no_skip_dispatches_start() {
+        let mock = Arc::new(MockPlanning::default());
+        let mock_ref = Arc::clone(&mock);
+        let ctx = test_ctx_with_planning(mock);
+        let mut reg = ToolRegistry::new();
+        super::register(&mut reg).expect("register");
+        let input = ToolInput {
+            name: ToolName::new("plan_research").expect("valid"),
+            tool_use_id: "tu_1".to_owned(),
+            arguments: serde_json::json!({"project_id": "01J0000000000000000000000"}),
+        };
+        let result = reg.execute(&input, &ctx).await.expect("execute");
+        assert!(!result.is_error);
+
+        let calls = mock_ref.transition_calls.lock().unwrap();
+        assert_eq!(calls[0].1, "start_research");
+    }
+
+    #[tokio::test]
+    async fn plan_roadmap_add_phase_calls_add_phase() {
+        let mock = Arc::new(MockPlanning::default());
+        let mock_ref = Arc::clone(&mock);
+        let ctx = test_ctx_with_planning(mock);
+        let mut reg = ToolRegistry::new();
+        super::register(&mut reg).expect("register");
+        let input = ToolInput {
+            name: ToolName::new("plan_roadmap").expect("valid"),
+            tool_use_id: "tu_1".to_owned(),
+            arguments: serde_json::json!({
+                "project_id": "01J0000000000000000000000",
+                "action": "add_phase",
+                "phase_name": "Foundation",
+                "phase_goal": "Set up core infrastructure"
+            }),
+        };
+        let result = reg.execute(&input, &ctx).await.expect("execute");
+        assert!(!result.is_error);
+
+        let calls = mock_ref.add_phase_calls.lock().unwrap();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].1, "Foundation");
+        assert_eq!(calls[0].2, "Set up core infrastructure");
+
+        // transition_project should NOT have been called
+        let t_calls = mock_ref.transition_calls.lock().unwrap();
+        assert!(t_calls.is_empty());
+    }
+
+    #[tokio::test]
+    async fn plan_status_returns_project_json() {
+        let mock = Arc::new(MockPlanning::default());
+        let ctx = test_ctx_with_planning(mock);
+        let mut reg = ToolRegistry::new();
+        super::register(&mut reg).expect("register");
+        let input = ToolInput {
+            name: ToolName::new("plan_status").expect("valid"),
+            tool_use_id: "tu_1".to_owned(),
+            arguments: serde_json::json!({"project_id": "01J0000000000000000000000"}),
+        };
+        let result = reg.execute(&input, &ctx).await.expect("execute");
+        assert!(!result.is_error);
+        assert!(result.content.text_summary().contains("Created"));
+    }
+
+    #[tokio::test]
+    async fn plan_step_complete_dispatches() {
+        let mock = Arc::new(MockPlanning::default());
+        let mock_ref = Arc::clone(&mock);
+        let ctx = test_ctx_with_planning(mock);
+        let mut reg = ToolRegistry::new();
+        super::register(&mut reg).expect("register");
+        let input = ToolInput {
+            name: ToolName::new("plan_step_complete").expect("valid"),
+            tool_use_id: "tu_1".to_owned(),
+            arguments: serde_json::json!({
+                "project_id": "proj1",
+                "phase_id": "phase1",
+                "plan_id": "plan1",
+                "achievement": "implemented the feature"
+            }),
+        };
+        let result = reg.execute(&input, &ctx).await.expect("execute");
+        assert!(!result.is_error);
+
+        let calls = mock_ref.complete_plan_calls.lock().unwrap();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0], ("proj1".to_owned(), "phase1".to_owned(), "plan1".to_owned()));
+    }
+
+    #[tokio::test]
+    async fn plan_step_fail_dispatches() {
+        let mock = Arc::new(MockPlanning::default());
+        let mock_ref = Arc::clone(&mock);
+        let ctx = test_ctx_with_planning(mock);
+        let mut reg = ToolRegistry::new();
+        super::register(&mut reg).expect("register");
+        let input = ToolInput {
+            name: ToolName::new("plan_step_fail").expect("valid"),
+            tool_use_id: "tu_1".to_owned(),
+            arguments: serde_json::json!({
+                "project_id": "proj1",
+                "phase_id": "phase1",
+                "plan_id": "plan1",
+                "reason": "compilation error"
+            }),
+        };
+        let result = reg.execute(&input, &ctx).await.expect("execute");
+        assert!(!result.is_error);
+
+        let calls = mock_ref.fail_plan_calls.lock().unwrap();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].3, "compilation error");
+    }
+
+    #[tokio::test]
+    async fn plan_verify_revert_dispatches_correctly() {
+        let mock = Arc::new(MockPlanning::default());
+        let mock_ref = Arc::clone(&mock);
+        let ctx = test_ctx_with_planning(mock);
+        let mut reg = ToolRegistry::new();
+        super::register(&mut reg).expect("register");
+        let input = ToolInput {
+            name: ToolName::new("plan_verify").expect("valid"),
+            tool_use_id: "tu_1".to_owned(),
+            arguments: serde_json::json!({
+                "project_id": "proj1",
+                "action": "revert",
+                "revert_to": "planning"
+            }),
+        };
+        let result = reg.execute(&input, &ctx).await.expect("execute");
+        assert!(!result.is_error);
+
+        let calls = mock_ref.transition_calls.lock().unwrap();
+        assert_eq!(calls[0].1, "revert_to_planning");
+    }
+
+    #[tokio::test]
+    async fn plan_execute_maps_actions() {
+        let mock = Arc::new(MockPlanning::default());
+        let mock_ref = Arc::clone(&mock);
+        let ctx = test_ctx_with_planning(mock);
+        let mut reg = ToolRegistry::new();
+        super::register(&mut reg).expect("register");
+
+        for (action, expected_transition) in [
+            ("start", "start_execution"),
+            ("pause", "pause"),
+            ("resume", "resume"),
+            ("abandon", "abandon"),
+            ("start_verification", "start_verification"),
+        ] {
+            // Reset transition result for each iteration
+            *mock_ref.transition_result.lock().unwrap() =
+                Some(Ok(r#"{"state":"ok"}"#.to_owned()));
+
+            let input = ToolInput {
+                name: ToolName::new("plan_execute").expect("valid"),
+                tool_use_id: "tu_1".to_owned(),
+                arguments: serde_json::json!({
+                    "project_id": "proj1",
+                    "action": action,
+                }),
+            };
+            reg.execute(&input, &ctx).await.expect("execute");
+
+            let calls = mock_ref.transition_calls.lock().unwrap();
+            let last = calls.last().expect("should have a call");
+            assert_eq!(last.1, expected_transition, "action '{action}' should map to '{expected_transition}'");
+        }
+    }
+
+    #[tokio::test]
+    async fn unknown_action_returns_error() {
+        let mock = Arc::new(MockPlanning::default());
+        let ctx = test_ctx_with_planning(mock);
+        let mut reg = ToolRegistry::new();
+        super::register(&mut reg).expect("register");
+        let input = ToolInput {
+            name: ToolName::new("plan_requirements").expect("valid"),
+            tool_use_id: "tu_1".to_owned(),
+            arguments: serde_json::json!({"project_id": "p1", "action": "invalid_action"}),
+        };
+        let result = reg.execute(&input, &ctx).await.expect("execute");
+        assert!(result.is_error);
+        assert!(result.content.text_summary().contains("unknown action"));
+    }
+}

--- a/crates/organon/src/types.rs
+++ b/crates/organon/src/types.rs
@@ -284,6 +284,70 @@ pub trait MessageService: Send + Sync {
     ) -> Pin<Box<dyn Future<Output = Result<(), String>> + Send + '_>>;
 }
 
+/// Planning project management for tool executors.
+pub trait PlanningService: Send + Sync {
+    /// Create a new project. Returns JSON representation of the created project.
+    fn create_project(
+        &self,
+        name: &str,
+        description: &str,
+        scope: Option<&str>,
+        mode: &str,
+        appetite_minutes: Option<u32>,
+        owner: &str,
+    ) -> Pin<Box<dyn Future<Output = Result<String, String>> + Send + '_>>;
+
+    /// Load a project by ID. Returns JSON representation.
+    fn load_project(
+        &self,
+        project_id: &str,
+    ) -> Pin<Box<dyn Future<Output = Result<String, String>> + Send + '_>>;
+
+    /// Apply a named state transition to a project. Returns updated project JSON.
+    ///
+    /// Valid transition names:
+    /// - `start_questioning`, `start_research`, `skip_research`, `skip_to_research`
+    /// - `start_scoping`, `start_planning`, `start_discussion`, `start_execution`
+    /// - `start_verification`, `complete`, `abandon`, `pause`, `resume`
+    /// - `revert_to_scoping`, `revert_to_planning`, `revert_to_executing`
+    fn transition_project(
+        &self,
+        project_id: &str,
+        transition: &str,
+    ) -> Pin<Box<dyn Future<Output = Result<String, String>> + Send + '_>>;
+
+    /// Add a phase to a project. Returns updated project JSON.
+    fn add_phase(
+        &self,
+        project_id: &str,
+        name: &str,
+        goal: &str,
+    ) -> Pin<Box<dyn Future<Output = Result<String, String>> + Send + '_>>;
+
+    /// Mark a plan as complete within a phase. Returns updated project JSON.
+    fn complete_plan(
+        &self,
+        project_id: &str,
+        phase_id: &str,
+        plan_id: &str,
+        achievement: Option<&str>,
+    ) -> Pin<Box<dyn Future<Output = Result<String, String>> + Send + '_>>;
+
+    /// Mark a plan as failed within a phase. Returns updated project JSON.
+    fn fail_plan(
+        &self,
+        project_id: &str,
+        phase_id: &str,
+        plan_id: &str,
+        reason: &str,
+    ) -> Pin<Box<dyn Future<Output = Result<String, String>> + Send + '_>>;
+
+    /// List all projects. Returns JSON array of project summaries.
+    fn list_projects(
+        &self,
+    ) -> Pin<Box<dyn Future<Output = Result<String, String>> + Send + '_>>;
+}
+
 /// Service locator for tool executors needing access to runtime services.
 pub struct ToolServices {
     pub cross_nous: Option<Arc<dyn CrossNousService>>,
@@ -291,6 +355,7 @@ pub struct ToolServices {
     pub note_store: Option<Arc<dyn NoteStore>>,
     pub blackboard_store: Option<Arc<dyn BlackboardStore>>,
     pub spawn: Option<Arc<dyn SpawnService>>,
+    pub planning: Option<Arc<dyn PlanningService>>,
     pub http_client: reqwest::Client,
     /// Catalog of lazy tools available for activation via `enable_tool`.
     pub lazy_tool_catalog: Vec<(ToolName, String)>,
@@ -304,6 +369,7 @@ impl std::fmt::Debug for ToolServices {
             .field("note_store", &self.note_store.is_some())
             .field("blackboard_store", &self.blackboard_store.is_some())
             .field("spawn", &self.spawn.is_some())
+            .field("planning", &self.planning.is_some())
             .field("lazy_tool_catalog_len", &self.lazy_tool_catalog.len())
             .finish_non_exhaustive()
     }


### PR DESCRIPTION
## Summary

- Add `PlanningService` trait to `organon/types.rs` with 7 async methods for project lifecycle management
- Create 10 planning tool executors in `organon/builtins/planning.rs`: create, research, requirements, roadmap, discuss, execute, verify, status, step_complete, step_fail
- Add `FilesystemPlanningService` adapter in `aletheia/planning_adapter.rs` wrapping dianoia's `ProjectWorkspace` with `spawn_blocking`
- Wire adapter into `main.rs` ToolServices construction
- All tools are lazy (`auto_activate: false`), category `Planning`

## Test plan

- [x] 14 unit tests in `planning.rs` (registration, missing service, CRUD, action dispatch, error propagation)
- [x] 5 integration tests in `planning_adapter.rs` (create/load roundtrip, transitions, phases, list)
- [x] `cargo test -p aletheia-organon` passes (88 tests)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace` passes (all crates, 0 failures)