### PR TITLE
feat(organon): enable_tool, web_search, web_fetch

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+target-dir = "/home/syn/aletheia/instance/theke/dev/aletheia/target"

--- a/crates/aletheia/src/main.rs
+++ b/crates/aletheia/src/main.rs
@@ -510,6 +510,7 @@ async fn serve(cli: Cli) -> Result<()> {
             note_store,
             blackboard_store,
             http_client: reqwest::Client::new(),
+            lazy_tool_catalog: tool_registry.lazy_tool_catalog(),
         })
     };
 

--- a/crates/nous/src/actor.rs
+++ b/crates/nous/src/actor.rs
@@ -258,6 +258,9 @@ impl NousActor {
             workspace: self.oikos.nous_dir(&self.id),
             allowed_roots: vec![self.oikos.root().to_path_buf()],
             services: self.tool_services.clone(),
+            active_tools: std::sync::Arc::new(std::sync::RwLock::new(
+                std::collections::HashSet::new(),
+            )),
         };
 
         crate::pipeline::run_pipeline(

--- a/crates/nous/src/execute.rs
+++ b/crates/nous/src/execute.rs
@@ -212,8 +212,6 @@ pub async fn execute(
         None
     };
 
-    let tool_defs = tools.to_hermeneus_tools();
-
     loop {
         iterations += 1;
 
@@ -222,12 +220,20 @@ pub async fn execute(
             break;
         }
 
+        // Rebuild tool list each iteration so enable_tool activations take effect
+        let active = tool_ctx
+            .active_tools
+            .read()
+            .expect("active_tools lock")
+            .clone();
+        let tool_defs = tools.to_hermeneus_tools_filtered(&active);
+
         let request = CompletionRequest {
             model: config.model.clone(),
             system: ctx.system_prompt.clone(),
             messages: messages.clone(),
             max_tokens: config.max_output_tokens,
-            tools: tool_defs.clone(),
+            tools: tool_defs,
             temperature: None,
             thinking: thinking.clone(),
             stop_sequences: vec![],
@@ -577,10 +583,11 @@ pub async fn execute_streaming(
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashSet;
     use std::future::Future;
     use std::path::PathBuf;
     use std::pin::Pin;
-    use std::sync::Mutex;
+    use std::sync::{Arc, Mutex, RwLock};
 
     use aletheia_hermeneus::provider::ProviderRegistry;
     use aletheia_hermeneus::types::{
@@ -687,6 +694,7 @@ mod tests {
             workspace: PathBuf::from("/tmp/test"),
             allowed_roots: vec![PathBuf::from("/tmp")],
             services: None,
+            active_tools: Arc::new(RwLock::new(HashSet::new())),
         }
     }
 

--- a/crates/nous/src/pipeline.rs
+++ b/crates/nous/src/pipeline.rs
@@ -865,11 +865,12 @@ mod tests {
     // --- run_pipeline ---
 
     #[tokio::test]
-    #[expect(clippy::too_many_lines, reason = "pipeline integration test requires full setup")]
+    #[expect(clippy::too_many_lines, reason = "integration test with full pipeline setup")]
     async fn run_pipeline_simple() {
+        use std::collections::HashSet;
         use std::fs;
         use std::path::PathBuf;
-        use std::sync::Mutex;
+        use std::sync::{Arc, Mutex, RwLock};
 
         use aletheia_hermeneus::provider::{LlmProvider, ProviderRegistry};
         use aletheia_hermeneus::types::{
@@ -946,6 +947,7 @@ mod tests {
             workspace: PathBuf::from("/tmp/test"),
             allowed_roots: vec![PathBuf::from("/tmp")],
             services: None,
+            active_tools: Arc::new(RwLock::new(HashSet::new())),
         };
 
         let session = crate::session::SessionState::new(

--- a/crates/organon/src/builtins/communication.rs
+++ b/crates/organon/src/builtins/communication.rs
@@ -169,7 +169,7 @@ fn message_def() -> ToolDef {
             required: vec!["to".to_owned(), "text".to_owned()],
         },
         category: ToolCategory::Communication,
-        auto_activate: false,
+        auto_activate: true,
     }
 }
 
@@ -220,7 +220,7 @@ fn sessions_ask_def() -> ToolDef {
             required: vec!["agentId".to_owned(), "message".to_owned()],
         },
         category: ToolCategory::Communication,
-        auto_activate: false,
+        auto_activate: true,
     }
 }
 
@@ -262,7 +262,7 @@ fn sessions_send_def() -> ToolDef {
             required: vec!["agentId".to_owned(), "message".to_owned()],
         },
         category: ToolCategory::Communication,
-        auto_activate: false,
+        auto_activate: true,
     }
 }
 
@@ -272,6 +272,9 @@ mod tests {
     use std::path::PathBuf;
     use std::pin::Pin;
     use std::sync::{Arc, Mutex};
+
+    use std::collections::HashSet;
+    use std::sync::RwLock;
 
     use aletheia_koina::id::{NousId, SessionId, ToolName};
 
@@ -285,6 +288,7 @@ mod tests {
             workspace: PathBuf::from("/tmp/test"),
             allowed_roots: vec![PathBuf::from("/tmp")],
             services: None,
+            active_tools: Arc::new(RwLock::new(HashSet::new())),
         }
     }
 
@@ -295,6 +299,7 @@ mod tests {
             workspace: PathBuf::from("/tmp/test"),
             allowed_roots: vec![PathBuf::from("/tmp")],
             services: Some(Arc::new(services)),
+            active_tools: Arc::new(RwLock::new(HashSet::new())),
         }
     }
 
@@ -444,6 +449,7 @@ mod tests {
             note_store: None,
             blackboard_store: None,
             http_client: reqwest::Client::new(),
+            lazy_tool_catalog: vec![],
             messenger: Some(messenger),
         });
         let mut reg = ToolRegistry::new();
