### PR TITLE
chore: mneme QA checkpoint — Phases A through E

### DIFF
--- a/crates/mneme/src/backup.rs
+++ b/crates/mneme/src/backup.rs
@@ -83,11 +83,11 @@ impl<'a> BackupManager<'a> {
     ///
     /// `VACUUM INTO` does not support parameter binding for the target path.
     /// The path is interpolated via `format!` into the SQL string. The sole
-    /// defense against path injection is [`validate_backup_path`], which
+    /// defense against path injection is `validate_backup_path`, which
     /// rejects any path containing characters outside the safe set
     /// (alphanumeric, `-`, `_`, `.`, `/`, `\`, space) and blocks `--` comment
     /// sequences. Any future changes to path construction MUST go through
-    /// `validate_backup_path`.
+    /// `validate_backup_path` (a private helper in this module).
     #[instrument(skip(self))]
     pub fn create_backup(&self) -> Result<BackupResult> {
         std::fs::create_dir_all(&self.backup_dir).context(error::IoSnafu {

--- a/crates/mneme/src/embedding.rs
+++ b/crates/mneme/src/embedding.rs
@@ -167,7 +167,7 @@ mod candle_provider {
         ///
         /// # Errors
         ///
-        /// Returns [`EmbeddingError::InitFailed`] if model download or initialization fails.
+        /// Returns `EmbeddingError::InitFailed` if model download or initialization fails.
         #[instrument]
         pub fn new(model_repo: Option<&str>) -> EmbeddingResult<Self> {
             let repo_id = model_repo.unwrap_or(Self::DEFAULT_REPO);

--- a/crates/mneme/src/import.rs
+++ b/crates/mneme/src/import.rs
@@ -1111,6 +1111,102 @@ mod tests {
         assert_eq!(result.messages_imported, 2);
     }
 
+    #[test]
+    fn import_multiple_sessions_counts_correctly() {
+        let store = test_store();
+        let dir = tempfile::tempdir().unwrap();
+        let mut agent = minimal_agent_file();
+        // Add a second session
+        agent.sessions.push(ExportedSession {
+            id: "ses-2".to_owned(),
+            session_key: "secondary".to_owned(),
+            status: "active".to_owned(),
+            session_type: "primary".to_owned(),
+            message_count: 1,
+            token_count_estimate: 50,
+            distillation_count: 0,
+            created_at: "2026-03-05T12:00:00Z".to_owned(),
+            updated_at: "2026-03-05T12:00:00Z".to_owned(),
+            working_state: None,
+            distillation_priming: None,
+            notes: vec![],
+            messages: vec![ExportedMessage {
+                role: "user".to_owned(),
+                content: "second session".to_owned(),
+                seq: 1,
+                token_estimate: 50,
+                is_distilled: false,
+                created_at: "2026-03-05T12:00:00Z".to_owned(),
+            }],
+        });
+
+        let id_gen = counter_id_gen();
+        let result = import_agent(&agent, &store, dir.path(), &*id_gen, &ImportOptions::default())
+            .unwrap();
+
+        assert_eq!(result.sessions_imported, 2);
+        assert_eq!(result.messages_imported, 3);
+    }
+
+    #[test]
+    fn import_notes_counted_in_result() {
+        let store = test_store();
+        let dir = tempfile::tempdir().unwrap();
+        let agent = minimal_agent_file();
+
+        let id_gen = counter_id_gen();
+        let result = import_agent(&agent, &store, dir.path(), &*id_gen, &ImportOptions::default())
+            .unwrap();
+
+        // minimal_agent_file has 1 note
+        assert_eq!(result.notes_imported, 1);
+    }
+
+    #[test]
+    fn validate_relative_path_rejects_windows_drive() {
+        assert!(!validate_relative_path("C:\\windows\\system32"));
+        assert!(!validate_relative_path("D:file.txt"));
+    }
+
+    #[test]
+    fn validate_relative_path_rejects_protocol() {
+        assert!(!validate_relative_path("file:///etc/passwd"));
+        assert!(!validate_relative_path("https://evil.com/payload"));
+    }
+
+    #[test]
+    fn validate_relative_path_accepts_nested_dirs() {
+        assert!(validate_relative_path("a/b/c/d.txt"));
+        assert!(validate_relative_path("memory/2026-03-09.md"));
+        assert!(validate_relative_path("SOUL.md"));
+    }
+
+    #[test]
+    fn import_skip_both_flags_imports_nothing_from_disk_or_sessions() {
+        let store = test_store();
+        let dir = tempfile::tempdir().unwrap();
+        let agent = minimal_agent_file();
+
+        let id_gen = counter_id_gen();
+        let result = import_agent(
+            &agent,
+            &store,
+            dir.path(),
+            &*id_gen,
+            &ImportOptions {
+                skip_sessions: true,
+                skip_workspace: true,
+                ..ImportOptions::default()
+            },
+        )
+        .unwrap();
+
+        assert_eq!(result.files_restored, 0);
+        assert_eq!(result.sessions_imported, 0);
+        assert_eq!(result.messages_imported, 0);
+        assert_eq!(result.notes_imported, 0);
+    }
+
     mod proptests {
         use super::*;
         use proptest::prelude::*;

--- a/crates/mneme/src/knowledge_store.rs
+++ b/crates/mneme/src/knowledge_store.rs
@@ -3,10 +3,10 @@
 //! This module requires the `mneme-engine` feature flag.
 //!
 //! **Coexistence with `sqlite` feature:** No link conflict. The `mneme-engine`
-//! vendored CozoDB uses only mem/redb/rocksdb storage backends — the
-//! `storage-sqlite` backend was removed. `rusqlite` (used by the `sqlite`
-//! feature) compiles with `features = ["bundled"]`, keeping its symbols
-//! isolated. Both features may be enabled simultaneously.
+//! vendored CozoDB uses only mem/redb/fjall storage backends — no C++
+//! dependencies. `rusqlite` (used by the `sqlite` feature) compiles with
+//! `features = ["bundled"]`, keeping its symbols isolated. Both features may
+//! be enabled simultaneously.
 //!
 //! # Schema
 //!

--- a/crates/mneme/src/lib.rs
+++ b/crates/mneme/src/lib.rs
@@ -86,7 +86,7 @@ mod assertions {
 /// link conflicts.
 ///
 /// The engine's `storage-sqlite` backend was removed; its remaining backends
-/// (mem, redb, rocksdb) have no `SQLite` dependency. `rusqlite` compiles with
+/// (mem, redb, fjall) have no `SQLite` dependency. `rusqlite` compiles with
 /// `features = ["bundled"]`, so its symbols are isolated. Both features can
 /// be active in the same binary.
 #[cfg(all(test, feature = "sqlite", feature = "mneme-engine"))]

--- a/crates/mneme/src/skill.rs
+++ b/crates/mneme/src/skill.rs
@@ -3,7 +3,7 @@
 //! Skills are facts with `fact_type = "skill"`. This module provides:
 //! - Structured content type for skill JSON
 //! - Parser for SKILL.md markdown files
-//! - Query helpers on [`KnowledgeStore`]
+//! - Query helpers on `KnowledgeStore`
 
 use serde::{Deserialize, Serialize};
 

--- a/docs/TECHNOLOGY.md
+++ b/docs/TECHNOLOGY.md
@@ -16,7 +16,7 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) for module boundaries, [PROJECT.md](PROJE
 | HTTP client | reqwest | node-fetch | Async, connection pooling, Anthropic + channel calls |
 | Anthropic API | Own client (~600 LOC) | @anthropic-ai/sdk | Stable API, reqwest + SSE, adaptive thinking, Tool Search Tool |
 | Unified store | Vendored Datalog engine (from CozoDB) | Qdrant + Neo4j | Rust-native embedded, Datalog, HNSW vectors + graph + relations in one DB. Zero external services. Vendored into `mneme/src/engine/`, gated behind `mneme-engine` feature. |
-| Embeddings | fastembed-rs + `EmbeddingProvider` trait | Python fastembed | Default: local ONNX (BAAI/bge-small-en-v1.5, 384 dims). Per-instance config. |
+| Embeddings | candle + `EmbeddingProvider` trait | fastembed-rs (ONNX) | Pure Rust, no C++ deps. Default: BAAI/bge-small-en-v1.5 (384 dims). Feature-gated behind `embed-candle`. |
 | Memory | Direct (no abstraction) | KnowledgeStore (embedded CozoDB) | ~50 LOC replaces the library |
 | Sessions | rusqlite + bundled | better-sqlite3 | WAL mode, no native addon |
 | Encryption | XChaCha20Poly1305 | None (plaintext) | Per-message encryption at rest, ~700ns overhead, zero plaintext on disk |
@@ -55,7 +55,7 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) for module boundaries, [PROJECT.md](PROJE
 - **Unstable crates** (pre-1.0, aggressive releases): pin exact version. Wrap in trait.
   - `wasmtime` - monthly major versions. Pin exact.
   - `rmcp` - 5 minor releases in 6 weeks. Pin exact. `McpProvider` trait.
-  - `fastembed` - active development. Pin minor.
+  - `candle-*` - pinned exact (`=0.9.2`). Pure Rust, no C++ deps.
   - `chromiumoxide` - niche. Pin exact.
 - **Stable crates** (1.0+): pin minor (`"1.49"` not `"=1.49.0"`).
 - **Never vendor** unless forced by platform issues. Cargo.lock suffices.
@@ -68,7 +68,7 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) for module boundaries, [PROJECT.md](PROJE
 
 ### Cross-Compilation Notes
 
-- `fastembed` (ONNX): may need special builds for aarch64. Feature-gate behind `fastembed`.
+- `candle`: pure Rust, cross-compiles cleanly. Feature-gated behind `embed-candle`.
 - `sonic-rs` (SIMD): aarch64 NEON supported but verify. Fallback to `serde_json` via feature flag.
 - `chromiumoxide`: requires Chromium on host. Feature-gate behind `browser`.
 - `extrasafe` (seccomp): Linux-only. Feature-gate behind `sandbox-seccomp`.
@@ -81,7 +81,7 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) for module boundaries, [PROJECT.md](PROJE
 |-------|-----------------|
 | **koina** | snafu, tracing, tracing-subscriber, miette |
 | **taxis** | koina, figment, serde, serde_json, snafu, tracing |
-| **mneme** | koina, snafu, serde, tracing, ulid, rusqlite (sqlite), fastembed (fastembed), jiff, ndarray |
+| **mneme** | koina, snafu, serde, tracing, ulid, rusqlite (sqlite), candle-core/nn/transformers (embed-candle), jiff, hnsw_rs, fjall |
 | **hermeneus** | koina, taxis, reqwest, reqwest-eventsource, sonic-rs, tokio, secrecy |
 | **organon** | koina, taxis, hermeneus, tokio, gix, extrasafe, chromiumoxide |
 | **nous** | koina, taxis, mneme, hermeneus, organon, melete, tokio, ulid, compact_str |


### PR DESCRIPTION
## Mneme QA Checkpoint Results — Phases A-E

### Gate Results
| Gate | Status | Evidence |
|------|--------|----------|
| Compilation | ✅ | `cargo check`, `cargo clippy -D warnings`, `cargo check --workspace` — all zero warnings |
| Tests | ✅ | 498 native + 2 ts_compat + 75 integration = 575 total, 0 failures, 0 ignored (target: 400+) |
| Phase A Stabilization | ✅ | 4 facade methods present, 80 `#[instrument]` annotations, zero `unwrap()` in production code |
| Phase B Test Coverage | ✅ | All modules at or above targets (knowledge_store: 87/60, recall: 60/55, extract: 47/40, store: 49/35, query: 36/30, import: 30/30, backup: 45/25, embedding: 33/28, export: 20/20, retention: 22/20). 7 proptest suites. |
| Phase C Type Safety | ✅ | FactId, EntityId, EmbeddingId newtypes in `id.rs`. jiff::Timestamp on all temporal fields. Validation: empty content rejected, confidence \[0.0, 1.0\] enforced, empty entity names rejected. |
| Phase D Capabilities | ✅ | QueryRewriter + TieredSearch (fast→enhanced→graph-enhanced). `query_facts_temporal`, `query_facts_diff`. `datalog_query` tool registered in organon. `KnowledgeExport` in AgentFile export. |
| Phase E Transformation | ✅ | fjall StoreTx backend (6 tests). hnsw_rs index (6 tests). RocksDB completely removed. Zero C++ deps — candle replaces fastembed. smartstring→compact_str complete (0 remnants). FTS stop words: 21,885 lines across 10+ languages. |
| Documentation | ✅ | 3 doc warnings fixed: broken link to private `validate_backup_path`, unresolvable `EmbeddingError::InitFailed`, feature-gated `KnowledgeStore` link. Zero warnings after fix. |
| Ground Truth | ✅ | All items from ground truth report resolved. TECHNOLOGY.md updated: fastembed→candle, rocksdb→fjall, dep table corrected. Stale doc comments in knowledge_store.rs and lib.rs updated. |

### Issues Found & Fixed
- 3 rustdoc warnings (broken intra-doc links to private/feature-gated items)
- TECHNOLOGY.md still referenced fastembed-rs and rocksdb — updated to candle and fjall
- Doc comments in `knowledge_store.rs` and `lib.rs` referenced rocksdb as storage backend — updated to fjall
- `import.rs` was 6 tests short of target (24/30) — added 6 tests: multi-session counts, notes counting, path validation edge cases (Windows drives, protocols, nested dirs), skip-both-flags

### Remaining Gaps
- **RelationshipId newtype**: Prompt expected it but relationships are CozoDB relation edges keyed by `(src: EntityId, dst: EntityId)` — no standalone ID needed. Architecture is correct.
- **TECHNOLOGY.md "Correct TECHNOLOGY.md" from Phase A**: Now done in this PR.