### PR TITLE
chore(mneme): strip engine copyright headers and audit comments

### DIFF
--- a/crates/mneme/src/engine/data/aggr.rs
+++ b/crates/mneme/src/engine/data/aggr.rs
@@ -1,6 +1,4 @@
-// Originally derived from CozoDB v0.7.6 (MPL-2.0).
-// Copyright 2022, The Cozo Project Authors — see NOTICE for details.
-
+//! Aggregation operators for Datalog queries.
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::{Debug, Formatter};
 

--- a/crates/mneme/src/engine/data/expr.rs
+++ b/crates/mneme/src/engine/data/expr.rs
@@ -1,6 +1,4 @@
-// Originally derived from CozoDB v0.7.6 (MPL-2.0).
-// Copyright 2022, The Cozo Project Authors — see NOTICE for details.
-
+//! Expression evaluation and representation.
 use std::cmp::{max, min};
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::{Debug, Display, Formatter};
@@ -99,12 +97,7 @@ pub fn eval_bytecode(
 ) -> Result<DataValue> {
     stack.clear();
     let mut pointer = 0;
-    // for (i, c) in bytecodes.iter().enumerate() {
-    //     println!("{i}  {c:?}");
-    // }
-    // println!();
     loop {
-        // println!("{pointer}  {stack:?}");
         if pointer == bytecodes.len() {
             break;
         }
@@ -428,11 +421,7 @@ impl Expr {
                     cond.do_binding_indices(coll)?;
                     val.do_binding_indices(coll)?;
                 }
-            } // Expr::Try { clauses, .. } => {
-            //     for clause in clauses {
-            //         clause.do_binding_indices(coll)
-            //     }
-            // }
+            }
             Expr::UnboundApply { op, span, .. } => {
                 bail!(NoImplementationError(*span, op.to_string()));
             }
@@ -647,9 +636,7 @@ impl Expr {
                                     StrRangeScanError(val.clone(), symb.span)
                                 })?;
                                 let lower = DataValue::from(s);
-                                // let lower = DataValue::Str(s.to_string());
                                 let mut upper = CompactString::from(s);
-                                // let mut upper = s.to_string();
                                 upper.push(LARGEST_UTF_CHAR);
                                 let upper = DataValue::Str(upper);
                                 return Ok(ValueRange::new(lower, upper));

--- a/crates/mneme/src/engine/data/functions.rs
+++ b/crates/mneme/src/engine/data/functions.rs
@@ -1,6 +1,4 @@
-// Originally derived from CozoDB v0.7.6 (MPL-2.0).
-// Copyright 2022, The Cozo Project Authors — see NOTICE for details.
-
+//! Built-in scalar functions.
 use std::cmp::Reverse;
 use std::collections::BTreeSet;
 use std::mem;
