### PR TITLE
test(eval,dianoia,daemon): hardening sweep for small crates

### DIFF
--- a/crates/daemon/src/bridge.rs
+++ b/crates/daemon/src/bridge.rs
@@ -41,7 +41,7 @@ impl DaemonBridge for NoopBridge {
     }
 }
 
-/// Wrap an `Arc<dyn DaemonBridge>` to forward to the inner trait.
+/// Wrap an `Arc<dyn DaemonBridge>` to forward to the inner bridge.
 impl DaemonBridge for Arc<dyn DaemonBridge> {
     fn send_prompt(
         &self,
@@ -50,5 +50,34 @@ impl DaemonBridge for Arc<dyn DaemonBridge> {
         prompt: &str,
     ) -> Pin<Box<dyn Future<Output = crate::error::Result<ExecutionResult>> + Send + '_>> {
         (**self).send_prompt(nous_id, session_key, prompt)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn noop_bridge_returns_not_success() {
+        let bridge = NoopBridge;
+        let result = bridge
+            .send_prompt("test-nous", "test-session", "hello")
+            .await
+            .expect("should not error");
+        assert!(!result.success, "NoopBridge should return success=false");
+    }
+
+    #[tokio::test]
+    async fn noop_bridge_output_contains_no_bridge() {
+        let bridge = NoopBridge;
+        let result = bridge
+            .send_prompt("test-nous", "test-session", "hello")
+            .await
+            .expect("should not error");
+        let output = result.output.expect("should have output");
+        assert!(
+            output.contains("no bridge configured"),
+            "output should mention no bridge configured, got: {output}"
+        );
     }
 }

--- a/crates/daemon/src/maintenance/db_monitor.rs
+++ b/crates/daemon/src/maintenance/db_monitor.rs
@@ -356,4 +356,72 @@ mod tests {
         assert!(report.databases.is_empty());
         assert_eq!(report.total_size_bytes, 0);
     }
+
+    #[test]
+    fn default_config_values() {
+        let config = DbMonitoringConfig::default();
+        assert!(config.enabled);
+        assert_eq!(config.data_dir, PathBuf::from("data"));
+        assert_eq!(config.warn_threshold_mb, 100);
+        assert_eq!(config.alert_threshold_mb, 500);
+    }
+
+    #[test]
+    fn db_status_display() {
+        assert_eq!(DbStatus::Ok.to_string(), "ok");
+        assert_eq!(DbStatus::Warning.to_string(), "warning");
+        assert_eq!(DbStatus::Alert.to_string(), "alert");
+    }
+
+    #[test]
+    fn cozo_directory_tracked() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let config = make_config(tmp.path());
+        fs::create_dir_all(config.data_dir.join("cozo")).unwrap();
+        fs::write(config.data_dir.join("cozo/shard1.dat"), "aaaa").unwrap();
+        fs::write(config.data_dir.join("cozo/shard2.dat"), "bbbb").unwrap();
+
+        let monitor = DbMonitor::new(config);
+        let report = monitor.check().expect("check succeeds");
+
+        let cozo = report
+            .databases
+            .iter()
+            .find(|d| d.name == "cozo/")
+            .expect("should have cozo/ entry");
+        assert_eq!(cozo.size_bytes, 8, "sum of two 4-byte files");
+    }
+
+    #[test]
+    fn multiple_known_and_extra_dbs() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let config = make_config(tmp.path());
+        fs::create_dir_all(&config.data_dir).unwrap();
+
+        fs::write(config.data_dir.join("sessions.db"), "s").unwrap();
+        fs::write(config.data_dir.join("planning.db"), "p").unwrap();
+        fs::write(config.data_dir.join("custom.db"), "c").unwrap();
+
+        let monitor = DbMonitor::new(config);
+        let report = monitor.check().expect("check succeeds");
+
+        let names: Vec<&str> = report.databases.iter().map(|d| d.name.as_str()).collect();
+        assert!(names.contains(&"sessions.db"));
+        assert!(names.contains(&"planning.db"));
+        assert!(names.contains(&"custom.db"));
+        assert_eq!(report.databases.len(), 3);
+    }
+
+    #[test]
+    fn empty_data_dir_returns_empty() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let config = make_config(tmp.path());
+        fs::create_dir_all(&config.data_dir).unwrap();
+        // No files in data dir.
+
+        let monitor = DbMonitor::new(config);
+        let report = monitor.check().expect("check succeeds");
+        assert!(report.databases.is_empty());
+        assert_eq!(report.total_size_bytes, 0);
+    }
 }

--- a/crates/daemon/src/maintenance/drift_detection.rs
+++ b/crates/daemon/src/maintenance/drift_detection.rs
@@ -281,4 +281,63 @@ mod tests {
         let report = detector.check().expect("check succeeds");
         assert!(report.missing_files.is_empty());
     }
+
+    #[test]
+    fn default_config_values() {
+        let config = DriftDetectionConfig::default();
+        assert!(config.enabled);
+        assert!(config.alert_on_missing);
+        assert_eq!(config.instance_root, PathBuf::from("instance"));
+        assert_eq!(config.example_root, PathBuf::from("instance.example"));
+        assert!(
+            config.ignore_patterns.contains(&"data/".to_owned()),
+            "default should ignore data/"
+        );
+        assert!(
+            config.ignore_patterns.contains(&"*.db".to_owned()),
+            "default should ignore *.db"
+        );
+    }
+
+    #[test]
+    fn empty_example_and_instance() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let config = make_config(tmp.path());
+
+        // Both directories exist but are empty.
+        fs::create_dir_all(&config.example_root).unwrap();
+        fs::create_dir_all(&config.instance_root).unwrap();
+
+        let detector = DriftDetector::new(config);
+        let report = detector.check().expect("check succeeds");
+        assert!(report.missing_files.is_empty());
+        assert!(report.extra_files.is_empty());
+    }
+
+    #[test]
+    fn nested_directory_missing_detected() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let config = make_config(tmp.path());
+
+        // Create a deeply nested structure in the example.
+        fs::create_dir_all(config.example_root.join("level1/level2/level3")).unwrap();
+        fs::write(
+            config.example_root.join("level1/level2/level3/deep.yaml"),
+            "",
+        )
+        .unwrap();
+
+        // Instance has nothing.
+        fs::create_dir_all(&config.instance_root).unwrap();
+
+        let detector = DriftDetector::new(config);
+        let report = detector.check().expect("check succeeds");
+
+        assert!(
+            report
+                .missing_files
+                .contains(&PathBuf::from("level1/level2/level3/deep.yaml")),
+            "should detect deeply nested missing file"
+        );
+    }
 }

