### PR TITLE
feat(hermeneus): replace Brave scraper with Anthropic server-side web search

### DIFF
--- a/crates/aletheia/src/main.rs
+++ b/crates/aletheia/src/main.rs
@@ -567,6 +567,7 @@ async fn serve(cli: Cli) -> Result<()> {
                 max_tool_iterations: resolved.max_tool_iterations,
                 loop_detection_threshold: 3,
                 domains,
+                server_tools: Vec::new(),
             };
             nous_manager
                 .spawn(

--- a/crates/hermeneus/src/anthropic/stream.rs
+++ b/crates/hermeneus/src/anthropic/stream.rs
@@ -71,6 +71,15 @@ enum BlockBuilder {
         text: String,
         signature: String,
     },
+    ServerToolUse {
+        id: String,
+        name: String,
+        input_json: String,
+    },
+    WebSearchToolResult {
+        tool_use_id: String,
+        content: serde_json::Value,
+    },
 }
 
 impl StreamAccumulator {
@@ -113,6 +122,10 @@ impl StreamAccumulator {
                     WireContentBlockStart::Text { .. } => "text",
                     WireContentBlockStart::ToolUse { .. } => "tool_use",
                     WireContentBlockStart::Thinking { .. } => "thinking",
+                    WireContentBlockStart::ServerToolUse { .. } => "server_tool_use",
+                    WireContentBlockStart::WebSearchToolResult { .. } => {
+                        "web_search_tool_result"
+                    }
                 };
                 on_event(StreamEvent::ContentBlockStart {
                     index,
@@ -130,6 +143,19 @@ impl StreamAccumulator {
                         text: thinking,
                         signature: String::new(),
                     },
+                    WireContentBlockStart::ServerToolUse { id, name } => {
+                        BlockBuilder::ServerToolUse {
+                            id,
+                            name,
+                            input_json: String::new(),
+                        }
+                    }
+                    WireContentBlockStart::WebSearchToolResult { tool_use_id } => {
+                        BlockBuilder::WebSearchToolResult {
+                            tool_use_id,
+                            content: serde_json::Value::Null,
+                        }
+                    }
                 };
                 // Ensure the blocks vec is large enough.
                 let idx = index as usize;
@@ -149,11 +175,12 @@ impl StreamAccumulator {
                             on_event(StreamEvent::TextDelta { text });
                         }
                         WireDelta::InputJsonDelta { partial_json } => {
-                            if let BlockBuilder::ToolUse {
-                                ref mut input_json, ..
-                            } = self.blocks[idx]
-                            {
-                                input_json.push_str(&partial_json);
+                            match &mut self.blocks[idx] {
+                                BlockBuilder::ToolUse { input_json, .. }
+                                | BlockBuilder::ServerToolUse { input_json, .. } => {
+                                    input_json.push_str(&partial_json);
+                                }
+                                _ => {}
                             }
                             on_event(StreamEvent::InputJsonDelta { partial_json });
                         }
@@ -230,6 +257,21 @@ impl StreamAccumulator {
                     } else {
                         Some(signature)
                     },
+                },
+                BlockBuilder::ServerToolUse {
+                    id,
+                    name,
+                    input_json,
+                } => {
+                    let input = serde_json::from_str(&input_json).unwrap_or_default();
+                    ContentBlock::ServerToolUse { id, name, input }
+                }
+                BlockBuilder::WebSearchToolResult {
+                    tool_use_id,
+                    content,
+                } => ContentBlock::WebSearchToolResult {
+                    tool_use_id,
+                    content,
                 },
             })
             .collect();
@@ -547,6 +589,78 @@ data: {\"type\":\"error\",\"error\":{\"type\":\"invalid_request_error\",\"messag
             matches!(err, Error::ApiError { status: 0, .. }),
             "expected ApiError, got: {err:?}"
         );
