### PR TITLE
feat(taxis): add YAML config loading and embed-candle check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2195,6 +2195,7 @@ dependencies = [
  "parking_lot",
  "pear",
  "serde",
+ "serde_yaml",
  "tempfile",
  "toml 0.8.23",
  "uncased",
@@ -5736,6 +5737,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap 2.13.0",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "sfa"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6890,6 +6904,12 @@ name = "unit-prefix"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,7 +102,7 @@ tracing-appender = "0.2"
 prometheus = { version = "0.14", features = ["process"] }
 
 # Config
-figment = { version = "0.10", features = ["toml", "env"] }
+figment = { version = "0.10", features = ["toml", "yaml", "env"] }
 
 # IDs
 uuid = { version = "1", features = ["v4"] }

--- a/crates/aletheia/src/commands/check_config.rs
+++ b/crates/aletheia/src/commands/check_config.rs
@@ -11,6 +11,10 @@ use aletheia_taxis::validate::validate_section;
 /// Run `aletheia check-config`: load config, validate all sections, report and exit.
 ///
 /// Exits 0 on success, 1 if any check fails.
+#[expect(
+    clippy::too_many_lines,
+    reason = "sequential validation checks read best as one flow"
+)]
 pub fn run(instance_root: Option<&PathBuf>) -> Result<()> {
     let oikos = match instance_root {
         Some(root) => Oikos::from_root(root),
@@ -67,6 +71,19 @@ pub fn run(instance_root: Option<&PathBuf>) -> Result<()> {
             }
         } else {
             println!("  [pass] {section} (using defaults)");
+        }
+    }
+
+    if config.embedding.provider == "candle" {
+        if cfg!(feature = "embed-candle") {
+            println!("  [pass] embedding: embed-candle compiled");
+        } else {
+            println!(
+                "  [FAIL] embedding: embed-candle feature not compiled\n         \
+                 Build with: cargo build --features embed-candle\n         \
+                 Or set embedding.provider to \"mock\" in config."
+            );
+            all_ok = false;
         }
     }
 

