### PR TITLE
feat(hermeneus): native Anthropic server-side tools

### DIFF
--- a/crates/aletheia/src/main.rs
+++ b/crates/aletheia/src/main.rs
@@ -696,6 +696,7 @@ async fn serve(cli: Cli) -> Result<()> {
         knowledge: knowledge_search,
         http_client: reqwest::Client::new(),
         lazy_tool_catalog: tool_registry.lazy_tool_catalog(),
+        server_tool_config: aletheia_organon::types::ServerToolConfig::default(),
     });
 
     // Spawn nous actors

--- a/crates/hermeneus/src/anthropic/wire.rs
+++ b/crates/hermeneus/src/anthropic/wire.rs
@@ -1076,6 +1076,154 @@ mod tests {
     }
 
     #[test]
+    fn wire_server_tool_serializes_type_field() {
+        let tool = WireServerTool {
+            tool_type: "web_search_20250305",
+            name: "web_search",
+            max_uses: Some(5),
+            allowed_domains: None,
+            blocked_domains: None,
+            user_location: None,
+        };
+        let json = serde_json::to_value(&tool).unwrap();
+        assert_eq!(json["type"], "web_search_20250305");
+        assert_eq!(json["name"], "web_search");
+        assert_eq!(json["max_uses"], 5);
+        assert!(json.get("allowed_domains").is_none());
+    }
+
+    #[test]
+    fn wire_server_tool_with_domain_filters() {
+        let allowed = vec!["example.com".to_owned()];
+        let blocked = vec!["evil.com".to_owned()];
+        let tool = WireServerTool {
+            tool_type: "web_search_20250305",
+            name: "web_search",
+            max_uses: None,
+            allowed_domains: Some(&allowed),
+            blocked_domains: Some(&blocked),
+            user_location: None,
+        };
+        let json = serde_json::to_value(&tool).unwrap();
+        assert_eq!(json["allowed_domains"][0], "example.com");
+        assert_eq!(json["blocked_domains"][0], "evil.com");
+        assert!(json.get("max_uses").is_none());
+    }
+
+    #[test]
+    fn wire_tool_entry_untagged_serialization() {
+        let user_tool = WireToolEntry::UserDefined(WireTool {
+            name: "read",
+            description: "Read a file",
+            input_schema: &serde_json::json!({"type": "object"}),
+            cache_control: None,
+        });
+        let server_tool = WireToolEntry::ServerSide(WireServerTool {
+            tool_type: "web_search_20250305",
+            name: "web_search",
+            max_uses: Some(3),
+            allowed_domains: None,
+            blocked_domains: None,
+            user_location: None,
+        });
+
+        let user_json = serde_json::to_value(&user_tool).unwrap();
+        assert!(user_json.get("type").is_none());
+        assert!(user_json.get("input_schema").is_some());
+
+        let server_json = serde_json::to_value(&server_tool).unwrap();
+        assert_eq!(server_json["type"], "web_search_20250305");
+        assert!(server_json.get("input_schema").is_none());
+    }
+
+    #[test]
+    fn wire_content_block_web_search_result_with_multiple_results() {
+        let json = r#"{"type":"web_search_tool_result","tool_use_id":"srvtoolu_456","content":[
+            {"type":"web_search_result","url":"https://a.com","title":"A","encrypted_content":"enc1"},
+            {"type":"web_search_result","url":"https://b.com","title":"B","encrypted_content":"enc2"},
+            {"type":"web_search_result","url":"https://c.com","title":"C","encrypted_content":"enc3"}
+        ]}"#;
+        let block: WireContentBlock = serde_json::from_str(json).unwrap();
+        let converted = block.into_content_block();
+        match converted {
+            ContentBlock::WebSearchToolResult { content, .. } => {
+                assert_eq!(content.as_array().unwrap().len(), 3);
+            }
+            _ => panic!("expected WebSearchToolResult"),
+        }
+    }
+
+    #[test]
+    fn wire_response_with_citation_web_search_result_location() {
+        let json = r#"{
+            "id": "msg_ws_cit",
+            "type": "message",
+            "role": "assistant",
+            "content": [{
+                "type": "text",
+                "text": "According to...",
+                "citations": [{
+                    "type": "web_search_result_location",
+                    "url": "https://example.com/article",
+                    "title": "Example Article",
+                    "cited_text": "relevant passage"
+                }]
+            }],
+            "model": "claude-opus-4-20250514",
+            "stop_reason": "end_turn",
+            "usage": {"input_tokens": 100, "output_tokens": 50}
+        }"#;
+        let resp: WireResponse = serde_json::from_str(json).unwrap();
+        let converted = resp.into_response().unwrap();
+        match &converted.content[0] {
+            ContentBlock::Text { citations, .. } => {
+                let cits = citations.as_ref().unwrap();
+                assert_eq!(cits.len(), 1);
+                match &cits[0] {
+                    crate::types::Citation::WebSearchResultLocation {
+                        url,
+                        title,
+                        cited_text,
+                    } => {
+                        assert_eq!(url, "https://example.com/article");
+                        assert_eq!(title.as_deref(), Some("Example Article"));
+                        assert_eq!(cited_text, "relevant passage");
+                    }
+                    _ => panic!("expected WebSearchResultLocation"),
+                }
+            }
+            _ => panic!("expected Text"),
+        }
+    }
+
+    #[test]
+    fn wire_request_code_execution_server_tool() {
+        let req = CompletionRequest {
+            model: "claude-opus-4-20250514".to_owned(),
+            messages: vec![Message {
+                role: Role::User,
+                content: Content::Text("run python".to_owned()),
+            }],
+            max_tokens: 1024,
+            server_tools: vec![crate::types::ServerToolDefinition {
+                tool_type: "code_execution_20250522".to_owned(),
+                name: "code_execution".to_owned(),
+                max_uses: None,
+                allowed_domains: None,
+                blocked_domains: None,
+                user_location: None,
+            }],
+            ..Default::default()
+        };
+        let wire = WireRequest::from_request(&req, None);
+        let json = serde_json::to_value(&wire).unwrap();
+        let tools = json["tools"].as_array().unwrap();
+        assert_eq!(tools.len(), 1);
+        assert_eq!(tools[0]["type"], "code_execution_20250522");
+        assert_eq!(tools[0]["name"], "code_execution");
+    }
+
+    #[test]
     fn wire_request_no_cache_system_is_string() {
         let req = CompletionRequest {
             model: "claude-opus-4-20250514".to_owned(),

--- a/crates/integration-tests/tests/organon_mneme_tools.rs
+++ b/crates/integration-tests/tests/organon_mneme_tools.rs
@@ -24,7 +24,8 @@ use aletheia_nous::adapters::{SessionBlackboardAdapter, SessionNoteAdapter};
 use aletheia_organon::builtins;
 use aletheia_organon::registry::ToolRegistry;
 use aletheia_organon::types::{
-    FactSummary, KnowledgeSearchService, MemoryResult, ToolContext, ToolInput, ToolServices,
+    FactSummary, KnowledgeSearchService, MemoryResult, ServerToolConfig, ToolContext, ToolInput,
+    ToolServices,
 };
 use std::sync::RwLock;
 
@@ -62,6 +63,7 @@ fn ctx_with_notes_bb(store: &Arc<Mutex<SessionStore>>) -> ToolContext {
             knowledge: None,
             http_client: reqwest::Client::new(),
             lazy_tool_catalog: vec![],
+            server_tool_config: ServerToolConfig::default(),
         })),
         active_tools: Arc::new(RwLock::new(HashSet::new())),
     }
