### PR TITLE
fix(sandbox): make deny patterns configurable per deployment

### DIFF
--- a/infrastructure/runtime/src/organon/built-in/exec.ts
+++ b/infrastructure/runtime/src/organon/built-in/exec.ts
@@ -52,7 +52,8 @@ export const execTool: ToolHandler = {
 
     // Pre-screen against deny patterns (always runs, even for bypassed agents)
     const extraPatterns = sandbox?.denyPatterns ?? [];
-    const screen = screenCommand(command, extraPatterns);
+    const removePatterns = sandbox?.removeDenyPatterns ?? [];
+    const screen = screenCommand(command, extraPatterns, removePatterns);
     if (!screen.allowed) {
       if (sandbox?.auditDenied) {
         log.warn(`Denied exec by ${context.nousId}: ${command.slice(0, 200)} (pattern: ${screen.matchedPattern})`);

--- a/infrastructure/runtime/src/organon/sandbox.test.ts
+++ b/infrastructure/runtime/src/organon/sandbox.test.ts
@@ -53,6 +53,27 @@ describe("screenCommand", () => {
     expect(r.matchedPattern).toBe("npm publish*");
   });
 
+  it("supports removing default deny patterns", () => {
+    // sudo is blocked by default
+    expect(screenCommand("sudo whoami").allowed).toBe(false);
+
+    // remove the sudo pattern
+    const r = screenCommand("sudo whoami", [], ["sudo *"]);
+    expect(r.allowed).toBe(true);
+  });
+
+  it("remove only affects exact matching patterns", () => {
+    // removing "sudo *" should not affect other patterns
+    const r = screenCommand("rm -rf /", [], ["sudo *"]);
+    expect(r.allowed).toBe(false);
+  });
+
+  it("extra patterns still apply after removing defaults", () => {
+    // remove sudo, but add it back as extra — still blocked
+    const r = screenCommand("sudo whoami", ["sudo *"], ["sudo *"]);
+    expect(r.allowed).toBe(false);
+  });
+
   it("exports default patterns list", () => {
     const patterns = getDefaultDenyPatterns();
     expect(patterns.length).toBeGreaterThan(5);

--- a/infrastructure/runtime/src/organon/sandbox.ts
+++ b/infrastructure/runtime/src/organon/sandbox.ts
@@ -31,8 +31,11 @@ export interface ScreenResult {
 export function screenCommand(
   command: string,
   extraDenyPatterns: string[] = [],
+  removeDenyPatterns: string[] = [],
 ): ScreenResult {
-  const patterns = [...DEFAULT_DENY_PATTERNS, ...extraDenyPatterns];
+  const removeSet = new Set(removeDenyPatterns);
+  const defaults = DEFAULT_DENY_PATTERNS.filter((p) => !removeSet.has(p));
+  const patterns = [...defaults, ...extraDenyPatterns];
   const normalized = command.replace(/\s+/g, " ").trim();
 
   for (const pattern of patterns) {

--- a/infrastructure/runtime/src/taxis/schema.ts
+++ b/infrastructure/runtime/src/taxis/schema.ts
@@ -517,6 +517,7 @@ const SandboxConfig = z
     memoryLimit: z.string().default("512m"),
     cpuLimit: z.number().default(1),
     denyPatterns: z.array(z.string()).default([]),
+    removeDenyPatterns: z.array(z.string()).default([]),
     auditDenied: z.boolean().default(true),
   })
   .default({});


### PR DESCRIPTION
## Summary

Makes the hardcoded sandbox deny patterns configurable without removing security defaults.

### Problem

The runtime sandbox blocks `sudo *`, `systemctl stop *`, `reboot*`, etc. via hardcoded patterns in `sandbox.ts`. There was no way to remove specific patterns for trusted deployments — only add new ones.

### Solution

New config field `sandbox.removeDenyPatterns` (default: `[]`). Patterns listed here are filtered out of the defaults before screening. Extra `denyPatterns` still stack on top.

```yaml
sandbox:
  removeDenyPatterns:
    - 'sudo *'
    - 'systemctl stop *'
    - 'systemctl disable *'
    - 'reboot*'
    - 'shutdown*'
```

### Changes

| File | Change |
|------|--------|
| `taxis/schema.ts` | Add `removeDenyPatterns` to SandboxConfig |
| `organon/sandbox.ts` | Filter defaults against removal set |
| `organon/built-in/exec.ts` | Pass `removeDenyPatterns` from config |
| `organon/sandbox.test.ts` | 3 new tests: removal, isolation, re-addition |

### Test plan

- [x] All 13 sandbox tests pass
- [x] Runtime builds cleanly
- [x] Existing behavior unchanged (empty `removeDenyPatterns` = no effect)