### PR TITLE
fix: note FK constraint + find tool glob/gitignore handling

### DIFF
--- a/crates/nous/src/actor.rs
+++ b/crates/nous/src/actor.rs
@@ -296,7 +296,7 @@ impl NousActor {
 
         let tool_ctx = ToolContext {
             nous_id,
-            session_id: SessionId::new(),
+            session_id: SessionId::parse(session.id.as_str()).unwrap_or_else(|_| SessionId::new()),
             workspace: self.oikos.nous_dir(&self.id),
             allowed_roots: vec![self.oikos.root().to_path_buf()],
             services: self.tool_services.clone(),
@@ -357,7 +357,7 @@ impl NousActor {
 
         let tool_ctx = ToolContext {
             nous_id,
-            session_id: SessionId::new(),
+            session_id: SessionId::parse(session.id.as_str()).unwrap_or_else(|_| SessionId::new()),
             workspace: self.oikos.nous_dir(&self.id),
             allowed_roots: vec![self.oikos.root().to_path_buf()],
             services: self.tool_services.clone(),

--- a/crates/organon/src/builtins/filesystem.rs
+++ b/crates/organon/src/builtins/filesystem.rs
@@ -178,6 +178,11 @@ impl ToolExecutor for FindExecutor {
     }
 }
 
+/// Returns `true` if the pattern contains glob metacharacters (`*`, `?`, `[`, `{`).
+fn is_glob_pattern(pattern: &str) -> bool {
+    pattern.contains('*') || pattern.contains('?') || pattern.contains('[') || pattern.contains('{')
+}
+
 fn try_fd(
     pattern: &str,
     path: &Path,
@@ -186,6 +191,13 @@ fn try_fd(
     max_depth: Option<u64>,
 ) -> std::io::Result<std::process::Output> {
     let mut cmd = Command::new("fd");
+    // --no-ignore: workspace dirs live under gitignored paths (instance/).
+    // --glob: only when the pattern uses glob metacharacters (*, ?, [, {).
+    //         Otherwise fd's default regex mode gives better substring matching.
+    cmd.arg("--no-ignore");
+    if is_glob_pattern(pattern) {
+        cmd.arg("--glob");
+    }
     cmd.arg(pattern)
         .arg(path)
         .arg("--max-results")


### PR DESCRIPTION
## Two bugs found during Metis deployment validation

### 1. `note` tool FK constraint failure (`actor.rs`)
`ToolContext` was creating `session_id: SessionId::new()` — a random ULID that doesn't exist in the sessions table. This caused FK constraint violations on `agent_notes` insert.

**Fix:** Parse the actual `session.id` from `SessionState` via `SessionId::parse()`.

### 2. `find` tool not locating workspace files (`filesystem.rs`)
Two issues:
- `fd` respects `.gitignore` by default, and `/instance/` is gitignored — all workspace files were invisible
- `fd` uses regex by default, but LLMs send glob patterns like `*.txt` which is invalid regex

**Fix:**
- Always pass `--no-ignore` so gitignored workspace paths are searchable
- Detect glob metacharacters (`*`, `?`, `[`, `{`) and add `--glob` flag only when present, preserving regex substring matching for simple patterns like `app`

### 3. Embedding config (Metis instance, not in diff)
Updated Metis `aletheia.yaml` to use `fastembed` provider (dim=384) instead of `mock`. The `fastembed` feature is already compiled in via mneme default features.

### Tests
- All 13 organon filesystem tests pass (including find glob + regex scenarios)
- All 202 nous tests pass
- `cargo check` clean