@@ -356,6 +358,7 @@ fn ctx_with_knowledge(svc: Arc<StubKnowledgeService>) -> ToolContext {
             knowledge: Some(svc),
             http_client: reqwest::Client::new(),
             lazy_tool_catalog: vec![],
+            server_tool_config: ServerToolConfig::default(),
         })),
         active_tools: Arc::new(RwLock::new(HashSet::new())),
     }

--- a/crates/nous/src/execute.rs
+++ b/crates/nous/src/execute.rs
@@ -236,13 +236,23 @@ pub async fn execute(
             .clone();
         let tool_defs = tools.to_hermeneus_tools_filtered(&active);
 
+        // Derive server tools from config + active_tools (enable_tool activations)
+        let server_tools = if let Some(services) = tool_ctx.services.as_deref() {
+            let mut st = services.server_tool_config.active_definitions(&active);
+            // Also include any raw server_tools from NousConfig for backward compat
+            st.extend(config.server_tools.clone());
+            st
+        } else {
+            config.server_tools.clone()
+        };
+
         let request = CompletionRequest {
             model: config.model.clone(),
             system: ctx.system_prompt.clone(),
             messages: messages.clone(),
             max_tokens: config.max_output_tokens,
             tools: tool_defs,
-            server_tools: config.server_tools.clone(),
+            server_tools,
             temperature: None,
             thinking: thinking.clone(),
             stop_sequences: vec![],
@@ -499,13 +509,27 @@ pub async fn execute_streaming(
             break;
         }
 
+        // Derive server tools from ServerToolConfig + NousConfig
+        let active = tool_ctx
+            .active_tools
+            .read()
+            .expect("active_tools lock")
+            .clone();
+        let server_tools = if let Some(services) = tool_ctx.services.as_deref() {
+            let mut st = services.server_tool_config.active_definitions(&active);
+            st.extend(config.server_tools.clone());
+            st
+        } else {
+            config.server_tools.clone()
+        };
+
         let request = CompletionRequest {
             model: config.model.clone(),
             system: ctx.system_prompt.clone(),
             messages: messages.clone(),
             max_tokens: config.max_output_tokens,
             tools: tool_defs.clone(),
-            server_tools: config.server_tools.clone(),
+            server_tools,
             temperature: None,
             thinking: thinking.clone(),
             stop_sequences: vec![],

--- a/crates/organon/src/builtins/agent.rs
+++ b/crates/organon/src/builtins/agent.rs
@@ -290,7 +290,8 @@ mod tests {
 
     use crate::registry::ToolRegistry;
     use crate::types::{
-        SpawnRequest, SpawnResult, SpawnService, ToolContext, ToolInput, ToolServices,
+        ServerToolConfig, SpawnRequest, SpawnResult, SpawnService, ToolContext, ToolInput,
+        ToolServices,
     };
 
     fn test_ctx() -> ToolContext {
@@ -319,6 +320,7 @@ mod tests {
                 planning: None,
                 knowledge: None,
                 lazy_tool_catalog: vec![],
+                server_tool_config: ServerToolConfig::default(),
                 http_client: reqwest::Client::new(),
             })),
             active_tools: Arc::new(RwLock::new(HashSet::new())),

--- a/crates/organon/src/builtins/communication.rs
+++ b/crates/organon/src/builtins/communication.rs
@@ -279,7 +279,9 @@ mod tests {
     use aletheia_koina::id::{NousId, SessionId, ToolName};
 
     use crate::registry::ToolRegistry;
-    use crate::types::{CrossNousService, MessageService, ToolContext, ToolInput, ToolServices};
+    use crate::types::{
+        CrossNousService, MessageService, ServerToolConfig, ToolContext, ToolInput, ToolServices,
+    };
 
     fn test_ctx() -> ToolContext {
         ToolContext {
@@ -453,6 +455,7 @@ mod tests {
             knowledge: None,
             http_client: reqwest::Client::new(),
             lazy_tool_catalog: vec![],
+            server_tool_config: ServerToolConfig::default(),
             messenger: Some(messenger),
         });
         let mut reg = ToolRegistry::new();
@@ -480,6 +483,7 @@ mod tests {
             knowledge: None,
             http_client: reqwest::Client::new(),
             lazy_tool_catalog: vec![],
+            server_tool_config: ServerToolConfig::default(),
             messenger: Some(messenger),
         });
         let mut reg = ToolRegistry::new();
@@ -514,6 +518,7 @@ mod tests {
             knowledge: None,
             http_client: reqwest::Client::new(),
             lazy_tool_catalog: vec![],
+            server_tool_config: ServerToolConfig::default(),
         });
         let mut reg = ToolRegistry::new();
         super::register(&mut reg).expect("register");
@@ -548,6 +553,7 @@ mod tests {
             knowledge: None,
             http_client: reqwest::Client::new(),
             lazy_tool_catalog: vec![],
+            server_tool_config: ServerToolConfig::default(),
         });
         let mut reg = ToolRegistry::new();
         super::register(&mut reg).expect("register");
@@ -577,6 +583,7 @@ mod tests {
             knowledge: None,
             http_client: reqwest::Client::new(),
             lazy_tool_catalog: vec![],
+            server_tool_config: ServerToolConfig::default(),
         });
         let mut reg = ToolRegistry::new();
         super::register(&mut reg).expect("register");
@@ -604,6 +611,7 @@ mod tests {
             knowledge: None,
             http_client: reqwest::Client::new(),
             lazy_tool_catalog: vec![],
+            server_tool_config: ServerToolConfig::default(),
         });
         let mut reg = ToolRegistry::new();
         super::register(&mut reg).expect("register");

