### PR TITLE
feat(hermeneus): message-level cache_control for prompt caching

### DIFF
--- a/crates/aletheia/src/main.rs
+++ b/crates/aletheia/src/main.rs
@@ -742,6 +742,7 @@ async fn serve(cli: Cli) -> Result<()> {
                 loop_detection_threshold: 3,
                 domains,
                 server_tools: Vec::new(),
+                cache_enabled: resolved.cache_enabled,
             };
             nous_manager
                 .spawn(

--- a/crates/hermeneus/src/anthropic/client.rs
+++ b/crates/hermeneus/src/anthropic/client.rs
@@ -273,6 +273,11 @@ impl AnthropicProvider {
                         ),
                         true,
                     );
+                    crate::metrics::record_cache_tokens(
+                        "anthropic",
+                        resp.usage.cache_read_tokens,
+                        resp.usage.cache_write_tokens,
+                    );
                     return Ok(resp);
                 }
                 Err(e) => {
@@ -499,6 +504,11 @@ impl AnthropicProvider {
                             resp.usage.output_tokens,
                         ),
                         true,
+                    );
+                    crate::metrics::record_cache_tokens(
+                        "anthropic",
+                        resp.usage.cache_read_tokens,
+                        resp.usage.cache_write_tokens,
                     );
                 }
                 return parsed;

--- a/crates/hermeneus/src/anthropic/wire.rs
+++ b/crates/hermeneus/src/anthropic/wire.rs
@@ -7,6 +7,8 @@ use crate::types::{
     ThinkingConfig, ToolChoice, Usage,
 };
 
+const MAX_TURN_CACHE_BREAKPOINTS: usize = 2;
+
 // ---------------------------------------------------------------------------
 // Request
 // ---------------------------------------------------------------------------
@@ -39,7 +41,22 @@ pub(crate) struct WireRequest<'a> {
 #[derive(Debug, Serialize)]
 pub(crate) struct WireMessage<'a> {
     pub role: &'a str,
-    pub content: &'a Content,
+    pub content: WireContent<'a>,
+}
+
+#[derive(Debug)]
+pub(crate) enum WireContent<'a> {
+    Borrowed(&'a Content),
+    WithCacheControl(serde_json::Value),
+}
+
+impl serde::Serialize for WireContent<'_> {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        match self {
+            Self::Borrowed(content) => content.serialize(serializer),
+            Self::WithCacheControl(value) => value.serialize(serializer),
+        }
+    }
 }
 
 #[derive(Debug, Serialize)]
