### PR TITLE
chore(mneme): standards compliance sweep

### DIFF
--- a/crates/mneme/src/conflict.rs
+++ b/crates/mneme/src/conflict.rs
@@ -48,6 +48,7 @@ pub enum ConflictError {
 
 /// How a new fact relates to an existing one.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub enum ConflictClassification {
     /// The new fact directly contradicts the existing fact.
     Contradicts,
@@ -106,6 +107,7 @@ pub struct ConflictResolution {
 
 /// Action to take after conflict resolution.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum ConflictAction {
     /// Insert the new fact (no conflict or supplements existing).
     Insert,

--- a/crates/mneme/src/consolidation/mod.rs
+++ b/crates/mneme/src/consolidation/mod.rs
@@ -102,6 +102,7 @@ pub enum ConsolidationError {
 
 /// Why a consolidation was triggered.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub enum ConsolidationTrigger {
     /// An entity accumulated more than the threshold of active facts.
     EntityOverflow {

--- a/crates/mneme/src/dedup.rs
+++ b/crates/mneme/src/dedup.rs
@@ -38,6 +38,7 @@ pub struct EntityMergeCandidate {
 
 /// Decision based on the merge score thresholds.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum MergeDecision {
     /// Score ≥ 0.90 — merge automatically.
     AutoMerge,

--- a/crates/mneme/src/embedding.rs
+++ b/crates/mneme/src/embedding.rs
@@ -82,8 +82,7 @@ impl MockEmbeddingProvider {
 impl EmbeddingProvider for MockEmbeddingProvider {
     #[instrument(skip(self, text))]
     fn embed(&self, text: &str) -> EmbeddingResult<Vec<f32>> {
-        // Deterministic pseudo-embedding from text content.
-        // Uses a simple multiplicative hash to spread bytes across dimensions.
+        // NOTE: deterministic pseudo-embedding — multiplicative hash spreads bytes across dimensions
         let mut vec = vec![0.0f32; self.dim];
         let bytes = text.as_bytes();
         let mut hash: u64 = 5381;
@@ -91,7 +90,7 @@ impl EmbeddingProvider for MockEmbeddingProvider {
             hash = hash.wrapping_mul(33).wrapping_add(u64::from(b));
         }
         for (i, v) in vec.iter_mut().enumerate() {
-            // Mix hash with position for per-dimension variation
+            // NOTE: mix hash with position for per-dimension variation
             let h = hash
                 .wrapping_mul(i as u64 + 1)
                 .wrapping_add(i as u64 * 2_654_435_761);
@@ -100,7 +99,6 @@ impl EmbeddingProvider for MockEmbeddingProvider {
                 *v = ((h % 10000) as f32 / 5000.0) - 1.0;
             }
         }
-        // L2 normalize
         let norm: f32 = vec.iter().map(|x| x * x).sum::<f32>().sqrt();
         if norm > 0.0 {
             for v in &mut vec {
@@ -173,7 +171,7 @@ mod candle_provider {
             let repo_id = model_repo.unwrap_or(Self::DEFAULT_REPO);
             let device = Device::Cpu;
 
-            // Download model files from HuggingFace Hub
+            // NOTE: download model files from HuggingFace Hub on first use; cached by hf-hub
             let api = hf_hub::api::sync::Api::new().map_err(|e| {
                 InitFailedSnafu {
                     message: format!("hf-hub API init failed: {e}"),
@@ -201,7 +199,6 @@ mod candle_provider {
                 .build()
             })?;
 
-            // Load config
             let config_str = std::fs::read_to_string(&config_path).map_err(|e| {
                 InitFailedSnafu {
                     message: format!("failed to read config.json: {e}"),
@@ -216,7 +213,7 @@ mod candle_provider {
             })?;
             let dimension = config.hidden_size;
 
-            // Load model weights (safe buffered read, no mmap)
+            // NOTE: buffered read instead of mmap to avoid SIGBUS on network-backed filesystems
             let weights_data = std::fs::read(&weights_path).map_err(|e| {
                 InitFailedSnafu {
                     message: format!("failed to read model weights: {e}"),
@@ -238,7 +235,6 @@ mod candle_provider {
                 .build()
             })?;
 
-            // Load tokenizer
             let mut tokenizer = Tokenizer::from_file(&tokenizer_path).map_err(|e| {
                 InitFailedSnafu {
                     message: format!("failed to load tokenizer: {e}"),
@@ -339,9 +335,8 @@ mod candle_provider {
                 .and_then(|t| t.sum_keepdim(1))
                 .and_then(|t| t.sqrt())
                 .map_err(Self::candle_err("norm computation"))?;
-            // Clamp norm to a small positive value to prevent NaN when the
-            // pooled vector has zero norm (e.g. all-zero input embeddings).
-            // A zero-norm input produces an all-zero output rather than NaN.
+            // WHY: clamp norm to ε to prevent NaN from zero-norm inputs (e.g. all-zero embeddings);
+            // produces an all-zero output instead
             let norm_safe = norm
                 .clamp(f32::EPSILON, f32::MAX)
                 .map_err(Self::candle_err("norm clamp"))?;
@@ -484,7 +479,6 @@ pub fn create_provider(config: &EmbeddingConfig) -> EmbeddingResult<Box<dyn Embe
                 .to_owned(),
         }
         .fail(),
-        // "voyage" => { ... }   // M1.3 Phase 3: Voyage AI API
         other => InitFailedSnafu {
             message: format!("unknown embedding provider: {other}"),
         }

--- a/crates/mneme/src/engine/data/relation.rs
+++ b/crates/mneme/src/engine/data/relation.rs
@@ -71,6 +71,7 @@ impl Display for NullableColType {
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
+#[non_exhaustive]
 pub enum ColType {
     Any,
     Bool,
@@ -93,6 +94,7 @@ pub enum ColType {
 }
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, serde::Deserialize, serde::Serialize)]
+#[non_exhaustive]
 pub enum VecElementType {
     F32,
     F64,

--- a/crates/mneme/src/engine/data/value.rs
+++ b/crates/mneme/src/engine/data/value.rs
@@ -125,6 +125,7 @@ impl From<(i64, bool)> for Validity {
 
 /// A Value in the database
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, serde::Deserialize, serde::Serialize, Hash)]
+#[non_exhaustive]
 pub enum DataValue {
     /// null
     Null,
@@ -187,6 +188,7 @@ impl Hash for JsonData {
 
 /// Vector of floating numbers
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub enum Vector {
     /// 32-bit float array
     F32(Array1<f32>),
@@ -476,6 +478,7 @@ impl From<bool> for DataValue {
 
 /// Representing a number
 #[derive(Copy, Clone, serde::Deserialize, serde::Serialize)]
+#[non_exhaustive]
 pub enum Num {
     /// intger number
     Int(i64),

--- a/crates/mneme/src/engine/fts/indexing.rs
+++ b/crates/mneme/src/engine/fts/indexing.rs
@@ -83,8 +83,6 @@ impl FtsCache {
 }
 
 struct PositionInfo {
-    // from: u32,
-    // to: u32,
     position: u32,
 }
 

--- a/crates/mneme/src/engine/parse/mod.rs
+++ b/crates/mneme/src/engine/parse/mod.rs
@@ -40,6 +40,7 @@ pub(crate) type Pairs<'a> = pest::iterators::Pairs<'a, Rule>;
 
 /// A parsed datalog script, as returned by `parse_script`.
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum DatalogScript {
     Single(InputProgram),
     Imperative(ImperativeProgram),
@@ -59,6 +60,7 @@ pub struct ImperativeSysop {
 }
 
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum ImperativeStmt {
     Break {
         target: Option<CompactString>,
@@ -93,7 +95,6 @@ pub enum ImperativeStmt {
     TempSwap {
         left: CompactString,
         right: CompactString,
-        // span: SourceSpan,
     },
     TempDebug {
         temp: CompactString,

--- a/crates/mneme/src/engine/parse/sys.rs
+++ b/crates/mneme/src/engine/parse/sys.rs
@@ -24,6 +24,7 @@ use crate::engine::runtime::relation::AccessLevel;
 use crate::engine::{Expr, FixedRule};
 
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum SysOp {
     Compact,
     ListColumns(Symbol),
@@ -85,6 +86,7 @@ pub struct HnswIndexConfig {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+#[non_exhaustive]
 pub enum HnswDistance {
     L2,
     InnerProduct,

--- a/crates/mneme/src/engine/runtime/callback.rs
+++ b/crates/mneme/src/engine/runtime/callback.rs
@@ -13,6 +13,7 @@ use crate::engine::{DbCore as Db, NamedRows, Storage};
 
 /// Represents the kind of operation that triggered the callback
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[non_exhaustive]
 pub enum CallbackOp {
     /// Triggered by Put operations
     Put,

--- a/crates/mneme/src/engine/runtime/db.rs
+++ b/crates/mneme/src/engine/runtime/db.rs
@@ -45,7 +45,7 @@ pub(crate) struct RunningQueryCleanup {
 
 impl Drop for RunningQueryCleanup {
     fn drop(&mut self) {
-        let mut map = self.running_queries.lock().unwrap(); // INVARIANT: lock is not poisoned
+        let mut map = self.running_queries.lock().expect("lock is not poisoned");
         if let Some(handle) = map.remove(&self.id) {
             handle.poison.0.store(true, Ordering::Relaxed);
         }
@@ -54,6 +54,7 @@ impl Drop for RunningQueryCleanup {
 
 /// Whether a script is mutable or immutable.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[non_exhaustive]
 pub enum ScriptMutability {
     /// The script is mutable.
     Mutable,
@@ -248,6 +249,7 @@ pub type Payload = (String, BTreeMap<String, DataValue>);
 
 /// Commands to be sent to a multi-transaction
 #[derive(Eq, PartialEq, Debug)]
+#[non_exhaustive]
 pub enum TransactionPayload {
     /// Commit the current transaction
     Commit,
@@ -288,7 +290,11 @@ impl<'s, S: Storage<'s>> Db<S> {
 
     /// This returns the set of fixed rule implementations for this specific backend.
     pub fn get_fixed_rules(&'s self) -> BTreeMap<String, Arc<Box<dyn FixedRule>>> {
-        return self.fixed_rules.read().unwrap().clone(); // INVARIANT: lock is not poisoned
+        return self
+            .fixed_rules
+            .read()
+            .expect("lock is not poisoned")
+            .clone();
     }
 
     /// Backup the running database into an Sqlite file.
@@ -330,8 +336,12 @@ impl<'s, S: Storage<'s>> Db<S> {
     where
         R: FixedRule + 'static,
     {
-        match self.fixed_rules.write().unwrap().entry(name) {
-            // INVARIANT: lock is not poisoned
+        match self
+            .fixed_rules
+            .write()
+            .expect("lock is not poisoned")
+            .entry(name)
+        {
             Entry::Vacant(ent) => {
                 ent.insert(Arc::new(Box::new(rule_impl)));
                 Ok(())
@@ -353,7 +363,12 @@ impl<'s, S: Storage<'s>> Db<S> {
             }
             .fail()?;
         }
-        Ok(self.fixed_rules.write().unwrap().remove(name).is_some()) // INVARIANT: lock is not poisoned
+        Ok(self
+            .fixed_rules
+            .write()
+            .expect("lock is not poisoned")
+            .remove(name)
+            .is_some())
     }
 
     /// Register callback channel to receive changes when the requested relation are successfully committed.
@@ -374,7 +389,7 @@ impl<'s, S: Storage<'s>> Db<S> {
             sender,
         };
 
-        let mut guard = self.event_callbacks.write().unwrap(); // INVARIANT: lock is not poisoned
+        let mut guard = self.event_callbacks.write().expect("lock is not poisoned");
         let new_id = self.callback_count.fetch_add(1, Ordering::SeqCst);
         guard
             .1
@@ -389,12 +404,21 @@ impl<'s, S: Storage<'s>> Db<S> {
     /// Unregister callbacks/channels to run when changes to relations are committed.
     #[cfg(not(target_arch = "wasm32"))]
     pub fn unregister_callback(&self, id: u32) -> bool {
-        let mut guard = self.event_callbacks.write().unwrap(); // INVARIANT: lock is not poisoned
+        let mut guard = self.event_callbacks.write().expect("lock is not poisoned");
         let ret = guard.0.remove(&id);
         if let Some(cb) = &ret {
-            guard.1.get_mut(&cb.dependent).unwrap().remove(&id);
+            guard
+                .1
+                .get_mut(&cb.dependent)
+                .expect("dependent entry exists if callback was registered")
+                .remove(&id);
 
-            if guard.1.get(&cb.dependent).unwrap().is_empty() {
+            if guard
+                .1
+                .get(&cb.dependent)
+                .expect("dependent entry exists if callback was registered")
+                .is_empty()
+            {
                 guard.1.remove(&cb.dependent);
             }
         }
@@ -408,7 +432,7 @@ impl<'s, S: Storage<'s>> Db<S> {
         let mut collected = vec![];
         let mut pending = vec![];
         {
-            let locks = self.relation_locks.read().unwrap(); // INVARIANT: lock is not poisoned
+            let locks = self.relation_locks.read().expect("lock is not poisoned");
             for rel in rels {
                 match locks.get(rel) {
                     None => {
@@ -419,7 +443,7 @@ impl<'s, S: Storage<'s>> Db<S> {
             }
         }
         if !pending.is_empty() {
-            let mut locks = self.relation_locks.write().unwrap(); // INVARIANT: lock is not poisoned
+            let mut locks = self.relation_locks.write().expect("lock is not poisoned");
             for rel in pending {
                 let lock = locks.entry(rel.clone()).or_default().clone();
                 collected.push(lock);

--- a/crates/mneme/src/engine/runtime/exec.rs
+++ b/crates/mneme/src/engine/runtime/exec.rs
@@ -117,7 +117,7 @@ impl<'s, S: Storage<'s>> Db<S> {
         }
         let write_lock = self.obtain_relation_locks(write_lock_names.iter());
         let _write_lock_guards = if is_write {
-            Some(write_lock[0].read().unwrap()) // INVARIANT: lock is not poisoned
+            Some(write_lock[0].read().expect("lock is not poisoned"))
         } else {
             None
         };
@@ -448,7 +448,10 @@ impl<'s, S: Storage<'s>> Db<S> {
             started_at: since_the_epoch,
             poison: poison.clone(),
         };
-        self.running_queries.lock().unwrap().insert(id, handle); // INVARIANT: lock is not poisoned
+        self.running_queries
+            .lock()
+            .expect("lock is not poisoned")
+            .insert(id, handle);
 
         // RAII cleanups of running query handle
         let _guard = RunningQueryCleanup {

--- a/crates/mneme/src/engine/runtime/imperative.rs
+++ b/crates/mneme/src/engine/runtime/imperative.rs
@@ -383,7 +383,10 @@ impl<'s, S: Storage<'s>> Db<S> {
                 started_at: since_the_epoch,
                 poison: poison.clone(),
             };
-            self.running_queries.lock().unwrap().insert(qid, q_handle);
+            self.running_queries
+                .lock()
+                .expect("lock is not poisoned")
+                .insert(qid, q_handle);
             let _guard = RunningQueryCleanup {
                 id: qid,
                 running_queries: self.running_queries.clone(),

--- a/crates/mneme/src/engine/runtime/relation.rs
+++ b/crates/mneme/src/engine/runtime/relation.rs
@@ -120,6 +120,7 @@ impl RelationHandle {
     Ord,
     PartialOrd,
 )]
+#[non_exhaustive]
 pub enum AccessLevel {
     Hidden,
     ReadOnly,
@@ -1451,8 +1452,16 @@ impl<'a> SessionTx<'a> {
         let is_lsh = rel.lsh_indices.contains_key(&idx_name.name);
         let is_fts = rel.fts_indices.contains_key(&idx_name.name);
         if is_lsh || is_fts {
-            self.tokenizers.named_cache.write().unwrap().clear(); // INVARIANT: lock is not poisoned
-            self.tokenizers.hashed_cache.write().unwrap().clear(); // INVARIANT: lock is not poisoned
+            self.tokenizers
+                .named_cache
+                .write()
+                .expect("lock is not poisoned")
+                .clear();
+            self.tokenizers
+                .hashed_cache
+                .write()
+                .expect("lock is not poisoned")
+                .clear();
         }
         if rel.indices.remove(&idx_name.name).is_none()
             && rel.hnsw_indices.remove(&idx_name.name).is_none()

--- a/crates/mneme/src/engine/runtime/sys.rs
+++ b/crates/mneme/src/engine/runtime/sys.rs
@@ -51,7 +51,7 @@ impl<'s, S: Storage<'s>> Db<S> {
             }
             SysOp::ListRelations => self.list_relations(tx),
             SysOp::ListFixedRules => {
-                let rules = self.fixed_rules.read().unwrap(); // INVARIANT: lock is not poisoned
+                let rules = self.fixed_rules.read().expect("lock is not poisoned");
                 Ok(NamedRows::new(
                     vec!["rule".to_string()],
                     rules
@@ -73,7 +73,10 @@ impl<'s, S: Storage<'s>> Db<S> {
                 } else {
                     self.obtain_relation_locks(rel_name_strs)
                 };
-                let _guards = locks.iter().map(|l| l.read().unwrap()).collect_vec(); // INVARIANT: lock is not poisoned
+                let _guards = locks
+                    .iter()
+                    .map(|l| l.read().expect("lock is not poisoned"))
+                    .collect_vec();
                 let mut bounds = vec![];
                 for rs in rel_names {
                     let bound = tx.destroy_relation(rs)?;
@@ -109,8 +112,8 @@ impl<'s, S: Storage<'s>> Db<S> {
                     let lock = self
                         .obtain_relation_locks(iter::once(&rel_name.name))
                         .pop()
-                        .unwrap();
-                    let _guard = lock.write().unwrap(); // INVARIANT: lock is not poisoned
+                        .expect("obtain_relation_locks returns one lock per name");
+                    let _guard = lock.write().expect("lock is not poisoned");
                     tx.create_index(rel_name, idx_name, cols)?;
                 }
                 Ok(NamedRows::new(
@@ -131,8 +134,8 @@ impl<'s, S: Storage<'s>> Db<S> {
                     let lock = self
                         .obtain_relation_locks(iter::once(&config.base_relation))
                         .pop()
-                        .unwrap();
-                    let _guard = lock.write().unwrap(); // INVARIANT: lock is not poisoned
+                        .expect("obtain_relation_locks returns one lock per name");
+                    let _guard = lock.write().expect("lock is not poisoned");
                     tx.create_hnsw_index(config)?;
                 }
                 Ok(NamedRows::new(
@@ -153,8 +156,8 @@ impl<'s, S: Storage<'s>> Db<S> {
                     let lock = self
                         .obtain_relation_locks(iter::once(&config.base_relation))
                         .pop()
-                        .unwrap();
-                    let _guard = lock.write().unwrap(); // INVARIANT: lock is not poisoned
+                        .expect("obtain_relation_locks returns one lock per name");
+                    let _guard = lock.write().expect("lock is not poisoned");
                     tx.create_fts_index(config)?;
                 }
                 Ok(NamedRows::new(
@@ -175,8 +178,8 @@ impl<'s, S: Storage<'s>> Db<S> {
                     let lock = self
                         .obtain_relation_locks(iter::once(&config.base_relation))
                         .pop()
-                        .unwrap();
-                    let _guard = lock.write().unwrap(); // INVARIANT: lock is not poisoned
+                        .expect("obtain_relation_locks returns one lock per name");
+                    let _guard = lock.write().expect("lock is not poisoned");
                     tx.create_minhash_lsh_index(config)?;
                 }
 
@@ -198,8 +201,8 @@ impl<'s, S: Storage<'s>> Db<S> {
                     let lock = self
                         .obtain_relation_locks(iter::once(&rel_name.name))
                         .pop()
-                        .unwrap();
-                    let _guard = lock.read().unwrap(); // INVARIANT: lock is not poisoned
+                        .expect("obtain_relation_locks returns one lock per name");
+                    let _guard = lock.read().expect("lock is not poisoned");
                     tx.remove_index(rel_name, idx_name)?
                 };
 
@@ -226,7 +229,10 @@ impl<'s, S: Storage<'s>> Db<S> {
                 } else {
                     self.obtain_relation_locks(rel_names)
                 };
-                let _guards = locks.iter().map(|l| l.read().unwrap()).collect_vec(); // INVARIANT: lock is not poisoned
+                let _guards = locks
+                    .iter()
+                    .map(|l| l.read().expect("lock is not poisoned"))
+                    .collect_vec();
                 for (old, new) in rename_pairs {
                     tx.rename_relation(old, new)?;
                 }
@@ -237,7 +243,7 @@ impl<'s, S: Storage<'s>> Db<S> {
             }
             SysOp::ListRunning => self.list_running(),
             SysOp::KillRunning(id) => {
-                let queries = self.running_queries.lock().unwrap(); // INVARIANT: lock is not poisoned
+                let queries = self.running_queries.lock().expect("lock is not poisoned");
                 Ok(match queries.get(id) {
                     None => NamedRows::new(
                         vec![STATUS_STR.to_string()],
@@ -319,7 +325,7 @@ impl<'s, S: Storage<'s>> Db<S> {
         let rows = self
             .running_queries
             .lock()
-            .unwrap()
+            .expect("lock is not poisoned")
             .iter()
             .map(|(k, v)| {
                 vec![

--- a/crates/mneme/src/engine/runtime/transact.rs
+++ b/crates/mneme/src/engine/runtime/transact.rs
@@ -247,17 +247,21 @@ impl<'s, S: Storage<'s>> Db<S> {
                     break;
                 }
                 TransactionPayload::Query((script, params)) => {
-                    let p = match parse_script(&script, &params, &self.fixed_rules.read().unwrap(), ts) // INVARIANT: lock is not poisoned
-                        {
-                            Ok(p) => p,
-                            Err(err) => {
-                                if results.send(Err(err)).is_err() {
-                                    break;
-                                } else {
-                                    continue;
-                                }
+                    let p = match parse_script(
+                        &script,
+                        &params,
+                        &self.fixed_rules.read().expect("lock is not poisoned"),
+                        ts,
+                    ) {
+                        Ok(p) => p,
+                        Err(err) => {
+                            if results.send(Err(err)).is_err() {
+                                break;
+                            } else {
+                                continue;
                             }
-                        };
+                        }
+                    };
 
                     let p = match p.get_single_program() {
                         Ok(p) => p,
@@ -358,7 +362,10 @@ impl<'s, S: Storage<'s>> Db<S> {
     pub fn import_relations(&'s self, data: BTreeMap<String, NamedRows>) -> Result<()> {
         let rel_names = data.keys().map(CompactString::from).collect_vec();
         let locks = self.obtain_relation_locks(rel_names.iter());
-        let _guards = locks.iter().map(|l| l.read().unwrap()).collect_vec(); // INVARIANT: lock is not poisoned
+        let _guards = locks
+            .iter()
+            .map(|l| l.read().expect("lock is not poisoned"))
+            .collect_vec();
 
         let cur_vld = current_validity();
 

--- a/crates/mneme/src/extract/mod.rs
+++ b/crates/mneme/src/extract/mod.rs
@@ -331,7 +331,6 @@ Rules:
             });
         }
 
-        // Classify the turn from combined content
         let combined: String =
             messages
                 .iter()
@@ -345,17 +344,15 @@ Rules:
                 });
         let turn_type = refinement::classify_turn(&combined);
 
-        // Build prompt with turn-type-specific instructions
         let prompt = self.build_prompt_with_turn_type(messages, Some(turn_type));
         let response = provider
             .complete(&prompt.system, &prompt.user_message)
             .await?;
         let mut extraction = self.parse_response(&response)?;
 
-        // Detect corrections in source content
         let correction = refinement::detect_correction(&combined);
 
-        // Post-process facts: classify type, boost confidence, apply quality filters
+        // NOTE: post-process each fact: classify type, apply correction flag, boost confidence, quality-filter
         let boost = turn_type.confidence_boost() + correction.confidence_boost;
         let mut filtered_count = 0;
 
@@ -363,20 +360,13 @@ Rules:
             .facts
             .into_iter()
             .filter_map(|mut fact| {
-                // Classify fact type
                 let fact_content = format!("{} {} {}", fact.subject, fact.predicate, fact.object);
                 let classified_type = refinement::classify_fact(&fact_content);
                 fact.fact_type = Some(classified_type.as_str().to_owned());
-
-                // Mark corrections
                 if correction.is_correction {
                     fact.is_correction = true;
                 }
-
-                // Apply confidence boost
                 fact.confidence = refinement::boosted_confidence(fact.confidence, boost);
-
-                // Quality filter
                 let filter = refinement::filter_fact(&fact_content, fact.confidence);
                 if filter.passed {
                     Some(fact)
@@ -425,7 +415,7 @@ Rules:
         let now = jiff::Timestamp::now();
         let mut result = PersistResult::default();
 
-        // Enforce per-turn extraction limits
+        // NOTE: enforce per-turn extraction limits to bound memory and DB writes
         let entities = if extraction.entities.len() > self.config.max_entities {
             tracing::warn!(
                 count = extraction.entities.len(),
@@ -532,7 +522,6 @@ Rules:
                 || crate::knowledge::FactType::classify(&content),
                 crate::knowledge::FactType::from_str_lossy,
             );
-            // Apply correction detection and confidence boost
             let is_correction =
                 fact.is_correction || crate::conflict::is_correction_heuristic(&content);
             let confidence = if is_correction {
@@ -1630,9 +1619,8 @@ mod proptests {
         #[test]
         fn slugify_never_panics(input in "\\PC{0,200}") {
             let result = slugify(&input);
-            // BUG: slugify uses char::is_alphanumeric() which is Unicode-aware,
-            // so non-ASCII alphanumeric chars (Tamil, Cyrillic, etc.) pass through.
-            // Slugs should ideally be ASCII-only. Documented for fix in a separate PR.
+            // FIXME: slugify uses char::is_alphanumeric() which is Unicode-aware, so non-ASCII
+            // alphanumeric chars (Tamil, Cyrillic, etc.) pass through; slugs should be ASCII-only
             assert!(
                 result.chars().all(|c| c.is_alphanumeric() || c == '-'),
                 "slugify produced unexpected character in: {result:?}"

--- a/crates/mneme/src/extract/refinement.rs
+++ b/crates/mneme/src/extract/refinement.rs
@@ -13,6 +13,7 @@ use serde::{Deserialize, Serialize};
 /// Classifies a conversation turn for context-dependent extraction.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
+#[non_exhaustive]
 pub enum TurnType {
     /// General conversation — extract facts, entities, relationships.
     Discussion,
@@ -148,7 +149,6 @@ fn is_tool_heavy(content: &str) -> bool {
         .map(|line| line.len() + 1) // +1 for newline
         .sum();
 
-    // Also count content within code blocks
     let code_block_chars = count_code_block_chars(content);
 
     let tool_chars = marker_adjacent_chars.max(code_block_chars);
@@ -190,7 +190,7 @@ fn has_planning_patterns(lower: &str) -> bool {
         "option b",
         "pros and cons",
     ];
-    // Require at least 2 planning keywords for confidence
+    // NOTE: require at least 2 matches to reduce false positives on casual mentions
     let matches = PATTERNS.iter().filter(|p| lower.contains(**p)).count();
     matches >= 2
 }
@@ -211,7 +211,7 @@ fn has_debugging_patterns(lower: &str) -> bool {
         "investigating",
         "root cause",
     ];
-    // Require at least 2 debugging keywords
+    // NOTE: require at least 2 matches to reduce false positives on casual mentions
     let matches = PATTERNS.iter().filter(|p| lower.contains(**p)).count();
     matches >= 2
 }
@@ -245,6 +245,7 @@ fn has_procedural_patterns(lower: &str) -> bool {
 /// Classification of extracted facts for FSRS decay rate tuning.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
+#[non_exhaustive]
 pub enum FactType {
     /// Personal identity information (name, role, background).
     Identity,
@@ -363,7 +364,7 @@ fn has_task_patterns(lower: &str) -> bool {
         "todo", "need to", "should", "will", "plan to", "going to", "must", "have to", "deadline",
         "due date",
     ];
-    // Need at least one strong task indicator
+    // NOTE: require both a general pattern and at least one strong task indicator (todo/deadline)
     PATTERNS.iter().any(|p| lower.contains(p))
         && (lower.contains("todo")
             || lower.contains("need to")
@@ -438,6 +439,7 @@ pub fn detect_correction(content: &str) -> CorrectionSignal {
 
 /// Reasons a fact may be rejected by quality filters.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum FilterReason {
     /// Confidence score below threshold.
     LowConfidence,

--- a/crates/mneme/src/instinct.rs
+++ b/crates/mneme/src/instinct.rs
@@ -57,6 +57,7 @@ pub struct ToolObservation {
 
 /// Outcome of a tool execution.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub enum ToolOutcome {
     /// Tool completed successfully.
     Success,
@@ -157,6 +158,7 @@ impl BehavioralPattern {
 /// Context categories for tool usage classification.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
+#[non_exhaustive]
 pub enum ContextCategory {
     /// File operations, grep, code-related queries.
     Code,

--- a/crates/mneme/src/knowledge.rs
+++ b/crates/mneme/src/knowledge.rs
@@ -107,6 +107,7 @@ pub struct EmbeddedChunk {
 /// Epistemic confidence tier.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
+#[non_exhaustive]
 pub enum EpistemicTier {
     /// Checked against ground truth.
     Verified,
@@ -146,6 +147,7 @@ impl std::fmt::Display for EpistemicTier {
 /// Reason for intentionally forgetting a fact.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
+#[non_exhaustive]
 pub enum ForgetReason {
     /// User explicitly requested removal.
     UserRequested,
@@ -203,6 +205,7 @@ impl std::str::FromStr for ForgetReason {
 /// research. Higher stability means slower decay.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
+#[non_exhaustive]
 pub enum FactType {
     /// "My name is X" — very stable (2 years).
     Identity,
@@ -293,7 +296,7 @@ impl FactType {
             "relationship" => Self::Relationship,
             "event" => Self::Event,
             "task" => Self::Task,
-            // "observation" and any unknown value both fall back to Observation
+            // NOTE: "observation" and any unknown value both fall back to Observation
             _ => Self::Observation,
         }
     }
@@ -373,15 +376,15 @@ pub fn parse_timestamp(s: &str) -> Option<jiff::Timestamp> {
     if s.is_empty() {
         return None;
     }
-    // Legacy far-future sentinel — jiff can't represent 9999-12-31 but can do 9999-01-01
+    // NOTE: legacy far-future sentinel — jiff can't represent 9999-12-31 but can do 9999-01-01
     if s.starts_with("9999-") {
         return Some(far_future());
     }
-    // Try full timestamp first
+    // NOTE: try full timestamp first, then fall back to date-only
     if let Ok(ts) = s.parse::<jiff::Timestamp>() {
         return Some(ts);
     }
-    // Try date-only (assume UTC midnight)
+    // NOTE: date-only strings are assumed to represent UTC midnight
     if let Ok(date) = s.parse::<jiff::civil::Date>() {
         return Some(
             date.to_zoned(jiff::tz::TimeZone::UTC)

--- a/crates/mneme/src/migration.rs
+++ b/crates/mneme/src/migration.rs
@@ -244,7 +244,7 @@ pub fn check_migrations(conn: &Connection) -> Result<Vec<PendingMigration>> {
 /// Ensure the `schema_version` table exists with the `description` column.
 fn bootstrap_version_table(conn: &Connection) -> Result<()> {
     if schema_version_table_exists(conn) {
-        // Older databases may lack the description column — add it if missing.
+        // NOTE: older databases may lack the description column — add it if missing
         if !has_description_column(conn) {
             conn.execute_batch(
                 "ALTER TABLE schema_version ADD COLUMN description TEXT NOT NULL DEFAULT ''",

--- a/crates/mneme/src/query.rs
+++ b/crates/mneme/src/query.rs
@@ -11,6 +11,7 @@ pub trait Field: Copy {
 
 /// Knowledge graph relations stored in the `CozoDB` engine.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum Relation {
     /// Temporal facts with validity windows and confidence scores.
     Facts,
@@ -36,6 +37,7 @@ impl Relation {
 
 /// Fields in the `facts` relation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum FactsField {
     Id,
     ValidFrom,
@@ -82,6 +84,7 @@ impl Field for FactsField {
 
 /// Fields in the `entities` relation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum EntitiesField {
     Id,
     Name,
@@ -106,6 +109,7 @@ impl Field for EntitiesField {
 
 /// Fields in the `relationships` relation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum RelationshipsField {
     Src,
     Dst,
@@ -128,6 +132,7 @@ impl Field for RelationshipsField {
 
 /// Fields in the `embeddings` relation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum EmbeddingsField {
     Id,
     Content,

--- a/crates/mneme/src/query_rewrite.rs
+++ b/crates/mneme/src/query_rewrite.rs
@@ -235,6 +235,7 @@ impl Default for TieredSearchConfig {
 
 /// Which search tier produced the final results.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum SearchTier {
     /// Single-query hybrid search (BM25 + vector).
     Fast,

--- a/crates/mneme/src/skill.rs
+++ b/crates/mneme/src/skill.rs
@@ -43,14 +43,14 @@ pub fn skill_decay_score(days_since_last_use: f64, usage_count: u32, confidence:
         f64::from(decay::DEFAULT_STALE_DAYS)
     };
 
-    // Exponential decay: 2^(-days / half_life)
+    // NOTE: exponential decay formula: 2^(-days / half_life)
     let recency = 2_f64.powf(-days_since_last_use / half_life);
 
-    // Usage provides a floor boost: frequent use prevents total decay
+    // NOTE: usage provides a floor boost — frequent use prevents total decay
     let usage_floor = f64::from(usage_count.min(20)) / 100.0; // max 0.20
 
     let raw = recency + usage_floor;
-    // Confidence acts as a ceiling
+    // NOTE: confidence acts as a ceiling on the returned score
     (raw * confidence.clamp(0.0, 1.0)).clamp(0.0, 1.0)
 }
 
@@ -119,7 +119,6 @@ pub fn parse_skill_md(source: &str, slug: &str) -> Result<SkillContent, SkillPar
 
     let (frontmatter, body) = split_frontmatter(source);
 
-    // Parse frontmatter if present
     let mut fm_tools: Vec<String> = Vec::new();
     let mut fm_domains: Vec<String> = Vec::new();
     if let Some(fm) = frontmatter {
@@ -133,10 +132,8 @@ pub fn parse_skill_md(source: &str, slug: &str) -> Result<SkillContent, SkillPar
         }
     }
 
-    // Extract title from first `# ` heading
     let mut lines = body.lines().peekable();
 
-    // Skip blank lines before title
     while lines.peek().is_some_and(|l| l.trim().is_empty()) {
         lines.next();
     }
@@ -146,7 +143,7 @@ pub fn parse_skill_md(source: &str, slug: &str) -> Result<SkillContent, SkillPar
         return Err(err("missing top-level heading (# Title)"));
     }
 
-    // Collect description: lines between title and first ## section
+    // NOTE: collect description from lines between the title and the first ## section
     let mut desc_lines = Vec::new();
     while let Some(&line) = lines.peek() {
         if line.starts_with("## ") {
@@ -160,7 +157,6 @@ pub fn parse_skill_md(source: &str, slug: &str) -> Result<SkillContent, SkillPar
     }
     let mut description = desc_lines.join(" ");
 
-    // Parse sections
     let mut current_section = String::new();
     let mut sections: std::collections::HashMap<String, Vec<String>> =
         std::collections::HashMap::new();
@@ -180,24 +176,23 @@ pub fn parse_skill_md(source: &str, slug: &str) -> Result<SkillContent, SkillPar
         }
     }
 
-    // Extract steps from "Steps" or "steps" section
     let steps = extract_steps(sections.get("steps").map_or(&[][..], |v| v.as_slice()));
 
-    // Extract tools from "Tools Used" section or frontmatter
+    // NOTE: prefer frontmatter tools list; fall back to parsing the "Tools Used" section
     let tools_used = if fm_tools.is_empty() {
         extract_tools(sections.get("tools used").map_or(&[][..], |v| v.as_slice()))
     } else {
         fm_tools
     };
 
-    // Domain tags from frontmatter, or derive from slug
+    // NOTE: prefer frontmatter domain tags; fall back to deriving from the slug
     let domain_tags = if fm_domains.is_empty() {
         derive_domain_tags(slug)
     } else {
         fm_domains
     };
 
-    // Use "When to Use" section as description if main description is empty
+    // NOTE: fall back to "When to Use" section when no description paragraph was found
     if description.is_empty()
         && let Some(when_lines) = sections.get("when to use")
     {
@@ -224,7 +219,6 @@ fn split_frontmatter(source: &str) -> (Option<&str>, &str) {
     if !trimmed.starts_with("---") {
         return (None, source);
     }
-    // Find closing ---
     let after_open = &trimmed[3..];
     if let Some(close_pos) = after_open.find("\n---") {
         let fm = &after_open[..close_pos];
@@ -251,7 +245,7 @@ fn extract_steps(lines: &[String]) -> Vec<String> {
     lines
         .iter()
         .filter_map(|line| {
-            // Strip ordered list prefix (e.g. "1. ", "2. ")
+            // NOTE: strip ordered list prefix (e.g., "1. ", "2. ") or bullet "- "
             let stripped = if let Some(pos) = line.find(". ") {
                 let prefix = &line[..pos];
                 if prefix.chars().all(|c| c.is_ascii_digit()) {
@@ -279,7 +273,6 @@ fn extract_tools(lines: &[String]) -> Vec<String> {
         .iter()
         .filter_map(|line| {
             let line = line.strip_prefix("- ").unwrap_or(line);
-            // Take everything before the colon as tool name
             let name = if let Some(colon_pos) = line.find(':') {
                 line[..colon_pos].trim()
             } else {
@@ -348,7 +341,7 @@ pub fn slugify(name: &str) -> String {
         })
         .collect();
 
-    // Collapse consecutive dashes and trim edges
+    // NOTE: collapse consecutive dashes and trim leading/trailing dashes
     let mut result = String::with_capacity(slug.len());
     let mut prev_dash = true; // suppress leading dashes
     for c in slug.chars() {
@@ -362,7 +355,6 @@ pub fn slugify(name: &str) -> String {
             prev_dash = false;
         }
     }
-    // Trim trailing dash
     if result.ends_with('-') {
         result.pop();
     }
@@ -392,10 +384,9 @@ pub fn format_skill_md(skill: &SkillContent) -> String {
     use std::fmt::Write as _;
     let mut md = String::with_capacity(512);
 
-    // YAML frontmatter
     md.push_str("---\n");
     let _ = writeln!(md, "name: {}", skill.name);
-    // Escape description for YAML (wrap in quotes if it contains colons or special chars)
+    // NOTE: wrap description in quotes when it contains YAML special characters (colon, hash, quote)
     let desc_needs_quoting = skill.description.contains(':')
         || skill.description.contains('#')
         || skill.description.contains('"');
@@ -406,8 +397,8 @@ pub fn format_skill_md(skill: &SkillContent) -> String {
         let _ = writeln!(md, "description: {}", skill.description);
     }
     if !skill.tools_used.is_empty() {
-        // Write both CC-native and aletheia-native keys for interop:
-        // `allowed-tools` is what CC reads; `tools` is what parse_skill_md reads.
+        // NOTE: write both keys for interop — `allowed-tools` is read by Claude Code;
+        // `tools` is what parse_skill_md reads back
         let _ = writeln!(md, "allowed-tools: {}", skill.tools_used.join(", "));
         let _ = writeln!(md, "tools: [{}]", skill.tools_used.join(", "));
     }
@@ -416,14 +407,12 @@ pub fn format_skill_md(skill: &SkillContent) -> String {
     }
     md.push_str("---\n\n");
 
-    // Title heading (required for parse_skill_md round-trip)
+    // NOTE: `# {name}` heading is required by parse_skill_md for round-trip compatibility
     let _ = writeln!(md, "# {}\n", skill.name);
 
-    // When to Use
     md.push_str("## When to Use\n");
     let _ = writeln!(md, "{}\n", skill.description);
 
-    // Steps
     if !skill.steps.is_empty() {
         md.push_str("## Steps\n");
         for (i, step) in skill.steps.iter().enumerate() {

--- a/crates/mneme/src/skills/candidate.rs
+++ b/crates/mneme/src/skills/candidate.rs
@@ -87,6 +87,7 @@ impl SkillCandidate {
 
 /// Outcome from [`CandidateTracker::track_sequence`].
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum TrackResult {
     /// Sequence failed the heuristic gates — not tracked.
     Rejected,

--- a/crates/mneme/src/skills/extract.rs
+++ b/crates/mneme/src/skills/extract.rs
@@ -142,6 +142,7 @@ impl<P: SkillExtractionProvider> SkillExtractor<P> {
 
 /// Result of a dedup check on a candidate skill.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum DedupOutcome {
     /// No duplicate found — promote normally.
     Unique,

--- a/crates/mneme/src/skills/heuristics.rs
+++ b/crates/mneme/src/skills/heuristics.rs
@@ -26,6 +26,7 @@ pub struct HeuristicScore {
 
 /// High-level pattern category detected in a tool call sequence.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub enum PatternType {
     /// Read → analyze → fix cycle (debugging → verification).
     Diagnostic,

--- a/crates/mneme/src/types.rs
+++ b/crates/mneme/src/types.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 /// Lifecycle status of a session.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
+#[non_exhaustive]
 pub enum SessionStatus {
     /// Session is live and accepting new messages.
     Active,
@@ -35,6 +36,7 @@ impl std::fmt::Display for SessionStatus {
 /// Session type — classifies session lifecycle behavior.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
+#[non_exhaustive]
 pub enum SessionType {
     /// Long-lived conversational session (the default).
     Primary,
@@ -81,6 +83,7 @@ impl std::fmt::Display for SessionType {
 /// Role of a message author within a conversation turn.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
+#[non_exhaustive]
 pub enum Role {
     /// System-injected context (bootstrap, instructions).
     System,

--- a/crates/mneme/src/vocab.rs
+++ b/crates/mneme/src/vocab.rs
@@ -2,6 +2,7 @@
 
 /// Result of normalizing a raw relationship type against the controlled vocabulary.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum RelationType {
     /// Matched a known vocabulary type (canonical uppercase form).
     Valid(&'static str),


### PR DESCRIPTION
## Summary
- Apply standards compliance fixes across 29 mneme source files
- Improve error handling, remove dead code, tighten visibility

## Test plan
- [ ] `cargo clippy -p aletheia-mneme -- -D warnings`
- [ ] `cargo test -p aletheia-mneme`