### PR TITLE
feat(symbolon): Claude Code OAuth credential provider (P331)

### DIFF
--- a/crates/aletheia/src/commands/server.rs
+++ b/crates/aletheia/src/commands/server.rs
@@ -32,7 +32,7 @@ use aletheia_pylon::router::build_router;
 use aletheia_pylon::state::AppState;
 use aletheia_symbolon::credential::{
     CredentialChain, CredentialFile, EnvCredentialProvider, FileCredentialProvider,
-    RefreshingCredentialProvider,
+    RefreshingCredentialProvider, claude_code_default_path, claude_code_provider,
 };
 use aletheia_symbolon::jwt::{JwtConfig, JwtManager};
 use aletheia_taxis::config::resolve_nous;
@@ -97,6 +97,7 @@ pub async fn run(args: Args) -> Result<()> {
         "embedding",
         "channels",
         "bindings",
+        "credential",
     ] {
         if let Some(section_value) = config_value.get(section) {
             validate_section(section, section_value)
@@ -597,6 +598,30 @@ fn build_provider_registry(
     )));
     // ANTHROPIC_API_KEY: auto-detects OAuth tokens by sk-ant-oat prefix
     chain.push(Box::new(EnvCredentialProvider::new("ANTHROPIC_API_KEY")));
+
+    // Claude Code credentials file — lowest priority in the chain.
+    // Enabled when credential.source is "auto" (default) or "claude-code".
+    let cred_source = config.credential.source.as_str();
+    if matches!(cred_source, "auto" | "claude-code") {
+        let cc_path = config
+            .credential
+            .claude_code_credentials
+            .as_ref()
+            .map(PathBuf::from)
+            .or_else(claude_code_default_path);
+
+        if let Some(path) = cc_path {
+            if let Some(provider) = claude_code_provider(&path) {
+                chain.push(provider);
+            } else if cred_source == "claude-code" {
+                // Explicit claude-code source but file missing/invalid — warn loudly
+                warn!(
+                    path = %path.display(),
+                    "credential.source is \"claude-code\" but credentials file not found or invalid"
+                );
+            }
+        }
+    }
 
     let credential_chain: Arc<dyn CredentialProvider> = Arc::new(CredentialChain::new(chain));
 

--- a/crates/symbolon/src/credential.rs
+++ b/crates/symbolon/src/credential.rs
@@ -565,6 +565,51 @@ pub async fn force_refresh(path: &Path) -> Result<CredentialFile, String> {
 }
 
 // ---------------------------------------------------------------------------
+// Claude Code credential detection
+// ---------------------------------------------------------------------------
+
+/// Default path to the Claude Code credentials file.
+///
+/// Returns `~/.claude/.credentials.json`, resolving `~` via `$HOME`.
+/// Returns `None` if `$HOME` is not set.
+#[must_use]
+pub fn claude_code_default_path() -> Option<PathBuf> {
+    std::env::var_os("HOME").map(|home| {
+        PathBuf::from(home)
+            .join(".claude")
+            .join(".credentials.json")
+    })
+}
+
+/// Build a credential provider from a Claude Code credentials file.
+///
+/// If the file contains a refresh token, returns a [`RefreshingCredentialProvider`]
+/// that keeps the token fresh in the background. Otherwise returns a
+/// [`FileCredentialProvider`] for static token reads.
+///
+/// Returns `None` if the file does not exist or cannot be parsed.
+pub fn claude_code_provider(path: &Path) -> Option<Box<dyn CredentialProvider>> {
+    if !path.exists() {
+        return None;
+    }
+    let cred = CredentialFile::load(path)?;
+    if cred.has_refresh_token() {
+        if let Some(refreshing) = RefreshingCredentialProvider::new(path.to_path_buf()) {
+            info!(
+                path = %path.display(),
+                "Claude Code credentials found (OAuth auto-refresh)"
+            );
+            return Some(Box::new(refreshing));
+        }
+    }
+    info!(
+        path = %path.display(),
+        "Claude Code credentials found (static token)"
+    );
+    Some(Box::new(FileCredentialProvider::new(path.to_path_buf())))
+}
+
+// ---------------------------------------------------------------------------
 // CredentialChain
 // ---------------------------------------------------------------------------
 

--- a/crates/symbolon/src/credential_tests.rs
+++ b/crates/symbolon/src/credential_tests.rs
@@ -250,6 +250,69 @@ fn chain_empty_providers_returns_none() {
     assert!(chain.get_credential().is_none());
 }
 
