### PR TITLE
feat(mneme): memory_forget tool with schema migration

### DIFF
--- a/crates/aletheia/src/knowledge_adapter.rs
+++ b/crates/aletheia/src/knowledge_adapter.rs
@@ -96,13 +96,16 @@ impl KnowledgeSearchService for KnowledgeSearchAdapter {
             // Mark old fact as superseded
             let retract_script = r"
                 ?[id, valid_from, content, nous_id, confidence, tier, valid_to, superseded_by, source_session_id, recorded_at,
-                  access_count, last_accessed_at, stability_hours, fact_type] :=
+                  access_count, last_accessed_at, stability_hours, fact_type,
+                  is_forgotten, forgotten_at, forget_reason] :=
                     *facts{id: $old_id, valid_from, content, nous_id, confidence, tier, source_session_id, recorded_at,
-                           access_count, last_accessed_at, stability_hours, fact_type},
+                           access_count, last_accessed_at, stability_hours, fact_type,
+                           is_forgotten, forgotten_at, forget_reason},
                     valid_to = $now,
                     superseded_by = $new_id
                 :put facts {id, valid_from => content, nous_id, confidence, tier, valid_to, superseded_by, source_session_id, recorded_at,
-                            access_count, last_accessed_at, stability_hours, fact_type}
+                            access_count, last_accessed_at, stability_hours, fact_type,
+                            is_forgotten, forgotten_at, forget_reason}
             ";
             let mut params = std::collections::BTreeMap::new();
             params.insert(
@@ -137,6 +140,9 @@ impl KnowledgeSearchService for KnowledgeSearchAdapter {
                 last_accessed_at: String::new(),
                 stability_hours: aletheia_mneme::knowledge::default_stability_hours(""),
                 fact_type: String::new(),
+                is_forgotten: false,
+                forgotten_at: None,
+                forget_reason: None,
             };
             self.store
                 .insert_fact(&new_fact)
@@ -159,12 +165,15 @@ impl KnowledgeSearchService for KnowledgeSearchAdapter {
 
             let script = r"
                 ?[id, valid_from, content, nous_id, confidence, tier, valid_to, superseded_by, source_session_id, recorded_at,
-                  access_count, last_accessed_at, stability_hours, fact_type] :=
+                  access_count, last_accessed_at, stability_hours, fact_type,
+                  is_forgotten, forgotten_at, forget_reason] :=
                     *facts{id: $fact_id, valid_from, content, nous_id, confidence, tier, superseded_by, source_session_id, recorded_at,
-                           access_count, last_accessed_at, stability_hours, fact_type},
+                           access_count, last_accessed_at, stability_hours, fact_type,
+                           is_forgotten, forgotten_at, forget_reason},
                     valid_to = $now
                 :put facts {id, valid_from => content, nous_id, confidence, tier, valid_to, superseded_by, source_session_id, recorded_at,
-                            access_count, last_accessed_at, stability_hours, fact_type}
+                            access_count, last_accessed_at, stability_hours, fact_type,
+                            is_forgotten, forgotten_at, forget_reason}
             ";
             let mut params = std::collections::BTreeMap::new();
             params.insert(
@@ -191,15 +200,11 @@ impl KnowledgeSearchService for KnowledgeSearchAdapter {
         let nous_id = nous_id.map(str::to_owned);
         let since = since.map(str::to_owned);
         Box::pin(async move {
-            let now = jiff::Zoned::now()
-                .strftime("%Y-%m-%dT%H:%M:%SZ")
-                .to_string();
             let agent = nous_id.as_deref().unwrap_or("");
             let facts = self
                 .store
-                .query_facts_async(
+                .audit_all_facts_async(
                     agent.to_owned(),
-                    now,
                     i64::try_from(limit).unwrap_or(i64::MAX),
                 )
                 .await
@@ -215,9 +220,43 @@ impl KnowledgeSearchService for KnowledgeSearchAdapter {
                     confidence: f.confidence,
                     tier: f.tier.to_string(),
                     recorded_at: f.recorded_at,
+                    is_forgotten: f.is_forgotten,
+                    forgotten_at: f.forgotten_at,
+                    forget_reason: f.forget_reason.map(|r| r.to_string()),
                 })
                 .collect();
             Ok(out)
+        })
+    }
+
+    fn forget_fact(
+        &self,
+        fact_id: &str,
+        reason: &str,
+    ) -> Pin<Box<dyn Future<Output = Result<(), String>> + Send + '_>> {
+        let fact_id = fact_id.to_owned();
+        let reason = reason.to_owned();
+        Box::pin(async move {
+            let reason: aletheia_mneme::knowledge::ForgetReason = reason
+                .parse()
+                .map_err(|e: String| e)?;
+            self.store
+                .forget_fact_async(fact_id, reason)
+                .await
+                .map_err(|e| format!("failed to forget fact: {e}"))
+        })
+    }
+
+    fn unforget_fact(
+        &self,
+        fact_id: &str,
+    ) -> Pin<Box<dyn Future<Output = Result<(), String>> + Send + '_>> {
+        let fact_id = fact_id.to_owned();
+        Box::pin(async move {
+            self.store
+                .unforget_fact_async(fact_id)
+                .await
+                .map_err(|e| format!("failed to unforget fact: {e}"))
         })
     }
 }

--- a/crates/aletheia/src/migrate_memory.rs
+++ b/crates/aletheia/src/migrate_memory.rs
@@ -247,6 +247,9 @@ fn import_fact(
         last_accessed_at: String::new(),
         stability_hours: aletheia_mneme::knowledge::default_stability_hours(""),
         fact_type: String::new(),
+        is_forgotten: false,
+        forgotten_at: None,
+        forget_reason: None,
     };
     knowledgedb
         .insert_fact(&fact)

--- a/crates/integration-tests/tests/knowledge_lifecycle.rs
+++ b/crates/integration-tests/tests/knowledge_lifecycle.rs
@@ -24,6 +24,9 @@ fn make_fact(id: &str, nous_id: &str, content: &str, confidence: f64, tier: Epis
         last_accessed_at: String::new(),
         stability_hours: 720.0,
         fact_type: String::new(),
+        is_forgotten: false,
+        forgotten_at: None,
+        forget_reason: None,
     }
 }
 
@@ -40,14 +43,17 @@ fn correct_fact(
 ) {
     let script = r"
         ?[id, valid_from, content, nous_id, confidence, tier, valid_to, superseded_by, source_session_id, recorded_at,
-          access_count, last_accessed_at, stability_hours, fact_type] :=
+          access_count, last_accessed_at, stability_hours, fact_type,
+          is_forgotten, forgotten_at, forget_reason] :=
             *facts{id, valid_from, content, nous_id, confidence, tier, source_session_id, recorded_at,
-                   access_count, last_accessed_at, stability_hours, fact_type},
+                   access_count, last_accessed_at, stability_hours, fact_type,
+                   is_forgotten, forgotten_at, forget_reason},
             id = $old_id,
             valid_to = $now,
             superseded_by = $new_id
         :put facts {id, valid_from => content, nous_id, confidence, tier, valid_to, superseded_by, source_session_id, recorded_at,
-                    access_count, last_accessed_at, stability_hours, fact_type}
+                    access_count, last_accessed_at, stability_hours, fact_type,
+                    is_forgotten, forgotten_at, forget_reason}
     ";
     let mut params = BTreeMap::new();
     params.insert("old_id".to_owned(), DataValue::Str(old_id.into()));
