### PR TITLE
chore: workspace and CI build hygiene (3 issues)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -59,7 +59,6 @@ jobs:
 
   msrv:
     name: MSRV (1.94)
-    continue-on-error: true
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -116,3 +115,13 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - name: Check migrate-qdrant feature compiles
         run: cargo check -p aletheia --features migrate-qdrant
+
+  embed-candle:
+    name: embed-candle feature
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - name: Check embed-candle feature compiles
+        run: cargo check -p aletheia --features embed-candle

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5082,7 +5082,6 @@ dependencies = [
  "bytes",
  "cookie",
  "cookie_store",
- "futures-channel",
  "futures-core",
  "futures-util",
  "h2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,7 +83,7 @@ toml = "1.0"
 # HTTP
 axum = "0.8"
 utoipa = { version = "5", features = ["axum_extras"] }
-reqwest = { version = "0.13", default-features = false, features = ["rustls-no-provider", "json", "blocking", "http2", "query"] }
+reqwest = { version = "0.13", default-features = false, features = ["rustls-no-provider", "json", "http2", "query"] }
 tower = "0.5"
 tower-http = { version = "0.6", features = ["cors", "compression-gzip", "trace", "limit", "set-header", "fs"] }
 axum-server = { version = "0.8", features = ["tls-rustls"] }
@@ -131,6 +131,12 @@ flate2 = "1"
 rustls = { version = "0.23", default-features = false, features = ["ring", "std", "logging", "tls12"] }
 rcgen = "0.14"
 regex = "1"
+
+# Auth
+jsonwebtoken = { version = "10", features = ["rust_crypto"] }
+
+# Database
+rusqlite = { version = "0.38", features = ["bundled"] }
 
 # String similarity
 strsim = "0.11"

--- a/crates/aletheia/Cargo.toml
+++ b/crates/aletheia/Cargo.toml
@@ -18,6 +18,9 @@ default = ["tui", "recall", "storage-fjall"]
 recall = ["aletheia-nous/knowledge-store", "aletheia-mneme/mneme-engine", "aletheia-mneme/storage-fjall", "aletheia-pylon/knowledge-store"]
 # fjall storage backend for mneme (LSM-tree, pure Rust, LZ4 compression).
 storage-fjall = ["aletheia-mneme/storage-fjall"]
+# Local ML embeddings via candle. Opt-in: not included in default builds.
+# Use: cargo build --features embed-candle
+embed-candle = ["aletheia-mneme/embed-candle"]
 migrate-qdrant = ["dep:qdrant-client", "aletheia-mneme/mneme-engine", "aletheia-mneme/storage-fjall"]
 tls = ["aletheia-pylon/tls"]
 tui = ["dep:theatron-tui"]

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -21,13 +21,10 @@ serde_json = { workspace = true }
 snafu = { workspace = true }
 tokio = { workspace = true, features = ["process"] }
 tokio-util = { workspace = true }
+rusqlite = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]
 static_assertions = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["test-util"] }
-
-[dependencies.rusqlite]
-version = "0.38"
-features = ["bundled"]

--- a/crates/integration-tests/Cargo.toml
+++ b/crates/integration-tests/Cargo.toml
@@ -28,7 +28,7 @@ aletheia-thesauros = { path = "../thesauros" }
 aletheia-pylon = { path = "../pylon" }
 aletheia-symbolon = { path = "../symbolon" }
 jiff = { workspace = true }
-jsonwebtoken = { version = "10", features = ["rust_crypto"] }
+jsonwebtoken = { workspace = true }
 axum = { workspace = true }
 reqwest = { workspace = true }
 rustls = { workspace = true }

--- a/crates/mneme/Cargo.toml
+++ b/crates/mneme/Cargo.toml
@@ -11,7 +11,7 @@ rust-version.workspace = true
 workspace = true
 
 [features]
-default = ["sqlite", "embed-candle", "graph-algo"]
+default = ["sqlite", "graph-algo"]
 graph-algo = []
 sqlite = ["dep:rusqlite"]
 embed-candle = ["dep:candle-core", "dep:candle-nn", "dep:candle-transformers", "dep:tokenizers", "dep:hf-hub"]
@@ -37,7 +37,7 @@ hnsw_rs = ["dep:hnsw_rs"]
 [dependencies]
 jiff = { workspace = true, features = ["serde"] }
 ndarray = { version = "0.17", features = ["serde"], optional = true }
