### PR TITLE
chore: cruft sweep — dead code, stale refs, unused deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -79,7 +79,6 @@ dependencies = [
 name = "aletheia-agora"
 version = "0.10.0"
 dependencies = [
- "aletheia-koina",
  "aletheia-taxis",
  "indexmap 2.13.0",
  "reqwest",
@@ -97,7 +96,6 @@ dependencies = [
 name = "aletheia-dianoia"
 version = "0.10.0"
 dependencies = [
- "aletheia-koina",
  "jiff",
  "serde",
  "serde_json",
@@ -173,7 +171,6 @@ dependencies = [
  "serde_json",
  "snafu",
  "static_assertions",
- "tracing",
  "tracing-subscriber",
  "ulid",
 ]
@@ -183,7 +180,6 @@ name = "aletheia-melete"
 version = "0.10.0"
 dependencies = [
  "aletheia-hermeneus",
- "aletheia-koina",
  "jiff",
  "serde",
  "serde_json",
@@ -198,7 +194,6 @@ name = "aletheia-mneme"
 version = "0.10.0"
 dependencies = [
  "aho-corasick",
- "aletheia-koina",
  "approx",
  "base64 0.22.1",
  "bytemuck",
@@ -224,9 +219,7 @@ dependencies = [
  "rand 0.8.5",
  "rayon",
  "regex",
- "rmp",
  "rmp-serde",
- "rmpv",
  "rocksdb",
  "rusqlite",
  "rust-stemmers",
@@ -266,7 +259,6 @@ dependencies = [
  "indexmap 2.13.0",
  "jiff",
  "prometheus",
- "reqwest",
  "serde",
  "serde_json",
  "snafu",
@@ -281,7 +273,6 @@ dependencies = [
 name = "aletheia-oikonomos"
 version = "0.10.0"
 dependencies = [
- "aletheia-koina",
  "chrono",
  "cron",
  "flate2",
@@ -319,7 +310,6 @@ name = "aletheia-pylon"
 version = "0.10.0"
 dependencies = [
  "aletheia-hermeneus",
- "aletheia-koina",
  "aletheia-mneme",
  "aletheia-nous",
  "aletheia-organon",
@@ -371,7 +361,6 @@ dependencies = [
 name = "aletheia-taxis"
 version = "0.10.0"
 dependencies = [
- "aletheia-koina",
  "figment",
  "serde",
  "serde_json",
@@ -416,7 +405,6 @@ dependencies = [
  "serde",
  "serde_json",
  "syntect",
- "textwrap",
  "tokio",
  "toml",
  "tracing",
@@ -5268,15 +5256,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rmpv"
-version = "1.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a4e1d4b9b938a26d2996af33229f0ca0956c652c1375067f0b45291c1df8417"
-dependencies = [
- "rmp",
-]
-
-[[package]]
 name = "rocksdb"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5794,12 +5773,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "smawk"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
-
-[[package]]
 name = "snafu"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6116,17 +6089,6 @@ dependencies = [
  "wezterm-dynamic",
  "wezterm-input-types",
  "winapi",
-]
-
-[[package]]
-name = "textwrap"
-version = "0.16.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
-dependencies = [
- "smawk",
- "unicode-linebreak",
- "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -6666,12 +6628,6 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
-
-[[package]]
-name = "unicode-linebreak"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
 
 [[package]]
 name = "unicode-normalization"

--- a/crates/agora/Cargo.toml
+++ b/crates/agora/Cargo.toml
@@ -11,7 +11,6 @@ rust-version.workspace = true
 workspace = true
 
 [dependencies]
-aletheia-koina = { path = "../koina" }
 aletheia-taxis = { path = "../taxis" }
 indexmap = { workspace = true }
 reqwest = { workspace = true }

--- a/crates/agora/src/error.rs
+++ b/crates/agora/src/error.rs
@@ -23,22 +23,6 @@ pub enum Error {
         location: snafu::Location,
     },
 
-    /// Channel send operation failed.
-    #[snafu(display("send failed on channel {channel}: {message}"))]
-    Send {
-        channel: String,
-        message: String,
-        #[snafu(implicit)]
-        location: snafu::Location,
-    },
-
-    /// Signal-specific error.
-    #[snafu(display("signal error: {source}"))]
-    Signal {
-        source: crate::semeion::error::Error,
-        #[snafu(implicit)]
-        location: snafu::Location,
-    },
 }
 
 /// Convenience alias for `Result` with agora's [`Error`] type.

--- a/crates/aletheia/src/main.rs
+++ b/crates/aletheia/src/main.rs
@@ -144,7 +144,7 @@ enum Command {
     Export {
         /// Agent (nous) ID to export
         nous_id: String,
-        /// Output file path (default: <nous-id>-<date>.agent.json)
+        /// Output file path (default: `{nous-id}-{date}.agent.json`)
         #[arg(short, long)]
         output: Option<PathBuf>,
         /// Include archived/distilled sessions

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -11,7 +11,6 @@ rust-version.workspace = true
 workspace = true
 
 [dependencies]
-aletheia-koina = { path = "../koina" }
 chrono = { workspace = true }
 cron = { workspace = true }
 flate2 = { workspace = true }

--- a/crates/dianoia/Cargo.toml
+++ b/crates/dianoia/Cargo.toml
@@ -11,7 +11,6 @@ rust-version.workspace = true
 workspace = true
 
 [dependencies]
-aletheia-koina = { path = "../koina" }
 jiff = { version = "0.2", features = ["serde"] }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/koina/Cargo.toml
+++ b/crates/koina/Cargo.toml
@@ -16,7 +16,6 @@ regex = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 snafu = { workspace = true }
-tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 ulid = { workspace = true }
 

--- a/crates/melete/Cargo.toml
+++ b/crates/melete/Cargo.toml
@@ -11,7 +11,6 @@ rust-version.workspace = true
 workspace = true
 
 [dependencies]
-aletheia-koina = { path = "../koina" }
 aletheia-hermeneus = { path = "../hermeneus" }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/mneme/Cargo.toml
+++ b/crates/mneme/Cargo.toml
@@ -22,7 +22,7 @@ mneme-engine = [
     # Engine (vendored CozoDB) dependencies
     "dep:rayon", "dep:graph", "dep:ordered-float", "dep:priority-queue",
     "dep:approx", "dep:smallvec", "dep:smartstring", "dep:serde_derive",
-    "dep:serde_bytes", "dep:rmp", "dep:rmp-serde", "dep:rmpv",
+    "dep:serde_bytes", "dep:rmp-serde",
     "dep:crossbeam", "dep:itertools", "dep:rustc-hash", "dep:twox-hash",
     "dep:byteorder", "dep:num-traits", "dep:regex", "dep:sha2",
     "dep:chrono", "dep:chrono-tz", "dep:either", "dep:rand", "dep:base64", "dep:casey",
@@ -33,7 +33,6 @@ mneme-engine = [
 storage-new-rocksdb = ["dep:rocksdb", "mneme-engine"]
 
 [dependencies]
-aletheia-koina = { path = "../koina" }
 fastembed = { version = "5", optional = true }
 jiff = { workspace = true, optional = true }
 miette = { version = "5.10.0", optional = true }
@@ -56,9 +55,7 @@ smallvec = { version = "1.13.2", features = ["serde", "write", "union", "const_g
 smartstring = { version = "1.0.1", features = ["serde"], optional = true }
 serde_derive = { version = "1.0", optional = true }
 serde_bytes = { version = "0.11", optional = true }
-rmp = { version = "0.8", optional = true }
 rmp-serde = { version = "1.2", optional = true }
-rmpv = { version = "1.0", optional = true }
 crossbeam = { version = "0.8.4", optional = true }
 itertools = { version = "0.12.1", optional = true }
 rustc-hash = { version = "2.1.1", optional = true }

--- a/crates/mneme/src/query.rs
+++ b/crates/mneme/src/query.rs
@@ -385,7 +385,7 @@ impl ScanBuilder {
 // ---------------------------------------------------------------------------
 
 /// Builder-generated query scripts for `KnowledgeStore` operations.
-#[allow(clippy::enum_glob_use, clippy::wildcard_imports)]
+#[allow(clippy::enum_glob_use, clippy::wildcard_imports)] // query builders use glob imports for field enum variants
 pub mod queries {
     use super::*;
 

--- a/crates/nous/Cargo.toml
+++ b/crates/nous/Cargo.toml
@@ -23,7 +23,6 @@ aletheia-taxis = { path = "../taxis" }
 aletheia-thesauros = { path = "../thesauros" }
 jiff = { workspace = true }
 prometheus = { workspace = true }
-reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 snafu = { workspace = true }

--- a/crates/pylon/Cargo.toml
+++ b/crates/pylon/Cargo.toml
@@ -44,7 +44,6 @@ prometheus = { workspace = true }
 ulid = { workspace = true }
 
 # Internal crates
-aletheia-koina = { path = "../koina" }
 aletheia-taxis = { path = "../taxis" }
 aletheia-hermeneus = { path = "../hermeneus" }
 aletheia-organon = { path = "../organon" }

--- a/crates/taxis/Cargo.toml
+++ b/crates/taxis/Cargo.toml
@@ -11,7 +11,6 @@ rust-version.workspace = true
 workspace = true
 
 [dependencies]
-aletheia-koina = { path = "../koina" }
 figment = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/taxis/src/loader.rs
+++ b/crates/taxis/src/loader.rs
@@ -63,7 +63,6 @@ pub fn write_config(oikos: &Oikos, config: &AletheiaConfig) -> Result<()> {
 }
 
 #[cfg(test)]
-#[allow(clippy::result_large_err)] // figment::Error is 208 bytes — external type, not ours to shrink
 mod tests {
     use super::*;
 

--- a/tui/Cargo.toml
+++ b/tui/Cargo.toml
@@ -31,7 +31,6 @@ serde_json = { workspace = true }
 pulldown-cmark = "0.13"
 
 # Text utilities
-textwrap = "0.16"
 unicode-width = "0.2"
 
 # CLI


### PR DESCRIPTION
## Summary

- Remove 2 unused snafu error variants (`Send`, `Signal`) from `agora::Error`
- Prune 13 unused Cargo dependencies across 10 crates (found via cargo-machete, verified with cargo check)
- Remove stale `#[allow]` lint suppression from taxis test module (lint doesn't trigger)
- Add `#[expect(clippy::similar_names)]` to Hinnant date algorithm functions (doe/doy standard names)
- Fix rustdoc warning for unescaped angle brackets in CLI doc comment

## Verification

- `cargo clippy --workspace --exclude aletheia-mneme-engine --all-targets -- -D warnings` — clean
- `cargo test --workspace` — all pass
- `cargo doc --workspace --no-deps` — no warnings

## Not touched (investigated, confirmed clean)

- No stale refs to removed crates (`eiron`, `arbor`, `graph_builder`, `nous::roles`, `agora::slack`)
- No TS-era leftovers in Rust crates
- No template directory ambiguity (only `shared/templates/` exists)
- No dead feature flags (engine features are in vendored CozoDB code, correctly excluded)
- `ts-compat-agent.json` fixture actively referenced by tests — kept
- TLS cert generation CLI correctly not feature-gated (only TLS server is)
- `#[allow]` in vendored `mneme/src/engine/` — correct, not touched