### PR TITLE
fix(pylon,tui): align nous list response and add name field

### DIFF
--- a/crates/aletheia/src/main.rs
+++ b/crates/aletheia/src/main.rs
@@ -698,6 +698,7 @@ async fn serve(cli: Cli) -> Result<()> {
 
             let nous_config = NousConfig {
                 id: resolved.id,
+                name: resolved.name,
                 model: resolved.model,
                 context_window: resolved.context_tokens,
                 max_output_tokens: resolved.max_output_tokens,

--- a/crates/nous/src/config.rs
+++ b/crates/nous/src/config.rs
@@ -7,6 +7,9 @@ use serde::{Deserialize, Serialize};
 pub struct NousConfig {
     /// Agent identifier (e.g. "syn", "demiurge").
     pub id: String,
+    /// Human-readable display name (e.g. "Syn"). Falls back to `id` if absent.
+    #[serde(default)]
+    pub name: Option<String>,
     /// Default model for this agent.
     pub model: String,
     /// Maximum context window tokens.
@@ -35,6 +38,7 @@ impl Default for NousConfig {
     fn default() -> Self {
         Self {
             id: "default".to_owned(),
+            name: None,
             model: "claude-opus-4-20250514".to_owned(),
             context_window: 200_000,
             max_output_tokens: 16_384,

--- a/crates/nous/src/spawn_svc.rs
+++ b/crates/nous/src/spawn_svc.rs
@@ -68,6 +68,7 @@ impl SpawnService for SpawnServiceImpl {
 
         let config = NousConfig {
             id: spawn_id.clone(),
+            name: None,
             model,
             context_window: 200_000,
             max_output_tokens: 16_384,

--- a/crates/pylon/src/handlers/nous.rs
+++ b/crates/pylon/src/handlers/nous.rs
@@ -28,6 +28,7 @@ pub async fn list(State(state): State<Arc<AppState>>, _claims: Claims) -> Json<N
         .into_iter()
         .map(|c| NousSummary {
             id: c.id.clone(),
+            name: c.name.clone().unwrap_or_else(|| c.id.clone()),
             model: c.model.clone(),
             status: "active".to_owned(),
         })
@@ -125,6 +126,8 @@ pub struct NousListResponse {
 pub struct NousSummary {
     /// Agent identifier.
     pub id: String,
+    /// Human-readable display name (falls back to `id`).
+    pub name: String,
     /// LLM model assigned to this agent.
     pub model: String,
     /// Lifecycle status (e.g. `"active"`).

--- a/tui/src/api/client.rs
+++ b/tui/src/api/client.rs
@@ -137,7 +137,7 @@ impl ApiClient {
         resp.error_for_status_ref()
             .context("agents request failed")?;
         let wrapper: AgentsResponse = resp.json().await?;
-        Ok(wrapper.agents)
+        Ok(wrapper.nous)
     }
 
     // --- Sessions ---

--- a/tui/src/api/types.rs
+++ b/tui/src/api/types.rs
@@ -7,11 +7,21 @@ use crate::id::{NousId, PlanId, SessionId, TurnId};
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Agent {
     pub id: NousId,
-    pub name: String,
+    /// Display name — falls back to `id` if absent.
+    #[serde(default)]
+    pub name: Option<String>,
     #[serde(default)]
     pub model: Option<String>,
     #[serde(default)]
     pub emoji: Option<String>,
+}
+
+impl Agent {
+    /// Display name: uses `name` if set, otherwise `id`.
+    #[must_use]
+    pub fn display_name(&self) -> &str {
+        self.name.as_deref().unwrap_or(&self.id)
+    }
 }
 
 // --- Session ---
@@ -227,7 +237,9 @@ pub struct DailyEntry {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AgentsResponse {
-    pub agents: Vec<Agent>,
+    /// Server returns `{"nous": [...]}` — accept both keys for resilience.
+    #[serde(alias = "agents")]
+    pub nous: Vec<Agent>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/tui/src/app.rs
+++ b/tui/src/app.rs
@@ -191,7 +191,7 @@ impl App {
             .into_iter()
             .map(|a| AgentState {
                 id: a.id.clone(),
-                name: a.name,
+                name: a.display_name().to_owned(),
                 emoji: a.emoji,
                 status: AgentStatus::Idle,
                 active_tool: None,

--- a/tui/src/update/api.rs
+++ b/tui/src/update/api.rs
@@ -8,8 +8,8 @@ pub(crate) fn handle_agents_loaded(app: &mut App, agents: Vec<Agent>) {
     app.agents = agents
         .into_iter()
         .map(|a| AgentState {
-            id: a.id,
-            name: a.name,
+            id: a.id.clone(),
+            name: a.display_name().to_owned(),
             emoji: a.emoji,
             status: AgentStatus::Idle,
             active_tool: None,

--- a/tui/src/update/sse.rs
+++ b/tui/src/update/sse.rs
@@ -23,8 +23,8 @@ pub(crate) async fn handle_sse_connected(app: &mut App) {
                 .map(|a| {
                     let notif = notifications.get(&a.id).copied().unwrap_or(false);
                     AgentState {
-                        id: a.id,
-                        name: a.name,
+                        id: a.id.clone(),
+                        name: a.display_name().to_owned(),
                         emoji: a.emoji,
                         status: AgentStatus::Idle,
                         active_tool: None,


### PR DESCRIPTION
Fixes TUI ↔ server compatibility for the `/api/v1/nous` endpoint.

**Server side:**
- Add `name: Option<String>` to `NousConfig`, propagated from `ResolvedNousConfig.name`
- `NousSummary` now includes `name` field (falls back to `id` when absent)
- Response key stays `nous` — consistent with Aletheia naming

**TUI side:**
- `AgentsResponse` deserializes `nous` key (with `agents` alias for back-compat)
- `Agent.name` is now `Option<String>` with `display_name()` helper
- All `Agent → AgentState` conversions use `display_name().to_owned()`

**No test changes needed** — pylon tests already assert on the `nous` key.