### PR TITLE
chore: instrument all tokio::spawn calls with tracing spans

### DIFF
--- a/crates/aletheia/src/commands/server.rs
+++ b/crates/aletheia/src/commands/server.rs
@@ -361,9 +361,12 @@ pub async fn run(args: Args) -> Result<()> {
     }
 
     daemon_runner.register_maintenance_tasks();
-    let daemon_handle = tokio::spawn(async move {
-        daemon_runner.run().await;
-    });
+    let daemon_handle = tokio::spawn(
+        async move {
+            daemon_runner.run().await;
+        }
+        .instrument(tracing::info_span!("daemon_runner")),
+    );
     info!("daemon started");
 
     // Wrap in Arc — shared between dispatcher and AppState

--- a/crates/aletheia/src/server.rs
+++ b/crates/aletheia/src/server.rs
@@ -310,9 +310,12 @@ pub(crate) async fn serve(cli: Cli) -> Result<()> {
     }
 
     daemon_runner.register_maintenance_tasks();
-    let daemon_handle = tokio::spawn(async move {
-        daemon_runner.run().await;
-    });
+    let daemon_handle = tokio::spawn(
+        async move {
+            daemon_runner.run().await;
+        }
+        .instrument(tracing::info_span!("daemon_runner")),
+    );
     info!("daemon started");
 
     // Wrap in Arc — shared between dispatcher and AppState

