### PR TITLE
fix: deployment bugs — FK constraint, FTS sanitization, jiff types, OAuth token support

### DIFF
--- a/crates/aletheia/src/main.rs
+++ b/crates/aletheia/src/main.rs
@@ -31,7 +31,7 @@ use aletheia_agora::semeion::client::SignalClient;
 use aletheia_agora::types::ChannelProvider;
 use aletheia_hermeneus::anthropic::AnthropicProvider;
 use aletheia_hermeneus::provider::{ProviderConfig, ProviderRegistry};
-use aletheia_koina::credential::CredentialProvider;
+use aletheia_koina::credential::{CredentialProvider, CredentialSource};
 use aletheia_mneme::embedding::{EmbeddingConfig, EmbeddingProvider, create_provider};
 use aletheia_mneme::store::SessionStore;
 use aletheia_nous::config::{NousConfig, PipelineConfig};
@@ -1061,6 +1061,12 @@ fn build_provider_registry(
         }
     }
 
+    // ANTHROPIC_AUTH_TOKEN is the Claude Code OAuth convention — always treat as OAuth
+    chain.push(Box::new(EnvCredentialProvider::with_source(
+        "ANTHROPIC_AUTH_TOKEN",
+        CredentialSource::OAuth,
+    )));
+    // ANTHROPIC_API_KEY: auto-detects OAuth tokens by sk-ant-oat prefix
     chain.push(Box::new(EnvCredentialProvider::new("ANTHROPIC_API_KEY")));
 
     let credential_chain: Arc<dyn CredentialProvider> = Arc::new(CredentialChain::new(chain));

--- a/crates/aletheia/src/migrate_memory.rs
+++ b/crates/aletheia/src/migrate_memory.rs
@@ -9,7 +9,7 @@ use sha2::{Digest, Sha256};
 use tracing::info;
 
 use aletheia_mneme::embedding::{EmbeddingConfig, EmbeddingProvider, create_provider};
-use aletheia_mneme::knowledge::{EmbeddedChunk, EpistemicTier, Fact};
+use aletheia_mneme::knowledge::{EmbeddedChunk, EpistemicTier, Fact, far_future, parse_timestamp};
 use aletheia_mneme::knowledge_store::{KnowledgeConfig, KnowledgeStore};
 use aletheia_taxis::oikos::Oikos;
 use qdrant_client::Qdrant;
