### PR TITLE
fix(thesauros,hermeneus): resolve 5 async/concurrency issues (#811-#814, #877)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,6 +132,7 @@ dependencies = [
  "aletheia-koina",
  "jiff",
  "prometheus",
+ "rand 0.9.2",
  "reqwest 0.13.2",
  "rustls",
  "secrecy",
@@ -400,6 +401,7 @@ dependencies = [
  "serde_yaml",
  "snafu",
  "tempfile",
+ "tokio",
  "tracing",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,6 +130,9 @@ regex = "1"
 # String similarity
 strsim = "0.11"
 
+# Random number generation
+rand = "0.9"
+
 # Testing
 proptest = "1"
 static_assertions = "1.1"

--- a/crates/hermeneus/Cargo.toml
+++ b/crates/hermeneus/Cargo.toml
@@ -14,6 +14,7 @@ workspace = true
 aletheia-koina = { path = "../koina" }
 jiff = { workspace = true }
 prometheus = { workspace = true }
+rand = { workspace = true }
 reqwest = { workspace = true }
 rustls = { workspace = true }
 secrecy = { workspace = true }

--- a/crates/hermeneus/src/anthropic/client.rs
+++ b/crates/hermeneus/src/anthropic/client.rs
@@ -5,11 +5,12 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+use rand::Rng as _;
 use reqwest::Client;
 use reqwest::header::{HeaderMap, HeaderValue};
 use secrecy::SecretString;
 use snafu::ResultExt;
-use tracing::{info, info_span};
+use tracing::{Instrument as _, info, info_span};
 
 use std::collections::HashMap;
 
@@ -77,6 +78,7 @@ fn build_http_client() -> Result<Client> {
     let _ = rustls::crypto::ring::default_provider().install_default();
 
     Client::builder()
+        .connect_timeout(Duration::from_secs(10))
         .timeout(Duration::from_secs(120))
         .build()
         .map_err(|e| {
@@ -150,10 +152,6 @@ impl AnthropicProvider {
     ///
     /// This is an `AnthropicProvider`-specific method. The `LlmProvider`
     /// trait only exposes `complete()`.
-    #[expect(
-        clippy::too_many_lines,
-        reason = "streaming retry loop with span recording at each exit point"
-    )]
     pub async fn complete_streaming(
         &self,
         request: &CompletionRequest,
@@ -169,7 +167,20 @@ impl AnthropicProvider {
             llm.retries = tracing::field::Empty,
             llm.stream = true,
         );
-        let _guard = span.enter();
+        self.complete_streaming_inner(request, &mut on_event)
+            .instrument(span)
+            .await
+    }
+
+    #[expect(
+        clippy::too_many_lines,
+        reason = "streaming retry loop with span recording at each exit point"
+    )]
+    async fn complete_streaming_inner(
+        &self,
+        request: &CompletionRequest,
+        on_event: &mut impl FnMut(StreamEvent),
+    ) -> Result<CompletionResponse> {
         let start = Instant::now();
 
         let wire = WireRequest::from_request(request, Some(true));
@@ -215,13 +226,14 @@ impl AnthropicProvider {
                         reason = "LLM call duration fits in u64"
                     )]
                     {
-                        span.record("llm.duration_ms", start.elapsed().as_millis() as u64);
+                        tracing::Span::current()
+                            .record("llm.duration_ms", start.elapsed().as_millis() as u64);
                     }
-                    span.record("llm.retries", attempt);
+                    tracing::Span::current().record("llm.retries", attempt);
                     if status == 401 {
-                        span.record("llm.status", "auth_failed");
+                        tracing::Span::current().record("llm.status", "auth_failed");
                     } else {
-                        span.record("llm.status", "error");
+                        tracing::Span::current().record("llm.status", "error");
                     }
                     return Err(err);
                 }
@@ -260,12 +272,13 @@ impl AnthropicProvider {
                         reason = "LLM call duration fits in u64"
                     )]
                     {
-                        span.record("llm.duration_ms", start.elapsed().as_millis() as u64);
+                        tracing::Span::current()
+                            .record("llm.duration_ms", start.elapsed().as_millis() as u64);
                     }
