### PR TITLE
feat(hermeneus): programmatic tool calling and code execution

### DIFF
--- a/crates/hermeneus/src/anthropic/stream.rs
+++ b/crates/hermeneus/src/anthropic/stream.rs
@@ -82,6 +82,12 @@ enum BlockBuilder {
         tool_use_id: String,
         content: serde_json::Value,
     },
+    CodeExecutionResult {
+        code: String,
+        stdout: String,
+        stderr: String,
+        return_code: i32,
+    },
 }
 
 impl StreamAccumulator {
@@ -129,6 +135,7 @@ impl StreamAccumulator {
                     WireContentBlockStart::Thinking { .. } => "thinking",
                     WireContentBlockStart::ServerToolUse { .. } => "server_tool_use",
                     WireContentBlockStart::WebSearchToolResult { .. } => "web_search_tool_result",
+                    WireContentBlockStart::CodeExecutionResult { .. } => "code_execution_result",
                 };
                 on_event(StreamEvent::ContentBlockStart {
                     index,
@@ -157,6 +164,14 @@ impl StreamAccumulator {
                         BlockBuilder::WebSearchToolResult {
                             tool_use_id,
                             content: serde_json::Value::Null,
+                        }
+                    }
+                    WireContentBlockStart::CodeExecutionResult {} => {
+                        BlockBuilder::CodeExecutionResult {
+                            code: String::new(),
+                            stdout: String::new(),
+                            stderr: String::new(),
+                            return_code: 0,
                         }
                     }
                 };
@@ -281,6 +296,17 @@ impl StreamAccumulator {
                 } => ContentBlock::WebSearchToolResult {
                     tool_use_id,
                     content,
+                },
+                BlockBuilder::CodeExecutionResult {
+                    code,
+                    stdout,
+                    stderr,
+                    return_code,
+                } => ContentBlock::CodeExecutionResult {
+                    code,
+                    stdout,
+                    stderr,
+                    return_code,
                 },
             })
             .collect();

--- a/crates/hermeneus/src/anthropic/wire.rs
+++ b/crates/hermeneus/src/anthropic/wire.rs
@@ -66,6 +66,9 @@ pub(crate) struct WireTool<'a> {
     pub input_schema: &'a serde_json::Value,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cache_control: Option<CacheControl>,
+    /// When true, the model returns `tool_use` blocks without executing.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub disable_passthrough: Option<bool>,
 }
 
 #[derive(Debug, Serialize)]
@@ -151,6 +154,13 @@ pub(crate) enum WireContentBlock {
     WebSearchToolResult {
         tool_use_id: String,
         content: serde_json::Value,
+    },
+    #[serde(rename = "code_execution_result")]
+    CodeExecutionResult {
+        code: String,
+        stdout: String,
+        stderr: String,
+        return_code: i32,
     },
 }
 
@@ -256,6 +266,7 @@ impl<'a> WireRequest<'a> {
                     description: &t.description,
                     input_schema: &t.input_schema,
                     cache_control,
+                    disable_passthrough: t.disable_passthrough,
                 })
             })
             .collect();
@@ -348,6 +359,17 @@ impl WireContentBlock {
             } => ContentBlock::WebSearchToolResult {
                 tool_use_id,
                 content,
+            },
+            Self::CodeExecutionResult {
+                code,
+                stdout,
+                stderr,
+                return_code,
+            } => ContentBlock::CodeExecutionResult {
+                code,
+                stdout,
+                stderr,
+                return_code,
             },
         }
     }
@@ -481,6 +503,8 @@ pub(crate) enum WireContentBlockStart {
     ServerToolUse { id: String, name: String },
     #[serde(rename = "web_search_tool_result")]
     WebSearchToolResult { tool_use_id: String },
+    #[serde(rename = "code_execution_result")]
+    CodeExecutionResult {},
 }
 
 #[derive(Debug, Deserialize)]
@@ -694,6 +718,7 @@ mod tests {
                     },
                     "required": ["command"]
                 }),
+                disable_passthrough: None,
             }],
             temperature: None,
             thinking: None,
