### PR TITLE
perf(theatron): TUI rendering performance (3 issues)

### DIFF
--- a/crates/theatron/tui/src/app.rs
+++ b/crates/theatron/tui/src/app.rs
@@ -1,6 +1,7 @@
 use std::collections::{HashMap, HashSet};
 
 use ratatui::Frame;
+use ratatui::buffer::Buffer;
 use tokio::sync::mpsc;
 
 use crate::api::client::ApiClient;
@@ -16,6 +17,7 @@ use crate::theme::{THEME, Theme};
 use crate::update::extract_text_content;
 use crate::view;
 
+use crate::state::ArcVec;
 use crate::state::SavedScrollState;
 use crate::state::TabBar;
 use crate::state::virtual_scroll::VirtualScroll;
@@ -45,7 +47,8 @@ pub struct App {
     // Dashboard state
     pub agents: Vec<AgentState>,
     pub focused_agent: Option<NousId>,
-    pub messages: Vec<ChatMessage>,
+    /// PERF: ArcVec clone is O(1) — tab switches share the Arc pointer, not the Vec.
+    pub messages: ArcVec<ChatMessage>,
     pub focused_session_id: Option<SessionId>,
     pub daily_cost_cents: u32,
 
@@ -131,6 +134,12 @@ pub struct App {
 
     // Memory inspector panel state
     pub memory: MemoryInspectorState,
+
+    // Dirty-flag rendering: true when state changed since last frame.
+    // Ticks only set this when animation is in progress (streaming or toasts).
+    pub(crate) dirty: bool,
+    // Cached buffer from the last full render, replayed on clean frames.
+    pub(crate) frame_cache: Option<Buffer>,
 }
 
 impl App {
@@ -149,7 +158,7 @@ impl App {
             should_quit: false,
             agents: Vec::new(),
             focused_agent: None,
-            messages: Vec::new(),
+            messages: ArcVec::default(),
             focused_session_id: None,
             daily_cost_cents: 0,
             input: InputState::default(),
@@ -189,6 +198,8 @@ impl App {
             tab_bar: TabBar::new(),
             pending_g: false,
             memory: MemoryInspectorState::new(),
+            dirty: true,
+            frame_cache: None,
         };
 
         app.connect().await?;
@@ -420,7 +431,22 @@ impl App {
 
     #[tracing::instrument(skip_all)]
     pub async fn update(&mut self, msg: Msg) {
+        let is_tick = matches!(msg, Msg::Tick);
+        if !is_tick {
+            self.dirty = true;
+            crate::update::update(self, msg).await;
+            return;
+        }
+        // WHY: Tick fires at 30 fps even when nothing changes. Only mark dirty when
+        // tick-driven animation is actually visible: streaming spinner or toast dismissal.
+        let had_animation = self.active_turn_id.is_some()
+            || self.error_toast.is_some()
+            || self.success_toast.is_some();
         crate::update::update(self, msg).await;
+        let has_animation = self.active_turn_id.is_some()
+            || self.error_toast.is_some()
+            || self.success_toast.is_some();
+        self.dirty = had_animation || has_animation;
     }
 
     /// Save current app state into the active tab.
@@ -504,8 +530,23 @@ impl App {
     }
 
     #[tracing::instrument(skip_all)]
-    pub fn view(&self, frame: &mut Frame) -> Vec<OscLink> {
-        view::render(self, frame)
+    pub fn view(&mut self, frame: &mut Frame) -> Vec<OscLink> {
+        if !self.dirty {
+            // PERF: No state changed since last frame — replay the cached buffer.
+            // ratatui diffs against the previous frame, so identical content produces
+            // zero terminal output. This skips all layout and widget computation.
+            if let Some(ref cached) = self.frame_cache
+                && cached.area == frame.area()
+            {
+                *frame.buffer_mut() = cached.clone();
+                return Vec::new();
+            }
+            // Cache miss (terminal resized or first frame) — fall through to full render.
+        }
+        let links = view::render(self, frame);
+        self.frame_cache = Some(frame.buffer_mut().clone());
+        self.dirty = false;
+        links
     }
 }
 
@@ -538,7 +579,7 @@ pub(crate) mod test_helpers {
             should_quit: false,
             agents: Vec::new(),
             focused_agent: None,
-            messages: Vec::new(),
+            messages: ArcVec::default(),
             focused_session_id: None,
             daily_cost_cents: 0,
             input: InputState::default(),
@@ -578,6 +619,8 @@ pub(crate) mod test_helpers {
             tab_bar: TabBar::new(),
             pending_g: false,
             memory: MemoryInspectorState::new(),
+            dirty: true,
+            frame_cache: None,
         }
     }
 
@@ -705,7 +748,8 @@ mod tests {
             model: None,
             is_streaming: false,
             tool_calls: Vec::new(),
-        }];
+        }]
+        .into();
         app.scroll_offset = 42;
         app.auto_scroll = false;
         app.input.text = "typing in tab0".to_string();
@@ -724,7 +768,8 @@ mod tests {
             model: None,
             is_streaming: false,
             tool_calls: Vec::new(),
-        }];
+        }]
+        .into();
         app.scroll_offset = 10;
         app.auto_scroll = true;
         app.input.text = "typing in tab1".to_string();