-                    span.record("llm.tokens_in", resp.usage.input_tokens);
-                    span.record("llm.tokens_out", resp.usage.output_tokens);
-                    span.record("llm.status", "ok");
-                    span.record("llm.retries", attempt);
+                    tracing::Span::current().record("llm.tokens_in", resp.usage.input_tokens);
+                    tracing::Span::current().record("llm.tokens_out", resp.usage.output_tokens);
+                    tracing::Span::current().record("llm.status", "ok");
+                    tracing::Span::current().record("llm.retries", attempt);
                     info!(
                         model = %request.model,
                         tokens_in = resp.usage.input_tokens,
@@ -302,10 +315,11 @@ impl AnthropicProvider {
                             reason = "LLM call duration fits in u64"
                         )]
                         {
-                            span.record("llm.duration_ms", start.elapsed().as_millis() as u64);
+                            tracing::Span::current()
+                                .record("llm.duration_ms", start.elapsed().as_millis() as u64);
                         }
-                        span.record("llm.retries", attempt);
-                        span.record("llm.status", "error");
+                        tracing::Span::current().record("llm.retries", attempt);
+                        tracing::Span::current().record("llm.status", "error");
                         return Err(e);
                     }
                     // Only retry RateLimited (overloaded/429); other errors are terminal.
@@ -319,10 +333,11 @@ impl AnthropicProvider {
                         reason = "LLM call duration fits in u64"
                     )]
                     {
-                        span.record("llm.duration_ms", start.elapsed().as_millis() as u64);
+                        tracing::Span::current()
+                            .record("llm.duration_ms", start.elapsed().as_millis() as u64);
                     }
-                    span.record("llm.retries", attempt);
-                    span.record("llm.status", "error");
+                    tracing::Span::current().record("llm.retries", attempt);
+                    tracing::Span::current().record("llm.status", "error");
                     return Err(e);
                 }
             }
@@ -333,10 +348,10 @@ impl AnthropicProvider {
             reason = "LLM call duration fits in u64"
         )]
         {
-            span.record("llm.duration_ms", start.elapsed().as_millis() as u64);
+            tracing::Span::current().record("llm.duration_ms", start.elapsed().as_millis() as u64);
         }
-        span.record("llm.retries", self.max_retries);
-        span.record("llm.status", "error");
+        tracing::Span::current().record("llm.retries", self.max_retries);
+        tracing::Span::current().record("llm.status", "error");
 
         crate::metrics::record_completion("anthropic", 0, 0, 0.0, false);
 
@@ -439,10 +454,6 @@ impl AnthropicProvider {
         Ok(headers)
     }
 
-    #[expect(
-        clippy::too_many_lines,
-        reason = "retry loop with span recording at each exit point"
-    )]
     async fn execute_with_retry(&self, request: &CompletionRequest) -> Result<CompletionResponse> {
         let span = info_span!("llm_call",
             llm.provider = "anthropic",
@@ -454,7 +465,19 @@ impl AnthropicProvider {
             llm.retries = tracing::field::Empty,
             llm.stream = false,
         );
-        let _guard = span.enter();
+        self.execute_with_retry_inner(request)
+            .instrument(span)
+            .await
+    }
+
+    #[expect(
+        clippy::too_many_lines,
+        reason = "retry loop with span recording at each exit point"
+    )]
+    async fn execute_with_retry_inner(
+        &self,
+        request: &CompletionRequest,
+    ) -> Result<CompletionResponse> {
         let start = Instant::now();
 
         let wire = WireRequest::from_request(request, None);
@@ -504,12 +527,13 @@ impl AnthropicProvider {
                         reason = "LLM call duration fits in u64"
                     )]
                     {
-                        span.record("llm.duration_ms", start.elapsed().as_millis() as u64);
+                        tracing::Span::current()
+                            .record("llm.duration_ms", start.elapsed().as_millis() as u64);
                     }
