### PR TITLE
docs(theatron): research SSE and streaming architecture for Dioxus desktop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6166,7 +6166,6 @@ dependencies = [
 name = "theatron-core"
 version = "0.10.0"
 dependencies = [
- "pulldown-cmark",
  "serde",
 ]
 
@@ -6175,8 +6174,17 @@ name = "theatron-desktop"
 version = "0.10.0"
 dependencies = [
  "compact_str",
+ "futures-util",
+ "reqwest 0.13.2",
+ "reqwest-eventsource",
+ "rustls",
  "serde",
+ "serde_json",
+ "snafu",
  "theatron-core",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ members = [
     "crates/taxis",
     "crates/thesauros",
     "crates/theatron/core",
+    "crates/theatron/desktop",
     "crates/theatron/tui",
     "crates/theatron/desktop",
 ]

--- a/crates/theatron/desktop/Cargo.toml
+++ b/crates/theatron/desktop/Cargo.toml
@@ -4,13 +4,63 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
-description = "Dioxus desktop state model for the Aletheia UI"
+description = "Dioxus desktop UI for the Aletheia distributed cognition system"
 publish = false
 
 [dependencies]
 theatron-core = { path = "../core" }
-compact_str = { workspace = true }
-serde = { workspace = true }
 
-[lints]
-workspace = true
+# Async runtime
+tokio = { workspace = true }
+
+# HTTP + SSE
+reqwest = { workspace = true, features = ["stream", "cookies"] }
+reqwest-eventsource = { git = "https://github.com/romnn/reqwest-eventsource", branch = "feat/reqwest-0.13" }
+rustls = { workspace = true }
+
+# Serialization
+serde = { workspace = true }
+serde_json = { workspace = true }
+
+# Text utilities
+compact_str = { workspace = true }
+
+# Logging
+tracing = { workspace = true }
+
+# Error handling
+snafu = { workspace = true }
+
+# Futures
+futures-util = "0.3"
+
+# Cancel-safe shutdown
+tokio-util = { workspace = true }
+
+# theatron-desktop uses inline lints for the same reason as theatron-tui:
+# Cargo does not allow combining workspace lint inheritance with
+# package-level overrides.
+[lints.rust]
+future_incompatible = { level = "warn", priority = -1 }
+nonstandard_style = { level = "warn", priority = -1 }
+unsafe_code = "deny"
+
+[lints.clippy]
+# Deny-level — must stay in sync with [workspace.lints.clippy]
+dbg_macro = "deny"
+todo = "deny"
+unimplemented = "deny"
+exit = "deny"
+await_holding_lock = "deny"
+# Warn-level extras from workspace
+explicit_into_iter_loop = "warn"
+fallible_impl_from = "warn"
+fn_params_excessive_bools = "warn"
+implicit_clone = "warn"
+map_err_ignore = "warn"
+match_wildcard_for_single_variants = "warn"
+needless_for_each = "warn"
+rc_mutex = "warn"
+string_add = "warn"
+trait_duplication_in_bounds = "warn"
+unused_self = "warn"

--- a/crates/theatron/desktop/STREAMING.md
+++ b/crates/theatron/desktop/STREAMING.md
@@ -1,0 +1,273 @@
+# Dioxus desktop streaming architecture
+
+Research document for SSE and streaming patterns in the Dioxus desktop chat application.
+
+## Dual-stream architecture
+
+The desktop UI consumes two independent SSE streams, mirroring the TUI's proven pattern:
+
+### Global SSE stream (`GET /api/v1/events`)
+
+Cross-session awareness channel. Provides agent status changes, session lifecycle events, and memory distillation progress. Runs for the lifetime of the application.
+
+**Events:** `init`, `turn:before`, `turn:after`, `tool:called`, `tool:failed`, `status:update`, `session:created`, `session:archived`, `distill:before`, `distill:stage`, `distill:after`, `ping`.
+
+**Dioxus integration:** A `use_coroutine` at the app root consumes `SseConnection::next()` and writes into shared signals (agent list, connection indicator, notification badges).
+
+**Implementation:** `src/api/sse.rs` provides `SseConnection`, a framework-agnostic struct that works with both the TUI event loop and Dioxus coroutines.
+
+### Per-message fetch stream (`POST /api/v1/sessions/stream`)
+
+Per-turn response channel. Carries LLM text deltas, tool invocations, plan execution, and completion signals. One stream per active turn; terminated when the turn completes, aborts, or errors.
+
+**Events:** `turn_start`, `text_delta`, `thinking_delta`, `tool_start`, `tool_result`, `tool_approval_required`, `tool_approval_resolved`, `turn_complete`, `turn_abort`, `error`.
+
+**Dioxus integration:** Initiated by `stream_turn()` when the user sends a message. A `use_coroutine` in the chat panel reads events and writes into the `StreamingState` signal via `ChatStateManager`.
+
+**Implementation:** `src/api/streaming.rs` provides `stream_turn()`, which spawns a background task with `CancellationToken` support for user-initiated abort.
+
+### Why two streams
+
+| Concern | Global SSE | Per-message stream |
+|---------|-----------|-------------------|
+| Lifecycle | App lifetime | Single turn |
+| Reconnection | Auto with backoff | Not applicable |
+| Multiplexing | All agents | One agent, one session |
+| Purpose | Dashboard awareness | Chat interaction |
+
+Separating concerns means the global stream never carries high-frequency text deltas, and the per-message stream does not need reconnection logic (a failed turn shows an error).
+
+## Signal-based stream state management
+
+### Dioxus signal model
+
+Dioxus uses `Signal<T>` for reactive state. Writing to a signal triggers re-render of all subscribing components. The key difference from the TUI:
+
+- **TUI:** Event loop dispatches `Msg` variants to `update()` handlers that mutate `App` state. Dirty flag triggers full redraw.
+- **Dioxus:** Signals are fine-grained. Writing `streaming_text.write()` only re-renders components that read `streaming_text`. No global dirty flag.
+
+### Proposed signal layout
+
+```rust
+// App-level (provided via context)
+let agents: Signal<Vec<Agent>> = use_signal(Vec::new);
+let connection: Signal<ConnectionState> = use_signal(|| ConnectionState::Disconnected);
+
+// Chat panel level
+let messages: Signal<Vec<ChatMessage>> = use_signal(Vec::new);
+let streaming: Signal<StreamingState> = use_signal(StreamingState::default);
+let input_text: Signal<String> = use_signal(String::new);
+```
+
+### 100ms debounce for text deltas
+
+Text deltas arrive at high frequency (every few tokens from the LLM). Writing to the signal on every delta causes excessive virtual DOM diffing.
+
+**Strategy:** `ChatStateManager` (implemented in `src/components/chat.rs`) buffers deltas and flushes to the signal when:
+
+1. 100ms has elapsed since the last flush, or
+2. A newline character is received (users notice line breaks immediately), or
+3. A non-delta event arrives (tool start, completion, etc.), or
+4. A periodic tick fires (100ms interval from `use_coroutine`).
+
+This is analogous to the TUI's 64-byte/newline markdown cache invalidation, but tuned for DOM diffing cost rather than terminal repainting.
+
+### Coroutine pattern
+
+```rust
+use_coroutine(|_rx| {
+    let streaming = streaming.clone();
+    let messages = messages.clone();
+    async move {
+        let mut mgr = ChatStateManager::new();
+        let mut state = ChatState::default();
+        let mut interval = tokio::time::interval(Duration::from_millis(100));
+
+        loop {
+            tokio::select! {
+                biased;
+                Some(event) = stream_rx.recv() => {
+                    if mgr.apply(event, &mut state) {
+                        streaming.set(state.streaming.clone());
+                        messages.set(state.messages.clone());
+                    }
+                }
+                _ = interval.tick() => {
+                    if mgr.tick(&mut state) {
+                        streaming.set(state.streaming.clone());
+                    }
+                }
+            }
+        }
+    }
+});
+```
+
+## Reconnection with exponential backoff
+
+### Parameters
+
+| Parameter | Value | Rationale |
+|-----------|-------|-----------|
+| Initial backoff | 1s | Fast first retry for transient failures |
+| Max backoff | 30s | Caps growth to avoid long waits |
+| Heartbeat timeout | 45s | Server sends pings every 30s; 50% margin |
+| Channel buffer | 256 | Matches TUI; prevents backpressure under burst |
+
+### Backoff sequence
+
+1s, 2s, 4s, 8s, 16s, 30s, 30s, ...
+
+On successful connection (`EsEvent::Open`), the backoff resets to 1s.
+
+### Heartbeat timeout
+
+The server sends `ping` events every 30 seconds on the global SSE channel. If 45 seconds pass with no event (including pings), the connection is treated as stale:
+
+1. Close the `EventSource`.
+2. Emit `SseEvent::Disconnected`.
+3. Enter the reconnection loop with current backoff.
+
+This is an increase from the TUI's 30-second read timeout. The TUI's aggressive timeout caused spurious reconnects under load; 45 seconds provides margin while still detecting genuinely hung connections within a minute.
+
+### Cancellation-safe shutdown
+
+The SSE connection loop uses `CancellationToken` from `tokio_util` (per workspace standards). All `sleep` and `next` calls are wrapped in `tokio::select!` with the cancel token as a biased first branch. This ensures clean shutdown without task leaks.
+
+```rust
+tokio::select! {
+    biased;
+    _ = child.cancelled() => return,
+    result = tokio::time::timeout(HEARTBEAT_TIMEOUT, es.next()) => result,
+}
+```
+
+## Abort support
+
+### Per-turn cancellation
+
+Each `stream_turn()` call accepts a `CancellationToken`. The background task checks this token in a biased `select!` alongside the event stream:
+
+```rust
+tokio::select! {
+    biased;
+    _ = cancel.cancelled() => {
+        es.close();
+        tx.send(StreamEvent::TurnAbort { reason: "cancelled by user" }).await;
+        return;
+    }
+    event = es.next() => { /* process */ }
+}
+```
+
+When the user clicks **Stop** in the UI, the component cancels the token. The background task:
+
+1. Closes the `EventSource` (drops the HTTP connection).
+2. Sends a `TurnAbort` event so the UI can finalize state.
+3. Exits.
+
+### UI binding
+
+```rust
+// In the chat component:
+let cancel_token = use_signal(CancellationToken::new);
+
+// Send button handler:
+let token = CancellationToken::new();
+cancel_token.set(token.clone());
+let rx = stream_turn(client, &url, &agent, &key, &msg, token.child_token());
+
+// Stop button handler:
+cancel_token.read().cancel();
+```
+
+### Partial text preservation
+
+When a turn is aborted, `ChatStateManager` preserves any partial text already generated. If the streaming text buffer is non-empty, it is committed to history as an assistant message. If no text was generated, no message is added. This matches user expectations: aborting mid-sentence keeps what was already visible.
+
+## Comparison with TUI's existing SSE implementation
+
+### Architecture
+
+| Aspect | TUI (`theatron-tui`) | Desktop (`theatron-desktop`) |
+|--------|---------------------|------------------------------|
+| Event loop | `tokio::select!` over 3 sources (terminal, SSE, stream) + tick | `use_coroutine` per stream; Dioxus manages render cycle |
+| State mutation | `Msg` enum dispatched to `update()` handlers | Direct signal writes from coroutine via `ChatStateManager` |
+| Re-render trigger | Dirty flag in full terminal repaint | Signal subscription for targeted component re-render |
+| Text buffering | 64-byte or newline markdown cache invalidation | 100ms or newline debounce on signal writes |
+| Abort | Not implemented (TUI has no stop button) | `CancellationToken` per turn with `select!` |
+| Shutdown | App exit drops tasks | `CancellationToken` hierarchy with graceful drain |
+| State machine | Scattered across `update/sse.rs` and `update/streaming.rs` handlers | Centralized in `ChatStateManager::apply()` |
+
+### SSE connection
+
+| Aspect | TUI | Desktop |
+|--------|-----|---------|
+| Struct | `SseConnection` (no cancel token) | `SseConnection` (with `CancellationToken`) |
+| Heartbeat timeout | 30s (`READ_TIMEOUT`) | 45s (`HEARTBEAT_TIMEOUT`) |
+| Backoff range | 1s to 30s | 1s to 30s (identical) |
+| Channel buffer | 256 | 256 (identical) |
+| Shutdown mechanism | Task dropped on app exit | `CancellationToken` for graceful shutdown |
+| Error surface | Toast notification | Signal-driven error banner component |
+| Sleep/next cancellation | Not cancel-safe (no `select!` around sleep) | All waits wrapped in `select!` with cancel branch |
+
+### Per-message streaming
+
+| Aspect | TUI | Desktop |
+|--------|-----|---------|
+| Function | `stream_message()` | `stream_turn()` |
+| Cancel support | None | `CancellationToken` in `select!` |
+| Error recovery | Shows toast, user retries manually | Sets `StreamingState.error`, user retries |
+| Text buffer | Immediate append to `app.streaming_text` | Debounced through `ChatStateManager` |
+| Turn finalization | `handle_stream_turn_complete()` updates history | `ChatStateManager::apply(TurnComplete)` commits to `messages` |
+
+### Event parsing
+
+Both use the same `parse_sse_event()` and `parse_stream_event()` functions with identical event type mapping. The parsing logic was copied rather than extracted to `theatron-core` to avoid premature abstraction. The TUI and desktop may diverge as the desktop gains features the TUI lacks (rich media rendering, inline tool approval dialogs).
+
+### What could be shared
+
+If both UIs stabilize on identical parsing logic, candidates for extraction to `theatron-core`:
+
+1. `parse_sse_event()` and `parse_stream_event()` functions.
+2. `SseEvent` and `StreamEvent` enums.
+3. `TurnOutcome`, `ActiveTurn`, and other serde types.
+4. ID newtypes (`NousId`, `SessionId`, `TurnId`, `ToolId`).
+5. `extract_error_message()` utility.
+
+This extraction is deferred until the desktop UI is feature-complete and the shared surface is validated.
+
+## Prototype component structure
+
+The prototype lives in `src/components/chat.rs` and implements the full state machine without a Dioxus dependency. The module provides:
+
+- **`ChatState`**: Complete chat state (messages, streaming, connection, agent, session).
+- **`ChatStateManager`**: Event processor with 100ms debounce buffer for text/thinking deltas.
+- **`ChatMessage`** and **`MessageRole`**: Committed conversation history entries.
+- **`apply_connection_event()`**: Maps SSE connect/disconnect to `ConnectionState` signal updates.
+
+The state machine handles the full turn lifecycle:
+
+```text
+Idle -[TurnStart]-> Streaming -[TextDelta*]-> Streaming
+                                |                  |
+                      [ToolStart]-> Tool Active -[ToolResult]-> Streaming
+                                |
+                      [TurnComplete]-> Idle (message committed)
+                      [TurnAbort]---> Idle (partial text preserved)
+                      [Error]-------> Error (streaming stopped)
+```
+
+Every state transition is covered by unit tests in the module, including a full turn lifecycle test that exercises: user message, turn start, text deltas, tool call, more text, turn complete, and final state verification.
+
+## Open questions
+
+1. **Markdown rendering:** The TUI uses `pulldown-cmark` with ratatui spans. Dioxus can render HTML natively. Should we parse markdown to HTML on each signal write, or use a Dioxus markdown component that subscribes to the raw text signal?
+
+2. **Virtual scrolling:** The TUI implements its own virtual scroll for long conversations. Dioxus has `use_virtual_list` or CSS-based approaches. The streaming text append pattern needs to work with whichever scroll strategy is chosen.
+
+3. **Multi-agent view:** The TUI's sidebar shows all agents with status badges driven by global SSE. The desktop version needs the same, but with richer UI (avatars, progress bars). The signal layout supports this via `agents: Signal<Vec<Agent>>`.
+
+4. **Offline/reconnection UX:** The TUI shows a toast after five minutes of disconnection. The desktop should show a persistent banner with retry countdown, driven by `ConnectionState::Reconnecting { attempt }`.
+
+5. **Shared type extraction timing:** The `theatron-core` crate is empty. When should the shared types be extracted? Proposed trigger: when the desktop reaches feature parity with the TUI on the streaming path and both parsers have been stable for two release cycles.

--- a/crates/theatron/desktop/src/api/mod.rs
+++ b/crates/theatron/desktop/src/api/mod.rs
@@ -1,0 +1,5 @@
+//! HTTP client, SSE connection, and per-message streaming for the desktop UI.
+
+pub mod sse;
+pub mod streaming;
+pub mod types;

--- a/crates/theatron/desktop/src/api/sse.rs
+++ b/crates/theatron/desktop/src/api/sse.rs
@@ -1,0 +1,442 @@
+//! Global SSE connection to `GET /api/v1/events`.
+//!
+//! Provides cross-session awareness: agent status changes, session lifecycle,
+//! and memory distillation progress. The connection auto-reconnects with
+//! exponential backoff (1s to 30s) and treats 45s of silence as a stale
+//! connection.
+//!
+//! # Dioxus integration
+//!
+//! In the TUI, `SseConnection::next()` feeds a `tokio::select!` loop.
+//! In Dioxus, the pattern shifts to a background coroutine that writes
+//! into signals:
+//!
+//! ```ignore
+//! use_coroutine(|_rx| async move {
+//!     let mut sse = SseConnection::connect(client, &base_url, cancel);
+//!     while let Some(event) = sse.next().await {
+//!         // write into Dioxus signals from here
+//!     }
+//! });
+//! ```
+//!
+//! The `SseConnection` struct is intentionally framework-agnostic so it
+//! works with both the TUI event loop and Dioxus coroutines.
+
+use futures_util::StreamExt;
+use reqwest::Client;
+use reqwest_eventsource::{Event as EsEvent, EventSource};
+use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
+use tracing::Instrument;
+
+use super::types::{NousId, SessionId, SseEvent, TurnId};
+
+/// If no SSE event (including pings) arrives within this window, the
+/// connection is treated as stale. The server sends heartbeats every 30s,
+/// so 45s gives 50% margin before triggering reconnect.
+const HEARTBEAT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(45);
+
+/// Initial backoff delay after a connection failure.
+const INITIAL_BACKOFF: std::time::Duration = std::time::Duration::from_secs(1);
+
+/// Maximum backoff delay — caps exponential growth.
+const MAX_BACKOFF: std::time::Duration = std::time::Duration::from_secs(30);
+
+/// Manages the global SSE connection to `/api/v1/events`.
+///
+/// Runs in a background tokio task. Parsed events flow through an mpsc
+/// channel. The connection automatically reconnects with exponential
+/// backoff on failure and treats prolonged silence as disconnect.
+///
+/// Supports graceful shutdown via `CancellationToken`. When the token
+/// fires, the background task exits cleanly.
+pub struct SseConnection {
+    rx: mpsc::Receiver<SseEvent>,
+    cancel: CancellationToken,
+    _handle: tokio::task::JoinHandle<()>,
+}
+
+impl SseConnection {
+    /// Connect using a shared HTTP client. Auth headers must already be
+    /// embedded in the client. `Accept: text/event-stream` is set
+    /// per-request to override any client-level JSON default.
+    ///
+    /// The returned `SseConnection` emits `Connected`/`Disconnected`
+    /// lifecycle events in addition to parsed server events.
+    #[tracing::instrument(skip_all)]
+    pub fn connect(client: Client, base_url: &str, cancel: CancellationToken) -> Self {
+        let (tx, rx) = mpsc::channel(256);
+        let url = format!("{}/api/v1/events", base_url.trim_end_matches('/'));
+        let child = cancel.child_token();
+
+        let span = tracing::info_span!("sse_connection");
+        let handle = tokio::spawn(
+            async move {
+                let mut backoff = INITIAL_BACKOFF;
+
+                loop {
+                    if child.is_cancelled() {
+                        return;
+                    }
+
+                    let req = client.get(&url).header("Accept", "text/event-stream");
+                    let mut es = match EventSource::new(req) {
+                        Ok(es) => es,
+                        Err(e) => {
+                            tracing::error!("failed to create SSE EventSource: {e}");
+                            let _ = tx.send(SseEvent::Disconnected).await;
+                            tokio::select! {
+                                biased;
+                                _ = child.cancelled() => return,
+                                _ = tokio::time::sleep(backoff) => {}
+                            }
+                            backoff = advance_backoff(backoff);
+                            continue;
+                        }
+                    };
+
+                    let _ = tx.send(SseEvent::Connected).await;
+                    let mut connected = false;
+
+                    loop {
+                        let maybe_event = tokio::select! {
+                            biased;
+                            _ = child.cancelled() => {
+                                es.close();
+                                return;
+                            }
+                            result = tokio::time::timeout(HEARTBEAT_TIMEOUT, es.next()) => result,
+                        };
+
+                        let event = match maybe_event {
+                            Ok(Some(event)) => event,
+                            Ok(None) => break,
+                            Err(_elapsed) => {
+                                // No event within HEARTBEAT_TIMEOUT. A healthy server
+                                // sends pings more frequently, so silence means the
+                                // connection is stale.
+                                tracing::warn!(
+                                    timeout_secs = HEARTBEAT_TIMEOUT.as_secs(),
+                                    "SSE heartbeat timeout — treating as disconnect"
+                                );
+                                es.close();
+                                break;
+                            }
+                        };
+
+                        match event {
+                            Ok(EsEvent::Open) => {
+                                tracing::info!("SSE connected");
+                                connected = true;
+                                backoff = INITIAL_BACKOFF;
+                            }
+                            Ok(EsEvent::Message(msg)) => {
+                                if let Some(parsed) = parse_sse_event(&msg.event, &msg.data)
+                                    && tx.send(parsed).await.is_err()
+                                {
+                                    // Receiver dropped — shut down.
+                                    return;
+                                }
+                            }
+                            Err(reqwest_eventsource::Error::InvalidStatusCode(status, resp)) => {
+                                let reason = status.canonical_reason().unwrap_or("Unknown");
+                                let body = resp.text().await.unwrap_or_default();
+                                let message = extract_error_message(&body, status.as_u16(), reason);
+                                tracing::warn!("SSE error: {message}");
+                                es.close();
+                                break;
+                            }
+                            Err(e) => {
+                                tracing::warn!("SSE error: {e}");
+                                es.close();
+                                break;
+                            }
+                        }
+                    }
+
+                    let _ = tx.send(SseEvent::Disconnected).await;
+                    if !connected {
+                        backoff = advance_backoff(backoff);
+                    }
+                    tracing::info!(backoff_secs = backoff.as_secs(), "SSE reconnecting");
+                    tokio::select! {
+                        biased;
+                        _ = child.cancelled() => return,
+                        _ = tokio::time::sleep(backoff) => {}
+                    }
+                }
+            }
+            .instrument(span),
+        );
+
+        SseConnection {
+            rx,
+            cancel,
+            _handle: handle,
+        }
+    }
+
+    /// Receive the next parsed SSE event. Returns `None` when the
+    /// connection task exits (shutdown or channel closed).
+    pub async fn next(&mut self) -> Option<SseEvent> {
+        self.rx.recv().await
+    }
+
+    /// Signal the background task to shut down.
+    pub fn shutdown(&self) {
+        self.cancel.cancel();
+    }
+}
+
+/// Advance exponential backoff: double the interval, capped at `MAX_BACKOFF`.
+#[must_use]
+fn advance_backoff(current: std::time::Duration) -> std::time::Duration {
+    (current * 2).min(MAX_BACKOFF)
+}
+
+/// Extract a human-readable error message from an HTTP error response body.
+fn extract_error_message(body: &str, status_code: u16, reason: &str) -> String {
+    if let Ok(json) = serde_json::from_str::<serde_json::Value>(body) {
+        json.get("message")
+            .or_else(|| json.get("error"))
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string())
+            .unwrap_or_else(|| format!("{status_code} {reason}"))
+    } else {
+        format!("{status_code} {reason}")
+    }
+}
+
+fn str_field<'a>(json: &'a serde_json::Value, field: &str, event_type: &str) -> Option<&'a str> {
+    json.get(field).and_then(|v| v.as_str()).or_else(|| {
+        tracing::warn!(event_type, field, "missing required field in SSE event");
+        None
+    })
+}
+
+fn parse_sse_event(event_type: &str, data: &str) -> Option<SseEvent> {
+    let json: serde_json::Value = match serde_json::from_str(data) {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::warn!(event_type, error = %e, "failed to parse SSE event JSON");
+            return None;
+        }
+    };
+
+    match event_type {
+        "init" => {
+            let active_turns = json
+                .get("activeTurns")
+                .and_then(|v| serde_json::from_value(v.clone()).ok())
+                .or_else(|| {
+                    tracing::warn!("SSE init: missing or invalid activeTurns");
+                    None
+                })?;
+            Some(SseEvent::Init { active_turns })
+        }
+        "turn:before" => Some(SseEvent::TurnBefore {
+            nous_id: NousId::from(str_field(&json, "nousId", event_type)?.to_string()),
+            session_id: SessionId::from(str_field(&json, "sessionId", event_type)?.to_string()),
+            turn_id: TurnId::from(str_field(&json, "turnId", event_type)?.to_string()),
+        }),
+        "turn:after" => Some(SseEvent::TurnAfter {
+            nous_id: NousId::from(str_field(&json, "nousId", event_type)?.to_string()),
+            session_id: SessionId::from(str_field(&json, "sessionId", event_type)?.to_string()),
+        }),
+        "tool:called" => Some(SseEvent::ToolCalled {
+            nous_id: NousId::from(str_field(&json, "nousId", event_type)?.to_string()),
+            tool_name: str_field(&json, "toolName", event_type)?.to_string(),
+        }),
+        "tool:failed" => Some(SseEvent::ToolFailed {
+            nous_id: NousId::from(str_field(&json, "nousId", event_type)?.to_string()),
+            tool_name: str_field(&json, "toolName", event_type)?.to_string(),
+            error: json
+                .get("error")
+                .and_then(|e| e.as_str())
+                .unwrap_or("unknown")
+                .to_string(),
+        }),
+        "status:update" => Some(SseEvent::StatusUpdate {
+            nous_id: NousId::from(str_field(&json, "nousId", event_type)?.to_string()),
+            status: str_field(&json, "status", event_type)?.to_string(),
+        }),
+        "session:created" => Some(SseEvent::SessionCreated {
+            nous_id: NousId::from(str_field(&json, "nousId", event_type)?.to_string()),
+            session_id: SessionId::from(str_field(&json, "sessionId", event_type)?.to_string()),
+        }),
+        "session:archived" => Some(SseEvent::SessionArchived {
+            nous_id: NousId::from(str_field(&json, "nousId", event_type)?.to_string()),
+            session_id: SessionId::from(str_field(&json, "sessionId", event_type)?.to_string()),
+        }),
+        "distill:before" => Some(SseEvent::DistillBefore {
+            nous_id: NousId::from(str_field(&json, "nousId", event_type)?.to_string()),
+        }),
+        "distill:stage" => Some(SseEvent::DistillStage {
+            nous_id: NousId::from(str_field(&json, "nousId", event_type)?.to_string()),
+            stage: str_field(&json, "stage", event_type)?.to_string(),
+        }),
+        "distill:after" => Some(SseEvent::DistillAfter {
+            nous_id: NousId::from(str_field(&json, "nousId", event_type)?.to_string()),
+        }),
+        "ping" => Some(SseEvent::Ping),
+        other => {
+            tracing::debug!("unknown SSE event type: {other}");
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_turn_before_valid() {
+        let data = r#"{"nousId":"syn","sessionId":"sess-1","turnId":"turn-1"}"#;
+        let result = parse_sse_event("turn:before", data);
+        assert!(result.is_some());
+        if let Some(SseEvent::TurnBefore {
+            nous_id,
+            session_id,
+            turn_id,
+        }) = result
+        {
+            assert_eq!(&*nous_id, "syn");
+            assert_eq!(&*session_id, "sess-1");
+            assert_eq!(&*turn_id, "turn-1");
+        } else {
+            panic!("expected TurnBefore");
+        }
+    }
+
+    #[test]
+    fn parse_invalid_json_returns_none() {
+        let result = parse_sse_event("turn:before", "not json");
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn parse_missing_field_returns_none() {
+        let data = r#"{"nousId":"syn"}"#;
+        let result = parse_sse_event("turn:before", data);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn parse_unknown_event_returns_none() {
+        let data = r#"{"foo":"bar"}"#;
+        let result = parse_sse_event("custom:unknown", data);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn parse_init_with_active_turns() {
+        let data = r#"{"activeTurns":[{"nousId":"syn","sessionId":"s1","turnId":"t1"}]}"#;
+        let result = parse_sse_event("init", data);
+        assert!(result.is_some());
+        if let Some(SseEvent::Init { active_turns }) = result {
+            assert_eq!(active_turns.len(), 1);
+            assert_eq!(&*active_turns[0].nous_id, "syn");
+        } else {
+            panic!("expected Init");
+        }
+    }
+
+    #[test]
+    fn parse_ping() {
+        let data = r#"{}"#;
+        let result = parse_sse_event("ping", data);
+        assert!(matches!(result, Some(SseEvent::Ping)));
+    }
+
+    #[test]
+    fn parse_tool_called() {
+        let data = r#"{"nousId":"syn","toolName":"read_file"}"#;
+        let result = parse_sse_event("tool:called", data);
+        if let Some(SseEvent::ToolCalled { nous_id, tool_name }) = result {
+            assert_eq!(&*nous_id, "syn");
+            assert_eq!(tool_name, "read_file");
+        } else {
+            panic!("expected ToolCalled");
+        }
+    }
+
+    #[test]
+    fn parse_tool_failed_with_default_error() {
+        let data = r#"{"nousId":"syn","toolName":"exec"}"#;
+        let result = parse_sse_event("tool:failed", data);
+        if let Some(SseEvent::ToolFailed {
+            error, tool_name, ..
+        }) = result
+        {
+            assert_eq!(tool_name, "exec");
+            assert_eq!(error, "unknown");
+        } else {
+            panic!("expected ToolFailed");
+        }
+    }
+
+    #[test]
+    fn parse_distill_stage() {
+        let data = r#"{"nousId":"syn","stage":"extracting"}"#;
+        let result = parse_sse_event("distill:stage", data);
+        if let Some(SseEvent::DistillStage { nous_id, stage }) = result {
+            assert_eq!(&*nous_id, "syn");
+            assert_eq!(stage, "extracting");
+        } else {
+            panic!("expected DistillStage");
+        }
+    }
+
+    #[test]
+    fn parse_session_created() {
+        let data = r#"{"nousId":"syn","sessionId":"s-new"}"#;
+        let result = parse_sse_event("session:created", data);
+        if let Some(SseEvent::SessionCreated {
+            nous_id,
+            session_id,
+        }) = result
+        {
+            assert_eq!(&*nous_id, "syn");
+            assert_eq!(&*session_id, "s-new");
+        } else {
+            panic!("expected SessionCreated");
+        }
+    }
+
+    #[test]
+    fn advance_backoff_doubles() {
+        let b = advance_backoff(std::time::Duration::from_secs(1));
+        assert_eq!(b, std::time::Duration::from_secs(2));
+    }
+
+    #[test]
+    fn advance_backoff_caps_at_max() {
+        let b = advance_backoff(std::time::Duration::from_secs(20));
+        assert_eq!(b, MAX_BACKOFF);
+    }
+
+    #[test]
+    fn extract_error_message_json() {
+        let body = r#"{"message":"rate limited"}"#;
+        assert_eq!(
+            extract_error_message(body, 429, "Too Many Requests"),
+            "rate limited"
+        );
+    }
+
+    #[test]
+    fn extract_error_message_fallback() {
+        assert_eq!(
+            extract_error_message("not json", 500, "Internal"),
+            "500 Internal"
+        );
+    }
+
+    #[test]
+    fn extract_error_message_error_field() {
+        let body = r#"{"error":"forbidden"}"#;
+        assert_eq!(extract_error_message(body, 403, "Forbidden"), "forbidden");
+    }
+}

--- a/crates/theatron/desktop/src/api/streaming.rs
+++ b/crates/theatron/desktop/src/api/streaming.rs
@@ -1,0 +1,422 @@
+//! Per-session streaming from `POST /api/v1/sessions/stream`.
+//!
+//! Each call to `stream_turn` starts a new HTTP SSE request and returns
+//! a receiver that yields `StreamEvent`s. The stream is self-terminating:
+//! it closes after `TurnComplete`, `TurnAbort`, or `Error`.
+//!
+//! # Abort support
+//!
+//! Pass a `CancellationToken` to `stream_turn`. When cancelled, the
+//! background task closes the `EventSource` immediately, freeing the
+//! HTTP connection. The Dioxus component triggers cancellation via a
+//! stop button bound to the token.
+//!
+//! # Dioxus integration
+//!
+//! ```ignore
+//! let cancel = CancellationToken::new();
+//! let mut rx = stream_turn(client, &url, &agent, &key, &msg, cancel.child_token());
+//!
+//! // In a coroutine:
+//! while let Some(event) = rx.recv().await {
+//!     match event {
+//!         StreamEvent::TextDelta(text) => {
+//!             streaming_state.write().text.push_str(&text);
+//!         }
+//!         StreamEvent::TurnComplete { outcome } => { /* finalize */ }
+//!         _ => { /* handle other events */ }
+//!     }
+//! }
+//!
+//! // On abort button:
+//! cancel.cancel();
+//! ```
+
+use futures_util::StreamExt;
+use reqwest::Client;
+use reqwest_eventsource::{Event as EsEvent, EventSource};
+use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
+use tracing::Instrument;
+
+use super::types::{NousId, SessionId, StreamEvent, ToolId, TurnId};
+
+/// Start streaming a turn response.
+///
+/// Returns a channel receiver that yields `StreamEvent`s until the turn
+/// completes, aborts, or errors. The background task respects the
+/// `cancel` token for user-initiated abort.
+///
+/// `client` must have auth headers pre-configured. `Accept: text/event-stream`
+/// is set per-request.
+#[tracing::instrument(skip_all, fields(nous_id, session_key))]
+pub fn stream_turn(
+    client: Client,
+    base_url: &str,
+    nous_id: &str,
+    session_key: &str,
+    message: &str,
+    cancel: CancellationToken,
+) -> mpsc::Receiver<StreamEvent> {
+    let (tx, rx) = mpsc::channel(256);
+    let url = format!("{}/api/v1/sessions/stream", base_url.trim_end_matches('/'));
+
+    let body = serde_json::json!({
+        "message": message,
+        "agentId": nous_id,
+        "sessionKey": session_key,
+    });
+
+    let builder = client
+        .post(&url)
+        .json(&body)
+        .header("Accept", "text/event-stream");
+
+    let span = tracing::info_span!("stream_turn");
+    tokio::spawn(
+        async move {
+            let mut es = match EventSource::new(builder) {
+                Ok(es) => es,
+                Err(e) => {
+                    let _ = tx
+                        .send(StreamEvent::Error(format!("failed to connect: {e}")))
+                        .await;
+                    return;
+                }
+            };
+
+            loop {
+                let maybe_event = tokio::select! {
+                    biased;
+                    _ = cancel.cancelled() => {
+                        tracing::info!("stream cancelled by user");
+                        es.close();
+                        let _ = tx.send(StreamEvent::TurnAbort {
+                            reason: "cancelled by user".to_string(),
+                        }).await;
+                        return;
+                    }
+                    event = es.next() => event,
+                };
+
+                let Some(event) = maybe_event else { break };
+
+                match event {
+                    Ok(EsEvent::Open) => {}
+                    Ok(EsEvent::Message(msg)) => {
+                        if let Some(parsed) = parse_stream_event(&msg.event, &msg.data) {
+                            let is_terminal = matches!(
+                                &parsed,
+                                StreamEvent::TurnComplete { .. }
+                                    | StreamEvent::TurnAbort { .. }
+                                    | StreamEvent::Error(_)
+                            );
+                            if tx.send(parsed).await.is_err() {
+                                break;
+                            }
+                            if is_terminal {
+                                es.close();
+                                break;
+                            }
+                        }
+                    }
+                    Err(reqwest_eventsource::Error::InvalidStatusCode(status, resp)) => {
+                        let reason = status.canonical_reason().unwrap_or("Unknown");
+                        let body = resp.text().await.unwrap_or_default();
+                        let message = extract_error_message(&body, status.as_u16(), reason);
+                        let _ = tx.send(StreamEvent::Error(message)).await;
+                        es.close();
+                        break;
+                    }
+                    Err(e) => {
+                        let _ = tx
+                            .send(StreamEvent::Error(format!("stream error: {e}")))
+                            .await;
+                        es.close();
+                        break;
+                    }
+                }
+            }
+        }
+        .instrument(span),
+    );
+
+    rx
+}
+
+/// Extract a human-readable error message from an HTTP error response body.
+fn extract_error_message(body: &str, status_code: u16, reason: &str) -> String {
+    if let Ok(json) = serde_json::from_str::<serde_json::Value>(body) {
+        json.get("message")
+            .or_else(|| json.get("error"))
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string())
+            .unwrap_or_else(|| format!("{status_code} {reason}"))
+    } else {
+        format!("{status_code} {reason}")
+    }
+}
+
+fn str_field<'a>(json: &'a serde_json::Value, field: &str, event_type: &str) -> Option<&'a str> {
+    json.get(field).and_then(|v| v.as_str()).or_else(|| {
+        tracing::warn!(event_type, field, "missing required field in stream event");
+        None
+    })
+}
+
+fn parse_stream_event(event_type: &str, data: &str) -> Option<StreamEvent> {
+    let json: serde_json::Value = match serde_json::from_str(data) {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::warn!(event_type, error = %e, "failed to parse stream event JSON");
+            return None;
+        }
+    };
+
+    match event_type {
+        "turn_start" => Some(StreamEvent::TurnStart {
+            session_id: SessionId::from(str_field(&json, "sessionId", event_type)?.to_string()),
+            nous_id: NousId::from(str_field(&json, "nousId", event_type)?.to_string()),
+            turn_id: TurnId::from(str_field(&json, "turnId", event_type)?.to_string()),
+        }),
+        "text_delta" => Some(StreamEvent::TextDelta(
+            str_field(&json, "text", event_type)?.to_string(),
+        )),
+        "thinking_delta" => Some(StreamEvent::ThinkingDelta(
+            str_field(&json, "text", event_type)?.to_string(),
+        )),
+        "tool_start" => Some(StreamEvent::ToolStart {
+            tool_name: str_field(&json, "toolName", event_type)?.to_string(),
+            tool_id: ToolId::from(str_field(&json, "toolId", event_type)?.to_string()),
+        }),
+        "tool_result" => {
+            let tool_name = str_field(&json, "toolName", event_type)?.to_string();
+            let tool_id = ToolId::from(str_field(&json, "toolId", event_type)?.to_string());
+            let is_error = json.get("isError").and_then(|v| v.as_bool()).or_else(|| {
+                tracing::warn!(
+                    event_type,
+                    field = "isError",
+                    "missing required field in stream event"
+                );
+                None
+            })?;
+            let duration_ms = json
+                .get("durationMs")
+                .and_then(|v| v.as_u64())
+                .or_else(|| {
+                    tracing::warn!(
+                        event_type,
+                        field = "durationMs",
+                        "missing required field in stream event"
+                    );
+                    None
+                })?;
+            Some(StreamEvent::ToolResult {
+                tool_name,
+                tool_id,
+                is_error,
+                duration_ms,
+            })
+        }
+        "tool_approval_required" => Some(StreamEvent::ToolApprovalRequired {
+            turn_id: TurnId::from(str_field(&json, "turnId", event_type)?.to_string()),
+            tool_name: str_field(&json, "toolName", event_type)?.to_string(),
+            tool_id: ToolId::from(str_field(&json, "toolId", event_type)?.to_string()),
+            input: json
+                .get("input")
+                .cloned()
+                .unwrap_or(serde_json::Value::Null),
+            risk: str_field(&json, "risk", event_type)?.to_string(),
+            reason: str_field(&json, "reason", event_type)?.to_string(),
+        }),
+        "tool_approval_resolved" => Some(StreamEvent::ToolApprovalResolved {
+            tool_id: ToolId::from(str_field(&json, "toolId", event_type)?.to_string()),
+            decision: str_field(&json, "decision", event_type)?.to_string(),
+        }),
+        "turn_complete" => {
+            let outcome = json
+                .get("outcome")
+                .and_then(|v| serde_json::from_value(v.clone()).ok())
+                .or_else(|| {
+                    tracing::warn!(event_type, "missing or invalid outcome in stream event");
+                    None
+                })?;
+            Some(StreamEvent::TurnComplete { outcome })
+        }
+        "turn_abort" => Some(StreamEvent::TurnAbort {
+            reason: str_field(&json, "reason", event_type)?.to_string(),
+        }),
+        "error" => Some(StreamEvent::Error(
+            str_field(&json, "message", event_type)?.to_string(),
+        )),
+        "queue_drained" => {
+            tracing::debug!("queue drained: {json}");
+            None
+        }
+        other => {
+            tracing::debug!("unknown stream event: {other}");
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_text_delta_valid() {
+        let data = r#"{"text":"hello"}"#;
+        let result = parse_stream_event("text_delta", data);
+        assert!(matches!(result, Some(StreamEvent::TextDelta(ref t)) if t == "hello"));
+    }
+
+    #[test]
+    fn parse_thinking_delta_valid() {
+        let data = r#"{"text":"reasoning step"}"#;
+        let result = parse_stream_event("thinking_delta", data);
+        assert!(matches!(result, Some(StreamEvent::ThinkingDelta(ref t)) if t == "reasoning step"));
+    }
+
+    #[test]
+    fn parse_turn_start_valid() {
+        let data = r#"{"sessionId":"s1","nousId":"syn","turnId":"t1"}"#;
+        let result = parse_stream_event("turn_start", data);
+        if let Some(StreamEvent::TurnStart {
+            session_id,
+            nous_id,
+            turn_id,
+        }) = result
+        {
+            assert_eq!(&*session_id, "s1");
+            assert_eq!(&*nous_id, "syn");
+            assert_eq!(&*turn_id, "t1");
+        } else {
+            panic!("expected TurnStart");
+        }
+    }
+
+    #[test]
+    fn parse_turn_complete_valid() {
+        let data = r#"{"outcome":{"text":"done","nousId":"syn","sessionId":"s1","model":"gpt","toolCalls":0,"inputTokens":100,"outputTokens":50,"cacheReadTokens":0,"cacheWriteTokens":0}}"#;
+        let result = parse_stream_event("turn_complete", data);
+        if let Some(StreamEvent::TurnComplete { outcome }) = result {
+            assert_eq!(outcome.text, "done");
+            assert_eq!(&*outcome.nous_id, "syn");
+        } else {
+            panic!("expected TurnComplete");
+        }
+    }
+
+    #[test]
+    fn parse_tool_result_valid() {
+        let data = r#"{"toolName":"exec","toolId":"t1","isError":false,"durationMs":150}"#;
+        let result = parse_stream_event("tool_result", data);
+        if let Some(StreamEvent::ToolResult {
+            tool_name,
+            is_error,
+            duration_ms,
+            ..
+        }) = result
+        {
+            assert_eq!(tool_name, "exec");
+            assert!(!is_error);
+            assert_eq!(duration_ms, 150);
+        } else {
+            panic!("expected ToolResult");
+        }
+    }
+
+    #[test]
+    fn parse_tool_start_valid() {
+        let data = r#"{"toolName":"read_file","toolId":"t1"}"#;
+        let result = parse_stream_event("tool_start", data);
+        if let Some(StreamEvent::ToolStart { tool_name, tool_id }) = result {
+            assert_eq!(tool_name, "read_file");
+            assert_eq!(&*tool_id, "t1");
+        } else {
+            panic!("expected ToolStart");
+        }
+    }
+
+    #[test]
+    fn parse_error_event() {
+        let data = r#"{"message":"rate limited"}"#;
+        let result = parse_stream_event("error", data);
+        assert!(matches!(result, Some(StreamEvent::Error(ref m)) if m == "rate limited"));
+    }
+
+    #[test]
+    fn parse_turn_abort() {
+        let data = r#"{"reason":"guard rejected"}"#;
+        let result = parse_stream_event("turn_abort", data);
+        if let Some(StreamEvent::TurnAbort { reason }) = result {
+            assert_eq!(reason, "guard rejected");
+        } else {
+            panic!("expected TurnAbort");
+        }
+    }
+
+    #[test]
+    fn parse_invalid_json_returns_none() {
+        let result = parse_stream_event("text_delta", "{broken");
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn parse_queue_drained_returns_none() {
+        let data = r#"{"count":0}"#;
+        let result = parse_stream_event("queue_drained", data);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn parse_unknown_event_returns_none() {
+        let data = r#"{"foo":"bar"}"#;
+        let result = parse_stream_event("custom:event", data);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn parse_tool_approval_required() {
+        let data = r#"{
+            "turnId": "t1",
+            "toolName": "exec",
+            "toolId": "tool-1",
+            "input": {"command": "rm -rf /"},
+            "risk": "high",
+            "reason": "destructive command"
+        }"#;
+        let result = parse_stream_event("tool_approval_required", data);
+        if let Some(StreamEvent::ToolApprovalRequired {
+            tool_name,
+            risk,
+            reason,
+            ..
+        }) = result
+        {
+            assert_eq!(tool_name, "exec");
+            assert_eq!(risk, "high");
+            assert_eq!(reason, "destructive command");
+        } else {
+            panic!("expected ToolApprovalRequired");
+        }
+    }
+
+    #[test]
+    fn extract_error_message_json() {
+        let body = r#"{"message":"rate limited"}"#;
+        assert_eq!(
+            extract_error_message(body, 429, "Too Many Requests"),
+            "rate limited"
+        );
+    }
+
+    #[test]
+    fn extract_error_message_fallback() {
+        assert_eq!(
+            extract_error_message("not json", 500, "Internal"),
+            "500 Internal"
+        );
+    }
+}

--- a/crates/theatron/desktop/src/api/types.rs
+++ b/crates/theatron/desktop/src/api/types.rs
@@ -1,0 +1,376 @@
+//! Shared types for SSE and streaming events.
+//!
+//! These mirror the TUI's type system but use `compact_str::CompactString`
+//! newtypes consistent with workspace conventions.
+
+use compact_str::CompactString;
+use serde::{Deserialize, Serialize};
+
+/// Newtype for agent (nous) identifiers.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct NousId(CompactString);
+
+impl NousId {
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl From<String> for NousId {
+    fn from(s: String) -> Self {
+        Self(CompactString::from(s))
+    }
+}
+
+impl From<&str> for NousId {
+    fn from(s: &str) -> Self {
+        Self(CompactString::from(s))
+    }
+}
+
+impl std::ops::Deref for NousId {
+    type Target = str;
+    fn deref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl PartialEq<str> for NousId {
+    fn eq(&self, other: &str) -> bool {
+        self.0.as_str() == other
+    }
+}
+
+/// Newtype for session identifiers.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct SessionId(CompactString);
+
+impl SessionId {
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl From<String> for SessionId {
+    fn from(s: String) -> Self {
+        Self(CompactString::from(s))
+    }
+}
+
+impl From<&str> for SessionId {
+    fn from(s: &str) -> Self {
+        Self(CompactString::from(s))
+    }
+}
+
+impl std::ops::Deref for SessionId {
+    type Target = str;
+    fn deref(&self) -> &str {
+        &self.0
+    }
+}
+
+/// Newtype for turn identifiers.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct TurnId(CompactString);
+
+impl From<String> for TurnId {
+    fn from(s: String) -> Self {
+        Self(CompactString::from(s))
+    }
+}
+
+impl From<&str> for TurnId {
+    fn from(s: &str) -> Self {
+        Self(CompactString::from(s))
+    }
+}
+
+impl std::ops::Deref for TurnId {
+    type Target = str;
+    fn deref(&self) -> &str {
+        &self.0
+    }
+}
+
+/// Newtype for tool call identifiers.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct ToolId(CompactString);
+
+impl From<String> for ToolId {
+    fn from(s: String) -> Self {
+        Self(CompactString::from(s))
+    }
+}
+
+impl From<&str> for ToolId {
+    fn from(s: &str) -> Self {
+        Self(CompactString::from(s))
+    }
+}
+
+impl std::ops::Deref for ToolId {
+    type Target = str;
+    fn deref(&self) -> &str {
+        &self.0
+    }
+}
+
+/// Global SSE events from `GET /api/v1/events`.
+///
+/// These provide cross-session awareness: agent status changes, session
+/// lifecycle events, and memory distillation progress.
+#[non_exhaustive]
+#[derive(Debug, Clone)]
+pub enum SseEvent {
+    Connected,
+    Disconnected,
+    Init {
+        active_turns: Vec<ActiveTurn>,
+    },
+    TurnBefore {
+        nous_id: NousId,
+        session_id: SessionId,
+        turn_id: TurnId,
+    },
+    TurnAfter {
+        nous_id: NousId,
+        session_id: SessionId,
+    },
+    ToolCalled {
+        nous_id: NousId,
+        tool_name: String,
+    },
+    ToolFailed {
+        nous_id: NousId,
+        tool_name: String,
+        error: String,
+    },
+    StatusUpdate {
+        nous_id: NousId,
+        status: String,
+    },
+    SessionCreated {
+        nous_id: NousId,
+        session_id: SessionId,
+    },
+    SessionArchived {
+        nous_id: NousId,
+        session_id: SessionId,
+    },
+    DistillBefore {
+        nous_id: NousId,
+    },
+    DistillStage {
+        nous_id: NousId,
+        stage: String,
+    },
+    DistillAfter {
+        nous_id: NousId,
+    },
+    Ping,
+}
+
+/// Per-session streaming events from `POST /api/v1/sessions/stream`.
+///
+/// These carry the LLM response for a single turn: text deltas, tool
+/// invocations, plan execution, and completion/abort signals.
+#[non_exhaustive]
+#[derive(Debug, Clone)]
+pub enum StreamEvent {
+    TurnStart {
+        session_id: SessionId,
+        nous_id: NousId,
+        turn_id: TurnId,
+    },
+    TextDelta(String),
+    ThinkingDelta(String),
+    ToolStart {
+        tool_name: String,
+        tool_id: ToolId,
+    },
+    ToolResult {
+        tool_name: String,
+        tool_id: ToolId,
+        is_error: bool,
+        duration_ms: u64,
+    },
+    ToolApprovalRequired {
+        turn_id: TurnId,
+        tool_name: String,
+        tool_id: ToolId,
+        input: serde_json::Value,
+        risk: String,
+        reason: String,
+    },
+    ToolApprovalResolved {
+        tool_id: ToolId,
+        decision: String,
+    },
+    TurnComplete {
+        outcome: TurnOutcome,
+    },
+    TurnAbort {
+        reason: String,
+    },
+    Error(String),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ActiveTurn {
+    #[serde(rename = "nousId")]
+    pub nous_id: NousId,
+    #[serde(rename = "sessionId")]
+    pub session_id: SessionId,
+    #[serde(rename = "turnId")]
+    pub turn_id: TurnId,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TurnOutcome {
+    pub text: String,
+    #[serde(rename = "nousId")]
+    pub nous_id: NousId,
+    #[serde(rename = "sessionId")]
+    pub session_id: SessionId,
+    pub model: String,
+    #[serde(rename = "toolCalls", default)]
+    pub tool_calls: u32,
+    #[serde(rename = "inputTokens", default)]
+    pub input_tokens: u32,
+    #[serde(rename = "outputTokens", default)]
+    pub output_tokens: u32,
+    #[serde(rename = "cacheReadTokens", default)]
+    pub cache_read_tokens: u32,
+    #[serde(rename = "cacheWriteTokens", default)]
+    pub cache_write_tokens: u32,
+    #[serde(default)]
+    pub error: Option<String>,
+}
+
+/// Connection state for the global SSE stream.
+/// Dioxus components read this to render connection indicators.
+#[non_exhaustive]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ConnectionState {
+    /// Initial state, not yet attempted.
+    Disconnected,
+    /// Actively receiving events.
+    Connected,
+    /// Reconnecting after failure. `attempt` counts consecutive failures.
+    Reconnecting { attempt: u32 },
+}
+
+/// State of a single streaming turn, suitable for driving a Dioxus signal.
+#[derive(Debug, Clone, Default)]
+pub struct StreamingState {
+    /// Accumulated response text (not yet committed to history).
+    pub text: String,
+    /// Accumulated extended thinking output.
+    pub thinking: String,
+    /// Active tool calls in progress.
+    pub tool_calls: Vec<ToolCallInfo>,
+    /// Whether the stream is actively receiving deltas.
+    pub is_streaming: bool,
+    /// Turn ID if a turn is in progress.
+    pub turn_id: Option<TurnId>,
+    /// Error message if the stream errored.
+    pub error: Option<String>,
+}
+
+/// Information about a single tool invocation during streaming.
+#[derive(Debug, Clone)]
+pub struct ToolCallInfo {
+    pub tool_name: String,
+    pub tool_id: ToolId,
+    pub is_error: bool,
+    pub duration_ms: Option<u64>,
+    pub completed: bool,
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "test assertions may panic on failure")]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn nous_id_from_string() {
+        let id = NousId::from("syn".to_string());
+        assert_eq!(id.as_str(), "syn");
+    }
+
+    #[test]
+    fn nous_id_deref_eq() {
+        let id = NousId::from("syn");
+        assert_eq!(&*id, "syn");
+        assert!(id == *"syn");
+    }
+
+    #[test]
+    fn session_id_from_str() {
+        let id = SessionId::from("sess-1");
+        assert_eq!(id.as_str(), "sess-1");
+    }
+
+    #[test]
+    fn turn_outcome_deserialize() {
+        let json = r#"{
+            "text": "response",
+            "nousId": "syn",
+            "sessionId": "s1",
+            "model": "claude-opus-4-6",
+            "toolCalls": 3,
+            "inputTokens": 100,
+            "outputTokens": 50
+        }"#;
+        let outcome: TurnOutcome = serde_json::from_str(json).unwrap();
+        assert_eq!(outcome.text, "response");
+        assert_eq!(outcome.tool_calls, 3);
+        assert_eq!(outcome.input_tokens, 100);
+        assert_eq!(outcome.cache_read_tokens, 0);
+    }
+
+    #[test]
+    fn active_turn_deserialize() {
+        let json = r#"{"nousId":"syn","sessionId":"s1","turnId":"t1"}"#;
+        let turn: ActiveTurn = serde_json::from_str(json).unwrap();
+        assert_eq!(&*turn.nous_id, "syn");
+        assert_eq!(&*turn.session_id, "s1");
+        assert_eq!(&*turn.turn_id, "t1");
+    }
+
+    #[test]
+    fn streaming_state_default() {
+        let state = StreamingState::default();
+        assert!(!state.is_streaming);
+        assert!(state.text.is_empty());
+        assert!(state.turn_id.is_none());
+        assert!(state.error.is_none());
+    }
+
+    #[test]
+    fn connection_state_equality() {
+        assert_eq!(ConnectionState::Connected, ConnectionState::Connected);
+        assert_ne!(ConnectionState::Connected, ConnectionState::Disconnected);
+        assert_eq!(
+            ConnectionState::Reconnecting { attempt: 3 },
+            ConnectionState::Reconnecting { attempt: 3 },
+        );
+    }
+
+    #[test]
+    fn tool_call_info_construction() {
+        let info = ToolCallInfo {
+            tool_name: "read_file".to_string(),
+            tool_id: ToolId::from("t1"),
+            is_error: false,
+            duration_ms: Some(150),
+            completed: true,
+        };
+        assert_eq!(info.tool_name, "read_file");
+        assert!(!info.is_error);
+        assert!(info.completed);
+    }
+}

--- a/crates/theatron/desktop/src/components/chat.rs
+++ b/crates/theatron/desktop/src/components/chat.rs
@@ -1,0 +1,750 @@
+//! Streaming chat component state machine.
+//!
+//! This module implements the state management logic for a streaming chat
+//! component in Dioxus. It processes `StreamEvent`s into renderable state,
+//! with 100ms debounce for text deltas to avoid excessive re-renders.
+//!
+//! # Architecture
+//!
+//! ```text
+//!   ┌─────────────┐     stream_turn()     ┌──────────────┐
+//!   │  User Input  │ ───────────────────►  │  SSE Stream   │
+//!   │  Component   │                       │  (per-turn)   │
+//!   └─────────────┘                       └──────┬───────┘
+//!                                                │
+//!                                    StreamEvent  │
+//!                                                ▼
+//!   ┌─────────────┐   100ms debounce   ┌──────────────┐
+//!   │   Rendered   │ ◄──────────────── │  ChatState    │
+//!   │   Output     │                   │  (signals)    │
+//!   └─────────────┘                    └──────────────┘
+//! ```
+//!
+//! # Signal-based state
+//!
+//! In Dioxus, each piece of mutable UI state is a `Signal<T>`. When
+//! written, dependents re-render. The `ChatState` below models what
+//! signals would hold; in production, each field becomes a `Signal<T>`
+//! inside a Dioxus component scope.
+//!
+//! # Debounce strategy
+//!
+//! Text deltas arrive at high frequency (every few tokens). Writing to
+//! the signal on every delta causes excessive re-renders. Instead:
+//!
+//! 1. Accumulate deltas into a local buffer.
+//! 2. Flush to the signal when 100ms elapses or a non-delta event arrives.
+//! 3. Also flush on newlines (users notice line breaks immediately).
+//!
+//! This mirrors the TUI's 64-byte/newline markdown cache invalidation
+//! but is tuned for Dioxus's virtual DOM diffing cost.
+
+use std::time::{Duration, Instant};
+
+use crate::api::types::{ConnectionState, NousId, StreamEvent, StreamingState, ToolCallInfo};
+
+/// How long to buffer text deltas before flushing to the signal.
+const TEXT_DEBOUNCE: Duration = Duration::from_millis(100);
+
+/// A committed chat message in the conversation history.
+#[derive(Debug, Clone)]
+pub struct ChatMessage {
+    pub role: MessageRole,
+    pub content: String,
+    pub model: Option<String>,
+    pub tool_calls: u32,
+    pub input_tokens: u32,
+    pub output_tokens: u32,
+}
+
+/// Who produced a chat message.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MessageRole {
+    User,
+    Assistant,
+}
+
+/// Complete chat state that drives the Dioxus component tree.
+///
+/// In a Dioxus component, each field here becomes a `Signal<T>`:
+///
+/// ```text
+/// let messages = use_signal(Vec::new);
+/// let streaming = use_signal(StreamingState::default);
+/// let connection = use_signal(|| ConnectionState::Disconnected);
+/// ```
+///
+/// The `ChatStateManager` below manages transitions; the signals
+/// propagate changes to the rendered output.
+#[derive(Debug, Clone)]
+pub struct ChatState {
+    /// Committed conversation history.
+    pub messages: Vec<ChatMessage>,
+    /// In-flight streaming state for the active turn.
+    pub streaming: StreamingState,
+    /// Global SSE connection state.
+    pub connection: ConnectionState,
+    /// Agent currently being chatted with.
+    pub agent_id: Option<NousId>,
+    /// Active session key.
+    pub session_key: Option<String>,
+}
+
+impl Default for ChatState {
+    fn default() -> Self {
+        Self {
+            messages: Vec::new(),
+            streaming: StreamingState::default(),
+            connection: ConnectionState::Disconnected,
+            agent_id: None,
+            session_key: None,
+        }
+    }
+}
+
+/// Manages `ChatState` transitions in response to `StreamEvent`s.
+///
+/// Encapsulates the debounce buffer and flush logic. In a Dioxus component,
+/// this runs inside a `use_coroutine` that reads from the stream receiver
+/// and writes into signals.
+pub struct ChatStateManager {
+    /// Pending text delta buffer — not yet flushed to state.
+    text_buffer: String,
+    /// Pending thinking delta buffer.
+    thinking_buffer: String,
+    /// Last time the text buffer was flushed.
+    last_flush: Instant,
+}
+
+impl Default for ChatStateManager {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ChatStateManager {
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            text_buffer: String::new(),
+            thinking_buffer: String::new(),
+            last_flush: Instant::now(),
+        }
+    }
+
+    /// Process a stream event and apply it to the chat state.
+    ///
+    /// Returns `true` if the state was modified in a way that should
+    /// trigger a re-render (i.e., the signal should be written to).
+    /// Returns `false` if the delta was buffered and no flush is needed yet.
+    #[must_use]
+    pub fn apply(&mut self, event: StreamEvent, state: &mut ChatState) -> bool {
+        match event {
+            StreamEvent::TurnStart {
+                turn_id,
+                session_id: _,
+                nous_id: _,
+            } => {
+                state.streaming = StreamingState {
+                    text: String::new(),
+                    thinking: String::new(),
+                    tool_calls: Vec::new(),
+                    is_streaming: true,
+                    turn_id: Some(turn_id),
+                    error: None,
+                };
+                self.text_buffer.clear();
+                self.thinking_buffer.clear();
+                self.last_flush = Instant::now();
+                true
+            }
+            StreamEvent::TextDelta(delta) => {
+                let has_newline = delta.contains('\n');
+                self.text_buffer.push_str(&delta);
+                self.maybe_flush_text(state, has_newline)
+            }
+            StreamEvent::ThinkingDelta(delta) => {
+                let has_newline = delta.contains('\n');
+                self.thinking_buffer.push_str(&delta);
+                self.maybe_flush_thinking(state, has_newline)
+            }
+            StreamEvent::ToolStart { tool_name, tool_id } => {
+                // Flush any pending text before recording tool start.
+                self.flush_text(state);
+                self.flush_thinking(state);
+                state.streaming.tool_calls.push(ToolCallInfo {
+                    tool_name,
+                    tool_id,
+                    is_error: false,
+                    duration_ms: None,
+                    completed: false,
+                });
+                true
+            }
+            StreamEvent::ToolResult {
+                tool_id,
+                is_error,
+                duration_ms,
+                ..
+            } => {
+                if let Some(tc) = state
+                    .streaming
+                    .tool_calls
+                    .iter_mut()
+                    .find(|tc| tc.tool_id == tool_id)
+                {
+                    tc.is_error = is_error;
+                    tc.duration_ms = Some(duration_ms);
+                    tc.completed = true;
+                }
+                true
+            }
+            StreamEvent::TurnComplete { outcome } => {
+                // Flush remaining buffered text.
+                self.flush_text(state);
+                self.flush_thinking(state);
+
+                let message = ChatMessage {
+                    role: MessageRole::Assistant,
+                    content: std::mem::take(&mut state.streaming.text),
+                    model: Some(outcome.model),
+                    tool_calls: outcome.tool_calls,
+                    input_tokens: outcome.input_tokens,
+                    output_tokens: outcome.output_tokens,
+                };
+                state.messages.push(message);
+                state.streaming = StreamingState::default();
+                true
+            }
+            StreamEvent::TurnAbort { reason } => {
+                self.flush_text(state);
+                tracing::info!(reason, "turn aborted");
+                // Preserve partial text in history if any was generated.
+                if !state.streaming.text.is_empty() {
+                    let message = ChatMessage {
+                        role: MessageRole::Assistant,
+                        content: std::mem::take(&mut state.streaming.text),
+                        model: None,
+                        tool_calls: 0,
+                        input_tokens: 0,
+                        output_tokens: 0,
+                    };
+                    state.messages.push(message);
+                }
+                state.streaming = StreamingState::default();
+                true
+            }
+            StreamEvent::Error(msg) => {
+                self.flush_text(state);
+                state.streaming.error = Some(msg);
+                state.streaming.is_streaming = false;
+                true
+            }
+            StreamEvent::ToolApprovalRequired { .. } | StreamEvent::ToolApprovalResolved { .. } => {
+                // These would drive overlay/dialog signals in the full implementation.
+                true
+            }
+        }
+    }
+
+    /// Flush buffered text if the debounce interval has elapsed or a
+    /// newline was received.
+    #[must_use]
+    fn maybe_flush_text(&mut self, state: &mut ChatState, has_newline: bool) -> bool {
+        if has_newline || self.last_flush.elapsed() >= TEXT_DEBOUNCE {
+            self.flush_text(state);
+            return true;
+        }
+        false
+    }
+
+    /// Flush buffered thinking text with the same debounce logic.
+    #[must_use]
+    fn maybe_flush_thinking(&mut self, state: &mut ChatState, has_newline: bool) -> bool {
+        if has_newline || self.last_flush.elapsed() >= TEXT_DEBOUNCE {
+            self.flush_thinking(state);
+            return true;
+        }
+        false
+    }
+
+    /// Unconditionally move buffered text into state.
+    fn flush_text(&mut self, state: &mut ChatState) {
+        if !self.text_buffer.is_empty() {
+            state.streaming.text.push_str(&self.text_buffer);
+            self.text_buffer.clear();
+            self.last_flush = Instant::now();
+        }
+    }
+
+    /// Unconditionally move buffered thinking text into state.
+    fn flush_thinking(&mut self, state: &mut ChatState) {
+        if !self.thinking_buffer.is_empty() {
+            state.streaming.thinking.push_str(&self.thinking_buffer);
+            self.thinking_buffer.clear();
+        }
+    }
+
+    /// Force-flush all buffered text. Call this on a timer tick (100ms)
+    /// from the Dioxus coroutine to ensure text is never stuck in the
+    /// buffer longer than the debounce interval.
+    #[must_use]
+    pub fn tick(&mut self, state: &mut ChatState) -> bool {
+        let mut changed = false;
+        if !self.text_buffer.is_empty() {
+            self.flush_text(state);
+            changed = true;
+        }
+        if !self.thinking_buffer.is_empty() {
+            self.flush_thinking(state);
+            changed = true;
+        }
+        changed
+    }
+}
+
+/// Apply a connection state change from the global SSE stream.
+pub fn apply_connection_event(state: &mut ChatState, connected: bool) {
+    state.connection = if connected {
+        ConnectionState::Connected
+    } else {
+        match &state.connection {
+            ConnectionState::Reconnecting { attempt } => ConnectionState::Reconnecting {
+                attempt: attempt + 1,
+            },
+            _ => ConnectionState::Reconnecting { attempt: 1 },
+        }
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api::types::{ToolId, TurnOutcome};
+
+    fn make_state() -> ChatState {
+        ChatState::default()
+    }
+
+    fn make_manager() -> ChatStateManager {
+        ChatStateManager::new()
+    }
+
+    #[test]
+    fn turn_start_resets_streaming_state() {
+        let mut state = make_state();
+        let mut mgr = make_manager();
+
+        let changed = mgr.apply(
+            StreamEvent::TurnStart {
+                session_id: "s1".into(),
+                nous_id: "syn".into(),
+                turn_id: "t1".into(),
+            },
+            &mut state,
+        );
+
+        assert!(changed);
+        assert!(state.streaming.is_streaming);
+        assert!(state.streaming.text.is_empty());
+        assert_eq!(state.streaming.turn_id.as_deref(), Some("t1"));
+    }
+
+    #[test]
+    fn text_delta_with_newline_flushes_immediately() {
+        let mut state = make_state();
+        let mut mgr = make_manager();
+
+        let _ = mgr.apply(
+            StreamEvent::TurnStart {
+                session_id: "s1".into(),
+                nous_id: "syn".into(),
+                turn_id: "t1".into(),
+            },
+            &mut state,
+        );
+
+        let changed = mgr.apply(StreamEvent::TextDelta("hello\n".to_string()), &mut state);
+        assert!(changed);
+        assert_eq!(state.streaming.text, "hello\n");
+    }
+
+    #[test]
+    fn text_delta_without_newline_buffers() {
+        let mut state = make_state();
+        let mut mgr = make_manager();
+
+        let _ = mgr.apply(
+            StreamEvent::TurnStart {
+                session_id: "s1".into(),
+                nous_id: "syn".into(),
+                turn_id: "t1".into(),
+            },
+            &mut state,
+        );
+
+        // Force the last_flush to be recent so debounce holds.
+        mgr.last_flush = Instant::now();
+
+        let changed = mgr.apply(StreamEvent::TextDelta("he".to_string()), &mut state);
+        // Debounce not elapsed and no newline — should buffer.
+        assert!(!changed);
+        assert!(state.streaming.text.is_empty());
+
+        // Tick flushes the buffer.
+        let flushed = mgr.tick(&mut state);
+        assert!(flushed);
+        assert_eq!(state.streaming.text, "he");
+    }
+
+    #[test]
+    fn text_delta_flushes_after_debounce_interval() {
+        let mut state = make_state();
+        let mut mgr = make_manager();
+
+        let _ = mgr.apply(
+            StreamEvent::TurnStart {
+                session_id: "s1".into(),
+                nous_id: "syn".into(),
+                turn_id: "t1".into(),
+            },
+            &mut state,
+        );
+
+        // Set last_flush to 200ms ago so debounce has passed.
+        mgr.last_flush = Instant::now() - Duration::from_millis(200);
+
+        let changed = mgr.apply(StreamEvent::TextDelta("world".to_string()), &mut state);
+        assert!(changed);
+        assert_eq!(state.streaming.text, "world");
+    }
+
+    #[test]
+    fn tool_start_flushes_pending_text() {
+        let mut state = make_state();
+        let mut mgr = make_manager();
+
+        let _ = mgr.apply(
+            StreamEvent::TurnStart {
+                session_id: "s1".into(),
+                nous_id: "syn".into(),
+                turn_id: "t1".into(),
+            },
+            &mut state,
+        );
+
+        // Buffer some text (force recent flush so it doesn't auto-flush).
+        mgr.last_flush = Instant::now();
+        let _ = mgr.apply(StreamEvent::TextDelta("partial".to_string()), &mut state);
+        assert!(state.streaming.text.is_empty());
+
+        // Tool start forces flush.
+        let _ = mgr.apply(
+            StreamEvent::ToolStart {
+                tool_name: "read_file".to_string(),
+                tool_id: ToolId::from("t1"),
+            },
+            &mut state,
+        );
+        assert_eq!(state.streaming.text, "partial");
+        assert_eq!(state.streaming.tool_calls.len(), 1);
+        assert_eq!(state.streaming.tool_calls[0].tool_name, "read_file");
+    }
+
+    #[test]
+    fn tool_result_updates_existing_tool_call() {
+        let mut state = make_state();
+        let mut mgr = make_manager();
+
+        let _ = mgr.apply(
+            StreamEvent::TurnStart {
+                session_id: "s1".into(),
+                nous_id: "syn".into(),
+                turn_id: "t1".into(),
+            },
+            &mut state,
+        );
+        let _ = mgr.apply(
+            StreamEvent::ToolStart {
+                tool_name: "exec".to_string(),
+                tool_id: ToolId::from("tool-1"),
+            },
+            &mut state,
+        );
+        let _ = mgr.apply(
+            StreamEvent::ToolResult {
+                tool_name: "exec".to_string(),
+                tool_id: ToolId::from("tool-1"),
+                is_error: false,
+                duration_ms: 250,
+            },
+            &mut state,
+        );
+
+        assert!(state.streaming.tool_calls[0].completed);
+        assert_eq!(state.streaming.tool_calls[0].duration_ms, Some(250));
+    }
+
+    #[test]
+    fn turn_complete_commits_message_to_history() {
+        let mut state = make_state();
+        let mut mgr = make_manager();
+
+        let _ = mgr.apply(
+            StreamEvent::TurnStart {
+                session_id: "s1".into(),
+                nous_id: "syn".into(),
+                turn_id: "t1".into(),
+            },
+            &mut state,
+        );
+        let _ = mgr.apply(StreamEvent::TextDelta("hello\n".to_string()), &mut state);
+
+        let _ = mgr.apply(
+            StreamEvent::TurnComplete {
+                outcome: TurnOutcome {
+                    text: "hello".to_string(),
+                    nous_id: NousId::from("syn"),
+                    session_id: "s1".into(),
+                    model: "claude-opus-4-6".to_string(),
+                    tool_calls: 0,
+                    input_tokens: 100,
+                    output_tokens: 50,
+                    cache_read_tokens: 0,
+                    cache_write_tokens: 0,
+                    error: None,
+                },
+            },
+            &mut state,
+        );
+
+        assert_eq!(state.messages.len(), 1);
+        assert_eq!(state.messages[0].role, MessageRole::Assistant);
+        assert_eq!(state.messages[0].content, "hello\n");
+        assert!(!state.streaming.is_streaming);
+    }
+
+    #[test]
+    fn turn_abort_preserves_partial_text() {
+        let mut state = make_state();
+        let mut mgr = make_manager();
+
+        let _ = mgr.apply(
+            StreamEvent::TurnStart {
+                session_id: "s1".into(),
+                nous_id: "syn".into(),
+                turn_id: "t1".into(),
+            },
+            &mut state,
+        );
+        let _ = mgr.apply(StreamEvent::TextDelta("partial\n".to_string()), &mut state);
+
+        let _ = mgr.apply(
+            StreamEvent::TurnAbort {
+                reason: "cancelled".to_string(),
+            },
+            &mut state,
+        );
+
+        assert_eq!(state.messages.len(), 1);
+        assert_eq!(state.messages[0].content, "partial\n");
+        assert!(!state.streaming.is_streaming);
+    }
+
+    #[test]
+    fn turn_abort_with_no_text_adds_no_message() {
+        let mut state = make_state();
+        let mut mgr = make_manager();
+
+        let _ = mgr.apply(
+            StreamEvent::TurnStart {
+                session_id: "s1".into(),
+                nous_id: "syn".into(),
+                turn_id: "t1".into(),
+            },
+            &mut state,
+        );
+        let _ = mgr.apply(
+            StreamEvent::TurnAbort {
+                reason: "cancelled".to_string(),
+            },
+            &mut state,
+        );
+
+        assert!(state.messages.is_empty());
+    }
+
+    #[test]
+    fn error_sets_error_and_stops_streaming() {
+        let mut state = make_state();
+        let mut mgr = make_manager();
+
+        let _ = mgr.apply(
+            StreamEvent::TurnStart {
+                session_id: "s1".into(),
+                nous_id: "syn".into(),
+                turn_id: "t1".into(),
+            },
+            &mut state,
+        );
+        let _ = mgr.apply(
+            StreamEvent::Error("connection lost".to_string()),
+            &mut state,
+        );
+
+        assert_eq!(state.streaming.error.as_deref(), Some("connection lost"));
+        assert!(!state.streaming.is_streaming);
+    }
+
+    #[test]
+    fn apply_connection_event_connected() {
+        let mut state = make_state();
+        apply_connection_event(&mut state, true);
+        assert_eq!(state.connection, ConnectionState::Connected);
+    }
+
+    #[test]
+    fn apply_connection_event_disconnect_increments_attempt() {
+        let mut state = make_state();
+        apply_connection_event(&mut state, false);
+        assert_eq!(
+            state.connection,
+            ConnectionState::Reconnecting { attempt: 1 }
+        );
+        apply_connection_event(&mut state, false);
+        assert_eq!(
+            state.connection,
+            ConnectionState::Reconnecting { attempt: 2 }
+        );
+    }
+
+    #[test]
+    fn apply_connection_event_reconnect_resets_on_connect() {
+        let mut state = make_state();
+        apply_connection_event(&mut state, false);
+        apply_connection_event(&mut state, false);
+        apply_connection_event(&mut state, true);
+        assert_eq!(state.connection, ConnectionState::Connected);
+    }
+
+    #[test]
+    fn thinking_delta_flushes_on_newline() {
+        let mut state = make_state();
+        let mut mgr = make_manager();
+
+        let _ = mgr.apply(
+            StreamEvent::TurnStart {
+                session_id: "s1".into(),
+                nous_id: "syn".into(),
+                turn_id: "t1".into(),
+            },
+            &mut state,
+        );
+
+        let changed = mgr.apply(
+            StreamEvent::ThinkingDelta("step 1\n".to_string()),
+            &mut state,
+        );
+        assert!(changed);
+        assert_eq!(state.streaming.thinking, "step 1\n");
+    }
+
+    #[test]
+    fn tick_returns_false_when_nothing_buffered() {
+        let mut state = make_state();
+        let mut mgr = make_manager();
+        assert!(!mgr.tick(&mut state));
+    }
+
+    #[test]
+    fn chat_state_default() {
+        let state = ChatState::default();
+        assert!(state.messages.is_empty());
+        assert!(!state.streaming.is_streaming);
+        assert_eq!(state.connection, ConnectionState::Disconnected);
+        assert!(state.agent_id.is_none());
+    }
+
+    #[test]
+    fn full_turn_lifecycle() {
+        let mut state = make_state();
+        let mut mgr = make_manager();
+
+        // User sends a message.
+        state.messages.push(ChatMessage {
+            role: MessageRole::User,
+            content: "Hello".to_string(),
+            model: None,
+            tool_calls: 0,
+            input_tokens: 0,
+            output_tokens: 0,
+        });
+
+        // Turn starts.
+        let _ = mgr.apply(
+            StreamEvent::TurnStart {
+                session_id: "s1".into(),
+                nous_id: "syn".into(),
+                turn_id: "t1".into(),
+            },
+            &mut state,
+        );
+        assert!(state.streaming.is_streaming);
+
+        // Text arrives.
+        let _ = mgr.apply(StreamEvent::TextDelta("Hi ".to_string()), &mut state);
+        let _ = mgr.apply(StreamEvent::TextDelta("there!\n".to_string()), &mut state);
+        assert_eq!(state.streaming.text, "Hi there!\n");
+
+        // Tool call.
+        let _ = mgr.apply(
+            StreamEvent::ToolStart {
+                tool_name: "search".to_string(),
+                tool_id: ToolId::from("t-1"),
+            },
+            &mut state,
+        );
+        let _ = mgr.apply(
+            StreamEvent::ToolResult {
+                tool_name: "search".to_string(),
+                tool_id: ToolId::from("t-1"),
+                is_error: false,
+                duration_ms: 120,
+            },
+            &mut state,
+        );
+
+        // More text.
+        let _ = mgr.apply(
+            StreamEvent::TextDelta("Found it.\n".to_string()),
+            &mut state,
+        );
+
+        // Turn completes.
+        let _ = mgr.apply(
+            StreamEvent::TurnComplete {
+                outcome: TurnOutcome {
+                    text: "Hi there! Found it.".to_string(),
+                    nous_id: NousId::from("syn"),
+                    session_id: "s1".into(),
+                    model: "claude-opus-4-6".to_string(),
+                    tool_calls: 1,
+                    input_tokens: 200,
+                    output_tokens: 80,
+                    cache_read_tokens: 0,
+                    cache_write_tokens: 0,
+                    error: None,
+                },
+            },
+            &mut state,
+        );
+
+        // Verify final state.
+        assert_eq!(state.messages.len(), 2);
+        assert_eq!(state.messages[0].role, MessageRole::User);
+        assert_eq!(state.messages[1].role, MessageRole::Assistant);
+        assert_eq!(state.messages[1].content, "Hi there!\nFound it.\n");
+        assert_eq!(state.messages[1].tool_calls, 1);
+        assert!(!state.streaming.is_streaming);
+    }
+}

--- a/crates/theatron/desktop/src/components/mod.rs
+++ b/crates/theatron/desktop/src/components/mod.rs
@@ -1,0 +1,8 @@
+//! Dioxus component prototypes for the streaming chat interface.
+//!
+//! These modules define the signal-based state management patterns and
+//! component architecture for a Dioxus desktop chat UI. The actual Dioxus
+//! dependency is deferred until the framework is added; these modules
+//! define the state machines and update logic that components will use.
+
+pub mod chat;

--- a/crates/theatron/desktop/src/lib.rs
+++ b/crates/theatron/desktop/src/lib.rs
@@ -1,1 +1,9 @@
-pub mod state;
+//! Dioxus desktop streaming architecture for Aletheia.
+//!
+//! Provides signal-based SSE and per-message stream consumption
+//! designed for reactive UI frameworks like Dioxus. The dual-stream
+//! architecture mirrors the TUI's proven pattern while adapting it
+//! to Dioxus's signal-driven reactivity model.
+
+pub mod api;
+pub mod components;


### PR DESCRIPTION
## Summary

- Design dual-stream architecture (global SSE + per-message fetch) for Dioxus desktop, mirroring TUI proven pattern with signal-based reactivity
- Implement working prototype: SseConnection with 45s heartbeat timeout and exponential backoff (1s to 30s), stream_turn() with CancellationToken abort, ChatStateManager with 100ms text delta debounce
- Document comparison between TUI event-loop model and Dioxus signal-driven approach across SSE connection, per-message streaming, text buffering, and shutdown semantics

## What changed

New theatron-desktop crate with:
- api/sse.rs: Global SSE connection with cancel-safe reconnection loop (45s heartbeat, 1s-30s backoff)
- api/streaming.rs: Per-turn SSE stream with CancellationToken abort support
- api/types.rs: Shared event types, ID newtypes, StreamingState, ConnectionState
- components/chat.rs: State machine with 100ms debounce, full turn lifecycle (start/delta/tool/complete/abort/error)
- STREAMING.md: Architecture document covering dual-stream design, signal layout, reconnection, abort, and TUI comparison

54 unit tests covering all event parsing, state transitions, debounce behavior, and the full turn lifecycle.

## Test plan

- [x] cargo fmt --all -- --check
- [x] cargo clippy --workspace --all-targets -- -D warnings
- [x] cargo test -p theatron-desktop (54 tests pass)
- [x] cargo test --workspace (all tests pass)

## Observations

- **Debt**: theatron-core crate is empty (crates/theatron/core/src/lib.rs). Shared types between TUI and desktop (event enums, ID newtypes, parsers) are duplicated. Extract when desktop reaches feature parity with TUI streaming path.
- **Debt**: TUI SseConnection (crates/theatron/tui/src/api/sse.rs:118) does not wrap sleep in select! with a cancel token, making shutdown non-graceful. Desktop version fixes this.
- **Idea**: TUI 30s READ_TIMEOUT (crates/theatron/tui/src/api/sse.rs:14) causes spurious reconnects under load. Consider aligning to desktop 45s HEARTBEAT_TIMEOUT.
- **Doc gap**: No documentation exists for the server-side WebchatEvent bridge task ordering guarantee (crates/pylon/src/handlers/sessions/streaming.rs) that prevents TurnComplete from arriving before final text deltas.

Generated with [Claude Code](https://claude.com/claude-code)