### PR TITLE
chore: document justified .expect() calls across compliant crates

### DIFF
--- a/crates/agora/src/listener.rs
+++ b/crates/agora/src/listener.rs
@@ -80,6 +80,10 @@ impl ChannelListener {
     /// The background polling handles are kept alive — they stop
     /// naturally when the receiver is dropped (closed channel).
     pub fn into_receiver(mut self) -> mpsc::Receiver<InboundMessage> {
+        #[expect(
+            clippy::expect_used,
+            reason = "rx is None only if into_receiver was already called; calling it twice is a programming error and panic is appropriate"
+        )]
         let rx = self
             .rx
             .take()

--- a/crates/agora/src/semeion/client.rs
+++ b/crates/agora/src/semeion/client.rs
@@ -139,6 +139,10 @@ impl SignalClient {
             }
         }
 
+        #[expect(
+            clippy::expect_used,
+            reason = "loop range 0..=backoffs.len() always executes at least one iteration, so last_err is always Some here"
+        )]
         Err(last_err.expect("at least one attempt was made"))
     }
 

--- a/crates/agora/src/semeion/mod.rs
+++ b/crates/agora/src/semeion/mod.rs
@@ -121,6 +121,10 @@ impl SignalProvider {
             let tx = tx.clone();
             let account_id = account_id.clone();
             let signal_client = signal_client.clone();
+            #[expect(
+                clippy::expect_used,
+                reason = "account_states and clients share the same key set; state is always inserted alongside the client in add_account"
+            )]
             let state = self
                 .account_states
                 .get(&account_id)

