### PR TITLE
sec(pylon): redact JWT signingKey from gateway config API response

### DIFF
--- a/crates/pylon/src/tests.rs
+++ b/crates/pylon/src/tests.rs
@@ -1873,6 +1873,38 @@ async fn config_section_requires_auth() {
     assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
 }
 
+// --- Gateway config redaction ---
+
+#[tokio::test]
+async fn gateway_config_signing_key_is_redacted() {
+    let (state, _dir) = test_state().await;
+
+    // Inject a signing key so there is a secret value to redact.
+    {
+        let mut config = state.config.write().await;
+        config.gateway.auth.signing_key = Some("super-secret-signing-key".to_owned());
+    }
+
+    let router = build_router(Arc::clone(&state), &test_security_config());
+    let resp = router
+        .oneshot(authed_get("/api/v1/config/gateway"))
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = body_json(resp).await;
+
+    // The raw secret must not appear anywhere in the response.
+    assert!(
+        !body.to_string().contains("super-secret-signing-key"),
+        "signing key must not appear in API response"
+    );
+    // The field must be replaced with the redaction placeholder.
+    assert_eq!(body["auth"]["signingKey"], "***");
+    // Non-secret fields must still be present and correct.
+    assert_eq!(body["port"], 18789);
+}
+
 // --- Router: Method Not Allowed ---
 
 #[tokio::test]

--- a/crates/taxis/src/redact.rs
+++ b/crates/taxis/src/redact.rs
@@ -9,6 +9,7 @@ const REDACTED: &str = "***";
 
 /// Paths whose leaf values are replaced with `"***"` in redacted output.
 const SENSITIVE_LEAVES: &[&[&str]] = &[
+    &["gateway", "auth", "signingKey"],
     &["gateway", "tls", "keyPath"],
     &["gateway", "tls", "certPath"],
 ];
@@ -87,6 +88,21 @@ fn redact_signal_accounts(root: &mut Value) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn redacts_gateway_signing_key() {
+        let mut config = AletheiaConfig::default();
+        config.gateway.auth.signing_key = Some("super-secret-jwt-signing-key".to_owned());
+
+        let redacted = redact(&config);
+        assert_eq!(redacted["gateway"]["auth"]["signingKey"], REDACTED);
+        // Raw secret must not appear anywhere in the output
+        assert!(
+            !redacted
+                .to_string()
+                .contains("super-secret-jwt-signing-key")
+        );
+    }
 
     #[test]
     fn redacts_tls_key_path() {


### PR DESCRIPTION
Closes #976

## Changes
- Added `gateway.auth.signingKey` to `SENSITIVE_LEAVES` in `crates/taxis/src/redact.rs` so the JWT signing key is replaced with `"***"` before the config is serialized for any API response. The internal `AletheiaConfig` struct retains the real value for runtime use.
- Added `redacts_gateway_signing_key` unit test in `redact.rs` asserting the field is replaced and the raw secret does not appear anywhere in the output.
- Added `gateway_config_signing_key_is_redacted` integration test in `crates/pylon/src/tests.rs` that injects a signing key into the in-memory config, calls `GET /api/v1/config/gateway`, and asserts: (a) the raw secret is absent from the response body, (b) `auth.signingKey` is `"***"`, and (c) the non-secret `port` field is still correct.

## Observations
Pre-existing `cargo fmt --check` / `cargo clippy -D warnings` failures found on `origin/main` (out of scope for this fix but required to unblock the CI gate):
- `organon/src/sandbox.rs`: `cast_possible_truncation` lint on Landlock ABI probe — suppressed with `#[expect]` and justification.
- `aletheia/src/commands/add_nous.rs`: `match` simplifiable with `.unwrap_or_default()`.
- `aletheia/src/commands/session_export.rs`: `push_str(&format!(...))` replaced with `writeln!`; string concatenation with `+` replaced with `push_str`.
- Several crates with rustfmt drift (`theatron`, `organon` test files) — reformatted only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)