### PR TITLE
fix(mneme): restore dead_code blanket for Rust 1.94 compat

### DIFF
--- a/crates/mneme/src/engine/data/expr.rs
+++ b/crates/mneme/src/engine/data/expr.rs
@@ -396,13 +396,11 @@ impl Expr {
         }
         Ok(())
     }
-    #[expect(dead_code, reason = "diagnostic helper for expression binding analysis")]
     pub(crate) fn binding_indices(&self) -> Result<BTreeSet<usize>> {
         let mut ret = BTreeSet::default();
         self.do_binding_indices(&mut ret)?;
         Ok(ret)
     }
-    #[expect(dead_code, reason = "recursive helper for binding_indices diagnostic")]
     fn do_binding_indices(&self, coll: &mut BTreeSet<usize>) -> Result<()> {
         match self {
             Expr::Binding { tuple_pos, .. } => {

--- a/crates/mneme/src/engine/data/program.rs
+++ b/crates/mneme/src/engine/data/program.rs
@@ -304,7 +304,6 @@ impl std::fmt::Display for WrongFixedRuleOptionError {
 impl std::error::Error for WrongFixedRuleOptionError {}
 
 impl MagicFixedRuleApply {
-    #[expect(dead_code, reason = "validation helper retained for fixed rule implementors")]
     pub(crate) fn relation_with_min_len(
         &self,
         idx: usize,
@@ -436,14 +435,12 @@ pub(crate) enum MagicFixedRuleRuleArg {
     },
 }
 impl MagicFixedRuleRuleArg {
-    #[expect(dead_code, reason = "accessor retained for external fixed rule implementations")]
     pub(crate) fn bindings(&self) -> &[Symbol] {
         match self {
             MagicFixedRuleRuleArg::InMem { bindings, .. }
             | MagicFixedRuleRuleArg::Stored { bindings, .. } => bindings,
         }
     }
-    #[expect(dead_code, reason = "accessor used by external fixed rule error reporting")]
     pub(crate) fn span(&self) -> SourceSpan {
         match self {
             MagicFixedRuleRuleArg::InMem { span, .. }

--- a/crates/mneme/src/engine/runtime/relation.rs
+++ b/crates/mneme/src/engine/runtime/relation.rs
@@ -192,7 +192,6 @@ impl RelationHandle {
         );
         Ok(NamedRows::new(headers, rows))
     }
-    #[expect(dead_code, reason = "utility method retained for future maintenance tooling")]
     pub(crate) fn amend_key_prefix(&self, data: &mut [u8]) {
         let prefix_bytes = self.id.0.to_be_bytes();
         data[0..8].copy_from_slice(&prefix_bytes);

--- a/crates/mneme/src/lib.rs
+++ b/crates/mneme/src/lib.rs
@@ -8,6 +8,7 @@
 #[cfg(feature = "mneme-engine")]
 #[expect(
     unsafe_code,
+    dead_code,
     private_interfaces,
     unused_imports,
     clippy::pedantic,


### PR DESCRIPTION
## Summary
- Rust 1.94 (stable on CI) detects dead struct fields that 1.90 didn't
- PR #705 removed `dead_code` from lib.rs `#[expect]` blanket, breaking CI
- Restores the blanket until engine remediation plan handles per-module
- Removes 6 `#[expect(dead_code)]` annotations made unfulfilled by the blanket

## Test plan
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean on 1.94
- [x] `cargo test --workspace` passes (8 pre-existing organon sandbox failures)