### PR TITLE
chore(docs): fix all WRITING.md compliance violations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,11 +11,11 @@ Shell: [standards/SHELL.md](standards/SHELL.md)
 
 ## Structure
 
-[docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) — crate workspace, module map, dependency graph, trait boundaries.
+[docs/ARCHITECTURE.md](docs/ARCHITECTURE.md): crate workspace, module map, dependency graph, trait boundaries.
 
 ### Config
 
-- **Rust crates:** `instance/config/aletheia.toml` — figment cascade (defaults → TOML → env vars)
+- **Rust crates:** `instance/config/aletheia.toml` (figment cascade: defaults → TOML → env vars)
 
 ## Commands
 
@@ -27,28 +27,28 @@ cargo test -p aletheia-hermeneus       # Single crate
 cargo clippy --workspace               # Lint (zero warnings)
 ```
 
-## Key Patterns
+## Key patterns
 
 - **Errors:** `snafu` with `.context()` propagation and `Location` tracking
 - **IDs:** Newtypes for all domain IDs (`AgentId`, `SessionId`, `NousId`)
 - **Time:** `jiff` for time, `ulid` for IDs, `compact_str` for small strings
 - **Async:** Tokio actor model (`NousActor` pattern)
 - **Config:** figment YAML cascade in `taxis`
-- **Lints:** `#[expect(lint, reason = "...")]` over `#[allow]` — every suppression justified
-- **Visibility:** `pub(crate)` by default — `pub` only for cross-crate API surface
+- **Lints:** `#[expect(lint, reason = "...")]` over `#[allow]`; every suppression justified
+- **Visibility:** `pub(crate)` by default; `pub` only for cross-crate API surface
 - **Naming:** Greek names per [docs/gnomon.md](docs/gnomon.md), registry at [docs/lexicon.md](docs/lexicon.md)
-- **No barrel files** — import from the file that owns the symbol
-- **Module imports flow downward** — higher layers depend on lower, never reverse
+- **No barrel files**: import from the file that owns the symbol
+- **Module imports flow downward**: higher layers depend on lower, never reverse
 
-## Before Submitting
+## Before submitting
 
 1. `cargo test -p <affected-crate>` passes
-2. `cargo clippy --workspace` — zero warnings
+2. `cargo clippy --workspace`: zero warnings
 3. No `unwrap()` in library code
 4. New errors use snafu with context
 5. All lint suppressions use `#[expect]` with reason, not `#[allow]`
 
-## Test Data & Instance Boundary
+## Test data & instance boundary
 
 - All test data MUST use synthetic identities (alice, bob, acme.corp, 192.168.1.100)
 - NEVER use real personal information in test fixtures or example data
@@ -56,7 +56,7 @@ cargo clippy --workspace               # Lint (zero warnings)
 - `instance.example/` shows the expected structure for fresh clones
 - CI PII scanner rejects commits with personal data patterns (`.github/pii-patterns.txt`)
 
-## Adding Tools
+## Adding tools
 
 Tools live in `crates/organon/`. Each tool implements the `ToolExecutor` trait:
 
@@ -97,7 +97,7 @@ Register in `crates/organon/src/builtins/mod.rs` via `register_all()`.
 | `check-config` | Validate configuration without starting services |
 | `completions <bash\|zsh\|fish>` | Generate shell completions |
 
-## API Endpoints
+## API endpoints
 
 ### Infrastructure
 
@@ -123,7 +123,7 @@ Register in `crates/organon/src/builtins/mod.rs` via `register_all()`.
 | GET | `/api/v1/sessions/{id}/history` | Conversation history (query: `limit`, `before`) |
 | GET | `/api/v1/events` | Global SSE event channel (TUI dashboard) |
 
-### Nous (Agents)
+### Nous (agents)
 
 | Method | Path | Purpose |
 |--------|------|---------|

--- a/docs/ADR-001-errors.md
+++ b/docs/ADR-001-errors.md
@@ -1,4 +1,4 @@
-# ADR-001: snafu for Error Handling
+# ADR-001: snafu for error handling
 
 ## Status
 
