### PR TITLE
feat(nous): actor crash recovery with liveness detection and auto-restart

### DIFF
--- a/crates/nous/src/actor.rs
+++ b/crates/nous/src/actor.rs
@@ -2,8 +2,10 @@
 
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::time::Instant;
 
 use tokio::sync::Mutex;
+use tokio::task::JoinSet;
 
 #[cfg(feature = "knowledge-store")]
 use aletheia_mneme::knowledge_store::KnowledgeStore;
@@ -33,6 +35,15 @@ use crate::session::SessionState;
 
 /// Default bounded channel capacity for the actor inbox.
 pub const DEFAULT_INBOX_CAPACITY: usize = 32;
+
+/// Maximum number of concurrent background tasks (extraction, distillation, skills).
+pub(crate) const MAX_SPAWNED_TASKS: usize = 8;
+
+/// Number of panics within `DEGRADED_WINDOW` that triggers degraded mode.
+const DEGRADED_PANIC_THRESHOLD: u32 = 5;
+
+/// Time window for panic counting (10 minutes).
+const DEGRADED_WINDOW: std::time::Duration = std::time::Duration::from_secs(600);
 
 /// A single nous agent running as a Tokio actor.
 ///
@@ -64,6 +75,14 @@ pub struct NousActor {
     skill_loader: Option<crate::skills::SkillLoader>,
     /// Candidate tracker for skill auto-capture pipeline.
     candidate_tracker: Arc<aletheia_mneme::skills::CandidateTracker>,
+    /// Number of panics caught by the panic boundary since start.
+    panic_count: u32,
+    /// Timestamps of recent panics for degraded-mode window calculation.
+    panic_timestamps: Vec<Instant>,
+    /// When the actor started running.
+    started_at: Instant,
+    /// Background tasks (extraction, distillation, skill analysis).
+    background_tasks: JoinSet<()>,
 }
 
 impl NousActor {
@@ -119,6 +138,10 @@ impl NousActor {
             #[cfg(feature = "knowledge-store")]
             skill_loader,
             candidate_tracker: Arc::new(aletheia_mneme::skills::CandidateTracker::new()),
+            panic_count: 0,
+            panic_timestamps: Vec::new(),
+            started_at: Instant::now(),
+            background_tasks: JoinSet::new(),
         }
     }
 
@@ -137,9 +160,13 @@ impl NousActor {
             return;
         }
 
