### PR TITLE
chore: remove dead wiring (5 issues)

### DIFF
--- a/crates/daemon/src/execution.rs
+++ b/crates/daemon/src/execution.rs
@@ -1,4 +1,4 @@
-//! Task action execution: commands, builtins, prompts, and knowledge maintenance.
+//! Task action execution: commands and builtins.
 
 use std::sync::Arc;
 
@@ -25,31 +25,6 @@ pub(crate) async fn execute_action(
 ) -> Result<ExecutionResult> {
     match action {
         TaskAction::Command(cmd) => execute_command(cmd).await,
-        TaskAction::Tool { name, .. } => {
-            tracing::info!(
-                nous_id = %nous_id,
-                tool = %name,
-                "tool execution not yet wired — requires organon integration"
-            );
-            Ok(ExecutionResult {
-                success: true,
-                output: None,
-            })
-        }
-        TaskAction::Prompt(prompt) => {
-            if let Some(bridge) = bridge {
-                bridge.send_prompt(nous_id, "daemon:prompt", prompt).await
-            } else {
-                tracing::warn!(
-                    nous_id = %nous_id,
-                    "prompt action skipped — no daemon bridge configured"
-                );
-                Ok(ExecutionResult {
-                    success: false,
-                    output: Some("no bridge configured".to_owned()),
-                })
-            }
-        }
         TaskAction::Builtin(builtin) => {
             execute_builtin(
                 builtin,
@@ -276,37 +251,6 @@ pub(crate) async fn execute_builtin(
                 messages = summary.messages_cleaned,
                 bytes_freed = summary.bytes_freed,
                 "maintenance: retention complete"
-            );
-            Ok(ExecutionResult {
-                success: true,
-                output: Some(format!(
-                    "{} sessions, {} messages cleaned, {} bytes freed",
-                    summary.sessions_cleaned, summary.messages_cleaned, summary.bytes_freed
-                )),
-            })
-        }
-        BuiltinTask::SessionRetention => {
-            let Some(executor) = retention_executor else {
-                tracing::warn!(
-                    nous_id = %nous_id,
-                    "session retention NOT_IMPLEMENTED: no retention executor configured"
-                );
-                return Ok(ExecutionResult {
-                    success: false,
-                    output: Some("NOT_IMPLEMENTED: no retention executor configured".to_owned()),
-                });
-            };
-            let summary = tokio::task::spawn_blocking(move || executor.execute_retention())
-                .await
-                .context(error::BlockingJoinSnafu {
-                    context: "session retention",
-                })??;
-            tracing::info!(
-                nous_id = %nous_id,
-                sessions = summary.sessions_cleaned,
-                messages = summary.messages_cleaned,
-                bytes_freed = summary.bytes_freed,
-                "maintenance: session retention complete"
             );
             Ok(ExecutionResult {
                 success: true,

--- a/crates/daemon/src/schedule.rs
+++ b/crates/daemon/src/schedule.rs
@@ -67,13 +67,6 @@ impl Default for TaskDef {
 pub enum TaskAction {
     /// Execute a shell command.
     Command(String),
-    /// Call a tool by name with JSON arguments.
-    Tool {
-        name: String,
-        args: serde_json::Value,
-    },
-    /// Send a prompt to the nous for processing.
-    Prompt(String),
     /// Run a built-in maintenance function.
     Builtin(BuiltinTask),
 }
@@ -83,8 +76,6 @@ pub enum TaskAction {
 pub enum BuiltinTask {
     /// Prosoche attention check.
     Prosoche,
-    /// Session retention policy enforcement.
-    SessionRetention,
     /// Rotate and compress old trace files.
     TraceRotation,
     /// Compare instance against template for configuration drift.

--- a/crates/diaporeia/src/server.rs
+++ b/crates/diaporeia/src/server.rs
@@ -75,7 +75,8 @@ impl rmcp::handler::server::ServerHandler for DiaporeiaServer {
         _params: Option<rmcp::model::PaginatedRequestParams>,
         _context: rmcp::service::RequestContext<rmcp::RoleServer>,
     ) -> Result<ListResourcesResult, rmcp::ErrorData> {
-        // Static resources (no dynamic listing in Phase 1).
+        // TODO(#1136): Enumerate nous and config resources dynamically when the
+        // v1.5 resource registry is implemented. Static resources use read_resource.
         Ok(ListResourcesResult {
             resources: vec![],
             next_cursor: None,

--- a/crates/diaporeia/src/tools/mod.rs
+++ b/crates/diaporeia/src/tools/mod.rs
@@ -268,6 +268,7 @@ impl DiaporeiaServer {
         &self,
         Parameters(_params): Parameters<params::KnowledgeSearchParams>,
     ) -> Result<CallToolResult, rmcp::ErrorData> {
+        // TODO(#1137): Wire to RecallEngine when knowledge store integration is complete.
         Ok(CallToolResult::success(vec![rmcp::model::Content::text(
             "Knowledge search is not available in this configuration. \
              The server must be built with the 'recall' feature enabled \

--- a/crates/hermeneus/src/anthropic/client.rs
+++ b/crates/hermeneus/src/anthropic/client.rs
@@ -17,7 +17,7 @@ use std::collections::HashMap;
 use crate::error::{self, Result};
 use crate::health::{HealthConfig, ProviderHealthTracker};
 use crate::provider::{LlmProvider, ModelPricing, ProviderConfig};
-use crate::types::{CompletionRequest, CompletionResponse, TokenCount};
+use crate::types::{CompletionRequest, CompletionResponse};
 use aletheia_koina::credential::{CredentialProvider, CredentialSource};
 
 use super::stream::{StreamAccumulator, StreamEvent, parse_sse_response};
@@ -394,49 +394,6 @@ impl AnthropicProvider {
         }))
     }
 
-    /// Count tokens for a request via the Anthropic `count_tokens` endpoint.
-    pub async fn count_tokens_request(&self, request: &CompletionRequest) -> Result<TokenCount> {
-        #[derive(serde::Deserialize)]
-        struct CountResponse {
-            input_tokens: u64,
-        }
-
-        let wire = WireRequest::from_request(request, None);
-        let body = serde_json::to_string(&wire).context(error::ParseResponseSnafu)?;
-        let headers = self.build_headers()?;
-
-        let response = self
-            .client
-            .post(format!("{}/v1/messages/count_tokens", self.base_url))
-            .headers(headers)
-            .body(body)
-            .send()
-            .await
-            .map_err(|e| {
-                error::ApiRequestSnafu {
-                    message: format!("count_tokens request failed: {e}"),
-                }
-                .build()
-            })?;
-
-        if !response.status().is_success() {
-            return Err(super::error::map_error_response(response).await);
-        }
-
-        let text = response.text().await.map_err(|e| {
-            error::ApiRequestSnafu {
-                message: format!("failed to read count_tokens response: {e}"),
-            }
-            .build()
-        })?;
-
-        let parsed: CountResponse =
-            serde_json::from_str(&text).context(error::ParseResponseSnafu)?;
-        Ok(TokenCount {
-            input_tokens: parsed.input_tokens,
-        })
-    }
-
     fn build_headers(&self) -> Result<HeaderMap> {
         let credential = self.credential_provider.get_credential().ok_or_else(|| {
             error::AuthFailedSnafu {
@@ -682,21 +639,6 @@ impl LlmProvider for AnthropicProvider {
         "anthropic"
     }
 
-    fn count_tokens<'a>(
-        &'a self,
-        request: &'a CompletionRequest,
-    ) -> Pin<Box<dyn Future<Output = Result<Option<TokenCount>>> + Send + 'a>> {
-        Box::pin(async move { self.count_tokens_request(request).await.map(Some) })
-    }
-
-    fn supports_caching(&self) -> bool {
-        true
-    }
-
-    fn supports_citations(&self) -> bool {
-        true
-    }
-
     fn supports_streaming(&self) -> bool {
         true
     }
@@ -707,10 +649,6 @@ impl LlmProvider for AnthropicProvider {
         on_event: &'a mut (dyn FnMut(StreamEvent) + Send),
     ) -> Pin<Box<dyn Future<Output = Result<CompletionResponse>> + Send + 'a>> {
         Box::pin(self.complete_streaming_inner(request, on_event))
-    }
-
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
     }
 }
 

--- a/crates/hermeneus/src/provider.rs
+++ b/crates/hermeneus/src/provider.rs
@@ -3,7 +3,6 @@
 //! Defines the interface all providers must implement. Types are modeled
 //! on the Anthropic Messages API; other providers adapt to this surface.
 
-use std::any::Any;
 use std::collections::HashMap;
 use std::future::Future;
 use std::pin::Pin;
@@ -11,7 +10,7 @@ use std::pin::Pin;
 use crate::anthropic::StreamEvent;
 use crate::error::{self, Result};
 use crate::health::{HealthConfig, ProviderHealth, ProviderHealthTracker};
-use crate::types::{CompletionRequest, CompletionResponse, TokenCount};
+use crate::types::{CompletionRequest, CompletionResponse};
 
 /// Trait for LLM providers.
 ///
@@ -43,33 +42,6 @@ pub trait LlmProvider: Send + Sync {
     /// Provider name for logging and diagnostics.
     fn name(&self) -> &str;
 
-    /// Estimate input tokens for a request (without calling the API).
-    ///
-    /// Default implementation returns `None` (unknown). Providers that
-    /// support local tokenization should override this.
-    fn estimate_tokens(&self, _text: &str) -> Option<u64> {
-        None
-    }
-
-    /// Count tokens for a request via the provider's API.
-    /// Returns None if the provider doesn't support server-side counting.
-    fn count_tokens<'a>(
-        &'a self,
-        _request: &'a CompletionRequest,
-    ) -> Pin<Box<dyn Future<Output = Result<Option<TokenCount>>> + Send + 'a>> {
-        Box::pin(async { Ok(None) })
-    }
-
-    /// Whether this provider supports prompt caching.
-    fn supports_caching(&self) -> bool {
-        false
-    }
-
-    /// Whether this provider supports citation tracking.
-    fn supports_citations(&self) -> bool {
-        false
-    }
-
     /// Whether this provider supports streaming completions.
     fn supports_streaming(&self) -> bool {
         false
@@ -90,9 +62,6 @@ pub trait LlmProvider: Send + Sync {
     ) -> Pin<Box<dyn Future<Output = Result<CompletionResponse>> + Send + 'a>> {
         self.complete(request)
     }
-
-    /// Downcast to concrete type for provider-specific features.
-    fn as_any(&self) -> &dyn Any;
 }
 
 /// Per-model pricing rates for cost estimation.
@@ -277,10 +246,6 @@ mod tests {
         )]
         fn name(&self) -> &str {
             "mock"
-        }
-
-        fn as_any(&self) -> &dyn Any {
-            self
         }
     }
 

--- a/crates/hermeneus/src/types.rs
+++ b/crates/hermeneus/src/types.rs
@@ -385,12 +385,6 @@ pub enum Citation {
     },
 }
 
-/// Token count result from the `count_tokens` endpoint.
-#[derive(Debug, Clone)]
-pub struct TokenCount {
-    pub input_tokens: u64,
-}
-
 /// Request to the LLM provider.
 #[derive(Debug, Clone)]
 pub struct CompletionRequest {

--- a/crates/integration-tests/tests/cross_crate_pipeline.rs
+++ b/crates/integration-tests/tests/cross_crate_pipeline.rs
@@ -84,10 +84,6 @@ impl LlmProvider for MockProvider {
     fn name(&self) -> &str {
         "mock"
     }
-
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
 }
 
 /// Captures all LLM requests for inspection.
@@ -149,10 +145,6 @@ impl LlmProvider for CapturingMockProvider {
     #[expect(clippy::unnecessary_literal_bound, reason = "trait requires &str")]
     fn name(&self) -> &str {
         "mock-capturing"
-    }
-
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
     }
 }
 
@@ -216,10 +208,6 @@ impl LlmProvider for SequentialMockProvider {
     fn name(&self) -> &str {
         "mock-sequential"
     }
-
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
 }
 
 /// Returns an error from the LLM.
@@ -251,10 +239,6 @@ impl LlmProvider for ErrorProvider {
     #[expect(clippy::unnecessary_literal_bound, reason = "trait requires &str")]
     fn name(&self) -> &str {
         "mock-error"
-    }
-
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
     }
 }
 

--- a/crates/integration-tests/tests/domain_packs.rs
+++ b/crates/integration-tests/tests/domain_packs.rs
@@ -79,10 +79,6 @@ impl LlmProvider for CapturingMockProvider {
     fn name(&self) -> &str {
         "mock-capturing"
     }
-
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
 }
 
 fn setup_oikos(dir: &Path, agent_id: &str) -> Arc<Oikos> {

--- a/crates/integration-tests/tests/end_to_end.rs
+++ b/crates/integration-tests/tests/end_to_end.rs
@@ -74,10 +74,6 @@ impl LlmProvider for MockProvider {
     fn name(&self) -> &str {
         "mock"
     }
-
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
 }
 
 struct CapturingMockProvider {
@@ -138,10 +134,6 @@ impl LlmProvider for CapturingMockProvider {
     #[expect(clippy::unnecessary_literal_bound, reason = "trait requires &str")]
     fn name(&self) -> &str {
         "mock-capturing"
-    }
-
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
     }
 }
 

--- a/crates/integration-tests/tests/eval_harness.rs
+++ b/crates/integration-tests/tests/eval_harness.rs
@@ -75,10 +75,6 @@ impl LlmProvider for MockProvider {
     fn name(&self) -> &str {
         "mock"
     }
-
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
 }
 
 async fn start_test_server() -> (String, String, tempfile::TempDir) {

--- a/crates/melete/src/distill_tests.rs
+++ b/crates/melete/src/distill_tests.rs
@@ -104,10 +104,6 @@ impl LlmProvider for MockProvider {
     fn name(&self) -> &str {
         "mock-distill"
     }
-
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
 }
 
 fn text_msg(role: Role, text: &str) -> Message {

--- a/crates/melete/src/roundtrip_tests.rs
+++ b/crates/melete/src/roundtrip_tests.rs
@@ -71,10 +71,6 @@ impl LlmProvider for MockProvider {
     fn name(&self) -> &str {
         "mock-roundtrip"
     }
-
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
 }
 
 // ═══════════════════════════════════════════════════════════════════════

--- a/crates/nous/src/actor/tests.rs
+++ b/crates/nous/src/actor/tests.rs
@@ -47,10 +47,6 @@ impl LlmProvider for MockProvider {
     fn name(&self) -> &str {
         "mock"
     }
-
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
 }
 
 fn test_config() -> NousConfig {
@@ -375,10 +371,6 @@ impl LlmProvider for PanickingProvider {
     #[expect(clippy::unnecessary_literal_bound, reason = "trait requires &str")]
     fn name(&self) -> &str {
         "panicking-mock"
-    }
-
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
     }
 }
 

--- a/crates/nous/src/execute/tests.rs
+++ b/crates/nous/src/execute/tests.rs
@@ -73,10 +73,6 @@ impl aletheia_hermeneus::provider::LlmProvider for MockProvider {
     fn name(&self) -> &str {
         "mock"
     }
-
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
 }
 
 struct EchoExecutor;

--- a/crates/nous/src/manager_tests.rs
+++ b/crates/nous/src/manager_tests.rs
@@ -42,10 +42,6 @@ impl LlmProvider for MockProvider {
     fn name(&self) -> &str {
         "mock"
     }
-
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
 }
 
 fn test_oikos() -> (tempfile::TempDir, Arc<Oikos>) {

--- a/crates/nous/src/pipeline_tests.rs
+++ b/crates/nous/src/pipeline_tests.rs
@@ -299,10 +299,6 @@ async fn run_pipeline_simple() {
         fn name(&self) -> &str {
             "mock"
         }
-
-        fn as_any(&self) -> &dyn std::any::Any {
-            self
-        }
     }
 
     let dir = TempDir::new().unwrap();

--- a/crates/nous/src/spawn_svc.rs
+++ b/crates/nous/src/spawn_svc.rs
@@ -230,10 +230,6 @@ mod tests {
         fn name(&self) -> &str {
             "mock"
         }
-
-        fn as_any(&self) -> &dyn std::any::Any {
-            self
-        }
     }
 
     fn test_oikos() -> (tempfile::TempDir, Arc<Oikos>) {
@@ -368,10 +364,6 @@ mod tests {
         #[expect(clippy::unnecessary_literal_bound, reason = "trait requires &str")]
         fn name(&self) -> &str {
             "slow"
-        }
-
-        fn as_any(&self) -> &dyn std::any::Any {
-            self
         }
     }
 

--- a/crates/pylon/src/tests.rs
+++ b/crates/pylon/src/tests.rs
@@ -84,10 +84,6 @@ impl LlmProvider for MockProvider {
     fn name(&self) -> &str {
         "mock"
     }
-
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
 }
 
 // --- JWT Test Helpers ---


### PR DESCRIPTION
Closes #1132, #1133, #1134, #1136, #1137

## Changes

- **#1132 `TaskAction::Tool`**: Removed the `Tool` variant from `TaskAction` — never constructed at any call site.
- **#1133 `BuiltinTask::SessionRetention`**: Removed this enum variant and its match arm — never registered as a task; `RetentionExecution` covers retention. `RetentionExecutor` trait and `RetentionSummary` preserved.
- **#1134 `LlmProvider` dead methods**: Removed five trait methods with zero call sites: `estimate_tokens`, `count_tokens`, `supports_caching`, `supports_citations`, `as_any`. Also removed the only-reachable-through-trait `count_tokens_request` and `TokenCount`. Removed the now-orphaned `fn as_any` from all mock implementations across `nous`, `melete`, `pylon`, and integration-test crates.
- **#1136 `list_resources`**: Replaced freeform comment with `TODO(#1136)` documenting the v1.5 resource registry stub.
- **#1137 Three additional stubs**: (1) `TaskAction::Prompt` removed — never constructed; (2) `taxis::RetentionConfig {}` verified already documented with `TODO(#1129)`; (3) `diaporeia::knowledge_search` annotated with `TODO(#1137)`.

## Observations

- Removing `as_any` from `LlmProvider` expanded the blast radius to 12 test files across `nous`, `melete`, `pylon`, and `integration-tests`. All had mock impls that implemented `fn as_any` only because the trait required it.
- `TaskAction::Prompt` was dead in the same way as `Tool` — matched in execution.rs but never constructed. Removed alongside Tool as part of #1137.
- `knowledge_maintenance.rs` has 5 `NOT_IMPLEMENTED` methods on `KnowledgeMaintenanceExecutor`; these are called through the trait interface and are not dead code. Documented in observations file.