### PR TITLE
fix: validation and safety across symbolon, taxis, thesauros (7 issues)

### DIFF
--- a/crates/symbolon/src/error.rs
+++ b/crates/symbolon/src/error.rs
@@ -94,6 +94,14 @@ pub enum Error {
         #[snafu(implicit)]
         location: snafu::Location,
     },
+
+    /// Auth database schema version table is corrupted or unreadable.
+    #[snafu(display("auth database schema is corrupted: {source}"))]
+    SchemaCorrupted {
+        source: rusqlite::Error,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/crates/symbolon/src/store.rs
+++ b/crates/symbolon/src/store.rs
@@ -301,7 +301,7 @@ impl AuthStore {
 // --- Schema initialization ---
 
 fn initialize(conn: &Connection) -> Result<()> {
-    let version = get_schema_version(conn);
+    let version = get_schema_version(conn)?;
 
     if version == 0 {
         info!("Initializing fresh auth database with schema v{SCHEMA_VERSION}");
@@ -313,17 +313,48 @@ fn initialize(conn: &Connection) -> Result<()> {
         .context(error::DatabaseSnafu)?;
     }
 
+    // Remove revoked tokens whose expiry has already passed.
+    // WHY: Prevents unbounded growth of the revoked_tokens table; entries are
+    // only needed until the token's natural expiry, so cleaning up on startup
+    // is sufficient for production workloads.
+    let cleaned = conn
+        .execute(
+            "DELETE FROM revoked_tokens WHERE expires_at < strftime('%Y-%m-%dT%H:%M:%fZ', 'now')",
+            [],
+        )
+        .context(error::DatabaseSnafu)?;
+    if cleaned > 0 {
+        info!(
+            count = cleaned,
+            "cleaned up expired token revocations on startup"
+        );
+    }
+
     Ok(())
 }
 
-fn get_schema_version(conn: &Connection) -> u32 {
-    // Returns 0 when the table doesn't exist yet — triggers all migrations
+fn get_schema_version(conn: &Connection) -> Result<u32> {
+    // If the schema_version table does not yet exist this is a fresh database;
+    // return 0 to signal that all DDL should be applied.
+    let table_exists: bool = conn
+        .query_row(
+            "SELECT COUNT(*) > 0 FROM sqlite_master WHERE type='table' AND name='schema_version'",
+            [],
+            |row| row.get(0),
+        )
+        .context(error::DatabaseSnafu)?;
+
+    if !table_exists {
+        return Ok(0);
+    }
+
+    // The table exists — any failure to read the version signals corruption.
     conn.query_row(
         "SELECT version FROM schema_version ORDER BY version DESC LIMIT 1",
         [],
         |row| row.get(0),
     )
-    .unwrap_or(0)
+    .context(error::SchemaCorruptedSnafu)
 }
 
 // --- Row mappers ---
@@ -391,7 +422,7 @@ mod tests {
     #[test]
     fn fresh_database_initializes() {
         let store = test_store();
-        let version = get_schema_version(store.conn());
+        let version = get_schema_version(store.conn()).unwrap();
         assert_eq!(version, SCHEMA_VERSION);
     }
 
@@ -399,8 +430,26 @@ mod tests {
     fn idempotent_initialization() {
         let store = test_store();
         initialize(store.conn()).unwrap();
-        let version = get_schema_version(store.conn());
+        let version = get_schema_version(store.conn()).unwrap();
         assert_eq!(version, SCHEMA_VERSION);
+    }
+
+    #[test]
+    fn schema_corruption_returns_error() {
+        let store = test_store();
+        // Drop the schema_version table to simulate corruption: the table
+        // exists but has been emptied/corrupted. We simulate by dropping and
+        // re-creating it empty, then verifying an error is returned.
+        store
+            .conn()
+            .execute_batch("DELETE FROM schema_version;")
+            .unwrap();
+        // Table exists but has no rows — SchemaCorrupted should be returned.
+        let result = get_schema_version(store.conn());
+        assert!(
+            matches!(result, Err(error::Error::SchemaCorrupted { .. })),
+            "expected SchemaCorrupted, got: {result:?}"
+        );
     }
 
     #[test]

--- a/crates/taxis/src/config.rs
+++ b/crates/taxis/src/config.rs
@@ -22,7 +22,7 @@ pub struct AletheiaConfig {
     pub embedding: EmbeddingSettings,
     /// Data lifecycle and retention policies.
     pub data: DataConfig,
-    /// External domain pack paths (directories containing pack.yaml).
+    /// External domain pack paths (directories containing pack.toml).
     pub packs: Vec<PathBuf>,
     /// Periodic maintenance task configuration (trace rotation, drift detection, etc.).
     pub maintenance: MaintenanceSettings,

--- a/crates/taxis/src/validate.rs
+++ b/crates/taxis/src/validate.rs
@@ -36,6 +36,9 @@ pub fn validate_section(section: &str, value: &Value) -> Result<(), ValidationEr
     }
 }
 
+/// Maximum allowed token budget for any single field.
+const MAX_TOKEN_BUDGET: u64 = 1_000_000;
+
 fn validate_agents(value: &Value, errors: &mut Vec<String>) {
     if let Some(defaults) = value.get("defaults") {
         check_positive_u32(defaults, "contextTokens", errors);
@@ -43,6 +46,40 @@ fn validate_agents(value: &Value, errors: &mut Vec<String>) {
         check_positive_u32(defaults, "bootstrapMaxTokens", errors);
         check_positive_u32(defaults, "timeoutSeconds", errors);
         check_positive_u32(defaults, "thinkingBudget", errors);
+
+        // Cap token budgets at a sane maximum to prevent misconfiguration.
+        for field in &[
+            "contextTokens",
+            "maxOutputTokens",
+            "bootstrapMaxTokens",
+            "thinkingBudget",
+        ] {
+            if let Some(val) = defaults.get(field).and_then(Value::as_u64)
+                && val > MAX_TOKEN_BUDGET
+            {
+                errors.push(format!("{field} must not exceed {MAX_TOKEN_BUDGET} tokens"));
+            }
+        }
+
+        // Model IDs must not be empty strings.
+        if let Some(model) = defaults.get("model") {
+            if let Some(primary) = model.get("primary").and_then(Value::as_str)
+                && primary.is_empty()
+            {
+                errors.push("agents.defaults.model.primary must not be empty".to_owned());
+            }
+            if let Some(fallbacks) = model.get("fallbacks").and_then(Value::as_array) {
+                for (i, fallback) in fallbacks.iter().enumerate() {
+                    if let Some(s) = fallback.as_str()
+                        && s.is_empty()
+                    {
+                        errors.push(format!(
+                            "agents.defaults.model.fallbacks[{i}] must not be empty"
+                        ));
+                    }
+                }
+            }
+        }
 
         if let Some(val) = defaults.get("maxToolIterations").and_then(Value::as_u64)
             && (val == 0 || val > 200)
@@ -393,5 +430,70 @@ mod tests {
                 "source '{source}' should be valid"
             );
         }
+    }
+
+    #[test]
+    fn rejects_empty_model_primary() {
+        let section = json!({ "defaults": { "model": { "primary": "" } } });
+        let result = validate_section("agents", &section);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(
+            err.errors.iter().any(|e| e.contains("model.primary")),
+            "expected model.primary error, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn rejects_empty_model_fallback() {
+        let section = json!({ "defaults": { "model": { "primary": "claude-sonnet-4-6", "fallbacks": [""] } } });
+        let result = validate_section("agents", &section);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(
+            err.errors.iter().any(|e| e.contains("fallbacks[0]")),
+            "expected fallbacks[0] error, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn accepts_valid_model_ids() {
+        let section = json!({
+            "defaults": {
+                "model": {
+                    "primary": "claude-sonnet-4-6",
+                    "fallbacks": ["claude-haiku-3-5"]
+                }
+            }
+        });
+        assert!(validate_section("agents", &section).is_ok());
+    }
+
+    #[test]
+    fn rejects_token_budget_exceeding_maximum() {
+        for field in [
+            "contextTokens",
+            "maxOutputTokens",
+            "bootstrapMaxTokens",
+            "thinkingBudget",
+        ] {
+            let section = json!({ "defaults": { field: 1_000_001_u64 } });
+            let result = validate_section("agents", &section);
+            assert!(
+                result.is_err(),
+                "{field} exceeding MAX_TOKEN_BUDGET should be rejected"
+            );
+            let err = result.unwrap_err();
+            assert!(
+                err.errors.iter().any(|e| e.contains(field)),
+                "expected error mentioning {field}, got: {err:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn accepts_token_budget_at_maximum() {
+        let section = json!({ "defaults": { "contextTokens": 1_000_000_u64 } });
+        assert!(validate_section("agents", &section).is_ok());
     }
 }

--- a/crates/thesauros/src/error.rs
+++ b/crates/thesauros/src/error.rs
@@ -17,7 +17,7 @@ pub enum Error {
         location: snafu::Location,
     },
 
-    /// Manifest file (pack.yaml) not found in pack directory.
+    /// Manifest file (pack.toml) not found in pack directory.
     #[snafu(display("manifest not found: {}", path.display()))]
     ManifestNotFound {
         path: PathBuf,
@@ -34,7 +34,7 @@ pub enum Error {
         location: snafu::Location,
     },
 
-    /// Failed to parse YAML manifest.
+    /// Failed to parse TOML manifest.
     #[snafu(display("failed to parse manifest at {}: {reason}", path.display()))]
     ParseManifest {
         path: PathBuf,
@@ -93,6 +93,24 @@ pub enum Error {
         #[snafu(implicit)]
         location: snafu::Location,
     },
+
+    /// Pack name fails validation (must be 1–64 alphanumeric/hyphen characters).
+    #[snafu(display(
+        "invalid pack name '{name}': must be 1-64 characters, alphanumeric and hyphens only"
+    ))]
+    InvalidPackName {
+        name: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    /// Pack version is an empty string.
+    #[snafu(display("pack '{pack}' has an empty version string"))]
+    InvalidPackVersion {
+        pack: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
 }
 
 /// Convenience alias for results with [`Error`].
@@ -125,12 +143,12 @@ mod tests {
     #[test]
     fn parse_manifest_display() {
         let err = Error::ParseManifest {
-            path: PathBuf::from("/some/pack.yaml"),
+            path: PathBuf::from("/some/pack.toml"),
             reason: "expected mapping".to_owned(),
             location: snafu::Location::new("test", 0, 0),
         };
         let msg = err.to_string();
-        assert!(msg.contains("pack.yaml"));
+        assert!(msg.contains("pack.toml"));
         assert!(msg.contains("expected mapping"));
     }
 

--- a/crates/thesauros/src/lib.rs
+++ b/crates/thesauros/src/lib.rs
@@ -3,7 +3,7 @@
 //! Thesauros (θησαυρός) — "treasure house." Loads external domain packs that
 //! inject context, tools, and configuration overlays into the agent runtime.
 //!
-//! A pack is a directory containing a `pack.yaml` manifest and referenced files.
+//! A pack is a directory containing a `pack.toml` manifest and referenced files.
 //! The loader resolves manifests, reads context files, and returns structured
 //! data for the bootstrap assembler and tool registry to consume.
 //!
@@ -13,7 +13,7 @@
 pub mod error;
 /// Pack loading and context resolution into [`loader::LoadedPack`] values.
 pub mod loader;
-/// Pack manifest parsing — reads `pack.yaml` into [`manifest::PackManifest`].
+/// Pack manifest parsing — reads `pack.toml` into [`manifest::PackManifest`].
 pub mod manifest;
 /// Registration of pack-declared tools into the [`aletheia_organon::registry::ToolRegistry`].
 pub mod tools;

--- a/crates/thesauros/src/manifest.rs
+++ b/crates/thesauros/src/manifest.rs
@@ -120,14 +120,14 @@ pub struct PackPropertyDef {
 
 /// Load and parse a pack manifest from a directory.
 ///
-/// Reads `{pack_root}/pack.yaml`, validates structure, and returns the parsed manifest.
+/// Reads `{pack_root}/pack.toml`, validates structure, and returns the parsed manifest.
 ///
 /// # Errors
 ///
 /// - [`error::Error::PackNotFound`] if `pack_root` does not exist
-/// - [`error::Error::ManifestNotFound`] if `pack.yaml` is missing
+/// - [`error::Error::ManifestNotFound`] if `pack.toml` is missing
 /// - [`error::Error::ReadFile`] if the file cannot be read
-/// - [`error::Error::ParseManifest`] if YAML parsing fails
+/// - [`error::Error::ParseManifest`] if TOML parsing fails
 pub fn load_manifest(pack_root: &Path) -> Result<PackManifest> {
     ensure!(
         pack_root.is_dir(),
@@ -153,7 +153,38 @@ pub fn load_manifest(pack_root: &Path) -> Result<PackManifest> {
             location: snafu::Location::new(file!(), line!(), column!()),
         })?;
 
+    validate_manifest(&manifest)?;
+
     Ok(manifest)
+}
+
+/// Validate pack name and version fields.
+///
+/// Name must be 1–64 characters, alphanumeric and hyphens only.
+/// Version must be non-empty.
+fn validate_manifest(manifest: &PackManifest) -> Result<()> {
+    if !is_valid_pack_name(&manifest.name) {
+        return Err(error::Error::InvalidPackName {
+            name: manifest.name.clone(),
+            location: snafu::Location::new(file!(), line!(), column!()),
+        });
+    }
+
+    if manifest.version.is_empty() {
+        return Err(error::Error::InvalidPackVersion {
+            pack: manifest.name.clone(),
+            location: snafu::Location::new(file!(), line!(), column!()),
+        });
+    }
+
+    Ok(())
+}
+
+/// Returns `true` if the name is 1–64 ASCII alphanumeric/hyphen characters.
+fn is_valid_pack_name(name: &str) -> bool {
+    !name.is_empty()
+        && name.len() <= 64
+        && name.chars().all(|c| c.is_ascii_alphanumeric() || c == '-')
 }
 
 /// Resolve a context entry path relative to the pack root.
@@ -457,5 +488,63 @@ description = "Table name"
             back.input_schema.unwrap().properties["query"].property_type,
             "string"
         );
+    }
+
+    #[test]
+    fn rejects_empty_pack_name() {
+        let dir = setup_pack(&[("pack.toml", "name = \"\"\nversion = \"1.0\"\n")]);
+        let err = load_manifest(dir.path()).unwrap_err();
+        assert!(
+            matches!(err, error::Error::InvalidPackName { .. }),
+            "expected InvalidPackName, got: {err}"
+        );
+    }
+
+    #[test]
+    fn rejects_pack_name_with_invalid_chars() {
+        let dir = setup_pack(&[("pack.toml", "name = \"my pack!\"\nversion = \"1.0\"\n")]);
+        let err = load_manifest(dir.path()).unwrap_err();
+        assert!(
+            matches!(err, error::Error::InvalidPackName { .. }),
+            "expected InvalidPackName, got: {err}"
+        );
+    }
+
+    #[test]
+    fn rejects_pack_name_too_long() {
+        let long_name = "a".repeat(65);
+        let toml = format!("name = \"{long_name}\"\nversion = \"1.0\"\n");
+        let dir = setup_pack(&[("pack.toml", &toml)]);
+        let err = load_manifest(dir.path()).unwrap_err();
+        assert!(
+            matches!(err, error::Error::InvalidPackName { .. }),
+            "expected InvalidPackName, got: {err}"
+        );
+    }
+
+    #[test]
+    fn rejects_empty_pack_version() {
+        let dir = setup_pack(&[("pack.toml", "name = \"my-pack\"\nversion = \"\"\n")]);
+        let err = load_manifest(dir.path()).unwrap_err();
+        assert!(
+            matches!(err, error::Error::InvalidPackVersion { .. }),
+            "expected InvalidPackVersion, got: {err}"
+        );
+    }
+
+    #[test]
+    fn accepts_valid_pack_name_with_hyphens() {
+        let dir = setup_pack(&[("pack.toml", "name = \"my-pack-123\"\nversion = \"1.0\"\n")]);
+        let manifest = load_manifest(dir.path()).unwrap();
+        assert_eq!(manifest.name, "my-pack-123");
+    }
+
+    #[test]
+    fn accepts_pack_name_at_max_length() {
+        let name = "a".repeat(64);
+        let toml = format!("name = \"{name}\"\nversion = \"1.0\"\n");
+        let dir = setup_pack(&[("pack.toml", &toml)]);
+        let manifest = load_manifest(dir.path()).unwrap();
+        assert_eq!(manifest.name.len(), 64);
     }
 }

--- a/crates/thesauros/src/tools.rs
+++ b/crates/thesauros/src/tools.rs
@@ -127,7 +127,11 @@ impl ToolExecutor for ShellToolExecutor {
             };
 
             if output.len() > MAX_OUTPUT_BYTES {
-                output.truncate(MAX_OUTPUT_BYTES);
+                // WHY: truncate() panics when the byte index falls inside a
+                // multi-byte character. floor_char_boundary() rounds down to
+                // the nearest valid char boundary, guaranteeing safety.
+                let boundary = output.floor_char_boundary(MAX_OUTPUT_BYTES);
+                output.truncate(boundary);
                 output.push_str("\n[output truncated]");
             }
 
@@ -148,6 +152,10 @@ pub fn register_pack_tools(packs: &[LoadedPack], registry: &mut ToolRegistry) ->
     let mut errors = Vec::new();
 
     for pack in packs {
+        // Track the error count before processing this pack so we can
+        // compute per-pack failures without affecting counts from prior packs.
+        let errors_before = errors.len();
+
         for tool_def in &pack.manifest.tools {
             match prepare_tool(tool_def, &pack.root, &pack.manifest.name) {
                 Ok((def, executor)) => match registry.register(def, executor) {
@@ -173,7 +181,8 @@ pub fn register_pack_tools(packs: &[LoadedPack], registry: &mut ToolRegistry) ->
         }
 
         if !pack.manifest.tools.is_empty() {
-            let registered = pack.manifest.tools.len() - errors.len();
+            let pack_errors = errors.len() - errors_before;
+            let registered = pack.manifest.tools.len() - pack_errors;
             if registered > 0 {
                 info!(
                     pack = %pack.manifest.name,
@@ -596,5 +605,107 @@ mod tests {
         let errors = register_pack_tools(&[], &mut registry);
         assert!(errors.is_empty());
         assert!(registry.definitions().is_empty());
+    }
+
+    #[test]
+    fn error_count_per_pack_not_cumulative() {
+        // Pack A: one invalid tool (missing command)
+        let dir_a = setup_pack_dir(&[]);
+        let pack_a = minimal_loaded_pack(
+            &dir_a,
+            vec![PackToolDef {
+                name: "bad_tool_a".to_owned(),
+                description: "Missing command".to_owned(),
+                command: "tools/nonexistent.sh".to_owned(),
+                timeout: 5000,
+                input_schema: None,
+            }],
+        );
+
+        // Pack B: one valid tool — must register successfully despite pack A's error.
+        let dir_b = setup_pack_dir(&[("tools/ok.sh", "#!/bin/sh\necho ok")]);
+        make_executable(&dir_b, "tools/ok.sh");
+        let pack_b = minimal_loaded_pack(
+            &dir_b,
+            vec![PackToolDef {
+                name: "good_tool_b".to_owned(),
+                description: "Good tool".to_owned(),
+                command: "tools/ok.sh".to_owned(),
+                timeout: 5000,
+                input_schema: None,
+            }],
+        );
+
+        let mut registry = ToolRegistry::new();
+        let errors = register_pack_tools(&[pack_a, pack_b], &mut registry);
+
+        // Exactly one error from pack A; pack B's tool registers successfully.
+        assert_eq!(
+            errors.len(),
+            1,
+            "expected one error from pack A, got: {errors:?}"
+        );
+        assert_eq!(
+            registry.definitions().len(),
+            1,
+            "pack B's tool should be registered"
+        );
+        assert_eq!(registry.definitions()[0].name.as_str(), "good_tool_b");
+    }
+
+    #[tokio::test]
+    async fn shell_executor_truncates_at_char_boundary() {
+        // Build output that contains a 3-byte UTF-8 sequence (U+2026 HORIZONTAL ELLIPSIS: 0xE2 0x80 0xA6)
+        // placed so it straddles the MAX_OUTPUT_BYTES boundary.
+        //
+        // We use a script that writes a known multi-byte sequence beyond the limit.
+        let ellipsis = "\u{2026}"; // 3 bytes: 0xE2 0x80 0xA6
+        // Fill output to MAX_OUTPUT_BYTES - 1 with ASCII 'a', then append the
+        // ellipsis so bytes [MAX_OUTPUT_BYTES-1 .. MAX_OUTPUT_BYTES+2) are the
+        // three bytes of U+2026. The old truncate() call would panic here.
+        let fill_len = MAX_OUTPUT_BYTES - 1;
+        let fill: String = "a".repeat(fill_len);
+        let full_output = format!("{fill}{ellipsis}extra");
+
+        // Write a script that prints the prepared string.
+        let script_content = format!("#!/bin/sh\nprintf '%s' '{full_output}'");
+        let dir = setup_pack_dir(&[("tools/multibyte.sh", &script_content)]);
+        make_executable(&dir, "tools/multibyte.sh");
+
+        let executor = ShellToolExecutor {
+            command_path: dir
+                .path()
+                .join("tools/multibyte.sh")
+                .canonicalize()
+                .unwrap(),
+            pack_root: dir.path().to_path_buf(),
+            timeout_ms: 5000,
+        };
+
+        let input = ToolInput {
+            name: ToolName::new("mb_tool").unwrap(),
+            tool_use_id: "toolu_mb".to_owned(),
+            arguments: serde_json::json!({}),
+        };
+        let ctx = ToolContext {
+            nous_id: aletheia_koina::id::NousId::new("test").unwrap(),
+            session_id: aletheia_koina::id::SessionId::new(),
+            workspace: dir.path().to_path_buf(),
+            allowed_roots: vec![],
+            services: None,
+            active_tools: std::sync::Arc::new(std::sync::RwLock::new(
+                std::collections::HashSet::new(),
+            )),
+        };
+
+        // Must not panic, and result must be valid UTF-8 ending with the truncation marker.
+        let result = executor.execute(&input, &ctx).await.unwrap();
+        let text = result.content.text_summary();
+        assert!(text.is_char_boundary(0), "result must be valid UTF-8");
+        assert!(
+            text.contains("[output truncated]"),
+            "truncation marker expected"
+        );
+        assert!(text.len() <= MAX_OUTPUT_BYTES + "[output truncated]".len() + 2);
     }
 }


### PR DESCRIPTION
Closes #1046, #1047, #1062, #1076, #1077, #1078, #1079

## Changes

### symbolon
- **#1046 revoked token cleanup:** `initialize()` now deletes expired entries from `revoked_tokens` on every store open. The `cleanup_expired_revocations()` public method remains for callers needing on-demand cleanup.
- **#1047 schema corruption error:** `get_schema_version` now returns `Result<u32>`. It checks `sqlite_master` first (fresh DB → `Ok(0)`); any failure to read from an existing `schema_version` table returns the new `SchemaCorrupted` error variant rather than silently returning 0.

### taxis
- **#1062 model ID and budget validation:** `validate_agents` now rejects empty `model.primary` and empty entries in `model.fallbacks`. Token budget fields (`contextTokens`, `maxOutputTokens`, `bootstrapMaxTokens`, `thinkingBudget`) are capped at `MAX_TOKEN_BUDGET = 1_000_000`.

### thesauros
- **#1076 per-pack error counting:** `register_pack_tools` snapshots `errors.len()` before processing each pack and computes pack-specific failures from the delta. Eliminates cross-pack underflow.
- **#1077 pack.yaml → pack.toml:** All doc comments, module descriptions, and error docs updated to reference `pack.toml`.
- **#1078 UTF-8 safe truncation:** `str::floor_char_boundary(MAX_OUTPUT_BYTES)` replaces the raw `truncate(MAX_OUTPUT_BYTES)` call. Prevents panic when a multi-byte character straddles the byte limit.
- **#1079 pack name/version validation:** `load_manifest` now calls `validate_manifest` after TOML parsing. Pack name must be 1–64 alphanumeric/hyphen characters. Version must be non-empty. Two new error variants: `InvalidPackName`, `InvalidPackVersion`.

## Test coverage
- `store::schema_corruption_returns_error` — deletes schema_version rows and asserts `SchemaCorrupted`
- `validate::rejects_empty_model_primary/fallback/token_budget_exceeding_maximum` — new taxis validation paths
- `tools::error_count_per_pack_not_cumulative` — two-pack scenario verifying isolation
- `tools::shell_executor_truncates_at_char_boundary` — multi-byte UTF-8 spanning the limit
- `manifest::rejects_empty_pack_name/version, rejects_invalid_chars, name_too_long, accepts_max_length` — name/version validation

## Observations
(captured in `~/dianoia/inbox/20260313-small-crate-observations.md`)

- Periodic cleanup of `revoked_tokens` between restarts is not yet scheduled; startup cleanup covers most cases but a background interval task would handle long-running instances better.
- Per-agent model IDs in `agents.list[*].model` are not yet validated (only `agents.defaults.model` is checked).
- Packs rejected by `load_manifest` validation are silently skipped in `load_packs`; consider surfacing them in a startup health report.