### PR TITLE
fix: replace silent unwrap_or with proper error handling

### DIFF
--- a/crates/agora/src/semeion/envelope.rs
+++ b/crates/agora/src/semeion/envelope.rs
@@ -105,7 +105,10 @@ pub fn extract_message(envelope: &SignalEnvelope) -> Option<InboundMessage> {
         sender_name: envelope.source_name.clone(),
         group_id,
         text: text.to_owned(),
-        timestamp: envelope.timestamp.or(data.timestamp).unwrap_or(0),
+        timestamp: envelope.timestamp.or(data.timestamp).unwrap_or_else(|| {
+            tracing::warn!("signal envelope has no timestamp, defaulting to 0");
+            0
+        }),
         attachments,
         raw: raw_value,
     })
@@ -302,6 +305,20 @@ mod tests {
 
         let msg = extract_message(&env).unwrap();
         assert_eq!(msg.text, "hi");
-        assert_eq!(msg.timestamp, 0); // no timestamp available
+        assert_eq!(msg.timestamp, 0); // no timestamp available — warns at runtime
+    }
+
+    #[test]
+    fn extract_uses_data_message_timestamp_as_fallback() {
+        let json = serde_json::json!({
+            "sourceNumber": "+1234567890",
+            "dataMessage": {
+                "timestamp": 1_709_000_000_000_u64,
+                "message": "fallback ts"
+            }
+        });
+        let env: SignalEnvelope = serde_json::from_value(json).unwrap();
+        let msg = extract_message(&env).unwrap();
+        assert_eq!(msg.timestamp, 1_709_000_000_000);
     }
 }

