### PR TITLE
docs: accuracy sweep — 14 issues across 8 files (P319)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,13 +5,8 @@
 ANTHROPIC_API_KEY=
 ALETHEIA_ROOT=/path/to/aletheia
 
-# Memory system
+# Embedding (optional — candle uses local models, no API key needed)
 VOYAGE_API_KEY=
-NEO4J_URL=neo4j://localhost:7687
-NEO4J_USER=neo4j
-NEO4J_PASSWORD=
-QDRANT_HOST=localhost
-QDRANT_PORT=6333
 
 # Optional — shared/bin tools
 BRAVE_API_KEY=

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,12 +62,11 @@ Tools live in `crates/organon/`. Each tool implements the `ToolExecutor` trait:
 
 ```rust
 pub trait ToolExecutor: Send + Sync {
-    fn definition(&self) -> &ToolDefinition;
-    fn execute(
-        &self,
-        input: serde_json::Value,
-        context: &ToolContext,
-    ) -> Result<String, ToolError>;
+    fn execute<'a>(
+        &'a self,
+        input: &'a ToolInput,
+        ctx: &'a ToolContext,
+    ) -> Pin<Box<dyn Future<Output = Result<ToolResult>> + Send + 'a>>;
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Not a chatbot framework. A distributed cognition system.
 
 ## Architecture
 
-Rust workspace with 16 crates. Single binary deployment.
+Rust workspace with 17 crates. Single binary deployment.
 
 ```text
      TUI / HTTP API              Signal Messenger

--- a/crates/agora/Cargo.toml
+++ b/crates/agora/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aletheia-agora"
 version.workspace = true
-description = "Channel registry and provider implementations (Signal, Slack)"
+description = "Channel registry and provider implementations (Signal)"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -119,7 +119,7 @@ Application crates in `crates/`, plus the `integration-tests` support crate.
 | `symbolon` | JWT tokens, password hashing, RBAC policies | koina |
 | `melete` | Context distillation, compression strategies, token budget management | koina, hermeneus |
 | `agora` | Channel registry, ChannelProvider trait, Signal JSON-RPC client | koina, taxis |
-| `oikonomos` | Background task scheduling, cron jobs, lifecycle events | koina |
+| `daemon` | Background task scheduling, cron jobs, lifecycle events | koina |
 | `dianoia` | Multi-phase planning orchestrator, project context tracking | koina |
 | `thesauros` | Domain pack loader - external knowledge, tools, config overlays | koina, organon |
 | `nous` | Agent pipeline, NousActor (tokio), bootstrap, recall, execute, finalize | koina, taxis, mneme, hermeneus, organon, melete, thesauros |
@@ -127,13 +127,13 @@ Application crates in `crates/`, plus the `integration-tests` support crate.
 | `diaporeia` | MCP server interface for external AI agents — `crates/diaporeia` | koina, taxis, nous, organon, mneme, symbolon |
 | `theatron-core` | Shared presentation types and traits for Aletheia UIs — `crates/theatron/core/` | nothing (leaf) |
 | `theatron-tui` | Terminal dashboard — `crates/theatron/tui/` | theatron-core, reqwest (standalone UI client) |
-| `aletheia` | Binary entrypoint (Clap CLI) - wires all crates together | taxis, hermeneus, organon, mneme, nous, symbolon, pylon, agora, thesauros, oikonomos, dianoia, theatron-tui (optional) |
+| `aletheia` | Binary entrypoint (Clap CLI) - wires all crates together | taxis, hermeneus, organon, mneme, nous, symbolon, pylon, agora, thesauros, daemon, dianoia, theatron-tui (optional) |
 
 **Support crates** (not part of the application dependency graph):
 
 | Crate | Domain | Depends On |
 |-------|--------|------------|
-| `dokimion` | Behavioral eval framework — HTTP scenario runner | nothing (leaf) |
+| `eval` | Behavioral eval framework — HTTP scenario runner | nothing (leaf) |
 | `integration-tests` | Cross-crate integration test suite | koina, taxis, mneme, hermeneus, nous, organon, pylon, symbolon, thesauros |
 
 ### Dependency Graph
@@ -155,10 +155,10 @@ Application crates in `crates/`, plus the `integration-tests` support crate.
 **Layer rules:**
 - **Leaf** (no workspace deps): `koina`
 - **Low** (koina only): `taxis`, `hermeneus`, `symbolon`, `mneme` (includes vendored CozoDB engine behind feature gate)
-- **Mid**: `melete` (koina + hermeneus), `organon` (koina + hermeneus), `agora` (koina + taxis), `oikonomos` (koina), `dianoia` (koina), `thesauros` (koina + organon)
+- **Mid**: `melete` (koina + hermeneus), `organon` (koina + hermeneus), `agora` (koina + taxis), `daemon` (koina), `dianoia` (koina), `thesauros` (koina + organon)
 - **High**: `nous` (multiple mid+low deps), `pylon` (multiple deps including nous), `diaporeia` (MCP server, multiple deps including nous)
 - **Top**: `aletheia` binary, `tui` (terminal dashboard)
