### PR TITLE
fix(mneme): eliminate unwrap() and audit unsafe in query/ module

### DIFF
--- a/crates/mneme/src/engine/query/compile.rs
+++ b/crates/mneme/src/engine/query/compile.rs
@@ -617,7 +617,10 @@ impl<'a> SessionTx<'a> {
         let cur_ret_set: BTreeSet<_> = ret.bindings_after_eliminate().into_iter().collect();
 
         if cur_ret_set != ret_vars_set {
-            let unbound = ret_vars_set.difference(&cur_ret_set).next().unwrap();
+            let unbound = ret_vars_set
+                .difference(&cur_ret_set)
+                .next()
+                .expect("difference is non-empty: cur_ret_set != ret_vars_set checked above");
             return Err(UnboundVariableSnafu {
                 message: format!("symbol '{unbound}' in rule head is unbound"),
             }

--- a/crates/mneme/src/engine/query/eval.rs
+++ b/crates/mneme/src/engine/query/eval.rs
@@ -288,7 +288,9 @@ impl<'a> SessionTx<'a> {
             }
             let mut changed = false;
             for (k, new_store) in to_merge {
-                let old_store = stores.get_mut(k).unwrap();
+                let old_store = stores
+                    .get_mut(k)
+                    .expect("to_merge key always present in stores: derived from stores entries");
                 old_store.merge_in(new_store)?;
                 trace!("delta for {}: {}", k, old_store.has_delta());
                 changed |= old_store.has_delta();
@@ -367,8 +369,13 @@ impl<'a> SessionTx<'a> {
             let value: Vec<_> = aggr
                 .iter()
                 .map(|a| -> Result<DataValue> {
-                    let (aggr, _) = a.as_ref().unwrap();
-                    let op = aggr.meet_op.as_ref().unwrap();
+                    let (aggr, _) = a
+                        .as_ref()
+                        .expect("aggr is Some: filtered with all(|a| a.is_some()) above");
+                    let op = aggr
+                        .meet_op
+                        .as_ref()
+                        .expect("meet_op is Some: meet aggregation validated at compile time");
                     Ok(op.init_val())
                 })
                 .try_collect()?;
@@ -425,7 +432,7 @@ impl<'a> SessionTx<'a> {
                             aggr_ops[aggr_idx]
                                 .normal_op
                                 .as_mut()
-                                .unwrap()
+                                .expect("normal_op is Some: set by normal_init in Vacant branch")
                                 .set(&item[*tuple_idx])?;
                         }
                     }
@@ -434,7 +441,11 @@ impl<'a> SessionTx<'a> {
                         for (i, (aggr, params)) in &val_indices_and_aggrs {
                             let mut cur_aggr = aggr.clone();
                             cur_aggr.normal_init(params)?;
-                            cur_aggr.normal_op.as_mut().unwrap().set(&item[*i])?;
+                            cur_aggr
+                                .normal_op
+                                .as_mut()
+                                .expect("normal_op is Some: set by normal_init immediately above")
+                                .set(&item[*i])?;
                             aggr_ops.push(cur_aggr)
                         }
                         ent.insert(aggr_ops);
@@ -462,10 +473,14 @@ impl<'a> SessionTx<'a> {
                 .aggr
                 .iter()
                 .map(|a| {
-                    let (aggr, args) = a.as_ref().unwrap();
+                    let (aggr, args) = a
+                        .as_ref()
+                        .expect("aggr is Some: checked with all(|v| v.is_some()) above");
                     let mut aggr = aggr.clone();
                     aggr.normal_init(args)?;
-                    let op = aggr.normal_op.unwrap();
+                    let op = aggr
+                        .normal_op
+                        .expect("normal_op is Some: set by normal_init immediately above");
                     op.get()
                 })
                 .try_collect()?;
@@ -477,7 +492,11 @@ impl<'a> SessionTx<'a> {
                 .iter()
                 .map(|(is_aggr, idx)| {
                     if *is_aggr {
-                        aggrs[*idx].normal_op.as_ref().unwrap().get()
+                        aggrs[*idx]
+                            .normal_op
+                            .as_ref()
+                            .expect("normal_op is Some: all aggr ops initialised before collection")
+                            .get()
                     } else {
                         Ok(keys[*idx].clone())
                     }
@@ -511,7 +530,9 @@ impl<'a> SessionTx<'a> {
         limiter: &QueryLimiter,
         poison: Poison,
     ) -> Result<(bool, RegularTempStore)> {
-        let prev_store = stores.get(rule_symb).unwrap();
+        let prev_store = stores
+            .get(rule_symb)
+            .expect("rule_symb always present in stores: inserted during plan compilation");
         let mut out_store = RegularTempStore::default();
         let should_check_limit = limiter.total.is_some() && rule_symb.is_prog_entry();
         for (rule_n, rule) in ruleset.iter().enumerate() {
@@ -519,7 +540,11 @@ impl<'a> SessionTx<'a> {
             let mut dependencies_changed = false;
 
             for (symb, multiplicity) in rule.contained_rules.iter() {
-                if stores.get(symb).unwrap().has_delta() {
+                if stores
+                    .get(symb)
+                    .expect("contained rule symbol always present in stores: validated by compiler")
+                    .has_delta()
+                {
                     dependencies_changed = true;
                     if *multiplicity == ContainedRuleMultiplicity::Many {
                         need_complete_run = true;
@@ -611,7 +636,11 @@ impl<'a> SessionTx<'a> {
             let mut dependencies_changed = false;
 
             for (symb, multiplicity) in rule.contained_rules.iter() {
-                if stores.get(symb).unwrap().has_delta() {
+                if stores
+                    .get(symb)
+                    .expect("contained rule symbol always present in stores: validated by compiler")
+                    .has_delta()
+                {
                     dependencies_changed = true;
                     if *multiplicity == ContainedRuleMultiplicity::Many {
                         need_complete_run = true;

--- a/crates/mneme/src/engine/query/graph.rs
+++ b/crates/mneme/src/engine/query/graph.rs
@@ -105,7 +105,9 @@ pub(crate) fn generalized_kahn(
             }
             break;
         }
-        let removed = safe_pending.pop().unwrap();
+        let removed = safe_pending
+            .pop()
+            .expect("safe_pending is non-empty: checked by is_empty guard above");
         current_stratum.push(removed);
         if let Some(edges) = graph.get(&removed) {
             for (nxt, poisoned) in edges {
@@ -173,10 +175,12 @@ impl<'a> TarjanScc<'a> {
                 self.low[at] = min(self.low[at], self.low[to]);
             }
         }
-        if self.ids[at].unwrap() == self.low[at] {
+        if self.ids[at].expect("ids[at] is Some: assigned on dfs() entry (line above recursive call)")
+            == self.low[at]
+        {
             while let Some(node) = self.stack.pop() {
                 self.on_stack[node] = false;
-                self.low[node] = self.ids[at].unwrap();
+                self.low[node] = self.ids[at].expect("ids[at] is Some: same assignment as above");
                 if node == at {
                     break;
                 }

--- a/crates/mneme/src/engine/query/magic.rs
+++ b/crates/mneme/src/engine/query/magic.rs
@@ -187,7 +187,7 @@ fn magic_rewrite_ruleset(
                             .entry(sup_kw.clone())
                             .or_default()
                             .mut_rules()
-                            .unwrap();
+                            .expect("entry is Rules variant: Default creates MagicRulesOrFixed::Rules");
                         let mut sup_rule_atoms = vec![];
                         mem::swap(&mut sup_rule_atoms, &mut collected_atoms);
 
@@ -216,7 +216,7 @@ fn magic_rewrite_ruleset(
                             .entry(inp_kw.clone())
                             .or_default()
                             .mut_rules()
-                            .unwrap();
+                            .expect("entry is Rules variant: Default creates MagicRulesOrFixed::Rules");
                         let inp_args = r_app
                             .args
                             .iter()
@@ -245,7 +245,7 @@ fn magic_rewrite_ruleset(
             .entry(rule_head.clone())
             .or_default()
             .mut_rules()
-            .unwrap();
+            .expect("entry is Rules variant: Default creates MagicRulesOrFixed::Rules");
         entry.push(MagicInlineRule {
             head: rule.head,
             aggr: rule.aggr,
@@ -343,7 +343,13 @@ impl NormalFormProgram {
                                                         .metadata
                                                         .keys
                                                         .last()
-                                                        .unwrap()
+                                                        .ok_or_else(|| {
+                                                            InvalidTimeTravelSnafu {
+                                                                message: format!("relation '{name}' has no key columns"),
+                                                            }
+                                                            .build()
+                                                            .into_box_err()
+                                                        })?
                                                         .typing;
                                                     if *last_col_type
                                                         != (NullableColType {
@@ -376,7 +382,13 @@ impl NormalFormProgram {
                                                         .metadata
                                                         .keys
                                                         .last()
-                                                        .unwrap()
+                                                        .ok_or_else(|| {
+                                                            InvalidTimeTravelSnafu {
+                                                                message: format!("relation '{name}' has no key columns"),
+                                                            }
+                                                            .build()
+                                                            .into_box_err()
+                                                        })?
                                                         .typing;
                                                     if *last_col_type
                                                         != (NullableColType {
@@ -464,9 +476,19 @@ impl NormalFormProgram {
             let original_rules = self
                 .prog
                 .get(head.as_plain_symbol())
-                .unwrap()
+                .expect("adorned head always has a corresponding entry in prog: \
+                         pending_adornment is seeded from prog keys")
                 .rules()
-                .unwrap();
+                .ok_or_else(|| {
+                    CompilationFailedSnafu {
+                        message: format!(
+                            "expected rules for '{}' but found fixed rule",
+                            head.as_plain_symbol()
+                        ),
+                    }
+                    .build()
+                    .into_box_err()
+                })?;
             let adornment = head.magic_adornment();
             let mut adorned_rules = Vec::with_capacity(original_rules.len());
             for rule in original_rules {

--- a/crates/mneme/src/engine/query/ra.rs
+++ b/crates/mneme/src/engine/query/ra.rs
@@ -250,7 +250,7 @@ impl Debug for RelAlgebra {
                 } else if r.data.len() == 1 {
                     f.debug_tuple("Singlet")
                         .field(&bindings)
-                        .field(r.data.first().unwrap())
+                        .field(r.data.first().expect("data.len() == 1 checked above"))
                         .finish()
                 } else {
                     f.debug_tuple("Fixed")
@@ -418,7 +418,14 @@ impl RelAlgebra {
                 span,
             })),
             Some(vld) => {
-                if storage.metadata.keys.last().unwrap().typing
+                let last_key = storage.metadata.keys.last().ok_or_else(|| {
+                    InvalidTimeTravelSnafu {
+                        message: "relation has no key columns",
+                    }
+                    .build()
+                    .into_box_err()
+                })?;
+                if last_key.typing
                     != (NullableColType {
                         coltype: ColType::Validity,
                         nullable: false,
@@ -1014,9 +1021,11 @@ impl FtsSearchRA {
                             match d {
                                 DataValue::Str(s) => {
                                     if !coll.is_empty() {
-                                        coll.write_str(" OR ").unwrap();
+                                        coll.write_str(" OR ")
+                                            .expect("write to CompactString is infallible");
                                     }
-                                    coll.write_str(&s).unwrap();
+                                    coll.write_str(&s)
+                                        .expect("write to CompactString is infallible");
                                 }
                                 d => {
                                     return Err(TypeSnafu {
@@ -1548,7 +1557,9 @@ impl TempStoreRA {
         delta_rule: Option<&MagicSymbol>,
         stores: &'a BTreeMap<MagicSymbol, EpochStore>,
     ) -> Result<TupleIter<'a>> {
-        let storage = stores.get(&self.storage_key).unwrap();
+        let storage = stores
+            .get(&self.storage_key)
+            .expect("TempStoreRA storage_key always present in stores: inserted by compiler");
 
         let scan_epoch = match delta_rule {
             None => false,
@@ -1572,7 +1583,9 @@ impl TempStoreRA {
         eliminate_indices: BTreeSet<usize>,
         stores: &'a BTreeMap<MagicSymbol, EpochStore>,
     ) -> Result<TupleIter<'a>> {
-        let storage = stores.get(&self.storage_key).unwrap();
+        let storage = stores
+            .get(&self.storage_key)
+            .expect("StoredRA storage_key always present in stores: inserted by compiler");
         debug_assert!(!right_join_indices.is_empty());
         let mut right_invert_indices = right_join_indices.iter().enumerate().collect_vec();
         right_invert_indices.sort_by_key(|(_, b)| **b);
@@ -1671,7 +1684,9 @@ impl TempStoreRA {
         delta_rule: Option<&MagicSymbol>,
         stores: &'a BTreeMap<MagicSymbol, EpochStore>,
     ) -> Result<TupleIter<'a>> {
-        let storage = stores.get(&self.storage_key).unwrap();
+        let storage = stores
+            .get(&self.storage_key)
+            .expect("StoredRA storage_key always present in stores: inserted by compiler");
 
         let mut right_invert_indices = right_join_indices.iter().enumerate().collect_vec();
         right_invert_indices.sort_by_key(|(_, b)| **b);
@@ -1809,8 +1824,12 @@ impl Joiner {
         let mut ret_l = Vec::with_capacity(self.left_keys.len());
         let mut ret_r = Vec::with_capacity(self.left_keys.len());
         for (l, r) in self.left_keys.iter().zip(self.right_keys.iter()) {
-            let l_pos = left_binding_map.get(l).unwrap();
-            let r_pos = right_binding_map.get(r).unwrap();
+            let l_pos = left_binding_map
+                .get(l)
+                .expect("left join key always present in left bindings: validated by compiler");
+            let r_pos = right_binding_map
+                .get(r)
+                .expect("right join key always present in right bindings: validated by compiler");
             ret_l.push(*l_pos);
             ret_r.push(*r_pos)
         }
@@ -1951,7 +1970,7 @@ impl NegJoin {
                         &self.left.bindings_after_eliminate(),
                         &self.right.bindings_after_eliminate(),
                     )
-                    .unwrap();
+                    .expect("join_indices always succeeds for validated plan");
                 if join_is_prefix(&join_indices.1) {
                     "mem_neg_prefix_join"
                 } else {
@@ -1965,7 +1984,7 @@ impl NegJoin {
                         &self.left.bindings_after_eliminate(),
                         &self.right.bindings_after_eliminate(),
                     )
-                    .unwrap();
+                    .expect("join_indices always succeeds for validated plan");
                 if join_is_prefix(&join_indices.1) {
                     "stored_neg_prefix_join"
                 } else {
@@ -1993,8 +2012,7 @@ impl NegJoin {
                     .join_indices(
                         &self.left.bindings_after_eliminate(),
                         &self.right.bindings_after_eliminate(),
-                    )
-                    .unwrap();
+                    )?;
                 r.neg_join(
                     self.left.iter(tx, delta_rule, stores)?,
                     join_indices,
@@ -2008,8 +2026,7 @@ impl NegJoin {
                     .join_indices(
                         &self.left.bindings_after_eliminate(),
                         &self.right.bindings_after_eliminate(),
-                    )
-                    .unwrap();
+                    )?;
                 v.neg_join(
                     tx,
                     self.left.iter(tx, delta_rule, stores)?,
@@ -2073,7 +2090,7 @@ impl InnerJoin {
                         &self.left.bindings_after_eliminate(),
                         &self.right.bindings_after_eliminate(),
                     )
-                    .unwrap();
+                    .expect("join_indices always succeeds for validated plan");
                 if join_is_prefix(&join_indices.1) {
                     "mem_prefix_join"
                 } else {
@@ -2087,7 +2104,7 @@ impl InnerJoin {
                         &self.left.bindings_after_eliminate(),
                         &self.right.bindings_after_eliminate(),
                     )
-                    .unwrap();
+                    .expect("join_indices always succeeds for validated plan");
                 if join_is_prefix(&join_indices.1) {
                     "stored_prefix_join"
                 } else {
@@ -2104,7 +2121,7 @@ impl InnerJoin {
                         &self.left.bindings_after_eliminate(),
                         &self.right.bindings_after_eliminate(),
                     )
-                    .unwrap();
+                    .expect("join_indices always succeeds for validated plan");
                 if join_is_prefix(&join_indices.1) {
                     "stored_prefix_join"
                 } else {
@@ -2137,8 +2154,7 @@ impl InnerJoin {
                     .join_indices(
                         &self.left.bindings_after_eliminate(),
                         &self.right.bindings_after_eliminate(),
-                    )
-                    .unwrap();
+                    )?;
                 f.join(
                     self.left.iter(tx, delta_rule, stores)?,
                     join_indices,
@@ -2151,8 +2167,7 @@ impl InnerJoin {
                     .join_indices(
                         &self.left.bindings_after_eliminate(),
                         &self.right.bindings_after_eliminate(),
-                    )
-                    .unwrap();
+                    )?;
                 if join_is_prefix(&join_indices.1) {
                     r.prefix_join(
                         self.left.iter(tx, delta_rule, stores)?,
@@ -2171,8 +2186,7 @@ impl InnerJoin {
                     .join_indices(
                         &self.left.bindings_after_eliminate(),
                         &self.right.bindings_after_eliminate(),
-                    )
-                    .unwrap();
+                    )?;
                 if join_is_prefix(&join_indices.1) {
                     r.prefix_join(
                         tx,
@@ -2190,8 +2204,7 @@ impl InnerJoin {
                     .join_indices(
                         &self.left.bindings_after_eliminate(),
                         &self.right.bindings_after_eliminate(),
-                    )
-                    .unwrap();
+                    )?;
                 if join_is_prefix(&join_indices.1) {
                     r.prefix_join(
                         tx,
@@ -2230,8 +2243,7 @@ impl InnerJoin {
         let right_bindings = self.right.bindings_after_eliminate();
         let (left_join_indices, right_join_indices) = self
             .joiner
-            .join_indices(&self.left.bindings_after_eliminate(), &right_bindings)
-            .unwrap();
+            .join_indices(&self.left.bindings_after_eliminate(), &right_bindings)?;
 
         let mut left_iter = self.left.iter(tx, delta_rule, stores)?;
         let left_cache = match left_iter.next() {

--- a/crates/mneme/src/engine/query/stored.rs
+++ b/crates/mneme/src/engine/query/stored.rs
@@ -76,7 +76,9 @@ impl<'a> SessionTx<'a> {
                     let program = parse_script(
                         trigger,
                         &Default::default(),
-                        &db.fixed_rules.read().unwrap(),
+                        &db.fixed_rules
+                    .read()
+                    .expect("fixed_rules lock is not poisoned"),
                         cur_vld,
                     )?
                     .get_single_program()?;
@@ -361,7 +363,9 @@ impl<'a> SessionTx<'a> {
         new_kv: &[DataValue],
     ) -> Result<()> {
         for (k, (idx_handle, _)) in rel_handle.fts_indices.iter() {
-            let (tokenizer, extractor) = processors.get(k).unwrap();
+            let (tokenizer, extractor) = processors
+                .get(k)
+                .expect("FTS processor always present: built from same fts_indices keys");
             self.put_fts_index_item(new_kv, extractor, stack, tokenizer, rel_handle, idx_handle)?;
         }
         Ok(())
@@ -375,7 +379,9 @@ impl<'a> SessionTx<'a> {
         old_kv: &[DataValue],
     ) -> Result<()> {
         for (k, (idx_handle, _)) in rel_handle.fts_indices.iter() {
-            let (tokenizer, extractor) = processors.get(k).unwrap();
+            let (tokenizer, extractor) = processors
+                .get(k)
+                .expect("FTS processor always present: built from same fts_indices keys");
             self.del_fts_index_item(old_kv, extractor, stack, tokenizer, rel_handle, idx_handle)?;
         }
         Ok(())
@@ -390,7 +396,9 @@ impl<'a> SessionTx<'a> {
         hash_perms_map: &BTreeMap<CompactString, HashPermutations>,
     ) -> Result<()> {
         for (k, (idx_handle, inv_idx_handle, manifest)) in rel_handle.lsh_indices.iter() {
-            let (tokenizer, extractor) = processors.get(k).unwrap();
+            let (tokenizer, extractor) = processors
+                .get(k)
+                .expect("LSH processor always present: built from same lsh_indices keys");
             self.put_lsh_index_item(
                 new_kv,
                 extractor,
@@ -400,7 +408,9 @@ impl<'a> SessionTx<'a> {
                 idx_handle,
                 inv_idx_handle,
                 manifest,
-                hash_perms_map.get(k).unwrap(),
+                hash_perms_map
+                    .get(k)
+                    .expect("hash_perms always present: built from same lsh_indices keys"),
             )?;
         }
         Ok(())
@@ -463,7 +473,15 @@ impl<'a> SessionTx<'a> {
                     .build()
                 })?
                 .next()
-                .unwrap();
+                .ok_or_else(|| {
+                    CompilationFailedSnafu {
+                        message: format!(
+                            "FTS extractor expression for '{name}' parsed to empty iterator"
+                        ),
+                    }
+                    .build()
+                    .into_box_err()
+                })?;
             let mut code_expr = build_expr(parsed, &Default::default())?;
             let binding_map = relation_store.raw_binding_map();
             code_expr.fill_binding_indices(&binding_map)?;
@@ -483,7 +501,15 @@ impl<'a> SessionTx<'a> {
                     .build()
                 })?
                 .next()
-                .unwrap();
+                .ok_or_else(|| {
+                    CompilationFailedSnafu {
+                        message: format!(
+                            "LSH extractor expression for '{name}' parsed to empty iterator"
+                        ),
+                    }
+                    .build()
+                    .into_box_err()
+                })?;
             let mut code_expr = build_expr(parsed, &Default::default())?;
             let binding_map = relation_store.raw_binding_map();
             code_expr.fill_binding_indices(&binding_map)?;
@@ -507,7 +533,15 @@ impl<'a> SessionTx<'a> {
                         .build()
                     })?
                     .next()
-                    .unwrap();
+                    .ok_or_else(|| {
+                        CompilationFailedSnafu {
+                            message: format!(
+                                "HNSW index filter for '{name}' parsed to empty iterator"
+                            ),
+                        }
+                        .build()
+                        .into_box_err()
+                    })?;
                 let mut code_expr = build_expr(parsed, &Default::default())?;
                 let binding_map = relation_store.raw_binding_map();
                 code_expr.fill_binding_indices(&binding_map)?;
@@ -702,7 +736,9 @@ impl<'a> SessionTx<'a> {
                 let mut program = parse_script(
                     trigger,
                     &Default::default(),
-                    &db.fixed_rules.read().unwrap(),
+                    &db.fixed_rules
+                    .read()
+                    .expect("fixed_rules lock is not poisoned"),
                     cur_vld,
                 )?
                 .get_single_program()?;
@@ -1048,7 +1084,9 @@ impl<'a> SessionTx<'a> {
                     let mut program = parse_script(
                         trigger,
                         &Default::default(),
-                        &db.fixed_rules.read().unwrap(),
+                        &db.fixed_rules
+                    .read()
+                    .expect("fixed_rules lock is not poisoned"),
                         cur_vld,
                     )?
                     .get_single_program()?;

--- a/crates/mneme/src/engine/query/stratify.rs
+++ b/crates/mneme/src/engine/query/stratify.rs
@@ -174,7 +174,9 @@ fn make_scc_reduced_graph(
         .collect::<BTreeMap<_, _>>();
     let mut ret: BTreeMap<usize, BTreeMap<usize, bool>> = Default::default();
     for (from, tos) in graph {
-        let from_idx = *indices.get(from).unwrap();
+        let from_idx = *indices
+            .get(from)
+            .expect("'from' always in indices: built from same graph structure as sccs");
         let cur_entry = ret.entry(from_idx).or_default();
         for (to, poisoned) in tos {
             let to_idx = match indices.get(to) {
@@ -276,7 +278,9 @@ impl NormalFormProgram {
         for (name, ruleset) in self.prog {
             if let Some(scc_idx) = invert_indices.get(&name) {
                 if let Some(rev_stratum_idx) = invert_sort_result.get(scc_idx) {
-                    let target = ret.get_mut(*rev_stratum_idx).unwrap();
+                    let target = ret
+                        .get_mut(*rev_stratum_idx)
+                        .expect("stratum index always valid: rev_stratum_idx derived from ret's range");
                     target.prog.insert(name, ruleset);
                 }
             }


### PR DESCRIPTION
## Summary

- **Zero `unwrap()` in non-test code** under `engine/query/`: all 58 occurrences replaced with `.expect("reason")` or proper `?` propagation
- **Unsafe audit complete**: no `unsafe` Rust blocks exist in `engine/query/` — occurrences of the word "unsafe" in `graph.rs` and `reorder.rs` are variable names and error-message strings only; no SAFETY comments needed
- **No behavioral changes**: all 694 tests pass, clippy clean

### Replacement strategy (by file)

| File | Pattern | Fix |
|------|---------|-----|
| `ra.rs` | `join_indices().unwrap()` in `iter()` | `?` propagation |
| `ra.rs` | `join_indices().unwrap()` in `join_type()` (returns `&str`) | `.expect()` (diagnostic, non-Result) |
| `ra.rs` | `stores.get(&storage_key).unwrap()` | `.expect()` (compiler-insertion invariant) |
| `ra.rs` | `write_str(...).unwrap()` on `CompactString` | `.expect()` (infallible write) |
| `ra.rs` | `metadata.keys.last().unwrap()` | `.ok_or_else()` → `InvalidTimeTravelSnafu` |
| `eval.rs` | `stores.get(symb).unwrap()` | `.expect()` (plan-compilation invariant) |
| `eval.rs` | `normal_op.as_ref().unwrap()` / `.as_mut().unwrap()` | `.expect()` (post-`normal_init` invariant) |
| `eval.rs` | `a.as_ref().unwrap()` in filtered iter | `.expect()` (`is_some()` guard above) |
| `compile.rs` | `difference().next().unwrap()` | `.expect()` (sets unequal, checked above) |
| `stored.rs` | `fixed_rules.read().unwrap()` | `.expect()` (poisoned lock is a fatal internal error) |
| `stored.rs` | `processors.get(k).unwrap()` | `.expect()` (built from same index keys) |
| `stored.rs` | `parse(...).next().unwrap()` | `.ok_or_else()` → `CompilationFailedSnafu` |
| `stratify.rs` | `indices.get(from).unwrap()` | `.expect()` (structural invariant) |
| `graph.rs` | `safe_pending.pop().unwrap()` | `.expect()` (non-empty guard above) |
| `graph.rs` | `self.ids[at].unwrap()` | `.expect()` (assigned on dfs entry) |
| `magic.rs` | `mut_rules().unwrap()` | `.expect()` (`Default` creates `Rules` variant) |
| `magic.rs` | `keys.last().unwrap()` | `.ok_or_else()` → `InvalidTimeTravelSnafu` |
| `magic.rs` | `prog.get().unwrap().rules().unwrap()` | `.expect()` + `.ok_or_else()` → `CompilationFailedSnafu` |

### Depends on
P240 (`refactor/query-errors`) — already squash-merged to main as #726.

## Test plan

- [x] `cargo check -p aletheia-mneme --features mneme-engine,storage-redb` — clean
- [x] `cargo test -p aletheia-mneme` — 694 passed, 0 failed
- [x] `cargo clippy -p aletheia-mneme --all-targets -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)