### PR TITLE
fix(pylon): health check tolerates busy actors during message processing

### DIFF
--- a/crates/nous/src/actor/mod.rs
+++ b/crates/nous/src/actor/mod.rs
@@ -2,6 +2,7 @@
 
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
 use std::time::Instant;
 
 use tokio::sync::Mutex;
@@ -87,6 +88,11 @@ pub struct NousActor {
     started_at: Instant,
     /// Background tasks (extraction, distillation, skill analysis).
     background_tasks: JoinSet<()>,
+    /// Set to `true` while processing a turn; `false` when idle.
+    /// Shared with the manager's `ActorEntry` so health checks can
+    /// distinguish a busy actor from an unresponsive one without queuing
+    /// through the inbox.
+    active_turn: Arc<AtomicBool>,
 }
 
 impl NousActor {
@@ -112,6 +118,7 @@ impl NousActor {
         #[cfg(feature = "knowledge-store")] knowledge_store: Option<Arc<KnowledgeStore>>,
         tool_services: Option<Arc<ToolServices>>,
         extra_bootstrap: Vec<BootstrapSection>,
+        active_turn: Arc<AtomicBool>,
     ) -> Self {
         // Build the skill loader from the knowledge store when available.
         #[cfg(feature = "knowledge-store")]
@@ -157,6 +164,7 @@ impl NousActor {
             panic_timestamps: Vec::new(),
             started_at: Instant::now(),
             background_tasks: JoinSet::new(),
+            active_turn,
         }
     }
 

--- a/crates/nous/src/actor/spawn.rs
+++ b/crates/nous/src/actor/spawn.rs
@@ -1,6 +1,7 @@
 //! Actor spawning and workspace validation.
 
 use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
 
 use tokio::sync::Mutex;
 use tokio::sync::mpsc;
@@ -50,10 +51,12 @@ pub fn spawn(
     extra_bootstrap: Vec<BootstrapSection>,
     cross_rx: Option<mpsc::Receiver<CrossNousEnvelope>>,
     cancel: CancellationToken,
-) -> (NousHandle, tokio::task::JoinHandle<()>) {
+) -> (NousHandle, tokio::task::JoinHandle<()>, Arc<AtomicBool>) {
     let (tx, rx) = mpsc::channel(DEFAULT_INBOX_CAPACITY);
     let id = config.id.clone();
     let handle = NousHandle::new(id.clone(), tx);
+
+    let active_turn = Arc::new(AtomicBool::new(false));
 
     let actor = NousActor::new(
         id.clone(),
@@ -72,12 +75,13 @@ pub fn spawn(
         knowledge_store,
         tool_services,
         extra_bootstrap,
+        Arc::clone(&active_turn),
     );
 
     let span = tracing::info_span!("nous_actor", nous.id = %id);
     let join_handle = tokio::spawn(async move { actor.run().await }.instrument(span));
 
-    (handle, join_handle)
+    (handle, join_handle, active_turn)
 }
 
 /// Validate the workspace directory exists and required files are resolvable.

--- a/crates/nous/src/actor/tests.rs
+++ b/crates/nous/src/actor/tests.rs
@@ -100,7 +100,7 @@ fn spawn_test_actor() -> (NousHandle, tokio::task::JoinHandle<()>, tempfile::Tem
     let config = test_config();
     let pipeline_config = PipelineConfig::default();
 
-    let (handle, join) = spawn(
+    let (handle, join, _active_turn) = spawn(
         config,
         pipeline_config,
         providers,
@@ -395,7 +395,7 @@ fn spawn_panicking_actor() -> (NousHandle, tokio::task::JoinHandle<()>, tempfile
     let config = test_config();
     let pipeline_config = PipelineConfig::default();
 
-    let (handle, join) = spawn(
+    let (handle, join, _active_turn) = spawn(
         config,
         pipeline_config,
         providers,
@@ -576,7 +576,7 @@ fn spawn_test_actor_with_store(
     let config = test_config();
     let pipeline_config = PipelineConfig::default();
 
-    let (handle, join) = spawn(
+    let (handle, join, _active_turn) = spawn(
         config,
         pipeline_config,
         providers,

--- a/crates/nous/src/actor/turn.rs
+++ b/crates/nous/src/actor/turn.rs
@@ -1,6 +1,7 @@
 //! Turn execution — handles individual turns with panic boundary protection.
 
 use std::sync::Arc;
+use std::sync::atomic::Ordering;
 
 use tokio::sync::mpsc;
 use tracing::{Instrument, debug, error, warn};
@@ -37,6 +38,7 @@ impl NousActor {
 
         self.lifecycle = NousLifecycle::Active;
         self.active_session = Some(session_key.clone());
+        self.active_turn.store(true, Ordering::Release);
 
         let result = self
             .execute_turn_with_panic_boundary(
@@ -65,6 +67,7 @@ impl NousActor {
         if self.lifecycle != NousLifecycle::Degraded {
             self.lifecycle = NousLifecycle::Idle;
         }
+        self.active_turn.store(false, Ordering::Release);
 
         // Ignore send error — caller may have dropped the receiver
         let _ = reply.send(result);
@@ -91,6 +94,7 @@ impl NousActor {
 
         self.lifecycle = NousLifecycle::Active;
         self.active_session = Some(session_key.clone());
+        self.active_turn.store(true, Ordering::Release);
 
         let result = self
             .execute_streaming_turn_with_panic_boundary(
@@ -119,6 +123,7 @@ impl NousActor {
         if self.lifecycle != NousLifecycle::Degraded {
             self.lifecycle = NousLifecycle::Idle;
         }
+        self.active_turn.store(false, Ordering::Release);
 
         let _ = reply.send(result);
     }

--- a/crates/nous/src/manager.rs
+++ b/crates/nous/src/manager.rs
@@ -2,8 +2,9 @@
 
 use std::collections::HashMap;
 use std::sync::Arc;
-
 use std::sync::Mutex;
+use std::sync::atomic::{AtomicBool, Ordering};
+
 use tokio::sync::Mutex as TokioMutex;
 
 #[cfg(feature = "knowledge-store")]
@@ -45,6 +46,10 @@ struct ActorEntry {
     restart_count: u32,
     /// When the actor was last (re)started.
     last_start: std::time::Instant,
+    /// Shared with the actor task. `true` while the actor is processing a turn.
+    /// Readable without queuing through the inbox — used by `check_health` to
+    /// distinguish a busy (healthy) actor from an unresponsive (dead) one.
+    active_turn: Arc<AtomicBool>,
 }
 
 /// Default interval between health polls (30 seconds).
@@ -201,7 +206,7 @@ impl NousManager {
         };
 
         let child_cancel = self.cancel.child_token();
-        let (handle, join_handle) = actor::spawn(
+        let (handle, join_handle, active_turn) = actor::spawn(
             config.clone(),
             pipeline_config.clone(),
             Arc::clone(&self.providers),
@@ -229,6 +234,7 @@ impl NousManager {
                 consecutive_misses: 0,
                 restart_count: 0,
                 last_start: std::time::Instant::now(),
+                active_turn,
             },
         );
         handle
@@ -254,12 +260,21 @@ impl NousManager {
 
     /// Check liveness of all actors by sending a ping with a timeout.
     ///
+    /// An actor that does not respond to a ping but has its `active_turn` flag
+    /// set is considered healthy-busy: it is processing a long turn (e.g. an
+    /// LLM call) and cannot dequeue inbox messages until the turn completes.
+    /// Only an actor that fails the ping **and** is not processing a turn is
+    /// reported as dead.
+    ///
     /// Returns a map of `nous_id → ActorHealth`.
     pub async fn check_health(&self) -> BTreeMap<String, ActorHealth> {
         let mut results = BTreeMap::new();
         for (id, entry) in &self.actors {
             let ping_result = entry.handle.ping(DEFAULT_PING_TIMEOUT).await;
-            let alive = ping_result.is_ok();
+            // WHY: An actor processing a long turn cannot dequeue Ping messages
+            // until the turn completes. Treat active_turn=true as a liveness
+            // signal so busy actors are not incorrectly declared dead.
+            let alive = ping_result.is_ok() || entry.active_turn.load(Ordering::Acquire);
 
             // Try to get status for panic_count and uptime
             let (panic_count, uptime) = if let Ok(status) = entry.handle.status().await {

--- a/crates/nous/src/manager_tests.rs
+++ b/crates/nous/src/manager_tests.rs
@@ -374,6 +374,49 @@ async fn check_health_detects_dead_actor() {
     assert!(!syn_health.alive, "dead actor should not be alive");
 }
 
+/// An actor processing a long turn cannot respond to pings — the inbox is
+/// occupied. `check_health` must report it alive as long as `active_turn`
+/// is set, distinguishing "busy" from "dead".
+#[tokio::test]
+async fn check_health_busy_actor_reports_alive() {
+    let (_dir, oikos) = test_oikos();
+    let mut mgr = test_manager(oikos);
+
+    mgr.spawn(syn_config(), PipelineConfig::default()).await;
+
+    // Simulate: actor is mid-turn (flag set) but its inbox is closed (ping fails).
+    mgr.actors
+        .get("syn")
+        .expect("actor registered")
+        .active_turn
+        .store(true, std::sync::atomic::Ordering::Release);
+
+    // Kill the actor so the ping fails.
+    let handle = mgr.actors.get("syn").expect("entry").handle.clone();
+    handle.shutdown().await.expect("shutdown sent");
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    // Ping fails but active_turn is set — must report healthy-busy, not dead.
+    let health = mgr.check_health().await;
+    assert!(
+        health.get("syn").expect("syn health").alive,
+        "busy actor (active_turn=true) must report alive even when ping fails"
+    );
+
+    // Clear the flag: actor is now both dead and idle — must report unhealthy.
+    mgr.actors
+        .get("syn")
+        .expect("actor registered")
+        .active_turn
+        .store(false, std::sync::atomic::Ordering::Release);
+
+    let health = mgr.check_health().await;
+    assert!(
+        !health.get("syn").expect("syn health").alive,
+        "dead actor with active_turn=false must report not alive"
+    );
+}
+
 #[test]
 fn backoff_calculation() {
     assert_eq!(super::calculate_backoff(0), Duration::from_secs(5));

--- a/crates/nous/src/spawn_svc.rs
+++ b/crates/nous/src/spawn_svc.rs
@@ -126,7 +126,7 @@ impl SpawnService for SpawnServiceImpl {
                 // Ephemeral actors get their own token; they are
                 // short-lived and don't need a shared parent.
                 let ephemeral_cancel = CancellationToken::new();
-                let (handle, join_handle) = actor::spawn(
+                let (handle, join_handle, _active_turn) = actor::spawn(
                     config,
                     pipeline_config,
                     providers,


### PR DESCRIPTION
Closes #975

## Changes
- Added `Arc<AtomicBool>` (`active_turn`) shared between each `NousActor` and its `ActorEntry` in `NousManager`
- Actor sets `active_turn = true` at the start of `handle_turn` / `handle_streaming_turn`, clears it after lifecycle reset — mirrors the `lifecycle = Active` window
- `check_health()` now treats a ping failure as **healthy** when `active_turn` is set: the actor is busy processing a turn, not dead
- An actor that fails the ping **and** has `active_turn = false` is genuinely unresponsive and continues to be reported as dead
- Test `check_health_busy_actor_reports_alive` verifies the busy path: kills the actor's inbox, sets the flag, asserts healthy; then clears the flag and asserts unhealthy
- Also fixed pre-existing clippy violations (`format_push_string`, `string_add`, `cast_possible_truncation`) exposed by the workspace-wide `cargo fmt` required for the validation gate

## Observations
- **Debt** `crates/aletheia/src/commands/session_export.rs:137–150,189`: Pre-existing `format_push_string` / `string_add` clippy violations were not caught because the repo had accumulated `cargo fmt` drift that hid the lint trigger. No CI combining `cargo fmt --check` + `cargo clippy -D warnings` in the same job.
- **Debt** `crates/organon/src/sandbox.rs:285`: `probe_landlock_abi` cast `i64 → i32` without suppression annotation; the cast is safe (Landlock ABI version ≤ 4 in current kernels) but clippy flagged it once the expression was reformatted from multi-line to single-line.