### PR TITLE
test(mneme): export/import and embedding test coverage

### DIFF
--- a/crates/mneme/src/embedding.rs
+++ b/crates/mneme/src/embedding.rs
@@ -367,6 +367,94 @@ mod tests {
         assert_send_sync::<MockEmbeddingProvider>();
     }
 
+    #[test]
+    fn embedding_empty_input() {
+        let provider = MockEmbeddingProvider::new(64);
+        let result = provider.embed("");
+        assert!(result.is_ok(), "empty string should produce a valid embedding");
+        let vec = result.unwrap();
+        assert_eq!(vec.len(), 64);
+    }
+
+    #[test]
+    fn embedding_long_input() {
+        let provider = MockEmbeddingProvider::new(128);
+        let long_text = "word ".repeat(10_000);
+        let result = provider.embed(&long_text);
+        assert!(result.is_ok(), "long input should succeed");
+        let vec = result.unwrap();
+        assert_eq!(vec.len(), 128);
+        let norm: f32 = vec.iter().map(|x| x * x).sum::<f32>().sqrt();
+        assert!(
+            (norm - 1.0).abs() < 0.01,
+            "long input embedding should be normalized, got {norm}"
+        );
+    }
+
+    #[test]
+    fn embedding_provider_switching() {
+        let small = create_provider(&EmbeddingConfig {
+            provider: "mock".to_owned(),
+            dimension: Some(64),
+            ..EmbeddingConfig::default()
+        })
+        .unwrap();
+
+        let large = create_provider(&EmbeddingConfig {
+            provider: "mock".to_owned(),
+            dimension: Some(256),
+            ..EmbeddingConfig::default()
+        })
+        .unwrap();
+
+        assert_eq!(small.dimension(), 64);
+        assert_eq!(large.dimension(), 256);
+
+        let v_small = small.embed("test").unwrap();
+        let v_large = large.embed("test").unwrap();
+        assert_eq!(v_small.len(), 64);
+        assert_eq!(v_large.len(), 256);
+        assert_ne!(v_small.len(), v_large.len());
+    }
+
+    #[test]
+    fn create_provider_custom_dimension() {
+        let config = EmbeddingConfig {
+            provider: "mock".to_owned(),
+            dimension: Some(512),
+            ..EmbeddingConfig::default()
+        };
+        let provider = create_provider(&config).unwrap();
+        assert_eq!(provider.dimension(), 512);
+
+        let vec = provider.embed("custom dim").unwrap();
+        assert_eq!(vec.len(), 512);
+    }
+
+    #[test]
+    fn embedding_batch_empty_list() {
+        let provider = MockEmbeddingProvider::new(64);
+        let result = provider.embed_batch(&[]);
+        assert!(result.is_ok());
+        assert!(result.unwrap().is_empty());
+    }
+
+    mod proptests {
+        use super::*;
+        use proptest::prelude::*;
+
+        proptest! {
+            #[test]
+            fn embedding_dimensions_constant(input in "[a-zA-Z ]{1,100}") {
+                let provider = MockEmbeddingProvider::new(384);
+                let vec = provider.embed(&input).unwrap();
+                prop_assert_eq!(vec.len(), 384);
+                let norm: f32 = vec.iter().map(|x| x * x).sum::<f32>().sqrt();
+                prop_assert!((norm - 1.0).abs() < 0.01, "norm was {}", norm);
+            }
+        }
+    }
+
     #[cfg(not(feature = "fastembed"))]
     #[test]
     fn fastembed_not_enabled_returns_error() {

--- a/crates/mneme/src/export.rs
+++ b/crates/mneme/src/export.rs
@@ -569,4 +569,130 @@ mod tests {
         assert_eq!(agent.sessions[0].messages.len(), 3);
         assert_eq!(agent.sessions[0].messages[0].content, "msg 1");
     }
+
+    #[test]
+    fn export_empty_agent() {
+        let store = test_store();
+        let dir = tempfile::tempdir().unwrap();
+        let opts = ExportOptions::default();
+
+        let agent = export_agent(
+            "nobody",
+            None,
+            None,
+            serde_json::json!({}),
+            &store,
+            dir.path(),
+            &opts,
+        )
+        .unwrap();
+
+        assert_eq!(agent.sessions.len(), 0);
+        assert!(agent.workspace.files.is_empty());
+        assert!(agent.workspace.binary_files.is_empty());
+        assert_eq!(agent.nous.id, "nobody");
+        assert!(agent.memory.is_none());
+
+        let json = serde_json::to_string(&agent).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert!(parsed.is_object(), "empty export produces valid JSON");
+    }
+
+    #[test]
+    fn export_preserves_timestamps() {
+        let store = test_store();
+        store
+            .create_session("ses-ts", "ts-agent", "main", None, None)
+            .unwrap();
+        store
+            .append_message("ses-ts", Role::User, "time test", None, None, 30)
+            .unwrap();
+
+        let dir = tempfile::tempdir().unwrap();
+        let agent = export_agent(
+            "ts-agent",
+            None,
+            None,
+            serde_json::json!({}),
+            &store,
+            dir.path(),
+            &ExportOptions::default(),
+        )
+        .unwrap();
+
+        let session = &agent.sessions[0];
+        assert!(!session.created_at.is_empty(), "created_at must be set");
+        assert!(!session.updated_at.is_empty(), "updated_at must be set");
+        assert!(
+            !session.messages[0].created_at.is_empty(),
+            "message created_at must be set"
+        );
+
+        let json = serde_json::to_string(&agent).unwrap();
+        let restored: crate::portability::AgentFile = serde_json::from_str(&json).unwrap();
+        assert_eq!(restored.sessions[0].created_at, session.created_at);
+        assert_eq!(restored.sessions[0].updated_at, session.updated_at);
+        assert_eq!(
+            restored.sessions[0].messages[0].created_at,
+            session.messages[0].created_at
+        );
+    }
+
+    #[test]
+    fn export_preserves_unicode() {
+        let store = test_store();
+        store
+            .create_session("ses-uni", "uni-agent", "main", None, None)
+            .unwrap();
+
+        let emoji = "Hello 🌍🔥 world";
+        let cjk = "你好世界 こんにちは";
+        let rtl = "مرحبا بالعالم";
+        let mixed = format!("{emoji} {cjk} {rtl}");
+
+        store
+            .append_message("ses-uni", Role::User, &mixed, None, None, 100)
+            .unwrap();
+        store
+            .add_note("ses-uni", "uni-agent", "context", &mixed)
+            .unwrap();
+
+        let dir = tempfile::tempdir().unwrap();
+        let unicode_file = "日本語.txt";
+        std::fs::write(dir.path().join(unicode_file), &mixed).unwrap();
+
+        let agent = export_agent(
+            "uni-agent",
+            Some("Ünïcödé Àgënt"),
+            None,
+            serde_json::json!({"note": cjk}),
+            &store,
+            dir.path(),
+            &ExportOptions::default(),
+        )
+        .unwrap();
+
+        assert_eq!(agent.sessions[0].messages[0].content, mixed);
+        assert_eq!(agent.sessions[0].notes[0].content, mixed);
+        assert_eq!(agent.nous.name.as_deref(), Some("Ünïcödé Àgënt"));
+
+        let json = serde_json::to_string_pretty(&agent).unwrap();
+        let restored: crate::portability::AgentFile = serde_json::from_str(&json).unwrap();
+        assert_eq!(restored.sessions[0].messages[0].content, mixed);
+        assert_eq!(restored.sessions[0].notes[0].content, mixed);
+    }
+
+    #[test]
+    fn scan_workspace_nested_structure() {
+        let dir = tempfile::tempdir().unwrap();
+        let sub = dir.path().join("sub/deep");
+        std::fs::create_dir_all(&sub).unwrap();
+        std::fs::write(dir.path().join("root.txt"), "root").unwrap();
+        std::fs::write(sub.join("nested.md"), "nested").unwrap();
+
+        let ws = scan_workspace(dir.path()).unwrap();
+        assert_eq!(ws.files.len(), 2);
+        assert!(ws.files.contains_key("root.txt"));
+        assert!(ws.files.contains_key("sub/deep/nested.md"));
+    }
 }

