### PR TITLE
chore(docs): writing standards compliance sweep

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -15,7 +15,7 @@ Do not open a public issue for security vulnerabilities.
 ## Scanning
 
 This repository uses:
-- **Dependabot** — automated dependency updates (Cargo, GitHub Actions)
-- **CodeQL** — static analysis for GitHub Actions workflows
-- **TruffleHog + Gitleaks** — secret detection in git history
-- **cargo audit + cargo deny** — Rust dependency vulnerability and license scanning
+- **Dependabot**: automated dependency updates (Cargo, GitHub Actions)
+- **CodeQL**: static analysis for GitHub Actions workflows
+- **TruffleHog + Gitleaks**: secret detection in git history
+- **cargo audit + cargo deny**: Rust dependency vulnerability and license scanning

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -22,7 +22,7 @@ How this was tested. Include relevant commands or test output.
 ## Checklist
 
 - [ ] `cargo test -p <affected-crate>` passes
-- [ ] `cargo clippy --workspace` — zero warnings
+- [ ] `cargo clippy --workspace` passes with zero warnings
 - [ ] New functionality has tests
 - [ ] No secrets or credentials in the diff
 - [ ] Commit message follows convention (`type(scope): description`)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Privacy-first. Runs on commodity hardware. No cloud dependencies beyond your LLM
 
 ---
 
-## What It Is
+## What it is
 
 Multiple AI agents working in concert with a human operator. Each agent has character, memory, and domain expertise. They persist understanding across sessions, coordinate through shared infrastructure, and evolve through use.
 
@@ -40,7 +40,7 @@ Rust workspace with 17 crates. Single binary deployment.
          Claude     Claude    Claude   Claude
 ```
 
-### Rust Crates (target)
+### Rust crates (target)
 
 See [ARCHITECTURE.md](docs/ARCHITECTURE.md) for the full dependency graph and trait boundaries.
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -8,14 +8,14 @@ Step-by-step guide from bare Linux or macOS to a running Aletheia instance. For 
 
 Five steps from a fresh clone to a running instance:
 
-**Step 1 — Install the binary**
+**Step 1: Install the binary**
 
 ```bash
 cargo build --release
 cp target/release/aletheia ~/.local/bin/
 ```
 
-**Step 2 — Copy the instance scaffold**
+**Step 2: Copy the instance scaffold**
 
 ```bash
 cp -r instance.example instance
@@ -23,9 +23,9 @@ cp -r instance.example instance
 
 This creates the directory tree (`config/`, `data/`, `nous/`, etc.) with template files ready to edit.
 
-**Step 3 — Configure credentials**
+**Step 3: Configure credentials**
 
