### PR TITLE
feat(mneme): add explicit forgetting with reason tracking (F.6)

### DIFF
--- a/crates/aletheia/src/knowledge_adapter.rs
+++ b/crates/aletheia/src/knowledge_adapter.rs
@@ -237,29 +237,33 @@ impl KnowledgeSearchService for KnowledgeSearchAdapter {
         &self,
         fact_id: &str,
         reason: &str,
-    ) -> Pin<Box<dyn Future<Output = Result<(), String>> + Send + '_>> {
+    ) -> Pin<Box<dyn Future<Output = Result<FactSummary, String>> + Send + '_>> {
         let fact_id = aletheia_mneme::id::FactId::from(fact_id);
         let reason = reason.to_owned();
         Box::pin(async move {
             let reason: aletheia_mneme::knowledge::ForgetReason =
                 reason.parse().map_err(|e: String| e)?;
-            self.store
+            let fact = self
+                .store
                 .forget_fact_async(fact_id, reason)
                 .await
-                .map_err(|e| format!("failed to forget fact: {e}"))
+                .map_err(|e| format!("failed to forget fact: {e}"))?;
+            Ok(fact_to_summary(fact))
         })
     }
 
     fn unforget_fact(
         &self,
         fact_id: &str,
-    ) -> Pin<Box<dyn Future<Output = Result<(), String>> + Send + '_>> {
+    ) -> Pin<Box<dyn Future<Output = Result<FactSummary, String>> + Send + '_>> {
         let fact_id = aletheia_mneme::id::FactId::from(fact_id);
         Box::pin(async move {
-            self.store
+            let fact = self
+                .store
                 .unforget_fact_async(fact_id)
                 .await
-                .map_err(|e| format!("failed to unforget fact: {e}"))
+                .map_err(|e| format!("failed to unforget fact: {e}"))?;
+            Ok(fact_to_summary(fact))
         })
     }
 
@@ -303,6 +307,19 @@ impl KnowledgeSearchService for KnowledgeSearchAdapter {
                 truncated,
             })
         })
+    }
+}
+
+fn fact_to_summary(f: Fact) -> FactSummary {
+    FactSummary {
+        id: f.id.to_string(),
+        content: f.content,
+        confidence: f.confidence,
+        tier: f.tier.to_string(),
+        recorded_at: aletheia_mneme::knowledge::format_timestamp(&f.recorded_at),
+        is_forgotten: f.is_forgotten,
+        forgotten_at: f.forgotten_at.map(|t| t.to_string()),
+        forget_reason: f.forget_reason.map(|r| r.to_string()),
     }
 }
 

