### PR TITLE
fix(mneme): close native code audit findings

### DIFF
--- a/crates/mneme/Cargo.toml
+++ b/crates/mneme/Cargo.toml
@@ -28,7 +28,7 @@ mneme-engine = [
     "dep:crossbeam", "dep:itertools", "dep:rustc-hash", "dep:twox-hash",
     "dep:regex", "dep:sha2",
     "dep:either", "dep:rand", "dep:base64",
-    "dep:uuid", "dep:pest", "dep:pest_derive", "dep:unicode-normalization",
+    "dep:uuid", "dep:pest", "dep:pest_derive",
     "dep:aho-corasick", "dep:rust-stemmers",
     "dep:bytemuck",
 ]
@@ -67,7 +67,7 @@ base64 = { version = "0.22", optional = true }
 uuid = { version = "1", features = ["v1", "v4", "serde"], optional = true }
 pest = { version = "2.8", optional = true }
 pest_derive = { version = "2.8", optional = true }
-unicode-normalization = { version = "0.1", optional = true }
+unicode-normalization = { version = "0.1" }
 aho-corasick = { version = "1.1", optional = true }
 rust-stemmers = { version = "1.2", optional = true }
 bytemuck = { version = "1.25", optional = true }

--- a/crates/mneme/src/embedding.rs
+++ b/crates/mneme/src/embedding.rs
@@ -29,6 +29,13 @@ pub enum EmbeddingError {
         #[snafu(implicit)]
         location: snafu::Location,
     },
+
+    /// The embedding model mutex was poisoned by a prior panic.
+    #[snafu(display("embedding model lock poisoned"))]
+    LockPoisoned {
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
 }
 
 /// Result type for embedding operations.
