### PR TITLE
fix: resolve Rust 1.94 clippy lints blocking CI

### DIFF
--- a/crates/aletheia/src/commands/add_nous.rs
+++ b/crates/aletheia/src/commands/add_nous.rs
@@ -168,10 +168,7 @@ fn scaffold_directory(oikos: &Oikos, args: &AddNousArgs) -> Result<()> {
 
 fn update_config(oikos: &Oikos, args: &AddNousArgs) -> Result<()> {
     let config_result = loader::load_config(oikos);
-    let mut config: AletheiaConfig = match config_result {
-        Ok(c) => c,
-        Err(_) => AletheiaConfig::default(),
-    };
+    let mut config: AletheiaConfig = config_result.unwrap_or_default();
 
     let already_listed = config.agents.list.iter().any(|a| a.id == args.name);
     if already_listed {

--- a/crates/aletheia/src/commands/session_export.rs
+++ b/crates/aletheia/src/commands/session_export.rs
@@ -1,5 +1,6 @@
 //! `aletheia export <session-id>` — export a session as Markdown or JSON.
 
+use std::fmt::Write as _;
 use std::io::Write as _;
 use std::path::PathBuf;
 
@@ -134,20 +135,20 @@ async fn fetch_history(
 fn render_markdown(session: &SessionResponse, history: &HistoryResponse) -> String {
     let mut out = String::new();
 
-    out.push_str(&format!("# Session: {}\n", session.session_key));
-    out.push_str(&format!("Started: {}\n", session.created_at));
+    let _ = writeln!(out, "# Session: {}", session.session_key);
+    let _ = writeln!(out, "Started: {}", session.created_at);
 
     for msg in &history.messages {
         out.push_str("\n---\n\n");
         match msg.role.as_str() {
             "tool" => {
                 let name = msg.tool_name.as_deref().unwrap_or("unknown");
-                out.push_str(&format!("## Tool Call: {name} — {}\n", msg.created_at));
-                out.push_str(&format!("**Output:** {}\n", msg.content));
+                let _ = writeln!(out, "## Tool Call: {name} — {}", msg.created_at);
+                let _ = writeln!(out, "**Output:** {}", msg.content);
             }
             role => {
                 let heading = capitalize_first(role);
-                out.push_str(&format!("## {heading} — {}\n", msg.created_at));
+                let _ = writeln!(out, "## {heading} — {}", msg.created_at);
                 out.push_str(&msg.content);
                 out.push('\n');
             }
@@ -186,6 +187,10 @@ fn capitalize_first(s: &str) -> String {
     let mut chars = s.chars();
     match chars.next() {
         None => String::new(),
-        Some(c) => c.to_uppercase().collect::<String>() + chars.as_str(),
+        Some(c) => {
+            let mut s = c.to_uppercase().collect::<String>();
+            s.push_str(chars.as_str());
+            s
+        }
     }
 }

--- a/crates/organon/src/builtins/workspace_tests.rs
+++ b/crates/organon/src/builtins/workspace_tests.rs
@@ -617,7 +617,10 @@ async fn exec_permissive_sandbox_runs_tool_regardless_of_landlock_availability()
     // on the kernel. This covers the graceful degradation path from #943.
     let dir = tempfile::tempdir().expect("create temp dir");
     let ctx = test_ctx(dir.path());
-    let input = tool_input("exec", serde_json::json!({ "command": "echo sandbox-permissive" }));
+    let input = tool_input(
+        "exec",
+        serde_json::json!({ "command": "echo sandbox-permissive" }),
+    );
     let result = ExecExecutor {
         sandbox: crate::sandbox::SandboxConfig {
             enabled: true,
@@ -628,7 +631,11 @@ async fn exec_permissive_sandbox_runs_tool_regardless_of_landlock_availability()
     .execute(&input, &ctx)
     .await
     .expect("execute");
-    assert!(!result.is_error, "tool must run in permissive mode: {:?}", result.content.text_summary());
+    assert!(
+        !result.is_error,
+        "tool must run in permissive mode: {:?}",
+        result.content.text_summary()
+    );
     assert!(
         result.content.text_summary().contains("sandbox-permissive"),
         "output must be captured: {}",
@@ -661,7 +668,10 @@ async fn exec_enforcing_sandbox_returns_clear_error_when_landlock_unavailable() 
     match probe_landlock_abi() {
         None => {
             // Landlock unavailable: error result must name the cause clearly.
-            assert!(result.is_error, "enforcing mode must error when Landlock unavailable");
+            assert!(
+                result.is_error,
+                "enforcing mode must error when Landlock unavailable"
+            );
             let msg = result.content.text_summary();
             assert!(
                 msg.contains("sandbox setup failed"),
@@ -674,7 +684,10 @@ async fn exec_enforcing_sandbox_returns_clear_error_when_landlock_unavailable() 
         }
         Some(_) => {
             // Landlock is available: execution proceeds normally, no opaque error.
-            assert!(!result.is_error, "enforcing mode must succeed when Landlock is available");
+            assert!(
+                !result.is_error,
+                "enforcing mode must succeed when Landlock is available"
+            );
         }
     }
 }

--- a/crates/organon/src/sandbox.rs
+++ b/crates/organon/src/sandbox.rs
@@ -282,11 +282,7 @@ pub fn probe_landlock_abi() -> Option<i32> {
             LANDLOCK_CREATE_RULESET_VERSION,
         )
     };
-    if v >= 1 {
-        Some(v as i32)
-    } else {
-        None
-    }
+    if v >= 1 { i32::try_from(v).ok() } else { None }
 }
 
 #[cfg(not(target_os = "linux"))]

--- a/crates/theatron/tui/src/api/sse.rs
+++ b/crates/theatron/tui/src/api/sse.rs
@@ -59,12 +59,8 @@ impl SseConnection {
                                     return; // Receiver dropped, shut down
                                 }
                             }
-                            Err(reqwest_eventsource::Error::InvalidStatusCode(
-                                status,
-                                resp,
-                            )) => {
-                                let reason =
-                                    status.canonical_reason().unwrap_or("Unknown");
+                            Err(reqwest_eventsource::Error::InvalidStatusCode(status, resp)) => {
+                                let reason = status.canonical_reason().unwrap_or("Unknown");
                                 let body = resp.text().await.unwrap_or_default();
                                 let message = if let Ok(json) =
                                     serde_json::from_str::<serde_json::Value>(&body)

--- a/crates/theatron/tui/src/api/streaming.rs
+++ b/crates/theatron/tui/src/api/streaming.rs
@@ -71,19 +71,16 @@ pub fn stream_message(
                     Err(reqwest_eventsource::Error::InvalidStatusCode(status, resp)) => {
                         let reason = status.canonical_reason().unwrap_or("Unknown");
                         let body = resp.text().await.unwrap_or_default();
-                        let message = if let Ok(json) =
-                            serde_json::from_str::<serde_json::Value>(&body)
-                        {
-                            json.get("message")
-                                .or_else(|| json.get("error"))
-                                .and_then(|v| v.as_str())
-                                .map(|s| s.to_string())
-                                .unwrap_or_else(|| {
-                                    format!("{} {}", status.as_u16(), reason)
-                                })
-                        } else {
-                            format!("{} {}", status.as_u16(), reason)
-                        };
+                        let message =
+                            if let Ok(json) = serde_json::from_str::<serde_json::Value>(&body) {
+                                json.get("message")
+                                    .or_else(|| json.get("error"))
+                                    .and_then(|v| v.as_str())
+                                    .map(|s| s.to_string())
+                                    .unwrap_or_else(|| format!("{} {}", status.as_u16(), reason))
+                            } else {
+                                format!("{} {}", status.as_u16(), reason)
+                            };
                         let _ = tx.send(StreamEvent::Error(message)).await;
                         es.close();
                         break;

--- a/crates/theatron/tui/src/update/memory.rs
+++ b/crates/theatron/tui/src/update/memory.rs
@@ -199,8 +199,7 @@ pub async fn handle_confidence_submit(app: &mut App) {
                 if let Some(f) = app.memory.facts.iter_mut().find(|f| f.id == id) {
                     f.confidence = prev_conf;
                 }
-                app.error_toast =
-                    Some(ErrorToast::new(format!("Confidence update failed: {e}")));
+                app.error_toast = Some(ErrorToast::new(format!("Confidence update failed: {e}")));
             }
         }
     }

--- a/crates/theatron/tui/src/update/sse.rs
+++ b/crates/theatron/tui/src/update/sse.rs
@@ -73,8 +73,7 @@ pub(crate) fn check_sse_reconnect_timeout(app: &mut App) {
             .unwrap_or(true)
     {
         app.error_toast = Some(ErrorToast::new(
-            "Server unreachable after 5 minutes. Check: journalctl --user -eu aletheia"
-                .to_string(),
+            "Server unreachable after 5 minutes. Check: journalctl --user -eu aletheia".to_string(),
         ));
     }
 }


### PR DESCRIPTION
## Changes
- `cast_possible_truncation`: use `i32::try_from` in `probe_landlock_abi`
- `manual_unwrap_or_default`: simplify config loading in `add_nous`
- `format_push_string` + `write_with_newline`: use `writeln!` in `session_export`
- `string_add`: use `push_str` in `capitalize_first`
- `cargo fmt`: format long lines across 4 test/TUI files

Rust 1.94 introduced new default clippy lints that break `-D warnings`. This unblocks all open PRs.