### PR TITLE
docs: accuracy sweep — fix 10 stale/incorrect documents

### DIFF
--- a/docs/ARCHITECTURE-GUIDE.md
+++ b/docs/ARCHITECTURE-GUIDE.md
@@ -72,31 +72,32 @@ Crates are organized in layers. Lower layers know nothing about higher layers.
 ### Leaf (no workspace dependencies)
 
 - **koina** — shared foundation: error types (snafu), tracing setup, safe wrappers (`trySafe`), filesystem utilities. Every other crate depends on this.
-- **symbolon** — authentication: JWT tokens, bearer validation, RBAC. Standalone — uses its own SQLite for token storage.
 
 ### Low (depends on koina)
 
 - **taxis** — configuration and paths. Loads the YAML config cascade (figment), resolves the oikos instance directory structure.
 - **hermeneus** — LLM provider abstraction. The Anthropic streaming client lives here. Handles retries, cost tracking, model routing.
+- **symbolon** — authentication: JWT tokens, bearer validation, RBAC. Depends on koina; uses its own SQLite for token storage.
 - **mneme** — memory engine. SQLite session store, embedded CozoDB for knowledge graphs and vector search, fastembed-rs for local embeddings, LLM-driven fact extraction.
-- **organon** — tool system. The `ToolRegistry` and `ToolExecutor` trait, plus built-in tools (write, edit, exec, web_search).
-- **agora** — channel system. The `ChannelProvider` trait, Signal client (semeion), message routing via bindings.
-- **melete** — distillation. Compresses conversation history when context windows fill up, flushes extracted knowledge to memory.
 
 ### Mid (depends on lower layers)
 
+- **melete** — distillation. Compresses conversation history when context windows fill up, flushes extracted knowledge to memory. Depends on koina + hermeneus.
+- **organon** — tool system. The `ToolRegistry` and `ToolExecutor` trait, plus built-in tools (write, edit, exec, web_search). Depends on koina + hermeneus.
+- **agora** — channel system. The `ChannelProvider` trait, Signal client (semeion), message routing via bindings. Depends on koina + taxis.
+- **oikonomos** (daemon) — background task runner. Cron scheduling, prosoche attention checks, trace rotation, drift detection, DB monitoring. Depends on koina.
+- **dianoia** — planning orchestrator. Multi-phase project state machine, workspace persistence. Depends on koina.
+- **thesauros** — domain pack loader. Reads `pack.yaml` manifests, registers pack tools and context overlays. Depends on koina + organon.
+
+### High (depends on multiple mid+low layers)
+
 - **nous** — the agent pipeline. `NousManager` owns all agents. `NousActor` is a Tokio actor (Alice Ryhl pattern) that runs the pipeline stages. Bootstrap file loading, recall integration, tool execution loop, finalization.
-- **dianoia** — planning orchestrator. Multi-phase project state machine, workspace persistence.
-- **thesauros** — domain pack loader. Reads `pack.yaml` manifests, registers pack tools and context overlays.
-
-### High (depends on everything)
-
 - **pylon** — HTTP gateway. Axum router with versioned API (`/api/v1/`), SSE streaming, OpenAPI spec, Prometheus metrics, security middleware (CORS, CSRF, TLS, auth).
-- **oikonomos** (daemon) — background task runner. Cron scheduling, prosoche attention checks, trace rotation, drift detection, DB monitoring.
 
 ### Top
 
 - **aletheia** — the binary. Wires everything together, CLI parsing (clap), graceful shutdown.
+- **tui** — terminal dashboard. Separate workspace member at `tui/`.
 
 ---
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,7 @@
 # Architecture
 
 > Module map, dependency graph, trait boundaries, and extension points.
-> Covers the Rust crate workspace (target) and TypeScript runtime (current production).
+> Covers the Rust crate workspace and TypeScript runtime (legacy).
 >
 > Technology choices and dependency policy: [TECHNOLOGY.md](TECHNOLOGY.md).
 > Project roadmap: [PROJECT.md](PROJECT.md).
@@ -28,15 +28,14 @@ aletheia
 ├── hermeneus     — Anthropic client, model routing, credentials, provider trait
 ├── organon       — tool registry + built-in tools
 ├── nous          — agent pipeline, bootstrap, recall, finalize, actor model
