### PR TITLE
fix(aletheia): sandbox config, credential status, auth warning, drift output (P330)

### DIFF
--- a/crates/aletheia/src/commands/credential.rs
+++ b/crates/aletheia/src/commands/credential.rs
@@ -16,6 +16,14 @@ pub enum Action {
     Refresh,
 }
 
+fn token_preview(s: &str) -> String {
+    if s.len() > 10 {
+        format!("{}...{}", &s[..10], &s[s.len() - 3..])
+    } else {
+        "***".to_owned()
+    }
+}
+
 pub async fn run(action: Action, instance_root: Option<&PathBuf>) -> Result<()> {
     let oikos = match instance_root {
         Some(root) => Oikos::from_root(root),
@@ -25,63 +33,53 @@ pub async fn run(action: Action, instance_root: Option<&PathBuf>) -> Result<()> 
 
     match action {
         Action::Status => {
-            match CredentialFile::load(&cred_path) {
-                Some(cred) => {
-                    let token_preview = if cred.token.len() > 10 {
-                        format!(
-                            "{}...{}",
-                            &cred.token[..10],
-                            &cred.token[cred.token.len() - 3..]
-                        )
+            if let Some(cred) = CredentialFile::load(&cred_path) {
+                let cred_type = if cred.has_refresh_token() {
+                    "OAuth (auto-refresh)"
+                } else {
+                    "static API key"
+                };
+                println!("Source:        file ({})", cred_path.display());
+                println!("Type:          {cred_type}");
+                println!("Token:         {}", token_preview(&cred.token));
+                if let Some(remaining) = cred.seconds_remaining() {
+                    let hours = remaining / 3600;
+                    let mins = (remaining % 3600) / 60;
+                    if remaining > 0 {
+                        println!("Expires:       {hours}h {mins}m remaining");
                     } else {
-                        "***".to_owned()
-                    };
-                    let cred_type = if cred.has_refresh_token() {
-                        "OAuth (auto-refresh)"
-                    } else {
-                        "static API key"
-                    };
-                    println!("Source:        file ({})", cred_path.display());
-                    println!("Type:          {cred_type}");
-                    println!("Token:         {token_preview}");
-                    if let Some(remaining) = cred.seconds_remaining() {
-                        let hours = remaining / 3600;
-                        let mins = (remaining % 3600) / 60;
-                        if remaining > 0 {
-                            println!("Expires:       {hours}h {mins}m remaining");
-                        } else {
-                            println!("Expires:       EXPIRED");
-                        }
-                    } else {
-                        println!("Expires:       no expiry set");
+                        println!("Expires:       EXPIRED");
                     }
-                    println!(
-                        "Refresh token: {}",
-                        if cred.has_refresh_token() {
-                            "present"
-                        } else {
-                            "absent"
-                        }
-                    );
+                } else {
+                    println!("Expires:       no expiry set");
                 }
-                None => {
-                    // Check env var fallback
-                    match std::env::var("ANTHROPIC_API_KEY") {
-                        Ok(key) if !key.is_empty() => {
-                            let preview = if key.len() > 10 {
-                                format!("{}...{}", &key[..10], &key[key.len() - 3..])
-                            } else {
-                                "***".to_owned()
-                            };
-                            println!("Source:        environment (ANTHROPIC_API_KEY)");
-                            println!("Type:          static API key");
-                            println!("Token:         {preview}");
-                        }
-                        _ => {
-                            println!("No credential found.");
-                            println!("Checked: {} (not found)", cred_path.display());
-                            println!("Checked: ANTHROPIC_API_KEY (not set)");
-                        }
+                println!(
+                    "Refresh token: {}",
+                    if cred.has_refresh_token() { "present" } else { "absent" }
+                );
+            } else {
+                // Check env var fallbacks in resolution order.
+                let auth_token =
+                    std::env::var("ANTHROPIC_AUTH_TOKEN").ok().filter(|v| !v.is_empty());
+                let api_key =
+                    std::env::var("ANTHROPIC_API_KEY").ok().filter(|v| !v.is_empty());
+
+                match (auth_token, api_key) {
+                    (Some(token), _) => {
+                        println!("Source:        environment (ANTHROPIC_AUTH_TOKEN)");
+                        println!("Type:          OAuth token");
+                        println!("Token:         {}", token_preview(&token));
+                    }
+                    (None, Some(key)) => {
+                        println!("Source:        environment (ANTHROPIC_API_KEY)");
+                        println!("Type:          static API key");
+                        println!("Token:         {}", token_preview(&key));
+                    }
+                    (None, None) => {
+                        println!("No credential found.");
+                        println!("Checked: {} (not found)", cred_path.display());
+                        println!("Checked: ANTHROPIC_AUTH_TOKEN (not set)");
+                        println!("Checked: ANTHROPIC_API_KEY (not set)");
                     }
                 }
             }

--- a/crates/aletheia/src/commands/maintenance.rs
+++ b/crates/aletheia/src/commands/maintenance.rs
@@ -22,6 +22,9 @@ pub enum Action {
     Run {
         /// Task name: trace-rotation, drift-detection, db-monitor, or all
         task: String,
+        /// List individual files (drift-detection only)
+        #[arg(long)]
+        verbose: bool,
     },
 }
 
@@ -41,7 +44,7 @@ pub fn run(action: Action, instance_root: Option<&PathBuf>) -> Result<()> {
             let statuses = runner.status();
             println!("{}", serde_json::to_string_pretty(&statuses)?);
         }
-        Action::Run { task } => {
+        Action::Run { task, verbose } => {
             let tasks: Vec<&str> = if task == "all" {
                 vec!["trace-rotation", "drift-detection", "db-monitor"]
             } else {
@@ -62,11 +65,24 @@ pub fn run(action: Action, instance_root: Option<&PathBuf>) -> Result<()> {
                         let report = DriftDetector::new(maint.drift_detection.clone())
                             .check()
                             .context("drift detection failed")?;
-                        println!(
-                            "drift-detection: {} missing, {} extra",
-                            report.missing_files.len(),
-                            report.extra_files.len()
-                        );
+                        let missing = report.missing_files.len();
+                        let extra = report.extra_files.len();
+                        if missing == 0 && extra == 0 {
+                            println!("drift-detection: clean");
+                        } else if verbose {
+                            println!("drift-detection: {missing} missing, {extra} extra");
+                            for path in &report.missing_files {
+                                println!("  missing: {}", path.display());
+                            }
+                            for path in &report.extra_files {
+                                println!("  extra:   {}", path.display());
+                            }
+                        } else {
+                            println!(
+                                "drift-detection: {missing} missing, {extra} extra  \
+                                 (use --verbose to list files)"
+                            );
+                        }
                     }
                     "db-monitor" => {
                         let report = DbMonitor::new(maint.db_monitoring.clone())

--- a/crates/aletheia/src/commands/server.rs
+++ b/crates/aletheia/src/commands/server.rs
@@ -159,7 +159,7 @@ pub async fn run(args: Args) -> Result<()> {
 
     // Build shared registries — single instances used by both NousManager and AppState
     let provider_registry = Arc::new(build_provider_registry(&config, &oikos));
-    let mut tool_registry = build_tool_registry()?;
+    let mut tool_registry = build_tool_registry(&config.sandbox)?;
 
     // Register domain pack tools alongside builtins
     let tool_errors = aletheia_thesauros::tools::register_pack_tools(&packs, &mut tool_registry);
@@ -468,7 +468,11 @@ pub async fn run(args: Args) -> Result<()> {
         other => other,
     };
 
-    // Warn if auth is disabled on a non-localhost bind address
+    // Warn unconditionally when auth is disabled — every request is granted Operator role.
+    if config.gateway.auth.mode == "none" {
+        warn!("auth mode is 'none' -- all requests granted Operator role");
+    }
+    // Additionally warn if auth is disabled on a non-localhost bind address.
     if config.gateway.auth.mode == "none"
         && bind_addr_str != "127.0.0.1"
         && bind_addr_str != "localhost"
@@ -626,9 +630,23 @@ fn build_provider_registry(
     registry
 }
 
-fn build_tool_registry() -> Result<ToolRegistry> {
+fn build_tool_registry(
+    sandbox_settings: &aletheia_taxis::config::SandboxSettings,
+) -> Result<ToolRegistry> {
     let mut registry = ToolRegistry::new();
-    builtins::register_all(&mut registry).context("failed to register builtin tools")?;
+    let sandbox = aletheia_organon::sandbox::SandboxConfig {
+        enabled: sandbox_settings.enabled,
+        enforcement: match sandbox_settings.enforcement {
+            aletheia_taxis::config::SandboxEnforcementMode::Enforcing => {
+                aletheia_organon::sandbox::SandboxEnforcement::Enforcing
+            }
+            _ => aletheia_organon::sandbox::SandboxEnforcement::Permissive,
+        },
+        extra_read_paths: sandbox_settings.extra_read_paths.clone(),
+        extra_write_paths: sandbox_settings.extra_write_paths.clone(),
+    };
+    builtins::register_all_with_sandbox(&mut registry, sandbox)
+        .context("failed to register builtin tools")?;
     info!(count = registry.definitions().len(), "tools registered");
     Ok(registry)
 }


### PR DESCRIPTION
Wire sandbox config into tool registry, fix credential status resolution order, add unconditional auth-none warning, improve drift detection output with verbose flag.

Closes #760, #761, #797, #922