### PR TITLE
fix(pylon,hermeneus,symbolon): auth bypass, model aliases, bind config, credential compat

### DIFF
--- a/crates/aletheia/src/main.rs
+++ b/crates/aletheia/src/main.rs
@@ -62,9 +62,9 @@ struct Cli {
     #[arg(short, long, default_value = "info")]
     log_level: String,
 
-    /// Bind address
-    #[arg(long, default_value = "127.0.0.1")]
-    bind: String,
+    /// Bind address (overrides config gateway.bind when set)
+    #[arg(long)]
+    bind: Option<String>,
 
     /// Port (overrides config gateway.port when set)
     #[arg(short, long)]
@@ -793,6 +793,7 @@ async fn serve(cli: Cli) -> Result<()> {
         oikos: oikos_arc,
         jwt_manager: Arc::new(jwt_manager),
         start_time: Instant::now(),
+        auth_mode: config.gateway.auth.mode.clone(),
         config: Arc::new(tokio::sync::RwLock::new(aletheia_config)),
     });
 
@@ -800,7 +801,14 @@ async fn serve(cli: Cli) -> Result<()> {
     let app = build_router(state.clone(), &security);
 
     let port = cli.port.unwrap_or(config.gateway.port);
-    let bind_addr = format!("{}:{}", cli.bind, port);
+    // Resolve bind address: CLI flag > config gateway.bind > default 127.0.0.1.
+    // "lan" is a semantic alias for "0.0.0.0" (listen on all interfaces).
+    let bind_host = cli.bind.as_deref().unwrap_or(&config.gateway.bind);
+    let bind_addr_str = match bind_host {
+        "lan" => "0.0.0.0",
+        other => other,
+    };
+    let bind_addr = format!("{bind_addr_str}:{port}");
     let listener = tokio::net::TcpListener::bind(&bind_addr)
         .await
         .with_context(|| format!("failed to bind to {bind_addr}"))?;
@@ -1526,7 +1534,7 @@ mod tests {
     fn cli_defaults() {
         let cli = Cli::parse_from(["aletheia"]);
         assert!(cli.port.is_none());
-        assert_eq!(cli.bind, "127.0.0.1");
+        assert!(cli.bind.is_none());
         assert_eq!(cli.log_level, "info");
         assert!(!cli.json_logs);
         assert!(cli.command.is_none());

--- a/crates/hermeneus/src/anthropic/client.rs
+++ b/crates/hermeneus/src/anthropic/client.rs
@@ -30,7 +30,9 @@ const BACKOFF_MAX_MS: u64 = 30_000;
 static SUPPORTED_MODELS: &[&str] = &[
     "claude-opus-4-6",
     "claude-opus-4-20250514",
+    "claude-sonnet-4-6",
     "claude-sonnet-4-20250514",
+    "claude-haiku-4-5",
     "claude-haiku-4-5-20251001",
 ];
 

--- a/crates/integration-tests/tests/end_to_end.rs
+++ b/crates/integration-tests/tests/end_to_end.rs
@@ -199,6 +199,7 @@ impl TestHarness {
             oikos,
             jwt_manager: Arc::clone(&jwt_manager),
             start_time: Instant::now(),
+            auth_mode: "token".to_owned(),
             config: Arc::new(tokio::sync::RwLock::new(
                 aletheia_taxis::config::AletheiaConfig::default(),
             )),

--- a/crates/integration-tests/tests/eval_harness.rs
+++ b/crates/integration-tests/tests/eval_harness.rs
@@ -129,6 +129,7 @@ async fn start_test_server() -> (String, String, tempfile::TempDir) {
         oikos,
         jwt_manager,
         start_time: Instant::now(),
+        auth_mode: "token".to_owned(),
         config: Arc::new(tokio::sync::RwLock::new(
             aletheia_taxis::config::AletheiaConfig::default(),
         )),

--- a/crates/pylon/src/extract.rs
+++ b/crates/pylon/src/extract.rs
@@ -28,6 +28,9 @@ impl FromRequestParts<Arc<AppState>> for OptionalClaims {
 }
 
 /// Authenticated user claims extracted from a JWT Bearer token.
+///
+/// When `auth_mode` is `"none"` in the gateway config, a synthetic admin
+/// identity is injected without requiring a Bearer token.
 #[derive(Debug, Clone)]
 pub struct Claims {
     /// Subject identifier (user or service principal).
@@ -45,6 +48,15 @@ impl FromRequestParts<Arc<AppState>> for Claims {
         parts: &mut Parts,
         state: &Arc<AppState>,
     ) -> Result<Self, Self::Rejection> {
+        // When auth is disabled, inject a synthetic admin identity.
+        if state.auth_mode == "none" {
+            return Ok(Self {
+                sub: "anonymous".to_owned(),
+                role: Role::Operator,
+                nous_id: None,
+            });
+        }
+
         let header = parts
             .headers
             .get("authorization")

--- a/crates/pylon/src/handlers/webchat.rs
+++ b/crates/pylon/src/handlers/webchat.rs
@@ -373,9 +373,16 @@ pub struct AuthModeResponse {
     pub session_auth: bool,
 }
 
-pub async fn auth_mode(_claims: OptionalClaims) -> Json<AuthModeResponse> {
+pub async fn auth_mode(
+    State(state): State<Arc<AppState>>,
+    _claims: OptionalClaims,
+) -> Json<AuthModeResponse> {
     Json(AuthModeResponse {
-        mode: "token",
+        mode: if state.auth_mode == "none" {
+            "none"
+        } else {
+            "token"
+        },
         session_auth: false,
     })
 }

--- a/crates/pylon/src/server.rs
+++ b/crates/pylon/src/server.rs
@@ -103,6 +103,7 @@ pub async fn run(config: ServerConfig) -> Result<(), ServerError> {
         oikos,
         jwt_manager,
         start_time: Instant::now(),
+        auth_mode: aletheia_config.gateway.auth.mode.clone(),
         config: Arc::new(tokio::sync::RwLock::new(aletheia_config)),
     });
 

--- a/crates/pylon/src/state.rs
+++ b/crates/pylon/src/state.rs
@@ -29,4 +29,6 @@ pub struct AppState {
     pub start_time: Instant,
     /// Runtime configuration, updatable via config API.
     pub config: Arc<tokio::sync::RwLock<AletheiaConfig>>,
+    /// Auth mode from gateway config (`"token"`, `"none"`, etc.).
+    pub auth_mode: String,
 }

--- a/crates/pylon/src/tests.rs
+++ b/crates/pylon/src/tests.rs
@@ -148,6 +148,7 @@ async fn test_state_with_provider(with_provider: bool) -> (Arc<AppState>, tempfi
         oikos,
         jwt_manager,
         start_time: Instant::now(),
+        auth_mode: "token".to_owned(),
         config: Arc::new(tokio::sync::RwLock::new(
             aletheia_taxis::config::AletheiaConfig::default(),
         )),

--- a/crates/symbolon/src/credential.rs
+++ b/crates/symbolon/src/credential.rs
@@ -31,9 +31,13 @@ const FILE_MTIME_CHECK_INTERVAL: Duration = Duration::from_secs(30);
 // ---------------------------------------------------------------------------
 
 /// On-disk credential file format.
+///
+/// Accepts both `"token"` (native format) and `"accessToken"` (Claude Code OAuth
+/// output) for backward compatibility. Serialization always writes `"token"`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CredentialFile {
     /// Access token (API key or OAuth access token).
+    #[serde(alias = "accessToken")]
     pub token: String,
     /// OAuth refresh token (absent for static API keys).
     #[serde(rename = "refreshToken", skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
## Summary

Fixes 4 issues found during Metis test deployment (prompt 115).

### Fix 1 — Auth bypass when mode=none
`auth.mode: none` in gateway config now actually disables JWT validation. The `Claims` extractor checks `AppState.auth_mode` and returns a synthetic Operator identity when auth is disabled. Webchat `/api/auth/mode` endpoint now returns the real config value instead of hardcoded `"token"`.

### Fix 2 — Model short aliases
Added `claude-sonnet-4-6` and `claude-haiku-4-5` to `SUPPORTED_MODELS`. The opus short alias already existed; sonnet and haiku were missing, causing the provider to reject the config default.

### Fix 3 — Bind address from config
CLI `--bind` is now `Option<String>` (was hardcoded default `127.0.0.1`). Falls through to `gateway.bind` from YAML config. `"lan"` maps to `0.0.0.0` (listen on all interfaces).

### Fix 4 — Credential format compatibility
`CredentialFile.token` now accepts `#[serde(alias = "accessToken")]` so Claude Code's OAuth output works without manual field remapping.

## Testing
- All 1,542 tests pass
- Clippy clean
- 10 files changed, 46 insertions, 7 deletions

## Blast Radius
- **pylon**: Claims extractor, AppState, auth_mode handler, tests
- **hermeneus**: Static model list
- **aletheia binary**: CLI bind field, bind resolution
- **symbolon**: Serde alias on CredentialFile
- **integration-tests**: AppState field added