### PR TITLE
docs: deployment documentation fixes (5 issues)

### DIFF
--- a/crates/pylon/src/handlers/sessions/streaming.rs
+++ b/crates/pylon/src/handlers/sessions/streaming.rs
@@ -172,10 +172,11 @@ pub async fn send_message(
                         idem_cache.remove(key);
                     }
 
+                    let (err_code, err_message) = turn_error_info(&err);
                     let _ = tx
                         .send(SseEvent::Error {
-                            code: "turn_failed".to_owned(),
-                            message: "An internal error occurred".to_owned(),
+                            code: err_code.to_owned(),
+                            message: err_message.to_owned(),
                         })
                         .await;
                     // Always send a completion marker so the client knows the
@@ -375,9 +376,10 @@ pub async fn stream_turn(
                     // Log full error internally; span carries session/nous context. (#844)
                     tracing::error!(error = %err, "streaming turn failed");
                     let _ = bridge_handle.await;
+                    let (_, err_message) = turn_error_info(&err);
                     let _ = webchat_tx
                         .send(WebchatEvent::Error {
-                            message: "An internal error occurred".to_owned(),
+                            message: err_message.to_owned(),
                         })
                         .await;
                     // Always send a completion marker so the TUI knows the stream
@@ -514,6 +516,39 @@ fn extract_idempotency_key(headers: &axum::http::HeaderMap) -> Result<Option<Str
         .build());
     }
     Ok(Some(key.to_owned()))
+}
+
+/// Categorize a nous turn error into a client-visible (code, message) pair.
+///
+/// Codes and messages identify the failure class without leaking internal
+/// paths, SQL, or provider credentials. See #844 for the security rationale.
+fn turn_error_info(err: &aletheia_nous::error::Error) -> (&'static str, &'static str) {
+    use aletheia_nous::error::Error;
+    match err {
+        Error::PipelineTimeout { .. } | Error::AskTimeout { .. } => {
+            ("turn_timeout", "turn timed out")
+        }
+        Error::GuardRejected { .. } => ("guard_rejected", "request rejected by safety guard"),
+        Error::InboxFull { .. } | Error::ServiceDegraded { .. } => {
+            ("service_busy", "agent is temporarily unavailable")
+        }
+        Error::Llm { source, .. } => classify_llm_error(source),
+        _ => ("turn_failed", "An internal error occurred"),
+    }
+}
+
+/// Map an LLM provider error to a client-visible (code, message) pair.
+fn classify_llm_error(err: &aletheia_hermeneus::error::Error) -> (&'static str, &'static str) {
+    use aletheia_hermeneus::error::Error;
+    match err {
+        Error::RateLimited { .. } => ("rate_limited", "rate limit exceeded"),
+        Error::ApiError { status, .. } if *status == 429 => ("rate_limited", "rate limit exceeded"),
+        Error::AuthFailed { .. } => ("provider_unavailable", "provider temporarily unavailable"),
+        Error::ApiError { status, .. } if *status == 503 => {
+            ("provider_unavailable", "provider temporarily unavailable")
+        }
+        _ => ("turn_failed", "An internal error occurred"),
+    }
 }
 
 /// Emit turn result as individual SSE events to a single client channel.

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -4,6 +4,64 @@ Step-by-step guide from bare Linux or macOS to a running Aletheia instance. For 
 
 ---
 