--- a/crates/integration-tests/tests/organon_mneme_tools.rs
+++ b/crates/integration-tests/tests/organon_mneme_tools.rs
@@ -314,17 +314,41 @@ impl KnowledgeSearchService for StubKnowledgeService {
 
     fn forget_fact(
         &self,
-        _fact_id: &str,
-        _reason: &str,
-    ) -> Pin<Box<dyn Future<Output = Result<(), String>> + Send + '_>> {
-        Box::pin(std::future::ready(Ok(())))
+        fact_id: &str,
+        reason: &str,
+    ) -> Pin<
+        Box<dyn Future<Output = Result<aletheia_organon::types::FactSummary, String>> + Send + '_>,
+    > {
+        let summary = aletheia_organon::types::FactSummary {
+            id: fact_id.to_owned(),
+            content: "mock fact".to_owned(),
+            confidence: 1.0,
+            tier: "established".to_owned(),
+            recorded_at: "2026-01-01T00:00:00Z".to_owned(),
+            is_forgotten: true,
+            forgotten_at: Some("2026-01-02T00:00:00Z".to_owned()),
+            forget_reason: Some(reason.to_owned()),
+        };
+        Box::pin(std::future::ready(Ok(summary)))
     }
 
     fn unforget_fact(
         &self,
-        _fact_id: &str,
-    ) -> Pin<Box<dyn Future<Output = Result<(), String>> + Send + '_>> {
-        Box::pin(std::future::ready(Ok(())))
+        fact_id: &str,
+    ) -> Pin<
+        Box<dyn Future<Output = Result<aletheia_organon::types::FactSummary, String>> + Send + '_>,
+    > {
+        let summary = aletheia_organon::types::FactSummary {
+            id: fact_id.to_owned(),
+            content: "mock fact".to_owned(),
+            confidence: 1.0,
+            tier: "established".to_owned(),
+            recorded_at: "2026-01-01T00:00:00Z".to_owned(),
+            is_forgotten: false,
+            forgotten_at: None,
+            forget_reason: None,
+        };
+        Box::pin(std::future::ready(Ok(summary)))
     }
 
     fn datalog_query(

--- a/crates/mneme/src/consolidation.rs
+++ b/crates/mneme/src/consolidation.rs
@@ -106,10 +106,7 @@ pub enum ConsolidationTrigger {
         fact_count: usize,
     },
     /// A Louvain community cluster accumulated more than the threshold of active facts.
-    CommunityOverflow {
-        cluster_id: i64,
-        fact_count: usize,
-    },
+    CommunityOverflow { cluster_id: i64, fact_count: usize },
 }
 
 impl ConsolidationTrigger {
@@ -204,11 +201,7 @@ pub struct ConsolidationAuditRecord {
 /// to the configured LLM provider.
 pub trait ConsolidationProvider: Send + Sync {
     /// Send a consolidation prompt and return the raw response.
-    fn consolidate(
-        &self,
-        system: &str,
-        user_message: &str,
-    ) -> Result<String, ConsolidationError>;
+    fn consolidate(&self, system: &str, user_message: &str) -> Result<String, ConsolidationError>;
 }
 
 // ---------------------------------------------------------------------------
@@ -423,12 +416,12 @@ pub const CONSOLIDATION_AUDIT_DDL: &str = r":create consolidation_audit {
 #[cfg(feature = "mneme-engine")]
 mod engine_impl {
     use crate::consolidation::{
+        CLUSTER_FACTS_FOR_CONSOLIDATION, COMMUNITY_OVERFLOW_CANDIDATES, CONSOLIDATION_AUDIT_DDL,
+        ConsolidatedFact, ConsolidationAuditRecord, ConsolidationCandidate, ConsolidationConfig,
+        ConsolidationError, ConsolidationProvider, ConsolidationResult, ConsolidationTrigger,
+        ENTITY_FACTS_FOR_CONSOLIDATION, ENTITY_OVERFLOW_CANDIDATES, RateLimitedSnafu, StoreSnafu,
         age_cutoff, batch_facts, consolidation_system_prompt, consolidation_user_message,
-        parse_consolidation_response, ConsolidatedFact, ConsolidationAuditRecord,
-        ConsolidationCandidate, ConsolidationConfig, ConsolidationError, ConsolidationProvider,
-        ConsolidationResult, ConsolidationTrigger, RateLimitedSnafu, StoreSnafu,
-        CLUSTER_FACTS_FOR_CONSOLIDATION, COMMUNITY_OVERFLOW_CANDIDATES,
-        CONSOLIDATION_AUDIT_DDL, ENTITY_FACTS_FOR_CONSOLIDATION, ENTITY_OVERFLOW_CANDIDATES,
+        parse_consolidation_response,
     };
     use crate::engine::DataValue;
     use crate::id::{EntityId, FactId};
@@ -471,7 +464,12 @@ mod engine_impl {
 
             let result = self
                 .run_query(ENTITY_OVERFLOW_CANDIDATES, params)
-                .map_err(|e| StoreSnafu { message: e.to_string() }.build())?;
+                .map_err(|e| {
+                    StoreSnafu {
+                        message: e.to_string(),
+                    }
+                    .build()
+                })?;
 
             let mut candidates = Vec::new();
             for row in &result.rows {
@@ -481,7 +479,12 @@ mod engine_impl {
 
                 let facts = self
                     .gather_entity_facts(nous_id, &entity_id, &cutoff)
-                    .map_err(|e| StoreSnafu { message: e.to_string() }.build())?;
+                    .map_err(|e| {
+                        StoreSnafu {
+                            message: e.to_string(),
+                        }
+                        .build()
+                    })?;
 
                 let fact_ids: Vec<FactId> = facts.iter().map(|(id, _, _, _)| id.clone()).collect();
 
@@ -521,7 +524,12 @@ mod engine_impl {
 
             let result = self
                 .run_query(COMMUNITY_OVERFLOW_CANDIDATES, params)
-                .map_err(|e| StoreSnafu { message: e.to_string() }.build())?;
+                .map_err(|e| {
+                    StoreSnafu {
+                        message: e.to_string(),
+                    }
+                    .build()
+                })?;
 
             let mut candidates = Vec::new();
             for row in &result.rows {
@@ -530,7 +538,12 @@ mod engine_impl {
 
                 let facts = self
                     .gather_cluster_facts(nous_id, cluster_id, &cutoff)
-                    .map_err(|e| StoreSnafu { message: e.to_string() }.build())?;
+                    .map_err(|e| {
+                        StoreSnafu {
+                            message: e.to_string(),
+                        }
+                        .build()
+                    })?;
 
                 let fact_ids: Vec<FactId> = facts.iter().map(|(id, _, _, _)| id.clone()).collect();
 
@@ -599,10 +612,20 @@ mod engine_impl {
             let facts = match &candidate.trigger {
                 ConsolidationTrigger::EntityOverflow { entity_id, .. } => self
                     .gather_entity_facts(nous_id, entity_id, &cutoff)
-                    .map_err(|e| StoreSnafu { message: e.to_string() }.build())?,
+                    .map_err(|e| {
+                        StoreSnafu {
+                            message: e.to_string(),
+                        }
+                        .build()
+                    })?,
                 ConsolidationTrigger::CommunityOverflow { cluster_id, .. } => self
                     .gather_cluster_facts(nous_id, *cluster_id, &cutoff)
-                    .map_err(|e| StoreSnafu { message: e.to_string() }.build())?,
+                    .map_err(|e| {
+                        StoreSnafu {
+                            message: e.to_string(),
+                        }
+                        .build()
+                    })?,
             };
 
             if facts.is_empty() {
@@ -652,15 +675,18 @@ mod engine_impl {
                     recorded_at: now,
                     access_count: 0,
                     last_accessed_at: None,
-                    stability_hours: crate::knowledge::FactType::Observation
-                        .base_stability_hours(),
+                    stability_hours: crate::knowledge::FactType::Observation.base_stability_hours(),
                     fact_type: "observation".to_owned(),
                     is_forgotten: false,
                     forgotten_at: None,
                     forget_reason: None,
                 };
-                self.insert_fact(&fact)
-                    .map_err(|e| StoreSnafu { message: e.to_string() }.build())?;
+                self.insert_fact(&fact).map_err(|e| {
+                    StoreSnafu {
+                        message: e.to_string(),
+                    }
+                    .build()
+                })?;
                 new_fact_ids.push(new_id);
             }
             Ok(new_fact_ids)
@@ -673,14 +699,16 @@ mod engine_impl {
             new_fact_ids: &[FactId],
         ) -> Result<(), ConsolidationError> {
             let now_str = crate::knowledge::format_timestamp(&jiff::Timestamp::now());
-            let superseding_id = new_fact_ids
-                .first()
-                .map(FactId::as_str)
-                .unwrap_or_default();
+            let superseding_id = new_fact_ids.first().map(FactId::as_str).unwrap_or_default();
 
             for original_id in &result.superseded_fact_ids {
                 self.supersede_fact_by_id(original_id, superseding_id, &now_str)
-                    .map_err(|e| StoreSnafu { message: e.to_string() }.build())?;
+                    .map_err(|e| {
+                        StoreSnafu {
+                            message: e.to_string(),
+                        }
+                        .build()
+                    })?;
             }
             Ok(())
         }
@@ -702,10 +730,9 @@ mod engine_impl {
                     .collect::<Vec<_>>(),
             )
             .unwrap_or_else(|_| "[]".to_owned());
-            let consolidated_ids_json = serde_json::to_string(
-                &new_fact_ids.iter().map(FactId::as_str).collect::<Vec<_>>(),
-            )
-            .unwrap_or_else(|_| "[]".to_owned());
+            let consolidated_ids_json =
+                serde_json::to_string(&new_fact_ids.iter().map(FactId::as_str).collect::<Vec<_>>())
+                    .unwrap_or_else(|_| "[]".to_owned());
 
             self.record_consolidation_audit(&ConsolidationAuditRecord {
                 id: audit_id,
@@ -717,7 +744,12 @@ mod engine_impl {
                 consolidated_fact_ids: consolidated_ids_json,
                 consolidated_at: now_str,
             })
-            .map_err(|e| StoreSnafu { message: e.to_string() }.build())
+            .map_err(|e| {
+                StoreSnafu {
+                    message: e.to_string(),
+                }
+                .build()
+            })
         }
 
         /// Mark a fact as superseded by ID, setting `valid_to` and `superseded_by`.
@@ -817,9 +849,12 @@ mod engine_impl {
 :sort -consolidated_at
 :limit 1
 ";
-            let result = self
-                .run_query(script, BTreeMap::new())
-                .map_err(|e| StoreSnafu { message: e.to_string() }.build())?;
+            let result = self.run_query(script, BTreeMap::new()).map_err(|e| {
+                StoreSnafu {
+                    message: e.to_string(),
+                }
+                .build()
+            })?;
 
             if let Some(row) = result.rows.first() {
                 Ok(Some(row[0].get_str().unwrap_or_default().to_owned()))
@@ -851,15 +886,15 @@ mod engine_impl {
             let mut results = Vec::new();
 
             for candidate in &self.find_entity_overflow_candidates(nous_id, config)? {
-                results.push(self.execute_consolidation(
-                    provider, candidate, nous_id, config, dry_run,
-                )?);
+                results.push(
+                    self.execute_consolidation(provider, candidate, nous_id, config, dry_run)?,
+                );
             }
 
             for candidate in &self.find_community_overflow_candidates(nous_id, config)? {
-                results.push(self.execute_consolidation(
-                    provider, candidate, nous_id, config, dry_run,
-                )?);
+                results.push(
+                    self.execute_consolidation(provider, candidate, nous_id, config, dry_run)?,
+                );
             }
 
             Ok(results)
@@ -875,8 +910,7 @@ mod engine_impl {
                 if let Some(last_ts) = crate::knowledge::parse_timestamp(&last_time) {
                     let now = jiff::Timestamp::now();
                     if let Ok(span) = now.since(last_ts) {
-                        let total_minutes =
-                            i64::from(span.get_hours()) * 60 + span.get_minutes();
+                        let total_minutes = i64::from(span.get_hours()) * 60 + span.get_minutes();
                         #[expect(
                             clippy::cast_precision_loss,
                             reason = "elapsed minutes as f64 is fine for rate limiting"
@@ -958,7 +992,9 @@ mod engine_impl {
 pub(crate) fn age_cutoff(min_age_days: u32) -> String {
     let now = jiff::Timestamp::now();
     let cutoff = now
-        .checked_sub(jiff::SignedDuration::from_hours(i64::from(min_age_days) * 24))
+        .checked_sub(jiff::SignedDuration::from_hours(
+            i64::from(min_age_days) * 24,
+        ))
         .unwrap_or(now);
     crate::knowledge::format_timestamp(&cutoff)
 }
@@ -1196,7 +1232,9 @@ Some trailing text."#;
     #[test]
     fn mock_provider_returns_response() {
         let provider = MockConsolidationProvider::new(r#"[{"content": "test"}]"#);
-        let result = provider.consolidate("system", "user").expect("should succeed");
+        let result = provider
+            .consolidate("system", "user")
+            .expect("should succeed");
         assert!(result.contains("test"));
     }
 
@@ -1232,9 +1270,7 @@ Some trailing text."#;
 
 #[cfg(all(test, feature = "mneme-engine"))]
 mod engine_tests {
-    use super::{
-        batch_facts, ConsolidationConfig, ConsolidationError, ConsolidationProvider,
-    };
+    use super::{ConsolidationConfig, ConsolidationError, ConsolidationProvider, batch_facts};
     use crate::id::{EntityId, FactId};
     use crate::knowledge::{self, EpistemicTier, Fact};
     use crate::knowledge_store::KnowledgeStore;
@@ -1244,7 +1280,13 @@ mod engine_tests {
         KnowledgeStore::open_mem().expect("open_mem")
     }
 
-    fn make_fact(id: &str, nous_id: &str, content: &str, tier: EpistemicTier, days_ago: i64) -> Fact {
+    fn make_fact(
+        id: &str,
+        nous_id: &str,
+        content: &str,
+        tier: EpistemicTier,
+        days_ago: i64,
+    ) -> Fact {
         let now = jiff::Timestamp::now();
         let recorded = now
             .checked_sub(jiff::SignedDuration::from_hours(days_ago * 24))
@@ -1270,17 +1312,10 @@ mod engine_tests {
         }
     }
 
-    fn insert_fact_with_entity(
-        store: &KnowledgeStore,
-        fact: &Fact,
-        entity_id: &str,
-    ) {
+    fn insert_fact_with_entity(store: &KnowledgeStore, fact: &Fact, entity_id: &str) {
         store.insert_fact(fact).expect("insert fact");
         store
-            .insert_fact_entity(
-                &fact.id,
-                &EntityId::from(entity_id),
-            )
+            .insert_fact_entity(&fact.id, &EntityId::from(entity_id))
             .expect("insert fact_entity");
     }
 
@@ -1402,7 +1437,10 @@ mod engine_tests {
             .find_entity_overflow_candidates(nous_id, &config)
             .expect("find candidates");
 
-        assert!(candidates.is_empty(), "recent facts should be excluded by age gate");
+        assert!(
+            candidates.is_empty(),
+            "recent facts should be excluded by age gate"
+        );
     }
 
     #[test]
@@ -1545,7 +1583,11 @@ mod engine_tests {
         let candidates_after = store
             .find_entity_overflow_candidates(nous_id, &config)
             .expect("find candidates after dry run");
-        assert_eq!(candidates_after.len(), 1, "dry run must not supersede facts");
+        assert_eq!(
+            candidates_after.len(),
+            1,
+            "dry run must not supersede facts"
+        );
         assert_eq!(candidates_after[0].fact_count, 12);
     }
 
@@ -1639,9 +1681,7 @@ mod engine_tests {
             .execute_consolidation(&provider, &candidates[0], nous_id, &config, false)
             .expect("execute");
 
-        let last_time = store
-            .last_consolidation_time(nous_id)
-            .expect("query audit");
+        let last_time = store.last_consolidation_time(nous_id).expect("query audit");
         assert!(last_time.is_some(), "audit record must be created");
     }
 

--- a/crates/mneme/src/engine/query/graph.rs
+++ b/crates/mneme/src/engine/query/graph.rs
@@ -175,7 +175,8 @@ impl<'a> TarjanScc<'a> {
                 self.low[at] = min(self.low[at], self.low[to]);
             }
         }
-        if self.ids[at].expect("ids[at] is Some: assigned on dfs() entry (line above recursive call)")
+        if self.ids[at]
+            .expect("ids[at] is Some: assigned on dfs() entry (line above recursive call)")
             == self.low[at]
         {
             while let Some(node) = self.stack.pop() {

--- a/crates/mneme/src/engine/query/magic.rs
+++ b/crates/mneme/src/engine/query/magic.rs
@@ -187,7 +187,9 @@ fn magic_rewrite_ruleset(
                             .entry(sup_kw.clone())
                             .or_default()
                             .mut_rules()
-                            .expect("entry is Rules variant: Default creates MagicRulesOrFixed::Rules");
+                            .expect(
+                                "entry is Rules variant: Default creates MagicRulesOrFixed::Rules",
+                            );
                         let mut sup_rule_atoms = vec![];
                         mem::swap(&mut sup_rule_atoms, &mut collected_atoms);
 
@@ -216,7 +218,9 @@ fn magic_rewrite_ruleset(
                             .entry(inp_kw.clone())
                             .or_default()
                             .mut_rules()
-                            .expect("entry is Rules variant: Default creates MagicRulesOrFixed::Rules");
+                            .expect(
+                                "entry is Rules variant: Default creates MagicRulesOrFixed::Rules",
+                            );
                         let inp_args = r_app
                             .args
                             .iter()
@@ -476,8 +480,10 @@ impl NormalFormProgram {
             let original_rules = self
                 .prog
                 .get(head.as_plain_symbol())
-                .expect("adorned head always has a corresponding entry in prog: \
-                         pending_adornment is seeded from prog keys")
+                .expect(
+                    "adorned head always has a corresponding entry in prog: \
+                         pending_adornment is seeded from prog keys",
+                )
                 .rules()
                 .ok_or_else(|| {
                     CompilationFailedSnafu {

--- a/crates/mneme/src/engine/query/ra.rs
+++ b/crates/mneme/src/engine/query/ra.rs
@@ -2007,12 +2007,10 @@ impl NegJoin {
         let eliminate_indices = get_eliminate_indices(&bindings, &self.to_eliminate);
         match &self.right {
             RelAlgebra::TempStore(r) => {
-                let join_indices = self
-                    .joiner
-                    .join_indices(
-                        &self.left.bindings_after_eliminate(),
-                        &self.right.bindings_after_eliminate(),
-                    )?;
+                let join_indices = self.joiner.join_indices(
+                    &self.left.bindings_after_eliminate(),
+                    &self.right.bindings_after_eliminate(),
+                )?;
                 r.neg_join(
                     self.left.iter(tx, delta_rule, stores)?,
                     join_indices,
@@ -2021,12 +2019,10 @@ impl NegJoin {
                 )
             }
             RelAlgebra::Stored(v) => {
-                let join_indices = self
-                    .joiner
-                    .join_indices(
-                        &self.left.bindings_after_eliminate(),
-                        &self.right.bindings_after_eliminate(),
-                    )?;
+                let join_indices = self.joiner.join_indices(
+                    &self.left.bindings_after_eliminate(),
+                    &self.right.bindings_after_eliminate(),
+                )?;
                 v.neg_join(
                     tx,
                     self.left.iter(tx, delta_rule, stores)?,
@@ -2149,12 +2145,10 @@ impl InnerJoin {
         let eliminate_indices = get_eliminate_indices(&bindings, &self.to_eliminate);
         match &self.right {
             RelAlgebra::Fixed(f) => {
-                let join_indices = self
-                    .joiner
-                    .join_indices(
-                        &self.left.bindings_after_eliminate(),
-                        &self.right.bindings_after_eliminate(),
-                    )?;
+                let join_indices = self.joiner.join_indices(
+                    &self.left.bindings_after_eliminate(),
+                    &self.right.bindings_after_eliminate(),
+                )?;
                 f.join(
                     self.left.iter(tx, delta_rule, stores)?,
                     join_indices,
@@ -2162,12 +2156,10 @@ impl InnerJoin {
                 )
             }
             RelAlgebra::TempStore(r) => {
-                let join_indices = self
-                    .joiner
-                    .join_indices(
-                        &self.left.bindings_after_eliminate(),
-                        &self.right.bindings_after_eliminate(),
-                    )?;
+                let join_indices = self.joiner.join_indices(
+                    &self.left.bindings_after_eliminate(),
+                    &self.right.bindings_after_eliminate(),
+                )?;
                 if join_is_prefix(&join_indices.1) {
                     r.prefix_join(
                         self.left.iter(tx, delta_rule, stores)?,
@@ -2181,12 +2173,10 @@ impl InnerJoin {
                 }
             }
             RelAlgebra::Stored(r) => {
-                let join_indices = self
-                    .joiner
-                    .join_indices(
-                        &self.left.bindings_after_eliminate(),
-                        &self.right.bindings_after_eliminate(),
-                    )?;
+                let join_indices = self.joiner.join_indices(
+                    &self.left.bindings_after_eliminate(),
+                    &self.right.bindings_after_eliminate(),
+                )?;
                 if join_is_prefix(&join_indices.1) {
                     r.prefix_join(
                         tx,
@@ -2199,12 +2189,10 @@ impl InnerJoin {
                 }
             }
             RelAlgebra::StoredWithValidity(r) => {
-                let join_indices = self
-                    .joiner
-                    .join_indices(
-                        &self.left.bindings_after_eliminate(),
-                        &self.right.bindings_after_eliminate(),
-                    )?;
+                let join_indices = self.joiner.join_indices(
+                    &self.left.bindings_after_eliminate(),
+                    &self.right.bindings_after_eliminate(),
+                )?;
                 if join_is_prefix(&join_indices.1) {
                     r.prefix_join(
                         tx,

--- a/crates/mneme/src/engine/query/stored.rs
+++ b/crates/mneme/src/engine/query/stored.rs
@@ -77,8 +77,8 @@ impl<'a> SessionTx<'a> {
                         trigger,
                         &Default::default(),
                         &db.fixed_rules
-                    .read()
-                    .expect("fixed_rules lock is not poisoned"),
+                            .read()
+                            .expect("fixed_rules lock is not poisoned"),
                         cur_vld,
                     )?
                     .get_single_program()?;
@@ -737,8 +737,8 @@ impl<'a> SessionTx<'a> {
                     trigger,
                     &Default::default(),
                     &db.fixed_rules
-                    .read()
-                    .expect("fixed_rules lock is not poisoned"),
+                        .read()
+                        .expect("fixed_rules lock is not poisoned"),
                     cur_vld,
                 )?
                 .get_single_program()?;
@@ -1085,8 +1085,8 @@ impl<'a> SessionTx<'a> {
                         trigger,
                         &Default::default(),
                         &db.fixed_rules
-                    .read()
-                    .expect("fixed_rules lock is not poisoned"),
+                            .read()
+                            .expect("fixed_rules lock is not poisoned"),
                         cur_vld,
                     )?
                     .get_single_program()?;

--- a/crates/mneme/src/engine/query/stratify.rs
+++ b/crates/mneme/src/engine/query/stratify.rs
@@ -278,9 +278,9 @@ impl NormalFormProgram {
         for (name, ruleset) in self.prog {
             if let Some(scc_idx) = invert_indices.get(&name) {
                 if let Some(rev_stratum_idx) = invert_sort_result.get(scc_idx) {
-                    let target = ret
-                        .get_mut(*rev_stratum_idx)
-                        .expect("stratum index always valid: rev_stratum_idx derived from ret's range");
+                    let target = ret.get_mut(*rev_stratum_idx).expect(
+                        "stratum index always valid: rev_stratum_idx derived from ret's range",
+                    );
                     target.prog.insert(name, ruleset);
                 }
             }

--- a/crates/mneme/src/error.rs
+++ b/crates/mneme/src/error.rs
@@ -205,6 +205,14 @@ pub enum Error {
         location: snafu::Location,
     },
 
+    /// Attempted to operate on a fact that does not exist.
+    #[snafu(display("fact not found: {id}"))]
+    FactNotFound {
+        id: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
     /// HNSW vector index operation failed.
     #[cfg(feature = "hnsw_rs")]
     #[snafu(display("HNSW index error: {message}"))]

--- a/crates/mneme/src/knowledge_store.rs
+++ b/crates/mneme/src/knowledge_store.rs
@@ -1085,7 +1085,8 @@ impl KnowledgeStore {
         &self,
         pending_fact_id: &crate::id::FactId,
     ) -> crate::error::Result<()> {
-        self.forget_fact(pending_fact_id, crate::knowledge::ForgetReason::Incorrect)
+        self.forget_fact(pending_fact_id, crate::knowledge::ForgetReason::Incorrect)?;
+        Ok(())
     }
 
     /// Check if a skill similar to the given content already exists.
@@ -1154,6 +1155,9 @@ impl KnowledgeStore {
         let script = build_hybrid_query(q);
         let rows = self.run_read(&script, params)?;
         let results = rows_to_hybrid_results(rows)?;
+
+        // Filter out forgotten facts — search indices don't carry is_forgotten.
+        let results = self.filter_forgotten_results(results)?;
 
         let fact_ids: Vec<crate::id::FactId> = results.iter().map(|r| r.id.clone()).collect();
         if let Err(e) = self.increment_access(&fact_ids) {
@@ -1409,12 +1413,23 @@ impl KnowledgeStore {
     }
 
     /// Soft-delete a fact: set `is_forgotten = true` with reason and timestamp.
+    ///
+    /// Returns the forgotten fact. Errors if the fact does not exist.
     #[instrument(skip(self))]
     pub fn forget_fact(
         &self,
         fact_id: &crate::id::FactId,
         reason: crate::knowledge::ForgetReason,
-    ) -> crate::error::Result<()> {
+    ) -> crate::error::Result<crate::knowledge::Fact> {
+        // Verify fact exists before mutating.
+        let existing = self.read_facts_by_id(fact_id.as_str())?;
+        if existing.is_empty() {
+            return Err(crate::error::FactNotFoundSnafu {
+                id: fact_id.as_str(),
+            }
+            .build());
+        }
+
         let now = crate::knowledge::format_timestamp(&jiff::Timestamp::now());
         let script = r"
             ?[id, valid_from, content, nous_id, confidence, tier, valid_to,
@@ -1443,12 +1458,34 @@ impl KnowledgeStore {
             "reason".to_owned(),
             crate::engine::DataValue::Str(reason.as_str().into()),
         );
-        self.run_mut(script, params)
+        self.run_mut(script, params)?;
+
+        // Re-read the fact to return its updated state.
+        let facts = self.read_facts_by_id(fact_id.as_str())?;
+        facts.into_iter().next().ok_or_else(|| {
+            crate::error::FactNotFoundSnafu {
+                id: fact_id.as_str(),
+            }
+            .build()
+        })
     }
 
     /// Reverse a soft-delete: clear `is_forgotten`, `forgotten_at`, `forget_reason`.
+    ///
+    /// Returns the restored fact. Errors if the fact does not exist.
     #[instrument(skip(self))]
-    pub fn unforget_fact(&self, fact_id: &crate::id::FactId) -> crate::error::Result<()> {
+    pub fn unforget_fact(
+        &self,
+        fact_id: &crate::id::FactId,
+    ) -> crate::error::Result<crate::knowledge::Fact> {
+        let existing = self.read_facts_by_id(fact_id.as_str())?;
+        if existing.is_empty() {
+            return Err(crate::error::FactNotFoundSnafu {
+                id: fact_id.as_str(),
+            }
+            .build());
+        }
+
         let script = r"
             ?[id, valid_from, content, nous_id, confidence, tier, valid_to,
               superseded_by, source_session_id, recorded_at,
@@ -1471,7 +1508,98 @@ impl KnowledgeStore {
             "id".to_owned(),
             crate::engine::DataValue::Str(fact_id.as_str().into()),
         );
-        self.run_mut(script, params)
+        self.run_mut(script, params)?;
+
+        let facts = self.read_facts_by_id(fact_id.as_str())?;
+        facts.into_iter().next().ok_or_else(|| {
+            crate::error::FactNotFoundSnafu {
+                id: fact_id.as_str(),
+            }
+            .build()
+        })
+    }
+
+    /// List only forgotten facts for a given agent, ordered by `forgotten_at`.
+    ///
+    /// Returns facts where `is_forgotten == true`, with their reasons and timestamps.
+    #[instrument(skip(self))]
+    pub fn list_forgotten(
+        &self,
+        nous_id: &str,
+        limit: i64,
+    ) -> crate::error::Result<Vec<crate::knowledge::Fact>> {
+        use crate::engine::DataValue;
+        use std::collections::BTreeMap;
+
+        let mut params = BTreeMap::new();
+        params.insert("nous_id".to_owned(), DataValue::Str(nous_id.into()));
+        params.insert("limit".to_owned(), DataValue::from(limit));
+        let rows = self.run_read(&queries::forgotten_facts(), params)?;
+        rows_to_facts(rows, nous_id)
+    }
+
+    /// Async `list_forgotten` — wraps sync call in `spawn_blocking`.
+    #[instrument(skip(self))]
+    pub async fn list_forgotten_async(
+        self: &std::sync::Arc<Self>,
+        nous_id: String,
+        limit: i64,
+    ) -> crate::error::Result<Vec<crate::knowledge::Fact>> {
+        use snafu::ResultExt;
+        let this = std::sync::Arc::clone(self);
+        tokio::task::spawn_blocking(move || this.list_forgotten(&nous_id, limit))
+            .await
+            .context(crate::error::JoinSnafu)?
+    }
+
+    /// Filter hybrid search results to exclude forgotten facts.
+    fn filter_forgotten_results(
+        &self,
+        results: Vec<HybridResult>,
+    ) -> crate::error::Result<Vec<HybridResult>> {
+        if results.is_empty() {
+            return Ok(results);
+        }
+
+        // Batch-check which fact IDs are forgotten via a single query.
+        let forgotten_ids = self.forgotten_fact_ids(&results)?;
+        if forgotten_ids.is_empty() {
+            return Ok(results);
+        }
+
+        Ok(results
+            .into_iter()
+            .filter(|r| !forgotten_ids.contains(r.id.as_str()))
+            .collect())
+    }
+
+    /// Return the set of fact IDs (from the given results) that are currently forgotten.
+    fn forgotten_fact_ids(
+        &self,
+        results: &[HybridResult],
+    ) -> crate::error::Result<std::collections::HashSet<String>> {
+        use crate::engine::DataValue;
+        use std::collections::BTreeMap;
+
+        // Build a Datalog query that checks each ID.
+        let id_list: Vec<String> = results
+            .iter()
+            .map(|r| format!("'{}'", r.id.as_str().replace('\'', "''")))
+            .collect();
+        let script = format!(
+            r"?[id] := *facts{{id, is_forgotten}}, is_forgotten == true, id in [{}]",
+            id_list.join(", ")
+        );
+        let rows = self.run_read(&script, BTreeMap::<String, DataValue>::new())?;
+        let mut ids = std::collections::HashSet::new();
+        for row in rows.rows {
+            if let Some(val) = row.first() {
+                if let Ok(s) = extract_str(val) {
+                    ids.insert(s);
+                }
+            }
+        }
+        Ok(ids)
     }
 
     /// Query facts valid at a specific point in time.
@@ -1648,7 +1776,7 @@ impl KnowledgeStore {
         self: &std::sync::Arc<Self>,
         fact_id: crate::id::FactId,
         reason: crate::knowledge::ForgetReason,
-    ) -> crate::error::Result<()> {
+    ) -> crate::error::Result<crate::knowledge::Fact> {
         use snafu::ResultExt;
         let this = std::sync::Arc::clone(self);
         tokio::task::spawn_blocking(move || this.forget_fact(&fact_id, reason))
@@ -1661,7 +1789,7 @@ impl KnowledgeStore {
     pub async fn unforget_fact_async(
         self: &std::sync::Arc<Self>,
         fact_id: crate::id::FactId,
-    ) -> crate::error::Result<()> {
+    ) -> crate::error::Result<crate::knowledge::Fact> {
         use snafu::ResultExt;
         let this = std::sync::Arc::clone(self);
         tokio::task::spawn_blocking(move || this.unforget_fact(&fact_id))
@@ -4499,28 +4627,27 @@ mod knowledge_store_tests {
         let fact = make_fact("f1", "agent-a", "Secret fact");
         store.insert_fact(&fact).expect("insert fact");
 
-        store
+        let forgotten = store
             .forget_fact(
                 &crate::id::FactId::new_unchecked("f1"),
                 ForgetReason::UserRequested,
             )
             .expect("forget fact");
+        assert!(forgotten.is_forgotten);
+        assert_eq!(forgotten.forget_reason, Some(ForgetReason::UserRequested));
+        assert!(forgotten.forgotten_at.is_some());
 
         let results = store
             .query_facts("agent-a", "2026-06-01", 10)
             .expect("query facts");
-        // query_facts returns current, non-forgotten facts
         assert!(
-            results.is_empty()
-                || results
-                    .iter()
-                    .all(|f| f.id.as_str() != "f1" || !f.is_forgotten),
-            "forgotten fact should be excluded or marked"
+            results.is_empty(),
+            "forgotten fact must not appear in recall"
         );
     }
 
     #[test]
-    fn unforget_fact_restores_visibility() {
+    fn forget_fact_then_unforget_restores_recall() {
         let store = make_store();
         let fact = make_fact("f1", "agent-a", "Recoverable fact");
         store.insert_fact(&fact).expect("insert fact");
@@ -4531,18 +4658,27 @@ mod knowledge_store_tests {
                 ForgetReason::Outdated,
             )
             .expect("forget");
-        store
+
+        // Verify excluded from recall
+        let results = store
+            .query_facts("agent-a", "2026-06-01", 10)
+            .expect("query");
+        assert!(results.is_empty(), "forgotten fact excluded from recall");
+
+        // Unforget
+        let restored = store
             .unforget_fact(&crate::id::FactId::new_unchecked("f1"))
             .expect("unforget");
+        assert!(!restored.is_forgotten);
+        assert!(restored.forgotten_at.is_none());
+        assert!(restored.forget_reason.is_none());
 
-        // After unforgetting, audit should show it as not forgotten
-        let all = store.audit_all_facts("agent-a", 100).expect("audit facts");
-        let found = all.iter().find(|f| f.id.as_str() == "f1");
-        assert!(found.is_some(), "fact should still exist");
-        assert!(
-            !found.expect("f1 must exist after unforget").is_forgotten,
-            "should not be forgotten"
-        );
+        // Verify returned to recall
+        let results = store
+            .query_facts("agent-a", "2026-06-01", 10)
+            .expect("query after unforget");
+        assert_eq!(results.len(), 1, "unforget must restore recall visibility");
+        assert_eq!(results[0].id.as_str(), "f1");
     }
 
     #[test]
@@ -4564,6 +4700,82 @@ mod knowledge_store_tests {
         let found = found.expect("f1 must appear in audit after forget");
         assert!(found.is_forgotten);
         assert_eq!(found.forget_reason, Some(ForgetReason::Privacy));
+    }
+
+    #[test]
+    fn forget_reason_roundtrips() {
+        let store = make_store();
+
+        let reasons = [
+            ("f-ur", ForgetReason::UserRequested),
+            ("f-od", ForgetReason::Outdated),
+            ("f-ic", ForgetReason::Incorrect),
+            ("f-pr", ForgetReason::Privacy),
+        ];
+
+        for (id, reason) in reasons {
+            let fact = make_fact(id, "agent-a", &format!("fact for {reason}"));
+            store.insert_fact(&fact).expect("insert");
+
+            let forgotten = store
+                .forget_fact(&crate::id::FactId::new_unchecked(id), reason)
+                .expect("forget");
+            assert_eq!(
+                forgotten.forget_reason,
+                Some(reason),
+                "reason must round-trip for {reason}"
+            );
+        }
+
+        // Verify all appear in list_forgotten
+        let forgotten_list = store
+            .list_forgotten("agent-a", 100)
+            .expect("list_forgotten");
+        assert_eq!(forgotten_list.len(), reasons.len());
+        for (id, reason) in reasons {
+            let found = forgotten_list
+                .iter()
+                .find(|f| f.id.as_str() == id)
+                .unwrap_or_else(|| panic!("missing {id} in list_forgotten"));
+            assert_eq!(found.forget_reason, Some(reason));
+        }
+    }
+
+    #[test]
+    fn forget_nonexistent_fact_errors() {
+        let store = make_store();
+        let result = store.forget_fact(
+            &crate::id::FactId::new_unchecked("nonexistent"),
+            ForgetReason::UserRequested,
+        );
+        assert!(result.is_err(), "forgetting non-existent fact must error");
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("not found"),
+            "error should mention not found: {err}"
+        );
+    }
+
+    #[test]
+    fn forget_excluded_from_temporal_diff() {
+        let store = make_store();
+        let fact = make_fact("f-diff", "agent-a", "Temporal diff fact");
+        store.insert_fact(&fact).expect("insert");
+
+        store
+            .forget_fact(
+                &crate::id::FactId::new_unchecked("f-diff"),
+                ForgetReason::Incorrect,
+            )
+            .expect("forget");
+
+        let diff = store
+            .query_facts_diff("agent-a", "2025-01-01", "2027-01-01")
+            .expect("diff");
+        assert!(
+            !diff.added.iter().any(|f| f.id.as_str() == "f-diff"),
+            "forgotten fact must not appear in temporal diff added"
+        );
     }
 
     // ---- Increment Access ----
@@ -4882,15 +5094,13 @@ mod knowledge_store_tests {
     }
 
     #[test]
-    fn forget_nonexistent_fact_succeeds() {
-        // forget_fact on a missing ID should not panic (Datalog :put on empty match is a noop)
+    fn forget_nonexistent_fact_returns_error() {
         let store = make_store();
         let result = store.forget_fact(
             &crate::id::FactId::new_unchecked("nonexistent"),
             ForgetReason::UserRequested,
         );
-        // The behavior is either Ok (noop) or Err — neither should panic
-        let _ = result;
+        assert!(result.is_err(), "forgetting a non-existent fact must error");
     }
 
     #[test]
@@ -5084,13 +5294,15 @@ mod knowledge_store_tests {
         let fact = make_fact("f-forget-async", "agent-a", "Async forget");
         store.insert_fact_async(fact).await.expect("insert");
 
-        store
+        let forgotten = store
             .forget_fact_async(
                 crate::id::FactId::new_unchecked("f-forget-async"),
                 ForgetReason::Incorrect,
             )
             .await
             .expect("async forget");
+        assert!(forgotten.is_forgotten);
+        assert_eq!(forgotten.forget_reason, Some(ForgetReason::Incorrect));
 
         let all = store
             .audit_all_facts_async("agent-a".to_owned(), 100)
@@ -5624,12 +5836,13 @@ mod knowledge_store_tests {
     }
 
     #[test]
-    fn forget_nonexistent_fact() {
+    fn forget_nonexistent_fact_is_err() {
         let store = make_store();
-        let _ = store.forget_fact(
+        let result = store.forget_fact(
             &crate::id::FactId::new_unchecked("nonexistent"),
             ForgetReason::UserRequested,
         );
+        assert!(result.is_err());
     }
 
     #[test]

--- a/crates/mneme/src/lib.rs
+++ b/crates/mneme/src/lib.rs
@@ -22,10 +22,10 @@ pub mod engine;
 /// Database backup and JSON export for session data.
 #[cfg(feature = "sqlite")]
 pub mod backup;
-/// LLM-driven fact consolidation for knowledge maintenance.
-pub mod consolidation;
 /// Conflict detection pipeline for fact insertion.
 pub mod conflict;
+/// LLM-driven fact consolidation for knowledge maintenance.
+pub mod consolidation;
 /// Entity deduplication pipeline for merging semantically identical entities.
 pub mod dedup;
 /// Embedding provider trait and implementations (candle, mock).

--- a/crates/mneme/src/query.rs
+++ b/crates/mneme/src/query.rs
@@ -781,6 +781,7 @@ pub mod queries {
                    access_count, last_accessed_at, stability_hours, fact_type,
                    is_forgotten, forgotten_at, forget_reason},
             nous_id = $nous_id,
+            is_forgotten == false,
             valid_from > $from_time,
             valid_from <= $to_time
     ";
@@ -797,10 +798,60 @@ pub mod queries {
                    access_count, last_accessed_at, stability_hours, fact_type,
                    is_forgotten, forgotten_at, forget_reason},
             nous_id = $nous_id,
+            is_forgotten == false,
             valid_to > $from_time,
             valid_to <= $to_time,
             valid_to != '9999-12-31'
     ";
+
+    /// Query returning only forgotten facts. Params: `$nous_id`, `$limit`.
+    pub fn forgotten_facts() -> String {
+        use FactsField::*;
+        QueryBuilder::new()
+            .scan(Relation::Facts)
+            .select(&[
+                Id,
+                Content,
+                Confidence,
+                Tier,
+                RecordedAt,
+                NousId,
+                ValidFrom,
+                ValidTo,
+                SupersededBy,
+                SourceSessionId,
+                AccessCount,
+                LastAccessedAt,
+                StabilityHours,
+                FactType,
+                IsForgotten,
+                ForgottenAt,
+                ForgetReason,
+            ])
+            .bind(Id)
+            .bind(ValidFrom)
+            .bind(Content)
+            .bind(NousId)
+            .bind(Confidence)
+            .bind(Tier)
+            .bind(ValidTo)
+            .bind(SupersededBy)
+            .bind(SourceSessionId)
+            .bind(RecordedAt)
+            .bind(AccessCount)
+            .bind(LastAccessedAt)
+            .bind(StabilityHours)
+            .bind(FactType)
+            .bind(IsForgotten)
+            .bind(ForgottenAt)
+            .bind(ForgetReason)
+            .filter("nous_id = $nous_id")
+            .filter("is_forgotten == true")
+            .order("-forgotten_at")
+            .limit("$limit")
+            .done()
+            .build_script()
+    }
 
     /// Audit query returning all facts regardless of forgotten/superseded/temporal state.
     /// Params: `$nous_id`, `$limit`.

--- a/crates/organon/src/builtins/memory.rs
+++ b/crates/organon/src/builtins/memory.rs
@@ -155,8 +155,9 @@ impl ToolExecutor for MemoryForgetExecutor {
             let reason = extract_str(&input.arguments, "reason", &input.name)?;
 
             match knowledge.forget_fact(fact_id, reason).await {
-                Ok(()) => Ok(ToolResult::text(format!(
-                    "Fact {fact_id} forgotten (reason: {reason})."
+                Ok(summary) => Ok(ToolResult::text(format!(
+                    "Fact {} forgotten (reason: {reason}). Content: {}",
+                    summary.id, summary.content
                 ))),
                 Err(e) => Ok(ToolResult::error(format!("Failed to forget fact: {e}"))),
             }

--- a/crates/organon/src/types.rs
+++ b/crates/organon/src/types.rs
@@ -401,12 +401,12 @@ pub trait KnowledgeSearchService: Send + Sync {
         &self,
         fact_id: &str,
         reason: &str,
-    ) -> Pin<Box<dyn Future<Output = Result<(), String>> + Send + '_>>;
+    ) -> Pin<Box<dyn Future<Output = Result<FactSummary, String>> + Send + '_>>;
 
     fn unforget_fact(
         &self,
         fact_id: &str,
-    ) -> Pin<Box<dyn Future<Output = Result<(), String>> + Send + '_>>;
+    ) -> Pin<Box<dyn Future<Output = Result<FactSummary, String>> + Send + '_>>;
 
     fn datalog_query(
         &self,


### PR DESCRIPTION
## Summary

- **Explicit forgetting** as a first-class operation: `forget_fact` soft-deletes facts with a `ForgetReason` enum (`UserRequested`, `Outdated`, `Incorrect`, `Privacy`), setting `is_forgotten`, `forgotten_at`, and `forget_reason` fields
- **Recall exclusion**: ALL recall queries now filter `is_forgotten == true` — including `TEMPORAL_DIFF_ADDED`, `TEMPORAL_DIFF_REMOVED`, and hybrid search results (via post-filter)
- **Audit visibility**: `list_forgotten` method returns only forgotten facts with their reasons; `audit_all_facts` continues to include everything
- **Error handling**: `forget_fact` and `unforget_fact` now return the affected `Fact` and error with `FactNotFound` on non-existent fact IDs
- **Tool executor**: `memory_forget` tool returns forgotten fact content in its response

## Test plan

- [x] `forget_fact_excludes_from_query` — forgotten fact not returned by `query_facts`
- [x] `forget_fact_then_unforget_restores_recall` — full forget→unforget→recall cycle
- [x] `forget_preserves_in_audit` — forgotten facts visible in audit queries
- [x] `forget_reason_roundtrips` — all 4 reason variants round-trip through store
- [x] `forget_nonexistent_fact_errors` — proper error on missing fact ID
- [x] `forget_excluded_from_temporal_diff` — forgotten facts excluded from diff queries
- [x] Async variants tested (`forget_fact_async_works`, `unforget_fact_async_works`)
- [x] `cargo fmt -- --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)