### PR TITLE
feat(theatron): add Nix flake for desktop packaging and dev shell

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake .#desktop

--- a/.gitignore
+++ b/.gitignore
@@ -102,6 +102,10 @@ shared/prosoche/activity_model.json
 # === Deploy backups ===
 .deploy-backup/
 
+# === Nix ===
+/result
+.direnv/
+
 # === Build artifacts / virtual environments ===
 .venv/
 node_modules/

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,120 @@
+{
+  description = "Aletheia — distributed cognition system";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    crane.url = "github:ipetkov/crane";
+  };
+
+  outputs = { self, nixpkgs, rust-overlay, crane }:
+    let
+      system = "x86_64-linux";
+      overlays = [ (import rust-overlay) ];
+      pkgs = import nixpkgs { inherit system overlays; };
+
+      rustVersion = "1.94.0";
+      rustToolchain = pkgs.rust-bin.stable.${rustVersion}.default.override {
+        extensions = [ "rust-src" "rust-analyzer" ];
+      };
+
+      craneLib = (crane.mkLib pkgs).overrideToolchain rustToolchain;
+
+      # Native libraries required by WGPU/Blitz at build and runtime.
+      wgpuNativeDeps = with pkgs; [
+        vulkan-loader
+        libxkbcommon
+        wayland
+
+        # X11
+        xorg.libX11
+        xorg.libXcursor
+        xorg.libXrandr
+        xorg.libXi
+        xorg.libxcb
+
+        # Font rendering
+        fontconfig
+        freetype
+      ];
+
+      # Build-time tools needed by native crates (C compilation, linking).
+      nativeBuildDeps = with pkgs; [
+        pkg-config
+        cmake
+        rustPlatform.bindgenHook
+      ];
+
+      # Shared source filter: include Rust sources, Cargo manifests,
+      # Dioxus config, and any asset files.
+      src = pkgs.lib.cleanSourceWith {
+        src = craneLib.path ./.;
+        filter = path: type:
+          (craneLib.filterCargoSources path type)
+          || builtins.match ".*Dioxus\\.toml$" path != null
+          || builtins.match ".*\\.css$" path != null
+          || builtins.match ".*\\.html$" path != null;
+      };
+
+      commonArgs = {
+        inherit src;
+        strictDeps = true;
+        nativeBuildInputs = nativeBuildDeps;
+        buildInputs = wgpuNativeDeps;
+      };
+
+      # Build workspace dependencies (cached separately from source).
+      cargoArtifacts = craneLib.buildDepsOnly (commonArgs // {
+        pname = "aletheia-workspace";
+        version = "0.11.0";
+      });
+
+      aletheia-desktop = craneLib.buildPackage (commonArgs // {
+        inherit cargoArtifacts;
+        pname = "aletheia-desktop";
+        version = "0.11.0";
+
+        cargoExtraArgs = "-p theatron-desktop";
+
+        # WHY: Nix sandbox has no GPU. The build only needs headers and
+        # link stubs, not a running GPU. Runtime GPU access is the user's
+        # responsibility.
+        doCheck = false;
+      });
+    in
+    {
+      packages.${system} = {
+        inherit aletheia-desktop;
+        default = aletheia-desktop;
+      };
+
+      devShells.${system}.desktop = craneLib.devShell {
+        # Inherit build inputs so native libraries are available.
+        inputsFrom = [ aletheia-desktop ];
+
+        packages = with pkgs; [
+          # Dioxus CLI for hot-patching development
+          dioxus-cli
+
+          # Build tooling
+          cargo-deny
+          cargo-watch
+
+          # Wayland session support
+          wayland-protocols
+          wayland-scanner
+        ];
+
+        # WHY: WGPU discovers the Vulkan ICD loader and GPU-adjacent
+        # libraries via LD_LIBRARY_PATH at runtime. Without this, the
+        # desktop app cannot find the Vulkan driver on NixOS.
+        LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath wgpuNativeDeps;
+      };
+
+      # Expose default dev shell for `nix develop` without a fragment.
+      devShells.${system}.default = self.devShells.${system}.desktop;
+    };
+}


### PR DESCRIPTION
## Summary

- Add `flake.nix` with Crane-based build for `theatron-desktop` crate and a dev shell with all WGPU/Blitz native dependencies
- Dev shell provides Rust 1.94 toolchain, `dioxus-cli` (dx), `cargo-deny`, `cargo-watch`, and all system libraries (vulkan-loader, libxkbcommon, wayland, X11, fontconfig, freetype)
- Add `.envrc` for direnv integration (`use flake .#desktop`) and Nix-related `.gitignore` entries

### Usage

```bash
nix develop .#desktop    # dev shell with all dependencies
nix build .#aletheia-desktop  # release build
dx serve                 # hot-patching development (inside dev shell)
```

## Test plan

- [ ] Verify `nix flake check` passes (may warn about GPU in sandbox)
- [ ] Verify `nix develop .#desktop` provides: Rust toolchain, `dx` CLI, `pkg-config`, all WGPU native deps
- [ ] Verify `nix build .#aletheia-desktop` compiles the desktop binary
- [ ] Verify `LD_LIBRARY_PATH` includes vulkan-loader path in dev shell
- [ ] Verify `direnv allow` activates the desktop dev shell

## Observations

- **Debt**: `crates/theatron/desktop` is listed twice in workspace `Cargo.toml` members (lines 23-24) — duplicate entry from scaffold merge
- **Idea**: Once flake.lock is generated (first `nix flake lock` invocation), it should be committed for reproducibility
- **Idea**: Consider adding `aarch64-linux` support via `flake-utils.lib.eachDefaultSystem` for ARM dev machines

🤖 Generated with [Claude Code](https://claude.com/claude-code)