### PR TITLE
chore(theatron,nous): standards compliance sweep

### DIFF
--- a/crates/nous/src/actor/background.rs
+++ b/crates/nous/src/actor/background.rs
@@ -98,7 +98,6 @@ impl NousActor {
             return;
         }
 
-        // Convert pipeline ToolCalls to mneme ToolCallRecords
         let records: Vec<ToolCallRecord> = tool_calls
             .iter()
             .map(|tc| {
@@ -142,7 +141,7 @@ impl NousActor {
             return;
         };
 
-        // Use the extraction model (Haiku) for cost-effective skill extraction
+        // WHY: extraction model (Haiku) for cost-effectiveness
         let model = extraction_config.model.clone();
         let providers = Arc::clone(&self.providers);
         let nous_id = self.id.clone();
@@ -179,9 +178,8 @@ impl NousActor {
     pub(super) async fn maybe_spawn_distillation(&mut self, session_key: &str) {
         use std::sync::atomic::Ordering;
 
-        // WHY(#1035): Two turns finishing close together can both observe the
-        // distillation trigger condition before either task commits its result.
-        // The atomic flag ensures only one distillation task runs at a time.
+        // WHY: two turns finishing close together can both observe the distillation trigger before
+        // either task commits — the atomic flag ensures only one distillation task runs at a time (#1035)
         if self
             .distillation_in_progress
             .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
@@ -193,8 +191,7 @@ impl NousActor {
 
         let did_spawn = self.try_spawn_distillation(session_key).await;
 
-        // Clear the flag immediately if we did not actually spawn a task.
-        // If a task was spawned, the task itself clears the flag on completion.
+        // NOTE: clear immediately if no task was spawned; spawned task clears the flag itself on completion
         if !did_spawn {
             self.distillation_in_progress
                 .store(false, Ordering::Release);
@@ -213,7 +210,7 @@ impl NousActor {
         };
         let session_id = session_state.id.clone();
 
-        // Quick trigger check under the lock — guard is dropped before any spawn
+        // WHY: trigger check under lock, guard dropped before spawn to avoid holding lock across .await
         let should_distill = {
             let store = store_arc.lock().await;
             let Ok(Some(session)) = store.find_session_by_id(&session_id) else {
@@ -253,7 +250,6 @@ impl NousActor {
         self.background_tasks.spawn(
             async move {
                 run_background_distillation(store, providers, session_id, nous_id, config).await;
-                // Clear the in-progress flag so the next turn can trigger distillation.
                 flag.store(false, Ordering::Release);
             }
             .instrument(span),
@@ -261,10 +257,6 @@ impl NousActor {
         true
     }
 }
-
-// ---------------------------------------------------------------------------
-// Free async functions for background work
-// ---------------------------------------------------------------------------
 
 /// Run extraction as a background task. Logs results, never panics.
 async fn run_extraction(
@@ -343,19 +335,16 @@ async fn run_skill_extraction(
 ) {
     use aletheia_mneme::skills::SkillExtractor;
 
-    // Find the candidate in the tracker
     let candidates = tracker.candidates_for(nous_id);
     let Some(candidate) = candidates.iter().find(|c| c.id == candidate_id) else {
         warn!(candidate_id = %candidate_id, "candidate not found in tracker");
         return;
     };
 
-    // Build the extraction provider (uses Haiku for cost-effectiveness)
     let provider = crate::extraction::HermeneusSkillExtractionProvider::new(providers, model);
     let extractor = SkillExtractor::new(provider);
 
-    // The current turn's tool calls are the only sequence we have at this point.
-    // In a richer implementation, we'd collect sequences from all session_refs.
+    // NOTE: only current-turn tool calls available; historical sequences not yet collected
     let sequences = vec![tool_calls.to_vec()];
 
     match extractor.extract_skill(candidate, &sequences).await {
@@ -371,7 +360,6 @@ async fn run_skill_extraction(
 
             #[cfg(feature = "knowledge-store")]
             if let Some(store) = knowledge_store {
-                // Check for duplicates before storing
                 let skill_content = extracted.to_skill_content();
                 match store.find_duplicate_skill(nous_id, &skill_content) {
                     Ok(Some(existing_id)) => {
@@ -382,13 +370,12 @@ async fn run_skill_extraction(
                         );
                         return;
                     }
-                    Ok(None) => {} // No duplicate, proceed
+                    Ok(None) => {}
                     Err(e) => {
                         warn!(error = %e, "failed to check skill duplicates, proceeding with storage");
                     }
                 }
 
-                // Store as pending_review fact
                 let pending = aletheia_mneme::skills::PendingSkill::new(&extracted, candidate_id);
                 match pending.to_json() {
                     Ok(content) => {
@@ -436,7 +423,7 @@ async fn run_skill_extraction(
 
             #[cfg(not(feature = "knowledge-store"))]
             {
-                let _ = candidate_id; // suppress unused warning
+                let _ = candidate_id; // WHY: suppress unused-variable warning in non-knowledge-store builds
                 info!("skill extracted but knowledge-store feature disabled, not persisting");
             }
         }
@@ -463,8 +450,7 @@ async fn run_background_distillation(
         return;
     };
 
-    // Load history under the lock, then release before async work.
-    // Guard is scoped to the block and dropped before the .await below.
+    // WHY: load under lock, then release before async work to avoid holding lock across .await
     let (history, session) = {
         let s = store.lock().await;
         let Ok(Some(session)) = s.find_session_by_id(&session_id) else {
@@ -478,7 +464,7 @@ async fn run_background_distillation(
                 return;
             }
         }
-    }; // guard dropped here — lock released before await
+    };
 
     let messages = crate::distillation::convert_to_hermeneus_messages(&history);
     let engine =
@@ -505,7 +491,6 @@ async fn run_background_distillation(
         }
     };
 
-    // Apply results under the lock — guard is scoped to this block
     let s = store.lock().await;
     if let Err(e) = crate::distillation::apply_distillation(&s, &session_id, &result, &history) {
         warn!(error = %e, "failed to apply distillation");

--- a/crates/nous/src/actor/mod.rs
+++ b/crates/nous/src/actor/mod.rs
@@ -124,13 +124,11 @@ impl NousActor {
         extra_bootstrap: Vec<BootstrapSection>,
         active_turn: Arc<AtomicBool>,
     ) -> Self {
-        // Build the skill loader from the knowledge store when available.
         #[cfg(feature = "knowledge-store")]
         let skill_loader = knowledge_store
             .as_ref()
             .map(|ks| crate::skills::SkillLoader::new(Arc::clone(ks)));
 
-        // Build the BM25 text search from the knowledge store when available.
         #[cfg(feature = "knowledge-store")]
         let text_search: Option<Arc<dyn crate::recall::TextSearch>> =
             knowledge_store
@@ -192,7 +190,6 @@ impl NousActor {
         info!(lifecycle = %self.lifecycle, "actor started");
 
         loop {
-            // Reap completed background tasks
             self.reap_background_tasks();
 
             tokio::select! {
@@ -271,7 +268,6 @@ impl NousActor {
             }
         }
 
-        // Drain remaining background tasks before exiting
         while self.background_tasks.join_next().await.is_some() {}
 
         info!(lifecycle = %self.lifecycle, panic_count = self.panic_count, "actor stopped");
@@ -358,8 +354,7 @@ impl NousActor {
     /// Cancel-safe. The inner `resolve_skills` spawns a separate Tokio task for
     /// the blocking search; cancelling this future at the await point loses the
     /// skill result but leaves no inconsistent state.
-    // Without the knowledge-store feature the body has no `.await` — that is
-    // intentional; the function stays async so callers can `.await` uniformly.
+    // WHY: body has no .await without knowledge-store feature — kept async so callers .await uniformly
     #[cfg_attr(
         not(feature = "knowledge-store"),
         expect(
@@ -377,7 +372,7 @@ impl NousActor {
                     .await;
             }
         }
-        // Suppress unused-variable warning when feature is off
+        // WHY: suppress unused-variable warning when tui feature is off
         #[cfg(not(feature = "knowledge-store"))]
         let _ = content;
 

--- a/crates/nous/src/actor/spawn.rs
+++ b/crates/nous/src/actor/spawn.rs
@@ -115,7 +115,6 @@ pub(crate) async fn validate_workspace(oikos: &Oikos, nous_id: &str) -> crate::e
         .build());
     }
 
-    // Log warnings for missing optional workspace files
     for filename in &[
         "USER.md",
         "AGENTS.md",

--- a/crates/nous/src/actor/turn.rs
+++ b/crates/nous/src/actor/turn.rs
@@ -50,7 +50,6 @@ impl NousActor {
             .await;
 
         if let Ok(ref turn_result) = result {
-            // Update per-session cumulative token count for spending cap enforcement.
             if let Some(session) = self.sessions.get_mut(&session_key) {
                 session.cumulative_tokens = session
                     .cumulative_tokens
@@ -63,13 +62,13 @@ impl NousActor {
         }
 
         self.active_session = None;
-        // Preserve degraded state — only reset to Idle if not degraded
+        // WHY: only reset to Idle if not degraded — preserve degraded state
         if self.lifecycle != NousLifecycle::Degraded {
             self.lifecycle = NousLifecycle::Idle;
         }
         self.active_turn.store(false, Ordering::Release);
 
-        // Ignore send error — caller may have dropped the receiver
+        // WHY: ignore send error — caller may have dropped the receiver
         let _ = reply.send(result);
     }
 
@@ -107,7 +106,6 @@ impl NousActor {
             .await;
 
         if let Ok(ref turn_result) = result {
-            // Update per-session cumulative token count for spending cap enforcement.
             if let Some(session) = self.sessions.get_mut(&session_key) {
                 session.cumulative_tokens = session
                     .cumulative_tokens
@@ -120,11 +118,13 @@ impl NousActor {
         }
 
         self.active_session = None;
+        // WHY: only reset to Idle if not degraded — preserve degraded state
         if self.lifecycle != NousLifecycle::Degraded {
             self.lifecycle = NousLifecycle::Idle;
         }
         self.active_turn.store(false, Ordering::Release);
 
+        // WHY: ignore send error — caller may have dropped the receiver
         let _ = reply.send(result);
     }
 
@@ -138,8 +138,7 @@ impl NousActor {
         content: &str,
         caller_span: tracing::Span,
     ) -> crate::error::Result<TurnResult> {
-        // Spawn the pipeline in a separate task so panics are caught by the
-        // JoinHandle rather than propagating into the actor loop.
+        // WHY: pipeline spawned in separate task so panics are caught by JoinHandle, not the actor loop
         let result = self
             .spawn_pipeline_task(session_key, session_id, content, None, caller_span)
             .await;
@@ -181,7 +180,6 @@ impl NousActor {
         stream_tx: Option<mpsc::Sender<TurnStreamEvent>>,
         caller_span: tracing::Span,
     ) -> Result<crate::error::Result<TurnResult>, tokio::task::JoinError> {
-        // Prepare all data needed by the pipeline before spawning
         let session = self
             .sessions
             .entry(session_key.to_owned())
@@ -335,7 +333,6 @@ impl NousActor {
         self.panic_count += 1;
         self.panic_timestamps.push(std::time::Instant::now());
 
-        // Prune timestamps outside the window
         let cutoff = std::time::Instant::now()
             .checked_sub(DEGRADED_WINDOW)
             .unwrap_or(self.started_at);
@@ -366,8 +363,7 @@ impl NousActor {
             .sessions
             .entry(session_key.to_owned())
             .or_insert_with(|| {
-                // Cross-nous messages don't carry a database session ID;
-                // generate a fresh one and let finalize create the DB row.
+                // WHY: cross-nous messages carry no database session ID — generate one so finalize can create the DB row
                 let id = SessionId::new().to_string();
                 debug!(session_key, session_id = %id, "creating new session");
                 SessionState::new(id, session_key.to_owned(), &self.config)
@@ -399,7 +395,6 @@ impl NousActor {
             )),
         };
 
-        // Merge static domain-pack sections with dynamic skill sections.
         let mut extra_bootstrap = self.extra_bootstrap.clone();
         extra_bootstrap.extend(self.resolve_skill_sections(content).await);
 

--- a/crates/nous/src/bootstrap/mod.rs
+++ b/crates/nous/src/bootstrap/mod.rs
@@ -21,6 +21,7 @@ use crate::error::{self, Result};
 ///
 /// Determines inclusion order and drop/truncation behavior under budget pressure.
 /// Derives `Ord` so sections sort Required-first.
+#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum SectionPriority {
     /// Must be included. Missing = error.
@@ -197,7 +198,7 @@ impl<'a, E: TokenEstimator> BootstrapAssembler<'a, E> {
         let mut sections = self.resolve_workspace_files(nous_id).await?;
         sections.extend(extra_sections);
 
-        // Stable sort preserves declaration order within same priority
+        // NOTE: stable sort preserves declaration order within same priority
         sections.sort_by_key(|s| s.priority);
 
         let mut included: Vec<BootstrapSection> = Vec::new();
@@ -335,7 +336,6 @@ impl<'a, E: TokenEstimator> BootstrapAssembler<'a, E> {
             return self.truncate_by_lines(section, max_tokens);
         }
 
-        // Pre-format each part so token estimates are accurate.
         let formatted: Vec<String> = parts
             .iter()
             .enumerate()
@@ -348,7 +348,6 @@ impl<'a, E: TokenEstimator> BootstrapAssembler<'a, E> {
             })
             .collect();
 
-        // Iterate from newest to oldest, collecting parts that fit.
         let mut tokens_used: u64 = 0;
         let mut kept: Vec<usize> = Vec::new();
 
@@ -362,14 +361,14 @@ impl<'a, E: TokenEstimator> BootstrapAssembler<'a, E> {
         }
 
         if kept.is_empty() {
-            // No single section fits within the budget — fall back to lines.
+            // NOTE: no single section fits in budget — fall back to line-by-line truncation
             return self.truncate_by_lines(section, max_tokens);
         }
 
-        // Restore chronological order (kept is currently newest-first).
+        // NOTE: reverse restores chronological order — kept is newest-first from the backwards iteration
         kept.reverse();
 
-        // Prepend truncation marker so the reader knows oldest content was dropped.
+        // WHY: prepend marker so callers can see that oldest sections were dropped
         let mut result = String::from("... [truncated for token budget] ...");
         for i in kept {
             result.push_str(&formatted[i]);
@@ -392,7 +391,6 @@ impl<'a, E: TokenEstimator> BootstrapAssembler<'a, E> {
     fn truncate_by_lines(&self, section: &BootstrapSection, max_tokens: u64) -> BootstrapSection {
         let lines: Vec<&str> = section.content.lines().collect();
 
-        // Iterate from newest to oldest, collecting lines that fit.
         let mut tokens_used: u64 = 0;
         let mut kept: Vec<&str> = Vec::new();
 
@@ -408,7 +406,7 @@ impl<'a, E: TokenEstimator> BootstrapAssembler<'a, E> {
         }
 
         if kept.is_empty() {
-            // Even one line exceeds the budget — return only the marker.
+            // NOTE: even one line exceeds budget — return only the truncation marker
             let content = "... [truncated for token budget] ...".to_owned();
             let final_tokens = self.estimator.estimate(&content);
             return BootstrapSection {
@@ -420,10 +418,10 @@ impl<'a, E: TokenEstimator> BootstrapAssembler<'a, E> {
             };
         }
 
-        // Restore chronological order (kept is currently newest-first).
+        // NOTE: reverse restores chronological order — kept is newest-first from the backwards iteration
         kept.reverse();
 
-        // Prepend truncation marker so the reader knows oldest lines were dropped.
+        // WHY: prepend marker so callers can see that oldest lines were dropped
         let mut result = String::from("... [truncated for token budget] ...\n");
         for line in kept {
             result.push_str(line);

--- a/crates/nous/src/bootstrap/tools.rs
+++ b/crates/nous/src/bootstrap/tools.rs
@@ -84,7 +84,6 @@ pub fn format_tool_summary_section(summaries: &[ToolSummary]) -> String {
 fn extract_one_liner(description: &str) -> String {
     let first_line = description.lines().next().unwrap_or(description);
 
-    // Find first sentence boundary
     let end = first_line.find(". ").map_or(first_line.len(), |i| i + 1);
 
     let sentence = &first_line[..end];

--- a/crates/nous/src/budget.rs
+++ b/crates/nous/src/budget.rs
@@ -149,6 +149,7 @@ pub struct StageTimingRecord {
 }
 
 /// How a pipeline stage completed.
+#[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum StageTimingStatus {
     /// Stage ran to completion within its time budget.

--- a/crates/nous/src/distillation.rs
+++ b/crates/nous/src/distillation.rs
@@ -39,12 +39,12 @@ pub fn should_trigger_distillation(
     context_window: u64,
     config: &DistillTriggerConfig,
 ) -> Option<String> {
-    // Never distill on the first turn
+    // WHY: never distill on the first turn — no history to summarize
     if session.message_count <= 0 {
         return None;
     }
 
-    // Prefer actual context from last input; fall back to estimate
+    // NOTE: prefer actual context from last input; fall back to estimate
     let actual_context = if session.last_input_tokens > 0 {
         session.last_input_tokens
     } else {
@@ -57,17 +57,14 @@ pub fn should_trigger_distillation(
     )]
     let actual_context_u64 = actual_context as u64;
 
-    // Signal 1: Absolute context threshold (120K+)
     if actual_context_u64 >= 120_000 {
         return Some(format!("context={actual_context} >= 120K"));
     }
 
-    // Signal 2: High message count (150+)
     if session.message_count >= 150 {
         return Some(format!("message_count={} >= 150", session.message_count));
     }
 
-    // Signal 3: Stale + messages (7 days since last distill + 20 msgs)
     if let Some(ref last) = session.last_distilled_at
         && let Ok(last_ts) = last.parse::<jiff::Timestamp>()
     {
@@ -78,12 +75,10 @@ pub fn should_trigger_distillation(
         }
     }
 
-    // Signal 4: Never distilled + enough messages (30+)
     if session.distillation_count == 0 && session.message_count >= 30 {
         return Some(format!("never distilled + {} msgs", session.message_count));
     }
 
-    // Signal 5: Legacy threshold (configurable ratio of context window)
     #[expect(
         clippy::cast_precision_loss,
         clippy::cast_possible_truncation,
@@ -123,8 +118,7 @@ pub async fn maybe_distill(
         return Ok(None);
     };
 
-    // Idempotency guard: skip if distillation was applied very recently (< 60s).
-    // Protects against concurrent background tasks running duplicate distillations.
+    // INVARIANT: idempotency guard — skip if distillation applied recently (< 60s) to protect against concurrent background tasks
     if let Some(ref last) = session.last_distilled_at
         && let Ok(last_ts) = last.parse::<jiff::Timestamp>()
     {
@@ -187,16 +181,13 @@ pub fn apply_distillation(
     result: &DistillResult,
     history: &[aletheia_mneme::types::Message],
 ) -> error::Result<()> {
-    // Collect seq numbers of messages that were distilled (all except verbatim tail)
     let distill_count = result.messages_distilled.min(history.len());
     let seqs: Vec<i64> = history[..distill_count].iter().map(|m| m.seq).collect();
 
-    // Mark messages as distilled first
     store
         .mark_messages_distilled(session_id, &seqs)
         .context(error::StoreSnafu)?;
 
-    // Insert summary and clean up distilled messages
     let summary_content = format!(
         "[Distillation #{}]\n\n{}",
         result.distillation_number, result.summary
@@ -205,7 +196,6 @@ pub fn apply_distillation(
         .insert_distillation_summary(session_id, &summary_content)
         .context(error::StoreSnafu)?;
 
-    // Record distillation metadata
     #[expect(clippy::cast_possible_wrap, reason = "token/message counts fit in i64")]
     store
         .record_distillation(

--- a/crates/nous/src/execute/mod.rs
+++ b/crates/nous/src/execute/mod.rs
@@ -91,7 +91,6 @@ pub async fn execute(
             break;
         }
 
-        // Rebuild tool list each iteration so enable_tool activations take effect
         let active = tool_ctx
             .active_tools
             .read()
@@ -102,10 +101,10 @@ pub async fn execute(
             .clone();
         let tool_defs = tools.to_hermeneus_tools_filtered(&active);
 
-        // Derive server tools from config + active_tools (enable_tool activations)
+        // WHY: derive server tools on each iteration so enable_tool activations take effect
         let server_tools = if let Some(services) = tool_ctx.services.as_deref() {
             let mut st = services.server_tool_config.active_definitions(&active);
-            // Also include any raw server_tools from NousConfig for backward compat
+            // WHY: also include raw server_tools from NousConfig for backward compatibility
             st.extend(config.server_tools.clone());
             st
         } else {
@@ -179,8 +178,7 @@ pub async fn execute(
         final_content = text_parts.join("");
         final_stop_reason = response.stop_reason.to_string();
 
-        // Only break if there are no LOCAL tool uses to dispatch.
-        // Server tool results (web search, code execution) do not require client tool_result.
+        // WHY: only break on no local tool uses — server tool results don't require client tool_result
         if tool_uses.is_empty() || response.stop_reason != StopReason::ToolUse {
             break;
         }
@@ -250,7 +248,7 @@ pub async fn execute_streaming(
 ) -> error::Result<TurnResult> {
     let streaming_provider = providers.find_streaming_provider(&config.model);
 
-    // Fall back to non-streaming if no streaming provider available
+    // NOTE: fall back to non-streaming execute if no streaming provider is registered for this model
     let Some(streaming_provider) = streaming_provider else {
         return execute(ctx, session, config, providers, tools, tool_ctx).await;
     };
@@ -302,7 +300,7 @@ pub async fn execute_streaming(
             break;
         }
 
-        // Derive server tools from ServerToolConfig + NousConfig
+        // WHY: derive server tools on each iteration so enable_tool activations take effect
         let active = tool_ctx
             .active_tools
             .read()

--- a/crates/nous/src/finalize.rs
+++ b/crates/nous/src/finalize.rs
@@ -24,9 +24,7 @@ use crate::session::SessionState;
 /// are a millisecond timestamp, so the result is monotonically increasing
 /// within each millisecond and practically unique across restarts.
 fn turn_seq_from_ulid(ulid: &Ulid) -> i64 {
-    // ULID is a 128-bit value. Shift right 65 bits to keep the upper 63
-    // bits (47-bit timestamp + 16-bit randomness prefix), then cast to i64.
-    // The mask guarantees the sign bit is zero, so the cast can never wrap.
+    // NOTE: ULID is 128-bit — shift right 65 bits to keep upper 63 bits (47-bit timestamp + 16-bit randomness prefix); mask ensures sign bit is zero so cast to i64 never wraps
     let raw = u128::from(*ulid);
     ((raw >> 65) & 0x7FFF_FFFF_FFFF_FFFF) as i64
 }
@@ -80,15 +78,9 @@ pub fn finalize(
     result: &TurnResult,
     config: &FinalizeConfig,
 ) -> error::Result<FinalizeResult> {
-    // Dedup guard: check if this turn was already finalized (usage record exists).
+    // INVARIANT: dedup guard — skip if this turn was already finalized (usage record exists)
     //
-    // WHY(#1036): Use turn_id (a fresh ULID from next_turn) as the unique key
-    // instead of the sequential turn counter. The sequential counter resets to 0
-    // after an actor restart with session adoption, causing false dedup hits that
-    // silently discard new turns. The ULID is globally unique per invocation.
-    //
-    // The turn_id's upper 63 bits are used as turn_seq. A ULID's upper bits carry
-    // the millisecond timestamp, making this value monotonically increasing.
+    // WHY: turn_id (fresh ULID) is the dedup key rather than session_id — see issue #1036
     let turn_seq = turn_seq_from_ulid(&session.turn_id);
     if store
         .usage_exists_for_turn(&session.id, turn_seq)
@@ -108,10 +100,7 @@ pub fn finalize(
     let mut messages_persisted = 0usize;
 
     if config.persist_messages {
-        // Ensure session record exists before inserting child messages.
-        // The nous actor creates sessions in memory; the SQLite store may
-        // not have a matching row yet, which would cause a FOREIGN KEY
-        // constraint failure on the messages table.
+        // WHY: ensure session row exists before child messages — FK constraint on messages table would otherwise fail
         store
             .find_or_create_session(
                 &session.id,
@@ -121,7 +110,6 @@ pub fn finalize(
                 None,
             )
             .context(error::StoreSnafu)?;
-        // User message
         #[expect(clippy::cast_possible_wrap, reason = "message length fits in i64")]
         let input_token_estimate = input_content.len() as i64 / 4;
         store
@@ -136,7 +124,6 @@ pub fn finalize(
             .context(error::StoreSnafu)?;
         messages_persisted += 1;
 
-        // Tool call/result pairs
         for tc in &result.tool_calls {
             let input_json = serde_json::to_string(&tc.input).unwrap_or_else(|e| {
                 warn!(error = %e, tool = %tc.name, "failed to serialize tool call input");
@@ -168,7 +155,6 @@ pub fn finalize(
             messages_persisted += 1;
         }
 
-        // Assistant response
         let output_tokens = i64::try_from(result.usage.output_tokens).unwrap_or(0);
         store
             .append_message(

--- a/crates/nous/src/history.rs
+++ b/crates/nous/src/history.rs
@@ -80,15 +80,11 @@ pub fn load_history(
         ));
     }
 
-    // Single query: load all messages once, then filter and budget manually.
-    // This eliminates the redundant second query that the old approach used and
-    // ensures the `truncated` flag applies the same role filter as the loading
-    // loop (fix for #1102).
+    // WHY: single query to eliminate redundant second query; also ensures truncated flag uses same role filter as load loop (fix for #1102)
     let all_messages = store
         .get_history(session_id, None)
         .context(error::StoreSnafu)?;
 
-    // Count messages eligible under the same role filter as the loading loop.
     let total_eligible = all_messages
         .iter()
         .filter(|m| {
@@ -96,8 +92,6 @@ pub fn load_history(
         })
         .count();
 
-    // Iterate newest-first: collect the most recent messages that fit within
-    // the available budget and max_messages cap.
     let mut collected: Vec<PipelineMessage> = Vec::new();
     let mut tokens_consumed: i64 = 0;
     let mut loaded_count: usize = 0;
@@ -132,11 +126,10 @@ pub fn load_history(
         loaded_count += 1;
     }
 
-    // Restore chronological order (collected is currently newest-first).
+    // WHY: restore chronological order — collected newest-first
     collected.reverse();
 
-    // Truncated when eligible messages exceed what was loaded — covers both
-    // budget truncation and max_messages truncation.
+    // INVARIANT: truncated when eligible messages exceed what was loaded
     let truncated = total_eligible > loaded_count;
 
     collected.push(PipelineMessage {

--- a/crates/nous/src/manager.rs
+++ b/crates/nous/src/manager.rs
@@ -165,7 +165,7 @@ impl NousManager {
         if let Some(old) = self.actors.remove(&id) {
             warn!(nous_id = %id, "replacing existing actor");
             let _ = old.handle.shutdown().await;
-            // Take join handle before awaiting — must not hold MutexGuard across .await.
+            // WHY: take join handle before awaiting — must not hold MutexGuard across .await
             let join_opt = old.join.lock().expect("join mutex not poisoned").take();
             if let Some(join) = join_opt {
                 let _ = join.await;
@@ -183,7 +183,6 @@ impl NousManager {
     ) -> NousHandle {
         let id = config.id.clone();
 
-        // Filter and convert domain pack sections for this agent (by ID or domain tags)
         let extra_bootstrap = {
             let estimator = CharEstimator;
             let mut sections = Vec::new();
@@ -276,7 +275,6 @@ impl NousManager {
             // signal so busy actors are not incorrectly declared dead.
             let alive = ping_result.is_ok() || entry.active_turn.load(Ordering::Acquire);
 
-            // Try to get status for panic_count and uptime
             let (panic_count, uptime) = if let Ok(status) = entry.handle.status().await {
                 (status.panic_count, status.uptime)
             } else {
@@ -301,7 +299,6 @@ impl NousManager {
     pub async fn health_cycle(&mut self) {
         let health = self.check_health().await;
 
-        // Collect IDs that need restart to avoid borrow issues
         let mut to_restart: Vec<String> = Vec::new();
 
         for (id, actor_health) in &health {
@@ -356,22 +353,18 @@ impl NousManager {
         let pipeline_config = entry.pipeline_config.clone();
         let prev_restart_count = entry.restart_count;
 
-        // Remove old entry
         if let Some(old) = self.actors.remove(id) {
-            // Take join handle before any await
+            // WHY: take join handle before awaiting — must not hold MutexGuard across .await
             let join_opt = old.join.lock().expect("join mutex not poisoned").take();
             if let Some(join) = join_opt {
-                // Don't wait too long for a dead actor
                 let _ = tokio::time::timeout(Duration::from_secs(2), join).await;
             }
         }
 
-        // Respawn
         let handle = self
             .spawn_inner(config.clone(), pipeline_config.clone())
             .await;
 
-        // Update restart tracking
         if let Some(entry) = self.actors.get_mut(id) {
             entry.restart_count = prev_restart_count + 1;
             entry.consecutive_misses = 0;
@@ -449,14 +442,13 @@ impl NousManager {
             }
         }
 
-        // Drain actors; collect handles and join handles for two-phase shutdown.
         let handles: Vec<(String, NousHandle)> = self
             .actors
             .iter()
             .map(|(id, e)| (id.clone(), e.handle.clone()))
             .collect();
 
-        // Take all join handles before any await — must not hold MutexGuard across .await.
+        // WHY: take all join handles before any await — must not hold MutexGuard across .await
         let joins: Vec<(String, Option<JoinHandle<()>>)> = self
             .actors
             .drain()
@@ -502,7 +494,6 @@ impl NousManager {
     pub async fn drain(&self, timeout: Duration) {
         info!(count = self.actors.len(), "draining all actors");
 
-        // Notify all actors simultaneously via the shared root token.
         self.cancel.cancel();
 
         if let Some(ref router) = self.router {
@@ -511,16 +502,14 @@ impl NousManager {
             }
         }
 
-        // Also send explicit Shutdown messages so actors waiting on inbox wake up.
+        // WHY: explicit Shutdown messages wake actors blocking on inbox recv
         for entry in self.actors.values() {
             if let Err(e) = entry.handle.shutdown().await {
                 warn!(nous_id = entry.handle.id(), error = %e, "failed to send shutdown");
             }
         }
 
-        // Await all join handles within the timeout, so callers can guarantee
-        // all Arc<KnowledgeStore> / fjall Database references are dropped.
-        // Take handles first to avoid holding MutexGuard across .await points.
+        // WHY: take handles before await — must not hold MutexGuard across .await
         let mut joins: Vec<(String, JoinHandle<()>)> = self
             .actors
             .iter()

--- a/crates/nous/src/message.rs
+++ b/crates/nous/src/message.rs
@@ -10,6 +10,7 @@ use crate::pipeline::TurnResult;
 use crate::stream::TurnStreamEvent;
 
 /// Messages sent to a [`NousActor`](crate::actor::NousActor) via its inbox.
+#[non_exhaustive]
 pub enum NousMessage {
     /// Process a user message in a session.
     Turn {
@@ -47,6 +48,7 @@ pub enum NousMessage {
 }
 
 /// Lifecycle state machine for a nous actor.
+#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum NousLifecycle {
     /// Processing a turn or background task.

--- a/crates/nous/src/metrics.rs
+++ b/crates/nous/src/metrics.rs
@@ -1,7 +1,6 @@
 //! Prometheus metric definitions for the agent pipeline.
 
-// Prometheus metric registration panics only if a duplicate name is registered
-// (programmer error), so .expect() is appropriate in LazyLock initializers.
+// WHY: registration panics only on duplicate name (programmer error), so .expect() is appropriate in LazyLock
 #![expect(
     clippy::expect_used,
     reason = "metric registration is infallible at startup"

--- a/crates/nous/src/pipeline.rs
+++ b/crates/nous/src/pipeline.rs
@@ -87,6 +87,7 @@ pub struct PipelineMessage {
 }
 
 /// Guard stage result.
+#[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum GuardResult {
     /// Request is allowed.
@@ -141,7 +142,6 @@ impl LoopDetector {
         let signature = format!("{tool_name}:{input_hash}");
         self.history.push_back(signature.clone());
 
-        // Evict oldest entry if over window cap
         if self.history.len() > self.window {
             self.history.pop_front();
         }
@@ -149,19 +149,15 @@ impl LoopDetector {
         let n = self.history.len();
         let t = self.threshold as usize;
 
-        // Check for N consecutive identical calls
         let recent = self.history.iter().rev().take(t);
         let all_same = recent.clone().count() >= t && recent.clone().all(|s| *s == signature);
         if all_same {
             return Some(signature);
         }
 
-        // Check for repeating sequence cycles (A→B→C→A etc.).
-        //
-        // A cycle of length L is confirmed when the last L×threshold history
-        // entries consist of exactly `threshold` repetitions of the same
-        // L-length pattern.  The inner comparison uses `VecDeque::get` so no
-        // allocation is required.
+        // NOTE: cycle detection — a cycle of length L is confirmed when the last L×threshold
+        // history entries consist of exactly `threshold` repetitions of the same L-length pattern;
+        // `VecDeque::get` is used to avoid allocation in the inner comparison.
         for cycle_len in 2..=CYCLE_DETECTION_MAX_LEN {
             let needed = cycle_len * t;
             if n < needed {
@@ -409,7 +405,6 @@ pub async fn run_pipeline(
     let _pipeline_guard = pipeline_span.enter();
     let mut stages_completed: u32 = 0;
 
-    // Stage 1: Context (with domain pack sections if any)
     let mut ctx = PipelineContext::default();
     {
         let span = info_span!(
@@ -437,7 +432,6 @@ pub async fn run_pipeline(
         stages_completed += 1;
     }
 
-    // Stage 1.5: Recall
     {
         let span = info_span!(
             "pipeline_stage",
@@ -456,7 +450,7 @@ pub async fn run_pipeline(
         )]
         let budget = ctx.remaining_tokens.max(0) as u64;
 
-        // BM25-only fallback when mock embedding provider is in use.
+        // NOTE: BM25-only fallback when mock embedding provider is in use.
         // Vector recall would produce meaningless results from hash-based embeddings.
         if is_mock_embedding {
             if let Some(ts) = text_search {
@@ -510,7 +504,6 @@ pub async fn run_pipeline(
         stages_completed += 1;
     }
 
-    // Stage 2: History
     {
         let span = info_span!(
             "pipeline_stage",
@@ -521,13 +514,13 @@ pub async fn run_pipeline(
         let _guard = span.enter();
         let start = Instant::now();
 
-        // Waterfall: unused system-prompt budget flows into the history budget
+        // NOTE: Waterfall — unused system-prompt budget flows into the history budget
         // so tokens not consumed by bootstrap or recall are not wasted.
         ctx.history_budget += ctx.remaining_tokens.max(0);
 
         let history_config = HistoryConfig::default();
         if let Some(store_mutex) = session_store {
-            // Guard is scoped to this block and dropped before the execute .await below
+            // WHY: guard scoped and dropped before execute .await
             let store = store_mutex.lock().await;
             let (messages, hist_result) = history::load_history(
                 &store,
@@ -561,7 +554,6 @@ pub async fn run_pipeline(
         stages_completed += 1;
     }
 
-    // Stage 3: Guard
     {
         let span = info_span!(
             "pipeline_stage",
@@ -610,9 +602,6 @@ pub async fn run_pipeline(
         }
     }
 
-    // Stage 4: Resolve (stub)
-
-    // Stage 5: Execute
     let result;
     {
         let span = info_span!(
@@ -626,8 +615,7 @@ pub async fn run_pipeline(
         let _guard = span.enter();
         let start = Instant::now();
 
-        // Compute the effective execute timeout: prefer per-stage budget, fall
-        // back to remaining time from total pipeline budget, whichever is tighter.
+        // NOTE: prefer per-stage budget, fall back to remaining time from total pipeline budget, whichever is tighter.
         let execute_secs = pipeline_config.stage_budget.execute_secs;
         let effective_execute_timeout = match (execute_secs > 0, total_timeout) {
             (true, Some(total)) => {
@@ -694,7 +682,6 @@ pub async fn run_pipeline(
         stages_completed += 1;
     }
 
-    // Stage 6: Finalize
     {
         let span = info_span!(
             "pipeline_stage",
@@ -742,8 +729,6 @@ pub async fn run_pipeline(
         stages_completed += 1;
     }
 
-    // Record tool observations for the instinct system (behavioral memory).
-    // This is non-blocking and does not affect the pipeline result.
     if !result.tool_calls.is_empty() {
         crate::instinct::record_observations(&result.tool_calls, &input.content, &config.id);
     }

--- a/crates/nous/src/recall.rs
+++ b/crates/nous/src/recall.rs
@@ -332,7 +332,6 @@ impl RecallStage {
     ) -> error::Result<RecallStageResult> {
         let k = self.config.max_results * 3;
 
-        // Cycle 1: embed and search with original query
         let query_vec = embed(query, embedding_provider)?;
         let raw_cycle1 = search(vector_search, query_vec, k)?;
 
@@ -341,7 +340,6 @@ impl RecallStage {
             return Ok(RecallStageResult::empty());
         }
 
-        // Rank cycle 1 for terminology discovery (clone raw for later merge)
         let candidates_c1 = self.build_candidates(raw_cycle1.clone(), nous_id);
         let ranked_c1 = self.engine.rank(candidates_c1);
 
@@ -353,7 +351,6 @@ impl RecallStage {
             return Ok(self.finalize_results(ranked_c1, remaining_budget));
         }
 
-        // Build refined query: original + discovered terms + gap entities
         let mut refined = String::from(query);
         for term in &terms {
             refined.push(' ');
@@ -371,11 +368,9 @@ impl RecallStage {
             "cycle 2 with refined query"
         );
 
-        // Cycle 2: embed and search with refined query
         let refined_vec = embed(&refined, embedding_provider)?;
         let raw_cycle2 = search(vector_search, refined_vec, k)?;
 
-        // Merge and deduplicate by source_id
         let mut seen: HashSet<String> = HashSet::new();
         let mut merged: Vec<KnowledgeRecallResult> = Vec::new();
         for r in raw_cycle1 {
@@ -497,8 +492,6 @@ impl RecallStage {
     }
 }
 
-// --- Helpers ---
-
 fn embed(query: &str, provider: &dyn EmbeddingProvider) -> error::Result<Vec<f32>> {
     provider.embed(query).map_err(|e| {
         error::RecallEmbeddingSnafu {
@@ -520,8 +513,6 @@ fn search(
         .build()
     })
 }
-
-// --- Stopword list ---
 
 static STOPWORDS: LazyLock<HashSet<&str>> = LazyLock::new(|| {
     HashSet::from([
@@ -659,8 +650,6 @@ fn is_stopword(word: &str) -> bool {
     STOPWORDS.contains(word)
 }
 
-// --- Terminology discovery ---
-
 /// Extract domain-specific terms from first-pass results not present in the original query.
 ///
 /// Splits result content on whitespace, filters stopwords and short words,
@@ -688,8 +677,6 @@ fn discover_terminology(results: &[ScoredResult], original_query: &str) -> Vec<S
     terms.into_iter().take(5).map(|(t, _)| t).collect()
 }
 
-// --- Gap detection ---
-
 /// Detect entity references in results that aren't captured as result IDs.
 ///
 /// Scans for capitalized multi-word phrases (2+ consecutive capitalized words)
@@ -700,7 +687,6 @@ fn detect_gaps(results: &[ScoredResult]) -> Vec<String> {
     let mut seen: HashSet<String> = HashSet::new();
 
     for result in results {
-        // Capitalized multi-word phrases
         let words: Vec<&str> = result.content.split_whitespace().collect();
         let mut i = 0;
         while i < words.len() {
@@ -720,7 +706,6 @@ fn detect_gaps(results: &[ScoredResult]) -> Vec<String> {
             }
         }
 
-        // Quoted strings
         for quoted in extract_quoted_strings(&result.content) {
             if !source_ids.contains(quoted.as_str()) && seen.insert(quoted.clone()) {
                 gaps.push(quoted);
@@ -745,8 +730,6 @@ fn extract_quoted_strings(text: &str) -> Vec<String> {
         .map(|(_, part)| (*part).to_owned())
         .collect()
 }
-
-// --- Formatting ---
 
 /// Format scored results as a markdown section.
 #[must_use]

--- a/crates/nous/src/skills.rs
+++ b/crates/nous/src/skills.rs
@@ -6,8 +6,6 @@
 //! Skills are injected at `SectionPriority::Flexible`, so they are truncated
 //! before workspace identity files under budget pressure.
 
-// ── Always-available pure utilities ─────────────────────────────────────────
-
 /// Maximum characters of task context to send as the BM25 query.
 ///
 /// Longer queries dilute BM25 scores; keep the signal tight.
@@ -30,13 +28,12 @@ pub(crate) fn extract_task_context(content: &str) -> String {
         return trimmed.to_owned();
     }
 
-    // Truncate to MAX_CONTEXT_CHARS at a valid char boundary
     let mut end = MAX_CONTEXT_CHARS;
     while end > 0 && !trimmed.is_char_boundary(end) {
         end -= 1;
     }
 
-    // Prefer breaking at a word boundary
+    // WHY: prefer breaking at word boundary to avoid cutting mid-word
     let word_end = trimmed[..end].rfind(' ').unwrap_or(end);
     trimmed[..word_end].trim_end().to_owned()
 }
@@ -57,9 +54,7 @@ fn sanitize_fts_query(input: &str) -> String {
             result.push(' ');
             prev_space = true;
         }
-        // Other punctuation is dropped
     }
-    // Trim trailing space
     if result.ends_with(' ') {
         result.pop();
     }
@@ -76,7 +71,7 @@ pub(crate) fn format_skill_as_markdown(skill: &aletheia_mneme::skill::SkillConte
     if !skill.steps.is_empty() {
         md.push_str("\n\n**Steps:**\n");
         for (i, step) in skill.steps.iter().enumerate() {
-            // writeln! on String never returns Err
+            // SAFETY: writeln! on String is infallible
             let _ = writeln!(md, "{}. {}", i + 1, step);
         }
     }
@@ -91,8 +86,6 @@ pub(crate) fn format_skill_as_markdown(skill: &aletheia_mneme::skill::SkillConte
 
     md
 }
-
-// ── knowledge-store-only items ───────────────────────────────────────────────
 
 #[cfg(feature = "knowledge-store")]
 use std::sync::Arc;
@@ -185,7 +178,7 @@ impl SkillLoader {
             return vec![];
         }
 
-        // Fetch 2× candidates to have headroom for ranking
+        // WHY: fetch 2x candidates to have headroom for ranking
         let fetch_limit = max_skills.saturating_mul(2).max(4);
         let store = Arc::clone(&self.knowledge_store);
         let nous_id_owned = nous_id.to_owned();
@@ -217,7 +210,7 @@ impl SkillLoader {
 
         let sections: Vec<BootstrapSection> = selected.iter().map(fact_to_section).collect();
 
-        // Increment access counts in the background — do not block the pipeline
+        // WHY: background increment avoids blocking the pipeline
         if !selected.is_empty() {
             let ids: Vec<_> = selected.iter().map(|f| f.id.clone()).collect();
             let store = Arc::clone(&self.knowledge_store);
@@ -298,7 +291,7 @@ pub(crate) fn rank_skills(candidates: Vec<Fact>) -> Vec<Fact> {
                 reason = "age in seconds converted to days; sub-second precision is not needed"
             )]
             let age_days = ((now_secs - reference_secs).max(0) as f64) / 86_400.0;
-            // Half-life of 30 days: recency = 2^(-age/30)
+            // NOTE: half-life of 30 days: recency = 2^(-age/30)
             let recency_score = 2_f64.powf(-age_days / 30.0);
 
             let score = 0.40 * position_score
@@ -310,14 +303,9 @@ pub(crate) fn rank_skills(candidates: Vec<Fact>) -> Vec<Fact> {
         })
         .collect();
 
-    // Sort descending by score
     scored.sort_by(|(a, _), (b, _)| b.partial_cmp(a).unwrap_or(std::cmp::Ordering::Equal));
     scored.into_iter().map(|(_, fact)| fact).collect()
 }
-
-// ============================================================================
-// Tests
-// ============================================================================
 
 #[cfg(test)]
 #[allow(clippy::unwrap_used, reason = "test assertions")]

--- a/crates/nous/src/spawn_svc.rs
+++ b/crates/nous/src/spawn_svc.rs
@@ -105,7 +105,6 @@ impl SpawnService for SpawnServiceImpl {
 
         Box::pin(
             async move {
-                // Create minimal workspace directory for the ephemeral agent
                 let nous_dir = oikos.nous_dir(&spawn_id);
                 if let Err(e) = tokio::fs::create_dir_all(&nous_dir).await {
                     return Err(format!("failed to create spawn workspace: {e}"));
@@ -120,8 +119,7 @@ impl SpawnService for SpawnServiceImpl {
                     return Err(format!("failed to write SOUL.md: {e}"));
                 }
 
-                // Ephemeral actors get their own token; they are
-                // short-lived and don't need a shared parent.
+                // WHY: ephemeral actors get their own cancellation token — short-lived, no shared parent
                 let ephemeral_cancel = CancellationToken::new();
                 let (handle, join_handle, _active_turn) = actor::spawn(
                     config,

--- a/crates/theatron/tui/src/actions.rs
+++ b/crates/theatron/tui/src/actions.rs
@@ -139,9 +139,7 @@ impl App {
                     auto_scroll: self.auto_scroll,
                 },
             );
-            // Prune stale entries once the map exceeds MAX_SCROLL_STATES.
-            // Retain only agents present in the current roster so that sessions
-            // closed or removed do not hold memory indefinitely.
+            // NOTE: prune stale entries once the map exceeds MAX_SCROLL_STATES, retaining only agents in the current roster
             if self.scroll_states.len() > MAX_SCROLL_STATES {
                 let active: Vec<_> = self.agents.iter().map(|a| a.id.clone()).collect();
                 self.scroll_states.retain(|k, _| active.contains(k));

--- a/crates/theatron/tui/src/api/client.rs
+++ b/crates/theatron/tui/src/api/client.rs
@@ -111,8 +111,7 @@ impl ApiClient {
     }
 
     fn request(&self, method: reqwest::Method, path: &str) -> reqwest::RequestBuilder {
-        // WHY: Authorization is already in the client's default headers (set at build time).
-        // No per-request header injection needed — the token does not change after construction.
+        // NOTE: no per-request header injection — token is fixed at construction
         self.client.request(method, self.url(path))
     }
 
@@ -396,9 +395,7 @@ impl ApiClient {
         let daily: DailyResponse = resp.json().await.context(HttpSnafu {
             operation: "costs response",
         })?;
-        // Get today's entry (last in list)
         let today_cost = daily.daily.last().map(|d| d.cost).unwrap_or(0.0);
-        // Convert dollars to cents
         Ok((today_cost * 100.0) as u32)
     }
 

--- a/crates/theatron/tui/src/api/error.rs
+++ b/crates/theatron/tui/src/api/error.rs
@@ -6,6 +6,7 @@ use snafu::prelude::*;
 /// - `Http`: a transport or connection error from `reqwest`
 /// - `Server`: a non-2xx HTTP response with a human-readable message from the server body
 /// - `Auth`: a 401/403 from the gateway
+#[non_exhaustive]
 #[derive(Debug, Snafu)]
 #[snafu(visibility(pub(crate)))]
 pub enum ApiError {

--- a/crates/theatron/tui/src/api/sse.rs
+++ b/crates/theatron/tui/src/api/sse.rs
@@ -54,7 +54,7 @@ impl SseConnection {
                         let maybe_event = tokio::time::timeout(READ_TIMEOUT, es.next()).await;
                         let event = match maybe_event {
                             Ok(Some(event)) => event,
-                            Ok(None) => break, // stream ended cleanly
+                            Ok(None) => break,
                             Err(_elapsed) => {
                                 // WHY: No event received within READ_TIMEOUT. A healthy
                                 // server sends pings more frequently than this window, so
@@ -78,7 +78,8 @@ impl SseConnection {
                                 if let Some(parsed) = parse_sse_event(&msg.event, &msg.data)
                                     && tx.send(parsed).await.is_err()
                                 {
-                                    return; // Receiver dropped, shut down
+                                    // WHY: receiver dropped — shut down the SSE loop
+                                    return;
                                 }
                             }
                             Err(reqwest_eventsource::Error::InvalidStatusCode(status, resp)) => {

--- a/crates/theatron/tui/src/app.rs
+++ b/crates/theatron/tui/src/app.rs
@@ -42,94 +42,70 @@ pub struct App {
     pub highlighter: crate::highlight::Highlighter,
     pub should_quit: bool,
 
-    // Dashboard state
     pub agents: Vec<AgentState>,
     pub focused_agent: Option<NousId>,
     pub messages: Vec<ChatMessage>,
     pub focused_session_id: Option<SessionId>,
     pub daily_cost_cents: u32,
 
-    // Input
     pub input: InputState,
 
-    // Layout
     pub sidebar_visible: bool,
     pub thinking_expanded: bool,
 
-    // Overlay
     pub overlay: Option<Overlay>,
 
-    // Streaming state
     pub active_turn_id: Option<TurnId>,
     pub streaming_text: String,
     pub streaming_thinking: String,
     pub streaming_tool_calls: Vec<ToolCallInfo>,
     pub(crate) stream_rx: Option<mpsc::Receiver<StreamEvent>>,
 
-    // SSE
     sse: Option<SseConnection>,
     pub sse_connected: bool,
     /// When the SSE stream last disconnected. Cleared on successful reconnect.
     pub sse_disconnected_at: Option<std::time::Instant>,
 
-    // Scroll
     pub scroll_offset: usize,
     pub auto_scroll: bool,
     pub(crate) scroll_states: HashMap<NousId, SavedScrollState>,
 
-    // Virtual scroll — O(viewport) rendering for large message lists
     pub(crate) virtual_scroll: VirtualScroll,
 
-    // Markdown cache — avoid re-parsing on every frame
     pub cached_markdown_text: String,
     pub cached_markdown_lines: Vec<ratatui::text::Line<'static>>,
 
-    // Tick counter for spinner animation
     pub tick_count: u64,
 
-    // Error toast (auto-dismiss after 5s)
     pub error_toast: Option<ErrorToast>,
-    // Success toast (auto-dismiss after 5s)
     pub success_toast: Option<ErrorToast>,
 
-    // @mention tab completion state
     pub tab_completion: Option<TabCompletion>,
 
-    // Terminal size for responsive layout
     pub terminal_width: u16,
     pub terminal_height: u16,
 
-    // Command palette (`:` mode)
     pub command_palette: CommandPaletteState,
 
-    // Status bar enhanced fields
     pub session_cost_cents: u32,
     pub context_usage_pct: Option<u8>,
     pub selection: SelectionContext,
 
-    // Message selection (None = auto-scroll mode, Some(index) = message selected)
     pub selected_message: Option<usize>,
     pub tool_expanded: HashSet<crate::id::ToolId>,
 
-    // Live filter (`/` mode)
     pub filter: FilterState,
 
-    // Stack-based navigation (Enter drills in, Esc pops out)
     pub view_stack: ViewStack,
 
-    // Per-view scroll state preservation
     pub(crate) view_scroll_states: HashMap<usize, SavedScrollState>,
 
-    // Operations pane (right-side panel)
     pub ops: OpsState,
 
-    // Multi-session tab bar
     pub(crate) tab_bar: TabBar,
 
-    // Vim `g` prefix pending (for gt/gT two-key sequences)
     pub(crate) pending_g: bool,
 
-    // Memory inspector panel state
     pub memory: MemoryInspectorState,
 }
 
@@ -232,8 +208,7 @@ impl App {
             }
         }
 
-        // SAFETY: sanitized at ingestion — all agent fields from API are sanitized here.
-        // Best-effort: if agent fetch fails, start with empty list and show error toast.
+        // NOTE: Best-effort agent fetch — on failure, start with empty list and show toast.
         let agents = match self.client.agents().await {
             Ok(a) => a,
             Err(e) => {
@@ -279,7 +254,6 @@ impl App {
             }
             self.load_focused_session().await;
 
-            // Create initial tab for the default agent/session
             let agent_name = self
                 .agents
                 .iter()
@@ -361,7 +335,6 @@ impl App {
 
             match self.client.history(&session_id).await {
                 Ok(history) => {
-                    // SAFETY: sanitized at ingestion — all message fields from API.
                     self.messages = history
                         .into_iter()
                         .filter_map(|m| {
@@ -384,8 +357,8 @@ impl App {
                             })
                         })
                         .collect();
-                    // Stale streaming markdown from the previous session must not
-                    // bleed through when the user switches agents.
+                    // WHY: Clear stale streaming markdown so it doesn't bleed through
+                    // when the user switches agents mid-stream.
                     self.cached_markdown_text.clear();
                     self.cached_markdown_lines.clear();
                     self.rebuild_virtual_scroll();
@@ -624,7 +597,7 @@ mod tests {
     use crate::state::{ChatMessage, OpsState};
 
     #[test]
-    fn test_app_constructs_with_defaults() {
+    fn app_constructs_with_default_state() {
         let app = test_app();
         assert!(!app.should_quit);
         assert!(app.auto_scroll);
@@ -641,7 +614,7 @@ mod tests {
     }
 
     #[test]
-    fn test_app_with_messages_populates() {
+    fn app_populates_state_from_message_list() {
         let app = test_app_with_messages(vec![("user", "hello"), ("assistant", "hi there")]);
         assert_eq!(app.messages.len(), 2);
         assert_eq!(app.messages[0].role, "user");

--- a/crates/theatron/tui/src/clipboard.rs
+++ b/crates/theatron/tui/src/clipboard.rs
@@ -1,7 +1,6 @@
 /// Copy text to the system clipboard.
 /// Tries arboard (native) first, falls back to OSC52 escape sequence.
 pub fn copy_to_clipboard(text: &str) -> Result<(), String> {
-    // Try native clipboard via arboard
     match arboard::Clipboard::new() {
         Ok(mut clipboard) => match clipboard.set_text(text) {
             Ok(()) => {
@@ -28,7 +27,7 @@ fn copy_osc52(text: &str) -> Result<(), String> {
 
     let encoded = STANDARD.encode(text.as_bytes());
 
-    // Check if we're in tmux — need passthrough wrapper
+    // NOTE: tmux requires an OSC52 passthrough wrapper for the escape sequence to reach the terminal
     let seq = if std::env::var("TMUX").is_ok() {
         format!("\x1bPtmux;\x1b\x1b]52;c;{}\x07\x1b\\", encoded)
     } else {

--- a/crates/theatron/tui/src/command/mod.rs
+++ b/crates/theatron/tui/src/command/mod.rs
@@ -189,7 +189,6 @@ pub fn build_suggestions(input: &str, agents: &[AgentState]) -> Vec<Suggestion> 
     let mut suggestions: Vec<Suggestion> = Vec::new();
 
     if query.is_empty() {
-        // Show all static commands + agent entries
         for cmd in COMMANDS {
             suggestions.push(Suggestion {
                 label: cmd.name.to_string(),
@@ -205,7 +204,6 @@ pub fn build_suggestions(input: &str, agents: &[AgentState]) -> Vec<Suggestion> 
             suggestions.push(agent_suggestion(agent, 0));
         }
     } else {
-        // Fuzzy match static commands
         for cmd in COMMANDS {
             if let Some(score) = best_match(&matcher, cmd, query) {
                 suggestions.push(Suggestion {
@@ -220,7 +218,6 @@ pub fn build_suggestions(input: &str, agents: &[AgentState]) -> Vec<Suggestion> 
             }
         }
 
-        // Inject dynamic agent suggestions
         for agent in agents {
             let mut best: Option<i64> = None;
             if let Some(s) = matcher.fuzzy_match(&agent.name, query) {
@@ -229,7 +226,7 @@ pub fn build_suggestions(input: &str, agents: &[AgentState]) -> Vec<Suggestion> 
             if let Some(s) = matcher.fuzzy_match(&agent.id, query) {
                 best = best.map_or(Some(s), |prev| Some(prev.max(s)));
             }
-            // Also match "agent <name>" as a compound
+            // NOTE: Also match "agent <name>" as a compound so typing "agent syn" surfaces the agent.
             let compound = format!("agent {}", agent.name);
             if let Some(s) = matcher.fuzzy_match(&compound, query) {
                 best = best.map_or(Some(s), |prev| Some(prev.max(s)));
@@ -241,7 +238,7 @@ pub fn build_suggestions(input: &str, agents: &[AgentState]) -> Vec<Suggestion> 
     }
 
     suggestions.sort_by(|a, b| b.score.cmp(&a.score));
-    // Show more on empty input (initial palette open), but still cap for display
+    // NOTE: Show more results on empty input (initial open) than for active queries.
     let limit = if query.is_empty() {
         MAX_SUGGESTIONS_INITIAL
     } else {

--- a/crates/theatron/tui/src/diff.rs
+++ b/crates/theatron/tui/src/diff.rs
@@ -123,7 +123,8 @@ pub(crate) fn compute_diff(path: &str, old: &str, new: &str) -> FileDiff {
         }
 
         hunks.push(DiffHunk {
-            old_start: old_start + 1, // 1-indexed
+            // NOTE: 1-indexed per unified diff spec
+            old_start: old_start + 1,
             new_start: new_start + 1,
             changes,
         });
@@ -147,7 +148,7 @@ pub(crate) fn collapse_to_replacements(hunks: &[DiffHunk]) -> Vec<DiffHunk> {
             while i < changes.len() {
                 match &changes[i] {
                     DiffChange::Delete(old_text) => {
-                        // Look ahead for adjacent Insert
+                        // WHY: look ahead for adjacent Insert to merge into a Replace
                         if i + 1 < changes.len()
                             && let DiffChange::Insert(new_text) = &changes[i + 1]
                         {
@@ -178,7 +179,6 @@ pub(crate) fn collapse_to_replacements(hunks: &[DiffHunk]) -> Vec<DiffHunk> {
 pub(crate) fn render_unified(file: &FileDiff, theme: &Theme) -> Vec<Line<'static>> {
     let mut lines = Vec::new();
 
-    // File header
     lines.push(Line::from(vec![Span::styled(
         format!("--- a/{}", file.path),
         theme.style_error().add_modifier(Modifier::BOLD),
@@ -197,7 +197,6 @@ pub(crate) fn render_unified(file: &FileDiff, theme: &Theme) -> Vec<Line<'static
         old_line = hunk.old_start;
         new_line = hunk.new_start;
 
-        // Count lines per side for hunk header
         let old_count = hunk
             .changes
             .iter()
@@ -209,7 +208,6 @@ pub(crate) fn render_unified(file: &FileDiff, theme: &Theme) -> Vec<Line<'static
             .filter(|c| matches!(c, DiffChange::Equal(_) | DiffChange::Insert(_)))
             .count();
 
-        // Hunk header
         lines.push(Line::from(vec![Span::styled(
             format!(
                 "@@ -{},{} +{},{} @@",
@@ -286,17 +284,16 @@ pub(crate) fn render_side_by_side(
 ) -> Vec<Line<'static>> {
     let mut lines = Vec::new();
     let half_width = (width as usize) / 2;
-    let gutter = 6; // "NNNN " line-number gutter
-    let content_width = half_width.saturating_sub(gutter + 2); // -2 for borders
+    // NOTE: 6-char line-number gutter "NNNN "
+    let gutter = 6;
+    let content_width = half_width.saturating_sub(gutter + 2);
 
-    // File header spanning full width
     let header = format!("  {} ", file.path);
     lines.push(Line::from(vec![Span::styled(
         header,
         theme.style_accent().add_modifier(Modifier::BOLD),
     )]));
 
-    // Column headers
     lines.push(Line::from(vec![
         Span::styled(format!("{:^half_width$}", "Old"), theme.style_dim()),
         Span::styled(format!("{:^half_width$}", "New"), theme.style_dim()),
@@ -315,7 +312,6 @@ pub(crate) fn render_side_by_side(
         old_line = hunk.old_start;
         new_line = hunk.new_start;
 
-        // Hunk separator
         lines.push(Line::from(vec![Span::styled(
             format!(
                 "@@ -{},{} +{},{} @@",
@@ -402,7 +398,6 @@ pub(crate) fn render_side_by_side(
 pub(crate) fn render_word_diff(file: &FileDiff, theme: &Theme) -> Vec<Line<'static>> {
     let mut lines = Vec::new();
 
-    // File header
     lines.push(Line::from(vec![Span::styled(
         format!("  {} ", file.path),
         theme.style_accent().add_modifier(Modifier::BOLD),
@@ -416,7 +411,6 @@ pub(crate) fn render_word_diff(file: &FileDiff, theme: &Theme) -> Vec<Line<'stat
         old_line = hunk.old_start;
         new_line = hunk.new_start;
 
-        // Hunk header
         lines.push(Line::from(vec![Span::styled(
             format!("@@ -{} +{} @@", hunk.old_start, hunk.new_start),
             Style::default().fg(theme.status.info),
@@ -456,7 +450,6 @@ pub(crate) fn render_word_diff(file: &FileDiff, theme: &Theme) -> Vec<Line<'stat
                     new_line += 1;
                 }
                 DiffChange::Replace { old, new } => {
-                    // Word-level diff within the line
                     let old_trimmed = old.trim_end_matches('\n');
                     let new_trimmed = new.trim_end_matches('\n');
                     let word_diff = TextDiff::from_words(old_trimmed, new_trimmed);
@@ -501,10 +494,6 @@ pub(crate) fn render_word_diff(file: &FileDiff, theme: &Theme) -> Vec<Line<'stat
     lines
 }
 
-// ---------------------------------------------------------------------------
-// Full render dispatch
-// ---------------------------------------------------------------------------
-
 /// Render a complete diff view state into ratatui Lines (mutable — updates total_lines).
 #[cfg(test)]
 pub(crate) fn render_diff_view(
@@ -514,7 +503,6 @@ pub(crate) fn render_diff_view(
 ) -> Vec<Line<'static>> {
     let mut all_lines: Vec<Line<'static>> = Vec::new();
 
-    // Mode indicator header
     all_lines.push(Line::from(vec![
         Span::styled(
             " Diff Viewer ",
@@ -571,7 +559,6 @@ pub(crate) fn render_diff_view_immutable(
 ) -> Vec<Line<'static>> {
     let mut all_lines: Vec<Line<'static>> = Vec::new();
 
-    // Mode indicator header
     all_lines.push(Line::from(vec![
         Span::styled(
             " Diff Viewer ",
@@ -612,15 +599,11 @@ pub(crate) fn render_diff_view_immutable(
             DiffMode::WordDiff => render_word_diff(file, theme),
         };
         all_lines.extend(file_lines);
-        all_lines.push(Line::raw("")); // spacer between files
+        all_lines.push(Line::raw(""));
     }
 
     all_lines
 }
-
-// ---------------------------------------------------------------------------
-// Parse git-style unified diff output
-// ---------------------------------------------------------------------------
 
 /// Parse `git diff` output into a list of `FileDiff`.
 pub(crate) fn parse_git_diff(raw: &str) -> Vec<FileDiff> {
@@ -634,7 +617,6 @@ pub(crate) fn parse_git_diff(raw: &str) -> Vec<FileDiff> {
 
     for line in raw.lines() {
         if line.starts_with("diff --git") {
-            // Flush previous file
             if let Some(path) = current_path.take() {
                 if in_hunk {
                     current_hunks.push(DiffHunk {
@@ -649,12 +631,11 @@ pub(crate) fn parse_git_diff(raw: &str) -> Vec<FileDiff> {
                 });
             }
 
-            // Extract path from "diff --git a/path b/path"
+            // NOTE: extract path from "diff --git a/path b/path" by splitting on " b/"
             let path = line.split(" b/").nth(1).unwrap_or("unknown").to_string();
             current_path = Some(path);
             in_hunk = false;
         } else if line.starts_with("@@") {
-            // Flush previous hunk
             if in_hunk {
                 current_hunks.push(DiffHunk {
                     old_start,
@@ -663,7 +644,6 @@ pub(crate) fn parse_git_diff(raw: &str) -> Vec<FileDiff> {
                 });
             }
 
-            // Parse "@@ -old,count +new,count @@"
             let (os, ns) = parse_hunk_header(line);
             old_start = os;
             new_start = ns;
@@ -678,11 +658,10 @@ pub(crate) fn parse_git_diff(raw: &str) -> Vec<FileDiff> {
             } else if line.is_empty() {
                 current_changes.push(DiffChange::Equal("\n".to_string()));
             }
-            // Skip lines like "\ No newline at end of file"
+            // NOTE: skip git metadata lines such as "\ No newline at end of file"
         }
     }
 
-    // Flush final file
     if let Some(path) = current_path {
         if in_hunk {
             current_hunks.push(DiffHunk {
@@ -701,7 +680,7 @@ pub(crate) fn parse_git_diff(raw: &str) -> Vec<FileDiff> {
 }
 
 fn parse_hunk_header(line: &str) -> (usize, usize) {
-    // "@@ -1,3 +1,4 @@" or "@@ -1 +1 @@"
+    // NOTE: handles both "@@ -1,3 +1,4 @@" and "@@ -1 +1 @@" (count optional)
     let stripped = line
         .trim_start_matches("@@ ")
         .split(" @@")
@@ -730,10 +709,6 @@ fn parse_hunk_header(line: &str) -> (usize, usize) {
     (old_start, new_start)
 }
 
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
 fn truncate_str(s: &str, max_chars: usize) -> String {
     if s.len() <= max_chars {
         s.to_string()
@@ -758,10 +733,6 @@ fn pad_to(s: String, width: usize) -> String {
         format!("{s:<width$}")
     }
 }
-
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
 
 #[cfg(test)]
 mod tests {

--- a/crates/theatron/tui/src/error.rs
+++ b/crates/theatron/tui/src/error.rs
@@ -1,6 +1,7 @@
 use snafu::prelude::*;
 
 /// Unified error type for the TUI crate.
+#[non_exhaustive]
 #[derive(Debug, Snafu)]
 #[snafu(visibility(pub(crate)))]
 pub enum Error {

--- a/crates/theatron/tui/src/highlight.rs
+++ b/crates/theatron/tui/src/highlight.rs
@@ -25,7 +25,6 @@ impl Highlighter {
     pub fn highlight(&self, code: &str, lang: &str) -> Vec<Line<'static>> {
         let theme = &self.theme_set.themes["base16-ocean.dark"];
 
-        // Try to find syntax by language token
         let syntax = self
             .syntax_set
             .find_syntax_by_token(lang)
@@ -61,7 +60,6 @@ impl Highlighter {
                     lines.push(Line::from(spans));
                 }
                 Err(_) => {
-                    // Fallback: plain text
                     lines.push(Line::raw(line_str.trim_end_matches('\n').to_string()));
                 }
             }

--- a/crates/theatron/tui/src/hyperlink.rs
+++ b/crates/theatron/tui/src/hyperlink.rs
@@ -4,8 +4,6 @@ use std::sync::LazyLock;
 
 use regex::Regex;
 
-// ── Public types ─────────────────────────────────────────────────────────────
-
 /// A link found during markdown rendering, positioned within the markdown lines.
 ///
 /// Line index and column are **relative** to the `Vec<Line>` returned by
@@ -38,8 +36,6 @@ pub(crate) struct OscLink {
     pub accent: (u8, u8, u8),
 }
 
-// ── Sequence helpers ──────────────────────────────────────────────────────────
-
 /// Format an OSC 8 hyperlink **opening** sequence.
 ///
 /// Format: `ESC ] 8 ;; URL BEL`
@@ -51,8 +47,6 @@ pub fn osc8_open(url: &str) -> String {
 pub const fn osc8_close() -> &'static str {
     "\x1b]8;;\x07"
 }
-
-// ── Terminal capability detection ─────────────────────────────────────────────
 
 /// Returns `true` if the running terminal is known to support OSC 8 hyperlinks.
 ///
@@ -68,7 +62,7 @@ pub fn supports_hyperlinks() -> bool {
 }
 
 fn probe_hyperlink_support() -> bool {
-    // TERM_PROGRAM — most reliable signal on macOS and some Linux terminals
+    // NOTE: TERM_PROGRAM — most reliable signal on macOS and some Linux terminals
     if let Ok(prog) = std::env::var("TERM_PROGRAM") {
         match prog.as_str() {
             "iTerm.app" | "WezTerm" | "ghostty" | "Ghostty" | "kitty" => return true,
@@ -76,42 +70,40 @@ fn probe_hyperlink_support() -> bool {
         }
     }
 
-    // Ghostty
+    // NOTE: Ghostty
     if std::env::var("GHOSTTY_BIN_DIR").is_ok() || std::env::var("GHOSTTY_RESOURCES_DIR").is_ok() {
         return true;
     }
 
-    // WezTerm
+    // NOTE: WezTerm
     if std::env::var("WEZTERM_EXECUTABLE").is_ok() || std::env::var("WEZTERM_PANE").is_ok() {
         return true;
     }
 
-    // Kitty
+    // NOTE: Kitty
     if std::env::var("KITTY_PID").is_ok() || std::env::var("KITTY_WINDOW_ID").is_ok() {
         return true;
     }
 
-    // Windows Terminal
+    // NOTE: Windows Terminal
     if std::env::var("WT_SESSION").is_ok() {
         return true;
     }
 
-    // foot
+    // NOTE: foot
     if let Ok(term) = std::env::var("TERM")
         && (term == "foot" || term == "foot-extra")
     {
         return true;
     }
 
-    // Alacritty 0.14+ sets ALACRITTY_SOCKET
+    // NOTE: Alacritty
     if std::env::var("ALACRITTY_SOCKET").is_ok() {
         return true;
     }
 
     false
 }
-
-// ── URL detection ─────────────────────────────────────────────────────────────
 
 /// Extract HTTP/HTTPS URLs from plain text.
 ///
@@ -169,8 +161,6 @@ fn trim_trailing_punct(url: &str) -> usize {
     end
 }
 
-// ── File-path link detection (bonus feature, not yet wired into renderer) ─────
-
 /// Detect `path/to/file.rs` and `path/to/file.rs:LINE` patterns in text.
 ///
 /// Returns `(start, end, path, url)` where `url` is a `file://` URL suitable
@@ -210,8 +200,6 @@ fn detect_file_paths(text: &str) -> Vec<(usize, usize, &str, String)> {
     }
     out
 }
-
-// ── Tests ─────────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
 mod tests {

--- a/crates/theatron/tui/src/keybindings.rs
+++ b/crates/theatron/tui/src/keybindings.rs
@@ -69,7 +69,6 @@ impl KeyContext {
 
 pub fn all_keybindings() -> &'static [Keybinding] {
     &[
-        // --- Chat (empty-input triggers) ---
         Keybinding {
             keys: "?",
             description: "Help",
@@ -136,7 +135,6 @@ pub fn all_keybindings() -> &'static [Keybinding] {
             contexts: &[KeyContext::Chat],
             show_in_status_bar: true,
         },
-        // --- Selection ---
         Keybinding {
             keys: "j / \u{2193}",
             description: "Next message",
@@ -209,7 +207,6 @@ pub fn all_keybindings() -> &'static [Keybinding] {
             contexts: &[KeyContext::Selection],
             show_in_status_bar: true,
         },
-        // --- Filter ---
         Keybinding {
             keys: "Enter",
             description: "Lock filter",
@@ -228,7 +225,6 @@ pub fn all_keybindings() -> &'static [Keybinding] {
             contexts: &[KeyContext::Filter],
             show_in_status_bar: true,
         },
-        // --- Command Palette ---
         Keybinding {
             keys: "Enter",
             description: "Execute command",
@@ -247,7 +243,6 @@ pub fn all_keybindings() -> &'static [Keybinding] {
             contexts: &[KeyContext::CommandPalette],
             show_in_status_bar: false,
         },
-        // --- Session List ---
         Keybinding {
             keys: "Enter",
             description: "Open session",
@@ -266,7 +261,6 @@ pub fn all_keybindings() -> &'static [Keybinding] {
             contexts: &[KeyContext::SessionList],
             show_in_status_bar: true,
         },
-        // --- Input ---
         Keybinding {
             keys: "Enter",
             description: "Send message",
@@ -309,7 +303,6 @@ pub fn all_keybindings() -> &'static [Keybinding] {
             contexts: &[KeyContext::Input],
             show_in_status_bar: false,
         },
-        // --- Overlay (generic) ---
         Keybinding {
             keys: "Esc",
             description: "Close",
@@ -328,7 +321,6 @@ pub fn all_keybindings() -> &'static [Keybinding] {
             contexts: &[KeyContext::Overlay],
             show_in_status_bar: false,
         },
-        // --- Global ---
         Keybinding {
             keys: "F1",
             description: "Help",
@@ -413,7 +405,6 @@ pub fn all_keybindings() -> &'static [Keybinding] {
             contexts: &[KeyContext::Global],
             show_in_status_bar: false,
         },
-        // --- Operations pane ---
         Keybinding {
             keys: "j / \u{2193}",
             description: "Next item",
@@ -444,7 +435,6 @@ pub fn all_keybindings() -> &'static [Keybinding] {
             contexts: &[KeyContext::Operations],
             show_in_status_bar: true,
         },
-        // --- Tool Approval ---
         Keybinding {
             keys: "A",
             description: "Approve tool",
@@ -457,7 +447,6 @@ pub fn all_keybindings() -> &'static [Keybinding] {
             contexts: &[KeyContext::ToolApproval],
             show_in_status_bar: true,
         },
-        // --- Plan Approval ---
         Keybinding {
             keys: "Space",
             description: "Toggle step",
@@ -476,7 +465,6 @@ pub fn all_keybindings() -> &'static [Keybinding] {
             contexts: &[KeyContext::PlanApproval],
             show_in_status_bar: true,
         },
-        // --- Settings ---
         Keybinding {
             keys: "Enter",
             description: "Edit / toggle",
@@ -501,7 +489,6 @@ pub fn all_keybindings() -> &'static [Keybinding] {
             contexts: &[KeyContext::Settings],
             show_in_status_bar: true,
         },
-        // --- Memory Inspector ---
         Keybinding {
             keys: "j / \u{2193}",
             description: "Next fact",
@@ -556,7 +543,6 @@ pub fn all_keybindings() -> &'static [Keybinding] {
             contexts: &[KeyContext::MemoryInspector],
             show_in_status_bar: true,
         },
-        // --- Fact Detail ---
         Keybinding {
             keys: "e",
             description: "Edit confidence",
@@ -588,7 +574,7 @@ pub fn all_keybindings() -> &'static [Keybinding] {
 pub fn current_contexts(app: &App) -> Vec<KeyContext> {
     let mut contexts = vec![KeyContext::Global];
 
-    // Memory inspector views take priority
+    // WHY: Memory inspector views return early to suppress all other context bindings.
     if matches!(
         app.view_stack.current(),
         crate::state::view_stack::View::FactDetail { .. }

--- a/crates/theatron/tui/src/lib.rs
+++ b/crates/theatron/tui/src/lib.rs
@@ -110,8 +110,7 @@ async fn run_loop(mut terminal: DefaultTerminal, app: &mut App) -> error::Result
     tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
     loop {
-        // Capture OSC 8 link data produced during the render pass.
-        // We use Cell so the draw closure can move data out without needing &mut app.
+        // NOTE: Cell lets the draw closure move link data out without needing &mut app.
         let link_cell: std::cell::Cell<Vec<hyperlink::OscLink>> = std::cell::Cell::new(Vec::new());
         terminal
             .draw(|frame| link_cell.set(app.view(frame)))
@@ -120,11 +119,9 @@ async fn run_loop(mut terminal: DefaultTerminal, app: &mut App) -> error::Result
             })?;
         let osc_links = link_cell.into_inner();
 
-        // Post-render: emit OSC 8 sequences over the already-rendered text.
-        // This works because OSC 8 is independent of visual rendering —
-        // we re-write the link text at its exact screen position wrapped in
-        // OSC 8 open/close sequences, which tells the terminal those cells
-        // are a clickable hyperlink without altering their visual appearance.
+        // NOTE: Emit OSC 8 sequences post-render. OSC 8 is independent of visual
+        // rendering — re-writing link text wrapped in open/close sequences marks those
+        // cells clickable without altering their visual appearance.
         if !osc_links.is_empty() {
             emit_osc8_links(terminal.backend_mut(), &osc_links).context(IoSnafu {
                 context: "emit osc8 links",
@@ -193,7 +190,7 @@ fn emit_osc8_links<W: std::io::Write>(writer: &mut W, links: &[OscLink]) -> std:
             SetForegroundColor(Color::Rgb { r, g, b }),
             SetAttribute(Attribute::Underlined),
             crossterm::style::Print(format!(
-                "{}{}{}", // OSC8_open + text + OSC8_close in one Print
+                "{}{}{}",
                 crate::hyperlink::osc8_open(&link.url),
                 link.text,
                 crate::hyperlink::osc8_close(),

--- a/crates/theatron/tui/src/mapping.rs
+++ b/crates/theatron/tui/src/mapping.rs
@@ -74,36 +74,33 @@ impl App {
             return Some(msg);
         }
 
-        // Vim g-prefix two-key sequences (gt = next tab, gT = prev tab)
+        // WHY: g-prefix must intercept before normal key routing so gt/gT are
+        // treated as two-key sequences; after 'g' is consumed, the second char falls through.
         if self.pending_g {
             return match (key.modifiers, key.code) {
                 (KeyModifiers::NONE, KeyCode::Char('t')) => Some(Msg::TabNext),
                 (KeyModifiers::SHIFT, KeyCode::Char('T')) => Some(Msg::TabPrev),
-                // Any other key after g: cancel pending, treat g+key as normal input
                 (KeyModifiers::NONE | KeyModifiers::SHIFT, KeyCode::Char(c)) => {
-                    // 'g' was consumed; pass the second char as input
                     Some(Msg::CharInput(c))
                 }
                 _ => None,
             };
         }
 
-        // Memory inspector has its own key handling
         if self.is_memory_view() {
             return self.map_memory_key(key);
         }
 
-        // View stack: Esc pops back when not at Home (takes priority over selection deselect)
+        // WHY: ViewPopBack takes priority over DeselectMessage so Esc always unwinds
+        // the view stack before affecting selection state.
         if !self.view_stack.is_home() && matches!((key.modifiers, key.code), (_, KeyCode::Esc)) {
             return Some(Msg::ViewPopBack);
         }
 
-        // Selection mode — single-letter keys become actions
         if self.selected_message.is_some() {
             return self.map_selection_key(key);
         }
 
-        // If ops pane is focused, route keys there
         if self.ops.visible && self.ops.focused_pane == crate::state::FocusedPane::Operations {
             return self.map_ops_pane_key(key);
         }
@@ -116,7 +113,6 @@ impl App {
             (KeyModifiers::CONTROL, KeyCode::Char('b')) => Some(Msg::ToggleThinking),
             (KeyModifiers::CONTROL, KeyCode::Char('o')) => Some(Msg::ToggleOpsPane),
 
-            // Tab management
             (KeyModifiers::CONTROL, KeyCode::Char('t')) => Some(Msg::TabNew),
             (KeyModifiers::CONTROL, KeyCode::Char('w')) if self.input.text.is_empty() => {
                 Some(Msg::TabClose)
@@ -135,7 +131,6 @@ impl App {
                 Some(Msg::OpenOverlay(OverlayKind::SessionPicker))
             }
 
-            // Tab switching: Ctrl+Tab or gt next, BackTab or gT prev
             (_, KeyCode::Tab) if key.modifiers.contains(KeyModifiers::CONTROL) => {
                 Some(Msg::TabNext)
             }
@@ -143,7 +138,6 @@ impl App {
                 Some(Msg::TabPrev)
             }
 
-            // Alt+1..9 jump to tab
             (KeyModifiers::ALT, KeyCode::Char(c @ '1'..='9')) => {
                 let n = (c as usize) - ('1' as usize);
                 Some(Msg::TabJump(n))
@@ -174,7 +168,8 @@ impl App {
             (_, KeyCode::End) if self.input.text.is_empty() => Some(Msg::ScrollToBottom),
             (_, KeyCode::End) => Some(Msg::CursorEnd),
 
-            // Up/Down with empty input enters selection mode; otherwise history nav
+            // WHY: Up/Down with empty input enters selection mode rather than history nav,
+            // matching the modal editing convention where arrow keys in read state navigate messages.
             (_, KeyCode::Up) if self.input.text.is_empty() && !self.messages.is_empty() => {
                 Some(Msg::SelectPrev)
             }
@@ -210,7 +205,6 @@ impl App {
                 Some(Msg::SelectPrev)
             }
 
-            // Vim g-prefix: 'g' on empty input starts two-key sequence
             (KeyModifiers::NONE, KeyCode::Char('g'))
                 if self.input.text.is_empty() && self.tab_bar.len() > 1 =>
             {
@@ -249,7 +243,6 @@ impl App {
     )]
     fn map_selection_key(&self, key: KeyEvent) -> Option<Msg> {
         match (key.modifiers, key.code) {
-            // Ctrl combos pass through to global handlers
             (KeyModifiers::CONTROL, KeyCode::Char('c'))
             | (KeyModifiers::CONTROL, KeyCode::Char('q')) => Some(Msg::Quit),
             (KeyModifiers::CONTROL, KeyCode::Char('f')) => Some(Msg::ToggleSidebar),
@@ -268,11 +261,9 @@ impl App {
                 Some(Msg::OpenOverlay(OverlayKind::SessionPicker))
             }
 
-            // Shift+Up/Down scroll (before bare Up/Down)
             (KeyModifiers::SHIFT, KeyCode::Up) => Some(Msg::ScrollUp),
             (KeyModifiers::SHIFT, KeyCode::Down) => Some(Msg::ScrollDown),
 
-            // Navigation
             (_, KeyCode::Char('j')) | (_, KeyCode::Down) => Some(Msg::SelectNext),
             (_, KeyCode::Char('k')) | (_, KeyCode::Up) => Some(Msg::SelectPrev),
             (_, KeyCode::Esc) => Some(Msg::DeselectMessage),
@@ -280,7 +271,6 @@ impl App {
             (_, KeyCode::Home) => Some(Msg::SelectFirst),
             (_, KeyCode::End) | (KeyModifiers::SHIFT, KeyCode::Char('G')) => Some(Msg::SelectLast),
 
-            // Actions
             (KeyModifiers::NONE, KeyCode::Char('c')) => {
                 Some(Msg::MessageAction(MessageActionKind::Copy))
             }
@@ -304,7 +294,6 @@ impl App {
             (_, KeyCode::PageDown) => Some(Msg::ScrollPageDown),
             (_, KeyCode::F(1)) => Some(Msg::OpenOverlay(OverlayKind::Help)),
 
-            // Any other character deselects and inserts into input
             (KeyModifiers::NONE | KeyModifiers::SHIFT, KeyCode::Char(c)) => Some(Msg::CharInput(c)),
 
             _ => None,
@@ -378,7 +367,6 @@ impl App {
     }
 
     fn map_memory_key(&self, key: KeyEvent) -> Option<Msg> {
-        // Global shortcuts pass through
         match (key.modifiers, key.code) {
             (KeyModifiers::CONTROL, KeyCode::Char('c'))
             | (KeyModifiers::CONTROL, KeyCode::Char('q')) => return Some(Msg::Quit),
@@ -386,7 +374,6 @@ impl App {
             _ => {}
         }
 
-        // Confidence editing mode
         if self.memory.editing_confidence {
             return match (key.modifiers, key.code) {
                 (_, KeyCode::Enter) => Some(Msg::MemoryConfidenceSubmit),
@@ -397,7 +384,6 @@ impl App {
             };
         }
 
-        // Search editing mode
         if self.memory.search_active {
             return match (key.modifiers, key.code) {
                 (_, KeyCode::Enter) => Some(Msg::MemorySearchSubmit),
@@ -410,7 +396,6 @@ impl App {
             };
         }
 
-        // Filter editing mode
         if self.memory.filter_editing {
             return match (key.modifiers, key.code) {
                 (_, KeyCode::Esc) => Some(Msg::MemoryFilterClose),
@@ -423,7 +408,6 @@ impl App {
             };
         }
 
-        // Fact detail view
         if matches!(
             self.view_stack.current(),
             crate::state::view_stack::View::FactDetail { .. }
@@ -437,7 +421,6 @@ impl App {
             };
         }
 
-        // Memory inspector main view
         match (key.modifiers, key.code) {
             (_, KeyCode::Esc) => Some(Msg::MemoryClose),
             (_, KeyCode::Up) | (KeyModifiers::NONE, KeyCode::Char('k')) => {
@@ -482,7 +465,6 @@ impl App {
             return self.map_settings_overlay_key(key);
         }
 
-        // Diff viewer has its own keybindings
         if self.is_diff_view_overlay() {
             return match (key.modifiers, key.code) {
                 (_, KeyCode::Esc) | (KeyModifiers::CONTROL, KeyCode::Char('c')) => {

--- a/crates/theatron/tui/src/markdown.rs
+++ b/crates/theatron/tui/src/markdown.rs
@@ -28,9 +28,7 @@ pub fn render(
 
     let mut lines: Vec<Line<'static>> = Vec::new();
     let mut current_spans: Vec<Span<'static>> = Vec::new();
-    // Byte-based column counter for the current (unflushed) line.
-    // Byte length is used intentionally — this matches the scroll calculation in
-    // view/chat.rs which also uses `span.content.len()` for line-width estimation.
+    // WHY: byte length matches scroll calculation in view/chat.rs which uses span.content.len()
     let mut current_col: u16 = 0;
     let mut style_stack: Vec<Style> = vec![Style::default().fg(theme.text.fg)];
     let mut in_code_block = false;
@@ -38,28 +36,23 @@ pub fn render(
     let mut code_block_lang: Option<String> = None;
     let mut list_depth: usize = 0;
 
-    // Link state
     let mut link_url: Option<String> = None;
     let mut link_start_line: usize = 0;
     let mut link_start_col: u16 = 0;
     let mut link_text_buf: String = String::new();
 
-    // Image state
     let mut in_image = false;
     let mut image_alt = String::new();
 
-    // Table state
     let mut in_table = false;
     let mut table_rows: Vec<Vec<String>> = Vec::new();
     let mut current_row: Vec<String> = Vec::new();
     let mut current_cell = String::new();
     let mut is_table_head = false;
 
-    // Blockquote nesting depth — tracked so paragraph start can prepend the │ prefix
-    // on the correct line rather than flushing it alone (bug fix: see Tag::BlockQuote below).
+    // WHY: paragraph start prepends │ (not BlockQuote) so the border lands on the same line as content
     let mut blockquote_depth: usize = 0;
 
-    // Collected hyperlinks (returned alongside lines)
     let mut md_links: Vec<MdLink> = Vec::new();
 
     for event in parser {
@@ -120,10 +113,8 @@ pub fn render(
                 }
                 Tag::Paragraph => {
                     flush_line(&mut lines, &mut current_spans, &mut current_col);
-                    // Bug fix: blockquote border belongs on the same line as content.
-                    // Previously the border was pushed in Tag::BlockQuote, which caused
-                    // Tag::Paragraph to flush it alone before any text arrived.
-                    // Now we emit the │ prefix here, after the flush, so it leads the content.
+                    // WHY: emit │ prefix here after flush so it leads content — if pushed in
+                    // Tag::BlockQuote, Paragraph would flush it alone before any text arrived.
                     for _ in 0..blockquote_depth {
                         push_span(
                             &mut current_spans,
@@ -136,9 +127,7 @@ pub fn render(
                     }
                 }
                 Tag::BlockQuote(_) => {
-                    // Flush any pending content, then enter blockquote context.
-                    // Do NOT push │ to current_spans here — Tag::Paragraph does it so the
-                    // border lands on the same line as the paragraph content.
+                    // WHY: do not push │ here — Tag::Paragraph does it so the border lands on content line
                     flush_line(&mut lines, &mut current_spans, &mut current_col);
                     let style = theme.style_muted();
                     style_stack.push(style);
@@ -188,7 +177,6 @@ pub fn render(
                     let lang_str = code_block_lang.as_deref().unwrap_or("");
                     let full_code = code_block_lines.join("\n");
 
-                    // Language label header
                     if !lang_str.is_empty() {
                         lines.push(Line::from(vec![
                             Span::styled(
@@ -204,7 +192,7 @@ pub fn render(
                         )));
                     }
 
-                    // Syntax-highlighted code lines — URLs inside NOT linkified
+                    // NOTE: URLs inside code blocks are not linkified
                     let highlighted = highlighter.highlight(&full_code, lang_str);
                     for hl_line in highlighted {
                         let mut spans =
@@ -240,7 +228,6 @@ pub fn render(
                     style_stack.pop();
                     if let Some(url) = link_url.take() {
                         let display_text = std::mem::take(&mut link_text_buf);
-                        // Record the hyperlink for post-render OSC 8
                         if !url.is_empty() && !display_text.is_empty() {
                             md_links.push(MdLink {
                                 line_idx: link_start_line,
@@ -249,8 +236,7 @@ pub fn render(
                                 url: url.clone(),
                             });
                         }
-                        // In terminals without OSC 8 support, show the URL in parentheses
-                        // so readers know where the link goes.
+                        // NOTE: terminals without OSC 8 support show URL in parentheses as fallback
                         if !hyperlink::supports_hyperlinks() {
                             push_span(
                                 &mut current_spans,
@@ -302,7 +288,7 @@ pub fn render(
                 } else if in_table {
                     current_cell.push_str(&text);
                 } else if link_url.is_some() {
-                    // Inside a markdown link — accumulate display text, don't auto-detect URLs
+                    // NOTE: inside a markdown link — accumulate display text, URL detection skipped
                     link_text_buf.push_str(&text);
                     let style = current_style(&style_stack);
                     push_span(
@@ -311,7 +297,6 @@ pub fn render(
                         Span::styled(text.to_string(), style),
                     );
                 } else {
-                    // Plain paragraph text — detect and linkify embedded URLs
                     let urls = hyperlink::detect_urls(&text);
                     if urls.is_empty() {
                         let style = current_style(&style_stack);
@@ -338,7 +323,7 @@ pub fn render(
                 if in_table {
                     current_cell.push_str(&format!("`{code}`"));
                 } else {
-                    // Inline code: render with code style, do NOT linkify
+                    // NOTE: inline code — rendered with code style, URLs not linkified
                     let s = format!("`{code}`");
                     push_span(
                         &mut current_spans,
@@ -365,10 +350,9 @@ pub fn render(
         }
     }
 
-    // Flush remaining content
     flush_line(&mut lines, &mut current_spans, &mut current_col);
 
-    // Suppress is_table_head warning — kept for future header-specific styling
+    // WHY: suppress unused warning — kept for future header-specific styling
     let _ = is_table_head;
 
     (lines, md_links)
@@ -408,12 +392,10 @@ fn linkify_text(
 
     let mut last = 0usize;
     for &(start, end, url) in urls {
-        // Text before this URL (plain style)
         if start > last {
             let before = &text[last..start];
             push_span(spans, col, Span::styled(before.to_string(), base_style));
         }
-        // The URL itself (link style)
         let url_text = &text[start..end];
         let link_col = *col;
         push_span(spans, col, Span::styled(url_text.to_string(), link_style));
@@ -425,7 +407,6 @@ fn linkify_text(
         });
         last = end;
     }
-    // Remaining text after the last URL
     if last < text.len() {
         push_span(
             spans,
@@ -441,7 +422,6 @@ fn render_table(rows: &[Vec<String>], lines: &mut Vec<Line<'static>>, theme: &Th
         return;
     }
 
-    // Calculate column widths
     let num_cols = rows.iter().map(|r| r.len()).max().unwrap_or(0);
     let mut col_widths: Vec<usize> = vec![0; num_cols];
     for row in rows {
@@ -452,7 +432,7 @@ fn render_table(rows: &[Vec<String>], lines: &mut Vec<Line<'static>>, theme: &Th
         }
     }
 
-    // Cap column widths to prevent overflow
+    // NOTE: cap column widths to prevent overflow on pathologically wide tables
     for w in &mut col_widths {
         *w = (*w).min(40);
     }
@@ -461,7 +441,6 @@ fn render_table(rows: &[Vec<String>], lines: &mut Vec<Line<'static>>, theme: &Th
     let header_style = theme.style_accent_bold();
     let cell_style = Style::default().fg(theme.text.fg);
 
-    // Top border
     let top = format!(
         " ┌{}┐",
         col_widths
@@ -478,7 +457,6 @@ fn render_table(rows: &[Vec<String>], lines: &mut Vec<Line<'static>>, theme: &Th
     lines.push(Line::from(Span::styled(top, border_style)));
 
     for (row_idx, row) in rows.iter().enumerate() {
-        // Row content
         let mut row_spans = vec![Span::styled(" │", border_style)];
         for (i, width) in col_widths.iter().enumerate() {
             let cell = row.get(i).map(|s| s.as_str()).unwrap_or("");
@@ -493,7 +471,6 @@ fn render_table(rows: &[Vec<String>], lines: &mut Vec<Line<'static>>, theme: &Th
         }
         lines.push(Line::from(row_spans));
 
-        // Separator after header
         if row_idx == 0 {
             let sep = format!(
                 " ├{}┤",
@@ -512,7 +489,6 @@ fn render_table(rows: &[Vec<String>], lines: &mut Vec<Line<'static>>, theme: &Th
         }
     }
 
-    // Bottom border
     let bottom = format!(
         " └{}┘",
         col_widths
@@ -724,7 +700,7 @@ mod tests {
     // ── Text formatting ───────────────────────────────────────────────────
 
     #[test]
-    fn test_bold_text_modifier() {
+    fn bold_text_renders_with_bold_modifier() {
         let lines = test_render("**bold**");
         assert!(
             !lines.is_empty(),
@@ -737,7 +713,7 @@ mod tests {
     }
 
     #[test]
-    fn test_italic_text() {
+    fn italic_text_renders_with_italic_modifier() {
         let lines = test_render("*italic*");
         assert!(!lines.is_empty());
         let all = all_lines_text(&lines);
@@ -749,7 +725,7 @@ mod tests {
     }
 
     #[test]
-    fn test_strikethrough_modifier() {
+    fn strikethrough_text_renders_with_strikethrough_modifier() {
         let lines = test_render("~~deleted~~");
         assert!(
             any_line_has_modifier(&lines, "deleted", Modifier::CROSSED_OUT),
@@ -758,7 +734,7 @@ mod tests {
     }
 
     #[test]
-    fn test_bold_italic_combined() {
+    fn bold_italic_text_renders_with_both_modifiers() {
         // ***text*** is bold + italic in CommonMark
         let lines = test_render("***combo***");
         assert!(!lines.is_empty());
@@ -773,7 +749,7 @@ mod tests {
     }
 
     #[test]
-    fn test_inline_code() {
+    fn inline_code_renders_without_bold_modifier() {
         let (lines, theme) = test_render_with_theme("use `std::mem::take`");
         let all = all_lines_text(&lines);
         assert!(
@@ -788,7 +764,7 @@ mod tests {
     }
 
     #[test]
-    fn test_nested_formatting() {
+    fn nested_formatting_applies_outer_and_inner_modifiers() {
         // Bold wrapping italic
         let lines = test_render("**bold _bold-italic_ bold**");
         let all = all_lines_text(&lines);
@@ -809,7 +785,7 @@ mod tests {
     // ── Headings ──────────────────────────────────────────────────────────
 
     #[test]
-    fn test_heading_h1() {
+    fn h1_heading_renders_with_bold_and_large_size() {
         let lines = test_render("# Heading One");
         assert!(!lines.is_empty());
         let text = line_text(&lines[0]);
@@ -821,7 +797,7 @@ mod tests {
     }
 
     #[test]
-    fn test_heading_h2() {
+    fn h2_heading_renders_with_bold() {
         let lines = test_render("## Heading Two");
         assert!(!lines.is_empty());
         let text = line_text(&lines[0]);
@@ -833,7 +809,7 @@ mod tests {
     }
 
     #[test]
-    fn test_heading_h3() {
+    fn h3_heading_renders_without_size_modifier() {
         let lines = test_render("### Heading Three");
         assert!(!lines.is_empty());
         let text = line_text(&lines[0]);
@@ -845,7 +821,7 @@ mod tests {
     }
 
     #[test]
-    fn test_heading_h4() {
+    fn h4_heading_renders_without_size_modifier() {
         let lines = test_render("#### Heading Four");
         assert!(!lines.is_empty());
         let text = line_text(&lines[0]);
@@ -857,7 +833,7 @@ mod tests {
     }
 
     #[test]
-    fn test_heading_style() {
+    fn heading_applies_correct_fg_color() {
         // Headings use style_accent_bold: accent fg + BOLD modifier
         let (lines, theme) = test_render_with_theme("# Styled Heading");
         assert!(!lines.is_empty());
@@ -878,7 +854,7 @@ mod tests {
     // ── Code blocks ───────────────────────────────────────────────────────
 
     #[test]
-    fn test_fenced_code_rust() {
+    fn fenced_code_block_rust_renders_syntax_highlighted() {
         let lines = test_render("```rust\nfn main() {}\n```");
         let all = all_lines_text(&lines);
         assert!(all.contains("fn main()"), "Rust code content must appear");
@@ -887,7 +863,7 @@ mod tests {
     }
 
     #[test]
-    fn test_fenced_code_python() {
+    fn fenced_code_block_python_renders_syntax_highlighted() {
         let lines = test_render("```python\ndef hello():\n    pass\n```");
         let all = all_lines_text(&lines);
         assert!(all.contains("def hello"), "Python code content must appear");
@@ -895,7 +871,7 @@ mod tests {
     }
 
     #[test]
-    fn test_fenced_code_no_language() {
+    fn fenced_code_block_without_language_renders_plain() {
         let lines = test_render("```\nplain code\n```");
         let all = all_lines_text(&lines);
         assert!(all.contains("plain code"));
@@ -910,7 +886,7 @@ mod tests {
     }
 
     #[test]
-    fn test_fenced_code_unknown_language() {
+    fn fenced_code_block_unknown_language_renders_plain() {
         // Falls back to plain text highlighting; must not panic
         let lines = test_render("```xyzzy_unknown\nsome code\n```");
         let all = all_lines_text(&lines);
@@ -921,7 +897,7 @@ mod tests {
     }
 
     #[test]
-    fn test_code_block_language_label() {
+    fn code_block_shows_language_in_header() {
         // The language name must appear in the header line
         let lines = test_render("```rust\nlet x = 1;\n```");
         let header_line = lines.iter().find(|l| line_text(l).contains("rust"));
@@ -932,7 +908,7 @@ mod tests {
     }
 
     #[test]
-    fn test_code_block_has_box_drawing() {
+    fn code_block_has_box_drawing_border() {
         let lines = test_render("```rust\nx\n```");
         let all = all_lines_text(&lines);
         // Top-left corner, vertical bar inside, bottom-left corner
@@ -942,7 +918,7 @@ mod tests {
     }
 
     #[test]
-    fn test_code_block_preserves_whitespace() {
+    fn code_block_preserves_internal_whitespace() {
         let lines = test_render("```\n    indented\n        double\n```");
         let all = all_lines_text(&lines);
         assert!(
@@ -956,7 +932,7 @@ mod tests {
     }
 
     #[test]
-    fn test_empty_code_block() {
+    fn empty_code_block_renders_border_only() {
         // Must not panic; produces border lines even with no content
         let lines = test_render("```rust\n```");
         let all = all_lines_text(&lines);
@@ -973,7 +949,7 @@ mod tests {
     // ── Lists ─────────────────────────────────────────────────────────────
 
     #[test]
-    fn test_unordered_list_bullet() {
+    fn unordered_list_item_renders_with_bullet() {
         let lines = test_render("- alpha\n- beta");
         let all = all_lines_text(&lines);
         assert!(
@@ -985,7 +961,7 @@ mod tests {
     }
 
     #[test]
-    fn test_nested_unordered_list() {
+    fn nested_unordered_list_indents_child_items() {
         let md = "- top\n  - nested\n    - deep";
         let lines = test_render(md);
         let all = all_lines_text(&lines);
@@ -1012,7 +988,7 @@ mod tests {
     }
 
     #[test]
-    fn test_list_with_formatting() {
+    fn list_item_with_bold_text_applies_bold_modifier() {
         let lines = test_render("- **bold item**\n- *italic item*");
         assert!(
             any_line_has_modifier(&lines, "bold item", Modifier::BOLD),
@@ -1027,7 +1003,7 @@ mod tests {
     // ── Blockquotes ───────────────────────────────────────────────────────
 
     #[test]
-    fn test_blockquote_simple() {
+    fn blockquote_renders_with_vertical_bar_prefix() {
         // Regression for blockquote border bug: │ and content must be on the SAME line.
         let lines = test_render("> hello");
         let all = all_lines_text(&lines);
@@ -1047,7 +1023,7 @@ mod tests {
     }
 
     #[test]
-    fn test_blockquote_border_fg() {
+    fn blockquote_border_uses_accent_foreground_color() {
         // The │ border span must use theme.borders.normal color.
         let (lines, theme) = test_render_with_theme("> check color");
         assert!(
@@ -1057,7 +1033,7 @@ mod tests {
     }
 
     #[test]
-    fn test_blockquote_with_formatting() {
+    fn blockquote_with_bold_content_applies_bold_modifier() {
         let lines = test_render("> **bold inside**");
         assert!(
             any_line_has_modifier(&lines, "bold inside", Modifier::BOLD),
@@ -1073,7 +1049,7 @@ mod tests {
     }
 
     #[test]
-    fn test_nested_blockquote() {
+    fn nested_blockquote_indents_inner_content() {
         // Two levels of blockquote should produce two │ characters on the content line.
         let lines = test_render("> > deeply nested");
         let all = all_lines_text(&lines);
@@ -1097,7 +1073,7 @@ mod tests {
     // ── Links ─────────────────────────────────────────────────────────────
 
     #[test]
-    fn test_link_underline_style() {
+    fn link_text_renders_with_underline_modifier() {
         let lines = test_render("[click here](https://example.com)");
         assert!(
             any_line_has_modifier(&lines, "click here", Modifier::UNDERLINED),
@@ -1106,7 +1082,7 @@ mod tests {
     }
 
     #[test]
-    fn test_link_url_appended() {
+    fn link_appends_url_after_display_text() {
         let lines = test_render("[text](https://example.com)");
         let all = all_lines_text(&lines);
         assert!(all.contains("text"), "link display text must appear");
@@ -1122,7 +1098,7 @@ mod tests {
     }
 
     #[test]
-    fn test_link_url_uses_dim_style() {
+    fn link_url_uses_dim_foreground_color() {
         let (lines, theme) = test_render_with_theme("[click](https://example.com)");
         assert!(
             any_line_has_fg(&lines, "https://example.com", theme.text.fg_dim),
@@ -1133,7 +1109,7 @@ mod tests {
     // ── Images ────────────────────────────────────────────────────────────
 
     #[test]
-    fn test_image_alt_text() {
+    fn image_with_alt_text_renders_alt_as_display() {
         let lines = test_render("![alt description](image.png)");
         let all = all_lines_text(&lines);
         assert!(
@@ -1143,7 +1119,7 @@ mod tests {
     }
 
     #[test]
-    fn test_image_no_alt() {
+    fn image_without_alt_renders_image_label() {
         let lines = test_render("![](image.png)");
         let all = all_lines_text(&lines);
         assert!(
@@ -1155,7 +1131,7 @@ mod tests {
     // ── Tables ────────────────────────────────────────────────────────────
 
     #[test]
-    fn test_table_simple() {
+    fn simple_table_renders_header_and_row() {
         let md = "| A | B |\n|---|---|\n| 1 | 2 |";
         let lines = test_render(md);
         let all = all_lines_text(&lines);
@@ -1175,7 +1151,7 @@ mod tests {
     }
 
     #[test]
-    fn test_table_header_style() {
+    fn table_header_cells_render_with_bold() {
         // The first row (header) uses style_accent_bold; data rows use fg.
         let (lines, theme) = test_render_with_theme("| Head |\n|-----|\n| data |");
         assert!(
@@ -1189,7 +1165,7 @@ mod tests {
     }
 
     #[test]
-    fn test_table_three_columns() {
+    fn table_with_three_columns_renders_all_cells() {
         let md = "| X | Y | Z |\n|---|---|---|\n| a | b | c |";
         let lines = test_render(md);
         let all = all_lines_text(&lines);
@@ -1214,7 +1190,7 @@ mod tests {
     // ── Structural ────────────────────────────────────────────────────────
 
     #[test]
-    fn test_horizontal_rule() {
+    fn horizontal_rule_spans_full_line() {
         let lines = test_render("---");
         let all = all_lines_text(&lines);
         assert!(
@@ -1233,7 +1209,7 @@ mod tests {
     }
 
     #[test]
-    fn test_horizontal_rule_style() {
+    fn horizontal_rule_uses_dim_foreground_color() {
         let (lines, theme) = test_render_with_theme("---");
         let rule_line = lines.iter().find(|l| line_text(l).contains('─'));
         assert!(rule_line.is_some());
@@ -1244,7 +1220,7 @@ mod tests {
     }
 
     #[test]
-    fn test_paragraph_spacing() {
+    fn consecutive_paragraphs_have_blank_line_separator() {
         // Two separate paragraphs must each appear in output
         let lines = test_render("first paragraph\n\nsecond paragraph");
         let all = all_lines_text(&lines);
@@ -1267,7 +1243,7 @@ mod tests {
     }
 
     #[test]
-    fn test_hard_line_break() {
+    fn hard_line_break_creates_new_line() {
         // Backslash at end of line is a hard break in CommonMark
         let lines = test_render("line one\\\nline two");
         let all = all_lines_text(&lines);
@@ -1286,7 +1262,7 @@ mod tests {
     }
 
     #[test]
-    fn test_soft_break_is_space() {
+    fn soft_break_renders_as_space_between_words() {
         // Two lines in the same paragraph (no blank line) join with a soft break (space)
         let lines = test_render("line one\nline two");
         // In a tight paragraph pulldown-cmark emits Text, SoftBreak, Text → same line
@@ -1307,7 +1283,7 @@ mod tests {
     // ── Edge cases ────────────────────────────────────────────────────────
 
     #[test]
-    fn test_empty_input() {
+    fn empty_input_renders_no_lines() {
         let lines = test_render("");
         assert!(
             lines.is_empty(),
@@ -1316,7 +1292,7 @@ mod tests {
     }
 
     #[test]
-    fn test_whitespace_only() {
+    fn whitespace_only_input_renders_empty() {
         // Must not panic and should produce no meaningful content
         let lines = test_render("   \n\n   ");
         // No assertion on exact count — just that it doesn't crash
@@ -1324,7 +1300,7 @@ mod tests {
     }
 
     #[test]
-    fn test_deeply_nested_lists() {
+    fn deeply_nested_list_indents_each_level() {
         // 5 levels of nesting — must not panic, indent grows correctly
         let md = "- l1\n  - l2\n    - l3\n      - l4\n        - l5";
         let lines = test_render(md);
@@ -1343,7 +1319,7 @@ mod tests {
     }
 
     #[test]
-    fn test_very_long_line() {
+    fn very_long_line_does_not_truncate_content() {
         // A single paragraph line >500 chars must render without panicking
         let long = "word ".repeat(120); // ~600 chars
         let lines = test_render(long.trim());
@@ -1354,7 +1330,7 @@ mod tests {
     }
 
     #[test]
-    fn test_unicode_content() {
+    fn unicode_content_renders_correctly() {
         // Emoji, CJK, and combining characters must all pass through cleanly
         let md = "Hello 🎉 world 你好世界 café";
         let lines = test_render(md);
@@ -1365,7 +1341,7 @@ mod tests {
     }
 
     #[test]
-    fn test_mixed_content() {
+    fn mixed_heading_and_paragraph_renders_both() {
         // Full document with multiple element types must render all parts
         let md = "# Title\n\nA paragraph.\n\n- item\n\n> quote\n\n```rust\ncode\n```\n\n| H |\n|---|\n| v |";
         let lines = test_render(md);
@@ -1380,14 +1356,14 @@ mod tests {
     }
 
     #[test]
-    fn test_unclosed_formatting() {
+    fn unclosed_bold_marker_renders_as_plain_text() {
         // pulldown-cmark treats unclosed ** as literal asterisks — must not panic
         let lines = test_render("**not closed");
         let _ = all_lines_text(&lines);
     }
 
     #[test]
-    fn test_ansi_passthrough() {
+    fn ansi_escape_sequences_pass_through_unchanged() {
         // The renderer itself does not strip ANSI — callers sanitize before passing.
         // Verify the renderer handles arbitrary bytes without panicking.
         let lines = test_render("plain text without escapes");
@@ -1396,7 +1372,7 @@ mod tests {
     }
 
     #[test]
-    fn test_ordered_list_renders_with_bullets() {
+    fn ordered_list_renders_with_bullet_prefix() {
         // Ordered lists use the same bullet renderer (no numbering yet)
         let lines = test_render("1. first\n2. second\n3. third");
         let all = all_lines_text(&lines);
@@ -1407,7 +1383,7 @@ mod tests {
     }
 
     #[test]
-    fn test_code_block_lang_in_header_style() {
+    fn code_block_language_label_uses_accent_color() {
         // Language label must be styled with code_lang color
         let (lines, theme) = test_render_with_theme("```python\npass\n```");
         let header = lines.iter().find(|l| line_text(l).contains("python"));
@@ -1419,7 +1395,7 @@ mod tests {
     }
 
     #[test]
-    fn test_blockquote_muted_text_style() {
+    fn blockquote_text_uses_dim_foreground_color() {
         // Text inside blockquote must use the muted style
         let (lines, theme) = test_render_with_theme("> muted content");
         assert!(
@@ -1429,7 +1405,7 @@ mod tests {
     }
 
     #[test]
-    fn test_inline_code_has_bg_color() {
+    fn inline_code_has_background_color() {
         // Inline code must have both fg (warning) and bg (code_bg)
         let (lines, theme) = test_render_with_theme("use `foo`");
         let code_span = lines
@@ -1451,7 +1427,7 @@ mod tests {
     }
 
     #[test]
-    fn test_extremely_long_line_no_overflow() {
+    fn extremely_long_line_does_not_overflow() {
         // A single line >65 535 bytes must not panic from u16 overflow in push_span.
         let long = "x".repeat(70_000);
         let lines = test_render(&long);
@@ -1462,7 +1438,7 @@ mod tests {
     }
 
     #[test]
-    fn test_deeply_nested_blockquotes() {
+    fn deeply_nested_blockquotes_indent_each_level() {
         // 50 levels of blockquote nesting must not stack overflow (iterative parser).
         let mut md: String = (0..50).map(|_| "> ").collect();
         md.push_str("deeply nested");

--- a/crates/theatron/tui/src/msg.rs
+++ b/crates/theatron/tui/src/msg.rs
@@ -12,7 +12,6 @@ use crate::id::{NousId, PlanId, SessionId, ToolId, TurnId};
               use wildcard or abbreviated patterns"
 )]
 pub enum Msg {
-    // --- Terminal input ---
     CharInput(char),
     Backspace,
     Delete,
@@ -20,17 +19,16 @@ pub enum Msg {
     CursorRight,
     CursorHome,
     CursorEnd,
-    DeleteWord,  // Ctrl+W
-    ClearLine,   // Ctrl+U
-    DeleteToEnd, // Ctrl+K
+    DeleteWord,
+    ClearLine,
+    DeleteToEnd,
     HistoryUp,
     HistoryDown,
-    Submit,           // Enter — send message
-    CopyLastResponse, // Ctrl+Y — copy last assistant response to clipboard
-    ComposeInEditor,  // Ctrl+E — open $EDITOR for multi-line compose
-    Quit,             // Ctrl+C or Ctrl+Q
+    Submit,
+    CopyLastResponse,
+    ComposeInEditor,
+    Quit,
 
-    // --- Command palette ---
     CommandPaletteOpen,
     CommandPaletteClose,
     CommandPaletteInput(char),
@@ -41,72 +39,64 @@ pub enum Msg {
     CommandPaletteDown,
     CommandPaletteTab,
 
-    NewSession,              // Ctrl+N — start new topic
-    SessionPickerNewSession, // 'n' in session picker — create and switch
-    SessionPickerArchive,    // 'd' in session picker — archive selected
+    NewSession,
+    SessionPickerNewSession,
+    SessionPickerArchive,
 
-    // --- Tabs ---
-    TabNew,         // Ctrl+T — open new tab (session picker)
-    TabClose,       // Ctrl+W — close current tab
-    TabNext,        // Ctrl+Tab or gt — next tab
-    TabPrev,        // Ctrl+Shift+Tab or gT — previous tab
-    TabJump(usize), // Alt+1..9 — jump to tab N (0-indexed)
-    GPrefix,        // 'g' prefix for two-key sequences (gt/gT)
+    TabNew,
+    TabClose,
+    TabNext,
+    TabPrev,
+    TabJump(usize),
+    GPrefix,
 
-    // --- Message selection ---
-    SelectPrev,                       // k or Up in selection mode
-    SelectNext,                       // j or Down in selection mode
-    DeselectMessage,                  // Esc — return to auto-scroll
-    SelectFirst,                      // Home in selection mode
-    SelectLast,                       // G or End in selection mode
-    MessageAction(MessageActionKind), // Action on selected message
+    SelectPrev,
+    SelectNext,
+    DeselectMessage,
+    SelectFirst,
+    SelectLast,
+    MessageAction(MessageActionKind),
 
-    // --- Filter (`/` mode) ---
     FilterOpen,
     FilterClose,
     FilterInput(char),
     FilterBackspace,
-    FilterClear,     // Ctrl+U — clear text, stay in edit mode
-    FilterConfirm,   // Enter — lock filter, exit edit mode
-    FilterNextMatch, // n — jump to next match
-    FilterPrevMatch, // N — jump to previous match
+    FilterClear,
+    FilterConfirm,
+    FilterNextMatch,
+    FilterPrevMatch,
 
-    // --- Navigation ---
     ScrollUp,
     ScrollDown,
     ScrollPageUp,
     ScrollPageDown,
     ScrollToBottom,
     FocusAgent(NousId),
-    NextAgent, // Ctrl+Tab or similar
+    NextAgent,
     PrevAgent,
 
-    // --- View stack navigation ---
-    ViewDrillIn, // Enter — push detail view based on context
-    ViewPopBack, // Esc — pop to previous view
+    ViewDrillIn,
+    ViewPopBack,
 
-    // --- Layout ---
-    ToggleSidebar,   // Ctrl+F
-    ToggleThinking,  // Ctrl+T
-    ToggleOpsPane,   // Ctrl+O or :ops
-    OpsFocusSwitch,  // Tab — switch focus between chat and ops
-    OpsScrollUp,     // k / Up in ops pane
-    OpsScrollDown,   // j / Down in ops pane
-    OpsSelectPrev,   // k in ops pane with selection
-    OpsSelectNext,   // j in ops pane with selection
-    OpsToggleExpand, // Enter in ops pane — expand/collapse selected item
+    ToggleSidebar,
+    ToggleThinking,
+    ToggleOpsPane,
+    OpsFocusSwitch,
+    OpsScrollUp,
+    OpsScrollDown,
+    OpsSelectPrev,
+    OpsSelectNext,
+    OpsToggleExpand,
     OpenOverlay(OverlayKind),
     CloseOverlay,
     Resize(u16, u16),
 
-    // --- Overlay interaction ---
     OverlayUp,
     OverlayDown,
     OverlaySelect,
     OverlayFilter(char),
     OverlayFilterBackspace,
 
-    // --- SSE global events ---
     SseConnected,
     SseDisconnected,
     SseInit {
@@ -153,7 +143,6 @@ pub enum Msg {
         nous_id: NousId,
     },
 
-    // --- Streaming response events ---
     StreamTurnStart {
         session_id: SessionId,
         nous_id: NousId,
@@ -207,7 +196,6 @@ pub enum Msg {
     },
     StreamError(String),
 
-    // --- API responses ---
     AgentsLoaded(Vec<Agent>),
     SessionsLoaded {
         nous_id: NousId,
@@ -223,12 +211,10 @@ pub enum Msg {
     AuthResult(AuthOutcome),
     ApiError(String),
 
-    // --- Settings ---
     SettingsLoaded(serde_json::Value),
     SettingsSaved,
     SettingsSaveError(String),
 
-    // --- Memory inspector ---
     MemoryOpen,
     MemoryClose,
     MemoryTabNext,
@@ -269,19 +255,17 @@ pub enum Msg {
     MemoryPageDown,
     MemoryPageUp,
 
-    // --- Errors / toasts ---
     ShowError(String),
     ShowSuccess(String),
     DismissError,
 
-    // --- Diff viewer ---
-    DiffOpen,       // :diff command — show uncommitted changes
-    DiffClose,      // Esc in diff view
-    DiffCycleMode,  // 'm' in diff view
-    DiffScrollUp,   // scroll up in diff view
-    DiffScrollDown, // scroll down in diff view
-    DiffPageUp,     // page up in diff view
-    DiffPageDown,   // page down in diff view
+    DiffOpen,
+    DiffClose,
+    DiffCycleMode,
+    DiffScrollUp,
+    DiffScrollDown,
+    DiffPageUp,
+    DiffPageDown,
     /// Auto-triggered diff from file modification tool result.
     DiffFromToolResult {
         path: String,
@@ -289,7 +273,6 @@ pub enum Msg {
         new_content: String,
     },
 
-    // --- Timer ---
     Tick,
 }
 

--- a/crates/theatron/tui/src/sanitize.rs
+++ b/crates/theatron/tui/src/sanitize.rs
@@ -20,79 +20,71 @@ pub fn sanitize_for_display(s: &str) -> Cow<'_, str> {
     while i < len {
         let b = bytes[i];
 
-        // 7-bit ESC introducer
+        // NOTE: 7-bit ESC introducer — 0x1B
         if b == 0x1B && i + 1 < len {
             let next = bytes[i + 1];
             match next {
-                // CSI: ESC [
+                // NOTE: CSI — ESC [
                 b'[' => {
                     i = skip_csi(bytes, i + 2);
                     continue;
                 }
-                // OSC: ESC ]
+                // NOTE: OSC — ESC ]
                 b']' => {
                     i = skip_osc(bytes, i + 2);
                     continue;
                 }
-                // DCS: ESC P
+                // NOTE: DCS — ESC P
                 b'P' => {
                     i = skip_until_st(bytes, i + 2);
                     continue;
                 }
-                // APC: ESC _
+                // NOTE: APC — ESC _
                 b'_' => {
                     i = skip_until_st(bytes, i + 2);
                     continue;
                 }
-                // SOS: ESC X
+                // NOTE: SOS — ESC X
                 b'X' => {
                     i = skip_until_st(bytes, i + 2);
                     continue;
                 }
-                // PM: ESC ^
+                // NOTE: PM — ESC ^
                 b'^' => {
                     i = skip_until_st(bytes, i + 2);
                     continue;
                 }
-                // ESC ( — character set designation (e.g., ESC(B)
+                // NOTE: ESC ( — character set designation, e.g., ESC(B for ASCII
                 b'(' | b')' | b'*' | b'+' if i + 2 < len => {
                     i += 3;
                     continue;
                 }
-                // Two-byte ESC sequences (e.g., ESC =, ESC >, ESC 7, ESC 8, etc.)
+                // NOTE: two-byte ESC sequences such as ESC =, ESC >, ESC 7
                 0x20..=0x7E => {
                     i += 2;
                     continue;
                 }
                 _ => {
-                    // Bare ESC followed by something unexpected — skip the ESC
+                    // NOTE: unrecognized ESC sequence — skip the ESC byte
                     i += 1;
                     continue;
                 }
             }
         }
 
-        // 8-bit C1 control characters (0x80-0x9F)
+        // NOTE: 8-bit C1 control characters (0x80–0x9F)
         if (0x80..=0x9F).contains(&b) {
-            // Only hit for single-byte values in valid UTF-8 context.
-            // In practice, UTF-8 multi-byte sequences start with 0xC0+,
-            // so 0x80-0x9F as a leading byte means Latin-1 C1 controls.
-            // However, in valid UTF-8 these bytes only appear as continuation
-            // bytes (never as leading bytes). We handle the U+0080..U+009F
-            // Unicode codepoints via char iteration below.
-            // For raw bytes, skip them.
             i += 1;
             continue;
         }
 
-        // C0 control characters
+        // NOTE: C0 control characters (0x00–0x1F)
         if b < 0x20 {
             match b {
                 b'\n' | b'\r' | b'\t' => {
                     out.push(b as char);
                 }
                 _ => {
-                    // Replace with Unicode control picture (U+2400 block)
                     out.push(control_picture(b));
                 }
             }
@@ -100,55 +92,52 @@ pub fn sanitize_for_display(s: &str) -> Cow<'_, str> {
             continue;
         }
 
-        // DEL
+        // NOTE: DEL — 0x7F
         if b == 0x7F {
-            out.push('\u{2421}'); // ␡
+            out.push('\u{2421}');
             i += 1;
             continue;
         }
 
-        // Normal byte — but we need to handle multi-byte UTF-8 correctly.
-        // Decode the next UTF-8 character.
         if let Some((ch, char_len)) = decode_utf8_char(bytes, i) {
-            // Check for Unicode C1 control characters (U+0080 to U+009F)
+            // NOTE: Unicode C1 control characters (U+0080–U+009F) — handle as named sequences
             if ('\u{0080}'..='\u{009F}').contains(&ch) {
                 match ch {
-                    // 8-bit CSI
+                    // NOTE: 8-bit CSI — U+009B
                     '\u{009B}' => {
                         i = skip_csi(bytes, i + char_len);
                         continue;
                     }
-                    // 8-bit OSC
+                    // NOTE: 8-bit OSC — U+009D
                     '\u{009D}' => {
                         i = skip_osc(bytes, i + char_len);
                         continue;
                     }
-                    // 8-bit DCS
+                    // NOTE: 8-bit DCS — U+0090
                     '\u{0090}' => {
                         i = skip_until_st(bytes, i + char_len);
                         continue;
                     }
-                    // 8-bit APC
+                    // NOTE: 8-bit APC — U+009F
                     '\u{009F}' => {
                         i = skip_until_st(bytes, i + char_len);
                         continue;
                     }
-                    // 8-bit SOS
+                    // NOTE: 8-bit SOS — U+0098
                     '\u{0098}' => {
                         i = skip_until_st(bytes, i + char_len);
                         continue;
                     }
-                    // 8-bit PM
+                    // NOTE: 8-bit PM — U+009E
                     '\u{009E}' => {
                         i = skip_until_st(bytes, i + char_len);
                         continue;
                     }
-                    // 8-bit ST — just drop it
+                    // NOTE: 8-bit ST — U+009C, drop
                     '\u{009C}' => {
                         i += char_len;
                         continue;
                     }
-                    // Other C1 — drop silently
                     _ => {
                         i += char_len;
                         continue;
@@ -158,7 +147,7 @@ pub fn sanitize_for_display(s: &str) -> Cow<'_, str> {
             out.push(ch);
             i += char_len;
         } else {
-            // Invalid UTF-8 byte — skip
+            // NOTE: invalid UTF-8 byte — skip
             i += 1;
         }
     }
@@ -170,12 +159,11 @@ pub fn sanitize_for_display(s: &str) -> Cow<'_, str> {
 fn needs_sanitization(s: &str) -> bool {
     for &b in s.as_bytes() {
         match b {
-            // C0 controls (except tab=0x09, LF=0x0A, CR=0x0D) and DEL
+            // NOTE: replace C0 controls (except HT/LF/CR) and DEL with control pictures
             0x00..=0x08 | 0x0B..=0x0C | 0x0E..=0x1F | 0x7F => return true,
             _ => {}
         }
     }
-    // Also check for Unicode C1 control characters
     for ch in s.chars() {
         if ('\u{0080}'..='\u{009F}').contains(&ch) {
             return true;
@@ -188,15 +176,12 @@ fn needs_sanitization(s: &str) -> bool {
 fn skip_csi(bytes: &[u8], start: usize) -> usize {
     let mut i = start;
     let len = bytes.len();
-    // Parameter bytes
     while i < len && (0x30..=0x3F).contains(&bytes[i]) {
         i += 1;
     }
-    // Intermediate bytes
     while i < len && (0x20..=0x2F).contains(&bytes[i]) {
         i += 1;
     }
-    // Final byte
     if i < len && (0x40..=0x7E).contains(&bytes[i]) {
         i += 1;
     }
@@ -209,18 +194,19 @@ fn skip_osc(bytes: &[u8], start: usize) -> usize {
     let len = bytes.len();
     while i < len {
         if bytes[i] == 0x07 {
-            return i + 1; // BEL terminator
+            return i + 1;
         }
         if bytes[i] == 0x1B && i + 1 < len && bytes[i + 1] == b'\\' {
-            return i + 2; // ST = ESC \
+            return i + 2;
         }
-        // 8-bit ST (U+009C as UTF-8: 0xC2 0x9C)
+        // NOTE: 8-bit ST as UTF-8 (U+009C = 0xC2 0x9C)
         if bytes[i] == 0xC2 && i + 1 < len && bytes[i + 1] == 0x9C {
             return i + 2;
         }
         i += 1;
     }
-    len // Unterminated — consume to end
+    // NOTE: unterminated sequence — consume to end of input
+    len
 }
 
 /// Skip until ST (ESC \ or 8-bit ST). Used for DCS, APC, SOS, PM.
@@ -229,53 +215,52 @@ fn skip_until_st(bytes: &[u8], start: usize) -> usize {
     let len = bytes.len();
     while i < len {
         if bytes[i] == 0x1B && i + 1 < len && bytes[i + 1] == b'\\' {
-            return i + 2; // ST = ESC \
+            return i + 2;
         }
-        // 8-bit ST (U+009C as UTF-8: 0xC2 0x9C)
+        // NOTE: 8-bit ST as UTF-8 (U+009C = 0xC2 0x9C)
         if bytes[i] == 0xC2 && i + 1 < len && bytes[i + 1] == 0x9C {
             return i + 2;
         }
         i += 1;
     }
-    len // Unterminated — consume to end
+    // NOTE: unterminated sequence — consume to end of input
+    len
 }
 
 /// Map a C0 control byte to its Unicode control picture character (U+2400 block).
 fn control_picture(byte: u8) -> char {
     match byte {
-        0x00 => '\u{2400}', // ␀ NUL
-        0x01 => '\u{2401}', // ␁ SOH
-        0x02 => '\u{2402}', // ␂ STX
-        0x03 => '\u{2403}', // ␃ ETX
-        0x04 => '\u{2404}', // ␄ EOT
-        0x05 => '\u{2405}', // ␅ ENQ
-        0x06 => '\u{2406}', // ␆ ACK
-        0x07 => '\u{2407}', // ␇ BEL
-        0x08 => '\u{2408}', // ␈ BS
-        // 0x09 = TAB (safe, handled before this)
-        // 0x0A = LF (safe, handled before this)
-        0x0B => '\u{240B}', // ␋ VT
-        0x0C => '\u{240C}', // ␌ FF
-        // 0x0D = CR (safe, handled before this)
-        0x0E => '\u{240E}', // ␎ SO
-        0x0F => '\u{240F}', // ␏ SI
-        0x10 => '\u{2410}', // ␐ DLE
-        0x11 => '\u{2411}', // ␑ DC1
-        0x12 => '\u{2412}', // ␒ DC2
-        0x13 => '\u{2413}', // ␓ DC3
-        0x14 => '\u{2414}', // ␔ DC4
-        0x15 => '\u{2415}', // ␕ NAK
-        0x16 => '\u{2416}', // ␖ SYN
-        0x17 => '\u{2417}', // ␗ ETB
-        0x18 => '\u{2418}', // ␘ CAN
-        0x19 => '\u{2419}', // ␙ EM
-        0x1A => '\u{241A}', // ␚ SUB
-        0x1B => '\u{241B}', // ␛ ESC
-        0x1C => '\u{241C}', // ␜ FS
-        0x1D => '\u{241D}', // ␝ GS
-        0x1E => '\u{241E}', // ␞ RS
-        0x1F => '\u{241F}', // ␟ US
-        _ => '\u{FFFD}',    // fallback replacement character
+        0x00 => '\u{2400}',
+        0x01 => '\u{2401}',
+        0x02 => '\u{2402}',
+        0x03 => '\u{2403}',
+        0x04 => '\u{2404}',
+        0x05 => '\u{2405}',
+        0x06 => '\u{2406}',
+        0x07 => '\u{2407}',
+        0x08 => '\u{2408}',
+        // NOTE: 0x09 TAB, 0x0A LF, 0x0D CR are safe and handled earlier
+        0x0B => '\u{240B}',
+        0x0C => '\u{240C}',
+        0x0E => '\u{240E}',
+        0x0F => '\u{240F}',
+        0x10 => '\u{2410}',
+        0x11 => '\u{2411}',
+        0x12 => '\u{2412}',
+        0x13 => '\u{2413}',
+        0x14 => '\u{2414}',
+        0x15 => '\u{2415}',
+        0x16 => '\u{2416}',
+        0x17 => '\u{2417}',
+        0x18 => '\u{2418}',
+        0x19 => '\u{2419}',
+        0x1A => '\u{241A}',
+        0x1B => '\u{241B}',
+        0x1C => '\u{241C}',
+        0x1D => '\u{241D}',
+        0x1E => '\u{241E}',
+        0x1F => '\u{241F}',
+        _ => '\u{FFFD}',
     }
 }
 

--- a/crates/theatron/tui/src/state/memory.rs
+++ b/crates/theatron/tui/src/state/memory.rs
@@ -3,6 +3,7 @@
 use serde::{Deserialize, Serialize};
 
 /// Sort options for the fact browser.
+#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FactSort {
     Confidence,
@@ -45,6 +46,7 @@ impl FactSort {
 }
 
 /// Which sub-view of the memory inspector is active.
+#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MemoryTab {
     Facts,
@@ -277,7 +279,6 @@ impl MemoryInspectorState {
         if iso.is_empty() {
             return "never".to_string();
         }
-        // Simple approach: just show date portion for now
         if let Some(date) = iso.split('T').next() {
             date.to_string()
         } else {

--- a/crates/theatron/tui/src/state/ops.rs
+++ b/crates/theatron/tui/src/state/ops.rs
@@ -1,6 +1,7 @@
 //! State for the operations pane — right-side panel showing thinking, tool calls, and diffs.
 
 /// Which pane currently has keyboard focus.
+#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum FocusedPane {
     #[default]
@@ -9,6 +10,7 @@ pub enum FocusedPane {
 }
 
 /// Status of a tool call in the operations pane.
+#[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum OpsToolStatus {
     Running,

--- a/crates/theatron/tui/src/state/tab.rs
+++ b/crates/theatron/tui/src/state/tab.rs
@@ -188,7 +188,6 @@ impl TabBar {
     pub(crate) fn find_by_title(&self, query: &str) -> Option<usize> {
         let query_lower = query.to_lowercase();
 
-        // Exact match first
         if let Some(idx) = self
             .tabs
             .iter()
@@ -197,7 +196,6 @@ impl TabBar {
             return Some(idx);
         }
 
-        // Prefix match
         if let Some(idx) = self
             .tabs
             .iter()
@@ -206,7 +204,6 @@ impl TabBar {
             return Some(idx);
         }
 
-        // Substring match
         self.tabs
             .iter()
             .position(|t| t.title.to_lowercase().contains(&query_lower))

--- a/crates/theatron/tui/src/state/virtual_scroll.rs
+++ b/crates/theatron/tui/src/state/virtual_scroll.rs
@@ -114,7 +114,6 @@ impl VirtualScroll {
             };
         }
 
-        // Compute top line (from top of content).
         let top_line = if auto_scroll {
             total.saturating_sub(vh)
         } else {
@@ -125,24 +124,21 @@ impl VirtualScroll {
 
         let bottom_line = top_line + vh;
 
-        // Binary search for the first item whose cumulative end > top_line.
-        // prefix_sums[i+1] = end of item i. We want the first i where prefix_sums[i+1] > top_line.
+        // NOTE: item_at_line binary-searches prefix_sums to find the item containing top_line.
         let first_item = self.item_at_line(top_line);
         let last_item = self.item_at_line(bottom_line.min(total));
 
-        // Line offset within first item for smooth sub-item scrolling.
         let first_item_start = self.prefix_sums[first_item];
         let line_offset = top_line.saturating_sub(first_item_start) as u16;
 
-        // Apply buffer zone.
         let start = first_item.saturating_sub(self.buffer);
         let end = (last_item + 1 + self.buffer).min(self.item_heights.len());
 
         ViewportSlice {
             range: start..end,
             line_offset: if start < first_item {
-                // Buffer items above — render them but don't offset into them.
-                // The offset applies from the start of the rendered range.
+                // NOTE: Buffer items above are rendered; add their height so the
+                // line_offset is relative to the start of the rendered range, not first_item.
                 let buffer_height: u64 = self.prefix_sums[first_item] - self.prefix_sums[start];
                 (buffer_height as u16).saturating_add(line_offset)
             } else {
@@ -157,21 +153,16 @@ impl VirtualScroll {
         if line == 0 {
             return 0;
         }
-        // We want the first i where prefix_sums[i+1] > line,
+        // NOTE: binary search — find first i where prefix_sums[i+1] > line,
         // i.e. the item whose cumulative range includes `line`.
-        // prefix_sums has len = n+1. Search in prefix_sums[1..] for the
-        // partition point where prefix_sums[i] <= line.
         let n = self.item_heights.len();
         if n == 0 {
             return 0;
         }
 
-        // Binary search: find largest i such that prefix_sums[i] <= line.
-        // That means item (i-1) ends at prefix_sums[i], so the line is in item i
-        // unless prefix_sums[i] == line exactly (then it's the start of item i).
+        // NOTE: partition_point returns the first index where prefix_sums[idx] > line,
+        // so the item containing `line` is idx - 1 (prefix_sums[idx-1] <= line < prefix_sums[idx]).
         let idx = self.prefix_sums.partition_point(|&s| s <= line);
-        // idx is the first index where prefix_sums[idx] > line.
-        // The item containing `line` is idx - 1 (since prefix_sums[idx-1] <= line < prefix_sums[idx]).
         idx.saturating_sub(1).min(n.saturating_sub(1))
     }
 
@@ -217,12 +208,9 @@ pub(crate) fn estimate_message_height(text_len: usize, has_tools: bool, width: u
     let w = width.max(1) as usize;
     let header = 1u16;
     let tools = if has_tools { 1u16 } else { 0 };
-    // Rough estimate: each line of text is ~width chars.
-    // Add 1 for partial last line. Newlines add extra lines.
     let content = if text_len == 0 {
         0u16
     } else {
-        // Count at least 1 line, plus wrapping
         (text_len / w + 1).min(u16::MAX as usize) as u16
     };
     let blank = 1u16;

--- a/crates/theatron/tui/src/theme.rs
+++ b/crates/theatron/tui/src/theme.rs
@@ -174,40 +174,40 @@ impl Theme {
         Self {
             colors: Colors {
                 bg: Color::Reset,
-                surface: Color::Indexed(235),        // #262626
-                surface_bright: Color::Indexed(237), // #3a3a3a
-                surface_dim: Color::Indexed(233),    // #121212
-                accent: Color::Indexed(111),         // #87afff
-                accent_dim: Color::Indexed(67),      // #5f87af
+                surface: Color::Indexed(235),
+                surface_bright: Color::Indexed(237),
+                surface_dim: Color::Indexed(233),
+                accent: Color::Indexed(111),
+                accent_dim: Color::Indexed(67),
             },
             text: TextColors {
-                fg: Color::Indexed(253),       // #dadada
-                fg_muted: Color::Indexed(245), // #8a8a8a
-                fg_dim: Color::Indexed(240),   // #585858
+                fg: Color::Indexed(253),
+                fg_muted: Color::Indexed(245),
+                fg_dim: Color::Indexed(240),
                 user: Color::Indexed(111),
                 assistant: Color::Indexed(114),
                 system: Color::Indexed(245),
             },
             borders: Borders {
-                normal: Color::Indexed(238), // #444444
+                normal: Color::Indexed(238),
                 focused: Color::Indexed(111),
-                separator: Color::Indexed(236), // #303030
+                separator: Color::Indexed(236),
                 selected: Color::Indexed(111),
             },
             status: StatusColors {
-                success: Color::Indexed(114), // #87d787
-                warning: Color::Indexed(221), // #ffd75f
-                error: Color::Indexed(167),   // #d75f5f
-                info: Color::Indexed(111),    // #87afff
+                success: Color::Indexed(114),
+                warning: Color::Indexed(221),
+                error: Color::Indexed(167),
+                info: Color::Indexed(111),
                 spinner: Color::Indexed(221),
                 idle: Color::Indexed(240),
                 streaming: Color::Indexed(114),
-                compacting: Color::Indexed(177), // #d787ff
+                compacting: Color::Indexed(177),
             },
             code: CodeColors {
-                fg: Color::Indexed(252),   // #d0d0d0
-                bg: Color::Indexed(236),   // #303030
-                lang: Color::Indexed(242), // #6c6c6c
+                fg: Color::Indexed(252),
+                bg: Color::Indexed(236),
+                lang: Color::Indexed(242),
             },
             thinking: ThinkingColors {
                 fg: Color::Indexed(242),
@@ -348,7 +348,7 @@ impl Theme {
 
 /// Detect terminal color capability from environment variables.
 fn detect_color_depth() -> ColorDepth {
-    // Check COLORTERM first — most reliable indicator
+    // WHY: COLORTERM is the most reliable indicator — check it before TERM.
     if let Ok(ct) = std::env::var("COLORTERM") {
         match ct.as_str() {
             "truecolor" | "24bit" => return ColorDepth::TrueColor,
@@ -356,7 +356,6 @@ fn detect_color_depth() -> ColorDepth {
         }
     }
 
-    // Known true-color terminals
     if let Ok(tp) = std::env::var("TERM_PROGRAM") {
         match tp.as_str() {
             "iTerm.app" | "WezTerm" | "Alacritty" | "kitty" => return ColorDepth::TrueColor,
@@ -364,19 +363,17 @@ fn detect_color_depth() -> ColorDepth {
         }
     }
 
-    // GNOME Terminal sets COLORTERM=truecolor but check VTE_VERSION as backup
+    // NOTE: GNOME Terminal sets COLORTERM=truecolor, but VTE_VERSION is a reliable backup.
     if std::env::var("VTE_VERSION").is_ok() {
         return ColorDepth::TrueColor;
     }
 
-    // Check TERM for 256-color support
     if let Ok(term) = std::env::var("TERM")
         && term.contains("256color")
     {
         return ColorDepth::Color256;
     }
 
-    // tmux usually supports 256 colors minimum
     if std::env::var("TMUX").is_ok() {
         return ColorDepth::Color256;
     }

--- a/crates/theatron/tui/src/update/api.rs
+++ b/crates/theatron/tui/src/update/api.rs
@@ -6,7 +6,6 @@ use crate::sanitize::sanitize_for_display;
 use crate::state::{AgentState, AgentStatus, ChatMessage};
 
 #[tracing::instrument(skip_all, fields(count = agents.len()))]
-// SAFETY: sanitized at ingestion — all Agent fields from API are sanitized here.
 pub(crate) fn handle_agents_loaded(app: &mut App, agents: Vec<Agent>) {
     app.agents = agents
         .into_iter()
@@ -30,7 +29,6 @@ pub(crate) fn handle_agents_loaded(app: &mut App, agents: Vec<Agent>) {
 }
 
 #[tracing::instrument(skip_all, fields(%nous_id, count = sessions.len()))]
-// SAFETY: sanitized at ingestion — session keys and fields from API are sanitized here.
 pub(crate) fn handle_sessions_loaded(app: &mut App, nous_id: NousId, sessions: Vec<Session>) {
     if let Some(agent) = app.agents.iter_mut().find(|a| a.id == nous_id) {
         agent.sessions = sanitize_sessions(sessions);
@@ -38,7 +36,6 @@ pub(crate) fn handle_sessions_loaded(app: &mut App, nous_id: NousId, sessions: V
 }
 
 #[tracing::instrument(skip_all, fields(count = messages.len()))]
-// SAFETY: sanitized at ingestion — all message content from API is sanitized here.
 pub(crate) fn handle_history_loaded(app: &mut App, messages: Vec<HistoryMessage>) {
     app.messages = messages
         .into_iter()
@@ -60,8 +57,8 @@ pub(crate) fn handle_history_loaded(app: &mut App, messages: Vec<HistoryMessage>
             })
         })
         .collect();
-    // Stale streaming markdown from the previous session must not bleed through
-    // when history is replaced on session switch.
+    // WHY: Clear stale streaming markdown so it doesn't bleed through when
+    // history is replaced on session switch.
     app.cached_markdown_text.clear();
     app.cached_markdown_lines.clear();
     app.rebuild_virtual_scroll();
@@ -143,7 +140,6 @@ pub(crate) async fn handle_session_picker_archive(app: &mut App) {
 }
 
 #[tracing::instrument(skip_all)]
-// SAFETY: sanitized at ingestion — error messages may contain external data.
 pub(crate) fn handle_show_error(app: &mut App, msg: String) {
     app.error_toast = Some(ErrorToast::new(sanitize_for_display(&msg).into_owned()));
 }

--- a/crates/theatron/tui/src/update/command.rs
+++ b/crates/theatron/tui/src/update/command.rs
@@ -39,7 +39,7 @@ pub fn handle_backspace(app: &mut App) {
         refresh_suggestions(app);
         app.command_palette.selected = 0;
     } else {
-        // Backspace on empty input closes palette (vim behavior)
+        // WHY: closes on empty backspace to match vim command-mode behavior
         app.command_palette.active = false;
     }
 }
@@ -90,7 +90,6 @@ pub fn handle_tab(app: &mut App) {
 
 #[tracing::instrument(skip_all)]
 pub async fn handle_select(app: &mut App) {
-    // Resolve to the selected suggestion before executing
     if let Some(suggestion) = app
         .command_palette
         .suggestions
@@ -107,7 +106,7 @@ pub async fn handle_select(app: &mut App) {
         if extra_args.is_empty() {
             app.command_palette.input = execute_as;
         } else {
-            // Preserve typed args (e.g., user typed "agent sy" but suggestion is "agent")
+            // NOTE: preserve typed args — user may have typed extra text beyond the suggestion base
             let suggestion_has_args = execute_as.contains(' ');
             if suggestion_has_args {
                 app.command_palette.input = execute_as;

--- a/crates/theatron/tui/src/update/diff.rs
+++ b/crates/theatron/tui/src/update/diff.rs
@@ -93,7 +93,7 @@ pub(crate) fn handle_diff_from_tool_result(
 ) {
     let file_diff = diff::compute_diff(path, old_content, new_content);
     if file_diff.hunks.is_empty() {
-        return; // no actual changes
+        return;
     }
     app.overlay = Some(Overlay::DiffView(DiffViewState::new(vec![file_diff])));
 }

--- a/crates/theatron/tui/src/update/filter.rs
+++ b/crates/theatron/tui/src/update/filter.rs
@@ -3,14 +3,13 @@ use crate::app::App;
 pub(crate) fn handle_open(app: &mut App) {
     app.filter.open();
     update_match_counts(app);
-    // Rebuild so the virtual scroll is fresh when the user exits filter mode.
+    // WHY: rebuild ensures virtual scroll reflects current state before the user exits filter mode
     app.rebuild_virtual_scroll();
 }
 
 pub(crate) fn handle_close(app: &mut App) {
     app.filter.close();
-    // Rebuild before scrolling to bottom so the virtual scroll reflects the
-    // full message list now that filtered rendering is deactivated.
+    // WHY: rebuild before scrolling to bottom so virtual scroll reflects the full message list
     app.rebuild_virtual_scroll();
     app.scroll_to_bottom();
 }
@@ -42,8 +41,7 @@ pub(crate) fn handle_confirm(app: &mut App) {
     } else {
         app.filter.confirm();
     }
-    // Rebuild so the virtual scroll is consistent with any layout changes that
-    // occurred while filter mode was active.
+    // WHY: rebuild so virtual scroll is consistent with any layout changes during filter mode
     app.rebuild_virtual_scroll();
 }
 

--- a/crates/theatron/tui/src/update/input.rs
+++ b/crates/theatron/tui/src/update/input.rs
@@ -48,7 +48,6 @@ pub(crate) fn handle_cursor_end(app: &mut App) {
 
 pub(crate) fn handle_delete_word(app: &mut App) {
     let mut pos = app.input.cursor;
-    // Skip trailing whitespace using Unicode char boundaries
     while pos > 0 {
         let prev = app.prev_char_boundary(pos);
         let is_ws = app.input.text[prev..pos]
@@ -61,7 +60,6 @@ pub(crate) fn handle_delete_word(app: &mut App) {
             break;
         }
     }
-    // Skip word characters (non-whitespace)
     while pos > 0 {
         let prev = app.prev_char_boundary(pos);
         let is_ws = app.input.text[prev..pos]
@@ -136,9 +134,7 @@ pub(crate) fn handle_copy_last_response(app: &mut App) {
     }
 }
 
-// Blocking is intentional: the TUI is suspended (ratatui::restore) so the event
-// loop is paused. The editor runs in the foreground terminal. No async work can
-// proceed while the terminal is owned by the child process.
+// WHY: blocking is intentional — TUI is suspended so the event loop is paused
 pub(crate) fn handle_compose_in_editor(app: &mut App) {
     let editor = std::env::var("EDITOR").unwrap_or_else(|_| "vi".to_string());
     let tmpfile = std::env::temp_dir().join("aletheia-compose.md");

--- a/crates/theatron/tui/src/update/memory.rs
+++ b/crates/theatron/tui/src/update/memory.rs
@@ -9,7 +9,6 @@ use crate::state::view_stack::View;
 pub async fn handle_open(app: &mut App) {
     app.view_stack.push(View::MemoryInspector);
     app.memory.loading = true;
-    // Load facts from the API
     load_facts(app).await;
 }
 
@@ -185,7 +184,7 @@ pub async fn handle_confidence_submit(app: &mut App) {
         .selected_fact()
         .map(|f| (f.id.clone(), f.confidence));
     if let Some((id, prev_conf)) = selected {
-        // Optimistic update: apply locally before the API round-trip.
+        // NOTE: optimistic update — applied locally before the API round-trip to avoid UI lag
         if let Some(f) = app.memory.facts.iter_mut().find(|f| f.id == id) {
             f.confidence = conf;
         }
@@ -195,7 +194,7 @@ pub async fn handle_confidence_submit(app: &mut App) {
                 app.error_toast = Some(ErrorToast::new(format!("Confidence set to {conf:.2}")));
             }
             Err(e) => {
-                // Revert the optimistic update on failure.
+                // NOTE: revert the optimistic update on failure
                 if let Some(f) = app.memory.facts.iter_mut().find(|f| f.id == id) {
                     f.confidence = prev_conf;
                 }
@@ -232,7 +231,7 @@ pub async fn handle_search_submit(app: &mut App) {
         return;
     }
     app.memory.search_active = false;
-    // Perform search via local fuzzy filtering for now
+    // NOTE: local fuzzy filtering — server-side semantic search not yet wired in
     let query = app.memory.search_query.to_lowercase();
     let terms: Vec<&str> = query.split_whitespace().collect();
 
@@ -287,8 +286,6 @@ pub fn handle_search_close(app: &mut App) {
     app.memory.search_results.clear();
 }
 
-// --- Data loading ---
-
 pub fn handle_facts_loaded(app: &mut App, facts: Vec<MemoryFact>, total: usize) {
     app.memory.facts = facts;
     app.memory.total_facts = total;
@@ -304,8 +301,6 @@ pub fn handle_detail_loaded(app: &mut App, detail: FactDetail) {
 pub fn handle_action_result(app: &mut App, message: String) {
     app.error_toast = Some(ErrorToast::new(message));
 }
-
-// --- Internal helpers ---
 
 async fn load_facts(app: &mut App) {
     let client = app.client.clone();
@@ -341,7 +336,7 @@ async fn load_fact_detail(app: &mut App, fact_id: &str) {
             tracing::debug!("failed to load fact detail: {e}");
         }
     }
-    // Fallback: create minimal detail from local data
+    // NOTE: fallback to local data when API detail fetch fails
     if let Some(fact) = app.memory.facts.iter().find(|f| f.id == fact_id) {
         app.memory.detail = Some(FactDetail {
             fact: fact.clone(),

--- a/crates/theatron/tui/src/update/mod.rs
+++ b/crates/theatron/tui/src/update/mod.rs
@@ -20,13 +20,11 @@ pub(crate) use api::extract_text_content;
 
 #[tracing::instrument(skip_all)]
 pub(crate) async fn update(app: &mut App, msg: Msg) {
-    // Clear pending_g on any message except GPrefix itself
     if !matches!(msg, Msg::GPrefix | Msg::Tick) {
         app.pending_g = false;
     }
 
     match msg {
-        // --- Tabs ---
         Msg::TabNew => tabs::handle_tab_new(app),
         Msg::TabClose => tabs::handle_tab_close(app),
         Msg::TabNext => tabs::handle_tab_next(app),
@@ -34,7 +32,6 @@ pub(crate) async fn update(app: &mut App, msg: Msg) {
         Msg::TabJump(n) => tabs::handle_tab_jump(app, n),
         Msg::GPrefix => tabs::handle_g_prefix(app),
 
-        // --- Message selection ---
         Msg::SelectPrev => selection::handle_select_prev(app),
         Msg::SelectNext => selection::handle_select_next(app),
         Msg::DeselectMessage => selection::handle_deselect(app),
@@ -42,9 +39,7 @@ pub(crate) async fn update(app: &mut App, msg: Msg) {
         Msg::SelectLast => selection::handle_select_last(app),
         Msg::MessageAction(action) => selection::handle_message_action(app, action),
 
-        // --- Input ---
         Msg::CharInput(c) => {
-            // If a message is selected and a non-action char arrives, deselect first
             if app.selected_message.is_some() {
                 selection::handle_deselect(app);
             }
@@ -65,7 +60,6 @@ pub(crate) async fn update(app: &mut App, msg: Msg) {
         Msg::CopyLastResponse => input::handle_copy_last_response(app),
         Msg::ComposeInEditor => input::handle_compose_in_editor(app),
 
-        // --- Filter ---
         Msg::FilterOpen => filter::handle_open(app),
         Msg::FilterClose => filter::handle_close(app),
         Msg::FilterInput(c) => filter::handle_input(app, c),
@@ -75,7 +69,6 @@ pub(crate) async fn update(app: &mut App, msg: Msg) {
         Msg::FilterNextMatch => filter::handle_next_match(app),
         Msg::FilterPrevMatch => filter::handle_prev_match(app),
 
-        // --- Command palette ---
         Msg::CommandPaletteOpen => command::handle_open(app),
         Msg::CommandPaletteClose => command::handle_close(app),
         Msg::CommandPaletteInput(c) => command::handle_input(app, c),
@@ -86,7 +79,6 @@ pub(crate) async fn update(app: &mut App, msg: Msg) {
         Msg::CommandPaletteDown => command::handle_down(app),
         Msg::CommandPaletteTab => command::handle_tab(app),
 
-        // --- Navigation ---
         Msg::ScrollUp => navigation::handle_scroll_up(app),
         Msg::ScrollDown => navigation::handle_scroll_down(app),
         Msg::ScrollPageUp => navigation::handle_scroll_page_up(app),
@@ -108,7 +100,6 @@ pub(crate) async fn update(app: &mut App, msg: Msg) {
         Msg::ViewDrillIn => view_nav::handle_drill_in(app),
         Msg::ViewPopBack => view_nav::handle_pop_back(app),
 
-        // --- Overlay ---
         Msg::OpenOverlay(kind) => overlay::handle_open_overlay(app, kind).await,
         Msg::CloseOverlay => overlay::handle_close_overlay(app),
         Msg::OverlayUp => overlay::handle_overlay_up(app),
@@ -133,7 +124,6 @@ pub(crate) async fn update(app: &mut App, msg: Msg) {
             }
         }
 
-        // --- SSE ---
         Msg::SseConnected => sse::handle_sse_connected(app).await,
         Msg::SseDisconnected => sse::handle_sse_disconnected(app),
         Msg::SseInit { active_turns } => sse::handle_sse_init(app, active_turns),
@@ -162,7 +152,6 @@ pub(crate) async fn update(app: &mut App, msg: Msg) {
         }
         Msg::SseDistillAfter { nous_id } => sse::handle_sse_distill_after(app, nous_id).await,
 
-        // --- Streaming ---
         Msg::StreamTurnStart {
             turn_id, nous_id, ..
         } => streaming::handle_stream_turn_start(app, turn_id, nous_id),
@@ -206,7 +195,6 @@ pub(crate) async fn update(app: &mut App, msg: Msg) {
         Msg::StreamTurnAbort { reason } => streaming::handle_stream_turn_abort(app, reason),
         Msg::StreamError(msg) => streaming::handle_stream_error(app, msg),
 
-        // --- API ---
         Msg::AgentsLoaded(agents) => api::handle_agents_loaded(app, agents),
         Msg::SessionsLoaded { nous_id, sessions } => {
             api::handle_sessions_loaded(app, nous_id, sessions)
@@ -220,7 +208,6 @@ pub(crate) async fn update(app: &mut App, msg: Msg) {
         Msg::SettingsLoaded(config) => settings::handle_loaded(app, config),
         Msg::SettingsSaved => settings::handle_saved(app),
         Msg::SettingsSaveError(msg) => settings::handle_save_error(app, msg),
-        // --- Memory inspector ---
         Msg::MemoryOpen => memory::handle_open(app).await,
         Msg::MemoryClose => memory::handle_close(app),
         Msg::MemoryTabNext => memory::handle_tab_next(app),
@@ -261,7 +248,6 @@ pub(crate) async fn update(app: &mut App, msg: Msg) {
         Msg::ShowError(msg) => api::handle_show_error(app, msg),
         Msg::ShowSuccess(msg) => api::handle_show_success(app, msg),
         Msg::DismissError => api::handle_dismiss_error(app),
-        // --- Diff viewer ---
         Msg::DiffOpen => diff::handle_diff_open(app).await,
         Msg::DiffClose => diff::handle_diff_close(app),
         Msg::DiffCycleMode => diff::handle_diff_cycle_mode(app),

--- a/crates/theatron/tui/src/update/navigation.rs
+++ b/crates/theatron/tui/src/update/navigation.rs
@@ -134,11 +134,8 @@ fn clamp_scroll_offset(app: &mut App) {
 pub(crate) fn handle_resize(app: &mut App, w: u16, h: u16) {
     app.terminal_width = w;
     app.terminal_height = h;
-    // Terminal width changed — recalculate message heights for wrapping.
     app.rebuild_virtual_scroll();
-    // After rebuild, heights may have changed due to reflow. Cap scroll_offset so
-    // the user cannot be stranded past the top of content. If already at the
-    // bottom, stay there. Auto-scroll mode is unaffected (it always pins to bottom).
+    // NOTE: cap scroll_offset after reflow so the user cannot scroll past the top of content; auto-scroll is unaffected
     if !app.auto_scroll {
         let total = app.virtual_scroll.total_height();
         let vh = chat_viewport_height(app) as u64;

--- a/crates/theatron/tui/src/update/overlay.rs
+++ b/crates/theatron/tui/src/update/overlay.rs
@@ -29,7 +29,7 @@ pub(crate) async fn handle_open_overlay(app: &mut App, kind: OverlayKind) {
 }
 
 pub(crate) fn handle_close_overlay(app: &mut App) {
-    // Settings edit mode: Esc cancels the edit, not the overlay
+    // NOTE: Esc in settings edit mode cancels the edit, not the overlay itself
     if let Some(Overlay::Settings(ref s)) = app.overlay
         && s.editing.is_some()
     {

--- a/crates/theatron/tui/src/update/selection.rs
+++ b/crates/theatron/tui/src/update/selection.rs
@@ -10,7 +10,6 @@ pub(crate) fn handle_select_prev(app: &mut App) {
     }
     match app.selected_message {
         None => {
-            // Enter selection mode on last message
             let idx = count - 1;
             app.selected_message = Some(idx);
             app.auto_scroll = false;
@@ -31,7 +30,6 @@ pub(crate) fn handle_select_next(app: &mut App) {
     }
     match app.selected_message {
         None => {
-            // Enter selection mode on last message
             let idx = count - 1;
             app.selected_message = Some(idx);
             app.auto_scroll = false;
@@ -110,7 +108,6 @@ fn action_yank_code_block(app: &mut App, idx: usize) {
             }
         }
     } else {
-        // No code block — copy full message
         match crate::clipboard::copy_to_clipboard(text) {
             Ok(()) => show_toast(app, "No code block found — copied full message"),
             Err(e) => {
@@ -140,7 +137,6 @@ fn action_delete(app: &mut App, idx: usize) {
         return;
     }
     app.messages.remove(idx);
-    // Fix selection index after removal
     let count = app.messages.len();
     if count == 0 {
         app.selected_message = None;
@@ -166,7 +162,6 @@ fn action_open_links(app: &mut App, idx: usize) {
             }
         }
         n => {
-            // Open the first link and notify about the rest
             if let Err(e) = open::that(&urls[0]) {
                 tracing::error!("failed to open URL: {e}");
                 show_toast(app, "Failed to open link");
@@ -183,7 +178,6 @@ fn action_inspect(app: &mut App, idx: usize) {
         show_toast(app, "No tool calls to inspect");
         return;
     }
-    // Toggle expanded state for all tool calls on this message
     let key = crate::id::ToolId::from(format!("msg:{idx}"));
     if app.tool_expanded.contains(&key) {
         app.tool_expanded.remove(&key);
@@ -249,7 +243,7 @@ fn extract_first_code_block(text: &str) -> Option<String> {
 fn extract_urls(text: &str) -> Vec<String> {
     let mut urls = Vec::new();
     for word in text.split_whitespace() {
-        // Handle markdown link syntax: [text](url)
+        // NOTE: handle markdown link syntax [text](url) before falling through to plain URL detection
         if let Some(paren_start) = word.find("](") {
             let url_part = &word[paren_start + 2..];
             let candidate = url_part

--- a/crates/theatron/tui/src/update/settings.rs
+++ b/crates/theatron/tui/src/update/settings.rs
@@ -4,7 +4,6 @@ use crate::sanitize::sanitize_for_display;
 use crate::state::Overlay;
 use crate::state::settings::{EditState, FieldType, SaveStatus, SettingsOverlay};
 
-// SAFETY: sanitized at ingestion — config from API is sanitized via sanitize_config_json.
 pub async fn handle_open(app: &mut App) {
     match app.client.config().await {
         Ok(config) => {
@@ -19,8 +18,6 @@ pub async fn handle_open(app: &mut App) {
     }
 }
 
-// SAFETY: sanitized at ingestion — config values from API are sanitized in SettingsOverlay.
-// Config values are mostly numbers/bools; string values are sanitized by sanitize_config_json.
 pub fn handle_loaded(app: &mut App, config: serde_json::Value) {
     let clean_config = sanitize_config_json(config);
     app.overlay = Some(Overlay::Settings(SettingsOverlay::from_config(
@@ -167,15 +164,13 @@ pub async fn handle_save(app: &mut App) {
 pub fn handle_saved(app: &mut App) {
     app.error_toast = Some(ErrorToast::new("Config saved and reloaded".to_owned()));
     app.overlay = None;
-    // Config changes can affect display (e.g. syntax highlighting theme). Invalidate
-    // the cached markdown lines and rebuild virtual scroll heights so the next render
-    // picks up fresh layout.
+    // WHY: Config changes can affect display (e.g. syntax highlighting theme), so
+    // invalidate the markdown cache and rebuild virtual scroll heights for the next render.
     app.cached_markdown_text.clear();
     app.cached_markdown_lines.clear();
     app.rebuild_virtual_scroll();
 }
 
-// SAFETY: sanitized at ingestion — error messages may contain external data.
 pub fn handle_save_error(app: &mut App, msg: String) {
     if let Some(Overlay::Settings(s)) = &mut app.overlay {
         s.save_status = SaveStatus::Error(sanitize_for_display(&msg).into_owned());

--- a/crates/theatron/tui/src/update/sse.rs
+++ b/crates/theatron/tui/src/update/sse.rs
@@ -111,7 +111,6 @@ pub(crate) async fn handle_sse_turn_after(app: &mut App, nous_id: NousId, sessio
         app.load_focused_session().await;
     }
 
-    // Mark background tabs as unread
     app.tab_bar.mark_unread(&nous_id, &session_id);
 }
 

--- a/crates/theatron/tui/src/update/streaming.rs
+++ b/crates/theatron/tui/src/update/streaming.rs
@@ -20,7 +20,6 @@ pub(crate) fn handle_stream_turn_start(app: &mut App, turn_id: TurnId, nous_id: 
     if let Some(agent) = app.agents.iter_mut().find(|a| a.id == nous_id) {
         agent.status = AgentStatus::Streaming;
     }
-    // Operations pane: clear previous turn data and auto-show
     app.ops.clear_turn();
     app.ops.auto_show_if_configured();
 }
@@ -59,7 +58,6 @@ pub(crate) fn handle_stream_tool_start(app: &mut App, tool_name: String) {
         duration_ms: None,
         is_error: false,
     });
-    // Operations pane: add tool call entry
     app.ops.push_tool_start(clean_name.clone(), None);
     if let Some(ref agent_id) = app.focused_agent
         && let Some(agent) = app.agents.iter_mut().find(|a| a.id == *agent_id)
@@ -87,7 +85,6 @@ pub(crate) fn handle_stream_tool_result(
         tc.duration_ms = Some(duration_ms);
         tc.is_error = is_error;
     }
-    // Operations pane: complete tool call
     app.ops
         .complete_tool(&tool_name, is_error, duration_ms, None);
     if let Some(ref agent_id) = app.focused_agent
@@ -190,8 +187,8 @@ pub(crate) async fn handle_stream_turn_complete(app: &mut App, outcome: TurnOutc
             tool_calls,
         });
         app.virtual_scroll.push_item(h);
-        // Scroll lock: when the user has scrolled up, keep the viewport anchored by
-        // compensating for the new content added below their current position.
+        // WHY: Keep the viewport anchored when scrolled up by compensating the
+        // scroll offset for the new content added below the current position.
         if !app.auto_scroll {
             app.scroll_offset = app.scroll_offset.saturating_add(h as usize);
         }
@@ -209,7 +206,6 @@ pub(crate) async fn handle_stream_turn_complete(app: &mut App, outcome: TurnOutc
         agent.status = AgentStatus::Idle;
         agent.active_tool = None;
     }
-    // Operations pane: auto-hide when turn completes
     app.ops.auto_hide_if_configured();
     if let Ok(cents) = app.client.today_cost_cents().await {
         app.daily_cost_cents = cents;
@@ -224,7 +220,6 @@ pub(crate) fn handle_stream_turn_abort(app: &mut App, reason: String) {
     app.streaming_tool_calls.clear();
     app.active_turn_id = None;
     app.stream_rx = None;
-    // Reset agent status so sidebar shows idle, not stuck on "working"
     if let Some(ref agent_id) = app.focused_agent
         && let Some(agent) = app.agents.iter_mut().find(|a| a.id == *agent_id)
     {
@@ -240,11 +235,9 @@ pub(crate) fn handle_stream_error(app: &mut App, msg: String) {
     app.error_toast = Some(ErrorToast::new(sanitize_for_display(&msg).into_owned()));
     app.active_turn_id = None;
     app.stream_rx = None;
-    // Clear streaming_tool_calls so the UI doesn't show a stale running spinner
-    // for the last tool. streaming_text is intentionally preserved so the user
-    // can read any partial response received before the error.
+    // WHY: Clear tool calls to remove stale spinners; preserve streaming_text
+    // so the user can read any partial response received before the error.
     app.streaming_tool_calls.clear();
-    // Reset agent status so sidebar shows idle, not stuck on "working"
     if let Some(ref agent_id) = app.focused_agent
         && let Some(agent) = app.agents.iter_mut().find(|a| a.id == *agent_id)
     {

--- a/crates/theatron/tui/src/update/tabs.rs
+++ b/crates/theatron/tui/src/update/tabs.rs
@@ -5,7 +5,6 @@ use crate::msg::ErrorToast;
 use crate::state::{Overlay, SessionPickerOverlay};
 
 pub(crate) fn handle_tab_new(app: &mut App) {
-    // Open session picker to choose what to open in the new tab
     app.overlay = Some(Overlay::SessionPicker(SessionPickerOverlay {
         cursor: 0,
         show_archived: false,
@@ -14,7 +13,6 @@ pub(crate) fn handle_tab_new(app: &mut App) {
 
 pub(crate) fn handle_tab_close(app: &mut App) {
     if app.tab_bar.len() <= 1 {
-        // Last tab — don't close, show hint
         app.error_toast = Some(ErrorToast::new("Cannot close last tab".into()));
         return;
     }

--- a/crates/theatron/tui/src/update/view_nav.rs
+++ b/crates/theatron/tui/src/update/view_nav.rs
@@ -39,7 +39,6 @@ pub(crate) fn handle_drill_in(app: &mut App) {
 
     match current {
         View::Home => {
-            // If a message is selected, drill into message detail
             if let Some(idx) = app.selected_message {
                 save_view_scroll(app);
                 app.view_stack
@@ -49,7 +48,6 @@ pub(crate) fn handle_drill_in(app: &mut App) {
                 return;
             }
 
-            // Otherwise drill into sessions for the focused agent
             let agent_id = app.focused_agent.clone();
             if let Some(agent_id) = agent_id {
                 save_view_scroll(app);
@@ -59,7 +57,6 @@ pub(crate) fn handle_drill_in(app: &mut App) {
             }
         }
         View::Sessions { ref agent_id } => {
-            // Drill into the focused session's conversation
             let agent_id = agent_id.clone();
             let session_id = app.focused_session_id.clone();
             if let Some(session_id) = session_id {
@@ -73,7 +70,6 @@ pub(crate) fn handle_drill_in(app: &mut App) {
             }
         }
         View::Conversation { .. } => {
-            // Drill into message detail if a message is selected
             if let Some(idx) = app.selected_message {
                 save_view_scroll(app);
                 app.view_stack
@@ -82,9 +78,7 @@ pub(crate) fn handle_drill_in(app: &mut App) {
                 app.auto_scroll = true;
             }
         }
-        View::MessageDetail { .. } | View::MemoryInspector | View::FactDetail { .. } => {
-            // Leaf views or views with their own drill-in handling
-        }
+        View::MessageDetail { .. } | View::MemoryInspector | View::FactDetail { .. } => {}
     }
 }
 
@@ -93,7 +87,6 @@ pub(crate) fn handle_drill_in(app: &mut App) {
 /// At Home, Esc deselects the message (existing behavior) or does nothing.
 pub(crate) fn handle_pop_back(app: &mut App) {
     if app.view_stack.is_home() {
-        // At home, Esc deselects if there's a selection, otherwise no-op
         if app.selected_message.is_some() {
             app.selected_message = None;
         }

--- a/crates/theatron/tui/src/view/chat.rs
+++ b/crates/theatron/tui/src/view/chat.rs
@@ -23,10 +23,8 @@ struct MessageCtx<'a> {
 pub fn render(app: &App, frame: &mut Frame, area: Rect, theme: &Theme) -> Vec<OscLink> {
     let inner_width = area.width.saturating_sub(2) as usize;
     let wrap_width = area.width.saturating_sub(2).max(1);
-    // With Borders::NONE the paragraph has the full area height available.
     let visible_height = area.height;
-    // Para-relative link data collected from all messages.
-    let mut para_links: Vec<(usize, u16, String, String)> = Vec::new(); // (line_idx, col, text, url)
+    let mut para_links: Vec<(usize, u16, String, String)> = Vec::new();
 
     let filter_active =
         app.filter.active && app.filter.scope == FilterScope::Chat && !app.filter.text.is_empty();
@@ -39,17 +37,16 @@ pub fn render(app: &App, frame: &mut Frame, area: Rect, theme: &Theme) -> Vec<Os
         .map(|a| a.name_lower.as_str())
         .unwrap_or("assistant");
 
-    // When filter is active, we fall back to iterating all messages (filter changes
-    // the visible set dynamically). For the non-filtered common path, we use the
-    // VirtualScroll prefix-sum index for O(log n) range lookup.
+    // NOTE: When filter is active, fall back to iterating all messages (filter changes
+    // the visible set dynamically). For the non-filtered path, use the VirtualScroll
+    // prefix-sum index for O(log n) range lookup.
 
     let mut lines: Vec<Line> = Vec::new();
-    lines.push(Line::raw("")); // top padding
+    lines.push(Line::raw(""));
 
     if filter_active {
-        // Filtered path: iterate all messages, skip non-matching.
-        // This is acceptable because filtering is interactive and users rarely
-        // have 15K messages with a filter active.
+        // NOTE: Filtered path iterates all messages; acceptable because filtering is
+        // interactive and users rarely have 15K messages with a filter active.
         render_filtered_messages(
             app,
             &mut lines,
@@ -61,7 +58,6 @@ pub fn render(app: &App, frame: &mut Frame, area: Rect, theme: &Theme) -> Vec<Os
             &mut para_links,
         );
     } else {
-        // Virtual scroll path: only render viewport + buffer items.
         render_virtual_messages(
             app,
             &mut lines,
@@ -74,7 +70,6 @@ pub fn render(app: &App, frame: &mut Frame, area: Rect, theme: &Theme) -> Vec<Os
         );
     }
 
-    // Empty state: no messages and not streaming — show helpful placeholder.
     if app.messages.is_empty() && app.active_turn_id.is_none() && !filter_active {
         lines.push(Line::from(vec![
             Span::raw(" "),
@@ -96,7 +91,6 @@ pub fn render(app: &App, frame: &mut Frame, area: Rect, theme: &Theme) -> Vec<Os
         ]));
     }
 
-    // Streaming response (in progress)
     if !app.streaming_text.is_empty()
         || !app.streaming_thinking.is_empty()
         || app.active_turn_id.is_some()
@@ -104,9 +98,8 @@ pub fn render(app: &App, frame: &mut Frame, area: Rect, theme: &Theme) -> Vec<Os
         render_streaming(app, &mut lines, inner_width, theme, agent_name_lower);
     }
 
-    // Bottom alignment: when total content is shorter than the pane, push it to
-    // the bottom by prepending empty lines.  Only applies when not scrolled
-    // (content fits in the viewport).
+    // NOTE: Push short content to the bottom by prepending empty lines when
+    // total content fits in the viewport (not scrolled).
     {
         let w = wrap_width.max(1) as usize;
         let total_visual: usize = lines
@@ -121,22 +114,19 @@ pub fn render(app: &App, frame: &mut Frame, area: Rect, theme: &Theme) -> Vec<Os
             let mut padded: Vec<Line<'static>> = vec![Line::raw(""); padding];
             padded.append(&mut lines);
             lines = padded;
-            // Shift all paragraph-relative link line indices by the padding.
             for (line_idx, _, _, _) in &mut para_links {
                 *line_idx += padding;
             }
         }
     }
 
-    // Pre-compute per-line widths — needed for resolve_osc_links and scroll calc.
     let line_widths: Vec<usize> = lines
         .iter()
         .map(|line| line.spans.iter().map(|s| s.content.len()).sum())
         .collect();
 
-    // Total visual rows of the final rendered lines vector (after padding + streaming).
-    // Used for auto-scroll so that streaming content appended after virtual render is
-    // always visible when the user is at the bottom.
+    // NOTE: Total visual rows after padding + streaming; used for auto-scroll so
+    // streaming content appended after virtual render is always visible at the bottom.
     let w = wrap_width.max(1) as usize;
     let total_visual: usize = line_widths
         .iter()
@@ -145,16 +135,12 @@ pub fn render(app: &App, frame: &mut Frame, area: Rect, theme: &Theme) -> Vec<Os
     let vh = visible_height as usize;
 
     let scroll = if app.auto_scroll {
-        // Pin to the very bottom of whatever was rendered (committed + streaming).
         total_visual.saturating_sub(vh)
     } else if filter_active {
-        // Filtered path: all messages are in `lines`; use the pre-computed total.
         total_visual
             .saturating_sub(vh)
             .saturating_sub(app.scroll_offset)
     } else {
-        // Virtual scroll path with manual offset: line_offset already positions us
-        // correctly within the rendered (viewport-only) items.
         let slice =
             app.virtual_scroll
                 .visible_slice(app.scroll_offset, app.auto_scroll, visible_height);
@@ -169,7 +155,6 @@ pub fn render(app: &App, frame: &mut Frame, area: Rect, theme: &Theme) -> Vec<Os
 
     frame.render_widget(paragraph, area);
 
-    // Resolve para-relative links to absolute screen coordinates.
     resolve_osc_links(
         &para_links,
         &line_widths,
@@ -196,14 +181,12 @@ fn resolve_osc_links(
         return Vec::new();
     }
 
-    // Extract accent RGB — fall back to a sensible default for non-Rgb variants.
     let accent = match theme.colors.accent {
         ratatui::style::Color::Rgb(r, g, b) => (r, g, b),
         _ => (120, 180, 255),
     };
 
-    // Pre-compute the cumulative visual-row offset for each logical line.
-    // visual_row_start[i] = number of visual rows before logical line i.
+    // NOTE: visual_row_start[i] = cumulative visual rows before logical line i.
     let mut visual_row_start: Vec<u32> = Vec::with_capacity(line_widths.len());
     let mut cumulative: u32 = 0;
     for &w in line_widths {
@@ -219,7 +202,6 @@ fn resolve_osc_links(
         let Some(&vrow_start) = visual_row_start.get(*line_idx) else {
             continue;
         };
-        // Adjust for which visual row within the wrapped line this col sits on.
         let col_row = if wrap_width > 0 {
             (*col as usize) / wrap_width
         } else {
@@ -227,10 +209,9 @@ fn resolve_osc_links(
         };
         let vrow = vrow_start as i32 + col_row as i32;
 
-        // Apply scroll: positive scroll shifts content upward (scroll=0 means show from top).
         let screen_row = vrow - scroll as i32;
         if screen_row < 0 || screen_row >= visible_height {
-            continue; // link is outside the visible window
+            continue;
         }
 
         let screen_x = area.x + (*col as usize % wrap_width.max(1)) as u16;
@@ -263,15 +244,12 @@ fn render_virtual_messages(
     agent_name: &str,
     para_links: &mut Vec<(usize, u16, String, String)>,
 ) {
-    // Ensure the virtual scroll cache is populated and matches current width.
-    // This is a read-only check — cache rebuilds happen in the update layer.
-    // If the cache is stale (width changed or item count mismatch), fall back to
-    // full iteration for this single frame. The next update tick will rebuild.
+    // NOTE: If the virtual scroll cache is stale (width changed or item count mismatch),
+    // fall back to full iteration for this frame; the next update tick will rebuild.
     let needs_fallback = app.virtual_scroll.len() != app.messages.len()
         || (app.virtual_scroll.cached_width() != wrap_width && !app.messages.is_empty());
 
     if needs_fallback {
-        // Fallback: render all messages this frame. The cache will be rebuilt.
         for (idx, msg) in app.messages.iter().enumerate() {
             let ctx = MessageCtx {
                 inner_width,
@@ -352,7 +330,6 @@ fn render_message(
         _ => ("system", theme.style_muted()),
     };
 
-    // Selection indicator prefix
     let marker = if ctx.selected { "▸" } else { " " };
     let marker_style = if ctx.selected {
         Style::default().fg(theme.borders.selected)
@@ -360,7 +337,6 @@ fn render_message(
         Style::default()
     };
 
-    // Header: selection marker + role name + optional model (dim) + timestamp
     let mut header_spans = vec![
         Span::styled(marker, marker_style),
         Span::styled(format!(" {}", role_label), role_style),
@@ -385,12 +361,10 @@ fn render_message(
 
     lines.push(Line::from(header_spans));
 
-    // Inline tool call summary (compact, between header and content)
     if !msg.tool_calls.is_empty() {
         render_tool_summary(&msg.tool_calls, lines, theme);
     }
 
-    // Message content — markdown parsed with syntax highlighting
     let (md_lines, md_links) = markdown::render(
         &msg.text,
         ctx.inner_width.saturating_sub(2),
@@ -398,7 +372,7 @@ fn render_message(
         &app.highlighter,
     );
     let content_prefix = if ctx.selected { "│" } else { " " };
-    let prefix_width: u16 = content_prefix.len() as u16; // always 1 byte for these strings
+    let prefix_width: u16 = content_prefix.len() as u16;
     let prefix_style = if ctx.selected {
         Style::default().fg(theme.borders.selected)
     } else {
@@ -407,8 +381,8 @@ fn render_message(
 
     let highlight_bg = Style::default().bg(theme.colors.accent_dim);
 
-    // Offset: paragraph line index of the first markdown line for this message.
-    // +1 for the header line; +1 more if tool calls were rendered.
+    // NOTE: Paragraph line index of the first markdown line; needed to convert
+    // markdown-relative link positions to paragraph-relative positions below.
     let md_para_offset = lines.len();
 
     for line in md_lines {
@@ -425,14 +399,12 @@ fn render_message(
         lines.push(Line::from(padded_spans));
     }
 
-    // Convert markdown-relative MdLink positions to paragraph-relative para_links.
     for link in md_links {
         let abs_line = md_para_offset + link.line_idx;
         let abs_col = prefix_width + link.col;
         para_links.push((abs_line, abs_col, link.text, link.url));
     }
 
-    // Breathing room between messages
     lines.push(Line::raw(""));
 }
 
@@ -454,12 +426,10 @@ fn highlight_span(
     let mut last_char_idx = 0;
 
     for (byte_start, _) in content_lower.match_indices(&pattern_lower) {
-        // Convert byte offset in the original string to char index
         let char_start = content[..byte_start].chars().count();
         let pattern_chars = pattern.chars().count();
         let char_end = char_start + pattern_chars;
 
-        // Re-slice the original content by reconstructing from char indices
         if char_start > last_char_idx {
             let before: String = content
                 .chars()
@@ -531,7 +501,6 @@ fn render_streaming(
     theme: &Theme,
     name: &str,
 ) {
-    // Thinking block (if visible)
     if app.thinking_expanded && !app.streaming_thinking.is_empty() {
         lines.push(Line::from(vec![
             Span::raw(" "),
@@ -556,7 +525,6 @@ fn render_streaming(
         ]));
     }
 
-    // Active tool calls during streaming (show completed + current)
     if !app.streaming_tool_calls.is_empty() {
         let mut tool_spans: Vec<Span> =
             vec![Span::raw("  "), Span::styled("╰─ ", theme.style_dim())];
@@ -567,7 +535,6 @@ fn render_streaming(
             }
 
             if tc.duration_ms.is_some() {
-                // Completed tool
                 let color = if tc.is_error {
                     theme.status.error
                 } else {
@@ -590,7 +557,6 @@ fn render_streaming(
                 };
                 tool_spans.push(Span::styled(label, Style::default().fg(color)));
             } else {
-                // Currently running tool — animated
                 let ch = theme::spinner_frame(app.tick_count);
                 tool_spans.push(Span::styled(
                     format!("{} {}", ch, tc.name),
@@ -602,14 +568,14 @@ fn render_streaming(
         lines.push(Line::from(tool_spans));
     }
 
-    // Streaming text with cursor
     if !app.streaming_text.is_empty() {
         lines.push(Line::from(vec![Span::styled(
             format!(" {}", name),
             theme.style_assistant(),
         )]));
 
-        // Use cached markdown if available (streaming content — links not tracked for OSC 8)
+        // NOTE: Use cached markdown lines when available; streaming links are not
+        // tracked for OSC 8 (positions change too rapidly during streaming).
         let rendered = if app.cached_markdown_text == app.streaming_text {
             app.cached_markdown_lines.clone()
         } else {
@@ -628,7 +594,6 @@ fn render_streaming(
             lines.push(Line::from(padded_spans));
         }
 
-        // Braille cursor
         let ch = theme::spinner_frame(app.tick_count);
         lines.push(Line::from(vec![
             Span::raw(" "),
@@ -640,7 +605,6 @@ fn render_streaming(
             ),
         ]));
     } else if app.active_turn_id.is_some() {
-        // No text yet — show spinner with agent name
         let ch = theme::spinner_frame(app.tick_count);
 
         lines.push(Line::from(vec![

--- a/crates/theatron/tui/src/view/command_palette.rs
+++ b/crates/theatron/tui/src/view/command_palette.rs
@@ -19,7 +19,6 @@ pub fn render(app: &App, frame: &mut Frame, area: Rect, theme: &Theme) {
     let palette = &app.command_palette;
     let mut lines: Vec<Line> = Vec::new();
 
-    // Input line: `:` prompt + typed text
     lines.push(Line::from(vec![
         Span::styled(
             ":",
@@ -30,7 +29,6 @@ pub fn render(app: &App, frame: &mut Frame, area: Rect, theme: &Theme) {
         Span::styled(&palette.input, theme.style_fg()),
     ]));
 
-    // Suggestion lines (max 8)
     for (i, suggestion) in palette.suggestions.iter().enumerate() {
         let selected = i == palette.selected;
         let marker = if selected { "▸" } else { " " };
@@ -95,8 +93,7 @@ pub fn render(app: &App, frame: &mut Frame, area: Rect, theme: &Theme) {
     let paragraph = Paragraph::new(lines).block(block);
     frame.render_widget(paragraph, area);
 
-    // Position cursor in the input area
     let cursor_x = area.x + 1 + palette.cursor as u16;
-    let cursor_y = area.y + 1; // +1 for top border
+    let cursor_y = area.y + 1;
     frame.set_cursor_position((cursor_x, cursor_y));
 }

--- a/crates/theatron/tui/src/view/input.rs
+++ b/crates/theatron/tui/src/view/input.rs
@@ -18,9 +18,10 @@ pub fn render(app: &App, frame: &mut Frame, area: Rect, theme: &Theme) {
         theme.colors.accent
     };
 
-    let prompt_width = prompt_str.len(); // ASCII-only prompt, bytes == display columns
+    // NOTE: ASCII-only prompt — bytes equal display columns
+    let prompt_width = prompt_str.len();
     let content_width = area.width.max(1) as usize;
-    let visible_rows = area.height.saturating_sub(1) as usize; // subtract top border
+    let visible_rows = area.height.saturating_sub(1) as usize;
 
     let text = app.input.text.as_str();
     let cursor_byte = app.input.cursor;
@@ -31,7 +32,6 @@ pub fn render(app: &App, frame: &mut Frame, area: Rect, theme: &Theme) {
     let (cursor_row, cursor_col) =
         cursor_visual_position(&line_ranges, text, cursor_byte, prompt_width);
 
-    // Scroll to keep cursor visible (cursor_row is 0-indexed).
     let scroll = if visible_rows > 0 {
         (cursor_row as usize).saturating_sub(visible_rows - 1)
     } else {
@@ -42,7 +42,6 @@ pub fn render(app: &App, frame: &mut Frame, area: Rect, theme: &Theme) {
     let has_above = scroll > 0;
     let has_below = scroll + visible_rows < total_rows;
 
-    // Build one ratatui Line per word-wrapped visual line.
     let mut ratatui_lines: Vec<Line<'static>> = Vec::with_capacity(total_rows);
     for (i, &(start, end)) in line_ranges.iter().enumerate() {
         let line_text = text[start..end].to_string();
@@ -56,7 +55,6 @@ pub fn render(app: &App, frame: &mut Frame, area: Rect, theme: &Theme) {
         }
     }
 
-    // Scroll indicator: annotate the last visible row when lines are hidden.
     if has_above || has_below {
         let indicator = match (has_above, has_below) {
             (true, true) => " ↕",
@@ -78,9 +76,8 @@ pub fn render(app: &App, frame: &mut Frame, area: Rect, theme: &Theme) {
         .scroll((scroll as u16, 0));
     frame.render_widget(paragraph, area);
 
-    // Position terminal cursor.
     let visible_row = (cursor_row as usize).saturating_sub(scroll);
-    let cursor_y = area.y + 1 + visible_row as u16; // +1 for top border
+    let cursor_y = area.y + 1 + visible_row as u16;
     let cursor_x = area.x + cursor_col;
     frame.set_cursor_position((cursor_x, cursor_y));
 }
@@ -120,7 +117,7 @@ pub(crate) fn word_wrap_lines(
             break;
         }
 
-        // Count display columns and find the last whitespace within `avail` columns.
+        // NOTE: count display columns and track the last whitespace within `avail` columns
         let mut last_ws_byte: Option<usize> = None; // byte offset within `remaining`
         let mut byte_at_avail: usize = remaining.len(); // byte offset of char at position `avail`
         let mut col_width = 0usize;
@@ -136,20 +133,19 @@ pub(crate) fn word_wrap_lines(
             col_width += UnicodeWidthChar::width(c).unwrap_or(1);
         }
 
-        // If remaining text fits entirely, this is the last line.
+        // NOTE: if remaining text fits entirely, this is the last line
         if col_width < avail || UnicodeWidthStr::width(remaining) <= avail {
             lines.push((pos, pos + remaining.len()));
             break;
         }
 
-        // Determine the break point.
         if let Some(ws_b) = last_ws_byte {
-            // Break at the last whitespace: exclude it from both lines.
+            // NOTE: break at the last whitespace — exclude it from both lines
             let ws_len = remaining[ws_b..].chars().next().map_or(1, |c| c.len_utf8());
             lines.push((pos, pos + ws_b));
             pos += ws_b + ws_len; // skip over the whitespace
         } else {
-            // No whitespace within `avail` — char-wrap at the boundary.
+            // NOTE: no whitespace within `avail` — char-wrap at the boundary
             lines.push((pos, pos + byte_at_avail));
             pos += byte_at_avail;
         }

--- a/crates/theatron/tui/src/view/memory.rs
+++ b/crates/theatron/tui/src/view/memory.rs
@@ -59,7 +59,6 @@ pub(crate) fn render_fact_detail(app: &App, frame: &mut Frame, area: Rect, theme
     if let Some(ref detail) = app.memory.detail {
         let f = &detail.fact;
 
-        // Header
         lines.push(Line::from(vec![
             Span::raw(" "),
             Span::styled(
@@ -69,7 +68,6 @@ pub(crate) fn render_fact_detail(app: &App, frame: &mut Frame, area: Rect, theme
         ]));
         lines.push(Line::raw(""));
 
-        // Metadata
         let tier_label = MemoryInspectorState::tier_abbrev(&f.tier);
         lines.push(meta_line(theme, "ID", &f.id));
         lines.push(meta_line(
@@ -115,7 +113,6 @@ pub(crate) fn render_fact_detail(app: &App, frame: &mut Frame, area: Rect, theme
 
         lines.push(Line::raw(""));
 
-        // Content
         lines.push(Line::from(vec![
             Span::raw("  "),
             Span::styled("Content:", theme.style_fg().add_modifier(Modifier::BOLD)),
@@ -127,7 +124,6 @@ pub(crate) fn render_fact_detail(app: &App, frame: &mut Frame, area: Rect, theme
             ]));
         }
 
-        // Relationships
         if !detail.relationships.is_empty() {
             lines.push(Line::raw(""));
             lines.push(Line::from(vec![
@@ -147,7 +143,6 @@ pub(crate) fn render_fact_detail(app: &App, frame: &mut Frame, area: Rect, theme
             }
         }
 
-        // Similar facts
         if !detail.similar.is_empty() {
             lines.push(Line::raw(""));
             lines.push(Line::from(vec![
@@ -181,7 +176,6 @@ pub(crate) fn render_fact_detail(app: &App, frame: &mut Frame, area: Rect, theme
         ]));
     }
 
-    // Confidence editing overlay
     if app.memory.editing_confidence {
         lines.push(Line::raw(""));
         lines.push(Line::from(vec![
@@ -198,7 +192,6 @@ pub(crate) fn render_fact_detail(app: &App, frame: &mut Frame, area: Rect, theme
         ]));
     }
 
-    // Help bar
     lines.push(Line::raw(""));
     let mut help = vec![
         Span::raw("  "),
@@ -244,7 +237,6 @@ fn render_tab_bar(app: &App, frame: &mut Frame, area: Rect, theme: &Theme) {
         spans.push(Span::styled(tab.label(), style));
     }
 
-    // Sort indicator
     spans.push(Span::raw("  "));
     let arrow = if app.memory.sort_asc { "↑" } else { "↓" };
     spans.push(Span::styled(
@@ -252,7 +244,6 @@ fn render_tab_bar(app: &App, frame: &mut Frame, area: Rect, theme: &Theme) {
         theme.style_dim(),
     ));
 
-    // Search indicator
     if app.memory.search_active {
         spans.push(Span::raw("  "));
         spans.push(Span::styled(
@@ -262,7 +253,6 @@ fn render_tab_bar(app: &App, frame: &mut Frame, area: Rect, theme: &Theme) {
         spans.push(Span::styled("▌", theme.style_accent()));
     }
 
-    // Filter indicator
     if app.memory.filter_editing {
         spans.push(Span::raw("  "));
         spans.push(Span::styled(
@@ -286,7 +276,6 @@ fn render_tab_bar(app: &App, frame: &mut Frame, area: Rect, theme: &Theme) {
 fn render_facts_table(app: &App, frame: &mut Frame, area: Rect, theme: &Theme) {
     let mut lines: Vec<Line> = Vec::new();
 
-    // Column header
     let header_style = theme.style_dim().add_modifier(Modifier::BOLD);
     lines.push(Line::from(vec![
         Span::styled("  ", Style::default()),
@@ -310,7 +299,7 @@ fn render_facts_table(app: &App, frame: &mut Frame, area: Rect, theme: &Theme) {
         }
     } else {
         let filter = app.memory.filter_text.to_lowercase();
-        let visible_height = area.height.saturating_sub(1) as usize; // -1 for header
+        let visible_height = area.height.saturating_sub(1) as usize;
         let content_width = area.width.saturating_sub(RESERVED_COLUMN_WIDTH) as usize;
 
         let type_filter = app.memory.type_filter.as_deref();
@@ -423,7 +412,6 @@ fn render_graph_view(app: &App, frame: &mut Frame, area: Rect, theme: &Theme) {
         ]));
         lines.push(Line::raw(""));
 
-        // Render entities as a list with relationship counts
         for (i, entity) in app.memory.entities.iter().enumerate() {
             let is_selected = i == app.memory.selected;
             let marker = if is_selected { "▸ " } else { "  " };
@@ -450,7 +438,6 @@ fn render_graph_view(app: &App, frame: &mut Frame, area: Rect, theme: &Theme) {
             ]));
         }
 
-        // Render relationships as ASCII edges
         if !app.memory.relationships.is_empty() {
             lines.push(Line::raw(""));
             lines.push(Line::from(vec![

--- a/crates/theatron/tui/src/view/mod.rs
+++ b/crates/theatron/tui/src/view/mod.rs
@@ -34,30 +34,28 @@ pub fn render(app: &App, frame: &mut Frame) -> Vec<OscLink> {
     let palette_active = app.command_palette.active;
     let show_tabs = tab_bar::should_show(app);
 
-    // When palette is active, it replaces the status bar with a variable-height area
+    // NOTE: When palette is active it replaces the status bar, expanding to fit suggestions.
     let bottom_height = if palette_active {
         let suggestion_lines = app
             .command_palette
             .suggestions
             .len()
             .min(MAX_PALETTE_SUGGESTIONS) as u16;
-        (STATUS_BAR_HEIGHT + suggestion_lines).max(3) // input + border + suggestions, min 3
+        (STATUS_BAR_HEIGHT + suggestion_lines).max(3)
     } else {
         STATUS_BAR_HEIGHT
     };
 
     let tab_height: u16 = if show_tabs { 1 } else { 0 };
 
-    let mut constraints = vec![
-        Constraint::Length(1), // title bar
-    ];
+    let mut constraints = vec![Constraint::Length(1)];
     if show_tabs {
-        constraints.push(Constraint::Length(tab_height)); // tab bar
+        constraints.push(Constraint::Length(tab_height));
     }
-    constraints.push(Constraint::Min(5)); // body
-    constraints.push(Constraint::Length(bottom_height)); // status bar or command palette
+    constraints.push(Constraint::Min(5));
+    constraints.push(Constraint::Length(bottom_height));
     if has_toast {
-        constraints.push(Constraint::Length(1)); // error or success toast
+        constraints.push(Constraint::Length(1));
     }
 
     let vertical = Layout::default()
@@ -65,7 +63,6 @@ pub fn render(app: &App, frame: &mut Frame) -> Vec<OscLink> {
         .constraints(constraints)
         .split(area);
 
-    // Index tracking based on optional tab bar
     let title_idx = 0;
     let tab_idx = if show_tabs { 1 } else { 0 };
     let body_idx = if show_tabs { 2 } else { 1 };
@@ -78,14 +75,12 @@ pub fn render(app: &App, frame: &mut Frame) -> Vec<OscLink> {
         tab_bar::render(app, frame, vertical[tab_idx], theme);
     }
 
-    // Bottom area: command palette or status bar
     if palette_active {
         command_palette::render(app, frame, vertical[bottom_idx], theme);
     } else {
         status_bar::render(app, frame, vertical[bottom_idx], theme);
     }
 
-    // Toast at bottom (error or success)
     if has_toast {
         if let Some(ref toast) = app.error_toast {
             let toast_line = ratatui::text::Line::from(vec![
@@ -106,13 +101,9 @@ pub fn render(app: &App, frame: &mut Frame) -> Vec<OscLink> {
         }
     }
 
-    // Responsive: hide sidebar on narrow terminals
     let show_sidebar = app.sidebar_visible && area.width >= MIN_SIDEBAR_TERMINAL_WIDTH;
-
-    // Responsive: show ops pane when visible and terminal wide enough
     let show_ops = app.ops.visible && area.width >= MIN_OPS_TERMINAL_WIDTH;
 
-    // Body: sidebar | main content area (dispatched by current view, with optional ops pane)
     let osc_links = if show_sidebar {
         let sidebar_and_rest = Layout::default()
             .direction(Direction::Horizontal)
@@ -162,7 +153,6 @@ pub fn render(app: &App, frame: &mut Frame) -> Vec<OscLink> {
         }
     };
 
-    // Render overlay on top if present
     if app.overlay.is_some() {
         overlay::render(app, frame, area, theme);
     }
@@ -216,13 +206,12 @@ fn render_chat_area(
     area: Rect,
     theme: &crate::theme::Theme,
 ) -> Vec<OscLink> {
-    // Dynamically size input area based on word-wrapped line count.
     let prompt_len: usize = if app.active_turn_id.is_some() { 9 } else { 2 };
     let content_width = area.width.max(1) as usize;
     let first_line_avail = content_width.saturating_sub(prompt_len).max(1);
     let wrapped_lines =
         input::word_wrap_lines(&app.input.text, first_line_avail, content_width).len() as u16;
-    let input_height = (wrapped_lines + 1).clamp(3, 8); // +1 for border, min 3, max 8
+    let input_height = (wrapped_lines + 1).clamp(3, 8);
 
     let filter_height: u16 = if app.filter.editing { 1 } else { 0 };
 

--- a/crates/theatron/tui/src/view/ops.rs
+++ b/crates/theatron/tui/src/view/ops.rs
@@ -51,7 +51,6 @@ pub fn render(app: &App, frame: &mut Frame, area: Rect, theme: &Theme) {
     let inner_width = inner.width.saturating_sub(1) as usize;
     let mut item_idx: usize = 0;
 
-    // --- Thinking block ---
     if !ops.thinking.text.is_empty() {
         let is_selected = ops.selected_item == Some(item_idx);
         render_thinking_block(
@@ -65,7 +64,6 @@ pub fn render(app: &App, frame: &mut Frame, area: Rect, theme: &Theme) {
         item_idx += 1;
     }
 
-    // --- Tool calls ---
     for tc in &ops.tool_calls {
         let is_selected = ops.selected_item == Some(item_idx);
         render_tool_call(
@@ -79,7 +77,6 @@ pub fn render(app: &App, frame: &mut Frame, area: Rect, theme: &Theme) {
         item_idx += 1;
     }
 
-    // --- File diffs ---
     if !ops.diffs.is_empty() {
         lines.push(Line::raw(""));
         lines.push(Line::from(vec![
@@ -91,7 +88,6 @@ pub fn render(app: &App, frame: &mut Frame, area: Rect, theme: &Theme) {
         }
     }
 
-    // --- Empty state ---
     if lines.is_empty() {
         lines.push(Line::raw(""));
         lines.push(Line::from(vec![
@@ -103,7 +99,6 @@ pub fn render(app: &App, frame: &mut Frame, area: Rect, theme: &Theme) {
         }
     }
 
-    // Calculate scroll
     let visible_height = inner.height as usize;
     let total_lines = lines.len();
     let scroll = if total_lines > visible_height {
@@ -138,7 +133,6 @@ fn render_thinking_block(
 
     let collapse_icon = if thinking.collapsed { "▶" } else { "▼" };
 
-    // Header
     lines.push(Line::from(vec![
         Span::styled(marker, marker_style),
         Span::styled(
@@ -204,7 +198,6 @@ fn render_thinking_block(
             ]));
         }
 
-        // Show streaming indicator if thinking text is still growing
         let ch = theme::spinner_frame(tick_count);
         lines.push(Line::from(vec![
             Span::raw("   "),
@@ -235,7 +228,6 @@ fn render_tool_call(
         Style::default()
     };
 
-    // Status indicator
     let (status_icon, status_style) = match tc.status {
         OpsToolStatus::Running => {
             let ch = theme::spinner_frame(tick_count);
@@ -256,7 +248,6 @@ fn render_tool_call(
         ),
     };
 
-    // Duration
     let duration_str = tc.duration_ms.map(|ms| {
         if ms >= MS_PER_SECOND {
             format!(" ({:.1}s)", ms as f64 / MS_PER_SECOND as f64)
@@ -265,7 +256,6 @@ fn render_tool_call(
         }
     });
 
-    // Header: marker + status + tool name (bold) + duration
     let mut header = vec![
         Span::styled(marker, marker_style),
         Span::styled(format!(" {status_icon}"), status_style),
@@ -283,7 +273,6 @@ fn render_tool_call(
 
     lines.push(Line::from(header));
 
-    // Input parameters (collapsed by default, shown when expanded)
     if tc.expanded {
         if let Some(ref input) = tc.input_json {
             lines.push(Line::from(vec![
@@ -308,7 +297,6 @@ fn render_tool_call(
             }
         }
 
-        // Output (truncated)
         if let Some(ref output) = tc.output {
             lines.push(Line::from(vec![
                 Span::raw("   "),
@@ -355,7 +343,6 @@ fn render_diff(
     lines: &mut Vec<Line<'static>>,
     theme: &Theme,
 ) {
-    // File path header
     lines.push(Line::from(vec![
         Span::raw("  "),
         Span::styled(
@@ -364,7 +351,6 @@ fn render_diff(
         ),
     ]));
 
-    // Deletions (red)
     for del in &diff.deletions {
         lines.push(Line::from(vec![
             Span::raw("  "),
@@ -372,7 +358,6 @@ fn render_diff(
         ]));
     }
 
-    // Additions (green)
     for add in &diff.additions {
         lines.push(Line::from(vec![
             Span::raw("  "),

--- a/crates/theatron/tui/src/view/overlay.rs
+++ b/crates/theatron/tui/src/view/overlay.rs
@@ -35,7 +35,6 @@ pub fn render(app: &App, frame: &mut Frame, area: Rect, theme: &Theme) {
 
     let popup_area = centered_rect(POPUP_WIDTH_PCT, POPUP_HEIGHT_PCT, area);
 
-    // Clear the area under the overlay
     frame.render_widget(Clear, popup_area);
 
     match overlay {
@@ -324,7 +323,6 @@ fn render_tool_approval(
         )),
     ];
 
-    // Truncated input display
     let input_str = serde_json::to_string_pretty(&approval.input).unwrap_or_default();
     for line in input_str.lines().take(TOOL_APPROVAL_INPUT_LINES) {
         lines.push(Line::from(Span::styled(
@@ -425,7 +423,6 @@ fn render_system_status(app: &App, frame: &mut Frame, area: Rect, theme: &Theme)
         .fg(theme.text.fg)
         .add_modifier(Modifier::BOLD);
 
-    // Connection status
     lines.push(Line::from(Span::styled("  Connection", section_style)));
     lines.push(Line::raw(""));
     let sse_status = if app.sse_connected {
@@ -450,7 +447,6 @@ fn render_system_status(app: &App, frame: &mut Frame, area: Rect, theme: &Theme)
     )));
     lines.push(Line::raw(""));
 
-    // Agents
     lines.push(Line::from(Span::styled("  Agents", section_style)));
     lines.push(Line::raw(""));
 
@@ -491,7 +487,6 @@ fn render_system_status(app: &App, frame: &mut Frame, area: Rect, theme: &Theme)
 
     lines.push(Line::raw(""));
 
-    // Cost
     let cost = app.daily_cost_cents as f64 / 100.0;
     lines.push(Line::from(Span::styled("  Today", section_style)));
     lines.push(Line::raw(""));
@@ -575,7 +570,7 @@ fn render_diff_view(
     area: Rect,
     theme: &Theme,
 ) {
-    // Render diff lines (without mutation — we compute total_lines here for scroll clamping)
+    // NOTE: render immutably first to get total_lines for scroll clamping before display
     let inner_area = Rect::new(
         area.x + 1,
         area.y + 1,
@@ -587,7 +582,6 @@ fn render_diff_view(
     let total = all_lines.len();
     let visible_height = inner_area.height as usize;
 
-    // Clamp scroll
     let scroll = diff_state
         .scroll_offset
         .min(total.saturating_sub(visible_height));

--- a/crates/theatron/tui/src/view/settings.rs
+++ b/crates/theatron/tui/src/view/settings.rs
@@ -73,7 +73,6 @@ pub fn render(overlay: &SettingsOverlay, frame: &mut Frame, area: Rect, theme: &
 
             let restart = if field.requires_restart { " *" } else { "" };
 
-            // Show inline edit buffer when editing this field
             if selected && let Some(ref edit) = overlay.editing {
                 lines.push(Line::from(vec![
                     Span::raw(format!("  {} ", marker)),
@@ -100,7 +99,6 @@ pub fn render(overlay: &SettingsOverlay, frame: &mut Frame, area: Rect, theme: &
         }
     }
 
-    // Status line
     lines.push(Line::raw(""));
     match &overlay.save_status {
         SaveStatus::Saving => {
@@ -124,7 +122,6 @@ pub fn render(overlay: &SettingsOverlay, frame: &mut Frame, area: Rect, theme: &
         SaveStatus::Idle => {}
     }
 
-    // Footer
     lines.push(Line::raw(""));
     lines.push(Line::from(vec![
         Span::raw("  "),
@@ -165,7 +162,6 @@ pub fn render(overlay: &SettingsOverlay, frame: &mut Frame, area: Rect, theme: &
     let visible_height = inner.height as usize;
     let total_lines = lines.len();
 
-    // Auto-scroll to keep cursor visible
     let cursor_line = estimate_cursor_line(overlay);
     let scroll = if cursor_line >= overlay.scroll_offset + visible_height {
         cursor_line.saturating_sub(visible_height - 1)
@@ -181,7 +177,6 @@ pub fn render(overlay: &SettingsOverlay, frame: &mut Frame, area: Rect, theme: &
         .wrap(Wrap { trim: false });
     frame.render_widget(paragraph, popup);
 
-    // Scrollbar
     if total_lines > visible_height {
         let mut scrollbar_state =
             ScrollbarState::new(total_lines.saturating_sub(visible_height)).position(scroll);

--- a/crates/theatron/tui/src/view/sidebar.rs
+++ b/crates/theatron/tui/src/view/sidebar.rs
@@ -11,7 +11,6 @@ use crate::theme::{self, Theme};
 pub fn render(app: &App, frame: &mut Frame, area: Rect, theme: &Theme) {
     let mut lines: Vec<Line> = Vec::new();
 
-    // Small top padding
     lines.push(Line::raw(""));
 
     if app.agents.is_empty() {
@@ -57,7 +56,6 @@ pub fn render(app: &App, frame: &mut Frame, area: Rect, theme: &Theme) {
             format!("{} {}", emoji, agent.name)
         };
 
-        // Build the line: indicator + name + notification dot
         let mut spans = vec![
             Span::raw("  "),
             status_icon,
@@ -65,14 +63,13 @@ pub fn render(app: &App, frame: &mut Frame, area: Rect, theme: &Theme) {
             Span::styled(name, name_style),
         ];
 
-        // Notification dot — shows when an unfocused agent completed a turn
+        // NOTE: shown only for unfocused agents — clears when the user switches focus
         if !is_focused && agent.has_notification {
             spans.push(Span::styled(" ●", Style::default().fg(theme.colors.accent)));
         }
 
         lines.push(Line::from(spans));
 
-        // Show active tool under working agents
         if let Some(ref tool) = agent.active_tool {
             let elapsed = tool.started_at.elapsed().as_secs_f32();
             let ch = theme::spinner_frame(app.tick_count);
@@ -85,7 +82,6 @@ pub fn render(app: &App, frame: &mut Frame, area: Rect, theme: &Theme) {
             ]));
         }
 
-        // Show compaction stage
         if let Some(ref stage) = agent.compaction_stage {
             lines.push(Line::from(vec![
                 Span::raw("     "),

--- a/crates/theatron/tui/src/view/tab_bar.rs
+++ b/crates/theatron/tui/src/view/tab_bar.rs
@@ -18,8 +18,6 @@ pub(crate) fn render(app: &App, frame: &mut Frame, area: Rect, theme: &Theme) {
     let active = app.tab_bar.active;
     let width = area.width as usize;
 
-    // Calculate how much space we have for tab titles
-    // Each tab: " [title] |" or " [title] " for last
     let separator = " | ";
     let plus_label = " + ";
 
@@ -32,7 +30,6 @@ pub(crate) fn render(app: &App, frame: &mut Frame, area: Rect, theme: &Theme) {
     let plus_width = plus_label.len();
     let available = width.saturating_sub(separators_width + plus_width + 1); // +1 for leading space
 
-    // Calculate max title length per tab
     let max_per_tab = if total_tabs > 0 {
         (available / total_tabs).max(3)
     } else {
@@ -44,10 +41,8 @@ pub(crate) fn render(app: &App, frame: &mut Frame, area: Rect, theme: &Theme) {
     for (idx, tab) in tabs.iter().enumerate() {
         let is_active = idx == active;
 
-        // Build title with truncation
         let title = truncate_title(&tab.title, max_per_tab);
 
-        // Unread indicator
         let prefix = if tab.unread && !is_active { "* " } else { " " };
 
         let style = if is_active {
@@ -77,13 +72,11 @@ pub(crate) fn render(app: &App, frame: &mut Frame, area: Rect, theme: &Theme) {
         }
     }
 
-    // "+" button
     spans.push(Span::styled(
         plus_label,
         Style::default().fg(theme.text.fg_dim),
     ));
 
-    // Pad remaining width
     let rendered_width: usize = spans.iter().map(|s| s.width()).sum();
     if rendered_width < width {
         spans.push(Span::styled(
@@ -105,7 +98,7 @@ fn truncate_title(title: &str, max_width: usize) -> String {
     if max_width <= 3 {
         return title.chars().take(max_width).collect();
     }
-    let mut end = max_width - 1; // leave room for ellipsis char
+    let mut end = max_width - 1;
     while end > 0 && !title.is_char_boundary(end) {
         end -= 1;
     }

--- a/crates/theatron/tui/src/view/title_bar.rs
+++ b/crates/theatron/tui/src/view/title_bar.rs
@@ -33,7 +33,6 @@ pub fn render(app: &App, frame: &mut Frame, area: Rect, theme: &Theme) {
         Span::styled("aletheia", theme.style_accent()),
     ];
 
-    // Breadcrumbs — show navigation path when not at Home
     if !app.view_stack.is_home() {
         let breadcrumbs = app.view_stack.breadcrumbs();
         let last_idx = breadcrumbs.len() - 1;
@@ -42,13 +41,11 @@ pub fn render(app: &App, frame: &mut Frame, area: Rect, theme: &Theme) {
 
         for (i, crumb) in breadcrumbs.iter().enumerate() {
             if i == last_idx {
-                // Current view — bold
                 spans.push(Span::styled(
                     crumb.to_string(),
                     theme.style_fg().add_modifier(Modifier::BOLD),
                 ));
             } else {
-                // Parent views — dim
                 spans.push(Span::styled(crumb.to_string(), theme.style_dim()));
                 spans.push(Span::styled(" > ", theme.style_dim()));
             }

--- a/crates/theatron/tui/src/view/views.rs
+++ b/crates/theatron/tui/src/view/views.rs
@@ -145,7 +145,6 @@ pub(crate) fn render_message_detail(
     lines.push(Line::raw(""));
 
     if let Some(msg) = app.messages.get(message_index) {
-        // Header
         let role_label = match msg.role.as_str() {
             "user" => "You",
             "assistant" => "Assistant",
@@ -159,7 +158,6 @@ pub(crate) fn render_message_detail(
             ),
         ]));
 
-        // Metadata
         if let Some(ref model) = msg.model {
             lines.push(Line::from(vec![
                 Span::raw("  "),
@@ -178,7 +176,6 @@ pub(crate) fn render_message_detail(
 
         lines.push(Line::raw(""));
 
-        // Tool calls
         if !msg.tool_calls.is_empty() {
             lines.push(Line::from(vec![
                 Span::raw("  "),
@@ -206,7 +203,6 @@ pub(crate) fn render_message_detail(
             lines.push(Line::raw(""));
         }
 
-        // Full content
         lines.push(Line::from(vec![
             Span::raw("  "),
             Span::styled("Content:", theme.style_fg().add_modifier(Modifier::BOLD)),
@@ -265,18 +261,12 @@ pub(crate) fn render_for_view(
     theme: &Theme,
 ) -> Vec<OscLink> {
     match app.view_stack.current() {
-        View::Home => {
-            // Home view uses the existing chat area rendering
-            super::render_chat_area(app, frame, area, theme)
-        }
+        View::Home => super::render_chat_area(app, frame, area, theme),
         View::Sessions { .. } => {
             render_sessions(app, frame, area, theme);
             Vec::new()
         }
-        View::Conversation { .. } => {
-            // Conversation view reuses the chat area rendering
-            super::render_chat_area(app, frame, area, theme)
-        }
+        View::Conversation { .. } => super::render_chat_area(app, frame, area, theme),
         View::MessageDetail { message_index } => {
             render_message_detail(app, frame, area, theme, *message_index);
             Vec::new()


### PR DESCRIPTION
## Summary

Standards compliance sweep across `theatron-tui` and `aletheia-nous` (67 files, −477 net lines).

### 1. Comment standardization
- Deleted step-label comments that restate code (`// Stage 1:`, `// Iterate from newest…`, `// Find first sentence boundary`, etc.)
- Deleted section-separator banners (`// ── Public types ──`, `// ---`, etc.)
- Deleted inline author/AI-indicator annotations
- Removed misused `// SAFETY:` tags on non-`unsafe` functions (`update/api.rs`, `update/settings.rs`)
- Tagged non-obvious comments with structured prefixes per STANDARDS.md: `WHY:`, `NOTE:`, `INVARIANT:`, `WARNING:`

### 2. `#[non_exhaustive]` on public enums
Added to enums that can grow new variants without a breaking change:
`Error`, `ApiError` (theatron); `FocusedPane`, `OpsToolStatus`, `FactSort`, `MemoryTab` (theatron state); `NousMessage`, `NousLifecycle`, `StageTimingStatus`, `GuardResult`, `SectionPriority` (nous).
Skipped: clap command enums (exhaustive by design), internal-only private types.

### 3. Unwrap audit
All `.unwrap()` calls in both crates are inside `#[cfg(test)]` blocks, already guarded by `#[expect(clippy::unwrap_used, reason = "…")]`. No library-code changes required.

### 4. Visibility audit
`-W unreachable_pub` returns zero warnings. `theatron-tui` exports only `pub mod error` and `pub fn run_tui`; all other modules are `pub(crate)` or private. `aletheia-nous` public API surface is already minimal. No changes required.

### 5. Test name quality
Renamed 56 test functions in `markdown.rs` and `app.rs` to describe behaviour: e.g. `test_render_bold` → `bold_text_renders_with_bold_style`, `test_app_constructs_with_defaults` → `app_constructs_with_default_state`.

## Validation gate

```
cargo fmt --all -- --check      ✓ clean
cargo clippy --workspace --all-targets -- -D warnings   ✓ 0 warnings
cargo test -p theatron-tui      ✓ 779 passed
cargo test -p aletheia-nous     ✓ 333 passed
```

## Observations (out of scope)

- `sanitize.rs` contains ~20 test functions with intentional raw ANSI sequences in string literals — these are correctly inside `#[cfg(test)]` and were left untouched.
- `bootstrap/mod.rs` `SectionPriority` uses explicit integer discriminants (0–3) for `Ord` correctness; `#[non_exhaustive]` was added safely because the discriminants are stable and the `Ord` impl is derived (not manual).
- No `pub` → `pub(crate)` changes were needed; the existing visibility boundaries are already correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)