--- a/crates/daemon/src/maintenance/retention.rs
+++ b/crates/daemon/src/maintenance/retention.rs
@@ -82,4 +82,18 @@ mod tests {
         let config = RetentionConfig::default();
         assert!(!config.enabled);
     }
+
+    #[test]
+    fn retention_summary_default() {
+        let summary = RetentionSummary::default();
+        assert_eq!(summary.sessions_cleaned, 0);
+        assert_eq!(summary.messages_cleaned, 0);
+        assert_eq!(summary.bytes_freed, 0);
+    }
+
+    #[test]
+    fn retention_config_enabled() {
+        let config = RetentionConfig { enabled: true };
+        assert!(config.enabled);
+    }
 }

--- a/crates/daemon/src/maintenance/trace_rotation.rs
+++ b/crates/daemon/src/maintenance/trace_rotation.rs
@@ -370,4 +370,63 @@ mod tests {
         assert_eq!(report.files_rotated, 0);
         assert_eq!(report.files_pruned, 0);
     }
+
+    #[test]
+    fn default_config_values() {
+        let config = TraceRotationConfig::default();
+        assert!(config.enabled);
+        assert_eq!(config.max_age_days, 14);
+        assert_eq!(config.max_total_size_mb, 500);
+        assert!(config.compress);
+        assert_eq!(config.max_archives, 30);
+        assert_eq!(config.trace_dir, PathBuf::from("logs/traces"));
+        assert_eq!(config.archive_dir, PathBuf::from("logs/traces/archive"));
+    }
+
+    #[test]
+    fn rotation_report_default() {
+        let report = RotationReport::default();
+        assert_eq!(report.files_rotated, 0);
+        assert_eq!(report.files_pruned, 0);
+        assert_eq!(report.bytes_freed, 0);
+    }
+
+    #[test]
+    fn no_files_to_rotate() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let mut config = make_config(tmp.path());
+        config.max_age_days = 9999;
+        config.max_total_size_mb = 9999;
+        fs::create_dir_all(&config.trace_dir).unwrap();
+        // Empty trace dir — nothing to rotate.
+
+        let rotator = TraceRotator::new(config);
+        let report = rotator.rotate().expect("rotation succeeds");
+        assert_eq!(report.files_rotated, 0);
+        assert_eq!(report.bytes_freed, 0);
+    }
+
+    #[test]
+    fn multiple_old_files_rotated() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let mut config = make_config(tmp.path());
+        config.max_age_days = 0; // treat all files as old
+        config.max_total_size_mb = 9999;
+        fs::create_dir_all(&config.trace_dir).unwrap();
+
+        fs::write(config.trace_dir.join("trace-1.log"), "data one").unwrap();
+        fs::write(config.trace_dir.join("trace-2.log"), "data two").unwrap();
+        fs::write(config.trace_dir.join("trace-3.log"), "data three").unwrap();
+
+        let rotator = TraceRotator::new(config.clone());
+        let report = rotator.rotate().expect("rotation succeeds");
+
+        assert_eq!(report.files_rotated, 3);
+        assert!(report.bytes_freed > 0);
+
+        // All should be in archive.
+        assert!(config.archive_dir.join("trace-1.log").exists());
+        assert!(config.archive_dir.join("trace-2.log").exists());
+        assert!(config.archive_dir.join("trace-3.log").exists());
+    }
 }

--- a/crates/daemon/src/prosoche.rs
+++ b/crates/daemon/src/prosoche.rs
@@ -104,4 +104,92 @@ mod tests {
         assert!(result.items.is_empty());
         assert!(!result.checked_at.is_empty());
     }
+
+    #[test]
+    fn prosoche_check_new() {
+        let check = ProsocheCheck::new("alice-nous");
+        // Verify nous_id is stored by running the check (which logs it).
+        // We can also verify via Debug output.
+        let debug = format!("{check:?}");
+        assert!(
+            debug.contains("alice-nous"),
+            "ProsocheCheck should store the nous_id"
+        );
+    }
+
+    #[test]
+    fn attention_item_category_label_calendar() {
+        let item = AttentionItem {
+            category: AttentionCategory::Calendar,
+            summary: "meeting".to_owned(),
+            urgency: Urgency::Medium,
+        };
+        assert_eq!(item.category_label(), "calendar");
+    }
+
+    #[test]
+    fn attention_item_category_label_task() {
+        let item = AttentionItem {
+            category: AttentionCategory::Task,
+            summary: "review PR".to_owned(),
+            urgency: Urgency::Low,
+        };
+        assert_eq!(item.category_label(), "task");
+    }
+
+    #[test]
+    fn attention_item_category_label_health() {
+        let item = AttentionItem {
+            category: AttentionCategory::SystemHealth,
+            summary: "disk full".to_owned(),
+            urgency: Urgency::Critical,
+        };
+        assert_eq!(item.category_label(), "health");
+    }
+
+    #[test]
+    fn attention_item_category_label_custom() {
+        let item = AttentionItem {
+            category: AttentionCategory::Custom("foo".to_owned()),
+            summary: "custom item".to_owned(),
+            urgency: Urgency::Low,
+        };
+        assert_eq!(item.category_label(), "foo");
+    }
+
+    #[test]
+    fn urgency_ordering() {
+        assert!(Urgency::Low < Urgency::Medium);
+        assert!(Urgency::Medium < Urgency::High);
+        assert!(Urgency::High < Urgency::Critical);
+    }
+
+    #[test]
+    fn prosoche_result_serialization() {
+        let result = ProsocheResult {
+            items: vec![AttentionItem {
+                category: AttentionCategory::Task,
+                summary: "test".to_owned(),
+                urgency: Urgency::High,
+            }],
+            checked_at: "2026-01-01T00:00:00Z".to_owned(),
+        };
+        let json = serde_json::to_string(&result).expect("serialize");
+        let back: ProsocheResult = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back.items.len(), 1);
+        assert_eq!(back.checked_at, "2026-01-01T00:00:00Z");
+    }
+
+    #[test]
+    fn attention_item_serialization() {
+        let item = AttentionItem {
+            category: AttentionCategory::Calendar,
+            summary: "standup".to_owned(),
+            urgency: Urgency::Medium,
+        };
+        let json = serde_json::to_string(&item).expect("serialize");
+        assert!(json.contains("Calendar"));
+        assert!(json.contains("standup"));
+        assert!(json.contains("Medium"));
+    }
 }

