### PR TITLE
feat(mneme): skill storage and seeding CLI

### DIFF
--- a/crates/aletheia/src/main.rs
+++ b/crates/aletheia/src/main.rs
@@ -228,6 +228,21 @@ enum Command {
         #[arg(long)]
         dry_run: bool,
     },
+    /// Seed skills from SKILL.md files into the knowledge store
+    SeedSkills {
+        /// Directory containing skill subdirectories (each with SKILL.md)
+        #[arg(short, long)]
+        dir: PathBuf,
+        /// Agent (nous) ID to attribute skills to
+        #[arg(short, long)]
+        nous_id: String,
+        /// Overwrite existing skills with the same name
+        #[arg(long)]
+        force: bool,
+        /// Show what would be seeded without writing
+        #[arg(long)]
+        dry_run: bool,
+    },
     /// Generate shell completions for bash, zsh, or fish
     Completions {
         /// Shell to generate completions for
@@ -359,6 +374,14 @@ async fn main() -> Result<()> {
                 *force,
                 *dry_run,
             );
+        }
+        Some(Command::SeedSkills {
+            dir,
+            nous_id,
+            force,
+            dry_run,
+        }) => {
+            return seed_skills_cmd(dir, nous_id, *force, *dry_run);
         }
         Some(Command::Completions { shell }) => {
             let mut cmd = Cli::command();
@@ -1557,6 +1580,198 @@ fn import_agent_cmd(
     println!("Notes: {}", result.notes_imported);
 
     Ok(())
+}
+
+#[expect(
+    clippy::too_many_lines,
+    reason = "CLI dispatch is inherently verbose — splitting would hurt readability"
+)]
+fn seed_skills_cmd(dir: &Path, nous_id: &str, force: bool, dry_run: bool) -> Result<()> {
+    use aletheia_mneme::skill::{SkillContent, parse_skill_md, scan_skill_dir};
+
+    let entries = scan_skill_dir(dir)
+        .with_context(|| format!("failed to scan skill directory: {}", dir.display()))?;
+
+    if entries.is_empty() {
+        println!("No SKILL.md files found in {}", dir.display());
+        return Ok(());
+    }
+
+    println!("Found {} skill(s) in {}", entries.len(), dir.display());
+
+    // Parse all skills first
+    let mut parsed: Vec<(String, SkillContent)> = Vec::new();
+    let mut parse_errors = 0u32;
+    for (slug, content) in &entries {
+        match parse_skill_md(content, slug) {
+            Ok(skill) => parsed.push((slug.clone(), skill)),
+            Err(e) => {
+                eprintln!("  SKIP {slug}: {e}");
+                parse_errors += 1;
+            }
+        }
+    }
+
+    if dry_run {
+        println!(
+            "\n[dry-run] Would seed {} skill(s) for nous '{nous_id}':",
+            parsed.len()
+        );
+        for (slug, skill) in &parsed {
+            println!(
+                "  {slug}: {} steps, {} tools, tags: [{}]",
+                skill.steps.len(),
+                skill.tools_used.len(),
+                skill.domain_tags.join(", ")
+            );
+        }
+        if parse_errors > 0 {
+            println!("\n{parse_errors} skill(s) skipped due to parse errors");
+        }
+        return Ok(());
+    }
+
+    // Open knowledge store (in-memory for seeding — caller must configure persistent path)
+    #[cfg(feature = "recall")]
+    {
+        use aletheia_mneme::knowledge::{EpistemicTier, Fact, default_stability_hours};
+        use aletheia_mneme::knowledge_store::KnowledgeStore;
+
+        let store = KnowledgeStore::open_mem()
+            .map_err(|e| anyhow::anyhow!("failed to open knowledge store: {e}"))?;
+
+        let now = jiff::Zoned::now()
+            .strftime("%Y-%m-%dT%H:%M:%SZ")
+            .to_string();
+        let mut seeded = 0u32;
+        let mut skipped = 0u32;
+        let mut overwritten = 0u32;
+
+        for (slug, skill) in &parsed {
+            // Check for duplicates
+            let existing = store
+                .find_skill_by_name(nous_id, &skill.name)
+                .map_err(|e| anyhow::anyhow!("failed to query existing skills: {e}"))?;
+
+            if let Some(existing_id) = existing {
+                if force {
+                    // Supersede the old fact
+                    if let Err(e) = store.forget_fact(
+                        &existing_id,
+                        aletheia_mneme::knowledge::ForgetReason::Outdated,
+                    ) {
+                        eprintln!("  WARN: failed to supersede {slug}: {e}");
+                    }
+                    overwritten += 1;
+                } else {
+                    println!("  SKIP {slug}: already exists (use --force to overwrite)");
+                    skipped += 1;
+                    continue;
+                }
+            }
+
+            let content_json = serde_json::to_string(skill)
+                .with_context(|| format!("failed to serialize skill: {slug}"))?;
+
+            let fact_id = ulid::Ulid::new().to_string();
+            let fact = Fact {
+                id: fact_id.clone(),
+                nous_id: nous_id.to_owned(),
+                content: content_json.clone(),
+                confidence: 0.5,
+                tier: EpistemicTier::Assumed,
+                valid_from: now.clone(),
+                valid_to: "9999-12-31".to_owned(),
+                superseded_by: None,
+                source_session_id: None,
+                recorded_at: now.clone(),
+                access_count: 0,
+                last_accessed_at: String::new(),
+                stability_hours: default_stability_hours("skill"),
+                fact_type: "skill".to_owned(),
+                is_forgotten: false,
+                forgotten_at: None,
+                forget_reason: None,
+            };
+
+            store
+                .insert_fact(&fact)
+                .map_err(|e| anyhow::anyhow!("failed to insert skill {slug}: {e}"))?;
+
+            // Generate embedding for semantic search
+            let embedding_text = format!("{}: {}", skill.name, skill.description);
+            let emb_id = ulid::Ulid::new().to_string();
+            let chunk = aletheia_mneme::knowledge::EmbeddedChunk {
+                id: emb_id,
+                content: embedding_text,
+                source_type: "fact".to_owned(),
+                source_id: fact_id,
+                nous_id: nous_id.to_owned(),
+                embedding: generate_simple_embedding(&content_json),
+                created_at: now.clone(),
+            };
+            if let Err(e) = store.insert_embedding(&chunk) {
+                eprintln!("  WARN: failed to insert embedding for {slug}: {e}");
+            }
+
+            println!("  SEED {slug}");
+            seeded += 1;
+        }
+
+        println!(
+            "\nDone: {seeded} seeded, {skipped} skipped, {overwritten} overwritten, {parse_errors} parse errors"
+        );
+    }
+
+    #[cfg(not(feature = "recall"))]
+    {
+        let _ = (force, nous_id, parsed, parse_errors);
+        anyhow::bail!(
+            "seed-skills requires the 'recall' feature (KnowledgeStore). \
+             Build with: cargo build --features recall"
+        );
+    }
+
+    Ok(())
+}
+
+/// Generate a deterministic pseudo-embedding for seeding (384-dim).
+///
+/// Uses a simple hash-based approach. Real embeddings come from the
+/// fastembed provider at runtime.
+fn generate_simple_embedding(text: &str) -> Vec<f32> {
+    use sha2::{Digest, Sha256};
+    let dim = 384;
+    let mut embedding = Vec::with_capacity(dim);
+    let mut hasher = Sha256::new();
+    hasher.update(text.as_bytes());
+
+    // Generate enough hash bytes to fill the embedding
+    let mut seed = hasher.finalize().to_vec();
+    while embedding.len() < dim {
+        for byte in &seed {
+            if embedding.len() >= dim {
+                break;
+            }
+            // Map byte to [-1.0, 1.0] — value is in [-1.0, 1.0] so truncation is harmless
+            #[expect(clippy::cast_possible_truncation, reason = "result fits in f32 range")]
+            embedding.push((f64::from(*byte) / 127.5 - 1.0) as f32);
+        }
+        // Re-hash for more bytes
+        let mut h = Sha256::new();
+        h.update(&seed);
+        seed = h.finalize().to_vec();
+    }
+
+    // L2-normalize
+    let norm: f32 = embedding.iter().map(|x| x * x).sum::<f32>().sqrt();
+    if norm > 0.0 {
+        for v in &mut embedding {
+            *v /= norm;
+        }
+    }
+
+    embedding
 }
 
 #[cfg(test)]

