### PR TITLE
feat(taxis): implement config reload without restart

### DIFF
--- a/crates/aletheia/src/commands/server.rs
+++ b/crates/aletheia/src/commands/server.rs
@@ -456,6 +456,7 @@ pub async fn run(args: Args) -> Result<()> {
     #[cfg(feature = "recall")]
     let knowledge_store = nous_manager.knowledge_store().cloned();
 
+    let (config_tx, _config_rx) = tokio::sync::watch::channel(aletheia_config.clone());
     let state = Arc::new(AppState {
         session_store,
         nous_manager: Arc::clone(&nous_manager),
@@ -466,6 +467,7 @@ pub async fn run(args: Args) -> Result<()> {
         start_time: Instant::now(),
         auth_mode: config.gateway.auth.mode.clone(),
         config: Arc::new(tokio::sync::RwLock::new(aletheia_config)),
+        config_tx,
         idempotency_cache: Arc::new(aletheia_pylon::idempotency::IdempotencyCache::new()),
         shutdown: shutdown_token.clone(),
         #[cfg(feature = "recall")]

--- a/crates/aletheia/src/server.rs
+++ b/crates/aletheia/src/server.rs
@@ -386,6 +386,7 @@ pub(crate) async fn serve(cli: Cli) -> Result<()> {
     #[cfg(feature = "recall")]
     let knowledge_store = nous_manager.knowledge_store().cloned();
 
+    let (config_tx, _config_rx) = tokio::sync::watch::channel(aletheia_config.clone());
     let state = Arc::new(AppState {
         session_store,
         nous_manager: Arc::clone(&nous_manager),
@@ -396,6 +397,7 @@ pub(crate) async fn serve(cli: Cli) -> Result<()> {
         start_time: Instant::now(),
         auth_mode: config.gateway.auth.mode.clone(),
         config: Arc::new(tokio::sync::RwLock::new(aletheia_config)),
+        config_tx,
         idempotency_cache: Arc::new(aletheia_pylon::idempotency::IdempotencyCache::new()),
         shutdown: shutdown_token.clone(),
         #[cfg(feature = "recall")]

--- a/crates/integration-tests/tests/cross_crate_pipeline.rs
+++ b/crates/integration-tests/tests/cross_crate_pipeline.rs
@@ -249,6 +249,8 @@ impl TestHarness {
             issuer: "aletheia-test".to_owned(),
         }));
 
+        let default_config = aletheia_taxis::config::AletheiaConfig::default();
+        let (config_tx, _config_rx) = tokio::sync::watch::channel(default_config.clone());
         let state = Arc::new(AppState {
             session_store,
             nous_manager: Arc::new(nous_manager),
@@ -258,9 +260,8 @@ impl TestHarness {
             jwt_manager: Arc::clone(&jwt_manager),
             start_time: Instant::now(),
             auth_mode: "token".to_owned(),
-            config: Arc::new(tokio::sync::RwLock::new(
-                aletheia_taxis::config::AletheiaConfig::default(),
-            )),
+            config: Arc::new(tokio::sync::RwLock::new(default_config)),
+            config_tx,
             idempotency_cache: Arc::new(aletheia_pylon::idempotency::IdempotencyCache::new()),
             shutdown: CancellationToken::new(),
             #[cfg(feature = "knowledge-store")]

--- a/crates/integration-tests/tests/end_to_end.rs
+++ b/crates/integration-tests/tests/end_to_end.rs
@@ -163,6 +163,8 @@ impl TestHarness {
             issuer: "aletheia-test".to_owned(),
         }));
 
+        let default_config = aletheia_taxis::config::AletheiaConfig::default();
+        let (config_tx, _config_rx) = tokio::sync::watch::channel(default_config.clone());
         let state = Arc::new(AppState {
             session_store,
             nous_manager: Arc::new(nous_manager),
@@ -172,9 +174,8 @@ impl TestHarness {
             jwt_manager: Arc::clone(&jwt_manager),
             start_time: Instant::now(),
             auth_mode: "token".to_owned(),
-            config: Arc::new(tokio::sync::RwLock::new(
-                aletheia_taxis::config::AletheiaConfig::default(),
-            )),
+            config: Arc::new(tokio::sync::RwLock::new(default_config)),
+            config_tx,
             idempotency_cache: Arc::new(aletheia_pylon::idempotency::IdempotencyCache::new()),
             shutdown: CancellationToken::new(),
             #[cfg(feature = "knowledge-store")]

--- a/crates/integration-tests/tests/eval_harness.rs
+++ b/crates/integration-tests/tests/eval_harness.rs
@@ -86,6 +86,8 @@ async fn start_test_server() -> (String, String, tempfile::TempDir) {
         .issue_access("test-user", Role::Operator, None)
         .expect("test token");
 
+    let default_config = aletheia_taxis::config::AletheiaConfig::default();
+    let (config_tx, _config_rx) = tokio::sync::watch::channel(default_config.clone());
     let state = Arc::new(AppState {
         session_store,
         nous_manager: Arc::new(nous_manager),
@@ -95,9 +97,8 @@ async fn start_test_server() -> (String, String, tempfile::TempDir) {
         jwt_manager,
         start_time: Instant::now(),
         auth_mode: "token".to_owned(),
-        config: Arc::new(tokio::sync::RwLock::new(
-            aletheia_taxis::config::AletheiaConfig::default(),
-        )),
+        config: Arc::new(tokio::sync::RwLock::new(default_config)),
+        config_tx,
         idempotency_cache: Arc::new(aletheia_pylon::idempotency::IdempotencyCache::new()),
         shutdown: CancellationToken::new(),
         #[cfg(feature = "knowledge-store")]

--- a/crates/pylon/src/handlers/config.rs
+++ b/crates/pylon/src/handlers/config.rs
@@ -26,13 +26,25 @@ const VALID_SECTIONS: &[&str] = &[
     "pricing",
 ];
 
-/// Response wrapper for config reload metadata.
+/// Response wrapper for config section update metadata.
 #[derive(serde::Serialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct ConfigUpdateResponse {
     pub section: String,
     pub config: Value,
     pub restart_required: Vec<String>,
+}
+
+/// Response wrapper for full config reload.
+#[derive(serde::Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ConfigReloadResponse {
+    /// Number of hot-reloadable values that were updated.
+    pub hot_reloaded: usize,
+    /// Field paths that changed but require a restart to take effect.
+    pub restart_required: Vec<String>,
+    /// All changed field paths (both hot and cold).
+    pub changed: Vec<String>,
 }
 
 /// GET /api/v1/config: full redacted config.
@@ -89,6 +101,69 @@ pub async fn get_section(
             location: snafu::Location::default(),
         }),
     }
+}
+
+/// POST /api/v1/config/reload: re-read config from disk and apply hot-reloadable values.
+///
+/// Re-reads `aletheia.toml` (and env overrides), validates the result, diffs
+/// against the current in-memory config, applies hot-reloadable changes, and
+/// logs what changed. Cold values (port, bind, TLS, auth mode, channels) are
+/// reported but not applied until restart.
+#[utoipa::path(
+    post,
+    path = "/api/v1/config/reload",
+    responses(
+        (status = 200, description = "Config reloaded", body = ConfigReloadResponse),
+        (status = 422, description = "New config is invalid, old config preserved"),
+    ),
+    security(("bearer_auth" = []))
+)]
+#[instrument(skip(state, _claims))]
+pub async fn reload_config(
+    State(state): State<Arc<AppState>>,
+    _claims: Claims,
+) -> Result<impl IntoResponse, ApiError> {
+    let current = state.config.read().await.clone();
+    let outcome = aletheia_taxis::reload::prepare_reload(&state.oikos, &current).map_err(|e| {
+        tracing::error!(error = %e, "config reload failed");
+        match e {
+            aletheia_taxis::reload::ReloadError::Validation { source, .. } => {
+                ApiError::ValidationFailed {
+                    errors: source.errors,
+                    location: snafu::Location::default(),
+                }
+            }
+            other => ApiError::Internal {
+                message: other.to_string(),
+                location: snafu::Location::default(),
+            },
+        }
+    })?;
+
+    let hot_reloaded = outcome.diff.hot_changes().len();
+    let restart_required: Vec<String> = outcome
+        .diff
+        .cold_changes()
+        .iter()
+        .map(|c| c.path.clone())
+        .collect();
+    let changed: Vec<String> = outcome
+        .diff
+        .changes
+        .iter()
+        .map(|c| c.path.clone())
+        .collect();
+
+    crate::server::apply_reload(&state, outcome).await;
+
+    Ok((
+        StatusCode::OK,
+        Json(ConfigReloadResponse {
+            hot_reloaded,
+            restart_required,
+            changed,
+        }),
+    ))
 }
 
 /// PUT /api/v1/config/{section}: update and persist a config section.
@@ -163,8 +238,12 @@ pub async fn update_section(
         .map(|p| (*p).to_owned())
         .collect();
 
-    *config = new_config;
+    *config = new_config.clone();
     let redacted = aletheia_taxis::redact::redact(&config);
+    drop(config);
+
+    let _ = state.config_tx.send(new_config);
+
     let section_value = redacted.get(&section).cloned().unwrap_or_else(|| {
         tracing::debug!(section = %section, "config section absent after update, returning null");
         Value::Null

--- a/crates/pylon/src/router.rs
+++ b/crates/pylon/src/router.rs
@@ -54,6 +54,7 @@ pub fn build_router(state: Arc<AppState>, security: &SecurityConfig) -> Router {
         .route("/nous/{id}", get(nous::get_status))
         .route("/nous/{id}/tools", get(nous::tools))
         .route("/config", get(config::get_config))
+        .route("/config/reload", post(config::reload_config))
         .route(
             "/config/{section}",
             get(config::get_section).put(config::update_section),

--- a/crates/pylon/src/server.rs
+++ b/crates/pylon/src/server.rs
@@ -117,6 +117,8 @@ pub async fn run(config: ServerConfig) -> Result<(), ServerError> {
     #[cfg(feature = "knowledge-store")]
     let knowledge_store = nous_manager.knowledge_store().cloned();
 
+    let (config_tx, _config_rx) = tokio::sync::watch::channel(aletheia_config.clone());
+
     let state = Arc::new(AppState {
         session_store: Arc::clone(&session_store),
         nous_manager: Arc::new(nous_manager),
@@ -127,11 +129,15 @@ pub async fn run(config: ServerConfig) -> Result<(), ServerError> {
         start_time: Instant::now(),
         auth_mode: aletheia_config.gateway.auth.mode.clone(),
         config: Arc::new(tokio::sync::RwLock::new(aletheia_config)),
+        config_tx,
         idempotency_cache: Arc::new(crate::idempotency::IdempotencyCache::new()),
         shutdown: CancellationToken::new(),
         #[cfg(feature = "knowledge-store")]
         knowledge_store,
     });
+
+    #[cfg(unix)]
+    spawn_sighup_handler(Arc::clone(&state));
 
     let app = build_router(state.clone(), &config.security);
 
@@ -228,6 +234,64 @@ fn serve_tls(
     _config: &ServerConfig,
 ) -> impl std::future::Future<Output = Result<(), ServerError>> {
     std::future::ready(TlsNotCompiledSnafu.fail())
+}
+
+/// Apply a prepared config reload to the live state.
+///
+/// Acquires the config write lock, swaps the config, logs the diff,
+/// and notifies subscribers via the watch channel.
+pub(crate) async fn apply_reload(state: &AppState, outcome: aletheia_taxis::reload::ReloadOutcome) {
+    aletheia_taxis::reload::log_diff(&outcome.diff);
+
+    let mut config = state.config.write().await;
+    *config = outcome.new_config.clone();
+    drop(config);
+
+    // WHY: send can only fail if all receivers are dropped, which means
+    // no actors are listening. Safe to ignore.
+    let _ = state.config_tx.send(outcome.new_config);
+}
+
+/// Spawn a background task that listens for SIGHUP and triggers config reload.
+///
+/// On each SIGHUP, re-reads config from disk, validates, diffs against the
+/// current config, and applies hot-reloadable values. Invalid configs are
+/// rejected with an error log; the running config is preserved.
+#[cfg(unix)]
+fn spawn_sighup_handler(state: Arc<AppState>) {
+    use tracing::Instrument;
+
+    let span = tracing::info_span!("sighup_reload");
+    tokio::spawn(
+        async move {
+            #[expect(
+                clippy::expect_used,
+                reason = "signal handler installation is infallible on supported platforms"
+            )]
+            let mut sighup = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::hangup())
+                .expect("failed to install SIGHUP handler");
+
+            loop {
+                sighup.recv().await;
+                info!("received SIGHUP, reloading config");
+
+                let current = state.config.read().await.clone();
+                match aletheia_taxis::reload::prepare_reload(&state.oikos, &current) {
+                    Ok(outcome) => {
+                        if outcome.diff.is_empty() {
+                            info!("config reload: no changes detected");
+                        } else {
+                            apply_reload(&state, outcome).await;
+                        }
+                    }
+                    Err(e) => {
+                        tracing::error!(error = %e, "config reload failed, keeping current config");
+                    }
+                }
+            }
+        }
+        .instrument(span),
+    );
 }
 
 #[expect(

--- a/crates/pylon/src/state.rs
+++ b/crates/pylon/src/state.rs
@@ -35,6 +35,11 @@ pub struct AppState {
     pub start_time: Instant,
     /// Runtime configuration, updatable via config API.
     pub config: Arc<tokio::sync::RwLock<AletheiaConfig>>,
+    /// Broadcast channel for config change notifications.
+    ///
+    /// Actors and subsystems subscribe via [`config_rx`](Self::config_rx) to
+    /// receive the latest config after each hot-reload.
+    pub config_tx: tokio::sync::watch::Sender<AletheiaConfig>,
     /// Auth mode from gateway config (`"token"`, `"none"`, etc.).
     pub auth_mode: String,
     /// Root shutdown token. Cancel to initiate graceful shutdown of all subsystems.
@@ -44,6 +49,17 @@ pub struct AppState {
     /// Shared knowledge store for fact/entity/relationship queries.
     #[cfg(feature = "knowledge-store")]
     pub knowledge_store: Option<Arc<KnowledgeStore>>,
+}
+
+impl AppState {
+    /// Subscribe to config change notifications.
+    ///
+    /// Returns a `watch::Receiver` that yields the latest config after each
+    /// successful reload. Actors should call `changed().await` to be notified.
+    #[must_use]
+    pub fn config_rx(&self) -> tokio::sync::watch::Receiver<AletheiaConfig> {
+        self.config_tx.subscribe()
+    }
 }
 
 #[cfg(test)]

--- a/crates/pylon/src/tests.rs
+++ b/crates/pylon/src/tests.rs
@@ -104,6 +104,9 @@ async fn test_state_with_provider(with_provider: bool) -> (Arc<AppState>, tempfi
 
     let jwt_manager = test_jwt_manager();
 
+    let default_config = aletheia_taxis::config::AletheiaConfig::default();
+    let (config_tx, _config_rx) = tokio::sync::watch::channel(default_config.clone());
+
     let state = Arc::new(AppState {
         session_store: Arc::clone(&session_store),
         nous_manager: Arc::new(nous_manager),
@@ -113,9 +116,8 @@ async fn test_state_with_provider(with_provider: bool) -> (Arc<AppState>, tempfi
         jwt_manager,
         start_time: Instant::now(),
         auth_mode: "token".to_owned(),
-        config: Arc::new(tokio::sync::RwLock::new(
-            aletheia_taxis::config::AletheiaConfig::default(),
-        )),
+        config: Arc::new(tokio::sync::RwLock::new(default_config)),
+        config_tx,
         idempotency_cache: Arc::new(crate::idempotency::IdempotencyCache::new()),
         shutdown: CancellationToken::new(),
         #[cfg(feature = "knowledge-store")]
@@ -1350,6 +1352,8 @@ async fn cors_rejects_unlisted_origin() {
 
 async fn app_auth_disabled() -> (axum::Router, tempfile::TempDir) {
     let (state, dir) = test_state().await;
+    let default_config = aletheia_taxis::config::AletheiaConfig::default();
+    let (config_tx, _config_rx) = tokio::sync::watch::channel(default_config);
     let state = Arc::new(AppState {
         auth_mode: "none".to_owned(),
         session_store: Arc::clone(&state.session_store),
@@ -1360,6 +1364,7 @@ async fn app_auth_disabled() -> (axum::Router, tempfile::TempDir) {
         jwt_manager: Arc::clone(&state.jwt_manager),
         start_time: state.start_time,
         config: Arc::clone(&state.config),
+        config_tx,
         idempotency_cache: Arc::clone(&state.idempotency_cache),
         shutdown: state.shutdown.clone(),
         #[cfg(feature = "knowledge-store")]

--- a/crates/taxis/src/reload.rs
+++ b/crates/taxis/src/reload.rs
@@ -1,6 +1,16 @@
-//! Hot-reload classification: which settings need a restart vs live update.
+//! Hot-reload classification, config diff, and reload orchestration.
+
+use serde_json::Value;
+use snafu::Snafu;
+use tracing::{info, warn};
+
+use crate::config::AletheiaConfig;
+use crate::oikos::Oikos;
 
 /// Field path prefixes that require a process restart to take effect.
+///
+/// All other config paths are hot-reloadable: they take effect immediately
+/// when the in-memory config is swapped.
 const RESTART_PREFIXES: &[&str] = &[
     "gateway.port",
     "gateway.bind",
@@ -25,7 +35,200 @@ pub fn restart_prefixes() -> &'static [&'static str] {
     RESTART_PREFIXES
 }
 
+/// A single changed field between two config versions.
+#[derive(Debug, Clone)]
+pub struct ConfigChange {
+    /// Dotted path to the changed field (e.g. `agents.defaults.thinkingBudget`).
+    pub path: String,
+    /// Whether this change requires a restart to take effect.
+    pub restart_required: bool,
+}
+
+/// Result of comparing two configs.
+#[derive(Debug, Clone)]
+pub struct ConfigDiff {
+    /// Fields that changed between old and new config.
+    pub changes: Vec<ConfigChange>,
+}
+
+impl ConfigDiff {
+    /// Returns true if no fields changed.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.changes.is_empty()
+    }
+
+    /// Returns only the changes that are hot-reloadable (no restart needed).
+    #[must_use]
+    pub fn hot_changes(&self) -> Vec<&ConfigChange> {
+        self.changes
+            .iter()
+            .filter(|c| !c.restart_required)
+            .collect()
+    }
+
+    /// Returns only the changes that require a restart.
+    #[must_use]
+    pub fn cold_changes(&self) -> Vec<&ConfigChange> {
+        self.changes.iter().filter(|c| c.restart_required).collect()
+    }
+}
+
+/// Compare two configs and return the list of changed field paths.
+///
+/// Serializes both configs to JSON and walks the tree to find leaf differences.
+/// Each changed path is classified as hot-reloadable or cold (restart required).
+#[must_use]
+pub fn diff_configs(old: &AletheiaConfig, new: &AletheiaConfig) -> ConfigDiff {
+    let old_value = serde_json::to_value(old).unwrap_or(Value::Null);
+    let new_value = serde_json::to_value(new).unwrap_or(Value::Null);
+
+    let mut changes = Vec::new();
+    diff_values(&old_value, &new_value, String::new(), &mut changes);
+
+    ConfigDiff { changes }
+}
+
+/// Log all changes from a config diff at appropriate levels.
+pub fn log_diff(diff: &ConfigDiff) {
+    if diff.is_empty() {
+        info!("config reload: no changes detected");
+        return;
+    }
+
+    for change in &diff.changes {
+        if change.restart_required {
+            warn!(
+                path = %change.path,
+                "config reload: cold value changed (restart required to take effect)"
+            );
+        } else {
+            info!(path = %change.path, "config reload: value updated");
+        }
+    }
+
+    let hot = diff.hot_changes().len();
+    let cold = diff.cold_changes().len();
+    info!(
+        hot_reloaded = hot,
+        restart_required = cold,
+        "config reload complete"
+    );
+}
+
+/// Errors from config reload attempts.
+#[derive(Debug, Snafu)]
+#[non_exhaustive]
+pub enum ReloadError {
+    /// Failed to load config from disk.
+    #[snafu(display("failed to load config: {source}"))]
+    Load {
+        source: crate::error::Error,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    /// New config failed validation; old config is preserved.
+    #[snafu(display("config validation failed: {source}"))]
+    Validation {
+        source: crate::validate::ValidationError,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+}
+
+/// Outcome of a successful reload preparation.
+pub struct ReloadOutcome {
+    /// The validated new config ready to be swapped in.
+    pub new_config: AletheiaConfig,
+    /// Diff between the old (current) and new config.
+    pub diff: ConfigDiff,
+}
+
+/// Load config from disk, validate, and diff against current.
+///
+/// On success, returns the new config and a diff. The caller is responsible
+/// for atomically swapping the config into the live store and notifying
+/// subscribers.
+///
+/// # Errors
+///
+/// Returns [`ReloadError::Load`] if reading from disk fails.
+/// Returns [`ReloadError::Validation`] if the new config is invalid
+/// (the current config is unchanged).
+#[expect(
+    clippy::result_large_err,
+    reason = "figment::Error is inherently large"
+)]
+pub fn prepare_reload(
+    oikos: &Oikos,
+    current: &AletheiaConfig,
+) -> Result<ReloadOutcome, ReloadError> {
+    use snafu::ResultExt;
+
+    let new_config = crate::loader::load_config(oikos).context(LoadSnafu)?;
+    crate::validate::validate_config(&new_config).context(ValidationSnafu)?;
+
+    let diff = diff_configs(current, &new_config);
+
+    Ok(ReloadOutcome { new_config, diff })
+}
+
+fn diff_values(old: &Value, new: &Value, prefix: String, changes: &mut Vec<ConfigChange>) {
+    match (old, new) {
+        (Value::Object(old_map), Value::Object(new_map)) => {
+            for (key, old_val) in old_map {
+                let path = if prefix.is_empty() {
+                    key.clone()
+                } else {
+                    format!("{prefix}.{key}")
+                };
+                match new_map.get(key) {
+                    Some(new_val) => diff_values(old_val, new_val, path, changes),
+                    None => changes.push(ConfigChange {
+                        restart_required: requires_restart(&path),
+                        path,
+                    }),
+                }
+            }
+            for key in new_map.keys() {
+                if !old_map.contains_key(key) {
+                    let path = if prefix.is_empty() {
+                        key.clone()
+                    } else {
+                        format!("{prefix}.{key}")
+                    };
+                    changes.push(ConfigChange {
+                        restart_required: requires_restart(&path),
+                        path,
+                    });
+                }
+            }
+        }
+        (Value::Array(old_arr), Value::Array(new_arr)) => {
+            if old_arr != new_arr {
+                changes.push(ConfigChange {
+                    restart_required: requires_restart(&prefix),
+                    path: prefix,
+                });
+            }
+        }
+        (old_val, new_val) => {
+            if old_val != new_val {
+                changes.push(ConfigChange {
+                    restart_required: requires_restart(&prefix),
+                    path: prefix,
+                });
+            }
+        }
+    }
+}
+
 #[cfg(test)]
+#[expect(
+    clippy::result_large_err,
+    reason = "figment::Jail closures return Box<dyn Error>; test error size doesn't matter"
+)]
 mod tests {
     use super::*;
 
@@ -63,5 +266,218 @@ mod tests {
     #[test]
     fn embedding_hot_reloadable() {
         assert!(!requires_restart("embedding.provider"));
+    }
+
+    #[test]
+    fn diff_identical_configs_is_empty() {
+        let config = AletheiaConfig::default();
+        let diff = diff_configs(&config, &config);
+        assert!(diff.is_empty(), "identical configs should have no diff");
+    }
+
+    #[test]
+    fn diff_detects_hot_reloadable_change() {
+        let old = AletheiaConfig::default();
+        let mut new = old.clone();
+        new.agents.defaults.thinking_budget = 20_000;
+
+        let diff = diff_configs(&old, &new);
+        assert!(!diff.is_empty(), "changed config should have diff");
+        assert!(
+            diff.hot_changes()
+                .iter()
+                .any(|c| c.path.contains("thinkingBudget")),
+            "thinkingBudget should appear in hot changes"
+        );
+        assert!(
+            diff.cold_changes().is_empty(),
+            "no cold changes expected for agent defaults"
+        );
+    }
+
+    #[test]
+    fn diff_detects_cold_change() {
+        let old = AletheiaConfig::default();
+        let mut new = old.clone();
+        new.gateway.port = 9999;
+
+        let diff = diff_configs(&old, &new);
+        assert!(!diff.is_empty(), "changed config should have diff");
+        assert!(
+            diff.cold_changes()
+                .iter()
+                .any(|c| c.path.contains("gateway.port")),
+            "gateway.port should appear in cold changes"
+        );
+    }
+
+    #[test]
+    fn diff_detects_multiple_changes() {
+        let old = AletheiaConfig::default();
+        let mut new = old.clone();
+        new.agents.defaults.thinking_budget = 20_000;
+        new.gateway.port = 9999;
+        new.maintenance.trace_rotation.max_age_days = 7;
+
+        let diff = diff_configs(&old, &new);
+        assert!(
+            diff.changes.len() >= 3,
+            "expected at least 3 changes, got {}",
+            diff.changes.len()
+        );
+    }
+
+    #[test]
+    fn diff_hot_and_cold_partition_correctly() {
+        let old = AletheiaConfig::default();
+        let mut new = old.clone();
+        new.agents.defaults.max_tool_iterations = 500;
+        new.gateway.port = 9999;
+
+        let diff = diff_configs(&old, &new);
+        let hot = diff.hot_changes();
+        let cold = diff.cold_changes();
+
+        assert!(!hot.is_empty(), "should have hot changes");
+        assert!(!cold.is_empty(), "should have cold changes");
+
+        for c in &hot {
+            assert!(
+                !c.restart_required,
+                "hot change should not require restart: {}",
+                c.path
+            );
+        }
+        for c in &cold {
+            assert!(
+                c.restart_required,
+                "cold change should require restart: {}",
+                c.path
+            );
+        }
+    }
+
+    #[test]
+    fn prepare_reload_succeeds_with_valid_config() {
+        figment::Jail::expect_with(|jail| {
+            std::fs::create_dir_all(jail.directory().join("config")).map_err(|e| e.to_string())?;
+            jail.create_file(
+                "config/aletheia.toml",
+                "[agents.defaults]\nthinkingBudget = 20000\n",
+            )?;
+
+            let oikos = Oikos::from_root(jail.directory());
+            let current = AletheiaConfig::default();
+
+            let outcome = prepare_reload(&oikos, &current).map_err(|e| e.to_string())?;
+            assert!(
+                !outcome.diff.is_empty(),
+                "thinkingBudget change should produce a diff"
+            );
+            assert_eq!(
+                outcome.new_config.agents.defaults.thinking_budget, 20_000,
+                "new config should have updated value"
+            );
+            assert!(
+                outcome.diff.cold_changes().is_empty(),
+                "agent defaults are hot-reloadable"
+            );
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn prepare_reload_rejects_invalid_config() {
+        figment::Jail::expect_with(|jail| {
+            std::fs::create_dir_all(jail.directory().join("config")).map_err(|e| e.to_string())?;
+            // WHY: maxToolIterations=0 is rejected by the validator (must be 1..=10000).
+            jail.create_file(
+                "config/aletheia.toml",
+                "[agents.defaults]\nmaxToolIterations = 0\n",
+            )?;
+
+            let oikos = Oikos::from_root(jail.directory());
+            let current = AletheiaConfig::default();
+
+            let result = prepare_reload(&oikos, &current);
+            assert!(result.is_err(), "invalid config should be rejected");
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn prepare_reload_preserves_current_on_rejection() {
+        figment::Jail::expect_with(|jail| {
+            std::fs::create_dir_all(jail.directory().join("config")).map_err(|e| e.to_string())?;
+            jail.create_file(
+                "config/aletheia.toml",
+                "[agents.defaults]\nmaxToolIterations = 0\n",
+            )?;
+
+            let oikos = Oikos::from_root(jail.directory());
+            let current = AletheiaConfig::default();
+            let original_budget = current.agents.defaults.thinking_budget;
+
+            let _ = prepare_reload(&oikos, &current);
+
+            // Current config is untouched (prepare_reload is pure: it returns
+            // a new config without mutating the current one).
+            assert_eq!(
+                current.agents.defaults.thinking_budget, original_budget,
+                "current config must not be modified on rejection"
+            );
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn prepare_reload_cold_values_appear_in_diff() {
+        figment::Jail::expect_with(|jail| {
+            std::fs::create_dir_all(jail.directory().join("config")).map_err(|e| e.to_string())?;
+            jail.create_file(
+                "config/aletheia.toml",
+                "[gateway]\nport = 9999\n\n[agents.defaults]\nthinkingBudget = 20000\n",
+            )?;
+
+            let oikos = Oikos::from_root(jail.directory());
+            let current = AletheiaConfig::default();
+
+            let outcome = prepare_reload(&oikos, &current).map_err(|e| e.to_string())?;
+
+            let cold = outcome.diff.cold_changes();
+            assert!(
+                cold.iter().any(|c| c.path.contains("gateway.port")),
+                "gateway.port should appear as a cold change"
+            );
+
+            let hot = outcome.diff.hot_changes();
+            assert!(
+                hot.iter().any(|c| c.path.contains("thinkingBudget")),
+                "thinkingBudget should appear as a hot change"
+            );
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn prepare_reload_no_changes_when_config_identical() {
+        figment::Jail::expect_with(|jail| {
+            std::fs::create_dir_all(jail.directory().join("config")).map_err(|e| e.to_string())?;
+            // Write default config to disk so load produces identical config.
+            let default_toml =
+                toml::to_string(&AletheiaConfig::default()).map_err(|e| e.to_string())?;
+            std::fs::write(jail.directory().join("config/aletheia.toml"), default_toml)
+                .map_err(|e| e.to_string())?;
+
+            let oikos = Oikos::from_root(jail.directory());
+            let current = AletheiaConfig::default();
+
+            let outcome = prepare_reload(&oikos, &current).map_err(|e| e.to_string())?;
+            assert!(
+                outcome.diff.is_empty(),
+                "identical config should produce empty diff"
+            );
+            Ok(())
+        });
     }
 }

--- a/crates/taxis/src/validate.rs
+++ b/crates/taxis/src/validate.rs
@@ -3,6 +3,8 @@
 use serde_json::Value;
 use snafu::Snafu;
 
+use crate::config::AletheiaConfig;
+
 /// Validation error with collected messages.
 #[derive(Debug, Snafu)]
 #[snafu(display("config validation failed:\n  - {}", errors.join("\n  - ")))]
@@ -10,6 +12,36 @@ pub struct ValidationError {
     pub errors: Vec<String>,
     #[snafu(implicit)]
     pub location: snafu::Location,
+}
+
+/// Validate an entire [`AletheiaConfig`] by checking each section.
+///
+/// Serializes to JSON and validates each top-level section using
+/// [`validate_section`]. Returns all validation errors collected
+/// across all sections.
+pub fn validate_config(config: &AletheiaConfig) -> Result<(), ValidationError> {
+    let value = serde_json::to_value(config).unwrap_or(Value::Null);
+    let Value::Object(ref sections) = value else {
+        return ValidationSnafu {
+            errors: vec!["config did not serialize to a JSON object".to_owned()],
+        }
+        .fail();
+    };
+
+    let mut all_errors = Vec::new();
+    for (section, val) in sections {
+        if let Err(err) = validate_section(section, val) {
+            for e in err.errors {
+                all_errors.push(format!("{section}: {e}"));
+            }
+        }
+    }
+
+    if all_errors.is_empty() {
+        Ok(())
+    } else {
+        ValidationSnafu { errors: all_errors }.fail()
+    }
 }
 
 /// Validate a config section update.
@@ -32,7 +64,7 @@ pub fn validate_section(section: &str, value: &Value) -> Result<(), ValidationEr
         "bindings" => validate_bindings(value, &mut errors),
         "credential" => validate_credential(value, &mut errors),
         // NOTE: these sections are pass-through with no validation rules
-        "packs" | "pricing" | "sandbox" => {}
+        "packs" | "pricing" | "sandbox" | "logging" | "mcp" => {}
         _ => errors.push(format!("unknown config section: {section}")),
     }
 
@@ -536,5 +568,28 @@ mod tests {
     fn accepts_token_budget_at_maximum() {
         let section = json!({ "defaults": { "contextTokens": 1_000_000_u64 } });
         assert!(validate_section("agents", &section).is_ok());
+    }
+
+    #[test]
+    fn validate_config_accepts_defaults() {
+        let config = AletheiaConfig::default();
+        assert!(
+            validate_config(&config).is_ok(),
+            "default config should be valid"
+        );
+    }
+
+    #[test]
+    fn validate_config_rejects_invalid_tool_iterations() {
+        let mut config = AletheiaConfig::default();
+        config.agents.defaults.max_tool_iterations = 0;
+
+        let result = validate_config(&config);
+        assert!(result.is_err(), "zero maxToolIterations should be rejected");
+        let err = result.unwrap_err();
+        assert!(
+            err.errors.iter().any(|e| e.contains("maxToolIterations")),
+            "error should mention maxToolIterations, got: {err:?}"
+        );
     }
 }

--- a/instance.example/config/aletheia.toml.example
+++ b/instance.example/config/aletheia.toml.example
@@ -4,6 +4,11 @@
 #
 # Config cascade: compiled defaults -> this file -> ALETHEIA_* env vars
 # Most settings have sensible defaults. Only override what you need.
+#
+# Hot reload: send SIGHUP or POST /api/v1/config/reload to apply changes
+# without restart. The following require a full restart:
+#   gateway.port, gateway.bind, gateway.tls, gateway.auth.mode,
+#   gateway.csrf, gateway.bodyLimit, channels
 
 # --- Gateway ---
 [gateway]


### PR DESCRIPTION
## Summary

- Add SIGHUP signal handler and `POST /api/v1/config/reload` endpoint for hot-reloading config without server restart
- Classify config fields as hot-reloadable (agents, maintenance, embedding, pricing, logging, mcp) or cold/restart-required (gateway.port, gateway.bind, gateway.tls, gateway.auth.mode, gateway.csrf, gateway.bodyLimit, channels)
- Add `prepare_reload` orchestrator in taxis: load from disk → validate → diff → return outcome
- Add `validate_config` for whole-config validation (reused by both reload paths)
- Add `watch::Sender<AletheiaConfig>` to AppState for actor config change notifications
- Invalid configs are rejected; old config is preserved with error logged
- Changed values are logged at appropriate levels (info for hot, warn for cold)

## Cold values (require restart)

`gateway.port`, `gateway.bind`, `gateway.tls.*`, `gateway.auth.mode`, `gateway.csrf.*`, `gateway.bodyLimit.*`, `channels.*`

## Observations

- **Debt**: `crates/pylon/src/handlers/knowledge.rs:289` — unused `state` variable, dead functions `get_fact_relationships` (L676) and `get_similar_facts` (L690). Pre-existing, causes clippy warnings.
- **Idea**: Actors could watch `config_rx` to dynamically adjust behavior (e.g., model fallback chain, recall weights) without requiring a full reload cycle through the manager.

## Test plan

- [x] `prepare_reload` succeeds with valid config change (thinking budget)
- [x] `prepare_reload` rejects invalid config (maxToolIterations=0), preserves current
- [x] Cold values (gateway.port) appear correctly in diff
- [x] Hot values (thinkingBudget) appear correctly in diff
- [x] No changes detected when config on disk matches current
- [x] `validate_config` accepts defaults, rejects invalid whole-config
- [x] All 111 taxis tests pass
- [x] Pylon compiles and tests pass

Closes #1449.

🤖 Generated with [Claude Code](https://claude.com/claude-code)