### PR TITLE
feat(koina): add RedactingLayer for tracing field redaction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -212,6 +212,7 @@ dependencies = [
  "serde_json",
  "snafu",
  "static_assertions",
+ "tracing",
  "tracing-subscriber",
  "ulid",
 ]

--- a/crates/aletheia/src/commands/server.rs
+++ b/crates/aletheia/src/commands/server.rs
@@ -23,6 +23,7 @@ use aletheia_agora::types::ChannelProvider;
 use aletheia_hermeneus::anthropic::AnthropicProvider;
 use aletheia_hermeneus::provider::{ProviderConfig, ProviderRegistry};
 use aletheia_koina::credential::{CredentialProvider, CredentialSource};
+use aletheia_koina::redacting_layer::RedactingLayer;
 use aletheia_mneme::embedding::{EmbeddingConfig, EmbeddingProvider, create_provider};
 use aletheia_mneme::store::SessionStore;
 use aletheia_nous::config::{NousConfig, PipelineConfig};
@@ -86,6 +87,7 @@ pub async fn run(args: Args) -> Result<()> {
         args.json_logs,
         &log_dir,
         &config.logging.level,
+        &config.logging.redaction,
     )
     .context("failed to initialise file logging")?;
 
@@ -868,6 +870,7 @@ fn init_tracing(
     json: bool,
     log_dir: &Path,
     file_level: &str,
+    redaction: &aletheia_taxis::config::RedactionSettings,
 ) -> Result<WorkerGuard> {
     // Console filter: respect RUST_LOG env var, fall back to the CLI level.
     let console_filter = EnvFilter::try_from_default_env()
@@ -884,14 +887,6 @@ fn init_tracing(
     // The non_blocking wrapper offloads writes to a background thread.
     let file_appender = tracing_appender::rolling::daily(log_dir, "aletheia.log");
     let (non_blocking, guard) = tracing_appender::non_blocking(file_appender);
-
-    // File layer: always JSON for machine-readable structured output.
-    let file_layer = fmt::layer()
-        .json()
-        .with_ansi(false)
-        .with_target(true)
-        .with_writer(non_blocking)
-        .with_filter(file_filter);
 
     // Console layers: exactly one is Some, the other None.
     // Option<L> implements Layer<S> as a no-op when None, so both arms compose
@@ -912,12 +907,37 @@ fn init_tracing(
             .with_filter(console_filter)
     });
 
-    tracing_subscriber::registry()
-        .with(json_console)
-        .with(text_console)
-        .with(file_layer)
-        .try_init()
-        .context("failed to set global tracing subscriber")?;
+    // File layer: redacting or plain depending on config.
+    if redaction.enabled {
+        let redacting = RedactingLayer::new(
+            non_blocking,
+            redaction.redact_fields.iter().cloned(),
+            redaction.truncate_fields.iter().cloned(),
+            redaction.truncate_length,
+        )
+        .with_filter(file_filter);
+
+        tracing_subscriber::registry()
+            .with(json_console)
+            .with(text_console)
+            .with(redacting)
+            .try_init()
+            .context("failed to set global tracing subscriber")?;
+    } else {
+        let file_layer = fmt::layer()
+            .json()
+            .with_ansi(false)
+            .with_target(true)
+            .with_writer(non_blocking)
+            .with_filter(file_filter);
+
+        tracing_subscriber::registry()
+            .with(json_console)
+            .with(text_console)
+            .with(file_layer)
+            .try_init()
+            .context("failed to set global tracing subscriber")?;
+    }
 
     Ok(guard)
 }

--- a/crates/koina/Cargo.toml
+++ b/crates/koina/Cargo.toml
@@ -16,6 +16,7 @@ regex = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 snafu = { workspace = true }
+tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 ulid = { workspace = true }
 

--- a/crates/koina/src/lib.rs
+++ b/crates/koina/src/lib.rs
@@ -12,6 +12,8 @@ pub mod error;
 pub mod id;
 /// Sensitive value redaction for safe log output (API keys, tokens, passwords).
 pub mod redact;
+/// Tracing layer that redacts sensitive field values before output.
+pub mod redacting_layer;
 /// Tracing subscriber initialization for human-readable and JSON log output.
 pub mod tracing_init;
 

