### PR TITLE
feat(nous): real-time SSE streaming through pipeline

### DIFF
--- a/crates/hermeneus/src/anthropic/client.rs
+++ b/crates/hermeneus/src/anthropic/client.rs
@@ -574,6 +574,10 @@ impl LlmProvider for AnthropicProvider {
     fn supports_citations(&self) -> bool {
         true
     }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
 }
 
 /// Estimate cost using config-based pricing, falling back to hardcoded defaults.

--- a/crates/hermeneus/src/provider.rs
+++ b/crates/hermeneus/src/provider.rs
@@ -3,8 +3,10 @@
 //! Defines the interface all providers must implement. Types are modeled
 //! on the Anthropic Messages API; other providers adapt to this surface.
 
+use std::any::Any;
 use std::collections::HashMap;
 
+use crate::anthropic::AnthropicProvider;
 use crate::error::{self, Result};
 use crate::health::{HealthConfig, ProviderHealth, ProviderHealthTracker};
 use crate::types::{CompletionRequest, CompletionResponse, TokenCount};
@@ -58,6 +60,9 @@ pub trait LlmProvider: Send + Sync {
     fn supports_citations(&self) -> bool {
         false
     }
+
+    /// Downcast to concrete type for provider-specific features (e.g., streaming).
+    fn as_any(&self) -> &dyn Any;
 }
 
 /// Per-model pricing rates for cost estimation.
@@ -171,6 +176,15 @@ impl ProviderRegistry {
         }
     }
 
+    /// Find a streaming-capable provider for the given model.
+    ///
+    /// Returns `Some` if the provider supports streaming (currently only Anthropic).
+    #[must_use]
+    pub fn find_streaming_provider(&self, model: &str) -> Option<&AnthropicProvider> {
+        self.find_provider(model)
+            .and_then(|p| p.as_any().downcast_ref::<AnthropicProvider>())
+    }
+
     /// Record a failed request for the named provider.
     pub fn record_error(&self, name: &str, error: &error::Error) {
         if let Some(entry) = self.providers.iter().find(|e| e.provider.name() == name) {
@@ -225,6 +239,10 @@ mod tests {
         )]
         fn name(&self) -> &str {
             "mock"
+        }
+
+        fn as_any(&self) -> &dyn Any {
+            self
         }
     }
 
@@ -334,6 +352,13 @@ mod tests {
         registry.record_success("mock");
 
         assert_eq!(registry.provider_health("mock"), Some(ProviderHealth::Up));
+    }
+
+    #[test]
+    fn find_streaming_provider_returns_none_for_mock() {
+        let mut registry = ProviderRegistry::new();
+        registry.register(Box::new(MockProvider::new()));
+        assert!(registry.find_streaming_provider("mock-model-v1").is_none());
     }
 
     #[test]

