### PR TITLE
fix(nous): align bootstrap workspace files with runtime and add startup validation

### DIFF
--- a/crates/nous/src/actor.rs
+++ b/crates/nous/src/actor.rs
@@ -6,7 +6,7 @@ use std::sync::{Arc, Mutex};
 use aletheia_mneme::store::SessionStore;
 
 use tokio::sync::mpsc;
-use tracing::{Instrument, debug, info, instrument, warn};
+use tracing::{Instrument, debug, error, info, instrument, warn};
 
 use crate::cross::CrossNousEnvelope;
 use crate::stream::TurnStreamEvent;
@@ -16,6 +16,7 @@ use aletheia_koina::id::{NousId, SessionId};
 use aletheia_mneme::embedding::EmbeddingProvider;
 use aletheia_organon::registry::ToolRegistry;
 use aletheia_organon::types::{ToolContext, ToolServices};
+use aletheia_taxis::cascade;
 use aletheia_taxis::oikos::Oikos;
 
 use crate::bootstrap::BootstrapSection;
@@ -96,6 +97,11 @@ impl NousActor {
     /// Run the actor loop until shutdown or all handles are dropped.
     #[instrument(skip(self), fields(nous.id = %self.id))]
     pub async fn run(mut self) {
+        if let Err(e) = validate_workspace(&self.oikos, &self.id) {
+            error!(error = %e, "workspace validation failed, shutting down");
+            return;
+        }
+
         info!(lifecycle = %self.lifecycle, "actor started");
 
         loop {
@@ -316,6 +322,9 @@ impl NousActor {
             workspace: self.oikos.nous_dir(&self.id),
             allowed_roots: vec![self.oikos.root().to_path_buf()],
             services: self.tool_services.clone(),
+            active_tools: std::sync::Arc::new(std::sync::RwLock::new(
+                std::collections::HashSet::new(),
+            )),
         };
 
         crate::pipeline::run_pipeline(
@@ -554,6 +563,56 @@ async fn run_background_distillation(
         messages_distilled = result.messages_distilled,
         "background distillation complete"
     );
+}
+
+/// Validate the workspace directory exists and required files are resolvable.
+///
+/// Called at actor startup before entering the message loop. Creates the
+/// workspace directory if missing and fails fast if SOUL.md cannot be found
+/// through the cascade.
+fn validate_workspace(oikos: &Oikos, nous_id: &str) -> crate::error::Result<()> {
+    let workspace = oikos.nous_dir(nous_id);
+    if !workspace.exists() {
+        warn!(
+            agent = nous_id,
+            path = %workspace.display(),
+            "workspace directory missing, creating"
+        );
+        std::fs::create_dir_all(&workspace).map_err(|e| {
+            crate::error::WorkspaceValidationSnafu {
+                nous_id: nous_id.to_owned(),
+                message: format!("failed to create workspace directory: {e}"),
+            }
+            .build()
+        })?;
+    }
+
+    if cascade::resolve(oikos, nous_id, "SOUL.md", None).is_none() {
+        return Err(crate::error::WorkspaceValidationSnafu {
+            nous_id: nous_id.to_owned(),
+            message: "SOUL.md not found in cascade (nous/, shared/, theke/)".to_owned(),
+        }
+        .build());
+    }
+
+    // Log warnings for missing optional workspace files
+    for filename in &[
+        "USER.md",
+        "AGENTS.md",
+        "GOALS.md",
+        "TOOLS.md",
+        "MEMORY.md",
+        "IDENTITY.md",
+        "PROSOCHE.md",
+        "CONTEXT.md",
+    ] {
+        if cascade::resolve(oikos, nous_id, filename, None).is_none() {
+            debug!(agent = nous_id, file = *filename, "optional workspace file not found");
+        }
+    }
+
+    info!(agent = nous_id, "workspace validated");
+    Ok(())
 }
 
 /// Spawn a nous actor, returning its handle and join handle.
@@ -899,5 +958,34 @@ mod tests {
     #[test]
     fn default_inbox_capacity_is_32() {
         assert_eq!(DEFAULT_INBOX_CAPACITY, 32);
+    }
+
+    #[test]
+    fn validate_workspace_creates_missing_dir() {
+        let dir = tempfile::TempDir::new().expect("tmpdir");
+        let root = dir.path();
+        // Only create shared/ with SOUL.md for cascade fallback
+        std::fs::create_dir_all(root.join("shared")).expect("mkdir shared");
+        std::fs::create_dir_all(root.join("theke")).expect("mkdir theke");
+        std::fs::write(root.join("shared/SOUL.md"), "# Test Soul").expect("write");
+
+        let oikos = Oikos::from_root(root);
+        super::validate_workspace(&oikos, "test-agent").unwrap();
+        assert!(root.join("nous/test-agent").exists());
+    }
+
+    #[test]
+    fn validate_workspace_fails_without_soul() {
+        let dir = tempfile::TempDir::new().expect("tmpdir");
+        let root = dir.path();
+        std::fs::create_dir_all(root.join("nous/test-agent")).expect("mkdir");
+        std::fs::create_dir_all(root.join("shared")).expect("mkdir shared");
+        std::fs::create_dir_all(root.join("theke")).expect("mkdir theke");
+
+        let oikos = Oikos::from_root(root);
+        let result = super::validate_workspace(&oikos, "test-agent");
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("SOUL.md"), "error should mention SOUL.md: {msg}");
     }
 }

--- a/crates/nous/src/bootstrap/mod.rs
+++ b/crates/nous/src/bootstrap/mod.rs
@@ -74,9 +74,13 @@ struct WorkspaceFileSpec {
 /// Priority ordering:
 /// - SOUL.md: Required (core identity)
 /// - USER.md: Important (operator profile, typically in theke/)
-/// - TELOS.md: Important (active goals)
-/// - AGENTS.md: Important (team topology, typically in theke/)
-/// - MNEME.md: Flexible + truncatable (operational memory, oldest entries dropped first)
+/// - AGENTS.md: Important (operating instructions, typically in theke/)
+/// - GOALS.md: Important + truncatable (active/completed/deferred goals)
+/// - TOOLS.md: Important + truncatable (available commands, SSH, paths)
+/// - MEMORY.md: Flexible + truncatable (operational memory, oldest entries dropped first)
+/// - IDENTITY.md: Flexible (name, emoji, avatar metadata)
+/// - PROSOCHE.md: Flexible (heartbeat checklist)
+/// - CONTEXT.md: Flexible + truncatable (runtime config, auto-generated)
 const WORKSPACE_FILES: &[WorkspaceFileSpec] = &[
     WorkspaceFileSpec {
         filename: "SOUL.md",
@@ -89,17 +93,37 @@ const WORKSPACE_FILES: &[WorkspaceFileSpec] = &[
         truncatable: false,
     },
     WorkspaceFileSpec {
-        filename: "TELOS.md",
-        priority: SectionPriority::Important,
-        truncatable: false,
-    },
-    WorkspaceFileSpec {
         filename: "AGENTS.md",
         priority: SectionPriority::Important,
         truncatable: false,
     },
     WorkspaceFileSpec {
-        filename: "MNEME.md",
+        filename: "GOALS.md",
+        priority: SectionPriority::Important,
+        truncatable: true,
+    },
+    WorkspaceFileSpec {
+        filename: "TOOLS.md",
+        priority: SectionPriority::Important,
+        truncatable: true,
+    },
+    WorkspaceFileSpec {
+        filename: "MEMORY.md",
+        priority: SectionPriority::Flexible,
+        truncatable: true,
+    },
+    WorkspaceFileSpec {
+        filename: "IDENTITY.md",
+        priority: SectionPriority::Flexible,
+        truncatable: false,
+    },
+    WorkspaceFileSpec {
+        filename: "PROSOCHE.md",
+        priority: SectionPriority::Flexible,
+        truncatable: false,
+    },
+    WorkspaceFileSpec {
+        filename: "CONTEXT.md",
         priority: SectionPriority::Flexible,
         truncatable: true,
     },
@@ -469,32 +493,32 @@ mod tests {
             "test",
             &[
                 ("SOUL.md", "identity"),
-                ("MNEME.md", "memory notes"),
-                ("TELOS.md", "goals"),
+                ("MEMORY.md", "memory notes"),
+                ("GOALS.md", "goals"),
             ],
         );
         let assembler = BootstrapAssembler::new(&oikos);
         let mut budget = default_budget();
 
         let result = assembler.assemble("test", &mut budget).unwrap();
-        // Required (SOUL) before Important (TELOS) before Flexible (MNEME)
+        // Required (SOUL) before Important (GOALS) before Flexible (MEMORY)
         let soul_pos = result
             .sections_included
             .iter()
             .position(|s| s == "SOUL.md")
             .unwrap();
-        let telos_pos = result
+        let goals_pos = result
             .sections_included
             .iter()
-            .position(|s| s == "TELOS.md")
+            .position(|s| s == "GOALS.md")
             .unwrap();
-        let mneme_pos = result
+        let memory_pos = result
             .sections_included
             .iter()
-            .position(|s| s == "MNEME.md")
+            .position(|s| s == "MEMORY.md")
             .unwrap();
-        assert!(soul_pos < telos_pos);
-        assert!(telos_pos < mneme_pos);
+        assert!(soul_pos < goals_pos);
+        assert!(goals_pos < memory_pos);
     }
 
     #[test]
@@ -504,16 +528,20 @@ mod tests {
             &[
                 ("SOUL.md", "identity"),
                 ("USER.md", "user info"),
-                ("TELOS.md", "goals"),
                 ("AGENTS.md", "team topology"),
-                ("MNEME.md", "memory"),
+                ("GOALS.md", "goals"),
+                ("TOOLS.md", "tool list"),
+                ("MEMORY.md", "memory"),
+                ("IDENTITY.md", "name and emoji"),
+                ("PROSOCHE.md", "checklist"),
+                ("CONTEXT.md", "runtime config"),
             ],
         );
         let assembler = BootstrapAssembler::new(&oikos);
         let mut budget = default_budget();
 
         let result = assembler.assemble("test", &mut budget).unwrap();
-        assert_eq!(result.sections_included.len(), 5);
+        assert_eq!(result.sections_included.len(), 9);
         assert!(result.total_tokens > 0);
     }
 
@@ -524,7 +552,7 @@ mod tests {
             &[
                 ("SOUL.md", "identity"),
                 ("AGENTS.md", ""),
-                ("TELOS.md", "   \n  \n  "), // whitespace-only
+                ("GOALS.md", "   \n  \n  "), // whitespace-only
             ],
         );
         let assembler = BootstrapAssembler::new(&oikos);
@@ -535,20 +563,20 @@ mod tests {
     }
 
     #[test]
-    fn assemble_mneme_truncated() {
-        // Create a large MNEME.md that exceeds a small budget
-        let large_mneme = "## Recent\nNew stuff here.\n## Old\nOld stuff here that is much longer and should be truncated when the budget is tight. ".repeat(50);
+    fn assemble_memory_truncated() {
+        // Create a large MEMORY.md that exceeds a small budget
+        let large_memory = "## Recent\nNew stuff here.\n## Old\nOld stuff here that is much longer and should be truncated when the budget is tight. ".repeat(50);
         let (_dir, oikos) = setup_oikos(
             "test",
-            &[("SOUL.md", "identity"), ("MNEME.md", &large_mneme)],
+            &[("SOUL.md", "identity"), ("MEMORY.md", &large_memory)],
         );
         let assembler = BootstrapAssembler::new(&oikos);
         // Small budget: enough for SOUL.md but not full MNEME.md
         let mut budget = TokenBudget::new(100_000, 0.0, 0, 500);
 
         let result = assembler.assemble("test", &mut budget).unwrap();
-        assert!(result.sections_included.contains(&"MNEME.md".to_owned()));
-        assert!(result.sections_truncated.contains(&"MNEME.md".to_owned()));
+        assert!(result.sections_included.contains(&"MEMORY.md".to_owned()));
+        assert!(result.sections_truncated.contains(&"MEMORY.md".to_owned()));
         assert!(
             result
                 .system_prompt
@@ -558,18 +586,18 @@ mod tests {
 
     #[test]
     fn assemble_optional_dropped() {
-        // SOUL.md fills the entire budget, MNEME.md gets dropped
+        // SOUL.md fills the entire budget, MEMORY.md gets dropped
         let large_soul = "x".repeat(2000); // ~500 tokens at 4 chars/token
         let (_dir, oikos) = setup_oikos(
             "test",
-            &[("SOUL.md", &large_soul), ("MNEME.md", "memory notes")],
+            &[("SOUL.md", &large_soul), ("MEMORY.md", "memory notes")],
         );
         let assembler = BootstrapAssembler::new(&oikos);
         let mut budget = TokenBudget::new(100_000, 0.0, 0, 500);
 
         let result = assembler.assemble("test", &mut budget).unwrap();
         assert!(result.sections_included.contains(&"SOUL.md".to_owned()));
-        assert!(result.sections_dropped.contains(&"MNEME.md".to_owned()));
+        assert!(result.sections_dropped.contains(&"MEMORY.md".to_owned()));
     }
 
     #[test]
@@ -638,7 +666,7 @@ mod tests {
         let assembler = BootstrapAssembler::new(&oikos);
 
         let section = BootstrapSection {
-            name: "MNEME.md".to_owned(),
+            name: "MEMORY.md".to_owned(),
             priority: SectionPriority::Flexible,
             content: "## Section A\nContent A.\n## Section B\nContent B.\n## Section C\nContent C."
                 .to_owned(),
@@ -658,7 +686,7 @@ mod tests {
         let assembler = BootstrapAssembler::new(&oikos);
 
         let section = BootstrapSection {
-            name: "MNEME.md".to_owned(),
+            name: "MEMORY.md".to_owned(),
             priority: SectionPriority::Flexible,
             content: "Line one\nLine two\nLine three\nLine four\nLine five".to_owned(),
             tokens: 100,

--- a/crates/nous/src/error.rs
+++ b/crates/nous/src/error.rs
@@ -31,6 +31,15 @@ pub enum Error {
         location: snafu::Location,
     },
 
+    /// Workspace validation failed on actor startup.
+    #[snafu(display("workspace validation failed for '{nous_id}': {message}"))]
+    WorkspaceValidation {
+        nous_id: String,
+        message: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
     /// Pipeline stage failed.
     #[snafu(display("pipeline stage '{stage}' failed: {message}"))]
     PipelineStage {

--- a/crates/nous/src/spawn_svc.rs
+++ b/crates/nous/src/spawn_svc.rs
@@ -200,6 +200,10 @@ mod tests {
         fn name(&self) -> &str {
             "mock"
         }
+
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
+        }
     }
 
     fn test_oikos() -> (tempfile::TempDir, Arc<Oikos>) {
@@ -333,6 +337,10 @@ mod tests {
         #[expect(clippy::unnecessary_literal_bound, reason = "trait requires &str")]
         fn name(&self) -> &str {
             "slow"
+        }
+
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
         }
     }
 }


### PR DESCRIPTION
## Summary

- Renamed TELOS.md -> GOALS.md and MNEME.md -> MEMORY.md in `WORKSPACE_FILES` constant to match actual workspace file names
- Added 4 missing workspace files: IDENTITY.md, TOOLS.md, PROSOCHE.md, CONTEXT.md (now 9 files, matching TypeScript runtime)
- Added `validate_workspace()` on actor startup: creates missing workspace dir, fails fast if SOUL.md not resolvable via cascade
- Added `WorkspaceValidation` error variant to nous error enum
- Fixed pre-existing compile errors: missing `active_tools` in streaming ToolContext, missing `as_any` in spawn_svc mocks

## Test plan

- [x] `cargo test -p aletheia-nous` (201 tests pass)
- [x] `cargo clippy -p aletheia-nous --all-targets -- -D warnings` (zero warnings)
- [ ] Verify agent bootstrap logs show all 9 files loaded (or gracefully skipped)

Closes #483