+    }
+
+    #[test]
+    fn parses_server_tool_use_stream() {
+        let sse = "\
+event: message_start\n\
+data: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_srv\",\"model\":\"claude-opus-4-20250514\",\"usage\":{\"input_tokens\":10,\"output_tokens\":0}}}\n\
+\n\
+event: content_block_start\n\
+data: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"server_tool_use\",\"id\":\"srvtoolu_1\",\"name\":\"web_search\"}}\n\
+\n\
+event: content_block_delta\n\
+data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"{\\\"query\\\": \\\"rust async\\\"}\"}}\n\
+\n\
+event: content_block_stop\n\
+data: {\"type\":\"content_block_stop\",\"index\":0}\n\
+\n\
+event: content_block_start\n\
+data: {\"type\":\"content_block_start\",\"index\":1,\"content_block\":{\"type\":\"web_search_tool_result\",\"tool_use_id\":\"srvtoolu_1\"}}\n\
+\n\
+event: content_block_stop\n\
+data: {\"type\":\"content_block_stop\",\"index\":1}\n\
+\n\
+event: content_block_start\n\
+data: {\"type\":\"content_block_start\",\"index\":2,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n\
+\n\
+event: content_block_delta\n\
+data: {\"type\":\"content_block_delta\",\"index\":2,\"delta\":{\"type\":\"text_delta\",\"text\":\"Based on my search...\"}}\n\
+\n\
+event: content_block_stop\n\
+data: {\"type\":\"content_block_stop\",\"index\":2}\n\
+\n\
+event: message_delta\n\
+data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"output_tokens\":20}}\n\
+\n\
+event: message_stop\n\
+data: {\"type\":\"message_stop\"}\n\
+\n";
+
+        let (events, response) = collect_events(sse);
+
+        // Verify block_type events emitted correctly
+        let block_starts: Vec<&str> = events
+            .iter()
+            .filter_map(|e| match e {
+                StreamEvent::ContentBlockStart { block_type, .. } => Some(block_type.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            block_starts,
+            vec!["server_tool_use", "web_search_tool_result", "text"]
+        );
+
+        // Verify content blocks in response
+        assert_eq!(response.content.len(), 3);
+        match &response.content[0] {
+            ContentBlock::ServerToolUse { id, name, input } => {
+                assert_eq!(id, "srvtoolu_1");
+                assert_eq!(name, "web_search");
+                assert_eq!(input["query"], "rust async");
+            }
+            _ => panic!("expected ServerToolUse"),
+        }
+        assert!(matches!(
+            &response.content[1],
+            ContentBlock::WebSearchToolResult { .. }
+        ));
+        match &response.content[2] {
+            ContentBlock::Text { text, .. } => assert_eq!(text, "Based on my search..."),
+            _ => panic!("expected Text"),
+        }
     }
 
     #[test]

--- a/crates/hermeneus/src/anthropic/wire.rs
+++ b/crates/hermeneus/src/anthropic/wire.rs
@@ -19,7 +19,7 @@ pub(crate) struct WireRequest<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub system: Option<serde_json::Value>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub tools: Vec<WireTool<'a>>,
+    pub tools: Vec<WireToolEntry<'a>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub temperature: Option<f32>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
@@ -49,6 +49,28 @@ pub(crate) struct WireTool<'a> {
     pub input_schema: &'a serde_json::Value,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cache_control: Option<CacheControl>,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct WireServerTool<'a> {
+    #[serde(rename = "type")]
+    pub tool_type: &'a str,
+    pub name: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_uses: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub allowed_domains: Option<&'a [String]>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub blocked_domains: Option<&'a [String]>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub user_location: Option<&'a serde_json::Value>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(untagged)]
+pub(crate) enum WireToolEntry<'a> {
+    UserDefined(WireTool<'a>),
+    ServerSide(WireServerTool<'a>),
 }
 
 #[derive(Debug, Serialize)]
@@ -102,6 +124,17 @@ pub(crate) enum WireContentBlock {
     },
     #[serde(rename = "thinking")]
     Thinking { thinking: String, signature: String },
+    #[serde(rename = "server_tool_use")]
+    ServerToolUse {
+        id: String,
+        name: String,
+        input: serde_json::Value,
+    },
+    #[serde(rename = "web_search_tool_result")]
+    WebSearchToolResult {
+        tool_use_id: String,
+        content: serde_json::Value,
+    },
 }
 
 // ---------------------------------------------------------------------------
@@ -168,25 +201,36 @@ impl<'a> WireRequest<'a> {
             })
             .collect();
 
-        let tool_count = req.tools.len();
-        let tools: Vec<WireTool<'a>> = req
+        let user_tool_count = req.tools.len();
+        let mut tools: Vec<WireToolEntry<'a>> = req
             .tools
             .iter()
             .enumerate()
             .map(|(i, t)| {
-                let cache_control = if req.cache_tools && i == tool_count - 1 {
+                let cache_control = if req.cache_tools && i == user_tool_count - 1 {
                     Some(CacheControl::ephemeral())
                 } else {
                     None
                 };
-                WireTool {
+                WireToolEntry::UserDefined(WireTool {
                     name: &t.name,
                     description: &t.description,
                     input_schema: &t.input_schema,
                     cache_control,
-                }
+                })
             })
             .collect();
+
+        for st in &req.server_tools {
+            tools.push(WireToolEntry::ServerSide(WireServerTool {
+                tool_type: &st.tool_type,
+                name: &st.name,
+                max_uses: st.max_uses,
+                allowed_domains: st.allowed_domains.as_deref(),
+                blocked_domains: st.blocked_domains.as_deref(),
+                user_location: st.user_location.as_ref(),
+            }));
+        }
 
         let thinking = req.thinking.as_ref().and_then(|tc| {
             if tc.enabled {
@@ -255,6 +299,16 @@ impl WireContentBlock {
             } => ContentBlock::Thinking {
                 thinking,
                 signature: Some(signature),
+            },
+            Self::ServerToolUse { id, name, input } => {
+                ContentBlock::ServerToolUse { id, name, input }
+            }
+            Self::WebSearchToolResult {
+                tool_use_id,
+                content,
+            } => ContentBlock::WebSearchToolResult {
+                tool_use_id,
+                content,
             },
         }
     }
@@ -328,6 +382,10 @@ pub(crate) enum WireContentBlockStart {
     ToolUse { id: String, name: String },
     #[serde(rename = "thinking")]
     Thinking { thinking: String },
+    #[serde(rename = "server_tool_use")]
+    ServerToolUse { id: String, name: String },
+    #[serde(rename = "web_search_tool_result")]
+    WebSearchToolResult { tool_use_id: String },
 }
 
 #[derive(Debug, Deserialize)]
@@ -786,6 +844,134 @@ mod tests {
             }
             _ => panic!("expected Thinking"),
         }
+    }
+
+    #[test]
+    fn wire_request_mixed_user_and_server_tools() {
+        let req = CompletionRequest {
+            model: "claude-opus-4-20250514".to_owned(),
+            messages: vec![Message {
+                role: Role::User,
+                content: Content::Text("search for rust".to_owned()),
+            }],
+            max_tokens: 1024,
+            tools: vec![ToolDefinition {
+                name: "read".to_owned(),
+                description: "Read a file".to_owned(),
+                input_schema: serde_json::json!({"type": "object"}),
+            }],
+            server_tools: vec![crate::types::ServerToolDefinition {
+                tool_type: "web_search_20250305".to_owned(),
+                name: "web_search".to_owned(),
+                max_uses: Some(5),
+                allowed_domains: None,
+                blocked_domains: None,
+                user_location: None,
+            }],
+            ..Default::default()
+        };
+        let wire = WireRequest::from_request(&req, None);
+        let json = serde_json::to_value(&wire).unwrap();
+        let tools = json["tools"].as_array().unwrap();
+        assert_eq!(tools.len(), 2);
+        // First: user-defined tool (has input_schema)
+        assert_eq!(tools[0]["name"], "read");
+        assert!(tools[0].get("input_schema").is_some());
+        assert!(tools[0].get("type").is_none());
+        // Second: server-side tool (has type, no input_schema)
+        assert_eq!(tools[1]["type"], "web_search_20250305");
+        assert_eq!(tools[1]["name"], "web_search");
+        assert_eq!(tools[1]["max_uses"], 5);
+        assert!(tools[1].get("input_schema").is_none());
+    }
+
+    #[test]
+    fn wire_content_block_server_tool_use() {
+        let json = r#"{"type":"server_tool_use","id":"srvtoolu_123","name":"web_search","input":{"query":"rust async"}}"#;
+        let block: WireContentBlock = serde_json::from_str(json).unwrap();
+        let converted = block.into_content_block();
+        match converted {
+            ContentBlock::ServerToolUse { id, name, input } => {
+                assert_eq!(id, "srvtoolu_123");
+                assert_eq!(name, "web_search");
+                assert_eq!(input["query"], "rust async");
+            }
+            _ => panic!("expected ServerToolUse"),
+        }
+    }
+
+    #[test]
+    fn wire_content_block_web_search_tool_result() {
+        let json = r#"{"type":"web_search_tool_result","tool_use_id":"srvtoolu_123","content":[{"type":"web_search_result","url":"https://example.com","title":"Example","encrypted_content":"abc"}]}"#;
+        let block: WireContentBlock = serde_json::from_str(json).unwrap();
+        let converted = block.into_content_block();
+        match converted {
+            ContentBlock::WebSearchToolResult {
+                tool_use_id,
+                content,
+            } => {
+                assert_eq!(tool_use_id, "srvtoolu_123");
+                assert!(content.is_array());
+            }
+            _ => panic!("expected WebSearchToolResult"),
+        }
+    }
+
+    #[test]
+    fn wire_response_with_server_tool_blocks() {
+        let json = r#"{
+            "id": "msg_srv",
+            "type": "message",
+            "role": "assistant",
+            "content": [
+                {"type": "server_tool_use", "id": "srvtoolu_1", "name": "web_search", "input": {"query": "test"}},
+                {"type": "web_search_tool_result", "tool_use_id": "srvtoolu_1", "content": []},
+                {"type": "text", "text": "Based on my search..."}
+            ],
+            "model": "claude-opus-4-20250514",
+            "stop_reason": "end_turn",
+            "usage": {"input_tokens": 10, "output_tokens": 5}
+        }"#;
+        let resp: WireResponse = serde_json::from_str(json).unwrap();
+        let converted = resp.into_response().unwrap();
+        assert_eq!(converted.content.len(), 3);
+        assert!(matches!(&converted.content[0], ContentBlock::ServerToolUse { .. }));
+        assert!(matches!(&converted.content[1], ContentBlock::WebSearchToolResult { .. }));
+        assert!(matches!(&converted.content[2], ContentBlock::Text { .. }));
+    }
+
+    #[test]
+    fn wire_request_cache_tools_only_on_user_tools() {
+        let req = CompletionRequest {
+            model: "claude-opus-4-20250514".to_owned(),
+            messages: vec![Message {
+                role: Role::User,
+                content: Content::Text("hi".to_owned()),
+            }],
+            max_tokens: 1024,
+            tools: vec![ToolDefinition {
+                name: "read".to_owned(),
+                description: "Read".to_owned(),
+                input_schema: serde_json::json!({}),
+            }],
+            server_tools: vec![crate::types::ServerToolDefinition {
+                tool_type: "web_search_20250305".to_owned(),
+                name: "web_search".to_owned(),
+                max_uses: Some(5),
+                allowed_domains: None,
+                blocked_domains: None,
+                user_location: None,
+            }],
+            cache_tools: true,
+            ..Default::default()
+        };
+        let wire = WireRequest::from_request(&req, None);
+        let json = serde_json::to_value(&wire).unwrap();
+        let tools = json["tools"].as_array().unwrap();
+        // cache_control on last user-defined tool
+        assert_eq!(tools[0]["cache_control"]["type"], "ephemeral");
+        // server tool has no cache_control
+        assert!(tools[1].get("cache_control").is_none());
     }
 
     #[test]

--- a/crates/hermeneus/src/types.rs
+++ b/crates/hermeneus/src/types.rs
@@ -116,6 +116,21 @@ pub enum ContentBlock {
         #[serde(skip_serializing_if = "Option::is_none")]
         signature: Option<String>,
     },
+
+    /// Server-side tool use (informational, not dispatched locally).
+    #[serde(rename = "server_tool_use")]
+    ServerToolUse {
+        id: String,
+        name: String,
+        input: serde_json::Value,
+    },
+
+    /// Server-side web search tool result (opaque, round-tripped verbatim).
+    #[serde(rename = "web_search_tool_result")]
+    WebSearchToolResult {
+        tool_use_id: String,
+        content: serde_json::Value,
+    },
 }
 
 /// Tool result content — simple text or rich content blocks.
@@ -203,6 +218,28 @@ pub struct DocumentSource {
     pub media_type: String,
     /// Base64-encoded PDF data.
     pub data: String,
+}
+
+/// A server-side tool definition (runs on the API provider's infrastructure).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ServerToolDefinition {
+    /// Server tool type identifier (e.g., `"web_search_20250305"`).
+    #[serde(rename = "type")]
+    pub tool_type: String,
+    /// Display name.
+    pub name: String,
+    /// Maximum uses per turn.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_uses: Option<u32>,
+    /// Allowed domains for web search.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub allowed_domains: Option<Vec<String>>,
+    /// Blocked domains for web search.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub blocked_domains: Option<Vec<String>>,
+    /// User location hint.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub user_location: Option<serde_json::Value>,
 }
 
 /// A tool definition.
