### PR TITLE
fix(theatron): viewport state, scroll bounds, cache invalidation (5 issues)

### DIFF
--- a/crates/theatron/tui/src/actions.rs
+++ b/crates/theatron/tui/src/actions.rs
@@ -1,6 +1,10 @@
 /// App action methods — message sending, tab completion, scroll state, cursor helpers.
 use tracing::Instrument;
 
+/// Maximum number of per-agent scroll states retained in memory.
+/// Entries beyond this cap are pruned to agents currently in the active roster.
+const MAX_SCROLL_STATES: usize = 100;
+
 use crate::api::streaming;
 use crate::app::App;
 use crate::state::virtual_scroll::estimate_message_height;
@@ -135,6 +139,13 @@ impl App {
                     auto_scroll: self.auto_scroll,
                 },
             );
+            // Prune stale entries once the map exceeds MAX_SCROLL_STATES.
+            // Retain only agents present in the current roster so that sessions
+            // closed or removed do not hold memory indefinitely.
+            if self.scroll_states.len() > MAX_SCROLL_STATES {
+                let active: Vec<_> = self.agents.iter().map(|a| a.id.clone()).collect();
+                self.scroll_states.retain(|k, _| active.contains(k));
+            }
         }
     }
 
@@ -227,6 +238,53 @@ mod tests {
         app.scroll_offset = 42;
         app.save_scroll_state();
         assert!(app.scroll_states.is_empty());
+    }
+
+    #[test]
+    fn scroll_states_pruned_when_exceeding_max() {
+        let mut app = test_app();
+        // Register one active agent.
+        app.agents.push(test_agent("active", "Active"));
+        app.focused_agent = Some("active".into());
+
+        // Pre-fill with MAX_SCROLL_STATES + 1 stale entries for agents not in roster.
+        for i in 0..=super::MAX_SCROLL_STATES {
+            app.scroll_states.insert(
+                crate::id::NousId::from(format!("stale-{i}")),
+                crate::state::SavedScrollState {
+                    scroll_offset: i,
+                    auto_scroll: false,
+                },
+            );
+        }
+
+        // One save_scroll_state call triggers pruning.
+        app.save_scroll_state();
+
+        // Only the active agent entry should survive.
+        assert!(
+            app.scroll_states.len() <= super::MAX_SCROLL_STATES,
+            "scroll_states must be capped at MAX_SCROLL_STATES after pruning"
+        );
+        assert!(
+            app.scroll_states
+                .contains_key(&crate::id::NousId::from("active")),
+            "active agent entry must be retained after pruning"
+        );
+    }
+
+    #[test]
+    fn scroll_states_within_limit_not_pruned() {
+        let mut app = test_app();
+        app.agents.push(test_agent("syn", "Syn"));
+        app.agents.push(test_agent("sol", "Sol"));
+        app.focused_agent = Some("syn".into());
+        app.scroll_offset = 10;
+        app.auto_scroll = false;
+
+        app.save_scroll_state();
+        // Well under the cap — no pruning should occur.
+        assert_eq!(app.scroll_states.len(), 1);
     }
 
     #[test]

--- a/crates/theatron/tui/src/app.rs
+++ b/crates/theatron/tui/src/app.rs
@@ -380,6 +380,10 @@ impl App {
                             })
                         })
                         .collect();
+                    // Stale streaming markdown from the previous session must not
+                    // bleed through when the user switches agents.
+                    self.cached_markdown_text.clear();
+                    self.cached_markdown_lines.clear();
                     self.rebuild_virtual_scroll();
                     self.scroll_to_bottom();
                 }
@@ -634,6 +638,28 @@ mod tests {
         assert_eq!(app.messages.len(), 2);
         assert_eq!(app.messages[0].role, "user");
         assert_eq!(app.messages[1].text, "hi there");
+    }
+
+    #[test]
+    fn markdown_cache_fields_exist_for_session_switch_clearing() {
+        // Verifies that the fields cleared on session switch are present and
+        // behave as expected when the caller clears them.
+        let mut app = test_app();
+        app.cached_markdown_text = "stale content from previous session".to_string();
+        app.cached_markdown_lines = vec![ratatui::text::Line::raw("stale line")];
+
+        // Simulate the clearing that load_focused_session performs on history load.
+        app.cached_markdown_text.clear();
+        app.cached_markdown_lines.clear();
+
+        assert!(
+            app.cached_markdown_text.is_empty(),
+            "markdown text cache must be cleared on session switch"
+        );
+        assert!(
+            app.cached_markdown_lines.is_empty(),
+            "markdown line cache must be cleared on session switch"
+        );
     }
 
     #[test]

