### PR TITLE
test(mneme): verify mneme-engine and sqlite feature coexistence

### DIFF
--- a/crates/mneme/src/knowledge_store.rs
+++ b/crates/mneme/src/knowledge_store.rs
@@ -1,13 +1,12 @@
 //! `CozoDB`-backed knowledge store implementation.
 //!
-//! This module is gated behind the `cozo` feature flag due to `sqlite3` link
-//! conflict with `rusqlite`. In the final binary, the session store will migrate
-//! from `rusqlite` to `CozoDB`'s embedded `SQLite` storage, resolving the conflict.
+//! This module requires the `mneme-engine` feature flag.
 //!
-//! Until then, this code compiles and tests only with:
-//! ```sh
-//! cargo test -p aletheia-mneme --no-default-features --features mneme-engine
-//! ```
+//! **Coexistence with `sqlite` feature:** No link conflict. The `mneme-engine`
+//! vendored CozoDB uses only mem/redb/rocksdb storage backends — the
+//! `storage-sqlite` backend was removed. `rusqlite` (used by the `sqlite`
+//! feature) compiles with `features = ["bundled"]`, keeping its symbols
+//! isolated. Both features may be enabled simultaneously.
 //!
 //! # Schema
 //!

--- a/crates/mneme/src/lib.rs
+++ b/crates/mneme/src/lib.rs
@@ -1,7 +1,7 @@
 //! aletheia-mneme — session store and memory engine
 //!
 //! Mneme (Μνήμη) — "memory." Manages sessions, messages, and usage tracking
-//! via embedded `SQLite` (`rusqlite`). Future: `CozoDB` for vectors + graph.
+//! via embedded `SQLite` (`rusqlite`) and the `CozoDB`-backed knowledge graph.
 //!
 //! Depends on `aletheia-koina` for types and errors.
 
@@ -76,4 +76,32 @@ mod assertions {
     use static_assertions::assert_impl_all;
 
     assert_impl_all!(SessionStore: Send);
+}
+
+/// Verify that `mneme-engine` and `sqlite` features coexist without `SQLite`
+/// link conflicts.
+///
+/// The engine's `storage-sqlite` backend was removed; its remaining backends
+/// (mem, redb, rocksdb) have no `SQLite` dependency. `rusqlite` compiles with
+/// `features = ["bundled"]`, so its symbols are isolated. Both features can
+/// be active in the same binary.
+#[cfg(all(test, feature = "sqlite", feature = "mneme-engine"))]
+mod coexistence_tests {
+    use crate::knowledge_store::KnowledgeStore;
+    use crate::store::SessionStore;
+
+    #[test]
+    fn engine_and_sqlite_session_store_coexist() {
+        // Open a KnowledgeStore using the mneme-engine (CozoDB, in-memory)
+        let ks = KnowledgeStore::open_mem()
+            .expect("KnowledgeStore::open_mem should succeed with mneme-engine feature");
+
+        // Open a SessionStore using rusqlite (in-memory)
+        let ss = SessionStore::open_in_memory()
+            .expect("SessionStore::open_in_memory should succeed with sqlite feature");
+
+        // Both instances are live in the same process — no link conflict.
+        drop(ks);
+        drop(ss);
+    }
 }


### PR DESCRIPTION
## Feature Flag Topology

`crates/mneme/Cargo.toml` features:

| Feature | Enables | Notes |
|---------|---------|-------|
| `sqlite` (default) | `rusqlite` (bundled), `jiff` | SessionStore — SQLite via rusqlite with bundled SQLite |
| `mneme-engine` | vendored CozoDB, `ndarray`, `rayon`, etc. | KnowledgeStore — Datalog engine, no SQLite storage backend |
| `storage-redb` | `redb` + `mneme-engine` | redb persistence for engine |
| `storage-new-rocksdb` | `rocksdb` + `mneme-engine` | RocksDB persistence for engine |
| `fastembed` (default) | fastembed | Local embedding inference |
| `graph-algo` (default) | — | Graph algorithms flag |

The binary crate (`crates/aletheia`) enables `mneme-engine` only via the `recall` and `migrate-qdrant` feature flags — not by default.

## Verification

```
cargo check -p aletheia-mneme --no-default-features --features "sqlite,mneme-engine"
# → Finished dev profile — no errors

cargo test -p aletheia-mneme --no-default-features --features "sqlite,mneme-engine"
# → 706 passed; 0 failed
```

## Finding: No Conflict

The PR #552 comment "no link conflict verified" is correct, for two independent reasons:

1. **CozoDB's SQLite storage was removed.** The engine's available backends are `mem`, `redb`, `rocksdb`, `temp` — no `sqlite` backend remains. `storage-sqlite` is documented as "removed" in the engine code.

2. **rusqlite uses `bundled` feature.** `rusqlite = { version = "0.38", features = ["bundled"] }` compiles its own copy of SQLite via `libsqlite3-sys`. Bundled mode statically links and does not use system `libsqlite3`, so even if another SQLite were present, there would be no symbol collision.

## Changes

- **`src/knowledge_store.rs`**: Updated stale module doc that referenced the obsolete `cozo` feature flag and warned of a link conflict that no longer exists.
- **`src/lib.rs`**: Added `coexistence_tests::engine_and_sqlite_session_store_coexist` test gated behind `cfg(all(test, feature = "sqlite", feature = "mneme-engine"))`. Instantiates both `KnowledgeStore` (engine) and `SessionStore` (sqlite) in the same process. Updated crate-level doc to reflect current dual-backend reality.

## Cutover Implication

**Safe to enable both features simultaneously in the production binary.** No mutual exclusivity gate is needed. When the production binary enables `recall` (which pulls in `mneme-engine` + `storage-redb`), it can coexist with the default `sqlite` feature used by `SessionStore`.

## Tests

- `cargo clippy --workspace --all-targets -- -D warnings` → zero warnings
- `cargo test -p aletheia-mneme --no-default-features --features "sqlite,mneme-engine"` → 706 passed
- `cargo test -p aletheia-integration-tests` → 7 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)