### PR TITLE
test: release binary smoke test suite

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,12 +50,14 @@ dependencies = [
  "aletheia-thesauros",
  "aletheia-tui",
  "anyhow",
+ "assert_cmd",
  "axum 0.8.8",
  "clap",
  "clap_complete",
  "cliclack",
  "jiff",
  "owo-colors",
+ "predicates",
  "qdrant-client",
  "rcgen",
  "reqwest 0.13.2",
@@ -623,6 +625,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert_cmd"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a686bbee5efb88a82df0621b236e74d925f470e5445d3220a5648b892ec99c9"
+dependencies = [
+ "anstyle",
+ "bstr",
+ "libc",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
+
+[[package]]
 name = "async-compression"
 version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -936,6 +953,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
 ]
 
 [[package]]
@@ -1731,6 +1759,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2165,6 +2199,15 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+]
+
+[[package]]
+name = "float-cmp"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -3635,6 +3678,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4243,6 +4292,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "predicates"
+version = "3.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ada8f2932f28a27ee7b70dd6c1c39ea0675c55a36879ab92f3a715eaa1e63cfe"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "float-cmp",
+ "normalize-line-endings",
+ "predicates-core",
+ "regex",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cad38746f3166b4031b1a0d39ad9f954dd291e7854fcc0eed52ee41a0b50d144"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0de1b847b39c8131db0467e9df1ff60e6d0562ab8e9a16e568ad0fdb372e2f2"
+dependencies = [
+ "predicates-core",
+ "termtree",
 ]
 
 [[package]]
@@ -5873,6 +5952,12 @@ checksum = "411c5bf740737c7918b8b1fe232dca4dc9f8e754b8ad5e20966814001ed0ac6b"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "termwiz"

--- a/crates/aletheia/Cargo.toml
+++ b/crates/aletheia/Cargo.toml
@@ -63,6 +63,8 @@ owo-colors = "4"
 supports-color = "3"
 
 [dev-dependencies]
+assert_cmd = "2"
+predicates = "3"
 tempfile = "3"
 serde_yaml = "0.9"
 

--- a/crates/aletheia/src/main.rs
+++ b/crates/aletheia/src/main.rs
@@ -57,7 +57,7 @@ use aletheia_taxis::loader::load_config;
 use aletheia_taxis::oikos::Oikos;
 
 #[derive(Debug, Parser)]
