### PR TITLE
fix: deployment flow audit and UX improvements

### DIFF
--- a/crates/aletheia/src/init.rs
+++ b/crates/aletheia/src/init.rs
@@ -49,7 +49,14 @@ pub(crate) fn run(root: PathBuf, non_interactive: bool, api_key: Option<String>)
 
     // Pre-check: existing instance
     let config_path = answers.root.join("config/aletheia.yaml");
-    if config_path.exists() && !non_interactive {
+    if config_path.exists() {
+        if non_interactive {
+            println!(
+                "Instance already exists at {}. Skipping (delete config/aletheia.yaml to re-initialize).",
+                answers.root.display()
+            );
+            return Ok(());
+        }
         let overwrite: bool = cliclack::confirm("Instance already exists. Overwrite?")
             .initial_value(false)
             .interact()?;
@@ -176,6 +183,8 @@ fn scaffold(answers: &Answers) -> Result<()> {
         root.join("config/credentials"),
         root.join(format!("nous/{}", answers.agent_id)),
         root.join("data"),
+        root.join("logs/traces"),
+        root.join("shared/coordination"),
     ];
     for dir in &dirs {
         std::fs::create_dir_all(dir)
@@ -383,6 +392,8 @@ mod tests {
         );
         assert!(dir.path().join("nous/main/SOUL.md").exists());
         assert!(dir.path().join("data").is_dir());
+        assert!(dir.path().join("logs/traces").is_dir());
+        assert!(dir.path().join("shared/coordination").is_dir());
 
         // Credential should contain the key
         let cred: serde_json::Value = serde_json::from_str(

--- a/crates/aletheia/src/main.rs
+++ b/crates/aletheia/src/main.rs
@@ -953,7 +953,16 @@ async fn serve(cli: Cli) -> Result<()> {
     let bind_addr = format!("{bind_addr_str}:{port}");
     let listener = tokio::net::TcpListener::bind(&bind_addr)
         .await
-        .with_context(|| format!("failed to bind to {bind_addr}"))?;
+        .map_err(|e| {
+            if e.kind() == std::io::ErrorKind::AddrInUse {
+                anyhow::anyhow!(
+                    "Port {port} is already in use.\n  \
+                     Use --port to choose another port, or stop the process using port {port}."
+                )
+            } else {
+                anyhow::anyhow!("failed to bind to {bind_addr}: {e}")
+            }
+        })?;
 
     info!(addr = %bind_addr, "pylon listening");
 
@@ -1058,7 +1067,10 @@ fn build_provider_registry(
     if let Some(cred) = credential_chain.get_credential() {
         info!(source = %cred.source, "credential resolved");
     } else {
-        warn!("no credential available — no LLM provider");
+        warn!(
+            "no credential found — server will start in degraded mode (no LLM)\n  \
+             Fix: set ANTHROPIC_API_KEY env var, or run `aletheia credential status`"
+        );
         return registry;
     }
 
@@ -1528,17 +1540,29 @@ async fn eval(
 
 async fn health(url: &str) -> Result<()> {
     let endpoint = format!("{url}/api/health");
-    let resp = reqwest::get(&endpoint)
-        .await
-        .with_context(|| format!("failed to connect to {endpoint}"))?;
+    let resp = reqwest::get(&endpoint).await.map_err(|e| {
+        if e.is_connect() {
+            anyhow::anyhow!(
+                "FAILED: cannot connect to {url}\n  \
+                 Is the server running? Start it with: aletheia"
+            )
+        } else {
+            anyhow::anyhow!("FAILED: {e}")
+        }
+    })?;
     let status = resp.status();
     let body: serde_json::Value = resp
         .json()
         .await
         .context("failed to parse health response")?;
-    println!("{}", serde_json::to_string_pretty(&body)?);
-    if !status.is_success() {
-        anyhow::bail!("health check returned {status}");
+    let health_status = body["status"].as_str().unwrap_or("unknown");
+    let version = body["version"].as_str().unwrap_or("unknown");
+    let uptime = body["uptime_seconds"].as_u64().unwrap_or(0);
+    if status.is_success() {
+        println!("OK — {health_status} | version {version} | uptime {uptime}s");
+    } else {
+        println!("{}", serde_json::to_string_pretty(&body)?);
+        anyhow::bail!("FAILED: health check returned HTTP {status}");
     }
     Ok(())
 }

--- a/crates/mneme/src/consolidation.rs
+++ b/crates/mneme/src/consolidation.rs
@@ -106,10 +106,7 @@ pub enum ConsolidationTrigger {
         fact_count: usize,
     },
     /// A Louvain community cluster accumulated more than the threshold of active facts.
-    CommunityOverflow {
-        cluster_id: i64,
-        fact_count: usize,
-    },
+    CommunityOverflow { cluster_id: i64, fact_count: usize },
 }
 
 impl ConsolidationTrigger {
@@ -204,11 +201,7 @@ pub struct ConsolidationAuditRecord {
 /// to the configured LLM provider.
 pub trait ConsolidationProvider: Send + Sync {
     /// Send a consolidation prompt and return the raw response.
-    fn consolidate(
-        &self,
-        system: &str,
-        user_message: &str,
-    ) -> Result<String, ConsolidationError>;
+    fn consolidate(&self, system: &str, user_message: &str) -> Result<String, ConsolidationError>;
 }
 
 // ---------------------------------------------------------------------------
@@ -423,12 +416,12 @@ pub const CONSOLIDATION_AUDIT_DDL: &str = r":create consolidation_audit {
 #[cfg(feature = "mneme-engine")]
 mod engine_impl {
     use crate::consolidation::{
+        CLUSTER_FACTS_FOR_CONSOLIDATION, COMMUNITY_OVERFLOW_CANDIDATES, CONSOLIDATION_AUDIT_DDL,
+        ConsolidatedFact, ConsolidationAuditRecord, ConsolidationCandidate, ConsolidationConfig,
+        ConsolidationError, ConsolidationProvider, ConsolidationResult, ConsolidationTrigger,
+        ENTITY_FACTS_FOR_CONSOLIDATION, ENTITY_OVERFLOW_CANDIDATES, RateLimitedSnafu, StoreSnafu,
         age_cutoff, batch_facts, consolidation_system_prompt, consolidation_user_message,
-        parse_consolidation_response, ConsolidatedFact, ConsolidationAuditRecord,
-        ConsolidationCandidate, ConsolidationConfig, ConsolidationError, ConsolidationProvider,
-        ConsolidationResult, ConsolidationTrigger, RateLimitedSnafu, StoreSnafu,
-        CLUSTER_FACTS_FOR_CONSOLIDATION, COMMUNITY_OVERFLOW_CANDIDATES,
-        CONSOLIDATION_AUDIT_DDL, ENTITY_FACTS_FOR_CONSOLIDATION, ENTITY_OVERFLOW_CANDIDATES,
+        parse_consolidation_response,
     };
     use crate::engine::DataValue;
     use crate::id::{EntityId, FactId};
@@ -471,7 +464,12 @@ mod engine_impl {
 
             let result = self
                 .run_query(ENTITY_OVERFLOW_CANDIDATES, params)
-                .map_err(|e| StoreSnafu { message: e.to_string() }.build())?;
+                .map_err(|e| {
+                    StoreSnafu {
+                        message: e.to_string(),
+                    }
+                    .build()
+                })?;
 
             let mut candidates = Vec::new();
             for row in &result.rows {
@@ -481,7 +479,12 @@ mod engine_impl {
 
                 let facts = self
                     .gather_entity_facts(nous_id, &entity_id, &cutoff)
-                    .map_err(|e| StoreSnafu { message: e.to_string() }.build())?;
+                    .map_err(|e| {
+                        StoreSnafu {
+                            message: e.to_string(),
+                        }
+                        .build()
+                    })?;
 
                 let fact_ids: Vec<FactId> = facts.iter().map(|(id, _, _, _)| id.clone()).collect();
 
@@ -521,7 +524,12 @@ mod engine_impl {
 
             let result = self
                 .run_query(COMMUNITY_OVERFLOW_CANDIDATES, params)
-                .map_err(|e| StoreSnafu { message: e.to_string() }.build())?;
+                .map_err(|e| {
+                    StoreSnafu {
+                        message: e.to_string(),
+                    }
+                    .build()
+                })?;
 
             let mut candidates = Vec::new();
             for row in &result.rows {
@@ -530,7 +538,12 @@ mod engine_impl {
 
                 let facts = self
                     .gather_cluster_facts(nous_id, cluster_id, &cutoff)
-                    .map_err(|e| StoreSnafu { message: e.to_string() }.build())?;
+                    .map_err(|e| {
+                        StoreSnafu {
+                            message: e.to_string(),
+                        }
+                        .build()
+                    })?;
 
                 let fact_ids: Vec<FactId> = facts.iter().map(|(id, _, _, _)| id.clone()).collect();
 
@@ -599,10 +612,20 @@ mod engine_impl {
             let facts = match &candidate.trigger {
                 ConsolidationTrigger::EntityOverflow { entity_id, .. } => self
                     .gather_entity_facts(nous_id, entity_id, &cutoff)
-                    .map_err(|e| StoreSnafu { message: e.to_string() }.build())?,
+                    .map_err(|e| {
+                        StoreSnafu {
+                            message: e.to_string(),
+                        }
+                        .build()
+                    })?,
                 ConsolidationTrigger::CommunityOverflow { cluster_id, .. } => self
                     .gather_cluster_facts(nous_id, *cluster_id, &cutoff)
-                    .map_err(|e| StoreSnafu { message: e.to_string() }.build())?,
+                    .map_err(|e| {
+                        StoreSnafu {
+                            message: e.to_string(),
+                        }
+                        .build()
+                    })?,
             };
 
             if facts.is_empty() {
@@ -652,15 +675,18 @@ mod engine_impl {
                     recorded_at: now,
                     access_count: 0,
                     last_accessed_at: None,
-                    stability_hours: crate::knowledge::FactType::Observation
-                        .base_stability_hours(),
+                    stability_hours: crate::knowledge::FactType::Observation.base_stability_hours(),
                     fact_type: "observation".to_owned(),
                     is_forgotten: false,
                     forgotten_at: None,
                     forget_reason: None,
                 };
-                self.insert_fact(&fact)
-                    .map_err(|e| StoreSnafu { message: e.to_string() }.build())?;
+                self.insert_fact(&fact).map_err(|e| {
+                    StoreSnafu {
+                        message: e.to_string(),
+                    }
+                    .build()
+                })?;
                 new_fact_ids.push(new_id);
             }
             Ok(new_fact_ids)
@@ -673,14 +699,16 @@ mod engine_impl {
             new_fact_ids: &[FactId],
         ) -> Result<(), ConsolidationError> {
             let now_str = crate::knowledge::format_timestamp(&jiff::Timestamp::now());
-            let superseding_id = new_fact_ids
-                .first()
-                .map(FactId::as_str)
-                .unwrap_or_default();
+            let superseding_id = new_fact_ids.first().map(FactId::as_str).unwrap_or_default();
 
             for original_id in &result.superseded_fact_ids {
                 self.supersede_fact_by_id(original_id, superseding_id, &now_str)
-                    .map_err(|e| StoreSnafu { message: e.to_string() }.build())?;
+                    .map_err(|e| {
+                        StoreSnafu {
+                            message: e.to_string(),
+                        }
+                        .build()
+                    })?;
             }
             Ok(())
         }
@@ -702,10 +730,9 @@ mod engine_impl {
                     .collect::<Vec<_>>(),
             )
             .unwrap_or_else(|_| "[]".to_owned());
-            let consolidated_ids_json = serde_json::to_string(
-                &new_fact_ids.iter().map(FactId::as_str).collect::<Vec<_>>(),
-            )
-            .unwrap_or_else(|_| "[]".to_owned());
+            let consolidated_ids_json =
+                serde_json::to_string(&new_fact_ids.iter().map(FactId::as_str).collect::<Vec<_>>())
+                    .unwrap_or_else(|_| "[]".to_owned());
 
             self.record_consolidation_audit(&ConsolidationAuditRecord {
                 id: audit_id,
@@ -717,7 +744,12 @@ mod engine_impl {
                 consolidated_fact_ids: consolidated_ids_json,
                 consolidated_at: now_str,
             })
-            .map_err(|e| StoreSnafu { message: e.to_string() }.build())
+            .map_err(|e| {
+                StoreSnafu {
+                    message: e.to_string(),
+                }
+                .build()
+            })
         }
 
         /// Mark a fact as superseded by ID, setting `valid_to` and `superseded_by`.
@@ -817,9 +849,12 @@ mod engine_impl {
 :sort -consolidated_at
 :limit 1
 ";
-            let result = self
-                .run_query(script, BTreeMap::new())
-                .map_err(|e| StoreSnafu { message: e.to_string() }.build())?;
+            let result = self.run_query(script, BTreeMap::new()).map_err(|e| {
+                StoreSnafu {
+                    message: e.to_string(),
+                }
+                .build()
+            })?;
 
             if let Some(row) = result.rows.first() {
                 Ok(Some(row[0].get_str().unwrap_or_default().to_owned()))
@@ -851,15 +886,15 @@ mod engine_impl {
             let mut results = Vec::new();
 
             for candidate in &self.find_entity_overflow_candidates(nous_id, config)? {
-                results.push(self.execute_consolidation(
-                    provider, candidate, nous_id, config, dry_run,
-                )?);
+                results.push(
+                    self.execute_consolidation(provider, candidate, nous_id, config, dry_run)?,
+                );
             }
 
             for candidate in &self.find_community_overflow_candidates(nous_id, config)? {
-                results.push(self.execute_consolidation(
-                    provider, candidate, nous_id, config, dry_run,
-                )?);
+                results.push(
+                    self.execute_consolidation(provider, candidate, nous_id, config, dry_run)?,
+                );
             }
 
             Ok(results)
@@ -875,8 +910,7 @@ mod engine_impl {
                 if let Some(last_ts) = crate::knowledge::parse_timestamp(&last_time) {
                     let now = jiff::Timestamp::now();
                     if let Ok(span) = now.since(last_ts) {
-                        let total_minutes =
-                            i64::from(span.get_hours()) * 60 + span.get_minutes();
+                        let total_minutes = i64::from(span.get_hours()) * 60 + span.get_minutes();
                         #[expect(
                             clippy::cast_precision_loss,
                             reason = "elapsed minutes as f64 is fine for rate limiting"
@@ -958,7 +992,9 @@ mod engine_impl {
 pub(crate) fn age_cutoff(min_age_days: u32) -> String {
     let now = jiff::Timestamp::now();
     let cutoff = now
-        .checked_sub(jiff::SignedDuration::from_hours(i64::from(min_age_days) * 24))
+        .checked_sub(jiff::SignedDuration::from_hours(
+            i64::from(min_age_days) * 24,
+        ))
         .unwrap_or(now);
     crate::knowledge::format_timestamp(&cutoff)
 }
@@ -1196,7 +1232,9 @@ Some trailing text."#;
     #[test]
     fn mock_provider_returns_response() {
         let provider = MockConsolidationProvider::new(r#"[{"content": "test"}]"#);
-        let result = provider.consolidate("system", "user").expect("should succeed");
+        let result = provider
+            .consolidate("system", "user")
+            .expect("should succeed");
         assert!(result.contains("test"));
     }
 
@@ -1232,9 +1270,7 @@ Some trailing text."#;
 
 #[cfg(all(test, feature = "mneme-engine"))]
 mod engine_tests {
-    use super::{
-        batch_facts, ConsolidationConfig, ConsolidationError, ConsolidationProvider,
-    };
+    use super::{ConsolidationConfig, ConsolidationError, ConsolidationProvider, batch_facts};
     use crate::id::{EntityId, FactId};
     use crate::knowledge::{self, EpistemicTier, Fact};
     use crate::knowledge_store::KnowledgeStore;
@@ -1244,7 +1280,13 @@ mod engine_tests {
         KnowledgeStore::open_mem().expect("open_mem")
     }
 
-    fn make_fact(id: &str, nous_id: &str, content: &str, tier: EpistemicTier, days_ago: i64) -> Fact {
+    fn make_fact(
+        id: &str,
+        nous_id: &str,
+        content: &str,
+        tier: EpistemicTier,
+        days_ago: i64,
+    ) -> Fact {
         let now = jiff::Timestamp::now();
         let recorded = now
             .checked_sub(jiff::SignedDuration::from_hours(days_ago * 24))
@@ -1270,17 +1312,10 @@ mod engine_tests {
         }
     }
 
-    fn insert_fact_with_entity(
-        store: &KnowledgeStore,
-        fact: &Fact,
-        entity_id: &str,
-    ) {
+    fn insert_fact_with_entity(store: &KnowledgeStore, fact: &Fact, entity_id: &str) {
         store.insert_fact(fact).expect("insert fact");
         store
-            .insert_fact_entity(
-                &fact.id,
-                &EntityId::from(entity_id),
-            )
+            .insert_fact_entity(&fact.id, &EntityId::from(entity_id))
             .expect("insert fact_entity");
     }
 
@@ -1402,7 +1437,10 @@ mod engine_tests {
             .find_entity_overflow_candidates(nous_id, &config)
             .expect("find candidates");
 
-        assert!(candidates.is_empty(), "recent facts should be excluded by age gate");
+        assert!(
+            candidates.is_empty(),
+            "recent facts should be excluded by age gate"
+        );
     }
 
     #[test]
@@ -1545,7 +1583,11 @@ mod engine_tests {
         let candidates_after = store
             .find_entity_overflow_candidates(nous_id, &config)
             .expect("find candidates after dry run");
-        assert_eq!(candidates_after.len(), 1, "dry run must not supersede facts");
+        assert_eq!(
+            candidates_after.len(),
+            1,
+            "dry run must not supersede facts"
+        );
         assert_eq!(candidates_after[0].fact_count, 12);
     }
 
@@ -1639,9 +1681,7 @@ mod engine_tests {
             .execute_consolidation(&provider, &candidates[0], nous_id, &config, false)
             .expect("execute");
 
-        let last_time = store
-            .last_consolidation_time(nous_id)
-            .expect("query audit");
+        let last_time = store.last_consolidation_time(nous_id).expect("query audit");
         assert!(last_time.is_some(), "audit record must be created");
     }
 

--- a/crates/mneme/src/engine/query/graph.rs
+++ b/crates/mneme/src/engine/query/graph.rs
@@ -175,7 +175,8 @@ impl<'a> TarjanScc<'a> {
                 self.low[at] = min(self.low[at], self.low[to]);
             }
         }
-        if self.ids[at].expect("ids[at] is Some: assigned on dfs() entry (line above recursive call)")
+        if self.ids[at]
+            .expect("ids[at] is Some: assigned on dfs() entry (line above recursive call)")
             == self.low[at]
         {
             while let Some(node) = self.stack.pop() {

--- a/crates/mneme/src/engine/query/magic.rs
+++ b/crates/mneme/src/engine/query/magic.rs
@@ -187,7 +187,9 @@ fn magic_rewrite_ruleset(
                             .entry(sup_kw.clone())
                             .or_default()
                             .mut_rules()
-                            .expect("entry is Rules variant: Default creates MagicRulesOrFixed::Rules");
+                            .expect(
+                                "entry is Rules variant: Default creates MagicRulesOrFixed::Rules",
+                            );
                         let mut sup_rule_atoms = vec![];
                         mem::swap(&mut sup_rule_atoms, &mut collected_atoms);
 
@@ -216,7 +218,9 @@ fn magic_rewrite_ruleset(
                             .entry(inp_kw.clone())
                             .or_default()
                             .mut_rules()
-                            .expect("entry is Rules variant: Default creates MagicRulesOrFixed::Rules");
+                            .expect(
+                                "entry is Rules variant: Default creates MagicRulesOrFixed::Rules",
+                            );
                         let inp_args = r_app
                             .args
                             .iter()
@@ -476,8 +480,10 @@ impl NormalFormProgram {
             let original_rules = self
                 .prog
                 .get(head.as_plain_symbol())
-                .expect("adorned head always has a corresponding entry in prog: \
-                         pending_adornment is seeded from prog keys")
+                .expect(
+                    "adorned head always has a corresponding entry in prog: \
+                         pending_adornment is seeded from prog keys",
+                )
                 .rules()
                 .ok_or_else(|| {
                     CompilationFailedSnafu {

--- a/crates/mneme/src/engine/query/ra.rs
+++ b/crates/mneme/src/engine/query/ra.rs
@@ -2007,12 +2007,10 @@ impl NegJoin {
         let eliminate_indices = get_eliminate_indices(&bindings, &self.to_eliminate);
         match &self.right {
             RelAlgebra::TempStore(r) => {
-                let join_indices = self
-                    .joiner
-                    .join_indices(
-                        &self.left.bindings_after_eliminate(),
-                        &self.right.bindings_after_eliminate(),
-                    )?;
+                let join_indices = self.joiner.join_indices(
+                    &self.left.bindings_after_eliminate(),
+                    &self.right.bindings_after_eliminate(),
+                )?;
                 r.neg_join(
                     self.left.iter(tx, delta_rule, stores)?,
                     join_indices,
@@ -2021,12 +2019,10 @@ impl NegJoin {
                 )
             }
             RelAlgebra::Stored(v) => {
-                let join_indices = self
-                    .joiner
-                    .join_indices(
-                        &self.left.bindings_after_eliminate(),
-                        &self.right.bindings_after_eliminate(),
-                    )?;
+                let join_indices = self.joiner.join_indices(
+                    &self.left.bindings_after_eliminate(),
+                    &self.right.bindings_after_eliminate(),
+                )?;
                 v.neg_join(
                     tx,
                     self.left.iter(tx, delta_rule, stores)?,
@@ -2149,12 +2145,10 @@ impl InnerJoin {
         let eliminate_indices = get_eliminate_indices(&bindings, &self.to_eliminate);
         match &self.right {
             RelAlgebra::Fixed(f) => {
-                let join_indices = self
-                    .joiner
-                    .join_indices(
-                        &self.left.bindings_after_eliminate(),
-                        &self.right.bindings_after_eliminate(),
-                    )?;
+                let join_indices = self.joiner.join_indices(
+                    &self.left.bindings_after_eliminate(),
+                    &self.right.bindings_after_eliminate(),
+                )?;
                 f.join(
                     self.left.iter(tx, delta_rule, stores)?,
                     join_indices,
@@ -2162,12 +2156,10 @@ impl InnerJoin {
                 )
             }
             RelAlgebra::TempStore(r) => {
-                let join_indices = self
-                    .joiner
-                    .join_indices(
-                        &self.left.bindings_after_eliminate(),
-                        &self.right.bindings_after_eliminate(),
-                    )?;
+                let join_indices = self.joiner.join_indices(
+                    &self.left.bindings_after_eliminate(),
+                    &self.right.bindings_after_eliminate(),
+                )?;
                 if join_is_prefix(&join_indices.1) {
                     r.prefix_join(
                         self.left.iter(tx, delta_rule, stores)?,
@@ -2181,12 +2173,10 @@ impl InnerJoin {
                 }
             }
             RelAlgebra::Stored(r) => {
-                let join_indices = self
-                    .joiner
-                    .join_indices(
-                        &self.left.bindings_after_eliminate(),
-                        &self.right.bindings_after_eliminate(),
-                    )?;
+                let join_indices = self.joiner.join_indices(
+                    &self.left.bindings_after_eliminate(),
+                    &self.right.bindings_after_eliminate(),
+                )?;
                 if join_is_prefix(&join_indices.1) {
                     r.prefix_join(
                         tx,
@@ -2199,12 +2189,10 @@ impl InnerJoin {
                 }
             }
             RelAlgebra::StoredWithValidity(r) => {
-                let join_indices = self
-                    .joiner
-                    .join_indices(
-                        &self.left.bindings_after_eliminate(),
-                        &self.right.bindings_after_eliminate(),
-                    )?;
+                let join_indices = self.joiner.join_indices(
+                    &self.left.bindings_after_eliminate(),
+                    &self.right.bindings_after_eliminate(),
+                )?;
                 if join_is_prefix(&join_indices.1) {
                     r.prefix_join(
                         tx,

--- a/crates/mneme/src/engine/query/stored.rs
+++ b/crates/mneme/src/engine/query/stored.rs
@@ -77,8 +77,8 @@ impl<'a> SessionTx<'a> {
                         trigger,
                         &Default::default(),
                         &db.fixed_rules
-                    .read()
-                    .expect("fixed_rules lock is not poisoned"),
+                            .read()
+                            .expect("fixed_rules lock is not poisoned"),
                         cur_vld,
                     )?
                     .get_single_program()?;
@@ -737,8 +737,8 @@ impl<'a> SessionTx<'a> {
                     trigger,
                     &Default::default(),
                     &db.fixed_rules
-                    .read()
-                    .expect("fixed_rules lock is not poisoned"),
+                        .read()
+                        .expect("fixed_rules lock is not poisoned"),
                     cur_vld,
                 )?
                 .get_single_program()?;
@@ -1085,8 +1085,8 @@ impl<'a> SessionTx<'a> {
                         trigger,
                         &Default::default(),
                         &db.fixed_rules
-                    .read()
-                    .expect("fixed_rules lock is not poisoned"),
+                            .read()
+                            .expect("fixed_rules lock is not poisoned"),
                         cur_vld,
                     )?
                     .get_single_program()?;

--- a/crates/mneme/src/engine/query/stratify.rs
+++ b/crates/mneme/src/engine/query/stratify.rs
@@ -278,9 +278,9 @@ impl NormalFormProgram {
         for (name, ruleset) in self.prog {
             if let Some(scc_idx) = invert_indices.get(&name) {
                 if let Some(rev_stratum_idx) = invert_sort_result.get(scc_idx) {
-                    let target = ret
-                        .get_mut(*rev_stratum_idx)
-                        .expect("stratum index always valid: rev_stratum_idx derived from ret's range");
+                    let target = ret.get_mut(*rev_stratum_idx).expect(
+                        "stratum index always valid: rev_stratum_idx derived from ret's range",
+                    );
                     target.prog.insert(name, ruleset);
                 }
             }

--- a/crates/mneme/src/lib.rs
+++ b/crates/mneme/src/lib.rs
@@ -22,10 +22,10 @@ pub mod engine;
 /// Database backup and JSON export for session data.
 #[cfg(feature = "sqlite")]
 pub mod backup;
-/// LLM-driven fact consolidation for knowledge maintenance.
-pub mod consolidation;
 /// Conflict detection pipeline for fact insertion.
 pub mod conflict;
+/// LLM-driven fact consolidation for knowledge maintenance.
+pub mod consolidation;
 /// Entity deduplication pipeline for merging semantically identical entities.
 pub mod dedup;
 /// Embedding provider trait and implementations (candle, mock).

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -77,23 +77,40 @@ See [SHELL-COMPLETIONS.md](SHELL-COMPLETIONS.md) for setting up tab-completion i
 
 The instance directory holds all runtime state: config, databases, agent workspaces, logs. It is gitignored — the platform code ships without instance data.
 
+### Recommended: use the init wizard
+
+```bash
+export ANTHROPIC_API_KEY="sk-ant-..."   # or enter interactively
+aletheia init                            # interactive wizard, creates ./instance
+```
+
+The wizard prompts for API key, model, agent name, and bind address, then writes a fully valid `config/aletheia.yaml`. For non-interactive (CI/scripting) use:
+
+```bash
+ANTHROPIC_API_KEY=sk-ant-... aletheia init --yes --instance-root /srv/aletheia/instance
+```
+
+### Manual: copy the example scaffold
+
 ```bash
 cp -r instance.example instance
 ```
+
+Then configure `instance/config/aletheia.yaml` (see below).
 
 This creates the full directory scaffold:
 
 ```text
 instance/
 ├── config/
-│   ├── aletheia.yaml       # Main config (from aletheia.yaml.example)
+│   ├── aletheia.yaml       # Main config
 │   ├── credentials/        # API keys, secrets
 │   └── tls/                # TLS certs (optional)
 ├── data/                   # SQLite databases, backups
 ├── logs/traces/            # Trace files
 ├── nous/                   # Agent workspaces
 │   └── _template/          # Template for new agents
-├── shared/                 # Shared tools, coordination, hooks
+├── shared/coordination/    # Cross-agent coordination state
 ├── theke/                  # Human + agent collaborative space
 ├── signal/                 # signal-cli data (if using Signal)
 ```
@@ -112,23 +129,22 @@ The binary finds the instance directory in this order:
 
 ## Configuration
 
-Copy and edit the example config:
-
-```bash
-cp instance/config/aletheia.yaml.example instance/config/aletheia.yaml
-```
-
-Minimal working config:
+The init wizard writes a complete `config/aletheia.yaml`. If you are setting up manually, create one:
 
 ```yaml
 gateway:
   port: 18789
-  bind: lan
+  bind: localhost
 
 agents:
+  defaults:
+    model:
+      primary: claude-sonnet-4-6
   list:
     - id: main
+      name: Main
       default: true
+      workspace: instance/nous/main
 ```
 
 The config cascade loads in order (later wins): compiled defaults, YAML file, `ALETHEIA_` environment variables. See [CONFIGURATION.md](CONFIGURATION.md) for the complete reference.
@@ -276,45 +292,40 @@ Exposes `nous_turn_duration_seconds`, `anthropic_requests_total`, `http_requests
 
 ## Systemd Service (Linux)
 
-Create a user service unit:
+A ready-to-use service template lives in `instance.example/services/aletheia.service`.
+It uses `%h` (systemd's `$HOME` specifier) so paths resolve automatically.
 
 ```bash
+# 1. Copy the template
 mkdir -p ~/.config/systemd/user
-```
+cp instance.example/services/aletheia.service ~/.config/systemd/user/aletheia.service
 
-```ini
-# ~/.config/systemd/user/aletheia.service
-[Unit]
-Description=Aletheia cognitive agent runtime
-After=network-online.target
-Wants=network-online.target
+# 2. Adjust paths if needed (binary not at ~/.local/bin/, instance not at ~/aletheia/instance/)
+#    Edit ~/.config/systemd/user/aletheia.service and update ExecStart and ALETHEIA_ROOT.
 
-[Service]
-Type=simple
-Environment=ALETHEIA_ROOT=/srv/aletheia/instance
-Environment=ANTHROPIC_API_KEY=sk-ant-...
-ExecStart=/usr/local/bin/aletheia
-Restart=on-failure
-RestartSec=5
-StandardOutput=journal
-StandardError=journal
-
-[Install]
-WantedBy=default.target
-```
-
-Enable and start:
-
-```bash
+# 3. Enable and start
 systemctl --user daemon-reload
 systemctl --user enable --now aletheia
-loginctl enable-linger    # services survive logout
+
+# 4. Persist across logout (run once per user)
+loginctl enable-linger
 ```
+
+The template sets `ALETHEIA_ROOT=%h/aletheia/instance` and loads an optional
+`EnvironmentFile` from `%h/aletheia/instance/config/env` (silently ignored if absent).
+If your API key is stored in `instance/config/credentials/anthropic.json` (written by
+`aletheia init`), no extra environment setup is needed.
 
 View logs:
 
 ```bash
 journalctl --user -u aletheia -f
+```
+
+Verify after start:
+
+```bash
+aletheia health
 ```
 
 ---

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -14,6 +14,27 @@ cargo build --release
 cp target/release/aletheia ~/.local/bin/
 ```
 
+## Initialize
+
+```bash
+export ANTHROPIC_API_KEY=sk-ant-...   # or enter it interactively
+aletheia init                          # creates instance/, prompts for settings
+```
+
+Accepts `--yes` for non-interactive setup (uses defaults + env var API key):
+
+```bash
+ANTHROPIC_API_KEY=sk-ant-... aletheia init --yes
+```
+
+## Run
+
+```bash
+aletheia              # start the server (gateway, agents, daemon)
+aletheia health       # check connectivity — prints OK or FAILED
+aletheia tui          # launch the terminal dashboard
+```
+
 ## Daily Use
 
 ```bash

--- a/instance.example/services/aletheia.service
+++ b/instance.example/services/aletheia.service
@@ -5,9 +5,14 @@ Wants=network-online.target
 
 [Service]
 Type=simple
-Environment=ALETHEIA_HOME=__ALETHEIA_HOME__
-EnvironmentFile=-__ALETHEIA_HOME__/instance/config/env
-ExecStart=__ALETHEIA_HOME__/target/release/aletheia
+# %h expands to the user's home directory at runtime.
+# ALETHEIA_ROOT tells the binary where to find the instance directory.
+Environment=ALETHEIA_ROOT=%h/aletheia/instance
+# Optional: set API key here if not stored in instance/config/credentials/anthropic.json
+# Environment=ANTHROPIC_API_KEY=sk-ant-...
+# Load additional env vars from a file (silently ignored if the file does not exist).
+EnvironmentFile=-%h/aletheia/instance/config/env
+ExecStart=%h/.local/bin/aletheia
 Restart=on-failure
 RestartSec=5
 StandardOutput=journal
@@ -16,10 +21,27 @@ StandardError=journal
 [Install]
 WantedBy=default.target
 
-# Usage:
-#   mkdir -p ~/.config/systemd/user
-#   cp instance.example/services/aletheia.service ~/.config/systemd/user/
-#   # Edit ExecStart path to match your installation
-#   systemctl --user daemon-reload
-#   systemctl --user enable --now aletheia
-#   loginctl enable-linger
+# --- Quick install ---
+#
+# 1. Copy this file:
+#    mkdir -p ~/.config/systemd/user
+#    cp instance.example/services/aletheia.service ~/.config/systemd/user/aletheia.service
+#
+# 2. If your binary is not at ~/.local/bin/aletheia, edit ExecStart, e.g.:
+#    sed -i 's|%h/.local/bin/aletheia|/usr/local/bin/aletheia|' ~/.config/systemd/user/aletheia.service
+#
+# 3. If your instance is not at ~/aletheia/instance, edit ALETHEIA_ROOT, e.g.:
+#    sed -i 's|%h/aletheia/instance|/srv/aletheia/instance|' ~/.config/systemd/user/aletheia.service
+#
+# 4. Enable and start:
+#    systemctl --user daemon-reload
+#    systemctl --user enable --now aletheia
+#
+# 5. Persist across logout (run once per user):
+#    loginctl enable-linger
+#
+# 6. Check logs:
+#    journalctl --user -u aletheia -f
+#
+# 7. Verify:
+#    aletheia health

--- a/tui/src/error.rs
+++ b/tui/src/error.rs
@@ -13,7 +13,9 @@ pub enum Error {
     TokenRequired { message: String },
 
     /// Gateway is unreachable (health check returned false or connection refused).
-    #[snafu(display("cannot reach gateway at {url}. Is it running?"))]
+    #[snafu(display(
+        "cannot reach gateway at {url}\n  Server not running. Start it with: aletheia"
+    ))]
     GatewayUnreachable { url: String },
 
     /// Could not determine the OS config directory (e.g. $HOME unset).


### PR DESCRIPTION
## Summary

- **init wizard**: scaffold now creates `logs/traces/` and `shared/coordination/` directories; `--yes` mode skips gracefully when instance already exists (no silent overwrite)
- **startup errors**: port-in-use error includes `--port` guidance; missing-credential warning now says how to fix it (`ANTHROPIC_API_KEY` or `aletheia credential`)
- **health check**: connection errors show `FAILED: cannot connect to <url> — Start with: aletheia` instead of raw reqwest; success prints human-readable `OK — healthy | version X | uptime Ns`
- **TUI**: `GatewayUnreachable` error now includes "Start with: aletheia" hint
- **systemd service**: replace `__ALETHEIA_HOME__` placeholders with `%h` systemd specifier; fix `ALETHEIA_HOME` → `ALETHEIA_ROOT`; add step-by-step install comments
- **QUICKSTART.md**: add `aletheia init` step (was missing entirely — users went straight to `aletheia` with no instance)
- **DEPLOYMENT.md**: prefer `aletheia init` as primary setup path; update systemd section to reference the service template
- **fmt**: apply `cargo fmt` to pre-existing formatting diffs in `mneme` crate

## Test plan

- [ ] `cargo fmt -- --check` passes
- [ ] `cargo clippy -p aletheia --all-targets -- -D warnings` passes
- [ ] `cargo test -p aletheia` — 31 tests pass
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [ ] `aletheia init --yes` in a fresh dir creates `logs/traces/` and `shared/coordination/`
- [ ] Running `aletheia init --yes` twice prints "Instance already exists, skipping" and returns 0
- [ ] `aletheia health` with no server running prints `FAILED: cannot connect` with actionable hint
- [ ] `aletheia health` with server running prints `OK — healthy | version … | uptime …s`
- [ ] `aletheia tui` with no server prints "Server not running. Start with: aletheia"
- [ ] Starting server with port already in use prints "Port N is already in use. Use --port…"

🤖 Generated with [Claude Code](https://claude.com/claude-code)