### PR TITLE
test(organon): comprehensive builtin tool executor tests

### DIFF
--- a/crates/mneme/src/export.rs
+++ b/crates/mneme/src/export.rs
@@ -176,7 +176,10 @@ fn query_all_entities(
         let aliases = if aliases_str.is_empty() {
             vec![]
         } else {
-            aliases_str.split(',').map(|s| s.trim().to_owned()).collect()
+            aliases_str
+                .split(',')
+                .map(|s| s.trim().to_owned())
+                .collect()
         };
         let created_at = row[4].get_str().unwrap_or_default().to_owned();
         let updated_at = row[5].get_str().unwrap_or_default().to_owned();

--- a/crates/mneme/src/knowledge_store.rs
+++ b/crates/mneme/src/knowledge_store.rs
@@ -720,8 +720,14 @@ impl KnowledgeStore {
     ///
     /// Takes the top entity IDs from existing results, queries their neighborhoods,
     /// and returns related facts as additional results.
-    #[expect(clippy::cast_precision_loss, reason = "rank indices fit in f64 mantissa")]
-    #[expect(clippy::cast_possible_wrap, reason = "rank indices are small positive values")]
+    #[expect(
+        clippy::cast_precision_loss,
+        reason = "rank indices fit in f64 mantissa"
+    )]
+    #[expect(
+        clippy::cast_possible_wrap,
+        reason = "rank indices are small positive values"
+    )]
     fn expand_via_graph(
         &self,
         existing: &[HybridResult],

--- a/crates/mneme/src/query_rewrite.rs
+++ b/crates/mneme/src/query_rewrite.rs
@@ -179,8 +179,8 @@ fn parse_rewrite_response(response: &str) -> Result<Vec<String>, RewriteError> {
     let trimmed = strip_code_fences(response);
 
     // Try parsing as a JSON array of strings
-    let variants: Vec<String> = serde_json::from_str(trimmed)
-        .map_err(|e| RewriteError::ParseResponse(e.to_string()))?;
+    let variants: Vec<String> =
+        serde_json::from_str(trimmed).map_err(|e| RewriteError::ParseResponse(e.to_string()))?;
 
     // Filter out empty strings
     let variants: Vec<String> = variants.into_iter().filter(|v| !v.is_empty()).collect();
@@ -361,7 +361,11 @@ mod tests {
         // Original + 3 variants = 4
         assert_eq!(result.variants.len(), 4);
         assert_eq!(result.variants[0], "What's Cody's truck?");
-        assert!(result.variants.contains(&"Cummins diesel specifications".to_owned()));
+        assert!(
+            result
+                .variants
+                .contains(&"Cummins diesel specifications".to_owned())
+        );
     }
 
     #[test]
@@ -411,9 +415,7 @@ mod tests {
     #[test]
     fn rewrite_with_context() {
         let rewriter = QueryRewriter::with_defaults();
-        let provider = MockProvider::with_response(
-            r#"["Cody truck", "vehicle maintenance"]"#,
-        );
+        let provider = MockProvider::with_response(r#"["Cody truck", "vehicle maintenance"]"#);
 
         let result = rewriter.rewrite(
             "What's the truck?",
@@ -432,9 +434,8 @@ mod tests {
             include_original: true,
         };
         let rewriter = QueryRewriter::new(config);
-        let provider = MockProvider::with_response(
-            r#"["variant 1", "variant 2", "variant 3", "variant 4"]"#,
-        );
+        let provider =
+            MockProvider::with_response(r#"["variant 1", "variant 2", "variant 3", "variant 4"]"#);
 
         let result = rewriter.rewrite("query", None, &provider);
 
@@ -448,9 +449,7 @@ mod tests {
     #[test]
     fn rewrite_strips_code_fences() {
         let rewriter = QueryRewriter::with_defaults();
-        let provider = MockProvider::with_response(
-            "```json\n[\"variant 1\", \"variant 2\"]\n```",
-        );
+        let provider = MockProvider::with_response("```json\n[\"variant 1\", \"variant 2\"]\n```");
 
         let result = rewriter.rewrite("query", None, &provider);
 
@@ -464,9 +463,7 @@ mod tests {
             include_original: false,
         };
         let rewriter = QueryRewriter::new(config);
-        let provider = MockProvider::with_response(
-            r#"["variant 1", "variant 2"]"#,
-        );
+        let provider = MockProvider::with_response(r#"["variant 1", "variant 2"]"#);
 
         let result = rewriter.rewrite("original query", None, &provider);
 
@@ -477,9 +474,7 @@ mod tests {
     #[test]
     fn rewrite_filters_empty_strings() {
         let rewriter = QueryRewriter::with_defaults();
-        let provider = MockProvider::with_response(
-            r#"["", "variant 1", "", "variant 2"]"#,
-        );
+        let provider = MockProvider::with_response(r#"["", "variant 1", "", "variant 2"]"#);
 
         let result = rewriter.rewrite("query", None, &provider);
 
@@ -508,8 +503,7 @@ mod tests {
 
     #[test]
     fn parse_response_with_fences() {
-        let variants =
-            parse_rewrite_response("```json\n[\"a\", \"b\"]\n```").unwrap();
+        let variants = parse_rewrite_response("```json\n[\"a\", \"b\"]\n```").unwrap();
         assert_eq!(variants, vec!["a", "b"]);
     }
 
@@ -557,12 +551,24 @@ mod tests {
     #[test]
     fn rrf_merge_deduplicates_by_id() {
         let q1 = vec![
-            TestResult { doc_id: "f1".to_owned(), score: 0.0 },
-            TestResult { doc_id: "f2".to_owned(), score: 0.0 },
+            TestResult {
+                doc_id: "f1".to_owned(),
+                score: 0.0,
+            },
+            TestResult {
+                doc_id: "f2".to_owned(),
+                score: 0.0,
+            },
         ];
         let q2 = vec![
-            TestResult { doc_id: "f2".to_owned(), score: 0.0 },
-            TestResult { doc_id: "f3".to_owned(), score: 0.0 },
+            TestResult {
+                doc_id: "f2".to_owned(),
+                score: 0.0,
+            },
+            TestResult {
+                doc_id: "f3".to_owned(),
+                score: 0.0,
+            },
         ];
 
         let merged = rrf_merge(&[q1, q2], 60.0);
@@ -578,12 +584,24 @@ mod tests {
     #[test]
     fn rrf_merge_boosts_duplicate_results() {
         let q1 = vec![
-            TestResult { doc_id: "f1".to_owned(), score: 0.0 },
-            TestResult { doc_id: "f2".to_owned(), score: 0.0 },
+            TestResult {
+                doc_id: "f1".to_owned(),
+                score: 0.0,
+            },
+            TestResult {
+                doc_id: "f2".to_owned(),
+                score: 0.0,
+            },
         ];
         let q2 = vec![
-            TestResult { doc_id: "f1".to_owned(), score: 0.0 },
-            TestResult { doc_id: "f3".to_owned(), score: 0.0 },
+            TestResult {
+                doc_id: "f1".to_owned(),
+                score: 0.0,
+            },
+            TestResult {
+                doc_id: "f3".to_owned(),
+                score: 0.0,
+            },
         ];
 
         let merged = rrf_merge(&[q1, q2], 60.0);
@@ -602,8 +620,14 @@ mod tests {
     #[test]
     fn rrf_merge_single_query() {
         let q1 = vec![
-            TestResult { doc_id: "f1".to_owned(), score: 0.0 },
-            TestResult { doc_id: "f2".to_owned(), score: 0.0 },
+            TestResult {
+                doc_id: "f1".to_owned(),
+                score: 0.0,
+            },
+            TestResult {
+                doc_id: "f2".to_owned(),
+                score: 0.0,
+            },
         ];
 
         let merged = rrf_merge(&[q1], 60.0);
@@ -616,13 +640,28 @@ mod tests {
     #[test]
     fn rrf_merge_preserves_order_by_score() {
         let q1 = vec![
-            TestResult { doc_id: "f1".to_owned(), score: 0.0 },
-            TestResult { doc_id: "f2".to_owned(), score: 0.0 },
-            TestResult { doc_id: "f3".to_owned(), score: 0.0 },
+            TestResult {
+                doc_id: "f1".to_owned(),
+                score: 0.0,
+            },
+            TestResult {
+                doc_id: "f2".to_owned(),
+                score: 0.0,
+            },
+            TestResult {
+                doc_id: "f3".to_owned(),
+                score: 0.0,
+            },
         ];
         let q2 = vec![
-            TestResult { doc_id: "f3".to_owned(), score: 0.0 },
-            TestResult { doc_id: "f1".to_owned(), score: 0.0 },
+            TestResult {
+                doc_id: "f3".to_owned(),
+                score: 0.0,
+            },
+            TestResult {
+                doc_id: "f1".to_owned(),
+                score: 0.0,
+            },
         ];
 
         let merged = rrf_merge(&[q1, q2], 60.0);

--- a/crates/organon/src/builtins/filesystem.rs
+++ b/crates/organon/src/builtins/filesystem.rs
@@ -79,7 +79,7 @@ impl ToolExecutor for GrepExecutor {
             };
 
             let output = try_rg(pattern, &path, max_results, case_sensitive, glob_filter)
-                .or_else(|_| try_grep_fallback(pattern, &path, case_sensitive));
+                .or_else(|_| try_grep_fallback(pattern, &path, case_sensitive, glob_filter));
 
             match output {
                 Ok(out) => {
@@ -91,6 +91,10 @@ impl ToolExecutor for GrepExecutor {
                     }
 
                     let text = truncate_output(stdout);
+                    // Enforce the line limit in case the backend (grep fallback) doesn't
+                    // natively support --max-count.
+                    let n = usize::try_from(max_results).unwrap_or(usize::MAX);
+                    let text = text.lines().take(n).collect::<Vec<_>>().join("\n");
                     Ok(ToolResult::text(text))
                 }
                 Err(e) => Ok(ToolResult::error(format!("grep failed: {e}"))),
@@ -127,11 +131,15 @@ fn try_grep_fallback(
     pattern: &str,
     path: &Path,
     case_sensitive: bool,
+    glob_filter: Option<&str>,
 ) -> std::io::Result<std::process::Output> {
     let mut cmd = Command::new("grep");
     cmd.arg("-rn");
     if !case_sensitive {
         cmd.arg("-i");
+    }
+    if let Some(glob) = glob_filter {
+        cmd.arg(format!("--include={glob}"));
     }
     cmd.arg(pattern).arg(path);
     run_command(&mut cmd)
@@ -170,6 +178,10 @@ impl ToolExecutor for FindExecutor {
                         return Ok(ToolResult::text("No files found."));
                     }
                     let text = truncate_output(stdout);
+                    // Enforce the result limit in case the backend (find fallback) doesn't
+                    // natively support --max-results.
+                    let n = usize::try_from(max_results).unwrap_or(usize::MAX);
+                    let text = text.lines().take(n).collect::<Vec<_>>().join("\n");
                     Ok(ToolResult::text(text))
                 }
                 Err(e) => Ok(ToolResult::error(format!("find failed: {e}"))),
@@ -229,7 +241,16 @@ fn try_find_fallback(
         cmd.arg("-type").arg(t);
     }
 
-    cmd.arg("-name").arg(pattern);
+    // fd uses regex/substring matching by default; map to find's glob matching.
+    // Wrap plain strings in wildcards so "foo" matches "foo.rs", "myfoo", etc.
+    let name_pattern = if pattern.is_empty() || pattern == "." {
+        "*".to_owned()
+    } else if is_glob_pattern(pattern) {
+        pattern.to_owned()
+    } else {
+        format!("*{pattern}*")
+    };
+    cmd.arg("-name").arg(name_pattern);
     run_command(&mut cmd)
 }
 
@@ -744,5 +765,327 @@ mod tests {
             let tn = ToolName::new(name).expect("valid");
             assert!(reg.get_def(&tn).is_some(), "{name} should be registered");
         }
+    }
+
+    // -- Parameter validation -----------------------------------------------
+
+    #[tokio::test]
+    async fn test_grep_when_pattern_argument_missing_returns_error() {
+        let dir = tempfile::tempdir().expect("tmpdir");
+        let ctx = test_ctx(dir.path());
+        let input = tool_input("grep", serde_json::json!({}));
+        let err = GrepExecutor
+            .execute(&input, &ctx)
+            .await
+            .expect_err("missing pattern should error");
+        assert!(err.to_string().contains("missing or invalid field"));
+    }
+
+    #[tokio::test]
+    async fn test_find_when_pattern_argument_missing_returns_error() {
+        let dir = tempfile::tempdir().expect("tmpdir");
+        let ctx = test_ctx(dir.path());
+        let input = tool_input("find", serde_json::json!({}));
+        let err = FindExecutor
+            .execute(&input, &ctx)
+            .await
+            .expect_err("missing pattern should error");
+        assert!(err.to_string().contains("missing or invalid field"));
+    }
+
+    // -- Grep result formatting ---------------------------------------------
+
+    #[tokio::test]
+    async fn test_grep_max_results_limits_output_lines() {
+        let dir = tempfile::tempdir().expect("tmpdir");
+        let content = "match1\nmatch2\nmatch3\nmatch4\nmatch5\nmatch6\nmatch7\nmatch8\n\
+                       match9\nmatch10\nmatch11\nmatch12\nmatch13\nmatch14\nmatch15\nmatch16\n\
+                       match17\nmatch18\nmatch19\nmatch20\n"
+            .to_owned();
+        std::fs::write(dir.path().join("big.txt"), &content).expect("write");
+
+        let ctx = test_ctx(dir.path());
+        let input = tool_input(
+            "grep",
+            serde_json::json!({ "pattern": "match", "maxResults": 5 }),
+        );
+        let result = GrepExecutor.execute(&input, &ctx).await.expect("exec");
+        assert!(!result.is_error);
+        let text = result.content.text_summary();
+        let match_count = text.lines().count();
+        assert!(
+            match_count <= 5,
+            "expected at most 5 lines, got {match_count}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_grep_case_sensitive_does_not_match_wrong_case() {
+        let dir = tempfile::tempdir().expect("tmpdir");
+        std::fs::write(dir.path().join("f.txt"), "HELLO world").expect("write");
+
+        let ctx = test_ctx(dir.path());
+        let input = tool_input(
+            "grep",
+            serde_json::json!({ "pattern": "hello", "caseSensitive": true }),
+        );
+        let result = GrepExecutor.execute(&input, &ctx).await.expect("exec");
+        assert!(!result.is_error);
+        assert_eq!(
+            result.content.text_summary(),
+            "No matches found.",
+            "case-sensitive search should not match HELLO with hello"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_grep_returns_error_result_for_invalid_path_outside_roots() {
+        let dir = tempfile::tempdir().expect("tmpdir");
+        let ctx = test_ctx(dir.path());
+        let input = tool_input(
+            "grep",
+            serde_json::json!({ "pattern": "x", "path": "/root/secret" }),
+        );
+        let err = GrepExecutor
+            .execute(&input, &ctx)
+            .await
+            .expect_err("outside root should fail");
+        assert!(err.to_string().contains("outside allowed roots"));
+    }
+
+    // -- Find result formatting ---------------------------------------------
+
+    #[tokio::test]
+    async fn test_find_empty_results_returns_not_error_message() {
+        let dir = tempfile::tempdir().expect("tmpdir");
+        let ctx = test_ctx(dir.path());
+        let input = tool_input("find", serde_json::json!({ "pattern": "zzz_never_exists" }));
+        let result = FindExecutor.execute(&input, &ctx).await.expect("exec");
+        assert!(!result.is_error);
+        assert_eq!(result.content.text_summary(), "No files found.");
+    }
+
+    #[tokio::test]
+    async fn test_find_glob_extension_filter_matches_correctly() {
+        let dir = tempfile::tempdir().expect("tmpdir");
+        std::fs::write(dir.path().join("main.rs"), "").expect("write");
+        std::fs::write(dir.path().join("main.py"), "").expect("write");
+        std::fs::write(dir.path().join("lib.rs"), "").expect("write");
+
+        let ctx = test_ctx(dir.path());
+        let input = tool_input("find", serde_json::json!({ "pattern": "*.rs" }));
+        let result = FindExecutor.execute(&input, &ctx).await.expect("exec");
+        assert!(!result.is_error);
+        let text = result.content.text_summary();
+        assert!(text.contains(".rs"), "should find .rs files");
+    }
+
+    #[tokio::test]
+    async fn test_find_max_results_limits_output() {
+        let dir = tempfile::tempdir().expect("tmpdir");
+        for i in 0..10 {
+            std::fs::write(dir.path().join(format!("file{i}.txt")), "").expect("write");
+        }
+
+        let ctx = test_ctx(dir.path());
+        let input = tool_input(
+            "find",
+            serde_json::json!({ "pattern": "file", "maxResults": 3 }),
+        );
+        let result = FindExecutor.execute(&input, &ctx).await.expect("exec");
+        assert!(!result.is_error);
+        let text = result.content.text_summary();
+        let line_count = text.lines().count();
+        assert!(
+            line_count <= 3,
+            "expected at most 3 results, got {line_count}"
+        );
+    }
+
+    // -- Ls result formatting -----------------------------------------------
+
+    #[tokio::test]
+    async fn test_ls_nonexistent_directory_returns_error_result() {
+        let dir = tempfile::tempdir().expect("tmpdir");
+        let ctx = test_ctx(dir.path());
+        let input = tool_input(
+            "ls",
+            serde_json::json!({ "path": dir.path().join("ghost").to_string_lossy().as_ref() }),
+        );
+        let result = LsExecutor.execute(&input, &ctx).await.expect("exec");
+        assert!(result.is_error);
+        assert!(
+            result
+                .content
+                .text_summary()
+                .contains("cannot read directory")
+        );
+    }
+
+    #[tokio::test]
+    async fn test_ls_empty_directory_returns_descriptive_message() {
+        let dir = tempfile::tempdir().expect("tmpdir");
+        let ctx = test_ctx(dir.path());
+        let input = tool_input("ls", serde_json::json!({}));
+        let result = LsExecutor.execute(&input, &ctx).await.expect("exec");
+        assert!(!result.is_error);
+        assert_eq!(result.content.text_summary(), "Directory is empty.");
+    }
+
+    #[tokio::test]
+    async fn test_ls_output_includes_file_size() {
+        let dir = tempfile::tempdir().expect("tmpdir");
+        std::fs::write(dir.path().join("sized.txt"), "12345").expect("write");
+        let ctx = test_ctx(dir.path());
+        let input = tool_input("ls", serde_json::json!({}));
+        let result = LsExecutor.execute(&input, &ctx).await.expect("exec");
+        assert!(!result.is_error);
+        let text = result.content.text_summary();
+        assert!(text.contains('5'), "should show file size 5");
+    }
+
+    #[tokio::test]
+    async fn test_ls_output_includes_date_column() {
+        let dir = tempfile::tempdir().expect("tmpdir");
+        std::fs::write(dir.path().join("dated.txt"), "content").expect("write");
+        let ctx = test_ctx(dir.path());
+        let input = tool_input("ls", serde_json::json!({}));
+        let result = LsExecutor.execute(&input, &ctx).await.expect("exec");
+        assert!(!result.is_error);
+        let text = result.content.text_summary();
+        // Date format: YYYY-MM-DD HH:MM
+        assert!(text.contains('-'), "should show date with hyphens");
+        assert!(text.contains(':'), "should show time with colon");
+    }
+
+    #[tokio::test]
+    async fn test_ls_uses_workspace_when_path_not_specified() {
+        let dir = tempfile::tempdir().expect("tmpdir");
+        std::fs::write(dir.path().join("sentinel.txt"), "").expect("write");
+        let ctx = test_ctx(dir.path());
+        let input = tool_input("ls", serde_json::json!({}));
+        let result = LsExecutor.execute(&input, &ctx).await.expect("exec");
+        assert!(!result.is_error);
+        assert!(result.content.text_summary().contains("sentinel.txt"));
+    }
+
+    // -- Helper function unit tests -----------------------------------------
+
+    #[test]
+    fn test_is_glob_pattern_detects_star() {
+        assert!(is_glob_pattern("*.rs"));
+    }
+
+    #[test]
+    fn test_is_glob_pattern_detects_question_mark() {
+        assert!(is_glob_pattern("file?.txt"));
+    }
+
+    #[test]
+    fn test_is_glob_pattern_detects_brackets() {
+        assert!(is_glob_pattern("[abc]def"));
+    }
+
+    #[test]
+    fn test_is_glob_pattern_detects_braces() {
+        assert!(is_glob_pattern("{foo,bar}"));
+    }
+
+    #[test]
+    fn test_is_glob_pattern_returns_false_for_plain_word() {
+        assert!(!is_glob_pattern("hello"));
+        assert!(!is_glob_pattern("file.txt"));
+        assert!(!is_glob_pattern("some_identifier"));
+    }
+
+    #[test]
+    fn test_days_to_ymd_known_epoch_gives_1970_01_01() {
+        let (y, m, d) = days_to_ymd(0);
+        assert_eq!((y, m, d), (1970, 1, 1));
+    }
+
+    #[test]
+    fn test_days_to_ymd_365_days_gives_1971_01_01() {
+        // 1970 was not a leap year, so day 365 = Jan 1, 1971
+        let (y, m, d) = days_to_ymd(365);
+        assert_eq!((y, m, d), (1971, 1, 1));
+    }
+
+    #[test]
+    fn test_days_to_ymd_known_date_2000_01_01() {
+        // Days from 1970-01-01 to 2000-01-01 = 30 * 365 + 8 leap days = 10957
+        let (y, m, d) = days_to_ymd(10957);
+        assert_eq!((y, m, d), (2000, 1, 1));
+    }
+
+    #[test]
+    fn test_truncate_output_short_string_returned_unchanged() {
+        let short = "hello world".to_owned();
+        assert_eq!(truncate_output(short.clone()), short);
+    }
+
+    #[test]
+    fn test_truncate_output_long_string_appends_truncation_marker() {
+        let long = "x".repeat(MAX_OUTPUT_BYTES + 100);
+        let result = truncate_output(long);
+        assert!(
+            result.ends_with("[output truncated]"),
+            "should end with truncation marker"
+        );
+        assert!(
+            result.len() <= MAX_OUTPUT_BYTES + 20,
+            "truncated result should be close to limit"
+        );
+    }
+
+    #[test]
+    fn test_truncate_output_exactly_at_limit_unchanged() {
+        let exactly = "y".repeat(MAX_OUTPUT_BYTES);
+        let result = truncate_output(exactly.clone());
+        assert_eq!(result, exactly, "exactly at limit should be unchanged");
+    }
+
+    // -- Tool definition schema tests ---------------------------------------
+
+    #[test]
+    fn test_grep_def_has_pattern_as_required() {
+        let mut reg = crate::registry::ToolRegistry::new();
+        register(&mut reg).expect("register");
+        let tn = ToolName::new("grep").expect("valid");
+        let def = reg.get_def(&tn).expect("grep registered");
+        assert!(def.input_schema.required.contains(&"pattern".to_owned()));
+    }
+
+    #[test]
+    fn test_find_def_has_pattern_as_required() {
+        let mut reg = crate::registry::ToolRegistry::new();
+        register(&mut reg).expect("register");
+        let tn = ToolName::new("find").expect("valid");
+        let def = reg.get_def(&tn).expect("find registered");
+        assert!(def.input_schema.required.contains(&"pattern".to_owned()));
+    }
+
+    #[test]
+    fn test_ls_def_has_no_required_fields() {
+        let mut reg = crate::registry::ToolRegistry::new();
+        register(&mut reg).expect("register");
+        let tn = ToolName::new("ls").expect("valid");
+        let def = reg.get_def(&tn).expect("ls registered");
+        assert!(
+            def.input_schema.required.is_empty(),
+            "ls should have no required fields"
+        );
+    }
+
+    #[test]
+    fn test_find_def_type_field_has_enum_values() {
+        let mut reg = crate::registry::ToolRegistry::new();
+        register(&mut reg).expect("register");
+        let tn = ToolName::new("find").expect("valid");
+        let def = reg.get_def(&tn).expect("find registered");
+        let type_prop = def.input_schema.properties.get("type").expect("type prop");
+        let enum_vals = type_prop.enum_values.as_ref().expect("enum values");
+        assert!(enum_vals.contains(&"f".to_owned()));
+        assert!(enum_vals.contains(&"d".to_owned()));
     }
 }

--- a/crates/organon/src/builtins/workspace.rs
+++ b/crates/organon/src/builtins/workspace.rs
@@ -689,4 +689,368 @@ mod tests {
             .expect_err("should reject traversal");
         assert!(err.to_string().contains("outside allowed roots"));
     }
+
+    // -- Parameter validation -----------------------------------------------
+
+    #[tokio::test]
+    async fn test_read_when_path_argument_missing_returns_invalid_input_error() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let ctx = test_ctx(dir.path());
+        let input = tool_input("read", serde_json::json!({}));
+        let err = ReadExecutor
+            .execute(&input, &ctx)
+            .await
+            .expect_err("missing path should error");
+        assert!(
+            err.to_string().contains("missing or invalid field"),
+            "error: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_write_when_path_argument_missing_returns_error() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let ctx = test_ctx(dir.path());
+        let input = tool_input("write", serde_json::json!({ "content": "data" }));
+        let err = WriteExecutor
+            .execute(&input, &ctx)
+            .await
+            .expect_err("missing path should error");
+        assert!(err.to_string().contains("missing or invalid field"));
+    }
+
+    #[tokio::test]
+    async fn test_write_when_content_argument_missing_returns_error() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let ctx = test_ctx(dir.path());
+        let input = tool_input("write", serde_json::json!({ "path": "out.txt" }));
+        let err = WriteExecutor
+            .execute(&input, &ctx)
+            .await
+            .expect_err("missing content should error");
+        assert!(err.to_string().contains("missing or invalid field"));
+    }
+
+    #[tokio::test]
+    async fn test_edit_when_old_text_argument_missing_returns_error() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        std::fs::write(dir.path().join("f.txt"), "hello world").expect("write");
+        let ctx = test_ctx(dir.path());
+        let input = tool_input(
+            "edit",
+            serde_json::json!({ "path": "f.txt", "new_text": "bye" }),
+        );
+        let err = EditExecutor
+            .execute(&input, &ctx)
+            .await
+            .expect_err("missing old_text should error");
+        assert!(err.to_string().contains("missing or invalid field"));
+    }
+
+    #[tokio::test]
+    async fn test_exec_when_command_argument_missing_returns_error() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let ctx = test_ctx(dir.path());
+        let input = tool_input("exec", serde_json::json!({}));
+        let err = ExecExecutor
+            .execute(&input, &ctx)
+            .await
+            .expect_err("missing command should error");
+        assert!(err.to_string().contains("missing or invalid field"));
+    }
+
+    // -- Extra / unknown params handled gracefully --------------------------
+
+    #[tokio::test]
+    async fn test_read_ignores_unknown_extra_fields() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        std::fs::write(dir.path().join("hi.txt"), "hello").expect("write");
+        let ctx = test_ctx(dir.path());
+        let input = tool_input(
+            "read",
+            serde_json::json!({ "path": "hi.txt", "unknownField": "ignored" }),
+        );
+        let result = ReadExecutor.execute(&input, &ctx).await.expect("execute");
+        assert!(!result.is_error);
+        assert_eq!(result.content.text_summary(), "hello");
+    }
+
+    // -- Write result formatting --------------------------------------------
+
+    #[tokio::test]
+    async fn test_write_reports_byte_count_in_success_message() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let ctx = test_ctx(dir.path());
+        let input = tool_input(
+            "write",
+            serde_json::json!({ "path": "out.txt", "content": "hello" }),
+        );
+        let result = WriteExecutor.execute(&input, &ctx).await.expect("execute");
+        assert!(!result.is_error);
+        assert!(result.content.text_summary().contains("wrote 5 bytes"));
+    }
+
+    #[tokio::test]
+    async fn test_write_overwrite_replaces_existing_content() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        std::fs::write(dir.path().join("out.txt"), "old content").expect("write");
+        let ctx = test_ctx(dir.path());
+        let input = tool_input(
+            "write",
+            serde_json::json!({ "path": "out.txt", "content": "new content" }),
+        );
+        let result = WriteExecutor.execute(&input, &ctx).await.expect("execute");
+        assert!(!result.is_error);
+        let on_disk = std::fs::read_to_string(dir.path().join("out.txt")).expect("read");
+        assert_eq!(on_disk, "new content");
+    }
+
+    #[tokio::test]
+    async fn test_write_append_creates_file_when_absent() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let ctx = test_ctx(dir.path());
+        let input = tool_input(
+            "write",
+            serde_json::json!({ "path": "new.txt", "content": "data", "append": true }),
+        );
+        let result = WriteExecutor.execute(&input, &ctx).await.expect("execute");
+        assert!(!result.is_error);
+        let on_disk = std::fs::read_to_string(dir.path().join("new.txt")).expect("read");
+        assert_eq!(on_disk, "data");
+    }
+
+    // -- Edit result formatting ---------------------------------------------
+
+    #[tokio::test]
+    async fn test_edit_when_file_does_not_exist_returns_error_result() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let ctx = test_ctx(dir.path());
+        let input = tool_input(
+            "edit",
+            serde_json::json!({
+                "path": "nonexistent.txt",
+                "old_text": "x",
+                "new_text": "y"
+            }),
+        );
+        let result = EditExecutor.execute(&input, &ctx).await.expect("execute");
+        assert!(result.is_error);
+        assert!(result.content.text_summary().contains("file not found"));
+    }
+
+    #[tokio::test]
+    async fn test_edit_success_message_contains_path() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        std::fs::write(dir.path().join("code.rs"), "fn old_name() {}").expect("write");
+        let ctx = test_ctx(dir.path());
+        let input = tool_input(
+            "edit",
+            serde_json::json!({
+                "path": "code.rs",
+                "old_text": "old_name",
+                "new_text": "new_name"
+            }),
+        );
+        let result = EditExecutor.execute(&input, &ctx).await.expect("execute");
+        assert!(!result.is_error);
+        let text = result.content.text_summary();
+        assert!(text.contains("code.rs"), "message should mention path");
+    }
+
+    #[tokio::test]
+    async fn test_edit_preserves_surrounding_content() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let original = "line1\nTARGET\nline3\n";
+        std::fs::write(dir.path().join("f.txt"), original).expect("write");
+        let ctx = test_ctx(dir.path());
+        let input = tool_input(
+            "edit",
+            serde_json::json!({
+                "path": "f.txt",
+                "old_text": "TARGET",
+                "new_text": "REPLACED"
+            }),
+        );
+        let result = EditExecutor.execute(&input, &ctx).await.expect("execute");
+        assert!(!result.is_error);
+        let on_disk = std::fs::read_to_string(dir.path().join("f.txt")).expect("read");
+        assert_eq!(on_disk, "line1\nREPLACED\nline3\n");
+    }
+
+    // -- Exec result formatting ---------------------------------------------
+
+    #[tokio::test]
+    async fn test_exec_failed_command_reports_nonzero_exit_code() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let ctx = test_ctx(dir.path());
+        let input = tool_input("exec", serde_json::json!({ "command": "exit 42" }));
+        let result = ExecExecutor.execute(&input, &ctx).await.expect("execute");
+        assert!(!result.is_error);
+        assert!(result.content.text_summary().contains("exit=42"));
+    }
+
+    #[tokio::test]
+    async fn test_exec_stderr_captured_in_output() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let ctx = test_ctx(dir.path());
+        let input = tool_input("exec", serde_json::json!({ "command": "echo errline >&2" }));
+        let result = ExecExecutor.execute(&input, &ctx).await.expect("execute");
+        assert!(!result.is_error);
+        assert!(result.content.text_summary().contains("errline"));
+    }
+
+    #[tokio::test]
+    async fn test_exec_working_directory_is_workspace() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let ctx = test_ctx(dir.path());
+        let input = tool_input("exec", serde_json::json!({ "command": "pwd" }));
+        let result = ExecExecutor.execute(&input, &ctx).await.expect("execute");
+        assert!(!result.is_error);
+        let text = result.content.text_summary();
+        let canonical = dir.path().canonicalize().expect("canon");
+        assert!(
+            text.contains(canonical.to_string_lossy().as_ref()),
+            "pwd should show workspace: {text}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_exec_output_format_includes_exit_then_stdout_then_stderr() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let ctx = test_ctx(dir.path());
+        let input = tool_input(
+            "exec",
+            serde_json::json!({ "command": "printf 'out'; echo err >&2" }),
+        );
+        let result = ExecExecutor.execute(&input, &ctx).await.expect("execute");
+        assert!(!result.is_error);
+        let text = result.content.text_summary();
+        let exit_pos = text.find("exit=0").expect("exit marker");
+        let out_pos = text.find("out").expect("stdout");
+        assert!(exit_pos < out_pos, "exit code should precede stdout");
+    }
+
+    // -- Helper functions ---------------------------------------------------
+
+    #[test]
+    fn test_validate_path_empty_string_returns_error() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let name = aletheia_koina::id::ToolName::new("read").expect("valid");
+        let ctx = test_ctx(dir.path());
+        let err = validate_path("", &ctx, &name).expect_err("empty path should fail");
+        assert!(err.to_string().contains("path must not be empty"));
+    }
+
+    #[test]
+    fn test_validate_path_relative_resolves_inside_workspace() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let name = aletheia_koina::id::ToolName::new("read").expect("valid");
+        let ctx = test_ctx(dir.path());
+        let resolved = validate_path("sub/file.txt", &ctx, &name).expect("valid relative path");
+        assert!(resolved.starts_with(dir.path()));
+        assert!(resolved.ends_with("sub/file.txt"));
+    }
+
+    #[test]
+    fn test_validate_path_rejects_absolute_outside_allowed_roots() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let name = aletheia_koina::id::ToolName::new("read").expect("valid");
+        let ctx = test_ctx(dir.path());
+        let err = validate_path("/etc/shadow", &ctx, &name).expect_err("outside roots");
+        assert!(err.to_string().contains("outside allowed roots"));
+    }
+
+    #[test]
+    fn test_normalize_removes_parent_dir_traversal() {
+        let input = Path::new("/a/b/../c");
+        let result = normalize(input);
+        assert_eq!(result, Path::new("/a/c"));
+    }
+
+    #[test]
+    fn test_normalize_removes_current_dir_component() {
+        let input = Path::new("/a/./b/./c");
+        let result = normalize(input);
+        assert_eq!(result, Path::new("/a/b/c"));
+    }
+
+    #[test]
+    fn test_normalize_handles_multiple_parent_traversals() {
+        let input = Path::new("/a/b/c/../../d");
+        let result = normalize(input);
+        assert_eq!(result, Path::new("/a/d"));
+    }
+
+    #[test]
+    fn test_extract_str_missing_field_returns_invalid_input_error() {
+        use aletheia_koina::id::ToolName;
+        let name = ToolName::new("test").expect("valid");
+        let args = serde_json::json!({ "other": "value" });
+        let err = extract_str(&args, "path", &name).expect_err("missing should fail");
+        assert!(err.to_string().contains("missing or invalid field: path"));
+    }
+
+    #[test]
+    fn test_extract_str_non_string_value_returns_error() {
+        use aletheia_koina::id::ToolName;
+        let name = ToolName::new("test").expect("valid");
+        let args = serde_json::json!({ "path": 42 });
+        let err = extract_str(&args, "path", &name).expect_err("wrong type should fail");
+        assert!(err.to_string().contains("missing or invalid field: path"));
+    }
+
+    #[test]
+    fn test_extract_opt_u64_returns_none_when_field_absent() {
+        let args = serde_json::json!({});
+        assert_eq!(extract_opt_u64(&args, "maxLines"), None);
+    }
+
+    #[test]
+    fn test_extract_opt_u64_returns_value_when_field_present() {
+        let args = serde_json::json!({ "maxLines": 42 });
+        assert_eq!(extract_opt_u64(&args, "maxLines"), Some(42));
+    }
+
+    #[test]
+    fn test_extract_opt_bool_returns_none_when_field_absent() {
+        let args = serde_json::json!({});
+        assert_eq!(extract_opt_bool(&args, "append"), None);
+    }
+
+    #[test]
+    fn test_extract_opt_bool_returns_value_when_field_present() {
+        let args = serde_json::json!({ "append": true });
+        assert_eq!(extract_opt_bool(&args, "append"), Some(true));
+    }
+
+    // -- Tool registration --------------------------------------------------
+
+    #[tokio::test]
+    async fn test_all_workspace_tools_registered() {
+        let mut reg = crate::registry::ToolRegistry::new();
+        register(&mut reg).expect("register");
+        for name in ["read", "write", "edit", "exec"] {
+            let tn = aletheia_koina::id::ToolName::new(name).expect("valid");
+            assert!(reg.get_def(&tn).is_some(), "{name} should be registered");
+        }
+    }
+
+    #[test]
+    fn test_read_tool_def_has_path_as_required() {
+        let mut reg = crate::registry::ToolRegistry::new();
+        register(&mut reg).expect("register");
+        let tn = aletheia_koina::id::ToolName::new("read").expect("valid");
+        let def = reg.get_def(&tn).expect("read registered");
+        assert!(def.input_schema.required.contains(&"path".to_owned()));
+    }
+
+    #[test]
+    fn test_write_tool_def_has_path_and_content_as_required() {
+        let mut reg = crate::registry::ToolRegistry::new();
+        register(&mut reg).expect("register");
+        let tn = aletheia_koina::id::ToolName::new("write").expect("valid");
+        let def = reg.get_def(&tn).expect("write registered");
+        assert!(def.input_schema.required.contains(&"path".to_owned()));
+        assert!(def.input_schema.required.contains(&"content".to_owned()));
+    }
 }

--- a/crates/organon/src/error.rs
+++ b/crates/organon/src/error.rs
@@ -53,3 +53,120 @@ pub enum Error {
 
 /// Convenience alias.
 pub type Result<T> = std::result::Result<T, Error>;
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+    use std::sync::{Arc, RwLock};
+
+    use aletheia_koina::id::{NousId, SessionId, ToolName};
+    use indexmap::IndexMap;
+
+    use crate::registry::ToolRegistry;
+    use crate::types::{InputSchema, ToolCategory, ToolContext, ToolDef, ToolInput};
+
+    fn test_def(name: &str) -> ToolDef {
+        ToolDef {
+            name: ToolName::new(name).expect("valid"),
+            description: "test".to_owned(),
+            extended_description: None,
+            input_schema: InputSchema {
+                properties: IndexMap::new(),
+                required: vec![],
+            },
+            category: ToolCategory::Workspace,
+            auto_activate: false,
+        }
+    }
+
+    fn test_ctx() -> ToolContext {
+        ToolContext {
+            nous_id: NousId::new("test-agent").expect("valid"),
+            session_id: SessionId::new(),
+            workspace: std::path::PathBuf::from("/tmp"),
+            allowed_roots: vec![std::path::PathBuf::from("/tmp")],
+            services: None,
+            active_tools: Arc::new(RwLock::new(HashSet::new())),
+        }
+    }
+
+    #[test]
+    fn test_error_tool_not_found_message_contains_name() {
+        let mut reg = ToolRegistry::new();
+        reg.register(test_def("present"), {
+            use std::future::Future;
+            use std::pin::Pin;
+            struct Noop;
+            impl crate::registry::ToolExecutor for Noop {
+                fn execute<'a>(
+                    &'a self,
+                    _: &'a ToolInput,
+                    _: &'a ToolContext,
+                ) -> Pin<
+                    Box<
+                        dyn Future<Output = crate::error::Result<crate::types::ToolResult>>
+                            + Send
+                            + 'a,
+                    >,
+                > {
+                    Box::pin(async { Ok(crate::types::ToolResult::text("ok")) })
+                }
+            }
+            Box::new(Noop)
+        })
+        .expect("register");
+
+        let msg = reg
+            .get_def(&ToolName::new("missing_tool").expect("valid"))
+            .is_none();
+        assert!(msg, "missing_tool should not be found");
+    }
+
+    #[tokio::test]
+    async fn test_error_tool_not_found_message_format() {
+        let reg = ToolRegistry::new();
+        let input = ToolInput {
+            name: ToolName::new("missing_tool").expect("valid"),
+            tool_use_id: "toolu_x".to_owned(),
+            arguments: serde_json::json!({}),
+        };
+        let err = reg
+            .execute(&input, &test_ctx())
+            .await
+            .expect_err("should fail");
+        assert!(
+            err.to_string().contains("tool not found: missing_tool"),
+            "err: {err}"
+        );
+    }
+
+    #[test]
+    fn test_error_duplicate_tool_message_format() {
+        use std::future::Future;
+        use std::pin::Pin;
+        struct Noop;
+        impl crate::registry::ToolExecutor for Noop {
+            fn execute<'a>(
+                &'a self,
+                _: &'a ToolInput,
+                _: &'a ToolContext,
+            ) -> Pin<
+                Box<
+                    dyn Future<Output = crate::error::Result<crate::types::ToolResult>> + Send + 'a,
+                >,
+            > {
+                Box::pin(async { Ok(crate::types::ToolResult::text("ok")) })
+            }
+        }
+        let mut reg = ToolRegistry::new();
+        reg.register(test_def("same_name"), Box::new(Noop))
+            .expect("first register");
+        let err = reg
+            .register(test_def("same_name"), Box::new(Noop))
+            .expect_err("duplicate");
+        assert!(
+            err.to_string().contains("duplicate tool: same_name"),
+            "err: {err}"
+        );
+    }
+}

--- a/crates/organon/src/registry.rs
+++ b/crates/organon/src/registry.rs
@@ -509,6 +509,177 @@ mod tests {
         assert_eq!(tools[0].name, "enable_tool");
     }
 
+    // -- Additional registry tests ------------------------------------------
+
+    #[test]
+    fn test_registry_new_has_no_definitions() {
+        let reg = ToolRegistry::new();
+        assert!(reg.definitions().is_empty());
+    }
+
+    #[test]
+    fn test_registry_default_is_same_as_new() {
+        let reg1 = ToolRegistry::new();
+        let reg2 = ToolRegistry::default();
+        assert_eq!(reg1.definitions().len(), reg2.definitions().len());
+    }
+
+    #[test]
+    fn test_definitions_preserves_insertion_order() {
+        let mut reg = ToolRegistry::new();
+        let (e1, _) = mock_executor("ok");
+        let (e2, _) = mock_executor("ok");
+        let (e3, _) = mock_executor("ok");
+        reg.register(test_def("alpha", ToolCategory::Workspace), e1)
+            .expect("register");
+        reg.register(test_def("beta", ToolCategory::Workspace), e2)
+            .expect("register");
+        reg.register(test_def("gamma", ToolCategory::Workspace), e3)
+            .expect("register");
+
+        let names: Vec<&str> = reg.definitions().iter().map(|d| d.name.as_str()).collect();
+        assert_eq!(names, ["alpha", "beta", "gamma"]);
+    }
+
+    #[test]
+    fn test_to_hermeneus_tools_schema_includes_required_fields() {
+        let mut reg = ToolRegistry::new();
+        let (exec, _) = mock_executor("ok");
+        let def = ToolDef {
+            name: ToolName::new("read").expect("valid"),
+            description: "Read a file".to_owned(),
+            extended_description: None,
+            input_schema: InputSchema {
+                properties: IndexMap::from([(
+                    "path".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::String,
+                        description: "File path".to_owned(),
+                        enum_values: None,
+                        default: None,
+                    },
+                )]),
+                required: vec!["path".to_owned()],
+            },
+            category: ToolCategory::Workspace,
+            auto_activate: false,
+        };
+        reg.register(def, exec).expect("register");
+        let tools = reg.to_hermeneus_tools();
+        let schema = &tools[0].input_schema;
+        assert_eq!(schema["required"][0], "path");
+    }
+
+    #[test]
+    fn test_to_hermeneus_tools_schema_includes_enum_values() {
+        let mut reg = ToolRegistry::new();
+        let (exec, _) = mock_executor("ok");
+        let def = ToolDef {
+            name: ToolName::new("find").expect("valid"),
+            description: "Find files".to_owned(),
+            extended_description: None,
+            input_schema: InputSchema {
+                properties: IndexMap::from([(
+                    "type".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::String,
+                        description: "Type filter".to_owned(),
+                        enum_values: Some(vec!["f".to_owned(), "d".to_owned()]),
+                        default: None,
+                    },
+                )]),
+                required: vec![],
+            },
+            category: ToolCategory::Workspace,
+            auto_activate: false,
+        };
+        reg.register(def, exec).expect("register");
+        let tools = reg.to_hermeneus_tools();
+        let schema = &tools[0].input_schema;
+        let enum_vals = &schema["properties"]["type"]["enum"];
+        assert_eq!(enum_vals[0], "f");
+        assert_eq!(enum_vals[1], "d");
+    }
+
+    #[test]
+    fn test_to_hermeneus_tools_schema_includes_default_values() {
+        let mut reg = ToolRegistry::new();
+        let (exec, _) = mock_executor("ok");
+        let def = ToolDef {
+            name: ToolName::new("grep").expect("valid"),
+            description: "Grep".to_owned(),
+            extended_description: None,
+            input_schema: InputSchema {
+                properties: IndexMap::from([(
+                    "caseSensitive".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::Boolean,
+                        description: "Case sensitive".to_owned(),
+                        enum_values: None,
+                        default: Some(serde_json::json!(true)),
+                    },
+                )]),
+                required: vec![],
+            },
+            category: ToolCategory::Workspace,
+            auto_activate: false,
+        };
+        reg.register(def, exec).expect("register");
+        let tools = reg.to_hermeneus_tools();
+        let schema = &tools[0].input_schema;
+        assert_eq!(schema["properties"]["caseSensitive"]["default"], true);
+    }
+
+    #[test]
+    fn test_lazy_catalog_includes_description() {
+        let mut reg = ToolRegistry::new();
+        let (exec, _) = mock_executor("ok");
+        reg.register(
+            ToolDef {
+                name: ToolName::new("web_search").expect("valid"),
+                description: "Search the web".to_owned(),
+                extended_description: None,
+                input_schema: InputSchema {
+                    properties: IndexMap::new(),
+                    required: vec![],
+                },
+                category: ToolCategory::Research,
+                auto_activate: false,
+            },
+            exec,
+        )
+        .expect("register");
+
+        let catalog = reg.lazy_tool_catalog();
+        assert_eq!(catalog.len(), 1);
+        assert_eq!(catalog[0].1, "Search the web");
+    }
+
+    #[test]
+    fn test_definitions_for_category_returns_empty_when_no_match() {
+        let mut reg = ToolRegistry::new();
+        let (e1, _) = mock_executor("ok");
+        reg.register(test_def("read", ToolCategory::Workspace), e1)
+            .expect("register");
+        let planning = reg.definitions_for_category(ToolCategory::Planning);
+        assert!(planning.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_execute_unknown_tool_returns_tool_not_found_error() {
+        let reg = ToolRegistry::new();
+        let input = ToolInput {
+            name: ToolName::new("ghost").expect("valid"),
+            tool_use_id: "toolu_x".to_owned(),
+            arguments: serde_json::json!({}),
+        };
+        let err = reg
+            .execute(&input, &test_ctx())
+            .await
+            .expect_err("not found");
+        assert!(err.to_string().contains("tool not found: ghost"));
+    }
+
     #[test]
     fn lazy_tool_catalog_excludes_auto_activate_and_enable_tool() {
         let mut reg = ToolRegistry::new();

--- a/crates/organon/src/types.rs
+++ b/crates/organon/src/types.rs
@@ -714,4 +714,140 @@ mod tests {
         assert_eq!(r.content.text_summary(), "desc");
         assert!(!r.is_error);
     }
+
+    // -- Additional types tests ---------------------------------------------
+
+    #[test]
+    fn test_input_schema_enum_values_serialized_in_json_schema() {
+        let schema = InputSchema {
+            properties: IndexMap::from([(
+                "type".to_owned(),
+                PropertyDef {
+                    property_type: PropertyType::String,
+                    description: "Type".to_owned(),
+                    enum_values: Some(vec!["a".to_owned(), "b".to_owned()]),
+                    default: None,
+                },
+            )]),
+            required: vec![],
+        };
+        let json = schema.to_json_schema();
+        assert_eq!(json["properties"]["type"]["enum"][0], "a");
+        assert_eq!(json["properties"]["type"]["enum"][1], "b");
+    }
+
+    #[test]
+    fn test_input_schema_with_no_required_fields_has_empty_required_array() {
+        let schema = InputSchema {
+            properties: IndexMap::new(),
+            required: vec![],
+        };
+        let json = schema.to_json_schema();
+        let required = json["required"].as_array().expect("array");
+        assert!(required.is_empty());
+    }
+
+    #[test]
+    fn test_property_type_display_all_variants() {
+        assert_eq!(PropertyType::String.to_string(), "string");
+        assert_eq!(PropertyType::Number.to_string(), "number");
+        assert_eq!(PropertyType::Integer.to_string(), "integer");
+        assert_eq!(PropertyType::Boolean.to_string(), "boolean");
+        assert_eq!(PropertyType::Array.to_string(), "array");
+        assert_eq!(PropertyType::Object.to_string(), "object");
+    }
+
+    #[test]
+    fn test_tool_category_all_categories_have_display() {
+        let cases = [
+            (ToolCategory::Workspace, "workspace"),
+            (ToolCategory::Memory, "memory"),
+            (ToolCategory::Communication, "communication"),
+            (ToolCategory::Planning, "planning"),
+            (ToolCategory::System, "system"),
+            (ToolCategory::Agent, "agent"),
+            (ToolCategory::Research, "research"),
+            (ToolCategory::Domain, "domain"),
+        ];
+        for (cat, expected) in cases {
+            assert_eq!(cat.to_string(), expected);
+        }
+    }
+
+    #[test]
+    fn test_tool_stats_initial_state_all_zeros() {
+        let stats = ToolStats::default();
+        assert_eq!(stats.total_calls, 0);
+        assert_eq!(stats.total_duration_ms, 0);
+        assert_eq!(stats.error_count, 0);
+        assert!(stats.calls_by_tool.is_empty());
+    }
+
+    #[test]
+    fn test_tool_stats_zero_errors_when_all_calls_succeed() {
+        let mut stats = ToolStats::default();
+        stats.record("read", 10, false);
+        stats.record("write", 20, false);
+        assert_eq!(stats.error_count, 0);
+    }
+
+    #[test]
+    fn test_tool_stats_top_tools_returns_empty_when_no_calls() {
+        let stats = ToolStats::default();
+        assert!(stats.top_tools(5).is_empty());
+    }
+
+    #[test]
+    fn test_tool_stats_top_tools_limited_to_n() {
+        let mut stats = ToolStats::default();
+        for name in ["a", "b", "c", "d", "e"] {
+            stats.record(name, 1, false);
+        }
+        let top = stats.top_tools(3);
+        assert_eq!(top.len(), 3);
+    }
+
+    #[test]
+    fn test_tool_result_text_is_not_error() {
+        let r = ToolResult::text("ok");
+        assert!(!r.is_error);
+    }
+
+    #[test]
+    fn test_tool_result_error_is_error() {
+        let r = ToolResult::error("bad");
+        assert!(r.is_error);
+    }
+
+    #[test]
+    fn test_tool_result_blocks_is_not_error() {
+        let r = ToolResult::blocks(vec![]);
+        assert!(!r.is_error);
+    }
+
+    #[test]
+    fn test_tool_def_auto_activate_stored_correctly() {
+        let def = ToolDef {
+            name: ToolName::new("t").expect("valid"),
+            description: "d".to_owned(),
+            extended_description: None,
+            input_schema: InputSchema {
+                properties: IndexMap::new(),
+                required: vec![],
+            },
+            category: ToolCategory::Workspace,
+            auto_activate: true,
+        };
+        assert!(def.auto_activate);
+    }
+
+    #[test]
+    fn test_input_schema_type_is_object_in_json_schema() {
+        let schema = InputSchema {
+            properties: IndexMap::new(),
+            required: vec![],
+        };
+        let json = schema.to_json_schema();
+        assert_eq!(json["type"], "object");
+    }
 }


### PR DESCRIPTION
## Summary

- Adds 84 new tests across filesystem, workspace, registry, types, and error modules (124 → 208 total)
- Fixes 4 pre-existing test failures caused by `rg`/`fd` not being system binaries
- Fixes 3 bugs in executor fallback behavior discovered while writing tests

## Bug Fixes

**grep glob fallback** (`filesystem.rs`): `try_grep_fallback` didn't accept `glob_filter`, so glob filtering was silently dropped when `rg` was unavailable. Fixed by passing `--include=<glob>` to GNU grep.

**grep/find max-results enforcement** (`filesystem.rs`): `maxResults` was only enforced by the native tool flags (`rg --max-count`, `fd --max-results`). When fallback commands run, the limit wasn't applied. Fixed with Rust-side post-processing that trims output to `n` lines regardless of backend.

**find pattern matching** (`filesystem.rs`): `try_find_fallback` used `find -name <pattern>` with exact matching, while `fd` uses substring/regex matching by default. Bare patterns like `"app"` wouldn't find `app.rs`. Fixed by wrapping non-glob patterns in `*...*`.

## New Test Coverage

| Area | Tests Added |
|------|-------------|
| Parameter validation | missing required fields → `InvalidInput` error for all executors |
| Exec formatting | stderr capture, non-zero exit codes, workspace cwd, output ordering |
| Write/Edit formatting | byte count, overwrite, append, edit message, surrounding content preserved |
| Helper functions | `validate_path`, `normalize`, `extract_str`, `extract_opt_*` |
| Filesystem helpers | `is_glob_pattern`, `days_to_ymd`, `truncate_output` |
| Tool definitions | required fields, enum values, schema shape per tool |
| Registry | insertion order, hermeneus schema serialization, lazy catalog |
| Types | all `PropertyType`/`ToolCategory` Display variants, `ToolStats` |
| Error | tool-not-found and duplicate-tool message format |

## Test plan

- [x] `cargo fmt --all --check` passes
- [x] `cargo clippy -p aletheia-organon --all-targets -- -D warnings` passes
- [x] `cargo test -p aletheia-organon` passes (208 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)