### PR TITLE
fix(tui): remove duplicate success_toast field

### DIFF
--- a/crates/theatron/tui/src/app.rs
+++ b/crates/theatron/tui/src/app.rs
@@ -87,9 +87,6 @@ pub struct App {
     // Success toast (auto-dismiss after 5s)
     pub success_toast: Option<ErrorToast>,
 
-    // Success toast (auto-dismiss after 5s)
-    pub success_toast: Option<ErrorToast>,
-
     // @mention tab completion state
     pub tab_completion: Option<TabCompletion>,
 


### PR DESCRIPTION
## Summary
- Remove duplicate `success_toast` field in `App` struct that breaks compilation
- Merge artifact from the parallel PR batch

## Test plan
- [ ] `cargo build --release` succeeds