### PR TITLE
fix: retry spawn on ETXTBSY in ShellToolExecutor

### DIFF
--- a/crates/thesauros/src/tools.rs
+++ b/crates/thesauros/src/tools.rs
@@ -43,16 +43,41 @@ impl ToolExecutor for ShellToolExecutor {
             });
             let timeout = Duration::from_millis(self.timeout_ms);
 
-            let mut child = match Command::new(&self.command_path)
-                .current_dir(&self.pack_root)
-                .stdin(Stdio::piped())
-                .stdout(Stdio::piped())
-                .stderr(Stdio::piped())
-                .spawn()
-            {
-                Ok(c) => c,
-                Err(e) => {
-                    return Ok(ToolResult::error(format!("spawn failed: {e}")));
+            // Retry on ETXTBSY (errno 26) — a benign race between writing/chmod
+            // on a script and exec'ing it. Common in CI and on busy systems.
+            let mut child = {
+                let mut last_err = None;
+                let mut spawned = None;
+                for attempt in 0..4 {
+                    match Command::new(&self.command_path)
+                        .current_dir(&self.pack_root)
+                        .stdin(Stdio::piped())
+                        .stdout(Stdio::piped())
+                        .stderr(Stdio::piped())
+                        .spawn()
+                    {
+                        Ok(c) => {
+                            spawned = Some(c);
+                            break;
+                        }
+                        Err(e) if e.raw_os_error() == Some(26) && attempt < 3 => {
+                            // ETXTBSY — brief backoff (1ms, 5ms, 25ms)
+                            std::thread::sleep(Duration::from_millis(1 << (2 * attempt)));
+                            last_err = Some(e);
+                        }
+                        Err(e) => {
+                            return Ok(ToolResult::error(format!("spawn failed: {e}")));
+                        }
+                    }
+                }
+                match spawned {
+                    Some(c) => c,
+                    None => {
+                        return Ok(ToolResult::error(format!(
+                            "spawn failed after retries: {}",
+                            last_err.unwrap()
+                        )));
+                    }
                 }
             };
 


### PR DESCRIPTION
## Problem

`ShellToolExecutor::spawn()` fails intermittently in CI with `Text file busy` (ETXTBSY, errno 26). This is a well-known Linux race condition between writing/chmod on a script file and exec'ing it — the kernel briefly holds a reference to the file after the write handle is closed.

This caused flaky CI failures on `shell_executor_runs_script` across multiple PRs (#624, prompt 102 commit).

## Fix

Retry loop around `Command::spawn()` specifically for errno 26 (ETXTBSY):
- Up to 4 attempts
- Exponential backoff: 1ms → 4ms → 16ms
- Only retries ETXTBSY; all other errors fail immediately
- Applied to the production executor, not just tests

## Testing

`cargo test -p aletheia-thesauros --lib -- tools::tests` — 12/12 pass
`cargo clippy -p aletheia-thesauros` — clean