### PR TITLE
chore(scripts): shell and CI standards compliance sweep

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
             grep -v 'instance.example/' | \
             grep -v 'node_modules/' | \
             grep -v '\.venv/' || true)
-          if [ -n "$HITS" ]; then
+          if [[ -n "$HITS" ]]; then
             echo "::error::PII patterns detected in tracked files:"
             echo "$HITS"
             exit 1

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v6
       - name: Set up Rust toolchain
         if: matrix.language == 'rust'
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4
         with:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
         with:
           components: clippy, rustfmt
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: Format
         run: cargo fmt --all -- --check

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,7 +15,7 @@ jobs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4
         id: release
         with:
           config-file: release-please-config.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,8 +14,8 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - name: Test
         run: cargo test --workspace
 
@@ -42,11 +42,11 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
         with:
           targets: ${{ matrix.target }}
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: ${{ matrix.target }}
 
@@ -88,7 +88,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: anchore/sbom-action@v0
+      - uses: anchore/sbom-action@57aae528053a48a3f6235f2d9461b05fbcb7366d # v0
         with:
           artifact-name: aletheia-sbom.spdx.json
           output-file: aletheia-sbom.spdx.json

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -29,10 +29,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
         with:
           components: clippy, rustfmt
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - name: Format
         run: cargo fmt --all -- --check
       - name: Clippy
@@ -43,8 +43,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - name: Install tool dependencies
         run: |
           # fd and ripgrep are required by organon filesystem tool tests
@@ -63,8 +63,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@1.94
-      - uses: Swatinem/rust-cache@v2
+      - uses: dtolnay/rust-toolchain@d1565eeb874f106d1696ad08faf835331133fe14 # 1.94
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - name: Check MSRV
         run: cargo check --workspace
 
@@ -74,8 +74,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - name: Check workspace with no default features
         run: cargo check --workspace --no-default-features
 
@@ -87,8 +87,8 @@ jobs:
       RUSTDOCFLAGS: "-D warnings"
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - name: Build docs
         run: cargo doc --workspace --no-deps
 
@@ -97,8 +97,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - name: Install tool dependencies
         run: |
           sudo apt-get update -qq
@@ -112,8 +112,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - name: Check migrate-qdrant feature compiles
         run: cargo check -p aletheia --features migrate-qdrant
 
@@ -122,10 +122,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
         with:
           components: llvm-tools-preview
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - name: Install cargo-llvm-cov
         run: cargo install cargo-llvm-cov --locked
       - name: Install tool dependencies

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: EmbarkStudios/cargo-deny-action@v2
+      - uses: EmbarkStudios/cargo-deny-action@3fd3802e88374d3fe9159b834c7714ec57d6c979 # v2
 
   secret-scan:
     runs-on: ubuntu-latest
@@ -38,7 +38,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: TruffleHog secret scan
-        uses: trufflesecurity/trufflehog@v3.93.7
+        uses: trufflesecurity/trufflehog@c3e599b7163e8198a55467f3133db0e7b2a492cb # v3.93.7
         with:
           extra_args: --only-verified
 
@@ -49,7 +49,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Gitleaks scan
-        uses: gitleaks/gitleaks-action@v2
+        uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITLEAKS_CONFIG: .gitleaks.toml

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -20,9 +20,9 @@ TIMESTAMP=$(date +%Y%m%d-%H%M%S)
 DRY_RUN=false
 
 for arg in "$@"; do
-  case $arg in
+  case "$arg" in
     --dry-run) DRY_RUN=true ;;
-    *) echo "Unknown option: $arg"; exit 1 ;;
+    *) echo "error: unknown option: $arg" >&2; exit 1 ;;
   esac
 done
 

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -18,20 +18,17 @@ set -euo pipefail
 # ── Colours ──────────────────────────────────────────────────────────────────
 RED='\033[0;31m'
 GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
 BOLD='\033[1m'
 RESET='\033[0m'
 
 # ── State ─────────────────────────────────────────────────────────────────────
 PASS=0
 FAIL=0
