### PR TITLE
fix(theatron): repair TUI chat viewport scroll behavior

### DIFF
--- a/crates/theatron/tui/src/update/navigation.rs
+++ b/crates/theatron/tui/src/update/navigation.rs
@@ -15,14 +15,25 @@ pub(crate) fn handle_scroll_down(app: &mut App) {
     }
 }
 
+/// Approximate chat viewport height from the current terminal height.
+///
+/// Subtracts fixed chrome: title bar (1) + status bar (2) + minimum input area (3).
+/// The result is used as the page-scroll distance so PageUp/PageDown move by one
+/// viewport rather than a hard-coded constant.
+fn chat_viewport_height(app: &App) -> usize {
+    app.terminal_height.saturating_sub(6).max(1) as usize
+}
+
 pub(crate) fn handle_scroll_page_up(app: &mut App) {
-    app.scroll_offset = app.scroll_offset.saturating_add(20);
+    let page = chat_viewport_height(app);
+    app.scroll_offset = app.scroll_offset.saturating_add(page);
     app.auto_scroll = false;
 }
 
 pub(crate) fn handle_scroll_page_down(app: &mut App) {
-    if app.scroll_offset >= 20 {
-        app.scroll_offset -= 20;
+    let page = chat_viewport_height(app);
+    if app.scroll_offset >= page {
+        app.scroll_offset -= page;
     } else {
         app.scroll_offset = 0;
         app.auto_scroll = true;
@@ -95,6 +106,18 @@ pub(crate) fn handle_resize(app: &mut App, w: u16, h: u16) {
     app.terminal_height = h;
     // Terminal width changed — recalculate message heights for wrapping.
     app.rebuild_virtual_scroll();
+    // After rebuild, heights may have changed due to reflow. Cap scroll_offset so
+    // the user cannot be stranded past the top of content. If already at the
+    // bottom, stay there. Auto-scroll mode is unaffected (it always pins to bottom).
+    if !app.auto_scroll {
+        let total = app.virtual_scroll.total_height();
+        let vh = chat_viewport_height(app) as u64;
+        let max_offset = total.saturating_sub(vh) as usize;
+        app.scroll_offset = app.scroll_offset.min(max_offset);
+        if app.scroll_offset == 0 {
+            app.auto_scroll = true;
+        }
+    }
 }
 
 #[cfg(test)]
@@ -139,17 +162,20 @@ mod tests {
     }
 
     #[test]
-    fn scroll_page_up_jumps_20() {
+    fn scroll_page_up_jumps_one_viewport() {
         let mut app = test_app();
+        // test_app terminal_height=40 → chat_viewport_height = 40-6 = 34
+        let expected = chat_viewport_height(&app);
         handle_scroll_page_up(&mut app);
-        assert_eq!(app.scroll_offset, 20);
+        assert_eq!(app.scroll_offset, expected);
         assert!(!app.auto_scroll);
     }
 
     #[test]
-    fn scroll_page_down_jumps_20() {
+    fn scroll_page_down_jumps_one_viewport() {
         let mut app = test_app();
-        app.scroll_offset = 30;
+        let page = chat_viewport_height(&app);
+        app.scroll_offset = page + 10;
         handle_scroll_page_down(&mut app);
         assert_eq!(app.scroll_offset, 10);
     }
@@ -157,7 +183,7 @@ mod tests {
     #[test]
     fn scroll_page_down_to_zero_auto_scrolls() {
         let mut app = test_app();
-        app.scroll_offset = 15;
+        app.scroll_offset = 5; // less than a full page
         app.auto_scroll = false;
         handle_scroll_page_down(&mut app);
         assert_eq!(app.scroll_offset, 0);
@@ -200,5 +226,44 @@ mod tests {
         handle_resize(&mut app, 200, 50);
         assert_eq!(app.terminal_width, 200);
         assert_eq!(app.terminal_height, 50);
+    }
+
+    #[test]
+    fn resize_clamps_scroll_offset_when_content_shrinks() {
+        use crate::app::test_helpers::test_app_with_messages;
+        let mut app = test_app_with_messages(vec![("user", "hi"), ("assistant", "hello")]);
+        app.rebuild_virtual_scroll();
+        // Scroll up to a large offset that will exceed content after resize
+        app.scroll_offset = 9999;
+        app.auto_scroll = false;
+        // Resize to a very tall terminal — content now fits, offset must be clamped to 0
+        handle_resize(&mut app, 120, 200);
+        assert_eq!(app.scroll_offset, 0);
+        assert!(app.auto_scroll);
+    }
+
+    #[test]
+    fn resize_preserves_valid_scroll_offset() {
+        use crate::app::test_helpers::test_app_with_messages;
+        let msgs: Vec<_> = (0..50)
+            .map(|i| {
+                (
+                    "user",
+                    if i % 2 == 0 {
+                        "hello world"
+                    } else {
+                        "response"
+                    },
+                )
+            })
+            .collect();
+        let mut app = test_app_with_messages(msgs);
+        app.rebuild_virtual_scroll();
+        app.scroll_offset = 5;
+        app.auto_scroll = false;
+        // Resize with same height — offset within valid range should be preserved
+        handle_resize(&mut app, 120, 40);
+        assert!(!app.auto_scroll);
+        assert_eq!(app.scroll_offset, 5);
     }
 }

--- a/crates/theatron/tui/src/update/streaming.rs
+++ b/crates/theatron/tui/src/update/streaming.rs
@@ -168,6 +168,11 @@ pub(crate) async fn handle_stream_turn_complete(app: &mut App, outcome: TurnOutc
             tool_calls,
         });
         app.virtual_scroll.push_item(h);
+        // Scroll lock: when the user has scrolled up, keep the viewport anchored by
+        // compensating for the new content added below their current position.
+        if !app.auto_scroll {
+            app.scroll_offset = app.scroll_offset.saturating_add(h as usize);
+        }
     }
     app.streaming_text.clear();
     app.streaming_thinking.clear();
@@ -449,5 +454,59 @@ mod tests {
         handle_stream_text_delta(&mut app, "line1\nline2".to_string());
         // newline should trigger markdown re-render
         assert!(!app.cached_markdown_text.is_empty());
+    }
+
+    fn make_outcome() -> TurnOutcome {
+        TurnOutcome {
+            text: String::new(),
+            nous_id: "syn".into(),
+            session_id: "s1".into(),
+            model: "claude".to_string(),
+            tool_calls: 0,
+            input_tokens: 0,
+            output_tokens: 0,
+            cache_read_tokens: 0,
+            cache_write_tokens: 0,
+            error: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn turn_complete_auto_scroll_stays_at_bottom() {
+        let mut app = test_app();
+        app.auto_scroll = true;
+        app.scroll_offset = 0;
+        app.streaming_text = "hello world".to_string();
+        handle_stream_turn_complete(&mut app, make_outcome()).await;
+        assert!(app.auto_scroll);
+        assert_eq!(app.scroll_offset, 0);
+    }
+
+    #[tokio::test]
+    async fn turn_complete_scroll_lock_preserves_offset() {
+        let mut app = test_app();
+        app.auto_scroll = false;
+        app.scroll_offset = 30;
+        app.rebuild_virtual_scroll();
+        app.streaming_text = "a new message with some text".to_string();
+        let offset_before = app.scroll_offset;
+        handle_stream_turn_complete(&mut app, make_outcome()).await;
+        // Offset must increase so the viewport stays anchored while new content lands below.
+        assert!(!app.auto_scroll);
+        assert!(
+            app.scroll_offset > offset_before,
+            "scroll_offset should increase when new message arrives while scrolled up"
+        );
+    }
+
+    #[tokio::test]
+    async fn turn_complete_no_text_does_not_change_scroll() {
+        let mut app = test_app();
+        app.auto_scroll = false;
+        app.scroll_offset = 10;
+        // streaming_text is empty — no message is committed, offset unchanged
+        handle_stream_turn_complete(&mut app, make_outcome()).await;
+        assert_eq!(app.scroll_offset, 10);
+        assert!(!app.auto_scroll);
     }
 }

--- a/crates/theatron/tui/src/view/chat.rs
+++ b/crates/theatron/tui/src/view/chat.rs
@@ -23,7 +23,8 @@ struct MessageCtx<'a> {
 pub fn render(app: &App, frame: &mut Frame, area: Rect, theme: &Theme) -> Vec<OscLink> {
     let inner_width = area.width.saturating_sub(2) as usize;
     let wrap_width = area.width.saturating_sub(2).max(1);
-    let visible_height = area.height.saturating_sub(2);
+    // With Borders::NONE the paragraph has the full area height available.
+    let visible_height = area.height;
     // Para-relative link data collected from all messages.
     let mut para_links: Vec<(usize, u16, String, String)> = Vec::new(); // (line_idx, col, text, url)
 
@@ -127,26 +128,33 @@ pub fn render(app: &App, frame: &mut Frame, area: Rect, theme: &Theme) -> Vec<Os
         }
     }
 
-    // Pre-compute per-line widths — needed for resolve_osc_links and legacy scroll.
+    // Pre-compute per-line widths — needed for resolve_osc_links and scroll calc.
     let line_widths: Vec<usize> = lines
         .iter()
         .map(|line| line.spans.iter().map(|s| s.content.len()).sum())
         .collect();
 
-    // For virtual scroll path, the scroll offset is already baked into which items
-    // we rendered and the line_offset. For filtered path, use legacy scroll calc.
-    let scroll = if filter_active {
-        compute_legacy_scroll(
-            &lines,
-            wrap_width,
-            visible_height,
-            app.auto_scroll,
-            app.scroll_offset,
-        )
+    // Total visual rows of the final rendered lines vector (after padding + streaming).
+    // Used for auto-scroll so that streaming content appended after virtual render is
+    // always visible when the user is at the bottom.
+    let w = wrap_width.max(1) as usize;
+    let total_visual: usize = line_widths
+        .iter()
+        .map(|&lw| if lw == 0 { 1 } else { lw.div_ceil(w) })
+        .sum();
+    let vh = visible_height as usize;
+
+    let scroll = if app.auto_scroll {
+        // Pin to the very bottom of whatever was rendered (committed + streaming).
+        total_visual.saturating_sub(vh)
+    } else if filter_active {
+        // Filtered path: all messages are in `lines`; use the pre-computed total.
+        total_visual
+            .saturating_sub(vh)
+            .saturating_sub(app.scroll_offset)
     } else {
-        // Virtual scroll: we rendered exactly the right items with correct offset.
-        // The line_offset from visible_slice tells us where to start within the
-        // rendered content.
+        // Virtual scroll path with manual offset: line_offset already positions us
+        // correctly within the rendered (viewport-only) items.
         let slice =
             app.virtual_scroll
                 .visible_slice(app.scroll_offset, app.auto_scroll, visible_height);
@@ -327,36 +335,6 @@ fn render_filtered_messages(
             agent_name,
         };
         render_message(app, msg, lines, &ctx, para_links);
-    }
-}
-
-/// Legacy scroll calculation for filtered mode (iterates all rendered lines).
-fn compute_legacy_scroll(
-    lines: &[Line<'_>],
-    wrap_width: u16,
-    visible_height: u16,
-    auto_scroll: bool,
-    scroll_offset: usize,
-) -> usize {
-    let w = wrap_width.max(1) as usize;
-    let total_visual_lines: usize = lines
-        .iter()
-        .map(|line| {
-            let line_width: usize = line.spans.iter().map(|s| s.content.len()).sum();
-            if line_width == 0 {
-                1
-            } else {
-                line_width.div_ceil(w)
-            }
-        })
-        .sum();
-    let vh = visible_height as usize;
-    if auto_scroll {
-        total_visual_lines.saturating_sub(vh)
-    } else {
-        total_visual_lines
-            .saturating_sub(vh)
-            .saturating_sub(scroll_offset)
     }
 }
 


### PR DESCRIPTION
Closes #974

## Changes

- **`visible_height` off-by-2** (`chat.rs`): With `Borders::NONE` the paragraph has the full `area.height` available. The prior `saturating_sub(2)` caused auto-scroll to stop 2 rows short and bottom-alignment to mis-pad content.

- **Unified scroll computation** (`chat.rs`): Derive `total_visual` from the final rendered lines vector (after streaming content is appended). Previously the virtual-scroll path computed `line_offset` from committed messages only, so streaming output could scroll off the bottom even with `auto_scroll = true`.

- **Scroll lock** (`streaming.rs`): When `auto_scroll = false` and a new assistant message is committed, `scroll_offset` is incremented by the item height. Previously the offset stayed fixed while `total_height` grew, causing the viewport to drift toward new content — violating the user's held position.

- **PageUp/PageDown page size** (`navigation.rs`): Replace hardcoded 20 lines with `terminal_height - 6` (approximating the chat viewport after fixed chrome). One keypress now scrolls one visible page.

- **Resize clamping** (`navigation.rs`): After `rebuild_virtual_scroll`, cap `scroll_offset` at the new valid maximum so the viewport cannot be stranded past the top of content after reflow; snap back to `auto_scroll = true` if offset reaches zero.

- **Dead code removed**: `compute_legacy_scroll` is gone; its logic is inlined into the unified scroll path.

## Tests added (759 total, +5)

- `turn_complete_auto_scroll_stays_at_bottom`
- `turn_complete_scroll_lock_preserves_offset`
- `turn_complete_no_text_does_not_change_scroll`
- `resize_clamps_scroll_offset_when_content_shrinks`
- `resize_preserves_valid_scroll_offset`

## Observations

- `crates/organon/src/sandbox.rs:285` — pre-existing `clippy::cast_possible_truncation` on `v as i32`; workspace clippy was already failing on `main`. Not in blast radius.
- `cargo fmt --check` has pre-existing diffs on `main` (`add_nous.rs`, `workspace_tests.rs`, `sse.rs`, `memory.rs`); this PR does not introduce new formatting issues.