### PR TITLE
fix(mneme): audit all unsafe blocks with SAFETY documentation

### DIFF
--- a/crates/mneme/src/engine/data/functions.rs
+++ b/crates/mneme/src/engine/data/functions.rs
@@ -2101,11 +2101,29 @@ pub(crate) fn op_vec(args: &[DataValue]) -> Result<DataValue> {
             match t {
                 VecElementType::F32 => {
                     let f32_count = bytes.len() / mem::size_of::<f32>();
-                    // SAFETY: `bytes` was produced by base64-decoding a serialised
-                    // f32 vector (written by `Vector::serialize`). `f32_count` is
-                    // `bytes.len() / size_of::<f32>()`, so the pointer covers exactly
-                    // `f32_count` valid f32-sized elements. The view is immediately
-                    // converted to an owned array, so no aliasing or lifetime issues.
+                    // Rust's global allocator guarantees allocations are aligned
+                    // to at least max_align_t (≥ 16 bytes on 64-bit platforms),
+                    // satisfying align_of::<f32>() == 4.
+                    debug_assert_eq!(
+                        bytes.as_ptr() as usize % mem::align_of::<f32>(),
+                        0,
+                        "Vec<u8> buffer must be aligned for f32 reinterpretation"
+                    );
+                    // SAFETY: `bytes` is a Vec<u8> produced by base64-decoding a
+                    // serialised f32 vector (written by `Vector::serialize`). Three
+                    // invariants hold:
+                    // (1) Alignment: the global allocator guarantees the buffer is
+                    //     aligned to at least max_align_t (≥ 16 B), which is larger
+                    //     than align_of::<f32>() (4 B); the debug_assert above
+                    //     verifies this at runtime in debug builds.
+                    // (2) Length: `f32_count` is `bytes.len() / size_of::<f32>()`, so
+                    //     the pointer covers exactly `f32_count` fully-initialised f32
+                    //     elements within the live `bytes` allocation.
+                    // (3) Lifetime: `arr` is immediately converted to an owned array
+                    //     via `to_owned()` before `bytes` is dropped, so the view
+                    //     never outlives the backing buffer.
+                    // Violating any of these would cause UB: misaligned read,
+                    // out-of-bounds access, or dangling pointer respectively.
                     let arr = unsafe {
                         ndarray::ArrayView1::from_shape_ptr(
                             ndarray::Dim([f32_count]),
@@ -2116,11 +2134,29 @@ pub(crate) fn op_vec(args: &[DataValue]) -> Result<DataValue> {
                 }
                 VecElementType::F64 => {
                     let f64_count = bytes.len() / mem::size_of::<f64>();
-                    // SAFETY: `bytes` was produced by base64-decoding a serialised
-                    // f64 vector (written by `Vector::serialize`). `f64_count` is
-                    // `bytes.len() / size_of::<f64>()`, so the pointer covers exactly
-                    // `f64_count` valid f64-sized elements. The view is immediately
-                    // converted to an owned array, so no aliasing or lifetime issues.
+                    // Rust's global allocator guarantees allocations are aligned
+                    // to at least max_align_t (≥ 16 bytes on 64-bit platforms),
+                    // satisfying align_of::<f64>() == 8.
+                    debug_assert_eq!(
+                        bytes.as_ptr() as usize % mem::align_of::<f64>(),
+                        0,
+                        "Vec<u8> buffer must be aligned for f64 reinterpretation"
+                    );
+                    // SAFETY: `bytes` is a Vec<u8> produced by base64-decoding a
+                    // serialised f64 vector (written by `Vector::serialize`). Three
+                    // invariants hold:
+                    // (1) Alignment: the global allocator guarantees the buffer is
+                    //     aligned to at least max_align_t (≥ 16 B), which is larger
+                    //     than align_of::<f64>() (8 B); the debug_assert above
+                    //     verifies this at runtime in debug builds.
+                    // (2) Length: `f64_count` is `bytes.len() / size_of::<f64>()`, so
+                    //     the pointer covers exactly `f64_count` fully-initialised f64
+                    //     elements within the live `bytes` allocation.
+                    // (3) Lifetime: `arr` is immediately converted to an owned array
+                    //     via `to_owned()` before `bytes` is dropped, so the view
+                    //     never outlives the backing buffer.
+                    // Violating any of these would cause UB: misaligned read,
+                    // out-of-bounds access, or dangling pointer respectively.
                     let arr = unsafe {
                         ndarray::ArrayView1::from_shape_ptr(
                             ndarray::Dim([f64_count]),

--- a/crates/mneme/src/engine/data/relation.rs
+++ b/crates/mneme/src/engine/data/relation.rs
@@ -347,11 +347,28 @@ impl NullableColType {
                             if f32_count != *len {
                                 bail!(make_err())
                             }
-                            // SAFETY: `bytes` is a base64-decoded f32 vector payload.
-                            // The length check above ensures `f32_count == *len`, so
-                            // the pointer covers exactly `f32_count` f32-aligned elements
-                            // within the live `bytes` allocation. The view is immediately
-                            // converted to an owned array before `bytes` is dropped.
+                            // Rust's global allocator guarantees allocations are aligned
+                            // to at least max_align_t (≥ 16 bytes on 64-bit platforms),
+                            // satisfying align_of::<f32>() == 4.
+                            debug_assert_eq!(
+                                bytes.as_ptr() as usize % mem::align_of::<f32>(),
+                                0,
+                                "Vec<u8> buffer must be aligned for f32 reinterpretation"
+                            );
+                            // SAFETY: `bytes` is a Vec<u8> produced by base64-decoding a
+                            // serialised f32 vector. Three invariants hold:
+                            // (1) Alignment: the global allocator guarantees the buffer is
+                            //     aligned to at least max_align_t (≥ 16 B), which is larger
+                            //     than align_of::<f32>() (4 B); the debug_assert above
+                            //     verifies this at runtime in debug builds.
+                            // (2) Length: the length check above ensures `f32_count == *len`,
+                            //     so the pointer covers exactly `f32_count` initialised f32
+                            //     elements within the live `bytes` allocation.
+                            // (3) Lifetime: `arr` is immediately converted to an owned array
+                            //     via `to_owned()` before `bytes` is dropped, so the view
+                            //     never outlives the backing buffer.
+                            // Violating any of these would cause UB: misaligned read,
+                            // out-of-bounds access, or dangling pointer respectively.
                             let arr = unsafe {
                                 ndarray::ArrayView1::from_shape_ptr(
                                     ndarray::Dim([f32_count]),
@@ -365,11 +382,28 @@ impl NullableColType {
                             if f64_count != *len {
                                 bail!(make_err())
                             }
-                            // SAFETY: `bytes` is a base64-decoded f64 vector payload.
-                            // The length check above ensures `f64_count == *len`, so
-                            // the pointer covers exactly `f64_count` f64-aligned elements
-                            // within the live `bytes` allocation. The view is immediately
-                            // converted to an owned array before `bytes` is dropped.
+                            // Rust's global allocator guarantees allocations are aligned
+                            // to at least max_align_t (≥ 16 bytes on 64-bit platforms),
+                            // satisfying align_of::<f64>() == 8.
+                            debug_assert_eq!(
+                                bytes.as_ptr() as usize % mem::align_of::<f64>(),
+                                0,
+                                "Vec<u8> buffer must be aligned for f64 reinterpretation"
+                            );
+                            // SAFETY: `bytes` is a Vec<u8> produced by base64-decoding a
+                            // serialised f64 vector. Three invariants hold:
+                            // (1) Alignment: the global allocator guarantees the buffer is
+                            //     aligned to at least max_align_t (≥ 16 B), which is larger
+                            //     than align_of::<f64>() (8 B); the debug_assert above
+                            //     verifies this at runtime in debug builds.
+                            // (2) Length: the length check above ensures `f64_count == *len`,
+                            //     so the pointer covers exactly `f64_count` initialised f64
+                            //     elements within the live `bytes` allocation.
+                            // (3) Lifetime: `arr` is immediately converted to an owned array
+                            //     via `to_owned()` before `bytes` is dropped, so the view
+                            //     never outlives the backing buffer.
+                            // Violating any of these would cause UB: misaligned read,
+                            // out-of-bounds access, or dangling pointer respectively.
                             let arr = unsafe {
                                 ndarray::ArrayView1::from_shape_ptr(
                                     ndarray::Dim([f64_count]),

--- a/crates/mneme/src/engine/runtime/minhash_lsh.rs
+++ b/crates/mneme/src/engine/runtime/minhash_lsh.rs
@@ -301,8 +301,17 @@ impl HashPermutations {
         Self(perms)
     }
     pub(crate) fn as_bytes(&self) -> &[u8] {
-        // SAFETY: `u32` has alignment >= `u8`. The pointer comes from a Vec<u32>,
-        // so it is valid for `len * size_of::<u32>()` bytes within the allocation.
+        // SAFETY: Reinterpreting Vec<u32> storage as &[u8] is sound because:
+        // (1) Alignment: align_of::<u8>() == 1 is always satisfied by any pointer,
+        //     including those from Vec<u32> (which are aligned to ≥ 4 bytes).
+        // (2) Validity: the pointer is non-null and the Vec owns `self.0.len()`
+        //     initialised u32 values; `len * size_of::<u32>()` is the exact byte
+        //     count of the live initialised data.
+        // (3) Lifetime: the returned slice borrows `self`, so it cannot outlive
+        //     the Vec — the borrow checker enforces this.
+        // (4) No aliasing: `&self` gives shared access; no exclusive reference to
+        //     the Vec storage exists for the lifetime of the returned slice.
+        // Violating these would cause UB: dangling pointer or out-of-bounds read.
         unsafe {
             std::slice::from_raw_parts(
                 self.0.as_ptr() as *const u8,
@@ -356,8 +365,17 @@ impl HashValues {
         matches as f32 / self.0.len() as f32
     }
     pub(crate) fn get_bytes(&self) -> &[u8] {
-        // SAFETY: Same as HashPermutations::as_bytes — u32-to-u8 reinterpretation
-        // is alignment-safe since align_of::<u8>() == 1 <= align_of::<u32>().
+        // SAFETY: Reinterpreting Vec<u32> storage as &[u8] is sound for the same
+        // reasons as `HashPermutations::as_bytes`:
+        // (1) Alignment: align_of::<u8>() == 1 is always satisfied by any pointer.
+        // (2) Validity: the pointer is non-null and the Vec owns `self.0.len()`
+        //     initialised u32 values; `len * size_of::<u32>()` is the exact byte
+        //     count of the live initialised data.
+        // (3) Lifetime: the returned slice borrows `self`, preventing it from
+        //     outliving the Vec — enforced by the borrow checker.
+        // (4) No aliasing: `&self` gives shared access; no exclusive reference to
+        //     the Vec storage exists for the lifetime of the returned slice.
+        // Violating these would cause UB: dangling pointer or out-of-bounds read.
         unsafe {
             std::slice::from_raw_parts(
                 self.0.as_ptr() as *const u8,


### PR DESCRIPTION
## Summary

- **`data/relation.rs` (2 sites):** `from_shape_ptr` SAFETY comments now enumerate all three required invariants (alignment via global allocator's `max_align_t` guarantee, length from byte-count calculation, lifetime via immediate `to_owned()`). Added `debug_assert_eq!` alignment guards before each call for runtime verification in debug builds.
- **`data/functions.rs` (2 sites):** Same improvements as `data/relation.rs` — the prior comments said "f32/f64-aligned elements" without justifying *why* the bytes pointer is sufficiently aligned.
- **`runtime/minhash_lsh.rs` (2 sites):** Expanded thin SAFETY comments for `HashPermutations::as_bytes` and `HashValues::get_bytes` to cover all `from_raw_parts` invariants: non-null validity, exact byte length, lifetime via borrow-checker enforcement, and absence of aliasing.
- **All other sites already complete:** `storage/fjall_backend.rs` (2 `unsafe impl Sync`), `fixed_rule/csr/mod.rs` (1 `from_raw_parts` with existing `debug_assert_eq!` size guard), `data/value.rs` (4 sites), `data/memcmp.rs` (2 `from_utf8_unchecked` sites) — all had complete SAFETY documentation from the prior codebase-wide comment audit.

## Test plan

- [x] `cargo check -p aletheia-mneme --features mneme-engine,storage-redb` — clean
- [x] `cargo test -p aletheia-mneme` — 549 tests passed, 0 failed
- [x] `cargo clippy -p aletheia-mneme --all-targets -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)