-rusqlite = { version = "0.38", features = ["bundled"], optional = true }
+rusqlite = { workspace = true, optional = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 snafu = { workspace = true }
@@ -57,12 +57,12 @@ crossbeam = { version = "0.8.4", optional = true }
 itertools = { version = "0.14.0", optional = true }
 rustc-hash = { version = "2.1.1", optional = true }
 twox-hash = { version = "2.1", optional = true }
-regex = { version = "1", optional = true }
+regex = { workspace = true, optional = true }
 sha2 = { version = "0.10", optional = true }
 either = { version = "1", optional = true }
-rand = { version = "0.9", optional = true }
-base64 = { version = "0.22", optional = true }
-uuid = { version = "1", features = ["v1", "v4", "serde"], optional = true }
+rand = { workspace = true, optional = true }
+base64 = { workspace = true, optional = true }
+uuid = { workspace = true, features = ["v1", "serde"], optional = true }
 pest = { version = "2.8", optional = true }
 pest_derive = { version = "2.8", optional = true }
 strsim = { workspace = true }

--- a/crates/mneme/src/embedding.rs
+++ b/crates/mneme/src/embedding.rs
@@ -398,7 +398,10 @@ mod candle_provider {
         }
     }
 
-    #[allow(clippy::items_after_test_module, reason = "test module accesses private CandelProvider methods")]
+    #[allow(
+        clippy::items_after_test_module,
+        reason = "test module accesses private CandelProvider methods"
+    )]
     impl EmbeddingProvider for CandelProvider {
         #[instrument(skip(self, text))]
         fn embed(&self, text: &str) -> EmbeddingResult<Vec<f32>> {

--- a/crates/pylon/Cargo.toml
+++ b/crates/pylon/Cargo.toml
@@ -60,7 +60,7 @@ http-body-util = "0.1"
 jiff = { workspace = true }
 # jsonwebtoken 10.x pins rand 0.8; no released version uses rand 0.9.
 # This causes a duplicate rand in the binary. Track: https://github.com/Keats/jsonwebtoken/issues
-jsonwebtoken = { version = "10", features = ["rust_crypto"] }
+jsonwebtoken = { workspace = true }
 reqwest = { workspace = true }
 secrecy = { workspace = true }
 static_assertions = { workspace = true }

--- a/crates/symbolon/Cargo.toml
+++ b/crates/symbolon/Cargo.toml
@@ -15,11 +15,12 @@ aletheia-koina = { path = "../koina" }
 argon2 = { version = "0.5", features = ["std"] }
 blake3 = "1"
 # jsonwebtoken 10.x pins rand 0.8; no released version uses rand 0.9.
-# This causes a duplicate rand 0.8 in the binary (rand 0.9 is the workspace version).
-jsonwebtoken = { version = "10", features = ["rust_crypto"] }
-rand = "0.9"
+# rand is declared explicitly to ensure the workspace 0.9 version is resolved
+# rather than the older 0.8 that jsonwebtoken transitively requires.
+jsonwebtoken = { workspace = true }
+rand = { workspace = true }
 reqwest = { workspace = true }
-rusqlite = { version = "0.38", features = ["bundled"] }
+rusqlite = { workspace = true }
 secrecy = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }


### PR DESCRIPTION
Closes #1109, #1110, #1111

## Changes

- **embed-candle opt-in** (#1109): removed from `aletheia-mneme` default features. The binary crate (`aletheia`) gains an explicit `embed-candle = ["aletheia-mneme/embed-candle"]` feature. Default `cargo build` no longer pulls in candle-core, candle-nn, candle-transformers, tokenizers, or hf-hub. CI gains an `embed-candle` job that verifies the feature compiles.

- **Dep hoisting** (#1110): `rusqlite` and `jsonwebtoken` hoisted to `[workspace.dependencies]`; three crates each now use `workspace = true`. `rand`, `base64`, and `regex` optional deps in `aletheia-mneme` also switched to workspace references (versions already matched). Reqwest `blocking` feature removed from workspace — no code in the workspace uses `reqwest::blocking`.

- **MSRV enforcement** (#1111): `continue-on-error: true` removed from the `msrv` job in `rust.yml`. MSRV breakage now fails CI. All CI actions were already pinned to SHA hashes on `origin/main` — no additional pinning needed.

## Observations

- All GitHub Actions were already SHA-pinned before this PR. Issue #1111's "pin CI actions" subtask was satisfied on `main`; only the `continue-on-error` removal was outstanding.
- `crates/mneme/src/embedding.rs` had a pre-existing rustfmt violation (`#[allow(...)]` attribute needed multi-line formatting). Fixed as necessary for `cargo fmt --check` to pass. File is outside the blast radius for Cargo.toml changes; noted in `~/dianoia/inbox/build-hygiene-407-observations.md`.
- The `#[allow(clippy::items_after_test_module, ...)]` in `embedding.rs` should be `#[expect]` per RUST.md. Out of scope here — needs a tracking issue.
- `timeout 120 cargo test --workspace` assumes a warm CI cache. On a cold local cache, compilation alone takes ~5 minutes; tests pass when given adequate time.