@@ -158,6 +175,10 @@ pub(crate) struct WireErrorDetail {
 // ---------------------------------------------------------------------------
 
 impl<'a> WireRequest<'a> {
+    #[expect(
+        clippy::too_many_lines,
+        reason = "request construction with caching logic"
+    )]
     pub(crate) fn from_request(req: &'a CompletionRequest, stream: Option<bool>) -> Self {
         // Extract system prompt from messages (Anthropic wants it as a top-level field).
         let system_text = req.system.clone().or_else(|| {
@@ -191,13 +212,31 @@ impl<'a> WireRequest<'a> {
             }
         });
 
-        let messages: Vec<WireMessage<'a>> = req
+        let non_system: Vec<&crate::types::Message> = req
             .messages
             .iter()
             .filter(|m| m.role != Role::System)
-            .map(|m| WireMessage {
-                role: m.role.as_str(),
-                content: &m.content,
+            .collect();
+
+        let cached_indices = if req.cache_turns {
+            compute_turn_cache_indices(&non_system)
+        } else {
+            Vec::new()
+        };
+
+        let messages: Vec<WireMessage<'a>> = non_system
+            .iter()
+            .enumerate()
+            .map(|(i, m)| {
+                let content = if cached_indices.contains(&i) {
+                    WireContent::WithCacheControl(content_with_cache_control(&m.content))
+                } else {
+                    WireContent::Borrowed(&m.content)
+                };
+                WireMessage {
+                    role: m.role.as_str(),
+                    content,
+                }
             })
             .collect();
 
@@ -321,6 +360,62 @@ impl WireUsage {
             output_tokens: self.output_tokens,
             cache_write_tokens: self.cache_creation_input_tokens,
             cache_read_tokens: self.cache_read_input_tokens,
+        }
+    }
+}
+
+/// Determine which message indices should receive `cache_control` breakpoints.
+///
+/// Strategy: mark the last user message before the current (final) message,
+/// plus one earlier user message if available. This creates up to
+/// `MAX_TURN_CACHE_BREAKPOINTS` breakpoints so the API can cache the
+/// conversation prefix on subsequent turns.
+fn compute_turn_cache_indices(messages: &[&crate::types::Message]) -> Vec<usize> {
+    if messages.len() < 2 {
+        return Vec::new();
+    }
+
+    let last_idx = messages.len() - 1;
+    let mut breakpoints = Vec::new();
+
+    for i in (0..last_idx).rev() {
+        if messages[i].role == Role::User {
+            breakpoints.push(i);
+            if breakpoints.len() >= MAX_TURN_CACHE_BREAKPOINTS {
+                break;
+            }
+        }
+    }
+
+    breakpoints
+}
+
+/// Transform content to include `cache_control: ephemeral` on the last block.
+///
+/// For `Content::Text`, wraps as a single-element block array.
+/// For `Content::Blocks`, clones and injects `cache_control` on the final block.
+fn content_with_cache_control(content: &Content) -> serde_json::Value {
+    let cc = serde_json::json!({"type": "ephemeral"});
+
+    match content {
+        Content::Text(text) => {
+            serde_json::json!([{
+                "type": "text",
+                "text": text,
+                "cache_control": cc
+            }])
+        }
+        Content::Blocks(blocks) => {
+            let mut arr: Vec<serde_json::Value> = blocks
+                .iter()
+                .map(|b| serde_json::to_value(b).unwrap_or_default())
+                .collect();
+            if let Some(last) = arr.last_mut() {
+                if let Some(obj) = last.as_object_mut() {
+                    obj.insert("cache_control".to_owned(), cc);
+                }
+            }
+            serde_json::Value::Array(arr)
         }
     }
 }
@@ -996,5 +1091,461 @@ mod tests {
         let json = serde_json::to_value(&wire).unwrap();
         assert!(json["system"].is_string());
         assert_eq!(json["system"], "test");
+    }
+
+    // -----------------------------------------------------------------------
+    // Turn-level cache_control tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn cache_turns_marks_text_content_as_blocks() {
+        let req = CompletionRequest {
+            model: "claude-opus-4-20250514".to_owned(),
+            messages: vec![
+                Message {
+                    role: Role::User,
+                    content: Content::Text("first".to_owned()),
+                },
+                Message {
+                    role: Role::Assistant,
+                    content: Content::Text("response".to_owned()),
+                },
+                Message {
+                    role: Role::User,
+                    content: Content::Text("second".to_owned()),
+                },
+            ],
+            max_tokens: 1024,
+            cache_turns: true,
+            ..Default::default()
+        };
+        let wire = WireRequest::from_request(&req, None);
+        let json = serde_json::to_value(&wire).unwrap();
+        let msgs = json["messages"].as_array().unwrap();
+        // First user message (index 0) should have cache_control
+        let first_content = &msgs[0]["content"];
+        assert!(first_content.is_array(), "text should be wrapped as blocks");
+        assert_eq!(first_content[0]["cache_control"]["type"], "ephemeral");
+        // Last message (current turn) should NOT have cache_control
+        let last_content = &msgs[2]["content"];
+        if last_content.is_string() {
+            // plain text, no cache_control — correct
+        } else {
+            assert!(
+                last_content[0].get("cache_control").is_none(),
+                "current turn should not be cached"
+            );
+        }
+    }
+
+    #[test]
+    fn cache_turns_disabled_leaves_content_unchanged() {
+        let req = CompletionRequest {
+            model: "claude-opus-4-20250514".to_owned(),
+            messages: vec![
+                Message {
+                    role: Role::User,
+                    content: Content::Text("first".to_owned()),
+                },
+                Message {
+                    role: Role::Assistant,
+                    content: Content::Text("response".to_owned()),
+                },
+                Message {
+                    role: Role::User,
+                    content: Content::Text("second".to_owned()),
+                },
+            ],
+            max_tokens: 1024,
+            cache_turns: false,
+            ..Default::default()
+        };
+        let wire = WireRequest::from_request(&req, None);
+        let json = serde_json::to_value(&wire).unwrap();
+        let msgs = json["messages"].as_array().unwrap();
+        // All content should be plain text strings (no cache_control injection)
+        for msg in msgs {
+            assert!(
+                msg["content"].is_string(),
+                "content should be plain text when cache_turns is disabled"
+            );
+        }
+    }
+
+    #[test]
+    fn cache_turns_single_message_no_breakpoints() {
+        let req = CompletionRequest {
+            model: "claude-opus-4-20250514".to_owned(),
+            messages: vec![Message {
+                role: Role::User,
+                content: Content::Text("only one".to_owned()),
+            }],
+            max_tokens: 1024,
+            cache_turns: true,
+            ..Default::default()
+        };
+        let wire = WireRequest::from_request(&req, None);
+        let json = serde_json::to_value(&wire).unwrap();
+        let msgs = json["messages"].as_array().unwrap();
+        assert!(
+            msgs[0]["content"].is_string(),
+            "single message should not get cache_control"
+        );
+    }
+
+    #[test]
+    fn cache_turns_multi_turn_marks_recent_user_messages() {
+        let req = CompletionRequest {
+            model: "claude-opus-4-20250514".to_owned(),
+            messages: vec![
+                Message {
+                    role: Role::User,
+                    content: Content::Text("turn 1".to_owned()),
+                },
+                Message {
+                    role: Role::Assistant,
+                    content: Content::Text("reply 1".to_owned()),
+                },
+                Message {
+                    role: Role::User,
+                    content: Content::Text("turn 2".to_owned()),
+                },
+                Message {
+                    role: Role::Assistant,
+                    content: Content::Text("reply 2".to_owned()),
+                },
+                Message {
+                    role: Role::User,
+                    content: Content::Text("turn 3".to_owned()),
+                },
+                Message {
+                    role: Role::Assistant,
+                    content: Content::Text("reply 3".to_owned()),
+                },
+                Message {
+                    role: Role::User,
+                    content: Content::Text("turn 4 (current)".to_owned()),
+                },
+            ],
+            max_tokens: 1024,
+            cache_turns: true,
+            ..Default::default()
+        };
+        let wire = WireRequest::from_request(&req, None);
+        let json = serde_json::to_value(&wire).unwrap();
+        let msgs = json["messages"].as_array().unwrap();
+
+        // Should have exactly MAX_TURN_CACHE_BREAKPOINTS cached user messages
+        let cached_count = msgs
+            .iter()
+            .filter(|m| {
+                let c = &m["content"];
+                c.is_array()
+                    && c.as_array().is_some_and(|arr| {
+                        arr.last().is_some_and(|b| b.get("cache_control").is_some())
+                    })
+            })
+            .count();
+        assert_eq!(cached_count, MAX_TURN_CACHE_BREAKPOINTS);
+
+        // Current turn (last message) should NOT be cached
+        let last = msgs.last().unwrap();
+        assert!(
+            last["content"].is_string(),
+            "current turn should not have cache_control"
+        );
+    }
+
+    #[test]
+    fn cache_turns_with_block_content() {
+        let req = CompletionRequest {
+            model: "claude-opus-4-20250514".to_owned(),
+            messages: vec![
+                Message {
+                    role: Role::User,
+                    content: Content::Blocks(vec![
+                        ContentBlock::Text {
+                            text: "block one".to_owned(),
+                            citations: None,
+                        },
+                        ContentBlock::Text {
+                            text: "block two".to_owned(),
+                            citations: None,
+                        },
+                    ]),
+                },
+                Message {
+                    role: Role::Assistant,
+                    content: Content::Text("ok".to_owned()),
+                },
+                Message {
+                    role: Role::User,
+                    content: Content::Text("current".to_owned()),
+                },
+            ],
+            max_tokens: 1024,
+            cache_turns: true,
+            ..Default::default()
+        };
+        let wire = WireRequest::from_request(&req, None);
+        let json = serde_json::to_value(&wire).unwrap();
+        let msgs = json["messages"].as_array().unwrap();
+
+        // First message (blocks) should have cache_control on last block
+        let first_content = msgs[0]["content"].as_array().unwrap();
+        assert_eq!(first_content.len(), 2);
+        assert!(
+            first_content[0].get("cache_control").is_none(),
+            "only last block gets cache_control"
+        );
+        assert_eq!(first_content[1]["cache_control"]["type"], "ephemeral");
+    }
+
+    #[test]
+    fn cache_turns_never_marks_current_message() {
+        let req = CompletionRequest {
+            model: "claude-opus-4-20250514".to_owned(),
+            messages: vec![
+                Message {
+                    role: Role::User,
+                    content: Content::Text("previous".to_owned()),
+                },
+                Message {
+                    role: Role::User,
+                    content: Content::Text("current".to_owned()),
+                },
+            ],
+            max_tokens: 1024,
+            cache_turns: true,
+            ..Default::default()
+        };
+        let wire = WireRequest::from_request(&req, None);
+        let json = serde_json::to_value(&wire).unwrap();
+        let msgs = json["messages"].as_array().unwrap();
+        // First user message should be cached
+        assert!(msgs[0]["content"].is_array());
+        assert_eq!(msgs[0]["content"][0]["cache_control"]["type"], "ephemeral");
+        // Second (last/current) should NOT be cached
+        assert!(msgs[1]["content"].is_string());
+    }
+
+    #[test]
+    fn cache_control_ephemeral_serialization() {
+        let cc = CacheControl::ephemeral();
+        let json = serde_json::to_value(&cc).unwrap();
+        assert_eq!(json["type"], "ephemeral");
+    }
+
+    #[test]
+    fn cache_control_roundtrip() {
+        let cc = CacheControl::ephemeral();
+        let json = serde_json::to_string(&cc).unwrap();
+        let back: CacheControl = serde_json::from_str(&json).unwrap();
+        assert_eq!(cc, back);
+    }
+
+    #[test]
+    fn compute_turn_cache_indices_empty() {
+        let messages: Vec<&crate::types::Message> = vec![];
+        let indices = compute_turn_cache_indices(&messages);
+        assert!(indices.is_empty());
+    }
+
+    #[test]
+    fn compute_turn_cache_indices_two_messages() {
+        let msgs = [
+            Message {
+                role: Role::User,
+                content: Content::Text("a".to_owned()),
+            },
+            Message {
+                role: Role::User,
+                content: Content::Text("b".to_owned()),
+            },
+        ];
+        let refs: Vec<&Message> = msgs.iter().collect();
+        let indices = compute_turn_cache_indices(&refs);
+        assert_eq!(indices, vec![0]);
+    }
+
+    #[test]
+    fn compute_turn_cache_indices_respects_max_breakpoints() {
+        let msgs = [
+            Message {
+                role: Role::User,
+                content: Content::Text("a".to_owned()),
+            },
+            Message {
+                role: Role::Assistant,
+                content: Content::Text("b".to_owned()),
+            },
+            Message {
+                role: Role::User,
+                content: Content::Text("c".to_owned()),
+            },
+            Message {
+                role: Role::Assistant,
+                content: Content::Text("d".to_owned()),
+            },
+            Message {
+                role: Role::User,
+                content: Content::Text("e".to_owned()),
+            },
+            Message {
+                role: Role::Assistant,
+                content: Content::Text("f".to_owned()),
+            },
+            Message {
+                role: Role::User,
+                content: Content::Text("g".to_owned()),
+            },
+        ];
+        let refs: Vec<&Message> = msgs.iter().collect();
+        let indices = compute_turn_cache_indices(&refs);
+        assert!(indices.len() <= MAX_TURN_CACHE_BREAKPOINTS);
+        // Should not include the last index (current message)
+        assert!(!indices.contains(&6));
+    }
+
+    #[test]
+    fn compute_turn_cache_indices_only_picks_user_messages() {
+        let msgs = [
+            Message {
+                role: Role::User,
+                content: Content::Text("a".to_owned()),
+            },
+            Message {
+                role: Role::Assistant,
+                content: Content::Text("b".to_owned()),
+            },
+            Message {
+                role: Role::Assistant,
+                content: Content::Text("c".to_owned()),
+            },
+            Message {
+                role: Role::User,
+                content: Content::Text("d".to_owned()),
+            },
+        ];
+        let refs: Vec<&Message> = msgs.iter().collect();
+        let indices = compute_turn_cache_indices(&refs);
+        // Should pick user message at index 0 (the only user message before the last)
+        assert_eq!(indices, vec![0]);
+    }
+
+    #[test]
+    fn wire_usage_cache_tokens_default_zero() {
+        let json = r#"{
+            "id": "msg_zero",
+            "type": "message",
+            "role": "assistant",
+            "content": [{"type": "text", "text": "hi"}],
+            "model": "claude-opus-4-20250514",
+            "stop_reason": "end_turn",
+            "usage": {"input_tokens": 10, "output_tokens": 5}
+        }"#;
+        let resp: WireResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.usage.cache_creation_input_tokens, 0);
+        assert_eq!(resp.usage.cache_read_input_tokens, 0);
+        let converted = resp.into_response().unwrap();
+        assert_eq!(converted.usage.cache_write_tokens, 0);
+        assert_eq!(converted.usage.cache_read_tokens, 0);
+    }
+
+    #[test]
+    fn wire_usage_cache_tokens_parsed() {
+        let json = r#"{
+            "id": "msg_cache",
+            "type": "message",
+            "role": "assistant",
+            "content": [{"type": "text", "text": "cached"}],
+            "model": "claude-opus-4-20250514",
+            "stop_reason": "end_turn",
+            "usage": {
+                "input_tokens": 100,
+                "output_tokens": 50,
+                "cache_creation_input_tokens": 1500,
+                "cache_read_input_tokens": 3000
+            }
+        }"#;
+        let resp: WireResponse = serde_json::from_str(json).unwrap();
+        let converted = resp.into_response().unwrap();
+        assert_eq!(converted.usage.cache_write_tokens, 1500);
+        assert_eq!(converted.usage.cache_read_tokens, 3000);
+    }
+
+    #[test]
+    fn content_with_cache_control_text() {
+        let content = Content::Text("hello".to_owned());
+        let value = content_with_cache_control(&content);
+        let arr = value.as_array().unwrap();
+        assert_eq!(arr.len(), 1);
+        assert_eq!(arr[0]["type"], "text");
+        assert_eq!(arr[0]["text"], "hello");
+        assert_eq!(arr[0]["cache_control"]["type"], "ephemeral");
+    }
+
+    #[test]
+    fn content_with_cache_control_blocks() {
+        let content = Content::Blocks(vec![
+            ContentBlock::Text {
+                text: "a".to_owned(),
+                citations: None,
+            },
+            ContentBlock::Text {
+                text: "b".to_owned(),
+                citations: None,
+            },
+        ]);
+        let value = content_with_cache_control(&content);
+        let arr = value.as_array().unwrap();
+        assert_eq!(arr.len(), 2);
+        // Only the last block should have cache_control
+        assert!(arr[0].get("cache_control").is_none());
+        assert_eq!(arr[1]["cache_control"]["type"], "ephemeral");
+    }
+
+    #[test]
+    fn cache_turns_combined_with_system_and_tools() {
+        let req = CompletionRequest {
+            model: "claude-opus-4-20250514".to_owned(),
+            system: Some("system prompt".to_owned()),
+            messages: vec![
+                Message {
+                    role: Role::User,
+                    content: Content::Text("turn 1".to_owned()),
+                },
+                Message {
+                    role: Role::Assistant,
+                    content: Content::Text("reply".to_owned()),
+                },
+                Message {
+                    role: Role::User,
+                    content: Content::Text("turn 2".to_owned()),
+                },
+            ],
+            max_tokens: 1024,
+            tools: vec![ToolDefinition {
+                name: "exec".to_owned(),
+                description: "run".to_owned(),
+                input_schema: serde_json::json!({}),
+            }],
+            cache_system: true,
+            cache_tools: true,
+            cache_turns: true,
+            ..Default::default()
+        };
+        let wire = WireRequest::from_request(&req, None);
+        let json = serde_json::to_value(&wire).unwrap();
+        // System is cached
+        assert_eq!(json["system"][0]["cache_control"]["type"], "ephemeral");
+        // Last tool is cached
+        assert_eq!(json["tools"][0]["cache_control"]["type"], "ephemeral");
+        // First user message is cached
+        let msgs = json["messages"].as_array().unwrap();
+        assert!(msgs[0]["content"].is_array());
+        assert_eq!(msgs[0]["content"][0]["cache_control"]["type"], "ephemeral");
+        // Current turn is not cached
+        assert!(msgs[2]["content"].is_string());
     }
 }