@@ -301,8 +338,10 @@ pub struct CompletionRequest {
     pub messages: Vec<Message>,
     /// Maximum output tokens.
     pub max_tokens: u32,
-    /// Available tools.
+    /// Available user-defined tools.
     pub tools: Vec<ToolDefinition>,
+    /// Server-side tools (e.g., web search) that execute on the provider's infrastructure.
+    pub server_tools: Vec<ServerToolDefinition>,
     /// Temperature (0.0–1.0).
     pub temperature: Option<f32>,
     /// Whether to enable extended thinking.
@@ -329,6 +368,7 @@ impl Default for CompletionRequest {
             messages: Vec::new(),
             max_tokens: 4096,
             tools: Vec::new(),
+            server_tools: Vec::new(),
             temperature: None,
             thinking: None,
             stop_sequences: Vec::new(),
@@ -681,12 +721,73 @@ mod tests {
     }
 
     #[test]
+    fn server_tool_use_block_serde() {
+        let block = ContentBlock::ServerToolUse {
+            id: "srvtoolu_123".to_owned(),
+            name: "web_search".to_owned(),
+            input: serde_json::json!({"query": "rust async"}),
+        };
+        let json = serde_json::to_string(&block).unwrap();
+        assert!(json.contains("server_tool_use"));
+        let back: ContentBlock = serde_json::from_str(&json).unwrap();
+        match back {
+            ContentBlock::ServerToolUse { id, name, input } => {
+                assert_eq!(id, "srvtoolu_123");
+                assert_eq!(name, "web_search");
+                assert_eq!(input["query"], "rust async");
+            }
+            _ => panic!("expected ServerToolUse"),
+        }
+    }
+
+    #[test]
+    fn web_search_tool_result_block_serde() {
+        let block = ContentBlock::WebSearchToolResult {
+            tool_use_id: "srvtoolu_123".to_owned(),
+            content: serde_json::json!([
+                {"type": "web_search_result", "url": "https://example.com", "title": "Example", "encrypted_content": "abc"}
+            ]),
+        };
+        let json = serde_json::to_string(&block).unwrap();
+        assert!(json.contains("web_search_tool_result"));
+        let back: ContentBlock = serde_json::from_str(&json).unwrap();
+        match back {
+            ContentBlock::WebSearchToolResult {
+                tool_use_id,
+                content,
+            } => {
+                assert_eq!(tool_use_id, "srvtoolu_123");
+                assert!(content.is_array());
+            }
+            _ => panic!("expected WebSearchToolResult"),
+        }
+    }
+
+    #[test]
+    fn server_tool_definition_serde() {
+        let def = ServerToolDefinition {
+            tool_type: "web_search_20250305".to_owned(),
+            name: "web_search".to_owned(),
+            max_uses: Some(5),
+            allowed_domains: None,
+            blocked_domains: None,
+            user_location: None,
+        };
+        let json = serde_json::to_string(&def).unwrap();
+        assert!(json.contains("web_search_20250305"));
+        let back: ServerToolDefinition = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.tool_type, "web_search_20250305");
+        assert_eq!(back.max_uses, Some(5));
+    }
+
+    #[test]
     fn completion_request_default() {
         let req = CompletionRequest::default();
         assert!(req.model.is_empty());
         assert!(req.system.is_none());
         assert!(req.messages.is_empty());
         assert_eq!(req.max_tokens, 4096);
+        assert!(req.server_tools.is_empty());
         assert!(!req.cache_system);
         assert!(!req.cache_tools);
         assert!(req.tool_choice.is_none());

--- a/crates/nous/src/actor.rs
+++ b/crates/nous/src/actor.rs
@@ -316,6 +316,9 @@ impl NousActor {
             workspace: self.oikos.nous_dir(&self.id),
             allowed_roots: vec![self.oikos.root().to_path_buf()],
             services: self.tool_services.clone(),
+            active_tools: std::sync::Arc::new(std::sync::RwLock::new(
+                std::collections::HashSet::new(),
+            )),
         };
 
         crate::pipeline::run_pipeline(

--- a/crates/nous/src/config.rs
+++ b/crates/nous/src/config.rs
@@ -26,6 +26,9 @@ pub struct NousConfig {
     /// Domain tags for this agent (static config + pack overlays).
     #[serde(default)]
     pub domains: Vec<String>,
+    /// Server-side tools to include in API requests (e.g., web search).
+    #[serde(default)]
+    pub server_tools: Vec<aletheia_hermeneus::types::ServerToolDefinition>,
 }
 
 impl Default for NousConfig {
@@ -41,6 +44,7 @@ impl Default for NousConfig {
             max_tool_iterations: 50,
             loop_detection_threshold: 3,
             domains: Vec::new(),
+            server_tools: Vec::new(),
         }
     }
 }

--- a/crates/nous/src/execute.rs
+++ b/crates/nous/src/execute.rs
@@ -34,13 +34,19 @@ fn simple_hash(value: &serde_json::Value) -> String {
 }
 
 /// Classify the interaction signals based on tool calls and content.
-fn classify_signals(tool_calls: &[ToolCall], _content: &str) -> Vec<InteractionSignal> {
+fn classify_signals(
+    tool_calls: &[ToolCall],
+    _content: &str,
+    used_server_web_search: bool,
+) -> Vec<InteractionSignal> {
     let mut signals = Vec::new();
 
-    if tool_calls.is_empty() {
+    if tool_calls.is_empty() && !used_server_web_search {
         signals.push(InteractionSignal::Conversation);
     } else {
-        signals.push(InteractionSignal::ToolExecution);
+        if !tool_calls.is_empty() {
+            signals.push(InteractionSignal::ToolExecution);
+        }
 
         let code_tools = ["write", "edit", "exec"];
         if tool_calls
@@ -51,9 +57,10 @@ fn classify_signals(tool_calls: &[ToolCall], _content: &str) -> Vec<InteractionS
         }
 
         let research_tools = ["web_search", "web_fetch"];
-        if tool_calls
-            .iter()
-            .any(|tc| research_tools.contains(&tc.name.as_str()))
+        if used_server_web_search
+            || tool_calls
+                .iter()
+                .any(|tc| research_tools.contains(&tc.name.as_str()))
         {
             signals.push(InteractionSignal::Research);
         }
@@ -202,6 +209,7 @@ pub async fn execute(
     let mut iterations: u32 = 0;
     let mut final_content = String::new();
     let mut final_stop_reason = String::new();
+    let mut used_server_web_search = false;
 
     let thinking = if config.thinking_enabled {
         Some(ThinkingConfig {
@@ -234,6 +242,7 @@ pub async fn execute(
             messages: messages.clone(),
             max_tokens: config.max_output_tokens,
             tools: tool_defs,
+            server_tools: config.server_tools.clone(),
             temperature: None,
             thinking: thinking.clone(),
             stop_sequences: vec![],
@@ -268,6 +277,9 @@ pub async fn execute(
                 }
                 ContentBlock::Thinking { thinking, .. } => {
                     debug!(len = thinking.len(), "thinking block received");
+                }
+                ContentBlock::ServerToolUse { name, .. } if name == "web_search" => {
+                    used_server_web_search = true;
                 }
                 _ => {}
             }
@@ -309,7 +321,7 @@ pub async fn execute(
         "execute stage complete"
     );
 
-    let signals = classify_signals(&all_tool_calls, &final_content);
+    let signals = classify_signals(&all_tool_calls, &final_content, used_server_web_search);
 
     Ok(TurnResult {
         content: final_content,
@@ -465,6 +477,7 @@ pub async fn execute_streaming(
     let mut iterations: u32 = 0;
     let mut final_content = String::new();
     let mut final_stop_reason = String::new();
+    let mut used_server_web_search = false;
 
     let thinking = if config.thinking_enabled {
         Some(ThinkingConfig {
@@ -491,6 +504,7 @@ pub async fn execute_streaming(
             messages: messages.clone(),
             max_tokens: config.max_output_tokens,
             tools: tool_defs.clone(),
+            server_tools: config.server_tools.clone(),
             temperature: None,
             thinking: thinking.clone(),
             stop_sequences: vec![],
@@ -528,6 +542,9 @@ pub async fn execute_streaming(
                 }
                 ContentBlock::Thinking { thinking, .. } => {
                     debug!(len = thinking.len(), "thinking block received");
+                }
+                ContentBlock::ServerToolUse { name, .. } if name == "web_search" => {
+                    used_server_web_search = true;
                 }
                 _ => {}
             }
@@ -570,7 +587,7 @@ pub async fn execute_streaming(
         "streaming execute stage complete"
     );
 
-    let signals = classify_signals(&all_tool_calls, &final_content);
+    let signals = classify_signals(&all_tool_calls, &final_content, used_server_web_search);
 
     Ok(TurnResult {
         content: final_content,
@@ -950,7 +967,7 @@ mod tests {
 
     #[test]
     fn signal_classification_conversation() {
-        let signals = classify_signals(&[], "Hello");
+        let signals = classify_signals(&[], "Hello", false);
         assert_eq!(signals, vec![InteractionSignal::Conversation]);
     }
 
@@ -964,7 +981,7 @@ mod tests {
             is_error: false,
             duration_ms: 10,
         }];
-        let signals = classify_signals(&calls, "");
+        let signals = classify_signals(&calls, "", false);
         assert!(signals.contains(&InteractionSignal::ToolExecution));
         assert!(signals.contains(&InteractionSignal::CodeGeneration));
     }
@@ -979,7 +996,7 @@ mod tests {
             is_error: false,
             duration_ms: 10,
         }];
-        let signals = classify_signals(&calls, "");
+        let signals = classify_signals(&calls, "", false);
         assert!(signals.contains(&InteractionSignal::ToolExecution));
         assert!(signals.contains(&InteractionSignal::Research));
     }
@@ -994,7 +1011,7 @@ mod tests {
             is_error: true,
             duration_ms: 10,
         }];
-        let signals = classify_signals(&calls, "");
+        let signals = classify_signals(&calls, "", false);
         assert!(signals.contains(&InteractionSignal::ToolExecution));
         assert!(signals.contains(&InteractionSignal::ErrorRecovery));
     }
@@ -1110,7 +1127,7 @@ mod tests {
 
     #[test]
     fn classify_signals_conversation_when_no_tools() {
-        let signals = classify_signals(&[], "some text");
+        let signals = classify_signals(&[], "some text", false);
         assert_eq!(signals, vec![InteractionSignal::Conversation]);
     }
 
@@ -1124,7 +1141,7 @@ mod tests {
             is_error: true,
             duration_ms: 5,
         }];
-        let signals = classify_signals(&calls, "");
+        let signals = classify_signals(&calls, "", false);
         assert!(
             signals.contains(&InteractionSignal::ToolExecution),
             "should have ToolExecution"
@@ -1132,6 +1149,19 @@ mod tests {
         assert!(
             signals.contains(&InteractionSignal::ErrorRecovery),
             "should have ErrorRecovery"
+        );
+    }
+
+    #[test]
+    fn classify_signals_server_web_search() {
+        let signals = classify_signals(&[], "", true);
+        assert!(
+            signals.contains(&InteractionSignal::Research),
+            "should have Research from server web search"
+        );
+        assert!(
+            !signals.contains(&InteractionSignal::Conversation),
+            "should not be Conversation when server web search was used"
         );
     }
 

--- a/crates/nous/src/spawn_svc.rs
+++ b/crates/nous/src/spawn_svc.rs
@@ -72,6 +72,7 @@ impl SpawnService for SpawnServiceImpl {
             max_tool_iterations: 25,
             loop_detection_threshold: 3,
             domains: Vec::new(),
+            server_tools: Vec::new(),
         };
 
         let pipeline_config = PipelineConfig {
@@ -199,6 +200,10 @@ mod tests {
         #[expect(clippy::unnecessary_literal_bound, reason = "trait requires &str")]
         fn name(&self) -> &str {
             "mock"
+        }
+
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
         }
     }
 
@@ -333,6 +338,10 @@ mod tests {
         #[expect(clippy::unnecessary_literal_bound, reason = "trait requires &str")]
         fn name(&self) -> &str {
             "slow"
+        }
+
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
         }
     }
 }

--- a/crates/organon/src/builtins/agent.rs
+++ b/crates/organon/src/builtins/agent.rs
@@ -321,6 +321,7 @@ mod tests {
                 note_store: None,
                 blackboard_store: None,
                 spawn: Some(spawn),
+                planning: None,
                 lazy_tool_catalog: vec![],
                 http_client: reqwest::Client::new(),
             })),

--- a/crates/organon/src/builtins/enable_tool.rs
+++ b/crates/organon/src/builtins/enable_tool.rs
@@ -124,6 +124,8 @@ mod tests {
                 messenger: None,
                 note_store: None,
                 blackboard_store: None,
+                spawn: None,
+                planning: None,
                 http_client: reqwest::Client::new(),
                 lazy_tool_catalog: catalog,
             })),

--- a/crates/organon/src/builtins/mod.rs
+++ b/crates/organon/src/builtins/mod.rs
@@ -12,7 +12,7 @@ pub mod filesystem;
 pub mod memory;
 /// Planning project management tools (create, status, execute, verify).
 pub mod planning;
-/// Web research tools (web_search, web_fetch).
+/// Web research tools (web_fetch). Web search uses Anthropic server-side tools.
 pub mod research;
 /// File viewing with multimodal support (images, PDFs, text).
 pub mod view_file;

--- a/crates/organon/src/builtins/research.rs
+++ b/crates/organon/src/builtins/research.rs
@@ -1,6 +1,9 @@
-//! Web research tools: web_search (Brave Search API) and web_fetch (HTTP GET).
+//! Web research tools: web_fetch (HTTP GET to text).
+//!
+//! Web search is now handled by Anthropic's server-side `web_search` tool,
+//! configured via `NousConfig.server_tools`. This module only provides
+//! `web_fetch` for direct URL retrieval.
 
-use std::fmt::Write as _;
 use std::future::Future;
 use std::pin::Pin;
 
@@ -20,117 +23,6 @@ fn require_services(ctx: &ToolContext) -> std::result::Result<&crate::types::Too
     ctx.services
         .as_deref()
         .ok_or_else(|| ToolResult::error("tool services not configured"))
-}
-
-// --- web_search ---
-
-struct WebSearchExecutor;
-
-impl ToolExecutor for WebSearchExecutor {
-    fn execute<'a>(
-        &'a self,
-        input: &'a ToolInput,
-        ctx: &'a ToolContext,
-    ) -> Pin<Box<dyn Future<Output = Result<ToolResult>> + Send + 'a>> {
-        Box::pin(async {
-            let services = match require_services(ctx) {
-                Ok(s) => s,
-                Err(r) => return Ok(r),
-            };
-
-            let query = extract_str(&input.arguments, "query", &input.name)?;
-            let count = extract_opt_u64(&input.arguments, "count")
-                .unwrap_or(10)
-                .min(20);
-
-            let api_key = match std::env::var("BRAVE_API_KEY") {
-                Ok(key) if !key.is_empty() => key,
-                _ => {
-                    return Ok(ToolResult::error(
-                        "BRAVE_API_KEY environment variable not set. \
-                         Set it to use web_search.",
-                    ))
-                }
-            };
-
-            let url = format!(
-                "https://api.search.brave.com/res/v1/web/search?q={}&count={count}",
-                urlencoding(query)
-            );
-
-            let response = services
-                .http_client
-                .get(&url)
-                .header("X-Subscription-Token", &api_key)
-                .header("Accept", "application/json")
-                .send()
-                .await;
-
-            let response = match response {
-                Ok(r) => r,
-                Err(e) => return Ok(ToolResult::error(format!("search request failed: {e}"))),
-            };
-
-            if !response.status().is_success() {
-                return Ok(ToolResult::error(format!(
-                    "search API returned status {}",
-                    response.status()
-                )));
-            }
-
-            let body: serde_json::Value = match response.json().await {
-                Ok(v) => v,
-                Err(e) => return Ok(ToolResult::error(format!("failed to parse response: {e}"))),
-            };
-
-            let results = body
-                .get("web")
-                .and_then(|w| w.get("results"))
-                .and_then(|r| r.as_array());
-
-            let Some(results) = results else {
-                return Ok(ToolResult::text("No results found."));
-            };
-
-            let mut output = String::new();
-            for (i, result) in results.iter().enumerate() {
-                let title = result.get("title").and_then(|v| v.as_str()).unwrap_or("");
-                let url = result.get("url").and_then(|v| v.as_str()).unwrap_or("");
-                let desc = result
-                    .get("description")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("");
-                if i > 0 {
-                    output.push_str("\n\n");
-                }
-                let _ = write!(output, "{title}\n{url}\n{desc}");
-            }
-
-            if output.is_empty() {
-                Ok(ToolResult::text("No results found."))
-            } else {
-                Ok(ToolResult::text(output))
-            }
-        })
-    }
-}
-
-/// Minimal URL encoding for query parameters.
-fn urlencoding(s: &str) -> String {
-    let mut result = String::with_capacity(s.len());
-    for b in s.bytes() {
-        match b {
-            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
-                result.push(b as char);
-            }
-            b' ' => result.push('+'),
-            _ => {
-                result.push('%');
-                let _ = write!(result, "{b:02X}");
-            }
-        }
-    }
-    result
 }
 
 // --- web_fetch ---
@@ -229,7 +121,6 @@ fn strip_html_tags(html: &str) -> String {
     let mut i = 0;
     while i < bytes.len() {
         if bytes[i] == b'<' {
-            // Check for script/style open/close
             if i + 7 < lower_bytes.len() && &lower_bytes[i..i + 7] == b"<script" {
                 in_script = true;
             }
@@ -255,7 +146,6 @@ fn strip_html_tags(html: &str) -> String {
 
         if bytes[i] == b'>' {
             in_tag = false;
-            // Insert space after closing tags to separate content
             if !last_was_whitespace && !result.is_empty() {
                 result.push(' ');
                 last_was_whitespace = true;
@@ -319,41 +209,7 @@ fn strip_html_tags(html: &str) -> String {
     result.trim().to_owned()
 }
 
-// --- Definitions ---
-
-fn web_search_def() -> ToolDef {
-    ToolDef {
-        name: ToolName::new("web_search").expect("valid tool name"),
-        description: "Search the web using Brave Search. Returns titles, URLs, and descriptions."
-            .to_owned(),
-        extended_description: None,
-        input_schema: InputSchema {
-            properties: IndexMap::from([
-                (
-                    "query".to_owned(),
-                    PropertyDef {
-                        property_type: PropertyType::String,
-                        description: "Search query".to_owned(),
-                        enum_values: None,
-                        default: None,
-                    },
-                ),
-                (
-                    "count".to_owned(),
-                    PropertyDef {
-                        property_type: PropertyType::Number,
-                        description: "Number of results (default: 10, max: 20)".to_owned(),
-                        enum_values: None,
-                        default: Some(serde_json::json!(10)),
-                    },
-                ),
-            ]),
-            required: vec!["query".to_owned()],
-        },
-        category: ToolCategory::Research,
-        auto_activate: false,
-    }
-}
+// --- Definition ---
 
 fn web_fetch_def() -> ToolDef {
     ToolDef {
@@ -392,7 +248,6 @@ fn web_fetch_def() -> ToolDef {
 }
 
 pub fn register(registry: &mut ToolRegistry) -> Result<()> {
-    registry.register(web_search_def(), Box::new(WebSearchExecutor))?;
     registry.register(web_fetch_def(), Box::new(WebFetchExecutor))?;
     Ok(())
 }
@@ -419,6 +274,8 @@ mod tests {
                 messenger: None,
                 note_store: None,
                 blackboard_store: None,
+                spawn: None,
+                planning: None,
                 http_client: reqwest::Client::new(),
                 lazy_tool_catalog: vec![],
             })),
@@ -455,44 +312,10 @@ mod tests {
     }
 
     #[test]
-    fn urlencoding_basic() {
-        assert_eq!(urlencoding("hello world"), "hello+world");
-        assert_eq!(urlencoding("a&b=c"), "a%26b%3Dc");
-        assert_eq!(urlencoding("simple"), "simple");
-    }
-
-    #[test]
-    fn web_search_def_is_lazy() {
-        let def = web_search_def();
-        assert!(!def.auto_activate);
-        assert_eq!(def.category, ToolCategory::Research);
-    }
-
-    #[test]
     fn web_fetch_def_is_lazy() {
         let def = web_fetch_def();
         assert!(!def.auto_activate);
         assert_eq!(def.category, ToolCategory::Research);
-    }
-
-    #[tokio::test]
-    async fn web_search_missing_api_key() {
-        // This test relies on BRAVE_API_KEY not being set or being empty
-        // in the CI/test environment. The executor checks for empty string.
-        let ctx = test_ctx();
-        let executor = WebSearchExecutor;
-        let input = ToolInput {
-            name: ToolName::new("web_search").expect("valid"),
-            tool_use_id: "toolu_1".to_owned(),
-            arguments: serde_json::json!({"query": "test"}),
-        };
-
-        let result = executor.execute(&input, &ctx).await.expect("execute");
-        // Either BRAVE_API_KEY is not set (error) or is set and makes a real request.
-        // In CI, it won't be set, so this tests the error path.
-        if result.is_error {
-            assert!(result.content.text_summary().contains("BRAVE_API_KEY"));
-        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- Replace custom `WebSearchExecutor` (Brave API + `BRAVE_API_KEY`) with Anthropic's native server-side `web_search` tool
- Extend wire format to support mixed tool arrays: user-defined tools (`input_schema`) alongside server tools (`type` + `name`)
- Add `ServerToolUse` and `WebSearchToolResult` content block variants with full round-trip support through streaming, wire serialization, and conversation history
- Config-driven via `NousConfig.server_tools`: operators control which server tools are active

## Changes

| Crate | What |
|-------|------|
| `hermeneus/types` | `ServerToolDefinition`, `ContentBlock::ServerToolUse`, `ContentBlock::WebSearchToolResult`, `CompletionRequest.server_tools` |
| `hermeneus/wire` | `WireToolEntry` untagged enum, server content block variants, cache control scoped to user tools only |
| `hermeneus/stream` | `BlockBuilder` variants for server blocks, SSE accumulation |
| `nous/execute` | Inject server tools into requests, detect server web search for Research signal |
| `nous/config` | `server_tools` field with serde default |
| `organon/research` | Remove `WebSearchExecutor` and Brave code, keep `web_fetch` |

## Test plan

- [x] `cargo test -p aletheia-hermeneus` (serde roundtrip, wire serialization, streaming)
- [x] `cargo test -p aletheia-nous` (signal classification, config defaults)
- [x] `cargo test -p aletheia-organon` (web_fetch preserved, web_search removed)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` (zero warnings)
- [x] `cargo test --workspace` (full suite green)
- [ ] Integration: configure `server_tools: [{type: "web_search", name: "web_search"}]` and verify agent uses native search with citations

🤖 Generated with [Claude Code](https://claude.com/claude-code)