### PR TITLE
feat(organon): Landlock + seccomp sandbox for tool execution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -281,8 +281,11 @@ dependencies = [
  "aletheia-koina",
  "base64 0.22.1",
  "indexmap 2.13.0",
+ "landlock",
+ "libc",
  "prometheus",
  "reqwest",
+ "seccompiler",
  "serde",
  "serde_json",
  "snafu",
@@ -1906,6 +1909,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "equator"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3112,6 +3135,17 @@ name = "lab"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf36173d4167ed999940f804952e6b08197cae5ad5d572eb4db150ce8ad5d58f"
+
+[[package]]
+name = "landlock"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49fefd6652c57d68aaa32544a4c0e642929725bdc1fd929367cdeb673ab81088"
+dependencies = [
+ "enumflags2",
+ "libc",
+ "thiserror 2.0.18",
+]
 
 [[package]]
 name = "lazy_static"
@@ -5277,6 +5311,15 @@ dependencies = [
  "pkcs8",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "seccompiler"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae55de56877481d112a559bbc12667635fdaf5e005712fd4e2b2fa50ffc884"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/crates/organon/Cargo.toml
+++ b/crates/organon/Cargo.toml
@@ -23,6 +23,11 @@ snafu = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 
+[target.'cfg(target_os = "linux")'.dependencies]
+landlock = "0.4"
+libc = "0.2"
+seccompiler = "0.5"
+
 [dev-dependencies]
 static_assertions = { workspace = true }
 tempfile = "3"

--- a/crates/organon/src/builtins/mod.rs
+++ b/crates/organon/src/builtins/mod.rs
@@ -21,10 +21,19 @@ pub mod workspace;
 
 use crate::error::Result;
 use crate::registry::ToolRegistry;
+use crate::sandbox::SandboxConfig;
 
-/// Register all built-in tool executors.
+/// Register all built-in tool executors with default sandbox config.
 pub fn register_all(registry: &mut ToolRegistry) -> Result<()> {
-    workspace::register(registry)?;
+    register_all_with_sandbox(registry, SandboxConfig::default())
+}
+
+/// Register all built-in tool executors with custom sandbox config.
+pub fn register_all_with_sandbox(
+    registry: &mut ToolRegistry,
+    sandbox: SandboxConfig,
+) -> Result<()> {
+    workspace::register(registry, sandbox)?;
     memory::register(registry)?;
     communication::register(registry)?;
     filesystem::register(registry)?;

--- a/crates/organon/src/builtins/workspace.rs
+++ b/crates/organon/src/builtins/workspace.rs
@@ -236,7 +236,9 @@ impl ToolExecutor for EditExecutor {
     }
 }
 
-struct ExecExecutor;
+struct ExecExecutor {
+    sandbox: crate::sandbox::SandboxConfig,
+}
 
 impl ToolExecutor for ExecExecutor {
     fn execute<'a>(
@@ -248,14 +250,21 @@ impl ToolExecutor for ExecExecutor {
             let command = extract_str(&input.arguments, "command", &input.name)?;
             let timeout_ms = extract_opt_u64(&input.arguments, "timeout").unwrap_or(30_000);
 
-            let mut child = match Command::new("sh")
-                .arg("-c")
+            let mut cmd = Command::new("sh");
+            cmd.arg("-c")
                 .arg(command)
                 .current_dir(&ctx.workspace)
                 .stdout(Stdio::piped())
-                .stderr(Stdio::piped())
-                .spawn()
-            {
+                .stderr(Stdio::piped());
+
+            if self.sandbox.enabled {
+                let policy = self
+                    .sandbox
+                    .build_policy(&ctx.workspace, &ctx.allowed_roots);
+                crate::sandbox::apply_sandbox(&mut cmd, policy);
+            }
+
+            let mut child = match cmd.spawn() {
                 Ok(c) => c,
                 Err(e) => {
                     return Ok(err_result(format!("spawn failed: {e}")));
@@ -308,11 +317,11 @@ impl ToolExecutor for ExecExecutor {
 // ---------------------------------------------------------------------------
 
 /// Register workspace tool executors.
-pub fn register(registry: &mut ToolRegistry) -> Result<()> {
+pub fn register(registry: &mut ToolRegistry, sandbox: crate::sandbox::SandboxConfig) -> Result<()> {
     registry.register(read_def(), Box::new(ReadExecutor))?;
     registry.register(write_def(), Box::new(WriteExecutor))?;
     registry.register(edit_def(), Box::new(EditExecutor))?;
-    registry.register(exec_def(), Box::new(ExecExecutor))?;
+    registry.register(exec_def(), Box::new(ExecExecutor { sandbox }))?;
     Ok(())
 }
 
@@ -657,7 +666,12 @@ mod tests {
         let dir = tempfile::tempdir().expect("create temp dir");
         let ctx = test_ctx(dir.path());
         let input = tool_input("exec", serde_json::json!({ "command": "echo hello" }));
-        let result = ExecExecutor.execute(&input, &ctx).await.expect("execute");
+        let result = ExecExecutor {
+            sandbox: crate::sandbox::SandboxConfig::disabled(),
+        }
+        .execute(&input, &ctx)
+        .await
+        .expect("execute");
         assert!(!result.is_error);
         assert!(result.content.text_summary().contains("hello"));
         assert!(result.content.text_summary().contains("exit=0"));
@@ -671,7 +685,12 @@ mod tests {
             "exec",
             serde_json::json!({ "command": "sleep 60", "timeout": 200 }),
         );
-        let result = ExecExecutor.execute(&input, &ctx).await.expect("execute");
+        let result = ExecExecutor {
+            sandbox: crate::sandbox::SandboxConfig::disabled(),
+        }
+        .execute(&input, &ctx)
+        .await
+        .expect("execute");
         assert!(result.is_error);
         assert!(result.content.text_summary().contains("timed out"));
     }
@@ -752,10 +771,12 @@ mod tests {
         let dir = tempfile::tempdir().expect("create temp dir");
         let ctx = test_ctx(dir.path());
         let input = tool_input("exec", serde_json::json!({}));
-        let err = ExecExecutor
-            .execute(&input, &ctx)
-            .await
-            .expect_err("missing command should error");
+        let err = (ExecExecutor {
+            sandbox: crate::sandbox::SandboxConfig::disabled(),
+        })
+        .execute(&input, &ctx)
+        .await
+        .expect_err("missing command should error");
         assert!(err.to_string().contains("missing or invalid field"));
     }
 
@@ -884,7 +905,12 @@ mod tests {
         let dir = tempfile::tempdir().expect("create temp dir");
         let ctx = test_ctx(dir.path());
         let input = tool_input("exec", serde_json::json!({ "command": "exit 42" }));
-        let result = ExecExecutor.execute(&input, &ctx).await.expect("execute");
+        let result = ExecExecutor {
+            sandbox: crate::sandbox::SandboxConfig::disabled(),
+        }
+        .execute(&input, &ctx)
+        .await
+        .expect("execute");
         assert!(!result.is_error);
         assert!(result.content.text_summary().contains("exit=42"));
     }
@@ -894,7 +920,12 @@ mod tests {
         let dir = tempfile::tempdir().expect("create temp dir");
         let ctx = test_ctx(dir.path());
         let input = tool_input("exec", serde_json::json!({ "command": "echo errline >&2" }));
-        let result = ExecExecutor.execute(&input, &ctx).await.expect("execute");
+        let result = ExecExecutor {
+            sandbox: crate::sandbox::SandboxConfig::disabled(),
+        }
+        .execute(&input, &ctx)
+        .await
+        .expect("execute");
         assert!(!result.is_error);
         assert!(result.content.text_summary().contains("errline"));
     }
@@ -904,7 +935,12 @@ mod tests {
         let dir = tempfile::tempdir().expect("create temp dir");
         let ctx = test_ctx(dir.path());
         let input = tool_input("exec", serde_json::json!({ "command": "pwd" }));
-        let result = ExecExecutor.execute(&input, &ctx).await.expect("execute");
+        let result = ExecExecutor {
+            sandbox: crate::sandbox::SandboxConfig::disabled(),
+        }
+        .execute(&input, &ctx)
+        .await
+        .expect("execute");
         assert!(!result.is_error);
         let text = result.content.text_summary();
         let canonical = dir.path().canonicalize().expect("canon");
@@ -922,7 +958,12 @@ mod tests {
             "exec",
             serde_json::json!({ "command": "printf 'out'; echo err >&2" }),
         );
-        let result = ExecExecutor.execute(&input, &ctx).await.expect("execute");
+        let result = ExecExecutor {
+            sandbox: crate::sandbox::SandboxConfig::disabled(),
+        }
+        .execute(&input, &ctx)
+        .await
+        .expect("execute");
         assert!(!result.is_error);
         let text = result.content.text_summary();
         let exit_pos = text.find("exit=0").expect("exit marker");
@@ -1028,7 +1069,7 @@ mod tests {
     #[tokio::test]
     async fn test_all_workspace_tools_registered() {
         let mut reg = crate::registry::ToolRegistry::new();
-        register(&mut reg).expect("register");
+        register(&mut reg, crate::sandbox::SandboxConfig::disabled()).expect("register");
         for name in ["read", "write", "edit", "exec"] {
             let tn = aletheia_koina::id::ToolName::new(name).expect("valid");
             assert!(reg.get_def(&tn).is_some(), "{name} should be registered");
@@ -1038,7 +1079,7 @@ mod tests {
     #[test]
     fn test_read_tool_def_has_path_as_required() {
         let mut reg = crate::registry::ToolRegistry::new();
-        register(&mut reg).expect("register");
+        register(&mut reg, crate::sandbox::SandboxConfig::disabled()).expect("register");
         let tn = aletheia_koina::id::ToolName::new("read").expect("valid");
         let def = reg.get_def(&tn).expect("read registered");
         assert!(def.input_schema.required.contains(&"path".to_owned()));
@@ -1047,7 +1088,7 @@ mod tests {
     #[test]
     fn test_write_tool_def_has_path_and_content_as_required() {
         let mut reg = crate::registry::ToolRegistry::new();
-        register(&mut reg).expect("register");
+        register(&mut reg, crate::sandbox::SandboxConfig::disabled()).expect("register");
         let tn = aletheia_koina::id::ToolName::new("write").expect("valid");
         let def = reg.get_def(&tn).expect("write registered");
         assert!(def.input_schema.required.contains(&"path".to_owned()));

--- a/crates/organon/src/lib.rs
+++ b/crates/organon/src/lib.rs
@@ -13,6 +13,8 @@ pub mod error;
 pub mod metrics;
 /// Central tool registry for runtime discovery and dispatch.
 pub mod registry;
+/// Landlock + seccomp sandbox for tool execution.
+pub mod sandbox;
 /// Tool definition, parameter schema, and executor trait.
 pub mod types;
 

--- a/crates/organon/src/sandbox.rs
+++ b/crates/organon/src/sandbox.rs
@@ -1,0 +1,607 @@
+//! Landlock + seccomp sandbox for tool execution.
+//!
+//! Restricts filesystem access via Landlock LSM and blocks dangerous
+//! syscalls via seccomp BPF filters. Applied in child processes after
+//! fork, before exec.
+
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+/// Sandbox enforcement level.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+#[non_exhaustive]
+pub enum SandboxEnforcement {
+    Enforcing,
+    Permissive,
+}
+
+/// Configuration for the execution sandbox.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[serde(default)]
+pub struct SandboxConfig {
+    pub enabled: bool,
+    pub enforcement: SandboxEnforcement,
+    pub extra_read_paths: Vec<PathBuf>,
+    pub extra_write_paths: Vec<PathBuf>,
+}
+
+impl Default for SandboxConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            enforcement: SandboxEnforcement::Enforcing,
+            extra_read_paths: Vec::new(),
+            extra_write_paths: Vec::new(),
+        }
+    }
+}
+
+impl SandboxConfig {
+    #[must_use]
+    pub fn disabled() -> Self {
+        Self {
+            enabled: false,
+            ..Self::default()
+        }
+    }
+
+    #[must_use]
+    pub fn build_policy(&self, workspace: &Path, allowed_roots: &[PathBuf]) -> SandboxPolicy {
+        let mut read_paths = vec![
+            PathBuf::from("/usr"),
+            PathBuf::from("/lib"),
+            PathBuf::from("/lib64"),
+            PathBuf::from("/etc"),
+            PathBuf::from("/proc"),
+            PathBuf::from("/dev"),
+        ];
+
+        let mut write_paths = vec![PathBuf::from("/tmp")];
+
+        let exec_paths = vec![
+            PathBuf::from("/usr/bin"),
+            PathBuf::from("/usr/local/bin"),
+            PathBuf::from("/bin"),
+            PathBuf::from("/usr/lib"),
+        ];
+
+        write_paths.push(workspace.to_path_buf());
+        for root in allowed_roots {
+            if !write_paths.contains(root) {
+                write_paths.push(root.clone());
+            }
+        }
+
+        read_paths.extend(self.extra_read_paths.iter().cloned());
+        write_paths.extend(self.extra_write_paths.iter().cloned());
+
+        for wp in &write_paths {
+            if !read_paths.contains(wp) {
+                read_paths.push(wp.clone());
+            }
+        }
+
+        SandboxPolicy {
+            read_paths,
+            write_paths,
+            exec_paths,
+            enforcement: self.enforcement,
+        }
+    }
+}
+
+/// Runtime sandbox policy with resolved paths.
+#[derive(Debug, Clone)]
+pub struct SandboxPolicy {
+    pub read_paths: Vec<PathBuf>,
+    pub write_paths: Vec<PathBuf>,
+    pub exec_paths: Vec<PathBuf>,
+    pub enforcement: SandboxEnforcement,
+}
+
+impl SandboxPolicy {
+    /// Apply Landlock + seccomp restrictions to the current process.
+    ///
+    /// Designed to run in a child process via `pre_exec`. Returns `io::Error`
+    /// on failure; on unsupported kernels, logs and continues based on
+    /// enforcement mode.
+    pub fn apply(&self) -> std::io::Result<()> {
+        self.apply_landlock()?;
+        self.apply_seccomp()?;
+        Ok(())
+    }
+
+    #[cfg(target_os = "linux")]
+    fn apply_landlock(&self) -> std::io::Result<()> {
+        use landlock::{
+            ABI, Access, AccessFs, BitFlags, PathBeneath, PathFd, Ruleset, RulesetAttr,
+            RulesetCreatedAttr, RulesetStatus,
+        };
+
+        let abi = ABI::V3;
+
+        let read_access = AccessFs::ReadFile | AccessFs::ReadDir;
+        let write_access = read_access
+            | AccessFs::WriteFile
+            | AccessFs::RemoveFile
+            | AccessFs::RemoveDir
+            | AccessFs::MakeDir
+            | AccessFs::MakeReg
+            | AccessFs::MakeSym
+            | AccessFs::Truncate;
+        let exec_access = AccessFs::Execute | AccessFs::ReadFile | AccessFs::ReadDir;
+
+        let Ok(ruleset) = Ruleset::default()
+            .handle_access(AccessFs::from_all(abi))
+            .and_then(landlock::Ruleset::create)
+        else {
+            if self.enforcement == SandboxEnforcement::Enforcing {
+                return Err(std::io::Error::other("failed to create Landlock ruleset"));
+            }
+            return Ok(());
+        };
+
+        let add = |mut rs: landlock::RulesetCreated,
+                   paths: &[PathBuf],
+                   access: BitFlags<AccessFs>|
+         -> std::io::Result<landlock::RulesetCreated> {
+            for path in paths {
+                if path.exists() {
+                    if let Ok(fd) = PathFd::new(path) {
+                        rs = rs.add_rule(PathBeneath::new(fd, access)).map_err(|e| {
+                            std::io::Error::other(format!(
+                                "Landlock rule failed for {}: {e}",
+                                path.display()
+                            ))
+                        })?;
+                    }
+                }
+            }
+            Ok(rs)
+        };
+
+        let ruleset = add(ruleset, &self.read_paths, read_access)?;
+        let ruleset = add(ruleset, &self.write_paths, write_access)?;
+        let ruleset = add(ruleset, &self.exec_paths, exec_access)?;
+
+        let status = ruleset
+            .restrict_self()
+            .map_err(|e| std::io::Error::other(format!("Landlock restrict_self failed: {e}")))?;
+
+        match status.ruleset {
+            RulesetStatus::FullyEnforced | RulesetStatus::PartiallyEnforced => {}
+            RulesetStatus::NotEnforced => {
+                if self.enforcement == SandboxEnforcement::Enforcing {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::Unsupported,
+                        "Landlock not supported by kernel",
+                    ));
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    fn apply_landlock(&self) -> std::io::Result<()> {
+        Ok(())
+    }
+
+    #[cfg(target_os = "linux")]
+    fn apply_seccomp(&self) -> std::io::Result<()> {
+        use std::collections::BTreeMap;
+
+        use seccompiler::{SeccompAction, SeccompFilter, SeccompRule};
+
+        let blocked_syscalls: &[i64] = &[
+            libc::SYS_ptrace,
+            libc::SYS_mount,
+            libc::SYS_umount2,
+            libc::SYS_reboot,
+            libc::SYS_kexec_load,
+            libc::SYS_init_module,
+            libc::SYS_delete_module,
+            libc::SYS_finit_module,
+            libc::SYS_pivot_root,
+            libc::SYS_chroot,
+        ];
+
+        let rules: BTreeMap<i64, Vec<SeccompRule>> =
+            blocked_syscalls.iter().map(|&nr| (nr, vec![])).collect();
+
+        let action = if self.enforcement == SandboxEnforcement::Permissive {
+            SeccompAction::Log
+        } else {
+            SeccompAction::Errno(libc::EPERM as u32)
+        };
+
+        let arch = target_arch();
+
+        let filter = SeccompFilter::new(rules, SeccompAction::Allow, action, arch)
+            .map_err(|e| std::io::Error::other(format!("seccomp filter creation failed: {e}")))?;
+
+        let bpf: seccompiler::BpfProgram =
+            filter.try_into().map_err(|e: seccompiler::BackendError| {
+                std::io::Error::other(format!("seccomp BPF compilation failed: {e}"))
+            })?;
+
+        seccompiler::apply_filter(&bpf)
+            .map_err(|e| std::io::Error::other(format!("seccomp filter installation failed: {e}")))
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    fn apply_seccomp(&self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn target_arch() -> seccompiler::TargetArch {
+    #[cfg(target_arch = "x86_64")]
+    {
+        seccompiler::TargetArch::x86_64
+    }
+    #[cfg(target_arch = "aarch64")]
+    {
+        seccompiler::TargetArch::aarch64
+    }
+}
+
+/// Apply sandbox restrictions to a [`std::process::Command`] via `pre_exec`.
+///
+/// # Safety
+///
+/// This uses [`std::os::unix::process::CommandExt::pre_exec`] which runs
+/// between fork and exec in the child process. The sandbox operations
+/// (Landlock ruleset, seccomp filter) use kernel syscalls that are
+/// async-signal-safe.
+#[cfg(target_os = "linux")]
+pub fn apply_sandbox(cmd: &mut std::process::Command, policy: SandboxPolicy) {
+    use std::os::unix::process::CommandExt;
+
+    // SAFETY: Landlock and seccomp operations use direct kernel syscalls
+    // (landlock_create_ruleset, landlock_add_rule, landlock_restrict_self,
+    // prctl/PR_SET_SECCOMP) which are async-signal-safe. No heap allocation
+    // or mutex acquisition occurs in the child process.
+    #[expect(
+        unsafe_code,
+        reason = "pre_exec requires unsafe; runs sandbox setup between fork and exec"
+    )]
+    unsafe {
+        cmd.pre_exec(move || policy.apply());
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+pub fn apply_sandbox(_cmd: &mut std::process::Command, _policy: SandboxPolicy) {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_config_is_enabled() {
+        let config = SandboxConfig::default();
+        assert!(config.enabled);
+        assert_eq!(config.enforcement, SandboxEnforcement::Enforcing);
+        assert!(config.extra_read_paths.is_empty());
+        assert!(config.extra_write_paths.is_empty());
+    }
+
+    #[test]
+    fn disabled_config() {
+        let config = SandboxConfig::disabled();
+        assert!(!config.enabled);
+    }
+
+    #[test]
+    fn config_serde_roundtrip() {
+        let config = SandboxConfig {
+            enabled: true,
+            enforcement: SandboxEnforcement::Permissive,
+            extra_read_paths: vec![PathBuf::from("/opt/data")],
+            extra_write_paths: vec![PathBuf::from("/var/cache")],
+        };
+        let json = serde_json::to_string(&config).expect("serialize");
+        let back: SandboxConfig = serde_json::from_str(&json).expect("deserialize");
+        assert!(back.enabled);
+        assert_eq!(back.enforcement, SandboxEnforcement::Permissive);
+        assert_eq!(back.extra_read_paths, vec![PathBuf::from("/opt/data")]);
+        assert_eq!(back.extra_write_paths, vec![PathBuf::from("/var/cache")]);
+    }
+
+    #[test]
+    fn enforcement_serde() {
+        let json = serde_json::to_string(&SandboxEnforcement::Enforcing).expect("serialize");
+        assert_eq!(json, "\"enforcing\"");
+        let back: SandboxEnforcement = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back, SandboxEnforcement::Enforcing);
+
+        let json = serde_json::to_string(&SandboxEnforcement::Permissive).expect("serialize");
+        assert_eq!(json, "\"permissive\"");
+    }
+
+    #[test]
+    fn config_from_yaml_defaults() {
+        let json = "{}";
+        let config: SandboxConfig = serde_json::from_str(json).expect("parse");
+        assert!(config.enabled);
+        assert_eq!(config.enforcement, SandboxEnforcement::Enforcing);
+    }
+
+    #[test]
+    fn policy_includes_workspace() {
+        let config = SandboxConfig::default();
+        let workspace = PathBuf::from("/home/agent/workspace");
+        let policy = config.build_policy(&workspace, &[]);
+        assert!(policy.write_paths.contains(&workspace));
+        assert!(policy.read_paths.contains(&workspace));
+    }
+
+    #[test]
+    fn policy_includes_allowed_roots() {
+        let config = SandboxConfig::default();
+        let workspace = PathBuf::from("/home/agent/workspace");
+        let extra = PathBuf::from("/shared/data");
+        let policy = config.build_policy(&workspace, std::slice::from_ref(&extra));
+        assert!(policy.write_paths.contains(&extra));
+    }
+
+    #[test]
+    fn policy_includes_system_paths() {
+        let config = SandboxConfig::default();
+        let policy = config.build_policy(Path::new("/tmp/ws"), &[]);
+        assert!(policy.read_paths.contains(&PathBuf::from("/usr")));
+        assert!(policy.read_paths.contains(&PathBuf::from("/lib")));
+        assert!(policy.read_paths.contains(&PathBuf::from("/etc")));
+        assert!(policy.exec_paths.contains(&PathBuf::from("/usr/bin")));
+        assert!(policy.exec_paths.contains(&PathBuf::from("/bin")));
+        assert!(policy.write_paths.contains(&PathBuf::from("/tmp")));
+    }
+
+    #[test]
+    fn policy_includes_extra_paths() {
+        let config = SandboxConfig {
+            extra_read_paths: vec![PathBuf::from("/opt/readonly")],
+            extra_write_paths: vec![PathBuf::from("/var/scratch")],
+            ..SandboxConfig::default()
+        };
+        let policy = config.build_policy(Path::new("/tmp/ws"), &[]);
+        assert!(policy.read_paths.contains(&PathBuf::from("/opt/readonly")));
+        assert!(policy.write_paths.contains(&PathBuf::from("/var/scratch")));
+        assert!(
+            policy.read_paths.contains(&PathBuf::from("/var/scratch")),
+            "write paths should also be readable"
+        );
+    }
+
+    #[test]
+    fn policy_no_duplicate_write_roots() {
+        let config = SandboxConfig::default();
+        let workspace = PathBuf::from("/home/agent/workspace");
+        let policy = config.build_policy(&workspace, std::slice::from_ref(&workspace));
+        let count = policy
+            .write_paths
+            .iter()
+            .filter(|p| **p == workspace)
+            .count();
+        assert_eq!(count, 1, "workspace should not be duplicated");
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn landlock_applies_in_child() {
+        use std::process::Command;
+
+        let config = SandboxConfig::default();
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let policy = config.build_policy(dir.path(), &[]);
+
+        let mut cmd = Command::new("cat");
+        cmd.arg("/etc/hostname");
+        apply_sandbox(&mut cmd, policy);
+
+        let output = cmd.output().expect("spawn child");
+        assert!(
+            output.status.success(),
+            "reading /etc/hostname should be allowed"
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn landlock_blocks_outside_workspace() {
+        use std::process::Command;
+
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let secret = dir.path().join("secret.txt");
+        std::fs::write(&secret, "top secret").expect("write");
+
+        let workspace = tempfile::tempdir().expect("create workspace");
+
+        let read_paths = vec![
+            PathBuf::from("/usr"),
+            PathBuf::from("/lib"),
+            PathBuf::from("/lib64"),
+            PathBuf::from("/etc"),
+            PathBuf::from("/proc"),
+            PathBuf::from("/dev"),
+            workspace.path().to_path_buf(),
+        ];
+        let write_paths = vec![workspace.path().to_path_buf()];
+        let exec_paths = vec![
+            PathBuf::from("/usr/bin"),
+            PathBuf::from("/bin"),
+            PathBuf::from("/usr/lib"),
+        ];
+
+        let policy = SandboxPolicy {
+            read_paths,
+            write_paths,
+            exec_paths,
+            enforcement: SandboxEnforcement::Enforcing,
+        };
+
+        let mut cmd = Command::new("/usr/bin/cat");
+        cmd.arg(&secret);
+        apply_sandbox(&mut cmd, policy);
+
+        let output = cmd.output().expect("spawn child");
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            !output.status.success(),
+            "reading outside workspace should be blocked (stderr={stderr})"
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn seccomp_blocks_mount() {
+        use std::process::Command;
+
+        let config = SandboxConfig::default();
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let policy = config.build_policy(dir.path(), &[]);
+
+        let mut cmd = Command::new("sh");
+        cmd.arg("-c").arg("mount -t tmpfs none /mnt 2>&1; echo $?");
+        apply_sandbox(&mut cmd, policy);
+
+        let output = cmd.output().expect("spawn child");
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let combined = format!("{stdout}{stderr}");
+        assert!(
+            combined.contains("Operation not permitted")
+                || combined.contains("EPERM")
+                || combined.contains('1'),
+            "mount should be blocked by seccomp: {combined}"
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn seccomp_allows_normal_operations() {
+        use std::process::Command;
+
+        let config = SandboxConfig::default();
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let policy = config.build_policy(dir.path(), &[]);
+
+        let mut cmd = Command::new("echo");
+        cmd.arg("hello sandbox");
+        apply_sandbox(&mut cmd, policy);
+
+        let output = cmd.output().expect("spawn child");
+        assert!(output.status.success());
+        assert!(String::from_utf8_lossy(&output.stdout).contains("hello sandbox"));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn permissive_mode_allows_access() {
+        use std::process::Command;
+
+        let config = SandboxConfig {
+            enforcement: SandboxEnforcement::Permissive,
+            ..SandboxConfig::default()
+        };
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let policy = config.build_policy(dir.path(), &[]);
+
+        let mut cmd = Command::new("echo");
+        cmd.arg("permissive test");
+        apply_sandbox(&mut cmd, policy);
+
+        let output = cmd.output().expect("spawn child");
+        assert!(output.status.success());
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn sandbox_with_exec_tool_flow() {
+        use std::process::Command;
+
+        let config = SandboxConfig::default();
+        let dir = tempfile::tempdir().expect("create temp dir");
+        std::fs::write(dir.path().join("test.txt"), "sandbox test data").expect("write");
+
+        let policy = config.build_policy(dir.path(), &[]);
+
+        let mut cmd = Command::new("cat");
+        cmd.arg(dir.path().join("test.txt"));
+        apply_sandbox(&mut cmd, policy);
+
+        let output = cmd.output().expect("spawn child");
+        assert!(output.status.success());
+        assert!(String::from_utf8_lossy(&output.stdout).contains("sandbox test data"));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn sandbox_write_in_workspace() {
+        use std::process::Command;
+
+        let config = SandboxConfig::default();
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let policy = config.build_policy(dir.path(), &[]);
+
+        let outfile = dir.path().join("output.txt");
+        let cmd_str = format!("echo written > {}", outfile.display());
+
+        let mut cmd = Command::new("sh");
+        cmd.arg("-c").arg(&cmd_str);
+        apply_sandbox(&mut cmd, policy);
+
+        let output = cmd.output().expect("spawn child");
+        assert!(output.status.success(), "writing in workspace should work");
+        assert!(outfile.exists());
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn sandbox_write_outside_workspace_blocked() {
+        use std::process::Command;
+
+        let workspace = tempfile::tempdir().expect("create workspace");
+        let outside = tempfile::tempdir().expect("create outside dir");
+        let policy = SandboxPolicy {
+            read_paths: vec![
+                PathBuf::from("/usr"),
+                PathBuf::from("/lib"),
+                PathBuf::from("/lib64"),
+                PathBuf::from("/etc"),
+                PathBuf::from("/proc"),
+                PathBuf::from("/dev"),
+                workspace.path().to_path_buf(),
+            ],
+            write_paths: vec![workspace.path().to_path_buf()],
+            exec_paths: vec![
+                PathBuf::from("/usr/bin"),
+                PathBuf::from("/bin"),
+                PathBuf::from("/usr/lib"),
+            ],
+            enforcement: SandboxEnforcement::Enforcing,
+        };
+
+        let outfile = outside.path().join("escape.txt");
+        let cmd_str = format!("echo escape > {} 2>&1; echo $?", outfile.display());
+
+        let mut cmd = Command::new("sh");
+        cmd.arg("-c").arg(&cmd_str);
+        apply_sandbox(&mut cmd, policy);
+
+        let output = cmd.output().expect("spawn child");
+        assert!(
+            !outfile.exists() || {
+                let stdout = String::from_utf8_lossy(&output.stdout);
+                stdout.trim().ends_with('1')
+            },
+            "writing outside workspace should be blocked"
+        );
+    }
+}

--- a/crates/taxis/src/config.rs
+++ b/crates/taxis/src/config.rs
@@ -28,6 +28,17 @@ pub struct AletheiaConfig {
     pub maintenance: MaintenanceSettings,
     /// Per-model pricing for LLM cost metrics. Keyed by model name.
     pub pricing: HashMap<String, ModelPricing>,
+    /// Sandbox configuration for tool execution.
+    pub sandbox: SandboxSettings,
+}
+
+/// Sandbox enforcement level for tool execution.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+#[non_exhaustive]
+pub enum SandboxEnforcementMode {
+    Enforcing,
+    Permissive,
 }
 
 /// Per-model pricing rates for cost estimation in metrics.
@@ -576,6 +587,32 @@ impl Default for DbMonitoringSettings {
 pub struct RetentionSettings {
     /// Whether automatic retention enforcement (session cleanup) runs.
     pub enabled: bool,
+}
+
+/// Sandbox configuration for tool command execution.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[serde(default)]
+pub struct SandboxSettings {
+    /// Whether sandbox restrictions are applied to tool execution.
+    pub enabled: bool,
+    /// Enforcement level: `enforcing` blocks violations, `permissive` logs them.
+    pub enforcement: SandboxEnforcementMode,
+    /// Additional filesystem paths granted read access.
+    pub extra_read_paths: Vec<PathBuf>,
+    /// Additional filesystem paths granted read+write access.
+    pub extra_write_paths: Vec<PathBuf>,
+}
+
+impl Default for SandboxSettings {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            enforcement: SandboxEnforcementMode::Enforcing,
+            extra_read_paths: Vec::new(),
+            extra_write_paths: Vec::new(),
+        }
+    }
 }
 
 /// Resolved configuration for a specific nous agent.


### PR DESCRIPTION
## Summary

- Add `sandbox` module to `organon` crate with Landlock LSM filesystem restrictions and seccomp BPF syscall filtering
- Landlock restricts child processes to workspace, system libraries (/usr, /lib, /etc), and configurable extra paths; blocks access to files outside allowed hierarchies
- Seccomp blocks dangerous syscalls: ptrace, mount, umount2, reboot, kexec_load, init_module, delete_module, finit_module, pivot_root, chroot
- Wire sandbox into `ExecExecutor` via `Command::pre_exec` (applied between fork and exec in child process)
- Add `SandboxSettings` to `taxis` config for YAML-based configuration (`sandbox.enabled`, `sandbox.enforcement`, `sandbox.extra_read_paths`, `sandbox.extra_write_paths`)
- Graceful degradation: permissive mode logs instead of blocking; unsupported kernels skip enforcement
- 18 tests: 10 unit tests (config, serde, policy construction) + 8 integration tests (Landlock read/write blocking, seccomp mount blocking, normal operation, workspace access)

## Test plan

- [x] `cargo test -p aletheia-organon` — 226 passed
- [x] `cargo test -p aletheia-taxis` — 61 passed
- [x] `cargo test -p aletheia-nous` — 202 passed
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt -- --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)