### PR TITLE
fix(diaporeia): MCP error sanitization (2 issues)

### DIFF
--- a/crates/diaporeia/src/error.rs
+++ b/crates/diaporeia/src/error.rs
@@ -68,8 +68,73 @@ pub enum Error {
 pub type Result<T> = std::result::Result<T, Error>;
 
 /// Convert a diaporeia `Error` into an rmcp `ErrorData` for tool return types.
+///
+/// Maps each variant to the appropriate MCP error code and strips server-side
+/// file paths from the message before it reaches the client.
 impl From<Error> for rmcp::ErrorData {
     fn from(err: Error) -> Self {
-        rmcp::ErrorData::internal_error(err.to_string(), None)
+        let message = crate::sanitize::strip_paths(&err.to_string());
+        match &err {
+            // Client provided an invalid agent or session ID — tell them what wasn't found.
+            Error::NousNotFound { .. } | Error::SessionNotFound { .. } => {
+                rmcp::ErrorData::invalid_params(message, None)
+            }
+            // Server-side failures — expose a sanitized message, never internal details.
+            Error::Pipeline { .. }
+            | Error::SessionStore { .. }
+            | Error::Serialization { .. }
+            | Error::Transport { .. }
+            | Error::WorkspaceFile { .. } => rmcp::ErrorData::internal_error(message, None),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn nous_not_found_maps_to_invalid_params() {
+        let err = NousNotFoundSnafu {
+            id: "missing-agent".to_string(),
+        }
+        .build();
+        let mcp: rmcp::ErrorData = err.into();
+        assert_eq!(mcp.code, rmcp::model::ErrorCode::INVALID_PARAMS);
+        assert!(mcp.message.contains("missing-agent"));
+    }
+
+    #[test]
+    fn session_not_found_maps_to_invalid_params() {
+        let err = SessionNotFoundSnafu {
+            id: "no-such-session".to_string(),
+        }
+        .build();
+        let mcp: rmcp::ErrorData = err.into();
+        assert_eq!(mcp.code, rmcp::model::ErrorCode::INVALID_PARAMS);
+    }
+
+    #[test]
+    fn pipeline_error_maps_to_internal_error() {
+        let err = PipelineSnafu {
+            message: "actor channel closed".to_string(),
+        }
+        .build();
+        let mcp: rmcp::ErrorData = err.into();
+        assert_eq!(mcp.code, rmcp::model::ErrorCode::INTERNAL_ERROR);
+    }
+
+    #[test]
+    fn pipeline_error_strips_server_path() {
+        let err = PipelineSnafu {
+            message: "error reading /home/alice/project/nous.rs: permission denied".to_string(),
+        }
+        .build();
+        let mcp: rmcp::ErrorData = err.into();
+        assert!(
+            !mcp.message.contains("/home/alice"),
+            "server path must not reach the client"
+        );
+        assert!(mcp.message.contains("[server path]"));
     }
 }

--- a/crates/diaporeia/src/lib.rs
+++ b/crates/diaporeia/src/lib.rs
@@ -16,6 +16,7 @@
 
 pub mod error;
 mod resources;
+pub(crate) mod sanitize;
 pub mod server;
 pub mod state;
 mod tools;

--- a/crates/diaporeia/src/resources/config.rs
+++ b/crates/diaporeia/src/resources/config.rs
@@ -3,7 +3,9 @@
 use rmcp::model::{
     RawResourceTemplate, ReadResourceRequestParams, ResourceContents, ResourceTemplate,
 };
+use snafu::ResultExt as _;
 
+use crate::error::SerializationSnafu;
 use crate::state::DiaporeiaState;
 
 /// Build resource templates for config resources.
@@ -53,7 +55,8 @@ pub(crate) async fn read_resource(
     });
 
     let json = serde_json::to_string_pretty(&redacted)
-        .map_err(|e| rmcp::ErrorData::internal_error(e.to_string(), None))?;
+        .context(SerializationSnafu {})
+        .map_err(rmcp::ErrorData::from)?;
 
     Ok(vec![ResourceContents::text(json, uri)])
 }

--- a/crates/diaporeia/src/resources/nous.rs
+++ b/crates/diaporeia/src/resources/nous.rs
@@ -5,7 +5,9 @@
 use rmcp::model::{
     RawResourceTemplate, ReadResourceRequestParams, ResourceContents, ResourceTemplate,
 };
+use snafu::ResultExt as _;
 
+use crate::error::WorkspaceFileSnafu;
 use crate::state::DiaporeiaState;
 
 /// Workspace files exposed as resources.
@@ -79,12 +81,9 @@ pub(crate) fn read_resource(
     };
 
     let file_path = state.oikos.nous_file(nous_id, filename);
-    let content = std::fs::read_to_string(&file_path).map_err(|e| {
-        rmcp::ErrorData::internal_error(
-            format!("failed to read {}: {e}", file_path.display()),
-            None,
-        )
-    })?;
+    let content = std::fs::read_to_string(&file_path)
+        .context(WorkspaceFileSnafu {})
+        .map_err(rmcp::ErrorData::from)?;
 
     Ok(vec![ResourceContents::text(content, uri)])
 }

