### PR TITLE
test(shared/bin): add bats tests for all utility scripts

### DIFF
--- a/shared/bin/tests/aletheia-backup.bats
+++ b/shared/bin/tests/aletheia-backup.bats
@@ -1,0 +1,76 @@
+#!/usr/bin/env bats
+
+# Tests for aletheia-backup
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+SCRIPT="$SCRIPT_DIR/aletheia-backup"
+
+setup() {
+    export ALETHEIA_ROOT="$(mktemp -d)"
+    export ALETHEIA_CONFIG_DIR="$ALETHEIA_ROOT"
+    export ALETHEIA_BACKUP_DIR="$ALETHEIA_ROOT/backups"
+    mkdir -p "$ALETHEIA_ROOT"
+}
+
+teardown() {
+    rm -rf "$ALETHEIA_ROOT"
+}
+
+@test "help flag exits 0 and shows usage" {
+    run "$SCRIPT" --help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Usage:"* ]]
+    [[ "$output" == *"--full"* ]]
+    [[ "$output" == *"--dest"* ]]
+    [[ "$output" == *"--list"* ]]
+}
+
+@test "short help flag exits 0" {
+    run "$SCRIPT" -h
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Usage:"* ]]
+}
+
+@test "unknown option exits non-zero" {
+    run "$SCRIPT" --invalid-flag
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Unknown option"* ]]
+}
+
+@test "list with no backups shows none" {
+    run "$SCRIPT" --list
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"(none)"* ]] || [[ "$output" == *"No backup directory"* ]]
+}
+
+@test "list with existing backup directory shows backups header" {
+    mkdir -p "$ALETHEIA_BACKUP_DIR"
+    run "$SCRIPT" --list
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Backups in"* ]]
+}
+
+@test "creates backup archive from empty config" {
+    mkdir -p "$ALETHEIA_ROOT"
+    run "$SCRIPT"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Backup complete"* ]]
+    # Verify a tar.gz was created
+    [ "$(ls "$ALETHEIA_BACKUP_DIR"/*.tar.gz 2>/dev/null | wc -l)" -ge 1 ]
+}
+
+@test "custom dest flag changes backup location" {
+    custom_dest="$(mktemp -d)"
+    run "$SCRIPT" --dest "$custom_dest"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"$custom_dest"* ]]
+    [ "$(ls "$custom_dest"/*.tar.gz 2>/dev/null | wc -l)" -ge 1 ]
+    rm -rf "$custom_dest"
+}
+
+@test "full flag includes full in backup name" {
+    run "$SCRIPT" --full
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"full (core + data)"* ]]
+    ls "$ALETHEIA_BACKUP_DIR"/aletheia-full-*.tar.gz >/dev/null 2>&1
+}

--- a/shared/bin/tests/credential-refresh.bats
+++ b/shared/bin/tests/credential-refresh.bats
@@ -1,0 +1,41 @@
+#!/usr/bin/env bats
+
+# Tests for credential-refresh (Python script)
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+SCRIPT="$SCRIPT_DIR/credential-refresh"
+
+@test "help flag exits 0 and shows usage" {
+    run "$SCRIPT" --help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Auto-refresh"* ]]
+    [[ "$output" == *"--force"* ]]
+    [[ "$output" == *"--daemon"* ]]
+    [[ "$output" == *"--status"* ]]
+}
+
+@test "short help flag exits 0" {
+    run "$SCRIPT" -h
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Auto-refresh"* ]]
+}
+
+@test "unknown option exits non-zero" {
+    run "$SCRIPT" --nonexistent-flag
+    [ "$status" -ne 0 ]
+}
+
+@test "status with missing credential file reports error" {
+    export HOME="$(mktemp -d)"
+    run "$SCRIPT" --status
+    # Should handle gracefully (prints error, doesn't crash with traceback)
+    [[ "$output" == *"Cannot read"* ]] || [[ "$output" == *"ERROR"* ]]
+    rm -rf "$HOME"
+}
+
+@test "refresh with missing credential file exits non-zero" {
+    export HOME="$(mktemp -d)"
+    run "$SCRIPT"
+    [ "$status" -ne 0 ]
+    rm -rf "$HOME"
+}

