### PR TITLE
chore: close documentation and test issues (#498-#501)

### DIFF
--- a/crates/aletheia/Cargo.toml
+++ b/crates/aletheia/Cargo.toml
@@ -48,6 +48,7 @@ ulid = { workspace = true }
 
 cliclack = "0.4"
 clap = { version = "4", features = ["derive", "env"] }
+clap_complete = "4"
 qdrant-client = { version = "1", optional = true }
 sha2 = "0.10"
 anyhow = "1"

--- a/crates/aletheia/src/main.rs
+++ b/crates/aletheia/src/main.rs
@@ -15,7 +15,7 @@ use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
 use anyhow::{Context, Result};
-use clap::{Parser, Subcommand};
+use clap::{CommandFactory, Parser, Subcommand};
 use tracing::{Instrument, info, warn};
 use tracing_subscriber::{EnvFilter, fmt};
 
@@ -228,6 +228,11 @@ enum Command {
         #[arg(long)]
         dry_run: bool,
     },
+    /// Generate shell completions for bash, zsh, or fish
+    Completions {
+        /// Shell to generate completions for
+        shell: clap_complete::Shell,
+    },
 }
 
 #[derive(Debug, Clone, Subcommand)]
@@ -354,6 +359,11 @@ async fn main() -> Result<()> {
                 *force,
                 *dry_run,
             );