--- a/crates/koina/src/redacting_layer.rs
+++ b/crates/koina/src/redacting_layer.rs
@@ -1,0 +1,406 @@
+//! Tracing layer that redacts sensitive field values before output.
+//!
+//! Sits in the subscriber stack as the file-output layer when redaction is
+//! enabled. Fields matching configured names are replaced or truncated, and
+//! all string values are scanned for API key patterns.
+
+use std::collections::HashSet;
+use std::fmt as stdfmt;
+use std::io::Write;
+use std::sync::Mutex;
+use std::time::SystemTime;
+
+use serde_json::{Map, Value};
+use tracing::field::{Field, Visit};
+use tracing::span::{Attributes, Id, Record};
+use tracing::{Event, Subscriber};
+use tracing_subscriber::Layer;
+use tracing_subscriber::layer::Context;
+use tracing_subscriber::registry::LookupSpan;
+
+use crate::redact::redact_sensitive;
+
+/// Redacted field storage attached to spans via extensions.
+#[derive(Default, Clone)]
+struct RedactedSpanFields {
+    fields: Map<String, Value>,
+}
+
+/// Tracing layer that redacts sensitive field values in structured JSON output.
+///
+/// Fields matching `redact_fields` have their values replaced with
+/// `[REDACTED]`. Fields matching `truncate_fields` are capped at
+/// `truncate_length` characters. All string values are scanned for API key
+/// patterns via [`redact_sensitive`].
+pub struct RedactingLayer<W> {
+    writer: Mutex<W>,
+    redact_fields: HashSet<String>,
+    truncate_fields: HashSet<String>,
+    truncate_length: usize,
+}
+
+impl<W> RedactingLayer<W> {
+    /// Create a redacting layer that writes JSON to the given writer.
+    pub fn new(
+        writer: W,
+        redact_fields: impl IntoIterator<Item = String>,
+        truncate_fields: impl IntoIterator<Item = String>,
+        truncate_length: usize,
+    ) -> Self {
+        Self {
+            writer: Mutex::new(writer),
+            redact_fields: redact_fields.into_iter().collect(),
+            truncate_fields: truncate_fields.into_iter().collect(),
+            truncate_length,
+        }
+    }
+
+    fn make_visitor(&self) -> RedactingVisitor<'_> {
+        RedactingVisitor {
+            fields: Map::new(),
+            redact_fields: &self.redact_fields,
+            truncate_fields: &self.truncate_fields,
+            truncate_length: self.truncate_length,
+        }
+    }
+}
+
+struct RedactingVisitor<'a> {
+    fields: Map<String, Value>,
+    redact_fields: &'a HashSet<String>,
+    truncate_fields: &'a HashSet<String>,
+    truncate_length: usize,
+}
+
+impl RedactingVisitor<'_> {
+    fn redact_string(&self, name: &str, value: &str) -> Value {
+        if self.redact_fields.contains(name) {
+            return Value::String("[REDACTED]".to_owned());
+        }
+        let redacted = redact_sensitive(value);
+        if self.truncate_fields.contains(name) && redacted.len() > self.truncate_length {
+            let truncated: String = redacted.chars().take(self.truncate_length).collect();
+            return Value::String(format!("{truncated}[TRUNCATED]"));
+        }
+        Value::String(redacted)
+    }
+}
+
+impl Visit for RedactingVisitor<'_> {
+    fn record_debug(&mut self, field: &Field, value: &dyn stdfmt::Debug) {
+        let s = format!("{value:?}");
+        let redacted = self.redact_string(field.name(), &s);
+        self.fields.insert(field.name().to_owned(), redacted);
+    }
+
+    fn record_str(&mut self, field: &Field, value: &str) {
+        let redacted = self.redact_string(field.name(), value);
+        self.fields.insert(field.name().to_owned(), redacted);
+    }
+
+    fn record_i64(&mut self, field: &Field, value: i64) {
+        if self.redact_fields.contains(field.name()) {
+            self.fields.insert(
+                field.name().to_owned(),
+                Value::String("[REDACTED]".to_owned()),
+            );
+        } else {
+            self.fields
+                .insert(field.name().to_owned(), Value::from(value));
+        }
+    }
+
+    fn record_u64(&mut self, field: &Field, value: u64) {
+        if self.redact_fields.contains(field.name()) {
+            self.fields.insert(
+                field.name().to_owned(),
+                Value::String("[REDACTED]".to_owned()),
+            );
+        } else {
+            self.fields
+                .insert(field.name().to_owned(), Value::from(value));
+        }
+    }
+
+    fn record_f64(&mut self, field: &Field, value: f64) {
+        if self.redact_fields.contains(field.name()) {
+            self.fields.insert(
+                field.name().to_owned(),
+                Value::String("[REDACTED]".to_owned()),
+            );
+        } else {
+            self.fields.insert(
+                field.name().to_owned(),
+                serde_json::Number::from_f64(value).map_or(Value::Null, Value::Number),
+            );
+        }
+    }
+
+    fn record_bool(&mut self, field: &Field, value: bool) {
+        if self.redact_fields.contains(field.name()) {
+            self.fields.insert(
+                field.name().to_owned(),
+                Value::String("[REDACTED]".to_owned()),
+            );
+        } else {
+            self.fields
+                .insert(field.name().to_owned(), Value::Bool(value));
+        }
+    }
+}
+
+fn epoch_secs() -> f64 {
+    SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs_f64()
+}
+
+impl<S, W> Layer<S> for RedactingLayer<W>
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+    W: Write + Send + 'static,
+{
+    fn on_new_span(&self, attrs: &Attributes<'_>, id: &Id, ctx: Context<'_, S>) {
+        let mut visitor = self.make_visitor();
+        attrs.record(&mut visitor);
+        if let Some(span) = ctx.span(id) {
+            span.extensions_mut().insert(RedactedSpanFields {
+                fields: visitor.fields,
+            });
+        }
+    }
+
+    fn on_record(&self, id: &Id, values: &Record<'_>, ctx: Context<'_, S>) {
+        let mut visitor = self.make_visitor();
+        values.record(&mut visitor);
+        if let Some(span) = ctx.span(id) {
+            let mut ext = span.extensions_mut();
+            if let Some(existing) = ext.get_mut::<RedactedSpanFields>() {
+                existing.fields.extend(visitor.fields);
+            } else {
+                ext.insert(RedactedSpanFields {
+                    fields: visitor.fields,
+                });
+            }
+        }
+    }
+
+    fn on_event(&self, event: &Event<'_>, ctx: Context<'_, S>) {
+        let mut visitor = self.make_visitor();
+        event.record(&mut visitor);
+
+        let meta = event.metadata();
+        let mut output = Map::new();
+        output.insert("timestamp".to_owned(), Value::from(epoch_secs()));
+        output.insert("level".to_owned(), Value::String(meta.level().to_string()));
+        output.insert("target".to_owned(), Value::String(meta.target().to_owned()));
+        output.insert("fields".to_owned(), Value::Object(visitor.fields));
+
+        if let Some(scope) = ctx.event_scope(event) {
+            let spans: Vec<Value> = scope
+                .from_root()
+                .map(|span| {
+                    let mut span_obj = Map::new();
+                    span_obj.insert("name".to_owned(), Value::String(span.name().to_owned()));
+                    let ext = span.extensions();
+                    if let Some(redacted) = ext.get::<RedactedSpanFields>() {
+                        for (k, v) in &redacted.fields {
+                            span_obj.insert(k.clone(), v.clone());
+                        }
+                    }
+                    Value::Object(span_obj)
+                })
+                .collect();
+            if !spans.is_empty() {
+                output.insert("spans".to_owned(), Value::Array(spans));
+            }
+        }
+
+        let json = Value::Object(output);
+        // WHY: Logging must never crash the application. Write failures
+        // in the tracing pipeline are silently dropped.
+        let Ok(mut writer) = self.writer.lock() else {
+            return;
+        };
+        let _ = serde_json::to_writer(&mut *writer, &json);
+        let _ = writer.write_all(b"\n");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+    use tracing_subscriber::layer::SubscriberExt;
+
+    #[derive(Clone)]
+    struct TestWriter(Arc<Mutex<Vec<u8>>>);
+
+    impl Write for TestWriter {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            let Ok(mut inner) = self.0.lock() else {
+                return Ok(buf.len());
+            };
+            inner.extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    fn setup(
+        redact_fields: &[&str],
+        truncate_fields: &[&str],
+        truncate_length: usize,
+    ) -> (Arc<Mutex<Vec<u8>>>, impl Subscriber) {
+        let buffer = Arc::new(Mutex::new(Vec::new()));
+        let layer = RedactingLayer::new(
+            TestWriter(Arc::clone(&buffer)),
+            redact_fields.iter().map(|s| (*s).to_owned()),
+            truncate_fields.iter().map(|s| (*s).to_owned()),
+            truncate_length,
+        );
+        (buffer, tracing_subscriber::registry().with(layer))
+    }
+
+    fn output_string(buffer: &Arc<Mutex<Vec<u8>>>) -> String {
+        let guard = buffer.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        String::from_utf8_lossy(&guard).into_owned()
+    }
+
+    #[test]
+    fn redacts_sensitive_field_names() {
+        let (buf, sub) = setup(&["token", "api_key", "password"], &[], 200);
+        tracing::subscriber::with_default(sub, || {
+            tracing::info!(token = "sk-secret-value", "check redaction");
+        });
+        let out = output_string(&buf);
+        assert!(
+            out.contains("[REDACTED]"),
+            "token field value must be redacted: {out}"
+        );
+        assert!(
+            !out.contains("sk-secret-value"),
+            "original value must not appear: {out}"
+        );
+    }
+
+    #[test]
+    fn redacts_api_key_patterns_in_any_field() {
+        let (buf, sub) = setup(&[], &[], 200);
+        tracing::subscriber::with_default(sub, || {
+            tracing::info!(
+                details = "key is sk-proj-abcdefghij1234567890abcdef end",
+                "api check"
+            );
+        });
+        let out = output_string(&buf);
+        assert!(
+            !out.contains("abcdefghij1234567890"),
+            "API key pattern must be scrubbed: {out}"
+        );
+    }
+
+    #[test]
+    fn truncates_long_content_fields() {
+        let (buf, sub) = setup(&[], &["body"], 20);
+        let long_value = "a".repeat(100);
+        tracing::subscriber::with_default(sub, || {
+            tracing::info!(body = long_value.as_str(), "truncation check");
+        });
+        let out = output_string(&buf);
+        assert!(
+            out.contains("[TRUNCATED]"),
+            "long body must be truncated: {out}"
+        );
+        assert!(
+            !out.contains(&"a".repeat(100)),
+            "full value must not appear: {out}"
+        );
+    }
+
+    #[test]
+    fn does_not_truncate_short_content() {
+        let (buf, sub) = setup(&[], &["body"], 200);
+        tracing::subscriber::with_default(sub, || {
+            tracing::info!(body = "short text", "no truncation");
+        });
+        let out = output_string(&buf);
+        assert!(
+            out.contains("short text"),
+            "short value must pass through: {out}"
+        );
+        assert!(
+            !out.contains("[TRUNCATED]"),
+            "short value must not be truncated: {out}"
+        );
+    }
+
+    #[test]
+    fn preserves_non_sensitive_fields() {
+        let (buf, sub) = setup(&["token"], &[], 200);
+        tracing::subscriber::with_default(sub, || {
+            tracing::info!(session_id = "abc-123", token = "secret", "mixed fields");
+        });
+        let out = output_string(&buf);
+        assert!(
+            out.contains("abc-123"),
+            "non-sensitive field must pass through: {out}"
+        );
+        assert!(
+            !out.contains("secret"),
+            "sensitive field must be redacted: {out}"
+        );
+    }
+
+    #[test]
+    fn includes_metadata_in_output() {
+        let (buf, sub) = setup(&[], &[], 200);
+        tracing::subscriber::with_default(sub, || {
+            tracing::warn!(count = 42_u64, "warning event");
+        });
+        let out = output_string(&buf);
+        assert!(out.contains("WARN"), "level must be present: {out}");
+        assert!(
+            out.contains("timestamp"),
+            "timestamp must be present: {out}"
+        );
+        assert!(out.contains("target"), "target must be present: {out}");
+    }
+
+    #[test]
+    fn redacts_numeric_secret_fields() {
+        let (buf, sub) = setup(&["secret"], &[], 200);
+        tracing::subscriber::with_default(sub, || {
+            tracing::info!(secret = 42_i64, "numeric secret");
+        });
+        let out = output_string(&buf);
+        assert!(
+            out.contains("[REDACTED]"),
+            "numeric secret must be redacted: {out}"
+        );
+    }
+
+    #[test]
+    fn includes_span_context_in_events() {
+        let (buf, sub) = setup(&["token"], &[], 200);
+        tracing::subscriber::with_default(sub, || {
+            let span = tracing::info_span!("request", token = "secret-tok", req_id = "r1");
+            let _guard = span.enter();
+            tracing::info!("inside span");
+        });
+        let out = output_string(&buf);
+        assert!(out.contains("request"), "span name must appear: {out}");
+        assert!(
+            out.contains("r1"),
+            "non-sensitive span field must appear: {out}"
+        );
+        assert!(
+            !out.contains("secret-tok"),
+            "sensitive span field must be redacted: {out}"
+        );
+    }
+}

--- a/crates/taxis/src/config.rs
+++ b/crates/taxis/src/config.rs
@@ -796,6 +796,8 @@ pub struct LoggingSettings {
     /// `"aletheia=debug,warn"`). Default: `"warn"`, which captures WARN and
     /// ERROR events from all crates regardless of the console log level.
     pub level: String,
+    /// Redaction settings for tracing spans and events.
+    pub redaction: RedactionSettings,
 }
 
 impl Default for LoggingSettings {
@@ -804,6 +806,51 @@ impl Default for LoggingSettings {
             log_dir: None,
             retention_days: 14,
             level: "warn".to_owned(),
+            redaction: RedactionSettings::default(),
+        }
+    }
+}
+
+/// Controls redaction of sensitive data in tracing output.
+///
+/// When enabled, field values matching sensitive names are replaced with
+/// `[REDACTED]`, API key patterns are scrubbed, and long content fields
+/// are truncated before reaching any subscriber.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[serde(default)]
+pub struct RedactionSettings {
+    /// Master switch for the redaction layer. Default: `true`.
+    pub enabled: bool,
+    /// Field names whose values are replaced with `[REDACTED]`.
+    pub redact_fields: Vec<String>,
+    /// Field names whose values are truncated to `truncate_length` chars.
+    pub truncate_fields: Vec<String>,
+    /// Maximum character length for truncated fields. Default: 200.
+    pub truncate_length: usize,
+}
+
+impl Default for RedactionSettings {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            redact_fields: vec![
+                "token".to_owned(),
+                "api_key".to_owned(),
+                "secret".to_owned(),
+                "password".to_owned(),
+                "bearer".to_owned(),
+                "authorization".to_owned(),
+                "credential".to_owned(),
+            ],
+            truncate_fields: vec![
+                "message".to_owned(),
+                "content".to_owned(),
+                "body".to_owned(),
+                "input".to_owned(),
+                "output".to_owned(),
+            ],
+            truncate_length: 200,
         }
     }
 }