--- a/crates/hermeneus/src/metrics.rs
+++ b/crates/hermeneus/src/metrics.rs
@@ -28,11 +28,23 @@ static LLM_REQUESTS_TOTAL: LazyLock<IntCounterVec> = LazyLock::new(|| {
     .expect("metric registration")
 });
 
+static LLM_CACHE_TOKENS_TOTAL: LazyLock<IntCounterVec> = LazyLock::new(|| {
+    register_int_counter_vec!(
+        Opts::new(
+            "aletheia_llm_cache_tokens_total",
+            "Total LLM cache tokens (read and written)"
+        ),
+        &["provider", "direction"]
+    )
+    .expect("metric registration")
+});
+
 /// Force-initialize all lazy metric statics.
 pub fn init() {
     LazyLock::force(&LLM_TOKENS_TOTAL);
     LazyLock::force(&LLM_COST_TOTAL);
     LazyLock::force(&LLM_REQUESTS_TOTAL);
+    LazyLock::force(&LLM_CACHE_TOKENS_TOTAL);
 }
 
 /// Record a completed LLM API call.
@@ -57,5 +69,19 @@ pub fn record_completion(
         LLM_COST_TOTAL
             .with_label_values(&[provider])
             .inc_by(cost_usd);
+    }
+}
+
+/// Record cache token usage from a completed LLM API call.
+pub fn record_cache_tokens(provider: &str, cache_read_tokens: u64, cache_write_tokens: u64) {
+    if cache_read_tokens > 0 {
+        LLM_CACHE_TOKENS_TOTAL
+            .with_label_values(&[provider, "read"])
+            .inc_by(cache_read_tokens);
+    }
+    if cache_write_tokens > 0 {
+        LLM_CACHE_TOKENS_TOTAL
+            .with_label_values(&[provider, "write"])
+            .inc_by(cache_write_tokens);
     }
 }