--- a/crates/mneme/src/import.rs
+++ b/crates/mneme/src/import.rs
@@ -687,4 +687,324 @@ mod tests {
         assert_eq!(result.files_restored, 0);
         assert_eq!(result.sessions_imported, 0);
     }
+
+    #[test]
+    fn import_corrupt_json_errors() {
+        let garbage_inputs = [
+            "",
+            "not json",
+            "{",
+            "null",
+            "42",
+            r#"{"version": "not_a_number"}"#,
+            r#"{"version": 1}"#, // missing required fields
+            r#"{"version": 1, "exportedAt": "x", "generator": "x"}"#, // missing nous
+        ];
+
+        for input in &garbage_inputs {
+            let result = serde_json::from_str::<AgentFile>(input);
+            assert!(
+                result.is_err(),
+                "expected error for input: {input:?}, got: {result:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn import_missing_optional_sections() {
+        let json = r#"{
+            "version": 1,
+            "exportedAt": "2026-03-05T12:00:00Z",
+            "generator": "test",
+            "nous": {
+                "id": "sparse",
+                "config": {}
+            },
+            "workspace": {
+                "files": {},
+                "binaryFiles": []
+            },
+            "sessions": []
+        }"#;
+
+        let agent: AgentFile = serde_json::from_str(json).unwrap();
+        assert!(agent.nous.name.is_none());
+        assert!(agent.nous.model.is_none());
+        assert!(agent.memory.is_none());
+
+        let store = test_store();
+        let dir = tempfile::tempdir().unwrap();
+        let id_gen = counter_id_gen();
+        let result = import_agent(
+            &agent,
+            &store,
+            dir.path(),
+            &*id_gen,
+            &ImportOptions::default(),
+        )
+        .unwrap();
+
+        assert_eq!(result.sessions_imported, 0);
+        assert_eq!(result.files_restored, 0);
+    }
+
+    #[test]
+    fn export_import_preserves_timestamps() {
+        let store = test_store();
+        store
+            .create_session("ses-ts", "ts-agent", "main", None, None)
+            .unwrap();
+        store
+            .append_message("ses-ts", Role::User, "hello", None, None, 50)
+            .unwrap();
+
+        let dir = tempfile::tempdir().unwrap();
+        let exported = export_agent(
+            "ts-agent",
+            None,
+            None,
+            serde_json::json!({}),
+            &store,
+            dir.path(),
+            &ExportOptions::default(),
+        )
+        .unwrap();
+
+        let orig_created = exported.sessions[0].created_at.clone();
+        let orig_updated = exported.sessions[0].updated_at.clone();
+        let orig_msg_ts = exported.sessions[0].messages[0].created_at.clone();
+
+        let json = serde_json::to_string(&exported).unwrap();
+        let restored: AgentFile = serde_json::from_str(&json).unwrap();
+
+        let import_store = test_store();
+        let import_dir = tempfile::tempdir().unwrap();
+        let id_gen = counter_id_gen();
+        import_agent(
+            &restored,
+            &import_store,
+            import_dir.path(),
+            &*id_gen,
+            &ImportOptions::default(),
+        )
+        .unwrap();
+
+        let sessions = import_store.list_sessions(Some("ts-agent")).unwrap();
+        assert_eq!(sessions.len(), 1);
+        assert_eq!(sessions[0].created_at, orig_created);
+        assert_eq!(sessions[0].updated_at, orig_updated);
+
+        let messages = import_store.get_history(&sessions[0].id, None).unwrap();
+        assert_eq!(messages[0].created_at, orig_msg_ts);
+    }
+
+    #[test]
+    fn export_import_preserves_unicode() {
+        let store = test_store();
+        store
+            .create_session("ses-uni", "uni", "main", None, None)
+            .unwrap();
+
+        let emoji = "Hello 🌍🔥 world";
+        let cjk = "你好世界 こんにちは";
+        let rtl = "مرحبا بالعالم";
+        let combined = format!("{emoji} {cjk} {rtl}");
+
+        store
+            .append_message("ses-uni", Role::User, &combined, None, None, 200)
+            .unwrap();
+        store
+            .add_note("ses-uni", "uni", "context", &combined)
+            .unwrap();
+
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("unicode.txt"), &combined).unwrap();
+
+        let exported = export_agent(
+            "uni",
+            Some("Ünïcödé"),
+            None,
+            serde_json::json!({}),
+            &store,
+            dir.path(),
+            &ExportOptions::default(),
+        )
+        .unwrap();
+
+        let json = serde_json::to_string_pretty(&exported).unwrap();
+        let restored: AgentFile = serde_json::from_str(&json).unwrap();
+
+        let import_store = test_store();
+        let import_dir = tempfile::tempdir().unwrap();
+        let id_gen = counter_id_gen();
+        import_agent(
+            &restored,
+            &import_store,
+            import_dir.path(),
+            &*id_gen,
+            &ImportOptions::default(),
+        )
+        .unwrap();
+
+        let content = std::fs::read_to_string(import_dir.path().join("unicode.txt")).unwrap();
+        assert_eq!(content, combined);
+
+        let sessions = import_store.list_sessions(Some("uni")).unwrap();
+        let messages = import_store.get_history(&sessions[0].id, None).unwrap();
+        assert_eq!(messages[0].content, combined);
+    }
+
+    #[test]
+    fn export_import_large_data() {
+        let store = test_store();
+        for i in 0..100 {
+            let sid = format!("ses-{i}");
+            store
+                .create_session(&sid, "bulk", &format!("key-{i}"), None, None)
+                .unwrap();
+            for j in 0..10 {
+                store
+                    .append_message(
+                        &sid,
+                        Role::User,
+                        &format!("message {j} in session {i}"),
+                        None,
+                        None,
+                        20,
+                    )
+                    .unwrap();
+            }
+        }
+
+        let dir = tempfile::tempdir().unwrap();
+        let exported = export_agent(
+            "bulk",
+            None,
+            None,
+            serde_json::json!({}),
+            &store,
+            dir.path(),
+            &ExportOptions {
+                max_messages_per_session: 0,
+                include_archived: false,
+            },
+        )
+        .unwrap();
+
+        assert_eq!(exported.sessions.len(), 100);
+        let total_msgs: usize = exported.sessions.iter().map(|s| s.messages.len()).sum();
+        assert_eq!(total_msgs, 1000);
+
+        let json = serde_json::to_string(&exported).unwrap();
+        let restored: AgentFile = serde_json::from_str(&json).unwrap();
+
+        let import_store = test_store();
+        let import_dir = tempfile::tempdir().unwrap();
+        let id_gen = counter_id_gen();
+        let result = import_agent(
+            &restored,
+            &import_store,
+            import_dir.path(),
+            &*id_gen,
+            &ImportOptions::default(),
+        )
+        .unwrap();
+
+        assert_eq!(result.sessions_imported, 100);
+        assert_eq!(result.messages_imported, 1000);
+    }
+
+    #[test]
+    fn category_validation_uses_shared_constant() {
+        let store = test_store();
+        let dir = tempfile::tempdir().unwrap();
+
+        let valid_categories = crate::schema::VALID_CATEGORIES;
+
+        let mut agent = minimal_agent_file();
+        agent.sessions[0].notes.clear();
+        for cat in valid_categories {
+            agent.sessions[0].notes.push(ExportedNote {
+                category: (*cat).to_owned(),
+                content: format!("note for {cat}"),
+                created_at: "2026-03-05T10:30:00Z".to_owned(),
+            });
+        }
+        agent.sessions[0].notes.push(ExportedNote {
+            category: "bogus_category".to_owned(),
+            content: "should default to context".to_owned(),
+            created_at: "2026-03-05T10:30:00Z".to_owned(),
+        });
+
+        let id_gen = counter_id_gen();
+        let result = import_agent(
+            &agent,
+            &store,
+            dir.path(),
+            &*id_gen,
+            &ImportOptions::default(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            result.notes_imported as usize,
+            valid_categories.len() + 1,
+            "all valid + 1 defaulted note imported"
+        );
+    }
+
+    mod proptests {
+        use super::*;
+        use proptest::prelude::*;
+
+        proptest! {
+            #[test]
+            fn export_import_preserves_content(
+                content in "[a-zA-Z0-9 ]{1,200}",
+                note_text in "[a-zA-Z0-9 ]{1,100}",
+            ) {
+                let store = test_store();
+                store
+                    .create_session("ses-prop", "prop-agent", "main", None, None)
+                    .unwrap();
+                store
+                    .append_message("ses-prop", Role::User, &content, None, None, 50)
+                    .unwrap();
+                store
+                    .add_note("ses-prop", "prop-agent", "context", &note_text)
+                    .unwrap();
+
+                let dir = tempfile::tempdir().unwrap();
+                let exported = export_agent(
+                    "prop-agent",
+                    None,
+                    None,
+                    serde_json::json!({}),
+                    &store,
+                    dir.path(),
+                    &ExportOptions::default(),
+                )
+                .unwrap();
+
+                let json = serde_json::to_string(&exported).unwrap();
+                let restored: AgentFile = serde_json::from_str(&json).unwrap();
+
+                let import_store = test_store();
+                let import_dir = tempfile::tempdir().unwrap();
+                let id_gen = counter_id_gen();
+                import_agent(
+                    &restored,
+                    &import_store,
+                    import_dir.path(),
+                    &*id_gen,
+                    &ImportOptions::default(),
+                )
+                .unwrap();
+
+                let sessions = import_store.list_sessions(Some("prop-agent")).unwrap();
+                let messages = import_store.get_history(&sessions[0].id, None).unwrap();
+                prop_assert_eq!(&messages[0].content, &content);
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Summary

- Adds test coverage for export/import round-trip preservation and embedding edge cases
- 17 new tests across export.rs, import.rs, and embedding.rs
- 2 property test suites (proptest) for content preservation and dimension invariance
- All 227 crate tests pass, zero clippy warnings

## Tests Added

### export.rs (4 tests)
- `export_empty_agent` — empty store → valid minimal AgentFile
- `export_preserves_timestamps` — created_at/updated_at survive serialization round-trip
- `export_preserves_unicode` — emoji 🌍🔥, CJK 你好, RTL مرحبا preserved
- `scan_workspace_nested_structure` — deep nested dirs scanned correctly

### import.rs (7 tests + 1 proptest)
- `import_corrupt_json_errors` — garbage/truncated/type-mismatched JSON → error, not panic
- `import_missing_optional_sections` — sparse AgentFile (no name/model/memory) imports cleanly
- `export_import_preserves_timestamps` — timestamps survive full export→serialize→import pipeline
- `export_import_preserves_unicode` — Unicode content round-trips through store→export→import→store
- `export_import_large_data` — 100 sessions × 10 messages (1000 total) round-trips
- `category_validation_uses_shared_constant` — all `VALID_CATEGORIES` accepted; invalid defaults to "context"
- **proptest**: arbitrary alphanumeric content preserved through export→import

### embedding.rs (5 tests + 1 proptest)
- `embedding_empty_input` — empty string produces valid embedding of correct dimension
- `embedding_long_input` — 50KB input embeds without error, output stays L2-normalized
- `embedding_provider_switching` — different dimension configs produce different-sized vectors
- `create_provider_custom_dimension` — non-default dimension (512) honored
- `embedding_batch_empty_list` — empty batch returns empty vec
- **proptest**: dimension count always 384 for arbitrary text input, output normalized

## Bugs Discovered

None — no bugs discovered during testing.

## Test plan

- [x] `cargo test -p aletheia-mneme` — 227 passed
- [x] `cargo clippy -p aletheia-mneme --all-targets -- -D warnings` — zero warnings


🤖 Generated with [Claude Code](https://claude.com/claude-code)