### PR TITLE
feat(nous): skill auto-capture LLM extraction and pipeline wiring

### DIFF
--- a/crates/aletheia/src/main.rs
+++ b/crates/aletheia/src/main.rs
@@ -257,6 +257,18 @@ enum Command {
         #[arg(short, long)]
         domain: Option<String>,
     },
+    /// Review pending auto-extracted skills (approve, reject, or list)
+    ReviewSkills {
+        /// Agent (nous) ID whose pending skills to review
+        #[arg(short, long)]
+        nous_id: String,
+        /// Action: list, approve, reject
+        #[arg(short, long, default_value = "list")]
+        action: String,
+        /// Fact ID of the pending skill (required for approve/reject)
+        #[arg(short, long)]
+        fact_id: Option<String>,
+    },
     /// Generate shell completions for bash, zsh, or fish
     Completions {
         /// Shell to generate completions for
@@ -403,6 +415,13 @@ async fn main() -> Result<()> {
             domain,
         }) => {
             return export_skills_cmd(&cli, nous_id, output, domain.as_deref());
+        }
+        Some(Command::ReviewSkills {
+            nous_id,
+            action,
+            fact_id,
+        }) => {
+            return review_skills_cmd(&cli, nous_id, action, fact_id.as_deref());
         }
         Some(Command::Completions { shell }) => {
             let mut cmd = Cli::command();
@@ -1886,6 +1905,100 @@ fn export_skills_cmd(cli: &Cli, nous_id: &str, output: &Path, domain: Option<&st
         let _ = (cli, nous_id, output, domain);
         anyhow::bail!(
             "export-skills requires the 'recall' feature (KnowledgeStore). \
+             Build with: cargo build --features recall"
+        );
+    }
+}
+
+fn review_skills_cmd(cli: &Cli, nous_id: &str, action: &str, fact_id: Option<&str>) -> Result<()> {
+    #[cfg(feature = "recall")]
+    {
+        use aletheia_mneme::knowledge_store::KnowledgeStore;
+        use aletheia_mneme::skills::extract::PendingSkill;
+
+        let oikos = match &cli.instance_root {
+            Some(root) => Oikos::from_root(root),
+            None => Oikos::discover(),
+        };
+        let knowledge_path = oikos.knowledge_db();
+
+        let config = aletheia_mneme::knowledge_store::KnowledgeConfig::default();
+        let store = KnowledgeStore::open_redb(&knowledge_path, config).map_err(|e| {
+            anyhow::anyhow!(
+                "failed to open knowledge store at {}: {e}",
+                knowledge_path.display()
+            )
+        })?;
+
+        match action {
+            "list" => {
+                let pending = store
+                    .find_pending_skills(nous_id)
+                    .map_err(|e| anyhow::anyhow!("failed to query pending skills: {e}"))?;
+
+                if pending.is_empty() {
+                    println!("No pending skills for nous '{nous_id}'");
+                    return Ok(());
+                }
+
+                println!(
+                    "Found {} pending skill(s) for nous '{nous_id}':\n",
+                    pending.len()
+                );
+                for fact in &pending {
+                    match PendingSkill::from_json(&fact.content) {
+                        Ok(ps) => {
+                            println!("  ID: {}", fact.id);
+                            println!("  Name: {}", ps.skill.name);
+                            println!(
+                                "  Description: {}",
+                                ps.skill.description.lines().next().unwrap_or("")
+                            );
+                            println!("  Tools: {}", ps.skill.tools_used.join(", "));
+                            println!("  Tags: {}", ps.skill.domain_tags.join(", "));
+                            println!("  Steps: {}", ps.skill.steps.len());
+                            println!("  Status: {}", ps.status);
+                            println!("  Candidate: {}", ps.candidate_id);
+                            println!("  Extracted: {}", ps.extracted_at);
+                            println!();
+                        }
+                        Err(e) => {
+                            eprintln!("  SKIP {}: failed to parse: {e}", fact.id);
+                        }
+                    }
+                }
+            }
+            "approve" => {
+                let fid = fact_id
+                    .ok_or_else(|| anyhow::anyhow!("--fact-id required for approve action"))?;
+                let fact_id = aletheia_mneme::id::FactId::from(fid);
+                let new_id = store
+                    .approve_pending_skill(&fact_id, nous_id)
+                    .map_err(|e| anyhow::anyhow!("failed to approve skill: {e}"))?;
+                println!("Approved: {fid} → new skill fact: {new_id}");
+            }
+            "reject" => {
+                let fid = fact_id
+                    .ok_or_else(|| anyhow::anyhow!("--fact-id required for reject action"))?;
+                let fact_id = aletheia_mneme::id::FactId::from(fid);
+                store
+                    .reject_pending_skill(&fact_id)
+                    .map_err(|e| anyhow::anyhow!("failed to reject skill: {e}"))?;
+                println!("Rejected: {fid}");
+            }
+            other => {
+                anyhow::bail!("unknown action '{other}'. Use: list, approve, reject");
+            }
+        }
+
+        Ok(())
+    }
+
+    #[cfg(not(feature = "recall"))]
+    {
+        let _ = (cli, nous_id, action, fact_id);
+        anyhow::bail!(
+            "review-skills requires the 'recall' feature (KnowledgeStore). \
              Build with: cargo build --features recall"
         );
     }

--- a/crates/mneme/src/knowledge_store.rs
+++ b/crates/mneme/src/knowledge_store.rs
@@ -798,6 +798,155 @@ impl KnowledgeStore {
         Ok(None)
     }
 
+    /// Find all pending-review skills for a specific nous.
+    ///
+    /// Pending skills are stored as facts with `fact_type = "skill_pending"`.
+    #[instrument(skip(self))]
+    pub fn find_pending_skills(
+        &self,
+        nous_id: &str,
+    ) -> crate::error::Result<Vec<crate::knowledge::Fact>> {
+        use crate::engine::DataValue;
+        use std::collections::BTreeMap;
+
+        let mut params = BTreeMap::new();
+        params.insert("nous_id".to_owned(), DataValue::Str(nous_id.into()));
+
+        let script = r"?[id, content, confidence, tier, recorded_at, nous_id,
+              valid_from, valid_to, superseded_by, source_session_id,
+              access_count, last_accessed_at, stability_hours, fact_type,
+              is_forgotten, forgotten_at, forget_reason] :=
+            *facts{id, valid_from, content, nous_id, confidence, tier, valid_to,
+                   superseded_by, source_session_id, recorded_at,
+                   access_count, last_accessed_at, stability_hours, fact_type,
+                   is_forgotten, forgotten_at, forget_reason},
+            nous_id = $nous_id,
+            fact_type = 'skill_pending',
+            is_null(superseded_by),
+            is_forgotten == false
+        :order -recorded_at";
+
+        let rows = self.run_read(script, params)?;
+        rows_to_facts(rows, nous_id)
+    }
+
+    /// Approve a pending skill — move it from `skill_pending` to `skill`.
+    ///
+    /// Supersedes the pending fact and creates a new fact with `fact_type = "skill"`.
+    /// Returns the new fact ID.
+    #[instrument(skip(self))]
+    pub fn approve_pending_skill(
+        &self,
+        pending_fact_id: &crate::id::FactId,
+        nous_id: &str,
+    ) -> crate::error::Result<crate::id::FactId> {
+        // Read the pending fact
+        let pending_facts = self.find_pending_skills(nous_id)?;
+        let pending = pending_facts
+            .iter()
+            .find(|f| f.id == *pending_fact_id)
+            .ok_or_else(|| {
+                crate::error::EngineQuerySnafu {
+                    message: format!("pending skill not found: {pending_fact_id}"),
+                }
+                .build()
+            })?;
+
+        // Parse the PendingSkill to get the inner SkillContent
+        let mut pending_skill =
+            crate::skills::PendingSkill::from_json(&pending.content).map_err(|e| {
+                crate::error::EngineQuerySnafu {
+                    message: format!("failed to parse pending skill: {e}"),
+                }
+                .build()
+            })?;
+        "approved".clone_into(&mut pending_skill.status);
+
+        // Create the approved skill fact with a ULID-based ID
+        let new_id = crate::id::FactId::from(ulid::Ulid::new().to_string());
+        let skill_json = serde_json::to_string(&pending_skill.skill).map_err(|e| {
+            crate::error::EngineQuerySnafu {
+                message: format!("failed to serialize skill: {e}"),
+            }
+            .build()
+        })?;
+
+        let now = jiff::Timestamp::now();
+        let approved_fact = crate::knowledge::Fact {
+            id: new_id.clone(),
+            nous_id: nous_id.to_owned(),
+            content: skill_json,
+            confidence: 0.8,
+            tier: crate::knowledge::EpistemicTier::Verified,
+            valid_from: now,
+            valid_to: jiff::Timestamp::from_second(i64::MAX / 2).unwrap_or(now),
+            superseded_by: None,
+            source_session_id: None,
+            recorded_at: now,
+            access_count: 0,
+            last_accessed_at: None,
+            stability_hours: 2190.0,
+            fact_type: "skill".to_owned(),
+            is_forgotten: false,
+            forgotten_at: None,
+            forget_reason: None,
+        };
+
+        self.insert_fact(&approved_fact)?;
+
+        // Supersede the pending fact by forgetting it
+        self.forget_fact(pending_fact_id, crate::knowledge::ForgetReason::Outdated)?;
+
+        Ok(new_id)
+    }
+
+    /// Reject a pending skill — mark it as forgotten.
+    #[instrument(skip(self))]
+    pub fn reject_pending_skill(
+        &self,
+        pending_fact_id: &crate::id::FactId,
+    ) -> crate::error::Result<()> {
+        self.forget_fact(pending_fact_id, crate::knowledge::ForgetReason::Incorrect)
+    }
+
+    /// Check if a skill similar to the given content already exists.
+    ///
+    /// Compares by name similarity (exact match) and by content similarity
+    /// using BM25 search. Returns the fact ID of the most similar existing
+    /// skill if similarity is high enough to be considered a duplicate.
+    #[instrument(skip(self, skill_content))]
+    pub fn find_duplicate_skill(
+        &self,
+        nous_id: &str,
+        skill_content: &crate::skill::SkillContent,
+    ) -> crate::error::Result<Option<crate::id::FactId>> {
+        // First check exact name match
+        if let Some(existing_id) = self.find_skill_by_name(nous_id, &skill_content.name)? {
+            return Ok(Some(crate::id::FactId::from(existing_id.as_str())));
+        }
+
+        // Then do a BM25 search using the skill description as query
+        let query = format!("{} {}", skill_content.name, skill_content.description);
+        let candidates = self.search_skills(nous_id, &query, 5)?;
+
+        for fact in candidates {
+            if let Ok(existing) = serde_json::from_str::<crate::skill::SkillContent>(&fact.content)
+            {
+                // Check tool overlap as a proxy for content similarity
+                let tool_overlap =
+                    compute_tool_overlap(&skill_content.tools_used, &existing.tools_used);
+                let name_sim = compute_name_similarity(&skill_content.name, &existing.name);
+
+                // High tool overlap + similar name = likely duplicate
+                if tool_overlap > 0.85 || (tool_overlap > 0.6 && name_sim > 0.5) {
+                    return Ok(Some(fact.id));
+                }
+            }
+        }
+
+        Ok(None)
+    }
+
     /// Hybrid BM25 + HNSW vector + graph retrieval fused via `ReciprocalRankFusion`.
     ///
     /// Runs a single Datalog query combining all three signals in the engine.
