### PR TITLE
feat(mneme): bi-temporal queries and datalog_query tool

### DIFF
--- a/crates/aletheia/src/knowledge_adapter.rs
+++ b/crates/aletheia/src/knowledge_adapter.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use aletheia_mneme::embedding::EmbeddingProvider;
 use aletheia_mneme::knowledge::{EpistemicTier, Fact};
 use aletheia_mneme::knowledge_store::{HybridQuery, KnowledgeStore};
-use aletheia_organon::types::{FactSummary, KnowledgeSearchService, MemoryResult};
+use aletheia_organon::types::{DatalogResult, FactSummary, KnowledgeSearchService, MemoryResult};
 
 pub struct KnowledgeSearchAdapter {
     store: Arc<KnowledgeStore>,
@@ -254,5 +254,86 @@ impl KnowledgeSearchService for KnowledgeSearchAdapter {
                 .await
                 .map_err(|e| format!("failed to unforget fact: {e}"))
         })
+    }
+
+    fn datalog_query(
+        &self,
+        query: &str,
+        params: Option<serde_json::Value>,
+        timeout_secs: Option<f64>,
+        row_limit: Option<usize>,
+    ) -> Pin<Box<dyn Future<Output = Result<DatalogResult, String>> + Send + '_>> {
+        let query = query.to_owned();
+        let row_limit = row_limit.unwrap_or(100);
+        let timeout = timeout_secs.map(std::time::Duration::from_secs_f64);
+        Box::pin(async move {
+            // Convert JSON params to BTreeMap<String, DataValue>
+            let mut cozo_params = std::collections::BTreeMap::new();
+            if let Some(serde_json::Value::Object(map)) = params {
+                for (k, v) in map {
+                    let dv = json_to_datavalue(&v);
+                    cozo_params.insert(k, dv);
+                }
+            }
+
+            let rows = self
+                .store
+                .run_query_with_timeout(&query, cozo_params, timeout)
+                .map_err(|e| e.to_string())?;
+
+            let columns = rows.headers.iter().map(ToString::to_string).collect();
+            let truncated = rows.rows.len() > row_limit;
+            let result_rows: Vec<Vec<serde_json::Value>> = rows
+                .rows
+                .into_iter()
+                .take(row_limit)
+                .map(|row| row.iter().map(datavalue_to_json).collect())
+                .collect();
+
+            Ok(DatalogResult {
+                columns,
+                rows: result_rows,
+                truncated,
+            })
+        })
+    }
+}
+
+fn json_to_datavalue(v: &serde_json::Value) -> aletheia_mneme::engine::DataValue {
+    use aletheia_mneme::engine::DataValue;
+    match v {
+        serde_json::Value::Null => DataValue::Null,
+        serde_json::Value::Bool(b) => DataValue::Bool(*b),
+        serde_json::Value::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                DataValue::from(i)
+            } else if let Some(f) = n.as_f64() {
+                DataValue::from(f)
+            } else {
+                DataValue::Null
+            }
+        }
+        serde_json::Value::String(s) => DataValue::Str(s.as_str().into()),
+        _ => DataValue::Str(v.to_string().into()),
+    }
+}
+
+fn datavalue_to_json(v: &aletheia_mneme::engine::DataValue) -> serde_json::Value {
+    use aletheia_mneme::engine::DataValue;
+    match v {
+        DataValue::Null => serde_json::Value::Null,
+        DataValue::Bool(b) => serde_json::Value::Bool(*b),
+        DataValue::Str(s) => serde_json::Value::String(s.to_string()),
+        dv => {
+            if let Some(i) = dv.get_int() {
+                serde_json::Value::Number(serde_json::Number::from(i))
+            } else if let Some(f) = dv.get_float() {
+                serde_json::Number::from_f64(f)
+                    .map(serde_json::Value::Number)
+                    .unwrap_or(serde_json::Value::String(f.to_string()))
+            } else {
+                serde_json::Value::String(format!("{dv:?}"))
+            }
+        }
     }
 }

--- a/crates/integration-tests/tests/organon_mneme_tools.rs
+++ b/crates/integration-tests/tests/organon_mneme_tools.rs
@@ -318,6 +318,26 @@ impl KnowledgeSearchService for StubKnowledgeService {
     ) -> Pin<Box<dyn Future<Output = Result<(), String>> + Send + '_>> {
         Box::pin(std::future::ready(Ok(())))
     }
+
+    fn datalog_query(
+        &self,
+        _query: &str,
+        _params: Option<serde_json::Value>,
+        _timeout_secs: Option<f64>,
+        _row_limit: Option<usize>,
+    ) -> Pin<
+        Box<
+            dyn Future<Output = Result<aletheia_organon::types::DatalogResult, String>> + Send + '_,
+        >,
+    > {
+        Box::pin(std::future::ready(Ok(
+            aletheia_organon::types::DatalogResult {
+                columns: vec!["stub".to_owned()],
+                rows: vec![],
+                truncated: false,
+            },
+        )))
+    }
 }
 
 fn ctx_with_knowledge(svc: Arc<StubKnowledgeService>) -> ToolContext {

--- a/crates/mneme/src/knowledge.rs
+++ b/crates/mneme/src/knowledge.rs
@@ -188,6 +188,18 @@ pub fn default_stability_hours(fact_type: &str) -> f64 {
     }
 }
 
