### PR TITLE
refactor(tui): migrate from anyhow to snafu error handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -400,6 +400,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "snafu",
  "syntect",
  "tokio",
  "toml",

--- a/tui/Cargo.toml
+++ b/tui/Cargo.toml
@@ -46,8 +46,9 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 tracing-appender = "0.2"
 
-# Error handling
+# Error handling — anyhow only for the run_tui() public boundary; snafu for all internals
 anyhow = "1"
+snafu = { workspace = true }
 
 # Futures
 futures-util = "0.3"

--- a/tui/src/api/client.rs
+++ b/tui/src/api/client.rs
@@ -1,7 +1,8 @@
-use anyhow::{Context, Result};
 use reqwest::{Client, Response, StatusCode};
+use snafu::prelude::*;
 
 use super::types::*;
+use crate::error::{AuthSnafu, HttpSnafu, Result};
 
 /// Percent-encode a value for use in a URL path segment.
 fn encode_path(s: &str) -> String {
@@ -43,7 +44,7 @@ impl ApiClient {
             .cookie_store(true)
             .timeout(std::time::Duration::from_secs(30))
             .build()
-            .context("failed to create HTTP client")?;
+            .context(HttpSnafu { operation: "build HTTP client" })?;
 
         Ok(Self {
             client,
@@ -87,7 +88,7 @@ impl ApiClient {
             .get(self.url("/api/health"))
             .send()
             .await
-            .context("health check failed")?;
+            .context(HttpSnafu { operation: "health check" })?;
         Ok(resp.status().is_success())
     }
 
@@ -99,8 +100,8 @@ impl ApiClient {
             .request(reqwest::Method::GET, "/api/auth/mode")
             .send()
             .await
-            .context("auth mode check failed")?;
-        Ok(resp.json().await?)
+            .context(HttpSnafu { operation: "auth mode check" })?;
+        resp.json().await.context(HttpSnafu { operation: "auth mode response" })
     }
 
     #[expect(dead_code, reason = "reserved for future interactive login flow")]
@@ -112,15 +113,15 @@ impl ApiClient {
             .json(&serde_json::json!({ "username": username, "password": password }))
             .send()
             .await
-            .context("login failed")?;
+            .context(HttpSnafu { operation: "login" })?;
 
         if resp.status() == StatusCode::UNAUTHORIZED {
-            anyhow::bail!("invalid credentials");
+            return AuthSnafu.fail();
         }
 
         resp.error_for_status_ref()
-            .context("login request failed")?;
-        Ok(resp.json().await?)
+            .context(HttpSnafu { operation: "login request" })?;
+        resp.json().await.context(HttpSnafu { operation: "login response" })
     }
 
     // --- Agents ---
@@ -131,11 +132,12 @@ impl ApiClient {
             .request(reqwest::Method::GET, "/api/v1/nous")
             .send()
             .await
-            .context("failed to load agents")?;
+            .context(HttpSnafu { operation: "load agents" })?;
         Self::check_auth(&resp)?;
         resp.error_for_status_ref()
-            .context("agents request failed")?;
-        let wrapper: AgentsResponse = resp.json().await?;
+            .context(HttpSnafu { operation: "agents request" })?;
+        let wrapper: AgentsResponse =
+            resp.json().await.context(HttpSnafu { operation: "agents response" })?;
         Ok(wrapper.nous)
     }
 
@@ -151,11 +153,12 @@ impl ApiClient {
             )
             .send()
             .await
-            .context("failed to load sessions")?;
+            .context(HttpSnafu { operation: "load sessions" })?;
         Self::check_auth(&resp)?;
         resp.error_for_status_ref()
-            .context("sessions request failed")?;
-        let wrapper: SessionsResponse = resp.json().await?;
+            .context(HttpSnafu { operation: "sessions request" })?;
+        let wrapper: SessionsResponse =
+            resp.json().await.context(HttpSnafu { operation: "sessions response" })?;
         Ok(wrapper.sessions)
     }
 
@@ -169,11 +172,12 @@ impl ApiClient {
             )
             .send()
             .await
-            .context("failed to load history")?;
+            .context(HttpSnafu { operation: "load history" })?;
         Self::check_auth(&resp)?;
         resp.error_for_status_ref()
-            .context("history request failed")?;
-        let wrapper: HistoryResponse = resp.json().await?;
+            .context(HttpSnafu { operation: "history request" })?;
+        let wrapper: HistoryResponse =
+            resp.json().await.context(HttpSnafu { operation: "history response" })?;
         Ok(wrapper.messages)
     }
 
@@ -187,11 +191,11 @@ impl ApiClient {
             }))
             .send()
             .await
