### PR TITLE
docs(theatron): research Dioxus state architecture for desktop UI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6170,6 +6170,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "theatron-desktop"
+version = "0.10.0"
+dependencies = [
+ "compact_str",
+ "serde",
+ "theatron-core",
+]
+
+[[package]]
 name = "theatron-tui"
 version = "0.10.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ members = [
     "crates/thesauros",
     "crates/theatron/core",
     "crates/theatron/tui",
+    "crates/theatron/desktop",
 ]
 
 [workspace.package]

--- a/crates/theatron/desktop/Cargo.toml
+++ b/crates/theatron/desktop/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "theatron-desktop"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+description = "Dioxus desktop state model for the Aletheia UI"
+publish = false
+
+[dependencies]
+theatron-core = { path = "../core" }
+compact_str = { workspace = true }
+serde = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/theatron/desktop/src/lib.rs
+++ b/crates/theatron/desktop/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod state;

--- a/crates/theatron/desktop/src/state/agent.rs
+++ b/crates/theatron/desktop/src/state/agent.rs
@@ -1,0 +1,118 @@
+//! Agent registry and connection status types.
+//!
+//! In Dioxus, `Signal<Vec<AgentEntry>>` lives in context. The sidebar reads it.
+//! `Signal<Option<NousId>>` tracks the focused agent. `Signal<ConnectionStatus>`
+//! drives the status bar indicator.
+
+use super::chat::NousId;
+
+/// An agent in the registry, displayed in the sidebar.
+#[derive(Debug, Clone)]
+pub struct AgentEntry {
+    pub id: NousId,
+    pub name: String,
+    pub emoji: Option<String>,
+    pub model: Option<String>,
+    pub status: AgentStatus,
+    pub active_tool: Option<String>,
+    pub has_notification: bool,
+}
+
+/// Agent lifecycle status, driven by SSE `StatusUpdate` events.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum AgentStatus {
+    #[default]
+    Idle,
+    Working,
+    Streaming,
+    Compacting,
+}
+
+impl AgentStatus {
+    /// Short label for status bar display.
+    #[must_use]
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Idle => "idle",
+            Self::Working => "working",
+            Self::Streaming => "streaming",
+            Self::Compacting => "compacting",
+        }
+    }
+
+    /// Whether the agent is doing work (any non-idle state).
+    #[must_use]
+    pub fn is_busy(self) -> bool {
+        !matches!(self, Self::Idle)
+    }
+}
+
+/// SSE connection health, shown in the status bar.
+#[non_exhaustive]
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub enum ConnectionStatus {
+    /// Connected and receiving events.
+    #[default]
+    Connected,
+    /// Disconnected, attempting reconnect.
+    Reconnecting {
+        /// Number of reconnect attempts so far.
+        attempt: u32,
+    },
+    /// Permanently failed (auth error, server gone).
+    Failed { reason: String },
+}
+
+impl ConnectionStatus {
+    #[must_use]
+    pub fn is_connected(&self) -> bool {
+        matches!(self, Self::Connected)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn agent_status_default_is_idle() {
+        assert_eq!(AgentStatus::default(), AgentStatus::Idle);
+    }
+
+    #[test]
+    fn agent_status_label() {
+        assert_eq!(AgentStatus::Idle.label(), "idle");
+        assert_eq!(AgentStatus::Working.label(), "working");
+        assert_eq!(AgentStatus::Streaming.label(), "streaming");
+        assert_eq!(AgentStatus::Compacting.label(), "compacting");
+    }
+
+    #[test]
+    fn agent_status_is_busy() {
+        assert!(!AgentStatus::Idle.is_busy());
+        assert!(AgentStatus::Working.is_busy());
+        assert!(AgentStatus::Streaming.is_busy());
+        assert!(AgentStatus::Compacting.is_busy());
+    }
+
+    #[test]
+    fn connection_status_default_connected() {
+        let status = ConnectionStatus::default();
+        assert!(status.is_connected());
+    }
+
+    #[test]
+    fn connection_status_reconnecting() {
+        let status = ConnectionStatus::Reconnecting { attempt: 3 };
+        assert!(!status.is_connected());
+    }
+
+    #[test]
+    fn connection_status_failed() {
+        let status = ConnectionStatus::Failed {
+            reason: "auth expired".to_string(),
+        };
+        assert!(!status.is_connected());
+    }
+}

--- a/crates/theatron/desktop/src/state/app.rs
+++ b/crates/theatron/desktop/src/state/app.rs
@@ -1,0 +1,232 @@
+//! Root application state.
+//!
+//! In Dioxus, `Store<AppState>` is provided via `use_context_provider` at the
+//! app root. Child components project into individual fields. This replaces
+//! the monolithic `App` struct from the ratatui TUI.
+
+use super::agent::{AgentEntry, ConnectionStatus};
+use super::chat::NousId;
+
+/// Root state provided to the entire component tree.
+///
+/// In Dioxus each field maps to a signal or sub-store:
+/// - `agents`, `focused_agent`, `overlay`, `connection` become `Signal<_>` fields.
+/// - `tabs` wraps `Signal<TabBar>` (same concept as TUI's `TabBar`).
+/// - Per-tab chat state lives in `AgentChatState` stores owned by tab components,
+///   not in `AppState` directly.
+#[derive(Debug, Clone)]
+pub struct AppState {
+    /// All registered agents, fetched on startup and updated via SSE.
+    pub agents: Vec<AgentEntry>,
+    /// Currently focused agent. `None` before first agent load.
+    pub focused_agent: Option<NousId>,
+    /// Tab bar managing multiple open conversations.
+    pub tabs: TabBar,
+    /// SSE connection health.
+    pub connection: ConnectionStatus,
+    /// Modal overlay (help, pickers, approvals). `None` when no overlay.
+    pub overlay: Option<Overlay>,
+    /// Sidebar visibility toggle.
+    pub sidebar_visible: bool,
+}
+
+impl Default for AppState {
+    fn default() -> Self {
+        Self {
+            agents: Vec::new(),
+            focused_agent: None,
+            tabs: TabBar::new(),
+            connection: ConnectionStatus::default(),
+            overlay: None,
+            sidebar_visible: true,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tab bar (simplified from TUI's TabBar, state lives in AgentChatState)
+// ---------------------------------------------------------------------------
+
+/// Unique tab identifier, distinct from session IDs.
+pub type TabId = u64;
+
+/// Metadata for a tab. The actual chat state lives in `AgentChatState`,
+/// owned by the tab's component, not here.
+#[derive(Debug, Clone)]
+pub struct TabEntry {
+    pub id: TabId,
+    pub agent_id: NousId,
+    pub title: String,
+    pub unread: bool,
+}
+
+/// Tab bar tracking open tabs and active index.
+#[derive(Debug, Clone)]
+pub struct TabBar {
+    pub tabs: Vec<TabEntry>,
+    pub active: usize,
+    next_id: TabId,
+}
+
+impl TabBar {
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            tabs: Vec::new(),
+            active: 0,
+            next_id: 1,
+        }
+    }
+
+    /// Create a new tab, returning its index.
+    pub fn create(&mut self, agent_id: NousId, title: impl Into<String>) -> usize {
+        let id = self.next_id;
+        self.next_id += 1;
+        self.tabs.push(TabEntry {
+            id,
+            agent_id,
+            title: title.into(),
+            unread: false,
+        });
+        self.tabs.len() - 1
+    }
+
+    /// Close a tab by index. Returns the removed entry.
+    pub fn close(&mut self, index: usize) -> Option<TabEntry> {
+        if index >= self.tabs.len() {
+            return None;
+        }
+        let entry = self.tabs.remove(index);
+        if self.tabs.is_empty() {
+            self.active = 0;
+        } else if self.active >= self.tabs.len() {
+            self.active = self.tabs.len() - 1;
+        } else if self.active > index {
+            self.active -= 1;
+        }
+        Some(entry)
+    }
+
+    /// Number of open tabs.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.tabs.len()
+    }
+
+    /// Whether the tab bar is empty.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.tabs.is_empty()
+    }
+
+    /// Get the active tab entry.
+    #[must_use]
+    pub fn active_tab(&self) -> Option<&TabEntry> {
+        self.tabs.get(self.active)
+    }
+}
+
+impl Default for TabBar {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Overlay
+// ---------------------------------------------------------------------------
+
+/// Modal overlays that block interaction with the main UI.
+#[non_exhaustive]
+#[derive(Debug, Clone)]
+pub enum Overlay {
+    Help,
+    AgentPicker { cursor: usize },
+    SessionPicker { cursor: usize, show_archived: bool },
+    ToolApproval(ToolApprovalOverlay),
+    Settings,
+}
+
+/// Tool approval dialog data.
+#[derive(Debug, Clone)]
+pub struct ToolApprovalOverlay {
+    pub tool_name: String,
+    pub input_json: String,
+    pub risk: String,
+    pub reason: String,
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "test assertions may panic on failure")]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn app_state_default() {
+        let state = AppState::default();
+        assert!(state.agents.is_empty());
+        assert!(state.focused_agent.is_none());
+        assert!(state.tabs.is_empty());
+        assert!(state.connection.is_connected());
+        assert!(state.overlay.is_none());
+        assert!(state.sidebar_visible);
+    }
+
+    #[test]
+    fn tab_bar_create_and_close() {
+        let mut bar = TabBar::new();
+        let idx = bar.create(NousId::from("syn"), "main");
+        assert_eq!(idx, 0);
+        assert_eq!(bar.len(), 1);
+        assert!(!bar.is_empty());
+
+        let entry = bar.close(0);
+        assert!(entry.is_some());
+        assert!(bar.is_empty());
+    }
+
+    #[test]
+    fn tab_bar_close_adjusts_active() {
+        let mut bar = TabBar::new();
+        bar.create(NousId::from("syn"), "a");
+        bar.create(NousId::from("syn"), "b");
+        bar.create(NousId::from("syn"), "c");
+        bar.active = 2;
+        bar.close(0); // remove "a", active should adjust from 2 to 1
+        assert_eq!(bar.active, 1);
+    }
+
+    #[test]
+    fn tab_bar_close_out_of_range() {
+        let mut bar = TabBar::new();
+        bar.create(NousId::from("syn"), "a");
+        assert!(bar.close(5).is_none());
+        assert_eq!(bar.len(), 1);
+    }
+
+    #[test]
+    fn tab_bar_active_tab() {
+        let mut bar = TabBar::new();
+        bar.create(NousId::from("syn"), "first");
+        let tab = bar.active_tab();
+        assert!(tab.is_some());
+        assert_eq!(tab.unwrap().title, "first");
+    }
+
+    #[test]
+    fn tab_bar_empty_active_tab_is_none() {
+        let bar = TabBar::new();
+        assert!(bar.active_tab().is_none());
+    }
+
+    #[test]
+    fn tab_ids_are_unique() {
+        let mut bar = TabBar::new();
+        bar.create(NousId::from("a"), "t1");
+        bar.create(NousId::from("b"), "t2");
+        bar.create(NousId::from("c"), "t3");
+        let ids: Vec<TabId> = bar.tabs.iter().map(|t| t.id).collect();
+        let unique: std::collections::HashSet<TabId> = ids.iter().copied().collect();
+        assert_eq!(ids.len(), unique.len());
+    }
+}

