### PR TITLE
perf(mneme): replace embedding Mutex with RwLock for concurrent recall

### DIFF
--- a/crates/mneme/src/embedding.rs
+++ b/crates/mneme/src/embedding.rs
@@ -30,7 +30,7 @@ pub enum EmbeddingError {
         location: snafu::Location,
     },
 
-    /// The embedding model mutex was poisoned by a prior panic.
+    /// The embedding model `RwLock` was poisoned by a prior panic.
     #[snafu(display("embedding model lock poisoned"))]
     LockPoisoned {
         #[snafu(implicit)]
@@ -132,10 +132,12 @@ mod candle_provider {
     ///
     /// Downloads and caches models from `HuggingFace` Hub on first use.
     /// Default model is `BAAI/bge-small-en-v1.5` (384 dimensions).
-    /// Thread-safe via internal mutex.
+    ///
+    /// Thread-safe via `RwLock`: multiple concurrent reads (embedding requests)
+    /// proceed in parallel. Write locks are only needed for model reload.
     pub struct CandelProvider {
-        model: std::sync::Mutex<BertModel>,
-        tokenizer: std::sync::Mutex<Tokenizer>,
+        model: std::sync::RwLock<BertModel>,
+        tokenizer: std::sync::RwLock<Tokenizer>,
         model_name: String,
         dimension: usize,
         device: Device,
@@ -239,8 +241,8 @@ mod candle_provider {
             }));
 
             Ok(Self {
-                model: std::sync::Mutex::new(model),
-                tokenizer: std::sync::Mutex::new(tokenizer),
+                model: std::sync::RwLock::new(model),
+                tokenizer: std::sync::RwLock::new(tokenizer),
                 model_name: repo_id.to_owned(),
                 dimension,
                 device,
@@ -258,10 +260,15 @@ mod candle_provider {
         }
 
         /// Tokenize, run model forward pass, and return raw hidden states + attention mask.
+        ///
+        /// Uses read locks on both tokenizer and model, allowing multiple
+        /// concurrent embedding requests to proceed in parallel.
         fn encode_and_forward(&self, texts: &[&str]) -> EmbeddingResult<(Tensor, Tensor)> {
+            // WHY: Read lock allows concurrent tokenization across callers.
+            // Tokenizer::encode_batch takes &self, no mutation needed.
             let tokenizer = self
                 .tokenizer
-                .lock()
+                .read()
                 .map_err(|_poison| LockPoisonedSnafu.build())?;
 
             let encodings = tokenizer.encode_batch(texts.to_vec(), true).map_err(|e| {
@@ -291,9 +298,11 @@ mod candle_provider {
             let attention_mask =
                 Tensor::stack(&attention_masks, 0).map_err(Self::candle_err("mask stack"))?;
 
+            // WHY: Read lock allows concurrent forward passes.
+            // BertModel::forward takes &self, no mutation needed.
             let model = self
                 .model
-                .lock()
+                .read()
                 .map_err(|_poison| LockPoisonedSnafu.build())?;
             let embeddings = model
                 .forward(&input_ids, &token_type_ids, Some(&attention_mask))

--- a/crates/mneme/src/embedding_tests.rs
+++ b/crates/mneme/src/embedding_tests.rs
@@ -284,6 +284,31 @@ fn mock_model_name() {
     assert_eq!(provider.model_name(), "mock-embedding");
 }
 
+#[tokio::test]
+async fn concurrent_embed_no_deadlock() {
+    use std::sync::Arc;
+    let provider = Arc::new(MockEmbeddingProvider::new(128));
+    let mut set = tokio::task::JoinSet::new();
+    for i in 0..4u32 {
+        let p = Arc::clone(&provider);
+        set.spawn(async move {
+            let text = format!("concurrent text {i}");
+            let vec = p.embed(&text).expect("concurrent embed must succeed");
+            assert_eq!(
+                vec.len(),
+                128,
+                "concurrent embed must produce correct dimension"
+            );
+            vec
+        });
+    }
+    let mut results = Vec::new();
+    while let Some(result) = set.join_next().await {
+        results.push(result.expect("spawned task must not panic"));
+    }
+    assert_eq!(results.len(), 4, "all 4 concurrent tasks must complete");
+}
+
 mod proptests {
     use super::*;
     use proptest::prelude::*;
@@ -319,24 +344,27 @@ fn candle_not_enabled_returns_error() {
 
 #[test]
 fn lock_poisoned_error_returns_err_not_panic() {
-    use std::sync::Mutex;
+    use std::sync::RwLock;
 
-    // Poison a mutex by panicking inside a thread while holding it.
-    let m: Mutex<u32> = Mutex::new(0);
+    // Poison an RwLock by panicking inside a thread while holding a write lock.
+    let m: RwLock<u32> = RwLock::new(0);
     let _ = std::panic::catch_unwind(|| {
-        let _guard = m.lock().expect("pre-poison lock must succeed");
+        let _guard = m.write().expect("pre-poison write lock must succeed");
         panic!("intentional poison");
     });
-    assert!(m.is_poisoned(), "mutex must be poisoned after thread panic");
+    assert!(
+        m.is_poisoned(),
+        "RwLock must be poisoned after thread panic"
+    );
 
-    // Simulate what embed() does: map_err to LockPoisoned.
+    // Simulate what embed() does: map_err to LockPoisoned on read().
     let result: EmbeddingResult<()> = m
-        .lock()
+        .read()
         .map_err(|_poison| LockPoisonedSnafu.build())
         .map(|_| ());
     assert!(
         matches!(result, Err(EmbeddingError::LockPoisoned { .. })),
-        "poisoned lock must produce EmbeddingError::LockPoisoned"
+        "poisoned RwLock read must produce EmbeddingError::LockPoisoned"
     );
 }
 
@@ -414,5 +442,39 @@ mod candle_tests {
     fn candle_provider_send_sync() {
         fn assert_send_sync<T: Send + Sync>() {}
         assert_send_sync::<CandelProvider>();
+    }
+
+    /// Spawn 4 tasks that embed concurrently via the shared candle provider.
+    /// Verifies no deadlock under concurrent read locks.
+    #[tokio::test]
+    async fn candle_concurrent_embed_no_deadlock() {
+        use std::sync::Arc;
+        let provider: Arc<dyn EmbeddingProvider> =
+            Arc::new(CandelProvider::new(None).expect("candle provider init for concurrent test"));
+        let mut set = tokio::task::JoinSet::new();
+        for i in 0..4u32 {
+            let p = Arc::clone(&provider);
+            set.spawn(async move {
+                let text = format!("concurrent candle text {i}");
+                let vec = p
+                    .embed(&text)
+                    .expect("concurrent candle embed must succeed");
+                assert_eq!(
+                    vec.len(),
+                    384,
+                    "concurrent candle embed must produce correct dimension"
+                );
+                vec
+            });
+        }
+        let mut results = Vec::new();
+        while let Some(result) = set.join_next().await {
+            results.push(result.expect("spawned candle task must not panic"));
+        }
+        assert_eq!(
+            results.len(),
+            4,
+            "all 4 concurrent candle tasks must complete"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Replace `std::sync::Mutex` with `std::sync::RwLock` on both `BertModel` and `Tokenizer` fields in `CandelProvider`
- Both `BertModel::forward()` and `Tokenizer::encode_batch()` take `&self`, so concurrent reads are safe
- Multiple nous actors can now embed simultaneously instead of serializing behind a mutex
- Add concurrent embedding tests (mock + candle) that spawn 4 tasks embedding in parallel

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes (888 mneme tests, all workspace tests)
- [x] New `concurrent_embed_no_deadlock` test verifies 4 concurrent tasks complete without deadlock
- [x] New `candle_concurrent_embed_no_deadlock` test (behind `embed-candle` feature) exercises real model concurrency
- [x] Existing `lock_poisoned_error_returns_err_not_panic` test updated to use `RwLock`

## Observations

- **Debt**: `CandelProvider` has no mechanism for model reload/hot-swap. The `RwLock` write path is unused today but positions for future reload support. (`crates/mneme/src/embedding.rs`)

Closes #1440

🤖 Generated with [Claude Code](https://claude.com/claude-code)