### PR TITLE
fix(mneme): correct 5 search/embedding algorithmic bugs

### DIFF
--- a/crates/mneme/src/conflict_tests.rs
+++ b/crates/mneme/src/conflict_tests.rs
@@ -120,6 +120,41 @@ fn cosine_similarity_different_lengths() {
     assert!((sim - 0.0).abs() < f64::EPSILON);
 }
 
+#[test]
+fn cosine_similarity_antiparallel() {
+    // Anti-parallel vectors (exactly opposite direction) should give -1.0.
+    // This verifies the dot product sign is preserved and norms are not squared.
+    let a = vec![1.0, 0.0, 0.0];
+    let b = vec![-1.0, 0.0, 0.0];
+    let sim = cosine_similarity(&a, &b);
+    assert!(
+        (sim - (-1.0)).abs() < 1e-6,
+        "anti-parallel vectors should have sim ~-1.0, got {sim}"
+    );
+}
+
+#[test]
+fn cosine_similarity_scale_invariant() {
+    // Scaling one vector must not change the cosine similarity.
+    // This verifies the denominator uses norms (not squared norms).
+    let a = vec![1.0, 2.0, 3.0];
+    let b = vec![2.0, 4.0, 6.0]; // b = 2 * a → same direction
+    let sim = cosine_similarity(&a, &b);
+    assert!(
+        (sim - 1.0).abs() < 1e-6,
+        "parallel vectors (one scaled) should have sim ~1.0, got {sim}"
+    );
+
+    // Scaling in both dimensions independently should not change the angle.
+    let c = vec![3.0, 0.0];
+    let d = vec![0.0, 7.0]; // orthogonal regardless of scale
+    let sim2 = cosine_similarity(&c, &d);
+    assert!(
+        sim2.abs() < 1e-6,
+        "orthogonal vectors with unequal magnitudes should have sim ~0.0, got {sim2}"
+    );
+}
+
 // --- Intra-batch dedup ---
 
 #[test]

--- a/crates/mneme/src/embedding.rs
+++ b/crates/mneme/src/embedding.rs
@@ -339,8 +339,14 @@ mod candle_provider {
                 .and_then(|t| t.sum_keepdim(1))
                 .and_then(|t| t.sqrt())
                 .map_err(Self::candle_err("norm computation"))?;
+            // Clamp norm to a small positive value to prevent NaN when the
+            // pooled vector has zero norm (e.g. all-zero input embeddings).
+            // A zero-norm input produces an all-zero output rather than NaN.
+            let norm_safe = norm
+                .clamp(f32::EPSILON, f32::MAX)
+                .map_err(Self::candle_err("norm clamp"))?;
             let normalized = pooled
-                .broadcast_div(&norm)
+                .broadcast_div(&norm_safe)
                 .map_err(Self::candle_err("normalization"))?;
 
             let mut results = Vec::with_capacity(batch_size);
@@ -361,6 +367,33 @@ mod candle_provider {
             }
             let (embeddings, attention_mask) = self.encode_and_forward(texts)?;
             Self::pool_and_normalize(&embeddings, &attention_mask, texts.len())
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+        use candle_core::{DType, Device, Tensor};
+
+        /// Zero-norm input must not produce NaN after L2 normalisation.
+        ///
+        /// When mean-pooling over an all-zero hidden-state tensor the resulting
+        /// pooled vector has norm 0.  Without the clamp this becomes 0/0 = NaN.
+        #[test]
+        fn pool_and_normalize_zero_input_no_nan() {
+            let device = Device::Cpu;
+            // shape: [batch=1, seq_len=2, hidden=4] — all zeros
+            let embeddings =
+                Tensor::zeros(&[1usize, 2usize, 4usize], DType::F32, &device).expect("zero tensor");
+            // attention mask: all ones (both tokens valid)
+            let attention_mask =
+                Tensor::ones(&[1usize, 2usize], DType::F32, &device).expect("ones mask");
+            let result = CandelProvider::pool_and_normalize(&embeddings, &attention_mask, 1)
+                .expect("pool_and_normalize on zero input must not fail");
+            assert_eq!(result.len(), 1, "batch size must be preserved");
+            for v in &result[0] {
+                assert!(!v.is_nan(), "zero-norm input must not produce NaN, got {v}");
+            }
         }
     }
 

