### PR TITLE
refactor(hermeneus): consolidate MockProvider into shared test utility

### DIFF
--- a/crates/hermeneus/Cargo.toml
+++ b/crates/hermeneus/Cargo.toml
@@ -24,6 +24,9 @@ snafu = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 
+[features]
+test-utils = []
+
 [dev-dependencies]
 proptest = { workspace = true }
 static_assertions = { workspace = true }

--- a/crates/hermeneus/src/lib.rs
+++ b/crates/hermeneus/src/lib.rs
@@ -15,5 +15,12 @@ pub mod health;
 pub mod metrics;
 /// [`LlmProvider`](provider::LlmProvider), [`ProviderConfig`](provider::ProviderConfig), and [`ProviderRegistry`](provider::ProviderRegistry).
 pub mod provider;
+/// Shared mock provider for tests across the workspace.
+#[cfg(any(test, feature = "test-utils"))]
+#[expect(
+    clippy::expect_used,
+    reason = "test-only code, panicking on poisoned mutex is correct"
+)]
+pub mod test_utils;
 /// Anthropic-native types for LLM requests and responses ([`CompletionRequest`](types::CompletionRequest), [`CompletionResponse`](types::CompletionResponse)).
 pub mod types;

--- a/crates/hermeneus/src/provider.rs
+++ b/crates/hermeneus/src/provider.rs
@@ -241,64 +241,14 @@ impl ProviderRegistry {
 #[cfg(test)]
 #[expect(clippy::unwrap_used, reason = "test assertions")]
 mod tests {
-    use std::future::Future;
-    use std::pin::Pin;
-
     use super::*;
+    use crate::test_utils::MockProvider;
     use crate::types::*;
-
-    /// A mock provider for testing.
-    struct MockProvider {
-        models: Vec<&'static str>,
-    }
-
-    impl MockProvider {
-        fn new() -> Self {
-            Self {
-                models: vec!["mock-model-v1", "mock-model-v2"],
-            }
-        }
-    }
-
-    impl LlmProvider for MockProvider {
-        fn complete<'a>(
-            &'a self,
-            _request: &'a CompletionRequest,
-        ) -> Pin<Box<dyn Future<Output = Result<CompletionResponse>> + Send + 'a>> {
-            Box::pin(async {
-                Ok(CompletionResponse {
-                    id: "mock-response-1".to_owned(),
-                    model: "mock-model-v1".to_owned(),
-                    stop_reason: StopReason::EndTurn,
-                    content: vec![ContentBlock::Text {
-                        text: "mock response".to_owned(),
-                        citations: None,
-                    }],
-                    usage: Usage {
-                        input_tokens: 100,
-                        output_tokens: 50,
-                        ..Usage::default()
-                    },
-                })
-            })
-        }
-
-        fn supported_models(&self) -> &[&str] {
-            &self.models
-        }
-
-        #[expect(
-            clippy::unnecessary_literal_bound,
-            reason = "trait requires &str return"
-        )]
-        fn name(&self) -> &str {
-            "mock"
-        }
-    }
 
     #[tokio::test]
     async fn mock_provider_completes() {
-        let provider = MockProvider::new();
+        let provider =
+            MockProvider::new("mock response").models(&["mock-model-v1", "mock-model-v2"]);
         let request = CompletionRequest {
             model: "mock-model-v1".to_owned(),
             system: None,
@@ -315,13 +265,14 @@ mod tests {
         };
 
         let response = provider.complete(&request).await.unwrap();
-        assert_eq!(response.id, "mock-response-1");
+        assert_eq!(response.id, "msg_mock");
         assert_eq!(response.stop_reason, StopReason::EndTurn);
     }
 
     #[test]
     fn supports_model_check() {
-        let provider = MockProvider::new();
+        let provider =
+            MockProvider::new("mock response").models(&["mock-model-v1", "mock-model-v2"]);
         assert!(provider.supports_model("mock-model-v1"));
         assert!(provider.supports_model("mock-model-v2"));
         assert!(!provider.supports_model("nonexistent"));
@@ -330,7 +281,9 @@ mod tests {
     #[test]
     fn registry_find_provider() {
         let mut registry = ProviderRegistry::new();
-        registry.register(Box::new(MockProvider::new()));
+        registry.register(Box::new(
+            MockProvider::new("mock response").models(&["mock-model-v1"]),
+        ));
 
         assert!(registry.find_provider("mock-model-v1").is_some());
         assert!(registry.find_provider("nonexistent").is_none());
@@ -381,7 +334,7 @@ mod tests {
     #[test]
     fn registry_health_starts_up() {
         let mut registry = ProviderRegistry::new();
-        registry.register(Box::new(MockProvider::new()));
+        registry.register(Box::new(MockProvider::new("mock response")));
 
         assert_eq!(registry.provider_health("mock"), Some(ProviderHealth::Up));
     }
@@ -395,7 +348,7 @@ mod tests {
     #[test]
     fn registry_record_error_updates_health() {
         let mut registry = ProviderRegistry::new();
-        registry.register(Box::new(MockProvider::new()));
+        registry.register(Box::new(MockProvider::new("mock response")));
 
         let err: crate::error::Error = crate::error::ApiRequestSnafu { message: "timeout" }.build();
         registry.record_error("mock", &err);
@@ -413,7 +366,7 @@ mod tests {
     #[test]
     fn registry_record_success_resets_health() {
         let mut registry = ProviderRegistry::new();
-        registry.register(Box::new(MockProvider::new()));
+        registry.register(Box::new(MockProvider::new("mock response")));
 
         let err: crate::error::Error = crate::error::ApiRequestSnafu { message: "timeout" }.build();
         registry.record_error("mock", &err);
@@ -425,14 +378,14 @@ mod tests {
     #[test]
     fn find_streaming_provider_returns_none_for_mock() {
         let mut registry = ProviderRegistry::new();
-        registry.register(Box::new(MockProvider::new()));
+        registry.register(Box::new(MockProvider::new("mock response")));
         assert!(registry.find_streaming_provider("mock-model-v1").is_none());
     }
 
     #[test]
     fn registry_record_unknown_is_noop() {
         let mut registry = ProviderRegistry::new();
-        registry.register(Box::new(MockProvider::new()));
+        registry.register(Box::new(MockProvider::new("mock response")));
         // Should not panic
         registry.record_success("nonexistent");
         let err: crate::error::Error = crate::error::ApiRequestSnafu { message: "timeout" }.build();

--- a/crates/hermeneus/src/test_utils.rs
+++ b/crates/hermeneus/src/test_utils.rs
@@ -1,0 +1,168 @@
+//! Shared mock LLM provider for tests.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Mutex;
+
+use crate::error::{self, Result};
+use crate::provider::LlmProvider;
+use crate::types::{CompletionRequest, CompletionResponse, ContentBlock, StopReason, Usage};
+
+/// Build a [`CompletionResponse`] with a single text block.
+#[must_use]
+pub fn make_response(text: &str) -> CompletionResponse {
+    CompletionResponse {
+        id: "msg_mock".to_owned(),
+        model: "mock-model".to_owned(),
+        stop_reason: StopReason::EndTurn,
+        content: vec![ContentBlock::Text {
+            text: text.to_owned(),
+            citations: None,
+        }],
+        usage: Usage {
+            input_tokens: 10,
+            output_tokens: 5,
+            ..Usage::default()
+        },
+    }
+}
+
+/// Configurable mock LLM provider for tests.
+///
+/// Supports fixed responses, response queues, request capturing,
+/// and error injection. Thread-safe via `std::sync::Mutex` (lock never
+/// held across `.await`).
+///
+/// # Examples
+///
+/// Fixed text response:
+/// ```ignore
+/// let provider = MockProvider::new("Hello!");
+/// ```
+///
+/// Response sequence (pops from front, repeats last):
+/// ```ignore
+/// let provider = MockProvider::with_responses(vec![r1, r2]);
+/// ```
+///
+/// Error injection:
+/// ```ignore
+/// let provider = MockProvider::error("network timeout");
+/// ```
+pub struct MockProvider {
+    // WHY: std::sync::Mutex is intentional: lock never held across .await
+    responses: Mutex<Vec<CompletionResponse>>,
+    error: Mutex<Option<error::Error>>,
+    models: &'static [&'static str],
+    provider_name: &'static str,
+    requests: Mutex<Vec<CompletionRequest>>,
+}
+
+impl MockProvider {
+    /// Create a mock that always returns the given text.
+    #[must_use]
+    pub fn new(text: &str) -> Self {
+        Self {
+            responses: Mutex::new(vec![make_response(text)]),
+            error: Mutex::new(None),
+            models: &["mock-model"],
+            provider_name: "mock",
+            requests: Mutex::new(Vec::new()),
+        }
+    }
+
+    /// Create a mock that returns responses in sequence.
+    ///
+    /// When only one response remains, it is cloned indefinitely.
+    #[must_use]
+    pub fn with_responses(responses: Vec<CompletionResponse>) -> Self {
+        Self {
+            responses: Mutex::new(responses),
+            error: Mutex::new(None),
+            models: &["mock-model"],
+            provider_name: "mock",
+            requests: Mutex::new(Vec::new()),
+        }
+    }
+
+    /// Create a mock that returns an [`ApiRequest`](error::ApiRequestSnafu) error.
+    #[must_use]
+    pub fn error(message: &str) -> Self {
+        Self {
+            responses: Mutex::new(Vec::new()),
+            error: Mutex::new(Some(
+                error::ApiRequestSnafu {
+                    message: message.to_owned(),
+                }
+                .build(),
+            )),
+            models: &["mock-model"],
+            provider_name: "mock",
+            requests: Mutex::new(Vec::new()),
+        }
+    }
+
+    /// Set the model list returned by `supported_models`.
+    #[must_use]
+    pub fn models(mut self, models: &'static [&'static str]) -> Self {
+        self.models = models;
+        self
+    }
+
+    /// Set the provider name returned by `name`.
+    #[must_use]
+    pub fn named(mut self, name: &'static str) -> Self {
+        self.provider_name = name;
+        self
+    }
+
+    /// Return all captured requests (most recent last).
+    #[must_use]
+    pub fn captured_requests(&self) -> Vec<CompletionRequest> {
+        self.requests
+            .lock()
+            .expect("mock request lock poisoned")
+            .clone()
+    }
+}
+
+impl LlmProvider for MockProvider {
+    fn complete<'a>(
+        &'a self,
+        request: &'a CompletionRequest,
+    ) -> Pin<Box<dyn Future<Output = Result<CompletionResponse>> + Send + 'a>> {
+        Box::pin(async {
+            self.requests
+                .lock()
+                .expect("mock request lock poisoned")
+                .push(request.clone());
+
+            // Error path: single-use, returns error on first call
+            {
+                let mut err_guard = self.error.lock().expect("mock error lock poisoned");
+                if let Some(err) = err_guard.take() {
+                    return Err(err);
+                }
+            }
+
+            // Success path: pop from front if multiple, clone last if one
+            let mut responses = self.responses.lock().expect("mock response lock poisoned");
+            if responses.len() > 1 {
+                Ok(responses.remove(0))
+            } else {
+                Ok(responses
+                    .first()
+                    .expect("MockProvider has no responses configured")
+                    .clone())
+            }
+        })
+    }
+
+    fn supported_models(&self) -> &[&str] {
+        self.models
+    }
+
+    fn name(&self) -> &str {
+        self.provider_name
+    }
+}

--- a/crates/integration-tests/Cargo.toml
+++ b/crates/integration-tests/Cargo.toml
@@ -21,7 +21,7 @@ aletheia-dokimion = { path = "../eval" }
 aletheia-koina = { path = "../koina" }
 aletheia-taxis = { path = "../taxis" }
 aletheia-mneme = { path = "../mneme", default-features = false }
-aletheia-hermeneus = { path = "../hermeneus" }
+aletheia-hermeneus = { path = "../hermeneus", features = ["test-utils"] }
 aletheia-nous = { path = "../nous" }
 aletheia-organon = { path = "../organon" }
 aletheia-thesauros = { path = "../thesauros" }

--- a/crates/integration-tests/tests/cross_crate_pipeline.rs
+++ b/crates/integration-tests/tests/cross_crate_pipeline.rs
@@ -19,6 +19,7 @@ use tokio::sync::Mutex as TokioMutex;
 use tower::ServiceExt;
 
 use aletheia_hermeneus::provider::{LlmProvider, ProviderRegistry};
+use aletheia_hermeneus::test_utils::MockProvider;
 use aletheia_hermeneus::types::*;
 use aletheia_mneme::store::SessionStore;
 use aletheia_nous::config::{NousConfig, PipelineConfig};
@@ -35,56 +36,6 @@ use tokio_util::sync::CancellationToken;
 // ---------------------------------------------------------------------------
 // Mock providers
 // ---------------------------------------------------------------------------
-
-/// Returns a fixed text response.
-struct MockProvider {
-    response: CompletionResponse,
-}
-
-impl MockProvider {
-    fn new(text: &str) -> Self {
-        Self {
-            response: CompletionResponse {
-                id: "msg_mock".to_owned(),
-                model: "mock-model".to_owned(),
-                stop_reason: StopReason::EndTurn,
-                content: vec![ContentBlock::Text {
-                    text: text.to_owned(),
-                    citations: None,
-                }],
-                usage: Usage {
-                    input_tokens: 10,
-                    output_tokens: 5,
-                    ..Usage::default()
-                },
-            },
-        }
-    }
-}
-
-impl LlmProvider for MockProvider {
-    fn complete<'a>(
-        &'a self,
-        _request: &'a CompletionRequest,
-    ) -> std::pin::Pin<
-        Box<
-            dyn std::future::Future<Output = aletheia_hermeneus::error::Result<CompletionResponse>>
-                + Send
-                + 'a,
-        >,
-    > {
-        Box::pin(async { Ok(self.response.clone()) })
-    }
-
-    fn supported_models(&self) -> &[&str] {
-        &["mock-model"]
-    }
-
-    #[expect(clippy::unnecessary_literal_bound, reason = "trait requires &str")]
-    fn name(&self) -> &str {
-        "mock"
-    }
-}
 
 /// Captures all LLM requests for inspection.
 struct CapturingMockProvider {
@@ -210,38 +161,6 @@ impl LlmProvider for SequentialMockProvider {
     }
 }
 
-/// Returns an error from the LLM.
-struct ErrorProvider;
-
-impl LlmProvider for ErrorProvider {
-    fn complete<'a>(
-        &'a self,
-        _request: &'a CompletionRequest,
-    ) -> std::pin::Pin<
-        Box<
-            dyn std::future::Future<Output = aletheia_hermeneus::error::Result<CompletionResponse>>
-                + Send
-                + 'a,
-        >,
-    > {
-        Box::pin(async {
-            Err(aletheia_hermeneus::error::ApiRequestSnafu {
-                message: "simulated provider failure".to_owned(),
-            }
-            .build())
-        })
-    }
-
-    fn supported_models(&self) -> &[&str] {
-        &["mock-model"]
-    }
-
-    #[expect(clippy::unnecessary_literal_bound, reason = "trait requires &str")]
-    fn name(&self) -> &str {
-        "mock-error"
-    }
-}
-
 // ---------------------------------------------------------------------------
 // Test harness
 // ---------------------------------------------------------------------------
@@ -254,7 +173,10 @@ struct TestHarness {
 
 impl TestHarness {
     async fn build() -> Self {
-        Self::build_with_provider(Box::new(MockProvider::new("Hello from mock!"))).await
+        Self::build_with_provider(Box::new(
+            MockProvider::new("Hello from mock!").models(&["mock-model"]),
+        ))
+        .await
     }
 
     async fn build_capturing(text: &str) -> (Self, Arc<Mutex<Vec<CompletionRequest>>>) {
@@ -967,7 +889,12 @@ async fn error_empty_rename_returns_400() {
 
 #[tokio::test]
 async fn error_provider_failure_returns_sse_error_event() {
-    let harness = TestHarness::build_with_provider(Box::new(ErrorProvider)).await;
+    let harness = TestHarness::build_with_provider(Box::new(
+        MockProvider::error("simulated provider failure")
+            .models(&["mock-model"])
+            .named("mock-error"),
+    ))
+    .await;
     let router = harness.router();
 
     let session = harness.create_session(&router).await;

--- a/crates/integration-tests/tests/end_to_end.rs
+++ b/crates/integration-tests/tests/end_to_end.rs
@@ -13,6 +13,7 @@ use secrecy::SecretString;
 use tower::ServiceExt;
 
 use aletheia_hermeneus::provider::{LlmProvider, ProviderRegistry};
+use aletheia_hermeneus::test_utils::MockProvider;
 use aletheia_hermeneus::types::*;
 use aletheia_mneme::store::SessionStore;
 use aletheia_nous::config::{NousConfig, PipelineConfig};
@@ -26,55 +27,6 @@ use aletheia_taxis::oikos::Oikos;
 use tokio_util::sync::CancellationToken;
 
 // --- Mock Providers ---
-
-struct MockProvider {
-    response: CompletionResponse,
-}
-
-impl MockProvider {
-    fn new() -> Self {
-        Self {
-            response: CompletionResponse {
-                id: "msg_test".to_owned(),
-                model: "mock-model".to_owned(),
-                stop_reason: StopReason::EndTurn,
-                content: vec![ContentBlock::Text {
-                    text: "Hello from mock!".to_owned(),
-                    citations: None,
-                }],
-                usage: Usage {
-                    input_tokens: 10,
-                    output_tokens: 5,
-                    ..Usage::default()
-                },
-            },
-        }
-    }
-}
-
-impl LlmProvider for MockProvider {
-    fn complete<'a>(
-        &'a self,
-        _request: &'a CompletionRequest,
-    ) -> std::pin::Pin<
-        Box<
-            dyn std::future::Future<Output = aletheia_hermeneus::error::Result<CompletionResponse>>
-                + Send
-                + 'a,
-        >,
-    > {
-        Box::pin(async { Ok(self.response.clone()) })
-    }
-
-    fn supported_models(&self) -> &[&str] {
-        &["mock-model"]
-    }
-
-    #[expect(clippy::unnecessary_literal_bound, reason = "trait requires &str")]
-    fn name(&self) -> &str {
-        "mock"
-    }
-}
 
 struct CapturingMockProvider {
     response: CompletionResponse,
@@ -147,7 +99,10 @@ struct TestHarness {
 
 impl TestHarness {
     async fn build() -> Self {
-        Self::build_with_provider(Box::new(MockProvider::new())).await
+        Self::build_with_provider(Box::new(
+            MockProvider::new("Hello from mock!").models(&["mock-model"]),
+        ))
+        .await
     }
 
     async fn build_capturing() -> (Self, Arc<Mutex<Vec<CompletionRequest>>>) {

--- a/crates/integration-tests/tests/eval_harness.rs
+++ b/crates/integration-tests/tests/eval_harness.rs
@@ -11,8 +11,8 @@ use secrecy::SecretString;
 use tokio::net::TcpListener;
 
 use aletheia_dokimion::runner::{RunConfig, ScenarioRunner};
-use aletheia_hermeneus::provider::{LlmProvider, ProviderRegistry};
-use aletheia_hermeneus::types::*;
+use aletheia_hermeneus::provider::ProviderRegistry;
+use aletheia_hermeneus::test_utils::MockProvider;
 use aletheia_mneme::store::SessionStore;
 use aletheia_nous::config::{NousConfig, PipelineConfig};
 use aletheia_nous::manager::NousManager;
@@ -26,55 +26,6 @@ use tokio_util::sync::CancellationToken;
 
 fn install_crypto_provider() {
     let _ = rustls::crypto::ring::default_provider().install_default();
-}
-
-struct MockProvider {
-    response: CompletionResponse,
-}
-
-impl MockProvider {
-    fn new() -> Self {
-        Self {
-            response: CompletionResponse {
-                id: "msg_test".to_owned(),
-                model: "mock-model".to_owned(),
-                stop_reason: StopReason::EndTurn,
-                content: vec![ContentBlock::Text {
-                    text: "Hello from eval harness!".to_owned(),
-                    citations: None,
-                }],
-                usage: Usage {
-                    input_tokens: 10,
-                    output_tokens: 5,
-                    ..Usage::default()
-                },
-            },
-        }
-    }
-}
-
-impl LlmProvider for MockProvider {
-    fn complete<'a>(
-        &'a self,
-        _request: &'a CompletionRequest,
-    ) -> std::pin::Pin<
-        Box<
-            dyn std::future::Future<Output = aletheia_hermeneus::error::Result<CompletionResponse>>
-                + Send
-                + 'a,
-        >,
-    > {
-        Box::pin(async { Ok(self.response.clone()) })
-    }
-
-    fn supported_models(&self) -> &[&str] {
-        &["mock-model"]
-    }
-
-    #[expect(clippy::unnecessary_literal_bound, reason = "trait requires &str")]
-    fn name(&self) -> &str {
-        "mock"
-    }
 }
 
 async fn start_test_server() -> (String, String, tempfile::TempDir) {
@@ -93,7 +44,9 @@ async fn start_test_server() -> (String, String, tempfile::TempDir) {
     let store = SessionStore::open_in_memory().expect("in-memory store");
 
     let mut provider_registry = ProviderRegistry::new();
-    provider_registry.register(Box::new(MockProvider::new()));
+    provider_registry.register(Box::new(
+        MockProvider::new("Hello from eval harness!").models(&["mock-model"]),
+    ));
     let provider_registry = Arc::new(provider_registry);
     let tool_registry = Arc::new(ToolRegistry::new());
     let session_store = Arc::new(TokioMutex::new(store));

--- a/crates/melete/Cargo.toml
+++ b/crates/melete/Cargo.toml
@@ -20,5 +20,6 @@ tokio = { workspace = true }
 jiff = { workspace = true }
 
 [dev-dependencies]
-tokio = { workspace = true, features = ["full", "test-util"] }
+aletheia-hermeneus = { path = "../hermeneus", features = ["test-utils"] }
 static_assertions = { workspace = true }
+tokio = { workspace = true, features = ["full", "test-util"] }

--- a/crates/melete/src/distill_tests.rs
+++ b/crates/melete/src/distill_tests.rs
@@ -1,109 +1,72 @@
 #![expect(clippy::unwrap_used, reason = "test assertions")]
-#![expect(clippy::expect_used, reason = "test assertions")]
+use aletheia_hermeneus::test_utils::MockProvider;
 use aletheia_hermeneus::types::{
     CompletionResponse, ContentBlock, StopReason, ToolResultContent, Usage,
 };
 
 use super::*;
 
-struct MockProvider {
-    response: std::sync::Mutex<Option<aletheia_hermeneus::error::Result<CompletionResponse>>>,
-}
-
-impl MockProvider {
-    fn success(summary: &str) -> Self {
-        Self {
-            response: std::sync::Mutex::new(Some(Ok(CompletionResponse {
-                id: "msg_distill_1".to_owned(),
-                model: "claude-sonnet-4-20250514".to_owned(),
-                stop_reason: StopReason::EndTurn,
-                content: vec![ContentBlock::Text {
-                    text: summary.to_owned(),
-                    citations: None,
-                }],
-                usage: Usage {
-                    input_tokens: 5000,
-                    output_tokens: 200,
-                    cache_read_tokens: 0,
-                    cache_write_tokens: 0,
-                },
-            }))),
-        }
-    }
-
-    fn empty_response() -> Self {
-        Self {
-            response: std::sync::Mutex::new(Some(Ok(CompletionResponse {
-                id: "msg_empty".to_owned(),
-                model: "claude-sonnet-4-20250514".to_owned(),
-                stop_reason: StopReason::EndTurn,
-                content: vec![],
-                usage: Usage::default(),
-            }))),
-        }
-    }
-
-    fn empty_text_blocks() -> Self {
-        Self {
-            response: std::sync::Mutex::new(Some(Ok(CompletionResponse {
-                id: "msg_empty_text".to_owned(),
-                model: "claude-sonnet-4-20250514".to_owned(),
-                stop_reason: StopReason::EndTurn,
-                content: vec![
-                    ContentBlock::Text {
-                        text: String::new(),
-                        citations: None,
-                    },
-                    ContentBlock::Text {
-                        text: "   ".to_owned(),
-                        citations: None,
-                    },
-                ],
-                usage: Usage::default(),
-            }))),
-        }
-    }
-
-    fn failure() -> Self {
-        Self {
-            response: std::sync::Mutex::new(Some(Err(
-                aletheia_hermeneus::error::ApiRequestSnafu {
-                    message: "network timeout".to_owned(),
-                }
-                .build(),
-            ))),
-        }
+fn distill_response(text: &str) -> CompletionResponse {
+    CompletionResponse {
+        id: "msg_distill_1".to_owned(),
+        model: "claude-sonnet-4-20250514".to_owned(),
+        stop_reason: StopReason::EndTurn,
+        content: vec![ContentBlock::Text {
+            text: text.to_owned(),
+            citations: None,
+        }],
+        usage: Usage {
+            input_tokens: 5000,
+            output_tokens: 200,
+            cache_read_tokens: 0,
+            cache_write_tokens: 0,
+        },
     }
 }
 
-impl LlmProvider for MockProvider {
-    fn complete<'a>(
-        &'a self,
-        _request: &'a CompletionRequest,
-    ) -> std::pin::Pin<
-        Box<
-            dyn std::future::Future<Output = aletheia_hermeneus::error::Result<CompletionResponse>>
-                + Send
-                + 'a,
-        >,
-    > {
-        Box::pin(async {
-            self.response
-                .lock()
-                .expect("lock poisoned") // INVARIANT: test mock, panic = test bug
-                .take()
-                .expect("mock provider called more than once")
-        })
-    }
+fn success_provider(summary: &str) -> MockProvider {
+    MockProvider::with_responses(vec![distill_response(summary)])
+        .models(&["claude-sonnet-4-20250514"])
+        .named("mock-distill")
+}
 
-    fn supported_models(&self) -> &[&str] {
-        &["claude-sonnet-4-20250514"]
-    }
+fn empty_response_provider() -> MockProvider {
+    MockProvider::with_responses(vec![CompletionResponse {
+        id: "msg_empty".to_owned(),
+        model: "claude-sonnet-4-20250514".to_owned(),
+        stop_reason: StopReason::EndTurn,
+        content: vec![],
+        usage: Usage::default(),
+    }])
+    .models(&["claude-sonnet-4-20250514"])
+    .named("mock-distill")
+}
 
-    #[expect(clippy::unnecessary_literal_bound)]
-    fn name(&self) -> &str {
-        "mock-distill"
-    }
+fn empty_text_provider() -> MockProvider {
+    MockProvider::with_responses(vec![CompletionResponse {
+        id: "msg_empty_text".to_owned(),
+        model: "claude-sonnet-4-20250514".to_owned(),
+        stop_reason: StopReason::EndTurn,
+        content: vec![
+            ContentBlock::Text {
+                text: String::new(),
+                citations: None,
+            },
+            ContentBlock::Text {
+                text: "   ".to_owned(),
+                citations: None,
+            },
+        ],
+        usage: Usage::default(),
+    }])
+    .models(&["claude-sonnet-4-20250514"])
+    .named("mock-distill")
+}
+
+fn failure_provider() -> MockProvider {
+    MockProvider::error("network timeout")
+        .models(&["claude-sonnet-4-20250514"])
+        .named("mock-distill")
 }
 
 fn text_msg(role: Role, text: &str) -> Message {
@@ -267,7 +230,7 @@ fn build_prompt_no_tools() {
 async fn distill_success_returns_result() {
     let engine = default_engine();
     let messages = sample_conversation();
-    let provider = MockProvider::success(MOCK_SUMMARY);
+    let provider = success_provider(MOCK_SUMMARY);
 
     let result = engine.distill(&messages, "test-nous", &provider, 1).await;
     assert!(result.is_ok());
@@ -284,7 +247,7 @@ async fn distill_success_returns_result() {
 async fn distill_token_estimates_populated() {
     let engine = default_engine();
     let messages = sample_conversation();
-    let provider = MockProvider::success(MOCK_SUMMARY);
+    let provider = success_provider(MOCK_SUMMARY);
 
     let result = engine
         .distill(&messages, "test-nous", &provider, 1)
@@ -299,7 +262,7 @@ async fn distill_token_estimates_populated() {
 async fn distill_distillation_number_passed_through() {
     let engine = default_engine();
     let messages = sample_conversation();
-    let provider = MockProvider::success(MOCK_SUMMARY);
+    let provider = success_provider(MOCK_SUMMARY);
 
     let result = engine
         .distill(&messages, "test-nous", &provider, 42)
@@ -312,7 +275,7 @@ async fn distill_distillation_number_passed_through() {
 async fn distill_timestamp_is_valid() {
     let engine = default_engine();
     let messages = sample_conversation();
-    let provider = MockProvider::success(MOCK_SUMMARY);
+    let provider = success_provider(MOCK_SUMMARY);
 
     let result = engine
         .distill(&messages, "test-nous", &provider, 1)
@@ -330,7 +293,7 @@ async fn distill_timestamp_is_valid() {
 #[tokio::test]
 async fn distill_empty_messages_returns_no_messages_error() {
     let engine = default_engine();
-    let provider = MockProvider::success(MOCK_SUMMARY);
+    let provider = success_provider(MOCK_SUMMARY);
 
     let result = engine.distill(&[], "test-nous", &provider, 1).await;
     assert!(result.is_err());
@@ -342,7 +305,7 @@ async fn distill_empty_messages_returns_no_messages_error() {
 async fn distill_llm_failure_returns_llm_call_error() {
     let engine = default_engine();
     let messages = sample_conversation();
-    let provider = MockProvider::failure();
+    let provider = failure_provider();
 
     let result = engine.distill(&messages, "test-nous", &provider, 1).await;
     assert!(result.is_err());
@@ -354,7 +317,7 @@ async fn distill_llm_failure_returns_llm_call_error() {
 async fn distill_empty_response_returns_empty_summary_error() {
     let engine = default_engine();
     let messages = sample_conversation();
-    let provider = MockProvider::empty_response();
+    let provider = empty_response_provider();
 
     let result = engine.distill(&messages, "test-nous", &provider, 1).await;
     assert!(result.is_err());
@@ -366,7 +329,7 @@ async fn distill_empty_response_returns_empty_summary_error() {
 async fn distill_whitespace_only_response_returns_empty_summary_error() {
     let engine = default_engine();
     let messages = sample_conversation();
-    let provider = MockProvider::empty_text_blocks();
+    let provider = empty_text_provider();
 
     let result = engine.distill(&messages, "test-nous", &provider, 1).await;
     assert!(result.is_err());
@@ -518,7 +481,7 @@ async fn distill_preserves_verbatim_messages() {
     };
     let engine = DistillEngine::new(config);
     let messages = sample_conversation(); // 6 messages
-    let provider = MockProvider::success(MOCK_SUMMARY);
+    let provider = success_provider(MOCK_SUMMARY);
 
     let result = engine
         .distill(&messages, "test-nous", &provider, 1)
@@ -615,7 +578,7 @@ fn backoff_schedule_is_exponential() {
 async fn distill_records_failure_on_llm_error() {
     let engine = default_engine();
     let messages = sample_conversation();
-    let provider = MockProvider::failure();
+    let provider = failure_provider();
 
     let _ = engine.distill(&messages, "test", &provider, 1).await;
 
@@ -632,7 +595,7 @@ async fn distill_records_success_and_clears_backoff() {
     assert!(engine.in_backoff());
 
     let messages = sample_conversation();
-    let provider = MockProvider::success(MOCK_SUMMARY);
+    let provider = success_provider(MOCK_SUMMARY);
     engine
         .distill(&messages, "test", &provider, 1)
         .await
@@ -800,7 +763,7 @@ fn estimate_tokens_includes_tool_result_content() {
 async fn distill_result_contains_memory_flush_field() {
     let engine = default_engine();
     let messages = sample_conversation();
-    let provider = MockProvider::success(MOCK_SUMMARY);
+    let provider = success_provider(MOCK_SUMMARY);
 
     let result = engine
         .distill(&messages, "test", &provider, 1)

--- a/crates/melete/src/roundtrip_tests.rs
+++ b/crates/melete/src/roundtrip_tests.rs
@@ -1,72 +1,16 @@
 //! Roundtrip and comprehensive tests for melete distillation pipeline.
 #![expect(clippy::unwrap_used, reason = "test assertions")]
-#![expect(clippy::expect_used, reason = "test assertions")]
 
-use std::sync::Mutex;
-
-use aletheia_hermeneus::provider::LlmProvider;
-use aletheia_hermeneus::types::{
-    CompletionRequest, CompletionResponse, Content, ContentBlock, Message, Role, StopReason,
-    ToolResultContent, Usage,
-};
+use aletheia_hermeneus::test_utils::MockProvider;
+use aletheia_hermeneus::types::{Content, ContentBlock, Message, Role, ToolResultContent};
 
 use crate::distill::{DistillConfig, DistillEngine, DistillSection};
 use crate::flush::{FlushItem, FlushSource, MemoryFlush};
 
-struct MockProvider {
-    response: Mutex<Option<aletheia_hermeneus::error::Result<CompletionResponse>>>,
-}
-
-impl MockProvider {
-    fn with_summary(summary: &str) -> Self {
-        Self {
-            response: Mutex::new(Some(Ok(CompletionResponse {
-                id: "msg_roundtrip".to_owned(),
-                model: "claude-sonnet-4-20250514".to_owned(),
-                stop_reason: StopReason::EndTurn,
-                content: vec![ContentBlock::Text {
-                    text: summary.to_owned(),
-                    citations: None,
-                }],
-                usage: Usage {
-                    input_tokens: 5000,
-                    output_tokens: 50,
-                    cache_read_tokens: 0,
-                    cache_write_tokens: 0,
-                },
-            }))),
-        }
-    }
-}
-
-impl LlmProvider for MockProvider {
-    fn complete<'a>(
-        &'a self,
-        _request: &'a CompletionRequest,
-    ) -> std::pin::Pin<
-        Box<
-            dyn std::future::Future<Output = aletheia_hermeneus::error::Result<CompletionResponse>>
-                + Send
-                + 'a,
-        >,
-    > {
-        Box::pin(async {
-            self.response
-                .lock()
-                .expect("lock") // INVARIANT: test mock, panic = test bug
-                .take()
-                .expect("mock provider called more than once")
-        })
-    }
-
-    fn supported_models(&self) -> &[&str] {
-        &["claude-sonnet-4-20250514"]
-    }
-
-    #[expect(clippy::unnecessary_literal_bound)]
-    fn name(&self) -> &str {
-        "mock-roundtrip"
-    }
+fn summary_provider(text: &str) -> MockProvider {
+    MockProvider::new(text)
+        .models(&["claude-sonnet-4-20250514"])
+        .named("mock-roundtrip")
 }
 
 fn text_msg(role: Role, text: &str) -> Message {
@@ -330,7 +274,7 @@ async fn test_split_when_verbatim_tail_zero_summarizes_all() {
     };
     let engine = DistillEngine::new(config);
     let messages = n_messages(6);
-    let provider = MockProvider::with_summary(FULL_SUMMARY);
+    let provider = summary_provider(FULL_SUMMARY);
 
     let result = engine
         .distill(&messages, "test", &provider, 1)
@@ -350,7 +294,7 @@ async fn test_split_when_verbatim_tail_equals_messages_distills_none() {
     };
     let engine = DistillEngine::new(config);
     let messages = n_messages(4);
-    let provider = MockProvider::with_summary(FULL_SUMMARY);
+    let provider = summary_provider(FULL_SUMMARY);
 
     let result = engine
         .distill(&messages, "test", &provider, 1)
@@ -370,7 +314,7 @@ async fn test_split_when_verbatim_tail_exceeds_messages_clamps() {
     };
     let engine = DistillEngine::new(config);
     let messages = n_messages(3);
-    let provider = MockProvider::with_summary(FULL_SUMMARY);
+    let provider = summary_provider(FULL_SUMMARY);
 
     let result = engine
         .distill(&messages, "test", &provider, 1)
@@ -395,7 +339,7 @@ async fn test_split_preserves_exact_tail_content() {
         text_msg(Role::User, "Third"),
         text_msg(Role::Assistant, "Fourth"),
     ];
-    let provider = MockProvider::with_summary(FULL_SUMMARY);
+    let provider = summary_provider(FULL_SUMMARY);
 
     let result = engine
         .distill(&messages, "test", &provider, 1)
@@ -484,7 +428,7 @@ async fn test_verbatim_tail_preserves_roles() {
         text_msg(Role::Assistant, "Recent assistant"),
         text_msg(Role::User, "Last user"),
     ];
-    let provider = MockProvider::with_summary(FULL_SUMMARY);
+    let provider = summary_provider(FULL_SUMMARY);
 
     let result = engine
         .distill(&messages, "test", &provider, 1)
@@ -506,7 +450,7 @@ async fn test_verbatim_tail_when_single_message_preserves_it() {
     };
     let engine = DistillEngine::new(config);
     let messages = vec![text_msg(Role::User, "Only message")];
-    let provider = MockProvider::with_summary(FULL_SUMMARY);
+    let provider = summary_provider(FULL_SUMMARY);
 
     let result = engine
         .distill(&messages, "test", &provider, 1)
@@ -545,7 +489,7 @@ async fn test_verbatim_tail_preserves_block_content() {
         text_msg(Role::Assistant, "Second"),
         block_msg.clone(),
     ];
-    let provider = MockProvider::with_summary(FULL_SUMMARY);
+    let provider = summary_provider(FULL_SUMMARY);
 
     let result = engine
         .distill(&messages, "test", &provider, 1)
@@ -635,7 +579,7 @@ async fn test_full_pipeline_preserves_tool_results() {
         text_msg(Role::User, "Thanks"),
         text_msg(Role::Assistant, "Welcome."),
     ];
-    let provider = MockProvider::with_summary(FULL_SUMMARY);
+    let provider = summary_provider(FULL_SUMMARY);
     let engine = default_engine();
 
     let result = engine
@@ -664,7 +608,7 @@ async fn test_full_pipeline_preserves_decisions() {
         text_msg(Role::User, "Done?"),
         text_msg(Role::Assistant, "All done."),
     ];
-    let provider = MockProvider::with_summary(FULL_SUMMARY);
+    let provider = summary_provider(FULL_SUMMARY);
     let engine = default_engine();
 
     let result = engine
@@ -693,7 +637,7 @@ async fn test_full_pipeline_preserves_corrections() {
         text_msg(Role::User, "Ship"),
         text_msg(Role::Assistant, "Shipped."),
     ];
-    let provider = MockProvider::with_summary(FULL_SUMMARY);
+    let provider = summary_provider(FULL_SUMMARY);
     let engine = default_engine();
 
     let result = engine
@@ -708,7 +652,7 @@ async fn test_full_pipeline_preserves_corrections() {
 #[tokio::test]
 async fn test_full_pipeline_reduces_token_count() {
     let messages = n_messages(20);
-    let provider = MockProvider::with_summary(FULL_SUMMARY);
+    let provider = summary_provider(FULL_SUMMARY);
     let engine = default_engine();
 
     let result = engine
@@ -727,7 +671,7 @@ async fn test_full_pipeline_reduces_token_count() {
 #[tokio::test]
 async fn test_full_pipeline_summary_contains_all_sections() {
     let messages = n_messages(10);
-    let provider = MockProvider::with_summary(FULL_SUMMARY);
+    let provider = summary_provider(FULL_SUMMARY);
     let engine = default_engine();
 
     let result = engine
@@ -757,7 +701,7 @@ async fn test_full_pipeline_verbatim_tail_integrity() {
         text_msg(Role::Assistant, "Hotel — preserved"),
         text_msg(Role::User, "India — preserved"),
     ];
-    let provider = MockProvider::with_summary(FULL_SUMMARY);
+    let provider = summary_provider(FULL_SUMMARY);
     let engine = default_engine();
 
     let result = engine
@@ -785,7 +729,7 @@ async fn test_full_pipeline_verbatim_tail_integrity() {
 
 #[tokio::test]
 async fn test_distill_when_empty_messages_returns_error() {
-    let provider = MockProvider::with_summary(FULL_SUMMARY);
+    let provider = summary_provider(FULL_SUMMARY);
     let engine = default_engine();
 
     let result = engine.distill(&[], "syn", &provider, 1).await;
@@ -802,7 +746,7 @@ async fn test_distill_when_single_message_all_verbatim() {
     };
     let engine = DistillEngine::new(config);
     let messages = vec![text_msg(Role::User, "Solo message")];
-    let provider = MockProvider::with_summary("## Summary\nSolo.");
+    let provider = summary_provider("## Summary\nSolo.");
 
     let result = engine
         .distill(&messages, "test", &provider, 1)
@@ -828,7 +772,7 @@ async fn test_distill_when_oversized_input_handles_gracefully() {
         ));
     }
 
-    let provider = MockProvider::with_summary(FULL_SUMMARY);
+    let provider = summary_provider(FULL_SUMMARY);
     let engine = default_engine();
 
     let result = engine
@@ -883,7 +827,7 @@ async fn test_distill_when_all_tool_call_messages() {
         ..DistillConfig::default()
     };
     let engine = DistillEngine::new(config);
-    let provider = MockProvider::with_summary(FULL_SUMMARY);
+    let provider = summary_provider(FULL_SUMMARY);
 
     let result = engine
         .distill(&messages, "test", &provider, 1)
@@ -906,7 +850,7 @@ async fn test_distill_when_two_messages_with_tail_three() {
         ..DistillConfig::default()
     };
     let engine = DistillEngine::new(config);
-    let provider = MockProvider::with_summary("## Summary\nGreeting.");
+    let provider = summary_provider("## Summary\nGreeting.");
 
     let result = engine
         .distill(&messages, "test", &provider, 1)

--- a/crates/nous/Cargo.toml
+++ b/crates/nous/Cargo.toml
@@ -32,6 +32,7 @@ tracing = { workspace = true }
 ulid = { workspace = true }
 
 [dev-dependencies]
+aletheia-hermeneus = { path = "../hermeneus", features = ["test-utils"] }
 indexmap = { workspace = true }
 static_assertions = { workspace = true }
 tempfile = { workspace = true }

--- a/crates/nous/src/actor/tests.rs
+++ b/crates/nous/src/actor/tests.rs
@@ -1,11 +1,8 @@
 #![expect(clippy::unwrap_used, reason = "test assertions")]
 #![expect(clippy::expect_used, reason = "test assertions")]
-use std::sync::Mutex;
-
 use aletheia_hermeneus::provider::LlmProvider;
-use aletheia_hermeneus::types::{
-    CompletionRequest, CompletionResponse, ContentBlock, StopReason, Usage,
-};
+use aletheia_hermeneus::test_utils::MockProvider;
+use aletheia_hermeneus::types::{CompletionRequest, CompletionResponse};
 use tokio_util::sync::CancellationToken;
 
 use super::*;
@@ -13,41 +10,6 @@ use super::*;
 use crate::handle::NousHandle;
 
 // --- Test infrastructure ---
-
-struct MockProvider {
-    // std::sync::Mutex is intentional: test mock, never crosses .await
-    response: Mutex<CompletionResponse>,
-}
-
-impl LlmProvider for MockProvider {
-    fn complete<'a>(
-        &'a self,
-        _request: &'a CompletionRequest,
-    ) -> std::pin::Pin<
-        Box<
-            dyn std::future::Future<Output = aletheia_hermeneus::error::Result<CompletionResponse>>
-                + Send
-                + 'a,
-        >,
-    > {
-        Box::pin(async {
-            #[expect(
-                clippy::expect_used,
-                reason = "test mock: poisoned lock means a test bug"
-            )]
-            Ok(self.response.lock().expect("lock poisoned").clone())
-        })
-    }
-
-    fn supported_models(&self) -> &[&str] {
-        &["test-model"]
-    }
-
-    #[expect(clippy::unnecessary_literal_bound, reason = "trait requires &str")]
-    fn name(&self) -> &str {
-        "mock"
-    }
-}
 
 fn test_config() -> NousConfig {
     NousConfig {
@@ -70,22 +32,9 @@ fn test_oikos() -> (tempfile::TempDir, Arc<Oikos>) {
 
 fn test_providers() -> Arc<ProviderRegistry> {
     let mut providers = ProviderRegistry::new();
-    providers.register(Box::new(MockProvider {
-        response: Mutex::new(CompletionResponse {
-            id: "resp-1".to_owned(),
-            model: "test-model".to_owned(),
-            stop_reason: StopReason::EndTurn,
-            content: vec![ContentBlock::Text {
-                text: "Hello from actor!".to_owned(),
-                citations: None,
-            }],
-            usage: Usage {
-                input_tokens: 100,
-                output_tokens: 50,
-                ..Usage::default()
-            },
-        }),
-    }));
+    providers.register(Box::new(
+        MockProvider::new("Hello from actor!").models(&["test-model"]),
+    ));
     Arc::new(providers)
 }
 

--- a/crates/nous/src/execute/tests.rs
+++ b/crates/nous/src/execute/tests.rs
@@ -5,12 +5,11 @@ use std::collections::HashSet;
 use std::future::Future;
 use std::path::PathBuf;
 use std::pin::Pin;
-use std::sync::{Arc, Mutex, RwLock};
+use std::sync::{Arc, RwLock};
 
 use aletheia_hermeneus::provider::ProviderRegistry;
-use aletheia_hermeneus::types::{
-    CompletionRequest, CompletionResponse, ContentBlock, StopReason, Usage,
-};
+use aletheia_hermeneus::test_utils::MockProvider;
+use aletheia_hermeneus::types::{CompletionResponse, ContentBlock, StopReason, Usage};
 use aletheia_koina::id::{NousId, SessionId, ToolName};
 use aletheia_organon::registry::{ToolExecutor, ToolRegistry};
 use aletheia_organon::types::{
@@ -23,57 +22,6 @@ use crate::pipeline::{InteractionSignal, PipelineContext, PipelineMessage};
 use crate::session::SessionState;
 
 // --- Test Infrastructure ---
-
-struct MockProvider {
-    // std::sync::Mutex is intentional: test mock, never crosses .await
-    responses: Mutex<Vec<CompletionResponse>>,
-}
-
-impl MockProvider {
-    fn with_responses(responses: Vec<CompletionResponse>) -> Self {
-        Self {
-            responses: Mutex::new(responses),
-        }
-    }
-}
-
-impl aletheia_hermeneus::provider::LlmProvider for MockProvider {
-    fn complete<'a>(
-        &'a self,
-        _request: &'a CompletionRequest,
-    ) -> std::pin::Pin<
-        Box<
-            dyn std::future::Future<Output = aletheia_hermeneus::error::Result<CompletionResponse>>
-                + Send
-                + 'a,
-        >,
-    > {
-        Box::pin(async {
-            #[expect(
-                clippy::expect_used,
-                reason = "test mock: poisoned lock means a test bug"
-            )]
-            let mut responses = self.responses.lock().expect("lock poisoned");
-            if responses.len() > 1 {
-                Ok(responses.remove(0))
-            } else {
-                Ok(responses[0].clone())
-            }
-        })
-    }
-
-    fn supported_models(&self) -> &[&str] {
-        &["test-model"]
-    }
-
-    #[expect(
-        clippy::unnecessary_literal_bound,
-        reason = "trait requires &str return"
-    )]
-    fn name(&self) -> &str {
-        "mock"
-    }
-}
 
 struct EchoExecutor;
 
@@ -208,9 +156,10 @@ fn make_registry_with(name: &str, executor: Box<dyn ToolExecutor>) -> ToolRegist
 #[tokio::test]
 async fn simple_text_response() {
     let mut providers = ProviderRegistry::new();
-    providers.register(Box::new(MockProvider::with_responses(vec![
-        make_text_response("Hello there!"),
-    ])));
+    providers.register(Box::new(
+        MockProvider::with_responses(vec![make_text_response("Hello there!")])
+            .models(&["test-model"]),
+    ));
 
     let tools = ToolRegistry::new();
     let result = execute(
@@ -236,10 +185,13 @@ async fn simple_text_response() {
 #[tokio::test]
 async fn single_tool_iteration() {
     let mut providers = ProviderRegistry::new();
-    providers.register(Box::new(MockProvider::with_responses(vec![
-        make_tool_response("exec", "toolu_1", serde_json::json!({"input": "test"})),
-        make_text_response("Done!"),
-    ])));
+    providers.register(Box::new(
+        MockProvider::with_responses(vec![
+            make_tool_response("exec", "toolu_1", serde_json::json!({"input": "test"})),
+            make_text_response("Done!"),
+        ])
+        .models(&["test-model"]),
+    ));
 
     let tools = make_registry_with("exec", Box::new(EchoExecutor));
 
@@ -269,11 +221,14 @@ async fn single_tool_iteration() {
 #[tokio::test]
 async fn multi_tool_iteration() {
     let mut providers = ProviderRegistry::new();
-    providers.register(Box::new(MockProvider::with_responses(vec![
-        make_tool_response("exec", "toolu_1", serde_json::json!({"input": "first"})),
-        make_tool_response("exec", "toolu_2", serde_json::json!({"input": "second"})),
-        make_text_response("All done!"),
-    ])));
+    providers.register(Box::new(
+        MockProvider::with_responses(vec![
+            make_tool_response("exec", "toolu_1", serde_json::json!({"input": "first"})),
+            make_tool_response("exec", "toolu_2", serde_json::json!({"input": "second"})),
+            make_text_response("All done!"),
+        ])
+        .models(&["test-model"]),
+    ));
 
     let tools = make_registry_with("exec", Box::new(EchoExecutor));
 
@@ -297,11 +252,10 @@ async fn multi_tool_iteration() {
 async fn loop_detection_triggers() {
     let mut providers = ProviderRegistry::new();
     let response = make_tool_response("exec", "toolu_1", serde_json::json!({"input": "same"}));
-    providers.register(Box::new(MockProvider::with_responses(vec![
-        response.clone(),
-        response.clone(),
-        response,
-    ])));
+    providers.register(Box::new(
+        MockProvider::with_responses(vec![response.clone(), response.clone(), response])
+            .models(&["test-model"]),
+    ));
 
     let tools = make_registry_with("exec", Box::new(EchoExecutor));
     let mut config = test_config();
@@ -327,7 +281,9 @@ async fn max_iterations_respected() {
     let responses: Vec<CompletionResponse> = (0..10)
         .map(|i| make_tool_response("exec", &format!("toolu_{i}"), serde_json::json!({"i": i})))
         .collect();
-    providers.register(Box::new(MockProvider::with_responses(responses)));
+    providers.register(Box::new(
+        MockProvider::with_responses(responses).models(&["test-model"]),
+    ));
 
     let tools = make_registry_with("exec", Box::new(EchoExecutor));
     let mut config = test_config();
@@ -351,10 +307,13 @@ async fn max_iterations_respected() {
 #[tokio::test]
 async fn tool_error_captured() {
     let mut providers = ProviderRegistry::new();
-    providers.register(Box::new(MockProvider::with_responses(vec![
-        make_tool_response("exec", "toolu_1", serde_json::json!({"input": "test"})),
-        make_text_response("Recovered"),
-    ])));
+    providers.register(Box::new(
+        MockProvider::with_responses(vec![
+            make_tool_response("exec", "toolu_1", serde_json::json!({"input": "test"})),
+            make_text_response("Recovered"),
+        ])
+        .models(&["test-model"]),
+    ));
 
     let tools = make_registry_with("exec", Box::new(ErrorExecutor));
 
@@ -429,10 +388,13 @@ fn signal_classification_error_recovery() {
 #[tokio::test]
 async fn usage_accumulates_across_iterations() {
     let mut providers = ProviderRegistry::new();
-    providers.register(Box::new(MockProvider::with_responses(vec![
-        make_tool_response("exec", "toolu_1", serde_json::json!({"input": "first"})),
-        make_text_response("Done"),
-    ])));
+    providers.register(Box::new(
+        MockProvider::with_responses(vec![
+            make_tool_response("exec", "toolu_1", serde_json::json!({"input": "first"})),
+            make_text_response("Done"),
+        ])
+        .models(&["test-model"]),
+    ));
 
     let tools = make_registry_with("exec", Box::new(EchoExecutor));
 
@@ -457,10 +419,13 @@ async fn usage_accumulates_across_iterations() {
 #[tokio::test]
 async fn tool_error_captured_not_propagated() {
     let mut providers = ProviderRegistry::new();
-    providers.register(Box::new(MockProvider::with_responses(vec![
-        make_tool_response("fail_tool", "tu_1", serde_json::json!({})),
-        make_text_response("recovered"),
-    ])));
+    providers.register(Box::new(
+        MockProvider::with_responses(vec![
+            make_tool_response("fail_tool", "tu_1", serde_json::json!({})),
+            make_text_response("recovered"),
+        ])
+        .models(&["test-model"]),
+    ));
 
     let tools = make_registry_with("fail_tool", Box::new(ErrorExecutor));
     let result = execute(
@@ -488,7 +453,9 @@ async fn max_iterations_stops_loop() {
     let responses: Vec<_> = (0..10)
         .map(|i| make_tool_response("echo", &format!("tu_{i}"), serde_json::json!({"i": i})))
         .collect();
-    providers.register(Box::new(MockProvider::with_responses(responses)));
+    providers.register(Box::new(
+        MockProvider::with_responses(responses).models(&["test-model"]),
+    ));
 
     let tools = make_registry_with("echo", Box::new(EchoExecutor));
     let mut config = test_config();
@@ -515,9 +482,9 @@ async fn max_iterations_stops_loop() {
 #[tokio::test]
 async fn text_response_no_tools() {
     let mut providers = ProviderRegistry::new();
-    providers.register(Box::new(MockProvider::with_responses(vec![
-        make_text_response("just text"),
-    ])));
+    providers.register(Box::new(
+        MockProvider::with_responses(vec![make_text_response("just text")]).models(&["test-model"]),
+    ));
 
     let tools = ToolRegistry::new();
     let result = execute(
@@ -606,9 +573,10 @@ fn classify_signals_both_server_tools() {
 #[tokio::test]
 async fn streaming_falls_back_to_non_streaming_for_mock() {
     let mut providers = ProviderRegistry::new();
-    providers.register(Box::new(MockProvider::with_responses(vec![
-        make_text_response("Hello streaming!"),
-    ])));
+    providers.register(Box::new(
+        MockProvider::with_responses(vec![make_text_response("Hello streaming!")])
+            .models(&["test-model"]),
+    ));
 
     let tools = ToolRegistry::new();
     let (tx, mut rx) = tokio::sync::mpsc::channel::<TurnStreamEvent>(64);
@@ -639,10 +607,13 @@ async fn streaming_falls_back_to_non_streaming_for_mock() {
 #[tokio::test]
 async fn streaming_tool_events_emitted() {
     let mut providers = ProviderRegistry::new();
-    providers.register(Box::new(MockProvider::with_responses(vec![
-        make_tool_response("exec", "toolu_1", serde_json::json!({"input": "test"})),
-        make_text_response("Done!"),
-    ])));
+    providers.register(Box::new(
+        MockProvider::with_responses(vec![
+            make_tool_response("exec", "toolu_1", serde_json::json!({"input": "test"})),
+            make_text_response("Done!"),
+        ])
+        .models(&["test-model"]),
+    ));
 
     let tools = make_registry_with("exec", Box::new(EchoExecutor));
     let (tx, mut rx) = tokio::sync::mpsc::channel::<TurnStreamEvent>(64);
@@ -685,9 +656,9 @@ async fn streaming_tool_events_emitted() {
 #[tokio::test]
 async fn empty_text_response() {
     let mut providers = ProviderRegistry::new();
-    providers.register(Box::new(MockProvider::with_responses(vec![
-        make_text_response(""),
-    ])));
+    providers.register(Box::new(
+        MockProvider::with_responses(vec![make_text_response("")]).models(&["test-model"]),
+    ));
 
     let tools = ToolRegistry::new();
     let result = execute(
@@ -729,7 +700,9 @@ async fn thinking_only_response() {
             ..Usage::default()
         },
     };
-    providers.register(Box::new(MockProvider::with_responses(vec![response])));
+    providers.register(Box::new(
+        MockProvider::with_responses(vec![response]).models(&["test-model"]),
+    ));
 
     let tools = ToolRegistry::new();
     let mut config = test_config();
@@ -844,9 +817,14 @@ fn classify_signals_multiple_flags() {
 #[tokio::test]
 async fn max_iterations_one_exits_immediately() {
     let mut providers = ProviderRegistry::new();
-    providers.register(Box::new(MockProvider::with_responses(vec![
-        make_tool_response("exec", "toolu_1", serde_json::json!({})),
-    ])));
+    providers.register(Box::new(
+        MockProvider::with_responses(vec![make_tool_response(
+            "exec",
+            "toolu_1",
+            serde_json::json!({}),
+        )])
+        .models(&["test-model"]),
+    ));
 
     let tools = make_registry_with("exec", Box::new(EchoExecutor));
     let mut config = test_config();

--- a/crates/nous/src/manager_tests.rs
+++ b/crates/nous/src/manager_tests.rs
@@ -1,48 +1,8 @@
 #![expect(clippy::expect_used, reason = "test assertions")]
-use std::sync::Mutex;
-
-use aletheia_hermeneus::provider::LlmProvider;
-use aletheia_hermeneus::types::{
-    CompletionRequest, CompletionResponse, ContentBlock, StopReason, Usage,
-};
+use aletheia_hermeneus::test_utils::MockProvider;
 
 use super::*;
 use crate::message::NousLifecycle;
-
-struct MockProvider {
-    // std::sync::Mutex is intentional: test mock, never crosses .await
-    response: Mutex<CompletionResponse>,
-}
-
-impl LlmProvider for MockProvider {
-    fn complete<'a>(
-        &'a self,
-        _request: &'a CompletionRequest,
-    ) -> std::pin::Pin<
-        Box<
-            dyn std::future::Future<Output = aletheia_hermeneus::error::Result<CompletionResponse>>
-                + Send
-                + 'a,
-        >,
-    > {
-        Box::pin(async {
-            #[expect(
-                clippy::expect_used,
-                reason = "test mock: poisoned lock means a test bug"
-            )]
-            Ok(self.response.lock().expect("lock poisoned").clone())
-        })
-    }
-
-    fn supported_models(&self) -> &[&str] {
-        &["test-model"]
-    }
-
-    #[expect(clippy::unnecessary_literal_bound, reason = "trait requires &str")]
-    fn name(&self) -> &str {
-        "mock"
-    }
-}
 
 fn test_oikos() -> (tempfile::TempDir, Arc<Oikos>) {
     let dir = tempfile::TempDir::new().expect("tmpdir");
@@ -59,22 +19,9 @@ fn test_oikos() -> (tempfile::TempDir, Arc<Oikos>) {
 
 fn test_providers() -> Arc<ProviderRegistry> {
     let mut providers = ProviderRegistry::new();
-    providers.register(Box::new(MockProvider {
-        response: Mutex::new(CompletionResponse {
-            id: "resp-1".to_owned(),
-            model: "test-model".to_owned(),
-            stop_reason: StopReason::EndTurn,
-            content: vec![ContentBlock::Text {
-                text: "Hello!".to_owned(),
-                citations: None,
-            }],
-            usage: Usage {
-                input_tokens: 100,
-                output_tokens: 50,
-                ..Usage::default()
-            },
-        }),
-    }));
+    providers.register(Box::new(
+        MockProvider::new("Hello!").models(&["test-model"]),
+    ));
     Arc::new(providers)
 }
 

--- a/crates/nous/src/pipeline_tests.rs
+++ b/crates/nous/src/pipeline_tests.rs
@@ -247,59 +247,18 @@ async fn assemble_context_populates_pipeline() {
 // --- run_pipeline ---
 
 #[tokio::test]
-#[expect(
-    clippy::too_many_lines,
-    reason = "integration test with full pipeline setup"
-)]
 async fn run_pipeline_simple() {
     use std::collections::HashSet;
     use std::fs;
     use std::path::PathBuf;
-    use std::sync::{Arc, Mutex, RwLock};
+    use std::sync::{Arc, RwLock};
 
-    use aletheia_hermeneus::provider::{LlmProvider, ProviderRegistry};
-    use aletheia_hermeneus::types::{
-        CompletionRequest, CompletionResponse, ContentBlock, StopReason, Usage,
-    };
+    use aletheia_hermeneus::provider::ProviderRegistry;
+    use aletheia_hermeneus::test_utils::MockProvider;
     use aletheia_koina::id::{NousId, SessionId};
     use aletheia_organon::registry::ToolRegistry;
     use aletheia_organon::types::ToolContext;
     use tempfile::TempDir;
-
-    struct MockProvider {
-        response: Mutex<CompletionResponse>,
-    }
-    impl LlmProvider for MockProvider {
-        fn complete<'a>(
-            &'a self,
-            _request: &'a CompletionRequest,
-        ) -> std::pin::Pin<
-            Box<
-                dyn std::future::Future<
-                        Output = aletheia_hermeneus::error::Result<CompletionResponse>,
-                    > + Send
-                    + 'a,
-            >,
-        > {
-            Box::pin(async {
-                #[expect(
-                    clippy::expect_used,
-                    reason = "test mock: poisoned lock means a test bug"
-                )]
-                Ok(self.response.lock().expect("lock poisoned").clone())
-            })
-        }
-        fn supported_models(&self) -> &[&str] {
-            &["test-model"]
-        }
-        #[expect(
-            clippy::unnecessary_literal_bound,
-            reason = "trait requires &str return"
-        )]
-        fn name(&self) -> &str {
-            "mock"
-        }
-    }
 
     let dir = TempDir::new().unwrap();
     let root = dir.path();
@@ -317,22 +276,9 @@ async fn run_pipeline_simple() {
     let pipeline_config = PipelineConfig::default();
 
     let mut providers = ProviderRegistry::new();
-    providers.register(Box::new(MockProvider {
-        response: Mutex::new(CompletionResponse {
-            id: "resp-1".to_owned(),
-            model: "test-model".to_owned(),
-            stop_reason: StopReason::EndTurn,
-            content: vec![ContentBlock::Text {
-                text: "Hello from pipeline!".to_owned(),
-                citations: None,
-            }],
-            usage: Usage {
-                input_tokens: 100,
-                output_tokens: 50,
-                ..Usage::default()
-            },
-        }),
-    }));
+    providers.register(Box::new(
+        MockProvider::new("Hello from pipeline!").models(&["test-model"]),
+    ));
 
     let tools = ToolRegistry::new();
     let tool_ctx = ToolContext {

--- a/crates/nous/src/spawn_svc.rs
+++ b/crates/nous/src/spawn_svc.rs
@@ -187,51 +187,14 @@ impl SpawnService for SpawnServiceImpl {
 #[cfg(test)]
 #[expect(clippy::expect_used, reason = "test assertions")]
 mod tests {
-    use std::sync::Mutex;
-
     use aletheia_hermeneus::provider::LlmProvider;
+    use aletheia_hermeneus::test_utils::MockProvider;
     use aletheia_hermeneus::types::{
         CompletionRequest, CompletionResponse, ContentBlock, StopReason, Usage,
     };
     use aletheia_taxis::oikos::Oikos;
 
     use super::*;
-
-    struct MockProvider {
-        // std::sync::Mutex is intentional: test mock, never crosses .await
-        response: Mutex<CompletionResponse>,
-    }
-
-    impl LlmProvider for MockProvider {
-        fn complete<'a>(
-            &'a self,
-            _request: &'a CompletionRequest,
-        ) -> std::pin::Pin<
-            Box<
-                dyn std::future::Future<
-                        Output = aletheia_hermeneus::error::Result<CompletionResponse>,
-                    > + Send
-                    + 'a,
-            >,
-        > {
-            Box::pin(async {
-                #[expect(
-                    clippy::expect_used,
-                    reason = "test mock: poisoned lock means a test bug"
-                )]
-                Ok(self.response.lock().expect("lock poisoned").clone())
-            })
-        }
-
-        fn supported_models(&self) -> &[&str] {
-            &["claude-sonnet-4-20250514", "claude-haiku-4-5-20251001"]
-        }
-
-        #[expect(clippy::unnecessary_literal_bound, reason = "trait requires &str")]
-        fn name(&self) -> &str {
-            "mock"
-        }
-    }
 
     fn test_oikos() -> (tempfile::TempDir, Arc<Oikos>) {
         let dir = tempfile::TempDir::new().expect("tmpdir");
@@ -243,23 +206,25 @@ mod tests {
     }
 
     fn test_providers() -> Arc<ProviderRegistry> {
+        let response = CompletionResponse {
+            id: "msg_mock".to_owned(),
+            model: "mock-model".to_owned(),
+            stop_reason: StopReason::EndTurn,
+            content: vec![ContentBlock::Text {
+                text: "Sub-agent result".to_owned(),
+                citations: None,
+            }],
+            usage: Usage {
+                input_tokens: 200,
+                output_tokens: 80,
+                ..Usage::default()
+            },
+        };
         let mut providers = ProviderRegistry::new();
-        providers.register(Box::new(MockProvider {
-            response: Mutex::new(CompletionResponse {
-                id: "resp-1".to_owned(),
-                model: "claude-sonnet-4-20250514".to_owned(),
-                stop_reason: StopReason::EndTurn,
-                content: vec![ContentBlock::Text {
-                    text: "Sub-agent result".to_owned(),
-                    citations: None,
-                }],
-                usage: Usage {
-                    input_tokens: 200,
-                    output_tokens: 80,
-                    ..Usage::default()
-                },
-            }),
-        }));
+        providers.register(Box::new(
+            MockProvider::with_responses(vec![response])
+                .models(&["claude-sonnet-4-20250514", "claude-haiku-4-5-20251001"]),
+        ));
         Arc::new(providers)
     }
 

--- a/crates/pylon/Cargo.toml
+++ b/crates/pylon/Cargo.toml
@@ -56,6 +56,7 @@ aletheia-nous = { path = "../nous" }
 aletheia-symbolon = { path = "../symbolon" }
 
 [dev-dependencies]
+aletheia-hermeneus = { path = "../hermeneus", features = ["test-utils"] }
 http-body-util = "0.1"
 jiff = { workspace = true }
 # jsonwebtoken 10.x pins rand 0.8; no released version uses rand 0.9.

--- a/crates/pylon/src/tests.rs
+++ b/crates/pylon/src/tests.rs
@@ -12,8 +12,8 @@ use axum::http::{Request, StatusCode};
 use secrecy::SecretString;
 use tower::ServiceExt;
 
-use aletheia_hermeneus::provider::{LlmProvider, ProviderRegistry};
-use aletheia_hermeneus::types::*;
+use aletheia_hermeneus::provider::ProviderRegistry;
+use aletheia_hermeneus::test_utils::MockProvider;
 use aletheia_mneme::store::SessionStore;
 use aletheia_nous::config::{NousConfig, PipelineConfig};
 use aletheia_nous::manager::NousManager;
@@ -32,55 +32,6 @@ fn test_security_config() -> SecurityConfig {
     SecurityConfig {
         csrf_enabled: false,
         ..SecurityConfig::default()
-    }
-}
-
-struct MockProvider {
-    response: CompletionResponse,
-}
-
-impl MockProvider {
-    fn new() -> Self {
-        Self {
-            response: CompletionResponse {
-                id: "msg_test".to_owned(),
-                model: "mock-model".to_owned(),
-                stop_reason: StopReason::EndTurn,
-                content: vec![ContentBlock::Text {
-                    text: "Hello from mock!".to_owned(),
-                    citations: None,
-                }],
-                usage: Usage {
-                    input_tokens: 10,
-                    output_tokens: 5,
-                    ..Usage::default()
-                },
-            },
-        }
-    }
-}
-
-impl LlmProvider for MockProvider {
-    fn complete<'a>(
-        &'a self,
-        _request: &'a CompletionRequest,
-    ) -> std::pin::Pin<
-        Box<
-            dyn std::future::Future<Output = aletheia_hermeneus::error::Result<CompletionResponse>>
-                + Send
-                + 'a,
-        >,
-    > {
-        Box::pin(async { Ok(self.response.clone()) })
-    }
-
-    fn supported_models(&self) -> &[&str] {
-        &["mock-model", "claude-opus-4-20250514"]
-    }
-
-    #[expect(clippy::unnecessary_literal_bound, reason = "trait requires &str")]
-    fn name(&self) -> &str {
-        "mock"
     }
 }
 
@@ -120,7 +71,9 @@ async fn test_state_with_provider(with_provider: bool) -> (Arc<AppState>, tempfi
 
     let mut provider_registry = ProviderRegistry::new();
     if with_provider {
-        provider_registry.register(Box::new(MockProvider::new()));
+        provider_registry.register(Box::new(
+            MockProvider::new("Hello from mock!").models(&["mock-model", "claude-opus-4-20250514"]),
+        ));
     }
     let provider_registry = Arc::new(provider_registry);
     let tool_registry = Arc::new(ToolRegistry::new());


### PR DESCRIPTION
## Summary
- Extract a single `MockProvider` into `hermeneus::test_utils` behind `feature = "test-utils"`, replacing ~10 duplicate implementations across 5 crates (~400 lines removed)
- Supports fixed text responses, response queues, error injection, model routing, and request capturing via builder pattern
- Specialized mocks (CapturingMockProvider, SequentialMockProvider, SlowProvider, PanickingProvider) remain local where needed

## Test plan
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` — 1320+ tests pass; 2 pre-existing failures unrelated to this change (`integration_server` TLS provider, `skill_decay` flaky test)

## Observations
- `CapturingMockProvider` and `SequentialMockProvider` in integration-tests use an external `Arc<Mutex<Vec>>` pattern not supported by the shared mock — kept local
- `spawn_svc.rs` tests assert exact token counts (200/80), so `test_providers()` uses `MockProvider::with_responses` with a custom `Usage` instead of `MockProvider::new`
- Removed stale `#[expect]` attributes for `clippy::expect_used` (no longer needed after removing inline mocks) and `clippy::too_many_lines` / `clippy::unnecessary_literal_bound` (functions shortened / field replaced literal)

Closes #1423

🤖 Generated with [Claude Code](https://claude.com/claude-code)