-#[command(name = "aletheia", about = "Cognitive agent runtime")]
+#[command(name = "aletheia", about = "Cognitive agent runtime", version)]
 struct Cli {
     /// Path to instance root directory
     #[arg(short = 'r', long)]

--- a/crates/aletheia/tests/smoke_test.rs
+++ b/crates/aletheia/tests/smoke_test.rs
@@ -1,0 +1,279 @@
+//! Smoke tests for the `aletheia` CLI binary.
+//!
+//! These tests use `assert_cmd` to invoke the compiled binary and verify that
+//! every subcommand is reachable, parses arguments, and produces useful output
+//! or graceful failures without a live server.
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+fn aletheia() -> Command {
+    Command::cargo_bin("aletheia").expect("aletheia binary must be compiled")
+}
+
+// ── Top-level flags ───────────────────────────────────────────────────────────
+
+#[test]
+fn top_level_help_exits_zero() {
+    aletheia()
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("aletheia"));
+}
+
+#[test]
+fn top_level_version_format() {
+    // --version should print "aletheia X.Y.Z"
+    aletheia()
+        .arg("--version")
+        .assert()
+        .success()
+        .stdout(predicate::str::is_match(r"aletheia \d+\.\d+\.\d+").unwrap());
+}
+
+#[test]
+fn top_level_help_lists_all_subcommands() {
+    let expected = [
+        "health",
+        "backup",
+        "maintenance",
+        "tls",
+        "status",
+        "credential",
+        "eval",
+        "export",
+        "tui",
+        "migrate-memory",
+        "init",
+        "import",
+        "seed-skills",
+        "export-skills",
+        "review-skills",
+        "completions",
+    ];
+    let output = aletheia()
+        .arg("--help")
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let help_text = String::from_utf8_lossy(&output);
+    for sub in expected {
+        assert!(
+            help_text.contains(sub),
+            "--help output missing subcommand '{sub}'"
+        );
+    }
+}
+
+// ── Subcommand --help (all 16) ────────────────────────────────────────────────
+
+macro_rules! help_test {
+    ($name:ident, $($arg:expr),+) => {
+        #[test]
+        fn $name() {
+            aletheia()
+                $(.arg($arg))+
+                .arg("--help")
+                .assert()
+                .success();
+        }
+    };
+}
+
+help_test!(health_help, "health");
+help_test!(backup_help, "backup");
+help_test!(maintenance_help, "maintenance");
+help_test!(maintenance_status_help, "maintenance", "status");
+help_test!(maintenance_run_help, "maintenance", "run");
+help_test!(tls_help, "tls");
+help_test!(tls_generate_help, "tls", "generate");
+help_test!(status_help, "status");
+help_test!(credential_help, "credential");
+help_test!(credential_status_help, "credential", "status");
+help_test!(credential_refresh_help, "credential", "refresh");
+help_test!(eval_help, "eval");
+help_test!(export_help, "export");
+help_test!(tui_help, "tui");
+help_test!(migrate_memory_help, "migrate-memory");
+help_test!(init_help, "init");
+help_test!(import_help, "import");
+help_test!(seed_skills_help, "seed-skills");
+help_test!(export_skills_help, "export-skills");
+help_test!(review_skills_help, "review-skills");
+help_test!(completions_help, "completions");
+
+// ── Completions (fully offline) ───────────────────────────────────────────────
+
+#[test]
+fn completions_bash_exits_zero() {
+    aletheia().args(["completions", "bash"]).assert().success();
+}
+
+#[test]
+fn completions_bash_output_contains_aletheia() {
+    aletheia()
+        .args(["completions", "bash"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("aletheia"));
+}
+
+#[test]
+fn completions_zsh_exits_zero() {
+    aletheia().args(["completions", "zsh"]).assert().success();
+}
+
+#[test]
+fn completions_fish_exits_zero() {
+    aletheia().args(["completions", "fish"]).assert().success();
+}
+
+#[test]
+fn completions_invalid_shell_fails() {
+    aletheia()
+        .args(["completions", "not-a-shell"])
+        .assert()
+        .failure();
+}
+
+// ── Health — graceful failure without a server ────────────────────────────────
+
+#[test]
+fn health_graceful_failure_no_server() {
+    // Port 19999 should have nothing listening in CI. The command must exit
+    // with code 0 or 1 (not panic / 101 etc.) and print a useful message.
+    let output = aletheia()
+        .args(["health", "--url", "http://127.0.0.1:19999"])
+        .output()
+        .expect("failed to run aletheia health");
+
+    let exit_code = output.status.code().unwrap_or(2);
+    assert!(
+        exit_code <= 1,
+        "health exited with code {exit_code}, expected 0 or 1"
+    );
+
+    let mut combined = String::from_utf8_lossy(&output.stdout).into_owned();
+    combined.push_str(&String::from_utf8_lossy(&output.stderr));
+    assert!(
+        combined.to_lowercase().contains("error")
+            || combined.to_lowercase().contains("connect")
+            || combined.to_lowercase().contains("refused")
+            || combined.to_lowercase().contains("unreachable")
+            || combined.to_lowercase().contains("failed"),
+        "health output should mention a connection problem; got: {combined}"
+    );
+}
+
+// ── Status — graceful failure without a server ────────────────────────────────
+
+#[test]
+fn status_graceful_failure_no_server() {
+    let output = aletheia()
+        .args(["status", "--url", "http://127.0.0.1:19999"])
+        .output()
+        .expect("failed to run aletheia status");
+
+    let exit_code = output.status.code().unwrap_or(2);
+    assert!(
+        exit_code <= 1,
+        "status exited with code {exit_code}, expected 0 or 1"
+    );
+}
+
+// ── Init — non-destructive (isolated temp dir) ────────────────────────────────
+
+#[test]
+fn init_with_missing_api_key_fails_usefully() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let instance_path = tmp.path().join("instance");
+
+    // Run with --yes (non-interactive) but no API key set.
+    // Should either succeed (unlikely in CI) or fail with a useful message —
+    // not panic or exit 101.
+    let output = aletheia()
+        .args([
+            "init",
+            "--instance-root",
+            instance_path.to_str().unwrap(),
+            "--yes",
+        ])
+        .env_remove("ANTHROPIC_API_KEY")
+        .output()
+        .expect("failed to run aletheia init");
+
+    let exit_code = output.status.code().unwrap_or(255);
+    let mut combined = String::from_utf8_lossy(&output.stdout).into_owned();
+    combined.push_str(&String::from_utf8_lossy(&output.stderr));
+
+    assert!(
+        exit_code <= 1
+            || combined.to_lowercase().contains("api")
+            || combined.to_lowercase().contains("key")
+            || combined.to_lowercase().contains("credential")
+            || combined.to_lowercase().contains("error"),
+        "init should exit cleanly or produce a useful error; exit={exit_code}, output={combined}"
+    );
+}
+
+// ── Import — missing file produces useful error ───────────────────────────────
+
+#[test]
+fn import_missing_file_produces_error() {
+    aletheia()
+        .args(["import", "/nonexistent/path/agent.json"])
+        .assert()
+        .failure()
+        .stderr(
+            predicate::str::contains("No such file")
+                .or(predicate::str::contains("not found"))
+                .or(predicate::str::contains("error"))
+                .or(predicate::str::contains("cannot")),
+        );
+}
+
+// ── Seed-skills — missing dir exits non-zero ──────────────────────────────────
+
+#[test]
+fn seed_skills_missing_dir_exits_nonzero() {
+    aletheia()
+        .args([
+            "seed-skills",
+            "--dir",
+            "/nonexistent/skills/dir",
+            "--nous-id",
+            "test-agent",
+            "--dry-run",
+        ])
+        .assert()
+        .failure();
+}
+
+// ── Unknown subcommand exits non-zero ─────────────────────────────────────────
+
+#[test]
+fn unknown_subcommand_exits_nonzero() {
+    aletheia()
+        .arg("totally-unknown-subcommand")
+        .assert()
+        .failure();
+}
+
+// ── No subcommand shows help or starts server (not panics) ────────────────────
+
+#[test]
+fn no_args_does_not_panic() {
+    // Running without arguments should either start the server (exit blocked by
+    // missing config) or print help. It must not exit with code 101 (Rust panic).
+    let output = aletheia()
+        .output()
+        .expect("failed to run aletheia with no args");
+
+    let exit_code = output.status.code().unwrap_or(101);
+    assert_ne!(exit_code, 101, "aletheia exited with a panic exit code");
+}