--- a/crates/mneme/src/error.rs
+++ b/crates/mneme/src/error.rs
@@ -221,6 +221,16 @@ pub enum Error {
         #[snafu(implicit)]
         location: snafu::Location,
     },
+
+    /// Embedding vector dimension does not match the store's configured dimension.
+    #[cfg(feature = "mneme-engine")]
+    #[snafu(display("embedding dimension mismatch: expected {expected}, got {actual}"))]
+    EmbeddingDimensionMismatch {
+        expected: usize,
+        actual: usize,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
 }
 
 /// Result alias using mneme's [`Error`] type.

--- a/crates/mneme/src/knowledge_store/facts.rs
+++ b/crates/mneme/src/knowledge_store/facts.rs
@@ -377,33 +377,48 @@ impl KnowledgeStore {
             .collect())
     }
 
-    /// Return the set of fact IDs (from the given results) that are currently forgotten.
-    fn forgotten_fact_ids(
+    /// Return the subset of the given fact IDs that are currently marked as forgotten.
+    ///
+    /// Used by sibling search methods (e.g. `search_vectors`) that retrieve results
+    /// from indices which do not carry the `is_forgotten` flag.
+    pub(super) fn query_forgotten_ids(
         &self,
-        results: &[super::HybridResult],
+        ids: &[&str],
     ) -> crate::error::Result<std::collections::HashSet<String>> {
         use crate::engine::DataValue;
         use std::collections::BTreeMap;
 
-        // Build a Datalog query that checks each ID.
-        let id_list: Vec<String> = results
+        if ids.is_empty() {
+            return Ok(std::collections::HashSet::new());
+        }
+
+        let id_list: Vec<String> = ids
             .iter()
-            .map(|r| format!("'{}'", r.id.as_str().replace('\'', "''")))
+            .map(|id| format!("'{}'", id.replace('\'', "''")))
             .collect();
         let script = format!(
             r"?[id] := *facts{{id, is_forgotten}}, is_forgotten == true, id in [{}]",
             id_list.join(", ")
         );
         let rows = self.run_read(&script, BTreeMap::<String, DataValue>::new())?;
-        let mut ids = std::collections::HashSet::new();
+        let mut result = std::collections::HashSet::new();
         for row in rows.rows {
             if let Some(val) = row.first()
                 && let Ok(s) = extract_str(val)
             {
-                ids.insert(s);
+                result.insert(s);
             }
         }
-        Ok(ids)
+        Ok(result)
+    }
+
+    /// Return the set of fact IDs (from the given results) that are currently forgotten.
+    fn forgotten_fact_ids(
+        &self,
+        results: &[super::HybridResult],
+    ) -> crate::error::Result<std::collections::HashSet<String>> {
+        let ids: Vec<&str> = results.iter().map(|r| r.id.as_str()).collect();
+        self.query_forgotten_ids(&ids)
     }
 
     /// Query facts valid at a specific point in time.

--- a/crates/mneme/src/knowledge_store/search.rs
+++ b/crates/mneme/src/knowledge_store/search.rs
@@ -21,6 +21,14 @@ impl KnowledgeStore {
             !chunk.embedding.is_empty(),
             crate::error::EmptyEmbeddingSnafu
         );
+        // Validate dimension before storing — a mismatch corrupts the HNSW index.
+        ensure!(
+            chunk.embedding.len() == self.dim,
+            crate::error::EmbeddingDimensionMismatchSnafu {
+                expected: self.dim,
+                actual: chunk.embedding.len(),
+            }
+        );
         let params = embedding_to_params(chunk, self.dim);
         self.run_mut(&queries::upsert_embedding(), params)
     }