--- a/crates/pylon/src/handlers/sessions/streaming.rs
+++ b/crates/pylon/src/handlers/sessions/streaming.rs
@@ -294,44 +294,47 @@ pub async fn stream_turn(
     // before emitting turn_complete (prevents the race where turn_complete
     // arrives at the TUI before the final text_delta events).
     let bridge_tx = webchat_tx.clone();
-    let bridge_handle = tokio::spawn(async move {
-        while let Some(event) = nous_rx.recv().await {
-            let webchat_event = match event {
-                TurnStreamEvent::LlmDelta(LlmStreamEvent::TextDelta { text }) => {
-                    WebchatEvent::TextDelta { text }
+    let bridge_handle = tokio::spawn(
+        async move {
+            while let Some(event) = nous_rx.recv().await {
+                let webchat_event = match event {
+                    TurnStreamEvent::LlmDelta(LlmStreamEvent::TextDelta { text }) => {
+                        WebchatEvent::TextDelta { text }
+                    }
+                    TurnStreamEvent::LlmDelta(LlmStreamEvent::ThinkingDelta { thinking }) => {
+                        WebchatEvent::ThinkingDelta { text: thinking }
+                    }
+                    TurnStreamEvent::ToolStart {
+                        tool_id,
+                        tool_name,
+                        input,
+                    } => WebchatEvent::ToolStart {
+                        tool_name,
+                        tool_id,
+                        input,
+                    },
+                    TurnStreamEvent::ToolResult {
+                        tool_id,
+                        tool_name,
+                        result,
+                        is_error,
+                        duration_ms,
+                    } => WebchatEvent::ToolResult {
+                        tool_name,
+                        tool_id,
+                        result,
+                        is_error,
+                        duration_ms,
+                    },
+                    _ => continue,
+                };
+                if bridge_tx.send(webchat_event).await.is_err() {
+                    break;
                 }
-                TurnStreamEvent::LlmDelta(LlmStreamEvent::ThinkingDelta { thinking }) => {
-                    WebchatEvent::ThinkingDelta { text: thinking }
-                }
-                TurnStreamEvent::ToolStart {
-                    tool_id,
-                    tool_name,
-                    input,
-                } => WebchatEvent::ToolStart {
-                    tool_name,
-                    tool_id,
-                    input,
-                },
-                TurnStreamEvent::ToolResult {
-                    tool_id,
-                    tool_name,
-                    result,
-                    is_error,
-                    duration_ms,
-                } => WebchatEvent::ToolResult {
-                    tool_name,
-                    tool_id,
-                    result,
-                    is_error,
-                    duration_ms,
-                },
-                _ => continue,
-            };
-            if bridge_tx.send(webchat_event).await.is_err() {
-                break;
             }
         }
-    });
+        .instrument(tracing::info_span!("sse_bridge")),
+    );
 
     // Run the turn, wait for bridge to drain, then emit completion event.
     tokio::spawn(
@@ -441,19 +444,22 @@ pub async fn events(
         .await;
 
     // Ping every 15 seconds to keep the connection alive.
-    tokio::spawn(async move {
-        let mut interval = tokio::time::interval(Duration::from_secs(15));
-        loop {
-            interval.tick().await;
-            if tx
-                .send(Event::default().event("ping").data("{}"))
-                .await
-                .is_err()
-            {
-                break;
+    tokio::spawn(
+        async move {
+            let mut interval = tokio::time::interval(Duration::from_secs(15));
+            loop {
+                interval.tick().await;
+                if tx
+                    .send(Event::default().event("ping").data("{}"))
+                    .await
+                    .is_err()
+                {
+                    break;
+                }
             }
         }
-    });
+        .instrument(tracing::info_span!("sse_ping")),
+    );
 
     let stream = ReceiverStream::new(rx).map(Ok);
 

--- a/crates/pylon/src/server.rs
+++ b/crates/pylon/src/server.rs
@@ -163,6 +163,7 @@ async fn serve_tls(app: axum::Router, config: &ServerConfig) -> Result<(), Serve
     use std::time::Duration;
 
     use axum_server::tls_rustls::RustlsConfig;
+    use tracing::Instrument;
 
     let cert_path = config
         .security
@@ -189,10 +190,13 @@ async fn serve_tls(app: axum::Router, config: &ServerConfig) -> Result<(), Serve
 
     let handle = axum_server::Handle::new();
     let shutdown_handle = handle.clone();
-    tokio::spawn(async move {
-        shutdown_signal().await;
-        shutdown_handle.graceful_shutdown(Some(Duration::from_secs(30)));
-    });
+    tokio::spawn(
+        async move {
+            shutdown_signal().await;
+            shutdown_handle.graceful_shutdown(Some(Duration::from_secs(30)));
+        }
+        .instrument(tracing::info_span!("shutdown_signal")),
+    );
 
     info!(addr = %config.bind_addr, tls = true, "pylon listening (TLS)");
 

--- a/crates/symbolon/src/credential.rs
+++ b/crates/symbolon/src/credential.rs
@@ -7,7 +7,7 @@ use std::sync::{Arc, RwLock};
 use std::time::{Duration, Instant, SystemTime};
 
 use serde::{Deserialize, Serialize};
-use tracing::{info, warn};
+use tracing::{Instrument, info, warn};
 
 use aletheia_koina::credential::{Credential, CredentialProvider, CredentialSource};
 
@@ -358,9 +358,12 @@ impl RefreshingCredentialProvider {
         let task_shutdown = Arc::clone(&shutdown);
         let task_path = path.clone();
 
-        let task = tokio::spawn(async move {
-            refresh_loop(task_state, task_shutdown, task_path).await;
-        });
+        let task = tokio::spawn(
+            async move {
+                refresh_loop(task_state, task_shutdown, task_path).await;
+            }
+            .instrument(tracing::info_span!("credential_refresh")),
+        );
 
         Some(Self {
             state,


### PR DESCRIPTION
## Changes
- Added `.instrument(info_span!(...))` to all uninstrumented `tokio::spawn` calls in non-test code
- Span names: `daemon_runner`, `shutdown_signal`, `sse_bridge`, `sse_ping`, `credential_refresh`
- Added `use tracing::Instrument` where needed (`symbolon/credential.rs`, scoped inside `#[cfg(feature = "tls")]` in `pylon/server.rs`)
- Fixed pre-existing clippy failures exposed by `cargo fmt`: `cast_possible_truncation` in `organon/sandbox.rs`, `format_push_string`/`write_with_newline` in `aletheia/session_export.rs`, `unwrap_or_default` in `aletheia/add_nous.rs`
- Ran `cargo fmt` across workspace to fix pre-existing formatting drift

## Observations
- `pylon/src/server.rs`: The `serve_tls` function is only compiled with `--features tls`; the `Instrument` import must be scoped inside the function to avoid unused-import warnings in default builds.
- Pre-existing `cargo clippy -- -D warnings` failures in `organon/sandbox.rs` and `aletheia/commands/session_export.rs` were blocking the validation gate and are fixed here as a necessary prerequisite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)