### PR TITLE
refactor(nous,pylon,organon): decompose hero functions (#940)

### DIFF
--- a/crates/nous/src/actor/background.rs
+++ b/crates/nous/src/actor/background.rs
@@ -323,6 +323,8 @@ async fn run_extraction(
     }
 }
 
+// NOTE(#940): 113 lines — extract → persist → handle lifecycle for skill extraction.
+// Single cohesive async operation, splitting would obscure the three-phase flow.
 /// Run LLM skill extraction as a background task. Logs results, never panics.
 async fn run_skill_extraction(
     model: &str,

--- a/crates/nous/src/actor/mod.rs
+++ b/crates/nous/src/actor/mod.rs
@@ -171,6 +171,8 @@ impl NousActor {
         }
     }
 
+    // NOTE(#940): 92 lines — actor message loop with tokio::select!. Under the 100-line
+    // threshold but noted for completeness; the select loop is one cohesive operation.
     /// Run the actor loop until shutdown or all handles are dropped.
     ///
     /// # Cancel safety

--- a/crates/nous/src/actor/turn.rs
+++ b/crates/nous/src/actor/turn.rs
@@ -166,6 +166,8 @@ impl NousActor {
         self.handle_pipeline_result(result, session_key)
     }
 
+    // NOTE(#940): 113 lines — setup and spawn a single pipeline task with streaming
+    // bridge. The sequential setup + spawn is one cohesive operation.
     /// Spawn the pipeline as a separate tokio task to catch panics.
     ///
     /// When `db_session_id` is `Some`, the actor adopts that ID for the

--- a/crates/nous/src/execute/mod.rs
+++ b/crates/nous/src/execute/mod.rs
@@ -5,14 +5,18 @@ mod dispatch;
 #[cfg(test)]
 mod tests;
 
+use std::collections::HashSet;
+
 use snafu::ResultExt;
 use tracing::{debug, info, instrument, warn};
 
 use aletheia_hermeneus::health::ProviderHealth;
-use aletheia_hermeneus::provider::ProviderRegistry;
+use aletheia_hermeneus::provider::{LlmProvider, ProviderRegistry};
 use aletheia_hermeneus::types::{
-    CompletionRequest, Content, ContentBlock, Message, Role, StopReason, ThinkingConfig,
+    CompletionRequest, Content, ContentBlock, Message, Role, ServerToolDefinition, StopReason,
+    ThinkingConfig,
 };
+use aletheia_koina::id::ToolName;
 use aletheia_organon::registry::ToolRegistry;
 use aletheia_organon::types::ToolContext;
 use tokio::sync::mpsc;
@@ -25,31 +29,15 @@ use crate::stream::TurnStreamEvent;
 
 use dispatch::{build_messages, classify_signals, dispatch_tools, dispatch_tools_streaming};
 