--- a/crates/theatron/tui/src/update/api.rs
+++ b/crates/theatron/tui/src/update/api.rs
@@ -61,6 +61,10 @@ pub(crate) fn handle_history_loaded(app: &mut App, messages: Vec<HistoryMessage>
             })
         })
         .collect();
+    // Stale streaming markdown from the previous session must not bleed through
+    // when history is replaced on session switch.
+    app.cached_markdown_text.clear();
+    app.cached_markdown_lines.clear();
     app.rebuild_virtual_scroll();
     app.scroll_to_bottom();
 }
@@ -409,6 +413,26 @@ mod tests {
         app.tick_count = u64::MAX;
         handle_tick(&mut app);
         assert_eq!(app.tick_count, 0);
+    }
+
+    #[test]
+    fn handle_history_loaded_clears_markdown_cache() {
+        use crate::app::test_helpers::*;
+        let mut app = test_app();
+        // Pre-populate stale cache from a previous streaming session.
+        app.cached_markdown_text = "stale from previous session".to_string();
+        app.cached_markdown_lines = vec![ratatui::text::Line::raw("stale")];
+
+        handle_history_loaded(&mut app, vec![]);
+
+        assert!(
+            app.cached_markdown_text.is_empty(),
+            "history load must clear stale markdown text cache"
+        );
+        assert!(
+            app.cached_markdown_lines.is_empty(),
+            "history load must clear stale markdown line cache"
+        );
     }
 
     #[test]

--- a/crates/theatron/tui/src/update/filter.rs
+++ b/crates/theatron/tui/src/update/filter.rs
@@ -3,10 +3,15 @@ use crate::app::App;
 pub(crate) fn handle_open(app: &mut App) {
     app.filter.open();
     update_match_counts(app);
+    // Rebuild so the virtual scroll is fresh when the user exits filter mode.
+    app.rebuild_virtual_scroll();
 }
 
 pub(crate) fn handle_close(app: &mut App) {
     app.filter.close();
+    // Rebuild before scrolling to bottom so the virtual scroll reflects the
+    // full message list now that filtered rendering is deactivated.
+    app.rebuild_virtual_scroll();
     app.scroll_to_bottom();
 }
 
@@ -37,6 +42,9 @@ pub(crate) fn handle_confirm(app: &mut App) {
     } else {
         app.filter.confirm();
     }
+    // Rebuild so the virtual scroll is consistent with any layout changes that
+    // occurred while filter mode was active.
+    app.rebuild_virtual_scroll();
 }
 
 pub(crate) fn handle_next_match(app: &mut App) {
@@ -180,5 +188,53 @@ mod tests {
         handle_input(&mut app, 'e');
         // "!he" inverts: matches messages NOT containing "he"
         assert_eq!(app.filter.match_count, 1); // "world" matches
+    }
+
+    #[test]
+    fn handle_open_rebuilds_virtual_scroll() {
+        let mut app = test_app_with_messages(vec![("user", "hi"), ("assistant", "hello")]);
+        // Simulate a stale virtual scroll by clearing it.
+        app.virtual_scroll.clear();
+        assert_eq!(app.virtual_scroll.len(), 0);
+
+        handle_open(&mut app);
+
+        assert_eq!(
+            app.virtual_scroll.len(),
+            app.messages.len(),
+            "virtual scroll must be rebuilt on filter open"
+        );
+    }
+
+    #[test]
+    fn handle_close_rebuilds_virtual_scroll() {
+        let mut app = test_app_with_messages(vec![("user", "hi"), ("assistant", "hello")]);
+        handle_open(&mut app);
+        // Corrupt the virtual scroll to simulate stale state.
+        app.virtual_scroll.clear();
+
+        handle_close(&mut app);
+
+        assert_eq!(
+            app.virtual_scroll.len(),
+            app.messages.len(),
+            "virtual scroll must be rebuilt on filter close"
+        );
+    }
+
+    #[test]
+    fn handle_confirm_rebuilds_virtual_scroll() {
+        let mut app = test_app_with_messages(vec![("user", "hello"), ("assistant", "world")]);
+        handle_open(&mut app);
+        handle_input(&mut app, 'h');
+        app.virtual_scroll.clear();
+
+        handle_confirm(&mut app);
+
+        assert_eq!(
+            app.virtual_scroll.len(),
+            app.messages.len(),
+            "virtual scroll must be rebuilt on filter confirm"
+        );
     }
 }

