### PR TITLE
fix(tui): pre-cutover quality pass

### DIFF
--- a/tui/src/app.rs
+++ b/tui/src/app.rs
@@ -222,7 +222,17 @@ impl App {
         }
 
         // SAFETY: sanitized at ingestion — all agent fields from API are sanitized here.
-        let agents = self.client.agents().await?;
+        // Best-effort: if agent fetch fails, start with empty list and show error toast.
+        let agents = match self.client.agents().await {
+            Ok(a) => a,
+            Err(e) => {
+                tracing::error!("failed to load agents: {e}");
+                self.error_toast = Some(ErrorToast::new(format!(
+                    "Failed to load agents: {e}. Retry with :reconnect"
+                )));
+                Vec::new()
+            }
+        };
         self.agents = agents
             .into_iter()
             .map(|a| {
@@ -421,6 +431,7 @@ impl App {
             tab.state.active_turn_id = self.active_turn_id.clone();
             tab.state.cached_markdown_text = self.cached_markdown_text.clone();
             tab.state.cached_markdown_lines = self.cached_markdown_lines.clone();
+            tab.state.ops = self.ops.clone();
         }
     }
 
@@ -443,6 +454,7 @@ impl App {
             self.active_turn_id = tab.state.active_turn_id.clone();
             self.cached_markdown_text = tab.state.cached_markdown_text.clone();
             self.cached_markdown_lines = tab.state.cached_markdown_lines.clone();
+            self.ops = tab.state.ops.clone();
         }
     }
 
@@ -589,6 +601,7 @@ pub(crate) mod test_helpers {
 #[cfg(test)]
 mod tests {
     use super::test_helpers::*;
+    use crate::state::{ChatMessage, OpsState};
 
     #[test]
     fn test_app_constructs_with_defaults() {
@@ -625,5 +638,79 @@ mod tests {
         let mut app = test_app();
         assert!(app.take_stream().is_none());
         app.restore_stream(None);
+    }
+
+    #[test]
+    fn tab_state_save_restore_roundtrip() {
+        let mut app = test_app();
+        let agent = test_agent("syn", "Syn");
+        let agent_id = agent.id.clone();
+        app.agents.push(agent);
+        app.focused_agent = Some(agent_id.clone());
+
+        // Create two tabs
+        let idx0 = app.tab_bar.create_tab(agent_id.clone(), "tab0");
+        app.tab_bar.active = idx0;
+
+        // Set up state in tab0
+        app.messages = vec![ChatMessage {
+            role: "user".to_string(),
+            text: "hello from tab0".to_string(),
+            text_lower: "hello from tab0".to_string(),
+            timestamp: None,
+            model: None,
+            is_streaming: false,
+            tool_calls: Vec::new(),
+        }];
+        app.scroll_offset = 42;
+        app.auto_scroll = false;
+        app.input.text = "typing in tab0".to_string();
+        app.ops.thinking.text = "thinking in tab0".to_string();
+        app.ops.push_tool_start("read_file".to_string(), None);
+        app.save_to_active_tab();
+
+        // Create tab1 with different state
+        let idx1 = app.tab_bar.create_tab(agent_id, "tab1");
+        app.tab_bar.active = idx1;
+        app.messages = vec![ChatMessage {
+            role: "assistant".to_string(),
+            text: "hello from tab1".to_string(),
+            text_lower: "hello from tab1".to_string(),
+            timestamp: None,
+            model: None,
+            is_streaming: false,
+            tool_calls: Vec::new(),
+        }];
+        app.scroll_offset = 10;
+        app.auto_scroll = true;
+        app.input.text = "typing in tab1".to_string();
+        app.ops = OpsState::default();
+        app.save_to_active_tab();
+
+        // Switch back to tab0 and verify state restored
+        app.tab_bar.active = idx0;
+        app.restore_from_active_tab();
+
+        assert_eq!(app.messages.len(), 1);
+        assert_eq!(app.messages[0].text, "hello from tab0");
+        assert_eq!(app.scroll_offset, 42);
+        assert!(!app.auto_scroll);
+        assert_eq!(app.input.text, "typing in tab0");
+        assert_eq!(app.ops.thinking.text, "thinking in tab0");
+        assert_eq!(app.ops.tool_calls.len(), 1);
+        assert_eq!(app.ops.tool_calls[0].name, "read_file");
+
+        // Switch to tab1 and verify its state
+        app.save_to_active_tab();
+        app.tab_bar.active = idx1;
+        app.restore_from_active_tab();
+
+        assert_eq!(app.messages.len(), 1);
+        assert_eq!(app.messages[0].text, "hello from tab1");
+        assert_eq!(app.scroll_offset, 10);
+        assert!(app.auto_scroll);
+        assert_eq!(app.input.text, "typing in tab1");
+        assert!(app.ops.thinking.text.is_empty());
+        assert!(app.ops.tool_calls.is_empty());
     }
 }

--- a/tui/src/markdown.rs
+++ b/tui/src/markdown.rs
@@ -375,8 +375,12 @@ pub fn render(
 }
 
 /// Push a span and advance the byte-based column counter.
+///
+/// Uses saturating addition to prevent overflow on pathologically long lines
+/// (>65 535 bytes without a newline). Link column positions may be slightly
+/// inaccurate in that extreme case, but the renderer will not panic.
 fn push_span(spans: &mut Vec<Span<'static>>, col: &mut u16, span: Span<'static>) {
-    *col += span.content.len() as u16;
+    *col = col.saturating_add(span.content.len().min(u16::MAX as usize) as u16);
     spans.push(span);
 }
 
@@ -1428,5 +1432,24 @@ mod tests {
             Some(theme.code.bg),
             "inline code bg must be code_bg color"
         );
+    }
+
+    #[test]
+    fn test_extremely_long_line_no_overflow() {
+        // A single line >65 535 bytes must not panic from u16 overflow in push_span.
+        let long = "x".repeat(70_000);
+        let lines = test_render(&long);
+        assert!(
+            !lines.is_empty(),
+            "extremely long line must produce output without panic"
+        );
+    }
+
+    #[test]
+    fn test_deeply_nested_blockquotes() {
+        // 50 levels of blockquote nesting must not stack overflow (iterative parser).
+        let md: String = (0..50).map(|_| "> ").collect::<String>() + "deeply nested";
+        let lines = test_render(&md);
+        assert!(!lines.is_empty());
     }
 }

