### PR TITLE
sec(pylon,taxis): rate limiting, localhost default, Signal DM hardening (#852, #853, #854)

### DIFF
--- a/crates/aletheia/src/commands/server.rs
+++ b/crates/aletheia/src/commands/server.rs
@@ -459,6 +459,7 @@ pub async fn run(args: Args) -> Result<()> {
     let bind_host = args.bind.as_deref().unwrap_or(&config.gateway.bind);
     let bind_addr_str = match bind_host {
         "lan" => "0.0.0.0",
+        "localhost" => "127.0.0.1",
         other => other,
     };
 

--- a/crates/diaporeia/src/resources/config.rs
+++ b/crates/diaporeia/src/resources/config.rs
@@ -1,6 +1,8 @@
 //! Configuration resources.
 
-use rmcp::model::{RawResourceTemplate, ReadResourceRequestParams, ResourceContents, ResourceTemplate};
+use rmcp::model::{
+    RawResourceTemplate, ReadResourceRequestParams, ResourceContents, ResourceTemplate,
+};
 
 use crate::state::DiaporeiaState;
 

--- a/crates/diaporeia/src/resources/nous.rs
+++ b/crates/diaporeia/src/resources/nous.rs
@@ -2,15 +2,29 @@
 //!
 //! Exposes agent workspace files (SOUL.md, IDENTITY.md, etc.) as MCP resources.
 
-use rmcp::model::{RawResourceTemplate, ReadResourceRequestParams, ResourceContents, ResourceTemplate};
+use rmcp::model::{
+    RawResourceTemplate, ReadResourceRequestParams, ResourceContents, ResourceTemplate,
+};
 
 use crate::state::DiaporeiaState;
 
 /// Workspace files exposed as resources.
 const WORKSPACE_FILES: &[(&str, &str, &str)] = &[
-    ("soul", "Nous SOUL", "Character and principles for a nous agent"),
-    ("identity", "Nous Identity", "Name and emoji identity for a nous agent"),
-    ("memory", "Nous Memory", "Persistent knowledge for a nous agent"),
+    (
+        "soul",
+        "Nous SOUL",
+        "Character and principles for a nous agent",
+    ),
+    (
+        "identity",
+        "Nous Identity",
+        "Name and emoji identity for a nous agent",
+    ),
+    (
+        "memory",
+        "Nous Memory",
+        "Persistent knowledge for a nous agent",
+    ),
     ("goals", "Nous Goals", "Active goals for a nous agent"),
     ("tools", "Nous Tools", "Tool inventory for a nous agent"),
 ];
@@ -20,12 +34,10 @@ pub(crate) fn resource_templates() -> Vec<ResourceTemplate> {
     WORKSPACE_FILES
         .iter()
         .map(|(slug, name, desc)| {
-            let raw = RawResourceTemplate::new(
-                format!("aletheia://nous/{{nous_id}}/{slug}"),
-                *name,
-            )
-            .with_description(*desc)
-            .with_mime_type("text/markdown");
+            let raw =
+                RawResourceTemplate::new(format!("aletheia://nous/{{nous_id}}/{slug}"), *name)
+                    .with_description(*desc)
+                    .with_mime_type("text/markdown");
             ResourceTemplate {
                 raw,
                 annotations: None,

--- a/crates/diaporeia/src/tools/mod.rs
+++ b/crates/diaporeia/src/tools/mod.rs
@@ -43,7 +43,9 @@ impl DiaporeiaServer {
         }))
         .map_err(|e| rmcp::ErrorData::internal_error(e.to_string(), None))?;
 
-        Ok(CallToolResult::success(vec![rmcp::model::Content::text(json)]))
+        Ok(CallToolResult::success(vec![rmcp::model::Content::text(
+            json,
+        )]))
     }
 
     /// List sessions, optionally filtered by nous agent ID.
@@ -75,7 +77,9 @@ impl DiaporeiaServer {
         let json = serde_json::to_string_pretty(&summaries)
             .map_err(|e| rmcp::ErrorData::internal_error(e.to_string(), None))?;
 
-        Ok(CallToolResult::success(vec![rmcp::model::Content::text(json)]))
+        Ok(CallToolResult::success(vec![rmcp::model::Content::text(
+            json,
+        )]))
     }
 
     /// Send a message to a nous agent session and get the response.
@@ -131,7 +135,9 @@ impl DiaporeiaServer {
         let json = serde_json::to_string_pretty(&history)
             .map_err(|e| rmcp::ErrorData::internal_error(e.to_string(), None))?;
 
-        Ok(CallToolResult::success(vec![rmcp::model::Content::text(json)]))
+        Ok(CallToolResult::success(vec![rmcp::model::Content::text(
+            json,
+        )]))
     }
 
     // -- Nous tools --
@@ -158,7 +164,9 @@ impl DiaporeiaServer {
         let json = serde_json::to_string_pretty(&list)
             .map_err(|e| rmcp::ErrorData::internal_error(e.to_string(), None))?;
 
-        Ok(CallToolResult::success(vec![rmcp::model::Content::text(json)]))
+        Ok(CallToolResult::success(vec![rmcp::model::Content::text(
+            json,
+        )]))
     }
 
     /// Get detailed status of a specific nous agent.
@@ -193,7 +201,9 @@ impl DiaporeiaServer {
         }))
         .map_err(|e| rmcp::ErrorData::internal_error(e.to_string(), None))?;
 
-        Ok(CallToolResult::success(vec![rmcp::model::Content::text(json)]))
+        Ok(CallToolResult::success(vec![rmcp::model::Content::text(
+            json,
+        )]))
     }
 
     /// List tools available to nous agents.