+/// Diff between two temporal snapshots of the knowledge base.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FactDiff {
+    /// Facts that became valid in the interval.
+    pub added: Vec<Fact>,
+    /// Facts where `valid_from` is before the interval but content or metadata changed.
+    /// Tuple: (old version, new version).
+    pub modified: Vec<(Fact, Fact)>,
+    /// Facts whose `valid_to` fell within the interval.
+    pub removed: Vec<Fact>,
+}
+
 /// Results from a semantic recall query.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RecallResult {

--- a/crates/mneme/src/knowledge_store.rs
+++ b/crates/mneme/src/knowledge_store.rs
@@ -685,6 +685,154 @@ impl KnowledgeStore {
         self.run_mut(script, params)
     }
 
+    /// Query facts valid at a specific point in time.
+    /// Returns facts where `valid_from <= at_time` AND `valid_to > at_time`.
+    pub fn query_facts_temporal(
+        &self,
+        nous_id: &str,
+        at_time: &str,
+        filter: Option<&str>,
+    ) -> crate::error::Result<Vec<crate::knowledge::Fact>> {
+        use crate::engine::DataValue;
+        use std::collections::BTreeMap;
+
+        let mut params = BTreeMap::new();
+        params.insert("nous_id".to_owned(), DataValue::Str(nous_id.into()));
+        params.insert("at_time".to_owned(), DataValue::Str(at_time.into()));
+
+        let rows = match filter {
+            Some(f) if !f.is_empty() => {
+                params.insert("filter".to_owned(), DataValue::Str(f.into()));
+                self.run_read(queries::TEMPORAL_FACTS_FILTERED, params)?
+            }
+            _ => self.run_read(&queries::temporal_facts(), params)?,
+        };
+        rows_to_facts(rows, nous_id)
+    }
+
+    /// Query facts that changed between two timestamps.
+    /// Returns facts where `valid_from` is in `(from_time, to_time]` OR
+    /// `valid_to` is in `(from_time, to_time]`.
+    pub fn query_facts_diff(
+        &self,
+        nous_id: &str,
+        from_time: &str,
+        to_time: &str,
+    ) -> crate::error::Result<crate::knowledge::FactDiff> {
+        use crate::engine::DataValue;
+        use std::collections::BTreeMap;
+
+        let mut params = BTreeMap::new();
+        params.insert("nous_id".to_owned(), DataValue::Str(nous_id.into()));
+        params.insert("from_time".to_owned(), DataValue::Str(from_time.into()));
+        params.insert("to_time".to_owned(), DataValue::Str(to_time.into()));
+
+        let added_rows = self.run_read(queries::TEMPORAL_DIFF_ADDED, params.clone())?;
+        let added = rows_to_facts(added_rows, nous_id)?;
+
+        let removed_rows = self.run_read(queries::TEMPORAL_DIFF_REMOVED, params)?;
+        let removed = rows_to_facts(removed_rows, nous_id)?;
+
+        // Modified facts: those that appear in both added and removed (supersession chain).
+        // A fact ID in removed that has a superseded_by pointing to one in added is a modification.
+        let added_ids: std::collections::HashSet<&str> =
+            added.iter().map(|f| f.id.as_str()).collect();
+        let mut modified = Vec::new();
+        let mut pure_removed = Vec::new();
+
+        for old in &removed {
+            if let Some(ref new_id) = old.superseded_by {
+                if added_ids.contains(new_id.as_str()) {
+                    if let Some(new_fact) = added.iter().find(|f| f.id == *new_id) {
+                        modified.push((old.clone(), new_fact.clone()));
+                        continue;
+                    }
+                }
+            }
+            pure_removed.push(old.clone());
+        }
+
+        // Pure added: those not part of a modification pair
+        let modified_new_ids: std::collections::HashSet<&str> =
+            modified.iter().map(|(_, new)| new.id.as_str()).collect();
+        let pure_added: Vec<_> = added
+            .into_iter()
+            .filter(|f| !modified_new_ids.contains(f.id.as_str()))
+            .collect();
+
+        Ok(crate::knowledge::FactDiff {
+            added: pure_added,
+            modified,
+            removed: pure_removed,
+        })
+    }
+
+    /// Search for facts relevant to a query, as they existed at a specific time.
+    /// Filters hybrid search results through the temporal lens.
+    pub fn search_temporal(
+        &self,
+        q: &HybridQuery,
+        at_time: &str,
+    ) -> crate::error::Result<Vec<HybridResult>> {
+        let all_results = self.search_hybrid(q)?;
+
+        // Get the set of fact IDs valid at the given time
+        // We query with an empty nous_id filter to get all facts across all agents
+        let valid_facts = self.query_facts_at_time_all(at_time)?;
+        let valid_ids: std::collections::HashSet<&str> =
+            valid_facts.iter().map(|f| f.id.as_str()).collect();
+
+        let filtered: Vec<HybridResult> = all_results
+            .into_iter()
+            .filter(|r| valid_ids.contains(r.id.as_str()))
+            .collect();
+
+        Ok(filtered)
+    }
+
+    /// Async `query_facts_temporal` wrapper.
+    pub async fn query_facts_temporal_async(
+        self: &std::sync::Arc<Self>,
+        nous_id: String,
+        at_time: String,
+        filter: Option<String>,
+    ) -> crate::error::Result<Vec<crate::knowledge::Fact>> {
+        use snafu::ResultExt;
+        let this = std::sync::Arc::clone(self);
+        tokio::task::spawn_blocking(move || {
+            this.query_facts_temporal(&nous_id, &at_time, filter.as_deref())
+        })
+        .await
+        .context(crate::error::JoinSnafu)?
+    }
+
+    /// Async `query_facts_diff` wrapper.
+    pub async fn query_facts_diff_async(
+        self: &std::sync::Arc<Self>,
+        nous_id: String,
+        from_time: String,
+        to_time: String,
+    ) -> crate::error::Result<crate::knowledge::FactDiff> {
+        use snafu::ResultExt;
+        let this = std::sync::Arc::clone(self);
+        tokio::task::spawn_blocking(move || this.query_facts_diff(&nous_id, &from_time, &to_time))
+            .await
+            .context(crate::error::JoinSnafu)?
+    }
+
+    /// Async `search_temporal` wrapper.
+    pub async fn search_temporal_async(
+        self: &std::sync::Arc<Self>,
+        q: HybridQuery,
+        at_time: String,
+    ) -> crate::error::Result<Vec<HybridResult>> {
+        use snafu::ResultExt;
+        let this = std::sync::Arc::clone(self);
+        tokio::task::spawn_blocking(move || this.search_temporal(&q, &at_time))
+            .await
+            .context(crate::error::JoinSnafu)?
+    }
+
     /// Audit query: returns all facts regardless of forgotten/superseded/temporal state.
     pub fn audit_all_facts(
         &self,
@@ -1054,6 +1202,34 @@ impl KnowledgeStore {
     }
 
     // --- Internal helpers ---
+
+    /// Query all facts valid at a specific time, across all nous IDs.
+    /// Used internally by `search_temporal` for filtering.
+    fn query_facts_at_time_all(
+        &self,
+        at_time: &str,
+    ) -> crate::error::Result<Vec<crate::knowledge::Fact>> {
+        use crate::engine::DataValue;
+        use std::collections::BTreeMap;
+
+        let script = r"
+            ?[id, content, confidence, tier, recorded_at, nous_id, valid_from, valid_to,
+              superseded_by, source_session_id,
+              access_count, last_accessed_at, stability_hours, fact_type,
+              is_forgotten, forgotten_at, forget_reason] :=
+                *facts{id, valid_from, content, nous_id, confidence, tier, valid_to,
+                       superseded_by, source_session_id, recorded_at,
+                       access_count, last_accessed_at, stability_hours, fact_type,
+                       is_forgotten, forgotten_at, forget_reason},
+                is_forgotten == false,
+                valid_from <= $at_time,
+                valid_to > $at_time
+        ";
+        let mut params = BTreeMap::new();
+        params.insert("at_time".to_owned(), DataValue::Str(at_time.into()));
+        let rows = self.run_read(script, params)?;
+        rows_to_facts(rows, "")
+    }
 
     /// Read a single fact by its ID (all temporal records matching).
     /// Returns all fields; does not apply time/validity filters.
@@ -3125,5 +3301,321 @@ mod knowledge_store_tests {
             .find(|f| f.id == "f-access-async")
             .expect("found");
         assert_eq!(found.access_count, 1);
+    }
+
+    // --- Bi-temporal query tests ---
+
+    fn make_temporal_fact(
+        id: &str,
+        nous_id: &str,
+        content: &str,
+        valid_from: &str,
+        valid_to: &str,
+    ) -> Fact {
+        Fact {
+            id: id.to_owned(),
+            nous_id: nous_id.to_owned(),
+            content: content.to_owned(),
+            confidence: 0.9,
+            tier: EpistemicTier::Inferred,
+            valid_from: valid_from.to_owned(),
+            valid_to: valid_to.to_owned(),
+            superseded_by: None,
+            source_session_id: None,
+            recorded_at: "2026-03-01T00:00:00Z".to_owned(),
+            access_count: 0,
+            last_accessed_at: String::new(),
+            stability_hours: 720.0,
+            fact_type: String::new(),
+            is_forgotten: false,
+            forgotten_at: None,
+            forget_reason: None,
+        }
+    }
+
+    #[cfg(feature = "mneme-engine")]
+    #[test]
+    fn temporal_query_point_in_time() {
+        let store = make_store();
+        store
+            .insert_fact(&make_temporal_fact(
+                "t1",
+                "agent",
+                "Rust is fast",
+                "2026-01-01",
+                "2026-06-01",
+            ))
+            .expect("insert t1");
+        store
+            .insert_fact(&make_temporal_fact(
+                "t2",
+                "agent",
+                "Python is dynamic",
+                "2026-03-01",
+                "9999-12-31",
+            ))
+            .expect("insert t2");
+
+        let at_feb = store
+            .query_facts_temporal("agent", "2026-02-01", None)
+            .expect("query feb");
+        assert_eq!(at_feb.len(), 1);
+        assert_eq!(at_feb[0].id, "t1");
+
+        let at_apr = store
+            .query_facts_temporal("agent", "2026-04-01", None)
+            .expect("query apr");
+        assert_eq!(at_apr.len(), 2);
+
+        let at_jul = store
+            .query_facts_temporal("agent", "2026-07-01", None)
+            .expect("query jul");
+        assert_eq!(at_jul.len(), 1);
+        assert_eq!(at_jul[0].id, "t2");
+    }
+
+    #[cfg(feature = "mneme-engine")]
+    #[test]
+    fn temporal_query_before_any_facts_returns_empty() {
+        let store = make_store();
+        store
+            .insert_fact(&make_temporal_fact(
+                "t1",
+                "agent",
+                "fact",
+                "2026-06-01",
+                "9999-12-31",
+            ))
+            .expect("insert");
+
+        let results = store
+            .query_facts_temporal("agent", "2026-01-01", None)
+            .expect("query");
+        assert!(results.is_empty());
+    }
+
+    #[cfg(feature = "mneme-engine")]
+    #[test]
+    fn temporal_query_boundary_inclusion() {
+        let store = make_store();
+        store
+            .insert_fact(&make_temporal_fact(
+                "t1",
+                "agent",
+                "boundary fact",
+                "2026-03-01",
+                "2026-06-01",
+            ))
+            .expect("insert");
+
+        let at_start = store
+            .query_facts_temporal("agent", "2026-03-01", None)
+            .expect("at valid_from");
+        assert_eq!(at_start.len(), 1, "valid_from boundary is inclusive");
+
+        let at_end = store
+            .query_facts_temporal("agent", "2026-06-01", None)
+            .expect("at valid_to");
+        assert!(at_end.is_empty(), "valid_to boundary is exclusive");
+    }
+
+    #[cfg(feature = "mneme-engine")]
+    #[test]
+    fn temporal_query_with_content_filter() {
+        let store = make_store();
+        store
+            .insert_fact(&make_temporal_fact(
+                "t1",
+                "agent",
+                "Rust is fast",
+                "2026-01-01",
+                "9999-12-31",
+            ))
+            .expect("insert t1");
+        store
+            .insert_fact(&make_temporal_fact(
+                "t2",
+                "agent",
+                "Python is dynamic",
+                "2026-01-01",
+                "9999-12-31",
+            ))
+            .expect("insert t2");
+
+        let filtered = store
+            .query_facts_temporal("agent", "2026-03-01", Some("Rust"))
+            .expect("filtered query");
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].id, "t1");
+    }
+
+    #[cfg(feature = "mneme-engine")]
+    #[test]
+    fn temporal_diff_added_and_removed() {
+        let store = make_store();
+        store
+            .insert_fact(&make_temporal_fact(
+                "old",
+                "agent",
+                "old knowledge",
+                "2026-01-01",
+                "2026-03-01",
+            ))
+            .expect("insert old");
+        store
+            .insert_fact(&make_temporal_fact(
+                "new",
+                "agent",
+                "new knowledge",
+                "2026-02-15",
+                "9999-12-31",
+            ))
+            .expect("insert new");
+
+        let diff = store
+            .query_facts_diff("agent", "2026-02-01", "2026-04-01")
+            .expect("diff");
+
+        assert_eq!(diff.added.len(), 1, "one fact added in interval");
+        assert_eq!(diff.added[0].id, "new");
+        assert_eq!(diff.removed.len(), 1, "one fact removed in interval");
+        assert_eq!(diff.removed[0].id, "old");
+    }
+
+    #[cfg(feature = "mneme-engine")]
+    #[test]
+    fn temporal_diff_supersession_chain() {
+        let store = make_store();
+        let mut fact_a = make_temporal_fact("a", "agent", "version 1", "2026-01-01", "2026-03-01");
+        fact_a.superseded_by = Some("b".to_owned());
+        store.insert_fact(&fact_a).expect("insert a");
+
+        store
+            .insert_fact(&make_temporal_fact(
+                "b",
+                "agent",
+                "version 2",
+                "2026-03-01",
+                "9999-12-31",
+            ))
+            .expect("insert b");
+
+        let diff = store
+            .query_facts_diff("agent", "2026-02-01", "2026-04-01")
+            .expect("diff");
+
+        assert_eq!(diff.modified.len(), 1, "one modified pair");
+        assert_eq!(diff.modified[0].0.id, "a");
+        assert_eq!(diff.modified[0].1.id, "b");
+        assert!(diff.added.is_empty(), "superseded new is not in pure added");
+        assert!(
+            diff.removed.is_empty(),
+            "superseding old is not in pure removed"
+        );
+    }
+
+    #[cfg(feature = "mneme-engine")]
+    #[test]
+    fn temporal_query_isolates_nous_ids() {
+        let store = make_store();
+        store
+            .insert_fact(&make_temporal_fact(
+                "t1",
+                "alice",
+                "Alice knows Rust",
+                "2026-01-01",
+                "9999-12-31",
+            ))
+            .expect("insert alice");
+        store
+            .insert_fact(&make_temporal_fact(
+                "t2",
+                "bob",
+                "Bob knows Python",
+                "2026-01-01",
+                "9999-12-31",
+            ))
+            .expect("insert bob");
+
+        let alice_facts = store
+            .query_facts_temporal("alice", "2026-03-01", None)
+            .expect("alice query");
+        assert_eq!(alice_facts.len(), 1);
+        assert_eq!(alice_facts[0].content, "Alice knows Rust");
+
+        let bob_facts = store
+            .query_facts_temporal("bob", "2026-03-01", None)
+            .expect("bob query");
+        assert_eq!(bob_facts.len(), 1);
+        assert_eq!(bob_facts[0].content, "Bob knows Python");
+    }
+
+    #[cfg(feature = "mneme-engine")]
+    #[test]
+    fn temporal_query_excludes_forgotten_facts() {
+        let store = make_store();
+        store
+            .insert_fact(&make_temporal_fact(
+                "t1",
+                "agent",
+                "forgotten fact",
+                "2026-01-01",
+                "9999-12-31",
+            ))
+            .expect("insert");
+        store
+            .forget_fact("t1", crate::knowledge::ForgetReason::UserRequested)
+            .expect("forget");
+
+        let results = store
+            .query_facts_temporal("agent", "2026-03-01", None)
+            .expect("query");
+        assert!(results.is_empty(), "forgotten facts should be excluded");
+    }
+
+    #[cfg(feature = "mneme-engine")]
+    #[tokio::test]
+    async fn temporal_query_async_works() {
+        let store = make_store();
+        store
+            .insert_fact(&make_temporal_fact(
+                "t1",
+                "agent",
+                "async temporal",
+                "2026-01-01",
+                "9999-12-31",
+            ))
+            .expect("insert");
+
+        let results = store
+            .query_facts_temporal_async("agent".to_owned(), "2026-03-01".to_owned(), None)
+            .await
+            .expect("async query");
+        assert_eq!(results.len(), 1);
+    }
+
+    #[cfg(feature = "mneme-engine")]
+    #[tokio::test]
+    async fn temporal_diff_async_works() {
+        let store = make_store();
+        store
+            .insert_fact(&make_temporal_fact(
+                "t1",
+                "agent",
+                "diff async",
+                "2026-02-01",
+                "9999-12-31",
+            ))
+            .expect("insert");
+
+        let diff = store
+            .query_facts_diff_async(
+                "agent".to_owned(),
+                "2026-01-01".to_owned(),
+                "2026-03-01".to_owned(),
+            )
+            .await
+            .expect("async diff");
+        assert_eq!(diff.added.len(), 1);
     }
 }

