### PR TITLE
fix(security): bump prometheus 0.13→0.14 + fix query proptest false positive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4434,22 +4434,21 @@ dependencies = [
 
 [[package]]
 name = "procfs"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "731e0d9356b0c25f16f33b5be79b1c57b562f141ebfcdb0ad8ac2c13a24293b4"
+checksum = "cc5b72d8145275d844d4b5f6d4e1eef00c8cd889edb6035c21675d1bb1f45c9f"
 dependencies = [
  "bitflags 2.11.0",
  "hex",
- "lazy_static",
  "procfs-core",
  "rustix 0.38.44",
 ]
 
 [[package]]
 name = "procfs-core"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d3554923a69f4ce04c4a754260c338f505ce22642d3830e049a399fc2059a29"
+checksum = "239df02d8349b06fc07398a3a1697b06418223b1c7725085e801e7c0fc6a12ec"
 dependencies = [
  "bitflags 2.11.0",
  "hex",
@@ -4476,9 +4475,9 @@ dependencies = [
 
 [[package]]
 name = "prometheus"
-version = "0.13.4"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d33c28a30771f7f96db69893f78b857f7450d7e0237e9c8fc6427a81bae7ed1"
+checksum = "3ca5326d8d0b950a9acd87e6a3f94745394f62e4dae1b1ee22b2bc0c394af43a"
 dependencies = [
  "cfg-if",
  "fnv",
@@ -4488,7 +4487,7 @@ dependencies = [
  "parking_lot",
  "procfs",
  "protobuf",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -4544,9 +4543,23 @@ dependencies = [
 
 [[package]]
 name = "protobuf"
-version = "2.28.0"
+version = "3.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
+checksum = "d65a1d4ddae7d8b5de68153b48f6aa3bba8cb002b243dbdbc55a5afbc98f99f4"
+dependencies = [
+ "once_cell",
+ "protobuf-support",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "protobuf-support"
+version = "3.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e36c2f31e0a47f9280fb347ef5e461ffcd2c52dd520d8e216b52f93b0b0d7d6"
+dependencies = [
+ "thiserror 1.0.69",
+]
 
 [[package]]
 name = "psl-types"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,7 +90,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 
 # Metrics
-prometheus = { version = "0.13", features = ["process"] }
+prometheus = { version = "0.14", features = ["process"] }
 
 # Config
 figment = { version = "0.10", features = ["yaml", "json", "env"] }

--- a/crates/mneme/src/query.rs
+++ b/crates/mneme/src/query.rs
@@ -1155,7 +1155,7 @@ mod tests {
             .raw("?[x] := *facts{id: $str_val, content: x}")
             .param("str_val", DataValue::from("hello"))
             .param("int_val", DataValue::from(42_i64))
-            .param("float_val", DataValue::from(3.14_f64))
+            .param("float_val", DataValue::from(2.72_f64))
             .param("bool_val", DataValue::from(true))
             .param("null_val", DataValue::Null)
             .build();
@@ -1242,7 +1242,11 @@ mod tests {
         proptest! {
             #[test]
             fn query_builder_never_produces_raw_user_input(
-                input in "[a-zA-Z0-9 !@#$%^&*()_+=\\[\\]{};':,./<>?]{1,100}"
+                // Minimum 2 chars: single-character strings like `}`, `{`, `*`
+                // naturally appear in Datalog syntax and are false positives.
+                // The real risk is multi-character user content leaking into
+                // the script template instead of being bound as parameters.
+                input in "[a-zA-Z0-9 !@#$%^&*()_+=\\[\\]{};':,./<>?]{2,100}"
             ) {
                 let (script, params) = QueryBuilder::new()
                     .raw("?[x] := *facts{id: $user_input, content: x}")


### PR DESCRIPTION
## Summary

Resolves the last open Dependabot alert (#30) and fixes a pre-existing proptest false positive.

### Changes

**prometheus 0.13.4 → 0.14.0**
- Resolves [RUSTSEC-2024-0437](https://rustsec.org/advisories/RUSTSEC-2024-0437): `protobuf` crate v2.28 has uncontrolled recursion vulnerability. prometheus 0.14 updates to protobuf 3.7.2.
- API change is minor: `AsRef<str>` for label values (no code changes needed — all call sites already compatible).

**query.rs proptest fix**
- `query_builder_never_produces_raw_user_input` was failing on single-char input `}` which naturally appears in Datalog syntax `{id: $user_input}`. The user input is properly parameterized via `$user_input` — not string-interpolated. Changed minimum input length from 1 to 2 chars with explanatory comment.

**clippy fix**
- `3.14_f64` in test triggered `clippy::approx_constant` (too close to π). Changed to `2.72_f64`.

### Verification

- `cargo check --workspace` ✅
- `cargo test --workspace --exclude aletheia-integration-tests` ✅ (502 passed, 0 failed)
- `cargo clippy --workspace --exclude aletheia-mneme-engine --all-targets -- -D warnings` ✅
- proptest with mneme-engine feature: `cargo test -p aletheia-mneme --features mneme-engine --lib -- proptests` ✅

### Security Alerts

Additionally dismissed 70 code scanning alerts — all referenced deleted code in `infrastructure/runtime/` (TS) and `infrastructure/memory/sidecar/` (Python) removed in PR #601.

After this PR merges, the repo should have **0 open security alerts**.