+// --- claude_code_default_path ---
+
+#[test]
+fn claude_code_default_path_uses_home() {
+    // This test depends on $HOME being set, which is typical in CI and dev.
+    if let Some(path) = claude_code_default_path() {
+        assert!(path.ends_with(".claude/.credentials.json"));
+    }
+}
+
+// --- claude_code_provider ---
+
+#[test]
+fn claude_code_provider_missing_file_returns_none() {
+    let result = claude_code_provider(Path::new("/nonexistent/.credentials.json"));
+    assert!(result.is_none());
+}
+
+#[test]
+fn claude_code_provider_static_token() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join(".credentials.json");
+    let cred = CredentialFile {
+        token: "sk-ant-api-static".to_owned(),
+        refresh_token: None,
+        expires_at: None,
+        scopes: None,
+        subscription_type: None,
+    };
+    cred.save(&path).unwrap();
+
+    let provider = claude_code_provider(&path).expect("should return provider");
+    let resolved = provider.get_credential().unwrap();
+    assert_eq!(resolved.secret, "sk-ant-api-static");
+    assert_eq!(resolved.source, CredentialSource::File);
+}
+
+#[tokio::test]
+async fn claude_code_provider_with_access_token_alias() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join(".credentials.json");
+    // Write raw JSON using "accessToken" (Claude Code native format)
+    std::fs::write(
+        &path,
+        r#"{"accessToken": "sk-ant-oat-cc-token", "refreshToken": "rt-cc"}"#,
+    )
+    .unwrap();
+
+    let provider = claude_code_provider(&path).expect("should return provider");
+    let resolved = provider.get_credential().unwrap();
+    assert_eq!(resolved.secret, "sk-ant-oat-cc-token");
+    // Has refresh token → OAuth source via RefreshingCredentialProvider
+    assert_eq!(resolved.source, CredentialSource::OAuth);
+}
+
+#[test]
+fn claude_code_provider_malformed_returns_none() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join(".credentials.json");
+    std::fs::write(&path, "not valid json").unwrap();
+    assert!(claude_code_provider(&path).is_none());
+}
+
 // --- unix_epoch_ms ---
 
 #[test]

--- a/crates/taxis/src/config.rs
+++ b/crates/taxis/src/config.rs
@@ -30,6 +30,8 @@ pub struct AletheiaConfig {
     pub pricing: HashMap<String, ModelPricing>,
     /// Sandbox configuration for tool execution.
     pub sandbox: SandboxSettings,
+    /// Credential resolution configuration.
+    pub credential: CredentialConfig,
 }
 
 /// Sandbox enforcement level for tool execution.
@@ -641,6 +643,34 @@ impl Default for SandboxSettings {
             enforcement: SandboxEnforcementMode::Enforcing,
             extra_read_paths: Vec::new(),
             extra_write_paths: Vec::new(),
+        }
+    }
+}
+
+/// Credential resolution configuration.
+///
+/// Controls how the server discovers LLM API credentials. The `source` field
+/// selects the strategy:
+///
+/// - `"auto"` (default): instance credential file → env vars → Claude Code credentials
+/// - `"api-key"`: only instance credential file and env vars
+/// - `"claude-code"`: prefer Claude Code's `~/.claude/.credentials.json`
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[serde(default)]
+pub struct CredentialConfig {
+    /// Credential source strategy: `"auto"`, `"api-key"`, or `"claude-code"`.
+    pub source: String,
+    /// Override path to the Claude Code credentials file.
+    /// Defaults to `~/.claude/.credentials.json`.
+    pub claude_code_credentials: Option<String>,
+}
+
+impl Default for CredentialConfig {
+    fn default() -> Self {
+        Self {
+            source: "auto".to_owned(),
+            claude_code_credentials: None,
         }
     }
 }

--- a/crates/taxis/src/validate.rs
+++ b/crates/taxis/src/validate.rs
@@ -24,6 +24,7 @@ pub fn validate_section(section: &str, value: &Value) -> Result<(), ValidationEr
         "embedding" => validate_embedding(value, &mut errors),
         "channels" => validate_channels(value, &mut errors),
         "bindings" => validate_bindings(value, &mut errors),
+        "credential" => validate_credential(value, &mut errors),
         "packs" | "pricing" | "sandbox" => {}
         _ => errors.push(format!("unknown config section: {section}")),
     }
@@ -179,6 +180,16 @@ fn validate_bindings(value: &Value, errors: &mut Vec<String>) {
                 }
                 _ => {}
             }
+        }
+    }
+}
+
+fn validate_credential(value: &Value, errors: &mut Vec<String>) {
+    if let Some(source) = value.get("source").and_then(Value::as_str) {
+        if !matches!(source, "auto" | "api-key" | "claude-code") {
+            errors.push(format!(
+                "credential.source must be \"auto\", \"api-key\", or \"claude-code\", got \"{source}\""
+            ));
         }
     }
 }
@@ -367,5 +378,25 @@ mod tests {
             { "channel": "signal", "source": "*", "nousId": "main" }
         ]);
         assert!(validate_section("bindings", &section).is_ok());
+    }
+
+    #[test]
+    fn rejects_invalid_credential_source() {
+        let section = json!({ "source": "magic" });
+        let result = validate_section("credential", &section);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.errors[0].contains("credential.source"));
+    }
+
+    #[test]
+    fn accepts_valid_credential_sources() {
+        for source in &["auto", "api-key", "claude-code"] {
+            let section = json!({ "source": source });
+            assert!(
+                validate_section("credential", &section).is_ok(),
+                "source '{source}' should be valid"
+            );
+        }
     }
 }


### PR DESCRIPTION
Add credential provider that reads Claude Code OAuth tokens from ~/.claude/.credentials.json with auto-refresh support. New credential.source config in taxis (auto/api-key/claude-code). 5 new tests.

Closes #915