### PR TITLE
perf(mneme): skip graph intelligence recall when weight is 0.0

### DIFF
--- a/crates/mneme/src/graph_intelligence.rs
+++ b/crates/mneme/src/graph_intelligence.rs
@@ -555,10 +555,21 @@ impl crate::knowledge_store::KnowledgeStore {
     ///
     /// Loads cached graph scores, computes BFS proximity from seed entities,
     /// populates context clusters, and computes supersession chain lengths.
+    ///
+    /// Pass the `relationship_proximity_weight` from [`RecallWeights`](crate::recall::RecallWeights)
+    /// so the pipeline can skip all graph traversal when the weight is zero.
+    /// Use [`RecallWeights::graph_recall_active`](crate::recall::RecallWeights::graph_recall_active)
+    /// to pre-check.
     pub fn build_graph_context(
         &self,
         seed_entity_ids: &[String],
+        relationship_proximity_weight: f64,
     ) -> crate::error::Result<GraphContext> {
+        // PERF: skip all graph traversal when the weight is effectively zero.
+        if relationship_proximity_weight < f64::EPSILON {
+            return Ok(GraphContext::default());
+        }
+
         let mut ctx = self.load_graph_context()?;
 
         // Populate context_clusters from seed entities

--- a/crates/mneme/src/graph_intelligence_tests.rs
+++ b/crates/mneme/src/graph_intelligence_tests.rs
@@ -654,7 +654,7 @@ mod engine_tests {
 
         // Build context with a1 as seed
         let ctx = store
-            .build_graph_context(&["a1".to_owned()])
+            .build_graph_context(&["a1".to_owned()], 0.10)
             .expect("build_graph_context");
 
         // a1 should be a seed → its cluster is in context_clusters
@@ -663,6 +663,47 @@ mod engine_tests {
         assert!(
             ctx.same_cluster("a2"),
             "a2 should be in same cluster as seed a1"
+        );
+    }
+
+    #[test]
+    fn build_graph_context_skipped_when_weight_zero() {
+        let store = test_store();
+
+        for (id, name) in [("x1", "X1"), ("x2", "X2")] {
+            store
+                .insert_entity(&make_entity(id, name))
+                .expect("insert entity");
+        }
+        store
+            .insert_relationship(&make_relationship("x1", "x2", "LINKED", 0.8))
+            .expect("insert relationship");
+        store.recompute_graph_scores().expect("recompute");
+
+        // With weight=0.0, build_graph_context returns empty without traversal.
+        let ctx = store
+            .build_graph_context(&["x1".to_owned()], 0.0)
+            .expect("build_graph_context with zero weight");
+        assert!(
+            ctx.is_empty(),
+            "graph context must be empty when weight is zero"
+        );
+        assert!(
+            ctx.proximity.is_empty(),
+            "no BFS proximity should be computed when weight is zero"
+        );
+        assert!(
+            ctx.chain_lengths.is_empty(),
+            "no chain lengths should be computed when weight is zero"
+        );
+
+        // With nonzero weight, graph data should be populated.
+        let ctx_active = store
+            .build_graph_context(&["x1".to_owned()], 0.10)
+            .expect("build_graph_context with nonzero weight");
+        assert!(
+            !ctx_active.is_empty(),
+            "graph context should have data when weight is nonzero"
         );
     }
 

--- a/crates/mneme/src/recall.rs
+++ b/crates/mneme/src/recall.rs
@@ -61,6 +61,17 @@ impl RecallWeights {
             + self.relationship_proximity
             + self.access_frequency
     }
+
+    /// Whether the graph intelligence recall pipeline should run.
+    ///
+    /// Returns `false` when the relationship proximity weight is effectively
+    /// zero, meaning graph traversal results would be multiplied by zero and
+    /// discarded. Callers should skip expensive graph operations (BFS,
+    /// `PageRank`, Louvain) when this returns `false`.
+    #[must_use]
+    pub fn graph_recall_active(&self) -> bool {
+        self.relationship_proximity >= f64::EPSILON
+    }
 }
 
 /// Raw factor scores for a single recall candidate.
@@ -278,10 +289,16 @@ impl RecallEngine {
     ///
     /// Superset of [`score_epistemic_tier`](Self::score_epistemic_tier): calling with `importance=0.0`
     /// produces the same result as the base scorer.
+    ///
+    /// Returns the base tier score directly when graph recall weight is zero.
     #[must_use]
     #[instrument(skip(self))]
     pub fn score_epistemic_tier_with_importance(&self, tier: &str, importance: f64) -> f64 {
         let base = self.score_epistemic_tier(tier);
+        // PERF: skip graph-enhanced scoring when relationship proximity weight is zero.
+        if !self.weights.graph_recall_active() {
+            return base;
+        }
         crate::graph_intelligence::score_epistemic_tier_with_importance(base, importance)
     }
 
@@ -289,6 +306,8 @@ impl RecallEngine {
     ///
     /// Superset of [`score_relationship_proximity`](Self::score_relationship_proximity): calling with `same_cluster=false`
     /// produces the same result as the base scorer.
+    ///
+    /// Returns the base hop score directly when graph recall weight is zero.
     #[must_use]
     #[instrument(skip(self))]
     pub fn score_relationship_proximity_with_cluster(
@@ -297,6 +316,10 @@ impl RecallEngine {
         same_cluster: bool,
     ) -> f64 {
         let base = self.score_relationship_proximity(hops);
+        // PERF: skip graph-enhanced scoring when relationship proximity weight is zero.
+        if !self.weights.graph_recall_active() {
+            return base;
+        }
         crate::graph_intelligence::score_relationship_proximity_with_cluster(base, same_cluster)
     }
 
@@ -304,10 +327,16 @@ impl RecallEngine {
     ///
     /// Superset of [`score_access_frequency`](Self::score_access_frequency): calling with `chain_length=0`
     /// produces the same result as the base scorer.
+    ///
+    /// Returns the base access score directly when graph recall weight is zero.
     #[must_use]
     #[instrument(skip(self))]
     pub fn score_access_with_evolution(&self, access_count: u64, chain_length: u32) -> f64 {
         let base = self.score_access_frequency(access_count);
+        // PERF: skip graph-enhanced scoring when relationship proximity weight is zero.
+        if !self.weights.graph_recall_active() {
+            return base;
+        }
         crate::graph_intelligence::score_access_with_evolution(base, chain_length)
     }
 }

--- a/crates/mneme/src/recall_tests.rs
+++ b/crates/mneme/src/recall_tests.rs
@@ -727,6 +727,89 @@ mod tests {
         assert!((ranked1[0].score - ranked2[0].score).abs() < f64::EPSILON);
     }
 
+    // --- Graph recall skip when weight is zero ---
+
+    #[test]
+    fn graph_recall_active_with_default_weights() {
+        let w = RecallWeights::default();
+        assert!(
+            w.graph_recall_active(),
+            "default relationship_proximity is 0.10, graph recall should be active"
+        );
+    }
+
+    #[test]
+    fn graph_recall_inactive_when_proximity_weight_zero() {
+        let w = RecallWeights {
+            relationship_proximity: 0.0,
+            ..RecallWeights::default()
+        };
+        assert!(
+            !w.graph_recall_active(),
+            "graph recall should be inactive when relationship_proximity is 0.0"
+        );
+    }
+
+    #[test]
+    fn graph_enhanced_scoring_skipped_when_weight_zero() {
+        let weights = RecallWeights {
+            relationship_proximity: 0.0,
+            ..RecallWeights::default()
+        };
+        let e = RecallEngine::with_weights(weights);
+
+        let base_tier = e.score_epistemic_tier("verified");
+        let enhanced_tier = e.score_epistemic_tier_with_importance("verified", 1.0);
+        assert!(
+            (base_tier - enhanced_tier).abs() < f64::EPSILON,
+            "with zero weight, importance boost should be skipped: base={base_tier}, enhanced={enhanced_tier}"
+        );
+
+        let base_prox = e.score_relationship_proximity(None);
+        let enhanced_prox = e.score_relationship_proximity_with_cluster(None, true);
+        assert!(
+            (base_prox - enhanced_prox).abs() < f64::EPSILON,
+            "with zero weight, cluster floor should be skipped: base={base_prox}, enhanced={enhanced_prox}"
+        );
+
+        let base_access = e.score_access_frequency(10);
+        let enhanced_access = e.score_access_with_evolution(10, 4);
+        assert!(
+            (base_access - enhanced_access).abs() < f64::EPSILON,
+            "with zero weight, evolution bonus should be skipped: base={base_access}, enhanced={enhanced_access}"
+        );
+    }
+
+    #[test]
+    fn graph_enhanced_scoring_active_when_weight_nonzero() {
+        let e = engine();
+        assert!(
+            e.weights().graph_recall_active(),
+            "default engine should have graph recall active"
+        );
+
+        let base_tier = e.score_epistemic_tier("inferred");
+        let enhanced_tier = e.score_epistemic_tier_with_importance("inferred", 1.0);
+        assert!(
+            enhanced_tier > base_tier,
+            "with nonzero weight, importance should boost: base={base_tier}, enhanced={enhanced_tier}"
+        );
+
+        let base_prox = e.score_relationship_proximity(None);
+        let enhanced_prox = e.score_relationship_proximity_with_cluster(None, true);
+        assert!(
+            enhanced_prox > base_prox,
+            "with nonzero weight, cluster floor should lift: base={base_prox}, enhanced={enhanced_prox}"
+        );
+
+        let base_access = e.score_access_frequency(10);
+        let enhanced_access = e.score_access_with_evolution(10, 4);
+        assert!(
+            enhanced_access > base_access,
+            "with nonzero weight, evolution bonus should apply: base={base_access}, enhanced={enhanced_access}"
+        );
+    }
+
     // --- Default and builder tests ---
 
     #[test]


### PR DESCRIPTION
## Summary

- Add `RecallWeights::graph_recall_active()` to check if graph recall pipeline should run
- Short-circuit graph-enhanced scoring methods (`score_epistemic_tier_with_importance`, `score_relationship_proximity_with_cluster`, `score_access_with_evolution`) on `RecallEngine` when relationship proximity weight is zero
- Add `relationship_proximity_weight` parameter to `KnowledgeStore::build_graph_context()` to skip BFS, PageRank, and Louvain traversal when weight is effectively zero

Closes #1447.

## Test plan

- [x] `graph_recall_active_with_default_weights` -- default weight (0.10) reports active
- [x] `graph_recall_inactive_when_proximity_weight_zero` -- zero weight reports inactive
- [x] `graph_enhanced_scoring_skipped_when_weight_zero` -- all three graph-enhanced scorers return base score when weight is zero
- [x] `graph_enhanced_scoring_active_when_weight_nonzero` -- normal behavior preserved with default weights
- [x] `build_graph_context_skipped_when_weight_zero` (mneme-engine) -- returns empty `GraphContext` without graph traversal when weight is zero; populates data when nonzero
- [x] All 891 existing + new tests pass (`cargo test -p aletheia-mneme`)

## Observations

- **Debt**: `crates/aletheia/src/commands/server.rs:697` -- pre-existing compilation error: missing `egress` and `egress_allowlist` fields in `SandboxConfig` initializer (unrelated to this PR)
- **Debt**: `crates/mneme/src/graph_intelligence.rs` -- 9 dead_code warnings on constants (`GRAPH_SCORES_DDL`, etc.) when compiled with `--all-targets` without `mneme-engine` feature; the `#[cfg_attr(not(test), expect(dead_code))]` attribute at module level doesn't suppress in test cfg

🤖 Generated with [Claude Code](https://claude.com/claude-code)