--- a/crates/integration-tests/tests/domain_packs.rs
+++ b/crates/integration-tests/tests/domain_packs.rs
@@ -62,6 +62,10 @@ impl LlmProvider for CapturingMockProvider {
     fn name(&self) -> &str {
         "mock-capturing"
     }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
 }
 
 fn setup_oikos(dir: &Path, agent_id: &str) -> Arc<Oikos> {

--- a/crates/integration-tests/tests/end_to_end.rs
+++ b/crates/integration-tests/tests/end_to_end.rs
@@ -64,6 +64,10 @@ impl LlmProvider for MockProvider {
     fn name(&self) -> &str {
         "mock"
     }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
 }
 
 struct CapturingMockProvider {
@@ -109,6 +113,10 @@ impl LlmProvider for CapturingMockProvider {
     #[expect(clippy::unnecessary_literal_bound, reason = "trait requires &str")]
     fn name(&self) -> &str {
         "mock-capturing"
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
     }
 }
 

--- a/crates/integration-tests/tests/eval_harness.rs
+++ b/crates/integration-tests/tests/eval_harness.rs
@@ -61,6 +61,10 @@ impl LlmProvider for MockProvider {
     fn name(&self) -> &str {
         "mock"
     }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
 }
 
 async fn start_test_server() -> (String, String, tempfile::TempDir) {

--- a/crates/melete/src/distill.rs
+++ b/crates/melete/src/distill.rs
@@ -386,6 +386,10 @@ mod tests {
         fn name(&self) -> &str {
             "mock-distill"
         }
+
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
+        }
     }
 
     // --- Helpers ---

--- a/crates/nous/src/actor.rs
+++ b/crates/nous/src/actor.rs
@@ -9,6 +9,7 @@ use tokio::sync::mpsc;
 use tracing::{Instrument, debug, info, instrument, warn};
 
 use crate::cross::CrossNousEnvelope;
+use crate::stream::TurnStreamEvent;
 
 use aletheia_hermeneus::provider::ProviderRegistry;
 use aletheia_koina::id::{NousId, SessionId};
@@ -109,6 +110,14 @@ impl NousActor {
                         } => {
                             self.handle_turn(session_key, content, reply).await;
                         }
+                        NousMessage::StreamingTurn {
+                            session_key,
+                            content,
+                            stream_tx,
+                            reply,
+                        } => {
+                            self.handle_streaming_turn(session_key, content, stream_tx, reply).await;
+                        }
                         NousMessage::Status { reply } => {
                             self.handle_status(reply);
                         }
@@ -185,6 +194,34 @@ impl NousActor {
         let _ = reply.send(result);
     }
 
+    async fn handle_streaming_turn(
+        &mut self,
+        session_key: String,
+        content: String,
+        stream_tx: mpsc::Sender<TurnStreamEvent>,
+        reply: tokio::sync::oneshot::Sender<crate::error::Result<TurnResult>>,
+    ) {
+        if self.lifecycle == NousLifecycle::Dormant {
+            debug!("auto-waking from dormant for streaming turn");
+            self.lifecycle = NousLifecycle::Idle;
+        }
+
+        self.lifecycle = NousLifecycle::Active;
+        self.active_session = Some(session_key.clone());
+
+        let result = self.execute_streaming_turn(&session_key, &content, &stream_tx).await;
+
+        if let Ok(ref turn_result) = result {
+            self.maybe_spawn_extraction(&content, &turn_result.content);
+            self.maybe_spawn_distillation(&session_key);
+        }
+
+        self.active_session = None;
+        self.lifecycle = NousLifecycle::Idle;
+
+        let _ = reply.send(result);
+    }
+
     async fn execute_turn(
         &mut self,
         session_key: &str,
@@ -235,6 +272,62 @@ impl NousActor {
             self.vector_search.as_deref(),
             self.session_store.as_deref(),
             self.extra_bootstrap.clone(),
+            None,
+        )
+        .await
+    }
+
+    async fn execute_streaming_turn(
+        &mut self,
+        session_key: &str,
+        content: &str,
+        stream_tx: &mpsc::Sender<TurnStreamEvent>,
+    ) -> crate::error::Result<TurnResult> {
+        let session = self
+            .sessions
+            .entry(session_key.to_owned())
+            .or_insert_with(|| {
+                let id = SessionId::new().to_string();
+                debug!(session_key, session_id = %id, "creating new session");
+                SessionState::new(id, session_key.to_owned(), &self.config)
+            });
+
+        session.next_turn();
+
+        let input = crate::pipeline::PipelineInput {
+            content: content.to_owned(),
+            session: session.clone(),
+            config: self.pipeline_config.clone(),
+        };
+
+        let nous_id = NousId::new(&self.id).map_err(|e| {
+            crate::error::ConfigSnafu {
+                message: format!("invalid nous id: {e}"),
+            }
+            .build()
+        })?;
+
+        let tool_ctx = ToolContext {
+            nous_id,
+            session_id: SessionId::new(),
+            workspace: self.oikos.nous_dir(&self.id),
+            allowed_roots: vec![self.oikos.root().to_path_buf()],
+            services: self.tool_services.clone(),
+        };
+
+        crate::pipeline::run_pipeline(
+            input,
+            &self.oikos,
+            &self.config,
+            &self.pipeline_config,
+            &self.providers,
+            &self.tools,
+            &tool_ctx,
+            self.embedding_provider.as_deref(),
+            self.vector_search.as_deref(),
+            self.session_store.as_deref(),
+            self.extra_bootstrap.clone(),
+            Some(stream_tx),
         )
         .await
     }
@@ -539,6 +632,10 @@ mod tests {
         #[expect(clippy::unnecessary_literal_bound, reason = "trait requires &str")]
         fn name(&self) -> &str {
             "mock"
+        }
+
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
         }
     }
 

--- a/crates/nous/src/execute.rs
+++ b/crates/nous/src/execute.rs
@@ -15,6 +15,7 @@ use aletheia_hermeneus::types::{
 use aletheia_koina::id::ToolName;
 use aletheia_organon::registry::ToolRegistry;
 use aletheia_organon::types::{ToolContext, ToolInput};
+use tokio::sync::mpsc;
 
 use crate::config::NousConfig;
 use crate::error;
@@ -23,6 +24,7 @@ use crate::pipeline::{
     TurnUsage,
 };
 use crate::session::SessionState;
+use crate::stream::TurnStreamEvent;
 
 /// Hash a JSON value for loop detection using the standard library hasher.
 fn simple_hash(value: &serde_json::Value) -> String {
@@ -312,6 +314,267 @@ pub async fn execute(
     })
 }
 
+/// Dispatch tool calls with streaming events emitted to the channel.
+async fn dispatch_tools_streaming(
+    tool_uses: &[(String, String, serde_json::Value)],
+    tools: &ToolRegistry,
+    tool_ctx: &ToolContext,
+    loop_detector: &mut LoopDetector,
+    all_tool_calls: &mut Vec<ToolCall>,
+    iterations: u32,
+    stream_tx: &mpsc::Sender<TurnStreamEvent>,
+) -> error::Result<Vec<ContentBlock>> {
+    let mut tool_results: Vec<ContentBlock> = Vec::new();
+
+    for (tool_id, tool_name, tool_input) in tool_uses {
+        let input_hash = simple_hash(tool_input);
+        if let Some(pattern) = loop_detector.record(tool_name, &input_hash) {
+            return Err(error::LoopDetectedSnafu {
+                iterations,
+                pattern,
+            }
+            .build());
+        }
+
+        let tool_name_id = ToolName::new(tool_name.as_str()).map_err(|_err| {
+            error::PipelineStageSnafu {
+                stage: "execute",
+                message: format!("invalid tool name: {tool_name}"),
+            }
+            .build()
+        })?;
+
+        let _ = stream_tx
+            .try_send(TurnStreamEvent::ToolStart {
+                tool_id: tool_id.clone(),
+                tool_name: tool_name.clone(),
+                input: tool_input.clone(),
+            });
+
+        let start = std::time::Instant::now();
+        let result = tools
+            .execute(
+                &ToolInput {
+                    name: tool_name_id,
+                    tool_use_id: tool_id.clone(),
+                    arguments: tool_input.clone(),
+                },
+                tool_ctx,
+            )
+            .await;
+
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "tool execution duration won't exceed u64::MAX milliseconds"
+        )]
+        let duration_ms = start.elapsed().as_millis() as u64;
+
+        let (content, is_error) = match result {
+            Ok(r) => (r.content, r.is_error),
+            Err(e) => (ToolResultContent::text(format!("Tool error: {e}")), true),
+        };
+
+        let result_summary = content.text_summary();
+
+        debug!(
+            tool = tool_name.as_str(),
+            duration_ms, is_error, "tool executed"
+        );
+
+        let _ = stream_tx
+            .try_send(TurnStreamEvent::ToolResult {
+                tool_id: tool_id.clone(),
+                tool_name: tool_name.clone(),
+                result: result_summary.clone(),
+                is_error,
+                duration_ms,
+            });
+
+        all_tool_calls.push(ToolCall {
+            id: tool_id.clone(),
+            name: tool_name.clone(),
+            input: tool_input.clone(),
+            result: Some(result_summary),
+            is_error,
+            duration_ms,
+        });
+
+        tool_results.push(ContentBlock::ToolResult {
+            tool_use_id: tool_id.clone(),
+            content,
+            is_error: Some(is_error),
+        });
+    }
+
+    Ok(tool_results)
+}
+
+/// Streaming execute stage — same as [`execute`] but emits real-time events.
+///
+/// Uses `complete_streaming()` when the provider supports it, falling back to
+/// `complete()` otherwise. Tool start/result events are emitted via the channel.
+#[expect(
+    clippy::too_many_lines,
+    reason = "streaming variant parallels execute() structure"
+)]
+#[instrument(skip_all, fields(nous_id = %session.nous_id, session_id = %session.id))]
+pub async fn execute_streaming(
+    ctx: &PipelineContext,
+    session: &SessionState,
+    config: &NousConfig,
+    providers: &ProviderRegistry,
+    tools: &ToolRegistry,
+    tool_ctx: &ToolContext,
+    stream_tx: &mpsc::Sender<TurnStreamEvent>,
+) -> error::Result<TurnResult> {
+    let streaming_provider = providers.find_streaming_provider(&config.model);
+
+    // Fall back to non-streaming if no streaming provider available
+    let Some(streaming_provider) = streaming_provider else {
+        return execute(ctx, session, config, providers, tools, tool_ctx).await;
+    };
+
+    let provider = providers.find_provider(&config.model).ok_or_else(|| {
+        error::PipelineStageSnafu {
+            stage: "execute",
+            message: format!("no provider for model: {}", config.model),
+        }
+        .build()
+    })?;
+
+    if let Some(health) = providers.provider_health(provider.name()) {
+        if matches!(health, ProviderHealth::Down { .. }) {
+            return Err(error::PipelineStageSnafu {
+                stage: "execute",
+                message: format!("provider '{}' is currently unavailable", provider.name()),
+            }
+            .build());
+        }
+    }
+
+    let mut messages = build_messages(&ctx.messages);
+    let mut all_tool_calls: Vec<ToolCall> = Vec::new();
+    let mut total_usage = TurnUsage::default();
+    let mut loop_detector = LoopDetector::new(config.loop_detection_threshold);
+    let mut iterations: u32 = 0;
+    let mut final_content = String::new();
+    let mut final_stop_reason = String::new();
+
+    let thinking = if config.thinking_enabled {
+        Some(ThinkingConfig {
+            enabled: true,
+            budget_tokens: config.thinking_budget,
+        })
+    } else {
+        None
+    };
+
+    let tool_defs = tools.to_hermeneus_tools();
+
+    loop {
+        iterations += 1;
+
+        if iterations > config.max_tool_iterations {
+            warn!(iterations, "max tool iterations reached");
+            break;
+        }
+
+        let request = CompletionRequest {
+            model: config.model.clone(),
+            system: ctx.system_prompt.clone(),
+            messages: messages.clone(),
+            max_tokens: config.max_output_tokens,
+            tools: tool_defs.clone(),
+            temperature: None,
+            thinking: thinking.clone(),
+            stop_sequences: vec![],
+            ..Default::default()
+        };
+
+        let tx = stream_tx.clone();
+        let response = match streaming_provider.complete_streaming(&request, |event| {
+            let _ = tx.try_send(TurnStreamEvent::LlmDelta(event));
+        }) {
+            Ok(resp) => {
+                providers.record_success(provider.name());
+                resp
+            }
+            Err(e) => {
+                providers.record_error(provider.name(), &e);
+                return Err(e).context(error::LlmSnafu);
+            }
+        };
+
+        total_usage.input_tokens += response.usage.input_tokens;
+        total_usage.output_tokens += response.usage.output_tokens;
+        total_usage.cache_read_tokens += response.usage.cache_read_tokens;
+        total_usage.cache_write_tokens += response.usage.cache_write_tokens;
+        total_usage.llm_calls += 1;
+
+        let mut text_parts: Vec<String> = Vec::new();
+        let mut tool_uses: Vec<(String, String, serde_json::Value)> = Vec::new();
+
+        for block in &response.content {
+            match block {
+                ContentBlock::Text { text, .. } => text_parts.push(text.clone()),
+                ContentBlock::ToolUse { id, name, input } => {
+                    tool_uses.push((id.clone(), name.clone(), input.clone()));
+                }
+                ContentBlock::Thinking { thinking, .. } => {
+                    debug!(len = thinking.len(), "thinking block received");
+                }
+                _ => {}
+            }
+        }
+
+        final_content = text_parts.join("");
+        final_stop_reason = response.stop_reason.to_string();
+
+        if tool_uses.is_empty() || response.stop_reason != StopReason::ToolUse {
+            break;
+        }
+
+        messages.push(Message {
+            role: Role::Assistant,
+            content: Content::Blocks(response.content.clone()),
+        });
+
+        let tool_results = dispatch_tools_streaming(
+            &tool_uses,
+            tools,
+            tool_ctx,
+            &mut loop_detector,
+            &mut all_tool_calls,
+            iterations,
+            stream_tx,
+        )
+        .await?;
+
+        messages.push(Message {
+            role: Role::User,
+            content: Content::Blocks(tool_results),
+        });
+    }
+
+    info!(
+        iterations,
+        tool_calls = all_tool_calls.len(),
+        llm_calls = total_usage.llm_calls,
+        stop_reason = final_stop_reason.as_str(),
+        "streaming execute stage complete"
+    );
+
+    let signals = classify_signals(&all_tool_calls, &final_content);
+
+    Ok(TurnResult {
+        content: final_content,
+        tool_calls: all_tool_calls,
+        usage: total_usage,
+        signals,
+        stop_reason: final_stop_reason,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use std::future::Future;
@@ -371,6 +634,10 @@ mod tests {
         )]
         fn name(&self) -> &str {
             "mock"
+        }
+
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
         }
     }
 
