### PR TITLE
feat(tui): stack-based navigation with breadcrumbs

### DIFF
--- a/tui/src/app.rs
+++ b/tui/src/app.rs
@@ -23,7 +23,8 @@ use crate::state::SavedScrollState;
 pub use crate::state::{
     AgentState, AgentStatus, ChatMessage, CommandPaletteState, ContextAction,
     ContextActionsOverlay, FilterState, InputState, Overlay, PlanApprovalOverlay, PlanStepApproval,
-    SelectionContext, SessionPickerOverlay, TabCompletion, ToolApprovalOverlay, ToolCallInfo,
+    SelectionContext, SessionPickerOverlay, TabCompletion, ToolApprovalOverlay, ToolCallInfo, View,
+    ViewStack,
 };
 
 // --- App ---
@@ -99,6 +100,12 @@ pub struct App {
 
     // Live filter (`/` mode)
     pub filter: FilterState,
+
+    // Stack-based navigation (Enter drills in, Esc pops out)
+    pub view_stack: ViewStack,
+
+    // Per-view scroll state preservation
+    pub(crate) view_scroll_states: HashMap<usize, SavedScrollState>,
 }
 
 impl App {
@@ -148,6 +155,8 @@ impl App {
             selected_message: None,
             tool_expanded: HashSet::new(),
             filter: FilterState::default(),
+            view_stack: ViewStack::new(),
+            view_scroll_states: HashMap::new(),
         };
 
         app.connect().await?;
@@ -421,6 +430,8 @@ pub(crate) mod test_helpers {
             selected_message: None,
             tool_expanded: HashSet::new(),
             filter: FilterState::default(),
+            view_stack: ViewStack::new(),
+            view_scroll_states: HashMap::new(),
         }
     }
 

--- a/tui/src/mapping.rs
+++ b/tui/src/mapping.rs
@@ -74,6 +74,16 @@ impl App {
             return Some(msg);
         }
 