--- a/crates/daemon/src/runner.rs
+++ b/crates/daemon/src/runner.rs
@@ -713,4 +713,122 @@ mod tests {
         let output = result.unwrap().output.unwrap_or_default();
         assert!(output.contains("skipped"));
     }
+
+    #[test]
+    fn status_empty_runner() {
+        let (_tx, rx) = watch::channel(false);
+        let runner = TaskRunner::new("test-nous", rx);
+        assert!(
+            runner.status().is_empty(),
+            "new runner should have no tasks"
+        );
+    }
+
+    #[test]
+    fn register_startup_task_immediate() {
+        let (_tx, rx) = watch::channel(false);
+        let mut runner = TaskRunner::new("test-nous", rx);
+
+        let task = TaskDef {
+            id: "startup-task".to_owned(),
+            name: "Startup".to_owned(),
+            nous_id: "test-nous".to_owned(),
+            schedule: Schedule::Startup,
+            action: TaskAction::Command("echo boot".to_owned()),
+            enabled: true,
+            active_window: None,
+        };
+        let before = jiff::Timestamp::now();
+        runner.register(task);
+
+        // Startup tasks should have next_run set to approximately now.
+        let statuses = runner.status();
+        let next_run_str = statuses[0]
+            .next_run
+            .as_ref()
+            .expect("startup should have next_run");
+        let next_run: jiff::Timestamp = next_run_str.parse().expect("valid timestamp");
+        assert!(
+            next_run >= before,
+            "startup task next_run should be >= time before registration"
+        );
+    }
+
+    #[test]
+    fn with_bridge_stores_bridge() {
+        let (_tx, rx) = watch::channel(false);
+        let bridge: Arc<dyn DaemonBridge> = Arc::new(crate::bridge::NoopBridge);
+        let runner = TaskRunner::with_bridge("test-nous", rx, bridge);
+        // Verify runner was created (bridge is private, but we can confirm no panic).
+        assert!(runner.status().is_empty());
+    }
+
+    #[test]
+    fn with_maintenance_builder_pattern() {
+        let (_tx, rx) = watch::channel(false);
+        let config = MaintenanceConfig::default();
+        let runner = TaskRunner::new("test-nous", rx).with_maintenance(config);
+        assert!(runner.status().is_empty());
+    }
+
+    #[test]
+    fn with_retention_builder_pattern() {
+        let (_tx, rx) = watch::channel(false);
+        let executor: Arc<dyn crate::maintenance::RetentionExecutor> =
+            Arc::new(MockRetentionExecutor);
+        let runner = TaskRunner::new("test-nous", rx).with_retention(executor);
+        assert!(runner.status().is_empty());
+    }
+
+    struct MockRetentionExecutor;
+
+    impl crate::maintenance::RetentionExecutor for MockRetentionExecutor {
+        fn execute_retention(&self) -> crate::error::Result<crate::maintenance::RetentionSummary> {
+            Ok(crate::maintenance::RetentionSummary::default())
+        }
+    }
+
+    #[test]
+    fn execution_result_serialization() {
+        let result = ExecutionResult {
+            success: true,
+            output: Some("hello".to_owned()),
+        };
+        let json = serde_json::to_string(&result).expect("serialize");
+        let back: ExecutionResult = serde_json::from_str(&json).expect("deserialize");
+        assert!(back.success);
+        assert_eq!(back.output.as_deref(), Some("hello"));
+    }
+
+    #[tokio::test]
+    async fn disabled_task_not_in_tick() {
+        let (_tx, rx) = watch::channel(false);
+        let mut runner = TaskRunner::new("test-nous", rx);
+
+        let task = TaskDef {
+            id: "disabled-task".to_owned(),
+            name: "Disabled".to_owned(),
+            nous_id: "test-nous".to_owned(),
+            schedule: Schedule::Interval(Duration::from_secs(60)),
+            action: TaskAction::Command("echo should-not-run".to_owned()),
+            enabled: false,
+            active_window: None,
+        };
+        runner.register(task);
+
+        // Force next_run to the past.
+        runner.tasks[0].next_run = Some(
+            jiff::Timestamp::now()
+                .checked_add(jiff::SignedDuration::from_secs(-10))
+                .unwrap(),
+        );
+
+        runner.tick().await;
+
+        let statuses = runner.status();
+        assert_eq!(
+            statuses[0].run_count, 0,
+            "disabled task should not have run"
+        );
+    }
 }

--- a/crates/daemon/src/schedule.rs
+++ b/crates/daemon/src/schedule.rs
@@ -236,4 +236,74 @@ mod tests {
         let expected = (9..17).contains(&now_hour);
         assert_eq!(result, expected);
     }
