### PR TITLE
refactor: code hygiene sweep — silent unwraps, mutex comments, validation error type

### DIFF
--- a/crates/agora/src/semeion/client.rs
+++ b/crates/agora/src/semeion/client.rs
@@ -206,7 +206,7 @@ impl SignalClient {
             Some(serde_json::Value::Array(items)) => {
                 let mut envelopes = Vec::with_capacity(items.len());
                 for item in items {
-                    let env_value = item.get("envelope").cloned().unwrap_or(item.clone());
+                    let env_value = item.get("envelope").cloned().unwrap_or(item);
 
                     match serde_json::from_value::<SignalEnvelope>(env_value) {
                         Ok(env) => envelopes.push(env),

--- a/crates/agora/src/semeion/mod.rs
+++ b/crates/agora/src/semeion/mod.rs
@@ -166,17 +166,17 @@ impl SignalProvider {
     fn build_send_params(account: &str, params: &ChannelSendParams) -> client::SendParams {
         let target = parse_target(&params.to);
         match target {
-            SignalTarget::Phone(ref phone) => client::SendParams {
+            SignalTarget::Phone(phone) => client::SendParams {
                 message: Some(params.text.clone()),
-                recipient: Some(phone.clone()),
+                recipient: Some(phone),
                 group_id: None,
                 account: Some(account.to_owned()),
                 attachments: params.attachments.clone(),
             },
-            SignalTarget::Group(ref group_id) => client::SendParams {
+            SignalTarget::Group(group_id) => client::SendParams {
                 message: Some(params.text.clone()),
                 recipient: None,
-                group_id: Some(group_id.clone()),
+                group_id: Some(group_id),
                 account: Some(account.to_owned()),
                 attachments: params.attachments.clone(),
             },

--- a/crates/aletheia/src/main.rs
+++ b/crates/aletheia/src/main.rs
@@ -781,7 +781,10 @@ async fn serve(cli: Cli) -> Result<()> {
     }
 
     // Pylon HTTP gateway — shares registries with NousManager
-    let aletheia_config = aletheia_taxis::loader::load_config(&oikos_arc).unwrap_or_default();
+    let aletheia_config = aletheia_taxis::loader::load_config(&oikos_arc).unwrap_or_else(|e| {
+        tracing::warn!("failed to load config, using defaults: {e}");
+        aletheia_taxis::config::AletheiaConfig::default()
+    });
     let state = Arc::new(AppState {
         session_store,
         nous_manager: Arc::clone(&nous_manager),

--- a/crates/integration-tests/tests/knowledge_engine.rs
+++ b/crates/integration-tests/tests/knowledge_engine.rs
@@ -58,7 +58,10 @@ fn fact_round_trip() {
 
     assert_eq!(results.len(), 1);
     assert_eq!(results[0].id, "f-1");
-    assert_eq!(results[0].content, "The researcher published findings on memory consolidation");
+    assert_eq!(
+        results[0].content,
+        "The researcher published findings on memory consolidation"
+    );
     assert!((results[0].confidence - 0.95).abs() < f64::EPSILON);
     assert_eq!(results[0].tier, EpistemicTier::Verified);
 }

--- a/crates/integration-tests/tests/recall_pipeline.rs
+++ b/crates/integration-tests/tests/recall_pipeline.rs
@@ -45,7 +45,13 @@ fn recall_with_mock_vectors_end_to_end() {
     });
 
     let result = stage
-        .run("What did the researcher publish?", "syn", &embedder, &search, 10000)
+        .run(
+            "What did the researcher publish?",
+            "syn",
+            &embedder,
+            &search,
+            10000,
+        )
         .expect("recall should succeed");
 
     assert!(result.candidates_found >= 1);

--- a/crates/koina/src/redact.rs
+++ b/crates/koina/src/redact.rs
@@ -7,21 +7,24 @@ use std::sync::LazyLock;
 
 use regex::Regex;
 
-static RE_ANTHROPIC_KEY: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"sk-ant-api03-[A-Za-z0-9_-]+").expect("regex"));
+static RE_ANTHROPIC_KEY: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"sk-ant-api03-[A-Za-z0-9_-]+").expect("static regex must compile")
+});
 
 static RE_SK_KEY: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"sk-[A-Za-z0-9_-]{20,}").expect("regex"));
+    LazyLock::new(|| Regex::new(r"sk-[A-Za-z0-9_-]{20,}").expect("static regex must compile"));
 
 static RE_BEARER: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"Bearer [A-Za-z0-9._-]+").expect("regex"));
+    LazyLock::new(|| Regex::new(r"Bearer [A-Za-z0-9._-]+").expect("static regex must compile"));
 
 static RE_JWT: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+").expect("regex")
+    Regex::new(r"eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+")
+        .expect("static regex must compile")
 });
 
 static RE_SECRETS: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"(?i)(password|secret|api_key|apikey)\s*[:=]\s*\S+").expect("regex")
