### PR TITLE
feat(mneme): access tracking schema + knowledge graph data audit

### DIFF
--- a/crates/aletheia/src/knowledge_adapter.rs
+++ b/crates/aletheia/src/knowledge_adapter.rs
@@ -95,11 +95,14 @@ impl KnowledgeSearchService for KnowledgeSearchAdapter {
 
             // Mark old fact as superseded
             let retract_script = r"
-                ?[id, valid_from, content, nous_id, confidence, tier, valid_to, superseded_by, source_session_id, recorded_at] :=
-                    *facts{id: $old_id, valid_from, content, nous_id, confidence, tier, source_session_id, recorded_at},
+                ?[id, valid_from, content, nous_id, confidence, tier, valid_to, superseded_by, source_session_id, recorded_at,
+                  access_count, last_accessed_at, stability_hours, fact_type] :=
+                    *facts{id: $old_id, valid_from, content, nous_id, confidence, tier, source_session_id, recorded_at,
+                           access_count, last_accessed_at, stability_hours, fact_type},
                     valid_to = $now,
                     superseded_by = $new_id
-                :put facts {id, valid_from => content, nous_id, confidence, tier, valid_to, superseded_by, source_session_id, recorded_at}
+                :put facts {id, valid_from => content, nous_id, confidence, tier, valid_to, superseded_by, source_session_id, recorded_at,
+                            access_count, last_accessed_at, stability_hours, fact_type}
             ";
             let mut params = std::collections::BTreeMap::new();
             params.insert(
@@ -130,6 +133,10 @@ impl KnowledgeSearchService for KnowledgeSearchAdapter {
                 superseded_by: None,
                 source_session_id: None,
                 recorded_at: now,
+                access_count: 0,
+                last_accessed_at: String::new(),
+                stability_hours: aletheia_mneme::knowledge::default_stability_hours(""),
+                fact_type: String::new(),
             };
             self.store
                 .insert_fact(&new_fact)
@@ -151,10 +158,13 @@ impl KnowledgeSearchService for KnowledgeSearchAdapter {
                 .to_string();
 
             let script = r"
-                ?[id, valid_from, content, nous_id, confidence, tier, valid_to, superseded_by, source_session_id, recorded_at] :=
-                    *facts{id: $fact_id, valid_from, content, nous_id, confidence, tier, superseded_by, source_session_id, recorded_at},
+                ?[id, valid_from, content, nous_id, confidence, tier, valid_to, superseded_by, source_session_id, recorded_at,
+                  access_count, last_accessed_at, stability_hours, fact_type] :=
+                    *facts{id: $fact_id, valid_from, content, nous_id, confidence, tier, superseded_by, source_session_id, recorded_at,
+                           access_count, last_accessed_at, stability_hours, fact_type},
                     valid_to = $now
-                :put facts {id, valid_from => content, nous_id, confidence, tier, valid_to, superseded_by, source_session_id, recorded_at}
+                :put facts {id, valid_from => content, nous_id, confidence, tier, valid_to, superseded_by, source_session_id, recorded_at,
+                            access_count, last_accessed_at, stability_hours, fact_type}
             ";
             let mut params = std::collections::BTreeMap::new();
             params.insert(

--- a/crates/aletheia/src/migrate_memory.rs
+++ b/crates/aletheia/src/migrate_memory.rs
@@ -243,6 +243,10 @@ fn import_fact(
         superseded_by: None,
         source_session_id: None,
         recorded_at: now.clone(),
+        access_count: 0,
+        last_accessed_at: String::new(),
+        stability_hours: aletheia_mneme::knowledge::default_stability_hours(""),
+        fact_type: String::new(),
     };
     knowledgedb
         .insert_fact(&fact)

--- a/crates/integration-tests/tests/access_tracking.rs
+++ b/crates/integration-tests/tests/access_tracking.rs
@@ -1,0 +1,184 @@
+//! Integration tests for access tracking and knowledge graph data audit.
+#![cfg(feature = "engine-tests")]
+
+use aletheia_mneme::embedding::{EmbeddingProvider, MockEmbeddingProvider};
+use aletheia_mneme::knowledge::{default_stability_hours, EmbeddedChunk, EpistemicTier, Fact};
+use aletheia_mneme::knowledge_store::{KnowledgeConfig, KnowledgeStore};
+use std::sync::Arc;
+
+fn open_store(dim: usize) -> Arc<KnowledgeStore> {
+    KnowledgeStore::open_mem_with_config(KnowledgeConfig { dim }).expect("open_mem")
+}
+
+fn make_fact(id: &str, nous_id: &str, content: &str) -> Fact {
+    Fact {
+        id: id.to_owned(),
+        nous_id: nous_id.to_owned(),
+        content: content.to_owned(),
+        confidence: 0.9,
+        tier: EpistemicTier::Inferred,
+        valid_from: "2026-01-01T00:00:00Z".to_owned(),
+        valid_to: "9999-12-31".to_owned(),
+        superseded_by: None,
+        source_session_id: Some("ses-test".to_owned()),
+        recorded_at: "2026-03-01T00:00:00Z".to_owned(),
+        access_count: 0,
+        last_accessed_at: String::new(),
+        stability_hours: 720.0,
+        fact_type: "inference".to_owned(),
+    }
+}
+
+#[test]
+fn insert_fact_then_search_increments_access_count() {
+    let dim = 8;
+    let store = open_store(dim);
+    let provider = MockEmbeddingProvider::new(dim);
+
+    let fact = make_fact("f-track-1", "syn", "Rust is great for systems programming");
+    store.insert_fact(&fact).expect("insert fact");
+
+    let embedding = provider.embed(&fact.content).expect("embed");
+    let chunk = EmbeddedChunk {
+        id: "emb-track-1".to_owned(),
+        content: fact.content.clone(),
+        source_type: "fact".to_owned(),
+        source_id: "f-track-1".to_owned(),
+        nous_id: "syn".to_owned(),
+        embedding: embedding.clone(),
+        created_at: "2026-03-01T00:00:00Z".to_owned(),
+    };
+    store.insert_embedding(&chunk).expect("insert embedding");
+
+    // Search with the same vector — should find our fact
+    let results = store.search_vectors(embedding, 5, 20).expect("search");
+    assert!(!results.is_empty(), "search must return results");
+    assert_eq!(results[0].source_id, "f-track-1");
+
+    // Verify access_count was incremented
+    let facts = store
+        .query_facts("syn", "2026-06-01T00:00:00Z", 10)
+        .expect("query facts");
+    let tracked = facts.iter().find(|f| f.id == "f-track-1").expect("find fact");
+    assert_eq!(tracked.access_count, 1, "access_count should be 1 after one search");
+    assert!(!tracked.last_accessed_at.is_empty(), "last_accessed_at should be set");
+}
+
+#[test]
+fn triple_search_yields_access_count_3() {
+    let dim = 8;
+    let store = open_store(dim);
+    let provider = MockEmbeddingProvider::new(dim);
+
+    let fact = make_fact("f-triple", "syn", "triple access test fact");
+    store.insert_fact(&fact).expect("insert fact");
+
+    let embedding = provider.embed(&fact.content).expect("embed");
+    let chunk = EmbeddedChunk {
+        id: "emb-triple".to_owned(),
+        content: fact.content.clone(),
+        source_type: "fact".to_owned(),
+        source_id: "f-triple".to_owned(),
+        nous_id: "syn".to_owned(),
+        embedding: embedding.clone(),
+        created_at: "2026-03-01T00:00:00Z".to_owned(),
+    };
+    store.insert_embedding(&chunk).expect("insert embedding");
+
+    // Search 3 times
+    for _ in 0..3 {
+        store.search_vectors(embedding.clone(), 5, 20).expect("search");
+    }
+
+    let facts = store
+        .query_facts("syn", "2026-06-01T00:00:00Z", 10)
+        .expect("query facts");
+    let tracked = facts.iter().find(|f| f.id == "f-triple").expect("find fact");
+    assert_eq!(tracked.access_count, 3, "access_count should be 3 after three searches");
+}
+
+#[test]
+fn increment_access_empty_ids_is_noop() {
+    let store = open_store(4);
+    store.increment_access(&[]).expect("empty increment should succeed");
+}
+
+#[test]
+fn default_stability_by_fact_type() {
+    assert!((default_stability_hours("identity") - 17520.0).abs() < f64::EPSILON);
+    assert!((default_stability_hours("preference") - 8760.0).abs() < f64::EPSILON);
+    assert!((default_stability_hours("relationship") - 4380.0).abs() < f64::EPSILON);
+    assert!((default_stability_hours("skill") - 2190.0).abs() < f64::EPSILON);
+    assert!((default_stability_hours("event") - 720.0).abs() < f64::EPSILON);
+    assert!((default_stability_hours("task") - 168.0).abs() < f64::EPSILON);
+    assert!((default_stability_hours("inference") - 720.0).abs() < f64::EPSILON);
+    assert!((default_stability_hours("unknown_type") - 720.0).abs() < f64::EPSILON);
+}
+
+#[test]
+#[ignore = "run manually: cargo test -p aletheia-integration-tests --features engine-tests audit -- --ignored --nocapture"]
+fn knowledge_graph_data_audit() {
+    let store = open_store(4);
+
+    // Query facts, entities, relationships
+    let facts = store.query_facts("", "9999-12-31", 1000).unwrap_or_default();
+
+    let entity_rows = store
+        .run_query("?[id, name, entity_type] := *entities{id, name, entity_type}", Default::default())
+        .map(|r| r.rows.len())
+        .unwrap_or(0);
+
+    let rel_rows = store
+        .run_query("?[src, dst, relation] := *relationships{src, dst, relation}", Default::default())
+        .map(|r| r.rows.len())
+        .unwrap_or(0);
+
+    println!("\n=== Knowledge Graph Data Audit ===");
+    println!("Facts:         {}", facts.len());
+    println!("Entities:      {entity_rows}");
+    println!("Relationships: {rel_rows}");
+
+    // Fact tier distribution
+    let verified = facts.iter().filter(|f| f.tier == EpistemicTier::Verified).count();
+    let inferred = facts.iter().filter(|f| f.tier == EpistemicTier::Inferred).count();
+    let assumed = facts.iter().filter(|f| f.tier == EpistemicTier::Assumed).count();
+    println!("\nFact tiers:");
+    println!("  Verified:  {verified}");
+    println!("  Inferred:  {inferred}");
+    println!("  Assumed:   {assumed}");
+
+    // Access tracking stats
+    let accessed = facts.iter().filter(|f| f.access_count > 0).count();
+    let max_access = facts.iter().map(|f| f.access_count).max().unwrap_or(0);
+    let avg_access = if facts.is_empty() {
+        0.0
+    } else {
+        facts.iter().map(|f| f64::from(f.access_count)).sum::<f64>() / facts.len() as f64
+    };
+    println!("\nAccess tracking:");
+    println!("  Facts accessed:    {accessed}/{}", facts.len());
+    println!("  Max access count:  {max_access}");
+    println!("  Avg access count:  {avg_access:.2}");
+
+    // Graph density
+    let density = if entity_rows > 1 {
+        rel_rows as f64 / (entity_rows as f64 * (entity_rows as f64 - 1.0))
+    } else {
+        0.0
+    };
+    println!("\nGraph density: {density:.4}");
+
+    // Phase F viability
+    println!("\n--- Phase F Viability ---");
+    if facts.is_empty() {
+        println!("No data yet. Phase F has nothing to calibrate against.");
+    } else {
+        println!("Facts with access data: {accessed}/{} ({:.0}%)", facts.len(), accessed as f64 / facts.len() as f64 * 100.0);
+        if accessed > 10 {
+            println!("Sufficient access data for initial FSRS calibration.");
+        } else {
+            println!("Need more access data before FSRS calibration is viable.");
+        }
+    }
+    println!("=================================\n");
+}

--- a/crates/integration-tests/tests/knowledge_engine.rs
+++ b/crates/integration-tests/tests/knowledge_engine.rs
@@ -18,6 +18,10 @@ fn make_fact(id: &str, nous_id: &str, content: &str, confidence: f64, tier: Epis
         superseded_by: None,
         source_session_id: None,
         recorded_at: "2026-03-01T00:00:00Z".to_owned(),
+        access_count: 0,
+        last_accessed_at: String::new(),
+        stability_hours: 720.0,
+        fact_type: String::new(),
     }
 }
 
@@ -37,6 +41,10 @@ fn fact_round_trip() {
         superseded_by: None,
         source_session_id: Some("ses-abc".to_owned()),
         recorded_at: "2026-03-01T00:00:00Z".to_owned(),
+        access_count: 0,
+        last_accessed_at: String::new(),
+        stability_hours: 720.0,
+        fact_type: String::new(),
     };
 
     store.insert_fact(&fact).expect("insert");
@@ -98,7 +106,7 @@ fn hnsw_vector_search() {
 fn schema_version_queryable() {
     let store = KnowledgeStore::open_mem_with_config(KnowledgeConfig { dim: 4 }).expect("open_mem");
     let version = store.schema_version().expect("version");
-    assert_eq!(version, 1);
+    assert_eq!(version, 2);
 }
 
 // Verify ordering of multiple facts by confidence (descending).
@@ -141,6 +149,10 @@ async fn async_spawn_blocking_wrapper() {
         superseded_by: None,
         source_session_id: None,
         recorded_at: "2026-03-01T00:00:00Z".to_owned(),
+        access_count: 0,
+        last_accessed_at: String::new(),
+        stability_hours: 720.0,
+        fact_type: String::new(),
     };
 
     store.insert_fact_async(fact).await.expect("async insert");
@@ -195,6 +207,10 @@ fn hybrid_retrieval_end_to_end() {
             superseded_by: None,
             source_session_id: None,
             recorded_at: "2026-03-01T00:00:00Z".to_owned(),
+            access_count: 0,
+            last_accessed_at: String::new(),
+            stability_hours: 720.0,
+            fact_type: String::new(),
         };
         store.insert_fact(&fact).expect("insert fact");
     }

--- a/crates/integration-tests/tests/knowledge_lifecycle.rs
+++ b/crates/integration-tests/tests/knowledge_lifecycle.rs
@@ -20,6 +20,10 @@ fn make_fact(id: &str, nous_id: &str, content: &str, confidence: f64, tier: Epis
         superseded_by: None,
         source_session_id: Some("ses-test".to_owned()),
         recorded_at: "2026-03-01T00:00:00Z".to_owned(),
+        access_count: 0,
+        last_accessed_at: String::new(),
+        stability_hours: 720.0,
+        fact_type: String::new(),
     }
 }
 
@@ -35,12 +39,15 @@ fn correct_fact(
     correction_time: &str,
 ) {
     let script = r"
-        ?[id, valid_from, content, nous_id, confidence, tier, valid_to, superseded_by, source_session_id, recorded_at] :=
-            *facts{id, valid_from, content, nous_id, confidence, tier, source_session_id, recorded_at},
+        ?[id, valid_from, content, nous_id, confidence, tier, valid_to, superseded_by, source_session_id, recorded_at,
+          access_count, last_accessed_at, stability_hours, fact_type] :=
+            *facts{id, valid_from, content, nous_id, confidence, tier, source_session_id, recorded_at,
+                   access_count, last_accessed_at, stability_hours, fact_type},
             id = $old_id,
             valid_to = $now,
             superseded_by = $new_id
-        :put facts {id, valid_from => content, nous_id, confidence, tier, valid_to, superseded_by, source_session_id, recorded_at}
+        :put facts {id, valid_from => content, nous_id, confidence, tier, valid_to, superseded_by, source_session_id, recorded_at,
+                    access_count, last_accessed_at, stability_hours, fact_type}
     ";
     let mut params = BTreeMap::new();
     params.insert("old_id".to_owned(), DataValue::Str(old_id.into()));
@@ -59,6 +66,10 @@ fn correct_fact(
         superseded_by: None,
         source_session_id: None,
         recorded_at: correction_time.to_owned(),
+        access_count: 0,
+        last_accessed_at: String::new(),
+        stability_hours: 720.0,
+        fact_type: String::new(),
     };
     store.insert_fact(&new_fact).expect("correct: insert new fact");
 }
@@ -67,11 +78,14 @@ fn correct_fact(
 /// Sets `valid_to` = `retraction_time` on the fact (soft delete).
 fn retract_fact(store: &Arc<KnowledgeStore>, fact_id: &str, retraction_time: &str) {
     let script = r"
-        ?[id, valid_from, content, nous_id, confidence, tier, valid_to, superseded_by, source_session_id, recorded_at] :=
-            *facts{id, valid_from, content, nous_id, confidence, tier, superseded_by, source_session_id, recorded_at},
+        ?[id, valid_from, content, nous_id, confidence, tier, valid_to, superseded_by, source_session_id, recorded_at,
+          access_count, last_accessed_at, stability_hours, fact_type] :=
+            *facts{id, valid_from, content, nous_id, confidence, tier, superseded_by, source_session_id, recorded_at,
+                   access_count, last_accessed_at, stability_hours, fact_type},
             id = $fact_id,
             valid_to = $now
-        :put facts {id, valid_from => content, nous_id, confidence, tier, valid_to, superseded_by, source_session_id, recorded_at}
+        :put facts {id, valid_from => content, nous_id, confidence, tier, valid_to, superseded_by, source_session_id, recorded_at,
+                    access_count, last_accessed_at, stability_hours, fact_type}
     ";
     let mut params = BTreeMap::new();
     params.insert("fact_id".to_owned(), DataValue::Str(fact_id.into()));

--- a/crates/integration-tests/tests/knowledge_recall.rs
+++ b/crates/integration-tests/tests/knowledge_recall.rs
@@ -35,6 +35,10 @@ fn sample_fact(id: &str, nous_id: &str, tier: EpistemicTier) -> Fact {
         superseded_by: None,
         source_session_id: None,
         recorded_at: "2026-03-01T00:00:00Z".to_owned(),
+        access_count: 0,
+        last_accessed_at: String::new(),
+        stability_hours: 720.0,
+        fact_type: String::new(),
     }
 }
 

--- a/crates/mneme/src/extract.rs
+++ b/crates/mneme/src/extract.rs
@@ -350,6 +350,10 @@ Rules:
                 superseded_by: None,
                 source_session_id: Some(source.to_owned()),
                 recorded_at: now.clone(),
+                access_count: 0,
+                last_accessed_at: String::new(),
+                stability_hours: crate::knowledge::default_stability_hours("inference"),
+                fact_type: "inference".to_owned(),
             };
             store.insert_fact(&f).map_err(|e| {
                 PersistSnafu {

--- a/crates/mneme/src/knowledge.rs
+++ b/crates/mneme/src/knowledge.rs
@@ -33,6 +33,14 @@ pub struct Fact {
     pub source_session_id: Option<String>,
     /// When this fact was recorded in the system.
     pub recorded_at: String,
+    /// Number of times this fact has been returned in recall/search results.
+    pub access_count: u32,
+    /// When this fact was last accessed (ISO 8601, empty = never).
+    pub last_accessed_at: String,
+    /// Initial stability for FSRS decay model (hours).
+    pub stability_hours: f64,
+    /// Fact classification for stability defaults.
+    pub fact_type: String,
 }
 
 /// An entity in the knowledge graph.
@@ -115,6 +123,19 @@ impl std::fmt::Display for EpistemicTier {
     }
 }
 
+/// Default FSRS stability by fact type (hours until 50% recall probability).
+#[must_use]
+pub fn default_stability_hours(fact_type: &str) -> f64 {
+    match fact_type {
+        "identity" => 17520.0,
+        "preference" => 8760.0,
+        "relationship" => 4380.0,
+        "skill" => 2190.0,
+        "task" => 168.0,
+        _ => 720.0,
+    }
+}
+
 /// Results from a semantic recall query.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RecallResult {
@@ -158,6 +179,10 @@ mod tests {
             superseded_by: None,
             source_session_id: Some("ses-123".to_owned()),
             recorded_at: "2026-02-28T00:00:00Z".to_owned(),
+            access_count: 0,
+            last_accessed_at: String::new(),
+            stability_hours: 720.0,
+            fact_type: String::new(),
         };
         let json = serde_json::to_string(&fact).unwrap();
         let back: Fact = serde_json::from_str(&json).unwrap();
@@ -241,6 +266,10 @@ mod tests {
             superseded_by: None,
             source_session_id: None,
             recorded_at: "2026-01-01T00:00:00Z".to_owned(),
+            access_count: 0,
+            last_accessed_at: String::new(),
+            stability_hours: 720.0,
+            fact_type: String::new(),
         };
         let json = serde_json::to_string(&fact).unwrap();
         let back: Fact = serde_json::from_str(&json).unwrap();
@@ -260,6 +289,10 @@ mod tests {
             superseded_by: None,
             source_session_id: None,
             recorded_at: "2026-01-01T00:00:00Z".to_owned(),
+            access_count: 0,
+            last_accessed_at: String::new(),
+            stability_hours: 720.0,
+            fact_type: String::new(),
         };
         let json = serde_json::to_string(&fact).unwrap();
         let back: Fact = serde_json::from_str(&json).unwrap();
@@ -286,6 +319,19 @@ mod tests {
         assert_eq!(EpistemicTier::Verified.to_string(), "verified");
         assert_eq!(EpistemicTier::Inferred.to_string(), "inferred");
         assert_eq!(EpistemicTier::Assumed.to_string(), "assumed");
+    }
+
+    #[test]
+    fn default_stability_by_fact_type() {
+        assert!((default_stability_hours("identity") - 17520.0).abs() < f64::EPSILON);
+        assert!((default_stability_hours("preference") - 8760.0).abs() < f64::EPSILON);
+        assert!((default_stability_hours("relationship") - 4380.0).abs() < f64::EPSILON);
+        assert!((default_stability_hours("skill") - 2190.0).abs() < f64::EPSILON);
+        assert!((default_stability_hours("event") - 720.0).abs() < f64::EPSILON);
+        assert!((default_stability_hours("task") - 168.0).abs() < f64::EPSILON);
+        assert!((default_stability_hours("inference") - 720.0).abs() < f64::EPSILON);
+        assert!((default_stability_hours("unknown") - 720.0).abs() < f64::EPSILON);
+        assert!((default_stability_hours("") - 720.0).abs() < f64::EPSILON);
     }
 
     #[test]

--- a/crates/mneme/src/knowledge_store.rs
+++ b/crates/mneme/src/knowledge_store.rs
@@ -16,7 +16,9 @@
 //! ```text
 //! facts { id: String, valid_from: String => content: String, nous_id: String,
 //!         confidence: Float, tier: String, valid_to: String, superseded_by: String?,
-//!         source_session_id: String?, recorded_at: String }
+//!         source_session_id: String?, recorded_at: String,
+//!         access_count: Int, last_accessed_at: String, stability_hours: Float,
+//!         fact_type: String }
 //!
 //! entities { id: String => name: String, entity_type: String, aliases: String,
 //!            created_at: String, updated_at: String }
@@ -55,7 +57,11 @@ pub const KNOWLEDGE_DDL: &[&str] = &[
         valid_to: String,
         superseded_by: String?,
         source_session_id: String?,
-        recorded_at: String
+        recorded_at: String,
+        access_count: Int,
+        last_accessed_at: String,
+        stability_hours: Float,
+        fact_type: String
     }",
     // Entities: typed nodes in the knowledge graph
     r":create entities {
@@ -180,7 +186,7 @@ pub struct KnowledgeStore {
 
 #[cfg(feature = "mneme-engine")]
 impl KnowledgeStore {
-    const SCHEMA_VERSION: i64 = 1;
+    const SCHEMA_VERSION: i64 = 2;
 
     /// Open an in-memory knowledge store with default configuration.
     pub fn open_mem() -> crate::error::Result<std::sync::Arc<Self>> {
@@ -240,6 +246,10 @@ impl KnowledgeStore {
             .is_ok();
 
         if already_initialized {
+            let current_version = self.schema_version().unwrap_or(0);
+            if current_version < Self::SCHEMA_VERSION {
+                self.migrate_v1_to_v2()?;
+            }
             return Ok(());
         }
 
@@ -416,7 +426,18 @@ impl KnowledgeStore {
         params.insert("ef".to_owned(), DataValue::from(ef));
 
         let rows = self.run_read(queries::SEMANTIC_SEARCH, params)?;
-        rows_to_recall_results(rows)
+        let results = rows_to_recall_results(rows)?;
+
+        let source_ids: Vec<String> = results
+            .iter()
+            .filter(|r| r.source_type == "fact")
+            .map(|r| r.source_id.clone())
+            .collect();
+        if let Err(e) = self.increment_access(&source_ids) {
+            tracing::warn!(error = %e, "failed to increment access counts");
+        }
+
+        Ok(results)
     }
 
     /// Get the current schema version.
@@ -527,7 +548,14 @@ impl KnowledgeStore {
 
         let script = build_hybrid_query(q);
         let rows = self.run_read(&script, params)?;
-        rows_to_hybrid_results(rows)
+        let results = rows_to_hybrid_results(rows)?;
+
+        let fact_ids: Vec<String> = results.iter().map(|r| r.id.clone()).collect();
+        if let Err(e) = self.increment_access(&fact_ids) {
+            tracing::warn!(error = %e, "failed to increment access counts");
+        }
+
+        Ok(results)
     }
 
     /// Async `search_hybrid` — wraps sync call in `spawn_blocking`.
@@ -538,6 +566,56 @@ impl KnowledgeStore {
         use snafu::ResultExt;
         let this = std::sync::Arc::clone(self);
         tokio::task::spawn_blocking(move || this.search_hybrid(&q))
+            .await
+            .context(crate::error::JoinSnafu)?
+    }
+
+    /// Increment access count and update last-accessed timestamp for the given fact IDs.
+    pub fn increment_access(&self, fact_ids: &[String]) -> crate::error::Result<()> {
+        if fact_ids.is_empty() {
+            return Ok(());
+        }
+        let now = jiff::Zoned::now()
+            .strftime("%Y-%m-%dT%H:%M:%SZ")
+            .to_string();
+        for id in fact_ids {
+            let script = r"
+                ?[id, valid_from, content, nous_id, confidence, tier, valid_to,
+                  superseded_by, source_session_id, recorded_at,
+                  new_count, new_last, stability_hours, fact_type] :=
+                    *facts{id: $id, valid_from, content, nous_id, confidence, tier,
+                           valid_to, superseded_by, source_session_id, recorded_at,
+                           access_count, last_accessed_at, stability_hours, fact_type},
+                    new_count = access_count + 1,
+                    new_last = $now
+                :put facts {id, valid_from => content, nous_id, confidence, tier,
+                            valid_to, superseded_by, source_session_id, recorded_at,
+                            access_count: new_count, last_accessed_at: new_last,
+                            stability_hours, fact_type}
+            ";
+            let mut params = std::collections::BTreeMap::new();
+            params.insert(
+                "id".to_owned(),
+                crate::engine::DataValue::Str(id.as_str().into()),
+            );
+            params.insert(
+                "now".to_owned(),
+                crate::engine::DataValue::Str(now.as_str().into()),
+            );
+            // Silently skip if fact doesn't exist (e.g. embedding-only result)
+            let _ = self.run_mut(script, params);
+        }
+        Ok(())
+    }
+
+    /// Async `increment_access` — wraps sync call in `spawn_blocking`.
+    pub async fn increment_access_async(
+        self: &std::sync::Arc<Self>,
+        fact_ids: Vec<String>,
+    ) -> crate::error::Result<()> {
+        use snafu::ResultExt;
+        let this = std::sync::Arc::clone(self);
+        tokio::task::spawn_blocking(move || this.increment_access(&fact_ids))
             .await
             .context(crate::error::JoinSnafu)?
     }
@@ -582,6 +660,135 @@ impl KnowledgeStore {
         tokio::task::spawn_blocking(move || this.search_vectors(query_vec, k, ef))
             .await
             .context(crate::error::JoinSnafu)?
+    }
+
+    // --- Migration ---
+
+    #[expect(clippy::too_many_lines, reason = "migration is a single linear sequence")]
+    fn migrate_v1_to_v2(&self) -> crate::error::Result<()> {
+        use crate::engine::{DataValue, ScriptMutability};
+        use std::collections::BTreeMap;
+
+        tracing::info!("migrating knowledge schema v1 -> v2");
+
+        // 1. Read all existing facts
+        let all_facts = self
+            .db
+            .run(
+                r"?[id, valid_from, content, nous_id, confidence, tier, valid_to,
+                    superseded_by, source_session_id, recorded_at] :=
+                    *facts{id, valid_from, content, nous_id, confidence, tier,
+                           valid_to, superseded_by, source_session_id, recorded_at}",
+                BTreeMap::new(),
+                ScriptMutability::Immutable,
+            )
+            .map_err(|e| {
+                crate::error::EngineQuerySnafu {
+                    message: format!("v1->v2 read facts: {e}"),
+                }
+                .build()
+            })?;
+
+        // 2. Drop FTS index (must be dropped before relation)
+        let _ = self.db.run(
+            "::fts drop facts:content_fts",
+            BTreeMap::new(),
+            ScriptMutability::Mutable,
+        );
+
+        // 3. Drop old facts relation
+        self.db
+            .run("::remove facts", BTreeMap::new(), ScriptMutability::Mutable)
+            .map_err(|e| {
+                crate::error::EngineQuerySnafu {
+                    message: format!("v1->v2 remove facts: {e}"),
+                }
+                .build()
+            })?;
+
+        // 4. Recreate with new schema (includes access tracking columns)
+        self.db
+            .run(KNOWLEDGE_DDL[0], BTreeMap::new(), ScriptMutability::Mutable)
+            .map_err(|e| {
+                crate::error::EngineQuerySnafu {
+                    message: format!("v1->v2 recreate facts: {e}"),
+                }
+                .build()
+            })?;
+
+        // 5. Reinsert facts with defaults for new columns
+        for row in &all_facts.rows {
+            let script = r"
+                ?[id, valid_from, content, nous_id, confidence, tier, valid_to,
+                  superseded_by, source_session_id, recorded_at,
+                  access_count, last_accessed_at, stability_hours, fact_type] <- [[
+                    $id, $valid_from, $content, $nous_id, $confidence, $tier, $valid_to,
+                    $superseded_by, $source_session_id, $recorded_at,
+                    0, '', 720.0, ''
+                ]]
+                :put facts {id, valid_from => content, nous_id, confidence, tier,
+                            valid_to, superseded_by, source_session_id, recorded_at,
+                            access_count, last_accessed_at, stability_hours, fact_type}
+            ";
+            let mut params = BTreeMap::new();
+            for (i, name) in [
+                "id",
+                "valid_from",
+                "content",
+                "nous_id",
+                "confidence",
+                "tier",
+                "valid_to",
+                "superseded_by",
+                "source_session_id",
+                "recorded_at",
+            ]
+            .iter()
+            .enumerate()
+            {
+                if let Some(val) = row.get(i) {
+                    params.insert((*name).to_owned(), val.clone());
+                }
+            }
+            self.db
+                .run(script, params, ScriptMutability::Mutable)
+                .map_err(|e| {
+                    crate::error::EngineQuerySnafu {
+                        message: format!("v1->v2 reinsert fact: {e}"),
+                    }
+                    .build()
+                })?;
+        }
+
+        // 6. Recreate FTS index
+        self.db
+            .run(fts_ddl(), BTreeMap::new(), ScriptMutability::Mutable)
+            .map_err(|e| {
+                crate::error::EngineQuerySnafu {
+                    message: format!("v1->v2 recreate FTS: {e}"),
+                }
+                .build()
+            })?;
+
+        // 7. Update schema version
+        let mut params = BTreeMap::new();
+        params.insert("key".to_owned(), DataValue::Str("schema".into()));
+        params.insert("version".to_owned(), DataValue::from(Self::SCHEMA_VERSION));
+        self.db
+            .run(
+                r"?[key, version] <- [[$key, $version]] :put schema_version { key => version }",
+                params,
+                ScriptMutability::Mutable,
+            )
+            .map_err(|e| {
+                crate::error::EngineQuerySnafu {
+                    message: format!("v1->v2 update version: {e}"),
+                }
+                .build()
+            })?;
+
+        tracing::info!("knowledge schema migration v1 -> v2 complete");
+        Ok(())
     }
 
     // --- Internal helpers ---
@@ -664,6 +871,22 @@ fn fact_to_params(
     p.insert(
         "recorded_at".to_owned(),
         DataValue::Str(fact.recorded_at.as_str().into()),
+    );
+    p.insert(
+        "access_count".to_owned(),
+        DataValue::from(i64::from(fact.access_count)),
+    );
+    p.insert(
+        "last_accessed_at".to_owned(),
+        DataValue::Str(fact.last_accessed_at.as_str().into()),
+    );
+    p.insert(
+        "stability_hours".to_owned(),
+        DataValue::from(fact.stability_hours),
+    );
+    p.insert(
+        "fact_type".to_owned(),
+        DataValue::Str(fact.fact_type.as_str().into()),
     );
     p
 }
@@ -756,6 +979,7 @@ fn embedding_to_params(
 // Parse rows from FULL_CURRENT_FACTS into Vec<Fact>.
 // Columns: id, content, confidence, tier, recorded_at, nous_id, valid_from, valid_to, superseded_by, source_session_id
 #[cfg(feature = "mneme-engine")]
+#[expect(clippy::too_many_lines, reason = "column extraction is sequential — splitting would obscure the mapping")]
 fn rows_to_facts(
     rows: crate::engine::NamedRows,
     nous_id: &str,
@@ -826,6 +1050,24 @@ fn rows_to_facts(
 
         let tier = parse_epistemic_tier(&tier_str)?;
 
+        #[expect(clippy::cast_possible_truncation, clippy::cast_sign_loss, reason = "access count fits in u32")]
+        let access_count = row
+            .get(10)
+            .and_then(|v| extract_int(v).ok())
+            .unwrap_or(0) as u32;
+        let last_accessed_at = row
+            .get(11)
+            .and_then(|v| extract_str(v).ok())
+            .unwrap_or_default();
+        let stability_hours = row
+            .get(12)
+            .and_then(|v| extract_float(v).ok())
+            .unwrap_or(720.0);
+        let fact_type = row
+            .get(13)
+            .and_then(|v| extract_str(v).ok())
+            .unwrap_or_default();
+
         out.push(Fact {
             id,
             nous_id: if nous_id_col.is_empty() {
@@ -841,6 +1083,10 @@ fn rows_to_facts(
             superseded_by,
             source_session_id,
             recorded_at,
+            access_count,
+            last_accessed_at,
+            stability_hours,
+            fact_type,
         });
     }
     Ok(out)
@@ -891,6 +1137,10 @@ fn rows_to_facts_partial(
             superseded_by: None,
             source_session_id: None,
             recorded_at: String::new(),
+            access_count: 0,
+            last_accessed_at: String::new(),
+            stability_hours: 720.0,
+            fact_type: String::new(),
         });
     }
     Ok(out)
@@ -1241,6 +1491,10 @@ mod tests {
             superseded_by: None,
             source_session_id: None,
             recorded_at: "2026-03-01T00:00:00Z".to_owned(),
+            access_count: 0,
+            last_accessed_at: String::new(),
+            stability_hours: 720.0,
+            fact_type: String::new(),
         };
         store.insert_fact(&fact).expect("insert fact");
 
@@ -1302,6 +1556,10 @@ mod tests {
             superseded_by: None,
             source_session_id: None,
             recorded_at: "2026-03-01T00:00:00Z".to_owned(),
+            access_count: 0,
+            last_accessed_at: String::new(),
+            stability_hours: 720.0,
+            fact_type: String::new(),
         };
         store.insert_fact(&f1).expect("insert f1");
         store
@@ -1328,6 +1586,10 @@ mod tests {
             superseded_by: None,
             source_session_id: None,
             recorded_at: "2026-03-01T00:00:00Z".to_owned(),
+            access_count: 0,
+            last_accessed_at: String::new(),
+            stability_hours: 720.0,
+            fact_type: String::new(),
         };
         store.insert_fact(&f2).expect("insert f2");
         store
@@ -1433,6 +1695,10 @@ mod tests {
             superseded_by: None,
             source_session_id: None,
             recorded_at: "2026-03-01T00:00:00Z".to_owned(),
+            access_count: 0,
+            last_accessed_at: String::new(),
+            stability_hours: 720.0,
+            fact_type: String::new(),
         };
         store.insert_fact(&fact).expect("insert fact");
 
@@ -1504,6 +1770,10 @@ mod tests {
             superseded_by: None,
             source_session_id: None,
             recorded_at: "2026-03-01T00:00:00Z".to_owned(),
+            access_count: 0,
+            last_accessed_at: String::new(),
+            stability_hours: 720.0,
+            fact_type: String::new(),
         };
         store.insert_fact(&fact).expect("insert fact");
 

--- a/crates/mneme/src/query.rs
+++ b/crates/mneme/src/query.rs
@@ -47,6 +47,10 @@ pub enum FactsField {
     SupersededBy,
     SourceSessionId,
     RecordedAt,
+    AccessCount,
+    LastAccessedAt,
+    StabilityHours,
+    FactType,
 }
 
 impl Field for FactsField {
@@ -62,6 +66,10 @@ impl Field for FactsField {
             Self::SupersededBy => "superseded_by",
             Self::SourceSessionId => "source_session_id",
             Self::RecordedAt => "recorded_at",
+            Self::AccessCount => "access_count",
+            Self::LastAccessedAt => "last_accessed_at",
+            Self::StabilityHours => "stability_hours",
+            Self::FactType => "fact_type",
         }
     }
 }
@@ -406,6 +414,10 @@ pub mod queries {
                 SupersededBy,
                 SourceSessionId,
                 RecordedAt,
+                AccessCount,
+                LastAccessedAt,
+                StabilityHours,
+                FactType,
             ])
             .done()
             .build_script()
@@ -427,6 +439,10 @@ pub mod queries {
             .bind(ValidTo)
             .bind(SupersededBy)
             .bind(RecordedAt)
+            .bind(AccessCount)
+            .bind(LastAccessedAt)
+            .bind(StabilityHours)
+            .bind(FactType)
             .filter("nous_id = $nous_id")
             .filter("valid_from <= $now")
             .filter("valid_to > $now")
@@ -454,6 +470,10 @@ pub mod queries {
                 ValidTo,
                 SupersededBy,
                 SourceSessionId,
+                AccessCount,
+                LastAccessedAt,
+                StabilityHours,
+                FactType,
             ])
             .bind(Id)
             .bind(ValidFrom)
@@ -465,6 +485,10 @@ pub mod queries {
             .bind(SupersededBy)
             .bind(SourceSessionId)
             .bind(RecordedAt)
+            .bind(AccessCount)
+            .bind(LastAccessedAt)
+            .bind(StabilityHours)
+            .bind(FactType)
             .filter("nous_id = $nous_id")
             .filter("valid_from <= $now")
             .filter("valid_to > $now")
@@ -512,6 +536,10 @@ pub mod queries {
                 SupersededBy,
                 SourceSessionId,
                 RecordedAt,
+                AccessCount,
+                LastAccessedAt,
+                StabilityHours,
+                FactType,
             ])
             .row(&[
                 "$old_id",
@@ -524,6 +552,10 @@ pub mod queries {
                 "$new_id",
                 "$old_source",
                 "$old_recorded",
+                "$old_access_count",
+                "$old_last_accessed_at",
+                "$old_stability_hours",
+                "$old_fact_type",
             ])
             .row(&[
                 "$new_id",
@@ -536,6 +568,10 @@ pub mod queries {
                 "null",
                 "$source_session_id",
                 "$now",
+                "0",
+                "\"\"",
+                "$stability_hours",
+                "$fact_type",
             ])
             .done()
             .build_script()
@@ -771,6 +807,10 @@ mod tests {
             "superseded_by",
             "source_session_id",
             "recorded_at",
+            "access_count",
+            "last_accessed_at",
+            "stability_hours",
+            "fact_type",
         ];
         let facts_enum_fields: Vec<&str> = [
             FactsField::Id,
@@ -783,6 +823,10 @@ mod tests {
             FactsField::SupersededBy,
             FactsField::SourceSessionId,
             FactsField::RecordedAt,
+            FactsField::AccessCount,
+            FactsField::LastAccessedAt,
+            FactsField::StabilityHours,
+            FactsField::FactType,
         ]
         .iter()
         .map(|f| f.name())
@@ -867,11 +911,14 @@ mod tests {
     fn test_builder_matches_upsert_fact() {
         let original = r"
         ?[id, valid_from, content, nous_id, confidence, tier, valid_to,
-          superseded_by, source_session_id, recorded_at] <- [[$id, $valid_from,
+          superseded_by, source_session_id, recorded_at,
+          access_count, last_accessed_at, stability_hours, fact_type] <- [[$id, $valid_from,
           $content, $nous_id, $confidence, $tier, $valid_to, $superseded_by,
-          $source_session_id, $recorded_at]]
+          $source_session_id, $recorded_at,
+          $access_count, $last_accessed_at, $stability_hours, $fact_type]]
         :put facts {id, valid_from => content, nous_id, confidence, tier,
-                    valid_to, superseded_by, source_session_id, recorded_at}
+                    valid_to, superseded_by, source_session_id, recorded_at,
+                    access_count, last_accessed_at, stability_hours, fact_type}
     ";
         let built = queries::upsert_fact();
         assert_eq!(normalize(&built), normalize(original));
@@ -882,7 +929,8 @@ mod tests {
         let original = r"
         ?[id, content, confidence, tier, recorded_at] :=
             *facts{id, valid_from, content, nous_id, confidence, tier,
-                   valid_to, superseded_by, recorded_at},
+                   valid_to, superseded_by, recorded_at,
+                   access_count, last_accessed_at, stability_hours, fact_type},
             nous_id = $nous_id,
             valid_from <= $now,
             valid_to > $now,
@@ -910,14 +958,18 @@ mod tests {
     fn test_builder_matches_supersede_fact() {
         let original = r#"
         ?[id, valid_from, content, nous_id, confidence, tier, valid_to,
-          superseded_by, source_session_id, recorded_at] <- [
+          superseded_by, source_session_id, recorded_at,
+          access_count, last_accessed_at, stability_hours, fact_type] <- [
             [$old_id, $old_valid_from, $old_content, $nous_id, $old_confidence,
-             $old_tier, $now, $new_id, $old_source, $old_recorded],
+             $old_tier, $now, $new_id, $old_source, $old_recorded,
+             $old_access_count, $old_last_accessed_at, $old_stability_hours, $old_fact_type],
             [$new_id, $now, $new_content, $nous_id, $new_confidence,
-             $new_tier, "9999-12-31", null, $source_session_id, $now]
+             $new_tier, "9999-12-31", null, $source_session_id, $now,
+             0, "", $stability_hours, $fact_type]
         ]
         :put facts {id, valid_from => content, nous_id, confidence, tier,
-                    valid_to, superseded_by, source_session_id, recorded_at}
+                    valid_to, superseded_by, source_session_id, recorded_at,
+                    access_count, last_accessed_at, stability_hours, fact_type}
     "#;
         let built = queries::supersede_fact();
         assert_eq!(normalize(&built), normalize(original));
@@ -960,9 +1012,11 @@ mod tests {
     #[test]
     fn test_builder_matches_full_current_facts() {
         let original = r"
-    ?[id, content, confidence, tier, recorded_at, nous_id, valid_from, valid_to, superseded_by, source_session_id] :=
+    ?[id, content, confidence, tier, recorded_at, nous_id, valid_from, valid_to, superseded_by, source_session_id,
+      access_count, last_accessed_at, stability_hours, fact_type] :=
         *facts{id, valid_from, content, nous_id, confidence, tier,
-               valid_to, superseded_by, source_session_id, recorded_at},
+               valid_to, superseded_by, source_session_id, recorded_at,
+               access_count, last_accessed_at, stability_hours, fact_type},
         nous_id = $nous_id,
         valid_from <= $now,
         valid_to > $now,


### PR DESCRIPTION
## Summary

- Add 4 columns to CozoDB `facts` relation: `access_count`, `last_accessed_at`, `stability_hours`, `fact_type`
- Instrument `search_hybrid()` and `search_vectors()` to increment access counters on returned facts (fire-and-forget, warn on failure)
- Add `increment_access()` / `increment_access_async()` public API
- Add `default_stability_hours()` mapping for FSRS decay model calibration
- Implement v1→v2 schema migration (read all → drop → recreate → reinsert with defaults → rebuild FTS)
- Bump `SCHEMA_VERSION` from 1 to 2
- Update all raw Datalog `:put` queries across `knowledge_adapter.rs`, `migrate_memory.rs`, and integration tests to carry new columns
- Add `FactsField` variants: `AccessCount`, `LastAccessedAt`, `StabilityHours`, `FactType`
- New integration test file `access_tracking.rs` with insert→search→verify and triple-search tests
- Ignored `knowledge_graph_data_audit` test for manual diagnostics

## Test plan

- [x] `cargo test -p aletheia-mneme --no-default-features --features mneme-engine --lib` — 298 passed
- [x] `cargo clippy -p aletheia-mneme --no-default-features --features mneme-engine --lib` — no new warnings (4 pre-existing unfulfilled lint expectations)
- [x] `cargo check -p aletheia-nous -p aletheia-organon` — clean
- [x] `cargo clippy -p aletheia-nous -p aletheia-organon` — clean
- [ ] Integration tests blocked by pre-existing `graph-algo` feature unification issue (same on main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)