### PR TITLE
fix(organon): sandbox exec paths, tilde expansion, permissive init defaults

### DIFF
--- a/crates/aletheia/src/commands/server.rs
+++ b/crates/aletheia/src/commands/server.rs
@@ -669,6 +669,7 @@ fn build_tool_registry(
         },
         extra_read_paths: sandbox_settings.extra_read_paths.clone(),
         extra_write_paths: sandbox_settings.extra_write_paths.clone(),
+        extra_exec_paths: sandbox_settings.extra_exec_paths.clone(),
     };
     builtins::register_all_with_sandbox(&mut registry, sandbox)
         .context("failed to register builtin tools")?;

--- a/crates/aletheia/src/init.rs
+++ b/crates/aletheia/src/init.rs
@@ -351,7 +351,7 @@ fn scaffold(answers: &Answers) -> Result<(), InitError> {
 
 fn render_config(a: &Answers) -> String {
     let workspace = format!("{}/nous/{}", a.root.display(), a.agent_id);
-    format!(
+    let mut config = format!(
         r#"# Aletheia Instance Configuration
 # Config cascade: compiled defaults -> this file -> ALETHEIA_* env vars
 # Full reference: docs/CONFIGURATION.md
@@ -438,8 +438,29 @@ outputCostPerMtok = 15.0
         agent_id = a.agent_id,
         agent_name = a.agent_name,
         workspace = workspace,
-    )
+    );
+    // WHY: single-agent init always produces a single-agent config.
+    // Append permissive sandbox defaults so the agent is functional on kernels
+    // without Landlock and can execute scripts from HOME — closes #1247.
+    config.push_str(SINGLE_AGENT_SANDBOX_TOML);
+    config
 }
+
+/// Sandbox section appended to single-agent init configs.
+///
+/// WHY: Single-agent local deployments need to run scripts from the operator's
+/// home directory and should not be blocked by strict Landlock enforcement
+/// when kernels do not support it. `enforcement=permissive` keeps the agent
+/// functional on older kernels; `extraExecPaths = ["~"]` grants exec access
+/// to HOME so scripts installed there are reachable — closes #1247.
+const SINGLE_AGENT_SANDBOX_TOML: &str = r#"
+# --- Sandbox ---
+# Single-agent permissive defaults: enforcement falls back gracefully on
+# kernels without Landlock and HOME is added to exec paths for local scripts.
+[sandbox]
+enforcement = "permissive"
+extraExecPaths = ["~"]
+"#;
 
 fn detect_timezone() -> String {
     jiff::tz::TimeZone::system()
@@ -697,6 +718,31 @@ mod tests {
         assert!(
             msg.contains("--instance-path") || msg.contains("ALETHEIA_INSTANCE_PATH"),
             "error should name the missing flag: {msg}"
+        );
+    }
+
+    #[test]
+    fn render_config_includes_permissive_sandbox_defaults() {
+        let answers = Answers::default();
+        let toml_str = render_config(&answers);
+        let value: toml::Value =
+            toml::from_str(&toml_str).expect("rendered config should be valid TOML");
+
+        let sandbox = value
+            .get("sandbox")
+            .expect("sandbox section must be present");
+        assert_eq!(
+            sandbox.get("enforcement").and_then(toml::Value::as_str),
+            Some("permissive"),
+            "single-agent init must use permissive enforcement"
+        );
+        let exec_paths = sandbox
+            .get("extraExecPaths")
+            .and_then(toml::Value::as_array)
+            .expect("extraExecPaths must be an array");
+        assert!(
+            exec_paths.iter().any(|v| v.as_str() == Some("~")),
+            "extraExecPaths must include ~ for home directory exec access"
         );
     }
 

--- a/crates/organon/src/builtins/workspace.rs
+++ b/crates/organon/src/builtins/workspace.rs
@@ -25,6 +25,20 @@ use crate::types::{
 
 const MAX_OUTPUT_BYTES: usize = 50 * 1024;
 
+/// Expand a leading `~` in a path string to the HOME environment variable.
+///
+/// If `HOME` is not set, returns the input unchanged so the subsequent
+/// path-validation step surfaces a clear "outside allowed roots" error rather
+/// than a confusing "no such file" error.
+fn expand_tilde_str(raw: &str) -> std::borrow::Cow<'_, str> {
+    if let Some(rest) = raw.strip_prefix('~')
+        && let Ok(home) = std::env::var("HOME")
+    {
+        return std::borrow::Cow::Owned(format!("{home}{rest}"));
+    }
+    std::borrow::Cow::Borrowed(raw)
+}
+
 pub(crate) fn validate_path(raw: &str, ctx: &ToolContext, tool_name: &ToolName) -> Result<PathBuf> {
     if raw.is_empty() {
         return Err(error::InvalidInputSnafu {
@@ -34,10 +48,17 @@ pub(crate) fn validate_path(raw: &str, ctx: &ToolContext, tool_name: &ToolName) 
         .build());
     }
 
-    let resolved = if Path::new(raw).is_absolute() {
-        PathBuf::from(raw)
+    // WHY: LLMs commonly emit `~/file` or `~` to refer to HOME. Without
+    // expansion the path resolves relative to workspace, producing a confusing
+    // "outside allowed roots" error. Expand before any other resolution so the
+    // absolute path check below works correctly — closes #1244.
+    let expanded = expand_tilde_str(raw);
+    let raw_expanded = expanded.as_ref();
+
+    let resolved = if Path::new(raw_expanded).is_absolute() {
+        PathBuf::from(raw_expanded)
     } else {
-        ctx.workspace.join(raw)
+        ctx.workspace.join(raw_expanded)
     };
 
     let normalized = normalize(&resolved);

--- a/crates/organon/src/builtins/workspace_tests.rs
+++ b/crates/organon/src/builtins/workspace_tests.rs
@@ -484,6 +484,55 @@ fn test_validate_path_empty_string_returns_error() {
 }
 
 #[test]
+fn test_expand_tilde_str_expands_home() {
+    if let Ok(home) = std::env::var("HOME") {
+        let expanded = expand_tilde_str("~/notes.txt");
+        assert_eq!(expanded, format!("{home}/notes.txt"));
+
+        let expanded_bare = expand_tilde_str("~");
+        assert_eq!(expanded_bare, home);
+    }
+}
+
+#[test]
+fn test_expand_tilde_str_leaves_non_tilde_unchanged() {
+    let result = expand_tilde_str("/absolute/path");
+    assert_eq!(result, "/absolute/path");
+
+    let result2 = expand_tilde_str("relative/path");
+    assert_eq!(result2, "relative/path");
+}
+
+#[test]
+fn test_validate_path_tilde_expands_to_home_before_resolution() {
+    // Build a ctx whose workspace is the HOME directory so the tilde-expanded
+    // path is inside allowed_roots.
+    if let Ok(home) = std::env::var("HOME") {
+        let home_path = std::path::PathBuf::from(&home);
+        // workspace = HOME, allowed_roots = [HOME]
+        let ctx = ToolContext {
+            nous_id: aletheia_koina::id::NousId::new("test-agent").expect("valid"),
+            session_id: aletheia_koina::id::SessionId::new(),
+            workspace: home_path.clone(),
+            allowed_roots: vec![home_path.clone()],
+            services: None,
+            active_tools: std::sync::Arc::new(std::sync::RwLock::new(
+                std::collections::HashSet::new(),
+            )),
+        };
+        let name = aletheia_koina::id::ToolName::new("read").expect("valid");
+
+        // "~/file.txt" must resolve to HOME/file.txt, which is inside HOME.
+        let resolved = validate_path("~/file.txt", &ctx, &name).expect("tilde path should resolve");
+        assert!(
+            resolved.starts_with(&home_path),
+            "resolved path should be under HOME: {}",
+            resolved.display()
+        );
+    }
+}
+
+#[test]
 fn test_validate_path_relative_resolves_inside_workspace() {
     let dir = tempfile::tempdir().expect("create temp dir");
     let name = aletheia_koina::id::ToolName::new("read").expect("valid");

--- a/crates/organon/src/sandbox.rs
+++ b/crates/organon/src/sandbox.rs
@@ -17,6 +17,22 @@ pub enum SandboxEnforcement {
     Permissive,
 }
 
+/// Expand a leading `~` to the HOME environment variable.
+///
+/// If the path does not start with `~`, or if `HOME` is not set, returns the
+/// path unchanged. This allows config files to use `~` as a portable reference
+/// to the operator's home directory.
+fn expand_tilde(path: &Path) -> PathBuf {
+    let s = path.to_string_lossy();
+    if s.starts_with('~')
+        && let Ok(home) = std::env::var("HOME")
+    {
+        let without_tilde = s.strip_prefix('~').unwrap_or(&s);
+        return PathBuf::from(format!("{home}{without_tilde}"));
+    }
+    path.to_path_buf()
+}
+
 /// Configuration for the execution sandbox.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -26,6 +42,11 @@ pub struct SandboxConfig {
     pub enforcement: SandboxEnforcement,
     pub extra_read_paths: Vec<PathBuf>,
     pub extra_write_paths: Vec<PathBuf>,
+    /// Additional filesystem paths granted execute access.
+    ///
+    /// Values may begin with `~` which is expanded to the HOME environment
+    /// variable at policy-build time.
+    pub extra_exec_paths: Vec<PathBuf>,
 }
 
 impl Default for SandboxConfig {
@@ -35,6 +56,7 @@ impl Default for SandboxConfig {
             enforcement: SandboxEnforcement::Enforcing,
             extra_read_paths: Vec::new(),
             extra_write_paths: Vec::new(),
+            extra_exec_paths: Vec::new(),
         }
     }
 }
@@ -71,7 +93,10 @@ impl SandboxConfig {
 
         let mut write_paths = vec![PathBuf::from("/tmp")];
 
-        let exec_paths = vec![
+        // WHY: System binary dirs are always executable. workspace and
+        // allowed_roots are also added so agents can execute scripts they own
+        // or that live in shared data directories — closes #1246.
+        let mut exec_paths = vec![
             PathBuf::from("/usr/bin"),
             PathBuf::from("/usr/local/bin"),
             PathBuf::from("/bin"),
@@ -80,17 +105,31 @@ impl SandboxConfig {
 
         write_paths.push(workspace.to_path_buf());
 
+        // WHY: workspace must be executable so agents can run scripts they
+        // create inside their own working directory.
+        if !exec_paths.contains(&workspace.to_path_buf()) {
+            exec_paths.push(workspace.to_path_buf());
+        }
+
         // WHY: allowed_roots grant read-only access to shared data that agents
         // may inspect but must not modify. Write access is limited to the
         // workspace and extra_write_paths, which are operator-controlled.
+        // Exec access is also granted so agents can run scripts in shared dirs.
         for root in allowed_roots {
             if !read_paths.contains(root) {
                 read_paths.push(root.clone());
+            }
+            if !exec_paths.contains(root) {
+                exec_paths.push(root.clone());
             }
         }
 
         read_paths.extend(self.extra_read_paths.iter().cloned());
         write_paths.extend(self.extra_write_paths.iter().cloned());
+
+        // WHY: extra_exec_paths support `~` prefix so operators can grant home
+        // directory exec access in the config without hard-coding the path.
+        exec_paths.extend(self.extra_exec_paths.iter().map(|p| expand_tilde(p)));
 
         for wp in &write_paths {
             if !read_paths.contains(wp) {
@@ -439,6 +478,7 @@ mod tests {
         assert_eq!(config.enforcement, SandboxEnforcement::Enforcing);
         assert!(config.extra_read_paths.is_empty());
         assert!(config.extra_write_paths.is_empty());
+        assert!(config.extra_exec_paths.is_empty());
     }
 
     #[test]
@@ -476,6 +516,7 @@ mod tests {
             enforcement: SandboxEnforcement::Permissive,
             extra_read_paths: vec![PathBuf::from("/opt/data")],
             extra_write_paths: vec![PathBuf::from("/var/cache")],
+            extra_exec_paths: vec![PathBuf::from("/opt/scripts")],
         };
         let json = serde_json::to_string(&config).expect("serialize");
         let back: SandboxConfig = serde_json::from_str(&json).expect("deserialize");
@@ -483,6 +524,7 @@ mod tests {
         assert_eq!(back.enforcement, SandboxEnforcement::Permissive);
         assert_eq!(back.extra_read_paths, vec![PathBuf::from("/opt/data")]);
         assert_eq!(back.extra_write_paths, vec![PathBuf::from("/var/cache")]);
+        assert_eq!(back.extra_exec_paths, vec![PathBuf::from("/opt/scripts")]);
     }
 
     #[test]
@@ -539,6 +581,75 @@ mod tests {
         assert!(policy.exec_paths.contains(&PathBuf::from("/usr/bin")));
         assert!(policy.exec_paths.contains(&PathBuf::from("/bin")));
         assert!(policy.write_paths.contains(&PathBuf::from("/tmp")));
+    }
+
+    #[test]
+    fn policy_includes_workspace_in_exec_paths() {
+        let config = SandboxConfig::default();
+        let workspace = PathBuf::from("/home/agent/workspace");
+        let policy = config.build_policy(&workspace, &[]);
+        assert!(
+            policy.exec_paths.contains(&workspace),
+            "workspace must be in exec_paths so agents can run scripts in their workspace"
+        );
+    }
+
+    #[test]
+    fn policy_includes_allowed_roots_in_exec_paths() {
+        let config = SandboxConfig::default();
+        let workspace = PathBuf::from("/home/agent/workspace");
+        let shared = PathBuf::from("/shared/scripts");
+        let policy = config.build_policy(&workspace, std::slice::from_ref(&shared));
+        assert!(
+            policy.exec_paths.contains(&shared),
+            "allowed_roots must be in exec_paths so agents can run scripts in shared dirs"
+        );
+    }
+
+    #[test]
+    fn policy_includes_extra_exec_paths() {
+        let config = SandboxConfig {
+            extra_exec_paths: vec![PathBuf::from("/opt/scripts")],
+            ..SandboxConfig::default()
+        };
+        let policy = config.build_policy(Path::new("/tmp/ws"), &[]);
+        assert!(
+            policy.exec_paths.contains(&PathBuf::from("/opt/scripts")),
+            "extra_exec_paths must appear in exec_paths"
+        );
+    }
+
+    #[test]
+    fn expand_tilde_replaces_home() {
+        // Only meaningful when HOME is set — guard with an env check.
+        if let Ok(home) = std::env::var("HOME") {
+            let p = expand_tilde(Path::new("~/scripts"));
+            assert_eq!(p, PathBuf::from(format!("{home}/scripts")));
+
+            let p2 = expand_tilde(Path::new("~"));
+            assert_eq!(p2, PathBuf::from(&home));
+        }
+    }
+
+    #[test]
+    fn expand_tilde_leaves_absolute_path_unchanged() {
+        let p = expand_tilde(Path::new("/usr/local/bin"));
+        assert_eq!(p, PathBuf::from("/usr/local/bin"));
+    }
+
+    #[test]
+    fn policy_expands_tilde_in_extra_exec_paths() {
+        if let Ok(home) = std::env::var("HOME") {
+            let config = SandboxConfig {
+                extra_exec_paths: vec![PathBuf::from("~")],
+                ..SandboxConfig::default()
+            };
+            let policy = config.build_policy(Path::new("/tmp/ws"), &[]);
+            assert!(
+                policy.exec_paths.contains(&PathBuf::from(&home)),
+                "~ in extra_exec_paths must be expanded to HOME"
+            );
+        }
     }
 
     #[test]

--- a/crates/taxis/src/config.rs
+++ b/crates/taxis/src/config.rs
@@ -633,6 +633,11 @@ pub struct SandboxSettings {
     pub extra_read_paths: Vec<PathBuf>,
     /// Additional filesystem paths granted read+write access.
     pub extra_write_paths: Vec<PathBuf>,
+    /// Additional filesystem paths granted execute access.
+    ///
+    /// Values may begin with `~` which is expanded to the HOME environment
+    /// variable at policy-build time.
+    pub extra_exec_paths: Vec<PathBuf>,
 }
 
 impl Default for SandboxSettings {
@@ -642,6 +647,7 @@ impl Default for SandboxSettings {
             enforcement: SandboxEnforcementMode::Enforcing,
             extra_read_paths: Vec::new(),
             extra_write_paths: Vec::new(),
+            extra_exec_paths: Vec::new(),
         }
     }
 }


### PR DESCRIPTION
## Summary

- **`build_policy()` adds `allowed_roots` and `workspace` to `exec_paths`** so agents can execute scripts in shared directories and their own workspace (closes #1246)
- **`SandboxConfig` / `SandboxSettings` gain `extra_exec_paths` field** for fine-grained operator control over executable paths; wired through `taxis` config cascade → `server.rs` → `organon`
- **Tilde expansion in tool path arguments** — `expand_tilde_str()` is called in `validate_path()` before resolution so `ls`, `read`, `write`, `find`, `grep` all accept `~`-prefixed paths (closes #1244)
- **`aletheia init` generates permissive sandbox defaults** — appends `[sandbox] enforcement = "permissive"` and `extraExecPaths = ["~"]` to single-agent configs so HOME scripts are reachable and the agent stays functional on kernels without Landlock (closes #1247)
- Two `collapsible_if` clippy lints fixed in the `expand_tilde` helpers

## Acceptance Criteria

- [x] `build_policy()` adds `allowed_roots` and `workspace` to `exec_paths` alongside `read_paths` and `write_paths`
- [x] `SandboxConfig` gains `extra_exec_paths` field for fine-grained exec control
- [x] Tool path arguments containing `~` are expanded to `HOME` before resolution
- [x] `aletheia init` generates permissive sandbox defaults for single-agent config (`enforcement=permissive`, `~` in exec paths)

## Test plan

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean (0 warnings)
- [x] `cargo test --workspace` — all pass (2300+ tests)
- [x] New unit tests: `policy_includes_workspace_in_exec_paths`, `policy_includes_allowed_roots_in_exec_paths`, `policy_includes_extra_exec_paths`, `expand_tilde_replaces_home`, `policy_expands_tilde_in_extra_exec_paths`, `render_config_includes_permissive_sandbox_defaults`, tilde expansion in `validate_path` tests
- [x] Self-review: diff touches only files within blast radius (`crates/organon/src/`, `crates/aletheia/src/commands/`, `crates/aletheia/src/init.rs`, `crates/taxis/src/config.rs`)

## Observations

- `crates/organon/src/builtins/workspace_tests.rs` — the `validate_path` tilde test relies on `HOME` being set; it guards with `if let Ok(home) = std::env::var("HOME")` so it is a no-op in environments without `HOME` rather than a false-negative failure (acceptable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)