### PR TITLE
chore(ci): remove duplicate TUI job, drop Node.js dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,8 @@ jobs:
           TYPES="feat|fix|refactor|chore|docs|test|ci|perf|style|build|revert"
           failed=0
           while IFS= read -r msg; do
+            # Skip merge commits (GitHub synthetic merges)
+            echo "$msg" | grep -qE "^Merge " && continue
             if ! echo "$msg" | grep -qE "^($TYPES)(\(.+\))?: .+"; then
               echo "::error::Bad commit message: $msg"
               echo "  Expected: <type>(<scope>): <description>"


### PR DESCRIPTION
## Summary

- Remove duplicate TUI job from `ci.yml` — `rust.yml` already runs workspace-wide clippy + test covering TUI
- Replace `commitlint` (Node.js) with a shell regex check for conventional commit format — drops the `actions/setup-node` + `npm install` step entirely
- Add GitHub repository topics: `ai-agents`, `rust`, `self-hosted`, `multi-agent`, `privacy-first`, `tui`, `exocortex`

Net: -29 lines, +12 lines. One fewer CI runtime dependency.

## Test plan

- [ ] CI passes on this PR (the commitlint job validates itself)
- [ ] `rust.yml` still covers TUI crate (already does via `cargo clippy --workspace` and `cargo test --workspace`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)