--- a/crates/organon/src/builtins/enable_tool.rs
+++ b/crates/organon/src/builtins/enable_tool.rs
@@ -34,18 +34,21 @@ impl ToolExecutor for EnableToolExecutor {
                 return Ok(ToolResult::error(format!("invalid tool name: {name}")));
             };
 
-            // Check if it's in the lazy catalog
+            // Check lazy catalog (native tools) and server tool catalog
+            let server_catalog = services.server_tool_config.catalog_entries();
             let catalog_entry = services
                 .lazy_tool_catalog
                 .iter()
-                .find(|(n, _)| *n == tool_name);
+                .find(|(n, _)| *n == tool_name)
+                .or_else(|| server_catalog.iter().find(|(n, _)| *n == tool_name));
 
             let Some((_, description)) = catalog_entry else {
-                let available: Vec<&str> = services
+                let mut available: Vec<&str> = services
                     .lazy_tool_catalog
                     .iter()
                     .map(|(n, _)| n.as_str())
                     .collect();
+                available.extend(server_catalog.iter().map(|(n, _)| n.as_str()));
                 return Ok(ToolResult::error(format!(
                     "tool '{name}' not found. Available tools: {}",
                     available.join(", ")
@@ -117,7 +120,7 @@ mod tests {
 
     use aletheia_koina::id::{NousId, SessionId, ToolName};
 
-    use crate::types::{ToolContext, ToolInput, ToolServices};
+    use crate::types::{ServerToolConfig, ToolContext, ToolInput, ToolServices};
 
     use super::*;
 
@@ -137,6 +140,7 @@ mod tests {
                 knowledge: None,
                 http_client: reqwest::Client::new(),
                 lazy_tool_catalog: catalog,
+                server_tool_config: ServerToolConfig::default(),
             })),
             active_tools: Arc::new(RwLock::new(HashSet::new())),
         }
@@ -224,5 +228,91 @@ mod tests {
 
         assert!(!result.is_error);
         assert!(result.content.text_summary().contains("already active"));
+    }
+
+    fn test_ctx_with_server_tools(config: ServerToolConfig) -> ToolContext {
+        ToolContext {
+            nous_id: NousId::new("test-agent").expect("valid"),
+            session_id: SessionId::new(),
+            workspace: std::path::PathBuf::from("/tmp/test"),
+            allowed_roots: vec![std::path::PathBuf::from("/tmp")],
+            services: Some(Arc::new(ToolServices {
+                cross_nous: None,
+                messenger: None,
+                note_store: None,
+                blackboard_store: None,
+                spawn: None,
+                planning: None,
+                knowledge: None,
+                http_client: reqwest::Client::new(),
+                lazy_tool_catalog: vec![],
+                server_tool_config: config,
+            })),
+            active_tools: Arc::new(RwLock::new(HashSet::new())),
+        }
+    }
+
+    #[tokio::test]
+    async fn enable_tool_activates_server_web_search() {
+        let ctx = test_ctx_with_server_tools(ServerToolConfig {
+            web_search: true,
+            web_search_max_uses: Some(5),
+            code_execution: false,
+        });
+
+        let executor = EnableToolExecutor;
+        let result = executor
+            .execute(&make_input("web_search"), &ctx)
+            .await
+            .expect("execute");
+
+        assert!(!result.is_error);
+        assert!(
+            result
+                .content
+                .text_summary()
+                .contains("Activated 'web_search'")
+        );
+
+        #[expect(
+            clippy::expect_used,
+            reason = "test assertion: poisoned lock means a test bug"
+        )]
+        let active = ctx.active_tools.read().expect("lock poisoned");
+        assert!(active.contains(&ToolName::new("web_search").expect("valid")));
+    }
+
+    #[tokio::test]
+    async fn enable_tool_server_tool_not_in_disabled_config() {
+        let ctx = test_ctx_with_server_tools(ServerToolConfig::default());
+
+        let executor = EnableToolExecutor;
+        let result = executor
+            .execute(&make_input("web_search"), &ctx)
+            .await
+            .expect("execute");
+
+        assert!(result.is_error);
+        assert!(result.content.text_summary().contains("not found"));
+    }
+
+    #[tokio::test]
+    async fn enable_tool_lists_server_tools_in_available() {
+        let ctx = test_ctx_with_server_tools(ServerToolConfig {
+            web_search: true,
+            web_search_max_uses: None,
+            code_execution: true,
+        });
+
+        let executor = EnableToolExecutor;
+        let result = executor
+            .execute(&make_input("nonexistent"), &ctx)
+            .await
+            .expect("execute");
+
+        assert!(result.is_error);
+        let text = result.content.text_summary();
+        assert!(text.contains("web_search"));
+        assert!(text.contains("code_execution"));
     }
 }