--- a/crates/hermeneus/src/types.rs
+++ b/crates/hermeneus/src/types.rs
@@ -254,17 +254,50 @@ pub struct ToolDefinition {
 }
 
 /// Cache control directive for prompt caching.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CacheControl {
     #[serde(rename = "type")]
-    pub control_type: String,
+    pub kind: CacheControlType,
+}
+
+/// The type of cache control.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum CacheControlType {
+    #[serde(rename = "ephemeral")]
+    Ephemeral,
 }
 
 impl CacheControl {
     #[must_use]
     pub fn ephemeral() -> Self {
         Self {
-            control_type: "ephemeral".to_owned(),
+            kind: CacheControlType::Ephemeral,
+        }
+    }
+}
+
+/// Caching strategy for prompt caching.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum CachingStrategy {
+    #[default]
+    Auto,
+    Disabled,
+}
+
+/// Configuration for prompt caching behavior.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CachingConfig {
+    pub enabled: bool,
+    #[serde(default)]
+    pub strategy: CachingStrategy,
+}
+
+impl Default for CachingConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            strategy: CachingStrategy::Auto,
         }
     }
 }
@@ -352,6 +385,8 @@ pub struct CompletionRequest {
     pub cache_system: bool,
     /// When true, last tool definition gets `cache_control: ephemeral`.
     pub cache_tools: bool,
+    /// When true, recent non-current conversation turns get `cache_control: ephemeral`.
+    pub cache_turns: bool,
     /// Control tool use behavior (auto/any/specific tool).
     pub tool_choice: Option<ToolChoice>,
     /// Request metadata for tracking.
@@ -374,6 +409,7 @@ impl Default for CompletionRequest {
             stop_sequences: Vec::new(),
             cache_system: false,
             cache_tools: false,
+            cache_turns: false,
             tool_choice: None,
             metadata: None,
             citations: None,
@@ -850,5 +886,38 @@ mod tests {
         let back: CompletionResponse = serde_json::from_str(&json).unwrap();
         assert_eq!(back.id, "msg_123");
         assert_eq!(back.stop_reason, StopReason::EndTurn);
+    }
+
+    #[test]
+    fn cache_control_type_serde() {
+        let cc = CacheControl::ephemeral();
+        let json = serde_json::to_string(&cc).unwrap();
+        assert!(json.contains("\"type\":\"ephemeral\""));
+        let back: CacheControl = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.kind, CacheControlType::Ephemeral);
+    }
+
+    #[test]
+    fn caching_config_defaults() {
+        let config = CachingConfig::default();
+        assert!(config.enabled);
+        assert_eq!(config.strategy, CachingStrategy::Auto);
+    }
+
+    #[test]
+    fn caching_strategy_serde_roundtrip() {
+        for strategy in [CachingStrategy::Auto, CachingStrategy::Disabled] {
+            let json = serde_json::to_string(&strategy).unwrap();
+            let back: CachingStrategy = serde_json::from_str(&json).unwrap();
+            assert_eq!(strategy, back);
+        }
+    }
+
+    #[test]
+    fn completion_request_cache_defaults() {
+        let req = CompletionRequest::default();
+        assert!(!req.cache_system);
+        assert!(!req.cache_tools);
+        assert!(!req.cache_turns);
     }
 }

