### PR TITLE
chore(workspace): audit empty match arms with intent documentation

### DIFF
--- a/crates/aletheia/src/commands/server.rs
+++ b/crates/aletheia/src/commands/server.rs
@@ -563,6 +563,7 @@ pub async fn run(args: Args) -> Result<()> {
     // Step 2–3: daemon runners have already observed token cancel via child tokens.
     // Await system daemon handle to confirm it has exited.
     match tokio::time::timeout(shutdown_timeout, daemon_handle).await {
+        // NOTE: daemon exited cleanly, nothing to do
         Ok(Ok(())) => {}
         Ok(Err(e)) => warn!(error = %e, "system daemon panicked during shutdown"),
         Err(_) => warn!(
@@ -831,6 +832,7 @@ fn spawn_log_retention(log_dir: PathBuf, retention_days: u32, token: Cancellatio
                             "log retention: removed old log files"
                         );
                     }
+                    // NOTE: no files pruned, nothing to report
                     Ok(Ok(_)) => {}
                     Ok(Err(e)) => {
                         tracing::warn!(error = %e, "log retention cleanup failed");
@@ -843,6 +845,7 @@ fn spawn_log_retention(log_dir: PathBuf, retention_days: u32, token: Cancellatio
                 tokio::select! {
                     biased;
                     () = token.cancelled() => break,
+                    // NOTE: 24h interval elapsed, run next retention cycle
                     () = tokio::time::sleep(std::time::Duration::from_secs(24 * 3600)) => {}
                 }
             }

--- a/crates/aletheia/src/main.rs
+++ b/crates/aletheia/src/main.rs
@@ -191,6 +191,7 @@ async fn main() -> Result<()> {
         Some(Command::AddNous(a)) => {
             return commands::add_nous::run(instance_root, &a).await;
         }
+        // NOTE: no subcommand, fall through to default server startup
         None => {}
     }
 

--- a/crates/aletheia/src/server.rs
+++ b/crates/aletheia/src/server.rs
@@ -466,6 +466,7 @@ pub(crate) async fn serve(cli: Cli) -> Result<()> {
     // Step 2–3: daemon runners have already observed token cancel via child tokens.
     // Await system daemon handle to confirm it has exited.
     match tokio::time::timeout(shutdown_timeout, daemon_handle).await {
+        // NOTE: daemon exited cleanly, nothing to do
         Ok(Ok(())) => {}
         Ok(Err(e)) => warn!(error = %e, "system daemon panicked during shutdown"),
         Err(_) => warn!(

--- a/crates/daemon/src/runner.rs
+++ b/crates/daemon/src/runner.rs
@@ -307,6 +307,7 @@ impl TaskRunner {
                     );
                     task.next_run = Some(jiff::Timestamp::now());
                 }
+                // NOTE: no missed cron window, no catch-up needed
                 Ok(false) => {}
                 Err(e) => {
                     tracing::warn!(

--- a/crates/hermeneus/src/anthropic/stream.rs
+++ b/crates/hermeneus/src/anthropic/stream.rs
@@ -197,6 +197,7 @@ impl StreamAccumulator {
                                 | BlockBuilder::ServerToolUse { input_json, .. } => {
                                     input_json.push_str(&partial_json);
                                 }
+                                // NOTE: InputJsonDelta for non-tool blocks is ignored
                                 _ => {}
                             }
                             on_event(StreamEvent::InputJsonDelta { partial_json });

--- a/crates/hermeneus/src/health.rs
+++ b/crates/hermeneus/src/health.rs
@@ -164,6 +164,7 @@ impl ProviderHealthTracker {
             ProviderHealth::Degraded { .. } => {
                 inner.health = ProviderHealth::Up;
             }
+            // NOTE: already healthy, no state transition needed
             ProviderHealth::Up => {}
             ProviderHealth::Down { .. } => {
                 // Success while Down means a probe succeeded: transition to Up
@@ -230,7 +231,7 @@ impl ProviderHealthTracker {
                     }
                 }
             }
-            // ParseResponse, UnsupportedModel, ProviderInit: not availability issues
+            // NOTE: non-availability errors (parse, unsupported model) do not affect health
             _ => {}
         }
     }

--- a/crates/melete/src/distill.rs
+++ b/crates/melete/src/distill.rs
@@ -552,6 +552,7 @@ fn collect_flush_section(
         "Task Context" => {
             *task_state = Some(content.join("\n"));
         }
+        // NOTE: unrecognized sections are not extracted
         _ => {}
     }
 }

--- a/crates/melete/src/prompt.rs
+++ b/crates/melete/src/prompt.rs
@@ -117,6 +117,7 @@ pub fn format_messages(messages: &[Message], include_tool_calls: bool) -> String
                         ContentBlock::Thinking { thinking, .. } => {
                             let _ = writeln!(block_text, "[Thinking: {thinking}]");
                         }
+                        // NOTE: other content block types not rendered in prompt summary
                         _ => {}
                     }
                 }

--- a/crates/mneme/src/consolidation/mod.rs
+++ b/crates/mneme/src/consolidation/mod.rs
@@ -279,6 +279,7 @@ fn extract_json_array(s: &str) -> Option<&str> {
                     return Some(&s[start..=start + i]);
                 }
             }
+            // NOTE: non-bracket character, no depth change
             _ => {}
         }
     }