@@ -786,11 +811,13 @@ mod tests {
                     name: "a".to_owned(),
                     description: "first".to_owned(),
                     input_schema: serde_json::json!({}),
+                    disable_passthrough: None,
                 },
                 ToolDefinition {
                     name: "b".to_owned(),
                     description: "second".to_owned(),
                     input_schema: serde_json::json!({}),
+                    disable_passthrough: None,
                 },
             ],
             cache_tools: true,
@@ -954,6 +981,7 @@ mod tests {
                 name: "read".to_owned(),
                 description: "Read a file".to_owned(),
                 input_schema: serde_json::json!({"type": "object"}),
+                disable_passthrough: None,
             }],
             server_tools: vec![crate::types::ServerToolDefinition {
                 tool_type: "web_search_20250305".to_owned(),
@@ -1054,6 +1082,7 @@ mod tests {
                 name: "read".to_owned(),
                 description: "Read".to_owned(),
                 input_schema: serde_json::json!({}),
+                disable_passthrough: None,
             }],
             server_tools: vec![crate::types::ServerToolDefinition {
                 tool_type: "web_search_20250305".to_owned(),
@@ -1117,6 +1146,7 @@ mod tests {
             description: "Read a file",
             input_schema: &serde_json::json!({"type": "object"}),
             cache_control: None,
+            disable_passthrough: None,
         });
         let server_tool = WireToolEntry::ServerSide(WireServerTool {
             tool_type: "web_search_20250305",
@@ -1677,6 +1707,7 @@ mod tests {
                 name: "exec".to_owned(),
                 description: "run".to_owned(),
                 input_schema: serde_json::json!({}),
+                disable_passthrough: None,
             }],
             cache_system: true,
             cache_tools: true,
@@ -1695,5 +1726,75 @@ mod tests {
         assert_eq!(msgs[0]["content"][0]["cache_control"]["type"], "ephemeral");
         // Current turn is not cached
         assert!(msgs[2]["content"].is_string());
+    }
+
+    #[test]
+    fn wire_content_block_code_execution_result() {
+        let json = r#"{"type":"code_execution_result","code":"print(42)","stdout":"42\n","stderr":"","return_code":0}"#;
+        let block: WireContentBlock = serde_json::from_str(json).unwrap();
+        let converted = block.into_content_block();
+        match converted {
+            ContentBlock::CodeExecutionResult {
+                code,
+                stdout,
+                stderr,
+                return_code,
+            } => {
+                assert_eq!(code, "print(42)");
+                assert_eq!(stdout, "42\n");
+                assert!(stderr.is_empty());
+                assert_eq!(return_code, 0);
+            }
+            _ => panic!("expected CodeExecutionResult"),
+        }
+    }
+
+    #[test]
+    fn wire_request_disable_passthrough_serialized() {
+        let req = CompletionRequest {
+            model: "claude-opus-4-20250514".to_owned(),
+            messages: vec![Message {
+                role: Role::User,
+                content: Content::Text("hi".to_owned()),
+            }],
+            max_tokens: 1024,
+            tools: vec![ToolDefinition {
+                name: "exec".to_owned(),
+                description: "Execute".to_owned(),
+                input_schema: serde_json::json!({"type": "object"}),
+                disable_passthrough: Some(true),
+            }],
+            ..Default::default()
+        };
+        let wire = WireRequest::from_request(&req, None);
+        let json = serde_json::to_value(&wire).unwrap();
+        let tools = json["tools"].as_array().unwrap();
+        assert_eq!(tools[0]["disable_passthrough"], true);
+    }
+
+    #[test]
+    fn wire_request_disable_passthrough_none_omitted() {
+        let req = CompletionRequest {
+            model: "claude-opus-4-20250514".to_owned(),
+            messages: vec![Message {
+                role: Role::User,
+                content: Content::Text("hi".to_owned()),
+            }],
+            max_tokens: 1024,
+            tools: vec![ToolDefinition {
+                name: "exec".to_owned(),
+                description: "Execute".to_owned(),
+                input_schema: serde_json::json!({"type": "object"}),
+                disable_passthrough: None,
+            }],
+            ..Default::default()
+        };
+        let wire = WireRequest::from_request(&req, None);
+        let json = serde_json::to_value(&wire).unwrap();
+        let tools = json["tools"].as_array().unwrap();
+        assert!(
+            tools[0].get("disable_passthrough").is_none(),
+            "None should be omitted from wire format"
+        );
     }
 }

--- a/crates/hermeneus/src/types.rs
+++ b/crates/hermeneus/src/types.rs
@@ -131,6 +131,22 @@ pub enum ContentBlock {
         tool_use_id: String,
         content: serde_json::Value,
     },
+
+    /// Server-side code execution result.
+    ///
+    /// Returned by the `code_execution_20250522` server tool. No client `tool_result`
+    /// is needed — the server executed the code and returns stdout, stderr, and return code.
+    #[serde(rename = "code_execution_result")]
+    CodeExecutionResult {
+        /// The Python code that was executed.
+        code: String,
+        /// Standard output from execution.
+        stdout: String,
+        /// Standard error from execution.
+        stderr: String,
+        /// Process return code (0 = success).
+        return_code: i32,
+    },
 }
 
 /// Tool result content — simple text or rich content blocks.
@@ -251,6 +267,11 @@ pub struct ToolDefinition {
     pub description: String,
     /// JSON Schema for the input parameters.
     pub input_schema: serde_json::Value,
+    /// When true, the model returns `tool_use` blocks but does not execute them.
+    /// The client must execute the tool and return a `tool_result`.
+    /// This prevents the model from calling the tool via server-side passthrough.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub disable_passthrough: Option<bool>,
 }
 
 /// Cache control directive for prompt caching.
@@ -919,5 +940,96 @@ mod tests {
         assert!(!req.cache_system);
         assert!(!req.cache_tools);
         assert!(!req.cache_turns);
+    }
+
+    #[test]
+    fn code_execution_result_block_serde() {
+        let block = ContentBlock::CodeExecutionResult {
+            code: "print('hello')".to_owned(),
+            stdout: "hello\n".to_owned(),
+            stderr: String::new(),
+            return_code: 0,
+        };
+        let json = serde_json::to_string(&block).unwrap();
+        assert!(json.contains("code_execution_result"));
+        assert!(json.contains("print('hello')"));
+        let back: ContentBlock = serde_json::from_str(&json).unwrap();
+        match back {
+            ContentBlock::CodeExecutionResult {
+                code,
+                stdout,
+                stderr,
+                return_code,
+            } => {
+                assert_eq!(code, "print('hello')");
+                assert_eq!(stdout, "hello\n");
+                assert!(stderr.is_empty());
+                assert_eq!(return_code, 0);
+            }
+            _ => panic!("expected CodeExecutionResult"),
+        }
+    }
+
+    #[test]
+    fn code_execution_result_nonzero_return_code() {
+        let json = r#"{"type":"code_execution_result","code":"exit(1)","stdout":"","stderr":"error","return_code":1}"#;
+        let block: ContentBlock = serde_json::from_str(json).unwrap();
+        match block {
+            ContentBlock::CodeExecutionResult {
+                return_code,
+                stderr,
+                ..
+            } => {
+                assert_eq!(return_code, 1);
+                assert_eq!(stderr, "error");
+            }
+            _ => panic!("expected CodeExecutionResult"),
+        }
+    }
+
+    #[test]
+    fn tool_definition_disable_passthrough_serde() {
+        let def = ToolDefinition {
+            name: "exec".to_owned(),
+            description: "Execute".to_owned(),
+            input_schema: serde_json::json!({"type": "object"}),
+            disable_passthrough: Some(true),
+        };
+        let json = serde_json::to_string(&def).unwrap();
+        assert!(json.contains("\"disable_passthrough\":true"));
+        let back: ToolDefinition = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.disable_passthrough, Some(true));
+    }
+
+    #[test]
+    fn tool_definition_disable_passthrough_none_omitted() {
+        let def = ToolDefinition {
+            name: "exec".to_owned(),
+            description: "Execute".to_owned(),
+            input_schema: serde_json::json!({"type": "object"}),
+            disable_passthrough: None,
+        };
+        let json = serde_json::to_string(&def).unwrap();
+        assert!(
+            !json.contains("disable_passthrough"),
+            "None should be omitted"
+        );
+    }
+
+    #[test]
+    fn code_execution_server_tool_definition_serde() {
+        let def = ServerToolDefinition {
+            tool_type: "code_execution_20250522".to_owned(),
+            name: "code_execution".to_owned(),
+            max_uses: None,
+            allowed_domains: None,
+            blocked_domains: None,
+            user_location: None,
+        };
+        let json = serde_json::to_string(&def).unwrap();
+        assert!(json.contains("code_execution_20250522"));
+        let back: ServerToolDefinition = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.tool_type, "code_execution_20250522");
+        assert_eq!(back.name, "code_execution");
     }
 }

