### PR TITLE
chore(tui,dokimion): add tracing instrumentation to key functions

### DIFF
--- a/crates/eval/src/sse.rs
+++ b/crates/eval/src/sse.rs
@@ -20,6 +20,7 @@ pub async fn parse_sse_stream(response: reqwest::Response) -> Result<Vec<ParsedS
 }
 
 /// Parse raw SSE text into events. Exposed for testing.
+#[tracing::instrument(skip(text), fields(text_len = text.len()))]
 pub fn parse_sse_text(text: &str) -> Result<Vec<ParsedSseEvent>> {
     let mut events = Vec::new();
     let mut current_event_type = String::new();

--- a/tui/src/actions.rs
+++ b/tui/src/actions.rs
@@ -6,6 +6,7 @@ use crate::app::App;
 use crate::state::{ChatMessage, SavedScrollState, TabCompletion};
 
 impl App {
+    #[tracing::instrument(skip(self, text), fields(agent = ?self.focused_agent))]
     pub(crate) fn send_message(&mut self, text: &str) {
         let agent_id = match &self.focused_agent {
             Some(id) => id.clone(),

--- a/tui/src/app.rs
+++ b/tui/src/app.rs
@@ -101,6 +101,7 @@ pub struct App {
 }
 
 impl App {
+    #[tracing::instrument(skip_all, fields(url = %config.url))]
     pub async fn init(config: Config) -> Result<Self> {
         let client = ApiClient::new(&config.url, config.token.clone())?;
 
@@ -153,6 +154,7 @@ impl App {
         Ok(app)
     }
 
+    #[tracing::instrument(skip(self), fields(url = %self.config.url))]
     async fn connect(&mut self) -> Result<()> {
         if !self.client.health().await.unwrap_or(false) {
             anyhow::bail!(
@@ -231,6 +233,7 @@ impl App {
         Ok(())
     }
 
+    #[tracing::instrument(skip(self), fields(agent = ?self.focused_agent))]
     pub(crate) async fn load_focused_session(&mut self) {
         let agent_id = match &self.focused_agent {
             Some(id) => id.clone(),

--- a/tui/src/config.rs
+++ b/tui/src/config.rs
@@ -43,6 +43,7 @@ impl std::fmt::Debug for Config {
 }
 
 impl Config {
+    #[tracing::instrument(skip(cli_token))]
     pub fn load(
         cli_url: Option<String>,
         cli_token: Option<String>,
@@ -61,6 +62,7 @@ impl Config {
         })
     }
 
+    #[tracing::instrument(skip(self))]
     pub fn clear_credentials(&self) -> Result<()> {
         let path = Self::config_path()?;
         if path.exists() {
@@ -74,6 +76,7 @@ impl Config {
     }
 
     #[expect(dead_code, reason = "called from login flow")]
+    #[tracing::instrument(skip(self, token))]
     pub fn save_token(&self, token: &str) -> Result<()> {
         let path = Self::config_path()?;
         let mut file_config = Self::load_file().unwrap_or_default();

--- a/tui/src/lib.rs
+++ b/tui/src/lib.rs
@@ -29,6 +29,7 @@ use crate::config::Config;
 use crate::events::Event;
 
 /// Entry point for the TUI, callable from the main `aletheia` binary or standalone.
+#[tracing::instrument(skip_all, fields(url, agent))]
 pub async fn run_tui(
     url: Option<String>,
     token: Option<String>,


### PR DESCRIPTION
## Summary

- Add `#[instrument]` spans to 9 functions across TUI and eval crates where failures would leave no trace in structured logs
- **TUI**: `run_tui`, `App::init`, `App::connect`, `App::load_focused_session`, `App::send_message`, `Config::load`, `Config::clear_credentials`, `Config::save_token`
- **Eval**: `parse_sse_text`
- Skips pure renderers, trivial getters, and high-frequency dispatch (update/view/map_event) where instrumentation adds noise without diagnostic value
- All spans skip `self` and sensitive fields (tokens, message text) — only structured metadata recorded

Addresses audit issue #8 (missing `#[instrument]` spans in eval and TUI crates).

## Test plan

- [x] `cargo clippy -p aletheia-tui -p aletheia-dokimion -- -D warnings` — zero warnings
- [x] `cargo test -p aletheia-tui -p aletheia-dokimion` — 38 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)