@@ -45,7 +53,22 @@ impl KnowledgeStore {
         params.insert("ef".to_owned(), DataValue::from(ef));
 
         let rows = self.run_read(queries::SEMANTIC_SEARCH, params)?;
-        let results = rows_to_recall_results(rows)?;
+        let mut results = rows_to_recall_results(rows)?;
+
+        // Filter out forgotten facts — the HNSW index does not carry is_forgotten.
+        let forgotten_ids = {
+            let ids: Vec<&str> = results
+                .iter()
+                .filter(|r| r.source_type == "fact")
+                .map(|r| r.source_id.as_str())
+                .collect();
+            self.query_forgotten_ids(&ids)?
+        };
+        if !forgotten_ids.is_empty() {
+            results.retain(|r| {
+                r.source_type != "fact" || !forgotten_ids.contains(r.source_id.as_str())
+            });
+        }
 
         let source_ids: Vec<crate::id::FactId> = results
             .iter()
@@ -281,16 +304,29 @@ impl KnowledgeStore {
             existing.iter().map(|r| r.id.as_str()).collect();
 
         for fact_id in &fact_ids {
-            // Try to find entity connections for this fact by checking entity neighborhoods
-            // Use the fact_id as a potential entity_id (facts often share IDs with their subject entities)
-            let entity_id = crate::id::EntityId::new_unchecked(*fact_id);
-            if let Ok(neighborhood) = self.entity_neighborhood(&entity_id) {
-                for row in &neighborhood.rows {
-                    // Extract neighbor entity IDs and find their associated facts
-                    if let Some(neighbor_id) = row.first().and_then(|v| v.get_str())
-                        && !existing_ids.contains(neighbor_id)
-                    {
-                        expanded_ids.insert(neighbor_id.to_owned());
+            // Look up which entities this fact references via the fact_entities relation.
+            // FactId and EntityId are distinct types — never cast one to the other.
+            let script = "?[entity_id] := *fact_entities{fact_id: $fid, entity_id}";
+            let mut fparams = std::collections::BTreeMap::new();
+            fparams.insert(
+                "fid".to_owned(),
+                crate::engine::DataValue::Str((*fact_id).into()),
+            );
+            let Ok(entity_rows) = self.run_read(script, fparams) else {
+                continue;
+            };
+            for entity_row in &entity_rows.rows {
+                let Some(entity_id_str) = entity_row.first().and_then(|v| v.get_str()) else {
+                    continue;
+                };
+                let entity_id = crate::id::EntityId::new_unchecked(entity_id_str);
+                if let Ok(neighborhood) = self.entity_neighborhood(&entity_id) {
+                    for row in &neighborhood.rows {
+                        if let Some(neighbor_id) = row.first().and_then(|v| v.get_str())
+                            && !existing_ids.contains(neighbor_id)
+                        {
+                            expanded_ids.insert(neighbor_id.to_owned());
+                        }
                     }
                 }
             }

--- a/crates/mneme/src/knowledge_store/tests.rs
+++ b/crates/mneme/src/knowledge_store/tests.rs
@@ -2584,3 +2584,158 @@ mod knowledge_store_tests {
         }
     }
 }
+
+// --- Search correctness regression tests (#1113–#1117) ---
+
+#[cfg(all(test, feature = "mneme-engine"))]
+#[expect(clippy::expect_used, reason = "test assertions")]
+mod search_correctness_tests {
+    use super::super::*;
+    use crate::knowledge::{EmbeddedChunk, EpistemicTier, Fact, ForgetReason};
+
+    const DIM: usize = 4;
+
+    fn make_store() -> std::sync::Arc<KnowledgeStore> {
+        KnowledgeStore::open_mem_with_config(KnowledgeConfig { dim: DIM })
+            .expect("open in-memory store")
+    }
+
+    fn ts(s: &str) -> jiff::Timestamp {
+        crate::knowledge::parse_timestamp(s).expect("valid test timestamp")
+    }
+
+    fn fact(id: &str, content: &str) -> Fact {
+        Fact {
+            id: crate::id::FactId::new_unchecked(id),
+            nous_id: "test-nous".to_owned(),
+            content: content.to_owned(),
+            confidence: 0.9,
+            tier: EpistemicTier::Inferred,
+            valid_from: ts("2026-01-01"),
+            valid_to: crate::knowledge::far_future(),
+            superseded_by: None,
+            source_session_id: None,
+            recorded_at: ts("2026-03-01T00:00:00Z"),
+            access_count: 0,
+            last_accessed_at: None,
+            stability_hours: 720.0,
+            fact_type: String::new(),
+            is_forgotten: false,
+            forgotten_at: None,
+            forget_reason: None,
+        }
+    }
+
+    fn embedding(id: &str, source_id: &str, vec: Vec<f32>) -> EmbeddedChunk {
+        EmbeddedChunk {
+            id: crate::id::EmbeddingId::new_unchecked(id),
+            content: format!("content for {id}"),
+            source_type: "fact".to_owned(),
+            source_id: source_id.to_owned(),
+            nous_id: "test-nous".to_owned(),
+            embedding: vec,
+            created_at: ts("2026-03-01T00:00:00Z"),
+        }
+    }
+
+    // Bug #1114 — search_vectors must not return forgotten facts.
+    #[test]
+    fn search_vectors_excludes_forgotten_facts() {
+        let store = make_store();
+
+        let f_live = fact("sv-live", "live banjo fact");
+        let f_forgotten = fact("sv-forgotten", "forgotten banjo fact");
+        store.insert_fact(&f_live).expect("insert live fact");
+        store
+            .insert_fact(&f_forgotten)
+            .expect("insert forgotten fact");
+
+        store
+            .insert_embedding(&embedding("sv-live", "sv-live", vec![1.0, 0.0, 0.0, 0.0]))
+            .expect("insert live embedding");
+        store
+            .insert_embedding(&embedding(
+                "sv-forgotten",
+                "sv-forgotten",
+                vec![1.0, 0.0, 0.0, 0.0],
+            ))
+            .expect("insert forgotten embedding");
+
+        // Forget sv-forgotten after inserting the embedding.
+        store
+            .forget_fact(
+                &crate::id::FactId::new_unchecked("sv-forgotten"),
+                ForgetReason::UserRequested,
+            )
+            .expect("forget fact");
+
+        let results = store
+            .search_vectors(vec![1.0, 0.0, 0.0, 0.0], 10, 20)
+            .expect("search_vectors");
+
+        let ids: Vec<&str> = results.iter().map(|r| r.source_id.as_str()).collect();
+        assert!(
+            !ids.contains(&"sv-forgotten"),
+            "forgotten fact must not appear in search_vectors results: {ids:?}"
+        );
+        assert!(
+            ids.contains(&"sv-live"),
+            "live fact must still appear in results: {ids:?}"
+        );
+    }
+
+    // Bug #1117 — insert_embedding must reject vectors with wrong dimension.
+    #[test]
+    fn insert_embedding_rejects_wrong_dimension() {
+        let store = make_store(); // DIM = 4
+        let fact_data = fact("dim-check", "dimension validation fact");
+        store.insert_fact(&fact_data).expect("insert fact");
+
+        let wrong_dim = EmbeddedChunk {
+            id: crate::id::EmbeddingId::new_unchecked("dim-check"),
+            content: "dimension validation fact".to_owned(),
+            source_type: "fact".to_owned(),
+            source_id: "dim-check".to_owned(),
+            nous_id: "test-nous".to_owned(),
+            // Wrong: 6 values instead of DIM=4
+            embedding: vec![0.1, 0.2, 0.3, 0.4, 0.5, 0.6],
+            created_at: ts("2026-03-01T00:00:00Z"),
+        };
+
+        let err = store
+            .insert_embedding(&wrong_dim)
+            .expect_err("must reject wrong-dimension embedding");
+        assert!(
+            matches!(
+                err,
+                crate::error::Error::EmbeddingDimensionMismatch {
+                    expected: 4,
+                    actual: 6,
+                    ..
+                }
+            ),
+            "expected EmbeddingDimensionMismatch, got: {err}"
+        );
+    }
+
+    // Bug #1117 — insert_embedding must accept vectors with correct dimension.
+    #[test]
+    fn insert_embedding_accepts_correct_dimension() {
+        let store = make_store(); // DIM = 4
+        let fact_data = fact("dim-ok", "correct dimension fact");
+        store.insert_fact(&fact_data).expect("insert fact");
+
+        let correct = EmbeddedChunk {
+            id: crate::id::EmbeddingId::new_unchecked("dim-ok"),
+            content: "correct dimension fact".to_owned(),
+            source_type: "fact".to_owned(),
+            source_id: "dim-ok".to_owned(),
+            nous_id: "test-nous".to_owned(),
+            embedding: vec![0.5, 0.5, 0.5, 0.5],
+            created_at: ts("2026-03-01T00:00:00Z"),
+        };
+        store
+            .insert_embedding(&correct)
+            .expect("correct-dimension embedding must be accepted");
+    }
+}


### PR DESCRIPTION
Closes #1113, #1114, #1115, #1116, #1117

## Changes

- **#1113 — Cosine similarity formula**: Verified `dot(a,b) / (‖a‖·‖b‖)` is correct (`norm_a.sqrt() * norm_b.sqrt()` = `‖a‖·‖b‖`, not squared norms). Added anti-parallel (`sim = -1.0`) and scale-invariant tests that would catch squared-norm or missing-sqrt bugs.
- **#1114 — Forgotten facts in vector search**: `search_vectors` was returning forgotten facts because the HNSW index carries no `is_forgotten` flag. Extracted `query_forgotten_ids(&[&str]) -> HashSet` as a `pub(super)` helper (shared with the existing `filter_forgotten_results` path in `search_hybrid`), then added a post-query filter in `search_vectors`. Test: insert two facts, forget one, assert it is absent from `search_vectors` results.
- **#1115 — FactId → EntityId type confusion in graph search**: `expand_via_graph` was calling `EntityId::new_unchecked(*fact_id)` — a direct type cast that always missed because fact IDs and entity IDs are in different namespaces. Fixed to query the `fact_entities` relation (`?[entity_id] := *fact_entities{fact_id: $fid, entity_id}`) and then look up each entity's neighbourhood.
- **#1116 — NaN on zero-norm input (candle)**: `pool_and_normalize` divided by zero when the mean-pooled vector had zero norm, producing NaN. Added `.clamp(f32::EPSILON, f32::MAX)` on the norm tensor before `broadcast_div`. Test: all-zeros hidden-state tensor → no NaN in output.
- **#1117 — Embedding dimension never validated**: `insert_embedding` silently accepted vectors of any length, silently corrupting the HNSW index. Added an `ensure!` guard against `chunk.embedding.len() != self.dim`, returning a new typed `EmbeddingDimensionMismatch` error. Tests: wrong-dimension insert returns the typed error; correct-dimension insert succeeds.

## Validation

```
cargo fmt --check       ✓
cargo clippy --workspace -- -D warnings   ✓
timeout 120 cargo test -p aletheia-mneme  ✓ (780 passed)
cargo test -p aletheia-mneme --features mneme-engine -- search_correctness_tests  ✓ (3 passed)
```

## Observations

- `expand_via_graph` still builds entity neighborhoods without capping the depth; for large graphs this could be slow. Out of scope for this fix (no correctness impact, only a performance concern).
- The candle `pool_and_normalize` test requires `embed-candle` feature and is placed inside the `candle_provider` private module so it can access the private function directly.