+        }
+        Some(Command::Completions { shell }) => {
+            let mut cmd = Cli::command();
+            clap_complete::generate(*shell, &mut cmd, "aletheia", &mut std::io::stdout());
+            return Ok(());
         }
         Some(Command::MigrateMemory {
             qdrant_url,

--- a/crates/pylon/src/tests.rs
+++ b/crates/pylon/src/tests.rs
@@ -395,6 +395,33 @@ async fn health_degraded_without_providers() {
     assert_eq!(body["status"], "degraded");
 }
 
+#[tokio::test]
+async fn health_checks_have_expected_shape() {
+    let (app, _dir) = app().await;
+    let resp = app
+        .oneshot(Request::get("/api/health").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = body_json(resp).await;
+
+    let checks = body["checks"].as_array().expect("checks is array");
+    assert!(checks.len() >= 2, "expected at least 2 health checks");
+
+    for check in checks {
+        assert!(check["name"].is_string(), "each check has a name");
+        assert!(check["status"].is_string(), "each check has a status");
+    }
+
+    let names: Vec<&str> = checks.iter().filter_map(|c| c["name"].as_str()).collect();
+    assert!(
+        names.contains(&"session_store"),
+        "missing session_store check"
+    );
+    assert!(names.contains(&"providers"), "missing providers check");
+}
+
 // --- Session CRUD Tests ---
 
 #[tokio::test]

--- a/crates/taxis/Cargo.toml
+++ b/crates/taxis/Cargo.toml
@@ -20,4 +20,5 @@ tracing = { workspace = true }
 
 [dev-dependencies]
 figment = { workspace = true, features = ["test"] }
+proptest = { workspace = true }
 tempfile = "3"

--- a/crates/taxis/src/config.rs
+++ b/crates/taxis/src/config.rs
@@ -895,4 +895,36 @@ mod tests {
         assert!((sonnet.input_cost_per_mtok - 3.0).abs() < f64::EPSILON);
         assert!((sonnet.output_cost_per_mtok - 15.0).abs() < f64::EPSILON);
     }
+
+    mod proptests {
+        use super::*;
+        use proptest::prelude::*;
+
+        fn arb_channel_binding() -> impl Strategy<Value = ChannelBinding> {
+            (
+                "[a-z]{3,10}",
+                "[a-zA-Z0-9+*]{1,20}",
+                "[a-z]{2,8}",
+                proptest::option::of("[a-z{}]{1,20}"),
+            )
+                .prop_map(|(channel, source, nous_id, session_key)| ChannelBinding {
+                    channel,
+                    source,
+                    nous_id,
+                    session_key: session_key.unwrap_or_else(default_session_pattern),
+                })
+        }
+
+        proptest! {
+            #[test]
+            fn channel_binding_roundtrip(binding in arb_channel_binding()) {
+                let json = serde_json::to_string(&binding).expect("serialize");
+                let back: ChannelBinding = serde_json::from_str(&json).expect("deserialize");
+                prop_assert_eq!(&binding.channel, &back.channel);
+                prop_assert_eq!(&binding.source, &back.source);
+                prop_assert_eq!(&binding.nous_id, &back.nous_id);
+                prop_assert_eq!(&binding.session_key, &back.session_key);
+            }
+        }
+    }
 }

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -67,6 +67,10 @@ cargo build --release
 
 Binary: `target/release/aletheia`
 
+### Shell Completions
+
+See [SHELL-COMPLETIONS.md](SHELL-COMPLETIONS.md) for setting up tab-completion in bash, zsh, and fish.
+
 ---
 
 ## Instance Setup

--- a/docs/PROSOCHE.md
+++ b/docs/PROSOCHE.md
@@ -1,0 +1,154 @@
+# Prosoche — Attention System
+
+**prosoche** (Greek: προσοχή) means "directed attention." In Stoic practice, prosoche is the discipline of sustained awareness — you cannot reveal what is hidden (aletheia) without first attending carefully.
+
+In Aletheia, prosoche is the **heartbeat subsystem**: a periodic background check that prompts each agent to survey its environment and report anything that needs attention.
+
+---
+
+## Architecture
+
+Prosoche lives inside the **oikonomos** daemon crate (`crates/daemon/`). It is an in-process background task that runs alongside the HTTP gateway.
+
+```text
+aletheia binary
+├── pylon (HTTP gateway)
+├── nous (agent actors)
+└── oikonomos (daemon)
+    ├── TaskRunner — cron/interval scheduler
+    ├── ProsocheCheck — heartbeat check definition
+    └── DaemonBridge — sends prompts to nous actors
+```
+
+### Data Flow
+
+1. `TaskRunner` fires the prosoche task on schedule
+2. Runner calls `DaemonBridge::send_prompt()` with session key `"daemon:prosoche"`
+3. The bridge routes the prompt to the target nous actor
+4. The agent reads its `PROSOCHE.md` workspace file and executes the checklist
+5. Results surface as a background session (detected by `session_key.contains("prosoche")`)
+
+---
+
+## Heartbeat Intervals
+
+The daemon supports multiple schedule types:
+
+| Type | Example | Use Case |
+|------|---------|----------|
+| `Cron` | `0 */45 8-23 * * *` | Every 45 min during waking hours |
+| `Interval` | `Duration::from_secs(3600)` | Fixed hourly interval |
+| `Once` | ISO 8601 timestamp | One-shot scheduled task |
+| `Startup` | — | Run once when daemon starts |
+
+### Default Maintenance Schedules
+
+| Task | Schedule |
+|------|----------|
+| Trace rotation | `0 0 3 * * *` (3 AM daily) |
+| Drift detection | `0 0 4 * * *` (4 AM daily) |
+| DB size monitor | Every 6 hours |
+| Retention | `0 30 3 * * *` (3:30 AM daily) |
+
+Tasks support optional **active windows** `(start_hour, end_hour)` to restrict execution to specific hours.
+
+---
+
+## Configuration
+
+### Agent Workspace File
+
+Each agent has an `instance/nous/<agent-id>/PROSOCHE.md` file that defines its heartbeat checklist. A template is provided at `instance.example/nous/_template/PROSOCHE.md`.
+
+The checklist specifies what the agent should check on each heartbeat tick:
+
+1. **Calendar** — upcoming events in the next 4 hours
+2. **Tasks** — overdue or due-today items
+3. **System health** — agent status checks
+
+**Constraints per tick:**
+- Maximum 5 tool calls
+- No investigation or research — just check and report
+- Response: `HEARTBEAT_OK` if nothing needs action, or brief one-line alerts
+
+### Attention Types
+
+```rust
+pub enum AttentionCategory {
+    Calendar,
+    Task,
+    SystemHealth,
+    Custom(String),
+}
+
+pub enum Urgency {
+    Low,       // Informational
+    Medium,    // Address within current session
+    High,      // Within hours
+    Critical,  // Immediate action
+}
+```
+
+---
+
+## Checks
+
+`ProsocheCheck` produces a `ProsocheResult` containing zero or more `AttentionItem` entries. Each item has a category, summary, and urgency level.
+
+Currently, prosoche dispatches a prompt to the agent and relies on the agent's tool access (calendar, task manager, system health) to perform the actual checks. If no bridge is configured, prosoche completes successfully with empty results and logs a warning.
+
+### Failure Handling
+
+- Tasks are disabled after **3 consecutive failures**
+- A successful execution resets the failure counter
+- Task status can be queried via `aletheia maintenance status`
+
+---
+
+## Extensibility
+
+### Adding a New Check Category
+
+1. Add a variant to `AttentionCategory` in `crates/daemon/src/prosoche.rs`
+2. Update the agent's `PROSOCHE.md` template with instructions for the new check
+3. Ensure the agent has access to the relevant tools (register in `organon`)
+
+### Custom Scheduled Tasks
+
+The `TaskRunner` accepts arbitrary tasks via `TaskAction`:
+
+| Action | Description |
+|--------|-------------|
+| `Command(String)` | Shell command |
+| `Tool { name, args }` | Tool invocation |
+| `Prompt(String)` | Prompt sent to a nous agent |
+| `Builtin(BuiltinTask)` | Built-in maintenance task |
+
+### Bridge Pattern
+
+The daemon communicates with nous actors through the `DaemonBridge` trait. This keeps the daemon crate decoupled from nous internals — the bridge is wired in the binary crate (`crates/aletheia/src/daemon_bridge.rs`).
+
+```rust
+pub trait DaemonBridge: Send + Sync {
+    fn send_prompt(
+        &self,
+        nous_id: &str,
+        session_key: &str,
+        prompt: &str,
+    ) -> Pin<Box<dyn Future<Output = Result<ExecutionResult>> + Send + '_>>;
+}
+```
+
+---
+
+## Operational Notes
+
+```bash
+# Check maintenance task status (includes prosoche)
+aletheia maintenance status
+
+# View prosoche activity in logs
+journalctl --user -u aletheia --since "1 hour ago" | grep prosoche
+```
+
+Prosoche workspace files have **priority 7** in the token budget — they are dropped before semi-static files (MEMORY, TOOLS) under budget pressure, but SOUL.md is never dropped.

--- a/docs/SHELL-COMPLETIONS.md
+++ b/docs/SHELL-COMPLETIONS.md
@@ -1,0 +1,63 @@
+# Shell Completions
+
+Aletheia provides tab-completion for all subcommands, flags, and options via [clap_complete](https://docs.rs/clap_complete).
+
+## Generating Completions
+
+```bash
+aletheia completions <SHELL>
+```
+
+Where `<SHELL>` is one of: `bash`, `zsh`, `fish`, `elvish`, `powershell`.
+
+---
+
+## Bash
+
+```bash
+# Generate and install
+aletheia completions bash > ~/.local/share/bash-completion/completions/aletheia
+
+# Or system-wide (requires root)
+aletheia completions bash | sudo tee /etc/bash_completion.d/aletheia > /dev/null
+```
+
+Reload your shell or source the file:
+
+```bash
+source ~/.local/share/bash-completion/completions/aletheia
+```
+
+---
+
+## Zsh
+
+```bash
+# Generate to a directory in your $fpath
+aletheia completions zsh > ~/.zfunc/_aletheia
+```
+
+Ensure `~/.zfunc` is in your `fpath` (add to `~/.zshrc` before `compinit`):
+
+```zsh
+fpath=(~/.zfunc $fpath)
+autoload -Uz compinit && compinit
+```
+
+Restart your shell or run `compinit` to pick up the new completions.
+
+---
+
+## Fish
+
+```bash
+aletheia completions fish > ~/.config/fish/completions/aletheia.fish
+```
+
+Fish picks up completions from this directory automatically — no restart needed.
+
+---
+
+## Verifying
+
+After installation, type `aletheia <TAB>` to see available subcommands, or `aletheia health --<TAB>` to see flags.


### PR DESCRIPTION
## Summary

- **Shell completions (#498):** Added `aletheia completions <shell>` subcommand via `clap_complete`. Created `docs/SHELL-COMPLETIONS.md` with setup instructions for bash, zsh, and fish. Linked from `docs/DEPLOYMENT.md`.
- **ChannelBinding proptest (#499):** Added property-based roundtrip test for `ChannelBinding` serialization/deserialization in `aletheia-taxis` using proptest.
- **Health endpoint test (#500):** Added integration test validating `/api/health` response JSON shape — verifies checks array contains `session_store` and `providers` entries with expected fields.
- **Prosoche documentation (#501):** Created `docs/PROSOCHE.md` documenting the attention system architecture, heartbeat intervals, configuration, checks, failure handling, and extensibility.

Closes #498, Closes #499, Closes #500, Closes #501

## Test plan

- [x] `cargo test -p aletheia-pylon` — 71 tests pass (including new `health_checks_have_expected_shape`)
- [x] `cargo test -p aletheia-taxis` — 61 tests pass (including new `channel_binding_roundtrip` proptest)
- [x] `cargo fmt -- --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)