### PR TITLE
sec(pylon): sanitize HTTP error responses (#827, #844-#847)

### DIFF
--- a/crates/pylon/src/error.rs
+++ b/crates/pylon/src/error.rs
@@ -135,10 +135,20 @@ impl IntoResponse for ApiError {
             None
         };
 
+        // For 5xx errors: log full internal details (request_id is in the active span) and
+        // return a generic message so internal paths, SQL, panic text, and provider details
+        // are never exposed to clients. (#827, #846, #847)
+        let client_message = if status.is_server_error() {
+            tracing::error!(error = %self, "internal server error");
+            "An internal error occurred".to_owned()
+        } else {
+            self.to_string()
+        };
+
         let body = ErrorResponse {
             error: ErrorBody {
                 code: code.to_owned(),
-                message: self.to_string(),
+                message: client_message,
                 details,
             },
         };
@@ -329,5 +339,92 @@ mod tests {
     #[test]
     fn api_error_is_send_sync() {
         static_assertions::assert_impl_all!(ApiError: Send, Sync);
+    }
+
+    // --- Sanitization tests (#827, #846, #847) ---
+
+    /// Helper: extract the `message` field from an `ErrorResponse` JSON body.
+    fn body_message(response: Response) -> String {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let body = rt
+            .block_on(axum::body::to_bytes(response.into_body(), 64 * 1024))
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        json["error"]["message"].as_str().unwrap().to_owned()
+    }
+
+    #[test]
+    fn internal_error_returns_generic_message() {
+        let err = ApiError::Internal {
+            message: "SELECT * FROM users; file: /etc/passwd".to_owned(),
+            location: snafu::Location::default(),
+        };
+        let response = err.into_response();
+        assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        let msg = body_message(response);
+        assert_eq!(msg, "An internal error occurred");
+        assert!(!msg.contains("SELECT"));
+        assert!(!msg.contains("/etc/passwd"));
+    }
+
+    #[test]
+    fn service_unavailable_returns_generic_message() {
+        let err = ApiError::ServiceUnavailable {
+            message: "provider auth failed: Anthropic API key is invalid".to_owned(),
+            location: snafu::Location::default(),
+        };
+        let response = err.into_response();
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+        let msg = body_message(response);
+        assert_eq!(msg, "An internal error occurred");
+        assert!(!msg.contains("Anthropic"));
+        assert!(!msg.contains("invalid"));
+    }
+
+    #[tokio::test]
+    async fn join_error_returns_generic_message() {
+        // JoinError converts to Internal, which must be sanitized.
+        let join_err = tokio::spawn(async { panic!("database connection string leaked") })
+            .await
+            .unwrap_err();
+        let api_err = ApiError::from(join_err);
+        let response = api_err.into_response();
+        assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        let bytes = axum::body::to_bytes(response.into_body(), 64 * 1024)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        let msg = json["error"]["message"].as_str().unwrap();
+        assert_eq!(msg, "An internal error occurred");
+        assert!(!msg.contains("database connection string"));
+    }
+
+    #[test]
+    fn auth_failed_does_not_leak_provider_details() {
+        let hermeneus_err = aletheia_hermeneus::error::Error::AuthFailed {
+            message: "Anthropic returned 401: x-api-key header is invalid".to_owned(),
+            location: snafu::Location::default(),
+        };
+        let api_err = ApiError::from(hermeneus_err);
+        let response = api_err.into_response();
+        // Maps to ServiceUnavailable (503) — must be sanitized.
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+        let msg = body_message(response);
+        assert_eq!(msg, "An internal error occurred");
+        assert!(!msg.contains("Anthropic"));
+        assert!(!msg.contains("x-api-key"));
+    }
+
+    #[test]
+    fn bad_request_message_is_preserved() {
+        // 4xx messages are user-facing and must NOT be sanitized.
+        let err = ApiError::BadRequest {
+            message: "content must not be empty".to_owned(),
+            location: snafu::Location::default(),
+        };
+        let response = err.into_response();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let msg = body_message(response);
+        assert!(msg.contains("content must not be empty"));
     }
 }

--- a/crates/pylon/src/handlers/config.rs
+++ b/crates/pylon/src/handlers/config.rs
@@ -140,11 +140,16 @@ pub async fn update_section(
         deep_merge(existing, body);
     }
 
-    // Deserialize back to verify structural validity
+    // Deserialize back to verify structural validity.
+    // Log serde details internally; the error message exposed to the client must not
+    // include field paths or internal type names from the serde error. (#845)
     let new_config: aletheia_taxis::config::AletheiaConfig =
-        serde_json::from_value(config_value).map_err(|e| ApiError::ValidationFailed {
-            errors: vec![format!("invalid config structure: {e}")],
-            location: snafu::Location::default(),
+        serde_json::from_value(config_value).map_err(|e| {
+            tracing::error!(error = %e, section = %section, "config deserialization failed after merge");
+            ApiError::ValidationFailed {
+                errors: vec!["Invalid configuration format".to_owned()],
+                location: snafu::Location::default(),
+            }
         })?;
 
     // Persist to disk

--- a/crates/pylon/src/handlers/sessions/streaming.rs
+++ b/crates/pylon/src/handlers/sessions/streaming.rs
@@ -142,11 +142,13 @@ pub async fn send_message(
                     }
                 }
                 Err(err) => {
-                    warn!(error = %err, "turn failed");
+                    // Log full error internally; the active span carries request_id and
+                    // session/nous context. Never forward internal details to the client. (#844)
+                    tracing::error!(error = %err, "turn failed");
                     let _ = tx
                         .send(SseEvent::Error {
                             code: "turn_failed".to_owned(),
-                            message: err.to_string(),
+                            message: "An internal error occurred".to_owned(),
                         })
                         .await;
                     // Always send a completion marker so the client knows the
@@ -338,11 +340,12 @@ pub async fn stream_turn(
                     }
                 }
                 Err(err) => {
-                    warn!(error = %err, "streaming turn failed");
+                    // Log full error internally; span carries session/nous context. (#844)
+                    tracing::error!(error = %err, "streaming turn failed");
                     let _ = bridge_handle.await;
                     let _ = webchat_tx
                         .send(WebchatEvent::Error {
-                            message: err.to_string(),
+                            message: "An internal error occurred".to_owned(),
                         })
                         .await;
                     // Always send a completion marker so the TUI knows the stream


### PR DESCRIPTION
## Summary

- **#827** — `Internal` (500) and `ServiceUnavailable` (503) responses now return `"An internal error occurred"` instead of the full snafu chain, which could contain file paths, SQL queries, and stack traces. Full details logged at ERROR level via the active tracing span (carries `request_id`).
- **#844** — SSE `Error` events in `send_message` and `stream_turn` now emit a generic message instead of `err.to_string()`. The full error is logged at ERROR level within the turn span (has session/nous context).
- **#845** — Config `update_section` no longer includes serde field paths in the 422 response. The raw serde error is logged with the section name; the client receives `"Invalid configuration format"`.
- **#846** — `JoinError` (which may contain panic messages) converts to `Internal`, which is sanitized at the `IntoResponse` boundary.
- **#847** — `AuthFailed` from hermeneus converts to `ServiceUnavailable` with the provider message in the internal field; this is sanitized to `"An internal error occurred"` before sending to the client.

All error responses already include `request_id` via the existing `enrich_error_response` middleware.

## Test plan

- [x] `internal_error_returns_generic_message` — SQL and file paths do not appear in 500 response body
- [x] `service_unavailable_returns_generic_message` — provider details do not appear in 503 body
- [x] `join_error_returns_generic_message` — panic message stripped from JoinError → 500
- [x] `auth_failed_does_not_leak_provider_details` — Anthropic key error stripped from 503
- [x] `bad_request_message_is_preserved` — 4xx messages are user-facing and unchanged
- [x] All 178 existing pylon tests pass
- [x] `cargo clippy -p aletheia-pylon --all-targets -- -D warnings` zero warnings

## Observations

- **Debt** — `crates/diaporeia/` has pre-existing unformatted code that `cargo fmt --all` reformats. Unrelated to this PR, but worth a chore ticket.
- **Idea** — `PipelineTimeout` (503) currently exposes the stage name and timeout duration. These are not sensitive, but if the policy tightens to "no implementation detail in 5xx", they'd need a custom `details` field in the response.

🤖 Generated with [Claude Code](https://claude.com/claude-code)