--- a/crates/diaporeia/src/sanitize.rs
+++ b/crates/diaporeia/src/sanitize.rs
@@ -1,0 +1,139 @@
+//! Error message sanitization for MCP responses.
+//!
+//! Strips server-side details (file system paths) before messages reach clients.
+
+/// Replace absolute file system paths in an error message with `[server path]`.
+///
+/// Detects Unix absolute paths: a `/` preceded by a word boundary (not another `/`
+/// or `:`) and followed by at least one alphanumeric character, `.`, `_`, or `-`.
+/// Tracks the last emitted byte across slice boundaries so that `://` in URI
+/// schemes (e.g. `aletheia://…`) is never misidentified as a path start.
+pub(crate) fn strip_paths(message: &str) -> String {
+    let mut result = String::with_capacity(message.len());
+    let mut remaining = message;
+    // WHY: `remaining` resets its indices each iteration, losing context about
+    // the byte immediately before the current slice. Track the last emitted byte
+    // so `://` and `//` sequences spanning slice boundaries are handled correctly.
+    let mut last_pushed_byte: Option<u8> = None;
+
+    loop {
+        let Some(slash_pos) = remaining.find('/') else {
+            result.push_str(remaining);
+            break;
+        };
+
+        // The byte immediately before this '/': either within `remaining`, or
+        // the last byte emitted by a previous iteration.
+        let prev_byte = if slash_pos > 0 {
+            remaining.as_bytes().get(slash_pos - 1).copied()
+        } else {
+            last_pushed_byte
+        };
+
+        // Skip `/` that follows another `/` or `:` — those are URI separators.
+        let is_word_boundary = !matches!(prev_byte, Some(b'/' | b':'));
+
+        let after_slash = &remaining[slash_pos + 1..];
+        let next_is_path_char = after_slash
+            .chars()
+            .next()
+            .is_some_and(|c| c.is_alphanumeric() || matches!(c, '_' | '-' | '.'));
+
+        if is_word_boundary && next_is_path_char {
+            // Emit everything before the slash, then the replacement.
+            result.push_str(&remaining[..slash_pos]);
+            result.push_str("[server path]");
+            last_pushed_byte = Some(b']');
+
+            // Advance past the entire path token (including any embedded slashes).
+            let path_len = after_slash
+                .find(|c: char| !c.is_alphanumeric() && !matches!(c, '/' | '_' | '-' | '.'))
+                .unwrap_or(after_slash.len());
+            remaining = &after_slash[path_len..];
+        } else {
+            result.push_str(&remaining[..=slash_pos]);
+            last_pushed_byte = Some(b'/');
+            remaining = after_slash;
+        }
+    }
+
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strips_absolute_path_from_message() {
+        let msg = "failed to read /home/alice/project/file.rs: No such file or directory";
+        let sanitized = strip_paths(msg);
+        assert!(!sanitized.contains("/home/alice"));
+        assert!(sanitized.contains("[server path]"));
+        assert!(sanitized.contains("No such file or directory"));
+    }
+
+    #[test]
+    fn strips_path_at_start_of_string() {
+        let sanitized = strip_paths("/etc/aletheia/config.toml: permission denied");
+        assert!(!sanitized.contains("/etc/"));
+        assert!(sanitized.starts_with("[server path]"));
+    }
+
+    #[test]
+    fn preserves_uri_scheme_double_slash() {
+        // `://` must not be treated as a path boundary — the ':' preceding '/'
+        // means no boundary, and last_pushed_byte carries that across iterations.
+        let msg = "unknown resource URI: aletheia://nous/agent1/soul";
+        let sanitized = strip_paths(msg);
+        assert!(
+            sanitized.contains("aletheia://"),
+            "URI scheme must be preserved"
+        );
+    }
+
+    #[test]
+    fn double_slash_prefix_is_not_a_path() {
+        // A string starting with `//` is not a Unix absolute path.
+        let sanitized = strip_paths("//see-the-docs");
+        assert!(
+            !sanitized.contains("[server path]"),
+            "// prefix must not be replaced"
+        );
+    }
+
+    #[test]
+    fn handles_empty_string() {
+        assert_eq!(strip_paths(""), "");
+    }
+
+    #[test]
+    fn handles_string_with_no_paths() {
+        let msg = "nous agent not found: some-agent-id";
+        assert_eq!(strip_paths(msg), msg);
+    }
+
+    #[test]
+    fn strips_multiple_paths_in_one_message() {
+        let msg = "copy /src/a.rs to /dst/b.rs failed";
+        let sanitized = strip_paths(msg);
+        assert!(!sanitized.contains("/src/"));
+        assert!(!sanitized.contains("/dst/"));
+        assert_eq!(
+            sanitized.matches("[server path]").count(),
+            2,
+            "both paths must be replaced"
+        );
+    }
+
+    #[test]
+    fn handles_bare_slash_at_end() {
+        // A lone trailing '/' with nothing after it should not be treated as a path.
+        let msg = "root is /";
+        let sanitized = strip_paths(msg);
+        assert_eq!(
+            sanitized, "root is /",
+            "trailing lone slash must be left unchanged"
+        );
+    }
+}

