### PR TITLE
docs(theatron): theatron-core extraction plan

### DIFF
--- a/docs/theatron-core-extraction.md
+++ b/docs/theatron-core-extraction.md
@@ -462,3 +462,7 @@ required by the prompt but left unaddressed.
 | Idea | `mapping.rs` | The file is 53 KB and handles all keymap translation. Splitting into sub-modules by domain (terminal, sse, stream, keybindings) would improve navigability. |
 | Missing test | `api/client.rs` | `check_status()` has no unit tests for the JSON body extraction path. It is the sole place that parses server error messages; a test with a mock response body would prevent silent regressions. |
 | Missing test | `api/client.rs` | `build_http_client()` has no test that verifies required headers (`x-requested-with`, `Content-Type`) are present on the built client. |
+| Bug | `api/types.rs:20-22` | `Agent::display_name()` returns empty string when `name = Some("")`. Inconsistent with `Session::label()` at line 46 which filters empty strings via `.filter(\|s\| !s.is_empty())`. |
+| Debt | `api/client.rs:487` | `knowledge_facts` query params built via string interpolation, not `.query()`. Injection-safe only because params are controlled, but inconsistent with `recall()` at line 427 which uses `.query()`. |
+| Missing test | `api/streaming.rs:165-222` | `tool_approval_required`, `tool_approval_resolved`, and all `plan_*` stream event parsing have no test coverage. |
+| Debt | `api/mod.rs:7-21` | Three `#[expect(unused_imports)]` on re-exports — barrel-file pattern fighting the linter. Will be resolved when `api/` module moves to core. |


### PR DESCRIPTION
## Summary

- Full audit of `theatron-tui` API layer: `api/client.rs` (639 lines), `api/types.rs` (519 lines), `api/sse.rs` (271 lines), `api/streaming.rs` (307 lines), `api/error.rs` (37 lines), `id.rs` (122 lines), `events.rs` (153 lines)
- Every function and type classified as **shared** (moves to `theatron-core`) or **TUI-specific** (stays) with rationale
- File-level extraction plan with proposed module structure, 7-step migration sequence, and per-step validation gates
- Test strategy ensuring zero behavior change: 39 tests move with their code, all TUI integration tests continue working
- Dependency analysis: what `theatron-core` gains, what `theatron-tui` loses, what consumes each
- Server/client protocol comparison: `WebchatEvent` drift (7 missing variants), `TurnOutcome` type mismatch (`u64` vs `u32`)

## Key findings

- **Entire `api/` subtree + `id.rs` + `StreamEvent` move** — no TUI dependency in any of these files
- `theatron-core` needs 9 dependencies (all already in workspace)
- `theatron-tui` can drop `reqwest`, `reqwest-eventsource`, `futures-util` as direct deps
- Only `Event` enum stays in TUI (wraps `crossterm::event::Event`)

## Observations (out of scope)

| Tag | Location |
|-----|----------|
| Bug | `api/types.rs:20-22` — `Agent::display_name()` returns empty string inconsistently |
| Bug | `api/client.rs:400` — float-to-u32 truncation in cost cents conversion |
| Debt | `str_field()` duplicated in `sse.rs` and `streaming.rs` |
| Debt | `InvalidStatusCode` error body parsing duplicated verbatim |
| Debt | `pylon/src/stream.rs` — `WebchatEvent` missing 7 variants the server actually emits |
| Debt | `TurnOutcome` defined independently in pylon and TUI with type mismatches |
| Debt | `knowledge_facts` uses string interpolation not `.query()` |
| Debt | `api/mod.rs` — 3 `#[expect(unused_imports)]` barrel-file lint suppressions |
| Missing test | `tool_approval_*` and `plan_*` stream event parsing uncovered |
| Missing test | `check_status()` JSON body extraction path untested |
| Missing test | `build_http_client()` header verification untested |

## Test plan

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — zero warnings
- [x] `cargo test --workspace` — 3,509 tests pass, 0 failures
- [x] `git diff --stat` — only `docs/theatron-core-extraction.md` changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)