### PR TITLE
fix(eval): framework reliability (4 issues)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,6 +138,7 @@ name = "aletheia-dokimion"
 version = "0.10.0"
 dependencies = [
  "owo-colors",
+ "regex",
  "reqwest 0.13.2",
  "rustls",
  "serde",

--- a/crates/eval/Cargo.toml
+++ b/crates/eval/Cargo.toml
@@ -13,6 +13,7 @@ workspace = true
 
 [dependencies]
 reqwest = { workspace = true }
+regex = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 snafu = { workspace = true }

--- a/crates/eval/src/error.rs
+++ b/crates/eval/src/error.rs
@@ -49,6 +49,12 @@ pub enum Error {
         #[snafu(implicit)]
         location: snafu::Location,
     },
+
+    #[snafu(display("no agents available: agent list is empty"))]
+    NoAgentsAvailable {
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/crates/eval/src/report.rs
+++ b/crates/eval/src/report.rs
@@ -188,6 +188,8 @@ mod tests {
                         category: "health",
                         requires_auth: false,
                         requires_nous: false,
+                        expected_contains: None,
+                        expected_pattern: None,
                     },
                     outcome: ScenarioOutcome::Passed {
                         duration: Duration::from_millis(50),
@@ -200,6 +202,8 @@ mod tests {
                         category: "session",
                         requires_auth: true,
                         requires_nous: true,
+                        expected_contains: None,
+                        expected_pattern: None,
                     },
                     outcome: ScenarioOutcome::Failed {
                         duration: Duration::from_millis(200),

--- a/crates/eval/src/runner.rs
+++ b/crates/eval/src/runner.rs
@@ -88,8 +88,9 @@ impl ScenarioRunner {
         let mut passed = 0_usize;
         let mut failed = 0_usize;
         let mut skipped = 0_usize;
+        let mut fail_fast_idx: Option<usize> = None;
 
-        for scenario in &scenarios {
+        for (i, scenario) in scenarios.iter().enumerate() {
             let meta = scenario.meta();
 
             // Pre-check: skip if prerequisites aren't met
@@ -163,8 +164,22 @@ impl ScenarioRunner {
             results.push(ScenarioResult { meta, outcome });
 
             if self.config.fail_fast && failed > 0 {
-                // Mark remaining as skipped
+                fail_fast_idx = Some(i + 1);
                 break;
+            }
+        }
+
+        // When fail_fast triggered, include remaining scenarios as skipped so that
+        // passed + failed + skipped == total. Omitting them makes counts inconsistent.
+        if let Some(remaining_start) = fail_fast_idx {
+            for scenario in &scenarios[remaining_start..] {
+                results.push(ScenarioResult {
+                    meta: scenario.meta(),
+                    outcome: ScenarioOutcome::Skipped {
+                        reason: "fail_fast: earlier scenario failed".to_owned(),
+                    },
+                });
+                skipped += 1;
             }
         }
 
@@ -192,6 +207,8 @@ mod tests {
                 category: "test",
                 requires_auth: false,
                 requires_nous: false,
+                expected_contains: None,
+                expected_pattern: None,
             }
         }
         fn run<'a>(&'a self, _client: &'a EvalClient) -> crate::scenario::ScenarioFuture<'a> {
@@ -209,6 +226,8 @@ mod tests {
                 category: "test",
                 requires_auth: false,
                 requires_nous: false,
+                expected_contains: None,
+                expected_pattern: None,
             }
         }
         fn run<'a>(&'a self, _client: &'a EvalClient) -> crate::scenario::ScenarioFuture<'a> {
@@ -286,6 +305,8 @@ mod tests {
             category: "unit",
             requires_auth: true,
             requires_nous: false,
+            expected_contains: None,
+            expected_pattern: None,
         };
         assert_eq!(meta.id, "test-scenario");
         assert_eq!(meta.description, "a test scenario");

--- a/crates/eval/src/scenario.rs
+++ b/crates/eval/src/scenario.rs
@@ -4,6 +4,8 @@ use std::future::Future;
 use std::pin::Pin;
 use std::time::Duration;
 
+use regex::Regex;
+
 use crate::client::EvalClient;
 use crate::error::{self, Error, Result};
 
@@ -23,6 +25,10 @@ pub struct ScenarioMeta {
     pub requires_auth: bool,
     /// Whether this scenario requires at least one configured nous.
     pub requires_nous: bool,
+    /// Optional substring that the response text must contain.
+    pub expected_contains: Option<&'static str>,
+    /// Optional regex pattern that the response text must match.
+    pub expected_pattern: Option<&'static str>,
 }
 
 /// Result of running a single scenario.
@@ -90,6 +96,43 @@ pub fn assert_eq_eval<T: PartialEq + std::fmt::Debug>(
     }
 }
 
+/// Validate a response string against the scenario's semantic criteria.
+///
+/// When neither `expected_contains` nor `expected_pattern` is set, accepts any
+/// non-empty response and logs a warning about missing validation criteria.
+#[tracing::instrument(skip(text), fields(scenario_id = meta.id, text_len = text.len()))]
+pub fn validate_response(meta: &ScenarioMeta, text: &str) -> Result<()> {
+    if meta.expected_contains.is_none() && meta.expected_pattern.is_none() {
+        tracing::warn!(
+            scenario_id = meta.id,
+            "no validation criteria specified; accepting any non-empty response"
+        );
+        return assert_eval(!text.is_empty(), "response should not be empty");
+    }
+
+    if let Some(keyword) = meta.expected_contains {
+        assert_eval(
+            text.contains(keyword),
+            format!("response missing expected text: {keyword:?}"),
+        )?;
+    }
+
+    if let Some(pattern) = meta.expected_pattern {
+        let re = Regex::new(pattern).map_err(|e| {
+            error::AssertionSnafu {
+                message: format!("invalid expected_pattern {pattern:?}: {e}"),
+            }
+            .build()
+        })?;
+        assert_eval(
+            re.is_match(text),
+            format!("response does not match expected_pattern: {pattern:?}"),
+        )?;
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 #[expect(clippy::unwrap_used, reason = "test assertions")]
 mod tests {
@@ -119,5 +162,62 @@ mod tests {
         assert!(result.is_err());
         let err_msg = result.unwrap_err().to_string();
         assert!(err_msg.contains("ctx"));
+    }
+
+    fn meta_with_criteria(
+        expected_contains: Option<&'static str>,
+        expected_pattern: Option<&'static str>,
+    ) -> ScenarioMeta {
+        ScenarioMeta {
+            id: "test",
+            description: "test",
+            category: "test",
+            requires_auth: false,
+            requires_nous: false,
+            expected_contains,
+            expected_pattern,
+        }
+    }
+
+    #[test]
+    fn validate_response_no_criteria_accepts_nonempty() {
+        let meta = meta_with_criteria(None, None);
+        assert!(validate_response(&meta, "some text").is_ok());
+    }
+
+    #[test]
+    fn validate_response_no_criteria_rejects_empty() {
+        let meta = meta_with_criteria(None, None);
+        assert!(validate_response(&meta, "").is_err());
+    }
+
+    #[test]
+    fn validate_response_expected_contains_passes() {
+        let meta = meta_with_criteria(Some("hello"), None);
+        assert!(validate_response(&meta, "say hello world").is_ok());
+    }
+
+    #[test]
+    fn validate_response_expected_contains_fails() {
+        let meta = meta_with_criteria(Some("hello"), None);
+        assert!(validate_response(&meta, "goodbye world").is_err());
+    }
+
+    #[test]
+    fn validate_response_expected_pattern_passes() {
+        let meta = meta_with_criteria(None, Some(r"\d+"));
+        assert!(validate_response(&meta, "answer is 42").is_ok());
+    }
+
+    #[test]
+    fn validate_response_expected_pattern_fails() {
+        let meta = meta_with_criteria(None, Some(r"\d+"));
+        assert!(validate_response(&meta, "no digits here").is_err());
+    }
+
+    #[test]
+    fn validate_response_invalid_pattern_returns_error() {
+        let meta = meta_with_criteria(None, Some(r"[invalid"));
+        assert!(validate_response(&meta, "text").is_err());
     }
 }

--- a/crates/eval/src/scenarios/auth.rs
+++ b/crates/eval/src/scenarios/auth.rs
@@ -19,6 +19,8 @@ impl Scenario for AuthRejectsNoToken {
             category: "auth",
             requires_auth: false,
             requires_nous: false,
+            expected_contains: None,
+            expected_pattern: None,
         }
     }
     fn run<'a>(&'a self, client: &'a EvalClient) -> ScenarioFuture<'a> {
@@ -41,6 +43,8 @@ impl Scenario for AuthRejectsBadToken {
             category: "auth",
             requires_auth: false,
             requires_nous: false,
+            expected_contains: None,
+            expected_pattern: None,
         }
     }
     fn run<'a>(&'a self, client: &'a EvalClient) -> ScenarioFuture<'a> {

--- a/crates/eval/src/scenarios/conversation.rs
+++ b/crates/eval/src/scenarios/conversation.rs
@@ -1,9 +1,10 @@
 //! Conversation scenarios — message flow, SSE, history.
 
+use snafu::OptionExt as _;
 use tracing::Instrument;
 
 use crate::client::{EvalClient, MessageRole};
-use crate::scenario::{Scenario, ScenarioFuture, ScenarioMeta, assert_eval};
+use crate::scenario::{Scenario, ScenarioFuture, ScenarioMeta, assert_eval, validate_response};
 use crate::sse;
 
 #[tracing::instrument(skip_all)]
@@ -25,13 +26,18 @@ impl Scenario for ConversationSendSse {
             category: "conversation",
             requires_auth: true,
             requires_nous: true,
+            expected_contains: None,
+            expected_pattern: None,
         }
     }
     fn run<'a>(&'a self, client: &'a EvalClient) -> ScenarioFuture<'a> {
         Box::pin(
             async move {
                 let nous_list = client.list_nous().await?;
-                let nous_id = &nous_list[0].id;
+                let nous = nous_list
+                    .first()
+                    .context(crate::error::NoAgentsAvailableSnafu)?;
+                let nous_id = &nous.id;
                 let key = super::unique_key("conv", "sse");
                 let session = client.create_session(nous_id, &key).await?;
                 let events = client
@@ -43,7 +49,7 @@ impl Scenario for ConversationSendSse {
                     "SSE stream should contain message_complete event",
                 )?;
                 let text = sse::extract_text(&events);
-                assert_eval(!text.is_empty(), "response text should not be empty")?;
+                validate_response(&self.meta(), &text)?;
                 let _ = client.close_session(&session.id).await;
                 Ok(())
             }
@@ -64,13 +70,18 @@ impl Scenario for ConversationHistoryReflects {
             category: "conversation",
             requires_auth: true,
             requires_nous: true,
+            expected_contains: None,
+            expected_pattern: None,
         }
     }
     fn run<'a>(&'a self, client: &'a EvalClient) -> ScenarioFuture<'a> {
         Box::pin(
             async move {
                 let nous_list = client.list_nous().await?;
-                let nous_id = &nous_list[0].id;
+                let nous = nous_list
+                    .first()
+                    .context(crate::error::NoAgentsAvailableSnafu)?;
+                let nous_id = &nous.id;
                 let key = super::unique_key("conv", "history");
                 let session = client.create_session(nous_id, &key).await?;
                 let _ = client
@@ -118,13 +129,18 @@ impl Scenario for ConversationMultiTurn {
             category: "conversation",
             requires_auth: true,
             requires_nous: true,
+            expected_contains: None,
+            expected_pattern: None,
         }
     }
     fn run<'a>(&'a self, client: &'a EvalClient) -> ScenarioFuture<'a> {
         Box::pin(
             async move {
                 let nous_list = client.list_nous().await?;
-                let nous_id = &nous_list[0].id;
+                let nous = nous_list
+                    .first()
+                    .context(crate::error::NoAgentsAvailableSnafu)?;
+                let nous_id = &nous.id;
                 let key = super::unique_key("conv", "multi");
                 let session = client.create_session(nous_id, &key).await?;
                 let _ = client
@@ -161,13 +177,18 @@ impl Scenario for ConversationEmptyRejected {
             category: "conversation",
             requires_auth: true,
             requires_nous: true,
+            expected_contains: None,
+            expected_pattern: None,
         }
     }
     fn run<'a>(&'a self, client: &'a EvalClient) -> ScenarioFuture<'a> {
         Box::pin(
             async move {
                 let nous_list = client.list_nous().await?;
-                let nous_id = &nous_list[0].id;
+                let nous = nous_list
+                    .first()
+                    .context(crate::error::NoAgentsAvailableSnafu)?;
+                let nous_id = &nous.id;
                 let key = super::unique_key("conv", "empty");
                 let session = client.create_session(nous_id, &key).await?;
                 match client.send_message(&session.id, "").await {

--- a/crates/eval/src/scenarios/health.rs
+++ b/crates/eval/src/scenarios/health.rs
@@ -23,6 +23,8 @@ impl Scenario for HealthReturnsOk {
             category: "health",
             requires_auth: false,
             requires_nous: false,
+            expected_contains: None,
+            expected_pattern: None,
         }
     }
     fn run<'a>(&'a self, client: &'a EvalClient) -> ScenarioFuture<'a> {
@@ -51,6 +53,8 @@ impl Scenario for HealthContainsVersion {
             category: "health",
             requires_auth: false,
             requires_nous: false,
+            expected_contains: None,
+            expected_pattern: None,
         }
     }
     fn run<'a>(&'a self, client: &'a EvalClient) -> ScenarioFuture<'a> {
@@ -76,6 +80,8 @@ impl Scenario for HealthReportsChecks {
             category: "health",
             requires_auth: false,
             requires_nous: false,
+            expected_contains: None,
+            expected_pattern: None,
         }
     }
     fn run<'a>(&'a self, client: &'a EvalClient) -> ScenarioFuture<'a> {

--- a/crates/eval/src/scenarios/nous.rs
+++ b/crates/eval/src/scenarios/nous.rs
@@ -22,6 +22,8 @@ impl Scenario for NousListReturnsArray {
             category: "nous",
             requires_auth: true,
             requires_nous: false,
+            expected_contains: None,
+            expected_pattern: None,
         }
     }
     fn run<'a>(&'a self, client: &'a EvalClient) -> ScenarioFuture<'a> {
@@ -50,6 +52,8 @@ impl Scenario for NousUnknownReturns404 {
             category: "nous",
             requires_auth: true,
             requires_nous: false,
+            expected_contains: None,
+            expected_pattern: None,
         }
     }
     fn run<'a>(&'a self, client: &'a EvalClient) -> ScenarioFuture<'a> {

--- a/crates/eval/src/scenarios/session.rs
+++ b/crates/eval/src/scenarios/session.rs
@@ -1,5 +1,6 @@
 //! Session CRUD lifecycle scenarios.
 
+use snafu::OptionExt as _;
 use tracing::Instrument;
 
 use crate::client::{EvalClient, SessionStatus};
@@ -23,13 +24,18 @@ impl Scenario for SessionCreateAndGet {
             category: "session",
             requires_auth: true,
             requires_nous: true,
+            expected_contains: None,
+            expected_pattern: None,
         }
     }
     fn run<'a>(&'a self, client: &'a EvalClient) -> ScenarioFuture<'a> {
         Box::pin(
             async move {
                 let nous_list = client.list_nous().await?;
-                let nous_id = &nous_list[0].id;
+                let nous = nous_list
+                    .first()
+                    .context(crate::error::NoAgentsAvailableSnafu)?;
+                let nous_id = &nous.id;
                 let key = super::unique_key("session", "create");
                 let session = client.create_session(nous_id, &key).await?;
                 assert_eval(!session.id.is_empty(), "session id should not be empty")?;
@@ -62,13 +68,18 @@ impl Scenario for SessionCloseArchives {
             category: "session",
             requires_auth: true,
             requires_nous: true,
+            expected_contains: None,
+            expected_pattern: None,
         }
     }
     fn run<'a>(&'a self, client: &'a EvalClient) -> ScenarioFuture<'a> {
         Box::pin(
             async move {
                 let nous_list = client.list_nous().await?;
-                let nous_id = &nous_list[0].id;
+                let nous = nous_list
+                    .first()
+                    .context(crate::error::NoAgentsAvailableSnafu)?;
+                let nous_id = &nous.id;
                 let key = super::unique_key("session", "close");
                 let session = client.create_session(nous_id, &key).await?;
                 client.close_session(&session.id).await?;
@@ -96,6 +107,8 @@ impl Scenario for SessionUnknown404 {
             category: "session",
             requires_auth: true,
             requires_nous: false,
+            expected_contains: None,
+            expected_pattern: None,
         }
     }
     fn run<'a>(&'a self, client: &'a EvalClient) -> ScenarioFuture<'a> {

--- a/crates/eval/src/sse.rs
+++ b/crates/eval/src/sse.rs
@@ -35,13 +35,22 @@ pub fn parse_sse_text(text: &str) -> Result<Vec<ParsedSseEvent>> {
         if line.is_empty() {
             // Empty line = event boundary
             if !current_event_type.is_empty() && !current_data.is_empty() {
-                let data: serde_json::Value =
-                    serde_json::from_str(&current_data).context(error::JsonSnafu)?;
-                events.push(ParsedSseEvent {
-                    event_type: std::mem::take(&mut current_event_type),
-                    data,
-                });
-                current_data.clear();
+                match serde_json::from_str::<serde_json::Value>(&current_data) {
+                    Ok(data) => {
+                        events.push(ParsedSseEvent {
+                            event_type: std::mem::take(&mut current_event_type),
+                            data,
+                        });
+                        current_data.clear();
+                    }
+                    Err(_) => {
+                        tracing::warn!(
+                            event_type = %current_event_type,
+                            raw_data = %current_data,
+                            "malformed SSE event skipped"
+                        );
+                    }
+                }
             }
             current_event_type.clear();
             current_data.clear();
@@ -67,12 +76,21 @@ pub fn parse_sse_text(text: &str) -> Result<Vec<ParsedSseEvent>> {
 
     // Handle trailing event without final blank line
     if !current_event_type.is_empty() && !current_data.is_empty() {
-        let data: serde_json::Value =
-            serde_json::from_str(&current_data).context(error::JsonSnafu)?;
-        events.push(ParsedSseEvent {
-            event_type: current_event_type,
-            data,
-        });
+        match serde_json::from_str::<serde_json::Value>(&current_data) {
+            Ok(data) => {
+                events.push(ParsedSseEvent {
+                    event_type: current_event_type,
+                    data,
+                });
+            }
+            Err(_) => {
+                tracing::warn!(
+                    event_type = %current_event_type,
+                    raw_data = %current_data,
+                    "malformed SSE event skipped"
+                );
+            }
+        }
     }
 
     Ok(events)
@@ -296,10 +314,19 @@ data: {\"stop_reason\":\"end_turn\",\"usage\":{\"input_tokens\":100,\"output_tok
     }
 
     #[test]
-    fn invalid_json_in_data_returns_error() {
+    fn malformed_json_event_skipped_parsing_continues() {
+        let input = "event: foo\ndata: not-json\n\nevent: text_delta\ndata: {\"text\":\"ok\"}\n\n";
+        let events = parse_sse_text(input).expect("parse should succeed");
+        // Malformed event is skipped; valid subsequent event is preserved
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].event_type, "text_delta");
+    }
+
+    #[test]
+    fn malformed_json_only_returns_empty() {
         let input = "event: foo\ndata: not-json\n\n";
-        let result = parse_sse_text(input);
-        assert!(result.is_err());
+        let events = parse_sse_text(input).expect("parse should succeed");
+        assert!(events.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
Closes #1085, #1086, #1087, #1088

## Changes
- Guard against empty agent list (error not panic)
- Skipped scenarios in fail_fast reports
- Malformed SSE events skipped, parsing continues
- Optional semantic validation for scenarios

## Observations
None.