### PR TITLE
fix(cli): TOML preservation, health check, overwrite safety, output format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,6 +74,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "toml 1.0.6+spec-1.1.0",
+ "toml_edit",
  "tracing",
  "tracing-subscriber",
  "ulid",

--- a/crates/aletheia/Cargo.toml
+++ b/crates/aletheia/Cargo.toml
@@ -67,6 +67,7 @@ rcgen = { workspace = true }
 time = "0.3"
 owo-colors = "4"
 supports-color = "3"
+toml_edit = "0.22"
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/crates/aletheia/src/cli_tests.rs
+++ b/crates/aletheia/src/cli_tests.rs
@@ -40,7 +40,7 @@ fn maintenance_status_parses() {
     assert!(matches!(
         cli.command,
         Some(Command::Maintenance {
-            action: maintenance::Action::Status
+            action: maintenance::Action::Status { .. }
         })
     ));
 }

--- a/crates/aletheia/src/commands/add_nous.rs
+++ b/crates/aletheia/src/commands/add_nous.rs
@@ -5,8 +5,6 @@ use std::path::PathBuf;
 use anyhow::{Context, Result, bail};
 use clap::Args;
 
-use aletheia_taxis::config::{AletheiaConfig, ModelSpec, NousDefinition};
-use aletheia_taxis::loader;
 use aletheia_taxis::oikos::Oikos;
 
 #[derive(Debug, Clone, Args)]
@@ -23,7 +21,7 @@ pub struct AddNousArgs {
     pub model: String,
 }
 
