### PR TITLE
refactor(nous): migrate SessionStore to tokio::sync::Mutex

### DIFF
--- a/crates/aletheia/src/main.rs
+++ b/crates/aletheia/src/main.rs
@@ -11,8 +11,9 @@ mod planning_adapter;
 mod status;
 
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use std::time::Instant;
+use tokio::sync::Mutex;
 
 use anyhow::{Context, Result};
 use clap::{CommandFactory, Parser, Subcommand};

--- a/crates/integration-tests/tests/organon_mneme_tools.rs
+++ b/crates/integration-tests/tests/organon_mneme_tools.rs
@@ -15,7 +15,8 @@ use std::collections::HashSet;
 use std::future::Future;
 use std::path::PathBuf;
 use std::pin::Pin;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
+use tokio::sync::Mutex;
 
 use aletheia_koina::id::ToolName;
 use aletheia_koina::id::{NousId, SessionId};
@@ -42,7 +43,7 @@ fn test_store() -> Arc<Mutex<SessionStore>> {
 fn ctx_with_notes_bb(store: &Arc<Mutex<SessionStore>>) -> ToolContext {
     let session_id = SessionId::new();
     {
-        let s = store.lock().unwrap();
+        let s = store.blocking_lock();
         s.create_session(&session_id.to_string(), "alice", "test-key", None, None)
             .expect("create session");
     }
@@ -87,7 +88,7 @@ fn tool_input(name: &str, args: serde_json::Value) -> ToolInput {
 // Note tool → real SessionStore
 // ---------------------------------------------------------------------------
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn note_add_and_list_uses_real_store() {
     let store = test_store();
     let reg = registry();
@@ -113,7 +114,7 @@ async fn note_add_and_list_uses_real_store() {
     assert!(r.content.text_summary().contains("remember the vow"));
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn note_delete_removes_from_real_store() {
     let store = test_store();
     let reg = registry();
@@ -141,7 +142,7 @@ async fn note_delete_removes_from_real_store() {
 // Blackboard tool → real SessionStore
 // ---------------------------------------------------------------------------
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn blackboard_write_and_read_uses_real_store() {
     let store = test_store();
     let reg = registry();
@@ -168,7 +169,7 @@ async fn blackboard_write_and_read_uses_real_store() {
     assert!(r.content.text_summary().contains("ready"));
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn blackboard_delete_uses_real_store() {
     let store = test_store();
     let reg = registry();
@@ -203,21 +204,21 @@ async fn blackboard_delete_uses_real_store() {
 // ---------------------------------------------------------------------------
 
 struct StubKnowledgeService {
-    facts: Mutex<Vec<(String, String)>>, // (id, content)
-    next_id: Mutex<u32>,
-    corrected: Mutex<Vec<(String, String)>>, // (old_id, new_id)
-    retracted: Mutex<Vec<String>>,
-    audited: Mutex<Vec<(String, String)>>, // (id, content) — FactSummary not Clone
+    facts: std::sync::Mutex<Vec<(String, String)>>, // (id, content)
+    next_id: std::sync::Mutex<u32>,
+    corrected: std::sync::Mutex<Vec<(String, String)>>, // (old_id, new_id)
+    retracted: std::sync::Mutex<Vec<String>>,
+    audited: std::sync::Mutex<Vec<(String, String)>>, // (id, content) — FactSummary not Clone
 }
 
 impl StubKnowledgeService {
     fn new() -> Self {
         Self {
-            facts: Mutex::new(Vec::new()),
-            next_id: Mutex::new(1),
-            corrected: Mutex::new(Vec::new()),
-            retracted: Mutex::new(Vec::new()),
-            audited: Mutex::new(Vec::new()),
+            facts: std::sync::Mutex::new(Vec::new()),
+            next_id: std::sync::Mutex::new(1),
+            corrected: std::sync::Mutex::new(Vec::new()),
+            retracted: std::sync::Mutex::new(Vec::new()),
+            audited: std::sync::Mutex::new(Vec::new()),
         }
     }
 

--- a/crates/nous/src/actor.rs
+++ b/crates/nous/src/actor.rs
@@ -1,7 +1,9 @@
 //! Tokio actor for a single nous agent instance.
 
 use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
+
+use tokio::sync::Mutex;
 
 #[cfg(feature = "knowledge-store")]
 use aletheia_mneme::knowledge_store::KnowledgeStore;
@@ -215,7 +217,7 @@ impl NousActor {
 
         if let Ok(ref turn_result) = result {
             self.maybe_spawn_extraction(&content, &turn_result.content);
-            self.maybe_spawn_distillation(&session_key);
+            self.maybe_spawn_distillation(&session_key).await;
         }
 
         self.active_session = None;
@@ -251,7 +253,7 @@ impl NousActor {
 
         if let Ok(ref turn_result) = result {
             self.maybe_spawn_extraction(&content, &turn_result.content);
-            self.maybe_spawn_distillation(&session_key);
+            self.maybe_spawn_distillation(&session_key).await;
         }
 
         self.active_session = None;
@@ -431,7 +433,7 @@ impl NousActor {
         );
     }
 
-    fn maybe_spawn_distillation(&self, session_key: &str) {
+    async fn maybe_spawn_distillation(&self, session_key: &str) {
         let Some(ref store_arc) = self.session_store else {
             return;
         };
@@ -440,12 +442,9 @@ impl NousActor {
         };
         let session_id = session_state.id.clone();
 
-        // Quick trigger check under the lock
+        // Quick trigger check under the lock — guard is dropped before any spawn
         let should_distill = {
-            let Ok(store) = store_arc.lock() else {
-                warn!("session store lock poisoned, skipping distillation check");
-                return;
-            };
+            let store = store_arc.lock().await;
             let Ok(Some(session)) = store.find_session_by_id(&session_id) else {
                 return;
             };
@@ -583,12 +582,10 @@ async fn run_background_distillation(
         return;
     };
 
-    // Load history under the lock, then release before async work
+    // Load history under the lock, then release before async work.
+    // Guard is scoped to the block and dropped before the .await below.
     let (history, session) = {
-        let Ok(s) = store.lock() else {
-            warn!("session store lock poisoned, skipping distillation");
-            return;
-        };
+        let s = store.lock().await;
         let Ok(Some(session)) = s.find_session_by_id(&session_id) else {
             return;
         };
@@ -600,7 +597,7 @@ async fn run_background_distillation(
                 return;
             }
         }
-    };
+    }; // guard dropped here — lock released before await
 
     let messages = crate::distillation::convert_to_hermeneus_messages(&history);
     let engine =
@@ -627,11 +624,8 @@ async fn run_background_distillation(
         }
     };
 
-    // Apply results under the lock
-    let Ok(s) = store.lock() else {
-        warn!("session store lock poisoned, skipping distillation apply");
-        return;
-    };
+    // Apply results under the lock — guard is scoped to this block
+    let s = store.lock().await;
     if let Err(e) = crate::distillation::apply_distillation(&s, &session_id, &result, &history) {
         warn!(error = %e, "failed to apply distillation");
         return;
@@ -762,6 +756,7 @@ mod tests {
     // --- Test infrastructure ---
 
     struct MockProvider {
+        // std::sync::Mutex is intentional — test mock, never crosses .await
         response: Mutex<CompletionResponse>,
     }
 

--- a/crates/nous/src/adapters.rs
+++ b/crates/nous/src/adapters.rs
@@ -1,18 +1,29 @@
 //! Trait adapters bridging organon tool traits to mneme SessionStore.
 
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
+
+use tokio::sync::Mutex;
 
 use aletheia_mneme::store::SessionStore;
 use aletheia_organon::types::{BlackboardEntry, BlackboardStore, NoteEntry, NoteStore};
 
 type BoxError = Box<dyn std::error::Error + Send + Sync>;
 
-fn lock_store(
-    store: &Mutex<SessionStore>,
-) -> Result<std::sync::MutexGuard<'_, SessionStore>, BoxError> {
-    store
-        .lock()
-        .map_err(|e| -> BoxError { e.to_string().into() })
+/// Acquire the store lock from a synchronous trait method inside an async context.
+///
+/// Uses `block_in_place` so the Tokio runtime can continue driving other tasks
+/// while the calling thread blocks waiting for the lock. Callers must be running
+/// on the **multi-thread** Tokio runtime; single-thread runtimes will panic.
+///
+/// The guard is held only for the duration of `f` and dropped before returning.
+fn with_store<F, T>(store: &Arc<Mutex<SessionStore>>, f: F) -> T
+where
+    F: FnOnce(&SessionStore) -> T,
+{
+    tokio::task::block_in_place(|| {
+        let guard = tokio::runtime::Handle::current().block_on(store.lock());
+        f(&guard)
+    })
 }
 
 /// Adapts `SessionStore` note methods to the `NoteStore` trait.
@@ -26,33 +37,36 @@ impl NoteStore for SessionNoteAdapter {
         category: &str,
         content: &str,
     ) -> Result<i64, BoxError> {
-        let store = lock_store(&self.0)?;
-        store
-            .add_note(session_id, nous_id, category, content)
-            .map_err(|e| Box::new(e) as BoxError)
+        with_store(&self.0, |store| {
+            store
+                .add_note(session_id, nous_id, category, content)
+                .map_err(|e| Box::new(e) as BoxError)
+        })
     }
 
     fn get_notes(&self, session_id: &str) -> Result<Vec<NoteEntry>, BoxError> {
-        let store = lock_store(&self.0)?;
-        let notes = store
-            .get_notes(session_id)
-            .map_err(|e| Box::new(e) as BoxError)?;
-        Ok(notes
-            .into_iter()
-            .map(|n| NoteEntry {
-                id: n.id,
-                category: n.category,
-                content: n.content,
-                created_at: n.created_at,
-            })
-            .collect())
+        with_store(&self.0, |store| {
+            let notes = store
+                .get_notes(session_id)
+                .map_err(|e| Box::new(e) as BoxError)?;
+            Ok(notes
+                .into_iter()
+                .map(|n| NoteEntry {
+                    id: n.id,
+                    category: n.category,
+                    content: n.content,
+                    created_at: n.created_at,
+                })
+                .collect())
+        })
     }
 
     fn delete_note(&self, note_id: i64) -> Result<bool, BoxError> {
-        let store = lock_store(&self.0)?;
-        store
-            .delete_note(note_id)
-            .map_err(|e| Box::new(e) as BoxError)
+        with_store(&self.0, |store| {
+            store
+                .delete_note(note_id)
+                .map_err(|e| Box::new(e) as BoxError)
+        })
     }
 }
 
@@ -67,49 +81,130 @@ impl BlackboardStore for SessionBlackboardAdapter {
         author: &str,
         ttl_seconds: i64,
     ) -> Result<(), BoxError> {
-        let store = lock_store(&self.0)?;
-        store
-            .blackboard_write(key, value, author, ttl_seconds)
-            .map_err(|e| Box::new(e) as BoxError)
+        with_store(&self.0, |store| {
+            store
+                .blackboard_write(key, value, author, ttl_seconds)
+                .map_err(|e| Box::new(e) as BoxError)
+        })
     }
 
     fn read(&self, key: &str) -> Result<Option<BlackboardEntry>, BoxError> {
-        let store = lock_store(&self.0)?;
-        let row = store
-            .blackboard_read(key)
-            .map_err(|e| Box::new(e) as BoxError)?;
-        Ok(row.map(|r| BlackboardEntry {
-            key: r.key,
-            value: r.value,
-            author_nous_id: r.author_nous_id,
-            ttl_seconds: r.ttl_seconds,
-            created_at: r.created_at,
-            expires_at: r.expires_at,
-        }))
-    }
-
-    fn list(&self) -> Result<Vec<BlackboardEntry>, BoxError> {
-        let store = lock_store(&self.0)?;
-        let rows = store
-            .blackboard_list()
-            .map_err(|e| Box::new(e) as BoxError)?;
-        Ok(rows
-            .into_iter()
-            .map(|r| BlackboardEntry {
+        with_store(&self.0, |store| {
+            let row = store
+                .blackboard_read(key)
+                .map_err(|e| Box::new(e) as BoxError)?;
+            Ok(row.map(|r| BlackboardEntry {
                 key: r.key,
                 value: r.value,
                 author_nous_id: r.author_nous_id,
                 ttl_seconds: r.ttl_seconds,
                 created_at: r.created_at,
                 expires_at: r.expires_at,
-            })
-            .collect())
+            }))
+        })
+    }
+
+    fn list(&self) -> Result<Vec<BlackboardEntry>, BoxError> {
+        with_store(&self.0, |store| {
+            let rows = store
+                .blackboard_list()
+                .map_err(|e| Box::new(e) as BoxError)?;
+            Ok(rows
+                .into_iter()
+                .map(|r| BlackboardEntry {
+                    key: r.key,
+                    value: r.value,
+                    author_nous_id: r.author_nous_id,
+                    ttl_seconds: r.ttl_seconds,
+                    created_at: r.created_at,
+                    expires_at: r.expires_at,
+                })
+                .collect())
+        })
     }
 
     fn delete(&self, key: &str, author: &str) -> Result<bool, BoxError> {
-        let store = lock_store(&self.0)?;
-        store
-            .blackboard_delete(key, author)
-            .map_err(|e| Box::new(e) as BoxError)
+        with_store(&self.0, |store| {
+            store
+                .blackboard_delete(key, author)
+                .map_err(|e| Box::new(e) as BoxError)
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aletheia_organon::types::NoteStore;
+
+    fn test_store() -> Arc<Mutex<SessionStore>> {
+        Arc::new(Mutex::new(
+            SessionStore::open_in_memory().expect("in-memory store"),
+        ))
+    }
+
+    /// Verify that `SessionNoteAdapter` can be locked and used from an async
+    /// context running on a multi-thread Tokio runtime.
+    ///
+    /// The adapter uses `block_in_place` internally, which requires the
+    /// multi-thread runtime — this test confirms that path works end-to-end.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn note_adapter_lock_works_in_async_context() {
+        let store = test_store();
+
+        // Seed a session
+        {
+            let s = store.lock().await;
+            s.create_session("sess-1", "alice", "test-key", None, None)
+                .expect("create session");
+        }
+
+        let adapter = SessionNoteAdapter(Arc::clone(&store));
+
+        // add_note calls block_in_place internally
+        let id = adapter
+            .add_note("sess-1", "alice", "task", "buy oat milk")
+            .expect("add_note");
+        assert!(id > 0, "note id should be positive");
+
+        // get_notes should return the note
+        let notes = adapter.get_notes("sess-1").expect("get_notes");
+        assert_eq!(notes.len(), 1);
+        assert_eq!(notes[0].content, "buy oat milk");
+
+        // delete_note should remove it
+        let deleted = adapter.delete_note(id).expect("delete_note");
+        assert!(deleted);
+        let notes_after = adapter.get_notes("sess-1").expect("get_notes after delete");
+        assert!(notes_after.is_empty());
+    }
+
+    /// Verify that two concurrent tasks can each acquire the adapter lock
+    /// without deadlocking — lock is released between calls.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn note_adapter_lock_released_between_calls() {
+        let store = test_store();
+        {
+            let s = store.lock().await;
+            s.create_session("sess-a", "bob", "key-a", None, None)
+                .expect("create session");
+        }
+
+        let adapter = Arc::new(SessionNoteAdapter(Arc::clone(&store)));
+        let adapter2 = Arc::clone(&adapter);
+
+        let h1 = tokio::task::spawn_blocking(move || {
+            adapter
+                .add_note("sess-a", "bob", "task", "first")
+                .expect("h1")
+        });
+        let h2 = tokio::task::spawn_blocking(move || {
+            adapter2
+                .add_note("sess-a", "bob", "task", "second")
+                .expect("h2")
+        });
+
+        let (id1, id2) = tokio::try_join!(h1, h2).expect("both tasks succeed");
+        assert_ne!(id1, id2, "two notes should have distinct ids");
     }
 }

--- a/crates/nous/src/execute.rs
+++ b/crates/nous/src/execute.rs
@@ -652,6 +652,7 @@ mod tests {
     // --- Test Infrastructure ---
 
     struct MockProvider {
+        // std::sync::Mutex is intentional — test mock, never crosses .await
         responses: Mutex<Vec<CompletionResponse>>,
     }
 

--- a/crates/nous/src/manager.rs
+++ b/crates/nous/src/manager.rs
@@ -1,7 +1,9 @@
 //! Manages all nous actor instances.
 
 use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
+
+use tokio::sync::Mutex;
 
 #[cfg(feature = "knowledge-store")]
 use aletheia_mneme::knowledge_store::KnowledgeStore;
@@ -295,6 +297,7 @@ mod tests {
     use crate::message::NousLifecycle;
 
     struct MockProvider {
+        // std::sync::Mutex is intentional — test mock, never crosses .await
         response: Mutex<CompletionResponse>,
     }
 

--- a/crates/nous/src/pipeline.rs
+++ b/crates/nous/src/pipeline.rs
@@ -10,8 +10,9 @@
 //! 6. **Finalize** — persist messages, update counts, extract facts
 
 use std::collections::VecDeque;
-use std::sync::Mutex;
 use std::time::Instant;
+
+use tokio::sync::Mutex;
 
 use serde::{Deserialize, Serialize};
 use tracing::{debug, error, info_span, instrument, warn};
@@ -438,12 +439,8 @@ pub async fn run_pipeline(
         let start = Instant::now();
         let history_config = HistoryConfig::default();
         if let Some(store_mutex) = session_store {
-            let store = store_mutex.lock().map_err(|_poison| {
-                crate::error::MutexPoisonedSnafu {
-                    what: "session store",
-                }
-                .build()
-            })?;
+            // Guard is scoped to this block and dropped before the execute .await below
+            let store = store_mutex.lock().await;
             let (messages, hist_result) = history::load_history(
                 &store,
                 &input.session.id,
@@ -576,12 +573,7 @@ pub async fn run_pipeline(
         let _guard = span.enter();
         let start = Instant::now();
         if let Some(store_mutex) = session_store {
-            let store = store_mutex.lock().map_err(|_poison| {
-                crate::error::MutexPoisonedSnafu {
-                    what: "session store",
-                }
-                .build()
-            })?;
+            let store = store_mutex.lock().await;
             let finalize_config = crate::finalize::FinalizeConfig::default();
             match crate::finalize::finalize(
                 &store,

--- a/crates/nous/src/spawn_svc.rs
+++ b/crates/nous/src/spawn_svc.rs
@@ -191,6 +191,7 @@ mod tests {
     use super::*;
 
     struct MockProvider {
+        // std::sync::Mutex is intentional — test mock, never crosses .await
         response: Mutex<CompletionResponse>,
     }
 

--- a/crates/pylon/src/handlers/sessions.rs
+++ b/crates/pylon/src/handlers/sessions.rs
@@ -67,12 +67,7 @@ pub async fn create(
     let skey = session_key.clone();
 
     let session = tokio::task::spawn_blocking(move || {
-        let store = state_clone.session_store.lock().map_err(|_poison| {
-            InternalSnafu {
-                message: "session store lock poisoned",
-            }
-            .build()
-        })?;
+        let store = state_clone.session_store.blocking_lock();
         store
             .find_or_create_session(&id_clone, &nid, &skey, Some(&model), None)
             .map_err(ApiError::from)
@@ -98,12 +93,7 @@ pub async fn list_sessions(
 
     let state_clone = Arc::clone(&state);
     let sessions = tokio::task::spawn_blocking(move || {
-        let store = state_clone.session_store.lock().map_err(|_poison| {
-            InternalSnafu {
-                message: "session store lock poisoned",
-            }
-            .build()
-        })?;
+        let store = state_clone.session_store.blocking_lock();
         store
             .list_sessions(nous_id.as_deref())
             .map_err(ApiError::from)
@@ -188,12 +178,7 @@ async fn archive_session_by_id(state: &Arc<AppState>, id: &str) -> Result<Status
     let state_clone = Arc::clone(state);
     let id_clone = id.to_owned();
     tokio::task::spawn_blocking(move || {
-        let store = state_clone.session_store.lock().map_err(|_poison| {
-            InternalSnafu {
-                message: "session store lock poisoned",
-            }
-            .build()
-        })?;
+        let store = state_clone.session_store.blocking_lock();
         store
             .update_session_status(&id_clone, SessionStatus::Archived)
             .map_err(ApiError::from)
@@ -216,12 +201,7 @@ pub async fn unarchive(
     let state_clone = Arc::clone(&state);
     let id_clone = id.clone();
     tokio::task::spawn_blocking(move || {
-        let store = state_clone.session_store.lock().map_err(|_poison| {
-            InternalSnafu {
-                message: "session store lock poisoned",
-            }
-            .build()
-        })?;
+        let store = state_clone.session_store.blocking_lock();
         store
             .update_session_status(&id_clone, SessionStatus::Active)
             .map_err(ApiError::from)
@@ -253,12 +233,7 @@ pub async fn rename(
     let id_clone = id.clone();
     let name = body.name;
     tokio::task::spawn_blocking(move || {
-        let store = state_clone.session_store.lock().map_err(|_poison| {
-            InternalSnafu {
-                message: "session store lock poisoned",
-            }
-            .build()
-        })?;
+        let store = state_clone.session_store.blocking_lock();
         store
             .update_display_name(&id_clone, &name)
             .map_err(ApiError::from)
@@ -298,12 +273,7 @@ pub async fn history(
     let id_clone = id.clone();
     let limit = params.limit;
     let messages = tokio::task::spawn_blocking(move || {
-        let store = state_clone.session_store.lock().map_err(|_poison| {
-            InternalSnafu {
-                message: "session store lock poisoned",
-            }
-            .build()
-        })?;
+        let store = state_clone.session_store.blocking_lock();
         store
             .get_history(&id_clone, limit.map(i64::from))
             .map_err(ApiError::from)
@@ -727,12 +697,7 @@ async fn resolve_session(
     let model_owned = model.map(ToOwned::to_owned);
 
     let session = tokio::task::spawn_blocking(move || {
-        let store = state_clone.session_store.lock().map_err(|_poison| {
-            InternalSnafu {
-                message: "session store lock poisoned",
-            }
-            .build()
-        })?;
+        let store = state_clone.session_store.blocking_lock();
         store
             .find_or_create_session(&id_clone, &aid, &skey, model_owned.as_deref(), None)
             .map_err(ApiError::from)
@@ -753,12 +718,7 @@ async fn store_message(
     let sid = session_id.to_owned();
     let content = content.to_owned();
     tokio::task::spawn_blocking(move || {
-        let store = state_clone.session_store.lock().map_err(|_poison| {
-            InternalSnafu {
-                message: "session store lock poisoned",
-            }
-            .build()
-        })?;
+        let store = state_clone.session_store.blocking_lock();
         store
             .append_message(&sid, role, &content, None, None, token_estimate)
             .map_err(ApiError::from)
@@ -774,12 +734,7 @@ async fn find_session(
     let id_owned = id.to_owned();
     let id_for_error = id.to_owned();
     let session = tokio::task::spawn_blocking(move || {
-        let store = state_clone.session_store.lock().map_err(|_poison| {
-            InternalSnafu {
-                message: "session store lock poisoned",
-            }
-            .build()
-        })?;
+        let store = state_clone.session_store.blocking_lock();
         store.find_session_by_id(&id_owned).map_err(ApiError::from)
     })
     .await??;

--- a/crates/pylon/src/handlers/webchat.rs
+++ b/crates/pylon/src/handlers/webchat.rs
@@ -16,7 +16,7 @@ use tracing::{instrument, warn};
 use aletheia_hermeneus::anthropic::StreamEvent as LlmStreamEvent;
 use aletheia_nous::stream::TurnStreamEvent;
 
-use crate::error::{ApiError, BadRequestSnafu, InternalSnafu, NousNotFoundSnafu};
+use crate::error::{ApiError, BadRequestSnafu, NousNotFoundSnafu};
 use crate::extract::OptionalClaims;
 use crate::state::AppState;
 use crate::stream::{TurnOutcome, WebchatEvent};
@@ -50,12 +50,7 @@ async fn resolve_session(
     let model_owned = model.map(ToOwned::to_owned);
 
     let session = tokio::task::spawn_blocking(move || {
-        let store = state_clone.session_store.lock().map_err(|_poison| {
-            InternalSnafu {
-                message: "session store lock poisoned",
-            }
-            .build()
-        })?;
+        let store = state_clone.session_store.blocking_lock();
         store
             .find_or_create_session(&id_clone, &aid, &skey, model_owned.as_deref(), None)
             .map_err(ApiError::from)
@@ -76,12 +71,7 @@ async fn store_message(
     let sid = session_id.to_owned();
     let content = content.to_owned();
     tokio::task::spawn_blocking(move || {
-        let store = state_clone.session_store.lock().map_err(|_poison| {
-            InternalSnafu {
-                message: "session store lock poisoned",
-            }
-            .build()
-        })?;
+        let store = state_clone.session_store.blocking_lock();
         store
             .append_message(&sid, role, &content, None, None, token_estimate)
             .map_err(ApiError::from)
@@ -423,12 +413,7 @@ pub async fn sessions_list(
 
     let state_clone = Arc::clone(&state);
     let sessions = tokio::task::spawn_blocking(move || {
-        let store = state_clone.session_store.lock().map_err(|_poison| {
-            InternalSnafu {
-                message: "session store lock poisoned",
-            }
-            .build()
-        })?;
+        let store = state_clone.session_store.blocking_lock();
         store
             .list_sessions(nous_id.as_deref())
             .map_err(ApiError::from)

--- a/crates/pylon/src/server.rs
+++ b/crates/pylon/src/server.rs
@@ -1,8 +1,9 @@
 //! Server entry point with graceful shutdown.
 
 use std::path::PathBuf;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use std::time::Instant;
+use tokio::sync::Mutex;
 
 use snafu::{ResultExt, Snafu};
 use tokio::net::TcpListener;

--- a/crates/pylon/src/state.rs
+++ b/crates/pylon/src/state.rs
@@ -1,7 +1,8 @@
 //! Shared application state accessible in all Axum handlers.
 
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use std::time::Instant;
+use tokio::sync::Mutex;
 
 use aletheia_hermeneus::provider::ProviderRegistry;
 use aletheia_mneme::store::SessionStore;

--- a/crates/pylon/src/tests.rs
+++ b/crates/pylon/src/tests.rs
@@ -1,7 +1,8 @@
 //! Integration tests for the pylon HTTP gateway.
 
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use std::time::{Duration, Instant};
+use tokio::sync::Mutex;
 
 use axum::body::Body;
 use axum::http::{Request, StatusCode};
@@ -553,7 +554,7 @@ async fn history_with_limit() {
     let id = created["id"].as_str().unwrap();
 
     {
-        let store = state.session_store.lock().unwrap();
+        let store = state.session_store.blocking_lock();
         for i in 1..=5 {
             store
                 .append_message(
@@ -1582,7 +1583,7 @@ async fn history_before_filter() {
     let id = created["id"].as_str().unwrap();
 
     {
-        let store = state.session_store.lock().unwrap();
+        let store = state.session_store.blocking_lock();
         for i in 1..=5 {
             store
                 .append_message(
@@ -2569,7 +2570,7 @@ async fn history_messages_have_expected_fields() {
     let id = created["id"].as_str().unwrap();
 
     {
-        let store = state.session_store.lock().unwrap();
+        let store = state.session_store.blocking_lock();
         store
             .append_message(
                 id,


### PR DESCRIPTION
## Summary

- Replace `std::sync::Mutex` with `tokio::sync::Mutex` for `SessionStore` in `adapters.rs`, `actor.rs`, `pipeline.rs`, and `manager.rs` — eliminates latent correctness issues where blocking lock acquisition could stall Tokio worker threads
- Sync trait bridge (`NoteStore`/`BlackboardStore`) uses `block_in_place` so the runtime can progress while the lock is acquired; requires multi-thread runtime (which production always uses)
- `maybe_spawn_distillation` made async; `run_background_distillation` acquires each lock with `.lock().await` and releases before any `.await` point
- Test mocks (`MockProvider.response`) intentionally remain `std::sync::Mutex` with explanatory comments — they never cross `.await` points
- Two new async adapter tests confirm `block_in_place` round-trips work end-to-end with a real `SessionStore`
- All callers updated: `pylon` handlers use `blocking_lock()` inside `spawn_blocking`, integration tests for real-store paths use `flavor = "multi_thread"`

## Test plan

- [x] `cargo test -p aletheia-nous` — 283 passed, 0 failed
- [x] `cargo clippy -p aletheia-nous --all-targets -- -D warnings` — clean
- [x] `cargo fmt -p aletheia-nous` — no diffs
- [ ] CI workspace sweep (pylon, aletheia, integration-tests compile + test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)