### PR TITLE
chore(docs): archive obsolete cutover validation document

### DIFF
--- a/docs/archive/CUTOVER_VALIDATION.md
+++ b/docs/archive/CUTOVER_VALIDATION.md
@@ -1,5 +1,9 @@
 # Cutover Validation — Rust Binary Replaces TS Runtime
 
+**STATUS: ARCHIVED** — This document describes validation work completed in early March 2026. The codebase has moved well beyond cutover (now at v0.10.1). File paths, line numbers, test counts, and specific claims are obsolete. Kept for historical reference only.
+
+---
+
 Validation report for the Rust binary taking over from the TypeScript runtime (deleted in PR #601).
 Run against commit `08ffa14` on branch `feat/cutover-validation`, 2026-03-08.
 


### PR DESCRIPTION
## Summary
- Reviewed CUTOVER_VALIDATION.md against current codebase
- Document describes validation work from early March (v0.10.0)
- Codebase now at v0.10.1 with significant changes
- File paths, line numbers, test counts, and version claims are stale
- No incoming links from other documentation

## Analysis
Assessed validity of claims in the document:
- **Valid (~20%)**: Tool registration, signal integration, distillation, bootstrap structure
- **Stale (~80%)**: Commit hash, branch, date, line numbers, test counts, version

Since <50% of the document remains accurate, archived per directive.

## Changes
- Moved `docs/CUTOVER_VALIDATION.md` → `docs/archive/CUTOVER_VALIDATION.md`
- Added "ARCHIVED" status header indicating this is historical reference only

## Acceptance Criteria
- [x] Every reference verified against codebase
- [x] Status header added (ARCHIVED)
- [x] No broken links from other docs (verified — no incoming links exist)
- [x] No Rust source files modified