### PR TITLE
fix(organon): tool safety and bounds (4 issues)

### DIFF
--- a/crates/organon/src/builtins/enable_tool.rs
+++ b/crates/organon/src/builtins/enable_tool.rs
@@ -59,9 +59,12 @@ impl ToolExecutor for EnableToolExecutor {
                 )));
             };
 
-            // Check if already active
+            // WHY: Single write lock for the check-and-set: acquiring a read
+            // lock to check then dropping it before acquiring a write lock
+            // creates a TOCTOU window where a concurrent caller can insert
+            // the same tool between the two acquisitions.
             {
-                let Ok(active) = ctx.active_tools.read() else {
+                let Ok(mut active) = ctx.active_tools.write() else {
                     return Ok(ToolResult::error(
                         "internal error: active_tools lock poisoned",
                     ));
@@ -69,15 +72,6 @@ impl ToolExecutor for EnableToolExecutor {
                 if active.contains(&tool_name) {
                     return Ok(ToolResult::text(format!("'{name}' is already active.")));
                 }
-            }
-
-            // Activate
-            {
-                let Ok(mut active) = ctx.active_tools.write() else {
-                    return Ok(ToolResult::error(
-                        "internal error: active_tools lock poisoned",
-                    ));
-                };
                 active.insert(tool_name);
             }
 

--- a/crates/organon/src/builtins/memory/knowledge_ops.rs
+++ b/crates/organon/src/builtins/memory/knowledge_ops.rs
@@ -38,11 +38,9 @@ impl ToolExecutor for MemorySearchExecutor {
             };
 
             let query = extract_str(&input.arguments, "query", &input.name)?;
-            #[expect(
-                clippy::cast_possible_truncation,
-                reason = "limit from user input is small"
-            )]
-            let limit = extract_opt_u64(&input.arguments, "limit").unwrap_or(10) as usize;
+            let limit = extract_opt_u64(&input.arguments, "limit")
+                .unwrap_or(10)
+                .min(100) as usize;
 
             let Some(knowledge) = services.knowledge.as_ref() else {
                 return Ok(ToolResult::error("knowledge store not configured"));
@@ -246,7 +244,7 @@ fn memory_search_def() -> ToolDef {
                     "limit".to_owned(),
                     PropertyDef {
                         property_type: PropertyType::Number,
-                        description: "Max results (default 10)".to_owned(),
+                        description: "Max results (default 10, max 100)".to_owned(),
                         enum_values: None,
                         default: Some(serde_json::json!(10)),
                     },

--- a/crates/organon/src/builtins/workspace.rs
+++ b/crates/organon/src/builtins/workspace.rs
@@ -388,7 +388,13 @@ impl ToolExecutor for ExecExecutor {
                     Ok(Some(s)) => break s,
                     Ok(None) => {
                         if Instant::now() >= deadline {
-                            // Dropping `guard` kills and reaps the child.
+                            // INVARIANT: kill() must always be followed by wait() to
+                            // prevent zombie accumulation. If the process exited between
+                            // try_wait() returning None and this kill(), kill() returns
+                            // ESRCH (safe to ignore); wait() still reaps the zombie
+                            // because no other caller can have waited on this child.
+                            let _ = guard.get_mut().kill();
+                            let _ = guard.get_mut().wait();
                             return Ok(err_result(format!(
                                 "command timed out after {timeout_ms}ms"
                             )));

--- a/crates/organon/src/process_guard.rs
+++ b/crates/organon/src/process_guard.rs
@@ -75,12 +75,12 @@ impl ProcessGuard {
 impl Drop for ProcessGuard {
     fn drop(&mut self) {
         if let Some(mut child) = self.child.take() {
-            // Best-effort kill. Returns an error if the process already
-            // exited — that is fine; we are ensuring cleanup, not asserting
-            // the process was alive.
+            // WHY: kill() may return ESRCH if the process already exited;
+            // safe to ignore — we are cleaning up, not asserting liveness.
             let _ = child.kill();
-            // Reap the (possibly-already-dead) child so it doesn't linger
-            // as a zombie. Errors indicate the OS already reaped it.
+            // INVARIANT: wait() after kill() prevents zombie accumulation.
+            // If try_wait() already reaped the zombie, wait() returns ECHILD
+            // which is safe to ignore — the goal (no zombie) is already met.
             let _ = child.wait();
         }
     }

--- a/crates/organon/src/sandbox.rs
+++ b/crates/organon/src/sandbox.rs
@@ -359,6 +359,16 @@ pub fn apply_sandbox(
     _cmd: &mut std::process::Command,
     _policy: SandboxPolicy,
 ) -> std::io::Result<()> {
+    // WHY: Landlock and seccomp are Linux-only kernel interfaces. On other
+    // platforms the sandbox is a no-op. Log once per process so operators
+    // know sandbox enforcement is absent without spamming every tool call.
+    static WARN_ONCE: std::sync::OnceLock<()> = std::sync::OnceLock::new();
+    WARN_ONCE.get_or_init(|| {
+        tracing::warn!(
+            "sandbox enforcement unavailable on non-Linux platforms; \
+             tool execution runs without filesystem or syscall restrictions"
+        );
+    });
     Ok(())
 }
 


### PR DESCRIPTION
Closes #1042, #1043, #1044, #1045

## Changes

- **enable_tool TOCTOU (#1042):** Collapsed the read-lock-check + write-lock-set pattern into a single write lock. The prior code dropped the read lock before acquiring the write lock, giving a concurrent caller a window to insert the same tool name.

- **Process timeout reaping (#1043):** Added explicit `kill()` + `wait()` calls in the timeout path in `workspace.rs` rather than relying on implicit drop. Upgraded the comments in `ProcessGuard::drop` to use `WHY:` and `INVARIANT:` tags documenting the ESRCH/ECHILD cases.

- **Knowledge search limit (#1044):** Added `.min(100)` to cap the `memory_search` limit parameter. Default remains 10. Updated the tool schema description to reflect the cap.

- **Non-Linux sandbox warning (#1045):** Added a `tracing::warn!` in the non-Linux `apply_sandbox` stub, guarded by `OnceLock` to emit once per process rather than once per tool call.

## Observations

None.