-/// Execute stage — calls the LLM and iterates on tool use.
-///
-/// This is the core agent loop. It:
-/// 1. Builds a `CompletionRequest` from pipeline context
-/// 2. Calls the LLM
-/// 3. Processes `tool_use` blocks by dispatching to the `ToolRegistry`
-/// 4. Feeds tool results back and re-calls the LLM
-/// 5. Repeats until `EndTurn`, `MaxTokens`, or iteration limit
-#[expect(
-    clippy::too_many_lines,
-    reason = "health check additions keep the loop cohesive"
-)]
-#[instrument(skip_all, fields(nous_id = %session.nous_id, session_id = %session.id))]
-pub async fn execute(
-    ctx: &PipelineContext,
-    session: &SessionState,
-    config: &NousConfig,
-    providers: &ProviderRegistry,
-    tools: &ToolRegistry,
-    tool_ctx: &ToolContext,
-) -> error::Result<TurnResult> {
-    let provider = providers.find_provider(&config.model).ok_or_else(|| {
+/// Resolve the LLM provider for `model` and verify it is not marked down.
+fn resolve_provider_checked<'a>(
+    providers: &'a ProviderRegistry,
+    model: &str,
+) -> error::Result<&'a dyn LlmProvider> {
+    let provider = providers.find_provider(model).ok_or_else(|| {
         error::PipelineStageSnafu {
             stage: "execute",
-            message: format!("no provider for model: {}", config.model),
+            message: format!("no provider for model: {model}"),
         }
         .build()
     })?;
@@ -64,6 +52,107 @@ pub async fn execute(
         .build());
     }
 
+    Ok(provider)
+}
+
+/// Read the current active-tools set and derive server-tool definitions.
+///
+/// Returns `(active_set, server_tools)` so callers can also filter local tool
+/// definitions against the same snapshot of `active`.
+fn resolve_active_server_tools(
+    tool_ctx: &ToolContext,
+    config: &NousConfig,
+) -> (HashSet<ToolName>, Vec<ServerToolDefinition>) {
+    let active = tool_ctx
+        .active_tools
+        .read()
+        .unwrap_or_else(|poisoned| {
+            warn!("active_tools lock poisoned by prior panic, recovering with last value");
+            poisoned.into_inner()
+        })
+        .clone();
+
+    let server_tools = if let Some(services) = tool_ctx.services.as_deref() {
+        let mut st = services.server_tool_config.active_definitions(&active);
+        // WHY: also include raw server_tools from NousConfig for backward compatibility
+        st.extend(config.server_tools.clone());
+        st
+    } else {
+        config.server_tools.clone()
+    };
+
+    (active, server_tools)
+}
+
+/// Extracted text, tool uses, and server-tool flags from a single LLM response.
+struct ResponseExtract {
+    text_parts: Vec<String>,
+    tool_uses: Vec<(String, String, serde_json::Value)>,
+    saw_server_web_search: bool,
+    saw_server_code_execution: bool,
+}
+
+/// Process response content blocks into text, tool-use tuples, and server-tool flags.
+fn process_response_blocks(content: &[ContentBlock]) -> ResponseExtract {
+    let mut extract = ResponseExtract {
+        text_parts: Vec::new(),
+        tool_uses: Vec::new(),
+        saw_server_web_search: false,
+        saw_server_code_execution: false,
+    };
+
+    for block in content {
+        match block {
+            ContentBlock::Text { text, .. } => extract.text_parts.push(text.clone()),
+            ContentBlock::ToolUse { id, name, input } => {
+                extract
+                    .tool_uses
+                    .push((id.clone(), name.clone(), input.clone()));
+            }
+            ContentBlock::Thinking { thinking, .. } => {
+                debug!(len = thinking.len(), "thinking block received");
+            }
+            ContentBlock::ServerToolUse { name, .. } if name == "web_search" => {
+                extract.saw_server_web_search = true;
+            }
+            ContentBlock::ServerToolUse { name, .. } if name == "code_execution" => {
+                extract.saw_server_code_execution = true;
+            }
+            ContentBlock::CodeExecutionResult {
+                code, return_code, ..
+            } => {
+                extract.saw_server_code_execution = true;
+                debug!(
+                    code_len = code.len(),
+                    return_code, "server code execution result received"
+                );
+            }
+            _ => {}
+        }
+    }
+
+    extract
+}
+
+/// Execute stage — calls the LLM and iterates on tool use.
+///
+/// This is the core agent loop. It:
+/// 1. Builds a `CompletionRequest` from pipeline context
+/// 2. Calls the LLM
+/// 3. Processes `tool_use` blocks by dispatching to the `ToolRegistry`
+/// 4. Feeds tool results back and re-calls the LLM
+/// 5. Repeats until `EndTurn`, `MaxTokens`, or iteration limit
+#[instrument(skip_all, fields(nous_id = %session.nous_id, session_id = %session.id))]
+pub async fn execute(
+    ctx: &PipelineContext,
+    session: &SessionState,
+    config: &NousConfig,
+    providers: &ProviderRegistry,
+    tools: &ToolRegistry,
+    tool_ctx: &ToolContext,
+) -> error::Result<TurnResult> {
+    let provider = resolve_provider_checked(providers, &config.model)?;
+
     let mut messages = build_messages(&ctx.messages);
     let mut all_tool_calls: Vec<ToolCall> = Vec::new();
     let mut total_usage = TurnUsage::default();
@@ -74,14 +163,10 @@ pub async fn execute(
     let mut used_server_web_search = false;
     let mut used_server_code_execution = false;
 
-    let thinking = if config.thinking_enabled {
-        Some(ThinkingConfig {
-            enabled: true,
-            budget_tokens: config.thinking_budget,
-        })
-    } else {
-        None
-    };
+    let thinking = config.thinking_enabled.then_some(ThinkingConfig {
+        enabled: true,
+        budget_tokens: config.thinking_budget,
+    });
 
     loop {
         iterations += 1;
@@ -91,25 +176,8 @@ pub async fn execute(
             break;
         }
 
-        let active = tool_ctx
-            .active_tools
-            .read()
-            .unwrap_or_else(|poisoned| {
-                warn!("active_tools lock poisoned by prior panic, recovering with last value");
-                poisoned.into_inner()
-            })
-            .clone();
+        let (active, server_tools) = resolve_active_server_tools(tool_ctx, config);
         let tool_defs = tools.to_hermeneus_tools_filtered(&active);
-
-        // WHY: derive server tools on each iteration so enable_tool activations take effect
-        let server_tools = if let Some(services) = tool_ctx.services.as_deref() {
-            let mut st = services.server_tool_config.active_definitions(&active);
-            // WHY: also include raw server_tools from NousConfig for backward compatibility
-            st.extend(config.server_tools.clone());
-            st
-        } else {
-            config.server_tools.clone()
-        };
 
         let request = CompletionRequest {
             model: config.model.clone(),
@@ -144,42 +212,14 @@ pub async fn execute(
         total_usage.cache_write_tokens += response.usage.cache_write_tokens;
         total_usage.llm_calls += 1;
 
-        let mut text_parts: Vec<String> = Vec::new();
-        let mut tool_uses: Vec<(String, String, serde_json::Value)> = Vec::new();
-
-        for block in &response.content {
-            match block {
-                ContentBlock::Text { text, .. } => text_parts.push(text.clone()),
-                ContentBlock::ToolUse { id, name, input } => {
-                    tool_uses.push((id.clone(), name.clone(), input.clone()));
-                }
-                ContentBlock::Thinking { thinking, .. } => {
-                    debug!(len = thinking.len(), "thinking block received");
-                }
-                ContentBlock::ServerToolUse { name, .. } if name == "web_search" => {
-                    used_server_web_search = true;
-                }
-                ContentBlock::ServerToolUse { name, .. } if name == "code_execution" => {
-                    used_server_code_execution = true;
-                }
-                ContentBlock::CodeExecutionResult {
-                    code, return_code, ..
-                } => {
-                    used_server_code_execution = true;
-                    debug!(
-                        code_len = code.len(),
-                        return_code, "server code execution result received"
-                    );
-                }
-                _ => {}
-            }
-        }
-
-        final_content = text_parts.join("");
+        let extracted = process_response_blocks(&response.content);
+        used_server_web_search |= extracted.saw_server_web_search;
+        used_server_code_execution |= extracted.saw_server_code_execution;
+        final_content = extracted.text_parts.join("");
         final_stop_reason = response.stop_reason.to_string();
 
         // WHY: only break on no local tool uses — server tool results don't require client tool_result
-        if tool_uses.is_empty() || response.stop_reason != StopReason::ToolUse {
+        if extracted.tool_uses.is_empty() || response.stop_reason != StopReason::ToolUse {
             break;
         }
 
@@ -189,7 +229,7 @@ pub async fn execute(
         });
 
         let tool_results = dispatch_tools(
-            &tool_uses,
+            &extracted.tool_uses,
             tools,
             tool_ctx,
             &mut loop_detector,
@@ -234,7 +274,7 @@ pub async fn execute(
 /// `complete()` otherwise. Tool start/result events are emitted via the channel.
 #[expect(
     clippy::too_many_lines,
-    reason = "streaming variant parallels execute() structure"
+    reason = "streaming agent loop parallels execute() with provider callback — one cohesive operation"
 )]
 #[instrument(skip_all, fields(nous_id = %session.nous_id, session_id = %session.id))]
 pub async fn execute_streaming(
@@ -246,30 +286,12 @@ pub async fn execute_streaming(
     tool_ctx: &ToolContext,
     stream_tx: &mpsc::Sender<TurnStreamEvent>,
 ) -> error::Result<TurnResult> {
-    let streaming_provider = providers.find_streaming_provider(&config.model);
-
-    // NOTE: fall back to non-streaming execute if no streaming provider is registered for this model
-    let Some(streaming_provider) = streaming_provider else {
+    let Some(streaming_provider) = providers.find_streaming_provider(&config.model) else {
+        // NOTE: fall back to non-streaming execute if no streaming provider is registered
         return execute(ctx, session, config, providers, tools, tool_ctx).await;
     };
 
-    let provider = providers.find_provider(&config.model).ok_or_else(|| {
-        error::PipelineStageSnafu {
-            stage: "execute",
-            message: format!("no provider for model: {}", config.model),
-        }
-        .build()
-    })?;
-
-    if let Some(health) = providers.provider_health(provider.name())
-        && matches!(health, ProviderHealth::Down { .. })
-    {
-        return Err(error::PipelineStageSnafu {
-            stage: "execute",
-            message: format!("provider '{}' is currently unavailable", provider.name()),
-        }
-        .build());
-    }
+    let provider = resolve_provider_checked(providers, &config.model)?;
 
     let mut messages = build_messages(&ctx.messages);
     let mut all_tool_calls: Vec<ToolCall> = Vec::new();
@@ -281,14 +303,10 @@ pub async fn execute_streaming(
     let mut used_server_web_search = false;
     let mut used_server_code_execution = false;
 
-    let thinking = if config.thinking_enabled {
-        Some(ThinkingConfig {
-            enabled: true,
-            budget_tokens: config.thinking_budget,
-        })
-    } else {
-        None
-    };
+    let thinking = config.thinking_enabled.then_some(ThinkingConfig {
+        enabled: true,
+        budget_tokens: config.thinking_budget,
+    });
 
     let tool_defs = tools.to_hermeneus_tools();
 
@@ -301,21 +319,7 @@ pub async fn execute_streaming(
         }
 
         // WHY: derive server tools on each iteration so enable_tool activations take effect
-        let active = tool_ctx
-            .active_tools
-            .read()
-            .unwrap_or_else(|poisoned| {
-                warn!("active_tools lock poisoned by prior panic, recovering with last value");
-                poisoned.into_inner()
-            })
-            .clone();
-        let server_tools = if let Some(services) = tool_ctx.services.as_deref() {
-            let mut st = services.server_tool_config.active_definitions(&active);
-            st.extend(config.server_tools.clone());
-            st
-        } else {
-            config.server_tools.clone()
-        };
+        let (_active, server_tools) = resolve_active_server_tools(tool_ctx, config);
 
         let request = CompletionRequest {
             model: config.model.clone(),
@@ -356,41 +360,13 @@ pub async fn execute_streaming(
         total_usage.cache_write_tokens += response.usage.cache_write_tokens;
         total_usage.llm_calls += 1;
 
-        let mut text_parts: Vec<String> = Vec::new();
-        let mut tool_uses: Vec<(String, String, serde_json::Value)> = Vec::new();
-
-        for block in &response.content {
-            match block {
-                ContentBlock::Text { text, .. } => text_parts.push(text.clone()),
-                ContentBlock::ToolUse { id, name, input } => {
-                    tool_uses.push((id.clone(), name.clone(), input.clone()));
-                }
-                ContentBlock::Thinking { thinking, .. } => {
-                    debug!(len = thinking.len(), "thinking block received");
-                }
-                ContentBlock::ServerToolUse { name, .. } if name == "web_search" => {
-                    used_server_web_search = true;
-                }
-                ContentBlock::ServerToolUse { name, .. } if name == "code_execution" => {
-                    used_server_code_execution = true;
-                }
-                ContentBlock::CodeExecutionResult {
-                    code, return_code, ..
-                } => {
-                    used_server_code_execution = true;
-                    debug!(
-                        code_len = code.len(),
-                        return_code, "server code execution result received"
-                    );
-                }
-                _ => {}
-            }
-        }
-
-        final_content = text_parts.join("");
+        let extracted = process_response_blocks(&response.content);
+        used_server_web_search |= extracted.saw_server_web_search;
+        used_server_code_execution |= extracted.saw_server_code_execution;
+        final_content = extracted.text_parts.join("");
         final_stop_reason = response.stop_reason.to_string();
 
-        if tool_uses.is_empty() || response.stop_reason != StopReason::ToolUse {
+        if extracted.tool_uses.is_empty() || response.stop_reason != StopReason::ToolUse {
             break;
         }
 
@@ -400,7 +376,7 @@ pub async fn execute_streaming(
         });
 
         let tool_results = dispatch_tools_streaming(
-            &tool_uses,
+            &extracted.tool_uses,
             tools,
             tool_ctx,
             &mut loop_detector,

--- a/crates/nous/src/finalize.rs
+++ b/crates/nous/src/finalize.rs
@@ -66,6 +66,8 @@ pub struct FinalizeResult {
 /// The nous actor creates sessions in memory (not in `SQLite`). Before
 /// appending messages we ensure the session record exists in the store,
 /// avoiding a FOREIGN KEY constraint violation on the `messages` table.
+// NOTE(#940): 120 lines — sequential persistence pipeline: persist assistant message,
+// store tool results, update session, emit events. One cohesive commit sequence.
 #[expect(
     clippy::too_many_lines,
     reason = "sequential persist pipeline with dedup guard adds a few lines over the limit"

--- a/crates/nous/src/pipeline.rs
+++ b/crates/nous/src/pipeline.rs
@@ -367,10 +367,6 @@ pub fn check_guard(session: &SessionState, config: &NousConfig) -> GuardResult {
     clippy::too_many_arguments,
     reason = "pipeline threading requires all dependencies until config struct refactor"
 )]
-#[expect(
-    clippy::too_many_lines,
-    reason = "pipeline orchestrator — sequential stages are clearer inline"
-)]
 pub async fn run_pipeline(
     input: PipelineInput,
     oikos: &Oikos,
@@ -406,328 +402,45 @@ pub async fn run_pipeline(
     let mut stages_completed: u32 = 0;
 
     let mut ctx = PipelineContext::default();
-    {
-        let span = info_span!(
-            "pipeline_stage",
-            stage = "context",
-            duration_ms = tracing::field::Empty,
-            status = tracing::field::Empty
-        );
-        let _guard = span.enter();
-        let start = Instant::now();
-        assemble_context_with_extra(oikos, config, pipeline_config, &mut ctx, extra_bootstrap)
-            .await
-            .inspect_err(|_| {
-                crate::metrics::record_error(&config.id, "context", "assembly_failed");
-            })?;
-        #[expect(
-            clippy::cast_possible_truncation,
-            reason = "stage duration fits in u64"
-        )]
-        {
-            span.record("duration_ms", start.elapsed().as_millis() as u64);
-        }
-        span.record("status", "ok");
-        crate::metrics::record_stage(&config.id, "context", start.elapsed().as_secs_f64());
-        stages_completed += 1;
-    }
 
-    {
-        let span = info_span!(
-            "pipeline_stage",
-            stage = "recall",
-            duration_ms = tracing::field::Empty,
-            status = tracing::field::Empty
-        );
-        let _guard = span.enter();
-        let start = Instant::now();
-        let recall_timeout_secs = pipeline_config.stage_budget.recall_secs;
-        let is_mock_embedding =
-            embedding_provider.is_some_and(|ep| ep.model_name() == "mock-embedding");
-        #[expect(
-            clippy::cast_sign_loss,
-            reason = "remaining_tokens is positive after context assembly"
-        )]
-        let budget = ctx.remaining_tokens.max(0) as u64;
+    run_context_stage(oikos, config, pipeline_config, &mut ctx, extra_bootstrap).await?;
+    stages_completed += 1;
 
-        // NOTE: BM25-only fallback when mock embedding provider is in use.
-        // Vector recall would produce meaningless results from hash-based embeddings.
-        if is_mock_embedding {
-            if let Some(ts) = text_search {
-                debug!("mock embedding provider — using BM25-only recall");
-                let recall_stage = crate::recall::RecallStage::new(config.recall.clone());
-                let result = recall_stage.run_bm25(&input.content, &config.id, ts, budget);
-                apply_recall_result(result, &mut ctx, &span);
-            } else {
-                debug!("recall skipped: mock embedding provider with no text search");
-                span.record("status", "skipped");
-            }
-        } else if let (Some(ep), Some(vs)) = (embedding_provider, vector_search) {
-            let recall_stage = crate::recall::RecallStage::new(config.recall.clone());
+    run_recall_stage(
+        config,
+        pipeline_config,
+        &mut ctx,
+        &input.content,
+        embedding_provider,
+        vector_search,
+        text_search,
+    )
+    .await;
+    stages_completed += 1;
 
-            let recall_result_opt = if recall_timeout_secs > 0 {
-                match tokio::time::timeout(
-                    Duration::from_secs(u64::from(recall_timeout_secs)),
-                    async { recall_stage.run(&input.content, &config.id, ep, vs, budget) },
-                )
-                .await
-                {
-                    Ok(result) => Some(result),
-                    Err(_elapsed) => {
-                        warn!(
-                            timeout_secs = recall_timeout_secs,
-                            "recall stage timed out, continuing without recalled knowledge"
-                        );
-                        span.record("status", "timeout");
-                        None
-                    }
-                }
-            } else {
-                Some(recall_stage.run(&input.content, &config.id, ep, vs, budget))
-            };
+    run_history_stage(config, &mut ctx, &input, session_store).await?;
+    stages_completed += 1;
 
-            if let Some(result) = recall_result_opt {
-                apply_recall_result(result, &mut ctx, &span);
-            }
-        } else {
-            debug!("recall skipped: embedding provider or vector search not configured");
-            span.record("status", "skipped");
-        }
-        #[expect(
-            clippy::cast_possible_truncation,
-            reason = "stage duration fits in u64"
-        )]
-        {
-            span.record("duration_ms", start.elapsed().as_millis() as u64);
-        }
-        crate::metrics::record_stage(&config.id, "recall", start.elapsed().as_secs_f64());
-        stages_completed += 1;
-    }
+    run_guard_stage(&input.session, config)?;
+    stages_completed += 1;
 
-    {
-        let span = info_span!(
-            "pipeline_stage",
-            stage = "history",
-            duration_ms = tracing::field::Empty,
-            status = tracing::field::Empty
-        );
-        let _guard = span.enter();
-        let start = Instant::now();
+    let result = run_execute_stage(
+        config,
+        pipeline_config,
+        &ctx,
+        &input,
+        providers,
+        tools,
+        tool_ctx,
+        stream_tx,
+        pipeline_start,
+        total_timeout,
+    )
+    .await?;
+    stages_completed += 1;
 
-        // NOTE: Waterfall — unused system-prompt budget flows into the history budget
-        // so tokens not consumed by bootstrap or recall are not wasted.
-        ctx.history_budget += ctx.remaining_tokens.max(0);
-
-        let history_config = HistoryConfig::default();
-        if let Some(store_mutex) = session_store {
-            // WHY: guard scoped and dropped before execute .await
-            let store = store_mutex.lock().await;
-            let (messages, hist_result) = history::load_history(
-                &store,
-                &input.session.id,
-                ctx.history_budget,
-                &history_config,
-                &input.content,
-            )
-            .inspect_err(|_| crate::metrics::record_error(&config.id, "history", "load_failed"))?;
-            ctx.messages = messages;
-            ctx.history_budget -= hist_result.tokens_consumed;
-            ctx.history_result = Some(hist_result);
-        } else {
-            #[expect(clippy::cast_possible_wrap, reason = "message length fits in i64")]
-            let token_estimate = (input.content.len() as i64 + 3) / 4;
-            ctx.messages.push(PipelineMessage {
-                role: "user".to_owned(),
-                content: input.content.clone(),
-                token_estimate,
-            });
-        }
-        #[expect(
-            clippy::cast_possible_truncation,
-            reason = "stage duration fits in u64"
-        )]
-        {
-            span.record("duration_ms", start.elapsed().as_millis() as u64);
-        }
-        span.record("status", "ok");
-        crate::metrics::record_stage(&config.id, "history", start.elapsed().as_secs_f64());
-        stages_completed += 1;
-    }
-
-    {
-        let span = info_span!(
-            "pipeline_stage",
-            stage = "guard",
-            duration_ms = tracing::field::Empty,
-            status = tracing::field::Empty
-        );
-        let _guard = span.enter();
-        let start = Instant::now();
-        let guard = check_guard(&input.session, config);
-        #[expect(
-            clippy::cast_possible_truncation,
-            reason = "stage duration fits in u64"
-        )]
-        {
-            span.record("duration_ms", start.elapsed().as_millis() as u64);
-        }
-        crate::metrics::record_stage(&config.id, "guard", start.elapsed().as_secs_f64());
-        match guard {
-            GuardResult::Allow => {
-                span.record("status", "ok");
-                stages_completed += 1;
-            }
-            GuardResult::RateLimited { retry_after_ms } => {
-                span.record("status", "error");
-                crate::metrics::record_error(&config.id, "guard", "rate_limited");
-                return Err(error::GuardRejectedSnafu {
-                    reason: format!("rate limited, retry after {retry_after_ms}ms"),
-                }
-                .build());
-            }
-            GuardResult::LoopDetected { pattern } => {
-                span.record("status", "error");
-                crate::metrics::record_error(&config.id, "guard", "loop_detected");
-                return Err(error::LoopDetectedSnafu {
-                    iterations: 0u32,
-                    pattern,
-                }
-                .build());
-            }
-            GuardResult::Rejected { reason } => {
-                span.record("status", "error");
-                crate::metrics::record_error(&config.id, "guard", "rejected");
-                return Err(error::GuardRejectedSnafu { reason }.build());
-            }
-        }
-    }
-
-    let result;
-    {
-        let span = info_span!(
-            "pipeline_stage",
-            stage = "execute",
-            duration_ms = tracing::field::Empty,
-            status = tracing::field::Empty,
-            tokens_in = tracing::field::Empty,
-            tokens_out = tracing::field::Empty,
-        );
-        let _guard = span.enter();
-        let start = Instant::now();
-
-        // NOTE: prefer per-stage budget, fall back to remaining time from total pipeline budget, whichever is tighter.
-        let execute_secs = pipeline_config.stage_budget.execute_secs;
-        let effective_execute_timeout = match (execute_secs > 0, total_timeout) {
-            (true, Some(total)) => {
-                let stage = Duration::from_secs(u64::from(execute_secs));
-                let remaining = total.saturating_sub(pipeline_start.elapsed());
-                Some(stage.min(remaining))
-            }
-            (true, None) => Some(Duration::from_secs(u64::from(execute_secs))),
-            (false, Some(total)) => Some(total.saturating_sub(pipeline_start.elapsed())),
-            (false, None) => None,
-        };
-
-        let execute_fut = async {
-            if let Some(tx) = stream_tx {
-                crate::execute::execute_streaming(
-                    &ctx,
-                    &input.session,
-                    config,
-                    providers,
-                    tools,
-                    tool_ctx,
-                    tx,
-                )
-                .await
-            } else {
-                crate::execute::execute(&ctx, &input.session, config, providers, tools, tool_ctx)
-                    .await
-            }
-        };
-
-        result = if let Some(timeout_dur) = effective_execute_timeout {
-            match tokio::time::timeout(timeout_dur, execute_fut).await {
-                Ok(res) => res.inspect_err(|_| {
-                    crate::metrics::record_error(&config.id, "execute", "pipeline_error");
-                })?,
-                Err(_elapsed) => {
-                    let secs = execute_secs.max(pipeline_config.stage_budget.total_secs);
-                    span.record("status", "timeout");
-                    crate::metrics::record_error(&config.id, "execute", "timeout");
-                    return Err(error::PipelineTimeoutSnafu {
-                        stage: "execute",
-                        timeout_secs: secs,
-                    }
-                    .build());
-                }
-            }
-        } else {
-            execute_fut.await.inspect_err(|_| {
-                crate::metrics::record_error(&config.id, "execute", "pipeline_error");
-            })?
-        };
-
-        #[expect(
-            clippy::cast_possible_truncation,
-            reason = "stage duration fits in u64"
-        )]
-        {
-            span.record("duration_ms", start.elapsed().as_millis() as u64);
-        }
-        span.record("tokens_in", result.usage.input_tokens);
-        span.record("tokens_out", result.usage.output_tokens);
-        span.record("status", "ok");
-        crate::metrics::record_stage(&config.id, "execute", start.elapsed().as_secs_f64());
-        stages_completed += 1;
-    }
-
-    {
-        let span = info_span!(
-            "pipeline_stage",
-            stage = "finalize",
-            duration_ms = tracing::field::Empty,
-            status = tracing::field::Empty
-        );
-        let _guard = span.enter();
-        let start = Instant::now();
-        if let Some(store_mutex) = session_store {
-            let store = store_mutex.lock().await;
-            let finalize_config = crate::finalize::FinalizeConfig::default();
-            match crate::finalize::finalize(
-                &store,
-                &input.session,
-                &input.content,
-                &result,
-                &finalize_config,
-            ) {
-                Ok(fr) => {
-                    debug!(
-                        messages = fr.messages_persisted,
-                        usage = fr.usage_recorded,
-                        "finalize complete"
-                    );
-                    span.record("status", "ok");
-                }
-                Err(e) => {
-                    error!(error = %e, "finalize failed, returning result without persistence");
-                    span.record("status", "error");
-                }
-            }
-        } else {
-            debug!("no session store, skipping finalize");
-            span.record("status", "skipped");
-        }
-        #[expect(
-            clippy::cast_possible_truncation,
-            reason = "stage duration fits in u64"
-        )]
-        {
-            span.record("duration_ms", start.elapsed().as_millis() as u64);
-        }
-        crate::metrics::record_stage(&config.id, "finalize", start.elapsed().as_secs_f64());
-        stages_completed += 1;
-    }
+    run_finalize_stage(config, &input, &result, session_store).await;
+    stages_completed += 1;
 
     if !result.tool_calls.is_empty() {
         crate::instinct::record_observations(&result.tool_calls, &input.content, &config.id);
@@ -759,6 +472,344 @@ pub async fn run_pipeline(
     );
 
     Ok(result)
+}
+
+/// Context stage — assemble bootstrap and system prompt.
+async fn run_context_stage(
+    oikos: &Oikos,
+    config: &NousConfig,
+    pipeline_config: &PipelineConfig,
+    ctx: &mut PipelineContext,
+    extra_bootstrap: Vec<BootstrapSection>,
+) -> error::Result<()> {
+    let span = info_span!(
+        "pipeline_stage",
+        stage = "context",
+        duration_ms = tracing::field::Empty,
+        status = tracing::field::Empty
+    );
+    let _guard = span.enter();
+    let start = Instant::now();
+    assemble_context_with_extra(oikos, config, pipeline_config, ctx, extra_bootstrap)
+        .await
+        .inspect_err(|_| {
+            crate::metrics::record_error(&config.id, "context", "assembly_failed");
+        })?;
+    record_stage_duration(&span, &start);
+    span.record("status", "ok");
+    crate::metrics::record_stage(&config.id, "context", start.elapsed().as_secs_f64());
+    Ok(())
+}
+
+/// Recall stage — retrieve relevant knowledge from vector/BM25 search.
+async fn run_recall_stage(
+    config: &NousConfig,
+    pipeline_config: &PipelineConfig,
+    ctx: &mut PipelineContext,
+    content: &str,
+    embedding_provider: Option<&dyn EmbeddingProvider>,
+    vector_search: Option<&dyn crate::recall::VectorSearch>,
+    text_search: Option<&dyn crate::recall::TextSearch>,
+) {
+    let span = info_span!(
+        "pipeline_stage",
+        stage = "recall",
+        duration_ms = tracing::field::Empty,
+        status = tracing::field::Empty
+    );
+    let _guard = span.enter();
+    let start = Instant::now();
+    let recall_timeout_secs = pipeline_config.stage_budget.recall_secs;
+    let is_mock_embedding =
+        embedding_provider.is_some_and(|ep| ep.model_name() == "mock-embedding");
+    #[expect(
+        clippy::cast_sign_loss,
+        reason = "remaining_tokens is positive after context assembly"
+    )]
+    let budget = ctx.remaining_tokens.max(0) as u64;
+
+    // NOTE: BM25-only fallback when mock embedding provider is in use.
+    // Vector recall would produce meaningless results from hash-based embeddings.
+    if is_mock_embedding {
+        if let Some(ts) = text_search {
+            debug!("mock embedding provider — using BM25-only recall");
+            let recall_stage = crate::recall::RecallStage::new(config.recall.clone());
+            let result = recall_stage.run_bm25(content, &config.id, ts, budget);
+            apply_recall_result(result, ctx, &span);
+        } else {
+            debug!("recall skipped: mock embedding provider with no text search");
+            span.record("status", "skipped");
+        }
+    } else if let (Some(ep), Some(vs)) = (embedding_provider, vector_search) {
+        let recall_stage = crate::recall::RecallStage::new(config.recall.clone());
+
+        let recall_result_opt = if recall_timeout_secs > 0 {
+            match tokio::time::timeout(Duration::from_secs(u64::from(recall_timeout_secs)), async {
+                recall_stage.run(content, &config.id, ep, vs, budget)
+            })
+            .await
+            {
+                Ok(result) => Some(result),
+                Err(_elapsed) => {
+                    warn!(
+                        timeout_secs = recall_timeout_secs,
+                        "recall stage timed out, continuing without recalled knowledge"
+                    );
+                    span.record("status", "timeout");
+                    None
+                }
+            }
+        } else {
+            Some(recall_stage.run(content, &config.id, ep, vs, budget))
+        };
+
+        if let Some(result) = recall_result_opt {
+            apply_recall_result(result, ctx, &span);
+        }
+    } else {
+        debug!("recall skipped: embedding provider or vector search not configured");
+        span.record("status", "skipped");
+    }
+    record_stage_duration(&span, &start);
+    crate::metrics::record_stage(&config.id, "recall", start.elapsed().as_secs_f64());
+}
+
+/// History stage — load conversation history within token budget.
+async fn run_history_stage(
+    config: &NousConfig,
+    ctx: &mut PipelineContext,
+    input: &PipelineInput,
+    session_store: Option<&Mutex<SessionStore>>,
+) -> error::Result<()> {
+    let span = info_span!(
+        "pipeline_stage",
+        stage = "history",
+        duration_ms = tracing::field::Empty,
+        status = tracing::field::Empty
+    );
+    let _guard = span.enter();
+    let start = Instant::now();
+
+    // NOTE: Waterfall — unused system-prompt budget flows into the history budget
+    // so tokens not consumed by bootstrap or recall are not wasted.
+    ctx.history_budget += ctx.remaining_tokens.max(0);
+
+    let history_config = HistoryConfig::default();
+    if let Some(store_mutex) = session_store {
+        // WHY: guard scoped and dropped before execute .await
+        let store = store_mutex.lock().await;
+        let (messages, hist_result) = history::load_history(
+            &store,
+            &input.session.id,
+            ctx.history_budget,
+            &history_config,
+            &input.content,
+        )
+        .inspect_err(|_| crate::metrics::record_error(&config.id, "history", "load_failed"))?;
+        ctx.messages = messages;
+        ctx.history_budget -= hist_result.tokens_consumed;
+        ctx.history_result = Some(hist_result);
+    } else {
+        #[expect(clippy::cast_possible_wrap, reason = "message length fits in i64")]
+        let token_estimate = (input.content.len() as i64 + 3) / 4;
+        ctx.messages.push(PipelineMessage {
+            role: "user".to_owned(),
+            content: input.content.clone(),
+            token_estimate,
+        });
+    }
+    record_stage_duration(&span, &start);
+    span.record("status", "ok");
+    crate::metrics::record_stage(&config.id, "history", start.elapsed().as_secs_f64());
+    Ok(())
+}
+
+/// Guard stage — check rate limits, loop detection, safety.
+fn run_guard_stage(session: &SessionState, config: &NousConfig) -> error::Result<()> {
+    let span = info_span!(
+        "pipeline_stage",
+        stage = "guard",
+        duration_ms = tracing::field::Empty,
+        status = tracing::field::Empty
+    );
+    let _guard = span.enter();
+    let start = Instant::now();
+    let guard = check_guard(session, config);
+    record_stage_duration(&span, &start);
+    crate::metrics::record_stage(&config.id, "guard", start.elapsed().as_secs_f64());
+    match guard {
+        GuardResult::Allow => {
+            span.record("status", "ok");
+            Ok(())
+        }
+        GuardResult::RateLimited { retry_after_ms } => {
+            span.record("status", "error");
+            crate::metrics::record_error(&config.id, "guard", "rate_limited");
+            Err(error::GuardRejectedSnafu {
+                reason: format!("rate limited, retry after {retry_after_ms}ms"),
+            }
+            .build())
+        }
+        GuardResult::LoopDetected { pattern } => {
+            span.record("status", "error");
+            crate::metrics::record_error(&config.id, "guard", "loop_detected");
+            Err(error::LoopDetectedSnafu {
+                iterations: 0u32,
+                pattern,
+            }
+            .build())
+        }
+        GuardResult::Rejected { reason } => {
+            span.record("status", "error");
+            crate::metrics::record_error(&config.id, "guard", "rejected");
+            Err(error::GuardRejectedSnafu { reason }.build())
+        }
+    }
+}
+
+/// Execute stage — call LLM with optional timeout and streaming.
+#[expect(
+    clippy::too_many_arguments,
+    reason = "stage receives all pipeline dependencies"
+)]
+async fn run_execute_stage(
+    config: &NousConfig,
+    pipeline_config: &PipelineConfig,
+    ctx: &PipelineContext,
+    input: &PipelineInput,
+    providers: &ProviderRegistry,
+    tools: &ToolRegistry,
+    tool_ctx: &ToolContext,
+    stream_tx: Option<&mpsc::Sender<TurnStreamEvent>>,
+    pipeline_start: Instant,
+    total_timeout: Option<Duration>,
+) -> error::Result<TurnResult> {
+    let span = info_span!(
+        "pipeline_stage",
+        stage = "execute",
+        duration_ms = tracing::field::Empty,
+        status = tracing::field::Empty,
+        tokens_in = tracing::field::Empty,
+        tokens_out = tracing::field::Empty,
+    );
+    let _guard = span.enter();
+    let start = Instant::now();
+
+    // NOTE: prefer per-stage budget, fall back to remaining time from total pipeline budget, whichever is tighter.
+    let execute_secs = pipeline_config.stage_budget.execute_secs;
+    let effective_execute_timeout = match (execute_secs > 0, total_timeout) {
+        (true, Some(total)) => {
+            let stage = Duration::from_secs(u64::from(execute_secs));
+            let remaining = total.saturating_sub(pipeline_start.elapsed());
+            Some(stage.min(remaining))
+        }
+        (true, None) => Some(Duration::from_secs(u64::from(execute_secs))),
+        (false, Some(total)) => Some(total.saturating_sub(pipeline_start.elapsed())),
+        (false, None) => None,
+    };
+
+    let execute_fut = async {
+        if let Some(tx) = stream_tx {
+            crate::execute::execute_streaming(
+                ctx,
+                &input.session,
+                config,
+                providers,
+                tools,
+                tool_ctx,
+                tx,
+            )
+            .await
+        } else {
+            crate::execute::execute(ctx, &input.session, config, providers, tools, tool_ctx).await
+        }
+    };
+
+    let result = if let Some(timeout_dur) = effective_execute_timeout {
+        match tokio::time::timeout(timeout_dur, execute_fut).await {
+            Ok(res) => res.inspect_err(|_| {
+                crate::metrics::record_error(&config.id, "execute", "pipeline_error");
+            })?,
+            Err(_elapsed) => {
+                let secs = execute_secs.max(pipeline_config.stage_budget.total_secs);
+                span.record("status", "timeout");
+                crate::metrics::record_error(&config.id, "execute", "timeout");
+                return Err(error::PipelineTimeoutSnafu {
+                    stage: "execute",
+                    timeout_secs: secs,
+                }
+                .build());
+            }
+        }
+    } else {
+        execute_fut.await.inspect_err(|_| {
+            crate::metrics::record_error(&config.id, "execute", "pipeline_error");
+        })?
+    };
+
+    record_stage_duration(&span, &start);
+    span.record("tokens_in", result.usage.input_tokens);
+    span.record("tokens_out", result.usage.output_tokens);
+    span.record("status", "ok");
+    crate::metrics::record_stage(&config.id, "execute", start.elapsed().as_secs_f64());
+    Ok(result)
+}
+
+/// Finalize stage — persist turn results to durable storage.
+async fn run_finalize_stage(
+    config: &NousConfig,
+    input: &PipelineInput,
+    result: &TurnResult,
+    session_store: Option<&Mutex<SessionStore>>,
+) {
+    let span = info_span!(
+        "pipeline_stage",
+        stage = "finalize",
+        duration_ms = tracing::field::Empty,
+        status = tracing::field::Empty
+    );
+    let _guard = span.enter();
+    let start = Instant::now();
+    if let Some(store_mutex) = session_store {
+        let store = store_mutex.lock().await;
+        let finalize_config = crate::finalize::FinalizeConfig::default();
+        match crate::finalize::finalize(
+            &store,
+            &input.session,
+            &input.content,
+            result,
+            &finalize_config,
+        ) {
+            Ok(fr) => {
+                debug!(
+                    messages = fr.messages_persisted,
+                    usage = fr.usage_recorded,
+                    "finalize complete"
+                );
+                span.record("status", "ok");
+            }
+            Err(e) => {
+                error!(error = %e, "finalize failed, returning result without persistence");
+                span.record("status", "error");
+            }
+        }
+    } else {
+        debug!("no session store, skipping finalize");
+        span.record("status", "skipped");
+    }
+    record_stage_duration(&span, &start);
+    crate::metrics::record_stage(&config.id, "finalize", start.elapsed().as_secs_f64());
+}
+
+/// Record elapsed duration on a pipeline stage span.
+fn record_stage_duration(span: &tracing::Span, start: &Instant) {
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "stage duration fits in u64"
+    )]
+    {
+        span.record("duration_ms", start.elapsed().as_millis() as u64);
+    }
 }
 
 /// Apply a recall result (vector or BM25) to the pipeline context.