@@ -205,7 +212,7 @@ impl EmbeddingProvider for FastEmbedProvider {
     fn embed(&self, text: &str) -> EmbeddingResult<Vec<f32>> {
         self.model
             .lock()
-            .expect("fastembed model lock") // INVARIANT: lock held only for embed call, poisoned = prior panic
+            .map_err(|_poison| LockPoisonedSnafu.build())?
             .embed(vec![text], None)
             .map_err(|e| {
                 EmbedFailedSnafu {
@@ -227,7 +234,7 @@ impl EmbeddingProvider for FastEmbedProvider {
     fn embed_batch(&self, texts: &[&str]) -> EmbeddingResult<Vec<Vec<f32>>> {
         self.model
             .lock()
-            .expect("fastembed model lock") // INVARIANT: lock held only for embed call, poisoned = prior panic
+            .map_err(|_poison| LockPoisonedSnafu.build())?
             .embed(texts, None)
             .map_err(|e| {
                 EmbedFailedSnafu {
@@ -588,6 +595,39 @@ mod tests {
         assert!(
             msg.contains("not enabled"),
             "expected 'not enabled' in error, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn lock_poisoned_error_returns_err_not_panic() {
+        use std::sync::Mutex;
+
+        // Poison a mutex by panicking inside a thread while holding it.
+        let m: Mutex<u32> = Mutex::new(0);
+        let _ = std::panic::catch_unwind(|| {
+            let _guard = m.lock().unwrap();
+            panic!("intentional poison");
+        });
+        assert!(m.is_poisoned(), "mutex must be poisoned after thread panic");
+
+        // Simulate what embed() does: map_err to LockPoisoned.
+        let result: EmbeddingResult<()> = m
+            .lock()
+            .map_err(|_poison| LockPoisonedSnafu.build())
+            .map(|_| ());
+        assert!(
+            matches!(result, Err(EmbeddingError::LockPoisoned { .. })),
+            "poisoned lock must produce EmbeddingError::LockPoisoned"
+        );
+    }
+
+    #[test]
+    fn lock_poisoned_error_formats() {
+        let err = LockPoisonedSnafu.build();
+        assert_eq!(
+            err.to_string(),
+            "embedding model lock poisoned",
+            "LockPoisoned display must match spec"
         );
     }
 

--- a/crates/mneme/src/error.rs
+++ b/crates/mneme/src/error.rs
@@ -143,6 +143,17 @@ pub enum Error {
         #[snafu(implicit)]
         location: snafu::Location,
     },
+
+    /// An entity ID contains characters not permitted in Datalog script interpolation.
+    ///
+    /// Valid entity IDs contain only ASCII alphanumerics, hyphens, and underscores.
+    #[cfg(feature = "mneme-engine")]
+    #[snafu(display("invalid entity id for query interpolation: {id:?}"))]
+    InvalidEntityId {
+        id: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
 }
 
 /// Result alias using mneme's [`Error`] type.

--- a/crates/mneme/src/export.rs
+++ b/crates/mneme/src/export.rs
@@ -185,7 +185,7 @@ fn query_all_entities(
         let updated_at = row[5].get_str().unwrap_or_default().to_owned();
 
         entities.push(crate::knowledge::Entity {
-            id,
+            id: crate::knowledge::EntityId::from(id),
             name,
             entity_type,
             aliases,
@@ -219,8 +219,8 @@ fn query_all_relationships(
         let created_at = row[4].get_str().unwrap_or_default().to_owned();
 
         relationships.push(crate::knowledge::Relationship {
-            src,
-            dst,
+            src: crate::knowledge::EntityId::from(src),
+            dst: crate::knowledge::EntityId::from(dst),
             relation,
             weight,
             created_at,

--- a/crates/mneme/src/extract.rs
+++ b/crates/mneme/src/extract.rs
@@ -276,7 +276,7 @@ Rules:
         let mut result = PersistResult::default();
 
         for entity in &extraction.entities {
-            let id = slugify(&entity.name);
+            let id = crate::knowledge::EntityId::from(slugify(&entity.name));
             let aliases = if entity.description.is_empty() {
                 vec![]
             } else {
@@ -324,8 +324,8 @@ Rules:
                 }
             };
             let r = Relationship {
-                src: slugify(&rel.source),
-                dst: slugify(&rel.target),
+                src: crate::knowledge::EntityId::from(slugify(&rel.source)),
+                dst: crate::knowledge::EntityId::from(slugify(&rel.target)),
                 relation: relation_type,
                 weight: rel.confidence,
                 created_at: now.clone(),
@@ -411,10 +411,17 @@ fn strip_code_fences(s: &str) -> &str {
     }
 }
 
-/// Slugify a string: lowercase, spaces to hyphens, keep alphanumeric and hyphens.
+/// Slugify a string: NFC-normalize, lowercase, spaces to hyphens, keep alphanumeric and hyphens.
+///
+/// Unicode Normalization Form C is applied first so that visually identical strings
+/// with different codepoint sequences (e.g. composed vs decomposed "café") produce the
+/// same slug.
 #[cfg(any(feature = "mneme-engine", test))]
 fn slugify(s: &str) -> String {
-    s.to_lowercase()
+    use unicode_normalization::UnicodeNormalization as _;
+    let normalized: String = s.nfc().collect();
+    normalized
+        .to_lowercase()
         .chars()
         .map(|c| if c.is_alphanumeric() { c } else { '-' })
         .collect::<String>()
@@ -425,46 +432,14 @@ fn slugify(s: &str) -> String {
 }
 
 /// Current time as ISO 8601 string (UTC, second precision).
+///
+/// Uses `jiff` (project standard) rather than `std::time::SystemTime` + manual
+/// epoch-day arithmetic. Format: `YYYY-MM-DDTHH:MM:SSZ`.
 #[cfg(feature = "mneme-engine")]
 fn now_iso8601() -> String {
-    use std::time::SystemTime;
-
-    let dur = SystemTime::now()
-        .duration_since(SystemTime::UNIX_EPOCH)
-        .unwrap_or_default();
-    let secs = dur.as_secs();
-    let days = secs / 86400;
-    let time_secs = secs % 86400;
-    let hours = time_secs / 3600;
-    let minutes = (time_secs % 3600) / 60;
-    let seconds = time_secs % 60;
-
-    // Simple epoch-day to y/m/d (civil calendar from days since 1970-01-01).
-    #[expect(clippy::cast_possible_wrap, reason = "epoch days fits in i64")]
-    let (y, m, d) = epoch_days_to_ymd(days as i64);
-    format!("{y:04}-{m:02}-{d:02}T{hours:02}:{minutes:02}:{seconds:02}Z")
-}
-
-/// Convert epoch days to (year, month, day). Algorithm from Howard Hinnant.
-#[cfg(feature = "mneme-engine")]
-#[allow(
-    clippy::cast_possible_truncation,
-    clippy::cast_lossless,
-    clippy::similar_names,
-    // Hinnant algorithm uses known-range casts; doe/doy are standard names
-)]
-fn epoch_days_to_ymd(days: i64) -> (i64, u32, u32) {
-    let z = days + 719_468;
-    let era = z.div_euclid(146_097);
-    let doe = z.rem_euclid(146_097) as u32;
-    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146_096) / 365;
-    let y = (yoe as i64) + era * 400;
-    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
-    let mp = (5 * doy + 2) / 153;
-    let d = doy - (153 * mp + 2) / 5 + 1;
-    let m = if mp < 10 { mp + 3 } else { mp - 9 };
-    let y = if m <= 2 { y + 1 } else { y };
-    (y, m, d)
+    jiff::Zoned::now()
+        .strftime("%Y-%m-%dT%H:%M:%SZ")
+        .to_string()
 }
 
 // ---------------------------------------------------------------------------
@@ -1250,6 +1225,39 @@ Some text
             result.chars().all(|c| c.is_alphanumeric() || c == '-'),
             "slugify output should only contain alphanumeric or hyphens"
         );
+    }
+
+    #[test]
+    fn slugify_nfc_normalization_composed_vs_decomposed() {
+        // "café" in NFC (composed é = U+00E9) vs NFD (decomposed e + combining accent)
+        let composed = "caf\u{00E9}"; // NFC é
+        let decomposed = "cafe\u{0301}"; // NFD: e + combining acute accent
+        let slug_composed = slugify(composed);
+        let slug_decomposed = slugify(decomposed);
+        assert_eq!(
+            slug_composed, slug_decomposed,
+            "NFC-composed and NFD-decomposed forms must produce the same slug"
+        );
+    }
+
+    #[test]
+    fn slugify_nfc_normalization_preserves_ascii() {
+        // NFC normalization must not alter plain ASCII
+        assert_eq!(slugify("hello-world"), "hello-world");
+        assert_eq!(slugify("Data Processor"), "data-processor");
+    }
+
+    #[cfg(feature = "mneme-engine")]
+    #[test]
+    fn now_iso8601_uses_jiff_format() {
+        let ts = now_iso8601();
+        // Must match YYYY-MM-DDTHH:MM:SSZ
+        assert_eq!(ts.len(), 20, "timestamp must be exactly 20 chars: {ts}");
+        assert!(ts.ends_with('Z'), "timestamp must end with Z: {ts}");
+        assert_eq!(&ts[10..11], "T", "timestamp must have T separator: {ts}");
+        // Year must be plausible (>= 2025)
+        let year: u32 = ts[..4].parse().expect("year must be numeric");
+        assert!(year >= 2025, "year must be >= 2025, got {year}");
     }
 
     #[cfg(feature = "mneme-engine")]

--- a/crates/mneme/src/knowledge.rs
+++ b/crates/mneme/src/knowledge.rs
@@ -10,6 +10,48 @@
 
 use serde::{Deserialize, Serialize};
 
+/// Typed newtype for entity identifiers in the knowledge graph.
+///
+/// Prevents accidental mixing of entity IDs with other string fields (e.g. `nous_id`,
+/// `source_session_id`). Serializes/deserializes as a plain string for backwards
+/// compatibility with existing storage schemas.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct EntityId(String);
+
+impl EntityId {
+    /// Borrow the inner string slice.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl From<String> for EntityId {
+    fn from(s: String) -> Self {
+        Self(s)
+    }
+}
+
+impl From<&str> for EntityId {
+    fn from(s: &str) -> Self {
+        Self(s.to_owned())
+    }
+}
+
+impl std::fmt::Display for EntityId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl std::ops::Deref for EntityId {
+    type Target = str;
+    fn deref(&self) -> &str {
+        &self.0
+    }
+}
+
 /// A memory fact extracted from conversation.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Fact {
@@ -53,7 +95,7 @@ pub struct Fact {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Entity {
     /// Unique identifier.
-    pub id: String,
+    pub id: EntityId,
     /// Display name.
     pub name: String,
     /// Entity type (person, project, tool, concept, etc.).
@@ -70,9 +112,9 @@ pub struct Entity {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Relationship {
     /// Source entity ID.
-    pub src: String,
+    pub src: EntityId,
     /// Target entity ID.
-    pub dst: String,
+    pub dst: EntityId,
     /// Relationship type (e.g. `works_on`, `knows`, `depends_on`).
     pub relation: String,
     /// Relationship weight/strength (0.0–1.0).
@@ -217,6 +259,57 @@ pub struct RecallResult {
 mod tests {
     use super::*;
 
+    // ---- EntityId ----
+
+    #[test]
+    fn entity_id_from_str() {
+        let id = EntityId::from("alice");
+        assert_eq!(id.as_str(), "alice");
+        assert_eq!(id.to_string(), "alice");
+    }
+
+    #[test]
+    fn entity_id_from_string() {
+        let id = EntityId::from("bob".to_owned());
+        assert_eq!(&*id, "bob");
+    }
+
+    #[test]
+    fn entity_id_serde_transparent() {
+        let id = EntityId::from("e-123");
+        let json = serde_json::to_string(&id).unwrap();
+        // Must serialize as a plain JSON string, not {"0":"e-123"}
+        assert_eq!(
+            json, r#""e-123""#,
+            "EntityId must serialize as plain string"
+        );
+        let back: EntityId = serde_json::from_str(&json).unwrap();
+        assert_eq!(id, back);
+    }
+
+    #[test]
+    fn entity_id_prevents_mixing_with_plain_string() {
+        // Compile-time: EntityId and String are distinct types.
+        // Runtime: confirm they compare correctly via as_str.
+        let eid = EntityId::from("nous-1");
+        let plain: String = "nous-1".to_owned();
+        assert_eq!(eid.as_str(), plain.as_str());
+    }
+
+    #[test]
+    fn entity_id_display_matches_inner_string() {
+        let id = EntityId::from("project-aletheia");
+        assert_eq!(format!("{id}"), "project-aletheia");
+    }
+
+    #[test]
+    fn entity_id_clone_equality() {
+        let a = EntityId::from("e-42");
+        let b = a.clone();
+        assert_eq!(a, b, "cloned EntityId must equal original");
+        assert_eq!(a.as_str(), b.as_str());
+    }
+
     #[test]
     fn epistemic_tier_serde_roundtrip() {
         for tier in [
@@ -260,7 +353,7 @@ mod tests {
     #[test]
     fn entity_serde_roundtrip() {
         let entity = Entity {
-            id: "e-1".to_owned(),
+            id: EntityId::from("e-1"),
             name: "Dr. Chen".to_owned(),
             entity_type: "person".to_owned(),
             aliases: vec!["acme_user".to_owned(), "test-user-01".to_owned()],
@@ -276,8 +369,8 @@ mod tests {
     #[test]
     fn relationship_serde_roundtrip() {
         let rel = Relationship {
-            src: "e-1".to_owned(),
-            dst: "e-2".to_owned(),
+            src: EntityId::from("e-1"),
+            dst: EntityId::from("e-2"),
             relation: "works_on".to_owned(),
             weight: 0.85,
             created_at: "2026-02-28T00:00:00Z".to_owned(),
@@ -375,7 +468,7 @@ mod tests {
     #[test]
     fn entity_empty_aliases() {
         let entity = Entity {
-            id: "e-2".to_owned(),
+            id: EntityId::from("e-2"),
             name: "Aletheia".to_owned(),
             entity_type: "project".to_owned(),
             aliases: vec![],

--- a/crates/mneme/src/knowledge_store.rs
+++ b/crates/mneme/src/knowledge_store.rs
@@ -135,6 +135,33 @@ pub fn fts_ddl() -> &'static str {
 #[cfg(feature = "mneme-engine")]
 use crate::query::queries;
 
+/// Typed wrapper for raw Datalog query results.
+///
+/// Returned by [`KnowledgeStore::run_query`] and related escape-hatch methods.
+/// Hides the `crate::engine::NamedRows` type from callers, keeping CozoDB
+/// internals encapsulated within the knowledge layer.
+///
+/// Row values are [`crate::engine::DataValue`] — call `.get_str()`, `.get_float()`,
+/// etc. to extract typed values.
+#[cfg(feature = "mneme-engine")]
+#[derive(Debug, Clone)]
+pub struct QueryResult {
+    /// Column names in the order they appear in each row.
+    pub headers: Vec<String>,
+    /// Result rows. Each row is a flat `Vec` matching `headers` by position.
+    pub rows: Vec<Vec<crate::engine::DataValue>>,
+}
+
+#[cfg(feature = "mneme-engine")]
+impl From<crate::engine::NamedRows> for QueryResult {
+    fn from(nr: crate::engine::NamedRows) -> Self {
+        Self {
+            headers: nr.headers,
+            rows: nr.rows,
+        }
+    }
+}
+
 /// Configuration for `KnowledgeStore` initialization.
 #[cfg(feature = "mneme-engine")]
 #[derive(Clone, Copy, Debug)]
@@ -422,18 +449,19 @@ impl KnowledgeStore {
         self.run_mut(&queries::upsert_relationship(), params)
     }
 
-    /// Query 2-hop entity neighborhood. Returns raw rows for flexible callers.
+    /// Query 2-hop entity neighborhood.
+    ///
+    /// Returns a [`QueryResult`] whose rows correspond to the Datalog output of
+    /// `ENTITY_NEIGHBORHOOD`. Columns: `id`, `score`, `hops`.
     #[instrument(skip(self))]
-    pub fn entity_neighborhood(
-        &self,
-        entity_id: &str,
-    ) -> crate::error::Result<crate::engine::NamedRows> {
+    pub fn entity_neighborhood(&self, entity_id: &str) -> crate::error::Result<QueryResult> {
         use crate::engine::DataValue;
         use std::collections::BTreeMap;
 
         let mut params = BTreeMap::new();
         params.insert("entity_id".to_owned(), DataValue::Str(entity_id.into()));
         self.run_read(queries::ENTITY_NEIGHBORHOOD, params)
+            .map(QueryResult::from)
     }
 
     /// Insert a vector embedding for semantic search.
@@ -504,13 +532,16 @@ impl KnowledgeStore {
     }
 
     /// Raw query escape hatch for callers needing custom Datalog.
+    ///
+    /// Returns a [`QueryResult`] rather than raw `NamedRows` to keep CozoDB
+    /// internals encapsulated. Access row values via `result.rows[i][j]`.
     #[instrument(skip(self, params))]
     pub fn run_query(
         &self,
         script: &str,
         params: std::collections::BTreeMap<String, crate::engine::DataValue>,
-    ) -> crate::error::Result<crate::engine::NamedRows> {
-        self.run_read(script, params)
+    ) -> crate::error::Result<QueryResult> {
+        self.run_read(script, params).map(QueryResult::from)
     }
 
     /// Run a custom Datalog query with an optional timeout.
@@ -520,13 +551,16 @@ impl KnowledgeStore {
     ///
     /// Note: timeout detection relies on the engine error containing "killed before completion"
     /// (from `CozoDB`'s internal `ProcessKilled` error). This is a known fragile dependency.
+    ///
+    /// Returns a [`QueryResult`] rather than raw `NamedRows` to keep CozoDB internals
+    /// encapsulated.
     #[instrument(skip(self, params))]
     pub fn run_query_with_timeout(
         &self,
         script: &str,
         params: std::collections::BTreeMap<String, crate::engine::DataValue>,
         timeout: Option<std::time::Duration>,
-    ) -> crate::error::Result<crate::engine::NamedRows> {
+    ) -> crate::error::Result<QueryResult> {
         use crate::engine::ScriptMutability;
         let script_with_timeout = match timeout {
             Some(d) => format!("{script}\n:timeout {}", d.as_secs_f64()),
@@ -534,6 +568,7 @@ impl KnowledgeStore {
         };
         self.db
             .run(&script_with_timeout, params, ScriptMutability::Immutable)
+            .map(QueryResult::from)
             .map_err(|e| {
                 let msg = e.to_string();
                 if msg.contains("killed before completion") {
@@ -549,15 +584,19 @@ impl KnowledgeStore {
 
     /// Raw mutable query escape hatch — runs script with `ScriptMutability::Mutable`.
     /// Required for `:rm` and `:put` operations from caller code.
+    ///
+    /// Returns a [`QueryResult`] rather than raw `NamedRows` to keep CozoDB internals
+    /// encapsulated.
     #[instrument(skip(self, params))]
     pub fn run_mut_query(
         &self,
         script: &str,
         params: std::collections::BTreeMap<String, crate::engine::DataValue>,
-    ) -> crate::error::Result<crate::engine::NamedRows> {
+    ) -> crate::error::Result<QueryResult> {
         use crate::engine::ScriptMutability;
         self.db
             .run(script, params, ScriptMutability::Mutable)
+            .map(QueryResult::from)
             .map_err(|e| {
                 crate::error::EngineQuerySnafu {
                     message: e.to_string(),
@@ -591,7 +630,7 @@ impl KnowledgeStore {
         params.insert("ef".to_owned(), DataValue::from(ef_i64));
         params.insert("limit".to_owned(), DataValue::from(limit_i64));
 
-        let script = build_hybrid_query(q);
+        let script = build_hybrid_query(q)?;
         let rows = self.run_read(&script, params)?;
         let results = rows_to_hybrid_results(rows)?;
 
@@ -1492,13 +1531,16 @@ impl KnowledgeStore {
     ///
     /// Equivalent to calling `run_query`, but makes the immutability contract explicit
     /// for callers who need a read-only guarantee (e.g., the `datalog_query` tool).
+    ///
+    /// Returns a [`QueryResult`] rather than raw `NamedRows` to keep CozoDB internals
+    /// encapsulated.
     #[instrument(skip(self, params))]
     pub fn run_script_read_only(
         &self,
         script: &str,
         params: std::collections::BTreeMap<String, crate::engine::DataValue>,
-    ) -> crate::error::Result<crate::engine::NamedRows> {
-        self.run_read(script, params)
+    ) -> crate::error::Result<QueryResult> {
+        self.run_read(script, params).map(QueryResult::from)
     }
 
     // --- Internal helpers ---
@@ -2129,20 +2171,38 @@ fn rows_to_recall_results(
     Ok(out)
 }
 
+/// Validate that an entity ID is safe for interpolation into a Datalog script.
+///
+/// Only ASCII alphanumerics, hyphens (`-`), and underscores (`_`) are permitted.
+/// This mirrors the character set produced by [`slugify`], preventing injection
+/// via maliciously crafted entity IDs.
+#[cfg(feature = "mneme-engine")]
+fn validate_entity_id_for_query(id: &str) -> crate::error::Result<()> {
+    if id
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+    {
+        Ok(())
+    } else {
+        crate::error::InvalidEntityIdSnafu { id: id.to_owned() }.fail()
+    }
+}
+
 // Build the hybrid Datalog query with dynamic graph sub-rules.
 // When seed_entities is empty, graph is an empty relation.
 // When non-empty, seeds are expanded inline (avoids is_in() built-in dependency).
+// All seed entity IDs are validated against [a-zA-Z0-9_-] before interpolation.
 #[cfg(feature = "mneme-engine")]
-fn build_hybrid_query(q: &HybridQuery) -> String {
+fn build_hybrid_query(q: &HybridQuery) -> crate::error::Result<String> {
     let graph_rules = if q.seed_entities.is_empty() {
         // Empty graph relation — graph signal contributes 0 to RRF
         "graph[id, score] <- []".to_owned()
     } else {
-        let seed_data: Vec<String> = q
-            .seed_entities
-            .iter()
-            .map(|s| format!("[\"{}\"]", s.replace('"', "\\\"")))
-            .collect();
+        let mut seed_data = Vec::with_capacity(q.seed_entities.len());
+        for s in &q.seed_entities {
+            validate_entity_id_for_query(s)?;
+            seed_data.push(format!("[\"{s}\"]"));
+        }
         let seeds_inline = seed_data.join(", ");
         format!(
             "seed_list[e] <- [{seeds_inline}]\n        \
@@ -2152,7 +2212,7 @@ fn build_hybrid_query(q: &HybridQuery) -> String {
              graph[id, sum(score)] := graph_raw[id, score]"
         )
     };
-    queries::HYBRID_SEARCH_BASE.replace("{GRAPH_RULES}", &graph_rules)
+    Ok(queries::HYBRID_SEARCH_BASE.replace("{GRAPH_RULES}", &graph_rules))
 }
 
 // Parse rows from ReciprocalRankFusion output into Vec<HybridResult>.
@@ -2379,7 +2439,7 @@ mod tests {
             limit: 5,
             ef: 20,
         };
-        let script = build_hybrid_query(&q);
+        let script = build_hybrid_query(&q).expect("valid query");
         assert!(
             script.contains("graph[id, score] <- []"),
             "empty seeds must produce empty graph relation"
@@ -2397,7 +2457,7 @@ mod tests {
             limit: 5,
             ef: 20,
         };
-        let script = build_hybrid_query(&q);
+        let script = build_hybrid_query(&q).expect("valid entity ids");
         assert!(
             script.contains("seed_list"),
             "non-empty seeds must produce seed_list relation"
@@ -2413,6 +2473,54 @@ mod tests {
             script.contains("sum(score)"),
             "must aggregate scores per entity"
         );
+    }
+
+    #[cfg(feature = "mneme-engine")]
+    #[test]
+    fn build_hybrid_query_rejects_injection_in_seed_id() {
+        // Seeds with characters outside [a-zA-Z0-9_-] must return an error.
+        let dangerous_seeds = [
+            "e-1\"; DROP TABLE facts; --",
+            "id with spaces",
+            "id\nnewline",
+            "id\"quote",
+            "id'apostrophe",
+        ];
+        for seed in dangerous_seeds {
+            let q = HybridQuery {
+                text: "test".into(),
+                embedding: vec![0.0; 4],
+                seed_entities: vec![seed.to_owned()],
+                limit: 5,
+                ef: 20,
+            };
+            let result = build_hybrid_query(&q);
+            assert!(
+                result.is_err(),
+                "seed {seed:?} must be rejected but build_hybrid_query succeeded"
+            );
+            assert!(
+                matches!(result, Err(crate::error::Error::InvalidEntityId { .. })),
+                "seed {seed:?} must produce InvalidEntityId error"
+            );
+        }
+    }
+
+    #[cfg(feature = "mneme-engine")]
+    #[test]
+    fn build_hybrid_query_accepts_valid_seed_ids() {
+        let valid_seeds = ["e-1", "some_entity", "CamelCase123", "a-b_c"];
+        for seed in valid_seeds {
+            let q = HybridQuery {
+                text: "test".into(),
+                embedding: vec![0.0; 4],
+                seed_entities: vec![seed.to_owned()],
+                limit: 5,
+                ef: 20,
+            };
+            let result = build_hybrid_query(&q);
+            assert!(result.is_ok(), "valid seed {seed:?} must be accepted");
+        }
     }
 
     #[cfg(feature = "mneme-engine")]
@@ -2485,7 +2593,9 @@ mod tests {
         reason = "integration test with setup/assert phases"
     )]
     fn hybrid_search_graph_aggregation() {
-        use crate::knowledge::{EmbeddedChunk, Entity, EpistemicTier, Fact, Relationship};
+        use crate::knowledge::{
+            EmbeddedChunk, Entity, EntityId, EpistemicTier, Fact, Relationship,
+        };
 
         let dim = 4;
         let store =
@@ -2561,7 +2671,7 @@ mod tests {
         for (id, name) in [("s1", "Seed1"), ("s2", "Seed2"), ("s3", "Seed3")] {
             store
                 .insert_entity(&Entity {
-                    id: id.to_owned(),
+                    id: EntityId::from(id),
                     name: name.to_owned(),
                     entity_type: "concept".to_owned(),
                     aliases: vec![],
@@ -2571,8 +2681,8 @@ mod tests {
                 .expect("insert entity");
             store
                 .insert_relationship(&Relationship {
-                    src: id.to_owned(),
-                    dst: "f1".to_owned(),
+                    src: EntityId::from(id),
+                    dst: EntityId::from("f1"),
                     relation: "describes".to_owned(),
                     weight: 0.7,
                     created_at: "2026-03-01T00:00:00Z".to_owned(),
@@ -2581,8 +2691,8 @@ mod tests {
         }
         store
             .insert_relationship(&Relationship {
-                src: "s1".to_owned(),
-                dst: "f2".to_owned(),
+                src: EntityId::from("s1"),
+                dst: EntityId::from("f2"),
                 relation: "describes".to_owned(),
                 weight: 0.7,
                 created_at: "2026-03-01T00:00:00Z".to_owned(),
@@ -2631,7 +2741,7 @@ mod tests {
     #[cfg(feature = "mneme-engine")]
     #[test]
     fn hybrid_search_two_signal_no_graph() {
-        use crate::knowledge::{EmbeddedChunk, Entity, EpistemicTier, Fact};
+        use crate::knowledge::{EmbeddedChunk, Entity, EntityId, EpistemicTier, Fact};
 
         let dim = 4;
         let store =
@@ -2674,7 +2784,7 @@ mod tests {
         // no matches for f-twosig
         store
             .insert_entity(&Entity {
-                id: "e-unrelated".to_owned(),
+                id: EntityId::from("e-unrelated"),
                 name: "Unrelated".to_owned(),
                 entity_type: "concept".to_owned(),
                 aliases: vec![],
@@ -2759,7 +2869,7 @@ mod tests {
 mod knowledge_store_tests {
     use super::*;
     use crate::knowledge::{
-        EmbeddedChunk, Entity, EpistemicTier, Fact, ForgetReason, Relationship,
+        EmbeddedChunk, Entity, EntityId, EpistemicTier, Fact, ForgetReason, Relationship,
     };
     use std::collections::BTreeMap;
     use std::sync::Arc;
@@ -2794,7 +2904,7 @@ mod knowledge_store_tests {
 
     fn make_entity(id: &str, name: &str, entity_type: &str) -> Entity {
         Entity {
-            id: id.to_owned(),
+            id: EntityId::from(id),
             name: name.to_owned(),
             entity_type: entity_type.to_owned(),
             aliases: vec![],
@@ -2805,8 +2915,8 @@ mod knowledge_store_tests {
 
     fn make_relationship(src: &str, dst: &str, relation: &str, weight: f64) -> Relationship {
         Relationship {
-            src: src.to_owned(),
-            dst: dst.to_owned(),
+            src: EntityId::from(src),
+            dst: EntityId::from(dst),
             relation: relation.to_owned(),
             weight,
             created_at: "2026-03-01T00:00:00Z".to_owned(),
@@ -3956,6 +4066,27 @@ mod knowledge_store_tests {
             result.is_err(),
             "import_from_backup should error on in-memory backend"
         );
+    }
+
+    #[test]
+    fn query_result_does_not_expose_named_rows_type() {
+        // run_query must return QueryResult, not crate::engine::NamedRows.
+        // This test validates the type is QueryResult and exposes .headers + .rows.
+        let store = make_store();
+        let result: QueryResult = store
+            .run_query("?[x] := x = 99", BTreeMap::new())
+            .expect("simple query");
+        assert_eq!(result.rows.len(), 1, "one result row expected");
+        assert!(!result.headers.is_empty(), "headers must be populated");
+    }
+
+    #[test]
+    fn query_result_from_run_script_read_only() {
+        let store = make_store();
+        let result: QueryResult = store
+            .run_script_read_only("?[x] := x = 42", BTreeMap::new())
+            .expect("read-only query should succeed");
+        assert_eq!(result.rows.len(), 1);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes #557 — fixes all 6 findings from the standards audit of mneme's ~9K lines of native code.

- **NamedRows encapsulated** — `run_query*`, `entity_neighborhood`, `run_script_read_only` now return `QueryResult` (typed wrapper with `.headers` + `.rows`) instead of leaking `crate::engine::NamedRows`. `From<NamedRows>` handles the conversion; callers are unaffected.
- **Query string interpolation validated** — `build_hybrid_query` now returns `Result<String>` and validates every seed entity ID against `[a-zA-Z0-9_-]` before interpolation. Invalid IDs produce `Error::InvalidEntityId`.
- **EntityId newtype** — `Entity.id`, `Relationship.src/.dst` changed from bare `String` to `EntityId`. Implements `From`, `Display`, `Deref`, serde-transparent. Zero-cost; all construction sites updated.
- **Unicode NFC normalization** — `unicode-normalization` promoted to always-on dep. `slugify` now NFC-normalises before lowercasing so composed/decomposed forms produce identical slugs.
- **jiff for time** — `now_iso8601` replaced with `jiff::Zoned::now().strftime(…)`. ~30 lines of manual epoch-day arithmetic + `epoch_days_to_ymd` removed.
- **Mutex `.lock().expect()` → snafu** — `FastEmbedProvider::embed` and `embed_batch` now propagate `EmbeddingError::LockPoisoned` instead of panicking on a poisoned lock.

## Test plan

- [x] 15 new unit tests covering every fix (lock poisoning, NFC slugs, jiff timestamps, EntityId serde, query injection rejection, QueryResult wrapping)
- [x] `cargo test -p aletheia-mneme` — 415 passed, 0 failed
- [x] `cargo clippy -p aletheia-mneme --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check -p aletheia-mneme` — clean
- [x] `cargo check -p aletheia` — downstream crate unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)