--- a/crates/nous/src/config.rs
+++ b/crates/nous/src/config.rs
@@ -32,6 +32,13 @@ pub struct NousConfig {
     /// Server-side tools to include in API requests (e.g., web search).
     #[serde(default)]
     pub server_tools: Vec<aletheia_hermeneus::types::ServerToolDefinition>,
+    /// Whether prompt caching is enabled for this agent.
+    #[serde(default = "default_cache_enabled")]
+    pub cache_enabled: bool,
+}
+
+fn default_cache_enabled() -> bool {
+    true
 }
 
 impl Default for NousConfig {
@@ -49,6 +56,7 @@ impl Default for NousConfig {
             loop_detection_threshold: 3,
             domains: Vec::new(),
             server_tools: Vec::new(),
+            cache_enabled: true,
         }
     }
 }
@@ -187,10 +195,12 @@ mod tests {
             loop_detection_threshold: 5,
             domains: vec!["medical".to_owned()],
             server_tools: Vec::new(),
+            cache_enabled: false,
         };
         assert_eq!(config.name.as_deref(), Some("Chiron"));
         assert!(config.thinking_enabled);
         assert_eq!(config.domains.len(), 1);
+        assert!(!config.cache_enabled);
     }
 
     #[test]

--- a/crates/nous/src/execute.rs
+++ b/crates/nous/src/execute.rs
@@ -246,6 +246,9 @@ pub async fn execute(
             temperature: None,
             thinking: thinking.clone(),
             stop_sequences: vec![],
+            cache_system: config.cache_enabled,
+            cache_tools: config.cache_enabled,
+            cache_turns: config.cache_enabled,
             ..Default::default()
         };
 
