### PR TITLE
refactor: replace Mutex .expect() with snafu, add logging to silent fallbacks

### DIFF
--- a/crates/hermeneus/src/anthropic/stream.rs
+++ b/crates/hermeneus/src/anthropic/stream.rs
@@ -6,6 +6,8 @@
 
 use std::io::BufRead;
 
+use tracing::warn;
+
 use crate::error::{self, Result};
 use crate::types::{CompletionResponse, ContentBlock, StopReason, Usage};
 
@@ -248,7 +250,10 @@ impl StreamAccumulator {
                     name,
                     input_json,
                 } => {
-                    let input = serde_json::from_str(&input_json).unwrap_or_default();
+                    let input = serde_json::from_str(&input_json).unwrap_or_else(|e| {
+                        warn!(error = %e, tool = %name, "failed to parse tool input JSON");
+                        serde_json::Value::Object(serde_json::Map::default())
+                    });
                     ContentBlock::ToolUse { id, name, input }
                 }
                 BlockBuilder::Thinking { text, signature } => ContentBlock::Thinking {
@@ -264,7 +269,10 @@ impl StreamAccumulator {
                     name,
                     input_json,
                 } => {
-                    let input = serde_json::from_str(&input_json).unwrap_or_default();
+                    let input = serde_json::from_str(&input_json).unwrap_or_else(|e| {
+                        warn!(error = %e, tool = %name, "failed to parse server tool input JSON");
+                        serde_json::Value::Object(serde_json::Map::default())
+                    });
                     ContentBlock::ServerToolUse { id, name, input }
                 }
                 BlockBuilder::WebSearchToolResult {

--- a/crates/hermeneus/src/health.rs
+++ b/crates/hermeneus/src/health.rs
@@ -102,7 +102,7 @@ impl ProviderHealthTracker {
     pub fn health(&self) -> ProviderHealth {
         self.inner
             .lock()
-            .expect("health lock poisoned")
+            .expect("health lock poisoned") // INVARIANT: short critical section, poisoned = prior panic
             .health
             .clone()
     }
@@ -113,7 +113,7 @@ impl ProviderHealthTracker {
     /// unless the cooldown has elapsed (auto-transitions to Degraded).
     /// `Down(AuthFailure)` never auto-recovers.
     pub fn check_available(&self) -> Result<(), ProviderHealth> {
-        let mut inner = self.inner.lock().expect("health lock poisoned");
+        let mut inner = self.inner.lock().expect("health lock poisoned"); // INVARIANT: short critical section, poisoned = prior panic
         match &inner.health {
             ProviderHealth::Up | ProviderHealth::Degraded { .. } => Ok(()),
             ProviderHealth::Down { since, reason } => {
@@ -146,7 +146,7 @@ impl ProviderHealthTracker {
 
     /// Record a successful request.
     pub fn record_success(&self) {
-        let mut inner = self.inner.lock().expect("health lock poisoned");
+        let mut inner = self.inner.lock().expect("health lock poisoned"); // INVARIANT: short critical section, poisoned = prior panic
         inner.total_requests += 1;
         match inner.health {
             ProviderHealth::Degraded { .. } => {
@@ -162,7 +162,7 @@ impl ProviderHealthTracker {
 
     /// Record a failed request and update health state.
     pub fn record_error(&self, error: &Error) {
-        let mut inner = self.inner.lock().expect("health lock poisoned");
+        let mut inner = self.inner.lock().expect("health lock poisoned"); // INVARIANT: short critical section, poisoned = prior panic
         inner.total_requests += 1;
         inner.total_errors += 1;
 

--- a/crates/mneme/src/extract.rs
+++ b/crates/mneme/src/extract.rs
@@ -408,7 +408,7 @@ fn now_iso8601() -> String {
 
 /// Convert epoch days to (year, month, day). Algorithm from Howard Hinnant.
 #[cfg(feature = "mneme-engine")]
-#[expect(clippy::cast_possible_truncation, clippy::cast_lossless, reason = "Hinnant algorithm uses known-range casts")]
+#[expect(clippy::cast_possible_truncation, clippy::cast_lossless, clippy::similar_names, reason = "Hinnant algorithm uses known-range casts and standard doe/doy names")]
 fn epoch_days_to_ymd(days: i64) -> (i64, u32, u32) {
     let z = days + 719_468;
     let era = z.div_euclid(146_097);

--- a/crates/nous/src/actor.rs
+++ b/crates/nous/src/actor.rs
@@ -411,7 +411,10 @@ impl NousActor {
 
         // Quick trigger check under the lock
         let should_distill = {
-            let store = store_arc.lock().expect("session store lock");
+            let Ok(store) = store_arc.lock() else {
+                warn!("session store lock poisoned, skipping distillation check");
+                return;
+            };
             let Ok(Some(session)) = store.find_session_by_id(&session_id) else {
                 return;
             };
@@ -551,7 +554,10 @@ async fn run_background_distillation(
 
     // Load history under the lock, then release before async work
     let (history, session) = {
-        let s = store.lock().expect("session store lock");
+        let Ok(s) = store.lock() else {
+            warn!("session store lock poisoned, skipping distillation");
+            return;
+        };
         let Ok(Some(session)) = s.find_session_by_id(&session_id) else {
             return;
         };
@@ -591,7 +597,10 @@ async fn run_background_distillation(
     };
 
     // Apply results under the lock
-    let s = store.lock().expect("session store lock");
+    let Ok(s) = store.lock() else {
+        warn!("session store lock poisoned, skipping distillation apply");
+        return;
+    };
     if let Err(e) = crate::distillation::apply_distillation(&s, &session_id, &result, &history) {
         warn!(error = %e, "failed to apply distillation");
         return;

--- a/crates/nous/src/adapters.rs
+++ b/crates/nous/src/adapters.rs
@@ -7,6 +7,14 @@ use aletheia_organon::types::{BlackboardEntry, BlackboardStore, NoteEntry, NoteS
 
 type BoxError = Box<dyn std::error::Error + Send + Sync>;
 
+fn lock_store(
+    store: &Mutex<SessionStore>,
+) -> Result<std::sync::MutexGuard<'_, SessionStore>, BoxError> {
+    store
+        .lock()
+        .map_err(|e| -> BoxError { e.to_string().into() })
+}
+
 /// Adapts `SessionStore` note methods to the `NoteStore` trait.
 pub struct SessionNoteAdapter(pub Arc<Mutex<SessionStore>>);
 
@@ -18,14 +26,14 @@ impl NoteStore for SessionNoteAdapter {
         category: &str,
         content: &str,
     ) -> Result<i64, BoxError> {
-        let store = self.0.lock().expect("session store lock");
+        let store = lock_store(&self.0)?;
         store
             .add_note(session_id, nous_id, category, content)
             .map_err(|e| Box::new(e) as BoxError)
     }
 
     fn get_notes(&self, session_id: &str) -> Result<Vec<NoteEntry>, BoxError> {
-        let store = self.0.lock().expect("session store lock");
+        let store = lock_store(&self.0)?;
         let notes = store
             .get_notes(session_id)
             .map_err(|e| Box::new(e) as BoxError)?;
@@ -41,7 +49,7 @@ impl NoteStore for SessionNoteAdapter {
     }
 
     fn delete_note(&self, note_id: i64) -> Result<bool, BoxError> {
-        let store = self.0.lock().expect("session store lock");
+        let store = lock_store(&self.0)?;
         store
             .delete_note(note_id)
             .map_err(|e| Box::new(e) as BoxError)
@@ -59,14 +67,14 @@ impl BlackboardStore for SessionBlackboardAdapter {
         author: &str,
         ttl_seconds: i64,
     ) -> Result<(), BoxError> {
-        let store = self.0.lock().expect("session store lock");
+        let store = lock_store(&self.0)?;
         store
             .blackboard_write(key, value, author, ttl_seconds)
             .map_err(|e| Box::new(e) as BoxError)
     }
 
     fn read(&self, key: &str) -> Result<Option<BlackboardEntry>, BoxError> {
-        let store = self.0.lock().expect("session store lock");
+        let store = lock_store(&self.0)?;
         let row = store
             .blackboard_read(key)
             .map_err(|e| Box::new(e) as BoxError)?;
@@ -81,7 +89,7 @@ impl BlackboardStore for SessionBlackboardAdapter {
     }
 
     fn list(&self) -> Result<Vec<BlackboardEntry>, BoxError> {
-        let store = self.0.lock().expect("session store lock");
+        let store = lock_store(&self.0)?;
         let rows = store
             .blackboard_list()
             .map_err(|e| Box::new(e) as BoxError)?;
@@ -99,7 +107,7 @@ impl BlackboardStore for SessionBlackboardAdapter {
     }
 
     fn delete(&self, key: &str, author: &str) -> Result<bool, BoxError> {
-        let store = self.0.lock().expect("session store lock");
+        let store = lock_store(&self.0)?;
         store
             .blackboard_delete(key, author)
             .map_err(|e| Box::new(e) as BoxError)

--- a/crates/nous/src/error.rs
+++ b/crates/nous/src/error.rs
@@ -146,6 +146,14 @@ pub enum Error {
         #[snafu(implicit)]
         location: snafu::Location,
     },
+
+    /// A mutex or rwlock was poisoned by a prior panic.
+    #[snafu(display("mutex poisoned: {what}"))]
+    MutexPoisoned {
+        what: &'static str,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
 }
 
 /// Convenience alias for results with [`Error`].

--- a/crates/nous/src/finalize.rs
+++ b/crates/nous/src/finalize.rs
@@ -7,7 +7,7 @@
 //! 4. Records token usage
 
 use snafu::ResultExt;
-use tracing::{debug, instrument};
+use tracing::{debug, instrument, warn};
 
 use aletheia_mneme::store::SessionStore;
 use aletheia_mneme::types::{Role, UsageRecord};
@@ -75,7 +75,10 @@ pub fn finalize(
 
         // Tool call/result pairs
         for tc in &result.tool_calls {
-            let input_json = serde_json::to_string(&tc.input).unwrap_or_default();
+            let input_json = serde_json::to_string(&tc.input).unwrap_or_else(|e| {
+                warn!(error = %e, tool = %tc.name, "failed to serialize tool call input");
+                String::new()
+            });
             store
                 .append_message(
                     &session.id,

--- a/crates/nous/src/pipeline.rs
+++ b/crates/nous/src/pipeline.rs
@@ -438,7 +438,9 @@ pub async fn run_pipeline(
         let start = Instant::now();
         let history_config = HistoryConfig::default();
         if let Some(store_mutex) = session_store {
-            let store = store_mutex.lock().expect("session store lock");
+            let store = store_mutex
+                .lock()
+                .map_err(|_poison| crate::error::MutexPoisonedSnafu { what: "session store" }.build())?;
             let (messages, hist_result) = history::load_history(
                 &store,
                 &input.session.id,
@@ -571,7 +573,9 @@ pub async fn run_pipeline(
         let _guard = span.enter();
         let start = Instant::now();
         if let Some(store_mutex) = session_store {
-            let store = store_mutex.lock().expect("session store lock");
+            let store = store_mutex
+                .lock()
+                .map_err(|_poison| crate::error::MutexPoisonedSnafu { what: "session store" }.build())?;
             let finalize_config = crate::finalize::FinalizeConfig::default();
             match crate::finalize::finalize(
                 &store,

--- a/crates/organon/src/builtins/enable_tool.rs
+++ b/crates/organon/src/builtins/enable_tool.rs
@@ -54,7 +54,11 @@ impl ToolExecutor for EnableToolExecutor {
 
             // Check if already active
             {
-                let active = ctx.active_tools.read().expect("active_tools lock");
+                let Ok(active) = ctx.active_tools.read() else {
+                    return Ok(ToolResult::error(
+                        "internal error: active_tools lock poisoned",
+                    ));
+                };
                 if active.contains(&tool_name) {
                     return Ok(ToolResult::text(format!("'{name}' is already active.")));
                 }
@@ -62,7 +66,11 @@ impl ToolExecutor for EnableToolExecutor {
 
             // Activate
             {
-                let mut active = ctx.active_tools.write().expect("active_tools lock");
+                let Ok(mut active) = ctx.active_tools.write() else {
+                    return Ok(ToolResult::error(
+                        "internal error: active_tools lock poisoned",
+                    ));
+                };
                 active.insert(tool_name);
             }
 

--- a/crates/organon/src/builtins/filesystem.rs
+++ b/crates/organon/src/builtins/filesystem.rs
@@ -311,6 +311,7 @@ fn format_system_time(time: &SystemTime) -> String {
     }
 }
 
+#[expect(clippy::similar_names, reason = "doe/doy are standard names in Hinnant's date algorithm")]
 fn days_to_ymd(days: u64) -> (u64, u64, u64) {
     // Algorithm from http://howardhinnant.github.io/date_algorithms.html
     let z = days + 719_468;

--- a/crates/pylon/src/handlers/sessions.rs
+++ b/crates/pylon/src/handlers/sessions.rs
@@ -65,8 +65,15 @@ pub async fn create(
     let skey = session_key.clone();
 
     let session = tokio::task::spawn_blocking(move || {
-        let store = state_clone.session_store.lock().expect("store lock");
-        store.find_or_create_session(&id_clone, &nid, &skey, Some(&model), None)
+        let store = state_clone.session_store.lock().map_err(|_poison| {
+            InternalSnafu {
+                message: "session store lock poisoned",
+            }
+            .build()
+        })?;
+        store
+            .find_or_create_session(&id_clone, &nid, &skey, Some(&model), None)
+            .map_err(ApiError::from)
     })
     .await??;
 
@@ -123,8 +130,15 @@ pub async fn close(
     let state_clone = Arc::clone(&state);
     let id_clone = id.clone();
     tokio::task::spawn_blocking(move || {
-        let store = state_clone.session_store.lock().expect("store lock");
-        store.update_session_status(&id_clone, SessionStatus::Archived)
+        let store = state_clone.session_store.lock().map_err(|_poison| {
+            InternalSnafu {
+                message: "session store lock poisoned",
+            }
+            .build()
+        })?;
+        store
+            .update_session_status(&id_clone, SessionStatus::Archived)
+            .map_err(ApiError::from)
     })
     .await??;
 
@@ -161,8 +175,15 @@ pub async fn history(
     let id_clone = id.clone();
     let limit = params.limit;
     let messages = tokio::task::spawn_blocking(move || {
-        let store = state_clone.session_store.lock().expect("store lock");
-        store.get_history(&id_clone, limit.map(i64::from))
+        let store = state_clone.session_store.lock().map_err(|_poison| {
+            InternalSnafu {
+                message: "session store lock poisoned",
+            }
+            .build()
+        })?;
+        store
+            .get_history(&id_clone, limit.map(i64::from))
+            .map_err(ApiError::from)
     })
     .await??;
 
@@ -290,7 +311,10 @@ pub async fn send_message(
     });
 
     let stream = ReceiverStream::new(rx).map(|event| {
-        let data = serde_json::to_string(&event).unwrap_or_default();
+        let data = serde_json::to_string(&event).unwrap_or_else(|e| {
+            warn!(error = %e, "failed to serialize SSE event");
+            String::new()
+        });
         Ok(Event::default().event(event.event_type()).data(data))
     });
 
@@ -351,11 +375,17 @@ async fn store_message(
     let sid = session_id.to_owned();
     let content = content.to_owned();
     tokio::task::spawn_blocking(move || {
-        let store = state_clone.session_store.lock().expect("store lock");
-        store.append_message(&sid, role, &content, None, None, token_estimate)
+        let store = state_clone.session_store.lock().map_err(|_poison| {
+            InternalSnafu {
+                message: "session store lock poisoned",
+            }
+            .build()
+        })?;
+        store
+            .append_message(&sid, role, &content, None, None, token_estimate)
+            .map_err(ApiError::from)
     })
     .await?
-    .map_err(ApiError::from)
 }
 
 async fn find_session(
@@ -366,8 +396,13 @@ async fn find_session(
     let id_owned = id.to_owned();
     let id_for_error = id.to_owned();
     let session = tokio::task::spawn_blocking(move || {
-        let store = state_clone.session_store.lock().expect("store lock");
-        store.find_session_by_id(&id_owned)
+        let store = state_clone.session_store.lock().map_err(|_poison| {
+            InternalSnafu {
+                message: "session store lock poisoned",
+            }
+            .build()
+        })?;
+        store.find_session_by_id(&id_owned).map_err(ApiError::from)
     })
     .await??;
 

--- a/crates/pylon/src/handlers/webchat.rs
+++ b/crates/pylon/src/handlers/webchat.rs
@@ -16,7 +16,7 @@ use tracing::{instrument, warn};
 use aletheia_hermeneus::anthropic::StreamEvent as LlmStreamEvent;
 use aletheia_nous::stream::TurnStreamEvent;
 
-use crate::error::{ApiError, BadRequestSnafu, NousNotFoundSnafu};
+use crate::error::{ApiError, BadRequestSnafu, InternalSnafu, NousNotFoundSnafu};
 use crate::extract::OptionalClaims;
 use crate::state::AppState;
 use crate::stream::{TurnOutcome, WebchatEvent};
@@ -50,8 +50,15 @@ async fn resolve_session(
     let model_owned = model.map(ToOwned::to_owned);
 
     let session = tokio::task::spawn_blocking(move || {
-        let store = state_clone.session_store.lock().expect("store lock");
-        store.find_or_create_session(&id_clone, &aid, &skey, model_owned.as_deref(), None)
+        let store = state_clone.session_store.lock().map_err(|_poison| {
+            InternalSnafu {
+                message: "session store lock poisoned",
+            }
+            .build()
+        })?;
+        store
+            .find_or_create_session(&id_clone, &aid, &skey, model_owned.as_deref(), None)
+            .map_err(ApiError::from)
     })
     .await??;
 
@@ -69,11 +76,17 @@ async fn store_message(
     let sid = session_id.to_owned();
     let content = content.to_owned();
     tokio::task::spawn_blocking(move || {
-        let store = state_clone.session_store.lock().expect("store lock");
-        store.append_message(&sid, role, &content, None, None, token_estimate)
+        let store = state_clone.session_store.lock().map_err(|_poison| {
+            InternalSnafu {
+                message: "session store lock poisoned",
+            }
+            .build()
+        })?;
+        store
+            .append_message(&sid, role, &content, None, None, token_estimate)
+            .map_err(ApiError::from)
     })
     .await?
-    .map_err(ApiError::from)
 }
 
 #[expect(
@@ -224,7 +237,10 @@ pub async fn stream(
     });
 
     let stream = ReceiverStream::new(webchat_rx).map(|event| {
-        let data = serde_json::to_string(&event).unwrap_or_default();
+        let data = serde_json::to_string(&event).unwrap_or_else(|e| {
+            warn!(error = %e, "failed to serialize SSE event");
+            String::new()
+        });
         Ok(Event::default().event(event.event_type()).data(data))
     });
 
@@ -396,8 +412,15 @@ pub async fn sessions_list(
 
     let state_clone = Arc::clone(&state);
     let sessions = tokio::task::spawn_blocking(move || {
-        let store = state_clone.session_store.lock().expect("store lock");
-        store.list_sessions(nous_id.as_deref())
+        let store = state_clone.session_store.lock().map_err(|_poison| {
+            InternalSnafu {
+                message: "session store lock poisoned",
+            }
+            .build()
+        })?;
+        store
+            .list_sessions(nous_id.as_deref())
+            .map_err(ApiError::from)
     })
     .await??;
 

--- a/crates/pylon/src/middleware.rs
+++ b/crates/pylon/src/middleware.rs
@@ -5,6 +5,7 @@ use axum::extract::Request;
 use axum::http::{Method, StatusCode};
 use axum::middleware::Next;
 use axum::response::{IntoResponse, Response};
+use tracing::warn;
 
 /// CSRF protection state stored as a router extension.
 #[derive(Debug, Clone)]
@@ -104,7 +105,10 @@ pub async fn enrich_error_response(request: Request, next: Next) -> Response {
 
     if let Some(error) = json.get_mut("error").and_then(|e| e.as_object_mut()) {
         error.insert("request_id".to_owned(), serde_json::Value::String(rid));
-        let new_bytes = serde_json::to_vec(&json).unwrap_or_default();
+        let new_bytes = serde_json::to_vec(&json).unwrap_or_else(|e| {
+            warn!(error = %e, "failed to re-serialize error response body");
+            Vec::new()
+        });
         return Response::from_parts(parts, Body::from(new_bytes));
     }
 

--- a/crates/symbolon/src/credential.rs
+++ b/crates/symbolon/src/credential.rs
@@ -204,7 +204,10 @@ impl FileCredentialProvider {
 
     fn reload(&self) -> Option<String> {
         let cred = CredentialFile::load(&self.path)?;
-        let mtime = self.current_mtime().unwrap_or(SystemTime::UNIX_EPOCH);
+        let mtime = self.current_mtime().unwrap_or_else(|| {
+            tracing::debug!(path = %self.path.display(), "could not read file mtime, using epoch");
+            SystemTime::UNIX_EPOCH
+        });
 
         let token = cred.token.clone();
         if let Ok(mut guard) = self.cached.write() {

--- a/crates/symbolon/src/jwt.rs
+++ b/crates/symbolon/src/jwt.rs
@@ -151,7 +151,10 @@ fn now_unix() -> i64 {
     i64::try_from(
         std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
+            .unwrap_or_else(|_| {
+                tracing::warn!("system clock before UNIX epoch, using epoch as fallback");
+                std::time::Duration::default()
+            })
             .as_secs(),
     )
     .unwrap_or(i64::MAX)

--- a/crates/symbolon/src/store.rs
+++ b/crates/symbolon/src/store.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 
 use rusqlite::Connection;
 use snafu::{IntoError, ResultExt};
-use tracing::{info, instrument};
+use tracing::{info, instrument, warn};
 
 use crate::error::{self, Result};
 use crate::types::{ApiKeyRecord, Role, User};
@@ -329,11 +329,15 @@ fn get_schema_version(conn: &Connection) -> u32 {
 
 fn map_user(row: &rusqlite::Row<'_>) -> rusqlite::Result<User> {
     let role_str: String = row.get("role")?;
+    let role = role_str.parse().unwrap_or_else(|_| {
+        warn!(role = %role_str, "unknown role in database, defaulting to Readonly");
+        Role::Readonly
+    });
     Ok(User {
         id: row.get("id")?,
         username: row.get("username")?,
         password_hash: row.get("password_hash")?,
-        role: role_str.parse().unwrap_or(Role::Readonly),
+        role,
         created_at: row.get("created_at")?,
         updated_at: row.get("updated_at")?,
     })
@@ -341,11 +345,15 @@ fn map_user(row: &rusqlite::Row<'_>) -> rusqlite::Result<User> {
 
 fn map_api_key(row: &rusqlite::Row<'_>) -> rusqlite::Result<ApiKeyRecord> {
     let role_str: String = row.get("role")?;
+    let role = role_str.parse().unwrap_or_else(|_| {
+        warn!(role = %role_str, "unknown role in database, defaulting to Readonly");
+        Role::Readonly
+    });
     Ok(ApiKeyRecord {
         id: row.get("id")?,
         prefix: row.get("prefix")?,
         key_hash: row.get("key_hash")?,
-        role: role_str.parse().unwrap_or(Role::Readonly),
+        role,
         nous_id: row.get("nous_id")?,
         created_at: row.get("created_at")?,
         expires_at: row.get("expires_at")?,

--- a/crates/taxis/src/redact.rs
+++ b/crates/taxis/src/redact.rs
@@ -1,6 +1,7 @@
 //! Config redaction — strips secrets from config before API exposure.
 
 use serde_json::Value;
+use tracing::debug;
 
 use crate::config::AletheiaConfig;
 
@@ -20,7 +21,10 @@ const SIGNAL_PII_KEYS: &[&str] = &["account"];
 
 /// Serialize config to JSON, then redact sensitive fields.
 pub fn redact(config: &AletheiaConfig) -> Value {
-    let mut value = serde_json::to_value(config).unwrap_or(Value::Null);
+    let mut value = serde_json::to_value(config).unwrap_or_else(|e| {
+        debug!(error = %e, "failed to serialize config for redaction");
+        Value::Null
+    });
     redact_sensitive_leaves(&mut value);
     redact_sensitive_keys(&mut value);
     redact_signal_accounts(&mut value);


### PR DESCRIPTION
Addresses #559, #567, #568, #573.

## Summary

- **Mutex safety**: Replace `.expect()` on lock acquisition with proper error handling across `nous`, `pylon`, and `organon`. Justified panics in `hermeneus/health.rs` documented with INVARIANT comments.
- **Silent unwrap audit**: Add `warn!`/`debug!` logging to 11 `unwrap_or` sites that silently swallowed errors (role parsing, JSON serialization, tool input parsing, config redaction, system time).
- **Bonus**: Fix two pre-existing `clippy::similar_names` warnings in Hinnant date algorithm code.

## Changes by crate

| Crate | Part 1 (mutex) | Part 2 (unwrap_or) |
|-------|----------------|---------------------|
| nous | MutexPoisoned snafu variant, 12 lock fixes | 1 logging site |
| pylon | 8 lock fixes (spawn_blocking → ApiError) | 3 logging sites |
| organon | 2 RwLock fixes (→ ToolResult::error) | — |
| hermeneus | 4 INVARIANT comments | 2 logging sites |
| symbolon | — | 4 logging sites |
| taxis | — | 1 logging site |

No behavioral changes — all fallback values remain the same, just observable now.

## Test plan

- [x] `cargo clippy --workspace --exclude aletheia-mneme-engine --all-targets -- -D warnings` clean
- [x] `cargo test -p aletheia-hermeneus` — 112 passed
- [x] `cargo test -p aletheia-nous` — 202 passed
- [x] `cargo test -p aletheia-symbolon` — 63 passed
- [x] `cargo test -p aletheia-organon` — 115 passed
- [x] `cargo test -p aletheia-taxis` — 60 passed
- [x] `cargo test -p aletheia-mneme` — all passed
- [x] Grep verification: no remaining unhandled `.expect()` on locks in production code