-Set your Anthropic API key as an environment variable (or use the init wizard — see [Instance setup](#instance-setup)):
+Set your Anthropic API key as an environment variable (or use the init wizard, see [Instance setup](#instance-setup)):
 
 ```bash
 export ANTHROPIC_API_KEY="sk-ant-..."
@@ -33,7 +33,7 @@ export ANTHROPIC_API_KEY="sk-ant-..."
 
 Then edit `instance/config/aletheia.toml` (copy from `instance/config/aletheia.toml.example` if it does not exist) and set the bind address, port, and auth mode.
 
-**Step 4 — Set up your first agent**
+**Step 4: Set up your first agent**
 
 ```bash
 cp -r instance/nous/_template instance/nous/main
@@ -48,7 +48,7 @@ id = "main"
 default = true
 ```
 
-**Step 5 — Start and verify**
+**Step 5: Start and verify**
 
 ```bash
 aletheia --instance-root ./instance
@@ -281,7 +281,7 @@ curl -X POST \
   http://127.0.0.1:18789/api/v1/sessions
 ```
 
-Missing the CSRF header returns `403 Forbidden`. No config change is needed to enable this — it is on by default.
+Missing the CSRF header returns `403 Forbidden`. No config change is needed to enable this; it is on by default.
 
 #### Disable CSRF for development
 
@@ -343,7 +343,7 @@ gateway:
 
 ### Recommended: use the init wizard
 
-The `aletheia init` wizard covers agent setup as part of instance initialization. It prompts for agent name and creates the workspace and config entry automatically. If you used `aletheia init`, your first agent is already configured — skip to [First run](#first-run).
+The `aletheia init` wizard covers agent setup as part of instance initialization. It prompts for agent name and creates the workspace and config entry automatically. If you used `aletheia init`, your first agent is already configured. Skip to [First run](#first-run).
 
 ### Manual: add an additional agent
 

--- a/docs/PACKS.md
+++ b/docs/PACKS.md
@@ -1,4 +1,4 @@
-# Domain Packs
+# Domain packs
 
 A domain pack bundles knowledge, tools, and configuration overlays that extend an Aletheia agent without modifying the core runtime. Packs keep domain-specific content (company IP, schemas, runbooks) separate from generic agent infrastructure.
 

--- a/docs/PROSOCHE.md
+++ b/docs/PROSOCHE.md
@@ -34,7 +34,7 @@ aletheia binary
 
 The daemon supports multiple schedule types:
 
-| Type | Example | Use Case |
+| Type | Example | Use case |
 |------|---------|----------|
 | `Cron` | `0 */45 8-23 * * *` | Every 45 min during waking hours |
 | `Interval` | `Duration::from_secs(3600)` | Fixed hourly interval |

--- a/instance.example/README.md
+++ b/instance.example/README.md
@@ -101,7 +101,7 @@ Tools, templates, hooks, and config all resolve through this cascade.
 1. **Organize by subject, not by agent.** Files go in `theke/projects/{name}/`, not `nous/{id}/docs/`. Any agent can find anything. One tree to search, one tree to prune.
 2. **`nous/{id}/` is identity + memory only.** No docs/, drafts/, plans/, research/, or archive/ directories in agent workspaces. If it's not a bootstrap file or session log, it belongs in theke/.
 3. **`theke/` is the single working filesystem.** Shared by default. The operator and all agents read/write here. Organized by what the work IS, not who's doing it.
-4. **`shared/` is runtime infrastructure.** Scripts, coordination, tools — not content humans navigate.
+4. **`shared/` is runtime infrastructure.** Scripts, coordination, and tools for the runtime, not browsable content.
 5. **If it doesn't ship to a GitHub clone, it's instance-only.** Skills, credentials, agent workspaces, traces — all instance.
 6. **Coordination state is ephemeral.** Traces and status files can be rotated/purged without data loss.
 7. **Archived agents can be removed.** If an agent is retired, remove its `nous/{id}/` directory. No cascade dependencies.

--- a/instance.example/nous/_template/AGENTS.md
+++ b/instance.example/nous/_template/AGENTS.md
@@ -33,7 +33,7 @@ Your workspace (`nous/{id}/`) holds **identity and session memory only**:
 
 **Rule:** Do not create directories like `docs/`, `drafts/`, `plans/`, `research/`, or `archive/` inside your workspace. If you catch yourself about to write a file to `nous/{id}/` that isn't an identity file or session log, put it in `theke/` instead.
 
-## Output Quality
+## Output quality
 
 **Thinking (never in chat):** Memory saves, "let me check..." narration, tool call planning, status tracking, context anxiety.
 
@@ -58,10 +58,10 @@ Your workspace (`nous/{id}/`) holds **identity and session memory only**:
 
 ## Delegation
 
-### Domain Agents (Peers)
+### Domain agents (peers)
 When a task falls outside your domain, route to the appropriate agent via `sessions_send` (fire-and-forget) or `sessions_ask` (need response). Don't attempt work you'll do poorly - route it cleanly.
 
-### Sub-Agent Workforce (Contractors)
+### Sub-agent workforce (contractors)
 For mechanical/investigative work, delegate via `sessions_spawn`:
 
 | Role | Model | Use For |
@@ -76,19 +76,19 @@ For mechanical/investigative work, delegate via `sessions_spawn`:
 
 **QA on results:** Check `status`/`confidence`. High confidence + routine -> integrate. Low confidence or high stakes -> verify first. Never dump raw sub-agent output - summarize and contextualize.
 
-### Name-Mention Forwarding
+### Name-mention forwarding
 When anyone mentions another agent with an implied task, forward immediately via `sessions_send`.
 
 ## Safety
 
 - Don't exfiltrate private data. `trash` > `rm`. When in doubt, ask.
 
-## External vs Internal
+## External vs internal
 
 **Free:** Read files, explore, organize, search web, work in theke/.
 **Ask first:** Emails, tweets, public posts - anything leaving the machine.
 
-## Self-Evolution
+## Self-evolution
 
 After significant sessions: What did I miss? Where was I lazy? What did I claim without verifying?
 

--- a/instance.example/nous/_template/PROSOCHE.md
+++ b/instance.example/nous/_template/PROSOCHE.md
@@ -1,8 +1,8 @@
-# Prosoche - Directed Attention
+# Prosoche: directed attention
 
 Prosoche (προσοχή) = directed attention. This file defines what the agent checks on each heartbeat tick.
 
-## Heartbeat Checklist
+## Heartbeat checklist
 
 On each heartbeat tick, execute **only** the numbered items below. Do not investigate, research, or explore beyond these checks.
 
@@ -26,7 +26,7 @@ nous-health
 ```
 Flag any agent that's unhealthy or unreachable.
 
-## Response Format
+## Response format
 
 If nothing needs action:
 ```text

--- a/instance.example/nous/_template/README.md
+++ b/instance.example/nous/_template/README.md
@@ -1,4 +1,4 @@
-# _example - Nous Agent Template
+# Nous agent template
 
 This directory is the reference template for new Aletheia agents. It shows the expected file and directory structure for a nous workspace.
 

--- a/instance.example/nous/_template/WORKFLOWS.md
+++ b/instance.example/nous/_template/WORKFLOWS.md
@@ -6,7 +6,7 @@
 
 ---
 
-## Prompting Pipeline
+## Prompting pipeline
 
 | What | Where |
 |------|-------|
@@ -53,7 +53,7 @@
 
 ---
 
-## Calendar & Tasks
+## Calendar and tasks
 
 | Tool | Use |
 |------|-----|
@@ -62,7 +62,7 @@
 
 ---
 
-## Agent Coordination
+## Agent coordination
 
 | Tool | Use |
 |------|-----|

--- a/instance.example/packs/starter/context/GETTING_STARTED.md
+++ b/instance.example/packs/starter/context/GETTING_STARTED.md
@@ -1,6 +1,6 @@
-# Getting Started
+# Getting started
 
-This is the starter domain pack — a minimal example you can copy and adapt.
+This is the starter domain pack: a minimal example you can copy and adapt.
 
 ## What domain packs do
 

--- a/shared/hooks/README.md
+++ b/shared/hooks/README.md
@@ -2,11 +2,11 @@
 
 Declarative shell hooks that fire at runtime lifecycle events.
 
-## How It Works
+## How it works
 
 Drop a `.yaml` file in this directory. Each file defines a hook that runs a shell command when an event fires on the internal event bus. No TypeScript required.
 
-## Hook Definition Format
+## Hook definition format
 
 ```yaml
 name: my-hook              # unique identifier
@@ -28,7 +28,7 @@ handler:
 nousFilter: [agent-a, agent-b]
 ```
 
-## Supported Events
+## Supported events
 
 | Event | Payload Fields | When |
 |-------|---------------|------|
@@ -45,7 +45,7 @@ nousFilter: [agent-a, agent-b]
 | `boot:ready` | port, tools, plugins | Runtime ready |
 | `config:reloaded` | added, removed | Config hot-reloaded |
 
-## Handler Protocol
+## Handler protocol
 
 Shell handlers receive the full event payload as JSON on **stdin**. This means your script can read structured data:
 
@@ -67,7 +67,7 @@ echo "Processing session: $SESSION_ID"
 - `1` -warning (logged if failAction is not "silent")
 - `2+` -error (always logged unless "silent")
 
-## Template Variables
+## Template variables
 
 Args and the command itself support `{{variable}}` substitution from the event payload:
 
@@ -79,7 +79,7 @@ Args and the command itself support `{{variable}}` substitution from the event p
 
 Missing variables resolve to empty string.
 
-## Per-Agent Hooks
+## Per-agent hooks
 
 Hooks in `shared/hooks/` apply globally. For agent-specific hooks, create a `hooks/` directory in the agent's workspace:
 
@@ -90,14 +90,14 @@ nous/<agent-b>/hooks/maintenance-log.yaml
 
 Or use `nousFilter` in a global hook to restrict which agents trigger it.
 
-## Allowed Script Extensions
+## Allowed script extensions
 
 For security, only these file extensions are allowed as hook commands:
 `.sh`, `.rb`, `.pl`
 
 Commands without extensions (e.g., `/usr/bin/curl`) are also allowed.
 
-## Fail Actions
+## Fail actions
 
 - **warn** (default) -log a warning on non-zero exit, don't affect the event
 - **silent** -swallow all errors silently

--- a/shared/templates/sections/development.md
+++ b/shared/templates/sections/development.md
@@ -1,6 +1,6 @@
-## Development Workflow
+## Development workflow
 
-### Local Validation
+### Local validation
 
 Run targeted tests during development:
 
@@ -15,7 +15,7 @@ Full suite as a final gate before PR:
 cargo test --workspace
 ```
 
-### Git Rules
+### Git rules
 
 - **Author:** `forkwright <forkwright@users.noreply.github.com>` (always)
 - **Branch from main:** `git checkout -b <type>/<description> main`
@@ -24,7 +24,7 @@ cargo test --workspace
 - **One logical change per commit.** Squash micro-commits before pushing.
 - **Always push after commit.** Commits without push don't exist.
 
-### Branch Naming
+### Branch naming
 
 | Type | Pattern | Example |
 |------|---------|---------|

--- a/shared/templates/sections/external_vs_internal.md
+++ b/shared/templates/sections/external_vs_internal.md
@@ -1,5 +1,5 @@
 
-## External vs Internal
+## External vs internal
 
 **Safe to do freely:** Read files, explore, organize, learn. Search the web. Work within this workspace.
 

--- a/shared/templates/sections/group_chats.md
+++ b/shared/templates/sections/group_chats.md
@@ -1,5 +1,5 @@
 
-## Group Chats
+## Group chats
 
 You have access to your human's stuff. That doesn't mean you share it. In groups, you're a participant - not their voice, not their proxy.
 

--- a/shared/templates/sections/memory.md
+++ b/shared/templates/sections/memory.md
@@ -3,7 +3,7 @@
 
 You wake up fresh each session. These files are your continuity:
 
-### Three-Tier Memory
+### Three-tier memory
 | Tier | File | Purpose | When to write |
 |------|------|---------|---------------|
 | **Raw** | `memory/YYYY-MM-DD.md` | Session logs, what happened | During/end of sessions |
@@ -17,12 +17,12 @@ You wake up fresh each session. These files are your continuity:
 - **Daily files** - Create automatically, consolidate weekly
 - **Graph** - Use `memory_search` for shared knowledge across all nous
 
-### 📝 Write It Down - No "Mental Notes"!
+### 📝 Write it down: no "mental notes"
 - "Mental notes" don't survive sessions. Files do.
 - When someone says "remember this" -> write it NOW
 - When you learn a lesson -> update your workspace files
 - When you make a mistake -> document it
 - **Text > Brain** 📝
 
-### Federated Search
+### Federated search
 Use `memory_search` tool for cross-session recall. Memories are auto-extracted from conversations.

--- a/shared/templates/sections/name_forwarding.md
+++ b/shared/templates/sections/name_forwarding.md
@@ -1,5 +1,5 @@
 
-## Name-Mention Forwarding
+## Name-mention forwarding
 
 When anyone mentions another nous by name with an implied task, forward immediately:
 

--- a/shared/templates/sections/output_quality.md
+++ b/shared/templates/sections/output_quality.md
@@ -1,4 +1,4 @@
-## Output Quality
+## Output quality
 
 Your chat output is for the human. Your thinking is for you. Keep them separate.
 
@@ -17,7 +17,7 @@ Your chat output is for the human. Your thinking is for you. Keep them separate.
 - Errors, blockers, things needing human input
 - Final summaries of completed work
 
-### Formatting Rules
+### Formatting rules
 
 **Tables** for comparisons, status, options:
 
@@ -33,7 +33,7 @@ Your chat output is for the human. Your thinking is for you. Keep them separate.
 ### Completed
 - PR #55 merged - working state + agent notes
 
-### In Progress
+### In progress
 - Spec 04 Phase 1 - message queue
 
 ### Blocked

--- a/shared/templates/sections/research_protocol.md
+++ b/shared/templates/sections/research_protocol.md
@@ -1,8 +1,8 @@
-## Research Protocol
+## Research protocol
 
 All research produced in this system follows a strict evidence hierarchy. This is non-negotiable.
 
-### Source Hierarchy (descending authority)
+### Source hierarchy (descending authority)
 
 | Tier | Source Type | Trust | Cite As |
 |------|-----------|-------|---------|
@@ -12,7 +12,7 @@ All research produced in this system follows a strict evidence hierarchy. This i
 | **S4** | Blog, talk, grey literature | Low | `[Author, Year, Source]` flagged as grey |
 | **S5** | Our own synthesis/interpretation | Claim only | `[Aletheia synthesis]` - always marked |
 
-### Claim Protocol
+### Claim protocol
 
 Every factual claim must:
 1. **Have an inline citation** - not just a bibliography at the end
@@ -23,7 +23,7 @@ Every factual claim must:
    - ⚠️ **Speculative** - our interpretation, a single source, or extrapolation
 4. **Never cite what you haven't read** - abstract ≠ paper. If you only read the abstract, say so.
 
-### Verification Steps
+### Verification steps
 
 Before including a source:
 1. **Read the actual paper** (at minimum: abstract, methods, results, limitations)
@@ -31,14 +31,14 @@ Before including a source:
 3. **Look for replication or contradiction** - one study is a data point, not a conclusion
 4. **Check for retraction/correction** - especially for preprints
 
-### Counter-Evidence Requirement
+### Counter-evidence requirement
 
 For any claim central to our thesis:
 - **Actively search for disconfirming evidence** ("X is wrong", "critique of X", "limitations of X")
 - **Steel-man the strongest counterargument** - present it fairly before responding
 - **If no counterargument found, note that explicitly** - absence of criticism is itself information (either too new or too niche)
 
-### Research Log
+### Research log
 
 Every research session must produce:
 - **Search queries used** (what you searched, where)
@@ -57,7 +57,7 @@ Gaps: [what's missing]
 Confidence: [high/medium/low] because [reason]
 ```
 
-### PRISMA-Lite for Systematic Work
+### PRISMA-lite for systematic work
 
 For systematic literature reviews (not quick lookups):
 1. **Define the question** precisely before searching
@@ -68,7 +68,7 @@ For systematic literature reviews (not quick lookups):
 6. **Synthesize** with explicit methodology
 7. **Report limitations** of the review itself
 
-### What This Prevents
+### What this prevents
 
 - **Citation laundering** - citing a source you found in another source's bibliography without reading it
 - **Confidence inflation** - treating one preprint as established fact

--- a/shared/templates/sections/safety.md
+++ b/shared/templates/sections/safety.md
@@ -6,7 +6,7 @@
 - `trash` > `rm` (recoverable beats gone forever)
 - When in doubt, ask.
 
-### Config Changes
+### Config changes
 **ALWAYS** validate before restart:
 ```bash
 aletheia doctor           # Validate runtime config

--- a/shared/templates/sections/self_evolution.md
+++ b/shared/templates/sections/self_evolution.md
@@ -1,5 +1,5 @@
 
-## Self-Evolution
+## Self-evolution
 
 After significant sessions, ask:
 - What did I miss?

--- a/shared/templates/sections/session_start.md
+++ b/shared/templates/sections/session_start.md
@@ -10,7 +10,7 @@ Before doing anything else:
 
 Don't ask permission. Just do it.
 
-## Pre-Compaction (Distillation)
+## Pre-compaction (distillation)
 
 When you receive a pre-compaction flush prompt (the runtime signals this before context distillation):
 1. Run `distill --nous $(basename $PWD) --text "YOUR_SUMMARY"` with key decisions, corrections, insights, and open threads

--- a/shared/templates/sections/shared_infrastructure.md
+++ b/shared/templates/sections/shared_infrastructure.md
@@ -1,5 +1,5 @@
 
-## Shared Infrastructure
+## Shared infrastructure
 
 All nous share common resources at `$ALETHEIA_SHARED`:
 
@@ -12,7 +12,7 @@ Convention-based paths (no mapping files needed):
 - Shared config: `$ALETHEIA_SHARED/config/$NAME`
 - Shared tools: `$ALETHEIA_SHARED/bin/$NAME`
 
-### Shared Memory
+### Shared memory
 - `$ALETHEIA_SHARED/memory/facts.jsonl` - Single fact store (symlinked to all nous)
 - `$ALETHEIA_SHARED/USER.md` - Human context (symlinked to all nous)
 

--- a/shared/templates/sections/status_reporting.md
+++ b/shared/templates/sections/status_reporting.md
@@ -1,5 +1,5 @@
 
-## Status Reporting
+## Status reporting
 
 When asked for status or during check-ins, use this format:
 
@@ -15,5 +15,5 @@ When asked for status or during check-ins, use this format:
 ### Blocked
 - [what's stuck and why]
 
-### Cross-Domain
+### Cross-domain
 - [anything affecting other nous/domains]


### PR DESCRIPTION
## Summary

- Eliminated em dashes from prose, replacing with colons, commas, semicolons, or separate sentences
- Fixed title-case headers to sentence case across 25 files
- Replaced metaphorical "navigate" with direct language in instance.example/README.md
- Fixed em dash in GETTING_STARTED.md (prose, not code block)
- standards/ directory content unchanged throughout

## Test plan

- [x] `grep -rn '—' docs/` returns zero matches outside code blocks
- [x] Spot-check of 5 files for banned words: no violations found
- [x] Heading hierarchy in docs/: no skipped levels
- [x] No content meaning changed (pure punctuation and case fixes)
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes (zero warnings)
- [x] `cargo test --workspace` passes

## Observations

- `docs/NIX.md` contains em dashes inside code blocks (Nix code examples, bash comment lines). These are exempt per the prompt (code blocks excluded).
- `docs/ARCHITECTURE.md` tree diagram uses em dashes as separators inside a `\`\`\`text\`\`\`` block. Exempt.
- `shared/bin/credential-refresh` (Python script) contains em dashes in log strings. Out of scope (not a .md file).
- `docs/ADR-001-errors.md` uses "Evaluation harness" as a technical compound noun — not the banned verb "harness."

🤖 Generated with [Claude Code](https://claude.com/claude-code)