--- a/crates/organon/src/builtins/memory.rs
+++ b/crates/organon/src/builtins/memory.rs
@@ -876,8 +876,8 @@ mod tests {
 
     use crate::registry::ToolRegistry;
     use crate::types::{
-        BlackboardEntry, BlackboardStore, NoteEntry, NoteStore, ToolContext, ToolInput,
-        ToolServices,
+        BlackboardEntry, BlackboardStore, NoteEntry, NoteStore, ServerToolConfig, ToolContext,
+        ToolInput, ToolServices,
     };
 
     type BoxError = Box<dyn std::error::Error + Send + Sync>;
@@ -1015,6 +1015,7 @@ mod tests {
                 knowledge: None,
                 http_client: reqwest::Client::new(),
                 lazy_tool_catalog: vec![],
+                server_tool_config: ServerToolConfig::default(),
             })),
             active_tools: Arc::new(RwLock::new(HashSet::new())),
         }

--- a/crates/organon/src/builtins/planning.rs
+++ b/crates/organon/src/builtins/planning.rs
@@ -831,7 +831,9 @@ mod tests {
     use aletheia_koina::id::{NousId, SessionId, ToolName};
 
     use crate::registry::ToolRegistry;
-    use crate::types::{PlanningService, ToolCategory, ToolContext, ToolInput, ToolServices};
+    use crate::types::{
+        PlanningService, ServerToolConfig, ToolCategory, ToolContext, ToolInput, ToolServices,
+    };
 
     fn test_ctx() -> ToolContext {
         ToolContext {
@@ -860,6 +862,7 @@ mod tests {
                 knowledge: None,
                 http_client: reqwest::Client::new(),
                 lazy_tool_catalog: vec![],
+                server_tool_config: ServerToolConfig::default(),
             })),
             active_tools: Arc::new(RwLock::new(HashSet::new())),
         }

