### PR TITLE
fix(hermeneus): circuit-breaker, incremental SSE, stop_reason, cache tokens, pricing

### DIFF
--- a/crates/hermeneus/src/anthropic/client.rs
+++ b/crates/hermeneus/src/anthropic/client.rs
@@ -15,11 +15,12 @@ use tracing::{Instrument as _, info, info_span};
 use std::collections::HashMap;
 
 use crate::error::{self, Result};
+use crate::health::{HealthConfig, ProviderHealthTracker};
 use crate::provider::{LlmProvider, ModelPricing, ProviderConfig};
 use crate::types::{CompletionRequest, CompletionResponse, TokenCount};
 use aletheia_koina::credential::{CredentialProvider, CredentialSource};
 
-use super::stream::{StreamAccumulator, StreamEvent, parse_sse_stream};
+use super::stream::{StreamAccumulator, StreamEvent, parse_sse_response};
 use super::wire::WireRequest;
 
 const DEFAULT_BASE_URL: &str = "https://api.anthropic.com";
@@ -47,6 +48,7 @@ pub struct AnthropicProvider {
     api_version: String,
     max_retries: u32,
     pricing: HashMap<String, ModelPricing>,
+    health: Arc<ProviderHealthTracker>,
 }
 
 /// Static credential provider for backward-compatible `from_config()`.
@@ -118,6 +120,7 @@ impl AnthropicProvider {
             api_version: DEFAULT_API_VERSION.to_owned(),
             max_retries: config.max_retries.unwrap_or(DEFAULT_MAX_RETRIES),
             pricing: config.pricing.clone(),
+            health: Arc::new(ProviderHealthTracker::new(HealthConfig::default())),
         })
     }
 
@@ -139,6 +142,7 @@ impl AnthropicProvider {
             api_version: DEFAULT_API_VERSION.to_owned(),
             max_retries: config.max_retries.unwrap_or(DEFAULT_MAX_RETRIES),
             pricing: config.pricing.clone(),
+            health: Arc::new(ProviderHealthTracker::new(HealthConfig::default())),
         })
     }
 
