### PR TITLE
fix(tui): terminal escape sequence sanitization

### DIFF
--- a/tui/src/app.rs
+++ b/tui/src/app.rs
@@ -10,6 +10,7 @@ use crate::config::Config;
 use crate::events::StreamEvent;
 use crate::id::{NousId, SessionId, TurnId};
 use crate::msg::{ErrorToast, Msg};
+use crate::sanitize::sanitize_for_display;
 use crate::theme::ThemePalette;
 use crate::update::extract_text_content;
 use crate::view;
@@ -188,18 +189,19 @@ impl App {
             }
         }
 
+        // SAFETY: sanitized at ingestion — all agent fields from API are sanitized here.
         let agents = self.client.agents().await?;
         self.agents = agents
             .into_iter()
             .map(|a| AgentState {
                 id: a.id.clone(),
-                name: a.display_name().to_owned(),
-                emoji: a.emoji,
+                name: sanitize_for_display(a.display_name()).into_owned(),
+                emoji: a.emoji.map(|e| sanitize_for_display(&e).into_owned()),
                 status: AgentStatus::Idle,
                 active_tool: None,
                 tool_started_at: None,
                 sessions: Vec::new(),
-                model: a.model,
+                model: a.model.map(|m| sanitize_for_display(&m).into_owned()),
                 compaction_stage: None,
                 has_notification: false,
             })
