### PR TITLE
safety(mneme): replace direct array indexing with bounds-checked access

### DIFF
--- a/crates/mneme/src/engine/data/functions/aggregate.rs
+++ b/crates/mneme/src/engine/data/functions/aggregate.rs
@@ -9,6 +9,8 @@ type Result<T> = DataResult<T>;
 use crate::engine::data::json::JsonValue;
 use crate::engine::data::value::{DataValue, JsonData};
 
+use super::arg;
+
 pub(crate) fn deep_merge_json(value1: JsonValue, value2: JsonValue) -> JsonValue {
     match (value1, value2) {
         (JsonValue::Object(mut obj1), JsonValue::Object(obj2)) => {
@@ -107,9 +109,9 @@ fn get_json_path_immutable_local<'a>(
 }
 
 pub(crate) fn get_impl(args: &[DataValue]) -> Result<DataValue> {
-    match &args[0] {
+    match arg(args, 0)? {
         DataValue::List(l) => {
-            let n = args[1].get_int().ok_or_else(|| {
+            let n = arg(args, 1)?.get_int().ok_or_else(|| {
                 TypeMismatchSnafu {
                     op: "get",
                     expected: "an integer as second argument",
@@ -117,10 +119,12 @@ pub(crate) fn get_impl(args: &[DataValue]) -> Result<DataValue> {
                 .build()
             })?;
             let idx = get_index(n, l.len(), false)?;
-            Ok(l[idx].clone())
+            Ok(l.get(idx)
+                .ok_or_else(|| IndexOutOfBoundsSnafu { index: idx as i64 }.build())?
+                .clone())
         }
         DataValue::Json(json) => {
-            let res = match &args[1] {
+            let res = match arg(args, 1)? {
                 DataValue::Str(s) => json
                     .get(s as &str)
                     .ok_or_else(|| {
@@ -171,7 +175,7 @@ pub(crate) fn op_list(args: &[DataValue]) -> Result<DataValue> {
 }
 
 pub(crate) fn op_concat(args: &[DataValue]) -> Result<DataValue> {
-    match &args[0] {
+    match arg(args, 0)? {
         DataValue::Str(_) => {
             let mut ret: String = Default::default();
             for arg in args {
@@ -228,15 +232,15 @@ pub(crate) fn op_concat(args: &[DataValue]) -> Result<DataValue> {
 }
 
 pub(crate) fn op_append(args: &[DataValue]) -> Result<DataValue> {
-    match &args[0] {
+    match arg(args, 0)? {
         DataValue::List(l) => {
             let mut l = l.clone();
-            l.push(args[1].clone());
+            l.push(arg(args, 1)?.clone());
             Ok(DataValue::List(l))
         }
         DataValue::Set(l) => {
             let mut l = l.iter().cloned().collect_vec();
-            l.push(args[1].clone());
+            l.push(arg(args, 1)?.clone());
             Ok(DataValue::List(l))
         }
         _ => TypeMismatchSnafu {
@@ -248,14 +252,14 @@ pub(crate) fn op_append(args: &[DataValue]) -> Result<DataValue> {
 }
 
 pub(crate) fn op_prepend(args: &[DataValue]) -> Result<DataValue> {
-    match &args[0] {
+    match arg(args, 0)? {
         DataValue::List(pl) => {
-            let mut l = vec![args[1].clone()];
+            let mut l = vec![arg(args, 1)?.clone()];
             l.extend_from_slice(pl);
             Ok(DataValue::List(l))
         }
         DataValue::Set(pl) => {
-            let mut l = vec![args[1].clone()];
+            let mut l = vec![arg(args, 1)?.clone()];
             l.extend(pl.iter().cloned());
             Ok(DataValue::List(l))
         }
@@ -294,7 +298,7 @@ pub(crate) fn op_union(args: &[DataValue]) -> Result<DataValue> {
 }
 
 pub(crate) fn op_difference(args: &[DataValue]) -> Result<DataValue> {
-    let mut start: BTreeSet<_> = match &args[0] {
+    let mut start: BTreeSet<_> = match arg(args, 0)? {
         DataValue::List(l) => l.iter().cloned().collect(),
         DataValue::Set(s) => s.iter().cloned().collect(),
         _ => {
@@ -305,7 +309,7 @@ pub(crate) fn op_difference(args: &[DataValue]) -> Result<DataValue> {
             .fail();
         }
     };
-    for arg in &args[1..] {
+    for arg in args.get(1..).unwrap_or_default() {
         match arg {
             DataValue::List(l) => {
                 for el in l {
@@ -330,7 +334,7 @@ pub(crate) fn op_difference(args: &[DataValue]) -> Result<DataValue> {
 }
 
 pub(crate) fn op_intersection(args: &[DataValue]) -> Result<DataValue> {
-    let mut start: BTreeSet<_> = match &args[0] {
+    let mut start: BTreeSet<_> = match arg(args, 0)? {
         DataValue::List(l) => l.iter().cloned().collect(),
         DataValue::Set(s) => s.iter().cloned().collect(),
         _ => {
@@ -341,7 +345,7 @@ pub(crate) fn op_intersection(args: &[DataValue]) -> Result<DataValue> {
             .fail();
         }
     };
-    for arg in &args[1..] {
+    for arg in args.get(1..).unwrap_or_default() {
         match arg {
             DataValue::List(l) => {
                 let other: BTreeSet<_> = l.iter().cloned().collect();
@@ -361,7 +365,7 @@ pub(crate) fn op_intersection(args: &[DataValue]) -> Result<DataValue> {
 }
 
 pub(crate) fn op_length(args: &[DataValue]) -> Result<DataValue> {
-    Ok(DataValue::from(match &args[0] {
+    Ok(DataValue::from(match arg(args, 0)? {
         DataValue::Set(s) => s.len() as i64,
         DataValue::List(l) => l.len() as i64,
         DataValue::Str(s) => s.chars().count() as i64,
@@ -378,7 +382,7 @@ pub(crate) fn op_length(args: &[DataValue]) -> Result<DataValue> {
 }
 
 pub(crate) fn op_first(args: &[DataValue]) -> Result<DataValue> {
-    Ok(args[0]
+    Ok(arg(args, 0)?
         .get_slice()
         .ok_or_else(|| {
             TypeMismatchSnafu {
@@ -393,7 +397,7 @@ pub(crate) fn op_first(args: &[DataValue]) -> Result<DataValue> {
 }
 
 pub(crate) fn op_last(args: &[DataValue]) -> Result<DataValue> {
-    Ok(args[0]
+    Ok(arg(args, 0)?
         .get_slice()
         .ok_or_else(|| {
             TypeMismatchSnafu {
@@ -408,7 +412,7 @@ pub(crate) fn op_last(args: &[DataValue]) -> Result<DataValue> {
 }
 
 pub(crate) fn op_sorted(args: &[DataValue]) -> Result<DataValue> {
-    let mut arg = args[0]
+    let mut a = arg(args, 0)?
         .get_slice()
         .ok_or_else(|| {
             TypeMismatchSnafu {
@@ -418,12 +422,12 @@ pub(crate) fn op_sorted(args: &[DataValue]) -> Result<DataValue> {
             .build()
         })?
         .to_vec();
-    arg.sort();
-    Ok(DataValue::List(arg))
+    a.sort();
+    Ok(DataValue::List(a))
 }
 
 pub(crate) fn op_reverse(args: &[DataValue]) -> Result<DataValue> {
-    let mut arg = args[0]
+    let mut a = arg(args, 0)?
         .get_slice()
         .ok_or_else(|| {
             TypeMismatchSnafu {
@@ -433,19 +437,19 @@ pub(crate) fn op_reverse(args: &[DataValue]) -> Result<DataValue> {
             .build()
         })?
         .to_vec();
-    arg.reverse();
-    Ok(DataValue::List(arg))
+    a.reverse();
+    Ok(DataValue::List(a))
 }
 
 pub(crate) fn op_chunks(args: &[DataValue]) -> Result<DataValue> {
-    let arg = args[0].get_slice().ok_or_else(|| {
+    let a = arg(args, 0)?.get_slice().ok_or_else(|| {
         TypeMismatchSnafu {
             op: "chunks",
             expected: "a list as first argument",
         }
         .build()
     })?;
-    let n = args[1].get_int().ok_or_else(|| {
+    let n = arg(args, 1)?.get_int().ok_or_else(|| {
         TypeMismatchSnafu {
             op: "chunks",
             expected: "an integer as second argument",
@@ -458,7 +462,7 @@ pub(crate) fn op_chunks(args: &[DataValue]) -> Result<DataValue> {
             message: "second argument to 'chunks' must be positive"
         }
     );
-    let res = arg
+    let res = a
         .chunks(n as usize)
         .map(|el| DataValue::List(el.to_vec()))
         .collect_vec();
@@ -466,14 +470,14 @@ pub(crate) fn op_chunks(args: &[DataValue]) -> Result<DataValue> {
 }
 
 pub(crate) fn op_chunks_exact(args: &[DataValue]) -> Result<DataValue> {
-    let arg = args[0].get_slice().ok_or_else(|| {
+    let a = arg(args, 0)?.get_slice().ok_or_else(|| {
         TypeMismatchSnafu {
             op: "chunks_exact",
             expected: "a list as first argument",
         }
         .build()
     })?;
-    let n = args[1].get_int().ok_or_else(|| {
+    let n = arg(args, 1)?.get_int().ok_or_else(|| {
         TypeMismatchSnafu {
             op: "chunks_exact",
             expected: "an integer as second argument",
@@ -486,7 +490,7 @@ pub(crate) fn op_chunks_exact(args: &[DataValue]) -> Result<DataValue> {
             message: "second argument to 'chunks_exact' must be positive"
         }
     );
-    let res = arg
+    let res = a
         .chunks_exact(n as usize)
         .map(|el| DataValue::List(el.to_vec()))
         .collect_vec();
@@ -494,14 +498,14 @@ pub(crate) fn op_chunks_exact(args: &[DataValue]) -> Result<DataValue> {
 }
 
 pub(crate) fn op_windows(args: &[DataValue]) -> Result<DataValue> {
-    let arg = args[0].get_slice().ok_or_else(|| {
+    let a = arg(args, 0)?.get_slice().ok_or_else(|| {
         TypeMismatchSnafu {
             op: "windows",
             expected: "a list as first argument",
         }
         .build()
     })?;
-    let n = args[1].get_int().ok_or_else(|| {
+    let n = arg(args, 1)?.get_int().ok_or_else(|| {
         TypeMismatchSnafu {
             op: "windows",
             expected: "an integer as second argument",
@@ -514,7 +518,7 @@ pub(crate) fn op_windows(args: &[DataValue]) -> Result<DataValue> {
             message: "second argument to 'windows' must be positive"
         }
     );
-    let res = arg
+    let res = a
         .windows(n as usize)
         .map(|el| DataValue::List(el.to_vec()))
         .collect_vec();
@@ -542,21 +546,21 @@ pub(crate) fn op_maybe_get(args: &[DataValue]) -> Result<DataValue> {
 }
 
 pub(crate) fn op_slice(args: &[DataValue]) -> Result<DataValue> {
-    let l = args[0].get_slice().ok_or_else(|| {
+    let l = arg(args, 0)?.get_slice().ok_or_else(|| {
         TypeMismatchSnafu {
             op: "slice",
             expected: "a list as first argument",
         }
         .build()
     })?;
-    let m = args[1].get_int().ok_or_else(|| {
+    let m = arg(args, 1)?.get_int().ok_or_else(|| {
         TypeMismatchSnafu {
             op: "slice",
             expected: "an integer as second argument",
         }
         .build()
     })?;
-    let n = args[2].get_int().ok_or_else(|| {
+    let n = arg(args, 2)?.get_int().ok_or_else(|| {
         TypeMismatchSnafu {
             op: "slice",
             expected: "an integer as third argument",
@@ -565,13 +569,17 @@ pub(crate) fn op_slice(args: &[DataValue]) -> Result<DataValue> {
     })?;
     let m = get_index(m, l.len(), false)?;
     let n = get_index(n, l.len(), true)?;
-    Ok(DataValue::List(l[m..n].to_vec()))
+    Ok(DataValue::List(
+        l.get(m..n)
+            .ok_or_else(|| IndexOutOfBoundsSnafu { index: n as i64 }.build())?
+            .to_vec(),
+    ))
 }
 
 pub(crate) fn op_int_range(args: &[DataValue]) -> Result<DataValue> {
     let [start, end] = match args.len() {
         1 => {
-            let end = args[0].get_int().ok_or_else(|| {
+            let end = arg(args, 0)?.get_int().ok_or_else(|| {
                 TypeMismatchSnafu {
                     op: "int_range",
                     expected: "an integer for end",
@@ -581,14 +589,14 @@ pub(crate) fn op_int_range(args: &[DataValue]) -> Result<DataValue> {
             [0, end]
         }
         2 => {
-            let start = args[0].get_int().ok_or_else(|| {
+            let start = arg(args, 0)?.get_int().ok_or_else(|| {
                 TypeMismatchSnafu {
                     op: "int_range",
                     expected: "an integer for start",
                 }
                 .build()
             })?;
-            let end = args[1].get_int().ok_or_else(|| {
+            let end = arg(args, 1)?.get_int().ok_or_else(|| {
                 TypeMismatchSnafu {
                     op: "int_range",
                     expected: "an integer for end",
@@ -598,21 +606,21 @@ pub(crate) fn op_int_range(args: &[DataValue]) -> Result<DataValue> {
             [start, end]
         }
         3 => {
-            let start = args[0].get_int().ok_or_else(|| {
+            let start = arg(args, 0)?.get_int().ok_or_else(|| {
                 TypeMismatchSnafu {
                     op: "int_range",
                     expected: "an integer for start",
                 }
                 .build()
             })?;
-            let end = args[1].get_int().ok_or_else(|| {
+            let end = arg(args, 1)?.get_int().ok_or_else(|| {
                 TypeMismatchSnafu {
                     op: "int_range",
                     expected: "an integer for end",
                 }
                 .build()
             })?;
-            let step = args[2].get_int().ok_or_else(|| {
+            let step = arg(args, 2)?.get_int().ok_or_else(|| {
                 TypeMismatchSnafu {
                     op: "int_range",
                     expected: "an integer for step",
@@ -646,7 +654,7 @@ pub(crate) fn op_int_range(args: &[DataValue]) -> Result<DataValue> {
 }
 
 pub(crate) fn op_assert(args: &[DataValue]) -> Result<DataValue> {
-    match &args[0] {
+    match arg(args, 0)? {
         DataValue::Bool(true) => Ok(DataValue::from(true)),
         _ => AssertionFailedSnafu {
             message: format!("{args:?}"),

--- a/crates/mneme/src/engine/data/functions/bits.rs
+++ b/crates/mneme/src/engine/data/functions/bits.rs
@@ -7,6 +7,7 @@ use std::ops::Div;
 
 use itertools::Itertools;
 
+use super::arg;
 use crate::engine::data::error::*;
 type Result<T> = DataResult<T>;
 use crate::engine::data::value::DataValue;
@@ -42,7 +43,7 @@ pub(crate) fn op_or(args: &[DataValue]) -> Result<DataValue> {
 }
 
 pub(crate) fn op_negate(args: &[DataValue]) -> Result<DataValue> {
-    if let DataValue::Bool(b) = &args[0] {
+    if let DataValue::Bool(b) = arg(args, 0)? {
         Ok(DataValue::from(!*b))
     } else {
         TypeMismatchSnafu {
@@ -54,7 +55,7 @@ pub(crate) fn op_negate(args: &[DataValue]) -> Result<DataValue> {
 }
 
 pub(crate) fn op_bit_and(args: &[DataValue]) -> Result<DataValue> {
-    match (&args[0], &args[1]) {
+    match (arg(args, 0)?, arg(args, 1)?) {
         (DataValue::Bytes(left), DataValue::Bytes(right)) => {
             snafu::ensure!(
                 left.len() == right.len(),
@@ -75,7 +76,7 @@ pub(crate) fn op_bit_and(args: &[DataValue]) -> Result<DataValue> {
 }
 
 pub(crate) fn op_bit_or(args: &[DataValue]) -> Result<DataValue> {
-    match (&args[0], &args[1]) {
+    match (arg(args, 0)?, arg(args, 1)?) {
         (DataValue::Bytes(left), DataValue::Bytes(right)) => {
             snafu::ensure!(
                 left.len() == right.len(),
@@ -96,7 +97,7 @@ pub(crate) fn op_bit_or(args: &[DataValue]) -> Result<DataValue> {
 }
 
 pub(crate) fn op_bit_not(args: &[DataValue]) -> Result<DataValue> {
-    match &args[0] {
+    match arg(args, 0)? {
         DataValue::Bytes(arg) => {
             let mut ret = arg.clone();
             for l in ret.iter_mut() {
@@ -113,7 +114,7 @@ pub(crate) fn op_bit_not(args: &[DataValue]) -> Result<DataValue> {
 }
 
 pub(crate) fn op_bit_xor(args: &[DataValue]) -> Result<DataValue> {
-    match (&args[0], &args[1]) {
+    match (arg(args, 0)?, arg(args, 1)?) {
         (DataValue::Bytes(left), DataValue::Bytes(right)) => {
             snafu::ensure!(
                 left.len() == right.len(),
@@ -134,7 +135,7 @@ pub(crate) fn op_bit_xor(args: &[DataValue]) -> Result<DataValue> {
 }
 
 pub(crate) fn op_unpack_bits(args: &[DataValue]) -> Result<DataValue> {
-    if let DataValue::Bytes(bs) = &args[0] {
+    if let DataValue::Bytes(bs) = arg(args, 0)? {
         let mut ret = vec![false; bs.len() * 8];
         for (chunk, byte) in bs.iter().enumerate() {
             ret[chunk * 8] = (*byte & 0b10000000) != 0;
@@ -159,7 +160,7 @@ pub(crate) fn op_unpack_bits(args: &[DataValue]) -> Result<DataValue> {
 }
 
 pub(crate) fn op_pack_bits(args: &[DataValue]) -> Result<DataValue> {
-    if let DataValue::List(v) = &args[0] {
+    if let DataValue::List(v) = arg(args, 0)? {
         let l = (v.len() as f64 / 8.).ceil() as usize;
         let mut res = vec![0u8; l];
         for (i, b) in v.iter().enumerate() {
@@ -194,7 +195,7 @@ pub(crate) fn op_pack_bits(args: &[DataValue]) -> Result<DataValue> {
             }
         }
         Ok(DataValue::Bytes(res))
-    } else if let DataValue::Set(v) = &args[0] {
+    } else if let DataValue::Set(v) = arg(args, 0)? {
         let l = v.iter().cloned().collect_vec();
         op_pack_bits(&[DataValue::List(l)])
     } else {

--- a/crates/mneme/src/engine/data/functions/math.rs
+++ b/crates/mneme/src/engine/data/functions/math.rs
@@ -5,6 +5,7 @@
 )]
 use std::ops::Rem;
 
+use super::arg;
 use crate::engine::data::error::*;
 type Result<T> = DataResult<T>;
 use crate::engine::data::value::{DataValue, Num, Vector};
@@ -34,7 +35,7 @@ pub(crate) fn ensure_same_value_type(a: &DataValue, b: &DataValue) -> Result<()>
 
 pub(crate) fn add_vecs(args: &[DataValue]) -> Result<DataValue> {
     if args.len() == 1 {
-        return Ok(args[0].clone());
+        return Ok(arg(args, 0)?.clone());
     }
     let (last, first) = args
         .split_last()
@@ -100,7 +101,7 @@ pub(crate) fn add_vecs(args: &[DataValue]) -> Result<DataValue> {
 
 pub(crate) fn mul_vecs(args: &[DataValue]) -> Result<DataValue> {
     if args.len() == 1 {
-        return Ok(args[0].clone());
+        return Ok(arg(args, 0)?.clone());
     }
     let (last, first) = args
         .split_last()
@@ -165,7 +166,7 @@ pub(crate) fn mul_vecs(args: &[DataValue]) -> Result<DataValue> {
 }
 
 pub(crate) fn op_eq(args: &[DataValue]) -> Result<DataValue> {
-    Ok(DataValue::from(match (&args[0], &args[1]) {
+    Ok(DataValue::from(match (arg(args, 0)?, arg(args, 1)?) {
         (DataValue::Num(Num::Float(f)), DataValue::Num(Num::Int(i)))
         | (DataValue::Num(Num::Int(i)), DataValue::Num(Num::Float(f))) => *i as f64 == *f,
         (a, b) => a == b,
@@ -173,7 +174,7 @@ pub(crate) fn op_eq(args: &[DataValue]) -> Result<DataValue> {
 }
 
 pub(crate) fn op_neq(args: &[DataValue]) -> Result<DataValue> {
-    Ok(DataValue::from(match (&args[0], &args[1]) {
+    Ok(DataValue::from(match (arg(args, 0)?, arg(args, 1)?) {
         (DataValue::Num(Num::Float(f)), DataValue::Num(Num::Int(i)))
         | (DataValue::Num(Num::Int(i)), DataValue::Num(Num::Float(f))) => *i as f64 != *f,
         (a, b) => a != b,
@@ -181,8 +182,8 @@ pub(crate) fn op_neq(args: &[DataValue]) -> Result<DataValue> {
 }
 
 pub(crate) fn op_gt(args: &[DataValue]) -> Result<DataValue> {
-    ensure_same_value_type(&args[0], &args[1])?;
-    Ok(DataValue::from(match (&args[0], &args[1]) {
+    ensure_same_value_type(arg(args, 0)?, arg(args, 1)?)?;
+    Ok(DataValue::from(match (arg(args, 0)?, arg(args, 1)?) {
         (DataValue::Num(Num::Float(l)), DataValue::Num(Num::Int(r))) => *l > *r as f64,
         (DataValue::Num(Num::Int(l)), DataValue::Num(Num::Float(r))) => *l as f64 > *r,
         (a, b) => a > b,
@@ -190,8 +191,8 @@ pub(crate) fn op_gt(args: &[DataValue]) -> Result<DataValue> {
 }
 
 pub(crate) fn op_ge(args: &[DataValue]) -> Result<DataValue> {
-    ensure_same_value_type(&args[0], &args[1])?;
-    Ok(DataValue::from(match (&args[0], &args[1]) {
+    ensure_same_value_type(arg(args, 0)?, arg(args, 1)?)?;
+    Ok(DataValue::from(match (arg(args, 0)?, arg(args, 1)?) {
         (DataValue::Num(Num::Float(l)), DataValue::Num(Num::Int(r))) => *l >= *r as f64,
         (DataValue::Num(Num::Int(l)), DataValue::Num(Num::Float(r))) => *l as f64 >= *r,
         (a, b) => a >= b,
@@ -199,8 +200,8 @@ pub(crate) fn op_ge(args: &[DataValue]) -> Result<DataValue> {
 }
 
 pub(crate) fn op_lt(args: &[DataValue]) -> Result<DataValue> {
-    ensure_same_value_type(&args[0], &args[1])?;
-    Ok(DataValue::from(match (&args[0], &args[1]) {
+    ensure_same_value_type(arg(args, 0)?, arg(args, 1)?)?;
+    Ok(DataValue::from(match (arg(args, 0)?, arg(args, 1)?) {
         (DataValue::Num(Num::Float(l)), DataValue::Num(Num::Int(r))) => *l < (*r as f64),
         (DataValue::Num(Num::Int(l)), DataValue::Num(Num::Float(r))) => (*l as f64) < *r,
         (a, b) => a < b,
@@ -208,8 +209,8 @@ pub(crate) fn op_lt(args: &[DataValue]) -> Result<DataValue> {
 }
 
 pub(crate) fn op_le(args: &[DataValue]) -> Result<DataValue> {
-    ensure_same_value_type(&args[0], &args[1])?;
-    Ok(DataValue::from(match (&args[0], &args[1]) {
+    ensure_same_value_type(arg(args, 0)?, arg(args, 1)?)?;
+    Ok(DataValue::from(match (arg(args, 0)?, arg(args, 1)?) {
         (DataValue::Num(Num::Float(l)), DataValue::Num(Num::Int(r))) => *l <= (*r as f64),
         (DataValue::Num(Num::Int(l)), DataValue::Num(Num::Float(r))) => (*l as f64) <= *r,
         (a, b) => a <= b,
@@ -277,7 +278,7 @@ pub(crate) fn op_min(args: &[DataValue]) -> Result<DataValue> {
 }
 
 pub(crate) fn op_sub(args: &[DataValue]) -> Result<DataValue> {
-    Ok(match (&args[0], &args[1]) {
+    Ok(match (arg(args, 0)?, arg(args, 1)?) {
         (DataValue::Num(Num::Int(a)), DataValue::Num(Num::Int(b))) => {
             DataValue::Num(Num::Int(*a - *b))
         }
@@ -375,7 +376,7 @@ pub(crate) fn op_mul(args: &[DataValue]) -> Result<DataValue> {
 }
 
 pub(crate) fn op_div(args: &[DataValue]) -> Result<DataValue> {
-    Ok(match (&args[0], &args[1]) {
+    Ok(match (arg(args, 0)?, arg(args, 1)?) {
         (DataValue::Num(Num::Int(a)), DataValue::Num(Num::Int(b))) => {
             DataValue::Num(Num::Float((*a as f64) / (*b as f64)))
         }
@@ -443,7 +444,7 @@ pub(crate) fn op_div(args: &[DataValue]) -> Result<DataValue> {
 }
 
 pub(crate) fn op_minus(args: &[DataValue]) -> Result<DataValue> {
-    Ok(match &args[0] {
+    Ok(match arg(args, 0)? {
         DataValue::Num(Num::Int(i)) => DataValue::Num(Num::Int(-(*i))),
         DataValue::Num(Num::Float(f)) => DataValue::Num(Num::Float(-(*f))),
         DataValue::Vec(Vector::F64(v)) => DataValue::Vec(Vector::F64(0. - v)),
@@ -459,7 +460,7 @@ pub(crate) fn op_minus(args: &[DataValue]) -> Result<DataValue> {
 }
 
 pub(crate) fn op_abs(args: &[DataValue]) -> Result<DataValue> {
-    Ok(match &args[0] {
+    Ok(match arg(args, 0)? {
         DataValue::Num(Num::Int(i)) => DataValue::Num(Num::Int(i.abs())),
         DataValue::Num(Num::Float(f)) => DataValue::Num(Num::Float(f.abs())),
         DataValue::Vec(Vector::F64(v)) => DataValue::Vec(Vector::F64(v.mapv(|x| x.abs()))),
@@ -475,7 +476,7 @@ pub(crate) fn op_abs(args: &[DataValue]) -> Result<DataValue> {
 }
 
 pub(crate) fn op_signum(args: &[DataValue]) -> Result<DataValue> {
-    Ok(match &args[0] {
+    Ok(match arg(args, 0)? {
         DataValue::Num(Num::Int(i)) => DataValue::Num(Num::Int(i.signum())),
         DataValue::Num(Num::Float(f)) => {
             if f.signum() < 0. {
@@ -499,7 +500,7 @@ pub(crate) fn op_signum(args: &[DataValue]) -> Result<DataValue> {
 }
 
 pub(crate) fn op_floor(args: &[DataValue]) -> Result<DataValue> {
-    Ok(match &args[0] {
+    Ok(match arg(args, 0)? {
         DataValue::Num(Num::Int(i)) => DataValue::Num(Num::Int(*i)),
         DataValue::Num(Num::Float(f)) => DataValue::Num(Num::Float(f.floor())),
         _ => {
@@ -513,7 +514,7 @@ pub(crate) fn op_floor(args: &[DataValue]) -> Result<DataValue> {
 }
 
 pub(crate) fn op_ceil(args: &[DataValue]) -> Result<DataValue> {
-    Ok(match &args[0] {
+    Ok(match arg(args, 0)? {
         DataValue::Num(Num::Int(i)) => DataValue::Num(Num::Int(*i)),
         DataValue::Num(Num::Float(f)) => DataValue::Num(Num::Float(f.ceil())),
         _ => {
@@ -527,7 +528,7 @@ pub(crate) fn op_ceil(args: &[DataValue]) -> Result<DataValue> {
 }
 
 pub(crate) fn op_round(args: &[DataValue]) -> Result<DataValue> {
-    Ok(match &args[0] {
+    Ok(match arg(args, 0)? {
         DataValue::Num(Num::Int(i)) => DataValue::Num(Num::Int(*i)),
         DataValue::Num(Num::Float(f)) => DataValue::Num(Num::Float(f.round())),
         _ => {
@@ -541,7 +542,7 @@ pub(crate) fn op_round(args: &[DataValue]) -> Result<DataValue> {
 }
 
 pub(crate) fn op_sqrt(args: &[DataValue]) -> Result<DataValue> {
-    let a = match &args[0] {
+    let a = match arg(args, 0)? {
         DataValue::Num(Num::Int(i)) => *i as f64,
         DataValue::Num(Num::Float(f)) => *f,
         DataValue::Vec(Vector::F32(v)) => {
@@ -562,7 +563,7 @@ pub(crate) fn op_sqrt(args: &[DataValue]) -> Result<DataValue> {
 }
 
 pub(crate) fn op_exp(args: &[DataValue]) -> Result<DataValue> {
-    let a = match &args[0] {
+    let a = match arg(args, 0)? {
         DataValue::Num(Num::Int(i)) => *i as f64,
         DataValue::Num(Num::Float(f)) => *f,
         DataValue::Vec(Vector::F32(v)) => {
@@ -583,7 +584,7 @@ pub(crate) fn op_exp(args: &[DataValue]) -> Result<DataValue> {
 }
 
 pub(crate) fn op_exp2(args: &[DataValue]) -> Result<DataValue> {
-    let a = match &args[0] {
+    let a = match arg(args, 0)? {
         DataValue::Num(Num::Int(i)) => *i as f64,
         DataValue::Num(Num::Float(f)) => *f,
         DataValue::Vec(Vector::F32(v)) => {
@@ -604,7 +605,7 @@ pub(crate) fn op_exp2(args: &[DataValue]) -> Result<DataValue> {
 }
 
 pub(crate) fn op_ln(args: &[DataValue]) -> Result<DataValue> {
-    let a = match &args[0] {
+    let a = match arg(args, 0)? {
         DataValue::Num(Num::Int(i)) => *i as f64,
         DataValue::Num(Num::Float(f)) => *f,
         DataValue::Vec(Vector::F32(v)) => {
@@ -625,7 +626,7 @@ pub(crate) fn op_ln(args: &[DataValue]) -> Result<DataValue> {
 }
 
 pub(crate) fn op_log2(args: &[DataValue]) -> Result<DataValue> {
-    let a = match &args[0] {
+    let a = match arg(args, 0)? {
         DataValue::Num(Num::Int(i)) => *i as f64,
         DataValue::Num(Num::Float(f)) => *f,
         DataValue::Vec(Vector::F32(v)) => {
@@ -646,7 +647,7 @@ pub(crate) fn op_log2(args: &[DataValue]) -> Result<DataValue> {
 }
 
 pub(crate) fn op_log10(args: &[DataValue]) -> Result<DataValue> {
-    let a = match &args[0] {
+    let a = match arg(args, 0)? {
         DataValue::Num(Num::Int(i)) => *i as f64,
         DataValue::Num(Num::Float(f)) => *f,
         DataValue::Vec(Vector::F32(v)) => {
@@ -667,11 +668,11 @@ pub(crate) fn op_log10(args: &[DataValue]) -> Result<DataValue> {
 }
 
 pub(crate) fn op_pow(args: &[DataValue]) -> Result<DataValue> {
-    let a = match &args[0] {
+    let a = match arg(args, 0)? {
         DataValue::Num(Num::Int(i)) => *i as f64,
         DataValue::Num(Num::Float(f)) => *f,
         DataValue::Vec(Vector::F32(v)) => {
-            let b = args[1].get_float().ok_or_else(|| {
+            let b = arg(args, 1)?.get_float().ok_or_else(|| {
                 TypeMismatchSnafu {
                     op: "pow",
                     expected: "numbers",
@@ -681,7 +682,7 @@ pub(crate) fn op_pow(args: &[DataValue]) -> Result<DataValue> {
             return Ok(DataValue::Vec(Vector::F32(v.mapv(|x| x.powf(b as f32)))));
         }
         DataValue::Vec(Vector::F64(v)) => {
-            let b = args[1].get_float().ok_or_else(|| {
+            let b = arg(args, 1)?.get_float().ok_or_else(|| {
                 TypeMismatchSnafu {
                     op: "pow",
                     expected: "numbers",
@@ -698,7 +699,7 @@ pub(crate) fn op_pow(args: &[DataValue]) -> Result<DataValue> {
             .fail();
         }
     };
-    let b = match &args[1] {
+    let b = match arg(args, 1)? {
         DataValue::Num(Num::Int(i)) => *i as f64,
         DataValue::Num(Num::Float(f)) => *f,
         _ => {
@@ -713,7 +714,7 @@ pub(crate) fn op_pow(args: &[DataValue]) -> Result<DataValue> {
 }
 
 pub(crate) fn op_mod(args: &[DataValue]) -> Result<DataValue> {
-    Ok(match (&args[0], &args[1]) {
+    Ok(match (arg(args, 0)?, arg(args, 1)?) {
         (DataValue::Num(Num::Int(a)), DataValue::Num(Num::Int(b))) => {
             if *b == 0 {
                 return TypeMismatchSnafu {
@@ -744,8 +745,8 @@ pub(crate) fn op_mod(args: &[DataValue]) -> Result<DataValue> {
 }
 
 pub(crate) fn op_is_in(args: &[DataValue]) -> Result<DataValue> {
-    let left = &args[0];
-    let right = args[1].get_slice().ok_or_else(|| {
+    let left = arg(args, 0)?;
+    let right = arg(args, 1)?.get_slice().ok_or_else(|| {
         TypeMismatchSnafu {
             op: "is_in",
             expected: "a list as right hand side",

--- a/crates/mneme/src/engine/data/functions/mod.rs
+++ b/crates/mneme/src/engine/data/functions/mod.rs
@@ -15,6 +15,21 @@ mod trig;
 mod utility;
 mod vector;
 
+/// Bounds-checked argument access for engine built-in functions.
+///
+/// The engine validates arity before calling functions (see `min_arity` in
+/// `Op`), so out-of-bounds access indicates an internal engine bug rather than
+/// user error. Returns a typed error instead of panicking.
+pub(crate) fn arg(args: &[DataValue], idx: usize) -> Result<&DataValue> {
+    args.get(idx).ok_or_else(|| {
+        TypeMismatchSnafu {
+            op: "builtin",
+            expected: format!("at least {} argument(s)", idx + 1),
+        }
+        .build()
+    })
+}
+
 pub(crate) use aggregate::*;
 pub(crate) use bits::*;
 pub(crate) use math::*;
@@ -195,5 +210,5 @@ define_op!(OP_COS_DIST, op_cos_dist, 2, false);
 define_op!(OP_T2S, op_t2s, 1, false);
 fn op_t2s(args: &[DataValue]) -> Result<DataValue> {
     // fast2s crate removed; pass through unchanged
-    Ok(args[0].clone())
+    Ok(arg(args, 0)?.clone())
 }

--- a/crates/mneme/src/engine/data/functions/string.rs
+++ b/crates/mneme/src/engine/data/functions/string.rs
@@ -6,12 +6,13 @@ use itertools::Itertools;
 use snafu::ResultExt;
 use unicode_normalization::UnicodeNormalization;
 
+use super::arg;
 use crate::engine::data::error::*;
 type Result<T> = DataResult<T>;
 use crate::engine::data::value::{DataValue, RegexWrapper};
 
 pub(crate) fn op_str_includes(args: &[DataValue]) -> Result<DataValue> {
-    match (&args[0], &args[1]) {
+    match (arg(args, 0)?, arg(args, 1)?) {
         (DataValue::Str(l), DataValue::Str(r)) => Ok(DataValue::from(l.find(r as &str).is_some())),
         _ => TypeMismatchSnafu {
             op: "str_includes",
@@ -22,7 +23,7 @@ pub(crate) fn op_str_includes(args: &[DataValue]) -> Result<DataValue> {
 }
 
 pub(crate) fn op_lowercase(args: &[DataValue]) -> Result<DataValue> {
-    match &args[0] {
+    match arg(args, 0)? {
         DataValue::Str(s) => Ok(DataValue::from(s.to_lowercase())),
         _ => TypeMismatchSnafu {
             op: "lowercase",
@@ -33,7 +34,7 @@ pub(crate) fn op_lowercase(args: &[DataValue]) -> Result<DataValue> {
 }
 
 pub(crate) fn op_uppercase(args: &[DataValue]) -> Result<DataValue> {
-    match &args[0] {
+    match arg(args, 0)? {
         DataValue::Str(s) => Ok(DataValue::from(s.to_uppercase())),
         _ => TypeMismatchSnafu {
             op: "uppercase",
@@ -44,7 +45,7 @@ pub(crate) fn op_uppercase(args: &[DataValue]) -> Result<DataValue> {
 }
 
 pub(crate) fn op_trim(args: &[DataValue]) -> Result<DataValue> {
-    match &args[0] {
+    match arg(args, 0)? {
         DataValue::Str(s) => Ok(DataValue::from(s.trim())),
         _ => TypeMismatchSnafu {
             op: "trim",
@@ -55,7 +56,7 @@ pub(crate) fn op_trim(args: &[DataValue]) -> Result<DataValue> {
 }
 
 pub(crate) fn op_trim_start(args: &[DataValue]) -> Result<DataValue> {
-    match &args[0] {
+    match arg(args, 0)? {
         DataValue::Str(s) => Ok(DataValue::from(s.trim_start())),
         v => TypeMismatchSnafu {
             op: "trim_start",
@@ -66,7 +67,7 @@ pub(crate) fn op_trim_start(args: &[DataValue]) -> Result<DataValue> {
 }
 
 pub(crate) fn op_trim_end(args: &[DataValue]) -> Result<DataValue> {
-    match &args[0] {
+    match arg(args, 0)? {
         DataValue::Str(s) => Ok(DataValue::from(s.trim_end())),
         _ => TypeMismatchSnafu {
             op: "trim_end",
@@ -77,7 +78,7 @@ pub(crate) fn op_trim_end(args: &[DataValue]) -> Result<DataValue> {
 }
 
 pub(crate) fn op_starts_with(args: &[DataValue]) -> Result<DataValue> {
-    match (&args[0], &args[1]) {
+    match (arg(args, 0)?, arg(args, 1)?) {
         (DataValue::Str(l), DataValue::Str(r)) => Ok(DataValue::from(l.starts_with(r as &str))),
         (DataValue::Bytes(l), DataValue::Bytes(r)) => {
             Ok(DataValue::from(l.starts_with(r as &[u8])))
@@ -91,7 +92,7 @@ pub(crate) fn op_starts_with(args: &[DataValue]) -> Result<DataValue> {
 }
 
 pub(crate) fn op_ends_with(args: &[DataValue]) -> Result<DataValue> {
-    match (&args[0], &args[1]) {
+    match (arg(args, 0)?, arg(args, 1)?) {
         (DataValue::Str(l), DataValue::Str(r)) => Ok(DataValue::from(l.ends_with(r as &str))),
         (DataValue::Bytes(l), DataValue::Bytes(r)) => Ok(DataValue::from(l.ends_with(r as &[u8]))),
         _ => TypeMismatchSnafu {
@@ -103,7 +104,7 @@ pub(crate) fn op_ends_with(args: &[DataValue]) -> Result<DataValue> {
 }
 
 pub(crate) fn op_regex(args: &[DataValue]) -> Result<DataValue> {
-    Ok(match &args[0] {
+    Ok(match arg(args, 0)? {
         r @ DataValue::Regex(_) => r.clone(),
         DataValue::Str(s) => DataValue::Regex(RegexWrapper(
             regex::Regex::new(s).context(InvalidRegexSnafu)?,
@@ -119,7 +120,7 @@ pub(crate) fn op_regex(args: &[DataValue]) -> Result<DataValue> {
 }
 
 pub(crate) fn op_regex_matches(args: &[DataValue]) -> Result<DataValue> {
-    match (&args[0], &args[1]) {
+    match (arg(args, 0)?, arg(args, 1)?) {
         (DataValue::Str(s), DataValue::Regex(r)) => Ok(DataValue::from(r.0.is_match(s))),
         _ => TypeMismatchSnafu {
             op: "regex_matches",
@@ -130,7 +131,7 @@ pub(crate) fn op_regex_matches(args: &[DataValue]) -> Result<DataValue> {
 }
 
 pub(crate) fn op_regex_replace(args: &[DataValue]) -> Result<DataValue> {
-    match (&args[0], &args[1], &args[2]) {
+    match (arg(args, 0)?, arg(args, 1)?, arg(args, 2)?) {
         (DataValue::Str(s), DataValue::Regex(r), DataValue::Str(rp)) => {
             Ok(DataValue::Str(r.0.replace(s, rp as &str).into()))
         }
@@ -143,7 +144,7 @@ pub(crate) fn op_regex_replace(args: &[DataValue]) -> Result<DataValue> {
 }
 
 pub(crate) fn op_regex_replace_all(args: &[DataValue]) -> Result<DataValue> {
-    match (&args[0], &args[1], &args[2]) {
+    match (arg(args, 0)?, arg(args, 1)?, arg(args, 2)?) {
         (DataValue::Str(s), DataValue::Regex(r), DataValue::Str(rp)) => {
             Ok(DataValue::Str(r.0.replace_all(s, rp as &str).into()))
         }
@@ -156,7 +157,7 @@ pub(crate) fn op_regex_replace_all(args: &[DataValue]) -> Result<DataValue> {
 }
 
 pub(crate) fn op_regex_extract(args: &[DataValue]) -> Result<DataValue> {
-    match (&args[0], &args[1]) {
+    match (arg(args, 0)?, arg(args, 1)?) {
         (DataValue::Str(s), DataValue::Regex(r)) => {
             let found =
                 r.0.find_iter(s)
@@ -173,7 +174,7 @@ pub(crate) fn op_regex_extract(args: &[DataValue]) -> Result<DataValue> {
 }
 
 pub(crate) fn op_regex_extract_first(args: &[DataValue]) -> Result<DataValue> {
-    match (&args[0], &args[1]) {
+    match (arg(args, 0)?, arg(args, 1)?) {
         (DataValue::Str(s), DataValue::Regex(r)) => {
             let found = r.0.find(s).map(|v| DataValue::from(v.as_str()));
             Ok(found.unwrap_or(DataValue::Null))
@@ -187,7 +188,7 @@ pub(crate) fn op_regex_extract_first(args: &[DataValue]) -> Result<DataValue> {
 }
 
 pub(crate) fn op_unicode_normalize(args: &[DataValue]) -> Result<DataValue> {
-    match (&args[0], &args[1]) {
+    match (arg(args, 0)?, arg(args, 1)?) {
         (DataValue::Str(s), DataValue::Str(n)) => Ok(DataValue::Str(match n as &str {
             "nfc" => s.nfc().collect(),
             "nfd" => s.nfd().collect(),
@@ -209,7 +210,7 @@ pub(crate) fn op_unicode_normalize(args: &[DataValue]) -> Result<DataValue> {
 }
 
 pub(crate) fn op_encode_base64(args: &[DataValue]) -> Result<DataValue> {
-    match &args[0] {
+    match arg(args, 0)? {
         DataValue::Bytes(b) => {
             let s = STANDARD.encode(b);
             Ok(DataValue::from(s))
@@ -224,7 +225,7 @@ pub(crate) fn op_encode_base64(args: &[DataValue]) -> Result<DataValue> {
 
 #[expect(clippy::map_err_ignore, reason = "error context preserved in message")]
 pub(crate) fn op_decode_base64(args: &[DataValue]) -> Result<DataValue> {
-    match &args[0] {
+    match arg(args, 0)? {
         DataValue::Str(s) => {
             let b = STANDARD.decode(s).map_err(|_| {
                 EncodingFailedSnafu {
@@ -244,7 +245,7 @@ pub(crate) fn op_decode_base64(args: &[DataValue]) -> Result<DataValue> {
 
 pub(crate) fn op_chars(args: &[DataValue]) -> Result<DataValue> {
     Ok(DataValue::List(
-        args[0]
+        arg(args, 0)?
             .get_str()
             .ok_or_else(|| {
                 TypeMismatchSnafu {
@@ -264,14 +265,14 @@ pub(crate) fn op_chars(args: &[DataValue]) -> Result<DataValue> {
 }
 
 pub(crate) fn op_slice_string(args: &[DataValue]) -> Result<DataValue> {
-    let s = args[0].get_str().ok_or_else(|| {
+    let s = arg(args, 0)?.get_str().ok_or_else(|| {
         TypeMismatchSnafu {
             op: "slice_string",
             expected: "a string as first argument",
         }
         .build()
     })?;
-    let m = args[1].get_int().ok_or_else(|| {
+    let m = arg(args, 1)?.get_int().ok_or_else(|| {
         TypeMismatchSnafu {
             op: "slice_string",
             expected: "an integer as second argument",
@@ -284,7 +285,7 @@ pub(crate) fn op_slice_string(args: &[DataValue]) -> Result<DataValue> {
             message: "second argument to 'slice_string' mut be a positive integer"
         }
     );
-    let n = args[2].get_int().ok_or_else(|| {
+    let n = arg(args, 2)?.get_int().ok_or_else(|| {
         TypeMismatchSnafu {
             op: "slice_string",
             expected: "an integer as third argument",
@@ -304,7 +305,7 @@ pub(crate) fn op_slice_string(args: &[DataValue]) -> Result<DataValue> {
 
 pub(crate) fn op_from_substrings(args: &[DataValue]) -> Result<DataValue> {
     let mut ret = String::new();
-    match &args[0] {
+    match arg(args, 0)? {
         DataValue::List(ss) => {
             for arg in ss {
                 if let DataValue::Str(s) = arg {

--- a/crates/mneme/src/engine/data/functions/temporal.rs
+++ b/crates/mneme/src/engine/data/functions/temporal.rs
@@ -13,6 +13,7 @@ use js_sys::Date;
 use rand::prelude::*;
 use uuid::v1::Timestamp;
 
+use super::arg;
 use crate::engine::data::error::*;
 type Result<T> = DataResult<T>;
 use crate::engine::data::value::{DataValue, UuidWrapper, Validity, ValidityTs};
@@ -66,7 +67,7 @@ pub(crate) fn op_now(_args: &[DataValue]) -> Result<DataValue> {
 
 #[expect(clippy::map_err_ignore, reason = "error context preserved in message")]
 pub(crate) fn op_format_timestamp(args: &[DataValue]) -> Result<DataValue> {
-    let millis = match &args[0] {
+    let millis = match arg(args, 0)? {
         DataValue::Validity(vld) => vld.timestamp.0.0 / 1000,
         v => {
             let f = v.get_float().ok_or_else(|| {
@@ -79,9 +80,10 @@ pub(crate) fn op_format_timestamp(args: &[DataValue]) -> Result<DataValue> {
             (f * 1000.) as i64
         }
     };
+    let raw_arg = arg(args, 0)?;
     let ts = jiff::Timestamp::from_millisecond(millis).map_err(|_| {
         BadTimeSnafu {
-            message: format!("bad time: {}", &args[0]),
+            message: format!("bad time: {raw_arg}"),
         }
         .build()
     })?;
@@ -113,7 +115,7 @@ pub(crate) fn op_format_timestamp(args: &[DataValue]) -> Result<DataValue> {
 
 #[expect(clippy::map_err_ignore, reason = "error context preserved in message")]
 pub(crate) fn op_parse_timestamp(args: &[DataValue]) -> Result<DataValue> {
-    let s = args[0].get_str().ok_or_else(|| {
+    let s = arg(args, 0)?.get_str().ok_or_else(|| {
         TypeMismatchSnafu {
             op: "parse_timestamp",
             expected: "a string",
@@ -161,7 +163,7 @@ pub(crate) fn op_rand_uuid_v4(_args: &[DataValue]) -> Result<DataValue> {
 }
 
 pub(crate) fn op_uuid_timestamp(args: &[DataValue]) -> Result<DataValue> {
-    Ok(match &args[0] {
+    Ok(match arg(args, 0)? {
         DataValue::Uuid(UuidWrapper(id)) => match id.get_timestamp() {
             None => DataValue::Null,
             Some(t) => {
@@ -185,7 +187,7 @@ pub(crate) fn op_rand_float(_args: &[DataValue]) -> Result<DataValue> {
 }
 
 pub(crate) fn op_rand_bernoulli(args: &[DataValue]) -> Result<DataValue> {
-    let prob = match &args[0] {
+    let prob = match arg(args, 0)? {
         DataValue::Num(n) => {
             let f = n.get_float();
             snafu::ensure!(
@@ -208,14 +210,14 @@ pub(crate) fn op_rand_bernoulli(args: &[DataValue]) -> Result<DataValue> {
 }
 
 pub(crate) fn op_rand_int(args: &[DataValue]) -> Result<DataValue> {
-    let lower = &args[0].get_int().ok_or_else(|| {
+    let lower = &arg(args, 0)?.get_int().ok_or_else(|| {
         TypeMismatchSnafu {
             op: "rand_int",
             expected: "integers",
         }
         .build()
     })?;
-    let upper = &args[1].get_int().ok_or_else(|| {
+    let upper = &arg(args, 1)?.get_int().ok_or_else(|| {
         TypeMismatchSnafu {
             op: "rand_int",
             expected: "integers",
@@ -226,7 +228,7 @@ pub(crate) fn op_rand_int(args: &[DataValue]) -> Result<DataValue> {
 }
 
 pub(crate) fn op_rand_choose(args: &[DataValue]) -> Result<DataValue> {
-    match &args[0] {
+    match arg(args, 0)? {
         DataValue::List(l) => Ok(l
             .choose(&mut rand::rng())
             .cloned()
@@ -247,7 +249,7 @@ pub(crate) fn op_rand_choose(args: &[DataValue]) -> Result<DataValue> {
 }
 
 pub(crate) fn op_validity(args: &[DataValue]) -> Result<DataValue> {
-    let ts = args[0].get_int().ok_or_else(|| {
+    let ts = arg(args, 0)?.get_int().ok_or_else(|| {
         TypeMismatchSnafu {
             op: "validity",
             expected: "an integer",
@@ -257,7 +259,7 @@ pub(crate) fn op_validity(args: &[DataValue]) -> Result<DataValue> {
     let is_assert = if args.len() == 1 {
         true
     } else {
-        args[1].get_bool().ok_or_else(|| {
+        arg(args, 1)?.get_bool().ok_or_else(|| {
             TypeMismatchSnafu {
                 op: "validity",
                 expected: "a boolean as second argument",

--- a/crates/mneme/src/engine/data/functions/trig.rs
+++ b/crates/mneme/src/engine/data/functions/trig.rs
@@ -1,10 +1,11 @@
 //! Trigonometric, hyperbolic, and geographic functions.
 use crate::engine::data::error::*;
 type Result<T> = DataResult<T>;
+use super::arg;
 use crate::engine::data::value::{DataValue, Num, Vector};
 
 pub(crate) fn op_sin(args: &[DataValue]) -> Result<DataValue> {
-    let a = match &args[0] {
+    let a = match arg(args, 0)? {
         DataValue::Num(Num::Int(i)) => *i as f64,
         DataValue::Num(Num::Float(f)) => *f,
         DataValue::Vec(Vector::F32(v)) => {
@@ -25,7 +26,7 @@ pub(crate) fn op_sin(args: &[DataValue]) -> Result<DataValue> {
 }
 
 pub(crate) fn op_cos(args: &[DataValue]) -> Result<DataValue> {
-    let a = match &args[0] {
+    let a = match arg(args, 0)? {
         DataValue::Num(Num::Int(i)) => *i as f64,
         DataValue::Num(Num::Float(f)) => *f,
         DataValue::Vec(Vector::F32(v)) => {
@@ -46,7 +47,7 @@ pub(crate) fn op_cos(args: &[DataValue]) -> Result<DataValue> {
 }
 
 pub(crate) fn op_tan(args: &[DataValue]) -> Result<DataValue> {
-    let a = match &args[0] {
+    let a = match arg(args, 0)? {
         DataValue::Num(Num::Int(i)) => *i as f64,
         DataValue::Num(Num::Float(f)) => *f,
         DataValue::Vec(Vector::F32(v)) => {
@@ -67,7 +68,7 @@ pub(crate) fn op_tan(args: &[DataValue]) -> Result<DataValue> {
 }
 
 pub(crate) fn op_asin(args: &[DataValue]) -> Result<DataValue> {
-    let a = match &args[0] {
+    let a = match arg(args, 0)? {
         DataValue::Num(Num::Int(i)) => *i as f64,
         DataValue::Num(Num::Float(f)) => *f,
         DataValue::Vec(Vector::F32(v)) => {
@@ -88,7 +89,7 @@ pub(crate) fn op_asin(args: &[DataValue]) -> Result<DataValue> {
 }
 
 pub(crate) fn op_acos(args: &[DataValue]) -> Result<DataValue> {
-    let a = match &args[0] {
+    let a = match arg(args, 0)? {
         DataValue::Num(Num::Int(i)) => *i as f64,
         DataValue::Num(Num::Float(f)) => *f,
         DataValue::Vec(Vector::F32(v)) => {
@@ -109,7 +110,7 @@ pub(crate) fn op_acos(args: &[DataValue]) -> Result<DataValue> {
 }
 
 pub(crate) fn op_atan(args: &[DataValue]) -> Result<DataValue> {
-    let a = match &args[0] {
+    let a = match arg(args, 0)? {
         DataValue::Num(Num::Int(i)) => *i as f64,
         DataValue::Num(Num::Float(f)) => *f,
         DataValue::Vec(Vector::F32(v)) => {
@@ -130,7 +131,7 @@ pub(crate) fn op_atan(args: &[DataValue]) -> Result<DataValue> {
 }
 
 pub(crate) fn op_atan2(args: &[DataValue]) -> Result<DataValue> {
-    let a = match &args[0] {
+    let a = match arg(args, 0)? {
         DataValue::Num(Num::Int(i)) => *i as f64,
         DataValue::Num(Num::Float(f)) => *f,
         _ => {
@@ -141,7 +142,7 @@ pub(crate) fn op_atan2(args: &[DataValue]) -> Result<DataValue> {
             .fail();
         }
     };
-    let b = match &args[1] {
+    let b = match arg(args, 1)? {
         DataValue::Num(Num::Int(i)) => *i as f64,
         DataValue::Num(Num::Float(f)) => *f,
         _ => {
@@ -157,7 +158,7 @@ pub(crate) fn op_atan2(args: &[DataValue]) -> Result<DataValue> {
 }
 
 pub(crate) fn op_sinh(args: &[DataValue]) -> Result<DataValue> {
-    let a = match &args[0] {
+    let a = match arg(args, 0)? {
         DataValue::Num(Num::Int(i)) => *i as f64,
         DataValue::Num(Num::Float(f)) => *f,
         DataValue::Vec(Vector::F32(v)) => {
@@ -178,7 +179,7 @@ pub(crate) fn op_sinh(args: &[DataValue]) -> Result<DataValue> {
 }
 
 pub(crate) fn op_cosh(args: &[DataValue]) -> Result<DataValue> {
-    let a = match &args[0] {
+    let a = match arg(args, 0)? {
         DataValue::Num(Num::Int(i)) => *i as f64,
         DataValue::Num(Num::Float(f)) => *f,
         DataValue::Vec(Vector::F32(v)) => {
@@ -199,7 +200,7 @@ pub(crate) fn op_cosh(args: &[DataValue]) -> Result<DataValue> {
 }
 
 pub(crate) fn op_tanh(args: &[DataValue]) -> Result<DataValue> {
-    let a = match &args[0] {
+    let a = match arg(args, 0)? {
         DataValue::Num(Num::Int(i)) => *i as f64,
         DataValue::Num(Num::Float(f)) => *f,
         DataValue::Vec(Vector::F32(v)) => {
@@ -220,7 +221,7 @@ pub(crate) fn op_tanh(args: &[DataValue]) -> Result<DataValue> {
 }
 
 pub(crate) fn op_asinh(args: &[DataValue]) -> Result<DataValue> {
-    let a = match &args[0] {
+    let a = match arg(args, 0)? {
         DataValue::Num(Num::Int(i)) => *i as f64,
         DataValue::Num(Num::Float(f)) => *f,
         DataValue::Vec(Vector::F32(v)) => {
@@ -241,7 +242,7 @@ pub(crate) fn op_asinh(args: &[DataValue]) -> Result<DataValue> {
 }
 
 pub(crate) fn op_acosh(args: &[DataValue]) -> Result<DataValue> {
-    let a = match &args[0] {
+    let a = match arg(args, 0)? {
         DataValue::Num(Num::Int(i)) => *i as f64,
         DataValue::Num(Num::Float(f)) => *f,
         DataValue::Vec(Vector::F32(v)) => {
@@ -262,7 +263,7 @@ pub(crate) fn op_acosh(args: &[DataValue]) -> Result<DataValue> {
 }
 
 pub(crate) fn op_atanh(args: &[DataValue]) -> Result<DataValue> {
-    let a = match &args[0] {
+    let a = match arg(args, 0)? {
         DataValue::Num(Num::Int(i)) => *i as f64,
         DataValue::Num(Num::Float(f)) => *f,
         DataValue::Vec(Vector::F32(v)) => {
@@ -290,10 +291,10 @@ pub(crate) fn op_haversine(args: &[DataValue]) -> Result<DataValue> {
         }
         .build()
     };
-    let lat1 = args[0].get_float().ok_or_else(make_err)?;
-    let lon1 = args[1].get_float().ok_or_else(make_err)?;
-    let lat2 = args[2].get_float().ok_or_else(make_err)?;
-    let lon2 = args[3].get_float().ok_or_else(make_err)?;
+    let lat1 = arg(args, 0)?.get_float().ok_or_else(make_err)?;
+    let lon1 = arg(args, 1)?.get_float().ok_or_else(make_err)?;
+    let lat2 = arg(args, 2)?.get_float().ok_or_else(make_err)?;
+    let lon2 = arg(args, 3)?.get_float().ok_or_else(make_err)?;
     let ret = 2.
         * f64::asin(f64::sqrt(
             f64::sin((lat1 - lat2) / 2.).powi(2)
@@ -310,10 +311,10 @@ pub(crate) fn op_haversine_deg_input(args: &[DataValue]) -> Result<DataValue> {
         }
         .build()
     };
-    let lat1 = args[0].get_float().ok_or_else(make_err)? * std::f64::consts::PI / 180.;
-    let lon1 = args[1].get_float().ok_or_else(make_err)? * std::f64::consts::PI / 180.;
-    let lat2 = args[2].get_float().ok_or_else(make_err)? * std::f64::consts::PI / 180.;
-    let lon2 = args[3].get_float().ok_or_else(make_err)? * std::f64::consts::PI / 180.;
+    let lat1 = arg(args, 0)?.get_float().ok_or_else(make_err)? * std::f64::consts::PI / 180.;
+    let lon1 = arg(args, 1)?.get_float().ok_or_else(make_err)? * std::f64::consts::PI / 180.;
+    let lat2 = arg(args, 2)?.get_float().ok_or_else(make_err)? * std::f64::consts::PI / 180.;
+    let lon2 = arg(args, 3)?.get_float().ok_or_else(make_err)? * std::f64::consts::PI / 180.;
     let ret = 2.
         * f64::asin(f64::sqrt(
             f64::sin((lat1 - lat2) / 2.).powi(2)
@@ -323,7 +324,7 @@ pub(crate) fn op_haversine_deg_input(args: &[DataValue]) -> Result<DataValue> {
 }
 
 pub(crate) fn op_deg_to_rad(args: &[DataValue]) -> Result<DataValue> {
-    let x = args[0].get_float().ok_or_else(|| {
+    let x = arg(args, 0)?.get_float().ok_or_else(|| {
         TypeMismatchSnafu {
             op: "deg_to_rad",
             expected: "numbers",
@@ -334,7 +335,7 @@ pub(crate) fn op_deg_to_rad(args: &[DataValue]) -> Result<DataValue> {
 }
 
 pub(crate) fn op_rad_to_deg(args: &[DataValue]) -> Result<DataValue> {
-    let x = args[0].get_float().ok_or_else(|| {
+    let x = arg(args, 0)?.get_float().ok_or_else(|| {
         TypeMismatchSnafu {
             op: "rad_to_deg",
             expected: "numbers",

--- a/crates/mneme/src/engine/data/functions/utility.rs
+++ b/crates/mneme/src/engine/data/functions/utility.rs
@@ -8,6 +8,7 @@ use std::str::FromStr;
 use serde_json::{Value, json};
 use snafu::ResultExt;
 
+use super::arg;
 use crate::engine::data::error::*;
 type Result<T> = DataResult<T>;
 use crate::engine::data::json::JsonValue;
@@ -149,32 +150,32 @@ fn json2val_local(res: Value) -> DataValue {
 }
 
 pub(crate) fn op_is_null(args: &[DataValue]) -> Result<DataValue> {
-    Ok(DataValue::from(matches!(args[0], DataValue::Null)))
+    Ok(DataValue::from(matches!(arg(args, 0)?, DataValue::Null)))
 }
 
 pub(crate) fn op_is_int(args: &[DataValue]) -> Result<DataValue> {
     Ok(DataValue::from(matches!(
-        args[0],
+        arg(args, 0)?,
         DataValue::Num(Num::Int(_))
     )))
 }
 
 pub(crate) fn op_is_float(args: &[DataValue]) -> Result<DataValue> {
     Ok(DataValue::from(matches!(
-        args[0],
+        arg(args, 0)?,
         DataValue::Num(Num::Float(_))
     )))
 }
 
 pub(crate) fn op_is_num(args: &[DataValue]) -> Result<DataValue> {
     Ok(DataValue::from(matches!(
-        args[0],
+        arg(args, 0)?,
         DataValue::Num(Num::Int(_)) | DataValue::Num(Num::Float(_))
     )))
 }
 
 pub(crate) fn op_is_finite(args: &[DataValue]) -> Result<DataValue> {
-    Ok(DataValue::from(match &args[0] {
+    Ok(DataValue::from(match arg(args, 0)? {
         DataValue::Num(Num::Int(_)) => true,
         DataValue::Num(Num::Float(f)) => f.is_finite(),
         _ => false,
@@ -182,48 +183,51 @@ pub(crate) fn op_is_finite(args: &[DataValue]) -> Result<DataValue> {
 }
 
 pub(crate) fn op_is_infinite(args: &[DataValue]) -> Result<DataValue> {
-    Ok(DataValue::from(match &args[0] {
+    Ok(DataValue::from(match arg(args, 0)? {
         DataValue::Num(Num::Float(f)) => f.is_infinite(),
         _ => false,
     }))
 }
 
 pub(crate) fn op_is_nan(args: &[DataValue]) -> Result<DataValue> {
-    Ok(DataValue::from(match &args[0] {
+    Ok(DataValue::from(match arg(args, 0)? {
         DataValue::Num(Num::Float(f)) => f.is_nan(),
         _ => false,
     }))
 }
 
 pub(crate) fn op_is_string(args: &[DataValue]) -> Result<DataValue> {
-    Ok(DataValue::from(matches!(args[0], DataValue::Str(_))))
+    Ok(DataValue::from(matches!(arg(args, 0)?, DataValue::Str(_))))
 }
 
 pub(crate) fn op_is_list(args: &[DataValue]) -> Result<DataValue> {
     Ok(DataValue::from(matches!(
-        args[0],
+        arg(args, 0)?,
         DataValue::List(_) | DataValue::Set(_)
     )))
 }
 
 pub(crate) fn op_is_vec(args: &[DataValue]) -> Result<DataValue> {
-    Ok(DataValue::from(matches!(args[0], DataValue::Vec(_))))
+    Ok(DataValue::from(matches!(arg(args, 0)?, DataValue::Vec(_))))
 }
 
 pub(crate) fn op_is_bytes(args: &[DataValue]) -> Result<DataValue> {
-    Ok(DataValue::from(matches!(args[0], DataValue::Bytes(_))))
+    Ok(DataValue::from(matches!(
+        arg(args, 0)?,
+        DataValue::Bytes(_)
+    )))
 }
 
 pub(crate) fn op_is_uuid(args: &[DataValue]) -> Result<DataValue> {
-    Ok(DataValue::from(matches!(args[0], DataValue::Uuid(_))))
+    Ok(DataValue::from(matches!(arg(args, 0)?, DataValue::Uuid(_))))
 }
 
 pub(crate) fn op_is_json(args: &[DataValue]) -> Result<DataValue> {
-    Ok(DataValue::from(matches!(args[0], DataValue::Json(_))))
+    Ok(DataValue::from(matches!(arg(args, 0)?, DataValue::Json(_))))
 }
 
 pub(crate) fn op_to_bool(args: &[DataValue]) -> Result<DataValue> {
-    Ok(DataValue::from(match &args[0] {
+    Ok(DataValue::from(match arg(args, 0)? {
         DataValue::Null => false,
         DataValue::Bool(b) => *b,
         DataValue::Num(n) => n.get_int() != Some(0),
@@ -248,7 +252,7 @@ pub(crate) fn op_to_bool(args: &[DataValue]) -> Result<DataValue> {
 }
 
 pub(crate) fn op_to_unity(args: &[DataValue]) -> Result<DataValue> {
-    Ok(DataValue::from(match &args[0] {
+    Ok(DataValue::from(match arg(args, 0)? {
         DataValue::Null => 0,
         DataValue::Bool(b) => *b as i64,
         DataValue::Num(n) => (n.get_float() != 0.) as i64,
@@ -274,7 +278,7 @@ pub(crate) fn op_to_unity(args: &[DataValue]) -> Result<DataValue> {
 
 #[expect(clippy::map_err_ignore, reason = "error context preserved in message")]
 pub(crate) fn op_to_int(args: &[DataValue]) -> Result<DataValue> {
-    Ok(match &args[0] {
+    Ok(match arg(args, 0)? {
         DataValue::Num(n) => match n.get_int() {
             None => {
                 let f = n.get_float();
@@ -303,7 +307,7 @@ pub(crate) fn op_to_int(args: &[DataValue]) -> Result<DataValue> {
 
 #[expect(clippy::map_err_ignore, reason = "error context preserved in message")]
 pub(crate) fn op_to_float(args: &[DataValue]) -> Result<DataValue> {
-    Ok(match &args[0] {
+    Ok(match arg(args, 0)? {
         DataValue::Num(n) => n.get_float().into(),
         DataValue::Null => DataValue::from(0.0),
         DataValue::Bool(b) => DataValue::from(if *b { 1.0 } else { 0.0 }),
@@ -328,12 +332,12 @@ pub(crate) fn op_to_float(args: &[DataValue]) -> Result<DataValue> {
 }
 
 pub(crate) fn op_to_string(args: &[DataValue]) -> Result<DataValue> {
-    Ok(DataValue::Str(val2str(&args[0]).into()))
+    Ok(DataValue::Str(val2str(arg(args, 0)?).into()))
 }
 
 #[expect(clippy::map_err_ignore, reason = "error context preserved in message")]
 pub(crate) fn op_to_uuid(args: &[DataValue]) -> Result<DataValue> {
-    match &args[0] {
+    match arg(args, 0)? {
         d @ DataValue::Uuid(_u) => Ok(d.clone()),
         DataValue::Str(s) => {
             let id = uuid::Uuid::try_parse(s)
@@ -349,14 +353,14 @@ pub(crate) fn op_to_uuid(args: &[DataValue]) -> Result<DataValue> {
 }
 
 pub(crate) fn op_json_to_scalar(args: &[DataValue]) -> Result<DataValue> {
-    Ok(match &args[0] {
+    Ok(match arg(args, 0)? {
         DataValue::Json(JsonData(j)) => json2val_local(j.clone()),
         d => d.clone(),
     })
 }
 
 pub(crate) fn op_json(args: &[DataValue]) -> Result<DataValue> {
-    Ok(DataValue::Json(JsonData(to_json(&args[0]))))
+    Ok(DataValue::Json(JsonData(to_json(arg(args, 0)?))))
 }
 
 pub(crate) fn op_json_object(args: &[DataValue]) -> Result<DataValue> {
@@ -376,7 +380,7 @@ pub(crate) fn op_json_object(args: &[DataValue]) -> Result<DataValue> {
 }
 
 pub(crate) fn op_parse_json(args: &[DataValue]) -> Result<DataValue> {
-    match args[0].get_str() {
+    match arg(args, 0)?.get_str() {
         Some(s) => {
             let value: serde_json::Value = serde_json::from_str(s).context(JsonSnafu)?;
             Ok(DataValue::Json(JsonData(value)))
@@ -390,7 +394,7 @@ pub(crate) fn op_parse_json(args: &[DataValue]) -> Result<DataValue> {
 }
 
 pub(crate) fn op_dump_json(args: &[DataValue]) -> Result<DataValue> {
-    match &args[0] {
+    match arg(args, 0)? {
         DataValue::Json(j) => Ok(DataValue::Str(j.0.to_string().into())),
         _ => TypeMismatchSnafu {
             op: "dump_json",
@@ -401,22 +405,22 @@ pub(crate) fn op_dump_json(args: &[DataValue]) -> Result<DataValue> {
 }
 
 pub(crate) fn op_set_json_path(args: &[DataValue]) -> Result<DataValue> {
-    let mut result = to_json(&args[0]);
-    let path = args[1].get_slice().ok_or_else(|| {
+    let mut result = to_json(arg(args, 0)?);
+    let path = arg(args, 1)?.get_slice().ok_or_else(|| {
         JsonPathSnafu {
             message: "json path must be a string",
         }
         .build()
     })?;
     let pointer = get_json_path(&mut result, path)?;
-    let new_val = to_json(&args[2]);
+    let new_val = to_json(arg(args, 2)?);
     *pointer = new_val;
     Ok(DataValue::Json(JsonData(result)))
 }
 
 pub(crate) fn op_remove_json_path(args: &[DataValue]) -> Result<DataValue> {
-    let mut result = to_json(&args[0]);
-    let path = args[1].get_slice().ok_or_else(|| {
+    let mut result = to_json(arg(args, 0)?);
+    let path = arg(args, 1)?.get_slice().ok_or_else(|| {
         JsonPathSnafu {
             message: "json path must be a string",
         }

--- a/crates/mneme/src/engine/data/functions/vector.rs
+++ b/crates/mneme/src/engine/data/functions/vector.rs
@@ -5,6 +5,7 @@ use base64::Engine;
 use base64::engine::general_purpose::STANDARD;
 use rand::Rng;
 
+use super::arg;
 use crate::engine::data::error::*;
 type Result<T> = DataResult<T>;
 use crate::engine::data::relation::VecElementType;
@@ -33,7 +34,7 @@ pub(crate) fn op_vec(args: &[DataValue]) -> Result<DataValue> {
         }
     };
 
-    match &args[0] {
+    match arg(args, 0)? {
         DataValue::Json(j) => {
             let arr = j.0.as_array().ok_or_else(|| {
                 TypeMismatchSnafu {
@@ -198,7 +199,7 @@ pub(crate) fn op_vec(args: &[DataValue]) -> Result<DataValue> {
 }
 
 pub(crate) fn op_rand_vec(args: &[DataValue]) -> Result<DataValue> {
-    let len = args[0].get_int().ok_or_else(|| {
+    let len = arg(args, 0)?.get_int().ok_or_else(|| {
         TypeMismatchSnafu {
             op: "rand_vec",
             expected: "an integer",
@@ -246,7 +247,7 @@ pub(crate) fn op_rand_vec(args: &[DataValue]) -> Result<DataValue> {
 }
 
 pub(crate) fn op_l2_normalize(args: &[DataValue]) -> Result<DataValue> {
-    let a = &args[0];
+    let a = arg(args, 0)?;
     match a {
         DataValue::Vec(Vector::F32(a)) => {
             let norm = a.dot(a).sqrt();
@@ -265,8 +266,8 @@ pub(crate) fn op_l2_normalize(args: &[DataValue]) -> Result<DataValue> {
 }
 
 pub(crate) fn op_l2_dist(args: &[DataValue]) -> Result<DataValue> {
-    let a = &args[0];
-    let b = &args[1];
+    let a = arg(args, 0)?;
+    let b = arg(args, 1)?;
     match (a, b) {
         (DataValue::Vec(Vector::F32(a)), DataValue::Vec(Vector::F32(b))) => {
             if a.len() != b.len() {
@@ -299,8 +300,8 @@ pub(crate) fn op_l2_dist(args: &[DataValue]) -> Result<DataValue> {
 }
 
 pub(crate) fn op_ip_dist(args: &[DataValue]) -> Result<DataValue> {
-    let a = &args[0];
-    let b = &args[1];
+    let a = arg(args, 0)?;
+    let b = arg(args, 1)?;
     match (a, b) {
         (DataValue::Vec(Vector::F32(a)), DataValue::Vec(Vector::F32(b))) => {
             if a.len() != b.len() {
@@ -333,8 +334,8 @@ pub(crate) fn op_ip_dist(args: &[DataValue]) -> Result<DataValue> {
 }
 
 pub(crate) fn op_cos_dist(args: &[DataValue]) -> Result<DataValue> {
-    let a = &args[0];
-    let b = &args[1];
+    let a = arg(args, 0)?;
+    let b = arg(args, 1)?;
     match (a, b) {
         (DataValue::Vec(Vector::F32(a)), DataValue::Vec(Vector::F32(b))) => {
             if a.len() != b.len() {


### PR DESCRIPTION
## Summary

- Add `arg()` bounds-checked helper for engine built-in function argument access
- Convert ~130 direct `args[N]` indexing sites across 9 files in `crates/mneme/src/engine/data/functions/` to use `arg(args, N)?`
- Convert `l[m..n]` slice range in `op_slice` to `.get(m..n)` with error propagation
- Convert `&args[1..]` to `args.get(1..).unwrap_or_default()` in set operations

All conversions return typed snafu errors instead of panicking on out-of-bounds access. No new `.unwrap()` or `.expect()` introduced.

## Audit notes

- **entity.rs**: All `row[N]` accesses are guarded by `row.len() < N` checks (pre-existing)
- **expr.rs, relation.rs, hnsw.rs**: Indexing is on fixed-arity operator args or iterator-derived indices (safe by construction)
- **theatron TUI files**: All indexing is guarded by prior bounds checks or loop conditions

## Observations

- **Debt**: `entity.rs` uses `continue` to silently skip short rows instead of returning errors
- **Debt**: `op_json_object` uses `pair[0]`/`pair[1]` from `chunks_exact(2)` (safe but inconsistent with new pattern)
- **Bug**: `integration_server` test fails on main (unrelated TLS provider issue)

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` (all pass except pre-existing integration_server failure)

Closes #1407.

🤖 Generated with [Claude Code](https://claude.com/claude-code)