### PR TITLE
refactor(mneme): replace BoxErr with QueryError snafu enum in query/

### DIFF
--- a/crates/mneme/src/engine/mod.rs
+++ b/crates/mneme/src/engine/mod.rs
@@ -33,7 +33,6 @@ pub(crate) mod data;
 pub(crate) mod fixed_rule;
 pub(crate) mod fts;
 pub(crate) mod parse;
-#[allow(clippy::all, clippy::restriction, unused_assignments)]
 pub(crate) mod query;
 #[allow(clippy::all, clippy::restriction, unused_assignments)]
 pub(crate) mod runtime;

--- a/crates/mneme/src/engine/query/compile.rs
+++ b/crates/mneme/src/engine/query/compile.rs
@@ -2,7 +2,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 
 use crate::engine::error::DbResult as Result;
-use crate::{bail, ensure};
+use crate::engine::query::error::*;
 use itertools::Itertools;
 
 use crate::engine::data::aggr::Aggregation;
@@ -119,9 +119,11 @@ impl<'a> SessionTx<'a> {
                                     let mut relation =
                                         self.compile_magic_rule_body(rule, &k, &store_arities, header)?;
                                     relation.fill_binding_indices_and_compile().map_err(|e| {
-                                        crate::engine::error::AdhocError(format!(
-                                            "{e}: error encountered when filling binding indices for {relation:#?}"
-                                        ))
+                                        CompilationFailedSnafu {
+                                            message: format!(
+                                                "{e}: error encountered when filling binding indices for {relation:#?}"
+                                            ),
+                                        }.build()
                                     })?;
                                     collected.push(CompiledRule {
                                         aggr: rule.aggr.clone(),
@@ -161,15 +163,18 @@ impl<'a> SessionTx<'a> {
             match atom {
                 MagicAtom::Rule(rule_app) => {
                     let store_arity = store_arities.get(&rule_app.name).ok_or_else(|| {
-                        crate::engine::error::AdhocError(format!(
-                            "Requested rule '{}' not found",
-                            rule_app.name.symbol()
-                        ))
+                        InvalidRelationSnafu {
+                            name: rule_app.name.symbol().to_string(),
+                            reason: "requested rule not found".to_string(),
+                        }
+                        .build()
                     })?;
 
-                    ensure!(
+                    snafu::ensure!(
                         *store_arity == rule_app.args.len(),
-                        "Arity mismatch for rule application"
+                        ArityMismatchSnafu {
+                            message: "arity mismatch for rule application",
+                        }
                     );
                     let mut prev_joiner_vars = vec![];
                     let mut right_joiner_vars = vec![];
@@ -195,11 +200,17 @@ impl<'a> SessionTx<'a> {
                 MagicAtom::Relation(rel_app) => {
                     let store = self.get_relation(&rel_app.name, false)?;
                     if store.access_level < AccessLevel::ReadOnly {
-                        bail!("Insufficient access level for this operation");
+                        return Err(InsufficientAccessSnafu {
+                            message: "insufficient access level for this operation",
+                        }
+                        .build()
+                        .into());
                     }
-                    ensure!(
+                    snafu::ensure!(
                         store.arity() == rel_app.args.len(),
-                        "Arity mismatch for relation application"
+                        ArityMismatchSnafu {
+                            message: "arity mismatch for relation application",
+                        }
                     );
                     // already existing vars
                     let mut prev_joiner_vars = vec![];
@@ -342,14 +353,17 @@ impl<'a> SessionTx<'a> {
                 }
                 MagicAtom::NegatedRule(rule_app) => {
                     let store_arity = store_arities.get(&rule_app.name).ok_or_else(|| {
-                        crate::engine::error::AdhocError(format!(
-                            "Requested rule '{}' not found",
-                            rule_app.name.symbol()
-                        ))
+                        InvalidRelationSnafu {
+                            name: rule_app.name.symbol().to_string(),
+                            reason: "requested rule not found".to_string(),
+                        }
+                        .build()
                     })?;
-                    ensure!(
+                    snafu::ensure!(
                         *store_arity == rule_app.args.len(),
-                        "Arity mismatch for negated rule application"
+                        ArityMismatchSnafu {
+                            message: "arity mismatch for negated rule application",
+                        }
                     );
 
                     let mut prev_joiner_vars = vec![];
@@ -374,9 +388,11 @@ impl<'a> SessionTx<'a> {
                 }
                 MagicAtom::NegatedRelation(rel_app) => {
                     let store = self.get_relation(&rel_app.name, false)?;
-                    ensure!(
+                    snafu::ensure!(
                         store.arity() == rel_app.args.len(),
-                        "Arity mismatch for relation application"
+                        ArityMismatchSnafu {
+                            message: "arity mismatch for relation application",
+                        }
                     );
 
                     // already existing vars
@@ -602,7 +618,11 @@ impl<'a> SessionTx<'a> {
 
         if cur_ret_set != ret_vars_set {
             let unbound = ret_vars_set.difference(&cur_ret_set).next().unwrap();
-            bail!("Symbol '{}' in rule head is unbound", unbound);
+            return Err(UnboundVariableSnafu {
+                message: format!("symbol '{unbound}' in rule head is unbound"),
+            }
+            .build()
+            .into());
         }
         let cur_ret_bindings = ret.bindings_after_eliminate();
         if ret_vars != cur_ret_bindings {

--- a/crates/mneme/src/engine/query/error.rs
+++ b/crates/mneme/src/engine/query/error.rs
@@ -1,0 +1,157 @@
+//! Error types for the Datalog query engine.
+use snafu::Snafu;
+
+/// Errors from the query engine (compilation, evaluation, stratification, graph traversal).
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub(crate)))]
+#[non_exhaustive]
+pub(crate) enum QueryError {
+    /// Query compilation failed (binding indices, arity checks, etc.).
+    #[snafu(display("compilation failed: {message}"))]
+    CompilationFailed {
+        message: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    /// Reference to a rule or relation that doesn't exist.
+    #[snafu(display("relation not found: '{name}' — {reason}"))]
+    InvalidRelation {
+        name: String,
+        reason: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    /// Negation stratification is impossible (cyclic negation).
+    #[snafu(display("stratification failed: {message}"))]
+    StratificationFailed {
+        message: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    /// Type error in a query expression.
+    #[snafu(display("type error: expected {expected}, got {got} in {context}"))]
+    TypeError {
+        expected: String,
+        got: String,
+        context: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    /// Graph traversal algorithm error.
+    #[snafu(display("graph traversal '{algorithm}' failed: {message}"))]
+    GraphTraversal {
+        algorithm: String,
+        message: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    /// Runtime evaluation error.
+    #[snafu(display("evaluation error: {message}"))]
+    EvalFailed {
+        message: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    /// Arity mismatch between rule/relation and its application.
+    #[snafu(display("arity mismatch: {message}"))]
+    ArityMismatch {
+        message: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    /// Unsafe negation or unbound variable in rule.
+    #[snafu(display("unsafe rule: {message}"))]
+    UnsafeRule {
+        message: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    /// Access level insufficient for the requested operation.
+    #[snafu(display("insufficient access: {message}"))]
+    InsufficientAccess {
+        message: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    /// Invalid time-travel scanning configuration.
+    #[snafu(display("invalid time travel: {message}"))]
+    InvalidTimeTravel {
+        message: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    /// A named field does not exist on a stored relation.
+    #[snafu(display("stored relation '{relation}' does not have field '{field}'"))]
+    FieldNotFound {
+        relation: String,
+        field: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    /// An unbound variable was found in a rule head or expression.
+    #[snafu(display("unbound variable: {message}"))]
+    UnboundVariable {
+        message: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    /// Error propagated from the data layer.
+    #[snafu(display("{source}"))]
+    Data {
+        source: crate::engine::data::error::DataError,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    /// Error propagated from the parse layer.
+    #[snafu(display("{source}"))]
+    Parse {
+        source: crate::engine::parse::error::ParseError,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    /// Stored relation operation error (create, replace, put, etc.).
+    #[snafu(display("stored relation error: {message}"))]
+    StoredRelation {
+        message: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+}
+
+pub(crate) type QueryResult<T> = std::result::Result<T, QueryError>;
+
+impl QueryError {
+    /// Convert into the engine's `BoxErr` for cross-module boundaries.
+    ///
+    /// This bridge exists during the migration period. The standard library
+    /// blanket impl `From<E: Error> for Box<dyn Error + Send + Sync>` already
+    /// provides automatic `?`-based conversion in `DbResult` contexts.
+    pub(crate) fn into_box_err(self) -> crate::engine::error::BoxErr {
+        Box::new(self)
+    }
+}
+
+/// Extension trait to convert `QueryResult<T>` into `DbResult<T>` at module boundaries.
+pub(crate) trait IntoDbResult<T> {
+    fn into_db_result(self) -> crate::engine::error::DbResult<T>;
+}
+
+impl<T> IntoDbResult<T> for QueryResult<T> {
+    fn into_db_result(self) -> crate::engine::error::DbResult<T> {
+        self.map_err(|e| e.into_box_err())
+    }
+}

--- a/crates/mneme/src/engine/query/eval.rs
+++ b/crates/mneme/src/engine/query/eval.rs
@@ -123,7 +123,10 @@ impl<'a> SessionTx<'a> {
             let mut to_merge = BTreeMap::new();
             let borrowed_stores = stores as &BTreeMap<_, _>;
             if epoch == 0 {
-                #[allow(clippy::needless_borrow)]
+                #[expect(
+                    clippy::needless_borrow,
+                    reason = "closure borrows &ruleset from pattern match binding"
+                )]
                 let execution = |(k, compiled_ruleset): (_, &CompiledRuleSet)| -> Result<_> {
                     let new_store = match compiled_ruleset {
                         CompiledRuleSet::Rules(ruleset) => match compiled_ruleset.aggr_kind() {
@@ -207,7 +210,10 @@ impl<'a> SessionTx<'a> {
                 }
             } else {
                 // Follow up epoch > 0
-                #[allow(clippy::needless_borrow)]
+                #[expect(
+                    clippy::needless_borrow,
+                    reason = "closure borrows &ruleset from pattern match binding"
+                )]
                 let execution = |(k, compiled_ruleset): (_, &CompiledRuleSet)| -> Result<_> {
                     let new_store = match compiled_ruleset {
                         CompiledRuleSet::Rules(ruleset) => {

--- a/crates/mneme/src/engine/query/logical.rs
+++ b/crates/mneme/src/engine/query/logical.rs
@@ -2,17 +2,14 @@
 use std::collections::BTreeSet;
 
 use crate::engine::error::DbResult as Result;
-use crate::{bail, ensure};
+use crate::engine::query::error::*;
 use itertools::Itertools;
-use snafu::Snafu;
 
 use crate::engine::data::expr::Expr;
 use crate::engine::data::program::{
     InputAtom, InputNamedFieldRelationApplyAtom, InputRelationApplyAtom, InputRuleApplyAtom,
     NormalFormAtom, NormalFormRelationApplyAtom, NormalFormRuleApplyAtom, TempSymbGen, Unification,
 };
-use crate::engine::parse::SourceSpan;
-
 use crate::engine::runtime::transact::SessionTx;
 
 #[derive(Debug)]
@@ -113,10 +110,18 @@ impl InputAtom {
                     span,
                 },
                 InputAtom::Unification { inner: _ } => {
-                    bail!("Unsafe negation in rule")
+                    return Err(UnsafeRuleSnafu {
+                        message: "unsafe negation in rule",
+                    }
+                    .build()
+                    .into());
                 }
                 InputAtom::Search { inner: _ } => {
-                    bail!("Unsafe negation in rule")
+                    return Err(UnsafeRuleSnafu {
+                        message: "unsafe negation in rule",
+                    }
+                    .build()
+                    .into());
                 }
             },
             InputAtom::Search { inner } => InputAtom::Search { inner },
@@ -148,12 +153,11 @@ impl InputAtom {
             .map(|col| &col.name)
             .collect();
         for k in args.keys() {
-            ensure!(
+            snafu::ensure!(
                 fields.contains(k),
-                NamedFieldNotFound {
+                FieldNotFoundSnafu {
                     relation: name.to_string(),
                     field: k.to_string(),
-                    span
                 }
             );
         }
@@ -199,9 +203,15 @@ impl InputAtom {
                 let mut args = args
                     .into_iter()
                     .map(|a| a.do_disjunctive_normal_form(r#gen, tx));
-                let mut result = args.next().ok_or_else(|| {
-                    crate::engine::error::AdhocError("empty conjunction".to_string())
-                })??;
+                let mut result =
+                    args.next()
+                        .ok_or_else(|| -> Box<dyn std::error::Error + Send + Sync> {
+                            CompilationFailedSnafu {
+                                message: "empty conjunction",
+                            }
+                            .build()
+                            .into()
+                        })??;
                 for a in args {
                     result = result.conjunctive_to_disjunctive_de_morgen(a?)
                 }
@@ -354,12 +364,4 @@ impl InputRelationApplyAtom {
         });
         Disjunction::conj(ret)
     }
-}
-
-#[derive(Debug, Snafu)]
-#[snafu(display("stored relation '{relation}' does not have field '{field}'"))]
-pub(crate) struct NamedFieldNotFound {
-    pub(crate) relation: String,
-    pub(crate) field: String,
-    pub(crate) span: SourceSpan,
 }

--- a/crates/mneme/src/engine/query/magic.rs
+++ b/crates/mneme/src/engine/query/magic.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeSet;
 use std::mem;
 
 use crate::engine::error::DbResult as Result;
-use crate::{bail, ensure};
+use crate::engine::query::error::*;
 use compact_str::CompactString;
 use itertools::Itertools;
 use smallvec::SmallVec;
@@ -351,7 +351,9 @@ impl NormalFormProgram {
                                                             nullable: false,
                                                         })
                                                     {
-                                                        bail!("Invalid time travel scanning for relation '{}'", name);
+                                                        return Err(InvalidTimeTravelSnafu {
+                                                        message: format!("invalid time travel scanning for relation '{name}'"),
+                                                    }.build().into());
                                                     }
                                                 }
 
@@ -382,7 +384,9 @@ impl NormalFormProgram {
                                                             nullable: false,
                                                         })
                                                     {
-                                                        bail!("Invalid time travel scanning for relation '{}'", name);
+                                                        return Err(InvalidTimeTravelSnafu {
+                                                        message: format!("invalid time travel scanning for relation '{name}'"),
+                                                    }.build().into());
                                                     }
                                                 }
                                                 let fields: BTreeSet<_> = relation
@@ -393,9 +397,12 @@ impl NormalFormProgram {
                                                     .map(|col| &col.name)
                                                     .collect();
                                                 for k in bindings.keys() {
-                                                    ensure!(
+                                                    snafu::ensure!(
                                                         fields.contains(&k),
-                                                        "stored relation '{}' does not have field '{}'", name, k
+                                                        FieldNotFoundSnafu {
+                                                            relation: name.to_string(),
+                                                            field: k.to_string(),
+                                                        }
                                                     );
                                                 }
                                                 let new_bindings = relation

--- a/crates/mneme/src/engine/query/mod.rs
+++ b/crates/mneme/src/engine/query/mod.rs
@@ -1,5 +1,6 @@
 //! Query planning, optimization, and evaluation.
 pub(crate) mod compile;
+pub(crate) mod error;
 pub(crate) mod eval;
 pub(crate) mod graph;
 pub(crate) mod logical;

--- a/crates/mneme/src/engine/query/ra.rs
+++ b/crates/mneme/src/engine/query/ra.rs
@@ -3,8 +3,8 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::{Debug, Formatter, Write};
 use std::iter;
 
-use crate::bail;
 use crate::engine::error::DbResult as Result;
+use crate::engine::query::error::*;
 use compact_str::CompactString;
 use either::{Left, Right};
 use itertools::Itertools;
@@ -128,7 +128,10 @@ impl UnificationRA {
                 .map_ok(move |tuple| -> Result<Vec<Tuple>> {
                     let result_list = eval_bytecode(&self.expr_bytecode, &tuple, &mut stack)?;
                     let result_list = result_list.get_slice().ok_or_else(|| {
-                        crate::engine::error::AdhocError("Invalid spread unification".to_string())
+                        EvalFailedSnafu {
+                            message: "Invalid spread unification",
+                        }
+                        .build()
                     })?;
                     let mut coll = vec![];
                     for result in result_list {
@@ -421,7 +424,11 @@ impl RelAlgebra {
                         nullable: false,
                     })
                 {
-                    bail!("Invalid time travel on relation");
+                    return Err(InvalidTimeTravelSnafu {
+                        message: "Invalid time travel on relation",
+                    }
+                    .build()
+                    .into());
                 };
                 Ok(Self::StoredWithValidity(StoredWithValidityRA {
                     bindings,
@@ -1011,12 +1018,28 @@ impl FtsSearchRA {
                                     }
                                     coll.write_str(&s).unwrap();
                                 }
-                                d => bail!("Expected string for FTS search, got {:?}", d),
+                                d => {
+                                    return Err(TypeSnafu {
+                                        expected: "string",
+                                        got: format!("{d:?}"),
+                                        context: "FTS search",
+                                    }
+                                    .build()
+                                    .into());
+                                }
                             }
                         }
                         coll
                     }
-                    d => bail!("Expected string for FTS search, got {:?}", d),
+                    d => {
+                        return Err(TypeSnafu {
+                            expected: "string",
+                            got: format!("{d:?}"),
+                            context: "FTS search",
+                        }
+                        .build()
+                        .into());
+                    }
                 };
 
                 let res = tx.fts_search(
@@ -1078,7 +1101,15 @@ impl HnswSearchRA {
             .map_ok(move |tuple| -> Result<_> {
                 let v = match tuple[bind_idx].clone() {
                     DataValue::Vec(v) => v,
-                    d => bail!("Expected vector, got {:?}", d),
+                    d => {
+                        return Err(TypeSnafu {
+                            expected: "vector",
+                            got: format!("{d:?}"),
+                            context: "HNSW search",
+                        }
+                        .build()
+                        .into());
+                    }
                 };
 
                 let res = tx.hnsw_knn(v, &config, &filter_code, &mut stack)?;

--- a/crates/mneme/src/engine/query/reorder.rs
+++ b/crates/mneme/src/engine/query/reorder.rs
@@ -2,9 +2,9 @@
 use std::collections::BTreeSet;
 use std::mem;
 
-use crate::bail;
 use crate::engine::data::program::{NormalFormAtom, NormalFormInlineRule};
 use crate::engine::error::DbResult as Result;
+use crate::engine::query::error::*;
 
 impl NormalFormInlineRule {
     pub(crate) fn convert_to_well_ordered_rule(self) -> Result<Self> {
@@ -180,30 +180,44 @@ impl NormalFormInlineRule {
                         if r.args.iter().any(|a| seen_variables.contains(a)) {
                             collected.push(NormalFormAtom::NegatedRule(r.clone()));
                         } else {
-                            bail!("Encountered unsafe negation, or empty rule definition");
+                            return Err(UnsafeRuleSnafu {
+                            message: "encountered unsafe negation, or empty rule definition",
+                        }.build().into());
                         }
                     }
                     NormalFormAtom::NegatedRelation(v) => {
                         if v.args.iter().any(|a| seen_variables.contains(a)) {
                             collected.push(NormalFormAtom::NegatedRelation(v.clone()));
                         } else {
-                            bail!("Encountered unsafe negation, or empty rule definition");
+                            return Err(UnsafeRuleSnafu {
+                            message: "encountered unsafe negation, or empty rule definition",
+                        }.build().into());
                         }
                     }
                     NormalFormAtom::Predicate(_p) => {
-                        bail!("Atom contains unbound variable, or rule contains no variable at all")
+                        return Err(UnboundVariableSnafu {
+                        message: "atom contains unbound variable, or rule contains no variable at all",
+                    }.build().into())
                     }
                     NormalFormAtom::Unification(_u) => {
-                        bail!("Atom contains unbound variable, or rule contains no variable at all")
+                        return Err(UnboundVariableSnafu {
+                        message: "atom contains unbound variable, or rule contains no variable at all",
+                    }.build().into())
                     }
                     NormalFormAtom::HnswSearch(_s) => {
-                        bail!("Atom contains unbound variable, or rule contains no variable at all")
+                        return Err(UnboundVariableSnafu {
+                        message: "atom contains unbound variable, or rule contains no variable at all",
+                    }.build().into())
                     }
                     NormalFormAtom::FtsSearch(_s) => {
-                        bail!("Atom contains unbound variable, or rule contains no variable at all")
+                        return Err(UnboundVariableSnafu {
+                        message: "atom contains unbound variable, or rule contains no variable at all",
+                    }.build().into())
                     }
                     NormalFormAtom::LshSearch(_s) => {
-                        bail!("Atom contains unbound variable, or rule contains no variable at all")
+                        return Err(UnboundVariableSnafu {
+                        message: "atom contains unbound variable, or rule contains no variable at all",
+                    }.build().into())
                     }
                 }
             }

--- a/crates/mneme/src/engine/query/stored.rs
+++ b/crates/mneme/src/engine/query/stored.rs
@@ -2,12 +2,11 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Arc;
 
-use crate::bail;
 use crate::engine::error::DbResult as Result;
+use crate::engine::query::error::*;
 use compact_str::CompactString;
 use itertools::Itertools;
 use pest::Parser;
-use snafu::Snafu;
 
 use crate::engine::data::expr::{Bytecode, Expr};
 use crate::engine::data::program::{
@@ -49,14 +48,26 @@ impl<'a> SessionTx<'a> {
         let mut replaced_old_triggers = None;
         if op == RelationOp::Replace {
             if !propagate_triggers {
-                bail!("replace op in trigger is not allowed")
+                return Err(StoredRelationSnafu {
+                    message: "replace op in trigger is not allowed",
+                }
+                .build()
+                .into());
             }
             if let Ok(old_handle) = self.get_relation(&meta.name, true) {
                 if !old_handle.indices.is_empty() {
-                    bail!("cannot replace relation since it has indices")
+                    return Err(StoredRelationSnafu {
+                        message: "cannot replace relation since it has indices",
+                    }
+                    .build()
+                    .into());
                 }
                 if old_handle.access_level < AccessLevel::Normal {
-                    bail!("Insufficient access level for this operation");
+                    return Err(InsufficientAccessSnafu {
+                        message: "Insufficient access level for this operation",
+                    }
+                    .build()
+                    .into());
                 }
                 if old_handle.has_triggers() {
                     replaced_old_triggers = Some((old_handle.put_triggers, old_handle.rm_triggers))
@@ -198,7 +209,11 @@ impl<'a> SessionTx<'a> {
             callback_targets.contains(&relation_store.name) || force_collect == relation_store.name;
 
         if relation_store.access_level < AccessLevel::Protected {
-            bail!("Insufficient access level for this operation");
+            return Err(InsufficientAccessSnafu {
+                message: "Insufficient access level for this operation",
+            }
+            .build()
+            .into());
         }
 
         let mut key_extractors = make_extractors(
@@ -256,11 +271,14 @@ impl<'a> SessionTx<'a> {
                 };
 
                 if already_exists {
-                    bail!(TransactAssertionFailure {
-                        relation: relation_store.name.to_string(),
-                        key: extracted,
-                        notice: "key exists in database".to_string()
-                    });
+                    return Err(StoredRelationSnafu {
+                        message: format!(
+                            "assertion failure for {:?} of {}: key exists in database",
+                            extracted, relation_store.name
+                        ),
+                    }
+                    .build()
+                    .into());
                 }
             }
 
@@ -438,7 +456,12 @@ impl<'a> SessionTx<'a> {
                 .get(name, &manifest.tokenizer, &manifest.filters)?;
 
             let parsed = DatalogParser::parse(Rule::expr, &manifest.extractor)
-                .map_err(|e| crate::engine::error::AdhocError(e.to_string()))?
+                .map_err(|e| {
+                    CompilationFailedSnafu {
+                        message: e.to_string(),
+                    }
+                    .build()
+                })?
                 .next()
                 .unwrap();
             let mut code_expr = build_expr(parsed, &Default::default())?;
@@ -453,7 +476,12 @@ impl<'a> SessionTx<'a> {
                 .get(name, &manifest.tokenizer, &manifest.filters)?;
 
             let parsed = DatalogParser::parse(Rule::expr, &manifest.extractor)
-                .map_err(|e| crate::engine::error::AdhocError(e.to_string()))?
+                .map_err(|e| {
+                    CompilationFailedSnafu {
+                        message: e.to_string(),
+                    }
+                    .build()
+                })?
                 .next()
                 .unwrap();
             let mut code_expr = build_expr(parsed, &Default::default())?;
@@ -472,7 +500,12 @@ impl<'a> SessionTx<'a> {
         for (name, (_, manifest)) in relation_store.hnsw_indices.iter() {
             if let Some(f_code) = &manifest.index_filter {
                 let parsed = DatalogParser::parse(Rule::expr, f_code)
-                    .map_err(|e| crate::engine::error::AdhocError(e.to_string()))?
+                    .map_err(|e| {
+                        CompilationFailedSnafu {
+                            message: e.to_string(),
+                        }
+                        .build()
+                    })?
                     .next()
                     .unwrap();
                 let mut code_expr = build_expr(parsed, &Default::default())?;
@@ -504,7 +537,11 @@ impl<'a> SessionTx<'a> {
             callback_targets.contains(&relation_store.name) || force_collect == relation_store.name;
 
         if relation_store.access_level < AccessLevel::Protected {
-            bail!("Insufficient access level for this operation");
+            return Err(InsufficientAccessSnafu {
+                message: "Insufficient access level for this operation",
+            }
+            .build()
+            .into());
         }
 
         let key_extractors = make_extractors(
@@ -551,11 +588,14 @@ impl<'a> SessionTx<'a> {
             };
             let original_val: Tuple = match original_val_bytes {
                 None => {
-                    bail!(TransactAssertionFailure {
-                        relation: relation_store.name.to_string(),
-                        key: new_kv,
-                        notice: "key to update does not exist".to_string()
-                    })
+                    return Err(StoredRelationSnafu {
+                        message: format!(
+                            "assertion failure for {:?} of {}: key to update does not exist",
+                            new_kv, relation_store.name
+                        ),
+                    }
+                    .build()
+                    .into());
                 }
                 Some(v) => rmp_serde::from_slice(&v[ENCODED_KEY_MIN_LEN..])
                     .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)?,
@@ -762,7 +802,11 @@ impl<'a> SessionTx<'a> {
         span: SourceSpan,
     ) -> Result<()> {
         if relation_store.access_level < AccessLevel::ReadOnly {
-            bail!("Insufficient access level for this operation");
+            return Err(InsufficientAccessSnafu {
+                message: "Insufficient access level for this operation",
+            }
+            .build()
+            .into());
         }
 
         let key_extractors = make_extractors(
@@ -784,11 +828,14 @@ impl<'a> SessionTx<'a> {
                 self.store_tx.exists(&key, true)?
             };
             if already_exists {
-                bail!(TransactAssertionFailure {
-                    relation: relation_store.name.to_string(),
-                    key: extracted,
-                    notice: "key exists in database".to_string()
-                })
+                return Err(StoredRelationSnafu {
+                    message: format!(
+                        "assertion failure for {:?} of {}: key exists in database",
+                        extracted, relation_store.name
+                    ),
+                }
+                .build()
+                .into());
             }
         }
         Ok(())
@@ -805,7 +852,11 @@ impl<'a> SessionTx<'a> {
         span: SourceSpan,
     ) -> Result<()> {
         if relation_store.access_level < AccessLevel::ReadOnly {
-            bail!("Insufficient access level for this operation");
+            return Err(InsufficientAccessSnafu {
+                message: "Insufficient access level for this operation",
+            }
+            .build()
+            .into());
         }
 
         let mut key_extractors = make_extractors(
@@ -839,19 +890,25 @@ impl<'a> SessionTx<'a> {
             };
             match existing {
                 None => {
-                    bail!(TransactAssertionFailure {
-                        relation: relation_store.name.to_string(),
-                        key: extracted,
-                        notice: "key does not exist in database".to_string()
-                    })
+                    return Err(StoredRelationSnafu {
+                        message: format!(
+                            "assertion failure for {:?} of {}: key does not exist in database",
+                            extracted, relation_store.name
+                        ),
+                    }
+                    .build()
+                    .into());
                 }
                 Some(v) => {
                     if &v as &[u8] != &val as &[u8] {
-                        bail!(TransactAssertionFailure {
-                            relation: relation_store.name.to_string(),
-                            key: extracted,
-                            notice: "key exists in database, but value does not match".to_string()
-                        })
+                        return Err(StoredRelationSnafu {
+                            message: format!(
+                                "assertion failure for {:?} of {}: key exists in database, but value does not match",
+                                extracted, relation_store.name
+                            ),
+                        }
+                        .build()
+                        .into());
                     }
                 }
             }
@@ -880,7 +937,11 @@ impl<'a> SessionTx<'a> {
             callback_targets.contains(&relation_store.name) || force_collect == relation_store.name;
 
         if relation_store.access_level < AccessLevel::Protected {
-            bail!("Insufficient access level for this operation");
+            return Err(InsufficientAccessSnafu {
+                message: "Insufficient access level for this operation",
+            }
+            .build()
+            .into());
         }
         let key_extractors = make_extractors(
             &relation_store.metadata.keys,
@@ -915,11 +976,14 @@ impl<'a> SessionTx<'a> {
                     self.store_tx.exists(&key, false)?
                 };
                 if !exists {
-                    bail!(TransactAssertionFailure {
-                        relation: relation_store.name.to_string(),
-                        key: extracted,
-                        notice: "key does not exists in database".to_string()
-                    });
+                    return Err(StoredRelationSnafu {
+                        message: format!(
+                            "assertion failure for {:?} of {}: key does not exists in database",
+                            extracted, relation_store.name
+                        ),
+                    }
+                    .build()
+                    .into());
                 }
             }
             if need_to_collect
@@ -1049,14 +1113,6 @@ impl<'a> SessionTx<'a> {
     }
 }
 
-#[derive(Debug, Snafu)]
-#[snafu(display("Assertion failure for {key:?} of {relation}: {notice}"))]
-struct TransactAssertionFailure {
-    relation: String,
-    key: Vec<DataValue>,
-    notice: String,
-}
-
 enum DataExtractor {
     DefaultExtractor(Expr, NullableColType),
     IndexExtractor(usize, NullableColType),
@@ -1068,15 +1124,17 @@ impl DataExtractor {
             DataExtractor::DefaultExtractor(expr, typ) => typ
                 .coerce(expr.clone().eval_to_const()?, cur_vld)
                 .map_err(|e| {
-                    crate::engine::error::AdhocError(format!(
-                        "{e}: when processing tuple {tuple:?}"
-                    ))
+                    EvalFailedSnafu {
+                        message: format!("{e}: when processing tuple {tuple:?}"),
+                    }
+                    .build()
                 })?,
             DataExtractor::IndexExtractor(i, typ) => {
                 typ.coerce(tuple[*i].clone(), cur_vld).map_err(|e| {
-                    crate::engine::error::AdhocError(format!(
-                        "{e}: when processing tuple {tuple:?}"
-                    ))
+                    EvalFailedSnafu {
+                        message: format!("{e}: when processing tuple {tuple:?}"),
+                    }
+                    .build()
                 })?
             }
         })
@@ -1134,10 +1192,11 @@ fn make_extractor(
             stored.typing.clone(),
         ))
     } else {
-        Err(Box::new(crate::engine::error::AdhocError(
-            "cannot make extractor for column".to_string(),
-        ))
-            as Box<dyn std::error::Error + Send + Sync + 'static>)
+        Err(StoredRelationSnafu {
+            message: "cannot make extractor for column",
+        }
+        .build()
+        .into())
     }
 }
 

--- a/crates/mneme/src/engine/query/stratify.rs
+++ b/crates/mneme/src/engine/query/stratify.rs
@@ -3,7 +3,7 @@ use std::collections::btree_map::Entry;
 use std::collections::{BTreeMap, BTreeSet};
 
 use crate::engine::error::DbResult as Result;
-use crate::ensure;
+use crate::engine::query::error::*;
 use itertools::Itertools;
 
 use crate::engine::data::program::{
@@ -150,7 +150,12 @@ fn verify_no_cycle(g: &StratifiedGraph<&'_ Symbol>, sccs: &[BTreeSet<&Symbol>]) 
         for scc in sccs {
             if scc.contains(k) {
                 for (v, negated) in vs {
-                    ensure!(!negated || !scc.contains(v), "Query is unstratifiable");
+                    snafu::ensure!(
+                        !negated || !scc.contains(v),
+                        StratificationFailedSnafu {
+                            message: "query is unstratifiable",
+                        }
+                    );
                 }
             }
         }


### PR DESCRIPTION
## Summary

- Add `engine/query/error.rs` with structured `QueryError` snafu enum containing 13 variants: `CompilationFailed`, `InvalidRelation`, `StratificationFailed`, `TypeError`, `GraphTraversal`, `EvalFailed`, `ArityMismatch`, `UnsafeRule`, `InsufficientAccess`, `InvalidTimeTravel`, `FieldNotFound`, `UnboundVariable`, `StoredRelation`, plus `Data` and `Parse` source-wrapping variants
- Remove blanket `#[allow(clippy::all, clippy::restriction, unused_assignments)]` from query module in `engine/mod.rs`
- Convert all `bail!`/`ensure!`/`AdhocError`/`miette!` usage across 9 query files to structured `QueryError` variants
- Convert `#[allow(clippy::needless_borrow)]` → `#[expect(..., reason = "...")]` in `eval.rs`
- Remove inline error structs `TransactAssertionFailure` (stored.rs) and `NamedFieldNotFound` (logical.rs)
- Add `into_box_err()` bridge method and `IntoDbResult` extension trait for cross-module boundaries

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy -p aletheia-mneme --all-targets -- -D warnings` zero warnings
- [x] `cargo test -p aletheia-mneme` — 643 tests pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] Zero `bail!`/`miette!`/`AdhocError` remaining in `engine/query/`
- [x] Zero `#[allow]` remaining in `engine/query/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)