### PR TITLE
feat(mneme): restore Db facade methods and extract category constant

### DIFF
--- a/crates/integration-tests/tests/engine_facade.rs
+++ b/crates/integration-tests/tests/engine_facade.rs
@@ -1,0 +1,67 @@
+//! Integration tests for the public `Db` facade: delegated methods and error behavior.
+#![cfg(feature = "engine-tests")]
+
+use std::collections::BTreeMap;
+
+use aletheia_mneme::engine::{DataValue, Db, ScriptMutability};
+
+#[test]
+fn run_read_only_returns_data() {
+    let db = Db::open_mem().expect("open mem");
+    db.run(
+        ":create test { k: String => v: Int }",
+        BTreeMap::new(),
+        ScriptMutability::Mutable,
+    )
+    .expect("create relation");
+    db.run(
+        "?[k, v] <- [['alice', 42]] :put test { k => v }",
+        BTreeMap::new(),
+        ScriptMutability::Mutable,
+    )
+    .expect("insert");
+
+    let result = db
+        .run_read_only("?[k, v] := *test[k, v]", BTreeMap::new())
+        .expect("read-only query");
+
+    assert_eq!(result.rows.len(), 1);
+    assert_eq!(result.rows[0][0], DataValue::Str("alice".into()));
+    assert_eq!(result.rows[0][1], DataValue::from(42i64));
+}
+
+#[test]
+fn backup_db_returns_unsupported_error() {
+    let db = Db::open_mem().expect("open mem");
+    let result = db.backup_db("/tmp/nonexistent.db");
+    assert!(result.is_err());
+    let msg = result.unwrap_err().to_string();
+    assert!(
+        msg.contains("storage-sqlite"),
+        "expected mention of storage-sqlite, got: {msg}"
+    );
+}
+
+#[test]
+fn restore_backup_returns_unsupported_error() {
+    let db = Db::open_mem().expect("open mem");
+    let result = db.restore_backup("/tmp/nonexistent.db");
+    assert!(result.is_err());
+    let msg = result.unwrap_err().to_string();
+    assert!(
+        msg.contains("storage-sqlite"),
+        "expected mention of storage-sqlite, got: {msg}"
+    );
+}
+
+#[test]
+fn import_from_backup_returns_unsupported_error() {
+    let db = Db::open_mem().expect("open mem");
+    let result = db.import_from_backup("/tmp/nonexistent.db", &[]);
+    assert!(result.is_err());
+    let msg = result.unwrap_err().to_string();
+    assert!(
+        msg.contains("storage-sqlite"),
+        "expected mention of storage-sqlite, got: {msg}"
+    );
+}

--- a/crates/mneme/src/engine/mod.rs
+++ b/crates/mneme/src/engine/mod.rs
@@ -1,7 +1,6 @@
 // aletheia-mneme-engine -- embedded Datalog + HNSW + graph engine for Aletheia
 
 use std::collections::BTreeMap;
-#[cfg(any(feature = "storage-redb", feature = "storage-new-rocksdb"))]
 use std::path::Path;
 
 use crossbeam::channel::{Receiver, Sender, bounded};
@@ -105,6 +104,64 @@ impl Db {
             Db::Redb(db) => db.run_script(script, params, mutability),
             #[cfg(feature = "storage-new-rocksdb")]
             Db::RocksDb(db) => db.run_script(script, params, mutability),
+        };
+        result.map_err(convert_err)
+    }
+
+    /// Execute a Datalog script in read-only mode.
+    pub fn run_read_only(
+        &self,
+        script: &str,
+        params: BTreeMap<String, DataValue>,
+    ) -> crate::engine::Result<NamedRows> {
+        self.run(script, params, ScriptMutability::Immutable)
+    }
+
+    /// Backup the running database into an SQLite file.
+    ///
+    /// Not currently supported — requires the removed `storage-sqlite` feature.
+    pub fn backup_db(&self, out_file: impl AsRef<Path>) -> crate::engine::Result<()> {
+        let path = out_file.as_ref();
+        let result = match self {
+            Db::Mem(db) => db.backup_db(path),
+            #[cfg(feature = "storage-redb")]
+            Db::Redb(db) => db.backup_db(path),
+            #[cfg(feature = "storage-new-rocksdb")]
+            Db::RocksDb(db) => db.backup_db(path),
+        };
+        result.map_err(convert_err)
+    }
+
+    /// Restore from an SQLite backup.
+    ///
+    /// Not currently supported — requires the removed `storage-sqlite` feature.
+    pub fn restore_backup(&self, in_file: impl AsRef<Path>) -> crate::engine::Result<()> {
+        let path = in_file.as_ref();
+        let result = match self {
+            Db::Mem(db) => db.restore_backup(path),
+            #[cfg(feature = "storage-redb")]
+            Db::Redb(db) => db.restore_backup(path),
+            #[cfg(feature = "storage-new-rocksdb")]
+            Db::RocksDb(db) => db.restore_backup(path),
+        };
+        result.map_err(convert_err)
+    }
+
+    /// Import data from relations in a backup file.
+    ///
+    /// Not currently supported — requires the removed `storage-sqlite` feature.
+    pub fn import_from_backup(
+        &self,
+        in_file: impl AsRef<Path>,
+        relations: &[String],
+    ) -> crate::engine::Result<()> {
+        let path = in_file.as_ref();
+        let result = match self {
+            Db::Mem(db) => db.import_from_backup(path, relations),
+            #[cfg(feature = "storage-redb")]
+            Db::Redb(db) => db.import_from_backup(path, relations),
+            #[cfg(feature = "storage-new-rocksdb")]
+            Db::RocksDb(db) => db.import_from_backup(path, relations),
         };
         result.map_err(convert_err)
     }