--- a/crates/nous/src/spawn_svc.rs
+++ b/crates/nous/src/spawn_svc.rs
@@ -48,6 +48,8 @@ impl SpawnServiceImpl {
 }
 
 impl SpawnService for SpawnServiceImpl {
+    // NOTE(#940): 130 lines — sequential ephemeral-actor lifecycle: build config, spawn
+    // actor, run single turn, teardown. Splitting would fragment a cohesive lifecycle.
     #[expect(clippy::too_many_lines, reason = "spawn setup requires many steps")]
     fn spawn_and_run(
         &self,

--- a/crates/organon/src/builtins/research.rs
+++ b/crates/organon/src/builtins/research.rs
@@ -90,6 +90,8 @@ async fn validate_url_not_internal(url_str: &str) -> std::result::Result<(), Str
 struct WebFetchExecutor;
 
 impl ToolExecutor for WebFetchExecutor {
+    // NOTE(#940): 109 lines — single SSRF-safe HTTP fetch operation: validate URL,
+    // build client, send response, process response. One cohesive I/O operation.
     fn execute<'a>(
         &'a self,
         input: &'a ToolInput,
@@ -201,6 +203,9 @@ impl ToolExecutor for WebFetchExecutor {
     }
 }
 
+// NOTE(#940): 100 lines — byte-level HTML tag stripping state machine. The sequential
+// character-by-character logic is inherently one operation; splitting would break the
+// state machine's flow.
 /// Strip HTML tags and collapse whitespace for readable text extraction.
 fn strip_html_tags(html: &str) -> String {
     let mut result = String::with_capacity(html.len() / 2);

--- a/crates/pylon/src/handlers/sessions/streaming.rs
+++ b/crates/pylon/src/handlers/sessions/streaming.rs
@@ -46,6 +46,9 @@ use super::{find_session, resolve_session};
     ),
     security(("bearer_auth" = []))
 )]
