### PR TITLE
style(workspace): fix import ordering violations

### DIFF
--- a/crates/dianoia/src/error.rs
+++ b/crates/dianoia/src/error.rs
@@ -1,7 +1,8 @@
 //! Dianoia-specific errors.
 
-use snafu::Snafu;
 use std::path::PathBuf;
+
+use snafu::Snafu;
 
 /// Errors from planning and project orchestration.
 #[derive(Debug, Snafu)]

--- a/crates/hermeneus/src/anthropic/client.rs
+++ b/crates/hermeneus/src/anthropic/client.rs
@@ -1,10 +1,12 @@
 //! Anthropic Messages API provider.
 
+use std::collections::HashMap;
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+use aletheia_koina::credential::{CredentialProvider, CredentialSource};
 use rand::Rng as _;
 use reqwest::Client;
 use reqwest::header::{HeaderMap, HeaderValue};
@@ -12,13 +14,10 @@ use secrecy::SecretString;
 use snafu::ResultExt;
 use tracing::{Instrument as _, info, info_span};
 
-use std::collections::HashMap;
-
 use crate::error::{self, Result};
 use crate::health::{HealthConfig, ProviderHealthTracker};
 use crate::provider::{LlmProvider, ModelPricing, ProviderConfig};
 use crate::types::{CompletionRequest, CompletionResponse};
-use aletheia_koina::credential::{CredentialProvider, CredentialSource};
 
 use super::stream::{StreamAccumulator, StreamEvent, parse_sse_response};
 use super::wire::WireRequest;

--- a/crates/koina/src/error.rs
+++ b/crates/koina/src/error.rs
@@ -1,7 +1,8 @@
 //! Error types for Aletheia.
 
-use snafu::Snafu;
 use std::path::PathBuf;
+
+use snafu::Snafu;
 
 /// Errors from core operations.
 #[derive(Debug, Snafu)]

--- a/crates/koina/src/id.rs
+++ b/crates/koina/src/id.rs
@@ -1,8 +1,9 @@
 //! Newtype wrappers for domain identifiers.
 
+use std::fmt;
+
 use compact_str::CompactString;
 use serde::{Deserialize, Serialize};
-use std::fmt;
 
 /// A nous (agent) identifier. Lowercase alphanumeric + hyphens, 1-64 chars.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]

--- a/crates/mneme/src/engine/fts/mod.rs
+++ b/crates/mneme/src/engine/fts/mod.rs
@@ -3,6 +3,13 @@
     clippy::expect_used,
     reason = "engine invariant — internal CozoDB algorithm correctness guarantee"
 )]
+use std::collections::HashMap;
+use std::sync::{Arc, RwLock};
+
+use compact_str::CompactString;
+use sha2::digest::FixedOutput;
+use sha2::{Digest, Sha256};
+
 use crate::engine::data::memcmp::MemCmpEncoder;
 use crate::engine::data::value::DataValue;
 use crate::engine::error::InternalResult as Result;
@@ -12,11 +19,6 @@ use crate::engine::fts::tokenizer::{
     RawTokenizer, RemoveLongFilter, SimpleTokenizer, SplitCompoundWords, Stemmer, StopWordFilter,
     TextAnalyzer, Tokenizer, WhitespaceTokenizer,
 };
-use compact_str::CompactString;
-use sha2::digest::FixedOutput;
-use sha2::{Digest, Sha256};
-use std::collections::HashMap;
-use std::sync::{Arc, RwLock};
 
 pub(crate) mod ast;
 pub(crate) mod error;

--- a/crates/mneme/src/engine/fts/tokenizer/tokenizer_impl.rs
+++ b/crates/mneme/src/engine/fts/tokenizer/tokenizer_impl.rs
@@ -1,11 +1,12 @@
 //! Core tokenizer trait implementations.
-use compact_str::CompactString;
-use rustc_hash::FxHashSet;
 /// The tokenizer module contains all of the tools used to process
 /// text in `tantivy`.
 use std::borrow::{Borrow, BorrowMut};
 use std::iter;
 use std::ops::{Deref, DerefMut};
+
+use compact_str::CompactString;
+use rustc_hash::FxHashSet;
 
 use crate::engine::fts::tokenizer::empty_tokenizer::EmptyTokenizer;
 

--- a/crates/mneme/src/id.rs
+++ b/crates/mneme/src/id.rs
@@ -3,8 +3,9 @@
 //! These types prevent accidental mixing of ID kinds at compile time.
 //! Cross-crate identifiers (`NousId`, `SessionId`) live in `koina::id`.
 
