### PR TITLE
fix: close compliant crate MEDIUM findings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,6 +52,7 @@ dependencies = [
  "anyhow",
  "axum 0.8.8",
  "clap",
+ "clap_complete",
  "cliclack",
  "jiff",
  "owo-colors",
@@ -350,6 +351,7 @@ name = "aletheia-taxis"
 version = "0.10.0"
 dependencies = [
  "figment",
+ "proptest",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -1192,6 +1194,15 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim",
+]
+
+[[package]]
+name = "clap_complete"
+version = "4.5.66"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c757a3b7e39161a4e56f9365141ada2a6c915a8622c408ab6bb4b5d047371031"
+dependencies = [
+ "clap",
 ]
 
 [[package]]

--- a/crates/nous/src/cross.rs
+++ b/crates/nous/src/cross.rs
@@ -145,6 +145,10 @@ impl CrossNousRouter {
     }
 
     /// Register a nous actor's inbox so it can receive cross-nous messages.
+    ///
+    /// # Cancel safety
+    ///
+    /// Cancel-safe. Uses a single `RwLock::write` + `insert`.
     #[instrument(skip(self, sender))]
     pub async fn register(
         &self,
@@ -162,6 +166,11 @@ impl CrossNousRouter {
     }
 
     /// Fire-and-forget send. Returns `Delivered` on success.
+    ///
+    /// # Cancel safety
+    ///
+    /// Not cancel-safe. If cancelled after `mpsc::send` succeeds, the message
+    /// is delivered but the caller never sees the `Delivered` result.
     #[instrument(skip(self, message), fields(msg_id = %message.id, from = %message.from, to = %message.to))]
     pub async fn send(&self, message: CrossNousMessage) -> error::Result<DeliveryState> {
         let to = message.to.clone();
@@ -201,6 +210,11 @@ impl CrossNousRouter {
     }
 
     /// Send and wait for reply. Returns the reply or a timeout error.
+    ///
+    /// # Cancel safety
+    ///
+    /// Not cancel-safe. If cancelled after sending the message, a pending reply
+    /// entry is leaked until timeout cleanup. Do not use in `select!` branches.
     #[instrument(skip(self, message), fields(msg_id = %message.id, from = %message.from, to = %message.to))]
     pub async fn ask(&self, mut message: CrossNousMessage) -> error::Result<CrossNousReply> {
         let to = message.to.clone();

--- a/crates/nous/src/handle.rs
+++ b/crates/nous/src/handle.rs
@@ -30,6 +30,12 @@ impl NousHandle {
     }
 
     /// Send a turn message and await the result.
+    ///
+    /// # Cancel safety
+    ///
+    /// Not cancel-safe. If cancelled after `mpsc::send` completes but before
+    /// `oneshot::recv` returns, the message is consumed by the actor but the
+    /// reply is lost. Callers should not use this in `select!` branches.
     pub async fn send_turn(
         &self,
         session_key: impl Into<String>,
@@ -61,6 +67,12 @@ impl NousHandle {
     ///
     /// Events are sent to `stream_tx` as the LLM generates content and tools execute.
     /// The final `TurnResult` is returned when the turn completes.
+    ///
+    /// # Cancel safety
+    ///
+    /// Not cancel-safe. Same as [`send_turn`](Self::send_turn) — if cancelled
+    /// between the inbox send and reply receipt, the turn runs but the result
+    /// is discarded.
     pub async fn send_turn_streaming(
         &self,
         session_key: impl Into<String>,
@@ -91,6 +103,11 @@ impl NousHandle {
     }
 
     /// Query the actor's current status.
+    ///
+    /// # Cancel safety
+    ///
+    /// Cancel-safe. Both `mpsc::send` and `oneshot::recv` are cancel-safe.
+    /// A lost status query has no side effects.
     pub async fn status(&self) -> error::Result<NousStatus> {
         let (tx, rx) = oneshot::channel();
         self.sender
@@ -111,6 +128,10 @@ impl NousHandle {
     }
 
     /// Transition the actor to dormant state.
+    ///
+    /// # Cancel safety
+    ///
+    /// Cancel-safe. Uses a single `mpsc::send` with no follow-up await.
     pub async fn sleep(&self) -> error::Result<()> {
         self.sender
             .send(NousMessage::Sleep)
@@ -124,6 +145,10 @@ impl NousHandle {
     }
 
     /// Wake the actor from dormant state.
+    ///
+    /// # Cancel safety
+    ///
+    /// Cancel-safe. Uses a single `mpsc::send` with no follow-up await.
     pub async fn wake(&self) -> error::Result<()> {
         self.sender
             .send(NousMessage::Wake)
@@ -137,6 +162,10 @@ impl NousHandle {
     }
 
     /// Request graceful shutdown.
+    ///
+    /// # Cancel safety
+    ///
+    /// Cancel-safe. Uses a single `mpsc::send` with no follow-up await.
     pub async fn shutdown(&self) -> error::Result<()> {
         self.sender
             .send(NousMessage::Shutdown)

--- a/crates/nous/src/manager.rs
+++ b/crates/nous/src/manager.rs
@@ -108,6 +108,12 @@ impl NousManager {
     /// Spawn a new nous actor and return its handle.
     ///
     /// If an actor with the same id already exists, the old actor is shut down first.
+    ///
+    /// # Cancel safety
+    ///
+    /// Not cancel-safe. If cancelled after removing an old actor but before
+    /// inserting the new entry, the old actor is lost. Only call during
+    /// sequential startup, never in a `select!`.
     pub async fn spawn(
         &mut self,
         config: NousConfig,
@@ -190,6 +196,11 @@ impl NousManager {
     }
 
     /// Query status from all actors.
+    ///
+    /// # Cancel safety
+    ///
+    /// Cancel-safe. Partial results are discarded if cancelled; no state is
+    /// mutated.
     pub async fn list(&self) -> Vec<NousStatus> {
         let mut statuses = Vec::with_capacity(self.actors.len());
         for entry in self.actors.values() {
@@ -204,6 +215,11 @@ impl NousManager {
     }
 
     /// Gracefully shut down all actors.
+    ///
+    /// # Cancel safety
+    ///
+    /// Not cancel-safe. If cancelled after draining actors but before joining
+    /// them, actor tasks may be leaked. Only call from shutdown paths.
     pub async fn shutdown_all(&mut self) {
         info!(count = self.actors.len(), "shutting down all actors");
 
@@ -238,6 +254,11 @@ impl NousManager {
     ///
     /// Used when the manager is behind `Arc` and mutable access is unavailable.
     /// Does not drain the entries — cleanup happens when the `Arc` drops.
+    ///
+    /// # Cancel safety
+    ///
+    /// Cancel-safe. Each `shutdown` send is independent; partial completion
+    /// leaves remaining actors running (they stop when the `Arc` drops).
     pub async fn shutdown_readonly(&self) {
         info!(count = self.actors.len(), "shutting down all actors");
 

--- a/crates/pylon/src/state.rs
+++ b/crates/pylon/src/state.rs
@@ -32,3 +32,6 @@ pub struct AppState {
     /// Auth mode from gateway config (`"token"`, `"none"`, etc.).
     pub auth_mode: String,
 }
+
+#[cfg(test)]
+static_assertions::assert_impl_all!(AppState: Send, Sync);

--- a/crates/taxis/src/redact.rs
+++ b/crates/taxis/src/redact.rs
@@ -20,6 +20,7 @@ const SENSITIVE_KEYS: &[&str] = &["token", "secret", "password", "apiKey", "api_
 const SIGNAL_PII_KEYS: &[&str] = &["account"];
 
 /// Serialize config to JSON, then redact sensitive fields.
+#[must_use]
 pub fn redact(config: &AletheiaConfig) -> Value {
     let mut value = serde_json::to_value(config).unwrap_or_else(|e| {
         debug!(error = %e, "failed to serialize config for redaction");

--- a/crates/taxis/src/reload.rs
+++ b/crates/taxis/src/reload.rs
@@ -12,6 +12,7 @@ const RESTART_PREFIXES: &[&str] = &[
 ];
 
 /// Returns true if changing the given dotted field path requires a restart.
+#[must_use]
 pub fn requires_restart(field_path: &str) -> bool {
     RESTART_PREFIXES
         .iter()
@@ -19,6 +20,7 @@ pub fn requires_restart(field_path: &str) -> bool {
 }
 
 /// Returns the list of field path prefixes that require restart.
+#[must_use]
 pub fn restart_prefixes() -> &'static [&'static str] {
     RESTART_PREFIXES
 }

--- a/crates/taxis/src/validate.rs
+++ b/crates/taxis/src/validate.rs
@@ -8,6 +8,8 @@ use snafu::Snafu;
 #[snafu(display("config validation failed:\n  - {}", errors.join("\n  - ")))]
 pub struct ValidationError {
     pub errors: Vec<String>,
+    #[snafu(implicit)]
+    pub location: snafu::Location,
 }
 
 /// Validate a config section update. Returns errors for invalid values.
@@ -26,7 +28,7 @@ pub fn validate_section(section: &str, value: &Value) -> Result<(), ValidationEr
     if errors.is_empty() {
         Ok(())
     } else {
-        Err(ValidationError { errors })
+        ValidationSnafu { errors }.fail()
     }
 }
 


### PR DESCRIPTION
## Summary

- **taxis**: Add `snafu::Location` tracking to `ValidationError` with implicit capture, replacing direct struct construction with `ValidationSnafu` builder
- **taxis**: Add `#[must_use]` to `requires_restart`, `restart_prefixes`, and `redact` functions
- **pylon**: Add `Send + Sync` static assertion for `AppState`
- **nous**: Add `# Cancel safety` doc sections to all public async functions in `handle.rs`, `manager.rs`, and `cross.rs`

Closes #570, Closes #566

## Test plan

- [x] `cargo check -p aletheia-taxis -p aletheia-pylon -p aletheia-nous`
- [x] `cargo test -p aletheia-taxis -p aletheia-pylon -p aletheia-nous` — all 61 tests pass
- [x] `cargo clippy -p aletheia-taxis -p aletheia-pylon -p aletheia-nous --all-targets -- -D warnings` — zero warnings
- [x] `cargo fmt -- --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)