-- **Support**: `dokimion` (eval), `integration-tests`
+- **Support**: `eval`, `integration-tests`
 
 Imports flow downward only. Lower-layer crates must not depend on higher layers.
 
@@ -194,14 +194,16 @@ Imports flow downward only. Lower-layer crates must not depend on higher layers.
 ## Release Profile
 
 ```toml
-[profile.release]
-strip = true
-lto = "thin"
-opt-level = "z"    # size-optimized — single static binary
-codegen-units = 1
+[profile.dev]
+opt-level = 1
 
 [profile.dev.package."*"]
 opt-level = 2      # optimize deps in dev — faster iteration
+
+[profile.release]
+lto = "thin"
+codegen-units = 1
+strip = "symbols"
 ```
 
 ---
@@ -212,6 +214,7 @@ opt-level = 2      # optimize deps in dev — faster iteration
 - **symbolon depends only on koina** (plus external crates: reqwest, rusqlite, jsonwebtoken).
 - **CozoDB engine is vendored** inside `mneme/src/engine/`, gated behind the `mneme-engine` feature.
 - **Trait boundaries are extension points.** `EmbeddingProvider`, `ChannelProvider`, `LlmProvider` - implement the trait, swap the provider.
-- **oikonomos depends only on koina** - lightweight scheduling, not a high-layer crate. No other application crate imports it.
+- **daemon depends only on koina** - lightweight scheduling, not a high-layer crate. No other application crate imports it.
 - **dianoia depends only on koina** - planning context decoupled from the agent pipeline. No other application crate imports it.
 - **thesauros loads domain packs** - knowledge, tools, config overlays bundled as portable extensions. Depends on koina + organon.
+- **nous requires a multi-thread Tokio runtime** (`rt-multi-thread`). The actor model and spawn-based timeout machinery depend on multiple OS threads. Single-thread runtime will deadlock.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -23,6 +23,7 @@ Later layers override earlier ones. All field names use `snake_case` in YAML; `c
 - [maintenance](#maintenance)
 - [pricing](#pricing)
 - [packs](#packs)
+- [sandbox](#sandbox)
 
 ---
 
@@ -46,6 +47,13 @@ Contains `defaults` (inherited by all agents) and `list` (per-agent definitions)
 | `max_tool_iterations` | u32 | `50` | Safety limit on consecutive tool use per turn |
 | `allowed_roots` | string[] | `[]` | Filesystem paths the agent may access |
 | `tool_timeouts` | object | see below | Per-tool execution timeout overrides |
+
+#### agents.defaults.caching
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `enabled` | bool | `true` | Whether prompt caching is active |
+| `strategy` | string | `"auto"` | Caching strategy: `"auto"` (cache system prompt and large context blocks) or `"disabled"` |
 
 #### agents.defaults.tool_timeouts
 
@@ -319,6 +327,12 @@ Background maintenance tasks. All run automatically when the server is running, 
 |-------|------|---------|-------------|
 | `enabled` | bool | `false` | Whether automatic retention enforcement runs |
 
+### maintenance.knowledge_maintenance_enabled
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `knowledge_maintenance_enabled` | bool | `false` | Whether background knowledge graph maintenance tasks run (entity deduplication, edge pruning, embedding refresh) |
+
 ```yaml
 maintenance:
   trace_rotation:
@@ -365,6 +379,28 @@ Array of filesystem paths to external domain packs. Each path should be a direct
 packs:
   - /srv/aletheia/packs/engineering
   - /srv/aletheia/packs/research
+```
+
+---
+
+## sandbox
+
+Filesystem sandbox applied to tool execution. When enabled, tools are restricted to the paths explicitly listed in `agents.*.allowed_roots` plus any extra paths declared here.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `enabled` | bool | `false` | Whether sandbox restrictions are applied |
+| `enforcement` | string | `"enforcing"` | `"enforcing"` blocks violations; `"permissive"` logs them without blocking |
+| `extra_read_paths` | string[] | `[]` | Additional filesystem paths granted read access to all tools |
+| `extra_write_paths` | string[] | `[]` | Additional filesystem paths granted read+write access to all tools |
+
+```yaml
+sandbox:
+  enabled: true
+  enforcement: enforcing
+  extra_read_paths:
+    - /usr/share/doc
+  extra_write_paths: []
 ```
 
 ---

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -25,7 +25,7 @@ Step-by-step guide from bare Linux or macOS to a running Aletheia instance. For 
 
 ### Software
 
-- No runtime dependencies beyond glibc (Linux). The binary is statically linked.
+- Links dynamically against glibc only (Linux). No other runtime dependencies.
 - **Build from source:** Rust 1.85+ (edition 2024), Cargo
 - **Optional:** signal-cli for Signal messaging channel
 
@@ -66,6 +66,16 @@ cargo build --release
 ```
 
 Binary: `target/release/aletheia`
