### PR TITLE
fix(symbolon): add clock skew tolerance to OAuth token expiry check

### DIFF
--- a/crates/symbolon/src/credential.rs
+++ b/crates/symbolon/src/credential.rs
@@ -34,6 +34,14 @@ const OAUTH_TOKEN_URL: &str = "https://console.anthropic.com/v1/oauth/token";
 /// Refresh when token has less than this many seconds remaining.
 const REFRESH_THRESHOLD_SECS: u64 = 3600;
 
+/// Clock skew tolerance for token expiry checks (seconds).
+///
+/// WHY: clock differences between the OAuth provider and local system
+/// cause freshly obtained tokens to appear expired. 30 seconds is
+/// conservative enough to catch genuine expiry while tolerating
+/// typical NTP drift.
+const CLOCK_SKEW_LEEWAY_SECS: u64 = 30;
+
 /// How often the background refresh task checks token expiry.
 const REFRESH_CHECK_INTERVAL_SECS: u64 = 60;
 
@@ -284,11 +292,14 @@ impl CredentialProvider for EnvCredentialProvider {
                 && let Some(exp_secs) = decode_jwt_exp_secs(&v)
             {
                 let now_secs = unix_epoch_ms() / 1000;
-                if exp_secs < now_secs {
+                if exp_secs + CLOCK_SKEW_LEEWAY_SECS < now_secs {
                     warn!(
                         var = %self.var_name,
-                        "OAuth token from environment variable appears expired \
-                         — falling through to next provider"
+                        exp_secs,
+                        now_secs,
+                        leeway_secs = CLOCK_SKEW_LEEWAY_SECS,
+                        "OAuth token from environment variable expired \
+                         (exp + leeway < now), falling through to next provider"
                     );
                     return None;
                 }
@@ -528,7 +539,7 @@ async fn refresh_loop(
             break;
         }
 
-        let (refresh_token, subscription_type, needs_refresh) = {
+        let (refresh_token, subscription_type, expires_at_ms, needs_refresh) = {
             let Ok(guard) = state.read() else {
                 continue;
             };
@@ -540,14 +551,23 @@ async fn refresh_loop(
             let remaining_secs = (s.expires_at_ms as i64 - now_ms as i64) / 1000;
             #[expect(clippy::cast_possible_wrap, reason = "threshold constant fits in i64")]
             let needs = remaining_secs < REFRESH_THRESHOLD_SECS as i64;
-            (s.refresh_token.clone(), s.subscription_type.clone(), needs)
+            (
+                s.refresh_token.clone(),
+                s.subscription_type.clone(),
+                s.expires_at_ms,
+                needs,
+            )
         };
 
         if !needs_refresh {
             continue;
         }
 
-        info!("credential refresh needed -- refreshing OAuth token");
+        info!(
+            expires_at_ms,
+            now_ms = unix_epoch_ms(),
+            "credential refresh needed, refreshing OAuth token"
+        );
 
         match do_refresh(&client, &refresh_token).await {
             Some(resp) => {

--- a/crates/symbolon/src/credential_tests.rs
+++ b/crates/symbolon/src/credential_tests.rs
@@ -220,6 +220,45 @@ fn env_provider_expired_oauth_falls_through() {
 
 #[test]
 #[expect(unsafe_code, reason = "test-only env var manipulation")]
+fn env_provider_within_skew_window_accepted() {
+    let var = "ALETHEIA_TEST_SKEW_OAUTH_505";
+    // Set exp to 10 seconds in the past: within the 30-second leeway window
+    let now_secs = unix_epoch_ms() / 1000;
+    let within_skew_token = make_test_oauth_token(now_secs - 10);
+    // SAFETY: test uses unique var name, no concurrent access
+    unsafe { std::env::set_var(var, &within_skew_token) };
+    let provider = EnvCredentialProvider::new(var);
+    let cred = provider.get_credential();
+    assert!(
+        cred.is_some(),
+        "token within clock skew leeway should be accepted"
+    );
+    assert_eq!(
+        cred.as_ref().map(|c| &c.source),
+        Some(&CredentialSource::OAuth)
+    );
+    unsafe { std::env::remove_var(var) };
+}
+
+#[test]
+#[expect(unsafe_code, reason = "test-only env var manipulation")]
+fn env_provider_beyond_skew_window_rejected() {
+    let var = "ALETHEIA_TEST_BEYOND_SKEW_OAUTH_505";
+    // Set exp to 60 seconds in the past: beyond the 30-second leeway
+    let now_secs = unix_epoch_ms() / 1000;
+    let beyond_skew_token = make_test_oauth_token(now_secs - 60);
+    // SAFETY: test uses unique var name, no concurrent access
+    unsafe { std::env::set_var(var, &beyond_skew_token) };
+    let provider = EnvCredentialProvider::new(var);
+    assert!(
+        provider.get_credential().is_none(),
+        "token beyond clock skew leeway should be rejected"
+    );
+    unsafe { std::env::remove_var(var) };
+}
+
+#[test]
+#[expect(unsafe_code, reason = "test-only env var manipulation")]
 fn env_provider_valid_oauth_returns_credential() {
     let var = "ALETHEIA_TEST_VALID_OAUTH_505";
     let future_secs = unix_epoch_ms() / 1000 + 7200;


### PR DESCRIPTION
## Summary

- Add 30-second `CLOCK_SKEW_LEEWAY_SECS` tolerance to `EnvCredentialProvider` OAuth token expiry check, fixing freshly obtained tokens being rejected when the provider's clock is slightly ahead of the local system
- Add structured debug logging (exp_secs, now_secs, leeway_secs) on token rejection and in the refresh loop for future diagnosis
- Add tests for within-skew acceptance and beyond-skew rejection

Closes #1382.

## Test plan

- [x] `env_provider_within_skew_window_accepted`: token with exp 10s in the past (within 30s leeway) is accepted
- [x] `env_provider_beyond_skew_window_rejected`: token with exp 60s in the past (beyond 30s leeway) is rejected
- [x] Existing `env_provider_expired_oauth_falls_through` still passes (exp=1 is far beyond leeway)
- [x] Existing `env_provider_valid_oauth_returns_credential` still passes (future exp)
- [x] All 103 symbolon tests pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean

## Observations

- **Debt**: `crates/aletheia/tests/integration_server.rs` fails on main with `No provider set` (reqwest TLS provider issue), unrelated to this change.
- **Idea**: `CLOCK_SKEW_LEEWAY_SECS` could be made configurable via `taxis` config in a follow-up if operators need to tune it for environments with larger clock drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)