### PR TITLE
test(mneme): expand retention test suite — 30 tests, 2 proptests

### DIFF
--- a/crates/mneme/src/retention_tests.rs
+++ b/crates/mneme/src/retention_tests.rs
@@ -676,6 +676,227 @@ fn policy_preserves_notes_in_archive() {
     assert_eq!(parsed["notes"][0]["category"], "context");
 }
 
+#[test]
+fn default_policy_has_correct_field_values() {
+    let policy = RetentionPolicy::default();
+    assert_eq!(
+        policy.session_max_age_days, 90,
+        "default session max age is 90 days"
+    );
+    assert_eq!(
+        policy.orphan_message_max_age_days, 30,
+        "default orphan message max age is 30 days"
+    );
+    assert_eq!(
+        policy.max_sessions_per_nous, 0,
+        "default max sessions per nous is 0 (unlimited)"
+    );
+    assert!(
+        policy.archive_before_delete,
+        "default archive_before_delete is true"
+    );
+}
+
+#[test]
+fn custom_policy_overrides_all_defaults() {
+    let policy = RetentionPolicy {
+        session_max_age_days: 14,
+        orphan_message_max_age_days: 7,
+        max_sessions_per_nous: 10,
+        archive_before_delete: false,
+    };
+    assert_eq!(policy.session_max_age_days, 14);
+    assert_eq!(policy.orphan_message_max_age_days, 7);
+    assert_eq!(policy.max_sessions_per_nous, 10);
+    assert!(!policy.archive_before_delete);
+}
+
+#[test]
+fn retention_boundary_age_keeps_within_threshold() {
+    let conn = test_conn();
+    let dir = tempfile::tempdir().expect("temp dir should be created");
+
+    // Policy: 30-day max age.
+    // 29-day session is within threshold — must be kept.
+    // 31-day session is past threshold — must be deleted.
+    insert_session(&conn, "boundary-young", "alice", "archived", 29);
+    insert_session(&conn, "boundary-old", "alice", "archived", 31);
+
+    let policy = RetentionPolicy {
+        session_max_age_days: 30,
+        archive_before_delete: false,
+        ..RetentionPolicy::default()
+    };
+
+    let result = policy
+        .apply(&conn, dir.path())
+        .expect("retention apply should succeed");
+    assert_eq!(
+        result.sessions_deleted, 1,
+        "only the 31-day session should be deleted"
+    );
+
+    let remaining: String = conn
+        .query_row("SELECT id FROM sessions", [], |row| row.get(0))
+        .expect("querying remaining session should succeed");
+    assert_eq!(
+        remaining, "boundary-young",
+        "29-day session survives a 30-day policy"
+    );
+}
+
+#[test]
+fn archive_preserves_message_seq_order() {
+    let conn = test_conn();
+    let dir = tempfile::tempdir().expect("temp dir should be created");
+    let archive_dir = dir.path().join("ordered-archive");
+
+    insert_session(&conn, "ordered-ses", "alice", "archived", 100);
+    // Insert messages out of seq order to verify the archive sorts them.
+    insert_message(&conn, "ordered-ses", 3);
+    insert_message(&conn, "ordered-ses", 1);
+    insert_message(&conn, "ordered-ses", 2);
+
+    let policy = RetentionPolicy {
+        session_max_age_days: 90,
+        archive_before_delete: true,
+        ..RetentionPolicy::default()
+    };
+
+    policy
+        .apply(&conn, &archive_dir)
+        .expect("retention apply should succeed");
+
+    let archive_path = archive_dir.join("ordered-ses.json");
+    let contents = std::fs::read_to_string(&archive_path).expect("archive file should be readable");
+    let parsed: serde_json::Value =
+        serde_json::from_str(&contents).expect("archive should be valid JSON");
+
+    let messages = parsed["messages"]
+        .as_array()
+        .expect("messages should be an array");
+    assert_eq!(messages.len(), 3);
+    assert_eq!(
+        messages[0]["seq"], 1i64,
+        "first message in archive has seq=1"
+    );
+    assert_eq!(
+        messages[1]["seq"], 2i64,
+        "second message in archive has seq=2"
+    );
+    assert_eq!(
+        messages[2]["seq"], 3i64,
+        "third message in archive has seq=3"
+    );
+}
+
+#[test]
+fn archive_handles_session_with_no_messages() {
+    let conn = test_conn();
+    let dir = tempfile::tempdir().expect("temp dir should be created");
+    let archive_dir = dir.path().join("empty-msg-archive");
+
+    insert_session(&conn, "no-messages", "alice", "archived", 100);
+
+    let policy = RetentionPolicy {
+        session_max_age_days: 90,
+        archive_before_delete: true,
+        ..RetentionPolicy::default()
+    };
+
+    policy
+        .apply(&conn, &archive_dir)
+        .expect("retention apply should succeed for session with no messages");
+
+    let archive_path = archive_dir.join("no-messages.json");
+    assert!(
+        archive_path.exists(),
+        "archive file should exist even when session has no messages"
+    );
+
+    let contents = std::fs::read_to_string(&archive_path).expect("archive file should be readable");
+    let parsed: serde_json::Value =
+        serde_json::from_str(&contents).expect("archive should be valid JSON");
+
+    assert_eq!(parsed["session"]["id"], "no-messages");
+    assert_eq!(
+        parsed["messages"]
+            .as_array()
+            .expect("messages should be an array")
+            .len(),
+        0,
+        "messages array is empty when session has no messages"
+    );
+}
+
+#[test]
+fn archive_handles_large_message_count() {
+    let conn = test_conn();
+    let dir = tempfile::tempdir().expect("temp dir should be created");
+    let archive_dir = dir.path().join("large-msg-archive");
+
+    insert_session(&conn, "large-ses", "alice", "archived", 100);
+    for i in 1i64..=105 {
+        insert_message(&conn, "large-ses", i);
+    }
+
+    let policy = RetentionPolicy {
+        session_max_age_days: 90,
+        archive_before_delete: true,
+        ..RetentionPolicy::default()
+    };
+
+    policy
+        .apply(&conn, &archive_dir)
+        .expect("retention apply should succeed for session with 105 messages");
+
+    let archive_path = archive_dir.join("large-ses.json");
+    let contents = std::fs::read_to_string(&archive_path).expect("archive file should be readable");
+    let parsed: serde_json::Value =
+        serde_json::from_str(&contents).expect("archive should be valid JSON");
+
+    assert_eq!(
+        parsed["messages"]
+            .as_array()
+            .expect("messages should be an array")
+            .len(),
+        105,
+        "all 105 messages are preserved in the archive"
+    );
+}
+
+#[test]
+fn recent_orphan_messages_not_deleted() {
+    let conn = test_conn();
+    let dir = tempfile::tempdir().expect("temp dir should be created");
+
+    // Insert an orphan with the current timestamp (SQLite DEFAULT = now).
+    // With a 30-day threshold, this message must not be cleaned up.
+    conn.execute_batch("PRAGMA foreign_keys = OFF")
+        .expect("disabling foreign keys should succeed");
+    conn.execute(
+        "INSERT INTO messages (session_id, seq, role, content) VALUES ('no-such-session', 1, 'user', 'recent orphan')",
+        [],
+    )
+    .expect("inserting recent orphan should succeed");
+    conn.execute_batch("PRAGMA foreign_keys = ON")
+        .expect("re-enabling foreign keys should succeed");
+
+    let policy = RetentionPolicy {
+        orphan_message_max_age_days: 30,
+        ..RetentionPolicy::default()
+    };
+
+    let result = policy
+        .apply(&conn, dir.path())
+        .expect("retention apply should succeed");
+    assert_eq!(
+        result.messages_deleted, 0,
+        "recent orphan should not be deleted"
+    );
+    assert_eq!(count_messages(&conn), 1, "recent orphan is retained");
+}
+
 mod proptests {
     use super::*;
     use proptest::prelude::*;
@@ -719,6 +940,44 @@ mod proptests {
             prop_assert_eq!(
                 after_first, after_second,
                 "second retention pass must not change session count"
+            );
+        }
+
+        #[test]
+        fn deletion_count_never_exceeds_total_session_count(
+            session_count in 1_usize..=15,
+            policy_days in 0_u32..=180,
+        ) {
+            let conn = test_conn();
+            let dir = tempfile::tempdir().expect("temp dir should be created");
+
+            for i in 0..session_count {
+                let age = i64::try_from(i).expect("test index fits i64") * 10 + 5;
+                insert_session(
+                    &conn,
+                    &format!("bound-{i}"),
+                    "alice",
+                    "archived",
+                    age,
+                );
+            }
+
+            let initial_count = count_sessions(&conn);
+            let policy = RetentionPolicy {
+                session_max_age_days: policy_days,
+                archive_before_delete: false,
+                ..RetentionPolicy::default()
+            };
+
+            let result = policy
+                .apply(&conn, dir.path())
+                .expect("retention apply should succeed");
+
+            prop_assert!(
+                result.sessions_deleted <= initial_count,
+                "sessions_deleted ({}) exceeded initial count ({})",
+                result.sessions_deleted,
+                initial_count,
             );
         }
     }


