### PR TITLE
refactor: CompactString for ID types (#1176)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6176,6 +6176,7 @@ dependencies = [
  "arboard",
  "base64 0.22.1",
  "clap",
+ "compact_str",
  "crossterm",
  "dirs",
  "futures-util",

--- a/crates/theatron/tui/Cargo.toml
+++ b/crates/theatron/tui/Cargo.toml
@@ -34,6 +34,7 @@ serde_json = { workspace = true }
 pulldown-cmark = "0.13"
 
 # Text utilities
+compact_str = { workspace = true }
 unicode-width = "0.2"
 
 # CLI

--- a/crates/theatron/tui/src/id.rs
+++ b/crates/theatron/tui/src/id.rs
@@ -1,5 +1,6 @@
 //! Newtype wrappers for domain identifiers in the TUI layer.
 
+use compact_str::CompactString;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
@@ -11,9 +12,12 @@ pub struct NousId(String);
 #[serde(transparent)]
 pub struct SessionId(String);
 
+// WHY: Decimal u64 strings are at most 20 bytes (u64::MAX), always within
+// CompactString's 24-byte inline limit. NousId (≤64 bytes), SessionId
+// (26-byte ULID), ToolId (≤128 bytes), and PlanId (variable) exceed it.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(transparent)]
-pub struct TurnId(String);
+pub struct TurnId(CompactString);
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(transparent)]
@@ -33,13 +37,13 @@ macro_rules! impl_id {
 
         impl From<String> for $ty {
             fn from(s: String) -> Self {
-                Self(s)
+                Self(s.into())
             }
         }
 
         impl From<&str> for $ty {
             fn from(s: &str) -> Self {
-                Self(s.to_string())
+                Self(s.into())
             }
         }
 
@@ -98,5 +102,20 @@ mod tests {
         let session = SessionId::from("agent".to_string());
         // These are different types — can't accidentally compare or swap them
         assert_eq!(&*nous, &*session);
+    }
+
+    #[test]
+    fn turn_id_serde_roundtrip() {
+        let id = TurnId::from("42".to_string());
+        let json = serde_json::to_string(&id).unwrap();
+        assert_eq!(json, r#""42""#);
+        let back: TurnId = serde_json::from_str(&json).unwrap();
+        assert_eq!(id, back);
+    }
+
+    #[test]
+    fn turn_id_max_value_fits_inline() {
+        let max = TurnId::from(u64::MAX.to_string());
+        assert_eq!(&*max, "18446744073709551615");
     }
 }


### PR DESCRIPTION
Closes #1176

## Changes

- Added `compact_str` to `theatron-tui` dependencies (already present in workspace)
- Migrated `TurnId` (theatron-tui) to `CompactString`
- Serde round-trip verified by `turn_id_serde_roundtrip` test

## Audit

### Migrated

| Type | Crate | Reason |
|------|-------|--------|
| `TurnId` | `theatron-tui` | Decimal u64 strings, max 20 bytes (u64::MAX) — always fits inline |

### Already optimal (no change)

| Type | Crate | Inner type | Reason |
|------|-------|-----------|--------|
| `NousId` | `koina` | `CompactString` | Already migrated |
| `ToolName` | `koina` | `CompactString` | Already migrated |
| `SessionId` | `koina` | `ulid::Ulid` | Binary ULID, no heap allocation |
| `TurnId` | `koina` | `u64` | Primitive, no allocation |

### Kept as String (length exceeds or may exceed 24 bytes)

| Type | Crate | Reason |
|------|-------|--------|
| `FactId` | `mneme` | Max 256 bytes; typical values include ULIDs (26 bytes) and entity names |
| `EntityId` | `mneme` | Max 256 bytes; variable-length entity names |
| `EmbeddingId` | `mneme` | Max 256 bytes; variable-length chunk identifiers |
| `NousId` | `theatron-tui` | Reflects koina NousId (≤64 bytes) — exceeds 24-byte threshold |
| `SessionId` | `theatron-tui` | ULID strings are 26 bytes — exceeds threshold |
| `ToolId` | `theatron-tui` | Reflects ToolName (≤128 bytes) — exceeds threshold |
| `PlanId` | `theatron-tui` | Variable length, uncertain |
| `RequestId` | `pylon` | ULID string = 26 bytes — exceeds threshold |

## Observations

- `timeout 120 cargo test --workspace` times out from a cold build (compilation alone exceeds 120s for this workspace). All tests pass with a warm build cache (~25s). Noted for CI tuning. See `~/dianoia/inbox/` for filed observation.