### PR TITLE
feat(mneme): graph-algo default feature + relation type validation

### DIFF
--- a/crates/mneme/Cargo.toml
+++ b/crates/mneme/Cargo.toml
@@ -11,7 +11,8 @@ rust-version.workspace = true
 workspace = true
 
 [features]
-default = ["sqlite", "fastembed"]
+default = ["sqlite", "fastembed", "graph-algo"]
+graph-algo = []
 sqlite = ["dep:rusqlite", "dep:jiff"]
 fastembed = ["dep:fastembed"]
 # mneme-engine coexists with sqlite (no link conflict verified).

--- a/crates/mneme/src/extract.rs
+++ b/crates/mneme/src/extract.rs
@@ -293,10 +293,33 @@ Rules:
         }
 
         for rel in &extraction.relationships {
+            let relation_type = match crate::vocab::normalize_relation(&rel.relation) {
+                crate::vocab::RelationType::Valid(canonical) => canonical.to_owned(),
+                crate::vocab::RelationType::Rejected => {
+                    tracing::warn!(
+                        relation = %rel.relation,
+                        source = %rel.source,
+                        target = %rel.target,
+                        "rejected relationship with banned type"
+                    );
+                    result.relationships_skipped += 1;
+                    continue;
+                }
+                crate::vocab::RelationType::Unknown(normalized) => {
+                    tracing::warn!(
+                        relation = %normalized,
+                        raw = %rel.relation,
+                        source = %rel.source,
+                        target = %rel.target,
+                        "persisting relationship with unknown type"
+                    );
+                    normalized
+                }
+            };
             let r = Relationship {
                 src: slugify(&rel.source),
                 dst: slugify(&rel.target),
-                relation: rel.relation.clone(),
+                relation: relation_type,
                 weight: rel.confidence,
                 created_at: now.clone(),
             };
@@ -352,6 +375,8 @@ pub struct PersistResult {
     pub entities_inserted: usize,
     /// Number of relationships written.
     pub relationships_inserted: usize,
+    /// Number of relationships skipped due to validation.
+    pub relationships_skipped: usize,
     /// Number of facts written.
     pub facts_inserted: usize,
 }
@@ -632,6 +657,7 @@ mod tests {
             .unwrap();
         assert_eq!(result.entities_inserted, 2);
         assert_eq!(result.relationships_inserted, 1);
+        assert_eq!(result.relationships_skipped, 0);
         assert_eq!(result.facts_inserted, 1);
 
         // Verify entities are queryable via entity_neighborhood.
@@ -650,5 +676,154 @@ mod tests {
             facts.iter().any(|f| f.content.contains("CozoDB")),
             "persisted fact should be retrievable"
         );
+    }
+
+    #[cfg(feature = "mneme-engine")]
+    #[test]
+    fn persist_skips_relates_to() {
+        let store = crate::knowledge_store::KnowledgeStore::open_mem().unwrap();
+        let engine = ExtractionEngine::new(ExtractionConfig::default());
+
+        let extraction = Extraction {
+            entities: vec![
+                ExtractedEntity {
+                    name: "Alice".to_owned(),
+                    entity_type: "person".to_owned(),
+                    description: String::new(),
+                },
+                ExtractedEntity {
+                    name: "Bob".to_owned(),
+                    entity_type: "person".to_owned(),
+                    description: String::new(),
+                },
+            ],
+            relationships: vec![ExtractedRelationship {
+                source: "Alice".to_owned(),
+                relation: "RELATES_TO".to_owned(),
+                target: "Bob".to_owned(),
+                confidence: 0.8,
+            }],
+            facts: vec![],
+        };
+
+        let result = engine
+            .persist(&extraction, &store, "session:test", "syn")
+            .unwrap();
+        assert_eq!(result.relationships_inserted, 0);
+        assert_eq!(result.relationships_skipped, 1);
+    }
+
+    #[cfg(feature = "mneme-engine")]
+    #[test]
+    fn persist_normalizes_relation_type() {
+        let store = crate::knowledge_store::KnowledgeStore::open_mem().unwrap();
+        let engine = ExtractionEngine::new(ExtractionConfig::default());
+
+        let extraction = Extraction {
+            entities: vec![
+                ExtractedEntity {
+                    name: "Alice".to_owned(),
+                    entity_type: "person".to_owned(),
+                    description: String::new(),
+                },
+                ExtractedEntity {
+                    name: "Acme".to_owned(),
+                    entity_type: "project".to_owned(),
+                    description: String::new(),
+                },
+            ],
+            relationships: vec![ExtractedRelationship {
+                source: "Alice".to_owned(),
+                relation: "works on".to_owned(),
+                target: "Acme".to_owned(),
+                confidence: 0.9,
+            }],
+            facts: vec![],
+        };
+
+        let result = engine
+            .persist(&extraction, &store, "session:test", "syn")
+            .unwrap();
+        assert_eq!(result.relationships_inserted, 1);
+        assert_eq!(result.relationships_skipped, 0);
+
+        let neighborhood = store.entity_neighborhood("alice").unwrap();
+        assert!(
+            neighborhood
+                .rows
+                .iter()
+                .any(|row| row.iter().any(|v| v.get_str() == Some("WORKS_AT"))),
+            "relationship should be stored as normalized WORKS_AT"
+        );
+    }
+
+    #[cfg(feature = "mneme-engine")]
+    #[test]
+    fn persist_accepts_unknown_type() {
+        let store = crate::knowledge_store::KnowledgeStore::open_mem().unwrap();
+        let engine = ExtractionEngine::new(ExtractionConfig::default());
+
+        let extraction = Extraction {
+            entities: vec![
+                ExtractedEntity {
+                    name: "Alice".to_owned(),
+                    entity_type: "person".to_owned(),
+                    description: String::new(),
+                },
+                ExtractedEntity {
+                    name: "Bob".to_owned(),
+                    entity_type: "person".to_owned(),
+                    description: String::new(),
+                },
+            ],
+            relationships: vec![ExtractedRelationship {
+                source: "Alice".to_owned(),
+                relation: "MENTORS".to_owned(),
+                target: "Bob".to_owned(),
+                confidence: 0.7,
+            }],
+            facts: vec![],
+        };
+
+        let result = engine
+            .persist(&extraction, &store, "session:test", "syn")
+            .unwrap();
+        assert_eq!(result.relationships_inserted, 1);
+        assert_eq!(result.relationships_skipped, 0);
+    }
+
+    #[cfg(feature = "mneme-engine")]
+    #[test]
+    fn persist_skips_is_type() {
+        let store = crate::knowledge_store::KnowledgeStore::open_mem().unwrap();
+        let engine = ExtractionEngine::new(ExtractionConfig::default());
+
+        let extraction = Extraction {
+            entities: vec![
+                ExtractedEntity {
+                    name: "Rust".to_owned(),
+                    entity_type: "tool".to_owned(),
+                    description: String::new(),
+                },
+                ExtractedEntity {
+                    name: "Language".to_owned(),
+                    entity_type: "concept".to_owned(),
+                    description: String::new(),
+                },
+            ],
+            relationships: vec![ExtractedRelationship {
+                source: "Rust".to_owned(),
+                relation: "is".to_owned(),
+                target: "Language".to_owned(),
+                confidence: 0.9,
+            }],
+            facts: vec![],
+        };
+
+        let result = engine
+            .persist(&extraction, &store, "session:test", "syn")
+            .unwrap();
+        assert_eq!(result.relationships_inserted, 0);
+        assert_eq!(result.relationships_skipped, 1);
     }
 }