--- a/shared/bin/tests/gcal.bats
+++ b/shared/bin/tests/gcal.bats
@@ -1,0 +1,28 @@
+#!/usr/bin/env bats
+
+# Tests for gcal (Google Calendar CLI)
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+SCRIPT="$SCRIPT_DIR/gcal"
+
+@test "help command exits 0 and shows usage" {
+    run "$SCRIPT" help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Usage:"* ]]
+    [[ "$output" == *"today"* ]]
+    [[ "$output" == *"tomorrow"* ]]
+    [[ "$output" == *"week"* ]]
+    [[ "$output" == *"calendars"* ]]
+}
+
+@test "no arguments shows usage" {
+    run "$SCRIPT"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Usage:"* ]]
+}
+
+@test "unknown command exits non-zero" {
+    run "$SCRIPT" nonexistent-command
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Unknown command"* ]]
+}

--- a/shared/bin/tests/pplx.bats
+++ b/shared/bin/tests/pplx.bats
@@ -1,0 +1,29 @@
+#!/usr/bin/env bats
+
+# Tests for pplx (Perplexity research wrapper)
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+SCRIPT="$SCRIPT_DIR/pplx"
+
+@test "exits non-zero with no arguments" {
+    # pplx requires PERPLEXITY_API_KEY, so unset it to test arg validation
+    # The script checks args before using the key due to set -euo pipefail,
+    # but the :? expansion fires first. Either way, non-zero exit is correct.
+    unset PERPLEXITY_API_KEY
+    run "$SCRIPT"
+    [ "$status" -ne 0 ]
+}
+
+@test "exits non-zero without PERPLEXITY_API_KEY" {
+    unset PERPLEXITY_API_KEY
+    run "$SCRIPT" "test query"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"PERPLEXITY_API_KEY"* ]]
+}
+
+@test "shows usage in error when no args and key is set" {
+    export PERPLEXITY_API_KEY="test-key-not-real"
+    run "$SCRIPT"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Usage:"* ]]
+}