--- a/crates/aletheia/src/knowledge_adapter.rs
+++ b/crates/aletheia/src/knowledge_adapter.rs
@@ -57,7 +57,10 @@ impl KnowledgeSearchService for KnowledgeSearchAdapter {
                 .store
                 .query_facts_async(nous_id, now, i64::try_from(limit).unwrap_or(i64::MAX))
                 .await
-                .unwrap_or_default();
+                .unwrap_or_else(|e| {
+                    tracing::warn!(error = %e, "fact query failed, returning empty results");
+                    Vec::new()
+                });
             let fact_map: std::collections::HashMap<&str, &Fact> =
                 facts.iter().map(|f| (f.id.as_str(), f)).collect();
 

--- a/crates/aletheia/src/main.rs
+++ b/crates/aletheia/src/main.rs
@@ -1423,13 +1423,18 @@ fn export_agent_cmd(
 
     let workspace_path = oikos.nous_dir(nous_id);
 
-    let agent_config = config
-        .agents
-        .list
-        .iter()
-        .find(|a| a.id == nous_id)
-        .map(|a| serde_json::to_value(a).unwrap_or_default())
-        .unwrap_or_default();
+    let agent_config =
+        config
+            .agents
+            .list
+            .iter()
+            .find(|a| a.id == nous_id)
+            .map_or(serde_json::Value::Null, |a| {
+                serde_json::to_value(a).unwrap_or_else(|e| {
+                    tracing::warn!(error = %e, "failed to serialize agent config");
+                    serde_json::Value::Null
+                })
+            });
 
     let opts = aletheia_mneme::export::ExportOptions {
         max_messages_per_session: max_messages,

--- a/crates/daemon/src/maintenance/trace_rotation.rs
+++ b/crates/daemon/src/maintenance/trace_rotation.rs
@@ -93,7 +93,10 @@ impl TraceRotator {
         let mut cumulative_freed: u64 = 0;
 
         for entry in &entries {
-            let age = now.duration_since(entry.modified).unwrap_or_default();
+            let age = now.duration_since(entry.modified).unwrap_or_else(|_| {
+                tracing::warn!(path = %entry.path.display(), "file modified time is in the future, treating age as zero");
+                std::time::Duration::default()
+            });
             let over_size = total_size_bytes.saturating_sub(cumulative_freed) > max_bytes;
 
             if age > max_age || over_size {

--- a/crates/eval/src/client.rs
+++ b/crates/eval/src/client.rs
@@ -96,7 +96,10 @@ impl EvalClient {
         let resp = self.authed_delete(&url).await?;
         let status = resp.status().as_u16();
         if status != 204 && status != 200 {
-            let body = resp.text().await.unwrap_or_default();
+            let body = resp.text().await.unwrap_or_else(|e| {
+                tracing::warn!(error = %e, "failed to read error response body");
+                String::new()
+            });
             return error::UnexpectedStatusSnafu {
                 endpoint: url,
                 status,
@@ -121,7 +124,10 @@ impl EvalClient {
         let resp = self.authed_post(&url, &body).await?;
         let status = resp.status().as_u16();
         if status != 200 {
-            let body_text = resp.text().await.unwrap_or_default();
+            let body_text = resp.text().await.unwrap_or_else(|e| {
+                tracing::warn!(error = %e, "failed to read error response body");
+                String::new()
+            });
             return error::UnexpectedStatusSnafu {
                 endpoint: url,
                 status,
@@ -225,7 +231,10 @@ impl EvalClient {
     ) -> Result<T> {
         let status = response.status().as_u16();
         if !accepted.contains(&status) {
-            let body = response.text().await.unwrap_or_default();
+            let body = response.text().await.unwrap_or_else(|e| {
+                tracing::warn!(error = %e, "failed to read error response body");
+                String::new()
+            });
             return error::UnexpectedStatusSnafu {
                 endpoint: url.to_owned(),
                 status,

--- a/crates/symbolon/src/api_key.rs
+++ b/crates/symbolon/src/api_key.rs
@@ -63,7 +63,10 @@ pub fn generate(
     // Re-read from DB to get populated timestamps
     let stored = store
         .find_api_key_by_hash(&record.key_hash)?
-        .unwrap_or(record);
+        .unwrap_or_else(|| {
+            tracing::warn!("could not re-read API key after storage, using unsaved record");
+            record
+        });
 
     Ok((full_key, stored))
 }

--- a/crates/symbolon/src/auth.rs
+++ b/crates/symbolon/src/auth.rs
@@ -197,7 +197,10 @@ fn is_authorized(claims: &Claims, action: &Action) -> bool {
 }
 
 fn format_unix_iso(unix_secs: i64) -> String {
-    let secs = u64::try_from(unix_secs).unwrap_or(0);
+    let secs = u64::try_from(unix_secs).unwrap_or_else(|_| {
+        tracing::warn!(unix_secs, "negative unix timestamp, clamping to epoch");
+        0
+    });
     let days = secs / 86400;
     let time_secs = secs % 86400;
     let hours = time_secs / 3600;
@@ -240,6 +243,26 @@ mod tests {
 
     fn secret(s: &str) -> SecretString {
         SecretString::from(s.to_owned())
+    }
+
+    // --- format_unix_iso ---
+
+    #[test]
+    fn format_unix_iso_positive_timestamp() {
+        let result = format_unix_iso(1_700_000_000);
+        assert!(result.contains("2023"), "expected year 2023, got {result}");
+    }
+
+    #[test]
+    fn format_unix_iso_negative_timestamp_clamps_to_epoch() {
+        let result = format_unix_iso(-100);
+        assert_eq!(result, "1970-01-01T00:00:00.000Z");
+    }
+
+    #[test]
+    fn format_unix_iso_zero_is_epoch() {
+        let result = format_unix_iso(0);
+        assert_eq!(result, "1970-01-01T00:00:00.000Z");
     }
 
     // --- Login flow ---

--- a/crates/symbolon/src/credential.rs
+++ b/crates/symbolon/src/credential.rs
@@ -11,6 +11,19 @@ use tracing::{info, warn};
 
 use aletheia_koina::credential::{Credential, CredentialProvider, CredentialSource};
 
+/// Return current time as milliseconds since UNIX epoch, warning if the clock
+/// is before epoch rather than silently returning zero.
+#[expect(clippy::cast_possible_truncation, reason = "ms timestamps fit in u64")]
+fn unix_epoch_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap_or_else(|_| {
+            tracing::warn!("system clock before UNIX epoch, using epoch as fallback");
+            Duration::default()
+        })
+        .as_millis() as u64
+}
+
 /// Claude Code production OAuth client ID.
 const OAUTH_CLIENT_ID: &str = "9d1c250a-e61b-44d9-88ed-5944d1962f5e";
 
@@ -95,14 +108,7 @@ impl CredentialFile {
     )]
     pub fn seconds_remaining(&self) -> Option<i64> {
         let expires_at_ms = self.expires_at?;
-        #[expect(
-            clippy::cast_possible_truncation,
-            reason = "ms timestamps fit in u64 until year 584M"
-        )]
-        let now_ms = SystemTime::now()
-            .duration_since(SystemTime::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_millis() as u64;
+        let now_ms = unix_epoch_ms();
         Some((expires_at_ms as i64 - now_ms as i64) / 1000)
     }
 
@@ -305,7 +311,12 @@ impl RefreshingCredentialProvider {
         let state = Arc::new(RwLock::new(Some(RefreshState {
             current_token: cred.token.clone(),
             refresh_token,
-            expires_at_ms: cred.expires_at.unwrap_or(0),
+            expires_at_ms: cred.expires_at.unwrap_or_else(|| {
+                warn!(
+                    "credential has no expiry, treating as immediately expired to trigger refresh"
+                );
+                0
+            }),
         })));
 
         let shutdown = Arc::new(AtomicBool::new(false));
@@ -394,11 +405,7 @@ async fn refresh_loop(
             let Some(s) = guard.as_ref() else {
                 continue;
             };
-            #[expect(clippy::cast_possible_truncation, reason = "ms timestamps fit in u64")]
-            let now_ms = SystemTime::now()
-                .duration_since(SystemTime::UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_millis() as u64;
+            let now_ms = unix_epoch_ms();
             #[expect(clippy::cast_possible_wrap, reason = "ms timestamps fit in i64")]
             let remaining_secs = (s.expires_at_ms as i64 - now_ms as i64) / 1000;
             #[expect(clippy::cast_possible_wrap, reason = "threshold constant fits in i64")]
@@ -414,11 +421,7 @@ async fn refresh_loop(
 
         match do_refresh(&client, &refresh_token).await {
             Some(resp) => {
-                #[expect(clippy::cast_possible_truncation, reason = "ms timestamps fit in u64")]
-                let now_ms = SystemTime::now()
-                    .duration_since(SystemTime::UNIX_EPOCH)
-                    .unwrap_or_default()
-                    .as_millis() as u64;
+                let now_ms = unix_epoch_ms();
                 let expires_at_ms = now_ms + resp.expires_in * 1000;
 
                 // Update in-memory state
@@ -508,11 +511,7 @@ pub async fn force_refresh(path: &Path) -> Result<CredentialFile, String> {
         .await
         .ok_or("OAuth refresh failed")?;
 
-    #[expect(clippy::cast_possible_truncation, reason = "ms timestamps fit in u64")]
-    let now_ms = SystemTime::now()
-        .duration_since(SystemTime::UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_millis() as u64;
+    let now_ms = unix_epoch_ms();
     let expires_at_ms = now_ms + resp.expires_in * 1000;
 
     let scopes = resp
@@ -790,5 +789,63 @@ mod tests {
     fn chain_empty_providers_returns_none() {
         let chain = CredentialChain::new(vec![]);
         assert!(chain.get_credential().is_none());
+    }
+
+    // --- unix_epoch_ms ---
+
+    #[test]
+    fn unix_epoch_ms_returns_nonzero() {
+        let ms = unix_epoch_ms();
+        assert!(
+            ms > 1_000_000_000_000,
+            "expected modern timestamp in ms, got {ms}"
+        );
+    }
+
+    // --- seconds_remaining ---
+
+    #[test]
+    fn seconds_remaining_none_when_no_expiry() {
+        let cred = CredentialFile {
+            token: "t".to_owned(),
+            refresh_token: None,
+            expires_at: None,
+            scopes: None,
+            subscription_type: None,
+        };
+        assert!(cred.seconds_remaining().is_none());
+    }
+
+    #[test]
+    fn seconds_remaining_negative_when_expired() {
+        let cred = CredentialFile {
+            token: "t".to_owned(),
+            refresh_token: None,
+            expires_at: Some(1_000_000_000_000),
+            scopes: None,
+            subscription_type: None,
+        };
+        let remaining = cred.seconds_remaining().unwrap();
+        assert!(
+            remaining < 0,
+            "expected negative remaining, got {remaining}"
+        );
+    }
+
+    #[test]
+    fn seconds_remaining_positive_for_future_expiry() {
+        let far_future_ms = unix_epoch_ms() + 3_600_000;
+        let cred = CredentialFile {
+            token: "t".to_owned(),
+            refresh_token: None,
+            expires_at: Some(far_future_ms),
+            scopes: None,
+            subscription_type: None,
+        };
+        let remaining = cred.seconds_remaining().unwrap();
+        assert!(
+            remaining > 0 && remaining <= 3600,
+            "expected ~3600s remaining, got {remaining}"
+        );
     }
 }

--- a/crates/symbolon/src/jwt.rs
+++ b/crates/symbolon/src/jwt.rs
@@ -135,6 +135,7 @@ impl JwtManager {
             nous_id: nous_id.map(str::to_owned),
             iss: self.config.issuer.clone(),
             iat: now,
+            // Saturate to i64::MAX: a TTL exceeding ~292 billion years is effectively infinite
             exp: now + i64::try_from(ttl.as_secs()).unwrap_or(i64::MAX),
             jti: ulid::Ulid::new().to_string(),
             kind,
@@ -157,6 +158,7 @@ fn now_unix() -> i64 {
             })
             .as_secs(),
     )
+    // Saturate: u64 seconds exceeding i64::MAX (~year 292B) clamps to max
     .unwrap_or(i64::MAX)
 }
 

--- a/crates/symbolon/src/store.rs
+++ b/crates/symbolon/src/store.rs
@@ -317,6 +317,7 @@ fn initialize(conn: &Connection) -> Result<()> {
 }
 
 fn get_schema_version(conn: &Connection) -> u32 {
+    // Returns 0 when the table doesn't exist yet — triggers all migrations
     conn.query_row(
         "SELECT version FROM schema_version ORDER BY version DESC LIMIT 1",
         [],


### PR DESCRIPTION
## Summary

- Replace silent `unwrap_or`/`unwrap_or_default` calls across symbolon and other crates with `unwrap_or_else` + `tracing::warn!` to surface failures instead of masking them
- Extract `unix_epoch_ms()` helper in credential.rs to centralize the system clock fallback pattern with a warning
- Document intentional defaults (JWT saturation, schema migration version) with inline comments
- Add tests for format_unix_iso edge cases, unix_epoch_ms, seconds_remaining, and timestamp fallback

### Crates touched
- `aletheia-symbolon` (auth, jwt, credential, store, api_key)
- `aletheia-dokimion` (eval client error bodies)
- `aletheia-agora` (signal envelope timestamps)
- `aletheia-oikonomos` (trace rotation mtime)
- `aletheia` (main binary, knowledge adapter)

## Test plan
- [x] `cargo test -p aletheia-symbolon` — 70 tests pass (7 new)
- [x] `cargo test -p aletheia-agora` — all pass (1 new)
- [x] `cargo test -p aletheia-oikonomos` — all pass
- [x] `cargo clippy` clean on all touched crates
- [x] `cargo fmt -- --check` clean

Closes #568, Closes #573

🤖 Generated with [Claude Code](https://claude.com/claude-code)