### PR TITLE
fix: sanitize PII patterns, User-Agent, and test data

### DIFF
--- a/.github/HISTORY-CLEANUP.md
+++ b/.github/HISTORY-CLEANUP.md
@@ -1,0 +1,12 @@
+# Git History Cleanup Plan
+
+Items to address via `git filter-repo`:
+
+1. Rewrite author/committer emails to GitHub noreply address
+2. Strip all `Co-authored-by: Claude` trailers
+3. Remove "Reverse-engineered from Claude Code's OAuth" from commit messages
+4. Verify prosoche/config.yaml (deleted file) no longer in history
+5. Verify Summus references removed from commit messages
+
+This is a one-time destructive operation requiring force push.
+All forks and local clones will need to re-clone after execution.

--- a/.github/pii-patterns.txt
+++ b/.github/pii-patterns.txt
@@ -1,14 +1,14 @@
 # PII detection patterns - one extended regex per line
 alice\.johnson
 forkwright
-[Kk]ickertz
+[A-Za-z]{3,}ertz\b
 acme-corp
 Springfield
 Baby #[0-9]
 Widget
-due October 2026
+due [A-Z][a-z]+ 20[0-9]{2}
 192\.168\.0\.
-\+1512[0-9]{7}
+\+1[0-9]{10}
 acme-workshop
 Acme Workshop LLC
-Kendall.s birthday
+[A-Z][a-z]+.s birthday

--- a/crates/nous/src/bootstrap/mod.rs
+++ b/crates/nous/src/bootstrap/mod.rs
@@ -628,13 +628,13 @@ mod tests {
         // USER.md only in theke (common pattern)
         let (_dir, oikos) = setup_oikos(
             "syn",
-            &[("SOUL.md", "identity"), ("theke:USER.md", "Chris K.")],
+            &[("SOUL.md", "identity"), ("theke:USER.md", "Alice T.")],
         );
         let assembler = BootstrapAssembler::new(&oikos);
         let mut budget = default_budget();
 
         let result = assembler.assemble("syn", &mut budget).unwrap();
-        assert!(result.system_prompt.contains("Chris K."));
+        assert!(result.system_prompt.contains("Alice T."));
         assert!(result.sections_included.contains(&"USER.md".to_owned()));
     }
 

--- a/crates/organon/src/builtins/research.rs
+++ b/crates/organon/src/builtins/research.rs
@@ -56,7 +56,7 @@ impl ToolExecutor for WebFetchExecutor {
                 .get(url)
                 .header(
                     "User-Agent",
-                    "Aletheia/1.0 (Research Agent; +https://github.com/CKickertz/aletheia)",
+                    "Aletheia/1.0 (Research Agent; +https://github.com/forkwright/aletheia)",
                 )
                 .send()
                 .await;

--- a/infrastructure/memory/sidecar/backfill.py
+++ b/infrastructure/memory/sidecar/backfill.py
@@ -28,7 +28,7 @@ EMBED_MODEL = os.environ.get("VOYAGE_MODEL", "voyage-4-large")  # 1024-dim defau
 CHUNK_SIZE = 512  # tokens ~= words * 1.3, keep chunks focused
 CHUNK_OVERLAP = 50  # overlap for context continuity
 BATCH_SIZE = 64  # Voyage batch limit
-USER_ID = os.environ.get("ALETHEIA_MEMORY_USER", "ck")
+USER_ID = os.environ.get("ALETHEIA_MEMORY_USER", "default")
 
 # Directories
 ALETHEIA_ROOT = Path(__file__).resolve().parent.parent.parent.parent

--- a/instance.example/README.md
+++ b/instance.example/README.md
@@ -59,7 +59,7 @@ instance/
 │
 ├── theke/                      # ALL working files — single shared tree
 │   ├── projects/               # Project-scoped work
-│   │   ├── {project-name}/     # e.g. aletheia/, ardent/, mba/, homelab/
+│   │   ├── {project-name}/     # e.g. aletheia/, my-project/, mba/, homelab/
 │   │   └── ...
 │   ├── research/               # Research not tied to a specific project
 │   ├── reference/              # Persistent reference material


### PR DESCRIPTION
## Summary

- **pii-patterns.txt**: Replace 4 literal PII patterns (surname, area code, family name, due date) with generalized regex patterns that still detect leaks without revealing actual values
- **User-Agent**: `CKickertz/aletheia` → `forkwright/aletheia` in research tool HTTP header
- **Test data**: `"Chris K."` → `"Alice T."` in bootstrap test, `"ck"` → `"default"` in backfill.py
- **instance.example**: `ardent/` → `my-project/` in directory tree example
- **HISTORY-CLEANUP.md**: Documents remaining git filter-repo items for #554

Closes #554, #555, #564, #574

## Test plan

- [x] `cargo test -p aletheia-nous` — 202 passed (bootstrap test with new synthetic name)
- [x] Grep verification: no literal PII remains in modified files
- [ ] Pre-existing clippy issue in `filesystem.rs:321` (`doy`/`doe` similar names) — unrelated to this PR