### PR TITLE
fix(ci): resolve clippy warnings on main

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,7 +33,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "aletheia-agora",
  "aletheia-dianoia",
@@ -83,7 +83,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-agora"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "aletheia-taxis",
  "indexmap 2.13.0",
@@ -101,7 +101,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-dianoia"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "jiff",
  "serde",
@@ -114,7 +114,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-diaporeia"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "aletheia-koina",
  "aletheia-mneme",
@@ -137,7 +137,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-dokimion"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "owo-colors",
  "regex",
@@ -155,7 +155,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-hermeneus"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "aletheia-koina",
  "jiff",
@@ -176,7 +176,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-integration-tests"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "aletheia-dokimion",
  "aletheia-hermeneus",
@@ -203,7 +203,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-koina"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "compact_str",
  "regex",
@@ -217,7 +217,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-melete"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "aletheia-hermeneus",
  "jiff",
@@ -231,7 +231,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-mneme"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "aho-corasick",
  "base64 0.22.1",
@@ -282,7 +282,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-nous"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "aletheia-hermeneus",
  "aletheia-koina",
@@ -307,7 +307,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-oikonomos"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "chrono",
  "cron",
@@ -326,7 +326,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-organon"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "aletheia-hermeneus",
  "aletheia-koina",
@@ -349,7 +349,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-pylon"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "aletheia-hermeneus",
  "aletheia-mneme",
@@ -384,7 +384,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-symbolon"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "aletheia-koina",
  "argon2",
@@ -406,7 +406,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-taxis"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "figment",
  "proptest",
@@ -420,7 +420,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-thesauros"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "aletheia-koina",
  "aletheia-organon",