--- a/crates/hermeneus/src/metrics.rs
+++ b/crates/hermeneus/src/metrics.rs
@@ -5,6 +5,10 @@ use std::sync::LazyLock;
 use prometheus::{CounterVec, IntCounterVec, Opts, register_counter_vec, register_int_counter_vec};
 
 static LLM_TOKENS_TOTAL: LazyLock<IntCounterVec> = LazyLock::new(|| {
+    #[expect(
+        clippy::expect_used,
+        reason = "metric registration fails only on name/label collision, a startup-time programming error that must not be silently ignored"
+    )]
     register_int_counter_vec!(
         Opts::new("aletheia_llm_tokens_total", "Total LLM tokens consumed"),
         &["provider", "direction"]
@@ -13,6 +17,10 @@ static LLM_TOKENS_TOTAL: LazyLock<IntCounterVec> = LazyLock::new(|| {
 });
 
 static LLM_COST_TOTAL: LazyLock<CounterVec> = LazyLock::new(|| {
+    #[expect(
+        clippy::expect_used,
+        reason = "metric registration fails only on name/label collision, a startup-time programming error that must not be silently ignored"
+    )]
     register_counter_vec!(
         Opts::new("aletheia_llm_cost_total", "Total LLM cost in USD"),
         &["provider"]
@@ -21,6 +29,10 @@ static LLM_COST_TOTAL: LazyLock<CounterVec> = LazyLock::new(|| {
 });
 
 static LLM_REQUESTS_TOTAL: LazyLock<IntCounterVec> = LazyLock::new(|| {
+    #[expect(
+        clippy::expect_used,
+        reason = "metric registration fails only on name/label collision, a startup-time programming error that must not be silently ignored"
+    )]
     register_int_counter_vec!(
         Opts::new("aletheia_llm_requests_total", "Total LLM API requests"),
         &["provider", "status"]

--- a/crates/mneme/src/export.rs
+++ b/crates/mneme/src/export.rs
@@ -176,7 +176,10 @@ fn query_all_entities(
         let aliases = if aliases_str.is_empty() {
             vec![]
         } else {
-            aliases_str.split(',').map(|s| s.trim().to_owned()).collect()
+            aliases_str
+                .split(',')
+                .map(|s| s.trim().to_owned())
+                .collect()
         };
         let created_at = row[4].get_str().unwrap_or_default().to_owned();
         let updated_at = row[5].get_str().unwrap_or_default().to_owned();

--- a/crates/mneme/src/knowledge_store.rs
+++ b/crates/mneme/src/knowledge_store.rs
@@ -720,8 +720,14 @@ impl KnowledgeStore {
     ///
     /// Takes the top entity IDs from existing results, queries their neighborhoods,
     /// and returns related facts as additional results.
-    #[expect(clippy::cast_precision_loss, reason = "rank indices fit in f64 mantissa")]
-    #[expect(clippy::cast_possible_wrap, reason = "rank indices are small positive values")]
+    #[expect(
+        clippy::cast_precision_loss,
+        reason = "rank indices fit in f64 mantissa"
+    )]
+    #[expect(
+        clippy::cast_possible_wrap,
+        reason = "rank indices are small positive values"
+    )]
     fn expand_via_graph(
         &self,
         existing: &[HybridResult],

--- a/crates/mneme/src/query_rewrite.rs
+++ b/crates/mneme/src/query_rewrite.rs
@@ -179,8 +179,8 @@ fn parse_rewrite_response(response: &str) -> Result<Vec<String>, RewriteError> {
     let trimmed = strip_code_fences(response);
 
     // Try parsing as a JSON array of strings
-    let variants: Vec<String> = serde_json::from_str(trimmed)
-        .map_err(|e| RewriteError::ParseResponse(e.to_string()))?;
+    let variants: Vec<String> =
+        serde_json::from_str(trimmed).map_err(|e| RewriteError::ParseResponse(e.to_string()))?;
 
     // Filter out empty strings
     let variants: Vec<String> = variants.into_iter().filter(|v| !v.is_empty()).collect();
@@ -361,7 +361,11 @@ mod tests {
         // Original + 3 variants = 4
         assert_eq!(result.variants.len(), 4);
         assert_eq!(result.variants[0], "What's Cody's truck?");
-        assert!(result.variants.contains(&"Cummins diesel specifications".to_owned()));
+        assert!(
+            result
+                .variants
+                .contains(&"Cummins diesel specifications".to_owned())
+        );
     }
 
     #[test]
@@ -411,9 +415,7 @@ mod tests {
     #[test]
     fn rewrite_with_context() {
         let rewriter = QueryRewriter::with_defaults();
-        let provider = MockProvider::with_response(
-            r#"["Cody truck", "vehicle maintenance"]"#,
-        );
+        let provider = MockProvider::with_response(r#"["Cody truck", "vehicle maintenance"]"#);
 
         let result = rewriter.rewrite(
             "What's the truck?",
@@ -432,9 +434,8 @@ mod tests {
             include_original: true,
         };
         let rewriter = QueryRewriter::new(config);
-        let provider = MockProvider::with_response(
-            r#"["variant 1", "variant 2", "variant 3", "variant 4"]"#,
-        );
+        let provider =
+            MockProvider::with_response(r#"["variant 1", "variant 2", "variant 3", "variant 4"]"#);
 
         let result = rewriter.rewrite("query", None, &provider);
 
@@ -448,9 +449,7 @@ mod tests {
     #[test]
     fn rewrite_strips_code_fences() {
         let rewriter = QueryRewriter::with_defaults();
-        let provider = MockProvider::with_response(
-            "```json\n[\"variant 1\", \"variant 2\"]\n```",
-        );
+        let provider = MockProvider::with_response("```json\n[\"variant 1\", \"variant 2\"]\n```");
 
         let result = rewriter.rewrite("query", None, &provider);
 
@@ -464,9 +463,7 @@ mod tests {
             include_original: false,
         };
         let rewriter = QueryRewriter::new(config);
-        let provider = MockProvider::with_response(
-            r#"["variant 1", "variant 2"]"#,
-        );
+        let provider = MockProvider::with_response(r#"["variant 1", "variant 2"]"#);
 
         let result = rewriter.rewrite("original query", None, &provider);
 
@@ -477,9 +474,7 @@ mod tests {
     #[test]
     fn rewrite_filters_empty_strings() {
         let rewriter = QueryRewriter::with_defaults();
-        let provider = MockProvider::with_response(
-            r#"["", "variant 1", "", "variant 2"]"#,
-        );
+        let provider = MockProvider::with_response(r#"["", "variant 1", "", "variant 2"]"#);
 
         let result = rewriter.rewrite("query", None, &provider);
 
@@ -508,8 +503,7 @@ mod tests {
 
     #[test]
     fn parse_response_with_fences() {
-        let variants =
-            parse_rewrite_response("```json\n[\"a\", \"b\"]\n```").unwrap();
+        let variants = parse_rewrite_response("```json\n[\"a\", \"b\"]\n```").unwrap();
         assert_eq!(variants, vec!["a", "b"]);
     }
 
@@ -557,12 +551,24 @@ mod tests {
     #[test]
     fn rrf_merge_deduplicates_by_id() {
         let q1 = vec![
-            TestResult { doc_id: "f1".to_owned(), score: 0.0 },
-            TestResult { doc_id: "f2".to_owned(), score: 0.0 },
+            TestResult {
+                doc_id: "f1".to_owned(),
+                score: 0.0,
+            },
+            TestResult {
+                doc_id: "f2".to_owned(),
+                score: 0.0,
+            },
         ];
         let q2 = vec![
-            TestResult { doc_id: "f2".to_owned(), score: 0.0 },
-            TestResult { doc_id: "f3".to_owned(), score: 0.0 },
+            TestResult {
+                doc_id: "f2".to_owned(),
+                score: 0.0,
+            },
+            TestResult {
+                doc_id: "f3".to_owned(),
+                score: 0.0,
+            },
         ];
 
         let merged = rrf_merge(&[q1, q2], 60.0);
@@ -578,12 +584,24 @@ mod tests {
     #[test]
     fn rrf_merge_boosts_duplicate_results() {
         let q1 = vec![
-            TestResult { doc_id: "f1".to_owned(), score: 0.0 },
-            TestResult { doc_id: "f2".to_owned(), score: 0.0 },
+            TestResult {
+                doc_id: "f1".to_owned(),
+                score: 0.0,
+            },
+            TestResult {
+                doc_id: "f2".to_owned(),
+                score: 0.0,
+            },
         ];
         let q2 = vec![
-            TestResult { doc_id: "f1".to_owned(), score: 0.0 },
-            TestResult { doc_id: "f3".to_owned(), score: 0.0 },
+            TestResult {
+                doc_id: "f1".to_owned(),
+                score: 0.0,
+            },
+            TestResult {
+                doc_id: "f3".to_owned(),
+                score: 0.0,
+            },
         ];
 
         let merged = rrf_merge(&[q1, q2], 60.0);
@@ -602,8 +620,14 @@ mod tests {
     #[test]
     fn rrf_merge_single_query() {
         let q1 = vec![
-            TestResult { doc_id: "f1".to_owned(), score: 0.0 },
-            TestResult { doc_id: "f2".to_owned(), score: 0.0 },
+            TestResult {
+                doc_id: "f1".to_owned(),
+                score: 0.0,
+            },
+            TestResult {
+                doc_id: "f2".to_owned(),
+                score: 0.0,
+            },
         ];
 
         let merged = rrf_merge(&[q1], 60.0);
@@ -616,13 +640,28 @@ mod tests {
     #[test]
     fn rrf_merge_preserves_order_by_score() {
         let q1 = vec![
-            TestResult { doc_id: "f1".to_owned(), score: 0.0 },
-            TestResult { doc_id: "f2".to_owned(), score: 0.0 },
-            TestResult { doc_id: "f3".to_owned(), score: 0.0 },
+            TestResult {
+                doc_id: "f1".to_owned(),
+                score: 0.0,
+            },
+            TestResult {
+                doc_id: "f2".to_owned(),
+                score: 0.0,
+            },
+            TestResult {
+                doc_id: "f3".to_owned(),
+                score: 0.0,
+            },
         ];
         let q2 = vec![
-            TestResult { doc_id: "f3".to_owned(), score: 0.0 },
-            TestResult { doc_id: "f1".to_owned(), score: 0.0 },
+            TestResult {
+                doc_id: "f3".to_owned(),
+                score: 0.0,
+            },
+            TestResult {
+                doc_id: "f1".to_owned(),
+                score: 0.0,
+            },
         ];
 
         let merged = rrf_merge(&[q1, q2], 60.0);

--- a/crates/thesauros/src/loader.rs
+++ b/crates/thesauros/src/loader.rs
@@ -81,6 +81,13 @@ impl LoadedPack {
 ///
 /// Reads manifests from each path, resolves context files, and returns loaded packs.
 /// Invalid or missing packs emit warnings and are skipped (graceful degradation).
+///
+/// # Blocking I/O
+///
+/// This function performs synchronous file I/O and is intended to be called once
+/// at startup, before the async runtime begins serving requests. If called from
+/// within an async context during normal operation, wrap in
+/// `tokio::task::spawn_blocking`.
 pub fn load_packs(paths: &[PathBuf]) -> Vec<LoadedPack> {
     let mut packs = Vec::with_capacity(paths.len());
 


### PR DESCRIPTION
## Summary

- **hermeneus/metrics.rs**: add `#[expect(clippy::expect_used)]` to three `LazyLock` metric statics — registration failure is a startup-time programming error; panic is correct and expected
- **agora/listener.rs**: annotate `into_receiver` — `rx` is `None` only if called twice, which is a programming error
- **agora/semeion/mod.rs**: annotate `account_states` lookup — key invariant enforced by `add_account`; `None` is impossible in correct usage
- **agora/semeion/client.rs**: annotate retry-loop tail — loop range `0..=backoffs.len()` always executes at least one iteration, so `last_err` is always `Some`
- **thesauros/loader.rs**: add `# Blocking I/O` doc note to `load_packs` documenting that it performs synchronous I/O and is intended for startup use
- Apply `cargo fmt` to pre-existing formatting drift in `mneme`

## Test plan

- [x] `cargo fmt --all --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes (zero warnings)
- [x] `cargo test -p aletheia-hermeneus` passes (112 tests)

Closes #567