+// NOTE(#940): ~89 lines excluding match arms — single SSE handler with preflight checks,
+// idempotency guard, and spawned turn task. The match arms account for the bulk of raw
+// line count; the control flow is a single cohesive request lifecycle.
 #[expect(
     clippy::too_many_lines,
     reason = "handler includes preflight checks, idempotency guard, and spawned turn task"
@@ -249,6 +252,8 @@ pub async fn send_message(
     ),
     security(("bearer_auth" = []))
 )]
+// NOTE(#940): ~109 lines excluding match arms — sequential SSE bridge setup with
+// turn spawn and completion event emission. Match arms inflate raw line count.
 #[expect(
     clippy::too_many_lines,
     reason = "streaming bridge setup is inherently sequential"

--- a/crates/pylon/src/router.rs
+++ b/crates/pylon/src/router.rs
@@ -25,6 +25,8 @@ use crate::security::SecurityConfig;
 use crate::state::AppState;
 
 /// Build the Axum router with all routes and middleware.
+// NOTE(#940): 130 lines — route and middleware layer assembly where ordering matters.
+// Extraction would obscure the middleware stack ordering that is critical for correctness.
 #[expect(
     clippy::too_many_lines,
     reason = "router construction requires assembling all routes and ordered middleware layers; extraction would obscure the stack ordering"


