### PR TITLE
feat(mneme): persistent storage via redb

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -204,6 +204,7 @@ dependencies = [
  "proptest",
  "rand 0.8.5",
  "rayon",
+ "redb",
  "regex",
  "rmp-serde",
  "rocksdb",
@@ -4983,6 +4984,15 @@ dependencies = [
  "time",
  "x509-parser",
  "yasna",
+]
+
+[[package]]
+name = "redb"
+version = "2.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eca1e9d98d5a7e9002d0013e18d5a9b000aee942eb134883a82f06ebffb6c01"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/crates/aletheia/Cargo.toml
+++ b/crates/aletheia/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/main.rs"
 [features]
 default = ["tui", "recall"]
 # Recall pipeline: enables KnowledgeStore (CozoDB) for vector search + extraction persistence.
-recall = ["aletheia-nous/knowledge-store", "aletheia-mneme/mneme-engine", "aletheia-pylon/knowledge-store"]
+recall = ["aletheia-nous/knowledge-store", "aletheia-mneme/mneme-engine", "aletheia-mneme/storage-redb", "aletheia-pylon/knowledge-store"]
 migrate-qdrant = ["dep:qdrant-client"]
 tls = ["aletheia-pylon/tls"]
 tui = ["dep:aletheia-tui"]

--- a/crates/aletheia/src/main.rs
+++ b/crates/aletheia/src/main.rs
@@ -592,9 +592,16 @@ async fn serve(cli: Cli) -> Result<()> {
     // Knowledge store for vector search and extraction persistence
     #[cfg(feature = "recall")]
     let knowledge_store = {
-        let store = aletheia_mneme::knowledge_store::KnowledgeStore::open_mem()
-            .context("failed to create knowledge store")?;
-        info!(dim = 384, "knowledge store created (in-memory)");
+        let kb_path = oikos_arc.knowledge_db();
+        if let Some(parent) = kb_path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let store = aletheia_mneme::knowledge_store::KnowledgeStore::open_redb(
+            &kb_path,
+            aletheia_mneme::knowledge_store::KnowledgeConfig::default(),
+        )
+        .context("failed to open knowledge store")?;
+        info!(path = %kb_path.display(), dim = 384, "knowledge store opened (redb)");
         Some(store)
     };
     #[cfg(not(feature = "recall"))]

--- a/crates/mneme/Cargo.toml
+++ b/crates/mneme/Cargo.toml
@@ -31,6 +31,7 @@ mneme-engine = [
     "dep:aho-corasick", "dep:rust-stemmers",
     "dep:bytemuck",
 ]
+storage-redb = ["dep:redb", "mneme-engine"]
 storage-new-rocksdb = ["dep:rocksdb", "mneme-engine"]
 
 [dependencies]
@@ -70,6 +71,7 @@ unicode-normalization = { version = "0.1", optional = true }
 aho-corasick = { version = "1.1", optional = true }
 rust-stemmers = { version = "1.2", optional = true }
 bytemuck = { version = "1.25", optional = true }
+redb = { version = "2", optional = true }
 rocksdb = { version = "0.22.0", optional = true }
 
 [dev-dependencies]

--- a/crates/mneme/src/engine/data/program.rs
+++ b/crates/mneme/src/engine/data/program.rs
@@ -8,7 +8,6 @@ use std::sync::Arc;
 
 use crate::engine::error::DbResult as Result;
 use crate::{bail, ensure, miette};
-use miette::Diagnostic;
 use smallvec::SmallVec;
 use smartstring::{LazyCompact, SmartString};
 

--- a/crates/mneme/src/engine/mod.rs
+++ b/crates/mneme/src/engine/mod.rs
@@ -1,7 +1,7 @@
 // aletheia-mneme-engine -- embedded Datalog + HNSW + graph engine for Aletheia
 
 use std::collections::BTreeMap;
-#[cfg(feature = "storage-new-rocksdb")]
+#[cfg(any(feature = "storage-redb", feature = "storage-new-rocksdb"))]
 use std::path::Path;
 
 use crossbeam::channel::{Receiver, Sender, bounded};
@@ -15,6 +15,8 @@ pub use crate::engine::fixed_rule::{FixedRule, FixedRuleInputRelation, FixedRule
 pub use crate::engine::runtime::callback::CallbackOp;
 pub use crate::engine::runtime::db::{NamedRows, ScriptMutability, TransactionPayload};
 pub use crate::engine::storage::mem::MemStorage;
+#[cfg(feature = "storage-redb")]
+pub use crate::engine::storage::redb::RedbStorage;
 #[cfg(feature = "storage-new-rocksdb")]
 pub use crate::engine::storage::newrocks::NewRocksDbStorage;
 pub use ndarray::Array1;
@@ -60,6 +62,8 @@ fn convert_err(e: crate::engine::error::BoxErr) -> Error {
 /// Public facade replacing DbInstance. Dispatches to concrete storage implementations.
 pub enum Db {
     Mem(crate::engine::runtime::db::Db<MemStorage>),
+    #[cfg(feature = "storage-redb")]
+    Redb(crate::engine::runtime::db::Db<RedbStorage>),
     #[cfg(feature = "storage-new-rocksdb")]
     RocksDb(crate::engine::runtime::db::Db<NewRocksDbStorage>),
 }
@@ -69,6 +73,14 @@ impl Db {
     pub fn open_mem() -> crate::engine::Result<Self> {
         crate::engine::storage::mem::new_mem_db()
             .map(Db::Mem)
+            .map_err(convert_err)
+    }
+
+    /// Open a redb-backed database at the given path.
+    #[cfg(feature = "storage-redb")]
+    pub fn open_redb(path: impl AsRef<Path>) -> crate::engine::Result<Self> {
+        crate::engine::storage::redb::new_cozo_redb(path)
+            .map(Db::Redb)
             .map_err(convert_err)
     }
 
@@ -89,6 +101,8 @@ impl Db {
     ) -> crate::engine::Result<NamedRows> {
         let result = match self {
             Db::Mem(db) => db.run_script(script, params, mutability),
+            #[cfg(feature = "storage-redb")]
+            Db::Redb(db) => db.run_script(script, params, mutability),
             #[cfg(feature = "storage-new-rocksdb")]
             Db::RocksDb(db) => db.run_script(script, params, mutability),
         };
@@ -106,6 +120,8 @@ impl Db {
     {
         let result = match self {
             Db::Mem(db) => db.export_relations(relations),
+            #[cfg(feature = "storage-redb")]
+            Db::Redb(db) => db.export_relations(relations),
             #[cfg(feature = "storage-new-rocksdb")]
             Db::RocksDb(db) => db.export_relations(relations),
         };
@@ -116,6 +132,8 @@ impl Db {
     pub fn import_relations(&self, data: BTreeMap<String, NamedRows>) -> crate::engine::Result<()> {
         let result = match self {
             Db::Mem(db) => db.import_relations(data),
+            #[cfg(feature = "storage-redb")]
+            Db::Redb(db) => db.import_relations(data),
             #[cfg(feature = "storage-new-rocksdb")]
             Db::RocksDb(db) => db.import_relations(data),
         };
@@ -130,6 +148,8 @@ impl Db {
     ) -> crate::engine::Result<()> {
         let result = match self {
             Db::Mem(db) => db.register_fixed_rule(name, rule),
+            #[cfg(feature = "storage-redb")]
+            Db::Redb(db) => db.register_fixed_rule(name, rule),
             #[cfg(feature = "storage-new-rocksdb")]
             Db::RocksDb(db) => db.register_fixed_rule(name, rule),
         };
@@ -148,6 +168,8 @@ impl Db {
     ) {
         match self {
             Db::Mem(db) => db.register_callback(relation, capacity),
+            #[cfg(feature = "storage-redb")]
+            Db::Redb(db) => db.register_callback(relation, capacity),
             #[cfg(feature = "storage-new-rocksdb")]
             Db::RocksDb(db) => db.register_callback(relation, capacity),
         }
@@ -172,6 +194,8 @@ impl Db {
     fn clone_inner(&self) -> DbInner {
         match self {
             Db::Mem(db) => DbInner::Mem(db.clone()),
+            #[cfg(feature = "storage-redb")]
+            Db::Redb(db) => DbInner::Redb(db.clone()),
             #[cfg(feature = "storage-new-rocksdb")]
             Db::RocksDb(db) => DbInner::RocksDb(db.clone()),
         }
@@ -181,6 +205,8 @@ impl Db {
 /// Internal enum for owned clones used in spawned tasks.
 enum DbInner {
     Mem(crate::engine::runtime::db::Db<MemStorage>),
+    #[cfg(feature = "storage-redb")]
+    Redb(crate::engine::runtime::db::Db<RedbStorage>),
     #[cfg(feature = "storage-new-rocksdb")]
     RocksDb(crate::engine::runtime::db::Db<NewRocksDbStorage>),
 }
@@ -194,6 +220,8 @@ impl DbInner {
     ) {
         match self {
             DbInner::Mem(db) => db.run_multi_transaction(write, payloads, results),
+            #[cfg(feature = "storage-redb")]
+            DbInner::Redb(db) => db.run_multi_transaction(write, payloads, results),
             #[cfg(feature = "storage-new-rocksdb")]
             DbInner::RocksDb(db) => db.run_multi_transaction(write, payloads, results),
         }
@@ -268,6 +296,8 @@ impl TestMultiTx {
 mod safety_assertions {
     use static_assertions::assert_impl_all;
     assert_impl_all!(crate::engine::runtime::db::Db<crate::engine::storage::mem::MemStorage>: Send, Sync);
+    #[cfg(feature = "storage-redb")]
+    assert_impl_all!(crate::engine::runtime::db::Db<crate::engine::storage::redb::RedbStorage>: Send, Sync);
     #[cfg(feature = "storage-new-rocksdb")]
     assert_impl_all!(crate::engine::runtime::db::Db<crate::engine::storage::newrocks::NewRocksDbStorage>: Send, Sync);
 }

--- a/crates/mneme/src/engine/storage/mod.rs
+++ b/crates/mneme/src/engine/storage/mod.rs
@@ -9,6 +9,8 @@ use crate::engine::data::value::ValidityTs;
 use crate::engine::runtime::relation::decode_tuple_from_kv;
 
 pub(crate) mod mem;
+#[cfg(feature = "storage-redb")]
+pub(crate) mod redb;
 #[cfg(feature = "storage-new-rocksdb")]
 pub(crate) mod newrocks;
 pub(crate) mod temp;

--- a/crates/mneme/src/engine/storage/redb.rs
+++ b/crates/mneme/src/engine/storage/redb.rs
@@ -1,0 +1,912 @@
+// redb persistent storage backend for the Datalog engine.
+
+use std::cmp::Ordering;
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::Path;
+use std::sync::Arc;
+
+use itertools::Itertools;
+
+use redb::ReadableTable;
+
+use crate::engine::data::tuple::{check_key_for_validity, Tuple};
+use crate::engine::data::value::ValidityTs;
+use crate::engine::error::DbResult as Result;
+use crate::engine::runtime::relation::{decode_tuple_from_kv, extend_tuple_from_v};
+use crate::engine::storage::{Storage, StoreTx};
+use crate::engine::utils::swap_option_result;
+use crate::engine::DbCore;
+use crate::{bail};
+
+const TABLE: redb::TableDefinition<'_, &[u8], &[u8]> = redb::TableDefinition::new("data");
+
+/// Opens or creates a redb-backed database at the given path.
+///
+/// Pure Rust, zero C dependencies, ACID transactions, single-file database.
+pub fn new_cozo_redb(path: impl AsRef<Path>) -> Result<DbCore<RedbStorage>> {
+    let path = path.as_ref();
+    fs::create_dir_all(path).map_err(|e| {
+        crate::engine::error::AdhocError(format!(
+            "cannot create directory {}: {e}",
+            path.display()
+        ))
+    })?;
+
+    let db_file = path.join("data.redb");
+    let db = redb::Database::create(&db_file).map_err(|e| {
+        crate::engine::error::AdhocError(format!(
+            "failed to open redb at {}: {e}",
+            db_file.display()
+        ))
+    })?;
+
+    // Ensure the data table exists before any reads
+    {
+        let write_txn = db
+            .begin_write()
+            .map_err(|e| crate::engine::error::AdhocError(format!("redb begin_write: {e}")))?;
+        write_txn
+            .open_table(TABLE)
+            .map_err(|e| crate::engine::error::AdhocError(format!("redb open_table: {e}")))?;
+        write_txn
+            .commit()
+            .map_err(|e| crate::engine::error::AdhocError(format!("redb commit: {e}")))?;
+    }
+
+    let storage = RedbStorage {
+        db: Arc::new(db),
+    };
+    let ret = DbCore::new(storage)?;
+    ret.initialize()?;
+    Ok(ret)
+}
+
+/// redb storage engine — pure Rust, zero C deps, single-file ACID database.
+#[derive(Clone)]
+pub struct RedbStorage {
+    db: Arc<redb::Database>,
+}
+
+impl<'s> Storage<'s> for RedbStorage {
+    type Tx = RedbTx<'s>;
+
+    fn storage_kind(&self) -> &'static str {
+        "redb"
+    }
+
+    fn transact(&'s self, write: bool) -> Result<Self::Tx> {
+        if write {
+            let snapshot = self.db.begin_read().map_err(|e| {
+                crate::engine::error::AdhocError(format!("redb begin_read for snapshot: {e}"))
+            })?;
+            Ok(RedbTx::Writer(RedbWriteTx {
+                storage: self,
+                snapshot,
+                delta: BTreeMap::new(),
+            }))
+        } else {
+            let read_txn = self.db.begin_read().map_err(|e| {
+                crate::engine::error::AdhocError(format!("redb begin_read: {e}"))
+            })?;
+            Ok(RedbTx::Reader(RedbReadTx { read_txn }))
+        }
+    }
+
+    fn range_compact(&'s self, _lower: &[u8], _upper: &[u8]) -> Result<()> {
+        // redb compacts internally
+        Ok(())
+    }
+
+    fn batch_put<'a>(
+        &'a self,
+        data: Box<dyn Iterator<Item = Result<(Vec<u8>, Vec<u8>)>> + 'a>,
+    ) -> Result<()> {
+        let write_txn = self.db.begin_write().map_err(|e| {
+            crate::engine::error::AdhocError(format!("redb begin_write: {e}"))
+        })?;
+        {
+            let mut table = write_txn.open_table(TABLE).map_err(|e| {
+                crate::engine::error::AdhocError(format!("redb open_table: {e}"))
+            })?;
+            for pair in data {
+                let (k, v) = pair?;
+                table.insert(k.as_slice(), v.as_slice()).map_err(|e| {
+                    crate::engine::error::AdhocError(format!("redb insert: {e}"))
+                })?;
+            }
+        }
+        write_txn.commit().map_err(|e| {
+            crate::engine::error::AdhocError(format!("redb commit: {e}"))
+        })?;
+        Ok(())
+    }
+}
+
+pub enum RedbTx<'s> {
+    Reader(RedbReadTx),
+    Writer(RedbWriteTx<'s>),
+}
+
+pub struct RedbReadTx {
+    read_txn: redb::ReadTransaction,
+}
+
+pub struct RedbWriteTx<'s> {
+    storage: &'s RedbStorage,
+    snapshot: redb::ReadTransaction,
+    delta: BTreeMap<Vec<u8>, Option<Vec<u8>>>,
+}
+
+// --- Helper: read from a ReadTransaction, collecting into Vec ---
+
+fn redb_table_get(
+    read_txn: &redb::ReadTransaction,
+    key: &[u8],
+) -> Result<Option<Vec<u8>>> {
+    let table = read_txn
+        .open_table(TABLE)
+        .map_err(|e| crate::engine::error::AdhocError(format!("redb open_table: {e}")))?;
+    let val = table
+        .get(key)
+        .map_err(|e| crate::engine::error::AdhocError(format!("redb get: {e}")))?
+        .map(|guard| guard.value().to_vec());
+    Ok(val)
+}
+
+fn redb_collect_range(
+    read_txn: &redb::ReadTransaction,
+    lower: &[u8],
+    upper: &[u8],
+) -> Result<Vec<(Vec<u8>, Vec<u8>)>> {
+    let table = read_txn
+        .open_table(TABLE)
+        .map_err(|e| crate::engine::error::AdhocError(format!("redb open_table: {e}")))?;
+    let range = table
+        .range(lower..upper)
+        .map_err(|e| crate::engine::error::AdhocError(format!("redb range: {e}")))?;
+    let mut results = Vec::new();
+    for entry in range {
+        let (k, v) = entry
+            .map_err(|e| crate::engine::error::AdhocError(format!("redb iter: {e}")))?;
+        results.push((k.value().to_vec(), v.value().to_vec()));
+    }
+    Ok(results)
+}
+
+fn redb_collect_all(
+    read_txn: &redb::ReadTransaction,
+) -> Result<Vec<(Vec<u8>, Vec<u8>)>> {
+    let table = read_txn
+        .open_table(TABLE)
+        .map_err(|e| crate::engine::error::AdhocError(format!("redb open_table: {e}")))?;
+    let iter = table
+        .iter()
+        .map_err(|e| crate::engine::error::AdhocError(format!("redb iter: {e}")))?;
+    let mut results = Vec::new();
+    for entry in iter {
+        let (k, v) = entry
+            .map_err(|e| crate::engine::error::AdhocError(format!("redb iter: {e}")))?;
+        results.push((k.value().to_vec(), v.value().to_vec()));
+    }
+    Ok(results)
+}
+
+// --- StoreTx implementation ---
+
+impl<'s> StoreTx<'s> for RedbTx<'s> {
+    fn get(&self, key: &[u8], _for_update: bool) -> Result<Option<Vec<u8>>> {
+        match self {
+            RedbTx::Reader(r) => redb_table_get(&r.read_txn, key),
+            RedbTx::Writer(w) => match w.delta.get(key) {
+                Some(cached) => Ok(cached.clone()),
+                None => redb_table_get(&w.snapshot, key),
+            },
+        }
+    }
+
+    fn put(&mut self, key: &[u8], val: &[u8]) -> Result<()> {
+        match self {
+            RedbTx::Reader(_) => {
+                bail!("write in read transaction")
+            }
+            RedbTx::Writer(w) => {
+                w.delta.insert(key.to_vec(), Some(val.to_vec()));
+                Ok(())
+            }
+        }
+    }
+
+    fn supports_par_put(&self) -> bool {
+        false
+    }
+
+    fn del(&mut self, key: &[u8]) -> Result<()> {
+        match self {
+            RedbTx::Reader(_) => {
+                bail!("write in read transaction")
+            }
+            RedbTx::Writer(w) => {
+                w.delta.insert(key.to_vec(), None);
+                Ok(())
+            }
+        }
+    }
+
+    fn del_range_from_persisted(&mut self, lower: &[u8], upper: &[u8]) -> Result<()> {
+        match self {
+            RedbTx::Reader(_) => {
+                bail!("write in read transaction")
+            }
+            RedbTx::Writer(w) => {
+                let persisted = redb_collect_range(&w.snapshot, lower, upper)?;
+                for (k, _) in persisted {
+                    w.delta.insert(k, None);
+                }
+                Ok(())
+            }
+        }
+    }
+
+    fn exists(&self, key: &[u8], _for_update: bool) -> Result<bool> {
+        Ok(match self {
+            RedbTx::Reader(r) => redb_table_get(&r.read_txn, key)?.is_some(),
+            RedbTx::Writer(w) => match w.delta.get(key) {
+                Some(cached) => cached.is_some(),
+                None => redb_table_get(&w.snapshot, key)?.is_some(),
+            },
+        })
+    }
+
+    fn commit(&mut self) -> Result<()> {
+        match self {
+            RedbTx::Reader(_) => Ok(()),
+            RedbTx::Writer(w) => {
+                if w.delta.is_empty() {
+                    return Ok(());
+                }
+
+                let write_txn = w.storage.db.begin_write().map_err(|e| {
+                    crate::engine::error::AdhocError(format!("redb begin_write: {e}"))
+                })?;
+                {
+                    let mut table = write_txn.open_table(TABLE).map_err(|e| {
+                        crate::engine::error::AdhocError(format!("redb open_table: {e}"))
+                    })?;
+                    for (k, mv) in &w.delta {
+                        match mv {
+                            None => {
+                                table.remove(k.as_slice()).map_err(|e| {
+                                    crate::engine::error::AdhocError(format!("redb remove: {e}"))
+                                })?;
+                            }
+                            Some(v) => {
+                                table.insert(k.as_slice(), v.as_slice()).map_err(|e| {
+                                    crate::engine::error::AdhocError(format!("redb insert: {e}"))
+                                })?;
+                            }
+                        }
+                    }
+                }
+                write_txn.commit().map_err(|e| {
+                    crate::engine::error::AdhocError(format!("redb commit: {e}"))
+                })?;
+
+                w.delta.clear();
+                Ok(())
+            }
+        }
+    }
+
+    fn range_scan_tuple<'a>(
+        &'a self,
+        lower: &[u8],
+        upper: &[u8],
+    ) -> Box<dyn Iterator<Item = Result<Tuple>> + 'a>
+    where
+        's: 'a,
+    {
+        match self {
+            RedbTx::Reader(r) => match redb_collect_range(&r.read_txn, lower, upper) {
+                Ok(pairs) => Box::new(
+                    pairs
+                        .into_iter()
+                        .map(|(k, v)| Ok(decode_tuple_from_kv(&k, &v, None))),
+                ),
+                Err(e) => Box::new(std::iter::once(Err(e))),
+            },
+            RedbTx::Writer(w) => {
+                match redb_collect_range(&w.snapshot, lower, upper) {
+                    Ok(persisted) => Box::new(DeltaMergeIter {
+                        change_iter: w
+                            .delta
+                            .range(lower.to_vec()..upper.to_vec())
+                            .fuse(),
+                        db_iter: persisted.into_iter().fuse(),
+                        change_cache: None,
+                        db_cache: None,
+                    }),
+                    Err(e) => Box::new(std::iter::once(Err(e))),
+                }
+            }
+        }
+    }
+
+    fn range_skip_scan_tuple<'a>(
+        &'a self,
+        lower: &[u8],
+        upper: &[u8],
+        valid_at: ValidityTs,
+    ) -> Box<dyn Iterator<Item = Result<Tuple>> + 'a> {
+        match self {
+            RedbTx::Reader(r) => match redb_collect_range(&r.read_txn, lower, upper) {
+                Ok(pairs) => Box::new(
+                    CollectedSkipIterator {
+                        data: pairs,
+                        pos: 0,
+                        upper: upper.to_vec(),
+                        valid_at,
+                        next_bound: lower.to_vec(),
+                    }
+                    .map(Ok),
+                ),
+                Err(e) => Box::new(std::iter::once(Err(e))),
+            },
+            RedbTx::Writer(w) => match redb_collect_range(&w.snapshot, lower, upper) {
+                Ok(persisted) => {
+                    // Collect merged view (persisted + delta) then apply skip logic
+                    let merged = merge_with_delta(
+                        persisted,
+                        &w.delta,
+                        lower,
+                        upper,
+                    );
+                    Box::new(
+                        CollectedSkipIterator {
+                            data: merged,
+                            pos: 0,
+                            upper: upper.to_vec(),
+                            valid_at,
+                            next_bound: lower.to_vec(),
+                        }
+                        .map(Ok),
+                    )
+                }
+                Err(e) => Box::new(std::iter::once(Err(e))),
+            },
+        }
+    }
+
+    fn range_scan<'a>(
+        &'a self,
+        lower: &[u8],
+        upper: &[u8],
+    ) -> Box<dyn Iterator<Item = Result<(Vec<u8>, Vec<u8>)>> + 'a>
+    where
+        's: 'a,
+    {
+        match self {
+            RedbTx::Reader(r) => match redb_collect_range(&r.read_txn, lower, upper) {
+                Ok(pairs) => Box::new(pairs.into_iter().map(Ok)),
+                Err(e) => Box::new(std::iter::once(Err(e))),
+            },
+            RedbTx::Writer(w) => match redb_collect_range(&w.snapshot, lower, upper) {
+                Ok(persisted) => Box::new(DeltaMergeIterRaw {
+                    change_iter: w
+                        .delta
+                        .range(lower.to_vec()..upper.to_vec())
+                        .fuse(),
+                    db_iter: persisted.into_iter().fuse(),
+                    change_cache: None,
+                    db_cache: None,
+                }),
+                Err(e) => Box::new(std::iter::once(Err(e))),
+            },
+        }
+    }
+
+    fn range_count<'a>(&'a self, lower: &[u8], upper: &[u8]) -> Result<usize>
+    where
+        's: 'a,
+    {
+        match self {
+            RedbTx::Reader(r) => {
+                let table = r.read_txn.open_table(TABLE).map_err(|e| {
+                    crate::engine::error::AdhocError(format!("redb open_table: {e}"))
+                })?;
+                let range = table.range(lower..upper).map_err(|e| {
+                    crate::engine::error::AdhocError(format!("redb range: {e}"))
+                })?;
+                Ok(range.count())
+            }
+            RedbTx::Writer(w) => {
+                let persisted = redb_collect_range(&w.snapshot, lower, upper)?;
+                Ok(DeltaMergeIterRaw {
+                    change_iter: w
+                        .delta
+                        .range(lower.to_vec()..upper.to_vec())
+                        .fuse(),
+                    db_iter: persisted.into_iter().fuse(),
+                    change_cache: None,
+                    db_cache: None,
+                }
+                .count())
+            }
+        }
+    }
+
+    fn total_scan<'a>(&'a self) -> Box<dyn Iterator<Item = Result<(Vec<u8>, Vec<u8>)>> + 'a>
+    where
+        's: 'a,
+    {
+        match self {
+            RedbTx::Reader(r) => match redb_collect_all(&r.read_txn) {
+                Ok(pairs) => Box::new(pairs.into_iter().map(Ok)),
+                Err(e) => Box::new(std::iter::once(Err(e))),
+            },
+            RedbTx::Writer(w) => match redb_collect_all(&w.snapshot) {
+                Ok(persisted) => Box::new(DeltaMergeIterRaw {
+                    change_iter: w.delta.iter().fuse(),
+                    db_iter: persisted.into_iter().fuse(),
+                    change_cache: None,
+                    db_cache: None,
+                }),
+                Err(e) => Box::new(std::iter::once(Err(e))),
+            },
+        }
+    }
+}
+
+// --- Merge iterators: delta cache + persisted data (owned variant) ---
+// Adapted from MemStorage's CacheIter/CacheIterRaw for owned persisted data.
+
+struct DeltaMergeIterRaw<'a, C>
+where
+    C: Iterator<Item = (&'a Vec<u8>, &'a Option<Vec<u8>>)> + 'a,
+{
+    change_iter: C,
+    db_iter: std::iter::Fuse<std::vec::IntoIter<(Vec<u8>, Vec<u8>)>>,
+    change_cache: Option<(&'a Vec<u8>, &'a Option<Vec<u8>>)>,
+    db_cache: Option<(Vec<u8>, Vec<u8>)>,
+}
+
+impl<'a, C> DeltaMergeIterRaw<'a, C>
+where
+    C: Iterator<Item = (&'a Vec<u8>, &'a Option<Vec<u8>>)> + 'a,
+{
+    #[inline]
+    fn fill_cache(&mut self) {
+        if self.change_cache.is_none() {
+            if let Some(kmv) = self.change_iter.next() {
+                self.change_cache = Some(kmv);
+            }
+        }
+        if self.db_cache.is_none() {
+            if let Some(kv) = self.db_iter.next() {
+                self.db_cache = Some(kv);
+            }
+        }
+    }
+
+    #[inline]
+    fn next_inner(&mut self) -> Result<Option<(Vec<u8>, Vec<u8>)>> {
+        loop {
+            self.fill_cache();
+            match (&self.change_cache, &self.db_cache) {
+                (None, None) => return Ok(None),
+                (Some(_), None) => {
+                    let (k, cv) = self.change_cache.take().unwrap();
+                    match cv {
+                        None => continue,
+                        Some(v) => return Ok(Some((k.clone(), v.clone()))),
+                    }
+                }
+                (None, Some(_)) => {
+                    let (k, v) = self.db_cache.take().unwrap();
+                    return Ok(Some((k, v)));
+                }
+                (Some((ck, _)), Some((dk, _))) => match ck.as_slice().cmp(dk.as_slice()) {
+                    Ordering::Less => {
+                        let (k, sv) = self.change_cache.take().unwrap();
+                        match sv {
+                            None => continue,
+                            Some(v) => return Ok(Some((k.clone(), v.clone()))),
+                        }
+                    }
+                    Ordering::Greater => {
+                        let (k, v) = self.db_cache.take().unwrap();
+                        return Ok(Some((k, v)));
+                    }
+                    Ordering::Equal => {
+                        // Delta overrides persisted
+                        self.db_cache.take();
+                        continue;
+                    }
+                },
+            }
+        }
+    }
+}
+
+impl<'a, C> Iterator for DeltaMergeIterRaw<'a, C>
+where
+    C: Iterator<Item = (&'a Vec<u8>, &'a Option<Vec<u8>>)> + 'a,
+{
+    type Item = Result<(Vec<u8>, Vec<u8>)>;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        swap_option_result(self.next_inner())
+    }
+}
+
+// Tuple-decoding variant for range_scan_tuple
+struct DeltaMergeIter<'a, C>
+where
+    C: Iterator<Item = (&'a Vec<u8>, &'a Option<Vec<u8>>)> + 'a,
+{
+    change_iter: C,
+    db_iter: std::iter::Fuse<std::vec::IntoIter<(Vec<u8>, Vec<u8>)>>,
+    change_cache: Option<(&'a Vec<u8>, &'a Option<Vec<u8>>)>,
+    db_cache: Option<(Vec<u8>, Vec<u8>)>,
+}
+
+impl<'a, C> DeltaMergeIter<'a, C>
+where
+    C: Iterator<Item = (&'a Vec<u8>, &'a Option<Vec<u8>>)> + 'a,
+{
+    #[inline]
+    fn fill_cache(&mut self) {
+        if self.change_cache.is_none() {
+            if let Some(kmv) = self.change_iter.next() {
+                self.change_cache = Some(kmv);
+            }
+        }
+        if self.db_cache.is_none() {
+            if let Some(kv) = self.db_iter.next() {
+                self.db_cache = Some(kv);
+            }
+        }
+    }
+
+    #[inline]
+    fn next_inner(&mut self) -> Result<Option<Tuple>> {
+        loop {
+            self.fill_cache();
+            match (&self.change_cache, &self.db_cache) {
+                (None, None) => return Ok(None),
+                (Some(_), None) => {
+                    let (k, cv) = self.change_cache.take().unwrap();
+                    match cv {
+                        None => continue,
+                        Some(v) => return Ok(Some(decode_tuple_from_kv(k, v, None))),
+                    }
+                }
+                (None, Some(_)) => {
+                    let (k, v) = self.db_cache.take().unwrap();
+                    return Ok(Some(decode_tuple_from_kv(&k, &v, None)));
+                }
+                (Some((ck, _)), Some((dk, _))) => match ck.as_slice().cmp(dk.as_slice()) {
+                    Ordering::Less => {
+                        let (k, sv) = self.change_cache.take().unwrap();
+                        match sv {
+                            None => continue,
+                            Some(v) => return Ok(Some(decode_tuple_from_kv(k, v, None))),
+                        }
+                    }
+                    Ordering::Greater => {
+                        let (k, v) = self.db_cache.take().unwrap();
+                        return Ok(Some(decode_tuple_from_kv(&k, &v, None)));
+                    }
+                    Ordering::Equal => {
+                        self.db_cache.take();
+                        continue;
+                    }
+                },
+            }
+        }
+    }
+}
+
+impl<'a, C> Iterator for DeltaMergeIter<'a, C>
+where
+    C: Iterator<Item = (&'a Vec<u8>, &'a Option<Vec<u8>>)> + 'a,
+{
+    type Item = Result<Tuple>;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        swap_option_result(self.next_inner())
+    }
+}
+
+// --- Skip-scan on collected data (validity-aware time-travel) ---
+
+struct CollectedSkipIterator {
+    data: Vec<(Vec<u8>, Vec<u8>)>,
+    pos: usize,
+    upper: Vec<u8>,
+    valid_at: ValidityTs,
+    next_bound: Vec<u8>,
+}
+
+impl Iterator for CollectedSkipIterator {
+    type Item = Tuple;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            // Find the next entry >= next_bound and < upper
+            while self.pos < self.data.len() {
+                if self.data[self.pos].0.as_slice() >= self.next_bound.as_slice() {
+                    break;
+                }
+                self.pos += 1;
+            }
+            if self.pos >= self.data.len() {
+                return None;
+            }
+
+            let (ref candidate_key, ref candidate_val) = self.data[self.pos];
+            if candidate_key.as_slice() >= self.upper.as_slice() {
+                return None;
+            }
+
+            let (ret, nxt_bound) =
+                check_key_for_validity(candidate_key, self.valid_at, None);
+            self.next_bound = nxt_bound;
+            self.pos += 1;
+
+            if let Some(mut nk) = ret {
+                extend_tuple_from_v(&mut nk, candidate_val);
+                return Some(nk);
+            }
+        }
+    }
+}
+
+/// Merge persisted data with delta, producing a sorted Vec of live (non-tombstoned) pairs.
+fn merge_with_delta(
+    persisted: Vec<(Vec<u8>, Vec<u8>)>,
+    delta: &BTreeMap<Vec<u8>, Option<Vec<u8>>>,
+    lower: &[u8],
+    upper: &[u8],
+) -> Vec<(Vec<u8>, Vec<u8>)> {
+    let mut result = Vec::new();
+    let mut db_iter = persisted.into_iter().peekable();
+    let mut delta_iter = delta
+        .range(lower.to_vec()..upper.to_vec())
+        .peekable();
+
+    loop {
+        match (db_iter.peek(), delta_iter.peek()) {
+            (None, None) => break,
+            (Some(_), None) => {
+                result.extend(db_iter);
+                break;
+            }
+            (None, Some(_)) => {
+                for (k, mv) in delta_iter {
+                    if let Some(v) = mv {
+                        result.push((k.clone(), v.clone()));
+                    }
+                }
+                break;
+            }
+            (Some((dk, _)), Some((ck, _))) => match dk.as_slice().cmp(ck.as_slice()) {
+                Ordering::Less => {
+                    result.push(db_iter.next().unwrap());
+                }
+                Ordering::Greater => {
+                    let (k, mv) = delta_iter.next().unwrap();
+                    if let Some(v) = mv {
+                        result.push((k.clone(), v.clone()));
+                    }
+                }
+                Ordering::Equal => {
+                    db_iter.next(); // discard persisted
+                    let (k, mv) = delta_iter.next().unwrap();
+                    if let Some(v) = mv {
+                        result.push((k.clone(), v.clone()));
+                    }
+                }
+            },
+        }
+    }
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::engine::data::value::{DataValue, Validity};
+    use crate::engine::runtime::db::ScriptMutability;
+    use std::collections::BTreeMap;
+    use tempfile::TempDir;
+
+    fn setup_test_db() -> Result<(TempDir, DbCore<RedbStorage>)> {
+        let temp_dir =
+            TempDir::new().map_err(|e| crate::engine::error::AdhocError(e.to_string()))?;
+        let db = new_cozo_redb(temp_dir.path())?;
+        db.run_script(
+            r#"
+            {:create plain {k: Int => v}}
+            {:create tt_test {k: Int, vld: Validity => v}}
+            "#,
+            Default::default(),
+            ScriptMutability::Mutable,
+        )?;
+        Ok((temp_dir, db))
+    }
+
+    #[test]
+    fn basic_operations() -> Result<()> {
+        let (_dir, db) = setup_test_db()?;
+
+        let mut to_import = BTreeMap::new();
+        to_import.insert(
+            "plain".to_string(),
+            crate::engine::NamedRows {
+                headers: vec!["k".to_string(), "v".to_string()],
+                rows: (0..100)
+                    .map(|i| vec![DataValue::from(i), DataValue::from(i * 2)])
+                    .collect(),
+                next: None,
+            },
+        );
+        db.import_relations(to_import)?;
+
+        let result = db.run_script(
+            "?[v] := *plain{k: 5, v}",
+            Default::default(),
+            ScriptMutability::Immutable,
+        )?;
+        assert_eq!(result.rows.len(), 1);
+        assert_eq!(result.rows[0][0], DataValue::from(10));
+
+        Ok(())
+    }
+
+    #[test]
+    fn time_travel() -> Result<()> {
+        let (_dir, db) = setup_test_db()?;
+
+        let mut to_import = BTreeMap::new();
+        to_import.insert(
+            "tt_test".to_string(),
+            crate::engine::NamedRows {
+                headers: vec!["k".to_string(), "vld".to_string(), "v".to_string()],
+                rows: vec![
+                    vec![
+                        DataValue::from(1),
+                        DataValue::Validity(Validity::from((0, true))),
+                        DataValue::from(100),
+                    ],
+                    vec![
+                        DataValue::from(1),
+                        DataValue::Validity(Validity::from((1, true))),
+                        DataValue::from(200),
+                    ],
+                ],
+                next: None,
+            },
+        );
+        db.import_relations(to_import)?;
+
+        let result = db.run_script(
+            "?[v] := *tt_test{k: 1, v @ 0}",
+            Default::default(),
+            ScriptMutability::Immutable,
+        )?;
+        assert_eq!(result.rows[0][0], DataValue::from(100));
+
+        let result = db.run_script(
+            "?[v] := *tt_test{k: 1, v @ 1}",
+            Default::default(),
+            ScriptMutability::Immutable,
+        )?;
+        assert_eq!(result.rows[0][0], DataValue::from(200));
+
+        Ok(())
+    }
+
+    #[test]
+    fn range_operations() -> Result<()> {
+        let (_dir, db) = setup_test_db()?;
+
+        let mut to_import = BTreeMap::new();
+        to_import.insert(
+            "plain".to_string(),
+            crate::engine::NamedRows {
+                headers: vec!["k".to_string(), "v".to_string()],
+                rows: (0..10)
+                    .map(|i| vec![DataValue::from(i), DataValue::from(i)])
+                    .collect(),
+                next: None,
+            },
+        );
+        db.import_relations(to_import)?;
+
+        let result = db.run_script(
+            "?[k, v] := *plain{k, v}, k >= 3, k < 7",
+            Default::default(),
+            ScriptMutability::Immutable,
+        )?;
+        assert_eq!(result.rows.len(), 4);
+        assert_eq!(result.rows[0][0], DataValue::from(3));
+        assert_eq!(result.rows[3][0], DataValue::from(6));
+
+        Ok(())
+    }
+
+    #[test]
+    fn persistence_across_restarts() -> Result<()> {
+        let dir =
+            TempDir::new().map_err(|e| crate::engine::error::AdhocError(e.to_string()))?;
+
+        // Write data
+        {
+            let db = new_cozo_redb(dir.path())?;
+            db.run_script(
+                "{:create persist_test {k: Int => v: String}}",
+                Default::default(),
+                ScriptMutability::Mutable,
+            )?;
+            db.run_script(
+                r#"?[k, v] <- [[1, "hello"], [2, "world"]] :put persist_test {k => v}"#,
+                Default::default(),
+                ScriptMutability::Mutable,
+            )?;
+        }
+
+        // Reopen and verify
+        {
+            let db = new_cozo_redb(dir.path())?;
+            let result = db.run_script(
+                "?[k, v] := *persist_test{k, v}",
+                Default::default(),
+                ScriptMutability::Immutable,
+            )?;
+            assert_eq!(result.rows.len(), 2);
+            assert_eq!(result.rows[0][0], DataValue::from(1));
+            assert_eq!(result.rows[0][1], DataValue::Str("hello".into()));
+            assert_eq!(result.rows[1][0], DataValue::from(2));
+            assert_eq!(result.rows[1][1], DataValue::Str("world".into()));
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn concurrent_reads() -> Result<()> {
+        let (_dir, db) = setup_test_db()?;
+
+        let mut to_import = BTreeMap::new();
+        to_import.insert(
+            "plain".to_string(),
+            crate::engine::NamedRows {
+                headers: vec!["k".to_string(), "v".to_string()],
+                rows: (0..10)
+                    .map(|i| vec![DataValue::from(i), DataValue::from(i)])
+                    .collect(),
+                next: None,
+            },
+        );
+        db.import_relations(to_import)?;
+
+        // Multiple concurrent read queries should all succeed
+        let r1 = db.run_script(
+            "?[k, v] := *plain{k, v}, k < 5",
+            Default::default(),
+            ScriptMutability::Immutable,
+        )?;
+        let r2 = db.run_script(
+            "?[k, v] := *plain{k, v}, k >= 5",
+            Default::default(),
+            ScriptMutability::Immutable,
+        )?;
+        assert_eq!(r1.rows.len(), 5);
+        assert_eq!(r2.rows.len(), 5);
+
+        Ok(())
+    }
+}

--- a/crates/mneme/src/knowledge_store.rs
+++ b/crates/mneme/src/knowledge_store.rs
@@ -205,9 +205,43 @@ impl KnowledgeStore {
         Ok(std::sync::Arc::new(store))
     }
 
+    /// Open a persistent knowledge store backed by redb at the given path.
+    #[cfg(feature = "storage-redb")]
+    pub fn open_redb(
+        path: impl AsRef<std::path::Path>,
+        config: KnowledgeConfig,
+    ) -> crate::error::Result<std::sync::Arc<Self>> {
+        let db = crate::engine::Db::open_redb(path).map_err(|e| {
+            crate::error::EngineInitSnafu {
+                message: e.to_string(),
+            }
+            .build()
+        })?;
+        let store = Self {
+            db: std::sync::Arc::new(db),
+            dim: config.dim,
+        };
+        store.init_schema()?;
+        Ok(std::sync::Arc::new(store))
+    }
+
     fn init_schema(&self) -> crate::error::Result<()> {
         use crate::engine::ScriptMutability;
         use std::collections::BTreeMap;
+
+        // Check if the database is already initialized (persistent reopen)
+        let already_initialized = self
+            .db
+            .run(
+                "?[v] := *schema_version{version: v}",
+                BTreeMap::new(),
+                ScriptMutability::Immutable,
+            )
+            .is_ok();
+
+        if already_initialized {
+            return Ok(());
+        }
 
         for ddl in KNOWLEDGE_DDL {
             self.db
@@ -250,8 +284,7 @@ impl KnowledgeStore {
                 .build()
             })?;
 
-        // Schema version tracking relation (no underscore prefix — CozoDB stores underscore
-        // relations only in temp_store_tx which does not persist across run() calls).
+        // Schema version tracking relation
         self.db
             .run(
                 r":create schema_version { key: String => version: Int }",
@@ -265,7 +298,6 @@ impl KnowledgeStore {
                 .build()
             })?;
 
-        // Insert initial version
         let mut params = BTreeMap::new();
         params.insert(
             "key".to_owned(),

--- a/crates/taxis/src/oikos.rs
+++ b/crates/taxis/src/oikos.rs
@@ -151,6 +151,12 @@ impl Oikos {
         self.root.join("data").join("planning.db")
     }
 
+    /// The knowledge store directory (redb persistent storage).
+    #[must_use]
+    pub fn knowledge_db(&self) -> PathBuf {
+        self.root.join("data").join("knowledge.redb")
+    }
+
     /// The backups directory.
     #[must_use]
     pub fn backups(&self) -> PathBuf {
@@ -254,6 +260,10 @@ mod tests {
         assert_eq!(
             oikos.planning_db(),
             PathBuf::from("/srv/instance/data/planning.db")
+        );
+        assert_eq!(
+            oikos.knowledge_db(),
+            PathBuf::from("/srv/instance/data/knowledge.redb")
         );
         assert_eq!(oikos.logs(), PathBuf::from("/srv/instance/logs"));
         assert_eq!(oikos.signal(), PathBuf::from("/srv/instance/signal"));


### PR DESCRIPTION
## Summary

- Implements `Storage`/`StoreTx` traits for **redb** (pure Rust, zero C deps, ACID, single-file DB)
- Uses delta-cache architecture: `BTreeMap` write buffer + `ReadTransaction` snapshot — no unsafe code needed
- `KnowledgeStore::open_redb(path, config)` with idempotent schema init (safe for restarts)
- Binary wired to persist knowledge at `instance/data/knowledge.redb/` when `recall` feature enabled
- Feature-gated: `storage-redb = ["dep:redb", "mneme-engine"]`, added to binary's `recall` feature

## Files changed

| File | What |
|------|------|
| `crates/mneme/src/engine/storage/redb.rs` | New: RedbStorage + RedbTx + delta-merge iterators + skip-scan + tests |
| `crates/mneme/src/engine/storage/mod.rs` | Wire redb module (feature-gated) |
| `crates/mneme/src/engine/mod.rs` | Db::Redb variant + open_redb() + all dispatch arms + DbInner + safety assertions |
| `crates/mneme/src/knowledge_store.rs` | open_redb() constructor + idempotent init_schema |
| `crates/mneme/Cargo.toml` | storage-redb feature + redb dep |
| `crates/taxis/src/oikos.rs` | knowledge_db() path resolver + test |
| `crates/aletheia/Cargo.toml` | Add storage-redb to recall feature |
| `crates/aletheia/src/main.rs` | Wire persistent knowledge store path |

## Test plan

- [x] `cargo test -p aletheia-mneme --features storage-redb,sqlite -- storage::redb` — 5/5 pass
- [x] `cargo clippy -p aletheia-mneme --features storage-redb,sqlite --all-targets` — zero warnings
- [x] `cargo clippy --workspace --exclude aletheia-mneme-engine --all-targets` — zero warnings
- [x] Persistence test: data survives across Db close/reopen cycles

🤖 Generated with [Claude Code](https://claude.com/claude-code)