-use serde::{Deserialize, Serialize};
 use std::fmt;
+
+use serde::{Deserialize, Serialize};
 
 /// Maximum byte length for mneme-local IDs.
 const MAX_ID_LEN: usize = 256;

--- a/crates/mneme/src/skills/extract.rs
+++ b/crates/mneme/src/skills/extract.rs
@@ -8,9 +8,10 @@
 //! The extracted skill is stored with `status: "pending_review"`: it is NOT
 //! automatically activated. A human or orchestrator must approve it first.
 
+use std::fmt::Write as _;
+
 use serde::{Deserialize, Serialize};
 use snafu::Snafu;
-use std::fmt::Write as _;
 
 use crate::skill::SkillContent;
 use crate::skills::{SkillCandidate, ToolCallRecord};

--- a/crates/mneme/src/skills/signature.rs
+++ b/crates/mneme/src/skills/signature.rs
@@ -9,9 +9,10 @@
 //! 2. Collapse consecutive duplicates (`Read, Read, Read` → `Read`).
 //! 3. Produce a stable u64 hash for fast pre-filter.
 
-use serde::{Deserialize, Serialize};
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
+
+use serde::{Deserialize, Serialize};
 
 use crate::skills::ToolCallRecord;
 

--- a/crates/nous/src/manager.rs
+++ b/crates/nous/src/manager.rs
@@ -1,30 +1,25 @@
 //! Manages all nous actor instances.
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
 
-use tokio::sync::Mutex as TokioMutex;
-
+use aletheia_hermeneus::provider::ProviderRegistry;
+use aletheia_mneme::embedding::EmbeddingProvider;
 #[cfg(feature = "knowledge-store")]
 use aletheia_mneme::knowledge_store::KnowledgeStore;
 use aletheia_mneme::store::SessionStore;
+use aletheia_organon::registry::ToolRegistry;
+use aletheia_organon::types::ToolServices;
+use aletheia_taxis::oikos::Oikos;
 use aletheia_thesauros::loader::LoadedPack;
-
-use std::collections::BTreeMap;
-use std::time::Duration;
-
+use tokio::sync::Mutex as TokioMutex;
 use tokio::sync::watch;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use tracing::{Instrument, debug, error, info, warn};
-
-use aletheia_hermeneus::provider::ProviderRegistry;
-use aletheia_mneme::embedding::EmbeddingProvider;
-use aletheia_organon::registry::ToolRegistry;
-use aletheia_organon::types::ToolServices;
-use aletheia_taxis::oikos::Oikos;
 
 use crate::actor;
 use crate::bootstrap::pack_sections_to_bootstrap;

--- a/crates/taxis/src/error.rs
+++ b/crates/taxis/src/error.rs
@@ -3,8 +3,9 @@
 //! Covers instance root discovery, configuration file reading, and
 //! TOML/JSON/Figment parsing failures during the configuration cascade.
 
-use snafu::Snafu;
 use std::path::PathBuf;
+
+use snafu::Snafu;
 
 /// Errors from configuration and path resolution.
 #[derive(Debug, Snafu)]

--- a/crates/theatron/tui/src/id.rs
+++ b/crates/theatron/tui/src/id.rs
@@ -1,8 +1,9 @@
 //! Newtype wrappers for domain identifiers in the TUI layer.
 
+use std::fmt;
+
 use compact_str::CompactString;
 use serde::{Deserialize, Serialize};
-use std::fmt;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(transparent)]


### PR DESCRIPTION
## Summary

- Reorders imports in 12 files across 7 crates (dianoia, hermeneus, koina, mneme, nous, taxis, theatron) to follow the standard: `std` → external crates → `crate::` → `super::`/`self::`, with blank line separators between each group
- Consolidates stray `std` imports scattered into later groups (hermeneus/client.rs, nous/manager.rs)
- Fixes fully inverted import blocks (mneme/fts/mod.rs, mneme/fts/tokenizer_impl.rs)

Closes #1426

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes (integration_server failure is pre-existing on main)

## Observations

- The `integration_server` test fails identically on main with a reqwest TLS provider panic — not related to this change.
- The mneme engine has ~100+ additional files with `use super::error::*` as the first import line. These follow a codebase convention for the embedded DB engine and were left out of scope to avoid a large, risky diff. A follow-up could address those if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)