### PR TITLE
chore: standards compliance sweep for remaining crates

### DIFF
--- a/crates/agora/src/listener.rs
+++ b/crates/agora/src/listener.rs
@@ -82,7 +82,7 @@ impl ChannelListener {
             }
         }
 
-        // Wait for all in-flight handler tasks to complete.
+        // WHY: wait for all in-flight handler tasks to complete before shutdown
         while let Some(result) = set.join_next().await {
             if let Err(e) = result {
                 tracing::warn!(error = %e, "handler task panicked");
@@ -106,7 +106,7 @@ impl ChannelListener {
             .rx
             .take()
             .expect("into_receiver called on consumed listener");
-        // Take the handles out before Drop can abort them.
+        // WHY: take handles out before Drop to prevent abort of tasks we're joining
         let handles = std::mem::take(&mut self.handles);
         (rx, handles)
     }
@@ -217,14 +217,11 @@ mod tests {
         let (_tx, rx) = mpsc::channel::<InboundMessage>(16);
 
         let handle = tokio::spawn(async {
-            // Simulate a long-running task
             tokio::time::sleep(std::time::Duration::from_secs(300)).await;
         });
 
         let listener = ChannelListener::from_parts(rx, vec![handle]);
         listener.stop();
-
-        // If we get here, the tasks were aborted successfully
     }
 
     #[tokio::test]
@@ -241,10 +238,8 @@ mod tests {
 
         {
             let _listener = ChannelListener::from_parts(rx, vec![handle]);
-            // listener drops here
         }
 
-        // Give the runtime a moment to process the abort
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
 
         assert!(
@@ -264,7 +259,6 @@ mod tests {
         let listener = ChannelListener::from_parts(rx, vec![handle]);
         let (_rx, handles) = listener.into_receiver();
 
-        // Handles are returned — caller can abort them for graceful shutdown.
         assert_eq!(handles.len(), 1);
         for h in &handles {
             h.abort();

--- a/crates/agora/src/router.rs
+++ b/crates/agora/src/router.rs
@@ -22,6 +22,7 @@ pub struct RouteDecision<'a> {
 
 /// How the routing decision was made.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum MatchReason {
     /// Matched by exact group ID binding on a specific channel.
     GroupBinding,
@@ -65,7 +66,7 @@ impl MessageRouter {
     }
 
     fn match_route(&self, msg: &InboundMessage) -> Option<RouteDecision<'_>> {
-        // Priority 1: exact group match (channel + group_id)
+        // NOTE: Priority 1: exact group match (channel + group_id)
         if let Some(group_id) = &msg.group_id {
             for b in &self.bindings {
                 if b.channel == msg.channel && b.source == *group_id {
@@ -78,7 +79,7 @@ impl MessageRouter {
             }
         }
 
-        // Priority 2: exact source match (channel + sender)
+        // NOTE: Priority 2: exact source match (channel + sender)
         for b in &self.bindings {
             if b.channel == msg.channel && b.source == msg.sender {
                 return Some(RouteDecision {
@@ -89,7 +90,7 @@ impl MessageRouter {
             }
         }
 
-        // Priority 3: channel default (source = "*")
+        // NOTE: Priority 3: channel default (source = "*")
         for b in &self.bindings {
             if b.channel == msg.channel && b.source == "*" {
                 return Some(RouteDecision {
@@ -100,7 +101,7 @@ impl MessageRouter {
             }
         }
 
-        // Priority 4: global default
+        // NOTE: Priority 4: global default
         self.default_nous.as_deref().map(|id| RouteDecision {
             nous_id: id,
             session_key: expand_session_key("{source}", msg),

--- a/crates/agora/src/semeion/client.rs
+++ b/crates/agora/src/semeion/client.rs
@@ -91,7 +91,7 @@ impl SignalClient {
             .await
             .context(error::HttpSnafu)?;
 
-        // 201 = accepted, no body (signal-cli convention for fire-and-forget)
+        // NOTE: 201 = accepted, no body (signal-cli convention for fire-and-forget)
         if response.status().as_u16() == 201 {
             return Ok(None);
         }
@@ -279,7 +279,7 @@ impl SendParams {
             );
         }
         if let Some(ref r) = self.recipient {
-            // signal-cli expects recipient as an array
+            // NOTE: signal-cli expects recipient as an array
             map.insert(
                 String::from("recipient"),
                 serde_json::Value::Array(vec![serde_json::Value::String(r.clone())]),
@@ -356,7 +356,6 @@ mod tests {
 
         let value = params.to_rpc_value();
         assert_eq!(value["message"], "hello");
-        // recipient is wrapped in an array
         assert_eq!(value["recipient"], serde_json::json!(["+1234567890"]));
         assert_eq!(value["account"], "+0987654321");
         assert!(value.get("groupId").is_none());
@@ -376,7 +375,6 @@ mod tests {
         let value = params.to_rpc_value();
         assert_eq!(value["message"], "group msg");
         assert!(value.get("recipient").is_none());
-        // group_id mapped to camelCase groupId
         assert_eq!(value["groupId"], "YWJjMTIz");
         assert_eq!(value["attachments"], serde_json::json!(["/tmp/photo.jpg"]));
     }

--- a/crates/agora/src/semeion/connection.rs
+++ b/crates/agora/src/semeion/connection.rs
@@ -7,6 +7,7 @@ use super::client;
 
 /// Connection states for a Signal account.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum ConnectionState {
     /// Signal-cli daemon is reachable.
     Connected,

--- a/crates/agora/src/semeion/mod.rs
+++ b/crates/agora/src/semeion/mod.rs
@@ -30,6 +30,7 @@ const DEFAULT_BUFFER_CAPACITY: usize = 100;
 
 /// Parsed Signal message target.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum SignalTarget {
     /// Direct message to a phone number (e.g., `"+1234567890"`).
     Phone(String),
@@ -237,7 +238,7 @@ impl ChannelProvider for SignalProvider {
                 };
             };
 
-            // Buffer immediately when the connection is known to be unavailable.
+            // WHY: buffer immediately when the connection is known to be unavailable.
             // For Connected state: attempt the send directly — no separate check-then-act,
             // so there is no TOCTOU window. If the connection dropped since we last polled,
             // the HTTP error handler below buffers the message.
@@ -258,8 +259,8 @@ impl ChannelProvider for SignalProvider {
                     error: None,
                 },
                 Err(e) => {
-                    // Buffer on transport failure (covers the case where the
-                    // connection dropped between the state check and this send).
+                    // WHY: buffer on transport failure — handles the case where the connection
+                    // dropped between the state check and this send (no TOCTOU window).
                     if matches!(e, error::Error::Http { .. }) {
                         let mut s = state_mutex.lock().await;
                         s.enqueue(send_params);
@@ -345,7 +346,6 @@ async fn poll_loop(
     loop {
         match signal_client.receive(None).await {
             Ok(envelopes) => {
-                // Restore connection if we were reconnecting.
                 {
                     let mut s = state.lock().await;
                     if s.state != ConnectionState::Connected {

--- a/crates/aletheia/src/cli_tests.rs
+++ b/crates/aletheia/src/cli_tests.rs
@@ -284,8 +284,6 @@ fn init_instance_root_alias_accepted() {
     }
 }
 
-// ── backup subcommand ────────────────────────────────────────────────────────
-
 #[test]
 fn backup_default_parses() {
     let cli = Cli::parse_from(["aletheia", "backup"]);
@@ -347,8 +345,6 @@ fn backup_export_json_flag_parses() {
     }
 }
 
-// ── credential subcommand ────────────────────────────────────────────────────
-
 #[test]
 fn credential_status_parses() {
     let cli = Cli::parse_from(["aletheia", "credential", "status"]);
@@ -370,8 +366,6 @@ fn credential_refresh_parses() {
         })
     ));
 }
-
-// ── tls subcommand ───────────────────────────────────────────────────────────
 
 #[test]
 fn tls_generate_defaults_parses() {
@@ -427,8 +421,6 @@ fn tls_generate_custom_options_parses() {
     }
 }
 
-// ── import subcommand ────────────────────────────────────────────────────────
-
 #[test]
 fn import_minimal_parses() {
     let cli = Cli::parse_from(["aletheia", "import", "/tmp/agent.agent.json"]);
@@ -470,8 +462,6 @@ fn import_with_all_flags_parses() {
     }
 }
 
-// ── completions subcommand ───────────────────────────────────────────────────
-
 #[test]
 fn completions_bash_parses() {
     let cli = Cli::parse_from(["aletheia", "completions", "bash"]);
@@ -494,15 +484,11 @@ fn completions_zsh_parses() {
     ));
 }
 
-// ── check-config subcommand ──────────────────────────────────────────────────
-
 #[test]
 fn check_config_parses() {
     let cli = Cli::parse_from(["aletheia", "check-config"]);
     assert!(matches!(cli.command, Some(Command::CheckConfig)));
 }
-
-// ── add-nous subcommand ──────────────────────────────────────────────────────
 
 #[test]
 fn add_nous_defaults_parses() {

--- a/crates/aletheia/src/commands/add_nous.rs
+++ b/crates/aletheia/src/commands/add_nous.rs
@@ -180,7 +180,6 @@ fn update_config(oikos: &Oikos, args: &AddNousArgs) -> Result<()> {
         .parse()
         .with_context(|| format!("failed to parse {}", config_path.display()))?;
 
-    // Check for duplicate before modifying
     let already_listed = doc
         .get("agents")
         .and_then(|a| a.as_table())
@@ -199,7 +198,6 @@ fn update_config(oikos: &Oikos, args: &AddNousArgs) -> Result<()> {
         );
     }
 
-    // Build the new agent table entry.
     // WHY: workspace is relative to ALETHEIA_ROOT so the config stays portable.
     let workspace = format!("nous/{}", args.name);
     let mut entry = toml_edit::Table::new();
@@ -216,7 +214,6 @@ fn update_config(oikos: &Oikos, args: &AddNousArgs) -> Result<()> {
     );
     entry.insert("model", toml_edit::Item::Table(model_table));
 
-    // Ensure [agents] table exists
     if doc.get("agents").and_then(|i| i.as_table()).is_none() {
         doc.insert("agents", toml_edit::Item::Table(toml_edit::Table::new()));
     }
@@ -225,7 +222,6 @@ fn update_config(oikos: &Oikos, args: &AddNousArgs) -> Result<()> {
         .as_table_mut()
         .ok_or_else(|| anyhow::anyhow!("[agents] in config is not a table"))?;
 
-    // Ensure [[agents.list]] array of tables exists
     if agents
         .get("list")
         .and_then(|i| i.as_array_of_tables())
@@ -243,7 +239,7 @@ fn update_config(oikos: &Oikos, args: &AddNousArgs) -> Result<()> {
 
     list.push(entry);
 
-    // Atomic write: write to .tmp then rename to preserve comments
+    // WHY: atomic write — write to .tmp then rename, preserving existing comments in the file
     std::fs::create_dir_all(&config_dir)
         .with_context(|| format!("failed to create {}", config_dir.display()))?;
     let tmp = config_dir.join("aletheia.toml.tmp");
@@ -394,7 +390,6 @@ mod tests {
         let oikos = Oikos::from_root(dir.path());
         std::fs::create_dir_all(dir.path().join("config")).unwrap();
 
-        // Write a config that has comments and custom formatting
         let original = "# My custom config\n\
             # This comment must survive\n\
             [gateway]\n\
@@ -447,7 +442,6 @@ mod tests {
             result.contains(r#"workspace = "nous/bob""#),
             "workspace path must be relative, got:\n{result}"
         );
-        // Must not contain an absolute path
         assert!(
             !result.contains("/nous/bob"),
             "workspace must not be absolute"
@@ -484,7 +478,7 @@ mod tests {
             model: "claude-sonnet-4-20250514".to_owned(),
         };
 
-        // Use a blocking executor for this test since run() is now async
+        // NOTE: use a blocking executor since run() is async
         let rt = tokio::runtime::Runtime::new().unwrap();
         let result = rt.block_on(run(Some(&dir.path().to_path_buf()), &args));
         assert!(result.is_err());

--- a/crates/aletheia/src/commands/agent_io.rs
+++ b/crates/aletheia/src/commands/agent_io.rs
@@ -5,8 +5,6 @@ use std::path::PathBuf;
 use anyhow::{Context, Result};
 use clap::Args;
 
-// ── Args structs for Command enum ──────────────────────────────────────────
-
 #[derive(Debug, Clone, Args)]
 pub struct ExportArgs {
     /// Agent (nous) ID to export
@@ -333,7 +331,6 @@ pub fn seed_skills(args: &SeedSkillsArgs) -> Result<()> {
 
     println!("Found {} skill(s) in {}", entries.len(), dir.display());
 
-    // Parse all skills first
     let mut parsed: Vec<(String, SkillContent)> = Vec::new();
     let mut parse_errors = 0u32;
     for (slug, content) in &entries {
@@ -365,7 +362,6 @@ pub fn seed_skills(args: &SeedSkillsArgs) -> Result<()> {
         return Ok(());
     }
 
-    // Open knowledge store (in-memory for seeding — caller must configure persistent path)
     #[cfg(feature = "recall")]
     {
         use aletheia_mneme::knowledge::{EpistemicTier, Fact, default_stability_hours};
@@ -380,14 +376,12 @@ pub fn seed_skills(args: &SeedSkillsArgs) -> Result<()> {
         let mut overwritten = 0u32;
 
         for (slug, skill) in &parsed {
-            // Check for duplicates
             let existing = store
                 .find_skill_by_name(nous_id, &skill.name)
                 .map_err(|e| anyhow::anyhow!("failed to query existing skills: {e}"))?;
 
             if let Some(existing_id) = existing {
                 if args.force {
-                    // Supersede the old fact
                     if let Err(e) = store.forget_fact(
                         &aletheia_mneme::id::FactId::from(existing_id),
                         aletheia_mneme::knowledge::ForgetReason::Outdated,
@@ -430,7 +424,6 @@ pub fn seed_skills(args: &SeedSkillsArgs) -> Result<()> {
                 .insert_fact(&fact)
                 .map_err(|e| anyhow::anyhow!("failed to insert skill {slug}: {e}"))?;
 
-            // Generate embedding for semantic search
             let embedding_text = format!("{}: {}", skill.name, skill.description);
             let emb_id = ulid::Ulid::new().to_string();
             let chunk = aletheia_mneme::knowledge::EmbeddedChunk {
@@ -501,7 +494,6 @@ pub fn export_skills(instance_root: Option<&PathBuf>, args: &ExportSkillsArgs) -
             return Ok(());
         }
 
-        // Parse facts into SkillContent
         let mut skills: Vec<SkillContent> = Vec::new();
         let mut parse_errors = 0u32;
         for fact in &facts {
@@ -514,7 +506,6 @@ pub fn export_skills(instance_root: Option<&PathBuf>, args: &ExportSkillsArgs) -
             }
         }
 
-        // Apply domain filter
         let domain_tags: Vec<&str> = args
             .domain
             .as_deref()
@@ -695,24 +686,21 @@ fn generate_simple_embedding(text: &str) -> Vec<f32> {
     let mut hasher = Sha256::new();
     hasher.update(text.as_bytes());
 
-    // Generate enough hash bytes to fill the embedding
     let mut seed = hasher.finalize().to_vec();
     while embedding.len() < dim {
         for byte in &seed {
             if embedding.len() >= dim {
                 break;
             }
-            // Map byte to [-1.0, 1.0] — value is in [-1.0, 1.0] so truncation is harmless
+            // WHY: map byte to [-1.0, 1.0] — value fits without overflow, truncation is harmless
             #[expect(clippy::cast_possible_truncation, reason = "result fits in f32 range")]
             embedding.push((f64::from(*byte) / 127.5 - 1.0) as f32);
         }
-        // Re-hash for more bytes
         let mut h = Sha256::new();
         h.update(&seed);
         seed = h.finalize().to_vec();
     }
 
-    // L2-normalize
     let norm: f32 = embedding.iter().map(|x| x * x).sum::<f32>().sqrt();
     if norm > 0.0 {
         for v in &mut embedding {

--- a/crates/aletheia/src/commands/backup.rs
+++ b/crates/aletheia/src/commands/backup.rs
@@ -128,7 +128,6 @@ pub fn run(instance_root: Option<&PathBuf>, args: &BackupArgs) -> Result<()> {
         return Ok(());
     }
 
-    // Default: create a backup
     let result = manager.create_backup().context("failed to create backup")?;
     println!(
         "Backup created: {} ({} bytes, {} sessions, {} messages)",

--- a/crates/aletheia/src/commands/check_config.rs
+++ b/crates/aletheia/src/commands/check_config.rs
@@ -21,7 +21,6 @@ pub fn run(instance_root: Option<&PathBuf>) -> Result<()> {
 
     let mut all_ok = true;
 
-    // Instance layout check
     match oikos.validate() {
         Ok(()) => println!("  [pass] instance layout"),
         Err(e) => {
@@ -30,7 +29,6 @@ pub fn run(instance_root: Option<&PathBuf>) -> Result<()> {
         }
     }
 
-    // Config load
     let config = match load_config(&oikos) {
         Ok(c) => {
             println!("  [pass] config loaded");
@@ -38,12 +36,10 @@ pub fn run(instance_root: Option<&PathBuf>) -> Result<()> {
         }
         Err(e) => {
             println!("  [FAIL] config load: {e}");
-            // Can't continue without config
             anyhow::bail!("config validation aborted: could not load config");
         }
     };
 
-    // Serialize config for section-by-section validation
     let config_value = match serde_json::to_value(&config) {
         Ok(v) => v,
         Err(e) => {
@@ -52,7 +48,6 @@ pub fn run(instance_root: Option<&PathBuf>) -> Result<()> {
         }
     };
 
-    // Validate each section
     for section in &[
         "agents",
         "gateway",
@@ -75,7 +70,6 @@ pub fn run(instance_root: Option<&PathBuf>) -> Result<()> {
         }
     }
 
-    // Agent workspace paths
     for agent in &config.agents.list {
         match oikos.validate_workspace_path(&agent.workspace) {
             Ok(()) => println!("  [pass] agent '{}' workspace", agent.id),
@@ -86,7 +80,6 @@ pub fn run(instance_root: Option<&PathBuf>) -> Result<()> {
         }
     }
 
-    // JWT key check
     let jwt_key = config
         .gateway
         .auth

--- a/crates/aletheia/src/commands/credential.rs
+++ b/crates/aletheia/src/commands/credential.rs
@@ -66,7 +66,7 @@ pub async fn run(action: Action, instance_root: Option<&PathBuf>) -> Result<()> 
                 );
             }
 
-            // Always check provider env vars, regardless of credential file presence.
+            // WHY: always check provider env vars, regardless of credential file presence
             let env_vars: &[(&str, &str)] = &[
                 ("ANTHROPIC_AUTH_TOKEN", "OAuth token"),
                 ("ANTHROPIC_API_KEY", "static API key"),

--- a/crates/aletheia/src/commands/server.rs
+++ b/crates/aletheia/src/commands/server.rs
@@ -64,21 +64,17 @@ pub async fn run(args: Args) -> Result<()> {
 
     info!("aletheia starting");
 
-    // Root cancellation token — cancelled on SIGTERM/SIGINT.
-    // Child tokens are propagated to every actor and daemon task.
+    // WHY: root cancellation token — child tokens propagated to every actor and daemon task
     let shutdown_token = CancellationToken::new();
 
-    // Oikos — instance directory resolution
     let oikos = match &args.instance_root {
         Some(root) => Oikos::from_root(root),
         None => Oikos::discover(),
     };
     info!(root = %oikos.root().display(), "instance discovered");
 
-    // Startup validation — fail fast before any actors or stores initialise
     oikos.validate().context("instance layout invalid")?;
 
-    // Config cascade: defaults → TOML → env
     let config = load_config(&oikos).context("failed to load config")?;
     info!(
         port = config.gateway.port,
@@ -86,7 +82,6 @@ pub async fn run(args: Args) -> Result<()> {
         "config loaded"
     );
 
-    // Validate all config sections — fail fast before any actors or stores initialise.
     let config_value =
         serde_json::to_value(&config).context("failed to serialize config for validation")?;
     for section in &[
@@ -106,7 +101,6 @@ pub async fn run(args: Args) -> Result<()> {
     }
     info!("config validated");
 
-    // JWT key validation — fail if auth mode requires JWT and the key is still the placeholder.
     let jwt_key = config
         .gateway
         .auth
@@ -126,7 +120,6 @@ pub async fn run(args: Args) -> Result<()> {
         );
     }
 
-    // Validate per-agent workspace paths — fatal if any agent workspace is invalid.
     for agent in &config.agents.list {
         oikos.validate_workspace_path(&agent.workspace).with_context(|| {
             format!(
@@ -136,11 +129,9 @@ pub async fn run(args: Args) -> Result<()> {
         })?;
     }
 
-    // Domain packs — load external knowledge packs declared in config
     let loaded_packs = aletheia_thesauros::loader::load_packs(&config.packs);
     let packs = Arc::new(loaded_packs);
 
-    // Session store
     let db_path = oikos.sessions_db();
     if let Some(parent) = db_path.parent() {
         std::fs::create_dir_all(parent)
@@ -152,17 +143,14 @@ pub async fn run(args: Args) -> Result<()> {
     ));
     info!(path = %db_path.display(), "session store opened");
 
-    // JWT manager — use the resolved key (validated above; placeholder only reaches here when mode="none").
     let jwt_manager = JwtManager::new(JwtConfig {
         signing_key: SecretString::from(effective_jwt_key),
         ..JwtConfig::default()
     });
 
-    // Build shared registries — single instances used by both NousManager and AppState
     let provider_registry = Arc::new(build_provider_registry(&config, &oikos));
     let mut tool_registry = build_tool_registry(&config.sandbox)?;
 
-    // Register domain pack tools alongside builtins
     let tool_errors = aletheia_thesauros::tools::register_pack_tools(&packs, &mut tool_registry);
     for err in &tool_errors {
         warn!(error = %err, "failed to register pack tool");
@@ -171,7 +159,6 @@ pub async fn run(args: Args) -> Result<()> {
     let tool_registry = Arc::new(tool_registry);
     let oikos_arc = Arc::new(oikos);
 
-    // Embedding provider — drives recall query embedding
     let embedding_config = EmbeddingConfig {
         provider: config.embedding.provider.clone(),
         model: config.embedding.model.clone(),
@@ -187,13 +174,10 @@ pub async fn run(args: Args) -> Result<()> {
         "embedding provider created"
     );
 
-    // Cross-nous router for inter-agent messaging
     let cross_router = Arc::new(CrossNousRouter::default());
 
-    // Build signal provider early so it can be shared with tool services
     let signal_provider = build_signal_provider(&config.channels.signal);
 
-    // Build tool services for communication + memory executors
     let (cross_nous, messenger, note_store, blackboard_store, spawn, planning) = {
         let cross_nous: Arc<dyn aletheia_organon::types::CrossNousService> =
             Arc::new(tool_adapters::CrossNousAdapter(Arc::clone(&cross_router)));
@@ -230,7 +214,6 @@ pub async fn run(args: Args) -> Result<()> {
         )
     };
 
-    // Knowledge store for vector search and extraction persistence
     #[cfg(feature = "recall")]
     let knowledge_store = {
         let kb_path = oikos_arc.knowledge_db();
@@ -245,7 +228,6 @@ pub async fn run(args: Args) -> Result<()> {
         info!(path = %kb_path.display(), dim = 384, "knowledge store opened (fjall)");
         Some(store)
     };
-    // Wire vector search from KnowledgeStore
     #[cfg(feature = "recall")]
     let vector_search: Option<Arc<dyn aletheia_nous::recall::VectorSearch>> =
         knowledge_store.as_ref().map(|ks| {
@@ -256,7 +238,6 @@ pub async fn run(args: Args) -> Result<()> {
     #[cfg(not(feature = "recall"))]
     let vector_search: Option<Arc<dyn aletheia_nous::recall::VectorSearch>> = None;
 
-    // Knowledge search adapter for tool layer
     #[cfg(feature = "recall")]
     let knowledge_search: Option<Arc<dyn aletheia_organon::types::KnowledgeSearchService>> =
         knowledge_store.as_ref().map(|ks| {
@@ -281,8 +262,7 @@ pub async fn run(args: Args) -> Result<()> {
         server_tool_config: aletheia_organon::types::ServerToolConfig::default(),
     });
 
-    // Spawn nous actors
-    // Clone knowledge_store Arc before moving into NousManager — needed for daemon executor.
+    // WHY: clone knowledge_store Arc before moving into NousManager — needed for daemon executor
     #[cfg(feature = "recall")]
     let knowledge_store_for_daemon = knowledge_store.clone();
 
@@ -306,7 +286,6 @@ pub async fn run(args: Args) -> Result<()> {
         for agent_def in &config.agents.list {
             let resolved = resolve_nous(&config, &agent_def.id);
 
-            // Merge domains from static config and pack overlays
             let mut domains = resolved.domains.clone();
             for pack in packs.iter() {
                 for d in pack.domains_for_agent(&agent_def.id) {
@@ -346,13 +325,11 @@ pub async fn run(args: Args) -> Result<()> {
         info!(count = nous_manager.count(), "nous actors spawned");
     }
 
-    // Daemon — background maintenance tasks
     let maintenance_config = maintenance::build_config(&oikos_arc, &config.maintenance);
     let daemon_token = shutdown_token.child_token();
     let mut daemon_runner =
         TaskRunner::new("system", daemon_token).with_maintenance(maintenance_config);
 
-    // Wire knowledge maintenance executor when recall feature is enabled
     #[cfg(feature = "recall")]
     if let Some(ks) = knowledge_store_for_daemon.as_ref() {
         let km_executor = Arc::new(
@@ -370,18 +347,14 @@ pub async fn run(args: Args) -> Result<()> {
     );
     info!("daemon started");
 
-    // Wrap in Arc — shared between dispatcher and AppState
     let nous_manager = Arc::new(nous_manager);
 
-    // Signal ready — all actors spawned, safe to accept inbound messages
     nous_manager.ready();
 
-    // Channel registry + inbound dispatch (gated on ready signal)
     let ready_rx = nous_manager.ready_rx();
     let (_channel_registry, _dispatch_handle) =
         start_inbound_dispatch(&config, &nous_manager, ready_rx, signal_provider.as_ref());
 
-    // Daemon runners — per-agent background task scheduling
     let daemon_bridge = Arc::new(daemon_bridge::NousDaemonBridge::new(Arc::clone(
         &nous_manager,
     )));
@@ -419,7 +392,6 @@ pub async fn run(args: Args) -> Result<()> {
         info!(count = config.agents.list.len(), "daemon runners spawned");
     }
 
-    // Pylon HTTP gateway — shares registries with NousManager
     let aletheia_config = aletheia_taxis::loader::load_config(&oikos_arc).unwrap_or_else(|e| {
         tracing::warn!("failed to load config, using defaults: {e}");
         aletheia_taxis::config::AletheiaConfig::default()
@@ -443,7 +415,6 @@ pub async fn run(args: Args) -> Result<()> {
         knowledge_store,
     });
 
-    // Diaporeia MCP server — shares state with pylon, zero overhead.
     let diaporeia_state = Arc::new(aletheia_diaporeia::state::DiaporeiaState {
         session_store: Arc::clone(&state.session_store),
         nous_manager: Arc::clone(&state.nous_manager),
@@ -460,8 +431,7 @@ pub async fn run(args: Args) -> Result<()> {
     let app = build_router(state.clone(), &security).merge(mcp_router);
 
     let port = args.port.unwrap_or(config.gateway.port);
-    // Resolve bind address: CLI flag > config gateway.bind > default 127.0.0.1.
-    // "lan" is a semantic alias for "0.0.0.0" (listen on all interfaces).
+    // NOTE: resolve bind address: CLI flag > config > default 127.0.0.1; "lan" = 0.0.0.0, "localhost" = 127.0.0.1
     let bind_host = args.bind.as_deref().unwrap_or(&config.gateway.bind);
     let bind_addr_str = match bind_host {
         "lan" => "0.0.0.0",
@@ -469,11 +439,11 @@ pub async fn run(args: Args) -> Result<()> {
         other => other,
     };
 
-    // Warn unconditionally when auth is disabled — every request is granted Operator role.
+    // WHY: warn when auth is disabled — every request gets Operator role
     if config.gateway.auth.mode == "none" {
         warn!("auth mode is 'none' -- all requests granted Operator role");
     }
-    // Additionally warn if auth is disabled on a non-localhost bind address.
+    // WHY: additionally warn when auth is disabled on non-localhost — exposes to network
     if config.gateway.auth.mode == "none"
         && bind_addr_str != "127.0.0.1"
         && bind_addr_str != "localhost"
@@ -502,8 +472,6 @@ pub async fn run(args: Args) -> Result<()> {
 
     info!(addr = %bind_addr, "pylon listening");
 
-    // Axum graceful shutdown: wait for OS signal, then cancel root token so
-    // all subsystems observe shutdown simultaneously.
     let token_for_signal = shutdown_token.clone();
     axum::serve(listener, app)
         .with_graceful_shutdown(async move {
@@ -514,21 +482,18 @@ pub async fn run(args: Args) -> Result<()> {
         .await
         .context("server error")?;
 
-    // ── Drain ordering ──────────────────────────────────────────────────────
+    // WHY: drain order matters —
     // 1. HTTP server has stopped accepting new requests (axum graceful_shutdown).
     // 2. Root token is cancelled — daemon tasks observe it and exit their loops.
     // 3. Wait for system daemon to finish in-flight maintenance work.
     // 4. Drain nous actors with a timeout, flushing fjall WAL and other state.
     //    Awaiting join handles ensures Arc<Database> drops, checkpointing the WAL.
     // 5. Drop AppState (session store, registries).
-    // ────────────────────────────────────────────────────────────────────────
 
     info!("shutting down");
 
     let shutdown_timeout = std::time::Duration::from_secs(10);
 
-    // Step 2–3: daemon runners have already observed token cancel via child tokens.
-    // Await system daemon handle to confirm it has exited.
     match tokio::time::timeout(shutdown_timeout, daemon_handle).await {
         Ok(Ok(())) => {}
         Ok(Err(e)) => warn!(error = %e, "system daemon panicked during shutdown"),
@@ -538,10 +503,8 @@ pub async fn run(args: Args) -> Result<()> {
         ),
     }
 
-    // Step 4: drain nous actors — cancel tokens fire, messages drain, WAL flushed.
     state.nous_manager.drain(shutdown_timeout).await;
 
-    // Step 5: AppState and session store drop here as `state` goes out of scope.
     drop(state);
 
     info!("shutdown complete");
@@ -573,38 +536,34 @@ fn build_provider_registry(
             })
             .collect();
 
-    // Build credential chain: file (with refresh) → env
     let cred_file = oikos.credentials().join("anthropic.json");
     let mut chain: Vec<Box<dyn CredentialProvider>> = Vec::new();
 
-    if cred_file.exists() {
-        // Check if file has a refresh token for OAuth mode
-        if let Some(cred) = CredentialFile::load(&cred_file) {
-            if cred.has_refresh_token() {
-                if let Some(refreshing) = RefreshingCredentialProvider::new(cred_file.clone()) {
-                    info!(path = %cred_file.display(), "credential file found (OAuth auto-refresh)");
-                    chain.push(Box::new(refreshing));
-                } else {
-                    info!(path = %cred_file.display(), "credential file found (static)");
-                    chain.push(Box::new(FileCredentialProvider::new(cred_file.clone())));
-                }
+    if cred_file.exists()
+        && let Some(cred) = CredentialFile::load(&cred_file)
+    {
+        if cred.has_refresh_token() {
+            if let Some(refreshing) = RefreshingCredentialProvider::new(cred_file.clone()) {
+                info!(path = %cred_file.display(), "credential file found (OAuth auto-refresh)");
+                chain.push(Box::new(refreshing));
             } else {
-                info!(path = %cred_file.display(), "credential file found (static API key)");
+                info!(path = %cred_file.display(), "credential file found (static)");
                 chain.push(Box::new(FileCredentialProvider::new(cred_file.clone())));
             }
+        } else {
+            info!(path = %cred_file.display(), "credential file found (static API key)");
+            chain.push(Box::new(FileCredentialProvider::new(cred_file.clone())));
         }
     }
 
-    // ANTHROPIC_AUTH_TOKEN is the Claude Code OAuth convention — always treat as OAuth
+    // NOTE: ANTHROPIC_AUTH_TOKEN is the Claude Code OAuth convention — always treat as OAuth
     chain.push(Box::new(EnvCredentialProvider::with_source(
         "ANTHROPIC_AUTH_TOKEN",
         CredentialSource::OAuth,
     )));
-    // ANTHROPIC_API_KEY: auto-detects OAuth tokens by sk-ant-oat prefix
+    // NOTE: ANTHROPIC_API_KEY auto-detects OAuth tokens by sk-ant-oat prefix
     chain.push(Box::new(EnvCredentialProvider::new("ANTHROPIC_API_KEY")));
 
-    // Claude Code credentials file — lowest priority in the chain.
-    // Enabled when credential.source is "auto" (default) or "claude-code".
     let cred_source = config.credential.source.as_str();
     if matches!(cred_source, "auto" | "claude-code") {
         let cc_path = config
@@ -618,7 +577,6 @@ fn build_provider_registry(
             if let Some(provider) = claude_code_provider(&path) {
                 chain.push(provider);
             } else if cred_source == "claude-code" {
-                // Explicit claude-code source but file missing/invalid — warn loudly
                 warn!(
                     path = %path.display(),
                     "credential.source is \"claude-code\" but credentials file not found or invalid"
@@ -629,7 +587,6 @@ fn build_provider_registry(
 
     let credential_chain: Arc<dyn CredentialProvider> = Arc::new(CredentialChain::new(chain));
 
-    // Resolve once at startup for logging
     if let Some(cred) = credential_chain.get_credential() {
         info!(source = %cred.source, "credential resolved");
     } else {
@@ -804,8 +761,6 @@ async fn shutdown_signal() {
         () = terminate => info!("received SIGTERM"),
     }
 }
-
-// -- Tool service adapters -------------------------------------------------
 
 mod tool_adapters {
     use std::future::Future;

--- a/crates/aletheia/src/commands/tls.rs
+++ b/crates/aletheia/src/commands/tls.rs
@@ -62,7 +62,6 @@ fn generate_certs(output_dir: &Path, days: u32, sans: &[String], force: bool) ->
         .push(rcgen::DnType::CommonName, "Aletheia Dev");
     params.not_after = rcgen::date_time_ymd(2030, 1, 1);
 
-    // Override validity if days is reasonable
     if days < 3650 {
         let now = time::OffsetDateTime::now_utc();
         let end = now + time::Duration::days(i64::from(days));
@@ -79,7 +78,7 @@ fn generate_certs(output_dir: &Path, days: u32, sans: &[String], force: bool) ->
     std::fs::write(&key_path, key_pair.serialize_pem())
         .with_context(|| format!("failed to write {}", key_path.display()))?;
 
-    // Restrict private key to owner-read-only (0600) — readable only by the process owner.
+    // WHY: restrict private key to owner-read-only (0600) — security requirement
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;

--- a/crates/aletheia/src/dispatch.rs
+++ b/crates/aletheia/src/dispatch.rs
@@ -24,7 +24,6 @@ pub fn spawn_dispatcher(
     let span = tracing::info_span!("message_dispatcher");
     tokio::spawn(
         async move {
-            // Wait for ready signal before processing messages
             while !*ready_rx.borrow_and_update() {
                 if ready_rx.changed().await.is_err() {
                     warn!("ready channel dropped before ready signal");

--- a/crates/aletheia/src/init.rs
+++ b/crates/aletheia/src/init.rs
@@ -112,7 +112,7 @@ pub(crate) fn run(args: RunArgs) -> Result<(), InitError> {
     let is_non_interactive = non_interactive || yes;
 
     let answers = if non_interactive {
-        // Strict non-interactive: --instance-path is required; everything else has defaults.
+        // NOTE: strict non-interactive: --instance-path is required; everything else has defaults
         let root = root.ok_or_else(|| {
             NonInteractiveMissingFlagSnafu {
                 missing: "--instance-path (or env ALETHEIA_INSTANCE_PATH)".to_owned(),
@@ -134,7 +134,7 @@ pub(crate) fn run(args: RunArgs) -> Result<(), InitError> {
             ..Answers::default()
         }
     } else if yes {
-        // Lenient non-interactive: skip prompts, apply defaults for missing values.
+        // NOTE: lenient non-interactive: skip prompts, apply defaults for missing values
         let root = root.unwrap_or_else(|| PathBuf::from("./instance"));
 
         if api_key.is_none() {
@@ -151,7 +151,6 @@ pub(crate) fn run(args: RunArgs) -> Result<(), InitError> {
             ..Answers::default()
         }
     } else {
-        // Interactive mode.
         let root = root.unwrap_or_else(|| PathBuf::from("./instance"));
         collect_interactive(Answers {
             root,
@@ -160,7 +159,6 @@ pub(crate) fn run(args: RunArgs) -> Result<(), InitError> {
         })?
     };
 
-    // Pre-check: existing instance
     let config_path = answers.root.join("config/aletheia.toml");
     if config_path.exists() {
         if is_non_interactive {
@@ -302,7 +300,6 @@ fn collect_credential() -> Result<Option<String>, InitError> {
 fn scaffold(answers: &Answers) -> Result<(), InitError> {
     let root = &answers.root;
 
-    // Create directories
     let dirs = [
         root.join("config/credentials"),
         root.join(format!("nous/{}", answers.agent_id)),
@@ -314,14 +311,12 @@ fn scaffold(answers: &Answers) -> Result<(), InitError> {
         std::fs::create_dir_all(dir).context(CreateDirSnafu { path: dir.clone() })?;
     }
 
-    // Write config
     let config_toml = render_config(answers);
     let config_path = root.join("config/aletheia.toml");
     std::fs::write(&config_path, config_toml).context(WriteFileSnafu {
         path: config_path.clone(),
     })?;
 
-    // Write credential
     if let Some(ref key) = answers.api_key {
         let cred_path = root.join(format!("config/credentials/{}.json", answers.api_provider));
         let cred_json = serde_json::json!({ "token": key });
@@ -332,7 +327,6 @@ fn scaffold(answers: &Answers) -> Result<(), InitError> {
         set_permissions(&cred_path, 0o600)?;
     }
 
-    // Write SOUL.md
     let soul = format!(
         "# {name}\n\n\
          You are {name}, an Aletheia cognitive agent.\n\n\
@@ -484,7 +478,6 @@ mod tests {
     fn default_answers_produce_valid_config() {
         let answers = Answers::default();
         let toml_str = render_config(&answers);
-        // Should be valid TOML that can be parsed
         let value: toml::Value =
             toml::from_str(&toml_str).expect("rendered config should be valid TOML");
         let gateway = value.get("gateway").expect("has gateway");
@@ -549,14 +542,12 @@ mod tests {
         assert!(dir.path().join("logs/traces").is_dir());
         assert!(dir.path().join("shared/coordination").is_dir());
 
-        // Credential should contain the key
         let cred: serde_json::Value = serde_json::from_str(
             &std::fs::read_to_string(dir.path().join("config/credentials/anthropic.json")).unwrap(),
         )
         .unwrap();
         assert_eq!(cred["token"].as_str(), Some("sk-ant-test-key"));
 
-        // SOUL.md should contain agent name
         let soul = std::fs::read_to_string(dir.path().join("nous/main/SOUL.md")).unwrap();
         assert!(soul.contains("Main"));
     }
@@ -603,8 +594,6 @@ mod tests {
         let mode = std::fs::metadata(&cred_path).unwrap().permissions().mode();
         assert_eq!(mode & 0o777, 0o600, "credential file should be 0600");
     }
-
-    // --- Non-interactive integration tests ---
 
     #[test]
     fn non_interactive_creates_valid_instance() {
@@ -703,8 +692,7 @@ mod tests {
     #[test]
     fn yes_flag_uses_default_instance_path() {
         let dir = tempfile::tempdir().unwrap();
-        // -y without explicit path: creates ./instance inside tmp — we provide a path
-        // here to avoid writing to the real cwd.
+        // NOTE: provide explicit path to avoid writing to real cwd
         let result = run(RunArgs {
             root: Some(dir.path().to_path_buf()),
             yes: true,

--- a/crates/aletheia/src/knowledge_adapter.rs
+++ b/crates/aletheia/src/knowledge_adapter.rs
@@ -49,7 +49,6 @@ impl KnowledgeSearchService for KnowledgeSearchAdapter {
                 .await
                 .map_err(|e| format!("hybrid search failed: {e}"))?;
 
-            // Resolve fact content from IDs via a point-in-time query
             let now = jiff::Zoned::now()
                 .strftime("%Y-%m-%dT%H:%M:%SZ")
                 .to_string();
@@ -96,7 +95,6 @@ impl KnowledgeSearchService for KnowledgeSearchAdapter {
                 .to_string();
             let new_id = format!("fact-{}", ulid::Ulid::new());
 
-            // Mark old fact as superseded
             let retract_script = r"
                 ?[id, valid_from, content, nous_id, confidence, tier, valid_to, superseded_by, source_session_id, recorded_at,
                   access_count, last_accessed_at, stability_hours, fact_type,
@@ -127,7 +125,6 @@ impl KnowledgeSearchService for KnowledgeSearchAdapter {
                 .run_mut_query(retract_script, params)
                 .map_err(|e| format!("failed to supersede old fact: {e}"))?;
 
-            // Insert corrected fact
             let ts_now = jiff::Timestamp::now();
             let new_fact = Fact {
                 id: aletheia_mneme::id::FactId::from(new_id.as_str()),
@@ -278,7 +275,6 @@ impl KnowledgeSearchService for KnowledgeSearchAdapter {
         let row_limit = row_limit.unwrap_or(100);
         let timeout = timeout_secs.map(std::time::Duration::from_secs_f64);
         Box::pin(async move {
-            // Convert JSON params to BTreeMap<String, DataValue>
             let mut cozo_params = std::collections::BTreeMap::new();
             if let Some(serde_json::Value::Object(map)) = params {
                 for (k, v) in map {

--- a/crates/aletheia/src/knowledge_maintenance.rs
+++ b/crates/aletheia/src/knowledge_maintenance.rs
@@ -54,7 +54,6 @@ impl KnowledgeMaintenanceExecutor for KnowledgeMaintenanceAdapter {
         for mut fact in facts {
             items_processed += 1;
 
-            // Compute age in hours from last access (or recorded_at if never accessed).
             let reference_time = fact.last_accessed_at.unwrap_or(fact.recorded_at);
             let age_secs = now.duration_since(reference_time).as_secs();
             #[expect(
@@ -67,7 +66,6 @@ impl KnowledgeMaintenanceExecutor for KnowledgeMaintenanceAdapter {
             let decay_score =
                 engine.score_decay(age_hours, fact_type, fact.tier, fact.access_count);
 
-            // Only update if decay score is meaningfully lower than current confidence.
             let new_confidence = (fact.confidence * decay_score).clamp(0.0, 1.0);
             if (fact.confidence - new_confidence).abs() > 0.01 {
                 fact.confidence = new_confidence;

--- a/crates/aletheia/src/status.rs
+++ b/crates/aletheia/src/status.rs
@@ -41,7 +41,6 @@ pub async fn run(url: &str, instance_root: Option<&std::path::PathBuf>) -> Resul
     println!("{}", "═".repeat(30));
     println!();
 
-    // Try to connect to pylon
     let health = fetch_health(url).await;
     let nous_list = fetch_nous(url).await;
 
@@ -59,7 +58,6 @@ pub async fn run(url: &str, instance_root: Option<&std::path::PathBuf>) -> Resul
         print_nous(&list, use_color);
     }
 
-    // Disk stats
     let oikos = match instance_root {
         Some(root) => aletheia_taxis::oikos::Oikos::from_root(root),
         None => aletheia_taxis::oikos::Oikos::discover(),

--- a/crates/dianoia/src/plan.rs
+++ b/crates/dianoia/src/plan.rs
@@ -145,11 +145,9 @@ mod tests {
         let mut dependent = Plan::new("dependent".into(), "wave 2".into(), 2);
         dependent.depends_on = vec![first.id, second.id];
 
-        // Wave 1 plans have no deps — always ready
         assert!(first.is_ready(&[]));
         assert!(second.is_ready(&[]));
 
-        // Wave 2 not ready until wave 1 complete
         assert!(!dependent.is_ready(&[]));
         assert!(!dependent.is_ready(&[first.id]));
         assert!(dependent.is_ready(&[first.id, second.id]));

--- a/crates/dianoia/src/project.rs
+++ b/crates/dianoia/src/project.rs
@@ -119,7 +119,7 @@ mod tests {
             "syn".into(),
         );
         let before = project.updated_at;
-        // Small sleep to ensure timestamp differs
+        // WHY: small sleep to ensure timestamp differs between state transitions
         std::thread::sleep(std::time::Duration::from_millis(2));
         project.advance(Transition::StartQuestioning).unwrap();
         assert_eq!(project.state, ProjectState::Questioning);
@@ -237,7 +237,6 @@ mod tests {
             ProjectMode::Full,
             "syn".into(),
         );
-        // Created -> StartExecution is invalid
         let result = project.advance(Transition::StartExecution);
         assert!(result.is_err());
         assert_eq!(project.state, ProjectState::Created);

--- a/crates/dianoia/src/state.rs
+++ b/crates/dianoia/src/state.rs
@@ -70,7 +70,6 @@ impl ProjectState {
     /// if the transition is invalid from the current state.
     pub fn transition(self, t: Transition) -> Result<Self> {
         match (&self, &t) {
-            // Unique forward transitions
             (Self::Created, Transition::StartQuestioning) => Ok(Self::Questioning),
             (Self::Questioning, Transition::StartResearch) => Ok(Self::Researching),
             (Self::Scoping, Transition::StartPlanning) => Ok(Self::Planning),
@@ -78,15 +77,12 @@ impl ProjectState {
             (Self::Executing, Transition::StartVerification) => Ok(Self::Verifying),
             (Self::Verifying, Transition::Complete) => Ok(Self::Complete),
 
-            // Multiple paths to Scoping
             (Self::Created, Transition::SkipToResearch)
             | (Self::Questioning, Transition::SkipResearch)
             | (Self::Researching, Transition::StartScoping) => Ok(Self::Scoping),
 
-            // Multiple paths to Executing
             (Self::Planning | Self::Discussing, Transition::StartExecution) => Ok(Self::Executing),
 
-            // Revert from verification to an earlier phase
             (
                 Self::Verifying,
                 Transition::Revert {
@@ -94,7 +90,6 @@ impl ProjectState {
                 },
             ) => Ok(to.clone()),
 
-            // Pause from any pausable state
             (
                 Self::Researching
                 | Self::Scoping
@@ -106,10 +101,8 @@ impl ProjectState {
                 previous: Box::new(self),
             }),
 
-            // Resume returns to the state before pause
             (Self::Paused { previous }, Transition::Resume) => Ok(*previous.clone()),
 
-            // Abandon from any non-terminal state
             (
                 Self::Created
                 | Self::Questioning
@@ -123,7 +116,6 @@ impl ProjectState {
                 Transition::Abandon,
             ) => Ok(Self::Abandoned),
 
-            // Terminal states and all invalid transitions
             _ => {
                 ensure!(
                     false,

--- a/crates/diaporeia/src/error.rs
+++ b/crates/diaporeia/src/error.rs
@@ -75,11 +75,11 @@ impl From<Error> for rmcp::ErrorData {
     fn from(err: Error) -> Self {
         let message = crate::sanitize::strip_paths(&err.to_string());
         match &err {
-            // Client provided an invalid agent or session ID — tell them what wasn't found.
+            // NOTE: client provided an invalid agent or session ID — include what wasn't found
             Error::NousNotFound { .. } | Error::SessionNotFound { .. } => {
                 rmcp::ErrorData::invalid_params(message, None)
             }
-            // Server-side failures — expose a sanitized message, never internal details.
+            // WHY: server-side failures expose only a sanitized message, never internal details
             Error::Pipeline { .. }
             | Error::SessionStore { .. }
             | Error::Serialization { .. }

--- a/crates/diaporeia/src/resources/nous.rs
+++ b/crates/diaporeia/src/resources/nous.rs
@@ -57,7 +57,7 @@ pub(crate) fn read_resource(
 ) -> Result<Vec<ResourceContents>, rmcp::ErrorData> {
     let uri = params.uri.as_str();
 
-    // Parse: aletheia://nous/{nous_id}/{file}
+    // NOTE: parse URI format: aletheia://nous/{nous_id}/{file}
     let path = uri
         .strip_prefix("aletheia://nous/")
         .ok_or_else(|| rmcp::ErrorData::invalid_params("invalid nous resource URI", None))?;

--- a/crates/diaporeia/src/sanitize.rs
+++ b/crates/diaporeia/src/sanitize.rs
@@ -22,7 +22,7 @@ pub(crate) fn strip_paths(message: &str) -> String {
             break;
         };
 
-        // The byte immediately before this '/': either within `remaining`, or
+        // NOTE: the byte immediately before this '/': either within `remaining`, or
         // the last byte emitted by a previous iteration.
         let prev_byte = if slash_pos > 0 {
             remaining.as_bytes().get(slash_pos - 1).copied()
@@ -30,7 +30,7 @@ pub(crate) fn strip_paths(message: &str) -> String {
             last_pushed_byte
         };
 
-        // Skip `/` that follows another `/` or `:` — those are URI separators.
+        // WHY: skip '/' that follows '/' or ':' — those are URI separators, not paths
         let is_word_boundary = !matches!(prev_byte, Some(b'/' | b':'));
 
         let after_slash = &remaining[slash_pos + 1..];
@@ -40,12 +40,10 @@ pub(crate) fn strip_paths(message: &str) -> String {
             .is_some_and(|c| c.is_alphanumeric() || matches!(c, '_' | '-' | '.'));
 
         if is_word_boundary && next_is_path_char {
-            // Emit everything before the slash, then the replacement.
             result.push_str(&remaining[..slash_pos]);
             result.push_str("[server path]");
             last_pushed_byte = Some(b']');
 
-            // Advance past the entire path token (including any embedded slashes).
             let path_len = after_slash
                 .find(|c: char| !c.is_alphanumeric() && !matches!(c, '/' | '_' | '-' | '.'))
                 .unwrap_or(after_slash.len());
@@ -82,7 +80,7 @@ mod tests {
 
     #[test]
     fn preserves_uri_scheme_double_slash() {
-        // `://` must not be treated as a path boundary — the ':' preceding '/'
+        // NOTE: `://` must not be treated as a path boundary — the ':' preceding '/'
         // means no boundary, and last_pushed_byte carries that across iterations.
         let msg = "unknown resource URI: aletheia://nous/agent1/soul";
         let sanitized = strip_paths(msg);
@@ -94,7 +92,7 @@ mod tests {
 
     #[test]
     fn double_slash_prefix_is_not_a_path() {
-        // A string starting with `//` is not a Unix absolute path.
+        // NOTE: a string starting with `//` is not a Unix absolute path.
         let sanitized = strip_paths("//see-the-docs");
         assert!(
             !sanitized.contains("[server path]"),
@@ -128,7 +126,7 @@ mod tests {
 
     #[test]
     fn handles_bare_slash_at_end() {
-        // A lone trailing '/' with nothing after it should not be treated as a path.
+        // NOTE: a lone trailing '/' with nothing after it should not be treated as a path.
         let msg = "root is /";
         let sanitized = strip_paths(msg);
         assert_eq!(

--- a/crates/diaporeia/src/server.rs
+++ b/crates/diaporeia/src/server.rs
@@ -35,7 +35,7 @@ impl DiaporeiaServer {
     }
 }
 
-// Type alias used by `get_info` — rmcp uses this name for the return.
+// NOTE: type alias required by rmcp — get_info must return this exact name
 type ServerInfo = InitializeResult;
 
 #[tool_handler]
@@ -75,8 +75,7 @@ impl rmcp::handler::server::ServerHandler for DiaporeiaServer {
         _params: Option<rmcp::model::PaginatedRequestParams>,
         _context: rmcp::service::RequestContext<rmcp::RoleServer>,
     ) -> Result<ListResourcesResult, rmcp::ErrorData> {
-        // TODO(#1136): Enumerate nous and config resources dynamically when the
-        // v1.5 resource registry is implemented. Static resources use read_resource.
+        // NOTE: static resources only — dynamic listing deferred
         Ok(ListResourcesResult {
             resources: vec![],
             next_cursor: None,

--- a/crates/diaporeia/src/tools/mod.rs
+++ b/crates/diaporeia/src/tools/mod.rs
@@ -19,8 +19,6 @@ use crate::server::DiaporeiaServer;
 /// used by the `#[tool_handler]` on the `ServerHandler` impl.
 #[tool_router(vis = "pub(crate)")]
 impl DiaporeiaServer {
-    // -- Session tools --
-
     /// Create a new session for a nous agent. Returns session metadata as JSON.
     #[tool(description = "Create a new session for a nous agent")]
     async fn session_create(
@@ -152,8 +150,6 @@ impl DiaporeiaServer {
         )]))
     }
 
-    // -- Nous tools --
-
     /// List all registered nous agents with their current status.
     #[tool(description = "List all registered nous agents with their current status")]
     async fn nous_list(&self) -> Result<CallToolResult, rmcp::ErrorData> {
@@ -260,8 +256,6 @@ impl DiaporeiaServer {
         )]))
     }
 
-    // -- Knowledge tools --
-
     /// Semantic search across the knowledge graph.
     #[tool(description = "Semantic search across the knowledge graph")]
     async fn knowledge_search(
@@ -276,8 +270,6 @@ impl DiaporeiaServer {
                 .to_string(),
         )]))
     }
-
-    // -- Config tools --
 
     /// Get the runtime configuration with sensitive fields redacted.
     #[tool(description = "Get the runtime configuration with sensitive fields redacted")]
@@ -311,8 +303,6 @@ impl DiaporeiaServer {
             json,
         )]))
     }
-
-    // -- System tools --
 
     /// System health check with uptime, actor health, and version info.
     #[tool(description = "System health check with uptime, actor health, and version info")]

--- a/crates/diaporeia/src/tools/params.rs
+++ b/crates/diaporeia/src/tools/params.rs
@@ -5,8 +5,6 @@
 use schemars::JsonSchema;
 use serde::Deserialize;
 
-// -- Session params --
-
 /// Parameters for creating a session.
 #[derive(Debug, Deserialize, JsonSchema)]
 pub(crate) struct SessionCreateParams {
@@ -43,16 +41,12 @@ pub(crate) struct SessionHistoryParams {
     pub limit: Option<i64>,
 }
 
-// -- Nous params --
-
 /// Parameters for querying a specific nous agent.
 #[derive(Debug, Deserialize, JsonSchema)]
 pub(crate) struct NousIdParam {
     /// The nous agent ID.
     pub nous_id: String,
 }
-
-// -- Knowledge params --
 
 /// Parameters for knowledge search.
 #[derive(Debug, Deserialize, JsonSchema)]

--- a/crates/eval/src/client.rs
+++ b/crates/eval/src/client.rs
@@ -34,8 +34,6 @@ impl EvalClient {
         &self.base_url
     }
 
-    // --- Health (no auth) ---
-
     /// Check instance health.
     #[instrument(skip(self))]
     pub async fn health(&self) -> Result<HealthResponse> {
@@ -43,8 +41,6 @@ impl EvalClient {
         let resp = self.http.get(&url).send().await.context(error::HttpSnafu)?;
         self.expect_ok(&url, resp).await
     }
-
-    // --- Nous ---
 
     /// List all configured nous agents.
     #[instrument(skip(self))]
@@ -62,8 +58,6 @@ impl EvalClient {
         let resp = self.authed_get(&url).await?;
         self.expect_ok(&url, resp).await
     }
-
-    // --- Sessions ---
 
     /// Create a new session bound to a nous agent.
     #[instrument(skip(self))]
@@ -110,8 +104,6 @@ impl EvalClient {
         Ok(())
     }
 
-    // --- Messages ---
-
     /// Send a message and collect the full SSE response.
     #[instrument(skip(self, content))]
     pub async fn send_message(
@@ -145,8 +137,6 @@ impl EvalClient {
         let resp = self.authed_get(&url).await?;
         self.expect_ok(&url, resp).await
     }
-
-    // --- Raw requests (for auth-testing scenarios) ---
 
     /// Send a GET request without any auth header.
     #[instrument(skip(self))]
@@ -184,8 +174,6 @@ impl EvalClient {
             .await
             .context(error::HttpSnafu)
     }
-
-    // --- Internal helpers ---
 
     async fn authed_get(&self, url: &str) -> Result<reqwest::Response> {
         let mut req = self.http.get(url);
@@ -246,8 +234,6 @@ impl EvalClient {
     }
 }
 
-// --- Typed domain enums ---
-
 /// Status reported by the `/api/health` endpoint.
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(rename_all = "lowercase")]
@@ -284,8 +270,6 @@ pub enum MessageRole {
     #[serde(untagged)]
     Unknown(String),
 }
-
-// --- Response types (local mirrors, no pylon dependency) ---
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct HealthResponse {

--- a/crates/eval/src/report.rs
+++ b/crates/eval/src/report.rs
@@ -139,6 +139,7 @@ pub fn print_report_json(report: &RunReport) {
 /// Typed outcome kind for JSON serialization — avoids bare "passed"/"failed"/"skipped" strings.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "lowercase")]
+#[non_exhaustive]
 pub enum OutcomeKind {
     Passed,
     Failed,

--- a/crates/eval/src/runner.rs
+++ b/crates/eval/src/runner.rs
@@ -60,11 +60,9 @@ impl ScenarioRunner {
             None => all_scenarios,
         };
 
-        // Pre-flight: check connectivity
         let health = self.client.health().await.ok();
         let has_token = self.client.has_token();
 
-        // Check if any nous agents are configured
         let has_nous = if has_token {
             self.client
                 .list_nous()
@@ -93,7 +91,6 @@ impl ScenarioRunner {
         for (i, scenario) in scenarios.iter().enumerate() {
             let meta = scenario.meta();
 
-            // Pre-check: skip if prerequisites aren't met
             if health.is_none() {
                 results.push(ScenarioResult {
                     meta: meta.clone(),
@@ -169,8 +166,7 @@ impl ScenarioRunner {
             }
         }
 
-        // When fail_fast triggered, include remaining scenarios as skipped so that
-        // passed + failed + skipped == total. Omitting them makes counts inconsistent.
+        // WHY: when fail_fast triggers, mark remaining as skipped so passed + failed + skipped == total
         if let Some(remaining_start) = fail_fast_idx {
             for scenario in &scenarios[remaining_start..] {
                 results.push(ScenarioResult {

--- a/crates/eval/src/sse.rs
+++ b/crates/eval/src/sse.rs
@@ -28,12 +28,11 @@ pub fn parse_sse_text(text: &str) -> Result<Vec<ParsedSseEvent>> {
 
     for line in text.lines() {
         if line.starts_with(':') {
-            // Comment / keepalive — skip
             continue;
         }
 
         if line.is_empty() {
-            // Empty line = event boundary
+            // NOTE: empty line signals SSE event boundary per the spec
             if !current_event_type.is_empty() && !current_data.is_empty() {
                 match serde_json::from_str::<serde_json::Value>(&current_data) {
                     Ok(data) => {
@@ -74,7 +73,7 @@ pub fn parse_sse_text(text: &str) -> Result<Vec<ParsedSseEvent>> {
         }
     }
 
-    // Handle trailing event without final blank line
+    // NOTE: handle trailing event without final blank line
     if !current_event_type.is_empty() && !current_data.is_empty() {
         match serde_json::from_str::<serde_json::Value>(&current_data) {
             Ok(data) => {
@@ -227,9 +226,7 @@ mod tests {
         let events = parse_sse_text(input).expect("parse");
         assert_eq!(events.len(), 1);
         assert_eq!(events[0].event_type, "text_delta");
-        // Two data lines should be joined with newline
-        let raw = format!("{}", events[0].data);
-        assert!(raw.contains("hello"));
+        assert!(format!("{}", events[0].data).contains("hello"));
     }
 
     #[test]
@@ -317,7 +314,7 @@ data: {\"stop_reason\":\"end_turn\",\"usage\":{\"input_tokens\":100,\"output_tok
     fn malformed_json_event_skipped_parsing_continues() {
         let input = "event: foo\ndata: not-json\n\nevent: text_delta\ndata: {\"text\":\"ok\"}\n\n";
         let events = parse_sse_text(input).expect("parse should succeed");
-        // Malformed event is skipped; valid subsequent event is preserved
+        // NOTE: malformed event is skipped; valid subsequent event is preserved
         assert_eq!(events.len(), 1);
         assert_eq!(events[0].event_type, "text_delta");
     }
@@ -331,9 +328,7 @@ data: {\"stop_reason\":\"end_turn\",\"usage\":{\"input_tokens\":100,\"output_tok
 
     #[test]
     fn whitespace_only_between_events() {
-        // Lines with only whitespace are not "empty" per str::lines, so they don't trigger
-        // event boundaries the same way. This tests that events separated by truly empty
-        // lines still parse correctly even if there's whitespace around them.
+        // NOTE: lines with only whitespace don't trigger event boundaries the same way as truly empty lines
         let input = "event: text_delta\ndata: {\"text\":\"a\"}\n\nevent: text_delta\ndata: {\"text\":\"b\"}\n\n";
         let events = parse_sse_text(input).expect("parse");
         assert_eq!(events.len(), 2);

--- a/crates/koina/src/error.rs
+++ b/crates/koina/src/error.rs
@@ -83,7 +83,7 @@ mod tests {
             path: PathBuf::from("/nonexistent/path"),
         });
         let err = err.unwrap_err();
-        // snafu chains preserve the source
+        // NOTE: snafu chains preserve the source error
         assert!(std::error::Error::source(&err).is_some());
     }
 

--- a/crates/koina/src/id.rs
+++ b/crates/koina/src/id.rs
@@ -190,8 +190,6 @@ impl From<ToolName> for String {
     }
 }
 
-// --- Validation ---
-
 fn validate_id(id: &str, kind: &'static str) -> Result<(), IdError> {
     if id.is_empty() {
         return Err(IdError::Empty { kind });
@@ -215,8 +213,6 @@ fn validate_id(id: &str, kind: &'static str) -> Result<(), IdError> {
     }
     Ok(())
 }
-
-// --- Errors ---
 
 /// Errors from identifier construction.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -348,8 +344,6 @@ mod tests {
         let back: ToolName = serde_json::from_str(&json).unwrap();
         assert_eq!(name, back);
     }
-
-    // --- Boundary values ---
 
     #[test]
     fn nous_id_max_length_accepted() {

--- a/crates/koina/src/lib.rs
+++ b/crates/koina/src/lib.rs
@@ -15,7 +15,6 @@ pub mod redact;
 /// Tracing subscriber initialization for human-readable and JSON log output.
 pub mod tracing_init;
 
-// --- Static assertions: key types are Send + Sync ---
 #[cfg(test)]
 mod assertions {
     use super::id::*;

--- a/crates/koina/src/tracing_init.rs
+++ b/crates/koina/src/tracing_init.rs
@@ -40,14 +40,12 @@ pub fn init_json() {
 
 #[cfg(test)]
 mod tests {
-    // Tracing init is global state — can only test it doesn't panic.
-    // Integration tests exercise actual output.
+    // NOTE: tracing init is global state — can only test it doesn't panic; integration tests exercise actual output
 
     #[test]
     fn env_filter_parses_default() {
         use tracing_subscriber::EnvFilter;
         let filter = EnvFilter::new("aletheia=info,warn");
-        // Just verifying it doesn't panic
         drop(filter);
     }
 }

--- a/crates/melete/src/distill.rs
+++ b/crates/melete/src/distill.rs
@@ -27,7 +27,7 @@ struct RetryState {
 impl RetryState {
     fn record_failure(&mut self) {
         self.consecutive_failures = self.consecutive_failures.saturating_add(1);
-        // Exponential backoff: 1, 2, 4, 8 turns; capped at MAX_BACKOFF_TURNS.
+        // NOTE: exponential backoff — 1, 2, 4, 8 turns; capped at MAX_BACKOFF_TURNS
         let shift = self.consecutive_failures.saturating_sub(1).min(3);
         self.turns_to_skip = (1u32 << shift).min(MAX_BACKOFF_TURNS);
     }
@@ -235,7 +235,7 @@ impl DistillEngine {
         context_window: u64,
         threshold: f64,
     ) -> bool {
-        // Need enough messages to summarize beyond the verbatim tail.
+        // NOTE: need enough messages to exceed the verbatim tail to trigger summarization
         let required = self.config.min_messages + self.config.verbatim_tail;
         if message_count < required {
             return false;

--- a/crates/melete/src/distill_tests.rs
+++ b/crates/melete/src/distill_tests.rs
@@ -163,7 +163,7 @@ fn should_distill_below_threshold_returns_false() {
 #[test]
 fn should_distill_at_threshold_returns_true() {
     let engine = default_engine();
-    // 10 >= min_messages(6) + verbatim_tail(3) = 9, tokens at threshold
+    // NOTE: 10 >= min_messages(6) + verbatim_tail(3) = 9, tokens at threshold
     assert!(engine.should_distill(10, 160_000, 200_000, 0.8));
 }
 
@@ -176,7 +176,7 @@ fn should_distill_above_threshold_returns_true() {
 #[test]
 fn should_distill_too_few_messages_returns_false() {
     let engine = default_engine();
-    // 5 < min_messages(6) + verbatim_tail(3) = 9
+    // NOTE: 5 < min_messages(6) + verbatim_tail(3) = 9
     assert!(!engine.should_distill(5, 190_000, 200_000, 0.8));
 }
 
@@ -189,14 +189,14 @@ fn should_distill_zero_context_window_returns_false() {
 #[test]
 fn should_distill_exact_min_plus_tail() {
     let engine = default_engine();
-    // Exactly min_messages(6) + verbatim_tail(3) = 9
+    // NOTE: exactly min_messages(6) + verbatim_tail(3) = 9
     assert!(engine.should_distill(9, 180_000, 200_000, 0.8));
 }
 
 #[test]
 fn should_distill_below_min_plus_tail_returns_false() {
     let engine = default_engine();
-    // 8 < min_messages(6) + verbatim_tail(3) = 9
+    // NOTE: 8 < min_messages(6) + verbatim_tail(3) = 9
     assert!(!engine.should_distill(8, 190_000, 200_000, 0.8));
 }
 
@@ -274,7 +274,7 @@ async fn distill_success_returns_result() {
 
     let result = result.unwrap();
     assert!(result.summary.contains("Fixed login bug"));
-    // 6 messages - 3 verbatim_tail = 3 distilled
+    // NOTE: 6 messages - 3 verbatim_tail = 3 distilled
     assert_eq!(result.messages_distilled, 3);
     assert_eq!(result.verbatim_messages.len(), 3);
     assert_eq!(result.distillation_number, 1);
@@ -319,7 +319,7 @@ async fn distill_timestamp_is_valid() {
         .await
         .unwrap();
 
-    // jiff::Timestamp::to_string() produces RFC 3339 / ISO 8601
+    // NOTE: jiff::Timestamp::to_string() produces RFC 3339 / ISO 8601
     assert!(
         result.timestamp.contains('T'),
         "timestamp should be ISO 8601: {}",
@@ -555,8 +555,6 @@ fn distill_section_equality() {
     );
 }
 
-// ─── Retry backoff (#1096) ────────────────────────────────────────────────────
-
 #[test]
 fn tick_turn_returns_false_when_no_failures() {
     let engine = default_engine();
@@ -572,10 +570,8 @@ fn in_backoff_is_false_on_fresh_engine() {
 #[test]
 fn backoff_activates_after_failure_and_expires_after_one_turn() {
     let engine = default_engine();
-    // Simulate one failure: turns_to_skip becomes 1.
     engine.retry_state.lock().unwrap().record_failure();
     assert!(engine.in_backoff());
-    // After one tick the backoff expires.
     assert!(engine.tick_turn()); // still in backoff, counter decrements to 0
     assert!(!engine.in_backoff());
     assert!(!engine.tick_turn()); // no longer in backoff
@@ -597,7 +593,7 @@ fn backoff_resets_on_success() {
 
 #[test]
 fn backoff_schedule_is_exponential() {
-    // After N failures, turns_to_skip = min(2^(N-1), 8).
+    // NOTE: after N failures, turns_to_skip = min(2^(N-1), 8)
     let cases: &[(u32, u32)] = &[(1, 1), (2, 2), (3, 4), (4, 8), (5, 8), (10, 8)];
     for &(failures, expected_skip) in cases {
         let engine = default_engine();
@@ -632,7 +628,6 @@ async fn distill_records_failure_on_llm_error() {
 #[tokio::test]
 async fn distill_records_success_and_clears_backoff() {
     let engine = default_engine();
-    // Prime with a failure first.
     engine.retry_state.lock().unwrap().record_failure();
     assert!(engine.in_backoff());
 
@@ -649,8 +644,6 @@ async fn distill_records_success_and_clears_backoff() {
     );
 }
 
-// ─── Context overflow hard stop (#1097) ──────────────────────────────────────
-
 #[test]
 fn enforce_context_limit_returns_zero_when_within_window() {
     let mut messages = sample_conversation();
@@ -662,12 +655,10 @@ fn enforce_context_limit_returns_zero_when_within_window() {
 
 #[test]
 fn enforce_context_limit_drops_oldest_messages_when_over() {
-    // Build messages where each has ~100 chars → ~25 tokens each.
     let mut messages: Vec<Message> = (0..10)
         .map(|i| text_msg(Role::User, &"x".repeat(100 + i)))
         .collect();
     let initial_count = messages.len();
-    // Set window so tight that we must drop some.
     let dropped = enforce_context_limit(&mut messages, 4);
     assert!(dropped > 0, "should have dropped some messages");
     assert_eq!(messages.len(), initial_count - dropped);
@@ -676,7 +667,7 @@ fn enforce_context_limit_drops_oldest_messages_when_over() {
 #[test]
 fn enforce_context_limit_keeps_at_least_one_message() {
     let mut messages = vec![text_msg(Role::User, "x".repeat(1000).as_str())];
-    // Window of 1 token — impossible to satisfy but we must keep the last message.
+    // NOTE: window of 1 token — impossible to satisfy, but we must keep the last message
     let dropped = enforce_context_limit(&mut messages, 1);
     assert_eq!(dropped, 0, "single message must not be dropped");
     assert_eq!(messages.len(), 1);
@@ -689,14 +680,11 @@ fn enforce_context_limit_drops_from_front() {
         text_msg(Role::User, &"b".repeat(400)),
         text_msg(Role::User, &"c".repeat(4)), // newest — should be kept
     ];
-    // Tokens: 100 + 100 + 1 = 201 total. Window of 2 keeps last ~8 chars = 2 tokens.
+    // NOTE: 201 total tokens, window of 2 keeps last ~8 chars = 2 tokens
     let dropped = enforce_context_limit(&mut messages, 2);
     assert!(dropped > 0);
-    // The surviving message must be the newest one.
     assert!(messages.last().unwrap().content.text().starts_with('c'));
 }
-
-// ─── nous_id sanitization (#1098) ────────────────────────────────────────────
 
 #[test]
 fn sanitize_nous_id_clean_string_unchanged() {
@@ -740,7 +728,7 @@ fn build_prompt_sanitizes_newline_in_nous_id() {
     let engine = default_engine();
     let request = engine.build_prompt(&sample_conversation(), "id\ninjection");
     let user_text = request.messages[0].content.text();
-    // Newline must be stripped from inside the nous_id quoted span.
+    // NOTE: newline must be stripped from inside the nous_id quoted span
     assert!(
         !user_text.contains("\"id\ninjection\""),
         "raw newline must not appear inside the quoted nous_id"
@@ -750,8 +738,6 @@ fn build_prompt_sanitizes_newline_in_nous_id() {
         "sanitized nous_id should appear without the embedded newline"
     );
 }
-
-// ─── Token estimation completeness (#1099) ───────────────────────────────────
 
 #[test]
 fn estimate_tokens_includes_tool_use_input() {
@@ -810,8 +796,6 @@ fn estimate_tokens_includes_tool_result_content() {
     );
 }
 
-// ─── MemoryFlush wiring (#1100) ───────────────────────────────────────────────
-
 #[tokio::test]
 async fn distill_result_contains_memory_flush_field() {
     let engine = default_engine();
@@ -822,7 +806,7 @@ async fn distill_result_contains_memory_flush_field() {
         .distill(&messages, "test", &provider, 1)
         .await
         .unwrap();
-    // The field exists — we don't assert content since mock summary has no decisions.
+    // NOTE: assert the field exists — mock summary has no decisions to assert content on
     let _ = &result.memory_flush;
 }
 
@@ -901,6 +885,5 @@ fn parse_summary_flush_source_is_extracted() {
     let summary = "## Key Decisions\n- Decision: Use snafu. Reason: Standard.\n";
     let flush = parse_summary_to_flush(summary, "2026-03-13T00:00:00Z");
     assert_eq!(flush.decisions.len(), 1);
-    // FlushSource is accessible from parent module's use statement.
     assert!(matches!(flush.decisions[0].source, FlushSource::Extracted));
 }

--- a/crates/melete/src/prompt.rs
+++ b/crates/melete/src/prompt.rs
@@ -136,7 +136,6 @@ fn truncate_tool_result(content: &str) -> &str {
     if content.len() <= MAX_TOOL_RESULT_LEN {
         content
     } else {
-        // Find a safe UTF-8 boundary near the limit
         let mut end = MAX_TOOL_RESULT_LEN;
         while end > 0 && !content.is_char_boundary(end) {
             end -= 1;

--- a/crates/melete/src/roundtrip_tests.rs
+++ b/crates/melete/src/roundtrip_tests.rs
@@ -13,10 +13,6 @@ use aletheia_hermeneus::types::{
 use crate::distill::{DistillConfig, DistillEngine, DistillSection};
 use crate::flush::{FlushItem, FlushSource, MemoryFlush};
 
-// ═══════════════════════════════════════════════════════════════════════
-// Mock provider
-// ═══════════════════════════════════════════════════════════════════════
-
 struct MockProvider {
     response: Mutex<Option<aletheia_hermeneus::error::Result<CompletionResponse>>>,
 }
@@ -72,10 +68,6 @@ impl LlmProvider for MockProvider {
         "mock-roundtrip"
     }
 }
-
-// ═══════════════════════════════════════════════════════════════════════
-// Helpers
-// ═══════════════════════════════════════════════════════════════════════
 
 fn text_msg(role: Role, text: &str) -> Message {
     Message {
@@ -135,10 +127,6 @@ Bug is fixed, migration applied, all tests passing.
 
 ## Corrections
 - CORRECTION: Initially looked at wrong file (session.rs), actually the bug was in login.rs";
-
-// ═══════════════════════════════════════════════════════════════════════
-// Serde roundtrip tests
-// ═══════════════════════════════════════════════════════════════════════
 
 #[test]
 fn test_distill_section_summary_roundtrip() {
@@ -333,10 +321,6 @@ fn test_all_standard_sections_roundtrip() {
     assert_eq!(sections, back);
 }
 
-// ═══════════════════════════════════════════════════════════════════════
-// Section splitting logic
-// ═══════════════════════════════════════════════════════════════════════
-
 #[tokio::test]
 async fn test_split_when_verbatim_tail_zero_summarizes_all() {
     let config = DistillConfig {
@@ -424,21 +408,17 @@ async fn test_split_preserves_exact_tail_content() {
     assert_eq!(result.verbatim_messages[1].content.text(), "Fourth");
 }
 
-// ═══════════════════════════════════════════════════════════════════════
-// Token budget calculation
-// ═══════════════════════════════════════════════════════════════════════
-
 #[test]
 fn test_should_distill_when_exactly_at_threshold_returns_true() {
     let engine = default_engine();
-    // ratio = 80000/100000 = 0.8, threshold = 0.8 → true
+    // NOTE: ratio = 80000/100000 = 0.8, threshold = 0.8 → true
     assert!(engine.should_distill(10, 80_000, 100_000, 0.8));
 }
 
 #[test]
 fn test_should_distill_when_just_below_threshold_returns_false() {
     let engine = default_engine();
-    // ratio = 79999/100000 = 0.79999, threshold = 0.8 → false
+    // NOTE: ratio = 79999/100000 = 0.79999, threshold = 0.8 → false
     assert!(!engine.should_distill(10, 79_999, 100_000, 0.8));
 }
 
@@ -469,7 +449,7 @@ fn test_should_distill_with_custom_min_messages() {
         ..DistillConfig::default()
     };
     let engine = DistillEngine::new(config);
-    // Need at least 25 messages (20 + 5)
+    // NOTE: need at least min_messages(20) + verbatim_tail(5) = 25 messages
     assert!(!engine.should_distill(24, 180_000, 200_000, 0.8));
     assert!(engine.should_distill(25, 180_000, 200_000, 0.8));
 }
@@ -482,14 +462,10 @@ fn test_should_distill_with_zero_verbatim_tail() {
         ..DistillConfig::default()
     };
     let engine = DistillEngine::new(config);
-    // Need only 6 messages (6 + 0)
+    // NOTE: need only min_messages(6) + verbatim_tail(0) = 6 messages
     assert!(!engine.should_distill(5, 180_000, 200_000, 0.8));
     assert!(engine.should_distill(6, 180_000, 200_000, 0.8));
 }
-
-// ═══════════════════════════════════════════════════════════════════════
-// Verbatim tail preservation
-// ═══════════════════════════════════════════════════════════════════════
 
 #[tokio::test]
 async fn test_verbatim_tail_preserves_roles() {
@@ -585,10 +561,6 @@ async fn test_verbatim_tail_preserves_block_content() {
     );
 }
 
-// ═══════════════════════════════════════════════════════════════════════
-// Model downshift selection
-// ═══════════════════════════════════════════════════════════════════════
-
 #[test]
 fn test_build_prompt_when_distillation_model_set_uses_it() {
     let config = DistillConfig {
@@ -648,10 +620,6 @@ fn test_build_prompt_downshift_opus_to_sonnet() {
     let request = engine.build_prompt(&n_messages(4), "test");
     assert_eq!(request.model, "claude-sonnet-4-20250514");
 }
-
-// ═══════════════════════════════════════════════════════════════════════
-// Integration: full distillation pipeline
-// ═══════════════════════════════════════════════════════════════════════
 
 #[tokio::test]
 async fn test_full_pipeline_preserves_tool_results() {
@@ -815,10 +783,6 @@ async fn test_full_pipeline_verbatim_tail_integrity() {
     assert_eq!(result.verbatim_messages[2].role, Role::User);
 }
 
-// ═══════════════════════════════════════════════════════════════════════
-// Edge cases
-// ═══════════════════════════════════════════════════════════════════════
-
 #[tokio::test]
 async fn test_distill_when_empty_messages_returns_error() {
     let provider = MockProvider::with_summary(FULL_SUMMARY);
@@ -953,10 +917,6 @@ async fn test_distill_when_two_messages_with_tail_three() {
     assert_eq!(result.messages_distilled, 0);
 }
 
-// ═══════════════════════════════════════════════════════════════════════
-// DistillSection heading/description coverage
-// ═══════════════════════════════════════════════════════════════════════
-
 #[test]
 fn test_section_heading_for_each_standard_variant() {
     let expected = [
@@ -1006,10 +966,6 @@ fn test_all_standard_returns_seven_sections() {
     assert_eq!(DistillSection::all_standard().len(), 7);
 }
 
-// ═══════════════════════════════════════════════════════════════════════
-// Prompt formatting
-// ═══════════════════════════════════════════════════════════════════════
-
 #[test]
 fn test_build_prompt_includes_message_count() {
     let engine = default_engine();
@@ -1041,10 +997,6 @@ fn test_build_prompt_with_system_message() {
     let text = request.messages[0].content.text();
     assert!(text.contains("[SYSTEM]"));
 }
-
-// ═══════════════════════════════════════════════════════════════════════
-// MemoryFlush additional tests
-// ═══════════════════════════════════════════════════════════════════════
 
 #[test]
 fn test_memory_flush_is_empty_when_only_empty_vecs() {
@@ -1110,10 +1062,6 @@ fn test_flush_source_labels_via_markdown() {
     assert!(md.contains("(source: agent_note)"));
     assert!(md.contains("(source: tool_pattern)"));
 }
-
-// ═══════════════════════════════════════════════════════════════════════
-// Config accessor
-// ═══════════════════════════════════════════════════════════════════════
 
 #[test]
 fn test_engine_config_returns_reference() {

--- a/crates/symbolon/src/api_key.rs
+++ b/crates/symbolon/src/api_key.rs
@@ -60,7 +60,6 @@ pub fn generate(
 
     store.store_api_key(&record)?;
 
-    // Re-read from DB to get populated timestamps
     let stored = store
         .find_api_key_by_hash(&record.key_hash)?
         .unwrap_or_else(|| {
@@ -83,12 +82,10 @@ pub fn validate(store: &AuthStore, raw_key: &str) -> Result<Claims> {
         .find_api_key_by_hash(&key_hash)?
         .ok_or_else(|| error::InvalidCredentialsSnafu.build())?;
 
-    // Check revocation
     if record.revoked_at.is_some() {
         return Err(error::InvalidCredentialsSnafu.build());
     }
 
-    // Check expiry
     if let Some(ref expires_at) = record.expires_at {
         let now = now_iso();
         if *expires_at < now {
@@ -96,7 +93,6 @@ pub fn validate(store: &AuthStore, raw_key: &str) -> Result<Claims> {
         }
     }
 
-    // Update last_used_at
     store.touch_api_key(&record.id)?;
 
     Ok(Claims {
@@ -145,14 +141,13 @@ fn now_iso() -> String {
 }
 
 fn time_from_unix(secs: u64) -> String {
-    // Simple ISO 8601 formatting without external dependency
+    // WHY: simple ISO 8601 formatting avoids adding an external date dependency
     let days = secs / 86400;
     let time_secs = secs % 86400;
     let hours = time_secs / 3600;
     let minutes = (time_secs % 3600) / 60;
     let seconds = time_secs % 60;
 
-    // Convert days since epoch to Y-M-D (simplified)
     let (year, month, day) = days_to_date(days);
     format!("{year:04}-{month:02}-{day:02}T{hours:02}:{minutes:02}:{seconds:02}.000Z")
 }
@@ -172,7 +167,6 @@ fn days_to_date(days_since_epoch: u64) -> (u64, u64, u64) {
     (y, m, d)
 }
 
-// We need hex encoding for the secret bytes
 mod hex {
     const HEX_CHARS: &[u8; 16] = b"0123456789abcdef";
 

--- a/crates/symbolon/src/auth.rs
+++ b/crates/symbolon/src/auth.rs
@@ -47,8 +47,6 @@ impl AuthService {
         &self.store
     }
 
-    // --- User management ---
-
     /// Register a new user with a hashed password.
     #[instrument(skip(self, password))]
     pub fn register_user(
@@ -61,8 +59,6 @@ impl AuthService {
         let id = ulid::Ulid::new().to_string();
         self.store.create_user(&id, username, &hash, role)
     }
-
-    // --- Authentication ---
 
     /// Authenticate via username + password. Returns a JWT pair.
     #[instrument(skip(self, password))]
@@ -142,8 +138,6 @@ impl AuthService {
         self.store.revoke_token(&claims.jti, &expires_at)
     }
 
-    // --- API key management ---
-
     /// Generate a new API key.
     pub fn generate_api_key(
         &self,
@@ -164,8 +158,6 @@ impl AuthService {
     pub fn list_api_keys(&self) -> Result<Vec<ApiKeyRecord>> {
         api_key::list(&self.store)
     }
-
-    // --- Authorization ---
 
     /// Check if claims authorize the given action. Returns `Ok(())` if allowed.
     pub fn authorize(&self, claims: &Claims, action: &Action) -> Result<()> {
@@ -246,8 +238,6 @@ mod tests {
         SecretString::from(s.to_owned())
     }
 
-    // --- format_unix_iso ---
-
     #[test]
     fn format_unix_iso_positive_timestamp() {
         let result = format_unix_iso(1_700_000_000);
@@ -265,8 +255,6 @@ mod tests {
         let result = format_unix_iso(0);
         assert_eq!(result, "1970-01-01T00:00:00.000Z");
     }
-
-    // --- Login flow ---
 
     #[test]
     fn register_and_login() {
@@ -297,8 +285,6 @@ mod tests {
         assert!(result.is_err());
     }
 
-    // --- Token lifecycle ---
-
     #[test]
     fn validate_then_logout_then_reject() {
         let svc = test_service();
@@ -306,13 +292,10 @@ mod tests {
             .unwrap();
         let pair = svc.login("alice", &secret("pw")).unwrap();
 
-        // Token is valid
         assert!(svc.validate_token(&pair.access_token).is_ok());
 
-        // Logout (revoke)
         svc.logout(&pair.access_token).unwrap();
 
-        // Token is now rejected
         let result = svc.validate_token(&pair.access_token);
         assert!(result.is_err());
     }
@@ -340,8 +323,6 @@ mod tests {
         assert!(result.is_err());
     }
 
-    // --- API key flow ---
-
     #[test]
     fn api_key_generate_authenticate_revoke() {
         let svc = test_service();
@@ -355,8 +336,6 @@ mod tests {
         svc.revoke_api_key(&record.id).unwrap();
         assert!(svc.authenticate_api_key(&key).is_err());
     }
-
-    // --- RBAC ---
 
     #[test]
     fn operator_can_do_everything() {
@@ -406,7 +385,6 @@ mod tests {
 
         let svc = test_service();
 
-        // Can access own sessions
         svc.authorize(
             &claims,
             &Action::ReadSession {
@@ -422,7 +400,6 @@ mod tests {
         )
         .unwrap();
 
-        // Cannot access other agent's sessions
         assert!(
             svc.authorize(
                 &claims,
@@ -442,11 +419,9 @@ mod tests {
             .is_err()
         );
 
-        // Cannot manage
         assert!(svc.authorize(&claims, &Action::ManageAgents).is_err());
         assert!(svc.authorize(&claims, &Action::ManageUsers).is_err());
 
-        // Can read dashboard
         svc.authorize(&claims, &Action::ReadDashboard).unwrap();
     }
 
@@ -514,17 +489,12 @@ mod tests {
         );
     }
 
-    // --- SQL injection safety ---
-
     #[test]
     fn sql_injection_in_username_parameterized() {
         let svc = test_service();
-        // This should not cause SQL injection — parameterized queries handle it
         let result = svc.login("'; DROP TABLE users; --", &secret("pw"));
-        assert!(result.is_err()); // Just a "not found" error, no SQL injection
+        assert!(result.is_err());
     }
-
-    // --- Duplicate registration ---
 
     #[test]
     fn duplicate_user_registration_rejected() {

--- a/crates/symbolon/src/credential.rs
+++ b/crates/symbolon/src/credential.rs
@@ -39,10 +39,6 @@ const REFRESH_CHECK_INTERVAL_SECS: u64 = 60;
 /// How often to check file mtime for external changes.
 const FILE_MTIME_CHECK_INTERVAL: Duration = Duration::from_secs(30);
 
-// ---------------------------------------------------------------------------
-// Credential file format (matches TS/Python)
-// ---------------------------------------------------------------------------
-
 /// On-disk credential file format.
 ///
 /// Accepts both `"token"` (native format) and `"accessToken"` (Claude Code OAuth
@@ -85,7 +81,6 @@ impl CredentialFile {
         file.sync_all()?;
         std::fs::rename(&tmp, path)?;
 
-        // Set restrictive permissions on Unix.
         #[cfg(unix)]
         {
             use std::os::unix::fs::PermissionsExt;
@@ -123,10 +118,6 @@ impl CredentialFile {
     }
 }
 
-// ---------------------------------------------------------------------------
-// OAuth response
-// ---------------------------------------------------------------------------
-
 #[derive(Deserialize)]
 struct OAuthResponse {
     access_token: String,
@@ -150,10 +141,6 @@ impl std::fmt::Debug for OAuthResponse {
 fn default_expires_in() -> u64 {
     28800 // 8 hours
 }
-
-// ---------------------------------------------------------------------------
-// EnvCredentialProvider
-// ---------------------------------------------------------------------------
 
 /// OAuth token prefix used by Claude Code for OAuth access tokens.
 const OAUTH_TOKEN_PREFIX: &str = "sk-ant-oat";
@@ -210,10 +197,6 @@ impl CredentialProvider for EnvCredentialProvider {
     }
 }
 
-// ---------------------------------------------------------------------------
-// FileCredentialProvider
-// ---------------------------------------------------------------------------
-
 struct CachedFile {
     token: String,
     mtime: SystemTime,
@@ -266,7 +249,6 @@ impl FileCredentialProvider {
 
 impl CredentialProvider for FileCredentialProvider {
     fn get_credential(&self) -> Option<Credential> {
-        // Check cache validity
         if let Ok(guard) = self.cached.read()
             && let Some(cached) = guard.as_ref()
         {
@@ -276,11 +258,9 @@ impl CredentialProvider for FileCredentialProvider {
                     source: CredentialSource::File,
                 });
             }
-            // Check if file changed
             if let Some(mtime) = self.current_mtime()
                 && mtime == cached.mtime
             {
-                // File unchanged — update check timestamp and return cached
                 drop(guard);
                 if let Ok(mut w) = self.cached.write()
                     && let Some(ref mut c) = *w
@@ -298,7 +278,6 @@ impl CredentialProvider for FileCredentialProvider {
             }
         }
 
-        // Cache miss or stale — reload
         self.reload().map(|token| Credential {
             secret: token,
             source: CredentialSource::File,
@@ -313,10 +292,6 @@ impl CredentialProvider for FileCredentialProvider {
         "file"
     }
 }
-
-// ---------------------------------------------------------------------------
-// RefreshingCredentialProvider
-// ---------------------------------------------------------------------------
 
 struct RefreshState {
     current_token: String,
@@ -381,7 +356,6 @@ impl RefreshingCredentialProvider {
 
 impl CredentialProvider for RefreshingCredentialProvider {
     fn get_credential(&self) -> Option<Credential> {
-        // Try in-memory refreshed token first
         if let Ok(guard) = self.state.read()
             && let Some(ref s) = *guard
             && !s.current_token.is_empty()
@@ -391,7 +365,6 @@ impl CredentialProvider for RefreshingCredentialProvider {
                 source: CredentialSource::OAuth,
             });
         }
-        // Fall back to file read
         self.file_provider.get_credential()
     }
 
@@ -432,7 +405,6 @@ async fn refresh_loop(
             break;
         }
 
-        // Check if refresh is needed
         let (refresh_token, needs_refresh) = {
             let Ok(guard) = state.read() else {
                 continue;
@@ -459,7 +431,6 @@ async fn refresh_loop(
                 let now_ms = unix_epoch_ms();
                 let expires_at_ms = now_ms + resp.expires_in * 1000;
 
-                // Update in-memory state
                 if let Ok(mut guard) = state.write() {
                     *guard = Some(RefreshState {
                         current_token: resp.access_token.clone(),
@@ -468,7 +439,6 @@ async fn refresh_loop(
                     });
                 }
 
-                // Update file
                 let scopes = resp
                     .scope
                     .map(|s| s.split_whitespace().map(String::from).collect());
@@ -566,10 +536,6 @@ pub async fn force_refresh(path: &Path) -> Result<CredentialFile, String> {
     Ok(updated)
 }
 
-// ---------------------------------------------------------------------------
-// Claude Code credential detection
-// ---------------------------------------------------------------------------
-
 /// Default path to the Claude Code credentials file.
 ///
 /// Returns `~/.claude/.credentials.json`, resolving `~` via `$HOME`.
@@ -610,10 +576,6 @@ pub fn claude_code_provider(path: &Path) -> Option<Box<dyn CredentialProvider>> 
     );
     Some(Box::new(FileCredentialProvider::new(path.to_path_buf())))
 }
-
-// ---------------------------------------------------------------------------
-// CredentialChain
-// ---------------------------------------------------------------------------
 
 /// Ordered list of credential providers. First to return `Some` wins.
 pub struct CredentialChain {

--- a/crates/symbolon/src/credential_tests.rs
+++ b/crates/symbolon/src/credential_tests.rs
@@ -1,8 +1,6 @@
 #![expect(clippy::unwrap_used, clippy::expect_used, reason = "test assertions")]
 use super::*;
 
-// --- CredentialFile ---
-
 #[test]
 fn credential_file_roundtrip() {
     let dir = tempfile::tempdir().unwrap();
@@ -60,10 +58,7 @@ fn has_refresh_token() {
     assert!(!empty.has_refresh_token());
 }
 
-// --- EnvCredentialProvider ---
-
-// EnvCredentialProvider tests use ANTHROPIC_API_KEY which is typically
-// set in CI/dev. We test the missing case with a guaranteed-absent var.
+// NOTE: env tests use a guaranteed-absent var name to avoid depending on CI/dev env vars
 
 #[test]
 fn env_provider_missing_returns_none() {
@@ -113,8 +108,6 @@ fn env_provider_with_source_forces_oauth() {
     unsafe { std::env::remove_var(var) };
 }
 
-// --- FileCredentialProvider ---
-
 #[test]
 fn file_provider_reads_token() {
     let dir = tempfile::tempdir().unwrap();
@@ -158,14 +151,12 @@ fn file_provider_detects_file_change() {
     let r1 = provider.get_credential().unwrap();
     assert_eq!(r1.secret, "token-v1");
 
-    // Invalidate cache timestamp to force mtime check
     if let Ok(mut guard) = provider.cached.write()
         && let Some(ref mut c) = *guard
     {
         c.checked_at = Instant::now()
             .checked_sub(Duration::from_secs(60))
             .unwrap_or(Instant::now());
-        // Also change mtime to force reload
         c.mtime = SystemTime::UNIX_EPOCH;
     }
 
@@ -178,8 +169,6 @@ fn file_provider_detects_file_change() {
     let r2 = provider.get_credential().unwrap();
     assert_eq!(r2.secret, "token-v2");
 }
-
-// --- CredentialChain ---
 
 struct StaticProvider {
     token: Option<String>,
@@ -251,17 +240,13 @@ fn chain_empty_providers_returns_none() {
     assert!(chain.get_credential().is_none());
 }
 
-// --- claude_code_default_path ---
-
 #[test]
 fn claude_code_default_path_uses_home() {
-    // This test depends on $HOME being set, which is typical in CI and dev.
+    // NOTE: depends on $HOME being set — typical in CI and dev
     if let Some(path) = claude_code_default_path() {
         assert!(path.ends_with(".claude/.credentials.json"));
     }
 }
-
-// --- claude_code_provider ---
 
 #[test]
 fn claude_code_provider_missing_file_returns_none() {
@@ -292,7 +277,6 @@ fn claude_code_provider_static_token() {
 async fn claude_code_provider_with_access_token_alias() {
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join(".credentials.json");
-    // Write raw JSON using "accessToken" (Claude Code native format)
     std::fs::write(
         &path,
         r#"{"accessToken": "sk-ant-oat-cc-token", "refreshToken": "rt-cc"}"#,
@@ -302,7 +286,6 @@ async fn claude_code_provider_with_access_token_alias() {
     let provider = claude_code_provider(&path).expect("should return provider");
     let resolved = provider.get_credential().unwrap();
     assert_eq!(resolved.secret, "sk-ant-oat-cc-token");
-    // Has refresh token → OAuth source via RefreshingCredentialProvider
     assert_eq!(resolved.source, CredentialSource::OAuth);
 }
 
@@ -314,8 +297,6 @@ fn claude_code_provider_malformed_returns_none() {
     assert!(claude_code_provider(&path).is_none());
 }
 
-// --- unix_epoch_ms ---
-
 #[test]
 fn unix_epoch_ms_returns_nonzero() {
     let ms = unix_epoch_ms();
@@ -324,8 +305,6 @@ fn unix_epoch_ms_returns_nonzero() {
         "expected modern timestamp in ms, got {ms}"
     );
 }
-
-// --- seconds_remaining ---
 
 #[test]
 fn seconds_remaining_none_when_no_expiry() {

--- a/crates/symbolon/src/jwt.rs
+++ b/crates/symbolon/src/jwt.rs
@@ -147,7 +147,7 @@ impl JwtManager {
             nous_id: nous_id.map(str::to_owned),
             iss: self.config.issuer.clone(),
             iat: now,
-            // Saturate to i64::MAX: a TTL exceeding ~292 billion years is effectively infinite
+            // WHY: saturate to i64::MAX — a TTL exceeding ~292 billion years is effectively infinite
             exp: now + i64::try_from(ttl.as_secs()).unwrap_or(i64::MAX),
             jti: ulid::Ulid::new().to_string(),
             kind,
@@ -170,7 +170,7 @@ fn now_unix() -> i64 {
             })
             .as_secs(),
     )
-    // Saturate: u64 seconds exceeding i64::MAX (~year 292B) clamps to max
+    // WHY: saturate u64 seconds to i64::MAX (~year 292B) to prevent overflow
     .unwrap_or(i64::MAX)
 }
 
@@ -235,7 +235,7 @@ mod tests {
     fn expired_token_rejected() {
         let mgr = test_manager();
 
-        // Manually encode a token with exp far in the past (beyond the 60s leeway)
+        // NOTE: manually encode a token with exp far in the past, beyond the 60s leeway
         let claims = Claims {
             sub: "user-1".to_owned(),
             role: Role::Operator,

--- a/crates/symbolon/src/password.rs
+++ b/crates/symbolon/src/password.rs
@@ -92,7 +92,6 @@ mod tests {
         let h1 = hash_password(&pw).unwrap();
         let h2 = hash_password(&pw).unwrap();
         assert_ne!(h1, h2);
-        // But both verify correctly
         assert!(verify_password(&pw, &h1).unwrap());
         assert!(verify_password(&pw, &h2).unwrap());
     }

--- a/crates/symbolon/src/store.rs
+++ b/crates/symbolon/src/store.rs
@@ -87,8 +87,6 @@ impl AuthStore {
         &self.conn
     }
 
-    // --- Users ---
-
     /// Create a new user.
     #[instrument(skip(self, password_hash))]
     pub fn create_user(
@@ -168,8 +166,6 @@ impl AuthStore {
             .context(error::DatabaseSnafu)?;
         Ok(rows > 0)
     }
-
-    // --- API Keys ---
 
     /// Store an API key record.
     pub fn store_api_key(&self, record: &ApiKeyRecord) -> Result<()> {
@@ -257,8 +253,6 @@ impl AuthStore {
         Ok(keys)
     }
 
-    // --- Token Revocation ---
-
     /// Revoke a JWT by its `jti`.
     pub fn revoke_token(&self, jti: &str, expires_at: &str) -> Result<()> {
         self.conn
@@ -298,8 +292,6 @@ impl AuthStore {
     }
 }
 
-// --- Schema initialization ---
-
 fn initialize(conn: &Connection) -> Result<()> {
     let version = get_schema_version(conn)?;
 
@@ -313,10 +305,8 @@ fn initialize(conn: &Connection) -> Result<()> {
         .context(error::DatabaseSnafu)?;
     }
 
-    // Remove revoked tokens whose expiry has already passed.
-    // WHY: Prevents unbounded growth of the revoked_tokens table; entries are
-    // only needed until the token's natural expiry, so cleaning up on startup
-    // is sufficient for production workloads.
+    // WHY: revoked tokens only need to be tracked until their natural expiry;
+    // startup cleanup is sufficient for production workloads.
     let cleaned = conn
         .execute(
             "DELETE FROM revoked_tokens WHERE expires_at < strftime('%Y-%m-%dT%H:%M:%fZ', 'now')",
@@ -334,7 +324,7 @@ fn initialize(conn: &Connection) -> Result<()> {
 }
 
 fn get_schema_version(conn: &Connection) -> Result<u32> {
-    // If the schema_version table does not yet exist this is a fresh database;
+    // NOTE: if the schema_version table does not yet exist, this is a fresh database;
     // return 0 to signal that all DDL should be applied.
     let table_exists: bool = conn
         .query_row(
@@ -348,7 +338,7 @@ fn get_schema_version(conn: &Connection) -> Result<u32> {
         return Ok(0);
     }
 
-    // The table exists — any failure to read the version signals corruption.
+    // NOTE: the table exists — any failure to read the version signals corruption.
     conn.query_row(
         "SELECT version FROM schema_version ORDER BY version DESC LIMIT 1",
         [],
@@ -356,8 +346,6 @@ fn get_schema_version(conn: &Connection) -> Result<u32> {
     )
     .context(error::SchemaCorruptedSnafu)
 }
-
-// --- Row mappers ---
 
 fn map_user(row: &rusqlite::Row<'_>) -> rusqlite::Result<User> {
     let role_str: String = row.get("role")?;
@@ -437,14 +425,11 @@ mod tests {
     #[test]
     fn schema_corruption_returns_error() {
         let store = test_store();
-        // Drop the schema_version table to simulate corruption: the table
-        // exists but has been emptied/corrupted. We simulate by dropping and
-        // re-creating it empty, then verifying an error is returned.
+        // NOTE: simulate corruption: drop and recreate schema_version empty to verify error path
         store
             .conn()
             .execute_batch("DELETE FROM schema_version;")
             .unwrap();
-        // Table exists but has no rows — SchemaCorrupted should be returned.
         let result = get_schema_version(store.conn());
         assert!(
             matches!(result, Err(error::Error::SchemaCorrupted { .. })),
@@ -521,11 +506,9 @@ mod tests {
     #[test]
     fn expired_revocation_cleanup() {
         let store = test_store();
-        // Insert an already-expired revocation
         store
             .revoke_token("old-jti", "2000-01-01T00:00:00.000Z")
             .unwrap();
-        // Insert a future revocation
         store
             .revoke_token("future-jti", "2099-01-01T00:00:00.000Z")
             .unwrap();

--- a/crates/symbolon/src/types.rs
+++ b/crates/symbolon/src/types.rs
@@ -48,6 +48,7 @@ impl std::str::FromStr for Role {
 /// Distinguishes access tokens from refresh tokens.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
+#[non_exhaustive]
 pub enum TokenKind {
     /// Short-lived token for API access.
     Access,

--- a/crates/taxis/src/cascade.rs
+++ b/crates/taxis/src/cascade.rs
@@ -17,6 +17,7 @@ use crate::oikos::Oikos;
 
 /// Which tier a resolved file came from.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
 pub enum Tier {
     /// Agent-specific (most specific).
     Nous,
@@ -80,7 +81,6 @@ pub fn discover(
         for entry in entries.flatten() {
             let path = entry.path();
 
-            // Skip directories and hidden files
             if !path.is_file() {
                 continue;
             }
@@ -89,7 +89,6 @@ pub fn discover(
                 _ => continue,
             };
 
-            // Extension filter
             if let Some(required_ext) = ext {
                 match path.extension().and_then(OsStr::to_str) {
                     Some(e) if e == required_ext => {}
@@ -97,7 +96,7 @@ pub fn discover(
                 }
             }
 
-            // Most specific wins — only insert if not already seen
+            // WHY: most specific wins — only insert if not already seen
             seen.entry(name.clone()).or_insert_with(|| CascadeEntry {
                 path,
                 tier: *tier,

--- a/crates/taxis/src/config.rs
+++ b/crates/taxis/src/config.rs
@@ -749,7 +749,7 @@ pub fn resolve_nous(config: &AletheiaConfig, nous_id: &str) -> ResolvedNousConfi
     let domains = agent.map(|a| a.domains.clone()).unwrap_or_default();
     let name = agent.and_then(|a| a.name.clone());
 
-    // Agent-level recall overrides; falls back to shared defaults.
+    // NOTE: Agent-level recall overrides; falls back to shared defaults.
     let recall = agent
         .and_then(|a| a.recall.clone())
         .unwrap_or_else(|| defaults.recall.clone());

--- a/crates/taxis/src/config_tests.rs
+++ b/crates/taxis/src/config_tests.rs
@@ -15,7 +15,6 @@ fn defaults_are_sensible() {
     assert_eq!(config.gateway.port, 18789);
     assert_eq!(config.gateway.bind, "localhost");
     assert_eq!(config.gateway.auth.mode, "token");
-    // Security config defaults
     assert!(!config.gateway.tls.enabled);
     assert!(config.gateway.tls.cert_path.is_none());
     assert!(config.gateway.cors.allowed_origins.is_empty());
@@ -32,7 +31,6 @@ fn defaults_are_sensible() {
     assert_eq!(config.embedding.provider, "candle");
     assert!(config.embedding.model.is_none());
     assert_eq!(config.embedding.dimension, 384);
-    // Maintenance defaults
     assert!(config.maintenance.trace_rotation.enabled);
     assert_eq!(config.maintenance.trace_rotation.max_age_days, 14);
     assert!(config.maintenance.drift_detection.enabled);

--- a/crates/taxis/src/loader.rs
+++ b/crates/taxis/src/loader.rs
@@ -82,7 +82,7 @@ pub fn write_config(oikos: &Oikos, config: &AletheiaConfig) -> Result<()> {
 mod tests {
     use super::*;
 
-    // All loader tests run inside figment::Jail to isolate env vars.
+    // NOTE: All loader tests run inside figment::Jail to isolate env vars.
 
     #[test]
     fn load_with_no_yaml_uses_defaults() {
@@ -146,7 +146,7 @@ mod tests {
     #[test]
     fn write_then_load_roundtrip() {
         figment::Jail::expect_with(|jail| {
-            // figment::Jail doesn't auto-create the config dir, so create it first.
+            // NOTE: figment::Jail doesn't auto-create the config dir, so create it first.
             std::fs::create_dir_all(jail.directory().join("config")).map_err(|e| e.to_string())?;
 
             let oikos = Oikos::from_root(jail.directory());

--- a/crates/taxis/src/oikos.rs
+++ b/crates/taxis/src/oikos.rs
@@ -35,23 +35,17 @@ impl Oikos {
         Self { root }
     }
 
-    // --- Root ---
-
     /// The instance root directory.
     #[must_use]
     pub fn root(&self) -> &Path {
         &self.root
     }
 
-    // --- Tier 0: Theke (human + nous collaborative) ---
-
     /// The theke directory (human + nous collaborative space).
     #[must_use]
     pub fn theke(&self) -> PathBuf {
         self.root.join("theke")
     }
-
-    // --- Tier 1: Shared (nous-only) ---
 
     /// The shared directory (nous-only shared resources).
     #[must_use]
@@ -83,8 +77,6 @@ impl Oikos {
         self.root.join("shared").join("coordination")
     }
 
-    // --- Tier 2: Nous (per-agent) ---
-
     /// The nous directory containing all agent workspaces.
     #[must_use]
     pub fn nous_root(&self) -> PathBuf {
@@ -102,8 +94,6 @@ impl Oikos {
     pub fn nous_file(&self, id: &str, filename: &str) -> PathBuf {
         self.nous_dir(id).join(filename)
     }
-
-    // --- Config ---
 
     /// The config directory.
     #[must_use]
@@ -132,8 +122,6 @@ impl Oikos {
     pub fn session_key(&self) -> PathBuf {
         self.root.join("config").join("session.key")
     }
-
-    // --- Data ---
 
     /// The data directory (runtime state).
     #[must_use]
@@ -171,8 +159,6 @@ impl Oikos {
         self.root.join("data").join("archive")
     }
 
-    // --- Logs ---
-
     /// The logs directory.
     #[must_use]
     pub fn logs(&self) -> PathBuf {
@@ -191,15 +177,11 @@ impl Oikos {
         self.root.join("logs").join("traces").join("archive")
     }
 
-    // --- Signal ---
-
     /// The Signal data directory.
     #[must_use]
     pub fn signal(&self) -> PathBuf {
         self.root.join("signal")
     }
-
-    // --- Startup validation ---
 
     /// Validate the instance layout at startup.
     ///
@@ -326,7 +308,6 @@ mod tests {
 
     #[test]
     fn oikos_env_override() {
-        // Test that from_root works regardless of env
         let oikos = Oikos::from_root("/custom/path");
         assert_eq!(oikos.root(), Path::new("/custom/path"));
     }
@@ -406,8 +387,6 @@ mod tests {
         assert!(cf.to_string_lossy().ends_with("aletheia.toml"));
     }
 
-    // --- validate() tests ---
-
     fn make_valid_instance() -> tempfile::TempDir {
         let dir = tempfile::tempdir().expect("create temp dir");
         std::fs::create_dir_all(dir.path().join("config")).unwrap();
@@ -441,7 +420,6 @@ mod tests {
     #[test]
     fn validate_fails_when_config_dir_missing() {
         let dir = tempfile::tempdir().expect("create temp dir");
-        // only data/, no config/
         std::fs::create_dir_all(dir.path().join("data")).unwrap();
         let oikos = Oikos::from_root(dir.path());
         let err = oikos.validate().unwrap_err();
@@ -463,7 +441,6 @@ mod tests {
     #[test]
     fn validate_fails_when_data_dir_missing() {
         let dir = tempfile::tempdir().expect("create temp dir");
-        // only config/, no data/
         std::fs::create_dir_all(dir.path().join("config")).unwrap();
         let oikos = Oikos::from_root(dir.path());
         let err = oikos.validate().unwrap_err();
@@ -481,11 +458,10 @@ mod tests {
     #[test]
     fn validate_warns_but_passes_without_nous_dir() {
         let dir = tempfile::tempdir().expect("create temp dir");
-        // config/ and data/ present, no nous/
         std::fs::create_dir_all(dir.path().join("config")).unwrap();
         std::fs::create_dir_all(dir.path().join("data")).unwrap();
         let oikos = Oikos::from_root(dir.path());
-        // Should succeed — missing nous/ is a warning, not an error
+        // NOTE: missing nous/ is a warning, not an error — the test verifies this
         assert!(oikos.validate().is_ok());
     }
 
@@ -499,10 +475,9 @@ mod tests {
         let data = dir.path().join("data");
         std::fs::create_dir_all(&data).unwrap();
 
-        // Remove write permission from data/
         std::fs::set_permissions(&data, std::fs::Permissions::from_mode(0o555)).unwrap();
 
-        // Skip if we can still write (running as root)
+        // NOTE: skip if running as root — root bypasses file permission checks
         let probe = data.join(".root-probe");
         let is_root = std::fs::write(&probe, b"x").is_ok();
         let _ = std::fs::remove_file(&probe);
@@ -514,7 +489,7 @@ mod tests {
         let oikos = Oikos::from_root(dir.path());
         let result = oikos.validate();
 
-        // Restore permissions so tempdir cleanup works
+        // WHY: restore permissions so tempdir cleanup works
         std::fs::set_permissions(&data, std::fs::Permissions::from_mode(0o755)).unwrap();
 
         let err = result.unwrap_err();
@@ -532,7 +507,7 @@ mod tests {
     #[test]
     fn validate_workspace_path_accepts_existing_relative() {
         let dir = make_valid_instance();
-        // nous/ already created by make_valid_instance
+        // NOTE: nous/ already created by make_valid_instance
         let oikos = Oikos::from_root(dir.path());
         assert!(oikos.validate_workspace_path("nous").is_ok());
     }
@@ -565,7 +540,6 @@ mod tests {
 
     #[test]
     fn init_layout_passes_validation() {
-        // Simulate what `aletheia init` should create
         let dir = tempfile::tempdir().expect("create temp dir");
         for sub in &["config", "data", "nous", "logs", "shared"] {
             std::fs::create_dir_all(dir.path().join(sub)).unwrap();

--- a/crates/taxis/src/redact.rs
+++ b/crates/taxis/src/redact.rs
@@ -74,7 +74,7 @@ mod tests {
 
         let redacted = redact(&config);
         assert_eq!(redacted["gateway"]["auth"]["signingKey"], REDACTED);
-        // Raw secret must not appear anywhere in the output
+        // INVARIANT: raw secret must not appear anywhere in the output
         assert!(
             !redacted
                 .to_string()

--- a/crates/taxis/src/validate.rs
+++ b/crates/taxis/src/validate.rs
@@ -47,7 +47,7 @@ fn validate_agents(value: &Value, errors: &mut Vec<String>) {
         check_positive_u32(defaults, "timeoutSeconds", errors);
         check_positive_u32(defaults, "thinkingBudget", errors);
 
-        // Cap token budgets at a sane maximum to prevent misconfiguration.
+        // WHY: Cap token budgets at a sane maximum to prevent misconfiguration.
         for field in &[
             "contextTokens",
             "maxOutputTokens",
@@ -61,7 +61,6 @@ fn validate_agents(value: &Value, errors: &mut Vec<String>) {
             }
         }
 
-        // Model IDs must not be empty strings.
         if let Some(model) = defaults.get("model") {
             if let Some(primary) = model.get("primary").and_then(Value::as_str)
                 && primary.is_empty()
@@ -94,7 +93,7 @@ fn validate_agents(value: &Value, errors: &mut Vec<String>) {
             errors.push("toolTimeouts.defaultMs must be positive".to_owned());
         }
 
-        // Bootstrap budget must fit within the context window.
+        // INVARIANT: Bootstrap budget must fit within the context window.
         let context = defaults.get("contextTokens").and_then(Value::as_u64);
         let bootstrap = defaults.get("bootstrapMaxTokens").and_then(Value::as_u64);
         if let (Some(ctx), Some(boot)) = (context, bootstrap)

--- a/crates/thesauros/src/loader.rs
+++ b/crates/thesauros/src/loader.rs
@@ -291,11 +291,9 @@ domains = ["healthcare", "sql"]
 
         let pack = load_single_pack(dir.path()).unwrap();
 
-        // chiron sees LOGIC.md (agent-specific) and GLOSSARY.md (no filter)
         let chiron_sections = pack.sections_for_agent("chiron");
         assert_eq!(chiron_sections.len(), 2);
 
-        // hermes sees only GLOSSARY.md (no agent filter)
         let hermes_sections = pack.sections_for_agent("hermes");
         assert_eq!(hermes_sections.len(), 1);
         assert_eq!(hermes_sections[0].name, "GLOSSARY.md");
@@ -311,7 +309,6 @@ domains = ["healthcare", "sql"]
 
         let pack = load_single_pack(dir.path()).unwrap();
 
-        // chiron matches by agent ID, sees both sections
         let sections = pack.sections_for_agent_or_domains("chiron", &[]);
         assert_eq!(sections.len(), 2);
     }
@@ -342,9 +339,8 @@ agents = ["sql"]
 
         let pack = load_single_pack(dir.path()).unwrap();
 
-        // hermes has no agent match but has healthcare domain
         let sections = pack.sections_for_agent_or_domains("hermes", &["healthcare".to_owned()]);
-        assert_eq!(sections.len(), 2); // general + healthcare
+        assert_eq!(sections.len(), 2);
         let names: Vec<&str> = sections.iter().map(|s| s.name.as_str()).collect();
         assert!(names.contains(&"general.md"));
         assert!(names.contains(&"healthcare.md"));
@@ -371,7 +367,6 @@ agents = ["chiron"]
 
         let pack = load_single_pack(dir.path()).unwrap();
 
-        // unknown agent, no matching domains: only general (no filter) section
         let sections = pack.sections_for_agent_or_domains("unknown", &["analytics".to_owned()]);
         assert_eq!(sections.len(), 1);
         assert_eq!(sections[0].name, "general.md");

--- a/crates/thesauros/src/manifest.rs
+++ b/crates/thesauros/src/manifest.rs
@@ -198,9 +198,8 @@ pub fn resolve_context_path(pack_root: &Path, entry: &ContextEntry) -> Result<Pa
         error::ContextFileNotFoundSnafu { path: &resolved }
     );
 
-    // WHY: `pack_root.join(path)` does not prevent `../` sequences from
-    // escaping the pack directory. Canonicalize resolves all symlinks and
-    // parent-dir components, then verify the result is still under the root.
+    // WHY: canonicalize resolves all symlinks and parent-dir components, then
+    // verify the result is still under the pack root to prevent path traversal
     let canonical = resolved
         .canonicalize()
         .context(error::ReadFileSnafu { path: resolved })?;
@@ -345,14 +344,11 @@ domains = ["healthcare", "analytics", "sql"]
 
     #[test]
     fn resolve_context_path_blocks_parent_dir_traversal() {
-        // Create the "outer" file that the traversal path would target.
         let outer = TempDir::new().unwrap();
         fs::write(outer.path().join("secret.md"), "secret content").unwrap();
 
-        // Create the pack directory; it has no legitimate files.
         let pack = TempDir::new().unwrap();
 
-        // Build a relative path that tries to escape via `../`.
         let traversal = format!(
             "../{}/secret.md",
             outer.path().file_name().unwrap().to_string_lossy()
@@ -449,7 +445,6 @@ description = "Table name"
         assert_eq!(schema.required, vec!["sql"]);
         assert_eq!(schema.properties["sql"].property_type, "string");
 
-        // Second tool uses default timeout
         assert_eq!(manifest.tools[1].timeout, 30_000);
     }
 

--- a/crates/thesauros/src/tools.rs
+++ b/crates/thesauros/src/tools.rs
@@ -43,8 +43,7 @@ impl ToolExecutor for ShellToolExecutor {
             });
             let timeout = Duration::from_millis(self.timeout_ms);
 
-            // Retry on ETXTBSY (errno 26) — a benign race between writing/chmod
-            // on a script and exec'ing it. Common in CI and on busy systems.
+            // WHY: retry on ETXTBSY (errno 26) — benign race between writing/chmod and exec
             let mut child = {
                 let mut last_err = None;
                 let mut spawned = None;
@@ -61,7 +60,7 @@ impl ToolExecutor for ShellToolExecutor {
                             break;
                         }
                         Err(e) if e.raw_os_error() == Some(26) && attempt < 3 => {
-                            // ETXTBSY — brief backoff (1ms, 5ms, 25ms)
+                            // WHY: brief exponential backoff on ETXTBSY before each retry
                             tokio::time::sleep(Duration::from_millis(1 << (2 * attempt))).await;
                             last_err = Some(e);
                         }
@@ -90,8 +89,8 @@ impl ToolExecutor for ShellToolExecutor {
                 }
             }
 
-            // Wait in a background thread to avoid blocking the async runtime,
-            // then enforce timeout from this async side via oneshot + tokio timeout.
+            // WHY: wait in a background thread to avoid blocking the async runtime;
+            // enforce timeout from the async side via oneshot + tokio timeout
             let (tx, rx) = tokio::sync::oneshot::channel();
             std::thread::spawn(move || {
                 let result = child.wait_with_output();
@@ -127,9 +126,8 @@ impl ToolExecutor for ShellToolExecutor {
             };
 
             if output.len() > MAX_OUTPUT_BYTES {
-                // WHY: truncate() panics when the byte index falls inside a
-                // multi-byte character. floor_char_boundary() rounds down to
-                // the nearest valid char boundary, guaranteeing safety.
+                // WHY: floor_char_boundary() rounds down to the nearest valid char boundary,
+                // guaranteeing the truncated slice is valid UTF-8
                 let boundary = output.floor_char_boundary(MAX_OUTPUT_BYTES);
                 output.truncate(boundary);
                 output.push_str("\n[output truncated]");
@@ -152,8 +150,8 @@ pub fn register_pack_tools(packs: &[LoadedPack], registry: &mut ToolRegistry) ->
     let mut errors = Vec::new();
 
     for pack in packs {
-        // Track the error count before processing this pack so we can
-        // compute per-pack failures without affecting counts from prior packs.
+        // WHY: snapshot error count before this pack to compute per-pack failures
+        // without contaminating counts from prior packs
         let errors_before = errors.len();
 
         for tool_def in &pack.manifest.tools {
@@ -241,7 +239,6 @@ fn prepare_tool(
 fn validate_command_path(pack_root: &Path, command: &str) -> Result<PathBuf, error::Error> {
     let resolved = pack_root.join(command);
 
-    // Canonicalize to resolve symlinks and ../ components
     let canonical =
         resolved
             .canonicalize()
@@ -327,7 +324,7 @@ mod tests {
             if let Some(parent) = path.parent() {
                 fs::create_dir_all(parent).unwrap();
             }
-            // Use explicit File to ensure fd is closed before any chmod/exec
+            // WHY: explicit File ensures fd is closed before chmod/exec — avoids ETXTBSY
             let file = std::fs::File::create(&path).unwrap();
             std::io::Write::write_all(&mut &file, content.as_bytes()).unwrap();
             file.sync_all().unwrap();
@@ -379,7 +376,7 @@ mod tests {
     fn validate_command_path_escape_rejected() {
         let dir = setup_pack_dir(&[("tools/test.sh", "#!/bin/sh")]);
         let result = validate_command_path(dir.path(), "../../../etc/passwd");
-        // Either ToolCommandNotFound (can't canonicalize) or ToolCommandEscape
+        // NOTE: returns ToolCommandNotFound (can't canonicalize) or ToolCommandEscape
         let err = result.unwrap_err();
         assert!(
             matches!(err, error::Error::ToolCommandNotFound { .. })
@@ -609,7 +606,6 @@ mod tests {
 
     #[test]
     fn error_count_per_pack_not_cumulative() {
-        // Pack A: one invalid tool (missing command)
         let dir_a = setup_pack_dir(&[]);
         let pack_a = minimal_loaded_pack(
             &dir_a,
@@ -622,7 +618,6 @@ mod tests {
             }],
         );
 
-        // Pack B: one valid tool — must register successfully despite pack A's error.
         let dir_b = setup_pack_dir(&[("tools/ok.sh", "#!/bin/sh\necho ok")]);
         make_executable(&dir_b, "tools/ok.sh");
         let pack_b = minimal_loaded_pack(
@@ -639,7 +634,6 @@ mod tests {
         let mut registry = ToolRegistry::new();
         let errors = register_pack_tools(&[pack_a, pack_b], &mut registry);
 
-        // Exactly one error from pack A; pack B's tool registers successfully.
         assert_eq!(
             errors.len(),
             1,
@@ -655,19 +649,13 @@ mod tests {
 
     #[tokio::test]
     async fn shell_executor_truncates_at_char_boundary() {
-        // Build output that contains a 3-byte UTF-8 sequence (U+2026 HORIZONTAL ELLIPSIS: 0xE2 0x80 0xA6)
-        // placed so it straddles the MAX_OUTPUT_BYTES boundary.
-        //
-        // We use a script that writes a known multi-byte sequence beyond the limit.
-        let ellipsis = "\u{2026}"; // 3 bytes: 0xE2 0x80 0xA6
-        // Fill output to MAX_OUTPUT_BYTES - 1 with ASCII 'a', then append the
-        // ellipsis so bytes [MAX_OUTPUT_BYTES-1 .. MAX_OUTPUT_BYTES+2) are the
-        // three bytes of U+2026. The old truncate() call would panic here.
+        // NOTE: U+2026 (3 bytes: 0xE2 0x80 0xA6) is placed straddling MAX_OUTPUT_BYTES
+        // so that naive truncate() would panic on the invalid byte boundary
+        let ellipsis = "\u{2026}"; // NOTE: 3 bytes: 0xE2 0x80 0xA6
         let fill_len = MAX_OUTPUT_BYTES - 1;
         let fill: String = "a".repeat(fill_len);
         let full_output = format!("{fill}{ellipsis}extra");
 
-        // Write a script that prints the prepared string.
         let script_content = format!("#!/bin/sh\nprintf '%s' '{full_output}'");
         let dir = setup_pack_dir(&[("tools/multibyte.sh", &script_content)]);
         make_executable(&dir, "tools/multibyte.sh");
@@ -698,7 +686,6 @@ mod tests {
             )),
         };
 
-        // Must not panic, and result must be valid UTF-8 ending with the truncation marker.
         let result = executor.execute(&input, &ctx).await.unwrap();
         let text = result.content.text_summary();
         assert!(text.is_char_boundary(0), "result must be valid UTF-8");


### PR DESCRIPTION
## Summary
- Standardized all inline comments with structured tags across 10 crates (WHY/NOTE/WARNING/PERF/SAFETY/INVARIANT)
- Removed commented-out code and restating comments (~460 lines net removed)
- Added `#[non_exhaustive]` to public enums: `Tier` (taxis), `MatchReason`/`SignalTarget`/`ConnectionState` (agora), `TokenKind` (symbolon), `OutcomeKind` (eval)
- Eliminated restating section dividers (`// --- X ---`, `// ═══...`, `// ─── X ───`) throughout
- Confirmed zero `.unwrap()` in library code; all found usages were in `#[cfg(test)]` blocks
- CLI binary (aletheia): production code had no bare unwraps; test code left as-is per policy

## Test plan
- [ ] `cargo test --workspace` — all tests pass
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` — zero warnings
- [ ] Zero unwraps in library code (non-CLI, non-test)
- [ ] No behavioral changes

## Observations
- `aletheia/src/server.rs` and `aletheia/src/commands/server.rs` appear to contain near-identical server startup/shutdown logic — possible duplication worth reviewing (out of scope for this PR)