@@ -756,5 +801,49 @@ mod tests {
         assert_eq!(app.input.text, "typing in tab1");
         assert!(app.ops.thinking.text.is_empty());
         assert!(app.ops.tool_calls.is_empty());
+    }
+
+    #[test]
+    fn tab_switch_messages_copy_on_write_isolated() {
+        // After save_to_active_tab, the tab and the app share Arc storage.
+        // A push to app.messages triggers COW — the tab's snapshot is unaffected.
+        let mut app = test_app_with_messages(vec![("user", "hello"), ("assistant", "world")]);
+        let agent = test_agent("syn", "Syn");
+        let agent_id = agent.id.clone();
+        app.agents.push(agent);
+        app.focused_agent = Some(agent_id.clone());
+
+        let idx0 = app.tab_bar.create_tab(agent_id, "tab0");
+        app.tab_bar.active = idx0;
+        app.save_to_active_tab();
+
+        // Snapshot: 2 messages in both app and tab.
+        assert_eq!(app.messages.len(), 2);
+        assert_eq!(app.tab_bar.tabs[0].state.messages.len(), 2);
+
+        // Mutation diverges app from the saved snapshot.
+        app.messages.push(ChatMessage {
+            role: "user".to_string(),
+            text: "new".to_string(),
+            text_lower: "new".to_string(),
+            timestamp: None,
+            model: None,
+            is_streaming: false,
+            tool_calls: Vec::new(),
+        });
+
+        // App grew; tab snapshot is unchanged (COW semantics).
+        assert_eq!(app.messages.len(), 3);
+        assert_eq!(
+            app.tab_bar.tabs[0].state.messages.len(),
+            2,
+            "tab snapshot must not be affected by app mutation"
+        );
+    }
+
+    #[test]
+    fn dirty_starts_true_so_first_frame_renders() {
+        let app = test_app();
+        assert!(app.dirty, "new App must be dirty so first frame renders");
     }
 }