-            .context("failed to create session")?;
+            .context(HttpSnafu { operation: "create session" })?;
         Self::check_auth(&resp)?;
         resp.error_for_status_ref()
-            .context("create session request failed")?;
-        Ok(resp.json().await?)
+            .context(HttpSnafu { operation: "create session request" })?;
+        resp.json().await.context(HttpSnafu { operation: "create session response" })
     }
 
     #[tracing::instrument(skip(self))]
@@ -203,9 +207,9 @@ impl ApiClient {
         )
         .send()
         .await
-        .context("failed to archive session")?
+        .context(HttpSnafu { operation: "archive session" })?
         .error_for_status_ref()
-        .context("archive request failed")?;
+        .context(HttpSnafu { operation: "archive request" })?;
         Ok(())
     }
 
@@ -218,9 +222,9 @@ impl ApiClient {
         )
         .send()
         .await
-        .context("failed to unarchive session")?
+        .context(HttpSnafu { operation: "unarchive session" })?
         .error_for_status_ref()
-        .context("unarchive request failed")?;
+        .context(HttpSnafu { operation: "unarchive request" })?;
         Ok(())
     }
 
@@ -234,9 +238,9 @@ impl ApiClient {
         .json(&serde_json::json!({ "name": name }))
         .send()
         .await
-        .context("failed to rename session")?
+        .context(HttpSnafu { operation: "rename session" })?
         .error_for_status_ref()
-        .context("rename request failed")?;
+        .context(HttpSnafu { operation: "rename request" })?;
         Ok(())
     }
 
@@ -252,9 +256,9 @@ impl ApiClient {
         )
         .send()
         .await
-        .context("failed to abort turn")?
+        .context(HttpSnafu { operation: "abort turn" })?
         .error_for_status_ref()
-        .context("abort request failed")?;
+        .context(HttpSnafu { operation: "abort request" })?;
         Ok(())
     }
 
@@ -268,9 +272,9 @@ impl ApiClient {
         )
         .send()
         .await
-        .context("failed to approve tool")?
+        .context(HttpSnafu { operation: "approve tool" })?
         .error_for_status_ref()
-        .context("approve request failed")?;
+        .context(HttpSnafu { operation: "approve request" })?;
         Ok(())
     }
 
@@ -284,9 +288,9 @@ impl ApiClient {
         )
         .send()
         .await
-        .context("failed to deny tool")?
+        .context(HttpSnafu { operation: "deny tool" })?
         .error_for_status_ref()
-        .context("deny request failed")?;
+        .context(HttpSnafu { operation: "deny request" })?;
         Ok(())
     }
 
@@ -301,9 +305,9 @@ impl ApiClient {
         )
         .send()
         .await
-        .context("failed to approve plan")?
+        .context(HttpSnafu { operation: "approve plan" })?
         .error_for_status_ref()
-        .context("plan approve failed")?;
+        .context(HttpSnafu { operation: "plan approve request" })?;
         Ok(())
     }
 
@@ -316,9 +320,9 @@ impl ApiClient {
         )
         .send()
         .await
-        .context("failed to cancel plan")?
+        .context(HttpSnafu { operation: "cancel plan" })?
         .error_for_status_ref()
-        .context("plan cancel failed")?;
+        .context(HttpSnafu { operation: "plan cancel request" })?;
         Ok(())
     }
 
@@ -330,10 +334,11 @@ impl ApiClient {
             .request(reqwest::Method::GET, "/api/v1/costs/daily")
             .send()
             .await
-            .context("failed to load costs")?;
+            .context(HttpSnafu { operation: "load costs" })?;
         resp.error_for_status_ref()
-            .context("costs request failed")?;
-        let daily: DailyResponse = resp.json().await?;
+            .context(HttpSnafu { operation: "costs request" })?;
+        let daily: DailyResponse =
+            resp.json().await.context(HttpSnafu { operation: "costs response" })?;
         // Get today's entry (last in list)
         let today_cost = daily.daily.last().map(|d| d.cost).unwrap_or(0.0);
         // Convert dollars to cents
@@ -351,9 +356,9 @@ impl ApiClient {
         )
         .send()
         .await
-        .context("failed to trigger distillation")?
+        .context(HttpSnafu { operation: "trigger distillation" })?
         .error_for_status_ref()
-        .context("distillation request failed")?;
+        .context(HttpSnafu { operation: "distillation request" })?;
         Ok(())
     }
 
