### PR TITLE
fix(mneme): SQL injection + lint hygiene

### DIFF
--- a/crates/mneme/src/backup.rs
+++ b/crates/mneme/src/backup.rs
@@ -8,6 +8,34 @@ use tracing::info;
 
 use crate::error::{self, Result};
 
+/// Validate a backup path contains only safe characters for SQL interpolation.
+///
+/// `SQLite` `VACUUM INTO` doesn't support parameter binding, so this is the
+/// only defense against path injection.
+fn validate_backup_path(path: &Path) -> Result<()> {
+    let path_str = path.to_str().ok_or_else(|| {
+        error::InvalidBackupPathSnafu {
+            path: path.to_string_lossy().into_owned(),
+        }
+        .build()
+    })?;
+
+    let has_safe_chars = path_str
+        .chars()
+        .all(|c| c.is_alphanumeric() || matches!(c, '-' | '_' | '.' | '/' | '\\' | ' '));
+
+    let has_sql_comment = path_str.contains("--");
+
+    snafu::ensure!(
+        has_safe_chars && !has_sql_comment,
+        error::InvalidBackupPathSnafu {
+            path: path_str.to_owned(),
+        }
+    );
+
+    Ok(())
+}
+
 /// Manages database backups and exports.
 pub struct BackupManager<'a> {
     conn: &'a Connection,
@@ -57,6 +85,7 @@ impl<'a> BackupManager<'a> {
         let timestamp = jiff::Timestamp::now().strftime("%Y%m%dT%H%M%S").to_string();
         let filename = format!("sessions_{timestamp}.db");
         let backup_path = self.backup_dir.join(&filename);
+        validate_backup_path(&backup_path)?;
 
         self.conn
             .execute(&format!("VACUUM INTO '{}'", backup_path.display()), [])
@@ -360,5 +389,47 @@ mod tests {
         let manager = BackupManager::new(&conn, "/nonexistent/path");
         let backups = manager.list_backups().unwrap();
         assert!(backups.is_empty());
+    }
+
+    #[test]
+    fn validate_rejects_single_quote() {
+        let path = Path::new("/tmp/it's-a-trap.db");
+        assert!(validate_backup_path(path).is_err());
+    }
+
+    #[test]
+    fn validate_rejects_semicolon() {
+        let path = Path::new("/tmp/backup;DROP TABLE sessions.db");
+        assert!(validate_backup_path(path).is_err());
+    }
+
+    #[test]
+    fn validate_rejects_backtick() {
+        let path = Path::new("/tmp/backup`cmd`.db");
+        assert!(validate_backup_path(path).is_err());
+    }
+
+    #[test]
+    fn validate_rejects_double_dash() {
+        let path = Path::new("/tmp/backup--comment.db");
+        assert!(validate_backup_path(path).is_err());
+    }
+
+    #[test]
+    fn validate_accepts_normal_path() {
+        let path = Path::new("/tmp/backup-2026-01-01.db");
+        assert!(validate_backup_path(path).is_ok());
+    }
+
+    #[test]
+    fn validate_accepts_path_with_spaces() {
+        let path = Path::new("/tmp/my backup.db");
+        assert!(validate_backup_path(path).is_ok());
+    }
+
+    #[test]
+    fn validate_accepts_dotted_path() {
+        let path = Path::new("/home/user/.config/backup.db");
+        assert!(validate_backup_path(path).is_ok());
     }
 }

--- a/crates/mneme/src/error.rs
+++ b/crates/mneme/src/error.rs
@@ -80,6 +80,15 @@ pub enum Error {
         location: snafu::Location,
     },
 
+    /// Backup path contains characters unsafe for SQL interpolation.
+    #[cfg(feature = "sqlite")]
+    #[snafu(display("invalid backup path: {path}"))]
+    InvalidBackupPath {
+        path: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
     /// Engine initialization failed.
     #[cfg(feature = "mneme-engine")]
     #[snafu(display("engine initialization failed: {message}"))]

--- a/crates/mneme/src/lib.rs
+++ b/crates/mneme/src/lib.rs
@@ -6,20 +6,19 @@
 //! Depends on `aletheia-koina` for types and errors.
 
 #[cfg(feature = "mneme-engine")]
-#[allow(
+#[expect(
     unsafe_code,
     dead_code,
     private_interfaces,
     unexpected_cfgs,
     unused_imports,
-    unreachable_code,
-    unused_variables,
     clippy::pedantic,
     clippy::mutable_key_type,
     clippy::type_complexity,
     clippy::too_many_arguments,
     clippy::non_canonical_partial_ord_impl,
-    clippy::neg_cmp_op_on_partial_ord
+    clippy::neg_cmp_op_on_partial_ord,
+    reason = "absorbed CozoDB engine code — refactoring deferred to Phase E"
 )]
 pub mod engine;
 


### PR DESCRIPTION
## Summary

- Add `validate_backup_path()` to reject unsafe characters before `VACUUM INTO` path interpolation in `backup.rs`. SQLite's `VACUUM INTO` doesn't support parameter binding, so character-level validation is the only defense against path injection.
- Add `InvalidBackupPath` error variant to `error.rs` (snafu pattern).
- Replace all `#[allow(lint)]` with `#[expect(lint, reason = "...")]` on the engine module in `lib.rs`. Removed `unreachable_code` and `unused_variables` (unfulfilled — those lints no longer fire).
- 7 new unit tests covering rejection of `'`, `;`, `` ` ``, `--` and acceptance of normal paths.

## Test plan

- [x] `cargo test -p aletheia-mneme` — 161 tests pass (including 7 new validation tests)
- [x] `cargo clippy -p aletheia-mneme --all-targets -- -D warnings` — zero warnings
- [x] `cargo check --workspace` — clean