--- a/tui/src/state/tab.rs
+++ b/tui/src/state/tab.rs
@@ -6,6 +6,7 @@ use crate::id::{NousId, SessionId, ToolId, TurnId};
 use crate::state::chat::{ChatMessage, SavedScrollState, ToolCallInfo};
 use crate::state::filter::FilterState;
 use crate::state::input::InputState;
+use crate::state::ops::OpsState;
 use crate::state::view_stack::ViewStack;
 
 /// Unique identifier for a tab, distinct from session IDs.
@@ -28,6 +29,7 @@ pub(crate) struct TabState {
     pub(crate) active_turn_id: Option<TurnId>,
     pub(crate) cached_markdown_text: String,
     pub(crate) cached_markdown_lines: Vec<ratatui::text::Line<'static>>,
+    pub(crate) ops: OpsState,
 }
 
 /// A single tab in the tab bar.
@@ -72,6 +74,7 @@ impl TabState {
             active_turn_id: None,
             cached_markdown_text: String::new(),
             cached_markdown_lines: Vec::new(),
+            ops: OpsState::default(),
         }
     }
 }

--- a/tui/src/update/streaming.rs
+++ b/tui/src/update/streaming.rs
@@ -194,8 +194,17 @@ pub(crate) fn handle_stream_turn_abort(app: &mut App, reason: String) {
     tracing::info!("turn aborted: {reason}");
     app.streaming_text.clear();
     app.streaming_thinking.clear();
+    app.streaming_tool_calls.clear();
     app.active_turn_id = None;
     app.stream_rx = None;
+    // Reset agent status so sidebar shows idle, not stuck on "working"
+    if let Some(ref agent_id) = app.focused_agent {
+        if let Some(agent) = app.agents.iter_mut().find(|a| a.id == *agent_id) {
+            agent.status = AgentStatus::Idle;
+            agent.active_tool = None;
+            agent.tool_started_at = None;
+        }
+    }
 }
 
 #[tracing::instrument(skip_all)]
@@ -205,6 +214,18 @@ pub(crate) fn handle_stream_error(app: &mut App, msg: String) {
     app.error_toast = Some(ErrorToast::new(sanitize_for_display(&msg).into_owned()));
     app.active_turn_id = None;
     app.stream_rx = None;
+    // Clear streaming_tool_calls so the UI doesn't show a stale running spinner
+    // for the last tool. streaming_text is intentionally preserved so the user
+    // can read any partial response received before the error.
+    app.streaming_tool_calls.clear();
+    // Reset agent status so sidebar shows idle, not stuck on "working"
+    if let Some(ref agent_id) = app.focused_agent {
+        if let Some(agent) = app.agents.iter_mut().find(|a| a.id == *agent_id) {
+            agent.status = AgentStatus::Idle;
+            agent.active_tool = None;
+            agent.tool_started_at = None;
+        }
+    }
 }
 
 #[cfg(test)]
