### PR TITLE
fix(mneme): race conditions, constraints, and indexes (5 issues)

### DIFF
--- a/crates/mneme/src/embedding.rs
+++ b/crates/mneme/src/embedding.rs
@@ -398,7 +398,10 @@ mod candle_provider {
         }
     }
 
-    #[allow(clippy::items_after_test_module, reason = "test module accesses private CandelProvider methods")]
+    #[allow(
+        clippy::items_after_test_module,
+        reason = "test module accesses private CandelProvider methods"
+    )]
     impl EmbeddingProvider for CandelProvider {
         #[instrument(skip(self, text))]
         fn embed(&self, text: &str) -> EmbeddingResult<Vec<f32>> {

--- a/crates/mneme/src/knowledge_store/mod.rs
+++ b/crates/mneme/src/knowledge_store/mod.rs
@@ -637,34 +637,6 @@ impl KnowledgeStore {
 
     // --- Internal helpers ---
 
-    /// Query all facts valid at a specific time, across all nous IDs.
-    /// Used internally by `search_temporal` for filtering.
-    pub(super) fn query_facts_at_time_all(
-        &self,
-        at_time: &str,
-    ) -> crate::error::Result<Vec<crate::knowledge::Fact>> {
-        use crate::engine::DataValue;
-        use std::collections::BTreeMap;
-
-        let script = r"
-            ?[id, content, confidence, tier, recorded_at, nous_id, valid_from, valid_to,
-              superseded_by, source_session_id,
-              access_count, last_accessed_at, stability_hours, fact_type,
-              is_forgotten, forgotten_at, forget_reason] :=
-                *facts{id, valid_from, content, nous_id, confidence, tier, valid_to,
-                       superseded_by, source_session_id, recorded_at,
-                       access_count, last_accessed_at, stability_hours, fact_type,
-                       is_forgotten, forgotten_at, forget_reason},
-                is_forgotten == false,
-                valid_from <= $at_time,
-                valid_to > $at_time
-        ";
-        let mut params = BTreeMap::new();
-        params.insert("at_time".to_owned(), DataValue::Str(at_time.into()));
-        let rows = self.run_read(script, params)?;
-        marshal::rows_to_facts(rows, "")
-    }
-
     /// Read a single fact by its ID (all temporal records matching).
     /// Returns all fields; does not apply time/validity filters.
     pub(super) fn read_facts_by_id(

--- a/crates/mneme/src/knowledge_store/search.rs
+++ b/crates/mneme/src/knowledge_store/search.rs
@@ -1,5 +1,6 @@
 use super::marshal::{
-    build_hybrid_query, embedding_to_params, rows_to_hybrid_results, rows_to_recall_results,
+    build_hybrid_query, embedding_to_params, extract_str, rows_to_hybrid_results,
+    rows_to_recall_results,
 };
 use super::{HybridQuery, HybridResult, KnowledgeStore, queries};
 use tracing::instrument;
@@ -381,19 +382,65 @@ impl KnowledgeStore {
         at_time: &str,
     ) -> crate::error::Result<Vec<HybridResult>> {
         let all_results = self.search_hybrid(q)?;
+        if all_results.is_empty() {
+            return Ok(all_results);
+        }
 
-        // Get the set of fact IDs valid at the given time
-        // We query with an empty nous_id filter to get all facts across all agents
-        let valid_facts = self.query_facts_at_time_all(at_time)?;
-        let valid_ids: std::collections::HashSet<&str> =
-            valid_facts.iter().map(|f| f.id.as_str()).collect();
+        // WHY: Query only the O(k) candidate IDs for temporal validity rather than
+        // loading all facts in the store. This replaces the former full-scan via
+        // query_facts_at_time_all. The is_forgotten check is also inlined so there
+        // is no separate N+1 query for forgotten filtering.
+        let candidate_ids: Vec<&str> = all_results.iter().map(|r| r.id.as_str()).collect();
+        let valid_ids = self.query_ids_valid_at(at_time, &candidate_ids)?;
 
-        let filtered: Vec<HybridResult> = all_results
+        Ok(all_results
             .into_iter()
             .filter(|r| valid_ids.contains(r.id.as_str()))
+            .collect())
+    }
+
+    /// Return the subset of `ids` that are not forgotten and whose validity
+    /// window contains `at_time` (`valid_from <= at_time < valid_to`).
+    fn query_ids_valid_at(
+        &self,
+        at_time: &str,
+        ids: &[&str],
+    ) -> crate::error::Result<std::collections::HashSet<String>> {
+        use crate::engine::DataValue;
+        use std::collections::BTreeMap;
+
+        if ids.is_empty() {
+            return Ok(std::collections::HashSet::new());
+        }
+
+        // Build an inline id list for Datalog's `in` operator.
+        let id_list: Vec<String> = ids
+            .iter()
+            .map(|id| format!("'{}'", id.replace('\'', "''")))
             .collect();
 
-        Ok(filtered)
+        let script = format!(
+            "?[id] := *facts{{id, valid_from, valid_to, is_forgotten}},
+                      is_forgotten == false,
+                      valid_from <= $at_time,
+                      valid_to > $at_time,
+                      id in [{}]",
+            id_list.join(", ")
+        );
+
+        let mut params = BTreeMap::new();
+        params.insert("at_time".to_owned(), DataValue::Str(at_time.into()));
+
+        let rows = self.run_read(&script, params)?;
+        let mut result = std::collections::HashSet::new();
+        for row in rows.rows {
+            if let Some(val) = row.first()
+                && let Ok(s) = extract_str(val)
+            {
+                result.insert(s);
+            }
+        }
+        Ok(result)
     }
 
     /// Async `search_temporal` wrapper.

--- a/crates/mneme/src/migration.rs
+++ b/crates/mneme/src/migration.rs
@@ -53,6 +53,93 @@ CREATE INDEX IF NOT EXISTS idx_blackboard_expires ON blackboard(expires_at);",
         up: "ALTER TABLE sessions ADD COLUMN display_name TEXT;",
         down: "ALTER TABLE sessions DROP COLUMN display_name;",
     },
+    Migration {
+        version: 4,
+        description: "add ON DELETE CASCADE to FK references, UNIQUE(session_id, turn_seq) on usage, hot-path indexes",
+        // WHY: SQLite cannot ALTER a table to add ON DELETE CASCADE or new UNIQUE
+        // constraints on existing columns. The standard workaround is to recreate
+        // the affected tables within a single transaction. DROP TABLE is DDL and
+        // does not trigger row-level FK enforcement, so PRAGMA foreign_keys = OFF
+        // is not required here.
+        up: "CREATE TABLE messages_new (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+  seq INTEGER NOT NULL,
+  role TEXT NOT NULL CHECK(role IN ('system', 'user', 'assistant', 'tool_result')),
+  content TEXT NOT NULL,
+  tool_call_id TEXT,
+  tool_name TEXT,
+  token_estimate INTEGER DEFAULT 0,
+  is_distilled INTEGER DEFAULT 0,
+  created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+  UNIQUE(session_id, seq)
+);
+INSERT INTO messages_new
+  SELECT id, session_id, seq, role, content, tool_call_id, tool_name,
+         token_estimate, is_distilled, created_at
+  FROM messages;
+DROP TABLE messages;
+ALTER TABLE messages_new RENAME TO messages;
+CREATE INDEX IF NOT EXISTS idx_messages_session ON messages(session_id, seq);
+CREATE INDEX IF NOT EXISTS idx_messages_distilled ON messages(session_id, is_distilled, seq);
+
+CREATE TABLE usage_new (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+  turn_seq INTEGER NOT NULL,
+  input_tokens INTEGER DEFAULT 0,
+  output_tokens INTEGER DEFAULT 0,
+  cache_read_tokens INTEGER DEFAULT 0,
+  cache_write_tokens INTEGER DEFAULT 0,
+  model TEXT,
+  created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+  UNIQUE(session_id, turn_seq)
+);
+INSERT INTO usage_new
+  SELECT id, session_id, turn_seq, input_tokens, output_tokens,
+         cache_read_tokens, cache_write_tokens, model, created_at
+  FROM usage;
+DROP TABLE usage;
+ALTER TABLE usage_new RENAME TO usage;
+CREATE INDEX IF NOT EXISTS idx_usage_session ON usage(session_id);
+
+CREATE TABLE distillations_new (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+  messages_before INTEGER NOT NULL,
+  messages_after INTEGER NOT NULL,
+  tokens_before INTEGER NOT NULL,
+  tokens_after INTEGER NOT NULL,
+  facts_extracted INTEGER DEFAULT 0,
+  model TEXT,
+  created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+);
+INSERT INTO distillations_new
+  SELECT id, session_id, messages_before, messages_after, tokens_before,
+         tokens_after, facts_extracted, model, created_at
+  FROM distillations;
+DROP TABLE distillations;
+ALTER TABLE distillations_new RENAME TO distillations;
+CREATE INDEX IF NOT EXISTS idx_distillations_session ON distillations(session_id);
+
+CREATE TABLE agent_notes_new (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+  nous_id TEXT NOT NULL,
+  category TEXT NOT NULL DEFAULT 'context' CHECK(category IN ('task', 'decision', 'preference', 'correction', 'context')),
+  content TEXT NOT NULL,
+  created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+);
+INSERT INTO agent_notes_new
+  SELECT id, session_id, nous_id, category, content, created_at
+  FROM agent_notes;
+DROP TABLE agent_notes;
+ALTER TABLE agent_notes_new RENAME TO agent_notes;
+CREATE INDEX IF NOT EXISTS idx_notes_session ON agent_notes(session_id);
+CREATE INDEX IF NOT EXISTS idx_notes_nous ON agent_notes(nous_id);",
+        down: "DROP INDEX IF EXISTS idx_messages_distilled;
+DROP INDEX IF EXISTS idx_distillations_session;",
+    },
 ];
 
 /// Outcome of a migration run.
@@ -223,8 +310,8 @@ mod tests {
             run_migrations(&conn).expect("migrations should apply successfully to a fresh DB");
 
         assert!(result.was_fresh);
-        assert_eq!(result.applied, vec![1, 2, 3]);
-        assert_eq!(result.current_version, 3);
+        assert_eq!(result.applied, vec![1, 2, 3, 4]);
+        assert_eq!(result.current_version, 4);
     }
 
     #[test]
@@ -235,7 +322,7 @@ mod tests {
         let result = run_migrations(&conn).expect("second migration run on same DB should succeed");
         assert!(!result.was_fresh);
         assert!(result.applied.is_empty());
-        assert_eq!(result.current_version, 3);
+        assert_eq!(result.current_version, 4);
     }
 
     #[test]
@@ -262,7 +349,7 @@ mod tests {
 
         let pending = check_migrations(&conn)
             .expect("check_migrations should return pending list without applying");
-        assert_eq!(pending.len(), 3);
+        assert_eq!(pending.len(), 4);
         assert_eq!(pending[0].version, 1);
 
         // Verify nothing was applied
@@ -321,9 +408,9 @@ mod tests {
     fn run_migrations_fresh_db_schema_version() {
         let conn = fresh_conn();
         let result = run_migrations(&conn).expect("migrations should apply to fresh DB");
-        assert_eq!(result.current_version, 3);
+        assert_eq!(result.current_version, 4);
         let version = get_schema_version(&conn);
-        assert_eq!(version, 3);
+        assert_eq!(version, 4);
     }
 
     #[test]
@@ -370,12 +457,12 @@ mod tests {
         conn.execute("INSERT INTO schema_version (version) VALUES (1)", [])
             .expect("inserting v1 schema_version record should succeed");
 
-        // Running migrations should detect existing v1 and apply v2+v3
+        // Running migrations should detect existing v1 and apply v2+v3+v4
         let result =
-            run_migrations(&conn).expect("migrations should apply v2 and v3 to a v1 database");
+            run_migrations(&conn).expect("migrations should apply v2, v3, v4 to a v1 database");
         assert!(!result.was_fresh);
-        assert_eq!(result.applied, vec![2, 3]);
-        assert_eq!(result.current_version, 3);
+        assert_eq!(result.applied, vec![2, 3, 4]);
+        assert_eq!(result.current_version, 4);
 
         // description column should have been added
         assert!(has_description_column(&conn));

--- a/crates/mneme/src/schema.rs
+++ b/crates/mneme/src/schema.rs
@@ -42,7 +42,7 @@ CREATE INDEX IF NOT EXISTS idx_sessions_thread ON sessions(thread_id);
 
 CREATE TABLE IF NOT EXISTS messages (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
-  session_id TEXT NOT NULL REFERENCES sessions(id),
+  session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
   seq INTEGER NOT NULL,
   role TEXT NOT NULL CHECK(role IN ('system', 'user', 'assistant', 'tool_result')),
   content TEXT NOT NULL,
@@ -55,24 +55,26 @@ CREATE TABLE IF NOT EXISTS messages (
 );
 
 CREATE INDEX IF NOT EXISTS idx_messages_session ON messages(session_id, seq);
+CREATE INDEX IF NOT EXISTS idx_messages_distilled ON messages(session_id, is_distilled, seq);
 
 CREATE TABLE IF NOT EXISTS usage (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
-  session_id TEXT NOT NULL REFERENCES sessions(id),
+  session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
   turn_seq INTEGER NOT NULL,
   input_tokens INTEGER DEFAULT 0,
   output_tokens INTEGER DEFAULT 0,
   cache_read_tokens INTEGER DEFAULT 0,
   cache_write_tokens INTEGER DEFAULT 0,
   model TEXT,
-  created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+  created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+  UNIQUE(session_id, turn_seq)
 );
 
 CREATE INDEX IF NOT EXISTS idx_usage_session ON usage(session_id);
 
 CREATE TABLE IF NOT EXISTS distillations (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
-  session_id TEXT NOT NULL REFERENCES sessions(id),
+  session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
   messages_before INTEGER NOT NULL,
   messages_after INTEGER NOT NULL,
   tokens_before INTEGER NOT NULL,
@@ -82,9 +84,11 @@ CREATE TABLE IF NOT EXISTS distillations (
   created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
 );
 
+CREATE INDEX IF NOT EXISTS idx_distillations_session ON distillations(session_id);
+
 CREATE TABLE IF NOT EXISTS agent_notes (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
-  session_id TEXT NOT NULL REFERENCES sessions(id),
+  session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
   nous_id TEXT NOT NULL,
   category TEXT NOT NULL DEFAULT 'context' CHECK(category IN ('task', 'decision', 'preference', 'correction', 'context')),
   content TEXT NOT NULL,
@@ -107,7 +111,7 @@ mod tests {
     fn fresh_database_initializes_via_migration() {
         let conn = Connection::open_in_memory().expect("in-memory SQLite opens");
         let result = migration::run_migrations(&conn).expect("initial migration succeeds");
-        assert_eq!(result.current_version, 3);
+        assert_eq!(result.current_version, 4);
     }
 
     #[test]
@@ -117,7 +121,7 @@ mod tests {
         migration::run_migrations(&conn).expect("idempotent second migration succeeds");
 
         let version = migration::get_schema_version(&conn);
-        assert_eq!(version, 3);
+        assert_eq!(version, 4);
     }
 
     #[test]

--- a/crates/mneme/src/store/message.rs
+++ b/crates/mneme/src/store/message.rs
@@ -26,20 +26,25 @@ impl SessionStore {
             .unchecked_transaction()
             .context(error::DatabaseSnafu)?;
 
+        // WHY: INSERT...SELECT computes the next seq within the INSERT statement,
+        // eliminating the TOCTOU window that existed when a separate SELECT was
+        // followed by a separate INSERT. The aggregate MAX() always returns one row
+        // even when no messages exist yet, so COALESCE handles the empty-session case.
+        tx.execute(
+            "INSERT INTO messages (session_id, seq, role, content, tool_call_id, tool_name, token_estimate, is_distilled)
+             SELECT ?1, COALESCE(MAX(seq), 0) + 1, ?2, ?3, ?4, ?5, ?6, 0
+             FROM messages WHERE session_id = ?1",
+            rusqlite::params![session_id, role.as_str(), content, tool_call_id, tool_name, token_estimate],
+        )
+        .context(error::DatabaseSnafu)?;
+
         let next_seq: i64 = tx
             .query_row(
-                "SELECT COALESCE(MAX(seq), 0) + 1 FROM messages WHERE session_id = ?1",
-                [session_id],
+                "SELECT seq FROM messages WHERE id = last_insert_rowid()",
+                [],
                 |row| row.get(0),
             )
             .context(error::DatabaseSnafu)?;
-
-        tx.execute(
-            "INSERT INTO messages (session_id, seq, role, content, tool_call_id, tool_name, token_estimate, is_distilled)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, 0)",
-            rusqlite::params![session_id, next_seq, role.as_str(), content, tool_call_id, tool_name, token_estimate],
-        )
-        .context(error::DatabaseSnafu)?;
 
         tx.execute(
             "UPDATE sessions SET message_count = message_count + 1, token_count_estimate = token_count_estimate + ?1, updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now') WHERE id = ?2",

--- a/crates/mneme/src/store/session.rs
+++ b/crates/mneme/src/store/session.rs
@@ -84,36 +84,53 @@ impl SessionStore {
         model: Option<&str>,
         parent_session_id: Option<&str>,
     ) -> Result<Session> {
-        // Check for active session
-        if let Some(session) = self.find_session(nous_id, session_key)? {
-            return Ok(session);
-        }
+        let session_type = SessionType::from_key(session_key);
 
-        // Check for archived/distilled session — reactivate
-        let mut stmt = self
+        // WHY: Atomic conditional insert. ON CONFLICT(nous_id, session_key) DO NOTHING
+        // eliminates the TOCTOU window between "check if exists" and "create if not".
+        // Two concurrent callers both reach this INSERT; one wins, one is silently
+        // ignored. Both then SELECT the same row below.
+        let rows_inserted = self
             .conn
-            .prepare_cached(
-                "SELECT id FROM sessions WHERE nous_id = ?1 AND session_key = ?2 AND status != 'active' ORDER BY updated_at DESC LIMIT 1",
+            .execute(
+                "INSERT INTO sessions (id, nous_id, session_key, parent_session_id, model, session_type)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+                 ON CONFLICT(nous_id, session_key) DO NOTHING",
+                rusqlite::params![id, nous_id, session_key, parent_session_id, model, session_type.as_str()],
             )
             .context(error::DatabaseSnafu)?;
 
-        let archived_id: Option<String> = stmt
-            .query_row([nous_id, session_key], |row| row.get(0))
-            .optional()
+        if rows_inserted > 0 {
+            info!(id, nous_id, session_key, %session_type, "created session");
+        }
+
+        // Fetch the session — either just-created or pre-existing.
+        let mut stmt = self
+            .conn
+            .prepare_cached("SELECT * FROM sessions WHERE nous_id = ?1 AND session_key = ?2")
             .context(error::DatabaseSnafu)?;
 
-        if let Some(archived_id) = archived_id {
+        let session = stmt
+            .query_row([nous_id, session_key], map_session)
+            .optional()
+            .context(error::DatabaseSnafu)?
+            .ok_or_else(|| {
+                error::SessionCreateSnafu {
+                    nous_id: nous_id.to_owned(),
+                }
+                .build()
+            })?;
+
+        // Reactivate if the existing session is not active.
+        if session.status != SessionStatus::Active {
             self.conn
                 .execute(
                     "UPDATE sessions SET status = 'active', updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now') WHERE id = ?1",
-                    [&archived_id],
+                    [&session.id],
                 )
                 .context(error::DatabaseSnafu)?;
-            info!(
-                id = archived_id,
-                nous_id, session_key, "reactivated archived session"
-            );
-            return self.find_session_by_id(&archived_id)?.ok_or_else(|| {
+            info!(id = session.id, nous_id, session_key, "reactivated session");
+            return self.find_session_by_id(&session.id)?.ok_or_else(|| {
                 error::SessionCreateSnafu {
                     nous_id: nous_id.to_owned(),
                 }
@@ -121,8 +138,7 @@ impl SessionStore {
             });
         }
 
-        // Create new
-        self.create_session(id, nous_id, session_key, parent_session_id, model)
+        Ok(session)
     }
 
     /// List sessions, optionally filtered by nous ID.


### PR DESCRIPTION
Closes #1058, #1059, #1060, #1061, #1118

## Changes

- **Atomic sequence counter (#1058):** `append_message` now uses `INSERT...SELECT` so the next `seq` is computed inside the INSERT statement itself. The previous read-then-insert pattern had a TOCTOU window where two concurrent writers could read the same `MAX(seq)` before either committed.

- **Session upsert (#1059):** `find_or_create_session` now issues `INSERT ... ON CONFLICT(nous_id, session_key) DO NOTHING` as its first step. Both concurrent callers land on the same row; the winner inserts, the loser silently skips. Both then SELECT the row and handle reactivation if needed. Replaces the three-step check-active / check-archived / create pattern.

- **Unique constraints and FK cascades (#1060):** Migration v4 recreates `messages`, `usage`, `distillations`, and `agent_notes` with `ON DELETE CASCADE` on their `session_id` foreign key. Adds `UNIQUE(session_id, turn_seq)` to `usage` so the `usage_exists_for_turn` check-before-insert pattern is backed by a hard constraint. SQLite does not support `ALTER TABLE ADD CONSTRAINT`, so table recreation inside a single transaction is the standard approach. `DROP TABLE` is DDL and does not trigger row-level FK enforcement, so `PRAGMA foreign_keys = OFF` is not needed.

- **Hot-path indexes (#1061):** Added `idx_messages_distilled(session_id, is_distilled, seq)` to serve `WHERE session_id = ? AND is_distilled = 0 ORDER BY seq` queries without a post-index filter pass. Added `idx_distillations_session(session_id)` for session-scoped distillation lookups.

- **`search_temporal` query-level filtering (#1118):** Replaced the full scan via `query_facts_at_time_all` (which loaded every valid fact in the store) with `query_ids_valid_at`, which checks only the O(k) candidate IDs returned by the hybrid search. The `is_forgotten` filter is inlined into the same Datalog query, eliminating the separate N+1 query that previously existed. Removed the now-dead `query_facts_at_time_all` function.

## Observations

- `crates/mneme/src/embedding.rs` had a pre-existing rustfmt violation (long `#[allow]` attribute not wrapped). Fixed as a prerequisite to pass `cargo fmt --check`.