### PR TITLE
docs(mneme): correct embedding model, feature flags, and dependency list

### DIFF
--- a/docs/ARCHITECTURE-GUIDE.md
+++ b/docs/ARCHITECTURE-GUIDE.md
@@ -78,7 +78,7 @@ Crates are organized in layers. Lower layers know nothing about higher layers.
 - **taxis** — configuration and paths. Loads the YAML config cascade (figment), resolves the oikos instance directory structure.
 - **hermeneus** — LLM provider abstraction. The Anthropic streaming client lives here. Handles retries, cost tracking, model routing.
 - **symbolon** — authentication: JWT tokens, bearer validation, RBAC. Depends on koina; uses its own SQLite for token storage.
-- **mneme** — memory engine. SQLite session store, embedded CozoDB for knowledge graphs and vector search, fastembed-rs for local embeddings, LLM-driven fact extraction.
+- **mneme** — memory engine. SQLite session store, vendored Datalog engine for knowledge graphs and vector search, fastembed-rs for local embeddings, LLM-driven fact extraction.
 
 ### Mid (depends on lower layers)
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -20,11 +20,13 @@ Module and crate names use Greek terms reflecting their purpose (nous = mind, mn
 aletheia
 ├── koina         — errors, tracing, safe wrappers, fs utils
 ├── taxis         — config, path resolution, oikos hierarchy, secret refs
-├── mneme         — unified memory (CozoDB embedded + fastembed-rs + extraction)
-│   ├── store     — CozoDB: vectors, graph, relations, bi-temporal facts — single embedded DB
-│   ├── embed     — EmbeddingProvider trait: fastembed-rs (local default) | HTTP API (Voyage, optional)
-│   ├── extract   — LLM-driven fact extraction, entity resolution, contradiction detection
-│   └── recall    — hybrid retrieval (vector + graph + BM25), MMR diversity, recollection-as-memory
+├── mneme         — session store (SQLite) + knowledge engine (vendored Datalog) + fastembed-rs
+│   ├── store     — SQLite session store: WAL, migrations, retention
+│   ├── knowledge — Datalog knowledge graph, HNSW vectors, entity relations
+│   ├── embedding — EmbeddingProvider trait: fastembed-rs (local default)
+│   ├── extract   — LLM-driven fact extraction, entity resolution
+│   ├── recall    — hybrid retrieval (vector + graph + BM25), MMR diversity
+│   └── engine/   — vendored Datalog + HNSW engine (mneme-engine feature gate)
 ├── hermeneus     — Anthropic client, model routing, credentials, provider trait
 ├── organon       — tool registry + built-in tools
 ├── nous          — agent pipeline, bootstrap, recall, finalize, actor model

--- a/docs/TECHNOLOGY.md
+++ b/docs/TECHNOLOGY.md
@@ -15,8 +15,8 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) for module boundaries, [PROJECT.md](PROJE
 | HTTP | Axum | Hono | SSE built-in, cleaner middleware |
 | HTTP client | reqwest | node-fetch | Async, connection pooling, Anthropic + channel calls |
 | Anthropic API | Own client (~600 LOC) | @anthropic-ai/sdk | Stable API, reqwest + SSE, adaptive thinking, Tool Search Tool |
-| Unified store | cozo (CozoDB) | Qdrant + Neo4j | Rust-native embedded, Datalog, HNSW vectors + graph + relations in one DB. Zero external services. `StorageProvider` trait boundary for risk mitigation. |
-| Embeddings | fastembed-rs + `EmbeddingProvider` trait | Python fastembed | Default: local ONNX (nomic-embed-text-v1.5). Optional: Voyage-4-large via HTTP API. Per-instance config. |
+| Unified store | Vendored Datalog engine (from CozoDB) | Qdrant + Neo4j | Rust-native embedded, Datalog, HNSW vectors + graph + relations in one DB. Zero external services. Vendored into `mneme/src/engine/`, gated behind `mneme-engine` feature. |
+| Embeddings | fastembed-rs + `EmbeddingProvider` trait | Python fastembed | Default: local ONNX (BAAI/bge-small-en-v1.5, 384 dims). Per-instance config. |
 | Memory | Direct (no abstraction) | KnowledgeStore (embedded CozoDB) | ~50 LOC replaces the library |
 | Sessions | rusqlite + bundled | better-sqlite3 | WAL mode, no native addon |
 | Encryption | XChaCha20Poly1305 | None (plaintext) | Per-message encryption at rest, ~700ns overhead, zero plaintext on disk |
@@ -55,7 +55,6 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) for module boundaries, [PROJECT.md](PROJE
 - **Unstable crates** (pre-1.0, aggressive releases): pin exact version. Wrap in trait.
   - `wasmtime` - monthly major versions. Pin exact.
   - `rmcp` - 5 minor releases in 6 weeks. Pin exact. `McpProvider` trait.
-  - `cozo` - pre-1.0, single maintainer. Pin exact. `StorageProvider` trait boundary.
   - `fastembed` - active development. Pin minor.
   - `chromiumoxide` - niche. Pin exact.
 - **Stable crates** (1.0+): pin minor (`"1.49"` not `"=1.49.0"`).
@@ -69,7 +68,7 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) for module boundaries, [PROJECT.md](PROJE
 
 ### Cross-Compilation Notes
 
-- `fastembed` (ONNX): may need special builds for aarch64. Feature-gate behind `embed-local`.
+- `fastembed` (ONNX): may need special builds for aarch64. Feature-gate behind `fastembed`.
 - `sonic-rs` (SIMD): aarch64 NEON supported but verify. Fallback to `serde_json` via feature flag.
 - `chromiumoxide`: requires Chromium on host. Feature-gate behind `browser`.
 - `extrasafe` (seccomp): Linux-only. Feature-gate behind `sandbox-seccomp`.
@@ -82,7 +81,7 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) for module boundaries, [PROJECT.md](PROJE
 |-------|-----------------|
 | **koina** | snafu, tracing, tracing-subscriber, miette |
 | **taxis** | koina, figment, serde, serde_json, snafu, tracing |
-| **mneme** | koina, taxis, cozo, fastembed, reqwest (HTTP embedding), ulid, blake3 |
+| **mneme** | koina, snafu, serde, tracing, ulid, rusqlite (sqlite), fastembed (fastembed), jiff, ndarray |
 | **hermeneus** | koina, taxis, reqwest, reqwest-eventsource, sonic-rs, tokio, secrecy |
 | **organon** | koina, taxis, hermeneus, tokio, gix, extrasafe, chromiumoxide |
 | **nous** | koina, taxis, mneme, hermeneus, organon, melete, tokio, ulid, compact_str |


### PR DESCRIPTION
## Summary

Documentation accuracy pass for mneme-related claims. Fixed 9 discrepancies where docs diverged from code.

## Discrepancies Found and Fixed

### docs/TECHNOLOGY.md (5 fixes)

| # | Error | Fix |
|---|-------|-----|
| 1 | Default model listed as `nomic-embed-text-v1.5` | Corrected to `BAAI/bge-small-en-v1.5` (384 dims) — per `embedding.rs:157` |
| 2 | Feature flag listed as `embed-local` | Corrected to `fastembed` — per `Cargo.toml:17` |
| 3 | `cozo` listed in pinning rules as external crate | Removed — engine is vendored source, no crate dependency |
| 4 | Unified store Choice: `cozo (CozoDB)` | Clarified as `Vendored Datalog engine (from CozoDB)` |
| 5 | mneme deps: `cozo, taxis, reqwest, blake3` | Removed phantom deps, added actual: `snafu, serde, tracing, rusqlite, jiff, ndarray` |

### docs/ARCHITECTURE.md (3 fixes)

| # | Error | Fix |
|---|-------|-----|
| 6 | mneme described as `CozoDB embedded` | Updated to `vendored Datalog` terminology |
| 7 | Submodule `store` described as `CozoDB: vectors, graph...` | Split into `store` (SQLite sessions) and `knowledge` (Datalog graph) |
| 8 | Submodule `embed` (nonexistent name) | Corrected to `embedding` (actual file name) |

### docs/ARCHITECTURE-GUIDE.md (1 fix)

| # | Error | Fix |
|---|-------|-----|
| 9 | `embedded CozoDB for knowledge graphs` | Changed to `vendored Datalog engine` |

## Verified Accurate (no change needed)

- `ARCHITECTURE.md` lines 115, 154, 274 — already say "vendored CozoDB engine behind `mneme-engine` feature gate"
- `ARCHITECTURE.md` line 92 — `cozo/` runtime data directory is the actual on-disk path
- `CONFIGURATION.md` — already says `BAAI/bge-small-en-v1.5`
- `crates/mneme/README.md` — does not exist

## Test plan

- [x] No remaining `nomic-embed-text` references in changed files
- [x] No remaining `embed-local` references in changed files
- [x] Markdown tables render correctly
- [x] Docs-only change — no build/test impact