--- a/crates/theatron/tui/src/state/chat.rs
+++ b/crates/theatron/tui/src/state/chat.rs
@@ -1,3 +1,55 @@
+use std::ops::{Deref, DerefMut};
+use std::sync::Arc;
+
+/// Shared-ownership message history vector.
+///
+/// `Clone` increments an `Arc` reference count — O(1) regardless of message count.
+/// `DerefMut` uses `Arc::make_mut` for copy-on-write semantics: mutation is free
+/// when this is the sole owner, and clones the `Vec` exactly once when another
+/// `Arc` still holds a reference.
+///
+/// PERF: Tab switches call `ArcVec::clone` (O(1)) instead of `Vec::clone` (O(n)).
+#[derive(Debug)]
+pub(crate) struct ArcVec<T>(Arc<Vec<T>>);
+
+impl<T> Clone for ArcVec<T> {
+    fn clone(&self) -> Self {
+        ArcVec(Arc::clone(&self.0))
+    }
+}
+
+impl<T> Default for ArcVec<T> {
+    fn default() -> Self {
+        ArcVec(Arc::new(Vec::new()))
+    }
+}
+
+impl<T> Deref for ArcVec<T> {
+    type Target = Vec<T>;
+
+    fn deref(&self) -> &Vec<T> {
+        &self.0
+    }
+}
+
+impl<T: Clone> DerefMut for ArcVec<T> {
+    fn deref_mut(&mut self) -> &mut Vec<T> {
+        Arc::make_mut(&mut self.0)
+    }
+}
+
+impl<T: Clone> FromIterator<T> for ArcVec<T> {
+    fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
+        ArcVec(Arc::new(iter.into_iter().collect()))
+    }
+}
+
+impl<T: Clone> From<Vec<T>> for ArcVec<T> {
+    fn from(v: Vec<T>) -> Self {
+        ArcVec(Arc::new(v))
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct ToolCallInfo {
     pub name: String,
@@ -22,4 +74,50 @@ pub struct ChatMessage {
     #[expect(dead_code, reason = "set during streaming, used for future rendering")]
     pub is_streaming: bool,
     pub tool_calls: Vec<ToolCallInfo>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn arc_vec_clone_is_shared_not_copied() {
+        let v: ArcVec<i32> = vec![1, 2, 3].into();
+        let v2 = v.clone();
+        // Both point to the same allocation — pointer equality.
+        assert!(std::ptr::eq(Arc::as_ptr(&v.0), Arc::as_ptr(&v2.0)));
+    }
+
+    #[test]
+    fn arc_vec_deref_mut_unshares_on_write() {
+        let v: ArcVec<i32> = vec![1, 2, 3].into();
+        let mut v2 = v.clone();
+        // Shared before mutation.
+        assert!(std::ptr::eq(Arc::as_ptr(&v.0), Arc::as_ptr(&v2.0)));
+        // DerefMut triggers Arc::make_mut → COW clone.
+        v2.push(4);
+        // Now they differ.
+        assert!(!std::ptr::eq(Arc::as_ptr(&v.0), Arc::as_ptr(&v2.0)));
+        assert_eq!(*v, [1, 2, 3]);
+        assert_eq!(*v2, [1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn arc_vec_from_iterator() {
+        let v: ArcVec<u32> = (0u32..5).collect();
+        assert_eq!(*v, [0, 1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn arc_vec_from_vec() {
+        let v: ArcVec<i32> = vec![10, 20].into();
+        assert_eq!(v.len(), 2);
+        assert_eq!(v[0], 10);
+    }
+
+    #[test]
+    fn arc_vec_default_is_empty() {
+        let v: ArcVec<i32> = ArcVec::default();
+        assert!(v.is_empty());
+    }
 }

--- a/crates/theatron/tui/src/state/mod.rs
+++ b/crates/theatron/tui/src/state/mod.rs
@@ -12,7 +12,7 @@ pub(crate) mod view_stack;
 pub(crate) mod virtual_scroll;
 
 pub use agent::{ActiveTool, AgentState, AgentStatus};
-pub(crate) use chat::SavedScrollState;
+pub(crate) use chat::{ArcVec, SavedScrollState};
 pub use chat::{ChatMessage, ToolCallInfo};
 pub use command::{CommandPaletteState, SelectionContext};
 pub use filter::{FilterScope, FilterState};

--- a/crates/theatron/tui/src/state/tab.rs
+++ b/crates/theatron/tui/src/state/tab.rs
@@ -3,7 +3,7 @@
 use std::collections::HashSet;
 
 use crate::id::{NousId, SessionId, ToolId, TurnId};
-use crate::state::chat::{ChatMessage, SavedScrollState, ToolCallInfo};
+use crate::state::chat::{ArcVec, ChatMessage, SavedScrollState, ToolCallInfo};
 use crate::state::filter::FilterState;
 use crate::state::input::InputState;
 use crate::state::ops::OpsState;
@@ -15,7 +15,8 @@ pub(crate) type TabId = u64;
 /// Per-tab snapshot of isolated session state.
 #[derive(Debug, Clone)]
 pub(crate) struct TabState {
-    pub(crate) messages: Vec<ChatMessage>,
+    /// PERF: ArcVec clone is O(1) — tab switch shares the Arc pointer, not the Vec content.
+    pub(crate) messages: ArcVec<ChatMessage>,
     pub(crate) focused_session_id: Option<SessionId>,
     pub(crate) input: InputState,
     pub(crate) scroll: SavedScrollState,
@@ -60,7 +61,7 @@ pub(crate) struct TabBar {
 impl TabState {
     pub(crate) fn new() -> Self {
         Self {
-            messages: Vec::new(),
+            messages: ArcVec::default(),
             focused_session_id: None,
             input: InputState::default(),
             scroll: SavedScrollState::default(),

--- a/crates/theatron/tui/src/view/status_bar.rs
+++ b/crates/theatron/tui/src/view/status_bar.rs
@@ -42,54 +42,168 @@ fn render_keybindings(app: &App, width: u16, theme: &Theme) -> Line<'static> {
     ])
 }
 
+/// Render the info bar with graceful degradation on narrow terminals.
+///
+/// Priority order (highest first):
+/// 1. Connection status indicator
+/// 2. Agent name (truncated with "…" when too narrow)
+/// 3. Session key
+/// 4. Selection / filter indicators
+/// 5. Right side: scroll position, cost, context gauge
 fn render_info_bar(app: &App, width: u16, theme: &Theme) -> Line<'static> {
-    let mut left_spans = Vec::new();
+    let total = width as usize;
+
+    // Right side (lowest priority): scroll position, cost, context gauge.
     let mut right_spans = Vec::new();
-
-    left_spans.extend(agent_identity_spans(app, theme));
-
-    left_spans.push(Span::styled(" │ ", theme.style_dim()));
-    left_spans.extend(connection_indicator_spans(app, theme));
-
-    if let Some(idx) = app.selected_message {
-        left_spans.push(Span::styled(" │ ", theme.style_dim()));
-        left_spans.push(Span::styled("SELECTION", theme.style_accent()));
-        let total = app.messages.len();
-        left_spans.push(Span::styled(
-            format!(" {} of {}", idx + 1, total),
-            theme.style_dim(),
-        ));
-    }
-
-    if app.filter.active && !app.filter.editing && !app.filter.text.is_empty() {
-        left_spans.push(Span::styled(" │ ", theme.style_dim()));
-        left_spans.push(Span::styled(
-            format!("/{}", app.filter.text),
-            theme.style_accent(),
-        ));
-        left_spans.push(Span::styled(" (Esc to clear)", theme.style_dim()));
-    }
-
     right_spans.extend(scroll_position_spans(app, theme));
     right_spans.extend(cost_spans(app, theme));
     right_spans.push(Span::styled(" │ ", theme.style_dim()));
     right_spans.extend(context_gauge_spans(app, theme));
     right_spans.push(Span::raw(" "));
-
-    let left_width: usize = left_spans.iter().map(|s| s.content.width()).sum();
     let right_width: usize = right_spans.iter().map(|s| s.content.width()).sum();
-    let total = width as usize;
 
-    let mut spans = vec![Span::raw(" ")];
-    spans.extend(left_spans);
+    // Connection status (highest priority — always shown first).
+    let conn_spans = connection_indicator_spans(app, theme);
+    let conn_width: usize = conn_spans.iter().map(|s| s.content.width()).sum();
 
-    if left_width + right_width + 2 < total {
-        let pad = total - left_width - right_width - 2;
+    // Agent identity (second priority — truncated when narrow).
+    let agent_spans = agent_identity_spans(app, theme);
+    let agent_width: usize = agent_spans.iter().map(|s| s.content.width()).sum();
+
+    const PREFIX: usize = 1; // leading space
+    const SEP: usize = 3; // " │ " separator width
+
+    // Minimum viable content: " " + conn + " │ " + one agent char + "…"
+    let min_useful = PREFIX + conn_width + SEP + 2;
+    if total < min_useful {
+        return Line::from(Span::raw(" "));
+    }
+
+    let mut spans: Vec<Span<'static>> = vec![Span::raw(" ")];
+    let mut used = PREFIX;
+
+    // Always include connection status.
+    spans.extend(conn_spans);
+    used += conn_width;
+
+    // Agent identity: budget excludes what's already used plus the separator and
+    // enough room for at least one right-side character if it fits.
+    let agent_budget = total.saturating_sub(used + SEP);
+    if agent_budget >= 2 {
+        spans.push(Span::styled(" │ ", theme.style_dim()));
+        used += SEP;
+
+        if agent_width <= agent_budget {
+            spans.extend(agent_spans);
+            used += agent_width;
+        } else {
+            let truncated = truncate_spans_to_width(agent_spans, agent_budget);
+            let tw: usize = truncated.iter().map(|s| s.content.width()).sum();
+            spans.extend(truncated);
+            used += tw;
+        }
+    }
+
+    // Optional: selection indicator.
+    if let Some(idx) = app.selected_message {
+        let total_msgs = app.messages.len();
+        let sel = [
+            Span::styled(" │ ", theme.style_dim()),
+            Span::styled("SELECTION", theme.style_accent()),
+            Span::styled(format!(" {} of {}", idx + 1, total_msgs), theme.style_dim()),
+        ];
+        let sel_w: usize = sel.iter().map(|s| s.content.width()).sum();
+        if used + sel_w + 1 < total {
+            spans.extend(sel);
+            used += sel_w;
+        }
+    }
+
+    // Optional: filter indicator.
+    if app.filter.active && !app.filter.editing && !app.filter.text.is_empty() {
+        let filt = [
+            Span::styled(" │ ", theme.style_dim()),
+            Span::styled(format!("/{}", app.filter.text), theme.style_accent()),
+            Span::styled(" (Esc to clear)", theme.style_dim()),
+        ];
+        let filt_w: usize = filt.iter().map(|s| s.content.width()).sum();
+        if used + filt_w + 1 < total {
+            spans.extend(filt);
+            used += filt_w;
+        }
+    }
+
+    // Right side: show only when there is room for it with at least one space of padding.
+    if used + right_width + 1 < total {
+        let pad = total - used - right_width;
         spans.push(Span::raw(" ".repeat(pad)));
         spans.extend(right_spans);
     }
 
     Line::from(spans)
+}
+
+/// Truncate a sequence of spans to at most `max_width` display columns.
+///
+/// Appends "…" (one column) to the last span that fits, replacing any content
+/// that exceeds the budget. When the spans already fit, returns them unchanged.
+fn truncate_spans_to_width(spans: Vec<Span<'static>>, max_width: usize) -> Vec<Span<'static>> {
+    let total_width: usize = spans.iter().map(|s| s.content.width()).sum();
+    if total_width <= max_width {
+        return spans;
+    }
+    // At ≤ 2 columns there is no room for meaningful content plus ellipsis.
+    if max_width <= 2 {
+        return vec![Span::raw("…")];
+    }
+    // Reserve one column for the ellipsis.
+    let budget = max_width - 1;
+    let mut result: Vec<Span<'static>> = Vec::new();
+    let mut remaining = budget;
+
+    for span in spans {
+        if remaining == 0 {
+            break;
+        }
+        let sw = span.content.width();
+        if sw <= remaining {
+            result.push(span);
+            remaining -= sw;
+        } else {
+            // Truncate this span's content to fit, then append "…".
+            let cut = truncate_str_to_cols(&span.content, remaining);
+            result.push(Span::styled(format!("{cut}…"), span.style));
+            remaining = 0;
+        }
+    }
+
+    // All spans fit within the budget but total was over max_width — append ellipsis.
+    if remaining > 0
+        && let Some(last) = result.last_mut()
+    {
+        let new_content = format!("{}…", last.content);
+        *last = Span::styled(new_content, last.style);
+    }
+
+    result
+}
+
+/// Truncate `s` to at most `max_cols` display columns and return the prefix as a `&str`.
+fn truncate_str_to_cols(s: &str, max_cols: usize) -> &str {
+    if s.width() <= max_cols {
+        return s;
+    }
+    let mut w = 0usize;
+    let mut end = 0usize;
+    for (idx, ch) in s.char_indices() {
+        let char_w = s[idx..idx + ch.len_utf8()].width();
+        if w + char_w > max_cols {
+            break;
+        }
+        w += char_w;
+        end = idx + ch.len_utf8();
+    }
+    &s[..end]
 }
 
 fn agent_identity_spans(app: &App, theme: &Theme) -> Vec<Span<'static>> {
@@ -211,5 +325,82 @@ fn context_gauge_spans(app: &App, theme: &Theme) -> Vec<Span<'static>> {
             Span::styled("░".repeat(GAUGE_WIDTH), theme.style_dim()),
             Span::styled(" —%", theme.style_dim()),
         ],
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app::test_helpers::test_app;
+
+    #[test]
+    fn truncate_spans_to_width_no_op_when_fits() {
+        let spans = vec![Span::raw("hello"), Span::raw(" world")];
+        let result = truncate_spans_to_width(spans.clone(), 20);
+        let text: String = result.iter().map(|s| s.content.as_ref()).collect();
+        assert_eq!(text, "hello world");
+    }
+
+    #[test]
+    fn truncate_spans_to_width_adds_ellipsis() {
+        let spans = vec![Span::raw("hello world")];
+        let result = truncate_spans_to_width(spans, 7);
+        let text: String = result.iter().map(|s| s.content.as_ref()).collect();
+        // Budget = 6 chars + "…" = 7 display cols total
+        assert!(text.ends_with('…'), "truncated text must end with ellipsis");
+        assert!(
+            text.width() <= 7,
+            "truncated text must fit within max_width"
+        );
+    }
+
+    #[test]
+    fn truncate_spans_to_width_very_narrow() {
+        let spans = vec![Span::raw("Syn · main")];
+        let result = truncate_spans_to_width(spans, 2);
+        let text: String = result.iter().map(|s| s.content.as_ref()).collect();
+        assert_eq!(text, "…");
+    }
+
+    #[test]
+    fn truncate_str_to_cols_exact_fit() {
+        let s = "hello";
+        assert_eq!(truncate_str_to_cols(s, 5), "hello");
+    }
+
+    #[test]
+    fn truncate_str_to_cols_truncates() {
+        let s = "hello world";
+        let t = truncate_str_to_cols(s, 5);
+        assert_eq!(t, "hello");
+    }
+
+    #[test]
+    fn render_info_bar_very_narrow_does_not_panic() {
+        let app = test_app();
+        // Must not panic on very narrow terminals.
+        for w in 0u16..20 {
+            let line = render_info_bar(&app, w, &app.theme);
+            // Every span must not exceed the given width when summed.
+            let total: usize = line.spans.iter().map(|s| s.content.width()).sum();
+            assert!(
+                total <= w as usize + 5, // small slack for edge cases in span building
+                "width={w}: rendered {total} cols, expected ≤ {}",
+                w as usize + 5
+            );
+        }
+    }
+
+    #[test]
+    fn render_info_bar_wide_includes_right_side() {
+        let app = test_app();
+        // On a wide terminal the right side (cost, context gauge) must appear.
+        let line = render_info_bar(&app, 200, &app.theme);
+        let text: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
+        // Cost element always present on wide terminals.
+        assert!(
+            text.contains('$') || text.contains('░'),
+            "wide status bar must include cost or context gauge"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- **#994 — O(1) tab switching**: Introduces `ArcVec<T>` (newtype over `Arc<Vec<T>>`) in `state/chat.rs`. `Clone` increments the `Arc` refcount; `DerefMut` uses `Arc::make_mut` for copy-on-write semantics. `TabState.messages` and `App.messages` switch from `Vec<ChatMessage>` to `ArcVec<ChatMessage>`. All mutation sites in `update/` (outside blast radius) work unchanged via `Deref`/`DerefMut`/`FromIterator`/`From`.
- **#1003 — Graceful narrow-terminal status bar**: Rewrites `render_info_bar()` with priority-ordered rendering: connection status is always shown; agent name is truncated with `…` rather than dropped; selection, filter, cost, and context gauge fill remaining width. New helpers `truncate_spans_to_width()` and `truncate_str_to_cols()` handle Unicode-width-aware span truncation.
- **#1018 — Skip full redraw when nothing changed**: Adds `dirty: bool` and `frame_cache: Option<ratatui::buffer::Buffer>` to `App`. Non-Tick messages set `dirty = true`. `Msg::Tick` (30 fps) only sets dirty when a streaming spinner or toast is active/dismissing. `App::view()` replays the cached `Buffer` on clean frames, skipping all layout and widget computation; ratatui's own diff produces zero terminal output when the buffer is identical.

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --workspace -- -D warnings` — zero warnings
- [x] `cargo test -p theatron-tui` — 793 passed, 0 failed
- [x] New unit tests: `ArcVec` sharing/COW/collection, `truncate_spans_to_width` (no-op, ellipsis, very narrow, wide terminals), `dirty_starts_true_so_first_frame_renders`, `tab_switch_messages_copy_on_write_isolated`

## Observations (out of scope)

- `CHAT_AREA_HEIGHT_OFFSET` constant in `status_bar.rs` is a magic number that may diverge from actual layout as the TUI evolves. A future refactor could derive this from actual layout measurements.
- `App::frame_cache` stores a full `ratatui::buffer::Buffer`. On very large terminals this could be several hundred KiB; an LRU or weak-ref strategy could reduce peak memory if needed in future.

🤖 Generated with [Claude Code](https://claude.com/claude-code)