@@ -467,6 +473,7 @@ mod tests {
             note_store: None,
             blackboard_store: None,
             http_client: reqwest::Client::new(),
+            lazy_tool_catalog: vec![],
             messenger: Some(messenger),
         });
         let mut reg = ToolRegistry::new();
@@ -497,6 +504,7 @@ mod tests {
                     note_store: None,
             blackboard_store: None,
             http_client: reqwest::Client::new(),
+            lazy_tool_catalog: vec![],
         });
         let mut reg = ToolRegistry::new();
         super::register(&mut reg).expect("register");
@@ -527,6 +535,7 @@ mod tests {
                     note_store: None,
             blackboard_store: None,
             http_client: reqwest::Client::new(),
+            lazy_tool_catalog: vec![],
         });
         let mut reg = ToolRegistry::new();
         super::register(&mut reg).expect("register");
@@ -552,6 +561,7 @@ mod tests {
                     note_store: None,
             blackboard_store: None,
             http_client: reqwest::Client::new(),
+            lazy_tool_catalog: vec![],
         });
         let mut reg = ToolRegistry::new();
         super::register(&mut reg).expect("register");
@@ -575,6 +585,7 @@ mod tests {
                     note_store: None,
             blackboard_store: None,
             http_client: reqwest::Client::new(),
+            lazy_tool_catalog: vec![],
         });
         let mut reg = ToolRegistry::new();
         super::register(&mut reg).expect("register");

--- a/crates/organon/src/builtins/enable_tool.rs
+++ b/crates/organon/src/builtins/enable_tool.rs
@@ -1,0 +1,208 @@
+//! Meta-tool for dynamically activating lazy tools per session.
+
+use std::future::Future;
+use std::pin::Pin;
+
+use aletheia_koina::id::ToolName;
+use indexmap::IndexMap;
+
+use crate::error::Result;
+use crate::registry::{ToolExecutor, ToolRegistry};
+use crate::types::{
+    InputSchema, PropertyDef, PropertyType, ToolCategory, ToolContext, ToolDef, ToolInput,
+    ToolResult,
+};
+
+use super::workspace::extract_str;
+
+struct EnableToolExecutor;
+
+impl ToolExecutor for EnableToolExecutor {
+    fn execute<'a>(
+        &'a self,
+        input: &'a ToolInput,
+        ctx: &'a ToolContext,
+    ) -> Pin<Box<dyn Future<Output = Result<ToolResult>> + Send + 'a>> {
+        Box::pin(async {
+            let name = extract_str(&input.arguments, "name", &input.name)?;
+
+            let Some(services) = ctx.services.as_deref() else {
+                return Ok(ToolResult::error("tool services not configured"));
+            };
+
+            let Ok(tool_name) = ToolName::new(name) else {
+                return Ok(ToolResult::error(format!("invalid tool name: {name}")));
+            };
+
+            // Check if it's in the lazy catalog
+            let catalog_entry = services
+                .lazy_tool_catalog
+                .iter()
+                .find(|(n, _)| *n == tool_name);
+
+            let Some((_, description)) = catalog_entry else {
+                let available: Vec<&str> = services
+                    .lazy_tool_catalog
+                    .iter()
+                    .map(|(n, _)| n.as_str())
+                    .collect();
+                return Ok(ToolResult::error(format!(
+                    "tool '{name}' not found. Available tools: {}",
+                    available.join(", ")
+                )));
+            };
+
+            // Check if already active
+            {
+                let active = ctx.active_tools.read().expect("active_tools lock");
+                if active.contains(&tool_name) {
+                    return Ok(ToolResult::text(format!("'{name}' is already active.")));
+                }
+            }
+
+            // Activate
+            {
+                let mut active = ctx.active_tools.write().expect("active_tools lock");
+                active.insert(tool_name);
+            }
+
+            Ok(ToolResult::text(format!(
+                "Activated '{name}': {description}"
+            )))
+        })
+    }
+}
+
+fn enable_tool_def() -> ToolDef {
+    ToolDef {
+        name: ToolName::new("enable_tool").expect("valid tool name"),
+        description: "Activate a tool for this session. Some tools are not loaded by default \
+                      and must be enabled first. Call with the tool name to activate it."
+            .to_owned(),
+        extended_description: None,
+        input_schema: InputSchema {
+            properties: IndexMap::from([(
+                "name".to_owned(),
+                PropertyDef {
+                    property_type: PropertyType::String,
+                    description: "Name of the tool to activate".to_owned(),
+                    enum_values: None,
+                    default: None,
+                },
+            )]),
+            required: vec!["name".to_owned()],
+        },
+        category: ToolCategory::System,
+        auto_activate: true,
+    }
+}
+
+pub fn register(registry: &mut ToolRegistry) -> Result<()> {
+    registry.register(enable_tool_def(), Box::new(EnableToolExecutor))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+    use std::sync::{Arc, RwLock};
+
+    use aletheia_koina::id::{NousId, SessionId, ToolName};
+
+    use crate::types::{ToolContext, ToolInput, ToolServices};
+
+    use super::*;
+
+    fn test_ctx_with_catalog(catalog: Vec<(ToolName, String)>) -> ToolContext {
+        ToolContext {
+            nous_id: NousId::new("test-agent").expect("valid"),
+            session_id: SessionId::new(),
+            workspace: std::path::PathBuf::from("/tmp/test"),
+            allowed_roots: vec![std::path::PathBuf::from("/tmp")],
+            services: Some(Arc::new(ToolServices {
+                cross_nous: None,
+                messenger: None,
+                note_store: None,
+                blackboard_store: None,
+                http_client: reqwest::Client::new(),
+                lazy_tool_catalog: catalog,
+            })),
+            active_tools: Arc::new(RwLock::new(HashSet::new())),
+        }
+    }
+
+    fn make_input(tool_name: &str) -> ToolInput {
+        ToolInput {
+            name: ToolName::new("enable_tool").expect("valid"),
+            tool_use_id: "toolu_1".to_owned(),
+            arguments: serde_json::json!({"name": tool_name}),
+        }
+    }
+
+    #[tokio::test]
+    async fn activate_known_tool() {
+        let ctx = test_ctx_with_catalog(vec![(
+            ToolName::new("web_search").expect("valid"),
+            "Search the web".to_owned(),
+        )]);
+
+        let executor = EnableToolExecutor;
+        let result = executor
+            .execute(&make_input("web_search"), &ctx)
+            .await
+            .expect("execute");
+
+        assert!(!result.is_error);
+        assert!(result.content.text_summary().contains("Activated 'web_search'"));
+
+        let active = ctx.active_tools.read().expect("lock");
+        assert!(active.contains(&ToolName::new("web_search").expect("valid")));
+    }
+
+    #[tokio::test]
+    async fn unknown_tool_lists_available() {
+        let ctx = test_ctx_with_catalog(vec![
+            (
+                ToolName::new("web_search").expect("valid"),
+                "Search the web".to_owned(),
+            ),
+            (
+                ToolName::new("web_fetch").expect("valid"),
+                "Fetch a URL".to_owned(),
+            ),
+        ]);
+
+        let executor = EnableToolExecutor;
+        let result = executor
+            .execute(&make_input("nonexistent"), &ctx)
+            .await
+            .expect("execute");
+
+        assert!(result.is_error);
+        let text = result.content.text_summary();
+        assert!(text.contains("web_search"));
+        assert!(text.contains("web_fetch"));
+    }
+
+    #[tokio::test]
+    async fn double_activate_is_idempotent() {
+        let ctx = test_ctx_with_catalog(vec![(
+            ToolName::new("web_search").expect("valid"),
+            "Search the web".to_owned(),
+        )]);
+
+        let executor = EnableToolExecutor;
+        executor
+            .execute(&make_input("web_search"), &ctx)
+            .await
+            .expect("first");
+
+        let result = executor
+            .execute(&make_input("web_search"), &ctx)
+            .await
+            .expect("second");
+
+        assert!(!result.is_error);
+        assert!(result.content.text_summary().contains("already active"));
+    }
+}