--- a/crates/mneme/src/dedup.rs
+++ b/crates/mneme/src/dedup.rs
@@ -254,7 +254,8 @@ pub(crate) fn classify_candidates(
         match MergeDecision::from_score(c.merge_score) {
             MergeDecision::AutoMerge => auto_merge.push(c),
             MergeDecision::Review => review.push(c),
-            MergeDecision::Skip => {} // discard
+            // NOTE: score below threshold, candidate discarded
+            MergeDecision::Skip => {}
         }
     }
 

--- a/crates/mneme/src/engine/data/expr.rs
+++ b/crates/mneme/src/engine/data/expr.rs
@@ -343,6 +343,7 @@ impl Expr {
                 })?;
                 *tuple_pos = Some(found_idx)
             }
+            // NOTE: constants have no variable bindings to process
             Expr::Const { .. } => {}
             Expr::Apply { args, .. } => {
                 for arg in args.iter_mut() {
@@ -373,6 +374,7 @@ impl Expr {
                     coll.insert(*idx);
                 }
             }
+            // NOTE: constants have no variable bindings to process
             Expr::Const { .. } => {}
             Expr::Apply { args, .. } => {
                 for arg in args.iter() {
@@ -445,6 +447,7 @@ impl Expr {
             Expr::Binding { var, .. } => {
                 coll.insert(var.clone());
             }
+            // NOTE: constants have no variable bindings to process
             Expr::Const { .. } => {}
             Expr::Apply { args, .. } => {
                 for arg in args.iter() {
@@ -604,6 +607,7 @@ impl Expr {
             Expr::Binding { var, .. } => {
                 coll.insert(var.to_string());
             }
+            // NOTE: constants have no variable bindings to process
             Expr::Const { .. } => {}
             Expr::Apply { args, .. } => {
                 for arg in args.iter() {

--- a/crates/mneme/src/engine/data/program.rs
+++ b/crates/mneme/src/engine/data/program.rs
@@ -907,6 +907,7 @@ impl MagicInlineRule {
                         }
                     }
                 }
+                // NOTE: non-rule atoms don't contribute to rule containment
                 _ => {}
             }
         }

--- a/crates/mneme/src/engine/parse/expr.rs
+++ b/crates/mneme/src/engine/parse/expr.rs
@@ -317,6 +317,7 @@ fn build_term(pair: Pair<'_>, param_pool: &BTreeMap<String, DataValue>) -> Resul
                         .collect_vec();
                     if let Some((cond, _)) = clauses.last() {
                         match cond {
+                            // NOTE: last clause already has true default, no null fallback needed
                             Expr::Const {
                                 val: DataValue::Bool(true),
                                 ..

--- a/crates/mneme/src/engine/parse/mod.rs
+++ b/crates/mneme/src/engine/parse/mod.rs
@@ -145,6 +145,7 @@ impl ImperativeStmt {
                     prog.needs_write_locks(collector);
                 }
             }
+            // NOTE: these statements don't acquire relation locks
             ImperativeStmt::TempDebug { .. }
             | ImperativeStmt::Break { .. }
             | ImperativeStmt::Continue { .. }
@@ -189,6 +190,7 @@ impl ImperativeStmt {
                 SysOp::RemoveIndex(rel, idx) => {
                     collector.insert(CompactString::from(format!("{}:{}", rel.name, idx.name)));
                 }
+                // NOTE: other system operations don't require relation locks
                 _ => {}
             },
         }

--- a/crates/mneme/src/engine/parse/query.rs
+++ b/crates/mneme/src/engine/parse/query.rs
@@ -495,6 +495,7 @@ fn apply_stored_relation(
     returning_mutation: ReturnMutation,
 ) -> Result<()> {
     match stored_relation {
+        // NOTE: no stored relation specified, query returns results directly
         None => {}
         Some(Left((name, span, op))) => {
             let head = prog.get_entry_out_head()?;

--- a/crates/mneme/src/engine/query/magic.rs
+++ b/crates/mneme/src/engine/query/magic.rs
@@ -42,6 +42,7 @@ impl NormalFormProgram {
                         }
                     }
                 }
+                // NOTE: fixed rules have no user-defined aggregations to exempt
                 NormalFormRulesOrFixed::Fixed { fixed: _ } => {}
             }
         }
@@ -278,6 +279,7 @@ impl NormalFormProgram {
                                         downstream_rules.insert(r_app.name.clone());
                                     }
                                 }
+                                // NOTE: non-rule atoms don't contribute downstream rules
                                 _ => {}
                             }
                         }

--- a/crates/mneme/src/engine/query/ra/filter.rs
+++ b/crates/mneme/src/engine/query/ra/filter.rs
@@ -66,6 +66,7 @@ impl FilteredRA {
                             match eval_bytecode_pred(p, &t, &mut stack, *span) {
                                 Ok(false) => return None,
                                 Err(e) => return Some(Err(e)),
+                                // NOTE: filter passed, continue to next
                                 Ok(true) => {}
                             }
                         }

--- a/crates/mneme/src/engine/query/ra/mod.rs
+++ b/crates/mneme/src/engine/query/ra/mod.rs
@@ -103,6 +103,7 @@ pub(crate) fn filter_iter(
                         debug!("{:?}", t);
                         return Some(Err(e));
                     }
+                    // NOTE: filter passed, continue to next
                     Ok(true) => {}
                 }
             }
@@ -265,6 +266,7 @@ impl Debug for RelAlgebra {
 impl RelAlgebra {
     pub(crate) fn fill_binding_indices_and_compile(&mut self) -> Result<()> {
         match self {
+            // NOTE: fixed relations have no binding indices to fill
             RelAlgebra::Fixed(_) => {}
             RelAlgebra::TempStore(d) => {
                 d.fill_binding_indices_and_compile()?;

--- a/crates/mneme/src/engine/query/sort.rs
+++ b/crates/mneme/src/engine/query/sort.rs
@@ -28,6 +28,7 @@ impl<'a> SessionTx<'a> {
         all_data.sort_by(|a, b| {
             for (idx, dir) in &idx_sorters {
                 match a[*idx].cmp(&b[*idx]) {
+                    // NOTE: equal on this key, continue to next sort key
                     Ordering::Equal => {}
                     o => {
                         return match dir {

--- a/crates/mneme/src/engine/query/stratify.rs
+++ b/crates/mneme/src/engine/query/stratify.rs
@@ -134,6 +134,7 @@ fn convert_normal_form_program_to_graph(
                         FixedRuleArg::InMem { name, .. } => {
                             ret.insert(name, true);
                         }
+                        // NOTE: stored relations are not in-memory, skip for stratification
                         FixedRuleArg::Stored { .. } | FixedRuleArg::NamedStored { .. } => {}
                     }
                 }

--- a/crates/mneme/src/engine/runtime/imperative.rs
+++ b/crates/mneme/src/engine/runtime/imperative.rs
@@ -230,6 +230,7 @@ impl<'s, S: Storage<'s>> Db<S> {
         loop {
             ctx.poison.check()?;
             match self.execute_imperative_stmts(body, tx, cur_vld, ctx)? {
+                // NOTE: body completed normally, continue loop iteration
                 Left(_) => {}
                 Right(ctrl) => match ctrl {
                     ControlCode::Termination(ret_val) => {

--- a/crates/mneme/src/engine/runtime/transact.rs
+++ b/crates/mneme/src/engine/runtime/transact.rs
@@ -282,6 +282,7 @@ impl<'s, S: Storage<'s>> Db<S> {
                                     .expect("obtain_relation_locks returns one lock per input");
                                 e.insert(lock);
                             }
+                            // NOTE: write lock already acquired for this relation
                             Entry::Occupied(_) => {}
                         }
                     }

--- a/crates/mneme/src/graph_intelligence.rs
+++ b/crates/mneme/src/graph_intelligence.rs
@@ -302,7 +302,7 @@ impl crate::knowledge_store::KnowledgeStore {
                 "cluster" => {
                     ctx.clusters.insert(entity_id.to_owned(), cluster_id);
                 }
-                // pagerank_max meta entry: normalization already done in Datalog
+                // NOTE: pagerank_max meta entry, normalization already done in Datalog
                 _ => {}
             }
         }

--- a/crates/mneme/src/instinct.rs
+++ b/crates/mneme/src/instinct.rs
@@ -477,6 +477,7 @@ pub(crate) fn aggregate_observations(observations: &[ToolObservation]) -> Vec<Be
             None => {
                 accum.first_observed = Some(obs.observed_at);
             }
+            // NOTE: current observation is not earlier, no update needed
             _ => {}
         }
 
@@ -487,6 +488,7 @@ pub(crate) fn aggregate_observations(observations: &[ToolObservation]) -> Vec<Be
             None => {
                 accum.last_observed = Some(obs.observed_at);
             }
+            // NOTE: current observation is not later, no update needed
             _ => {}
         }
     }

--- a/crates/nous/src/actor/background.rs
+++ b/crates/nous/src/actor/background.rs
@@ -18,6 +18,7 @@ impl NousActor {
     pub(super) fn reap_background_tasks(&mut self) {
         while let Some(result) = self.background_tasks.try_join_next() {
             match result {
+                // NOTE: task completed successfully, no action needed
                 Ok(()) => {}
                 Err(e) => {
                     if e.is_panic() {
@@ -373,6 +374,7 @@ async fn run_skill_extraction(
                         );
                         return;
                     }
+                    // NOTE: no duplicate found, proceed with storage
                     Ok(None) => {}
                     Err(e) => {
                         warn!(error = %e, "failed to check skill duplicates, proceeding with storage");

--- a/crates/nous/src/execute/mod.rs
+++ b/crates/nous/src/execute/mod.rs
@@ -127,6 +127,7 @@ fn process_response_blocks(content: &[ContentBlock]) -> ResponseExtract {
                     return_code, "server code execution result received"
                 );
             }
+            // NOTE: other content block types (images, etc.) are not tracked in extraction
             _ => {}
         }
     }

--- a/crates/nous/src/execute/tests.rs
+++ b/crates/nous/src/execute/tests.rs
@@ -670,6 +670,7 @@ async fn streaming_tool_events_emitted() {
         match event {
             TurnStreamEvent::ToolStart { .. } => tool_start_count += 1,
             TurnStreamEvent::ToolResult { .. } => tool_result_count += 1,
+            // NOTE: counting only ToolStart/ToolResult events
             _ => {}
         }
     }

--- a/crates/nous/src/handle.rs
+++ b/crates/nous/src/handle.rs
@@ -393,6 +393,7 @@ mod tests {
                         received += 1;
                     }
                     NousMessage::Shutdown => break,
+                    // NOTE: test actor ignores non-Turn/non-Shutdown messages
                     _ => {}
                 }
             }

--- a/crates/nous/src/history.rs
+++ b/crates/nous/src/history.rs
@@ -104,6 +104,7 @@ pub fn load_history(
         match msg.role {
             Role::System => continue,
             Role::ToolResult if !config.include_tool_messages => continue,
+            // NOTE: User and Assistant roles pass through for inclusion
             _ => {}
         }
 

--- a/crates/nous/src/user_error.rs
+++ b/crates/nous/src/user_error.rs
@@ -192,6 +192,7 @@ mod tests {
         };
         let uf = to_user_facing(&err).expect("should convert");
         match uf {
+            // NOTE: expected variant matched, assertion passes
             UserFacingError::RateLimited {
                 retry_after_secs: Some(5),
             } => {}

--- a/crates/organon/src/builtins/workspace.rs
+++ b/crates/organon/src/builtins/workspace.rs
@@ -126,6 +126,7 @@ pub(crate) fn normalize(path: &Path) -> PathBuf {
             Component::ParentDir => {
                 result.pop();
             }
+            // NOTE: current-dir component (`.`) is a no-op in normalization
             Component::CurDir => {}
             other => result.push(other),
         }
@@ -218,6 +219,7 @@ impl ToolExecutor for ReadExecutor {
                 Err(e) => {
                     return Ok(err_result(format!("read failed: {e}")));
                 }
+                // NOTE: metadata check passed, proceed to read content
                 Ok(_) => {}
             }
 

--- a/crates/organon/src/sandbox.rs
+++ b/crates/organon/src/sandbox.rs
@@ -251,6 +251,7 @@ impl SandboxPolicy {
             .map_err(|e| std::io::Error::other(format!("Landlock restrict_self failed: {e}")))?;
 
         match status.ruleset {
+            // NOTE: sandbox enforcement active, no action needed
             RulesetStatus::FullyEnforced | RulesetStatus::PartiallyEnforced => {}
             RulesetStatus::NotEnforced => {
                 if self.enforcement == SandboxEnforcement::Enforcing {
@@ -436,6 +437,7 @@ pub fn apply_sandbox(
                  Set enforcement=permissive to run without sandboxing.",
             ));
         }
+        // NOTE: Landlock ABI available, proceed with sandbox setup
         (Some(_), _) => {}
     }
 

--- a/crates/pylon/src/handlers/knowledge.rs
+++ b/crates/pylon/src/handlers/knowledge.rs
@@ -723,6 +723,7 @@ pub(crate) fn sort_facts(facts: &mut [aletheia_mneme::knowledge::Fact], sort: &s
                 .unwrap_or(std::cmp::Ordering::Equal);
             if desc { cmp.reverse() } else { cmp }
         }),
+        // NOTE: unrecognized sort field, facts retain original order
         _ => {}
     }
 }

--- a/crates/taxis/src/cascade.rs
+++ b/crates/taxis/src/cascade.rs
@@ -91,6 +91,7 @@ pub fn discover(
 
             if let Some(required_ext) = ext {
                 match path.extension().and_then(OsStr::to_str) {
+                    // NOTE: extension matches, fall through to insertion
                     Some(e) if e == required_ext => {}
                     _ => continue,
                 }

--- a/crates/taxis/src/redact.rs
+++ b/crates/taxis/src/redact.rs
@@ -59,6 +59,7 @@ fn redact_sensitive_keys(value: &mut Value) {
                 redact_sensitive_keys(item);
             }
         }
+        // NOTE: leaf values (null, bool, number, string) have no keys to redact
         _ => {}
     }
 }

--- a/crates/taxis/src/validate.rs
+++ b/crates/taxis/src/validate.rs
@@ -25,6 +25,7 @@ pub fn validate_section(section: &str, value: &Value) -> Result<(), ValidationEr
         "channels" => validate_channels(value, &mut errors),
         "bindings" => validate_bindings(value, &mut errors),
         "credential" => validate_credential(value, &mut errors),
+        // NOTE: these sections are pass-through with no validation rules
         "packs" | "pricing" | "sandbox" => {}
         _ => errors.push(format!("unknown config section: {section}")),
     }
@@ -216,6 +217,7 @@ fn validate_bindings(value: &Value, errors: &mut Vec<String>) {
                 None | Some("") => {
                     errors.push(format!("bindings[{i}].{field} must not be empty"));
                 }
+                // NOTE: non-empty field value passes validation
                 _ => {}
             }
         }

--- a/crates/theatron/desktop/src/api/sse.rs
+++ b/crates/theatron/desktop/src/api/sse.rs
@@ -89,6 +89,7 @@ impl SseConnection {
                             tokio::select! {
                                 biased;
                                 _ = child.cancelled() => return,
+                                // NOTE: backoff elapsed, retry connection
                                 _ = tokio::time::sleep(backoff) => {}
                             }
                             backoff = advance_backoff(backoff);
@@ -163,6 +164,7 @@ impl SseConnection {
                     tokio::select! {
                         biased;
                         _ = child.cancelled() => return,
+                        // NOTE: backoff elapsed, retry connection
                         _ = tokio::time::sleep(backoff) => {}
                     }
                 }

--- a/crates/theatron/desktop/src/api/streaming.rs
+++ b/crates/theatron/desktop/src/api/streaming.rs
@@ -102,6 +102,7 @@ pub fn stream_turn(
                 let Some(event) = maybe_event else { break };
 
                 match event {
+                    // NOTE: SSE connection opened, no action needed
                     Ok(EsEvent::Open) => {}
                     Ok(EsEvent::Message(msg)) => {
                         if let Some(parsed) = parse_stream_event(&msg.event, &msg.data) {

--- a/crates/theatron/desktop/src/services/connection.rs
+++ b/crates/theatron/desktop/src/services/connection.rs
@@ -239,6 +239,7 @@ impl ConnectionService {
                     tokio::select! {
                         biased;
                         _ = self.cancel.cancelled() => return,
+                        // NOTE: backoff elapsed, retry connection
                         _ = tokio::time::sleep(delay) => {}
                     }
                 }
@@ -259,6 +260,7 @@ impl ConnectionService {
             tokio::select! {
                 biased;
                 _ = self.cancel.cancelled() => return,
+                // NOTE: interval elapsed, proceed to health check
                 _ = tokio::time::sleep(HEALTH_CHECK_INTERVAL) => {}
             }
 
@@ -310,6 +312,7 @@ impl ConnectionService {
             tokio::select! {
                 biased;
                 _ = self.cancel.cancelled() => return false,
+                // NOTE: backoff elapsed, retry connection
                 _ = tokio::time::sleep(delay) => {}
             }
 

--- a/crates/theatron/tui/src/api/streaming.rs
+++ b/crates/theatron/tui/src/api/streaming.rs
@@ -50,6 +50,7 @@ pub fn stream_message(
 
             while let Some(event) = es.next().await {
                 match event {
+                    // NOTE: SSE connection opened, no action needed
                     Ok(EsEvent::Open) => {}
                     Ok(EsEvent::Message(msg)) => {
                         if let Some(parsed) = parse_stream_event(&msg.event, &msg.data) {

--- a/crates/theatron/tui/src/hyperlink.rs
+++ b/crates/theatron/tui/src/hyperlink.rs
@@ -66,6 +66,7 @@ fn probe_hyperlink_support() -> bool {
     if let Ok(prog) = std::env::var("TERM_PROGRAM") {
         match prog.as_str() {
             "iTerm.app" | "WezTerm" | "ghostty" | "Ghostty" | "kitty" => return true,
+            // NOTE: unrecognized TERM_PROGRAM, continue probing other signals
             _ => {}
         }
     }

--- a/crates/theatron/tui/src/mapping.rs
+++ b/crates/theatron/tui/src/mapping.rs
@@ -346,6 +346,7 @@ impl App {
             (KeyModifiers::CONTROL, KeyCode::Char('c'))
             | (KeyModifiers::CONTROL, KeyCode::Char('q')) => return Some(Msg::Quit),
             (KeyModifiers::CONTROL, KeyCode::Char('f')) => return Some(Msg::ToggleSidebar),
+            // NOTE: unhandled key combinations produce no action
             _ => {}
         }
 

--- a/crates/theatron/tui/src/markdown.rs
+++ b/crates/theatron/tui/src/markdown.rs
@@ -163,6 +163,7 @@ pub fn render(
                 Tag::TableCell => {
                     current_cell.clear();
                 }
+                // NOTE: unhandled start tags (footnotes, metadata) are ignored
                 _ => {}
             },
             Event::End(tag_end) => match tag_end {
@@ -276,6 +277,7 @@ pub fn render(
                 TagEnd::TableCell => {
                     current_row.push(current_cell.trim().to_string());
                 }
+                // NOTE: unhandled end tags are ignored
                 _ => {}
             },
             Event::Text(text) => {
@@ -346,6 +348,7 @@ pub fn render(
                 flush_line(&mut lines, &mut current_spans, &mut current_col);
                 lines.push(Line::from(Span::styled("─".repeat(40), theme.style_dim())));
             }
+            // NOTE: unhandled markdown events (footnotes, etc.) are ignored
             _ => {}
         }
     }

--- a/crates/theatron/tui/src/sanitize.rs
+++ b/crates/theatron/tui/src/sanitize.rs
@@ -161,6 +161,7 @@ fn needs_sanitization(s: &str) -> bool {
         match b {
             // NOTE: replace C0 controls (except HT/LF/CR) and DEL with control pictures
             0x00..=0x08 | 0x0B..=0x0C | 0x0E..=0x1F | 0x7F => return true,
+            // NOTE: printable ASCII byte, no sanitization needed
             _ => {}
         }
     }

--- a/crates/theatron/tui/src/theme.rs
+++ b/crates/theatron/tui/src/theme.rs
@@ -543,6 +543,7 @@ fn detect_color_depth() -> ColorDepth {
     if let Ok(ct) = std::env::var("COLORTERM") {
         match ct.as_str() {
             "truecolor" | "24bit" => return ColorDepth::TrueColor,
+            // NOTE: unrecognized COLORTERM value, check other env vars
             _ => {}
         }
     }
@@ -550,6 +551,7 @@ fn detect_color_depth() -> ColorDepth {
     if let Ok(tp) = std::env::var("TERM_PROGRAM") {
         match tp.as_str() {
             "iTerm.app" | "WezTerm" | "Alacritty" | "kitty" => return ColorDepth::TrueColor,
+            // NOTE: unrecognized terminal program, continue probing
             _ => {}
         }
     }

--- a/crates/theatron/tui/src/update/command.rs
+++ b/crates/theatron/tui/src/update/command.rs
@@ -98,6 +98,7 @@ pub fn handle_down(app: &mut App) {
                 app.command_palette.cursor = app.command_palette.input.len();
                 refresh_suggestions(app);
             }
+            // NOTE: already at latest input, no history to navigate
             None => {}
         }
     } else {

--- a/crates/theatron/tui/src/update/input.rs
+++ b/crates/theatron/tui/src/update/input.rs
@@ -110,6 +110,7 @@ pub(crate) fn handle_history_down(app: &mut App) {
             app.input.text = app.input.history[app.input.history.len() - 1 - idx].clone();
             app.input.cursor = app.input.text.len();
         }
+        // NOTE: already at latest input, no history to navigate
         None => {}
     }
 }

--- a/crates/theatron/tui/src/update/mod.rs
+++ b/crates/theatron/tui/src/update/mod.rs
@@ -116,6 +116,7 @@ pub(crate) async fn update(app: &mut App, msg: Msg) {
                     match c {
                         's' | 'S' => settings::handle_save(app).await,
                         'r' | 'R' => settings::handle_reset(app),
+                        // NOTE: other keys ignored in settings non-edit mode
                         _ => {}
                     }
                 }
@@ -205,6 +206,7 @@ pub(crate) async fn update(app: &mut App, msg: Msg) {
         }
         Msg::HistoryLoaded { messages, .. } => api::handle_history_loaded(app, messages),
         Msg::CostLoaded { daily_total_cents } => api::handle_cost_loaded(app, daily_total_cents),
+        // NOTE: auth/API errors handled upstream, no local state update needed
         Msg::AuthResult(_) | Msg::ApiError(_) => {}
         Msg::NewSession => api::handle_new_session(app).await,
         Msg::SessionPickerNewSession => api::handle_session_picker_new(app).await,
@@ -243,6 +245,7 @@ pub(crate) async fn update(app: &mut App, msg: Msg) {
         Msg::MemoryPageUp => memory::handle_page_up(app),
         Msg::MemoryFactsLoaded { facts, total } => memory::handle_facts_loaded(app, facts, total),
         Msg::MemoryDetailLoaded(detail) => memory::handle_detail_loaded(app, *detail),
+        // NOTE: memory data variants handled in memory inspector view
         Msg::MemoryEntitiesLoaded(_)
         | Msg::MemoryRelationshipsLoaded(_)
         | Msg::MemoryTimelineLoaded(_) => {}
@@ -255,6 +258,7 @@ pub(crate) async fn update(app: &mut App, msg: Msg) {
         Msg::SessionSearchClose => search::handle_close(app),
         Msg::SessionSearchInput(c) => search::handle_input(app, c),
         Msg::SessionSearchBackspace => search::handle_backspace(app),
+        // NOTE: submit triggers search via SessionSearchSelect
         Msg::SessionSearchSubmit => {}
         Msg::SessionSearchUp => search::handle_up(app),
         Msg::SessionSearchDown => search::handle_down(app),

--- a/crates/theatron/tui/src/update/overlay.rs
+++ b/crates/theatron/tui/src/update/overlay.rs
@@ -83,6 +83,7 @@ pub(crate) fn handle_overlay_up(app: &mut App) {
         Some(Overlay::Settings(_)) => {
             super::settings::handle_up(app);
         }
+        // NOTE: no overlay or non-navigable overlay, nothing to do
         _ => {}
     }
 }
@@ -113,6 +114,7 @@ pub(crate) fn handle_overlay_down(app: &mut App) {
         Some(Overlay::Settings(_)) => {
             super::settings::handle_down(app);
         }
+        // NOTE: no overlay or non-navigable overlay, nothing to do
         _ => {}
     }
 }

--- a/crates/theatron/tui/src/update/settings.rs
+++ b/crates/theatron/tui/src/update/settings.rs
@@ -81,6 +81,7 @@ pub fn handle_enter(app: &mut App) {
                     cursor,
                 });
             }
+            // NOTE: read-only fields cannot be edited
             FieldType::ReadOnly => {}
         }
     }
@@ -99,6 +100,7 @@ fn confirm_edit(s: &mut SettingsOverlay) {
             FieldType::Text => {
                 field.value = serde_json::Value::String(edit.buffer);
             }
+            // NOTE: ReadOnly and Boolean fields don't need text confirmation
             _ => {}
         }
     }

--- a/crates/theatron/tui/src/update/view_nav.rs
+++ b/crates/theatron/tui/src/update/view_nav.rs
@@ -78,6 +78,7 @@ pub(crate) fn handle_drill_in(app: &mut App) {
                 app.auto_scroll = true;
             }
         }
+        // NOTE: already at detail level, no further drill-in
         View::MessageDetail { .. } | View::MemoryInspector | View::FactDetail { .. } => {}
     }
 }

--- a/crates/theatron/tui/src/view/settings.rs
+++ b/crates/theatron/tui/src/view/settings.rs
@@ -119,6 +119,7 @@ pub fn render(overlay: &SettingsOverlay, frame: &mut Frame, area: Rect, theme: &
                 theme.style_error(),
             )));
         }
+        // NOTE: idle state has no status line to render
         SaveStatus::Idle => {}
     }
 


### PR DESCRIPTION
## Summary

- Audited all 75+ empty match arms (`=> {}`) across 52 files in the workspace
- Added structured `// NOTE:` comments to every empty arm explaining why it's intentionally empty
- No behavioral changes — comments only

## Categories found

- **Intentional no-ops**: fall-through to default behavior (e.g., `None => {}` when no subcommand)
- **Timer elapsed**: `tokio::select!` backoff/sleep arms that proceed to next iteration
- **Filter/predicate passes**: `Ok(true) => {}` in filter chains
- **Constants in expr trees**: `Expr::Const` has no variable bindings to process
- **Clean shutdown**: daemon exited normally, nothing to report
- **Non-navigable UI states**: read-only fields, detail views with no further drill-in

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes (pre-existing integration_server TLS failure excluded)
- [x] No behavioral changes — diff is comments only (78 insertions, 3 modifications)

## Observations

- The original estimate of "25 empty match arms" was low — the actual count is 75+ across the workspace, with a significant cluster in `crates/mneme/src/engine/` (the Datalog query engine)
- The pre-existing `integration_server` test fails on main due to a missing TLS provider — unrelated to this PR

Closes #1398

🤖 Generated with [Claude Code](https://claude.com/claude-code)