-pub fn run(instance_root: Option<&PathBuf>, args: &AddNousArgs) -> Result<()> {
+pub async fn run(instance_root: Option<&PathBuf>, args: &AddNousArgs) -> Result<()> {
     validate_name(&args.name)?;
     validate_provider(&args.provider)?;
 
@@ -44,7 +42,7 @@ pub fn run(instance_root: Option<&PathBuf>, args: &AddNousArgs) -> Result<()> {
 
     scaffold_directory(&oikos, args)?;
     update_config(&oikos, args)?;
-    try_register(&args.name);
+    try_register(&args.name).await;
     print_summary(&oikos, args);
 
     Ok(())
@@ -166,11 +164,33 @@ fn scaffold_directory(oikos: &Oikos, args: &AddNousArgs) -> Result<()> {
     Ok(())
 }
 
+/// Modify the TOML config in-place using `toml_edit` to preserve comments and structure.
 fn update_config(oikos: &Oikos, args: &AddNousArgs) -> Result<()> {
-    let config_result = loader::load_config(oikos);
-    let mut config: AletheiaConfig = config_result.unwrap_or_default();
+    let config_path = oikos.config().join("aletheia.toml");
+    let config_dir = oikos.config();
 
-    let already_listed = config.agents.list.iter().any(|a| a.id == args.name);
+    let existing = if config_path.exists() {
+        std::fs::read_to_string(&config_path)
+            .with_context(|| format!("failed to read {}", config_path.display()))?
+    } else {
+        String::new()
+    };
+
+    let mut doc: toml_edit::DocumentMut = existing
+        .parse()
+        .with_context(|| format!("failed to parse {}", config_path.display()))?;
+
+    // Check for duplicate before modifying
+    let already_listed = doc
+        .get("agents")
+        .and_then(|a| a.as_table())
+        .and_then(|a| a.get("list"))
+        .and_then(|l| l.as_array_of_tables())
+        .is_some_and(|list| {
+            list.iter()
+                .any(|t| t.get("id").and_then(|v| v.as_str()) == Some(args.name.as_str()))
+        });
+
     if already_listed {
         bail!(
             "agent '{}' already exists in the configuration file.\n\
@@ -179,36 +199,66 @@ fn update_config(oikos: &Oikos, args: &AddNousArgs) -> Result<()> {
         );
     }
 
-    let workspace = format!("{}/nous/{}", oikos.root().display(), args.name);
+    // Build the new agent table entry.
+    // WHY: workspace is relative to ALETHEIA_ROOT so the config stays portable.
+    let workspace = format!("nous/{}", args.name);
+    let mut entry = toml_edit::Table::new();
+    entry.insert("id", toml_edit::value(args.name.clone()));
+    entry.insert("name", toml_edit::value(capitalize(&args.name)));
+    entry.insert("workspace", toml_edit::value(workspace));
+    entry.insert("default", toml_edit::value(false));
 
-    config.agents.list.push(NousDefinition {
-        id: args.name.clone(),
-        name: Some(capitalize(&args.name)),
-        model: Some(ModelSpec {
-            primary: args.model.clone(),
-            fallbacks: Vec::new(),
-        }),
-        workspace,
-        thinking_enabled: None,
-        allowed_roots: Vec::new(),
-        domains: Vec::new(),
-        default: false,
-    });
+    let mut model_table = toml_edit::Table::new();
+    model_table.insert("primary", toml_edit::value(args.model.clone()));
+    model_table.insert(
+        "fallbacks",
+        toml_edit::Item::Value(toml_edit::Value::Array(toml_edit::Array::new())),
+    );
+    entry.insert("model", toml_edit::Item::Table(model_table));
 
-    loader::write_config(oikos, &config)
-        .map_err(|e| anyhow::anyhow!("failed to write config: {e}"))?;
+    // Ensure [agents] table exists
+    if doc.get("agents").and_then(|i| i.as_table()).is_none() {
+        doc.insert("agents", toml_edit::Item::Table(toml_edit::Table::new()));
+    }
+
+    let agents = doc["agents"]
+        .as_table_mut()
+        .ok_or_else(|| anyhow::anyhow!("[agents] in config is not a table"))?;
+
+    // Ensure [[agents.list]] array of tables exists
+    if agents
+        .get("list")
+        .and_then(|i| i.as_array_of_tables())
+        .is_none()
+    {
+        agents.insert(
+            "list",
+            toml_edit::Item::ArrayOfTables(toml_edit::ArrayOfTables::new()),
+        );
+    }
+
+    let list = agents["list"]
+        .as_array_of_tables_mut()
+        .ok_or_else(|| anyhow::anyhow!("agents.list in config is not an array of tables"))?;
+
+    list.push(entry);
+
+    // Atomic write: write to .tmp then rename to preserve comments
+    std::fs::create_dir_all(&config_dir)
+        .with_context(|| format!("failed to create {}", config_dir.display()))?;
+    let tmp = config_dir.join("aletheia.toml.tmp");
+    std::fs::write(&tmp, doc.to_string())
+        .with_context(|| format!("failed to write {}", tmp.display()))?;
+    std::fs::rename(&tmp, &config_path)
+        .with_context(|| format!("failed to rename {}", tmp.display()))?;
 
     Ok(())
 }
 
-fn try_register(name: &str) {
-    // WHY: reqwest::blocking panics inside a tokio runtime, so we use a raw
-    // TCP connect probe to check if the server is listening.
-    use std::net::{Ipv4Addr, SocketAddrV4, TcpStream};
-
-    let addr = SocketAddrV4::new(Ipv4Addr::LOCALHOST, 18789);
-    let server_running =
-        TcpStream::connect_timeout(&addr.into(), std::time::Duration::from_secs(1)).is_ok();
+/// Check if the server is reachable by hitting its health endpoint.
+async fn try_register(name: &str) {
+    let url = "http://127.0.0.1:18789/api/health";
+    let server_running = reqwest::get(url).await.is_ok();
 
     if server_running {
         println!(
@@ -339,6 +389,90 @@ mod tests {
     }
 
     #[test]
+    fn update_config_appends_without_destroying_comments() {
+        let dir = tempfile::tempdir().unwrap();
+        let oikos = Oikos::from_root(dir.path());
+        std::fs::create_dir_all(dir.path().join("config")).unwrap();
+
+        // Write a config that has comments and custom formatting
+        let original = "# My custom config\n\
+            # This comment must survive\n\
+            [gateway]\n\
+            port = 9999\n\
+            \n";
+        std::fs::write(dir.path().join("config/aletheia.toml"), original).unwrap();
+
+        let args = AddNousArgs {
+            name: "alice".to_owned(),
+            provider: "anthropic".to_owned(),
+            model: "claude-sonnet-4-20250514".to_owned(),
+        };
+        update_config(&oikos, &args).unwrap();
+
+        let result = std::fs::read_to_string(dir.path().join("config/aletheia.toml")).unwrap();
+        assert!(
+            result.contains("# My custom config"),
+            "comment must survive"
+        );
+        assert!(
+            result.contains("# This comment must survive"),
+            "comment must survive"
+        );
+        assert!(
+            result.contains("port = 9999"),
+            "existing config must survive"
+        );
+        assert!(result.contains(r#"id = "alice""#), "new agent must appear");
+        assert!(
+            result.contains(r#"workspace = "nous/alice""#),
+            "workspace must be relative"
+        );
+    }
+
+    #[test]
+    fn update_config_workspace_path_is_relative() {
+        let dir = tempfile::tempdir().unwrap();
+        let oikos = Oikos::from_root(dir.path());
+        std::fs::create_dir_all(dir.path().join("config")).unwrap();
+
+        let args = AddNousArgs {
+            name: "bob".to_owned(),
+            provider: "anthropic".to_owned(),
+            model: "claude-sonnet-4-20250514".to_owned(),
+        };
+        update_config(&oikos, &args).unwrap();
+
+        let result = std::fs::read_to_string(dir.path().join("config/aletheia.toml")).unwrap();
+        assert!(
+            result.contains(r#"workspace = "nous/bob""#),
+            "workspace path must be relative, got:\n{result}"
+        );
+        // Must not contain an absolute path
+        assert!(
+            !result.contains("/nous/bob"),
+            "workspace must not be absolute"
+        );
+    }
+
+    #[test]
+    fn update_config_rejects_duplicate() {
+        let dir = tempfile::tempdir().unwrap();
+        let oikos = Oikos::from_root(dir.path());
+        std::fs::create_dir_all(dir.path().join("config")).unwrap();
+
+        let args = AddNousArgs {
+            name: "charlie".to_owned(),
+            provider: "anthropic".to_owned(),
+            model: "claude-sonnet-4-20250514".to_owned(),
+        };
+        update_config(&oikos, &args).unwrap();
+        let result = update_config(&oikos, &args);
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("already exists"), "got: {msg}");
+    }
+
+    #[test]
     fn scaffold_errors_when_directory_exists() {
         let dir = tempfile::tempdir().unwrap();
         let _oikos = Oikos::from_root(dir.path());
@@ -350,7 +484,9 @@ mod tests {
             model: "claude-sonnet-4-20250514".to_owned(),
         };
 
-        let result = run(Some(&dir.path().to_path_buf()), &args);
+        // Use a blocking executor for this test since run() is now async
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let result = rt.block_on(run(Some(&dir.path().to_path_buf()), &args));
         assert!(result.is_err());
         let msg = result.unwrap_err().to_string();
         assert!(

--- a/crates/aletheia/src/commands/agent_io.rs
+++ b/crates/aletheia/src/commands/agent_io.rs
@@ -23,6 +23,9 @@ pub struct ExportArgs {
     /// Compact JSON (no pretty printing)
     #[arg(long)]
     pub compact: bool,
+    /// Overwrite existing output file without prompting
+    #[arg(long)]
+    pub force: bool,
 }
 
 #[expect(
@@ -211,6 +214,13 @@ pub fn export_agent(instance_root: Option<&PathBuf>, args: &ExportArgs) -> Resul
         let date = jiff::Timestamp::now().strftime("%Y-%m-%d").to_string();
         PathBuf::from(format!("{nous_id}-{date}.agent.json"))
     });
+
+    if output_path.exists() && !args.force {
+        anyhow::bail!(
+            "output file already exists: {}\nUse --force to overwrite.",
+            output_path.display()
+        );
+    }
 
     let json = if args.compact {
         serde_json::to_string(&agent_file)?

--- a/crates/aletheia/src/commands/backup.rs
+++ b/crates/aletheia/src/commands/backup.rs
@@ -8,6 +8,10 @@ use clap::Args;
 use aletheia_mneme::store::SessionStore;
 use aletheia_taxis::oikos::Oikos;
 
+#[expect(
+    clippy::struct_excessive_bools,
+    reason = "CLI flags — each bool is a distinct switch"
+)]
 #[derive(Debug, Clone, Args)]
 pub struct BackupArgs {
     /// List available backups
@@ -22,6 +26,12 @@ pub struct BackupArgs {
     /// Export sessions as JSON
     #[arg(long)]
     pub export_json: bool,
+    /// Output as JSON (for --list)
+    #[arg(long)]
+    pub json: bool,
+    /// Skip confirmation prompt when pruning
+    #[arg(long)]
+    pub yes: bool,
 }
 
 pub fn run(instance_root: Option<&PathBuf>, args: &BackupArgs) -> Result<()> {
@@ -30,6 +40,8 @@ pub fn run(instance_root: Option<&PathBuf>, args: &BackupArgs) -> Result<()> {
         prune,
         keep,
         export_json,
+        json,
+        yes,
     } = args;
     let oikos = match instance_root {
         Some(root) => Oikos::from_root(root),
@@ -45,7 +57,18 @@ pub fn run(instance_root: Option<&PathBuf>, args: &BackupArgs) -> Result<()> {
 
     if list {
         let backups = manager.list_backups().context("failed to list backups")?;
-        if backups.is_empty() {
+        if json {
+            let items: Vec<serde_json::Value> = backups
+                .iter()
+                .map(|b| {
+                    serde_json::json!({
+                        "filename": b.filename,
+                        "size_bytes": b.size_bytes,
+                    })
+                })
+                .collect();
+            println!("{}", serde_json::to_string_pretty(&items)?);
+        } else if backups.is_empty() {
             println!("No backups found.");
         } else {
             for b in &backups {
@@ -56,6 +79,35 @@ pub fn run(instance_root: Option<&PathBuf>, args: &BackupArgs) -> Result<()> {
     }
 
     if prune {
+        let backups = manager.list_backups().context("failed to list backups")?;
+        let to_remove: Vec<_> = backups.iter().skip(keep).collect();
+
+        if to_remove.is_empty() {
+            println!(
+                "Nothing to prune: {} backup(s) found, keeping {keep}.",
+                backups.len()
+            );
+            return Ok(());
+        }
+
+        if !yes {
+            println!("The following backup(s) will be deleted:");
+            for b in &to_remove {
+                println!("  {} ({} bytes)", b.filename, b.size_bytes);
+            }
+            print!("Proceed? [y/N] ");
+            std::io::Write::flush(&mut std::io::stdout()).context("failed to flush stdout")?;
+
+            let mut input = String::new();
+            std::io::BufRead::read_line(&mut std::io::stdin().lock(), &mut input)
+                .context("failed to read confirmation")?;
+
+            if !input.trim().eq_ignore_ascii_case("y") {
+                println!("Aborted.");
+                return Ok(());
+            }
+        }
+
         let removed = manager
             .prune_backups(keep)
             .context("failed to prune backups")?;

--- a/crates/aletheia/src/commands/maintenance.rs
+++ b/crates/aletheia/src/commands/maintenance.rs
@@ -17,7 +17,11 @@ use tokio_util::sync::CancellationToken;
 #[derive(Debug, Clone, Subcommand)]
 pub enum Action {
     /// Show status of all maintenance tasks
-    Status,
+    Status {
+        /// Output as JSON instead of human-readable table
+        #[arg(long)]
+        json: bool,
+    },
     /// Run a specific maintenance task immediately
     Run {
         /// Task name: trace-rotation, drift-detection, db-monitor, or all
@@ -37,12 +41,22 @@ pub fn run(action: Action, instance_root: Option<&PathBuf>) -> Result<()> {
     let maint = build_config(&oikos, &config.maintenance);
 
     match action {
-        Action::Status => {
+        Action::Status { json } => {
             let token = CancellationToken::new();
             let mut runner = TaskRunner::new("system", token).with_maintenance(maint);
             runner.register_maintenance_tasks();
             let statuses = runner.status();
-            println!("{}", serde_json::to_string_pretty(&statuses)?);
+            if json {
+                println!("{}", serde_json::to_string_pretty(&statuses)?);
+            } else {
+                println!("{:<24} {:<8} {:<6} Last Run", "Task", "Enabled", "Runs");
+                println!("{}", "-".repeat(60));
+                for s in &statuses {
+                    let last = s.last_run.as_deref().unwrap_or("never");
+                    let enabled = if s.enabled { "yes" } else { "no" };
+                    println!("{:<24} {:<8} {:<6} {}", s.name, enabled, s.run_count, last);
+                }
+            }
         }
         Action::Run { task, verbose } => {
             let tasks: Vec<&str> = if task == "all" {

--- a/crates/aletheia/src/commands/tls.rs
+++ b/crates/aletheia/src/commands/tls.rs
@@ -18,6 +18,9 @@ pub enum Action {
         /// Subject Alternative Names (hostnames/IPs)
         #[arg(long, default_values_t = vec!["localhost".to_owned(), "127.0.0.1".to_owned()])]
         san: Vec<String>,
+        /// Overwrite existing certificate files without prompting
+        #[arg(long)]
+        force: bool,
     },
 }
 
@@ -27,13 +30,28 @@ pub fn run(action: &Action) -> Result<()> {
             output_dir,
             days,
             san,
-        } => generate_certs(output_dir, *days, san),
+            force,
+        } => generate_certs(output_dir, *days, san, *force),
     }
 }
 
-fn generate_certs(output_dir: &Path, days: u32, sans: &[String]) -> Result<()> {
+fn generate_certs(output_dir: &Path, days: u32, sans: &[String], force: bool) -> Result<()> {
     std::fs::create_dir_all(output_dir)
         .with_context(|| format!("failed to create {}", output_dir.display()))?;
+
+    let cert_path = output_dir.join("cert.pem");
+    let key_path = output_dir.join("key.pem");
+
+    if !force {
+        for path in [&cert_path, &key_path] {
+            if path.exists() {
+                anyhow::bail!(
+                    "file already exists: {}\nUse --force to overwrite.",
+                    path.display()
+                );
+            }
+        }
+    }
 
     let subject_alt_names: Vec<String> = sans.to_vec();
     let key_pair = rcgen::KeyPair::generate().context("failed to generate key pair")?;
@@ -55,9 +73,6 @@ fn generate_certs(output_dir: &Path, days: u32, sans: &[String]) -> Result<()> {
     let cert = params
         .self_signed(&key_pair)
         .context("failed to generate self-signed certificate")?;
-
-    let cert_path = output_dir.join("cert.pem");
-    let key_path = output_dir.join("key.pem");
 
     std::fs::write(&cert_path, cert.pem())
         .with_context(|| format!("failed to write {}", cert_path.display()))?;

--- a/crates/aletheia/src/main.rs
+++ b/crates/aletheia/src/main.rs
@@ -187,7 +187,7 @@ async fn main() -> Result<()> {
             return commands::check_config::run(instance_root);
         }
         Some(Command::AddNous(a)) => {
-            return commands::add_nous::run(instance_root, &a);
+            return commands::add_nous::run(instance_root, &a).await;
         }
         None => {}
     }


### PR DESCRIPTION
## Summary
- add-nous uses toml_edit to preserve config comments and formatting (#986)
- Health check uses HTTP /api/health instead of bare TCP probe (#987)
- Workspace path written relative to ALETHEIA_ROOT (#988)
- export and tls generate refuse overwrite without --force (#1055)
- backup prune shows affected files and prompts for confirmation (#1056)
- maintenance/backup default to human-readable tables with --json flag (#1057)

Closes #986, #987, #988, #1055, #1056, #1057

## Validation
- `cargo fmt --check` clean
- `cargo clippy --workspace --all-targets -- -D warnings` clean
- `cargo test -p aletheia` — 36 tests pass

## Test plan
- [ ] Verify add-nous preserves TOML comments
- [ ] Verify health check hits HTTP endpoint
- [ ] Verify --force flag on export/tls commands
- [ ] Verify --json flag on maintenance/backup commands