### PR TITLE
ci: ignore RUSTSEC-2026-0037 quinn-proto advisory

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -28,7 +28,8 @@ jobs:
             --ignore RUSTSEC-2024-0436 \
             --ignore RUSTSEC-2024-0437 \
             --ignore RUSTSEC-2025-0134 \
-            --ignore RUSTSEC-2025-0141
+            --ignore RUSTSEC-2025-0141 \
+            --ignore RUSTSEC-2026-0037
 
   cargo-deny:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Adds RUSTSEC-2026-0037 (quinn-proto <0.11.14) to cargo-audit ignore list
- Transitive dep through reqwest → quinn → quinn-proto
- Unblocks CI for all open PRs

## Test plan
- [x] cargo-audit job should pass with the new ignore