### PR DESCRIPTION
## Summary

- Add `RedactingLayer` implementing `tracing_subscriber::Layer` in `aletheia-koina` that intercepts `on_new_span`, `on_record`, and `on_event` to redact sensitive field values before they reach log files
- Add `RedactionSettings` config struct to `aletheia-taxis` with TOML-configurable field lists, truncation length, and enable/disable toggle
- Wire the layer into the subscriber stack in `server.rs`, replacing the plain `fmt::Layer` for file output when redaction is enabled

### Redaction rules

- Fields named `token`, `api_key`, `secret`, `password`, `bearer`, `authorization`, `credential` → `[REDACTED]`
- Fields named `message`, `content`, `body`, `input`, `output` → truncated to 200 chars with `[TRUNCATED]`
- API key patterns (`sk-*`, `sk-ant-*`, Bearer tokens, JWTs) caught by regex in all string values via existing `koina::redact::redact_sensitive`
- Numeric and boolean values on secret fields also redacted
- Span context included in event output with redacted span fields

### Config

```toml
[logging.redaction]
enabled = true
redact_fields = ["token", "api_key", "secret", "password", "bearer", "authorization", "credential"]
truncate_fields = ["message", "content", "body", "input", "output"]
truncate_length = 200
```

Closes #1433.

## Test plan

- [x] 8 unit tests in `redacting_layer::tests` covering:
  - Sensitive field name redaction
  - API key pattern scrubbing in arbitrary fields
  - Long content truncation with `[TRUNCATED]` marker
  - Short content pass-through (no false truncation)
  - Non-sensitive field preservation
  - Metadata (level, timestamp, target) in output
  - Numeric field redaction
  - Span context with mixed sensitive/non-sensitive fields
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy -p aletheia-koina -p aletheia --all-targets -- -D warnings` passes
- [x] `cargo test -p aletheia-koina` passes (51 tests)
- [x] Pre-existing integration test failure on main confirmed unrelated (reqwest TLS provider)

## Observations

- **Bug**: `integration_server` test fails on main with "No provider set" (reqwest TLS), unrelated to this PR
- **Idea**: Console layers could also benefit from redaction; currently only file output is redacted (crates/aletheia/src/commands/server.rs:903)

🤖 Generated with [Claude Code](https://claude.com/claude-code)