@@ -506,6 +509,9 @@ pub async fn execute_streaming(
             temperature: None,
             thinking: thinking.clone(),
             stop_sequences: vec![],
+            cache_system: config.cache_enabled,
+            cache_tools: config.cache_enabled,
+            cache_turns: config.cache_enabled,
             ..Default::default()
         };
 

--- a/crates/nous/src/spawn_svc.rs
+++ b/crates/nous/src/spawn_svc.rs
@@ -79,6 +79,7 @@ impl SpawnService for SpawnServiceImpl {
             loop_detection_threshold: 3,
             domains: Vec::new(),
             server_tools: Vec::new(),
+            cache_enabled: true,
         };
 
         let pipeline_config = PipelineConfig {

--- a/crates/taxis/src/config.rs
+++ b/crates/taxis/src/config.rs
@@ -97,6 +97,8 @@ pub struct AgentDefaults {
     pub allowed_roots: Vec<String>,
     /// Per-tool execution timeout overrides.
     pub tool_timeouts: ToolTimeouts,
+    /// Prompt caching configuration.
+    pub caching: CachingConfig,
 }
 
 impl Default for AgentDefaults {
@@ -113,6 +115,7 @@ impl Default for AgentDefaults {
             max_tool_iterations: 50,
             allowed_roots: Vec::new(),
             tool_timeouts: ToolTimeouts::default(),
+            caching: CachingConfig::default(),
         }
     }
 }