--- a/crates/organon/src/builtins/research.rs
+++ b/crates/organon/src/builtins/research.rs
@@ -265,7 +265,7 @@ mod tests {
 
     use aletheia_koina::id::{NousId, SessionId, ToolName};
 
-    use crate::types::{ToolContext, ToolInput, ToolServices};
+    use crate::types::{ServerToolConfig, ToolContext, ToolInput, ToolServices};
 
     use super::*;
 
@@ -285,6 +285,7 @@ mod tests {
                 knowledge: None,
                 http_client: reqwest::Client::new(),
                 lazy_tool_catalog: vec![],
+                server_tool_config: ServerToolConfig::default(),
             })),
             active_tools: Arc::new(RwLock::new(HashSet::new())),
         }

--- a/crates/organon/src/types.rs
+++ b/crates/organon/src/types.rs
@@ -424,6 +424,76 @@ pub struct DatalogResult {
     pub truncated: bool,
 }
 
+/// Configuration for server-side tools that execute on the API provider's infrastructure.
+///
+/// Controls which server tools are available for per-session activation via `enable_tool`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ServerToolConfig {
+    /// Whether web search is available for activation.
+    #[serde(default)]
+    pub web_search: bool,
+    /// Maximum web search uses per turn (None = provider default).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub web_search_max_uses: Option<u32>,
+    /// Whether code execution is available for activation.
+    #[serde(default)]
+    pub code_execution: bool,
+}
+
+impl ServerToolConfig {
+    /// Generate catalog entries for server tools available via `enable_tool`.
+    #[must_use]
+    pub fn catalog_entries(&self) -> Vec<(ToolName, String)> {
+        let mut entries = Vec::new();
+        if self.web_search {
+            entries.push((
+                ToolName::new("web_search").expect("valid tool name"),
+                "Search the web using Anthropic's server-side web search".to_owned(),
+            ));
+        }
+        if self.code_execution {
+            entries.push((
+                ToolName::new("code_execution").expect("valid tool name"),
+                "Execute Python code in a sandboxed server-side environment".to_owned(),
+            ));
+        }
+        entries
+    }
+
+    /// Produce server tool definitions for tools that are currently active.
+    #[must_use]
+    pub fn active_definitions(
+        &self,
+        active: &HashSet<ToolName>,
+    ) -> Vec<aletheia_hermeneus::types::ServerToolDefinition> {
+        let mut defs = Vec::new();
+        let web_search_name = ToolName::new("web_search").expect("valid tool name");
+        let code_exec_name = ToolName::new("code_execution").expect("valid tool name");
+
+        if self.web_search && active.contains(&web_search_name) {
+            defs.push(aletheia_hermeneus::types::ServerToolDefinition {
+                tool_type: "web_search_20250305".to_owned(),
+                name: "web_search".to_owned(),
+                max_uses: self.web_search_max_uses,
+                allowed_domains: None,
+                blocked_domains: None,
+                user_location: None,
+            });
+        }
+        if self.code_execution && active.contains(&code_exec_name) {
+            defs.push(aletheia_hermeneus::types::ServerToolDefinition {
+                tool_type: "code_execution_20250522".to_owned(),
+                name: "code_execution".to_owned(),
+                max_uses: None,
+                allowed_domains: None,
+                blocked_domains: None,
+                user_location: None,
+            });
+        }
+        defs
+    }
+}
+
 /// Service locator for tool executors needing access to runtime services.
 pub struct ToolServices {
     pub cross_nous: Option<Arc<dyn CrossNousService>>,
@@ -436,6 +506,8 @@ pub struct ToolServices {
     pub http_client: reqwest::Client,
     /// Catalog of lazy tools available for activation via `enable_tool`.
     pub lazy_tool_catalog: Vec<(ToolName, String)>,
+    /// Server tool configuration for provider-side tools (web search, code execution).
+    pub server_tool_config: ServerToolConfig,
 }
 
 impl std::fmt::Debug for ToolServices {
@@ -449,6 +521,7 @@ impl std::fmt::Debug for ToolServices {
             .field("planning", &self.planning.is_some())
             .field("knowledge", &self.knowledge.is_some())
             .field("lazy_tool_catalog_len", &self.lazy_tool_catalog.len())
+            .field("server_tool_config", &self.server_tool_config)
             .finish_non_exhaustive()
     }
 }
@@ -849,5 +922,141 @@ mod tests {
         };
         let json = schema.to_json_schema();
         assert_eq!(json["type"], "object");
+    }
+
+    // --- ServerToolConfig tests ---
+
+    #[test]
+    fn server_tool_config_default_disables_all() {
+        let config = ServerToolConfig::default();
+        assert!(!config.web_search);
+        assert!(!config.code_execution);
+        assert!(config.web_search_max_uses.is_none());
+    }
+
+    #[test]
+    fn server_tool_config_serde_roundtrip() {
+        let config = ServerToolConfig {
+            web_search: true,
+            web_search_max_uses: Some(5),
+            code_execution: true,
+        };
+        let json = serde_json::to_string(&config).expect("serialize");
+        let back: ServerToolConfig = serde_json::from_str(&json).expect("deserialize");
+        assert!(back.web_search);
+        assert_eq!(back.web_search_max_uses, Some(5));
+        assert!(back.code_execution);
+    }
+
+    #[test]
+    fn server_tool_config_catalog_entries_empty_when_disabled() {
+        let config = ServerToolConfig::default();
+        assert!(config.catalog_entries().is_empty());
+    }
+
+    #[test]
+    fn server_tool_config_catalog_entries_web_search() {
+        let config = ServerToolConfig {
+            web_search: true,
+            web_search_max_uses: None,
+            code_execution: false,
+        };
+        let entries = config.catalog_entries();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].0.as_str(), "web_search");
+    }
+
+    #[test]
+    fn server_tool_config_catalog_entries_both() {
+        let config = ServerToolConfig {
+            web_search: true,
+            web_search_max_uses: Some(3),
+            code_execution: true,
+        };
+        let entries = config.catalog_entries();
+        assert_eq!(entries.len(), 2);
+        let names: Vec<&str> = entries.iter().map(|(n, _)| n.as_str()).collect();
+        assert!(names.contains(&"web_search"));
+        assert!(names.contains(&"code_execution"));
+    }
+
+    #[test]
+    fn server_tool_config_active_definitions_empty_when_none_active() {
+        let config = ServerToolConfig {
+            web_search: true,
+            web_search_max_uses: Some(5),
+            code_execution: true,
+        };
+        let active = HashSet::new();
+        let defs = config.active_definitions(&active);
+        assert!(defs.is_empty());
+    }
+
+    #[test]
+    fn server_tool_config_active_definitions_web_search() {
+        let config = ServerToolConfig {
+            web_search: true,
+            web_search_max_uses: Some(5),
+            code_execution: false,
+        };
+        let mut active = HashSet::new();
+        active.insert(ToolName::new("web_search").expect("valid"));
+        let defs = config.active_definitions(&active);
+        assert_eq!(defs.len(), 1);
+        assert_eq!(defs[0].tool_type, "web_search_20250305");
+        assert_eq!(defs[0].name, "web_search");
+        assert_eq!(defs[0].max_uses, Some(5));
+    }
+
+    #[test]
+    fn server_tool_config_active_definitions_code_execution() {
+        let config = ServerToolConfig {
+            web_search: false,
+            web_search_max_uses: None,
+            code_execution: true,
+        };
+        let mut active = HashSet::new();
+        active.insert(ToolName::new("code_execution").expect("valid"));
+        let defs = config.active_definitions(&active);
+        assert_eq!(defs.len(), 1);
+        assert_eq!(defs[0].tool_type, "code_execution_20250522");
+        assert_eq!(defs[0].name, "code_execution");
+    }
+
+    #[test]
+    fn server_tool_config_active_ignores_disabled_tools() {
+        let config = ServerToolConfig {
+            web_search: false,
+            web_search_max_uses: None,
+            code_execution: false,
+        };
+        let mut active = HashSet::new();
+        active.insert(ToolName::new("web_search").expect("valid"));
+        active.insert(ToolName::new("code_execution").expect("valid"));
+        let defs = config.active_definitions(&active);
+        assert!(defs.is_empty());
+    }
+
+    #[test]
+    fn server_tool_config_active_definitions_both() {
+        let config = ServerToolConfig {
+            web_search: true,
+            web_search_max_uses: None,
+            code_execution: true,
+        };
+        let mut active = HashSet::new();
+        active.insert(ToolName::new("web_search").expect("valid"));
+        active.insert(ToolName::new("code_execution").expect("valid"));
+        let defs = config.active_definitions(&active);
+        assert_eq!(defs.len(), 2);
+    }
+
+    #[test]
+    fn server_tool_config_deserializes_from_partial_json() {
+        let json = r#"{"web_search": true}"#;
+        let config: ServerToolConfig = serde_json::from_str(json).expect("deserialize");
+        assert!(config.web_search);
+        assert!(!config.code_execution);
+        assert!(config.web_search_max_uses.is_none());
     }
 }


### PR DESCRIPTION
## Summary

- Add `ServerToolConfig` struct to organon for per-session control of Anthropic server-side tools (`web_search_20250305`, `code_execution_20250522`)
- Bridge the `enable_tool` mechanism so `enable_tool("web_search")` activates the native server-side web search tool instead of requiring raw `ServerToolDefinition` config
- Update execute stage to derive server tools from `active_tools` set, enabling dynamic activation mid-conversation
- Add 20 new tests covering `ServerToolConfig`, enable_tool server tool integration, wire serialization, and citation parsing

## Test plan

- [x] `cargo fmt --all --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes (zero warnings)
- [x] `cargo test -p aletheia-hermeneus` — 118 tests pass
- [x] `cargo test -p aletheia-organon` — 134 tests pass (4 pre-existing filesystem failures on main)
- [x] `cargo test -p aletheia-nous` — 281 tests pass
- [x] 20 new tests for ServerToolConfig, enable_tool integration, wire format, and response parsing

🤖 Generated with [Claude Code](https://claude.com/claude-code)