@@ -370,10 +375,10 @@ impl ApiClient {
             .query(&[("q", query)])
             .send()
             .await
-            .context("failed to recall memory")?;
+            .context(HttpSnafu { operation: "recall memory" })?;
         resp.error_for_status_ref()
-            .context("recall request failed")?;
-        Ok(resp.text().await?)
+            .context(HttpSnafu { operation: "recall request" })?;
+        resp.text().await.context(HttpSnafu { operation: "recall response" })
     }
 
     // --- Config ---
@@ -384,11 +389,11 @@ impl ApiClient {
             .request(reqwest::Method::GET, "/api/v1/config")
             .send()
             .await
-            .context("failed to load config")?;
+            .context(HttpSnafu { operation: "load config" })?;
         Self::check_auth(&resp)?;
         resp.error_for_status_ref()
-            .context("config request failed")?;
-        Ok(resp.json().await?)
+            .context(HttpSnafu { operation: "config request" })?;
+        resp.json().await.context(HttpSnafu { operation: "config response" })
     }
 
     #[tracing::instrument(skip(self, data))]
@@ -403,11 +408,11 @@ impl ApiClient {
             .json(data)
             .send()
             .await
-            .context("failed to update config")?;
+            .context(HttpSnafu { operation: "update config" })?;
         Self::check_auth(&resp)?;
         resp.error_for_status_ref()
-            .context("config update failed")?;
-        Ok(resp.json().await?)
+            .context(HttpSnafu { operation: "config update request" })?;
+        resp.json().await.context(HttpSnafu { operation: "config update response" })
     }
 
     // --- Message queue (mid-turn) ---
@@ -422,25 +427,17 @@ impl ApiClient {
         .json(&serde_json::json!({ "text": text }))
         .send()
         .await
-        .context("failed to queue message")?
+        .context(HttpSnafu { operation: "queue message" })?
         .error_for_status_ref()
-        .context("queue request failed")?;
+        .context(HttpSnafu { operation: "queue request" })?;
         Ok(())
     }
 
     fn check_auth(resp: &Response) -> Result<()> {
         if resp.status() == StatusCode::UNAUTHORIZED || resp.status() == StatusCode::FORBIDDEN {
-            return Err(AuthError.into());
+            return AuthSnafu.fail();
         }
         Ok(())
-    }
-
-    #[expect(
-        dead_code,
-        reason = "reserved for auth-aware error display in update handlers"
-    )]
-    pub fn is_auth_error(err: &anyhow::Error) -> bool {
-        err.downcast_ref::<AuthError>().is_some()
     }
 
     #[expect(dead_code, reason = "reserved for future SSE connection management")]
@@ -449,17 +446,6 @@ impl ApiClient {
         &self.client
     }
 }
