### PR TITLE
fix: use ALETHEIA_ROOT in macOS LaunchAgent plist

### DIFF
--- a/instance.example/services/com.aletheia.gateway.plist
+++ b/instance.example/services/com.aletheia.gateway.plist
@@ -6,20 +6,20 @@
     <string>com.aletheia.gateway</string>
     <key>ProgramArguments</key>
     <array>
-        <string>__ALETHEIA_HOME__/target/release/aletheia</string>
+        <string>__ALETHEIA_ROOT__/target/release/aletheia</string>
     </array>
     <key>EnvironmentVariables</key>
     <dict>
-        <key>ALETHEIA_HOME</key>
-        <string>__ALETHEIA_HOME__</string>
+        <key>ALETHEIA_ROOT</key>
+        <string>__ALETHEIA_ROOT__/instance</string>
     </dict>
     <key>RunAtLoad</key>
     <true/>
     <key>KeepAlive</key>
     <true/>
     <key>StandardOutPath</key>
-    <string>__ALETHEIA_HOME__/instance/logs/gateway.log</string>
+    <string>__ALETHEIA_ROOT__/instance/logs/gateway.log</string>
     <key>StandardErrorPath</key>
-    <string>__ALETHEIA_HOME__/instance/logs/gateway.err</string>
+    <string>__ALETHEIA_ROOT__/instance/logs/gateway.err</string>
 </dict>
 </plist>


### PR DESCRIPTION
Closes #955

## Changes
- Replaced `ALETHEIA_HOME` with `ALETHEIA_ROOT` in `instance.example/services/com.aletheia.gateway.plist`
- Points `ALETHEIA_ROOT` at the instance subdirectory to match oikos discovery logic
- Aligns plist template with systemd template, `.env.example`, and all documentation

## Context
The binary reads `ALETHEIA_ROOT` (`crates/taxis/src/oikos.rs:33`). The plist template was the only file still using the old `ALETHEIA_HOME` name.