### PR TITLE
chore: remove phantom config fields (6 issues)

### DIFF
--- a/crates/nous/src/config.rs
+++ b/crates/nous/src/config.rs
@@ -85,14 +85,6 @@ impl Default for NousConfig {
 /// Pipeline configuration — controls stage behavior.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PipelineConfig {
-    /// Percentage of context window that triggers distillation.
-    pub distillation_threshold: f64,
-    /// Whether to include agent notes in context.
-    pub include_notes: bool,
-    /// Whether to include working state in context.
-    pub include_working_state: bool,
-    /// Maximum number of notes to inject.
-    pub max_notes: usize,
     /// Token budget for history (remaining after bootstrap).
     pub history_budget_ratio: f64,
     /// Knowledge extraction configuration (None = disabled).
@@ -106,10 +98,6 @@ pub struct PipelineConfig {
 impl Default for PipelineConfig {
     fn default() -> Self {
         Self {
-            distillation_threshold: 0.9,
-            include_notes: true,
-            include_working_state: true,
-            max_notes: 50,
             history_budget_ratio: 0.6,
             extraction: None,
             stage_budget: StageBudget::default(),
@@ -171,8 +159,8 @@ mod tests {
     #[test]
     fn pipeline_config_defaults() {
         let config = PipelineConfig::default();
-        assert!((config.distillation_threshold - 0.9).abs() < f64::EPSILON);
-        assert!(config.include_notes);
+        assert!((config.history_budget_ratio - 0.6).abs() < f64::EPSILON);
+        assert!(config.extraction.is_none());
     }
 
     #[test]
@@ -189,8 +177,8 @@ mod tests {
         let config = PipelineConfig::default();
         let json = serde_json::to_string(&config).unwrap();
         let back: PipelineConfig = serde_json::from_str(&json).unwrap();
-        assert!((back.distillation_threshold - 0.9).abs() < f64::EPSILON);
-        assert_eq!(back.max_notes, 50);
+        assert!((back.history_budget_ratio - 0.6).abs() < f64::EPSILON);
+        assert!(back.extraction.is_none());
     }
 
     #[test]
@@ -225,11 +213,5 @@ mod tests {
         assert!(config.thinking_enabled);
         assert_eq!(config.domains.len(), 1);
         assert!(!config.cache_enabled);
-    }
-
-    #[test]
-    fn pipeline_config_extraction_default_is_none() {
-        let config = PipelineConfig::default();
-        assert!(config.extraction.is_none());
     }
 }

--- a/crates/nous/src/spawn_svc.rs
+++ b/crates/nous/src/spawn_svc.rs
@@ -86,10 +86,6 @@ impl SpawnService for SpawnServiceImpl {
         };
 
         let pipeline_config = PipelineConfig {
-            distillation_threshold: 1.0,
-            include_notes: false,
-            include_working_state: false,
-            max_notes: 0,
             history_budget_ratio: 0.6,
             extraction: None,
             stage_budget: StageBudget::default(),

--- a/crates/taxis/src/config.rs
+++ b/crates/taxis/src/config.rs
@@ -166,10 +166,6 @@ pub struct AgentDefaults {
     pub max_output_tokens: u32,
     /// Token budget for bootstrap (system prompt + persona) content.
     pub bootstrap_max_tokens: u32,
-    /// IANA timezone for date/time formatting in prompts.
-    pub user_timezone: String,
-    /// Per-turn timeout in seconds before the request is cancelled.
-    pub timeout_seconds: u32,
     /// Whether extended thinking is enabled by default.
     pub thinking_enabled: bool,
     /// Maximum tokens allocated to extended thinking when enabled.
@@ -178,8 +174,6 @@ pub struct AgentDefaults {
     pub max_tool_iterations: u32,
     /// Filesystem paths the agent is permitted to access.
     pub allowed_roots: Vec<String>,
-    /// Per-tool execution timeout overrides.
-    pub tool_timeouts: ToolTimeouts,
     /// Prompt caching configuration.
     pub caching: CachingConfig,
     /// Recall pipeline settings applied to all agents unless overridden.
@@ -193,13 +187,10 @@ impl Default for AgentDefaults {
             context_tokens: 200_000,
             max_output_tokens: 16_384,
             bootstrap_max_tokens: 40_000,
-            user_timezone: "UTC".to_owned(),
-            timeout_seconds: 300,
             thinking_enabled: false,
             thinking_budget: 10_000,
             max_tool_iterations: 50,
             allowed_roots: Vec::new(),
-            tool_timeouts: ToolTimeouts::default(),
             caching: CachingConfig::default(),
             recall: RecallSettings::default(),
         }
@@ -222,26 +213,6 @@ impl Default for ModelSpec {
         Self {
             primary: "claude-sonnet-4-6".to_owned(),
             fallbacks: Vec::new(),
-        }
-    }
-}
-
-/// Tool execution timeout settings.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-#[serde(default)]
-pub struct ToolTimeouts {
-    /// Default timeout for all tools in milliseconds.
-    pub default_ms: u64,
-    /// Per-tool timeout overrides keyed by tool name.
-    pub overrides: HashMap<String, u64>,
-}
-
-impl Default for ToolTimeouts {
-    fn default() -> Self {
-        Self {
-            default_ms: 120_000,
-            overrides: HashMap::new(),
         }
     }
 }
@@ -502,55 +473,24 @@ impl Default for SignalConfig {
 }
 
 /// Configuration for a single Signal account.
-#[expect(
-    clippy::struct_excessive_bools,
-    reason = "mirrors TS config schema 1:1"
-)]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[serde(default)]
 pub struct SignalAccountConfig {
-    /// Human-readable label for this account.
-    pub name: Option<String>,
     /// Whether this account is active.
     pub enabled: bool,
-    /// Phone number or account identifier registered with Signal.
-    pub account: Option<String>,
     /// Hostname for the signal-cli JSON-RPC HTTP interface.
     pub http_host: String,
     /// Port for the signal-cli JSON-RPC HTTP interface.
     pub http_port: u16,
-    /// Filesystem path to the signal-cli binary (auto-detected if `None`).
-    pub cli_path: Option<String>,
-    /// Whether to auto-start signal-cli when the daemon starts.
-    pub auto_start: bool,
-    /// Direct message policy: `"contacts"` (known contacts only), `"open"` (anyone), `"allowlist"` restricts.
-    pub dm_policy: String,
-    /// Group message policy: `"open"` or `"allowlist"`.
-    pub group_policy: String,
-    /// Whether the bot must be @mentioned to respond in groups.
-    pub require_mention: bool,
-    /// Whether to send read receipts for processed messages.
-    pub send_read_receipts: bool,
-    /// Maximum characters per outbound text chunk before splitting.
-    pub text_chunk_limit: u32,
 }
 
 impl Default for SignalAccountConfig {
     fn default() -> Self {
         Self {
-            name: None,
             enabled: true,
-            account: None,
             http_host: "localhost".to_owned(),
             http_port: 8080,
-            cli_path: None,
-            auto_start: true,
-            dm_policy: "contacts".to_owned(),
-            group_policy: "allowlist".to_owned(),
-            require_mention: true,
-            send_read_receipts: true,
-            text_chunk_limit: 2000,
         }
     }
 }
@@ -565,30 +505,13 @@ pub struct DataConfig {
 }
 
 /// Session retention policy configuration.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+///
+/// Retention execution is not yet implemented; this struct is a placeholder.
+// TODO(#1129): Wire retention policy fields when the executor is implemented.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[serde(default)]
-pub struct RetentionConfig {
-    /// Max age for closed sessions (days).
-    pub session_max_age_days: u32,
-    /// Max age for orphaned messages (days).
-    pub orphan_message_max_age_days: u32,
-    /// Max sessions to retain per nous (0 = unlimited).
-    pub max_sessions_per_nous: u32,
-    /// Archive sessions to JSON before deletion.
-    pub archive_before_delete: bool,
-}
-
-impl Default for RetentionConfig {
-    fn default() -> Self {
-        Self {
-            session_max_age_days: 90,
-            orphan_message_max_age_days: 30,
-            max_sessions_per_nous: 0,
-            archive_before_delete: true,
-        }
-    }
-}
+pub struct RetentionConfig {}
 /// Instance maintenance settings.
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -782,10 +705,6 @@ pub struct ResolvedNousConfig {
     pub allowed_roots: Vec<String>,
     /// Knowledge domains this agent covers.
     pub domains: Vec<String>,
-    /// IANA timezone for prompt formatting.
-    pub user_timezone: String,
-    /// Per-turn timeout in seconds.
-    pub timeout_seconds: u32,
     /// Whether prompt caching is enabled.
     pub cache_enabled: bool,
     /// Resolved recall pipeline settings.
@@ -849,8 +768,6 @@ pub fn resolve_nous(config: &AletheiaConfig, nous_id: &str) -> ResolvedNousConfi
         workspace,
         allowed_roots,
         domains,
-        user_timezone: defaults.user_timezone.clone(),
-        timeout_seconds: defaults.timeout_seconds,
         cache_enabled: defaults.caching.enabled && defaults.caching.strategy != "disabled",
         recall,
     }

--- a/crates/taxis/src/config_tests.rs
+++ b/crates/taxis/src/config_tests.rs
@@ -9,12 +9,9 @@ fn defaults_are_sensible() {
     assert_eq!(config.agents.defaults.max_output_tokens, 16_384);
     assert_eq!(config.agents.defaults.bootstrap_max_tokens, 40_000);
     assert_eq!(config.agents.defaults.model.primary, "claude-sonnet-4-6");
-    assert_eq!(config.agents.defaults.user_timezone, "UTC");
-    assert_eq!(config.agents.defaults.timeout_seconds, 300);
     assert!(!config.agents.defaults.thinking_enabled);
     assert_eq!(config.agents.defaults.thinking_budget, 10_000);
     assert_eq!(config.agents.defaults.max_tool_iterations, 50);
-    assert_eq!(config.agents.defaults.tool_timeouts.default_ms, 120_000);
     assert_eq!(config.gateway.port, 18789);
     assert_eq!(config.gateway.bind, "localhost");
     assert_eq!(config.gateway.auth.mode, "token");
@@ -73,11 +70,7 @@ fn camel_case_compat() {
             "defaults": {
                 "contextTokens": 100000,
                 "maxOutputTokens": 8192,
-                "bootstrapMaxTokens": 20000,
-                "userTimezone": "America/New_York",
-                "toolTimeouts": {
-                    "defaultMs": 60000
-                }
+                "bootstrapMaxTokens": 20000
             },
             "list": []
         }
@@ -86,8 +79,6 @@ fn camel_case_compat() {
     assert_eq!(config.agents.defaults.context_tokens, 100_000);
     assert_eq!(config.agents.defaults.max_output_tokens, 8192);
     assert_eq!(config.agents.defaults.bootstrap_max_tokens, 20_000);
-    assert_eq!(config.agents.defaults.user_timezone, "America/New_York");
-    assert_eq!(config.agents.defaults.tool_timeouts.default_ms, 60_000);
 }
 
 #[test]
@@ -174,12 +165,6 @@ fn signal_account_defaults() {
     assert!(account.enabled);
     assert_eq!(account.http_host, "localhost");
     assert_eq!(account.http_port, 8080);
-    assert!(account.auto_start);
-    assert_eq!(account.dm_policy, "contacts");
-    assert_eq!(account.group_policy, "allowlist");
-    assert!(account.require_mention);
-    assert!(account.send_read_receipts);
-    assert_eq!(account.text_chunk_limit, 2000);
 }
 
 #[test]

--- a/crates/taxis/src/loader.rs
+++ b/crates/taxis/src/loader.rs
@@ -152,13 +152,11 @@ mod tests {
             let oikos = Oikos::from_root(jail.directory());
             let mut config = AletheiaConfig::default();
             config.gateway.port = 9876;
-            config.agents.defaults.timeout_seconds = 600;
 
             write_config(&oikos, &config).map_err(|e| e.to_string())?;
             let loaded = load_config(&oikos).map_err(|e| e.to_string())?;
 
             assert_eq!(loaded.gateway.port, 9876);
-            assert_eq!(loaded.agents.defaults.timeout_seconds, 600);
             assert_eq!(loaded.agents.defaults.context_tokens, 200_000);
             Ok(())
         });

--- a/crates/taxis/src/redact.rs
+++ b/crates/taxis/src/redact.rs
@@ -17,9 +17,6 @@ const SENSITIVE_LEAVES: &[&[&str]] = &[
 /// Object keys at any depth whose values are unconditionally redacted.
 const SENSITIVE_KEYS: &[&str] = &["token", "secret", "password", "apiKey", "api_key"];
 
-/// Keys within Signal account objects that contain PII.
-const SIGNAL_PII_KEYS: &[&str] = &["account"];
-
 /// Serialize config to JSON, then redact sensitive fields.
 #[must_use]
 pub fn redact(config: &AletheiaConfig) -> Value {
@@ -29,7 +26,6 @@ pub fn redact(config: &AletheiaConfig) -> Value {
     });
     redact_sensitive_leaves(&mut value);
     redact_sensitive_keys(&mut value);
-    redact_signal_accounts(&mut value);
     value
 }
 
@@ -64,24 +60,6 @@ fn redact_sensitive_keys(value: &mut Value) {
             }
         }
         _ => {}
-    }
-}
-
-fn redact_signal_accounts(root: &mut Value) {
-    let accounts = root
-        .pointer_mut("/channels/signal/accounts")
-        .and_then(Value::as_object_mut);
-
-    if let Some(accounts_map) = accounts {
-        for (_label, account) in accounts_map.iter_mut() {
-            if let Value::Object(acct) = account {
-                for key in SIGNAL_PII_KEYS {
-                    if acct.contains_key(*key) {
-                        acct.insert((*key).to_owned(), Value::String(REDACTED.to_owned()));
-                    }
-                }
-            }
-        }
     }
 }
 
@@ -122,24 +100,7 @@ mod tests {
 
         assert_eq!(redacted["gateway"]["port"], 18789);
         assert_eq!(redacted["agents"]["defaults"]["contextTokens"], 200_000);
-        assert_eq!(redacted["agents"]["defaults"]["timeoutSeconds"], 300);
         assert_eq!(redacted["embedding"]["provider"], "candle");
-    }
-
-    #[test]
-    fn redacts_signal_phone_numbers() {
-        let mut config = AletheiaConfig::default();
-        config.channels.signal.accounts.insert(
-            "main".to_owned(),
-            crate::config::SignalAccountConfig {
-                account: Some("+447700900000".to_owned()),
-                ..Default::default()
-            },
-        );
-
-        let redacted = redact(&config);
-        let account = &redacted["channels"]["signal"]["accounts"]["main"]["account"];
-        assert_eq!(account, REDACTED);
     }
 
     #[test]

--- a/instance.example/config/aletheia.toml.example
+++ b/instance.example/config/aletheia.toml.example
@@ -36,9 +36,6 @@ contextTokens = 200000
 # thinkingBudget = 10000
 # maxToolIterations = 50
 
-# [agents.defaults.toolTimeouts]
-# defaultMs = 120000
-
 [[agents.list]]
 id = "main"
 default = true
@@ -52,7 +49,6 @@ workspace = "nous/main"
 # enabled = true
 #
 # [channels.signal.accounts.default]
-# account = "+1XXXXXXXXXX"
 # httpHost = "localhost"
 # httpPort = 8080
 
@@ -66,11 +62,6 @@ workspace = "nous/main"
 # [embedding]
 # provider = "candle"       # mock | candle
 # dimension = 384
-
-# --- Data retention ---
-# [data.retention]
-# sessionMaxAgeDays = 90
-# archiveBeforeDelete = true
 
 # --- Maintenance ---
 # [maintenance.traceRotation]


### PR DESCRIPTION
Closes #1125, #1126, #1127, #1128, #1129, #1130

## Changes

- **#1126** — Removed `timeout_seconds` and `user_timezone` from `AgentDefaults` and `ResolvedNousConfig`. Neither field is read by the nous actor, pipeline, or any runtime code path.
- **#1127** — Removed `ToolTimeouts` struct and `tool_timeouts` field from `AgentDefaults`. Tool execution uses hardcoded timeouts; the config was parsed but never forwarded to any executor.
- **#1128** — Removed 9 of 12 fields from `SignalAccountConfig`. Only `enabled`, `http_host`, and `http_port` are consumed by `build_signal_provider`. The `account` phone-number field, policy fields (`dm_policy`, `group_policy`, `require_mention`), `send_read_receipts`, `text_chunk_limit`, `name`, `auto_start`, and `cli_path` were all phantom.
- **#1129** — Collapsed `RetentionConfig` (`data.retention.*`) to an empty placeholder. The four policy fields (`session_max_age_days`, `orphan_message_max_age_days`, `max_sessions_per_nous`, `archive_before_delete`) were parsed but `mneme::RetentionPolicy::apply` is never called from the server or maintenance executor. Added `TODO(#1129)` to restore when wired.
- **#1130** — Removed `distillation_threshold`, `include_notes`, `include_working_state`, and `max_notes` from `PipelineConfig`. No pipeline stage reads them; they were constructed in `spawn_svc.rs` but discarded.
- **#1125** — Confirmed `allowed_roots` is fully wired (`AgentDefaults` → `ResolvedNousConfig` → `ToolContext` → workspace path validation). No change needed.
- Updated `instance.example/config/aletheia.toml.example` and all affected tests to match.

## Observations

- **#1125 not phantom**: `allowed_roots` flows through the entire stack correctly. The prompt's concern was a false positive.
- **#1129 confirmed phantom**: The exploration agent initially reported `data.retention` fields as "wired via mneme." Deeper investigation showed `mneme::RetentionPolicy` exists with a full implementation but is never instantiated or called from any runtime code path. The fields were phantom.
- **Signal field count**: The prompt cited "7 of 11 fields." The actual struct had 12 fields; 3 are used and 9 were removed.
- **#1131 not touched**: `SIGNAL_CAPABILITIES.max_text_length` remains hardcoded at 2000. That is additive work per scope constraints.