### PR DESCRIPTION
## Summary

- **Decomposed `run_pipeline`** (389→~100 lines) in `nous/pipeline.rs` into 6 stage helpers + a timing utility, eliminating the largest SRP violation in the codebase
- **Decomposed `execute`/`execute_streaming`** in `nous/execute/mod.rs` by extracting 3 shared helpers (`resolve_provider_checked`, `resolve_active_server_tools`, `process_response_blocks`), reducing duplication and bringing both under 150 lines
- **Audited 19 functions** over 80 lines across `nous`, `organon`, and `pylon` crates — 10 functions intentionally left large with `NOTE(#940)` comments explaining why splitting would hurt readability

### Observations

| Function | Crate | Lines | Decision | Rationale |
|----------|-------|-------|----------|-----------|
| `run_pipeline` | nous | 389→~100 | **Decomposed** | 6 unrelated pipeline stages mixed in one function |
| `execute` | nous | 189→~95 | **Decomposed** | Shared provider/response logic extracted to helpers |
| `execute_streaming` | nous | 202→~140 | **Decomposed** | Same shared helpers; still needs `#[expect]` |
| `spawn_and_run` | nous | 130 | Left | Sequential ephemeral-actor lifecycle |
| `finalize` | nous | 120 | Left | Sequential persistence pipeline |
| `run_skill_extraction` | nous | 113 | Left | Extract→persist→handle flow |
| `spawn_pipeline_task` | nous | 113 | Left | Setup + spawn single task |
| `run` (actor loop) | nous | 92 | Left | `tokio::select!` message loop |
| `build_router` | pylon | 130 | Left | Middleware stack ordering matters |
| `send_message` | pylon | 176 (~89 excl. match) | Left | SSE handler; match arms inflate count |
| `stream_turn` | pylon | 189 (~109 excl. match) | Left | SSE bridge; match arms inflate count |
| `WebFetchExecutor::execute` | organon | 109 | Left | Single SSRF-safe I/O operation |
| `strip_html_tags` | organon | 100 | Left | Byte-level state machine |

## Test plan

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — zero warnings
- [x] `cargo test --workspace` — all tests pass
- [x] No function in hot-path crates exceeds 150 lines (excluding match arms)
- [x] All intentionally-large functions have `NOTE(#940)` comments

Closes #940

🤖 Generated with [Claude Code](https://claude.com/claude-code)