### PR TITLE
refactor(theatron): TUI code quality — constants and lint denials

### DIFF
--- a/crates/theatron/tui/src/api/client.rs
+++ b/crates/theatron/tui/src/api/client.rs
@@ -1,7 +1,7 @@
 use reqwest::{Client, Response, StatusCode, header};
 use snafu::prelude::*;
 
-use super::error::{AuthSnafu, HttpSnafu, Result, ServerSnafu};
+use super::error::{ApiError, AuthSnafu, HttpSnafu, Result, ServerSnafu};
 use super::types::*;
 
 /// Percent-encode a value for use in a URL path segment.
@@ -37,7 +37,7 @@ pub(crate) fn build_http_client(token: Option<&str>) -> Result<Client> {
 
     if let Some(t) = token {
         let auth_value = header::HeaderValue::from_str(&format!("Bearer {t}"))
-            .expect("token must be a valid header value");
+            .map_err(|_invalid| ApiError::InvalidToken)?;
         headers.insert(header::AUTHORIZATION, auth_value);
     }
 

--- a/crates/theatron/tui/src/api/error.rs
+++ b/crates/theatron/tui/src/api/error.rs
@@ -26,6 +26,10 @@ pub enum ApiError {
     /// Credentials rejected by the gateway.
     #[snafu(display("authentication failed: token expired or invalid"))]
     Auth,
+
+    /// Token contains characters that are not valid in an HTTP header value.
+    #[snafu(display("invalid token: contains characters not valid in HTTP headers"))]
+    InvalidToken,
 }
 
 pub(crate) type Result<T> = std::result::Result<T, ApiError>;

--- a/crates/theatron/tui/src/api/types.rs
+++ b/crates/theatron/tui/src/api/types.rs
@@ -253,6 +253,7 @@ pub struct SessionsResponse {
 }
 
 #[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "test assertions may panic on failure")]
 mod tests {
     use super::*;
 

--- a/crates/theatron/tui/src/app.rs
+++ b/crates/theatron/tui/src/app.rs
@@ -30,6 +30,11 @@ pub use crate::state::{
     TabCompletion, ToolApprovalOverlay, ToolCallInfo, View, ViewStack,
 };
 
+/// Default terminal width used before the first resize event arrives.
+const DEFAULT_TERMINAL_WIDTH: u16 = 120;
+/// Default terminal height used before the first resize event arrives.
+const DEFAULT_TERMINAL_HEIGHT: u16 = 40;
+
 pub struct App {
     pub config: Config,
     pub client: ApiClient,
@@ -169,8 +174,8 @@ impl App {
             error_toast: None,
             success_toast: None,
             tab_completion: None,
-            terminal_width: 120,
-            terminal_height: 40,
+            terminal_width: DEFAULT_TERMINAL_WIDTH,
+            terminal_height: DEFAULT_TERMINAL_HEIGHT,
             command_palette: CommandPaletteState::default(),
             session_cost_cents: 0,
             context_usage_pct: None,
@@ -505,6 +510,10 @@ impl App {
 }
 
 #[cfg(test)]
+#[expect(
+    clippy::unwrap_used,
+    reason = "test helper; ApiClient construction failure indicates a bug in test setup"
+)]
 pub(crate) mod test_helpers {
     use super::*;
     use std::collections::{HashMap, HashSet};
@@ -554,8 +563,8 @@ pub(crate) mod test_helpers {
             error_toast: None,
             success_toast: None,
             tab_completion: None,
-            terminal_width: 120,
-            terminal_height: 40,
+            terminal_width: DEFAULT_TERMINAL_WIDTH,
+            terminal_height: DEFAULT_TERMINAL_HEIGHT,
             command_palette: CommandPaletteState::default(),
             session_cost_cents: 0,
             context_usage_pct: None,
@@ -611,6 +620,7 @@ pub(crate) mod test_helpers {
 #[cfg(test)]
 mod tests {
     use super::test_helpers::*;
+    use super::{DEFAULT_TERMINAL_HEIGHT, DEFAULT_TERMINAL_WIDTH};
     use crate::state::{ChatMessage, OpsState};
 
     #[test]
@@ -624,8 +634,8 @@ mod tests {
         assert!(app.messages.is_empty());
         assert!(app.agents.is_empty());
         assert_eq!(app.scroll_offset, 0);
-        assert_eq!(app.terminal_width, 120);
-        assert_eq!(app.terminal_height, 40);
+        assert_eq!(app.terminal_width, DEFAULT_TERMINAL_WIDTH);
+        assert_eq!(app.terminal_height, DEFAULT_TERMINAL_HEIGHT);
         assert!(!app.sse_connected);
         assert!(app.sse_disconnected_at.is_none());
     }

--- a/crates/theatron/tui/src/clipboard.rs
+++ b/crates/theatron/tui/src/clipboard.rs
@@ -47,6 +47,7 @@ fn copy_osc52(text: &str) -> Result<(), String> {
 }
 
 #[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "test assertions may panic on failure")]
 mod tests {
     #[test]
     fn copy_osc52_generates_valid_sequence() {

--- a/crates/theatron/tui/src/command/mod.rs
+++ b/crates/theatron/tui/src/command/mod.rs
@@ -291,6 +291,7 @@ fn filter_commands(input: &str) -> Vec<Suggestion> {
 }
 
 #[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "test assertions may panic on failure")]
 mod tests {
     use super::*;
 

--- a/crates/theatron/tui/src/config.rs
+++ b/crates/theatron/tui/src/config.rs
@@ -147,6 +147,7 @@ fn write_config(path: &Path, content: &str) -> Result<()> {
 }
 
 #[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "test assertions may panic on failure")]
 mod tests {
     use super::*;
 

--- a/crates/theatron/tui/src/hyperlink.rs
+++ b/crates/theatron/tui/src/hyperlink.rs
@@ -123,6 +123,10 @@ fn probe_hyperlink_support() -> bool {
 /// The caller is responsible for skipping code blocks and inline code —
 /// those contexts should not be passed to this function.
 pub fn detect_urls(text: &str) -> Vec<(usize, usize, &str)> {
+    #[expect(
+        clippy::expect_used,
+        reason = "regex is a compile-time string literal and is always valid"
+    )]
     static URL_RE: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(r#"https?://[^\s<>{}|\\^`\[\]'"]+"#).expect("hyperlink URL regex is valid")
     });
@@ -176,6 +180,10 @@ fn trim_trailing_punct(url: &str) -> usize {
 /// Not yet called by the renderer; kept in `#[cfg(test)]` until wired in.
 #[cfg(test)]
 fn detect_file_paths(text: &str) -> Vec<(usize, usize, &str, String)> {
+    #[expect(
+        clippy::expect_used,
+        reason = "regex is a compile-time string literal and is always valid"
+    )]
     static PATH_RE: LazyLock<Regex> = LazyLock::new(|| {
         // crates/foo/src/bar.rs:142  or  src/foo.rs  or  ./src/foo.ts
         Regex::new(r"(?:\.{0,2}/)?(?:[a-zA-Z0-9_\-]+/)+[a-zA-Z0-9_\-]+\.[a-zA-Z]{1,6}(?::[0-9]+)?")

--- a/crates/theatron/tui/src/id.rs
+++ b/crates/theatron/tui/src/id.rs
@@ -71,6 +71,7 @@ impl_id!(ToolId);
 impl_id!(PlanId);
 
 #[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "test assertions may panic on failure")]
 mod tests {
     use super::*;
 

--- a/crates/theatron/tui/src/lib.rs
+++ b/crates/theatron/tui/src/lib.rs
@@ -1,4 +1,5 @@
 //! TUI entry point for the Aletheia client.
+#![deny(clippy::unwrap_used, clippy::expect_used)]
 
 mod actions;
 mod api;
@@ -100,9 +101,12 @@ async fn run_tui_inner(
     result
 }
 
+/// Tick interval in milliseconds — drives spinner animation and cursor blink (~30 fps).
+const TICK_INTERVAL_MS: u64 = 33;
+
 async fn run_loop(mut terminal: DefaultTerminal, app: &mut App) -> error::Result<()> {
     let mut term_events = EventStream::new();
-    let mut tick = tokio::time::interval(std::time::Duration::from_millis(33));
+    let mut tick = tokio::time::interval(std::time::Duration::from_millis(TICK_INTERVAL_MS));
     tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
     loop {
@@ -220,6 +224,7 @@ async fn recv_stream(
 }
 
 #[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "test assertions may panic on failure")]
 mod tests {
     use super::*;
 

--- a/crates/theatron/tui/src/markdown.rs
+++ b/crates/theatron/tui/src/markdown.rs
@@ -541,6 +541,7 @@ fn current_style(stack: &[Style]) -> Style {
 }
 
 #[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "test assertions may panic on failure")]
 mod tests {
     use super::*;
     use ratatui::style::{Color, Modifier};

--- a/crates/theatron/tui/src/state/memory.rs
+++ b/crates/theatron/tui/src/state/memory.rs
@@ -293,6 +293,7 @@ impl Default for MemoryInspectorState {
 }
 
 #[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "test assertions may panic on failure")]
 mod tests {
     use super::*;
 

--- a/crates/theatron/tui/src/state/ops.rs
+++ b/crates/theatron/tui/src/state/ops.rs
@@ -290,6 +290,7 @@ fn parse_diff_from_output(output: &str, tool_name: &str) -> Option<OpsDiffEntry>
 }
 
 #[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "test assertions may panic on failure")]
 mod tests {
     use super::*;
 

--- a/crates/theatron/tui/src/state/overlay.rs
+++ b/crates/theatron/tui/src/state/overlay.rs
@@ -74,6 +74,7 @@ pub struct PlanStepApproval {
 }
 
 #[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "test assertions may panic on failure")]
 mod tests {
     use super::*;
 

--- a/crates/theatron/tui/src/state/settings.rs
+++ b/crates/theatron/tui/src/state/settings.rs
@@ -389,6 +389,7 @@ fn field(
 }
 
 #[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "test assertions may panic on failure")]
 mod tests {
     use super::*;
 

--- a/crates/theatron/tui/src/state/tab.rs
+++ b/crates/theatron/tui/src/state/tab.rs
@@ -233,6 +233,7 @@ impl TabBar {
 }
 
 #[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "test assertions may panic on failure")]
 mod tests {
     use super::*;
 

--- a/crates/theatron/tui/src/state/view_stack.rs
+++ b/crates/theatron/tui/src/state/view_stack.rs
@@ -67,8 +67,11 @@ impl ViewStack {
     }
 
     /// The currently active view (top of stack).
+    #[expect(
+        clippy::expect_used,
+        reason = "ViewStack invariant: stack is never empty — new() initialises with Home and pop() guards the minimum"
+    )]
     pub fn current(&self) -> &View {
-        // SAFETY: invariant guarantees at least one element.
         self.stack.last().expect("ViewStack invariant: never empty")
     }
 

--- a/crates/theatron/tui/src/state/virtual_scroll.rs
+++ b/crates/theatron/tui/src/state/virtual_scroll.rs
@@ -231,6 +231,7 @@ pub(crate) fn estimate_message_height(text_len: usize, has_tools: bool, width: u
 }
 
 #[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "test assertions may panic on failure")]
 mod tests {
     use super::*;
 

--- a/crates/theatron/tui/src/update/api.rs
+++ b/crates/theatron/tui/src/update/api.rs
@@ -242,6 +242,7 @@ fn extract_texts_from_array(arr: &[serde_json::Value]) -> Option<String> {
 }
 
 #[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "test assertions may panic on failure")]
 mod tests {
     use super::*;
 

--- a/crates/theatron/tui/src/update/memory.rs
+++ b/crates/theatron/tui/src/update/memory.rs
@@ -379,6 +379,7 @@ struct FactsListResponse {
 }
 
 #[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "test assertions may panic on failure")]
 mod tests {
     use super::*;
     use crate::app::test_helpers::*;

--- a/crates/theatron/tui/src/update/mod.rs
+++ b/crates/theatron/tui/src/update/mod.rs
@@ -281,6 +281,7 @@ pub(crate) async fn update(app: &mut App, msg: Msg) {
 }
 
 #[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "test assertions may panic on failure")]
 mod tests {
     use super::*;
     use crate::app::test_helpers::test_app;

--- a/crates/theatron/tui/src/update/selection.rs
+++ b/crates/theatron/tui/src/update/selection.rs
@@ -281,6 +281,7 @@ fn show_toast(app: &mut App, message: &str) {
 }
 
 #[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "test assertions may panic on failure")]
 mod tests {
     use super::*;
     use crate::app::test_helpers::*;

--- a/crates/theatron/tui/src/update/settings.rs
+++ b/crates/theatron/tui/src/update/settings.rs
@@ -221,6 +221,7 @@ pub fn is_editing(app: &App) -> bool {
 }
 
 #[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "test assertions may panic on failure")]
 mod tests {
     use super::*;
     use crate::app::test_helpers::*;

--- a/crates/theatron/tui/src/update/sse.rs
+++ b/crates/theatron/tui/src/update/sse.rs
@@ -189,6 +189,7 @@ pub(crate) async fn handle_sse_distill_after(app: &mut App, nous_id: NousId) {
 }
 
 #[cfg(test)]
+#[expect(clippy::expect_used, reason = "test assertions may panic on failure")]
 mod tests {
     use super::*;
     use crate::app::test_helpers::*;

--- a/crates/theatron/tui/src/update/streaming.rs
+++ b/crates/theatron/tui/src/update/streaming.rs
@@ -254,6 +254,7 @@ pub(crate) fn handle_stream_error(app: &mut App, msg: String) {
 }
 
 #[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "test assertions may panic on failure")]
 mod tests {
     use super::*;
     use crate::api::types::PlanStep;

--- a/crates/theatron/tui/src/view/command_palette.rs
+++ b/crates/theatron/tui/src/view/command_palette.rs
@@ -1,6 +1,9 @@
 use ratatui::Frame;
 use ratatui::layout::Rect;
 use ratatui::style::{Modifier, Style};
+
+/// Fixed column width for command labels in the suggestion list.
+const COMMAND_LABEL_DISPLAY_WIDTH: usize = 12;
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Paragraph};
 
@@ -57,7 +60,10 @@ pub fn render(app: &App, frame: &mut Frame, area: Rect, theme: &Theme) {
                 },
             ),
             Span::styled("●", Style::default().fg(category_color)),
-            Span::styled(format!(" {:<12}", suggestion.label), name_style),
+            Span::styled(
+                format!(" {:<COMMAND_LABEL_DISPLAY_WIDTH$}", suggestion.label),
+                name_style,
+            ),
             Span::styled(&suggestion.description, theme.style_muted()),
         ];
 

--- a/crates/theatron/tui/src/view/filter_bar.rs
+++ b/crates/theatron/tui/src/view/filter_bar.rs
@@ -1,6 +1,11 @@
 use ratatui::Frame;
 use ratatui::layout::Rect;
 use ratatui::text::{Line, Span};
+
+/// Number of ticks per full cursor blink cycle (on + off).
+const BLINK_PERIOD_TICKS: u64 = 6;
+/// Number of ticks the cursor is visible within each blink cycle.
+const BLINK_ON_TICKS: u64 = 3;
 use ratatui::widgets::Paragraph;
 use unicode_width::UnicodeWidthStr;
 
@@ -10,7 +15,11 @@ use crate::theme::Theme;
 pub fn render(app: &App, frame: &mut Frame, area: Rect, theme: &Theme) {
     let width = area.width as usize;
 
-    let cursor_char = if app.tick_count % 6 < 3 { "█" } else { " " };
+    let cursor_char = if app.tick_count % BLINK_PERIOD_TICKS < BLINK_ON_TICKS {
+        "█"
+    } else {
+        " "
+    };
     let (before_cursor, after_cursor) = app.filter.text.split_at(app.filter.cursor);
 
     let mut left_spans = vec![

--- a/crates/theatron/tui/src/view/input.rs
+++ b/crates/theatron/tui/src/view/input.rs
@@ -202,6 +202,7 @@ pub(crate) fn cursor_visual_position(
 }
 
 #[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "test assertions may panic on failure")]
 mod tests {
     use super::*;
 

--- a/crates/theatron/tui/src/view/memory.rs
+++ b/crates/theatron/tui/src/view/memory.rs
@@ -1,6 +1,25 @@
 //! Rendering for the memory inspector panel views.
 
 use ratatui::Frame;
+
+/// Height of the tab bar row in the memory inspector layout.
+const TAB_BAR_HEIGHT: u16 = 2;
+/// Minimum height for the content area in the memory inspector layout.
+const CONTENT_MIN_HEIGHT: u16 = 3;
+/// Height of the status/help bar at the bottom of the memory inspector.
+const STATUS_BAR_HEIGHT: u16 = 1;
+/// Column width reserved for confidence, tier, and type columns in the facts table.
+const RESERVED_COLUMN_WIDTH: u16 = 28;
+/// Maximum number of relationships shown in the graph view before truncating.
+const RELATIONSHIP_DISPLAY_LIMIT: usize = 20;
+/// Maximum content length for similar-fact snippets shown in the detail view.
+const SIMILAR_FACT_TRUNCATE_LEN: usize = 60;
+/// Column width for the fact type field in the facts table.
+const FACT_TYPE_COLUMN_WIDTH: usize = 10;
+/// Confidence threshold above which a fact is considered high-confidence.
+const CONFIDENCE_HIGH_THRESHOLD: f64 = 0.8;
+/// Confidence threshold above which a fact is considered medium-confidence.
+const CONFIDENCE_MED_THRESHOLD: f64 = 0.5;
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
 use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
@@ -15,9 +34,9 @@ pub(crate) fn render_inspector(app: &App, frame: &mut Frame, area: Rect, theme: 
     let layout = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
-            Constraint::Length(2), // tab bar
-            Constraint::Min(3),    // content
-            Constraint::Length(1), // status/help bar
+            Constraint::Length(TAB_BAR_HEIGHT),
+            Constraint::Min(CONTENT_MIN_HEIGHT),
+            Constraint::Length(STATUS_BAR_HEIGHT),
         ])
         .split(area);
 
@@ -139,7 +158,7 @@ pub(crate) fn render_fact_detail(app: &App, frame: &mut Frame, area: Rect, theme
                 ),
             ]));
             for sim in &detail.similar {
-                let truncated = truncate(&sim.content, 60);
+                let truncated = truncate(&sim.content, SIMILAR_FACT_TRUNCATE_LEN);
                 lines.push(Line::from(vec![
                     Span::raw("    "),
                     Span::styled(
@@ -292,7 +311,7 @@ fn render_facts_table(app: &App, frame: &mut Frame, area: Rect, theme: &Theme) {
     } else {
         let filter = app.memory.filter_text.to_lowercase();
         let visible_height = area.height.saturating_sub(1) as usize; // -1 for header
-        let content_width = area.width.saturating_sub(28) as usize; // space for columns
+        let content_width = area.width.saturating_sub(RESERVED_COLUMN_WIDTH) as usize;
 
         let type_filter = app.memory.type_filter.as_deref();
         let tier_filter = app.memory.tier_filter.as_deref();
@@ -340,7 +359,11 @@ fn render_facts_table(app: &App, frame: &mut Frame, area: Rect, theme: &Theme) {
             let tier_str = format!("{} ", MemoryInspectorState::tier_abbrev(&fact.tier));
             let tier_style = tier_style(theme, &fact.tier);
 
-            let type_str = format!("{:<10} ", truncate(&fact.fact_type, 10));
+            let type_str = format!(
+                "{:<width$} ",
+                truncate(&fact.fact_type, FACT_TYPE_COLUMN_WIDTH),
+                width = FACT_TYPE_COLUMN_WIDTH
+            );
 
             let content = truncate(&fact.content.replace('\n', " "), content_width);
             let content_style = if fact.is_forgotten {
@@ -437,7 +460,12 @@ fn render_graph_view(app: &App, frame: &mut Frame, area: Rect, theme: &Theme) {
                     theme.style_fg().add_modifier(Modifier::BOLD),
                 ),
             ]));
-            for rel in app.memory.relationships.iter().take(20) {
+            for rel in app
+                .memory
+                .relationships
+                .iter()
+                .take(RELATIONSHIP_DISPLAY_LIMIT)
+            {
                 lines.push(Line::from(vec![
                     Span::raw("    "),
                     Span::styled(&rel.src, theme.style_accent()),
@@ -561,9 +589,9 @@ fn meta_line<'a>(theme: &'a Theme, label: &'a str, value: &str) -> Line<'a> {
 }
 
 fn confidence_style(theme: &Theme, conf: f64) -> Style {
-    if conf >= 0.8 {
+    if conf >= CONFIDENCE_HIGH_THRESHOLD {
         theme.style_success()
-    } else if conf >= 0.5 {
+    } else if conf >= CONFIDENCE_MED_THRESHOLD {
         theme.style_warning()
     } else {
         theme.style_error()

--- a/crates/theatron/tui/src/view/ops.rs
+++ b/crates/theatron/tui/src/view/ops.rs
@@ -13,6 +13,10 @@ const THINKING_TRUNCATE_LINES: usize = 20;
 const TOOL_OUTPUT_TRUNCATE_LINES: usize = 15;
 const JSON_TRUNCATE_BYTES: usize = 300;
 const MS_PER_SECOND: u64 = 1000;
+/// Minimum column width reserved for the chat pane when calculating ops pane size.
+const MIN_CHAT_PANE_WIDTH: u16 = 40;
+/// Minimum column width for the operations pane.
+const MIN_OPS_PANE_WIDTH: u16 = 20;
 
 pub fn render(app: &App, frame: &mut Frame, area: Rect, theme: &Theme) {
     let ops = &app.ops;
@@ -382,11 +386,9 @@ fn render_diff(
 
 /// Calculate the width for the ops pane in columns, respecting minimum widths.
 pub fn ops_pane_width(total_width: u16, pct: u16) -> u16 {
-    let min_chat = 40u16;
-    let min_ops = 20u16;
-    let available = total_width.saturating_sub(min_chat);
+    let available = total_width.saturating_sub(MIN_CHAT_PANE_WIDTH);
     let desired = (total_width as u32 * pct as u32 / 100) as u16;
-    desired.clamp(min_ops, available.max(min_ops))
+    desired.clamp(MIN_OPS_PANE_WIDTH, available.max(MIN_OPS_PANE_WIDTH))
 }
 
 #[cfg(test)]

--- a/crates/theatron/tui/src/view/overlay.rs
+++ b/crates/theatron/tui/src/view/overlay.rs
@@ -10,13 +10,30 @@ use crate::diff;
 use crate::keybindings;
 use crate::theme::Theme;
 
+/// Width percentage for the default (help/agent/session) popup.
+const POPUP_WIDTH_PCT: u16 = 60;
+/// Height percentage for the default popup.
+const POPUP_HEIGHT_PCT: u16 = 70;
+/// Width percentage for compact overlays (context actions).
+const COMPACT_POPUP_WIDTH_PCT: u16 = 40;
+/// Height percentage for compact overlays.
+const COMPACT_POPUP_HEIGHT_PCT: u16 = 50;
+/// Width percentage for the diff view overlay.
+const DIFF_POPUP_WIDTH_PCT: u16 = 80;
+/// Height percentage for the diff view overlay.
+const DIFF_POPUP_HEIGHT_PCT: u16 = 85;
+/// Column width reserved for the key label in the help overlay keybinding list.
+const HELP_KEY_COLUMN_WIDTH: usize = 13;
+/// Maximum number of tool-input lines shown in the tool approval overlay before truncating.
+const TOOL_APPROVAL_INPUT_LINES: usize = 10;
+
 pub fn render(app: &App, frame: &mut Frame, area: Rect, theme: &Theme) {
     let overlay = match &app.overlay {
         Some(o) => o,
         None => return,
     };
 
-    let popup_area = centered_rect(60, 70, area);
+    let popup_area = centered_rect(POPUP_WIDTH_PCT, POPUP_HEIGHT_PCT, area);
 
     // Clear the area under the overlay
     frame.render_widget(Clear, popup_area);
@@ -32,15 +49,15 @@ pub fn render(app: &App, frame: &mut Frame, area: Rect, theme: &Theme) {
         Overlay::ToolApproval(approval) => render_tool_approval(frame, popup_area, approval, theme),
         Overlay::PlanApproval(plan) => render_plan_approval(frame, popup_area, plan, theme),
         Overlay::ContextActions(ctx) => {
-            let compact_area = centered_rect(40, 50, area);
+            let compact_area =
+                centered_rect(COMPACT_POPUP_WIDTH_PCT, COMPACT_POPUP_HEIGHT_PCT, area);
             frame.render_widget(Clear, compact_area);
             render_context_actions(frame, compact_area, ctx, theme);
         }
         Overlay::SystemStatus => render_system_status(app, frame, popup_area, theme),
         Overlay::Settings(settings) => super::settings::render(settings, frame, area, theme),
         Overlay::DiffView(diff_state) => {
-            // Diff overlay uses a larger area (80% x 85%)
-            let diff_area = centered_rect(80, 85, area);
+            let diff_area = centered_rect(DIFF_POPUP_WIDTH_PCT, DIFF_POPUP_HEIGHT_PCT, area);
             frame.render_widget(Clear, diff_area);
             render_diff_view(diff_state, frame, diff_area, theme);
         }
@@ -100,7 +117,7 @@ fn render_help(app: &App, frame: &mut Frame, area: Rect, theme: &Theme) {
         lines.push(Line::raw(""));
         for kb in bindings {
             lines.push(Line::from(vec![
-                Span::styled(format!("  {:<13}", kb.keys), key_style),
+                Span::styled(format!("  {:<HELP_KEY_COLUMN_WIDTH$}", kb.keys), key_style),
                 Span::styled(kb.description, desc_style),
             ]));
         }
@@ -309,13 +326,13 @@ fn render_tool_approval(
 
     // Truncated input display
     let input_str = serde_json::to_string_pretty(&approval.input).unwrap_or_default();
-    for line in input_str.lines().take(10) {
+    for line in input_str.lines().take(TOOL_APPROVAL_INPUT_LINES) {
         lines.push(Line::from(Span::styled(
             format!("  {}", line),
             theme.style_dim(),
         )));
     }
-    if input_str.lines().count() > 10 {
+    if input_str.lines().count() > TOOL_APPROVAL_INPUT_LINES {
         lines.push(Line::from(Span::styled("  …", theme.style_dim())));
     }
 

--- a/crates/theatron/tui/src/view/settings.rs
+++ b/crates/theatron/tui/src/view/settings.rs
@@ -1,6 +1,17 @@
 use ratatui::Frame;
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
 use ratatui::style::{Modifier, Style};
+
+/// Width percentage for the settings popup.
+const POPUP_WIDTH_PCT: u16 = 70;
+/// Height percentage for the settings popup.
+const POPUP_HEIGHT_PCT: u16 = 85;
+/// Fixed column width for field labels (padded with spaces on the right).
+const LABEL_COLUMN_WIDTH: usize = 28;
+/// Fixed column width for displayed field values.
+const VALUE_COLUMN_WIDTH: usize = 12;
+/// Lines emitted per settings section: one blank line + one header line + one blank line.
+const LINES_PER_SECTION: usize = 3;
 use ratatui::symbols;
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{
@@ -11,7 +22,7 @@ use crate::state::settings::{FieldType, SaveStatus, SettingsOverlay};
 use crate::theme::Theme;
 
 pub fn render(overlay: &SettingsOverlay, frame: &mut Frame, area: Rect, theme: &Theme) {
-    let popup = centered_rect(70, 85, area);
+    let popup = centered_rect(POPUP_WIDTH_PCT, POPUP_HEIGHT_PCT, area);
     frame.render_widget(Clear, popup);
 
     let mut lines: Vec<Line> = Vec::new();
@@ -66,7 +77,7 @@ pub fn render(overlay: &SettingsOverlay, frame: &mut Frame, area: Rect, theme: &
             if selected && let Some(ref edit) = overlay.editing {
                 lines.push(Line::from(vec![
                     Span::raw(format!("  {} ", marker)),
-                    Span::styled(format!("{:<28}", field.label), label_style),
+                    Span::styled(format!("{:<LABEL_COLUMN_WIDTH$}", field.label), label_style),
                     Span::styled(
                         &edit.buffer,
                         Style::default()
@@ -78,8 +89,8 @@ pub fn render(overlay: &SettingsOverlay, frame: &mut Frame, area: Rect, theme: &
             } else {
                 lines.push(Line::from(vec![
                     Span::raw(format!("  {} ", marker)),
-                    Span::styled(format!("{:<28}", field.label), label_style),
-                    Span::styled(format!("{:<12}", value_str), value_style),
+                    Span::styled(format!("{:<LABEL_COLUMN_WIDTH$}", field.label), label_style),
+                    Span::styled(format!("{:<VALUE_COLUMN_WIDTH$}", value_str), value_style),
                     Span::styled(tag, tag_style),
                     Span::styled(restart, Style::default().fg(theme.status.warning)),
                 ]));
@@ -196,7 +207,7 @@ fn estimate_cursor_line(overlay: &SettingsOverlay) -> usize {
     let mut line = 0;
     let mut field_idx = 0;
     for section in &overlay.sections {
-        line += 3; // blank + header + blank
+        line += LINES_PER_SECTION;
         for _ in &section.fields {
             if field_idx == overlay.cursor {
                 return line;

--- a/crates/theatron/tui/src/view/status_bar.rs
+++ b/crates/theatron/tui/src/view/status_bar.rs
@@ -3,6 +3,10 @@ use ratatui::layout::Rect;
 use ratatui::style::Style;
 use ratatui::text::{Line, Span};
 use ratatui::widgets::Paragraph;
+
+/// Rows consumed by the status bar, tab bar, and input area above and below the chat pane.
+/// Used to estimate the visible viewport height for scrollbar position calculation.
+const CHAT_AREA_HEIGHT_OFFSET: u16 = 6;
 use unicode_width::UnicodeWidthStr;
 
 use crate::app::App;
@@ -163,7 +167,7 @@ fn format_cost(cents: u32) -> String {
 }
 
 fn scroll_position_spans(app: &App, theme: &Theme) -> Vec<Span<'static>> {
-    let viewport = app.terminal_height.saturating_sub(6); // approximate chat area
+    let viewport = app.terminal_height.saturating_sub(CHAT_AREA_HEIGHT_OFFSET);
     match app
         .virtual_scroll
         .scrollbar_position(app.scroll_offset, app.auto_scroll, viewport)


### PR DESCRIPTION
## Summary

- **Extract magic numbers** into named `const` declarations across 13 view/state files: popup percentages, column widths, height offsets, blink timing, pane minimum widths, tick interval, and default terminal dimensions.
- **Add `#![deny(clippy::unwrap_used, clippy::expect_used)]`** to `lib.rs` and resolve all violations: error propagation via a new `ApiError::InvalidToken` snafu variant, `#[expect]` with documented reasons for LazyLock regex statics and the `ViewStack` invariant, and `#[expect]` on all 20+ test modules.
- No behaviour changes — purely mechanical extraction and lint compliance.

## Changed files

| File | Change |
|------|--------|
| `lib.rs` | Add crate-level lint denials; extract `TICK_INTERVAL_MS` |
| `app.rs` | Extract `DEFAULT_TERMINAL_WIDTH/HEIGHT` |
| `api/error.rs` | Add `InvalidToken` snafu variant |
| `api/client.rs` | Replace bare `.expect()` with `map_err` propagation |
| `hyperlink.rs` | `#[expect]` on LazyLock regex statics |
| `state/view_stack.rs` | `#[expect]` on invariant-protected `.expect()` |
| `view/overlay.rs` | Extract 8 constants (popup pcts, column widths) |
| `view/settings.rs` | Extract 5 constants (popup pcts, column widths) |
| `view/memory.rs` | Extract 9 constants (heights, widths, thresholds) |
| `view/command_palette.rs` | Extract `COMMAND_LABEL_DISPLAY_WIDTH` |
| `view/filter_bar.rs` | Extract `BLINK_PERIOD_TICKS`, `BLINK_ON_TICKS` |
| `view/ops.rs` | Extract `MIN_CHAT_PANE_WIDTH`, `MIN_OPS_PANE_WIDTH` |
| `view/status_bar.rs` | Extract `CHAT_AREA_HEIGHT_OFFSET` |
| 20 test modules | Add `#[expect(clippy::unwrap_used)]` at mod level |

## Test plan

- [x] `cargo fmt --all --check` — clean
- [x] `cargo clippy --workspace -- -D warnings` — zero warnings
- [x] `cargo test -p theatron-tui` — 779 passed, 0 failed

## Observations (out of scope)

- `main.rs` binary has a `.expect()` on the crypto-provider registration that is unaffected (separate compilation unit, lib-crate lint denial does not apply).
- Several view files contain additional layout logic that could benefit from further decomposition, but that is out of scope for this refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)