### PR TITLE
chore: post-merge workspace hygiene audit

### DIFF
--- a/crates/aletheia/Cargo.toml
+++ b/crates/aletheia/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
+repository.workspace = true
 description = "Aletheia cognitive agent runtime"
 publish = false
 
@@ -65,8 +66,8 @@ supports-color = "3"
 [dev-dependencies]
 assert_cmd = "2"
 predicates = "3"
-tempfile = "3"
-serde_yaml = "0.9"
+tempfile = { workspace = true }
+serde_yaml = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/dianoia/Cargo.toml
+++ b/crates/dianoia/Cargo.toml
@@ -11,7 +11,7 @@ rust-version.workspace = true
 workspace = true
 
 [dependencies]
-jiff = { version = "0.2", features = ["serde"] }
+jiff = { workspace = true, features = ["serde"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 snafu = { workspace = true }
@@ -19,4 +19,4 @@ ulid = { workspace = true }
 
 [dev-dependencies]
 static_assertions = { workspace = true }
-tempfile = "3"
+tempfile = { workspace = true }

--- a/crates/eval/Cargo.toml
+++ b/crates/eval/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
+repository.workspace = true
 description = "Behavioral eval framework — scenario-based API testing against a live instance"
 publish = false
 

--- a/crates/integration-tests/Cargo.toml
+++ b/crates/integration-tests/Cargo.toml
@@ -3,6 +3,8 @@ name = "aletheia-integration-tests"
 version.workspace = true
 publish = false
 edition.workspace = true
+license.workspace = true
+repository.workspace = true
 rust-version.workspace = true
 
 [lints]
@@ -32,7 +34,7 @@ reqwest = { workspace = true }
 rustls = { workspace = true }
 secrecy = { workspace = true }
 serde_json = { workspace = true }
-tempfile = "3"
-tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
+tempfile = { workspace = true }
+tokio = { workspace = true }
 tokio-util = { workspace = true }
 tower = { workspace = true }

--- a/crates/melete/Cargo.toml
+++ b/crates/melete/Cargo.toml
@@ -20,5 +20,5 @@ tokio = { workspace = true }
 jiff = { workspace = true }
 
 [dev-dependencies]
-tokio = { version = "1", features = ["full", "test-util"] }
+tokio = { workspace = true, features = ["full", "test-util"] }
 static_assertions = { workspace = true }

--- a/crates/mneme/Cargo.toml
+++ b/crates/mneme/Cargo.toml
@@ -85,7 +85,7 @@ hf-hub = { version = "0.5", optional = true, default-features = false, features 
 
 [dev-dependencies]
 static_assertions = { workspace = true }
-tempfile = "3"
+tempfile = { workspace = true }
 proptest = { workspace = true }
 tokio = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/crates/mneme/src/engine/data/aggr.rs
+++ b/crates/mneme/src/engine/data/aggr.rs
@@ -1364,7 +1364,6 @@ impl Aggregation {
         Ok(())
     }
     pub(crate) fn normal_init(&mut self, args: &[DataValue]) -> Result<()> {
-        #[allow(clippy::box_default)]
         self.normal_op.replace(match self.name {
             name if name == AGGR_AND.name => Box::new(AggrAnd::default()),
             name if name == AGGR_OR.name => Box::new(AggrOr::default()),

--- a/crates/mneme/src/engine/fixed_rule/algos/pagerank.rs
+++ b/crates/mneme/src/engine/fixed_rule/algos/pagerank.rs
@@ -16,7 +16,10 @@ use crate::engine::runtime::temp_store::RegularTempStore;
 pub(crate) struct PageRank;
 
 impl FixedRule for PageRank {
-    #[allow(unused_variables)]
+    #[expect(
+        unused_variables,
+        reason = "poison is required by the FixedRule trait but PageRank does not poll for cancellation"
+    )]
     fn run(
         &self,
         payload: FixedRulePayload<'_, '_>,

--- a/crates/mneme/src/engine/fixed_rule/algos/random_walk.rs
+++ b/crates/mneme/src/engine/fixed_rule/algos/random_walk.rs
@@ -20,7 +20,6 @@ use crate::engine::runtime::temp_store::RegularTempStore;
 pub(crate) struct RandomWalk;
 
 impl FixedRule for RandomWalk {
-    #[allow(clippy::neg_cmp_op_on_partial_ord)]
     fn run(
         &self,
         payload: FixedRulePayload<'_, '_>,

--- a/crates/mneme/src/engine/fixed_rule/mod.rs
+++ b/crates/mneme/src/engine/fixed_rule/mod.rs
@@ -7,9 +7,8 @@ use crate::engine::error::DbResult as Result;
 #[cfg(feature = "graph-algo")]
 use crate::engine::fixed_rule::csr::{CsrBuilder, DirectedCsrGraph};
 use crate::ensure;
-#[allow(unused_imports)]
 use compact_str::CompactString;
-#[allow(unused_imports)]
+#[cfg(feature = "graph-algo")]
 use either::{Left, Right};
 use itertools::Itertools;
 use snafu::Snafu;

--- a/crates/mneme/src/engine/parse/mod.rs
+++ b/crates/mneme/src/engine/parse/mod.rs
@@ -40,29 +40,23 @@ pub(crate) type Pairs<'a> = pest::iterators::Pairs<'a, Rule>;
 /// A parsed datalog script, as returned by `parse_script`.
 #[derive(Debug)]
 pub enum DatalogScript {
-    #[allow(missing_docs)]
     Single(InputProgram),
-    #[allow(missing_docs)]
     Imperative(ImperativeProgram),
-    #[allow(missing_docs)]
     Sys(SysOp),
 }
 
-#[allow(missing_docs)]
 #[derive(Debug)]
 pub struct ImperativeStmtClause {
     pub prog: InputProgram,
     pub store_as: Option<CompactString>,
 }
 
-#[allow(missing_docs)]
 #[derive(Debug)]
 pub struct ImperativeSysop {
     pub sysop: SysOp,
     pub store_as: Option<CompactString>,
 }
 
-#[allow(missing_docs)]
 #[derive(Debug)]
 pub enum ImperativeStmt {
     Break {

--- a/crates/mneme/src/engine/parse/sys.rs
+++ b/crates/mneme/src/engine/parse/sys.rs
@@ -52,7 +52,6 @@ pub struct FtsIndexConfig {
     pub filters: Vec<TokenizerConfig>,
 }
 
-#[allow(missing_docs)]
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct MinHashLshConfig {
     pub base_relation: CompactString,

--- a/crates/mneme/src/id.rs
+++ b/crates/mneme/src/id.rs
@@ -42,6 +42,9 @@ macro_rules! define_id {
             /// Create without validation — for internal row parsing where
             /// the ID was already validated on insert.
             #[must_use]
+            // `#[expect]` cannot be used: the macro is invoked for multiple ID types; some
+            // invocations have callers (fulfilling the lint) while others don't (unfulfilled
+            // expectation). `#[allow]` applies to all invocations uniformly.
             #[allow(dead_code, reason = "used by row parsers and tests; not all ID types have production callers yet")]
             pub(crate) fn new_unchecked(id: impl Into<String>) -> Self {
                 Self(id.into())

--- a/crates/mneme/src/query.rs
+++ b/crates/mneme/src/query.rs
@@ -399,10 +399,12 @@ impl ScanBuilder {
 // ---------------------------------------------------------------------------
 
 /// Builder-generated query scripts for `KnowledgeStore` operations.
+// `#[expect]` cannot be used here: this module is only compiled with mneme-engine, so the
+// expectation would be unfulfilled in default-feature compilations that omit this module.
 #[allow(
     clippy::enum_glob_use,
     clippy::wildcard_imports,
-    // query builders use glob imports for field enum variants
+    reason = "query builders use glob imports for enum field variants"
 )]
 pub mod queries {
     use super::*;

--- a/crates/nous/Cargo.toml
+++ b/crates/nous/Cargo.toml
@@ -34,4 +34,4 @@ ulid = { workspace = true }
 [dev-dependencies]
 indexmap = { workspace = true }
 static_assertions = { workspace = true }
-tempfile = "3"
+tempfile = { workspace = true }

--- a/crates/organon/Cargo.toml
+++ b/crates/organon/Cargo.toml
@@ -31,5 +31,5 @@ seccompiler = "0.5"
 [dev-dependencies]
 rustls = { workspace = true }
 static_assertions = { workspace = true }
-tempfile = "3"
+tempfile = { workspace = true }
 tokio = { workspace = true }

--- a/crates/organon/src/builtins/filesystem.rs
+++ b/crates/organon/src/builtins/filesystem.rs
@@ -348,7 +348,6 @@ fn format_system_time(time: &SystemTime) -> String {
     }
 }
 
-#[allow(clippy::similar_names)] // doe/doy are standard names in Hinnant's date algorithm
 fn days_to_ymd(days: u64) -> (u64, u64, u64) {
     // Algorithm from http://howardhinnant.github.io/date_algorithms.html
     let z = days + 719_468;

--- a/crates/pylon/Cargo.toml
+++ b/crates/pylon/Cargo.toml
@@ -60,6 +60,6 @@ jsonwebtoken = { version = "10", features = ["rust_crypto"] }
 reqwest = { workspace = true }
 secrecy = { workspace = true }
 static_assertions = { workspace = true }
-tempfile = "3"
-tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "signal", "test-util"] }
+tempfile = { workspace = true }
+tokio = { workspace = true, features = ["test-util"] }
 tracing-subscriber = { workspace = true }

--- a/crates/taxis/Cargo.toml
+++ b/crates/taxis/Cargo.toml
@@ -21,4 +21,4 @@ tracing = { workspace = true }
 [dev-dependencies]
 figment = { workspace = true, features = ["test"] }
 proptest = { workspace = true }
-tempfile = "3"
+tempfile = { workspace = true }

--- a/crates/taxis/src/loader.rs
+++ b/crates/taxis/src/loader.rs
@@ -63,7 +63,10 @@ pub fn write_config(oikos: &Oikos, config: &AletheiaConfig) -> Result<()> {
 }
 
 #[cfg(test)]
-#[allow(clippy::result_large_err)]
+#[expect(
+    clippy::result_large_err,
+    reason = "figment::Jail closures return Box<dyn Error>; test error size doesn't matter"
+)]
 mod tests {
     use super::*;
 

--- a/crates/thesauros/Cargo.toml
+++ b/crates/thesauros/Cargo.toml
@@ -23,4 +23,4 @@ serde_yaml = { workspace = true }
 
 [dev-dependencies]
 futures = "0.3"
-tempfile = "3"
+tempfile = { workspace = true }

--- a/deny.toml
+++ b/deny.toml
@@ -124,9 +124,6 @@ skip = [
     # foldhash — 0.1 from older hashmap ecosystem, 0.2 from current; qdrant-client pulls 0.1.
     { name = "foldhash", version = "=0.1.5" },
 
-    # lru 0.14 — aletheia-mneme (HNSW remediation) pins lru 0.14; lru 0.16 is canonical.
-    { name = "lru", version = "=0.14.0" },
-
     # hashbrown — four versions coexist: 0.12 from indexmap 1.x (qdrant/tonic era),
     # 0.14 from mid-cycle deps, 0.15 from near-current; 0.16 is canonical.
     { name = "hashbrown", version = "=0.12.3" },


### PR DESCRIPTION
## Summary

- **`#[allow]` → `#[expect]`**: Converted lint suppressions to `#[expect]` with reasons where the lint fires reliably (taxis, pagerank). Removed 8 dead suppressions in mneme engine (missing_docs, box_default, neg_cmp_op_on_partial_ord) that hadn't fired in years. Feature-conditional suppressions in `query.rs` and the `define_id` macro use `#[allow(reason=)]` (Rust 1.81+) since `#[expect]` is unfulfilled across feature-split compilations.
- **Cargo.toml dedup**: Converted bare `tempfile = "3"`, `serde_yaml = "0.9"`, and inline `jiff`/`tokio` versions to `workspace = true` across 9 crates.
- **Missing package metadata**: Added `repository.workspace = true` to aletheia and eval; `license.workspace = true` + `repository.workspace = true` to integration-tests.
- **deny.toml**: Removed stale `lru = "=0.14.0"` skip entry — lru was bumped to 0.16.3 in #742, 0.14 is no longer in the dep tree.
- **cfg gate cleanup**: Gated `use either::{Left, Right}` behind `#[cfg(feature = "graph-algo")]` instead of a blanket `#[allow(unused_imports)]`.
- **cargo fmt**: Reformatted 4 engine files that had drifted from rustfmt style.

## Test plan

- [x] `cargo fmt -- --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean (zero errors, zero warnings)
- [x] `cargo test -p aletheia-mneme` — 771 tests pass
- [x] `cargo test -p aletheia-taxis -p aletheia-koina -p aletheia-dianoia -p aletheia-oikonomos -p aletheia-hermeneus -p aletheia-melete -p aletheia-nous -p aletheia-organon -p aletheia-symbolon -p aletheia-thesauros` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)