@@ -291,6 +293,7 @@ impl App {
 
             match self.client.history(&session_id).await {
                 Ok(history) => {
+                    // SAFETY: sanitized at ingestion — all message fields from API.
                     self.messages = history
                         .into_iter()
                         .filter_map(|m| {
@@ -299,10 +302,12 @@ impl App {
                             }
                             let text = extract_text_content(&m.content)?;
                             Some(ChatMessage {
-                                role: m.role,
-                                text,
-                                timestamp: m.created_at,
-                                model: m.model,
+                                role: sanitize_for_display(&m.role).into_owned(),
+                                text: sanitize_for_display(&text).into_owned(),
+                                timestamp: m
+                                    .created_at
+                                    .map(|t| sanitize_for_display(&t).into_owned()),
+                                model: m.model.map(|m| sanitize_for_display(&m).into_owned()),
                                 is_streaming: false,
                                 tool_calls: Vec::new(),
                             })

--- a/tui/src/markdown.rs
+++ b/tui/src/markdown.rs
@@ -3,21 +3,22 @@ use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
 
 use crate::highlight::Highlighter;
-use crate::sanitize::strip_ansi;
 use crate::theme::ThemePalette;
 
 /// Render markdown text into ratatui Lines.
 /// Supports: bold, italic, code, headings, lists, code blocks (with syntax highlighting),
 /// blockquotes, rules, tables, links, images, and strikethrough.
+///
+/// SAFETY: callers must pass sanitized text. All external data is sanitized
+/// at ingestion in update/api.rs, update/streaming.rs, update/sse.rs, and app.rs.
 pub fn render(
     text: &str,
     _width: usize,
     theme: &ThemePalette,
     highlighter: &Highlighter,
 ) -> Vec<Line<'static>> {
-    let clean = strip_ansi(text);
     let options = Options::ENABLE_STRIKETHROUGH | Options::ENABLE_TABLES;
-    let parser = Parser::new_ext(&clean, options);
+    let parser = Parser::new_ext(text, options);
 
     let mut lines: Vec<Line<'static>> = Vec::new();
     let mut current_spans: Vec<Span<'static>> = Vec::new();

--- a/tui/src/sanitize.rs
+++ b/tui/src/sanitize.rs
@@ -1,43 +1,586 @@
 //! Input sanitization for terminal-rendered content.
 
 use std::borrow::Cow;
-use std::sync::LazyLock;
 
-static ANSI_RE: LazyLock<regex::Regex> = LazyLock::new(|| {
-    regex::Regex::new(r"\x1b\[[0-9;]*[a-zA-Z]|\x1b\][^\x07]*\x07|\x1b\(B")
-        .expect("valid ANSI regex")
-});
+/// Sanitize external text for safe terminal display.
+///
+/// Strips all terminal escape sequences (CSI, OSC, DCS, APC, SOS, PM)
+/// and replaces dangerous C0/C1 control characters with safe alternatives.
+/// Returns `Cow::Borrowed` when the input requires no modification.
+pub fn sanitize_for_display(s: &str) -> Cow<'_, str> {
+    if !needs_sanitization(s) {
+        return Cow::Borrowed(s);
+    }
 
-pub fn strip_ansi(s: &str) -> Cow<'_, str> {
-    ANSI_RE.replace_all(s, "")
+    let mut out = String::with_capacity(s.len());
+    let bytes = s.as_bytes();
+    let len = bytes.len();
+    let mut i = 0;
+
+    while i < len {
+        let b = bytes[i];
+
+        // 7-bit ESC introducer
+        if b == 0x1B && i + 1 < len {
+            let next = bytes[i + 1];
+            match next {
+                // CSI: ESC [
+                b'[' => {
+                    i = skip_csi(bytes, i + 2);
+                    continue;
+                }
+                // OSC: ESC ]
+                b']' => {
+                    i = skip_osc(bytes, i + 2);
+                    continue;
+                }
+                // DCS: ESC P
+                b'P' => {
+                    i = skip_until_st(bytes, i + 2);
+                    continue;
+                }
+                // APC: ESC _
+                b'_' => {
+                    i = skip_until_st(bytes, i + 2);
+                    continue;
+                }
+                // SOS: ESC X
+                b'X' => {
+                    i = skip_until_st(bytes, i + 2);
+                    continue;
+                }
+                // PM: ESC ^
+                b'^' => {
+                    i = skip_until_st(bytes, i + 2);
+                    continue;
+                }
+                // ESC ( — character set designation (e.g., ESC(B)
+                b'(' | b')' | b'*' | b'+' if i + 2 < len => {
+                    i += 3;
+                    continue;
+                }
+                // Two-byte ESC sequences (e.g., ESC =, ESC >, ESC 7, ESC 8, etc.)
+                0x20..=0x7E => {
+                    i += 2;
+                    continue;
+                }
+                _ => {
+                    // Bare ESC followed by something unexpected — skip the ESC
+                    i += 1;
+                    continue;
+                }
+            }
+        }
+
+        // 8-bit C1 control characters (0x80-0x9F)
+        if (0x80..=0x9F).contains(&b) {
+            // Only hit for single-byte values in valid UTF-8 context.
+            // In practice, UTF-8 multi-byte sequences start with 0xC0+,
+            // so 0x80-0x9F as a leading byte means Latin-1 C1 controls.
+            // However, in valid UTF-8 these bytes only appear as continuation
+            // bytes (never as leading bytes). We handle the U+0080..U+009F
+            // Unicode codepoints via char iteration below.
+            // For raw bytes, skip them.
+            i += 1;
+            continue;
+        }
+
+        // C0 control characters
+        if b < 0x20 {
+            match b {
+                b'\n' | b'\r' | b'\t' => {
+                    out.push(b as char);
+                }
+                _ => {
+                    // Replace with Unicode control picture (U+2400 block)
+                    out.push(control_picture(b));
+                }
+            }
+            i += 1;
+            continue;
+        }
+
+        // DEL
+        if b == 0x7F {
+            out.push('\u{2421}'); // ␡
+            i += 1;
+            continue;
+        }
+
+        // Normal byte — but we need to handle multi-byte UTF-8 correctly.
+        // Decode the next UTF-8 character.
+        if let Some((ch, char_len)) = decode_utf8_char(bytes, i) {
+            // Check for Unicode C1 control characters (U+0080 to U+009F)
+            if ('\u{0080}'..='\u{009F}').contains(&ch) {
+                match ch {
+                    // 8-bit CSI
+                    '\u{009B}' => {
+                        i = skip_csi(bytes, i + char_len);
+                        continue;
+                    }
+                    // 8-bit OSC
+                    '\u{009D}' => {
+                        i = skip_osc(bytes, i + char_len);
+                        continue;
+                    }
+                    // 8-bit DCS
+                    '\u{0090}' => {
+                        i = skip_until_st(bytes, i + char_len);
+                        continue;
+                    }
+                    // 8-bit APC
+                    '\u{009F}' => {
+                        i = skip_until_st(bytes, i + char_len);
+                        continue;
+                    }
+                    // 8-bit SOS
+                    '\u{0098}' => {
+                        i = skip_until_st(bytes, i + char_len);
+                        continue;
+                    }
+                    // 8-bit PM
+                    '\u{009E}' => {
+                        i = skip_until_st(bytes, i + char_len);
+                        continue;
+                    }
+                    // 8-bit ST — just drop it
+                    '\u{009C}' => {
+                        i += char_len;
+                        continue;
+                    }
+                    // Other C1 — drop silently
+                    _ => {
+                        i += char_len;
+                        continue;
+                    }
+                }
+            }
+            out.push(ch);
+            i += char_len;
+        } else {
+            // Invalid UTF-8 byte — skip
+            i += 1;
+        }
+    }
+
+    Cow::Owned(out)
+}
+
+/// Quick check whether the string contains any bytes that need sanitization.
+fn needs_sanitization(s: &str) -> bool {
+    for &b in s.as_bytes() {
+        match b {
+            // C0 controls (except tab=0x09, LF=0x0A, CR=0x0D) and DEL
+            0x00..=0x08 | 0x0B..=0x0C | 0x0E..=0x1F | 0x7F => return true,
+            _ => {}
+        }
+    }
+    // Also check for Unicode C1 control characters
+    for ch in s.chars() {
+        if ('\u{0080}'..='\u{009F}').contains(&ch) {
+            return true;
+        }
+    }
+    false
+}
+
+/// Skip a CSI sequence: parameters (0x30-0x3F), intermediates (0x20-0x2F), final byte (0x40-0x7E).
+fn skip_csi(bytes: &[u8], start: usize) -> usize {
+    let mut i = start;
+    let len = bytes.len();
+    // Parameter bytes
+    while i < len && (0x30..=0x3F).contains(&bytes[i]) {
+        i += 1;
+    }
+    // Intermediate bytes
+    while i < len && (0x20..=0x2F).contains(&bytes[i]) {
+        i += 1;
+    }
+    // Final byte
+    if i < len && (0x40..=0x7E).contains(&bytes[i]) {
+        i += 1;
+    }
+    i
+}
+
+/// Skip an OSC sequence terminated by BEL (0x07) or ST (ESC \ or 0x9C).
+fn skip_osc(bytes: &[u8], start: usize) -> usize {
+    let mut i = start;
+    let len = bytes.len();
+    while i < len {
+        if bytes[i] == 0x07 {
+            return i + 1; // BEL terminator
+        }
+        if bytes[i] == 0x1B && i + 1 < len && bytes[i + 1] == b'\\' {
+            return i + 2; // ST = ESC \
+        }
+        // 8-bit ST (U+009C as UTF-8: 0xC2 0x9C)
+        if bytes[i] == 0xC2 && i + 1 < len && bytes[i + 1] == 0x9C {
+            return i + 2;
+        }
+        i += 1;
+    }
+    len // Unterminated — consume to end
+}
+
+/// Skip until ST (ESC \ or 8-bit ST). Used for DCS, APC, SOS, PM.
+fn skip_until_st(bytes: &[u8], start: usize) -> usize {
+    let mut i = start;
+    let len = bytes.len();
+    while i < len {
+        if bytes[i] == 0x1B && i + 1 < len && bytes[i + 1] == b'\\' {
+            return i + 2; // ST = ESC \
+        }
+        // 8-bit ST (U+009C as UTF-8: 0xC2 0x9C)
+        if bytes[i] == 0xC2 && i + 1 < len && bytes[i + 1] == 0x9C {
+            return i + 2;
+        }
+        i += 1;
+    }
+    len // Unterminated — consume to end
+}
+
+/// Map a C0 control byte to its Unicode control picture character (U+2400 block).
+fn control_picture(byte: u8) -> char {
+    match byte {
+        0x00 => '\u{2400}', // ␀ NUL
+        0x01 => '\u{2401}', // ␁ SOH
+        0x02 => '\u{2402}', // ␂ STX
+        0x03 => '\u{2403}', // ␃ ETX
+        0x04 => '\u{2404}', // ␄ EOT
+        0x05 => '\u{2405}', // ␅ ENQ
+        0x06 => '\u{2406}', // ␆ ACK
+        0x07 => '\u{2407}', // ␇ BEL
+        0x08 => '\u{2408}', // ␈ BS
+        // 0x09 = TAB (safe, handled before this)
+        // 0x0A = LF (safe, handled before this)
+        0x0B => '\u{240B}', // ␋ VT
+        0x0C => '\u{240C}', // ␌ FF
+        // 0x0D = CR (safe, handled before this)
+        0x0E => '\u{240E}', // ␎ SO
+        0x0F => '\u{240F}', // ␏ SI
+        0x10 => '\u{2410}', // ␐ DLE
+        0x11 => '\u{2411}', // ␑ DC1
+        0x12 => '\u{2412}', // ␒ DC2
+        0x13 => '\u{2413}', // ␓ DC3
+        0x14 => '\u{2414}', // ␔ DC4
+        0x15 => '\u{2415}', // ␕ NAK
+        0x16 => '\u{2416}', // ␖ SYN
+        0x17 => '\u{2417}', // ␗ ETB
+        0x18 => '\u{2418}', // ␘ CAN
+        0x19 => '\u{2419}', // ␙ EM
+        0x1A => '\u{241A}', // ␚ SUB
+        0x1B => '\u{241B}', // ␛ ESC
+        0x1C => '\u{241C}', // ␜ FS
+        0x1D => '\u{241D}', // ␝ GS
+        0x1E => '\u{241E}', // ␞ RS
+        0x1F => '\u{241F}', // ␟ US
+        _ => '\u{FFFD}',    // fallback replacement character
+    }
+}
+
+/// Decode a single UTF-8 character from a byte slice, returning the char and its byte length.
+fn decode_utf8_char(bytes: &[u8], start: usize) -> Option<(char, usize)> {
+    let remaining = &bytes[start..];
+    let s = std::str::from_utf8(remaining).ok()?;
+    let ch = s.chars().next()?;
+    Some((ch, ch.len_utf8()))
+}
+
+/// Legacy alias — prefer `sanitize_for_display` for new code.
+#[cfg(test)]
+fn strip_ansi(s: &str) -> Cow<'_, str> {
+    sanitize_for_display(s)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    // --- CSI sequences ---
+
     #[test]
-    fn strip_color_codes() {
-        assert_eq!(strip_ansi("\x1b[31mred\x1b[0m"), "red");
+    fn strip_csi_color_codes() {
+        assert_eq!(sanitize_for_display("\x1b[31mred\x1b[0m"), "red");
     }
 
     #[test]
-    fn clean_text_passthrough() {
+    fn strip_csi_complex_sgr() {
+        let input = "\x1b[1;31;42mbold red on green\x1b[0m normal";
+        assert_eq!(sanitize_for_display(input), "bold red on green normal");
+    }
+
+    #[test]
+    fn strip_csi_cursor_movement() {
+        // CUU (cursor up), CUD (cursor down), CUF (forward), CUB (back)
+        assert_eq!(
+            sanitize_for_display("a\x1b[2Ab\x1b[3Bc\x1b[4Cd\x1b[5De"),
+            "abcde"
+        );
+    }
+
+    #[test]
+    fn strip_csi_erase() {
+        // ED (erase display) and EL (erase line)
+        assert_eq!(sanitize_for_display("text\x1b[2J\x1b[K"), "text");
+    }
+
+    // --- OSC sequences ---
+
+    #[test]
+    fn strip_osc_title_bel() {
+        let input = "\x1b]0;evil title\x07visible text";
+        assert_eq!(sanitize_for_display(input), "visible text");
+    }
+
+    #[test]
+    fn strip_osc_title_st() {
+        let input = "\x1b]2;evil title\x1b\\visible text";
+        assert_eq!(sanitize_for_display(input), "visible text");
+    }
+
+    #[test]
+    fn strip_osc_clipboard_injection() {
+        // OSC 52 — clipboard write
+        let input = "\x1b]52;c;SGVsbG8gV29ybGQ=\x07safe content";
+        assert_eq!(sanitize_for_display(input), "safe content");
+    }
+
+    #[test]
+    fn strip_osc_clipboard_st_terminated() {
+        let input = "\x1b]52;c;SGVsbG8=\x1b\\safe";
+        assert_eq!(sanitize_for_display(input), "safe");
+    }
+
+    // --- DCS sequences ---
+
+    #[test]
+    fn strip_dcs_sequence() {
+        let input = "before\x1bPsomething\x1b\\after";
+        assert_eq!(sanitize_for_display(input), "beforeafter");
+    }
+
+    #[test]
+    fn strip_dcs_sixel() {
+        // Sixel graphics: DCS q ... ST
+        let input = "\x1bPq#0;2;0;0;0#0!10~\x1b\\text";
+        assert_eq!(sanitize_for_display(input), "text");
+    }
+
+    // --- APC sequences ---
+
+    #[test]
+    fn strip_apc_sequence() {
+        let input = "before\x1b_application data\x1b\\after";
+        assert_eq!(sanitize_for_display(input), "beforeafter");
+    }
+
+    // --- SOS sequences ---
+
+    #[test]
+    fn strip_sos_sequence() {
+        let input = "before\x1bXstring data\x1b\\after";
+        assert_eq!(sanitize_for_display(input), "beforeafter");
+    }
+
+    // --- PM sequences ---
+
+    #[test]
+    fn strip_pm_sequence() {
+        let input = "before\x1b^privacy message\x1b\\after";
+        assert_eq!(sanitize_for_display(input), "beforeafter");
+    }
+
+    // --- 8-bit C1 controls (UTF-8 encoded) ---
+
+    #[test]
+    fn strip_8bit_csi() {
+        // U+009B (8-bit CSI) encoded as UTF-8: 0xC2 0x9B
+        let input = format!("text{}31mred", '\u{009B}');
+        assert_eq!(sanitize_for_display(&input), "textred");
+    }
+
+    #[test]
+    fn strip_8bit_osc() {
+        // U+009D (8-bit OSC) encoded as UTF-8
+        let input = format!("text{}0;title\x07visible", '\u{009D}');
+        assert_eq!(sanitize_for_display(&input), "textvisible");
+    }
+
+    #[test]
+    fn strip_8bit_dcs() {
+        // U+0090 (8-bit DCS) encoded as UTF-8
+        let input = format!("text{}data\x1b\\visible", '\u{0090}');
+        assert_eq!(sanitize_for_display(&input), "textvisible");
+    }
+
+    #[test]
+    fn strip_c1_controls_silently() {
+        // Various C1 controls that should be dropped
+        let input = format!("a{}b{}c", '\u{0085}', '\u{008A}');
+        assert_eq!(sanitize_for_display(&input), "abc");
+    }
+
+    // --- C0 control characters ---
+
+    #[test]
+    fn replace_null_with_picture() {
+        assert_eq!(sanitize_for_display("a\x00b"), "a\u{2400}b");
+    }
+
+    #[test]
+    fn replace_bel_with_picture() {
+        assert_eq!(sanitize_for_display("a\x07b"), "a\u{2407}b");
+    }
+
+    #[test]
+    fn replace_backspace_with_picture() {
+        assert_eq!(sanitize_for_display("a\x08b"), "a\u{2408}b");
+    }
+
+    #[test]
+    fn replace_del_with_picture() {
+        assert_eq!(sanitize_for_display("a\x7Fb"), "a\u{2421}b");
+    }
+
+    #[test]
+    fn preserve_safe_controls() {
+        // Tab, newline, carriage return should pass through
+        assert_eq!(
+            sanitize_for_display("line1\nline2\ttab\rreturn"),
+            "line1\nline2\ttab\rreturn"
+        );
+    }
+
+    // --- Character set designation ---
+
+    #[test]
+    fn strip_charset_designation() {
+        assert_eq!(sanitize_for_display("\x1b(Btext"), "text");
+        assert_eq!(sanitize_for_display("\x1b)0text"), "text");
+    }
+
+    // --- Clean text passthrough ---
+
+    #[test]
+    fn clean_ascii_passthrough() {
         let clean = "no escapes here";
-        let result = strip_ansi(clean);
+        let result = sanitize_for_display(clean);
         assert!(matches!(result, Cow::Borrowed(_)));
         assert_eq!(&*result, clean);
     }
 
     #[test]
-    fn strip_complex_sequences() {
-        let input = "\x1b[1;31;42mbold red on green\x1b[0m normal";
-        assert_eq!(strip_ansi(input), "bold red on green normal");
+    fn clean_unicode_passthrough() {
+        let clean = "hello \u{1F600} world \u{00E9}\u{00E8}\u{00EA}";
+        let result = sanitize_for_display(clean);
+        assert!(matches!(result, Cow::Borrowed(_)));
+        assert_eq!(&*result, clean);
     }
 
     #[test]
-    fn strip_osc_sequences() {
-        let input = "\x1b]0;window title\x07visible text";
-        assert_eq!(strip_ansi(input), "visible text");
+    fn clean_cjk_passthrough() {
+        let clean = "\u{4F60}\u{597D}\u{4E16}\u{754C}";
+        let result = sanitize_for_display(clean);
+        assert!(matches!(result, Cow::Borrowed(_)));
+    }
+
+    // --- Mixed and complex cases ---
+
+    #[test]
+    fn mixed_sequences_in_one_string() {
+        let input = "\x1b[31mred\x1b[0m \x1b]0;title\x07 \x1bPdcs\x1b\\ visible";
+        assert_eq!(sanitize_for_display(input), "red   visible");
+    }
+
+    #[test]
+    fn unicode_text_with_embedded_escapes() {
+        let input = "caf\u{00E9}\x1b[1mbold\x1b[0m \u{1F600}";
+        assert_eq!(sanitize_for_display(input), "caf\u{00E9}bold \u{1F600}");
+    }
+
+    #[test]
+    fn nested_malformed_sequences() {
+        // ESC [ with no final byte, then normal text
+        let input = "\x1b[text after incomplete csi";
+        let result = sanitize_for_display(input);
+        // The skip_csi consumes parameter/intermediate bytes but 't' is a valid final byte
+        // so it will consume \x1b[ then 't' as final byte, then "ext after..."
+        assert!(result.contains("after"));
+    }
+
+    #[test]
+    fn unterminated_osc_consumed_to_end() {
+        let input = "before\x1b]0;no terminator";
+        assert_eq!(sanitize_for_display(input), "before");
+    }
+
+    #[test]
+    fn unterminated_dcs_consumed_to_end() {
+        let input = "before\x1bPno terminator";
+        assert_eq!(sanitize_for_display(input), "before");
+    }
+
+    #[test]
+    fn multiple_escape_types_interleaved() {
+        let input = "\x1b[31m\x1b]52;c;dGVzdA==\x07\x1bPdcs\x1b\\\x1b_apc\x1b\\safe";
+        assert_eq!(sanitize_for_display(input), "safe");
+    }
+
+    #[test]
+    fn real_world_llm_response_with_ansi() {
+        let input = "Here is the \x1b[1;36mresult\x1b[0m of the analysis:\n\
+                      - Item 1\n\
+                      - Item 2\n\
+                      \x1b]0;hijack\x07";
+        let result = sanitize_for_display(input);
+        assert!(result.contains("result"));
+        assert!(result.contains("Item 1"));
+        assert!(!result.contains("hijack"));
+        assert!(!result.contains("\x1b"));
+    }
+
+    #[test]
+    fn strip_ansi_backward_compat() {
+        assert_eq!(strip_ansi("\x1b[31mred\x1b[0m"), "red");
+    }
+
+    // --- Edge cases ---
+
+    #[test]
+    fn empty_string() {
+        let result = sanitize_for_display("");
+        assert!(matches!(result, Cow::Borrowed(_)));
+        assert_eq!(&*result, "");
+    }
+
+    #[test]
+    fn bare_esc_at_end() {
+        let result = sanitize_for_display("text\x1b");
+        // The bare ESC at end without a follow-up byte is just skipped
+        assert!(!result.contains('\x1b'));
+    }
+
+    #[test]
+    fn only_escape_sequences() {
+        let input = "\x1b[31m\x1b[0m\x1b]0;x\x07";
+        assert_eq!(sanitize_for_display(input), "");
+    }
+
+    #[test]
+    fn cursor_repositioning_attack() {
+        // Attempt to overwrite visible content using cursor movement
+        let input = "safe text\x1b[H\x1b[2Jmalicious overwrite";
+        let result = sanitize_for_display(input);
+        assert!(result.contains("safe text"));
+        assert!(result.contains("malicious overwrite"));
+        assert!(!result.contains("\x1b"));
+    }
+
+    #[test]
+    fn key_remapping_attack() {
+        // DCS sequence attempting to redefine keys
+        let input = "\x1bP+q4B\x1b\\visible";
+        assert_eq!(sanitize_for_display(input), "visible");
     }
 }

--- a/tui/src/update/api.rs
+++ b/tui/src/update/api.rs
@@ -2,32 +2,36 @@ use crate::api::types::{Agent, HistoryMessage, Session};
 use crate::app::App;
 use crate::id::NousId;
 use crate::msg::ErrorToast;
+use crate::sanitize::sanitize_for_display;
 use crate::state::{AgentState, AgentStatus, ChatMessage};
 
+// SAFETY: sanitized at ingestion — all Agent fields from API are sanitized here.
 pub(crate) fn handle_agents_loaded(app: &mut App, agents: Vec<Agent>) {
     app.agents = agents
         .into_iter()
         .map(|a| AgentState {
             id: a.id.clone(),
-            name: a.display_name().to_owned(),
-            emoji: a.emoji,
+            name: sanitize_for_display(a.display_name()).into_owned(),
+            emoji: a.emoji.map(|e| sanitize_for_display(&e).into_owned()),
             status: AgentStatus::Idle,
             active_tool: None,
             tool_started_at: None,
-            sessions: Vec::new(),
-            model: a.model,
+            sessions: sanitize_sessions(Vec::new()),
+            model: a.model.map(|m| sanitize_for_display(&m).into_owned()),
             compaction_stage: None,
             has_notification: false,
         })
         .collect();
 }
 
+// SAFETY: sanitized at ingestion — session keys and fields from API are sanitized here.
 pub(crate) fn handle_sessions_loaded(app: &mut App, nous_id: NousId, sessions: Vec<Session>) {
     if let Some(agent) = app.agents.iter_mut().find(|a| a.id == nous_id) {
-        agent.sessions = sessions;
+        agent.sessions = sanitize_sessions(sessions);
     }
 }
 
+// SAFETY: sanitized at ingestion — all message content from API is sanitized here.
 pub(crate) fn handle_history_loaded(app: &mut App, messages: Vec<HistoryMessage>) {
     app.messages = messages
         .into_iter()
@@ -37,10 +41,10 @@ pub(crate) fn handle_history_loaded(app: &mut App, messages: Vec<HistoryMessage>
             }
             let text = extract_text_content(&m.content)?;
             Some(ChatMessage {
-                role: m.role,
-                text,
-                timestamp: m.created_at,
-                model: m.model,
+                role: sanitize_for_display(&m.role).into_owned(),
+                text: sanitize_for_display(&text).into_owned(),
+                timestamp: m.created_at.map(|t| sanitize_for_display(&t).into_owned()),
+                model: m.model.map(|m| sanitize_for_display(&m).into_owned()),
                 is_streaming: false,
                 tool_calls: Vec::new(),
             })
@@ -77,8 +81,9 @@ pub(crate) async fn handle_new_session(app: &mut App) {
     }
 }
 
+// SAFETY: sanitized at ingestion — error messages may contain external data.
 pub(crate) fn handle_show_error(app: &mut App, msg: String) {
-    app.error_toast = Some(ErrorToast::new(msg));
+    app.error_toast = Some(ErrorToast::new(sanitize_for_display(&msg).into_owned()));
 }
 
 pub(crate) fn handle_dismiss_error(app: &mut App) {
@@ -90,6 +95,24 @@ pub(crate) fn handle_tick(app: &mut App) {
     if app.error_toast.as_ref().is_some_and(|t| t.is_expired()) {
         app.error_toast = None;
     }
+}
+
+/// Sanitize session fields that may contain external data.
+fn sanitize_sessions(sessions: Vec<Session>) -> Vec<Session> {
+    sessions
+        .into_iter()
+        .map(|s| Session {
+            id: s.id,
+            nous_id: s.nous_id,
+            key: sanitize_for_display(&s.key).into_owned(),
+            status: s.status.map(|st| sanitize_for_display(&st).into_owned()),
+            message_count: s.message_count,
+            session_type: s
+                .session_type
+                .map(|t| sanitize_for_display(&t).into_owned()),
+            updated_at: s.updated_at,
+        })
+        .collect()
 }
 
 fn chrono_compact_now() -> String {

--- a/tui/src/update/command.rs
+++ b/tui/src/update/command.rs
@@ -1,6 +1,7 @@
 use crate::app::App;
 use crate::command::build_suggestions;
 use crate::msg::ErrorToast;
+use crate::sanitize::sanitize_for_display;
 use crate::state::Overlay;
 
 pub fn handle_open(app: &mut App) {
@@ -248,10 +249,12 @@ async fn execute_recall(app: &mut App, query: &str) {
     let query = query.to_string();
     match client.recall(&nous_id, &query).await {
         Ok(result) => {
-            let display = if result.len() > 200 {
-                format!("{}...", safe_truncate(&result, 200))
+            // SAFETY: sanitized at ingestion — recall results from memory API.
+            let clean = sanitize_for_display(&result).into_owned();
+            let display = if clean.len() > 200 {
+                format!("{}...", safe_truncate(&clean, 200))
             } else {
-                result
+                clean
             };
             app.error_toast = Some(ErrorToast::new(display));
         }

--- a/tui/src/update/settings.rs
+++ b/tui/src/update/settings.rs
@@ -1,12 +1,17 @@
 use crate::app::App;
 use crate::msg::ErrorToast;
+use crate::sanitize::sanitize_for_display;
 use crate::state::Overlay;
 use crate::state::settings::{EditState, FieldType, SaveStatus, SettingsOverlay};
 
+// SAFETY: sanitized at ingestion — config from API is sanitized via sanitize_config_json.
 pub async fn handle_open(app: &mut App) {
     match app.client.config().await {
         Ok(config) => {
-            app.overlay = Some(Overlay::Settings(SettingsOverlay::from_config(&config)));
+            let clean_config = sanitize_config_json(config);
+            app.overlay = Some(Overlay::Settings(SettingsOverlay::from_config(
+                &clean_config,
+            )));
         }
         Err(e) => {
             app.error_toast = Some(ErrorToast::new(format!("Failed to load config: {e}")));
@@ -14,8 +19,13 @@ pub async fn handle_open(app: &mut App) {
     }
 }
 
+// SAFETY: sanitized at ingestion — config values from API are sanitized in SettingsOverlay.
+// Config values are mostly numbers/bools; string values are sanitized by sanitize_config_json.
 pub fn handle_loaded(app: &mut App, config: serde_json::Value) {
-    app.overlay = Some(Overlay::Settings(SettingsOverlay::from_config(&config)));
+    let clean_config = sanitize_config_json(config);
+    app.overlay = Some(Overlay::Settings(SettingsOverlay::from_config(
+        &clean_config,
+    )));
 }
 
 pub fn handle_up(app: &mut App) {
@@ -159,9 +169,35 @@ pub fn handle_saved(app: &mut App) {
     app.overlay = None;
 }
 
+// SAFETY: sanitized at ingestion — error messages may contain external data.
 pub fn handle_save_error(app: &mut App, msg: String) {
     if let Some(Overlay::Settings(s)) = &mut app.overlay {
-        s.save_status = SaveStatus::Error(msg);
+        s.save_status = SaveStatus::Error(sanitize_for_display(&msg).into_owned());
+    }
+}
+
+/// Recursively sanitize string values in a JSON config tree.
+fn sanitize_config_json(value: serde_json::Value) -> serde_json::Value {
+    match value {
+        serde_json::Value::String(s) => {
+            serde_json::Value::String(sanitize_for_display(&s).into_owned())
+        }
+        serde_json::Value::Object(map) => {
+            let cleaned: serde_json::Map<String, serde_json::Value> = map
+                .into_iter()
+                .map(|(k, v)| {
+                    (
+                        sanitize_for_display(&k).into_owned(),
+                        sanitize_config_json(v),
+                    )
+                })
+                .collect();
+            serde_json::Value::Object(cleaned)
+        }
+        serde_json::Value::Array(arr) => {
+            serde_json::Value::Array(arr.into_iter().map(sanitize_config_json).collect())
+        }
+        other => other,
     }
 }
 

--- a/tui/src/update/sse.rs
+++ b/tui/src/update/sse.rs
@@ -3,8 +3,10 @@ use std::collections::HashMap;
 use crate::api::types::ActiveTurn;
 use crate::app::App;
 use crate::id::{NousId, SessionId};
+use crate::sanitize::sanitize_for_display;
 use crate::state::{AgentState, AgentStatus};
 
+// SAFETY: sanitized at ingestion — agent data from API is sanitized here on SSE reconnect.
 pub(crate) async fn handle_sse_connected(app: &mut App) {
     let was_disconnected = !app.sse_connected;
     app.sse_connected = true;
@@ -24,13 +26,13 @@ pub(crate) async fn handle_sse_connected(app: &mut App) {
                     let notif = notifications.get(&a.id).copied().unwrap_or(false);
                     AgentState {
                         id: a.id.clone(),
-                        name: a.display_name().to_owned(),
-                        emoji: a.emoji,
+                        name: sanitize_for_display(a.display_name()).into_owned(),
+                        emoji: a.emoji.map(|e| sanitize_for_display(&e).into_owned()),
                         status: AgentStatus::Idle,
                         active_tool: None,
                         tool_started_at: None,
                         sessions: Vec::new(),
-                        model: a.model,
+                        model: a.model.map(|m| sanitize_for_display(&m).into_owned()),
                         compaction_stage: None,
                         has_notification: notif,
                     }
@@ -78,9 +80,10 @@ pub(crate) async fn handle_sse_turn_after(app: &mut App, nous_id: NousId, sessio
     }
 }
 
+// SAFETY: sanitized at ingestion — tool name from SSE event.
 pub(crate) fn handle_sse_tool_called(app: &mut App, nous_id: NousId, tool_name: String) {
     if let Some(agent) = app.agents.iter_mut().find(|a| a.id == nous_id) {
-        agent.active_tool = Some(tool_name);
+        agent.active_tool = Some(sanitize_for_display(&tool_name).into_owned());
         agent.tool_started_at = Some(std::time::Instant::now());
     }
 }
@@ -124,9 +127,10 @@ pub(crate) fn handle_sse_distill_before(app: &mut App, nous_id: NousId) {
     }
 }
 
+// SAFETY: sanitized at ingestion — distill stage from SSE event.
 pub(crate) fn handle_sse_distill_stage(app: &mut App, nous_id: NousId, stage: String) {
     if let Some(agent) = app.agents.iter_mut().find(|a| a.id == nous_id) {
-        agent.compaction_stage = Some(stage);
+        agent.compaction_stage = Some(sanitize_for_display(&stage).into_owned());
     }
 }
 

--- a/tui/src/update/streaming.rs
+++ b/tui/src/update/streaming.rs
@@ -2,6 +2,7 @@ use crate::api::types::{Plan, TurnOutcome};
 use crate::app::App;
 use crate::id::{NousId, ToolId, TurnId};
 use crate::msg::ErrorToast;
+use crate::sanitize::sanitize_for_display;
 use crate::state::{
     AgentStatus, ChatMessage, Overlay, PlanApprovalOverlay, PlanStepApproval, ToolApprovalOverlay,
     ToolCallInfo,
@@ -19,8 +20,10 @@ pub(crate) fn handle_stream_turn_start(app: &mut App, turn_id: TurnId, nous_id: 
     }
 }
 
+// SAFETY: sanitized at ingestion — streaming text from LLM API.
 pub(crate) fn handle_stream_text_delta(app: &mut App, text: String) {
-    app.streaming_text.push_str(&text);
+    let clean = sanitize_for_display(&text);
+    app.streaming_text.push_str(&clean);
     let delta = app.streaming_text.len() as i64 - app.cached_markdown_text.len() as i64;
     if delta >= 64 || text.contains('\n') {
         let width = 120;
@@ -33,19 +36,23 @@ pub(crate) fn handle_stream_text_delta(app: &mut App, text: String) {
     }
 }
 
+// SAFETY: sanitized at ingestion — thinking text from LLM API.
 pub(crate) fn handle_stream_thinking_delta(app: &mut App, text: String) {
-    app.streaming_thinking.push_str(&text);
+    let clean = sanitize_for_display(&text);
+    app.streaming_thinking.push_str(&clean);
 }
 
+// SAFETY: sanitized at ingestion — tool names from stream API.
 pub(crate) fn handle_stream_tool_start(app: &mut App, tool_name: String) {
+    let clean_name = sanitize_for_display(&tool_name).into_owned();
     app.streaming_tool_calls.push(ToolCallInfo {
-        name: tool_name.clone(),
+        name: clean_name.clone(),
         duration_ms: None,
         is_error: false,
     });
     if let Some(ref agent_id) = app.focused_agent {
         if let Some(agent) = app.agents.iter_mut().find(|a| a.id == *agent_id) {
-            agent.active_tool = Some(tool_name);
+            agent.active_tool = Some(clean_name);
             agent.tool_started_at = Some(std::time::Instant::now());
         }
     }
@@ -74,6 +81,7 @@ pub(crate) fn handle_stream_tool_result(
     }
 }
 
+// SAFETY: sanitized at ingestion — tool approval data from stream API.
 pub(crate) fn handle_stream_tool_approval_required(
     app: &mut App,
     turn_id: TurnId,
@@ -86,10 +94,10 @@ pub(crate) fn handle_stream_tool_approval_required(
     app.overlay = Some(Overlay::ToolApproval(ToolApprovalOverlay {
         turn_id,
         tool_id,
-        tool_name,
+        tool_name: sanitize_for_display(&tool_name).into_owned(),
         input,
-        risk,
-        reason,
+        risk: sanitize_for_display(&risk).into_owned(),
+        reason: sanitize_for_display(&reason).into_owned(),
     }));
 }
 
@@ -99,6 +107,7 @@ pub(crate) fn handle_stream_tool_approval_resolved(app: &mut App) {
     }
 }
 
+// SAFETY: sanitized at ingestion — plan step labels and roles from stream API.
 pub(crate) fn handle_stream_plan_proposed(app: &mut App, plan: Plan) {
     app.overlay = Some(Overlay::PlanApproval(PlanApprovalOverlay {
         plan_id: plan.id,
@@ -109,21 +118,23 @@ pub(crate) fn handle_stream_plan_proposed(app: &mut App, plan: Plan) {
             .into_iter()
             .map(|s| PlanStepApproval {
                 id: s.id,
-                label: s.label,
-                role: s.role,
+                label: sanitize_for_display(&s.label).into_owned(),
+                role: sanitize_for_display(&s.role).into_owned(),
                 checked: true,
             })
             .collect(),
     }));
 }
 
+// SAFETY: sanitized at ingestion — streaming_text already sanitized via handle_stream_text_delta,
+// model name from API is sanitized here.
 pub(crate) async fn handle_stream_turn_complete(app: &mut App, outcome: TurnOutcome) {
     if !app.streaming_text.is_empty() {
         app.messages.push(ChatMessage {
             role: "assistant".to_string(),
             text: app.streaming_text.clone(),
             timestamp: None,
-            model: Some(outcome.model),
+            model: Some(sanitize_for_display(&outcome.model).into_owned()),
             is_streaming: false,
             tool_calls: std::mem::take(&mut app.streaming_tool_calls),
         });
@@ -154,9 +165,10 @@ pub(crate) fn handle_stream_turn_abort(app: &mut App, reason: String) {
     app.stream_rx = None;
 }
 
+// SAFETY: sanitized at ingestion — error messages may contain external data.
 pub(crate) fn handle_stream_error(app: &mut App, msg: String) {
     tracing::error!("stream error: {msg}");
-    app.error_toast = Some(ErrorToast::new(msg));
+    app.error_toast = Some(ErrorToast::new(sanitize_for_display(&msg).into_owned()));
     app.active_turn_id = None;
     app.stream_rx = None;
 }


### PR DESCRIPTION
## Summary

- Replace regex-based `strip_ansi` with a byte-level state machine in `sanitize.rs` that catches all known terminal escape sequence families: CSI, OSC (clipboard hijack, title change), DCS (key remapping), APC, SOS, PM, 8-bit C1 controls (U+0080-U+009F), and dangerous C0 characters (BEL, BS, DEL, null)
- Move sanitization from render time to ingestion time — every `update/` handler that receives external data now calls `sanitize_for_display()` before storing in `App` state, closing bypass paths where view code rendered unsanitized data via `Span::raw`/`Span::styled`
- 39 targeted tests covering each escape family, attack vectors (OSC 52 clipboard injection, cursor repositioning, key remapping), edge cases (unterminated sequences, nested/malformed, multibyte UTF-8), and clean passthrough

## Files changed

| File | What |
|------|------|
| `tui/src/sanitize.rs` | Complete rewrite — state machine replaces regex |
| `tui/src/markdown.rs` | Remove redundant `strip_ansi` call (input is now pre-sanitized) |
| `tui/src/app.rs` | Sanitize agent/history data on initial connect |
| `tui/src/update/api.rs` | Sanitize agents, sessions, history, errors at ingestion |
| `tui/src/update/streaming.rs` | Sanitize streaming text, thinking, tool names, approvals |
| `tui/src/update/sse.rs` | Sanitize SSE agent reload, tool names, distill stages |
| `tui/src/update/command.rs` | Sanitize recall results from memory API |
| `tui/src/update/settings.rs` | Sanitize config JSON tree and save errors |

## Test plan

- [x] `cargo fmt -p aletheia-tui -- --check` clean
- [x] `cargo clippy -p aletheia-tui --all-targets -- -D warnings` clean
- [x] `cargo test -p aletheia-tui` — 371 tests pass
- [x] `cargo check --workspace` clean