### PR TITLE
refactor(mneme): engine nesting and function length (2 issues)

### DIFF
--- a/crates/mneme/src/engine/parse/query.rs
+++ b/crates/mneme/src/engine/parse/query.rs
@@ -31,7 +31,7 @@ use crate::engine::fixed_rule::FixedRuleHandle;
 use crate::engine::fixed_rule::utilities::constant::Constant;
 use crate::engine::parse::expr::build_expr;
 use crate::engine::parse::schema::parse_schema;
-use crate::engine::parse::{DatalogParser, ExtractSpan, Pair, Pairs, Rule};
+use crate::engine::parse::{DatalogParser, ExtractSpan, Pair, Pairs, Rule, SourceSpan};
 use crate::engine::runtime::relation::InputRelationHandle;
 
 pub(crate) fn parse_query(
@@ -43,373 +43,52 @@ pub(crate) fn parse_query(
     let mut progs: BTreeMap<Symbol, InputInlineRulesOrFixed> = Default::default();
     let mut out_opts: QueryOutOptions = Default::default();
     let mut disable_magic_rewrite = false;
-
     let mut stored_relation = None;
     let mut returning_mutation = ReturnMutation::NotReturning;
 
     for pair in src {
         match pair.as_rule() {
-            Rule::rule => {
-                let (name, rule) = parse_rule(pair, param_pool, cur_vld)?;
-
-                match progs.entry(name) {
-                    Entry::Vacant(e) => {
-                        e.insert(InputInlineRulesOrFixed::Rules { rules: vec![rule] });
-                    }
-                    Entry::Occupied(mut e) => {
-                        let key = e.key().to_string();
-                        match e.get_mut() {
-                            InputInlineRulesOrFixed::Rules { rules: rs } => {
-                                let prev = rs
-                                    .first()
-                                    .expect("rules vec always has at least one element");
-                                if prev.aggr != rule.aggr {
-                                    return Err(InvalidQuerySnafu {
-                                        message: format!("Rule {key} has multiple definitions with conflicting heads")
-                                    }
-                                    .build().into());
-                                }
-
-                                rs.push(rule);
-                            }
-                            InputInlineRulesOrFixed::Fixed { .. } => {
-                                return Err(InvalidQuerySnafu {
-                                    message: format!(
-                                        "The rule '{}' cannot have multiple definitions since it contains non-Horn clauses",
-                                        e.key().name
-                                    )
-                                }
-                                .build().into())
-                            }
-                        }
-                    }
-                }
-            }
+            Rule::rule => add_rule_to_program(pair, param_pool, cur_vld, &mut progs)?,
             Rule::fixed_rule => {
-                let (name, apply) = parse_fixed_rule(pair, param_pool, fixed_rules, cur_vld)?;
-
-                match progs.entry(name) {
-                    Entry::Vacant(e) => {
-                        e.insert(InputInlineRulesOrFixed::Fixed { fixed: apply });
-                    }
-                    Entry::Occupied(e) => {
-                        let found_name = e.key().name.to_string();
-                        return Err(InvalidQuerySnafu {
-                            message: format!(
-                                "The rule '{found_name}' cannot have multiple definitions since it contains non-Horn clauses"
-                            )
-                        }
-                        .build().into());
-                    }
-                }
+                add_fixed_rule_to_program(pair, param_pool, fixed_rules, cur_vld, &mut progs)?;
             }
-            Rule::const_rule => {
-                let span = pair.extract_span();
-                let mut src = pair.into_inner();
-                let (name, mut head, aggr) =
-                    parse_rule_head(src.next().expect("pest guarantees rule head"), param_pool)?;
-
-                if progs.contains_key(&name) {
-                    return Err(InvalidQuerySnafu {
-                        message: format!(
-                            "The rule '{}' cannot have multiple definitions since it contains non-Horn clauses",
-                            name.name
-                        )
-                    }
-                    .build().into());
-                }
-
-                for (a, _v) in aggr.iter().zip(head.iter()) {
-                    if a.is_some() {
-                        return Err(InvalidQuerySnafu {
-                            message: "Constant rules cannot have aggregation application"
-                                .to_string(),
-                        }
-                        .build()
-                        .into());
-                    }
-                }
-                let data_part = src
-                    .next()
-                    .expect("pest guarantees data part after rule head");
-                let data_part_str = data_part.as_str();
-                let data = build_expr(data_part.clone(), param_pool)?;
-                let mut options = BTreeMap::new();
-                options.insert(CompactString::from("data"), data);
-                let handle = FixedRuleHandle {
-                    name: Symbol::new("Constant", span),
-                };
-                let fixed_impl = Box::new(Constant);
-                fixed_impl.init_options(&mut options, span)?;
-                let arity = fixed_impl.arity(&options, &head, span)?;
-
-                if arity == 0 {
-                    return Err(InvalidQuerySnafu {
-                        message: "Encountered empty row for constant rule".to_string(),
-                    }
-                    .build()
-                    .into());
-                }
-                if !head.is_empty() && arity != head.len() {
-                    return Err(InvalidQuerySnafu {
-                        message: "Fixed rule head arity mismatch".to_string(),
-                    }
-                    .build()
-                    .into());
-                }
-                if head.is_empty()
-                    && name.is_prog_entry()
-                    && let Ok(mut datalist) = DatalogParser::parse(Rule::param_list, data_part_str)
-                {
-                    for s in datalist
-                        .next()
-                        .expect("pest guarantees param_list token")
-                        .into_inner()
-                    {
-                        if s.as_rule() == Rule::param {
-                            head.push(Symbol::new(
-                                s.as_str()
-                                    .strip_prefix('$')
-                                    .expect("pest guarantees $ prefix on param"),
-                                Default::default(),
-                            ));
-                        }
-                    }
-                }
-                progs.insert(
-                    name,
-                    InputInlineRulesOrFixed::Fixed {
-                        fixed: FixedRuleApply {
-                            fixed_handle: handle,
-                            rule_args: vec![],
-                            options: Arc::new(options),
-                            head,
-                            arity,
-                            span,
-                            fixed_impl: Arc::new(fixed_impl),
-                        },
-                    },
-                );
-            }
+            Rule::const_rule => add_const_rule_to_program(pair, param_pool, &mut progs)?,
             Rule::timeout_option => {
-                let pair = pair
-                    .into_inner()
-                    .next()
-                    .expect("pest guarantees timeout value");
-                let _span = pair.extract_span();
-                let timeout = build_expr(pair, param_pool)?
-                    .eval_to_const()
-                    .map_err(|_err| {
-                        InvalidQuerySnafu {
-                            message: "Query option is not constant".to_string(),
-                        }
-                        .build()
-                    })?
-                    .get_float()
-                    .ok_or_else(|| {
-                        InvalidQuerySnafu {
-                            message: "Query option requires a non-negative number".to_string(),
-                        }
-                        .build()
-                    })?;
-                if timeout > 0. {
-                    out_opts.timeout = Some(timeout);
-                } else {
-                    out_opts.timeout = None;
-                }
+                let timeout = parse_query_option_float(pair, param_pool)?;
+                out_opts.timeout = if timeout > 0. { Some(timeout) } else { None };
             }
             Rule::sleep_option => {
-                #[cfg(target_arch = "wasm32")]
-                return Err(InvalidQuerySnafu {
-                    message: ":sleep is not supported under WASM".to_string(),
-                }
-                .build()
-                .into());
-
-                #[cfg(not(target_arch = "wasm32"))]
-                {
-                    let pair = pair
-                        .into_inner()
-                        .next()
-                        .expect("pest guarantees sleep value");
-                    let _span = pair.extract_span();
-                    let sleep = build_expr(pair, param_pool)?
-                        .eval_to_const()
-                        .map_err(|_err| {
-                            InvalidQuerySnafu {
-                                message: "Query option is not constant".to_string(),
-                            }
-                            .build()
-                        })?
-                        .get_float()
-                        .ok_or_else(|| {
-                            InvalidQuerySnafu {
-                                message: "Query option requires a non-negative number".to_string(),
-                            }
-                            .build()
-                        })?;
-                    if sleep <= 0. {
-                        return Err(InvalidQuerySnafu {
-                            message: "Query option :sleep requires a positive integer".to_string(),
-                        }
-                        .build()
-                        .into());
-                    }
-                    out_opts.sleep = Some(sleep);
-                }
+                out_opts.sleep = Some(parse_sleep_option(pair, param_pool)?);
             }
             Rule::limit_option => {
-                let pair = pair
-                    .into_inner()
-                    .next()
-                    .expect("pest guarantees limit value");
-                let _span = pair.extract_span();
-                let limit = build_expr(pair, param_pool)?
-                    .eval_to_const()
-                    .map_err(|_err| {
-                        InvalidQuerySnafu {
-                            message: "Query option is not constant".to_string(),
-                        }
-                        .build()
-                    })?
-                    .get_non_neg_int()
-                    .ok_or_else(|| {
-                        InvalidQuerySnafu {
-                            message: "Query option requires a non-negative integer".to_string(),
-                        }
-                        .build()
-                    })?;
-                out_opts.limit = Some(limit as usize);
+                out_opts.limit = Some(parse_query_option_usize(pair, param_pool)?);
             }
             Rule::offset_option => {
-                let pair = pair
-                    .into_inner()
-                    .next()
-                    .expect("pest guarantees offset value");
-                let _span = pair.extract_span();
-                let offset = build_expr(pair, param_pool)?
-                    .eval_to_const()
-                    .map_err(|_err| {
-                        InvalidQuerySnafu {
-                            message: "Query option is not constant".to_string(),
-                        }
-                        .build()
-                    })?
-                    .get_non_neg_int()
-                    .ok_or_else(|| {
-                        InvalidQuerySnafu {
-                            message: "Query option requires a non-negative integer".to_string(),
-                        }
-                        .build()
-                    })?;
-                out_opts.offset = Some(offset as usize);
+                out_opts.offset = Some(parse_query_option_usize(pair, param_pool)?);
             }
             Rule::sort_option => {
-                for part in pair.into_inner() {
-                    let mut var = "";
-                    let mut dir = SortDir::Asc;
-                    let mut span = part.extract_span();
-                    for a in part.into_inner() {
-                        match a.as_rule() {
-                            Rule::out_arg => {
-                                var = a.as_str();
-                                span = a.extract_span();
-                            }
-                            Rule::sort_asc => dir = SortDir::Asc,
-                            Rule::sort_desc => dir = SortDir::Dsc,
-                            _ => unreachable!(),
-                        }
-                    }
-                    out_opts.sorters.push((Symbol::new(var, span), dir));
-                }
+                collect_sort_option(pair, &mut out_opts);
             }
             Rule::returning_option => {
                 returning_mutation = ReturnMutation::Returning;
             }
             Rule::relation_option => {
-                let span = pair.extract_span();
-                let mut args = pair.into_inner();
-                let op = match args.next().expect("pest guarantees relation op").as_rule() {
-                    Rule::relation_create => RelationOp::Create,
-                    Rule::relation_replace => RelationOp::Replace,
-                    Rule::relation_put => RelationOp::Put,
-                    Rule::relation_insert => RelationOp::Insert,
-                    Rule::relation_update => RelationOp::Update,
-                    Rule::relation_rm => RelationOp::Rm,
-                    Rule::relation_delete => RelationOp::Delete,
-                    Rule::relation_ensure => RelationOp::Ensure,
-                    Rule::relation_ensure_not => RelationOp::EnsureNot,
-                    _ => unreachable!(),
-                };
-
-                let name_p = args.next().expect("pest guarantees relation name");
-                let name = Symbol::new(name_p.as_str(), name_p.extract_span());
-                match args.next() {
-                    None => stored_relation = Some(Left((name, span, op))),
-                    Some(schema_p) => {
-                        let (mut metadata, mut key_bindings, mut dep_bindings) =
-                            parse_schema(schema_p)?;
-                        if !matches!(op, RelationOp::Create | RelationOp::Replace) {
-                            key_bindings.extend(dep_bindings);
-                            dep_bindings = vec![];
-                            metadata.keys.extend(metadata.non_keys);
-                            metadata.non_keys = vec![];
-                        }
-                        stored_relation = Some(Right((
-                            InputRelationHandle {
-                                name,
-                                metadata,
-                                key_bindings,
-                                dep_bindings,
-                                span,
-                            },
-                            op,
-                        )))
-                    }
-                }
+                stored_relation = Some(parse_relation_stored_option(pair, param_pool)?);
             }
             Rule::assert_none_option => {
-                if out_opts.assertion.is_some() {
-                    return Err(InvalidQuerySnafu {
-                        message: "Multiple query output assertions defined".to_string(),
-                    }
-                    .build()
-                    .into());
-                }
-                out_opts.assertion = Some(QueryAssertion::AssertNone(pair.extract_span()))
+                set_unique_assertion(
+                    &mut out_opts,
+                    QueryAssertion::AssertNone(pair.extract_span()),
+                )?;
             }
             Rule::assert_some_option => {
-                if out_opts.assertion.is_some() {
-                    return Err(InvalidQuerySnafu {
-                        message: "Multiple query output assertions defined".to_string(),
-                    }
-                    .build()
-                    .into());
-                }
-                out_opts.assertion = Some(QueryAssertion::AssertSome(pair.extract_span()))
+                set_unique_assertion(
+                    &mut out_opts,
+                    QueryAssertion::AssertSome(pair.extract_span()),
+                )?;
             }
             Rule::disable_magic_rewrite_option => {
-                let pair = pair
-                    .into_inner()
-                    .next()
-                    .expect("pest guarantees magic rewrite value");
-                let _span = pair.extract_span();
-                let val = build_expr(pair, param_pool)?
-                    .eval_to_const()
-                    .map_err(|_err| {
-                        InvalidQuerySnafu {
-                            message: "Query option is not constant".to_string(),
-                        }
-                        .build()
-                    })?
-                    .get_bool()
-                    .ok_or_else(|| {
-                        InvalidQuerySnafu {
-                            message: "Query option requires a boolean".to_string(),
-                        }
-                        .build()
-                    })?;
-                disable_magic_rewrite = val;
+                disable_magic_rewrite = parse_query_option_bool(pair, param_pool)?;
             }
             Rule::EOI => break,
             r => unreachable!("{:?}", r),
@@ -422,6 +101,377 @@ pub(crate) fn parse_query(
         disable_magic_rewrite,
     };
 
+    ensure_empty_create_has_const_rule(&mut prog);
+    apply_stored_relation(&mut prog, stored_relation, returning_mutation)?;
+    ensure_empty_create_has_const_rule(&mut prog);
+    validate_sort_keys(&mut prog)?;
+    resolve_empty_mutation_head(&mut prog)?;
+
+    Ok(prog)
+}
+
+fn add_rule_to_program(
+    pair: Pair<'_>,
+    param_pool: &BTreeMap<String, DataValue>,
+    cur_vld: ValidityTs,
+    progs: &mut BTreeMap<Symbol, InputInlineRulesOrFixed>,
+) -> Result<()> {
+    let (name, rule) = parse_rule(pair, param_pool, cur_vld)?;
+    match progs.entry(name) {
+        Entry::Vacant(e) => {
+            e.insert(InputInlineRulesOrFixed::Rules { rules: vec![rule] });
+        }
+        Entry::Occupied(mut e) => {
+            let key = e.key().to_string();
+            match e.get_mut() {
+                InputInlineRulesOrFixed::Rules { rules: rs } => {
+                    let prev = rs
+                        .first()
+                        .expect("rules vec always has at least one element");
+                    if prev.aggr != rule.aggr {
+                        return Err(InvalidQuerySnafu {
+                            message: format!(
+                                "Rule {key} has multiple definitions with conflicting heads"
+                            ),
+                        }
+                        .build()
+                        .into());
+                    }
+                    rs.push(rule);
+                }
+                InputInlineRulesOrFixed::Fixed { .. } => {
+                    return Err(InvalidQuerySnafu {
+                        message: format!(
+                            "The rule '{}' cannot have multiple definitions since it contains non-Horn clauses",
+                            e.key().name
+                        ),
+                    }
+                    .build()
+                    .into());
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+fn add_fixed_rule_to_program(
+    pair: Pair<'_>,
+    param_pool: &BTreeMap<String, DataValue>,
+    fixed_rules: &BTreeMap<String, Arc<Box<dyn FixedRule>>>,
+    cur_vld: ValidityTs,
+    progs: &mut BTreeMap<Symbol, InputInlineRulesOrFixed>,
+) -> Result<()> {
+    let (name, apply) = parse_fixed_rule(pair, param_pool, fixed_rules, cur_vld)?;
+    match progs.entry(name) {
+        Entry::Vacant(e) => {
+            e.insert(InputInlineRulesOrFixed::Fixed { fixed: apply });
+        }
+        Entry::Occupied(e) => {
+            return Err(InvalidQuerySnafu {
+                message: format!(
+                    "The rule '{}' cannot have multiple definitions since it contains non-Horn clauses",
+                    e.key().name
+                ),
+            }
+            .build()
+            .into());
+        }
+    }
+    Ok(())
+}
+
+fn add_const_rule_to_program(
+    pair: Pair<'_>,
+    param_pool: &BTreeMap<String, DataValue>,
+    progs: &mut BTreeMap<Symbol, InputInlineRulesOrFixed>,
+) -> Result<()> {
+    let span = pair.extract_span();
+    let mut src = pair.into_inner();
+    let (name, head, aggr) =
+        parse_rule_head(src.next().expect("pest guarantees rule head"), param_pool)?;
+
+    if progs.contains_key(&name) {
+        return Err(InvalidQuerySnafu {
+            message: format!(
+                "The rule '{}' cannot have multiple definitions since it contains non-Horn clauses",
+                name.name
+            ),
+        }
+        .build()
+        .into());
+    }
+
+    for (a, _v) in aggr.iter().zip(head.iter()) {
+        if a.is_some() {
+            return Err(InvalidQuerySnafu {
+                message: "Constant rules cannot have aggregation application".to_string(),
+            }
+            .build()
+            .into());
+        }
+    }
+
+    let data_part = src
+        .next()
+        .expect("pest guarantees data part after rule head");
+    build_and_insert_const_rule(name, head, data_part, param_pool, progs, span)
+}
+
+fn build_and_insert_const_rule(
+    name: Symbol,
+    mut head: Vec<Symbol>,
+    data_part: Pair<'_>,
+    param_pool: &BTreeMap<String, DataValue>,
+    progs: &mut BTreeMap<Symbol, InputInlineRulesOrFixed>,
+    span: SourceSpan,
+) -> Result<()> {
+    let data_part_str = data_part.as_str();
+    let data = build_expr(data_part.clone(), param_pool)?;
+    let mut options = BTreeMap::new();
+    options.insert(CompactString::from("data"), data);
+    let handle = FixedRuleHandle {
+        name: Symbol::new("Constant", span),
+    };
+    let fixed_impl = Box::new(Constant);
+    fixed_impl.init_options(&mut options, span)?;
+    let arity = fixed_impl.arity(&options, &head, span)?;
+
+    if arity == 0 {
+        return Err(InvalidQuerySnafu {
+            message: "Encountered empty row for constant rule".to_string(),
+        }
+        .build()
+        .into());
+    }
+    if !head.is_empty() && arity != head.len() {
+        return Err(InvalidQuerySnafu {
+            message: "Fixed rule head arity mismatch".to_string(),
+        }
+        .build()
+        .into());
+    }
+
+    if head.is_empty()
+        && name.is_prog_entry()
+        && let Ok(mut datalist) = DatalogParser::parse(Rule::param_list, data_part_str)
+    {
+        extend_head_from_params(
+            &mut head,
+            datalist.next().expect("pest guarantees param_list token"),
+        );
+    }
+
+    progs.insert(
+        name,
+        InputInlineRulesOrFixed::Fixed {
+            fixed: FixedRuleApply {
+                fixed_handle: handle,
+                rule_args: vec![],
+                options: Arc::new(options),
+                head,
+                arity,
+                span,
+                fixed_impl: Arc::new(fixed_impl),
+            },
+        },
+    );
+    Ok(())
+}
+
+fn extend_head_from_params(head: &mut Vec<Symbol>, param_list: Pair<'_>) {
+    for s in param_list.into_inner() {
+        if s.as_rule() == Rule::param {
+            head.push(Symbol::new(
+                s.as_str()
+                    .strip_prefix('$')
+                    .expect("pest guarantees $ prefix on param"),
+                Default::default(),
+            ));
+        }
+    }
+}
+
+fn parse_query_option_float(
+    pair: Pair<'_>,
+    param_pool: &BTreeMap<String, DataValue>,
+) -> Result<f64> {
+    let inner = pair
+        .into_inner()
+        .next()
+        .expect("pest guarantees option value");
+    build_expr(inner, param_pool)?
+        .eval_to_const()
+        .map_err(|_err| {
+            InvalidQuerySnafu {
+                message: "Query option is not constant".to_string(),
+            }
+            .build()
+        })?
+        .get_float()
+        .ok_or_else(|| {
+            InvalidQuerySnafu {
+                message: "Query option requires a non-negative number".to_string(),
+            }
+            .build()
+        })
+        .map_err(Into::into)
+}
+
+fn parse_sleep_option(pair: Pair<'_>, param_pool: &BTreeMap<String, DataValue>) -> Result<f64> {
+    #[cfg(target_arch = "wasm32")]
+    return Err(InvalidQuerySnafu {
+        message: ":sleep is not supported under WASM".to_string(),
+    }
+    .build()
+    .into());
+
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        let sleep = parse_query_option_float(pair, param_pool)?;
+        if sleep <= 0. {
+            return Err(InvalidQuerySnafu {
+                message: "Query option :sleep requires a positive integer".to_string(),
+            }
+            .build()
+            .into());
+        }
+        Ok(sleep)
+    }
+}
+
+fn parse_query_option_usize(
+    pair: Pair<'_>,
+    param_pool: &BTreeMap<String, DataValue>,
+) -> Result<usize> {
+    let inner = pair
+        .into_inner()
+        .next()
+        .expect("pest guarantees option value");
+    let n = build_expr(inner, param_pool)?
+        .eval_to_const()
+        .map_err(|_err| {
+            InvalidQuerySnafu {
+                message: "Query option is not constant".to_string(),
+            }
+            .build()
+        })?
+        .get_non_neg_int()
+        .ok_or_else(|| {
+            InvalidQuerySnafu {
+                message: "Query option requires a non-negative integer".to_string(),
+            }
+            .build()
+        })?;
+    Ok(n as usize)
+}
+
+fn parse_query_option_bool(
+    pair: Pair<'_>,
+    param_pool: &BTreeMap<String, DataValue>,
+) -> Result<bool> {
+    let inner = pair
+        .into_inner()
+        .next()
+        .expect("pest guarantees option value");
+    build_expr(inner, param_pool)?
+        .eval_to_const()
+        .map_err(|_err| {
+            InvalidQuerySnafu {
+                message: "Query option is not constant".to_string(),
+            }
+            .build()
+        })?
+        .get_bool()
+        .ok_or_else(|| {
+            InvalidQuerySnafu {
+                message: "Query option requires a boolean".to_string(),
+            }
+            .build()
+        })
+        .map_err(Into::into)
+}
+
+fn collect_sort_option(pair: Pair<'_>, out_opts: &mut QueryOutOptions) {
+    for part in pair.into_inner() {
+        let mut var = "";
+        let mut dir = SortDir::Asc;
+        let mut span = part.extract_span();
+        for a in part.into_inner() {
+            match a.as_rule() {
+                Rule::out_arg => {
+                    var = a.as_str();
+                    span = a.extract_span();
+                }
+                Rule::sort_asc => dir = SortDir::Asc,
+                Rule::sort_desc => dir = SortDir::Dsc,
+                _ => unreachable!(),
+            }
+        }
+        out_opts.sorters.push((Symbol::new(var, span), dir));
+    }
+}
+
+fn set_unique_assertion(out_opts: &mut QueryOutOptions, assertion: QueryAssertion) -> Result<()> {
+    if out_opts.assertion.is_some() {
+        return Err(InvalidQuerySnafu {
+            message: "Multiple query output assertions defined".to_string(),
+        }
+        .build()
+        .into());
+    }
+    out_opts.assertion = Some(assertion);
+    Ok(())
+}
+
+type StoredRelationSpec =
+    either::Either<(Symbol, SourceSpan, RelationOp), (InputRelationHandle, RelationOp)>;
+
+fn parse_relation_stored_option(
+    pair: Pair<'_>,
+    _param_pool: &BTreeMap<String, DataValue>,
+) -> Result<StoredRelationSpec> {
+    let span = pair.extract_span();
+    let mut args = pair.into_inner();
+    let op = match args.next().expect("pest guarantees relation op").as_rule() {
+        Rule::relation_create => RelationOp::Create,
+        Rule::relation_replace => RelationOp::Replace,
+        Rule::relation_put => RelationOp::Put,
+        Rule::relation_insert => RelationOp::Insert,
+        Rule::relation_update => RelationOp::Update,
+        Rule::relation_rm => RelationOp::Rm,
+        Rule::relation_delete => RelationOp::Delete,
+        Rule::relation_ensure => RelationOp::Ensure,
+        Rule::relation_ensure_not => RelationOp::EnsureNot,
+        _ => unreachable!(),
+    };
+    let name_p = args.next().expect("pest guarantees relation name");
+    let name = Symbol::new(name_p.as_str(), name_p.extract_span());
+    match args.next() {
+        None => Ok(Left((name, span, op))),
+        Some(schema_p) => {
+            let (mut metadata, mut key_bindings, mut dep_bindings) = parse_schema(schema_p)?;
+            if !matches!(op, RelationOp::Create | RelationOp::Replace) {
+                key_bindings.extend(dep_bindings);
+                dep_bindings = vec![];
+                metadata.keys.extend(metadata.non_keys);
+                metadata.non_keys = vec![];
+            }
+            Ok(Right((
+                InputRelationHandle {
+                    name,
+                    metadata,
+                    key_bindings,
+                    dep_bindings,
+                    span,
+                },
+                op,
+            )))
+        }
+    }
+}
+
+fn ensure_empty_create_has_const_rule(prog: &mut InputProgram) {
     if prog.prog.is_empty()
         && let Some((
             InputRelationHandle {
@@ -435,9 +485,15 @@ pub(crate) fn parse_query(
     {
         let mut bindings = key_bindings.clone();
         bindings.extend_from_slice(dep_bindings);
-        make_empty_const_rule(&mut prog, &bindings);
+        make_empty_const_rule(prog, &bindings);
     }
+}
 
+fn apply_stored_relation(
+    prog: &mut InputProgram,
+    stored_relation: Option<StoredRelationSpec>,
+    returning_mutation: ReturnMutation,
+) -> Result<()> {
     match stored_relation {
         None => {}
         Some(Left((name, span, op))) => {
@@ -445,7 +501,6 @@ pub(crate) fn parse_query(
             for symb in &head {
                 symb.ensure_valid_field()?;
             }
-
             let metadata = StoredRelationMetadata {
                 keys: head
                     .iter()
@@ -460,7 +515,6 @@ pub(crate) fn parse_query(
                     .collect(),
                 non_keys: vec![],
             };
-
             let handle = InputRelationHandle {
                 name,
                 metadata,
@@ -468,33 +522,33 @@ pub(crate) fn parse_query(
                 dep_bindings: vec![],
                 span,
             };
-            prog.out_opts.store_relation = Some((handle, op, returning_mutation))
+            prog.out_opts.store_relation = Some((handle, op, returning_mutation));
         }
-        Some(Right((h, o))) => prog.out_opts.store_relation = Some((h, o, returning_mutation)),
+        Some(Right((h, o))) => {
+            prog.out_opts.store_relation = Some((h, o, returning_mutation));
+        }
     }
+    Ok(())
+}
 
-    if prog.prog.is_empty()
-        && let Some((handle, RelationOp::Create, _)) = &prog.out_opts.store_relation
-    {
-        let mut bindings = handle.dep_bindings.clone();
-        bindings.extend_from_slice(&handle.key_bindings);
-        make_empty_const_rule(&mut prog, &bindings);
+fn validate_sort_keys(prog: &mut InputProgram) -> Result<()> {
+    if prog.out_opts.sorters.is_empty() {
+        return Ok(());
     }
-
-    if !prog.out_opts.sorters.is_empty() {
-        let head_args = prog.get_entry_out_head()?;
-
-        for (sorter, _) in &prog.out_opts.sorters {
-            if !head_args.contains(sorter) {
-                return Err(InvalidQuerySnafu {
-                    message: "Sort key not found".to_string(),
-                }
-                .build()
-                .into());
+    let head_args = prog.get_entry_out_head()?;
+    for (sorter, _) in &prog.out_opts.sorters {
+        if !head_args.contains(sorter) {
+            return Err(InvalidQuerySnafu {
+                message: "Sort key not found".to_string(),
             }
+            .build()
+            .into());
         }
     }
+    Ok(())
+}
 
+fn resolve_empty_mutation_head(prog: &mut InputProgram) -> Result<()> {
     let empty_mutation_head = match &prog.out_opts.store_relation {
         None => false,
         Some((handle, _, _)) => {
@@ -540,8 +594,7 @@ pub(crate) fn parse_query(
             unreachable!()
         }
     }
-
-    Ok(prog)
+    Ok(())
 }
 
 fn parse_rule(
@@ -644,173 +697,206 @@ fn parse_atom(
             let expr = build_expr(src, param_pool)?;
             InputAtom::Predicate { inner: expr }
         }
-        Rule::unify => {
-            let span = src.extract_span();
-            let mut src = src.into_inner();
-            let var = src.next().expect("pest guarantees unify variable");
-            let mut symb = Symbol::new(var.as_str(), var.extract_span());
-            if symb.is_ignored_symbol() {
-                symb.name = format!("*^*{}", *ignored_counter).into();
-                *ignored_counter += 1;
-            }
-            let expr = build_expr(
-                src.next().expect("pest guarantees unify expression"),
-                param_pool,
-            )?;
-            InputAtom::Unification {
-                inner: Unification {
-                    binding: symb,
-                    expr,
-                    one_many_unif: false,
-                    span,
-                },
-            }
-        }
-        Rule::unify_multi => {
-            let span = src.extract_span();
-            let mut src = src.into_inner();
-            let var = src.next().expect("pest guarantees unify_multi variable");
-            let mut symb = Symbol::new(var.as_str(), var.extract_span());
-            if symb.is_ignored_symbol() {
-                symb.name = format!("*^*{}", *ignored_counter).into();
-                *ignored_counter += 1;
-            }
-            src.next().expect("pest guarantees unify_multi separator");
-            let expr = build_expr(
-                src.next().expect("pest guarantees unify_multi expression"),
-                param_pool,
-            )?;
-            InputAtom::Unification {
-                inner: Unification {
-                    binding: symb,
-                    expr,
-                    one_many_unif: true,
-                    span,
-                },
-            }
-        }
-        Rule::rule_apply => {
-            let span = src.extract_span();
-            let mut src = src.into_inner();
-            let name = src.next().expect("pest guarantees rule_apply name");
-            let args: Vec<_> = src
-                .next()
-                .expect("pest guarantees rule_apply args")
-                .into_inner()
-                .map(|v| build_expr(v, param_pool))
-                .try_collect()?;
-            InputAtom::Rule {
-                inner: InputRuleApplyAtom {
-                    name: Symbol::new(name.as_str(), name.extract_span()),
-                    args,
-                    span,
-                },
-            }
-        }
-        Rule::relation_apply => {
-            let span = src.extract_span();
-            let mut src = src.into_inner();
-            let name = src.next().expect("pest guarantees relation_apply name");
-            let args: Vec<_> = src
-                .next()
-                .expect("pest guarantees relation_apply args")
-                .into_inner()
-                .map(|v| build_expr(v, param_pool))
-                .try_collect()?;
-            let valid_at = match src.next() {
-                None => None,
-                Some(vld_clause) => {
-                    let vld_expr = build_expr(
-                        vld_clause
-                            .into_inner()
-                            .next()
-                            .expect("pest guarantees validity expr"),
-                        param_pool,
-                    )?;
-                    Some(expr2vld_spec(vld_expr, cur_vld)?)
-                }
-            };
-            InputAtom::Relation {
-                inner: InputRelationApplyAtom {
-                    name: Symbol::new(&name.as_str()[1..], name.extract_span()),
-                    args,
-                    valid_at,
-                    span,
-                },
-            }
-        }
-        Rule::search_apply => {
-            let span = src.extract_span();
-            let mut src = src.into_inner();
-            let name_p = src.next().expect("pest guarantees search_apply name");
-            let name_segs = name_p.as_str().split(':').collect_vec();
-
-            if name_segs.len() != 2 {
-                return Err(InvalidQuerySnafu {
-                    message: "Search head must be of the form `relation_name:index_name`"
-                        .to_string(),
-                }
-                .build()
-                .into());
-            }
-            let relation = Symbol::new(name_segs[0], name_p.extract_span());
-            let index = Symbol::new(name_segs[1], name_p.extract_span());
-            let bindings: BTreeMap<CompactString, Expr> = src
-                .next()
-                .expect("pest guarantees search_apply bindings")
-                .into_inner()
-                .map(|arg| extract_named_apply_arg(arg, param_pool))
-                .try_collect()?;
-            let parameters: BTreeMap<CompactString, Expr> = src
-                .map(|arg| extract_named_apply_arg(arg, param_pool))
-                .try_collect()?;
-
-            let opts = SearchInput {
-                relation,
-                index,
-                bindings,
-                span,
-                parameters,
-            };
-
-            InputAtom::Search { inner: opts }
-        }
-        Rule::relation_named_apply => {
-            let span = src.extract_span();
-            let mut src = src.into_inner();
-            let name_p = src
-                .next()
-                .expect("pest guarantees relation_named_apply name");
-            let name = Symbol::new(&name_p.as_str()[1..], name_p.extract_span());
-            let args = src
-                .next()
-                .expect("pest guarantees relation_named_apply args")
-                .into_inner()
-                .map(|arg| extract_named_apply_arg(arg, param_pool))
-                .try_collect()?;
-            let valid_at = match src.next() {
-                None => None,
-                Some(vld_clause) => {
-                    let vld_expr = build_expr(
-                        vld_clause
-                            .into_inner()
-                            .next()
-                            .expect("pest guarantees validity expr"),
-                        param_pool,
-                    )?;
-                    Some(expr2vld_spec(vld_expr, cur_vld)?)
-                }
-            };
-            InputAtom::NamedFieldRelation {
-                inner: InputNamedFieldRelationApplyAtom {
-                    name,
-                    args,
-                    span,
-                    valid_at,
-                },
-            }
-        }
+        Rule::unify => parse_unify_atom(src, param_pool, ignored_counter)?,
+        Rule::unify_multi => parse_unify_multi_atom(src, param_pool, ignored_counter)?,
+        Rule::rule_apply => parse_rule_apply_atom(src, param_pool)?,
+        Rule::relation_apply => parse_relation_apply_atom(src, param_pool, cur_vld)?,
+        Rule::search_apply => parse_search_apply_atom(src, param_pool)?,
+        Rule::relation_named_apply => parse_relation_named_apply_atom(src, param_pool, cur_vld)?,
         r => unreachable!("{:?}", r),
+    })
+}
+
+fn parse_unify_atom(
+    src: Pair<'_>,
+    param_pool: &BTreeMap<String, DataValue>,
+    ignored_counter: &mut u32,
+) -> Result<InputAtom> {
+    let span = src.extract_span();
+    let mut src = src.into_inner();
+    let var = src.next().expect("pest guarantees unify variable");
+    let mut symb = Symbol::new(var.as_str(), var.extract_span());
+    if symb.is_ignored_symbol() {
+        symb.name = format!("*^*{}", *ignored_counter).into();
+        *ignored_counter += 1;
+    }
+    let expr = build_expr(
+        src.next().expect("pest guarantees unify expression"),
+        param_pool,
+    )?;
+    Ok(InputAtom::Unification {
+        inner: Unification {
+            binding: symb,
+            expr,
+            one_many_unif: false,
+            span,
+        },
+    })
+}
+
+fn parse_unify_multi_atom(
+    src: Pair<'_>,
+    param_pool: &BTreeMap<String, DataValue>,
+    ignored_counter: &mut u32,
+) -> Result<InputAtom> {
+    let span = src.extract_span();
+    let mut src = src.into_inner();
+    let var = src.next().expect("pest guarantees unify_multi variable");
+    let mut symb = Symbol::new(var.as_str(), var.extract_span());
+    if symb.is_ignored_symbol() {
+        symb.name = format!("*^*{}", *ignored_counter).into();
+        *ignored_counter += 1;
+    }
+    src.next().expect("pest guarantees unify_multi separator");
+    let expr = build_expr(
+        src.next().expect("pest guarantees unify_multi expression"),
+        param_pool,
+    )?;
+    Ok(InputAtom::Unification {
+        inner: Unification {
+            binding: symb,
+            expr,
+            one_many_unif: true,
+            span,
+        },
+    })
+}
+
+fn parse_rule_apply_atom(
+    src: Pair<'_>,
+    param_pool: &BTreeMap<String, DataValue>,
+) -> Result<InputAtom> {
+    let span = src.extract_span();
+    let mut src = src.into_inner();
+    let name = src.next().expect("pest guarantees rule_apply name");
+    let args: Vec<_> = src
+        .next()
+        .expect("pest guarantees rule_apply args")
+        .into_inner()
+        .map(|v| build_expr(v, param_pool))
+        .try_collect()?;
+    Ok(InputAtom::Rule {
+        inner: InputRuleApplyAtom {
+            name: Symbol::new(name.as_str(), name.extract_span()),
+            args,
+            span,
+        },
+    })
+}
+
+fn parse_relation_apply_atom(
+    src: Pair<'_>,
+    param_pool: &BTreeMap<String, DataValue>,
+    cur_vld: ValidityTs,
+) -> Result<InputAtom> {
+    let span = src.extract_span();
+    let mut src = src.into_inner();
+    let name = src.next().expect("pest guarantees relation_apply name");
+    let args: Vec<_> = src
+        .next()
+        .expect("pest guarantees relation_apply args")
+        .into_inner()
+        .map(|v| build_expr(v, param_pool))
+        .try_collect()?;
+    let valid_at = match src.next() {
+        None => None,
+        Some(vld_clause) => {
+            let vld_expr = build_expr(
+                vld_clause
+                    .into_inner()
+                    .next()
+                    .expect("pest guarantees validity expr"),
+                param_pool,
+            )?;
+            Some(expr2vld_spec(vld_expr, cur_vld)?)
+        }
+    };
+    Ok(InputAtom::Relation {
+        inner: InputRelationApplyAtom {
+            name: Symbol::new(&name.as_str()[1..], name.extract_span()),
+            args,
+            valid_at,
+            span,
+        },
+    })
+}
+
+fn parse_search_apply_atom(
+    src: Pair<'_>,
+    param_pool: &BTreeMap<String, DataValue>,
+) -> Result<InputAtom> {
+    let span = src.extract_span();
+    let mut src = src.into_inner();
+    let name_p = src.next().expect("pest guarantees search_apply name");
+    let name_segs = name_p.as_str().split(':').collect_vec();
+
+    if name_segs.len() != 2 {
+        return Err(InvalidQuerySnafu {
+            message: "Search head must be of the form `relation_name:index_name`".to_string(),
+        }
+        .build()
+        .into());
+    }
+    let relation = Symbol::new(name_segs[0], name_p.extract_span());
+    let index = Symbol::new(name_segs[1], name_p.extract_span());
+    let bindings: BTreeMap<CompactString, Expr> = src
+        .next()
+        .expect("pest guarantees search_apply bindings")
+        .into_inner()
+        .map(|arg| extract_named_apply_arg(arg, param_pool))
+        .try_collect()?;
+    let parameters: BTreeMap<CompactString, Expr> = src
+        .map(|arg| extract_named_apply_arg(arg, param_pool))
+        .try_collect()?;
+
+    Ok(InputAtom::Search {
+        inner: SearchInput {
+            relation,
+            index,
+            bindings,
+            span,
+            parameters,
+        },
+    })
+}
+
+fn parse_relation_named_apply_atom(
+    src: Pair<'_>,
+    param_pool: &BTreeMap<String, DataValue>,
+    cur_vld: ValidityTs,
+) -> Result<InputAtom> {
+    let span = src.extract_span();
+    let mut src = src.into_inner();
+    let name_p = src
+        .next()
+        .expect("pest guarantees relation_named_apply name");
+    let name = Symbol::new(&name_p.as_str()[1..], name_p.extract_span());
+    let args = src
+        .next()
+        .expect("pest guarantees relation_named_apply args")
+        .into_inner()
+        .map(|arg| extract_named_apply_arg(arg, param_pool))
+        .try_collect()?;
+    let valid_at = match src.next() {
+        None => None,
+        Some(vld_clause) => {
+            let vld_expr = build_expr(
+                vld_clause
+                    .into_inner()
+                    .next()
+                    .expect("pest guarantees validity expr"),
+                param_pool,
+            )?;
+            Some(expr2vld_spec(vld_expr, cur_vld)?)
+        }
+    };
+    Ok(InputAtom::NamedFieldRelation {
+        inner: InputNamedFieldRelationApplyAtom {
+            name,
+            args,
+            span,
+            valid_at,
+        },
     })
 }
 
@@ -915,180 +1001,16 @@ fn parse_fixed_rule(
 
     let name_pair = src.next().expect("pest guarantees fixed rule name");
     let fixed_name = &name_pair.as_str();
-    let mut rule_args: Vec<FixedRuleArg> = vec![];
-    let mut options: BTreeMap<CompactString, Expr> = Default::default();
     let args_list = src.next().expect("pest guarantees fixed rule args list");
     let args_list_span = args_list.extract_span();
 
-    for nxt in args_list.into_inner() {
-        match nxt.as_rule() {
-            Rule::fixed_rel => {
-                let inner = nxt
-                    .into_inner()
-                    .next()
-                    .expect("pest guarantees fixed_rel inner");
-                let span = inner.extract_span();
-                match inner.as_rule() {
-                    Rule::fixed_rule_rel => {
-                        let mut els = inner.into_inner();
-                        let name = els.next().expect("pest guarantees fixed_rule_rel name");
-                        let mut bindings = Vec::with_capacity(els.size_hint().1.unwrap_or(4));
-                        for v in els {
-                            let s = v.as_str();
-                            if s == "_" {
-                                let symb =
-                                    Symbol::new(format!("*_*{binding_gen_id}"), v.extract_span());
-                                binding_gen_id += 1;
-                                bindings.push(symb);
-                            } else {
-                                if !seen_bindings.insert(s) {
-                                    return Err(InvalidQuerySnafu {
-                                        message: "fixed rule cannot have duplicate bindings"
-                                            .to_string(),
-                                    }
-                                    .build()
-                                    .into());
-                                }
-                                let symb = Symbol::new(s, v.extract_span());
-                                bindings.push(symb);
-                            }
-                        }
-                        rule_args.push(FixedRuleArg::InMem {
-                            name: Symbol::new(name.as_str(), name.extract_span()),
-                            bindings,
-                            span,
-                        })
-                    }
-                    Rule::fixed_relation_rel => {
-                        let mut els = inner.into_inner();
-                        let name = els.next().expect("pest guarantees fixed_relation_rel name");
-                        let mut bindings = vec![];
-                        let mut valid_at = None;
-                        for v in els {
-                            match v.as_rule() {
-                                Rule::var => {
-                                    let s = v.as_str();
-                                    if s == "_" {
-                                        let symb = Symbol::new(
-                                            format!("*_*{binding_gen_id}"),
-                                            v.extract_span(),
-                                        );
-                                        binding_gen_id += 1;
-                                        bindings.push(symb);
-                                    } else {
-                                        if !seen_bindings.insert(s) {
-                                            return Err(InvalidQuerySnafu {
-                                                message:
-                                                    "fixed rule cannot have duplicate bindings"
-                                                        .to_string(),
-                                            }
-                                            .build()
-                                            .into());
-                                        }
-                                        bindings.push(Symbol::new(v.as_str(), v.extract_span()))
-                                    }
-                                }
-                                Rule::validity_clause => {
-                                    let vld_inner = v
-                                        .into_inner()
-                                        .next()
-                                        .expect("pest guarantees validity expr");
-                                    let vld_expr = build_expr(vld_inner, param_pool)?;
-                                    valid_at = Some(expr2vld_spec(vld_expr, cur_vld)?)
-                                }
-                                _ => unreachable!(),
-                            }
-                        }
-                        rule_args.push(FixedRuleArg::Stored {
-                            name: Symbol::new(
-                                name.as_str()
-                                    .strip_prefix('*')
-                                    .expect("pest guarantees * prefix on stored relation"),
-                                name.extract_span(),
-                            ),
-                            bindings,
-                            valid_at,
-                            span,
-                        })
-                    }
-                    Rule::fixed_named_relation_rel => {
-                        let mut els = inner.into_inner();
-                        let name = els
-                            .next()
-                            .expect("pest guarantees fixed_named_relation_rel name");
-                        let mut bindings = BTreeMap::new();
-                        let mut valid_at = None;
-                        for p in els {
-                            match p.as_rule() {
-                                Rule::fixed_named_relation_arg_pair => {
-                                    let mut vs = p.into_inner();
-                                    let kp = vs.next().expect("pest guarantees named arg key");
-                                    let k = CompactString::from(kp.as_str());
-                                    let v = match vs.next() {
-                                        Some(vp) => {
-                                            if !seen_bindings.insert(vp.as_str()) {
-                                                return Err(InvalidQuerySnafu {
-                                                    message:
-                                                        "fixed rule cannot have duplicate bindings"
-                                                            .to_string(),
-                                                }
-                                                .build()
-                                                .into());
-                                            }
-                                            Symbol::new(vp.as_str(), vp.extract_span())
-                                        }
-                                        None => {
-                                            if !seen_bindings.insert(kp.as_str()) {
-                                                return Err(InvalidQuerySnafu {
-                                                    message:
-                                                        "fixed rule cannot have duplicate bindings"
-                                                            .to_string(),
-                                                }
-                                                .build()
-                                                .into());
-                                            }
-                                            Symbol::new(k.clone(), kp.extract_span())
-                                        }
-                                    };
-                                    bindings.insert(k, v);
-                                }
-                                Rule::validity_clause => {
-                                    let vld_inner = p
-                                        .into_inner()
-                                        .next()
-                                        .expect("pest guarantees validity expr");
-                                    let vld_expr = build_expr(vld_inner, param_pool)?;
-                                    valid_at = Some(expr2vld_spec(vld_expr, cur_vld)?)
-                                }
-                                _ => unreachable!(),
-                            }
-                        }
-
-                        rule_args.push(FixedRuleArg::NamedStored {
-                            name: Symbol::new(
-                                name.as_str()
-                                    .strip_prefix(':')
-                                    .expect("pest guarantees : prefix on named stored relation"),
-                                name.extract_span(),
-                            ),
-                            bindings,
-                            valid_at,
-                            span,
-                        })
-                    }
-                    _ => unreachable!(),
-                }
-            }
-            Rule::fixed_opt_pair => {
-                let mut inner = nxt.into_inner();
-                let name = inner.next().expect("pest guarantees option name").as_str();
-                let val = inner.next().expect("pest guarantees option value");
-                let val = build_expr(val, param_pool)?;
-                options.insert(CompactString::from(name), val);
-            }
-            _ => unreachable!(),
-        }
-    }
+    let (rule_args, mut options) = collect_fixed_rule_args(
+        args_list,
+        &mut seen_bindings,
+        &mut binding_gen_id,
+        param_pool,
+        cur_vld,
+    )?;
 
     let fixed = FixedRuleHandle::new(fixed_name, name_pair.extract_span());
 
@@ -1121,6 +1043,211 @@ fn parse_fixed_rule(
             fixed_impl: fixed_impl.clone(),
         },
     ))
+}
+
+fn collect_fixed_rule_args<'i>(
+    args_list: Pair<'i>,
+    seen_bindings: &mut BTreeSet<&'i str>,
+    binding_gen_id: &mut u32,
+    param_pool: &BTreeMap<String, DataValue>,
+    cur_vld: ValidityTs,
+) -> Result<(Vec<FixedRuleArg>, BTreeMap<CompactString, Expr>)> {
+    let mut rule_args: Vec<FixedRuleArg> = vec![];
+    let mut options: BTreeMap<CompactString, Expr> = Default::default();
+    for nxt in args_list.into_inner() {
+        match nxt.as_rule() {
+            Rule::fixed_rel => {
+                let inner = nxt
+                    .into_inner()
+                    .next()
+                    .expect("pest guarantees fixed_rel inner");
+                let arg = match inner.as_rule() {
+                    Rule::fixed_rule_rel => {
+                        parse_fixed_rule_rel_arg(inner, seen_bindings, binding_gen_id)?
+                    }
+                    Rule::fixed_relation_rel => parse_fixed_relation_rel_arg(
+                        inner,
+                        seen_bindings,
+                        binding_gen_id,
+                        param_pool,
+                        cur_vld,
+                    )?,
+                    Rule::fixed_named_relation_rel => parse_fixed_named_relation_rel_arg(
+                        inner,
+                        seen_bindings,
+                        param_pool,
+                        cur_vld,
+                    )?,
+                    _ => unreachable!(),
+                };
+                rule_args.push(arg);
+            }
+            Rule::fixed_opt_pair => {
+                let mut inner = nxt.into_inner();
+                let name = inner.next().expect("pest guarantees option name").as_str();
+                let val = inner.next().expect("pest guarantees option value");
+                let val = build_expr(val, param_pool)?;
+                options.insert(CompactString::from(name), val);
+            }
+            _ => unreachable!(),
+        }
+    }
+    Ok((rule_args, options))
+}
+
+fn parse_fixed_rule_rel_arg<'i>(
+    inner: Pair<'i>,
+    seen_bindings: &mut BTreeSet<&'i str>,
+    binding_gen_id: &mut u32,
+) -> Result<FixedRuleArg> {
+    let span = inner.extract_span();
+    let mut els = inner.into_inner();
+    let name = els.next().expect("pest guarantees fixed_rule_rel name");
+    let mut bindings = Vec::with_capacity(els.size_hint().1.unwrap_or(4));
+    for v in els {
+        let s = v.as_str();
+        if s == "_" {
+            let symb = Symbol::new(format!("*_*{binding_gen_id}"), v.extract_span());
+            *binding_gen_id += 1;
+            bindings.push(symb);
+        } else {
+            if !seen_bindings.insert(s) {
+                return Err(InvalidQuerySnafu {
+                    message: "fixed rule cannot have duplicate bindings".to_string(),
+                }
+                .build()
+                .into());
+            }
+            bindings.push(Symbol::new(s, v.extract_span()));
+        }
+    }
+    Ok(FixedRuleArg::InMem {
+        name: Symbol::new(name.as_str(), name.extract_span()),
+        bindings,
+        span,
+    })
+}
+
+fn parse_fixed_relation_rel_arg<'i>(
+    inner: Pair<'i>,
+    seen_bindings: &mut BTreeSet<&'i str>,
+    binding_gen_id: &mut u32,
+    param_pool: &BTreeMap<String, DataValue>,
+    cur_vld: ValidityTs,
+) -> Result<FixedRuleArg> {
+    let span = inner.extract_span();
+    let mut els = inner.into_inner();
+    let name = els.next().expect("pest guarantees fixed_relation_rel name");
+    let mut bindings = vec![];
+    let mut valid_at = None;
+    for v in els {
+        match v.as_rule() {
+            Rule::var => {
+                let s = v.as_str();
+                if s == "_" {
+                    let symb = Symbol::new(format!("*_*{binding_gen_id}"), v.extract_span());
+                    *binding_gen_id += 1;
+                    bindings.push(symb);
+                } else {
+                    if !seen_bindings.insert(s) {
+                        return Err(InvalidQuerySnafu {
+                            message: "fixed rule cannot have duplicate bindings".to_string(),
+                        }
+                        .build()
+                        .into());
+                    }
+                    bindings.push(Symbol::new(v.as_str(), v.extract_span()))
+                }
+            }
+            Rule::validity_clause => {
+                let vld_inner = v
+                    .into_inner()
+                    .next()
+                    .expect("pest guarantees validity expr");
+                let vld_expr = build_expr(vld_inner, param_pool)?;
+                valid_at = Some(expr2vld_spec(vld_expr, cur_vld)?)
+            }
+            _ => unreachable!(),
+        }
+    }
+    Ok(FixedRuleArg::Stored {
+        name: Symbol::new(
+            name.as_str()
+                .strip_prefix('*')
+                .expect("pest guarantees * prefix on stored relation"),
+            name.extract_span(),
+        ),
+        bindings,
+        valid_at,
+        span,
+    })
+}
+
+fn parse_fixed_named_relation_rel_arg<'i>(
+    inner: Pair<'i>,
+    seen_bindings: &mut BTreeSet<&'i str>,
+    param_pool: &BTreeMap<String, DataValue>,
+    cur_vld: ValidityTs,
+) -> Result<FixedRuleArg> {
+    let span = inner.extract_span();
+    let mut els = inner.into_inner();
+    let name = els
+        .next()
+        .expect("pest guarantees fixed_named_relation_rel name");
+    let mut bindings = BTreeMap::new();
+    let mut valid_at = None;
+    for p in els {
+        match p.as_rule() {
+            Rule::fixed_named_relation_arg_pair => {
+                let mut vs = p.into_inner();
+                let kp = vs.next().expect("pest guarantees named arg key");
+                let k = CompactString::from(kp.as_str());
+                let v = match vs.next() {
+                    Some(vp) => {
+                        if !seen_bindings.insert(vp.as_str()) {
+                            return Err(InvalidQuerySnafu {
+                                message: "fixed rule cannot have duplicate bindings".to_string(),
+                            }
+                            .build()
+                            .into());
+                        }
+                        Symbol::new(vp.as_str(), vp.extract_span())
+                    }
+                    None => {
+                        if !seen_bindings.insert(kp.as_str()) {
+                            return Err(InvalidQuerySnafu {
+                                message: "fixed rule cannot have duplicate bindings".to_string(),
+                            }
+                            .build()
+                            .into());
+                        }
+                        Symbol::new(k.clone(), kp.extract_span())
+                    }
+                };
+                bindings.insert(k, v);
+            }
+            Rule::validity_clause => {
+                let vld_inner = p
+                    .into_inner()
+                    .next()
+                    .expect("pest guarantees validity expr");
+                let vld_expr = build_expr(vld_inner, param_pool)?;
+                valid_at = Some(expr2vld_spec(vld_expr, cur_vld)?)
+            }
+            _ => unreachable!(),
+        }
+    }
+    Ok(FixedRuleArg::NamedStored {
+        name: Symbol::new(
+            name.as_str()
+                .strip_prefix(':')
+                .expect("pest guarantees : prefix on named stored relation"),
+            name.extract_span(),
+        ),
+        bindings,
+        valid_at,
+        span,
+    })
 }
 
 fn make_empty_const_rule(prog: &mut InputProgram, bindings: &[Symbol]) {

--- a/crates/mneme/src/engine/query/eval.rs
+++ b/crates/mneme/src/engine/query/eval.rs
@@ -24,7 +24,7 @@ use crate::engine::query::compile::{
     AggrKind, CompiledProgram, CompiledRule, CompiledRuleSet, ContainedRuleMultiplicity,
 };
 use crate::engine::runtime::db::Poison;
-use crate::engine::runtime::temp_store::{EpochStore, MeetAggrStore, RegularTempStore};
+use crate::engine::runtime::temp_store::{EpochStore, MeetAggrStore, RegularTempStore, TempStore};
 use crate::engine::runtime::transact::SessionTx;
 
 pub(crate) struct QueryLimiter {
@@ -105,6 +105,216 @@ impl<'a> SessionTx<'a> {
         let ret_area = stores.remove(&entry_symbol).ok_or(NoEntryError)?;
         Ok((ret_area, early_return))
     }
+
+    #[expect(
+        clippy::needless_borrow,
+        reason = "closure borrows &ruleset from pattern match binding"
+    )]
+    fn eval_compiled_ruleset_epoch_zero<'b>(
+        &self,
+        k: &'b MagicSymbol,
+        compiled_ruleset: &CompiledRuleSet,
+        stores: &BTreeMap<MagicSymbol, EpochStore>,
+        limiter: &QueryLimiter,
+        used_limiter: &AtomicBool,
+        poison: Poison,
+    ) -> Result<(&'b MagicSymbol, TempStore)> {
+        let new_store = match compiled_ruleset {
+            CompiledRuleSet::Rules(ruleset) => match compiled_ruleset.aggr_kind() {
+                AggrKind::None => {
+                    let res = self.initial_rule_non_aggr_eval(
+                        k,
+                        &ruleset,
+                        stores,
+                        limiter,
+                        poison.clone(),
+                    )?;
+                    used_limiter.fetch_or(res.0, Ordering::Relaxed);
+                    res.1.wrap()
+                }
+                AggrKind::Normal => {
+                    let res =
+                        self.initial_rule_aggr_eval(k, &ruleset, stores, limiter, poison.clone())?;
+                    used_limiter.fetch_or(res.0, Ordering::Relaxed);
+                    res.1.wrap()
+                }
+                AggrKind::Meet => {
+                    let new = self.initial_rule_meet_eval(k, &ruleset, stores, poison.clone())?;
+                    new.wrap()
+                }
+            },
+            CompiledRuleSet::Fixed(fixed) => {
+                let fixed_impl = fixed.fixed_impl.as_ref();
+                let mut out = RegularTempStore::default();
+                let payload = FixedRulePayload {
+                    manifest: &fixed,
+                    stores,
+                    tx: self,
+                };
+                fixed_impl.run(payload, &mut out, poison.clone())?;
+                out.wrap()
+            }
+        };
+        Ok((k, new_store))
+    }
+
+    fn run_epoch_zero_rules<'b>(
+        &self,
+        prog: &'b CompiledProgram,
+        stores: &BTreeMap<MagicSymbol, EpochStore>,
+        limiter: &QueryLimiter,
+        used_limiter: &AtomicBool,
+        poison: Poison,
+    ) -> Result<BTreeMap<&'b MagicSymbol, TempStore>> {
+        let execution = |(k, compiled_ruleset): (_, &CompiledRuleSet)| {
+            self.eval_compiled_ruleset_epoch_zero(
+                k,
+                compiled_ruleset,
+                stores,
+                limiter,
+                used_limiter,
+                poison.clone(),
+            )
+        };
+
+        let mut to_merge = BTreeMap::new();
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            let limiter_enabled = limiter.total.is_some();
+            for res in prog
+                .iter()
+                .filter(|(symb, _)| limiter_enabled && symb.is_prog_entry())
+                .map(execution)
+            {
+                let (k, new_store) = res?;
+                to_merge.insert(k, new_store);
+                if limiter.is_stopped() {
+                    break;
+                }
+            }
+            let execs = prog
+                .par_iter()
+                .filter(|(symb, _)| !(limiter_enabled && symb.is_prog_entry()))
+                .map(execution);
+            for res in execs.collect::<Vec<_>>() {
+                let (k, new_store) = res?;
+                to_merge.insert(k, new_store);
+            }
+        }
+        #[cfg(target_arch = "wasm32")]
+        {
+            for res in prog.iter().map(execution) {
+                let (k, new_store) = res?;
+                to_merge.insert(k, new_store);
+            }
+        }
+        Ok(to_merge)
+    }
+
+    #[expect(
+        clippy::needless_borrow,
+        reason = "closure borrows &ruleset from pattern match binding"
+    )]
+    fn eval_compiled_ruleset_subsequent_epoch<'b>(
+        &self,
+        k: &'b MagicSymbol,
+        compiled_ruleset: &CompiledRuleSet,
+        epoch: u32,
+        stores: &BTreeMap<MagicSymbol, EpochStore>,
+        limiter: &QueryLimiter,
+        used_limiter: &AtomicBool,
+        poison: Poison,
+    ) -> Result<(&'b MagicSymbol, TempStore)> {
+        let new_store = match compiled_ruleset {
+            CompiledRuleSet::Rules(ruleset) => {
+                match compiled_ruleset.aggr_kind() {
+                    AggrKind::None => {
+                        let res = self.incremental_rule_non_aggr_eval(
+                            k,
+                            &ruleset,
+                            epoch,
+                            stores,
+                            limiter,
+                            poison.clone(),
+                        )?;
+                        used_limiter.fetch_or(res.0, Ordering::Relaxed);
+                        res.1.wrap()
+                    }
+                    AggrKind::Meet => {
+                        let new =
+                            self.incremental_rule_meet_eval(k, &ruleset, stores, poison.clone())?;
+                        new.wrap()
+                    }
+                    AggrKind::Normal => {
+                        // not doing anything
+                        RegularTempStore::default().wrap()
+                    }
+                }
+            }
+            CompiledRuleSet::Fixed(_) => {
+                // no need to do anything, algos are only calculated once
+                RegularTempStore::default().wrap()
+            }
+        };
+        Ok((k, new_store))
+    }
+
+    fn run_subsequent_epoch_rules<'b>(
+        &self,
+        prog: &'b CompiledProgram,
+        stores: &BTreeMap<MagicSymbol, EpochStore>,
+        epoch: u32,
+        limiter: &QueryLimiter,
+        used_limiter: &AtomicBool,
+        poison: Poison,
+    ) -> Result<BTreeMap<&'b MagicSymbol, TempStore>> {
+        let execution = |(k, compiled_ruleset): (_, &CompiledRuleSet)| {
+            self.eval_compiled_ruleset_subsequent_epoch(
+                k,
+                compiled_ruleset,
+                epoch,
+                stores,
+                limiter,
+                used_limiter,
+                poison.clone(),
+            )
+        };
+
+        let mut to_merge = BTreeMap::new();
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            let limiter_enabled = limiter.total.is_some();
+            // entry rules with limiter must execute sequentially in order to get deterministic ordering
+            for res in prog
+                .iter()
+                .filter(|(symb, _)| limiter_enabled && symb.is_prog_entry())
+                .map(execution)
+            {
+                let (k, new_store) = res?;
+                to_merge.insert(k, new_store);
+                if limiter.is_stopped() {
+                    break;
+                }
+            }
+            let execs = prog
+                .par_iter()
+                .filter(|(symb, _)| !(limiter_enabled && symb.is_prog_entry()))
+                .map(execution);
+            for res in execs.collect::<Vec<_>>() {
+                let (k, new_store) = res?;
+                to_merge.insert(k, new_store);
+            }
+        }
+        #[cfg(target_arch = "wasm32")]
+        {
+            for res in prog.iter().map(execution) {
+                let (k, new_store) = res?;
+                to_merge.insert(k, new_store);
+            }
+        }
+        Ok(to_merge)
+    }
+
     /// returns true if early return is activated
     fn semi_naive_magic_evaluate(
         &self,
@@ -119,177 +329,30 @@ impl<'a> SessionTx<'a> {
             skip: num_to_skip,
             counter: 0.into(),
         };
-
         let used_limiter: AtomicBool = false.into();
 
         for epoch in 0u32.. {
             debug!("epoch {}", epoch);
-            let mut to_merge = BTreeMap::new();
             let borrowed_stores = stores as &BTreeMap<_, _>;
-            if epoch == 0 {
-                #[expect(
-                    clippy::needless_borrow,
-                    reason = "closure borrows &ruleset from pattern match binding"
-                )]
-                let execution = |(k, compiled_ruleset): (_, &CompiledRuleSet)| -> Result<_> {
-                    let new_store = match compiled_ruleset {
-                        CompiledRuleSet::Rules(ruleset) => match compiled_ruleset.aggr_kind() {
-                            AggrKind::None => {
-                                let res = self.initial_rule_non_aggr_eval(
-                                    k,
-                                    &ruleset,
-                                    borrowed_stores,
-                                    &limiter,
-                                    poison.clone(),
-                                )?;
-                                used_limiter.fetch_or(res.0, Ordering::Relaxed);
-                                res.1.wrap()
-                            }
-                            AggrKind::Normal => {
-                                let res = self.initial_rule_aggr_eval(
-                                    k,
-                                    &ruleset,
-                                    borrowed_stores,
-                                    &limiter,
-                                    poison.clone(),
-                                )?;
-                                used_limiter.fetch_or(res.0, Ordering::Relaxed);
-                                res.1.wrap()
-                            }
-                            AggrKind::Meet => {
-                                let new = self.initial_rule_meet_eval(
-                                    k,
-                                    &ruleset,
-                                    borrowed_stores,
-                                    poison.clone(),
-                                )?;
-                                new.wrap()
-                            }
-                        },
-                        CompiledRuleSet::Fixed(fixed) => {
-                            let fixed_impl = fixed.fixed_impl.as_ref();
-                            let mut out = RegularTempStore::default();
-                            let payload = FixedRulePayload {
-                                manifest: &fixed,
-                                stores: borrowed_stores,
-                                tx: self,
-                            };
-                            fixed_impl.run(payload, &mut out, poison.clone())?;
-                            out.wrap()
-                        }
-                    };
-                    Ok((k, new_store))
-                };
-                #[cfg(not(target_arch = "wasm32"))]
-                {
-                    let limiter_enabled = limiter.total.is_some();
-                    for res in prog
-                        .iter()
-                        .filter(|(symb, _)| limiter_enabled && symb.is_prog_entry())
-                        .map(execution)
-                    {
-                        let (k, new_store) = res?;
-                        to_merge.insert(k, new_store);
-                        if limiter.is_stopped() {
-                            break;
-                        }
-                    }
-
-                    let execs = prog
-                        .par_iter()
-                        .filter(|(symb, _)| !(limiter_enabled && symb.is_prog_entry()))
-                        .map(execution);
-
-                    for res in execs.collect::<Vec<_>>() {
-                        let (k, new_store) = res?;
-                        to_merge.insert(k, new_store);
-                    }
-                }
-                #[cfg(target_arch = "wasm32")]
-                {
-                    for res in prog.iter().map(execution) {
-                        let (k, new_store) = res?;
-                        to_merge.insert(k, new_store);
-                    }
-                }
+            let to_merge = if epoch == 0 {
+                self.run_epoch_zero_rules(
+                    prog,
+                    borrowed_stores,
+                    &limiter,
+                    &used_limiter,
+                    poison.clone(),
+                )?
             } else {
-                // Follow up epoch > 0
-                #[expect(
-                    clippy::needless_borrow,
-                    reason = "closure borrows &ruleset from pattern match binding"
-                )]
-                let execution = |(k, compiled_ruleset): (_, &CompiledRuleSet)| -> Result<_> {
-                    let new_store = match compiled_ruleset {
-                        CompiledRuleSet::Rules(ruleset) => {
-                            match compiled_ruleset.aggr_kind() {
-                                AggrKind::None => {
-                                    let res = self.incremental_rule_non_aggr_eval(
-                                        k,
-                                        &ruleset,
-                                        epoch,
-                                        borrowed_stores,
-                                        &limiter,
-                                        poison.clone(),
-                                    )?;
-                                    used_limiter.fetch_or(res.0, Ordering::Relaxed);
-                                    res.1.wrap()
-                                }
-                                AggrKind::Meet => {
-                                    let new = self.incremental_rule_meet_eval(
-                                        k,
-                                        &ruleset,
-                                        borrowed_stores,
-                                        poison.clone(),
-                                    )?;
-                                    new.wrap()
-                                }
-                                AggrKind::Normal => {
-                                    // not doing anything
-                                    RegularTempStore::default().wrap()
-                                }
-                            }
-                        }
+                self.run_subsequent_epoch_rules(
+                    prog,
+                    borrowed_stores,
+                    epoch,
+                    &limiter,
+                    &used_limiter,
+                    poison.clone(),
+                )?
+            };
 
-                        CompiledRuleSet::Fixed(_) => {
-                            // no need to do anything, algos are only calculated once
-                            RegularTempStore::default().wrap()
-                        }
-                    };
-                    Ok((k, new_store))
-                };
-                #[cfg(not(target_arch = "wasm32"))]
-                {
-                    let limiter_enabled = limiter.total.is_some();
-                    // entry rules with limiter must execute sequentially in order to get deterministic ordering
-                    for res in prog
-                        .iter()
-                        .filter(|(symb, _)| limiter_enabled && symb.is_prog_entry())
-                        .map(execution)
-                    {
-                        let (k, new_store) = res?;
-                        to_merge.insert(k, new_store);
-                        if limiter.is_stopped() {
-                            break;
-                        }
-                    }
-
-                    let execs = prog
-                        .par_iter()
-                        .filter(|(symb, _)| !(limiter_enabled && symb.is_prog_entry()))
-                        .map(execution);
-                    for res in execs.collect::<Vec<_>>() {
-                        let (k, new_store) = res?;
-                        to_merge.insert(k, new_store);
-                    }
-                }
-                #[cfg(target_arch = "wasm32")]
-                {
-                    for res in prog.iter().map(execution) {
-                        let (k, new_store) = res?;
-                        to_merge.insert(k, new_store);
-                    }
-                }
-            }
             let mut changed = false;
             for (k, new_store) in to_merge {
                 let old_store = stores

--- a/crates/mneme/src/engine/runtime/imperative.rs
+++ b/crates/mneme/src/engine/runtime/imperative.rs
@@ -15,7 +15,9 @@ use itertools::Itertools;
 use crate::engine::data::program::RelationOp;
 use crate::engine::data::relation::{ColType, ColumnDef, NullableColType, StoredRelationMetadata};
 use crate::engine::data::symb::Symbol;
-use crate::engine::parse::{ImperativeCondition, ImperativeProgram, ImperativeStmt, SourceSpan};
+use crate::engine::parse::{
+    ImperativeCondition, ImperativeProgram, ImperativeStmt, ImperativeStmtClause, SourceSpan,
+};
 use crate::engine::runtime::callback::CallbackCollector;
 use crate::engine::runtime::db::{
     RunningQueryCleanup, RunningQueryHandle, seconds_since_the_epoch,
@@ -28,6 +30,55 @@ enum ControlCode {
     Termination(NamedRows),
     Break(Option<CompactString>, SourceSpan),
     Continue(Option<CompactString>, SourceSpan),
+}
+
+struct ImperativeCallbackCtx<'ctx> {
+    cleanups: &'ctx mut Vec<(Vec<u8>, Vec<u8>)>,
+    callback_targets: &'ctx BTreeSet<CompactString>,
+    callback_collector: &'ctx mut CallbackCollector,
+    poison: &'ctx Poison,
+    readonly: bool,
+}
+
+fn execute_temp_swap_stmt(
+    tx: &mut SessionTx<'_>,
+    left: &CompactString,
+    right: &CompactString,
+) -> Result<()> {
+    tx.rename_temp_relation(
+        Symbol::new(left.clone(), Default::default()),
+        Symbol::new(CompactString::from("_*temp*"), Default::default()),
+    )?;
+    tx.rename_temp_relation(
+        Symbol::new(right.clone(), Default::default()),
+        Symbol::new(left.clone(), Default::default()),
+    )?;
+    tx.rename_temp_relation(
+        Symbol::new(CompactString::from("_*temp*"), Default::default()),
+        Symbol::new(right.clone(), Default::default()),
+    )?;
+    Ok(())
+}
+
+fn execute_program_stmt<'s, S: Storage<'s>>(
+    db: &'s Db<S>,
+    prog: &ImperativeStmtClause,
+    tx: &mut SessionTx<'_>,
+    cur_vld: ValidityTs,
+    ctx: &mut ImperativeCallbackCtx<'_>,
+) -> Result<NamedRows> {
+    let ret = db.execute_single_program(
+        prog.prog.clone(),
+        tx,
+        ctx.cleanups,
+        cur_vld,
+        ctx.callback_targets,
+        ctx.callback_collector,
+    )?;
+    if let Some(store_as) = &prog.store_as {
+        tx.script_store_as_relation(db, store_as, &ret, cur_vld)?;
+    }
+    Ok(ret)
 }
 
 impl<'s, S: Storage<'s>> Db<S> {
@@ -62,20 +113,158 @@ impl<'s, S: Storage<'s>> Db<S> {
         Ok(!res.rows.is_empty())
     }
 
+    fn collect_return_rows(
+        &'s self,
+        returns: &[Either<ImperativeStmtClause, CompactString>],
+        tx: &mut SessionTx<'_>,
+        cur_vld: ValidityTs,
+        ctx: &mut ImperativeCallbackCtx<'_>,
+    ) -> Result<ControlCode> {
+        if returns.is_empty() {
+            return Ok(ControlCode::Termination(NamedRows::default()));
+        }
+        let mut current = None;
+        for nxt in returns.iter().rev() {
+            let mut nr = match nxt {
+                Left(prog) => self.execute_single_program(
+                    prog.prog.clone(),
+                    tx,
+                    ctx.cleanups,
+                    cur_vld,
+                    ctx.callback_targets,
+                    ctx.callback_collector,
+                )?,
+                Right(rel) => {
+                    let relation = tx.get_relation(rel, false)?;
+                    relation.as_named_rows(tx)?
+                }
+            };
+            if let Left(pg) = nxt
+                && let Some(store_as) = &pg.store_as
+            {
+                tx.script_store_as_relation(self, store_as, &nr, cur_vld)?;
+            }
+            nr.next = current;
+            current = Some(Box::new(nr))
+        }
+        #[expect(
+            clippy::expect_used,
+            reason = "returns is non-empty (checked above), so loop runs at least once"
+        )]
+        Ok(ControlCode::Termination(
+            *current.expect("returns is non-empty"),
+        ))
+    }
+
+    fn execute_ignore_error_program(
+        &'s self,
+        prog: &ImperativeStmtClause,
+        tx: &mut SessionTx<'_>,
+        cur_vld: ValidityTs,
+        ctx: &mut ImperativeCallbackCtx<'_>,
+    ) -> Result<NamedRows> {
+        match self.execute_single_program(
+            prog.prog.clone(),
+            tx,
+            ctx.cleanups,
+            cur_vld,
+            ctx.callback_targets,
+            ctx.callback_collector,
+        ) {
+            Ok(res) => {
+                if let Some(store_as) = &prog.store_as {
+                    tx.script_store_as_relation(self, store_as, &res, cur_vld)?;
+                }
+                Ok(res)
+            }
+            Err(_) => Ok(NamedRows::new(
+                vec!["status".to_string()],
+                vec![vec![DataValue::from("FAILED")]],
+            )),
+        }
+    }
+
+    fn execute_if_stmt(
+        &'s self,
+        condition: &ImperativeCondition,
+        then_branch: &ImperativeProgram,
+        else_branch: &ImperativeProgram,
+        negated: bool,
+        ret: &mut NamedRows,
+        tx: &mut SessionTx<'_>,
+        cur_vld: ValidityTs,
+        ctx: &mut ImperativeCallbackCtx<'_>,
+    ) -> Result<Option<ControlCode>> {
+        let cond_val = self.execute_imperative_condition(
+            condition,
+            tx,
+            ctx.cleanups,
+            cur_vld,
+            ctx.callback_targets,
+            ctx.callback_collector,
+        )?;
+        let to_execute = if cond_val ^ negated {
+            then_branch
+        } else {
+            else_branch
+        };
+        match self.execute_imperative_stmts(to_execute, tx, cur_vld, ctx)? {
+            Left(rows) => {
+                *ret = rows;
+                Ok(None)
+            }
+            Right(ctrl) => Ok(Some(ctrl)),
+        }
+    }
+
+    fn execute_loop_stmt(
+        &'s self,
+        label: &Option<CompactString>,
+        body: &ImperativeProgram,
+        ret: &mut NamedRows,
+        tx: &mut SessionTx<'_>,
+        cur_vld: ValidityTs,
+        ctx: &mut ImperativeCallbackCtx<'_>,
+    ) -> Result<Option<ControlCode>> {
+        *ret = NamedRows::default();
+        loop {
+            ctx.poison.check()?;
+            match self.execute_imperative_stmts(body, tx, cur_vld, ctx)? {
+                Left(_) => {}
+                Right(ctrl) => match ctrl {
+                    ControlCode::Termination(ret_val) => {
+                        return Ok(Some(ControlCode::Termination(ret_val)));
+                    }
+                    ControlCode::Break(break_label, span) => {
+                        if break_label.is_none() || break_label == *label {
+                            break;
+                        } else {
+                            return Ok(Some(ControlCode::Break(break_label, span)));
+                        }
+                    }
+                    ControlCode::Continue(cont_label, span) => {
+                        if cont_label.is_none() || cont_label == *label {
+                            continue;
+                        } else {
+                            return Ok(Some(ControlCode::Continue(cont_label, span)));
+                        }
+                    }
+                },
+            }
+        }
+        Ok(None)
+    }
+
     fn execute_imperative_stmts(
         &'s self,
         ps: &ImperativeProgram,
         tx: &mut SessionTx<'_>,
-        cleanups: &mut Vec<(Vec<u8>, Vec<u8>)>,
         cur_vld: ValidityTs,
-        callback_targets: &BTreeSet<CompactString>,
-        callback_collector: &mut CallbackCollector,
-        poison: &Poison,
-        readonly: bool,
+        ctx: &mut ImperativeCallbackCtx<'_>,
     ) -> Result<Either<NamedRows, ControlCode>> {
         let mut ret = NamedRows::default();
         for p in ps {
-            poison.check()?;
+            ctx.poison.check()?;
             match p {
                 ImperativeStmt::Break { target, span, .. } => {
                     return Ok(Right(ControlCode::Break(target.clone(), *span)));
@@ -84,40 +273,7 @@ impl<'s, S: Storage<'s>> Db<S> {
                     return Ok(Right(ControlCode::Continue(target.clone(), *span)));
                 }
                 ImperativeStmt::Return { returns } => {
-                    if returns.is_empty() {
-                        return Ok(Right(ControlCode::Termination(NamedRows::default())));
-                    }
-                    let mut current = None;
-                    for nxt in returns.iter().rev() {
-                        let mut nr = match nxt {
-                            Left(prog) => self.execute_single_program(
-                                prog.prog.clone(),
-                                tx,
-                                cleanups,
-                                cur_vld,
-                                callback_targets,
-                                callback_collector,
-                            )?,
-                            Right(rel) => {
-                                let relation = tx.get_relation(rel, false)?;
-                                relation.as_named_rows(tx)?
-                            }
-                        };
-                        if let Left(pg) = nxt
-                            && let Some(store_as) = &pg.store_as
-                        {
-                            tx.script_store_as_relation(self, store_as, &nr, cur_vld)?;
-                        }
-                        nr.next = current;
-                        current = Some(Box::new(nr))
-                    }
-                    #[expect(
-                        clippy::expect_used,
-                        reason = "returns is non-empty (checked above), so loop runs at least once"
-                    )]
-                    return Ok(Right(ControlCode::Termination(
-                        *current.expect("returns is non-empty"),
-                    )));
+                    return Ok(Right(self.collect_return_rows(returns, tx, cur_vld, ctx)?));
                 }
                 ImperativeStmt::TempDebug { temp, .. } => {
                     let relation = tx.get_relation(temp, false)?;
@@ -125,46 +281,16 @@ impl<'s, S: Storage<'s>> Db<S> {
                     ret = NamedRows::default();
                 }
                 ImperativeStmt::SysOp { sysop, .. } => {
-                    ret = self.run_sys_op_with_tx(tx, &sysop.sysop, readonly, true)?;
+                    ret = self.run_sys_op_with_tx(tx, &sysop.sysop, ctx.readonly, true)?;
                     if let Some(store_as) = &sysop.store_as {
                         tx.script_store_as_relation(self, store_as, &ret, cur_vld)?;
                     }
                 }
                 ImperativeStmt::Program { prog, .. } => {
-                    ret = self.execute_single_program(
-                        prog.prog.clone(),
-                        tx,
-                        cleanups,
-                        cur_vld,
-                        callback_targets,
-                        callback_collector,
-                    )?;
-                    if let Some(store_as) = &prog.store_as {
-                        tx.script_store_as_relation(self, store_as, &ret, cur_vld)?;
-                    }
+                    ret = execute_program_stmt(self, prog, tx, cur_vld, ctx)?;
                 }
                 ImperativeStmt::IgnoreErrorProgram { prog, .. } => {
-                    match self.execute_single_program(
-                        prog.prog.clone(),
-                        tx,
-                        cleanups,
-                        cur_vld,
-                        callback_targets,
-                        callback_collector,
-                    ) {
-                        Ok(res) => {
-                            if let Some(store_as) = &prog.store_as {
-                                tx.script_store_as_relation(self, store_as, &res, cur_vld)?;
-                            }
-                            ret = res
-                        }
-                        Err(_) => {
-                            ret = NamedRows::new(
-                                vec!["status".to_string()],
-                                vec![vec![DataValue::from("FAILED")]],
-                            )
-                        }
-                    }
+                    ret = self.execute_ignore_error_program(prog, tx, cur_vld, ctx)?;
                 }
                 ImperativeStmt::If {
                     condition,
@@ -173,83 +299,28 @@ impl<'s, S: Storage<'s>> Db<S> {
                     negated,
                     ..
                 } => {
-                    let cond_val = self.execute_imperative_condition(
+                    if let Some(ctrl) = self.execute_if_stmt(
                         condition,
+                        then_branch,
+                        else_branch,
+                        *negated,
+                        &mut ret,
                         tx,
-                        cleanups,
                         cur_vld,
-                        callback_targets,
-                        callback_collector,
-                    )?;
-                    let cond_val = if *negated { !cond_val } else { cond_val };
-                    let to_execute = if cond_val { then_branch } else { else_branch };
-                    match self.execute_imperative_stmts(
-                        to_execute,
-                        tx,
-                        cleanups,
-                        cur_vld,
-                        callback_targets,
-                        callback_collector,
-                        poison,
-                        readonly,
+                        ctx,
                     )? {
-                        Left(rows) => {
-                            ret = rows;
-                        }
-                        Right(ctrl) => return Ok(Right(ctrl)),
+                        return Ok(Right(ctrl));
                     }
                 }
                 ImperativeStmt::Loop { label, body, .. } => {
-                    ret = Default::default();
-                    loop {
-                        poison.check()?;
-
-                        match self.execute_imperative_stmts(
-                            body,
-                            tx,
-                            cleanups,
-                            cur_vld,
-                            callback_targets,
-                            callback_collector,
-                            poison,
-                            readonly,
-                        )? {
-                            Left(_) => {}
-                            Right(ctrl) => match ctrl {
-                                ControlCode::Termination(ret) => {
-                                    return Ok(Right(ControlCode::Termination(ret)));
-                                }
-                                ControlCode::Break(break_label, span) => {
-                                    if break_label.is_none() || break_label == *label {
-                                        break;
-                                    } else {
-                                        return Ok(Right(ControlCode::Break(break_label, span)));
-                                    }
-                                }
-                                ControlCode::Continue(cont_label, span) => {
-                                    if cont_label.is_none() || cont_label == *label {
-                                        continue;
-                                    } else {
-                                        return Ok(Right(ControlCode::Continue(cont_label, span)));
-                                    }
-                                }
-                            },
-                        }
+                    if let Some(ctrl) =
+                        self.execute_loop_stmt(label, body, &mut ret, tx, cur_vld, ctx)?
+                    {
+                        return Ok(Right(ctrl));
                     }
                 }
                 ImperativeStmt::TempSwap { left, right, .. } => {
-                    tx.rename_temp_relation(
-                        Symbol::new(left.clone(), Default::default()),
-                        Symbol::new(CompactString::from("_*temp*"), Default::default()),
-                    )?;
-                    tx.rename_temp_relation(
-                        Symbol::new(right.clone(), Default::default()),
-                        Symbol::new(left.clone(), Default::default()),
-                    )?;
-                    tx.rename_temp_relation(
-                        Symbol::new(CompactString::from("_*temp*"), Default::default()),
-                        Symbol::new(right.clone(), Default::default()),
-                    )?;
+                    execute_temp_swap_stmt(tx, left, right)?;
                     ret = NamedRows::default();
                     break;
                 }
@@ -318,16 +389,14 @@ impl<'s, S: Storage<'s>> Db<S> {
                 running_queries: self.running_queries.clone(),
             };
 
-            match self.execute_imperative_stmts(
-                ps,
-                &mut tx,
-                &mut cleanups,
-                cur_vld,
-                &callback_targets,
-                &mut callback_collector,
-                &poison,
+            let mut ctx = ImperativeCallbackCtx {
+                cleanups: &mut cleanups,
+                callback_targets: &callback_targets,
+                callback_collector: &mut callback_collector,
+                poison: &poison,
                 readonly,
-            )? {
+            };
+            match self.execute_imperative_stmts(ps, &mut tx, cur_vld, &mut ctx)? {
                 Left(res) => ret = res,
                 Right(ctrl) => match ctrl {
                     ControlCode::Termination(res) => {


### PR DESCRIPTION
Closes #1178, #1179

## Changes
- Depth-13 nesting flattened to max depth 5
- 5 long functions decomposed into focused helpers
- Behavior unchanged (refactoring only)

## Details

### Task 1 — Deep nesting (#1179)
`parse_fixed_rule` in `parse/query.rs` had a match block nested 13 levels deep. Extracted the three match arms into:
- `parse_fixed_rule_rel_arg<'i>` — handles `rel_arg` variant
- `parse_fixed_relation_rel_arg<'i>` — handles `relation` rel_arg variant
- `parse_fixed_named_relation_rel_arg<'i>` — handles named relation rel_arg variant

Max nesting in the function is now 4 levels.

### Task 2 — Long functions (#1178)
Five functions decomposed (all now ≤80 lines):

**`parse/query.rs`**
- `parse_query` (509→~50 lines): extracted 14+ helpers including `add_rule_to_program`, `add_fixed_rule_to_program`, `add_const_rule_to_program`, option parsers, sort/unique helpers
- `parse_atom` (207→~50 lines): extracted `parse_relation_apply_atom`, `parse_search_apply_atom`, `parse_relation_named_apply_atom`, `parse_unify_atom`, `parse_unify_multi_atom`, `parse_rule_apply_atom`
- `add_const_rule_to_program` (extracted helper, trimmed to ≤80 lines): extracted `build_and_insert_const_rule`, `extend_head_from_params`

**`query/eval.rs`**
- `semi_naive_magic_evaluate` (199→~52 lines): extracted `run_epoch_zero_rules`, `run_subsequent_epoch_rules`, `eval_compiled_ruleset_epoch_zero`, `eval_compiled_ruleset_subsequent_epoch`

**`runtime/imperative.rs`**
- `execute_imperative_stmts` (195→~58 lines): introduced `ImperativeCallbackCtx<'ctx>` to bundle repeated parameters; extracted `execute_program_stmt`, `execute_temp_swap_stmt`; refactored `execute_if_stmt` and `execute_loop_stmt` signatures to take `ret: &mut NamedRows` and return `Result<Option<ControlCode>>`

## Observations
- `initial_rule_aggr_eval` (138 lines), `incremental_rule_non_aggr_eval` (102 lines), `incremental_rule_meet_eval` (95 lines), and `execute_imperative` (101 lines) were already long before this PR and were not among the 5 identified decomposition targets; left unchanged.