--- a/crates/organon/src/builtins/filesystem.rs
+++ b/crates/organon/src/builtins/filesystem.rs
@@ -393,7 +393,7 @@ fn grep_def() -> ToolDef {
             required: vec!["pattern".to_owned()],
         },
         category: ToolCategory::Workspace,
-        auto_activate: false,
+        auto_activate: true,
     }
 }
 
@@ -453,7 +453,7 @@ fn find_def() -> ToolDef {
             required: vec!["pattern".to_owned()],
         },
         category: ToolCategory::Workspace,
-        auto_activate: false,
+        auto_activate: true,
     }
 }
 
@@ -486,7 +486,7 @@ fn ls_def() -> ToolDef {
             required: vec![],
         },
         category: ToolCategory::Workspace,
-        auto_activate: false,
+        auto_activate: true,
     }
 }
 
@@ -496,6 +496,9 @@ fn ls_def() -> ToolDef {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashSet;
+    use std::sync::{Arc, RwLock};
+
     use aletheia_koina::id::{NousId, SessionId, ToolName};
 
     use super::*;
@@ -507,6 +510,7 @@ mod tests {
             workspace: dir.to_path_buf(),
             allowed_roots: vec![dir.to_path_buf()],
             services: None,
+            active_tools: Arc::new(RwLock::new(HashSet::new())),
         }
     }
 

--- a/crates/organon/src/builtins/memory.rs
+++ b/crates/organon/src/builtins/memory.rs
@@ -323,7 +323,7 @@ fn mem0_search_def() -> ToolDef {
             required: vec!["query".to_owned()],
         },
         category: ToolCategory::Memory,
-        auto_activate: false,
+        auto_activate: true,
     }
 }
 
@@ -377,7 +377,7 @@ fn note_def() -> ToolDef {
             required: vec!["action".to_owned()],
         },
         category: ToolCategory::Memory,
-        auto_activate: false,
+        auto_activate: true,
     }
 }
 
@@ -428,14 +428,15 @@ fn blackboard_def() -> ToolDef {
             required: vec!["action".to_owned()],
         },
         category: ToolCategory::Memory,
-        auto_activate: false,
+        auto_activate: true,
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashSet;
     use std::path::PathBuf;
-    use std::sync::{Arc, Mutex};
+    use std::sync::{Arc, Mutex, RwLock};
 
     use aletheia_koina::id::{NousId, SessionId, ToolName};
 
@@ -557,6 +558,7 @@ mod tests {
             workspace: PathBuf::from("/tmp/test"),
             allowed_roots: vec![PathBuf::from("/tmp")],
             services: None,
+            active_tools: Arc::new(RwLock::new(HashSet::new())),
         }
     }
 
@@ -575,7 +577,9 @@ mod tests {
                 note_store: Some(note_store),
                 blackboard_store: Some(bb_store),
                 http_client: reqwest::Client::new(),
+                lazy_tool_catalog: vec![],
             })),
+            active_tools: Arc::new(RwLock::new(HashSet::new())),
         }
     }
 