### PR DESCRIPTION
## Summary

- Expands `retention_tests.rs` from 22 tests to 30 tests (28 `#[test]` functions + 2 proptest property-based tests)
- Adds 7 new unit tests covering gaps in the requirements
- Adds a second proptest verifying a key invariant
- No changes to implementation code (`retention.rs` is untouched)
- All tests use synthetic identities (alice, bob, charlie)

### New unit tests

| Test | Requirement covered |
|------|-------------------|
| `default_policy_has_correct_field_values` | R1: default field values |
| `custom_policy_overrides_all_defaults` | R2: custom overrides |
| `retention_boundary_age_keeps_within_threshold` | R6: boundary conditions |
| `archive_preserves_message_seq_order` | R9: archive ordering |
| `archive_handles_session_with_no_messages` | R10: zero messages |
| `archive_handles_large_message_count` | R11: 100+ messages |
| `recent_orphan_messages_not_deleted` | R14: orphan age threshold |

### New proptest

`deletion_count_never_exceeds_total_session_count` — for any combination of session count (1–15) and policy age (0–180 days), `result.sessions_deleted <= initial_session_count`.

## Validation gate

```
cargo fmt --all -- --check       ✓
cargo clippy -p aletheia-mneme -- -D warnings  ✓ (zero warnings)
cargo test -p aletheia-mneme -- retention      ✓ (30 passed)
```

## Observations

- **Archive file naming** (requirement 12) specifies "includes session ID and timestamp". The implementation names files `{session_id}.json` only — the `archived_at` timestamp is inside the JSON, not the filename. This is a minor implementation gap; the existing filename scheme is safe and unambiguous since session IDs are unique. Worth noting for any future rename.
- **MaintenanceReport tests** (requirements 17–19) target `MaintenanceReport` from `crates/daemon/src/maintenance/knowledge.rs`, which is outside the blast radius (`crates/mneme/` only). These are not covered here; they belong in a daemon-crate test task.
- **Concurrent execution** (requirement 21: "retention during active session creation doesn't corrupt state") cannot be tested against an in-memory `rusqlite::Connection` because `Connection` is not `Send`. True concurrent write testing would require a file-backed database and multiple threads. The existing `retention_concurrent_access` test verifies idempotency of sequential dual-pass runs as the nearest feasible approximation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)