@@ -248,23 +248,22 @@ fn import_fact(
     embedder: &Arc<dyn EmbeddingProvider>,
 ) -> Result<()> {
     let fact_id = format!("migrated-{}", content_hash(&record.content));
-    let now = jiff::Zoned::now()
-        .strftime("%Y-%m-%dT%H:%M:%SZ")
-        .to_string();
+    let now = jiff::Timestamp::now();
+    let valid_from = parse_timestamp(&record.created_at).unwrap_or(now);
 
     let fact = Fact {
-        id: fact_id.clone(),
+        id: fact_id.clone().into(),
         nous_id: agent_id.to_owned(),
         content: record.content.clone(),
         confidence: 0.7,
         tier: EpistemicTier::Inferred,
-        valid_from: record.created_at.clone(),
-        valid_to: "9999-12-31".to_owned(),
+        valid_from,
+        valid_to: far_future(),
         superseded_by: None,
         source_session_id: None,
-        recorded_at: now.clone(),
+        recorded_at: now,
         access_count: 0,
-        last_accessed_at: String::new(),
+        last_accessed_at: None,
         stability_hours: aletheia_mneme::knowledge::default_stability_hours(""),
         fact_type: String::new(),
         is_forgotten: false,
@@ -277,7 +276,7 @@ fn import_fact(
 
     if let Ok(embedding) = embedder.embed(&record.content) {
         let chunk = EmbeddedChunk {
-            id: format!("emb-{fact_id}"),
+            id: format!("emb-{fact_id}").into(),
             content: record.content.clone(),
             source_type: "fact".to_owned(),
             source_id: fact_id,

--- a/crates/nous/src/finalize.rs
+++ b/crates/nous/src/finalize.rs
@@ -47,6 +47,12 @@ pub struct FinalizeResult {
 ///
 /// Errors from the store are propagated but callers should treat them as
 /// non-fatal — the user already has their response.
+///
+/// # Session guarantee
+///
+/// The nous actor creates sessions in memory (not in `SQLite`). Before
+/// appending messages we ensure the session record exists in the store,
+/// avoiding a FOREIGN KEY constraint violation on the `messages` table.
 #[instrument(skip_all, fields(session_id = %session.id))]
 pub fn finalize(
     store: &SessionStore,
@@ -58,6 +64,19 @@ pub fn finalize(
     let mut messages_persisted = 0usize;
 
     if config.persist_messages {
+        // Ensure session record exists before inserting child messages.
+        // The nous actor creates sessions in memory; the SQLite store may
+        // not have a matching row yet, which would cause a FOREIGN KEY
+        // constraint failure on the messages table.
+        store
+            .find_or_create_session(
+                &session.id,
+                &session.nous_id,
+                &session.session_key,
+                Some(&session.model),
+                None,
+            )
+            .context(error::StoreSnafu)?;
         // User message
         #[expect(clippy::cast_possible_wrap, reason = "message length fits in i64")]
         let input_token_estimate = input_content.len() as i64 / 4;
@@ -261,6 +280,32 @@ mod tests {
 
         let history = store.get_history("ses-1", None).expect("history");
         assert!(history.is_empty());
+    }
+
+    /// Regression test for #747: finalize must succeed even when the session
+    /// record does not yet exist in `SQLite`. The nous actor creates sessions in
+    /// memory, so the first call to finalize is responsible for ensuring the
+    /// row exists before inserting child messages (FOREIGN KEY constraint).
+    #[test]
+    fn finalize_creates_session_if_missing() {
+        let store = SessionStore::open_in_memory().expect("in-memory store");
+        // Do NOT call store.create_session — the actor wouldn't have done so.
+        let config_nous = NousConfig {
+            id: "test-nous".to_owned(),
+            model: "test-model".to_owned(),
+            ..NousConfig::default()
+        };
+        let session = SessionState::new("ses-orphan".to_owned(), "main".to_owned(), &config_nous);
+        let result = simple_result();
+        let config = FinalizeConfig::default();
+
+        // This would previously fail with FOREIGN KEY constraint error
+        finalize(&store, &session, "Hi from orphan", &result, &config).expect("finalize");
+
+        let history = store.get_history("ses-orphan", None).expect("history");
+        assert_eq!(history.len(), 2);
+        assert_eq!(history[0].role, Role::User);
+        assert_eq!(history[1].role, Role::Assistant);
     }
 
     #[test]

--- a/crates/nous/src/skills.rs
+++ b/crates/nous/src/skills.rs
@@ -17,10 +17,15 @@ const MAX_CONTEXT_CHARS: usize = 200;
 /// Extracts a concise task description from the latest user message.
 ///
 /// The result is used as the BM25 query for skill search, so brevity
-/// is preferred. Trims whitespace and truncates at a word boundary.
+/// is preferred. Trims whitespace, strips punctuation that `CozoDB` FTS
+/// cannot parse, and truncates at a word boundary.
 #[cfg(any(feature = "knowledge-store", test))]
 pub(crate) fn extract_task_context(content: &str) -> String {
-    let trimmed = content.trim();
+    let sanitized = sanitize_fts_query(content);
+    let trimmed = sanitized.trim();
+    if trimmed.is_empty() {
+        return String::new();
+    }
     if trimmed.len() <= MAX_CONTEXT_CHARS {
         return trimmed.to_owned();
     }
@@ -34,6 +39,31 @@ pub(crate) fn extract_task_context(content: &str) -> String {
     // Prefer breaking at a word boundary
     let word_end = trimmed[..end].rfind(' ').unwrap_or(end);
     trimmed[..word_end].trim_end().to_owned()
+}
+
+/// Strip characters that `CozoDB` FTS (tantivy) cannot parse.
+///
+/// Keeps alphanumeric chars, whitespace, hyphens, and underscores.
+/// Collapses runs of whitespace into a single space.
+#[cfg(any(feature = "knowledge-store", test))]
+fn sanitize_fts_query(input: &str) -> String {
+    let mut result = String::with_capacity(input.len());
+    let mut prev_space = false;
+    for ch in input.chars() {
+        if ch.is_alphanumeric() || ch == '-' || ch == '_' {
+            result.push(ch);
+            prev_space = false;
+        } else if ch.is_whitespace() && !prev_space && !result.is_empty() {
+            result.push(' ');
+            prev_space = true;
+        }
+        // Other punctuation is dropped
+    }
+    // Trim trailing space
+    if result.ends_with(' ') {
+        result.pop();
+    }
+    result
 }
 
 /// Format a [`SkillContent`] as a compact markdown section for the system prompt.
@@ -293,6 +323,34 @@ pub(crate) fn rank_skills(candidates: Vec<Fact>) -> Vec<Fact> {
 mod tests {
     use super::*;
 
+    // ── sanitize_fts_query ─────────────────────────────────────────────────
+
+    #[test]
+    fn sanitize_fts_strips_punctuation() {
+        assert_eq!(
+            sanitize_fts_query("Hello, how are you?"),
+            "Hello how are you"
+        );
+    }
+
+    #[test]
+    fn sanitize_fts_preserves_hyphens_and_underscores() {
+        assert_eq!(
+            sanitize_fts_query("rust-error_handling"),
+            "rust-error_handling"
+        );
+    }
+
+    #[test]
+    fn sanitize_fts_collapses_whitespace() {
+        assert_eq!(sanitize_fts_query("a  ,  b"), "a b");
+    }
+
+    #[test]
+    fn sanitize_fts_only_punctuation_returns_empty() {
+        assert_eq!(sanitize_fts_query("?!@#$%"), "");
+    }
+
     // ── extract_task_context ─────────────────────────────────────────────────
 
     #[test]
@@ -311,6 +369,15 @@ mod tests {
     fn extract_task_context_empty_returns_empty() {
         assert_eq!(extract_task_context(""), "");
         assert_eq!(extract_task_context("   "), "");
+    }
+
+    #[test]
+    fn extract_task_context_sanitizes_punctuation() {
+        // This was bug #746: punctuated input caused FTS parse errors
+        let ctx = extract_task_context("Hello, how are you?");
+        assert_eq!(ctx, "Hello how are you");
+        assert!(!ctx.contains(','));
+        assert!(!ctx.contains('?'));
     }
 
     #[test]

--- a/crates/symbolon/src/credential.rs
+++ b/crates/symbolon/src/credential.rs
@@ -144,9 +144,17 @@ fn default_expires_in() -> u64 {
 // EnvCredentialProvider
 // ---------------------------------------------------------------------------
 
+/// OAuth token prefix used by Claude Code for OAuth access tokens.
+const OAUTH_TOKEN_PREFIX: &str = "sk-ant-oat";
+
 /// Reads a credential from an environment variable.
+///
+/// Automatically detects OAuth tokens by the `sk-ant-oat` prefix and
+/// returns [`CredentialSource::OAuth`] so callers use `Bearer` auth.
 pub struct EnvCredentialProvider {
     var_name: String,
+    /// Force the credential source (e.g. OAuth for `ANTHROPIC_AUTH_TOKEN`).
+    force_source: Option<CredentialSource>,
 }
 
 impl EnvCredentialProvider {
@@ -154,6 +162,16 @@ impl EnvCredentialProvider {
     pub fn new(var_name: impl Into<String>) -> Self {
         Self {
             var_name: var_name.into(),
+            force_source: None,
+        }
+    }
+
+    /// Create a provider that always returns the given source type.
+    #[must_use]
+    pub fn with_source(var_name: impl Into<String>, source: CredentialSource) -> Self {
+        Self {
+            var_name: var_name.into(),
+            force_source: Some(source),
         }
     }
 }
@@ -164,10 +182,14 @@ impl CredentialProvider for EnvCredentialProvider {
             if v.is_empty() {
                 None
             } else {
-                Some(Credential {
-                    secret: v,
-                    source: CredentialSource::Environment,
-                })
+                let source = self.force_source.clone().unwrap_or_else(|| {
+                    if v.starts_with(OAUTH_TOKEN_PREFIX) {
+                        CredentialSource::OAuth
+                    } else {
+                        CredentialSource::Environment
+                    }
+                });
+                Some(Credential { secret: v, source })
             }
         })
     }
@@ -651,6 +673,42 @@ mod tests {
     fn env_provider_name() {
         let provider = EnvCredentialProvider::new("MY_VAR");
         assert_eq!(provider.name(), "MY_VAR");
+    }
+
+    #[test]
+    #[expect(unsafe_code, reason = "test-only env var manipulation")]
+    fn env_provider_detects_oauth_by_prefix() {
+        let var = "ALETHEIA_TEST_OAUTH_PREFIX_748";
+        // SAFETY: test uses unique var name, no concurrent access
+        unsafe { std::env::set_var(var, "sk-ant-oat-test-token-value") };
+        let provider = EnvCredentialProvider::new(var);
+        let cred = provider.get_credential().unwrap();
+        assert_eq!(cred.source, CredentialSource::OAuth);
+        unsafe { std::env::remove_var(var) };
+    }
+
+    #[test]
+    #[expect(unsafe_code, reason = "test-only env var manipulation")]
+    fn env_provider_api_key_stays_environment() {
+        let var = "ALETHEIA_TEST_APIKEY_748";
+        // SAFETY: test uses unique var name, no concurrent access
+        unsafe { std::env::set_var(var, "sk-ant-api-test-key") };
+        let provider = EnvCredentialProvider::new(var);
+        let cred = provider.get_credential().unwrap();
+        assert_eq!(cred.source, CredentialSource::Environment);
+        unsafe { std::env::remove_var(var) };
+    }
+
+    #[test]
+    #[expect(unsafe_code, reason = "test-only env var manipulation")]
+    fn env_provider_with_source_forces_oauth() {
+        let var = "ALETHEIA_TEST_FORCE_OAUTH_748";
+        // SAFETY: test uses unique var name, no concurrent access
+        unsafe { std::env::set_var(var, "any-token-value") };
+        let provider = EnvCredentialProvider::with_source(var, CredentialSource::OAuth);
+        let cred = provider.get_credential().unwrap();
+        assert_eq!(cred.source, CredentialSource::OAuth);
+        unsafe { std::env::remove_var(var) };
     }
 
     // --- FileCredentialProvider ---


### PR DESCRIPTION
## Summary

Fixes four bugs discovered during deployment testing:

- **#745 (migrate_memory jiff types):** `migrate_memory.rs` constructed `Fact` and `EmbeddedChunk` with `String` timestamps, but structs now use `jiff::Timestamp`. Fixed by using `parse_timestamp()`, `Timestamp::now()`, and `far_future()` sentinel. Also fixed `FactId`/`EmbeddingId` newtype usage.

- **#746 (FTS query sanitization):** `resolve_skills` passed raw user message content as a CozoDB FTS query. Punctuation like commas and question marks caused tantivy parse errors. Added `sanitize_fts_query()` that strips non-alphanumeric characters (preserving hyphens, underscores, and whitespace) before BM25 search.

- **#747 (FOREIGN KEY constraint in finalize):** The nous actor creates sessions in memory but never persisted them to SQLite. When finalize called `append_message()`, the FOREIGN KEY constraint on `messages.session_id → sessions.id` failed. Fixed by calling `find_or_create_session()` at the start of finalize to ensure the session record exists before inserting child messages.

- **#748 (ANTHROPIC_AUTH_TOKEN env var):** Added `ANTHROPIC_AUTH_TOKEN` to the credential chain with forced `CredentialSource::OAuth`. Also added automatic OAuth token detection by `sk-ant-oat` prefix in `EnvCredentialProvider`. The hermeneus client already uses `Bearer` auth + `anthropic-beta: oauth-2025-04-20` header for OAuth-sourced credentials.

Fixes #745, fixes #746, fixes #747, fixes #748

## Test plan

- [x] `cargo check --features migrate-qdrant` passes (no type errors)
- [x] `sanitize_fts_query` tests: strips punctuation, preserves hyphens/underscores, collapses whitespace
- [x] `extract_task_context_sanitizes_punctuation` test: "Hello, how are you?" → "Hello how are you"
- [x] `finalize_creates_session_if_missing` test: finalize succeeds without pre-created session
- [x] `env_provider_detects_oauth_by_prefix` test: sk-ant-oat → OAuth source
- [x] `env_provider_with_source_forces_oauth` test: ANTHROPIC_AUTH_TOKEN → OAuth
- [x] `env_provider_api_key_stays_environment` test: regular keys → Environment source
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt -- --check` clean
- [x] All existing tests pass (326 nous, 73 symbolon, all mneme)

🤖 Generated with [Claude Code](https://claude.com/claude-code)