-SKIP=0
 FAILURES=()
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
 pass() { echo -e "  ${GREEN}✓${RESET} $1"; PASS=$(( PASS + 1 )); }
 fail() { echo -e "  ${RED}✗${RESET} $1"; FAIL=$(( FAIL + 1 )); FAILURES+=("$1"); }
-skip() { echo -e "  ${YELLOW}○${RESET} $1 (skipped)"; SKIP=$(( SKIP + 1 )); }
 section() { echo -e "\n${BOLD}$1${RESET}"; }
 
 # Run the binary and check the exit code and optional output pattern.
@@ -202,14 +199,15 @@ fi
 section "Import (missing file — expect error)"
 check "import with missing file exits non-zero" 1 "" -- \
     import /nonexistent/path/to/agent.json --dry-run 2>/dev/null || true
-IMPORT_EXIT=0
-"$BINARY" import /nonexistent/file.agent.json 2>&1 | grep -qiE "no such|not found|error|cannot" \
-    && pass "import missing file produces useful error" \
-    || fail "import missing file produced no error message"
+if "$BINARY" import /nonexistent/file.agent.json 2>&1 | grep -qiE "no such|not found|error|cannot"; then
+    pass "import missing file produces useful error"
+else
+    fail "import missing file produced no error message"
+fi
 
 section "Seed-skills (dry-run with missing dir — expect error)"
 SEED_EXIT=0
-SEED_OUT=$("$BINARY" seed-skills --dir /nonexistent/dir --nous-id test-id --dry-run 2>&1) || SEED_EXIT=$?
+"$BINARY" seed-skills --dir /nonexistent/dir --nous-id test-id --dry-run >/dev/null 2>&1 || SEED_EXIT=$?
 if [[ "$SEED_EXIT" -ne 0 ]]; then
     pass "seed-skills with missing dir exits non-zero"
 else
@@ -226,10 +224,10 @@ else
 fi
 
 # ── Summary ───────────────────────────────────────────────────────────────────
-TOTAL=$(( PASS + FAIL + SKIP ))
+TOTAL=$(( PASS + FAIL ))
 echo ""
 echo "────────────────────────────────────"
-echo -e "${BOLD}Results${RESET}: $TOTAL tests — ${GREEN}$PASS passed${RESET}, ${RED}$FAIL failed${RESET}, ${YELLOW}$SKIP skipped${RESET}"
+echo -e "${BOLD}Results${RESET}: $TOTAL tests — ${GREEN}$PASS passed${RESET}, ${RED}$FAIL failed${RESET}"
 
 if [[ "${#FAILURES[@]}" -gt 0 ]]; then
     echo ""


### PR DESCRIPTION
## Summary
- All shell scripts pass shellcheck with zero warnings
- Added strict mode (`set -euo pipefail`) was already present; fixed remaining violations
- Removed dead `skip()` function and `YELLOW` colour constant from `smoke-test.sh`
- Quoted `$arg` in `deploy.sh` case statement; routed unknown-option error to stderr
- Fixed `[[ ]]` bracket usage in `ci.yml` pii-scan step (was using `[ ]`)
- Pinned third-party GitHub Actions to commit SHAs across all workflows

## Pinned actions
| Action | Tag | SHA |
|--------|-----|-----|
| `dtolnay/rust-toolchain` | `stable` | `631a55b` |
| `dtolnay/rust-toolchain` | `1.94` | `d1565ee` |
| `Swatinem/rust-cache` | `v2` | `e18b497` |
| `googleapis/release-please-action` | `v4` | `16a9c90` |
| `anchore/sbom-action` | `v0` | `57aae52` |
| `EmbarkStudios/cargo-deny-action` | `v2` | `3fd3802` |
| `trufflesecurity/trufflehog` | `v3.93.7` | `c3e599b` |
| `gitleaks/gitleaks-action` | `v2` | `ff98106` |

## Test plan
- [ ] `shellcheck scripts/*.sh shared/bin/start.sh shared/hooks/_templates/loop-guard.sh` — zero warnings
- [ ] CI workflows unchanged in behavior
- [ ] `scripts/deploy.sh --dry-run` still works
- [ ] `scripts/smoke-test.sh` still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)