@@ -70,6 +76,9 @@ fn correct_fact(
         last_accessed_at: String::new(),
         stability_hours: 720.0,
         fact_type: String::new(),
+        is_forgotten: false,
+        forgotten_at: None,
+        forget_reason: None,
     };
     store.insert_fact(&new_fact).expect("correct: insert new fact");
 }
@@ -79,13 +88,16 @@ fn correct_fact(
 fn retract_fact(store: &Arc<KnowledgeStore>, fact_id: &str, retraction_time: &str) {
     let script = r"
         ?[id, valid_from, content, nous_id, confidence, tier, valid_to, superseded_by, source_session_id, recorded_at,
-          access_count, last_accessed_at, stability_hours, fact_type] :=
+          access_count, last_accessed_at, stability_hours, fact_type,
+          is_forgotten, forgotten_at, forget_reason] :=
             *facts{id, valid_from, content, nous_id, confidence, tier, superseded_by, source_session_id, recorded_at,
-                   access_count, last_accessed_at, stability_hours, fact_type},
+                   access_count, last_accessed_at, stability_hours, fact_type,
+                   is_forgotten, forgotten_at, forget_reason},
             id = $fact_id,
             valid_to = $now
         :put facts {id, valid_from => content, nous_id, confidence, tier, valid_to, superseded_by, source_session_id, recorded_at,
-                    access_count, last_accessed_at, stability_hours, fact_type}
+                    access_count, last_accessed_at, stability_hours, fact_type,
+                    is_forgotten, forgotten_at, forget_reason}
     ";
     let mut params = BTreeMap::new();
     params.insert("fact_id".to_owned(), DataValue::Str(fact_id.into()));
@@ -97,8 +109,10 @@ fn retract_fact(store: &Arc<KnowledgeStore>, fact_id: &str, retraction_time: &st
 /// This is what `audit_facts` SHOULD do (the adapter currently filters out historical facts).
 fn audit_all_facts(store: &Arc<KnowledgeStore>, nous_id: &str) -> Vec<AuditRow> {
     let script = r"
-        ?[id, content, confidence, tier, valid_from, valid_to, superseded_by, recorded_at] :=
-            *facts{id, valid_from, content, nous_id, confidence, tier, valid_to, superseded_by, recorded_at},
+        ?[id, content, confidence, tier, valid_from, valid_to, superseded_by, recorded_at,
+          is_forgotten, forgotten_at, forget_reason] :=
+            *facts{id, valid_from, content, nous_id, confidence, tier, valid_to, superseded_by, recorded_at,
+                   is_forgotten, forgotten_at, forget_reason},
             nous_id = $nous_id
         :order recorded_at
     ";
@@ -146,6 +160,20 @@ fn audit_all_facts(store: &Arc<KnowledgeStore>, nous_id: &str) -> Vec<AuditRow> 
                 DataValue::Str(s) => s.to_string(),
                 other => panic!("expected Str for recorded_at, got {other:?}"),
             };
+            let is_forgotten = match &row[8] {
+                DataValue::Bool(b) => *b,
+                other => panic!("expected Bool for is_forgotten, got {other:?}"),
+            };
+            let forgotten_at = match &row[9] {
+                DataValue::Null => None,
+                DataValue::Str(s) => Some(s.to_string()),
+                other => panic!("expected Str or Null for forgotten_at, got {other:?}"),
+            };
+            let forget_reason = match &row[10] {
+                DataValue::Null => None,
+                DataValue::Str(s) => Some(s.to_string()),
+                other => panic!("expected Str or Null for forget_reason, got {other:?}"),
+            };
             AuditRow {
                 id,
                 content,
@@ -155,6 +183,9 @@ fn audit_all_facts(store: &Arc<KnowledgeStore>, nous_id: &str) -> Vec<AuditRow> 
                 valid_to,
                 superseded_by,
                 recorded_at,
+                is_forgotten,
+                forgotten_at,
+                forget_reason,
             }
         })
         .collect()
@@ -171,6 +202,9 @@ struct AuditRow {
     valid_to: String,
     superseded_by: Option<String>,
     recorded_at: String,
+    is_forgotten: bool,
+    forgotten_at: Option<String>,
+    forget_reason: Option<String>,
 }
 
 fn open_store() -> Arc<KnowledgeStore> {
@@ -369,4 +403,149 @@ fn supersession_chain() {
     assert_eq!(a_v1.valid_to, "2026-04-01T00:00:00Z", "v1 expired at v2 creation");
     assert_eq!(a_v2.valid_to, "2026-07-01T00:00:00Z", "v2 expired at v3 creation");
     assert_eq!(a_v3.valid_to, "9999-12-31", "v3 still current");
+}
+
+// --- Forget lifecycle tests ---
+
+#[test]
+fn forget_excludes_from_recall() {
+    use aletheia_mneme::knowledge::ForgetReason;
+
+    let store = open_store();
+    let nous = "test-agent";
+    let query_time = "2026-07-01T00:00:00Z";
+
+    let fact = make_fact("f-forget", nous, "Bob's SSN is 123-45-6789", 0.9, EpistemicTier::Verified);
+    store.insert_fact(&fact).expect("insert");
+
+    // Visible before forget
+    let results = store.query_facts(nous, query_time, 10).expect("query before forget");
+    assert_eq!(results.len(), 1);
+
+    // Forget it
+    store.forget_fact("f-forget", ForgetReason::Privacy).expect("forget");
+
+    // Not visible after forget
+    let results = store.query_facts(nous, query_time, 10).expect("query after forget");
+    assert!(results.is_empty(), "forgotten fact should be excluded from recall");
+}
+
+#[test]
+fn forget_preserves_for_audit() {
+    use aletheia_mneme::knowledge::ForgetReason;
+
+    let store = open_store();
+    let nous = "test-agent";
+
+    let fact = make_fact("f-audit", nous, "sensitive data", 0.9, EpistemicTier::Verified);
+    store.insert_fact(&fact).expect("insert");
+
+    store.forget_fact("f-audit", ForgetReason::Privacy).expect("forget");
+
+    let audit = audit_all_facts(&store, nous);
+    assert_eq!(audit.len(), 1, "forgotten fact should appear in audit");
+
+    let row = &audit[0];
+    assert!(row.is_forgotten, "should be marked forgotten");
+    assert!(row.forgotten_at.is_some(), "should have forgotten_at timestamp");
+    assert_eq!(row.forget_reason.as_deref(), Some("privacy"), "should have privacy reason");
+}
+
+#[test]
+fn unforget_restores_to_search() {
+    use aletheia_mneme::knowledge::ForgetReason;
+
+    let store = open_store();
+    let nous = "test-agent";
+    let query_time = "2026-07-01T00:00:00Z";
+
+    let fact = make_fact("f-unforget", nous, "reinstated fact", 0.9, EpistemicTier::Verified);
+    store.insert_fact(&fact).expect("insert");
+
+    store.forget_fact("f-unforget", ForgetReason::Outdated).expect("forget");
+
+    let results = store.query_facts(nous, query_time, 10).expect("query after forget");
+    assert!(results.is_empty(), "should be excluded after forget");
+
+    store.unforget_fact("f-unforget").expect("unforget");
+
+    let results = store.query_facts(nous, query_time, 10).expect("query after unforget");
+    assert_eq!(results.len(), 1, "should be restored after unforget");
+    assert_eq!(results[0].id, "f-unforget");
+
+    // Audit should show cleared forget metadata
+    let audit = audit_all_facts(&store, nous);
+    let row = &audit[0];
+    assert!(!row.is_forgotten, "should not be marked forgotten after unforget");
+    assert!(row.forgotten_at.is_none(), "forgotten_at should be cleared");
+    assert!(row.forget_reason.is_none(), "forget_reason should be cleared");
+}
+
+#[test]
+fn forget_with_each_reason() {
+    use aletheia_mneme::knowledge::ForgetReason;
+
+    let store = open_store();
+    let nous = "test-agent";
+
+    for (i, (reason, reason_str)) in [
+        (ForgetReason::UserRequested, "user_requested"),
+        (ForgetReason::Outdated, "outdated"),
+        (ForgetReason::Incorrect, "incorrect"),
+        (ForgetReason::Privacy, "privacy"),
+    ]
+    .iter()
+    .enumerate()
+    {
+        let id = format!("f-reason-{i}");
+        let fact = make_fact(&id, nous, &format!("fact for {reason_str}"), 0.9, EpistemicTier::Verified);
+        store.insert_fact(&fact).expect("insert");
+        store.forget_fact(&id, *reason).expect("forget");
+    }
+
+    let audit = audit_all_facts(&store, nous);
+    assert_eq!(audit.len(), 4);
+    for (i, reason_str) in ["user_requested", "outdated", "incorrect", "privacy"].iter().enumerate() {
+        let row = audit.iter().find(|r| r.id == format!("f-reason-{i}")).expect("find fact");
+        assert!(row.is_forgotten);
+        assert_eq!(row.forget_reason.as_deref(), Some(*reason_str));
+    }
+}
+
+#[test]
+fn full_forget_lifecycle() {
+    use aletheia_mneme::knowledge::ForgetReason;
+
+    let store = open_store();
+    let nous = "test-agent";
+    let query_time = "2026-07-01T00:00:00Z";
+
+    // 1. Insert
+    let fact = make_fact("f-lifecycle", nous, "Alice's phone number is 555-0123", 0.95, EpistemicTier::Verified);
+    store.insert_fact(&fact).expect("insert");
+
+    // 2. Search — found
+    let results = store.query_facts(nous, query_time, 10).expect("query");
+    assert_eq!(results.len(), 1);
+
+    // 3. Forget — privacy
+    store.forget_fact("f-lifecycle", ForgetReason::Privacy).expect("forget");
+
+    // 4. Search — not found
+    let results = store.query_facts(nous, query_time, 10).expect("query after forget");
+    assert!(results.is_empty());
+
+    // 5. Audit — found with metadata
+    let audit = audit_all_facts(&store, nous);
+    assert_eq!(audit.len(), 1);
+    assert!(audit[0].is_forgotten);
+    assert_eq!(audit[0].forget_reason.as_deref(), Some("privacy"));
+
+    // 6. Unforget
+    store.unforget_fact("f-lifecycle").expect("unforget");
+
+    // 7. Search — found again
+    let results = store.query_facts(nous, query_time, 10).expect("query after unforget");
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].content, "Alice's phone number is 555-0123");
 }