@@ -153,6 +156,26 @@ impl Default for ToolTimeouts {
         Self {
             default_ms: 120_000,
             overrides: HashMap::new(),
+        }
+    }
+}
+
+/// Prompt caching configuration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[serde(default)]
+pub struct CachingConfig {
+    /// Whether prompt caching is enabled.
+    pub enabled: bool,
+    /// Caching strategy: `"auto"` or `"disabled"`.
+    pub strategy: String,
+}
+
+impl Default for CachingConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            strategy: "auto".to_owned(),
         }
     }
 }
@@ -590,6 +613,8 @@ pub struct ResolvedNousConfig {
     pub user_timezone: String,
     /// Per-turn timeout in seconds.
     pub timeout_seconds: u32,
+    /// Whether prompt caching is enabled.
+    pub cache_enabled: bool,
 }
 
 /// Resolve effective configuration for a specific nous agent.
@@ -646,6 +671,7 @@ pub fn resolve_nous(config: &AletheiaConfig, nous_id: &str) -> ResolvedNousConfi
         domains,
         user_timezone: defaults.user_timezone.clone(),
         timeout_seconds: defaults.timeout_seconds,
+        cache_enabled: defaults.caching.enabled && defaults.caching.strategy != "disabled",
     }
 }
 


### PR DESCRIPTION
## Summary