+        // View stack: Esc pops back when not at Home (takes priority over selection deselect)
+        if !self.view_stack.is_home()
+            && matches!(
+                (key.modifiers, key.code),
+                (_, KeyCode::Esc)
+            )
+        {
+            return Some(Msg::ViewPopBack);
+        }
+
         // Selection mode — single-letter keys become actions
         if self.selected_message.is_some() {
             return self.map_selection_key(key);
@@ -186,7 +196,7 @@ impl App {
             (_, KeyCode::Char('j')) | (_, KeyCode::Down) => Some(Msg::SelectNext),
             (_, KeyCode::Char('k')) | (_, KeyCode::Up) => Some(Msg::SelectPrev),
             (_, KeyCode::Esc) => Some(Msg::DeselectMessage),
-            (_, KeyCode::Enter) => Some(Msg::OpenContextActions),
+            (_, KeyCode::Enter) => Some(Msg::ViewDrillIn),
             (_, KeyCode::Home) => Some(Msg::SelectFirst),
             (_, KeyCode::End) | (KeyModifiers::SHIFT, KeyCode::Char('G')) => Some(Msg::SelectLast),
 
@@ -854,15 +864,15 @@ mod tests {
         assert!(matches!(msg, Some(Msg::CharInput('v'))));
     }
 
-    // --- Enter in selection mode opens context actions ---
+    // --- Enter in selection mode drills into detail view ---
 
     #[test]
-    fn selection_mode_enter_opens_context_actions() {
+    fn selection_mode_enter_drills_in() {
         let mut app = test_app_with_messages(vec![("user", "a")]);
         app.selected_message = Some(0);
         let event = Event::Terminal(key(KeyCode::Enter));
         let msg = app.map_event(event);
-        assert!(matches!(msg, Some(Msg::OpenContextActions)));
+        assert!(matches!(msg, Some(Msg::ViewDrillIn)));
     }
 
     // --- Context actions overlay j/k navigation ---
@@ -899,5 +909,40 @@ mod tests {
         let event = Event::Terminal(key(KeyCode::Char('k')));
         let msg = app.map_event(event);
         assert!(matches!(msg, Some(Msg::OverlayUp)));
+    }
+
+    // --- View stack navigation key tests ---
+
+    #[test]
+    fn esc_at_non_home_view_pops_back() {
+        let mut app = test_app();
+        app.view_stack.push(crate::state::View::Sessions {
+            agent_id: "syn".into(),
+        });
+        let event = Event::Terminal(key(KeyCode::Esc));
+        let msg = app.map_event(event);
+        assert!(matches!(msg, Some(Msg::ViewPopBack)));
+    }
+
+    #[test]
+    fn esc_at_home_with_selection_deselects() {
+        let mut app = test_app_with_messages(vec![("user", "a")]);
+        app.selected_message = Some(0);
+        // view_stack is Home by default
+        let event = Event::Terminal(key(KeyCode::Esc));
+        let msg = app.map_event(event);
+        assert!(matches!(msg, Some(Msg::DeselectMessage)));
+    }
+
+    #[test]
+    fn esc_at_non_home_with_selection_still_pops() {
+        let mut app = test_app_with_messages(vec![("user", "a")]);
+        app.selected_message = Some(0);
+        app.view_stack.push(crate::state::View::MessageDetail {
+            message_index: 0,
+        });
+        let event = Event::Terminal(key(KeyCode::Esc));
+        let msg = app.map_event(event);
+        assert!(matches!(msg, Some(Msg::ViewPopBack)));
     }
 }

--- a/tui/src/msg.rs
+++ b/tui/src/msg.rs
@@ -73,6 +73,10 @@ pub enum Msg {
     NextAgent, // Ctrl+Tab or similar
     PrevAgent,
 
+    // --- View stack navigation ---
+    ViewDrillIn,  // Enter — push detail view based on context
+    ViewPopBack,  // Esc — pop to previous view
+
     // --- Layout ---
     ToggleSidebar,  // Ctrl+F
     ToggleThinking, // Ctrl+T

--- a/tui/src/state/mod.rs
+++ b/tui/src/state/mod.rs
@@ -5,6 +5,7 @@ mod filter;
 mod input;
 mod overlay;
 pub mod settings;
+pub(crate) mod view_stack;
 
 pub use agent::{AgentState, AgentStatus};
 pub(crate) use chat::SavedScrollState;
@@ -16,3 +17,4 @@ pub use overlay::{
     ContextAction, ContextActionsOverlay, Overlay, PlanApprovalOverlay, PlanStepApproval,
     SessionPickerOverlay, ToolApprovalOverlay,
 };
+pub use view_stack::{View, ViewStack};

--- a/tui/src/state/view_stack.rs
+++ b/tui/src/state/view_stack.rs
@@ -1,0 +1,284 @@
+//! Stack-based navigation for hierarchical view drill-in/drill-out.
+//!
+//! Enter pushes a detail view onto the stack, Esc pops back.
+//! The stack always has at least one element (Home).
+
+use crate::id::{NousId, SessionId};
+
+/// A distinct view that can be navigated to.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum View {
+    /// Top-level: agent sidebar + active conversation.
+    Home,
+    /// Session list for a specific agent.
+    Sessions { agent_id: NousId },
+    /// Single conversation view.
+    Conversation {
+        agent_id: NousId,
+        session_id: SessionId,
+    },
+    /// Full message detail (content, tool results, metadata).
+    MessageDetail { message_index: usize },
+}
+
+impl View {
+    /// Short human-readable label for breadcrumb display.
+    pub fn label(&self) -> &str {
+        match self {
+            Self::Home => "Home",
+            Self::Sessions { .. } => "Sessions",
+            Self::Conversation { .. } => "Conversation",
+            Self::MessageDetail { .. } => "Message",
+        }
+    }
+}
+
+/// A stack of views supporting push/pop navigation with breadcrumbs.
+///
+/// Invariant: the stack always contains at least one element (`View::Home`).
+#[derive(Debug, Clone)]
+pub struct ViewStack {
+    stack: Vec<View>,
+}
+
+impl ViewStack {
+    pub fn new() -> Self {
+        Self {
+            stack: vec![View::Home],
+        }
+    }
+
+    /// Push a new view onto the stack.
+    pub fn push(&mut self, view: View) {
+        self.stack.push(view);
+    }
+
+    /// Pop the current view, returning it. Returns `None` if at Home (cannot pop).
+    pub fn pop(&mut self) -> Option<View> {
+        if self.stack.len() > 1 {
+            self.stack.pop()
+        } else {
+            None
+        }
+    }
+
+    /// The currently active view (top of stack).
+    pub fn current(&self) -> &View {
+        // SAFETY: invariant guarantees at least one element.
+        self.stack.last().expect("ViewStack invariant: never empty")
+    }
+
+    /// Generate breadcrumb labels for the full navigation path.
+    pub fn breadcrumbs(&self) -> Vec<&str> {
+        self.stack.iter().map(|v| v.label()).collect()
+    }
+
+    /// Current stack depth (1 = Home only).
+    pub fn depth(&self) -> usize {
+        self.stack.len()
+    }
+
+    /// Whether we're at the root Home view.
+    pub fn is_home(&self) -> bool {
+        self.stack.len() == 1
+    }
+}
+
+impl Default for ViewStack {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_starts_at_home() {
+        let stack = ViewStack::new();
+        assert_eq!(stack.current(), &View::Home);
+        assert_eq!(stack.depth(), 1);
+        assert!(stack.is_home());
+    }
+
+    #[test]
+    fn push_increases_depth() {
+        let mut stack = ViewStack::new();
+        stack.push(View::Sessions {
+            agent_id: "syn".into(),
+        });
+        assert_eq!(stack.depth(), 2);
+        assert!(!stack.is_home());
+    }
+
+    #[test]
+    fn push_changes_current() {
+        let mut stack = ViewStack::new();
+        stack.push(View::Sessions {
+            agent_id: "syn".into(),
+        });
+        assert_eq!(
+            stack.current(),
+            &View::Sessions {
+                agent_id: "syn".into()
+            }
+        );
+    }
+
+    #[test]
+    fn pop_returns_to_previous() {
+        let mut stack = ViewStack::new();
+        stack.push(View::Sessions {
+            agent_id: "syn".into(),
+        });
+        let popped = stack.pop();
+        assert_eq!(
+            popped,
+            Some(View::Sessions {
+                agent_id: "syn".into()
+            })
+        );
+        assert_eq!(stack.current(), &View::Home);
+        assert!(stack.is_home());
+    }
+
+    #[test]
+    fn pop_at_home_returns_none() {
+        let mut stack = ViewStack::new();
+        assert!(stack.pop().is_none());
+        assert_eq!(stack.current(), &View::Home);
+        assert_eq!(stack.depth(), 1);
+    }
+
+    #[test]
+    fn cannot_pop_below_home() {
+        let mut stack = ViewStack::new();
+        stack.pop();
+        stack.pop();
+        stack.pop();
+        assert_eq!(stack.depth(), 1);
+        assert_eq!(stack.current(), &View::Home);
+    }
+
+    #[test]
+    fn breadcrumbs_single_level() {
+        let stack = ViewStack::new();
+        assert_eq!(stack.breadcrumbs(), vec!["Home"]);
+    }
+
+    #[test]
+    fn breadcrumbs_multi_level() {
+        let mut stack = ViewStack::new();
+        stack.push(View::Sessions {
+            agent_id: "syn".into(),
+        });
+        stack.push(View::Conversation {
+            agent_id: "syn".into(),
+            session_id: "abc123".into(),
+        });
+        assert_eq!(stack.breadcrumbs(), vec!["Home", "Sessions", "Conversation"]);
+    }
+
+    #[test]
+    fn breadcrumbs_after_pop() {
+        let mut stack = ViewStack::new();
+        stack.push(View::Sessions {
+            agent_id: "syn".into(),
+        });
+        stack.push(View::Conversation {
+            agent_id: "syn".into(),
+            session_id: "abc123".into(),
+        });
+        stack.pop();
+        assert_eq!(stack.breadcrumbs(), vec!["Home", "Sessions"]);
+    }
+
+    #[test]
+    fn deep_navigation_chain() {
+        let mut stack = ViewStack::new();
+        stack.push(View::Sessions {
+            agent_id: "syn".into(),
+        });
+        stack.push(View::Conversation {
+            agent_id: "syn".into(),
+            session_id: "sess1".into(),
+        });
+        stack.push(View::MessageDetail { message_index: 5 });
+        assert_eq!(stack.depth(), 4);
+        assert_eq!(
+            stack.breadcrumbs(),
+            vec!["Home", "Sessions", "Conversation", "Message"]
+        );
+
+        // Pop all the way back
+        stack.pop();
+        assert_eq!(stack.depth(), 3);
+        stack.pop();
+        assert_eq!(stack.depth(), 2);
+        stack.pop();
+        assert!(stack.is_home());
+    }
+
+    #[test]
+    fn view_labels() {
+        assert_eq!(View::Home.label(), "Home");
+        assert_eq!(
+            View::Sessions {
+                agent_id: "x".into()
+            }
+            .label(),
+            "Sessions"
+        );
+        assert_eq!(
+            View::Conversation {
+                agent_id: "x".into(),
+                session_id: "y".into()
+            }
+            .label(),
+            "Conversation"
+        );
+        assert_eq!(View::MessageDetail { message_index: 0 }.label(), "Message");
+    }
+
+    #[test]
+    fn default_is_home() {
+        let stack = ViewStack::default();
+        assert!(stack.is_home());
+        assert_eq!(stack.current(), &View::Home);
+    }
+
+    #[test]
+    fn view_eq_same_variant_different_data() {
+        let a = View::Sessions {
+            agent_id: "syn".into(),
+        };
+        let b = View::Sessions {
+            agent_id: "cody".into(),
+        };
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn view_eq_different_variants() {
+        let a = View::Home;
+        let b = View::Sessions {
+            agent_id: "syn".into(),
+        };
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn message_detail_push_pop() {
+        let mut stack = ViewStack::new();
+        stack.push(View::MessageDetail { message_index: 42 });
+        assert_eq!(
+            stack.current(),
+            &View::MessageDetail { message_index: 42 }
+        );
+        assert_eq!(stack.breadcrumbs(), vec!["Home", "Message"]);
+        stack.pop();
+        assert!(stack.is_home());
+    }
+}

--- a/tui/src/update/mod.rs
+++ b/tui/src/update/mod.rs
@@ -8,6 +8,7 @@ pub(crate) mod selection;
 pub(crate) mod settings;
 mod sse;
 mod streaming;
+pub(crate) mod view_nav;
 
 use crate::app::App;
 use crate::msg::Msg;
@@ -81,6 +82,8 @@ pub(crate) async fn update(app: &mut App, msg: Msg) {
         Msg::ToggleSidebar => navigation::handle_toggle_sidebar(app),
         Msg::ToggleThinking => navigation::handle_toggle_thinking(app),
         Msg::Resize(w, h) => navigation::handle_resize(app, w, h),
+        Msg::ViewDrillIn => view_nav::handle_drill_in(app),
+        Msg::ViewPopBack => view_nav::handle_pop_back(app),
 
         // --- Overlay ---
         Msg::OpenOverlay(kind) => overlay::handle_open_overlay(app, kind).await,

--- a/tui/src/update/view_nav.rs
+++ b/tui/src/update/view_nav.rs
@@ -1,0 +1,275 @@
+//! View stack navigation handlers — drill-in (Enter) and pop-back (Esc).
+
+use crate::app::App;
+use crate::state::view_stack::View;
+use crate::state::SavedScrollState;
+
+/// Save the current scroll state keyed by the view stack depth before pushing.
+fn save_view_scroll(app: &mut App) {
+    let depth = app.view_stack.depth();
+    app.view_scroll_states.insert(
+        depth,
+        SavedScrollState {
+            scroll_offset: app.scroll_offset,
+            auto_scroll: app.auto_scroll,
+        },
+    );
+}
+
+/// Restore scroll state for the current view stack depth after popping.
+fn restore_view_scroll(app: &mut App) {
+    let depth = app.view_stack.depth();
+    if let Some(state) = app.view_scroll_states.remove(&depth) {
+        app.scroll_offset = state.scroll_offset;
+        app.auto_scroll = state.auto_scroll;
+    } else {
+        app.scroll_to_bottom();
+    }
+}
+
+/// Handle Enter — drill into a detail view based on the current context.
+///
+/// The drill-in target depends on the current view:
+/// - Home + agent sidebar focused → Sessions for that agent
+/// - Home + message selected → MessageDetail
+/// - Sessions + session selected → Conversation
+/// - Conversation + message selected → MessageDetail
+pub(crate) fn handle_drill_in(app: &mut App) {
+    let current = app.view_stack.current().clone();
+
+    match current {
+        View::Home => {
+            // If a message is selected, drill into message detail
+            if let Some(idx) = app.selected_message {
+                save_view_scroll(app);
+                app.view_stack.push(View::MessageDetail {
+                    message_index: idx,
+                });
+                app.scroll_offset = 0;
+                app.auto_scroll = true;
+                return;
+            }
+
+            // Otherwise drill into sessions for the focused agent
+            let agent_id = app.focused_agent.clone();
+            if let Some(agent_id) = agent_id {
+                save_view_scroll(app);
+                app.view_stack.push(View::Sessions { agent_id });
+                app.scroll_offset = 0;
+                app.auto_scroll = true;
+            }
+        }
+        View::Sessions { ref agent_id } => {
+            // Drill into the focused session's conversation
+            let agent_id = agent_id.clone();
+            let session_id = app.focused_session_id.clone();
+            if let Some(session_id) = session_id {
+                save_view_scroll(app);
+                app.view_stack.push(View::Conversation {
+                    agent_id,
+                    session_id,
+                });
+                app.scroll_offset = 0;
+                app.auto_scroll = true;
+            }
+        }
+        View::Conversation { .. } => {
+            // Drill into message detail if a message is selected
+            if let Some(idx) = app.selected_message {
+                save_view_scroll(app);
+                app.view_stack.push(View::MessageDetail {
+                    message_index: idx,
+                });
+                app.scroll_offset = 0;
+                app.auto_scroll = true;
+            }
+        }
+        View::MessageDetail { .. } => {
+            // Leaf view — no further drill-in
+        }
+    }
+}
+
+/// Handle Esc — pop back to the previous view.
+///
+/// At Home, Esc deselects the message (existing behavior) or does nothing.
+pub(crate) fn handle_pop_back(app: &mut App) {
+    if app.view_stack.is_home() {
+        // At home, Esc deselects if there's a selection, otherwise no-op
+        if app.selected_message.is_some() {
+            app.selected_message = None;
+        }
+        return;
+    }
+
+    app.view_stack.pop();
+    restore_view_scroll(app);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app::test_helpers::*;
+
+    #[test]
+    fn drill_in_from_home_with_agent_pushes_sessions() {
+        let mut app = test_app();
+        app.agents.push(test_agent("syn", "Syn"));
+        app.focused_agent = Some("syn".into());
+
+        handle_drill_in(&mut app);
+
+        assert_eq!(
+            app.view_stack.current(),
+            &View::Sessions {
+                agent_id: "syn".into()
+            }
+        );
+        assert_eq!(app.view_stack.depth(), 2);
+    }
+
+    #[test]
+    fn drill_in_from_home_with_selected_message_pushes_detail() {
+        let mut app = test_app_with_messages(vec![("user", "hello"), ("assistant", "hi")]);
+        app.selected_message = Some(1);
+
+        handle_drill_in(&mut app);
+
+        assert_eq!(
+            app.view_stack.current(),
+            &View::MessageDetail { message_index: 1 }
+        );
+    }
+
+    #[test]
+    fn drill_in_from_home_no_agent_is_noop() {
+        let mut app = test_app();
+        handle_drill_in(&mut app);
+        assert!(app.view_stack.is_home());
+    }
+
+    #[test]
+    fn drill_in_from_sessions_with_session_pushes_conversation() {
+        let mut app = test_app();
+        app.agents.push(test_agent("syn", "Syn"));
+        app.focused_agent = Some("syn".into());
+        app.focused_session_id = Some("sess1".into());
+        app.view_stack.push(View::Sessions {
+            agent_id: "syn".into(),
+        });
+
+        handle_drill_in(&mut app);
+
+        assert_eq!(
+            app.view_stack.current(),
+            &View::Conversation {
+                agent_id: "syn".into(),
+                session_id: "sess1".into(),
+            }
+        );
+    }
+
+    #[test]
+    fn drill_in_from_conversation_with_selected_message() {
+        let mut app = test_app_with_messages(vec![("user", "hello")]);
+        app.selected_message = Some(0);
+        app.view_stack.push(View::Conversation {
+            agent_id: "syn".into(),
+            session_id: "s1".into(),
+        });
+
+        handle_drill_in(&mut app);
+
+        assert_eq!(
+            app.view_stack.current(),
+            &View::MessageDetail { message_index: 0 }
+        );
+    }
+
+    #[test]
+    fn drill_in_from_leaf_is_noop() {
+        let mut app = test_app();
+        app.view_stack.push(View::MessageDetail { message_index: 0 });
+        let depth_before = app.view_stack.depth();
+
+        handle_drill_in(&mut app);
+
+        assert_eq!(app.view_stack.depth(), depth_before);
+    }
+
+    #[test]
+    fn pop_back_from_sessions_returns_home() {
+        let mut app = test_app();
+        app.view_stack.push(View::Sessions {
+            agent_id: "syn".into(),
+        });
+
+        handle_pop_back(&mut app);
+
+        assert!(app.view_stack.is_home());
+    }
+
+    #[test]
+    fn pop_back_at_home_deselects_message() {
+        let mut app = test_app_with_messages(vec![("user", "a")]);
+        app.selected_message = Some(0);
+
+        handle_pop_back(&mut app);
+
+        assert!(app.selected_message.is_none());
+        assert!(app.view_stack.is_home());
+    }
+
+    #[test]
+    fn pop_back_at_home_no_selection_is_noop() {
+        let mut app = test_app();
+        handle_pop_back(&mut app);
+        assert!(app.view_stack.is_home());
+    }
+
+    #[test]
+    fn scroll_state_preserved_across_drill_and_pop() {
+        let mut app = test_app();
+        app.agents.push(test_agent("syn", "Syn"));
+        app.focused_agent = Some("syn".into());
+        app.scroll_offset = 42;
+        app.auto_scroll = false;
+
+        handle_drill_in(&mut app);
+        assert_eq!(app.scroll_offset, 0);
+        assert!(app.auto_scroll);
+
+        handle_pop_back(&mut app);
+        assert_eq!(app.scroll_offset, 42);
+        assert!(!app.auto_scroll);
+    }
+
+    #[test]
+    fn scroll_state_multi_level_preservation() {
+        let mut app = test_app();
+        app.agents.push(test_agent("syn", "Syn"));
+        app.focused_agent = Some("syn".into());
+        app.focused_session_id = Some("s1".into());
+        app.scroll_offset = 10;
+        app.auto_scroll = false;
+
+        // Home → Sessions
+        handle_drill_in(&mut app);
+        app.scroll_offset = 20;
+        app.auto_scroll = false;
+
+        // Sessions → Conversation
+        handle_drill_in(&mut app);
+        app.scroll_offset = 30;
+
+        // Pop Conversation → Sessions
+        handle_pop_back(&mut app);
+        assert_eq!(app.scroll_offset, 20);
+        assert!(!app.auto_scroll);
+
+        // Pop Sessions → Home
+        handle_pop_back(&mut app);
+        assert_eq!(app.scroll_offset, 10);
+        assert!(!app.auto_scroll);
+    }
+}

--- a/tui/src/view/mod.rs
+++ b/tui/src/view/mod.rs
@@ -7,6 +7,7 @@ pub(crate) mod settings;
 mod sidebar;
 mod status_bar;
 mod title_bar;
+mod views;
 
 use ratatui::Frame;
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
@@ -80,7 +81,7 @@ pub fn render(app: &App, frame: &mut Frame) {
     // Responsive: hide sidebar on narrow terminals
     let show_sidebar = app.sidebar_visible && area.width >= MIN_SIDEBAR_TERMINAL_WIDTH;
 
-    // Body: sidebar | chat area
+    // Body: sidebar | main content area (dispatched by current view)
     if show_sidebar {
         let horizontal = Layout::default()
             .direction(Direction::Horizontal)
@@ -91,12 +92,12 @@ pub fn render(app: &App, frame: &mut Frame) {
             .split(vertical[1]);
 
         sidebar::render(app, frame, horizontal[0], theme);
-        render_chat_area(app, frame, horizontal[1], theme);
+        views::render_for_view(app, frame, horizontal[1], theme);
 
         SIDEBAR_RECT.store_rect(horizontal[0]);
     } else {
         SIDEBAR_RECT.store_rect(Rect::ZERO);
-        render_chat_area(app, frame, vertical[1], theme);
+        views::render_for_view(app, frame, vertical[1], theme);
     }
 
     // Render overlay on top if present

--- a/tui/src/view/title_bar.rs
+++ b/tui/src/view/title_bar.rs
@@ -1,5 +1,6 @@
 use ratatui::Frame;
 use ratatui::layout::Rect;
+use ratatui::style::Modifier;
 use ratatui::text::{Line, Span};
 use ratatui::widgets::Paragraph;
 
@@ -27,15 +28,42 @@ pub fn render(app: &App, frame: &mut Frame, area: Rect, theme: &ThemePalette) {
         Span::styled("○", theme.style_error())
     };
 
-    let title = Line::from(vec![
+    let mut spans = vec![
         Span::styled(" ✦ ", theme.style_accent_bold()),
         Span::styled("aletheia", theme.style_accent()),
-        Span::styled(" │ ", theme.style_dim()),
-        Span::styled(agent_name, theme.style_fg()),
-        Span::raw(" "),
-        sse_indicator,
-    ]);
+    ];
 
+    // Breadcrumbs — show navigation path when not at Home
+    if !app.view_stack.is_home() {
+        let breadcrumbs = app.view_stack.breadcrumbs();
+        let last_idx = breadcrumbs.len() - 1;
+
+        spans.push(Span::styled(" │ ", theme.style_dim()));
+
+        for (i, crumb) in breadcrumbs.iter().enumerate() {
+            if i == last_idx {
+                // Current view — bold
+                spans.push(Span::styled(
+                    crumb.to_string(),
+                    theme
+                        .style_fg()
+                        .add_modifier(Modifier::BOLD),
+                ));
+            } else {
+                // Parent views — dim
+                spans.push(Span::styled(crumb.to_string(), theme.style_dim()));
+                spans.push(Span::styled(" > ", theme.style_dim()));
+            }
+        }
+    } else {
+        spans.push(Span::styled(" │ ", theme.style_dim()));
+        spans.push(Span::styled(agent_name, theme.style_fg()));
+    }
+
+    spans.push(Span::raw(" "));
+    spans.push(sse_indicator);
+
+    let title = Line::from(spans);
     let bar = Paragraph::new(title).style(theme.style_surface());
     frame.render_widget(bar, area);
 }

--- a/tui/src/view/views.rs
+++ b/tui/src/view/views.rs
@@ -1,0 +1,256 @@
+//! View-specific rendering for each View variant in the navigation stack.
+
+use ratatui::Frame;
+use ratatui::layout::Rect;
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Paragraph, Wrap};
+
+use crate::app::App;
+use crate::state::view_stack::View;
+use crate::theme::ThemePalette;
+
+/// Render the sessions list for a specific agent.
+pub(crate) fn render_sessions(app: &App, frame: &mut Frame, area: Rect, theme: &ThemePalette) {
+    let mut lines: Vec<Line> = Vec::new();
+    lines.push(Line::raw(""));
+
+    let agent = app
+        .focused_agent
+        .as_ref()
+        .and_then(|id| app.agents.iter().find(|a| a.id == *id));
+
+    if let Some(agent) = agent {
+        lines.push(Line::from(vec![
+            Span::raw(" "),
+            Span::styled(
+                format!("Sessions for {}", agent.name),
+                theme
+                    .style_accent()
+                    .add_modifier(Modifier::BOLD),
+            ),
+        ]));
+        lines.push(Line::raw(""));
+
+        if agent.sessions.is_empty() {
+            lines.push(Line::from(vec![
+                Span::raw("  "),
+                Span::styled("No sessions found.", theme.style_dim()),
+            ]));
+        } else {
+            for (idx, session) in agent.sessions.iter().enumerate() {
+                let is_focused = app
+                    .focused_session_id
+                    .as_ref()
+                    .is_some_and(|id| *id == session.id);
+
+                let marker = if is_focused { "▸" } else { " " };
+                let marker_style = if is_focused {
+                    Style::default().fg(theme.selected)
+                } else {
+                    Style::default()
+                };
+
+                let status_icon = match session.status.as_deref() {
+                    Some("archived") => "◌",
+                    Some("active") => "●",
+                    _ => "○",
+                };
+
+                let name_style = if is_focused {
+                    theme
+                        .style_fg()
+                        .add_modifier(Modifier::BOLD)
+                } else {
+                    theme.style_fg()
+                };
+
+                let mut spans = vec![
+                    Span::styled(marker, marker_style),
+                    Span::raw(" "),
+                    Span::styled(status_icon, theme.style_dim()),
+                    Span::raw(" "),
+                    Span::styled(format!("{}. {}", idx + 1, session.key), name_style),
+                ];
+
+                if let Some(ref updated) = session.updated_at {
+                    let time_str = updated
+                        .split('T')
+                        .nth(1)
+                        .and_then(|t| t.split('.').next())
+                        .unwrap_or(updated);
+                    spans.push(Span::styled(format!("  {time_str}"), theme.style_dim()));
+                }
+
+                lines.push(Line::from(spans));
+            }
+        }
+    } else {
+        lines.push(Line::from(vec![
+            Span::raw("  "),
+            Span::styled("No agent selected.", theme.style_dim()),
+        ]));
+    }
+
+    lines.push(Line::raw(""));
+    lines.push(Line::from(vec![
+        Span::raw("  "),
+        Span::styled("Enter", theme.style_accent()),
+        Span::styled(" select  ", theme.style_dim()),
+        Span::styled("Esc", theme.style_accent()),
+        Span::styled(" back", theme.style_dim()),
+    ]));
+
+    let block = Block::default().borders(Borders::NONE);
+    let paragraph = Paragraph::new(lines).block(block).wrap(Wrap { trim: false });
+    frame.render_widget(paragraph, area);
+}
+
+/// Render full message detail view.
+pub(crate) fn render_message_detail(
+    app: &App,
+    frame: &mut Frame,
+    area: Rect,
+    theme: &ThemePalette,
+    message_index: usize,
+) {
+    let mut lines: Vec<Line> = Vec::new();
+    lines.push(Line::raw(""));
+
+    if let Some(msg) = app.messages.get(message_index) {
+        // Header
+        let role_label = match msg.role.as_str() {
+            "user" => "You",
+            "assistant" => "Assistant",
+            _ => "System",
+        };
+        lines.push(Line::from(vec![
+            Span::raw(" "),
+            Span::styled(
+                format!("Message #{message_index} — {role_label}"),
+                theme
+                    .style_accent()
+                    .add_modifier(Modifier::BOLD),
+            ),
+        ]));
+
+        // Metadata
+        if let Some(ref model) = msg.model {
+            lines.push(Line::from(vec![
+                Span::raw("  "),
+                Span::styled("Model: ", theme.style_dim()),
+                Span::styled(model.clone(), theme.style_fg()),
+            ]));
+        }
+
+        if let Some(ref ts) = msg.timestamp {
+            lines.push(Line::from(vec![
+                Span::raw("  "),
+                Span::styled("Time: ", theme.style_dim()),
+                Span::styled(ts.clone(), theme.style_fg()),
+            ]));
+        }
+
+        lines.push(Line::raw(""));
+
+        // Tool calls
+        if !msg.tool_calls.is_empty() {
+            lines.push(Line::from(vec![
+                Span::raw("  "),
+                Span::styled(
+                    "Tool Calls:",
+                    theme
+                        .style_fg()
+                        .add_modifier(Modifier::BOLD),
+                ),
+            ]));
+            for tc in &msg.tool_calls {
+                let status = if tc.is_error { "FAILED" } else { "OK" };
+                let dur = tc
+                    .duration_ms
+                    .map(|ms| format!(" ({ms}ms)"))
+                    .unwrap_or_default();
+                let color = if tc.is_error { theme.error } else { theme.fg_dim };
+                lines.push(Line::from(vec![
+                    Span::raw("    "),
+                    Span::styled(format!("{} [{status}]{dur}", tc.name), Style::default().fg(color)),
+                ]));
+            }
+            lines.push(Line::raw(""));
+        }
+
+        // Full content
+        lines.push(Line::from(vec![
+            Span::raw("  "),
+            Span::styled(
+                "Content:",
+                theme
+                    .style_fg()
+                    .add_modifier(Modifier::BOLD),
+            ),
+        ]));
+
+        let rendered = crate::markdown::render(
+            &msg.text,
+            area.width.saturating_sub(4) as usize,
+            theme,
+            &app.highlighter,
+        );
+        for line in rendered {
+            let mut padded = vec![Span::raw("  ")];
+            padded.extend(line.spans);
+            lines.push(Line::from(padded));
+        }
+    } else {
+        lines.push(Line::from(vec![
+            Span::raw("  "),
+            Span::styled(
+                format!("Message #{message_index} not found."),
+                theme.style_error(),
+            ),
+        ]));
+    }
+
+    lines.push(Line::raw(""));
+    lines.push(Line::from(vec![
+        Span::raw("  "),
+        Span::styled("Esc", theme.style_accent()),
+        Span::styled(" back  ", theme.style_dim()),
+        Span::styled("c", theme.style_accent()),
+        Span::styled(" copy  ", theme.style_dim()),
+        Span::styled("y", theme.style_accent()),
+        Span::styled(" yank code", theme.style_dim()),
+    ]));
+
+    let block = Block::default().borders(Borders::NONE);
+    let scroll = if app.auto_scroll {
+        0
+    } else {
+        app.scroll_offset as u16
+    };
+    let paragraph = Paragraph::new(lines)
+        .block(block)
+        .wrap(Wrap { trim: false })
+        .scroll((scroll, 0));
+    frame.render_widget(paragraph, area);
+}
+
+/// Dispatch rendering to the appropriate view based on the current view stack.
+pub(crate) fn render_for_view(app: &App, frame: &mut Frame, area: Rect, theme: &ThemePalette) {
+    match app.view_stack.current() {
+        View::Home => {
+            // Home view uses the existing chat area rendering
+            super::render_chat_area(app, frame, area, theme);
+        }
+        View::Sessions { .. } => {
+            render_sessions(app, frame, area, theme);
+        }
+        View::Conversation { .. } => {
+            // Conversation view reuses the chat area rendering
+            super::render_chat_area(app, frame, area, theme);
+        }
+        View::MessageDetail { message_index } => {
+            render_message_detail(app, frame, area, theme, *message_index);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- **ViewStack type** with push/pop/current/breadcrumbs — the stack always has `Home` at the bottom (cannot be popped)
- **Enter drills in**: selection mode Enter pushes `MessageDetail` (or `Sessions`/`Conversation` from appropriate views)
- **Esc pops back**: returns to previous view; at Home, deselects message instead
- **Breadcrumb bar**: rendered in title bar showing `Home > Sessions > Conversation` with dim parents / bold current
- **View-specific rendering**: sessions list for agents, full message detail with metadata/tool calls/markdown
- **Scroll state preservation**: per-view scroll offset saved on push, restored on pop
- **28 new tests** across ViewStack unit tests, view_nav integration tests, and mapping key tests

## Test plan

- [x] `cargo check -p aletheia-tui` — compiles clean
- [x] `cargo test -p aletheia-tui` — 461 tests pass (28 new)
- [x] `cargo clippy -p aletheia-tui --all-targets -- -D warnings` — zero warnings
- [ ] Manual: launch TUI, select a message, press Enter → message detail view with breadcrumbs
- [ ] Manual: press Esc → returns to Home view with scroll position restored
- [ ] Manual: drill Home → Sessions → Conversation → Message, verify breadcrumbs update

🤖 Generated with [Claude Code](https://claude.com/claude-code)