@@ -803,6 +807,7 @@ mod tests {
             workspace: PathBuf::from("/tmp/test"),
             allowed_roots: vec![PathBuf::from("/tmp")],
             services: ctx.services.clone(),
+            active_tools: Arc::new(RwLock::new(HashSet::new())),
         };
         let del = ToolInput {
             name: ToolName::new("blackboard").expect("valid"),

--- a/crates/organon/src/builtins/mod.rs
+++ b/crates/organon/src/builtins/mod.rs
@@ -2,10 +2,14 @@
 
 /// Inter-agent communication tools (send_message, broadcast).
 pub mod communication;
+/// Dynamic tool activation meta-tool.
+pub mod enable_tool;
 /// Filesystem navigation tools (grep, find, ls).
 pub mod filesystem;
 /// Knowledge graph and session memory tools (remember, recall).
 pub mod memory;
+/// Web research tools (web_search, web_fetch).
+pub mod research;
 /// File viewing with multimodal support (images, PDFs, text).
 pub mod view_file;
 /// File and shell workspace tools (read, write, edit, exec).
@@ -21,5 +25,7 @@ pub fn register_all(registry: &mut ToolRegistry) -> Result<()> {
     communication::register(registry)?;
     filesystem::register(registry)?;
     view_file::register(registry)?;
+    enable_tool::register(registry)?;
+    research::register(registry)?;
     Ok(())
 }

--- a/crates/organon/src/builtins/research.rs
+++ b/crates/organon/src/builtins/research.rs
@@ -1,0 +1,512 @@
+//! Web research tools: web_search (Brave Search API) and web_fetch (HTTP GET).
+
+use std::fmt::Write as _;
+use std::future::Future;
+use std::pin::Pin;
+
+use aletheia_koina::id::ToolName;
+use indexmap::IndexMap;
+
+use crate::error::Result;
+use crate::registry::{ToolExecutor, ToolRegistry};
+use crate::types::{
+    InputSchema, PropertyDef, PropertyType, ToolCategory, ToolContext, ToolDef, ToolInput,
+    ToolResult,
+};
+
+use super::workspace::{extract_opt_u64, extract_str};
+
+fn require_services(ctx: &ToolContext) -> std::result::Result<&crate::types::ToolServices, ToolResult> {
+    ctx.services
+        .as_deref()
+        .ok_or_else(|| ToolResult::error("tool services not configured"))
+}
+
+// --- web_search ---
+
+struct WebSearchExecutor;
+
+impl ToolExecutor for WebSearchExecutor {
+    fn execute<'a>(
+        &'a self,
+        input: &'a ToolInput,
+        ctx: &'a ToolContext,
+    ) -> Pin<Box<dyn Future<Output = Result<ToolResult>> + Send + 'a>> {
+        Box::pin(async {
+            let services = match require_services(ctx) {
+                Ok(s) => s,
+                Err(r) => return Ok(r),
+            };
+
+            let query = extract_str(&input.arguments, "query", &input.name)?;
+            let count = extract_opt_u64(&input.arguments, "count")
+                .unwrap_or(10)
+                .min(20);
+
+            let api_key = match std::env::var("BRAVE_API_KEY") {
+                Ok(key) if !key.is_empty() => key,
+                _ => {
+                    return Ok(ToolResult::error(
+                        "BRAVE_API_KEY environment variable not set. \
+                         Set it to use web_search.",
+                    ))
+                }
+            };
+
+            let url = format!(
+                "https://api.search.brave.com/res/v1/web/search?q={}&count={count}",
+                urlencoding(query)
+            );
+
+            let response = services
+                .http_client
+                .get(&url)
+                .header("X-Subscription-Token", &api_key)
+                .header("Accept", "application/json")
+                .send()
+                .await;
+
+            let response = match response {
+                Ok(r) => r,
+                Err(e) => return Ok(ToolResult::error(format!("search request failed: {e}"))),
+            };
+
+            if !response.status().is_success() {
+                return Ok(ToolResult::error(format!(
+                    "search API returned status {}",
+                    response.status()
+                )));
+            }
+
+            let body: serde_json::Value = match response.json().await {
+                Ok(v) => v,
+                Err(e) => return Ok(ToolResult::error(format!("failed to parse response: {e}"))),
+            };
+
+            let results = body
+                .get("web")
+                .and_then(|w| w.get("results"))
+                .and_then(|r| r.as_array());
+
+            let Some(results) = results else {
+                return Ok(ToolResult::text("No results found."));
+            };
+
+            let mut output = String::new();
+            for (i, result) in results.iter().enumerate() {
+                let title = result.get("title").and_then(|v| v.as_str()).unwrap_or("");
+                let url = result.get("url").and_then(|v| v.as_str()).unwrap_or("");
+                let desc = result
+                    .get("description")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("");
+                if i > 0 {
+                    output.push_str("\n\n");
+                }
+                let _ = write!(output, "{title}\n{url}\n{desc}");
+            }
+
+            if output.is_empty() {
+                Ok(ToolResult::text("No results found."))
+            } else {
+                Ok(ToolResult::text(output))
+            }
+        })
+    }
+}
+
+/// Minimal URL encoding for query parameters.
+fn urlencoding(s: &str) -> String {
+    let mut result = String::with_capacity(s.len());
+    for b in s.bytes() {
+        match b {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                result.push(b as char);
+            }
+            b' ' => result.push('+'),
+            _ => {
+                result.push('%');
+                let _ = write!(result, "{b:02X}");
+            }
+        }
+    }
+    result
+}
+
+// --- web_fetch ---
+
+struct WebFetchExecutor;
+
+impl ToolExecutor for WebFetchExecutor {
+    fn execute<'a>(
+        &'a self,
+        input: &'a ToolInput,
+        ctx: &'a ToolContext,
+    ) -> Pin<Box<dyn Future<Output = Result<ToolResult>> + Send + 'a>> {
+        Box::pin(async {
+            let services = match require_services(ctx) {
+                Ok(s) => s,
+                Err(r) => return Ok(r),
+            };
+
+            let url = extract_str(&input.arguments, "url", &input.name)?;
+            let max_length = extract_opt_u64(&input.arguments, "maxLength").unwrap_or(50_000);
+
+            // Basic URL validation
+            if !url.starts_with("http://") && !url.starts_with("https://") {
+                return Ok(ToolResult::error("URL must start with http:// or https://"));
+            }
+
+            let response = services
+                .http_client
+                .get(url)
+                .header(
+                    "User-Agent",
+                    "Aletheia/1.0 (Research Agent; +https://github.com/CKickertz/aletheia)",
+                )
+                .send()
+                .await;
+
+            let response = match response {
+                Ok(r) => r,
+                Err(e) => return Ok(ToolResult::error(format!("fetch failed: {e}"))),
+            };
+
+            if !response.status().is_success() {
+                return Ok(ToolResult::error(format!(
+                    "HTTP {}",
+                    response.status()
+                )));
+            }
+
+            let content_type = response
+                .headers()
+                .get("content-type")
+                .and_then(|v| v.to_str().ok())
+                .unwrap_or("")
+                .to_owned();
+
+            let body = match response.text().await {
+                Ok(t) => t,
+                Err(e) => return Ok(ToolResult::error(format!("failed to read body: {e}"))),
+            };
+
+            let text = if content_type.contains("text/html") {
+                strip_html_tags(&body)
+            } else {
+                body
+            };
+
+            #[expect(clippy::cast_possible_truncation, reason = "max_length fits in usize")]
+            let max_len = max_length as usize;
+            let truncated = if text.len() > max_len {
+                let mut end = max_len;
+                while end > 0 && !text.is_char_boundary(end) {
+                    end -= 1;
+                }
+                format!("{}...\n\n[Truncated at {max_length} characters]", &text[..end])
+            } else {
+                text
+            };
+
+            Ok(ToolResult::text(truncated))
+        })
+    }
+}
+
+/// Strip HTML tags and collapse whitespace for readable text extraction.
+fn strip_html_tags(html: &str) -> String {
+    let mut result = String::with_capacity(html.len() / 2);
+    let mut in_tag = false;
+    let mut in_script = false;
+    let mut in_style = false;
+    let mut last_was_whitespace = false;
+
+    let lower = html.to_lowercase();
+    let bytes = html.as_bytes();
+    let lower_bytes = lower.as_bytes();
+
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'<' {
+            // Check for script/style open/close
+            if i + 7 < lower_bytes.len() && &lower_bytes[i..i + 7] == b"<script" {
+                in_script = true;
+            }
+            if i + 9 < lower_bytes.len() && &lower_bytes[i..i + 9] == b"</script>" {
+                in_script = false;
+                in_tag = false;
+                i += 9;
+                continue;
+            }
+            if i + 6 < lower_bytes.len() && &lower_bytes[i..i + 6] == b"<style" {
+                in_style = true;
+            }
+            if i + 8 < lower_bytes.len() && &lower_bytes[i..i + 8] == b"</style>" {
+                in_style = false;
+                in_tag = false;
+                i += 8;
+                continue;
+            }
+            in_tag = true;
+            i += 1;
+            continue;
+        }
+
+        if bytes[i] == b'>' {
+            in_tag = false;
+            // Insert space after closing tags to separate content
+            if !last_was_whitespace && !result.is_empty() {
+                result.push(' ');
+                last_was_whitespace = true;
+            }
+            i += 1;
+            continue;
+        }
+
+        if in_tag || in_script || in_style {
+            i += 1;
+            continue;
+        }
+
+        // Decode common HTML entities
+        if bytes[i] == b'&' {
+            if i + 4 <= bytes.len() && &bytes[i..i + 4] == b"&lt;" {
+                result.push('<');
+                last_was_whitespace = false;
+                i += 4;
+                continue;
+            }
+            if i + 4 <= bytes.len() && &bytes[i..i + 4] == b"&gt;" {
+                result.push('>');
+                last_was_whitespace = false;
+                i += 4;
+                continue;
+            }
+            if i + 5 <= bytes.len() && &bytes[i..i + 5] == b"&amp;" {
+                result.push('&');
+                last_was_whitespace = false;
+                i += 5;
+                continue;
+            }
+            if i + 6 <= bytes.len() && &bytes[i..i + 6] == b"&nbsp;" {
+                result.push(' ');
+                last_was_whitespace = true;
+                i += 6;
+                continue;
+            }
+            if i + 6 <= bytes.len() && &bytes[i..i + 6] == b"&quot;" {
+                result.push('"');
+                last_was_whitespace = false;
+                i += 6;
+                continue;
+            }
+        }
+
+        let ch = bytes[i] as char;
+        if ch.is_ascii_whitespace() {
+            if !last_was_whitespace && !result.is_empty() {
+                result.push(' ');
+                last_was_whitespace = true;
+            }
+        } else {
+            result.push(ch);
+            last_was_whitespace = false;
+        }
+        i += 1;
+    }
+
+    result.trim().to_owned()
+}
+
+// --- Definitions ---
+
+fn web_search_def() -> ToolDef {
+    ToolDef {
+        name: ToolName::new("web_search").expect("valid tool name"),
+        description: "Search the web using Brave Search. Returns titles, URLs, and descriptions."
+            .to_owned(),
+        extended_description: None,
+        input_schema: InputSchema {
+            properties: IndexMap::from([
+                (
+                    "query".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::String,
+                        description: "Search query".to_owned(),
+                        enum_values: None,
+                        default: None,
+                    },
+                ),
+                (
+                    "count".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::Number,
+                        description: "Number of results (default: 10, max: 20)".to_owned(),
+                        enum_values: None,
+                        default: Some(serde_json::json!(10)),
+                    },
+                ),
+            ]),
+            required: vec!["query".to_owned()],
+        },
+        category: ToolCategory::Research,
+        auto_activate: false,
+    }
+}
+
+fn web_fetch_def() -> ToolDef {
+    ToolDef {
+        name: ToolName::new("web_fetch").expect("valid tool name"),
+        description:
+            "Fetch a URL and return its content as text. HTML pages are converted to readable text."
+                .to_owned(),
+        extended_description: None,
+        input_schema: InputSchema {
+            properties: IndexMap::from([
+                (
+                    "url".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::String,
+                        description: "URL to fetch".to_owned(),
+                        enum_values: None,
+                        default: None,
+                    },
+                ),
+                (
+                    "maxLength".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::Number,
+                        description: "Maximum response length in characters (default: 50000)"
+                            .to_owned(),
+                        enum_values: None,
+                        default: Some(serde_json::json!(50000)),
+                    },
+                ),
+            ]),
+            required: vec!["url".to_owned()],
+        },
+        category: ToolCategory::Research,
+        auto_activate: false,
+    }
+}
+
+pub fn register(registry: &mut ToolRegistry) -> Result<()> {
+    registry.register(web_search_def(), Box::new(WebSearchExecutor))?;
+    registry.register(web_fetch_def(), Box::new(WebFetchExecutor))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+    use std::sync::{Arc, RwLock};
+
+    use aletheia_koina::id::{NousId, SessionId, ToolName};
+
+    use crate::types::{ToolContext, ToolInput, ToolServices};
+
+    use super::*;
+
+    fn test_ctx() -> ToolContext {
+        ToolContext {
+            nous_id: NousId::new("test-agent").expect("valid"),
+            session_id: SessionId::new(),
+            workspace: std::path::PathBuf::from("/tmp/test"),
+            allowed_roots: vec![std::path::PathBuf::from("/tmp")],
+            services: Some(Arc::new(ToolServices {
+                cross_nous: None,
+                messenger: None,
+                note_store: None,
+                blackboard_store: None,
+                http_client: reqwest::Client::new(),
+                lazy_tool_catalog: vec![],
+            })),
+            active_tools: Arc::new(RwLock::new(HashSet::new())),
+        }
+    }
+
+    #[test]
+    fn strip_html_basic() {
+        let html = "<html><body><h1>Title</h1><p>Hello world</p></body></html>";
+        let text = strip_html_tags(html);
+        assert_eq!(text, "Title Hello world");
+    }
+
+    #[test]
+    fn strip_html_script_and_style() {
+        let html = "<p>Before</p><script>var x = 1;</script><style>.a{}</style><p>After</p>";
+        let text = strip_html_tags(html);
+        assert_eq!(text, "Before After");
+    }
+
+    #[test]
+    fn strip_html_entities() {
+        let html = "&amp; &lt;tag&gt; &quot;quoted&quot;";
+        let text = strip_html_tags(html);
+        assert_eq!(text, "& <tag> \"quoted\"");
+    }
+
+    #[test]
+    fn strip_html_whitespace_collapse() {
+        let html = "<p>  lots   of    spaces  </p>";
+        let text = strip_html_tags(html);
+        assert_eq!(text, "lots of spaces");
+    }
+
+    #[test]
+    fn urlencoding_basic() {
+        assert_eq!(urlencoding("hello world"), "hello+world");
+        assert_eq!(urlencoding("a&b=c"), "a%26b%3Dc");
+        assert_eq!(urlencoding("simple"), "simple");
+    }
+
+    #[test]
+    fn web_search_def_is_lazy() {
+        let def = web_search_def();
+        assert!(!def.auto_activate);
+        assert_eq!(def.category, ToolCategory::Research);
+    }
+
+    #[test]
+    fn web_fetch_def_is_lazy() {
+        let def = web_fetch_def();
+        assert!(!def.auto_activate);
+        assert_eq!(def.category, ToolCategory::Research);
+    }
+
+    #[tokio::test]
+    async fn web_search_missing_api_key() {
+        // This test relies on BRAVE_API_KEY not being set or being empty
+        // in the CI/test environment. The executor checks for empty string.
+        let ctx = test_ctx();
+        let executor = WebSearchExecutor;
+        let input = ToolInput {
+            name: ToolName::new("web_search").expect("valid"),
+            tool_use_id: "toolu_1".to_owned(),
+            arguments: serde_json::json!({"query": "test"}),
+        };
+
+        let result = executor.execute(&input, &ctx).await.expect("execute");
+        // Either BRAVE_API_KEY is not set (error) or is set and makes a real request.
+        // In CI, it won't be set, so this tests the error path.
+        if result.is_error {
+            assert!(result.content.text_summary().contains("BRAVE_API_KEY"));
+        }
+    }
+
+    #[tokio::test]
+    async fn web_fetch_invalid_url() {
+        let ctx = test_ctx();
+        let executor = WebFetchExecutor;
+        let input = ToolInput {
+            name: ToolName::new("web_fetch").expect("valid"),
+            tool_use_id: "toolu_1".to_owned(),
+            arguments: serde_json::json!({"url": "not-a-url"}),
+        };
+
+        let result = executor.execute(&input, &ctx).await.expect("execute");
+        assert!(result.is_error);
+        assert!(result.content.text_summary().contains("http"));
+    }
+}