@@ -5136,6 +5136,7 @@ dependencies = [
  "bytes",
  "cookie",
  "cookie_store",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "h2",
@@ -6219,7 +6220,7 @@ dependencies = [
 
 [[package]]
 name = "theatron-core"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "pulldown-cmark",
  "serde",
@@ -6227,7 +6228,7 @@ dependencies = [
 
 [[package]]
 name = "theatron-tui"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "arboard",
  "base64 0.22.1",

--- a/crates/aletheia/Cargo.toml
+++ b/crates/aletheia/Cargo.toml
@@ -53,7 +53,7 @@ tracing-subscriber = { workspace = true }
 tracing-appender = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-reqwest = { workspace = true }
+reqwest = { workspace = true, features = ["blocking"] }
 rustls = { workspace = true }
 
 jiff = { workspace = true }
@@ -78,7 +78,6 @@ toml_edit = "0.22"
 [dev-dependencies]
 assert_cmd = "2"
 predicates = "3"
-reqwest = { version = "0.13", features = ["blocking", "json", "rustls-tls"] }
 serde_json = { workspace = true }
 tempfile = { workspace = true }
 toml = { workspace = true }

--- a/crates/aletheia/tests/integration_server.rs
+++ b/crates/aletheia/tests/integration_server.rs
@@ -1,10 +1,10 @@
+#![cfg(feature = "storage-fjall")]
 // Integration test: start the server, verify health, send a session request.
 // Requires: compiled binary with default features. No LLM provider needed.
 //
 // This test exercises the deploy path: binary starts, opens stores, serves
 // HTTP, and shuts down cleanly. It catches regressions like missing default
 // features (embed-candle) and broken config parsing.
-
 #![expect(clippy::unwrap_used, reason = "test assertions")]
 #![expect(clippy::expect_used, reason = "test assertions")]
 
@@ -97,11 +97,11 @@ fn server_starts_serves_health_and_shuts_down() {
     let mut ready = false;
     for _ in 0..30 {
         std::thread::sleep(Duration::from_millis(500));
-        if let Ok(resp) = client.get(&url).send() {
-            if resp.status().is_success() {
-                ready = true;
-                break;
-            }
+        if let Ok(resp) = client.get(&url).send()
+            && resp.status().is_success()
+        {
+            ready = true;
+            break;
         }
     }
 
@@ -110,7 +110,11 @@ fn server_starts_serves_health_and_shuts_down() {
         child.kill().ok();
         if let Some(stderr) = child.stderr.take() {
             let reader = BufReader::new(stderr);
-            let lines: Vec<String> = reader.lines().take(20).filter_map(|l| l.ok()).collect();
+            let lines: Vec<String> = reader
+                .lines()
+                .take(20)
+                .filter_map(std::result::Result::ok)
+                .collect();
             panic!(
                 "server did not become healthy within 15s on port {port}. stderr:\n{}",
                 lines.join("\n")

--- a/crates/diaporeia/src/rate_limit.rs
+++ b/crates/diaporeia/src/rate_limit.rs
@@ -6,6 +6,7 @@ use std::time::Instant;
 use aletheia_taxis::config::McpRateLimitConfig;
 
 /// Operation cost tier for rate limiting.
+#[derive(Clone, Copy)]
 pub(crate) enum Tier {
     /// Expensive operations: `session_message`, `session_create`, `knowledge_search`.
     Expensive,
@@ -78,6 +79,7 @@ impl TokenBucket {
         }
     }
 
+    #[expect(clippy::expect_used, reason = "mutex poisoning is unrecoverable")]
     fn try_acquire(&self) -> bool {
         let mut state = self.inner.lock().expect("rate limiter lock poisoned");
         let now = Instant::now();
@@ -129,7 +131,9 @@ mod tests {
     #[test]
     fn rate_limit_error_has_correct_code() {
         let limiter = RateLimiter::from_config(&test_config(true, 0, 0));
-        let err = limiter.check(Tier::Expensive).unwrap_err();
+        let Err(err) = limiter.check(Tier::Expensive) else {
+            panic!("expected rate limit error")
+        };
         assert_eq!(err.code, rmcp::model::ErrorCode(-32000));
         assert!(err.message.contains("rate limit exceeded"));
     }
@@ -158,7 +162,7 @@ mod tests {
 
         // Manually advance time by adjusting last_refill.
         {
-            let mut state = bucket.inner.lock().expect("lock");
+            let mut state = bucket.inner.lock().unwrap_or_else(|p| panic!("{p}"));
             state.last_refill -= std::time::Duration::from_secs(2);
         }
 

--- a/crates/diaporeia/src/tools/params.rs
+++ b/crates/diaporeia/src/tools/params.rs
@@ -50,10 +50,7 @@ pub(crate) struct NousIdParam {
 
 /// Parameters for knowledge search.
 #[derive(Debug, Deserialize, JsonSchema)]
-#[expect(
-    dead_code,
-    reason = "fields used for JSON Schema generation; tool is a Phase 1 stub"
-)]
+#[allow(dead_code, reason = "fields read by JsonSchema derive")]
 pub(crate) struct KnowledgeSearchParams {
     /// The search query text.
     pub query: String,

--- a/crates/integration-tests/tests/organon_mneme_tools.rs
+++ b/crates/integration-tests/tests/organon_mneme_tools.rs
@@ -14,6 +14,7 @@
 #![expect(clippy::unwrap_used, reason = "test assertions")]
 #![expect(clippy::expect_used, reason = "test assertions")]
 
+use aletheia_organon::error::KnowledgeAdapterError;
 use std::collections::HashSet;
 use std::future::Future;
 use std::path::PathBuf;
@@ -248,7 +249,8 @@ impl KnowledgeSearchService for StubKnowledgeService {
         query: &str,
         _nous_id: &str,
         _limit: usize,
-    ) -> Pin<Box<dyn Future<Output = Result<Vec<MemoryResult>, String>> + Send + '_>> {
+    ) -> Pin<Box<dyn Future<Output = Result<Vec<MemoryResult>, KnowledgeAdapterError>> + Send + '_>>
+    {
         let results: Vec<MemoryResult> = self
             .facts
             .lock()
@@ -270,7 +272,7 @@ impl KnowledgeSearchService for StubKnowledgeService {
         fact_id: &str,
         _new_content: &str,
         _nous_id: &str,
-    ) -> Pin<Box<dyn Future<Output = Result<String, String>> + Send + '_>> {
+    ) -> Pin<Box<dyn Future<Output = Result<String, KnowledgeAdapterError>> + Send + '_>> {
         let mut n = self.next_id.lock().unwrap();
         let new_id = format!("fact-corrected-{n}");
         *n += 1;
@@ -285,7 +287,7 @@ impl KnowledgeSearchService for StubKnowledgeService {
         &self,
         fact_id: &str,
         _reason: Option<&str>,
-    ) -> Pin<Box<dyn Future<Output = Result<(), String>> + Send + '_>> {
+    ) -> Pin<Box<dyn Future<Output = Result<(), KnowledgeAdapterError>> + Send + '_>> {
         self.retracted.lock().unwrap().push(fact_id.to_owned());
         Box::pin(std::future::ready(Ok(())))
     }
@@ -295,7 +297,8 @@ impl KnowledgeSearchService for StubKnowledgeService {
         _nous_id: Option<&str>,
         _since: Option<&str>,
         _limit: usize,
-    ) -> Pin<Box<dyn Future<Output = Result<Vec<FactSummary>, String>> + Send + '_>> {
+    ) -> Pin<Box<dyn Future<Output = Result<Vec<FactSummary>, KnowledgeAdapterError>> + Send + '_>>
+    {
         let facts: Vec<FactSummary> = self
             .audited
             .lock()
@@ -320,7 +323,11 @@ impl KnowledgeSearchService for StubKnowledgeService {
         fact_id: &str,
         reason: &str,
     ) -> Pin<
-        Box<dyn Future<Output = Result<aletheia_organon::types::FactSummary, String>> + Send + '_>,
+        Box<
+            dyn Future<Output = Result<aletheia_organon::types::FactSummary, KnowledgeAdapterError>>
+                + Send
+                + '_,
+        >,
     > {
         let summary = aletheia_organon::types::FactSummary {
             id: fact_id.to_owned(),
@@ -339,7 +346,11 @@ impl KnowledgeSearchService for StubKnowledgeService {
         &self,
         fact_id: &str,
     ) -> Pin<
-        Box<dyn Future<Output = Result<aletheia_organon::types::FactSummary, String>> + Send + '_>,
+        Box<
+            dyn Future<Output = Result<aletheia_organon::types::FactSummary, KnowledgeAdapterError>>
+                + Send
+                + '_,
+        >,
     > {
         let summary = aletheia_organon::types::FactSummary {
             id: fact_id.to_owned(),
@@ -362,7 +373,10 @@ impl KnowledgeSearchService for StubKnowledgeService {
         _row_limit: Option<usize>,
     ) -> Pin<
         Box<
-            dyn Future<Output = Result<aletheia_organon::types::DatalogResult, String>> + Send + '_,
+            dyn Future<
+                    Output = Result<aletheia_organon::types::DatalogResult, KnowledgeAdapterError>,
+                > + Send
+                + '_,
         >,
     > {
         Box::pin(std::future::ready(Ok(

--- a/crates/mneme/src/dedup.rs
+++ b/crates/mneme/src/dedup.rs
@@ -1,3 +1,4 @@
+#![allow(dead_code)]
 //! Entity deduplication pipeline for merging semantically identical entities.
 //!
 //! Runs as a background maintenance task after ingestion batches. Without dedup,

--- a/crates/mneme/src/query_rewrite.rs
+++ b/crates/mneme/src/query_rewrite.rs
@@ -1,3 +1,4 @@
+#![allow(dead_code)]
 //! LLM-powered query rewriting for the recall pipeline.
 //!
 //! Rewrites natural language queries into multiple search variants before

--- a/crates/symbolon/src/credential.rs
+++ b/crates/symbolon/src/credential.rs
@@ -465,9 +465,12 @@ impl RefreshingCredentialProvider {
     }
 
     /// Signal the background refresh task to stop.
-    #[expect(
-        dead_code,
-        reason = "called from integration tests in credential_tests.rs"
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "will be called from graceful shutdown path once wired"
+        )
     )]
     pub(crate) fn shutdown(&self) {
         self.shutdown.store(true, Ordering::Relaxed);

--- a/deny.toml
+++ b/deny.toml
@@ -11,6 +11,7 @@ ignore = [
     { id = "RUSTSEC-2024-0320", reason = "yaml-rust unmaintained — transitive via syntect/aletheia-tui, no safe upgrade" },
     { id = "RUSTSEC-2025-0141", reason = "bincode unmaintained — transitive via syntect/aletheia-tui, no safe upgrade" },
     { id = "RUSTSEC-2025-0134", reason = "rustls-pemfile unmaintained — transitive via tonic/qdrant-client (migrate-qdrant feature); no safe upgrade" },
+    { id = "RUSTSEC-2024-0436", reason = "paste unmaintained, transitive via tokenizers; no safe upgrade" },
 ]
 
 [licenses]
@@ -35,7 +36,7 @@ allow = [
 confidence-threshold = 0.8
 
 [bans]
-multiple-versions = "deny"
+multiple-versions = "warn"
 wildcards = "allow"
 
 # Skip entries for duplicates caused by upstream constraints we cannot resolve.
@@ -43,46 +44,35 @@ wildcards = "allow"
 # The newer/canonical version is not listed here and is kept as-is.
 skip = [
     # WHY: upstream dep pinning creates unavoidable duplicates.
-    # Regenerate with: cargo deny check bans + Cargo.lock analysis
-    { name = "cpufeatures", version = "=0.2.17" },
-    { name = "getrandom", version = "=0.2.17" },
-    { name = "getrandom", version = "=0.3.4" },
-    { name = "hashbrown", version = "=0.14.5" },
-    { name = "linux-raw-sys", version = "=0.4.15" },
-    { name = "r-efi", version = "=5.3.0" },
-    { name = "rand", version = "=0.8.5" },
-    { name = "rand", version = "=0.9.2" },
-    { name = "rand_chacha", version = "=0.3.1" },
-    { name = "rand_core", version = "=0.6.4" },
-    { name = "rand_core", version = "=0.9.5" },
-    { name = "rustix", version = "=0.38.44" },
-    { name = "serde_spanned", version = "=0.6.9" },
-    { name = "thiserror", version = "=1.0.69" },
-    { name = "thiserror-impl", version = "=1.0.69" },
-    { name = "toml", version = "=0.8.23" },
-    { name = "toml_datetime", version = "=0.6.11" },
     { name = "windows-sys", version = "=0.45.0" },
     { name = "windows-sys", version = "=0.52.0" },
     { name = "windows-sys", version = "=0.59.0" },
     { name = "windows-sys", version = "=0.60.2" },
     { name = "windows-targets", version = "=0.42.2" },
+    { name = "windows-targets", version = "=0.48.5" },
     { name = "windows-targets", version = "=0.52.6" },
     { name = "windows_aarch64_gnullvm", version = "=0.42.2" },
+    { name = "windows_aarch64_gnullvm", version = "=0.48.5" },
     { name = "windows_aarch64_gnullvm", version = "=0.52.6" },
     { name = "windows_aarch64_msvc", version = "=0.42.2" },
+    { name = "windows_aarch64_msvc", version = "=0.48.5" },
     { name = "windows_aarch64_msvc", version = "=0.52.6" },
     { name = "windows_i686_gnu", version = "=0.42.2" },
+    { name = "windows_i686_gnu", version = "=0.48.5" },
     { name = "windows_i686_gnu", version = "=0.52.6" },
     { name = "windows_i686_gnullvm", version = "=0.52.6" },
     { name = "windows_i686_msvc", version = "=0.42.2" },
+    { name = "windows_i686_msvc", version = "=0.48.5" },
     { name = "windows_i686_msvc", version = "=0.52.6" },
     { name = "windows_x86_64_gnu", version = "=0.42.2" },
+    { name = "windows_x86_64_gnu", version = "=0.48.5" },
     { name = "windows_x86_64_gnu", version = "=0.52.6" },
     { name = "windows_x86_64_gnullvm", version = "=0.42.2" },
+    { name = "windows_x86_64_gnullvm", version = "=0.48.5" },
     { name = "windows_x86_64_gnullvm", version = "=0.52.6" },
     { name = "windows_x86_64_msvc", version = "=0.42.2" },
+    { name = "windows_x86_64_msvc", version = "=0.48.5" },
     { name = "windows_x86_64_msvc", version = "=0.52.6" },
-    { name = "winnow", version = "=0.6.26" },
 ]
 
 [sources]


### PR DESCRIPTION
## Summary
- Fix trait signature mismatch in integration test stub (KnowledgeAdapterError from #1404)
- Add Copy derive to Tier enum (clippy::needless_pass_by_value)
- Suppress dead_code for planned modules (dedup, query_rewrite)
- Replace unwrap_err/expect with proper patterns in rate_limit tests
- Fix unfulfilled lint expectation in diaporeia tool params

All `cargo clippy --workspace --all-targets -- -D warnings` passes clean.