### PR TITLE
perf(theatron): batch streaming token renders at frame boundary

### DIFF
--- a/crates/theatron/tui/src/app.rs
+++ b/crates/theatron/tui/src/app.rs
@@ -580,10 +580,30 @@ impl App {
             }
             // Cache miss (terminal resized or first frame): fall through to full render.
         }
+        // PERF: Refresh the streaming markdown cache once per frame instead of on
+        // every text delta. Multiple deltas arriving between frames are batched
+        // into a single markdown::render call, reducing CPU from O(tokens) to O(frames).
+        self.refresh_streaming_markdown_cache();
         let links = view::render(self, frame);
         self.frame_cache = Some(frame.buffer_mut().clone());
         self.dirty = false;
         links
+    }
+
+    /// Rebuild the streaming markdown cache if the text has changed since the
+    /// last render. Called once per frame, not per token delta.
+    pub(crate) fn refresh_streaming_markdown_cache(&mut self) {
+        if self.streaming_text.is_empty() {
+            return;
+        }
+        let width = self.terminal_width.saturating_sub(4).max(1) as usize;
+        if self.markdown_cache.text == self.streaming_text && self.markdown_cache.width == width {
+            return;
+        }
+        self.markdown_cache.lines =
+            crate::markdown::render(&self.streaming_text, width, &self.theme, &self.highlighter).0;
+        self.markdown_cache.text = self.streaming_text.clone();
+        self.markdown_cache.width = width;
     }
 }
 

--- a/crates/theatron/tui/src/lib.rs
+++ b/crates/theatron/tui/src/lib.rs
@@ -171,12 +171,35 @@ async fn run_loop(mut terminal: DefaultTerminal, app: &mut App) -> error::Result
             app.update(msg).await;
         }
 
+        // PERF: Drain all buffered stream events before the next frame.
+        // At high token rates (50-100 tokens/sec) multiple TextDelta events
+        // queue between frames. Processing them all here batches the text
+        // appends so the next frame renders once with all accumulated deltas.
+        drain_pending_stream_events(app).await;
+
         if app.should_quit {
             break;
         }
     }
 
     Ok(())
+}
+
+/// Drain all currently-buffered stream events without blocking.
+///
+/// This prevents one-event-per-frame bottlenecks during high-rate streaming.
+/// The receiver is temporarily taken from the app and restored after draining.
+async fn drain_pending_stream_events(app: &mut App) {
+    let Some(mut rx) = app.take_stream() else {
+        return;
+    };
+    while let Ok(stream_event) = rx.try_recv() {
+        let event = Event::Stream(stream_event);
+        if let Some(msg) = app.map_event(event) {
+            app.update(msg).await;
+        }
+    }
+    app.restore_stream(Some(rx));
 }
 
 /// Write OSC 8 hyperlink sequences to the terminal **after** ratatui has

--- a/crates/theatron/tui/src/update/streaming.rs
+++ b/crates/theatron/tui/src/update/streaming.rs
@@ -28,14 +28,10 @@ pub(crate) fn handle_stream_turn_start(app: &mut App, turn_id: TurnId, nous_id: 
 pub(crate) fn handle_stream_text_delta(app: &mut App, text: String) {
     let clean = sanitize_for_display(&text);
     app.streaming_text.push_str(&clean);
-    // PERF: Update the markdown cache on every delta so the view can use the
-    // cached lines (cheap clone) instead of calling markdown::render per frame.
-    // The width subtracts 4 to match the view's inner_width.saturating_sub(2).
-    let width = app.terminal_width.saturating_sub(4).max(1) as usize;
-    app.markdown_cache.lines =
-        crate::markdown::render(&app.streaming_text, width, &app.theme, &app.highlighter).0;
-    app.markdown_cache.text = app.streaming_text.clone();
-    app.markdown_cache.width = width;
+    // PERF: Markdown re-rendering is deferred to the frame boundary (app.view)
+    // so that multiple text deltas arriving between frames are batched into a
+    // single markdown::render call. At 100 tokens/sec with 60fps rendering,
+    // this reduces markdown parses from ~100/sec to at most 60/sec.
     if app.auto_scroll {
         app.scroll_offset = 0;
     }
@@ -520,19 +516,26 @@ mod tests {
     }
 
     #[test]
-    fn text_delta_always_updates_markdown_cache() {
+    fn text_delta_defers_markdown_cache() {
         let mut app = test_app();
         handle_stream_text_delta(&mut app, "hello".to_string());
-        assert_eq!(app.markdown_cache.text, "hello");
-        assert!(!app.markdown_cache.lines.is_empty());
+        // PERF: markdown cache is no longer updated per-delta; it is refreshed
+        // once per frame in App::refresh_streaming_markdown_cache.
+        assert!(
+            app.markdown_cache.text.is_empty(),
+            "cache must not update on delta (deferred to frame boundary)"
+        );
+        assert_eq!(app.streaming_text, "hello");
     }
 
     #[test]
-    fn text_delta_cache_tracks_width() {
+    fn refresh_markdown_cache_updates_after_delta() {
         let mut app = test_app();
         app.terminal_width = 80;
         handle_stream_text_delta(&mut app, "hello\nworld".to_string());
+        app.refresh_streaming_markdown_cache();
         assert_eq!(app.markdown_cache.text, "hello\nworld");
+        assert!(!app.markdown_cache.lines.is_empty());
         // Width should be terminal_width - 4 (matching the view's inner_width - 2)
         assert_eq!(app.markdown_cache.width, 76);
     }


### PR DESCRIPTION
## Summary
- Defer markdown re-rendering from per-token (`handle_stream_text_delta`) to per-frame (`App::view`), reducing markdown parses from ~100/sec to at most 60/sec at high token rates
- Add `drain_pending_stream_events` to batch all queued `TextDelta` events before each frame, preventing one-event-per-frame bottlenecks
- Update tests to reflect deferred cache semantics

Closes #1452

## Observations
- **Debt**: `scroll_line_down_to_zero_enables_auto_scroll` test fails on main (pre-existing, `crates/theatron/tui/src/update/navigation.rs:279`)
- **Debt**: `benchmark_push_item_amortized` is flaky under system load (`crates/theatron/tui/src/state/virtual_scroll.rs:490`)

## Test plan
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy -p theatron-tui --all-targets -- -D warnings` passes
- [x] `cargo test -p theatron-tui` passes (2 pre-existing failures unrelated to this change)
- [x] New tests `text_delta_defers_markdown_cache` and `refresh_markdown_cache_updates_after_delta` pass
- [ ] Manual verification: streaming at high token rates is visually smooth with no missing tokens

🤖 Generated with [Claude Code](https://claude.com/claude-code)