--- a/crates/organon/src/builtins/view_file.rs
+++ b/crates/organon/src/builtins/view_file.rs
@@ -209,12 +209,15 @@ fn view_file_def() -> crate::types::ToolDef {
             required: vec!["path".to_owned()],
         },
         category: ToolCategory::Workspace,
-        auto_activate: false,
+        auto_activate: true,
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashSet;
+    use std::sync::{Arc, RwLock};
+
     use aletheia_koina::id::{NousId, SessionId, ToolName};
 
     use super::*;
@@ -227,6 +230,7 @@ mod tests {
             workspace: dir.to_path_buf(),
             allowed_roots: vec![dir.to_path_buf()],
             services: None,
+            active_tools: Arc::new(RwLock::new(HashSet::new())),
         }
     }
 

--- a/crates/organon/src/builtins/workspace.rs
+++ b/crates/organon/src/builtins/workspace.rs
@@ -345,7 +345,7 @@ fn read_def() -> ToolDef {
             required: vec!["path".to_owned()],
         },
         category: ToolCategory::Workspace,
-        auto_activate: false,
+        auto_activate: true,
     }
 }
 
@@ -387,7 +387,7 @@ fn write_def() -> ToolDef {
             required: vec!["path".to_owned(), "content".to_owned()],
         },
         category: ToolCategory::Workspace,