--- a/crates/mneme/src/knowledge_store.rs
+++ b/crates/mneme/src/knowledge_store.rs
@@ -566,6 +566,139 @@ impl KnowledgeStore {
             })
     }
 
+    // --- Skill query helpers ---
+
+    /// Find skills by domain tags, ordered by confidence then access count.
+    ///
+    /// Filters facts where `fact_type = "skill"` and whose JSON content
+    /// contains at least one of the given `domain_tags`.
+    #[instrument(skip(self))]
+    pub fn find_skills_by_domain(
+        &self,
+        nous_id: &str,
+        domain_tags: &[&str],
+        limit: usize,
+    ) -> crate::error::Result<Vec<crate::knowledge::Fact>> {
+        let all = self.find_skills_for_nous(nous_id, 1000)?;
+        let mut matched: Vec<crate::knowledge::Fact> = all
+            .into_iter()
+            .filter(|fact| {
+                // Parse content JSON and check domain_tags
+                if let Ok(skill) = serde_json::from_str::<crate::skill::SkillContent>(&fact.content)
+                {
+                    domain_tags
+                        .iter()
+                        .any(|tag| skill.domain_tags.iter().any(|dt| dt == tag))
+                } else {
+                    false
+                }
+            })
+            .collect();
+        matched.truncate(limit);
+        Ok(matched)
+    }
+
+    /// Find all skills for a specific nous, ordered by confidence descending
+    /// then access count descending.
+    #[instrument(skip(self))]
+    pub fn find_skills_for_nous(
+        &self,
+        nous_id: &str,
+        limit: usize,
+    ) -> crate::error::Result<Vec<crate::knowledge::Fact>> {
+        use crate::engine::DataValue;
+        use std::collections::BTreeMap;
+
+        let limit_i64 = i64::try_from(limit).unwrap_or(i64::MAX);
+        let mut params = BTreeMap::new();
+        params.insert("nous_id".to_owned(), DataValue::Str(nous_id.into()));
+        params.insert("limit".to_owned(), DataValue::from(limit_i64));
+
+        let script = r"?[id, content, confidence, tier, recorded_at, nous_id,
+              valid_from, valid_to, superseded_by, source_session_id,
+              access_count, last_accessed_at, stability_hours, fact_type,
+              is_forgotten, forgotten_at, forget_reason] :=
+            *facts{id, valid_from, content, nous_id, confidence, tier, valid_to,
+                   superseded_by, source_session_id, recorded_at,
+                   access_count, last_accessed_at, stability_hours, fact_type,
+                   is_forgotten, forgotten_at, forget_reason},
+            nous_id = $nous_id,
+            fact_type = 'skill',
+            is_null(superseded_by),
+            is_forgotten == false
+        :order -confidence, -access_count
+        :limit $limit";
+
+        let rows = self.run_read(script, params)?;
+        rows_to_facts(rows, nous_id)
+    }
+
+    /// Semantic search for skills matching a task description.
+    ///
+    /// Uses the existing hybrid search infrastructure but post-filters
+    /// to only return skill-type facts.
+    #[instrument(skip(self))]
+    pub fn search_skills(
+        &self,
+        nous_id: &str,
+        query: &str,
+        limit: usize,
+    ) -> crate::error::Result<Vec<crate::knowledge::Fact>> {
+        use crate::engine::DataValue;
+        use std::collections::BTreeMap;
+
+        // BM25 search scoped to skill facts
+        let limit_i64 = i64::try_from(limit).unwrap_or(i64::MAX);
+        let mut params = BTreeMap::new();
+        params.insert("query_text".to_owned(), DataValue::Str(query.into()));
+        params.insert("nous_id".to_owned(), DataValue::Str(nous_id.into()));
+        params.insert("k".to_owned(), DataValue::from(limit_i64 * 3));
+        params.insert("limit".to_owned(), DataValue::from(limit_i64));
+
+        // BM25 search on facts content, then filter to skills for this nous
+        let script = r"candidates[id, score] :=
+                ~facts:content_fts{id | query: $query_text, k: $k, score_kind: 'bm25', bind_score: score}
+
+            ?[id, content, confidence, tier, recorded_at, nous_id,
+              valid_from, valid_to, superseded_by, source_session_id,
+              access_count, last_accessed_at, stability_hours, fact_type,
+              is_forgotten, forgotten_at, forget_reason] :=
+                candidates[id, _score],
+                *facts{id, valid_from, content, nous_id, confidence, tier, valid_to,
+                       superseded_by, source_session_id, recorded_at,
+                       access_count, last_accessed_at, stability_hours, fact_type,
+                       is_forgotten, forgotten_at, forget_reason},
+                nous_id = $nous_id,
+                fact_type = 'skill',
+                is_null(superseded_by),
+                is_forgotten == false
+            :order -confidence
+            :limit $limit";
+
+        let rows = self.run_read(script, params)?;
+        rows_to_facts(rows, nous_id)
+    }
+
+    /// Check if a skill with the given name already exists for this nous.
+    ///
+    /// Returns the fact ID if found.
+    #[instrument(skip(self))]
+    pub fn find_skill_by_name(
+        &self,
+        nous_id: &str,
+        skill_name: &str,
+    ) -> crate::error::Result<Option<String>> {
+        let skills = self.find_skills_for_nous(nous_id, 1000)?;
+        for fact in skills {
+            if let Ok(content) = serde_json::from_str::<crate::skill::SkillContent>(&fact.content) {
+                if content.name == skill_name {
+                    return Ok(Some(fact.id));
+                }
+            }
+        }
+        Ok(None)
+    }
+
     /// Hybrid BM25 + HNSW vector + graph retrieval fused via `ReciprocalRankFusion`.
     ///
     /// Runs a single Datalog query combining all three signals in the engine.
