### PR TITLE
chore(dokimion): eval infrastructure cleanup

### DIFF
--- a/crates/eval/src/client.rs
+++ b/crates/eval/src/client.rs
@@ -1,6 +1,6 @@
 //! HTTP client for interacting with a running Aletheia instance.
 
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use snafu::ResultExt;
 use tracing::instrument;
 
@@ -246,11 +246,50 @@ impl EvalClient {
     }
 }
 
+// --- Typed domain enums ---
+
+/// Status reported by the `/api/health` endpoint.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "lowercase")]
+#[non_exhaustive]
+pub enum InstanceStatus {
+    Healthy,
+    Degraded,
+    /// Catch-all for future or unexpected status strings.
+    #[serde(untagged)]
+    Unknown(String),
+}
+
+/// Lifecycle status of a session.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "lowercase")]
+#[non_exhaustive]
+pub enum SessionStatus {
+    Active,
+    Archived,
+    /// Catch-all for future or unexpected status strings.
+    #[serde(untagged)]
+    Unknown(String),
+}
+
+/// Role of a message in conversation history.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "lowercase")]
+#[non_exhaustive]
+pub enum MessageRole {
+    User,
+    Assistant,
+    Tool,
+    /// Catch-all for future or unexpected role strings.
+    #[serde(untagged)]
+    Unknown(String),
+}
+
 // --- Response types (local mirrors, no pylon dependency) ---
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct HealthResponse {
-    pub status: String,
+    pub status: InstanceStatus,
     pub version: String,
     pub uptime_seconds: u64,
     pub checks: Vec<HealthCheck>,
@@ -296,7 +335,7 @@ pub struct SessionResponse {
     pub id: String,
     pub nous_id: String,
     pub session_key: String,
-    pub status: String,
+    pub status: SessionStatus,
     pub model: Option<String>,
     pub message_count: i64,
     pub token_count_estimate: i64,
@@ -313,7 +352,7 @@ pub struct HistoryResponse {
 pub struct HistoryMessage {
     pub id: i64,
     pub seq: i64,
-    pub role: String,
+    pub role: MessageRole,
     pub content: String,
     pub tool_call_id: Option<String>,
     pub tool_name: Option<String>,
@@ -369,5 +408,70 @@ mod tests {
         let client = EvalClient::new("http://localhost", Some("secret-token".to_owned()));
         assert!(client.has_token());
         assert_eq!(client.base_url(), "http://localhost");
+    }
+
+    #[test]
+    fn instance_status_deserializes_healthy() {
+        let status: InstanceStatus = serde_json::from_str("\"healthy\"").expect("deserialize");
+        assert_eq!(status, InstanceStatus::Healthy);
+    }
+
+    #[test]
+    fn instance_status_deserializes_degraded() {
+        let status: InstanceStatus = serde_json::from_str("\"degraded\"").expect("deserialize");
+        assert_eq!(status, InstanceStatus::Degraded);
+    }
+
+    #[test]
+    fn instance_status_deserializes_unknown() {
+        let status: InstanceStatus = serde_json::from_str("\"starting\"").expect("deserialize");
+        assert!(matches!(status, InstanceStatus::Unknown(_)));
+    }
+
+    #[test]
+    fn session_status_roundtrip() {
+        let cases = [
+            (SessionStatus::Active, "\"active\""),
+            (SessionStatus::Archived, "\"archived\""),
+        ];
+        for (variant, expected_json) in &cases {
+            let json = serde_json::to_string(variant).expect("serialize");
+            assert_eq!(json, *expected_json);
+            let back: SessionStatus = serde_json::from_str(&json).expect("deserialize");
+            assert_eq!(&back, variant);
+        }
+    }
+
+    #[test]
+    fn session_status_unknown_passthrough() {
+        let status: SessionStatus = serde_json::from_str("\"suspended\"").expect("deserialize");
+        assert!(matches!(status, SessionStatus::Unknown(_)));
+        if let SessionStatus::Unknown(s) = status {
+            assert_eq!(s, "suspended");
+        }
+    }
+
+    #[test]
+    fn message_role_roundtrip() {
+        let cases = [
+            (MessageRole::User, "\"user\""),
+            (MessageRole::Assistant, "\"assistant\""),
+            (MessageRole::Tool, "\"tool\""),
+        ];
+        for (variant, expected_json) in &cases {
+            let json = serde_json::to_string(variant).expect("serialize");
+            assert_eq!(json, *expected_json);
+            let back: MessageRole = serde_json::from_str(&json).expect("deserialize");
+            assert_eq!(&back, variant);
+        }
+    }
+
+    #[test]
+    fn message_role_unknown_passthrough() {
+        let role: MessageRole = serde_json::from_str("\"system\"").expect("deserialize");
+        assert!(matches!(role, MessageRole::Unknown(_)));
+        if let MessageRole::Unknown(s) = role {
+            assert_eq!(s, "system");
+        }
     }
 }

--- a/crates/eval/src/report.rs
+++ b/crates/eval/src/report.rs
@@ -107,9 +107,9 @@ pub fn print_report_json(report: &RunReport) {
                 id: r.meta.id.to_owned(),
                 category: r.meta.category.to_owned(),
                 outcome: match &r.outcome {
-                    ScenarioOutcome::Passed { .. } => "passed".to_owned(),
-                    ScenarioOutcome::Failed { .. } => "failed".to_owned(),
-                    ScenarioOutcome::Skipped { .. } => "skipped".to_owned(),
+                    ScenarioOutcome::Passed { .. } => OutcomeKind::Passed,
+                    ScenarioOutcome::Failed { .. } => OutcomeKind::Failed,
+                    ScenarioOutcome::Skipped { .. } => OutcomeKind::Skipped,
                 },
                 duration_ms: match &r.outcome {
                     ScenarioOutcome::Passed { duration }
@@ -130,9 +130,19 @@ pub fn print_report_json(report: &RunReport) {
             .collect(),
     };
 
-    if let Ok(json) = serde_json::to_string_pretty(&json_report) {
-        println!("{json}");
+    match serde_json::to_string_pretty(&json_report) {
+        Ok(json) => println!("{json}"),
+        Err(e) => tracing::error!(error = %e, "failed to serialize eval report as JSON"),
     }
+}
+
+/// Typed outcome kind for JSON serialization — avoids bare "passed"/"failed"/"skipped" strings.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum OutcomeKind {
+    Passed,
+    Failed,
+    Skipped,
 }
 
 #[derive(Serialize)]
@@ -148,7 +158,7 @@ struct JsonReport {
 struct JsonScenarioResult {
     id: String,
     category: String,
-    outcome: String,
+    outcome: OutcomeKind,
     duration_ms: Option<u64>,
     error: Option<String>,
     skip_reason: Option<String>,
@@ -227,7 +237,7 @@ mod tests {
             results: vec![JsonScenarioResult {
                 id: "health-ok".to_owned(),
                 category: "health".to_owned(),
-                outcome: "passed".to_owned(),
+                outcome: OutcomeKind::Passed,
                 duration_ms: Some(50),
                 error: None,
                 skip_reason: None,
@@ -240,5 +250,28 @@ mod tests {
         assert!(json.contains("\"total_duration_ms\""));
         assert!(json.contains("\"results\""));
         assert!(json.contains("health-ok"));
+    }
+
+    #[test]
+    fn outcome_kind_serializes_to_lowercase_string() {
+        assert_eq!(
+            serde_json::to_string(&OutcomeKind::Passed).expect("serialize"),
+            "\"passed\""
+        );
+        assert_eq!(
+            serde_json::to_string(&OutcomeKind::Failed).expect("serialize"),
+            "\"failed\""
+        );
+        assert_eq!(
+            serde_json::to_string(&OutcomeKind::Skipped).expect("serialize"),
+            "\"skipped\""
+        );
+    }
+
+    #[test]
+    fn outcome_kind_equality() {
+        assert_eq!(OutcomeKind::Passed, OutcomeKind::Passed);
+        assert_ne!(OutcomeKind::Passed, OutcomeKind::Failed);
+        assert_ne!(OutcomeKind::Failed, OutcomeKind::Skipped);
     }
 }

--- a/crates/eval/src/scenarios/conversation.rs
+++ b/crates/eval/src/scenarios/conversation.rs
@@ -2,7 +2,7 @@
 
 use tracing::Instrument;
 
-use crate::client::EvalClient;
+use crate::client::{EvalClient, MessageRole};
 use crate::scenario::{Scenario, ScenarioFuture, ScenarioMeta, assert_eval};
 use crate::sse;
 
@@ -14,17 +14,6 @@ pub fn scenarios() -> Vec<Box<dyn Scenario>> {
         Box::new(ConversationMultiTurn),
         Box::new(ConversationEmptyRejected),
     ]
-}
-
-fn unique_key(suffix: &str) -> String {
-    format!(
-        "eval-conv-{}-{}",
-        suffix,
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_millis()
-    )
 }
 
 struct ConversationSendSse;
@@ -43,7 +32,7 @@ impl Scenario for ConversationSendSse {
             async move {
                 let nous_list = client.list_nous().await?;
                 let nous_id = &nous_list[0].id;
-                let key = unique_key("sse");
+                let key = super::unique_key("conv", "sse");
                 let session = client.create_session(nous_id, &key).await?;
                 let events = client
                     .send_message(&session.id, "Hello, this is an eval test.")
@@ -82,7 +71,7 @@ impl Scenario for ConversationHistoryReflects {
             async move {
                 let nous_list = client.list_nous().await?;
                 let nous_id = &nous_list[0].id;
-                let key = unique_key("history");
+                let key = super::unique_key("conv", "history");
                 let session = client.create_session(nous_id, &key).await?;
                 let _ = client
                     .send_message(&session.id, "Eval history test message.")
@@ -96,16 +85,16 @@ impl Scenario for ConversationHistoryReflects {
                     ),
                 )?;
                 assert_eval(
-                    history.messages[0].role == "user",
+                    history.messages[0].role == MessageRole::User,
                     format!(
-                        "first message should be user, got {}",
+                        "first message should be user, got {:?}",
                         history.messages[0].role
                     ),
                 )?;
                 assert_eval(
-                    history.messages[1].role == "assistant",
+                    history.messages[1].role == MessageRole::Assistant,
                     format!(
-                        "second message should be assistant, got {}",
+                        "second message should be assistant, got {:?}",
                         history.messages[1].role
                     ),
                 )?;
@@ -136,7 +125,7 @@ impl Scenario for ConversationMultiTurn {
             async move {
                 let nous_list = client.list_nous().await?;
                 let nous_id = &nous_list[0].id;
-                let key = unique_key("multi");
+                let key = super::unique_key("conv", "multi");
                 let session = client.create_session(nous_id, &key).await?;
                 let _ = client
                     .send_message(&session.id, "First eval message.")
@@ -179,7 +168,7 @@ impl Scenario for ConversationEmptyRejected {
             async move {
                 let nous_list = client.list_nous().await?;
                 let nous_id = &nous_list[0].id;
-                let key = unique_key("empty");
+                let key = super::unique_key("conv", "empty");
                 let session = client.create_session(nous_id, &key).await?;
                 match client.send_message(&session.id, "").await {
                     Err(crate::error::Error::UnexpectedStatus { status, .. }) => {

--- a/crates/eval/src/scenarios/health.rs
+++ b/crates/eval/src/scenarios/health.rs
@@ -2,7 +2,7 @@
 
 use tracing::Instrument;
 
-use crate::client::EvalClient;
+use crate::client::{EvalClient, InstanceStatus};
 use crate::scenario::{Scenario, ScenarioFuture, ScenarioMeta, assert_eval};
 
 #[tracing::instrument(skip_all)]
@@ -30,8 +30,11 @@ impl Scenario for HealthReturnsOk {
             async move {
                 let health = client.health().await?;
                 assert_eval(
-                    health.status == "healthy" || health.status == "degraded",
-                    format!("expected healthy or degraded, got {}", health.status),
+                    matches!(health.status, InstanceStatus::Healthy | InstanceStatus::Degraded),
+                    format!(
+                        "expected healthy or degraded, got {:?}",
+                        health.status
+                    ),
                 )
             }
             .instrument(tracing::info_span!("scenario", id = "health-returns-ok")),

--- a/crates/eval/src/scenarios/mod.rs
+++ b/crates/eval/src/scenarios/mod.rs
@@ -19,3 +19,78 @@ pub fn all_scenarios() -> Vec<Box<dyn Scenario>> {
     scenarios.extend(conversation::scenarios());
     scenarios
 }
+
+/// Generate a timestamped unique session key for eval scenarios.
+///
+/// Keys are prefixed with `eval-` followed by the given suffix and a
+/// millisecond-resolution UNIX timestamp to avoid collisions between runs.
+pub(super) fn unique_key(prefix: &str, suffix: &str) -> String {
+    format!(
+        "eval-{prefix}-{suffix}-{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis()
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unique_key_contains_prefix_and_suffix() {
+        let key = unique_key("session", "create");
+        assert!(key.starts_with("eval-session-create-"), "key: {key}");
+    }
+
+    #[test]
+    fn unique_key_is_nonempty() {
+        let key = unique_key("foo", "bar");
+        assert!(!key.is_empty());
+    }
+
+    #[test]
+    fn all_scenarios_returns_nonempty_list() {
+        let scenarios = all_scenarios();
+        assert!(!scenarios.is_empty(), "scenario registry should not be empty");
+    }
+
+    #[test]
+    fn all_scenarios_have_unique_ids() {
+        let scenarios = all_scenarios();
+        let mut ids: Vec<&str> = scenarios.iter().map(|s| s.meta().id).collect();
+        let total = ids.len();
+        ids.sort_unstable();
+        ids.dedup();
+        assert_eq!(ids.len(), total, "duplicate scenario IDs detected");
+    }
+
+    #[test]
+    fn all_scenarios_have_nonempty_descriptions() {
+        let scenarios = all_scenarios();
+        for s in &scenarios {
+            let meta = s.meta();
+            assert!(!meta.description.is_empty(), "scenario {} has empty description", meta.id);
+            assert!(!meta.category.is_empty(), "scenario {} has empty category", meta.id);
+        }
+    }
+
+    #[test]
+    fn scenario_filter_by_id_substring() {
+        let all = all_scenarios();
+        let filter = "health";
+        let filtered: Vec<_> = all.into_iter().filter(|s| s.meta().id.contains(filter)).collect();
+        assert!(!filtered.is_empty(), "filter 'health' should match at least one scenario");
+        for s in &filtered {
+            assert!(s.meta().id.contains(filter), "scenario {} should contain 'health'", s.meta().id);
+        }
+    }
+
+    #[test]
+    fn scenario_filter_nonexistent_returns_empty() {
+        let all = all_scenarios();
+        let filtered: Vec<_> = all.into_iter().filter(|s| s.meta().id.contains("xyzzy-nonexistent")).collect();
+        assert!(filtered.is_empty());
+    }
+}

--- a/crates/eval/src/scenarios/session.rs
+++ b/crates/eval/src/scenarios/session.rs
@@ -2,7 +2,7 @@
 
 use tracing::Instrument;
 
-use crate::client::EvalClient;
+use crate::client::{EvalClient, SessionStatus};
 use crate::scenario::{Scenario, ScenarioFuture, ScenarioMeta, assert_eq_eval, assert_eval};
 
 #[tracing::instrument(skip_all)]
@@ -12,17 +12,6 @@ pub fn scenarios() -> Vec<Box<dyn Scenario>> {
         Box::new(SessionCloseArchives),
         Box::new(SessionUnknown404),
     ]
-}
-
-fn unique_key(suffix: &str) -> String {
-    format!(
-        "eval-{}-{}",
-        suffix,
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_millis()
-    )
 }
 
 struct SessionCreateAndGet;
@@ -41,14 +30,14 @@ impl Scenario for SessionCreateAndGet {
             async move {
                 let nous_list = client.list_nous().await?;
                 let nous_id = &nous_list[0].id;
-                let key = unique_key("create");
+                let key = super::unique_key("session", "create");
                 let session = client.create_session(nous_id, &key).await?;
                 assert_eval(!session.id.is_empty(), "session id should not be empty")?;
                 assert_eq_eval(&session.nous_id, nous_id, "nous_id should match")?;
                 assert_eq_eval(&session.session_key, &key, "session_key should match")?;
                 assert_eq_eval(
                     &session.status,
-                    &"active".to_owned(),
+                    &SessionStatus::Active,
                     "status should be active",
                 )?;
                 let fetched = client.get_session(&session.id).await?;
@@ -80,13 +69,13 @@ impl Scenario for SessionCloseArchives {
             async move {
                 let nous_list = client.list_nous().await?;
                 let nous_id = &nous_list[0].id;
-                let key = unique_key("close");
+                let key = super::unique_key("session", "close");
                 let session = client.create_session(nous_id, &key).await?;
                 client.close_session(&session.id).await?;
                 let fetched = client.get_session(&session.id).await?;
                 assert_eq_eval(
                     &fetched.status,
-                    &"archived".to_owned(),
+                    &SessionStatus::Archived,
                     "closed session should be archived",
                 )
             }


### PR DESCRIPTION
## Summary

- **Typed enums** replacing bare `String` comparisons in response types and scenario assertions: `InstanceStatus` (healthy/degraded), `SessionStatus` (active/archived), `MessageRole` (user/assistant/tool), `OutcomeKind` (passed/failed/skipped). Each includes an `Unknown(String)` catch-all for forward compatibility.
- **Deduplicated `unique_key` helper** — moved from `session.rs` and `conversation.rs` into `scenarios/mod.rs`; single source of truth for timestamped eval session keys.
- **Fixed silent failure in `print_report_json`** — was silently dropping serialization errors; now logs via `tracing::error!`.
- **16 new unit tests** covering: serde roundtrips for all new enums, unknown variant passthrough, scenario registry invariants (unique IDs, non-empty descriptions), filter-by-substring behaviour, `OutcomeKind` serialization.

## Validation

```
cargo check -p aletheia-dokimion -p aletheia  ✓
cargo test -p aletheia-dokimion               ✓  57 passed
cargo clippy -p aletheia-dokimion --all-targets -- -D warnings  ✓
aletheia eval --help                          ✓
```

## Test plan

- [x] All 57 existing + new unit tests pass
- [x] `cargo clippy` clean — zero warnings
- [x] `aletheia eval --help` renders correctly
- [x] No stale references to removed infrastructure (mem0, qdrant, neo4j, langfuse, python/node)
- [x] No hardcoded passwords or secrets in eval code

Closes #562

🤖 Generated with [Claude Code](https://claude.com/claude-code)