+## Getting started (first-time setup)
+
+Five steps from a fresh clone to a running instance:
+
+**Step 1 — Install the binary**
+
+```bash
+cargo build --release
+cp target/release/aletheia ~/.local/bin/
+```
+
+**Step 2 — Copy the instance scaffold**
+
+```bash
+cp -r instance.example instance
+```
+
+This creates the directory tree (`config/`, `data/`, `nous/`, etc.) with template files ready to edit.
+
+**Step 3 — Configure credentials**
+
+Set your Anthropic API key as an environment variable (or use the init wizard — see [Instance setup](#instance-setup)):
+
+```bash
+export ANTHROPIC_API_KEY="sk-ant-..."
+```
+
+Then edit `instance/config/aletheia.toml` (copy from `instance/config/aletheia.toml.example` if it does not exist) and set the bind address, port, and auth mode.
+
+**Step 4 — Set up your first agent**
+
+```bash
+cp -r instance/nous/_template instance/nous/main
+```
+
+Edit `instance/nous/main/SOUL.md` with your agent's identity, then add the agent to `aletheia.toml`:
+
+```toml
+[agents]
+[[agents.list]]
+id = "main"
+default = true
+```
+
+**Step 5 — Start and verify**
+
+```bash
+aletheia --instance-root ./instance
+# In another terminal:
+aletheia health
+```
+
+A `healthy` response means the server is running with a registered LLM provider. If the status is `degraded`, verify your `ANTHROPIC_API_KEY` is set and the config loaded it.
+
+> **Faster alternative:** Run `aletheia init` to let the interactive wizard perform steps 2–4 automatically.
+
+---
+
 ## System requirements
 
 ### Hardware
@@ -206,25 +264,35 @@ This displays the current token or a way to generate one. Tokens are managed by 
 
 ### POST/PUT/DELETE CSRF protection
 
-State-changing requests (POST, PUT, DELETE, PATCH) require a CSRF header by default. Enable CSRF in your config:
+CSRF protection is **enabled by default**. All state-changing requests (POST, PUT, DELETE, PATCH) to `/api/v1/` must include the header:
 
-```yaml
-[gateway.csrf]
-enabled = true
+```
+X-Requested-With: aletheia
 ```
 
-The default header is `X-Requested-With: aletheia`. Include this header on all state-changing requests:
+Include this header on every mutating curl call:
 
 ```bash
 curl -X POST \
   -H "Authorization: Bearer your-token" \
   -H "X-Requested-With: aletheia" \
   -H "Content-Type: application/json" \
-  -d '{"nous_id": "main"}' \
+  -d '{"nous_id": "main", "session_key": "default"}' \
   http://127.0.0.1:18789/api/v1/sessions
 ```
 
-If CSRF is disabled in the config, the header is not required.
+Missing the CSRF header returns `403 Forbidden`. No config change is needed to enable this — it is on by default.
+
+#### Disable CSRF for development
+
+To turn off CSRF checks in a local development instance, add to `aletheia.toml`:
+
+```toml
+[gateway.csrf]
+enabled = false
+```
+
+With CSRF disabled, the `X-Requested-With` header is no longer required. Do not disable CSRF on any instance exposed to a network.
 
 ### No authentication mode
 
@@ -273,19 +341,27 @@ gateway:
 
 ## Agent setup
 
-Each agent needs a workspace directory under `instance/nous/`:
+### Recommended: use the init wizard
+
+The `aletheia init` wizard covers agent setup as part of instance initialization. It prompts for agent name and creates the workspace and config entry automatically. If you used `aletheia init`, your first agent is already configured — skip to [First run](#first-run).
+
+### Manual: add an additional agent
+
+To add a second agent or to configure one by hand:
+
+1. Create a workspace from the template:
 
 ```bash
 cp -r instance/nous/_template instance/nous/main
 ```
 
-Edit the bootstrap files:
-- `SOUL.md`: agent identity and character
-- `IDENTITY.md`: display name, emoji
-- `GOALS.md`: current goals
-- `MEMORY.md`: persistent operational memory
+2. Edit the bootstrap files in the new workspace:
+   - `SOUL.md`: agent identity and character
+   - `IDENTITY.md`: display name, emoji
+   - `GOALS.md`: current goals
+   - `MEMORY.md`: persistent operational memory
 
-Register the agent in `aletheia.toml`:
+3. Register the agent in `aletheia.toml`:
 
 ```yaml
 agents:
@@ -293,6 +369,8 @@ agents:
     - id: main
       default: true
 ```
+
+> **Manual alternative:** Steps 1–3 above apply to both first-time manual setups and adding agents to an existing instance. If you used the init wizard, only step 3 may be needed to add additional agents.
 
 ---
 
@@ -367,6 +445,31 @@ aletheia status
 ```
 
 Displays agent count, active sessions, uptime, and provider status.
+
+### API smoke test
+
+Create a session and send a message to verify the full request path. Replace `YOUR_TOKEN` with the token from `aletheia credential status`.
+
+```bash
+# Create a session (nous_id and session_key are both required)
+curl -s -X POST \
+  -H "Authorization: Bearer YOUR_TOKEN" \
+  -H "X-Requested-With: aletheia" \
+  -H "Content-Type: application/json" \
+  -d '{"nous_id": "main", "session_key": "smoke-test"}' \
+  http://127.0.0.1:18789/api/v1/sessions | jq .id
+```
+
+Use the returned session ID to send a message (the response is an SSE stream):
+
+```bash
+curl -s -X POST \
+  -H "Authorization: Bearer YOUR_TOKEN" \
+  -H "X-Requested-With: aletheia" \
+  -H "Content-Type: application/json" \
+  -d '{"content": "Hello"}' \
+  http://127.0.0.1:18789/api/v1/sessions/SESSION_ID/messages
+```
 
 ### Prometheus metrics
 


### PR DESCRIPTION
Closes #985, #989, #990, #991, #992

## Changes

- **Agent setup consolidation (#985):** Added a "Recommended: use the init wizard" path at the top of the Agent setup section. The manual approach (copy template + register in TOML) is preserved as a named "Manual: add an additional agent" section with a callout note.

- **CSRF documentation (#989):** Removed the misleading `[gateway.csrf] enabled = true` snippet that implied CSRF needed to be turned on (it is on by default). Documented the required `X-Requested-With: aletheia` header clearly. Added a new "Disable CSRF for development" subsection showing the `enabled = false` config.

- **curl examples (#990):** Fixed the session-creation example by adding the required `session_key` field (previously only `nous_id` was shown, which would have returned 400). Added an "API smoke test" section in Verification with correct field names for both session creation and message sending.

- **Message send error reasons (#991):** Added `turn_error_info` and `classify_llm_error` helper functions in `crates/pylon/src/handlers/sessions/streaming.rs`. Error SSE events now carry specific codes (`turn_timeout`, `rate_limited`, `provider_unavailable`, `guard_rejected`, `service_busy`) instead of a single opaque `turn_failed` code. Internal error details are never forwarded to the client (security constraint from #844 is preserved).

- **First-time setup guide (#992):** Added a "Getting Started (first-time setup)" section at the top of `DEPLOYMENT.md` with a five-step walkthrough: install binary, copy instance scaffold, configure credentials, set up first agent, start and verify.

## Observations

- `WebchatEvent::Error` (TUI streaming protocol) has only `message`, not `code`. The REST SSE `SseEvent::Error` has both. A follow-up could add `code: Option<String>` to `WebchatEvent::Error` with `skip_serializing_if` for backward compat. Details in `~/dianoia/inbox/20260313_406-deploy-docs-observations.md`.

- `StreamTurnRequest` uses `agent_id` (not `nous_id`) for the TUI streaming endpoint. This is intentional for TUI compat but undocumented. Noted in observations file.