--- a/crates/mneme/src/lib.rs
+++ b/crates/mneme/src/lib.rs
@@ -64,6 +64,8 @@ pub mod schema;
 pub mod store;
 /// Core types for sessions, messages, usage records, and agent notes.
 pub mod types;
+/// Controlled relationship type vocabulary for knowledge graph validation.
+pub mod vocab;
 
 #[cfg(all(test, feature = "sqlite"))]
 mod assertions {

--- a/crates/mneme/src/vocab.rs
+++ b/crates/mneme/src/vocab.rs
@@ -1,0 +1,278 @@
+//! Controlled relationship type vocabulary for knowledge graph extraction.
+
+/// Result of normalizing a raw relationship type against the controlled vocabulary.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RelationType {
+    /// Matched a known vocabulary type (canonical uppercase form).
+    Valid(&'static str),
+    /// Matched a rejected type — must not be persisted.
+    Rejected,
+    /// No match in vocabulary or rejected list — caller decides whether to persist.
+    Unknown(String),
+}
+
+/// Relationship types that must never enter the knowledge graph.
+/// INVARIANT: `RELATES_TO` eliminated in vocab redesign — see `semantic-invariants.md`
+const REJECTED_TYPES: &[&str] = &["RELATES_TO", "IS"];
+
+/// Controlled vocabulary — mirrors Python `vocab.py` `_HARDCODED_VOCAB`.
+const CONTROLLED_VOCAB: &[&str] = &[
+    "COMMUNICATES_VIA",
+    "COMPATIBLE_WITH",
+    "CONFIGURED_WITH",
+    "CONNECTED_TO",
+    "CREATED",
+    "DEPENDS_ON",
+    "DIAGNOSED_WITH",
+    "INSTALLED_ON",
+    "INTERESTED_IN",
+    "KNOWS",
+    "LIVES_IN",
+    "LOCATED_IN",
+    "MAINTAINS",
+    "MANAGES",
+    "MEMBER_OF",
+    "OWNS",
+    "PART_OF",
+    "PREFERS",
+    "PRESCRIBED",
+    "RUNS_ON",
+    "SCHEDULED_FOR",
+    "SERVES",
+    "SKILLED_IN",
+    "STUDIES",
+    "TREATS",
+    "USES",
+    "VEHICLE_IS",
+    "WORKS_AT",
+];
+
+/// Normalize a raw relationship string and classify it.
+///
+/// 1. Trim, uppercase, replace spaces/hyphens with underscores.
+/// 2. Check rejected list → `Rejected`.
+/// 3. Check controlled vocabulary → `Valid`.
+/// 4. Check alias map → `Valid` (mapped canonical form).
+/// 5. Otherwise → `Unknown` (uppercased form returned for caller to decide).
+pub fn normalize_relation(raw: &str) -> RelationType {
+    let normalized: String = raw
+        .trim()
+        .to_uppercase()
+        .chars()
+        .map(|c| if c == ' ' || c == '-' { '_' } else { c })
+        .collect();
+
+    if REJECTED_TYPES.contains(&normalized.as_str()) {
+        return RelationType::Rejected;
+    }
+
+    if CONTROLLED_VOCAB.contains(&normalized.as_str()) {
+        return RelationType::Valid(
+            CONTROLLED_VOCAB
+                .iter()
+                .find(|&&v| v == normalized)
+                .expect("just checked contains"),
+        );
+    }
+
+    if let Some(mapped) = lookup_alias(&normalized) {
+        return RelationType::Valid(mapped);
+    }
+
+    // Also try the lowercase form against the alias map (handles "works on" → "works_on")
+    let lower = normalized.to_lowercase();
+    if let Some(mapped) = lookup_alias(&lower) {
+        return RelationType::Valid(mapped);
+    }
+
+    RelationType::Unknown(normalized)
+}
+
+/// Alias map mirroring Python `vocab.py` `TYPE_MAP`.
+fn lookup_alias(key: &str) -> Option<&'static str> {
+    match key {
+        "has" | "HAS" | "has_a" | "HAS_A" => Some("OWNS"),
+        "is_part_of" | "IS_PART_OF" | "part_of" | "PART_OF" => {
+            Some(vocab_entry("PART_OF"))
+        }
+        "works_at" | "WORKS_AT" | "works_on" | "WORKS_ON" => {
+            Some(vocab_entry("WORKS_AT"))
+        }
+        "lives_in" | "LIVES_IN" => Some(vocab_entry("LIVES_IN")),
+        "located_in" | "LOCATED_IN" | "located_at" | "LOCATED_AT" => {
+            Some(vocab_entry("LOCATED_IN"))
+        }
+        "uses" | "USES" | "used_by" | "USED_BY" | "used_for" | "USED_FOR" => {
+            Some(vocab_entry("USES"))
+        }
+        "runs_on" | "RUNS_ON" | "runs" | "RUNS" => Some(vocab_entry("RUNS_ON")),
+        "depends_on" | "DEPENDS_ON" | "requires" | "REQUIRES" => {
+            Some(vocab_entry("DEPENDS_ON"))
+        }
+        "knows" | "KNOWS" | "knows_about" | "KNOWS_ABOUT" | "knows_of" | "KNOWS_OF" => {
+            Some(vocab_entry("KNOWS"))
+        }
+        "prefers" | "PREFERS" | "likes" | "LIKES" => Some(vocab_entry("PREFERS")),
+        "interested_in" | "INTERESTED_IN" => Some(vocab_entry("INTERESTED_IN")),
+        "studies" | "STUDIES" | "studying" | "STUDYING" => Some(vocab_entry("STUDIES")),
+        "created" | "CREATED" | "created_by" | "CREATED_BY" | "built" | "BUILT" | "made"
+        | "MADE" => Some(vocab_entry("CREATED")),
+        "maintains" | "MAINTAINS" => Some(vocab_entry("MAINTAINS")),
+        "managed_by" | "MANAGED_BY" | "manages" | "MANAGES" => {
+            Some(vocab_entry("MANAGES"))
+        }
+        "member_of" | "MEMBER_OF" | "belongs_to" | "BELONGS_TO" => {
+            Some(vocab_entry("MEMBER_OF"))
+        }
+        "skilled_in" | "SKILLED_IN" | "skilled_at" | "SKILLED_AT" => {
+            Some(vocab_entry("SKILLED_IN"))
+        }
+        "owns" | "OWNS" => Some(vocab_entry("OWNS")),
+        "installed_on" | "INSTALLED_ON" | "installed" | "INSTALLED" => {
+            Some(vocab_entry("INSTALLED_ON"))
+        }
+        "compatible_with" | "COMPATIBLE_WITH" => Some(vocab_entry("COMPATIBLE_WITH")),
+        "connected_to" | "CONNECTED_TO" => Some(vocab_entry("CONNECTED_TO")),
+        "communicates_via" | "COMMUNICATES_VIA" => Some(vocab_entry("COMMUNICATES_VIA")),
+        "configured_with" | "CONFIGURED_WITH" => Some(vocab_entry("CONFIGURED_WITH")),
+        "serves" | "SERVES" => Some(vocab_entry("SERVES")),
+        "diagnosed_with" | "DIAGNOSED_WITH" => Some(vocab_entry("DIAGNOSED_WITH")),
+        "prescribed" | "PRESCRIBED" => Some(vocab_entry("PRESCRIBED")),
+        "treats" | "TREATS" => Some(vocab_entry("TREATS")),
+        "scheduled_for" | "SCHEDULED_FOR" => Some(vocab_entry("SCHEDULED_FOR")),
+        "vehicle_is" | "VEHICLE_IS" => Some(vocab_entry("VEHICLE_IS")),
+        _ => None,
+    }
+}
+
+/// Return a `&'static str` from `CONTROLLED_VOCAB` for a known key.
+fn vocab_entry(key: &str) -> &'static str {
+    CONTROLLED_VOCAB
+        .iter()
+        .find(|&&v| v == key)
+        .expect("vocab_entry called with key not in CONTROLLED_VOCAB")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn relates_to_rejected() {
+        assert_eq!(normalize_relation("RELATES_TO"), RelationType::Rejected);
+    }
+
+    #[test]
+    fn is_rejected() {
+        assert_eq!(normalize_relation("IS"), RelationType::Rejected);
+    }
+
+    #[test]
+    fn relates_to_lowercase_rejected() {
+        assert_eq!(normalize_relation("relates_to"), RelationType::Rejected);
+    }
+
+    #[test]
+    fn relates_to_spaces_rejected() {
+        assert_eq!(normalize_relation("relates to"), RelationType::Rejected);
+    }
+
+    #[test]
+    fn knows_valid() {
+        assert_eq!(normalize_relation("KNOWS"), RelationType::Valid("KNOWS"));
+    }
+
+    #[test]
+    fn works_at_valid() {
+        assert_eq!(
+            normalize_relation("WORKS_AT"),
+            RelationType::Valid("WORKS_AT")
+        );
+    }
+
+    #[test]
+    fn works_on_alias() {
+        assert_eq!(
+            normalize_relation("works on"),
+            RelationType::Valid("WORKS_AT")
+        );
+    }
+
+    #[test]
+    fn has_maps_to_owns() {
+        assert_eq!(normalize_relation("has"), RelationType::Valid("OWNS"));
+    }
+
+    #[test]
+    fn connected_to_valid() {
+        assert_eq!(
+            normalize_relation("CONNECTED_TO"),
+            RelationType::Valid("CONNECTED_TO")
+        );
+    }
+
+    #[test]
+    fn unknown_type() {
+        assert_eq!(
+            normalize_relation("SOME_NEW_TYPE"),
+            RelationType::Unknown("SOME_NEW_TYPE".to_owned())
+        );
+    }
+
+    #[test]
+    fn member_of_alias() {
+        assert_eq!(
+            normalize_relation("member of"),
+            RelationType::Valid("MEMBER_OF")
+        );
+    }
+
+    #[test]
+    fn hyphenated_alias() {
+        assert_eq!(
+            normalize_relation("works-at"),
+            RelationType::Valid("WORKS_AT")
+        );
+    }
+
+    #[test]
+    fn case_insensitive() {
+        assert_eq!(normalize_relation("knows"), RelationType::Valid("KNOWS"));
+    }
+
+    #[test]
+    fn whitespace_trimmed() {
+        assert_eq!(
+            normalize_relation("  KNOWS  "),
+            RelationType::Valid("KNOWS")
+        );
+    }
+
+    #[test]
+    fn controlled_vocab_excludes_relates_to() {
+        assert!(!CONTROLLED_VOCAB.contains(&"RELATES_TO"));
+    }
+
+    #[test]
+    fn all_vocab_entries_are_uppercase() {
+        for entry in CONTROLLED_VOCAB {
+            assert_eq!(*entry, entry.to_uppercase(), "{entry} is not uppercase");
+        }
+    }
+
+    #[test]
+    fn created_by_alias() {
+        assert_eq!(
+            normalize_relation("created by"),
+            RelationType::Valid("CREATED")
+        );
+    }
+
+    #[test]
+    fn depends_on_alias() {
+        assert_eq!(
+            normalize_relation("depends on"),
+            RelationType::Valid("DEPENDS_ON")
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Declare `graph-algo = []` feature and add to defaults in `crates/mneme/Cargo.toml` — 31 cfg guards across 3 files now compile when `mneme-engine` is active
- New `vocab` module with controlled vocabulary (27 types mirroring Python `vocab.py`), rejected set (`RELATES_TO`, `IS`), and alias normalization
- Validation integrated into `extract.rs` `persist()` — rejected types skipped, known types normalized, unknown types accepted with warning (soft constraint)
- 19 vocab unit tests + 4 persist integration tests

## Notes

- **cfg guard count:** 31 across 3 files (27 `fixed_rule/mod.rs`, 3 `strongly_connected_components.rs`, 1 `runtime/tests.rs`) — prompt predicted 32
- **Vocab discrepancy:** prompt suggested rejecting `CONNECTED_TO` and `HAS`, but Python `vocab.py` (the source of truth per prompt instructions) has `CONNECTED_TO` in `CONTROLLED_VOCAB` and maps `HAS` → `OWNS`. Implementation follows Python for cross-layer consistency.

## Test plan

- [x] `cargo test -p aletheia-mneme` — 172 tests pass (default features)
- [x] `cargo test -p aletheia-mneme --no-default-features --lib` — 88 tests pass
- [x] `cargo clippy -p aletheia-mneme --all-targets -- -D warnings` — clean
- [x] `cargo check -p aletheia-nous -p aletheia-organon` — downstream crates compile