### PR TITLE
sec(aletheia,mneme): anyhow to snafu, unsafe audit, bytemuck casts (P332)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,6 +66,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "snafu",
  "supports-color",
  "tempfile",
  "theatron-tui",

--- a/crates/aletheia/Cargo.toml
+++ b/crates/aletheia/Cargo.toml
@@ -59,6 +59,7 @@ clap_complete = "4"
 qdrant-client = { version = "1", optional = true }
 sha2 = "0.10"
 anyhow = "1"
+snafu = { workspace = true }
 rcgen = { workspace = true }
 # time is a direct dep because rcgen's CertificateParams.not_before/not_after are
 # time::OffsetDateTime. rcgen already depends on time transitively, so this does

--- a/crates/aletheia/src/init.rs
+++ b/crates/aletheia/src/init.rs
@@ -2,7 +2,50 @@
 
 use std::path::{Path, PathBuf};
 
-use anyhow::{Context, Result};
+use snafu::{ResultExt, Snafu};
+
+#[derive(Debug, Snafu)]
+pub(crate) enum InitError {
+    #[snafu(display("interactive prompt failed"))]
+    Prompt {
+        source: std::io::Error,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+    #[snafu(display("ANTHROPIC_API_KEY not set"))]
+    MissingApiKey {
+        source: std::env::VarError,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+    #[snafu(display("failed to create directory {path}"))]
+    CreateDir {
+        path: String,
+        source: std::io::Error,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+    #[snafu(display("failed to write {path}"))]
+    WriteFile {
+        path: String,
+        source: std::io::Error,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+    #[snafu(display("failed to serialize credential JSON"))]
+    SerializeJson {
+        source: serde_json::Error,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+    #[snafu(display("failed to set permissions on {path}"))]
+    SetPermissions {
+        path: String,
+        source: std::io::Error,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+}
 
 /// User choices collected during the interactive (or non-interactive) flow.
 struct Answers {
@@ -31,7 +74,11 @@ impl Default for Answers {
     }
 }
 
-pub(crate) fn run(root: PathBuf, non_interactive: bool, api_key: Option<String>) -> Result<()> {
+pub(crate) fn run(
+    root: PathBuf,
+    non_interactive: bool,
+    api_key: Option<String>,
+) -> Result<(), InitError> {
     let mut answers = Answers {
         root,
         api_key,
@@ -59,9 +106,10 @@ pub(crate) fn run(root: PathBuf, non_interactive: bool, api_key: Option<String>)
         }
         let overwrite: bool = cliclack::confirm("Instance already exists. Overwrite?")
             .initial_value(false)
-            .interact()?;
+            .interact()
+            .context(PromptSnafu)?;
         if !overwrite {
-            cliclack::outro_cancel("Aborted.")?;
+            cliclack::outro_cancel("Aborted.").context(PromptSnafu)?;
             return Ok(());
         }
     }
@@ -80,18 +128,20 @@ pub(crate) fn run(root: PathBuf, non_interactive: bool, api_key: Option<String>)
              \n\
              \x1b[36m  aletheia tui\x1b[0m",
             answers.root.display()
-        ))?;
+        ))
+        .context(PromptSnafu)?;
     }
 
     Ok(())
 }
 
-fn collect_interactive(mut answers: Answers) -> Result<Answers> {
-    cliclack::intro("Aletheia Instance Setup")?;
+fn collect_interactive(mut answers: Answers) -> Result<Answers, InitError> {
+    cliclack::intro("Aletheia Instance Setup").context(PromptSnafu)?;
 
     let root: String = cliclack::input("Instance root")
         .default_input(&answers.root.display().to_string())
-        .interact()?;
+        .interact()
+        .context(PromptSnafu)?;
     answers.root = PathBuf::from(root);
 
     answers.api_key = collect_credential()?;
@@ -100,7 +150,8 @@ fn collect_interactive(mut answers: Answers) -> Result<Answers> {
         .item("claude-sonnet-4-6", "claude-sonnet-4-6 (recommended)", "")
         .item("claude-opus-4-6", "claude-opus-4-6", "")
         .item("claude-haiku-4-5", "claude-haiku-4-5", "")
-        .interact()?;
+        .interact()
+        .context(PromptSnafu)?;
     model.clone_into(&mut answers.model);
 
     let agent_id: String = cliclack::input("Agent ID")
@@ -117,41 +168,47 @@ fn collect_interactive(mut answers: Answers) -> Result<Answers> {
                 Ok(())
             }
         })
-        .interact()?;
+        .interact()
+        .context(PromptSnafu)?;
     answers.agent_id = agent_id;
 
     let default_name = capitalize(&answers.agent_id);
     let agent_name: String = cliclack::input("Agent display name")
         .default_input(&default_name)
-        .interact()?;
+        .interact()
+        .context(PromptSnafu)?;
     answers.agent_name = agent_name;
 
     let bind: &str = cliclack::select("Gateway bind")
         .item("localhost", "localhost (this machine only)", "")
         .item("lan", "lan (network/Tailscale accessible)", "")
-        .interact()?;
+        .interact()
+        .context(PromptSnafu)?;
     bind.clone_into(&mut answers.bind);
 
     let auth: &str = cliclack::select("Auth mode")
         .item("none", "none (no authentication — single user)", "")
         .item("token", "token (API key required to connect)", "")
-        .interact()?;
+        .interact()
+        .context(PromptSnafu)?;
     auth.clone_into(&mut answers.auth_mode);
 
     let tz: String = cliclack::input("Timezone")
         .default_input(&answers.timezone)
-        .interact()?;
+        .interact()
+        .context(PromptSnafu)?;
     answers.timezone = tz;
 
     Ok(answers)
 }
 
-fn collect_credential() -> Result<Option<String>> {
+fn collect_credential() -> Result<Option<String>, InitError> {
     let cred_choice: &str = cliclack::select("Anthropic API credential")
         .item("paste", "Paste API key", "")
         .item("env", "Use ANTHROPIC_API_KEY env var", "")
         .item("skip", "Skip (configure later)", "")
-        .interact()?;
+        .interact()
+        .context(PromptSnafu)?;
 
     match cred_choice {
         "paste" => {
@@ -164,18 +221,19 @@ fn collect_credential() -> Result<Option<String>> {
                         Ok(())
                     }
                 })
-                .interact()?;
+                .interact()
+                .context(PromptSnafu)?;
             Ok(Some(key))
         }
         "env" => {
-            let key = std::env::var("ANTHROPIC_API_KEY").context("ANTHROPIC_API_KEY not set")?;
+            let key = std::env::var("ANTHROPIC_API_KEY").context(MissingApiKeySnafu)?;
             Ok(Some(key))
         }
         _ => Ok(None),
     }
 }
 
-fn scaffold(answers: &Answers) -> Result<()> {
+fn scaffold(answers: &Answers) -> Result<(), InitError> {
     let root = &answers.root;
 
     // Create directories
@@ -187,22 +245,26 @@ fn scaffold(answers: &Answers) -> Result<()> {
         root.join("shared/coordination"),
     ];
     for dir in &dirs {
-        std::fs::create_dir_all(dir)
-            .with_context(|| format!("failed to create {}", dir.display()))?;
+        std::fs::create_dir_all(dir).context(CreateDirSnafu {
+            path: dir.display().to_string(),
+        })?;
     }
 
     // Write config
     let config_toml = render_config(answers);
     let config_path = root.join("config/aletheia.toml");
-    std::fs::write(&config_path, config_toml)
-        .with_context(|| format!("failed to write {}", config_path.display()))?;
+    std::fs::write(&config_path, config_toml).context(WriteFileSnafu {
+        path: config_path.display().to_string(),
+    })?;
 
     // Write credential
     if let Some(ref key) = answers.api_key {
         let cred_path = root.join("config/credentials/anthropic.json");
         let cred_json = serde_json::json!({ "token": key });
-        std::fs::write(&cred_path, serde_json::to_string_pretty(&cred_json)?)
-            .with_context(|| format!("failed to write {}", cred_path.display()))?;
+        let json_str = serde_json::to_string_pretty(&cred_json).context(SerializeJsonSnafu)?;
+        std::fs::write(&cred_path, json_str).context(WriteFileSnafu {
+            path: cred_path.display().to_string(),
+        })?;
         set_permissions(&cred_path, 0o600)?;
     }
 
@@ -216,8 +278,9 @@ fn scaffold(answers: &Answers) -> Result<()> {
         name = answers.agent_name
     );
     let soul_path = root.join(format!("nous/{}/SOUL.md", answers.agent_id));
-    std::fs::write(&soul_path, soul)
-        .with_context(|| format!("failed to write {}", soul_path.display()))?;
+    std::fs::write(&soul_path, soul).context(WriteFileSnafu {
+        path: soul_path.display().to_string(),
+    })?;
 
     Ok(())
 }
@@ -333,14 +396,17 @@ fn capitalize(s: &str) -> String {
 }
 
 #[cfg(unix)]
-fn set_permissions(path: &Path, mode: u32) -> Result<()> {
+fn set_permissions(path: &Path, mode: u32) -> Result<(), InitError> {
     use std::os::unix::fs::PermissionsExt;
-    std::fs::set_permissions(path, std::fs::Permissions::from_mode(mode))
-        .with_context(|| format!("failed to set permissions on {}", path.display()))
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(mode)).context(
+        SetPermissionsSnafu {
+            path: path.display().to_string(),
+        },
+    )
 }
 
 #[cfg(not(unix))]
-fn set_permissions(_path: &Path, _mode: u32) -> Result<()> {
+fn set_permissions(_path: &Path, _mode: u32) -> Result<(), InitError> {
     Ok(())
 }
 

--- a/crates/aletheia/src/main.rs
+++ b/crates/aletheia/src/main.rs
@@ -120,14 +120,20 @@ async fn main() -> Result<()> {
     let instance_root = cli.instance_root.as_ref();
 
     match cli.command {
-        Some(Command::Init(a)) => return init::run(a.instance_root, a.yes, a.api_key),
+        Some(Command::Init(a)) => {
+            return init::run(a.instance_root, a.yes, a.api_key).map_err(anyhow::Error::from);
+        }
         Some(Command::Health(a)) => return commands::health::run(&a).await,
         Some(Command::Backup(a)) => return commands::backup::run(instance_root, &a),
         Some(Command::Maintenance { action }) => {
             return commands::maintenance::run(action, instance_root);
         }
         Some(Command::Tls { action }) => return commands::tls::run(&action),
-        Some(Command::Status { url }) => return status::run(&url, instance_root).await,
+        Some(Command::Status { url }) => {
+            return status::run(&url, instance_root)
+                .await
+                .map_err(anyhow::Error::from);
+        }
         Some(Command::Credential { action }) => {
             return commands::credential::run(action, instance_root).await;
         }

--- a/crates/aletheia/src/status.rs
+++ b/crates/aletheia/src/status.rs
@@ -2,11 +2,29 @@
 
 use std::path::Path;
 
-use anyhow::{Context, Result};
 use owo_colors::OwoColorize;
+use snafu::{ResultExt, Snafu};
+
+#[derive(Debug, Snafu)]
+pub(crate) enum StatusError {
+    #[snafu(display("failed to connect to {endpoint}"))]
+    Connect {
+        endpoint: String,
+        source: reqwest::Error,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+    #[snafu(display("failed to parse response from {endpoint}"))]
+    ParseResponse {
+        endpoint: String,
+        source: reqwest::Error,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+}
 
 /// Run the status command against a running (or stopped) instance.
-pub async fn run(url: &str, instance_root: Option<&std::path::PathBuf>) -> Result<()> {
+pub async fn run(url: &str, instance_root: Option<&std::path::PathBuf>) -> Result<(), StatusError> {
     let use_color = supports_color::on(supports_color::Stream::Stdout).is_some();
     let version = env!("CARGO_PKG_VERSION");
 
@@ -73,16 +91,20 @@ struct NousInfo {
     session_count: usize,
 }
 
-async fn fetch_health(url: &str) -> Result<HealthResponse> {
+async fn fetch_health(url: &str) -> Result<HealthResponse, StatusError> {
     let endpoint = format!("{url}/api/health");
-    let resp = reqwest::get(&endpoint).await.context("failed to connect")?;
-    resp.json().await.context("failed to parse health response")
+    let resp = reqwest::get(&endpoint).await.context(ConnectSnafu {
+        endpoint: endpoint.clone(),
+    })?;
+    resp.json().await.context(ParseResponseSnafu { endpoint })
 }
 
-async fn fetch_nous(url: &str) -> Result<Vec<NousInfo>> {
+async fn fetch_nous(url: &str) -> Result<Vec<NousInfo>, StatusError> {
     let endpoint = format!("{url}/api/v1/nous");
-    let resp = reqwest::get(&endpoint).await.context("failed to connect")?;
-    resp.json().await.context("failed to parse nous response")
+    let resp = reqwest::get(&endpoint).await.context(ConnectSnafu {
+        endpoint: endpoint.clone(),
+    })?;
+    resp.json().await.context(ParseResponseSnafu { endpoint })
 }
 
 fn print_gateway_up(url: &str, health: &HealthResponse, color: bool) {

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -11,6 +11,7 @@ rust-version.workspace = true
 workspace = true
 
 [dependencies]
+# Required by the `cron` crate API for schedule parsing
 chrono = { workspace = true }
 cron = { workspace = true }
 flate2 = { workspace = true }

--- a/crates/mneme/src/engine/mod.rs
+++ b/crates/mneme/src/engine/mod.rs
@@ -73,7 +73,6 @@ pub(crate) mod parse;
 )]
 pub(crate) mod query;
 #[expect(
-    unsafe_code,
     private_interfaces,
     clippy::pedantic,
     clippy::mutable_key_type,

--- a/crates/mneme/src/engine/runtime/minhash_lsh.rs
+++ b/crates/mneme/src/engine/runtime/minhash_lsh.rs
@@ -353,23 +353,7 @@ impl HashPermutations {
         Self(perms)
     }
     pub(crate) fn as_bytes(&self) -> &[u8] {
-        // SAFETY: Reinterpreting Vec<u32> storage as &[u8] is sound because:
-        // (1) Alignment: align_of::<u8>() == 1 is always satisfied by any pointer,
-        //     including those from Vec<u32> (which are aligned to ≥ 4 bytes).
-        // (2) Validity: the pointer is non-null and the Vec owns `self.0.len()`
-        //     initialised u32 values; `len * size_of::<u32>()` is the exact byte
-        //     count of the live initialised data.
-        // (3) Lifetime: the returned slice borrows `self`, so it cannot outlive
-        //     the Vec — the borrow checker enforces this.
-        // (4) No aliasing: `&self` gives shared access; no exclusive reference to
-        //     the Vec storage exists for the lifetime of the returned slice.
-        // Violating these would cause UB: dangling pointer or out-of-bounds read.
-        unsafe {
-            std::slice::from_raw_parts(
-                self.0.as_ptr() as *const u8,
-                self.0.len() * std::mem::size_of::<u32>(),
-            )
-        }
+        bytemuck::cast_slice(&self.0)
     }
     // this is the inverse of `as_bytes`
     pub(crate) fn from_bytes(bytes: &[u8]) -> Result<Self> {
@@ -421,23 +405,7 @@ impl HashValues {
         matches as f32 / self.0.len() as f32
     }
     pub(crate) fn get_bytes(&self) -> &[u8] {
-        // SAFETY: Reinterpreting Vec<u32> storage as &[u8] is sound for the same
-        // reasons as `HashPermutations::as_bytes`:
-        // (1) Alignment: align_of::<u8>() == 1 is always satisfied by any pointer.
-        // (2) Validity: the pointer is non-null and the Vec owns `self.0.len()`
-        //     initialised u32 values; `len * size_of::<u32>()` is the exact byte
-        //     count of the live initialised data.
-        // (3) Lifetime: the returned slice borrows `self`, preventing it from
-        //     outliving the Vec — enforced by the borrow checker.
-        // (4) No aliasing: `&self` gives shared access; no exclusive reference to
-        //     the Vec storage exists for the lifetime of the returned slice.
-        // Violating these would cause UB: dangling pointer or out-of-bounds read.
-        unsafe {
-            std::slice::from_raw_parts(
-                self.0.as_ptr() as *const u8,
-                self.0.len() * std::mem::size_of::<u32>(),
-            )
-        }
+        bytemuck::cast_slice(&self.0)
     }
 }
 

--- a/crates/mneme/src/hnsw_index.rs
+++ b/crates/mneme/src/hnsw_index.rs
@@ -66,17 +66,39 @@ impl Default for HnswConfig {
 /// - Persistence via dump/load to disk
 /// - Arc-wrapped for shared concurrent access
 ///
-/// # Persistence lifetime
+/// # Persistence and the `'static` transmute
 ///
-/// `HnswIo` is kept alive alongside `Hnsw` because `load_hnsw` borrows the
-/// loader (for mmap support). The `_loader` field is declared before `inner`
-/// so Rust drops it *after* the `Hnsw`, guaranteeing the borrow remains valid.
+/// `hnsw_rs::HnswIo::load_hnsw` returns a `Hnsw<'_, …>` that borrows the
+/// loader. We extend that lifetime to `'static` via `mem::transmute` so the
+/// index can be stored in a `'static`-bounded field.
+///
+/// **Safety invariant:** This is sound because we do **not** use mmap. When
+/// mmap is disabled (our default), `load_hnsw` copies all point data into
+/// heap-owned `Vec`s inside the `Hnsw` struct. The loader is not accessed
+/// after `load_hnsw` returns; it is retained in `_loader` only to satisfy
+/// the type system's lifetime requirement at construction time.
+///
+/// Drop order (fields drop in declaration order): `_loader` drops before
+/// `inner`. Because the `Hnsw` owns its data and never dereferences the
+/// loader at runtime, this ordering is safe regardless of which field drops
+/// first.
+///
+/// `#[repr(C)]` pins the field layout so static offset assertions below
+/// remain accurate if the struct is ever modified.
+#[repr(C)]
 pub struct HnswIndex {
-    /// Kept alive so loaded `Hnsw` borrow remains valid. Dropped after `inner`.
+    /// Retained to satisfy the type system; not accessed after construction.
     _loader: RwLock<Option<Box<HnswIo>>>,
     inner: RwLock<Option<Hnsw<'static, f32, DistCosine>>>,
     config: HnswConfig,
 }
+
+// Compile-time assertion: `_loader` must precede `inner` in the struct layout.
+// If the field order is changed the safety argument above must be re-evaluated.
+const _: () = assert!(
+    std::mem::offset_of!(HnswIndex, _loader) < std::mem::offset_of!(HnswIndex, inner),
+    "_loader must be declared before inner; see safety comment on HnswIndex"
+);
 
 impl HnswIndex {
     /// Create a new empty HNSW index.
@@ -113,15 +135,14 @@ impl HnswIndex {
                         }
                         .build()
                     })?;
-                // SAFETY: The `HnswIo` loader is heap-allocated in a pinned `Box`
-                // and stored in `_loader`, which is declared before `inner` — so it
-                // is dropped *after* the `Hnsw`. This guarantees the loader outlives
-                // the index data. Without mmap (our default), `Hnsw` owns all point
-                // data and does not dereference the loader at runtime, but the type
-                // system requires the lifetime relationship regardless.
+                // SAFETY: Extending the `Hnsw` lifetime to `'static` is sound
+                // because mmap is not used. `load_hnsw` copies all point data into
+                // heap-owned allocations inside `Hnsw`; the loader is not accessed
+                // after this call returns. The `_loader` Box is stored in the struct
+                // to satisfy the type system — see the safety invariant on `HnswIndex`.
                 #[expect(
                     unsafe_code,
-                    reason = "lifetime extension: Box<HnswIo> stored in struct outlives Hnsw"
+                    reason = "lifetime extension: Hnsw owns its data after load (no mmap)"
                 )]
                 let hnsw: Hnsw<'static, f32, DistCosine> = unsafe { std::mem::transmute(hnsw) };
                 return Ok(Arc::new(Self {


### PR DESCRIPTION
Replace anyhow with typed snafu errors in init/status, document chrono dep, add repr(C)+offset assertion to HnswIndex, replace unsafe transmute with bytemuck in minhash_lsh.

Closes #779, #780, #801, #803