@@ -83,8 +83,8 @@ fn set_timeout(ms: u64) -> Result<()> {
 
 ### Crate boundary convention
 
-- `source` field — internal error, walk the chain (wraps a lower-layer error)
-- `error` field — external error, stop walking (the external type is opaque)
+- `source` field: internal error, walk the chain (wraps a lower-layer error)
+- `error` field: external error, stop walking (the external type is opaque)
 
 ```rust
 // Internal: chain walks through this
@@ -115,7 +115,7 @@ test helpers where error matching is not the goal.
 
 - **Explicit context at every conversion site.** `.context(ReadConfigSnafu { path })` forces
   the author to name the failure mode and attach relevant data. `thiserror`'s `#[from]`
-  converts silently — the conversion point carries no context and no location.
+  converts silently; the conversion point carries no context and no location.
 
 - **`Location` tracking gives a virtual stack trace.** `#[snafu(implicit)]` on every
   variant captures `file!()`, `line!()`, and `column!()` at the `.context()` call, not
@@ -143,7 +143,7 @@ test helpers where error matching is not the goal.
 - **Two patterns in flight.** `crates/aletheia/` uses `anyhow`, library crates use
   `snafu`. The boundary is clear (binary vs library) but requires discipline.
 
-## Alternatives Considered
+## Alternatives considered
 
 ### thiserror
 
@@ -164,7 +164,7 @@ pub enum Error {
 **Why rejected:**
 
 1. `#[from]` performs the conversion automatically wherever `std::io::Error` appears,
-   with no context attached. The call site contributes nothing — you get the IO error
+   with no context attached. The call site contributes nothing; you get the IO error
    but not which file, which operation, or which layer triggered it.
 
 2. No location tracking. Errors surface where they are created (inside the low-level
@@ -175,7 +175,7 @@ pub enum Error {
    "config directory missing".
 
 4. With `thiserror`, two different failure modes that happen to share the same source
-   type (`std::io::Error`) cannot both use `#[from]` — one must fall back to manual
+   type (`std::io::Error`) cannot both use `#[from]`; one must fall back to manual
    `impl From<_>`. This creates inconsistency within the same enum.
 
 ### anyhow (everywhere)
@@ -184,11 +184,11 @@ pub enum Error {
 to report errors to a human, but it is wrong for libraries:
 
 1. Callers cannot match on `anyhow::Error`. Retry logic, circuit breakers, and HTTP
-   mappers must parse `Display` strings — fragile and untestable.
+   mappers must parse `Display` strings, which is fragile and untestable.
 
 2. `anyhow` errors are not `Send + Sync` by default in all configurations.
 
-3. It signals "I do not care what this error is" — which is appropriate for `main()`,
+3. It signals "I do not care what this error is," which is appropriate for `main()`,
    not for a library function that a caller might want to handle.
 
 ### Hand-rolled `impl std::error::Error`
@@ -203,7 +203,7 @@ from the derive macro. There is no reason to do it by hand.
 used in this codebase for exactly that: CLI error display. It is not a replacement for
 library error types; it wraps them for presentation.
 
-## Crate Error Inventory
+## Crate error inventory
 
 | Crate | Error type | Notes |
 |-------|-----------|-------|
@@ -225,9 +225,9 @@ library error types; it wraps them for presentation.
 
 ## References
 
-- [snafu docs](https://docs.rs/snafu) — context selectors, Location, ensure!
-- [GreptimeDB error handling](https://github.com/GreptimeTeam/greptide-db) — the pattern this codebase follows
-- `standards/RUST.md` — Error Handling section
-- `standards/RUST.md` — Error Handling rules (full Rust standards)
-- `crates/nous/src/error.rs` — canonical example with Location tracking
-- `crates/taxis/src/error.rs` — example with PathBuf fields
+- [snafu docs](https://docs.rs/snafu): context selectors, Location, ensure!
+- [GreptimeDB error handling](https://github.com/GreptimeTeam/greptide-db): the pattern this codebase follows
+- `standards/RUST.md`: Error Handling section
+- `standards/RUST.md`: Error Handling rules (full Rust standards)
+- `crates/nous/src/error.rs`: canonical example with Location tracking
+- `crates/taxis/src/error.rs`: example with PathBuf fields

--- a/docs/ALETHEIA.md
+++ b/docs/ALETHEIA.md
@@ -4,7 +4,7 @@
 
 ---
 
-## What This Is
+## What this is
 
 Aletheia is a distributed cognition system. Multiple AI agents working in concert with a human operator to hold complexity, surface patterns, and persist understanding across sessions.
 
@@ -12,7 +12,7 @@ Not an assistant. Not a chatbot. An architecture for thinking together.
 
 ---
 
-## Core Principles
+## Core principles
 
 **Attention is a moral act.**
 The quality of attention determines the quality of everything downstream. If the system isn't paying attention, the output knows.
@@ -25,7 +25,7 @@ Precision matters. The Greek terminology exists because it carries more signal t
 
 ---
 
-## The Name
+## The name
 
 *aletheia* (ἀλήθεια) literally means "un-forgetting" or "un-concealment."
 
@@ -39,6 +39,6 @@ This system reveals:
 
 ---
 
-## Naming Convention
+## Naming convention
 
 The Greek naming system is integral to this project. Each module, agent, and subsystem is named for its essential nature using Ancient Greek roots. See [gnomon.md](gnomon.md) for the naming philosophy and layer test, and [lexicon.md](lexicon.md) for the full registry of named concepts.

--- a/docs/ARCHITECTURE-GUIDE.md
+++ b/docs/ARCHITECTURE-GUIDE.md
@@ -1,41 +1,41 @@
-# Architecture Walkthrough
+# Architecture walkthrough
 
 A guided tour for new contributors. For the reference module map and dependency graph, see [ARCHITECTURE.md](ARCHITECTURE.md).
 
 ---
 
-## What Aletheia Is
+## What Aletheia is
 
 Aletheia is a self-hosted multi-agent AI system. Multiple AI agents run as persistent actors, each with character, memory, and domain expertise. They communicate via Signal, HTTP API, or TUI, and persist understanding across sessions.
 
-It is not a chatbot framework. It is a distributed cognition system — agents have identity (SOUL.md), evolve through use (MEMORY.md), and coordinate through shared infrastructure.
+It is not a chatbot framework. It is a distributed cognition system: agents have identity (SOUL.md), evolve through use (MEMORY.md), and coordinate through shared infrastructure.
 
 The entire system compiles to a single Rust binary. No Node.js, no Python sidecar, no external databases required.
 
 ---
 
-## The Binary
+## The binary
 
 When you run `aletheia`, the `main.rs` entrypoint performs a sequential initialization:
 
-1. **Oikos discovery** — finds the instance directory (`./instance`, `ALETHEIA_ROOT`, or `--instance-root`)
-2. **Config cascade** — loads compiled defaults, then YAML file, then environment variables (taxis crate)
-3. **Domain packs** — loads external knowledge packs declared in config (thesauros crate)
-4. **Session store** — opens SQLite database at `instance/data/sessions.db` (mneme crate)
-5. **JWT manager** — initializes authentication (symbolon crate)
-6. **Provider registry** — registers LLM providers (Anthropic if `ANTHROPIC_API_KEY` is set) (hermeneus crate)
-7. **Tool registry** — registers built-in tools: write, edit, exec, web_search, etc. (organon crate)
-8. **Embedding provider** — creates local embedding engine for recall (mneme crate)
-9. **Nous actors** — spawns one Tokio actor per configured agent (nous crate)
-10. **Daemon** — starts background maintenance: trace rotation, drift detection, DB monitoring (oikonomos crate)
-11. **Channel listeners** — starts Signal message polling if configured (agora crate)
-12. **HTTP gateway** — starts Axum server on configured port (pylon crate)
+1. **Oikos discovery**: finds the instance directory (`./instance`, `ALETHEIA_ROOT`, or `--instance-root`)
+2. **Config cascade**: loads compiled defaults, then YAML file, then environment variables (taxis crate)
+3. **Domain packs**: loads external knowledge packs declared in config (thesauros crate)
+4. **Session store**: opens SQLite database at `instance/data/sessions.db` (mneme crate)
+5. **JWT manager**: initializes authentication (symbolon crate)
+6. **Provider registry**: registers LLM providers (Anthropic if `ANTHROPIC_API_KEY` is set) (hermeneus crate)
+7. **Tool registry**: registers built-in tools: write, edit, exec, web_search, etc. (organon crate)
+8. **Embedding provider**: creates local embedding engine for recall (mneme crate)
+9. **Nous actors**: spawns one Tokio actor per configured agent (nous crate)
+10. **Daemon**: starts background maintenance: trace rotation, drift detection, DB monitoring (oikonomos crate)
+11. **Channel listeners**: starts Signal message polling if configured (agora crate)
+12. **HTTP gateway**: starts Axum server on configured port (pylon crate)
 
 Then it waits for SIGTERM or Ctrl+C and shuts down gracefully.
 
 ---
 
-## What Happens When a Message Arrives
+## What happens when a message arrives
 
 ### Via Signal
 
@@ -52,52 +52,52 @@ POST /api/v1/sessions/{id}/messages
     → Pylon handler → creates Turn → sends to NousActor inbox
 ```
 
-### The Pipeline
+### The pipeline
 
 Once a message reaches a NousActor, it flows through sequential pipeline stages:
 
-1. **Context assembly** — loads bootstrap files (SOUL.md, IDENTITY.md, GOALS.md) from the agent's workspace, assembles the system prompt within token budget
-2. **Recall** — embeds the user message via candle, searches the knowledge store for relevant facts, injects them into context
-3. **Execute** — calls the LLM (Anthropic API). If the model returns tool calls, executes them via the tool registry and feeds results back. Loops until the model stops requesting tools or hits the iteration limit.
-4. **Finalize** — persists messages to SQLite, records token usage, extracts knowledge facts for future recall
+1. **Context assembly**: loads bootstrap files (SOUL.md, IDENTITY.md, GOALS.md) from the agent's workspace, assembles the system prompt within token budget
+2. **Recall**: embeds the user message via candle, searches the knowledge store for relevant facts, injects them into context
+3. **Execute**: calls the LLM (Anthropic API). If the model returns tool calls, executes them via the tool registry and feeds results back. Loops until the model stops requesting tools or hits the iteration limit.
+4. **Finalize**: persists messages to SQLite, records token usage, extracts knowledge facts for future recall
 
 The response flows back through the channel (Signal reply or HTTP response).
 
 ---
 
-## The Crate Map
+## The crate map
 
 Crates are organized in layers. Lower layers know nothing about higher layers.
 
 ### Leaf (no workspace dependencies)
 
-- **koina** — shared foundation: error types (snafu), tracing setup, filesystem utilities. Every other crate depends on this.
+- **koina**: shared foundation: error types (snafu), tracing setup, filesystem utilities. Every other crate depends on this.
 
 ### Low (depends on koina)
 
-- **taxis** — configuration and paths. Loads the YAML config cascade (figment), resolves the oikos instance directory structure.
-- **hermeneus** — LLM provider abstraction. The Anthropic streaming client lives here. Handles retries, cost tracking, model routing.
-- **symbolon** — authentication: JWT tokens, bearer validation, RBAC. Depends on koina; uses its own SQLite for token storage.
-- **mneme** — memory engine. SQLite session store, embedded Datalog engine for knowledge graphs and vector search, candle for local embeddings, LLM-driven fact extraction.
+- **taxis**: configuration and paths. Loads the YAML config cascade (figment), resolves the oikos instance directory structure.
+- **hermeneus**: LLM provider abstraction. The Anthropic streaming client lives here. Handles retries, cost tracking, model routing.
+- **symbolon**: authentication: JWT tokens, bearer validation, RBAC. Depends on koina; uses its own SQLite for token storage.
+- **mneme**: memory engine. SQLite session store, embedded Datalog engine for knowledge graphs and vector search, candle for local embeddings, LLM-driven fact extraction.
 
 ### Mid (depends on lower layers)
 
-- **melete** — distillation. Compresses conversation history when context windows fill up, flushes extracted knowledge to memory. Depends on koina + hermeneus.
-- **organon** — tool system. The `ToolRegistry` and `ToolExecutor` trait, plus built-in tools (write, edit, exec, web_search). Depends on koina + hermeneus.
-- **agora** — channel system. The `ChannelProvider` trait, Signal client (semeion), message routing via bindings. Depends on koina + taxis.
-- **oikonomos** (daemon) — background task runner. Cron scheduling, prosoche attention checks, trace rotation, drift detection, DB monitoring. Depends on koina.
-- **dianoia** — planning orchestrator. Multi-phase project state machine, workspace persistence. Depends on koina.
-- **thesauros** — domain pack loader. Reads `pack.yaml` manifests, registers pack tools and context overlays. Depends on koina + organon.
+- **melete**: distillation. Compresses conversation history when context windows fill up, flushes extracted knowledge to memory. Depends on koina + hermeneus.
+- **organon**: tool system. The `ToolRegistry` and `ToolExecutor` trait, plus built-in tools (write, edit, exec, web_search). Depends on koina + hermeneus.
+- **agora**: channel system. The `ChannelProvider` trait, Signal client (semeion), message routing via bindings. Depends on koina + taxis.
+- **oikonomos** (daemon): background task runner. Cron scheduling, prosoche attention checks, trace rotation, drift detection, DB monitoring. Depends on koina.
+- **dianoia**: planning orchestrator. Multi-phase project state machine, workspace persistence. Depends on koina.
+- **thesauros**: domain pack loader. Reads `pack.yaml` manifests, registers pack tools and context overlays. Depends on koina + organon.
 
 ### High (depends on multiple mid+low layers)
 
-- **nous** — the agent pipeline. `NousManager` owns all agents. `NousActor` is a Tokio actor (Alice Ryhl pattern) that runs the pipeline stages. Bootstrap file loading, recall integration, tool execution loop, finalization.
-- **pylon** — HTTP gateway. Axum router with versioned API (`/api/v1/`), SSE streaming, OpenAPI spec, Prometheus metrics, security middleware (CORS, CSRF, TLS, auth).
+- **nous**: the agent pipeline. `NousManager` owns all agents. `NousActor` is a Tokio actor (Alice Ryhl pattern) that runs the pipeline stages. Bootstrap file loading, recall integration, tool execution loop, finalization.
+- **pylon**: HTTP gateway. Axum router with versioned API (`/api/v1/`), SSE streaming, OpenAPI spec, Prometheus metrics, security middleware (CORS, CSRF, TLS, auth).
 
 ### Top
 
-- **aletheia** — the binary. Wires everything together, CLI parsing (clap), graceful shutdown.
-- **tui** — terminal dashboard. Separate workspace member at `tui/`.
+- **aletheia**: the binary. Wires everything together, CLI parsing (clap), graceful shutdown.
+- **tui**: terminal dashboard. Separate workspace member at `tui/`.
 
 ---
 
@@ -117,13 +117,13 @@ instance/
 ```
 
 Three-tier cascade (most specific wins):
-1. `nous/{id}/` — per-agent overrides
-2. `shared/` — shared across all agents
-3. `theke/` — human + agent collaborative space
+1. `nous/{id}/`: per-agent overrides
+2. `shared/`: shared across all agents
+3. `theke/`: human + agent collaborative space
 
 ---
 
-## Where to Start
+## Where to start
 
 | I want to... | Look at... |
 |--------------|------------|

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -14,7 +14,7 @@ Module and crate names use Greek terms reflecting their purpose (nous = mind, mn
 
 ---
 
-## The Binary
+## The binary
 
 ```text
 aletheia
@@ -44,7 +44,7 @@ aletheia
 
 ---
 
-## The Oikos (Instance Structure)
+## The Oikos (instance structure)
 
 Platform (tracked) vs. instance (gitignored). One directory, one boundary.
 
@@ -103,7 +103,7 @@ The oikos hierarchy is described in [CONFIGURATION.md](CONFIGURATION.md).
 
 ---
 
-## Rust Crate Workspace
+## Rust crate workspace
 
 Application crates in `crates/`, plus the `integration-tests` support crate.
 
@@ -124,19 +124,19 @@ Application crates in `crates/`, plus the `integration-tests` support crate.
 | `thesauros` | Domain pack loader - external knowledge, tools, config overlays | koina, organon |
 | `nous` | Agent pipeline, NousActor (tokio), bootstrap, recall, execute, finalize | koina, taxis, mneme, hermeneus, organon, melete, thesauros |
 | `pylon` | Axum HTTP gateway, SSE streaming, auth middleware | koina, taxis, hermeneus, organon, mneme, nous, symbolon |
-| `diaporeia` | MCP server interface for external AI agents — `crates/diaporeia` | koina, taxis, nous, organon, mneme, symbolon |
-| `theatron-core` | Shared presentation types and traits for Aletheia UIs — `crates/theatron/core/` | nothing (leaf) |
-| `theatron-tui` | Terminal dashboard — `crates/theatron/tui/` | theatron-core, reqwest (standalone UI client) |
+| `diaporeia` | MCP server interface for external AI agents (`crates/diaporeia`) | koina, taxis, nous, organon, mneme, symbolon |
+| `theatron-core` | Shared presentation types and traits for Aletheia UIs (`crates/theatron/core/`) | nothing (leaf) |
+| `theatron-tui` | Terminal dashboard (`crates/theatron/tui/`) | theatron-core, reqwest (standalone UI client) |
 | `aletheia` | Binary entrypoint (Clap CLI) - wires all crates together | taxis, hermeneus, organon, mneme, nous, symbolon, pylon, agora, thesauros, daemon, dianoia, theatron-tui (optional) |
 
 **Support crates** (not part of the application dependency graph):
 
 | Crate | Domain | Depends On |
 |-------|--------|------------|
-| `eval` | Behavioral eval framework — HTTP scenario runner | nothing (leaf) |
+| `eval` | Behavioral eval framework (HTTP scenario runner) | nothing (leaf) |
 | `integration-tests` | Cross-crate integration test suite | koina, taxis, mneme, hermeneus, nous, organon, pylon, symbolon, thesauros |
 
-### Dependency Graph
+### Dependency graph
 
 ```text
                           aletheia (binary)
@@ -162,7 +162,7 @@ Application crates in `crates/`, plus the `integration-tests` support crate.
 
 Imports flow downward only. Lower-layer crates must not depend on higher layers.
 
-### Trait Boundaries
+### Trait boundaries
 
 | Trait | Crate | Purpose |
 |-------|-------|---------|
@@ -170,7 +170,7 @@ Imports flow downward only. Lower-layer crates must not depend on higher layers.
 | `ChannelProvider` | agora | Send/receive on a messaging channel |
 | `LlmProvider` | hermeneus | LLM API calls |
 
-### Planned Crates
+### Planned crates
 
 | Crate | Domain | Milestone |
 |-------|--------|-----------|
@@ -179,9 +179,9 @@ Imports flow downward only. Lower-layer crates must not depend on higher layers.
 
 ---
 
-## Adding Components
+## Adding components
 
-### Rust Crate
+### Rust crate
 
 1. Create `crates/<name>/` with `Cargo.toml` and `src/lib.rs`
 2. Add to workspace `members` in root `Cargo.toml`
@@ -191,7 +191,7 @@ Imports flow downward only. Lower-layer crates must not depend on higher layers.
 
 ---
 
-## Release Profile
+## Release profile
 
 ```toml
 [profile.dev]
@@ -208,7 +208,7 @@ strip = "symbols"
 
 ---
 
-## Structural Properties
+## Structural properties
 
 - **koina is a true leaf node.** No workspace deps in Rust.
 - **symbolon depends only on koina** (plus external crates: reqwest, rusqlite, jsonwebtoken).

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -79,7 +79,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 #### Testing
 - Cross-crate integration test suite for cutover validation (#737)
 - Baseline tests for all 18 graph algorithms and KCore (#709)
-- Comprehensive markdown renderer test coverage (#673)
+- Complete markdown renderer test coverage (#673)
 - Phase B test hardening and instrumentation for mneme (#665)
 - Builtin tool executor tests for organon (#661)
 - mneme-engine and SQLite feature coexistence tests (#681)
@@ -135,7 +135,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
-## [1.3.0] — Memory System Audit & Overhaul
+## [1.3.0]: memory system audit & overhaul
 
 ### Added
 
@@ -175,7 +175,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - JWT, RBAC, sessions, audit log, retention, and TLS
 - Zero-config onboarding and hermeneus OAuth credential pill
 - Research stack, service watchdog, and workspace tooling
-- Comprehensive test suite with >80% coverage
+- Complete test suite with >80% coverage
 
 ### Fixed
 - Path traversal, RCE, auth bypass, and credential exposure
@@ -189,7 +189,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
-## [1.2.0] — Onboarding & Mac Support
+## [1.2.0]: onboarding & Mac support
 
 ### Added
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1,4 +1,4 @@
-# Configuration Reference
+# Configuration reference
 
 **File:** `instance/config/aletheia.toml`
 
@@ -12,7 +12,7 @@ Later layers override earlier ones. All field names use `snake_case` in YAML; `c
 
 ---
 
-## Table of Contents
+## Table of contents
 
 - [agents](#agents)
 - [gateway](#gateway)
@@ -46,7 +46,7 @@ Contains `defaults` (inherited by all agents) and `list` (per-agent definitions)
 | `thinking_budget` | u32 | `10000` | Max tokens for extended thinking |
 | `max_tool_iterations` | u32 | `50` | Safety limit on consecutive tool use per turn |
 | `allowed_roots` | string[] | `[]` | Filesystem paths the agent may access |
-| `tool_timeouts` | object | see below | Per-tool execution timeout overrides |
+| `tool_timeouts` | object | see `agents.defaults.tool_timeouts` section | Per-tool execution timeout overrides |
 
 #### agents.defaults.caching
 
@@ -226,7 +226,7 @@ channels:
 
 ## bindings
 
-Array of routing rules mapping channel sources to agents. Evaluated in order — first match wins.
+Array of routing rules mapping channel sources to agents. Evaluated in order; first match wins.
 
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
@@ -267,7 +267,7 @@ embedding:
   dimension: 384
 ```
 
-The `mock` provider returns zero vectors — useful for development without loading ML models.
+The `mock` provider returns zero vectors, useful for development without loading ML models.
 
 ---
 
@@ -405,7 +405,7 @@ sandbox:
 
 ---
 
-## Environment Variables
+## Environment variables
 
 Any config key can be set via environment variable with the `ALETHEIA_` prefix and double underscores for nesting:
 
@@ -420,7 +420,7 @@ The `ANTHROPIC_API_KEY` environment variable is read separately by the provider 
 
 ---
 
-## Minimal Config
+## Minimal config
 
 ```yaml
 agents:

--- a/docs/DATA.md
+++ b/docs/DATA.md
@@ -1,8 +1,8 @@
-# Data Sovereignty
+# Data sovereignty
 
 What Aletheia stores, where it lives, and how to control it.
 
-## Data Inventory
+## Data inventory
 
 | Data | Location | Format | Description |
 |------|----------|--------|-------------|
@@ -18,7 +18,7 @@ What Aletheia stores, where it lives, and how to control it.
 | Backups | `instance/data/backups/` | SQLite | Point-in-time session database copies |
 | Archives | `instance/data/archive/` | JSON | Retained session exports before deletion |
 
-## Storage Locations
+## Storage locations
 
 All data lives under the instance root directory. Default: `./instance`. Override with `ALETHEIA_ROOT` or the `-r` flag.
 
@@ -38,7 +38,7 @@ instance/
 └── signal/                  # Signal messenger data
 ```
 
-## Data Flow
+## Data flow
 
 ```text
 Inbound message
@@ -53,7 +53,7 @@ Inbound message
 
 All processing happens locally. The only external call is to the configured LLM provider (Anthropic by default) for inference.
 
-## Retention Defaults
+## Retention defaults
 
 Configured in `instance/config/aletheia.toml` under `data.retention`:
 
@@ -70,7 +70,7 @@ The retention policy only deletes **closed** sessions (archived or distilled). A
 
 When `archiveBeforeDelete` is true, each session is exported to `instance/data/archive/sessions/{session_id}.json` before removal.
 
-## Backup and Export
+## Backup and export
 
 ### Create a backup
 
@@ -139,7 +139,7 @@ rm -rf instance/nous/*/memory/
 
 The database will be recreated on next startup with the migration framework.
 
-## Third-Party Data Flows
+## Third-party data flows
 
 | Destination | Data Sent | When |
 |-------------|-----------|------|
@@ -148,7 +148,7 @@ The database will be recreated on next startup with the migration framework.
 
 **Everything else stays local.** The knowledge graph, embeddings, session history, agent workspaces, configuration, and credentials never leave your machine.
 
-## Privacy by Default
+## Privacy by default
 
 - **No telemetry.** No usage data, analytics, or crash reports.
 - **No phone-home.** No update checks, license validation, or beacon requests.

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -4,7 +4,7 @@ Step-by-step guide from bare Linux or macOS to a running Aletheia instance. For 
 
 ---
 
-## System Requirements
+## System requirements
 
 ### Hardware
 
@@ -14,7 +14,7 @@ Step-by-step guide from bare Linux or macOS to a running Aletheia instance. For 
 | RAM | 2 GB | 4 GB (candle model loading) |
 | Disk | 1 GB | 10 GB (session data growth) |
 
-### Operating System
+### Operating system
 
 | Target | Notes |
 |--------|-------|
@@ -41,7 +41,7 @@ See [NETWORK.md](NETWORK.md) for the complete network call inventory.
 
 ## Installation
 
-### Prebuilt Binary
+### Prebuilt binary
 
 Download from [GitHub Releases](https://github.com/forkwright/aletheia/releases):
 
@@ -57,7 +57,7 @@ chmod +x aletheia-linux-amd64
 sudo mv aletheia-linux-amd64 /usr/local/bin/aletheia
 ```
 
-### Build from Source
+### Build from source
 
 ```bash
 git clone https://github.com/forkwright/aletheia.git
@@ -67,9 +67,9 @@ cargo build --release
 
 Binary: `target/release/aletheia`
 
-### Headless Build (no TUI)
+### Headless build (no TUI)
 
-The TUI (terminal dashboard) is compiled in by default. To build without it — useful for servers, containers, or minimal footprints — disable the `tui` feature:
+The TUI (terminal dashboard) is compiled in by default. To build without it (useful for servers, containers, or minimal footprints), disable the `tui` feature:
 
 ```bash
 cargo build --release --no-default-features --features tls
@@ -77,15 +77,15 @@ cargo build --release --no-default-features --features tls
 
 The headless binary accepts all the same CLI flags and API endpoints. The `aletheia status` command falls back to a plain-text summary when TUI is absent.
 
-### Shell Completions
+### Shell completions
 
 See [SHELL-COMPLETIONS.md](SHELL-COMPLETIONS.md) for setting up tab-completion in bash, zsh, and fish.
 
 ---
 
-## Instance Setup
+## Instance setup
 
-The instance directory holds all runtime state: config, databases, agent workspaces, logs. It is gitignored — the platform code ships without instance data.
+The instance directory holds all runtime state: config, databases, agent workspaces, logs. It is gitignored; the platform code ships without instance data.
 
 ### Recommended: use the init wizard
 
@@ -108,7 +108,7 @@ Copy the example scaffold to create your instance directory:
 cp -r instance.example instance
 ```
 
-Then configure `instance/config/aletheia.toml` (see below). The scaffold provides a template with all required directories and example configuration files.
+Then configure `instance/config/aletheia.toml` (see the Configuration section). The scaffold provides a template with all required directories and example configuration files.
 
 This creates the full directory scaffold:
 
@@ -129,7 +129,7 @@ instance/
 
 See [instance.example/README.md](../instance.example/README.md) for the three-tier cascade and what goes where.
 
-### Instance Discovery
+### Instance discovery
 
 The binary finds the instance directory in this order:
 
@@ -168,7 +168,7 @@ agents:
       workspace: instance/nous/main
 ```
 
-The workspace path can be relative (relative to the instance root) or absolute. In the example above, `instance/nous/main` is relative and will resolve to `./instance/instance/nous/main` when the instance root is `./instance`. For absolute paths, use the full filesystem path: `/srv/aletheia/instance/nous/main`.
+The workspace path can be relative (relative to the instance root) or absolute. In this example, `instance/nous/main` is relative and will resolve to `./instance/instance/nous/main` when the instance root is `./instance`. For absolute paths, use the full filesystem path: `/srv/aletheia/instance/nous/main`.
 
 The config cascade loads in order (later wins): compiled defaults, YAML file, `ALETHEIA_` environment variables. See [CONFIGURATION.md](CONFIGURATION.md) for the complete reference.
 
@@ -241,7 +241,7 @@ mode = "none"
 
 ## Credentials
 
-### LLM Provider
+### LLM provider
 
 Set the Anthropic API key as an environment variable:
 
@@ -251,7 +251,7 @@ export ANTHROPIC_API_KEY="sk-ant-..."
 
 The binary reads `ANTHROPIC_API_KEY` from the environment at startup. If unset, it starts without an LLM provider (health check reports degraded status).
 
-### TLS (Optional)
+### TLS (optional)
 
 Generate self-signed certificates for LAN use:
 
@@ -271,7 +271,7 @@ gateway:
 
 ---
 
-## Agent Setup
+## Agent setup
 
 Each agent needs a workspace directory under `instance/nous/`:
 
@@ -280,10 +280,10 @@ cp -r instance/nous/_template instance/nous/main
 ```
 
 Edit the bootstrap files:
-- `SOUL.md` — agent identity and character
-- `IDENTITY.md` — display name, emoji
-- `GOALS.md` — current goals
-- `MEMORY.md` — persistent operational memory
+- `SOUL.md`: agent identity and character
+- `IDENTITY.md`: display name, emoji
+- `GOALS.md`: current goals
+- `MEMORY.md`: persistent operational memory
 
 Register the agent in `aletheia.toml`:
 
@@ -296,7 +296,7 @@ agents:
 
 ---
 
-## First Run
+## First run
 
 ```bash
 aletheia --instance-root ./instance
@@ -320,7 +320,7 @@ The startup sequence:
 8. Starts channel listeners (Signal, if configured)
 9. Starts HTTP gateway on configured bind:port
 
-### CLI Flags
+### CLI flags
 
 | Flag | Default | Description |
 |------|---------|-------------|
@@ -334,7 +334,7 @@ The startup sequence:
 
 ## Verification
 
-### Health Check
+### Health check
 
 ```bash
 # CLI
@@ -360,7 +360,7 @@ Healthy response:
 
 Status values: `healthy` (all pass), `degraded` (warnings, e.g. no LLM provider), `unhealthy` (failures).
 
-### System Status
+### System status
 
 ```bash
 aletheia status
@@ -368,7 +368,7 @@ aletheia status
 
 Displays agent count, active sessions, uptime, and provider status.
 
-### Prometheus Metrics
+### Prometheus metrics
 
 ```bash
 curl -s http://127.0.0.1:18789/metrics
@@ -378,7 +378,7 @@ Exposes `nous_turn_duration_seconds`, `anthropic_requests_total`, `http_requests
 
 ---
 
-## Systemd Service (Linux)
+## Systemd service (Linux)
 
 A ready-to-use service template lives in `instance.example/services/aletheia.service`.
 It uses `%h` (systemd's `$HOME` specifier) so paths resolve automatically.
@@ -452,14 +452,14 @@ aletheia maintenance run all                    # run everything
 | `ANTHROPIC_API_KEY not set` | Export the env var or add to systemd `Environment=` |
 | Port already in use | `fuser -k 18789/tcp` then restart, or change `gateway.port` in config |
 | Config parse error | Check YAML syntax, verify field names match [CONFIGURATION.md](CONFIGURATION.md) |
-| Health returns `degraded` | No LLM provider registered — check API key |
-| Health returns `unhealthy` | Session store failed to open — check `instance/data/` permissions |
+| Health returns `degraded` | No LLM provider registered; check API key |
+| Health returns `unhealthy` | Session store failed to open; check `instance/data/` permissions |
 | Signal not receiving | Verify signal-cli daemon is running on configured host:port |
-| Bind address error | Check `--bind` flag or `gateway.bind` config — `lan` resolves to LAN interface |
+| Bind address error | Check `--bind` flag or `gateway.bind` config; `lan` resolves to LAN interface |
 
 ---
 
-## Optional: Signal Messaging
+## Optional: Signal messaging
 
 Aletheia can receive and send messages via [Signal](https://signal.org/) using the [signal-cli](https://github.com/AsamK/signal-cli) JSON-RPC daemon.
 

--- a/docs/HISTORY-CLEANUP.md
+++ b/docs/HISTORY-CLEANUP.md
@@ -1,4 +1,4 @@
-# Git History Cleanup Plan
+# Git history cleanup plan
 
 Items to address via `git filter-repo`:
 

--- a/docs/NETWORK.md
+++ b/docs/NETWORK.md
@@ -1,27 +1,27 @@
-# Network Call Inventory
+# Network call inventory
 
 Every outbound network connection Aletheia makes, documented for transparency.
 
 ---
 
-## Outbound Connections
+## Outbound connections
 
 | Destination | Protocol | Port | When | Data Sent | Configurable |
 |-------------|----------|------|------|-----------|-------------|
 | `api.anthropic.com` | HTTPS | 443 | Every LLM call | Conversation messages, system prompts, tool call results | `ANTHROPIC_API_KEY` env var; base URL via provider config |
 | signal-cli daemon | HTTP (JSON-RPC) | 8080 | When Signal channel is enabled | Message text, recipient IDs | `channels.signal.accounts.*.http_host`, `http_port` |
 
-## Local-Only Components
+## Local-only components
 
 These components make **no network calls**:
 
-- **candle** — pure Rust inference for embeddings, runs entirely in-process
-- **mneme** — embedded graph + vector database, no network protocol
-- **SQLite** — session store, file-based
-- **Prometheus metrics** — passive endpoint (`GET /metrics`), scraped by external collector
-- **Configuration loading** — reads local YAML file only
+- **candle**: pure Rust inference for embeddings, runs entirely in-process
+- **mneme**: embedded graph + vector database, no network protocol
+- **SQLite**: session store, file-based
+- **Prometheus metrics**: passive endpoint (`GET /metrics`), scraped by external collector
+- **Configuration loading**: reads local YAML file only
 
-## Inbound Connections
+## Inbound connections
 
 | Listener | Protocol | Default Port | Purpose |
 |----------|----------|-------------|---------|
@@ -29,7 +29,7 @@ These components make **no network calls**:
 
 ---
 
-## No Telemetry
+## No telemetry
 
 Aletheia makes zero unsolicited outbound network connections. There is no:
 
@@ -41,20 +41,20 @@ Aletheia makes zero unsolicited outbound network connections. There is no:
 
 The only outbound connections are to services you explicitly configure (LLM provider, Signal). Crates that use `reqwest`:
 
-- `hermeneus` — LLM provider API calls (Anthropic, etc.)
-- `agora` — Signal JSON-RPC (localhost)
-- `symbolon` — OAuth token refresh/validation
-- `organon` — tool execution (web_search, HTTP tools)
-- `nous` — pipeline HTTP calls
-- `aletheia` — binary entry point (health checks, eval runner)
-- `eval` (dokimion) — behavioral eval HTTP scenario runner
-- `tui` — terminal dashboard API client
+- `hermeneus`: LLM provider API calls (Anthropic, etc.)
+- `agora`: Signal JSON-RPC (localhost)
+- `symbolon`: OAuth token refresh/validation
+- `organon`: tool execution (web_search, HTTP tools)
+- `nous`: pipeline HTTP calls
+- `aletheia`: binary entry point (health checks, eval runner)
+- `eval` (dokimion): behavioral eval HTTP scenario runner
+- `tui`: terminal dashboard API client
 
 All reqwest usage targets either the configured LLM provider, localhost services, or user-initiated tool calls. No unsolicited outbound connections.
 
 ---
 
-## Firewall Rules
+## Firewall rules
 
 Minimum rules for a working deployment:
 
@@ -68,7 +68,7 @@ Air-gapped operation is possible with a local LLM provider (configurable base UR
 
 ---
 
-## Data Flow Diagram
+## Data flow diagram
 
 ```text
                     INBOUND                              OUTBOUND
@@ -104,12 +104,12 @@ Air-gapped operation is possible with a local LLM provider (configurable base UR
             LOCAL          LOCAL          LOCAL
 ```
 
-### What Leaves the System
+### What leaves the system
 
 - **User messages and system prompts** → sent to Anthropic API for inference
 - **Signal messages** → routed through Signal protocol (E2E encrypted)
 
-### What Stays Local
+### What stays local
 
 - **Session history** → SQLite (`instance/data/sessions.db`)
 - **Knowledge graphs and vectors** → mneme (embedded Datalog engine)

--- a/docs/NIX.md
+++ b/docs/NIX.md
@@ -7,22 +7,22 @@ tags:
   - infrastructure
 ---
 
-# Nix Language & NixOS Standards
+# Nix language & NixOS standards
 
 > Companion to `standards/RUST.md`. This covers Nix the language, flake conventions, NixOS module patterns, and Aletheia-specific packaging decisions.
 
 ---
 
-## Table of Contents
+## Table of contents
 
 1. [Philosophy](#1-philosophy)
-2. [Language Fundamentals](#2-language-fundamentals)
-3. [Style & Formatting](#3-style--formatting)
-4. [Flake Structure](#4-flake-structure)
-5. [Module Patterns](#5-module-patterns)
-6. [Derivation & Packaging](#6-derivation--packaging)
-7. [Anti-Patterns](#7-anti-patterns)
-8. [Our Conventions](#8-our-conventions)
+2. [Language fundamentals](#2-language-fundamentals)
+3. [Style & formatting](#3-style--formatting)
+4. [Flake structure](#4-flake-structure)
+5. [Module patterns](#5-module-patterns)
+6. [Derivation & packaging](#6-derivation--packaging)
+7. [Anti-patterns](#7-anti-patterns)
+8. [Our conventions](#8-our-conventions)
 9. [Tooling](#9-tooling)
 10. [Reference](#10-reference)
 
@@ -42,15 +42,15 @@ Core mental model shift from imperative Linux:
 | Rollback = hope + backups | Rollback = `nixos-rebuild switch --rollback` |
 | "Works on my machine" | Reproducible by definition (same inputs → same outputs) |
 
-**Why this matters for Aletheia:** One flake, multiple deployment targets — server (worker-node), desktop (Metis replacement), USB recovery stick. The system state IS a git commit.
+**Why this matters for Aletheia:** One flake, multiple deployment targets: server (worker-node), desktop (Metis replacement), USB recovery stick. The system state IS a git commit.
 
 ---
 
-## 2. Language Fundamentals
+## 2. Language fundamentals
 
 ### Types
 
-Nix has very few types. This is intentional — simplicity enables reproducibility.
+Nix has very few types. This is intentional; simplicity enables reproducibility.
 
 **Primitive types:**
 
@@ -93,9 +93,9 @@ x: y: x + y
 { foo, bar, ... }: foo + bar
 ```
 
-### Key Expressions
+### Key expressions
 
-**`let ... in`** — Local bindings. The workhorse of factoring out code:
+**`let ... in`**: Local bindings. The workhorse of factoring out code:
 
 ```nix
 let
@@ -105,7 +105,7 @@ in
   pkgs.mkShell { name = "my-shell-${version}"; }
 ```
 
-**`if ... then ... else`** — Everything is an expression. `if` returns a value:
+**`if ... then ... else`**: Everything is an expression. `if` returns a value:
 
 ```nix
 {
@@ -113,7 +113,7 @@ in
 }
 ```
 
-**`inherit`** — Shorthand for `x = x` in attrsets. NOT OOP inheritance:
+**`inherit`**: Shorthand for `x = x` in attrsets. NOT OOP inheritance:
 
 ```nix
 let
@@ -124,14 +124,14 @@ in {
 }
 ```
 
-**`with`** — Brings attrset keys into scope. **Use sparingly** (see Anti-Patterns):
+**`with`**: Brings attrset keys into scope. **Use sparingly** (see Anti-Patterns):
 
 ```nix
 with pkgs; [ git curl jq ]
 # equivalent to: [ pkgs.git pkgs.curl pkgs.jq ]
 ```
 
-**`//`** — Shallow merge of attrsets. Right takes precedence:
+**`//`**: Shallow merge of attrsets. Right takes precedence:
 
 ```nix
 { a = 1; b = { x = 1; }; } // { b = 2; c = 3; }
@@ -150,11 +150,11 @@ Nix is lazily evaluated. Values are only computed when needed. This enables:
 
 ---
 
-## 3. Style & Formatting
+## 3. Style & formatting
 
 ### Formatter
 
-**nixfmt** (RFC 166) — the official Nix formatter, adopted by the NixOS project in 2024.
+**nixfmt** (RFC 166): the official Nix formatter, adopted by the NixOS project in 2024.
 
 ```bash
 # Format a file
@@ -166,7 +166,7 @@ nixfmt --check file.nix
 
 Not alejandra. nixfmt is the official standard now.
 
-### Naming Conventions
+### Naming conventions
 
 | Context | Convention | Example |
 |---------|-----------|---------|
@@ -191,7 +191,7 @@ Two spaces. No tabs. Consistent with our Rust style.
 
 Use comments to explain **why**, not what. Same philosophy as Rust standards.
 
-### String Style
+### String style
 
 ```nix
 # Short strings: double quotes
@@ -210,7 +210,7 @@ Use comments to explain **why**, not what. Same philosophy as Rust standards.
 
 ---
 
-## 4. Flake Structure
+## 4. Flake structure
 
 ### Anatomy
 
@@ -230,11 +230,11 @@ Every flake has three top-level attributes:
 }
 ```
 
-- `description` — Simple string. No Nix evaluation allowed at top level.
-- `inputs` — Flake references (other flakes, git repos, paths). Locked by `flake.lock`.
-- `outputs` — A function from inputs to an attrset following the flake schema.
+- `description`: Simple string. No Nix evaluation allowed at top level.
+- `inputs`: Flake references (other flakes, git repos, paths). Locked by `flake.lock`.
+- `outputs`: A function from inputs to an attrset following the flake schema.
 
-### Input Conventions
+### Input conventions
 
 ```nix
 inputs = {
@@ -257,7 +257,7 @@ inputs = {
 
 **Always use `.follows`** for transitive nixpkgs dependencies. Without it, different inputs can pull different nixpkgs versions, breaking the reproducibility guarantee.
 
-### Output Schema
+### Output schema
 
 ```nix
 outputs = { self, nixpkgs, crane, ... }: {
@@ -280,7 +280,7 @@ outputs = { self, nixpkgs, crane, ... }: {
 };
 ```
 
-### Multi-System Pattern
+### Multi-system pattern
 
 Don't repeat yourself per architecture. Use `lib.genAttrs` or a helper:
 
@@ -300,9 +300,9 @@ in {
 }
 ```
 
-Or use `flake-utils.lib.eachDefaultSystem` — but understand what it does. It's just a helper that generates the per-system attrsets. Don't put system-independent outputs (modules, overlays) inside it.
+Or use `flake-utils.lib.eachDefaultSystem`, but understand what it does. It's just a helper that generates the per-system attrsets. Don't put system-independent outputs (modules, overlays) inside it.
 
-### Lock File
+### Lock file
 
 `flake.lock` is auto-generated and pinpoints exact versions of all inputs. **Commit it.** It IS your reproducibility. Update intentionally:
 
@@ -314,11 +314,11 @@ nix flake lock --update-input nixpkgs  # Older syntax
 
 ---
 
-## 5. Module Patterns
+## 5. Module patterns
 
 NixOS modules are the building blocks of system configuration. A module is a function that returns an attrset with `imports`, `options`, and `config`.
 
-### Module Structure
+### Module structure
 
 ```nix
 { config, lib, pkgs, ... }:
@@ -368,17 +368,17 @@ in {
 }
 ```
 
-### Key Module Functions
+### Key module functions
 
 | Function | Priority | Purpose |
 |----------|----------|---------|
 | `lib.mkDefault` | 1000 | Set default value (overridable by normal assignment at priority 100) |
 | `lib.mkForce` | 50 | Force a value (overrides almost everything) |
 | `lib.mkOverride N` | N | Set with specific priority (lower number = higher priority) |
-| `lib.mkIf cond { ... }` | — | Conditional config. Only evaluates if `cond` is true. |
-| `lib.mkMerge [ ... ]` | — | Merge multiple config fragments. Use inside `config =`. |
-| `lib.mkEnableOption "desc"` | — | Shorthand for a boolean option with default `false`. |
-| `lib.mkPackageOption pkgs "name" {}` | — | Package option with default from pkgs. |
+| `lib.mkIf cond { ... }` | n/a | Conditional config. Only evaluates if `cond` is true. |
+| `lib.mkMerge [ ... ]` | n/a | Merge multiple config fragments. Use inside `config =`. |
+| `lib.mkEnableOption "desc"` | n/a | Shorthand for a boolean option with default `false`. |
+| `lib.mkPackageOption pkgs "name" {}` | n/a | Package option with default from pkgs. |
 | `lib.mkBefore content` | 500 | Place content before default in ordered merges (lists, strings). |
 | `lib.mkAfter content` | 1500 | Place content after default in ordered merges. |
 
@@ -392,7 +392,7 @@ let cfg = config.services.aletheia; in { ... }
 
 This avoids repeating `config.services.aletheia.enable` everywhere.
 
-### Pattern: Conditional blocks with mkIf + mkMerge
+### Pattern: conditional blocks with mkIf + mkMerge
 
 ```nix
 config = lib.mkMerge [
@@ -405,7 +405,7 @@ config = lib.mkMerge [
 ];
 ```
 
-### Pattern: Module composition
+### Pattern: module composition
 
 Split config into logical files. Use `imports` to compose:
 
@@ -428,7 +428,7 @@ modules/
 
 ---
 
-## 6. Derivation & Packaging
+## 6. Derivation & packaging
 
 ### Rust with Crane
 
@@ -480,7 +480,7 @@ in {
 | `buildRustPackage` (nixpkgs) | ❌ Avoid | Single-phase, rebuilds deps on every source change, requires `cargoHash` |
 | `naersk` | ❌ Avoid | Maintained but less composable than crane, smaller community |
 
-### NixOS Configuration
+### NixOS configuration
 
 ```nix
 nixosConfigurations.worker-node = nixpkgs.lib.nixosSystem {
@@ -499,7 +499,7 @@ nixosConfigurations.worker-node = nixpkgs.lib.nixosSystem {
 };
 ```
 
-### Development Shell
+### Development shell
 
 ```nix
 devShells.default = pkgs.mkShell {
@@ -516,9 +516,9 @@ devShells.default = pkgs.mkShell {
 
 ---
 
-## 7. Anti-Patterns
+## 7. Anti-patterns
 
-### ❌ `rec { ... }` — Avoid recursive attrsets
+### ❌ `rec { ... }`: avoid recursive attrsets
 
 ```nix
 # BAD: Easy to create infinite recursion by shadowing
@@ -542,7 +542,7 @@ let
 in attrset
 ```
 
-### ❌ `with` at file scope — Pollutes namespace
+### ❌ `with` at file scope: pollutes namespace
 
 ```nix
 # BAD: Where does `curl` come from? Static analysis can't tell.
@@ -571,7 +571,7 @@ with pkgs;
 # Prefer explicit pkgs.X for anything non-trivial.
 ```
 
-### ❌ Lookup paths (`<nixpkgs>`) — Non-reproducible
+### ❌ Lookup paths (`<nixpkgs>`): non-reproducible
 
 ```nix
 # BAD: Depends on $NIX_PATH environment variable
@@ -581,7 +581,7 @@ import <nixpkgs> {}
 import nixpkgs { system = "x86_64-linux"; config = {}; overlays = []; }
 ```
 
-### ❌ Unpinned `import <nixpkgs> {}` — Impure config
+### ❌ Unpinned `import <nixpkgs> {}`: impure config
 
 ```nix
 # BAD: System files can influence the result
@@ -647,9 +647,9 @@ flake-utils.lib.eachDefaultSystem (system: {
 
 ---
 
-## 8. Our Conventions
+## 8. Our conventions
 
-### Aletheia Flake Structure
+### Aletheia flake structure
 
 ```
 aletheia/
@@ -692,7 +692,7 @@ aletheia/
 11. **Checks gate CI.** `nix flake check` must pass. Include clippy, tests, formatting.
 12. **No lookup paths.** No `<nixpkgs>`. No `$NIX_PATH` dependencies.
 
-### Aletheia-Specific Packaging Notes
+### Aletheia-specific packaging notes
 
 From the [Nix integration plan](../planning/nix-integration.md):
 
@@ -745,7 +745,7 @@ nix why-depends ./result /nix/store/<hash>-foo
 
 ## 10. Reference
 
-### Useful Builtins
+### Useful builtins
 
 | Function | Purpose |
 |----------|---------|
@@ -764,7 +764,7 @@ nix why-depends ./result /nix/store/<hash>-foo
 | `builtins.toString x` | Convert to string (wider than interpolation) |
 | `builtins.typeOf x` | Returns type name as string |
 
-### Useful lib Functions
+### Useful lib functions
 
 | Function | Purpose |
 |----------|---------|
@@ -789,9 +789,9 @@ nix why-depends ./result /nix/store/<hash>-foo
 | `lib.traceValSeq x` | Deep-eval then print (debug) |
 | `lib.fix f` | Fixed-point combinator (self-referencing values) |
 
-### Learning Path
+### Learning path
 
-1. **Nix language:** [ayats.org/blog/nix-tuto-1](https://ayats.org/blog/nix-tuto-1) — best single tutorial
+1. **Nix language:** [ayats.org/blog/nix-tuto-1](https://ayats.org/blog/nix-tuto-1) (best single tutorial)
 2. **Derivations:** [ayats.org/blog/nix-tuto-2](https://ayats.org/blog/nix-tuto-2)
 3. **Flakes:** [Practical Nix flake anatomy](https://vtimofeenko.com/posts/practical-nix-flake-anatomy-a-guided-tour-of-flake.nix/)
 4. **NixOS modules:** [NixOS Modules Explained](https://saylesss88.github.io/NixOS_Modules_Explained_3.html)

--- a/docs/PACKS.md
+++ b/docs/PACKS.md
@@ -2,7 +2,7 @@
 
 A domain pack bundles knowledge, tools, and configuration overlays that extend an Aletheia agent without modifying the core runtime. Packs keep domain-specific content (company IP, schemas, runbooks) separate from generic agent infrastructure.
 
-## Directory Structure
+## Directory structure
 
 ```text
 my-pack/
@@ -61,7 +61,7 @@ description = "SQL query to execute"
 domains = ["healthcare", "sql"]
 ```
 
-## Context Entries
+## Context entries
 
 Each context entry maps to a file injected into the agent's system prompt at startup.
 
@@ -80,7 +80,7 @@ Priority controls inclusion order when the token budget is tight:
 
 The `agents` field filters which agents receive the section. An empty list means all agents. Values match against both agent IDs (e.g., `chiron`) and domain tags (e.g., `healthcare`).
 
-## Tool Definitions
+## Tool definitions
 
 Tools are shell commands exposed to the LLM as callable functions. The runtime pipes JSON to stdin and reads JSON from stdout.
 
@@ -126,7 +126,7 @@ Domain merging at startup:
 2. Pack overlay domains (union across all loaded packs)
 3. Combined domains stored on the agent's config
 
-## How It Works
+## How it works
 
 ### Bootstrap injection
 Context entries load into `PackSection` values, filter by agent ID and domain tags, convert to `BootstrapSection` values, and merge into the bootstrap assembler alongside workspace files (SOUL.md, USER.md, etc.). Pack sections participate in the same priority sorting and token budget as workspace files.
@@ -137,7 +137,7 @@ Tool definitions are validated (command exists, path is safe, schema parses), co
 ### Domain resolution
 At spawn time, the manager calls `sections_for_agent_or_domains(agent_id, domains)` on each loaded pack. A section matches if its `agents` list is empty, contains the agent ID, or contains any of the agent's domain tags.
 
-## How to Create a Custom Pack
+## How to create a custom pack
 
 1. **Create the pack directory** anywhere on the filesystem (e.g., `instance/packs/my-pack/`).
 
@@ -226,7 +226,7 @@ agents = ["healthcare"]
 domains = ["healthcare"]
 ```
 
-## Pack Resolution Order
+## Pack resolution order
 
 Packs are loaded in the order they appear in the `packs` config list. When multiple packs match an agent:
 
@@ -234,10 +234,10 @@ Packs are loaded in the order they appear in the `packs` config list. When multi
 - **Tools**: tool names must be unique across all packs; duplicates are rejected at startup
 - **Domain overlays**: merged (union) across all packs for each agent
 
-There is no override or shadowing mechanism — packs compose, they do not replace each other.
+There is no override or shadowing mechanism; packs compose, they do not replace each other.
 
-## See Also
+## See also
 
-- `instance.example/packs/starter/` — minimal working example
-- `docs/CONFIGURATION.md` — full `aletheia.yaml` reference
-- `crates/thesauros/` — pack loader source
+- `instance.example/packs/starter/`: minimal working example
+- `docs/CONFIGURATION.md`: full `aletheia.yaml` reference
+- `crates/thesauros/`: pack loader source

--- a/docs/PII-REWRITE.md
+++ b/docs/PII-REWRITE.md
@@ -1,11 +1,11 @@
-# PII History Rewrite
+# PII history rewrite
 
 Documents the git history rewrite performed to remove personally identifiable
 information from the Aletheia repository prior to public release.
 
-## What Was Found
+## What was found
 
-### Author/Committer Fields
+### Author/committer fields
 The following identities contained PII (real names, work emails, business names):
 
 | Identity | PII Type |
@@ -18,11 +18,11 @@ The following identities contained PII (real names, work emails, business names)
 Non-PII pseudonymous identities (`Aletheia`, `Syn`, `Demiurge`) were also
 consolidated for consistency.
 
-### Co-Authored-By Trailers
+### Co-authored-by trailers
 Multiple commit messages contained `Co-authored-by:` trailers with real names
 and emails. All were removed.
 
-### Commit Message Bodies
+### Commit message bodies
 Some commit messages referenced:
 - `REDACTED/aletheia` (GitHub username with real surname)
 - `/home/REDACTED/` (home directory paths)
@@ -33,12 +33,12 @@ Some commit messages referenced:
 `.github/pii-patterns.txt` contained a regex pattern matching a real surname.
 Genericized to `[A-Za-z]{3,}ample\b`.
 
-## What Was Changed
+## What was changed
 
 ### Tool
 `git filter-repo` with `--mailmap` and `--message-callback`.
 
-### Identity Consolidation (.mailmap)
+### Identity consolidation (.mailmap)
 All human identities were mapped to: `Cody <cody@aletheia.dev>`
 
 Bot identities were preserved:
@@ -46,7 +46,7 @@ Bot identities were preserved:
 - `github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>`
 - `GitHub <noreply@github.com>` (committer for web merges)
 
-### Message Rewrites
+### Message rewrites
 | Pattern | Replacement |
 |---------|-------------|
 | `Co-authored-by:` trailers | Removed |
@@ -63,10 +63,10 @@ Bot identities were preserved:
 | `REDACTED` (username) | `cody` |
 | `REDACTED` (surname, word boundary) | `Cody` |
 
-### File Changes
+### File changes
 - `.github/pii-patterns.txt`: surname-specific regex → `[A-Za-z]{3,}ample\b`
 
-## How to Verify
+## How to verify
 
 ```bash
 # No PII in author/committer fields

--- a/docs/PROJECT.md
+++ b/docs/PROJECT.md
@@ -1,4 +1,4 @@
-# Aletheia - Project Plan
+# Aletheia - project plan
 
 Roadmap and design intent for Aletheia's evolution.
 
@@ -26,14 +26,14 @@ See [TECHNOLOGY.md](TECHNOLOGY.md) for technology decisions, dependency policy, 
 
 | Milestone | Summary | Status |
 |-----------|---------|--------|
-| M0a | Oikos migration — instance structure, tool resolution, config cascade | Done |
-| M0b | Foundation crates — koina errors, taxis config, newtypes, tracing | Done |
-| M1 | Memory + LLM client — Anthropic streaming, embedded Datalog engine, hybrid recall, embeddings | Done |
-| M2 | Agent core — tool registry, nous pipeline, bootstrap assembly, execute stage | Done |
-| M3 | Gateway + auth + channels — pylon HTTP, symbolon JWT, agora Signal, end-to-end wiring | Done |
-| M4 | Multi-nous + background — NousActor, daemon, dianoia planning, cross-nous sessions | Done |
-| M5 | Plugins + portability — WASM plugins, agent export/import (autarkeia #507, skills #676-#696) | In progress |
-| M6 | Platform extensions — composable ops, A2A interop, eBPF sensing, NixOS module | Backlog |
+| M0a | Oikos migration: instance structure, tool resolution, config cascade | Done |
+| M0b | Foundation crates: koina errors, taxis config, newtypes, tracing | Done |
+| M1 | Memory + LLM client: Anthropic streaming, embedded Datalog engine, hybrid recall, embeddings | Done |
+| M2 | Agent core: tool registry, nous pipeline, bootstrap assembly, execute stage | Done |
+| M3 | Gateway + auth + channels: pylon HTTP, symbolon JWT, agora Signal, end-to-end wiring | Done |
+| M4 | Multi-nous + background: NousActor, daemon, dianoia planning, cross-nous sessions | Done |
+| M5 | Plugins + portability: WASM plugins, agent export/import (autarkeia #507, skills #676-#696) | In progress |
+| M6 | Platform extensions: composable ops, A2A interop, eBPF sensing, NixOS module | Backlog |
 
 See `Cargo.toml` workspace members for current crate inventory.
 
@@ -46,7 +46,7 @@ See `Cargo.toml` workspace members for current crate inventory.
 | HTTP API | Active | REST on port 18789, SSE streaming |
 | Desktop app | Planned | Design knowledge captured in planning docs |
 
-## Related Documents
+## Related documents
 
 | Document | Purpose |
 |----------|---------|

--- a/docs/PROSOCHE.md
+++ b/docs/PROSOCHE.md
@@ -1,6 +1,6 @@
-# Prosoche — Attention System
+# Prosoche: attention system
 
-**prosoche** (Greek: προσοχή) means "directed attention." In Stoic practice, prosoche is the discipline of sustained awareness — you cannot reveal what is hidden (aletheia) without first attending carefully.
+**prosoche** (Greek: προσοχή) means "directed attention." In Stoic practice, prosoche is the discipline of sustained awareness; you cannot reveal what is hidden (aletheia) without first attending carefully.
 
 In Aletheia, prosoche is the **heartbeat subsystem**: a periodic background check that prompts each agent to survey its environment and report anything that needs attention.
 
@@ -20,7 +20,7 @@ aletheia binary
     └── DaemonBridge — sends prompts to nous actors
 ```
 
-### Data Flow
+### Data flow
 
 1. `TaskRunner` fires the prosoche task on schedule
 2. Runner calls `DaemonBridge::send_prompt()` with session key `"daemon:prosoche"`
@@ -30,7 +30,7 @@ aletheia binary
 
 ---
 
-## Heartbeat Intervals
+## Heartbeat intervals
 
 The daemon supports multiple schedule types:
 
@@ -39,9 +39,9 @@ The daemon supports multiple schedule types:
 | `Cron` | `0 */45 8-23 * * *` | Every 45 min during waking hours |
 | `Interval` | `Duration::from_secs(3600)` | Fixed hourly interval |
 | `Once` | ISO 8601 timestamp | One-shot scheduled task |
-| `Startup` | — | Run once when daemon starts |
+| `Startup` | n/a | Run once when daemon starts |
 
-### Default Maintenance Schedules
+### Default maintenance schedules
 
 | Task | Schedule |
 |------|----------|
@@ -56,22 +56,22 @@ Tasks support optional **active windows** `(start_hour, end_hour)` to restrict e
 
 ## Configuration
 
-### Agent Workspace File
+### Agent workspace file
 
 Each agent has an `instance/nous/<agent-id>/PROSOCHE.md` file that defines its heartbeat checklist. A template is provided at `instance.example/nous/_template/PROSOCHE.md`.
 
 The checklist specifies what the agent should check on each heartbeat tick:
 
-1. **Calendar** — upcoming events in the next 4 hours
-2. **Tasks** — overdue or due-today items
-3. **System health** — agent status checks
+1. **Calendar**: upcoming events in the next 4 hours
+2. **Tasks**: overdue or due-today items
+3. **System health**: agent status checks
 
 **Constraints per tick:**
 - Maximum 5 tool calls
-- No investigation or research — just check and report
+- No investigation or research; just check and report
 - Response: `HEARTBEAT_OK` if nothing needs action, or brief one-line alerts
 
-### Attention Types
+### Attention types
 
 ```rust
 pub enum AttentionCategory {
@@ -97,7 +97,7 @@ pub enum Urgency {
 
 Currently, prosoche dispatches a prompt to the agent and relies on the agent's tool access (calendar, task manager, system health) to perform the actual checks. If no bridge is configured, prosoche completes successfully with empty results and logs a warning.
 
-### Failure Handling
+### Failure handling
 
 - Tasks are disabled after **3 consecutive failures**
 - A successful execution resets the failure counter
@@ -107,13 +107,13 @@ Currently, prosoche dispatches a prompt to the agent and relies on the agent's t
 
 ## Extensibility
 
-### Adding a New Check Category
+### Adding a new check category
 
 1. Add a variant to `AttentionCategory` in `crates/daemon/src/prosoche.rs`
 2. Update the agent's `PROSOCHE.md` template with instructions for the new check
 3. Ensure the agent has access to the relevant tools (register in `organon`)
 
-### Custom Scheduled Tasks
+### Custom scheduled tasks
 
 The `TaskRunner` accepts arbitrary tasks via `TaskAction`:
 
@@ -124,9 +124,9 @@ The `TaskRunner` accepts arbitrary tasks via `TaskAction`:
 | `Prompt(String)` | Prompt sent to a nous agent |
 | `Builtin(BuiltinTask)` | Built-in maintenance task |
 
-### Bridge Pattern
+### Bridge pattern
 
-The daemon communicates with nous actors through the `DaemonBridge` trait. This keeps the daemon crate decoupled from nous internals — the bridge is wired in the binary crate (`crates/aletheia/src/daemon_bridge.rs`).
+The daemon communicates with nous actors through the `DaemonBridge` trait. This keeps the daemon crate decoupled from nous internals; the bridge is wired in the binary crate (`crates/aletheia/src/daemon_bridge.rs`).
 
 ```rust
 pub trait DaemonBridge: Send + Sync {
@@ -141,7 +141,7 @@ pub trait DaemonBridge: Send + Sync {
 
 ---
 
-## Operational Notes
+## Operational notes
 
 ```bash
 # Check maintenance task status (includes prosoche)
@@ -151,4 +151,4 @@ aletheia maintenance status
 journalctl --user -u aletheia --since "1 hour ago" | grep prosoche
 ```
 
-Prosoche workspace files have **priority 7** in the token budget — they are dropped before semi-static files (MEMORY, TOOLS) under budget pressure, but SOUL.md is never dropped.
+Prosoche workspace files have **priority 7** in the token budget; they are dropped before semi-static files (MEMORY, TOOLS) under budget pressure, but SOUL.md is never dropped.

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -35,7 +35,7 @@ aletheia health       # check connectivity — prints OK or FAILED
 aletheia tui          # launch the terminal dashboard
 ```
 
-## Daily Use
+## Daily use
 
 ```bash
 aletheia              # start the server (gateway, agents, daemon)
@@ -48,11 +48,11 @@ Run `aletheia --help` for the full command reference.
 
 Memory (embedded engine, candle) is embedded in the binary. No external databases, containers, or sidecars required.
 
-## Optional: Signal Integration
+## Optional: Signal integration
 
 Requires [signal-cli](https://github.com/AsamK/signal-cli) and a registered phone number. See [CONFIGURATION.md](CONFIGURATION.md#channelssignal) for setup.
 
-## Next Steps
+## Next steps
 
 - [CONFIGURATION.md](CONFIGURATION.md) - config reference
 - [DEPLOYMENT.md](DEPLOYMENT.md) - production setup

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,12 +1,12 @@
 # Releasing Aletheia
 
-## Version Scheme
+## Version scheme
 
 Semantic Versioning. Pre-1.0, MINOR bumps may include breaking changes with documented migration. PATCH bumps are backwards-compatible.
 
 The canonical version lives in `Cargo.toml` at `[workspace.package].version`. All crates inherit it via `version.workspace = true`.
 
-## Automated Release Process
+## Automated release process
 
 1. Merge conventional-commit-formatted PRs to `main`
 2. [release-please](https://github.com/googleapis/release-please) opens a
@@ -20,7 +20,7 @@ The canonical version lives in `Cargo.toml` at `[workspace.package].version`. Al
    - Generates and attaches an SBOM (SPDX)
    - Uploads everything to the GitHub Release
 
-## Supported Platforms
+## Supported platforms
 
 | Target | Runner | Method |
 |--------|--------|--------|
@@ -29,7 +29,7 @@ The canonical version lives in `Cargo.toml` at `[workspace.package].version`. Al
 | `x86_64-apple-darwin` | `macos-latest` | Native cross-compile |
 | `aarch64-apple-darwin` | `macos-latest` | Native cargo build |
 
-## Manual Release
+## Manual release
 
 When release-please fails or you need an out-of-band release:
 
@@ -46,7 +46,7 @@ git push origin main --tags
 
 The tag push triggers the release workflow.
 
-## Hotfix Process
+## Hotfix process
 
 ```bash
 # Branch from the release tag
@@ -62,7 +62,7 @@ git push origin hotfix/0.10.1 --tags
 
 The tag push builds binaries the same way. Merge the hotfix branch back to `main` afterwards.
 
-## Binary Verification
+## Binary verification
 
 Each binary has a `.sha256` companion file attached to the GitHub Release.
 
@@ -76,7 +76,7 @@ sha256sum -c aletheia-linux-amd64.sha256
 
 The SBOM (`aletheia-sbom.spdx.json`) is also attached to each release, listing all Cargo dependencies with versions.
 
-## Supply Chain
+## Supply chain
 
 - `cargo-audit` and `cargo-deny` run on every PR (`.github/workflows/security.yml`)
 - `deny.toml` enforces license policy and advisory checks

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -1,8 +1,8 @@
-# Operational Runbook
+# Operational runbook
 
 For setup and deployment, see [DEPLOYMENT.md](DEPLOYMENT.md).
 
-## Service Architecture
+## Service architecture
 
 ```text
 aletheia                         (port 18789)  -- Rust binary, API
@@ -12,7 +12,7 @@ aletheia                         (port 18789)  -- Rust binary, API
 
 Memory (embedded engine, candle, SQLite) is embedded in the binary. No external databases or sidecars required.
 
-## Quick Health Check
+## Quick health check
 
 ```bash
 aletheia health          # connectivity, dependencies
@@ -21,7 +21,7 @@ aletheia status          # agent status, sessions, cron jobs
 
 ---
 
-## Start Procedure
+## Start procedure
 
 ### 1. Check port is free
 
@@ -54,7 +54,7 @@ curl -s http://localhost:18789/api/health | jq .
 
 ---
 
-## Stop Procedure
+## Stop procedure
 
 ```bash
 systemctl --user stop aletheia
@@ -64,7 +64,7 @@ Or send SIGTERM / Ctrl+C to the running process. The binary shuts down gracefull
 
 ---
 
-## Deploy / Update
+## Deploy / update
 
 ```bash
 cd <repo>
@@ -75,7 +75,7 @@ systemctl --user restart aletheia
 
 ---
 
-## Common Issues
+## Common issues
 
 ### EADDRINUSE on port 18789
 
@@ -121,14 +121,14 @@ Router auto-failover handles 429/5xx across providers. Expired OAuth tokens need
 
 ---
 
-## Log Locations
+## Log locations
 
 | Service | Log |
 |---------|-----|
 | Gateway | stdout / `journalctl --user -u aletheia` |
 | Signal-cli | Gateway stdout (subprocess) |
 
-## Key Paths
+## Key paths
 
 | Path | Purpose |
 |------|---------|
@@ -137,6 +137,6 @@ Router auto-failover handles 429/5xx across providers. Expired OAuth tokens need
 | `instance/data/engine/` | Knowledge graph (embedded Datalog engine) |
 | `instance/nous/<id>/` | Agent workspaces |
 
-## Pre-Restart Checklist
+## Pre-restart checklist
 
 Always run `aletheia health` before restarting. Fix reported failures first - restarting with broken dependencies adds confusion.

--- a/docs/SHELL-COMPLETIONS.md
+++ b/docs/SHELL-COMPLETIONS.md
@@ -1,8 +1,8 @@
-# Shell Completions
+# Shell completions
 
 Aletheia provides tab-completion for all subcommands, flags, and options via [clap_complete](https://docs.rs/clap_complete).
 
-## Generating Completions
+## Generating completions
 
 ```bash
 aletheia completions <SHELL>
@@ -54,7 +54,7 @@ Restart your shell or run `compinit` to pick up the new completions.
 aletheia completions fish > ~/.config/fish/completions/aletheia.fish
 ```
 
-Fish picks up completions from this directory automatically — no restart needed.
+Fish picks up completions from this directory automatically; no restart needed.
 
 ---
 

--- a/docs/TECHNOLOGY.md
+++ b/docs/TECHNOLOGY.md
@@ -1,4 +1,4 @@
-# Technology Decisions
+# Technology decisions
 
 Technology decisions and dependency policy.
 
@@ -6,7 +6,7 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) for module boundaries, [PROJECT.md](PROJE
 
 ---
 
-## Decision Table
+## Decision table
 
 | Layer | Choice | Replaces | Rationale |
 |-------|--------|----------|-----------|
@@ -25,15 +25,15 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) for module boundaries, [PROJECT.md](PROJE
 | Errors | snafu + anyhow | AletheiaError hierarchy | snafu for library/mid-level enums (context wrapping, Location-based virtual stack traces, multiple variants from same source type - GreptimeDB pattern). anyhow for application entry. |
 | Logging | tracing + Langfuse | tslog | Spans, layers, OpenTelemetry. Langfuse for LLM-specific traces. |
 | CLI | clap | Commander | Compile-time validation |
-| JSON | serde_json | — | Standard Rust JSON; sonic-rs was evaluated but not adopted |
+| JSON | serde_json | n/a | Standard Rust JSON; sonic-rs was evaluated but not adopted |
 | Hashing | blake3 + foldhash | crypto.createHash / ahash | blake3 for content hashing (dedup, loop detection). foldhash for HashMap keys. |
 | Secrets | secrecy | None | `SecretString` / `SecretVec` - zeroizes on drop, redacts in Debug |
 | Hot reload | arc-swap + notify | SIGUSR1 | arc-swap for zero-downtime config swap. notify for file watching. |
 | Strings | compact_str | String | 24-byte inline for short strings (agent names, tool names, domain tags) |
 | Enums | strum | None | Derive Display, EnumString, EnumIter for all typed enums |
-| Git | gix | — | Rust-native git for workspace auto-commit. No subprocess. |
-| Password | argon2 | — | Password hashing for symbolon. Memory-hard. |
-| Cron | cron + jiff | — | cron for schedule parsing. jiff for time/date (by BurntSushi). |
+| Git | gix | n/a | Rust-native git for workspace auto-commit. No subprocess. |
+| Password | argon2 | n/a | Password hashing for symbolon. Memory-hard. |
+| Cron | cron + jiff | n/a | cron for schedule parsing. jiff for time/date (by BurntSushi). |
 | Concurrent maps | papaya | DashMap | Lock-free, better scaling under contention |
 | Seccomp | extrasafe | None | Declarative syscall filtering for sandboxed tools |
 | HTML | dom_smoothie | scraper | Readability extraction + HTML-to-Markdown, single pass |
@@ -46,11 +46,11 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) for module boundaries, [PROJECT.md](PROJE
 
 ---
 
-## Dependency Policy
+## Dependency policy
 
 ~55 direct crates across the workspace. Each crate uses 5-15. Lean for the scope.
 
-### Pinning Rules
+### Pinning rules
 
 - **Unstable crates** (pre-1.0, aggressive releases): pin exact version. Wrap in trait.
   - `wasmtime` - monthly major versions. Pin exact.
@@ -60,13 +60,13 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) for module boundaries, [PROJECT.md](PROJE
 - **Stable crates** (1.0+): pin minor (`"1.49"` not `"=1.49.0"`).
 - **Never vendor** unless forced by platform issues. Cargo.lock suffices.
 
-### Corrections from Audit
+### Corrections from audit
 
 - `serde_yml` is banned (unsound unsafe) - use `serde_yaml` if YAML parsing is needed
 - `async-trait` crate is unnecessary - use native `async fn in trait` (Rust 1.75+)
 - `thiserror` replaced by `snafu` for library crates (GreptimeDB pattern)
 
-### Cross-Compilation Notes
+### Cross-compilation notes
 
 - `candle`: pure Rust, cross-compiles cleanly. Feature-gated behind `embed-candle`.
 - `serde_json`: standard, no platform-specific concerns.
@@ -75,7 +75,7 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) for module boundaries, [PROJECT.md](PROJE
 
 ---
 
-## Crate-to-Module Mapping
+## Crate-to-module mapping
 
 | Crate | Key Dependencies |
 |-------|-----------------|

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -1,6 +1,6 @@
 # Upgrading Aletheia
 
-## Upgrade Process
+## Upgrade process
 
 1. Check current version: `aletheia health` or `aletheia --version`
 2. Back up before upgrading:
@@ -24,7 +24,7 @@
    ```
 8. Verify: `aletheia health`
 
-### Building from Source
+### Building from source
 
 ```bash
 git fetch origin && git checkout vX.Y.Z
@@ -34,9 +34,9 @@ cargo build --release
 
 ---
 
-## Config Compatibility
+## Config compatibility
 
-The config system uses figment with `serde(default)` on all structs. New config fields added in newer versions automatically get their compiled defaults — no manual migration needed for minor versions.
+The config system uses figment with `serde(default)` on all structs. New config fields added in newer versions automatically get their compiled defaults; no manual migration needed for minor versions.
 
 Both `snake_case` and `camelCase` field names work via serde's `rename_all = "camelCase"`.
 
@@ -44,7 +44,7 @@ Check `git log --oneline` or [GitHub releases](https://github.com/forkwright/ale
 
 ---
 
-## Database Migration
+## Database migration
 
 SQLite schema migrations run automatically on startup via `SessionStore::open()`. No manual migration steps required.
 
@@ -59,14 +59,14 @@ The embedded Datalog engine (knowledge store) manages its own schema versioning 
 
 ## Rollback
 
-### Pre-Upgrade Checklist
+### Pre-upgrade checklist
 
 Before any upgrade:
-1. `aletheia backup` — creates timestamped database backup
+1. `aletheia backup`: creates timestamped database backup
 2. Save the current binary: `cp /usr/local/bin/aletheia /usr/local/bin/aletheia.prev`
 3. Record current version: `aletheia health | jq .version`
 
-### Rollback Procedure
+### Rollback procedure
 
 1. Stop the service:
    ```bash
@@ -87,7 +87,7 @@ Before any upgrade:
    ```
 5. Verify: `aletheia health`
 
-### Rollback Limitations
+### Rollback limitations
 
 - **SQLite migrations are forward-only.** If a newer version added tables or columns, the older binary may not understand the new schema. Restore from backup in this case.
 - **Knowledge engine schema changes** are also forward-only.

--- a/docs/WORKSPACE_FILES.md
+++ b/docs/WORKSPACE_FILES.md
@@ -1,4 +1,4 @@
-# Workspace Files Reference
+# Workspace files reference
 
 Each nous has a workspace directory (`instance/nous/<name>/`) containing up to 10 markdown files that form its identity, memory, and runtime context. The bootstrap system (`crates/nous/src/bootstrap/`) reads these files, applies token budgeting, and assembles them into the system prompt for each API call. For shared tools available to all agents, see [shared/TOOLS-INFRASTRUCTURE.md](../shared/TOOLS-INFRASTRUCTURE.md).
 
@@ -20,7 +20,7 @@ Each nous has a workspace directory (`instance/nous/<name>/`) containing up to 1
 
 ---
 
-## Load Order and Priority
+## Load order and priority
 
 Files are loaded in strict priority order (1 = highest). The priority number determines two things:
 
@@ -31,7 +31,7 @@ If a file does not exist in the workspace directory, it is silently skipped. Emp
 
 ---
 
-## Required vs Optional
+## Required vs optional
 
 Only one file is truly required for a nous to function:
 
@@ -41,7 +41,7 @@ All other files are optional. A minimal nous needs only SOUL.md. In practice, mo
 
 ---
 
-## Hand-Written vs Auto-Generated
+## Hand-written vs auto-generated
 
 **Hand-written by the operator:**
 - SOUL.md, USER.md, AGENTS.md, IDENTITY.md, GOALS.md
@@ -56,7 +56,7 @@ All other files are optional. A minimal nous needs only SOUL.md. In practice, mo
 
 ---
 
-## Token Budget
+## Token budget
 
 The bootstrap system enforces a configurable token budget (default: 40,000 tokens, set via `bootstrap_max_tokens` in `aletheia.toml`).
 
@@ -73,7 +73,7 @@ The bootstrap budget is one piece of the total context window (`context_tokens`,
 
 ---
 
-## Anthropic Prompt Caching
+## Anthropic prompt caching
 
 The bootstrap assembles all workspace files into a single system prompt block. When `cache_system` is enabled on the `CompletionRequest` (configured via `hermeneus`), Anthropic's prompt caching applies a `cache_control: { "type": "ephemeral" }` breakpoint to the system block. This caches the entire assembled system prompt across turns within the same session, reducing input token costs.
 
@@ -81,15 +81,15 @@ Because all workspace files are concatenated into one block, any change to any f
 
 ---
 
-## Additional Injection Points
+## Additional injection points
 
 Beyond the 9 workspace files, the bootstrap accepts extra sections via `assemble_with_extra()`. Domain packs (loaded by `thesauros`) provide additional context and tool overlays as `BootstrapSection` values that participate in the same priority sorting and token budget as workspace files.
 
 ---
 
-## File Location Rule
+## File location rule
 
-Agent workspaces (`instance/nous/{id}/`) hold **identity files and session memory only**. All other working files — research, plans, drafts, specs, notes, project work — belong in `instance/theke/`.
+Agent workspaces (`instance/nous/{id}/`) hold **identity files and session memory only**. All other working files (research, plans, drafts, specs, notes, project work) belong in `instance/theke/`.
 
 ### What stays in `nous/{id}/`
 

--- a/docs/archive/CUTOVER_VALIDATION.md
+++ b/docs/archive/CUTOVER_VALIDATION.md
@@ -1,6 +1,6 @@
-# Cutover Validation — Rust Binary Replaces TS Runtime
+# Cutover validation: Rust binary replaces TS runtime
 
-**STATUS: ARCHIVED** — This document describes validation work completed in early March 2026. The codebase has moved well beyond cutover (now at v0.10.1). File paths, line numbers, test counts, and specific claims are obsolete. Kept for historical reference only.
+**STATUS: ARCHIVED.** This document describes validation work completed in early March 2026. The codebase has moved well beyond cutover (now at v0.10.1). File paths, line numbers, test counts, and specific claims are obsolete. Kept for historical reference only.
 
 ---
 
@@ -9,7 +9,7 @@ Run against commit `08ffa14` on branch `feat/cutover-validation`, 2026-03-08.
 
 ---
 
-## Cutover Readiness
+## Cutover readiness
 
 | Area | Status | Notes |
 |------|--------|-------|
@@ -18,8 +18,8 @@ Run against commit `08ffa14` on branch `feat/cutover-validation`, 2026-03-08.
 | Clippy | ✅ | Zero warnings |
 | Fmt | ✅ | Fixed multi-line `#[expect]` in `mneme/src/knowledge_store.rs` |
 | Bootstrap | ✅ | SOUL.md required, all others gracefully skipped if absent |
-| Config | ⚠️ | `instance/config/aletheia.toml` is gitignored — operator must configure |
-| Sessions | ✅ | DB at `{instance_root}/data/sessions.db` — stable path, no migration needed |
+| Config | ⚠️ | `instance/config/aletheia.toml` is gitignored; operator must configure |
+| Sessions | ✅ | DB at `{instance_root}/data/sessions.db` (stable path, no migration needed) |
 | Service file | ✅ | Template at `instance.example/services/aletheia.service`; points to Rust binary |
 | Tool parity | ✅ | 32 tools registered; all TS-era tools present plus new ones |
 | Signal | ✅ | `build_signal_provider()` present; gated on config; warns gracefully if unconfigured |
@@ -28,7 +28,7 @@ Run against commit `08ffa14` on branch `feat/cutover-validation`, 2026-03-08.
 
 ---
 
-## Findings Detail
+## Findings detail
 
 ### Build (✅)
 
@@ -40,7 +40,7 @@ cargo clippy --workspace --exclude aletheia-mneme-engine --all-targets -- -D war
 cargo fmt --all -- --check → clean (after fix)
 ```
 
-**Fix applied:** `crates/mneme/src/knowledge_store.rs` — rustfmt reformatted a single-line
+**Fix applied:** `crates/mneme/src/knowledge_store.rs`: rustfmt reformatted a single-line
 `#[expect(clippy::too_many_lines, ...)]` to multi-line form. No logic change.
 
 ### Bootstrap (✅)
@@ -49,9 +49,9 @@ The bootstrap assembler (`crates/nous/src/bootstrap/mod.rs`) implements a three-
 `nous/{id}/` → `shared/` → `theke/`
 
 Priority handling:
-- **SOUL.md**: `Required` — returns `ContextAssembly` error if missing or unreadable
-- **USER.md, AGENTS.md, GOALS.md, TOOLS.md**: `Important` — silently skipped if absent
-- **MEMORY.md, IDENTITY.md, PROSOCHE.md, CONTEXT.md**: `Flexible` — silently skipped if absent
+- **SOUL.md**: `Required` (returns `ContextAssembly` error if missing or unreadable)
+- **USER.md, AGENTS.md, GOALS.md, TOOLS.md**: `Important` (silently skipped if absent)
+- **MEMORY.md, IDENTITY.md, PROSOCHE.md, CONTEXT.md**: `Flexible` (silently skipped if absent)
 
 The actor (`crates/nous/src/actor.rs:669`) validates SOUL.md at spawn time with a clear
 `WorkspaceValidation` error. All other missing files log a `debug` message and continue.
@@ -59,7 +59,7 @@ The actor (`crates/nous/src/actor.rs:669`) validates SOUL.md at spawn time with 
 **Operator requirement:** Each agent needs `instance/nous/{id}/SOUL.md` (or in `shared/` or `theke/`).
 No other file is required for the binary to start an agent.
 
-### Configuration (⚠️ — operator action required)
+### Configuration (⚠️, operator action required)
 
 `instance/config/aletheia.toml` is gitignored (operator-specific). The binary starts and
 warns gracefully without it (defaulting all settings). For production:
@@ -73,19 +73,19 @@ warns gracefully without it (defaulting all settings). For production:
 The config cascade (`figment`: defaults → YAML → env vars) means the binary can start with
 zero config and then be layered.
 
-### Session Continuity (✅)
+### Session continuity (✅)
 
 ```
 oikos.sessions_db() → {instance_root}/data/sessions.db
 ```
 
-Confirmed in `crates/taxis/src/oikos.rs:144`. The TS runtime was deleted in PR #601 — no
+Confirmed in `crates/taxis/src/oikos.rs:144`. The TS runtime was deleted in PR #601; no
 concurrent runtime to migrate away from. If `instance_root` is stable across the cutover,
 all existing session history is preserved.
 
-No existing `sessions.db` or `store.db` found in the dev checkout (expected — gitignored).
+No existing `sessions.db` or `store.db` found in the dev checkout (expected, gitignored).
 
-### Service File (✅)
+### Service file (✅)
 
 Template at `instance.example/services/aletheia.service`:
 
@@ -99,7 +99,7 @@ RestartSec=5
 - `EnvironmentFile=-__ALETHEIA_HOME__/instance/config/env` for env vars
 - Operator must replace `__ALETHEIA_HOME__` placeholder before installing
 
-### Tool Parity (✅)
+### Tool parity (✅)
 
 32 tools registered via `crates/organon/src/builtins/mod.rs:register_all()`:
 
@@ -117,10 +117,10 @@ TOOLS.md in each agent workspace is an `Important` (optional) file read from the
 The `summarize_tools()` API in `bootstrap/tools.rs` generates dynamic tool listings for
 the `/api/v1/nous/{id}/tools` endpoint and inline bootstrap injection.
 
-### Signal Integration (✅)
+### Signal integration (✅)
 
 Path verified in `crates/aletheia/src/main.rs`:
-1. `build_signal_provider(config.channels.signal)` — creates `Arc<SignalProvider>` if enabled
+1. `build_signal_provider(config.channels.signal)`: creates `Arc<SignalProvider>` if enabled
 2. Registered into `ChannelRegistry` at startup
 3. `start_inbound_dispatch()` starts the Signal listener loop
 4. `message` tool routes outbound through `ChannelProvider` interface
@@ -133,17 +133,17 @@ Trigger: `maybe_spawn_distillation()` called after every turn completion in `act
 
 Pipeline (`crates/nous/src/distillation.rs`):
 1. `should_trigger_distillation()` checks token usage and message count
-2. Background async task spawned — does not block the main turn
+2. Background async task spawned (does not block the main turn)
 3. `DistillEngine::distill()` calls LLM to produce summary
 4. `apply_distillation()` marks messages as distilled, inserts `[Distillation #N]` summary
 5. `record_distillation()` updates `distillation_count` + `last_distilled_at` on session
 
 **Survival across distillation:**
-- `working_state` — separate `sessions.working_state` column, not in message history → survives
-- `agent_notes` — `agent_notes` table, session-scoped, separate from messages → survives
+- `working_state`: separate `sessions.working_state` column, not in message history → survives
+- `agent_notes`: `agent_notes` table, session-scoped, separate from messages → survives
 - Verbatim tail messages are preserved (only oldest messages get distilled)
 
-### Eval Smoke Test (✅ — degraded, as expected)
+### Eval smoke test (✅, degraded as expected)
 
 ```bash
 ./target/release/aletheia -r instance/ --log-level warn &
@@ -194,13 +194,13 @@ None. The binary is complete and correct.
 **GO.**
 
 The Rust binary fully replaces the TypeScript runtime. All 10 TS runtime capabilities are
-implemented. The binary handles incomplete configuration gracefully. Tests are comprehensive
-and passing. The only prerequisites are operator-side instance configuration — none of which
+implemented. The binary handles incomplete configuration gracefully. Tests are complete
+and passing. The only prerequisites are operator-side instance configuration, none of which
 require code changes.
 
 ---
 
-## Deployment Checklist
+## Deployment checklist
 
 Exact commands to switch from TS to Rust (assuming instance is already at `~/aletheia/instance/`):
 

--- a/docs/gnomon.md
+++ b/docs/gnomon.md
@@ -1,30 +1,30 @@
 # Gnomon
 
-*γνώμων — that which reveals by indicating*
+*γνώμων: that which reveals by indicating*
 
-A sundial's gnomon doesn't contain time. It casts a shadow that makes time legible. The best names work the same way — they don't describe what something is. They reveal what was already there.
+A sundial's gnomon doesn't contain time. It casts a shadow that makes time legible. The best names work the same way: they don't describe what something is. They reveal what was already there.
 
 ---
 
 ## Why Greek
 
-Ancient Greek was engineered across centuries for a single purpose — distinguishing between closely related things that matter. Where English has "knowledge," Greek has episteme (systematic knowledge), gnosis (direct acquaintance), techne (craft knowledge), phronesis (practical wisdom), and nous (direct apprehension). These aren't synonyms. They're fundamentally different stances toward the world.
+Ancient Greek was engineered across centuries for a single purpose: distinguishing between closely related things that matter. Where English has "knowledge," Greek has episteme (systematic knowledge), gnosis (direct acquaintance), techne (craft knowledge), phronesis (practical wisdom), and nous (direct apprehension). These aren't synonyms. They're fundamentally different stances toward the world.
 
 This precision extends beyond epistemics. Where English has "form," Greek has morphe (the form that makes a thing *this kind* of thing), schema (the shape or figure), eidos (the visible form), and typos (the impression left by a blow). Where English has "order," Greek has taxis (arrangement), kosmos (the beautiful order of a whole), and logos (the rational principle that structures).
 
-When you name a module *Dianoia*, you're not saying "thinking" — you're saying *discursive reasoning that works through problems step by step*, as distinct from noesis (immediate insight) or episteme (systematic knowledge). When you name a platform *Harmonia*, you're not saying "media player" — you're saying *the fitting-together of parts into a concordant whole*. The Greek carries the distinction natively. English requires a paragraph.
+When you name a module *Dianoia*, you're not saying "thinking"; you're saying *discursive reasoning that works through problems step by step*, as distinct from noesis (immediate insight) or episteme (systematic knowledge). When you name a platform *Harmonia*, you're not saying "media player"; you're saying *the fitting-together of parts into a concordant whole*. The Greek carries the distinction natively. English requires a paragraph.
 
 Greek also offers:
 
 - **Productive compounding.** Roots, prefixes, and suffixes combine systematically. The grammar builds meaning.
 - **Defamiliarization.** An unfamiliar word resists assumption. You have to ask what it means, which means you have to think about what the thing *does*.
-- **Density.** Meaning compressed into sound. Aletheia is four syllables carrying an entire ontology — truth as *unconcealment*, the negation of forgetting.
+- **Density.** Meaning compressed into sound. Aletheia is four syllables carrying an entire ontology: truth as *unconcealment*, the negation of forgetting.
 
 The goal is not erudition. The goal is precision tools for systems that distinguish between many closely related things.
 
 ---
 
-## Building Names
+## Building names
 
 Greek names are constructed, not found. Three components combine.
 
@@ -75,45 +75,45 @@ A name like **προσοχή** (prosoche) is: πρός (toward) + ἔχω (to ho
 
 ---
 
-## The Layer Test
+## The layer test
 
 Every name must work at multiple levels of abstraction simultaneously. This is the primary quality test.
 
 | Layer | What it answers | Failure mode |
 |-------|----------------|--------------|
-| **L1 — Practical** | What does this do? | Too abstract to use |
-| **L2 — Structural** | How does this relate to other things? | Isolated, doesn't compose |
-| **L3 — Philosophical** | What essential nature does this name unconceal? | Decorative, not meaningful |
-| **L4 — Reflexive** | Does the name exhibit what it describes? | Inert, doesn't reward reflection |
+| **L1: Practical** | What does this do? | Too abstract to use |
+| **L2: Structural** | How does this relate to other things? | Isolated, doesn't compose |
+| **L3: Philosophical** | What essential nature does this name unconceal? | Decorative, not meaningful |
+| **L4: Reflexive** | Does the name exhibit what it describes? | Inert, doesn't reward reflection |
 
 A name that works at L1 but not L3 is a label. A name that works at L3 but not L1 is pretension.
 
-**Aletheia** (ἀλήθεια — unconcealment):
+**Aletheia** (ἀλήθεια, unconcealment):
 
 | Layer | Reading |
 |-------|---------|
-| L1 | A cognitive system — agents, memory, orchestration |
+| L1 | A cognitive system: agents, memory, orchestration |
 | L2 | The substrate that makes the other systems possible |
-| L3 | Truth as unconcealment — the negation of forgetting. Not truth as correspondence but truth as *revealing what was hidden* |
-| L4 | The system itself practices unconcealment — surfacing latent knowledge, making hidden patterns legible, refusing to let things stay forgotten |
+| L3 | Truth as unconcealment, the negation of forgetting. Not truth as correspondence but truth as *revealing what was hidden* |
+| L4 | The system itself practices unconcealment, surfacing latent knowledge, making hidden patterns legible, refusing to let things stay forgotten |
 
-**Harmonia** (ἁρμονία — fitting-together):
+**Harmonia** (ἁρμονία, fitting-together):
 
 | Layer | Reading |
 |-------|---------|
-| L1 | A media platform — backend, player, audio core unified |
+| L1 | A media platform: backend, player, audio core unified |
 | L2 | The integration layer that makes disparate media components work as one |
-| L3 | The fitting-together of parts — not mere compatibility but active concordance, each part finding its place within a whole |
+| L3 | The fitting-together of parts, not mere compatibility but active concordance, each part finding its place within a whole |
 | L4 | The platform harmonizes: Mouseion (collection) and Akroasis (listening) joined into a coherent whole. The name describes its own architecture |
 
-**Akroasis** (ἀκρόασις — attentive reception):
+**Akroasis** (ἀκρόασις, attentive reception):
 
 | Layer | Reading |
 |-------|---------|
 | L1 | RF intelligence, mesh networking, communications sovereignty |
 | L2 | The system that makes electromagnetic and digital activity intelligible and actionable |
-| L3 | Not passive hearing but *attentive reception*. Aristotle's Physics was called "Physike Akroasis" — learning through disciplined listening |
-| L4 | The system listens at every level — spectrum, mesh, network, proximity — then understands, then acts |
+| L3 | Not passive hearing but *attentive reception*. Aristotle's Physics was called "Physike Akroasis," learning through disciplined listening |
+| L4 | The system listens at every level (spectrum, mesh, network, proximity), then understands, then acts |
 
 ---
 
@@ -121,9 +121,9 @@ A name that works at L1 but not L3 is a label. A name that works at L3 but not L
 
 Names in a system are not independent. They compose. The relationships between names carry meaning.
 
-**Noesis** and **Dianoia** are the two sides of Plato's divided line — one sees the whole immediately, the other works through it step by step. Placing them in the same system asserts that both modes are necessary.
+**Noesis** and **Dianoia** are the two sides of Plato's divided line; one sees the whole immediately, the other works through it step by step. Placing them in the same system asserts that both modes are necessary.
 
-**Lethe** (λήθη — concealment) and **Aletheia** (ἀ-λήθεια — unconcealment) share the same root, opposite directions. One unconceals truth, the other conceals the operator. The strongest topological pairing in the ecosystem.
+**Lethe** (λήθη, concealment) and **Aletheia** (ἀ-λήθεια, unconcealment) share the same root, opposite directions. One unconceals truth, the other conceals the operator. The strongest topological pairing in the ecosystem.
 
 **Prosoche** (sustained attention) is the *practice* that makes **Aletheia** (unconcealment) possible. You can't reveal what's hidden without attending carefully. The names encode this dependency.
 
@@ -136,19 +136,19 @@ When you add a new name, it must compose with what exists. A name that fits loca
 
 ---
 
-## The Gnomon Principle
+## The gnomon principle
 
 A gnomon doesn't contain time. It doesn't measure time. It casts a shadow, and the shadow makes time legible.
 
 The best names are gnomons. They indicate without containing. The name Aletheia doesn't *make* the system true. It reveals that the system was already an act of unconcealment. The name Harmonia doesn't *make* the platform coherent. It reveals that the fitting-together of collection and listening was always the essential nature.
 
-A name succeeds as a gnomon when someone encounters it, learns what it means, and feels that the thing has become more itself — not differently described but more clearly *seen*.
+A name succeeds as a gnomon when someone encounters it, learns what it means, and feels that the thing has become more itself, not differently described but more clearly *seen*.
 
 A name fails as a gnomon when the name draws attention to itself rather than to what it names. If you're explaining the name, it's decoration. If the name is explaining the thing, it's a gnomon.
 
 ---
 
-## When Naming
+## When naming
 
 1. **Wait.** Let the thing reveal its nature before fixing the name. Build first, name when the essential nature becomes clear. Premature naming produces labels.
 2. **Identify what needs unconcealing.** Not what the thing *does technically* but what it *essentially is*.
@@ -158,7 +158,7 @@ A name fails as a gnomon when the name draws attention to itself rather than to 
 6. **Check the topology.** Does this name compose with what exists?
 7. **Listen for recognition.** The right name feels discovered, not invented. If you're arguing for why it fits, it doesn't.
 
-### Anti-Patterns
+### Anti-patterns
 
 - **Naming the implementation.** You named what it does technically, not what it essentially is. "Tracker" is an implementation. Prosoche is the essential nature that tracking serves.
 - **Naming too precisely.** A name that works at only one layer is brittle. Essential-nature names survive refactors because the nature persists even when the mechanism changes.
@@ -170,9 +170,9 @@ A name fails as a gnomon when the name draws attention to itself rather than to 
 
 ## Sources
 
-- **Plato** — *Republic* (the divided line: dianoia and noesis), *Meno* (anamnesis), *Theaetetus* (knowledge and perception)
-- **Aristotle** — *Nicomachean Ethics* (ergon, phronesis, techne), *Categories* (fundamental ways a thing can be), *Metaphysics* (energeia, morphe/hyle)
-- **The Stoics** — Epictetus and Marcus Aurelius on prosoche (attention as practice), melete (care as disciplined practice)
-- **Heidegger** — *Being and Time* on aletheia as unconcealment
-- **Jacob Klein** — *Greek Mathematical Thought and the Origin of Algebra* on naming and knowing
-- **Liddell-Scott-Jones** — *Greek-English Lexicon*
+- **Plato**: *Republic* (the divided line: dianoia and noesis), *Meno* (anamnesis), *Theaetetus* (knowledge and perception)
+- **Aristotle**: *Nicomachean Ethics* (ergon, phronesis, techne), *Categories* (fundamental ways a thing can be), *Metaphysics* (energeia, morphe/hyle)
+- **The Stoics**: Epictetus and Marcus Aurelius on prosoche (attention as practice), melete (care as disciplined practice)
+- **Heidegger**: *Being and Time* on aletheia as unconcealment
+- **Jacob Klein**: *Greek Mathematical Thought and the Origin of Algebra* on naming and knowing
+- **Liddell-Scott-Jones**: *Greek-English Lexicon*

--- a/docs/lexicon.md
+++ b/docs/lexicon.md
@@ -1,95 +1,95 @@
-# Aletheia — Lexicon
+# Aletheia: lexicon
 
 *Living registry. Updated as crates are added or renamed.*
 *For the naming methodology and construction system, see [gnomon.md](gnomon.md).*
 
 ---
 
-## Project Name
+## Project name
 
-**Aletheia** (ἀλήθεια) — Truth as unconcealment, the negation of forgetting.
+**Aletheia** (ἀλήθεια): Truth as unconcealment, the negation of forgetting.
 
 | Layer | Reading |
 |-------|---------|
-| L1 | Multi-agent cognitive runtime — memory, orchestration, multi-nous cognition |
+| L1 | Multi-agent cognitive runtime: memory, orchestration, multi-nous cognition |
 | L2 | The substrate; everything else is housed within it |
-| L3 | Truth as unconcealment — ἀ-λήθεια: not-hidden. Not truth as correspondence but truth as *revealing what was hidden* |
-| L4 | The system itself practices unconcealment — surfacing latent knowledge, refusing to let things stay forgotten |
+| L3 | Truth as unconcealment, ἀ-λήθεια: not-hidden. Not truth as correspondence but truth as *revealing what was hidden* |
+| L4 | The system itself practices unconcealment, surfacing latent knowledge, refusing to let things stay forgotten |
 
 ---
 
-## Crate Names
+## Crate names
 
-### Leaf Layer
-
-| Crate | Greek | Over | L3 Essential Nature |
-|-------|-------|------|---------------------|
-| **Koina** | κοινά | "utils" | The commons — what is held in common. Errors (snafu), tracing, fs utilities, safe wrappers. The public utility of collective thought. |
-| **Symbolon** | σύμβολον | "auth" | The token of recognition — two halves of a broken coin. JWT tokens, password hashing, RBAC policies. Identity as shared history. |
-
-### Low Layer
+### Leaf layer
 
 | Crate | Greek | Over | L3 Essential Nature |
 |-------|-------|------|---------------------|
-| **Taxis** | τάξις | "config" | The arrangement that makes a collection coherent — Aristotle's word for ordered structure. Config loading (figment YAML cascade), path resolution, oikos hierarchy. |
+| **Koina** | κοινά | "utils" | The commons, what is held in common. Errors (snafu), tracing, fs utilities, safe wrappers. The public utility of collective thought. |
+| **Symbolon** | σύμβολον | "auth" | The token of recognition: two halves of a broken coin. JWT tokens, password hashing, RBAC policies. Identity as shared history. |
+
+### Low layer
+
+| Crate | Greek | Over | L3 Essential Nature |
+|-------|-------|------|---------------------|
+| **Taxis** | τάξις | "config" | The arrangement that makes a collection coherent, Aristotle's word for ordered structure. Config loading (figment YAML cascade), path resolution, oikos hierarchy. |
 | **Hermeneus** | ἑρμηνεύς | "provider" | Hermes' art of carrying meaning across worlds. Anthropic client, model routing, credential management. The translation layer between nous and LLM backends. |
-| **Mneme** | μνήμη | "store" | Memory as active faculty — the Muse's gift, not passive storage. Unified memory store: embeddings, knowledge graph, hybrid recall. |
-| **Organon** | ὄργανον | "tools" | Aristotle's name for the instruments of thought — that by which the mind extends itself. Tool registry, definitions, built-in tool set. |
-| **Agora** | ἀγορά | "channels" | The gathering place — Greek civic space where voices meet and meaning is made public. Channel registry, ChannelProvider trait, Signal JSON-RPC client. |
-| **Melete** | μελέτη | "distillation" | Disciplined practice — one of the original Muses. Context distillation, compression strategies, token budget management. Attending carefully to what was. |
+| **Mneme** | μνήμη | "store" | Memory as active faculty, the Muse's gift, not passive storage. Unified memory store: embeddings, knowledge graph, hybrid recall. |
+| **Organon** | ὄργανον | "tools" | Aristotle's name for the instruments of thought, that by which the mind extends itself. Tool registry, definitions, built-in tool set. |
+| **Agora** | ἀγορά | "channels" | The gathering place, Greek civic space where voices meet and meaning is made public. Channel registry, ChannelProvider trait, Signal JSON-RPC client. |
+| **Melete** | μελέτη | "distillation" | Disciplined practice, one of the original Muses. Context distillation, compression strategies, token budget management. Attending carefully to what was. |
 
-### Mid Layer
-
-| Crate | Greek | Over | L3 Essential Nature |
-|-------|-------|------|---------------------|
-| **Nous** | νοῦς | "agent" | Direct apprehension — the highest mode of knowing, distinct from discursive thought. The agent pipeline: bootstrap, recall, execute, finalize. |
-| **Dianoia** | διάνοια | "planning" | Discursive reasoning — Plato's divided line: thinking *through* problems step by step. Multi-phase planning orchestrator, project context tracking. |
-| **Thesauros** | θησαυρός | "packs" | The storehouse — a treasury of accumulated knowledge held ready for use. Domain pack loader: knowledge, tools, config overlays. |
-| **Dokimion** | δοκίμιον | "eval" | The test, the proof — that which demonstrates whether something is genuine. Behavioral evaluation framework, HTTP scenario runner. |
-
-### High Layer
+### Mid layer
 
 | Crate | Greek | Over | L3 Essential Nature |
 |-------|-------|------|---------------------|
-| **Pylon** | πυλών | "gateway" | The gate — the architectural boundary between inside and outside. Axum HTTP gateway, SSE streaming, auth middleware. |
+| **Nous** | νοῦς | "agent" | Direct apprehension, the highest mode of knowing, distinct from discursive thought. The agent pipeline: bootstrap, recall, execute, finalize. |
+| **Dianoia** | διάνοια | "planning" | Discursive reasoning, Plato's divided line: thinking *through* problems step by step. Multi-phase planning orchestrator, project context tracking. |
+| **Thesauros** | θησαυρός | "packs" | The storehouse, a treasury of accumulated knowledge held ready for use. Domain pack loader: knowledge, tools, config overlays. |
+| **Dokimion** | δοκίμιον | "eval" | The test, the proof, that which demonstrates whether something is genuine. Behavioral evaluation framework, HTTP scenario runner. |
 
-### Top Layer
+### High layer
+
+| Crate | Greek | Over | L3 Essential Nature |
+|-------|-------|------|---------------------|
+| **Pylon** | πυλών | "gateway" | The gate, the architectural boundary between inside and outside. Axum HTTP gateway, SSE streaming, auth middleware. |
+
+### Top layer
 
 | Crate | Greek | Over | L3 Essential Nature |
 |-------|-------|------|---------------------|
 | **Aletheia** | ἀλήθεια | "binary" | The entrypoint. The system as a whole, invoked by name. CLI, serve mode, the single binary. |
 
-### Internal Modules
+### Internal modules
 
 | Name | Greek | Over | L3 Essential Nature |
 |------|-------|------|---------------------|
-| **Semeion** | σημεῖον | "signal" | The sign, the mark — communication as semiotics. Signal messaging integration inside Agora. |
-| **Oikonomos** | οἰκονόμος | "daemon" | The household steward — manages the oikos, keeps things in order. Background scheduling, cron, lifecycle events. |
-| **Prosoche** | προσοχή | "heartbeat" | Sustained directed attention — the practice that makes unconcealment possible. Attention checks, health monitoring, directive surfacing. |
-| **Theke** | θήκη | "vault" | A repository in the original sense — a place that holds what matters. Tier-0 instance directory, human + nous collaborative space. |
-| **Diaporeia** | διαπορεία | "mcp-server" | Passage through — transit between worlds. MCP server bridge for external AI agents. |
+| **Semeion** | σημεῖον | "signal" | The sign, the mark; communication as semiotics. Signal messaging integration inside Agora. |
+| **Oikonomos** | οἰκονόμος | "daemon" | The household steward, managing the oikos and keeping things in order. Background scheduling, cron, lifecycle events. |
+| **Prosoche** | προσοχή | "heartbeat" | Sustained directed attention, the practice that makes unconcealment possible. Attention checks, health monitoring, directive surfacing. |
+| **Theke** | θήκη | "vault" | A repository in the original sense, a place that holds what matters. Tier-0 instance directory, human + nous collaborative space. |
+| **Diaporeia** | διαπορεία | "mcp-server" | Passage through, transit between worlds. MCP server bridge for external AI agents. |
 
 ### Planned
 
 | Name | Greek | Over | L3 Essential Nature |
 |------|-------|------|---------------------|
-| **Prostheke** | προσθήκη | "plugins" | The supplement, the addition. WASM plugin host (wasmtime) — extend the system without touching core. |
-| **Autarkeia** | αὐτάρκεια | "export/import" | Self-sufficiency — the Stoic virtue of needing nothing external. Agent portability across instances. |
-| **Theatron** | θέατρον | "frontend" | The place for seeing — Greek theater where truth was made visible. TUI client and future UI surfaces. |
+| **Prostheke** | προσθήκη | "plugins" | The supplement, the addition. WASM plugin host (wasmtime): extend the system without touching core. |
+| **Autarkeia** | αὐτάρκεια | "export/import" | Self-sufficiency, the Stoic virtue of needing nothing external. Agent portability across instances. |
+| **Theatron** | θέατρον | "frontend" | The place for seeing, Greek theater where truth was made visible. TUI client and future UI surfaces. |
 
 ---
 
-## Key Topological Relationships
+## Key topological relationships
 
-- **Nous ↔ Dianoia** — Plato's divided line. Noesis (immediate apprehension) and dianoia (step-by-step reasoning). Both modes are necessary.
-- **Prosoche → Aletheia** — Sustained attention is the practice that makes unconcealment possible. You can't reveal what's hidden without attending carefully.
-- **Mneme ↔ Melete** — Memory holds what was experienced. Disciplined practice refines it into wisdom.
-- **Organon → Nous** — The instruments serve the mind. Tools extend the agent's reach.
-- **Agora → Nous** — Voices from the gathering place reach the mind. Channels feed the agent.
+- **Nous ↔ Dianoia**: Plato's divided line. Noesis (immediate apprehension) and dianoia (step-by-step reasoning). Both modes are necessary.
+- **Prosoche → Aletheia**: Sustained attention is the practice that makes unconcealment possible. You can't reveal what's hidden without attending carefully.
+- **Mneme ↔ Melete**: Memory holds what was experienced. Disciplined practice refines it into wisdom.
+- **Organon → Nous**: The instruments serve the mind. Tools extend the agent's reach.
+- **Agora → Nous**: Voices from the gathering place reach the mind. Channels feed the agent.
 
 ---
 
-## Rejected Names
+## Rejected names
 
 | Name | Meaning | Why Rejected |
 |------|---------|-------------|

--- a/docs/mneme-ground-truth.md
+++ b/docs/mneme-ground-truth.md
@@ -1,4 +1,4 @@
-# Mneme Ground Truth Report
+# Mneme ground truth report
 
 Generated: 2026-03-08
 
@@ -10,7 +10,7 @@ Generated: 2026-03-08
 - Broken/incomplete capabilities: none found at the code level; see gaps section for missing features from plan
 - Stubs/dead code: none found
 
-## Gate Results
+## Gate results
 
 | Gate | Status | Evidence |
 |------|--------|----------|
@@ -25,9 +25,9 @@ Generated: 2026-03-08
 | Schema Integrity | PASS | DDL has all required fields (access_count, last_accessed_at, stability_hours, fact_type, is_forgotten, forgotten_at, forget_reason). Migrations v1->v2->v3 tested. Schema version tracking works. |
 | Dead Code | PASS | No todo!(), unimplemented!(), or stub methods found in mneme src (non-engine). |
 
-## Detailed Findings
+## Detailed findings
 
-### Gate 1: Test Suite Health
+### Gate 1: test suite health
 
 ```
 Unit tests:  241 pass, 0 fail, 0 ignored (lib tests)
@@ -50,7 +50,7 @@ Test distribution by module:
 - embedding: 7 tests (fastembed init, deterministic, normalized, dimension, batch matching)
 - store: various session store tests
 
-### Gate 2: Knowledge Store CRUD
+### Gate 2: knowledge store CRUD
 
 All operations verified via integration tests (`knowledge_engine.rs`, `knowledge_lifecycle.rs`, `access_tracking.rs`):
 
@@ -63,7 +63,7 @@ All operations verified via integration tests (`knowledge_engine.rs`, `knowledge
 7. **Unforget fact -> restored**: `unforget_restores_to_search` - forget then unforget. Fact returns to query results. Audit shows cleared forget metadata.
 8. **Access tracking**: `insert_fact_then_search_increments_access_count`, `triple_search_yields_access_count_3` - vector search increments access_count and sets last_accessed_at. 3 searches = access_count 3.
 
-### Gate 3: Recall Engine
+### Gate 3: recall engine
 
 44 unit tests verify the 6-factor scoring formula:
 
@@ -88,7 +88,7 @@ Integration tests (`recall_scoring.rs`, `knowledge_recall.rs`):
 - recent outranks old
 - custom weights shift ranking
 
-### Gate 4: Extraction Pipeline
+### Gate 4: extraction pipeline
 
 Parse tests verify:
 - Valid JSON with entities, relationships, facts parsed correctly
@@ -113,7 +113,7 @@ Vocab validation:
 - Aliases map correctly (has->OWNS, works on->WORKS_AT, created by->CREATED, etc.)
 - Unknown types return Unknown(String), not a fallback
 
-### Gate 5: Backup & Retention
+### Gate 5: backup & retention
 
 Backup (19 tests):
 - `backup_creates_valid_sqlite_database`: VACUUM INTO produces a real SQLite file
@@ -133,7 +133,7 @@ Retention (13 tests):
 - Active sessions skipped
 - Property test: applying retention twice is idempotent
 
-### Gate 6: Import/Export Round-Trip
+### Gate 6: import/export round-trip
 
 21 tests covering:
 - `export_import_roundtrip`: export agent data, import to fresh store, verify fact/note counts and content match
@@ -145,7 +145,7 @@ Retention (13 tests):
 - `rejects_unsupported_version`: future format versions rejected gracefully
 - Property test: export_import_preserves_content with random data
 
-### Gate 7: Property Tests
+### Gate 7: property tests
 
 8 property tests, all pass:
 
@@ -160,7 +160,7 @@ Retention (13 tests):
 | retention | `retention_idempotency` | Applying retention policy twice produces same result as once |
 | import | `export_import_preserves_content` | Random agent data round-trips through export/import with content preserved |
 
-### Gate 8: Integration Tests
+### Gate 8: integration tests
 
 89 tests across 17 test files in `aletheia-integration-tests`:
 
@@ -183,7 +183,7 @@ Retention (13 tests):
 
 All tests verify real behavior, not just compilation. Tests assert on content, counts, ordering, and field values.
 
-### Gate 9: Schema Integrity
+### Gate 9: schema integrity
 
 **Knowledge Store DDL** (`knowledge_store.rs` KNOWLEDGE_DDL):
 All required fields present in the facts relation:
@@ -210,7 +210,7 @@ All required fields present in the facts relation:
 
 **One bug found and fixed**: `schema_version_queryable` integration test asserted `== 2` but actual version is 3 (bumped by v2->v3 migration adding forget columns). Fixed to assert `== 3`.
 
-### Gate 10: Dead Code and Stub Detection
+### Gate 10: dead code and stub detection
 
 No stubs found:
 - Zero `todo!()` or `unimplemented!()` in `crates/mneme/src/*.rs` (excluding engine/)
@@ -227,7 +227,7 @@ All public methods on KnowledgeStore have real implementations:
 - `increment_access`: access tracking
 - All have async wrappers via `spawn_blocking`
 
-## Gaps vs. mneme-excellence.md Phase A Items
+## Gaps vs. mneme-excellence.md phase A items
 
 | Phase A Task | Status | Evidence |
 |-------------|--------|----------|
@@ -242,7 +242,7 @@ All public methods on KnowledgeStore have real implementations:
 | Fix lib.rs #[allow] -> #[expect] | DONE | Engine module uses `#[expect]` with reason strings. |
 | Correct TECHNOLOGY.md | NOT VERIFIED | Not in scope for this validation (docs, not code). |
 
-## What the Waves Actually Delivered
+## What the waves actually delivered
 
 The waves (PRs #593-#620) delivered genuine working capabilities, not just code that compiles:
 

--- a/planning/requirements.md
+++ b/planning/requirements.md
@@ -1,4 +1,4 @@
-# Aletheia — Requirements Tracking
+# Aletheia: requirements tracking
 
 Functional and non-functional requirements. Updated through Wave 9 (#756).
 
@@ -11,26 +11,26 @@ Functional and non-functional requirements. Updated through Wave 9 (#756).
 | ID | Requirement | Status |
 |----|-------------|--------|
 | MEM-01 | Hybrid recall: vector + graph + BM25 with MMR diversity | Done |
-| MEM-02 | Mem0 sidecar integration | Inactive — replaced by mneme direct implementation |
+| MEM-02 | Mem0 sidecar integration | Inactive: replaced by mneme direct implementation |
 | MEM-03 | Explicit forgetting API | Done (#736) |
 | MEM-04 | Distillation + memory flush (melete) | Done |
 
 ---
 
-## Mneme Phases
+## Mneme phases
 
 | Phase | Description | Status |
 |-------|-------------|--------|
-| A | SQLite session store — WAL, migrations, retention | Done |
-| B | Datalog engine absorption — embedded Datalog + HNSW | Done |
+| A | SQLite session store: WAL, migrations, retention | Done |
+| B | Datalog engine absorption: embedded Datalog + HNSW | Done |
 | C | Embedding provider trait + candle default | Done (#693) |
-| D | Hybrid recall pipeline — vector + graph + BM25 + MMR | Done |
-| E | Error remediation — snafu migration, BoxErr elimination | Done (#749, #752) |
-| F | Engine hygiene — unsafe SAFETY docs, lint suppressions, dead code | Done (#750, #752, #753) |
+| D | Hybrid recall pipeline: vector + graph + BM25 + MMR | Done |
+| E | Error remediation: snafu migration, BoxErr elimination | Done (#749, #752) |
+| F | Engine hygiene: unsafe SAFETY docs, lint suppressions, dead code | Done (#750, #752, #753) |
 
 ---
 
-## Engine Hygiene (completed Wave 8–9)
+## Engine hygiene (completed Wave 8–9)
 
 - **Snafu migration:** All library crates use snafu error enums. `anyhow` limited to binary entry points. Done.
 - **Unwrap elimination:** No `unwrap()` in library code. Documented exceptions with SAFETY comments. Done.
@@ -50,11 +50,11 @@ Functional and non-functional requirements. Updated through Wave 9 (#756).
 | SKILL-04 | Skill export/import (autarkeia) | Done (#507) |
 | SKILL-05 | Cross-nous skill sharing | Done (#696) |
 | SKILL-06 | Skill versioning | Done (#696) |
-| SKILL-07 | Skill quality lifecycle — promotion, demotion, expiry | Done (#740) |
+| SKILL-07 | Skill quality lifecycle: promotion, demotion, expiry | Done (#740) |
 
 ---
 
-## Agent Model (NOUS)
+## Agent model (NOUS)
 
 | ID | Requirement | Status |
 |----|-------------|--------|
@@ -71,12 +71,12 @@ Functional and non-functional requirements. Updated through Wave 9 (#756).
 
 | ID | Requirement | Status |
 |----|-------------|--------|
-| PLUG-01 | WASM plugin host (wasmtime) | Planned — M6 |
+| PLUG-01 | WASM plugin host (wasmtime) | Planned (M6) |
 | PLUG-02 | Agent export/import (autarkeia) | Done (#507) |
 
 ---
 
-## Non-Functional
+## Non-functional
 
 | ID | Requirement | Status |
 |----|-------------|--------|

--- a/planning/roadmap.md
+++ b/planning/roadmap.md
@@ -1,4 +1,4 @@
-# Aletheia — Implementation Roadmap
+# Aletheia: implementation roadmap
 
 Tracks the prompt-driven implementation plan. Each Wave is a batch of PRs shipped together.
 
@@ -30,12 +30,12 @@ All done.
 
 | PR | Title |
 |----|-------|
-| #732 | Runtime snafu — error enum migration across runtime crates |
-| #733 | TUI error recovery — graceful degradation on API errors |
-| #734 | Core pipeline safety — cancel-safe select! branches |
-| #735 | Deployment flow — systemd unit, NixOS module skeleton |
-| #736 | Explicit forgetting — knowledge deletion API |
-| #737 | Cross-crate integration tests — pylon + mneme + nous end-to-end |
+| #732 | Runtime snafu: error enum migration across runtime crates |
+| #733 | TUI error recovery: graceful degradation on API errors |
+| #734 | Core pipeline safety: cancel-safe select! branches |
+| #735 | Deployment flow: systemd unit, NixOS module skeleton |
+| #736 | Explicit forgetting: knowledge deletion API |
+| #737 | Cross-crate integration tests: pylon + mneme + nous end-to-end |
 
 ---
 
@@ -44,10 +44,10 @@ All done.
 | PR | Title |
 |----|-------|
 | #738 | Daemon task backoff + health checks |
-| #739 | Actor crash recovery — NousActor supervisor restart |
-| #740 | Skill quality lifecycle — promotion, demotion, expiry |
+| #739 | Actor crash recovery: NousActor supervisor restart |
+| #740 | Skill quality lifecycle: promotion, demotion, expiry |
 | #741 | HNSW bounded cache + panic elimination |
-| #742 | lru dep bump — update to current release |
+| #742 | lru dep bump: update to current release |
 
 ---
 
@@ -55,12 +55,12 @@ All done.
 
 | PR | Title |
 |----|-------|
-| #743 | CHANGELOG generation — automated from conventional commits |
-| #744 | Smoke test suite — binary-level integration checks |
-| #749 | Engine facade consolidation — BoxErr → InternalError |
-| #750 | Workspace hygiene — lint cleanup, unused deps |
-| #751 | Deploy bug fixes — config cascade edge cases |
-| #752 | Final validation — zero blanket suppressions. Engine error remediation COMPLETE. |
+| #743 | CHANGELOG generation: automated from conventional commits |
+| #744 | Smoke test suite: binary-level integration checks |
+| #749 | Engine facade consolidation: BoxErr → InternalError |
+| #750 | Workspace hygiene: lint cleanup, unused deps |
+| #751 | Deploy bug fixes: config cascade edge cases |
+| #752 | Final validation: zero blanket suppressions. Engine error remediation COMPLETE. |
 
 ---
 
@@ -68,14 +68,14 @@ All done.
 
 | PR | Title |
 |----|-------|
-| #753 | Unsafe SAFETY docs — all 14 unsafe sites documented (#753 = P202 verification) |
-| #754 | Pylon handler tests — unit tests for all HTTP endpoints |
-| #755 | CLI modularization — main.rs 2245 → 172 lines, commands/ submodule |
-| #756 | Monolith decomposition — 7 large files split into focused modules |
+| #753 | Unsafe SAFETY docs: all 14 unsafe sites documented (#753 = P202 verification) |
+| #754 | Pylon handler tests: unit tests for all HTTP endpoints |
+| #755 | CLI modularization: main.rs 2245 → 172 lines, commands/ submodule |
+| #756 | Monolith decomposition: 7 large files split into focused modules |
 
 ---
 
-## In Flight
+## In flight
 
 None. All waves complete.
 
@@ -85,4 +85,4 @@ None. All waves complete.
 
 | Prompt | Title | Status |
 |--------|-------|--------|
-| P019 | Cutover validation | HELD — pending operator readiness |
+| P019 | Cutover validation | HELD: pending operator readiness |


### PR DESCRIPTION
## Changes

- Replaced all prose em dashes (291 in scope) with appropriate punctuation (commas, colons, semicolons, or restructured sentences); 36 em dashes in code fences were correctly left untouched
- Fixed all headers to sentence case (first word + proper nouns/acronyms only)
- Fixed skipped heading levels
- Replaced AI trope words: `comprehensive` → `complete`/`full`, metaphorical `navigate` → `handle`/`work through`, `underscore` as verb → `highlight`/`show`
- Removed filler phrases (`it is important to note`, `please note that`, etc.)
- Fixed spatial references (`see below`, `in the example above`) → named section references
- All changes preserve original meaning

## Observations

None outside scope.

## Verification

```
grep -rn '—' docs/ planning/ CLAUDE.md --include='*.md' | wc -l
# => 36 (all inside code fences)
```