--- a/crates/mneme/src/extract.rs
+++ b/crates/mneme/src/extract.rs
@@ -354,6 +354,9 @@ Rules:
                 last_accessed_at: String::new(),
                 stability_hours: crate::knowledge::default_stability_hours("inference"),
                 fact_type: "inference".to_owned(),
+                is_forgotten: false,
+                forgotten_at: None,
+                forget_reason: None,
             };
             store.insert_fact(&f).map_err(|e| {
                 PersistSnafu {

--- a/crates/mneme/src/knowledge.rs
+++ b/crates/mneme/src/knowledge.rs
@@ -41,6 +41,12 @@ pub struct Fact {
     pub stability_hours: f64,
     /// Fact classification for stability defaults.
     pub fact_type: String,
+    /// Whether this fact has been intentionally excluded from recall.
+    pub is_forgotten: bool,
+    /// When the fact was forgotten (ISO 8601).
+    pub forgotten_at: Option<String>,
+    /// Why the fact was forgotten.
+    pub forget_reason: Option<ForgetReason>,
 }
 
 /// An entity in the knowledge graph.
@@ -123,6 +129,52 @@ impl std::fmt::Display for EpistemicTier {
     }
 }
 
+/// Reason for intentionally forgetting a fact.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ForgetReason {
+    /// User explicitly requested removal.
+    UserRequested,
+    /// Fact is outdated.
+    Outdated,
+    /// Fact is incorrect.
+    Incorrect,
+    /// Privacy concern.
+    Privacy,
+}
+
+impl ForgetReason {
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::UserRequested => "user_requested",
+            Self::Outdated => "outdated",
+            Self::Incorrect => "incorrect",
+            Self::Privacy => "privacy",
+        }
+    }
+}
+
+impl std::fmt::Display for ForgetReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl std::str::FromStr for ForgetReason {
+    type Err = String;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        match s {
+            "user_requested" => Ok(Self::UserRequested),
+            "outdated" => Ok(Self::Outdated),
+            "incorrect" => Ok(Self::Incorrect),
+            "privacy" => Ok(Self::Privacy),
+            other => Err(format!("unknown forget reason: {other}")),
+        }
+    }
+}
+
 /// Default FSRS stability by fact type (hours until 50% recall probability).
 #[must_use]
 pub fn default_stability_hours(fact_type: &str) -> f64 {
@@ -183,6 +235,9 @@ mod tests {
             last_accessed_at: String::new(),
             stability_hours: 720.0,
             fact_type: String::new(),
+            is_forgotten: false,
+            forgotten_at: None,
+            forget_reason: None,
         };
         let json = serde_json::to_string(&fact).unwrap();
         let back: Fact = serde_json::from_str(&json).unwrap();
@@ -270,6 +325,9 @@ mod tests {
             last_accessed_at: String::new(),
             stability_hours: 720.0,
             fact_type: String::new(),
+            is_forgotten: false,
+            forgotten_at: None,
+            forget_reason: None,
         };
         let json = serde_json::to_string(&fact).unwrap();
         let back: Fact = serde_json::from_str(&json).unwrap();
@@ -293,6 +351,9 @@ mod tests {
             last_accessed_at: String::new(),
             stability_hours: 720.0,
             fact_type: String::new(),
+            is_forgotten: false,
+            forgotten_at: None,
+            forget_reason: None,
         };
         let json = serde_json::to_string(&fact).unwrap();
         let back: Fact = serde_json::from_str(&json).unwrap();
@@ -345,5 +406,59 @@ mod tests {
             let expected = format!("\"{}\"", tier.as_str());
             assert_eq!(json, expected);
         }
+    }
+
+    #[test]
+    fn forget_reason_serde_roundtrip() {
+        for reason in [
+            ForgetReason::UserRequested,
+            ForgetReason::Outdated,
+            ForgetReason::Incorrect,
+            ForgetReason::Privacy,
+        ] {
+            let json = serde_json::to_string(&reason).unwrap();
+            let back: ForgetReason = serde_json::from_str(&json).unwrap();
+            assert_eq!(reason, back);
+        }
+    }
+
+    #[test]
+    fn forget_reason_as_str_matches_serde() {
+        for reason in [
+            ForgetReason::UserRequested,
+            ForgetReason::Outdated,
+            ForgetReason::Incorrect,
+            ForgetReason::Privacy,
+        ] {
+            let json = serde_json::to_string(&reason).unwrap();
+            let expected = format!("\"{}\"", reason.as_str());
+            assert_eq!(json, expected);
+        }
+    }
+
+    #[test]
+    fn forget_reason_from_str_roundtrip() {
+        for reason in [
+            ForgetReason::UserRequested,
+            ForgetReason::Outdated,
+            ForgetReason::Incorrect,
+            ForgetReason::Privacy,
+        ] {
+            let parsed: ForgetReason = reason.as_str().parse().unwrap();
+            assert_eq!(reason, parsed);
+        }
+    }
+
+    #[test]
+    fn forget_reason_from_str_unknown() {
+        assert!("bogus".parse::<ForgetReason>().is_err());
+    }
+
+    #[test]
+    fn forget_reason_display() {
+        assert_eq!(ForgetReason::UserRequested.to_string(), "user_requested");
+        assert_eq!(ForgetReason::Outdated.to_string(), "outdated");
+        assert_eq!(ForgetReason::Incorrect.to_string(), "incorrect");
+        assert_eq!(ForgetReason::Privacy.to_string(), "privacy");
     }
 }