--- a/crates/mneme/src/query.rs
+++ b/crates/mneme/src/query.rs
@@ -693,6 +693,111 @@ pub mod queries {
         :limit $limit
     ";
 
+    /// Bi-temporal point-in-time query with all fields. Params: `$nous_id`, `$at_time`.
+    /// Returns facts where `valid_from <= at_time` AND `valid_to > at_time` AND not forgotten.
+    pub fn temporal_facts() -> String {
+        use FactsField::*;
+        QueryBuilder::new()
+            .scan(Relation::Facts)
+            .select(&[
+                Id,
+                Content,
+                Confidence,
+                Tier,
+                RecordedAt,
+                NousId,
+                ValidFrom,
+                ValidTo,
+                SupersededBy,
+                SourceSessionId,
+                AccessCount,
+                LastAccessedAt,
+                StabilityHours,
+                FactType,
+                IsForgotten,
+                ForgottenAt,
+                ForgetReason,
+            ])
+            .bind(Id)
+            .bind(ValidFrom)
+            .bind(Content)
+            .bind(NousId)
+            .bind(Confidence)
+            .bind(Tier)
+            .bind(ValidTo)
+            .bind(SupersededBy)
+            .bind(SourceSessionId)
+            .bind(RecordedAt)
+            .bind(AccessCount)
+            .bind(LastAccessedAt)
+            .bind(StabilityHours)
+            .bind(FactType)
+            .bind(IsForgotten)
+            .bind(ForgottenAt)
+            .bind(ForgetReason)
+            .filter("nous_id = $nous_id")
+            .filter("is_forgotten == false")
+            .filter("valid_from <= $at_time")
+            .filter("valid_to > $at_time")
+            .order("-confidence")
+            .done()
+            .build_script()
+    }
+
+    /// Bi-temporal point-in-time query with optional content filter. Params: `$nous_id`, `$at_time`.
+    /// Same as `temporal_facts` but uses a raw script to support an optional `contains()` filter.
+    pub const TEMPORAL_FACTS_FILTERED: &str = r"
+        ?[id, content, confidence, tier, recorded_at, nous_id, valid_from, valid_to,
+          superseded_by, source_session_id,
+          access_count, last_accessed_at, stability_hours, fact_type,
+          is_forgotten, forgotten_at, forget_reason] :=
+            *facts{id, valid_from, content, nous_id, confidence, tier, valid_to,
+                   superseded_by, source_session_id, recorded_at,
+                   access_count, last_accessed_at, stability_hours, fact_type,
+                   is_forgotten, forgotten_at, forget_reason},
+            nous_id = $nous_id,
+            is_forgotten == false,
+            valid_from <= $at_time,
+            valid_to > $at_time,
+            str_includes(content, $filter)
+        :order -confidence
+    ";
+
+    /// Facts that changed (became valid or expired) in an interval.
+    /// Params: `$nous_id`, `$from_time`, `$to_time`.
+    /// Returns all facts where `valid_from` is in `(from_time, to_time]` OR
+    /// `valid_to` is in `(from_time, to_time]`.
+    pub const TEMPORAL_DIFF_ADDED: &str = r"
+        ?[id, content, confidence, tier, recorded_at, nous_id, valid_from, valid_to,
+          superseded_by, source_session_id,
+          access_count, last_accessed_at, stability_hours, fact_type,
+          is_forgotten, forgotten_at, forget_reason] :=
+            *facts{id, valid_from, content, nous_id, confidence, tier, valid_to,
+                   superseded_by, source_session_id, recorded_at,
+                   access_count, last_accessed_at, stability_hours, fact_type,
+                   is_forgotten, forgotten_at, forget_reason},
+            nous_id = $nous_id,
+            valid_from > $from_time,
+            valid_from <= $to_time
+    ";
+
+    /// Facts that expired (`valid_to` fell) in an interval.
+    /// Params: `$nous_id`, `$from_time`, `$to_time`.
+    pub const TEMPORAL_DIFF_REMOVED: &str = r"
+        ?[id, content, confidence, tier, recorded_at, nous_id, valid_from, valid_to,
+          superseded_by, source_session_id,
+          access_count, last_accessed_at, stability_hours, fact_type,
+          is_forgotten, forgotten_at, forget_reason] :=
+            *facts{id, valid_from, content, nous_id, confidence, tier, valid_to,
+                   superseded_by, source_session_id, recorded_at,
+                   access_count, last_accessed_at, stability_hours, fact_type,
+                   is_forgotten, forgotten_at, forget_reason},
+            nous_id = $nous_id,
+            valid_to > $from_time,
+            valid_to <= $to_time,
+            valid_to != '9999-12-31'
+    ";
+
     /// Audit query returning all facts regardless of forgotten/superseded/temporal state.
     /// Params: `$nous_id`, `$limit`.
     pub fn audit_all_facts() -> String {

--- a/crates/organon/src/builtins/memory.rs
+++ b/crates/organon/src/builtins/memory.rs
@@ -393,7 +393,180 @@ impl ToolExecutor for BlackboardExecutor {
 
 // --- Registration ---
 
-/// Register memory tool executors.
+// --- Datalog Query ---
+
+const MUTATION_KEYWORDS: &[&str] = &[":put", ":rm", ":replace", ":create", ":ensure"];
+const DEFAULT_ROW_LIMIT: usize = 100;
+const DEFAULT_TIMEOUT_SECS: f64 = 5.0;
+
+struct DatalogQueryExecutor;
+
+impl ToolExecutor for DatalogQueryExecutor {
+    fn execute<'a>(
+        &'a self,
+        input: &'a ToolInput,
+        ctx: &'a ToolContext,
+    ) -> Pin<Box<dyn Future<Output = Result<ToolResult>> + Send + 'a>> {
+        Box::pin(async {
+            let services = match require_services(ctx) {
+                Ok(s) => s,
+                Err(e) => return Ok(e),
+            };
+
+            let query = extract_str(&input.arguments, "query", &input.name)?;
+
+            let params = input.arguments.get("params").cloned();
+            let timeout = input
+                .arguments
+                .get("timeout_secs")
+                .and_then(serde_json::Value::as_f64);
+            let row_limit = input
+                .arguments
+                .get("row_limit")
+                .and_then(serde_json::Value::as_u64)
+                .map(|v| usize::try_from(v).unwrap_or(DEFAULT_ROW_LIMIT));
+
+            // Defense in depth: reject mutation keywords before sending to engine
+            let query_lower = query.to_lowercase();
+            for kw in MUTATION_KEYWORDS {
+                if query_lower.contains(kw) {
+                    return Ok(ToolResult::error(format!(
+                        "mutation keyword '{kw}' is not allowed in read-only queries"
+                    )));
+                }
+            }
+
+            let Some(knowledge) = services.knowledge.as_ref() else {
+                return Ok(ToolResult::error("knowledge store not configured"));
+            };
+
+            match knowledge
+                .datalog_query(
+                    query,
+                    params,
+                    Some(timeout.unwrap_or(DEFAULT_TIMEOUT_SECS)),
+                    Some(row_limit.unwrap_or(DEFAULT_ROW_LIMIT)),
+                )
+                .await
+            {
+                Ok(result) => {
+                    let table = format_as_markdown_table(&result);
+                    let mut output = table;
+                    if result.truncated {
+                        use std::fmt::Write;
+                        let _ = write!(
+                            output,
+                            "\n\n_Results truncated to {} rows._",
+                            row_limit.unwrap_or(DEFAULT_ROW_LIMIT)
+                        );
+                    }
+                    Ok(ToolResult::text(output))
+                }
+                Err(e) => Ok(ToolResult::error(e)),
+            }
+        })
+    }
+}
+
+fn format_as_markdown_table(result: &crate::types::DatalogResult) -> String {
+    if result.columns.is_empty() || result.rows.is_empty() {
+        return "No results.".to_owned();
+    }
+
+    let mut out = String::new();
+
+    // Header
+    out.push('|');
+    for col in &result.columns {
+        out.push(' ');
+        out.push_str(col);
+        out.push_str(" |");
+    }
+    out.push('\n');
+
+    // Separator
+    out.push('|');
+    for _ in &result.columns {
+        out.push_str(" --- |");
+    }
+    out.push('\n');
+
+    // Rows
+    for row in &result.rows {
+        out.push('|');
+        for cell in row {
+            out.push(' ');
+            match cell {
+                serde_json::Value::String(s) => out.push_str(s),
+                serde_json::Value::Null => out.push_str("null"),
+                other => out.push_str(&other.to_string()),
+            }
+            out.push_str(" |");
+        }
+        out.push('\n');
+    }
+
+    out
+}
+
+fn datalog_query_def() -> ToolDef {
+    ToolDef {
+        name: ToolName::new("datalog_query").expect("valid tool name"),
+        description: "Execute a read-only Datalog query against the knowledge graph. \
+            Returns tabular results. Use for advanced knowledge exploration, debugging \
+            recall quality, or querying graph structure. Cannot modify data."
+            .to_owned(),
+        extended_description: None,
+        input_schema: InputSchema {
+            properties: IndexMap::from([
+                (
+                    "query".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::String,
+                        description:
+                            "CozoScript/Datalog query. Must be read-only (no :put, :rm, :replace)."
+                                .to_owned(),
+                        enum_values: None,
+                        default: None,
+                    },
+                ),
+                (
+                    "params".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::Object,
+                        description:
+                            "Optional named parameters for the query (e.g., {\"nous_id\": \"syn\"})"
+                                .to_owned(),
+                        enum_values: None,
+                        default: None,
+                    },
+                ),
+                (
+                    "timeout_secs".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::Number,
+                        description: "Query timeout in seconds (default: 5)".to_owned(),
+                        enum_values: None,
+                        default: Some(serde_json::json!(5)),
+                    },
+                ),
+                (
+                    "row_limit".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::Integer,
+                        description: "Maximum number of result rows (default: 100)".to_owned(),
+                        enum_values: None,
+                        default: Some(serde_json::json!(100)),
+                    },
+                ),
+            ]),
+            required: vec!["query".to_owned()],
+        },
+        category: ToolCategory::Memory,
+        auto_activate: false,
+    }
+}
+
 pub fn register(registry: &mut ToolRegistry) -> Result<()> {
     registry.register(memory_search_def(), Box::new(MemorySearchExecutor))?;
     registry.register(memory_correct_def(), Box::new(MemoryCorrectExecutor))?;
@@ -402,6 +575,7 @@ pub fn register(registry: &mut ToolRegistry) -> Result<()> {
     registry.register(memory_audit_def(), Box::new(MemoryAuditExecutor))?;
     registry.register(note_def(), Box::new(NoteExecutor))?;
     registry.register(blackboard_def(), Box::new(BlackboardExecutor))?;
+    registry.register(datalog_query_def(), Box::new(DatalogQueryExecutor))?;
     Ok(())
 }
 
@@ -850,7 +1024,7 @@ mod tests {
     async fn register_memory_tools() {
         let mut reg = ToolRegistry::new();
         super::register(&mut reg).expect("register");
-        assert_eq!(reg.definitions().len(), 7);
+        assert_eq!(reg.definitions().len(), 8);
     }
 
     #[tokio::test]
@@ -1230,5 +1404,142 @@ mod tests {
         let name = ToolName::new("memory_forget").expect("valid");
         let def = reg.get_def(&name).expect("found");
         assert!(!def.auto_activate);
+    }
+
+    // --- Datalog query tool tests ---
+
+    #[tokio::test]
+    async fn datalog_query_rejects_mutation_keywords() {
+        let mut reg = ToolRegistry::new();
+        super::register(&mut reg).expect("register");
+        let note_store = Arc::new(MockNoteStore::new());
+        let bb_store = Arc::new(MockBlackboardStore::new());
+        let ctx = ctx_with_services(note_store, bb_store);
+
+        let mutations = vec![
+            (":put facts {}", ":put"),
+            (":rm facts {}", ":rm"),
+            (":replace facts {}", ":replace"),
+            (":create facts {}", ":create"),
+            (":ensure facts {}", ":ensure"),
+        ];
+
+        for (query, keyword) in mutations {
+            let input = ToolInput {
+                name: ToolName::new("datalog_query").expect("valid"),
+                tool_use_id: "tu_1".to_owned(),
+                arguments: serde_json::json!({"query": query}),
+            };
+            let result = reg.execute(&input, &ctx).await.expect("execute");
+            assert!(
+                result.is_error,
+                "query containing '{keyword}' should be rejected"
+            );
+            assert!(
+                result.content.text_summary().contains("mutation keyword"),
+                "error should mention mutation keyword for '{keyword}': {}",
+                result.content.text_summary()
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn datalog_query_no_knowledge_returns_error() {
+        let mut reg = ToolRegistry::new();
+        super::register(&mut reg).expect("register");
+        let note_store = Arc::new(MockNoteStore::new());
+        let bb_store = Arc::new(MockBlackboardStore::new());
+        let ctx = ctx_with_services(note_store, bb_store);
+
+        let input = ToolInput {
+            name: ToolName::new("datalog_query").expect("valid"),
+            tool_use_id: "tu_1".to_owned(),
+            arguments: serde_json::json!({"query": "?[x] := x = 42"}),
+        };
+        let result = reg.execute(&input, &ctx).await.expect("execute");
+        assert!(result.is_error);
+        assert!(
+            result
+                .content
+                .text_summary()
+                .contains("knowledge store not configured")
+        );
+    }
+
+    #[tokio::test]
+    async fn datalog_query_not_auto_activated() {
+        let mut reg = ToolRegistry::new();
+        super::register(&mut reg).expect("register");
+        let name = ToolName::new("datalog_query").expect("valid");
+        let def = reg.get_def(&name).expect("found");
+        assert!(!def.auto_activate);
+    }
+
+    #[tokio::test]
+    async fn datalog_query_rejects_case_insensitive_mutations() {
+        let mut reg = ToolRegistry::new();
+        super::register(&mut reg).expect("register");
+        let note_store = Arc::new(MockNoteStore::new());
+        let bb_store = Arc::new(MockBlackboardStore::new());
+        let ctx = ctx_with_services(note_store, bb_store);
+
+        let input = ToolInput {
+            name: ToolName::new("datalog_query").expect("valid"),
+            tool_use_id: "tu_1".to_owned(),
+            arguments: serde_json::json!({"query": ":PUT facts {}"}),
+        };
+        let result = reg.execute(&input, &ctx).await.expect("execute");
+        assert!(result.is_error, "uppercase mutation should be rejected");
+    }
+
+    #[test]
+    fn markdown_table_empty_result() {
+        let result = crate::types::DatalogResult {
+            columns: vec![],
+            rows: vec![],
+            truncated: false,
+        };
+        let table = super::format_as_markdown_table(&result);
+        assert_eq!(table, "No results.");
+    }
+
+    #[test]
+    fn markdown_table_formats_correctly() {
+        let result = crate::types::DatalogResult {
+            columns: vec!["id".to_owned(), "name".to_owned()],
+            rows: vec![
+                vec![
+                    serde_json::Value::String("1".to_owned()),
+                    serde_json::Value::String("alice".to_owned()),
+                ],
+                vec![
+                    serde_json::Value::Number(serde_json::Number::from(2)),
+                    serde_json::Value::Null,
+                ],
+            ],
+            truncated: false,
+        };
+        let table = super::format_as_markdown_table(&result);
+        assert!(table.contains("| id | name |"));
+        assert!(table.contains("| --- | --- |"));
+        assert!(table.contains("| 1 | alice |"));
+        assert!(table.contains("| 2 | null |"));
+    }
+
+    #[tokio::test]
+    async fn datalog_query_missing_query_param() {
+        let mut reg = ToolRegistry::new();
+        super::register(&mut reg).expect("register");
+        let note_store = Arc::new(MockNoteStore::new());
+        let bb_store = Arc::new(MockBlackboardStore::new());
+        let ctx = ctx_with_services(note_store, bb_store);
+
+        let input = ToolInput {
+            name: ToolName::new("datalog_query").expect("valid"),
+            tool_use_id: "tu_1".to_owned(),
+            arguments: serde_json::json!({}),
+        };
+        let result = reg.execute(&input, &ctx).await;
+        assert!(result.is_err(), "missing required param should error");
     }
 }

--- a/crates/organon/src/types.rs
+++ b/crates/organon/src/types.rs
@@ -407,6 +407,21 @@ pub trait KnowledgeSearchService: Send + Sync {
         &self,
         fact_id: &str,
     ) -> Pin<Box<dyn Future<Output = Result<(), String>> + Send + '_>>;
+
+    fn datalog_query(
+        &self,
+        query: &str,
+        params: Option<serde_json::Value>,
+        timeout_secs: Option<f64>,
+        row_limit: Option<usize>,
+    ) -> Pin<Box<dyn Future<Output = Result<DatalogResult, String>> + Send + '_>>;
+}
+
+/// Result from a read-only Datalog query.
+pub struct DatalogResult {
+    pub columns: Vec<String>,
+    pub rows: Vec<Vec<serde_json::Value>>,
+    pub truncated: bool,
 }
 
 /// Service locator for tool executors needing access to runtime services.


### PR DESCRIPTION
## Summary

- **Bi-temporal query API**: `query_facts_temporal` (point-in-time), `query_facts_diff` (added/modified/removed between timestamps), `search_temporal` (hybrid search with temporal filter)
- **`datalog_query` tool**: Read-only Datalog queries against the knowledge graph with mutation keyword rejection, configurable timeout (default 5s), row limit (default 100), and markdown table output formatting
- **17 new tests**: 10 bi-temporal tests (point-in-time, boundary, diff, supersession, isolation, forgotten, async) + 7 datalog tool tests (mutation rejection, case-insensitive, missing params, markdown formatting)

## Test plan

- [x] `cargo fmt --all --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes (zero warnings)
- [x] `cargo test -p aletheia-mneme --features mneme-engine` — 509 tests pass
- [x] `cargo test -p aletheia-organon` — 124 tests pass (4 pre-existing filesystem test failures on main)
- [x] `cargo check --workspace` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)