### PR TITLE
fix(scripts): add set -euo pipefail to all shell scripts

### DIFF
--- a/crates/theatron/desktop/scripts/fetch-fonts.sh
+++ b/crates/theatron/desktop/scripts/fetch-fonts.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
+set -euo pipefail
 # Fetch IBM Plex Mono and Cormorant Garamond font files (OFL licensed).
 #
 # Usage: ./scripts/fetch-fonts.sh
 # Run from the desktop crate root (crates/theatron/desktop/).
-
-set -euo pipefail
 
 FONT_DIR="assets/fonts"
 WORK_DIR="$(mktemp -d)"

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
+set -euo pipefail
 # Bump the workspace version in Cargo.toml and the release-please manifest.
 # Fallback for when release-please TOML updater doesn't handle Cargo.toml.
 #
 # Usage: scripts/bump-version.sh 0.11.0
-
-set -euo pipefail
 
 VERSION="${1:?Usage: $0 <version>}"
 

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
+set -euo pipefail
 # Baseline: TBD% line coverage (run and record after initial setup)
 #
 # Generates HTML + LCOV coverage reports for the Aletheia Rust workspace.
 # Excludes vendored mneme-engine and benchmark crate from metrics.
 #
 # Prerequisites: cargo install cargo-llvm-cov
-set -euo pipefail
 
 cargo llvm-cov \
     --workspace \

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,11 +1,10 @@
 #!/usr/bin/env bash
+set -euo pipefail
 # Deploy aletheia binary to the local instance.
 # Usage: scripts/deploy.sh [--build] [--restart]
 #   --build    Build release binary before deploying (default: use existing)
 #   --restart  Restart systemd service after deploy (default: just copy)
 #   No flags:  build + copy + restart (full deploy)
-
-set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 INSTANCE_ROOT="${ALETHEIA_INSTANCE:-$HOME/ergon/instance}"

--- a/scripts/health-monitor.sh
+++ b/scripts/health-monitor.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 # Health monitor for aletheia. Run via cron or systemd timer.
 # Checks service health, token expiry, and logs warnings.
 #
@@ -8,8 +9,6 @@
 #
 # Cron example (every 5 minutes):
 #   */5 * * * * /path/to/scripts/health-monitor.sh --notify >> /tmp/aletheia-health.log 2>&1
-
-set -euo pipefail
 
 HEALTH_URL="${ALETHEIA_HEALTH_URL:-http://localhost:18789/api/health}"
 METRICS_URL="${ALETHEIA_METRICS_URL:-http://localhost:18789/metrics}"

--- a/scripts/rollback.sh
+++ b/scripts/rollback.sh
@@ -1,9 +1,8 @@
 #!/usr/bin/env bash
+set -euo pipefail
 # rollback.sh — Restore previous Aletheia deployment
 #
 # Usage: ./scripts/rollback.sh [backup-timestamp]
-
-set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 BACKUP_DIR="$REPO_ROOT/.deploy-backup"

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 # smoke-test.sh — Release binary smoke test for the aletheia CLI.
 #
 # Exercises every subcommand to verify the binary is correctly linked,
@@ -12,8 +13,6 @@
 #   --binary PATH   Use an existing binary at PATH (skips build)
 #   --build         Force a release build before testing (default if no binary found)
 #   --help          Show this message
-
-set -euo pipefail
 
 # ── Colours ──────────────────────────────────────────────────────────────────
 RED='\033[0;31m'

--- a/shared/bin/start.sh
+++ b/shared/bin/start.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
+set -euo pipefail
 # start.sh — Template for ~/.aletheia/start.sh
 # Copy to ~/.aletheia/start.sh and make executable.
 # Run `claude setup-token` first to get a 1-year OAuth token, then this script
 # uses credential-refresh to keep it renewed automatically on every startup.
-set -euo pipefail
 
 ALETHEIA_CREDS="$HOME/.aletheia/credentials/anthropic.json"
 CLAUDE_JSON="$HOME/.claude.json"


### PR DESCRIPTION
## Summary
- Moved `set -euo pipefail` to line 2 (immediately after the shebang) in all 8 shell scripts that had it positioned lower in the file
- All 9 `.sh` files in the repo now consistently have strict mode on line 2
- No behavioral changes: all scripts already had the directive, this standardizes placement

## Scripts modified
- `shared/bin/start.sh`
- `crates/theatron/desktop/scripts/fetch-fonts.sh`
- `scripts/bump-version.sh`
- `scripts/coverage.sh`
- `scripts/deploy.sh`
- `scripts/rollback.sh`
- `scripts/smoke-test.sh`
- `scripts/health-monitor.sh`

## Observations
- `shared/hooks/_templates/loop-guard.sh` already had correct placement (no change needed)
- The `integration_server` test fails on main with a TLS provider error (pre-existing, unrelated)

Closes #1393

## Test plan
- [x] Verified all 9 `.sh` files have `set -euo pipefail` on line 2
- [x] Verified no script relies on unset variable expansion (all use `${VAR:-default}` patterns)
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes (except pre-existing `integration_server` failure on main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)