+
+### Headless Build (no TUI)
+
+The TUI (terminal dashboard) is compiled in by default. To build without it — useful for servers, containers, or minimal footprints — disable the `tui` feature:
+
+```bash
+cargo build --release --no-default-features --features tls
+```
+
+The headless binary accepts all the same CLI flags and API endpoints. The `aletheia status` command falls back to a plain-text summary when TUI is absent.
 
 ### Shell Completions
 
@@ -238,7 +248,7 @@ The startup sequence:
 |------|---------|-------------|
 | `-r, --instance-root` | auto-discover | Path to instance directory |
 | `-l, --log-level` | `info` | Log level (trace, debug, info, warn, error) |
-| `--bind` | `127.0.0.1` | Bind address |
+| `--bind` | `localhost` | Bind address |
 | `-p, --port` | `18789` | Listen port |
 | `--json-logs` | off | Emit JSON-structured logs |
 

--- a/docs/STANDARDS.md
+++ b/docs/STANDARDS.md
@@ -75,6 +75,18 @@ Doc comments (rustdoc `///`, JSDoc `/** */`) only on:
 - Functions that can panic (mandatory `# Panics` section)
 - Functions returning `Result` with non-obvious error conditions
 
+Structured inline comment categories (use the prefix exactly as shown):
+
+| Prefix | When to use |
+|--------|-------------|
+| `// SAFETY:` | Precedes every `unsafe` block — explains why it is sound |
+| `// INVARIANT:` | Documents a maintained invariant at a call site or type definition |
+| `// NOTE:` | Non-obvious context that does not fit the surrounding code's logic |
+| `// TODO(#NNN):` | Known gap, must reference a tracking issue number |
+| `// FIXME(#NNN):` | Temporary workaround pending a fix, must reference an issue |
+
+No bare `// TODO` or `// FIXME` without an issue number — they become invisible debt.
+
 ### Testing (Universal)
 
 Behavior over implementation:
@@ -317,8 +329,10 @@ todo = "deny"
 unimplemented = "deny"
 exit = "deny"
 
+# Correctness: holding std::sync::Mutex across .await causes deadlocks
+await_holding_lock = "deny"
+
 # High-value warnings
-await_holding_lock = "warn"
 explicit_into_iter_loop = "warn"
 fallible_impl_from = "warn"
 fn_params_excessive_bools = "warn"
@@ -329,7 +343,7 @@ match_wildcard_for_single_variants = "warn"
 needless_for_each = "warn"
 rc_mutex = "warn"
 string_add = "warn"
-string_to_string = "warn"
+# string_to_string removed — covered by implicit_clone since clippy 1.80
 trait_duplication_in_bounds = "warn"
 unused_self = "warn"
 ```
@@ -341,9 +355,9 @@ Features are additive. Never negative names. Binary crate is the feature aggrega
 ```toml
 # Illustrative pattern — see crates/aletheia/Cargo.toml for actual binary features
 [features]
-default = ["tui", "recall"]
-recall = ["aletheia-nous/knowledge-store", "aletheia-mneme/mneme-engine", "aletheia-pylon/knowledge-store"]
-tui = ["dep:aletheia-tui"]
+default = ["tui"]
+knowledge-store = ["aletheia-nous/knowledge-store", "aletheia-mneme/mneme-engine"]
+tui = ["dep:aletheia-theatron-tui"]
 tls = ["aletheia-pylon/tls"]
 ```
 
@@ -421,6 +435,7 @@ exclude = ["aletheia-mneme-engine", "aletheia-integration-tests"]
 ignore = [
     { id = "RUSTSEC-2023-0071", reason = "rsa timing side-channel via jsonwebtoken — no safe upgrade, local-only use" },
     { id = "RUSTSEC-2025-0057", reason = "fxhash unmaintained — transitive via graph_builder, no safe upgrade" },
+    # additional entries — see deny.toml for the full list
 ]
 
 [licenses]
@@ -428,8 +443,8 @@ allow = [
     "MIT", "Apache-2.0", "AGPL-3.0-or-later",
     "BSD-2-Clause", "BSD-3-Clause", "ISC", "Zlib",
     "Unicode-3.0", "BSL-1.0", "CC0-1.0", "0BSD",
+    "MPL-2.0", "LGPL-3.0-or-later", "NCSA", "CDLA-Permissive-2.0", "OpenSSL",
 ]
-confidence-threshold = 0.8
 
 [bans]
 multiple-versions = "warn"
@@ -438,7 +453,7 @@ wildcards = "allow"
 [sources]
 unknown-registry = "deny"
 unknown-git = "deny"
-allow-git = []
+allow-git = ["https://github.com/romnn/reqwest-eventsource"]
 ```
 
 ---


### PR DESCRIPTION
Fix documentation accuracy issues found in standards audit across 8 files. Covers crate count, stale crate names, removed service references, trait signatures, config sections, and lint/deny.toml accuracy.

Closes #787, #815, #816, #818, #819, #820, #821, #823, #879, #880, #881, #884, #885, #886, #887, #888