-
-#[derive(Debug)]
-struct AuthError;
-
-impl std::fmt::Display for AuthError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "authentication failed: token expired or invalid")
-    }
-}
-
-impl std::error::Error for AuthError {}
 
 #[cfg(test)]
 mod tests {

--- a/tui/src/app.rs
+++ b/tui/src/app.rs
@@ -1,12 +1,12 @@
 use std::collections::{HashMap, HashSet};
 
-use anyhow::Result;
 use ratatui::Frame;
 use tokio::sync::mpsc;
 
 use crate::api::client::ApiClient;
 use crate::api::sse::SseConnection;
 use crate::config::Config;
+use crate::error::{GatewayUnreachableSnafu, Result, TokenRequiredSnafu};
 use crate::events::StreamEvent;
 use crate::id::{NousId, SessionId, TurnId};
 use crate::msg::{ErrorToast, Msg};
@@ -158,10 +158,7 @@ impl App {
     #[tracing::instrument(skip(self), fields(url = %self.config.url))]
     async fn connect(&mut self) -> Result<()> {
         if !self.client.health().await.unwrap_or(false) {
-            anyhow::bail!(
-                "cannot reach gateway at {}. Is it running?",
-                self.config.url
-            );
+            return GatewayUnreachableSnafu { url: self.config.url.clone() }.fail();
         }
 
         match self.client.auth_mode().await {
@@ -171,16 +168,18 @@ impl App {
                 }
                 "token" => {
                     if self.client.token().is_none() {
-                        anyhow::bail!(
-                            "gateway requires token auth. Pass --token or set ALETHEIA_TOKEN"
-                        );
+                        return TokenRequiredSnafu {
+                            message: "gateway requires token auth. Pass --token or set ALETHEIA_TOKEN",
+                        }
+                        .fail();
                     }
                 }
                 _ => {
                     if self.client.token().is_none() {
-                        anyhow::bail!(
-                            "gateway requires authentication. Pass --token or set ALETHEIA_TOKEN"
-                        );
+                        return TokenRequiredSnafu {
+                            message: "gateway requires authentication. Pass --token or set ALETHEIA_TOKEN",
+                        }
+                        .fail();
                     }
                 }
             },

--- a/tui/src/config.rs
+++ b/tui/src/config.rs
@@ -1,6 +1,8 @@
-use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
+use snafu::prelude::*;
 use std::path::{Path, PathBuf};
+
+use crate::error::{ConfigDirSnafu, IoSnafu, Result, YamlSnafu};
 
 const DEFAULT_URL: &str = "http://localhost:18789";
 
@@ -68,7 +70,7 @@ impl Config {
         if path.exists() {
             let mut file_config = Self::load_file().unwrap_or_default();
             file_config.token = None;
-            let yaml_str = serde_yaml::to_string(&file_config)?;
+            let yaml_str = serde_yaml::to_string(&file_config).context(YamlSnafu)?;
             write_config(&path, &yaml_str)?;
             tracing::info!("cleared credentials from {}", path.display());
         }
@@ -81,9 +83,10 @@ impl Config {
         let path = Self::config_path()?;
         let mut file_config = Self::load_file().unwrap_or_default();
         file_config.token = Some(token.to_string());
-        let yaml_str = serde_yaml::to_string(&file_config)?;
+        let yaml_str = serde_yaml::to_string(&file_config).context(YamlSnafu)?;
         if let Some(parent) = path.parent() {
-            std::fs::create_dir_all(parent)?;
+            std::fs::create_dir_all(parent)
+                .context(IoSnafu { context: "create config directory" })?;
         }
         write_config(&path, &yaml_str)?;
         tracing::info!("saved token to {}", path.display());
@@ -93,7 +96,7 @@ impl Config {
     fn config_path() -> Result<PathBuf> {
         dirs::config_dir()
             .map(|d| d.join("aletheia").join("tui.yaml"))
-            .context("could not determine config directory")
+            .context(ConfigDirSnafu)
     }
 
     fn legacy_config_path() -> Option<PathBuf> {
@@ -134,11 +137,12 @@ impl Config {
 }
 
 fn write_config(path: &Path, content: &str) -> Result<()> {
-    std::fs::write(path, content)?;
+    std::fs::write(path, content).context(IoSnafu { context: "write config file" })?;
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
-        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))?;
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))
+            .context(IoSnafu { context: "set config file permissions" })?;
     }
     Ok(())
 }

--- a/tui/src/error.rs
+++ b/tui/src/error.rs
@@ -1,0 +1,48 @@
+use snafu::prelude::*;
+
+/// Unified error type for the TUI crate.
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub(crate)))]
+pub enum Error {
+    /// HTTP transport or status error from a REST API call.
+    #[snafu(display("{operation}: {source}"))]
+    Http {
+        operation: &'static str,
+        source: reqwest::Error,
+    },
+
+    /// Credentials rejected by the gateway.
+    #[snafu(display("authentication failed: token expired or invalid"))]
+    Auth,
+
+    /// Token is required but was not supplied.
+    #[snafu(display("{message}"))]
+    TokenRequired { message: String },
+
+    /// Gateway is unreachable (health check returned false or connection refused).
+    #[snafu(display("cannot reach gateway at {url}. Is it running?"))]
+    GatewayUnreachable { url: String },
+
+    /// Could not determine the OS config directory (e.g. $HOME unset).
+    #[snafu(display("could not determine config directory"))]
+    ConfigDir,
+
+    /// File-system I/O error.
+    #[snafu(display("{context}: {source}"))]
+    Io {
+        context: &'static str,
+        source: std::io::Error,
+    },
+
+    /// YAML serialization / deserialization error.
+    #[snafu(display("YAML error: {source}"))]
+    Yaml { source: serde_yaml::Error },
+
+    /// Invalid `tracing` filter directive.
+    #[snafu(display("invalid log directive: {source}"))]
+    LogDirective {
+        source: tracing_subscriber::filter::ParseError,
+    },
+}
+
+pub(crate) type Result<T, E = Error> = std::result::Result<T, E>;

--- a/tui/src/lib.rs
+++ b/tui/src/lib.rs
@@ -1,11 +1,4 @@
 //! TUI entry point for the Aletheia client.
-//!
-//! Error handling uses `anyhow` throughout this crate. The TUI is a thin
-//! terminal UI layer: all errors surface to the user as display text (via
-//! `eprintln!` in `run_tui` or the in-app toast system). No caller outside
-//! this crate needs to match on error variants, so typed snafu errors would
-//! add complexity with no benefit. Internal state errors use the app's own
-//! `Msg::ShowError` path rather than `Result` propagation.
 
 mod actions;
 mod api;
