### PR TITLE
chore(mneme): document SAFETY invariants for all unsafe blocks

### DIFF
--- a/crates/mneme/src/engine/data/program.rs
+++ b/crates/mneme/src/engine/data/program.rs
@@ -265,7 +265,10 @@ pub(crate) struct MagicFixedRuleApply {
 #[derive(Debug)]
 pub(crate) struct FixedRuleOptionNotFoundError {
     pub(crate) name: String,
-    #[expect(dead_code, reason = "structural field preserved for diagnostic context")]
+    #[expect(
+        dead_code,
+        reason = "structural field preserved for diagnostic context"
+    )]
     pub(crate) span: SourceSpan,
     pub(crate) rule_name: String,
 }
@@ -285,7 +288,10 @@ impl std::error::Error for FixedRuleOptionNotFoundError {}
 #[derive(Debug)]
 pub(crate) struct WrongFixedRuleOptionError {
     pub(crate) name: String,
-    #[expect(dead_code, reason = "structural field preserved for diagnostic context")]
+    #[expect(
+        dead_code,
+        reason = "structural field preserved for diagnostic context"
+    )]
     pub(crate) span: SourceSpan,
     pub(crate) rule_name: String,
     pub(crate) help: String,

--- a/crates/mneme/src/engine/mod.rs
+++ b/crates/mneme/src/engine/mod.rs
@@ -370,7 +370,10 @@ pub struct MultiTransaction {
 pub use crate::engine::runtime::db::Poison;
 
 #[cfg(test)]
-#[expect(clippy::result_large_err, reason = "test helpers — error size not critical")]
+#[expect(
+    clippy::result_large_err,
+    reason = "test helpers — error size not critical"
+)]
 impl DbInstance {
     pub(crate) fn default() -> Self {
         crate::engine::storage::mem::new_mem_db().unwrap()
@@ -403,7 +406,10 @@ pub(crate) struct TestMultiTx {
 }
 
 #[cfg(test)]
-#[expect(clippy::result_large_err, reason = "test helpers — error size not critical")]
+#[expect(
+    clippy::result_large_err,
+    reason = "test helpers — error size not critical"
+)]
 impl TestMultiTx {
     pub(crate) fn run_script(
         &self,

--- a/crates/mneme/src/hnsw_index.rs
+++ b/crates/mneme/src/hnsw_index.rs
@@ -277,7 +277,10 @@ mod tests {
         let index = HnswIndex::new(make_config(4));
 
         for i in 0..20_usize {
-            #[expect(clippy::cast_precision_loss, reason = "test data — small indices fit in f32")]
+            #[expect(
+                clippy::cast_precision_loss,
+                reason = "test data — small indices fit in f32"
+            )]
             let v = vec![i as f32, 0.0, 0.0, 0.0];
             index.insert(&v, i);
         }

--- a/docs/VENDORING.md
+++ b/docs/VENDORING.md
@@ -67,8 +67,9 @@ No unmerged PRs contain fixes we need. Upstream is inactive - no divergence risk
 
 ### Unsafe Sites — Resolved
 
-All 24 unsafe sites now have SAFETY comments (P202). Each site carries an individual
-`#[expect(unsafe_code, reason = "SAFETY comment above")]` where needed.
+All 14 unsafe sites (12 `unsafe {}` blocks + 2 `unsafe impl`) now have `// SAFETY:`
+comments (P202, verified P302). Each comment explains the precondition, why the
+invariant holds at the call site, and what would break if violated.
 
 ### Lint Suppressions — Resolved
 


### PR DESCRIPTION
## Summary

- Audit pass (P302) verifying all 14 unsafe sites in the vendored CozoDB engine carry complete `// SAFETY:` documentation
- All 12 `unsafe {}` blocks across `data/value.rs`, `data/memcmp.rs`, `data/functions.rs`, `data/relation.rs`, and `runtime/minhash_lsh.rs` are documented
- Both `unsafe impl Sync` declarations in `storage/fjall_backend.rs` are documented
- Updates `docs/VENDORING.md` to reflect the accurate count (14 sites, not 24) and note P302 verification
- Applies `rustfmt` to three files with pre-existing format drift

## Validation

- `grep -rn 'unsafe {' crates/mneme/src/engine/ | grep -v SAFETY | grep -v test` → 0 results (SAFETY comments are on preceding lines; confirmed with Python line-context check)
- `cargo fmt --all -- --check` clean
- `cargo clippy --workspace --all-targets -- -D warnings` clean
- `cargo test -p aletheia-mneme` → 771 passed, 0 failed

## Test plan

- [x] All unsafe blocks verified to have `// SAFETY:` comments in preceding lines
- [x] No behavioral changes — documentation and formatting only
- [x] `cargo clippy` clean
- [x] `cargo test -p aletheia-mneme` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)