--- a/crates/nous/src/execute.rs
+++ b/crates/nous/src/execute.rs
@@ -38,20 +38,23 @@ fn classify_signals(
     tool_calls: &[ToolCall],
     _content: &str,
     used_server_web_search: bool,
+    used_server_code_execution: bool,
 ) -> Vec<InteractionSignal> {
     let mut signals = Vec::new();
+    let used_any_server_tool = used_server_web_search || used_server_code_execution;
 
-    if tool_calls.is_empty() && !used_server_web_search {
+    if tool_calls.is_empty() && !used_any_server_tool {
         signals.push(InteractionSignal::Conversation);
     } else {
-        if !tool_calls.is_empty() {
+        if !tool_calls.is_empty() || used_any_server_tool {
             signals.push(InteractionSignal::ToolExecution);
         }
 
         let code_tools = ["write", "edit", "exec"];
-        if tool_calls
-            .iter()
-            .any(|tc| code_tools.contains(&tc.name.as_str()))
+        if used_server_code_execution
+            || tool_calls
+                .iter()
+                .any(|tc| code_tools.contains(&tc.name.as_str()))
         {
             signals.push(InteractionSignal::CodeGeneration);
         }
@@ -210,6 +213,7 @@ pub async fn execute(
     let mut final_content = String::new();
     let mut final_stop_reason = String::new();
     let mut used_server_web_search = false;
+    let mut used_server_code_execution = false;
 
     let thinking = if config.thinking_enabled {
         Some(ThinkingConfig {
@@ -294,6 +298,18 @@ pub async fn execute(
                 ContentBlock::ServerToolUse { name, .. } if name == "web_search" => {
                     used_server_web_search = true;
                 }
+                ContentBlock::ServerToolUse { name, .. } if name == "code_execution" => {
+                    used_server_code_execution = true;
+                }
+                ContentBlock::CodeExecutionResult {
+                    code, return_code, ..
+                } => {
+                    used_server_code_execution = true;
+                    debug!(
+                        code_len = code.len(),
+                        return_code, "server code execution result received"
+                    );
+                }
                 _ => {}
             }
         }
@@ -301,6 +317,8 @@ pub async fn execute(
         final_content = text_parts.join("");
         final_stop_reason = response.stop_reason.to_string();
 
+        // Only break if there are no LOCAL tool uses to dispatch.
+        // Server tool results (web search, code execution) do not require client tool_result.
         if tool_uses.is_empty() || response.stop_reason != StopReason::ToolUse {
             break;
         }
@@ -334,7 +352,12 @@ pub async fn execute(
         "execute stage complete"
     );
 
-    let signals = classify_signals(&all_tool_calls, &final_content, used_server_web_search);
+    let signals = classify_signals(
+        &all_tool_calls,
+        &final_content,
+        used_server_web_search,
+        used_server_code_execution,
+    );
 
     Ok(TurnResult {
         content: final_content,
@@ -489,6 +512,7 @@ pub async fn execute_streaming(
     let mut final_content = String::new();
     let mut final_stop_reason = String::new();
     let mut used_server_web_search = false;
+    let mut used_server_code_execution = false;
 
     let thinking = if config.thinking_enabled {
         Some(ThinkingConfig {
@@ -574,6 +598,18 @@ pub async fn execute_streaming(
                 ContentBlock::ServerToolUse { name, .. } if name == "web_search" => {
                     used_server_web_search = true;
                 }
+                ContentBlock::ServerToolUse { name, .. } if name == "code_execution" => {
+                    used_server_code_execution = true;
+                }
+                ContentBlock::CodeExecutionResult {
+                    code, return_code, ..
+                } => {
+                    used_server_code_execution = true;
+                    debug!(
+                        code_len = code.len(),
+                        return_code, "server code execution result received"
+                    );
+                }
                 _ => {}
             }
         }
@@ -615,7 +651,12 @@ pub async fn execute_streaming(
         "streaming execute stage complete"
     );
 
-    let signals = classify_signals(&all_tool_calls, &final_content, used_server_web_search);
+    let signals = classify_signals(
+        &all_tool_calls,
+        &final_content,
+        used_server_web_search,
+        used_server_code_execution,
+    );
 
     Ok(TurnResult {
         content: final_content,
@@ -1000,7 +1041,7 @@ mod tests {
 
     #[test]
     fn signal_classification_conversation() {
-        let signals = classify_signals(&[], "Hello", false);
+        let signals = classify_signals(&[], "Hello", false, false);
         assert_eq!(signals, vec![InteractionSignal::Conversation]);
     }
 
@@ -1014,7 +1055,7 @@ mod tests {
             is_error: false,
             duration_ms: 10,
         }];
-        let signals = classify_signals(&calls, "", false);
+        let signals = classify_signals(&calls, "", false, false);
         assert!(signals.contains(&InteractionSignal::ToolExecution));
         assert!(signals.contains(&InteractionSignal::CodeGeneration));
     }
@@ -1029,7 +1070,7 @@ mod tests {
             is_error: false,
             duration_ms: 10,
         }];
-        let signals = classify_signals(&calls, "", false);
+        let signals = classify_signals(&calls, "", false, false);
         assert!(signals.contains(&InteractionSignal::ToolExecution));
         assert!(signals.contains(&InteractionSignal::Research));
     }
@@ -1044,7 +1085,7 @@ mod tests {
             is_error: true,
             duration_ms: 10,
         }];
-        let signals = classify_signals(&calls, "", false);
+        let signals = classify_signals(&calls, "", false, false);
         assert!(signals.contains(&InteractionSignal::ToolExecution));
         assert!(signals.contains(&InteractionSignal::ErrorRecovery));
     }
@@ -1160,7 +1201,7 @@ mod tests {
 
     #[test]
     fn classify_signals_conversation_when_no_tools() {
-        let signals = classify_signals(&[], "some text", false);
+        let signals = classify_signals(&[], "some text", false, false);
         assert_eq!(signals, vec![InteractionSignal::Conversation]);
     }
 
@@ -1174,7 +1215,7 @@ mod tests {
             is_error: true,
             duration_ms: 5,
         }];
-        let signals = classify_signals(&calls, "", false);
+        let signals = classify_signals(&calls, "", false, false);
         assert!(
             signals.contains(&InteractionSignal::ToolExecution),
             "should have ToolExecution"
@@ -1187,7 +1228,7 @@ mod tests {
 
     #[test]
     fn classify_signals_server_web_search() {
-        let signals = classify_signals(&[], "", true);
+        let signals = classify_signals(&[], "", true, false);
         assert!(
             signals.contains(&InteractionSignal::Research),
             "should have Research from server web search"
@@ -1196,6 +1237,32 @@ mod tests {
             !signals.contains(&InteractionSignal::Conversation),
             "should not be Conversation when server web search was used"
         );
+    }
+
+    #[test]
+    fn classify_signals_server_code_execution() {
+        let signals = classify_signals(&[], "", false, true);
+        assert!(
+            signals.contains(&InteractionSignal::ToolExecution),
+            "should have ToolExecution from server code execution"
+        );
+        assert!(
+            signals.contains(&InteractionSignal::CodeGeneration),
+            "should have CodeGeneration from server code execution"
+        );
+        assert!(
+            !signals.contains(&InteractionSignal::Conversation),
+            "should not be Conversation when server code execution was used"
+        );
+    }
+
+    #[test]
+    fn classify_signals_both_server_tools() {
+        let signals = classify_signals(&[], "", true, true);
+        assert!(signals.contains(&InteractionSignal::ToolExecution));
+        assert!(signals.contains(&InteractionSignal::Research));
+        assert!(signals.contains(&InteractionSignal::CodeGeneration));
+        assert!(!signals.contains(&InteractionSignal::Conversation));
     }
 
     // --- Streaming Tests ---
@@ -1393,7 +1460,7 @@ mod tests {
             is_error: false,
             duration_ms: 10,
         }];
-        let signals = classify_signals(&calls, "", false);
+        let signals = classify_signals(&calls, "", false, false);
         assert!(signals.contains(&InteractionSignal::CodeGeneration));
     }
 
@@ -1407,7 +1474,7 @@ mod tests {
             is_error: false,
             duration_ms: 10,
         }];
-        let signals = classify_signals(&calls, "", false);
+        let signals = classify_signals(&calls, "", false, false);
         assert!(signals.contains(&InteractionSignal::Research));
     }
 
@@ -1431,7 +1498,7 @@ mod tests {
                 duration_ms: 5,
             },
         ];
-        let signals = classify_signals(&calls, "", false);
+        let signals = classify_signals(&calls, "", false, false);
         assert!(signals.contains(&InteractionSignal::ToolExecution));
         assert!(signals.contains(&InteractionSignal::CodeGeneration));
         assert!(signals.contains(&InteractionSignal::Research));

--- a/crates/organon/src/registry.rs
+++ b/crates/organon/src/registry.rs
@@ -129,6 +129,7 @@ impl ToolRegistry {
                 name: t.def.name.as_str().to_owned(),
                 description: t.def.description.clone(),
                 input_schema: t.def.input_schema.to_json_schema(),
+                disable_passthrough: None,
             })
             .collect()
     }
@@ -154,6 +155,7 @@ impl ToolRegistry {
                 name: t.def.name.as_str().to_owned(),
                 description: t.def.description.clone(),
                 input_schema: t.def.input_schema.to_json_schema(),
+                disable_passthrough: None,
             })
             .collect()
     }


### PR DESCRIPTION
## Summary

- Add `ContentBlock::CodeExecutionResult` for parsing Anthropic's `code_execution_20250522` server-side tool results (code, stdout, stderr, return_code)
- Add `disable_passthrough` field on `ToolDefinition` for programmatic tool calling — prevents model from executing tools server-side, returning structured `tool_use` blocks for client execution instead
- Wire code execution results into the pipeline: no client `tool_result` needed (server-side execution complete), classified as `ToolExecution` + `CodeGeneration` signals
- Streaming support via `BlockBuilder::CodeExecutionResult` and `WireContentBlockStart::CodeExecutionResult`
- Configuration toggle via existing `ServerToolConfig.code_execution` (opt-in, default off)

## Test plan

- [x] `ContentBlock::CodeExecutionResult` serde roundtrip (success + nonzero return code)
- [x] `ToolDefinition.disable_passthrough` serialization (Some(true) included, None omitted)
- [x] `ServerToolDefinition` for code_execution_20250522 serde
- [x] `WireContentBlock::CodeExecutionResult` wire deserialization + conversion
- [x] `WireRequest` serializes `disable_passthrough` on tool definitions
- [x] `WireRequest` omits `disable_passthrough` when None
- [x] `classify_signals` recognizes server code execution as ToolExecution + CodeGeneration
- [x] `classify_signals` handles both server tools simultaneously
- [x] All 523 existing tests pass (hermeneus: 240, nous: 283)
- [x] Clippy clean on hermeneus, organon, nous

🤖 Generated with [Claude Code](https://claude.com/claude-code)