-        auto_activate: false,
+        auto_activate: true,
     }
 }
 
@@ -433,7 +433,7 @@ fn edit_def() -> ToolDef {
             ],
         },
         category: ToolCategory::Workspace,
-        auto_activate: false,
+        auto_activate: true,
     }
 }
 
@@ -467,7 +467,7 @@ fn exec_def() -> ToolDef {
             required: vec!["command".to_owned()],
         },
         category: ToolCategory::Workspace,
-        auto_activate: false,
+        auto_activate: true,
     }
 }
 
@@ -477,6 +477,9 @@ fn exec_def() -> ToolDef {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashSet;
+    use std::sync::{Arc, RwLock};
+
     use aletheia_koina::id::{NousId, SessionId};
 
     use super::*;
@@ -488,6 +491,7 @@ mod tests {
             workspace: dir.to_path_buf(),
             allowed_roots: vec![dir.to_path_buf()],
             services: None,
+            active_tools: Arc::new(RwLock::new(HashSet::new())),
         }
     }
 

--- a/crates/organon/src/registry.rs
+++ b/crates/organon/src/registry.rs
@@ -1,5 +1,6 @@
 //! Tool registry — the single source of truth for available tools.
 
+use std::collections::HashSet;
 use std::future::Future;
 use std::pin::Pin;
 use std::time::Instant;
