### PR TITLE
feat(organon): RAII cleanup guards for processes, temp dirs, and storage

### DIFF
--- a/crates/mneme/src/engine/storage/redb.rs
+++ b/crates/mneme/src/engine/storage/redb.rs
@@ -24,6 +24,15 @@ const TABLE: redb::TableDefinition<'_, &[u8], &[u8]> = redb::TableDefinition::ne
 /// Opens or creates a redb-backed database at the given path.
 ///
 /// Pure Rust, zero C dependencies, ACID transactions, single-file database.
+///
+/// # Cleanup contract
+///
+/// - The returned `DbCore` holds an `Arc<redb::Database>`.  All temporary
+///   directories used during testing are managed by `tempfile::TempDir`,
+///   which removes the directory (and its `data.redb` file) on drop — even
+///   on panic.  Production paths live under `instance/` and are not
+///   automatically removed.
+/// - redb flushes its WAL on `Database` drop; no manual flush is needed.
 pub fn new_cozo_redb(path: impl AsRef<Path>) -> Result<DbCore<RedbStorage>> {
     let path = path.as_ref();
     fs::create_dir_all(path).map_err(|e| {
@@ -58,6 +67,17 @@ pub fn new_cozo_redb(path: impl AsRef<Path>) -> Result<DbCore<RedbStorage>> {
 }
 
 /// redb storage engine — pure Rust, zero C deps, single-file ACID database.
+///
+/// # Cleanup and WAL safety
+///
+/// `redb::Database` owns the write-ahead log.  When the last `Arc<Database>`
+/// reference is dropped, redb flushes and closes the WAL automatically —
+/// no explicit flush call is required.  Uncommitted `WriteTransaction`
+/// values roll back when dropped without calling `commit()`.
+///
+/// The `DbCore<RedbStorage>` wrapper holds the `Arc<Database>` and may be
+/// cloned; the underlying file is closed (and flushed) once *all* clones
+/// are dropped.
 #[derive(Clone)]
 pub struct RedbStorage {
     db: Arc<redb::Database>,
@@ -709,6 +729,64 @@ mod tests {
             ScriptMutability::Mutable,
         )?;
         Ok((temp_dir, db))
+    }
+
+    /// Verify that `TempDir` cleans up the database file on drop — including
+    /// when the outer scope exits normally.  This documents the RAII contract
+    /// relied on by all redb tests.
+    #[test]
+    fn temp_dir_raii_removes_database_file_on_drop() {
+        let db_path = {
+            let dir =
+                TempDir::new().map_err(|e| crate::engine::error::AdhocError(e.to_string()))
+                    .expect("create temp dir");
+            let db_file = dir.path().join("data.redb");
+            let path_copy = db_file.clone();
+
+            // Create the database so the file exists.
+            new_cozo_redb(dir.path()).expect("create db");
+            assert!(db_file.exists(), "data.redb should exist while TempDir is live");
+
+            path_copy
+            // `dir` (TempDir) drops here, removing the directory tree.
+        };
+        assert!(!db_path.exists(), "data.redb should be removed after TempDir drop");
+    }
+
+    /// Verify that data written and committed before dropping the Database
+    /// is readable after reopening — confirming WAL flush on drop.
+    #[test]
+    fn redb_flushes_wal_on_database_drop() -> Result<()> {
+        use crate::engine::runtime::db::ScriptMutability;
+
+        let dir = TempDir::new().map_err(|e| crate::engine::error::AdhocError(e.to_string()))?;
+
+        // Write and commit data, then drop the Database.
+        {
+            let db = new_cozo_redb(dir.path())?;
+            db.run_script(
+                "{:create wal_check {k: Int => v: String}}",
+                Default::default(),
+                ScriptMutability::Mutable,
+            )?;
+            db.run_script(
+                r#"?[k, v] <- [[42, "sentinel"]] :put wal_check {k => v}"#,
+                Default::default(),
+                ScriptMutability::Mutable,
+            )?;
+            // `db` dropped here — redb flushes WAL.
+        }
+
+        // Reopen and confirm the data survived.
+        let db2 = new_cozo_redb(dir.path())?;
+        let result = db2.run_script(
+            "?[v] := *wal_check{k: 42, v}",
+            Default::default(),
+            ScriptMutability::Immutable,
+        )?;
+        assert_eq!(result.rows.len(), 1, "row should survive WAL flush on drop");
+        assert_eq!(result.rows[0][0], DataValue::Str("sentinel".into()));
+        Ok(())
     }
 
     #[test]

--- a/crates/organon/src/builtins/filesystem.rs
+++ b/crates/organon/src/builtins/filesystem.rs
@@ -12,6 +12,7 @@ use aletheia_koina::id::ToolName;
 use indexmap::IndexMap;
 
 use crate::error::Result;
+use crate::process_guard::ProcessGuard;
 use crate::registry::{ToolExecutor, ToolRegistry};
 use crate::types::{
     InputSchema, PropertyDef, PropertyType, ToolCategory, ToolContext, ToolDef, ToolInput,
@@ -35,18 +36,22 @@ fn truncate_output(mut output: String) -> String {
 }
 
 fn run_command(cmd: &mut Command) -> std::io::Result<std::process::Output> {
-    let mut child = cmd.stdout(Stdio::piped()).stderr(Stdio::piped()).spawn()?;
+    // Wrap in ProcessGuard so the child is killed and reaped on any early
+    // return (I/O error, panic, etc.) before we reach wait().
+    let mut guard =
+        ProcessGuard::new(cmd.stdout(Stdio::piped()).stderr(Stdio::piped()).spawn()?);
 
     let mut stdout = String::new();
-    if let Some(ref mut pipe) = child.stdout {
+    if let Some(ref mut pipe) = guard.get_mut().stdout {
         let _ = pipe.read_to_string(&mut stdout);
     }
     let mut stderr = String::new();
-    if let Some(ref mut pipe) = child.stderr {
+    if let Some(ref mut pipe) = guard.get_mut().stderr {
         let _ = pipe.read_to_string(&mut stderr);
     }
 
-    let status = child.wait()?;
+    // Detach the guard (no kill needed) and reap the process.
+    let status = guard.detach().wait()?;
     Ok(std::process::Output {
         status,
         stdout: stdout.into_bytes(),

--- a/crates/organon/src/builtins/workspace.rs
+++ b/crates/organon/src/builtins/workspace.rs
@@ -7,6 +7,8 @@ use std::pin::Pin;
 use std::process::{Command, Stdio};
 use std::time::{Duration, Instant};
 
+use crate::process_guard::ProcessGuard;
+
 use aletheia_koina::id::ToolName;
 use indexmap::IndexMap;
 
@@ -264,8 +266,10 @@ impl ToolExecutor for ExecExecutor {
                 crate::sandbox::apply_sandbox(&mut cmd, policy);
             }
 
-            let mut child = match cmd.spawn() {
-                Ok(c) => c,
+            // Wrap immediately so the child is killed on any early return
+            // (timeout, wait error, or panic).
+            let mut guard = match cmd.spawn() {
+                Ok(c) => ProcessGuard::new(c),
                 Err(e) => {
                     return Ok(err_result(format!("spawn failed: {e}")));
                 }
@@ -273,12 +277,11 @@ impl ToolExecutor for ExecExecutor {
 
             let deadline = Instant::now() + Duration::from_millis(timeout_ms);
             let status = loop {
-                match child.try_wait() {
+                match guard.get_mut().try_wait() {
                     Ok(Some(s)) => break s,
                     Ok(None) => {
                         if Instant::now() >= deadline {
-                            let _ = child.kill();
-                            let _ = child.wait();
+                            // Dropping `guard` kills and reaps the child.
                             return Ok(err_result(format!(
                                 "command timed out after {timeout_ms}ms"
                             )));
@@ -291,12 +294,16 @@ impl ToolExecutor for ExecExecutor {
                 }
             };
 
+            // Process exited normally (`try_wait` already reaped the zombie).
+            // Read captured stdio via the guard. The guard's Drop will call
+            // kill() + wait() on the already-dead process, both of which
+            // safely ignore ESRCH / ECHILD errors.
             let mut stdout = String::new();
-            if let Some(ref mut pipe) = child.stdout {
+            if let Some(ref mut pipe) = guard.get_mut().stdout {
                 let _ = pipe.read_to_string(&mut stdout);
             }
             let mut stderr = String::new();
-            if let Some(ref mut pipe) = child.stderr {
+            if let Some(ref mut pipe) = guard.get_mut().stderr {
                 let _ = pipe.read_to_string(&mut stderr);
             }
 

--- a/crates/organon/src/lib.rs
+++ b/crates/organon/src/lib.rs
@@ -11,6 +11,8 @@ pub mod builtins;
 /// Organon-specific error types and result alias.
 pub mod error;
 pub mod metrics;
+/// RAII guard for subprocess lifecycle — kills and reaps on drop.
+pub(crate) mod process_guard;
 /// Central tool registry for runtime discovery and dispatch.
 pub mod registry;
 /// Landlock + seccomp sandbox for tool execution.

--- a/crates/organon/src/process_guard.rs
+++ b/crates/organon/src/process_guard.rs
@@ -1,0 +1,276 @@
+//! RAII guard for subprocess lifecycle management.
+//!
+//! [`ProcessGuard`] wraps a [`std::process::Child`] and guarantees the child
+//! process is killed and reaped when the guard is dropped — including on
+//! panic.  This prevents both orphan processes (child outlives parent) and
+//! zombie accumulation (child exited but not reaped).
+//!
+//! # Usage pattern
+//!
+//! Wrap the child immediately after `spawn()`, then interact via
+//! [`get_mut()`][ProcessGuard::get_mut]:
+//!
+//! ```ignore
+//! let child = Command::new("sh").arg("-c").arg(cmd).spawn()?;
+//! let mut guard = ProcessGuard::new(child);
+//!
+//! // Poll, read I/O, enforce a deadline…
+//! match guard.get_mut().try_wait() { ... }
+//!
+//! // Timeout path: just return early — drop kills the child automatically.
+//!
+//! // Normal exit path: detach to take ownership back and read stdio.
+//! let mut child = guard.detach();
+//! child.wait()?;
+//! ```
+
+/// RAII guard that kills and reaps a child process on drop.
+///
+/// Drop calls `kill()` followed by `wait()` on the inner
+/// [`Child`][std::process::Child].  Both calls ignore errors: `kill()` fails
+/// if the process has already exited (safe), and `wait()` fails if the OS
+/// has already reaped the zombie (safe).
+pub(crate) struct ProcessGuard {
+    child: Option<std::process::Child>,
+}
+
+impl ProcessGuard {
+    /// Wrap a spawned child process in a kill-on-drop guard.
+    pub(crate) fn new(child: std::process::Child) -> Self {
+        Self {
+            child: Some(child),
+        }
+    }
+
+    /// Borrow the inner [`Child`][std::process::Child] for polling or I/O.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the guard has already been consumed via
+    /// [`detach()`][Self::detach].
+    pub(crate) fn get_mut(&mut self) -> &mut std::process::Child {
+        self.child.as_mut().expect("ProcessGuard already consumed")
+    }
+
+    /// Take ownership of the child, disarming the kill-on-drop.
+    ///
+    /// The caller is responsible for reaping the process (calling `wait()` or
+    /// `try_wait()`).  Use this after the process has exited normally and you
+    /// need the exit status or remaining stdio output.
+    ///
+    /// # Panics
+    ///
+    /// Panics if called on an already-detached guard.
+    pub(crate) fn detach(mut self) -> std::process::Child {
+        self.child.take().expect("ProcessGuard already consumed")
+    }
+}
+
+impl Drop for ProcessGuard {
+    fn drop(&mut self) {
+        if let Some(mut child) = self.child.take() {
+            // Best-effort kill. Returns an error if the process already
+            // exited — that is fine; we are ensuring cleanup, not asserting
+            // the process was alive.
+            let _ = child.kill();
+            // Reap the (possibly-already-dead) child so it doesn't linger
+            // as a zombie. Errors indicate the OS already reaped it.
+            let _ = child.wait();
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use std::process::Command;
+    use std::time::Duration;
+
+    use super::*;
+
+    /// Spawn a long-running process, drop the guard, and verify the process
+    /// is no longer alive.
+    #[test]
+    fn kills_child_on_drop() {
+        let child = Command::new("sleep")
+            .arg("60")
+            .spawn()
+            .expect("spawn sleep");
+        let pid = child.id();
+
+        let guard = ProcessGuard::new(child);
+        drop(guard);
+
+        // Give the OS a moment to clean up.
+        std::thread::sleep(Duration::from_millis(50));
+
+        // `kill -0 <pid>` succeeds only if the process exists.
+        let alive = Command::new("kill")
+            .args(["-0", &pid.to_string()])
+            .output()
+            .expect("kill -0")
+            .status
+            .success();
+        assert!(!alive, "process {pid} should have been killed on drop");
+    }
+
+    /// After `detach()`, the guard no longer kills the child.
+    #[test]
+    fn detach_prevents_kill() {
+        let child = Command::new("sleep")
+            .arg("60")
+            .spawn()
+            .expect("spawn sleep");
+        let pid = child.id();
+
+        let guard = ProcessGuard::new(child);
+        let mut child = guard.detach(); // disarms kill-on-drop
+
+        // Process should still be alive right after detach.
+        let alive = Command::new("kill")
+            .args(["-0", &pid.to_string()])
+            .output()
+            .expect("kill -0")
+            .status
+            .success();
+        assert!(alive, "process {pid} should still be alive after detach");
+
+        // Clean up explicitly.
+        let _ = child.kill();
+        let _ = child.wait();
+    }
+
+    /// `get_mut()` exposes the child for polling.
+    #[test]
+    fn get_mut_allows_try_wait() {
+        let child = Command::new("true").spawn().expect("spawn true");
+        let mut guard = ProcessGuard::new(child);
+
+        // `true` exits immediately; wait until try_wait says so.
+        let mut status = None;
+        for _ in 0..50 {
+            if let Ok(Some(s)) = guard.get_mut().try_wait() {
+                status = Some(s);
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        let status = status.expect("process should have exited");
+        assert!(status.success());
+    }
+
+    /// Dropping a guard whose child has already exited is safe (no panic,
+    /// no double-kill errors propagated).
+    #[test]
+    fn drop_of_already_exited_child_is_safe() {
+        let child = Command::new("true").spawn().expect("spawn true");
+        let mut guard = ProcessGuard::new(child);
+
+        // Wait for exit.
+        loop {
+            if let Ok(Some(_)) = guard.get_mut().try_wait() {
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+
+        // Drop must not panic even though the process has already exited.
+        drop(guard);
+    }
+
+    /// `detach()` followed by `wait()` is the normal success path: get the
+    /// exit status without triggering the kill-on-drop.
+    #[test]
+    fn detach_then_wait_gives_exit_status() {
+        let child = Command::new("sh")
+            .args(["-c", "exit 7"])
+            .spawn()
+            .expect("spawn");
+        let guard = ProcessGuard::new(child);
+        let mut child = guard.detach();
+        let status = child.wait().expect("wait");
+        assert_eq!(status.code(), Some(7));
+    }
+
+    /// A guard that is constructed but immediately dropped (zero-size path)
+    /// does not crash.
+    #[test]
+    fn guard_with_short_lived_process_does_not_crash() {
+        let child = Command::new("echo")
+            .arg("hello")
+            .spawn()
+            .expect("spawn echo");
+        let _guard = ProcessGuard::new(child);
+        // guard dropped here — process may already be dead
+    }
+
+    /// Panic while a guard is live causes Drop to run and kill the child.
+    ///
+    /// This verifies the invariant without needing `UnwindSafe` on `Child`:
+    /// we spawn the child, record its PID, then in a separate thread (which
+    /// can unwind without propagating to the test thread) we create a guard
+    /// and panic.
+    #[test]
+    fn guard_cleans_up_on_thread_panic() {
+        use std::sync::mpsc;
+
+        let child = Command::new("sleep")
+            .arg("60")
+            .spawn()
+            .expect("spawn sleep");
+        let pid = child.id();
+
+        // Channel to send the child into the panicking thread.
+        let (tx, rx) = mpsc::channel::<std::process::Child>();
+        tx.send(child).unwrap();
+
+        let handle = std::thread::spawn(move || {
+            let child = rx.recv().unwrap();
+            let _guard = ProcessGuard::new(child);
+            panic!("intentional panic to test guard cleanup");
+        });
+
+        // Thread panics; guard's Drop runs and kills the child.
+        let _ = handle.join(); // join is Ok(Err(panic)), we don't care
+
+        std::thread::sleep(Duration::from_millis(100));
+
+        let alive = Command::new("kill")
+            .args(["-0", &pid.to_string()])
+            .output()
+            .expect("kill -0")
+            .status
+            .success();
+        assert!(!alive, "process {pid} should have been killed by guard drop on panic");
+    }
+
+    /// Two sequential guards for two different processes both clean up
+    /// independently.
+    #[test]
+    fn multiple_guards_are_independent() {
+        let c1 = Command::new("sleep").arg("60").spawn().expect("spawn 1");
+        let c2 = Command::new("sleep").arg("60").spawn().expect("spawn 2");
+        let pid1 = c1.id();
+        let pid2 = c2.id();
+
+        let g1 = ProcessGuard::new(c1);
+        let g2 = ProcessGuard::new(c2);
+        drop(g1);
+        drop(g2);
+
+        std::thread::sleep(Duration::from_millis(50));
+
+        for pid in [pid1, pid2] {
+            let alive = Command::new("kill")
+                .args(["-0", &pid.to_string()])
+                .output()
+                .expect("kill -0")
+                .status
+                .success();
+            assert!(!alive, "process {pid} should have been killed");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- **ProcessGuard** (`crates/organon/src/process_guard.rs`): new RAII type wrapping `std::process::Child` that kills and reaps the child on drop — including on panic. Drop calls `kill()` followed by `wait()`, both error-ignoring so they're safe whether the process is alive or already dead.
- **Tool executor integration**: `ExecExecutor` (workspace tools) and `run_command` (filesystem grep/find) now wrap spawned children in `ProcessGuard` immediately after `spawn()`, eliminating the window where a panic could leak a subprocess.
- **Temp directory audit**: all production temp usage is either atomic rename-after-write (`credential.rs`) or test-scoped `tempfile::TempDir` (already RAII). No custom guard needed; documented in `new_cozo_redb`.
- **redb WAL documentation**: added doc comments to `RedbStorage` and `new_cozo_redb` explaining that redb flushes the WAL on `Database` drop and uncommitted `WriteTransaction`s roll back automatically.

## Tests

10 new tests (8 in `process_guard.rs`, 2 in `redb.rs`):

| Test | What it verifies |
|------|-----------------|
| `kills_child_on_drop` | Guard kills subprocess on normal drop |
| `detach_prevents_kill` | `detach()` disarms kill-on-drop |
| `get_mut_allows_try_wait` | `get_mut()` exposes child for polling |
| `drop_of_already_exited_child_is_safe` | Drop on dead process does not panic |
| `detach_then_wait_gives_exit_status` | Normal success path: detach + wait |
| `guard_with_short_lived_process_does_not_crash` | Edge case: echo exits before drop |
| `guard_cleans_up_on_thread_panic` | RAII holds through unwind in a thread |
| `multiple_guards_are_independent` | Two guards each kill their own child |
| `temp_dir_raii_removes_database_file_on_drop` | `TempDir` removes `data.redb` on drop |
| `redb_flushes_wal_on_database_drop` | Data written before drop is readable after reopen |

## Test plan

- [x] `cargo check -p aletheia-mneme -p aletheia-nous -p aletheia-organon` — clean
- [x] `cargo test -p aletheia-organon` — 248 passed
- [x] `cargo test -p aletheia-mneme` — 405 passed + 2 integration tests
- [x] `cargo clippy -p aletheia-mneme -p aletheia-nous -p aletheia-organon --all-targets -- -D warnings` — zero warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)