--- a/crates/mneme/src/knowledge_store.rs
+++ b/crates/mneme/src/knowledge_store.rs
@@ -18,7 +18,8 @@
 //!         confidence: Float, tier: String, valid_to: String, superseded_by: String?,
 //!         source_session_id: String?, recorded_at: String,
 //!         access_count: Int, last_accessed_at: String, stability_hours: Float,
-//!         fact_type: String }
+//!         fact_type: String, is_forgotten: Bool, forgotten_at: String?,
+//!         forget_reason: String? }
 //!
 //! entities { id: String => name: String, entity_type: String, aliases: String,
 //!            created_at: String, updated_at: String }
@@ -61,7 +62,10 @@ pub const KNOWLEDGE_DDL: &[&str] = &[
         access_count: Int,
         last_accessed_at: String,
         stability_hours: Float,
-        fact_type: String
+        fact_type: String,
+        is_forgotten: Bool default false,
+        forgotten_at: String?,
+        forget_reason: String?
     }",
     // Entities: typed nodes in the knowledge graph
     r":create entities {
@@ -186,7 +190,7 @@ pub struct KnowledgeStore {
 
 #[cfg(feature = "mneme-engine")]
 impl KnowledgeStore {
-    const SCHEMA_VERSION: i64 = 2;
+    const SCHEMA_VERSION: i64 = 3;
 
     /// Open an in-memory knowledge store with default configuration.
     pub fn open_mem() -> crate::error::Result<std::sync::Arc<Self>> {
@@ -247,8 +251,11 @@ impl KnowledgeStore {
 
         if already_initialized {
             let current_version = self.schema_version().unwrap_or(0);
-            if current_version < Self::SCHEMA_VERSION {
+            if current_version < 2 {
                 self.migrate_v1_to_v2()?;
+            }
+            if current_version < 3 {
+                self.migrate_v2_to_v3()?;
             }
             return Ok(());
         }
@@ -582,16 +589,19 @@ impl KnowledgeStore {
             let script = r"
                 ?[id, valid_from, content, nous_id, confidence, tier, valid_to,
                   superseded_by, source_session_id, recorded_at,
-                  new_count, new_last, stability_hours, fact_type] :=
+                  new_count, new_last, stability_hours, fact_type,
+                  is_forgotten, forgotten_at, forget_reason] :=
                     *facts{id: $id, valid_from, content, nous_id, confidence, tier,
                            valid_to, superseded_by, source_session_id, recorded_at,
-                           access_count, last_accessed_at, stability_hours, fact_type},
+                           access_count, last_accessed_at, stability_hours, fact_type,
+                           is_forgotten, forgotten_at, forget_reason},
                     new_count = access_count + 1,
                     new_last = $now
                 :put facts {id, valid_from => content, nous_id, confidence, tier,
                             valid_to, superseded_by, source_session_id, recorded_at,
                             access_count: new_count, last_accessed_at: new_last,
-                            stability_hours, fact_type}
+                            stability_hours, fact_type,
+                            is_forgotten, forgotten_at, forget_reason}
             ";
             let mut params = std::collections::BTreeMap::new();
             params.insert(
@@ -620,7 +630,129 @@ impl KnowledgeStore {
             .context(crate::error::JoinSnafu)?
     }
 
+    /// Soft-delete a fact: set `is_forgotten = true` with reason and timestamp.
+    pub fn forget_fact(
+        &self,
+        fact_id: &str,
+        reason: crate::knowledge::ForgetReason,
+    ) -> crate::error::Result<()> {
+        let now = jiff::Zoned::now()
+            .strftime("%Y-%m-%dT%H:%M:%SZ")
+            .to_string();
+        let script = r"
+            ?[id, valid_from, content, nous_id, confidence, tier, valid_to,
+              superseded_by, source_session_id, recorded_at,
+              access_count, last_accessed_at, stability_hours, fact_type,
+              is_forgotten, forgotten_at, forget_reason] :=
+                *facts{id: $id, valid_from, content, nous_id, confidence, tier,
+                       valid_to, superseded_by, source_session_id, recorded_at,
+                       access_count, last_accessed_at, stability_hours, fact_type},
+                is_forgotten = true,
+                forgotten_at = $now,
+                forget_reason = $reason
+            :put facts {id, valid_from => content, nous_id, confidence, tier,
+                        valid_to, superseded_by, source_session_id, recorded_at,
+                        access_count, last_accessed_at, stability_hours, fact_type,
+                        is_forgotten, forgotten_at, forget_reason}
+        ";
+        let mut params = std::collections::BTreeMap::new();
+        params.insert(
+            "id".to_owned(),
+            crate::engine::DataValue::Str(fact_id.into()),
+        );
+        params.insert(
+            "now".to_owned(),
+            crate::engine::DataValue::Str(now.into()),
+        );
+        params.insert(
+            "reason".to_owned(),
+            crate::engine::DataValue::Str(reason.as_str().into()),
+        );
+        self.run_mut(script, params)
+    }
+
+    /// Reverse a soft-delete: clear `is_forgotten`, `forgotten_at`, `forget_reason`.
+    pub fn unforget_fact(&self, fact_id: &str) -> crate::error::Result<()> {
+        let script = r"
+            ?[id, valid_from, content, nous_id, confidence, tier, valid_to,
+              superseded_by, source_session_id, recorded_at,
+              access_count, last_accessed_at, stability_hours, fact_type,
+              is_forgotten, forgotten_at, forget_reason] :=
+                *facts{id: $id, valid_from, content, nous_id, confidence, tier,
+                       valid_to, superseded_by, source_session_id, recorded_at,
+                       access_count, last_accessed_at, stability_hours, fact_type},
+                is_forgotten = false,
+                forgotten_at = null,
+                forget_reason = null
+            :put facts {id, valid_from => content, nous_id, confidence, tier,
+                        valid_to, superseded_by, source_session_id, recorded_at,
+                        access_count, last_accessed_at, stability_hours, fact_type,
+                        is_forgotten, forgotten_at, forget_reason}
+        ";
+        let mut params = std::collections::BTreeMap::new();
+        params.insert(
+            "id".to_owned(),
+            crate::engine::DataValue::Str(fact_id.into()),
+        );
+        self.run_mut(script, params)
+    }
+
+    /// Audit query: returns all facts regardless of forgotten/superseded/temporal state.
+    pub fn audit_all_facts(
+        &self,
+        nous_id: &str,
+        limit: i64,
+    ) -> crate::error::Result<Vec<crate::knowledge::Fact>> {
+        use crate::engine::DataValue;
+        use std::collections::BTreeMap;
+
+        let mut params = BTreeMap::new();
+        params.insert("nous_id".to_owned(), DataValue::Str(nous_id.into()));
+        params.insert("limit".to_owned(), DataValue::from(limit));
+
+        let rows = self.run_read(&queries::audit_all_facts(), params)?;
+        rows_to_facts(rows, nous_id)
+    }
+
     // --- Async wrappers ---
+
+    /// Async `forget_fact` — wraps sync call in `spawn_blocking`.
+    pub async fn forget_fact_async(
+        self: &std::sync::Arc<Self>,
+        fact_id: String,
+        reason: crate::knowledge::ForgetReason,
+    ) -> crate::error::Result<()> {
+        use snafu::ResultExt;
+        let this = std::sync::Arc::clone(self);
+        tokio::task::spawn_blocking(move || this.forget_fact(&fact_id, reason))
+            .await
+            .context(crate::error::JoinSnafu)?
+    }
+
+    /// Async `unforget_fact` — wraps sync call in `spawn_blocking`.
+    pub async fn unforget_fact_async(
+        self: &std::sync::Arc<Self>,
+        fact_id: String,
+    ) -> crate::error::Result<()> {
+        use snafu::ResultExt;
+        let this = std::sync::Arc::clone(self);
+        tokio::task::spawn_blocking(move || this.unforget_fact(&fact_id))
+            .await
+            .context(crate::error::JoinSnafu)?
+    }
+
+    /// Async `audit_all_facts` — wraps sync call in `spawn_blocking`.
+    pub async fn audit_all_facts_async(
+        self: &std::sync::Arc<Self>,
+        nous_id: String,
+        limit: i64,
+    ) -> crate::error::Result<Vec<crate::knowledge::Fact>> {
+        use snafu::ResultExt;
+        let this = std::sync::Arc::clone(self);
+        tokio::task::spawn_blocking(move || this.audit_all_facts(&nous_id, limit))
+            .await
+            .context(crate::error::JoinSnafu)?
+    }
 
     /// Async `insert_fact` — wraps sync call in `spawn_blocking`.
     pub async fn insert_fact_async(
@@ -791,6 +923,142 @@ impl KnowledgeStore {
         Ok(())
     }
 
+    #[expect(clippy::too_many_lines, reason = "migration is a single linear sequence")]
+    fn migrate_v2_to_v3(&self) -> crate::error::Result<()> {
+        use crate::engine::{DataValue, ScriptMutability};
+        use std::collections::BTreeMap;
+
+        tracing::info!("migrating knowledge schema v2 -> v3");
+
+        // 1. Read all existing facts (v2 schema: 14 columns)
+        let all_facts = self
+            .db
+            .run(
+                r"?[id, valid_from, content, nous_id, confidence, tier, valid_to,
+                    superseded_by, source_session_id, recorded_at,
+                    access_count, last_accessed_at, stability_hours, fact_type] :=
+                    *facts{id, valid_from, content, nous_id, confidence, tier,
+                           valid_to, superseded_by, source_session_id, recorded_at,
+                           access_count, last_accessed_at, stability_hours, fact_type}",
+                BTreeMap::new(),
+                ScriptMutability::Immutable,
+            )
+            .map_err(|e| {
+                crate::error::EngineQuerySnafu {
+                    message: format!("v2->v3 read facts: {e}"),
+                }
+                .build()
+            })?;
+
+        // 2. Drop FTS index
+        let _ = self.db.run(
+            "::fts drop facts:content_fts",
+            BTreeMap::new(),
+            ScriptMutability::Mutable,
+        );
+
+        // 3. Drop old facts relation
+        self.db
+            .run("::remove facts", BTreeMap::new(), ScriptMutability::Mutable)
+            .map_err(|e| {
+                crate::error::EngineQuerySnafu {
+                    message: format!("v2->v3 remove facts: {e}"),
+                }
+                .build()
+            })?;
+
+        // 4. Recreate with new schema (includes forget columns)
+        self.db
+            .run(KNOWLEDGE_DDL[0], BTreeMap::new(), ScriptMutability::Mutable)
+            .map_err(|e| {
+                crate::error::EngineQuerySnafu {
+                    message: format!("v2->v3 recreate facts: {e}"),
+                }
+                .build()
+            })?;
+
+        // 5. Reinsert facts with defaults for new columns
+        for row in &all_facts.rows {
+            let script = r"
+                ?[id, valid_from, content, nous_id, confidence, tier, valid_to,
+                  superseded_by, source_session_id, recorded_at,
+                  access_count, last_accessed_at, stability_hours, fact_type,
+                  is_forgotten, forgotten_at, forget_reason] <- [[
+                    $id, $valid_from, $content, $nous_id, $confidence, $tier, $valid_to,
+                    $superseded_by, $source_session_id, $recorded_at,
+                    $access_count, $last_accessed_at, $stability_hours, $fact_type,
+                    false, null, null
+                ]]
+                :put facts {id, valid_from => content, nous_id, confidence, tier,
+                            valid_to, superseded_by, source_session_id, recorded_at,
+                            access_count, last_accessed_at, stability_hours, fact_type,
+                            is_forgotten, forgotten_at, forget_reason}
+            ";
+            let mut params = BTreeMap::new();
+            for (i, name) in [
+                "id",
+                "valid_from",
+                "content",
+                "nous_id",
+                "confidence",
+                "tier",
+                "valid_to",
+                "superseded_by",
+                "source_session_id",
+                "recorded_at",
+                "access_count",
+                "last_accessed_at",
+                "stability_hours",
+                "fact_type",
+            ]
+            .iter()
+            .enumerate()
+            {
+                if let Some(val) = row.get(i) {
+                    params.insert((*name).to_owned(), val.clone());
+                }
+            }
+            self.db
+                .run(script, params, ScriptMutability::Mutable)
+                .map_err(|e| {
+                    crate::error::EngineQuerySnafu {
+                        message: format!("v2->v3 reinsert fact: {e}"),
+                    }
+                    .build()
+                })?;
+        }
+
+        // 6. Recreate FTS index
+        self.db
+            .run(fts_ddl(), BTreeMap::new(), ScriptMutability::Mutable)
+            .map_err(|e| {
+                crate::error::EngineQuerySnafu {
+                    message: format!("v2->v3 recreate FTS: {e}"),
+                }
+                .build()
+            })?;
+
+        // 7. Update schema version
+        let mut params = BTreeMap::new();
+        params.insert("key".to_owned(), DataValue::Str("schema".into()));
+        params.insert("version".to_owned(), DataValue::from(Self::SCHEMA_VERSION));
+        self.db
+            .run(
+                r"?[key, version] <- [[$key, $version]] :put schema_version { key => version }",
+                params,
+                ScriptMutability::Mutable,
+            )
+            .map_err(|e| {
+                crate::error::EngineQuerySnafu {
+                    message: format!("v2->v3 update version: {e}"),
+                }
+                .build()
+            })?;
+
+        tracing::info!("knowledge schema migration v2 -> v3 complete");
+        Ok(())
+    }
+
     // --- Internal helpers ---
 
     fn run_mut(
@@ -887,6 +1155,24 @@ fn fact_to_params(
     p.insert(
         "fact_type".to_owned(),
         DataValue::Str(fact.fact_type.as_str().into()),
+    );
+    p.insert(
+        "is_forgotten".to_owned(),
+        DataValue::Bool(fact.is_forgotten),
+    );
+    p.insert(
+        "forgotten_at".to_owned(),
+        match &fact.forgotten_at {
+            Some(s) => DataValue::Str(s.as_str().into()),
+            None => DataValue::Null,
+        },
+    );
+    p.insert(
+        "forget_reason".to_owned(),
+        match &fact.forget_reason {
+            Some(r) => DataValue::Str(r.as_str().into()),
+            None => DataValue::Null,
+        },
     );
     p
 }
@@ -1067,6 +1353,19 @@ fn rows_to_facts(
             .get(13)
             .and_then(|v| extract_str(v).ok())
             .unwrap_or_default();
+        let is_forgotten = row
+            .get(14)
+            .and_then(|v| extract_bool(v).ok())
+            .unwrap_or(false);
+        let forgotten_at = row
+            .get(15)
+            .and_then(|v| extract_optional_str(v).ok())
+            .unwrap_or(None);
+        let forget_reason = row
+            .get(16)
+            .and_then(|v| extract_optional_str(v).ok())
+            .unwrap_or(None)
+            .and_then(|s| s.parse::<crate::knowledge::ForgetReason>().ok());
 
         out.push(Fact {
             id,
@@ -1087,6 +1386,9 @@ fn rows_to_facts(
             last_accessed_at,
             stability_hours,
             fact_type,
+            is_forgotten,
+            forgotten_at,
+            forget_reason,
         });
     }
     Ok(out)
@@ -1141,6 +1443,9 @@ fn rows_to_facts_partial(
             last_accessed_at: String::new(),
             stability_hours: 720.0,
             fact_type: String::new(),
+            is_forgotten: false,
+            forgotten_at: None,
+            forget_reason: None,
         });
     }
     Ok(out)
@@ -1324,6 +1629,17 @@ fn extract_int(val: &crate::engine::DataValue) -> crate::error::Result<i64> {
 }
 
 #[cfg(feature = "mneme-engine")]
+fn extract_bool(val: &crate::engine::DataValue) -> crate::error::Result<bool> {
+    match val {
+        crate::engine::DataValue::Bool(b) => Ok(*b),
+        other => Err(crate::error::ConversionSnafu {
+            message: format!("expected Bool, got {other:?}"),
+        }
+        .build()),
+    }
+}
+
+#[cfg(feature = "mneme-engine")]
 fn parse_epistemic_tier(s: &str) -> crate::error::Result<crate::knowledge::EpistemicTier> {
     use crate::knowledge::EpistemicTier;
     match s {
@@ -1495,6 +1811,9 @@ mod tests {
             last_accessed_at: String::new(),
             stability_hours: 720.0,
             fact_type: String::new(),
+            is_forgotten: false,
+            forgotten_at: None,
+            forget_reason: None,
         };
         store.insert_fact(&fact).expect("insert fact");
 
@@ -1560,6 +1879,9 @@ mod tests {
             last_accessed_at: String::new(),
             stability_hours: 720.0,
             fact_type: String::new(),
+            is_forgotten: false,
+            forgotten_at: None,
+            forget_reason: None,
         };
         store.insert_fact(&f1).expect("insert f1");
         store
@@ -1590,6 +1912,9 @@ mod tests {
             last_accessed_at: String::new(),
             stability_hours: 720.0,
             fact_type: String::new(),
+            is_forgotten: false,
+            forgotten_at: None,
+            forget_reason: None,
         };
         store.insert_fact(&f2).expect("insert f2");
         store
@@ -1699,6 +2024,9 @@ mod tests {
             last_accessed_at: String::new(),
             stability_hours: 720.0,
             fact_type: String::new(),
+            is_forgotten: false,
+            forgotten_at: None,
+            forget_reason: None,
         };
         store.insert_fact(&fact).expect("insert fact");
 
@@ -1774,6 +2102,9 @@ mod tests {
             last_accessed_at: String::new(),
             stability_hours: 720.0,
             fact_type: String::new(),
+            is_forgotten: false,
+            forgotten_at: None,
+            forget_reason: None,
         };
         store.insert_fact(&fact).expect("insert fact");
 

--- a/crates/mneme/src/query.rs
+++ b/crates/mneme/src/query.rs
@@ -51,6 +51,9 @@ pub enum FactsField {
     LastAccessedAt,
     StabilityHours,
     FactType,
+    IsForgotten,
+    ForgottenAt,
+    ForgetReason,
 }
 
 impl Field for FactsField {
@@ -70,6 +73,9 @@ impl Field for FactsField {
             Self::LastAccessedAt => "last_accessed_at",
             Self::StabilityHours => "stability_hours",
             Self::FactType => "fact_type",
+            Self::IsForgotten => "is_forgotten",
+            Self::ForgottenAt => "forgotten_at",
+            Self::ForgetReason => "forget_reason",
         }
     }
 }
@@ -418,6 +424,9 @@ pub mod queries {
                 LastAccessedAt,
                 StabilityHours,
                 FactType,
+                IsForgotten,
+                ForgottenAt,
+                ForgetReason,
             ])
             .done()
             .build_script()
@@ -443,10 +452,14 @@ pub mod queries {
             .bind(LastAccessedAt)
             .bind(StabilityHours)
             .bind(FactType)
+            .bind(IsForgotten)
+            .bind(ForgottenAt)
+            .bind(ForgetReason)
             .filter("nous_id = $nous_id")
             .filter("valid_from <= $now")
             .filter("valid_to > $now")
             .filter("is_null(superseded_by)")
+            .filter("is_forgotten == false")
             .order("-confidence")
             .limit("$limit")
             .done()
@@ -474,6 +487,9 @@ pub mod queries {
                 LastAccessedAt,
                 StabilityHours,
                 FactType,
+                IsForgotten,
+                ForgottenAt,
+                ForgetReason,
             ])
             .bind(Id)
             .bind(ValidFrom)
@@ -489,10 +505,14 @@ pub mod queries {
             .bind(LastAccessedAt)
             .bind(StabilityHours)
             .bind(FactType)
+            .bind(IsForgotten)
+            .bind(ForgottenAt)
+            .bind(ForgetReason)
             .filter("nous_id = $nous_id")
             .filter("valid_from <= $now")
             .filter("valid_to > $now")
             .filter("is_null(superseded_by)")
+            .filter("is_forgotten == false")
             .order("-confidence")
             .limit("$limit")
             .done()
@@ -511,8 +531,10 @@ pub mod queries {
             .bind(Confidence)
             .bind(Tier)
             .bind(ValidTo)
+            .bind(IsForgotten)
             .filter("valid_from <= $time")
             .filter("valid_to > $time")
+            .filter("is_forgotten == false")
             .done()
             .build_script()
     }
@@ -540,6 +562,9 @@ pub mod queries {
                 LastAccessedAt,
                 StabilityHours,
                 FactType,
+                IsForgotten,
+                ForgottenAt,
+                ForgetReason,
             ])
             .row(&[
                 "$old_id",
@@ -556,6 +581,9 @@ pub mod queries {
                 "$old_last_accessed_at",
                 "$old_stability_hours",
                 "$old_fact_type",
+                "$old_is_forgotten",
+                "$old_forgotten_at",
+                "$old_forget_reason",
             ])
             .row(&[
                 "$new_id",
@@ -572,6 +600,9 @@ pub mod queries {
                 "\"\"",
                 "$stability_hours",
                 "$fact_type",
+                "false",
+                "null",
+                "null",
             ])
             .done()
             .build_script()
@@ -661,6 +692,55 @@ pub mod queries {
         :order -rrf_score
         :limit $limit
     ";
+
+    /// Audit query returning all facts regardless of forgotten/superseded/temporal state.
+    /// Params: `$nous_id`, `$limit`.
+    pub fn audit_all_facts() -> String {
+        use FactsField::*;
+        QueryBuilder::new()
+            .scan(Relation::Facts)
+            .select(&[
+                Id,
+                Content,
+                Confidence,
+                Tier,
+                RecordedAt,
+                NousId,
+                ValidFrom,
+                ValidTo,
+                SupersededBy,
+                SourceSessionId,
+                AccessCount,
+                LastAccessedAt,
+                StabilityHours,
+                FactType,
+                IsForgotten,
+                ForgottenAt,
+                ForgetReason,
+            ])
+            .bind(Id)
+            .bind(ValidFrom)
+            .bind(Content)
+            .bind(NousId)
+            .bind(Confidence)
+            .bind(Tier)
+            .bind(ValidTo)
+            .bind(SupersededBy)
+            .bind(SourceSessionId)
+            .bind(RecordedAt)
+            .bind(AccessCount)
+            .bind(LastAccessedAt)
+            .bind(StabilityHours)
+            .bind(FactType)
+            .bind(IsForgotten)
+            .bind(ForgottenAt)
+            .bind(ForgetReason)
+            .filter("nous_id = $nous_id")
+            .order("-recorded_at")
+            .limit("$limit")
+            .done()
+            .build_script()
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -811,6 +891,9 @@ mod tests {
             "last_accessed_at",
             "stability_hours",
             "fact_type",
+            "is_forgotten",
+            "forgotten_at",
+            "forget_reason",
         ];
         let facts_enum_fields: Vec<&str> = [
             FactsField::Id,
@@ -827,6 +910,9 @@ mod tests {
             FactsField::LastAccessedAt,
             FactsField::StabilityHours,
             FactsField::FactType,
+            FactsField::IsForgotten,
+            FactsField::ForgottenAt,
+            FactsField::ForgetReason,
         ]
         .iter()
         .map(|f| f.name())
@@ -912,13 +998,16 @@ mod tests {
         let original = r"
         ?[id, valid_from, content, nous_id, confidence, tier, valid_to,
           superseded_by, source_session_id, recorded_at,
-          access_count, last_accessed_at, stability_hours, fact_type] <- [[$id, $valid_from,
+          access_count, last_accessed_at, stability_hours, fact_type,
+          is_forgotten, forgotten_at, forget_reason] <- [[$id, $valid_from,
           $content, $nous_id, $confidence, $tier, $valid_to, $superseded_by,
           $source_session_id, $recorded_at,
-          $access_count, $last_accessed_at, $stability_hours, $fact_type]]
+          $access_count, $last_accessed_at, $stability_hours, $fact_type,
+          $is_forgotten, $forgotten_at, $forget_reason]]
         :put facts {id, valid_from => content, nous_id, confidence, tier,
                     valid_to, superseded_by, source_session_id, recorded_at,
-                    access_count, last_accessed_at, stability_hours, fact_type}
+                    access_count, last_accessed_at, stability_hours, fact_type,
+                    is_forgotten, forgotten_at, forget_reason}
     ";
         let built = queries::upsert_fact();
         assert_eq!(normalize(&built), normalize(original));
@@ -930,11 +1019,13 @@ mod tests {
         ?[id, content, confidence, tier, recorded_at] :=
             *facts{id, valid_from, content, nous_id, confidence, tier,
                    valid_to, superseded_by, recorded_at,
-                   access_count, last_accessed_at, stability_hours, fact_type},
+                   access_count, last_accessed_at, stability_hours, fact_type,
+                   is_forgotten, forgotten_at, forget_reason},
             nous_id = $nous_id,
             valid_from <= $now,
             valid_to > $now,
-            is_null(superseded_by)
+            is_null(superseded_by),
+            is_forgotten == false
         :order -confidence
         :limit $limit
     ";
@@ -946,9 +1037,10 @@ mod tests {
     fn test_builder_matches_facts_at_time() {
         let original = r"
         ?[id, content, confidence, tier] :=
-            *facts{id, valid_from, content, confidence, tier, valid_to},
+            *facts{id, valid_from, content, confidence, tier, valid_to, is_forgotten},
             valid_from <= $time,
-            valid_to > $time
+            valid_to > $time,
+            is_forgotten == false
     ";
         let built = queries::facts_at_time();
         assert_eq!(normalize(&built), normalize(original));
@@ -959,17 +1051,21 @@ mod tests {
         let original = r#"
         ?[id, valid_from, content, nous_id, confidence, tier, valid_to,
           superseded_by, source_session_id, recorded_at,
-          access_count, last_accessed_at, stability_hours, fact_type] <- [
+          access_count, last_accessed_at, stability_hours, fact_type,
+          is_forgotten, forgotten_at, forget_reason] <- [
             [$old_id, $old_valid_from, $old_content, $nous_id, $old_confidence,
              $old_tier, $now, $new_id, $old_source, $old_recorded,
-             $old_access_count, $old_last_accessed_at, $old_stability_hours, $old_fact_type],
+             $old_access_count, $old_last_accessed_at, $old_stability_hours, $old_fact_type,
+             $old_is_forgotten, $old_forgotten_at, $old_forget_reason],
             [$new_id, $now, $new_content, $nous_id, $new_confidence,
              $new_tier, "9999-12-31", null, $source_session_id, $now,
-             0, "", $stability_hours, $fact_type]
+             0, "", $stability_hours, $fact_type,
+             false, null, null]
         ]
         :put facts {id, valid_from => content, nous_id, confidence, tier,
                     valid_to, superseded_by, source_session_id, recorded_at,
-                    access_count, last_accessed_at, stability_hours, fact_type}
+                    access_count, last_accessed_at, stability_hours, fact_type,
+                    is_forgotten, forgotten_at, forget_reason}
     "#;
         let built = queries::supersede_fact();
         assert_eq!(normalize(&built), normalize(original));
@@ -1013,14 +1109,17 @@ mod tests {
     fn test_builder_matches_full_current_facts() {
         let original = r"
     ?[id, content, confidence, tier, recorded_at, nous_id, valid_from, valid_to, superseded_by, source_session_id,
-      access_count, last_accessed_at, stability_hours, fact_type] :=
+      access_count, last_accessed_at, stability_hours, fact_type,
+      is_forgotten, forgotten_at, forget_reason] :=
         *facts{id, valid_from, content, nous_id, confidence, tier,
                valid_to, superseded_by, source_session_id, recorded_at,
-               access_count, last_accessed_at, stability_hours, fact_type},
+               access_count, last_accessed_at, stability_hours, fact_type,
+               is_forgotten, forgotten_at, forget_reason},
         nous_id = $nous_id,
         valid_from <= $now,
         valid_to > $now,
-        is_null(superseded_by)
+        is_null(superseded_by),
+        is_forgotten == false
     :order -confidence
     :limit $limit
 ";

--- a/crates/organon/src/builtins/memory.rs
+++ b/crates/organon/src/builtins/memory.rs
@@ -132,6 +132,38 @@ impl ToolExecutor for MemoryRetractExecutor {
     }
 }
 
+// --- Memory Forget ---
+
+struct MemoryForgetExecutor;
+
+impl ToolExecutor for MemoryForgetExecutor {
+    fn execute<'a>(
+        &'a self,
+        input: &'a ToolInput,
+        ctx: &'a ToolContext,
+    ) -> Pin<Box<dyn Future<Output = Result<ToolResult>> + Send + 'a>> {
+        Box::pin(async {
+            let services = match require_services(ctx) {
+                Ok(s) => s,
+                Err(e) => return Ok(e),
+            };
+            let Some(knowledge) = services.knowledge.as_ref() else {
+                return Ok(ToolResult::error("knowledge store not configured"));
+            };
+
+            let fact_id = extract_str(&input.arguments, "fact_id", &input.name)?;
+            let reason = extract_str(&input.arguments, "reason", &input.name)?;
+
+            match knowledge.forget_fact(fact_id, reason).await {
+                Ok(()) => Ok(ToolResult::text(format!(
+                    "Fact {fact_id} forgotten (reason: {reason})."
+                ))),
+                Err(e) => Ok(ToolResult::error(format!("Failed to forget fact: {e}"))),
+            }
+        })
+    }
+}
+
 // --- Memory Audit ---
 
 struct MemoryAuditExecutor;
@@ -169,8 +201,17 @@ impl ToolExecutor for MemoryAuditExecutor {
                     let lines: Vec<String> = facts
                         .iter()
                         .map(|f| {
+                            let forgotten_suffix = if f.is_forgotten {
+                                let reason = f
+                                    .forget_reason
+                                    .as_deref()
+                                    .unwrap_or("unknown");
+                                format!(" [FORGOTTEN: {reason}]")
+                            } else {
+                                String::new()
+                            };
                             format!(
-                                "- [{}] ({:.0}% {}) {} ({})",
+                                "- [{}] ({:.0}% {}) {} ({}){forgotten_suffix}",
                                 f.id,
                                 f.confidence * 100.0,
                                 f.tier,
@@ -360,6 +401,7 @@ pub fn register(registry: &mut ToolRegistry) -> Result<()> {
     registry.register(memory_search_def(), Box::new(MemorySearchExecutor))?;
     registry.register(memory_correct_def(), Box::new(MemoryCorrectExecutor))?;
     registry.register(memory_retract_def(), Box::new(MemoryRetractExecutor))?;
+    registry.register(memory_forget_def(), Box::new(MemoryForgetExecutor))?;
     registry.register(memory_audit_def(), Box::new(MemoryAuditExecutor))?;
     registry.register(note_def(), Box::new(NoteExecutor))?;
     registry.register(blackboard_def(), Box::new(BlackboardExecutor))?;
@@ -461,6 +503,46 @@ fn memory_retract_def() -> ToolDef {
                 ),
             ]),
             required: vec!["fact_id".to_owned()],
+        },
+        category: ToolCategory::Memory,
+        auto_activate: false,
+    }
+}
+
+fn memory_forget_def() -> ToolDef {
+    ToolDef {
+        name: ToolName::new("memory_forget").expect("valid tool name"),
+        description: "Soft-delete a fact from memory (reversible, preserves audit trail)"
+            .to_owned(),
+        extended_description: None,
+        input_schema: InputSchema {
+            properties: IndexMap::from([
+                (
+                    "fact_id".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::String,
+                        description: "ID of the fact to forget".to_owned(),
+                        enum_values: None,
+                        default: None,
+                    },
+                ),
+                (
+                    "reason".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::String,
+                        description:
+                            "Why: user_requested, outdated, incorrect, privacy".to_owned(),
+                        enum_values: Some(vec![
+                            "user_requested".to_owned(),
+                            "outdated".to_owned(),
+                            "incorrect".to_owned(),
+                            "privacy".to_owned(),
+                        ]),
+                        default: None,
+                    },
+                ),
+            ]),
+            required: vec!["fact_id".to_owned(), "reason".to_owned()],
         },
         category: ToolCategory::Memory,
         auto_activate: false,
@@ -772,7 +854,7 @@ mod tests {
     async fn register_memory_tools() {
         let mut reg = ToolRegistry::new();
         super::register(&mut reg).expect("register");
-        assert_eq!(reg.definitions().len(), 6);
+        assert_eq!(reg.definitions().len(), 7);
     }
 
     #[tokio::test]
@@ -1118,6 +1200,38 @@ mod tests {
         let mut reg = ToolRegistry::new();
         super::register(&mut reg).expect("register");
         let name = ToolName::new("memory_audit").expect("valid");
+        let def = reg.get_def(&name).expect("found");
+        assert!(!def.auto_activate);
+    }
+
+    #[tokio::test]
+    async fn memory_forget_no_knowledge_returns_error() {
+        let mut reg = ToolRegistry::new();
+        super::register(&mut reg).expect("register");
+        let note_store = Arc::new(MockNoteStore::new());
+        let bb_store = Arc::new(MockBlackboardStore::new());
+        let ctx = ctx_with_services(note_store, bb_store);
+
+        let input = ToolInput {
+            name: ToolName::new("memory_forget").expect("valid"),
+            tool_use_id: "tu_1".to_owned(),
+            arguments: serde_json::json!({"fact_id": "f-1", "reason": "privacy"}),
+        };
+        let result = reg.execute(&input, &ctx).await.expect("execute");
+        assert!(result.is_error);
+        assert!(
+            result
+                .content
+                .text_summary()
+                .contains("knowledge store not configured")
+        );
+    }
+
+    #[tokio::test]
+    async fn memory_forget_not_auto_activated() {
+        let mut reg = ToolRegistry::new();
+        super::register(&mut reg).expect("register");
+        let name = ToolName::new("memory_forget").expect("valid");
         let def = reg.get_def(&name).expect("found");
         assert!(!def.auto_activate);
     }

--- a/crates/organon/src/types.rs
+++ b/crates/organon/src/types.rs
@@ -361,6 +361,9 @@ pub struct FactSummary {
     pub confidence: f64,
     pub tier: String,
     pub recorded_at: String,
+    pub is_forgotten: bool,
+    pub forgotten_at: Option<String>,
+    pub forget_reason: Option<String>,
 }
 
 /// Abstracts knowledge store operations for memory tools.
@@ -393,6 +396,17 @@ pub trait KnowledgeSearchService: Send + Sync {
         since: Option<&str>,
         limit: usize,
     ) -> Pin<Box<dyn Future<Output = Result<Vec<FactSummary>, String>> + Send + '_>>;
+
+    fn forget_fact(
+        &self,
+        fact_id: &str,
+        reason: &str,
+    ) -> Pin<Box<dyn Future<Output = Result<(), String>> + Send + '_>>;
+
+    fn unforget_fact(
+        &self,
+        fact_id: &str,
+    ) -> Pin<Box<dyn Future<Output = Result<(), String>> + Send + '_>>;
 }
 
 /// Service locator for tool executors needing access to runtime services.


### PR DESCRIPTION
## Summary

- Add soft-delete (forget/unforget) for facts, distinct from temporal retraction — forgotten facts are excluded from all recall but preserved in audit with full metadata
- Schema migration v2→v3 adds `is_forgotten`, `forgotten_at`, `forget_reason` columns to facts relation with `ForgetReason` enum (user_requested, outdated, incorrect, privacy)
- New `memory_forget` tool in organon (lazy, via `enable_tool`) with `forget_fact`/`unforget_fact` on `KnowledgeSearchService` trait
- Query builder extended with `is_forgotten == false` filtering on all search paths; new `audit_all_facts` query bypasses filters for audit trail

## Changes

| Crate | What |
|-------|------|
| `mneme/knowledge.rs` | `ForgetReason` enum + 3 fields on `Fact` |
| `mneme/query.rs` | 3 new `FactsField` variants, updated all queries, `audit_all_facts()` builder |
| `mneme/knowledge_store.rs` | DDL v3, migration, `forget_fact`/`unforget_fact`/`audit_all_facts` methods |
| `organon/types.rs` | `FactSummary` + `KnowledgeSearchService` trait extensions |
| `organon/builtins/memory.rs` | `MemoryForgetExecutor` + def, audit display update |
| `aletheia/knowledge_adapter.rs` | Trait impl for forget/unforget, audit fix |
| `integration-tests` | 5 new forget lifecycle tests |

## Test plan

- [x] `cargo test -p aletheia-mneme --no-default-features --features mneme-engine --lib` — 303 passed
- [x] `cargo test -p aletheia-organon` — 117 passed
- [x] `cargo clippy -p aletheia-mneme --all-targets -- -D warnings` — clean
- [x] `cargo clippy -p aletheia-organon --all-targets -- -D warnings` — clean
- [ ] Integration tests written but blocked by pre-existing `graph-algo` compile errors (same on main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)