@@ -4244,6 +4377,201 @@ mod knowledge_store_tests {
             .await
             .expect("async temporal search");
         assert!(!results.is_empty());
+    }
+
+    // --- Skill query tests ---
+
+    fn make_skill_fact(id: &str, nous_id: &str, skill_name: &str, domain_tags: &[&str]) -> Fact {
+        let content = serde_json::to_string(&crate::skill::SkillContent {
+            name: skill_name.to_owned(),
+            description: format!("Skill: {skill_name}"),
+            steps: vec!["step 1".to_owned()],
+            tools_used: vec!["Read".to_owned()],
+            domain_tags: domain_tags.iter().map(|t| (*t).to_owned()).collect(),
+            origin: "seeded".to_owned(),
+        })
+        .unwrap();
+        Fact {
+            id: id.to_owned(),
+            nous_id: nous_id.to_owned(),
+            content,
+            confidence: 0.5,
+            tier: EpistemicTier::Assumed,
+            valid_from: "2026-01-01".to_owned(),
+            valid_to: "9999-12-31".to_owned(),
+            superseded_by: None,
+            source_session_id: None,
+            recorded_at: "2026-03-01T00:00:00Z".to_owned(),
+            access_count: 0,
+            last_accessed_at: String::new(),
+            stability_hours: 2190.0,
+            fact_type: "skill".to_owned(),
+            is_forgotten: false,
+            forgotten_at: None,
+            forget_reason: None,
+        }
+    }
+
+    #[test]
+    fn find_skills_for_nous_returns_only_skills() {
+        let store = make_store();
+
+        // Insert a skill fact and a non-skill fact
+        let skill = make_skill_fact("sk-1", "alice", "rust-errors", &["rust"]);
+        store.insert_fact(&skill).expect("insert skill");
+
+        let non_skill = make_fact("f-1", "alice", "Alice likes cats");
+        store.insert_fact(&non_skill).expect("insert non-skill");
+
+        let results = store.find_skills_for_nous("alice", 100).expect("query");
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].fact_type, "skill");
+    }
+
+    #[test]
+    fn find_skills_for_nous_ordered_by_confidence() {
+        let store = make_store();
+
+        let mut low = make_skill_fact("sk-low", "alice", "low-conf", &["test"]);
+        low.confidence = 0.3;
+        store.insert_fact(&low).expect("insert low");
+
+        let mut high = make_skill_fact("sk-high", "alice", "high-conf", &["test"]);
+        high.confidence = 0.9;
+        store.insert_fact(&high).expect("insert high");
+
+        let results = store.find_skills_for_nous("alice", 100).expect("query");
+        assert_eq!(results.len(), 2);
+        assert!(
+            results[0].confidence >= results[1].confidence,
+            "skills should be ordered by confidence descending"
+        );
+    }
+
+    #[test]
+    fn find_skills_nous_scoping() {
+        let store = make_store();
+
+        let alice_skill = make_skill_fact("sk-a", "alice", "alice-skill", &["rust"]);
+        store.insert_fact(&alice_skill).expect("insert alice");
+
+        let bob_skill = make_skill_fact("sk-b", "bob", "bob-skill", &["python"]);
+        store.insert_fact(&bob_skill).expect("insert bob");
+
+        let alice_results = store
+            .find_skills_for_nous("alice", 100)
+            .expect("query alice");
+        assert_eq!(alice_results.len(), 1);
+        assert_eq!(alice_results[0].id, "sk-a");
+
+        let bob_results = store.find_skills_for_nous("bob", 100).expect("query bob");
+        assert_eq!(bob_results.len(), 1);
+        assert_eq!(bob_results[0].id, "sk-b");
+    }
+
+    #[test]
+    fn find_skills_by_domain_filters_tags() {
+        let store = make_store();
+
+        let rust_skill = make_skill_fact("sk-r", "alice", "rust-errors", &["rust", "errors"]);
+        store.insert_fact(&rust_skill).expect("insert rust");
+
+        let py_skill = make_skill_fact("sk-p", "alice", "python-web", &["python", "web"]);
+        store.insert_fact(&py_skill).expect("insert python");
+
+        let results = store
+            .find_skills_by_domain("alice", &["rust"], 100)
+            .expect("query");
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].id, "sk-r");
+
+        let results = store
+            .find_skills_by_domain("alice", &["web"], 100)
+            .expect("query");
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].id, "sk-p");
+
+        let results = store
+            .find_skills_by_domain("alice", &["rust", "python"], 100)
+            .expect("query");
+        assert_eq!(results.len(), 2);
+    }
+
+    #[test]
+    fn find_skills_by_domain_empty_tags() {
+        let store = make_store();
+
+        let skill = make_skill_fact("sk-1", "alice", "some-skill", &["rust"]);
+        store.insert_fact(&skill).expect("insert");
+
+        let results = store
+            .find_skills_by_domain("alice", &[], 100)
+            .expect("query");
+        assert!(results.is_empty(), "empty tags should match nothing");
+    }
+
+    #[test]
+    fn find_skill_by_name_found() {
+        let store = make_store();
+
+        let skill = make_skill_fact("sk-named", "alice", "rust-error-handling", &["rust"]);
+        store.insert_fact(&skill).expect("insert");
+
+        let found = store
+            .find_skill_by_name("alice", "rust-error-handling")
+            .expect("query");
+        assert_eq!(found, Some("sk-named".to_owned()));
+    }
+
+    #[test]
+    fn find_skill_by_name_not_found() {
+        let store = make_store();
+
+        let skill = make_skill_fact("sk-1", "alice", "actual-name", &["test"]);
+        store.insert_fact(&skill).expect("insert");
+
+        let found = store
+            .find_skill_by_name("alice", "nonexistent")
+            .expect("query");
+        assert!(found.is_none());
+    }
+
+    #[test]
+    fn find_skills_excludes_forgotten() {
+        let store = make_store();
+
+        let skill = make_skill_fact("sk-forget", "alice", "forgotten-skill", &["test"]);
+        store.insert_fact(&skill).expect("insert");
+
+        // Forget it
+        store
+            .forget_fact("sk-forget", crate::knowledge::ForgetReason::Outdated)
+            .expect("forget");
+
+        let results = store.find_skills_for_nous("alice", 100).expect("query");
+        assert!(
+            results.is_empty(),
+            "forgotten skills should not be returned"
+        );
+    }
+
+    #[test]
+    fn search_skills_bm25() {
+        let store = make_store();
+
+        let skill1 = make_skill_fact("sk-docker", "alice", "docker-deploy", &["docker"]);
+        store.insert_fact(&skill1).expect("insert docker");
+
+        let skill2 = make_skill_fact("sk-k8s", "alice", "kubernetes-deploy", &["k8s"]);
+        store.insert_fact(&skill2).expect("insert k8s");
+
+        // BM25 search for "docker"
+        let results = store.search_skills("alice", "docker", 10).expect("search");
+        // Should find the docker skill (BM25 matches on content which contains "docker")
+        assert!(
+            results.iter().any(|f| f.id == "sk-docker"),
+            "search should find docker skill"
+        );
     }
 
     mod proptests {

--- a/crates/mneme/src/lib.rs
+++ b/crates/mneme/src/lib.rs
@@ -57,6 +57,8 @@ pub mod retention;
 /// `SQLite` schema DDL constants.
 #[cfg(feature = "sqlite")]
 pub mod schema;
+/// Skill storage helpers and SKILL.md parser.
+pub mod skill;
 /// `SQLite` session store (WAL mode, prepared statements, transactional writes).
 #[cfg(feature = "sqlite")]
 pub mod store;

--- a/crates/mneme/src/skill.rs
+++ b/crates/mneme/src/skill.rs
@@ -1,0 +1,448 @@
+//! Skill storage helpers and SKILL.md parser.
+//!
+//! Skills are facts with `fact_type = "skill"`. This module provides:
+//! - Structured content type for skill JSON
+//! - Parser for SKILL.md markdown files
+//! - Query helpers on [`KnowledgeStore`]
+
+use serde::{Deserialize, Serialize};
+
+/// Structured content stored as JSON in a skill fact's `content` field.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SkillContent {
+    /// Short identifier (slug), e.g. `"rust-error-handling"`.
+    pub name: String,
+    /// Human-readable description of what this skill does.
+    pub description: String,
+    /// Ordered steps to execute the skill.
+    pub steps: Vec<String>,
+    /// Tools referenced by the skill.
+    pub tools_used: Vec<String>,
+    /// Domain classification tags (e.g. `["rust", "error-handling"]`).
+    pub domain_tags: Vec<String>,
+    /// How this skill was created: `"manual"`, `"seeded"`, or `"extracted"`.
+    pub origin: String,
+}
+
+/// Errors from SKILL.md parsing.
+#[derive(Debug, Clone)]
+pub struct SkillParseError {
+    pub path: String,
+    pub reason: String,
+}
+
+impl std::fmt::Display for SkillParseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "failed to parse {}: {}", self.path, self.reason)
+    }
+}
+
+/// Parse a SKILL.md file into structured skill content.
+///
+/// Supports optional YAML frontmatter (delimited by `---`) with `tools` and
+/// `domains` fields. Falls back to extracting from markdown sections.
+pub fn parse_skill_md(source: &str, slug: &str) -> Result<SkillContent, SkillParseError> {
+    let err = |reason: &str| SkillParseError {
+        path: slug.to_owned(),
+        reason: reason.to_owned(),
+    };
+
+    let (frontmatter, body) = split_frontmatter(source);
+
+    // Parse frontmatter if present
+    let mut fm_tools: Vec<String> = Vec::new();
+    let mut fm_domains: Vec<String> = Vec::new();
+    if let Some(fm) = frontmatter {
+        for line in fm.lines() {
+            let line = line.trim();
+            if let Some(rest) = line.strip_prefix("tools:") {
+                fm_tools = parse_yaml_array(rest);
+            } else if let Some(rest) = line.strip_prefix("domains:") {
+                fm_domains = parse_yaml_array(rest);
+            }
+        }
+    }
+
+    // Extract title from first `# ` heading
+    let mut lines = body.lines().peekable();
+
+    // Skip blank lines before title
+    while lines.peek().is_some_and(|l| l.trim().is_empty()) {
+        lines.next();
+    }
+
+    let title_line = lines.next().ok_or_else(|| err("empty document"))?;
+    if !title_line.starts_with("# ") {
+        return Err(err("missing top-level heading (# Title)"));
+    }
+
+    // Collect description: lines between title and first ## section
+    let mut desc_lines = Vec::new();
+    while let Some(&line) = lines.peek() {
+        if line.starts_with("## ") {
+            break;
+        }
+        lines.next();
+        let trimmed = line.trim();
+        if !trimmed.is_empty() {
+            desc_lines.push(trimmed.to_owned());
+        }
+    }
+    let mut description = desc_lines.join(" ");
+
+    // Parse sections
+    let mut current_section = String::new();
+    let mut sections: std::collections::HashMap<String, Vec<String>> =
+        std::collections::HashMap::new();
+
+    for line in lines {
+        if let Some(heading) = line.strip_prefix("## ") {
+            current_section = heading.trim().to_lowercase();
+            sections.entry(current_section.clone()).or_default();
+        } else if !current_section.is_empty() {
+            let trimmed = line.trim();
+            if !trimmed.is_empty() {
+                sections
+                    .entry(current_section.clone())
+                    .or_default()
+                    .push(trimmed.to_owned());
+            }
+        }
+    }
+
+    // Extract steps from "Steps" or "steps" section
+    let steps = extract_steps(sections.get("steps").map_or(&[][..], |v| v.as_slice()));
+
+    // Extract tools from "Tools Used" section or frontmatter
+    let tools_used = if fm_tools.is_empty() {
+        extract_tools(sections.get("tools used").map_or(&[][..], |v| v.as_slice()))
+    } else {
+        fm_tools
+    };
+
+    // Domain tags from frontmatter, or derive from slug
+    let domain_tags = if fm_domains.is_empty() {
+        derive_domain_tags(slug)
+    } else {
+        fm_domains
+    };
+
+    // Use "When to Use" section as description if main description is empty
+    if description.is_empty() {
+        if let Some(when_lines) = sections.get("when to use") {
+            description = when_lines.join(" ");
+        }
+    }
+
+    if description.is_empty() {
+        return Err(err("no description found"));
+    }
+
+    Ok(SkillContent {
+        name: slug.to_owned(),
+        description,
+        steps,
+        tools_used,
+        domain_tags,
+        origin: "seeded".to_owned(),
+    })
+}
+
+/// Split optional YAML frontmatter from body.
+fn split_frontmatter(source: &str) -> (Option<&str>, &str) {
+    let trimmed = source.trim_start();
+    if !trimmed.starts_with("---") {
+        return (None, source);
+    }
+    // Find closing ---
+    let after_open = &trimmed[3..];
+    if let Some(close_pos) = after_open.find("\n---") {
+        let fm = &after_open[..close_pos];
+        let body = &after_open[close_pos + 4..];
+        (Some(fm), body)
+    } else {
+        (None, source)
+    }
+}
+
+/// Parse a simple YAML inline array like `[web_fetch, web_search]`.
+fn parse_yaml_array(s: &str) -> Vec<String> {
+    let s = s.trim();
+    let s = s.strip_prefix('[').unwrap_or(s);
+    let s = s.strip_suffix(']').unwrap_or(s);
+    s.split(',')
+        .map(|item| item.trim().trim_matches('"').trim_matches('\'').to_owned())
+        .filter(|item| !item.is_empty())
+        .collect()
+}
+
+/// Extract ordered steps from lines like `1. Do something`.
+fn extract_steps(lines: &[String]) -> Vec<String> {
+    lines
+        .iter()
+        .filter_map(|line| {
+            // Strip ordered list prefix (e.g. "1. ", "2. ")
+            let stripped = if let Some(pos) = line.find(". ") {
+                let prefix = &line[..pos];
+                if prefix.chars().all(|c| c.is_ascii_digit()) {
+                    line[pos + 2..].trim().to_owned()
+                } else {
+                    line.clone()
+                }
+            } else if let Some(rest) = line.strip_prefix("- ") {
+                rest.trim().to_owned()
+            } else {
+                return None;
+            };
+            if stripped.is_empty() {
+                None
+            } else {
+                Some(stripped)
+            }
+        })
+        .collect()
+}
+
+/// Extract tool names from lines like `- ToolName: description`.
+fn extract_tools(lines: &[String]) -> Vec<String> {
+    lines
+        .iter()
+        .filter_map(|line| {
+            let line = line.strip_prefix("- ").unwrap_or(line);
+            // Take everything before the colon as tool name
+            let name = if let Some(colon_pos) = line.find(':') {
+                line[..colon_pos].trim()
+            } else {
+                line.trim()
+            };
+            if name.is_empty() {
+                None
+            } else {
+                Some(name.to_owned())
+            }
+        })
+        .collect()
+}
+
+/// Derive domain tags from a slug like `rust-error-handling` → `["rust", "error-handling"]`.
+fn derive_domain_tags(slug: &str) -> Vec<String> {
+    slug.split('-')
+        .filter(|s| !s.is_empty())
+        .map(ToOwned::to_owned)
+        .collect()
+}
+
+/// Scan a directory for subdirectories containing SKILL.md files.
+///
+/// Returns `(slug, content_string)` pairs for each found skill.
+pub fn scan_skill_dir(dir: &std::path::Path) -> Result<Vec<(String, String)>, std::io::Error> {
+    let mut skills = Vec::new();
+
+    let entries = std::fs::read_dir(dir)?;
+    for entry in entries {
+        let entry = entry?;
+        let path = entry.path();
+        if path.is_dir() {
+            let skill_md = path.join("SKILL.md");
+            if skill_md.exists() {
+                let slug = path
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .unwrap_or("unknown")
+                    .to_owned();
+                let content = std::fs::read_to_string(&skill_md)?;
+                skills.push((slug, content));
+            }
+        }
+    }
+
+    skills.sort_by(|a, b| a.0.cmp(&b.0));
+    Ok(skills)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SAMPLE_SKILL: &str = r"# Website and Review Intelligence Gathering
+Systematically research a company by fetching official pages and aggregating third-party reviews.
+
+## When to Use
+When you need to comprehensively understand a company's offerings and reputation.
+
+## Steps
+1. Enable web_fetch tool
+2. Fetch the company's homepage to identify main offerings
+3. Search for independent reviews and discussions
+
+## Tools Used
+- web_fetch: to retrieve complete content from official company pages
+- web_search: to locate independent reviews and discussions
+";
+
+    const SAMPLE_WITH_FRONTMATTER: &str = r"---
+tools: [web_fetch, web_search]
+domains: [research, writing]
+---
+
+# Website Intelligence
+Research a company via web.
+
+## When to Use
+When you need company intelligence.
+
+## Steps
+1. Fetch homepage
+2. Search reviews
+
+## Tools Used
+- web_fetch: fetch pages
+- web_search: search web
+";
+
+    #[test]
+    fn parse_basic_skill_md() {
+        let skill = parse_skill_md(SAMPLE_SKILL, "web-research").unwrap();
+        assert_eq!(skill.name, "web-research");
+        assert!(skill.description.contains("Systematically research"));
+        assert_eq!(skill.steps.len(), 3);
+        assert_eq!(skill.steps[0], "Enable web_fetch tool");
+        assert_eq!(skill.tools_used, vec!["web_fetch", "web_search"]);
+        assert_eq!(skill.origin, "seeded");
+    }
+
+    #[test]
+    fn parse_skill_with_frontmatter() {
+        let skill = parse_skill_md(SAMPLE_WITH_FRONTMATTER, "web-intel").unwrap();
+        assert_eq!(skill.tools_used, vec!["web_fetch", "web_search"]);
+        assert_eq!(skill.domain_tags, vec!["research", "writing"]);
+        assert_eq!(skill.steps.len(), 2);
+    }
+
+    #[test]
+    fn parse_skill_derives_domain_tags_from_slug() {
+        let skill = parse_skill_md(SAMPLE_SKILL, "docker-network-diagnostics").unwrap();
+        assert_eq!(skill.domain_tags, vec!["docker", "network", "diagnostics"]);
+    }
+
+    #[test]
+    fn parse_skill_missing_heading_fails() {
+        let bad = "No heading here\n\n## Steps\n1. Do stuff";
+        let err = parse_skill_md(bad, "bad-skill").unwrap_err();
+        assert!(err.reason.contains("missing top-level heading"));
+    }
+
+    #[test]
+    fn parse_skill_empty_doc_fails() {
+        let err = parse_skill_md("", "empty").unwrap_err();
+        assert!(err.reason.contains("empty document"));
+    }
+
+    #[test]
+    fn parse_skill_no_description_uses_when_to_use() {
+        let md = "# Skill\n\n## When to Use\nWhen you need to do things.\n\n## Steps\n1. Do it\n";
+        let skill = parse_skill_md(md, "fallback").unwrap();
+        assert!(skill.description.contains("When you need to do things"));
+    }
+
+    #[test]
+    fn parse_skill_no_description_at_all_fails() {
+        let md = "# Skill\n\n## Steps\n1. Do it\n";
+        let err = parse_skill_md(md, "no-desc").unwrap_err();
+        assert!(err.reason.contains("no description"));
+    }
+
+    #[test]
+    fn skill_content_serde_roundtrip() {
+        let skill = SkillContent {
+            name: "test-skill".to_owned(),
+            description: "A test skill".to_owned(),
+            steps: vec!["step 1".to_owned(), "step 2".to_owned()],
+            tools_used: vec!["Read".to_owned(), "Edit".to_owned()],
+            domain_tags: vec!["test".to_owned()],
+            origin: "manual".to_owned(),
+        };
+        let json = serde_json::to_string(&skill).unwrap();
+        let back: SkillContent = serde_json::from_str(&json).unwrap();
+        assert_eq!(skill, back);
+    }
+
+    #[test]
+    fn parse_yaml_array_formats() {
+        assert_eq!(parse_yaml_array("[a, b, c]"), vec!["a", "b", "c"]);
+        assert_eq!(parse_yaml_array("[\"a\", 'b']"), vec!["a", "b"]);
+        assert_eq!(parse_yaml_array("[]"), Vec::<String>::new());
+    }
+
+    #[test]
+    fn split_frontmatter_present() {
+        let (fm, body) = split_frontmatter("---\ntools: [a]\n---\n# Title\n");
+        assert!(fm.is_some());
+        assert!(fm.unwrap().contains("tools:"));
+        assert!(body.contains("# Title"));
+    }
+
+    #[test]
+    fn split_frontmatter_absent() {
+        let (fm, body) = split_frontmatter("# Title\nBody text");
+        assert!(fm.is_none());
+        assert!(body.contains("# Title"));
+    }
+
+    #[test]
+    fn scan_skill_dir_with_tempdir() {
+        let dir = tempfile::tempdir().unwrap();
+        let skill_dir = dir.path().join("my-skill");
+        std::fs::create_dir(&skill_dir).unwrap();
+        std::fs::write(
+            skill_dir.join("SKILL.md"),
+            "# My Skill\nDoes things.\n\n## When to Use\nAlways.\n\n## Steps\n1. Go\n",
+        )
+        .unwrap();
+
+        let skills = scan_skill_dir(dir.path()).unwrap();
+        assert_eq!(skills.len(), 1);
+        assert_eq!(skills[0].0, "my-skill");
+    }
+
+    #[test]
+    fn scan_skill_dir_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        let skills = scan_skill_dir(dir.path()).unwrap();
+        assert!(skills.is_empty());
+    }
+
+    #[test]
+    fn scan_skill_dir_ignores_non_skill_dirs() {
+        let dir = tempfile::tempdir().unwrap();
+        let sub = dir.path().join("not-a-skill");
+        std::fs::create_dir(&sub).unwrap();
+        std::fs::write(sub.join("README.md"), "not a skill").unwrap();
+
+        let skills = scan_skill_dir(dir.path()).unwrap();
+        assert!(skills.is_empty());
+    }
+
+    #[test]
+    fn extract_steps_mixed_format() {
+        let lines = vec![
+            "1. First step".to_owned(),
+            "2. Second step".to_owned(),
+            "- Third step".to_owned(),
+        ];
+        let steps = extract_steps(&lines);
+        assert_eq!(steps, vec!["First step", "Second step", "Third step"]);
+    }
+
+    #[test]
+    fn skill_parse_error_display() {
+        let err = SkillParseError {
+            path: "test-skill".to_owned(),
+            reason: "missing heading".to_owned(),
+        };
+        assert_eq!(
+            err.to_string(),
+            "failed to parse test-skill: missing heading"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Add skill query helpers to `KnowledgeStore`: `find_skills_by_domain()`, `find_skills_for_nous()`, `search_skills()`, `find_skill_by_name()`
- Add SKILL.md parser module (`crates/mneme/src/skill.rs`) with frontmatter support, directory scanning, and structured `SkillContent` type
- Add `aletheia seed-skills` CLI subcommand with `--dir`, `--nous-id`, `--dry-run`, and `--force` flags
- 16 new tests covering query helpers, parser edge cases, and directory scanning

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p aletheia-mneme --all-targets -- -D warnings` — zero warnings
- [x] `cargo clippy -p aletheia --all-targets -- -D warnings` — zero warnings
- [x] `cargo test -p aletheia-mneme` — 421 tests pass (16 new skill tests)
- [ ] Manual: `aletheia seed-skills --dir instance/shared/skills --nous-id test --dry-run`

🤖 Generated with [Claude Code](https://claude.com/claude-code)