@@ -1989,6 +2138,75 @@ fn embedding_to_params(
         DataValue::Str(crate::knowledge::format_timestamp(&chunk.created_at).into()),
     );
     p
+}
+
+// ---------------------------------------------------------------------------
+// Dedup helpers
+// ---------------------------------------------------------------------------
+
+/// Compute Jaccard overlap between two tool lists.
+///
+/// Returns 1.0 for identical sets, 0.0 for disjoint.
+#[cfg(feature = "mneme-engine")]
+#[expect(
+    clippy::cast_precision_loss,
+    reason = "tool set sizes are small; precision loss is impossible in practice"
+)]
+fn compute_tool_overlap(a: &[String], b: &[String]) -> f64 {
+    if a.is_empty() && b.is_empty() {
+        return 1.0;
+    }
+    let set_a: std::collections::HashSet<&str> = a.iter().map(String::as_str).collect();
+    let set_b: std::collections::HashSet<&str> = b.iter().map(String::as_str).collect();
+    let intersection = set_a.intersection(&set_b).count();
+    let union = set_a.union(&set_b).count();
+    if union == 0 {
+        return 1.0;
+    }
+    intersection as f64 / union as f64
+}
+
+/// Compute name similarity using longest common subsequence ratio.
+///
+/// Returns 1.0 for identical names, 0.0 for completely different.
+#[cfg(feature = "mneme-engine")]
+#[expect(
+    clippy::cast_precision_loss,
+    reason = "name lengths are small; precision loss is impossible in practice"
+)]
+fn compute_name_similarity(a: &str, b: &str) -> f64 {
+    if a == b {
+        return 1.0;
+    }
+    let a_lower = a.to_lowercase();
+    let b_lower = b.to_lowercase();
+    let a_chars: Vec<char> = a_lower.chars().collect();
+    let b_chars: Vec<char> = b_lower.chars().collect();
+    let max_len = a_chars.len().max(b_chars.len());
+    if max_len == 0 {
+        return 1.0;
+    }
+    let lcs = lcs_char_length(&a_chars, &b_chars);
+    lcs as f64 / max_len as f64
+}
+
+/// Classic DP Longest Common Subsequence length for char slices.
+#[cfg(feature = "mneme-engine")]
+fn lcs_char_length(a: &[char], b: &[char]) -> usize {
+    let m = a.len();
+    let n = b.len();
+    let mut dp = vec![0usize; (m + 1) * (n + 1)];
+    let idx = |i: usize, j: usize| i * (n + 1) + j;
+    for i in 1..=m {
+        for j in 1..=n {
+            dp[idx(i, j)] = if a[i - 1] == b[j - 1] {
+                dp[idx(i - 1, j - 1)] + 1
+            } else {
+                dp[idx(i - 1, j)].max(dp[idx(i, j - 1)])
+            };
+        }
+    }
+    dp[idx(m, n)]
 }
 
 // Parse rows from FULL_CURRENT_FACTS into Vec<Fact>.