--- a/crates/theatron/tui/src/update/navigation.rs
+++ b/crates/theatron/tui/src/update/navigation.rs
@@ -4,6 +4,7 @@ use crate::id::NousId;
 pub(crate) fn handle_scroll_up(app: &mut App) {
     app.scroll_offset = app.scroll_offset.saturating_add(3);
     app.auto_scroll = false;
+    clamp_scroll_offset(app);
 }
 
 pub(crate) fn handle_scroll_down(app: &mut App) {
@@ -28,6 +29,7 @@ pub(crate) fn handle_scroll_page_up(app: &mut App) {
     let page = chat_viewport_height(app);
     app.scroll_offset = app.scroll_offset.saturating_add(page);
     app.auto_scroll = false;
+    clamp_scroll_offset(app);
 }
 
 pub(crate) fn handle_scroll_page_down(app: &mut App) {
@@ -105,6 +107,28 @@ pub(crate) fn handle_toggle_ops_pane(app: &mut App) {
 
 pub(crate) fn handle_ops_focus_switch(app: &mut App) {
     app.ops.toggle_focus();
+}
+
+/// Clamp `scroll_offset` to the maximum scrollable distance given current content
+/// and viewport height. When messages are present and the offset would place the
+/// viewport past the top of the content, it is reduced to the valid maximum.
+/// If the clamped offset reaches zero, auto-scroll is re-enabled.
+///
+/// No-op when there are no messages (nothing to bound against) or when
+/// auto-scroll is already active.
+fn clamp_scroll_offset(app: &mut App) {
+    if app.auto_scroll || app.messages.is_empty() {
+        return;
+    }
+    let total = app.virtual_scroll.total_height();
+    let vh = chat_viewport_height(app) as u64;
+    let max_offset = total.saturating_sub(vh) as usize;
+    if app.scroll_offset > max_offset {
+        app.scroll_offset = max_offset;
+        if max_offset == 0 {
+            app.auto_scroll = true;
+        }
+    }
 }
 
 pub(crate) fn handle_resize(app: &mut App, w: u16, h: u16) {
@@ -232,6 +256,65 @@ mod tests {
         handle_resize(&mut app, 200, 50);
         assert_eq!(app.terminal_width, 200);
         assert_eq!(app.terminal_height, 50);
+    }
+
+    #[test]
+    fn scroll_up_clamped_to_content_height_with_messages() {
+        use crate::app::test_helpers::test_app_with_messages;
+        // Two short messages, very tall terminal — content fits, max_offset = 0.
+        let mut app = test_app_with_messages(vec![("user", "hi"), ("assistant", "hey")]);
+        app.rebuild_virtual_scroll();
+        app.auto_scroll = false;
+        // Scrolling up when content fits should clamp back to 0.
+        handle_scroll_up(&mut app);
+        assert_eq!(app.scroll_offset, 0);
+        assert!(
+            app.auto_scroll,
+            "should re-enable auto-scroll when clamped to 0"
+        );
+    }
+
+    #[test]
+    fn scroll_up_does_not_clamp_empty_messages() {
+        // Without messages the clamp must not activate — existing behaviour preserved.
+        let mut app = test_app();
+        handle_scroll_up(&mut app);
+        assert_eq!(app.scroll_offset, 3);
+        assert!(!app.auto_scroll);
+    }
+
+    #[test]
+    fn scroll_page_up_clamped_to_content_height_with_messages() {
+        use crate::app::test_helpers::test_app_with_messages;
+        let mut app = test_app_with_messages(vec![("user", "hi"), ("assistant", "hey")]);
+        app.rebuild_virtual_scroll();
+        app.auto_scroll = false;
+        handle_scroll_page_up(&mut app);
+        // Content fits in the tall test terminal — offset must be clamped to 0.
+        assert_eq!(app.scroll_offset, 0);
+        assert!(app.auto_scroll);
+    }
+
+    #[test]
+    fn scroll_up_preserves_valid_offset_within_content() {
+        use crate::app::test_helpers::test_app_with_messages;
+        // Build enough messages to exceed the test viewport (40 rows).
+        let msgs: Vec<_> = (0..30)
+            .map(|_| ("user", "hello world long enough line"))
+            .collect();
+        let mut app = test_app_with_messages(msgs);
+        app.rebuild_virtual_scroll();
+        app.auto_scroll = false;
+        let total = app.virtual_scroll.total_height();
+        let vh = chat_viewport_height(&app) as u64;
+        // Offset within valid range: no clamping expected.
+        if total > vh {
+            app.scroll_offset = 3;
+            handle_scroll_up(&mut app);
+            // Offset should be 6 (3 + 3) as long as content allows.
+            assert!(app.scroll_offset <= (total.saturating_sub(vh) as usize));
+            assert!(!app.auto_scroll);
+        }
     }
 
     #[test]

--- a/crates/theatron/tui/src/update/settings.rs
+++ b/crates/theatron/tui/src/update/settings.rs
@@ -167,6 +167,12 @@ pub async fn handle_save(app: &mut App) {
 pub fn handle_saved(app: &mut App) {
     app.error_toast = Some(ErrorToast::new("Config saved and reloaded".to_owned()));
     app.overlay = None;
+    // Config changes can affect display (e.g. syntax highlighting theme). Invalidate
+    // the cached markdown lines and rebuild virtual scroll heights so the next render
+    // picks up fresh layout.
+    app.cached_markdown_text.clear();
+    app.cached_markdown_lines.clear();
+    app.rebuild_virtual_scroll();
 }
 
 // SAFETY: sanitized at ingestion — error messages may contain external data.

--- a/crates/theatron/tui/src/update/streaming.rs
+++ b/crates/theatron/tui/src/update/streaming.rs
@@ -32,7 +32,7 @@ pub(crate) fn handle_stream_text_delta(app: &mut App, text: String) {
     app.streaming_text.push_str(&clean);
     let delta = app.streaming_text.len() as i64 - app.cached_markdown_text.len() as i64;
     if delta >= 64 || text.contains('\n') {
-        let width = 120;
+        let width = app.terminal_width.saturating_sub(2).max(1) as usize;
         app.cached_markdown_lines =
             crate::markdown::render(&app.streaming_text, width, &app.theme, &app.highlighter).0;
         app.cached_markdown_text = app.streaming_text.clone();
@@ -454,6 +454,16 @@ mod tests {
         handle_stream_text_delta(&mut app, "line1\nline2".to_string());
         // newline should trigger markdown re-render
         assert!(!app.cached_markdown_text.is_empty());
+    }
+
+    #[test]
+    fn text_delta_uses_terminal_width_not_hardcoded() {
+        let mut app = test_app();
+        app.terminal_width = 80;
+        // Trigger a cache update via newline
+        handle_stream_text_delta(&mut app, "hello\nworld".to_string());
+        // Cache should be populated (width is passed correctly even if _width is unused internally)
+        assert_eq!(app.cached_markdown_text, "hello\nworld");
     }
 
     fn make_outcome() -> TurnOutcome {


### PR DESCRIPTION
Closes #993, #1000, #1004, #1010, #1013

## Changes
- Markdown width uses terminal width instead of hardcoded 120
- Cache invalidated on session switch
- scroll_states pruned to active sessions
- Scroll offset clamped to content bounds
- Virtual scroll rebuilds on filter/theme change

## Observations

**`markdown::render()` width parameter is currently unused** (`_width` naming convention) — Fix #993 is correct API hygiene and future-proofs the call site, but has no immediate visual effect. The `render()` implementation should be updated in a follow-up to actually honour the width parameter for line-wrapping.