-│   └── roles     — tekton, theoros, zetetes, kritikos, ergates
 ├── dianoia       — planning / project orchestration
 ├── pylon         — Axum HTTP gateway, SSE, static UI serving
 ├── symbolon      — JWT auth, sessions, RBAC
 ├── agora         — channel registry + ChannelProvider trait
-│   ├── semeion   — Signal (signal-cli subprocess)
-│   └── slack     — Slack (raw API + WebSocket)
-├── daemon           — oikonomos: per-nous background tasks, cron, evolution, prosoche
+│   └── semeion   — Signal (signal-cli subprocess)
+├── daemon        — oikonomos: per-nous background tasks, cron, evolution, prosoche
 ├── melete        — distillation, reflection, memory flush, consolidation
+├── tui           — terminal dashboard                                  (separate workspace member at tui/)
 ├── prostheke     — WASM plugin host (wasmtime)                         [planned: M5]
 └── autarkeia     — agent export/import                                 [planned: M5]
 ```
@@ -116,15 +115,16 @@ Application crates in `crates/`, plus the `integration-tests` support crate.
 | `mneme` | Unified memory store, embedding provider trait, knowledge retrieval. Includes vendored CozoDB engine behind `mneme-engine` feature gate. | koina |
 | `hermeneus` | Anthropic client, model routing, credential management, provider trait | koina |
 | `organon` | Tool registry, tool definitions, built-in tool set | koina, hermeneus |
-| `symbolon` | JWT tokens, password hashing, RBAC policies | nothing (leaf) |
+| `symbolon` | JWT tokens, password hashing, RBAC policies | koina |
 | `melete` | Context distillation, compression strategies, token budget management | koina, hermeneus |
 | `agora` | Channel registry, ChannelProvider trait, Signal JSON-RPC client | koina, taxis |
 | `oikonomos` | Background task scheduling, cron jobs, lifecycle events | koina |
 | `dianoia` | Multi-phase planning orchestrator, project context tracking | koina |
 | `thesauros` | Domain pack loader - external knowledge, tools, config overlays | koina, organon |
-| `nous` | Agent pipeline, NousActor (tokio), bootstrap, recall, execute, finalize | koina, taxis, mneme, hermeneus, organon, thesauros |
+| `nous` | Agent pipeline, NousActor (tokio), bootstrap, recall, execute, finalize | koina, taxis, mneme, hermeneus, organon, melete, thesauros |
 | `pylon` | Axum HTTP gateway, SSE streaming, static UI serving, auth middleware | koina, taxis, hermeneus, organon, mneme, nous, symbolon |
-| `aletheia` | Binary entrypoint (Clap CLI) - wires all crates together | taxis, hermeneus, organon, mneme, nous, symbolon, pylon, agora, thesauros, oikonomos, dianoia |
+| `tui` | Terminal dashboard — separate workspace member at `tui/` | reqwest (standalone UI client) |
+| `aletheia` | Binary entrypoint (Clap CLI) - wires all crates together | taxis, hermeneus, organon, mneme, nous, symbolon, pylon, agora, thesauros, oikonomos, dianoia, tui (optional) |
 
 **Support crates** (not part of the application dependency graph):
 
@@ -150,12 +150,12 @@ Application crates in `crates/`, plus the `integration-tests` support crate.
 ```
 
 **Layer rules:**
-- **Leaf** (no workspace deps): `koina`, `symbolon`
-- **Low** (leaf deps only): `taxis`, `hermeneus`, `melete`, `agora`, `mneme` (includes vendored CozoDB engine behind feature gate)
-- **Mid**: `organon` (koina + hermeneus), `oikonomos` (koina), `dianoia` (koina), `thesauros` (koina + organon)
+- **Leaf** (no workspace deps): `koina`
+- **Low** (koina only): `taxis`, `hermeneus`, `symbolon`, `mneme` (includes vendored CozoDB engine behind feature gate)
+- **Mid**: `melete` (koina + hermeneus), `organon` (koina + hermeneus), `agora` (koina + taxis), `oikonomos` (koina), `dianoia` (koina), `thesauros` (koina + organon)
 - **High**: `nous` (multiple mid+low deps), `pylon` (multiple deps including nous)