@@ -131,11 +132,46 @@ impl ToolRegistry {
             })
             .collect()
     }
+
+    /// Convert tools to LLM wire format, filtered by activation state.
+    ///
+    /// Includes tools where:
+    /// - `auto_activate == true` (always-on essentials)
+    /// - name is in the `active` set (dynamically activated via `enable_tool`)
+    /// - name is `enable_tool` (always available so agents can activate more)
+    pub fn to_hermeneus_tools_filtered(
+        &self,
+        active: &HashSet<ToolName>,
+    ) -> Vec<aletheia_hermeneus::types::ToolDefinition> {
+        self.tools
+            .values()
+            .filter(|t| {
+                t.def.auto_activate
+                    || active.contains(&t.def.name)
+                    || t.def.name.as_str() == "enable_tool"
+            })
+            .map(|t| aletheia_hermeneus::types::ToolDefinition {
+                name: t.def.name.as_str().to_owned(),
+                description: t.def.description.clone(),
+                input_schema: t.def.input_schema.to_json_schema(),
+            })
+            .collect()
+    }
+
+    /// Catalog of lazy tools (`auto_activate=false`) for the `enable_tool` executor.
+    #[must_use]
+    pub fn lazy_tool_catalog(&self) -> Vec<(ToolName, String)> {
+        self.tools
+            .values()
+            .filter(|t| !t.def.auto_activate && t.def.name.as_str() != "enable_tool")
+            .map(|t| (t.def.name.clone(), t.def.description.clone()))
+            .collect()
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use std::sync::{Arc, Mutex};
+    use std::sync::{Arc, Mutex, RwLock};
 
     use aletheia_koina::id::{NousId, SessionId};
 
@@ -168,6 +204,7 @@ mod tests {
             workspace: std::path::PathBuf::from("/tmp/test"),
             allowed_roots: vec![std::path::PathBuf::from("/tmp")],
             services: None,
+            active_tools: Arc::new(RwLock::new(HashSet::new())),
         }
     }
 
@@ -363,5 +400,117 @@ mod tests {
 
         let id = captured.lock().expect("lock").clone();
         assert_eq!(id.as_deref(), Some("test-agent"));
+    }
+
+    fn test_def_with_activate(name: &str, category: ToolCategory, auto_activate: bool) -> ToolDef {
+        ToolDef {
+            name: ToolName::new(name).expect("valid"),
+            description: format!("Test tool: {name}"),
+            extended_description: None,
+            input_schema: InputSchema {
+                properties: IndexMap::new(),
+                required: vec![],
+            },
+            category,
+            auto_activate,
+        }
+    }
+
+    #[test]
+    fn filtered_tools_respects_auto_activate() {
+        let mut reg = ToolRegistry::new();
+        let (e1, _) = mock_executor("ok");
+        let (e2, _) = mock_executor("ok");
+        let (e3, _) = mock_executor("ok");
+        reg.register(
+            test_def_with_activate("read", ToolCategory::Workspace, true),
+            e1,
+        )
+        .expect("register");
+        reg.register(
+            test_def_with_activate("web_search", ToolCategory::Research, false),
+            e2,
+        )
+        .expect("register");
+        reg.register(
+            test_def_with_activate("enable_tool", ToolCategory::System, true),
+            e3,
+        )
+        .expect("register");
+
+        let active = HashSet::new();
+        let tools = reg.to_hermeneus_tools_filtered(&active);
+        let names: Vec<&str> = tools.iter().map(|t| t.name.as_str()).collect();
+        assert!(names.contains(&"read"));
+        assert!(names.contains(&"enable_tool"));
+        assert!(!names.contains(&"web_search"));
+    }
+
+    #[test]
+    fn filtered_tools_includes_active_set() {
+        let mut reg = ToolRegistry::new();
+        let (e1, _) = mock_executor("ok");
+        let (e2, _) = mock_executor("ok");
+        reg.register(
+            test_def_with_activate("read", ToolCategory::Workspace, true),
+            e1,
+        )
+        .expect("register");
+        reg.register(
+            test_def_with_activate("web_search", ToolCategory::Research, false),
+            e2,
+        )
+        .expect("register");
+
+        let mut active = HashSet::new();
+        active.insert(ToolName::new("web_search").expect("valid"));
+        let tools = reg.to_hermeneus_tools_filtered(&active);
+        let names: Vec<&str> = tools.iter().map(|t| t.name.as_str()).collect();
+        assert!(names.contains(&"read"));
+        assert!(names.contains(&"web_search"));
+    }
+
+    #[test]
+    fn filtered_tools_always_includes_enable_tool() {
+        let mut reg = ToolRegistry::new();
+        let (e1, _) = mock_executor("ok");
+        // enable_tool with auto_activate=false should still appear
+        reg.register(
+            test_def_with_activate("enable_tool", ToolCategory::System, false),
+            e1,
+        )
+        .expect("register");
+
+        let active = HashSet::new();
+        let tools = reg.to_hermeneus_tools_filtered(&active);
+        assert_eq!(tools.len(), 1);
+        assert_eq!(tools[0].name, "enable_tool");
+    }
+
+    #[test]
+    fn lazy_tool_catalog_excludes_auto_activate_and_enable_tool() {
+        let mut reg = ToolRegistry::new();
+        let (e1, _) = mock_executor("ok");
+        let (e2, _) = mock_executor("ok");
+        let (e3, _) = mock_executor("ok");
+        reg.register(
+            test_def_with_activate("read", ToolCategory::Workspace, true),
+            e1,
+        )
+        .expect("register");
+        reg.register(
+            test_def_with_activate("web_search", ToolCategory::Research, false),
+            e2,
+        )
+        .expect("register");
+        reg.register(
+            test_def_with_activate("enable_tool", ToolCategory::System, true),
+            e3,
+        )
+        .expect("register");
+
+        let catalog = reg.lazy_tool_catalog();
+        assert_eq!(catalog.len(), 1);
+        assert_eq!(catalog[0].0.as_str(), "web_search");
     }
 }