--- a/crates/mneme/src/import.rs
+++ b/crates/mneme/src/import.rs
@@ -243,7 +243,7 @@ fn import_sessions(
         }
 
         // Import notes
-        let valid_categories = ["task", "decision", "preference", "correction", "context"];
+        let valid_categories = crate::schema::VALID_CATEGORIES;
         for note in &exported.notes {
             let category = if valid_categories.contains(&note.category.as_str()) {
                 &note.category

--- a/crates/mneme/src/schema.rs
+++ b/crates/mneme/src/schema.rs
@@ -3,6 +3,9 @@
 //! The DDL is the v1 baseline. Migration management lives in `migration.rs`.
 //! This matches the TS schema exactly for wire-compatible databases.
 
+/// Valid agent note categories. Single source of truth — used by DDL CHECK constraint and import validation.
+pub const VALID_CATEGORIES: &[&str] = &["task", "decision", "preference", "correction", "context"];
+
 /// Base DDL — creates all tables for a fresh database (migration v1).
 pub const DDL: &str = r"
 CREATE TABLE IF NOT EXISTS sessions (
@@ -97,6 +100,7 @@ mod tests {
     use rusqlite::Connection;
 
     use crate::migration;
+    use crate::schema::{DDL, VALID_CATEGORIES};
 
     #[test]
     fn fresh_database_initializes_via_migration() {
@@ -136,6 +140,35 @@ mod tests {
                 )
                 .unwrap();
             assert!(exists, "table {table} should exist");
+        }
+    }
+
+    #[test]
+    fn valid_categories_matches_ddl_check_constraint() {
+        let marker = "CHECK(category IN (";
+        let start = DDL.find(marker).expect("CHECK constraint for category exists in DDL");
+        let inner_start = start + marker.len();
+        let inner_end = DDL[inner_start..]
+            .find("))")
+            .expect("closing parens for CHECK constraint")
+            + inner_start;
+        let inner = &DDL[inner_start..inner_end];
+
+        let ddl_cats: Vec<&str> = inner.split(", ").map(|s| s.trim_matches('\'')).collect();
+
+        assert_eq!(
+            ddl_cats.len(),
+            VALID_CATEGORIES.len(),
+            "DDL has {} categories but VALID_CATEGORIES has {}: DDL={ddl_cats:?}, const={VALID_CATEGORIES:?}",
+            ddl_cats.len(),
+            VALID_CATEGORIES.len(),
+        );
+
+        for cat in VALID_CATEGORIES {
+            assert!(
+                ddl_cats.contains(cat),
+                "VALID_CATEGORIES has '{cat}' but it is missing from DDL CHECK constraint"
+            );
         }
     }
 }


### PR DESCRIPTION
## Summary

- Expose `run_read_only`, `backup_db`, `restore_backup`, and `import_from_backup` on the public `Db` enum facade, delegating to inner engine types
- Extract `VALID_CATEGORIES` constant in `schema.rs` as single source of truth for agent note categories, replacing the hardcoded list in `import.rs`
- Add integration tests for all new facade methods and a sync test ensuring `VALID_CATEGORIES` matches the DDL CHECK constraint

## Test plan

- [x] `cargo test -p aletheia-mneme` — 155 tests pass
- [x] `cargo test -p aletheia-integration-tests --features engine-tests` — all pass including 4 new `engine_facade` tests
- [x] `cargo clippy -p aletheia-mneme --all-targets -- -D warnings` — clean
- [x] `cargo check -p aletheia-nous -p aletheia-organon -p aletheia-pylon` — downstream crates compile

🤖 Generated with [Claude Code](https://claude.com/claude-code)