### PR TITLE
fix(nous): replace blocking I/O with tokio equivalents in async contexts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,7 +109,7 @@ cron = "0.15"
 jiff = "0.2"
 
 # Async
-tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "signal", "sync", "time"] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "signal", "sync", "time", "fs"] }
 tokio-stream = "0.1"
 tokio-util = { version = "0.7", features = ["rt"] }
 

--- a/crates/nous/src/actor.rs
+++ b/crates/nous/src/actor.rs
@@ -118,7 +118,7 @@ impl NousActor {
     /// inconsistent state.
     #[instrument(skip(self), fields(nous.id = %self.id))]
     pub async fn run(mut self) {
-        if let Err(e) = validate_workspace(&self.oikos, &self.id) {
+        if let Err(e) = validate_workspace(&self.oikos, &self.id).await {
             error!(error = %e, "workspace validation failed, shutting down");
             return;
         }
@@ -653,15 +653,16 @@ async fn run_background_distillation(
 /// Called at actor startup before entering the message loop. Creates the
 /// workspace directory if missing and fails fast if SOUL.md cannot be found
 /// through the cascade.
-fn validate_workspace(oikos: &Oikos, nous_id: &str) -> crate::error::Result<()> {
+async fn validate_workspace(oikos: &Oikos, nous_id: &str) -> crate::error::Result<()> {
     let workspace = oikos.nous_dir(nous_id);
-    if !workspace.exists() {
+    let exists = tokio::fs::try_exists(&workspace).await.unwrap_or(false);
+    if !exists {
         warn!(
             agent = nous_id,
             path = %workspace.display(),
             "workspace directory missing, creating"
         );
-        std::fs::create_dir_all(&workspace).map_err(|e| {
+        tokio::fs::create_dir_all(&workspace).await.map_err(|e| {
             crate::error::WorkspaceValidationSnafu {
                 nous_id: nous_id.to_owned(),
                 message: format!("failed to create workspace directory: {e}"),
@@ -1065,8 +1066,8 @@ mod tests {
         assert_eq!(DEFAULT_INBOX_CAPACITY, 32);
     }
 
-    #[test]
-    fn validate_workspace_creates_missing_dir() {
+    #[tokio::test]
+    async fn validate_workspace_creates_missing_dir() {
         let dir = tempfile::TempDir::new().expect("tmpdir");
         let root = dir.path();
         // Only create shared/ with SOUL.md for cascade fallback
@@ -1075,12 +1076,12 @@ mod tests {
         std::fs::write(root.join("shared/SOUL.md"), "# Test Soul").expect("write");
 
         let oikos = Oikos::from_root(root);
-        super::validate_workspace(&oikos, "test-agent").unwrap();
+        super::validate_workspace(&oikos, "test-agent").await.unwrap();
         assert!(root.join("nous/test-agent").exists());
     }
 
-    #[test]
-    fn validate_workspace_fails_without_soul() {
+    #[tokio::test]
+    async fn validate_workspace_fails_without_soul() {
         let dir = tempfile::TempDir::new().expect("tmpdir");
         let root = dir.path();
         std::fs::create_dir_all(root.join("nous/test-agent")).expect("mkdir");
@@ -1088,7 +1089,7 @@ mod tests {
         std::fs::create_dir_all(root.join("theke")).expect("mkdir theke");
 
         let oikos = Oikos::from_root(root);
-        let result = super::validate_workspace(&oikos, "test-agent");
+        let result = super::validate_workspace(&oikos, "test-agent").await;
         assert!(result.is_err());
         let msg = result.unwrap_err().to_string();
         assert!(

--- a/crates/nous/src/bootstrap/mod.rs
+++ b/crates/nous/src/bootstrap/mod.rs
@@ -169,8 +169,8 @@ impl<'a, E: TokenEstimator> BootstrapAssembler<'a, E> {
     ///
     /// Returns [`error::Error::ContextAssembly`] if a Required file (SOUL.md) is
     /// missing or unreadable.
-    pub fn assemble(&self, nous_id: &str, budget: &mut TokenBudget) -> Result<BootstrapResult> {
-        self.assemble_with_extra(nous_id, budget, Vec::new())
+    pub async fn assemble(&self, nous_id: &str, budget: &mut TokenBudget) -> Result<BootstrapResult> {
+        self.assemble_with_extra(nous_id, budget, Vec::new()).await
     }
 
     /// Assemble the bootstrap system prompt with additional sections from domain packs.
@@ -183,13 +183,13 @@ impl<'a, E: TokenEstimator> BootstrapAssembler<'a, E> {
     ///
     /// Returns [`error::Error::ContextAssembly`] if a Required file (SOUL.md) is
     /// missing or unreadable.
-    pub fn assemble_with_extra(
+    pub async fn assemble_with_extra(
         &self,
         nous_id: &str,
         budget: &mut TokenBudget,
         extra_sections: Vec<BootstrapSection>,
     ) -> Result<BootstrapResult> {
-        let mut sections = self.resolve_workspace_files(nous_id)?;
+        let mut sections = self.resolve_workspace_files(nous_id).await?;
         sections.extend(extra_sections);
 
         // Stable sort preserves declaration order within same priority
@@ -261,7 +261,7 @@ impl<'a, E: TokenEstimator> BootstrapAssembler<'a, E> {
     }
 
     /// Resolve workspace files through the cascade and read their contents.
-    fn resolve_workspace_files(&self, nous_id: &str) -> Result<Vec<BootstrapSection>> {
+    async fn resolve_workspace_files(&self, nous_id: &str) -> Result<Vec<BootstrapSection>> {
         let mut sections = Vec::new();
 
         for spec in WORKSPACE_FILES {
@@ -276,7 +276,7 @@ impl<'a, E: TokenEstimator> BootstrapAssembler<'a, E> {
                 continue;
             };
 
-            match std::fs::read_to_string(&p) {
+            match tokio::fs::read_to_string(&p).await {
                 Ok(content) => {
                     let content = content.trim().to_owned();
                     if content.is_empty() {
@@ -449,25 +449,25 @@ mod tests {
 
     // --- Assembly tests ---
 
-    #[test]
-    fn assemble_with_required_only() {
+    #[tokio::test]
+    async fn assemble_with_required_only() {
         let (_dir, oikos) = setup_oikos("test", &[("SOUL.md", "I am a test agent.")]);
         let assembler = BootstrapAssembler::new(&oikos);
         let mut budget = default_budget();
 
-        let result = assembler.assemble("test", &mut budget).unwrap();
+        let result = assembler.assemble("test", &mut budget).await.unwrap();
         assert!(result.system_prompt.contains("I am a test agent."));
         assert_eq!(result.sections_included, vec!["SOUL.md"]);
         assert!(result.sections_dropped.is_empty());
     }
 
-    #[test]
-    fn assemble_missing_required_errors() {
+    #[tokio::test]
+    async fn assemble_missing_required_errors() {
         let (_dir, oikos) = setup_oikos("test", &[("USER.md", "some user info")]);
         let assembler = BootstrapAssembler::new(&oikos);
         let mut budget = default_budget();
 
-        let err = assembler.assemble("test", &mut budget).unwrap_err();
+        let err = assembler.assemble("test", &mut budget).await.unwrap_err();
         let msg = err.to_string();
         assert!(
             msg.contains("SOUL.md"),
@@ -475,20 +475,20 @@ mod tests {
         );
     }
 
-    #[test]
-    fn assemble_missing_optional_skips() {
+    #[tokio::test]
+    async fn assemble_missing_optional_skips() {
         let (_dir, oikos) = setup_oikos("test", &[("SOUL.md", "identity")]);
         let assembler = BootstrapAssembler::new(&oikos);
         let mut budget = default_budget();
 
-        let result = assembler.assemble("test", &mut budget).unwrap();
+        let result = assembler.assemble("test", &mut budget).await.unwrap();
         // Only SOUL.md included, others silently skipped
         assert_eq!(result.sections_included, vec!["SOUL.md"]);
         assert!(result.sections_dropped.is_empty());
     }
 
-    #[test]
-    fn assemble_priority_ordering() {
+    #[tokio::test]
+    async fn assemble_priority_ordering() {
         let (_dir, oikos) = setup_oikos(
             "test",
             &[
@@ -500,7 +500,7 @@ mod tests {
         let assembler = BootstrapAssembler::new(&oikos);
         let mut budget = default_budget();
 
-        let result = assembler.assemble("test", &mut budget).unwrap();
+        let result = assembler.assemble("test", &mut budget).await.unwrap();
         // Required (SOUL) before Important (GOALS) before Flexible (MEMORY)
         let soul_pos = result
             .sections_included
@@ -521,8 +521,8 @@ mod tests {
         assert!(goals_pos < memory_pos);
     }
 
-    #[test]
-    fn assemble_all_files_present() {
+    #[tokio::test]
+    async fn assemble_all_files_present() {
         let (_dir, oikos) = setup_oikos(
             "test",
             &[
@@ -540,13 +540,13 @@ mod tests {
         let assembler = BootstrapAssembler::new(&oikos);
         let mut budget = default_budget();
 
-        let result = assembler.assemble("test", &mut budget).unwrap();
+        let result = assembler.assemble("test", &mut budget).await.unwrap();
         assert_eq!(result.sections_included.len(), 9);
         assert!(result.total_tokens > 0);
     }
 
-    #[test]
-    fn assemble_empty_file_skipped() {
+    #[tokio::test]
+    async fn assemble_empty_file_skipped() {
         let (_dir, oikos) = setup_oikos(
             "test",
             &[
@@ -558,12 +558,12 @@ mod tests {
         let assembler = BootstrapAssembler::new(&oikos);
         let mut budget = default_budget();
 
-        let result = assembler.assemble("test", &mut budget).unwrap();
+        let result = assembler.assemble("test", &mut budget).await.unwrap();
         assert_eq!(result.sections_included, vec!["SOUL.md"]);
     }
 
-    #[test]
-    fn assemble_memory_truncated() {
+    #[tokio::test]
+    async fn assemble_memory_truncated() {
         // Create a large MEMORY.md that exceeds a small budget
         let large_memory = "## Recent\nNew stuff here.\n## Old\nOld stuff here that is much longer and should be truncated when the budget is tight. ".repeat(50);
         let (_dir, oikos) = setup_oikos(
@@ -574,7 +574,7 @@ mod tests {
         // Small budget: enough for SOUL.md but not full MNEME.md
         let mut budget = TokenBudget::new(100_000, 0.0, 0, 500);
 
-        let result = assembler.assemble("test", &mut budget).unwrap();
+        let result = assembler.assemble("test", &mut budget).await.unwrap();
         assert!(result.sections_included.contains(&"MEMORY.md".to_owned()));
         assert!(result.sections_truncated.contains(&"MEMORY.md".to_owned()));
         assert!(
@@ -584,8 +584,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn assemble_optional_dropped() {
+    #[tokio::test]
+    async fn assemble_optional_dropped() {
         // SOUL.md fills the entire budget, MEMORY.md gets dropped
         let large_soul = "x".repeat(2000); // ~500 tokens at 4 chars/token
         let (_dir, oikos) = setup_oikos(
@@ -595,36 +595,36 @@ mod tests {
         let assembler = BootstrapAssembler::new(&oikos);
         let mut budget = TokenBudget::new(100_000, 0.0, 0, 500);
 
-        let result = assembler.assemble("test", &mut budget).unwrap();
+        let result = assembler.assemble("test", &mut budget).await.unwrap();
         assert!(result.sections_included.contains(&"SOUL.md".to_owned()));
         assert!(result.sections_dropped.contains(&"MEMORY.md".to_owned()));
     }
 
-    #[test]
-    fn assemble_budget_consumed_correctly() {
+    #[tokio::test]
+    async fn assemble_budget_consumed_correctly() {
         let (_dir, oikos) =
             setup_oikos("test", &[("SOUL.md", "identity"), ("USER.md", "user info")]);
         let assembler = BootstrapAssembler::new(&oikos);
         let mut budget = default_budget();
 
-        let result = assembler.assemble("test", &mut budget).unwrap();
+        let result = assembler.assemble("test", &mut budget).await.unwrap();
         assert_eq!(budget.consumed(), result.total_tokens);
         assert!(result.total_tokens > 0);
     }
 
-    #[test]
-    fn assemble_cascade_nous_tier() {
+    #[tokio::test]
+    async fn assemble_cascade_nous_tier() {
         // File only in nous tier
         let (_dir, oikos) = setup_oikos("syn", &[("SOUL.md", "I am Syn.")]);
         let assembler = BootstrapAssembler::new(&oikos);
         let mut budget = default_budget();
 
-        let result = assembler.assemble("syn", &mut budget).unwrap();
+        let result = assembler.assemble("syn", &mut budget).await.unwrap();
         assert!(result.system_prompt.contains("I am Syn."));
     }
 
-    #[test]
-    fn assemble_cascade_theke_fallback() {
+    #[tokio::test]
+    async fn assemble_cascade_theke_fallback() {
         // USER.md only in theke (common pattern)
         let (_dir, oikos) = setup_oikos(
             "syn",
@@ -633,13 +633,13 @@ mod tests {
         let assembler = BootstrapAssembler::new(&oikos);
         let mut budget = default_budget();
 
-        let result = assembler.assemble("syn", &mut budget).unwrap();
+        let result = assembler.assemble("syn", &mut budget).await.unwrap();
         assert!(result.system_prompt.contains("Alice T."));
         assert!(result.sections_included.contains(&"USER.md".to_owned()));
     }
 
-    #[test]
-    fn assemble_nous_overrides_theke() {
+    #[tokio::test]
+    async fn assemble_nous_overrides_theke() {
         // SOUL.md in both tiers — nous wins
         let dir = TempDir::new().unwrap();
         let root = dir.path();
@@ -653,7 +653,7 @@ mod tests {
         let assembler = BootstrapAssembler::new(&oikos);
         let mut budget = default_budget();
 
-        let result = assembler.assemble("syn", &mut budget).unwrap();
+        let result = assembler.assemble("syn", &mut budget).await.unwrap();
         assert!(result.system_prompt.contains("nous-specific soul"));
         assert!(!result.system_prompt.contains("theke soul"));
     }
@@ -743,8 +743,8 @@ mod tests {
         assert!(result.is_empty());
     }
 
-    #[test]
-    fn assemble_with_extra_includes_pack_sections() {
+    #[tokio::test]
+    async fn assemble_with_extra_includes_pack_sections() {
         let (_dir, oikos) = setup_oikos("test", &[("SOUL.md", "I am a test agent.")]);
         let assembler = BootstrapAssembler::new(&oikos);
         let mut budget = default_budget();
@@ -759,6 +759,7 @@ mod tests {
 
         let result = assembler
             .assemble_with_extra("test", &mut budget, extra)
+            .await
             .unwrap();
         assert!(result.system_prompt.contains("Domain logic from pack."));
         assert!(
@@ -769,8 +770,8 @@ mod tests {
         assert_eq!(result.sections_included.len(), 2);
     }
 
-    #[test]
-    fn assemble_with_extra_respects_priority_ordering() {
+    #[tokio::test]
+    async fn assemble_with_extra_respects_priority_ordering() {
         let (_dir, oikos) = setup_oikos("test", &[("SOUL.md", "identity")]);
         let assembler = BootstrapAssembler::new(&oikos);
         let mut budget = default_budget();
@@ -794,6 +795,7 @@ mod tests {
 
         let result = assembler
             .assemble_with_extra("test", &mut budget, extra)
+            .await
             .unwrap();
 
         // SOUL.md (Required) < important-pack (Important) < optional-pack (Optional)

--- a/crates/nous/src/pipeline.rs
+++ b/crates/nous/src/pipeline.rs
@@ -263,18 +263,18 @@ impl TurnUsage {
 /// Returns [`crate::error::Error::ContextAssembly`] if required workspace files
 /// (e.g. SOUL.md) are missing.
 #[instrument(skip_all, fields(nous_id = %nous_config.id))]
-pub fn assemble_context(
+pub async fn assemble_context(
     oikos: &Oikos,
     nous_config: &NousConfig,
     pipeline_config: &PipelineConfig,
     ctx: &mut PipelineContext,
 ) -> crate::error::Result<()> {
-    assemble_context_with_extra(oikos, nous_config, pipeline_config, ctx, Vec::new())
+    assemble_context_with_extra(oikos, nous_config, pipeline_config, ctx, Vec::new()).await
 }
 
 /// Assemble bootstrap context with extra sections from domain packs.
 #[instrument(skip_all, fields(nous_id = %nous_config.id))]
-pub fn assemble_context_with_extra(
+pub async fn assemble_context_with_extra(
     oikos: &Oikos,
     nous_config: &NousConfig,
     pipeline_config: &PipelineConfig,
@@ -289,7 +289,9 @@ pub fn assemble_context_with_extra(
     );
 
     let assembler = BootstrapAssembler::new(oikos);
-    let result = assembler.assemble_with_extra(&nous_config.id, &mut budget, extra_sections)?;
+    let result = assembler
+        .assemble_with_extra(&nous_config.id, &mut budget, extra_sections)
+        .await?;
 
     ctx.system_prompt = Some(result.system_prompt);
     #[expect(
@@ -361,7 +363,8 @@ pub async fn run_pipeline(
         );
         let _guard = span.enter();
         let start = Instant::now();
-        assemble_context_with_extra(oikos, config, pipeline_config, &mut ctx, extra_bootstrap)?;
+        assemble_context_with_extra(oikos, config, pipeline_config, &mut ctx, extra_bootstrap)
+            .await?;
         #[expect(
             clippy::cast_possible_truncation,
             reason = "stage duration fits in u64"
@@ -840,8 +843,8 @@ mod tests {
 
     // --- Context assembly ---
 
-    #[test]
-    fn assemble_context_populates_pipeline() {
+    #[tokio::test]
+    async fn assemble_context_populates_pipeline() {
         use crate::config::{NousConfig, PipelineConfig};
         use aletheia_taxis::oikos::Oikos;
         use std::fs;
@@ -863,7 +866,9 @@ mod tests {
         let pipeline_config = PipelineConfig::default();
         let mut ctx = PipelineContext::default();
 
-        assemble_context(&oikos, &nous_config, &pipeline_config, &mut ctx).unwrap();
+        assemble_context(&oikos, &nous_config, &pipeline_config, &mut ctx)
+            .await
+            .unwrap();
 
         assert!(ctx.system_prompt.is_some());
         let prompt = ctx.system_prompt.unwrap();
@@ -1132,8 +1137,8 @@ mod tests {
         assert_eq!(check_guard(&session, &config), GuardResult::Allow);
     }
 
-    #[test]
-    fn assemble_context_missing_soul_returns_error() {
+    #[tokio::test]
+    async fn assemble_context_missing_soul_returns_error() {
         use aletheia_taxis::oikos::Oikos;
         use tempfile::TempDir;
 
@@ -1152,7 +1157,7 @@ mod tests {
         let pipeline_config = crate::config::PipelineConfig::default();
         let mut ctx = PipelineContext::default();
 
-        let err = assemble_context(&oikos, &config, &pipeline_config, &mut ctx);
+        let err = assemble_context(&oikos, &config, &pipeline_config, &mut ctx).await;
         assert!(err.is_err());
         let msg = err.unwrap_err().to_string();
         assert!(msg.contains("SOUL.md"), "got: {msg}");

--- a/crates/nous/src/spawn_svc.rs
+++ b/crates/nous/src/spawn_svc.rs
@@ -109,14 +109,16 @@ impl SpawnService for SpawnServiceImpl {
             async move {
                 // Create minimal workspace directory for the ephemeral agent
                 let nous_dir = oikos.nous_dir(&spawn_id);
-                if let Err(e) = std::fs::create_dir_all(&nous_dir) {
+                if let Err(e) = tokio::fs::create_dir_all(&nous_dir).await {
                     return Err(format!("failed to create spawn workspace: {e}"));
                 }
                 let soul_path = nous_dir.join("SOUL.md");
-                if let Err(e) = std::fs::write(
+                if let Err(e) = tokio::fs::write(
                     &soul_path,
                     format!("You are an ephemeral {role_desc} sub-agent. Complete the assigned task precisely and concisely."),
-                ) {
+                )
+                .await
+                {
                     return Err(format!("failed to write SOUL.md: {e}"));
                 }
 
@@ -149,7 +151,7 @@ impl SpawnService for SpawnServiceImpl {
                 let _ = join_handle.await;
 
                 // Clean up ephemeral workspace
-                let _ = std::fs::remove_dir_all(&nous_dir);
+                let _ = tokio::fs::remove_dir_all(&nous_dir).await;
 
                 match result {
                     Ok(Ok(turn)) => Ok(SpawnResult {

--- a/tui/src/lib.rs
+++ b/tui/src/lib.rs
@@ -66,9 +66,11 @@ async fn run_tui_inner(
     let log_dir = dirs::data_local_dir()
         .unwrap_or_else(|| std::path::PathBuf::from("."))
         .join("aletheia");
-    std::fs::create_dir_all(&log_dir).context(IoSnafu {
-        context: "create log directory",
-    })?;
+    tokio::fs::create_dir_all(&log_dir)
+        .await
+        .context(IoSnafu {
+            context: "create log directory",
+        })?;
     let file_appender = rolling::daily(&log_dir, "tui.log");
     let (non_blocking, _guard) = tracing_appender::non_blocking(file_appender);
     fmt()


### PR DESCRIPTION
## Summary

- **bootstrap/mod.rs**: `resolve_workspace_files` converted to `async fn` using `tokio::fs::read_to_string`; `assemble` and `assemble_with_extra` promoted to async (14 call sites updated including tests)
- **pipeline.rs**: `assemble_context` and `assemble_context_with_extra` promoted to async; call in `run_pipeline` updated with `.await`
- **spawn_svc.rs**: `std::fs::create_dir_all`, `std::fs::write`, and `std::fs::remove_dir_all` replaced with `tokio::fs` equivalents inside the ephemeral agent `async` block
- **actor.rs**: `validate_workspace` promoted to `async fn`; `Path::exists()` replaced with `tokio::fs::try_exists`, `std::fs::create_dir_all` replaced with `tokio::fs::create_dir_all`
- **tui/src/lib.rs**: startup log-dir creation changed from `std::fs::create_dir_all` to `tokio::fs::create_dir_all`
- **Cargo.toml**: added `"fs"` to workspace tokio feature list

## Justification note

`tui/src/update/input.rs` `handle_compose_in_editor` retains intentional blocking: the TUI calls `ratatui::restore()` before launching the editor, suspending the event loop entirely. The existing comment documents this.

## Test plan

- [x] `cargo check -p aletheia-nous -p aletheia-tui` — clean
- [x] `cargo test -p aletheia-nous` — 281 passed, 0 failed
- [x] `cargo clippy -p aletheia-nous -p aletheia-tui --all-targets -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)