### PR TITLE
fix: correct snafu NoneError and unused feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,7 +99,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 prometheus = { version = "0.14", features = ["process"] }
 
 # Config
-figment = { version = "0.10", features = ["toml", "json", "env"] }
+figment = { version = "0.10", features = ["toml", "env"] }
 
 # IDs
 uuid = { version = "1", features = ["v4"] }

--- a/crates/diaporeia/src/transport.rs
+++ b/crates/diaporeia/src/transport.rs
@@ -28,8 +28,6 @@ pub fn streamable_http_router(state: Arc<DiaporeiaState>) -> axum::Router {
 /// Reads JSON-RPC from stdin, writes to stdout. Blocks until the connection
 /// closes or the shutdown token fires.
 pub async fn serve_stdio(state: Arc<DiaporeiaState>) -> Result<()> {
-    use snafu::IntoError;
-
     let server = DiaporeiaServer::with_state(state);
     let service = server
         .serve(rmcp::transport::io::stdio())
@@ -38,14 +36,14 @@ pub async fn serve_stdio(state: Arc<DiaporeiaState>) -> Result<()> {
             error::TransportSnafu {
                 message: e.to_string(),
             }
-            .into_error(snafu::NoneError)
+            .build()
         })?;
 
     service.waiting().await.map_err(|e| {
         error::TransportSnafu {
             message: e.to_string(),
         }
-        .into_error(snafu::NoneError)
+        .build()
     })?;
 
     Ok(())


### PR DESCRIPTION
Closes #1147, #1148

## Changes
- Fixed incorrect snafu::NoneError usage in diaporeia transport: replaced `.into_error(snafu::NoneError)` with `.build()` on the `TransportSnafu` context builder, which has no `source` field. `snafu::NoneError` was removed in snafu v0.8.
- Removed unused figment `json` feature flag from workspace Cargo.toml — the project uses TOML config; no code uses the JSON figment provider.

## Observations
None out of scope.
