### PR TITLE
perf(mneme): iterate get_history_with_budget at SQL level

### DIFF
--- a/crates/mneme/src/store/message.rs
+++ b/crates/mneme/src/store/message.rs
@@ -184,17 +184,36 @@ impl SessionStore {
     }
 
     /// Get message history within a token budget (most recent first, working backward).
+    ///
+    /// Iterates messages newest-first at the SQL level and stops once the
+    /// budget is exhausted, so only the necessary rows are loaded into memory.
+    /// At least one message is always returned (even if it alone exceeds the budget).
+    ///
+    /// # Errors
+    ///
+    /// Returns `Database` if the query fails.
     #[instrument(skip(self), level = "debug")]
     pub fn get_history_with_budget(
         &self,
         session_id: &str,
         max_tokens: i64,
     ) -> Result<Vec<Message>> {
-        let all = self.get_history(session_id, None)?;
-        let mut total: i64 = 0;
-        let mut result = Vec::new();
+        let mut stmt = self
+            .conn
+            .prepare_cached(
+                "SELECT * FROM messages \
+                 WHERE session_id = ?1 AND is_distilled = 0 \
+                 ORDER BY seq DESC",
+            )
+            .context(error::DatabaseSnafu)?;
 
-        for msg in all.into_iter().rev() {
+        let mut rows = stmt.query([session_id]).context(error::DatabaseSnafu)?;
+
+        let mut result = Vec::new();
+        let mut total: i64 = 0;
+
+        while let Some(row) = rows.next().context(error::DatabaseSnafu)? {
+            let msg = map_message(row).context(error::DatabaseSnafu)?;
             if total + msg.token_estimate > max_tokens && !result.is_empty() {
                 break;
             }

--- a/crates/mneme/src/store/tests.rs
+++ b/crates/mneme/src/store/tests.rs
@@ -409,6 +409,52 @@ fn budget_always_includes_at_least_one() {
     assert_eq!(history.len(), 1);
 }
 
+#[test]
+fn budget_loads_only_fitting_messages() {
+    let store = test_store();
+    store
+        .create_session("ses-1", "syn", "main", None, None)
+        .expect("create session");
+
+    // Insert 50 messages, each with 100 token estimate (total = 5000 tokens).
+    for i in 1..=50 {
+        store
+            .append_message(
+                "ses-1",
+                Role::User,
+                &format!("message {i}"),
+                None,
+                None,
+                100,
+            )
+            .expect("append message");
+    }
+
+    // Budget of 500 fits exactly 5 messages.
+    let history = store
+        .get_history_with_budget("ses-1", 500)
+        .expect("get history with budget");
+    assert_eq!(
+        history.len(),
+        5,
+        "budget of 500 should fit 5 messages at 100 tokens each"
+    );
+    assert_eq!(history[0].content, "message 46");
+    assert_eq!(history[4].content, "message 50");
+
+    // Budget that fits all messages returns everything.
+    let all = store
+        .get_history_with_budget("ses-1", 10_000)
+        .expect("get history with budget");
+    assert_eq!(
+        all.len(),
+        50,
+        "budget exceeding total should return all messages"
+    );
+    assert_eq!(all[0].content, "message 1");
+    assert_eq!(all[49].content, "message 50");
+}
+
 // --- Blackboard ---
 
 #[test]


### PR DESCRIPTION
## Summary

- `get_history_with_budget` no longer loads all messages into memory; it queries with `ORDER BY seq DESC` and stops iterating once the token budget is exhausted
- Only the necessary rows are materialized, then reversed for chronological order
- Adds `budget_loads_only_fitting_messages` test with 50 messages verifying partial and full budget loading

Closes #1432

## Observations

- **Debt** `crates/mneme/src/graph_intelligence.rs:180`, `crates/mneme/src/succession.rs:128-216`: Several `pub const` SQL query strings are unused in test cfg, causing `dead_code` warnings with `--all-targets`. Pre-existing on main.

## Test plan

- [x] Existing `history_with_budget` test passes (budget=200, 3 messages at 100 each, returns 2)
- [x] Existing `budget_always_includes_at_least_one` test passes (single 999999-token message with budget=1)
- [x] New `budget_loads_only_fitting_messages` test: 50 messages at 100 tokens each, budget=500 returns exactly 5 most recent; budget=10000 returns all 50
- [x] Integration test `history_budget_returns_most_recent` passes
- [x] All 888 mneme tests pass
- [x] `cargo fmt --all -- --check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)