--- a/crates/mneme/src/skills/extract.rs
+++ b/crates/mneme/src/skills/extract.rs
@@ -1,0 +1,699 @@
+//! LLM-based skill extraction from promoted candidates.
+//!
+//! When a [`SkillCandidate`] is promoted (recurrence count ≥ 3), this module
+//! builds an extraction prompt from the candidate metadata and tool call
+//! sequences, sends it to a cost-effective LLM (Haiku), and parses the
+//! structured skill definition from the response.
+//!
+//! The extracted skill is stored with `status: "pending_review"` — it is NOT
+//! automatically activated. A human or orchestrator must approve it first.
+
+use serde::{Deserialize, Serialize};
+use snafu::Snafu;
+use std::fmt::Write as _;
+
+use crate::skill::SkillContent;
+use crate::skills::{SkillCandidate, ToolCallRecord};
+
+// ---------------------------------------------------------------------------
+// Error
+// ---------------------------------------------------------------------------
+
+/// Errors from the skill extraction pipeline.
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub))]
+pub enum SkillExtractionError {
+    /// The LLM provider returned an error.
+    #[snafu(display("LLM extraction failed: {message}"))]
+    LlmCall {
+        message: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+    /// The LLM response could not be parsed as valid skill JSON.
+    #[snafu(display("failed to parse skill extraction response: {message}"))]
+    ParseResponse {
+        message: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+}
+
+// ---------------------------------------------------------------------------
+// Provider trait
+// ---------------------------------------------------------------------------
+
+/// Minimal LLM completion interface for skill extraction.
+///
+/// Keeps mneme independent of hermeneus. The nous layer bridges this trait
+/// to the full provider API, just like [`crate::extract::ExtractionProvider`].
+pub trait SkillExtractionProvider: Send + Sync {
+    /// Send a system + user message to the LLM and return the text response.
+    fn complete(&self, system: &str, user_message: &str) -> Result<String, SkillExtractionError>;
+}
+
+// ---------------------------------------------------------------------------
+// Extracted skill (intermediate representation)
+// ---------------------------------------------------------------------------
+
+/// A skill definition extracted by the LLM, before human review.
+///
+/// This is the raw LLM output, parsed from JSON. It gets converted to
+/// [`SkillContent`] for storage as a fact with `fact_type = "skill"`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ExtractedSkill {
+    /// Human-readable skill name.
+    pub name: String,
+    /// Description of what this skill does and when to use it.
+    pub description: String,
+    /// Ordered steps to execute the skill.
+    pub steps: Vec<String>,
+    /// Tools referenced by the skill.
+    pub tools_used: Vec<String>,
+    /// Domain classification tags.
+    pub domain_tags: Vec<String>,
+    /// When this skill should be applied (situational guidance).
+    pub when_to_use: String,
+}
+
+impl ExtractedSkill {
+    /// Convert to [`SkillContent`] for fact storage.
+    pub fn to_skill_content(&self) -> SkillContent {
+        SkillContent {
+            name: self.name.clone(),
+            description: if self.when_to_use.is_empty() {
+                self.description.clone()
+            } else {
+                format!(
+                    "{}\n\n## When to Use\n\n{}",
+                    self.description, self.when_to_use
+                )
+            },
+            steps: self.steps.clone(),
+            tools_used: self.tools_used.clone(),
+            domain_tags: self.domain_tags.clone(),
+            origin: "extracted".to_owned(),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Extractor
+// ---------------------------------------------------------------------------
+
+/// Extracts structured skill definitions from promoted candidates via LLM.
+pub struct SkillExtractor<P> {
+    provider: P,
+}
+
+impl<P: SkillExtractionProvider> SkillExtractor<P> {
+    /// Create a new extractor with the given LLM provider.
+    pub fn new(provider: P) -> Self {
+        Self { provider }
+    }
+
+    /// Extract a structured skill definition from a promoted candidate.
+    ///
+    /// `tool_call_sequences` should contain the tool call sequences from each
+    /// session where the pattern was observed (one vec per session).
+    pub fn extract_skill(
+        &self,
+        candidate: &SkillCandidate,
+        tool_call_sequences: &[Vec<ToolCallRecord>],
+    ) -> Result<ExtractedSkill, SkillExtractionError> {
+        let system = EXTRACTION_SYSTEM_PROMPT;
+        let user_message = build_extraction_prompt(candidate, tool_call_sequences);
+        let response = self.provider.complete(system, &user_message)?;
+        parse_skill_response(&response)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Prompt construction
+// ---------------------------------------------------------------------------
+
+const EXTRACTION_SYSTEM_PROMPT: &str = r#"You are a skill extraction engine for an AI agent system. Your job is to analyze tool call patterns and produce structured skill definitions.
+
+Given a recurring tool call pattern observed across multiple sessions, generate a reusable skill definition that captures the generalizable workflow.
+
+Rules:
+- Name should be descriptive and kebab-case (e.g. "multi-file-refactor", "test-driven-bug-fix")
+- Description should explain what the skill accomplishes, not just list steps
+- Steps should be generalized — replace specific file names/paths with placeholders
+- Tools should only include tool names actually used in the pattern
+- Domain tags should classify the skill broadly (e.g. "rust", "debugging", "refactoring", "testing")
+- when_to_use should describe the situation that triggers this skill
+
+Respond with ONLY a JSON object, no markdown fences, no explanation:
+{
+  "name": "...",
+  "description": "...",
+  "steps": ["...", "..."],
+  "tools_used": ["...", "..."],
+  "domain_tags": ["...", "..."],
+  "when_to_use": "..."
+}"#;
+
+/// Build the user message for skill extraction.
+fn build_extraction_prompt(
+    candidate: &SkillCandidate,
+    tool_call_sequences: &[Vec<ToolCallRecord>],
+) -> String {
+    let mut prompt = String::with_capacity(1024);
+
+    // Candidate metadata
+    let _ = writeln!(prompt, "## Candidate Pattern");
+    let _ = writeln!(prompt, "- Recurrence count: {}", candidate.recurrence_count);
+    if let Some(ref pattern) = candidate.pattern_type {
+        let _ = writeln!(prompt, "- Detected pattern type: {pattern:?}");
+    }
+    let _ = writeln!(
+        prompt,
+        "- Heuristic score: {:.2}",
+        candidate.heuristic_score
+    );
+    let _ = writeln!(
+        prompt,
+        "- Normalized tool sequence: {}",
+        candidate.signature.normalized.join(" → ")
+    );
+    let _ = writeln!(
+        prompt,
+        "- Sessions observed: {}",
+        candidate.session_refs.len()
+    );
+    let _ = writeln!(prompt);
+
+    // Tool call sequences
+    let _ = writeln!(prompt, "## Observed Tool Call Sequences");
+    for (i, seq) in tool_call_sequences.iter().enumerate() {
+        let _ = writeln!(prompt, "\n### Session {} ({} calls)", i + 1, seq.len());
+        for (j, tc) in seq.iter().enumerate() {
+            let status = if tc.is_error { " [ERROR]" } else { "" };
+            let _ = writeln!(
+                prompt,
+                "{}. {} ({}ms){}",
+                j + 1,
+                tc.tool_name,
+                tc.duration_ms,
+                status
+            );
+        }
+    }
+
+    prompt
+}
+
+// ---------------------------------------------------------------------------
+// Response parsing
+// ---------------------------------------------------------------------------
+
+/// Parse the LLM response into an [`ExtractedSkill`].
+///
+/// Handles JSON embedded in markdown fences, bare JSON, and minor formatting
+/// issues from the LLM.
+fn parse_skill_response(response: &str) -> Result<ExtractedSkill, SkillExtractionError> {
+    let trimmed = response.trim();
+
+    // Strip markdown code fences if present
+    let json_str = if trimmed.starts_with("```") {
+        // Find the opening fence end (after ```json or ```)
+        let start = trimmed.find('\n').map_or(0, |i| i + 1);
+        let end = trimmed
+            .rfind("```")
+            .filter(|&e| e > start)
+            .unwrap_or(trimmed.len());
+        &trimmed[start..end]
+    } else {
+        trimmed
+    };
+
+    // Try to find JSON object boundaries
+    let json_str = json_str.trim();
+    let json_str = if let Some(start) = json_str.find('{') {
+        let end = json_str.rfind('}').unwrap_or(json_str.len());
+        &json_str[start..=end]
+    } else {
+        json_str
+    };
+
+    serde_json::from_str::<ExtractedSkill>(json_str).map_err(|e| {
+        ParseResponseSnafu {
+            message: format!(
+                "invalid JSON in LLM response: {e}. Response was: {}",
+                &response[..response.len().min(200)]
+            ),
+        }
+        .build()
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Pending skill wrapper
+// ---------------------------------------------------------------------------
+
+/// A skill awaiting human review before activation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PendingSkill {
+    /// The extracted skill content.
+    pub skill: SkillContent,
+    /// The candidate that was promoted to trigger extraction.
+    pub candidate_id: String,
+    /// Review status: `"pending_review"`, `"approved"`, `"rejected"`.
+    pub status: String,
+    /// When the skill was extracted.
+    pub extracted_at: jiff::Timestamp,
+}
+
+impl PendingSkill {
+    /// Create a new pending skill from an extracted skill and candidate.
+    pub fn new(extracted: &ExtractedSkill, candidate_id: &str) -> Self {
+        Self {
+            skill: extracted.to_skill_content(),
+            candidate_id: candidate_id.to_owned(),
+            status: "pending_review".to_owned(),
+            extracted_at: jiff::Timestamp::now(),
+        }
+    }
+
+    /// Serialize to JSON for storage in a fact's `content` field.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`serde_json::Error`] if serialization fails.
+    pub fn to_json(&self) -> Result<String, serde_json::Error> {
+        serde_json::to_string(self)
+    }
+
+    /// Deserialize from a fact's `content` field.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`serde_json::Error`] if the JSON is malformed.
+    pub fn from_json(json: &str) -> Result<Self, serde_json::Error> {
+        serde_json::from_str(json)
+    }
+
+    /// Returns `true` if the skill is pending review.
+    pub fn is_pending(&self) -> bool {
+        self.status == "pending_review"
+    }
+
+    /// Returns `true` if the skill has been approved.
+    pub fn is_approved(&self) -> bool {
+        self.status == "approved"
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::skills::heuristics::PatternType;
+    use crate::skills::signature::SequenceSignature;
+
+    // -- Mock provider --------------------------------------------------------
+
+    struct MockProvider {
+        response: Result<String, SkillExtractionError>,
+    }
+
+    impl MockProvider {
+        fn ok(response: &str) -> Self {
+            Self {
+                response: Ok(response.to_owned()),
+            }
+        }
+
+        fn err(msg: &str) -> Self {
+            Self {
+                response: Err(LlmCallSnafu {
+                    message: msg.to_owned(),
+                }
+                .build()),
+            }
+        }
+    }
+
+    impl SkillExtractionProvider for MockProvider {
+        fn complete(
+            &self,
+            _system: &str,
+            _user_message: &str,
+        ) -> Result<String, SkillExtractionError> {
+            self.response.as_ref().cloned().map_err(|_prev| {
+                LlmCallSnafu {
+                    message: "mock error".to_owned(),
+                }
+                .build()
+            })
+        }
+    }
+
+    fn sample_candidate() -> SkillCandidate {
+        SkillCandidate {
+            id: "cand-001".to_owned(),
+            nous_id: "test-nous".to_owned(),
+            signature: SequenceSignature {
+                normalized: vec![
+                    "Grep".to_owned(),
+                    "Read".to_owned(),
+                    "Edit".to_owned(),
+                    "Bash".to_owned(),
+                ],
+                hash: 12345,
+            },
+            recurrence_count: 3,
+            session_refs: vec!["s1".to_owned(), "s2".to_owned(), "s3".to_owned()],
+            first_seen: jiff::Timestamp::now(),
+            last_seen: jiff::Timestamp::now(),
+            heuristic_score: 0.72,
+            pattern_type: Some(PatternType::Diagnostic),
+        }
+    }
+
+    fn sample_sequences() -> Vec<Vec<ToolCallRecord>> {
+        vec![
+            vec![
+                ToolCallRecord::new("Grep", 120),
+                ToolCallRecord::new("Read", 80),
+                ToolCallRecord::new("Read", 90),
+                ToolCallRecord::new("Edit", 150),
+                ToolCallRecord::new("Bash", 200),
+                ToolCallRecord::new("Bash", 100),
+            ],
+            vec![
+                ToolCallRecord::new("Grep", 110),
+                ToolCallRecord::new("Read", 75),
+                ToolCallRecord::new("Edit", 160),
+                ToolCallRecord::new("Edit", 90),
+                ToolCallRecord::new("Bash", 180),
+                ToolCallRecord::new("Bash", 120),
+            ],
+        ]
+    }
+
+    fn valid_json_response() -> String {
+        r#"{
+            "name": "test-driven-bug-fix",
+            "description": "Diagnose test failures, fix source code, and validate",
+            "steps": [
+                "Search for failing test references",
+                "Read relevant source files",
+                "Edit source to fix the issue",
+                "Run tests to verify"
+            ],
+            "tools_used": ["Grep", "Read", "Edit", "Bash"],
+            "domain_tags": ["testing", "debugging"],
+            "when_to_use": "When a test failure needs diagnosis and fix"
+        }"#
+        .to_owned()
+    }
+
+    // -- Prompt construction --------------------------------------------------
+
+    #[test]
+    fn build_prompt_includes_candidate_metadata() {
+        let candidate = sample_candidate();
+        let seqs = sample_sequences();
+        let prompt = build_extraction_prompt(&candidate, &seqs);
+
+        assert!(prompt.contains("Recurrence count: 3"));
+        assert!(prompt.contains("Diagnostic"));
+        assert!(prompt.contains("0.72"));
+        assert!(prompt.contains("Grep → Read → Edit → Bash"));
+    }
+
+    #[test]
+    fn build_prompt_includes_all_sessions() {
+        let candidate = sample_candidate();
+        let seqs = sample_sequences();
+        let prompt = build_extraction_prompt(&candidate, &seqs);
+
+        assert!(prompt.contains("Session 1"));
+        assert!(prompt.contains("Session 2"));
+        assert!(prompt.contains("6 calls"));
+    }
+
+    #[test]
+    fn build_prompt_includes_tool_call_details() {
+        let candidate = sample_candidate();
+        let seqs = vec![vec![
+            ToolCallRecord::new("Read", 50),
+            ToolCallRecord::errored("Bash", 300),
+        ]];
+        let prompt = build_extraction_prompt(&candidate, &seqs);
+
+        assert!(prompt.contains("Read (50ms)"));
+        assert!(prompt.contains("Bash (300ms) [ERROR]"));
+    }
+
+    #[test]
+    fn build_prompt_handles_empty_sequences() {
+        let candidate = sample_candidate();
+        let prompt = build_extraction_prompt(&candidate, &[]);
+
+        assert!(prompt.contains("Candidate Pattern"));
+        assert!(prompt.contains("Observed Tool Call Sequences"));
+    }
+
+    #[test]
+    fn build_prompt_no_pattern_type() {
+        let mut candidate = sample_candidate();
+        candidate.pattern_type = None;
+        let seqs = sample_sequences();
+        let prompt = build_extraction_prompt(&candidate, &seqs);
+
+        assert!(!prompt.contains("pattern type"));
+    }
+
+    // -- Response parsing -----------------------------------------------------
+
+    #[test]
+    fn parse_valid_json_response() {
+        let response = valid_json_response();
+        let skill = parse_skill_response(&response).unwrap();
+
+        assert_eq!(skill.name, "test-driven-bug-fix");
+        assert_eq!(skill.steps.len(), 4);
+        assert_eq!(skill.tools_used, vec!["Grep", "Read", "Edit", "Bash"]);
+        assert_eq!(skill.domain_tags, vec!["testing", "debugging"]);
+        assert!(!skill.when_to_use.is_empty());
+    }
+
+    #[test]
+    fn parse_json_in_markdown_fences() {
+        let response = format!("```json\n{}\n```", valid_json_response());
+        let skill = parse_skill_response(&response).unwrap();
+        assert_eq!(skill.name, "test-driven-bug-fix");
+    }
+
+    #[test]
+    fn parse_json_in_bare_fences() {
+        let response = format!("```\n{}\n```", valid_json_response());
+        let skill = parse_skill_response(&response).unwrap();
+        assert_eq!(skill.name, "test-driven-bug-fix");
+    }
+
+    #[test]
+    fn parse_json_with_surrounding_text() {
+        let response = format!(
+            "Here is the extracted skill:\n{}\nDone.",
+            valid_json_response()
+        );
+        let skill = parse_skill_response(&response).unwrap();
+        assert_eq!(skill.name, "test-driven-bug-fix");
+    }
+
+    #[test]
+    fn parse_malformed_json_returns_error() {
+        let response = "not json at all";
+        let result = parse_skill_response(response);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.to_string().contains("invalid JSON"));
+    }
+
+    #[test]
+    fn parse_incomplete_json_returns_error() {
+        let response = r#"{"name": "test", "description": "d"}"#;
+        let result = parse_skill_response(response);
+        // Missing required fields
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn parse_empty_response_returns_error() {
+        let result = parse_skill_response("");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn parse_empty_fields_succeeds() {
+        let response = r#"{
+            "name": "minimal-skill",
+            "description": "A minimal skill",
+            "steps": [],
+            "tools_used": [],
+            "domain_tags": [],
+            "when_to_use": ""
+        }"#;
+        let skill = parse_skill_response(response).unwrap();
+        assert_eq!(skill.name, "minimal-skill");
+        assert!(skill.steps.is_empty());
+    }
+
+    // -- Extractor end-to-end -------------------------------------------------
+
+    #[test]
+    fn extractor_returns_skill_on_valid_response() {
+        let provider = MockProvider::ok(&valid_json_response());
+        let extractor = SkillExtractor::new(provider);
+        let candidate = sample_candidate();
+        let seqs = sample_sequences();
+
+        let skill = extractor.extract_skill(&candidate, &seqs).unwrap();
+        assert_eq!(skill.name, "test-driven-bug-fix");
+    }
+
+    #[test]
+    fn extractor_returns_error_on_provider_failure() {
+        let provider = MockProvider::err("API rate limited");
+        let extractor = SkillExtractor::new(provider);
+        let candidate = sample_candidate();
+        let seqs = sample_sequences();
+
+        let result = extractor.extract_skill(&candidate, &seqs);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn extractor_returns_error_on_malformed_response() {
+        let provider = MockProvider::ok("this is not json");
+        let extractor = SkillExtractor::new(provider);
+        let candidate = sample_candidate();
+        let seqs = sample_sequences();
+
+        let result = extractor.extract_skill(&candidate, &seqs);
+        assert!(result.is_err());
+    }
+
+    // -- ExtractedSkill → SkillContent ----------------------------------------
+
+    #[test]
+    fn to_skill_content_sets_origin_extracted() {
+        let extracted = ExtractedSkill {
+            name: "test-skill".to_owned(),
+            description: "A test skill".to_owned(),
+            steps: vec!["step 1".to_owned()],
+            tools_used: vec!["Read".to_owned()],
+            domain_tags: vec!["test".to_owned()],
+            when_to_use: "When testing".to_owned(),
+        };
+        let content = extracted.to_skill_content();
+        assert_eq!(content.origin, "extracted");
+    }
+
+    #[test]
+    fn to_skill_content_includes_when_to_use_in_description() {
+        let extracted = ExtractedSkill {
+            name: "test-skill".to_owned(),
+            description: "A test skill".to_owned(),
+            steps: vec![],
+            tools_used: vec![],
+            domain_tags: vec![],
+            when_to_use: "When you need to test".to_owned(),
+        };
+        let content = extracted.to_skill_content();
+        assert!(content.description.contains("When to Use"));
+        assert!(content.description.contains("When you need to test"));
+    }
+
+    #[test]
+    fn to_skill_content_omits_when_to_use_if_empty() {
+        let extracted = ExtractedSkill {
+            name: "test-skill".to_owned(),
+            description: "A test skill".to_owned(),
+            steps: vec![],
+            tools_used: vec![],
+            domain_tags: vec![],
+            when_to_use: String::new(),
+        };
+        let content = extracted.to_skill_content();
+        assert_eq!(content.description, "A test skill");
+    }
+
+    // -- PendingSkill ---------------------------------------------------------
+
+    #[test]
+    fn pending_skill_new_sets_status() {
+        let extracted = ExtractedSkill {
+            name: "test".to_owned(),
+            description: "d".to_owned(),
+            steps: vec![],
+            tools_used: vec![],
+            domain_tags: vec![],
+            when_to_use: String::new(),
+        };
+        let pending = PendingSkill::new(&extracted, "cand-001");
+        assert!(pending.is_pending());
+        assert!(!pending.is_approved());
+        assert_eq!(pending.candidate_id, "cand-001");
+        assert_eq!(pending.status, "pending_review");
+    }
+
+    #[test]
+    fn pending_skill_serialization_roundtrip() {
+        let extracted = ExtractedSkill {
+            name: "roundtrip-skill".to_owned(),
+            description: "Tests serialization".to_owned(),
+            steps: vec!["step 1".to_owned()],
+            tools_used: vec!["Read".to_owned()],
+            domain_tags: vec!["test".to_owned()],
+            when_to_use: "For tests".to_owned(),
+        };
+        let pending = PendingSkill::new(&extracted, "cand-002");
+        let json = pending.to_json().unwrap();
+        let back = PendingSkill::from_json(&json).unwrap();
+        assert_eq!(back.skill.name, "roundtrip-skill");
+        assert_eq!(back.candidate_id, "cand-002");
+        assert!(back.is_pending());
+    }
+
+    #[test]
+    fn pending_skill_approved_status() {
+        let mut pending = PendingSkill {
+            skill: SkillContent {
+                name: "s".to_owned(),
+                description: "d".to_owned(),
+                steps: vec![],
+                tools_used: vec![],
+                domain_tags: vec![],
+                origin: "extracted".to_owned(),
+            },
+            candidate_id: "c".to_owned(),
+            status: "approved".to_owned(),
+            extracted_at: jiff::Timestamp::now(),
+        };
+        assert!(pending.is_approved());
+        assert!(!pending.is_pending());
+
+        pending.status = "rejected".to_owned();
+        assert!(!pending.is_approved());
+        assert!(!pending.is_pending());
+    }
+
+    // -- System prompt --------------------------------------------------------
+
+    #[test]
+    fn system_prompt_requests_json() {
+        assert!(EXTRACTION_SYSTEM_PROMPT.contains("JSON"));
+        assert!(EXTRACTION_SYSTEM_PROMPT.contains("name"));
+        assert!(EXTRACTION_SYSTEM_PROMPT.contains("steps"));
+        assert!(EXTRACTION_SYSTEM_PROMPT.contains("tools_used"));
+        assert!(EXTRACTION_SYSTEM_PROMPT.contains("domain_tags"));
+    }
+}

--- a/crates/mneme/src/skills/mod.rs
+++ b/crates/mneme/src/skills/mod.rs
@@ -13,10 +13,14 @@
 //! ```
 
 pub mod candidate;
+pub mod extract;
 pub mod heuristics;
 pub mod signature;
 
 pub use candidate::{CandidateTracker, SkillCandidate, TrackResult};
+pub use extract::{
+    ExtractedSkill, PendingSkill, SkillExtractionError, SkillExtractionProvider, SkillExtractor,
+};
 pub use heuristics::{HeuristicScore, PatternType, score_sequence};
 pub use signature::{SequenceSignature, sequence_signature, signature_similarity};
 

--- a/crates/nous/src/actor.rs
+++ b/crates/nous/src/actor.rs
@@ -62,6 +62,8 @@ pub struct NousActor {
     /// Skill loader for per-turn skill injection. None when knowledge-store is disabled.
     #[cfg(feature = "knowledge-store")]
     skill_loader: Option<crate::skills::SkillLoader>,
+    /// Candidate tracker for skill auto-capture pipeline.
+    candidate_tracker: Arc<aletheia_mneme::skills::CandidateTracker>,
 }
 
 impl NousActor {
@@ -116,6 +118,7 @@ impl NousActor {
             extra_bootstrap,
             #[cfg(feature = "knowledge-store")]
             skill_loader,
+            candidate_tracker: Arc::new(aletheia_mneme::skills::CandidateTracker::new()),
         }
     }
 
@@ -238,6 +241,7 @@ impl NousActor {
 
         if let Ok(ref turn_result) = result {
             self.maybe_spawn_extraction(&content, &turn_result.content);
+            self.maybe_spawn_skill_analysis(&turn_result.tool_calls, &session_key);
             self.maybe_spawn_distillation(&session_key).await;
         }
 
@@ -274,6 +278,7 @@ impl NousActor {
 
         if let Ok(ref turn_result) = result {
             self.maybe_spawn_extraction(&content, &turn_result.content);
+            self.maybe_spawn_skill_analysis(&turn_result.tool_calls, &session_key);
             self.maybe_spawn_distillation(&session_key).await;
         }
 
@@ -462,6 +467,94 @@ impl NousActor {
         );
     }
 
+    /// Analyze tool calls from the completed turn for skill auto-capture.
+    ///
+    /// Converts the turn's tool calls to mneme's [`ToolCallRecord`] format,
+    /// runs them through the heuristic filter and candidate tracker, and
+    /// spawns LLM extraction if a candidate is promoted (Rule of Three).
+    fn maybe_spawn_skill_analysis(
+        &self,
+        tool_calls: &[crate::pipeline::ToolCall],
+        session_key: &str,
+    ) {
+        use aletheia_mneme::skills::{ToolCallRecord, TrackResult};
+
+        if tool_calls.is_empty() {
+            return;
+        }
+
+        // Convert pipeline ToolCalls to mneme ToolCallRecords
+        let records: Vec<ToolCallRecord> = tool_calls
+            .iter()
+            .map(|tc| {
+                if tc.is_error {
+                    ToolCallRecord::errored(&tc.name, tc.duration_ms)
+                } else {
+                    ToolCallRecord::new(&tc.name, tc.duration_ms)
+                }
+            })
+            .collect();
+
+        let nous_id = self.id.clone();
+        let result = self
+            .candidate_tracker
+            .track_sequence(&records, session_key, &nous_id);
+
+        match result {
+            TrackResult::Rejected => {
+                debug!("skill analysis: sequence rejected by heuristic filter");
+            }
+            TrackResult::New => {
+                info!("skill analysis: new candidate tracked");
+            }
+            TrackResult::Tracked(count) => {
+                info!(count, "skill analysis: candidate recurrence updated");
+            }
+            TrackResult::Promoted(candidate_id) => {
+                info!(candidate_id = %candidate_id, "skill analysis: candidate promoted, spawning LLM extraction");
+                self.spawn_skill_extraction(&candidate_id, &records);
+            }
+        }
+    }
+
+    /// Spawn background LLM extraction for a promoted skill candidate.
+    fn spawn_skill_extraction(
+        &self,
+        candidate_id: &str,
+        tool_calls: &[aletheia_mneme::skills::ToolCallRecord],
+    ) {
+        let Some(ref extraction_config) = self.pipeline_config.extraction else {
+            return;
+        };
+
+        // Use the extraction model (Haiku) for cost-effective skill extraction
+        let model = extraction_config.model.clone();
+        let providers = Arc::clone(&self.providers);
+        let nous_id = self.id.clone();
+        let candidate_id = candidate_id.to_owned();
+        let tool_calls = tool_calls.to_vec();
+        let tracker = Arc::clone(&self.candidate_tracker);
+        #[cfg(feature = "knowledge-store")]
+        let knowledge_store = self.knowledge_store.clone();
+        let span = tracing::info_span!("skill_extraction", nous.id = %nous_id, candidate.id = %candidate_id);
+
+        tokio::spawn(
+            async move {
+                run_skill_extraction(
+                    &model,
+                    providers,
+                    &nous_id,
+                    &candidate_id,
+                    &tool_calls,
+                    &tracker,
+                    #[cfg(feature = "knowledge-store")]
+                    knowledge_store.as_ref(),
+                );
+            }
+            .instrument(span),
+        );
+    }
+
     async fn maybe_spawn_distillation(&self, session_key: &str) {
         let Some(ref store_arc) = self.session_store else {
             return;
@@ -524,7 +617,10 @@ impl NousActor {
     // intentional; the function stays async so callers can `.await` uniformly.
     #[cfg_attr(
         not(feature = "knowledge-store"),
-        expect(clippy::unused_async, reason = "await compiled away without knowledge-store feature")
+        expect(
+            clippy::unused_async,
+            reason = "await compiled away without knowledge-store feature"
+        )
     )]
     async fn resolve_skill_sections(&self, content: &str) -> Vec<BootstrapSection> {
         #[cfg(feature = "knowledge-store")]
@@ -532,11 +628,7 @@ impl NousActor {
             if let Some(ref loader) = self.skill_loader {
                 let task_context = crate::skills::extract_task_context(content);
                 return loader
-                    .resolve_skills(
-                        &self.id,
-                        &task_context,
-                        crate::skills::DEFAULT_MAX_SKILLS,
-                    )
+                    .resolve_skills(&self.id, &task_context, crate::skills::DEFAULT_MAX_SKILLS)
                     .await;
             }
         }
@@ -634,6 +726,126 @@ fn run_extraction(
         }
         Err(e) => {
             warn!(nous_id = %nous_id, error = %e, "extraction failed");
+        }
+    }
+}
+
+/// Run LLM skill extraction as a background task. Logs results, never panics.
+fn run_skill_extraction(
+    model: &str,
+    providers: Arc<ProviderRegistry>,
+    nous_id: &str,
+    candidate_id: &str,
+    tool_calls: &[aletheia_mneme::skills::ToolCallRecord],
+    tracker: &aletheia_mneme::skills::CandidateTracker,
+    #[cfg(feature = "knowledge-store")] knowledge_store: Option<&Arc<KnowledgeStore>>,
+) {
+    use aletheia_mneme::skills::SkillExtractor;
+
+    // Find the candidate in the tracker
+    let candidates = tracker.candidates_for(nous_id);
+    let Some(candidate) = candidates.iter().find(|c| c.id == candidate_id) else {
+        warn!(candidate_id = %candidate_id, "candidate not found in tracker");
+        return;
+    };
+
+    // Build the extraction provider (uses Haiku for cost-effectiveness)
+    let provider = crate::extraction::HermeneusSkillExtractionProvider::new(providers, model);
+    let extractor = SkillExtractor::new(provider);
+
+    // The current turn's tool calls are the only sequence we have at this point.
+    // In a richer implementation, we'd collect sequences from all session_refs.
+    let sequences = vec![tool_calls.to_vec()];
+
+    match extractor.extract_skill(candidate, &sequences) {
+        Ok(extracted) => {
+            info!(
+                nous_id = %nous_id,
+                skill_name = %extracted.name,
+                steps = extracted.steps.len(),
+                tools = extracted.tools_used.len(),
+                domains = ?extracted.domain_tags,
+                "skill extracted from promoted candidate"
+            );
+
+            #[cfg(feature = "knowledge-store")]
+            if let Some(store) = knowledge_store {
+                // Check for duplicates before storing
+                let skill_content = extracted.to_skill_content();
+                match store.find_duplicate_skill(nous_id, &skill_content) {
+                    Ok(Some(existing_id)) => {
+                        info!(
+                            existing_id = %existing_id,
+                            skill_name = %extracted.name,
+                            "duplicate skill detected, skipping storage"
+                        );
+                        return;
+                    }
+                    Ok(None) => {} // No duplicate, proceed
+                    Err(e) => {
+                        warn!(error = %e, "failed to check skill duplicates, proceeding with storage");
+                    }
+                }
+
+                // Store as pending_review fact
+                let pending = aletheia_mneme::skills::PendingSkill::new(&extracted, candidate_id);
+                match pending.to_json() {
+                    Ok(content) => {
+                        let fact_id =
+                            aletheia_mneme::id::FactId::from(ulid::Ulid::new().to_string());
+                        let now = jiff::Timestamp::now();
+                        let fact = aletheia_mneme::knowledge::Fact {
+                            id: fact_id.clone(),
+                            nous_id: nous_id.to_owned(),
+                            content,
+                            confidence: 0.6, // Pending review — moderate confidence
+                            tier: aletheia_mneme::knowledge::EpistemicTier::Inferred,
+                            valid_from: now,
+                            valid_to: jiff::Timestamp::from_second(i64::MAX / 2).unwrap_or(now),
+                            superseded_by: None,
+                            source_session_id: None,
+                            recorded_at: now,
+                            access_count: 0,
+                            last_accessed_at: None,
+                            stability_hours: 720.0,
+                            fact_type: "skill_pending".to_owned(),
+                            is_forgotten: false,
+                            forgotten_at: None,
+                            forget_reason: None,
+                        };
+
+                        match store.insert_fact(&fact) {
+                            Ok(()) => {
+                                info!(
+                                    fact_id = %fact_id,
+                                    skill_name = %extracted.name,
+                                    "pending skill stored for review"
+                                );
+                            }
+                            Err(e) => {
+                                warn!(error = %e, "failed to store pending skill");
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        warn!(error = %e, "failed to serialize pending skill");
+                    }
+                }
+            }
+
+            #[cfg(not(feature = "knowledge-store"))]
+            {
+                let _ = candidate_id; // suppress unused warning
+                info!("skill extracted but knowledge-store feature disabled, not persisting");
+            }
+        }
+        Err(e) => {
+            warn!(
+                nous_id = %nous_id,
+                candidate_id = %candidate_id,
+                error = %e,
+                "skill extraction failed"
+            );
         }
     }
 }

--- a/crates/nous/src/extraction.rs
+++ b/crates/nous/src/extraction.rs
@@ -1,10 +1,17 @@
 //! Bridge from nous to mneme's extraction pipeline via hermeneus providers.
+//!
+//! Provides [`HermeneusExtractionProvider`] for fact extraction and
+//! [`HermeneusSkillExtractionProvider`] for skill extraction — both bridge
+//! hermeneus's `ProviderRegistry` to mneme's provider traits.
 
 use std::sync::Arc;
 
 use aletheia_hermeneus::provider::ProviderRegistry;
 use aletheia_hermeneus::types::{CompletionRequest, Content, ContentBlock, Message, Role};
 use aletheia_mneme::extract::{ExtractionError, ExtractionProvider, LlmCallSnafu};
+use aletheia_mneme::skills::extract::{
+    LlmCallSnafu as SkillLlmCallSnafu, SkillExtractionError, SkillExtractionProvider,
+};
 use snafu::OptionExt;
 
 /// Bridges hermeneus `ProviderRegistry` to mneme's `ExtractionProvider` trait.
@@ -62,6 +69,63 @@ impl ExtractionProvider for HermeneusExtractionProvider {
             })
             .context(LlmCallSnafu {
                 message: "no text content in extraction response",
+            })
+    }
+}
+
+/// Bridges hermeneus `ProviderRegistry` to mneme's [`SkillExtractionProvider`] trait.
+pub(crate) struct HermeneusSkillExtractionProvider {
+    providers: Arc<ProviderRegistry>,
+    model: String,
+}
+
+impl HermeneusSkillExtractionProvider {
+    pub(crate) fn new(providers: Arc<ProviderRegistry>, model: &str) -> Self {
+        Self {
+            providers,
+            model: model.to_owned(),
+        }
+    }
+}
+
+impl SkillExtractionProvider for HermeneusSkillExtractionProvider {
+    fn complete(&self, system: &str, user_message: &str) -> Result<String, SkillExtractionError> {
+        let request = CompletionRequest {
+            model: self.model.clone(),
+            system: Some(system.to_owned()),
+            messages: vec![Message {
+                role: Role::User,
+                content: Content::Text(user_message.to_owned()),
+            }],
+            max_tokens: 2048,
+            tools: Vec::new(),
+            temperature: None,
+            thinking: None,
+            stop_sequences: Vec::new(),
+            ..Default::default()
+        };
+
+        let provider = self.providers.find_provider(&self.model).ok_or_else(|| {
+            SkillLlmCallSnafu {
+                message: format!("no provider for model {}", self.model),
+            }
+            .build()
+        })?;
+
+        let response = provider.complete(&request).map_err(|e| {
+            let msg = e.to_string();
+            SkillLlmCallSnafu { message: msg }.build()
+        })?;
+
+        response
+            .content
+            .iter()
+            .find_map(|block| match block {
+                ContentBlock::Text { text, .. } => Some(text.clone()),
+                _ => None,
+            })
+            .context(SkillLlmCallSnafu {
+                message: "no text content in skill extraction response",
             })
     }
 }

--- a/crates/nous/src/skills.rs
+++ b/crates/nous/src/skills.rs
@@ -38,9 +38,7 @@ pub(crate) fn extract_task_context(content: &str) -> String {
 
 /// Format a [`SkillContent`] as a compact markdown section for the system prompt.
 #[cfg(any(feature = "knowledge-store", test))]
-pub(crate) fn format_skill_as_markdown(
-    skill: &aletheia_mneme::skill::SkillContent,
-) -> String {
+pub(crate) fn format_skill_as_markdown(skill: &aletheia_mneme::skill::SkillContent) -> String {
     use std::fmt::Write as _;
 
     let mut md = format!("**{}**\n\n{}", skill.name, skill.description);
@@ -273,10 +271,7 @@ pub(crate) fn rank_skills(candidates: Vec<Fact>) -> Vec<Fact> {
             )]
             let access_score = (fact.access_count.min(20) as f64) / 20.0;
 
-            let reference_secs = fact
-                .last_accessed_at
-                .unwrap_or(fact.valid_from)
-                .as_second();
+            let reference_secs = fact.last_accessed_at.unwrap_or(fact.valid_from).as_second();
             let age_days = ((now_secs - reference_secs).max(0) as f64) / 86_400.0;
             // Half-life of 30 days: recency = 2^(-age/30)
             let recency_score = 2_f64.powf(-age_days / 30.0);
@@ -327,7 +322,10 @@ mod tests {
     fn extract_task_context_truncates_long_input() {
         let long = "a".repeat(250);
         let ctx = extract_task_context(&long);
-        assert!(ctx.len() <= MAX_CONTEXT_CHARS, "should be truncated to ≤200 chars");
+        assert!(
+            ctx.len() <= MAX_CONTEXT_CHARS,
+            "should be truncated to ≤200 chars"
+        );
     }
 
     #[test]
@@ -422,8 +420,7 @@ mod tests {
             confidence,
             tier: aletheia_mneme::knowledge::EpistemicTier::Verified,
             valid_from: jiff::Timestamp::now(),
-            valid_to: jiff::Timestamp::from_second(i64::MAX / 2)
-                .unwrap_or(jiff::Timestamp::now()),
+            valid_to: jiff::Timestamp::from_second(i64::MAX / 2).unwrap_or(jiff::Timestamp::now()),
             superseded_by: None,
             source_session_id: None,
             recorded_at: jiff::Timestamp::now(),

--- a/crates/pylon/src/handlers/knowledge.rs
+++ b/crates/pylon/src/handlers/knowledge.rs
@@ -374,7 +374,10 @@ pub async fn timeline(
         // Access events (summarized)
         if fact.access_count > 0 && fact.last_accessed_at.is_some() {
             events.push(TimelineEvent {
-                timestamp: fact.last_accessed_at.map(|t| t.to_string()).unwrap_or_default(),
+                timestamp: fact
+                    .last_accessed_at
+                    .map(|t| t.to_string())
+                    .unwrap_or_default(),
                 event_type: "accessed".to_string(),
                 description: format!(
                     "{} accesses, stability: {:.0}h",


### PR DESCRIPTION
## Summary

Implements **Prompt #174** — the final piece of the skill auto-capture pipeline. After #168 (SkillLoader), #173 (Heuristics), and #169 (Export), this adds LLM-based skill extraction from promoted candidates and wires the full pipeline into the actor's post-turn flow.

## Pipeline Flow

```
Turn completes → tool_calls collected
  → maybe_spawn_skill_analysis()
    → Convert ToolCalls → ToolCallRecords
    → Heuristic filter (score_sequence)
    → CandidateTracker (signature hash, recurrence)
    → If promoted (recurrence ≥ 3):
      → spawn_skill_extraction() (background task)
        → LLM extraction via SkillExtractor<P>
        → Dedup check (tool overlap + name similarity)
        → Store as fact_type = "skill_pending"
        → Human reviews via CLI: aletheia review-skills
        → Approve → fact_type = "skill" (active)
```

## Changes

### `crates/mneme/src/skills/extract.rs` (NEW — 699 lines)
- `SkillExtractionProvider` trait — LLM interface, keeps mneme independent of hermeneus
- `SkillExtractor<P>` — builds extraction prompt from candidate metadata + tool call sequences
- `ExtractedSkill` — intermediate JSON representation from LLM response
- `PendingSkill` — wrapper with `pending_review`/`approved`/`rejected` status lifecycle
- Robust JSON response parsing: bare JSON, markdown fences, surrounding text
- **23 tests**: prompt construction, response parsing, round-trips, error cases

### `crates/mneme/src/knowledge_store.rs` (+218 lines)
- `find_pending_skills(nous_id)` — queries `fact_type = "skill_pending"`
- `approve_pending_skill()` — promotes to `fact_type = "skill"`, forgets pending
- `reject_pending_skill()` — marks as forgotten
- `find_duplicate_skill()` — Jaccard tool overlap + LCS name similarity dedup
- Helper functions: `compute_tool_overlap`, `compute_name_similarity`, `lcs_char_length`

### `crates/nous/src/actor.rs` (+224 lines)
- `candidate_tracker: Arc<CandidateTracker>` field on `NousActor`
- `maybe_spawn_skill_analysis()` — post-turn hook in both `handle_turn` and `handle_streaming_turn`
- `spawn_skill_extraction()` + `run_skill_extraction()` — background extraction with dedup + storage

### `crates/nous/src/extraction.rs` (+64 lines)
- `HermeneusSkillExtractionProvider` — bridges hermeneus providers to mneme's `SkillExtractionProvider` trait

### `crates/aletheia/src/main.rs` (+113 lines)
- `aletheia review-skills --nous-id <id> --action list|approve|reject [--fact-id <id>]`
- Lists pending skills with full metadata; approve/reject workflow

## Design Decisions
- **Human review gate**: extracted skills are `skill_pending`, never auto-activated
- **Cost-effective**: uses extraction config model (Haiku) for LLM calls
- **Dedup threshold**: `tool_overlap > 0.85 OR (tool_overlap > 0.6 AND name_sim > 0.5)`
- **In-memory candidate tracker**: per-actor, doesn't survive restarts (rebuilt from recurrence)
- **Pure library functions**: `SkillExtractor`, `PendingSkill`, dedup helpers all reusable by CLI, energeia bridge, and tests

## Tests
- 23 new tests in `extract.rs` (prompt, parsing, serialization, extractor integration)
- All 547 mneme tests pass
- All 300 nous tests pass
- Clippy clean on mneme + nous targets

## Also included
- `cargo fmt` normalization on `skills.rs`, `knowledge.rs` handler (whitespace only)