### PR TITLE
feat(deploy): add backup, rollback, and health check

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,88 +1,275 @@
 #!/usr/bin/env bash
 set -euo pipefail
 # Deploy aletheia binary to the local instance.
-# Usage: scripts/deploy.sh [--build] [--restart]
-#   --build    Build release binary before deploying (default: use existing)
-#   --restart  Restart systemd service after deploy (default: just copy)
-#   No flags:  build + copy + restart (full deploy)
+#
+# Usage: scripts/deploy.sh [--build] [--restart] [--rollback] [--dry-run]
+#   --build      Build release binary before deploying (default: use existing)
+#   --restart    Restart systemd service after deploy (default: just copy)
+#   --rollback   Restore the most recent backup and restart
+#   --dry-run    Show what would happen without executing
+#   No flags:    build + copy + restart (full deploy)
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 INSTANCE_ROOT="${ALETHEIA_INSTANCE:-$HOME/ergon/instance}"
 BINARY_SRC="$REPO_ROOT/target/release/aletheia"
 BINARY_DST="${ALETHEIA_BINARY:-$HOME/ergon/bin/aletheia}"
 SERVICE="aletheia.service"
+BACKUP_DIR="${INSTANCE_ROOT}/.deploy-backup"
+DEPLOY_LOG="${INSTANCE_ROOT}/deploy.log"
+HEALTH_URL="${ALETHEIA_HEALTH_URL:-http://localhost:18789/api/health}"
+HEALTH_TIMEOUT=30
+MAX_BACKUPS=3
 
-# Parse flags
+# --- Logging ---
+
+log() {
+    local msg
+    msg="[deploy] $(date -u +"%Y-%m-%dT%H:%M:%SZ") $*"
+    echo "$msg"
+    if [[ "$DRY_RUN" == false ]]; then
+        mkdir -p "$(dirname "$DEPLOY_LOG")"
+        echo "$msg" >> "$DEPLOY_LOG"
+    fi
+}
+
+die() {
+    log "ERROR: $*" >&2
+    exit 1
+}
+
+# --- Parse flags ---
+
 BUILD=false
 RESTART=false
+ROLLBACK=false
+DRY_RUN=false
+
 if [[ $# -eq 0 ]]; then
     BUILD=true
     RESTART=true
 fi
+
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --build) BUILD=true; shift ;;
         --restart) RESTART=true; shift ;;
-        *) echo "Unknown flag: $1"; exit 1 ;;
+        --rollback) ROLLBACK=true; shift ;;
+        --dry-run) DRY_RUN=true; shift ;;
+        *) die "Unknown flag: $1" ;;
     esac
 done
 