+        self.started_at = Instant::now();
         info!(lifecycle = %self.lifecycle, "actor started");
 
         loop {
+            // Reap completed background tasks
+            self.reap_background_tasks();
+
             tokio::select! {
                 msg = self.inbox.recv() => {
                     let Some(msg) = msg else { break };
@@ -149,7 +176,14 @@ impl NousActor {
                             content,
                             reply,
                         } => {
-                            self.handle_turn(session_key, content, reply).await;
+                            if self.lifecycle == NousLifecycle::Degraded {
+                                let _ = reply.send(Err(crate::error::ServiceDegradedSnafu {
+                                    nous_id: self.id.clone(),
+                                    panic_count: self.panic_count,
+                                }.build()));
+                            } else {
+                                self.handle_turn(session_key, content, reply).await;
+                            }
                         }
                         NousMessage::StreamingTurn {
                             session_key,
@@ -157,10 +191,21 @@ impl NousActor {
                             stream_tx,
                             reply,
                         } => {
-                            self.handle_streaming_turn(session_key, content, stream_tx, reply).await;
+                            if self.lifecycle == NousLifecycle::Degraded {
+                                let _ = reply.send(Err(crate::error::ServiceDegradedSnafu {
+                                    nous_id: self.id.clone(),
+                                    panic_count: self.panic_count,
+                                }.build()));
+                                drop(stream_tx);
+                            } else {
+                                self.handle_streaming_turn(session_key, content, stream_tx, reply).await;
+                            }
                         }
                         NousMessage::Status { reply } => {
                             self.handle_status(reply);
+                        }
+                        NousMessage::Ping { reply } => {
+                            let _ = reply.send(());
                         }
                         NousMessage::Sleep => {
                             self.handle_sleep();
@@ -191,7 +236,10 @@ impl NousActor {
             }
         }
 
-        info!(lifecycle = %self.lifecycle, "actor stopped");
+        // Drain remaining background tasks before exiting
+        while self.background_tasks.join_next().await.is_some() {}
+
+        info!(lifecycle = %self.lifecycle, panic_count = self.panic_count, "actor stopped");
     }
 
     /// # Cancel safety
@@ -237,7 +285,9 @@ impl NousActor {
         self.lifecycle = NousLifecycle::Active;
         self.active_session = Some(session_key.clone());
 
-        let result = self.execute_turn(&session_key, &content).await;
+        let result = self
+            .execute_turn_with_panic_boundary(&session_key, &content)
+            .await;
 
         if let Ok(ref turn_result) = result {
             self.maybe_spawn_extraction(&content, &turn_result.content);
@@ -246,7 +296,10 @@ impl NousActor {
         }
 
         self.active_session = None;
-        self.lifecycle = NousLifecycle::Idle;
+        // Preserve degraded state — only reset to Idle if not degraded
+        if self.lifecycle != NousLifecycle::Degraded {
+            self.lifecycle = NousLifecycle::Idle;
+        }
 
         // Ignore send error — caller may have dropped the receiver
         let _ = reply.send(result);
@@ -273,7 +326,7 @@ impl NousActor {
         self.active_session = Some(session_key.clone());
 
         let result = self
-            .execute_streaming_turn(&session_key, &content, &stream_tx)
+            .execute_streaming_turn_with_panic_boundary(&session_key, &content, &stream_tx)
             .await;
 
         if let Ok(ref turn_result) = result {
@@ -283,9 +336,219 @@ impl NousActor {
         }
 
         self.active_session = None;
-        self.lifecycle = NousLifecycle::Idle;
+        if self.lifecycle != NousLifecycle::Degraded {
+            self.lifecycle = NousLifecycle::Idle;
+        }
 
         let _ = reply.send(result);
+    }
+
+    /// Execute a turn with a panic boundary. If the pipeline panics, the panic
+    /// is caught, logged, and an error is returned to the caller. The actor
+    /// continues processing subsequent messages.
+    async fn execute_turn_with_panic_boundary(
+        &mut self,
+        session_key: &str,
+        content: &str,
+    ) -> crate::error::Result<TurnResult> {
+        // Spawn the pipeline in a separate task so panics are caught by the
+        // JoinHandle rather than propagating into the actor loop.
+        let result = self.spawn_pipeline_task(session_key, content, None).await;
+        self.handle_pipeline_result(result, session_key)
+    }
+
+    /// Execute a streaming turn with a panic boundary.
+    async fn execute_streaming_turn_with_panic_boundary(
+        &mut self,
+        session_key: &str,
+        content: &str,
+        stream_tx: &mpsc::Sender<TurnStreamEvent>,
+    ) -> crate::error::Result<TurnResult> {
+        let result = self
+            .spawn_pipeline_task(session_key, content, Some(stream_tx.clone()))
+            .await;
+        self.handle_pipeline_result(result, session_key)
+    }
+
+    /// Spawn the pipeline as a separate tokio task to catch panics.
+    async fn spawn_pipeline_task(
+        &mut self,
+        session_key: &str,
+        content: &str,
+        stream_tx: Option<mpsc::Sender<TurnStreamEvent>>,
+    ) -> Result<crate::error::Result<TurnResult>, tokio::task::JoinError> {
+        // Prepare all data needed by the pipeline before spawning
+        let session = self
+            .sessions
+            .entry(session_key.to_owned())
+            .or_insert_with(|| {
+                let id = SessionId::new().to_string();
+                debug!(session_key, session_id = %id, "creating new session");
+                SessionState::new(id, session_key.to_owned(), &self.config)
+            });
+
+        session.next_turn();
+
+        let input = crate::pipeline::PipelineInput {
+            content: content.to_owned(),
+            session: session.clone(),
+            config: self.pipeline_config.clone(),
+        };
+
+        let nous_id = NousId::new(&self.id).map_err(|e| {
+            crate::error::ConfigSnafu {
+                message: format!("invalid nous id: {e}"),
+            }
+            .build()
+        });
+
+        let nous_id = match nous_id {
+            Ok(id) => id,
+            Err(e) => return Ok(Err(e)),
+        };
+
+        let tool_ctx = ToolContext {
+            nous_id,
+            session_id: SessionId::parse(session.id.as_str()).unwrap_or_else(|_| SessionId::new()),
+            workspace: self.oikos.nous_dir(&self.id),
+            allowed_roots: vec![self.oikos.root().to_path_buf()],
+            services: self.tool_services.clone(),
+            active_tools: std::sync::Arc::new(std::sync::RwLock::new(
+                std::collections::HashSet::new(),
+            )),
+        };
+
+        let mut extra_bootstrap = self.extra_bootstrap.clone();
+        extra_bootstrap.extend(self.resolve_skill_sections(content).await);
+
+        let oikos = Arc::clone(&self.oikos);
+        let config = self.config.clone();
+        let pipeline_config = self.pipeline_config.clone();
+        let providers = Arc::clone(&self.providers);
+        let tools = Arc::clone(&self.tools);
+        let embedding_provider = self.embedding_provider.clone();
+        let vector_search = self.vector_search.clone();
+        let session_store = self.session_store.clone();
+        let span = tracing::Span::current();
+
+        tokio::spawn(
+            async move {
+                match stream_tx {
+                    Some(ref stx) => {
+                        crate::pipeline::run_pipeline(
+                            input,
+                            &oikos,
+                            &config,
+                            &pipeline_config,
+                            &providers,
+                            &tools,
+                            &tool_ctx,
+                            embedding_provider.as_deref(),
+                            vector_search.as_deref(),
+                            session_store.as_deref(),
+                            extra_bootstrap,
+                            Some(stx),
+                        )
+                        .await
+                    }
+                    None => {
+                        crate::pipeline::run_pipeline(
+                            input,
+                            &oikos,
+                            &config,
+                            &pipeline_config,
+                            &providers,
+                            &tools,
+                            &tool_ctx,
+                            embedding_provider.as_deref(),
+                            vector_search.as_deref(),
+                            session_store.as_deref(),
+                            extra_bootstrap,
+                            None,
+                        )
+                        .await
+                    }
+                }
+            }
+            .instrument(span),
+        )
+        .await
+    }
+
+    /// Convert a spawned pipeline result (which may be a panic) into an `error::Result`.
+    /// Records panic if one occurred and potentially enters degraded mode.
+    fn handle_pipeline_result(
+        &mut self,
+        result: Result<crate::error::Result<TurnResult>, tokio::task::JoinError>,
+        session_key: &str,
+    ) -> crate::error::Result<TurnResult> {
+        match result {
+            Ok(inner) => inner,
+            Err(join_error) => {
+                self.record_panic();
+
+                let panic_msg = if join_error.is_panic() {
+                    let panic_payload = join_error.into_panic();
+                    if let Some(s) = panic_payload.downcast_ref::<&str>() {
+                        (*s).to_owned()
+                    } else if let Some(s) = panic_payload.downcast_ref::<String>() {
+                        s.clone()
+                    } else {
+                        "unknown panic".to_owned()
+                    }
+                } else {
+                    format!("task cancelled: {join_error}")
+                };
+
+                error!(
+                    nous_id = %self.id,
+                    session_key = %session_key,
+                    panic_count = self.panic_count,
+                    message = %panic_msg,
+                    "pipeline panicked — actor continues"
+                );
+
+                Err(crate::error::PipelinePanicSnafu {
+                    nous_id: self.id.clone(),
+                    message: panic_msg,
+                }
+                .build())
+            }
+        }
+    }
+
+    /// Record a panic occurrence. Enters degraded mode if too many panics in the window.
+    fn record_panic(&mut self) {
+        self.panic_count += 1;
+        self.panic_timestamps.push(Instant::now());
+
+        // Prune timestamps outside the window
+        let cutoff = Instant::now()
+            .checked_sub(DEGRADED_WINDOW)
+            .unwrap_or(self.started_at);
+        self.panic_timestamps.retain(|t| *t > cutoff);
+
+        if self.panic_timestamps.len() >= DEGRADED_PANIC_THRESHOLD as usize {
+            warn!(
+                nous_id = %self.id,
+                panic_count = self.panic_count,
+                recent_panics = self.panic_timestamps.len(),
+                "entering degraded mode — too many panics in window"
+            );
+            self.lifecycle = NousLifecycle::Degraded;
+        }
+    }
+
+    /// Reap completed background tasks and log any failures.
+    fn reap_background_tasks(&mut self) {
+        while let Some(result) = self.background_tasks.try_join_next() {
+            match result {
+                Ok(()) => {}
+                Err(e) => {
+                    warn!(nous_id = %self.id, error = %e, "background task failed");
+                }
+            }
+        }
     }
 
     /// # Cancel safety
@@ -354,82 +617,19 @@ impl NousActor {
         .await
     }
 
-    /// # Cancel safety
-    ///
-    /// Cancel-safe — same profile as `execute_turn`.
-    async fn execute_streaming_turn(
-        &mut self,
-        session_key: &str,
-        content: &str,
-        stream_tx: &mpsc::Sender<TurnStreamEvent>,
-    ) -> crate::error::Result<TurnResult> {
-        let session = self
-            .sessions
-            .entry(session_key.to_owned())
-            .or_insert_with(|| {
-                let id = SessionId::new().to_string();
-                debug!(session_key, session_id = %id, "creating new session");
-                SessionState::new(id, session_key.to_owned(), &self.config)
-            });
-
-        session.next_turn();
-
-        let input = crate::pipeline::PipelineInput {
-            content: content.to_owned(),
-            session: session.clone(),
-            config: self.pipeline_config.clone(),
-        };
-
-        let nous_id = NousId::new(&self.id).map_err(|e| {
-            crate::error::ConfigSnafu {
-                message: format!("invalid nous id: {e}"),
-            }
-            .build()
-        })?;
-
-        let tool_ctx = ToolContext {
-            nous_id,
-            session_id: SessionId::parse(session.id.as_str()).unwrap_or_else(|_| SessionId::new()),
-            workspace: self.oikos.nous_dir(&self.id),
-            allowed_roots: vec![self.oikos.root().to_path_buf()],
-            services: self.tool_services.clone(),
-            active_tools: std::sync::Arc::new(std::sync::RwLock::new(
-                std::collections::HashSet::new(),
-            )),
-        };
-
-        // Merge static domain-pack sections with dynamic skill sections.
-        let mut extra_bootstrap = self.extra_bootstrap.clone();
-        extra_bootstrap.extend(self.resolve_skill_sections(content).await);
-
-        crate::pipeline::run_pipeline(
-            input,
-            &self.oikos,
-            &self.config,
-            &self.pipeline_config,
-            &self.providers,
-            &self.tools,
-            &tool_ctx,
-            self.embedding_provider.as_deref(),
-            self.vector_search.as_deref(),
-            self.session_store.as_deref(),
-            extra_bootstrap,
-            Some(stream_tx),
-        )
-        .await
-    }
-
     fn handle_status(&self, reply: tokio::sync::oneshot::Sender<NousStatus>) {
         let status = NousStatus {
             id: self.id.clone(),
             lifecycle: self.lifecycle,
             session_count: self.sessions.len(),
             active_session: self.active_session.clone(),
+            panic_count: self.panic_count,
+            uptime: self.started_at.elapsed(),
         };
         let _ = reply.send(status);
     }
 
-    fn maybe_spawn_extraction(&self, user_content: &str, assistant_content: &str) {
+    fn maybe_spawn_extraction(&mut self, user_content: &str, assistant_content: &str) {
         let Some(ref extraction_config) = self.pipeline_config.extraction else {
             return;
         };
@@ -451,7 +651,12 @@ impl NousActor {
         #[cfg(feature = "knowledge-store")]
         let knowledge_store = self.knowledge_store.clone();
 
-        tokio::spawn(
+        if self.background_tasks.len() >= MAX_SPAWNED_TASKS {
+            warn!(nous_id = %self.id, limit = MAX_SPAWNED_TASKS, "background task limit reached, skipping extraction");
+            return;
+        }
+
+        self.background_tasks.spawn(
             async move {
                 run_extraction(
                     &config,
@@ -474,7 +679,7 @@ impl NousActor {
     /// runs them through the heuristic filter and candidate tracker, and
     /// spawns LLM extraction if a candidate is promoted (Rule of Three).
     fn maybe_spawn_skill_analysis(
-        &self,
+        &mut self,
         tool_calls: &[crate::pipeline::ToolCall],
         session_key: &str,
     ) {
@@ -520,7 +725,7 @@ impl NousActor {
 
     /// Spawn background LLM extraction for a promoted skill candidate.
     fn spawn_skill_extraction(
-        &self,
+        &mut self,
         candidate_id: &str,
         tool_calls: &[aletheia_mneme::skills::ToolCallRecord],
     ) {
@@ -539,7 +744,12 @@ impl NousActor {
         let knowledge_store = self.knowledge_store.clone();
         let span = tracing::info_span!("skill_extraction", nous.id = %nous_id, candidate.id = %candidate_id);
 
-        tokio::spawn(
+        if self.background_tasks.len() >= MAX_SPAWNED_TASKS {
+            warn!(nous_id = %self.id, limit = MAX_SPAWNED_TASKS, "background task limit reached, skipping skill extraction");
+            return;
+        }
+
+        self.background_tasks.spawn(
             async move {
                 run_skill_extraction(
                     &model,
@@ -557,7 +767,7 @@ impl NousActor {
         );
     }
 
-    async fn maybe_spawn_distillation(&self, session_key: &str) {
+    async fn maybe_spawn_distillation(&mut self, session_key: &str) {
         let Some(ref store_arc) = self.session_store else {
             return;
         };
@@ -597,7 +807,12 @@ impl NousActor {
         let span =
             tracing::info_span!("distillation", nous.id = %nous_id, session.id = %session_id);
 
-        tokio::spawn(
+        if self.background_tasks.len() >= MAX_SPAWNED_TASKS {
+            warn!(nous_id = %self.id, limit = MAX_SPAWNED_TASKS, "background task limit reached, skipping distillation");
+            return;
+        }
+
+        self.background_tasks.spawn(
             run_background_distillation(store, providers, session_id, nous_id, config)
                 .instrument(span),
         );
@@ -653,6 +868,9 @@ impl NousActor {
             NousLifecycle::Dormant => {
                 debug!("already dormant");
             }
+            NousLifecycle::Degraded => {
+                debug!("cannot sleep while degraded");
+            }
         }
     }
 
@@ -664,6 +882,9 @@ impl NousActor {
             }
             NousLifecycle::Idle | NousLifecycle::Active => {
                 debug!(lifecycle = %self.lifecycle, "already awake");
+            }
+            NousLifecycle::Degraded => {
+                debug!("cannot wake from degraded — requires restart");
             }
         }
     }
@@ -1381,5 +1602,220 @@ mod tests {
             msg.contains("SOUL.md"),
             "error should mention SOUL.md: {msg}"
         );
+    }
+
+    // --- Resilience tests ---
+
+    /// Mock provider that panics on every call.
+    struct PanickingProvider;
+
+    impl LlmProvider for PanickingProvider {
+        fn complete<'a>(
+            &'a self,
+            _request: &'a CompletionRequest,
+        ) -> std::pin::Pin<
+            Box<
+                dyn std::future::Future<
+                        Output = aletheia_hermeneus::error::Result<CompletionResponse>,
+                    > + Send
+                    + 'a,
+            >,
+        > {
+            Box::pin(async { panic!("deliberate test panic in pipeline") })
+        }
+
+        fn supported_models(&self) -> &[&str] {
+            &["test-model"]
+        }
+
+        #[expect(clippy::unnecessary_literal_bound, reason = "trait requires &str")]
+        fn name(&self) -> &str {
+            "panicking-mock"
+        }
+
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
+        }
+    }
+
+    fn panicking_providers() -> Arc<ProviderRegistry> {
+        let mut providers = ProviderRegistry::new();
+        providers.register(Box::new(PanickingProvider));
+        Arc::new(providers)
+    }
+
+    fn spawn_panicking_actor() -> (NousHandle, tokio::task::JoinHandle<()>, tempfile::TempDir) {
+        let (dir, oikos) = test_oikos();
+        let providers = panicking_providers();
+        let tools = Arc::new(ToolRegistry::new());
+        let config = test_config();
+        let pipeline_config = PipelineConfig::default();
+
+        let (handle, join) = spawn(
+            config,
+            pipeline_config,
+            providers,
+            tools,
+            oikos,
+            None,
+            None,
+            None,
+            #[cfg(feature = "knowledge-store")]
+            None,
+            None,
+            Vec::new(),
+            None,
+            CancellationToken::new(),
+        );
+        (handle, join, dir)
+    }
+
+    #[tokio::test]
+    async fn actor_survives_pipeline_panic() {
+        let (handle, join, _dir) = spawn_panicking_actor();
+
+        // First turn panics — should return an error, not kill the actor
+        let result = handle.send_turn("main", "Hello").await;
+        assert!(result.is_err(), "panicking turn should return error");
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("panic") || msg.contains("pipeline"),
+            "error should mention panic: {msg}"
+        );
+
+        // Actor is still alive — can respond to status
+        let status = handle.status().await.expect("actor should still be alive");
+        assert_eq!(status.panic_count, 1);
+        assert_eq!(status.lifecycle, NousLifecycle::Idle);
+
+        // Second panicking turn also returns error, actor still alive
+        let result2 = handle.send_turn("main", "Hello again").await;
+        assert!(result2.is_err());
+
+        let status2 = handle
+            .status()
+            .await
+            .expect("actor still alive after 2 panics");
+        assert_eq!(status2.panic_count, 2);
+
+        handle.shutdown().await.expect("shutdown");
+        join.await.expect("join");
+    }
+
+    #[tokio::test]
+    async fn ping_pong_liveness() {
+        let (handle, join, _dir) = spawn_test_actor();
+
+        let result = handle.ping(std::time::Duration::from_secs(5)).await;
+        assert!(result.is_ok(), "ping should succeed on healthy actor");
+
+        handle.shutdown().await.expect("shutdown");
+        join.await.expect("join");
+    }
+
+    #[tokio::test]
+    async fn ping_fails_on_dead_actor() {
+        let (handle, join, _dir) = spawn_test_actor();
+
+        // Shut down the actor first
+        handle.shutdown().await.expect("shutdown");
+        join.await.expect("join");
+
+        // Ping should fail
+        let result = handle.ping(std::time::Duration::from_millis(100)).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn send_timeout_fires_when_inbox_full() {
+        // Create a channel with capacity 1
+        let (tx, _rx) = mpsc::channel(1);
+        let handle = NousHandle::new("test-agent".to_owned(), tx.clone());
+
+        // Fill the inbox — don't drop _rx so the channel stays open
+        // Send one message to fill the single slot
+        let (reply_tx, _reply_rx) = tokio::sync::oneshot::channel();
+        tx.send(NousMessage::Turn {
+            session_key: "main".to_owned(),
+            content: "filler".to_owned(),
+            reply: reply_tx,
+        })
+        .await
+        .expect("fill inbox");
+
+        // Now the inbox is full — send_turn_with_timeout should fail
+        let result = handle
+            .send_turn_with_timeout("main", "Hello", std::time::Duration::from_millis(50))
+            .await;
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("inbox full"),
+            "should report inbox full: {msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn degraded_state_after_repeated_panics() {
+        let (handle, join, _dir) = spawn_panicking_actor();
+
+        // Trigger enough panics to enter degraded mode (5 in window)
+        for i in 0..5 {
+            let result = handle.send_turn("main", &format!("panic {i}")).await;
+            assert!(result.is_err());
+        }
+
+        let status = handle.status().await.expect("status");
+        assert_eq!(
+            status.lifecycle,
+            NousLifecycle::Degraded,
+            "should be degraded after 5 panics"
+        );
+        assert_eq!(status.panic_count, 5);
+
+        // Subsequent turn should get ServiceDegraded error
+        let result = handle.send_turn("main", "more work").await;
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("degraded"), "should report degraded: {msg}");
+
+        handle.shutdown().await.expect("shutdown");
+        join.await.expect("join");
+    }
+
+    #[tokio::test]
+    async fn background_task_reaping() {
+        let (handle, join, _dir) = spawn_test_actor();
+
+        // Run a turn — this may spawn background tasks (extraction etc.)
+        // Even if no tasks spawn, the reaping code runs each loop iteration.
+        let result = handle.send_turn("main", "Hello").await.expect("turn");
+        assert_eq!(result.content, "Hello from actor!");
+
+        // The actor is still responsive — reaping didn't break anything.
+        let status = handle.status().await.expect("status");
+        assert_eq!(status.lifecycle, NousLifecycle::Idle);
+
+        handle.shutdown().await.expect("shutdown");
+        join.await.expect("join");
+    }
+
+    #[tokio::test]
+    async fn status_includes_uptime() {
+        let (handle, join, _dir) = spawn_test_actor();
+
+        // Give the actor a moment to start
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        let status = handle.status().await.expect("status");
+        // Uptime should be non-zero — the actor has been alive for at least a few ms
+        assert!(
+            !status.uptime.is_zero(),
+            "uptime should be non-zero, got {:?}",
+            status.uptime
+        );
+
+        handle.shutdown().await.expect("shutdown");
+        join.await.expect("join");
     }
 }

--- a/crates/nous/src/error.rs
+++ b/crates/nous/src/error.rs
@@ -163,6 +163,33 @@ pub enum Error {
         #[snafu(implicit)]
         location: snafu::Location,
     },
+
+    /// Actor inbox is full and the send timed out.
+    #[snafu(display("actor '{nous_id}' inbox full after {timeout_secs}s"))]
+    InboxFull {
+        nous_id: String,
+        timeout_secs: u64,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    /// Actor is in degraded state after repeated panics.
+    #[snafu(display("actor '{nous_id}' is degraded after {panic_count} panics"))]
+    ServiceDegraded {
+        nous_id: String,
+        panic_count: u32,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    /// Pipeline stage panicked (caught by the panic boundary).
+    #[snafu(display("pipeline panic in actor '{nous_id}': {message}"))]
+    PipelinePanic {
+        nous_id: String,
+        message: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
 }
 
 /// Convenience alias for results with [`Error`].
@@ -317,6 +344,42 @@ mod tests {
         let msg = err.to_string();
         assert!(msg.contains("execute"));
         assert!(msg.contains("300s"));
+    }
+
+    #[test]
+    fn error_display_inbox_full() {
+        let err = InboxFullSnafu {
+            nous_id: "syn",
+            timeout_secs: 30u64,
+        }
+        .build();
+        let msg = err.to_string();
+        assert!(msg.contains("syn"));
+        assert!(msg.contains("inbox full"));
+    }
+
+    #[test]
+    fn error_display_service_degraded() {
+        let err = ServiceDegradedSnafu {
+            nous_id: "syn",
+            panic_count: 5u32,
+        }
+        .build();
+        let msg = err.to_string();
+        assert!(msg.contains("degraded"));
+        assert!(msg.contains("5 panics"));
+    }
+
+    #[test]
+    fn error_display_pipeline_panic() {
+        let err = PipelinePanicSnafu {
+            nous_id: "syn",
+            message: "null pointer",
+        }
+        .build();
+        let msg = err.to_string();
+        assert!(msg.contains("panic"));
+        assert!(msg.contains("null pointer"));
     }
 
     #[test]

--- a/crates/nous/src/handle.rs
+++ b/crates/nous/src/handle.rs
@@ -1,11 +1,16 @@
 //! Cloneable actor handle for sending messages to a [`NousActor`](crate::actor::NousActor).
 
+use std::time::Duration;
+
 use tokio::sync::{mpsc, oneshot};
 
-use crate::error::{self, ActorRecvSnafu, ActorSendSnafu};
+use crate::error::{self, ActorRecvSnafu, ActorSendSnafu, InboxFullSnafu};
 use crate::message::{NousMessage, NousStatus};
 use crate::pipeline::TurnResult;
 use crate::stream::TurnStreamEvent;
+
+/// Default timeout for sending messages to an actor's inbox.
+pub const DEFAULT_SEND_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Cloneable handle for communicating with a nous actor.
 ///
@@ -31,6 +36,9 @@ impl NousHandle {
 
     /// Send a turn message and await the result.
     ///
+    /// Uses [`DEFAULT_SEND_TIMEOUT`] for the inbox send. If the inbox is full
+    /// for longer than the timeout, returns [`InboxFull`](error::Error::InboxFull).
+    ///
     /// # Cancel safety
     ///
     /// Not cancel-safe. If cancelled after `mpsc::send` completes but before
@@ -41,20 +49,24 @@ impl NousHandle {
         session_key: impl Into<String>,
         content: impl Into<String>,
     ) -> error::Result<TurnResult> {
-        let (tx, rx) = oneshot::channel();
-        self.sender
-            .send(NousMessage::Turn {
-                session_key: session_key.into(),
-                content: content.into(),
-                reply: tx,
-            })
+        self.send_turn_with_timeout(session_key, content, DEFAULT_SEND_TIMEOUT)
             .await
-            .map_err(|_send_err| {
-                ActorSendSnafu {
-                    message: format!("actor '{}' inbox closed", self.id),
-                }
-                .build()
-            })?;
+    }
+
+    /// Send a turn message with a configurable inbox timeout.
+    pub async fn send_turn_with_timeout(
+        &self,
+        session_key: impl Into<String>,
+        content: impl Into<String>,
+        timeout: Duration,
+    ) -> error::Result<TurnResult> {
+        let (tx, rx) = oneshot::channel();
+        let msg = NousMessage::Turn {
+            session_key: session_key.into(),
+            content: content.into(),
+            reply: tx,
+        };
+        self.send_with_timeout(msg, timeout).await?;
         rx.await.map_err(|_send_err| {
             ActorRecvSnafu {
                 message: format!("actor '{}' dropped reply", self.id),
@@ -68,6 +80,8 @@ impl NousHandle {
     /// Events are sent to `stream_tx` as the LLM generates content and tools execute.
     /// The final `TurnResult` is returned when the turn completes.
     ///
+    /// Uses [`DEFAULT_SEND_TIMEOUT`] for the inbox send.
+    ///
     /// # Cancel safety
     ///
     /// Not cancel-safe. Same as [`send_turn`](Self::send_turn) — if cancelled
@@ -79,27 +93,73 @@ impl NousHandle {
         content: impl Into<String>,
         stream_tx: mpsc::Sender<TurnStreamEvent>,
     ) -> error::Result<TurnResult> {
-        let (tx, rx) = oneshot::channel();
-        self.sender
-            .send(NousMessage::StreamingTurn {
-                session_key: session_key.into(),
-                content: content.into(),
-                stream_tx,
-                reply: tx,
-            })
+        self.send_turn_streaming_with_timeout(session_key, content, stream_tx, DEFAULT_SEND_TIMEOUT)
             .await
-            .map_err(|_send_err| {
-                ActorSendSnafu {
-                    message: format!("actor '{}' inbox closed", self.id),
-                }
-                .build()
-            })?;
+    }
+
+    /// Send a streaming turn with a configurable inbox timeout.
+    pub async fn send_turn_streaming_with_timeout(
+        &self,
+        session_key: impl Into<String>,
+        content: impl Into<String>,
+        stream_tx: mpsc::Sender<TurnStreamEvent>,
+        timeout: Duration,
+    ) -> error::Result<TurnResult> {
+        let (tx, rx) = oneshot::channel();
+        let msg = NousMessage::StreamingTurn {
+            session_key: session_key.into(),
+            content: content.into(),
+            stream_tx,
+            reply: tx,
+        };
+        self.send_with_timeout(msg, timeout).await?;
         rx.await.map_err(|_send_err| {
             ActorRecvSnafu {
                 message: format!("actor '{}' dropped reply", self.id),
             }
             .build()
         })?
+    }
+
+    /// Send a ping to the actor and wait for a reply.
+    ///
+    /// Returns `Ok(())` if the actor responds within `timeout`, or an error
+    /// if the actor is unresponsive.
+    ///
+    /// # Cancel safety
+    ///
+    /// Cancel-safe. Both sides are cancel-safe and a lost ping has no side effects.
+    pub async fn ping(&self, timeout: Duration) -> error::Result<()> {
+        let (tx, rx) = oneshot::channel();
+        self.send_with_timeout(NousMessage::Ping { reply: tx }, timeout)
+            .await?;
+        match tokio::time::timeout(timeout, rx).await {
+            Ok(Ok(())) => Ok(()),
+            Ok(Err(_)) => Err(ActorRecvSnafu {
+                message: format!("actor '{}' dropped ping reply", self.id),
+            }
+            .build()),
+            Err(_) => Err(ActorRecvSnafu {
+                message: format!("actor '{}' ping timed out", self.id),
+            }
+            .build()),
+        }
+    }
+
+    /// Send a message to the actor's inbox with a timeout.
+    async fn send_with_timeout(&self, msg: NousMessage, timeout: Duration) -> error::Result<()> {
+        match tokio::time::timeout(timeout, self.sender.send(msg)).await {
+            Ok(Ok(())) => Ok(()),
+            Ok(Err(_)) => Err(ActorSendSnafu {
+                message: format!("actor '{}' inbox closed", self.id),
+            }
+            .build()),
+            Err(_) => Err(InboxFullSnafu {
+                nous_id: self.id.clone(),
+                timeout_secs: timeout.as_secs(),
+            }
+            .build()),
+        }
     }
 
     /// Query the actor's current status.

--- a/crates/nous/src/manager.rs
+++ b/crates/nous/src/manager.rs
@@ -11,12 +11,13 @@ use aletheia_mneme::knowledge_store::KnowledgeStore;
 use aletheia_mneme::store::SessionStore;
 use aletheia_thesauros::loader::LoadedPack;
 
+use std::collections::BTreeMap;
 use std::time::Duration;
 
 use tokio::sync::watch;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
-use tracing::{info, warn};
+use tracing::{Instrument, debug, error, info, warn};
 
 use aletheia_hermeneus::provider::ProviderRegistry;
 use aletheia_mneme::embedding::EmbeddingProvider;
@@ -29,7 +30,7 @@ use crate::bootstrap::pack_sections_to_bootstrap;
 use crate::budget::CharEstimator;
 use crate::config::{NousConfig, PipelineConfig};
 use crate::handle::NousHandle;
-use crate::message::NousStatus;
+use crate::message::{ActorHealth, NousStatus};
 
 struct ActorEntry {
     handle: NousHandle,
@@ -37,7 +38,26 @@ struct ActorEntry {
     /// from a shared reference, await it, and confirm the actor has stopped.
     join: Mutex<Option<JoinHandle<()>>>,
     config: NousConfig,
+    pipeline_config: PipelineConfig,
+    /// Number of consecutive health-check misses.
+    consecutive_misses: u32,
+    /// Number of times this actor has been restarted.
+    restart_count: u32,
+    /// When the actor was last (re)started.
+    last_start: std::time::Instant,
 }
+
+/// Default interval between health polls (30 seconds).
+pub const DEFAULT_HEALTH_INTERVAL: Duration = Duration::from_secs(30);
+
+/// Default ping timeout for liveness checks (5 seconds).
+pub const DEFAULT_PING_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Consecutive misses before declaring an actor dead.
+const DEAD_THRESHOLD: u32 = 3;
+
+/// Maximum backoff between restart attempts (5 minutes).
+const MAX_RESTART_BACKOFF: Duration = Duration::from_secs(300);
 
 /// Manages the lifecycle of all nous actors.
 pub struct NousManager {
@@ -143,6 +163,17 @@ impl NousManager {
             }
         }
 
+        self.spawn_inner(config, pipeline_config).await
+    }
+
+    /// Internal spawn that does not check for existing actors.
+    async fn spawn_inner(
+        &mut self,
+        config: NousConfig,
+        pipeline_config: PipelineConfig,
+    ) -> NousHandle {
+        let id = config.id.clone();
+
         // Filter and convert domain pack sections for this agent (by ID or domain tags)
         let extra_bootstrap = {
             let estimator = CharEstimator;
@@ -168,7 +199,7 @@ impl NousManager {
         let child_cancel = self.cancel.child_token();
         let (handle, join_handle) = actor::spawn(
             config.clone(),
-            pipeline_config,
+            pipeline_config.clone(),
             Arc::clone(&self.providers),
             Arc::clone(&self.tools),
             Arc::clone(&self.oikos),
@@ -190,6 +221,10 @@ impl NousManager {
                 handle: handle.clone(),
                 join: Mutex::new(Some(join_handle)),
                 config,
+                pipeline_config,
+                consecutive_misses: 0,
+                restart_count: 0,
+                last_start: std::time::Instant::now(),
             },
         );
         handle
@@ -211,6 +246,150 @@ impl NousManager {
     #[must_use]
     pub fn configs(&self) -> Vec<&NousConfig> {
         self.actors.values().map(|e| &e.config).collect()
+    }
+
+    /// Check liveness of all actors by sending a ping with a timeout.
+    ///
+    /// Returns a map of `nous_id → ActorHealth`.
+    pub async fn check_health(&self) -> BTreeMap<String, ActorHealth> {
+        let mut results = BTreeMap::new();
+        for (id, entry) in &self.actors {
+            let ping_result = entry.handle.ping(DEFAULT_PING_TIMEOUT).await;
+            let alive = ping_result.is_ok();
+
+            // Try to get status for panic_count and uptime
+            let (panic_count, uptime) = if let Ok(status) = entry.handle.status().await {
+                (status.panic_count, status.uptime)
+            } else {
+                (0, entry.last_start.elapsed())
+            };
+
+            results.insert(
+                id.clone(),
+                ActorHealth {
+                    alive,
+                    panic_count,
+                    uptime,
+                },
+            );
+        }
+        results
+    }
+
+    /// Run one health-check cycle: ping all actors, track misses, restart dead ones.
+    ///
+    /// Call this periodically from a background task.
+    pub async fn health_cycle(&mut self) {
+        let health = self.check_health().await;
+
+        // Collect IDs that need restart to avoid borrow issues
+        let mut to_restart: Vec<String> = Vec::new();
+
+        for (id, actor_health) in &health {
+            if let Some(entry) = self.actors.get_mut(id) {
+                if actor_health.alive {
+                    entry.consecutive_misses = 0;
+                } else {
+                    entry.consecutive_misses += 1;
+                    if entry.consecutive_misses == 1 {
+                        warn!(nous_id = %id, "actor missed health check");
+                    }
+                    if entry.consecutive_misses >= DEAD_THRESHOLD {
+                        error!(
+                            nous_id = %id,
+                            misses = entry.consecutive_misses,
+                            "actor declared dead — scheduling restart"
+                        );
+                        to_restart.push(id.clone());
+                    }
+                }
+            }
+        }
+
+        for id in to_restart {
+            self.restart_actor(&id).await;
+        }
+    }
+
+    /// Restart a dead actor with exponential backoff.
+    async fn restart_actor(&mut self, id: &str) {
+        let Some(entry) = self.actors.get(id) else {
+            return;
+        };
+
+        let restart_count = entry.restart_count;
+        let backoff = calculate_backoff(restart_count);
+
+        info!(
+            nous_id = %id,
+            restart_count = restart_count + 1,
+            backoff_secs = backoff.as_secs(),
+            "restarting dead actor after backoff"
+        );
+
+        tokio::time::sleep(backoff).await;
+
+        let config = entry.config.clone();
+        let pipeline_config = entry.pipeline_config.clone();
+        let prev_restart_count = entry.restart_count;
+
+        // Remove old entry
+        if let Some(old) = self.actors.remove(id) {
+            // Take join handle before any await
+            let join_opt = old.join.lock().expect("join mutex not poisoned").take();
+            if let Some(join) = join_opt {
+                // Don't wait too long for a dead actor
+                let _ = tokio::time::timeout(Duration::from_secs(2), join).await;
+            }
+        }
+
+        // Respawn
+        let handle = self
+            .spawn_inner(config.clone(), pipeline_config.clone())
+            .await;
+
+        // Update restart tracking
+        if let Some(entry) = self.actors.get_mut(id) {
+            entry.restart_count = prev_restart_count + 1;
+            entry.consecutive_misses = 0;
+        }
+
+        info!(
+            nous_id = %id,
+            restart_count = prev_restart_count + 1,
+            "actor restarted successfully"
+        );
+
+        drop(handle);
+    }
+
+    /// Spawn a background task that runs `health_cycle` on an interval.
+    ///
+    /// Returns a `JoinHandle` that can be used to track or cancel the poller.
+    /// The poller stops when the cancellation token fires.
+    pub fn start_health_poller(
+        manager: Arc<TokioMutex<Self>>,
+        interval: Duration,
+        cancel: CancellationToken,
+    ) -> JoinHandle<()> {
+        tokio::spawn(
+            async move {
+                debug!(interval_secs = interval.as_secs(), "health poller started");
+                loop {
+                    tokio::select! {
+                        () = tokio::time::sleep(interval) => {
+                            let mut mgr = manager.lock().await;
+                            mgr.health_cycle().await;
+                        }
+                        () = cancel.cancelled() => {
+                            debug!("health poller cancelled");
+                            break;
+                        }
+                    }
+                }
+            }
+            .instrument(tracing::info_span!("health_poller")),
+        )
     }
 
     /// Query status from all actors.
@@ -379,6 +558,14 @@ impl NousManager {
     pub fn count(&self) -> usize {
         self.actors.len()
     }
+}
+
+/// Calculate exponential backoff: 5s, 15s, 45s, 2min, 5min cap.
+fn calculate_backoff(restart_count: u32) -> Duration {
+    let base_secs: u64 = 5;
+    let multiplier = 3u64.saturating_pow(restart_count);
+    let secs = base_secs.saturating_mul(multiplier);
+    Duration::from_secs(secs).min(MAX_RESTART_BACKOFF)
 }
 
 #[cfg(test)]
@@ -722,5 +909,51 @@ mod tests {
 
         // 1-nanosecond timeout: drain will warn but must not panic.
         mgr.drain(Duration::from_nanos(1)).await;
+    }
+
+    // --- Resilience tests ---
+
+    #[tokio::test]
+    async fn check_health_reports_alive_actors() {
+        let (_dir, oikos) = test_oikos();
+        let mut mgr = test_manager(oikos);
+
+        mgr.spawn(syn_config(), PipelineConfig::default()).await;
+
+        let health = mgr.check_health().await;
+        assert_eq!(health.len(), 1);
+        let syn_health = health.get("syn").expect("syn health");
+        assert!(syn_health.alive, "healthy actor should be alive");
+        assert_eq!(syn_health.panic_count, 0);
+
+        mgr.shutdown_all().await;
+    }
+
+    #[tokio::test]
+    async fn check_health_detects_dead_actor() {
+        let (_dir, oikos) = test_oikos();
+        let mut mgr = test_manager(oikos);
+
+        let handle = mgr.spawn(syn_config(), PipelineConfig::default()).await;
+
+        // Kill the actor by sending shutdown directly
+        handle.shutdown().await.expect("shutdown");
+        // Wait for actor to stop
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        let health = mgr.check_health().await;
+        let syn_health = health.get("syn").expect("syn health");
+        assert!(!syn_health.alive, "dead actor should not be alive");
+    }
+
+    #[test]
+    fn backoff_calculation() {
+        assert_eq!(super::calculate_backoff(0), Duration::from_secs(5));
+        assert_eq!(super::calculate_backoff(1), Duration::from_secs(15));
+        assert_eq!(super::calculate_backoff(2), Duration::from_secs(45));
+        assert_eq!(super::calculate_backoff(3), Duration::from_secs(135));
+        // After 4+ restarts, caps at 5 minutes
+        assert_eq!(super::calculate_backoff(4), Duration::from_secs(300));
+        assert_eq!(super::calculate_backoff(10), Duration::from_secs(300));
     }
 }

--- a/crates/nous/src/message.rs
+++ b/crates/nous/src/message.rs
@@ -1,6 +1,7 @@
 //! Actor message types, lifecycle state machine, and status snapshots.
 
 use std::fmt;
+use std::time::Duration;
 
 use tokio::sync::{mpsc, oneshot};
 
@@ -25,6 +26,8 @@ pub enum NousMessage {
     },
     /// Query current lifecycle state.
     Status { reply: oneshot::Sender<NousStatus> },
+    /// Liveness ping — actor replies immediately to prove it's alive.
+    Ping { reply: oneshot::Sender<()> },
     /// Transition to dormant (sleep).
     Sleep,
     /// Wake from dormant.
@@ -42,6 +45,8 @@ pub enum NousLifecycle {
     Idle,
     /// Paused, inbox buffered. Wakes on message or schedule.
     Dormant,
+    /// Too many panics — only accepts Status and Ping queries.
+    Degraded,
 }
 
 impl fmt::Display for NousLifecycle {
@@ -50,6 +55,7 @@ impl fmt::Display for NousLifecycle {
             Self::Active => write!(f, "active"),
             Self::Idle => write!(f, "idle"),
             Self::Dormant => write!(f, "dormant"),
+            Self::Degraded => write!(f, "degraded"),
         }
     }
 }
@@ -65,6 +71,21 @@ pub struct NousStatus {
     pub session_count: usize,
     /// Currently active session key, if any.
     pub active_session: Option<String>,
+    /// Number of panics caught by the panic boundary.
+    pub panic_count: u32,
+    /// How long the actor has been running.
+    pub uptime: Duration,
+}
+
+/// Health snapshot returned by the manager's periodic health check.
+#[derive(Debug, Clone)]
+pub struct ActorHealth {
+    /// Whether the actor responded to a ping in time.
+    pub alive: bool,
+    /// Number of panics caught since (re)start.
+    pub panic_count: u32,
+    /// Uptime since last (re)start.
+    pub uptime: Duration,
 }
 
 #[cfg(test)]
@@ -76,6 +97,7 @@ mod tests {
         assert_eq!(NousLifecycle::Active.to_string(), "active");
         assert_eq!(NousLifecycle::Idle.to_string(), "idle");
         assert_eq!(NousLifecycle::Dormant.to_string(), "dormant");
+        assert_eq!(NousLifecycle::Degraded.to_string(), "degraded");
     }
 
     #[test]
@@ -83,6 +105,7 @@ mod tests {
         assert_eq!(NousLifecycle::Active, NousLifecycle::Active);
         assert_ne!(NousLifecycle::Active, NousLifecycle::Idle);
         assert_ne!(NousLifecycle::Idle, NousLifecycle::Dormant);
+        assert_ne!(NousLifecycle::Dormant, NousLifecycle::Degraded);
     }
 
     #[test]
@@ -92,11 +115,14 @@ mod tests {
             lifecycle: NousLifecycle::Idle,
             session_count: 3,
             active_session: None,
+            panic_count: 0,
+            uptime: Duration::from_secs(60),
         };
         assert_eq!(status.id, "syn");
         assert_eq!(status.lifecycle, NousLifecycle::Idle);
         assert_eq!(status.session_count, 3);
         assert!(status.active_session.is_none());
+        assert_eq!(status.panic_count, 0);
     }
 
     #[test]
@@ -106,6 +132,8 @@ mod tests {
             lifecycle: NousLifecycle::Active,
             session_count: 1,
             active_session: Some("main".to_owned()),
+            panic_count: 0,
+            uptime: Duration::from_secs(0),
         };
         assert_eq!(status.lifecycle, NousLifecycle::Active);
         assert_eq!(status.active_session.as_deref(), Some("main"));
@@ -124,13 +152,26 @@ mod tests {
             NousLifecycle::Active,
             NousLifecycle::Idle,
             NousLifecycle::Dormant,
+            NousLifecycle::Degraded,
         ];
         let displays: Vec<String> = variants.iter().map(ToString::to_string).collect();
-        assert_eq!(displays.len(), 3);
+        assert_eq!(displays.len(), 4);
         // Ensure no duplicates
         let mut deduped = displays.clone();
         deduped.sort();
         deduped.dedup();
-        assert_eq!(deduped.len(), 3);
+        assert_eq!(deduped.len(), 4);
+    }
+
+    #[test]
+    fn actor_health_construction() {
+        let health = ActorHealth {
+            alive: true,
+            panic_count: 2,
+            uptime: Duration::from_secs(120),
+        };
+        assert!(health.alive);
+        assert_eq!(health.panic_count, 2);
+        assert_eq!(health.uptime.as_secs(), 120);
     }
 }


### PR DESCRIPTION
## Summary

- **Panic boundary**: Pipeline execution spawned in a separate Tokio task — panics caught via JoinHandle, logged with full context (nous_id, session_key, message), error returned to client. Actor continues processing next inbox message.
- **Liveness detection**: `Ping` message variant + `NousManager::check_health()` pings all actors with 5s timeout, returns `ActorHealth { alive, panic_count, uptime }`.
- **Periodic health polling**: `start_health_poller()` runs `check_health()` every 30s. After 3 consecutive misses → actor declared dead → restart with exponential backoff (5s → 15s → 45s → 2min → 5min cap).
- **Send timeout**: `send_turn()` / `send_turn_streaming()` default 30s timeout on inbox send. Returns `InboxFull` error instead of blocking forever (maps to HTTP 503 at pylon layer).
- **Spawned task accounting**: Extraction, distillation, and skill analysis tasks tracked in `JoinSet` with max concurrent limit of 8. Reaped each loop iteration with failure logging.
- **Graceful degradation**: 5+ panics in 10 minutes → `Degraded` lifecycle. Rejects `Turn` with `ServiceDegraded`, still responds to `Status`/`Ping`.

## Test plan

- [x] `actor_survives_pipeline_panic` — panicking provider, actor continues
- [x] `ping_pong_liveness` — ping succeeds on healthy actor
- [x] `ping_fails_on_dead_actor` — ping fails after shutdown
- [x] `send_timeout_fires_when_inbox_full` — inbox full → InboxFull error
- [x] `degraded_state_after_repeated_panics` — 5 panics → Degraded lifecycle
- [x] `background_task_reaping` — reaping doesn't break normal operation
- [x] `status_includes_uptime` — uptime field is non-zero
- [x] `check_health_reports_alive_actors` — manager health check
- [x] `check_health_detects_dead_actor` — dead actor detected
- [x] `backoff_calculation` — exponential backoff values correct
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — zero warnings
- [x] `cargo test -p aletheia-nous` — 318 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)