-- **Top**: `aletheia` binary
-- **Support**: `integration-tests`
+- **Top**: `aletheia` binary, `tui` (terminal dashboard)
+- **Support**: `dokimion` (eval), `integration-tests`
 
 Imports flow downward only. Lower-layer crates must not depend on higher layers.
 
@@ -177,7 +177,7 @@ Imports flow downward only. Lower-layer crates must not depend on higher layers.
 
 ---
 
-## TypeScript Runtime (Current Production)
+## TypeScript Runtime (Legacy)
 
 All modules in `infrastructure/runtime/src/`:
 
@@ -248,7 +248,7 @@ taxis → mneme → hermeneus → organon → nous → dianoia → prostheke →
 
 ### Plugin
 
-See [docs/PLUGINS.md](PLUGINS.md).
+See [docs/PLUGINS-DESIGN.md](PLUGINS-DESIGN.md).
 
 ---
 
@@ -270,7 +270,7 @@ opt-level = 2      # optimize deps in dev — faster iteration
 ## Structural Properties
 
 - **koina is a true leaf node** in both stacks. No `index.ts` in TS - import from specific files. No workspace deps in Rust.
-- **symbolon is zero-dependency** in both stacks. Takes `Database.Database` as constructor argument in TS.
+- **symbolon depends only on koina** in Rust (plus external crates: reqwest, rusqlite, jsonwebtoken). Zero-dependency in TS (takes `Database.Database` as constructor argument).
 - **CozoDB engine is vendored** inside `mneme/src/engine/`, gated behind the `mneme-engine` feature.
 - **Trait boundaries are extension points.** `EmbeddingProvider`, `ChannelProvider`, `LlmProvider` - implement the trait, swap the provider.
 - **oikonomos depends only on koina** - lightweight scheduling, not a high-layer crate. No other application crate imports it.

--- a/docs/DATA.md
+++ b/docs/DATA.md
@@ -28,7 +28,6 @@ instance/
 ├── config/credentials/      # API keys
 ├── data/
 │   ├── sessions.db          # Session store (SQLite, WAL mode)
-│   ├── planning.db          # Planning state
 │   ├── cozo/                # Knowledge graph (CozoDB)
 │   ├── backups/             # Database backups
 │   └── archive/sessions/    # Archived session JSON files

--- a/docs/NETWORK.md
+++ b/docs/NETWORK.md
@@ -39,7 +39,18 @@ Aletheia makes zero unsolicited outbound network connections. There is no:
 - License validation
 - Beacon or heartbeat to any external service
 
-The only outbound connections are to services you explicitly configure (LLM provider, Signal). This is verifiable by inspecting the codebase — the only HTTP client (`reqwest`) usage is in `crates/hermeneus/` (LLM calls) and `crates/agora/` (Signal JSON-RPC).
+The only outbound connections are to services you explicitly configure (LLM provider, Signal). Crates that use `reqwest`:
+
+- `hermeneus` — LLM provider API calls (Anthropic, etc.)
+- `agora` — Signal JSON-RPC (localhost)
+- `symbolon` — OAuth token refresh/validation
+- `organon` — tool execution (web_search, HTTP tools)
+- `nous` — pipeline HTTP calls
+- `aletheia` — binary entry point (health checks, eval runner)
+- `eval` (dokimion) — behavioral eval HTTP scenario runner
+- `tui` — terminal dashboard API client
+
+All reqwest usage targets either the configured LLM provider, localhost services, or user-initiated tool calls. No unsolicited outbound connections.
 
 ---
 

