### PR TITLE
fix(pylon): session safety and error mapping (5 issues)

### DIFF
--- a/crates/pylon/src/error.rs
+++ b/crates/pylon/src/error.rs
@@ -180,9 +180,32 @@ impl IntoResponse for ApiError {
 impl From<aletheia_mneme::error::Error> for ApiError {
     #[track_caller]
     fn from(err: aletheia_mneme::error::Error) -> Self {
-        Self::Internal {
-            message: err.to_string(),
-            location: snafu::Location::default(),
+        use aletheia_mneme::error::Error;
+        match err {
+            Error::SessionNotFound { id, .. } => Self::SessionNotFound {
+                id,
+                location: snafu::Location::default(),
+            },
+            Error::FactNotFound { id, .. } => Self::NotFound {
+                path: format!("fact/{id}"),
+                location: snafu::Location::default(),
+            },
+            // Validation errors are the caller's fault — expose the message.
+            Error::EmptyContent { .. }
+            | Error::ContentTooLong { .. }
+            | Error::InvalidConfidence { .. }
+            | Error::InvalidTimestamp { .. }
+            | Error::EmptyEntityName { .. }
+            | Error::InvalidWeight { .. }
+            | Error::EmptyEmbedding { .. }
+            | Error::EmptyEmbeddingContent { .. } => Self::BadRequest {
+                message: err.to_string(),
+                location: snafu::Location::default(),
+            },
+            _ => Self::Internal {
+                message: err.to_string(),
+                location: snafu::Location::default(),
+            },
         }
     }
 }
@@ -437,5 +460,48 @@ mod tests {
         assert_eq!(response.status(), StatusCode::BAD_REQUEST);
         let msg = body_message(response);
         assert!(msg.contains("content must not be empty"));
+    }
+
+    #[test]
+    fn mneme_session_not_found_maps_to_404() {
+        let mneme_err = aletheia_mneme::error::Error::SessionNotFound {
+            id: "ses-01abc".to_owned(),
+            location: snafu::Location::default(),
+        };
+        let api_err = ApiError::from(mneme_err);
+        let response = api_err.into_response();
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[test]
+    fn mneme_fact_not_found_maps_to_404() {
+        let mneme_err = aletheia_mneme::error::Error::FactNotFound {
+            id: "fact-01abc".to_owned(),
+            location: snafu::Location::default(),
+        };
+        let api_err = ApiError::from(mneme_err);
+        let response = api_err.into_response();
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[test]
+    fn mneme_empty_content_maps_to_400() {
+        let mneme_err = aletheia_mneme::error::Error::EmptyContent {
+            location: snafu::Location::default(),
+        };
+        let api_err = ApiError::from(mneme_err);
+        let response = api_err.into_response();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn mneme_invalid_confidence_maps_to_400() {
+        let mneme_err = aletheia_mneme::error::Error::InvalidConfidence {
+            value: 1.5,
+            location: snafu::Location::default(),
+        };
+        let api_err = ApiError::from(mneme_err);
+        let response = api_err.into_response();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     }
 }

--- a/crates/pylon/src/handlers/metrics.rs
+++ b/crates/pylon/src/handlers/metrics.rs
@@ -12,7 +12,14 @@ use crate::state::AppState;
 /// Prometheus content type for the metrics endpoint.
 pub(crate) const METRICS_CONTENT_TYPE: &str = "text/plain; version=0.0.4; charset=utf-8";
 
-/// GET /metrics -- Prometheus text format exposition.
+/// GET /metrics — Prometheus text-format metrics exposition.
+#[utoipa::path(
+    get,
+    path = "/metrics",
+    responses(
+        (status = 200, description = "Prometheus text-format metrics", content_type = "text/plain"),
+    ),
+)]
 #[expect(clippy::expect_used, reason = "Prometheus text encoding is infallible")]
 pub async fn expose(State(state): State<Arc<AppState>>) -> impl IntoResponse {
     let uptime = state.start_time.elapsed().as_secs_f64();

--- a/crates/pylon/src/handlers/sessions/mod.rs
+++ b/crates/pylon/src/handlers/sessions/mod.rs
@@ -75,9 +75,22 @@ pub async fn create(
 
     let session = tokio::task::spawn_blocking(move || {
         let store = state_clone.session_store.blocking_lock();
-        store
-            .find_or_create_session(&id_clone, &nid, &skey, Some(&model), None)
-            .map_err(ApiError::from)
+        match store.find_or_create_session(&id_clone, &nid, &skey, Some(&model), None) {
+            Ok(session) => Ok(session),
+            Err(e) if is_unique_constraint_violation(&e) => {
+                // WHY: Two concurrent POST requests both passed the "find existing" check
+                // and raced to INSERT. The schema's UNIQUE(nous_id, session_key) constraint
+                // caught the duplicate. Return whichever session won the race.
+                store
+                    .find_session(&nid, &skey)
+                    .map_err(ApiError::from)?
+                    .ok_or_else(|| ApiError::Internal {
+                        message: "session missing after constraint violation".to_owned(),
+                        location: snafu::Location::default(),
+                    })
+            }
+            Err(e) => Err(ApiError::from(e)),
+        }
     })
     .await??;
 
@@ -95,7 +108,7 @@ pub async fn create(
     path = "/api/v1/sessions",
     params(("nous_id" = Option<String>, Query, description = "Filter sessions by agent ID")),
     responses(
-        (status = 200, description = "Session list"),
+        (status = 200, description = "Session list", body = ListSessionsResponse),
         (status = 401, description = "Unauthorized", body = ErrorResponse),
     ),
     security(("bearer_auth" = []))
@@ -368,13 +381,34 @@ pub(crate) async fn resolve_session(
 
     let session = tokio::task::spawn_blocking(move || {
         let store = state_clone.session_store.blocking_lock();
-        store
-            .find_or_create_session(&id_clone, &aid, &skey, model_owned.as_deref(), None)
-            .map_err(ApiError::from)
+        match store.find_or_create_session(&id_clone, &aid, &skey, model_owned.as_deref(), None) {
+            Ok(session) => Ok(session),
+            Err(e) if is_unique_constraint_violation(&e) => {
+                // WHY: Concurrent stream requests may race to create the same session.
+                // Fall back to returning whichever session won the INSERT race.
+                store
+                    .find_session(&aid, &skey)
+                    .map_err(ApiError::from)?
+                    .ok_or_else(|| ApiError::Internal {
+                        message: "session missing after constraint violation".to_owned(),
+                        location: snafu::Location::default(),
+                    })
+            }
+            Err(e) => Err(ApiError::from(e)),
+        }
     })
     .await??;
 
     Ok(session.id)
+}
+
+/// Returns `true` when a mneme error is a `SQLite` UNIQUE constraint violation.
+///
+/// `SQLite` always includes "UNIQUE constraint failed" in the error message for
+/// constraint violations. We match on the string because pylon does not take a
+/// direct rusqlite dependency — the type lives inside mneme's `Database` variant.
+fn is_unique_constraint_violation(err: &aletheia_mneme::error::Error) -> bool {
+    err.to_string().contains("UNIQUE constraint failed")
 }
 
 pub(crate) async fn find_session(

--- a/crates/pylon/src/handlers/sessions/types.rs
+++ b/crates/pylon/src/handlers/sessions/types.rs
@@ -62,21 +62,29 @@ pub struct HistoryParams {
 }
 
 /// Response for `GET /api/v1/sessions` (list).
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 pub struct ListSessionsResponse {
+    /// Session summaries matching the query.
     pub sessions: Vec<SessionListItem>,
 }
 
 /// Session summary for list endpoints.
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct SessionListItem {
+    /// Session identifier.
     pub id: String,
+    /// Nous agent that owns this session.
     pub nous_id: String,
+    /// Client-chosen deduplication key.
     pub session_key: String,
+    /// Lifecycle status (e.g. `"active"`, `"archived"`).
     pub status: String,
+    /// Total messages stored in this session.
     pub message_count: i64,
+    /// ISO 8601 last-updated timestamp.
     pub updated_at: String,
+    /// Human-readable display name, if set.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub display_name: Option<String>,
 }

--- a/crates/pylon/src/openapi.rs
+++ b/crates/pylon/src/openapi.rs
@@ -20,6 +20,7 @@ use utoipa::OpenApi;
     ),
     paths(
         crate::handlers::health::check,
+        crate::handlers::metrics::expose,
         // Sessions
         crate::handlers::sessions::list_sessions,
         crate::handlers::sessions::create,
@@ -58,6 +59,8 @@ use utoipa::OpenApi;
         crate::handlers::sessions::RenameSessionRequest,
         crate::handlers::sessions::SendMessageRequest,
         crate::handlers::sessions::SessionResponse,
+        crate::handlers::sessions::ListSessionsResponse,
+        crate::handlers::sessions::SessionListItem,
         crate::handlers::sessions::HistoryResponse,
         crate::handlers::sessions::HistoryMessage,
         crate::handlers::nous::NousListResponse,


### PR DESCRIPTION
Closes #1031, #1032, #1069, #1107, #1120

## Changes

- **Config write ordering (#1031):** Confirmed disk write precedes in-memory update in `update_section`. The `write_config()` call at line 155 runs before `*config = new_config` at line 171; if disk write fails the `?` returns early and memory is never touched.

- **Session uniqueness (#1032):** The schema already carries `UNIQUE(nous_id, session_key)`. Added graceful handling in both `create` and `resolve_session`: on a `UNIQUE constraint failed` error, retry `find_session` to return whichever session won the concurrent-INSERT race instead of propagating a 500.

- **OpenAPI spec (#1069):** Added `#[utoipa::path]` to `metrics::expose` and registered it in `ApiDoc`. Added `ListSessionsResponse` and `SessionListItem` (`ToSchema`) to the components schema registry. Updated the `list_sessions` path annotation to include `body = ListSessionsResponse`.

- **SessionNotFound → 404 (#1107):** `From<aletheia_mneme::error::Error>` now matches `Error::SessionNotFound { id }` and maps it to `ApiError::SessionNotFound` (404) instead of the `_` wildcard which mapped to 500.

- **Error mapper (#1120):** Added explicit match arms: `FactNotFound` → 404, and all validation errors (`EmptyContent`, `ContentTooLong`, `InvalidConfidence`, `InvalidTimestamp`, `EmptyEntityName`, `InvalidWeight`, `EmptyEmbedding`, `EmptyEmbeddingContent`) → 400 Bad Request. Unknown/internal errors still fall through to 500.

## Observations

- `openapi.rs` uses `#[allow(clippy::needless_for_each)]` instead of `#[expect]`. The standards require `#[expect]` with a reason. Out of scope for this PR but worth tracking.