### PR TITLE
fix(pylon,tui): streaming race, camelCase deserialization, cursor offset

### DIFF
--- a/crates/pylon/src/handlers/sessions.rs
+++ b/crates/pylon/src/handlers/sessions.rs
@@ -452,8 +452,11 @@ pub async fn stream_turn(
     let aid = agent_id;
 
     // Bridge nous stream events to webchat events in real-time.
+    // Returns a JoinHandle so the turn task can wait for all deltas to drain
+    // before emitting turn_complete (prevents the race where turn_complete
+    // arrives at the TUI before the final text_delta events).
     let bridge_tx = webchat_tx.clone();
-    tokio::spawn(async move {
+    let bridge_handle = tokio::spawn(async move {
         while let Some(event) = nous_rx.recv().await {
             let webchat_event = match event {
                 TurnStreamEvent::LlmDelta(LlmStreamEvent::TextDelta { text }) => {
@@ -492,13 +495,18 @@ pub async fn stream_turn(
         }
     });
 
-    // Run the turn and emit completion event.
+    // Run the turn, wait for bridge to drain, then emit completion event.
     tokio::spawn(async move {
         match handle
             .send_turn_streaming(&session_key, &message, nous_tx)
             .await
         {
             Ok(result) => {
+                // Wait for the bridge to finish forwarding all buffered deltas
+                // before sending turn_complete. This prevents the TUI from
+                // seeing turn_complete before the final text_delta events.
+                let _ = bridge_handle.await;
+
                 let token_estimate = i64::try_from(result.usage.output_tokens).unwrap_or(0);
                 let _ = webchat_tx
                     .send(WebchatEvent::TurnComplete {
@@ -526,6 +534,7 @@ pub async fn stream_turn(
             }
             Err(err) => {
                 warn!(error = %err, "streaming turn failed");
+                let _ = bridge_handle.await;
                 let _ = webchat_tx
                     .send(WebchatEvent::Error {
                         message: err.to_string(),
@@ -735,11 +744,12 @@ pub struct SendMessageRequest {
 #[serde(rename_all = "camelCase")]
 pub struct StreamTurnRequest {
     /// Target agent ID.
+    #[serde(alias = "agentId")]
     pub agent_id: String,
     /// User message text.
     pub message: String,
     /// Session key for deduplication (defaults to "main").
-    #[serde(default = "default_session_key")]
+    #[serde(alias = "sessionKey", default = "default_session_key")]
     pub session_key: String,
 }
 

--- a/tui/src/view/input.rs
+++ b/tui/src/view/input.rs
@@ -32,9 +32,11 @@ pub fn render(app: &App, frame: &mut Frame, area: Rect, theme: &ThemePalette) {
     let paragraph = Paragraph::new(line).block(block).wrap(Wrap { trim: false });
     frame.render_widget(paragraph, area);
 
-    // Calculate cursor position with wrapping
+    // Calculate cursor position with wrapping.
+    // Block has Borders::TOP only — no left/right borders consume width,
+    // so the inner content width equals the full area width.
     let prompt_width = prompt_str.len() as u16;
-    let content_width = area.width.saturating_sub(1); // account for possible border
+    let content_width = area.width.max(1);
     let total_offset = prompt_width + app.input.cursor as u16;
     let cursor_y = area.y + 1 + (total_offset / content_width); // +1 for top border
     let cursor_x = area.x + (total_offset % content_width);

--- a/tui/src/view/mod.rs
+++ b/tui/src/view/mod.rs
@@ -138,7 +138,7 @@ fn render_chat_area(app: &App, frame: &mut Frame, area: Rect, theme: &crate::the
     // Dynamically size input area based on text length (wrapping)
     let prompt_len: u16 = if app.active_turn_id.is_some() { 9 } else { 2 };
     let text_len = app.input.text.len() as u16 + prompt_len;
-    let content_width = area.width.saturating_sub(1).max(1);
+    let content_width = area.width.max(1);
     let wrapped_lines = (text_len / content_width) + 1;
     let input_height = (wrapped_lines + 1).clamp(3, 8); // +1 for border, min 3, max 8
 


### PR DESCRIPTION
Three fixes from TUI deployment testing on Metis:

**1. StreamTurnRequest camelCase** (Issue #2 from deployment log)
- TUI sends `agentId`/`sessionKey` (camelCase) but server's `StreamTurnRequest` had bare `agent_id`/`session_key`
- Added `#[serde(alias = "agentId")]` and `#[serde(alias = "sessionKey")]` to accept both formats

**2. `turn_complete` arriving before `text_delta` events** (Issue #3)
- Two spawned tasks shared `webchat_tx`: a bridge task forwarding deltas and a turn task emitting completion
- When `send_turn_streaming()` returned, the bridge could still have buffered events in `nous_rx`
- Turn task now awaits the bridge `JoinHandle` before sending `TurnComplete`, guaranteeing all deltas are delivered first
- Same fix applied to the error path

**3. Input cursor offset** (visual bug)
- `content_width` was calculated as `area.width - 1` "for possible border" but the input block only has `Borders::TOP` — no left/right borders
- The off-by-one in modular arithmetic shifted the cursor 2-3 chars right
- Fixed both the cursor calculation in `input.rs` and the matching height calculation in `mod.rs`