@@ -202,16 +212,16 @@ impl DiaporeiaServer {
         &self,
         Parameters(params): Parameters<params::NousIdParam>,
     ) -> Result<CallToolResult, rmcp::ErrorData> {
-        let _handle =
-            self.state
-                .nous_manager
-                .get(&params.nous_id)
-                .ok_or_else(|| {
-                    rmcp::ErrorData::internal_error(
-                        format!("nous agent not found: {}", params.nous_id),
-                        None,
-                    )
-                })?;
+        let _handle = self
+            .state
+            .nous_manager
+            .get(&params.nous_id)
+            .ok_or_else(|| {
+                rmcp::ErrorData::internal_error(
+                    format!("nous agent not found: {}", params.nous_id),
+                    None,
+                )
+            })?;
 
         let defs = self.state.tool_registry.definitions();
         let tools: Vec<serde_json::Value> = defs
@@ -228,7 +238,9 @@ impl DiaporeiaServer {
         let json = serde_json::to_string_pretty(&tools)
             .map_err(|e| rmcp::ErrorData::internal_error(e.to_string(), None))?;
 
-        Ok(CallToolResult::success(vec![rmcp::model::Content::text(json)]))
+        Ok(CallToolResult::success(vec![rmcp::model::Content::text(
+            json,
+        )]))
     }
 
     // -- Knowledge tools --
@@ -276,7 +288,9 @@ impl DiaporeiaServer {
         let json = serde_json::to_string_pretty(&redacted)
             .map_err(|e| rmcp::ErrorData::internal_error(e.to_string(), None))?;
 
-        Ok(CallToolResult::success(vec![rmcp::model::Content::text(json)]))
+        Ok(CallToolResult::success(vec![rmcp::model::Content::text(
+            json,
+        )]))
     }
 
     // -- System tools --
@@ -312,6 +326,8 @@ impl DiaporeiaServer {
         let json = serde_json::to_string_pretty(&result)
             .map_err(|e| rmcp::ErrorData::internal_error(e.to_string(), None))?;
 
-        Ok(CallToolResult::success(vec![rmcp::model::Content::text(json)]))
+        Ok(CallToolResult::success(vec![rmcp::model::Content::text(
+            json,
+        )]))
     }
 }

