### PR TITLE
fix(aletheia): guard embed-candle default feature against removal

### DIFF
--- a/crates/aletheia/Cargo.toml
+++ b/crates/aletheia/Cargo.toml
@@ -13,6 +13,9 @@ name = "aletheia"
 path = "src/main.rs"
 
 [features]
+# WARNING: embed-candle must remain in defaults. It has been accidentally
+# removed three times: #1263, #1326, #1378. A compile-time test in
+# tests/default_features.rs guards against recurrence.
 default = ["tui", "recall", "storage-fjall", "embed-candle"]
 # MCP server (Model Context Protocol). Disabled by default: adds context-window
 # cost and auth friction for local deployments. Enable with `--features mcp`.

--- a/crates/aletheia/tests/default_features.rs
+++ b/crates/aletheia/tests/default_features.rs
@@ -1,0 +1,15 @@
+//! Guards against accidental removal of required default features.
+
+#[test]
+fn embed_candle_is_in_default_features() {
+    #[expect(
+        clippy::assertions_on_constants,
+        reason = "intentional compile-time feature guard"
+    )]
+    {
+        assert!(
+            cfg!(feature = "embed-candle"),
+            "embed-candle must be in default features (see #1263, #1326, #1378)"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a `WARNING:` comment in `crates/aletheia/Cargo.toml` referencing all three incidents (#1263, #1326, #1378) where `embed-candle` was accidentally dropped from default features
- Adds a compile-time guard test (`tests/default_features.rs`) that asserts `cfg!(feature = "embed-candle")` under default features, so any future removal will fail the test suite

Closes #1378

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test -p aletheia --test default_features` passes
- [x] `embed-candle` is in default features
- [x] Warning comment references #1263, #1326, #1378

## Observations

- **Bug** `crates/aletheia/tests/integration_server.rs`: `server_starts_serves_health_and_shuts_down` panics with "No provider set" (reqwest TLS). Pre-existing on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)