--- a/crates/organon/src/types.rs
+++ b/crates/organon/src/types.rs
@@ -1,9 +1,10 @@
 //! Core types for tool definitions, input/output, and execution context.
 
+use std::collections::HashSet;
 use std::future::Future;
 use std::path::PathBuf;
 use std::pin::Pin;
-use std::sync::Arc;
+use std::sync::{Arc, RwLock};
 
 use aletheia_koina::id::{NousId, SessionId, ToolName};
 use indexmap::IndexMap;
@@ -146,6 +147,8 @@ pub enum ToolCategory {
     System,
     /// Agent coordination and spawning.
     Agent,
+    /// Web research and information retrieval.
+    Research,
     /// External domain pack tools.
     Domain,
 }
@@ -159,6 +162,7 @@ impl std::fmt::Display for ToolCategory {
             Self::Planning => f.write_str("planning"),
             Self::System => f.write_str("system"),
             Self::Agent => f.write_str("agent"),
+            Self::Research => f.write_str("research"),
             Self::Domain => f.write_str("domain"),
         }
     }
@@ -287,6 +291,8 @@ pub struct ToolServices {
     pub note_store: Option<Arc<dyn NoteStore>>,
     pub blackboard_store: Option<Arc<dyn BlackboardStore>>,
     pub http_client: reqwest::Client,
+    /// Catalog of lazy tools available for activation via `enable_tool`.
+    pub lazy_tool_catalog: Vec<(ToolName, String)>,
 }
 
 impl std::fmt::Debug for ToolServices {
@@ -296,6 +302,7 @@ impl std::fmt::Debug for ToolServices {
             .field("messenger", &self.messenger.is_some())
             .field("note_store", &self.note_store.is_some())
             .field("blackboard_store", &self.blackboard_store.is_some())
+            .field("lazy_tool_catalog_len", &self.lazy_tool_catalog.len())
             .finish_non_exhaustive()
     }
 }
@@ -311,8 +318,10 @@ pub struct ToolContext {
     pub workspace: PathBuf,
     /// Allowed filesystem roots for sandboxing.
     pub allowed_roots: Vec<PathBuf>,
-/// Optional runtime services for tools that need cross-cutting capabilities.
+    /// Optional runtime services for tools that need cross-cutting capabilities.
     pub services: Option<Arc<ToolServices>>,
+    /// Per-session set of dynamically activated tools (via `enable_tool`).
+    pub active_tools: Arc<RwLock<HashSet<ToolName>>>,
 }
 
 /// Persistent session notes storage.
@@ -455,6 +464,7 @@ mod tests {
     fn tool_category_display() {
         assert_eq!(ToolCategory::Workspace.to_string(), "workspace");
         assert_eq!(ToolCategory::Communication.to_string(), "communication");
+        assert_eq!(ToolCategory::Research.to_string(), "research");
     }
 
     #[test]

--- a/crates/thesauros/src/tools.rs
+++ b/crates/thesauros/src/tools.rs
@@ -513,6 +513,9 @@ mod tests {
             workspace: dir.path().to_path_buf(),
             allowed_roots: vec![],
             services: None,
+            active_tools: std::sync::Arc::new(std::sync::RwLock::new(
+                std::collections::HashSet::new(),
+            )),
         };
 
         let result = futures::executor::block_on(executor.execute(&input, &ctx)).unwrap();
@@ -542,6 +545,9 @@ mod tests {
             workspace: dir.path().to_path_buf(),
             allowed_roots: vec![],
             services: None,
+            active_tools: std::sync::Arc::new(std::sync::RwLock::new(
+                std::collections::HashSet::new(),
+            )),
         };
 
         let result = futures::executor::block_on(executor.execute(&input, &ctx)).unwrap();


### PR DESCRIPTION
## Summary

- Add `enable_tool` meta-tool for per-session dynamic tool activation
- Add `web_search` (Brave Search API) and `web_fetch` (HTTP GET + HTML stripping) as first lazy tools
- Implement tool filtering in execute stage: only `auto_activate=true` tools + session-activated tools sent to LLM
- All existing essential tools (read, write, edit, exec, grep, find, ls, mem0_search, note, blackboard, message, sessions_send, sessions_ask, view_file) flipped to `auto_activate: true`

## Changes

| Area | Change |
|------|--------|
| `organon/types.rs` | `active_tools` on ToolContext, `lazy_tool_catalog` on ToolServices, `Research` category |
| `organon/registry.rs` | `to_hermeneus_tools_filtered()`, `lazy_tool_catalog()` methods |
| `organon/builtins/enable_tool.rs` | New enable_tool executor |
| `organon/builtins/research.rs` | New web_search and web_fetch executors |
| `nous/execute.rs` | Tool list rebuilt per-iteration with activation filter |
| `aletheia/main.rs` | Populate lazy_tool_catalog in ToolServices |
| All builtin defs | Essential tools set `auto_activate: true` |

## Test plan

- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test -p aletheia-organon` (90 tests, including enable_tool and research)
- [x] `cargo test -p aletheia-nous` (194 tests)
- [x] `cargo test --workspace` (all pass)