-# Refresh OAuth token from Claude Code credentials
+# --- Backup functions ---
+
+backup_binary() {
+    if [[ ! -f "$BINARY_DST" ]]; then
+        log "No existing binary at $BINARY_DST, skipping backup"
+        return 0
+    fi
+
+    local timestamp
+    timestamp="$(date -u +"%Y%m%dT%H%M%SZ")"
+    local backup_path="${BACKUP_DIR}/aletheia.backup.${timestamp}"
+
+    if [[ "$DRY_RUN" == true ]]; then
+        log "[dry-run] Would back up $BINARY_DST to $backup_path"
+        log "[dry-run] Would prune backups beyond $MAX_BACKUPS"
+        return 0
+    fi
+
+    mkdir -p "$BACKUP_DIR"
+    cp -- "$BINARY_DST" "$backup_path"
+
+    if [[ ! -f "$backup_path" ]]; then
+        die "Backup failed: $backup_path not created"
+    fi
+
+    log "Backed up binary to $backup_path ($(stat -c%s "$backup_path") bytes)"
+
+    # Prune old backups, keep the newest MAX_BACKUPS
+    local -a backups
+    mapfile -t backups < <(find "$BACKUP_DIR" -maxdepth 1 -name 'aletheia.backup.*' -type f -printf '%T@\t%p\n' 2>/dev/null \
+        | sort -rn | cut -f2-)
+    local count=${#backups[@]}
+    if (( count > MAX_BACKUPS )); then
+        local i
+        for (( i = MAX_BACKUPS; i < count; i++ )); do
+            log "Pruning old backup: ${backups[$i]}"
+            rm -f -- "${backups[$i]}"
+        done
+    fi
+}
+
+get_latest_backup() {
+    find "$BACKUP_DIR" -maxdepth 1 -name 'aletheia.backup.*' -type f -printf '%T@\t%p\n' 2>/dev/null \
+        | sort -rn | head -1 | cut -f2-
+}
+
+# --- Health check ---
+
+check_health() {
+    local elapsed=0
+    local interval=3
+
+    log "Waiting up to ${HEALTH_TIMEOUT}s for health check..."
+
+    while (( elapsed < HEALTH_TIMEOUT )); do
+        if health_response=$(curl -sf --max-time 5 "$HEALTH_URL" 2>/dev/null); then
+            local status
+            status=$(echo "$health_response" | python3 -c "import sys,json; print(json.load(sys.stdin)['status'])" 2>/dev/null) || true
+            local version
+            version=$(echo "$health_response" | python3 -c "import sys,json; print(json.load(sys.stdin)['version'])" 2>/dev/null) || true
+
+            if [[ "$status" == "healthy" || "$status" == "degraded" ]]; then
+                log "Health check passed: $status v${version:-unknown}"
+                return 0
+            fi
+            log "Health status: $status (waiting...)"
+        fi
+
+        sleep "$interval"
+        elapsed=$(( elapsed + interval ))
+    done
+
+    log "Health check failed after ${HEALTH_TIMEOUT}s"
+    return 1
+}
+
+# --- Rollback ---
+
+do_rollback() {
+    local backup
+    backup="$(get_latest_backup)"
+
+    if [[ -z "$backup" ]]; then
+        die "No backups found in $BACKUP_DIR"
+    fi
+
+    if [[ "$DRY_RUN" == true ]]; then
+        log "[dry-run] Would restore $backup to $BINARY_DST"
+        log "[dry-run] Would restart $SERVICE"
+        log "[dry-run] Would run health check"
+        return 0
+    fi
+
+    log "Rolling back from $backup..."
+
+    # Stop service
+    if systemctl --user is-active "$SERVICE" &>/dev/null; then
+        log "Stopping $SERVICE..."
+        systemctl --user stop "$SERVICE"
+    fi
+
+    # Restore binary
+    cp -- "$backup" "$BINARY_DST"
+    log "Restored binary from $backup"
+
+    # Restart service
+    systemctl --user daemon-reload
+    systemctl --user start "$SERVICE"
+    log "Service restarted"
+
+    # Verify health
+    if check_health; then
+        log "Rollback complete"
+    else
+        die "Service unhealthy after rollback. Manual intervention required."
+    fi
+}
+
+# --- Refresh OAuth token ---
+
 refresh_token() {
     local cred_file="$HOME/.claude/.credentials.json"
     if [[ -f "$cred_file" ]]; then
         local token
-        token=$(python3 -c "import json; d=json.load(open('$cred_file')); print(d['claudeAiOauth']['accessToken'])" 2>/dev/null)
+        token=$(python3 -c "import json; d=json.load(open('$cred_file')); print(d['claudeAiOauth']['accessToken'])" 2>/dev/null) || return 0
         if [[ -n "$token" ]]; then
             local svc_file="$HOME/.config/systemd/user/$SERVICE"
             if grep -q "ANTHROPIC_AUTH_TOKEN" "$svc_file" 2>/dev/null; then
                 sed -i "s|ANTHROPIC_AUTH_TOKEN=.*|ANTHROPIC_AUTH_TOKEN=$token|" "$svc_file"
-                echo "Token updated in $SERVICE"
+                log "Token updated in $SERVICE"
             fi
         fi
     fi
 }
 
+# --- Main ---
+
+# Handle rollback mode
+if [[ "$ROLLBACK" == true ]]; then
+    log "=== Rollback requested ==="
+    do_rollback
+    exit 0
+fi
+
+log "=== Deploy started ==="
+
 # Build
-if $BUILD; then
-    echo "Building release binary..."
-    cd "$REPO_ROOT"
-    cargo build --release -p aletheia
-    echo "Built: $(./target/release/aletheia --version)"
+if [[ "$BUILD" == true ]]; then
+    if [[ "$DRY_RUN" == true ]]; then
+        log "[dry-run] Would build release binary"
+    else
+        log "Building release binary..."
+        cd "$REPO_ROOT"
+        cargo build --release -p aletheia
+        log "Built: $(./target/release/aletheia --version)"
+    fi
 fi
 
 # Verify binary exists
-if [[ ! -f "$BINARY_SRC" ]]; then
-    echo "Error: binary not found at $BINARY_SRC"
-    echo "Run with --build or build manually first."
-    exit 1
+if [[ "$DRY_RUN" == false && ! -f "$BINARY_SRC" ]]; then
+    die "Binary not found at $BINARY_SRC. Run with --build or build manually first."
 fi
+
+# Backup existing binary before deploy
+backup_binary
 
 # Stop service if running
 if systemctl --user is-active "$SERVICE" &>/dev/null; then
-    echo "Stopping $SERVICE..."
-    systemctl --user stop "$SERVICE"
+    if [[ "$DRY_RUN" == true ]]; then
+        log "[dry-run] Would stop $SERVICE"
+    else
+        log "Stopping $SERVICE..."
+        systemctl --user stop "$SERVICE"
+    fi
 fi
 
 # Copy binary
-mkdir -p "$(dirname "$BINARY_DST")"
-cp "$BINARY_SRC" "$BINARY_DST"
-echo "Deployed: $BINARY_DST"
+if [[ "$DRY_RUN" == true ]]; then
+    log "[dry-run] Would copy $BINARY_SRC to $BINARY_DST"
+else
+    mkdir -p "$(dirname "$BINARY_DST")"
+    cp -- "$BINARY_SRC" "$BINARY_DST"
+    log "Deployed: $BINARY_DST"
+fi
 
 # Refresh token
-refresh_token
+if [[ "$DRY_RUN" == false ]]; then
+    refresh_token
+else
+    log "[dry-run] Would refresh OAuth token"
+fi
 
-# Restart
-if $RESTART; then
-    systemctl --user daemon-reload
-    systemctl --user start "$SERVICE"
-    sleep 3
-    if systemctl --user is-active "$SERVICE" &>/dev/null; then
-        echo "Service running."
-        curl -sf http://localhost:18789/api/health 2>/dev/null | python3 -c "import sys,json; d=json.load(sys.stdin); print(f'Health: {d[\"status\"]} v{d[\"version\"]}')" 2>/dev/null || echo "Health check: waiting..."
+# Restart and health check
+if [[ "$RESTART" == true ]]; then
+    if [[ "$DRY_RUN" == true ]]; then
+        log "[dry-run] Would restart $SERVICE"
+        log "[dry-run] Would run health check (${HEALTH_TIMEOUT}s timeout)"
+        log "[dry-run] Would auto-rollback on health check failure"
     else
-        echo "ERROR: Service failed to start"
-        journalctl --user -eu "$SERVICE" --since "10 sec ago" --no-pager | tail -5
-        exit 1
+        systemctl --user daemon-reload
+        systemctl --user start "$SERVICE"
+        log "Service started"
+
+        if check_health; then
+            log "=== Deploy complete ==="
+        else
+            log "Health check failed, triggering automatic rollback..."
+            do_rollback
+            die "Deploy failed. Rolled back to previous version."
+        fi
     fi
+else
+    log "=== Deploy complete (no restart) ==="
 fi

--- a/scripts/rollback.sh
+++ b/scripts/rollback.sh
@@ -1,44 +1,63 @@
 #!/usr/bin/env bash
-set -euo pipefail
-# rollback.sh — Restore previous Aletheia deployment
+# Restore previous Aletheia deployment from backup.
 #
-# Usage: ./scripts/rollback.sh [backup-timestamp]
+# Usage: scripts/rollback.sh [backup-file]
+#   backup-file  Specific backup file path (default: most recent)
+#
+# Prefer `scripts/deploy.sh --rollback` for integrated rollback with
+# logging and health verification.
 
-REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-BACKUP_DIR="$REPO_ROOT/.deploy-backup"
+set -euo pipefail
 
-log() { echo "[rollback] $(date +%H:%M:%S) $*"; }
-die() { echo "[rollback] ERROR: $*" >&2; exit 1; }
+INSTANCE_ROOT="${ALETHEIA_INSTANCE:-$HOME/ergon/instance}"
+BINARY_DST="${ALETHEIA_BINARY:-$HOME/ergon/bin/aletheia}"
+BACKUP_DIR="${INSTANCE_ROOT}/.deploy-backup"
+SERVICE="aletheia.service"
+HEALTH_URL="${ALETHEIA_HEALTH_URL:-http://localhost:18789/api/health}"
 
-# Find the latest backup or use specified timestamp
+log() { echo "[rollback] $(date -u +"%Y-%m-%dT%H:%M:%SZ") $*"; }
+die() { echo "[rollback] $(date -u +"%Y-%m-%dT%H:%M:%SZ") ERROR: $*" >&2; exit 1; }
+
+# Find backup
 if [[ -n "${1:-}" ]]; then
-  BACKUP="$BACKUP_DIR/$1"
+    BACKUP="$1"
 else
-  BACKUP=$(find "$BACKUP_DIR" -maxdepth 1 -mindepth 1 -type d -printf '%T@\t%p\n' | sort -rn | head -1 | cut -f2-)
+    BACKUP=$(find "$BACKUP_DIR" -maxdepth 1 -name 'aletheia.backup.*' -type f -printf '%T@\t%p\n' 2>/dev/null \
+        | sort -rn | head -1 | cut -f2-)
 fi
 
-[[ -d "$BACKUP" ]] || die "No backup found at $BACKUP"
+[[ -f "$BACKUP" ]] || die "No backup found at ${BACKUP:-$BACKUP_DIR/}"
 
 log "Rolling back from $BACKUP..."
 
-# Restore binary
-if [[ -f "$BACKUP/aletheia" ]]; then
-  cp "$BACKUP/aletheia" "$REPO_ROOT/target/release/aletheia"
-  log "Binary restored"
+# Stop service
+if systemctl --user is-active "$SERVICE" &>/dev/null; then
+    log "Stopping $SERVICE..."
+    systemctl --user stop "$SERVICE"
 fi
 
-# Show the git SHA for reference
-if [[ -f "$BACKUP/git-sha" ]]; then
-  log "Backup was from commit: $(cat "$BACKUP/git-sha")"
-fi
+# Restore binary
+cp -- "$BACKUP" "$BINARY_DST"
+log "Binary restored to $BINARY_DST"
 
 # Restart
-log "Restarting daemon..."
-sudo systemctl restart aletheia || die "Restart failed after rollback"
+log "Starting $SERVICE..."
+systemctl --user daemon-reload
+systemctl --user start "$SERVICE"
 
-sleep 3
-if systemctl is-active --quiet aletheia; then
-  log "✓ Rollback complete. Daemon is running."
+# Health check (15s timeout for rollback)
+elapsed=0
+while (( elapsed < 15 )); do
+    if curl -sf --max-time 5 "$HEALTH_URL" &>/dev/null; then
+        log "Rollback complete. Service is healthy."
+        exit 0
+    fi
+    sleep 3
+    elapsed=$(( elapsed + 3 ))
+done
+
+if systemctl --user is-active "$SERVICE" &>/dev/null; then
+    log "Rollback complete. Service is running (health endpoint not yet responding)."
 else
-  die "Daemon failed to start after rollback"
+    die "Service failed to start after rollback"
 fi


### PR DESCRIPTION
## Summary

- Back up the current binary (with timestamp) before each deploy; retain last 3, prune older
- After restart, poll health endpoint for up to 30s; auto-rollback on failure
- Add `--rollback` flag for manual restore from most recent backup
- Add `--dry-run` flag to preview deploy steps without executing
- Log every step with UTC timestamps to `$INSTANCE_ROOT/deploy.log`
- Update standalone `rollback.sh` to match new flat-file backup layout

Closes #1442

## Observations

- **Debt** `scripts/deploy.sh:183-192` — `refresh_token` reads Claude credentials and sed-patches the systemd unit file inline. Fragile if the unit file format changes. Could use `systemctl set-environment` instead.
- **Missing test** — No bats tests for deploy/rollback scripts. The SHELL.md standard recommends bats for non-trivial scripts.
- **Bug** `tests/integration_server` — Pre-existing failure on main (`reqwest` "No provider set" panic). Unrelated to this PR.

## Test plan

- [ ] `shellcheck scripts/deploy.sh scripts/rollback.sh` passes clean
- [ ] `cargo fmt --all -- --check` passes
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [ ] `cargo test --workspace` passes (excluding pre-existing integration_server failure)
- [ ] Manual: `scripts/deploy.sh --dry-run` shows expected steps without side effects
- [ ] Manual: full deploy creates backup in `$INSTANCE_ROOT/.deploy-backup/`
- [ ] Manual: `scripts/deploy.sh --rollback` restores from latest backup

🤖 Generated with [Claude Code](https://claude.com/claude-code)