--- a/crates/diaporeia/src/tools/params.rs
+++ b/crates/diaporeia/src/tools/params.rs
@@ -56,7 +56,10 @@ pub(crate) struct NousIdParam {
 
 /// Parameters for knowledge search.
 #[derive(Debug, Deserialize, JsonSchema)]
-#[expect(dead_code, reason = "fields used for JSON Schema generation; tool is a Phase 1 stub")]
+#[expect(
+    dead_code,
+    reason = "fields used for JSON Schema generation; tool is a Phase 1 stub"
+)]
 pub(crate) struct KnowledgeSearchParams {
     /// The search query text.
     pub query: String,

--- a/crates/diaporeia/src/transport.rs
+++ b/crates/diaporeia/src/transport.rs
@@ -2,9 +2,9 @@
 
 use std::sync::Arc;
 
+use rmcp::ServiceExt;
 use rmcp::transport::streamable_http_server::session::local::LocalSessionManager;
 use rmcp::transport::streamable_http_server::tower::StreamableHttpService;
-use rmcp::ServiceExt;
 
 use crate::error::{self, Result};
 use crate::server::DiaporeiaServer;
@@ -34,12 +34,19 @@ pub async fn serve_stdio(state: Arc<DiaporeiaState>) -> Result<()> {
     let service = server
         .serve(rmcp::transport::io::stdio())
         .await
-        .map_err(|e| error::TransportSnafu { message: e.to_string() }.into_error(snafu::NoneError))?;
+        .map_err(|e| {
+            error::TransportSnafu {
+                message: e.to_string(),
+            }
+            .into_error(snafu::NoneError)
+        })?;
 
-    service
-        .waiting()
-        .await
-        .map_err(|e| error::TransportSnafu { message: e.to_string() }.into_error(snafu::NoneError))?;
+    service.waiting().await.map_err(|e| {
+        error::TransportSnafu {
+            message: e.to_string(),
+        }
+        .into_error(snafu::NoneError)
+    })?;
 
     Ok(())
 }

--- a/crates/pylon/src/middleware.rs
+++ b/crates/pylon/src/middleware.rs
@@ -1,5 +1,9 @@
 //! Custom middleware layers for pylon.
 
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
 use axum::body::Body;
 use axum::extract::Request;
 use axum::http::{Method, StatusCode};
@@ -129,4 +133,115 @@ pub async fn record_http_metrics(request: Request, next: Next) -> Response {
     crate::metrics::record_request(&method, &path, status, duration);
 
     response
+}
+
+/// Per-IP sliding-window rate limiter.
+///
+/// Each IP gets a fixed window of `window` duration. The window resets when
+/// expired. Uses `std::sync::Mutex` (not tokio) — the critical section is
+/// short and contains no `.await` points.
+pub struct RateLimiter {
+    max_requests: u32,
+    window: Duration,
+    state: Mutex<HashMap<String, (Instant, u32)>>,
+}
+
+impl RateLimiter {
+    pub fn new(requests_per_minute: u32) -> Self {
+        Self {
+            max_requests: requests_per_minute,
+            window: Duration::from_secs(60),
+            state: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Check whether the given client key is within the rate limit.
+    ///
+    /// Returns `None` if the request is allowed, or `Some(retry_after_secs)`
+    /// if the limit has been exceeded.
+    pub fn check(&self, client: &str) -> Option<u64> {
+        let now = Instant::now();
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+
+        if let Some((window_start, count)) = state.get_mut(client) {
+            if now.duration_since(*window_start) >= self.window {
+                // Window expired — start a new one.
+                *window_start = now;
+                *count = 1;
+                None
+            } else if *count >= self.max_requests {
+                let elapsed = now.duration_since(*window_start);
+                let remaining = self.window.saturating_sub(elapsed);
+                Some(remaining.as_secs() + 1)
+            } else {
+                *count += 1;
+                None
+            }
+        } else {
+            state.insert(client.to_owned(), (now, 1));
+            None
+        }
+    }
+}
+
+/// Extract the best available client identifier from request headers.
+///
+/// Checks `X-Forwarded-For` (reverse proxy) then `X-Real-IP`, falling back
+/// to `"127.0.0.1"` for direct connections.
+fn extract_client_key(request: &Request) -> String {
+    if let Some(xff) = request.headers().get("x-forwarded-for") {
+        if let Ok(s) = xff.to_str() {
+            let ip = s.split(',').next().unwrap_or("").trim();
+            if !ip.is_empty() {
+                return ip.to_owned();
+            }
+        }
+    }
+    if let Some(xri) = request.headers().get("x-real-ip") {
+        if let Ok(s) = xri.to_str() {
+            let ip = s.trim();
+            if !ip.is_empty() {
+                return ip.to_owned();
+            }
+        }
+    }
+    "127.0.0.1".to_owned()
+}
+
+/// Middleware that enforces per-IP rate limiting.
+///
+/// Reads the `Arc<RateLimiter>` from request extensions (installed by
+/// `build_router`). Returns 429 Too Many Requests with a `Retry-After` header
+/// when the client has exceeded the configured limit.
+pub async fn rate_limit(request: Request, next: Next) -> Response {
+    let limiter = request.extensions().get::<Arc<RateLimiter>>().cloned();
+    let Some(limiter) = limiter else {
+        return next.run(request).await;
+    };
+
+    let client = extract_client_key(&request);
+    if let Some(retry_after) = limiter.check(&client) {
+        let mut response = (
+            StatusCode::TOO_MANY_REQUESTS,
+            axum::Json(serde_json::json!({
+                "error": {
+                    "code": "rate_limit_exceeded",
+                    "message": "too many requests — retry after the indicated number of seconds",
+                    "retry_after": retry_after
+                }
+            })),
+        )
+            .into_response();
+        if let Ok(value) = axum::http::HeaderValue::from_str(&retry_after.to_string()) {
+            response
+                .headers_mut()
+                .insert(axum::http::header::RETRY_AFTER, value);
+        }
+        return response;
+    }
+
+    next.run(request).await
 }

--- a/crates/pylon/src/router.rs
+++ b/crates/pylon/src/router.rs
@@ -17,8 +17,8 @@ use tracing::info_span;
 use crate::error::ApiError;
 use crate::handlers::{config, health, knowledge, metrics, nous, sessions};
 use crate::middleware::{
-    CsrfState, RequestId, enrich_error_response, inject_request_id, record_http_metrics,
-    require_csrf_header,
+    CsrfState, RateLimiter, RequestId, enrich_error_response, inject_request_id, rate_limit,
+    record_http_metrics, require_csrf_header,
 };
 use crate::openapi;
 use crate::security::SecurityConfig;
@@ -80,6 +80,14 @@ pub fn build_router(state: Arc<AppState>, security: &SecurityConfig) -> Router {
         .route("/metrics", get(metrics::expose));
 
     router = router.fallback(fallback_handler);
+
+    // Rate limiting — per-IP sliding window, applied before business logic
+    if security.rate_limit_enabled {
+        let limiter = Arc::new(RateLimiter::new(security.rate_limit_requests_per_minute));
+        router = router
+            .layer(axum::middleware::from_fn(rate_limit))
+            .layer(axum::Extension(limiter));
+    }
 
     // CSRF protection — inject state and apply middleware
     if security.csrf_enabled {

--- a/crates/pylon/src/security.rs
+++ b/crates/pylon/src/security.rs
@@ -25,6 +25,10 @@ pub struct SecurityConfig {
     pub tls_cert_path: Option<PathBuf>,
     /// Path to PEM private key file.
     pub tls_key_path: Option<PathBuf>,
+    /// Whether per-IP rate limiting is active.
+    pub rate_limit_enabled: bool,
+    /// Maximum requests per minute per client IP.
+    pub rate_limit_requests_per_minute: u32,
 }
 
 impl SecurityConfig {
@@ -41,6 +45,8 @@ impl SecurityConfig {
             tls_enabled: gateway.tls.enabled,
             tls_cert_path: gateway.tls.cert_path.as_ref().map(PathBuf::from),
             tls_key_path: gateway.tls.key_path.as_ref().map(PathBuf::from),
+            rate_limit_enabled: gateway.rate_limit.enabled,
+            rate_limit_requests_per_minute: gateway.rate_limit.requests_per_minute,
         }
     }
 }
@@ -57,6 +63,8 @@ impl Default for SecurityConfig {
             tls_enabled: false,
             tls_cert_path: None,
             tls_key_path: None,
+            rate_limit_enabled: false,
+            rate_limit_requests_per_minute: 60,
         }
     }
 }

--- a/crates/taxis/src/config.rs
+++ b/crates/taxis/src/config.rs
@@ -226,7 +226,7 @@ pub struct NousDefinition {
 pub struct GatewayConfig {
     /// TCP port the gateway listens on.
     pub port: u16,
-    /// Bind mode: `"lan"` for LAN-accessible, `"localhost"` for loopback only.
+    /// Bind mode: `"localhost"` for loopback only, `"lan"` for all interfaces.
     pub bind: String,
     /// Authentication configuration.
     pub auth: GatewayAuthConfig,
@@ -238,18 +238,21 @@ pub struct GatewayConfig {
     pub body_limit: BodyLimitConfig,
     /// CSRF protection settings.
     pub csrf: CsrfConfig,
+    /// Rate limiting settings.
+    pub rate_limit: RateLimitConfig,
 }
 
 impl Default for GatewayConfig {
     fn default() -> Self {
         Self {
             port: 18789,
-            bind: "lan".to_owned(),
+            bind: "localhost".to_owned(),
             auth: GatewayAuthConfig::default(),
             tls: TlsConfig::default(),
             cors: CorsConfig::default(),
             body_limit: BodyLimitConfig::default(),
             csrf: CsrfConfig::default(),
+            rate_limit: RateLimitConfig::default(),
         }
     }
 }
@@ -348,6 +351,26 @@ impl Default for CsrfConfig {
     }
 }
 
+/// Rate limiting configuration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[serde(default)]
+pub struct RateLimitConfig {
+    /// Whether rate limiting is active.
+    pub enabled: bool,
+    /// Maximum requests per minute per client IP.
+    pub requests_per_minute: u32,
+}
+
+impl Default for RateLimitConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            requests_per_minute: 60,
+        }
+    }
+}
+
 /// Embedding provider configuration for recall pipeline.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -423,7 +446,7 @@ pub struct SignalAccountConfig {
     pub cli_path: Option<String>,
     /// Whether to auto-start signal-cli when the daemon starts.
     pub auto_start: bool,