--- a/docs/PLUGINS-DESIGN.md
+++ b/docs/PLUGINS-DESIGN.md
@@ -1,4 +1,16 @@
-# Plugins
+# Plugin System (Design Document)
+
+<!-- TODO: not yet implemented — planned for M5 milestone (prostheke crate, WASM host via wasmtime) -->
+
+This document describes the **planned** plugin system. It is not yet implemented in the Rust binary.
+
+**Current extension mechanism:** Domain packs via the `thesauros` crate. See [ARCHITECTURE.md](ARCHITECTURE.md) for the thesauros entry.
+
+---
+
+The design below is from the TypeScript-era plugin loader (`infrastructure/runtime/src/prostheke/`). The Rust implementation will use WASM (wasmtime) instead of JavaScript, but the lifecycle hook model is expected to carry forward.
+
+## Planned Structure
 
 Plugins hook into the agent lifecycle and register custom tools.
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -14,36 +14,18 @@ cargo build --release
 cp target/release/aletheia ~/.local/bin/
 ```
 
-For headless or CLI-only setups, run `aletheia init` instead.
-
 ## Daily Use
 
 ```bash
-aletheia start      # start memory services + gateway
-aletheia stop       # stop gateway
-aletheia restart    # stop then start
-aletheia logs -f    # follow gateway logs
-aletheia status     # live metrics (requires running gateway)
-aletheia doctor     # validate config and connectivity
+aletheia              # start the server (gateway, agents, daemon)
+aletheia health       # check config and connectivity
+aletheia status       # agent status, sessions, cron jobs
+aletheia backup       # create a point-in-time database backup
 ```
 
-Run `aletheia help` for the full command reference.
+Run `aletheia --help` for the full command reference.
 
-## Memory Infrastructure
-
-`aletheia start` brings up Qdrant automatically if Podman or Docker is installed and `infrastructure/memory/docker-compose.yml` exists.
-
-```text
-Memory services:
-  qdrant      OK running
-  mem0        -  deprecated (replaced by embedded KnowledgeStore)
-```
-
-**macOS (native, no Docker):** `brew install qdrant` - `aletheia start` detects native services.
-
-**Linux / Docker / Podman:** Ensure Docker or Podman is running. `aletheia start` handles the rest.
-
-Skip with `aletheia start --no-memory`. Memory is now embedded via KnowledgeStore (no external sidecar needed).
+Memory (CozoDB, fastembed-rs) is embedded in the binary. No external databases, containers, or sidecars required.
 
 ## Optional: Signal Integration
 
@@ -54,4 +36,4 @@ Requires [signal-cli](https://github.com/AsamK/signal-cli) and a registered phon
 - [CONFIGURATION.md](CONFIGURATION.md) - config reference
 - [DEPLOYMENT.md](DEPLOYMENT.md) - production setup
 - [WORKSPACE_FILES.md](WORKSPACE_FILES.md) - agent workspace files
-- [PLUGINS.md](PLUGINS.md) - plugin system
+- [ARCHITECTURE.md](ARCHITECTURE.md) - system architecture and extension points

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -5,17 +5,17 @@ For setup and deployment, see [DEPLOYMENT.md](DEPLOYMENT.md).
 ## Service Architecture
 
 ```text
-aletheia gateway              (port 18789)  -- Rust binary, web UI, API
-+-- signal-cli daemon         (port 8080)   -- Signal messaging
-+-- aletheia-memory sidecar   (port 8230)   -- (deprecated, replaced by embedded KnowledgeStore)
-|   +-- qdrant                (port 6333)   -- vector store (container)
-+-- daemon (oikonomos)        (in-process)  -- heartbeats, scheduled tasks, prosoche
+aletheia                         (port 18789)  -- Rust binary, web UI, API
++-- signal-cli daemon            (port 8080)   -- Signal messaging (subprocess)
++-- daemon (oikonomos)           (in-process)  -- heartbeats, scheduled tasks, prosoche
 ```
+
+Memory (CozoDB, fastembed-rs, SQLite) is embedded in the binary. No external databases or sidecars required.
 
 ## Quick Health Check
 
 ```bash
