### PR TITLE
feat(taxis): add encryption at rest for sensitive config fields

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -408,8 +408,11 @@ dependencies = [
 name = "aletheia-taxis"
 version = "0.12.0"
 dependencies = [
+ "base64 0.22.1",
  "figment",
  "proptest",
+ "rand 0.9.2",
+ "ring",
  "serde",
  "serde_json",
  "snafu",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,6 +131,7 @@ tokio-util = { version = "0.7", features = ["rt"] }
 flate2 = "1"
 
 # TLS / Security
+ring = "0.17"
 rustls = { version = "0.23", default-features = false, features = ["ring", "std", "logging", "tls12"] }
 rcgen = "0.14"
 regex = "1"

--- a/crates/aletheia/src/commands/config.rs
+++ b/crates/aletheia/src/commands/config.rs
@@ -1,0 +1,72 @@
+//! `aletheia config`: encryption key management and config encryption.
+
+use std::path::PathBuf;
+
+use anyhow::Result;
+use clap::Subcommand;
+
+use aletheia_taxis::encrypt;
+use aletheia_taxis::oikos::Oikos;
+
+#[derive(Debug, Clone, Subcommand)]
+pub enum Action {
+    /// Generate a new master encryption key
+    InitKey,
+    /// Encrypt sensitive plaintext values in aletheia.toml
+    Encrypt,
+}
+
+pub fn run(action: &Action, instance_root: Option<&PathBuf>) -> Result<()> {
+    match action {
+        Action::InitKey => run_init_key(),
+        Action::Encrypt => run_encrypt(instance_root),
+    }
+}
+
+fn run_init_key() -> Result<()> {
+    let key_path = encrypt::master_key_path()
+        .ok_or_else(|| anyhow::anyhow!("cannot determine key path: HOME not set"))?;
+
+    println!("Generating master key at {}", key_path.display());
+    encrypt::generate_master_key(&key_path)?;
+    println!("Master key generated.");
+    println!("  Permissions: 0600 (owner read/write only)");
+    println!(
+        "  Back up this file securely. Without it, encrypted config values cannot be recovered."
+    );
+    Ok(())
+}
+
+fn run_encrypt(instance_root: Option<&PathBuf>) -> Result<()> {
+    let oikos = match instance_root {
+        Some(root) => Oikos::from_root(root),
+        None => Oikos::discover(),
+    };
+
+    let key_path = encrypt::master_key_path()
+        .ok_or_else(|| anyhow::anyhow!("cannot determine key path: HOME not set"))?;
+
+    let master_key = encrypt::load_master_key(&key_path)?.ok_or_else(|| {
+        anyhow::anyhow!(
+            "no master key found at {}\n  Run `aletheia config init-key` first.",
+            key_path.display()
+        )
+    })?;
+
+    let toml_path = oikos.config().join("aletheia.toml");
+    if !toml_path.exists() {
+        anyhow::bail!("config file not found: {}", toml_path.display());
+    }
+
+    let count = encrypt::encrypt_config_file(&toml_path, &master_key)?;
+
+    if count == 0 {
+        println!("No plaintext sensitive values found to encrypt.");
+    } else {
+        println!(
+            "Encrypted {count} sensitive value(s) in {}",
+            toml_path.display()
+        );
+    }
+    Ok(())
+}

--- a/crates/aletheia/src/commands/mod.rs
+++ b/crates/aletheia/src/commands/mod.rs
@@ -4,6 +4,7 @@ pub mod add_nous;
 pub mod agent_io;
 pub mod backup;
 pub mod check_config;
+pub mod config;
 pub mod credential;
 pub mod eval;
 pub mod health;

--- a/crates/aletheia/src/main.rs
+++ b/crates/aletheia/src/main.rs
@@ -24,6 +24,7 @@ use commands::agent_io::{
     SeedSkillsArgs, TuiArgs,
 };
 use commands::backup::BackupArgs;
+use commands::config;
 use commands::credential;
 use commands::eval::EvalArgs;
 use commands::health::HealthArgs;
@@ -112,6 +113,11 @@ enum Command {
     },
     /// Validate configuration without starting any services
     CheckConfig,
+    /// Config encryption management
+    Config {
+        #[command(subcommand)]
+        action: config::Action,
+    },
     /// Scaffold a new nous agent directory
     AddNous(AddNousArgs),
 }
@@ -187,6 +193,9 @@ async fn main() -> Result<()> {
         }
         Some(Command::CheckConfig) => {
             return commands::check_config::run(instance_root);
+        }
+        Some(Command::Config { action }) => {
+            return commands::config::run(&action, instance_root);
         }
         Some(Command::AddNous(a)) => {
             return commands::add_nous::run(instance_root, &a).await;

--- a/crates/taxis/Cargo.toml
+++ b/crates/taxis/Cargo.toml
@@ -11,7 +11,10 @@ rust-version.workspace = true
 workspace = true
 
 [dependencies]
+base64 = { workspace = true }
 figment = { workspace = true }
+rand = { workspace = true }
+ring = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 snafu = { workspace = true }

--- a/crates/taxis/src/encrypt.rs
+++ b/crates/taxis/src/encrypt.rs
@@ -1,0 +1,684 @@
+//! Encryption at rest for sensitive configuration fields.
+//!
+//! Sensitive values in `aletheia.toml` (API keys, signing keys, secrets) can be
+//! encrypted with a master key. Encrypted values are stored with an `enc:` prefix
+//! followed by base64-encoded ciphertext. On config load, `enc:` values are
+//! transparently decrypted. If the master key is missing, encrypted values pass
+//! through as-is with a warning.
+
+use std::path::{Path, PathBuf};
+
+use base64::Engine as _;
+use ring::aead::{Aad, CHACHA20_POLY1305, LessSafeKey, NONCE_LEN, Nonce, UnboundKey};
+use ring::rand::{SecureRandom, SystemRandom};
+use snafu::ResultExt;
+use tracing::warn;
+
+use crate::error::{self, Result};
+
+/// Prefix marking an encrypted config value.
+pub const ENCRYPTED_PREFIX: &str = "enc:";
+
+/// Length of the ChaCha20-Poly1305 key in bytes.
+const KEY_LEN: usize = 32;
+
+/// Default path for the master key file.
+fn default_key_path() -> Option<PathBuf> {
+    std::env::var_os("HOME").map(|home| {
+        PathBuf::from(home)
+            .join(".config")
+            .join("aletheia")
+            .join("master.key")
+    })
+}
+
+/// Resolve the master key file path.
+///
+/// Checks `ALETHEIA_MASTER_KEY` env var first, then falls back to
+/// `~/.config/aletheia/master.key`.
+#[must_use]
+pub fn master_key_path() -> Option<PathBuf> {
+    std::env::var_os("ALETHEIA_MASTER_KEY")
+        .map(PathBuf::from)
+        .or_else(default_key_path)
+}
+
+/// Load the 32-byte master key from the key file.
+///
+/// The file must contain exactly 64 hex characters (32 bytes).
+/// Returns `None` if the file does not exist.
+///
+/// # Errors
+///
+/// Returns an error if the file exists but cannot be read or contains
+/// invalid hex data.
+#[expect(
+    clippy::result_large_err,
+    reason = "taxis Error is inherently large due to PathBuf fields"
+)]
+pub fn load_master_key(path: &Path) -> Result<Option<[u8; KEY_LEN]>> {
+    if !path.exists() {
+        return Ok(None);
+    }
+
+    let contents = std::fs::read_to_string(path).context(error::ReadConfigSnafu {
+        path: path.to_path_buf(),
+    })?;
+    let hex = contents.trim();
+    parse_hex_key(hex, path)
+}
+
+#[expect(
+    clippy::result_large_err,
+    reason = "taxis Error is inherently large due to PathBuf fields"
+)]
+fn parse_hex_key(hex: &str, path: &Path) -> Result<Option<[u8; KEY_LEN]>> {
+    if hex.len() != KEY_LEN * 2 {
+        return Err(error::InvalidMasterKeySnafu {
+            path: path.to_path_buf(),
+            reason: format!("expected {} hex characters, got {}", KEY_LEN * 2, hex.len()),
+        }
+        .build());
+    }
+
+    let mut key = [0u8; KEY_LEN];
+    for (i, chunk) in hex.as_bytes().chunks(2).enumerate() {
+        let hi = hex_digit(chunk[0]).ok_or_else(|| {
+            error::InvalidMasterKeySnafu {
+                path: path.to_path_buf(),
+                reason: format!("invalid hex character at position {}", i * 2),
+            }
+            .build()
+        })?;
+        let lo = hex_digit(chunk[1]).ok_or_else(|| {
+            error::InvalidMasterKeySnafu {
+                path: path.to_path_buf(),
+                reason: format!("invalid hex character at position {}", i * 2 + 1),
+            }
+            .build()
+        })?;
+        key[i] = (hi << 4) | lo;
+    }
+
+    Ok(Some(key))
+}
+
+fn hex_digit(b: u8) -> Option<u8> {
+    match b {
+        b'0'..=b'9' => Some(b - b'0'),
+        b'a'..=b'f' => Some(b - b'a' + 10),
+        b'A'..=b'F' => Some(b - b'A' + 10),
+        _ => None,
+    }
+}
+
+fn to_hex(bytes: &[u8]) -> String {
+    let mut s = String::with_capacity(bytes.len() * 2);
+    for &b in bytes {
+        s.push(char::from(b"0123456789abcdef"[usize::from(b >> 4)]));
+        s.push(char::from(b"0123456789abcdef"[usize::from(b & 0x0f)]));
+    }
+    s
+}
+
+/// Generate a new random master key and write it to the given path.
+///
+/// Creates parent directories and sets file permissions to 0600.
+///
+/// # Errors
+///
+/// Returns an error if the file already exists, the directory cannot be
+/// created, or the file cannot be written.
+#[expect(
+    clippy::result_large_err,
+    reason = "taxis Error is inherently large due to PathBuf fields"
+)]
+pub fn generate_master_key(path: &Path) -> Result<()> {
+    if path.exists() {
+        return Err(error::MasterKeyExistsSnafu {
+            path: path.to_path_buf(),
+        }
+        .build());
+    }
+
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).context(error::WriteConfigSnafu {
+            path: parent.to_path_buf(),
+        })?;
+    }
+
+    let rng = SystemRandom::new();
+    let mut key = [0u8; KEY_LEN];
+    // WHY: ring::error::Unspecified has no useful fields to propagate
+    rng.fill(&mut key).map_err(|_unspecified| {
+        error::EncryptSnafu {
+            reason: "failed to generate random key".to_owned(),
+        }
+        .build()
+    })?;
+
+    let hex = to_hex(&key);
+    std::fs::write(path, hex.as_bytes()).context(error::WriteConfigSnafu {
+        path: path.to_path_buf(),
+    })?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600)).context(
+            error::WriteConfigSnafu {
+                path: path.to_path_buf(),
+            },
+        )?;
+    }
+
+    Ok(())
+}
+
+/// Whether a string value is encrypted (starts with `enc:`).
+#[must_use]
+pub fn is_encrypted(value: &str) -> bool {
+    value.starts_with(ENCRYPTED_PREFIX)
+}
+
+/// Encrypt a plaintext string value using ChaCha20-Poly1305.
+///
+/// Returns `enc:` + base64(nonce || ciphertext+tag).
+///
+/// # Errors
+///
+/// Returns an error if encryption fails.
+#[expect(
+    clippy::result_large_err,
+    reason = "taxis Error is inherently large due to PathBuf fields"
+)]
+pub fn encrypt_value(plaintext: &str, master_key: &[u8; KEY_LEN]) -> Result<String> {
+    // WHY: ring::error::Unspecified has no useful fields to propagate
+    let unbound = UnboundKey::new(&CHACHA20_POLY1305, master_key)
+        .map_err(|_unspecified| build_encrypt_error())?;
+    let key = LessSafeKey::new(unbound);
+
+    let rng = SystemRandom::new();
+    let mut nonce_bytes = [0u8; NONCE_LEN];
+    rng.fill(&mut nonce_bytes)
+        .map_err(|_unspecified| build_encrypt_error())?;
+
+    let nonce = Nonce::assume_unique_for_key(nonce_bytes);
+
+    let mut in_out = plaintext.as_bytes().to_vec();
+    key.seal_in_place_append_tag(nonce, Aad::empty(), &mut in_out)
+        .map_err(|_unspecified| build_encrypt_error())?;
+
+    // nonce || ciphertext+tag
+    let mut payload = Vec::with_capacity(NONCE_LEN + in_out.len());
+    payload.extend_from_slice(&nonce_bytes);
+    payload.extend_from_slice(&in_out);
+
+    let encoded = base64::engine::general_purpose::STANDARD.encode(&payload);
+    Ok(format!("{ENCRYPTED_PREFIX}{encoded}"))
+}
+
+/// Decrypt an `enc:`-prefixed string value.
+///
+/// # Errors
+///
+/// Returns an error if the value is malformed or decryption fails.
+#[expect(
+    clippy::result_large_err,
+    reason = "taxis Error is inherently large due to PathBuf fields"
+)]
+pub fn decrypt_value(encrypted: &str, master_key: &[u8; KEY_LEN]) -> Result<String> {
+    let encoded = encrypted
+        .strip_prefix(ENCRYPTED_PREFIX)
+        .ok_or_else(|| build_decrypt_error("missing enc: prefix"))?;
+
+    // WHY: base64::DecodeError is not useful to propagate through taxis Error
+    let payload = base64::engine::general_purpose::STANDARD
+        .decode(encoded)
+        .map_err(|_decode_err| build_decrypt_error("invalid base64"))?;
+
+    if payload.len() < NONCE_LEN + CHACHA20_POLY1305.tag_len() {
+        return Err(build_decrypt_error("ciphertext too short"));
+    }
+
+    let (nonce_bytes, ciphertext) = payload.split_at(NONCE_LEN);
+    // WHY: ring::error::Unspecified has no useful fields to propagate
+    let nonce = Nonce::try_assume_unique_for_key(nonce_bytes)
+        .map_err(|_unspecified| build_decrypt_error("invalid nonce"))?;
+
+    let unbound = UnboundKey::new(&CHACHA20_POLY1305, master_key)
+        .map_err(|_unspecified| build_decrypt_error("invalid key"))?;
+    let key = LessSafeKey::new(unbound);
+
+    let mut in_out = ciphertext.to_vec();
+    let plaintext = key
+        .open_in_place(nonce, Aad::empty(), &mut in_out)
+        .map_err(|_unspecified| {
+            build_decrypt_error("decryption failed (wrong key or corrupted data)")
+        })?;
+
+    String::from_utf8(plaintext.to_vec())
+        .map_err(|_utf8_err| build_decrypt_error("decrypted value is not valid UTF-8"))
+}
+
+fn build_encrypt_error() -> error::Error {
+    error::EncryptSnafu {
+        reason: "encryption operation failed".to_owned(),
+    }
+    .build()
+}
+
+fn build_decrypt_error(reason: &str) -> error::Error {
+    error::DecryptSnafu {
+        reason: reason.to_owned(),
+    }
+    .build()
+}
+
+/// Encrypt sensitive plaintext values in a TOML config file in place.
+///
+/// Reads the file, encrypts sensitive string values that aren't already
+/// `enc:`-prefixed, and writes back atomically (via tmp + rename).
+/// Returns the number of values encrypted.
+///
+/// # Errors
+///
+/// Returns an error if the file cannot be read/written or encryption fails.
+#[expect(
+    clippy::result_large_err,
+    reason = "taxis Error is inherently large due to PathBuf fields"
+)]
+pub fn encrypt_config_file(toml_path: &Path, master_key: &[u8; KEY_LEN]) -> Result<usize> {
+    let content =
+        std::fs::read_to_string(toml_path).context(error::ReadConfigSnafu { path: toml_path })?;
+    let mut value: toml::Value = toml::from_str(&content).map_err(|e| {
+        error::DecryptSnafu {
+            reason: format!("invalid TOML: {e}"),
+        }
+        .build()
+    })?;
+
+    let count = encrypt_sensitive_values(&mut value, master_key)?;
+
+    if count > 0 {
+        let encrypted_toml = toml::to_string(&value).map_err(|e| {
+            error::EncryptSnafu {
+                reason: format!("failed to serialize TOML: {e}"),
+            }
+            .build()
+        })?;
+
+        let tmp_path = toml_path.with_extension("toml.tmp");
+        std::fs::write(&tmp_path, &encrypted_toml).context(error::WriteConfigSnafu {
+            path: tmp_path.clone(),
+        })?;
+        std::fs::rename(&tmp_path, toml_path).context(error::WriteConfigSnafu {
+            path: toml_path.to_path_buf(),
+        })?;
+    }
+
+    Ok(count)
+}
+
+/// Keys in TOML whose string values are considered sensitive and eligible for
+/// encryption. Matches the patterns used by `redact.rs`.
+const SENSITIVE_TOML_KEYS: &[&str] = &[
+    "signingKey",
+    "signing_key",
+    "token",
+    "secret",
+    "password",
+    "apiKey",
+    "api_key",
+];
+
+/// Recursively decrypt all `enc:`-prefixed string values in a TOML value tree.
+///
+/// If `master_key` is `None`, logs a warning for each encrypted value found
+/// and leaves it unchanged (plaintext fallback).
+pub fn decrypt_toml_values(value: &mut toml::Value, master_key: Option<&[u8; KEY_LEN]>) {
+    match value {
+        toml::Value::String(s) if is_encrypted(s) => {
+            if let Some(key) = master_key {
+                match decrypt_value(s, key) {
+                    Ok(plaintext) => *s = plaintext,
+                    Err(e) => {
+                        warn!(error = %e, "failed to decrypt config value, leaving encrypted");
+                    }
+                }
+            } else {
+                warn!(
+                    "encrypted config value found but no master key available \
+                     -- value will remain encrypted"
+                );
+            }
+        }
+        toml::Value::Table(table) => {
+            for (_key, val) in table.iter_mut() {
+                decrypt_toml_values(val, master_key);
+            }
+        }
+        toml::Value::Array(arr) => {
+            for item in arr {
+                decrypt_toml_values(item, master_key);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Recursively encrypt plaintext string values for sensitive keys in a TOML
+/// value tree. Only encrypts values that are not already `enc:`-prefixed.
+///
+/// # Errors
+///
+/// Returns an error if any encryption operation fails.
+#[expect(
+    clippy::result_large_err,
+    reason = "taxis Error is inherently large due to PathBuf fields"
+)]
+pub fn encrypt_sensitive_values(
+    value: &mut toml::Value,
+    master_key: &[u8; KEY_LEN],
+) -> Result<usize> {
+    let mut count = 0;
+    encrypt_recursive(value, master_key, &mut count)?;
+    Ok(count)
+}
+
+#[expect(
+    clippy::result_large_err,
+    reason = "taxis Error is inherently large due to PathBuf fields"
+)]
+fn encrypt_recursive(
+    value: &mut toml::Value,
+    master_key: &[u8; KEY_LEN],
+    count: &mut usize,
+) -> Result<()> {
+    match value {
+        toml::Value::Table(table) => {
+            for (key, val) in table.iter_mut() {
+                if is_sensitive_key(key) {
+                    if let toml::Value::String(s) = val
+                        && !s.is_empty()
+                        && !is_encrypted(s)
+                    {
+                        *s = encrypt_value(s, master_key)?;
+                        *count += 1;
+                    }
+                } else {
+                    encrypt_recursive(val, master_key, count)?;
+                }
+            }
+        }
+        toml::Value::Array(arr) => {
+            for item in arr {
+                encrypt_recursive(item, master_key, count)?;
+            }
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+fn is_sensitive_key(key: &str) -> bool {
+    let lower = key.to_lowercase();
+    SENSITIVE_TOML_KEYS
+        .iter()
+        .any(|s| lower == s.to_lowercase())
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "test assertions")]
+mod tests {
+    use super::*;
+
+    fn test_key() -> [u8; KEY_LEN] {
+        let mut key = [0u8; KEY_LEN];
+        for (i, byte) in key.iter_mut().enumerate() {
+            #[expect(
+                clippy::cast_possible_truncation,
+                reason = "test key generation wraps by design"
+            )]
+            {
+                *byte = (i as u8).wrapping_mul(7).wrapping_add(42);
+            }
+        }
+        key
+    }
+
+    #[test]
+    fn encrypt_decrypt_roundtrip() {
+        let key = test_key();
+        let plaintext = "sk-ant-api-secret-key-12345";
+        let encrypted = encrypt_value(plaintext, &key).unwrap();
+
+        assert!(
+            is_encrypted(&encrypted),
+            "encrypted value must start with enc:"
+        );
+        assert!(encrypted.starts_with(ENCRYPTED_PREFIX));
+
+        let decrypted = decrypt_value(&encrypted, &key).unwrap();
+        assert_eq!(decrypted, plaintext);
+    }
+
+    #[test]
+    fn encrypt_decrypt_empty_string() {
+        let key = test_key();
+        let encrypted = encrypt_value("", &key).unwrap();
+        let decrypted = decrypt_value(&encrypted, &key).unwrap();
+        assert_eq!(decrypted, "");
+    }
+
+    #[test]
+    fn encrypt_decrypt_unicode() {
+        let key = test_key();
+        let plaintext = "secret-with-unicode-\u{1f512}\u{1f511}";
+        let encrypted = encrypt_value(plaintext, &key).unwrap();
+        let decrypted = decrypt_value(&encrypted, &key).unwrap();
+        assert_eq!(decrypted, plaintext);
+    }
+
+    #[test]
+    fn detect_encrypted_vs_plaintext() {
+        assert!(is_encrypted("enc:abc123"));
+        assert!(!is_encrypted("plaintext-value"));
+        assert!(!is_encrypted(""));
+        assert!(!is_encrypted("ENC:uppercase-not-matched"));
+    }
+
+    #[test]
+    fn wrong_key_fails_decryption() {
+        let key1 = test_key();
+        let mut key2 = test_key();
+        key2[0] ^= 0xff;
+
+        let encrypted = encrypt_value("secret", &key1).unwrap();
+        let result = decrypt_value(&encrypted, &key2);
+        assert!(result.is_err(), "decryption with wrong key must fail");
+    }
+
+    #[test]
+    fn corrupted_ciphertext_fails() {
+        let key = test_key();
+        let encrypted = encrypt_value("secret", &key).unwrap();
+
+        // Corrupt one byte in the base64 payload
+        let mut chars: Vec<char> = encrypted.chars().collect();
+        let mid = chars.len() / 2;
+        chars[mid] = if chars[mid] == 'A' { 'B' } else { 'A' };
+        let corrupted: String = chars.into_iter().collect();
+
+        // May fail at base64 decode or at decryption
+        let result = decrypt_value(&corrupted, &key);
+        assert!(result.is_err(), "corrupted ciphertext must fail");
+    }
+
+    #[test]
+    fn too_short_ciphertext_fails() {
+        let key = test_key();
+        let result = decrypt_value("enc:AAAA", &key);
+        assert!(result.is_err(), "too-short ciphertext must fail");
+    }
+
+    #[test]
+    fn invalid_base64_fails() {
+        let key = test_key();
+        let result = decrypt_value("enc:!!!invalid!!!", &key);
+        assert!(result.is_err(), "invalid base64 must fail");
+    }
+
+    #[test]
+    fn decrypt_toml_with_key() {
+        let key = test_key();
+        let secret = "my-jwt-signing-key";
+        let encrypted = encrypt_value(secret, &key).unwrap();
+
+        let toml_str = format!(
+            r#"
+            [gateway.auth]
+            mode = "token"
+            signingKey = "{encrypted}"
+            "#
+        );
+        let mut value: toml::Value = toml::from_str(&toml_str).unwrap();
+        decrypt_toml_values(&mut value, Some(&key));
+
+        let signing_key = value["gateway"]["auth"]["signingKey"].as_str().unwrap();
+        assert_eq!(signing_key, secret);
+    }
+
+    #[test]
+    fn decrypt_toml_without_key_leaves_encrypted() {
+        let key = test_key();
+        let encrypted = encrypt_value("secret", &key).unwrap();
+
+        let toml_str = format!(
+            r#"
+            [gateway.auth]
+            signingKey = "{encrypted}"
+            "#
+        );
+        let mut value: toml::Value = toml::from_str(&toml_str).unwrap();
+        decrypt_toml_values(&mut value, None);
+
+        let signing_key = value["gateway"]["auth"]["signingKey"].as_str().unwrap();
+        assert!(
+            is_encrypted(signing_key),
+            "without master key, value must stay encrypted"
+        );
+    }
+
+    #[test]
+    fn encrypt_sensitive_values_in_toml() {
+        let key = test_key();
+        let toml_str = r#"
+            [gateway]
+            port = 18789
+
+            [gateway.auth]
+            mode = "token"
+            signingKey = "my-secret-key"
+
+            [gateway.tls]
+            enabled = false
+        "#;
+        let mut value: toml::Value = toml::from_str(toml_str).unwrap();
+        let count = encrypt_sensitive_values(&mut value, &key).unwrap();
+
+        assert_eq!(count, 1, "only signingKey should be encrypted");
+
+        let signing_key = value["gateway"]["auth"]["signingKey"].as_str().unwrap();
+        assert!(is_encrypted(signing_key), "signingKey must be encrypted");
+
+        // Decrypt and verify roundtrip
+        let decrypted = decrypt_value(signing_key, &key).unwrap();
+        assert_eq!(decrypted, "my-secret-key");
+    }
+
+    #[test]
+    fn encrypt_skips_already_encrypted_values() {
+        let key = test_key();
+        let already = encrypt_value("existing", &key).unwrap();
+
+        let toml_str = format!(
+            r#"
+            [gateway.auth]
+            signingKey = "{already}"
+            "#
+        );
+        let mut value: toml::Value = toml::from_str(&toml_str).unwrap();
+        let count = encrypt_sensitive_values(&mut value, &key).unwrap();
+
+        assert_eq!(count, 0, "already-encrypted values must be skipped");
+    }
+
+    #[test]
+    fn master_key_file_roundtrip() {
+        let dir = tempfile::tempdir().unwrap();
+        let key_path = dir.path().join("master.key");
+
+        generate_master_key(&key_path).unwrap();
+
+        assert!(key_path.exists());
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let perms = std::fs::metadata(&key_path).unwrap().permissions();
+            assert_eq!(
+                perms.mode() & 0o777,
+                0o600,
+                "key file must have 0600 permissions"
+            );
+        }
+
+        let key = load_master_key(&key_path).unwrap();
+        assert!(key.is_some(), "master key should be loaded");
+        let key = key.unwrap();
+        assert_ne!(key, [0u8; KEY_LEN], "key must not be all zeros");
+    }
+
+    #[test]
+    fn load_missing_key_returns_none() {
+        let result = load_master_key(Path::new("/nonexistent/path/master.key")).unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn generate_key_rejects_existing_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let key_path = dir.path().join("master.key");
+
+        generate_master_key(&key_path).unwrap();
+        let result = generate_master_key(&key_path);
+        assert!(result.is_err(), "must reject if key file already exists");
+    }
+
+    #[test]
+    fn hex_key_parsing_rejects_wrong_length() {
+        let result = parse_hex_key("abcd", Path::new("test.key"));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn hex_key_parsing_rejects_invalid_chars() {
+        let bad = "zz".repeat(KEY_LEN);
+        let result = parse_hex_key(&bad, Path::new("test.key"));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn each_encryption_produces_different_ciphertext() {
+        let key = test_key();
+        let plaintext = "same-input";
+        let enc1 = encrypt_value(plaintext, &key).unwrap();
+        let enc2 = encrypt_value(plaintext, &key).unwrap();
+        assert_ne!(enc1, enc2, "random nonce must produce different ciphertext");
+
+        // Both must decrypt to the same value
+        assert_eq!(decrypt_value(&enc1, &key).unwrap(), plaintext);
+        assert_eq!(decrypt_value(&enc2, &key).unwrap(), plaintext);
+    }
+}

--- a/crates/taxis/src/error.rs
+++ b/crates/taxis/src/error.rs
@@ -114,6 +114,42 @@ pub enum Error {
         #[snafu(implicit)]
         location: snafu::Location,
     },
+
+    /// The master key file is invalid (wrong length, bad hex).
+    #[snafu(display("invalid master key at {}: {reason}", path.display()))]
+    InvalidMasterKey {
+        path: PathBuf,
+        reason: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    /// The master key file already exists.
+    #[snafu(display(
+        "master key already exists at {}\n  help: delete the file first if you want to regenerate",
+        path.display()
+    ))]
+    MasterKeyExists {
+        path: PathBuf,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    /// Encryption operation failed.
+    #[snafu(display("encryption failed: {reason}"))]
+    Encrypt {
+        reason: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    /// Decryption operation failed.
+    #[snafu(display("decryption failed: {reason}"))]
+    Decrypt {
+        reason: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
 }
 
 /// Convenience alias for `Result<T, Error>`.

--- a/crates/taxis/src/lib.rs
+++ b/crates/taxis/src/lib.rs
@@ -9,6 +9,8 @@
 pub mod cascade;
 /// Configuration types for an Aletheia instance (agents, gateway, channels, embedding).
 pub mod config;
+/// Encryption at rest for sensitive configuration values.
+pub mod encrypt;
 /// Taxis-specific error types for configuration loading and path resolution.
 pub mod error;
 /// Figment-based configuration loader with TOML file and environment variable cascade.

--- a/crates/taxis/src/loader.rs
+++ b/crates/taxis/src/loader.rs
@@ -6,6 +6,7 @@ use snafu::ResultExt;
 use tracing::warn;
 
 use crate::config::AletheiaConfig;
+use crate::encrypt;
 use crate::error::{FigmentSnafu, Result, SerializeTomlSnafu, WriteConfigSnafu};
 use crate::oikos::Oikos;
 
@@ -13,8 +14,12 @@ use crate::oikos::Oikos;
 ///
 /// Resolution order (later wins):
 /// 1. Compiled defaults ([`AletheiaConfig::default()`])
-/// 2. `{oikos.config()}/aletheia.toml` (if it exists)
+/// 2. `{oikos.config()}/aletheia.toml` (if it exists), with `enc:` values decrypted
 /// 3. Environment variables: `ALETHEIA_*` (e.g. `ALETHEIA_GATEWAY__PORT=9000`)
+///
+/// Encrypted values (`enc:` prefix) are transparently decrypted using the
+/// master key from `~/.config/aletheia/master.key`. If the key is missing,
+/// encrypted values pass through unchanged with a warning.
 #[expect(
     clippy::result_large_err,
     reason = "figment::Error is inherently large"
@@ -26,10 +31,16 @@ pub fn load_config(oikos: &Oikos) -> Result<AletheiaConfig> {
     let mut figment = Figment::new().merge(Serialized::defaults(AletheiaConfig::default()));
 
     if toml_path.exists() {
-        figment = figment.merge(Toml::file(&toml_path));
+        let toml_content =
+            std::fs::read_to_string(&toml_path).context(crate::error::ReadConfigSnafu {
+                path: toml_path.clone(),
+            })?;
+
+        let decrypted_content = decrypt_toml_content(&toml_content);
+        figment = figment.merge(Toml::string(&decrypted_content));
     } else if yaml_path.exists() {
         warn!(
-            "Found aletheia.yaml but not aletheia.toml — run migration or rename. \
+            "Found aletheia.yaml but not aletheia.toml -- run migration or rename. \
              See docs/CONFIGURATION.md."
         );
     } else {
@@ -42,6 +53,32 @@ pub fn load_config(oikos: &Oikos) -> Result<AletheiaConfig> {
     figment = figment.merge(Env::prefixed("ALETHEIA_").split("__"));
 
     figment.extract().context(FigmentSnafu)
+}
+
+/// Parse TOML content, decrypt any `enc:` values, and serialize back.
+///
+/// If the master key is unavailable or the TOML is unparseable, returns the
+/// original content unchanged.
+fn decrypt_toml_content(content: &str) -> String {
+    let mut value: toml::Value = match toml::from_str(content) {
+        Ok(v) => v,
+        Err(_) => return content.to_owned(),
+    };
+
+    let master_key = match encrypt::master_key_path() {
+        Some(path) => match encrypt::load_master_key(&path) {
+            Ok(key) => key,
+            Err(e) => {
+                warn!(error = %e, "failed to load master key, encrypted values will not be decrypted");
+                None
+            }
+        },
+        None => None,
+    };
+
+    encrypt::decrypt_toml_values(&mut value, master_key.as_ref());
+
+    toml::to_string(&value).unwrap_or_else(|_| content.to_owned())
 }
 
 /// Write configuration to the instance TOML file.


### PR DESCRIPTION
## Summary

- Add ChaCha20-Poly1305 encryption for sensitive config values (API keys, OAuth secrets, JWT signing keys) in `aletheia.toml`, using `enc:` prefix to distinguish encrypted from plaintext
- Transparent decrypt-on-load in figment config loader with graceful fallback (warning if master key missing)
- CLI commands `aletheia config init-key` (generate master key at `~/.config/aletheia/master.key` with 0600 perms) and `aletheia config encrypt` (encrypt plaintext sensitive values in place)
- 17 unit tests covering round-trip, error cases, key management, TOML operations, and fallback behavior

## Test plan

- [x] `cargo fmt --all` passes
- [x] `cargo clippy -p aletheia-taxis -p aletheia --all-targets -- -D warnings` passes
- [x] All 117 taxis tests pass (including 17 new encryption tests)
- [ ] CI green on full workspace build

Closes #1434

🤖 Generated with [Claude Code](https://claude.com/claude-code)