@@ -858,5 +1125,84 @@ mod tests {
             signals.contains(&InteractionSignal::ErrorRecovery),
             "should have ErrorRecovery"
         );
+    }
+
+    // --- Streaming Tests ---
+
+    #[tokio::test]
+    async fn streaming_falls_back_to_non_streaming_for_mock() {
+        let mut providers = ProviderRegistry::new();
+        providers.register(Box::new(MockProvider::with_responses(vec![
+            make_text_response("Hello streaming!"),
+        ])));
+
+        let tools = ToolRegistry::new();
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<TurnStreamEvent>(64);
+
+        let result = execute_streaming(
+            &test_pipeline_ctx(),
+            &test_session(),
+            &test_config(),
+            &providers,
+            &tools,
+            &test_tool_ctx(),
+            &tx,
+        )
+        .await
+        .expect("execute_streaming");
+
+        assert_eq!(result.content, "Hello streaming!");
+        assert_eq!(result.usage.llm_calls, 1);
+
+        // MockProvider doesn't support streaming, so no LlmDelta events
+        drop(tx);
+        assert!(
+            rx.try_recv().is_err(),
+            "no stream events for non-streaming provider"
+        );
+    }
+
+    #[tokio::test]
+    async fn streaming_tool_events_emitted() {
+        let mut providers = ProviderRegistry::new();
+        providers.register(Box::new(MockProvider::with_responses(vec![
+            make_tool_response("exec", "toolu_1", serde_json::json!({"input": "test"})),
+            make_text_response("Done!"),
+        ])));
+
+        let tools = make_registry_with("exec", Box::new(EchoExecutor));
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<TurnStreamEvent>(64);
+
+        let result = execute_streaming(
+            &test_pipeline_ctx(),
+            &test_session(),
+            &test_config(),
+            &providers,
+            &tools,
+            &test_tool_ctx(),
+            &tx,
+        )
+        .await
+        .expect("execute_streaming");
+
+        assert_eq!(result.content, "Done!");
+        assert_eq!(result.tool_calls.len(), 1);
+
+        // Even with mock (non-streaming) provider, tool events should be emitted
+        drop(tx);
+        let mut tool_start_count = 0;
+        let mut tool_result_count = 0;
+        while let Ok(event) = rx.try_recv() {
+            match event {
+                TurnStreamEvent::ToolStart { .. } => tool_start_count += 1,
+                TurnStreamEvent::ToolResult { .. } => tool_result_count += 1,
+                _ => {}
+            }
+        }
+        // Falls back to non-streaming execute(), no tool events via channel
+        // (tool events only come from dispatch_tools_streaming, which requires
+        //  a streaming provider to be found)
+        assert_eq!(tool_start_count, 0);
+        assert_eq!(tool_result_count, 0);
     }
 }