-aletheia doctor          # connectivity, dependencies, boot persistence
+aletheia health          # connectivity, dependencies
 aletheia status          # agent status, sessions, cron jobs
 ```
 
@@ -23,31 +23,7 @@ aletheia status          # agent status, sessions, cron jobs
 
 ## Start Procedure
 
-### 1. Verify containers
-
-```bash
-podman ps | grep -E "qdrant|neo4j"
-# If not running:
-podman start qdrant neo4j
-```
-
-### 2. Verify memory sidecar
-
-```bash
-curl -s http://localhost:8230/health | python3 -m json.tool
-# Expected: {"status":"ok","qdrant":"ok","neo4j":"ok","embedder":"ok"}
-```
-
-If down:
-
-```bash
-systemctl --user status aletheia-memory
-# Or start manually:
-cd <repo>/infrastructure/memory/sidecar
-.venv/bin/uvicorn aletheia_memory.app:app --host 0.0.0.0 --port 8230 &
-```
-
-### 3. Check port is free
+### 1. Check port is free
 
 ```bash
 ss -tlnp | grep 18789
@@ -55,35 +31,36 @@ ss -tlnp | grep 18789
 fuser -k 18789/tcp
 ```
 
-### 4. Start gateway
+### 2. Start the binary
 
 ```bash
-aletheia gateway start
+aletheia
 ```
 
-### 5. Verify
+The binary serves the HTTP gateway, spawns nous actors, starts the daemon, and (if configured) launches signal-cli. No subcommand needed.
+
+Or via systemd:
+
+```bash
+systemctl --user start aletheia
+```
+
+### 3. Verify
 
 ```bash
 sleep 3
 curl -s http://localhost:18789/api/setup/status | python3 -m json.tool
 ```
 
-
-
 ---
 
 ## Stop Procedure
 
 ```bash
-# Gateway
 systemctl --user stop aletheia
-
-# Memory sidecar (optional -- usually leave running)
-pkill -f "aletheia_memory"
-
-# Containers (optional -- usually leave running)
-podman stop qdrant
 ```
+
+Or send SIGTERM / Ctrl+C to the running process. The binary shuts down gracefully.
 
 ---
 
@@ -106,25 +83,14 @@ systemctl --user restart aletheia
 fuser 18789/tcp              # find PID
 fuser -k 18789/tcp           # kill it
 sleep 2
-aletheia gateway start
-```
-
-### Memory sidecar unhealthy
-
-```bash
-curl -s http://localhost:8230/health
-curl -s http://localhost:6333/healthz       # Qdrant
-curl -s http://localhost:7474               # Neo4j
-
-# Restart (VOYAGE_API_KEY only in systemd service file):
-systemctl --user restart aletheia-memory
+aletheia
 ```
 
 ### Signal-cli not receiving messages
 
 ```bash
 ps aux | grep signal-cli | grep -v grep
-# If not running, restart gateway -- it auto-starts signal-cli.
+# If not running, restart the binary -- it auto-starts signal-cli.
 # If running but not receiving:
 signal-cli -a +15550100001 receive --timeout 5
 ```
@@ -139,8 +105,8 @@ journalctl --user -u aletheia --since "1 hour ago" | grep prosoche
 ### Agent not responding
 
 ```bash
-aletheia sessions             # check session exists
-aletheia doctor               # check agent config
+aletheia status              # check agent and session state
+aletheia health              # check config and connectivity
 ls -la <repo>/nous/<agent-id>/SOUL.md   # verify workspace readable
 ```
 
@@ -160,8 +126,6 @@ Router auto-failover handles 429/5xx across providers. Expired OAuth tokens need
 | Service | Log |
 |---------|-----|
 | Gateway | stdout / `journalctl --user -u aletheia` |
-| Memory sidecar | stdout / `journalctl --user -u aletheia-memory` |
-| Qdrant | `podman logs qdrant` |
 | Signal-cli | Gateway stdout (subprocess) |
 
 ## Key Paths
@@ -170,10 +134,10 @@ Router auto-failover handles 429/5xx across providers. Expired OAuth tokens need
 |------|---------|
 | `instance/config/aletheia.yaml` | Main config |
 | `instance/data/sessions.db` | SQLite session store |
+| `instance/data/cozo/` | CozoDB knowledge graph (embedded) |
 | `instance/nous/<id>/` | Agent workspaces |
-| `infrastructure/memory/sidecar/` | Python memory sidecar |
 | `ui/` | Svelte web UI |
 
 ## Pre-Restart Checklist
 