+
+    #[test]
+    fn interval_short_duration() {
+        let schedule = Schedule::Interval(Duration::from_millis(1));
+        let next = schedule
+            .next_run()
+            .expect("no error")
+            .expect("should have next");
+        // Should be very close to now (within a few seconds).
+        let diff = next
+            .since(jiff::Timestamp::now())
+            .expect("since should work");
+        assert!(diff.get_seconds() < 2, "1ms interval should be near-future");
+    }
+
+    #[test]
+    fn cron_hourly_expression() {
+        let schedule = Schedule::Cron("0 0 * * * *".to_owned());
+        let next = schedule.next_run().expect("no error");
+        assert!(next.is_some(), "hourly cron should produce next_run");
+    }
+
+    #[test]
+    fn cron_complex_expression() {
+        let schedule = Schedule::Cron("0 */15 9-17 * * MON-FRI".to_owned());
+        let next = schedule.next_run().expect("no error");
+        assert!(
+            next.is_some(),
+            "complex cron expression should parse and produce next_run"
+        );
+    }
+
+    #[test]
+    fn in_window_same_start_end() {
+        // (10, 10): start <= end path, hour >= 10 && hour < 10 is always false.
+        assert!(
+            !Schedule::in_window(Some((10, 10))),
+            "same start and end should always be false"
+        );
+    }
+
+    #[test]
+    fn schedule_debug_format() {
+        let schedule = Schedule::Interval(Duration::from_secs(60));
+        let debug_str = format!("{schedule:?}");
+        assert!(
+            debug_str.contains("Interval"),
+            "Debug should contain variant name"
+        );
+    }
+
+    #[test]
+    fn task_status_fields() {
+        let status = TaskStatus {
+            id: "test-id".to_owned(),
+            name: "Test Task".to_owned(),
+            enabled: true,
+            next_run: Some("2026-01-01T00:00:00Z".to_owned()),
+            last_run: None,
+            run_count: 42,
+            consecutive_failures: 0,
+        };
+        assert_eq!(status.id, "test-id");
+        assert_eq!(status.name, "Test Task");
+        assert!(status.enabled);
+        assert!(status.next_run.is_some());
+        assert!(status.last_run.is_none());
+        assert_eq!(status.run_count, 42);
+        assert_eq!(status.consecutive_failures, 0);
+    }
 }