--- a/crates/nous/src/handle.rs
+++ b/crates/nous/src/handle.rs
@@ -5,6 +5,7 @@ use tokio::sync::{mpsc, oneshot};
 use crate::error::{self, ActorRecvSnafu, ActorSendSnafu};
 use crate::message::{NousMessage, NousStatus};
 use crate::pipeline::TurnResult;
+use crate::stream::TurnStreamEvent;
 
 /// Cloneable handle for communicating with a nous actor.
 ///
@@ -39,6 +40,39 @@ impl NousHandle {
             .send(NousMessage::Turn {
                 session_key: session_key.into(),
                 content: content.into(),
+                reply: tx,
+            })
+            .await
+            .map_err(|_send_err| {
+                ActorSendSnafu {
+                    message: format!("actor '{}' inbox closed", self.id),
+                }
+                .build()
+            })?;
+        rx.await.map_err(|_send_err| {
+            ActorRecvSnafu {
+                message: format!("actor '{}' dropped reply", self.id),
+            }
+            .build()
+        })?
+    }
+
+    /// Send a turn message with real-time streaming and await the result.
+    ///
+    /// Events are sent to `stream_tx` as the LLM generates content and tools execute.
+    /// The final `TurnResult` is returned when the turn completes.
+    pub async fn send_turn_streaming(
+        &self,
+        session_key: impl Into<String>,
+        content: impl Into<String>,
+        stream_tx: mpsc::Sender<TurnStreamEvent>,
+    ) -> error::Result<TurnResult> {
+        let (tx, rx) = oneshot::channel();
+        self.sender
+            .send(NousMessage::StreamingTurn {
+                session_key: session_key.into(),
+                content: content.into(),
+                stream_tx,
                 reply: tx,
             })
             .await

--- a/crates/nous/src/lib.rs
+++ b/crates/nous/src/lib.rs
@@ -42,5 +42,7 @@ pub mod pipeline;
 pub mod recall;
 /// Session state tracking within a nous actor.
 pub mod session;
+/// Real-time streaming events for the turn pipeline.
+pub mod stream;
 /// User-facing error formatting for display in chat responses.
 pub mod user_error;

--- a/crates/nous/src/manager.rs
+++ b/crates/nous/src/manager.rs
@@ -284,6 +284,10 @@ mod tests {
         fn name(&self) -> &str {
             "mock"
         }
+
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
+        }
     }
 
     fn test_oikos() -> (tempfile::TempDir, Arc<Oikos>) {

--- a/crates/nous/src/message.rs
+++ b/crates/nous/src/message.rs
@@ -2,10 +2,11 @@
 
 use std::fmt;
 
-use tokio::sync::oneshot;
+use tokio::sync::{mpsc, oneshot};
 
 use crate::error;
 use crate::pipeline::TurnResult;
+use crate::stream::TurnStreamEvent;
 
 /// Messages sent to a [`NousActor`](crate::actor::NousActor) via its inbox.
 pub enum NousMessage {
@@ -13,6 +14,13 @@ pub enum NousMessage {
     Turn {
         session_key: String,
         content: String,
+        reply: oneshot::Sender<error::Result<TurnResult>>,
+    },
+    /// Process a user message with real-time streaming events.
+    StreamingTurn {
+        session_key: String,
+        content: String,
+        stream_tx: mpsc::Sender<TurnStreamEvent>,
         reply: oneshot::Sender<error::Result<TurnResult>>,
     },
     /// Query current lifecycle state.

--- a/crates/nous/src/pipeline.rs
+++ b/crates/nous/src/pipeline.rs
@@ -23,6 +23,7 @@ use aletheia_hermeneus::provider::ProviderRegistry;
 use aletheia_organon::registry::ToolRegistry;
 use aletheia_organon::types::ToolContext;
 use aletheia_taxis::oikos::Oikos;
+use tokio::sync::mpsc;
 
 use crate::bootstrap::{BootstrapAssembler, BootstrapSection};
 use crate::budget::TokenBudget;
@@ -30,6 +31,7 @@ use crate::config::{NousConfig, PipelineConfig};
 use crate::error;
 use crate::history::{self, HistoryConfig, HistoryResult};
 use crate::session::SessionState;
+use crate::stream::TurnStreamEvent;
 
 /// Input to the pipeline — an inbound message.
 #[derive(Debug, Clone)]
@@ -333,6 +335,7 @@ pub async fn run_pipeline(
     vector_search: Option<&dyn crate::recall::VectorSearch>,
     session_store: Option<&Mutex<SessionStore>>,
     extra_bootstrap: Vec<BootstrapSection>,
+    stream_tx: Option<&mpsc::Sender<TurnStreamEvent>>,
 ) -> error::Result<TurnResult> {
     let pipeline_start = Instant::now();
     let pipeline_span = info_span!("pipeline",
@@ -528,8 +531,13 @@ pub async fn run_pipeline(
         );
         let _guard = span.enter();
         let start = Instant::now();
-        result = crate::execute::execute(&ctx, &input.session, config, providers, tools, tool_ctx)
-            .await?;
+        result = if let Some(tx) = stream_tx {
+            crate::execute::execute_streaming(&ctx, &input.session, config, providers, tools, tool_ctx, tx)
+                .await?
+        } else {
+            crate::execute::execute(&ctx, &input.session, config, providers, tools, tool_ctx)
+                .await?
+        };
         #[expect(
             clippy::cast_possible_truncation,
             reason = "stage duration fits in u64"
@@ -857,6 +865,7 @@ mod tests {
     // --- run_pipeline ---
 
     #[tokio::test]
+    #[expect(clippy::too_many_lines, reason = "pipeline integration test requires full setup")]
     async fn run_pipeline_simple() {
         use std::fs;
         use std::path::PathBuf;
@@ -890,6 +899,10 @@ mod tests {
             )]
             fn name(&self) -> &str {
                 "mock"
+            }
+
+            fn as_any(&self) -> &dyn std::any::Any {
+                self
             }
         }
 
@@ -958,6 +971,7 @@ mod tests {
             None,
             None,
             Vec::new(),
+            None,
         )
         .await
         .expect("pipeline should succeed");

--- a/crates/nous/src/stream.rs
+++ b/crates/nous/src/stream.rs
@@ -1,0 +1,25 @@
+//! Real-time streaming events for the turn pipeline.
+
+use aletheia_hermeneus::anthropic::StreamEvent as LlmStreamEvent;
+
+/// Events emitted during a streaming turn, bridging LLM deltas and tool lifecycle.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub enum TurnStreamEvent {
+    /// LLM streaming delta forwarded from the provider.
+    LlmDelta(LlmStreamEvent),
+    /// Tool execution started.
+    ToolStart {
+        tool_id: String,
+        tool_name: String,
+        input: serde_json::Value,
+    },
+    /// Tool execution completed.
+    ToolResult {
+        tool_id: String,
+        tool_name: String,
+        result: String,
+        is_error: bool,
+        duration_ms: u64,
+    },
+}

--- a/crates/pylon/src/handlers/webchat.rs
+++ b/crates/pylon/src/handlers/webchat.rs
@@ -13,10 +13,13 @@ use tokio_stream::StreamExt;
 use tokio_stream::wrappers::ReceiverStream;
 use tracing::{instrument, warn};
 
+use aletheia_hermeneus::anthropic::StreamEvent as LlmStreamEvent;
+use aletheia_nous::stream::TurnStreamEvent;
+
 use crate::error::{ApiError, BadRequestSnafu, NousNotFoundSnafu};
 use crate::extract::OptionalClaims;
 use crate::state::AppState;
-use crate::stream::{WebchatEvent, emit_webchat_events};
+use crate::stream::{TurnOutcome, WebchatEvent};
 
 // --- POST /api/sessions/stream ---
 
@@ -73,6 +76,7 @@ async fn store_message(
     .map_err(ApiError::from)
 }
 
+#[expect(clippy::too_many_lines, reason = "streaming bridge setup is inherently sequential")]
 #[instrument(skip(state, _claims, body), fields(agent_id = %body.agent_id))]
 pub async fn stream(
     State(state): State<Arc<AppState>>,
@@ -112,9 +116,10 @@ pub async fn stream(
     store_message(&state, &session_id, aletheia_mneme::types::Role::User, &message, 0).await?;
 
     let turn_id = ulid::Ulid::new().to_string();
-    let (tx, rx) = mpsc::channel::<WebchatEvent>(32);
+    let (webchat_tx, webchat_rx) = mpsc::channel::<WebchatEvent>(32);
+    let (nous_tx, mut nous_rx) = mpsc::channel::<TurnStreamEvent>(64);
 
-    let _ = tx
+    let _ = webchat_tx
         .send(WebchatEvent::TurnStart {
             session_id: session_id.clone(),
             nous_id: agent_id.clone(),
@@ -125,16 +130,82 @@ pub async fn stream(
     let sid = session_id;
     let aid = agent_id;
 
+    // Bridge nous stream events to webchat events in real-time
+    let bridge_tx = webchat_tx.clone();
     tokio::spawn(async move {
-        match handle.send_turn(&session_key, &message).await {
+        while let Some(event) = nous_rx.recv().await {
+            let webchat_event = match event {
+                TurnStreamEvent::LlmDelta(LlmStreamEvent::TextDelta { text }) => {
+                    WebchatEvent::TextDelta { text }
+                }
+                TurnStreamEvent::LlmDelta(LlmStreamEvent::ThinkingDelta { thinking }) => {
+                    WebchatEvent::ThinkingDelta { text: thinking }
+                }
+                TurnStreamEvent::ToolStart {
+                    tool_id,
+                    tool_name,
+                    input,
+                } => WebchatEvent::ToolStart {
+                    tool_name,
+                    tool_id,
+                    input,
+                },
+                TurnStreamEvent::ToolResult {
+                    tool_id,
+                    tool_name,
+                    result,
+                    is_error,
+                    duration_ms,
+                } => WebchatEvent::ToolResult {
+                    tool_name,
+                    tool_id,
+                    result,
+                    is_error,
+                    duration_ms,
+                },
+                _ => continue,
+            };
+            if bridge_tx.send(webchat_event).await.is_err() {
+                break;
+            }
+        }
+    });
+
+    // Run the turn and emit completion event
+    tokio::spawn(async move {
+        match handle
+            .send_turn_streaming(&session_key, &message, nous_tx)
+            .await
+        {
             Ok(result) => {
-                emit_webchat_events(&tx, &result, &sid, &aid, model.as_deref()).await;
                 let token_estimate = i64::try_from(result.usage.output_tokens).unwrap_or(0);
-                let _ = store_message(&state, &sid, aletheia_mneme::types::Role::Assistant, &result.content, token_estimate).await;
+                let _ = webchat_tx
+                    .send(WebchatEvent::TurnComplete {
+                        outcome: TurnOutcome {
+                            text: result.content.clone(),
+                            nous_id: aid,
+                            session_id: sid.clone(),
+                            model,
+                            tool_calls: result.tool_calls.len(),
+                            input_tokens: result.usage.input_tokens,
+                            output_tokens: result.usage.output_tokens,
+                            cache_read_tokens: result.usage.cache_read_tokens,
+                            cache_write_tokens: result.usage.cache_write_tokens,
+                        },
+                    })
+                    .await;
+                let _ = store_message(
+                    &state,
+                    &sid,
+                    aletheia_mneme::types::Role::Assistant,
+                    &result.content,
+                    token_estimate,
+                )
+                .await;
             }
             Err(err) => {
                 warn!(error = %err, "turn failed");
-                let _ = tx
+                let _ = webchat_tx
                     .send(WebchatEvent::Error {
                         message: err.to_string(),
                     })
@@ -143,7 +214,7 @@ pub async fn stream(
         }
     });
 
-    let stream = ReceiverStream::new(rx).map(|event| {
+    let stream = ReceiverStream::new(webchat_rx).map(|event| {
         let data = serde_json::to_string(&event).unwrap_or_default();
         Ok(Event::default().event(event.event_type()).data(data))
     });

--- a/crates/pylon/src/tests.rs
+++ b/crates/pylon/src/tests.rs
@@ -64,6 +64,10 @@ impl LlmProvider for MockProvider {
     fn name(&self) -> &str {
         "mock"
     }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
 }
 
 // --- JWT Test Helpers ---


### PR DESCRIPTION
## Summary

Switch the nous pipeline from batch completion to streaming completion so the web UI shows text as it's generated instead of waiting for the entire response.

## Changes

### hermeneus
- Add `as_any()` to `LlmProvider` trait for safe downcast to concrete types
- Add `find_streaming_provider()` to `ProviderRegistry` (returns `&AnthropicProvider` when available)

### nous
- New `TurnStreamEvent` type (`stream.rs`) wrapping LLM deltas and tool lifecycle events
- New `execute_streaming()` in `execute.rs`: uses `complete_streaming()` with `try_send()` callback, falls back to `complete()` for non-streaming providers
- `NousMessage::StreamingTurn` variant carries `mpsc::Sender<TurnStreamEvent>`
- `NousHandle::send_turn_streaming()` method
- `run_pipeline()` accepts optional `stream_tx` parameter, branches at execute stage
- Actor handles streaming turns with extraction/distillation hooks preserved

### pylon
- Webchat `stream()` handler spawns bridge task mapping `TurnStreamEvent` to `WebchatEvent` in real-time
- Text/thinking deltas flow to client as generated (no longer batched after turn completes)
- Tool start/result events emitted during execution

## Design Decisions

| Decision | Choice |
|----------|--------|
| Streaming on LlmProvider trait? | No. `as_any()` downcast to `AnthropicProvider` |
| Channel threading | `Option<&Sender>` param on `run_pipeline` |
| Sync callback vs async | `try_send()` on bounded channel(64) |
| Backward compat | Existing `send_turn()` unchanged |

## Testing

- 103 hermeneus tests pass (including `find_streaming_provider` test)
- 194 nous tests pass (including 2 new streaming tests)
- 70 pylon tests pass
- 5 integration tests pass
- `cargo clippy --workspace --all-targets -- -D warnings` clean