- Add message-level `cache_control` support to `WireMessage`, enabling Anthropic's multi-turn prompt caching (up to 90% cost reduction on cache hits)
- Implement automatic turn-marking strategy: the last 2 user messages before the current turn receive `cache_control: ephemeral` breakpoints
- Add `CachingConfig` to taxis `AgentDefaults` with `enabled`/`strategy` fields (`auto` or `disabled`)
- Wire `cache_system`, `cache_tools`, and `cache_turns` flags through `NousConfig` into the execution pipeline
- Add Prometheus `aletheia_llm_cache_tokens_total` metric for cache read/write token tracking
- Improve `CacheControl` type to use a typed `CacheControlType` enum instead of a raw String
- 19 new tests covering wire serialization, strategy logic, metrics parsing, and round-trips

## Changes by crate

| Crate | What |
|-------|------|
| `hermeneus` | `WireContent` enum, turn cache strategy, `CacheControl`/`CachingConfig` types, cache metrics |
| `nous` | `cache_enabled` on `NousConfig`, cache flags in `CompletionRequest` construction |
| `taxis` | `CachingConfig` in `AgentDefaults`, `cache_enabled` in `ResolvedNousConfig` |
| `aletheia` | Wire `cache_enabled` through to `NousConfig` in main |

## Test plan

- [x] 19 new tests for wire format, strategy, metrics, and config
- [x] All 281 existing tests pass (`cargo test -p aletheia-hermeneus -p aletheia-nous`)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)