@@ -362,14 +383,24 @@ mod tests {
     #[test]
     fn turn_abort_clears_state() {
         let mut app = test_app();
+        app.agents.push(test_agent("syn", "Syn"));
+        app.focused_agent = Some("syn".into());
         app.active_turn_id = Some("t1".into());
         app.streaming_text = "partial".to_string();
+        app.streaming_tool_calls.push(ToolCallInfo {
+            name: "read_file".to_string(),
+            duration_ms: None,
+            is_error: false,
+        });
+        app.agents[0].status = AgentStatus::Working;
 
         handle_stream_turn_abort(&mut app, "user cancelled".to_string());
 
         assert!(app.active_turn_id.is_none());
         assert!(app.streaming_text.is_empty());
+        assert!(app.streaming_tool_calls.is_empty());
         assert!(app.stream_rx.is_none());
+        assert_eq!(app.agents[0].status, AgentStatus::Idle);
     }
 
     #[test]
@@ -382,6 +413,34 @@ mod tests {
         assert!(app.error_toast.is_some());
         assert_eq!(app.error_toast.as_ref().unwrap().message, "connection lost");
         assert!(app.active_turn_id.is_none());
+    }
+
+    #[test]
+    fn stream_error_clears_tool_calls_and_resets_agent() {
+        let mut app = test_app();
+        app.agents.push(test_agent("syn", "Syn"));
+        app.focused_agent = Some("syn".into());
+        app.active_turn_id = Some("t1".into());
+        app.streaming_text = "partial response".to_string();
+        app.streaming_tool_calls.push(ToolCallInfo {
+            name: "grep".to_string(),
+            duration_ms: None,
+            is_error: false,
+        });
+        app.agents[0].status = AgentStatus::Working;
+        app.agents[0].active_tool = Some("grep".to_string());
+
+        handle_stream_error(&mut app, "connection reset".to_string());
+
+        // Partial text preserved for user inspection
+        assert_eq!(app.streaming_text, "partial response");
+        // Tool calls cleared so no stale spinners
+        assert!(app.streaming_tool_calls.is_empty());
+        // Agent back to idle
+        assert_eq!(app.agents[0].status, AgentStatus::Idle);
+        assert!(app.agents[0].active_tool.is_none());
+        // Error toast displayed
+        assert!(app.error_toast.is_some());
     }
 
     #[test]

--- a/tui/src/view/chat.rs
+++ b/tui/src/view/chat.rs
@@ -73,6 +73,21 @@ pub fn render(app: &App, frame: &mut Frame, area: Rect, theme: &Theme) -> Vec<Os
         );
     }
 
+    // Empty state: no messages and not streaming — show helpful placeholder.
+    if app.messages.is_empty() && app.active_turn_id.is_none() && !filter_active {
+        lines.push(Line::from(vec![
+            Span::raw(" "),
+            Span::styled("no messages yet", theme.style_dim()),
+        ]));
+        lines.push(Line::from(vec![
+            Span::raw(" "),
+            Span::styled(
+                "type a message below to start a conversation",
+                theme.style_muted(),
+            ),
+        ]));
+    }
+
     if filter_active && lines.len() <= 1 {
         lines.push(Line::from(vec![
             Span::raw(" "),

--- a/tui/src/view/sidebar.rs
+++ b/tui/src/view/sidebar.rs
@@ -14,6 +14,17 @@ pub fn render(app: &App, frame: &mut Frame, area: Rect, theme: &Theme) {
     // Small top padding
     lines.push(Line::raw(""));
 
+    if app.agents.is_empty() {
+        lines.push(Line::from(vec![
+            Span::raw("  "),
+            Span::styled("no agents", theme.style_dim()),
+        ]));
+        lines.push(Line::from(vec![
+            Span::raw("  "),
+            Span::styled("waiting for connection…", theme.style_muted()),
+        ]));
+    }
+
     for agent in &app.agents {
         let is_focused = app.focused_agent.as_ref() == Some(&agent.id);
 


### PR DESCRIPTION
## Summary

Runtime correctness fixes for TUI cutover readiness — six issues found and fixed across error recovery, state management, rendering safety, and empty-state UX.

- **connect() resilience**: agents fetch converted from hard `?` failure to best-effort with error toast, allowing degraded startup when backend is unreachable
- **stream error/abort cleanup**: clear `streaming_tool_calls` and reset agent status to `Idle` so sidebar doesn't show stale working spinner after mid-stream disconnect
- **tab state isolation**: add `OpsState` to `TabState` save/restore so operations pane data (thinking text, tool call history) is preserved per-tab when switching
- **markdown u16 overflow**: use saturating arithmetic in `push_span` column counter to prevent panic on pathologically long lines (>65KB without newline)
- **empty states**: add placeholder messages in sidebar ("no agents / waiting for connection") and chat view ("no messages yet") instead of blank screen

## Audit findings

| Area | Status | Notes |
|------|--------|-------|
| connect() error recovery | **Fixed** | agents fetch was `?` — now best-effort with toast |
| SSE reconnection | Already OK | Exponential backoff 1s→30s with auto-reconnect |
| Stream error handling | **Fixed** | Tool calls + agent status not cleaned up on error/abort |
| Tab state isolation | **Fixed** | OpsState missing from save/restore |
| Virtual scroll edge cases | Already OK | Handles empty, single-item, variable-height, zero-height |
| Empty states | **Fixed** | Sidebar + chat had no placeholder for empty data |
| Input edge cases | Already OK | UTF-8 boundary-safe, history navigation guarded |
| Markdown rendering | **Fixed** | u16 column overflow on extreme line lengths |

## Test plan

- [x] `cargo fmt -p aletheia-tui -- --check` — clean
- [x] `cargo clippy -p aletheia-tui --all-targets -- -D warnings` — zero warnings
- [x] `cargo test -p aletheia-tui` — 737 tests pass (4 new)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — zero warnings
- [ ] Manual: start TUI with backend down, verify error toast + degraded mode
- [ ] Manual: disconnect SSE mid-stream, verify partial response + idle agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)