--- a/shared/bin/tests/run-tests.sh
+++ b/shared/bin/tests/run-tests.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+if ! command -v bats &>/dev/null; then
+    echo "error: bats not found. Install with: apt install bats" >&2
+    exit 1
+fi
+
+echo "Running shared/bin utility script tests..."
+echo ""
+
+if [[ $# -gt 0 ]]; then
+    bats "$@"
+else
+    bats "$SCRIPT_DIR"/*.bats
+fi

--- a/shared/bin/tests/scholar.bats
+++ b/shared/bin/tests/scholar.bats
@@ -1,0 +1,49 @@
+#!/usr/bin/env bats
+
+# Tests for scholar (academic research tool)
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+SCRIPT="$SCRIPT_DIR/scholar"
+
+@test "help flag exits 0 and shows usage" {
+    run "$SCRIPT" --help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"scholar"* ]]
+    [[ "$output" == *"Search"* ]] || [[ "$output" == *"search"* ]]
+}
+
+@test "short help flag exits 0" {
+    run "$SCRIPT" -h
+    [ "$status" -eq 0 ]
+}
+
+@test "no arguments shows help" {
+    run "$SCRIPT"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"scholar"* ]]
+}
+
+@test "fetch subcommand with no identifier exits non-zero" {
+    run "$SCRIPT" fetch
+    [ "$status" -ne 0 ]
+}
+
+@test "bib subcommand with no DOI exits non-zero" {
+    run "$SCRIPT" bib
+    [ "$status" -ne 0 ]
+}
+
+@test "info subcommand with no DOI exits non-zero" {
+    run "$SCRIPT" info
+    [ "$status" -ne 0 ]
+}
+
+@test "cite subcommand with no paper ID exits non-zero" {
+    run "$SCRIPT" cite
+    [ "$status" -ne 0 ]
+}
+
+@test "refs subcommand with no paper ID exits non-zero" {
+    run "$SCRIPT" refs
+    [ "$status" -ne 0 ]
+}

--- a/shared/bin/tests/start-sh.bats
+++ b/shared/bin/tests/start-sh.bats
@@ -1,0 +1,31 @@
+#!/usr/bin/env bats
+bats_require_minimum_version 1.5.0
+
+# Tests for start.sh
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+SCRIPT="$SCRIPT_DIR/start.sh"
+
+setup() {
+    export TEST_HOME="$(mktemp -d)"
+}
+
+teardown() {
+    rm -rf "$TEST_HOME"
+}
+
+@test "exits non-zero when no credentials exist" {
+    run env HOME="$TEST_HOME" ALETHEIA_ROOT="$TEST_HOME/.aletheia" bash "$SCRIPT"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"No credentials found"* ]]
+}
+
+@test "exits non-zero when aletheia binary does not exist" {
+    mkdir -p "$TEST_HOME/.aletheia/credentials"
+    cat > "$TEST_HOME/.aletheia/credentials/anthropic.json" <<'EOF'
+{"token": "sk-ant-api03-fake", "apiKey": "sk-ant-api03-fake"}
+EOF
+    chmod 600 "$TEST_HOME/.aletheia/credentials/anthropic.json"
+    run -127 env HOME="$TEST_HOME" ALETHEIA_ROOT="$TEST_HOME/.aletheia" bash "$SCRIPT"
+    [ "$status" -eq 127 ]
+}

--- a/shared/bin/tests/transcribe.bats
+++ b/shared/bin/tests/transcribe.bats
@@ -1,0 +1,36 @@
+#!/usr/bin/env bats
+
+# Tests for transcribe
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+SCRIPT="$SCRIPT_DIR/transcribe"
+
+setup() {
+    export ALETHEIA_ROOT="$(mktemp -d)"
+}
+
+teardown() {
+    rm -rf "$ALETHEIA_ROOT"
+}
+
+@test "help flag exits 0" {
+    run "$SCRIPT" --help
+    [ "$status" -eq 0 ]
+}
+
+@test "short help flag exits 0" {
+    run "$SCRIPT" -h
+    [ "$status" -eq 0 ]
+}
+
+@test "exits non-zero with no input file" {
+    run "$SCRIPT"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"No input file"* ]]
+}
+
+@test "exits non-zero with nonexistent file" {
+    run "$SCRIPT" /nonexistent/file.wav
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"File not found"* ]]
+}

--- a/shared/bin/tests/wiki.bats
+++ b/shared/bin/tests/wiki.bats
@@ -1,0 +1,35 @@
+#!/usr/bin/env bats
+
+# Tests for wiki (Wikipedia lookup)
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+SCRIPT="$SCRIPT_DIR/wiki"
+
+@test "help flag exits 0 and shows usage" {
+    run "$SCRIPT" --help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Wikipedia"* ]]
+    [[ "$output" == *"--search"* ]]
+    [[ "$output" == *"--refs"* ]]
+    [[ "$output" == *"--full"* ]]
+}
+
+@test "short help flag exits 0" {
+    run "$SCRIPT" -h
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Wikipedia"* ]]
+}
+
+@test "no arguments shows help" {
+    run "$SCRIPT"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"usage"* ]] || [[ "$output" == *"Wikipedia"* ]]
+}
+
+@test "json flag is accepted without error on valid query" {
+    # This makes a network call, but validates the flag parsing
+    run "$SCRIPT" --json "Test" 2>/dev/null
+    # Either succeeds (network available) or fails gracefully
+    # The key assertion: the flag doesn't cause an argument parsing error
+    [[ "$status" -eq 0 ]] || [[ "$output" != *"unrecognized arguments"* ]]
+}


### PR DESCRIPTION
## Summary
- Adds bats test files for all 8 utility scripts in `shared/bin/`: aletheia-backup, credential-refresh, gcal, pplx, scholar, start.sh, transcribe, wiki
- Each script has 2+ test cases covering help flags and error handling (invalid args, missing credentials, nonexistent files)
- Includes `run-tests.sh` CI runner that checks for bats and runs all `.bats` files
- 37 tests total, all passing with zero warnings

## Test plan
- [x] `bats shared/bin/tests/*.bats` — all 37 pass
- [x] Tests use temp dirs and mock environments (no production data access)
- [x] `run-tests.sh` works standalone for CI integration
- [x] No Rust code changed (shell-only PR)

## Observations
- **Debt:** `crates/aletheia/src/commands/server.rs:697` — missing `egress` and `egress_allowlist` fields in `SandboxConfig` initializer causes compilation failure on main. Pre-existing, unrelated to this PR.
- **Debt:** `shared/bin/transcribe:1` — uses `#!/bin/bash` instead of `#!/usr/bin/env bash` per SHELL.md standards.
- **Debt:** `crates/theatron/tui/src/msg.rs:304,309,314` — unfulfilled lint expectations (dead_code) generating warnings on main.

Closes #1456

🤖 Generated with [Claude Code](https://claude.com/claude-code)