--- a/crates/aletheia/src/commands/server.rs
+++ b/crates/aletheia/src/commands/server.rs
@@ -622,28 +622,27 @@ fn build_provider_registry(
         .or_else(claude_code_default_path);
 
     // When source is "claude-code", prioritize Claude Code credentials
-    if cred_source == "claude-code" {
-        if let Some(ref cc_path) = claude_code_path {
-            if let Some(provider) = claude_code_provider(cc_path) {
-                chain.push(provider);
-            }
-        }
+    if cred_source == "claude-code"
+        && let Some(ref cc_path) = claude_code_path
+        && let Some(provider) = claude_code_provider(cc_path)
+    {
+        chain.push(provider);
     }
 
-    if cred_file.exists() {
-        if let Some(cred) = CredentialFile::load(&cred_file) {
-            if cred.has_refresh_token() {
-                if let Some(refreshing) = RefreshingCredentialProvider::new(cred_file.clone()) {
-                    info!(path = %cred_file.display(), "credential file found (OAuth auto-refresh)");
-                    chain.push(Box::new(refreshing));
-                } else {
-                    info!(path = %cred_file.display(), "credential file found (static)");
-                    chain.push(Box::new(FileCredentialProvider::new(cred_file.clone())));
-                }
+    if cred_file.exists()
+        && let Some(cred) = CredentialFile::load(&cred_file)
+    {
+        if cred.has_refresh_token() {
+            if let Some(refreshing) = RefreshingCredentialProvider::new(cred_file.clone()) {
+                info!(path = %cred_file.display(), "credential file found (OAuth auto-refresh)");
+                chain.push(Box::new(refreshing));
             } else {
-                info!(path = %cred_file.display(), "credential file found (static API key)");
+                info!(path = %cred_file.display(), "credential file found (static)");
                 chain.push(Box::new(FileCredentialProvider::new(cred_file.clone())));
             }
+        } else {
+            info!(path = %cred_file.display(), "credential file found (static API key)");
+            chain.push(Box::new(FileCredentialProvider::new(cred_file.clone())));
         }
     }
 
@@ -656,12 +655,11 @@ fn build_provider_registry(
     chain.push(Box::new(EnvCredentialProvider::new("ANTHROPIC_API_KEY")));
 
     // When source is "auto", add Claude Code credentials as lowest-priority fallback
-    if cred_source == "auto" {
-        if let Some(ref cc_path) = claude_code_path {
-            if let Some(provider) = claude_code_provider(cc_path) {
-                chain.push(provider);
-            }
-        }
+    if cred_source == "auto"
+        && let Some(ref cc_path) = claude_code_path
+        && let Some(provider) = claude_code_provider(cc_path)
+    {
+        chain.push(provider);
     }
 
     let credential_chain: Arc<dyn CredentialProvider> = Arc::new(CredentialChain::new(chain));

--- a/crates/aletheia/tests/smoke_test.rs
+++ b/crates/aletheia/tests/smoke_test.rs
@@ -257,6 +257,41 @@ fn seed_skills_missing_dir_exits_nonzero() {
         .failure();
 }
 
+// ── Check-config — embed-candle detection ─────────────────────────────────────
+
+#[test]
+fn check_config_reports_embed_candle_status() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let instance = tmp.path();
+
+    // Create minimal instance layout so check-config can proceed.
+    std::fs::create_dir_all(instance.join("config")).unwrap();
+    std::fs::create_dir_all(instance.join("data")).unwrap();
+
+    let output = aletheia()
+        .args([
+            "--instance-root",
+            instance.to_str().unwrap(),
+            "check-config",
+        ])
+        .output()
+        .expect("failed to run check-config");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    if cfg!(feature = "embed-candle") {
+        assert!(
+            stdout.contains("[pass] embedding: embed-candle compiled"),
+            "expected [pass] embedding when embed-candle compiled; got: {stdout}"
+        );
+    } else {
+        assert!(
+            stdout.contains("[FAIL] embedding: embed-candle feature not compiled"),
+            "expected [FAIL] embedding when embed-candle not compiled; got: {stdout}"
+        );
+    }
+}
+
 // ── Unknown subcommand exits non-zero ─────────────────────────────────────────
 
 #[test]

--- a/crates/dianoia/src/phase.rs
+++ b/crates/dianoia/src/phase.rs
@@ -90,6 +90,7 @@ impl Phase {
 }
 
 #[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "test assertions")]
 mod tests {
     use super::*;
 

--- a/crates/diaporeia/src/rate_limit.rs
+++ b/crates/diaporeia/src/rate_limit.rs
@@ -6,8 +6,9 @@ use std::time::Instant;
 use aletheia_taxis::config::McpRateLimitConfig;
 
 /// Operation cost tier for rate limiting.
+#[derive(Clone, Copy)]
 pub(crate) enum Tier {
-    /// Expensive operations: session_message, session_create, knowledge_search.
+    /// Expensive operations: `session_message`, `session_create`, `knowledge_search`.
     Expensive,
     /// Cheap operations: list, status, health, config reads.
     Cheap,
@@ -78,6 +79,10 @@ impl TokenBucket {
         }
     }
 
+    #[expect(
+        clippy::expect_used,
+        reason = "poisoned mutex = prior panic, unrecoverable"
+    )]
     fn try_acquire(&self) -> bool {
         let mut state = self.inner.lock().expect("rate limiter lock poisoned");
         let now = Instant::now();
@@ -94,6 +99,7 @@ impl TokenBucket {
 }
 
 #[cfg(test)]
+#[expect(clippy::unwrap_used, clippy::expect_used, reason = "test assertions")]
 mod tests {
     use super::*;
 

--- a/crates/diaporeia/src/tools/params.rs
+++ b/crates/diaporeia/src/tools/params.rs
@@ -50,9 +50,9 @@ pub(crate) struct NousIdParam {
 
 /// Parameters for knowledge search.
 #[derive(Debug, Deserialize, JsonSchema)]
-#[expect(
+#[allow(
     dead_code,
-    reason = "fields used for JSON Schema generation; tool is a Phase 1 stub"
+    reason = "fields read via Deserialize + JsonSchema, not direct access"
 )]
 pub(crate) struct KnowledgeSearchParams {
     /// The search query text.
@@ -133,7 +133,7 @@ mod tests {
 
     #[test]
     fn session_list_params_allows_empty_filter() {
-        let json = r#"{}"#;
+        let json = r"{}";
         let params: SessionListParams = serde_json::from_str(json).unwrap();
         assert!(params.nous_id.is_none());
     }

--- a/crates/symbolon/src/credential.rs
+++ b/crates/symbolon/src/credential.rs
@@ -465,6 +465,7 @@ impl RefreshingCredentialProvider {
     }
 
     /// Signal the background refresh task to stop.
+    #[cfg(test)]
     pub(crate) fn shutdown(&self) {
         self.shutdown.store(true, Ordering::Relaxed);
     }

--- a/crates/taxis/src/config.rs
+++ b/crates/taxis/src/config.rs
@@ -820,7 +820,7 @@ pub struct McpConfig {
 /// Per-session rate limiting configuration for MCP requests.
 ///
 /// Applies separate token bucket limits for expensive operations
-/// (session_message, session_create, knowledge_search) and cheap
+/// (`session_message`, `session_create`, `knowledge_search`) and cheap
 /// read/status operations. Limits are enforced per MCP session.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]

--- a/crates/taxis/src/loader.rs
+++ b/crates/taxis/src/loader.rs
@@ -1,7 +1,7 @@
-//! Figment-based configuration loading with TOML cascade.
+//! Figment-based configuration loading with TOML/YAML cascade.
 
 use figment::Figment;
-use figment::providers::{Env, Format, Serialized, Toml};
+use figment::providers::{Env, Format, Serialized, Toml, Yaml};
 use snafu::ResultExt;
 use tracing::warn;
 
@@ -9,11 +9,11 @@ use crate::config::AletheiaConfig;
 use crate::error::{FigmentSnafu, Result, SerializeTomlSnafu, WriteConfigSnafu};
 use crate::oikos::Oikos;
 
-/// Load configuration with cascade: defaults → TOML → environment.
+/// Load configuration with cascade: defaults → config file → environment.
 ///
 /// Resolution order (later wins):
 /// 1. Compiled defaults ([`AletheiaConfig::default()`])
-/// 2. `{oikos.config()}/aletheia.toml` (if it exists)
+/// 2. `{oikos.config()}/aletheia.toml` or `aletheia.yaml` (TOML takes precedence)
 /// 3. Environment variables: `ALETHEIA_*` (e.g. `ALETHEIA_GATEWAY__PORT=9000`)
 #[expect(
     clippy::result_large_err,
@@ -25,13 +25,19 @@ pub fn load_config(oikos: &Oikos) -> Result<AletheiaConfig> {
 
     let mut figment = Figment::new().merge(Serialized::defaults(AletheiaConfig::default()));
 
-    if toml_path.exists() {
-        figment = figment.merge(Toml::file(&toml_path));
-    } else if yaml_path.exists() {
+    let has_toml = toml_path.exists();
+    let has_yaml = yaml_path.exists();
+
+    if has_toml && has_yaml {
         warn!(
-            "Found aletheia.yaml but not aletheia.toml — run migration or rename. \
-             See docs/CONFIGURATION.md."
+            "Both aletheia.toml and aletheia.yaml found — using TOML, ignoring YAML. \
+             Remove aletheia.yaml to silence this warning."
         );
+        figment = figment.merge(Toml::file(&toml_path));
+    } else if has_toml {
+        figment = figment.merge(Toml::file(&toml_path));
+    } else if has_yaml {
+        figment = figment.merge(Yaml::file(&yaml_path));
     } else {
         warn!(
             "No config file found, using defaults. \
@@ -139,6 +145,55 @@ mod tests {
 
             assert_eq!(config.gateway.port, 18789);
             assert_eq!(config.agents.defaults.context_tokens, 200_000);
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn load_from_yaml_file() {
+        figment::Jail::expect_with(|jail| {
+            std::fs::create_dir_all(jail.directory().join("config")).map_err(|e| e.to_string())?;
+            jail.create_file(
+                "config/aletheia.yaml",
+                "gateway:\n  port: 8888\nagents:\n  defaults:\n    contextTokens: 50000\n",
+            )?;
+
+            let oikos = Oikos::from_root(jail.directory());
+            let config = load_config(&oikos).map_err(|e| e.to_string())?;
+
+            assert_eq!(config.gateway.port, 8888);
+            assert_eq!(config.agents.defaults.context_tokens, 50_000);
+            assert_eq!(config.agents.defaults.model.primary, "claude-sonnet-4-6");
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn toml_takes_precedence_over_yaml() {
+        figment::Jail::expect_with(|jail| {
+            std::fs::create_dir_all(jail.directory().join("config")).map_err(|e| e.to_string())?;
+            jail.create_file("config/aletheia.toml", "[gateway]\nport = 1111\n")?;
+            jail.create_file("config/aletheia.yaml", "gateway:\n  port: 2222\n")?;
+
+            let oikos = Oikos::from_root(jail.directory());
+            let config = load_config(&oikos).map_err(|e| e.to_string())?;
+
+            assert_eq!(config.gateway.port, 1111);
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn env_overrides_yaml() {
+        figment::Jail::expect_with(|jail| {
+            std::fs::create_dir_all(jail.directory().join("config")).map_err(|e| e.to_string())?;
+            jail.create_file("config/aletheia.yaml", "gateway:\n  port: 8888\n")?;
+            jail.set_env("ALETHEIA_GATEWAY__PORT", "5555");
+
+            let oikos = Oikos::from_root(jail.directory());
+            let config = load_config(&oikos).map_err(|e| e.to_string())?;
+
+            assert_eq!(config.gateway.port, 5555);
             Ok(())
         });
     }


### PR DESCRIPTION
## Summary

- Load `aletheia.yaml` via figment's YAML provider when present; TOML takes precedence when both exist (with warning logged)
- Add compile-time `embed-candle` detection to `check-config`: reports `[FAIL]` when the candle provider is configured but the feature is not compiled
- Fix pre-existing clippy warnings surfaced by Rust 1.94

Closes #1297, #1296.

## Test plan

- [x] `load_from_yaml_file` — YAML config loads correctly
- [x] `toml_takes_precedence_over_yaml` — TOML wins when both exist
- [x] `env_overrides_yaml` — env vars override YAML values
- [x] `check_config_reports_embed_candle_status` — integration test verifies [FAIL]/[pass] output
- [x] All 102 taxis tests pass
- [x] All 37 aletheia smoke tests pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean

## Observations

- **Bug** `crates/diaporeia/src/sanitize.rs:142,157` — two pre-existing test failures (`preserves_forward_slash_in_fraction`, `preserves_relative_path_in_error_message`); path sanitizer is too aggressive with `/` characters
- **Debt** `serde_yaml` is marked deprecated upstream (v0.9.34+deprecated); figment's `yaml` feature depends on it. Monitor for figment migration to a replacement crate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)