@@ -2103,6 +2101,11 @@ pub(crate) fn op_vec(args: &[DataValue]) -> Result<DataValue> {
             match t {
                 VecElementType::F32 => {
                     let f32_count = bytes.len() / mem::size_of::<f32>();
+                    // SAFETY: `bytes` was produced by base64-decoding a serialised
+                    // f32 vector (written by `Vector::serialize`). `f32_count` is
+                    // `bytes.len() / size_of::<f32>()`, so the pointer covers exactly
+                    // `f32_count` valid f32-sized elements. The view is immediately
+                    // converted to an owned array, so no aliasing or lifetime issues.
                     let arr = unsafe {
                         ndarray::ArrayView1::from_shape_ptr(
                             ndarray::Dim([f32_count]),
@@ -2113,6 +2116,11 @@ pub(crate) fn op_vec(args: &[DataValue]) -> Result<DataValue> {
                 }
                 VecElementType::F64 => {
                     let f64_count = bytes.len() / mem::size_of::<f64>();
+                    // SAFETY: `bytes` was produced by base64-decoding a serialised
+                    // f64 vector (written by `Vector::serialize`). `f64_count` is
+                    // `bytes.len() / size_of::<f64>()`, so the pointer covers exactly
+                    // `f64_count` valid f64-sized elements. The view is immediately
+                    // converted to an owned array, so no aliasing or lifetime issues.
                     let arr = unsafe {
                         ndarray::ArrayView1::from_shape_ptr(
                             ndarray::Dim([f64_count]),

--- a/crates/mneme/src/engine/data/json.rs
+++ b/crates/mneme/src/engine/data/json.rs
@@ -1,6 +1,4 @@
-// Originally derived from CozoDB v0.7.6 (MPL-2.0).
-// Copyright 2022, The Cozo Project Authors — see NOTICE for details.
-
+//! JSON serialization and deserialization for data values.
 use base64::Engine;
 use base64::engine::general_purpose::STANDARD;
 pub(crate) use serde_json::Value as JsonValue;

--- a/crates/mneme/src/engine/data/memcmp.rs
+++ b/crates/mneme/src/engine/data/memcmp.rs
@@ -1,6 +1,4 @@
-// Originally derived from CozoDB v0.7.6 (MPL-2.0).
-// Copyright 2022, The Cozo Project Authors — see NOTICE for details.
-
+//! Memory-comparable encoding for composite keys.
 use std::cmp::Reverse;
 use std::collections::BTreeSet;
 use std::io::Write;
@@ -250,6 +248,9 @@ impl DataValue {
             }
             STR_TAG => {
                 let (bytes, remaining) = decode_bytes(remaining);
+                // SAFETY: These bytes were produced by `encode_datavalue` for a
+                // `DataValue::Str`, which called `s.as_bytes()` on a valid Rust `&str`.
+                // UTF-8 validity is therefore guaranteed by the encoding invariant.
                 let s = unsafe { String::from_utf8_unchecked(bytes) };
                 (DataValue::Str(s.into()), remaining)
             }
@@ -276,6 +277,10 @@ impl DataValue {
             }
             REGEX_TAG => {
                 let (bytes, remaining) = decode_bytes(remaining);
+                // SAFETY: These bytes were produced by `encode_datavalue` for a
+                // `DataValue::Regex`, which serialised the regex source string via
+                // `s.as_bytes()`. The original source is a valid Rust `&str`, so
+                // UTF-8 validity is guaranteed by the encoding invariant.
                 let s = unsafe { String::from_utf8_unchecked(bytes) };
                 (
                     DataValue::Regex(RegexWrapper(Regex::from_str(&s).unwrap())),

--- a/crates/mneme/src/engine/data/mod.rs
+++ b/crates/mneme/src/engine/data/mod.rs
@@ -1,7 +1,4 @@
-// Originally derived from CozoDB v0.7.6 (MPL-2.0).
-// Copyright 2022, The Cozo Project Authors — see NOTICE for details.
-
-// Suppress clippy lints for vendored engine code.
+//! Core data types for the Datalog engine.
 #[allow(
     warnings,
     clippy::all,

--- a/crates/mneme/src/engine/data/program.rs
+++ b/crates/mneme/src/engine/data/program.rs
@@ -1,6 +1,4 @@
-// Originally derived from CozoDB v0.7.6 (MPL-2.0).
-// Copyright 2022, The Cozo Project Authors — see NOTICE for details.
-
+//! Datalog program representation.
 use std::collections::btree_map::Entry;
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::{Debug, Display, Formatter};
@@ -226,21 +224,6 @@ impl InputInlineRulesOrFixed {
             InputInlineRulesOrFixed::Fixed { fixed, .. } => fixed.span,
         }
     }
-    // pub(crate) fn used_rule(&self, rule_name: &Symbol) -> bool {
-    //     match self {
-    //         InputInlineRulesOrFixed::Rules { rules, .. } => rules
-    //             .iter()
-    //             .any(|rule| rule.body.iter().any(|atom| atom.used_rule(rule_name))),
-    //         InputInlineRulesOrFixed::Fixed { fixed, .. } => fixed.rule_args.iter().any(|arg| {
-    //             if let FixedRuleArg::InMem { name, .. } = arg {
-    //                 if name == rule_name {
-    //                     return true;
-    //                 }
-    //             }
-    //             false
-    //         }),
-    //     }
-    // }
 }
 
 #[derive(Clone)]
@@ -1011,12 +994,9 @@ pub(crate) struct FtsSearch {
     pub(crate) manifest: FtsIndexManifest,
     pub(crate) bindings: Vec<Symbol>,
     pub(crate) k: usize,
-    // pub(crate) k1: f64,
-    // pub(crate) b: f64,
     pub(crate) query: Symbol,
     pub(crate) score_kind: FtsScoreKind,
     pub(crate) bind_score: Option<Symbol>,
-    // pub(crate) lax_mode: bool,
     pub(crate) filter: Option<Expr>,
     pub(crate) span: SourceSpan,
 }
@@ -1786,16 +1766,6 @@ impl Display for InputAtom {
 }
 
 impl InputAtom {
-    // pub(crate) fn used_rule(&self, rule_name: &Symbol) -> bool {
-    //     match self {
-    //         InputAtom::Rule { inner } => inner.name == *rule_name,
-    //         InputAtom::Negation { inner, .. } => inner.used_rule(rule_name),
-    //         InputAtom::Conjunction { inner, .. } | InputAtom::Disjunction { inner, .. } => {
-    //             inner.iter().any(|a| a.used_rule(rule_name))
-    //         }
-    //         _ => false,
-    //     }
-    // }
     pub(crate) fn span(&self) -> SourceSpan {
         match self {
             InputAtom::Negation { span, .. }

--- a/crates/mneme/src/engine/data/relation.rs
+++ b/crates/mneme/src/engine/data/relation.rs
@@ -1,6 +1,4 @@
-// Originally derived from CozoDB v0.7.6 (MPL-2.0).
-// Copyright 2022, The Cozo Project Authors — see NOTICE for details.
-
+//! Relation metadata and schema definitions.
 use crate::engine::error::DbResult as Result;
 use crate::{bail, ensure};
 use base64::Engine;
@@ -349,6 +347,11 @@ impl NullableColType {
                             if f32_count != *len {
                                 bail!(make_err())
                             }
+                            // SAFETY: `bytes` is a base64-decoded f32 vector payload.
+                            // The length check above ensures `f32_count == *len`, so
+                            // the pointer covers exactly `f32_count` f32-aligned elements
+                            // within the live `bytes` allocation. The view is immediately
+                            // converted to an owned array before `bytes` is dropped.
                             let arr = unsafe {
                                 ndarray::ArrayView1::from_shape_ptr(
                                     ndarray::Dim([f32_count]),
@@ -362,6 +365,11 @@ impl NullableColType {
                             if f64_count != *len {
                                 bail!(make_err())
                             }
+                            // SAFETY: `bytes` is a base64-decoded f64 vector payload.
+                            // The length check above ensures `f64_count == *len`, so
+                            // the pointer covers exactly `f64_count` f64-aligned elements
+                            // within the live `bytes` allocation. The view is immediately
+                            // converted to an owned array before `bytes` is dropped.
                             let arr = unsafe {
                                 ndarray::ArrayView1::from_shape_ptr(
                                     ndarray::Dim([f64_count]),

--- a/crates/mneme/src/engine/data/symb.rs
+++ b/crates/mneme/src/engine/data/symb.rs
@@ -1,6 +1,4 @@
-// Originally derived from CozoDB v0.7.6 (MPL-2.0).
-// Copyright 2022, The Cozo Project Authors — see NOTICE for details.
-
+//! Symbol (identifier) types.
 use std::cmp::Ordering;
 use std::fmt::{Debug, Display, Formatter};
 use std::hash::{Hash, Hasher};

--- a/crates/mneme/src/engine/data/tests/aggrs.rs
+++ b/crates/mneme/src/engine/data/tests/aggrs.rs
@@ -1,6 +1,4 @@
-// Originally derived from CozoDB v0.7.6 (MPL-2.0).
-// Copyright 2022, The Cozo Project Authors — see NOTICE for details.
-
+//! Tests for aggregation operators.
 use itertools::Itertools;
 
 use crate::engine::data::aggr::parse_aggr;

--- a/crates/mneme/src/engine/data/tests/exprs.rs
+++ b/crates/mneme/src/engine/data/tests/exprs.rs
@@ -1,6 +1,4 @@
-// Originally derived from CozoDB v0.7.6 (MPL-2.0).
-// Copyright 2022, The Cozo Project Authors — see NOTICE for details.
-
+//! Tests for expression evaluation.
 use crate::engine::{DataValue, DbInstance};
 
 #[test]

--- a/crates/mneme/src/engine/data/tests/functions.rs
+++ b/crates/mneme/src/engine/data/tests/functions.rs
@@ -1,6 +1,4 @@
-// Originally derived from CozoDB v0.7.6 (MPL-2.0).
-// Copyright 2022, The Cozo Project Authors — see NOTICE for details.
-
+//! Tests for built-in functions.
 use regex::Regex;
 use serde_json::json;
 use std::f64::consts::{E, PI};

--- a/crates/mneme/src/engine/data/tests/json.rs
+++ b/crates/mneme/src/engine/data/tests/json.rs
@@ -1,6 +1,4 @@
-// Originally derived from CozoDB v0.7.6 (MPL-2.0).
-// Copyright 2022, The Cozo Project Authors — see NOTICE for details.
-
+//! Tests for JSON round-tripping.
 use serde_json::json;
 
 use crate::engine::data::json::JsonValue;

--- a/crates/mneme/src/engine/data/tests/memcmp.rs
+++ b/crates/mneme/src/engine/data/tests/memcmp.rs
@@ -1,6 +1,4 @@
-// Originally derived from CozoDB v0.7.6 (MPL-2.0).
-// Copyright 2022, The Cozo Project Authors — see NOTICE for details.
-
+//! Tests for memory-comparable encoding.
 use uuid::Uuid;
 
 use crate::engine::data::memcmp::{MemCmpEncoder, decode_bytes};

--- a/crates/mneme/src/engine/data/tests/mod.rs
+++ b/crates/mneme/src/engine/data/tests/mod.rs
@@ -1,6 +1,4 @@
-// Originally derived from CozoDB v0.7.6 (MPL-2.0).
-// Copyright 2022, The Cozo Project Authors — see NOTICE for details.
-
+//! Test module for engine data types.
 mod aggrs;
 mod exprs;
 mod functions;

--- a/crates/mneme/src/engine/data/tests/validity.rs
+++ b/crates/mneme/src/engine/data/tests/validity.rs
@@ -1,6 +1,4 @@
-// Originally derived from CozoDB v0.7.6 (MPL-2.0).
-// Copyright 2022, The Cozo Project Authors — see NOTICE for details.
-
+//! Tests for temporal validity ranges.
 use crate::engine::DbInstance;
 use crate::engine::data::value::DataValue;
 use serde_json::json;

--- a/crates/mneme/src/engine/data/tests/values.rs
+++ b/crates/mneme/src/engine/data/tests/values.rs
@@ -1,6 +1,4 @@
-// Originally derived from CozoDB v0.7.6 (MPL-2.0).
-// Copyright 2022, The Cozo Project Authors — see NOTICE for details.
-
+//! Tests for core value type.
 use std::collections::{BTreeMap, HashMap};
 use std::mem::size_of;
 

--- a/crates/mneme/src/engine/data/tuple.rs
+++ b/crates/mneme/src/engine/data/tuple.rs
@@ -1,6 +1,4 @@
-// Originally derived from CozoDB v0.7.6 (MPL-2.0).
-// Copyright 2022, The Cozo Project Authors — see NOTICE for details.
-
+//! Tuple encoding and decoding.
 use crate::engine::data::functions::TERMINAL_VALIDITY;
 use crate::engine::error::DbResult as Result;
 use std::cmp::Reverse;

--- a/crates/mneme/src/engine/data/value.rs
+++ b/crates/mneme/src/engine/data/value.rs
@@ -1,6 +1,4 @@
-// Originally derived from CozoDB v0.7.6 (MPL-2.0).
-// Copyright 2022, The Cozo Project Authors — see NOTICE for details.
-
+//! Core value type for the Datalog engine.
 use base64::Engine;
 use base64::engine::general_purpose::STANDARD;
 use ndarray::Array1;
@@ -211,6 +209,9 @@ impl serde::Serialize for Vector {
                 let arr = a.as_slice().unwrap();
                 let len = std::mem::size_of_val(arr);
                 let ptr = arr.as_ptr() as *const u8;
+                // SAFETY: `ptr` comes from a valid &[f32] allocation. Reinterpreting as
+                // &[u8] is safe because u8 has alignment 1 (always satisfied) and `len`
+                // is exactly `size_of_val(arr)` — the true byte length of the slice.
                 let bytes = unsafe { std::slice::from_raw_parts(ptr, len) };
                 state.serialize_element(&VecBytes(bytes))?;
             }
@@ -219,6 +220,9 @@ impl serde::Serialize for Vector {
                 let arr = a.as_slice().unwrap();
                 let len = std::mem::size_of_val(arr);
                 let ptr = arr.as_ptr() as *const u8;
+                // SAFETY: `ptr` comes from a valid &[f64] allocation. Reinterpreting as
+                // &[u8] is safe because u8 has alignment 1 (always satisfied) and `len`
+                // is exactly `size_of_val(arr)` — the true byte length of the slice.
                 let bytes = unsafe { std::slice::from_raw_parts(ptr, len) };
                 state.serialize_element(&VecBytes(bytes))?;
             }
@@ -260,6 +264,10 @@ impl<'de> Visitor<'de> for VectorVisitor {
                 let mut v = vec![];
                 v.reserve_exact(len);
                 let ptr = v.as_mut_ptr() as *mut u8;
+                // SAFETY: `v` has capacity for `len` f32 values, which is exactly
+                // `bytes.len()` bytes. `copy_nonoverlapping` writes into the reserved
+                // (but not yet initialized) capacity. After the copy every element is
+                // initialised, so `set_len(len)` is sound.
                 unsafe {
                     std::ptr::copy_nonoverlapping(bytes.as_ptr(), ptr, bytes.len());
                     v.set_len(len);
@@ -271,6 +279,10 @@ impl<'de> Visitor<'de> for VectorVisitor {
                 let mut v = vec![];
                 v.reserve_exact(len);
                 let ptr = v.as_mut_ptr() as *mut u8;
+                // SAFETY: `v` has capacity for `len` f64 values, which is exactly
+                // `bytes.len()` bytes. `copy_nonoverlapping` writes into the reserved
+                // (but not yet initialized) capacity. After the copy every element is
+                // initialised, so `set_len(len)` is sound.
                 unsafe {
                     std::ptr::copy_nonoverlapping(bytes.as_ptr(), ptr, bytes.len());
                     v.set_len(len);

--- a/crates/mneme/src/engine/datalog.pest
+++ b/crates/mneme/src/engine/datalog.pest
@@ -1,7 +1,4 @@
-// Originally derived from CozoDB v0.7.6 (MPL-2.0).
-// Copyright 2022, The Cozo Project Authors — see NOTICE for details.
-
-
+// Datalog grammar for the query parser.
 script = _{sys_script | imperative_script | query_script}
 query_script = {SOI ~ (option | rule | const_rule | fixed_rule)+ ~ EOI}
 query_script_inner = {"{" ~ (option | rule | const_rule | fixed_rule)+ ~ "}"}

--- a/crates/mneme/src/engine/error.rs
+++ b/crates/mneme/src/engine/error.rs
@@ -1,4 +1,4 @@
-// Public crate-level error type for mneme-engine.
+//! Error types for the Datalog engine.
 use snafu::Snafu;
 
 /// Top-level error type for the mneme-engine public API.

--- a/crates/mneme/src/engine/fixed_rule/algos/all_pairs_shortest_path.rs
+++ b/crates/mneme/src/engine/fixed_rule/algos/all_pairs_shortest_path.rs
@@ -1,6 +1,4 @@
-// Originally derived from CozoDB v0.7.6 (MPL-2.0).
-// Copyright 2022, The Cozo Project Authors — see NOTICE for details.
-
+//! All-pairs shortest path (Floyd-Warshall).
 use crate::engine::error::DbResult as Result;
 use crate::engine::fixed_rule::csr::DirectedCsrGraph;
 use std::cmp::Reverse;

--- a/crates/mneme/src/engine/fixed_rule/algos/astar.rs
+++ b/crates/mneme/src/engine/fixed_rule/algos/astar.rs
@@ -1,6 +1,4 @@
-// Originally derived from CozoDB v0.7.6 (MPL-2.0).
-// Copyright 2022, The Cozo Project Authors — see NOTICE for details.
-
+//! A* shortest path search.
 use std::cmp::Reverse;
 use std::collections::BTreeMap;
 

--- a/crates/mneme/src/engine/fixed_rule/algos/bfs.rs
+++ b/crates/mneme/src/engine/fixed_rule/algos/bfs.rs
@@ -1,6 +1,4 @@
-// Originally derived from CozoDB v0.7.6 (MPL-2.0).
-// Copyright 2022, The Cozo Project Authors — see NOTICE for details.
-
+//! Breadth-first search traversal.
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 
 use crate::engine::error::DbResult as Result;

--- a/crates/mneme/src/engine/fixed_rule/algos/degree_centrality.rs
+++ b/crates/mneme/src/engine/fixed_rule/algos/degree_centrality.rs
@@ -1,6 +1,4 @@
-// Originally derived from CozoDB v0.7.6 (MPL-2.0).
-// Copyright 2022, The Cozo Project Authors — see NOTICE for details.
-
+//! Degree centrality computation.
 use std::collections::BTreeMap;
 
 use crate::engine::error::DbResult as Result;

--- a/crates/mneme/src/engine/fixed_rule/algos/dfs.rs
+++ b/crates/mneme/src/engine/fixed_rule/algos/dfs.rs
@@ -1,6 +1,4 @@
-// Originally derived from CozoDB v0.7.6 (MPL-2.0).
-// Copyright 2022, The Cozo Project Authors — see NOTICE for details.
-
+//! Depth-first search traversal.
 use std::collections::{BTreeMap, BTreeSet};
 
 use crate::engine::error::DbResult as Result;

--- a/crates/mneme/src/engine/fixed_rule/algos/kruskal.rs
+++ b/crates/mneme/src/engine/fixed_rule/algos/kruskal.rs
@@ -1,6 +1,4 @@
-// Originally derived from CozoDB v0.7.6 (MPL-2.0).
-// Copyright 2022, The Cozo Project Authors — see NOTICE for details.
-
+//! Minimum spanning tree (Kruskal).
 use crate::engine::error::DbResult as Result;
 use crate::engine::fixed_rule::csr::DirectedCsrGraph;
 use std::cmp::Reverse;

--- a/crates/mneme/src/engine/fixed_rule/algos/label_propagation.rs
+++ b/crates/mneme/src/engine/fixed_rule/algos/label_propagation.rs
@@ -1,6 +1,4 @@
-// Originally derived from CozoDB v0.7.6 (MPL-2.0).
-// Copyright 2022, The Cozo Project Authors — see NOTICE for details.
-
+//! Label propagation community detection.
 use std::collections::BTreeMap;
 
 use crate::engine::error::DbResult as Result;

--- a/crates/mneme/src/engine/fixed_rule/algos/louvain.rs
+++ b/crates/mneme/src/engine/fixed_rule/algos/louvain.rs
@@ -1,6 +1,4 @@
-// Originally derived from CozoDB v0.7.6 (MPL-2.0).
-// Copyright 2022, The Cozo Project Authors — see NOTICE for details.
-
+//! Louvain community detection.
 use std::collections::{BTreeMap, BTreeSet};
 
 use crate::engine::error::DbResult as Result;

--- a/crates/mneme/src/engine/fixed_rule/algos/mod.rs
+++ b/crates/mneme/src/engine/fixed_rule/algos/mod.rs
@@ -1,6 +1,4 @@
-// Originally derived from CozoDB v0.7.6 (MPL-2.0).
-// Copyright 2022, The Cozo Project Authors — see NOTICE for details.
-
+//! Graph algorithm implementations as fixed rules.
 pub(crate) mod all_pairs_shortest_path;
 pub(crate) mod astar;
 pub(crate) mod bfs;

--- a/crates/mneme/src/engine/fixed_rule/algos/pagerank.rs
+++ b/crates/mneme/src/engine/fixed_rule/algos/pagerank.rs
@@ -1,6 +1,4 @@
-// Originally derived from CozoDB v0.7.6 (MPL-2.0).
-// Copyright 2022, The Cozo Project Authors — see NOTICE for details.
-
+//! PageRank fixed rule.
 use std::collections::BTreeMap;
 
 use crate::engine::error::DbResult as Result;

--- a/crates/mneme/src/engine/fixed_rule/algos/prim.rs
+++ b/crates/mneme/src/engine/fixed_rule/algos/prim.rs
@@ -1,6 +1,4 @@
-// Originally derived from CozoDB v0.7.6 (MPL-2.0).
-// Copyright 2022, The Cozo Project Authors — see NOTICE for details.
-
+//! Minimum spanning tree (Prim).
 use crate::engine::error::DbResult as Result;
 use crate::engine::fixed_rule::csr::DirectedCsrGraph;
 use std::cmp::Reverse;

--- a/crates/mneme/src/engine/fixed_rule/algos/random_walk.rs
+++ b/crates/mneme/src/engine/fixed_rule/algos/random_walk.rs
@@ -1,6 +1,4 @@
-// Originally derived from CozoDB v0.7.6 (MPL-2.0).
-// Copyright 2022, The Cozo Project Authors — see NOTICE for details.
-
+//! Random walk over graphs.
 use std::collections::BTreeMap;
 
 use crate::engine::error::DbResult as Result;

--- a/crates/mneme/src/engine/fixed_rule/algos/shortest_path_bfs.rs
+++ b/crates/mneme/src/engine/fixed_rule/algos/shortest_path_bfs.rs
@@ -1,6 +1,4 @@
-// Originally derived from CozoDB v0.7.6 (MPL-2.0).
-// Copyright 2022, The Cozo Project Authors — see NOTICE for details.
-
+//! Unweighted shortest path via BFS.
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 
 use crate::engine::error::DbResult as Result;

--- a/crates/mneme/src/engine/fixed_rule/algos/shortest_path_dijkstra.rs
+++ b/crates/mneme/src/engine/fixed_rule/algos/shortest_path_dijkstra.rs
@@ -1,6 +1,4 @@
-// Originally derived from CozoDB v0.7.6 (MPL-2.0).
-// Copyright 2022, The Cozo Project Authors — see NOTICE for details.
-
+//! Weighted shortest path (Dijkstra).
 use crate::engine::error::DbResult as Result;
 use crate::engine::fixed_rule::csr::DirectedCsrGraph;
 use std::cmp::{Ordering, Reverse};

--- a/crates/mneme/src/engine/fixed_rule/algos/strongly_connected_components.rs
+++ b/crates/mneme/src/engine/fixed_rule/algos/strongly_connected_components.rs
@@ -1,7 +1,5 @@
-// Originally derived from CozoDB v0.7.6 (MPL-2.0).
-// Copyright 2022, The Cozo Project Authors — see NOTICE for details.
-
-#![allow(unused_imports)]
+//! Tarjan's strongly connected components.
+#![expect(unused_imports, reason = "algorithm may use additional imports depending on feature flags")]
 
 use crate::engine::error::DbResult as Result;
 use crate::engine::fixed_rule::csr::DirectedCsrGraph;

--- a/crates/mneme/src/engine/fixed_rule/algos/top_sort.rs
+++ b/crates/mneme/src/engine/fixed_rule/algos/top_sort.rs
@@ -1,6 +1,4 @@
-// Originally derived from CozoDB v0.7.6 (MPL-2.0).
-// Copyright 2022, The Cozo Project Authors — see NOTICE for details.
-
+//! Topological sort.
 use crate::engine::error::DbResult as Result;
 use crate::engine::fixed_rule::csr::DirectedCsrGraph;
 use std::collections::BTreeMap;

--- a/crates/mneme/src/engine/fixed_rule/algos/triangles.rs
+++ b/crates/mneme/src/engine/fixed_rule/algos/triangles.rs
@@ -1,6 +1,4 @@
-// Originally derived from CozoDB v0.7.6 (MPL-2.0).
-// Copyright 2022, The Cozo Project Authors — see NOTICE for details.
-
+//! Triangle counting in graphs.
 use std::collections::BTreeMap;
 
 use crate::engine::error::DbResult as Result;

--- a/crates/mneme/src/engine/fixed_rule/algos/yen.rs
+++ b/crates/mneme/src/engine/fixed_rule/algos/yen.rs
@@ -1,6 +1,4 @@
-// Originally derived from CozoDB v0.7.6 (MPL-2.0).
-// Copyright 2022, The Cozo Project Authors — see NOTICE for details.
-
+//! Yen's k-shortest paths.
 use std::collections::{BTreeMap, BTreeSet};
 
 use crate::engine::error::DbResult as Result;

--- a/crates/mneme/src/engine/fixed_rule/csr/mod.rs
+++ b/crates/mneme/src/engine/fixed_rule/csr/mod.rs
@@ -1,12 +1,4 @@
-// CSR (Compressed Sparse Row) graph representation.
-//
-// Derived from the `graph` crate (graph_builder 0.4.1, graph 0.3.1).
-// Original authors: Neo4j Labs. Licensed under Apache-2.0.
-// https://crates.io/crates/graph / https://crates.io/crates/graph_builder
-//
-// Absorbed into the engine to eliminate an external dependency with known
-// rayon >=1.11 build breakage and heavy transitive deps (dashmap, memmap2,
-// num, etc.). Only the subset used by engine graph algorithms is retained.
+//! Compressed sparse row graph representation.
 
 mod page_rank;
 

--- a/crates/mneme/src/engine/fixed_rule/csr/page_rank.rs
+++ b/crates/mneme/src/engine/fixed_rule/csr/page_rank.rs
@@ -1,12 +1,4 @@
-// PageRank algorithm for directed CSR graphs.
-//
-// Derived from the `graph` crate (graph 0.3.1).
-// Original authors: Neo4j Labs. Licensed under Apache-2.0.
-// https://crates.io/crates/graph
-//
-// Simplified: single-threaded (graph sizes in this engine are small),
-// no atomic floats, no rayon. The original used thread-scoped parallelism
-// which is unnecessary for the in-process graph algorithm use case.
+//! PageRank over CSR graphs.
 
 use super::DirectedCsrGraph;
 

--- a/crates/mneme/src/engine/fixed_rule/mod.rs
+++ b/crates/mneme/src/engine/fixed_rule/mod.rs
@@ -1,6 +1,4 @@
-// Originally derived from CozoDB v0.7.6 (MPL-2.0).
-// Copyright 2022, The Cozo Project Authors — see NOTICE for details.
-
+//! Fixed (built-in) rules for the Datalog engine.
 use std::collections::BTreeMap;
 use std::sync::Arc;
 

--- a/crates/mneme/src/engine/fixed_rule/utilities/constant.rs
+++ b/crates/mneme/src/engine/fixed_rule/utilities/constant.rs
@@ -1,6 +1,4 @@
-// Originally derived from CozoDB v0.7.6 (MPL-2.0).
-// Copyright 2022, The Cozo Project Authors — see NOTICE for details.
-
+//! Constant-value fixed rule.
 use std::collections::BTreeMap;
 
 use crate::engine::error::DbResult as Result;

--- a/crates/mneme/src/engine/fixed_rule/utilities/mod.rs
+++ b/crates/mneme/src/engine/fixed_rule/utilities/mod.rs
@@ -1,6 +1,4 @@
-// Originally derived from CozoDB v0.7.6 (MPL-2.0).
-// Copyright 2022, The Cozo Project Authors — see NOTICE for details.
-
+//! Utility fixed rules.
 pub(crate) mod constant;
 pub(crate) mod reorder_sort;
 pub(crate) mod rrf;

--- a/crates/mneme/src/engine/fixed_rule/utilities/reorder_sort.rs
+++ b/crates/mneme/src/engine/fixed_rule/utilities/reorder_sort.rs
@@ -1,6 +1,4 @@
-// Originally derived from CozoDB v0.7.6 (MPL-2.0).
-// Copyright 2022, The Cozo Project Authors — see NOTICE for details.
-
+//! Reorder and sort fixed rule.
 use std::collections::BTreeMap;
 
 use crate::bail;

--- a/crates/mneme/src/engine/fixed_rule/utilities/rrf.rs
+++ b/crates/mneme/src/engine/fixed_rule/utilities/rrf.rs
@@ -1,4 +1,4 @@
-// ReciprocalRankFusion fixed rule: fuses BM25, vector, and graph ranked lists.
+//! Reciprocal rank fusion fixed rule.
 
 use std::collections::BTreeMap;
 

--- a/crates/mneme/src/engine/fts/ast.rs
+++ b/crates/mneme/src/engine/fts/ast.rs
@@ -1,6 +1,4 @@
-// Originally derived from CozoDB v0.7.6 (MPL-2.0).
-// Copyright 2023, The Cozo Project Authors — see NOTICE for details.
-
+//! Full-text search query AST.
 use crate::engine::fts::tokenizer::TextAnalyzer;
 use compact_str::CompactString;
 use ordered_float::OrderedFloat;
@@ -46,16 +44,6 @@ pub(crate) enum FtsExpr {
 }
 
 impl FtsExpr {
-    // pub(crate) fn needs_idf(&self) -> bool {
-    //     match self {
-    //         FtsExpr::Literal(_) => false,
-    //         FtsExpr::Near(_) => false,
-    //         FtsExpr::And(exprs) => exprs.iter().any(|e| e.needs_idf()),
-    //         FtsExpr::Or(_) => true,
-    //         FtsExpr::Not(lhs, _) => lhs.needs_idf(),
-    //     }
-    // }
-
     pub(crate) fn tokenize(self, tokenizer: &TextAnalyzer) -> Self {
         self.do_tokenize(tokenizer).flatten()
     }

--- a/crates/mneme/src/engine/fts/indexing.rs
+++ b/crates/mneme/src/engine/fts/indexing.rs
@@ -1,6 +1,4 @@
-// Originally derived from CozoDB v0.7.6 (MPL-2.0).
-// Copyright 2023, The Cozo Project Authors — see NOTICE for details.
-
+//! Full-text search indexing operations.
 use crate::bail;
 use crate::engine::data::expr::{Bytecode, eval_bytecode, eval_bytecode_pred};
 use crate::engine::data::program::{FtsScoreKind, FtsSearch};

--- a/crates/mneme/src/engine/fts/mod.rs
+++ b/crates/mneme/src/engine/fts/mod.rs
@@ -1,6 +1,4 @@
-// Originally derived from CozoDB v0.7.6 (MPL-2.0).
-// Copyright 2023, The Cozo Project Authors — see NOTICE for details.
-
+//! Full-text search subsystem.
 use crate::engine::data::memcmp::MemCmpEncoder;
 use crate::engine::data::value::DataValue;
 use crate::engine::error::DbResult as Result;
@@ -37,7 +35,6 @@ pub struct TokenizerConfig {
 }
 
 impl TokenizerConfig {
-    // use sha256::digest;
     pub(crate) fn config_hash(&self, filters: &[Self]) -> impl AsRef<[u8]> {
         let mut hasher = Sha256::new();
         hasher.update(self.name.as_bytes());

--- a/crates/mneme/src/engine/fts/tokenizer/alphanum_only.rs
+++ b/crates/mneme/src/engine/fts/tokenizer/alphanum_only.rs
@@ -1,24 +1,4 @@
-// # Example
-// ```rust
-// use tantivy::tokenizer::*;
-//
-// let tokenizer = TextAnalyzer::from(RawTokenizer)
-//   .filter(AlphaNumOnlyFilter);
-//
-// let mut stream = tokenizer.token_stream("hello there");
-// // is none because the raw filter emits one token that
-// // contains a space
-// assert!(stream.next().is_none());
-//
-// let tokenizer = TextAnalyzer::from(SimpleTokenizer)
-//   .filter(AlphaNumOnlyFilter);
-//
-// let mut stream = tokenizer.token_stream("hello there 💣");
-// assert!(stream.next().is_some());
-// assert!(stream.next().is_some());
-// // the "emoji" is dropped because its not an alphanum
-// assert!(stream.next().is_none());
-// ```
+//! Filter that removes non-alphanumeric tokens.
 use super::{BoxTokenStream, Token, TokenFilter, TokenStream};
 
 /// `TokenFilter` that removes all tokens that contain non

--- a/crates/mneme/src/engine/fts/tokenizer/ascii_folding_filter.rs
+++ b/crates/mneme/src/engine/fts/tokenizer/ascii_folding_filter.rs
@@ -1,3 +1,4 @@
+//! Folds Unicode characters to ASCII equivalents.
 use std::mem;
 
 use super::{BoxTokenStream, Token, TokenFilter, TokenStream};
@@ -44,11 +45,6 @@ impl<'a> TokenStream for AsciiFoldingFilterTokenStream<'a> {
     }
 }
 
-// Returns a string that represents the ascii folded version of
-// the character. If the `char` does not require ascii folding
-// (e.g. simple ASCII chars like `A`) or if the `char`
-// does not have a sensible ascii equivalent (e.g.: Kanjis like 馬,
-// this function returns `None`.
 fn fold_non_ascii_char(c: char) -> Option<&'static str> {
     match c {
         '\u{00C0}' | // À  [LATIN CAPITAL LETTER A WITH GRAVE]

--- a/crates/mneme/src/engine/fts/tokenizer/empty_tokenizer.rs
+++ b/crates/mneme/src/engine/fts/tokenizer/empty_tokenizer.rs
@@ -1,3 +1,4 @@
+//! No-op tokenizer producing zero tokens.
 use crate::engine::fts::tokenizer::{BoxTokenStream, Token, TokenStream, Tokenizer};
 
 #[derive(Clone)]

--- a/crates/mneme/src/engine/fts/tokenizer/lower_caser.rs
+++ b/crates/mneme/src/engine/fts/tokenizer/lower_caser.rs
@@ -1,3 +1,4 @@
+//! Lowercasing token filter.
 use std::mem;
 
 use super::{Token, TokenFilter, TokenStream};

--- a/crates/mneme/src/engine/fts/tokenizer/mod.rs
+++ b/crates/mneme/src/engine/fts/tokenizer/mod.rs
@@ -1,126 +1,4 @@
-// Originally derived from CozoDB v0.7.6 (MPL-2.0).
-// Tokenizer code adapted from the Tantivy project (MIT license).
-// https://github.com/quickwit-oss/tantivy/tree/0.19.2/src/tokenizer
-
-//! Tokenizer are in charge of chopping text into a stream of tokens
-//! ready for indexing.
-//!
-//! You must define in your schema which tokenizer should be used for
-//! each of your fields :
-//!
-//! ```text
-//! use tantivy::schema::*;
-//!
-//! let mut schema_builder = Schema::builder();
-//!
-//! let text_options = TextOptions::default()
-//!     .set_indexing_options(
-//!         TextFieldIndexing::default()
-//!             .set_tokenizer("en_stem")
-//!             .set_index_option(IndexRecordOption::Basic)
-//!     )
-//!     .set_stored();
-//!
-//! let id_options = TextOptions::default()
-//!     .set_indexing_options(
-//!         TextFieldIndexing::default()
-//!             .set_tokenizer("raw_ids")
-//!             .set_index_option(IndexRecordOption::WithFreqsAndPositions)
-//!     )
-//!     .set_stored();
-//!
-//! schema_builder.add_text_field("title", text_options.clone());
-//! schema_builder.add_text_field("text", text_options);
-//! schema_builder.add_text_field("uuid", id_options);
-//!
-//! let schema = schema_builder.build();
-//! ```
-//!
-//! By default, `tantivy` offers the following tokenizers:
-//!
-//! ## `default`
-//!
-//! `default` is the tokenizer that will be used if you do not
-//! assign a specific tokenizer to your text field.
-//! It will chop your text on punctuation and whitespaces,
-//! removes tokens that are longer than 40 chars, and lowercase your text.
-//!
-//! ## `raw`
-//! Does not actual tokenizer your text. It keeps it entirely unprocessed.
-//! It can be useful to index uuids, or urls for instance.
-//!
-//! ## `en_stem`
-//!
-//! In addition to what `default` does, the `en_stem` tokenizer also
-//! apply stemming to your tokens. Stemming consists in trimming words to
-//! remove their inflection. This tokenizer is slower than the default one,
-//! but is recommended to improve recall.
-//!
-//!
-//! # Custom tokenizers
-//!
-//! You can write your own tokenizer by implementing the [`Tokenizer`] trait
-//! or you can extend an existing [`Tokenizer`] by chaining it with several
-//! [`TokenFilter`]s.
-//!
-//! For instance, the `en_stem` is defined as follows.
-//!
-//! ```text
-//! use tantivy::tokenizer::*;
-//!
-//! let en_stem = TextAnalyzer::from(SimpleTokenizer)
-//!     .filter(RemoveLongFilter::limit(40))
-//!     .filter(LowerCaser)
-//!     .filter(Stemmer::new(Language::English));
-//! ```
-//!
-//! Once your tokenizer is defined, you need to
-//! register it with a name in your index's [`TokenizerManager`].
-//!
-//! ```text
-//! # use tantivy::schema::Schema;
-//! # use tantivy::tokenizer::*;
-//! # use tantivy::Index;
-//! #
-//! let custom_en_tokenizer = SimpleTokenizer;
-//! # let schema = Schema::builder().build();
-//! let index = Index::create_in_ram(schema);
-//! index.tokenizers()
-//!      .register("custom_en", custom_en_tokenizer);
-//! ```
-//!
-//! If you built your schema programmatically, a complete example
-//! could like this for instance.
-//!
-//! Note that tokens with a len greater or equal to
-//! [`MAX_TOKEN_LEN`].
-//!
-//! # Example
-//!
-//! ```text
-//! use tantivy::schema::{Schema, IndexRecordOption, TextOptions, TextFieldIndexing};
-//! use tantivy::tokenizer::*;
-//! use tantivy::Index;
-//!
-//! let mut schema_builder = Schema::builder();
-//! let text_field_indexing = TextFieldIndexing::default()
-//!     .set_tokenizer("custom_en")
-//!     .set_index_option(IndexRecordOption::WithFreqsAndPositions);
-//! let text_options = TextOptions::default()
-//!     .set_indexing_options(text_field_indexing)
-//!     .set_stored();
-//! schema_builder.add_text_field("title", text_options);
-//! let schema = schema_builder.build();
-//! let index = Index::create_in_ram(schema);
-//!
-//! // We need to register our tokenizer :
-//! let custom_en_tokenizer = TextAnalyzer::from(SimpleTokenizer)
-//!     .filter(RemoveLongFilter::limit(40))
-//!     .filter(LowerCaser);
-//! index
-//!     .tokenizers()
-//!     .register("custom_en", custom_en_tokenizer);
-//! ```
+//! Text tokenization pipeline for full-text search indexing.
 mod alphanum_only;
 mod ascii_folding_filter;
 mod empty_tokenizer;
@@ -146,7 +24,6 @@ pub(crate) use self::simple_tokenizer::SimpleTokenizer;
 pub(crate) use self::split_compound_words::SplitCompoundWords;
 pub(crate) use self::stemmer::{Language, Stemmer};
 pub(crate) use self::stop_word_filter::StopWordFilter;
-// pub(crate) use self::tokenized_string::{PreTokenizedStream, PreTokenizedString};
 pub(crate) use self::tokenizer_impl::{
     BoxTokenFilter, BoxTokenStream, TextAnalyzer, Token, TokenFilter, TokenStream, Tokenizer,
 };
@@ -154,15 +31,8 @@ pub(crate) use self::whitespace_tokenizer::WhitespaceTokenizer;
 
 #[cfg(test)]
 pub(crate) mod tests {
-    // use super::{
-    //     Language, LowerCaser, RemoveLongFilter, SimpleTokenizer, Stemmer, Token,
-    // };
-    // use crate::engine::fts::tokenizer::TextAnalyzer;
-
     use crate::engine::fts::tokenizer::Token;
 
-    /// This is a function that can be used in tests and doc tests
-    /// to assert a token's correctness.
     pub(crate) fn assert_token(token: &Token, position: usize, text: &str, from: usize, to: usize) {
         assert_eq!(
             token.position, position,

--- a/crates/mneme/src/engine/fts/tokenizer/ngram_tokenizer.rs
+++ b/crates/mneme/src/engine/fts/tokenizer/ngram_tokenizer.rs
@@ -1,3 +1,4 @@
+//! N-gram tokenizer.
 use super::{Token, TokenStream, Tokenizer};
 use crate::engine::fts::tokenizer::BoxTokenStream;
 
@@ -105,18 +106,6 @@ impl NgramTokenizer {
         }
     }
 
-    // /// Create a `NGramTokenizer` which generates tokens for all inner ngrams.
-    // ///
-    // /// This is as opposed to only prefix ngrams    .
-    // pub(crate) fn all_ngrams(min_gram: usize, max_gram: usize) -> NgramTokenizer {
-    //     Self::new(min_gram, max_gram, false)
-    // }
-    //
-    // /// Create a `NGramTokenizer` which only generates tokens for the
-    // /// prefix ngrams.
-    // pub(crate) fn prefix_only(min_gram: usize, max_gram: usize) -> NgramTokenizer {
-    //     Self::new(min_gram, max_gram, true)
-    // }
 }
 
 /// TokenStream associate to the `NgramTokenizer`
@@ -307,15 +296,6 @@ fn utf8_codepoint_width(b: u8) -> usize {
 mod tests {
 
     use super::{CodepointFrontiers, StutteringIterator, utf8_codepoint_width};
-    // use crate::engine::fts::tokenizer::tests::assert_token;
-    // use crate::engine::fts::tokenizer::tokenizer_impl::Tokenizer;
-    // use crate::engine::fts::tokenizer::{BoxTokenStream, Token};
-
-    // fn test_helper(mut tokenizer: BoxTokenStream<'_>) -> Vec<Token> {
-    //     let mut tokens: Vec<Token> = vec![];
-    //     tokenizer.process(&mut |token: &Token| tokens.push(token.clone()));
-    //     tokens
-    // }
 
     #[test]
     fn test_utf8_codepoint_width() {
@@ -349,85 +329,6 @@ mod tests {
             vec![0, 1, 4]
         );
     }
-
-    // #[test]
-    // fn test_ngram_tokenizer_1_2_false() {
-    //     let tokens = test_helper(NgramTokenizer::all_ngrams(1, 2).token_stream("hello"));
-    //     assert_eq!(tokens.len(), 9);
-    //     assert_token(&tokens[0], 0, "h", 0, 1);
-    //     assert_token(&tokens[1], 0, "he", 0, 2);
-    //     assert_token(&tokens[2], 0, "e", 1, 2);
-    //     assert_token(&tokens[3], 0, "el", 1, 3);
-    //     assert_token(&tokens[4], 0, "l", 2, 3);
-    //     assert_token(&tokens[5], 0, "ll", 2, 4);
-    //     assert_token(&tokens[6], 0, "l", 3, 4);
-    //     assert_token(&tokens[7], 0, "lo", 3, 5);
-    //     assert_token(&tokens[8], 0, "o", 4, 5);
-    // }
-
-    // #[test]
-    // fn test_ngram_tokenizer_min_max_equal() {
-    //     let tokens = test_helper(NgramTokenizer::all_ngrams(3, 3).token_stream("hello"));
-    //     assert_eq!(tokens.len(), 3);
-    //     assert_token(&tokens[0], 0, "hel", 0, 3);
-    //     assert_token(&tokens[1], 0, "ell", 1, 4);
-    //     assert_token(&tokens[2], 0, "llo", 2, 5);
-    // }
-
-    // #[test]
-    // fn test_ngram_tokenizer_2_5_prefix() {
-    //     let tokens = test_helper(NgramTokenizer::prefix_only(2, 5).token_stream("frankenstein"));
-    //     assert_eq!(tokens.len(), 4);
-    //     assert_token(&tokens[0], 0, "fr", 0, 2);
-    //     assert_token(&tokens[1], 0, "fra", 0, 3);
-    //     assert_token(&tokens[2], 0, "fran", 0, 4);
-    //     assert_token(&tokens[3], 0, "frank", 0, 5);
-    // }
-
-    // #[test]
-    // fn test_ngram_non_ascii_1_2() {
-    //     let tokens = test_helper(NgramTokenizer::all_ngrams(1, 2).token_stream("hεllo"));
-    //     assert_eq!(tokens.len(), 9);
-    //     assert_token(&tokens[0], 0, "h", 0, 1);
-    //     assert_token(&tokens[1], 0, "hε", 0, 3);
-    //     assert_token(&tokens[2], 0, "ε", 1, 3);
-    //     assert_token(&tokens[3], 0, "εl", 1, 4);
-    //     assert_token(&tokens[4], 0, "l", 3, 4);
-    //     assert_token(&tokens[5], 0, "ll", 3, 5);
-    //     assert_token(&tokens[6], 0, "l", 4, 5);
-    //     assert_token(&tokens[7], 0, "lo", 4, 6);
-    //     assert_token(&tokens[8], 0, "o", 5, 6);
-    // }
-
-    // #[test]
-    // fn test_ngram_non_ascii_2_5_prefix() {
-    //     let tokens = test_helper(NgramTokenizer::prefix_only(2, 5).token_stream("hεllo"));
-    //     assert_eq!(tokens.len(), 4);
-    //     assert_token(&tokens[0], 0, "hε", 0, 3);
-    //     assert_token(&tokens[1], 0, "hεl", 0, 4);
-    //     assert_token(&tokens[2], 0, "hεll", 0, 5);
-    //     assert_token(&tokens[3], 0, "hεllo", 0, 6);
-    // }
-
-    // #[test]
-    // fn test_ngram_empty() {
-    //     let tokens = test_helper(NgramTokenizer::all_ngrams(1, 5).token_stream(""));
-    //     assert!(tokens.is_empty());
-    //     let tokens = test_helper(NgramTokenizer::all_ngrams(2, 5).token_stream(""));
-    //     assert!(tokens.is_empty());
-    // }
-
-    // #[test]
-    // #[should_panic(expected = "min_gram must be greater than 0")]
-    // fn test_ngram_min_max_interval_empty() {
-    //     test_helper(NgramTokenizer::all_ngrams(0, 2).token_stream("hellossss"));
-    // }
-
-    // #[test]
-    // #[should_panic(expected = "min_gram must not be greater than max_gram")]
-    // fn test_invalid_interval_should_panic_if_smaller() {
-    //     NgramTokenizer::all_ngrams(2, 1);
-    // }
 
     #[test]
     fn test_stutterring_iterator_empty() {

--- a/crates/mneme/src/engine/fts/tokenizer/raw_tokenizer.rs
+++ b/crates/mneme/src/engine/fts/tokenizer/raw_tokenizer.rs
@@ -1,3 +1,4 @@
+//! Tokenizer that emits the entire input as one token.
 use super::{Token, TokenStream, Tokenizer};
 use crate::engine::fts::tokenizer::BoxTokenStream;
 

--- a/crates/mneme/src/engine/fts/tokenizer/remove_long.rs
+++ b/crates/mneme/src/engine/fts/tokenizer/remove_long.rs
@@ -1,16 +1,4 @@
-//! # Example
-//! ```text
-//! use tantivy::tokenizer::*;
-//!
-//! let tokenizer = TextAnalyzer::from(SimpleTokenizer)
-//!   .filter(RemoveLongFilter::limit(5));
-//!
-//! let mut stream = tokenizer.token_stream("toolong nice");
-//! // because `toolong` is more than 5 characters, it is filtered
-//! // out of the token stream.
-//! assert_eq!(stream.next().unwrap().text, "nice");
-//! assert!(stream.next().is_none());
-//! ```
+//! Filter that removes tokens exceeding a byte-length limit.
 use super::{Token, TokenFilter, TokenStream};
 use crate::engine::fts::tokenizer::BoxTokenStream;
 

--- a/crates/mneme/src/engine/fts/tokenizer/simple_tokenizer.rs
+++ b/crates/mneme/src/engine/fts/tokenizer/simple_tokenizer.rs
@@ -1,3 +1,4 @@
+//! Tokenizer splitting on non-alphanumeric characters.
 use std::str::CharIndices;
 
 use super::{BoxTokenStream, Token, TokenStream, Tokenizer};

--- a/crates/mneme/src/engine/fts/tokenizer/split_compound_words.rs
+++ b/crates/mneme/src/engine/fts/tokenizer/split_compound_words.rs
@@ -1,3 +1,4 @@
+//! Compound word splitting filter.
 use super::{BoxTokenStream, Token, TokenFilter, TokenStream};
 use crate::engine::error::DbResult as Result;
 use aho_corasick::{AhoCorasick, AhoCorasickBuilder, MatchKind};

--- a/crates/mneme/src/engine/fts/tokenizer/stemmer.rs
+++ b/crates/mneme/src/engine/fts/tokenizer/stemmer.rs
@@ -1,3 +1,4 @@
+//! Snowball stemming filter.
 use std::borrow::Cow;
 use std::mem;
 

--- a/crates/mneme/src/engine/fts/tokenizer/stop_word_filter/mod.rs
+++ b/crates/mneme/src/engine/fts/tokenizer/stop_word_filter/mod.rs
@@ -1,15 +1,4 @@
-//! # Example
-//! ```text
-//! use tantivy::tokenizer::*;
-//!
-//! let tokenizer = TextAnalyzer::from(SimpleTokenizer)
-//!   .filter(StopWordFilter::remove(vec!["the".to_string(), "is".to_string()]));
-//!
-//! let mut stream = tokenizer.token_stream("the fox is crafty");
-//! assert_eq!(stream.next().unwrap().text, "fox");
-//! assert_eq!(stream.next().unwrap().text, "crafty");
-//! assert!(stream.next().is_none());
-//! ```
+//! Stop word removal filter with multi-language support.
 #[rustfmt::skip]
 mod stopwords;
 

--- a/crates/mneme/src/engine/fts/tokenizer/stop_word_filter/stopwords.rs
+++ b/crates/mneme/src/engine/fts/tokenizer/stop_word_filter/stopwords.rs
@@ -1,3 +1,4 @@
+//! Stop word lists for supported languages.
 /*
 These stop word lists are from the stopwords-iso project (https://github.com/stopwords-iso/stopwords-iso/) which carries the MIT license.
 */

--- a/crates/mneme/src/engine/fts/tokenizer/tokenized_string.rs
+++ b/crates/mneme/src/engine/fts/tokenizer/tokenized_string.rs
@@ -1,3 +1,4 @@
+//! Pre-tokenized string wrapper.
 use std::cmp::Ordering;
 
 use crate::engine::fts::tokenizer::{Token, TokenStream};

--- a/crates/mneme/src/engine/fts/tokenizer/tokenizer_impl.rs
+++ b/crates/mneme/src/engine/fts/tokenizer/tokenizer_impl.rs
@@ -1,3 +1,4 @@
+//! Core tokenizer trait implementations.
 use compact_str::CompactString;
 use rustc_hash::FxHashSet;
 /// The tokenizer module contains all of the tools used to process

--- a/crates/mneme/src/engine/fts/tokenizer/whitespace_tokenizer.rs
+++ b/crates/mneme/src/engine/fts/tokenizer/whitespace_tokenizer.rs
@@ -1,3 +1,4 @@
+//! Whitespace-based tokenizer.
 use std::str::CharIndices;
 
 use super::{BoxTokenStream, Token, TokenStream, Tokenizer};

--- a/crates/mneme/src/engine/mod.rs
+++ b/crates/mneme/src/engine/mod.rs
@@ -1,4 +1,4 @@
-// aletheia-mneme-engine -- embedded Datalog + HNSW + graph engine for Aletheia
+//! Embedded Datalog engine with HNSW and graph support.
 
 use std::collections::BTreeMap;
 use std::path::Path;
@@ -8,7 +8,6 @@ use crossbeam::channel::{Receiver, Sender, bounded};
 pub mod error;
 pub use error::{Error, Result};
 
-// Public type re-exports
 pub use crate::engine::data::value::{DataValue, ValidityTs, Vector};
 pub use crate::engine::fixed_rule::{FixedRule, FixedRuleInputRelation, FixedRulePayload};
 pub use crate::engine::runtime::callback::CallbackOp;
@@ -20,19 +19,16 @@ pub use crate::engine::storage::mem::MemStorage;
 pub use crate::engine::storage::redb::RedbStorage;
 pub use ndarray::Array1;
 
-// Internal re-exports needed by submodules (not part of the public API)
 pub(crate) use crate::engine::data::expr::Expr;
 pub(crate) use crate::engine::data::symb::Symbol;
 pub(crate) use crate::engine::parse::SourceSpan;
 pub(crate) use crate::engine::runtime::db::Db as DbCore;
 pub(crate) use crate::engine::runtime::relation::decode_tuple_from_kv;
 pub(crate) use crate::engine::storage::{Storage, StoreTx};
-// Test-only type alias — matches original `DbInstance` used in internal test modules
 #[cfg(test)]
 pub(crate) type DbInstance =
     crate::engine::runtime::db::Db<crate::engine::storage::mem::MemStorage>;
 
-// All internal modules — pub(crate) only
 pub(crate) mod data;
 pub(crate) mod fixed_rule;
 pub(crate) mod fts;

--- a/crates/mneme/src/engine/parse/expr.rs
+++ b/crates/mneme/src/engine/parse/expr.rs
@@ -1,6 +1,4 @@
-// Originally derived from CozoDB v0.7.6 (MPL-2.0).
-// Copyright 2022, The Cozo Project Authors — see NOTICE for details.
-
+//! Expression parsing from Datalog source.
 use std::collections::BTreeMap;
 
 use crate::engine::error::DbResult as Result;

--- a/crates/mneme/src/engine/parse/fts.rs
+++ b/crates/mneme/src/engine/parse/fts.rs
@@ -1,6 +1,4 @@
-// Originally derived from CozoDB v0.7.6 (MPL-2.0).
-// Copyright 2023, The Cozo Project Authors — see NOTICE for details.
-
+//! Full-text search clause parsing.
 use crate::engine::error::DbResult as Result;
 use crate::engine::fts::ast::{FtsExpr, FtsLiteral, FtsNear};
 use crate::engine::parse::expr::parse_string;

--- a/crates/mneme/src/engine/parse/imperative.rs
+++ b/crates/mneme/src/engine/parse/imperative.rs
@@ -1,6 +1,4 @@
-// Originally derived from CozoDB v0.7.6 (MPL-2.0).
-// Copyright 2022, The Cozo Project Authors — see NOTICE for details.
-
+//! Imperative script parsing.
 use std::collections::BTreeMap;
 use std::sync::Arc;
 
@@ -64,7 +62,6 @@ fn parse_imperative_stmt(
             ImperativeStmt::Continue { target, span }
         }
         Rule::return_stmt => {
-            // let span = pair.extract_span();
             let mut rets = vec![];
             for p in pair.into_inner() {
                 match p.as_rule() {
@@ -139,7 +136,6 @@ fn parse_imperative_stmt(
             ImperativeStmt::Loop { label: mark, body }
         }
         Rule::temp_swap => {
-            // let span = pair.extract_span();
             let mut pairs = pair.into_inner();
             let left = pairs.next().unwrap();
             let left_name = left.as_str();
@@ -152,7 +148,6 @@ fn parse_imperative_stmt(
             }
         }
         Rule::debug_stmt => {
-            // let span = pair.extract_span();
             let name_p = pair.into_inner().next().unwrap();
             let name = name_p.as_str();
 

--- a/crates/mneme/src/engine/parse/mod.rs
+++ b/crates/mneme/src/engine/parse/mod.rs
@@ -1,6 +1,3 @@
-// Originally derived from CozoDB v0.7.6 (MPL-2.0).
-// Copyright 2022, The Cozo Project Authors — see NOTICE for details.
-
 //! AST for the datalog query language.
 
 use std::cmp::{max, min};

--- a/crates/mneme/src/engine/parse/query.rs
+++ b/crates/mneme/src/engine/parse/query.rs
@@ -1,6 +1,4 @@
-// Originally derived from CozoDB v0.7.6 (MPL-2.0).
-// Copyright 2022, The Cozo Project Authors — see NOTICE for details.
-
+//! Datalog query parsing.
 use std::cmp::Reverse;
 use std::collections::btree_map::Entry;
 use std::collections::{BTreeMap, BTreeSet};
@@ -395,8 +393,6 @@ pub(crate) fn parse_query(
             make_empty_const_rule(&mut prog, &bindings);
         }
     }
-
-    // let head_arity = prog.get_entry_arity()?;
 
     match stored_relation {
         None => {}

--- a/crates/mneme/src/engine/parse/schema.rs
+++ b/crates/mneme/src/engine/parse/schema.rs
@@ -1,6 +1,4 @@
-// Originally derived from CozoDB v0.7.6 (MPL-2.0).
-// Copyright 2022, The Cozo Project Authors — see NOTICE for details.
-
+//! Schema definition parsing.
 use std::collections::BTreeSet;
 
 use crate::engine::error::DbResult as Result;

--- a/crates/mneme/src/engine/parse/sys.rs
+++ b/crates/mneme/src/engine/parse/sys.rs
@@ -1,6 +1,4 @@
-// Originally derived from CozoDB v0.7.6 (MPL-2.0).
-// Copyright 2022, The Cozo Project Authors — see NOTICE for details.
-
+//! System command parsing.
 use std::collections::BTreeMap;
 use std::sync::Arc;
 

--- a/crates/mneme/src/engine/query/compile.rs
+++ b/crates/mneme/src/engine/query/compile.rs
@@ -1,6 +1,4 @@
-// Originally derived from CozoDB v0.7.6 (MPL-2.0).
-// Copyright 2022, The Cozo Project Authors — see NOTICE for details.
-
+//! Query plan compilation from logical to relational algebra.
 use std::collections::{BTreeMap, BTreeSet};
 
 use crate::engine::error::DbResult as Result;

--- a/crates/mneme/src/engine/query/eval.rs
+++ b/crates/mneme/src/engine/query/eval.rs
@@ -1,6 +1,4 @@
-// Originally derived from CozoDB v0.7.6 (MPL-2.0).
-// Copyright 2022, The Cozo Project Authors — see NOTICE for details.
-
+//! Query plan evaluation.
 use std::collections::BTreeMap;
 use std::collections::btree_map::Entry;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};

--- a/crates/mneme/src/engine/query/graph.rs
+++ b/crates/mneme/src/engine/query/graph.rs
@@ -1,6 +1,4 @@
-// Originally derived from CozoDB v0.7.6 (MPL-2.0).
-// Copyright 2022, The Cozo Project Authors — see NOTICE for details.
-
+//! Dependency graph analysis for stratification.
 use std::cmp::min;
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::Debug;

--- a/crates/mneme/src/engine/query/logical.rs
+++ b/crates/mneme/src/engine/query/logical.rs
@@ -1,6 +1,4 @@
-// Originally derived from CozoDB v0.7.6 (MPL-2.0).
-// Copyright 2022, The Cozo Project Authors — see NOTICE for details.
-
+//! Logical plan representation.
 use std::collections::BTreeSet;
 
 use crate::engine::error::DbResult as Result;

--- a/crates/mneme/src/engine/query/magic.rs
+++ b/crates/mneme/src/engine/query/magic.rs
@@ -1,6 +1,4 @@
-// Originally derived from CozoDB v0.7.6 (MPL-2.0).
-// Copyright 2022, The Cozo Project Authors — see NOTICE for details.
-
+//! Magic sets query transformation.
 use std::collections::BTreeSet;
 use std::mem;
 

--- a/crates/mneme/src/engine/query/mod.rs
+++ b/crates/mneme/src/engine/query/mod.rs
@@ -1,6 +1,4 @@
-// Originally derived from CozoDB v0.7.6 (MPL-2.0).
-// Copyright 2022, The Cozo Project Authors — see NOTICE for details.
-
+//! Query planning, optimization, and evaluation.
 pub(crate) mod compile;
 pub(crate) mod eval;
 pub(crate) mod graph;

--- a/crates/mneme/src/engine/query/ra.rs
+++ b/crates/mneme/src/engine/query/ra.rs
@@ -1,6 +1,4 @@
-// Originally derived from CozoDB v0.7.6 (MPL-2.0).
-// Copyright 2022, The Cozo Project Authors — see NOTICE for details.
-
+//! Relational algebra operators.
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::{Debug, Formatter, Write};
 use std::iter;

--- a/crates/mneme/src/engine/query/reorder.rs
+++ b/crates/mneme/src/engine/query/reorder.rs
@@ -1,6 +1,4 @@
-// Originally derived from CozoDB v0.7.6 (MPL-2.0).
-// Copyright 2022, The Cozo Project Authors — see NOTICE for details.
-
+//! Join reordering heuristics.
 use std::collections::BTreeSet;
 use std::mem;
 

--- a/crates/mneme/src/engine/query/sort.rs
+++ b/crates/mneme/src/engine/query/sort.rs
@@ -1,6 +1,4 @@
-// Originally derived from CozoDB v0.7.6 (MPL-2.0).
-// Copyright 2022, The Cozo Project Authors — see NOTICE for details.
-
+//! Sort operators for query output.
 use std::cmp::Ordering;
 use std::collections::BTreeMap;
 

--- a/crates/mneme/src/engine/query/stored.rs
+++ b/crates/mneme/src/engine/query/stored.rs
@@ -1,6 +1,4 @@
-// Originally derived from CozoDB v0.7.6 (MPL-2.0).
-// Copyright 2022, The Cozo Project Authors — see NOTICE for details.
-
+//! Stored relation access operators.
 use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Arc;
 

--- a/crates/mneme/src/engine/query/stratify.rs
+++ b/crates/mneme/src/engine/query/stratify.rs
@@ -1,6 +1,4 @@
-// Originally derived from CozoDB v0.7.6 (MPL-2.0).
-// Copyright 2022, The Cozo Project Authors — see NOTICE for details.
-
+//! Datalog program stratification.
 use std::collections::btree_map::Entry;
 use std::collections::{BTreeMap, BTreeSet};
 

--- a/crates/mneme/src/engine/runtime/callback.rs
+++ b/crates/mneme/src/engine/runtime/callback.rs
@@ -1,6 +1,4 @@
-// Originally derived from CozoDB v0.7.6 (MPL-2.0).
-// Copyright 2022, The Cozo Project Authors — see NOTICE for details.
-
+//! Callback-based relation triggers.
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::{Display, Formatter};
 

--- a/crates/mneme/src/engine/runtime/db.rs
+++ b/crates/mneme/src/engine/runtime/db.rs
@@ -1,6 +1,4 @@
-// Originally derived from CozoDB v0.7.6 (MPL-2.0).
-// Copyright 2022, The Cozo Project Authors — see NOTICE for details.
-
+//! Core database instance and session management.
 use std::collections::btree_map::Entry;
 use std::collections::{BTreeMap, BTreeSet};
 use std::default::Default;

--- a/crates/mneme/src/engine/runtime/hnsw.rs
+++ b/crates/mneme/src/engine/runtime/hnsw.rs
@@ -1,6 +1,4 @@
-// Originally derived from CozoDB v0.7.6 (MPL-2.0).
-// Copyright 2023, The Cozo Project Authors — see NOTICE for details.
-
+//! Hierarchical Navigable Small World vector index.
 use crate::bail;
 use crate::engine::data::expr::{Bytecode, eval_bytecode_pred};
 use crate::engine::data::program::HnswSearch;
@@ -505,17 +503,6 @@ impl<'a> SessionTx<'a> {
         vec_cache: &mut VectorCache,
     ) -> Result<PriorityQueue<CompoundKey, Reverse<OrderedFloat<f64>>>> {
         let mut candidates = PriorityQueue::new();
-        // Simple non-heuristic selection
-        // let mut temp = found.clone();
-        // while temp.len() > m {
-        //     temp.pop();
-        // }
-        // for (item, dist) in temp.iter() {
-        //     candidates.push(item.clone(), Reverse(*dist));
-        // }
-        // return Ok(candidates);
-        // End of simple non-heuristic selection
-
         let mut ret: PriorityQueue<CompoundKey, Reverse<OrderedFloat<_>>> = PriorityQueue::new();
         let mut discarded: PriorityQueue<_, Reverse<OrderedFloat<_>>> = PriorityQueue::new();
         for (item, dist) in found.iter() {

--- a/crates/mneme/src/engine/runtime/imperative.rs
+++ b/crates/mneme/src/engine/runtime/imperative.rs
@@ -1,6 +1,4 @@
-// Originally derived from CozoDB v0.7.6 (MPL-2.0).
-// Copyright 2022, The Cozo Project Authors — see NOTICE for details.
-
+//! Imperative script execution.
 use std::collections::{BTreeMap, BTreeSet};
 use std::sync::atomic::Ordering;
 

--- a/crates/mneme/src/engine/runtime/minhash_lsh.rs
+++ b/crates/mneme/src/engine/runtime/minhash_lsh.rs
@@ -1,7 +1,4 @@
-// Originally derived from CozoDB v0.7.6 (MPL-2.0).
-// Copyright 2023, The Cozo Project Authors — see NOTICE for details.
-
-// Some ideas are from https://github.com/schelterlabs/rust-minhash
+//! MinHash locality-sensitive hashing.
 
 use crate::bail;
 use crate::engine::data::expr::{Bytecode, eval_bytecode, eval_bytecode_pred};
@@ -368,10 +365,6 @@ impl HashValues {
             )
         }
     }
-    // pub(crate) fn get_byte_chunks(&self, n_chunks: usize) -> impl Iterator<Item = &[u8]> {
-    //     let chunk_size = self.0.len() * std::mem::size_of::<u32>() / n_chunks;
-    //     self.get_bytes().chunks_exact(chunk_size)
-    // }
 }
 
 #[cfg(test)]

--- a/crates/mneme/src/engine/runtime/mod.rs
+++ b/crates/mneme/src/engine/runtime/mod.rs
@@ -1,6 +1,4 @@
-// Originally derived from CozoDB v0.7.6 (MPL-2.0).
-// Copyright 2022, The Cozo Project Authors — see NOTICE for details.
-
+//! Runtime execution layer for the Datalog engine.
 pub(crate) mod callback;
 pub(crate) mod db;
 pub(crate) mod hnsw;

--- a/crates/mneme/src/engine/runtime/relation.rs
+++ b/crates/mneme/src/engine/runtime/relation.rs
@@ -1,6 +1,4 @@
-// Originally derived from CozoDB v0.7.6 (MPL-2.0).
-// Copyright 2022, The Cozo Project Authors — see NOTICE for details.
-
+//! Stored relation management.
 use std::collections::BTreeMap;
 use std::fmt::{Debug, Display, Formatter};
 use std::sync::atomic::Ordering;
@@ -686,9 +684,6 @@ impl<'a> SessionTx<'a> {
         let is_temp = name.starts_with('_');
         let mut to_clean = vec![];
 
-        // if name.starts_with('_') {
-        //     bail!("Cannot destroy temp relation");
-        // }
         let store = self.get_relation(name, true)?;
         if !store.has_no_index() {
             bail!(

--- a/crates/mneme/src/engine/runtime/temp_store.rs
+++ b/crates/mneme/src/engine/runtime/temp_store.rs
@@ -1,6 +1,4 @@
-// Originally derived from CozoDB v0.7.6 (MPL-2.0).
-// Copyright 2022, The Cozo Project Authors — see NOTICE for details.
-
+//! Temporary in-memory tuple store for query evaluation.
 use std::cmp::Ordering;
 use std::collections::BTreeMap;
 use std::collections::Bound::Included;

--- a/crates/mneme/src/engine/runtime/tests.rs
+++ b/crates/mneme/src/engine/runtime/tests.rs
@@ -1,6 +1,4 @@
-// Originally derived from CozoDB v0.7.6 (MPL-2.0).
-// Copyright 2022, The Cozo Project Authors — see NOTICE for details.
-
+//! Integration tests for the engine runtime.
 use std::collections::BTreeMap;
 use std::time::Duration;
 
@@ -243,83 +241,6 @@ fn do_not_unify_underscore() {
 
 #[test]
 fn imperative_script() {
-    // let db = DbInstance::default();
-    // let res = db
-    //     .run_default(
-    //         r#"
-    //     {:create _test {a}}
-    //
-    //     %loop
-    //         %if { len[count(x)] := *_test[x]; ?[x] := len[z], x = z >= 10 }
-    //             %then %return _test
-    //         %end
-    //         { ?[a] := a = rand_uuid_v1(); :put _test {a} }
-    //         %debug _test
-    //     %end
-    // "#,
-    //         Default::default(),
-    //     )
-    //     .unwrap();
-    // assert_eq!(res.rows.len(), 10);
-    //
-    // let res = db
-    //     .run_default(
-    //         r#"
-    //     {?[a] <- [[1], [2], [3]]
-    //      :replace _test {a}}
-    //
-    //     %loop
-    //         { ?[a] := *_test[a]; :limit 1; :rm _test {a} }
-    //         %debug _test
-    //
-    //         %if_not _test
-    //         %then %break
-    //         %end
-    //     %end
-    //
-    //     %return _test
-    // "#,
-    //         Default::default(),
-    //     )
-    //     .unwrap();
-    // assert_eq!(res.rows.len(), 0);
-    //
-    // let res = db.run_default(
-    //     r#"
-    //     {:create _test {a}}
-    //
-    //     %loop
-    //         { ?[a] := a = rand_uuid_v1(); :put _test {a} }
-    //
-    //         %if { len[count(x)] := *_test[x]; ?[x] := len[z], x = z < 10 }
-    //             %continue
-    //         %end
-    //
-    //         %return _test
-    //         %debug _test
-    //     %end
-    // "#,
-    //     Default::default(),
-    // );
-    // if let Err(err) = &res {
-    //     eprintln!("{err:?}");
-    // }
-    // assert_eq!(res.unwrap().rows.len(), 10);
-    //
-    // let res = db
-    //     .run_default(
-    //         r#"
-    //     {?[a] <- [[1], [2], [3]]
-    //      :replace _test {a}}
-    //     {?[a] <- []
-    //      :replace _test2 {a}}
-    //     %swap _test _test2
-    //     %return _test
-    // "#,
-    //         Default::default(),
-    //     )
-    //     .unwrap();
-    // assert_eq!(res.rows.len(), 0);
 }
 
 #[test]
@@ -1004,9 +925,6 @@ fn test_lsh_indexing() {
         ",
         )
         .unwrap();
-    // for row in _res.into_json()["rows"].as_array().unwrap() {
-    //     println!("{}", row);
-    // }
     let _res = db
         .run_default(
             r"
@@ -1015,9 +933,6 @@ fn test_lsh_indexing() {
         ",
         )
         .unwrap();
-    // for row in res.into_json()["rows"].as_array().unwrap() {
-    //     println!("{}", row);
-    // }
     let res = db
         .run_default(
             r"
@@ -1080,10 +995,6 @@ fn tokenizers() {
         )
         .unwrap();
 
-    // let tokenizer = TextAnalyzer::from(SimpleTokenizer)
-    //     .filter(RemoveLongFilter::limit(40))
-    //     .filter(LowerCaser)
-    //     .filter(Stemmer::new(Language::English));
     let mut token_stream = tokenizer.token_stream("It is closer to Apache Lucene than to Elasticsearch or Apache Solr in the sense it is not an off-the-shelf search engine server, but rather a crate that can be used to build such a search engine.");
     while let Some(token) = token_stream.next() {
         println!("Token {:?}", token.text);
@@ -1209,9 +1120,6 @@ fn returning() {
         .run_default(r"?[x, y] <- [[1, 2]] :insert a {x => y} ")
         .unwrap();
     assert_eq!(res.into_json()["rows"], json!([["OK"]]));
-    // for row in res.into_json()["rows"].as_array().unwrap() {
-    //     println!("{}", row);
-    // }
 
     let res = db
         .run_default(r"?[x, y] <- [[1, 3], [2, 4]] :returning :put a {x => y} ")
@@ -1220,18 +1128,10 @@ fn returning() {
         res.into_json()["rows"],
         json!([["inserted", 1, 3], ["inserted", 2, 4], ["replaced", 1, 2]])
     );
-    // println!("{:?}", res.headers);
-    // for row in res.into_json()["rows"].as_array().unwrap() {
-    //     println!("{}", row);
-    // }
 
     let res = db
         .run_default(r"?[x] <- [[1], [4]] :returning :rm a {x} ")
         .unwrap();
-    // println!("{:?}", res.headers);
-    // for row in res.into_json()["rows"].as_array().unwrap() {
-    //     println!("{}", row);
-    // }
     assert_eq!(
         res.into_json()["rows"],
         json!([

--- a/crates/mneme/src/engine/runtime/transact.rs
+++ b/crates/mneme/src/engine/runtime/transact.rs
@@ -1,6 +1,4 @@
-// Originally derived from CozoDB v0.7.6 (MPL-2.0).
-// Copyright 2022, The Cozo Project Authors — see NOTICE for details.
-
+//! Schema and relation transact operations.
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU32, AtomicU64};
 

--- a/crates/mneme/src/engine/storage/fjall_backend.rs
+++ b/crates/mneme/src/engine/storage/fjall_backend.rs
@@ -1,10 +1,4 @@
-// fjall persistent storage backend for the Datalog engine.
-//
-// Replaces redb as the primary on-disk backend. Key advantages:
-// - Native read-your-own-writes via SingleWriterTxDatabase (no delta buffer)
-// - LSM-tree with LZ4 compression
-// - Pure Rust, zero C dependencies
-// - Streaming prefix/range iterators
+//! Fjall persistent storage backend.
 
 use std::fs;
 use std::path::Path;
@@ -121,8 +115,10 @@ pub struct FjallWriteTx<'s> {
     keyspace: &'s fjall::SingleWriterTxKeyspace,
 }
 
-// fjall's Snapshot and SingleWriterWriteTx are safe to share across threads.
-// Snapshot is a read-only view; SingleWriterWriteTx is protected by a mutex guard.
+// SAFETY: fjall's Snapshot is a read-only view with no interior mutability, so
+// sharing a reference across threads is sound. SingleWriterWriteTx is protected
+// by an external mutex guard at the call site, ensuring exclusive access while
+// the reference is live. Both impls are therefore safe to declare Sync.
 unsafe impl Sync for FjallReadTx<'_> {}
 unsafe impl Sync for FjallWriteTx<'_> {}
 
@@ -367,8 +363,6 @@ impl<'s> StoreTx<'s> for FjallTx<'s> {
     }
 }
 
-// --- Helper: collect range from any Readable ---
-
 fn fjall_collect_range(
     readable: &impl fjall::Readable,
     keyspace: &impl AsRef<fjall::Keyspace>,
@@ -396,8 +390,6 @@ fn fjall_collect_all(
     }
     Ok(results)
 }
-
-// --- Skip-scan on collected data (validity-aware time-travel) ---
 
 struct CollectedSkipIterator {
     data: Vec<(Vec<u8>, Vec<u8>)>,

--- a/crates/mneme/src/engine/storage/mem.rs
+++ b/crates/mneme/src/engine/storage/mem.rs
@@ -1,6 +1,4 @@
-// Originally derived from CozoDB v0.7.6 (MPL-2.0).
-// Copyright 2022, The Cozo Project Authors — see NOTICE for details.
-
+//! In-memory storage backend.
 use crate::bail;
 use crate::engine::error::DbResult as Result;
 use crossbeam::sync::{ShardedLock, ShardedLockReadGuard, ShardedLockWriteGuard};

--- a/crates/mneme/src/engine/storage/mod.rs
+++ b/crates/mneme/src/engine/storage/mod.rs
@@ -1,6 +1,4 @@
-// Originally derived from CozoDB v0.7.6 (MPL-2.0).
-// Copyright 2022, The Cozo Project Authors — see NOTICE for details.
-
+//! Storage backend abstraction layer.
 use crate::engine::error::DbResult as Result;
 use itertools::Itertools;
 

--- a/crates/mneme/src/engine/storage/redb.rs
+++ b/crates/mneme/src/engine/storage/redb.rs
@@ -1,4 +1,4 @@
-// redb persistent storage backend for the Datalog engine.
+//! Redb persistent storage backend.
 
 use std::cmp::Ordering;
 use std::collections::BTreeMap;
@@ -155,8 +155,6 @@ pub struct RedbWriteTx<'s> {
     delta: BTreeMap<Vec<u8>, Option<Vec<u8>>>,
 }
 
-// --- Helper: read from a ReadTransaction, collecting into Vec ---
-
 fn redb_table_get(read_txn: &redb::ReadTransaction, key: &[u8]) -> Result<Option<Vec<u8>>> {
     let table = read_txn
         .open_table(TABLE)
@@ -203,8 +201,6 @@ fn redb_collect_all(read_txn: &redb::ReadTransaction) -> Result<Vec<(Vec<u8>, Ve
     }
     Ok(results)
 }
-
-// --- StoreTx implementation ---
 
 impl<'s> StoreTx<'s> for RedbTx<'s> {
     fn get(&self, key: &[u8], _for_update: bool) -> Result<Option<Vec<u8>>> {
@@ -453,9 +449,6 @@ impl<'s> StoreTx<'s> for RedbTx<'s> {
     }
 }
 
-// --- Merge iterators: delta cache + persisted data (owned variant) ---
-// Adapted from MemStorage's CacheIter/CacheIterRaw for owned persisted data.
-
 struct DeltaMergeIterRaw<'a, C>
 where
     C: Iterator<Item = (&'a Vec<u8>, &'a Option<Vec<u8>>)> + 'a,
@@ -536,7 +529,6 @@ where
     }
 }
 
-// Tuple-decoding variant for range_scan_tuple
 struct DeltaMergeIter<'a, C>
 where
     C: Iterator<Item = (&'a Vec<u8>, &'a Option<Vec<u8>>)> + 'a,
@@ -615,8 +607,6 @@ where
         swap_option_result(self.next_inner())
     }
 }
-
-// --- Skip-scan on collected data (validity-aware time-travel) ---
 
 struct CollectedSkipIterator {
     data: Vec<(Vec<u8>, Vec<u8>)>,

--- a/crates/mneme/src/engine/storage/temp.rs
+++ b/crates/mneme/src/engine/storage/temp.rs
@@ -1,6 +1,4 @@
-// Originally derived from CozoDB v0.7.6 (MPL-2.0).
-// Copyright 2022, The Cozo Project Authors — see NOTICE for details.
-
+//! Temporary (session-scoped) storage backend.
 use std::collections::BTreeMap;
 use std::default::Default;
 

--- a/crates/mneme/src/engine/utils.rs
+++ b/crates/mneme/src/engine/utils.rs
@@ -1,6 +1,4 @@
-// Originally derived from CozoDB v0.7.6 (MPL-2.0).
-// Copyright 2022, The Cozo Project Authors — see NOTICE for details.
-
+//! Small utility helpers for the engine.
 #[inline(always)]
 pub(crate) fn swap_option_result<T, E>(d: Result<Option<T>, E>) -> Option<Result<T, E>> {
     match d {


### PR DESCRIPTION
## Summary

- Strip all copyright/attribution headers from 78+ files in `crates/mneme/src/engine/`
- Add `//!` module doc comments to every `.rs` file in the engine module
- Remove section banner comments (`// ---`), commented-out code (~250 lines), stale Tantivy doc comments, and "what" comments restating code
- Add `// SAFETY:` comments to all `unsafe` blocks
- Convert one `#![allow(unused_imports)]` to `#[expect]` with reason

100 files changed, 146 insertions(+), 738 deletions(-) — net reduction of ~600 lines of comment noise.

## Engine Audit Findings

### Files Needing Future Refactoring
- **data/aggr.rs** (~1200 lines) — large aggregation registry, foreign vtable pattern
- **data/functions.rs** (~2100+ lines) — massive function registry, undocumented semantics
- **data/expr.rs** — bytecode compiler with opaque opcodes, dead code
- **query/ra.rs** — complex join logic with minimal algorithmic comments
- **query/magic.rs** — magic sets transformation, no INVARIANT comments
- **runtime/hnsw.rs** — HNSW index with minimal algorithmic documentation
- **fts/tokenizer/** — absorbed Tantivy code, retains original style
- **fixed_rule/csr/** — absorbed graph crate code (Apache-2.0)

### Unsafe Blocks (All Now Documented)
- `data/value.rs`, `data/memcmp.rs`, `data/functions.rs`, `data/relation.rs` — pointer casts for vector serialization
- `fixed_rule/csr/mod.rs` — CSR layout cast
- `storage/fjall_backend.rs` — `unsafe impl Sync`
- `runtime/minhash_lsh.rs` — hash signature byte views

### Observations
- **Debt:** Blanket `#[allow(warnings, clippy::all, ...)]` on all data/parse/query/runtime submodules suppresses all lint categories
- **Debt:** Several `#[allow(dead_code)]` fields may be genuinely dead and removable
- **Missing test:** `fts/tokenizer/ngram_tokenizer.rs` test suite was commented out (removed); no replacement
- **Missing test:** `fixed_rule/csr/page_rank.rs` has no unit tests
- **Doc gap:** `storage/mod.rs` Storage/StoreTx trait methods lack error condition docs
- **Idea:** `fts/tokenizer/stopwords.rs` could use a build script instead of checked-in arrays

## Test plan
- [x] `cargo check -p aletheia-mneme` — clean
- [x] `cargo clippy -p aletheia-mneme --all-targets -- -D warnings` — zero warnings
- [x] `cargo test -p aletheia-mneme` — 547 tests pass
- [x] Zero `// Originally derived` or `// Copyright` lines remain
- [x] Every `.rs` file has `//!` module doc comment
- [x] Zero section banners, zero commented-out code blocks
- [x] All `unsafe` blocks have `// SAFETY:` comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)