### PR TITLE
chore(pylon,organon,hermeneus,daemon): standards compliance sweep

### DIFF
--- a/crates/daemon/src/maintenance/db_monitor.rs
+++ b/crates/daemon/src/maintenance/db_monitor.rs
@@ -57,6 +57,7 @@ pub struct DbInfo {
 }
 
 /// Health status of a database based on size thresholds.
+#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum DbStatus {
     /// Size is within normal bounds.

--- a/crates/daemon/src/maintenance/drift_detection.rs
+++ b/crates/daemon/src/maintenance/drift_detection.rs
@@ -77,7 +77,6 @@ impl DriftDetector {
             ..Default::default()
         };
 
-        // Walk example root and check each entry against instance.
         self.walk_example(&self.config.example_root, &mut report)?;
 
         Ok(report)
@@ -125,24 +124,19 @@ impl DriftDetector {
 
         for pattern in &self.config.ignore_patterns {
             if pattern.ends_with('/') {
-                // Directory prefix match.
                 let prefix = &pattern[..pattern.len() - 1];
                 if path_str.starts_with(prefix) || path_str == *prefix {
                     return true;
                 }
             } else if pattern.starts_with("*.") {
-                // Extension match.
-                let ext = &pattern[1..]; // e.g., ".db"
+                let ext = &pattern[1..];
                 if path_str.ends_with(ext) {
                     return true;
                 }
-            } else {
-                // Exact match on filename component.
-                if let Some(name) = relative.file_name().and_then(|n| n.to_str())
-                    && name == pattern
-                {
-                    return true;
-                }
+            } else if let Some(name) = relative.file_name().and_then(|n| n.to_str())
+                && name == pattern
+            {
+                return true;
             }
         }
 
@@ -176,11 +170,9 @@ mod tests {
         let tmp = tempfile::tempdir().expect("tempdir");
         let config = make_config(tmp.path());
 
-        // Create example structure.
         fs::create_dir_all(config.example_root.join("config")).unwrap();
         fs::write(config.example_root.join("config/aletheia.toml"), "").unwrap();
 
-        // Instance has the dir but not the file.
         fs::create_dir_all(config.instance_root.join("config")).unwrap();
 
         let detector = DriftDetector::new(config);
@@ -199,11 +191,9 @@ mod tests {
         let tmp = tempfile::tempdir().expect("tempdir");
         let config = make_config(tmp.path());
 
-        // Example has a nous/ dir.
         fs::create_dir_all(config.example_root.join("nous")).unwrap();
         fs::write(config.example_root.join("nous/SOUL.md"), "").unwrap();
 
-        // Instance has nothing.
         fs::create_dir_all(&config.instance_root).unwrap();
 
         let detector = DriftDetector::new(config);
@@ -222,7 +212,6 @@ mod tests {
         let tmp = tempfile::tempdir().expect("tempdir");
         let config = make_config(tmp.path());
 
-        // Example has data/ and signal/ dirs, plus a .db file.
         fs::create_dir_all(config.example_root.join("data")).unwrap();
         fs::write(config.example_root.join("data/sessions.db"), "").unwrap();
         fs::create_dir_all(config.example_root.join("signal")).unwrap();
@@ -230,13 +219,11 @@ mod tests {
         fs::create_dir_all(config.example_root.join("logs")).unwrap();
         fs::write(config.example_root.join("logs/.gitkeep"), "").unwrap();
 
-        // Instance has nothing.
         fs::create_dir_all(&config.instance_root).unwrap();
 
         let detector = DriftDetector::new(config);
         let report = detector.check().expect("check succeeds");
 
-        // None of the ignored items should appear.
         for path in &report.missing_files {
             let path_str = path.to_string_lossy();
             assert!(
@@ -277,7 +264,6 @@ mod tests {
         let tmp = tempfile::tempdir().expect("tempdir");
         let config = make_config(tmp.path());
 
-        // Create identical structures.
         fs::create_dir_all(config.example_root.join("config")).unwrap();
         fs::write(config.example_root.join("config/aletheia.toml"), "").unwrap();
         fs::create_dir_all(config.instance_root.join("config")).unwrap();
@@ -310,7 +296,6 @@ mod tests {
         let tmp = tempfile::tempdir().expect("tempdir");
         let config = make_config(tmp.path());
 
-        // Both directories exist but are empty.
         fs::create_dir_all(&config.example_root).unwrap();
         fs::create_dir_all(&config.instance_root).unwrap();
 
@@ -325,7 +310,6 @@ mod tests {
         let tmp = tempfile::tempdir().expect("tempdir");
         let config = make_config(tmp.path());
 
-        // Create a deeply nested structure in the example.
         fs::create_dir_all(config.example_root.join("level1/level2/level3")).unwrap();
         fs::write(
             config.example_root.join("level1/level2/level3/deep.yaml"),
@@ -333,7 +317,6 @@ mod tests {
         )
         .unwrap();
 
-        // Instance has nothing.
         fs::create_dir_all(&config.instance_root).unwrap();
 
         let detector = DriftDetector::new(config);

--- a/crates/daemon/src/maintenance/trace_rotation.rs
+++ b/crates/daemon/src/maintenance/trace_rotation.rs
@@ -85,10 +85,8 @@ impl TraceRotator {
 
         let mut entries = self.list_trace_files()?;
 
-        // Sort by modification time ascending (oldest first).
         entries.sort_by_key(|e| e.modified);
 
-        // Calculate total size.
         let total_size_bytes: u64 = entries.iter().map(|e| e.size).sum();
         let max_bytes = self.config.max_total_size_mb * 1024 * 1024;
 
@@ -109,7 +107,6 @@ impl TraceRotator {
             }
         }
 
-        // Rotate eligible files.
         for entry in &to_rotate {
             let dest = self
                 .config
@@ -139,7 +136,6 @@ impl TraceRotator {
             report.bytes_freed += entry.size;
         }
 
-        // Prune old archives beyond max_archives.
         report.files_pruned = self.prune_archives()?;
 
         Ok(report)
@@ -157,7 +153,6 @@ impl TraceRotator {
             })?;
             let path = entry.path();
 
-            // Skip directories (including archive/).
             if path.is_dir() {
                 continue;
             }
@@ -244,7 +239,6 @@ impl TraceRotator {
             archives.push((path, modified, metadata.len()));
         }
 
-        // Sort oldest first.
         archives.sort_by_key(|(_, modified, _)| *modified);
 
         let mut pruned = 0u32;
@@ -302,8 +296,6 @@ mod tests {
         let report = rotator.rotate().expect("rotation succeeds");
 
         assert_eq!(report.files_rotated, 1);
-        // Rename-and-reopen: original path gets a fresh empty file so active
-        // writers can continue without stalling.
         assert!(
             file.exists(),
             "replacement file should exist at original path"
@@ -345,7 +337,6 @@ mod tests {
         let config = make_config(tmp.path());
         fs::create_dir_all(&config.archive_dir).unwrap();
 
-        // Create 5 archives, max is 3.
         for i in 0..5 {
             fs::write(config.archive_dir.join(format!("archive-{i}.log")), "data").unwrap();
         }
@@ -375,11 +366,9 @@ mod tests {
         let report = rotator.rotate().expect("rotation succeeds");
 
         assert_eq!(report.files_rotated, 1);
-        // Original should be gone, .gz should exist.
         assert!(!config.archive_dir.join("trace.log").exists());
         assert!(config.archive_dir.join("trace.log.gz").exists());
 
-        // Verify decompression.
         let compressed = fs::read(config.archive_dir.join("trace.log.gz")).unwrap();
         let mut decoder = flate2::read::GzDecoder::new(&compressed[..]);
         let mut decompressed = String::new();
@@ -428,7 +417,6 @@ mod tests {
         config.max_age_days = 9999;
         config.max_total_size_mb = 9999;
         fs::create_dir_all(&config.trace_dir).unwrap();
-        // Empty trace dir — nothing to rotate.
 
         let rotator = TraceRotator::new(config);
         let report = rotator.rotate().expect("rotation succeeds");
@@ -453,8 +441,6 @@ mod tests {
 
         assert_eq!(report.files_rotated, 3);
         assert!(report.bytes_freed > 0);
-
-        // All should be in archive.
         assert!(config.archive_dir.join("trace-1.log").exists());
         assert!(config.archive_dir.join("trace-2.log").exists());
         assert!(config.archive_dir.join("trace-3.log").exists());

--- a/crates/daemon/src/prosoche.rs
+++ b/crates/daemon/src/prosoche.rs
@@ -36,6 +36,7 @@ pub struct AttentionItem {
 }
 
 /// Categories of attention items.
+#[non_exhaustive]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum AttentionCategory {
     /// Calendar event or deadline.
@@ -49,6 +50,7 @@ pub enum AttentionCategory {
 }
 
 /// Urgency level for attention items.
+#[non_exhaustive]
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Urgency {
     /// Informational, no action needed soon.
@@ -106,15 +108,12 @@ impl ProsocheCheck {
     pub async fn run(&self) -> crate::error::Result<ProsocheResult> {
         let mut items = Vec::new();
 
-        // Disk space check.
         if let Some(ref data_dir) = self.data_dir {
             items.extend(check_disk_space(data_dir).await);
         }
 
-        // Database size check.
         items.extend(check_db_sizes(&self.db_paths));
 
-        // Memory check.
         items.extend(check_memory());
 
         tracing::info!(
@@ -190,9 +189,7 @@ async fn disk_usage_percent(path: &Path) -> std::io::Result<f64> {
 
 /// Parse the percentage from `df --output=pcent` output.
 fn parse_df_percent(output: &str) -> std::io::Result<f64> {
-    // Output format:
-    // Use%
-    //  42%
+    // NOTE: df --output=pcent output has a header line then lines like " 42%".
     for line in output.lines().skip(1) {
         let trimmed = line.trim().trim_end_matches('%');
         if let Ok(val) = trimmed.parse::<f64>() {
@@ -255,7 +252,6 @@ fn check_memory() -> Vec<AttentionItem> {
             let rss_mb = resident_kb / 1024;
             let mut items = Vec::new();
 
-            // Warn at 1 GB RSS, critical at 2 GB.
             if rss_mb >= 2048 {
                 items.push(AttentionItem {
                     category: AttentionCategory::SystemHealth,
@@ -310,7 +306,6 @@ mod tests {
     async fn prosoche_returns_items_for_default() {
         let check = ProsocheCheck::new("test-nous");
         let result = check.run().await.expect("should succeed");
-        // Without data_dir or db_paths, only memory check runs.
         assert!(!result.checked_at.is_empty());
     }
 

--- a/crates/daemon/src/runner.rs
+++ b/crates/daemon/src/runner.rs
@@ -331,10 +331,8 @@ impl TaskRunner {
     pub async fn run(&mut self) {
         tracing::info!(nous_id = %self.nous_id, tasks = self.tasks.len(), "daemon started");
 
-        // Restore persisted state before checking for missed windows.
         self.restore_state();
 
-        // Check for missed cron windows on startup.
         self.check_missed_cron_catchup();
 
         let mut interval = tokio::time::interval(Duration::from_secs(1));
@@ -385,7 +383,6 @@ impl TaskRunner {
 
             let elapsed = in_flight.started_at.elapsed();
 
-            // Check for 2x timeout — cancel the task.
             if elapsed > in_flight.timeout * 2 {
                 tracing::warn!(
                     task_id = %task_id,
@@ -400,7 +397,6 @@ impl TaskRunner {
                 continue;
             }
 
-            // Check for 1x timeout — warn.
             if elapsed > in_flight.timeout && !in_flight.warned {
                 tracing::warn!(
                     task_id = %task_id,
@@ -411,7 +407,6 @@ impl TaskRunner {
                 in_flight.warned = true;
             }
 
-            // Check if the task completed.
             if in_flight.handle.is_finished() {
                 let in_flight = self.in_flight.remove(&task_id).expect("just checked");
                 let duration = in_flight.started_at.elapsed();
@@ -485,7 +480,7 @@ impl TaskRunner {
         task.consecutive_failures += 1;
         task.last_run = Some(jiff::Timestamp::now());
 
-        // GraphHealthCheck failures don't count toward auto-disable.
+        // WHY: GraphHealthCheck is a diagnostic — failures don't count toward auto-disable.
         let exempt = matches!(
             task.def.action,
             TaskAction::Builtin(BuiltinTask::GraphHealthCheck)
@@ -501,11 +496,9 @@ impl TaskRunner {
                 "task auto-disabled after 3 consecutive failures"
             );
         } else {
-            // Apply exponential backoff.
             let delay = backoff_delay(task.consecutive_failures);
             task.backoff_until = Some(Instant::now() + delay);
 
-            // Next run is the later of the schedule's next_run and the backoff.
             let scheduled_next = task.def.schedule.next_run().unwrap_or(None);
             let backoff_ts = jiff::Timestamp::now()
                 .checked_add(jiff::SignedDuration::from_nanos(
@@ -610,7 +603,7 @@ impl TaskRunner {
                 continue;
             }
 
-            // Backpressure: skip if previous execution is still in progress.
+            // WHY: skip tasks still in-flight to prevent overlapping executions.
             if self.in_flight.contains_key(&self.tasks[i].def.id) {
                 tracing::debug!(
                     task_id = %self.tasks[i].def.id,
@@ -619,7 +612,6 @@ impl TaskRunner {
                 continue;
             }
 
-            // Check backoff.
             if let Some(backoff_until) = self.tasks[i].backoff_until
                 && now_instant < backoff_until
             {
@@ -636,7 +628,6 @@ impl TaskRunner {
             let task_id = self.tasks[i].def.id.clone();
             let timeout = self.tasks[i].def.timeout;
 
-            // Clone Arc handles for the spawned task.
             let bridge = self.bridge.clone();
             let maintenance = self.maintenance.clone();
             let retention_executor = self.retention_executor.clone();

--- a/crates/daemon/src/runner_tests.rs
+++ b/crates/daemon/src/runner_tests.rs
@@ -388,8 +388,6 @@ async fn independent_child_tokens_isolated() {
     let _ = tokio::time::timeout(Duration::from_secs(2), handle_b).await;
 }
 
-// --- Exponential backoff tests ---
-
 #[test]
 fn backoff_applied_on_failure() {
     let token = CancellationToken::new();
@@ -432,8 +430,6 @@ fn backoff_cleared_on_success() {
     assert!(runner.tasks[0].backoff_until.is_none());
     assert_eq!(runner.tasks[0].consecutive_failures, 0);
 }
-
-// --- Hung task detection tests ---
 
 #[tokio::test]
 async fn hung_task_cancelled_after_2x_timeout() {
@@ -478,8 +474,6 @@ async fn hung_task_cancelled_after_2x_timeout() {
     assert!(!runner.in_flight.contains_key("hung-task"));
     assert_eq!(runner.tasks[0].consecutive_failures, 1);
 }
-
-// --- Missed cron catch-up tests ---
 
 #[test]
 fn missed_cron_catchup_fires_on_startup() {
@@ -552,8 +546,6 @@ fn missed_cron_catchup_skips_disabled_catch_up() {
 
     assert_eq!(runner.tasks[0].next_run.unwrap(), future_run);
 }
-
-// --- Task metrics tests ---
 
 #[test]
 fn task_metrics_on_success() {

--- a/crates/daemon/src/schedule.rs
+++ b/crates/daemon/src/schedule.rs
@@ -9,6 +9,7 @@ use snafu::ResultExt;
 use crate::error::{self, Result};
 
 /// When a task should run.
+#[non_exhaustive]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum Schedule {
     /// Cron expression (e.g., `"0 */45 8-23 * * *"` for every 45min 8am-11pm).
@@ -63,6 +64,7 @@ impl Default for TaskDef {
 }
 
 /// What a background task does.
+#[non_exhaustive]
 #[derive(Debug, Clone)]
 pub enum TaskAction {
     /// Execute a shell command.
@@ -79,6 +81,7 @@ pub enum TaskAction {
 }
 
 /// Built-in maintenance tasks.
+#[non_exhaustive]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum BuiltinTask {
     /// Prosoche attention check.
@@ -125,7 +128,7 @@ impl Schedule {
                 let schedule = cron::Schedule::from_str(expr).context(error::InvalidCronSnafu {
                     expression: expr.clone(),
                 })?;
-                // chrono::Utc is required by the `cron` crate iterator API.
+                // WHY: chrono::Utc is required by the cron crate's iterator API.
                 let next = schedule.upcoming(chrono::Utc).next();
                 Ok(next.map(|dt| {
                     jiff::Timestamp::from_second(dt.timestamp())
@@ -170,7 +173,6 @@ impl Schedule {
             .checked_sub(jiff::SignedDuration::from_hours(24))
             .expect("24h subtraction overflow");
 
-        // Don't catch up windows older than 24 hours.
         if last_run < twenty_four_hours_ago {
             return Ok(false);
         }
@@ -179,16 +181,14 @@ impl Schedule {
             expression: expr.clone(),
         })?;
 
-        // chrono::DateTime is required by the `cron` crate's `.after()` API.
+        // WHY: chrono::DateTime is required by the cron crate's after() API.
         let last_run_dt = chrono::DateTime::from_timestamp(last_run.as_second(), 0)
             .expect("jiff timestamp within valid range");
 
-        // Check if there's any scheduled run between last_run and now.
         let next_after_last = schedule.after(&last_run_dt).next();
         if let Some(next) = next_after_last {
             let next_ts = jiff::Timestamp::from_second(next.timestamp())
                 .expect("cron timestamp within valid jiff range");
-            // If the next scheduled run after last_run is before now, we missed it.
             Ok(next_ts < now)
         } else {
             Ok(false)
@@ -211,10 +211,8 @@ impl Schedule {
         let hour = u8::try_from(now.hour()).expect("hour in u8 range");
 
         if start <= end {
-            // Normal window: e.g., 9-17
             hour >= start && hour < end
         } else {
-            // Overnight window: e.g., 22-06
             hour >= start || hour < end
         }
     }
@@ -320,7 +318,6 @@ mod tests {
 
     #[test]
     fn in_window_full_day() {
-        // 0-24 should always be active (every hour is >= 0 and < 24)
         assert!(Schedule::in_window(Some((0, 24))));
     }
 

--- a/crates/daemon/src/state.rs
+++ b/crates/daemon/src/state.rs
@@ -212,7 +212,6 @@ mod tests {
                 .unwrap();
         }
 
-        // Re-open: state should survive.
         let store2 = TaskStateStore::open(&db_path).unwrap();
         let loaded = store2.load_all().unwrap();
         assert_eq!(loaded.len(), 1);

--- a/crates/hermeneus/src/anthropic/client.rs
+++ b/crates/hermeneus/src/anthropic/client.rs
@@ -213,7 +213,6 @@ impl AnthropicProvider {
 
             let headers = self.build_headers()?;
 
-            // HTTP-level errors (connection, non-200 status)
             let mut response = match self
                 .client
                 .post(format!("{}/v1/messages", self.base_url))
@@ -257,7 +256,6 @@ impl AnthropicProvider {
                 continue;
             }
 
-            // Parse SSE events incrementally as bytes arrive from the response stream.
             let mut accumulator = StreamAccumulator::new();
             let mut content_started = false;
 
@@ -615,7 +613,6 @@ impl AnthropicProvider {
             let err = super::error::map_error_response(response).await;
             self.health.record_error(&err);
 
-            // Non-retryable: 401, 400-level (except 429).
             if status == 401 || ((400..500).contains(&status) && status != 429) {
                 #[expect(
                     clippy::cast_possible_truncation,
@@ -636,7 +633,6 @@ impl AnthropicProvider {
                 return Err(err);
             }
 
-            // Retryable: 429, 5xx, network errors.
             last_error = Some(err);
         }
 

--- a/crates/hermeneus/src/anthropic/client_tests.rs
+++ b/crates/hermeneus/src/anthropic/client_tests.rs
@@ -49,8 +49,6 @@ fn valid_wire_response_json() -> serde_json::Value {
     })
 }
 
-// --- from_config tests ---
-
 #[test]
 fn from_config_missing_api_key() {
     let config = ProviderConfig {
@@ -91,8 +89,6 @@ fn from_config_valid() {
         "debug should show base_url: {debug}"
     );
 }
-
-// --- wiremock integration tests ---
 
 #[tokio::test]
 async fn complete_success() {
@@ -239,8 +235,6 @@ async fn complete_malformed_body() {
     );
 }
 
-// --- estimate_cost unit tests ---
-
 #[test]
 #[allow(clippy::float_cmp, reason = "exact zero comparison in pricing test")]
 fn estimate_cost_no_pricing_returns_zero() {
@@ -295,8 +289,6 @@ fn estimate_cost_config_overrides_default() {
     // (1000 * 20.0 + 100 * 100.0) / 1_000_000 = 30000 / 1_000_000 = 0.03
     assert!((cost - 0.03).abs() < 0.0001);
 }
-
-// --- backoff_delay unit tests ---
 
 #[test]
 fn backoff_delay_respects_retry_after() {

--- a/crates/hermeneus/src/anthropic/stream.rs
+++ b/crates/hermeneus/src/anthropic/stream.rs
@@ -743,7 +743,6 @@ data: {\"type\":\"message_stop\"}\n\
 
         let (events, response) = collect_events(sse);
 
-        // Verify block_type events emitted correctly
         let block_starts: Vec<&str> = events
             .iter()
             .filter_map(|e| match e {
@@ -756,7 +755,6 @@ data: {\"type\":\"message_stop\"}\n\
             vec!["server_tool_use", "web_search_tool_result", "text"]
         );
 
-        // Verify content blocks in response
         assert_eq!(response.content.len(), 3);
         match &response.content[0] {
             ContentBlock::ServerToolUse { id, name, input } => {

--- a/crates/hermeneus/src/anthropic/wire/request.rs
+++ b/crates/hermeneus/src/anthropic/wire/request.rs
@@ -4,10 +4,6 @@ use crate::types::{CacheControl, CompletionRequest, Content, Role, ThinkingConfi
 
 use super::{compute_turn_cache_indices, content_with_cache_control};
 
-// ---------------------------------------------------------------------------
-// Request
-// ---------------------------------------------------------------------------
-
 #[derive(Debug, Serialize)]
 pub(crate) struct WireRequest<'a> {
     pub model: &'a str,
@@ -94,10 +90,6 @@ pub(crate) struct WireThinkingConfig {
     pub config_type: &'static str,
     pub budget_tokens: u32,
 }
-
-// ---------------------------------------------------------------------------
-// Conversions
-// ---------------------------------------------------------------------------
 
 impl<'a> WireRequest<'a> {
     #[expect(

--- a/crates/hermeneus/src/anthropic/wire/response.rs
+++ b/crates/hermeneus/src/anthropic/wire/response.rs
@@ -4,10 +4,6 @@ use crate::types::{CompletionResponse, ContentBlock, Usage};
 
 use super::parse_stop_reason;
 
-// ---------------------------------------------------------------------------
-// Response
-// ---------------------------------------------------------------------------
-
 #[derive(Debug, Deserialize)]
 pub(crate) struct WireResponse {
     pub id: String,
@@ -68,10 +64,6 @@ pub(crate) enum WireContentBlock {
     },
 }
 
-// ---------------------------------------------------------------------------
-// Error response
-// ---------------------------------------------------------------------------
-
 #[derive(Debug, Deserialize)]
 pub(crate) struct WireErrorResponse {
     pub error: WireErrorDetail,
@@ -83,10 +75,6 @@ pub(crate) struct WireErrorDetail {
     pub error_type: String,
     pub message: String,
 }
-
-// ---------------------------------------------------------------------------
-// Conversions
-// ---------------------------------------------------------------------------
 
 impl WireResponse {
     pub(crate) fn into_response(self) -> Result<CompletionResponse, String> {

--- a/crates/hermeneus/src/anthropic/wire/stream.rs
+++ b/crates/hermeneus/src/anthropic/wire/stream.rs
@@ -2,10 +2,6 @@ use serde::Deserialize;
 
 use super::response::{WireErrorDetail, WireUsage};
 
-// ---------------------------------------------------------------------------
-// Streaming wire types
-// ---------------------------------------------------------------------------
-
 #[derive(Debug, Deserialize)]
 #[serde(tag = "type")]
 pub(crate) enum WireStreamEvent {

--- a/crates/hermeneus/src/anthropic/wire/tests_extended.rs
+++ b/crates/hermeneus/src/anthropic/wire/tests_extended.rs
@@ -108,10 +108,6 @@ fn wire_request_no_cache_system_is_string() {
     assert_eq!(json["system"], "test");
 }
 
-// -----------------------------------------------------------------------
-// Turn-level cache_control tests
-// -----------------------------------------------------------------------
-
 #[test]
 fn cache_turns_marks_text_content_as_blocks() {
     let req = CompletionRequest {

--- a/crates/hermeneus/src/types.rs
+++ b/crates/hermeneus/src/types.rs
@@ -157,6 +157,7 @@ pub enum ContentBlock {
 /// Tool result content — simple text or rich content blocks.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
+#[non_exhaustive]
 pub enum ToolResultContent {
     /// Simple text result (most common case, backward compatible).
     Text(String),
@@ -292,6 +293,7 @@ pub struct CacheControl {
 }
 
 /// The type of cache control.
+#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum CacheControlType {
     #[serde(rename = "ephemeral")]
@@ -310,6 +312,7 @@ impl CacheControl {
 /// Caching strategy for prompt caching.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
+#[non_exhaustive]
 pub enum CachingStrategy {
     #[default]
     Auto,
@@ -336,6 +339,7 @@ impl Default for CachingConfig {
 /// Control tool use behavior.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type")]
+#[non_exhaustive]
 pub enum ToolChoice {
     #[serde(rename = "auto")]
     Auto,

--- a/crates/hermeneus/src/types_tests.rs
+++ b/crates/hermeneus/src/types_tests.rs
@@ -513,7 +513,6 @@ fn code_execution_server_tool_definition_serde() {
     assert_eq!(back.name, "code_execution");
 }
 
-// --- Proptest serde roundtrip tests ---
 //
 // Per project standards (standards/STANDARDS.md): every type that implements
 // Serialize + Deserialize gets a roundtrip property test.

--- a/crates/organon/src/builtins/filesystem.rs
+++ b/crates/organon/src/builtins/filesystem.rs
@@ -53,7 +53,6 @@ fn run_command(cmd: &mut Command) -> std::io::Result<std::process::Output> {
         let _ = pipe.read_to_string(&mut stderr);
     }
 
-    // Detach the guard (no kill needed) and reap the process.
     let status = guard.detach().wait()?;
     Ok(std::process::Output {
         status,
@@ -61,10 +60,6 @@ fn run_command(cmd: &mut Command) -> std::io::Result<std::process::Output> {
         stderr: stderr.into_bytes(),
     })
 }
-
-// ---------------------------------------------------------------------------
-// Grep
-// ---------------------------------------------------------------------------
 
 struct GrepExecutor;
 
@@ -158,10 +153,6 @@ fn try_grep_fallback(
     cmd.arg(pattern).arg(path);
     run_command(&mut cmd)
 }
-
-// ---------------------------------------------------------------------------
-// Find
-// ---------------------------------------------------------------------------
 
 struct FindExecutor;
 
@@ -274,10 +265,6 @@ fn try_find_fallback(
     run_command(&mut cmd)
 }
 
-// ---------------------------------------------------------------------------
-// Ls
-// ---------------------------------------------------------------------------
-
 struct LsExecutor;
 
 impl ToolExecutor for LsExecutor {
@@ -356,7 +343,6 @@ fn format_system_time(time: &SystemTime) -> String {
             let hours = time_of_day / 3600;
             let minutes = (time_of_day % 3600) / 60;
 
-            // Days since epoch to Y-M-D (simplified)
             let (year, month, day) = days_to_ymd(days);
             format!("{year:04}-{month:02}-{day:02} {hours:02}:{minutes:02}")
         }
@@ -378,10 +364,6 @@ fn days_to_ymd(days: u64) -> (u64, u64, u64) {
     let y = if m <= 2 { y + 1 } else { y };
     (y, m, d)
 }
-
-// ---------------------------------------------------------------------------
-// Tool definitions
-// ---------------------------------------------------------------------------
 
 pub fn register(registry: &mut ToolRegistry) -> Result<()> {
     registry.register(grep_def(), Box::new(GrepExecutor))?;
@@ -543,10 +525,6 @@ fn ls_def() -> ToolDef {
         auto_activate: true,
     }
 }
-
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
 
 #[cfg(test)]
 #[path = "filesystem_tests.rs"]

--- a/crates/organon/src/builtins/filesystem_tests.rs
+++ b/crates/organon/src/builtins/filesystem_tests.rs
@@ -25,8 +25,6 @@ fn tool_input(name: &str, args: serde_json::Value) -> ToolInput {
     }
 }
 
-// -- GrepExecutor -------------------------------------------------------
-
 #[tokio::test]
 async fn grep_finds_pattern() {
     let dir = tempfile::tempdir().expect("tmpdir");
@@ -90,8 +88,6 @@ async fn grep_no_matches_not_error() {
     assert_eq!(result.content.text_summary(), "No matches found.");
 }
 
-// -- FindExecutor -------------------------------------------------------
-
 #[tokio::test]
 async fn find_locates_files() {
     let dir = tempfile::tempdir().expect("tmpdir");
@@ -139,8 +135,6 @@ async fn find_max_depth() {
     assert!(text.contains("shallow"));
     assert!(!text.contains("deep"));
 }
-
-// -- LsExecutor ---------------------------------------------------------
 
 #[tokio::test]
 async fn ls_lists_directory() {
@@ -205,8 +199,6 @@ async fn ls_dirs_sorted_before_files() {
     );
 }
 
-// -- Path validation ----------------------------------------------------
-
 #[tokio::test]
 async fn path_validation_rejects_outside_roots() {
     let dir = tempfile::tempdir().expect("tmpdir");
@@ -222,8 +214,6 @@ async fn path_validation_rejects_outside_roots() {
     assert!(err.to_string().contains("outside allowed roots"));
 }
 
-// -- Registration -------------------------------------------------------
-
 #[tokio::test]
 async fn all_tools_registered() {
     let mut reg = crate::registry::ToolRegistry::new();
@@ -234,8 +224,6 @@ async fn all_tools_registered() {
         assert!(reg.get_def(&tn).is_some(), "{name} should be registered");
     }
 }
-
-// -- Parameter validation -----------------------------------------------
 
 #[tokio::test]
 async fn test_grep_when_pattern_argument_missing_returns_error() {
@@ -260,8 +248,6 @@ async fn test_find_when_pattern_argument_missing_returns_error() {
         .expect_err("missing pattern should error");
     assert!(err.to_string().contains("missing or invalid field"));
 }
-
-// -- Grep result formatting ---------------------------------------------
 
 #[tokio::test]
 async fn test_grep_max_results_limits_output_lines() {
@@ -321,8 +307,6 @@ async fn test_grep_returns_error_result_for_invalid_path_outside_roots() {
     assert!(err.to_string().contains("outside allowed roots"));
 }
 
-// -- Find result formatting ---------------------------------------------
-
 #[tokio::test]
 async fn test_find_empty_results_returns_not_error_message() {
     let dir = tempfile::tempdir().expect("tmpdir");
@@ -369,8 +353,6 @@ async fn test_find_max_results_limits_output() {
         "expected at most 3 results, got {line_count}"
     );
 }
-
-// -- Ls result formatting -----------------------------------------------
 
 #[tokio::test]
 async fn test_ls_nonexistent_directory_returns_error_result() {
@@ -436,8 +418,6 @@ async fn test_ls_uses_workspace_when_path_not_specified() {
     assert!(!result.is_error);
     assert!(result.content.text_summary().contains("sentinel.txt"));
 }
-
-// -- Helper function unit tests -----------------------------------------
 
 #[test]
 fn test_is_glob_pattern_detects_star() {
@@ -512,8 +492,6 @@ fn test_truncate_output_exactly_at_limit_unchanged() {
     let result = truncate_output(exactly.clone());
     assert_eq!(result, exactly, "exactly at limit should be unchanged");
 }
-
-// -- Tool definition schema tests ---------------------------------------
 
 #[test]
 fn test_grep_def_has_pattern_as_required() {

--- a/crates/organon/src/builtins/memory/blackboard.rs
+++ b/crates/organon/src/builtins/memory/blackboard.rs
@@ -103,8 +103,6 @@ impl ToolExecutor for BlackboardExecutor {
     }
 }
 
-// --- Tool Definition ---
-
 fn blackboard_def() -> ToolDef {
     ToolDef {
         name: ToolName::new("blackboard").expect("valid tool name"),
@@ -155,8 +153,6 @@ fn blackboard_def() -> ToolDef {
         auto_activate: true,
     }
 }
-
-// --- Registration ---
 
 pub(super) fn register(registry: &mut ToolRegistry) -> Result<()> {
     registry.register(blackboard_def(), Box::new(BlackboardExecutor))?;

--- a/crates/organon/src/builtins/memory/datalog.rs
+++ b/crates/organon/src/builtins/memory/datalog.rs
@@ -135,8 +135,6 @@ pub(super) fn format_as_markdown_table(result: &crate::types::DatalogResult) -> 
     out
 }
 
-// --- Tool Definition ---
-
 fn datalog_query_def() -> ToolDef {
     ToolDef {
         name: ToolName::new("datalog_query").expect("valid tool name"),
@@ -194,8 +192,6 @@ fn datalog_query_def() -> ToolDef {
         auto_activate: false,
     }
 }
-
-// --- Registration ---
 
 pub(super) fn register(registry: &mut ToolRegistry) -> Result<()> {
     registry.register(datalog_query_def(), Box::new(DatalogQueryExecutor))?;

--- a/crates/organon/src/builtins/memory/knowledge_ops.rs
+++ b/crates/organon/src/builtins/memory/knowledge_ops.rs
@@ -21,8 +21,6 @@ use crate::builtins::workspace::{extract_opt_u64, extract_str};
 
 use super::require_services;
 
-// --- Memory Search ---
-
 struct MemorySearchExecutor;
 
 impl ToolExecutor for MemorySearchExecutor {
@@ -68,8 +66,6 @@ fn format_results(results: &[crate::types::MemoryResult]) -> String {
         })
 }
 
-// --- Memory Correct ---
-
 struct MemoryCorrectExecutor;
 
 impl ToolExecutor for MemoryCorrectExecutor {
@@ -103,8 +99,6 @@ impl ToolExecutor for MemoryCorrectExecutor {
     }
 }
 
-// --- Memory Retract ---
-
 struct MemoryRetractExecutor;
 
 impl ToolExecutor for MemoryRetractExecutor {
@@ -132,8 +126,6 @@ impl ToolExecutor for MemoryRetractExecutor {
         })
     }
 }
-
-// --- Memory Forget ---
 
 struct MemoryForgetExecutor;
 
@@ -165,8 +157,6 @@ impl ToolExecutor for MemoryForgetExecutor {
         })
     }
 }
-
-// --- Memory Audit ---
 
 struct MemoryAuditExecutor;
 
@@ -226,8 +216,6 @@ impl ToolExecutor for MemoryAuditExecutor {
         })
     }
 }
-
-// --- Tool Definitions ---
 
 fn memory_search_def() -> ToolDef {
     ToolDef {
@@ -408,8 +396,6 @@ fn memory_audit_def() -> ToolDef {
         auto_activate: false,
     }
 }
-
-// --- Registration ---
 
 pub(super) fn register(registry: &mut ToolRegistry) -> Result<()> {
     registry.register(memory_search_def(), Box::new(MemorySearchExecutor))?;

--- a/crates/organon/src/builtins/memory/note.rs
+++ b/crates/organon/src/builtins/memory/note.rs
@@ -101,8 +101,6 @@ impl ToolExecutor for NoteExecutor {
     }
 }
 
-// --- Tool Definition ---
-
 fn note_def() -> ToolDef {
     ToolDef {
         name: ToolName::new("note").expect("valid tool name"),
@@ -156,8 +154,6 @@ fn note_def() -> ToolDef {
         auto_activate: true,
     }
 }
-
-// --- Registration ---
 
 pub(super) fn register(registry: &mut ToolRegistry) -> Result<()> {
     registry.register(note_def(), Box::new(NoteExecutor))?;

--- a/crates/organon/src/builtins/memory/tests.rs
+++ b/crates/organon/src/builtins/memory/tests.rs
@@ -18,8 +18,6 @@ fn install_crypto_provider() {
     let _ = rustls::crypto::ring::default_provider().install_default();
 }
 
-// --- In-memory mock stores ---
-
 struct MockNoteStore {
     notes: Mutex<Vec<NoteEntry>>,
     next_id: Mutex<i64>,
@@ -213,8 +211,6 @@ async fn memory_search_no_services_returns_error() {
     assert!(result.content.text_summary().contains("not configured"));
 }
 
-// --- Note tests ---
-
 #[tokio::test]
 async fn note_add_and_list() {
     let mut reg = ToolRegistry::new();
@@ -304,8 +300,6 @@ async fn note_rejects_over_500_chars() {
     assert!(result.is_error);
     assert!(result.content.text_summary().contains("500"));
 }
-
-// --- Blackboard tests ---
 
 #[tokio::test]
 async fn blackboard_write_and_read() {
@@ -413,8 +407,6 @@ async fn blackboard_delete_only_author() {
     let r2 = reg.execute(&del2, &ctx).await.expect("execute");
     assert!(r2.content.text_summary().contains("deleted"));
 }
-
-// --- Memory management tool tests ---
 
 #[tokio::test]
 async fn memory_correct_no_knowledge_returns_error() {
@@ -543,8 +535,6 @@ async fn memory_forget_not_auto_activated() {
     let def = reg.get_def(&name).expect("found");
     assert!(!def.auto_activate);
 }
-
-// --- Datalog query tool tests ---
 
 #[tokio::test]
 async fn datalog_query_rejects_mutation_keywords() {

--- a/crates/organon/src/builtins/planning.rs
+++ b/crates/organon/src/builtins/planning.rs
@@ -25,8 +25,6 @@ fn require_planning(
         .ok_or_else(|| ToolResult::error("planning service not configured"))
 }
 
-// --- Executors ---
-
 struct PlanCreateExecutor;
 
 impl ToolExecutor for PlanCreateExecutor {
@@ -361,8 +359,6 @@ impl ToolExecutor for PlanStepFailExecutor {
         })
     }
 }
-
-// --- Registration ---
 
 pub fn register(registry: &mut ToolRegistry) -> Result<()> {
     registry.register(plan_create_def(), Box::new(PlanCreateExecutor))?;

--- a/crates/organon/src/builtins/research.rs
+++ b/crates/organon/src/builtins/research.rs
@@ -33,8 +33,6 @@ fn require_services(
         .ok_or_else(|| ToolResult::error("tool services not configured"))
 }
 
-// --- SSRF protection ---
-
 /// Blocked cloud metadata hostnames.
 const BLOCKED_HOSTNAMES: &[&str] = &["localhost", "metadata.google.internal"];
 
@@ -63,7 +61,6 @@ async fn validate_url_not_internal(url_str: &str) -> std::result::Result<(), Str
 
     let host = parsed.host_str().ok_or("URL has no host")?;
 
-    // Block known metadata / internal hostnames
     let host_lower = host.to_lowercase();
     for blocked in BLOCKED_HOSTNAMES {
         if host_lower == *blocked {
@@ -71,7 +68,6 @@ async fn validate_url_not_internal(url_str: &str) -> std::result::Result<(), Str
         }
     }
 
-    // Resolve DNS and check every address
     let port = parsed.port_or_known_default().unwrap_or(80);
     let addrs: Vec<std::net::SocketAddr> = tokio::net::lookup_host(format!("{host}:{port}"))
         .await
@@ -91,8 +87,6 @@ async fn validate_url_not_internal(url_str: &str) -> std::result::Result<(), Str
     Ok(())
 }
 
-// --- web_fetch ---
-
 struct WebFetchExecutor;
 
 impl ToolExecutor for WebFetchExecutor {
@@ -110,17 +104,14 @@ impl ToolExecutor for WebFetchExecutor {
             let url = extract_str(&input.arguments, "url", &input.name)?;
             let max_length = extract_opt_u64(&input.arguments, "maxLength").unwrap_or(50_000);
 
-            // Basic URL validation
             if !url.starts_with("http://") && !url.starts_with("https://") {
                 return Ok(ToolResult::error("URL must start with http:// or https://"));
             }
 
-            // SSRF protection: resolve hostname and block private/internal IPs
             if let Err(msg) = validate_url_not_internal(url).await {
                 return Ok(ToolResult::error(msg));
             }
 
-            // Build a client that checks redirects against private IPs
             let ssrf_safe_client = reqwest::Client::builder()
                 .redirect(redirect::Policy::custom(|attempt| {
                     let url = attempt.url();
@@ -141,7 +132,6 @@ impl ToolExecutor for WebFetchExecutor {
                     {
                         return attempt.stop();
                     }
-                    // Limit redirect chain length
                     if attempt.previous().len() >= 10 {
                         return attempt.stop();
                     }
@@ -264,7 +254,6 @@ fn strip_html_tags(html: &str) -> String {
             continue;
         }
 
-        // Decode common HTML entities
         if bytes[i] == b'&' {
             if i + 4 <= bytes.len() && &bytes[i..i + 4] == b"&lt;" {
                 result.push('<');
@@ -313,8 +302,6 @@ fn strip_html_tags(html: &str) -> String {
 
     result.trim().to_owned()
 }
-
-// --- Definition ---
 
 fn web_fetch_def() -> ToolDef {
     ToolDef {

--- a/crates/organon/src/builtins/view_file.rs
+++ b/crates/organon/src/builtins/view_file.rs
@@ -304,7 +304,7 @@ mod tests {
                     other => panic!("expected Image block, got {other:?}"),
                 }
             }
-            other @ ToolResultContent::Text(_) => panic!("expected Blocks, got {other:?}"),
+            other => panic!("expected Blocks, got {other:?}"),
         }
     }
 

--- a/crates/organon/src/builtins/workspace.rs
+++ b/crates/organon/src/builtins/workspace.rs
@@ -25,10 +25,6 @@ use crate::types::{
 
 const MAX_OUTPUT_BYTES: usize = 50 * 1024;
 
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
 pub(crate) fn validate_path(raw: &str, ctx: &ToolContext, tool_name: &ToolName) -> Result<PathBuf> {
     if raw.is_empty() {
         return Err(error::InvalidInputSnafu {
@@ -172,10 +168,6 @@ fn is_protected_file(path: &Path, workspace: &Path) -> Option<&'static str> {
 fn err_result(msg: String) -> ToolResult {
     ToolResult::error(msg)
 }
-
-// ---------------------------------------------------------------------------
-// Executors
-// ---------------------------------------------------------------------------
 
 struct ReadExecutor;
 
@@ -503,10 +495,6 @@ impl ToolExecutor for ExecExecutor {
     }
 }
 
-// ---------------------------------------------------------------------------
-// Tool definitions (schemas unchanged)
-// ---------------------------------------------------------------------------
-
 /// Register workspace tool executors.
 pub fn register(registry: &mut ToolRegistry, sandbox: crate::sandbox::SandboxConfig) -> Result<()> {
     registry.register(read_def(), Box::new(ReadExecutor))?;
@@ -670,10 +658,6 @@ fn exec_def() -> ToolDef {
         auto_activate: true,
     }
 }
-
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
 
 #[cfg(test)]
 #[path = "workspace_tests.rs"]

--- a/crates/organon/src/builtins/workspace_tests.rs
+++ b/crates/organon/src/builtins/workspace_tests.rs
@@ -25,8 +25,6 @@ fn tool_input(name: &str, args: serde_json::Value) -> ToolInput {
     }
 }
 
-// -- ReadExecutor -------------------------------------------------------
-
 #[tokio::test]
 async fn read_existing_file() {
     let dir = tempfile::tempdir().expect("create temp dir");
@@ -63,8 +61,6 @@ async fn read_missing_file() {
     assert!(result.is_error);
     assert!(result.content.text_summary().contains("file not found"));
 }
-
-// -- WriteExecutor ------------------------------------------------------
 
 #[tokio::test]
 async fn write_creates_file() {
@@ -110,8 +106,6 @@ async fn write_append_mode() {
     let on_disk = std::fs::read_to_string(dir.path().join("log.txt")).expect("read");
     assert_eq!(on_disk, "first\nsecond\n");
 }
-
-// -- EditExecutor -------------------------------------------------------
 
 #[tokio::test]
 async fn edit_single_match() {
@@ -172,8 +166,6 @@ async fn edit_multiple_matches() {
     assert!(result.content.text_summary().contains("2 times"));
 }
 
-// -- ExecExecutor -------------------------------------------------------
-
 #[tokio::test]
 async fn exec_simple_command() {
     let dir = tempfile::tempdir().expect("create temp dir");
@@ -208,8 +200,6 @@ async fn exec_timeout() {
     assert!(result.content.text_summary().contains("timed out"));
 }
 
-// -- Path traversal -----------------------------------------------------
-
 #[tokio::test]
 async fn path_traversal_blocked() {
     let dir = tempfile::tempdir().expect("create temp dir");
@@ -221,8 +211,6 @@ async fn path_traversal_blocked() {
         .expect_err("should reject traversal");
     assert!(err.to_string().contains("outside allowed roots"));
 }
-
-// -- Parameter validation -----------------------------------------------
 
 #[tokio::test]
 async fn test_read_when_path_argument_missing_returns_invalid_input_error() {
@@ -293,8 +281,6 @@ async fn test_exec_when_command_argument_missing_returns_error() {
     assert!(err.to_string().contains("missing or invalid field"));
 }
 
-// -- Extra / unknown params handled gracefully --------------------------
-
 #[tokio::test]
 async fn test_read_ignores_unknown_extra_fields() {
     let dir = tempfile::tempdir().expect("create temp dir");
@@ -308,8 +294,6 @@ async fn test_read_ignores_unknown_extra_fields() {
     assert!(!result.is_error);
     assert_eq!(result.content.text_summary(), "hello");
 }
-
-// -- Write result formatting --------------------------------------------
 
 #[tokio::test]
 async fn test_write_reports_byte_count_in_success_message() {
@@ -352,8 +336,6 @@ async fn test_write_append_creates_file_when_absent() {
     let on_disk = std::fs::read_to_string(dir.path().join("new.txt")).expect("read");
     assert_eq!(on_disk, "data");
 }
-
-// -- Edit result formatting ---------------------------------------------
 
 #[tokio::test]
 async fn test_edit_when_file_does_not_exist_returns_error_result() {
@@ -410,8 +392,6 @@ async fn test_edit_preserves_surrounding_content() {
     let on_disk = std::fs::read_to_string(dir.path().join("f.txt")).expect("read");
     assert_eq!(on_disk, "line1\nREPLACED\nline3\n");
 }
-
-// -- Exec result formatting ---------------------------------------------
 
 #[tokio::test]
 async fn test_exec_failed_command_reports_nonzero_exit_code() {
@@ -493,8 +473,6 @@ async fn test_exec_output_format_includes_exit_then_stdout_then_stderr() {
     let out_pos = text.find("out").expect("stdout");
     assert!(exit_pos < out_pos, "exit code should precede stdout");
 }
-
-// -- Helper functions ---------------------------------------------------
 
 #[test]
 fn test_validate_path_empty_string_returns_error() {
@@ -587,8 +565,6 @@ fn test_extract_opt_bool_returns_value_when_field_present() {
     assert_eq!(extract_opt_bool(&args, "append"), Some(true));
 }
 
-// -- Tool registration --------------------------------------------------
-
 #[tokio::test]
 async fn test_all_workspace_tools_registered() {
     let mut reg = crate::registry::ToolRegistry::new();
@@ -617,8 +593,6 @@ fn test_write_tool_def_has_path_and_content_as_required() {
     assert!(def.input_schema.required.contains(&"path".to_owned()));
     assert!(def.input_schema.required.contains(&"content".to_owned()));
 }
-
-// -- Sandbox fallback integration ---------------------------------------
 
 #[cfg(target_os = "linux")]
 #[tokio::test]
@@ -702,8 +676,6 @@ async fn exec_enforcing_sandbox_returns_clear_error_when_landlock_unavailable() 
     }
 }
 
-// -- parse_command_args -------------------------------------------------
-
 #[test]
 fn parse_command_args_splits_simple_command() {
     let (prog, args) = parse_command_args("echo hello world").expect("parse");
@@ -773,8 +745,6 @@ fn parse_command_args_program_only() {
     assert_eq!(prog, "ls");
     assert!(args.is_empty());
 }
-
-// -- Protected file enforcement -----------------------------------------
 
 #[tokio::test]
 async fn write_blocks_identity_md() {

--- a/crates/organon/src/process_guard.rs
+++ b/crates/organon/src/process_guard.rs
@@ -86,10 +86,6 @@ impl Drop for ProcessGuard {
     }
 }
 
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
-
 #[cfg(test)]
 #[expect(clippy::unwrap_used, reason = "test assertions")]
 #[expect(clippy::expect_used, reason = "test assertions")]
@@ -112,10 +108,8 @@ mod tests {
         let guard = ProcessGuard::new(child);
         drop(guard);
 
-        // Give the OS a moment to clean up.
         std::thread::sleep(Duration::from_millis(50));
 
-        // `kill -0 <pid>` succeeds only if the process exists.
         let alive = Command::new("kill")
             .args(["-0", &pid.to_string()])
             .output()

--- a/crates/organon/src/registry.rs
+++ b/crates/organon/src/registry.rs
@@ -512,23 +512,21 @@ mod tests {
         assert_eq!(tools[0].name, "enable_tool");
     }
 
-    // -- Additional registry tests ------------------------------------------
-
     #[test]
-    fn test_registry_new_has_no_definitions() {
+    fn empty_registry_has_no_definitions() {
         let reg = ToolRegistry::new();
         assert!(reg.definitions().is_empty());
     }
 
     #[test]
-    fn test_registry_default_is_same_as_new() {
+    fn default_registry_equals_new_registry() {
         let reg1 = ToolRegistry::new();
         let reg2 = ToolRegistry::default();
         assert_eq!(reg1.definitions().len(), reg2.definitions().len());
     }
 
     #[test]
-    fn test_definitions_preserves_insertion_order() {
+    fn definitions_preserves_insertion_order() {
         let mut reg = ToolRegistry::new();
         let (e1, _) = mock_executor("ok");
         let (e2, _) = mock_executor("ok");
@@ -545,7 +543,7 @@ mod tests {
     }
 
     #[test]
-    fn test_to_hermeneus_tools_schema_includes_required_fields() {
+    fn schema_includes_required_fields() {
         let mut reg = ToolRegistry::new();
         let (exec, _) = mock_executor("ok");
         let def = ToolDef {
@@ -574,7 +572,7 @@ mod tests {
     }
 
     #[test]
-    fn test_to_hermeneus_tools_schema_includes_enum_values() {
+    fn schema_includes_enum_values() {
         let mut reg = ToolRegistry::new();
         let (exec, _) = mock_executor("ok");
         let def = ToolDef {
@@ -605,7 +603,7 @@ mod tests {
     }
 
     #[test]
-    fn test_to_hermeneus_tools_schema_includes_default_values() {
+    fn schema_includes_default_values() {
         let mut reg = ToolRegistry::new();
         let (exec, _) = mock_executor("ok");
         let def = ToolDef {
@@ -634,7 +632,7 @@ mod tests {
     }
 
     #[test]
-    fn test_lazy_catalog_includes_description() {
+    fn lazy_catalog_includes_description() {
         let mut reg = ToolRegistry::new();
         let (exec, _) = mock_executor("ok");
         reg.register(
@@ -659,7 +657,7 @@ mod tests {
     }
 
     #[test]
-    fn test_definitions_for_category_returns_empty_when_no_match() {
+    fn definitions_for_category_returns_empty_when_no_match() {
         let mut reg = ToolRegistry::new();
         let (e1, _) = mock_executor("ok");
         reg.register(test_def("read", ToolCategory::Workspace), e1)
@@ -669,7 +667,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_execute_unknown_tool_returns_tool_not_found_error() {
+    async fn execute_returns_tool_not_found_for_unknown_name() {
         let reg = ToolRegistry::new();
         let input = ToolInput {
             name: ToolName::new("ghost").expect("valid"),

--- a/crates/organon/src/types_tests.rs
+++ b/crates/organon/src/types_tests.rs
@@ -275,8 +275,6 @@ fn test_input_schema_type_is_object_in_json_schema() {
     assert_eq!(json["type"], "object");
 }
 
-// --- ServerToolConfig tests ---
-
 #[test]
 fn server_tool_config_default_disables_all() {
     let config = ServerToolConfig::default();

--- a/crates/pylon/src/error.rs
+++ b/crates/pylon/src/error.rs
@@ -145,17 +145,15 @@ impl IntoResponse for ApiError {
             Self::NotImplemented { .. } => (StatusCode::NOT_IMPLEMENTED, "not_implemented", None),
         };
 
-        // Extract retry-after value before moving self for Display
+        // WHY: retry_after_secs must be extracted before self is moved into client_message construction below.
         let retry_after_secs = if let Self::RateLimited { retry_after_ms, .. } = &self {
-            // Convert ms to seconds (ceiling division so 1500ms → 2s)
             Some(retry_after_ms.div_ceil(1000))
         } else {
             None
         };
 
-        // For 5xx errors: log full internal details (request_id is in the active span) and
-        // return a generic message so internal paths, SQL, panic text, and provider details
-        // are never exposed to clients. (#827, #846, #847)
+        // WHY: 5xx errors log full details internally but return a generic message so SQL paths,
+        // panic text, and provider details are never exposed to clients (#827, #846, #847).
         let client_message = if status.is_server_error() {
             tracing::error!(error = %self, "internal server error");
             "An internal error occurred".to_owned()
@@ -173,7 +171,7 @@ impl IntoResponse for ApiError {
 
         let mut response = (status, Json(body)).into_response();
 
-        // RFC 6585: 429 responses SHOULD include a Retry-After header.
+        // WHY: RFC 6585 requires Retry-After on 429 responses.
         if let Some(secs) = retry_after_secs {
             response.headers_mut().insert(
                 axum::http::header::RETRY_AFTER,
@@ -199,7 +197,7 @@ impl From<aletheia_mneme::error::Error> for ApiError {
                 path: format!("fact/{id}"),
                 location: snafu::Location::default(),
             },
-            // Validation errors are the caller's fault — expose the message.
+            // WHY: validation errors are the caller's fault and are safe to expose.
             Error::EmptyContent { .. }
             | Error::ContentTooLong { .. }
             | Error::InvalidConfidence { .. }
@@ -384,8 +382,6 @@ mod tests {
         static_assertions::assert_impl_all!(ApiError: Send, Sync);
     }
 
-    // --- Sanitization tests (#827, #846, #847) ---
-
     /// Helper: extract the `message` field from an `ErrorResponse` JSON body.
     fn body_message(response: Response) -> String {
         let rt = tokio::runtime::Runtime::new().unwrap();
@@ -426,7 +422,6 @@ mod tests {
 
     #[tokio::test]
     async fn join_error_returns_generic_message() {
-        // JoinError converts to Internal, which must be sanitized.
         let join_err = tokio::spawn(async { panic!("database connection string leaked") })
             .await
             .unwrap_err();
@@ -450,7 +445,6 @@ mod tests {
         };
         let api_err = ApiError::from(hermeneus_err);
         let response = api_err.into_response();
-        // Maps to ServiceUnavailable (503) — must be sanitized.
         assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
         let msg = body_message(response);
         assert_eq!(msg, "An internal error occurred");
@@ -460,7 +454,6 @@ mod tests {
 
     #[test]
     fn bad_request_message_is_preserved() {
-        // 4xx messages are user-facing and must NOT be sanitized.
         let err = ApiError::BadRequest {
             message: "content must not be empty".to_owned(),
             location: snafu::Location::default(),

--- a/crates/pylon/src/extract.rs
+++ b/crates/pylon/src/extract.rs
@@ -31,8 +31,6 @@ impl FromRequestParts<Arc<AppState>> for Claims {
         parts: &mut Parts,
         state: &Arc<AppState>,
     ) -> Result<Self, Self::Rejection> {
-        // When auth is disabled, inject a minimal read-only identity.
-        //
         // WHY: Granting Operator role bypasses all access controls and lets
         // any network caller manage agents, modify config, and access all
         // sessions. Auth-disabled deployments should receive the least

--- a/crates/pylon/src/handlers/config.rs
+++ b/crates/pylon/src/handlers/config.rs
@@ -118,7 +118,6 @@ pub async fn update_section(
         });
     }
 
-    // Validate
     if let Err(err) = aletheia_taxis::validate::validate_section(&section, &body) {
         return Err(ApiError::ValidationFailed {
             errors: err.errors,
@@ -126,7 +125,6 @@ pub async fn update_section(
         });
     }
 
-    // Deep-merge into current config (body patches only changed fields)
     let mut config = state.config.write().await;
     let mut config_value = serde_json::to_value(&*config).map_err(|e| ApiError::Internal {
         message: format!("failed to serialize config: {e}"),
@@ -152,7 +150,6 @@ pub async fn update_section(
             }
         })?;
 
-    // Persist to disk
     aletheia_taxis::loader::write_config(&state.oikos, &new_config).map_err(|e| {
         ApiError::Internal {
             message: format!("failed to write config: {e}"),
@@ -160,14 +157,12 @@ pub async fn update_section(
         }
     })?;
 
-    // Identify restart-required fields
     let restart_required: Vec<String> = aletheia_taxis::reload::restart_prefixes()
         .iter()
         .filter(|p| p.starts_with(&format!("{section}.")))
         .map(|p| (*p).to_owned())
         .collect();
 
-    // Update in-memory config
     *config = new_config;
     let redacted = aletheia_taxis::redact::redact(&config);
     let section_value = redacted.get(&section).cloned().unwrap_or_else(|| {

--- a/crates/pylon/src/handlers/knowledge.rs
+++ b/crates/pylon/src/handlers/knowledge.rs
@@ -198,26 +198,21 @@ pub async fn list_facts(
 ) -> Result<Json<FactsResponse>, ApiError> {
     use aletheia_mneme::knowledge::EpistemicTier;
 
-    // Enforce pagination bounds: cap limit at MAX_LIMIT.
     query.limit = query.limit.min(MAX_LIMIT);
 
-    // Build facts from the knowledge store if available.
     let mut facts = get_stored_facts(&state, &query);
 
-    // Apply text filter
     if let Some(ref filter) = query.filter {
         let filter_lower = filter.to_lowercase();
         facts.retain(|f| f.content.to_lowercase().contains(&filter_lower));
     }
 
-    // Apply fact_type filter
     if let Some(ref ft) = query.fact_type
         && ft != "all"
     {
         facts.retain(|f| f.fact_type == *ft);
     }
 
-    // Apply tier filter
     if let Some(ref tier) = query.tier {
         let tier_enum = match tier.as_str() {
             "verified" => Some(EpistemicTier::Verified),
@@ -230,17 +225,14 @@ pub async fn list_facts(
         }
     }
 
-    // Filter forgotten unless explicitly requested
     if !query.include_forgotten {
         facts.retain(|f| !f.is_forgotten);
     }
 
     let total = facts.len();
 
-    // Sort
     sort_facts(&mut facts, &query.sort, &query.order);
 
-    // Paginate
     let start = query.offset.min(facts.len());
     let end = (start + query.limit).min(facts.len());
     let facts = facts[start..end].to_vec();
@@ -273,7 +265,6 @@ pub async fn get_fact(
             location: snafu::Location::default(),
         })?;
 
-    // Get relationships involving entities mentioned in this fact
     let relationships = get_fact_relationships(&state, &fact);
     let similar = get_similar_facts(&state, &fact);
 
@@ -496,7 +487,6 @@ pub async fn search(
                 }
             }
             if score > 0.0 {
-                // Boost by confidence
                 score *= f.confidence;
                 Some(SearchResult {
                     id: f.id.to_string(),
@@ -546,7 +536,6 @@ pub async fn timeline(
         if fact.is_forgotten {
             continue;
         }
-        // Creation event
         events.push(TimelineEvent {
             timestamp: fact.recorded_at.to_string(),
             event_type: "created".to_string(),
@@ -555,7 +544,6 @@ pub async fn timeline(
             confidence: Some(fact.confidence),
         });
 
-        // Access events (summarized)
         if fact.access_count > 0 && fact.last_accessed_at.is_some() {
             events.push(TimelineEvent {
                 timestamp: fact
@@ -669,7 +657,7 @@ pub(crate) fn sort_facts(facts: &mut [aletheia_mneme::knowledge::Fact], sort: &s
                 .unwrap_or(std::cmp::Ordering::Equal);
             if desc { cmp.reverse() } else { cmp }
         }),
-        _ => {} // No sorting for unknown fields
+        _ => {}
     }
 }
 

--- a/crates/pylon/src/handlers/sessions/mod.rs
+++ b/crates/pylon/src/handlers/sessions/mod.rs
@@ -1,6 +1,6 @@
 //! Session management and message streaming handlers.
 
-// `pub(crate)` so utoipa-generated `__path_*` types are visible to the OpenAPI derive.
+// WHY: pub(crate) so utoipa-generated `__path_*` types are visible to the OpenAPI derive.
 pub(crate) mod streaming;
 mod types;
 

--- a/crates/pylon/src/handlers/sessions/streaming.rs
+++ b/crates/pylon/src/handlers/sessions/streaming.rs
@@ -56,7 +56,6 @@ pub async fn send_message(
     axum::extract::Path(session_id): axum::extract::Path<String>,
     Json(body): Json<SendMessageRequest>,
 ) -> Result<Sse<impl tokio_stream::Stream<Item = Result<Event, Infallible>>>, ApiError> {
-    // --- Idempotency key extraction ---
     let idempotency_key = extract_idempotency_key(&headers)?;
 
     if let Some(ref key) = idempotency_key {
@@ -110,7 +109,6 @@ pub async fn send_message(
         .build());
     }
 
-    // Resolve the nous actor
     let nous_id = &session.nous_id;
     let handle = state
         .nous_manager
@@ -123,7 +121,6 @@ pub async fn send_message(
         })?
         .clone();
 
-    // Pre-flight: verify provider exists for the model
     if let Some(config) = state.nous_manager.get_config(nous_id)
         && state
             .provider_registry

--- a/crates/pylon/src/idempotency.rs
+++ b/crates/pylon/src/idempotency.rs
@@ -98,7 +98,6 @@ impl IdempotencyCache {
             };
         }
 
-        // Evict oldest if at capacity
         while inner.entries.len() >= inner.capacity {
             if let Some(oldest_key) = inner.order.pop_front() {
                 inner.entries.remove(&oldest_key);
@@ -157,7 +156,6 @@ impl CacheInner {
                     break;
                 }
             } else {
-                // Stale order entry — remove it
                 self.order.pop_front();
             }
         }
@@ -174,16 +172,12 @@ mod tests {
         let cache = IdempotencyCache::new();
         let key = "test-key-001";
 
-        // First lookup: miss, inserted as InFlight
         assert!(matches!(cache.check_or_insert(key), LookupResult::Miss));
 
-        // Second lookup while in-flight: conflict
         assert!(matches!(cache.check_or_insert(key), LookupResult::Conflict));
 
-        // Complete the entry
         cache.complete(key, StatusCode::OK, r#"{"ok":true}"#.to_owned());
 
-        // Third lookup: hit with cached response
         match cache.check_or_insert(key) {
             LookupResult::Hit { status, body } => {
                 assert_eq!(status, StatusCode::OK);
@@ -218,7 +212,6 @@ mod tests {
             cache.check_or_insert(&format!("key-{i}"));
         }
 
-        // Oldest (key-0) should be evicted
         assert_eq!(cache.len(), 3);
         let inner = cache.inner.lock().unwrap();
         assert!(!inner.entries.contains_key("key-0"));
@@ -232,12 +225,11 @@ mod tests {
                 entries: HashMap::new(),
                 order: VecDeque::new(),
                 capacity: DEFAULT_CAPACITY,
-                ttl: Duration::from_millis(0), // immediate expiry
+                ttl: Duration::from_millis(0),
             }),
         };
 
         cache.check_or_insert("expired-key");
-        // Next call triggers eviction of the expired entry, then inserts fresh
         assert!(matches!(
             cache.check_or_insert("expired-key"),
             LookupResult::Miss

--- a/crates/pylon/src/metrics.rs
+++ b/crates/pylon/src/metrics.rs
@@ -1,6 +1,5 @@
 //! Prometheus metric definitions for the HTTP gateway.
 
-// Prometheus metric registration panics only on duplicate name (programmer error).
 #![expect(
     clippy::expect_used,
     reason = "metric registration is infallible at startup"
@@ -93,7 +92,7 @@ fn looks_like_id(s: &str) -> bool {
     if s.is_empty() {
         return false;
     }
-    // ULIDs (26 alphanumeric), UUIDs (36 with hyphens), or long hex strings
+    // NOTE: ULIDs are 26 alphanumeric chars; UUIDs are 36 chars with hyphens.
     let len = s.len();
     (len >= 20 && s.chars().all(|c| c.is_ascii_alphanumeric()))
         || (len == 36 && s.contains('-') && s.chars().all(|c| c.is_ascii_hexdigit() || c == '-'))

--- a/crates/pylon/src/openapi.rs
+++ b/crates/pylon/src/openapi.rs
@@ -1,7 +1,5 @@
 //! `OpenAPI` specification generation.
 #![allow(clippy::needless_for_each)]
-// utoipa OpenApi derive macro
-// OpenAPI spec serialization to JSON is infallible for well-formed specs.
 #![expect(
     clippy::expect_used,
     reason = "OpenAPI JSON serialization is infallible"

--- a/crates/pylon/src/stream.rs
+++ b/crates/pylon/src/stream.rs
@@ -6,6 +6,7 @@ use utoipa::ToSchema;
 /// SSE event emitted to the client during message streaming.
 #[derive(Debug, Clone, Serialize, ToSchema)]
 #[serde(tag = "type")]
+#[non_exhaustive]
 pub enum SseEvent {
     /// Incremental text output from the assistant.
     #[serde(rename = "text_delta")]
@@ -72,6 +73,7 @@ impl SseEvent {
 /// to avoid changing the per-session message API shape.
 #[derive(Debug, Clone, Serialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
+#[non_exhaustive]
 pub enum WebchatEvent {
     TurnStart {
         #[serde(rename = "sessionId")]

--- a/crates/pylon/src/tests.rs
+++ b/crates/pylon/src/tests.rs
@@ -35,8 +35,6 @@ fn test_security_config() -> SecurityConfig {
     }
 }
 
-// --- Mock Provider ---
-
 struct MockProvider {
     response: CompletionResponse,
 }
@@ -90,8 +88,6 @@ impl LlmProvider for MockProvider {
     }
 }
 
-// --- JWT Test Helpers ---
-
 fn test_jwt_manager() -> Arc<JwtManager> {
     Arc::new(JwtManager::new(JwtConfig {
         signing_key: SecretString::from("test-secret-key-for-jwt".to_owned()),
@@ -106,8 +102,6 @@ fn default_token() -> String {
         .issue_access("test-user", aletheia_symbolon::types::Role::Operator, None)
         .expect("test token")
 }
-
-// --- Test Helpers ---
 
 async fn test_state() -> (Arc<AppState>, tempfile::TempDir) {
     test_state_with_provider(true).await
@@ -265,8 +259,6 @@ async fn create_test_session(app: &axum::Router) -> serde_json::Value {
     body_json(resp).await
 }
 
-// --- Auth Tests ---
-
 #[tokio::test]
 async fn health_no_auth_required() {
     let (app, _dir) = app().await;
@@ -389,8 +381,6 @@ async fn missing_bearer_prefix() {
     assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
 }
 
-// --- Health Tests ---
-
 #[tokio::test]
 async fn health_returns_200() {
     let (app, _dir) = app().await;
@@ -445,8 +435,6 @@ async fn health_checks_have_expected_shape() {
     );
     assert!(names.contains(&"providers"), "missing providers check");
 }
-
-// --- Session CRUD Tests ---
 
 #[tokio::test]
 async fn create_session_returns_201() {
@@ -538,8 +526,6 @@ async fn close_unknown_session_returns_404() {
     assert_eq!(resp.status(), StatusCode::NOT_FOUND);
 }
 
-// --- History Tests ---
-
 #[tokio::test]
 async fn history_empty_for_new_session() {
     let (router, _dir) = app().await;
@@ -603,8 +589,6 @@ async fn history_with_limit() {
     let body = body_json(resp).await;
     assert_eq!(body["messages"].as_array().unwrap().len(), 3);
 }
-
-// --- SSE Message Tests ---
 
 #[tokio::test]
 async fn send_message_returns_sse_content_type() {
@@ -722,8 +706,6 @@ async fn send_message_stores_in_history() {
     assert_eq!(messages[0]["content"], "Hello!");
 }
 
-// --- Error Format Tests ---
-
 #[tokio::test]
 async fn error_response_has_consistent_structure() {
     let (app, _dir) = app().await;
@@ -783,8 +765,6 @@ async fn malformed_send_body_returns_error() {
     );
 }
 
-// --- Nous Tests ---
-
 #[tokio::test]
 async fn list_nous_returns_agents() {
     let (app, _dir) = app().await;
@@ -835,8 +815,6 @@ async fn get_nous_tools() {
     assert!(body["tools"].is_array());
 }
 
-// --- Concurrent access ---
-
 #[tokio::test]
 async fn concurrent_session_creation() {
     let (state, _dir) = test_state().await;
@@ -864,8 +842,6 @@ async fn concurrent_session_creation() {
     }
 }
 
-// --- SSE with no provider ---
-
 #[tokio::test]
 async fn send_message_no_provider_returns_error() {
     let (state, _dir) = test_state_with_provider(false).await;
@@ -882,8 +858,6 @@ async fn send_message_no_provider_returns_error() {
     let resp = router.clone().oneshot(req).await.unwrap();
     assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
 }
-
-// --- Actor-routed tests ---
 
 #[tokio::test]
 async fn send_message_routes_through_actor() {
@@ -1074,8 +1048,6 @@ async fn missing_auth_header_returns_401() {
     assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
 }
 
-// --- Security Header Tests ---
-
 #[tokio::test]
 async fn security_headers_present_on_response() {
     let (app, _dir) = app().await;
@@ -1123,8 +1095,6 @@ async fn hsts_header_present_when_tls_enabled() {
     );
 }
 
-// --- Body Limit Tests ---
-
 #[tokio::test]
 async fn oversized_body_returns_413() {
     let (state, _dir) = test_state().await;
@@ -1148,8 +1118,6 @@ async fn oversized_body_returns_413() {
     let resp = router.oneshot(req).await.unwrap();
     assert_eq!(resp.status(), StatusCode::PAYLOAD_TOO_LARGE);
 }
-
-// --- CSRF Tests ---
 
 #[tokio::test]
 async fn csrf_rejects_post_without_header() {
@@ -1218,8 +1186,6 @@ async fn csrf_allows_get_without_header() {
 
     assert_eq!(resp.status(), StatusCode::OK);
 }
-
-// --- OpenAPI Tests ---
 
 #[tokio::test]
 async fn openapi_spec_returns_valid_json() {
@@ -1300,8 +1266,6 @@ async fn openapi_spec_has_schemas() {
     assert!(schemas.contains_key("HealthResponse"));
     assert!(schemas.contains_key("NousStatus"));
 }
-
-// --- Metrics Tests ---
 
 #[tokio::test]
 async fn metrics_returns_200_with_prometheus_content_type() {
@@ -1389,8 +1353,6 @@ async fn metrics_counters_increment_after_request() {
     );
 }
 
-// --- CORS Tests ---
-
 #[tokio::test]
 async fn cors_permissive_when_no_origins_configured() {
     let (state, _dir) = test_state().await;
@@ -1432,8 +1394,6 @@ async fn cors_rejects_unlisted_origin() {
     let allow_origin = resp.headers().get("access-control-allow-origin");
     assert!(allow_origin.is_none() || allow_origin.unwrap() != "http://evil.example.com");
 }
-
-// --- Auth mode "none" bypasses JWT ---
 
 async fn app_auth_disabled() -> (axum::Router, tempfile::TempDir) {
     let (state, dir) = test_state().await;
@@ -1481,8 +1441,6 @@ async fn auth_mode_none_injects_anonymous_identity() {
 
     assert_eq!(resp.status(), StatusCode::OK);
 }
-
-// --- Session list with filter ---
 
 #[tokio::test]
 async fn list_sessions_returns_empty_initially() {
@@ -1541,8 +1499,6 @@ async fn list_sessions_filter_by_nous_id() {
     assert!(sessions2.is_empty());
 }
 
-// --- POST archive endpoint ---
-
 #[tokio::test]
 async fn archive_via_post_returns_204() {
     let (router, _dir) = app().await;
@@ -1570,8 +1526,6 @@ async fn archive_unknown_session_returns_404() {
     assert_eq!(resp.status(), StatusCode::NOT_FOUND);
 }
 
-// --- Create session with unknown nous ---
-
 #[tokio::test]
 async fn create_session_unknown_nous_returns_404() {
     let (app, _dir) = app().await;
@@ -1589,8 +1543,6 @@ async fn create_session_unknown_nous_returns_404() {
     let body = body_json(resp).await;
     assert_eq!(body["error"]["code"], "nous_not_found");
 }
-
-// --- History with before filter ---
 
 #[tokio::test]
 async fn history_before_filter() {
@@ -1628,8 +1580,6 @@ async fn history_before_filter() {
     let messages = body["messages"].as_array().unwrap();
     assert!(messages.iter().all(|m| m["seq"].as_i64().unwrap() < 3));
 }
-
-// --- Stream turn (TUI protocol) ---
 
 #[tokio::test]
 async fn stream_turn_returns_sse() {
@@ -1714,8 +1664,6 @@ async fn stream_turn_unknown_agent_returns_404() {
     assert_eq!(resp.status(), StatusCode::NOT_FOUND);
 }
 
-// --- Events SSE ---
-
 #[tokio::test]
 async fn events_endpoint_returns_sse() {
     // WHY: /api/v1/events is removed (stub replaced with 404) until a real
@@ -1742,8 +1690,6 @@ async fn events_stream_contains_init_event() {
         "events endpoint should return not_implemented code"
     );
 }
-
-// --- Config handler tests ---
 
 #[tokio::test]
 async fn config_get_requires_auth() {
@@ -1799,8 +1745,6 @@ async fn config_update_invalid_section_returns_404() {
     assert_eq!(resp.status(), StatusCode::NOT_FOUND);
 }
 
-// --- Nous tools for unknown nous ---
-
 #[tokio::test]
 async fn nous_tools_unknown_returns_404() {
     let (app, _dir) = app().await;
@@ -1813,8 +1757,6 @@ async fn nous_tools_unknown_returns_404() {
     let body = body_json(resp).await;
     assert_eq!(body["error"]["code"], "nous_not_found");
 }
-
-// --- Nous list auth required ---
 
 #[tokio::test]
 async fn nous_list_requires_auth() {
@@ -1847,8 +1789,6 @@ async fn nous_tools_requires_auth() {
     assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
 }
 
-// --- Config requires auth ---
-
 #[tokio::test]
 async fn config_section_requires_auth() {
     let (app, _dir) = app().await;
@@ -1859,8 +1799,6 @@ async fn config_section_requires_auth() {
     let resp = app.oneshot(req).await.unwrap();
     assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
 }
-
-// --- Gateway config redaction ---
 
 #[tokio::test]
 async fn gateway_config_signing_key_is_redacted() {
@@ -1891,8 +1829,6 @@ async fn gateway_config_signing_key_is_redacted() {
     // Non-secret fields must still be present and correct.
     assert_eq!(body["port"], 18789);
 }
-
-// --- Router: Method Not Allowed ---
 
 #[tokio::test]
 async fn put_on_sessions_returns_405() {
@@ -1936,8 +1872,6 @@ async fn post_on_health_returns_405() {
     assert_eq!(resp.status(), StatusCode::METHOD_NOT_ALLOWED);
 }
 
-// --- Request ID injection ---
-
 #[tokio::test]
 async fn request_id_present_in_error_responses() {
     let (app, _dir) = app().await;
@@ -1951,8 +1885,6 @@ async fn request_id_present_in_error_responses() {
     assert!(!request_id.is_empty());
     assert!(request_id.len() >= 20, "request_id should be a ULID");
 }
-
-// --- SseEvent serialization ---
 
 #[test]
 fn sse_event_type_text_delta() {
@@ -2048,8 +1980,6 @@ fn sse_event_error_serialization() {
     assert_eq!(json["code"], "turn_failed");
     assert_eq!(json["message"], "provider error");
 }
-
-// --- TUI stream event type tests ---
 
 #[test]
 fn tui_event_turn_start_type() {
@@ -2163,8 +2093,6 @@ fn tui_event_turn_complete_serialization() {
     assert_eq!(outcome["cacheReadTokens"], 10);
     assert_eq!(outcome["cacheWriteTokens"], 20);
 }
-
-// --- Error type tests ---
 
 #[test]
 fn api_error_session_not_found_status_code() {
@@ -2327,8 +2255,6 @@ fn api_error_validation_failed_includes_errors() {
     assert_eq!(errors.len(), 2);
 }
 
-// --- SecurityConfig tests ---
-
 #[test]
 fn security_config_default_values() {
     let config = SecurityConfig::default();
@@ -2362,8 +2288,6 @@ fn security_config_from_gateway() {
     assert!(config.csrf_enabled);
     assert_eq!(config.cors_max_age_secs, 3600);
 }
-
-// --- deep_merge tests ---
 
 #[test]
 fn deep_merge_overwrites_scalar() {
@@ -2404,8 +2328,6 @@ fn deep_merge_replaces_non_object_with_object() {
     assert_eq!(base["key"]["nested"], true);
 }
 
-// --- Session response fields ---
-
 #[tokio::test]
 async fn session_response_has_all_expected_fields() {
     let (app, _dir) = app().await;
@@ -2420,8 +2342,6 @@ async fn session_response_has_all_expected_fields() {
     assert!(session["created_at"].is_string());
     assert!(session["updated_at"].is_string());
 }
-
-// --- History response structure ---
 
 #[tokio::test]
 async fn history_messages_have_expected_fields() {
@@ -2459,8 +2379,6 @@ async fn history_messages_have_expected_fields() {
     assert!(msg["created_at"].is_string());
 }
 
-// --- Nous status response fields ---
-
 #[tokio::test]
 async fn nous_status_response_has_all_fields() {
     let (app, _dir) = app().await;
@@ -2476,8 +2394,6 @@ async fn nous_status_response_has_all_fields() {
     assert!(body["max_tool_iterations"].is_number());
     assert!(body["status"].is_string());
 }
-
-// --- CSRF with wrong header value ---
 
 #[tokio::test]
 async fn csrf_rejects_wrong_header_value() {
@@ -2507,8 +2423,6 @@ async fn csrf_rejects_wrong_header_value() {
     let resp = router.oneshot(req).await.unwrap();
     assert_eq!(resp.status(), StatusCode::FORBIDDEN);
 }
-
-// --- CSRF allows DELETE with correct header ---
 
 #[tokio::test]
 async fn csrf_allows_delete_with_correct_header() {
@@ -2555,8 +2469,6 @@ async fn csrf_allows_delete_with_correct_header() {
     let resp = router.clone().oneshot(delete_req).await.unwrap();
     assert_eq!(resp.status(), StatusCode::NO_CONTENT);
 }
-
-// --- Idempotency-Key Tests (#866) ---
 
 /// Helper: build a POST send-message request with an optional Idempotency-Key header.
 fn send_message_req(session_id: &str, idempotency_key: Option<&str>) -> Request<Body> {
@@ -2704,8 +2616,6 @@ async fn idempotency_key_64_chars_accepted() {
     let resp = router.clone().oneshot(req).await.unwrap();
     assert_eq!(resp.status(), StatusCode::OK);
 }
-
-// --- SSE stream correctness tests ---
 
 /// Parse every `data:` line in an SSE body into JSON values.
 ///


### PR DESCRIPTION
## Summary

- **Comment standardization**: deleted all restating/decorative \`//\` comments and section-header separators across \`pylon\`, \`organon\`, \`hermeneus\`, and \`daemon\`; surviving non-obvious rationale comments tagged with \`WHY:\` or \`NOTE:\` prefixes
- **\`#[non_exhaustive]\`**: added to public domain enums that could grow — \`SseEvent\`, \`WebchatEvent\` (pylon); \`ToolResultContent\`, \`ToolResultBlock\`, \`CacheControlType\`, \`CachingStrategy\`, \`ToolChoice\` (hermeneus); \`Schedule\`, \`TaskAction\`, \`BuiltinTask\`, \`AttentionCategory\`, \`Urgency\`, \`DbStatus\` (daemon)
- **Test naming**: renamed 9 test functions in \`organon/registry.rs\` from \`test_*\` prefix to behavior-descriptive names
- **Clippy fix**: collapsed \`else { if … }\` into \`else if\` in \`daemon/maintenance/drift_detection.rs\`
- **Match arm update**: widened exhaustive \`ToolResultContent\` match in \`organon/view_file.rs\` to wildcard after adding \`#[non_exhaustive]\`

## Validation gate

- \`cargo fmt --all -- --check\` ✅
- \`cargo clippy --workspace --all-targets -- -D warnings\` ✅
- \`cargo test -p aletheia-pylon -p aletheia-organon -p aletheia-hermeneus -p aletheia-oikonomos\` — 751 tests, 0 failed ✅

Full \`cargo test --workspace\` hit a disk-space/sccache OOM mid-compilation unrelated to these changes.

## Observations (out of scope)

\`Role\` and \`Content\` in \`hermeneus/src/types.rs\` were candidates for \`#[non_exhaustive]\` but are exhaustively matched in \`crates/melete/src/{prompt,distill}.rs\`. Adding the attribute requires cascade fixes in \`melete\`, which is outside this sweep's blast radius. A follow-up chore targeting \`melete\` should add \`#[non_exhaustive]\` to those two enums and update the downstream matches.

## Test plan

- [x] \`cargo fmt --all -- --check\` — clean
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` — clean
- [x] 4 in-scope crate test suites — 751 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)