--- a/crates/dianoia/src/phase.rs
+++ b/crates/dianoia/src/phase.rs
@@ -88,3 +88,98 @@ impl Phase {
         pct
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_phase_defaults() {
+        let phase = Phase::new("Foundation".into(), "Build foundation".into(), 1);
+        assert_eq!(phase.name, "Foundation");
+        assert_eq!(phase.goal, "Build foundation");
+        assert_eq!(phase.order, 1);
+        assert_eq!(phase.state, PhaseState::Pending);
+        assert!(phase.plans.is_empty());
+        assert!(phase.requirements.is_empty());
+    }
+
+    #[test]
+    fn add_plan_to_phase() {
+        let mut phase = Phase::new("P1".into(), "g".into(), 1);
+        let plan = Plan::new("task".into(), "desc".into(), 1);
+        phase.add_plan(plan);
+        assert_eq!(phase.plans.len(), 1);
+    }
+
+    #[test]
+    fn is_complete_when_complete() {
+        let mut phase = Phase::new("P1".into(), "g".into(), 1);
+        phase.state = PhaseState::Complete;
+        assert!(phase.is_complete());
+    }
+
+    #[test]
+    fn is_not_complete_when_pending() {
+        let phase = Phase::new("P1".into(), "g".into(), 1);
+        assert!(!phase.is_complete());
+    }
+
+    #[test]
+    fn completion_percentage_empty_plans() {
+        let phase = Phase::new("P1".into(), "g".into(), 1);
+        assert!((phase.completion_percentage() - 0.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn completion_percentage_all_complete() {
+        let mut phase = Phase::new("P1".into(), "g".into(), 1);
+        let mut p1 = Plan::new("t1".into(), "d1".into(), 1);
+        p1.state = PlanState::Complete;
+        let mut p2 = Plan::new("t2".into(), "d2".into(), 1);
+        p2.state = PlanState::Complete;
+        phase.add_plan(p1);
+        phase.add_plan(p2);
+        assert!((phase.completion_percentage() - 100.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn completion_percentage_mixed() {
+        let mut phase = Phase::new("P1".into(), "g".into(), 1);
+        let mut p1 = Plan::new("t1".into(), "d1".into(), 1);
+        p1.state = PlanState::Complete;
+        let p2 = Plan::new("t2".into(), "d2".into(), 1); // Pending
+        let mut p3 = Plan::new("t3".into(), "d3".into(), 1);
+        p3.state = PlanState::Failed;
+        let mut p4 = Plan::new("t4".into(), "d4".into(), 1);
+        p4.state = PlanState::Stuck;
+        phase.add_plan(p1);
+        phase.add_plan(p2);
+        phase.add_plan(p3);
+        phase.add_plan(p4);
+        assert!((phase.completion_percentage() - 75.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn completion_percentage_skipped_counts() {
+        let mut phase = Phase::new("P1".into(), "g".into(), 1);
+        let mut p1 = Plan::new("t1".into(), "d1".into(), 1);
+        p1.state = PlanState::Skipped;
+        phase.add_plan(p1);
+        assert!((phase.completion_percentage() - 100.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn phase_state_variants() {
+        assert_ne!(PhaseState::Pending, PhaseState::Active);
+        assert_ne!(PhaseState::Executing, PhaseState::Verifying);
+        assert_eq!(
+            PhaseState::Failed { can_retry: true },
+            PhaseState::Failed { can_retry: true }
+        );
+        assert_ne!(
+            PhaseState::Failed { can_retry: true },
+            PhaseState::Failed { can_retry: false }
+        );
+    }
+}

--- a/crates/dianoia/src/plan.rs
+++ b/crates/dianoia/src/plan.rs
@@ -153,4 +153,64 @@ mod tests {
         assert!(!dependent.is_ready(&[first.id]));
         assert!(dependent.is_ready(&[first.id, second.id]));
     }
+
+    #[test]
+    fn new_plan_defaults() {
+        let plan = Plan::new("task".into(), "desc".into(), 1);
+        assert_eq!(plan.title, "task");
+        assert_eq!(plan.description, "desc");
+        assert_eq!(plan.wave, 1);
+        assert_eq!(plan.state, PlanState::Pending);
+        assert_eq!(plan.iterations, 0);
+        assert_eq!(plan.max_iterations, 10);
+        assert!(plan.depends_on.is_empty());
+        assert!(plan.blockers.is_empty());
+        assert!(plan.achievements.is_empty());
+    }
+
+    #[test]
+    fn is_ready_no_deps() {
+        let plan = Plan::new("task".into(), "desc".into(), 1);
+        assert!(plan.is_ready(&[]));
+        assert!(plan.is_ready(&[Ulid::new()]));
+    }
+
+    #[test]
+    fn mark_stuck_sets_state_and_blocker() {
+        let mut plan = Plan::new("task".into(), "desc".into(), 1);
+        let blocker = Blocker {
+            description: "blocked on review".into(),
+            plan_id: plan.id,
+            detected_at: jiff::Timestamp::now(),
+        };
+        plan.mark_stuck(blocker);
+        assert_eq!(plan.state, PlanState::Stuck);
+        assert_eq!(plan.blockers.len(), 1);
+        assert_eq!(plan.blockers[0].description, "blocked on review");
+    }
+
+    #[test]
+    fn record_iteration_within_limit() {
+        let mut plan = Plan::new("task".into(), "desc".into(), 1);
+        plan.max_iterations = 5;
+        for _ in 0..5 {
+            assert!(plan.record_iteration().is_ok());
+        }
+        assert_eq!(plan.iterations, 5);
+        assert_eq!(plan.state, PlanState::Pending);
+    }
+
+    #[test]
+    fn blocker_creation() {
+        let plan_id = Ulid::new();
+        let now = jiff::Timestamp::now();
+        let blocker = Blocker {
+            description: "needs API design decision".into(),
+            plan_id,
+            detected_at: now,
+        };
+        assert_eq!(blocker.description, "needs API design decision");
+        assert_eq!(blocker.plan_id, plan_id);
+        assert_eq!(blocker.detected_at, now);
+    }
 }

--- a/crates/dianoia/src/project.rs
+++ b/crates/dianoia/src/project.rs
@@ -146,4 +146,112 @@ mod tests {
         let active = project.active_phase().unwrap();
         assert_eq!(active.name, "Phase 2");
     }
+
+    #[test]
+    fn quick_mode_project() {
+        let project = Project::new(
+            "quick-task".into(),
+            "a quick task".into(),
+            ProjectMode::Quick {
+                appetite_minutes: 30,
+            },
+            "bob".into(),
+        );
+        assert_eq!(
+            project.mode,
+            ProjectMode::Quick {
+                appetite_minutes: 30
+            }
+        );
+        assert_eq!(project.state, ProjectState::Created);
+    }
+
+    #[test]
+    fn background_mode_project() {
+        let project = Project::new(
+            "bg-task".into(),
+            "background work".into(),
+            ProjectMode::Background,
+            "alice".into(),
+        );
+        assert_eq!(project.mode, ProjectMode::Background);
+        assert_eq!(project.owner, "alice");
+    }
+
+    #[test]
+    fn add_phase_updates_timestamp() {
+        let mut project = Project::new(
+            "test".into(),
+            "desc".into(),
+            ProjectMode::Full,
+            "syn".into(),
+        );
+        let before = project.updated_at;
+        std::thread::sleep(std::time::Duration::from_millis(2));
+        let phase = Phase::new("Phase 1".into(), "First".into(), 1);
+        project.add_phase(phase);
+        assert!(project.updated_at >= before);
+        assert_eq!(project.phases.len(), 1);
+    }
+
+    #[test]
+    fn active_phase_mut_returns_mutable() {
+        let mut project = Project::new(
+            "test".into(),
+            "desc".into(),
+            ProjectMode::Full,
+            "syn".into(),
+        );
+        let phase = Phase::new("Phase 1".into(), "First".into(), 1);
+        project.add_phase(phase);
+
+        let active = project.active_phase_mut().unwrap();
+        active.state = PhaseState::Complete;
+
+        assert!(project.active_phase().is_none());
+    }
+
+    #[test]
+    fn all_phases_complete_returns_none() {
+        let mut project = Project::new(
+            "test".into(),
+            "desc".into(),
+            ProjectMode::Full,
+            "syn".into(),
+        );
+        let mut phase1 = Phase::new("P1".into(), "g1".into(), 1);
+        phase1.state = PhaseState::Complete;
+        let mut phase2 = Phase::new("P2".into(), "g2".into(), 2);
+        phase2.state = PhaseState::Complete;
+        project.add_phase(phase1);
+        project.add_phase(phase2);
+        assert!(project.active_phase().is_none());
+    }
+
+    #[test]
+    fn advance_invalid_transition_fails() {
+        let mut project = Project::new(
+            "test".into(),
+            "desc".into(),
+            ProjectMode::Full,
+            "syn".into(),
+        );
+        // Created -> StartExecution is invalid
+        let result = project.advance(Transition::StartExecution);
+        assert!(result.is_err());
+        assert_eq!(project.state, ProjectState::Created);
+    }
+
+    #[test]
+    fn project_scope_can_be_set() {
+        let mut project = Project::new(
+            "test".into(),
+            "desc".into(),
+            ProjectMode::Full,
+            "syn".into(),
+        );
+        assert!(project.scope.is_none());
+        project.scope = Some("crate dianoia only".into());
+        assert_eq!(project.scope.as_deref(), Some("crate dianoia only"));
+    }
 }

--- a/crates/dianoia/src/state.rs
+++ b/crates/dianoia/src/state.rs
@@ -358,4 +358,79 @@ mod tests {
             .is_active()
         );
     }
+
+    #[test]
+    fn questioning_skip_research() {
+        let state = ProjectState::Questioning;
+        let state = state.transition(Transition::SkipResearch).unwrap();
+        assert_eq!(state, ProjectState::Scoping);
+    }
+
+    #[test]
+    fn researching_to_scoping() {
+        let state = ProjectState::Researching;
+        let state = state.transition(Transition::StartScoping).unwrap();
+        assert_eq!(state, ProjectState::Scoping);
+    }
+
+    #[test]
+    fn pause_from_each_pausable_state() {
+        for start in [
+            ProjectState::Researching,
+            ProjectState::Scoping,
+            ProjectState::Planning,
+            ProjectState::Discussing,
+            ProjectState::Executing,
+        ] {
+            let paused = start.clone().transition(Transition::Pause).unwrap();
+            assert!(matches!(paused, ProjectState::Paused { .. }));
+            if let ProjectState::Paused { previous } = paused {
+                assert_eq!(*previous, start);
+            }
+        }
+    }
+
+    #[test]
+    fn cannot_pause_from_created() {
+        let result = ProjectState::Created.transition(Transition::Pause);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn cannot_pause_from_questioning() {
+        let result = ProjectState::Questioning.transition(Transition::Pause);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn revert_to_invalid_state_rejected() {
+        let state = ProjectState::Verifying;
+        let result = state.transition(Transition::Revert {
+            to: ProjectState::Researching,
+        });
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn abandon_from_paused() {
+        let state = ProjectState::Paused {
+            previous: Box::new(ProjectState::Planning),
+        };
+        let state = state.transition(Transition::Abandon).unwrap();
+        assert_eq!(state, ProjectState::Abandoned);
+    }
+
+    #[test]
+    fn double_pause_not_possible() {
+        let state = ProjectState::Paused {
+            previous: Box::new(ProjectState::Executing),
+        };
+        let result = state.transition(Transition::Pause);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn complete_is_not_active() {
+        assert!(!ProjectState::Complete.is_active());
+    }
 }

--- a/crates/dianoia/src/workspace.rs
+++ b/crates/dianoia/src/workspace.rs
@@ -201,4 +201,85 @@ mod tests {
         let result = ProjectWorkspace::open("/nonexistent/workspace/path");
         assert!(result.is_err());
     }
+
+    #[test]
+    fn layout_paths_are_correct() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("myproject");
+        let ws = ProjectWorkspace::create(&root).unwrap();
+        let layout = ws.layout();
+        assert_eq!(layout.root, root);
+        assert_eq!(layout.project_file, root.join("PROJECT.json"));
+        assert_eq!(layout.phases_dir, root.join("phases"));
+        assert_eq!(layout.blockers_dir, root.join(".dianoia").join("blockers"));
+        assert_eq!(layout.artifacts_dir, root.join("artifacts"));
+    }
+
+    #[test]
+    fn read_blockers_empty_phase() {
+        let dir = tempfile::tempdir().unwrap();
+        let ws = ProjectWorkspace::create(dir.path().join("project")).unwrap();
+        let blockers = ws.read_blockers("nonexistent-phase").unwrap();
+        assert!(blockers.is_empty());
+    }
+
+    #[test]
+    fn multiple_blockers_for_phase() {
+        let dir = tempfile::tempdir().unwrap();
+        let ws = ProjectWorkspace::create(dir.path().join("project")).unwrap();
+
+        let plan_id_1 = ulid::Ulid::new();
+        let plan_id_2 = ulid::Ulid::new();
+
+        let first_blocker = Blocker {
+            description: "first blocker".into(),
+            plan_id: plan_id_1,
+            detected_at: jiff::Timestamp::now(),
+        };
+        let second_blocker = Blocker {
+            description: "second blocker".into(),
+            plan_id: plan_id_2,
+            detected_at: jiff::Timestamp::now(),
+        };
+
+        ws.write_blocker("phase-a", &first_blocker).unwrap();
+        ws.write_blocker("phase-a", &second_blocker).unwrap();
+
+        let blockers = ws.read_blockers("phase-a").unwrap();
+        assert_eq!(blockers.len(), 2);
+    }
+
+    #[test]
+    fn save_project_with_phases() {
+        use crate::phase::Phase;
+
+        let dir = tempfile::tempdir().unwrap();
+        let ws = ProjectWorkspace::create(dir.path().join("project")).unwrap();
+
+        let mut project = Project::new(
+            "phased".into(),
+            "project with phases".into(),
+            ProjectMode::Full,
+            "syn".into(),
+        );
+        project.add_phase(Phase::new("Phase 1".into(), "Foundation".into(), 1));
+        project.add_phase(Phase::new("Phase 2".into(), "Features".into(), 2));
+
+        ws.save_project(&project).unwrap();
+        let loaded = ws.load_project().unwrap();
+        assert_eq!(loaded.phases.len(), 2);
+        assert_eq!(loaded.phases[0].name, "Phase 1");
+        assert_eq!(loaded.phases[1].name, "Phase 2");
+    }
+
+    #[test]
+    fn workspace_layout_contains_expected_dirs() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("ws-dirs");
+        let _ws = ProjectWorkspace::create(&root).unwrap();
+
+        assert!(root.join("phases").is_dir());
+        assert!(root.join("artifacts").is_dir());
+        assert!(root.join(".dianoia").join("blockers").is_dir());
+    }
 }

--- a/crates/eval/src/client.rs
+++ b/crates/eval/src/client.rs
@@ -329,4 +329,36 @@ mod tests {
         let with = EvalClient::new("http://localhost", Some("tok".to_owned()));
         assert!(with.has_token());
     }
+
+    #[test]
+    fn url_construction_no_trailing_slash() {
+        let client = EvalClient::new("http://localhost:8080", None);
+        assert_eq!(client.base_url(), "http://localhost:8080");
+    }
+
+    #[test]
+    fn url_construction_multiple_trailing_slashes() {
+        let client = EvalClient::new("http://localhost:8080///", None);
+        assert_eq!(client.base_url(), "http://localhost:8080");
+    }
+
+    #[test]
+    fn base_url_returns_stored_url() {
+        let client = EvalClient::new("http://192.168.1.100:3000", None);
+        assert_eq!(client.base_url(), "http://192.168.1.100:3000");
+    }
+
+    #[test]
+    fn new_client_without_token() {
+        let client = EvalClient::new("http://localhost", None);
+        assert!(!client.has_token());
+        assert_eq!(client.base_url(), "http://localhost");
+    }
+
+    #[test]
+    fn new_client_with_token() {
+        let client = EvalClient::new("http://localhost", Some("secret-token".to_owned()));
+        assert!(client.has_token());
+        assert_eq!(client.base_url(), "http://localhost");
+    }
 }

--- a/crates/eval/src/report.rs
+++ b/crates/eval/src/report.rs
@@ -151,3 +151,92 @@ struct JsonScenarioResult {
     error: Option<String>,
     skip_reason: Option<String>,
 }
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use crate::runner::RunReport;
+    use crate::scenario::{ScenarioMeta, ScenarioOutcome, ScenarioResult};
+
+    use super::*;
+
+    fn sample_report() -> RunReport {
+        RunReport {
+            passed: 2,
+            failed: 1,
+            skipped: 1,
+            total_duration: Duration::from_millis(1234),
+            results: vec![
+                ScenarioResult {
+                    meta: ScenarioMeta {
+                        id: "health-ok",
+                        description: "health endpoint returns ok",
+                        category: "health",
+                        requires_auth: false,
+                        requires_nous: false,
+                    },
+                    outcome: ScenarioOutcome::Passed {
+                        duration: Duration::from_millis(50),
+                    },
+                },
+                ScenarioResult {
+                    meta: ScenarioMeta {
+                        id: "session-create",
+                        description: "session creation works",
+                        category: "session",
+                        requires_auth: true,
+                        requires_nous: true,
+                    },
+                    outcome: ScenarioOutcome::Failed {
+                        duration: Duration::from_millis(200),
+                        error: crate::error::AssertionSnafu {
+                            message: "status mismatch",
+                        }
+                        .build(),
+                    },
+                },
+            ],
+        }
+    }
+
+    #[test]
+    fn json_report_serializes() {
+        let report = sample_report();
+        let json_report = JsonReport {
+            passed: report.passed,
+            failed: report.failed,
+            skipped: report.skipped,
+            total_duration_ms: u64::try_from(report.total_duration.as_millis()).unwrap_or(u64::MAX),
+            results: vec![],
+        };
+        let json = serde_json::to_string(&json_report).expect("serialization should succeed");
+        assert!(!json.is_empty());
+    }
+
+    #[test]
+    fn json_report_contains_expected_fields() {
+        let report = sample_report();
+        let json_report = JsonReport {
+            passed: report.passed,
+            failed: report.failed,
+            skipped: report.skipped,
+            total_duration_ms: u64::try_from(report.total_duration.as_millis()).unwrap_or(u64::MAX),
+            results: vec![JsonScenarioResult {
+                id: "health-ok".to_owned(),
+                category: "health".to_owned(),
+                outcome: "passed".to_owned(),
+                duration_ms: Some(50),
+                error: None,
+                skip_reason: None,
+            }],
+        };
+        let json = serde_json::to_string_pretty(&json_report).expect("serialize");
+        assert!(json.contains("\"passed\""));
+        assert!(json.contains("\"failed\""));
+        assert!(json.contains("\"skipped\""));
+        assert!(json.contains("\"total_duration_ms\""));
+        assert!(json.contains("\"results\""));
+        assert!(json.contains("health-ok"));
+    }
+}

--- a/crates/eval/src/runner.rs
+++ b/crates/eval/src/runner.rs
@@ -234,4 +234,63 @@ mod tests {
         assert_eq!(report.failed, 1);
         assert_eq!(report.skipped, 2);
     }
+
+    #[test]
+    fn scenario_outcome_is_passed() {
+        let outcome = ScenarioOutcome::Passed {
+            duration: Duration::from_millis(100),
+        };
+        assert!(outcome.is_passed());
+        assert!(!outcome.is_failed());
+    }
+
+    #[test]
+    fn scenario_outcome_is_failed() {
+        let outcome = ScenarioOutcome::Failed {
+            duration: Duration::from_millis(100),
+            error: crate::error::AssertionSnafu {
+                message: "test failure",
+            }
+            .build(),
+        };
+        assert!(outcome.is_failed());
+        assert!(!outcome.is_passed());
+    }
+
+    #[test]
+    fn scenario_outcome_skipped_not_passed_or_failed() {
+        let outcome = ScenarioOutcome::Skipped {
+            reason: "not applicable".to_owned(),
+        };
+        assert!(!outcome.is_passed());
+        assert!(!outcome.is_failed());
+    }
+
+    #[test]
+    fn run_report_total_count() {
+        let report = RunReport {
+            passed: 5,
+            failed: 2,
+            skipped: 3,
+            total_duration: Duration::from_secs(1),
+            results: vec![],
+        };
+        assert_eq!(report.passed + report.failed + report.skipped, 10);
+    }
+
+    #[test]
+    fn scenario_meta_fields() {
+        let meta = crate::scenario::ScenarioMeta {
+            id: "test-scenario",
+            description: "a test scenario",
+            category: "unit",
+            requires_auth: true,
+            requires_nous: false,
+        };
+        assert_eq!(meta.id, "test-scenario");
+        assert_eq!(meta.description, "a test scenario");
+        assert_eq!(meta.category, "unit");
+        assert!(meta.requires_auth);
+        assert!(!meta.requires_nous);
+    }
 }

--- a/crates/eval/src/scenario.rs
+++ b/crates/eval/src/scenario.rs
@@ -87,3 +87,34 @@ pub fn assert_eq_eval<T: PartialEq + std::fmt::Debug>(
         .fail()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn assert_eval_passes_on_true() {
+        let result = assert_eval(true, "ok");
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn assert_eval_fails_on_false() {
+        let result = assert_eval(false, "fail");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn assert_eq_eval_equal_values() {
+        let result = assert_eq_eval(&1, &1, "ctx");
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn assert_eq_eval_different_values() {
+        let result = assert_eq_eval(&1, &2, "ctx");
+        assert!(result.is_err());
+        let err_msg = result.unwrap_err().to_string();
+        assert!(err_msg.contains("ctx"));
+    }
+}

--- a/crates/eval/src/sse.rs
+++ b/crates/eval/src/sse.rs
@@ -196,4 +196,114 @@ mod tests {
         assert_eq!(events.len(), 1);
         assert_eq!(events[0].event_type, "text_delta");
     }
+
+    #[test]
+    fn multiline_data_concatenated() {
+        let input = "event: text_delta\ndata: {\"text\":\ndata: \"hello\"}\n\n";
+        let events = parse_sse_text(input).expect("parse");
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].event_type, "text_delta");
+        // Two data lines should be joined with newline
+        let raw = format!("{}", events[0].data);
+        assert!(raw.contains("hello"));
+    }
+
+    #[test]
+    fn only_comments_returns_empty() {
+        let input = ":ping\n:keepalive\n";
+        let events = parse_sse_text(input).expect("parse");
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn event_without_data_ignored() {
+        let input = "event: foo\n\n";
+        let events = parse_sse_text(input).expect("parse");
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn data_without_event_ignored() {
+        let input = "data: {\"x\":1}\n\n";
+        let events = parse_sse_text(input).expect("parse");
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn extract_text_empty_events() {
+        let events: Vec<ParsedSseEvent> = vec![];
+        assert_eq!(extract_text(&events), "");
+    }
+
+    #[test]
+    fn is_complete_false_without_complete_event() {
+        let input = "event: text_delta\ndata: {\"text\":\"hi\"}\n\n";
+        let events = parse_sse_text(input).expect("parse");
+        assert!(!is_complete(&events));
+    }
+
+    #[test]
+    fn has_error_false_without_error_event() {
+        let input = "event: text_delta\ndata: {\"text\":\"hi\"}\n\n";
+        let events = parse_sse_text(input).expect("parse");
+        assert!(!has_error(&events));
+    }
+
+    #[test]
+    fn tool_call_count_zero() {
+        let input = "event: text_delta\ndata: {\"text\":\"hi\"}\n\nevent: message_complete\ndata: {\"stop_reason\":\"end_turn\"}\n\n";
+        let events = parse_sse_text(input).expect("parse");
+        assert_eq!(tool_call_count(&events), 0);
+    }
+
+    #[test]
+    fn extract_usage_returns_none_without_complete() {
+        let input = "event: text_delta\ndata: {\"text\":\"hi\"}\n\n";
+        let events = parse_sse_text(input).expect("parse");
+        assert!(extract_usage(&events).is_none());
+    }
+
+    #[test]
+    fn multiple_events_mixed_types() {
+        let input = "\
+event: text_delta\n\
+data: {\"text\":\"Hello\"}\n\
+\n\
+event: tool_use\n\
+data: {\"id\":\"t1\",\"name\":\"search\",\"input\":{\"q\":\"test\"}}\n\
+\n\
+event: tool_result\n\
+data: {\"tool_use_id\":\"t1\",\"content\":\"result\",\"is_error\":false}\n\
+\n\
+event: message_complete\n\
+data: {\"stop_reason\":\"end_turn\",\"usage\":{\"input_tokens\":100,\"output_tokens\":50}}\n\
+\n";
+        let events = parse_sse_text(input).expect("parse");
+        assert_eq!(events.len(), 4);
+        assert_eq!(extract_text(&events), "Hello");
+        assert_eq!(tool_call_count(&events), 1);
+        assert!(is_complete(&events));
+        assert!(!has_error(&events));
+        let usage = extract_usage(&events).expect("usage");
+        assert_eq!(usage.input_tokens, 100);
+        assert_eq!(usage.output_tokens, 50);
+    }
+
+    #[test]
+    fn invalid_json_in_data_returns_error() {
+        let input = "event: foo\ndata: not-json\n\n";
+        let result = parse_sse_text(input);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn whitespace_only_between_events() {
+        // Lines with only whitespace are not "empty" per str::lines, so they don't trigger
+        // event boundaries the same way. This tests that events separated by truly empty
+        // lines still parse correctly even if there's whitespace around them.
+        let input = "event: text_delta\ndata: {\"text\":\"a\"}\n\nevent: text_delta\ndata: {\"text\":\"b\"}\n\n";
+        let events = parse_sse_text(input).expect("parse");
+        assert_eq!(events.len(), 2);
+        assert_eq!(extract_text(&events), "ab");
+    }
 }


### PR DESCRIPTION
## Summary

- **eval (dokimion)**: 13 → 41 tests — SSE parsing edge cases (multiline data, invalid JSON, comments-only), client URL construction, scenario outcome helpers, report JSON serialization, assert_eval/assert_eq_eval
- **dianoia**: 20 → 56 tests — Phase lifecycle (completion percentage, state variants), plan defaults/blockers/mark_stuck, project modes (Quick/Background) and mutations, state machine coverage (pause from each pausable state, revert rejection, double-pause prevention), workspace persistence with phases and multiple blockers
- **daemon (oikonomos)**: 40 → 76 tests — Schedule short intervals and complex cron, prosoche type serialization and urgency ordering, runner builder pattern and empty status, NoopBridge behavior, maintenance config defaults, trace rotation with multiple files, drift detection nested dirs, db_monitor cozo directory and display formatting, retention summary defaults

Combined: 67 → 173 tests (+106). All clippy clean, no non-test code modified.

## Test plan

- [x] `cargo test -p aletheia-dokimion` — 41 passed
- [x] `cargo test -p aletheia-dianoia` — 56 passed
- [x] `cargo test -p aletheia-oikonomos` — 76 passed
- [x] `cargo clippy -p aletheia-dokimion -p aletheia-dianoia -p aletheia-oikonomos --all-targets -- -D warnings` — zero warnings
- [x] `cargo fmt -- --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)