-    /// Direct message policy: `"open"` accepts all, `"allowlist"` restricts.
+    /// Direct message policy: `"contacts"` (known contacts only), `"open"` (anyone), `"allowlist"` restricts.
     pub dm_policy: String,
     /// Group message policy: `"open"` or `"allowlist"`.
     pub group_policy: String,
@@ -445,7 +468,7 @@ impl Default for SignalAccountConfig {
             http_port: 8080,
             cli_path: None,
             auto_start: true,
-            dm_policy: "open".to_owned(),
+            dm_policy: "contacts".to_owned(),
             group_policy: "allowlist".to_owned(),
             require_mention: true,
             send_read_receipts: true,

--- a/crates/taxis/src/config_tests.rs
+++ b/crates/taxis/src/config_tests.rs
@@ -14,7 +14,7 @@ fn defaults_are_sensible() {
     assert_eq!(config.agents.defaults.max_tool_iterations, 50);
     assert_eq!(config.agents.defaults.tool_timeouts.default_ms, 120_000);
     assert_eq!(config.gateway.port, 18789);
-    assert_eq!(config.gateway.bind, "lan");
+    assert_eq!(config.gateway.bind, "localhost");
     assert_eq!(config.gateway.auth.mode, "token");
     // Security config defaults
     assert!(!config.gateway.tls.enabled);
@@ -25,6 +25,8 @@ fn defaults_are_sensible() {
     assert!(config.gateway.csrf.enabled);
     assert_eq!(config.gateway.csrf.header_name, "x-requested-with");
     assert_eq!(config.gateway.csrf.header_value, "aletheia");
+    assert!(!config.gateway.rate_limit.enabled);
+    assert_eq!(config.gateway.rate_limit.requests_per_minute, 60);
     assert!(config.channels.signal.enabled);
     assert!(config.channels.signal.accounts.is_empty());
     assert!(config.bindings.is_empty());
@@ -168,7 +170,7 @@ fn signal_account_defaults() {
     assert_eq!(account.http_host, "localhost");
     assert_eq!(account.http_port, 8080);
     assert!(account.auto_start);
-    assert_eq!(account.dm_policy, "open");
+    assert_eq!(account.dm_policy, "contacts");
     assert_eq!(account.group_policy, "allowlist");
     assert!(account.require_mention);
     assert!(account.send_read_receipts);

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -108,7 +108,7 @@ HTTP gateway serving the API.
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `port` | u16 | `18789` | Listen port |
-| `bind` | string | `"lan"` | Bind mode: `"lan"`, `"localhost"`, `"auto"`, or a custom address |
+| `bind` | string | `"localhost"` | Bind mode: `"localhost"` (loopback only), `"lan"` (all interfaces), or a custom address |
 | `auth.mode` | string | `"token"` | Auth mode: `"token"` (bearer) or `"none"` |
 
 ### gateway.tls
@@ -140,10 +140,23 @@ HTTP gateway serving the API.
 | `header_name` | string | `"x-requested-with"` | Required header name |
 | `header_value` | string | `"aletheia"` | Required header value |
 
+### gateway.rate_limit
+
+Per-IP rate limiting for API endpoints. Requests that exceed the limit receive
+`429 Too Many Requests` with a `Retry-After` header indicating when to retry.
+
+The client IP is read from `X-Forwarded-For` or `X-Real-IP` (reverse proxy)
+and falls back to `127.0.0.1` for direct connections.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `enabled` | bool | `false` | Whether rate limiting is active |
+| `requestsPerMinute` | u32 | `60` | Maximum requests per minute per client IP |
+
 ```yaml
 gateway:
   port: 18789
-  bind: lan
+  bind: localhost
   auth:
     mode: token
   tls:
@@ -181,7 +194,7 @@ gateway:
 | `http_port` | u16 | `8080` | signal-cli JSON-RPC port |
 | `cli_path` | string | -- | Path to signal-cli binary (auto-detected if unset) |
 | `auto_start` | bool | `true` | Auto-start receive loop |
-| `dm_policy` | string | `"open"` | DM access: `"open"`, `"allowlist"` |
+| `dm_policy` | string | `"contacts"` | DM access: `"contacts"` (known contacts only), `"open"` (anyone), `"allowlist"` |
 | `group_policy` | string | `"allowlist"` | Group access: `"open"`, `"allowlist"` |
 | `require_mention` | bool | `true` | Require @mention in groups |
 | `send_read_receipts` | bool | `true` | Send read receipts |
@@ -196,7 +209,7 @@ channels:
         account: "+15551234567"
         http_host: localhost
         http_port: 8080
-        dm_policy: open
+        dm_policy: contacts
         group_policy: allowlist
         require_mention: true
 ```


### PR DESCRIPTION
## Summary

- **#852 — Rate limiting**: Added per-IP sliding-window rate limiter middleware to pylon. Returns `429 Too Many Requests` with `Retry-After` header when limit is exceeded. Configurable via `gateway.rate_limit.enabled` / `gateway.rate_limit.requestsPerMinute` (default: disabled, 60 req/min). Client IP extracted from `X-Forwarded-For` / `X-Real-IP`; falls back to `127.0.0.1` for direct connections. No new dependencies — implemented with `std::sync::Mutex<HashMap>`.

- **#853 — Default bind address**: Changed `gateway.bind` default from `"lan"` (`0.0.0.0`, all interfaces) to `"localhost"` (`127.0.0.1`). This is a single-user system; LAN/public access requires explicit opt-in. Also normalised `"localhost" → "127.0.0.1"` in `commands/server.rs` (was missing, unlike `server.rs`).

- **#854 — Signal DM policy**: Changed `dm_policy` default from `"open"` (accepts DMs from anyone) to `"contacts"` (only known contacts). Documented in CONFIGURATION.md.

## Blast radius

- `crates/pylon/src/middleware.rs` — `RateLimiter` struct + `rate_limit` middleware
- `crates/pylon/src/router.rs` — wires rate limit layer
- `crates/pylon/src/security.rs` — two new fields: `rate_limit_enabled`, `rate_limit_requests_per_minute`
- `crates/taxis/src/config.rs` — `RateLimitConfig` struct, added to `GatewayConfig`; `bind` default; `dm_policy` default
- `crates/taxis/src/config_tests.rs` — updated assertions for new defaults
- `crates/aletheia/src/commands/server.rs` — `"localhost" => "127.0.0.1"` mapping
- `docs/CONFIGURATION.md` — updated defaults, added `gateway.rate_limit` section
- `crates/diaporeia/` — `cargo fmt` reformatting only (long import lines)

## Observations (out of scope)

- **Debt** `crates/aletheia/src/server.rs:390` — Duplicate bind-resolution logic exists in both `server.rs` and `commands/server.rs`. They were inconsistent before this PR. Both are now aligned, but the duplication is worth removing in a follow-up.
- **Idea** `crates/pylon/src/middleware.rs` — The `RateLimiter` map is unbounded (no eviction). For long-running servers with many unique client IPs (e.g., behind a proxy with spoofed X-Forwarded-For), memory could grow. A periodic cleanup task or LRU cap would be appropriate.
- **Missing test** `crates/pylon/src/tests.rs` — No test covers the 429 path. A test that sends `requests_per_minute + 1` requests to a router built with rate limiting enabled would be a good addition.

## Test plan

- [x] `cargo test -p aletheia-pylon -p aletheia-taxis` — 82 tests pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — zero warnings
- [x] `cargo fmt --all` — applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)