### PR TITLE
perf(build): increase codegen-units for faster dev builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -155,6 +155,7 @@ wiremock = "0.6"
 
 [profile.dev]
 opt-level = 1
+codegen-units = 256
 
 [profile.dev.package."*"]
 opt-level = 2


### PR DESCRIPTION
## Summary

- Set `codegen-units = 256` in `[profile.dev]` to maximize compilation parallelism during development
- `[profile.release]` retains `codegen-units = 1` for maximum runtime optimization
- No other profile settings changed

## Observations

- `integration_server` test fails on main with `No provider set` (reqwest TLS provider issue), pre-existing and unrelated to this change

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes (excluding pre-existing integration_server failure)
- [x] `git diff --stat` shows only `Cargo.toml` changed

Closes #1420