### PR TITLE
fix: correct comment/code divergence (4 issues)

### DIFF
--- a/crates/aletheia/src/commands/server.rs
+++ b/crates/aletheia/src/commands/server.rs
@@ -78,7 +78,7 @@ pub async fn run(args: Args) -> Result<()> {
     // Startup validation — fail fast before any actors or stores initialise
     oikos.validate().context("instance layout invalid")?;
 
-    // Config cascade: defaults → YAML → env
+    // Config cascade: defaults → TOML → env
     let config = load_config(&oikos).context("failed to load config")?;
     info!(
         port = config.gateway.port,

--- a/crates/aletheia/src/server.rs
+++ b/crates/aletheia/src/server.rs
@@ -63,7 +63,7 @@ pub(crate) async fn serve(cli: Cli) -> Result<()> {
     // Startup validation — fail fast before any actors or stores initialise
     oikos.validate().context("instance layout invalid")?;
 
-    // Config cascade: defaults → YAML → env
+    // Config cascade: defaults → TOML → env
     let config = load_config(&oikos).context("failed to load config")?;
     info!(
         port = config.gateway.port,

--- a/crates/mneme/src/recall.rs
+++ b/crates/mneme/src/recall.rs
@@ -205,7 +205,7 @@ impl RecallEngine {
 
     /// Compute the relationship proximity score from graph hops.
     ///
-    /// Direct neighbor = 1.0, 2-hop = 0.5, 3-hop = 0.25, etc.
+    /// Same entity (0 hops) or direct neighbor (1 hop) = 1.0, 2-hop = 0.5, 3-hop = 0.25, etc.
     /// No connection = 0.0.
     #[must_use]
     #[instrument(skip(self))]
@@ -221,7 +221,7 @@ impl RecallEngine {
 
     /// Compute the access frequency score.
     ///
-    /// Logarithmic scaling: `score = log(1 + count) / log(1 + max_count)`
+    /// Logarithmic scaling: `score = ln(1 + count) / ln(1 + max_count)`
     #[must_use]
     #[instrument(skip(self))]
     pub fn score_access_frequency(&self, access_count: u64) -> f64 {

--- a/crates/nous/src/recall.rs
+++ b/crates/nous/src/recall.rs
@@ -105,12 +105,14 @@ impl VectorSearch for KnowledgeVectorSearch {
     }
 }
 
-/// Per-factor scoring weights for the recall pipeline.
+/// Per-factor base scores for the recall pipeline.
 ///
-/// Each weight is applied to the corresponding [`aletheia_mneme::recall::FactorScores`]
-/// field before the engine aggregates them into a final score. All weights default to
-/// the values that were previously hardcoded, preserving existing behaviour unless an
-/// operator overrides them in taxis config.
+/// These values are placed directly into the non-vector
+/// [`aletheia_mneme::recall::FactorScores`] fields. Only vector similarity is computed
+/// from the actual embedding distance; decay, relevance, tier, proximity, and frequency
+/// use these configured values as their scores. All values default to the previously
+/// hardcoded constants, preserving existing behaviour unless an operator overrides them
+/// in taxis config.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RecallWeights {
     /// Temporal decay weight (0.0–1.0).

--- a/crates/taxis/src/config.rs
+++ b/crates/taxis/src/config.rs
@@ -86,7 +86,7 @@ pub struct AgentsConfig {
 /// Per-factor scoring weights for the recall pipeline.
 ///
 /// Mirrors the weights in the nous recall stage but lives in taxis so operators
-/// can tune them per-agent via YAML without creating a taxis → nous dependency.
+/// can tune them per-agent via TOML without creating a taxis → nous dependency.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[serde(default)]

--- a/crates/taxis/src/lib.rs
+++ b/crates/taxis/src/lib.rs
@@ -11,7 +11,7 @@ pub mod cascade;
 pub mod config;
 /// Taxis-specific error types for configuration loading and path resolution.
 pub mod error;
-/// Figment-based configuration loader with YAML file and environment variable cascade.
+/// Figment-based configuration loader with TOML file and environment variable cascade.
 pub mod loader;
 /// Instance directory structure and path resolution for all Aletheia subsystems.
 pub mod oikos;

--- a/crates/taxis/src/loader.rs
+++ b/crates/taxis/src/loader.rs
@@ -44,7 +44,7 @@ pub fn load_config(oikos: &Oikos) -> Result<AletheiaConfig> {
     figment.extract().context(FigmentSnafu)
 }
 
-/// Write configuration to the instance YAML file.
+/// Write configuration to the instance TOML file.
 ///
 /// Uses atomic write: writes to a `.tmp` file, then renames. This prevents
 /// corruption if the process is killed during write.

--- a/crates/theatron/tui/src/theme.rs
+++ b/crates/theatron/tui/src/theme.rs
@@ -101,7 +101,7 @@ pub struct Theme {
 }
 
 /// The active theme. Detected from the terminal environment at first access.
-/// Future: configurable via `aletheia.yaml`.
+/// Future: configurable via `aletheia.toml`.
 pub static THEME: std::sync::LazyLock<Theme> = std::sync::LazyLock::new(Theme::default);
 
 impl Default for Theme {

--- a/docs/ARCHITECTURE-GUIDE.md
+++ b/docs/ARCHITECTURE-GUIDE.md
@@ -87,7 +87,7 @@ Crates are organized in layers. Lower layers know nothing about higher layers.
 - **agora**: channel system. The `ChannelProvider` trait, Signal client (semeion), message routing via bindings. Depends on koina + taxis.
 - **oikonomos** (daemon): background task runner. Cron scheduling, prosoche attention checks, trace rotation, drift detection, DB monitoring. Depends on koina.
 - **dianoia**: planning orchestrator. Multi-phase project state machine, workspace persistence. Depends on koina.
-- **thesauros**: domain pack loader. Reads `pack.yaml` manifests, registers pack tools and context overlays. Depends on koina + organon.
+- **thesauros**: domain pack loader. Reads `pack.toml` manifests, registers pack tools and context overlays. Depends on koina + organon.
 
 ### High (depends on multiple mid+low layers)
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -373,7 +373,7 @@ pricing:
 
 ## packs
 
-Array of filesystem paths to external domain packs. Each path should be a directory containing `pack.yaml`. See [PACKS.md](PACKS.md).
+Array of filesystem paths to external domain packs. Each path should be a directory containing `pack.toml`. See [PACKS.md](PACKS.md).
 
 ```yaml
 packs:


### PR DESCRIPTION
Closes #1138, #1139, #1141, #1142

## Changes

- **#1138** `pack.yaml` → `pack.toml` in `docs/ARCHITECTURE-GUIDE.md` and `docs/CONFIGURATION.md`
- **#1139** `write_config` doc in `taxis/src/loader.rs`: "YAML file" → "TOML file"
- **#1141** Recall scoring comments in `mneme/src/recall.rs`:
  - `score_relationship_proximity`: doc now reflects that 0-hop (same entity) also returns 1.0, not just 1-hop (direct neighbor)
  - `score_access_frequency`: `log(...)` → `ln(...)` to match the `.ln()` call in code
- **#1142** Six additional stale comments:
  1. `taxis/src/lib.rs`: loader module doc "YAML file" → "TOML file"
  2. `taxis/src/config.rs`: `RecallWeights` doc "via YAML" → "via TOML"
  3. `aletheia/src/server.rs`: inline comment "YAML" → "TOML"
  4. `aletheia/src/commands/server.rs`: same inline comment
  5. `theatron/tui/src/theme.rs`: future-config reference "aletheia.yaml" → "aletheia.toml"
  6. `nous/src/recall.rs`: `RecallWeights` doc corrected — these values are placed directly as factor scores (not applied as multipliers to computed scores); only vector similarity is computed from actual embedding distance

## Observations

None — all findings were in scope.