### PR TITLE
fix(nous,pylon,daemon): core pipeline pre-cutover quality pass

### DIFF
--- a/crates/daemon/src/runner.rs
+++ b/crates/daemon/src/runner.rs
@@ -16,6 +16,12 @@ use crate::maintenance::{
 };
 use crate::schedule::{BuiltinTask, Schedule, TaskAction, TaskDef, TaskStatus};
 
+/// Maximum wall-clock duration for any single task execution (10 minutes).
+///
+/// Prevents a hung task (e.g., a blocking shell command or an unresponsive
+/// knowledge store operation) from blocking the runner indefinitely.
+const TASK_EXECUTION_TIMEOUT: Duration = Duration::from_secs(600);
+
 /// Per-nous background task runner.
 pub struct TaskRunner {
     nous_id: String,
@@ -321,7 +327,26 @@ impl TaskRunner {
             let task_id = self.tasks[i].def.id.clone();
 
             self.in_flight.insert(task_id.clone());
-            let result = self.execute_action(&action, &nous_id).await;
+            let result = match tokio::time::timeout(
+                TASK_EXECUTION_TIMEOUT,
+                self.execute_action(&action, &nous_id),
+            )
+            .await
+            {
+                Ok(r) => r,
+                Err(_elapsed) => {
+                    tracing::warn!(
+                        task_id = %task_id,
+                        timeout_secs = TASK_EXECUTION_TIMEOUT.as_secs(),
+                        "task execution timed out"
+                    );
+                    Err(error::TaskFailedSnafu {
+                        task_id: task_id.clone(),
+                        reason: format!("timed out after {}s", TASK_EXECUTION_TIMEOUT.as_secs()),
+                    }
+                    .build())
+                }
+            };
             self.in_flight.remove(&task_id);
 
             let task = &mut self.tasks[i];
@@ -1044,6 +1069,52 @@ mod tests {
         assert!(
             result.is_ok(),
             "shutdown should complete well within {timeout:?}"
+        );
+    }
+
+    /// A failing task does not prevent subsequent tasks from running.
+    #[tokio::test]
+    async fn failing_task_does_not_block_others() {
+        let token = CancellationToken::new();
+        let mut runner = TaskRunner::new("test-nous", token);
+
+        // Register a failing task and a succeeding task
+        runner.register(TaskDef {
+            id: "fail-task".to_owned(),
+            name: "Fail".to_owned(),
+            nous_id: "test-nous".to_owned(),
+            schedule: Schedule::Interval(Duration::from_secs(60)),
+            action: TaskAction::Command("exit 1".to_owned()),
+            enabled: true,
+            active_window: None,
+        });
+        runner.register(TaskDef {
+            id: "ok-task".to_owned(),
+            name: "Ok".to_owned(),
+            nous_id: "test-nous".to_owned(),
+            schedule: Schedule::Interval(Duration::from_secs(60)),
+            action: TaskAction::Command("echo ok".to_owned()),
+            enabled: true,
+            active_window: None,
+        });
+
+        // Force both to fire now
+        let past = jiff::Timestamp::now()
+            .checked_add(jiff::SignedDuration::from_secs(-1))
+            .unwrap();
+        runner.tasks[0].next_run = Some(past);
+        runner.tasks[1].next_run = Some(past);
+
+        runner.tick().await;
+
+        let statuses = runner.status();
+        assert_eq!(
+            statuses[0].consecutive_failures, 1,
+            "first task should have failed"
+        );
+        assert_eq!(
+            statuses[1].run_count, 1,
+            "second task should have succeeded"
         );
     }
 

--- a/crates/nous/src/error.rs
+++ b/crates/nous/src/error.rs
@@ -154,6 +154,15 @@ pub enum Error {
         #[snafu(implicit)]
         location: snafu::Location,
     },
+
+    /// A pipeline stage exceeded its time budget.
+    #[snafu(display("pipeline stage '{stage}' timed out after {timeout_secs}s"))]
+    PipelineTimeout {
+        stage: String,
+        timeout_secs: u32,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
 }
 
 /// Convenience alias for results with [`Error`].
@@ -296,6 +305,18 @@ mod tests {
         }
         .build();
         assert!(err.to_string().contains("session store"));
+    }
+
+    #[test]
+    fn error_display_pipeline_timeout() {
+        let err = PipelineTimeoutSnafu {
+            stage: "execute",
+            timeout_secs: 300u32,
+        }
+        .build();
+        let msg = err.to_string();
+        assert!(msg.contains("execute"));
+        assert!(msg.contains("300s"));
     }
 
     #[test]

--- a/crates/nous/src/handle.rs
+++ b/crates/nous/src/handle.rs
@@ -268,6 +268,56 @@ mod tests {
         assert!(msg.contains("dropped reply"), "got: {msg}");
     }
 
+    /// Verify the actor pattern: when the oneshot reply sender fires into a
+    /// dropped receiver, it does not panic — the `let _ = reply.send(result)`
+    /// pattern silently discards the error.
+    #[tokio::test]
+    async fn actor_continues_after_reply_channel_dropped() {
+        let (tx, mut rx) = mpsc::channel::<NousMessage>(4);
+        let handle = NousHandle::new("syn".to_owned(), tx);
+
+        // Simulate actor loop: receive messages and reply
+        let actor = tokio::spawn(async move {
+            let mut received = 0u32;
+            while let Some(msg) = rx.recv().await {
+                match msg {
+                    NousMessage::Turn { reply, .. } | NousMessage::StreamingTurn { reply, .. } => {
+                        // Actor sends result — receiver may already be dropped.
+                        // This must not panic.
+                        let _ = reply.send(Err(crate::error::PipelineStageSnafu {
+                            stage: "test",
+                            message: "simulated",
+                        }
+                        .build()));
+                        received += 1;
+                    }
+                    NousMessage::Shutdown => break,
+                    _ => {}
+                }
+            }
+            received
+        });
+
+        // Send a turn, then drop the handle's receiver (simulating client disconnect)
+        let send_result = {
+            let (reply_tx, _reply_rx) = tokio::sync::oneshot::channel();
+            handle
+                .sender
+                .send(NousMessage::Turn {
+                    session_key: "main".to_owned(),
+                    content: "hello".to_owned(),
+                    reply: reply_tx,
+                })
+                .await
+        };
+        assert!(send_result.is_ok());
+
+        // Actor should still be alive — send shutdown and verify it processed the turn
+        let _ = handle.shutdown().await;
+        let received = actor.await.expect("actor should not panic");
+        assert_eq!(received, 1, "actor should have processed the turn");
+    }
+
     #[test]
     fn handle_send_sync() {
         static_assertions::assert_impl_all!(NousHandle: Send, Sync, Clone);

--- a/crates/nous/src/pipeline.rs
+++ b/crates/nous/src/pipeline.rs
@@ -1,7 +1,7 @@
 //! Message processing pipeline.
 
 use std::collections::VecDeque;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use tokio::sync::Mutex;
 
@@ -332,6 +332,13 @@ pub async fn run_pipeline(
     stream_tx: Option<&mpsc::Sender<TurnStreamEvent>>,
 ) -> error::Result<TurnResult> {
     let pipeline_start = Instant::now();
+    let total_timeout = if pipeline_config.stage_budget.total_secs > 0 {
+        Some(Duration::from_secs(u64::from(
+            pipeline_config.stage_budget.total_secs,
+        )))
+    } else {
+        None
+    };
     let pipeline_span = info_span!("pipeline",
         nous_id = %config.id,
         session_id = %input.session.id,
@@ -378,6 +385,7 @@ pub async fn run_pipeline(
         );
         let _guard = span.enter();
         let start = Instant::now();
+        let recall_timeout_secs = pipeline_config.stage_budget.recall_secs;
         if let (Some(ep), Some(vs)) = (embedding_provider, vector_search) {
             let recall_config = crate::recall::RecallConfig::default();
             let recall_stage = crate::recall::RecallStage::new(recall_config);
@@ -386,24 +394,51 @@ pub async fn run_pipeline(
                 reason = "remaining_tokens is positive after context assembly"
             )]
             let budget = ctx.remaining_tokens.max(0) as u64;
-            match recall_stage.run(&input.content, &config.id, ep, vs, budget) {
-                Ok(recall_result) => {
-                    if let Some(ref section) = recall_result.recall_section {
-                        if let Some(ref mut prompt) = ctx.system_prompt {
-                            prompt.push_str("\n\n");
-                            prompt.push_str(section);
-                        }
-                        #[expect(clippy::cast_possible_wrap, reason = "recall tokens fit in i64")]
-                        {
-                            ctx.remaining_tokens -= recall_result.tokens_consumed as i64;
-                        }
+
+            let recall_result_opt = if recall_timeout_secs > 0 {
+                match tokio::time::timeout(
+                    Duration::from_secs(u64::from(recall_timeout_secs)),
+                    async { recall_stage.run(&input.content, &config.id, ep, vs, budget) },
+                )
+                .await
+                {
+                    Ok(result) => Some(result),
+                    Err(_elapsed) => {
+                        warn!(
+                            timeout_secs = recall_timeout_secs,
+                            "recall stage timed out, continuing without recalled knowledge"
+                        );
+                        span.record("status", "timeout");
+                        None
                     }
-                    ctx.recall_result = Some(recall_result);
-                    span.record("status", "ok");
                 }
-                Err(e) => {
-                    warn!(error = %e, "recall stage failed, continuing without recalled knowledge");
-                    span.record("status", "error");
+            } else {
+                Some(recall_stage.run(&input.content, &config.id, ep, vs, budget))
+            };
+
+            if let Some(result) = recall_result_opt {
+                match result {
+                    Ok(recall_result) => {
+                        if let Some(ref section) = recall_result.recall_section {
+                            if let Some(ref mut prompt) = ctx.system_prompt {
+                                prompt.push_str("\n\n");
+                                prompt.push_str(section);
+                            }
+                            #[expect(
+                                clippy::cast_possible_wrap,
+                                reason = "recall tokens fit in i64"
+                            )]
+                            {
+                                ctx.remaining_tokens -= recall_result.tokens_consumed as i64;
+                            }
+                        }
+                        ctx.recall_result = Some(recall_result);
+                        span.record("status", "ok");
+                    }
+                    Err(e) => {
+                        warn!(error = %e, "recall stage failed, continuing without recalled knowledge");
+                        span.record("status", "error");
+                    }
                 }
             }
         } else {
@@ -527,21 +562,56 @@ pub async fn run_pipeline(
         );
         let _guard = span.enter();
         let start = Instant::now();
-        result = if let Some(tx) = stream_tx {
-            crate::execute::execute_streaming(
-                &ctx,
-                &input.session,
-                config,
-                providers,
-                tools,
-                tool_ctx,
-                tx,
-            )
-            .await?
-        } else {
-            crate::execute::execute(&ctx, &input.session, config, providers, tools, tool_ctx)
-                .await?
+
+        // Compute the effective execute timeout: prefer per-stage budget, fall
+        // back to remaining time from total pipeline budget, whichever is tighter.
+        let execute_secs = pipeline_config.stage_budget.execute_secs;
+        let effective_execute_timeout = match (execute_secs > 0, total_timeout) {
+            (true, Some(total)) => {
+                let stage = Duration::from_secs(u64::from(execute_secs));
+                let remaining = total.saturating_sub(pipeline_start.elapsed());
+                Some(stage.min(remaining))
+            }
+            (true, None) => Some(Duration::from_secs(u64::from(execute_secs))),
+            (false, Some(total)) => Some(total.saturating_sub(pipeline_start.elapsed())),
+            (false, None) => None,
         };
+
+        let execute_fut = async {
+            if let Some(tx) = stream_tx {
+                crate::execute::execute_streaming(
+                    &ctx,
+                    &input.session,
+                    config,
+                    providers,
+                    tools,
+                    tool_ctx,
+                    tx,
+                )
+                .await
+            } else {
+                crate::execute::execute(&ctx, &input.session, config, providers, tools, tool_ctx)
+                    .await
+            }
+        };
+
+        result = if let Some(timeout_dur) = effective_execute_timeout {
+            match tokio::time::timeout(timeout_dur, execute_fut).await {
+                Ok(res) => res?,
+                Err(_elapsed) => {
+                    let secs = execute_secs.max(pipeline_config.stage_budget.total_secs);
+                    span.record("status", "timeout");
+                    return Err(error::PipelineTimeoutSnafu {
+                        stage: "execute",
+                        timeout_secs: secs,
+                    }
+                    .build());
+                }
+            }
+        } else {
+            execute_fut.await?
+        };
+
         #[expect(
             clippy::cast_possible_truncation,
             reason = "stage duration fits in u64"

--- a/crates/pylon/src/error.rs
+++ b/crates/pylon/src/error.rs
@@ -127,6 +127,14 @@ impl IntoResponse for ApiError {
             ),
         };
 
+        // Extract retry-after value before moving self for Display
+        let retry_after_secs = if let Self::RateLimited { retry_after_ms, .. } = &self {
+            // Convert ms to seconds (ceiling division so 1500ms → 2s)
+            Some(retry_after_ms.div_ceil(1000))
+        } else {
+            None
+        };
+
         let body = ErrorResponse {
             error: ErrorBody {
                 code: code.to_owned(),
@@ -135,7 +143,18 @@ impl IntoResponse for ApiError {
             },
         };
 
-        (status, Json(body)).into_response()
+        let mut response = (status, Json(body)).into_response();
+
+        // RFC 6585: 429 responses SHOULD include a Retry-After header.
+        if let Some(secs) = retry_after_secs {
+            response.headers_mut().insert(
+                axum::http::header::RETRY_AFTER,
+                axum::http::HeaderValue::from_str(&secs.to_string())
+                    .unwrap_or_else(|_| axum::http::HeaderValue::from_static("60")),
+            );
+        }
+
+        response
     }
 }
 
@@ -195,6 +214,14 @@ impl From<aletheia_nous::error::Error> for ApiError {
                 message: reason,
                 location: snafu::Location::default(),
             },
+            Error::PipelineTimeout {
+                stage,
+                timeout_secs,
+                ..
+            } => Self::ServiceUnavailable {
+                message: format!("pipeline stage '{stage}' timed out after {timeout_secs}s"),
+                location: snafu::Location::default(),
+            },
             Error::Llm { source, .. } => Self::from(source),
             _ => Self::Internal {
                 message: err.to_string(),
@@ -211,5 +238,96 @@ impl From<tokio::task::JoinError> for ApiError {
             message: format!("task join failed: {err}"),
             location: snafu::Location::default(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::response::IntoResponse;
+
+    #[test]
+    fn rate_limited_includes_retry_after_header() {
+        let err = ApiError::RateLimited {
+            retry_after_ms: 5000,
+            location: snafu::Location::default(),
+        };
+        let response = err.into_response();
+        assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
+        let retry = response
+            .headers()
+            .get(axum::http::header::RETRY_AFTER)
+            .expect("should have Retry-After header");
+        assert_eq!(retry.to_str().unwrap(), "5");
+    }
+
+    #[test]
+    fn rate_limited_zero_ms_has_retry_after() {
+        let err = ApiError::RateLimited {
+            retry_after_ms: 0,
+            location: snafu::Location::default(),
+        };
+        let response = err.into_response();
+        assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
+        let retry = response
+            .headers()
+            .get(axum::http::header::RETRY_AFTER)
+            .expect("should have Retry-After header");
+        assert_eq!(retry.to_str().unwrap(), "0");
+    }
+
+    #[test]
+    fn non_rate_limited_no_retry_after() {
+        let err = ApiError::Internal {
+            message: "test".to_owned(),
+            location: snafu::Location::default(),
+        };
+        let response = err.into_response();
+        assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        assert!(
+            response
+                .headers()
+                .get(axum::http::header::RETRY_AFTER)
+                .is_none(),
+            "non-429 should not have Retry-After"
+        );
+    }
+
+    #[test]
+    fn session_not_found_returns_404() {
+        let err = ApiError::SessionNotFound {
+            id: "ses-123".to_owned(),
+            location: snafu::Location::default(),
+        };
+        let response = err.into_response();
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[test]
+    fn pipeline_timeout_maps_to_service_unavailable() {
+        let err = aletheia_nous::error::Error::PipelineTimeout {
+            stage: "execute".to_owned(),
+            timeout_secs: 300,
+            location: snafu::Location::default(),
+        };
+        let api_err = ApiError::from(err);
+        let response = api_err.into_response();
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+    }
+
+    #[test]
+    fn guard_rejected_maps_to_forbidden() {
+        let err = aletheia_nous::error::Error::GuardRejected {
+            reason: "safety check".to_owned(),
+            location: snafu::Location::default(),
+        };
+        let api_err = ApiError::from(err);
+        let response = api_err.into_response();
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[test]
+    fn api_error_is_send_sync() {
+        static_assertions::assert_impl_all!(ApiError: Send, Sync);
     }
 }

--- a/crates/pylon/src/handlers/sessions.rs
+++ b/crates/pylon/src/handlers/sessions.rs
@@ -399,6 +399,17 @@ pub async fn send_message(
                         message: err.to_string(),
                     })
                     .await;
+                // Always send a completion marker so the client knows the
+                // stream is finished, even on error paths.
+                let _ = tx
+                    .send(SseEvent::MessageComplete {
+                        stop_reason: "error".to_owned(),
+                        usage: UsageData {
+                            input_tokens: 0,
+                            output_tokens: 0,
+                        },
+                    })
+                    .await;
             }
         }
     });
@@ -574,6 +585,23 @@ pub async fn stream_turn(
                 let _ = webchat_tx
                     .send(WebchatEvent::Error {
                         message: err.to_string(),
+                    })
+                    .await;
+                // Always send a completion marker so the TUI knows the stream
+                // is finished, even on error paths.
+                let _ = webchat_tx
+                    .send(WebchatEvent::TurnComplete {
+                        outcome: TurnOutcome {
+                            text: String::new(),
+                            nous_id: aid,
+                            session_id: sid,
+                            model,
+                            tool_calls: 0,
+                            input_tokens: 0,
+                            output_tokens: 0,
+                            cache_read_tokens: 0,
+                            cache_write_tokens: 0,
+                        },
                     })
                     .await;
             }


### PR DESCRIPTION
## Summary

- **Pipeline stage timeouts enforced**: `StageBudget` config (recall_secs, execute_secs, total_secs) was defined but never applied. Recall and Execute stages now use `tokio::time::timeout()` to prevent hung LLM calls or slow vector searches from blocking the actor indefinitely. Returns a descriptive `PipelineTimeout` error.

- **SSE completion markers on error paths**: `send_message` and `stream_turn` now always emit `MessageComplete`/`TurnComplete` after `Error` events, preventing clients from hanging on failed turns waiting for a stream-end signal.

- **Daemon task execution timeout**: All `TaskRunner.execute_action()` calls are wrapped in a 10-minute timeout, preventing hung shell commands or blocking maintenance operations from stalling the daemon event loop.

- **Retry-After header on 429**: `ApiError::RateLimited` responses now include the RFC 6585 `Retry-After` header (seconds), enabling well-behaved clients to back off correctly.

- **PipelineTimeout error mapping**: New `PipelineTimeout` variant in nous error maps to `ServiceUnavailable` (503) in pylon, giving clients a clear signal that the turn timed out.

### Audit findings (no fix needed)

- **Cancel safety**: Actor already handles dropped oneshot receivers correctly via `let _ = reply.send(result)` — continues processing inbox.
- **Tool loop termination**: `max_tool_iterations` enforced, `LoopDetector` works, tool errors reported back to LLM as error tool_results.
- **SessionStore contention**: All pylon handlers use `spawn_blocking` + `blocking_lock()` consistently. Pipeline uses `tokio::sync::Mutex` correctly.
- **Distillation safety**: Background fire-and-forget task — LLM failure returns early, original history preserved.

## Test plan

- [x] `cargo fmt -- --check` passes
- [x] `cargo clippy -p aletheia-nous -p aletheia-pylon -p aletheia-oikonomos --all-targets -- -D warnings` — zero warnings
- [x] `cargo test -p aletheia-nous -p aletheia-pylon -p aletheia-oikonomos` — 158 tests pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — zero warnings
- [x] New test: actor continues after reply channel dropped (cancel safety)
- [x] New test: daemon task failure isolation (failing task doesn't block others)
- [x] New tests: Retry-After header on 429, absent on non-429
- [x] New tests: PipelineTimeout and GuardRejected error mapping
- [x] New test: PipelineTimeout error display

🤖 Generated with [Claude Code](https://claude.com/claude-code)