-                    span.record("llm.tokens_in", resp.usage.input_tokens);
-                    span.record("llm.tokens_out", resp.usage.output_tokens);
-                    span.record("llm.status", "ok");
-                    span.record("llm.retries", attempt);
+                    tracing::Span::current().record("llm.tokens_in", resp.usage.input_tokens);
+                    tracing::Span::current().record("llm.tokens_out", resp.usage.output_tokens);
+                    tracing::Span::current().record("llm.status", "ok");
+                    tracing::Span::current().record("llm.retries", attempt);
                     info!(
                         model = %request.model,
                         tokens_in = resp.usage.input_tokens,
@@ -547,15 +571,16 @@ impl AnthropicProvider {
                     reason = "LLM call duration fits in u64"
                 )]
                 {
-                    span.record("llm.duration_ms", start.elapsed().as_millis() as u64);
+                    tracing::Span::current()
+                        .record("llm.duration_ms", start.elapsed().as_millis() as u64);
                 }
-                span.record("llm.retries", attempt);
+                tracing::Span::current().record("llm.retries", attempt);
                 if status == 401 {
-                    span.record("llm.status", "auth_failed");
+                    tracing::Span::current().record("llm.status", "auth_failed");
                 } else if status == 429 {
-                    span.record("llm.status", "rate_limited");
+                    tracing::Span::current().record("llm.status", "rate_limited");
                 } else {
-                    span.record("llm.status", "error");
+                    tracing::Span::current().record("llm.status", "error");
                 }
                 return Err(err);
             }
@@ -569,10 +594,10 @@ impl AnthropicProvider {
             reason = "LLM call duration fits in u64"
         )]
         {
-            span.record("llm.duration_ms", start.elapsed().as_millis() as u64);
+            tracing::Span::current().record("llm.duration_ms", start.elapsed().as_millis() as u64);
         }
-        span.record("llm.retries", self.max_retries);
-        span.record("llm.status", "error");
+        tracing::Span::current().record("llm.retries", self.max_retries);
+        tracing::Span::current().record("llm.status", "error");
 
         crate::metrics::record_completion("anthropic", 0, 0, 0.0, false);
 
@@ -656,10 +681,10 @@ pub(crate) fn backoff_delay(attempt: u32, last_error: Option<&error::Error>) -> 
     let base = BACKOFF_BASE_MS * BACKOFF_FACTOR.pow(attempt.saturating_sub(1));
     let capped = base.min(BACKOFF_MAX_MS);
 
-    // ±25% jitter via integer math: range = capped / 4
+    // ±25% random jitter: prevents thundering herd under concurrent load
     let jitter_range = capped / 4;
     let delay = if jitter_range > 0 {
-        let offset = (u64::from(attempt) * 7 + 13) % (jitter_range * 2);
+        let offset = rand::rng().random_range(0..jitter_range * 2);
         capped - jitter_range + offset
     } else {
         capped

--- a/crates/thesauros/Cargo.toml
+++ b/crates/thesauros/Cargo.toml
@@ -18,6 +18,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
 snafu = { workspace = true }
+tokio = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]