@@ -13,6 +6,7 @@ mod app;
 mod clipboard;
 mod command;
 mod config;
+pub(crate) mod error;
 mod events;
 mod highlight;
 mod id;
@@ -26,18 +20,22 @@ mod theme;
 mod update;
 mod view;
 
-use anyhow::Result;
 use crossterm::event::EventStream;
 use futures_util::StreamExt;
 use ratatui::DefaultTerminal;
+use snafu::prelude::*;
 use tracing_appender::rolling;
 use tracing_subscriber::{EnvFilter, fmt};
 
 use crate::app::App;
 use crate::config::Config;
+use crate::error::{IoSnafu, LogDirectiveSnafu};
 use crate::events::Event;
 
 /// Entry point for the TUI, callable from the main `aletheia` binary or standalone.
+///
+/// Returns `anyhow::Result` as the public boundary so the binary crate can use
+/// anyhow for top-level error reporting. All internal code uses `crate::error::Error`.
 #[tracing::instrument(skip_all, fields(url, agent))]
 pub async fn run_tui(
     url: Option<String>,
@@ -45,15 +43,34 @@ pub async fn run_tui(
     agent: Option<String>,
     session: Option<String>,
     logout: bool,
-) -> Result<()> {
+) -> anyhow::Result<()> {
+    run_tui_inner(url, token, agent, session, logout)
+        .await
+        .map_err(|e| anyhow::anyhow!("{e}"))
+}
+
+async fn run_tui_inner(
+    url: Option<String>,
+    token: Option<String>,
+    agent: Option<String>,
+    session: Option<String>,
+    logout: bool,
+) -> error::Result<()> {
     let log_dir = dirs::data_local_dir()
         .unwrap_or_else(|| std::path::PathBuf::from("."))
         .join("aletheia");
-    std::fs::create_dir_all(&log_dir)?;
+    std::fs::create_dir_all(&log_dir).context(IoSnafu { context: "create log directory" })?;
     let file_appender = rolling::daily(&log_dir, "tui.log");
     let (non_blocking, _guard) = tracing_appender::non_blocking(file_appender);
     fmt()
-        .with_env_filter(EnvFilter::from_default_env().add_directive("aletheia_tui=debug".parse()?))
+        .with_env_filter(
+            EnvFilter::from_default_env()
+                .add_directive(
+                    "aletheia_tui=debug"
+                        .parse()
+                        .context(LogDirectiveSnafu)?,
+                ),
+        )
         .with_writer(non_blocking)
         .with_ansi(false)
         .init();
@@ -75,19 +92,21 @@ pub async fn run_tui(
     ratatui::restore();
 
     if let Err(ref e) = result {
-        eprintln!("Error: {e:#}");
+        eprintln!("Error: {e}");
     }
 
     result
 }
 
-async fn run_loop(mut terminal: DefaultTerminal, app: &mut App) -> Result<()> {
+async fn run_loop(mut terminal: DefaultTerminal, app: &mut App) -> error::Result<()> {
     let mut term_events = EventStream::new();
     let mut tick = tokio::time::interval(std::time::Duration::from_millis(33));
     tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
     loop {
-        terminal.draw(|frame| app.view(frame))?;
+        terminal
+            .draw(|frame| app.view(frame))
+            .context(IoSnafu { context: "terminal draw" })?;
 
         let mut sse_rx = app.take_sse();
         let mut stream_rx = app.take_stream();


### PR DESCRIPTION
## Summary

- Introduces `tui/src/error.rs` with a typed snafu `Error` enum covering all TUI error paths: `Http`, `Auth`, `TokenRequired`, `GatewayUnreachable`, `ConfigDir`, `Io`, `Yaml`, `LogDirective`
- Migrates `config.rs`, `api/client.rs`, `app.rs`, and `lib.rs` from `anyhow::Result` / `.context("string")` to `crate::error::Result` with typed `.context(VariantSnafu { … })`
- Removes `AuthError` ad-hoc struct from `api/client.rs` — replaced by `Error::Auth` variant
- Keeps `run_tui()` returning `anyhow::Result` as the public boundary (acceptable per STANDARDS.md — the binary crate uses anyhow); an internal `run_tui_inner()` returns `crate::error::Result`
- Adds `snafu` workspace dep to `tui/Cargo.toml`; retains `anyhow` only for the boundary function

## Test plan

- [x] `cargo check -p aletheia-tui` — clean
- [x] `cargo test -p aletheia-tui` — 432 passed, 0 failed
- [x] `cargo clippy -p aletheia-tui --all-targets -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)