### PR TITLE
docs: update stale standards references to standards/ paths

### DIFF
--- a/crates/hermeneus/src/types_tests.rs
+++ b/crates/hermeneus/src/types_tests.rs
@@ -515,7 +515,7 @@ fn code_execution_server_tool_definition_serde() {
 
 // --- Proptest serde roundtrip tests ---
 //
-// Per project standards (docs/STANDARDS.md): every type that implements
+// Per project standards (standards/STANDARDS.md): every type that implements
 // Serialize + Deserialize gets a roundtrip property test.
 
 mod proptests {

--- a/crates/organon/src/builtins/workspace.rs
+++ b/crates/organon/src/builtins/workspace.rs
@@ -154,7 +154,7 @@ const PROTECTED_FILES: &[&str] = &[
     "TOOLS.md",
     "MEMORY.md",
     ".claude/settings.json",
-    ".claude/rules",
+    "standards",
 ];
 
 /// Check if a resolved path matches a protected file pattern.

--- a/llms.txt
+++ b/llms.txt
@@ -21,7 +21,7 @@ Rust workspace with 16 crates. TUI client.
 
 ## Standards
 
-- [STANDARDS](docs/STANDARDS.md): Coding standards
+- [STANDARDS](standards/STANDARDS.md): Coding standards
 - [CLAUDE](CLAUDE.md): AI agent workspace rules and conventions
 
 ## Agents
@@ -46,4 +46,4 @@ Rust workspace with 16 crates. TUI client.
 - `tui/`: Terminal UI client (workspace member)
 - `instance.example/nous/_template/`: Template agent workspace (SOUL.md, USER.md, AGENTS.md)
 - `instance.example/config/`: Example gateway config
-- `.claude/rules/`: Rust coding rules for AI agents
+- `standards/`: Coding standards for AI agents


### PR DESCRIPTION
## Summary

Updates stale file references left over from the `.claude/rules/` → `standards/` migration:

- **llms.txt**: `docs/STANDARDS.md` → `standards/STANDARDS.md`, `.claude/rules/` → `standards/`
- **crates/hermeneus/src/types_tests.rs**: comment reference `docs/STANDARDS.md` → `standards/STANDARDS.md`
- **crates/organon/src/builtins/workspace.rs**: protected files list `.claude/rules` → `standards`