--- a/crates/theatron/desktop/src/state/chat.rs
+++ b/crates/theatron/desktop/src/state/chat.rs
@@ -1,0 +1,522 @@
+//! Per-agent chat state for a single tab/conversation.
+//!
+//! `AgentChatState` owns everything a tab needs: messages, streaming turn,
+//! input buffer, scroll position, operations pane, and error state. In Dioxus
+//! this maps to `Store<AgentChatState>` with field-level subscriptions.
+
+use std::time::Instant;
+
+use compact_str::CompactString;
+
+// ---------------------------------------------------------------------------
+// Domain ID newtypes (mirrors theatron-tui id.rs)
+// ---------------------------------------------------------------------------
+
+/// Agent identifier.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct NousId(CompactString);
+
+impl NousId {
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl<T: Into<CompactString>> From<T> for NousId {
+    fn from(v: T) -> Self {
+        Self(v.into())
+    }
+}
+
+/// Session key.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct SessionId(CompactString);
+
+impl SessionId {
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl<T: Into<CompactString>> From<T> for SessionId {
+    fn from(v: T) -> Self {
+        Self(v.into())
+    }
+}
+
+/// Turn identifier within a session.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct TurnId(CompactString);
+
+impl TurnId {
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl<T: Into<CompactString>> From<T> for TurnId {
+    fn from(v: T) -> Self {
+        Self(v.into())
+    }
+}
+
+/// Tool execution identifier.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ToolId(CompactString);
+
+impl ToolId {
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl<T: Into<CompactString>> From<T> for ToolId {
+    fn from(v: T) -> Self {
+        Self(v.into())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Chat message (finalized, immutable after append)
+// ---------------------------------------------------------------------------
+
+/// A finalized chat message in the conversation history.
+#[derive(Debug, Clone)]
+pub struct ChatMessage {
+    pub role: MessageRole,
+    pub text: String,
+    pub timestamp: Option<String>,
+    pub model: Option<String>,
+    pub tool_calls: Vec<ToolCallSummary>,
+}
+
+/// Message author role.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MessageRole {
+    User,
+    Assistant,
+    System,
+    ToolResult,
+}
+
+/// Summary of a completed tool call, attached to an assistant message.
+#[derive(Debug, Clone)]
+pub struct ToolCallSummary {
+    pub name: String,
+    pub tool_id: ToolId,
+    pub duration_ms: Option<u64>,
+    pub is_error: bool,
+}
+
+// ---------------------------------------------------------------------------
+// Streaming turn (mutable, in-progress)
+// ---------------------------------------------------------------------------
+
+/// Current streaming turn state. Only one turn streams at a time per tab.
+#[non_exhaustive]
+#[derive(Debug, Clone, Default)]
+pub enum StreamingTurn {
+    /// No active streaming turn.
+    #[default]
+    Idle,
+    /// Turn in progress, accumulating deltas.
+    Active {
+        turn_id: TurnId,
+        text: String,
+        thinking: String,
+        tool_calls: Vec<LiveToolCall>,
+        pending_approval: Option<ToolApproval>,
+    },
+    /// Abort requested, waiting for server acknowledgment.
+    Aborting { turn_id: TurnId, reason: String },
+}
+
+impl StreamingTurn {
+    /// Whether a turn is actively streaming.
+    #[must_use]
+    pub fn is_active(&self) -> bool {
+        matches!(self, Self::Active { .. })
+    }
+
+    /// The turn ID if streaming or aborting.
+    #[must_use]
+    pub fn turn_id(&self) -> Option<&TurnId> {
+        match self {
+            Self::Idle => None,
+            Self::Active { turn_id, .. } | Self::Aborting { turn_id, .. } => Some(turn_id),
+        }
+    }
+}
+
+/// A tool call during a streaming turn, tracking its lifecycle.
+#[non_exhaustive]
+#[derive(Debug, Clone)]
+pub enum LiveToolCall {
+    /// Tool is executing.
+    Running {
+        name: String,
+        tool_id: ToolId,
+        started_at: Instant,
+    },
+    /// Tool needs user approval before proceeding.
+    AwaitingApproval {
+        name: String,
+        tool_id: ToolId,
+        approval: ToolApproval,
+    },
+    /// Tool finished (success or failure).
+    Completed {
+        name: String,
+        tool_id: ToolId,
+        duration_ms: u64,
+        is_error: bool,
+    },
+}
+
+impl LiveToolCall {
+    /// The tool name regardless of lifecycle phase.
+    #[must_use]
+    pub fn name(&self) -> &str {
+        match self {
+            Self::Running { name, .. }
+            | Self::AwaitingApproval { name, .. }
+            | Self::Completed { name, .. } => name,
+        }
+    }
+
+    /// The tool ID regardless of lifecycle phase.
+    #[must_use]
+    pub fn tool_id(&self) -> &ToolId {
+        match self {
+            Self::Running { tool_id, .. }
+            | Self::AwaitingApproval { tool_id, .. }
+            | Self::Completed { tool_id, .. } => tool_id,
+        }
+    }
+}
+
+/// Pending tool approval request.
+#[derive(Debug, Clone)]
+pub struct ToolApproval {
+    pub tool_name: String,
+    pub tool_id: ToolId,
+    pub input_json: String,
+    pub risk: String,
+    pub reason: String,
+}
+
+// ---------------------------------------------------------------------------
+// Input and scroll state
+// ---------------------------------------------------------------------------
+
+/// Input buffer state for the chat input area.
+#[derive(Debug, Clone, Default)]
+pub struct InputState {
+    pub text: String,
+    pub cursor: usize,
+    pub history: Vec<String>,
+    pub history_index: Option<usize>,
+}
+
+/// Scroll position for a chat view.
+#[derive(Debug, Clone, Default)]
+pub struct ScrollState {
+    pub offset: usize,
+    pub auto_scroll: bool,
+}
+
+// ---------------------------------------------------------------------------
+// Operations pane state
+// ---------------------------------------------------------------------------
+
+/// The operations pane shows thinking, tool calls, and diffs during a turn.
+#[derive(Debug, Clone)]
+pub struct OperationsPane {
+    pub visible: bool,
+    pub width_pct: u16,
+    pub focused: bool,
+    pub scroll_offset: usize,
+    pub selected_item: Option<usize>,
+    pub thinking_text: String,
+    pub thinking_collapsed: bool,
+    pub tool_calls: Vec<OpsToolEntry>,
+    pub diffs: Vec<DiffEntry>,
+}
+
+impl Default for OperationsPane {
+    fn default() -> Self {
+        Self {
+            visible: false,
+            width_pct: 40,
+            focused: false,
+            scroll_offset: 0,
+            selected_item: None,
+            thinking_text: String::new(),
+            thinking_collapsed: false,
+            tool_calls: Vec::new(),
+            diffs: Vec::new(),
+        }
+    }
+}
+
+/// A tool call entry in the operations pane.
+#[derive(Debug, Clone)]
+pub struct OpsToolEntry {
+    pub name: String,
+    pub input_json: Option<String>,
+    pub output: Option<String>,
+    pub status: OpsToolStatus,
+    pub duration_ms: Option<u64>,
+    pub expanded: bool,
+}
+
+/// Tool call status in the operations pane.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OpsToolStatus {
+    Running,
+    Complete,
+    Failed,
+}
+
+/// A file diff extracted from tool output.
+#[derive(Debug, Clone)]
+pub struct DiffEntry {
+    pub file_path: String,
+    pub additions: Vec<String>,
+    pub deletions: Vec<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Chat error
+// ---------------------------------------------------------------------------
+
+/// Errors that display in the chat view.
+#[non_exhaustive]
+#[derive(Debug, Clone)]
+pub enum ChatError {
+    /// SSE stream broke or server returned an error during a turn.
+    StreamFailed { message: String },
+    /// History fetch failed (network, auth, not found).
+    HistoryLoadFailed { message: String },
+    /// Session creation failed.
+    SessionCreateFailed { message: String },
+    /// Lost connection to the server.
+    Disconnected,
+}
+
+impl std::fmt::Display for ChatError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::StreamFailed { message } => write!(f, "stream failed: {message}"),
+            Self::HistoryLoadFailed { message } => write!(f, "history load failed: {message}"),
+            Self::SessionCreateFailed { message } => {
+                write!(f, "session creation failed: {message}")
+            }
+            Self::Disconnected => write!(f, "disconnected from server"),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Per-agent chat state (one per tab)
+// ---------------------------------------------------------------------------
+
+/// Complete state for one agent chat tab. In Dioxus, this is the value inside
+/// `Store<AgentChatState>`. Each tab component owns its own store instance.
+#[derive(Debug, Clone)]
+pub struct AgentChatState {
+    /// Which agent this tab belongs to.
+    pub agent_id: NousId,
+    /// Active session within this tab.
+    pub session_id: Option<SessionId>,
+    /// Generation counter: incremented on every session/agent switch.
+    /// Stale API responses compare against this to avoid overwriting
+    /// the wrong session's messages.
+    pub generation: u64,
+    /// Finalized conversation history.
+    pub messages: Vec<ChatMessage>,
+    /// In-progress streaming turn.
+    pub streaming: StreamingTurn,
+    /// Chat input buffer.
+    pub input: InputState,
+    /// Scroll position.
+    pub scroll: ScrollState,
+    /// Right-side operations pane.
+    pub ops: OperationsPane,
+    /// Current error, if any. Displayed in the chat view.
+    pub error: Option<ChatError>,
+    /// Whether this tab has unseen activity (background turn completed).
+    pub has_notification: bool,
+}
+
+impl AgentChatState {
+    /// Create a new empty chat state for an agent.
+    #[must_use]
+    pub fn new(agent_id: NousId) -> Self {
+        Self {
+            agent_id,
+            session_id: None,
+            generation: 0,
+            messages: Vec::new(),
+            streaming: StreamingTurn::Idle,
+            input: InputState::default(),
+            scroll: ScrollState::default(),
+            ops: OperationsPane::default(),
+            error: None,
+            has_notification: false,
+        }
+    }
+
+    /// Bump the generation counter. Call on every session or agent switch.
+    /// Returns the new generation for passing to async fetches.
+    #[must_use]
+    pub fn bump_generation(&mut self) -> u64 {
+        self.generation += 1;
+        self.generation
+    }
+
+    /// Check whether a fetch result matches the current generation.
+    #[must_use]
+    pub fn is_current_generation(&self, expected: u64) -> bool {
+        self.generation == expected
+    }
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "test assertions may panic on failure")]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_agent_chat_state_is_idle() {
+        let state = AgentChatState::new(NousId::from("syn"));
+        assert_eq!(state.agent_id.as_str(), "syn");
+        assert!(state.session_id.is_none());
+        assert_eq!(state.generation, 0);
+        assert!(state.messages.is_empty());
+        assert!(!state.streaming.is_active());
+        assert!(state.error.is_none());
+    }
+
+    #[test]
+    fn bump_generation_increments_and_returns() {
+        let mut state = AgentChatState::new(NousId::from("syn"));
+        assert_eq!(state.bump_generation(), 1);
+        assert_eq!(state.bump_generation(), 2);
+        assert_eq!(state.generation, 2);
+    }
+
+    #[test]
+    fn is_current_generation_true_when_matching() {
+        let mut state = AgentChatState::new(NousId::from("syn"));
+        let current = state.bump_generation();
+        assert!(state.is_current_generation(current));
+    }
+
+    #[test]
+    fn is_current_generation_false_when_stale() {
+        let mut state = AgentChatState::new(NousId::from("syn"));
+        let old = state.bump_generation();
+        let _ = state.bump_generation();
+        assert!(!state.is_current_generation(old));
+    }
+
+    #[test]
+    fn streaming_turn_idle_has_no_turn_id() {
+        let turn = StreamingTurn::Idle;
+        assert!(turn.turn_id().is_none());
+        assert!(!turn.is_active());
+    }
+
+    #[test]
+    fn streaming_turn_active_has_turn_id() {
+        let turn = StreamingTurn::Active {
+            turn_id: TurnId::from("t1"),
+            text: String::new(),
+            thinking: String::new(),
+            tool_calls: Vec::new(),
+            pending_approval: None,
+        };
+        assert!(turn.is_active());
+        assert_eq!(turn.turn_id().unwrap().as_str(), "t1");
+    }
+
+    #[test]
+    fn streaming_turn_aborting_has_turn_id() {
+        let turn = StreamingTurn::Aborting {
+            turn_id: TurnId::from("t2"),
+            reason: "user cancelled".to_string(),
+        };
+        assert!(!turn.is_active());
+        assert_eq!(turn.turn_id().unwrap().as_str(), "t2");
+    }
+
+    #[test]
+    fn live_tool_call_name_and_id_accessors() {
+        let tc = LiveToolCall::Running {
+            name: "read_file".to_string(),
+            tool_id: ToolId::from("tc1"),
+            started_at: Instant::now(),
+        };
+        assert_eq!(tc.name(), "read_file");
+        assert_eq!(tc.tool_id().as_str(), "tc1");
+
+        let tc = LiveToolCall::Completed {
+            name: "write_file".to_string(),
+            tool_id: ToolId::from("tc2"),
+            duration_ms: 200,
+            is_error: false,
+        };
+        assert_eq!(tc.name(), "write_file");
+        assert_eq!(tc.tool_id().as_str(), "tc2");
+    }
+
+    #[test]
+    fn chat_error_display() {
+        let err = ChatError::StreamFailed {
+            message: "timeout".to_string(),
+        };
+        assert_eq!(format!("{err}"), "stream failed: timeout");
+
+        let err = ChatError::Disconnected;
+        assert_eq!(format!("{err}"), "disconnected from server");
+    }
+
+    #[test]
+    fn operations_pane_default() {
+        let ops = OperationsPane::default();
+        assert!(!ops.visible);
+        assert_eq!(ops.width_pct, 40);
+        assert!(ops.tool_calls.is_empty());
+    }
+
+    #[test]
+    fn input_state_default_is_empty() {
+        let input = InputState::default();
+        assert!(input.text.is_empty());
+        assert_eq!(input.cursor, 0);
+        assert!(input.history.is_empty());
+    }
+
+    #[test]
+    fn scroll_state_default() {
+        let scroll = ScrollState::default();
+        assert_eq!(scroll.offset, 0);
+        assert!(!scroll.auto_scroll);
+    }
+
+    #[test]
+    fn nous_id_equality() {
+        let a = NousId::from("syn");
+        let b = NousId::from("syn");
+        let c = NousId::from("demiurge");
+        assert_eq!(a, b);
+        assert_ne!(a, c);
+    }
+}

--- a/crates/theatron/desktop/src/state/collections.rs
+++ b/crates/theatron/desktop/src/state/collections.rs
@@ -1,0 +1,241 @@
+//! Reactive collection patterns for file trees and entity lists.
+//!
+//! These types model dynamic, filterable, sortable collections. In Dioxus they
+//! wrap in `Store<T>` to get field-level subscriptions. The `version` counter
+//! provides a cheap change signal for components that only need "did it change?"
+//! without reading the full vec.
+
+use super::chat::NousId;
+
+// ---------------------------------------------------------------------------
+// Reactive list (generic pattern)
+// ---------------------------------------------------------------------------
+
+/// A versioned list that exposes a cheap change counter.
+///
+/// Components that render the full list subscribe to `items`.
+/// Components that only show a count or badge subscribe to `version`.
+#[derive(Debug, Clone)]
+pub struct ReactiveList<T> {
+    pub items: Vec<T>,
+    /// Monotonically increasing counter, bumped on every mutation.
+    pub version: u64,
+}
+
+impl<T> Default for ReactiveList<T> {
+    fn default() -> Self {
+        Self {
+            items: Vec::new(),
+            version: 0,
+        }
+    }
+}
+
+impl<T> ReactiveList<T> {
+    /// Append an item and bump the version.
+    pub fn push(&mut self, item: T) {
+        self.items.push(item);
+        self.version += 1;
+    }
+
+    /// Replace the entire list. Useful after a full API fetch.
+    pub fn replace(&mut self, items: Vec<T>) {
+        self.items = items;
+        self.version += 1;
+    }
+
+    /// Remove an item by index.
+    pub fn remove(&mut self, index: usize) -> Option<T> {
+        if index < self.items.len() {
+            let item = self.items.remove(index);
+            self.version += 1;
+            Some(item)
+        } else {
+            None
+        }
+    }
+
+    /// Number of items.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.items.len()
+    }
+
+    /// Whether the list is empty.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.items.is_empty()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// File tree
+// ---------------------------------------------------------------------------
+
+/// Kind of file system entry.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FileKind {
+    File,
+    Directory,
+    Symlink,
+}
+
+/// A single entry in the flat file tree. Directories are expandable/collapsible.
+/// The tree is stored as a flat sorted vec with depth levels, not recursive nodes.
+/// This simplifies virtual scrolling (O(visible) rendering).
+#[derive(Debug, Clone)]
+pub struct FileEntry {
+    pub path: String,
+    pub depth: u16,
+    pub kind: FileKind,
+    /// Whether a directory's children are visible.
+    pub expanded: bool,
+    pub selected: bool,
+}
+
+/// State for the workspace file tree panel.
+#[derive(Debug, Clone, Default)]
+pub struct FileTreeState {
+    pub entries: ReactiveList<FileEntry>,
+    pub filter: String,
+}
+
+// ---------------------------------------------------------------------------
+// Entity list (knowledge graph)
+// ---------------------------------------------------------------------------
+
+/// A knowledge graph entity displayed in the memory inspector.
+#[derive(Debug, Clone)]
+pub struct Entity {
+    pub id: String,
+    pub name: String,
+    pub entity_type: String,
+    pub aliases: Vec<String>,
+}
+
+/// Sort order for the entity list.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum EntitySort {
+    #[default]
+    Name,
+    Type,
+    RecentlyUpdated,
+}
+
+/// State for the entity list in the memory inspector.
+#[derive(Debug, Clone, Default)]
+pub struct EntityListState {
+    pub entities: ReactiveList<Entity>,
+    pub sort: EntitySort,
+    pub filter_text: String,
+    pub selected: Option<usize>,
+}
+
+// ---------------------------------------------------------------------------
+// Session list
+// ---------------------------------------------------------------------------
+
+/// A session entry in the session picker.
+#[derive(Debug, Clone)]
+pub struct SessionEntry {
+    pub id: String,
+    pub nous_id: NousId,
+    pub display_name: Option<String>,
+    pub message_count: u32,
+    pub is_archived: bool,
+    pub updated_at: Option<String>,
+}
+
+/// State for the session list (per-agent or global).
+#[derive(Debug, Clone, Default)]
+pub struct SessionListState {
+    pub sessions: ReactiveList<SessionEntry>,
+    pub show_archived: bool,
+    pub selected: Option<usize>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reactive_list_default_empty() {
+        let list: ReactiveList<i32> = ReactiveList::default();
+        assert!(list.is_empty());
+        assert_eq!(list.len(), 0);
+        assert_eq!(list.version, 0);
+    }
+
+    #[test]
+    fn reactive_list_push_bumps_version() {
+        let mut list = ReactiveList::default();
+        list.push(1);
+        assert_eq!(list.len(), 1);
+        assert_eq!(list.version, 1);
+        list.push(2);
+        assert_eq!(list.version, 2);
+    }
+
+    #[test]
+    fn reactive_list_replace_bumps_version() {
+        let mut list = ReactiveList::default();
+        list.push(1);
+        list.push(2);
+        let v_before = list.version;
+        list.replace(vec![10, 20, 30]);
+        assert_eq!(list.len(), 3);
+        assert_eq!(list.version, v_before + 1);
+        assert_eq!(list.items, vec![10, 20, 30]);
+    }
+
+    #[test]
+    fn reactive_list_remove_bumps_version() {
+        let mut list = ReactiveList::default();
+        list.push("a");
+        list.push("b");
+        let v_before = list.version;
+        let removed = list.remove(0);
+        assert_eq!(removed, Some("a"));
+        assert_eq!(list.len(), 1);
+        assert_eq!(list.version, v_before + 1);
+    }
+
+    #[test]
+    fn reactive_list_remove_out_of_range() {
+        let mut list: ReactiveList<i32> = ReactiveList::default();
+        list.push(1);
+        let v_before = list.version;
+        assert!(list.remove(5).is_none());
+        assert_eq!(list.version, v_before); // no bump
+    }
+
+    #[test]
+    fn file_tree_default() {
+        let tree = FileTreeState::default();
+        assert!(tree.entries.is_empty());
+        assert!(tree.filter.is_empty());
+    }
+
+    #[test]
+    fn entity_sort_default_is_name() {
+        assert_eq!(EntitySort::default(), EntitySort::Name);
+    }
+
+    #[test]
+    fn entity_list_default() {
+        let list = EntityListState::default();
+        assert!(list.entities.is_empty());
+        assert!(list.filter_text.is_empty());
+        assert!(list.selected.is_none());
+    }
+
+    #[test]
+    fn session_list_default() {
+        let list = SessionListState::default();
+        assert!(list.sessions.is_empty());
+        assert!(!list.show_archived);
+        assert!(list.selected.is_none());
+    }
+}

--- a/crates/theatron/desktop/src/state/mod.rs
+++ b/crates/theatron/desktop/src/state/mod.rs
@@ -1,0 +1,10 @@
+//! Reactive state model for Dioxus-based Theatron frontends.
+//!
+//! Each module defines the data shape for a domain. The types are plain structs
+//! and enums, suitable for wrapping in `Signal<T>` or `Store<T>` at the
+//! component layer.
+
+pub mod agent;
+pub mod app;
+pub mod chat;
+pub mod collections;

--- a/docs/theatron-dioxus-state.md
+++ b/docs/theatron-dioxus-state.md
@@ -1,0 +1,731 @@
+# Theatron Desktop: Dioxus State Architecture
+
+> Research document for the Aletheia Dioxus desktop UI state model.
+> Covers state primitives, per-agent chat state, reactive collections,
+> generation tracking, TUI-to-Dioxus mapping, and key hooks.
+>
+> Reference implementation: `crates/theatron/tui/` (ratatui TUI).
+> Target implementation: `crates/theatron/desktop/` (Dioxus 0.6).
+
+---
+
+## 1. Dioxus 0.6 State Primitives
+
+Dioxus 0.6 provides three primary reactive state primitives. Each operates at a
+different granularity and suits different ownership patterns.
+
+### Signal\<T\>
+
+A `Signal<T>` is a single reactive cell. Reading a signal inside a component
+subscribes that component to changes. Writing triggers re-render of all
+subscribers. Best for simple scalar values.
+
+```rust
+// Simple boolean toggle — all readers re-render on change.
+let sidebar_visible = use_signal(|| true);
+
+// Read (subscribes the component):
+if sidebar_visible() {
+    render_sidebar();
+}
+
+// Write (notifies all subscribers):
+sidebar_visible.set(false);
+```
+
+**Characteristics:**
+- Whole-value comparison: any `set()` triggers subscribers even if the inner
+  value is unchanged (unless `PartialEq` short-circuit is used via `set_if_neq`).
+- No field-level granularity: reading `signal().some_field` subscribes to the
+  entire signal, not just that field.
+- Cheapest primitive for leaf values (`bool`, `u32`, `Option<String>`).
+
+### Store\<T\>
+
+A `Store<T>` wraps a struct and provides **field-level subscriptions**. Reading
+`store.field_name` subscribes only to that field. Writing one field does not
+re-render components that only read other fields.
+
+```rust
+#[derive(Store, Clone)]
+struct AgentChatState {
+    messages: Vec<ChatMessage>,
+    streaming_turn: StreamingTurn,
+    error: Option<ChatError>,
+    generation: u64,
+}
+
+let chat = use_store(|| AgentChatState::default());
+
+// This component re-renders only when `streaming_turn` changes:
+let turn = chat.streaming_turn();
+
+// This component re-renders only when `messages` changes:
+let msgs = chat.messages();
+```
+
+**Characteristics:**
+- Field-level reactivity reduces unnecessary re-renders.
+- Requires `#[derive(Store)]` on the state struct.
+- Best for medium-to-large state structs where different components read
+  different fields.
+- Nested structs can also derive `Store` for deeper granularity.
+
+### Context Providers
+
+Context providers make state available to an entire subtree without prop
+drilling. Any component in the subtree can `use_context::<T>()` to access it.
+
+```rust
+// At the app root:
+use_context_provider(|| Signal::new(AppConfig::default()));
+use_context_provider(|| Signal::new(ConnectionStatus::Connected));
+
+// In any descendant:
+let config = use_context::<Signal<AppConfig>>();
+let status = use_context::<Signal<ConnectionStatus>>();
+```
+
+**Characteristics:**
+- Tree-wide visibility; no explicit prop threading.
+- Typically wraps a `Signal<T>` or `Store<T>`.
+- Best for truly global state: config, theme, connection status, agent registry.
+
+### Comparison Table
+
+| Primitive | Granularity | Subscription Scope | Best For |
+|-----------|------------|-------------------|----------|
+| `Signal<T>` | Whole value | Any component that reads | Simple scalars, toggles, counters |
+| `Store<T>` | Per field | Components reading specific fields | Per-agent chat state, complex structs |
+| Context | Tree-wide access | Via `use_context` | App config, theme, connection status |
+
+### Recommendation
+
+| State Domain | Primitive | Rationale |
+|-------------|-----------|-----------|
+| Per-agent chat state | `Store<AgentChatState>` | Field-level subscriptions: message list changes don't re-render the streaming indicator |
+| Simple UI toggles | `Signal<bool>` | Sidebar visibility, thinking expanded, auto-scroll |
+| App-wide singletons | Context + `Signal<T>` | Connection status, daily cost, agent registry |
+| Derived/computed values | `use_memo` | Filtered message counts, sorted agent lists |
+
+---
+
+## 2. Per-Agent Chat State Model
+
+Each agent tab owns an `AgentChatState` stored as a `Store<T>`. This replaces
+the TUI's monolithic `App` struct where streaming fields, messages, and scroll
+state are all top-level fields swapped on tab switch.
+
+**Reference:** `crates/theatron/desktop/src/state/chat.rs`
+
+### Core Struct
+
+```rust
+#[derive(Store, Clone, Default)]
+pub struct AgentChatState {
+    /// Chat history for this agent's active session.
+    pub messages: Vec<ChatMessage>,
+
+    /// Current streaming turn state machine.
+    pub streaming_turn: StreamingTurn,
+
+    /// Live tool calls during the active turn.
+    pub tool_calls: Vec<LiveToolCall>,
+
+    /// Operations pane state (thinking text, tool results, diffs).
+    pub ops: OpsState,
+
+    /// Current error, if any.
+    pub error: Option<ChatError>,
+
+    /// Session ID for the active conversation.
+    pub session_id: Option<SessionId>,
+
+    /// Generation counter — incremented on agent/session switch.
+    /// Used to discard stale API responses.
+    pub generation: u64,
+
+    /// Cost tracking for the active session.
+    pub session_cost_cents: u32,
+    pub context_usage_pct: Option<u8>,
+}
+```
+
+### StreamingTurn Enum
+
+Models the lifecycle of a single LLM turn as a state machine:
+
+```rust
+#[derive(Clone, Default, PartialEq)]
+pub enum StreamingTurn {
+    /// No active turn. The input box is editable.
+    #[default]
+    Idle,
+
+    /// LLM is generating. Streaming text accumulates.
+    Active {
+        turn_id: TurnId,
+        text: String,
+        thinking: String,
+        cached_markdown: Vec<Line<'static>>,
+    },
+
+    /// User requested abort. Waiting for server confirmation.
+    Aborting { turn_id: TurnId },
+}
+```
+
+**Transitions:**
+```
+Idle → Active       on TurnStart event
+Active → Aborting   on user abort request
+Active → Idle       on TurnComplete / TurnAbort / Error
+Aborting → Idle     on TurnAbort confirmation from server
+```
+
+The `Active` variant holds all in-flight streaming data that the TUI currently
+scatters across `app.streaming_text`, `app.streaming_thinking`,
+`app.cached_markdown_text`, and `app.cached_markdown_lines`. Colocating these
+in the enum variant ensures they are always created and destroyed together.
+
+### LiveToolCall Lifecycle
+
+Models an individual tool call within a turn:
+
+```rust
+#[derive(Clone, PartialEq)]
+pub enum LiveToolCall {
+    /// Tool is executing on the server.
+    Running {
+        tool_id: ToolId,
+        name: String,
+        started_at: Instant,
+    },
+
+    /// Server requests user approval before proceeding.
+    AwaitingApproval {
+        tool_id: ToolId,
+        turn_id: TurnId,
+        name: String,
+        input: serde_json::Value,
+        risk: String,
+        reason: String,
+    },
+
+    /// Tool finished (success or error).
+    Completed {
+        tool_id: ToolId,
+        name: String,
+        is_error: bool,
+        duration_ms: u64,
+    },
+}
+```
+
+**Transitions:**
+```
+Running → AwaitingApproval   on ToolApprovalRequired event
+Running → Completed          on ToolResult event
+AwaitingApproval → Running   on user approval (ToolApprovalResolved)
+AwaitingApproval → Completed on user rejection
+```
+
+This replaces the TUI's `ToolCallInfo` (a plain struct with optional fields)
+and the `ToolApprovalOverlay` (a separate overlay struct). The enum makes
+illegal states unrepresentable: a tool call cannot simultaneously be running
+and awaiting approval.
+
+### Abort Support
+
+The TUI handles abort by clearing `app.stream_rx` and resetting
+`app.active_turn_id` to `None`. In the Dioxus model, abort is a first-class
+state:
+
+1. User presses Escape or clicks abort during `StreamingTurn::Active`.
+2. State transitions to `StreamingTurn::Aborting { turn_id }`.
+3. The abort request is sent to the server via POST.
+4. On `TurnAbort` event from the server, state returns to `Idle`.
+5. If the server responds with `TurnComplete` instead (abort arrived too late),
+   the response is committed normally and state returns to `Idle`.
+
+The `Aborting` variant allows the UI to show a "cancelling..." indicator
+without the ambiguity of checking multiple fields.
+
+### ChatError Enum
+
+```rust
+#[derive(Clone, PartialEq, Snafu)]
+pub enum ChatError {
+    #[snafu(display("Connection lost: {message}"))]
+    ConnectionLost { message: String },
+
+    #[snafu(display("Stream error: {message}"))]
+    StreamError { message: String },
+
+    #[snafu(display("Server error {status}: {message}"))]
+    ServerError { status: u16, message: String },
+
+    #[snafu(display("Request timeout after {seconds}s"))]
+    Timeout { seconds: u64 },
+}
+```
+
+Replaces the TUI's `ErrorToast` (a string + timestamp). Structured errors
+enable the UI to show different treatments: a reconnect button for
+`ConnectionLost`, a retry button for `Timeout`, an inline error for
+`StreamError`.
+
+---
+
+## 3. Reactive Collections
+
+Standard `Vec<T>` inside a `Store` field triggers re-renders on any mutation,
+even appending a single element. For large collections, this is wasteful.
+
+**Reference:** `crates/theatron/desktop/src/state/collections.rs`
+
+### ReactiveList\<T\>
+
+A wrapper around `Vec<T>` with a version counter for granular change detection:
+
+```rust
+#[derive(Clone)]
+pub struct ReactiveList<T> {
+    items: Vec<T>,
+    version: u64,
+}
+
+impl<T> ReactiveList<T> {
+    pub fn push(&mut self, item: T) {
+        self.items.push(item);
+        self.version += 1;
+    }
+
+    pub fn clear(&mut self) {
+        self.items.clear();
+        self.version += 1;
+    }
+
+    pub fn version(&self) -> u64 {
+        self.version
+    }
+
+    pub fn items(&self) -> &[T] {
+        &self.items
+    }
+
+    pub fn len(&self) -> usize {
+        self.items.len()
+    }
+}
+```
+
+Components use `use_memo` keyed on `list.version()` to avoid recomputing
+derived state (filtered views, rendered markdown) when the list has not
+changed:
+
+```rust
+let messages = chat.messages();
+let filtered = use_memo(move || {
+    let msgs = messages();
+    let ver = msgs.version();
+    // Only recompute when version bumps
+    msgs.items()
+        .iter()
+        .filter(|m| m.role == "assistant")
+        .cloned()
+        .collect::<Vec<_>>()
+});
+```
+
+### File Tree: Flat Sorted Vec with Depth
+
+File trees are stored as a flat `Vec<FileEntry>` sorted by path, with a depth
+field for indentation. This avoids recursive tree structures that complicate
+reactive updates.
+
+```rust
+#[derive(Clone, PartialEq)]
+pub struct FileEntry {
+    pub path: String,
+    pub name: String,
+    pub depth: u16,
+    pub is_dir: bool,
+    pub expanded: bool,
+}
+```
+
+Expansion/collapse toggles the `expanded` flag and inserts/removes children
+in-place. The flat structure maps directly to a virtualised list without tree
+traversal.
+
+### Entity List with Sort/Filter
+
+The memory inspector's entity and fact lists use `ReactiveList<T>` with
+separate sort and filter signals:
+
+```rust
+let facts = use_store(|| ReactiveList::<MemoryFact>::new());
+let sort_key = use_signal(|| FactSort::Confidence);
+let sort_asc = use_signal(|| false);
+let filter_text = use_signal(|| String::new());
+
+let visible_facts = use_memo(move || {
+    let mut items = facts.items().to_vec();
+    let filter = filter_text();
+    if !filter.is_empty() {
+        let lower = filter.to_lowercase();
+        items.retain(|f| f.content.to_lowercase().contains(&lower));
+    }
+    items.sort_by(|a, b| match sort_key() {
+        FactSort::Confidence => a.confidence.partial_cmp(&b.confidence).unwrap(),
+        FactSort::Recency => a.last_accessed_at.cmp(&b.last_accessed_at),
+        // ...
+    });
+    if !sort_asc() { items.reverse(); }
+    items
+});
+```
+
+Each signal (`sort_key`, `sort_asc`, `filter_text`) triggers recomputation
+independently. Changing the sort order does not re-fetch from the API; it only
+recomputes the memo.
+
+---
+
+## 4. History Generation Tracking
+
+When the user switches agents or sessions, in-flight API responses from the
+previous context must be discarded. The TUI handles this implicitly by
+clearing `app.messages` on switch and trusting that `load_focused_session`
+replaces the data. This is fragile with async responses: a slow history
+response for agent A can arrive after the user has already switched to agent B.
+
+The generation counter pattern makes this explicit.
+
+### Pattern
+
+```rust
+impl AgentChatState {
+    /// Increment the generation. Called on every agent/session switch.
+    pub fn bump_generation(&mut self) {
+        self.generation += 1;
+    }
+
+    /// Check whether a response belongs to the current generation.
+    pub fn is_current_generation(&self, gen: u64) -> bool {
+        self.generation == gen
+    }
+}
+```
+
+### Usage
+
+```rust
+// On agent switch:
+chat.write().bump_generation();
+let gen = chat.read().generation;
+
+// Spawn async history load:
+let chat_handle = chat.clone();
+spawn(async move {
+    let history = client.history(&session_id).await;
+    // Only apply if the user hasn't switched away:
+    if chat_handle.read().is_current_generation(gen) {
+        chat_handle.write().messages = ReactiveList::from(history);
+    }
+});
+```
+
+The same pattern applies to:
+- **SSE event routing:** Events carry `nous_id` and `session_id`. Before
+  applying a `turn:after` event, check that the event's agent matches the
+  current generation.
+- **Streaming turn responses:** The `TurnStart` event captures the generation.
+  Subsequent `TextDelta` events are discarded if the generation has advanced.
+- **Cost queries:** `today_cost_cents` responses are applied unconditionally
+  (they are global), but `session_cost_cents` checks generation.
+
+This eliminates the class of bugs where stale data from a previous context
+bleeds into the current view, which the TUI mitigates through synchronous
+clearing in `load_focused_session` and `restore_from_active_tab`.
+
+---
+
+## 5. TUI State Model Mapped to Dioxus Idioms
+
+The TUI's `App` struct (defined in `crates/theatron/tui/src/app.rs`) is a
+monolithic state bag with 40+ fields. In Dioxus, this decomposes into
+purpose-specific stores, signals, and context providers owned by the
+appropriate component.
+
+### What Disappears
+
+These TUI concerns have no Dioxus equivalent because Dioxus handles them
+natively:
+
+| TUI Field/Concept | Why It Disappears |
+|-------------------|-------------------|
+| `dirty: bool`, `frame_cache: Option<Buffer>` | Dioxus has its own VDOM diffing; no manual dirty tracking |
+| `terminal_width`, `terminal_height` | Dioxus layout engine (Taffy) handles sizing |
+| `virtual_scroll: VirtualScroll` | Dioxus virtualised list components handle this |
+| `pending_g: bool` (vim-style key chords) | Desktop uses standard key event handling, no chord state machine |
+| `ViewStack` (stack-based navigation) | Dioxus Router with URL-based navigation |
+| `tab_completion: Option<TabCompletion>` | Native text input with platform autocomplete |
+| `scroll_offset`, `auto_scroll`, `scroll_states` | CSS `overflow-y: auto` + `scroll_into_view()` |
+| `cached_markdown_text/lines` | Computed in `use_memo`; Dioxus caches automatically |
+| `tick_count: u64` | No manual tick loop; reactivity is event-driven |
+| `highlighter: Highlighter` | Kept but managed differently (web-based syntax highlighting or wasm) |
+
+### What Stays (Restructured)
+
+| TUI Field | Dioxus Form | Owner |
+|-----------|-------------|-------|
+| `agents: Vec<AgentState>` | `Signal<Vec<AgentState>>` in context | App root |
+| `focused_agent: Option<NousId>` | `Signal<Option<NousId>>` in context | App root |
+| `messages: ArcVec<ChatMessage>` | `Store<AgentChatState>.messages` | Per-tab `Store` |
+| `streaming_text/thinking/tool_calls` | `StreamingTurn::Active { .. }` | Per-tab `Store` |
+| `active_turn_id` | `StreamingTurn::Active { turn_id }` | Per-tab `Store` |
+| `sse_connected`, `sse_disconnected_at` | `Signal<ConnectionStatus>` in context | App root |
+| `sidebar_visible` | `Signal<bool>` | Layout component |
+| `thinking_expanded` | `Signal<bool>` | Operations pane component |
+| `overlay: Option<Overlay>` | `Signal<Option<Overlay>>` | App root |
+| `daily_cost_cents` | `Signal<u32>` in context | App root |
+| `session_cost_cents`, `context_usage_pct` | `Store<AgentChatState>` fields | Per-tab `Store` |
+| `filter: FilterState` | `Signal<FilterState>` | Chat component |
+| `ops: OpsState` | `Store<AgentChatState>.ops` | Per-tab `Store` |
+| `tab_bar: TabBar` | `Signal<TabBar>` | Tab bar component |
+| `memory: MemoryInspectorState` | `Store<MemoryInspectorState>` | Memory inspector route |
+| `error_toast`, `success_toast` | `Signal<Option<Toast>>` in context | App root (toast layer) |
+| `command_palette: CommandPaletteState` | `Signal<CommandPaletteState>` | Command palette component |
+| `config: Config` | Context provider (read-only) | App root |
+
+### What Is New
+
+| Concept | Details |
+|---------|---------|
+| `Store<T>` field-level subscriptions | Components subscribe to individual fields, not the whole struct |
+| Generation counter | Explicit staleness guard for async responses (see section 4) |
+| `StreamingTurn` enum | Replaces scattered streaming fields with a state machine |
+| `LiveToolCall` enum | Replaces `ToolCallInfo` struct + `ToolApprovalOverlay` with a unified lifecycle |
+| `ChatError` enum | Structured errors replace string-based `ErrorToast` |
+| `ReactiveList<T>` | Version-tracked collections for granular memo invalidation |
+| Router-based navigation | Replaces `ViewStack` push/pop with URL segments |
+
+### Component-State Ownership Sketch
+
+```
+App (root)
+├── context: Signal<Vec<AgentState>>       // agent registry
+├── context: Signal<Option<NousId>>        // focused agent
+├── context: Signal<ConnectionStatus>      // SSE health
+├── context: Signal<u32>                   // daily_cost_cents
+├── context: Signal<Option<Toast>>         // toast notifications
+├── context: Config                        // read-only config
+│
+├── TabBar
+│   └── Signal<TabBar>                     // tab list + active index
+│
+├── Sidebar
+│   ├── reads: context agents, focused_agent
+│   └── Signal<bool> sidebar_visible
+│
+├── ChatPane (per tab)
+│   ├── Store<AgentChatState>              // owns all per-agent state
+│   │   ├── .messages                      // subscribed by MessageList
+│   │   ├── .streaming_turn               // subscribed by StreamingIndicator
+│   │   ├── .tool_calls                   // subscribed by ToolCallList
+│   │   ├── .ops                          // subscribed by OperationsPane
+│   │   ├── .error                        // subscribed by ErrorBanner
+│   │   └── .generation                   // checked by async callbacks
+│   ├── Signal<FilterState>               // local to chat
+│   └── Signal<bool> auto_scroll          // local to chat
+│
+├── OperationsPane
+│   ├── reads: Store<AgentChatState>.ops
+│   ├── reads: Store<AgentChatState>.streaming_turn
+│   └── Signal<bool> thinking_expanded
+│
+├── CommandPalette
+│   └── Signal<CommandPaletteState>
+│
+├── OverlayLayer
+│   └── Signal<Option<Overlay>>
+│
+└── Router
+    ├── /                                  // Home (chat view)
+    ├── /sessions/:agent_id                // Session picker
+    ├── /memory                            // Memory inspector
+    │   └── Store<MemoryInspectorState>
+    └── /memory/facts/:fact_id             // Fact detail
+```
+
+---
+
+## 6. Key Dioxus Hooks
+
+### use_coroutine — SSE Connections
+
+Long-lived async tasks that send events into the reactive system. Replaces the
+TUI's `SseConnection` background task + `mpsc::Receiver` polling loop.
+
+```rust
+let sse = use_coroutine(|mut rx: UnboundedReceiver<SseCommand>| {
+    let client = use_context::<ApiClient>();
+    async move {
+        loop {
+            let mut es = EventSource::new(client.sse_url()).await;
+            while let Some(event) = es.next().await {
+                match event {
+                    SseEvent::TurnBefore { nous_id, .. } => {
+                        // Update agent status via context signal
+                    }
+                    SseEvent::Disconnected => {
+                        // Set connection status to disconnected
+                        break; // will reconnect via outer loop
+                    }
+                    _ => {}
+                }
+            }
+            // Exponential backoff before reconnect
+            tokio::time::sleep(backoff).await;
+        }
+    }
+});
+```
+
+The coroutine also receives commands from the UI (e.g., `SseCommand::Reconnect`)
+via its `UnboundedReceiver`.
+
+### use_effect — Side Effects on Signal Changes
+
+Runs a closure whenever its tracked signals change. Replaces the TUI's
+imperative "if this field changed, do that" logic scattered across update
+handlers.
+
+```rust
+// Auto-scroll to bottom when new messages arrive:
+use_effect(move || {
+    let msgs = chat.messages();
+    let version = msgs.version();
+    // Scroll the container to the bottom
+    if auto_scroll() {
+        scroll_container.set(ScrollPosition::Bottom);
+    }
+});
+
+// Auto-show operations pane when streaming starts:
+use_effect(move || {
+    let turn = chat.streaming_turn();
+    match turn {
+        StreamingTurn::Active { .. } => ops_visible.set(true),
+        StreamingTurn::Idle => ops_visible.set(false),
+        _ => {}
+    }
+});
+```
+
+### use_memo — Cached Derived State
+
+Computes a value from signals and caches it until inputs change. Replaces the
+TUI's manual cache fields (`cached_markdown_text`, `cached_markdown_lines`,
+`text_lower`).
+
+```rust
+// Rendered markdown, recomputed only when streaming text changes:
+let rendered_markdown = use_memo(move || {
+    let turn = chat.streaming_turn();
+    match turn {
+        StreamingTurn::Active { ref text, .. } => {
+            markdown::render(text)
+        }
+        _ => vec![],
+    }
+});
+
+// Filtered message count for the filter bar:
+let match_count = use_memo(move || {
+    let filter = filter_state();
+    let msgs = chat.messages();
+    if filter.text.is_empty() {
+        return msgs.len();
+    }
+    let (pattern, inverted) = filter.pattern();
+    msgs.items()
+        .iter()
+        .filter(|m| m.text_lower.contains(pattern) != inverted)
+        .count()
+});
+```
+
+### use_resource — Async Reactive Values
+
+Fetches data asynchronously when dependencies change. Replaces the TUI's
+`load_focused_session` imperative async call.
+
+```rust
+// Load chat history when the session changes:
+let history = use_resource(move || {
+    let session_id = chat.session_id();
+    let gen = chat.generation();
+    async move {
+        let session_id = session_id?;
+        let history = client.history(&session_id).await.ok()?;
+        Some((history, gen))
+    }
+});
+
+// Apply loaded history, checking generation:
+use_effect(move || {
+    if let Some(Some((history, gen))) = history.value().as_ref() {
+        if chat.read().is_current_generation(*gen) {
+            chat.write().messages = ReactiveList::from(history.clone());
+        }
+    }
+});
+```
+
+`use_resource` automatically re-runs when `chat.session_id()` changes,
+and the result is available as a reactive `Resource<T>` that components can
+read.
+
+---
+
+## 7. Open Questions
+
+The following items are out of scope for this document but noted for future
+investigation:
+
+- **Tab state persistence across app restarts.** The TUI's `TabBar` is
+  ephemeral. Should the desktop app persist open tabs to disk (SQLite or
+  local storage)?
+
+- **Multi-window support.** Dioxus desktop supports multiple windows. Should
+  agent tabs be detachable into separate OS windows? This complicates shared
+  context providers.
+
+- **Undo/redo for input state.** The TUI has no undo. The desktop text input
+  can leverage platform undo stacks, but should `AgentChatState` mutations
+  (e.g., message deletion) also be undoable?
+
+- **Offline mode.** What happens when the gateway is unreachable? The
+  `ConnectionStatus` signal can drive a read-only mode, but caching strategy
+  for previously loaded conversations is undefined.
+
+- **WebSocket vs SSE.** The TUI uses SSE (`/api/v1/events`). Dioxus desktop
+  could use WebSocket for bidirectional communication (abort signals, typing
+  indicators). This would change the `use_coroutine` connection model.
+
+- **Optimistic updates.** When the user sends a message, should it appear in
+  the message list immediately (optimistic) or only after the server confirms
+  the turn start? The TUI waits for `TurnStart`. Optimistic updates improve
+  perceived latency but require rollback on error.
+
+- **State serialization for dev tools.** Dioxus has a devtools protocol.
+  Should `AgentChatState` implement `Serialize` for inspection? This adds a
+  trait bound to all nested types.
+
+- **Memory inspector as a separate route vs inline pane.** The TUI uses a
+  `ViewStack` push to show the memory inspector. The desktop could use a
+  router route (`/memory`) or a slide-out panel. Router is cleaner but loses
+  the "drill in from chat" context.


