### PR TITLE
infra(aletheia): add RUST_BACKTRACE=1 to systemd and install panic handler

### DIFF
--- a/crates/aletheia/src/main.rs
+++ b/crates/aletheia/src/main.rs
@@ -122,6 +122,8 @@ enum Command {
     reason = "ring crypto provider installation is infallible unless already installed"
 )]
 async fn main() -> Result<()> {
+    install_panic_hook();
+
     rustls::crypto::ring::default_provider()
         .install_default()
         .expect("failed to install ring crypto provider");
@@ -202,6 +204,15 @@ async fn main() -> Result<()> {
         json_logs: cli.json_logs,
     })
     .await
+}
+
+fn install_panic_hook() {
+    let default_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        let backtrace = std::backtrace::Backtrace::force_capture();
+        tracing::error!(%backtrace, "panic: {info}");
+        default_hook(info);
+    }));
 }
 
 #[cfg(test)]

--- a/instance.example/services/aletheia.service
+++ b/instance.example/services/aletheia.service
@@ -8,6 +8,7 @@ Type=simple
 # %h expands to the user's home directory at runtime.
 # ALETHEIA_ROOT tells the binary where to find the instance directory.
 Environment=ALETHEIA_ROOT=%h/aletheia/instance
+Environment=RUST_BACKTRACE=1
 # Optional: set API key here if not stored in instance/config/credentials/anthropic.json
 # Environment=ANTHROPIC_API_KEY=sk-ant-...
 # Load additional env vars from a file (silently ignored if the file does not exist).


### PR DESCRIPTION
## Summary

- Set `Environment="RUST_BACKTRACE=1"` in `instance.example/services/aletheia.service` so crash backtraces are captured in the journal
- Install a custom panic hook at the top of `main()` that logs panic info + full backtrace via `tracing::error!` before the default handler runs
- Hook is installed before any async tasks spawn (first line in `main`)

Closes #1410

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes (pre-existing integration_server failure unrelated to this change)
- [ ] Verify panic hook logs backtrace by triggering a panic in a dev build

## Observations

- `tests/integration_server.rs::server_starts_serves_health_and_shuts_down` fails on main with `No provider set` (reqwest missing rustls crypto provider in test binary). Pre-existing, unrelated to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)