+    Regex::new(r"(?i)(password|secret|api_key|apikey)\s*[:=]\s*\S+")
+        .expect("static regex must compile")
 });
 
 /// Redact sensitive values (API keys, JWTs, bearer tokens, passwords) from a string.

--- a/crates/melete/src/distill.rs
+++ b/crates/melete/src/distill.rs
@@ -373,7 +373,7 @@ mod tests {
         ) -> aletheia_hermeneus::error::Result<CompletionResponse> {
             self.response
                 .lock()
-                .expect("lock poisoned")
+                .expect("lock poisoned") // INVARIANT: test mock, panic = test bug
                 .take()
                 .expect("mock provider called more than once")
         }

--- a/crates/melete/src/roundtrip_tests.rs
+++ b/crates/melete/src/roundtrip_tests.rs
@@ -42,7 +42,7 @@ impl LlmProvider for MockProvider {
     ) -> aletheia_hermeneus::error::Result<CompletionResponse> {
         self.response
             .lock()
-            .expect("lock")
+            .expect("lock") // INVARIANT: test mock, panic = test bug
             .take()
             .expect("mock provider called more than once")
     }

--- a/crates/mneme/src/embedding.rs
+++ b/crates/mneme/src/embedding.rs
@@ -202,7 +202,7 @@ impl EmbeddingProvider for FastEmbedProvider {
     fn embed(&self, text: &str) -> EmbeddingResult<Vec<f32>> {
         self.model
             .lock()
-            .expect("fastembed model lock")
+            .expect("fastembed model lock") // INVARIANT: lock held only for embed call, poisoned = prior panic
             .embed(vec![text], None)
             .map_err(|e| {
                 EmbedFailedSnafu {
@@ -223,7 +223,7 @@ impl EmbeddingProvider for FastEmbedProvider {
     fn embed_batch(&self, texts: &[&str]) -> EmbeddingResult<Vec<Vec<f32>>> {
         self.model
             .lock()
-            .expect("fastembed model lock")
+            .expect("fastembed model lock") // INVARIANT: lock held only for embed call, poisoned = prior panic
             .embed(texts, None)
             .map_err(|e| {
                 EmbedFailedSnafu {

--- a/crates/nous/src/actor.rs
+++ b/crates/nous/src/actor.rs
@@ -770,7 +770,7 @@ mod tests {
             &self,
             _request: &CompletionRequest,
         ) -> aletheia_hermeneus::error::Result<CompletionResponse> {
-            Ok(self.response.lock().expect("lock").clone())
+            Ok(self.response.lock().expect("lock").clone()) // INVARIANT: test mock, panic = test bug
         }
 
         fn supported_models(&self) -> &[&str] {

--- a/crates/nous/src/execute.rs
+++ b/crates/nous/src/execute.rs
@@ -232,7 +232,7 @@ pub async fn execute(
         let active = tool_ctx
             .active_tools
             .read()
-            .expect("active_tools lock")
+            .expect("active_tools lock") // INVARIANT: RwLock read, short critical section, poisoned = prior panic
             .clone();
         let tool_defs = tools.to_hermeneus_tools_filtered(&active);
 
@@ -638,7 +638,7 @@ mod tests {
             &self,
             _request: &CompletionRequest,
         ) -> aletheia_hermeneus::error::Result<CompletionResponse> {
-            let mut responses = self.responses.lock().expect("lock");
+            let mut responses = self.responses.lock().expect("lock"); // INVARIANT: test mock, panic = test bug
             if responses.len() > 1 {
                 Ok(responses.remove(0))
             } else {

--- a/crates/nous/src/manager.rs
+++ b/crates/nous/src/manager.rs
@@ -282,7 +282,7 @@ mod tests {
             &self,
             _request: &CompletionRequest,
         ) -> aletheia_hermeneus::error::Result<CompletionResponse> {
-            Ok(self.response.lock().expect("lock").clone())
+            Ok(self.response.lock().expect("lock").clone()) // INVARIANT: test mock, panic = test bug
         }
 
         fn supported_models(&self) -> &[&str] {

--- a/crates/nous/src/pipeline.rs
+++ b/crates/nous/src/pipeline.rs
@@ -910,7 +910,7 @@ mod tests {
                 &self,
                 _request: &CompletionRequest,
             ) -> aletheia_hermeneus::error::Result<CompletionResponse> {
-                Ok(self.response.lock().expect("lock").clone())
+                Ok(self.response.lock().expect("lock").clone()) // INVARIANT: test mock, panic = test bug
             }
             fn supported_models(&self) -> &[&str] {
                 &["test-model"]

--- a/crates/nous/src/spawn_svc.rs
+++ b/crates/nous/src/spawn_svc.rs
@@ -197,7 +197,7 @@ mod tests {
             &self,
             _request: &CompletionRequest,
         ) -> aletheia_hermeneus::error::Result<CompletionResponse> {
-            Ok(self.response.lock().expect("lock").clone())
+            Ok(self.response.lock().expect("lock").clone()) // INVARIANT: test mock, panic = test bug
         }
 
         fn supported_models(&self) -> &[&str] {

--- a/crates/organon/src/builtins/enable_tool.rs
+++ b/crates/organon/src/builtins/enable_tool.rs
@@ -171,7 +171,7 @@ mod tests {
                 .contains("Activated 'web_search'")
         );
 
-        let active = ctx.active_tools.read().expect("lock");
+        let active = ctx.active_tools.read().expect("lock"); // INVARIANT: test assertion, panic = test bug
         assert!(active.contains(&ToolName::new("web_search").expect("valid")));
     }
 

--- a/crates/organon/src/registry.rs
+++ b/crates/organon/src/registry.rs
@@ -191,7 +191,7 @@ mod tests {
             _ctx: &'a ToolContext,
         ) -> Pin<Box<dyn Future<Output = Result<ToolResult>> + Send + 'a>> {
             Box::pin(async {
-                self.calls.lock().expect("lock").push(input.name.clone());
+                self.calls.lock().expect("lock").push(input.name.clone()); // INVARIANT: test mock, panic = test bug
                 Ok(ToolResult::text(self.response.clone()))
             })
         }
@@ -278,7 +278,7 @@ mod tests {
         let result = reg.execute(&input, &test_ctx()).await.expect("execute");
         assert_eq!(result.content.text_summary(), "hello");
         assert!(!result.is_error);
-        assert_eq!(calls.lock().expect("lock").len(), 1);
+        assert_eq!(calls.lock().expect("lock").len(), 1); // INVARIANT: test assertion, panic = test bug
     }
 
     #[tokio::test]
@@ -376,7 +376,7 @@ mod tests {
                 let nous_id = ctx.nous_id.as_str().to_owned();
                 let captured = Arc::clone(&self.captured_nous_id);
                 Box::pin(async move {
-                    *captured.lock().expect("lock") = Some(nous_id);
+                    *captured.lock().expect("lock") = Some(nous_id); // INVARIANT: test mock, panic = test bug
                     Ok(ToolResult::text("ok"))
                 })
             }
@@ -398,7 +398,7 @@ mod tests {
         };
         reg.execute(&input, &test_ctx()).await.expect("execute");
 
-        let id = captured.lock().expect("lock").clone();
+        let id = captured.lock().expect("lock").clone(); // INVARIANT: test assertion, panic = test bug
         assert_eq!(id.as_deref(), Some("test-agent"));
     }
 

--- a/crates/pylon/src/handlers/config.rs
+++ b/crates/pylon/src/handlers/config.rs
@@ -119,9 +119,9 @@ pub async fn update_section(
     }
 
     // Validate
-    if let Err(errors) = aletheia_taxis::validate::validate_section(&section, &body) {
+    if let Err(err) = aletheia_taxis::validate::validate_section(&section, &body) {
         return Err(ApiError::ValidationFailed {
-            errors: errors.0,
+            errors: err.errors,
             location: snafu::Location::default(),
         });
     }
@@ -165,7 +165,10 @@ pub async fn update_section(
     // Update in-memory config
     *config = new_config;
     let redacted = aletheia_taxis::redact::redact(&config);
-    let section_value = redacted.get(&section).cloned().unwrap_or(Value::Null);
+    let section_value = redacted.get(&section).cloned().unwrap_or_else(|| {
+        tracing::debug!(section = %section, "config section absent after update, returning null");
+        Value::Null
+    });
 
     Ok((
         StatusCode::OK,

--- a/crates/symbolon/src/api_key.rs
+++ b/crates/symbolon/src/api_key.rs
@@ -38,7 +38,10 @@ pub fn generate(
         let expiry = std::time::SystemTime::now() + d;
         let secs = expiry
             .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
+            .unwrap_or_else(|e| {
+                tracing::warn!("failed to compute expiry timestamp: {e}");
+                std::time::Duration::default()
+            })
             .as_secs();
         time_from_unix(secs)
     });
@@ -130,7 +133,10 @@ fn parse_key(raw: &str) -> Result<(&str, &str, &str)> {
 fn now_iso() -> String {
     let secs = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
-        .unwrap_or_default()
+        .unwrap_or_else(|e| {
+            tracing::warn!("failed to get current timestamp: {e}");
+            std::time::Duration::default()
+        })
         .as_secs();
     time_from_unix(secs)
 }

--- a/crates/symbolon/src/credential.rs
+++ b/crates/symbolon/src/credential.rs
@@ -471,7 +471,10 @@ async fn do_refresh(client: &reqwest::Client, refresh_token: &str) -> Option<OAu
 
     if !resp.status().is_success() {
         let status = resp.status();
-        let body = resp.text().await.unwrap_or_default();
+        let body = resp.text().await.unwrap_or_else(|e| {
+            warn!("failed to read OAuth error response body: {e}");
+            String::new()
+        });
         warn!(status = %status, body = %body, "OAuth refresh returned error");
         return None;
     }

--- a/crates/taxis/src/validate.rs
+++ b/crates/taxis/src/validate.rs
@@ -1,27 +1,17 @@
 //! Config section validation — rejects invalid values before persisting.
 
 use serde_json::Value;
+use snafu::Snafu;
 
-/// Validation errors collected during config validation.
-#[derive(Debug)]
-pub struct ValidationErrors(pub Vec<String>);
-
-impl std::fmt::Display for ValidationErrors {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        for (i, err) in self.0.iter().enumerate() {
-            if i > 0 {
-                writeln!(f)?;
-            }
-            write!(f, "  - {err}")?;
-        }
-        Ok(())
-    }
+/// Validation error with collected messages.
+#[derive(Debug, Snafu)]
+#[snafu(display("config validation failed:\n  - {}", errors.join("\n  - ")))]
+pub struct ValidationError {
+    pub errors: Vec<String>,
 }
 
-impl std::error::Error for ValidationErrors {}
-
 /// Validate a config section update. Returns errors for invalid values.
-pub fn validate_section(section: &str, value: &Value) -> Result<(), ValidationErrors> {
+pub fn validate_section(section: &str, value: &Value) -> Result<(), ValidationError> {
     let mut errors = Vec::new();
 
     match section {
@@ -36,7 +26,7 @@ pub fn validate_section(section: &str, value: &Value) -> Result<(), ValidationEr
     if errors.is_empty() {
         Ok(())
     } else {
-        Err(ValidationErrors(errors))
+        Err(ValidationError { errors })
     }
 }
 
@@ -142,7 +132,7 @@ mod tests {
         let section = json!({ "defaults": { "timeoutSeconds": 0 } });
         let result = validate_section("agents", &section);
         assert!(result.is_err());
-        assert!(result.unwrap_err().0[0].contains("timeoutSeconds"));
+        assert!(result.unwrap_err().errors[0].contains("timeoutSeconds"));
     }
 
     #[test]

--- a/crates/thesauros/src/tools.rs
+++ b/crates/thesauros/src/tools.rs
@@ -37,7 +37,10 @@ impl ToolExecutor for ShellToolExecutor {
     ) -> Pin<Box<dyn Future<Output = aletheia_organon::error::Result<ToolResult>> + Send + 'a>>
     {
         Box::pin(async {
-            let json_input = serde_json::to_string(&input.arguments).unwrap_or_default();
+            let json_input = serde_json::to_string(&input.arguments).unwrap_or_else(|e| {
+                tracing::debug!("failed to serialize tool arguments: {e}");
+                String::new()
+            });
             let timeout = Duration::from_millis(self.timeout_ms);
 
             let mut child = match Command::new(&self.command_path)


### PR DESCRIPTION
## Summary

Consolidated fixes from standards audit (issues #559, #568, #570, #571, #573, #577):

- **Silent unwrap_or_default**: Added `warn!`/`debug!` logging to 5 sites where errors were silently swallowed (api_key timestamps, credential OAuth body, config section lookup, main config load, tool arg serialization). Remaining sites confirmed intentional with obvious defaults.
- **Mutex .expect() justification**: All 14 Mutex lock expects now have INVARIANT comments explaining why panic is acceptable.
- **taxis ValidationError**: Replaced ad-hoc `ValidationErrors(Vec<String>)` with proper snafu error type.
- **agora clone reduction**: Removed 3 unnecessary clones — moved owned values from match arms instead of cloning through `ref` patterns.
- **koina regex expects**: Improved panic messages on static regex compilation.

No public API changes. All changes are internal.

## Test plan

- [x] `cargo clippy --workspace --exclude aletheia-mneme-engine --all-targets -- -D warnings` — zero warnings
- [x] `cargo test --workspace --exclude aletheia-integration-tests` — all pass
- [x] `cargo fmt --all -- --check` — clean

Closes #559, #568, #570, #571, #573, #577.