@@ -155,7 +159,7 @@ impl AnthropicProvider {
     pub async fn complete_streaming(
         &self,
         request: &CompletionRequest,
-        mut on_event: impl FnMut(StreamEvent),
+        mut on_event: impl FnMut(StreamEvent) + Send,
     ) -> Result<CompletionResponse> {
         let span = info_span!("llm_call",
             llm.provider = "anthropic",
@@ -179,8 +183,16 @@ impl AnthropicProvider {
     async fn complete_streaming_inner(
         &self,
         request: &CompletionRequest,
-        on_event: &mut impl FnMut(StreamEvent),
+        on_event: &mut (dyn FnMut(StreamEvent) + Send),
     ) -> Result<CompletionResponse> {
+        if let Err(health) = self.health.check_available() {
+            tracing::warn!(?health, "circuit-breaker open; streaming request rejected");
+            return Err(error::ApiRequestSnafu {
+                message: format!("provider circuit-breaker open: {health:?}"),
+            }
+            .build());
+        }
+
         let start = Instant::now();
         let mut ttft: Option<std::time::Duration> = None;
 
@@ -202,7 +214,7 @@ impl AnthropicProvider {
             let headers = self.build_headers()?;
 
             // HTTP-level errors (connection, non-200 status)
-            let response = match self
+            let mut response = match self
                 .client
                 .post(format!("{}/v1/messages", self.base_url))
                 .headers(headers)
@@ -212,7 +224,9 @@ impl AnthropicProvider {
             {
                 Ok(r) => r,
                 Err(e) => {
-                    last_error = Some(super::error::map_request_error(&e));
+                    let err = super::error::map_request_error(&e);
+                    self.health.record_error(&err);
+                    last_error = Some(err);
                     continue;
                 }
             };
@@ -220,6 +234,7 @@ impl AnthropicProvider {
             if !response.status().is_success() {
                 let status = response.status().as_u16();
                 let err = super::error::map_error_response(response).await;
+                self.health.record_error(&err);
                 // Non-retryable HTTP status: 401, 400-level (except 429)
                 if status == 401 || ((400..500).contains(&status) && status != 429) {
                     #[expect(
@@ -242,18 +257,11 @@ impl AnthropicProvider {
                 continue;
             }
 
-            // Read the full response body and parse SSE from it
-            let response_bytes = response.bytes().await.map_err(|e| {
-                error::ApiRequestSnafu {
-                    message: format!("failed to read streaming response body: {e}"),
-                }
-                .build()
-            })?;
-            let reader = std::io::Cursor::new(response_bytes);
+            // Parse SSE events incrementally as bytes arrive from the response stream.
             let mut accumulator = StreamAccumulator::new();
             let mut content_started = false;
 
-            let stream_result = parse_sse_stream(reader, &mut accumulator, &mut |event| {
+            let stream_result = parse_sse_response(&mut response, &mut accumulator, &mut |event| {
                 if matches!(
                     event,
                     StreamEvent::TextDelta { .. }
@@ -266,11 +274,13 @@ impl AnthropicProvider {
                     content_started = true;
                 }
                 on_event(event);
-            });
+            })
+            .await;
 
             match stream_result {
                 Ok(()) => {
                     let resp = accumulator.finish();
+                    self.health.record_success();
                     #[expect(
                         clippy::cast_possible_truncation,
                         reason = "LLM call duration fits in u64"
@@ -322,6 +332,7 @@ impl AnthropicProvider {
                     // produce duplicates. Propagate immediately.
                     if content_started {
                         tracing::error!("SSE error after content started streaming — cannot retry");
+                        self.health.record_error(&e);
                         #[expect(
                             clippy::cast_possible_truncation,
                             reason = "LLM call duration fits in u64"
@@ -342,9 +353,11 @@ impl AnthropicProvider {
                     // Only retry RateLimited (overloaded/429); other errors are terminal.
                     if matches!(e, error::Error::RateLimited { .. }) {
                         tracing::warn!("SSE stream returned retryable error before content");
+                        self.health.record_error(&e);
                         last_error = Some(e);
                         continue;
                     }
+                    self.health.record_error(&e);
                     #[expect(
                         clippy::cast_possible_truncation,
                         reason = "LLM call duration fits in u64"
@@ -496,6 +509,17 @@ impl AnthropicProvider {
         &self,
         request: &CompletionRequest,
     ) -> Result<CompletionResponse> {
+        if let Err(health) = self.health.check_available() {
+            tracing::warn!(
+                ?health,
+                "circuit-breaker open; non-streaming request rejected"
+            );
+            return Err(error::ApiRequestSnafu {
+                message: format!("provider circuit-breaker open: {health:?}"),
+            }
+            .build());
+        }
+
         let start = Instant::now();
 
         let wire = WireRequest::from_request(request, None);
@@ -520,7 +544,9 @@ impl AnthropicProvider {
             {
                 Ok(r) => r,
                 Err(e) => {
-                    last_error = Some(super::error::map_request_error(&e));
+                    let err = super::error::map_request_error(&e);
+                    self.health.record_error(&err);
+                    last_error = Some(err);
                     continue;
                 }
             };
@@ -540,6 +566,7 @@ impl AnthropicProvider {
                             .map_err(|msg| error::ApiRequestSnafu { message: msg }.build())
                     });
                 if let Ok(ref resp) = parsed {
+                    self.health.record_success();
                     #[expect(
                         clippy::cast_possible_truncation,
                         reason = "LLM call duration fits in u64"
@@ -586,6 +613,7 @@ impl AnthropicProvider {
             }
 
             let err = super::error::map_error_response(response).await;
+            self.health.record_error(&err);
 
             // Non-retryable: 401, 400-level (except 429).
             if status == 401 || ((400..500).contains(&status) && status != 429) {
@@ -669,12 +697,27 @@ impl LlmProvider for AnthropicProvider {
         true
     }
 
+    fn supports_streaming(&self) -> bool {
+        true
+    }
+
+    fn complete_streaming<'a>(
+        &'a self,
+        request: &'a CompletionRequest,
+        on_event: &'a mut (dyn FnMut(StreamEvent) + Send),
+    ) -> Pin<Box<dyn Future<Output = Result<CompletionResponse>> + Send + 'a>> {
+        Box::pin(self.complete_streaming_inner(request, on_event))
+    }
+
     fn as_any(&self) -> &dyn std::any::Any {
         self
     }
 }
 
-/// Estimate cost using config-based pricing, falling back to hardcoded defaults.
+/// Estimate cost using configured pricing.
+///
+/// Returns `0.0` and logs a warning when no pricing is configured for the
+/// model — callers display cost as "unknown" rather than a misleading figure.
 #[expect(
     clippy::cast_precision_loss,
     reason = "token counts are small enough for f64 precision"
@@ -685,16 +728,12 @@ fn estimate_cost(
     input_tokens: u64,
     output_tokens: u64,
 ) -> f64 {
-    let (in_rate, out_rate) = if let Some(p) = pricing.get(model) {
-        (p.input_cost_per_mtok, p.output_cost_per_mtok)
-    } else if model.contains("opus") {
-        (15.0, 75.0)
-    } else if model.contains("haiku") {
-        (0.80, 4.0)
-    } else {
-        (3.0, 15.0)
+    let Some(p) = pricing.get(model) else {
+        tracing::warn!(model, "no pricing configured for model; cost reported as 0");
+        return 0.0;
     };
-    (input_tokens as f64 * in_rate + output_tokens as f64 * out_rate) / 1_000_000.0
+    (input_tokens as f64 * p.input_cost_per_mtok + output_tokens as f64 * p.output_cost_per_mtok)
+        / 1_000_000.0
 }
 
 pub(crate) fn backoff_delay(attempt: u32, last_error: Option<&error::Error>) -> Duration {

--- a/crates/hermeneus/src/anthropic/client_tests.rs
+++ b/crates/hermeneus/src/anthropic/client_tests.rs
@@ -242,32 +242,25 @@ async fn complete_malformed_body() {
 // --- estimate_cost unit tests ---
 
 #[test]
-fn estimate_cost_opus() {
+fn estimate_cost_no_pricing_returns_zero() {
+    // Without configured pricing, cost is always 0.0 regardless of model.
     let pricing = HashMap::new();
-    let cost = estimate_cost(&pricing, "claude-opus-4-20250514", 1000, 100);
-    assert!((cost - 0.0225).abs() < 0.0001);
-}
-
-#[test]
-fn estimate_cost_sonnet() {
-    let pricing = HashMap::new();
-    let cost = estimate_cost(&pricing, "claude-sonnet-4-20250514", 1000, 100);
-    assert!((cost - 0.0045).abs() < 0.0001);
-}
-
-#[test]
-fn estimate_cost_haiku() {
-    let pricing = HashMap::new();
-    let cost = estimate_cost(&pricing, "claude-haiku-4-5-20251001", 1000, 100);
-    assert!((cost - 0.0012).abs() < 0.0001);
-}
-
-#[test]
-fn estimate_cost_unknown_defaults_to_sonnet() {
-    let pricing = HashMap::new();
-    let cost_unknown = estimate_cost(&pricing, "some-unknown-model", 1000, 100);
-    let cost_sonnet = estimate_cost(&pricing, "claude-sonnet-4-20250514", 1000, 100);
-    assert!((cost_unknown - cost_sonnet).abs() < 0.0001);
+    assert_eq!(
+        estimate_cost(&pricing, "claude-opus-4-20250514", 1000, 100),
+        0.0
+    );
+    assert_eq!(
+        estimate_cost(&pricing, "claude-sonnet-4-20250514", 1000, 100),
+        0.0
+    );
+    assert_eq!(
+        estimate_cost(&pricing, "claude-haiku-4-5-20251001", 1000, 100),
+        0.0
+    );
+    assert_eq!(
+        estimate_cost(&pricing, "some-unknown-model", 1000, 100),
+        0.0
+    );
 }
 
 #[test]

--- a/crates/hermeneus/src/anthropic/stream.rs
+++ b/crates/hermeneus/src/anthropic/stream.rs
@@ -4,8 +4,7 @@
 //! blocks into a final [`CompletionResponse`], and emits [`StreamEvent`]s
 //! to a callback for real-time UI updates.
 
-use std::io::BufRead;
-
+use reqwest::Response;
 use tracing::warn;
 
 use crate::error::{self, Result};
@@ -228,7 +227,13 @@ impl StreamAccumulator {
             }
             WireStreamEvent::MessageDelta { delta, usage } => {
                 self.output_tokens = usage.output_tokens;
-                let stop_reason = parse_stop_reason_lenient(&delta.stop_reason);
+                // Accumulate cache token deltas reported in the streaming message_delta event.
+                self.cache_write_tokens += usage.cache_creation_input_tokens;
+                self.cache_read_tokens += usage.cache_read_input_tokens;
+                let stop_reason = delta
+                    .stop_reason
+                    .parse::<StopReason>()
+                    .unwrap_or(StopReason::EndTurn);
                 self.stop_reason = Some(stop_reason);
                 on_event(StreamEvent::MessageStop {
                     stop_reason,
@@ -331,8 +336,9 @@ impl StreamAccumulator {
 /// Uses lossy UTF-8 conversion so that proxy-injected non-UTF8 bytes do not
 /// abort the stream — replacement characters (`\u{FFFD}`) appear in event
 /// data instead of causing an error.
+#[cfg(test)]
 pub(crate) fn parse_sse_stream(
-    mut reader: impl BufRead,
+    mut reader: impl std::io::BufRead,
     accumulator: &mut StreamAccumulator,
     on_event: &mut impl FnMut(StreamEvent),
 ) -> Result<()> {
@@ -394,13 +400,68 @@ fn convert_wire_usage(wire: &WireUsage) -> Usage {
     }
 }
 
-fn parse_stop_reason_lenient(s: &str) -> StopReason {
-    match s {
-        "tool_use" => StopReason::ToolUse,
-        "max_tokens" => StopReason::MaxTokens,
-        "stop_sequence" => StopReason::StopSequence,
-        _ => StopReason::EndTurn,
+/// Parse SSE events incrementally from a live HTTP response stream.
+///
+/// Reads the response body byte-by-byte via [`Response::chunk`], accumulating
+/// bytes until a newline and dispatching complete SSE events as they arrive.
+/// Unlike `parse_sse_stream` (test-only sync variant), this does not buffer the entire response body
+/// before parsing — each event is processed as soon as the final byte of its
+/// `data:` line is received.
+///
+/// Uses lossy UTF-8 so proxy-injected non-UTF-8 bytes produce replacement
+/// characters (`\u{FFFD}`) rather than aborting the stream.
+pub(crate) async fn parse_sse_response(
+    response: &mut Response,
+    accumulator: &mut StreamAccumulator,
+    on_event: &mut impl FnMut(StreamEvent),
+) -> Result<()> {
+    // WHY: Pre-allocated buffer for the current line; SSE lines are short.
+    let mut line_buf: Vec<u8> = Vec::with_capacity(256);
+    let mut current_event_type = String::new();
+    let mut current_data = String::new();
+
+    loop {
+        let chunk = response.chunk().await.map_err(|e| {
+            error::ApiRequestSnafu {
+                message: format!("stream read error: {e}"),
+            }
+            .build()
+        })?;
+
+        let Some(bytes) = chunk else { break };
+
+        for &byte in &bytes {
+            if byte == b'\n' {
+                let line_cow = String::from_utf8_lossy(&line_buf);
+                let line = line_cow.trim_end_matches('\r');
+
+                if line.is_empty() {
+                    if !current_data.is_empty() && current_event_type != "ping" {
+                        let event: WireStreamEvent =
+                            serde_json::from_str(&current_data).map_err(|e| {
+                                error::ApiRequestSnafu {
+                                    message: format!("stream parse error: {e}"),
+                                }
+                                .build()
+                            })?;
+                        accumulator.process_event(event, on_event)?;
+                    }
+                    current_event_type.clear();
+                    current_data.clear();
+                } else if let Some(et) = line.strip_prefix("event: ") {
+                    et.clone_into(&mut current_event_type);
+                } else if let Some(data) = line.strip_prefix("data: ") {
+                    data.clone_into(&mut current_data);
+                }
+                // Ignore other SSE lines (id:, retry:, comments).
+                line_buf.clear();
+            } else {
+                line_buf.push(byte);
+            }
+        }
     }
+
+    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/hermeneus/src/anthropic/wire.rs
+++ b/crates/hermeneus/src/anthropic/wire.rs
@@ -443,13 +443,7 @@ fn content_with_cache_control(content: &Content) -> serde_json::Value {
 }
 
 fn parse_stop_reason(s: &str) -> Result<StopReason, String> {
-    match s {
-        "end_turn" => Ok(StopReason::EndTurn),
-        "tool_use" => Ok(StopReason::ToolUse),
-        "max_tokens" => Ok(StopReason::MaxTokens),
-        "stop_sequence" => Ok(StopReason::StopSequence),
-        other => Err(format!("unknown stop_reason: {other}")),
-    }
+    s.parse()
 }
 
 // ---------------------------------------------------------------------------
@@ -530,8 +524,16 @@ pub(crate) struct WireMessageDeltaBody {
 }
 
 #[derive(Debug, Deserialize)]
+#[expect(
+    clippy::struct_field_names,
+    reason = "field names mirror the Anthropic wire format exactly"
+)]
 pub(crate) struct WireMessageDeltaUsage {
     pub output_tokens: u64,
+    #[serde(default)]
+    pub cache_creation_input_tokens: u64,
+    #[serde(default)]
+    pub cache_read_input_tokens: u64,
 }
 
 #[cfg(test)]

--- a/crates/hermeneus/src/provider.rs
+++ b/crates/hermeneus/src/provider.rs
@@ -8,7 +8,7 @@ use std::collections::HashMap;
 use std::future::Future;
 use std::pin::Pin;
 
-use crate::anthropic::AnthropicProvider;
+use crate::anthropic::StreamEvent;
 use crate::error::{self, Result};
 use crate::health::{HealthConfig, ProviderHealth, ProviderHealthTracker};
 use crate::types::{CompletionRequest, CompletionResponse, TokenCount};
@@ -70,7 +70,28 @@ pub trait LlmProvider: Send + Sync {
         false
     }
 
-    /// Downcast to concrete type for provider-specific features (e.g., streaming).
+    /// Whether this provider supports streaming completions.
+    fn supports_streaming(&self) -> bool {
+        false
+    }
+
+    /// Send a streaming completion request, emitting [`StreamEvent`]s incrementally.
+    ///
+    /// The default implementation ignores `on_event` and delegates to `complete()`.
+    /// Providers that support streaming should override both this method and
+    /// `supports_streaming()`.
+    ///
+    /// # Errors
+    /// Same as `complete`, plus mid-stream transport errors when overridden.
+    fn complete_streaming<'a>(
+        &'a self,
+        request: &'a CompletionRequest,
+        _on_event: &'a mut (dyn FnMut(StreamEvent) + Send),
+    ) -> Pin<Box<dyn Future<Output = Result<CompletionResponse>> + Send + 'a>> {
+        self.complete(request)
+    }
+
+    /// Downcast to concrete type for provider-specific features.
     fn as_any(&self) -> &dyn Any;
 }
 
@@ -187,11 +208,10 @@ impl ProviderRegistry {
 
     /// Find a streaming-capable provider for the given model.
     ///
-    /// Returns `Some` if the provider supports streaming (currently only Anthropic).
+    /// Returns `Some` if the provider supports streaming.
     #[must_use]
-    pub fn find_streaming_provider(&self, model: &str) -> Option<&AnthropicProvider> {
-        self.find_provider(model)
-            .and_then(|p| p.as_any().downcast_ref::<AnthropicProvider>())
+    pub fn find_streaming_provider(&self, model: &str) -> Option<&dyn LlmProvider> {
+        self.find_provider(model).filter(|p| p.supports_streaming())
     }
 
     /// Record a failed request for the named provider.

--- a/crates/hermeneus/src/types.rs
+++ b/crates/hermeneus/src/types.rs
@@ -496,6 +496,20 @@ impl std::fmt::Display for StopReason {
     }
 }
 
+impl std::str::FromStr for StopReason {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "end_turn" => Ok(Self::EndTurn),
+            "tool_use" => Ok(Self::ToolUse),
+            "max_tokens" => Ok(Self::MaxTokens),
+            "stop_sequence" => Ok(Self::StopSequence),
+            other => Err(format!("unknown stop_reason: {other}")),
+        }
+    }
+}
+
 /// Token usage for a completion.
 #[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
 pub struct Usage {

--- a/crates/nous/src/execute/mod.rs
+++ b/crates/nous/src/execute/mod.rs
@@ -338,7 +338,7 @@ pub async fn execute_streaming(
 
         let tx = stream_tx.clone();
         let response = match streaming_provider
-            .complete_streaming(&request, |event| {
+            .complete_streaming(&request, &mut |event| {
                 let _ = tx.try_send(TurnStreamEvent::LlmDelta(event));
             })
             .await


### PR DESCRIPTION
## Summary

Resolves six issues in the `aletheia-hermeneus` LLM client (#1090–#1095):

- **#1090 — Health circuit-breaker wired in**: `ProviderHealthTracker` was declared but never consulted. Both `execute_with_retry_inner` and `complete_streaming_inner` now call `check_available()` at entry, `record_error()` on every failure path (network errors, HTTP 4xx/5xx, stream parse errors), and `record_success()` on a fully parsed response.

- **#1091 — Incremental SSE parsing**: `complete_streaming` previously buffered the entire response body (`bytes().await`) before parsing. It now consumes the stream chunk-by-chunk via `Response::chunk()` through a new `parse_sse_response()` async function. The sync `parse_sse_stream` is now `#[cfg(test)]`-only.

- **#1092 — Unified `stop_reason` parsing**: `wire.rs` had a strict `parse_stop_reason` function; `stream.rs` had a separate lenient `parse_stop_reason_lenient`. Both are replaced by a single `impl std::str::FromStr for StopReason` on the canonical type. Both callers use `.parse::<StopReason>()`.

- **#1093 — Cache token deltas**: `WireMessageDeltaUsage` was missing `cache_creation_input_tokens` / `cache_read_input_tokens`. Added with `#[serde(default)]`. `StreamAccumulator` now accumulates them into `cache_write_tokens` / `cache_read_tokens` and reports them in the final `Usage`.

- **#1094 — Stale hardcoded pricing removed**: `estimate_cost` fell back to hardcoded per-model rates (15/75 for opus, 3/15 for sonnet, 0.80/4 for haiku). These are removed. When no pricing is configured for a model, `estimate_cost` returns `0.0` and emits `tracing::warn!`. Tests updated to expect `0.0` for empty pricing maps.

- **#1095 — Streaming abstracted behind `LlmProvider`**: `find_streaming_provider` returned `Option<&AnthropicProvider>` (concrete downcast). Added `supports_streaming() -> bool` (default: `false`) and `complete_streaming()` (default: delegates to `complete()`) to the `LlmProvider` trait. `AnthropicProvider` overrides both. `find_streaming_provider` now returns `Option<&dyn LlmProvider>` and uses `supports_streaming()`. `nous::execute` updated to pass `&mut closure`.

## Test plan

- [x] `cargo fmt --check` — passes
- [x] `cargo clippy --workspace -- -D warnings` — zero warnings
- [x] `timeout 120 cargo test -p aletheia-hermeneus` — 151 passed, 0 failed

## Observations (out of scope)

- `ProviderRegistry` maintains its own per-provider `ProviderHealthTracker` entries independent of the one embedded in `AnthropicProvider`. The embedded tracker is authoritative for circuit-breaking; the registry trackers are informational for external callers. If full deduplication is desired, the registry could delegate to the provider's internal tracker via a new trait method — tracked separately.
- `count_tokens_request` has no health tracking; it is an ancillary endpoint whose failure does not affect provider availability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)