### PR DESCRIPTION
## Summary

- Research Dioxus 0.6 state primitives (Signal vs Store vs context) with recommendations for the theatron desktop frontend
- Design per-agent chat state model (`AgentChatState`) with streaming turn state machine, tool call lifecycle tracking, and generation-based stale fetch prevention
- Define reactive collection patterns (`ReactiveList<T>`) for file trees, entity lists, and session lists
- Map existing TUI state model to Dioxus idioms with complete type definitions in `crates/theatron/desktop/`

## What's included

| File | Purpose |
|------|---------|
| `docs/theatron-dioxus-state.md` | Research document with analysis, comparisons, and recommendations |
| `crates/theatron/desktop/` | New crate with state type definitions (7 files, 35 tests) |

## Acceptance criteria

- [x] Signals vs stores vs context providers compared with concrete examples
- [x] Per-agent chat state model designed (messages, streaming, tool calls, errors, abort)
- [x] Reactive collections for file trees and entity lists designed
- [x] History generation tracking to prevent stale fetches during agent switching
- [x] TUI state model mapped to Dioxus idioms with type definitions

## Validation

- `cargo fmt -p theatron-desktop -- --check` — clean
- `cargo clippy -p theatron-desktop -- -D warnings` — clean
- `cargo test -p theatron-desktop` — 35/35 pass

## Observations

- **Out of scope**: Actual Dioxus component implementations, SSE integration, routing — this PR covers only the state architecture research and type definitions
- **`ReactiveList<T>` cannot derive `Default`** because generic `Default` impls require `T: Default`, but our lists should default to empty regardless of `T`
- **`OperationsPane` cannot derive `Default`** because `width_pct` defaults to 40, not 0
- **`AppState` cannot derive `Default`** because `sidebar_visible` defaults to `true` and `tabs` uses `TabBar::new()`
- **ID newtypes** use `compact_str::CompactString` matching the TUI crate pattern, but may want to converge on shared types from `theatron-core` later

## Test plan

- [x] All 35 unit tests pass
- [x] Clippy zero warnings
- [x] Format check passes
- [ ] Review research doc for architectural soundness

🤖 Generated with [Claude Code](https://claude.com/claude-code)