-Always run `aletheia doctor` before restarting. Fix reported failures first - restarting with broken dependencies adds confusion.
+Always run `aletheia health` before restarting. Fix reported failures first - restarting with broken dependencies adds confusion.

--- a/docs/STANDARDS.md
+++ b/docs/STANDARDS.md
@@ -337,14 +337,12 @@ unused_self = "warn"
 Features are additive. Never negative names. Binary crate is the feature aggregator.
 
 ```toml
+# Illustrative pattern — see crates/aletheia/Cargo.toml for actual binary features
 [features]
-default = ["signal", "fastembed", "graph"]
-signal = ["dep:signal-ipc"]
-browser = ["dep:chromiumoxide"]
-graph = ["dep:cozo"]
-fastembed = ["dep:fastembed"]
-voyage = ["dep:reqwest"]
-wasm-plugins = ["dep:wasmtime"]
+default = ["tui", "recall"]
+recall = ["aletheia-nous/knowledge-store", "aletheia-mneme/mneme-engine", "aletheia-pylon/knowledge-store"]
+tui = ["dep:aletheia-tui"]
+tls = ["aletheia-pylon/tls"]
 ```
 
 ### Conversion Methods
@@ -414,23 +412,31 @@ cargo bench  # regression detection via divan
 
 ### Supply Chain (`deny.toml`)
 ```toml
+[graph]
+exclude = ["aletheia-mneme-engine", "aletheia-integration-tests"]
+
 [advisories]
-vulnerability = "deny"
-unmaintained = "warn"
-yanked = "warn"
+ignore = [
+    { id = "RUSTSEC-2023-0071", reason = "rsa timing side-channel via jsonwebtoken — no safe upgrade, local-only use" },
+    { id = "RUSTSEC-2025-0057", reason = "fxhash unmaintained — transitive via graph_builder, no safe upgrade" },
+]
 
 [licenses]
-unlicensed = "deny"
-allow = ["MIT", "Apache-2.0", "BSD-2-Clause", "BSD-3-Clause", "ISC", "Zlib", "Unicode-3.0"]
-copyleft = "deny"
+allow = [
+    "MIT", "Apache-2.0", "AGPL-3.0-or-later",
+    "BSD-2-Clause", "BSD-3-Clause", "ISC", "Zlib",
+    "Unicode-3.0", "BSL-1.0", "CC0-1.0", "0BSD",
+]
+confidence-threshold = 0.8
 
 [bans]
 multiple-versions = "warn"
-wildcards = "deny"
+wildcards = "allow"
 
 [sources]
 unknown-registry = "deny"
 unknown-git = "deny"
+allow-git = []
 ```
 
 ---

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -40,7 +40,7 @@ The config system uses figment with `serde(default)` on all structs. New config 
 
 Both `snake_case` and `camelCase` field names work via serde's `rename_all = "camelCase"`.
 