--- a/crates/mneme/src/engine/runtime/callback.rs
+++ b/crates/mneme/src/engine/runtime/callback.rs
@@ -72,7 +72,10 @@ impl<'s, S: Storage<'s>> Db<S> {
 
         for (table, vals) in collector {
             for (op, new, old) in vals {
-                let (cbs, cb_dir) = &*self.event_callbacks.read().expect("event_callbacks lock poisoned");
+                let (cbs, cb_dir) = &*self
+                    .event_callbacks
+                    .read()
+                    .expect("event_callbacks lock poisoned");
                 if let Some(cb_ids) = cb_dir.get(&table) {
                     let mut it = cb_ids.iter();
                     if let Some(fst) = it.next() {
@@ -95,7 +98,10 @@ impl<'s, S: Storage<'s>> Db<S> {
         }
 
         if !to_remove.is_empty() {
-            let (cbs, cb_dir) = &mut *self.event_callbacks.write().expect("event_callbacks lock poisoned");
+            let (cbs, cb_dir) = &mut *self
+                .event_callbacks
+                .write()
+                .expect("event_callbacks lock poisoned");
             for removing_id in &to_remove {
                 if let Some(removed) = cbs.remove(removing_id) {
                     if let Some(set) = cb_dir.get_mut(&removed.dependent) {

--- a/crates/mneme/src/engine/runtime/hnsw.rs
+++ b/crates/mneme/src/engine/runtime/hnsw.rs
@@ -63,8 +63,7 @@ impl VectorCache {
     fn new(distance: HnswDistance, capacity: usize) -> Self {
         Self {
             cache: LruCache::new(
-                NonZeroUsize::new(capacity)
-                    .expect("VectorCache capacity must be > 0"),
+                NonZeroUsize::new(capacity).expect("VectorCache capacity must be > 0"),
             ),
             distance,
         }
@@ -109,7 +108,8 @@ impl VectorCache {
                 }
                 _ => bail!(
                     "Cannot compute cosine distance between {:?} and {:?}",
-                    v1, v2
+                    v1,
+                    v2
                 ),
             },
             HnswDistance::InnerProduct => match (v1, v2) {
@@ -232,10 +232,18 @@ impl<'a> SessionTx<'a> {
         if let Some(ep) = ep_res {
             let ep = ep?;
             // bottom level since we are going up
-            let bottom_level = ep[0].get_int().expect("HNSW index stores integers at this position");
+            let bottom_level = ep[0]
+                .get_int()
+                .expect("HNSW index stores integers at this position");
             let ep_t_key = ep[1..orig_table.metadata.keys.len() + 1].to_vec();
-            let ep_idx = ep[orig_table.metadata.keys.len() + 1].get_int().expect("HNSW index stores integers at this position") as usize;
-            let ep_subidx = ep[orig_table.metadata.keys.len() + 2].get_int().expect("HNSW index stores integers at this position") as i32;
+            let ep_idx = ep[orig_table.metadata.keys.len() + 1]
+                .get_int()
+                .expect("HNSW index stores integers at this position")
+                as usize;
+            let ep_subidx = ep[orig_table.metadata.keys.len() + 2]
+                .get_int()
+                .expect("HNSW index stores integers at this position")
+                as i32;
             let ep_key = (ep_t_key, ep_idx, ep_subidx);
             vec_cache.ensure_key(&ep_key, orig_table, self)?;
             let ep_distance = vec_cache.v_dist(q, &ep_key)?;
@@ -380,7 +388,11 @@ impl<'a> SessionTx<'a> {
                     let mut target_self_val: Vec<DataValue> =
                         rmp_serde::from_slice(&target_self_val_bytes[ENCODED_KEY_MIN_LEN..])
                             .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)?;
-                    let mut target_degree = target_self_val[0].get_float().expect("HNSW index stores floats at this position") as usize + 1;
+                    let mut target_degree = target_self_val[0]
+                        .get_float()
+                        .expect("HNSW index stores floats at this position")
+                        as usize
+                        + 1;
                     if target_degree > m_max {
                         // shrink links
                         target_degree = self.hnsw_shrink_neighbour(
@@ -498,7 +510,10 @@ impl<'a> SessionTx<'a> {
                 let old_existing_val: Vec<DataValue> =
                     rmp_serde::from_slice(&old_existing_val[ENCODED_KEY_MIN_LEN..])
                         .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)?;
-                if old_existing_val[2].get_bool().expect("HNSW index stores bools at this position") {
+                if old_existing_val[2]
+                    .get_bool()
+                    .expect("HNSW index stores bools at this position")
+                {
                     self.store_tx.del(&old_key_bytes)?;
                 } else {
                     let old_val = vec![
@@ -547,7 +562,8 @@ impl<'a> SessionTx<'a> {
             }
         }
         while !candidates.is_empty() && ret.len() < m {
-            let (cand_key, Reverse(OrderedFloat(cand_dist_to_q))) = candidates.pop()
+            let (cand_key, Reverse(OrderedFloat(cand_dist_to_q))) = candidates
+                .pop()
                 .expect("checked !is_empty() in while condition");
             let mut should_add = true;
             for (existing, _) in ret.iter() {
@@ -567,8 +583,9 @@ impl<'a> SessionTx<'a> {
         }
         if manifest.keep_pruned_connections {
             while !discarded.is_empty() && ret.len() < m {
-                let (nearest_triple, Reverse(OrderedFloat(nearest_dist))) =
-                    discarded.pop().expect("checked !is_empty() in while condition");
+                let (nearest_triple, Reverse(OrderedFloat(nearest_dist))) = discarded
+                    .pop()
+                    .expect("checked !is_empty() in while condition");
                 ret.push(nearest_triple, Reverse(OrderedFloat(nearest_dist)));
             }
         }
@@ -595,7 +612,9 @@ impl<'a> SessionTx<'a> {
         }
 
         while let Some((candidate, Reverse(OrderedFloat(candidate_dist)))) = candidates.pop() {
-            let (_, OrderedFloat(furtherest_dist)) = found_nn.peek().expect("found_nn is non-empty: populated before search loop");
+            let (_, OrderedFloat(furtherest_dist)) = found_nn
+                .peek()
+                .expect("found_nn is non-empty: populated before search loop");
             let furtherest_dist = *furtherest_dist;
             if candidate_dist > furtherest_dist {
                 break;
@@ -609,7 +628,9 @@ impl<'a> SessionTx<'a> {
                 }
                 vec_cache.ensure_key(&neighbour_key, orig_table, self)?;
                 let neighbour_dist = vec_cache.v_dist(q, &neighbour_key)?;
-                let (_, OrderedFloat(cand_furtherest_dist)) = found_nn.peek().expect("found_nn is non-empty: populated before search loop");
+                let (_, OrderedFloat(cand_furtherest_dist)) = found_nn
+                    .peek()
+                    .expect("found_nn is non-empty: populated before search loop");
                 if found_nn.len() < ef || neighbour_dist < *cand_furtherest_dist {
                     candidates.push(neighbour_key.clone(), Reverse(OrderedFloat(neighbour_dist)));
                     found_nn.push(neighbour_key.clone(), OrderedFloat(neighbour_dist));
@@ -641,8 +662,14 @@ impl<'a> SessionTx<'a> {
             .filter_map(move |res| {
                 let tuple = res.ok()?;
 
-                let key_idx = tuple[2 * key_len + 3].get_int().expect("HNSW index stores integers at this position") as usize;
-                let key_subidx = tuple[2 * key_len + 4].get_int().expect("HNSW index stores integers at this position") as i32;
+                let key_idx = tuple[2 * key_len + 3]
+                    .get_int()
+                    .expect("HNSW index stores integers at this position")
+                    as usize;
+                let key_subidx = tuple[2 * key_len + 4]
+                    .get_int()
+                    .expect("HNSW index stores integers at this position")
+                    as i32;
                 let key_tup = tuple[key_len + 3..2 * key_len + 3].to_vec();
                 if key_tup == cand_key.0 {
                     None
@@ -650,16 +677,22 @@ impl<'a> SessionTx<'a> {
                     if include_deleted {
                         return Some((
                             (key_tup, key_idx, key_subidx),
-                            tuple[2 * key_len + 5].get_float().expect("HNSW index stores floats at this position"),
+                            tuple[2 * key_len + 5]
+                                .get_float()
+                                .expect("HNSW index stores floats at this position"),
                         ));
                     }
-                    let is_deleted = tuple[2 * key_len + 7].get_bool().expect("HNSW index stores bools at this position");
+                    let is_deleted = tuple[2 * key_len + 7]
+                        .get_bool()
+                        .expect("HNSW index stores bools at this position");
                     if is_deleted {
                         None
                     } else {
                         Some((
                             (key_tup, key_idx, key_subidx),
-                            tuple[2 * key_len + 5].get_float().expect("HNSW index stores floats at this position"),
+                            tuple[2 * key_len + 5]
+                                .get_float()
+                                .expect("HNSW index stores floats at this position"),
                         ))
                     }
                 }
@@ -731,7 +764,9 @@ impl<'a> SessionTx<'a> {
         }
         let mut extracted_vectors = vec![];
         for idx in &manifest.vec_fields {
-            let val = tuple.get(*idx).expect("vec_fields indices validated at index creation");
+            let val = tuple
+                .get(*idx)
+                .expect("vec_fields indices validated at index creation");
             if let DataValue::Vec(v) = val {
                 extracted_vectors.push((v, *idx, -1));
             } else if let DataValue::List(l) = val {
@@ -774,8 +809,14 @@ impl<'a> SessionTx<'a> {
                 Ok(t) => Some({
                     (
                         t[1..orig_table.metadata.keys.len() + 1].to_vec(),
-                        t[orig_table.metadata.keys.len() + 1].get_int().expect("HNSW index stores integers at this position") as usize,
-                        t[orig_table.metadata.keys.len() + 2].get_int().expect("HNSW index stores integers at this position") as i32,
+                        t[orig_table.metadata.keys.len() + 1]
+                            .get_int()
+                            .expect("HNSW index stores integers at this position")
+                            as usize,
+                        t[orig_table.metadata.keys.len() + 2]
+                            .get_int()
+                            .expect("HNSW index stores integers at this position")
+                            as i32,
                     )
                 }),
                 Err(_) => None,
@@ -843,19 +884,24 @@ impl<'a> SessionTx<'a> {
                     neighbour_self_key.push(DataValue::from(neighbour_key.1 as i64));
                     neighbour_self_key.push(DataValue::from(neighbour_key.2 as i64));
                 }
-                let neighbour_val_bytes = match self
-                    .store_tx
-                    .get(
-                        &idx_table.encode_key_for_store(&neighbour_self_key, Default::default())?,
-                        false,
-                    )? {
+                let neighbour_val_bytes = match self.store_tx.get(
+                    &idx_table.encode_key_for_store(&neighbour_self_key, Default::default())?,
+                    false,
+                )? {
                     Some(bytes) => bytes,
-                    None => bail!("HNSW neighbour self-key not found during removal, index may be corrupted"),
+                    None => bail!(
+                        "HNSW neighbour self-key not found during removal, index may be corrupted"
+                    ),
                 };
                 let mut neighbour_val: Vec<DataValue> =
                     rmp_serde::from_slice(&neighbour_val_bytes[ENCODED_KEY_MIN_LEN..])
                         .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)?;
-                neighbour_val[0] = DataValue::from(neighbour_val[0].get_float().expect("HNSW index stores floats at this position") - 1.);
+                neighbour_val[0] = DataValue::from(
+                    neighbour_val[0]
+                        .get_float()
+                        .expect("HNSW index stores floats at this position")
+                        - 1.,
+                );
                 self.store_tx.put(
                     &idx_table.encode_key_for_store(&neighbour_self_key, Default::default())?,
                     &idx_table.encode_val_only_for_store(&neighbour_val, Default::default())?,
@@ -886,7 +932,9 @@ impl<'a> SessionTx<'a> {
             if let Some(ep) = ep_res {
                 let ep = ep?;
                 let target_key_bytes = idx_table.encode_key_for_store(&ep, Default::default())?;
-                let bottom_level = ep[0].get_int().expect("HNSW index stores integers at this position");
+                let bottom_level = ep[0]
+                    .get_int()
+                    .expect("HNSW index stores integers at this position");
                 // canary value is for conflict detection: prevent the scenario of disconnected graphs at all levels
                 let canary_value = [
                     DataValue::from(bottom_level),
@@ -921,7 +969,8 @@ impl<'a> SessionTx<'a> {
             (Vector::F64(v), VecElementType::F32) => Vector::F32(v.mapv(|x| x as f32)),
         };
 
-        let mut vec_cache = VectorCache::new(config.manifest.distance, DEFAULT_VECTOR_CACHE_CAPACITY);
+        let mut vec_cache =
+            VectorCache::new(config.manifest.distance, DEFAULT_VECTOR_CACHE_CAPACITY);
 
         let ep_res = config
             .idx_handle
@@ -934,7 +983,9 @@ impl<'a> SessionTx<'a> {
             .next();
         if let Some(ep) = ep_res {
             let ep = ep?;
-            let bottom_level = ep[0].get_int().expect("HNSW index stores integers at this position");
+            let bottom_level = ep[0]
+                .get_int()
+                .expect("HNSW index stores integers at this position");
             let ep_idx = match ep[config.base_handle.metadata.keys.len() + 1].get_int() {
                 Some(x) => x as usize,
                 None => {
@@ -945,7 +996,8 @@ impl<'a> SessionTx<'a> {
             let ep_t_key = ep[1..config.base_handle.metadata.keys.len() + 1].to_vec();
             let ep_subidx = ep[config.base_handle.metadata.keys.len() + 2]
                 .get_int()
-                .expect("HNSW index stores integers at this position") as i32;
+                .expect("HNSW index stores integers at this position")
+                as i32;
             let ep_key = (ep_t_key, ep_idx, ep_subidx);
             vec_cache.ensure_key(&ep_key, &config.base_handle, self)?;
             let ep_distance = vec_cache.v_dist(&q, &ep_key)?;
@@ -1092,7 +1144,10 @@ mod tests {
         // Most recent insertions (5..10) should be in cache
         for i in 5..10u8 {
             let key = (vec![DataValue::from(i as i64)], 0, -1);
-            assert!(cache.cache.contains(&key), "recent key {i} should be in cache");
+            assert!(
+                cache.cache.contains(&key),
+                "recent key {i} should be in cache"
+            );
         }
         // Oldest insertions (0..5) should have been evicted
         for i in 0..5u8 {
@@ -1115,7 +1170,10 @@ mod tests {
         let v1 = Vector::F64(ndarray::Array1::from_vec(vec![0.0, 0.0]));
         let v2 = Vector::F64(ndarray::Array1::from_vec(vec![3.0, 4.0]));
         let d = cache.dist(&v1, &v2).unwrap();
-        assert!((d - 25.0).abs() < 1e-10, "L2 squared distance should be 25.0, got {d}");
+        assert!(
+            (d - 25.0).abs() < 1e-10,
+            "L2 squared distance should be 25.0, got {d}"
+        );
     }
 
     #[test]
@@ -1123,16 +1181,17 @@ mod tests {
         let cache = VectorCache::new(HnswDistance::Cosine, 10);
         let v = Vector::F64(ndarray::Array1::from_vec(vec![1.0, 0.0, 0.0]));
         let d = cache.dist(&v, &v).unwrap();
-        assert!(d.abs() < 1e-10, "cosine distance of identical vectors should be ~0, got {d}");
+        assert!(
+            d.abs() < 1e-10,
+            "cosine distance of identical vectors should be ~0, got {d}"
+        );
     }
 
     #[test]
     fn hnsw_insert_and_search() {
         let db = DbInstance::default();
-        db.run_default(
-            ":create vectors { id: Int => vec: <F32; 4> }",
-        )
-        .unwrap();
+        db.run_default(":create vectors { id: Int => vec: <F32; 4> }")
+            .unwrap();
         db.run_default(
             r#"::hnsw create vectors:idx {
                 dim: 4,
@@ -1163,16 +1222,18 @@ mod tests {
         // The closest vector should be id=5 (exact match)
         // HNSW is approximate — the exact match (id=5) should be among top results
         let ids: Vec<i64> = res.rows.iter().filter_map(|r| r[0].get_int()).collect();
-        assert!(ids.contains(&5), "exact match id=5 should be among top-k results, got {:?}", ids);
+        assert!(
+            ids.contains(&5),
+            "exact match id=5 should be among top-k results, got {:?}",
+            ids
+        );
     }
 
     #[test]
     fn hnsw_empty_search() {
         let db = DbInstance::default();
-        db.run_default(
-            ":create vectors { id: Int => vec: <F32; 4> }",
-        )
-        .unwrap();
+        db.run_default(":create vectors { id: Int => vec: <F32; 4> }")
+            .unwrap();
         db.run_default(
             r#"::hnsw create vectors:idx {
                 dim: 4,
@@ -1190,16 +1251,17 @@ mod tests {
         let res = db.run_default(
             r#"?[id, dist] := ~vectors:idx{id | query: vec([1.0, 2.0, 3.0, 4.0]), k: 5, ef: 50, bind_distance: dist}"#,
         ).unwrap();
-        assert!(res.rows.is_empty(), "empty index search should return no results");
+        assert!(
+            res.rows.is_empty(),
+            "empty index search should return no results"
+        );
     }
 
     #[test]
     fn hnsw_delete() {
         let db = DbInstance::default();
-        db.run_default(
-            ":create vectors { id: Int => vec: <F32; 4> }",
-        )
-        .unwrap();
+        db.run_default(":create vectors { id: Int => vec: <F32; 4> }")
+            .unwrap();
         db.run_default(
             r#"::hnsw create vectors:idx {
                 dim: 4,
@@ -1228,16 +1290,17 @@ mod tests {
             r#"?[id, dist] := ~vectors:idx{id | query: vec([5.0, 5.0, 5.0, 5.0]), k: 3, ef: 50, bind_distance: dist}"#,
         ).unwrap();
         let ids: Vec<i64> = res.rows.iter().filter_map(|r| r[0].get_int()).collect();
-        assert!(!ids.contains(&5), "deleted vector id=5 should not appear in results");
+        assert!(
+            !ids.contains(&5),
+            "deleted vector id=5 should not appear in results"
+        );
     }
 
     #[test]
     fn hnsw_search_results_ordered_by_distance() {
         let db = DbInstance::default();
-        db.run_default(
-            ":create vectors { id: Int => vec: <F32; 4> }",
-        )
-        .unwrap();
+        db.run_default(":create vectors { id: Int => vec: <F32; 4> }")
+            .unwrap();
         db.run_default(
             r#"::hnsw create vectors:idx {
                 dim: 4,
@@ -1264,7 +1327,12 @@ mod tests {
         let distances: Vec<f64> = res.rows.iter().filter_map(|r| r[1].get_float()).collect();
         assert!(!distances.is_empty(), "should return results");
         for window in distances.windows(2) {
-            assert!(window[0] <= window[1], "results should be ordered by distance: {} <= {}", window[0], window[1]);
+            assert!(
+                window[0] <= window[1],
+                "results should be ordered by distance: {} <= {}",
+                window[0],
+                window[1]
+            );
         }
     }
 }

--- a/crates/mneme/src/engine/runtime/minhash_lsh.rs
+++ b/crates/mneme/src/engine/runtime/minhash_lsh.rs
@@ -37,10 +37,15 @@ impl<'a> SessionTx<'a> {
                             .into_iter()
                             .map(|chunk| match chunk {
                                 DataValue::Bytes(b) => b,
-                                other => panic!("LSH index invariant violated: expected Bytes, got {other:?}"),
+                                other => panic!(
+                                    "LSH index invariant violated: expected Bytes, got {other:?}"
+                                ),
                             })
                             .collect_vec(),
-                        other => bail!("LSH index invariant violated: expected List, got {:?}", other),
+                        other => bail!(
+                            "LSH index invariant violated: expected List, got {:?}",
+                            other
+                        ),
                     }
                 } else {
                     return Ok(());
@@ -79,10 +84,15 @@ impl<'a> SessionTx<'a> {
                     .into_iter()
                     .map(|chunk| match chunk {
                         DataValue::Bytes(b) => b,
-                        other => panic!("LSH index invariant violated: expected Bytes, got {other:?}"),
+                        other => {
+                            panic!("LSH index invariant violated: expected Bytes, got {other:?}")
+                        }
                     })
                     .collect_vec(),
-                other => bail!("LSH index invariant violated: expected List, got {:?}", other),
+                other => bail!(
+                    "LSH index invariant violated: expected List, got {:?}",
+                    other
+                ),
             };
             self.del_lsh_index_item(tuple, Some(bytes), idx_handle, inv_idx_handle)?;
         }

--- a/crates/mneme/src/engine/runtime/temp_store.rs
+++ b/crates/mneme/src/engine/runtime/temp_store.rs
@@ -120,7 +120,10 @@ impl MeetAggrStore {
             Some(prev_aggr) => {
                 let mut changed = false;
                 for (i, (aggr_op, _)) in self.aggregations.iter().enumerate() {
-                    let op = aggr_op.meet_op.as_ref().expect("meet_op is set for meet-capable aggregations");
+                    let op = aggr_op
+                        .meet_op
+                        .as_ref()
+                        .expect("meet_op is set for meet-capable aggregations");
                     changed |= op.update(&mut prev_aggr[i], &val_part[i])?;
                 }
                 Ok(changed)
@@ -156,7 +159,10 @@ impl MeetAggrStore {
                 if ret.partial_cmp(&lower as &[DataValue]) == Some(Ordering::Less) {
                     None
                 } else {
-                    match ret.partial_cmp(&upper as &[DataValue]).expect("DataValue tuples are always comparable") {
+                    match ret
+                        .partial_cmp(&upper as &[DataValue])
+                        .expect("DataValue tuples are always comparable")
+                    {
                         Ordering::Less => Some(ret),
                         Ordering::Equal => {
                             if upper_inclusive {
@@ -192,7 +198,10 @@ impl MeetAggrStore {
                     {
                         let target = ent.get_mut();
                         for (i, (aggr_op, _)) in self.aggregations.iter().enumerate() {
-                            let op = aggr_op.meet_op.as_ref().expect("meet_op is set for meet-capable aggregations");
+                            let op = aggr_op
+                                .meet_op
+                                .as_ref()
+                                .expect("meet_op is set for meet-capable aggregations");
                             changed |= op.update(&mut target[i], &v[i])?;
                         }
                     }
@@ -337,9 +346,11 @@ pub(crate) struct TupleInIter<'a>(&'a Tuple, &'a Tuple, bool);
 
 impl<'a> TupleInIter<'a> {
     pub(crate) fn get(self, idx: usize) -> &'a DataValue {
-        self.0
-            .get(idx)
-            .unwrap_or_else(|| self.1.get(idx - self.0.len()).expect("idx is within combined tuple bounds"))
+        self.0.get(idx).unwrap_or_else(|| {
+            self.1
+                .get(idx - self.0.len())
+                .expect("idx is within combined tuple bounds")
+        })
     }
     fn should_skip(&self) -> bool {
         self.2

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -1,0 +1,247 @@
+#!/usr/bin/env bash
+# smoke-test.sh — Release binary smoke test for the aletheia CLI.
+#
+# Exercises every subcommand to verify the binary is correctly linked,
+# parses arguments, and produces useful output or graceful failures.
+# Does NOT require a live server instance.
+#
+# Usage:
+#   ./scripts/smoke-test.sh [--binary PATH] [--build]
+#
+# Options:
+#   --binary PATH   Use an existing binary at PATH (skips build)
+#   --build         Force a release build before testing (default if no binary found)
+#   --help          Show this message
+
+set -euo pipefail
+
+# ── Colours ──────────────────────────────────────────────────────────────────
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BOLD='\033[1m'
+RESET='\033[0m'
+
+# ── State ─────────────────────────────────────────────────────────────────────
+PASS=0
+FAIL=0
+SKIP=0
+FAILURES=()
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+pass() { echo -e "  ${GREEN}✓${RESET} $1"; PASS=$(( PASS + 1 )); }
+fail() { echo -e "  ${RED}✗${RESET} $1"; FAIL=$(( FAIL + 1 )); FAILURES+=("$1"); }
+skip() { echo -e "  ${YELLOW}○${RESET} $1 (skipped)"; SKIP=$(( SKIP + 1 )); }
+section() { echo -e "\n${BOLD}$1${RESET}"; }
+
+# Run the binary and check the exit code and optional output pattern.
+# Usage: check <description> <expected-exit> [output-pattern] -- <binary-args...>
+check() {
+    local desc="$1"
+    local want_exit="$2"
+    local pattern="${3:-}"
+    shift 3
+    # consume the separator "--"
+    if [[ "${1:-}" == "--" ]]; then shift; fi
+
+    local actual_exit=0
+    local output
+    output=$("$BINARY" "$@" 2>&1) || actual_exit=$?
+
+    if [[ "$actual_exit" -ne "$want_exit" ]]; then
+        fail "$desc (exit $actual_exit, expected $want_exit)"
+        return
+    fi
+
+    if [[ -n "$pattern" ]] && ! echo "$output" | grep -qE "$pattern"; then
+        fail "$desc (output missing pattern: $pattern)"
+        return
+    fi
+
+    pass "$desc"
+}
+
+# Runs the binary; passes if exit ≤ 1 (0 = success, 1 = expected failure like
+# "no server"). Used for commands that gracefully fail without a live instance.
+check_graceful() {
+    local desc="$1"
+    local pattern="${2:-}"
+    shift 2
+    if [[ "${1:-}" == "--" ]]; then shift; fi
+
+    local actual_exit=0
+    local output
+    output=$("$BINARY" "$@" 2>&1) || actual_exit=$?
+
+    if [[ "$actual_exit" -gt 1 ]]; then
+        fail "$desc (unexpected exit $actual_exit)"
+        return
+    fi
+
+    if [[ -n "$pattern" ]] && ! echo "$output" | grep -qiE "$pattern"; then
+        fail "$desc (output missing pattern: $pattern)"
+        return
+    fi
+
+    pass "$desc"
+}
+
+# ── Argument parsing ───────────────────────────────────────────────────────────
+BINARY=""
+FORCE_BUILD=0
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --binary) BINARY="$2"; shift 2 ;;
+        --build)  FORCE_BUILD=1; shift ;;
+        --help)
+            sed -n '2,12p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+            exit 0
+            ;;
+        *) echo "Unknown option: $1" >&2; exit 1 ;;
+    esac
+done
+
+# ── Build ─────────────────────────────────────────────────────────────────────
+DEFAULT_BINARY="$REPO_ROOT/target/release/aletheia"
+
+if [[ -z "$BINARY" ]]; then
+    if [[ "$FORCE_BUILD" -eq 1 ]] || [[ ! -x "$DEFAULT_BINARY" ]]; then
+        section "Building release binary"
+        cargo build --release --manifest-path "$REPO_ROOT/Cargo.toml" --bin aletheia
+    fi
+    BINARY="$DEFAULT_BINARY"
+fi
+
+if [[ ! -x "$BINARY" ]]; then
+    echo -e "${RED}Binary not found or not executable: $BINARY${RESET}" >&2
+    echo "Run with --build to build it first." >&2
+    exit 1
+fi
+
+BINARY_VERSION=$("$BINARY" --version 2>&1 | head -1)
+echo -e "${BOLD}Aletheia smoke test${RESET}"
+echo "Binary : $BINARY"
+echo "Version: $BINARY_VERSION"
+
+# ── Tests ─────────────────────────────────────────────────────────────────────
+
+section "Top-level flags"
+check "--help exits 0 and shows usage"     0 "[Uu]sage" -- --help
+check "--version exits 0 and shows version" 0 "aletheia" -- --version
+
+section "Global help covers all subcommands"
+for sub in health backup maintenance tls status credential eval export tui \
+           migrate-memory init import seed-skills export-skills review-skills completions; do
+    check "--help mentions '$sub'" 0 "$sub" -- --help
+done
+
+section "Subcommand --help (all 16)"
+check "health --help"         0 "server" -- health --help
+check "backup --help"         0 "backup" -- backup --help
+check "maintenance --help"    0 "maintenance" -- maintenance --help
+check "maintenance status --help"   0 "" -- maintenance status --help
+check "maintenance run --help"      0 "" -- maintenance run --help
+check "tls --help"            0 "tls\|TLS\|certificate" -- tls --help
+check "tls generate --help"   0 "" -- tls generate --help
+check "status --help"         0 "status" -- status --help
+check "credential --help"     0 "credential\|Credential" -- credential --help
+check "credential status --help"  0 "" -- credential status --help
+check "credential refresh --help" 0 "" -- credential refresh --help
+check "eval --help"           0 "eval\|scenario" -- eval --help
+check "export --help"         0 "export\|agent" -- export --help
+check "tui --help"            0 "tui\|dashboard" -- tui --help
+check "migrate-memory --help" 0 "migrat\|qdrant\|Qdrant" -- migrate-memory --help
+check "init --help"           0 "init\|instance" -- init --help
+check "import --help"         0 "import\|agent" -- import --help
+check "seed-skills --help"    0 "skill" -- seed-skills --help
+check "export-skills --help"  0 "skill\|export" -- export-skills --help
+check "review-skills --help"  0 "skill\|review" -- review-skills --help
+check "completions --help"    0 "completions\|shell" -- completions --help
+
+section "Shell completions (offline)"
+check "completions bash exits 0"  0 "" -- completions bash
+check "completions bash contains aletheia"  0 "aletheia" -- completions bash
+check "completions zsh exits 0"   0 "" -- completions zsh
+check "completions fish exits 0"  0 "" -- completions fish
+
+# Verify that the bash completion output contains function/command markers
+COMP_OUTPUT=$("$BINARY" completions bash 2>&1)
+if echo "$COMP_OUTPUT" | grep -qE "^(function |_aletheia|complete )"; then
+    pass "completions bash output looks like valid bash completion"
+else
+    fail "completions bash output missing expected completion markers"
+fi
+
+section "Health (graceful failure without server)"
+check_graceful "health gracefully fails without server" \
+    "error\|connect\|refused\|unreachable\|failed" -- \
+    health --url "http://127.0.0.1:19999"
+
+section "Status (graceful failure without instance)"
+check_graceful "status gracefully fails without server" \
+    "error\|connect\|refused\|unreachable\|failed\|status" -- \
+    status --url "http://127.0.0.1:19999"
+
+section "Init (non-destructive)"
+TMPDIR_INIT=$(mktemp -d)
+trap 'rm -rf "$TMPDIR_INIT"' EXIT
+# init with --yes and a temp dir; will fail due to missing API key but should
+# print a useful error rather than panicking
+INIT_EXIT=0
+INIT_OUT=$("$BINARY" init --instance-root "$TMPDIR_INIT/instance" --yes 2>&1) || INIT_EXIT=$?
+if [[ "$INIT_EXIT" -le 1 ]]; then
+    pass "init --yes exits cleanly (exit $INIT_EXIT)"
+elif echo "$INIT_OUT" | grep -qiE "api.?key|anthropic|credential|error"; then
+    pass "init --yes fails with useful error message"
+else
+    fail "init --yes panicked or produced no useful output (exit $INIT_EXIT)"
+fi
+
+section "Import (missing file — expect error)"
+check "import with missing file exits non-zero" 1 "" -- \
+    import /nonexistent/path/to/agent.json --dry-run 2>/dev/null || true
+IMPORT_EXIT=0
+"$BINARY" import /nonexistent/file.agent.json 2>&1 | grep -qiE "no such|not found|error|cannot" \
+    && pass "import missing file produces useful error" \
+    || fail "import missing file produced no error message"
+
+section "Seed-skills (dry-run with missing dir — expect error)"
+SEED_EXIT=0
+SEED_OUT=$("$BINARY" seed-skills --dir /nonexistent/dir --nous-id test-id --dry-run 2>&1) || SEED_EXIT=$?
+if [[ "$SEED_EXIT" -ne 0 ]]; then
+    pass "seed-skills with missing dir exits non-zero"
+else
+    fail "seed-skills with missing dir should have exited non-zero"
+fi
+
+section "Unknown subcommand"
+UNKNOWN_EXIT=0
+"$BINARY" totally-unknown-subcommand 2>/dev/null || UNKNOWN_EXIT=$?
+if [[ "$UNKNOWN_EXIT" -ne 0 ]]; then
+    pass "unknown subcommand exits non-zero (exit $UNKNOWN_EXIT)"
+else
+    fail "unknown subcommand should exit non-zero"
+fi
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+TOTAL=$(( PASS + FAIL + SKIP ))
+echo ""
+echo "────────────────────────────────────"
+echo -e "${BOLD}Results${RESET}: $TOTAL tests — ${GREEN}$PASS passed${RESET}, ${RED}$FAIL failed${RESET}, ${YELLOW}$SKIP skipped${RESET}"
+
+if [[ "${#FAILURES[@]}" -gt 0 ]]; then
+    echo ""
+    echo -e "${RED}Failed tests:${RESET}"
+    for f in "${FAILURES[@]}"; do
+        echo "  • $f"
+    done
+fi
+
+echo "────────────────────────────────────"
+
+if [[ "$FAIL" -gt 0 ]]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

- **`scripts/smoke-test.sh`**: Bash script covering all 16 CLI subcommands — tests `--help` for each, shell completions (bash/zsh/fish), graceful failure without a live server, non-destructive `init`, and unknown-subcommand handling. Exits 1 on any failure, 0 if all pass.
- **`crates/aletheia/tests/smoke_test.rs`**: 36 `assert_cmd`-based integration tests mirroring the bash script. Runs in <0.1s with a pre-built binary; usable in CI with `timeout 30 cargo test -p aletheia`.
- **Binary fix**: Added `version` to the `#[command]` attribute so `aletheia --version` is now exposed.
- **Formatting**: Applied `cargo fmt` to pre-existing violations in `crates/mneme` (required for `fmt -- --check` gate).

## Test plan

- [x] `cargo fmt -- --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes (zero errors)
- [x] `timeout 30 cargo test -p aletheia` passes (36/36 in 0.06s)
- [ ] Run `./scripts/smoke-test.sh --build` manually against a release binary to verify the bash script end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)