### PR TITLE
chore: codebase-wide comment audit

### DIFF
--- a/crates/integration-tests/src/lib.rs
+++ b/crates/integration-tests/src/lib.rs
@@ -1,3 +1,1 @@
 //! Cross-crate integration test suite for the Aletheia workspace.
-//!
-//! All tests live in `tests/*.rs` and exercise interactions across crate boundaries.

--- a/crates/koina/src/error.rs
+++ b/crates/koina/src/error.rs
@@ -1,7 +1,4 @@
 //! Error types for Aletheia.
-//!
-//! Each crate defines its own error enum using `snafu`. This module provides
-//! the koina-level errors (config, I/O, serialization) that other crates wrap.
 
 use snafu::Snafu;
 use std::path::PathBuf;

--- a/crates/koina/src/id.rs
+++ b/crates/koina/src/id.rs
@@ -1,7 +1,4 @@
 //! Newtype wrappers for domain identifiers.
-//!
-//! Every domain concept gets its own type. No raw `String` or `u64` for identifiers.
-//! Construction validates. The type *is* the documentation.
 
 use compact_str::CompactString;
 use serde::{Deserialize, Serialize};

--- a/crates/koina/src/tracing_init.rs
+++ b/crates/koina/src/tracing_init.rs
@@ -1,7 +1,4 @@
 //! Tracing initialization for Aletheia.
-//!
-//! Sets up structured logging via `tracing-subscriber`. Supports JSON output
-//! for production and human-readable output for development.
 
 use tracing_subscriber::{EnvFilter, fmt};
 

--- a/crates/melete/src/distill.rs
+++ b/crates/melete/src/distill.rs
@@ -294,8 +294,6 @@ mod tests {
 
     use super::*;
 
-    // --- Mock provider ---
-
     struct MockProvider {
         response: std::sync::Mutex<Option<aletheia_hermeneus::error::Result<CompletionResponse>>>,
     }
@@ -392,8 +390,6 @@ mod tests {
         }
     }
 
