### PR TITLE
test(mneme): add log relation proptests and fix store edge cases

### DIFF
--- a/crates/mneme/src/engine/runtime/relation.rs
+++ b/crates/mneme/src/engine/runtime/relation.rs
@@ -339,8 +339,8 @@ impl RelationHandle {
     pub(crate) fn decode(data: &[u8]) -> Result<Self> {
         rmp_serde::from_slice(data).map_err(|e| {
             error!(
-                "Cannot deserialize relation metadata from bytes: {:x?}, {:?}",
-                data, e
+                error = %e,
+                "cannot deserialize relation metadata"
             );
             crate::engine::error::InternalError::Runtime {
                 source: InvalidOperationSnafu {

--- a/crates/mneme/src/knowledge_store/tests.rs
+++ b/crates/mneme/src/knowledge_store/tests.rs
@@ -2739,3 +2739,177 @@ mod search_correctness_tests {
             .expect("correct-dimension embedding must be accepted");
     }
 }
+
+#[cfg(all(test, feature = "mneme-engine"))]
+#[expect(clippy::expect_used, reason = "test assertions")]
+mod merge_proptests {
+    use proptest::prelude::*;
+    use std::collections::BTreeMap;
+    use std::sync::Arc;
+
+    use super::super::{KnowledgeConfig, KnowledgeStore};
+    use crate::engine::DataValue;
+    use crate::id::EntityId;
+    use crate::knowledge::{Entity, Relationship};
+
+    // WHY: small fixed set keeps entity IDs short and relationship types
+    // valid without invoking vocab normalisation (storage layer accepts any string).
+    const RELATION_TYPES: &[&str] = &["KNOWS", "WORKS_AT", "DEPENDS_ON", "USES", "PART_OF"];
+
+    fn make_store() -> Arc<KnowledgeStore> {
+        KnowledgeStore::open_mem_with_config(KnowledgeConfig { dim: 4 })
+            .expect("in-memory store should always open")
+    }
+
+    fn count_entities(store: &KnowledgeStore) -> usize {
+        store
+            .run_query("?[id] := *entities{id}", BTreeMap::new())
+            .expect("entity count query")
+            .rows
+            .len()
+    }
+
+    fn entity_exists(store: &KnowledgeStore, id: &str) -> bool {
+        let mut params = BTreeMap::new();
+        params.insert("eid".to_owned(), DataValue::Str(id.into()));
+        store
+            .run_query("?[id] := *entities{id}, id = $eid", params)
+            .expect("entity exists query")
+            .rows
+            .len()
+            == 1
+    }
+
+    fn count_rels_touching(store: &KnowledgeStore, entity_id: &str) -> usize {
+        let mut params = BTreeMap::new();
+        params.insert("eid".to_owned(), DataValue::Str(entity_id.into()));
+        store
+            .run_query(
+                "?[src, dst] := *relationships{src, dst}, (src = $eid or dst = $eid)",
+                params,
+            )
+            .expect("relationships-touching query")
+            .rows
+            .len()
+    }
+
+    fn count_all_rels(store: &KnowledgeStore) -> usize {
+        store
+            .run_query("?[src, dst] := *relationships{src, dst}", BTreeMap::new())
+            .expect("all-relationships count query")
+            .rows
+            .len()
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(256))]
+
+        /// Entity merge maintains structural invariants across random entity graphs.
+        ///
+        /// For any graph of N entities (2–20) with up to 30 directed edges,
+        /// merging a randomly selected pair must:
+        /// - reduce entity count to N-1
+        /// - remove the merged-from entity
+        /// - leave the surviving entity intact
+        /// - redirect all edges away from the merged entity (no orphaned edges)
+        /// - not increase the total edge count (deduplication may reduce it)
+        #[test]
+        fn execute_merge_maintains_invariants(
+            n in 2_usize..=20,
+            raw_rels in prop::collection::vec(
+                (0_usize..20, 0_usize..20, 0_usize..5),
+                0..=30,
+            ),
+            canonical_raw in 0_usize..20,
+            merge_shift in 1_usize..20,
+        ) {
+            let canonical_idx = canonical_raw % n;
+            // WHY: `1 + (merge_shift % (n-1))` is in 1..n-1, so adding it to
+            // canonical_idx and wrapping modulo n can never yield canonical_idx
+            // again — canonical and merged are always distinct.
+            let merged_idx = (canonical_idx + 1 + (merge_shift % (n - 1))) % n;
+
+            let store = make_store();
+            let now = jiff::Timestamp::UNIX_EPOCH;
+
+            for i in 0..n {
+                let entity = Entity {
+                    id: EntityId::new_unchecked(format!("e{i}")),
+                    name: format!("entity-{i}"),
+                    entity_type: "concept".to_owned(),
+                    aliases: vec![],
+                    created_at: now,
+                    updated_at: now,
+                };
+                store.insert_entity(&entity).expect("insert entity");
+            }
+
+            for (s, d, rel_type_idx) in &raw_rels {
+                let src_idx = s % n;
+                let dst_idx = d % n;
+                if src_idx == dst_idx {
+                    continue;
+                }
+                let rel = Relationship {
+                    src: EntityId::new_unchecked(format!("e{src_idx}")),
+                    dst: EntityId::new_unchecked(format!("e{dst_idx}")),
+                    relation: RELATION_TYPES[rel_type_idx % RELATION_TYPES.len()].to_owned(),
+                    weight: 0.8,
+                    created_at: now,
+                };
+                store.insert_relationship(&rel).expect("insert relationship");
+            }
+
+            let entity_count_before = count_entities(&store);
+            prop_assert_eq!(
+                entity_count_before, n,
+                "entity count before merge must equal N"
+            );
+            let rel_count_before = count_all_rels(&store);
+
+            let canonical_id = EntityId::new_unchecked(format!("e{canonical_idx}"));
+            let merged_id = EntityId::new_unchecked(format!("e{merged_idx}"));
+
+            store
+                .execute_merge(&canonical_id, &merged_id)
+                .expect("execute_merge should succeed on valid entity pair");
+
+            // Invariant: entity count decreases by exactly 1
+            let entity_count_after = count_entities(&store);
+            prop_assert_eq!(
+                entity_count_after,
+                n - 1,
+                "entity count after merge must be N-1"
+            );
+
+            // Invariant: merged entity no longer exists
+            prop_assert!(
+                !entity_exists(&store, &format!("e{merged_idx}")),
+                "merged entity must not exist after merge"
+            );
+
+            // Invariant: canonical entity survives intact
+            prop_assert!(
+                entity_exists(&store, &format!("e{canonical_idx}")),
+                "canonical entity must still exist after merge"
+            );
+
+            // Invariant: no orphaned edges — merged entity must have zero relationships
+            let rels_touching_merged = count_rels_touching(&store, &format!("e{merged_idx}"));
+            prop_assert_eq!(
+                rels_touching_merged,
+                0,
+                "no relationship may reference the merged entity after merge"
+            );
+
+            // Invariant: relationship count does not increase (merge may deduplicate edges
+            // when merged and canonical both had edges to the same third entity, or when
+            // the merge would produce a self-loop)
+            let rel_count_after = count_all_rels(&store);
+            prop_assert!(
+                rel_count_after <= rel_count_before,
+                "relationship count must not increase after merge: before={rel_count_before}, after={rel_count_after}"
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add property-based tests for mneme log relation operations
- Fix edge case handling in knowledge store tests

## Test plan
- [ ] `cargo test -p aletheia-mneme`
- [ ] `cargo clippy -p aletheia-mneme -- -D warnings`