### PR TITLE
feat(taxis): reverse phantom config — promote hardcoded values to operator config

### DIFF
--- a/crates/aletheia/src/commands/server.rs
+++ b/crates/aletheia/src/commands/server.rs
@@ -295,6 +295,11 @@ pub async fn run(args: Args) -> Result<()> {
                 }
             }
 
+            let mut recall: aletheia_nous::recall::RecallConfig = resolved.recall.into();
+            // WHY: chars_per_token lives on AgentDefaults (LLM-level setting),
+            //      not on RecallSettings, so it must be forwarded explicitly.
+            recall.chars_per_token = u64::from(resolved.chars_per_token);
+
             let nous_config = NousConfig {
                 id: resolved.id,
                 name: resolved.name,
@@ -310,12 +315,14 @@ pub async fn run(args: Args) -> Result<()> {
                 server_tools: Vec::new(),
                 cache_enabled: resolved.cache_enabled,
                 session_token_cap: 500_000,
-                recall: resolved.recall.into(),
+                recall,
+                chars_per_token: resolved.chars_per_token,
             };
             nous_manager
                 .spawn(
                     nous_config,
                     PipelineConfig {
+                        history_budget_ratio: resolved.history_budget_ratio,
                         extraction: Some(aletheia_mneme::extract::ExtractionConfig::default()),
                         ..PipelineConfig::default()
                     },

--- a/crates/nous/src/bootstrap/bootstrap_tests.rs
+++ b/crates/nous/src/bootstrap/bootstrap_tests.rs
@@ -308,7 +308,7 @@ fn pack_sections_to_bootstrap_converts_priorities() {
     ];
 
     let refs: Vec<&PackSection> = sections.iter().collect();
-    let result = pack_sections_to_bootstrap(&refs, &CharEstimator);
+    let result = pack_sections_to_bootstrap(&refs, &CharEstimator::default());
 
     assert_eq!(result.len(), 2);
     assert_eq!(result[0].name, "[test-pack] LOGIC.md");
@@ -324,7 +324,7 @@ fn pack_sections_to_bootstrap_converts_priorities() {
 
 #[test]
 fn pack_sections_to_bootstrap_empty_input() {
-    let result = pack_sections_to_bootstrap(&[], &CharEstimator);
+    let result = pack_sections_to_bootstrap(&[], &CharEstimator::default());
     assert!(result.is_empty());
 }
 

--- a/crates/nous/src/bootstrap/mod.rs
+++ b/crates/nous/src/bootstrap/mod.rs
@@ -149,7 +149,19 @@ impl<'a> BootstrapAssembler<'a, CharEstimator> {
     pub fn new(oikos: &'a Oikos) -> Self {
         Self {
             oikos,
-            estimator: CharEstimator,
+            estimator: CharEstimator::default(),
+        }
+    }
+
+    /// Create an assembler with a configurable characters-per-token divisor.
+    ///
+    /// Wires the operator-configured `chars_per_token` value from
+    /// `agents.defaults.chars_per_token` into the bootstrap estimator.
+    #[must_use]
+    pub fn new_with_chars_per_token(oikos: &'a Oikos, chars_per_token: u64) -> Self {
+        Self {
+            oikos,
+            estimator: CharEstimator::new(chars_per_token),
         }
     }
 }

--- a/crates/nous/src/budget.rs
+++ b/crates/nous/src/budget.rs
@@ -10,15 +10,35 @@ pub trait TokenEstimator: Send + Sync {
     fn estimate(&self, text: &str) -> u64;
 }
 
-/// Character-based token estimator: 1 token ≈ 4 characters (ceiling division).
+/// Character-based token estimator: 1 token ≈ N characters (ceiling division).
 ///
 /// Conservative estimate suitable for budget planning. Actual token counts
 /// from the Anthropic API will be lower, giving natural headroom.
-pub struct CharEstimator;
+/// `chars_per_token` is configurable via `agents.defaults.chars_per_token`
+/// in `aletheia.toml`; the default of 4 preserves prior behaviour.
+pub struct CharEstimator {
+    chars_per_token: u64,
+}
+
+impl CharEstimator {
+    /// Create an estimator with an explicit characters-per-token divisor.
+    #[must_use]
+    pub fn new(chars_per_token: u64) -> Self {
+        Self { chars_per_token }
+    }
+}
+
+impl Default for CharEstimator {
+    fn default() -> Self {
+        // WHY: 4 chars per token is the classic heuristic for English text and
+        //      matches the historical hardcoded value — no behaviour change.
+        Self { chars_per_token: 4 }
+    }
+}
 
 impl TokenEstimator for CharEstimator {
     fn estimate(&self, text: &str) -> u64 {
-        (text.len() as u64).div_ceil(4)
+        (text.len() as u64).div_ceil(self.chars_per_token)
     }
 }
 
@@ -253,28 +273,28 @@ mod tests {
 
     #[test]
     fn char_estimator_empty_string() {
-        assert_eq!(CharEstimator.estimate(""), 0);
+        assert_eq!(CharEstimator::default().estimate(""), 0);
     }
 
     #[test]
     fn char_estimator_exact_multiple() {
         // 8 chars / 4 = 2 tokens
-        assert_eq!(CharEstimator.estimate("abcdefgh"), 2);
+        assert_eq!(CharEstimator::default().estimate("abcdefgh"), 2);
     }
 
     #[test]
     fn char_estimator_rounds_up() {
         // 5 chars -> ceil(5/4) = 2
-        assert_eq!(CharEstimator.estimate("hello"), 2);
+        assert_eq!(CharEstimator::default().estimate("hello"), 2);
         // 1 char -> ceil(1/4) = 1
-        assert_eq!(CharEstimator.estimate("a"), 1);
+        assert_eq!(CharEstimator::default().estimate("a"), 1);
         // 3 chars -> ceil(3/4) = 1
-        assert_eq!(CharEstimator.estimate("abc"), 1);
+        assert_eq!(CharEstimator::default().estimate("abc"), 1);
     }
 
     #[test]
     fn char_estimator_single_char() {
-        assert_eq!(CharEstimator.estimate("x"), 1);
+        assert_eq!(CharEstimator::default().estimate("x"), 1);
     }
 
     #[test]

--- a/crates/nous/src/config.rs
+++ b/crates/nous/src/config.rs
@@ -50,6 +50,13 @@ pub struct NousConfig {
     /// Wired from the taxis per-agent config block at startup.
     #[serde(default)]
     pub recall: RecallConfig,
+    /// Characters per token for conservative token-budget estimation.
+    ///
+    /// Used by `CharEstimator` when sizing bootstrap sections and recall
+    /// output.  The default of 4 follows the common "1 token ≈ 4 chars"
+    /// heuristic. Wired from `agents.defaults.chars_per_token` at startup.
+    #[serde(default = "default_chars_per_token")]
+    pub chars_per_token: u32,
 }
 
 fn default_cache_enabled() -> bool {
@@ -58,6 +65,13 @@ fn default_cache_enabled() -> bool {
 
 fn default_session_token_cap() -> u64 {
     500_000
+}
+
+fn default_chars_per_token() -> u32 {
+    // WHY: must match AgentDefaults::chars_per_token default in taxis so that
+    //      the serde default (used when deserialising NousConfig directly)
+    //      is identical to the value wired at startup via ResolvedNousConfig.
+    4
 }
 
 impl Default for NousConfig {
@@ -78,6 +92,7 @@ impl Default for NousConfig {
             cache_enabled: true,
             session_token_cap: default_session_token_cap(),
             recall: RecallConfig::default(),
+            chars_per_token: default_chars_per_token(),
         }
     }
 }
@@ -208,6 +223,7 @@ mod tests {
             cache_enabled: false,
             session_token_cap: 250_000,
             recall: RecallConfig::default(),
+            chars_per_token: 4,
         };
         assert_eq!(config.name.as_deref(), Some("Chiron"));
         assert!(config.thinking_enabled);

--- a/crates/nous/src/manager.rs
+++ b/crates/nous/src/manager.rs
@@ -184,7 +184,7 @@ impl NousManager {
         let id = config.id.clone();
 
         let extra_bootstrap = {
-            let estimator = CharEstimator;
+            let estimator = CharEstimator::new(u64::from(config.chars_per_token));
             let mut sections = Vec::new();
             for pack in self.packs.iter() {
                 let agent_sections = pack.sections_for_agent_or_domains(&id, &config.domains);

--- a/crates/nous/src/recall.rs
+++ b/crates/nous/src/recall.rs
@@ -157,6 +157,23 @@ pub struct RecallConfig {
     /// Per-factor scoring weights applied when building candidates.
     #[serde(default)]
     pub weights: RecallWeights,
+    /// Per-factor engine scoring weights for the mneme `RecallEngine`.
+    ///
+    /// Controls the weighted combination of retrieval signals. Wired from
+    /// `agents.defaults.recall.engine_weights` at startup; defaults match
+    /// the mneme engine built-in values for zero behavioural change.
+    #[serde(default)]
+    pub engine_weights: aletheia_taxis::config::RecallEngineWeights,
+    /// Characters per token for recall budget estimation.
+    ///
+    /// Wired from `agents.defaults.chars_per_token` at startup.
+    /// Default: 4 (1 token ≈ 4 chars).
+    #[serde(default = "default_chars_per_token")]
+    pub chars_per_token: u64,
+}
+
+fn default_chars_per_token() -> u64 {
+    4
 }
 
 impl Default for RecallConfig {
@@ -169,6 +186,8 @@ impl Default for RecallConfig {
             iterative: false,
             max_cycles: 2,
             weights: RecallWeights::default(),
+            engine_weights: aletheia_taxis::config::RecallEngineWeights::default(),
+            chars_per_token: default_chars_per_token(),
         }
     }
 }
@@ -189,6 +208,11 @@ impl From<aletheia_taxis::config::RecallSettings> for RecallConfig {
                 relationship_proximity: s.weights.relationship_proximity,
                 access_frequency: s.weights.access_frequency,
             },
+            engine_weights: s.engine_weights,
+            // NOTE: chars_per_token is forwarded separately from AgentDefaults
+            //       via NousConfig; the From conversion cannot carry it since
+            //       RecallSettings does not own that field.
+            chars_per_token: default_chars_per_token(),
         }
     }
 }
@@ -224,11 +248,20 @@ pub struct RecallStage {
 }
 
 impl RecallStage {
-    /// Create a recall stage with default scoring weights.
+    /// Create a recall stage, wiring operator-configured engine weights.
     #[must_use]
     pub fn new(config: RecallConfig) -> Self {
+        let ew = &config.engine_weights;
+        let engine_weights = aletheia_mneme::recall::RecallWeights {
+            vector_similarity: ew.vector_similarity,
+            decay: ew.decay,
+            relevance: ew.relevance,
+            epistemic_tier: ew.epistemic_tier,
+            relationship_proximity: ew.relationship_proximity,
+            access_frequency: ew.access_frequency,
+        };
         Self {
-            engine: RecallEngine::new(),
+            engine: RecallEngine::with_weights(engine_weights),
             config,
         }
     }
@@ -467,17 +500,14 @@ impl RecallStage {
             .collect()
     }
 
-    #[expect(
-        clippy::unused_self,
-        reason = "will use config fields when budget strategy is extended"
-    )]
     fn format_within_budget(&self, results: &[ScoredResult], budget: u64) -> (usize, String, u64) {
+        let cpt = self.config.chars_per_token;
         let mut included = Vec::with_capacity(results.len());
 
         for result in results {
             included.push(result);
             let section = format_section(&included);
-            let tokens = estimate_tokens(&section);
+            let tokens = estimate_tokens(&section, cpt);
             if tokens > budget {
                 included.pop();
                 break;
@@ -489,7 +519,7 @@ impl RecallStage {
         }
 
         let section = format_section(&included);
-        let tokens = estimate_tokens(&section);
+        let tokens = estimate_tokens(&section, cpt);
         (included.len(), section, tokens)
     }
 }
@@ -749,11 +779,15 @@ pub fn format_section(results: &[&ScoredResult]) -> String {
     out
 }
 
-/// Estimate token count from text length (~4 chars per token, ceiling).
+/// Estimate token count from text length using a configurable character divisor.
+///
+/// `chars_per_token` is the number of characters assumed per token. Use
+/// `RecallConfig::chars_per_token` for operator-configurable behaviour, or
+/// pass `4` directly in tests and contexts without a live config.
 #[must_use]
-pub fn estimate_tokens(text: &str) -> u64 {
+pub fn estimate_tokens(text: &str, chars_per_token: u64) -> u64 {
     let len = text.len() as u64;
-    len.div_ceil(4)
+    len.div_ceil(chars_per_token.max(1))
 }
 
 #[cfg(test)]

--- a/crates/nous/src/recall_tests.rs
+++ b/crates/nous/src/recall_tests.rs
@@ -234,11 +234,25 @@ fn recall_respects_token_budget() {
 
 #[test]
 fn estimate_tokens_heuristic() {
-    assert_eq!(estimate_tokens(""), 0);
-    assert_eq!(estimate_tokens("abcd"), 1);
-    assert_eq!(estimate_tokens("abcde"), 2);
+    assert_eq!(estimate_tokens("", 4), 0);
+    assert_eq!(estimate_tokens("abcd", 4), 1);
+    assert_eq!(estimate_tokens("abcde", 4), 2);
     let text = "x".repeat(400);
-    assert_eq!(estimate_tokens(&text), 100);
+    assert_eq!(estimate_tokens(&text, 4), 100);
+}
+
+#[test]
+fn estimate_tokens_custom_divisor() {
+    // 8 chars / 2 = 4 tokens
+    assert_eq!(estimate_tokens("abcdefgh", 2), 4);
+    // 5 chars / 3 = ceil(5/3) = 2 tokens
+    assert_eq!(estimate_tokens("hello", 3), 2);
+}
+
+#[test]
+fn estimate_tokens_divisor_clamp() {
+    // divisor 0 should be treated as 1 (no division by zero)
+    assert_eq!(estimate_tokens("a", 0), 1);
 }
 
 #[test]

--- a/crates/nous/src/skills.rs
+++ b/crates/nous/src/skills.rs
@@ -244,7 +244,7 @@ pub(crate) fn fact_to_section(fact: &Fact) -> BootstrapSection {
         fact.content.clone()
     };
 
-    let tokens = CharEstimator.estimate(&content);
+    let tokens = CharEstimator::default().estimate(&content);
 
     BootstrapSection {
         name: format!("[skill] {}", fact.id),

--- a/crates/nous/src/spawn_svc.rs
+++ b/crates/nous/src/spawn_svc.rs
@@ -83,6 +83,7 @@ impl SpawnService for SpawnServiceImpl {
             cache_enabled: true,
             session_token_cap: 500_000,
             recall: crate::recall::RecallConfig::default(),
+            chars_per_token: 4,
         };
 
         let pipeline_config = PipelineConfig {

--- a/crates/taxis/src/config.rs
+++ b/crates/taxis/src/config.rs
@@ -115,6 +115,45 @@ impl Default for RecallWeights {
     }
 }
 
+/// Per-factor engine scoring weights for the mneme `RecallEngine`.
+///
+/// These multipliers determine how much each retrieval signal contributes to the
+/// final relevance score. Weights need not sum to 1.0 — the engine normalises
+/// the weighted sum automatically. Defaults match the mneme engine's built-in
+/// values so that omitting this section produces identical behaviour.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[serde(default)]
+pub struct RecallEngineWeights {
+    /// Cosine-similarity weight. Default: 0.35
+    pub vector_similarity: f64,
+    /// FSRS power-law temporal decay weight. Default: 0.20
+    pub decay: f64,
+    /// Nous-relevance weight (own memories rank higher). Default: 0.15
+    pub relevance: f64,
+    /// Epistemic-tier weight (verified > inferred > assumed). Default: 0.15
+    pub epistemic_tier: f64,
+    /// Knowledge-graph relationship proximity weight. Default: 0.10
+    pub relationship_proximity: f64,
+    /// Access-frequency weight. Default: 0.05
+    pub access_frequency: f64,
+}
+
+impl Default for RecallEngineWeights {
+    fn default() -> Self {
+        // WHY: values match mneme::recall::RecallWeights defaults so no behavioural
+        //      change occurs when an operator omits this section from the config.
+        Self {
+            vector_similarity: 0.35,
+            decay: 0.20,
+            relevance: 0.15,
+            epistemic_tier: 0.15,
+            relationship_proximity: 0.10,
+            access_frequency: 0.05,
+        }
+    }
+}
+
 /// Recall pipeline settings for a nous agent.
 ///
 /// Resolved from taxis config and forwarded to the recall stage via
@@ -135,8 +174,13 @@ pub struct RecallSettings {
     pub iterative: bool,
     /// Maximum retrieval cycles when iterative mode is enabled.
     pub max_cycles: usize,
-    /// Per-factor scoring weights.
+    /// Per-factor scoring weights (factor scores for non-vector signals).
     pub weights: RecallWeights,
+    /// Per-factor engine scoring weights used by the mneme `RecallEngine`.
+    ///
+    /// Controls how much each retrieval signal contributes to the final
+    /// weighted relevance score. Defaults match mneme's built-in values.
+    pub engine_weights: RecallEngineWeights,
 }
 
 impl Default for RecallSettings {
@@ -149,6 +193,7 @@ impl Default for RecallSettings {
             iterative: false,
             max_cycles: 2,
             weights: RecallWeights::default(),
+            engine_weights: RecallEngineWeights::default(),
         }
     }
 }
@@ -178,6 +223,20 @@ pub struct AgentDefaults {
     pub caching: CachingConfig,
     /// Recall pipeline settings applied to all agents unless overridden.
     pub recall: RecallSettings,
+    /// Characters per token for conservative token-budget estimation.
+    ///
+    /// Used by `CharEstimator` when counting tokens from raw text length.
+    /// The default of 4 follows the common "1 token ≈ 4 chars" heuristic for
+    /// English text. Increase for more conservative budgets; decrease for
+    /// languages with shorter tokens.
+    pub chars_per_token: u32,
+    /// Fraction of the context window reserved for conversation history.
+    ///
+    /// The pipeline partitions the context window into three zones:
+    /// `history` (this fraction), `turn reserve` (`max_output_tokens`), and
+    /// `bootstrap` (the remainder, capped at `bootstrap_max_tokens`).
+    /// Default: 0.6 (60 % of the context window).
+    pub history_budget_ratio: f64,
 }
 
 impl Default for AgentDefaults {
@@ -193,6 +252,8 @@ impl Default for AgentDefaults {
             allowed_roots: Vec::new(),
             caching: CachingConfig::default(),
             recall: RecallSettings::default(),
+            chars_per_token: 4,
+            history_budget_ratio: 0.6,
         }
     }
 }
@@ -715,6 +776,10 @@ pub struct ResolvedNousConfig {
     pub cache_enabled: bool,
     /// Resolved recall pipeline settings.
     pub recall: RecallSettings,
+    /// Characters per token for token-budget estimation.
+    pub chars_per_token: u32,
+    /// Fraction of the context window reserved for conversation history.
+    pub history_budget_ratio: f64,
 }
 
 /// Resolve effective configuration for a specific nous agent.
@@ -776,6 +841,8 @@ pub fn resolve_nous(config: &AletheiaConfig, nous_id: &str) -> ResolvedNousConfi
         domains,
         cache_enabled: defaults.caching.enabled && defaults.caching.strategy != "disabled",
         recall,
+        chars_per_token: defaults.chars_per_token,
+        history_budget_ratio: defaults.history_budget_ratio,
     }
 }
 


### PR DESCRIPTION
## Summary

Closes #1131. Three categories of hardcoded runtime values are now configurable in `aletheia.toml` without recompiling. All defaults equal the previous values — no behavioural change when config is absent.

- **`[agents.defaults].chars_per_token`** (u32, default `4`): characters-per-token divisor for conservative token-budget estimation. Used by `CharEstimator` during bootstrap assembly and by the recall stage when accounting budget for injected knowledge.
- **`[agents.defaults].history_budget_ratio`** (f64, default `0.6`): fraction of the context window reserved for conversation history when computing the bootstrap budget via `TokenBudget`. Previously hardcoded in `PipelineConfig::default()`.
- **`[agents.defaults.recall].engine_weights`** (`RecallEngineWeights`, six f64 fields): per-factor multipliers for the mneme `RecallEngine` weighted sum. Previous hardcoded values become explicit defaults: `vector_similarity=0.35`, `decay=0.20`, `relevance=0.15`, `epistemic_tier=0.15`, `relationship_proximity=0.10`, `access_frequency=0.05`. `RecallStage::new()` now calls `RecallEngine::with_weights()` using the operator config instead of `RecallEngine::new()` (built-in defaults).

## Acceptance criteria

- [x] Token estimation multiplier configurable in `[agents.defaults]` (LLM config section)
- [x] Recall scoring weights and thresholds configurable in `[agents.defaults.recall]`
- [x] Context window reservation size configurable (`history_budget_ratio`)
- [x] All promoted values default to their previous hardcoded values

## Test plan

- `cargo fmt --all -- --check` ✅
- `cargo clippy --workspace --all-targets -- -D warnings` ✅ (no warnings)
- `cargo test --workspace` ✅ (all test results: ok)
- New tests: `estimate_tokens_custom_divisor`, `estimate_tokens_divisor_clamp` in `recall_tests.rs`

## Observations (out of scope — do not fix)

- **Debt** `crates/aletheia/src/commands/server.rs:308` — `loop_detection_threshold: 3` and `session_token_cap: 500_000` are still hardcoded in the `NousConfig` struct literal and are not wired from taxis config. These are additional phantom-config candidates for a follow-up to #1131.
- **Debt** `crates/nous/src/spawn_svc.rs:70` — ephemeral sub-agent `NousConfig` uses hardcoded values (`context_window: 200_000`, `max_output_tokens: 16_384`, etc.) that are not derived from operator config. This is intentional for ephemeral agents but worth reviewing if sub-agent behaviour needs operator tunability.
- **Idea** `crates/nous/src/recall.rs` — The `chars_per_token` field on `RecallConfig` is separately forwarded from `AgentDefaults` because it is not part of `RecallSettings`. A future refactor could consolidate this forwarding by adding a dedicated `estimation` sub-section to `AgentDefaults`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)