-    // --- Helpers ---
-
     fn text_msg(role: Role, text: &str) -> Message {
         Message {
             role,
@@ -442,8 +438,6 @@ Bug is fixed, test passes.
 ## Corrections
 - Initially looked at wrong file before finding the issue in login.rs";
 
-    // --- should_distill tests ---
-
     #[test]
     fn should_distill_below_threshold_returns_false() {
         let engine = default_engine();
@@ -489,8 +483,6 @@ Bug is fixed, test passes.
         // 8 < min_messages(6) + verbatim_tail(3) = 9
         assert!(!engine.should_distill(8, 190_000, 200_000, 0.8));
     }
-
-    // --- build_prompt tests ---
 
     #[test]
     fn build_prompt_has_system_prompt() {
@@ -554,8 +546,6 @@ Bug is fixed, test passes.
         let request = engine.build_prompt(&sample_conversation(), "test");
         assert!(request.tools.is_empty());
     }
-
-    // --- distill tests ---
 
     #[tokio::test]
     async fn distill_success_returns_result() {
@@ -621,8 +611,6 @@ Bug is fixed, test passes.
         );
     }
 
-    // --- error cases ---
-
     #[tokio::test]
     async fn distill_empty_messages_returns_no_messages_error() {
         let engine = default_engine();
@@ -670,8 +658,6 @@ Bug is fixed, test passes.
         assert!(err.to_string().contains("empty summary"));
     }
 
-    // --- config defaults ---
-
     #[test]
     fn config_default_model() {
         let config = DistillConfig::default();
@@ -685,8 +671,6 @@ Bug is fixed, test passes.
         assert_eq!(config.min_messages, 6);
         assert!(config.include_tool_calls);
     }
-
-    // --- estimate_tokens ---
 
     #[test]
     fn estimate_tokens_chars_div_4() {
@@ -705,8 +689,6 @@ Bug is fixed, test passes.
         let messages: Vec<Message> = vec![];
         assert_eq!(estimate_tokens(&messages), 0);
     }
-
-    // --- extract_summary_text ---
 
     #[test]
     fn extract_summary_from_text_blocks() {
@@ -750,8 +732,6 @@ Bug is fixed, test passes.
         assert_eq!(text, "summary");
     }
 
-    // --- new config defaults ---
-
     #[test]
     fn config_default_sections() {
         let config = DistillConfig::default();
@@ -776,8 +756,6 @@ Bug is fixed, test passes.
         let config = DistillConfig::default();
         assert!(config.distillation_model.is_none());
     }
-
-    // --- model downshift ---
 
     #[test]
     fn build_prompt_uses_distillation_model_when_set() {
@@ -815,8 +793,6 @@ Bug is fixed, test passes.
         assert!(system.contains("## Key Decisions"));
         assert!(!system.contains("## Open Threads"));
     }
-
-    // --- verbatim tail ---
 
     #[tokio::test]
     async fn distill_preserves_verbatim_messages() {

--- a/crates/melete/src/lib.rs
+++ b/crates/melete/src/lib.rs
@@ -1,11 +1,4 @@
 //! aletheia-melete — context distillation engine
-//!
-//! Melete (Μελέτη) — "practice, exercise." One of the three original Muses,
-//! representing meditation and the discipline of focused thought. Compresses
-//! conversation history into structured summaries that preserve essential
-//! context across distillation boundaries.
-//!
-//! Depends on `aletheia-koina` (types) and `aletheia-hermeneus` (LLM provider).
 
 /// Context distillation engine: token budgeting, LLM-driven summarization, and verbatim tail preservation.
 pub mod distill;

--- a/crates/mneme/src/id.rs
+++ b/crates/mneme/src/id.rs
@@ -133,8 +133,6 @@ mod tests {
         let fact: FactId = "id-1".into();
         let entity: EntityId = "id-1".into();
         // Same string content, but different types — this is the point.
-        // The following would not compile:
-        // let _: FactId = entity;
         assert_eq!(fact.as_str(), entity.as_str());
     }
 

--- a/crates/nous/src/budget.rs
+++ b/crates/nous/src/budget.rs
@@ -126,8 +126,6 @@ impl TokenBudget {
     }
 }
 
-// --- Time budget (complementary to token budget) ---
-
 use crate::config::StageBudget;
 use std::time::{Duration, Instant};
 
@@ -251,8 +249,6 @@ impl TimeBudget {
 mod tests {
     use super::*;
 
-    // --- CharEstimator ---
-
     #[test]
     fn char_estimator_empty_string() {
         assert_eq!(CharEstimator.estimate(""), 0);
@@ -278,8 +274,6 @@ mod tests {
     fn char_estimator_single_char() {
         assert_eq!(CharEstimator.estimate("x"), 1);
     }
-
-    // --- TokenBudget ---
 
     #[test]
     fn budget_computes_system_budget() {
@@ -345,15 +339,11 @@ mod tests {
         assert_eq!(budget.remaining(), 44_000);
     }
 
-    // --- Static assertions ---
-
     #[test]
     fn char_estimator_is_send_sync() {
         fn assert_send_sync<T: Send + Sync>() {}
         assert_send_sync::<CharEstimator>();
     }
-
-    // --- TimeBudget ---
 
     #[test]
     fn time_budget_not_exceeded_initially() {

--- a/crates/nous/src/extraction.rs
+++ b/crates/nous/src/extraction.rs
@@ -1,8 +1,4 @@
 //! Bridge from nous to mneme's extraction pipeline via hermeneus providers.
-//!
-//! Provides [`HermeneusExtractionProvider`] for fact extraction and
-//! [`HermeneusSkillExtractionProvider`] for skill extraction — both bridge
-//! hermeneus's `ProviderRegistry` to mneme's provider traits.
 
 use std::sync::Arc;
 

--- a/crates/nous/src/lib.rs
+++ b/crates/nous/src/lib.rs
@@ -1,10 +1,4 @@
 //! aletheia-nous — agent session pipeline
-//!
-//! Nous (νοῦς) — "mind." The agent session manager, message pipeline,
-//! and tool execution engine. Each nous instance runs a pipeline:
-//! context → history → guard → resolve → execute → finalize.
-//!
-//! Depends on all foundation crates: koina, taxis, mneme, hermeneus.
 
 /// Tokio actor driving a single nous instance's message loop.
 pub mod actor;

--- a/crates/nous/src/pipeline.rs
+++ b/crates/nous/src/pipeline.rs
@@ -1,13 +1,4 @@
 //! Message processing pipeline.
-//!
-//! Each inbound message flows through stages:
-//! 1. **Context** — assemble bootstrap (SOUL.md, USER.md, etc.)
-//!     - **Recall** — retrieve and inject relevant knowledge
-//! 2. **History** — load conversation history within token budget
-//! 3. **Guard** — check rate limits, loop detection, safety
-//! 4. **Resolve** — resolve model, tools, and routing
-//! 5. **Execute** — call LLM, process tool use, iterate
-//! 6. **Finalize** — persist messages, update counts, extract facts
 
 use std::collections::VecDeque;
 use std::time::Instant;

--- a/crates/pylon/src/handlers/knowledge.rs
+++ b/crates/pylon/src/handlers/knowledge.rs
@@ -160,8 +160,6 @@ pub struct TimelineResponse {
     pub events: Vec<TimelineEvent>,
 }
 
-// --- Handlers ---
-
 /// GET /api/v1/knowledge/facts
 ///
 /// List facts with sorting, filtering, and pagination.
@@ -392,8 +390,6 @@ pub async fn timeline(
     events.sort_by(|a, b| a.timestamp.cmp(&b.timestamp));
     Ok(Json(TimelineResponse { events }))
 }
-
-// --- Internal helpers ---
 
 fn get_stored_facts(
     _state: &AppState,

--- a/crates/pylon/src/handlers/nous.rs
+++ b/crates/pylon/src/handlers/nous.rs
@@ -112,8 +112,6 @@ pub async fn tools(
     Ok(Json(ToolsResponse { tools }))
 }
 
-// --- Response types ---
-
 /// Response listing all registered nous agents.
 #[derive(Debug, Serialize, ToSchema)]
 pub struct NousListResponse {

--- a/crates/pylon/src/handlers/sessions.rs
+++ b/crates/pylon/src/handlers/sessions.rs
@@ -635,10 +635,6 @@ pub async fn events(
     )
 }
 
-// ---------------------------------------------------------------------------
-// Internal helpers
-// ---------------------------------------------------------------------------
-
 /// Emit turn result as individual SSE events to a single client channel.
 ///
 /// Each SSE endpoint serves exactly one client — there is no multi-subscriber
@@ -741,8 +737,6 @@ async fn find_session(
 
     session.ok_or_else(|| SessionNotFoundSnafu { id: id_for_error }.build())
 }
-
-// --- Request/Response types ---
 
 /// Body for `POST /api/v1/sessions`.
 #[derive(Debug, Deserialize, ToSchema)]

--- a/crates/pylon/src/handlers/webchat.rs
+++ b/crates/pylon/src/handlers/webchat.rs
@@ -21,8 +21,6 @@ use crate::extract::OptionalClaims;
 use crate::state::AppState;
 use crate::stream::{TurnOutcome, WebchatEvent};
 
-// --- POST /api/sessions/stream ---
-
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct StreamRequest {
@@ -243,8 +241,6 @@ pub async fn stream(
     ))
 }
 
-// --- GET /api/agents ---
-
 #[derive(Debug, Serialize)]
 pub struct AgentsListResponse {
     pub agents: Vec<AgentInfo>,
@@ -285,8 +281,6 @@ pub async fn agents_list(
 
     Json(AgentsListResponse { agents })
 }
-
-// --- GET /api/agents/{id}/identity ---
 
 #[derive(Debug, Serialize)]
 pub struct AgentIdentityResponse {
@@ -343,8 +337,6 @@ fn parse_identity(content: &str, fallback_name: &str) -> (String, Option<String>
     (name, emoji)
 }
 
-// --- GET /api/branding ---
-
 #[derive(Debug, Serialize)]
 pub struct BrandingResponse {
     pub name: &'static str,
@@ -353,8 +345,6 @@ pub struct BrandingResponse {
 pub async fn branding(_claims: OptionalClaims) -> Json<BrandingResponse> {
     Json(BrandingResponse { name: "Aletheia" })
 }
-
-// --- GET /api/auth/mode ---
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -376,8 +366,6 @@ pub async fn auth_mode(
         session_auth: false,
     })
 }
-
-// --- GET /api/sessions ---
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -435,8 +423,6 @@ pub async fn sessions_list(
 
     Ok(Json(SessionsListResponse { sessions: items }))
 }
-
-// --- GET /api/events ---
 
 pub async fn events_sse(
     _claims: OptionalClaims,

--- a/tui/src/api/client.rs
+++ b/tui/src/api/client.rs
@@ -81,8 +81,6 @@ impl ApiClient {
         req
     }
 
-    // --- Health ---
-
     #[tracing::instrument(skip(self))]
     pub async fn health(&self) -> Result<bool> {
         let resp = self
@@ -95,8 +93,6 @@ impl ApiClient {
             })?;
         Ok(resp.status().is_success())
     }
-
-    // --- Auth ---
 
     #[tracing::instrument(skip(self))]
     pub async fn auth_mode(&self) -> Result<AuthMode> {
@@ -135,8 +131,6 @@ impl ApiClient {
         })
     }
 
-    // --- Agents ---
-
     #[tracing::instrument(skip(self))]
     pub async fn agents(&self) -> Result<Vec<Agent>> {
         let resp = self
@@ -155,8 +149,6 @@ impl ApiClient {
         })?;
         Ok(wrapper.nous)
     }
-
-    // --- Sessions ---
 
     #[tracing::instrument(skip(self))]
     pub async fn sessions(&self, nous_id: &str) -> Result<Vec<Session>> {
@@ -284,8 +276,6 @@ impl ApiClient {
         Ok(())
     }
 
-    // --- Turns ---
-
     #[expect(dead_code, reason = "reserved for turn abort keybinding")]
     #[tracing::instrument(skip(self))]
     pub async fn abort_turn(&self, turn_id: &str) -> Result<()> {
@@ -346,8 +336,6 @@ impl ApiClient {
         Ok(())
     }
 
-    // --- Plans ---
-
     #[tracing::instrument(skip(self))]
     pub async fn approve_plan(&self, plan_id: &str) -> Result<()> {
         let encoded = encode_path(plan_id);
@@ -386,8 +374,6 @@ impl ApiClient {
         Ok(())
     }
 
-    // --- Costs ---
-
     #[tracing::instrument(skip(self))]
     pub async fn today_cost_cents(&self) -> Result<u32> {
         let resp = self
@@ -409,8 +395,6 @@ impl ApiClient {
         Ok((today_cost * 100.0) as u32)
     }
 
-    // --- Distillation ---
-
     #[tracing::instrument(skip(self))]
     pub async fn compact(&self, session_id: &str) -> Result<()> {
         let encoded = encode_path(session_id);
@@ -429,8 +413,6 @@ impl ApiClient {
         })?;
         Ok(())
     }
-
-    // --- Memory recall ---
 
     #[tracing::instrument(skip(self))]
     pub async fn recall(&self, nous_id: &str, query: &str) -> Result<String> {
@@ -453,8 +435,6 @@ impl ApiClient {
             operation: "recall response",
         })
     }
-
-    // --- Config ---
 
     #[tracing::instrument(skip(self))]
     pub async fn config(&self) -> Result<serde_json::Value> {
@@ -497,8 +477,6 @@ impl ApiClient {
             operation: "config update response",
         })
     }
-
-    // --- Knowledge ---
 
     #[tracing::instrument(skip(self))]
     pub async fn knowledge_facts(
@@ -607,8 +585,6 @@ impl ApiClient {
         })?;
         Ok(())
     }
-
-    // --- Message queue (mid-turn) ---
 
     #[tracing::instrument(skip(self, text))]
     pub async fn queue_message(&self, session_id: &str, text: &str) -> Result<()> {

--- a/tui/src/api/types.rs
+++ b/tui/src/api/types.rs
@@ -2,8 +2,6 @@ use serde::{Deserialize, Serialize};
 
 use crate::id::{NousId, PlanId, SessionId, TurnId};
 
-// --- Agent ---
-
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Agent {
     pub id: NousId,
@@ -23,8 +21,6 @@ impl Agent {
         self.name.as_deref().unwrap_or(&self.id)
     }
 }
-
-// --- Session ---
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Session {
@@ -66,8 +62,6 @@ impl Session {
     }
 }
 
-// --- History ---
-
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct HistoryMessage {
     pub role: String,
@@ -85,8 +79,6 @@ pub struct HistoryMessage {
 pub struct HistoryResponse {
     pub messages: Vec<HistoryMessage>,
 }
-
-// --- Turn outcome ---
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TurnOutcome {
@@ -109,8 +101,6 @@ pub struct TurnOutcome {
     #[serde(default)]
     pub error: Option<String>,
 }
-
-// --- Plans ---
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PlanStep {
@@ -136,8 +126,6 @@ pub struct Plan {
     pub total_estimated_cost_cents: u32,
     pub status: String,
 }
-
-// --- SSE events ---
 
 #[non_exhaustive]
 #[derive(Debug, Clone)]
@@ -200,8 +188,6 @@ pub struct ActiveTurn {
     pub turn_id: TurnId,
 }
 
-// --- Auth ---
-
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AuthMode {
     pub mode: String,
@@ -219,8 +205,6 @@ impl std::fmt::Debug for LoginResponse {
             .finish()
     }
 }
-
-// --- Costs ---
 
 #[expect(dead_code, reason = "deserialization target for /api/v1/costs")]
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -255,8 +239,6 @@ pub struct DailyEntry {
     #[serde(default)]
     pub turns: u32,
 }
-
-// --- Response wrappers ---
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AgentsResponse {

--- a/tui/src/app.rs
+++ b/tui/src/app.rs
@@ -30,8 +30,6 @@ pub use crate::state::{
     TabCompletion, ToolApprovalOverlay, ToolCallInfo, View, ViewStack,
 };
 
-// --- App ---
-
 pub struct App {
     pub config: Config,
     pub client: ApiClient,
@@ -377,8 +375,6 @@ impl App {
         }
     }
 
-    // --- Event source management (take/restore pattern for borrow checker) ---
-
     #[tracing::instrument(skip_all)]
     pub fn take_sse(&mut self) -> Option<SseConnection> {
         self.sse.take()
@@ -399,14 +395,10 @@ impl App {
         self.stream_rx = rx;
     }
 
-    // --- State update ---
-
     #[tracing::instrument(skip_all)]
     pub async fn update(&mut self, msg: Msg) {
         crate::update::update(self, msg).await;
     }
-
-    // --- Tab state management ---
 
     /// Save current app state into the active tab.
     pub(crate) fn save_to_active_tab(&mut self) {
@@ -485,8 +477,6 @@ impl App {
         self.tab_bar.clear_active_unread();
         self.restore_from_active_tab();
     }
-
-    // --- View ---
 
     #[tracing::instrument(skip_all)]
     pub fn view(&self, frame: &mut Frame) -> Vec<OscLink> {

--- a/tui/src/diff.rs
+++ b/tui/src/diff.rs
@@ -1,9 +1,4 @@
 //! Diff computation and rendering for file changes.
-//!
-//! Three display modes:
-//! - **Unified**: standard +/- format with colored additions/deletions
-//! - **SideBySide**: split layout with old on left, new on right
-//! - **WordDiff**: inline highlighting of changed words/tokens within lines
 
 use ratatui::layout::Rect;
 use ratatui::style::{Color, Modifier, Style};
@@ -11,10 +6,6 @@ use ratatui::text::{Line, Span};
 use similar::{ChangeTag, TextDiff};
 
 use crate::theme::ThemePalette;
-
-// ---------------------------------------------------------------------------
-// Types
-// ---------------------------------------------------------------------------
 
 /// Display mode for the diff viewer.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -110,10 +101,6 @@ impl DiffViewState {
     }
 }
 
-// ---------------------------------------------------------------------------
-// Diff Computation
-// ---------------------------------------------------------------------------
-
 /// Compute a diff between old and new text for a single file.
 pub(crate) fn compute_diff(path: &str, old: &str, new: &str) -> FileDiff {
     let text_diff = TextDiff::from_lines(old, new);
@@ -186,10 +173,6 @@ pub(crate) fn collapse_to_replacements(hunks: &[DiffHunk]) -> Vec<DiffHunk> {
         })
         .collect()
 }
-
-// ---------------------------------------------------------------------------
-// Rendering — Unified
-// ---------------------------------------------------------------------------
 
 /// Render hunks in unified diff format.
 pub(crate) fn render_unified(file: &FileDiff, theme: &ThemePalette) -> Vec<Line<'static>> {
@@ -282,10 +265,6 @@ pub(crate) fn render_unified(file: &FileDiff, theme: &ThemePalette) -> Vec<Line<
 
     lines
 }
-
-// ---------------------------------------------------------------------------
-// Rendering — Side-by-Side
-// ---------------------------------------------------------------------------
 
 /// Render hunks in a side-by-side layout.
 pub(crate) fn render_side_by_side(
@@ -400,10 +379,6 @@ pub(crate) fn render_side_by_side(
 
     lines
 }
-
-// ---------------------------------------------------------------------------
-// Rendering — Word Diff (inline)
-// ---------------------------------------------------------------------------
 
 /// Render hunks with inline word-level highlighting.
 pub(crate) fn render_word_diff(file: &FileDiff, theme: &ThemePalette) -> Vec<Line<'static>> {

--- a/tui/src/hyperlink.rs
+++ b/tui/src/hyperlink.rs
@@ -1,24 +1,4 @@
 //! OSC 8 terminal hyperlink support.
-//!
-//! # Overview
-//! - URL detection in plain text via [`detect_urls`]
-//! - Terminal capability detection via [`supports_hyperlinks`]
-//! - OSC 8 escape sequence helpers: [`osc8_open`], [`osc8_close`]
-//! - [`MdLink`] — link metadata returned by the markdown renderer
-//! - [`OscLink`] — screen-resolved hyperlink ready for post-render emission
-//!
-//! # OSC 8 format
-//! ```text
-//! ESC ] 8 ;; URL BEL  <display text>  ESC ] 8 ;; BEL
-//! \x1b]8;;https://example.com\x07  click here  \x1b]8;;\x07
-//! ```
-//!
-//! # Ratatui status
-//! Ratatui 0.30 has no native OSC 8 support (tracked upstream in #1227).
-//! We implement a **post-render** approach: after `terminal.draw()` completes,
-//! we re-write link text at its screen position, wrapped in OSC 8 sequences.
-//! The visual appearance is identical (underline + accent colour already set by
-//! ratatui); OSC 8 merely adds clickable hyperlink metadata on top.
 
 use std::sync::LazyLock;
 

--- a/tui/src/state/tab.rs
+++ b/tui/src/state/tab.rs
@@ -1,8 +1,4 @@
 //! Tab bar state for multi-session tabbed navigation.
-//!
-//! Each tab holds an isolated snapshot of session state (messages, scroll position,
-//! input buffer, selection, filter). Switching tabs saves the current state and
-//! restores the target tab's state.
 
 use std::collections::HashSet;
 

--- a/tui/src/state/view_stack.rs
+++ b/tui/src/state/view_stack.rs
@@ -1,7 +1,4 @@
 //! Stack-based navigation for hierarchical view drill-in/drill-out.
-//!
-//! Enter pushes a detail view onto the stack, Esc pops back.
-//! The stack always has at least one element (Home).
 
 use crate::id::{NousId, SessionId};
 

--- a/tui/src/theme.rs
+++ b/tui/src/theme.rs
@@ -20,48 +20,39 @@ pub enum ColorDepth {
     reason = "palette fields are the complete semantic color set"
 )]
 pub struct ThemePalette {
-    // --- Surface colors ---
     pub bg: Color,
     pub surface: Color,
     pub surface_bright: Color,
     pub surface_dim: Color,
 
-    // --- Text ---
     pub fg: Color,
     pub fg_muted: Color,
     pub fg_dim: Color,
 
-    // --- Accent ---
     pub accent: Color,
     pub accent_dim: Color,
 
-    // --- Semantic ---
     pub success: Color,
     pub warning: Color,
     pub error: Color,
     pub info: Color,
 
-    // --- Agent role colors ---
     pub user: Color,
     pub assistant: Color,
     pub system: Color,
 
-    // --- Interactive ---
     pub selected: Color,
     pub border: Color,
     pub border_focused: Color,
     pub separator: Color,
 
-    // --- Code ---
     pub code_fg: Color,
     pub code_bg: Color,
     pub code_lang: Color,
 
-    // --- Thinking ---
     pub thinking: Color,
     pub thinking_border: Color,
 
-    // --- Status ---
     pub spinner: Color,
     pub idle: Color,
     pub streaming: Color,
@@ -216,8 +207,6 @@ impl ThemePalette {
             depth: ColorDepth::Basic,
         }
     }
-
-    // --- Convenience style constructors ---
 
     pub fn style_fg(&self) -> Style {
         Style::default().fg(self.fg)

--- a/tui/src/view/chat.rs
+++ b/tui/src/view/chat.rs
@@ -38,8 +38,6 @@ pub fn render(app: &App, frame: &mut Frame, area: Rect, theme: &ThemePalette) ->
         .map(|a| a.name_lower.as_str())
         .unwrap_or("assistant");
 
-    // --- Virtual scroll: determine which messages to render ---
-    //
     // When filter is active, we fall back to iterating all messages (filter changes
     // the visible set dynamically). For the non-filtered common path, we use the
     // VirtualScroll prefix-sum index for O(log n) range lookup.

--- a/tui/src/view/memory.rs
+++ b/tui/src/view/memory.rs
@@ -209,8 +209,6 @@ pub(crate) fn render_fact_detail(app: &App, frame: &mut Frame, area: Rect, theme
     frame.render_widget(paragraph, area);
 }
 
-// --- Internal renderers ---
-
 fn render_tab_bar(app: &App, frame: &mut Frame, area: Rect, theme: &ThemePalette) {
     let tabs = [MemoryTab::Facts, MemoryTab::Graph, MemoryTab::Timeline];
     let mut spans: Vec<Span> = vec![Span::raw(" ")];
@@ -553,8 +551,6 @@ fn render_memory_status(app: &App, frame: &mut Frame, area: Rect, theme: &ThemeP
     let paragraph = Paragraph::new(vec![line]);
     frame.render_widget(paragraph, area);
 }
-
-// --- Helpers ---
 
 fn meta_line<'a>(theme: &'a ThemePalette, label: &'a str, value: &str) -> Line<'a> {
     Line::from(vec![


### PR DESCRIPTION
## Summary

- Removed all section banner comments (`// --- ... ---`, `// -----------`) across 13 files
- Trimmed multi-line `//!` file headers to one line in 12 files
- Removed commented-out code (`// let _: FactId = entity;` in `mneme/id.rs`)
- No copyright/license headers, AI generation indicators, or stale TODOs found outside the excluded `engine/` directory

220 lines deleted, zero additions.

## Files changed

| File | Violation | Fix |
|------|-----------|-----|
| `crates/melete/src/distill.rs` | 12 test section banners | Removed |
| `tui/src/theme.rs` | 10 struct field banners | Removed |
| `crates/pylon/src/handlers/webchat.rs` | 7 route section banners | Removed |
| `tui/src/api/client.rs` | 12 method group banners | Removed |
| `tui/src/app.rs` | 5 method group banners | Removed |
| `crates/pylon/src/handlers/knowledge.rs` | 2 banners | Removed |
| `tui/src/api/types.rs` | 9 struct group banners | Removed |
| `crates/pylon/src/handlers/sessions.rs` | 2 banners | Removed |
| `crates/pylon/src/handlers/nous.rs` | 1 banner | Removed |
| `crates/nous/src/budget.rs` | 5 section banners | Removed |
| `tui/src/view/memory.rs` | 2 banners | Removed |
| `tui/src/view/chat.rs` | 1 banner | Removed |
| `tui/src/diff.rs` | Multi-line header + 4 separator blocks | Trimmed/removed |
| `tui/src/hyperlink.rs` | 21-line `//!` header | Trimmed to 1 line |
| `crates/melete/src/lib.rs` | 8-line `//!` header | Trimmed to 1 line |
| `crates/koina/src/id.rs` | 4-line `//!` header | Trimmed to 1 line |
| `crates/koina/src/error.rs` | 4-line `//!` header | Trimmed to 1 line |
| `crates/koina/src/tracing_init.rs` | 4-line `//!` header | Trimmed to 1 line |
| `tui/src/state/view_stack.rs` | 4-line `//!` header | Trimmed to 1 line |
| `tui/src/state/tab.rs` | 5-line `//!` header | Trimmed to 1 line |
| `crates/nous/src/lib.rs` | 7-line `//!` header | Trimmed to 1 line |
| `crates/nous/src/pipeline.rs` | 10-line `//!` header | Trimmed to 1 line |
| `crates/nous/src/extraction.rs` | 5-line `//!` header | Trimmed to 1 line |
| `crates/integration-tests/src/lib.rs` | 3-line `//!` header | Trimmed to 1 line |
| `crates/mneme/src/id.rs` | Commented-out code | Removed |

## Observations

- **Debt:** `tui/src/api/client.rs` and `tui/src/api/types.rs` are large files organized purely by section banners — the lack of structural separation will be felt now. These could benefit from being split into smaller modules in a future refactor.
- **Debt:** `tui/src/diff.rs` had heavy use of `// -----------` separators to demarcate three display modes (Unified, SideBySide, WordDiff). These are now removed; the functions remain but the visual grouping is gone. Candidate for module-per-display-mode split.
- **Idea:** `tui/src/theme.rs` struct fields grouped by role (Surface, Text, Accent, etc.) were documented only via banners. A struct-of-structs grouping would make the organization explicit in the type system.

## Validation

- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test -p aletheia-koina -p aletheia-taxis -p aletheia-hermeneus -p aletheia-nous -p aletheia-organon -p aletheia-pylon` — 960 tests pass, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)