-Check [CHANGELOG.md](../CHANGELOG.md) for breaking changes per version. Pre-1.0, MINOR bumps may include breaking changes with documented migration steps.
+Check `git log --oneline` or [GitHub releases](https://github.com/forkwright/aletheia/releases) for breaking changes per version. Pre-1.0, MINOR bumps may include breaking changes with documented migration steps.
 
 ---
 

--- a/docs/VENDORING.md
+++ b/docs/VENDORING.md
@@ -14,23 +14,11 @@
 | Copyright | Copyright 2022-2024 Ziyang Hu and CozoDB contributors |
 | Location | `crates/mneme/src/engine/` (behind `mneme-engine` feature gate) |
 
-### graph_builder (vendored for CozoDB transitive use)
-
-| Field | Value |
-|-------|-------|
-| Original project | graph (neo4j-labs) |
-| Original crate | graph_builder |
-| Version | 0.4.1 |
-| Source | https://github.com/neo4j-labs/graph |
-| License | MIT |
-| Copyright | Copyright (c) neo4j-labs contributors |
-| Location | `vendor/graph_builder/` (transitive dependency of CozoDB, not a workspace crate) |
+CozoDB transitively depends on `graph_builder` (0.4.1, MIT, neo4j-labs) via crates.io. It is not vendored on disk. Rayon is pinned to =1.10.0 to work around a type mismatch in `EdgeList::edges()` (graph#138).
 
 ## License Compliance
 
 Per MPL-2.0 Section 3.1, source files from CozoDB retain their original license. MPL-2.0 is compatible with Aletheia's AGPL-3.0-or-later per Section 3.3 (Secondary License). Copyright headers in absorbed source files are preserved verbatim.
-
-graph_builder is MIT-licensed. No additional compliance requirements beyond preserving the copyright notice.
 
 ## Modifications from Original
 
@@ -45,14 +33,6 @@ graph_builder is MIT-licensed. No additional compliance requirements beyond pres
 - `lib.rs` rewritten: new `Db` facade enum replacing `DbInstance`
 - `env_logger` moved to dev-dependencies
 - Absorbed into `crates/mneme/src/engine/` as a feature-gated module
-
-### graph_builder (vendor/)
-
-- `compat.rs` removed (polyfills replaced with stdlib equivalents)
-- `build.rs` removed (feature probes for pre-1.80 Rust no longer needed)
-- Unused input formats removed: dotgraph, gdl, graph500, binary
-- `adj_list.rs` removed (only CSR graphs used)
-- rayon pinned to =1.10.0 (1.11 breaks `EdgeList::edges()`)
 
 ## Upstream Status
 
@@ -70,19 +50,6 @@ graph_builder is MIT-licensed. No additional compliance requirements beyond pres
 - **#287** - env_logger in non-dev dependencies. Moved to dev-dependencies in absorption.
 
 No unmerged PRs contain fixes we need. Upstream is inactive - no divergence risk. Future CozoDB development (if any) would need manual review for cherry-pick into the engine module.
-
-### graph_builder
-
-| Field | Value |
-|-------|-------|
-| Repository | https://github.com/neo4j-labs/graph |
-| Version absorbed | 0.4.1 |
-| Upstream status | Inactive |
-
-**Relevant issues:**
-- **graph#138** - rayon 1.11 type mismatch in `EdgeList::edges()`. Pinned rayon to =1.10.0.
-
-Upstream inactive. graph_builder 0.4.1 is the final version used by CozoDB. The `graph` facade crate (0.3.1) remains a crates.io dependency for PageRank.
 
 ## Cleanup Backlog
 


### PR DESCRIPTION
## Summary

Systematic accuracy sweep across 10 documentation files, verifying every factual claim against the current codebase. Closes #563.

- **PLUGINS.md** → renamed to PLUGINS-DESIGN.md, marked as planned M5 feature (prostheke WASM host). Points to thesauros domain packs as current extension mechanism.
- **RUNBOOK.md** — removed deprecated memory sidecar/Qdrant/Neo4j sections, fixed nonexistent `aletheia gateway start` command (binary just runs `aletheia`)
- **QUICKSTART.md** — removed deprecated memory infrastructure section, fixed CLI commands to match actual binary
- **ARCHITECTURE.md** — fixed symbolon layer classification (was "leaf", actually depends on koina), added melete to nous dependency list, removed phantom `nous/roles` and `agora/slack` sub-modules, added TUI crate, changed TS runtime header from "Current Production" to "Legacy"
- **ARCHITECTURE-GUIDE.md** — reconciled layer classifications with ARCHITECTURE.md (symbolon leaf→low, organon low→mid, added TUI)
- **UPGRADING.md** — replaced reference to nonexistent CHANGELOG.md with git log guidance
- **VENDORING.md** — removed phantom `vendor/graph_builder/` section (not vendored on disk, it's a crates.io transitive dep)
- **STANDARDS.md** — replaced deny.toml example with actual config (was missing 4 licenses, had wrong wildcards policy, missing graph excludes and advisory ignores), updated feature flag example to match actual binary features
- **DATA.md** — removed phantom `planning.db` from storage tree (path defined in oikos but never created)
- **NETWORK.md** — fixed reqwest scope claim from "2 crates" to accurate list of 8 crates with their purposes

## Verification

Every change was verified against the actual codebase:
- Cargo.toml files for dependency claims
- Source directories for sub-module existence
- deny.toml for supply chain config
- CLI entry point for available commands
- File system for vendor directory contents