### PR TITLE
refactor(mneme): replace BoxErr with structured snafu errors

### DIFF
--- a/crates/mneme/src/engine/data/error.rs
+++ b/crates/mneme/src/engine/data/error.rs
@@ -1,0 +1,33 @@
+use snafu::Snafu;
+
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub(crate)))]
+pub(crate) enum DataError {
+    #[snafu(display("type coercion failed: {message}"))]
+    TypeCoercion {
+        message: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("invalid value: {message}"))]
+    InvalidValue {
+        message: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("unbound variable: {name}"))]
+    UnboundVariable {
+        name: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("{message}"))]
+    Internal {
+        message: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+}

--- a/crates/mneme/src/engine/data/expr.rs
+++ b/crates/mneme/src/engine/data/expr.rs
@@ -66,11 +66,25 @@ pub enum Bytecode {
 #[diagnostic(code(eval::unbound))]
 struct UnboundVariableError(String, #[label] SourceSpan);
 
+impl From<UnboundVariableError> for crate::engine::error::EngineError {
+    #[track_caller]
+    fn from(e: UnboundVariableError) -> Self {
+        crate::engine::error::EngineError::from_display(e)
+    }
+}
+
 #[derive(Error, Diagnostic, Debug)]
 #[error("The tuple bound by variable '{0}' is too short: index is {1}, length is {2}")]
 #[diagnostic(help("This is definitely a bug. Please report it."))]
 #[diagnostic(code(eval::tuple_too_short))]
 struct TupleTooShortError(String, usize, usize, #[label] SourceSpan);
+
+impl From<TupleTooShortError> for crate::engine::error::EngineError {
+    #[track_caller]
+    fn from(e: TupleTooShortError) -> Self {
+        crate::engine::error::EngineError::from_display(e)
+    }
+}
 
 pub fn eval_bytecode_pred(
     bytecodes: &[Bytecode],
@@ -251,10 +265,24 @@ impl Display for Expr {
 #[diagnostic(code(eval::no_implementation))]
 pub(crate) struct NoImplementationError(#[label] pub(crate) SourceSpan, pub(crate) String);
 
+impl From<NoImplementationError> for crate::engine::error::EngineError {
+    #[track_caller]
+    fn from(e: NoImplementationError) -> Self {
+        crate::engine::error::EngineError::from_display(e)
+    }
+}
+
 #[derive(Debug, Error, Diagnostic)]
 #[error("Found value {1:?} where a boolean value is expected")]
 #[diagnostic(code(eval::predicate_not_bool))]
 pub(crate) struct PredicateTypeError(#[label] pub(crate) SourceSpan, pub(crate) DataValue);
+
+impl From<PredicateTypeError> for crate::engine::error::EngineError {
+    #[track_caller]
+    fn from(e: PredicateTypeError) -> Self {
+        crate::engine::error::EngineError::from_display(e)
+    }
+}
 
 #[derive(Debug, Error, Diagnostic)]
 #[error("Cannot build entity ID from {0:?}")]
@@ -262,10 +290,24 @@ pub(crate) struct PredicateTypeError(#[label] pub(crate) SourceSpan, pub(crate) 
 #[diagnostic(help("Entity ID should be an integer satisfying certain constraints"))]
 struct BadEntityId(DataValue, #[label] SourceSpan);
 
+impl From<BadEntityId> for crate::engine::error::EngineError {
+    #[track_caller]
+    fn from(e: BadEntityId) -> Self {
+        crate::engine::error::EngineError::from_display(e)
+    }
+}
+
 #[derive(Error, Diagnostic, Debug)]
 #[error("Evaluation of expression failed")]
 #[diagnostic(code(eval::throw))]
 struct EvalRaisedError(#[label] SourceSpan, #[help] String);
+
+impl From<EvalRaisedError> for crate::engine::error::EngineError {
+    #[track_caller]
+    fn from(e: EvalRaisedError) -> Self {
+        crate::engine::error::EngineError::from_display(e)
+    }
+}
 
 impl Expr {
     pub(crate) fn compile(&self) -> Result<Vec<Bytecode>> {
@@ -339,6 +381,13 @@ impl Expr {
                 #[diagnostic(code(eval::bad_binding))]
                 struct BadBindingError(String, #[label] SourceSpan);
 
+                impl From<BadBindingError> for crate::engine::error::EngineError {
+                    #[track_caller]
+                    fn from(e: BadBindingError) -> Self {
+                        crate::engine::error::EngineError::from_display(e)
+                    }
+                }
+
                 let found_idx = *binding_map
                     .get(var)
                     .ok_or_else(|| BadBindingError(var.to_string(), var.span))?;
@@ -404,6 +453,13 @@ impl Expr {
         #[error("Expression contains unevaluated constant")]
         #[diagnostic(code(eval::not_constant))]
         struct NotConstError;
+
+        impl From<NotConstError> for crate::engine::error::EngineError {
+            #[track_caller]
+            fn from(e: NotConstError) -> Self {
+                crate::engine::error::EngineError::from_display(e)
+            }
+        }
 
         self.partial_eval()?;
         match self {
@@ -587,6 +643,13 @@ impl Expr {
                                     #[diagnostic(code(eval::bad_string_range_scan))]
                                     #[diagnostic(help("A string argument is required"))]
                                     struct StrRangeScanError(DataValue, #[label] SourceSpan);
+
+                                    impl From<StrRangeScanError> for crate::engine::error::EngineError {
+                                        #[track_caller]
+                                        fn from(e: StrRangeScanError) -> Self {
+                                            crate::engine::error::EngineError::from_display(e)
+                                        }
+                                    }
 
                                     StrRangeScanError(val.clone(), symb.span)
                                 })?;

--- a/crates/mneme/src/engine/data/functions.rs
+++ b/crates/mneme/src/engine/data/functions.rs
@@ -270,7 +270,8 @@ define_op!(OP_PARSE_JSON, 1, false);
 pub(crate) fn op_parse_json(args: &[DataValue]) -> Result<DataValue> {
     match args[0].get_str() {
         Some(s) => {
-            let value: serde_json::Value = serde_json::from_str(s)?;
+            let value: serde_json::Value = serde_json::from_str(s)
+                .map_err(|e| crate::engine::error::EngineError::from_display(e))?;
             Ok(DataValue::Json(JsonData(value)))
         }
         None => bail!("parse_json requires a string argument"),

--- a/crates/mneme/src/engine/data/mod.rs
+++ b/crates/mneme/src/engine/data/mod.rs
@@ -8,6 +8,7 @@
 
 // Vendored from CozoDB v0.7.6. Suppress all clippy lints.
 #[allow(warnings, clippy::all, clippy::pedantic, clippy::nursery, clippy::restriction)]
+pub(crate) mod error;
 pub(crate) mod aggr;
 #[allow(warnings, clippy::all, clippy::pedantic, clippy::nursery, clippy::restriction)]
 pub(crate) mod expr;

--- a/crates/mneme/src/engine/data/program.rs
+++ b/crates/mneme/src/engine/data/program.rs
@@ -298,6 +298,13 @@ pub(crate) struct FixedRuleOptionNotFoundError {
     pub(crate) rule_name: String,
 }
 
+impl From<FixedRuleOptionNotFoundError> for crate::engine::error::EngineError {
+    #[track_caller]
+    fn from(e: FixedRuleOptionNotFoundError) -> Self {
+        crate::engine::error::EngineError::from_display(e)
+    }
+}
+
 #[derive(Error, Diagnostic, Debug)]
 #[error("Wrong value for option '{name}' of '{rule_name}'")]
 #[diagnostic(code(fixed_rule::arg_wrong))]
@@ -308,6 +315,13 @@ pub(crate) struct WrongFixedRuleOptionError {
     pub(crate) rule_name: String,
     #[help]
     pub(crate) help: String,
+}
+
+impl From<WrongFixedRuleOptionError> for crate::engine::error::EngineError {
+    #[track_caller]
+    fn from(e: WrongFixedRuleOptionError) -> Self {
+        crate::engine::error::EngineError::from_display(e)
+    }
 }
 
 impl MagicFixedRuleApply {
@@ -345,6 +359,13 @@ impl MagicFixedRuleApply {
             #[label]
             span: SourceSpan,
             rule_name: String,
+        }
+
+        impl From<FixedRuleNotEnoughRelationError> for crate::engine::error::EngineError {
+            #[track_caller]
+            fn from(e: FixedRuleNotEnoughRelationError) -> Self {
+                crate::engine::error::EngineError::from_display(e)
+            }
         }
 
         Ok(self
@@ -550,11 +571,25 @@ impl Display for InputProgram {
 #[diagnostic(help("You need to explicitly name your entry arguments"))]
 struct EntryHeadNotExplicitlyDefinedError(#[label] SourceSpan);
 
+impl From<EntryHeadNotExplicitlyDefinedError> for crate::engine::error::EngineError {
+    #[track_caller]
+    fn from(e: EntryHeadNotExplicitlyDefinedError) -> Self {
+        crate::engine::error::EngineError::from_display(e)
+    }
+}
+
 #[derive(Debug, Diagnostic, Error)]
 #[error("Program has no entry")]
 #[diagnostic(code(parser::no_entry))]
 #[diagnostic(help("You need to have one rule named '?'"))]
 pub(crate) struct NoEntryError;
+
+impl From<NoEntryError> for crate::engine::error::EngineError {
+    #[track_caller]
+    fn from(e: NoEntryError) -> Self {
+        crate::engine::error::EngineError::from_display(e)
+    }
+}
 
 impl InputProgram {
     pub(crate) fn needs_write_lock(&self) -> Option<SmartString<LazyCompact>> {
@@ -1139,6 +1174,13 @@ impl SearchInput {
                 #[diagnostic(code(parser::expected_int_for_hnsw_k))]
                 struct ExpectedPosIntForFtsK(#[label] SourceSpan);
 
+                impl From<ExpectedPosIntForFtsK> for crate::engine::error::EngineError {
+                    #[track_caller]
+                    fn from(e: ExpectedPosIntForFtsK) -> Self {
+                        crate::engine::error::EngineError::from_display(e)
+                    }
+                }
+
                 ensure!(k > 0, ExpectedPosIntForFtsK(self.span));
                 Some(k as usize)
             }
@@ -1273,6 +1315,13 @@ impl SearchInput {
         #[error("Expected positive integer for `k`")]
         #[diagnostic(code(parser::expected_int_for_hnsw_k))]
         struct ExpectedPosIntForFtsK(#[label] SourceSpan);
+
+        impl From<ExpectedPosIntForFtsK> for crate::engine::error::EngineError {
+            #[track_caller]
+            fn from(e: ExpectedPosIntForFtsK) -> Self {
+                crate::engine::error::EngineError::from_display(e)
+            }
+        }
 
         ensure!(k > 0, ExpectedPosIntForFtsK(self.span));
 
@@ -1438,6 +1487,13 @@ impl SearchInput {
         #[diagnostic(code(parser::expected_int_for_hnsw_k))]
         struct ExpectedPosIntForHnswK(#[label] SourceSpan);
 
+        impl From<ExpectedPosIntForHnswK> for crate::engine::error::EngineError {
+            #[track_caller]
+            fn from(e: ExpectedPosIntForHnswK) -> Self {
+                crate::engine::error::EngineError::from_display(e)
+            }
+        }
+
         ensure!(k > 0, ExpectedPosIntForHnswK(self.span));
 
         let ef_expr = self
@@ -1452,6 +1508,13 @@ impl SearchInput {
         #[diagnostic(code(parser::expected_int_for_hnsw_ef))]
         struct ExpectedPosIntForHnswEf(#[label] SourceSpan);
 
+        impl From<ExpectedPosIntForHnswEf> for crate::engine::error::EngineError {
+            #[track_caller]
+            fn from(e: ExpectedPosIntForHnswEf) -> Self {
+                crate::engine::error::EngineError::from_display(e)
+            }
+        }
+
         ensure!(ef > 0, ExpectedPosIntForHnswEf(self.span));
 
         let radius_expr = self.parameters.remove("radius");
@@ -1464,6 +1527,13 @@ impl SearchInput {
                 #[error("Expected positive float for `radius`")]
                 #[diagnostic(code(parser::expected_float_for_hnsw_radius))]
                 struct ExpectedFloatForHnswRadius(#[label] SourceSpan);
+
+                impl From<ExpectedFloatForHnswRadius> for crate::engine::error::EngineError {
+                    #[track_caller]
+                    fn from(e: ExpectedFloatForHnswRadius) -> Self {
+                        crate::engine::error::EngineError::from_display(e)
+                    }
+                }
 
                 ensure!(r > 0.0, ExpectedFloatForHnswRadius(self.span));
                 Some(r)

--- a/crates/mneme/src/engine/data/relation.rs
+++ b/crates/mneme/src/engine/data/relation.rs
@@ -183,6 +183,13 @@ impl NullableColType {
                 #[diagnostic(code(eval::coercion_null))]
                 struct InvalidNullValue(NullableColType);
 
+                impl From<InvalidNullValue> for crate::engine::error::EngineError {
+                    #[track_caller]
+                    fn from(e: InvalidNullValue) -> Self {
+                        crate::engine::error::EngineError::from_display(e)
+                    }
+                }
+
                 Err(InvalidNullValue(self.clone()).into())
             };
         }
@@ -191,6 +198,13 @@ impl NullableColType {
         #[error("data coercion failed: expected type {0}, got value {1:?}")]
         #[diagnostic(code(eval::coercion_failed))]
         struct DataCoercionFailed(NullableColType, DataValue);
+
+        impl From<DataCoercionFailed> for crate::engine::error::EngineError {
+            #[track_caller]
+            fn from(e: DataCoercionFailed) -> Self {
+                crate::engine::error::EngineError::from_display(e)
+            }
+        }
 
         #[derive(Debug, Error, Diagnostic)]
         #[error("bad list length: expected datatype {0}, got length {1}")]
@@ -229,6 +243,14 @@ impl NullableColType {
                     #[error("cannot decode string as base64-encoded bytes: {0}")]
                     #[diagnostic(code(eval::coercion_bad_base_64))]
                     struct BadBase64EncodedString(String);
+
+                    impl From<BadBase64EncodedString> for crate::engine::error::EngineError {
+                        #[track_caller]
+                        fn from(e: BadBase64EncodedString) -> Self {
+                            crate::engine::error::EngineError::from_display(e)
+                        }
+                    }
+
                     let b = STANDARD
                         .decode(s)
                         .map_err(|e| BadBase64EncodedString(e.to_string()))?;
@@ -337,6 +359,13 @@ impl NullableColType {
                 #[error("{0} cannot be coerced into validity")]
                 #[diagnostic(code(eval::invalid_validity))]
                 struct InvalidValidity(DataValue);
+
+                impl From<InvalidValidity> for crate::engine::error::EngineError {
+                    #[track_caller]
+                    fn from(e: InvalidValidity) -> Self {
+                        crate::engine::error::EngineError::from_display(e)
+                    }
+                }
 
                 match data {
                     vld @ DataValue::Validity(_) => vld,

--- a/crates/mneme/src/engine/error.rs
+++ b/crates/mneme/src/engine/error.rs
@@ -1,15 +1,14 @@
-// Public crate-level error type for mneme-engine.
+// Public and internal error types for mneme-engine.
 use snafu::Snafu;
 
 /// Top-level error type for the mneme-engine public API.
 ///
-/// Internal modules use `DbResult<T>` (see below). The public `Db` facade
-/// converts internal errors to this type at the boundary.
+/// Consumers match on `QueryKilled` for cancellation handling; all other
+/// engine failures surface through `Engine`.
 #[derive(Debug, Snafu)]
 #[snafu(visibility(pub))]
 #[non_exhaustive]
 pub enum Error {
-    /// A database engine operation failed.
     #[snafu(display("{message}"))]
     Engine {
         message: String,
@@ -17,10 +16,6 @@ pub enum Error {
         location: snafu::Location,
     },
 
-    /// A running query was cancelled via poison/timeout.
-    ///
-    /// Replaces fragile string-matching on "killed before completion".
-    /// Consumers can match this variant instead of parsing error messages.
     #[snafu(display("Running query was killed before completion"))]
     QueryKilled {
         #[snafu(implicit)]
@@ -30,81 +25,140 @@ pub enum Error {
 
 pub type Result<T> = std::result::Result<T, Error>;
 
-/// Internal error type replacing `miette::Box<dyn std::error::Error + Send + Sync>`.
+/// Internal error type replacing `BoxErr`.
 ///
-/// All CozoDB internal modules use this for `?`-based error propagation.
-/// At the public `Db` facade boundary, this is converted to `Error::Engine`.
-pub(crate) type BoxErr = Box<dyn std::error::Error + Send + Sync + 'static>;
-pub(crate) type DbResult<T> = std::result::Result<T, BoxErr>;
+/// All engine modules propagate errors through this enum. Per-module error
+/// enums feed in via `#[snafu(transparent)]` which auto-generates `From` impls.
+/// At the public `Db` facade, `EngineError` converts to `Error` via `From`.
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub(crate)))]
+pub(crate) enum EngineError {
+    #[snafu(display("{message}"))]
+    Internal {
+        message: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
 
-/// Ad-hoc string error, replaces `bail!("message")` at internal call sites.
-#[derive(Debug)]
-pub(crate) struct AdhocError(pub(crate) String);
+    #[snafu(display("Running query was killed before completion"))]
+    ProcessKilled {
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
 
-impl std::fmt::Display for AdhocError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(&self.0)
+    #[snafu(transparent)]
+    Storage {
+        source: crate::engine::storage::error::StorageError,
+    },
+
+    #[snafu(transparent)]
+    Data {
+        source: crate::engine::data::error::DataError,
+    },
+
+    #[snafu(transparent)]
+    Fts {
+        source: crate::engine::fts::error::FtsError,
+    },
+
+    #[snafu(transparent)]
+    Parse {
+        source: crate::engine::parse::error::CozoParseError,
+    },
+
+    #[snafu(transparent)]
+    Query {
+        source: crate::engine::query::error::QueryError,
+    },
+
+    #[snafu(transparent)]
+    Runtime {
+        source: crate::engine::runtime::error::RuntimeError,
+    },
+
+    #[snafu(transparent)]
+    FixedRule {
+        source: crate::engine::fixed_rule::error::FixedRuleError,
+    },
+}
+
+impl From<EngineError> for Error {
+    fn from(e: EngineError) -> Self {
+        match e {
+            EngineError::ProcessKilled { .. } => QueryKilledSnafu.build(),
+            other => EngineSnafu {
+                message: other.to_string(),
+            }
+            .build(),
+        }
     }
 }
 
-impl std::error::Error for AdhocError {}
+pub(crate) type DbResult<T> = std::result::Result<T, EngineError>;
 
-/// Compatibility `bail!` macro replacing miette's `bail!` in internal CozoDB code.
-///
-/// Supports both string-format form (`bail!("msg")`, `bail!("fmt {}", val)`)
-/// and struct form (`bail!(SomeErrorStruct { ... })`).
+impl EngineError {
+    #[track_caller]
+    pub(crate) fn from_display(e: impl std::fmt::Display) -> Self {
+        EngineError::Internal {
+            message: e.to_string(),
+            location: snafu::Location::default(),
+        }
+    }
+}
+
+/// Compatibility `bail!` macro — produces `EngineError::Internal` for string forms.
 #[macro_export]
 macro_rules! bail {
-    // String literal with format args
     ($fmt:literal, $($arg:tt)+) => {
-        return Err(Box::new($crate::engine::error::AdhocError(format!($fmt, $($arg)+)))
-            as Box<dyn std::error::Error + Send + Sync + 'static>)
+        return Err($crate::engine::error::EngineError::Internal {
+            message: format!($fmt, $($arg)+),
+            location: snafu::Location::default(),
+        })
     };
-    // String literal alone (optional trailing comma)
     ($msg:literal $(,)?) => {
-        return Err(Box::new($crate::engine::error::AdhocError($msg.to_string()))
-            as Box<dyn std::error::Error + Send + Sync + 'static>)
+        return Err($crate::engine::error::EngineError::Internal {
+            message: $msg.to_string(),
+            location: snafu::Location::default(),
+        })
     };
-    // Struct/enum expression form
     ($e:expr) => {
-        return Err(Box::new($e) as Box<dyn std::error::Error + Send + Sync + 'static>)
+        return Err($crate::engine::error::EngineError::from_display($e))
     };
 }
 
-/// Compatibility `miette!` macro: creates a `BoxErr` from a format string or struct expression.
-///
-/// Replaces `miette::miette!("msg")` in vendored CozoDB data module code.
+/// Compatibility `miette!` macro — creates an `EngineError` value (no return).
 #[macro_export]
 macro_rules! miette {
     ($fmt:literal, $($arg:tt)+) => {
-        Box::new($crate::engine::error::AdhocError(format!($fmt, $($arg)+)))
-            as Box<dyn std::error::Error + Send + Sync + 'static>
+        $crate::engine::error::EngineError::Internal {
+            message: format!($fmt, $($arg)+),
+            location: snafu::Location::default(),
+        }
     };
     ($msg:literal $(,)?) => {
-        Box::new($crate::engine::error::AdhocError($msg.to_string()))
-            as Box<dyn std::error::Error + Send + Sync + 'static>
+        $crate::engine::error::EngineError::Internal {
+            message: $msg.to_string(),
+            location: snafu::Location::default(),
+        }
     };
     ($e:expr) => {
-        Box::new($e) as Box<dyn std::error::Error + Send + Sync + 'static>
+        $crate::engine::error::EngineError::from_display($e)
     };
 }
 
-/// Compatibility `ensure!` macro replacing miette's `ensure!` in internal CozoDB code.
+/// Compatibility `ensure!` macro — conditional bail.
 #[macro_export]
 macro_rules! ensure {
-    // Format string with args (optional trailing comma)
     ($cond:expr, $fmt:literal, $($arg:tt)+) => {
         if !($cond) {
             $crate::bail!($fmt, $($arg)+)
         }
     };
-    // String literal alone (optional trailing comma)
     ($cond:expr, $msg:literal $(,)?) => {
         if !($cond) {
             $crate::bail!($msg)
         }
     };
-    // Struct/enum expression form
     ($cond:expr, $e:expr) => {
         if !($cond) {
             $crate::bail!($e)

--- a/crates/mneme/src/engine/fixed_rule/algos/prim.rs
+++ b/crates/mneme/src/engine/fixed_rule/algos/prim.rs
@@ -42,15 +42,11 @@ impl FixedRule for MinimumSpanningTreePrim {
             Err(_) => 0,
             Ok(rel) => {
                 let tuple = rel.iter()?.next().ok_or_else(|| {
-                    
-
-                    crate::engine::error::AdhocError("The provided starting nodes relation is empty".to_string()))
+                    crate::engine::error::EngineError::from_display("The provided starting nodes relation is empty")
                 })??;
                 let dv = &tuple[0];
                 *inv_indices.get(dv).ok_or_else(|| {
-                    
-
-                    crate::engine::error::AdhocError("The requested starting node {0:?} is not found".to_string()), rel.span())
+                    crate::engine::error::EngineError::from_display(format!("The requested starting node {dv:?} is not found"))
                 })?
             }
         };

--- a/crates/mneme/src/engine/fixed_rule/error.rs
+++ b/crates/mneme/src/engine/fixed_rule/error.rs
@@ -1,0 +1,33 @@
+use snafu::Snafu;
+
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub(crate)))]
+pub(crate) enum FixedRuleError {
+    #[snafu(display("bad edge weight: {message}"))]
+    BadEdgeWeight {
+        message: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("node not found: {message}"))]
+    NodeNotFound {
+        message: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("option not found: {message}"))]
+    OptionNotFound {
+        message: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("{message}"))]
+    Internal {
+        message: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+}

--- a/crates/mneme/src/engine/fixed_rule/mod.rs
+++ b/crates/mneme/src/engine/fixed_rule/mod.rs
@@ -39,6 +39,7 @@ use crate::engine::runtime::temp_store::{EpochStore, RegularTempStore};
 use crate::engine::runtime::transact::SessionTx;
 use crate::engine::NamedRows;
 
+pub(crate) mod error;
 #[cfg(feature = "graph-algo")]
 pub(crate) mod algos;
 pub(crate) mod utilities;
@@ -83,7 +84,7 @@ impl<'a, 'b> FixedRuleInputRelation<'a, 'b> {
         Ok(match &self.arg_manifest {
             MagicFixedRuleRuleArg::InMem { name, .. } => {
                 let store = self.stores.get(name).ok_or_else(|| {
-                    crate::engine::error::AdhocError(format!("The requested rule '{}' cannot be found", name.symbol()))
+                    crate::engine::error::EngineError::from_display(format!("The requested rule '{}' cannot be found", name.symbol()))
                 })?;
                 Box::new(store.all_iter().map(|t| Ok(t.into_tuple())))
             }
@@ -102,7 +103,7 @@ impl<'a, 'b> FixedRuleInputRelation<'a, 'b> {
         Ok(match self.arg_manifest {
             MagicFixedRuleRuleArg::InMem { name, .. } => {
                 let store = self.stores.get(name).ok_or_else(|| {
-                    crate::engine::error::AdhocError(format!("The requested rule '{}' cannot be found", name.symbol()))
+                    crate::engine::error::EngineError::from_display(format!("The requested rule '{}' cannot be found", name.symbol()))
                 })?;
                 let t = vec![prefix.clone()];
                 Box::new(store.prefix_iter(&t).map(|t| Ok(t.into_tuple())))
@@ -145,14 +146,14 @@ impl<'a, 'b> FixedRuleInputRelation<'a, 'b> {
                 let mut tuple = tuple.into_iter();
                 let from = match tuple.next() {
                     None => {
-                        error = Some(crate::engine::error::AdhocError("The relation cannot be interpreted as an edge".to_string()));
+                        error = Some(crate::engine::error::EngineError::from_display("The relation cannot be interpreted as an edge".to_string()));
                         return None;
                     }
                     Some(f) => f,
                 };
                 let to = match tuple.next() {
                     None => {
-                        error = Some(crate::engine::error::AdhocError("The relation cannot be interpreted as an edge".to_string()));
+                        error = Some(crate::engine::error::EngineError::from_display("The relation cannot be interpreted as an edge".to_string()));
                         return None;
                     }
                     Some(f) => f,
@@ -218,14 +219,14 @@ impl<'a, 'b> FixedRuleInputRelation<'a, 'b> {
                 let mut tuple = tuple.into_iter();
                 let from = match tuple.next() {
                     None => {
-                        error = Some(crate::engine::error::AdhocError("The relation cannot be interpreted as an edge".to_string()));
+                        error = Some(crate::engine::error::EngineError::from_display("The relation cannot be interpreted as an edge".to_string()));
                         return None;
                     }
                     Some(f) => f,
                 };
                 let to = match tuple.next() {
                     None => {
-                        error = Some(crate::engine::error::AdhocError("The relation cannot be interpreted as an edge".to_string()));
+                        error = Some(crate::engine::error::EngineError::from_display("The relation cannot be interpreted as an edge".to_string()));
                         return None;
                     }
                     Some(f) => f,
@@ -614,8 +615,8 @@ impl SimpleFixedRule {
                     let (app2db_sender, app2db_receiver) = bounded(0);
                     db2app_sender
                         .send((inputs, options, app2db_sender))
-                        .map_err(|e| crate::engine::error::AdhocError(e.to_string()))?;
-                    app2db_receiver.recv().map_err(|e| crate::engine::error::AdhocError(e.to_string()))?
+                        .map_err(|e| crate::engine::error::EngineError::from_display(e.to_string()))?;
+                    app2db_receiver.recv().map_err(|e| crate::engine::error::EngineError::from_display(e.to_string()))?
                 }),
             },
             db2app_receiver,
@@ -833,8 +834,12 @@ struct BadEdgeWeightError {
     span: SourceSpan,
 }
 
-
-
+impl From<BadEdgeWeightError> for crate::engine::error::EngineError {
+    #[track_caller]
+    fn from(e: BadEdgeWeightError) -> Self {
+        crate::engine::error::EngineError::from_display(e)
+    }
+}
 
 
 #[derive(Debug, Snafu)]
@@ -844,8 +849,12 @@ pub(crate) struct NodeNotFoundError {
     pub(crate) span: SourceSpan,
 }
 
-
-
+impl From<NodeNotFoundError> for crate::engine::error::EngineError {
+    #[track_caller]
+    fn from(e: NodeNotFoundError) -> Self {
+        crate::engine::error::EngineError::from_display(e)
+    }
+}
 
 
 impl MagicFixedRuleRuleArg {
@@ -857,7 +866,7 @@ impl MagicFixedRuleRuleArg {
         Ok(match self {
             MagicFixedRuleRuleArg::InMem { name, .. } => {
                 let store = stores.get(name).ok_or_else(|| {
-                    crate::engine::error::AdhocError(format!("The requested rule '{}' cannot be found", name.symbol()))
+                    crate::engine::error::EngineError::from_display(format!("The requested rule '{}' cannot be found", name.symbol()))
                 })?;
                 store.arity
             }

--- a/crates/mneme/src/engine/fixed_rule/utilities/constant.rs
+++ b/crates/mneme/src/engine/fixed_rule/utilities/constant.rs
@@ -98,7 +98,7 @@ impl FixedRule for Constant {
 
                         ensure!(
                             *l == tuple.len(),
-                            crate::engine::error::AdhocError("Constant head must have the same arity as the data given".to_string())
+                            crate::engine::error::EngineError::from_display("Constant head must have the same arity as the data given".to_string())
                         );
                     };
                     last_len = Some(tuple.len());

--- a/crates/mneme/src/engine/fixed_rule/utilities/reorder_sort.rs
+++ b/crates/mneme/src/engine/fixed_rule/utilities/reorder_sort.rs
@@ -132,7 +132,7 @@ impl FixedRule for ReorderSort {
         _span: SourceSpan,
     ) -> Result<usize> {
         let out_opts = opts.get("out").ok_or_else(|| {
-            crate::engine::error::AdhocError("ReorderSort: option 'out' not provided".to_string())
+            crate::engine::error::EngineError::from_display("ReorderSort: option 'out' not provided".to_string())
         })?;
         Ok(match out_opts {
             Expr::Const {

--- a/crates/mneme/src/engine/fts/error.rs
+++ b/crates/mneme/src/engine/fts/error.rs
@@ -1,0 +1,26 @@
+use snafu::Snafu;
+
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub(crate)))]
+pub(crate) enum FtsError {
+    #[snafu(display("tokenizer configuration error: {message}"))]
+    TokenizerConfig {
+        message: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("indexing failed: {message}"))]
+    IndexingFailed {
+        message: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("{message}"))]
+    Internal {
+        message: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+}

--- a/crates/mneme/src/engine/fts/indexing.rs
+++ b/crates/mneme/src/engine/fts/indexing.rs
@@ -64,7 +64,7 @@ impl FtsCache {
                     let doc_key = key_tuple[1..].to_vec();
                     let vals: Vec<DataValue> =
                         rmp_serde::from_slice(&vvec[ENCODED_KEY_MIN_LEN..])
-                            .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)?;
+                            .map_err(|e| crate::engine::error::EngineError::from_display(e))?;
                     let total_length = vals[3].get_int().unwrap_or(0) as u32;
                     doc_lengths
                         .entry(doc_key)
@@ -148,7 +148,7 @@ impl<'a> SessionTx<'a> {
             }
 
             let vals: Vec<DataValue> = rmp_serde::from_slice(&vvec[ENCODED_KEY_MIN_LEN..])
-                .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)?;
+                .map_err(|e| crate::engine::error::EngineError::from_display(e))?;
             let froms = vals[0].get_slice().unwrap();
             let tos = vals[1].get_slice().unwrap();
             let positions = vals[2].get_slice().unwrap();
@@ -354,7 +354,7 @@ impl<'a> SessionTx<'a> {
             let mut cand_tuple = config
                 .base_handle
                 .get(self, &found_key)?
-                .ok_or_else(|| crate::engine::error::AdhocError("corrupted index".to_string()))?;
+                .ok_or_else(|| crate::engine::error::EngineError::from_display("corrupted index".to_string()))?;
 
             if config.bind_score.is_some() {
                 cand_tuple.push(DataValue::from(score));

--- a/crates/mneme/src/engine/fts/mod.rs
+++ b/crates/mneme/src/engine/fts/mod.rs
@@ -21,6 +21,7 @@ use smartstring::{LazyCompact, SmartString};
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 
+pub(crate) mod error;
 pub(crate) mod ast;
 pub(crate) mod indexing;
 pub(crate) mod tokenizer;
@@ -82,19 +83,19 @@ impl TokenizerConfig {
                     .args.first()
                     .unwrap_or(&DataValue::from(1))
                     .get_int()
-                    .ok_or_else(|| crate::engine::error::AdhocError("First argument `min_gram` must be an integer".to_string()))?;
+                    .ok_or_else(|| crate::engine::error::EngineError::from_display("First argument `min_gram` must be an integer".to_string()))?;
                 let max_gram = self
                     .args
                     .get(1)
                     .unwrap_or(&DataValue::from(min_gram))
                     .get_int()
-                    .ok_or_else(|| crate::engine::error::AdhocError("Second argument `max_gram` must be an integer".to_string()))?;
+                    .ok_or_else(|| crate::engine::error::EngineError::from_display("Second argument `max_gram` must be an integer".to_string()))?;
                 let prefix_only = self
                     .args
                     .get(2)
                     .unwrap_or(&DataValue::Bool(false))
                     .get_bool()
-                    .ok_or_else(|| crate::engine::error::AdhocError("Third argument `prefix_only` must be a boolean".to_string()))?;
+                    .ok_or_else(|| crate::engine::error::EngineError::from_display("Third argument `prefix_only` must be a boolean".to_string()))?;
                 ensure!(min_gram >= 1, "min_gram must be >= 1");
                 ensure!(max_gram >= min_gram, "max_gram must be >= min_gram");
                 Box::new(NgramTokenizer::new(
@@ -113,9 +114,9 @@ impl TokenizerConfig {
             "LowerCase" | "Lowercase" => LowerCaser.into(),
             "RemoveLong" => RemoveLongFilter::limit(
                 self.args.first()
-                    .ok_or_else(|| crate::engine::error::AdhocError("Missing first argument `min_length`".to_string()))?
+                    .ok_or_else(|| crate::engine::error::EngineError::from_display("Missing first argument `min_length`".to_string()))?
                     .get_int()
-                    .ok_or_else(|| crate::engine::error::AdhocError("First argument `min_length` must be an integer".to_string()))?
+                    .ok_or_else(|| crate::engine::error::EngineError::from_display("First argument `min_length` must be an integer".to_string()))?
                     as usize,
             )
             .into(),
@@ -123,14 +124,14 @@ impl TokenizerConfig {
                 let mut list_values = Vec::new();
                 match self
                     .args.first()
-                    .ok_or_else(|| crate::engine::error::AdhocError("Missing first argument `compound_words_list`".to_string()))?
+                    .ok_or_else(|| crate::engine::error::EngineError::from_display("Missing first argument `compound_words_list`".to_string()))?
                 {
                     DataValue::List(l) => {
                         for v in l {
                             list_values.push(
                                 v.get_str()
                                     .ok_or_else(|| {
-                                        crate::engine::error::AdhocError("First argument `compound_words_list` must be a list of strings".to_string())
+                                        crate::engine::error::EngineError::from_display("First argument `compound_words_list` must be a list of strings".to_string())
                                     })?,
                             );
                         }
@@ -138,16 +139,16 @@ impl TokenizerConfig {
                     _ => bail!("First argument `compound_words_list` must be a list of strings"),
                 }
                 SplitCompoundWords::from_dictionary(list_values)
-                    .map_err(|e| crate::engine::error::AdhocError(format!("Failed to load dictionary: {}", e)))?
+                    .map_err(|e| crate::engine::error::EngineError::from_display(format!("Failed to load dictionary: {}", e)))?
                     .into()
             }
             "Stemmer" => {
                 let language = match self
                     .args.first()
-                    .ok_or_else(|| crate::engine::error::AdhocError("Missing first argument `language` to Stemmer".to_string()))?
+                    .ok_or_else(|| crate::engine::error::EngineError::from_display("Missing first argument `language` to Stemmer".to_string()))?
                     .get_str()
                     .ok_or_else(|| {
-                        crate::engine::error::AdhocError("First argument `language` to Stemmer must be a string".to_string())
+                        crate::engine::error::EngineError::from_display("First argument `language` to Stemmer must be a string".to_string())
                     })?
                     .to_lowercase()
                     .as_str()
@@ -176,7 +177,7 @@ impl TokenizerConfig {
             }
             "Stopwords" => {
                 match self.args.first().ok_or_else(|| {
-                    crate::engine::error::AdhocError("Filter Stopwords requires language name or a list of stopwords".to_string())
+                    crate::engine::error::EngineError::from_display("Filter Stopwords requires language name or a list of stopwords".to_string())
                 })? {
                     DataValue::Str(name) => StopWordFilter::for_lang(name)?.into(),
                     DataValue::List(l) => {
@@ -185,7 +186,7 @@ impl TokenizerConfig {
                             stopwords.push(
                                 v.get_str()
                                     .ok_or_else(|| {
-                                        crate::engine::error::AdhocError(
+                                        crate::engine::error::EngineError::from_display(
                                             "First argument `stopwords` must be a list of strings".to_string()
                                         )
                                     })?

--- a/crates/mneme/src/engine/fts/tokenizer/split_compound_words.rs
+++ b/crates/mneme/src/engine/fts/tokenizer/split_compound_words.rs
@@ -56,7 +56,7 @@ impl SplitCompoundWords {
         let dict = AhoCorasickBuilder::new()
             .match_kind(MatchKind::LeftmostLongest)
             .build(dict)
-            .map_err(|e| crate::engine::error::AdhocError(e.to_string()))?;
+            .map_err(|e| crate::engine::error::EngineError::from_display(e.to_string()))?;
 
         Ok(Self::from_automaton(dict))
     }

--- a/crates/mneme/src/engine/mod.rs
+++ b/crates/mneme/src/engine/mod.rs
@@ -43,13 +43,6 @@ pub(crate) mod runtime;
 pub(crate) mod storage;
 pub(crate) mod utils;
 
-/// Convert an internal BoxErr to the public Error type, detecting ProcessKilled for typed matching.
-fn convert_err(e: crate::engine::error::BoxErr) -> Error {
-    if e.downcast_ref::<crate::engine::runtime::db::ProcessKilled>().is_some() {
-        return error::QueryKilledSnafu.build();
-    }
-    error::EngineSnafu { message: e.to_string() }.build()
-}
 
 /// Public facade replacing DbInstance. Dispatches to concrete storage implementations.
 pub enum Db {
@@ -63,7 +56,7 @@ impl Db {
     pub fn open_mem() -> crate::engine::Result<Self> {
         crate::engine::storage::mem::new_cozo_mem()
             .map(Db::Mem)
-            .map_err(convert_err)
+            .map_err(Error::from)
     }
 
     /// Open a RocksDB-backed database at the given path.
@@ -71,7 +64,7 @@ impl Db {
     pub fn open_rocksdb(path: impl AsRef<Path>) -> crate::engine::Result<Self> {
         crate::engine::storage::newrocks::new_cozo_newrocksdb(path)
             .map(Db::RocksDb)
-            .map_err(convert_err)
+            .map_err(Error::from)
     }
 
     /// Execute a Datalog script.
@@ -86,7 +79,7 @@ impl Db {
             #[cfg(feature = "storage-new-rocksdb")]
             Db::RocksDb(db) => db.run_script(script, params, mutability),
         };
-        result.map_err(convert_err)
+        result.map_err(Error::from)
     }
 
     /// Export relations for backup.
@@ -100,7 +93,7 @@ impl Db {
             #[cfg(feature = "storage-new-rocksdb")]
             Db::RocksDb(db) => db.export_relations(relations),
         };
-        result.map_err(convert_err)
+        result.map_err(Error::from)
     }
 
     /// Import relations from backup.
@@ -110,7 +103,7 @@ impl Db {
             #[cfg(feature = "storage-new-rocksdb")]
             Db::RocksDb(db) => db.import_relations(data),
         };
-        result.map_err(convert_err)
+        result.map_err(Error::from)
     }
 
     /// Register a custom fixed rule (graph algorithm).
@@ -124,7 +117,7 @@ impl Db {
             #[cfg(feature = "storage-new-rocksdb")]
             Db::RocksDb(db) => db.register_fixed_rule(name, rule),
         };
-        result.map_err(convert_err)
+        result.map_err(Error::from)
     }
 
     /// Register a callback for relation changes.

--- a/crates/mneme/src/engine/parse/error.rs
+++ b/crates/mneme/src/engine/parse/error.rs
@@ -1,0 +1,26 @@
+use snafu::Snafu;
+
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub(crate)))]
+pub(crate) enum CozoParseError {
+    #[snafu(display("syntax error: {message}"))]
+    Syntax {
+        message: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("invalid expression: {message}"))]
+    InvalidExpression {
+        message: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("{message}"))]
+    Internal {
+        message: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+}

--- a/crates/mneme/src/engine/parse/expr.rs
+++ b/crates/mneme/src/engine/parse/expr.rs
@@ -185,7 +185,7 @@ fn build_term(pair: Pair<'_>, param_pool: &BTreeMap<String, DataValue>) -> Resul
             Expr::Const {
                 val: param_pool
                     .get(param_str)
-                    .ok_or_else(|| crate::engine::error::AdhocError(format!("Required parameter {param_str} not found")))?
+                    .ok_or_else(|| crate::engine::error::EngineError::from_display(format!("Required parameter {param_str} not found")))?
                     .clone(),
                 span,
             }
@@ -197,7 +197,7 @@ fn build_term(pair: Pair<'_>, param_pool: &BTreeMap<String, DataValue>) -> Resul
                 .as_str()
                 .replace('_', "")
                 .parse::<i64>()
-                .map_err(|_| crate::engine::error::AdhocError("Cannot parse integer".to_string()))?;
+                .map_err(|_| crate::engine::error::EngineError::from_display("Cannot parse integer".to_string()))?;
             Expr::Const {
                 val: DataValue::from(i),
                 span,
@@ -231,7 +231,7 @@ fn build_term(pair: Pair<'_>, param_pool: &BTreeMap<String, DataValue>) -> Resul
                 .as_str()
                 .replace('_', "")
                 .parse::<f64>()
-                .map_err(|_| crate::engine::error::AdhocError("Cannot parse float".to_string()))?;
+                .map_err(|_| crate::engine::error::EngineError::from_display("Cannot parse float".to_string()))?;
             Expr::Const {
                 val: DataValue::from(f),
                 span,
@@ -336,7 +336,7 @@ fn build_term(pair: Pair<'_>, param_pool: &BTreeMap<String, DataValue>) -> Resul
                 "if" => {
                     
 
-                    ensure!(args.len() == 2 || args.len() == 3, crate::engine::error::AdhocError("wrong number of arguments to if: 2 or 3 required".to_string()));
+                    ensure!(args.len() == 2 || args.len() == 3, crate::engine::error::EngineError::from_display("wrong number of arguments to if: 2 or 3 required".to_string()));
 
                     let mut clauses = vec![];
                     let mut args = args.into_iter();
@@ -425,7 +425,7 @@ fn parse_quoted_string(pair: Pair<'_>) -> Result<SmartString<LazyCompact>> {
             s if s.starts_with(r"\u") => {
                 let code = parse_int(s, 16) as u32;
                 let ch = char::from_u32(code)
-                    .ok_or_else(|| crate::engine::error::AdhocError(format!("invalid UTF8 code {code}")))?;
+                    .ok_or_else(|| crate::engine::error::EngineError::from_display(format!("invalid UTF8 code {code}")))?;
                 ret.push(ch);
             }
             s if s.starts_with('\\') => {
@@ -454,7 +454,7 @@ fn parse_s_quoted_string(pair: Pair<'_>) -> Result<SmartString<LazyCompact>> {
             s if s.starts_with(r"\u") => {
                 let code = parse_int(s, 16) as u32;
                 let ch = char::from_u32(code)
-                    .ok_or_else(|| crate::engine::error::AdhocError(format!("invalid UTF8 code {code}")))?;
+                    .ok_or_else(|| crate::engine::error::EngineError::from_display(format!("invalid UTF8 code {code}")))?;
                 ret.push(ch);
             }
             s if s.starts_with('\\') => {

--- a/crates/mneme/src/engine/parse/fts.rs
+++ b/crates/mneme/src/engine/parse/fts.rs
@@ -17,7 +17,7 @@ use pest::Parser;
 use smartstring::SmartString;
 
 pub(crate) fn parse_fts_query(q: &str) -> Result<FtsExpr> {
-    let mut pairs = CozoScriptParser::parse(Rule::fts_doc, q).map_err(|e| crate::engine::error::AdhocError(e.to_string()))?;
+    let mut pairs = CozoScriptParser::parse(Rule::fts_doc, q).map_err(|e| crate::engine::error::EngineError::from_display(e.to_string()))?;
     let pairs = pairs.next().unwrap().into_inner();
     let pairs: Vec<_> = pairs
         .filter(|r| r.as_rule() != Rule::EOI)
@@ -70,7 +70,7 @@ fn build_term(pair: Pair<'_>) -> Result<FtsExpr> {
                             .as_str()
                             .replace('_', "")
                             .parse::<i64>()
-                            .map_err(|e| crate::engine::error::AdhocError(e.to_string()))?;
+                            .map_err(|e| crate::engine::error::EngineError::from_display(e.to_string()))?;
                         distance = i as u32;
                     }
                     _ => literals.push(build_phrase(pair)?),
@@ -104,7 +104,7 @@ fn build_phrase(pair: Pair<'_>) -> Result<FtsLiteral> {
                             .as_str()
                             .replace('_', "")
                             .parse::<f64>()
-                            .map_err(|e| crate::engine::error::AdhocError(e.to_string()))?;
+                            .map_err(|e| crate::engine::error::EngineError::from_display(e.to_string()))?;
                         booster = f;
                     }
                     Rule::int => {
@@ -112,7 +112,7 @@ fn build_phrase(pair: Pair<'_>) -> Result<FtsLiteral> {
                             .as_str()
                             .replace('_', "")
                             .parse::<i64>()
-                            .map_err(|e| crate::engine::error::AdhocError(e.to_string()))?;
+                            .map_err(|e| crate::engine::error::EngineError::from_display(e.to_string()))?;
                         booster = i as f64;
                     }
                     _ => unreachable!("unexpected rule: {:?}", boosted.as_rule()),

--- a/crates/mneme/src/engine/parse/mod.rs
+++ b/crates/mneme/src/engine/parse/mod.rs
@@ -32,6 +32,7 @@ use crate::engine::parse::schema::parse_nullable_type;
 use crate::engine::parse::sys::{parse_sys, SysOp};
 use crate::engine::{Expr, FixedRule};
 
+pub(crate) mod error;
 pub(crate) mod expr;
 pub(crate) mod fts;
 pub(crate) mod imperative;
@@ -259,9 +260,16 @@ pub(crate) struct ParseError {
     pub(crate) span: SourceSpan,
 }
 
+impl From<ParseError> for crate::engine::error::EngineError {
+    #[track_caller]
+    fn from(e: ParseError) -> Self {
+        crate::engine::error::EngineError::from_display(e)
+    }
+}
+
 pub(crate) fn parse_type(src: &str) -> Result<NullableColType> {
     let parsed = CozoScriptParser::parse(Rule::col_type_with_term, src)
-        .map_err(|e| crate::engine::error::AdhocError(e.to_string()))?
+        .map_err(|e| crate::engine::error::EngineError::from_display(e.to_string()))?
         .next()
         .unwrap();
     parse_nullable_type(parsed.into_inner().next().unwrap())

--- a/crates/mneme/src/engine/parse/query.rs
+++ b/crates/mneme/src/engine/parse/query.rs
@@ -212,9 +212,9 @@ pub(crate) fn parse_query(
                 let _span = pair.extract_span();
                 let timeout = build_expr(pair, param_pool)?
                     .eval_to_const()
-                    .map_err(|_err| crate::engine::error::AdhocError("Query option {} is not constant".to_string()))?
+                    .map_err(|_err| crate::engine::error::EngineError::from_display("Query option {} is not constant".to_string()))?
                     .get_float()
-                    .ok_or(crate::engine::error::AdhocError("Query option {} requires a non-negative integer".to_string()))?;
+                    .ok_or(crate::engine::error::EngineError::from_display("Query option {} requires a non-negative integer".to_string()))?;
                 if timeout > 0. {
                     out_opts.timeout = Some(timeout);
                 } else {
@@ -231,10 +231,10 @@ pub(crate) fn parse_query(
                     let _span = pair.extract_span();
                     let sleep = build_expr(pair, param_pool)?
                         .eval_to_const()
-                        .map_err(|_err| crate::engine::error::AdhocError("Query option {} is not constant".to_string()))?
+                        .map_err(|_err| crate::engine::error::EngineError::from_display("Query option {} is not constant".to_string()))?
                         .get_float()
-                        .ok_or(crate::engine::error::AdhocError("Query option {} requires a non-negative integer".to_string()))?;
-                    ensure!(sleep > 0., crate::engine::error::AdhocError("Query option {} requires a positive integer".to_string()));
+                        .ok_or(crate::engine::error::EngineError::from_display("Query option {} requires a non-negative integer".to_string()))?;
+                    ensure!(sleep > 0., crate::engine::error::EngineError::from_display("Query option {} requires a positive integer".to_string()));
                     out_opts.sleep = Some(sleep);
                 }
             }
@@ -243,9 +243,9 @@ pub(crate) fn parse_query(
                 let _span = pair.extract_span();
                 let limit = build_expr(pair, param_pool)?
                     .eval_to_const()
-                    .map_err(|_err| crate::engine::error::AdhocError("Query option {} is not constant".to_string()))?
+                    .map_err(|_err| crate::engine::error::EngineError::from_display("Query option {} is not constant".to_string()))?
                     .get_non_neg_int()
-                    .ok_or(crate::engine::error::AdhocError("Query option {} requires a non-negative integer".to_string()))?;
+                    .ok_or(crate::engine::error::EngineError::from_display("Query option {} requires a non-negative integer".to_string()))?;
                 out_opts.limit = Some(limit as usize);
             }
             Rule::offset_option => {
@@ -253,9 +253,9 @@ pub(crate) fn parse_query(
                 let _span = pair.extract_span();
                 let offset = build_expr(pair, param_pool)?
                     .eval_to_const()
-                    .map_err(|_err| crate::engine::error::AdhocError("Query option {} is not constant".to_string()))?
+                    .map_err(|_err| crate::engine::error::EngineError::from_display("Query option {} is not constant".to_string()))?
                     .get_non_neg_int()
-                    .ok_or(crate::engine::error::AdhocError("Query option {} requires a non-negative integer".to_string()))?;
+                    .ok_or(crate::engine::error::EngineError::from_display("Query option {} requires a non-negative integer".to_string()))?;
                 out_opts.offset = Some(offset as usize);
             }
             Rule::sort_option => {
@@ -341,9 +341,9 @@ pub(crate) fn parse_query(
                 let _span = pair.extract_span();
                 let val = build_expr(pair, param_pool)?
                     .eval_to_const()
-                    .map_err(|_err| crate::engine::error::AdhocError("Query option is not constant".to_string()))?
+                    .map_err(|_err| crate::engine::error::EngineError::from_display("Query option is not constant".to_string()))?
                     .get_bool()
-                    .ok_or(crate::engine::error::AdhocError("Query option requires a boolean".to_string()))?;
+                    .ok_or(crate::engine::error::EngineError::from_display("Query option requires a boolean".to_string()))?;
                 disable_magic_rewrite = val;
             }
             Rule::EOI => break,
@@ -488,7 +488,7 @@ fn parse_rule(
 
     
 
-    ensure!(!head.is_empty(), crate::engine::error::AdhocError("Horn-clause rule cannot have empty rule head".to_string()));
+    ensure!(!head.is_empty(), crate::engine::error::EngineError::from_display("Horn-clause rule cannot have empty rule head".to_string()));
     let body = src.next().unwrap();
     let mut body_clauses = vec![];
     let mut ignored_counter = 0;
@@ -772,7 +772,7 @@ fn parse_rule_head_arg(
                 Symbol::new(var.as_str(), var.extract_span()),
                 Some((
                     parse_aggr(aggr_name)
-                        .ok_or_else(|| crate::engine::error::AdhocError(format!("Aggregation '{aggr_name}' not found")))?
+                        .ok_or_else(|| crate::engine::error::EngineError::from_display(format!("Aggregation '{aggr_name}' not found")))?
                         .clone(),
                     args,
                 )),
@@ -798,7 +798,7 @@ fn parse_fixed_rule(
     
 
     for (a, _v) in aggr.iter().zip(head.iter()) {
-        ensure!(a.is_none(), crate::engine::error::AdhocError("fixed rule cannot be combined with aggregation".to_string()))
+        ensure!(a.is_none(), crate::engine::error::EngineError::from_display("fixed rule cannot be combined with aggregation".to_string()))
     }
 
     let mut seen_bindings = BTreeSet::new();
@@ -947,7 +947,7 @@ fn parse_fixed_rule(
 
     let fixed_impl = fixed_rules
         .get(&fixed.name as &str)
-        .ok_or_else(|| crate::engine::error::AdhocError(format!("Fixed rule '{}' not found", fixed.name)))?;
+        .ok_or_else(|| crate::engine::error::EngineError::from_display(format!("Fixed rule '{}' not found", fixed.name)))?;
     fixed_impl.init_options(&mut options, args_list_span)?;
     let arity = fixed_impl.arity(&options, &head, name_pair.extract_span())?;
 
@@ -1006,13 +1006,13 @@ fn expr2vld_spec(expr: Expr, cur_vld: ValidityTs) -> Result<ValidityTs> {
     let _vld_span = expr.span();
     match expr.eval_to_const()? {
         DataValue::Num(n) => {
-            let microseconds = n.get_int().ok_or(crate::engine::error::AdhocError("bad specification of validity".to_string()))?;
+            let microseconds = n.get_int().ok_or(crate::engine::error::EngineError::from_display("bad specification of validity".to_string()))?;
             Ok(ValidityTs(Reverse(microseconds)))
         }
         DataValue::Str(s) => match &s as &str {
             "NOW" => Ok(cur_vld),
             "END" => Ok(MAX_VALIDITY_TS),
-            s => Ok(str2vld(s).map_err(|_| crate::engine::error::AdhocError("bad specification of validity".to_string()))?),
+            s => Ok(str2vld(s).map_err(|_| crate::engine::error::EngineError::from_display("bad specification of validity".to_string()))?),
         },
         _ => {
             bail!("bad specification of validity")

--- a/crates/mneme/src/engine/parse/schema.rs
+++ b/crates/mneme/src/engine/parse/schema.rs
@@ -121,7 +121,7 @@ fn parse_type_inner(pair: Pair<'_>) -> Result<ColType> {
 
                     
 
-                    let n = dv.get_int().ok_or(crate::engine::error::AdhocError("Bad specification of list length in type".to_string()))?;
+                    let n = dv.get_int().ok_or(crate::engine::error::EngineError::from_display("Bad specification of list length in type".to_string()))?;
                     ensure!(n >= 0, "Bad specification of list length in type: negative length");
                     Some(n as usize)
                 }
@@ -139,7 +139,7 @@ fn parse_type_inner(pair: Pair<'_>) -> Result<ColType> {
                 _ => unreachable!()
             };
             let len = inner.next().unwrap();
-            let len = len.as_str().replace('_', "").parse::<usize>().map_err(|e| crate::engine::error::AdhocError(e.to_string()))?;
+            let len = len.as_str().replace('_', "").parse::<usize>().map_err(|e| crate::engine::error::EngineError::from_display(e.to_string()))?;
             ColType::Vec {
                 eltype,
                 len,

--- a/crates/mneme/src/engine/parse/sys.rs
+++ b/crates/mneme/src/engine/parse/sys.rs
@@ -115,7 +115,7 @@ pub(crate) fn parse_sys(
             let i_val = i_val.eval_to_const()?;
             let i_val = i_val
                 .get_int()
-                .ok_or_else(|| crate::engine::error::AdhocError("Process ID must be an integer".to_string()))?;
+                .ok_or_else(|| crate::engine::error::EngineError::from_display("Process ID must be an integer".to_string()))?;
             SysOp::KillRunning(i_val as u64)
         }
         Rule::explain_op => {
@@ -247,7 +247,7 @@ pub(crate) fn parse_sys(
                                 expr.partial_eval()?;
                                 let v = expr.eval_to_const()?;
                                 false_positive_weight = v.get_float().ok_or_else(|| {
-                                    crate::engine::error::AdhocError("false_positive_weight must be a float".to_string())
+                                    crate::engine::error::EngineError::from_display("false_positive_weight must be a float".to_string())
                                 })?;
                             }
                             "false_negative_weight" => {
@@ -255,7 +255,7 @@ pub(crate) fn parse_sys(
                                 expr.partial_eval()?;
                                 let v = expr.eval_to_const()?;
                                 false_negative_weight = v.get_float().ok_or_else(|| {
-                                    crate::engine::error::AdhocError("false_negative_weight must be a float".to_string())
+                                    crate::engine::error::EngineError::from_display("false_negative_weight must be a float".to_string())
                                 })?;
                             }
                             "n_gram" => {
@@ -264,7 +264,7 @@ pub(crate) fn parse_sys(
                                 let v = expr.eval_to_const()?;
                                 n_gram = v
                                     .get_int()
-                                    .ok_or_else(|| crate::engine::error::AdhocError("n_gram must be an integer".to_string()))?
+                                    .ok_or_else(|| crate::engine::error::EngineError::from_display("n_gram must be an integer".to_string()))?
                                     as usize;
                             }
                             "n_perm" => {
@@ -273,7 +273,7 @@ pub(crate) fn parse_sys(
                                 let v = expr.eval_to_const()?;
                                 n_perm = v
                                     .get_int()
-                                    .ok_or_else(|| crate::engine::error::AdhocError("n_perm must be an integer".to_string()))?
+                                    .ok_or_else(|| crate::engine::error::EngineError::from_display("n_perm must be an integer".to_string()))?
                                     as usize;
                             }
                             "target_threshold" => {
@@ -282,7 +282,7 @@ pub(crate) fn parse_sys(
                                 let v = expr.eval_to_const()?;
                                 target_threshold = v
                                     .get_float()
-                                    .ok_or_else(|| crate::engine::error::AdhocError("target_threshold must be a float".to_string()))?;
+                                    .ok_or_else(|| crate::engine::error::EngineError::from_display("target_threshold must be a float".to_string()))?;
                             }
                             "extractor" => {
                                 let mut ex = build_expr(opt_val, param_pool)?;
@@ -537,7 +537,7 @@ pub(crate) fn parse_sys(
                                 let v = build_expr(opt_val, param_pool)?
                                     .eval_to_const()?
                                     .get_int()
-                                    .ok_or_else(|| crate::engine::error::AdhocError(format!("Invalid vec_dim: {}", opt_val_str)))?;
+                                    .ok_or_else(|| crate::engine::error::EngineError::from_display(format!("Invalid vec_dim: {}", opt_val_str)))?;
                                 ensure!(v > 0, "Invalid vec_dim: {}", v);
                                 vec_dim = v as usize;
                             }
@@ -546,7 +546,7 @@ pub(crate) fn parse_sys(
                                     .eval_to_const()?
                                     .get_int()
                                     .ok_or_else(|| {
-                                        crate::engine::error::AdhocError(format!("Invalid ef_construction: {}", opt_val_str))
+                                        crate::engine::error::EngineError::from_display(format!("Invalid ef_construction: {}", opt_val_str))
                                     })?;
                                 ensure!(v > 0, "Invalid ef_construction: {}", v);
                                 ef_construction = v as usize;
@@ -556,7 +556,7 @@ pub(crate) fn parse_sys(
                                     .eval_to_const()?
                                     .get_int()
                                     .ok_or_else(|| {
-                                        crate::engine::error::AdhocError(format!("Invalid m_neighbours: {}", opt_val_str))
+                                        crate::engine::error::EngineError::from_display(format!("Invalid m_neighbours: {}", opt_val_str))
                                     })?;
                                 ensure!(v > 0, "Invalid m_neighbours: {}", v);
                                 m_neighbours = v as usize;
@@ -566,7 +566,7 @@ pub(crate) fn parse_sys(
                                     "F32" | "Float" => VecElementType::F32,
                                     "F64" | "Double" => VecElementType::F64,
                                     _ => {
-                                        return Err(Box::new(crate::engine::error::AdhocError(format!("Invalid dtype: {}", opt_val.as_str()))) as crate::engine::error::BoxErr)
+                                        return Err(crate::engine::error::EngineError::from_display(format!("Invalid dtype: {}", opt_val.as_str())))
                                     }
                                 }
                             }
@@ -596,7 +596,7 @@ pub(crate) fn parse_sys(
                             "keep_pruned_connections" => {
                                 keep_pruned_connections = opt_val.as_str().trim() == "true";
                             }
-                            _ => return Err(Box::new(crate::engine::error::AdhocError(format!("Invalid option: {}", opt_name.as_str()))) as crate::engine::error::BoxErr),
+                            _ => return Err(crate::engine::error::EngineError::from_display(format!("Invalid option: {}", opt_name.as_str()))),
                         }
                     }
                     if ef_construction == 0 {
@@ -645,7 +645,7 @@ pub(crate) fn parse_sys(
 
                     
 
-                    ensure!(!cols.is_empty(), crate::engine::error::AdhocError("index must have at least one column specified".to_string()));
+                    ensure!(!cols.is_empty(), crate::engine::error::EngineError::from_display("index must have at least one column specified".to_string()));
                     SysOp::CreateIndex(
                         Symbol::new(rel.as_str(), rel.extract_span()),
                         Symbol::new(name.as_str(), name.extract_span()),

--- a/crates/mneme/src/engine/query/compile.rs
+++ b/crates/mneme/src/engine/query/compile.rs
@@ -130,7 +130,7 @@ impl<'a> SessionTx<'a> {
                                     let mut relation =
                                         self.compile_magic_rule_body(rule, &k, &store_arities, header)?;
                                     relation.fill_binding_indices_and_compile().map_err(|e| {
-                                        crate::engine::error::AdhocError(format!(
+                                        crate::engine::error::EngineError::from_display(format!(
                                             "{e}: error encountered when filling binding indices for {relation:#?}"
                                         ))
                                     })?;
@@ -172,7 +172,7 @@ impl<'a> SessionTx<'a> {
             match atom {
                 MagicAtom::Rule(rule_app) => {
                     let store_arity = store_arities.get(&rule_app.name).ok_or_else(|| {
-                        crate::engine::error::AdhocError(format!("Requested rule '{}' not found", rule_app.name.symbol()))
+                        crate::engine::error::EngineError::from_display(format!("Requested rule '{}' not found", rule_app.name.symbol()))
                     })?;
 
                     ensure!(
@@ -351,7 +351,7 @@ impl<'a> SessionTx<'a> {
                 }
                 MagicAtom::NegatedRule(rule_app) => {
                     let store_arity = store_arities.get(&rule_app.name).ok_or_else(|| {
-                        crate::engine::error::AdhocError(format!("Requested rule '{}' not found", rule_app.name.symbol()))
+                        crate::engine::error::EngineError::from_display(format!("Requested rule '{}' not found", rule_app.name.symbol()))
                     })?;
                     ensure!(
                         *store_arity == rule_app.args.len(),

--- a/crates/mneme/src/engine/query/error.rs
+++ b/crates/mneme/src/engine/query/error.rs
@@ -1,0 +1,33 @@
+use snafu::Snafu;
+
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub(crate)))]
+pub(crate) enum QueryError {
+    #[snafu(display("compilation failed: {message}"))]
+    CompilationFailed {
+        message: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("assertion failure: {message}"))]
+    AssertionFailure {
+        message: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("stratification failed: {message}"))]
+    StratificationFailed {
+        message: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("{message}"))]
+    Internal {
+        message: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+}

--- a/crates/mneme/src/engine/query/logical.rs
+++ b/crates/mneme/src/engine/query/logical.rs
@@ -204,7 +204,7 @@ impl InputAtom {
                     .map(|a| a.do_disjunctive_normal_form(r#gen, tx));
                 let mut result = args
                     .next()
-                    .ok_or_else(|| crate::engine::error::AdhocError("empty conjunction".to_string()))??;
+                    .ok_or_else(|| crate::engine::error::EngineError::from_display("empty conjunction".to_string()))??;
                 for a in args {
                     result = result.conjunctive_to_disjunctive_de_morgen(a?)
                 }

--- a/crates/mneme/src/engine/query/mod.rs
+++ b/crates/mneme/src/engine/query/mod.rs
@@ -6,6 +6,7 @@
  * You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+pub(crate) mod error;
 pub(crate) mod compile;
 pub(crate) mod eval;
 pub(crate) mod graph;

--- a/crates/mneme/src/engine/query/ra.rs
+++ b/crates/mneme/src/engine/query/ra.rs
@@ -137,7 +137,7 @@ impl UnificationRA {
                     let result_list = result_list.get_slice().ok_or_else(|| {
                         
 
-                        crate::engine::error::AdhocError("Invalid spread unification".to_string())
+                        crate::engine::error::EngineError::from_display("Invalid spread unification".to_string())
                     })?;
                     let mut coll = vec![];
                     for result in result_list {
@@ -818,7 +818,7 @@ impl InlineFixedRA {
 }
 
 pub(crate) fn flatten_err<T>(
-    v: std::result::Result<Result<T>, crate::engine::error::BoxErr>,
+    v: std::result::Result<Result<T>, crate::engine::error::EngineError>,
 ) -> Result<T> {
     match v {
         Err(e) => Err(e),

--- a/crates/mneme/src/engine/query/stored.rs
+++ b/crates/mneme/src/engine/query/stored.rs
@@ -449,7 +449,7 @@ impl<'a> SessionTx<'a> {
                 .get(name, &manifest.tokenizer, &manifest.filters)?;
 
             let parsed = CozoScriptParser::parse(Rule::expr, &manifest.extractor)
-                .map_err(|e| crate::engine::error::AdhocError(e.to_string()))?
+                .map_err(|e| crate::engine::error::EngineError::from_display(e.to_string()))?
                 .next()
                 .unwrap();
             let mut code_expr = build_expr(parsed, &Default::default())?;
@@ -464,7 +464,7 @@ impl<'a> SessionTx<'a> {
                 .get(name, &manifest.tokenizer, &manifest.filters)?;
 
             let parsed = CozoScriptParser::parse(Rule::expr, &manifest.extractor)
-                .map_err(|e| crate::engine::error::AdhocError(e.to_string()))?
+                .map_err(|e| crate::engine::error::EngineError::from_display(e.to_string()))?
                 .next()
                 .unwrap();
             let mut code_expr = build_expr(parsed, &Default::default())?;
@@ -483,7 +483,7 @@ impl<'a> SessionTx<'a> {
         for (name, (_, manifest)) in relation_store.hnsw_indices.iter() {
             if let Some(f_code) = &manifest.index_filter {
                 let parsed = CozoScriptParser::parse(Rule::expr, f_code)
-                    .map_err(|e| crate::engine::error::AdhocError(e.to_string()))?
+                    .map_err(|e| crate::engine::error::EngineError::from_display(e.to_string()))?
                     .next()
                     .unwrap();
                 let mut code_expr = build_expr(parsed, &Default::default())?;
@@ -569,7 +569,7 @@ impl<'a> SessionTx<'a> {
                     })
                 }
                 Some(v) => rmp_serde::from_slice(&v[ENCODED_KEY_MIN_LEN..])
-                    .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)?,
+                    .map_err(|e| crate::engine::error::EngineError::from_display(e))?,
             };
             let mut old_kv = Vec::with_capacity(relation_store.arity());
             old_kv.extend_from_slice(&new_kv);
@@ -1077,10 +1077,10 @@ impl DataExtractor {
         Ok(match self {
             DataExtractor::DefaultExtractor(expr, typ) => typ
                 .coerce(expr.clone().eval_to_const()?, cur_vld)
-                .map_err(|e| crate::engine::error::AdhocError(format!("{e}: when processing tuple {tuple:?}")))?,
+                .map_err(|e| crate::engine::error::EngineError::from_display(format!("{e}: when processing tuple {tuple:?}")))?,
             DataExtractor::IndexExtractor(i, typ) => typ
                 .coerce(tuple[*i].clone(), cur_vld)
-                .map_err(|e| crate::engine::error::AdhocError(format!("{e}: when processing tuple {tuple:?}")))?,
+                .map_err(|e| crate::engine::error::EngineError::from_display(format!("{e}: when processing tuple {tuple:?}")))?,
         })
     }
 }
@@ -1137,7 +1137,7 @@ fn make_extractor(
         ))
     } else {
         
-        Err(Box::new(crate::engine::error::AdhocError("cannot make extractor for column".to_string())) as Box<dyn std::error::Error + Send + Sync + 'static>)
+        Err(crate::engine::error::EngineError::from_display("cannot make extractor for column"))
     }
 }
 

--- a/crates/mneme/src/engine/runtime/db.rs
+++ b/crates/mneme/src/engine/runtime/db.rs
@@ -191,31 +191,31 @@ impl NamedRows {
     pub fn from_json(value: &JsonValue) -> Result<Self> {
         let headers = value
             .get("headers")
-            .ok_or_else(|| crate::engine::error::AdhocError("NamedRows requires 'headers' field".to_string()))?;
+            .ok_or_else(|| crate::engine::error::EngineError::from_display("NamedRows requires 'headers' field".to_string()))?;
         let headers = headers
             .as_array()
-            .ok_or_else(|| crate::engine::error::AdhocError("'headers' field must be an array".to_string()))?;
+            .ok_or_else(|| crate::engine::error::EngineError::from_display("'headers' field must be an array".to_string()))?;
         let headers = headers
             .iter()
             .map(|h| -> Result<String> {
                 let h = h
                     .as_str()
-                    .ok_or_else(|| crate::engine::error::AdhocError("'headers' field must be an array of strings".to_string()))?;
+                    .ok_or_else(|| crate::engine::error::EngineError::from_display("'headers' field must be an array of strings".to_string()))?;
                 Ok(h.to_string())
             })
             .try_collect()?;
         let rows = value
             .get("rows")
-            .ok_or_else(|| crate::engine::error::AdhocError("NamedRows requires 'rows' field".to_string()))?;
+            .ok_or_else(|| crate::engine::error::EngineError::from_display("NamedRows requires 'rows' field".to_string()))?;
         let rows = rows
             .as_array()
-            .ok_or_else(|| crate::engine::error::AdhocError("'rows' field must be an array".to_string()))?;
+            .ok_or_else(|| crate::engine::error::EngineError::from_display("'rows' field must be an array".to_string()))?;
         let rows = rows
             .iter()
             .map(|row| -> Result<Vec<DataValue>> {
                 let row = row
                     .as_array()
-                    .ok_or_else(|| crate::engine::error::AdhocError("'rows' field must be an array of arrays".to_string()))?;
+                    .ok_or_else(|| crate::engine::error::EngineError::from_display("'rows' field must be an array of arrays".to_string()))?;
                 Ok(row.iter().map(DataValue::from).collect_vec())
             })
             .try_collect()?;
@@ -535,7 +535,7 @@ impl<'s, S: Storage<'s>> Db<S> {
                 .keys
                 .iter()
                 .map(|col| -> Result<(usize, &ColumnDef)> {
-                    let idx = header2idx.get(&col.name as &str).ok_or_else(|| crate::engine::error::AdhocError(format!("required header {} not found for relation {}",
+                    let idx = header2idx.get(&col.name as &str).ok_or_else(|| crate::engine::error::EngineError::from_display(format!("required header {} not found for relation {}",
                             col.name,
                             relation)))?;
                     Ok((*idx, col))
@@ -550,7 +550,7 @@ impl<'s, S: Storage<'s>> Db<S> {
                     .non_keys
                     .iter()
                     .map(|col| -> Result<(usize, &ColumnDef)> {
-                        let idx = header2idx.get(&col.name as &str).ok_or_else(|| crate::engine::error::AdhocError(format!("required header {} not found for relation {}",
+                        let idx = header2idx.get(&col.name as &str).ok_or_else(|| crate::engine::error::EngineError::from_display(format!("required header {} not found for relation {}",
                                 col.name,
                                 relation)))?;
                         Ok((*idx, col))
@@ -564,7 +564,7 @@ impl<'s, S: Storage<'s>> Db<S> {
                     .map(|(i, col)| -> Result<DataValue> {
                         let v = row
                             .get(*i)
-                            .ok_or_else(|| crate::engine::error::AdhocError(format!("row too short: {:?}", row)))?;
+                            .ok_or_else(|| crate::engine::error::EngineError::from_display(format!("row too short: {:?}", row)))?;
                         col.typing.coerce(v.clone(), cur_vld)
                     })
                     .try_collect()?;
@@ -592,7 +592,7 @@ impl<'s, S: Storage<'s>> Db<S> {
                         .map(|(i, col)| -> Result<DataValue> {
                             let v = row
                                 .get(*i)
-                                .ok_or_else(|| crate::engine::error::AdhocError(format!("row too short: {:?}", row)))?;
+                                .ok_or_else(|| crate::engine::error::EngineError::from_display(format!("row too short: {:?}", row)))?;
                             col.typing.coerce(v.clone(), cur_vld)
                         })
                         .try_collect()?;
@@ -1555,7 +1555,7 @@ impl<'s, S: Storage<'s>> Db<S> {
                             ""
                         },
                     )
-                    .map_err(|e| crate::engine::error::AdhocError(format!("{e}: when executing against relation '{}'", meta.name)))?;
+                    .map_err(|e| crate::engine::error::EngineError::from_display(format!("{e}: when executing against relation '{}'", meta.name)))?;
                 clean_ups.extend(to_clear);
                 let returned_rows =
                     tx.get_returning_rows(callback_collector, &meta.name, returning)?;
@@ -1611,7 +1611,7 @@ impl<'s, S: Storage<'s>> Db<S> {
                             ""
                         },
                     )
-                    .map_err(|e| crate::engine::error::AdhocError(format!("{e}: when executing against relation '{}'", meta.name)))?;
+                    .map_err(|e| crate::engine::error::EngineError::from_display(format!("{e}: when executing against relation '{}'", meta.name)))?;
                 clean_ups.extend(to_clear);
                 let returned_rows =
                     tx.get_returning_rows(callback_collector, &meta.name, returning)?;
@@ -1898,7 +1898,7 @@ pub(crate) fn seconds_since_the_epoch() -> Result<f64> {
     #[cfg(not(target_arch = "wasm32"))]
     return Ok(now
         .duration_since(UNIX_EPOCH)
-        .map_err(|e| crate::engine::error::AdhocError(e.to_string()))?
+        .map_err(|e| crate::engine::error::EngineError::from_display(e.to_string()))?
         .as_secs_f64());
 
     #[cfg(target_arch = "wasm32")]

--- a/crates/mneme/src/engine/runtime/error.rs
+++ b/crates/mneme/src/engine/runtime/error.rs
@@ -1,0 +1,33 @@
+use snafu::Snafu;
+
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub(crate)))]
+pub(crate) enum RuntimeError {
+    #[snafu(display("relation access error: {message}"))]
+    RelationAccess {
+        message: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("arity mismatch: {message}"))]
+    ArityMismatch {
+        message: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("transaction failed: {message}"))]
+    TransactionFailed {
+        message: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("{message}"))]
+    Internal {
+        message: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+}

--- a/crates/mneme/src/engine/runtime/hnsw.rs
+++ b/crates/mneme/src/engine/runtime/hnsw.rs
@@ -346,7 +346,7 @@ impl<'a> SessionTx<'a> {
                     };
                     let mut target_self_val: Vec<DataValue> =
                         rmp_serde::from_slice(&target_self_val_bytes[ENCODED_KEY_MIN_LEN..])
-                            .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)?;
+                            .map_err(|e| crate::engine::error::EngineError::from_display(e))?;
                     let mut target_degree = target_self_val[0].get_float().unwrap() as usize + 1; // INVARIANT: float stored by HNSW insert path
                     if target_degree > m_max {
                         // shrink links
@@ -461,7 +461,7 @@ impl<'a> SessionTx<'a> {
                     }
                 };
                 let old_existing_val: Vec<DataValue> =
-                    rmp_serde::from_slice(&old_existing_val[ENCODED_KEY_MIN_LEN..]).map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)?;
+                    rmp_serde::from_slice(&old_existing_val[ENCODED_KEY_MIN_LEN..]).map_err(|e| crate::engine::error::EngineError::from_display(e))?;
                 if old_existing_val[2].get_bool().unwrap() {
                     self.store_tx.del(&old_key_bytes)?;
                 } else {
@@ -828,7 +828,7 @@ impl<'a> SessionTx<'a> {
                     )?
                     .unwrap();
                 let mut neighbour_val: Vec<DataValue> =
-                    rmp_serde::from_slice(&neighbour_val_bytes[ENCODED_KEY_MIN_LEN..]).map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)?;
+                    rmp_serde::from_slice(&neighbour_val_bytes[ENCODED_KEY_MIN_LEN..]).map_err(|e| crate::engine::error::EngineError::from_display(e))?;
                 neighbour_val[0] = DataValue::from(neighbour_val[0].get_float().unwrap() - 1.); // INVARIANT: float stored by HNSW insert path
                 self.store_tx.put(
                     &idx_table.encode_key_for_store(&neighbour_self_key, Default::default())?,
@@ -970,7 +970,7 @@ impl<'a> SessionTx<'a> {
                 let mut cand_tuple = config
                     .base_handle
                     .get(self, &cand_key.0)?
-                    .ok_or_else(|| crate::engine::error::AdhocError("corrupted index".to_string()))?;
+                    .ok_or_else(|| crate::engine::error::EngineError::from_display("corrupted index".to_string()))?;
 
                 // make sure the order is the same as in all_bindings()!!!
                 if config.bind_field.is_some() {

--- a/crates/mneme/src/engine/runtime/minhash_lsh.rs
+++ b/crates/mneme/src/engine/runtime/minhash_lsh.rs
@@ -185,7 +185,7 @@ impl<'a> SessionTx<'a> {
             let orig_tuple = config
                 .base_handle
                 .get(self, &key)?
-                .ok_or_else(|| crate::engine::error::AdhocError("Tuple not found in base LSH relation".to_string()))?;
+                .ok_or_else(|| crate::engine::error::EngineError::from_display("Tuple not found in base LSH relation".to_string()))?;
             if let Some((filter_code, span)) = filter_code {
                 if !eval_bytecode_pred(filter_code, &orig_tuple, stack, *span)? {
                     continue;
@@ -311,7 +311,7 @@ impl HashPermutations {
     // this is the inverse of `as_bytes`
     pub(crate) fn from_bytes(bytes: &[u8]) -> Result<Self> {
         let perms: &[u32] = bytemuck::try_cast_slice(bytes)
-            .map_err(|e| crate::engine::error::AdhocError(format!("MinHash permutation bytes are misaligned: {e}")))?;
+            .map_err(|e| crate::engine::error::EngineError::from_display(format!("MinHash permutation bytes are misaligned: {e}")))?;
         Ok(Self(perms.to_vec()))
     }
 }

--- a/crates/mneme/src/engine/runtime/mod.rs
+++ b/crates/mneme/src/engine/runtime/mod.rs
@@ -6,6 +6,7 @@
  * You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+pub(crate) mod error;
 pub(crate) mod callback;
 pub(crate) mod db;
 pub(crate) mod imperative;

--- a/crates/mneme/src/engine/runtime/relation.rs
+++ b/crates/mneme/src/engine/runtime/relation.rs
@@ -339,6 +339,13 @@ impl Debug for RelationHandle {
 #[snafu(display("Cannot deserialize relation"))]
 pub(crate) struct RelationDeserError;
 
+impl From<RelationDeserError> for crate::engine::error::EngineError {
+    #[track_caller]
+    fn from(e: RelationDeserError) -> Self {
+        crate::engine::error::EngineError::from_display(e)
+    }
+}
+
 impl RelationHandle {
     pub(crate) fn arity(&self) -> usize {
         self.metadata.non_keys.len() + self.metadata.keys.len()
@@ -405,16 +412,16 @@ impl RelationHandle {
             tx.temp_store_tx
                 .get(&key_data, false)?
                 .map(|val_data| rmp_serde::from_slice::<Vec<DataValue>>(&val_data[ENCODED_KEY_MIN_LEN..])
-                    .map_err(|e| crate::engine::error::AdhocError(format!("failed to deserialize stored tuple: {e}"))))
+                    .map_err(|e| crate::engine::error::EngineError::from_display(format!("failed to deserialize stored tuple: {e}"))))
                 .transpose()
-                .map_err(|e| Box::new(e) as crate::engine::error::BoxErr)
+                .map_err(|e| crate::engine::error::EngineError::from_display(e))
         } else {
             tx.store_tx
                 .get(&key_data, false)?
                 .map(|val_data| rmp_serde::from_slice::<Vec<DataValue>>(&val_data[ENCODED_KEY_MIN_LEN..])
-                    .map_err(|e| crate::engine::error::AdhocError(format!("failed to deserialize stored tuple: {e}"))))
+                    .map_err(|e| crate::engine::error::EngineError::from_display(format!("failed to deserialize stored tuple: {e}"))))
                 .transpose()
-                .map_err(|e| Box::new(e) as crate::engine::error::BoxErr)
+                .map_err(|e| crate::engine::error::EngineError::from_display(e))
         }
     }
 
@@ -644,11 +651,11 @@ impl<'a> SessionTx<'a> {
         let found = if name.starts_with('_') {
             self.temp_store_tx
                 .get(&encoded, lock)?
-                .ok_or_else(|| crate::engine::error::AdhocError("Cannot find requested stored relation".to_string()))?
+                .ok_or_else(|| crate::engine::error::EngineError::from_display("Cannot find requested stored relation".to_string()))?
         } else {
             self.store_tx
                 .get(&encoded, lock)?
-                .ok_or_else(|| crate::engine::error::AdhocError("Cannot find requested stored relation".to_string()))?
+                .ok_or_else(|| crate::engine::error::EngineError::from_display("Cannot find requested stored relation".to_string()))?
         };
         let metadata = RelationHandle::decode(&found)?;
         Ok(metadata)
@@ -798,7 +805,7 @@ impl<'a> SessionTx<'a> {
             self.tokenizers
                 .get(&idx_handle.name, &manifest.tokenizer, &manifest.filters)?;
         let parsed = CozoScriptParser::parse(Rule::expr, &manifest.extractor)
-            .map_err(|e| crate::engine::error::AdhocError(e.to_string()))?
+            .map_err(|e| crate::engine::error::EngineError::from_display(e.to_string()))?
             .next()
             .unwrap();
         let mut code_expr = build_expr(parsed, &Default::default())?;
@@ -931,7 +938,7 @@ impl<'a> SessionTx<'a> {
                 .get(&idx_handle.name, &manifest.tokenizer, &manifest.filters)?;
 
         let parsed = CozoScriptParser::parse(Rule::expr, &manifest.extractor)
-            .map_err(|e| crate::engine::error::AdhocError(e.to_string()))?
+            .map_err(|e| crate::engine::error::EngineError::from_display(e.to_string()))?
             .next()
             .unwrap();
         let mut code_expr = build_expr(parsed, &Default::default())?;
@@ -1130,7 +1137,7 @@ impl<'a> SessionTx<'a> {
         }
         let filter = if let Some(f_code) = &manifest.index_filter {
             let parsed = CozoScriptParser::parse(Rule::expr, f_code)
-                .map_err(|e| crate::engine::error::AdhocError(e.to_string()))?
+                .map_err(|e| crate::engine::error::EngineError::from_display(e.to_string()))?
                 .next()
                 .unwrap();
             let mut code_expr = build_expr(parsed, &Default::default())?;

--- a/crates/mneme/src/engine/storage/error.rs
+++ b/crates/mneme/src/engine/storage/error.rs
@@ -1,0 +1,31 @@
+use snafu::Snafu;
+
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub(crate)))]
+pub(crate) enum StorageError {
+    #[snafu(display("write attempted in read transaction"))]
+    WriteInReadTx {
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("transaction already committed"))]
+    TransactionCommitted {
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("unsupported storage version: {version}"))]
+    UnsupportedVersion {
+        version: u64,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("{message}"))]
+    Internal {
+        message: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+}

--- a/crates/mneme/src/engine/storage/mod.rs
+++ b/crates/mneme/src/engine/storage/mod.rs
@@ -13,6 +13,7 @@ use crate::engine::data::tuple::Tuple;
 use crate::engine::data::value::ValidityTs;
 use crate::engine::runtime::relation::decode_tuple_from_kv;
 
+pub(crate) mod error;
 pub(crate) mod mem;
 pub(crate) mod temp;
 #[cfg(feature = "storage-new-rocksdb")]

--- a/crates/mneme/src/engine/storage/newrocks.rs
+++ b/crates/mneme/src/engine/storage/newrocks.rs
@@ -36,11 +36,11 @@ pub fn new_cozo_newrocksdb(path: impl AsRef<Path>) -> Result<Db<NewRocksDbStorag
     let manifest_path = path_buf.join("manifest");
     let is_new = if manifest_path.exists() {
         let manifest_bytes = fs::read(&manifest_path)
-            .map_err(|e| crate::engine::error::AdhocError(e.to_string()))
-            .map_err(|e| crate::engine::error::AdhocError(format!("failed to read manifest: {e}")))?;
+            .map_err(|e| crate::engine::error::EngineError::from_display(e.to_string()))
+            .map_err(|e| crate::engine::error::EngineError::from_display(format!("failed to read manifest: {e}")))?;
         let existing: DbManifest = rmp_serde::from_slice(&manifest_bytes)
-            .map_err(|e| crate::engine::error::AdhocError(e.to_string()))
-            .map_err(|e| crate::engine::error::AdhocError(format!("failed to parse manifest: {e}")))?;
+            .map_err(|e| crate::engine::error::EngineError::from_display(e.to_string()))
+            .map_err(|e| crate::engine::error::EngineError::from_display(format!("failed to parse manifest: {e}")))?;
 
         if existing.storage_version != CURRENT_STORAGE_VERSION {
             return Err(bail!(
@@ -54,24 +54,24 @@ pub fn new_cozo_newrocksdb(path: impl AsRef<Path>) -> Result<Db<NewRocksDbStorag
             storage_version: CURRENT_STORAGE_VERSION,
         };
         let manifest_bytes = rmp_serde::to_vec_named(&manifest)
-            .map_err(|e| crate::engine::error::AdhocError(e.to_string()))
-            .map_err(|e| crate::engine::error::AdhocError(format!("failed to serialize manifest: {e}")))?;
+            .map_err(|e| crate::engine::error::EngineError::from_display(e.to_string()))
+            .map_err(|e| crate::engine::error::EngineError::from_display(format!("failed to serialize manifest: {e}")))?;
         fs::write(&manifest_path, &manifest_bytes)
-            .map_err(|e| crate::engine::error::AdhocError(e.to_string()))
-            .map_err(|e| crate::engine::error::AdhocError(format!("failed to write manifest: {e}")))?;
+            .map_err(|e| crate::engine::error::EngineError::from_display(e.to_string()))
+            .map_err(|e| crate::engine::error::EngineError::from_display(format!("failed to write manifest: {e}")))?;
         true
     };
 
     let store_path = path_buf.join("data");
-    let store_path_str = store_path.to_str().ok_or(crate::engine::error::AdhocError("bad path name".to_string()))?;
+    let store_path_str = store_path.to_str().ok_or(crate::engine::error::EngineError::from_display("bad path name".to_string()))?;
 
     let mut options = Options::default();
     options.create_if_missing(is_new);
     // Add any necessary RocksDB options here
 
     let db = OptimisticTransactionDB::open(&options, store_path_str)
-        .map_err(|e| crate::engine::error::AdhocError(e.to_string()))
-        .map_err(|e| crate::engine::error::AdhocError(format!("Failed to open RocksDB: {e}")))?;
+        .map_err(|e| crate::engine::error::EngineError::from_display(e.to_string()))
+        .map_err(|e| crate::engine::error::EngineError::from_display(format!("Failed to open RocksDB: {e}")))?;
 
     let ret = Db::new(NewRocksDbStorage::new(db))?;
     ret.initialize()?;
@@ -119,7 +119,7 @@ impl<'s> Storage<'s> for NewRocksDbStorage {
         }
         self.db
             .write(batch)
-            .map_err(|e| crate::engine::error::AdhocError(e.to_string()))
+            .map_err(|e| crate::engine::error::EngineError::from_display(e.to_string()))
             .wrap_err_with(|| "Batch put failed")
     }
 }
@@ -142,11 +142,11 @@ impl<'s> StoreTx<'s> for NewRocksDbTx<'s> {
         let db_tx = self
             .db_tx
             .as_ref()
-            .ok_or_else(|| crate::engine::error::AdhocError("Transaction already committed".to_string()))?;
+            .ok_or_else(|| crate::engine::error::EngineError::from_display("Transaction already committed".to_string()))?;
 
         db_tx
             .get(key)
-            .map_err(|e| crate::engine::error::AdhocError(e.to_string()))
+            .map_err(|e| crate::engine::error::EngineError::from_display(e.to_string()))
             .wrap_err("failed to get value")
     }
 
@@ -154,11 +154,11 @@ impl<'s> StoreTx<'s> for NewRocksDbTx<'s> {
         let db_tx = self
             .db_tx
             .as_mut()
-            .ok_or_else(|| crate::engine::error::AdhocError("Transaction already committed".to_string()))?;
+            .ok_or_else(|| crate::engine::error::EngineError::from_display("Transaction already committed".to_string()))?;
 
         db_tx
             .put(key, val)
-            .map_err(|e| crate::engine::error::AdhocError(e.to_string()))
+            .map_err(|e| crate::engine::error::EngineError::from_display(e.to_string()))
             .wrap_err("failed to put value")
     }
 
@@ -171,9 +171,9 @@ impl<'s> StoreTx<'s> for NewRocksDbTx<'s> {
         match self.db_tx {
             Some(ref db_tx) => db_tx
                 .put(key, val)
-                .map_err(|e| crate::engine::error::AdhocError(e.to_string()))
+                .map_err(|e| crate::engine::error::EngineError::from_display(e.to_string()))
                 .wrap_err_with(|| "Parallel put failed"),
-            None => Err(crate::engine::error::AdhocError("Transaction already committed".to_string())),
+            None => Err(crate::engine::error::EngineError::from_display("Transaction already committed".to_string())),
         }
     }
 
@@ -182,9 +182,9 @@ impl<'s> StoreTx<'s> for NewRocksDbTx<'s> {
         match self.db_tx {
             Some(ref mut db_tx) => db_tx
                 .delete(key)
-                .map_err(|e| crate::engine::error::AdhocError(e.to_string()))
+                .map_err(|e| crate::engine::error::EngineError::from_display(e.to_string()))
                 .wrap_err_with(|| "Delete operation failed"),
-            None => Err(crate::engine::error::AdhocError("Transaction already committed".to_string())),
+            None => Err(crate::engine::error::EngineError::from_display("Transaction already committed".to_string())),
         }
     }
 
@@ -198,19 +198,19 @@ impl<'s> StoreTx<'s> for NewRocksDbTx<'s> {
                 ));
                 for item in iter {
                     let (k, _) = item
-                        .map_err(|e| crate::engine::error::AdhocError(e.to_string()))
-                        .map_err(|e| crate::engine::error::AdhocError(format!("{}: {e}", "Error iterating during range delete")))?;
+                        .map_err(|e| crate::engine::error::EngineError::from_display(e.to_string()))
+                        .map_err(|e| crate::engine::error::EngineError::from_display(format!("{}: {e}", "Error iterating during range delete")))?;
                     if k >= upper.into() {
                         break;
                     }
                     db_tx
                         .delete(&k)
-                        .map_err(|e| crate::engine::error::AdhocError(e.to_string()))
-                        .map_err(|e| crate::engine::error::AdhocError(format!("{}: {e}", "Error deleting during range delete")))?;
+                        .map_err(|e| crate::engine::error::EngineError::from_display(e.to_string()))
+                        .map_err(|e| crate::engine::error::EngineError::from_display(format!("{}: {e}", "Error deleting during range delete")))?;
                 }
                 Ok(())
             }
-            None => Err(crate::engine::error::AdhocError("Transaction already committed".to_string())),
+            None => Err(crate::engine::error::EngineError::from_display("Transaction already committed".to_string())),
         }
     }
 
@@ -219,10 +219,10 @@ impl<'s> StoreTx<'s> for NewRocksDbTx<'s> {
         let db_tx = self
             .db_tx
             .as_ref()
-            .ok_or(crate::engine::error::AdhocError("Transaction already committed".to_string()))?;
+            .ok_or(crate::engine::error::EngineError::from_display("Transaction already committed".to_string()))?;
         db_tx
             .get(key)
-            .map_err(|e| crate::engine::error::AdhocError(e.to_string()))
+            .map_err(|e| crate::engine::error::EngineError::from_display(e.to_string()))
             .wrap_err("Error during exists check")
             .map(|opt| opt.is_some())
     }
@@ -231,7 +231,7 @@ impl<'s> StoreTx<'s> for NewRocksDbTx<'s> {
         let db_tx = self.db_tx.take().expect("Transaction already committed");
         db_tx
             .commit()
-            .map_err(|e| crate::engine::error::AdhocError(e.to_string()))
+            .map_err(|e| crate::engine::error::EngineError::from_display(e.to_string()))
             .wrap_err_with(|| "Commit failed")
     }
 
@@ -311,7 +311,7 @@ impl<'s> StoreTx<'s> for NewRocksDbTx<'s> {
         let db_tx = self
             .db_tx
             .as_ref()
-            .ok_or(crate::engine::error::AdhocError("Transaction already committed".to_string()))?;
+            .ok_or(crate::engine::error::EngineError::from_display("Transaction already committed".to_string()))?;
         let iter = db_tx.iterator(rocksdb::IteratorMode::From(
             lower,
             rocksdb::Direction::Forward,
@@ -332,7 +332,7 @@ impl<'s> StoreTx<'s> for NewRocksDbTx<'s> {
         match self.db_tx {
             Some(ref db_tx) => Box::new(db_tx.iterator(rocksdb::IteratorMode::Start).map(|item| {
                 item.map(|(k, v)| (k.to_vec(), v.to_vec()))
-                    .map_err(|e| crate::engine::error::AdhocError(e.to_string()))
+                    .map_err(|e| crate::engine::error::EngineError::from_display(e.to_string()))
                     .wrap_err_with(|| "Error during total scan")
             })),
             None => Box::new(std::iter::once(Err(bail!(
@@ -359,7 +359,7 @@ impl<'a> Iterator for NewRocksDbIterator<'a> {
                     }
                     return Some(Ok(decode_tuple_from_kv(&k, &v, None)));
                 }
-                Err(e) => return Some(Err(crate::engine::error::AdhocError(format!("Iterator error: {}", e)))),
+                Err(e) => return Some(Err(crate::engine::error::EngineError::from_display(format!("Iterator error: {}", e)))),
             }
         }
         None
@@ -397,7 +397,7 @@ impl<'a> Iterator for NewRocksDbSkipIterator<'a> {
                         return Some(Ok(tup));
                     }
                 }
-                Some(Err(e)) => return Some(Err(crate::engine::error::AdhocError(format!("Iterator Error: {}", e)))),
+                Some(Err(e)) => return Some(Err(crate::engine::error::EngineError::from_display(format!("Iterator Error: {}", e)))),
             }
         }
     }
@@ -419,7 +419,7 @@ impl<'a> Iterator for NewRocksDbIteratorRaw<'a> {
                 }
                 Some(Ok((k.to_vec(), v.to_vec())))
             }
-            Some(Err(e)) => Some(Err(crate::engine::error::AdhocError(format!("Iterator error: {}", e)))),
+            Some(Err(e)) => Some(Err(crate::engine::error::EngineError::from_display(format!("Iterator error: {}", e)))),
             None => None,
         }
     }
@@ -434,7 +434,7 @@ mod tests {
     use tempfile::TempDir;
 
     fn setup_test_db() -> Result<(TempDir, Db<NewRocksDbStorage>)> {
-        let temp_dir = TempDir::new().map_err(|e| crate::engine::error::AdhocError(e.to_string()))?;
+        let temp_dir = TempDir::new().map_err(|e| crate::engine::error::EngineError::from_display(e.to_string()))?;
         let db = new_cozo_newrocksdb(temp_dir.path())?;
 
         // Create test tables with proper ScriptMutability parameter


### PR DESCRIPTION
## Summary

- Replace `BoxErr` (`Box<dyn Error>`) and `AdhocError` with structured `EngineError` enum using snafu
- Create 7 per-module error enums (`StorageError`, `DataError`, `FtsError`, `CozoParseError`, `QueryError`, `RuntimeError`, `FixedRuleError`) with `#[snafu(transparent)]` propagation
- Delete `convert_err()` — `EngineError` converts to public `Error` via `From` impl, pattern-matching `ProcessKilled` → `QueryKilled`
- Update `bail!`/`miette!`/`ensure!` macros to produce `EngineError::Internal` with `snafu::Location` tracking
- Add `From<InlineError> for EngineError` at each inline error type definition (~20 types)
- `DbResult<T>` now aliases `Result<T, EngineError>` instead of `Result<T, BoxErr>`

## Test plan

- [x] `cargo check -p aletheia-mneme --features mneme-engine` — zero errors
- [ ] `cargo test -p aletheia-mneme --features mneme-engine` — all pass
- [ ] `cargo clippy --workspace` — no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)