--- a/crates/thesauros/src/tools.rs
+++ b/crates/thesauros/src/tools.rs
@@ -62,7 +62,7 @@ impl ToolExecutor for ShellToolExecutor {
                         }
                         Err(e) if e.raw_os_error() == Some(26) && attempt < 3 => {
                             // ETXTBSY — brief backoff (1ms, 5ms, 25ms)
-                            std::thread::sleep(Duration::from_millis(1 << (2 * attempt)));
+                            tokio::time::sleep(Duration::from_millis(1 << (2 * attempt))).await;
                             last_err = Some(e);
                         }
                         Err(e) => {
@@ -91,16 +91,21 @@ impl ToolExecutor for ShellToolExecutor {
             }
 
             // Wait in a background thread to avoid blocking the async runtime,
-            // then enforce timeout from this side via channel.
-            let (tx, rx) = std::sync::mpsc::channel();
+            // then enforce timeout from this async side via oneshot + tokio timeout.
+            let (tx, rx) = tokio::sync::oneshot::channel();
             std::thread::spawn(move || {
                 let result = child.wait_with_output();
                 let _ = tx.send(result);
             });
 
-            let output_result = match rx.recv_timeout(timeout) {
-                Ok(Ok(o)) => o,
-                Ok(Err(e)) => return Ok(ToolResult::error(format!("wait failed: {e}"))),
+            let output_result = match tokio::time::timeout(timeout, rx).await {
+                Ok(Ok(Ok(o))) => o,
+                Ok(Ok(Err(e))) => return Ok(ToolResult::error(format!("wait failed: {e}"))),
+                Ok(Err(_)) => {
+                    return Ok(ToolResult::error(
+                        "wait channel closed unexpectedly".to_owned(),
+                    ));
+                }
                 Err(_) => {
                     return Ok(ToolResult::error(format!(
                         "command timed out after {}ms",
@@ -517,8 +522,8 @@ mod tests {
         assert!(registry.definitions().is_empty());
     }
 
-    #[test]
-    fn shell_executor_runs_script() {
+    #[tokio::test]
+    async fn shell_executor_runs_script() {
         let dir = setup_pack_dir(&[("tools/echo.sh", "#!/bin/sh\ncat")]);
         make_executable(&dir, "tools/echo.sh");
 
@@ -544,7 +549,7 @@ mod tests {
             )),
         };
 
-        let result = futures::executor::block_on(executor.execute(&input, &ctx)).unwrap();
+        let result = executor.execute(&input, &ctx).await.unwrap();
         assert!(
             !result.is_error,
             "unexpected error: {}",
@@ -553,8 +558,8 @@ mod tests {
         assert!(result.content.text_summary().contains("hello"));
     }
 
-    #[test]
-    fn shell_executor_nonzero_exit_is_error() {
+    #[tokio::test]
+    async fn shell_executor_nonzero_exit_is_error() {
         let dir = setup_pack_dir(&[("tools/fail.sh", "#!/bin/sh\nexit 1")]);
         make_executable(&dir, "tools/fail.sh");
 
@@ -580,7 +585,7 @@ mod tests {
             )),
         };
 
-        let result = futures::executor::block_on(executor.execute(&input, &ctx)).unwrap();
+        let result = executor.execute(&input, &ctx).await.unwrap();
         assert!(result.is_error);
     }
 


### PR DESCRIPTION
## Summary

- **#811** (`thesauros`): `std::sync::mpsc::recv_timeout()` in `ShellToolExecutor::execute` blocks a Tokio thread while waiting for child output. Replaced with `tokio::sync::oneshot` + `tokio::time::timeout().await`.
- **#814** (`thesauros`): `std::thread::sleep()` in the ETXTBSY retry loop holds a runtime thread hostage. Replaced with `tokio::time::sleep().await`.
- **#877** (`hermeneus`): `span.enter()` guards in `complete_streaming` and `execute_with_retry` were held across `.await` points, corrupting the tracing subscriber's span stack. Split each into a thin wrapper that attaches the span via `.instrument(span)` and an `_inner` method containing the retry body; `span.record()` → `tracing::Span::current().record()` throughout.
- **#812** (`hermeneus`): The reqwest `Client` builder had no `connect_timeout`, so a DNS/TCP hang would block for the full 120s request timeout. Added `connect_timeout(10s)`.
- **#813** (`hermeneus`): Backoff jitter used a deterministic formula `(attempt * 7 + 13) % range`, producing identical delays for concurrent requests at the same retry count. Replaced with `rand::rng().random_range(0..range)`.

Shell executor tests updated from `futures::executor::block_on` to `#[tokio::test]` + `.await` since they now drive Tokio-native APIs.

## Observations (out of scope — not investigated)

- **Debt** `crates/thesauros/src/tools.rs:96` — `std::thread::spawn` for child process waiting is fine but could be replaced with `tokio::process::Command` entirely, which would eliminate the oneshot channel indirection. Not touched as it's beyond the fix scope.
- **Missing test** `crates/hermeneus/src/anthropic/client.rs` — `complete_streaming` has no unit test exercising the retry path; only `execute_with_retry` (non-streaming) is covered by wiremock tests.

## Test plan

- [x] `cargo clippy -p aletheia-thesauros -p aletheia-hermeneus --all-targets -- -D warnings` — zero warnings
- [x] `cargo test -p aletheia-thesauros -p aletheia-hermeneus` — 187 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)