--- a/crates/diaporeia/src/tools/mod.rs
+++ b/crates/diaporeia/src/tools/mod.rs
@@ -8,7 +8,9 @@ pub(crate) mod params;
 use rmcp::handler::server::wrapper::Parameters;
 use rmcp::model::CallToolResult;
 use rmcp::{tool, tool_router};
+use snafu::{OptionExt as _, ResultExt as _};
 
+use crate::error::{NousNotFoundSnafu, PipelineSnafu, SerializationSnafu, SessionStoreSnafu};
 use crate::server::DiaporeiaServer;
 
 /// Register all tools on the server via the `#[tool_router]` macro.
@@ -31,7 +33,8 @@ impl DiaporeiaServer {
         let store = self.state.session_store.lock().await;
         let session = store
             .find_or_create_session(&session_id, &params.nous_id, session_key, None, None)
-            .map_err(|e| rmcp::ErrorData::internal_error(e.to_string(), None))?;
+            .context(SessionStoreSnafu {})
+            .map_err(rmcp::ErrorData::from)?;
 
         let json = serde_json::to_string_pretty(&serde_json::json!({
             "id": session.id,
@@ -41,7 +44,8 @@ impl DiaporeiaServer {
             "message_count": session.message_count,
             "created_at": session.created_at,
         }))
-        .map_err(|e| rmcp::ErrorData::internal_error(e.to_string(), None))?;
+        .context(SerializationSnafu {})
+        .map_err(rmcp::ErrorData::from)?;
 
         Ok(CallToolResult::success(vec![rmcp::model::Content::text(
             json,
@@ -57,7 +61,8 @@ impl DiaporeiaServer {
         let store = self.state.session_store.lock().await;
         let sessions = store
             .list_sessions(params.nous_id.as_deref())
-            .map_err(|e| rmcp::ErrorData::internal_error(e.to_string(), None))?;
+            .context(SessionStoreSnafu {})
+            .map_err(rmcp::ErrorData::from)?;
 
         let summaries: Vec<serde_json::Value> = sessions
             .iter()
@@ -75,7 +80,8 @@ impl DiaporeiaServer {
             .collect();
 
         let json = serde_json::to_string_pretty(&summaries)
-            .map_err(|e| rmcp::ErrorData::internal_error(e.to_string(), None))?;
+            .context(SerializationSnafu {})
+            .map_err(rmcp::ErrorData::from)?;
 
         Ok(CallToolResult::success(vec![rmcp::model::Content::text(
             json,
@@ -92,17 +98,21 @@ impl DiaporeiaServer {
             .state
             .nous_manager
             .get(&params.nous_id)
-            .ok_or_else(|| {
-                rmcp::ErrorData::internal_error(
-                    format!("nous agent not found: {}", params.nous_id),
-                    None,
-                )
-            })?;
+            .context(NousNotFoundSnafu {
+                id: params.nous_id.clone(),
+            })
+            .map_err(rmcp::ErrorData::from)?;
 
         let result = handle
             .send_turn(&params.session_key, &params.content)
             .await
-            .map_err(|e| rmcp::ErrorData::internal_error(e.to_string(), None))?;
+            .map_err(|e| {
+                PipelineSnafu {
+                    message: e.to_string(),
+                }
+                .build()
+            })
+            .map_err(rmcp::ErrorData::from)?;
 
         Ok(CallToolResult::success(vec![rmcp::model::Content::text(
             result.content,
@@ -118,7 +128,8 @@ impl DiaporeiaServer {
         let store = self.state.session_store.lock().await;
         let messages = store
             .get_history(&params.session_id, params.limit)
-            .map_err(|e| rmcp::ErrorData::internal_error(e.to_string(), None))?;
+            .context(SessionStoreSnafu {})
+            .map_err(rmcp::ErrorData::from)?;
 
         let history: Vec<serde_json::Value> = messages
             .iter()
@@ -133,7 +144,8 @@ impl DiaporeiaServer {
             .collect();
 
         let json = serde_json::to_string_pretty(&history)
-            .map_err(|e| rmcp::ErrorData::internal_error(e.to_string(), None))?;
+            .context(SerializationSnafu {})
+            .map_err(rmcp::ErrorData::from)?;
 
         Ok(CallToolResult::success(vec![rmcp::model::Content::text(
             json,
@@ -162,7 +174,8 @@ impl DiaporeiaServer {
             .collect();
 
         let json = serde_json::to_string_pretty(&list)
-            .map_err(|e| rmcp::ErrorData::internal_error(e.to_string(), None))?;
+            .context(SerializationSnafu {})
+            .map_err(rmcp::ErrorData::from)?;
 
         Ok(CallToolResult::success(vec![rmcp::model::Content::text(
             json,
@@ -179,17 +192,21 @@ impl DiaporeiaServer {
             .state
             .nous_manager
             .get(&params.nous_id)
-            .ok_or_else(|| {
-                rmcp::ErrorData::internal_error(
-                    format!("nous agent not found: {}", params.nous_id),
-                    None,
-                )
-            })?;
+            .context(NousNotFoundSnafu {
+                id: params.nous_id.clone(),
+            })
+            .map_err(rmcp::ErrorData::from)?;
 
         let status = handle
             .status()
             .await
-            .map_err(|e| rmcp::ErrorData::internal_error(e.to_string(), None))?;
+            .map_err(|e| {
+                PipelineSnafu {
+                    message: e.to_string(),
+                }
+                .build()
+            })
+            .map_err(rmcp::ErrorData::from)?;
 
         let json = serde_json::to_string_pretty(&serde_json::json!({
             "id": status.id,
@@ -199,7 +216,8 @@ impl DiaporeiaServer {
             "panic_count": status.panic_count,
             "uptime_secs": status.uptime.as_secs(),
         }))
-        .map_err(|e| rmcp::ErrorData::internal_error(e.to_string(), None))?;
+        .context(SerializationSnafu {})
+        .map_err(rmcp::ErrorData::from)?;
 
         Ok(CallToolResult::success(vec![rmcp::model::Content::text(
             json,
@@ -216,12 +234,10 @@ impl DiaporeiaServer {
             .state
             .nous_manager
             .get(&params.nous_id)
-            .ok_or_else(|| {
-                rmcp::ErrorData::internal_error(
-                    format!("nous agent not found: {}", params.nous_id),
-                    None,
-                )
-            })?;
+            .context(NousNotFoundSnafu {
+                id: params.nous_id.clone(),
+            })
+            .map_err(rmcp::ErrorData::from)?;
 
         let defs = self.state.tool_registry.definitions();
         let tools: Vec<serde_json::Value> = defs
@@ -236,7 +252,8 @@ impl DiaporeiaServer {
             .collect();
 
         let json = serde_json::to_string_pretty(&tools)
-            .map_err(|e| rmcp::ErrorData::internal_error(e.to_string(), None))?;
+            .context(SerializationSnafu {})
+            .map_err(rmcp::ErrorData::from)?;
 
         Ok(CallToolResult::success(vec![rmcp::model::Content::text(
             json,
@@ -286,7 +303,8 @@ impl DiaporeiaServer {
         });
 
         let json = serde_json::to_string_pretty(&redacted)
-            .map_err(|e| rmcp::ErrorData::internal_error(e.to_string(), None))?;
+            .context(SerializationSnafu {})
+            .map_err(rmcp::ErrorData::from)?;
 
         Ok(CallToolResult::success(vec![rmcp::model::Content::text(
             json,
@@ -324,7 +342,8 @@ impl DiaporeiaServer {
         });
 
         let json = serde_json::to_string_pretty(&result)
-            .map_err(|e| rmcp::ErrorData::internal_error(e.to_string(), None))?;
+            .context(SerializationSnafu {})
+            .map_err(rmcp::ErrorData::from)?;
 
         Ok(CallToolResult::success(vec![rmcp::model::Content::text(
             json,


### PR DESCRIPTION
Closes #1106, #1119

## Changes
- Server-side file paths stripped from all MCP errors
- All errors routed through typed error system
- Client-facing messages provide useful context without internals

## What changed

**New module: `sanitize.rs`**
Implements `strip_paths(message: &str) -> String` which replaces Unix absolute paths (e.g. `/home/user/project/file.rs`) with `[server path]`. Tracks the last emitted byte across slice boundaries so that URI scheme separators (`://`) are never misidentified as path starts. 8 unit tests.

**`error.rs` — central error handler**
`From<Error> for rmcp::ErrorData` now:
1. Calls `strip_paths` on every outbound message before it reaches the client
2. Maps `NousNotFound` and `SessionNotFound` to `INVALID_PARAMS` (client provided a bad ID); all server-side failures to `INTERNAL_ERROR`

**`resources/nous.rs`** (#1106 root cause)
Removed explicit `file_path.display()` in the I/O error message. File read now uses `.context(WorkspaceFileSnafu {})` so the path goes into the snafu chain (internal, for logs/debugging) but never into the client-facing string.

**`resources/config.rs`** + **`tools/mod.rs`**
All `map_err(|e| rmcp::ErrorData::internal_error(e.to_string(), None))` calls replaced with `.context(SessionStoreSnafu {})`, `.context(SerializationSnafu {})`, `.map_err(|e| PipelineSnafu { message: e.to_string() }.build())`, etc. Every error now flows through `From<Error> for rmcp::ErrorData`, picking up sanitization and correct error codes automatically.

## Observations
None.