### PR TITLE
api(workspace): add #[must_use] to public functions with unused return values

### DIFF
--- a/crates/agora/src/registry.rs
+++ b/crates/agora/src/registry.rs
@@ -36,6 +36,7 @@ impl ChannelRegistry {
     /// # Errors
     ///
     /// Returns [`crate::error::Error::DuplicateChannel`] if a provider with the same ID is already registered.
+    #[must_use = "this returns a Result that may contain an error"]
     pub fn register(&mut self, provider: Arc<dyn ChannelProvider>) -> Result<()> {
         let id = provider.id().to_owned();
         ensure!(

--- a/crates/agora/src/router.rs
+++ b/crates/agora/src/router.rs
@@ -57,6 +57,7 @@ impl MessageRouter {
     }
 
     /// Resolve which nous should handle this message.
+    #[must_use = "this returns None when no matching route is found"]
     pub fn resolve(&self, msg: &InboundMessage) -> Option<RouteDecision<'_>> {
         let decision = self.match_route(msg);
         if let Some(ref d) = decision {

--- a/crates/agora/src/semeion/client.rs
+++ b/crates/agora/src/semeion/client.rs
@@ -54,6 +54,7 @@ impl SignalClient {
     /// # Errors
     ///
     /// Returns [`super::error::Error::Http`] if the HTTP client cannot be constructed.
+    #[must_use = "this returns a Result that may contain a construction error"]
     pub fn new(base_url: &str) -> Result<Self> {
         let base = normalize_url(base_url);
 

--- a/crates/agora/src/semeion/envelope.rs
+++ b/crates/agora/src/semeion/envelope.rs
@@ -72,6 +72,7 @@ pub struct Attachment {
 ///
 /// Returns `None` for sync messages, receipt messages, typing indicators,
 /// data messages with no text, and messages with no identifiable sender.
+#[must_use = "this returns None when the envelope contains no message"]
 pub fn extract_message(envelope: &SignalEnvelope) -> Option<InboundMessage> {
     let data = envelope.data_message.as_ref()?;
 

--- a/crates/aletheia/src/commands/agent_io.rs
+++ b/crates/aletheia/src/commands/agent_io.rs
@@ -166,6 +166,7 @@ use aletheia_taxis::config::resolve_nous;
 use aletheia_taxis::loader::load_config;
 use aletheia_taxis::oikos::Oikos;
 
+#[must_use = "this returns a Result that may contain an I/O error"]
 pub fn export_agent(instance_root: Option<&PathBuf>, args: &ExportArgs) -> Result<()> {
     let nous_id = &args.nous_id;
     let oikos = match instance_root {
@@ -240,6 +241,7 @@ pub fn export_agent(instance_root: Option<&PathBuf>, args: &ExportArgs) -> Resul
     Ok(())
 }
 
+#[must_use = "this returns a Result that may contain an I/O error"]
 pub fn import_agent(instance_root: Option<&PathBuf>, args: &ImportArgs) -> Result<()> {
     let json = std::fs::read_to_string(&args.file)
         .with_context(|| format!("failed to read {}", args.file.display()))?;
@@ -316,6 +318,7 @@ pub fn import_agent(instance_root: Option<&PathBuf>, args: &ImportArgs) -> Resul
     clippy::too_many_lines,
     reason = "CLI dispatch is inherently verbose — splitting would hurt readability"
 )]
+#[must_use = "this returns a Result that may contain an error"]
 pub fn seed_skills(args: &SeedSkillsArgs) -> Result<()> {
     use aletheia_mneme::skill::{SkillContent, parse_skill_md, scan_skill_dir};
 
@@ -464,6 +467,7 @@ pub fn seed_skills(args: &SeedSkillsArgs) -> Result<()> {
 ///
 /// Reads skill facts from an in-process `KnowledgeStore`, converts them to
 /// `SkillContent`, and writes `.claude/skills/<slug>/SKILL.md` files.
+#[must_use = "this returns a Result that may contain an I/O error"]
 pub fn export_skills(instance_root: Option<&PathBuf>, args: &ExportSkillsArgs) -> Result<()> {
     #[cfg(feature = "recall")]
     {
@@ -546,6 +550,7 @@ pub fn export_skills(instance_root: Option<&PathBuf>, args: &ExportSkillsArgs) -
     }
 }
 
+#[must_use = "this returns a Result that may contain an error"]
 pub fn review_skills(instance_root: Option<&PathBuf>, args: &ReviewSkillsArgs) -> Result<()> {
     #[cfg(feature = "recall")]
     {

--- a/crates/daemon/src/schedule.rs
+++ b/crates/daemon/src/schedule.rs
@@ -113,6 +113,7 @@ impl Schedule {
         clippy::expect_used,
         reason = "timestamp conversions are within valid ranges; interval durations fit in i64 nanos for any reasonable schedule"
     )]
+    #[must_use = "this returns a Result that may contain a scheduling error"]
     pub fn next_run(&self) -> Result<Option<jiff::Timestamp>> {
         match self {
             Self::Cron(expr) => {
@@ -154,6 +155,7 @@ impl Schedule {
         clippy::expect_used,
         reason = "timestamp conversions within valid ranges; 24h subtraction from current time cannot overflow"
     )]
+    #[must_use = "this returns a Result that may contain an error"]
     pub fn missed_since(&self, last_run: jiff::Timestamp) -> Result<bool> {
         let Self::Cron(expr) = self else {
             return Ok(false);

--- a/crates/daemon/src/state.rs
+++ b/crates/daemon/src/state.rs
@@ -30,6 +30,7 @@ pub struct TaskStateStore {
 
 impl TaskStateStore {
     /// Open (or create) the task state database at `path`.
+    #[must_use = "this returns a Result that may contain a construction error"]
     pub fn open(path: &Path) -> Result<Self> {
         let conn = rusqlite::Connection::open(path).map_err(|e| {
             crate::error::TaskFailedSnafu {
@@ -62,6 +63,7 @@ impl TaskStateStore {
     }
 
     /// Load all persisted task states.
+    #[must_use = "this returns a Result that may contain a read error"]
     pub fn load_all(&self) -> Result<Vec<TaskState>> {
         let mut stmt = self
             .conn
@@ -108,6 +110,7 @@ impl TaskStateStore {
     }
 
     /// Persist (upsert) the state for a task.
+    #[must_use = "this returns a Result that may contain a write error"]
     pub fn save(&self, state: &TaskState) -> Result<()> {
         self.conn
             .execute(

--- a/crates/dianoia/src/project.rs
+++ b/crates/dianoia/src/project.rs
@@ -63,6 +63,7 @@ impl Project {
     }
 
     /// Advance project state via a transition.
+    #[must_use = "this returns a Result that may indicate a state transition failure"]
     pub fn advance(&mut self, transition: Transition) -> Result<()> {
         let current = self.state.clone();
         self.state = current.transition(transition)?;

--- a/crates/dianoia/src/state.rs
+++ b/crates/dianoia/src/state.rs
@@ -68,6 +68,7 @@ pub enum Transition {
 impl ProjectState {
     /// Attempt a state transition. Returns the new state or an error
     /// if the transition is invalid from the current state.
+    #[must_use = "this returns a Result that may indicate a state transition failure"]
     pub fn transition(self, t: Transition) -> Result<Self> {
         match (&self, &t) {
             (Self::Created, Transition::StartQuestioning) => Ok(Self::Questioning),

--- a/crates/dianoia/src/workspace.rs
+++ b/crates/dianoia/src/workspace.rs
@@ -33,6 +33,7 @@ impl ProjectWorkspace {
     /// # Errors
     ///
     /// Returns [`crate::error::Error::WorkspaceIo`] if the workspace directories cannot be created.
+    #[must_use = "this returns a Result that may contain a write error"]
     pub fn create(root: impl Into<PathBuf>) -> Result<Self> {
         let root = root.into();
         let layout = Self::build_layout(&root);
@@ -49,6 +50,7 @@ impl ProjectWorkspace {
     }
 
     /// Open an existing workspace.
+    #[must_use = "this returns a Result that may contain a construction error"]
     pub fn open(root: impl Into<PathBuf>) -> Result<Self> {
         let root = root.into();
         if !root.exists() {
@@ -63,6 +65,7 @@ impl ProjectWorkspace {
     ///
     /// Returns [`crate::error::Error::WorkspaceSerialize`] if the project cannot be serialized to JSON.
     /// Returns [`crate::error::Error::WorkspaceIo`] if the project file cannot be written.
+    #[must_use = "this returns a Result that may contain a write error"]
     pub fn save_project(&self, project: &Project) -> Result<()> {
         let layout = self.layout();
         let json = serde_json::to_string_pretty(project).context(error::WorkspaceSerializeSnafu)?;
@@ -73,6 +76,7 @@ impl ProjectWorkspace {
     }
 
     /// Load project state from disk.
+    #[must_use = "this returns a Result that may contain a read error"]
     pub fn load_project(&self) -> Result<Project> {
         let layout = self.layout();
         if !layout.project_file.exists() {
@@ -91,6 +95,7 @@ impl ProjectWorkspace {
     }
 
     /// Write a blocker file for stuck detection integration.
+    #[must_use = "this returns a Result that may contain a write error"]
     pub fn write_blocker(&self, phase_id: &str, blocker: &Blocker) -> Result<()> {
         let layout = self.layout();
         let phase_blockers = layout.blockers_dir.join(phase_id);
@@ -109,6 +114,7 @@ impl ProjectWorkspace {
     }
 
     /// Read all blockers for a phase.
+    #[must_use = "this returns a Result that may contain a read error"]
     pub fn read_blockers(&self, phase_id: &str) -> Result<Vec<Blocker>> {
         let layout = self.layout();
         let phase_blockers = layout.blockers_dir.join(phase_id);

--- a/crates/eval/src/scenario.rs
+++ b/crates/eval/src/scenario.rs
@@ -68,6 +68,7 @@ pub trait Scenario: Send + Sync {
 
 /// Assert a condition, returning an assertion error if it fails.
 #[tracing::instrument(skip_all)]
+#[must_use = "this returns a Result that may contain an assertion failure"]
 pub fn assert_eval(condition: bool, message: impl Into<String>) -> Result<()> {
     if condition {
         Ok(())
@@ -101,6 +102,7 @@ pub fn assert_eq_eval<T: PartialEq + std::fmt::Debug>(
 /// When neither `expected_contains` nor `expected_pattern` is set, accepts any
 /// non-empty response and logs a warning about missing validation criteria.
 #[tracing::instrument(skip(text), fields(scenario_id = meta.id, text_len = text.len()))]
+#[must_use = "this returns a Result that may indicate validation failure"]
 pub fn validate_response(meta: &ScenarioMeta, text: &str) -> Result<()> {
     if meta.expected_contains.is_none() && meta.expected_pattern.is_none() {
         tracing::warn!(

--- a/crates/eval/src/sse.rs
+++ b/crates/eval/src/sse.rs
@@ -21,6 +21,7 @@ pub async fn parse_sse_stream(response: reqwest::Response) -> Result<Vec<ParsedS
 
 /// Parse raw SSE text into events. Exposed for testing.
 #[tracing::instrument(skip(text), fields(text_len = text.len()))]
+#[must_use = "this returns a Result that may contain a parse error"]
 pub fn parse_sse_text(text: &str) -> Result<Vec<ParsedSseEvent>> {
     let mut events = Vec::new();
     let mut current_event_type = String::new();
@@ -131,6 +132,7 @@ pub struct UsageData {
 }
 
 #[tracing::instrument(skip_all, fields(event_count = events.len()))]
+#[must_use = "this returns None when usage data is not present"]
 pub fn extract_usage(events: &[ParsedSseEvent]) -> Option<UsageData> {
     events
         .iter()

--- a/crates/hermeneus/src/anthropic/client.rs
+++ b/crates/hermeneus/src/anthropic/client.rs
@@ -107,6 +107,7 @@ impl AnthropicProvider {
     ///
     /// # Errors
     /// Returns `ProviderInit` if `api_key` is missing.
+    #[must_use = "this returns a Result that may contain a construction error"]
     pub fn from_config(config: &ProviderConfig) -> Result<Self> {
         let api_key = config
             .api_key

--- a/crates/hermeneus/src/fallback.rs
+++ b/crates/hermeneus/src/fallback.rs
@@ -172,7 +172,10 @@ mod tests {
         }
     }
 
-    #[expect(clippy::unnecessary_wraps, reason = "returns Result to match Vec<Result> in mock")]
+    #[expect(
+        clippy::unnecessary_wraps,
+        reason = "returns Result to match Vec<Result> in mock"
+    )]
     fn ok_response(model: &str) -> Result<CompletionResponse> {
         Ok(CompletionResponse {
             id: "resp-1".to_owned(),

--- a/crates/hermeneus/src/health.rs
+++ b/crates/hermeneus/src/health.rs
@@ -116,6 +116,7 @@ impl ProviderHealthTracker {
     /// Returns `Ok(())` if Up or Degraded. Returns `Err(health)` if Down,
     /// unless the cooldown has elapsed (auto-transitions to Degraded).
     /// `Down(AuthFailure)` never auto-recovers.
+    #[must_use = "this returns a Result that may indicate validation failure"]
     pub fn check_available(&self) -> Result<(), ProviderHealth> {
         #[expect(
             clippy::expect_used,

--- a/crates/integration-tests/tests/pipeline_assembly.rs
+++ b/crates/integration-tests/tests/pipeline_assembly.rs
@@ -40,8 +40,8 @@ fn pipeline_context_guard_blocks_flow() {
 fn loop_detector_integrates_with_guard() {
     let mut detector = LoopDetector::new(3);
 
-    detector.record("exec", "hash1");
-    detector.record("exec", "hash1");
+    let _ = detector.record("exec", "hash1");
+    let _ = detector.record("exec", "hash1");
     let loop_result = detector.record("exec", "hash1");
 
     let guard = match loop_result {

--- a/crates/koina/src/id.rs
+++ b/crates/koina/src/id.rs
@@ -17,6 +17,7 @@ impl NousId {
     /// # Errors
     /// Returns an error if the ID is empty, exceeds 64 characters,
     /// or contains characters other than lowercase alphanumeric and hyphens.
+    #[must_use = "this returns a Result that may contain a construction error"]
     pub fn new(id: impl Into<CompactString>) -> Result<Self, IdError> {
         let id = id.into();
         validate_id(&id, "NousId")?;
@@ -82,6 +83,7 @@ impl SessionId {
     ///
     /// # Errors
     /// Returns an error if the string is not a valid ULID.
+    #[must_use = "this returns a Result that may contain a construction error"]
     pub fn parse(s: &str) -> Result<Self, IdError> {
         let ulid = s
             .parse::<ulid::Ulid>()
@@ -177,6 +179,7 @@ impl ToolName {
     /// # Errors
     /// Returns an error if the name is empty, exceeds 128 characters,
     /// or contains characters other than alphanumeric, hyphens, and underscores.
+    #[must_use = "this returns a Result that may contain a construction error"]
     pub fn new(name: impl Into<CompactString>) -> Result<Self, IdError> {
         let name = name.into();
         if name.is_empty() {

--- a/crates/koina/src/redacting_layer.rs
+++ b/crates/koina/src/redacting_layer.rs
@@ -267,7 +267,9 @@ mod tests {
     }
 
     fn output_string(buffer: &Arc<Mutex<Vec<u8>>>) -> String {
-        let guard = buffer.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        let guard = buffer
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         String::from_utf8_lossy(&guard).into_owned()
     }
 

--- a/crates/mneme/src/backup.rs
+++ b/crates/mneme/src/backup.rs
@@ -89,6 +89,7 @@ impl<'a> BackupManager<'a> {
     /// sequences. Any future changes to path construction MUST go through
     /// `validate_backup_path` (a private helper in this module).
     #[instrument(skip(self))]
+    #[must_use = "this returns a Result that may contain a write error"]
     pub fn create_backup(&self) -> Result<BackupResult> {
         std::fs::create_dir_all(&self.backup_dir).context(error::IoSnafu {
             path: self.backup_dir.clone(),
@@ -135,6 +136,7 @@ impl<'a> BackupManager<'a> {
 
     /// Export all sessions as individual JSON files.
     #[instrument(skip(self))]
+    #[must_use = "this returns a Result that may contain an I/O error"]
     pub fn export_sessions_json(&self, output_dir: &Path) -> Result<ExportResult> {
         std::fs::create_dir_all(output_dir).context(error::IoSnafu {
             path: output_dir.to_path_buf(),
@@ -171,6 +173,7 @@ impl<'a> BackupManager<'a> {
 
     /// List available backup files.
     #[instrument(skip(self))]
+    #[must_use = "this returns a Result that may contain a query error"]
     pub fn list_backups(&self) -> Result<Vec<BackupInfo>> {
         if !self.backup_dir.exists() {
             return Ok(Vec::new());
@@ -208,6 +211,7 @@ impl<'a> BackupManager<'a> {
 
     /// Prune old backups, keeping the N most recent.
     #[instrument(skip(self))]
+    #[must_use = "this returns a Result that may contain a deletion error"]
     pub fn prune_backups(&self, keep: usize) -> Result<u32> {
         let backups = self.list_backups()?;
         let mut removed = 0u32;

--- a/crates/mneme/src/extract/mod.rs
+++ b/crates/mneme/src/extract/mod.rs
@@ -251,6 +251,7 @@ Rules:
     ///
     /// Strips markdown code fences if present.
     #[instrument(skip(self, response))]
+    #[must_use = "this returns a Result that may contain a parse error"]
     pub fn parse_response(&self, response: &str) -> Result<Extraction, ExtractionError> {
         let trimmed = strip_code_fences(response);
         serde_json::from_str(trimmed).context(ParseResponseSnafu)

--- a/crates/mneme/src/id.rs
+++ b/crates/mneme/src/id.rs
@@ -23,6 +23,7 @@ macro_rules! define_id {
             /// # Errors
             /// Returns `IdValidationError` if the value is empty or exceeds
             /// the maximum length.
+            #[must_use = "this returns a Result that may contain a construction error"]
             pub fn new(id: impl Into<String>) -> Result<Self, IdValidationError> {
                 let id = id.into();
                 if id.is_empty() {

--- a/crates/mneme/src/migration.rs
+++ b/crates/mneme/src/migration.rs
@@ -167,6 +167,7 @@ pub struct PendingMigration {
 /// Migrations are applied in version order. Each migration runs inside a
 /// transaction: the up SQL executes, then the version is recorded. If any
 /// migration fails, the transaction rolls back and the error is returned.
+#[must_use = "this returns a Result that may contain a migration error"]
 pub fn run_migrations(conn: &Connection) -> Result<MigrationResult> {
     let was_fresh = !schema_version_table_exists(conn);
 
@@ -235,6 +236,7 @@ pub fn run_migrations(conn: &Connection) -> Result<MigrationResult> {
 }
 
 /// Report pending migrations without applying them.
+#[must_use = "this returns a Result that may indicate validation failure"]
 pub fn check_migrations(conn: &Connection) -> Result<Vec<PendingMigration>> {
     bootstrap_version_table(conn)?;
     let current = get_schema_version(conn);

--- a/crates/mneme/src/retention.rs
+++ b/crates/mneme/src/retention.rs
@@ -63,6 +63,7 @@ impl RetentionPolicy {
         clippy::expect_used,
         reason = "timestamp arithmetic uses bounded durations well within i64 range"
     )]
+    #[must_use = "this returns a Result that may contain an error"]
     pub fn apply(&self, conn: &Connection, archive_dir: &Path) -> Result<RetentionResult> {
         let page_size = get_page_size(conn);
         let free_before = get_free_pages(conn);

--- a/crates/mneme/src/skill.rs
+++ b/crates/mneme/src/skill.rs
@@ -104,6 +104,7 @@ impl std::fmt::Display for SkillParseError {
 ///
 /// Supports optional YAML frontmatter (delimited by `---`) with `tools` and
 /// `domains` fields. Falls back to extracting from markdown sections.
+#[must_use = "this returns a Result that may contain a parse error"]
 pub fn parse_skill_md(source: &str, slug: &str) -> Result<SkillContent, SkillParseError> {
     let err = |reason: &str| SkillParseError {
         path: slug.to_owned(),
@@ -284,6 +285,7 @@ fn derive_domain_tags(slug: &str) -> Vec<String> {
 /// Scan a directory for subdirectories containing SKILL.md files.
 ///
 /// Returns `(slug, content_string)` pairs for each found skill.
+#[must_use = "this returns a Result that may contain an error"]
 pub fn scan_skill_dir(dir: &std::path::Path) -> Result<Vec<(String, String)>, std::io::Error> {
     let mut skills = Vec::new();
 

--- a/crates/mneme/src/skills/candidate.rs
+++ b/crates/mneme/src/skills/candidate.rs
@@ -63,6 +63,7 @@ impl SkillCandidate {
     /// # Errors
     ///
     /// Returns a [`serde_json::Error`] if serialisation fails.
+    #[must_use = "this returns a Result that may contain a serialization error"]
     pub fn to_json(&self) -> Result<String, serde_json::Error> {
         serde_json::to_string(self)
     }
@@ -72,6 +73,7 @@ impl SkillCandidate {
     /// # Errors
     ///
     /// Returns a [`serde_json::Error`] if the JSON is malformed or the schema changed.
+    #[must_use = "this returns a Result that may contain a construction error"]
     pub fn from_json(json: &str) -> Result<Self, serde_json::Error> {
         serde_json::from_str(json)
     }

--- a/crates/mneme/src/skills/extract.rs
+++ b/crates/mneme/src/skills/extract.rs
@@ -416,6 +416,7 @@ impl PendingSkill {
     /// # Errors
     ///
     /// Returns a [`serde_json::Error`] if serialization fails.
+    #[must_use = "this returns a Result that may contain a serialization error"]
     pub fn to_json(&self) -> Result<String, serde_json::Error> {
         serde_json::to_string(self)
     }
@@ -425,6 +426,7 @@ impl PendingSkill {
     /// # Errors
     ///
     /// Returns a [`serde_json::Error`] if the JSON is malformed.
+    #[must_use = "this returns a Result that may contain a construction error"]
     pub fn from_json(json: &str) -> Result<Self, serde_json::Error> {
         serde_json::from_str(json)
     }

--- a/crates/mneme/src/store/message.rs
+++ b/crates/mneme/src/store/message.rs
@@ -148,6 +148,7 @@ impl SessionStore {
 
     /// Get message history for a session.
     #[instrument(skip(self))]
+    #[must_use = "this returns a Result that may contain a query error"]
     pub fn get_history(&self, session_id: &str, limit: Option<i64>) -> Result<Vec<Message>> {
         let mut messages = Vec::new();
 
@@ -229,6 +230,7 @@ impl SessionStore {
 
     /// Mark messages as distilled and recalculate session token count.
     #[instrument(skip(self, seqs), fields(count = seqs.len()))]
+    #[must_use = "this returns a Result that may contain a write error"]
     pub fn mark_messages_distilled(&self, session_id: &str, seqs: &[i64]) -> Result<()> {
         if seqs.is_empty() {
             return Ok(());
@@ -292,6 +294,7 @@ impl SessionStore {
     /// unnecessary because the UNIQUE constraint is only violated if seq 0 already exists.
     /// Deleting the old summary first makes seq 0 available without any renumbering.
     #[instrument(skip(self, content))]
+    #[must_use = "this returns a Result that may contain a write error"]
     pub fn insert_distillation_summary(&self, session_id: &str, content: &str) -> Result<()> {
         let tx = self
             .conn
@@ -392,6 +395,7 @@ impl SessionStore {
 
     /// Check if usage has already been recorded for a given session + turn.
     #[instrument(skip(self), level = "debug")]
+    #[must_use = "this returns a Result that may contain a query error"]
     pub fn usage_exists_for_turn(&self, session_id: &str, turn_seq: i64) -> Result<bool> {
         let exists: bool = self
             .conn
@@ -406,6 +410,7 @@ impl SessionStore {
 
     /// Record token usage for a turn.
     #[instrument(skip(self, record), level = "debug")]
+    #[must_use = "this returns a Result that may contain a write error"]
     pub fn record_usage(&self, record: &UsageRecord) -> Result<()> {
         self.conn
             .execute(

--- a/crates/mneme/src/store/peripherals.rs
+++ b/crates/mneme/src/store/peripherals.rs
@@ -32,6 +32,7 @@ impl SessionStore {
 
     /// Get notes for a session.
     #[instrument(skip(self))]
+    #[must_use = "this returns a Result that may contain a query error"]
     pub fn get_notes(&self, session_id: &str) -> Result<Vec<AgentNote>> {
         let mut stmt = self
             .conn
@@ -62,6 +63,7 @@ impl SessionStore {
 
     /// Delete a note by ID.
     #[instrument(skip(self))]
+    #[must_use = "this returns a Result that may contain a deletion error"]
     pub fn delete_note(&self, note_id: i64) -> Result<bool> {
         let rows = self
             .conn
@@ -99,6 +101,7 @@ impl SessionStore {
 
     /// Read a blackboard entry by key, filtering expired entries.
     #[instrument(skip(self))]
+    #[must_use = "this returns a Result that may contain an error"]
     pub fn blackboard_read(&self, key: &str) -> Result<Option<BlackboardRow>> {
         let result = self
             .conn
@@ -125,6 +128,7 @@ impl SessionStore {
 
     /// List all non-expired blackboard entries.
     #[instrument(skip(self))]
+    #[must_use = "this returns a Result that may contain an error"]
     pub fn blackboard_list(&self) -> Result<Vec<BlackboardRow>> {
         let mut stmt = self
             .conn
@@ -158,6 +162,7 @@ impl SessionStore {
 
     /// Delete a blackboard entry. Only the original author can delete.
     #[instrument(skip(self))]
+    #[must_use = "this returns a Result that may contain an error"]
     pub fn blackboard_delete(&self, key: &str, author: &str) -> Result<bool> {
         let rows = self
             .conn

--- a/crates/mneme/src/store/session.rs
+++ b/crates/mneme/src/store/session.rs
@@ -12,6 +12,7 @@ impl SessionStore {
 
     /// Find an active session by nous ID and session key.
     #[instrument(skip(self))]
+    #[must_use = "this returns a Result that may contain a query error"]
     pub fn find_session(&self, nous_id: &str, session_key: &str) -> Result<Option<Session>> {
         let mut stmt = self
             .conn
@@ -30,6 +31,7 @@ impl SessionStore {
 
     /// Find a session by ID (any status).
     #[instrument(skip(self))]
+    #[must_use = "this returns a Result that may contain a query error"]
     pub fn find_session_by_id(&self, id: &str) -> Result<Option<Session>> {
         let mut stmt = self
             .conn
@@ -143,6 +145,7 @@ impl SessionStore {
 
     /// List sessions, optionally filtered by nous ID.
     #[instrument(skip(self))]
+    #[must_use = "this returns a Result that may contain a query error"]
     pub fn list_sessions(&self, nous_id: Option<&str>) -> Result<Vec<Session>> {
         let mut sessions = Vec::new();
 
@@ -177,6 +180,7 @@ impl SessionStore {
 
     /// Update session status.
     #[instrument(skip(self))]
+    #[must_use = "this returns a Result that may contain a write error"]
     pub fn update_session_status(&self, id: &str, status: SessionStatus) -> Result<()> {
         self.conn
             .execute(
@@ -189,6 +193,7 @@ impl SessionStore {
 
     /// Update session display name.
     #[instrument(skip(self))]
+    #[must_use = "this returns a Result that may contain a write error"]
     pub fn update_display_name(&self, id: &str, display_name: &str) -> Result<()> {
         self.conn
             .execute(

--- a/crates/nous/src/pipeline.rs
+++ b/crates/nous/src/pipeline.rs
@@ -138,6 +138,7 @@ impl LoopDetector {
     /// 2–`CYCLE_DETECTION_MAX_LEN` repeated at least N times, where
     /// N = threshold. This catches both single-tool hammering and longer
     /// cycles such as A → B → C → A.
+    #[must_use = "this returns None when no recording was produced"]
     pub fn record(&mut self, tool_name: &str, input_hash: &str) -> Option<String> {
         let signature = format!("{tool_name}:{input_hash}");
         self.history.push_back(signature.clone());

--- a/crates/nous/src/pipeline_tests.rs
+++ b/crates/nous/src/pipeline_tests.rs
@@ -34,8 +34,8 @@ fn loop_detector_different_inputs_ok() {
 #[test]
 fn loop_detector_reset() {
     let mut det = LoopDetector::new(3);
-    det.record("exec", "same");
-    det.record("exec", "same");
+    let _ = det.record("exec", "same");
+    let _ = det.record("exec", "same");
     det.reset();
     assert_eq!(det.call_count(), 0);
     assert!(det.record("exec", "same").is_none()); // Reset cleared history
@@ -149,9 +149,9 @@ fn loop_detector_threshold_1() {
 #[test]
 fn loop_detector_call_count_tracks() {
     let mut det = LoopDetector::new(10);
-    det.record("a", "1");
-    det.record("b", "2");
-    det.record("c", "3");
+    let _ = det.record("a", "1");
+    let _ = det.record("b", "2");
+    let _ = det.record("c", "3");
     assert_eq!(det.call_count(), 3);
 }
 
@@ -159,7 +159,7 @@ fn loop_detector_call_count_tracks() {
 fn loop_detector_many_unique_then_repeat() {
     let mut det = LoopDetector::new(3);
     for i in 0..20 {
-        det.record("tool", &format!("hash{i}"));
+        let _ = det.record("tool", &format!("hash{i}"));
     }
     assert!(det.record("exec", "same").is_none());
     assert!(det.record("exec", "same").is_none());
@@ -332,7 +332,7 @@ fn loop_detector_window_cap_evicts_old_calls() {
     let mut det = LoopDetector::new(100); // high threshold so no loop triggers
     // Insert more entries than the window to trigger eviction
     for i in 0..55 {
-        det.record("tool", &format!("hash{i}"));
+        let _ = det.record("tool", &format!("hash{i}"));
     }
     assert_eq!(
         det.call_count(),
@@ -344,9 +344,9 @@ fn loop_detector_window_cap_evicts_old_calls() {
 #[test]
 fn loop_detector_pattern_count_tracks_repetitions() {
     let mut det = LoopDetector::new(100);
-    det.record("exec", "same");
-    det.record("exec", "same");
-    det.record("exec", "same");
+    let _ = det.record("exec", "same");
+    let _ = det.record("exec", "same");
+    let _ = det.record("exec", "same");
     assert_eq!(det.pattern_count(), 3);
 }
 
@@ -359,9 +359,9 @@ fn loop_detector_pattern_count_zero_on_empty() {
 #[test]
 fn loop_detector_pattern_count_resets_on_different() {
     let mut det = LoopDetector::new(100);
-    det.record("exec", "hash1");
-    det.record("exec", "hash1");
-    det.record("read", "hash2");
+    let _ = det.record("exec", "hash1");
+    let _ = det.record("exec", "hash1");
+    let _ = det.record("read", "hash2");
     assert_eq!(det.pattern_count(), 1, "different call breaks the streak");
 }
 
@@ -370,7 +370,7 @@ fn loop_detector_window_still_detects_loops() {
     let mut det = LoopDetector::new(3);
     // Fill window with unique calls
     for i in 0..18 {
-        det.record("tool", &format!("hash{i}"));
+        let _ = det.record("tool", &format!("hash{i}"));
     }
     // Now trigger a loop within the window
     assert!(det.record("exec", "same").is_none());
@@ -412,8 +412,8 @@ fn loop_detector_non_repeating_interleaved_not_detected() {
 #[test]
 fn loop_detector_reset_clears_pattern_count() {
     let mut det = LoopDetector::new(100);
-    det.record("exec", "same");
-    det.record("exec", "same");
+    let _ = det.record("exec", "same");
+    let _ = det.record("exec", "same");
     assert_eq!(det.pattern_count(), 2);
     det.reset();
     assert_eq!(det.pattern_count(), 0);

--- a/crates/nous/src/user_error.rs
+++ b/crates/nous/src/user_error.rs
@@ -75,6 +75,7 @@ impl fmt::Display for UserFacingError {
 /// Convert a pipeline error into a user-facing error, if applicable.
 ///
 /// Returns `None` for internal errors that should not be shown to users.
+#[must_use = "this returns None when the error has no user-facing representation"]
 pub fn to_user_facing(error: &crate::error::Error) -> Option<UserFacingError> {
     use crate::error::Error;
     use aletheia_hermeneus::error::Error as HError;

--- a/crates/organon/src/registry.rs
+++ b/crates/organon/src/registry.rs
@@ -58,6 +58,7 @@ impl ToolRegistry {
     /// # Errors
     ///
     /// Returns [`crate::error::Error::DuplicateTool`] if a tool with the same name is already registered.
+    #[must_use = "this returns a Result that may contain an error"]
     pub fn register(&mut self, def: ToolDef, executor: Box<dyn ToolExecutor>) -> Result<()> {
         ensure!(
             !self.tools.contains_key(&def.name),

--- a/crates/organon/src/sandbox.rs
+++ b/crates/organon/src/sandbox.rs
@@ -356,6 +356,7 @@ static LANDLOCK_ABI: std::sync::LazyLock<Option<i32>> = std::sync::LazyLock::new
 /// a `pre_exec` closure. The result is used to detect mismatches early so
 /// errors surface with context rather than as opaque "Permission denied" failures.
 #[cfg(target_os = "linux")]
+#[must_use = "this returns None when the kernel feature is not available"]
 pub fn probe_landlock_abi() -> Option<i32> {
     // WHY: landlock_create_ruleset with LANDLOCK_CREATE_RULESET_VERSION returns
     // the ABI version as a non-negative integer, or -1 with errno set to
@@ -382,6 +383,7 @@ pub fn probe_landlock_abi() -> Option<i32> {
 }
 
 #[cfg(not(target_os = "linux"))]
+#[must_use = "this returns None when the kernel feature is not available"]
 pub fn probe_landlock_abi() -> Option<i32> {
     None
 }

--- a/crates/pylon/src/middleware.rs
+++ b/crates/pylon/src/middleware.rs
@@ -198,6 +198,7 @@ impl RateLimiter {
     ///
     /// Returns `None` if the request is allowed, or `Some(retry_after_secs)`
     /// if the limit has been exceeded.
+    #[must_use = "this returns None when the check passes"]
     pub fn check(&self, client: &str) -> Option<u64> {
         let now = Instant::now();
         let mut state = self

--- a/crates/pylon/src/router.rs
+++ b/crates/pylon/src/router.rs
@@ -127,10 +127,10 @@ pub fn build_router(state: Arc<AppState>, security: &SecurityConfig) -> Router {
     router = router.layer(
         TraceLayer::new_for_http()
             .make_span_with(|request: &axum::http::Request<_>| {
-                let request_id = request
-                    .extensions()
-                    .get::<RequestId>()
-                    .map_or_else(|| ulid::Ulid::new().to_string(), std::string::ToString::to_string);
+                let request_id = request.extensions().get::<RequestId>().map_or_else(
+                    || ulid::Ulid::new().to_string(),
+                    std::string::ToString::to_string,
+                );
                 info_span!("http_request",
                     http.method = %request.method(),
                     http.path = %request.uri().path(),

--- a/crates/symbolon/src/credential.rs
+++ b/crates/symbolon/src/credential.rs
@@ -84,6 +84,7 @@ impl CredentialFile {
     /// WHY: Claude Code changed its `.credentials.json` layout to nest all OAuth fields
     /// under a `claudeAiOauth` top-level key. Without unwrapping it, fresh credentials
     /// are invisible and the chain falls back to a stale env-var token.
+    #[must_use = "this returns None when no credential is found"]
     pub fn load(path: &Path) -> Option<Self> {
         let contents = std::fs::read_to_string(path).ok()?;
 
@@ -438,6 +439,7 @@ impl RefreshingCredentialProvider {
     ///
     /// Reads the credential file immediately and spawns a background refresh
     /// task. Requires a tokio runtime to be active.
+    #[must_use = "this returns None when the credential cannot be constructed"]
     pub fn new(path: PathBuf) -> Option<Self> {
         let cred = CredentialFile::load(&path)?;
         let refresh_token = cred.refresh_token.clone().filter(|t| !t.is_empty())?;
@@ -706,6 +708,7 @@ pub fn claude_code_default_path() -> Option<PathBuf> {
 /// [`FileCredentialProvider`] for static token reads.
 ///
 /// Returns `None` if the file does not exist or cannot be parsed.
+#[must_use = "this returns None when no Claude Code provider is available"]
 pub fn claude_code_provider(path: &Path) -> Option<Box<dyn CredentialProvider>> {
     if !path.exists() {
         return None;

--- a/crates/symbolon/src/jwt.rs
+++ b/crates/symbolon/src/jwt.rs
@@ -64,6 +64,7 @@ impl JwtConfig {
     ///
     /// Returns [`crate::error::Error::InsecureKey`] if `auth_mode` is not `"none"` and the signing
     /// key is still the built-in insecure placeholder.
+    #[must_use = "this returns a Result that may indicate validation failure"]
     pub fn validate_for_auth_mode(&self, auth_mode: &str) -> Result<()> {
         if auth_mode != "none" && self.has_insecure_key() {
             tracing::error!(
@@ -105,6 +106,7 @@ impl JwtManager {
     ///
     /// Returns an error if the JWT claims cannot be encoded or signed.
     #[instrument(skip(self), fields(kind = "access"))]
+    #[must_use = "this returns a Result that may contain an authentication error"]
     pub fn issue_access(&self, sub: &str, role: Role, nous_id: Option<&str>) -> Result<String> {
         self.issue(
             sub,
@@ -128,6 +130,7 @@ impl JwtManager {
     /// Returns [`crate::error::Error::ExpiredToken`] if the token's expiration time has passed.
     /// Returns [`crate::error::Error::TokenDecode`] if the token is malformed, has an invalid
     /// signature, or fails any other JWT validation check.
+    #[must_use = "this returns a Result that may indicate validation failure"]
     pub fn validate(&self, token: &str) -> Result<Claims> {
         let mut validation = Validation::new(Algorithm::HS256);
         validation.set_issuer(&[&self.config.issuer]);

--- a/crates/taxis/src/encrypt.rs
+++ b/crates/taxis/src/encrypt.rs
@@ -56,6 +56,7 @@ pub fn master_key_path() -> Option<PathBuf> {
     clippy::result_large_err,
     reason = "taxis Error is inherently large due to PathBuf fields"
 )]
+#[must_use = "this returns a Result that may contain a read error"]
 pub fn load_master_key(path: &Path) -> Result<Option<[u8; KEY_LEN]>> {
     if !path.exists() {
         return Ok(None);
@@ -133,6 +134,7 @@ fn to_hex(bytes: &[u8]) -> String {
     clippy::result_large_err,
     reason = "taxis Error is inherently large due to PathBuf fields"
 )]
+#[must_use = "this returns a Result that may contain a cryptographic error"]
 pub fn generate_master_key(path: &Path) -> Result<()> {
     if path.exists() {
         return Err(error::MasterKeyExistsSnafu {
@@ -192,6 +194,7 @@ pub fn is_encrypted(value: &str) -> bool {
     clippy::result_large_err,
     reason = "taxis Error is inherently large due to PathBuf fields"
 )]
+#[must_use = "this returns a Result that may contain a cryptographic error"]
 pub fn encrypt_value(plaintext: &str, master_key: &[u8; KEY_LEN]) -> Result<String> {
     // WHY: ring::error::Unspecified has no useful fields to propagate
     let unbound = UnboundKey::new(&CHACHA20_POLY1305, master_key)
@@ -227,6 +230,7 @@ pub fn encrypt_value(plaintext: &str, master_key: &[u8; KEY_LEN]) -> Result<Stri
     clippy::result_large_err,
     reason = "taxis Error is inherently large due to PathBuf fields"
 )]
+#[must_use = "this returns a Result that may contain a cryptographic error"]
 pub fn decrypt_value(encrypted: &str, master_key: &[u8; KEY_LEN]) -> Result<String> {
     let encoded = encrypted
         .strip_prefix(ENCRYPTED_PREFIX)
@@ -288,6 +292,7 @@ fn build_decrypt_error(reason: &str) -> error::Error {
     clippy::result_large_err,
     reason = "taxis Error is inherently large due to PathBuf fields"
 )]
+#[must_use = "this returns a Result that may contain a cryptographic error"]
 pub fn encrypt_config_file(toml_path: &Path, master_key: &[u8; KEY_LEN]) -> Result<usize> {
     let content =
         std::fs::read_to_string(toml_path).context(error::ReadConfigSnafu { path: toml_path })?;

--- a/crates/taxis/src/loader.rs
+++ b/crates/taxis/src/loader.rs
@@ -29,6 +29,7 @@ use crate::oikos::Oikos;
     clippy::result_large_err,
     reason = "figment::Error is inherently large"
 )]
+#[must_use = "this returns a Result that may contain a read error"]
 pub fn load_config(oikos: &Oikos) -> Result<AletheiaConfig> {
     let toml_path = oikos.config().join("aletheia.toml");
     let yaml_path = oikos.config().join("aletheia.yaml");
@@ -100,6 +101,7 @@ fn decrypt_toml_content(content: &str) -> String {
     clippy::result_large_err,
     reason = "figment::Error is inherently large"
 )]
+#[must_use = "this returns a Result that may contain a write error"]
 pub fn write_config(oikos: &Oikos, config: &AletheiaConfig) -> Result<()> {
     let toml = toml::to_string(config).map_err(|e| {
         SerializeTomlSnafu {

--- a/crates/taxis/src/validate.rs
+++ b/crates/taxis/src/validate.rs
@@ -19,6 +19,7 @@ pub struct ValidationError {
 /// Serializes to JSON and validates each top-level section using
 /// [`validate_section`]. Returns all validation errors collected
 /// across all sections.
+#[must_use = "this returns a Result that may indicate validation failure"]
 pub fn validate_config(config: &AletheiaConfig) -> Result<(), ValidationError> {
     let value = serde_json::to_value(config).unwrap_or(Value::Null);
     let Value::Object(ref sections) = value else {
@@ -51,6 +52,7 @@ pub fn validate_config(config: &AletheiaConfig) -> Result<(), ValidationError> {
 /// Returns [`ValidationError`] if any field value is out of range, empty when
 /// required, or the section name is unrecognized. The error contains all
 /// collected validation messages.
+#[must_use = "this returns a Result that may indicate validation failure"]
 pub fn validate_section(section: &str, value: &Value) -> Result<(), ValidationError> {
     let mut errors = Vec::new();
 

--- a/crates/theatron/desktop/src/services/config.rs
+++ b/crates/theatron/desktop/src/services/config.rs
@@ -70,6 +70,7 @@ fn config_path() -> Result<PathBuf, ConfigError> {
 /// # Errors
 ///
 /// Returns an error if the file exists but cannot be read or parsed.
+#[must_use = "this returns a Result that may contain a read error"]
 pub fn load() -> Result<ConnectionConfig, ConfigError> {
     let path = config_path()?;
 
@@ -90,6 +91,7 @@ pub fn load() -> Result<ConnectionConfig, ConfigError> {
 ///
 /// Returns an error if the directory cannot be created or the file cannot
 /// be written.
+#[must_use = "this returns a Result that may contain a write error"]
 pub fn save(config: &ConnectionConfig) -> Result<(), ConfigError> {
     let path = config_path()?;
 

--- a/crates/theatron/desktop/src/services/connection.rs
+++ b/crates/theatron/desktop/src/services/connection.rs
@@ -80,6 +80,7 @@ impl PylonClient {
     ///
     /// Returns `InvalidToken` if the auth token contains non-ASCII characters.
     /// Returns `ClientBuild` if the reqwest client cannot be constructed.
+    #[must_use = "this returns a Result that may contain a construction error"]
     pub fn new(config: &ConnectionConfig) -> Result<Self, ConnectionError> {
         let mut headers = HeaderMap::new();
         headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));

--- a/crates/theatron/desktop/src/state/app.rs
+++ b/crates/theatron/desktop/src/state/app.rs
@@ -96,6 +96,7 @@ impl TabBar {
     }
 
     /// Close a tab by index. Returns the removed entry.
+    #[must_use = "this returns None when no view was closed"]
     pub fn close(&mut self, index: usize) -> Option<TabEntry> {
         if index >= self.tabs.len() {
             return None;

--- a/crates/theatron/tui/src/api/client.rs
+++ b/crates/theatron/tui/src/api/client.rs
@@ -88,6 +88,7 @@ impl ApiClient {
     ///
     /// Returns [`ApiError::InvalidToken`] if `token` contains characters invalid in HTTP headers.
     /// Returns [`ApiError::Http`] if the HTTP client cannot be constructed.
+    #[must_use = "this returns a Result that may contain a construction error"]
     pub fn new(base_url: &str, token: Option<String>) -> Result<Self> {
         let client = build_http_client(token.as_deref())?;
 
@@ -108,6 +109,7 @@ impl ApiClient {
         &self.base_url
     }
 
+    #[must_use = "this returns None when no token is available"]
     pub fn token(&self) -> Option<&str> {
         self.token.as_deref()
     }

--- a/crates/theatron/tui/src/app.rs
+++ b/crates/theatron/tui/src/app.rs
@@ -455,6 +455,7 @@ impl App {
     }
 
     #[tracing::instrument(skip_all)]
+    #[must_use = "this returns None when the value has already been taken"]
     pub fn take_sse(&mut self) -> Option<SseConnection> {
         self.sse.take()
     }
@@ -465,6 +466,7 @@ impl App {
     }
 
     #[tracing::instrument(skip_all)]
+    #[must_use = "this returns None when the value has already been taken"]
     pub fn take_stream(&mut self) -> Option<mpsc::Receiver<StreamEvent>> {
         self.stream_rx.take()
     }

--- a/crates/theatron/tui/src/clipboard.rs
+++ b/crates/theatron/tui/src/clipboard.rs
@@ -1,5 +1,6 @@
 /// Copy text to the system clipboard.
 /// Tries arboard (native) first, falls back to OSC52 escape sequence.
+#[must_use = "this returns a Result that may contain a clipboard error"]
 pub fn copy_to_clipboard(text: &str) -> Result<(), String> {
     match arboard::Clipboard::new() {
         Ok(mut clipboard) => match clipboard.set_text(text) {

--- a/crates/theatron/tui/src/config.rs
+++ b/crates/theatron/tui/src/config.rs
@@ -109,6 +109,7 @@ impl Config {
         reason = "consistent instance-method API; &self kept for tracing::instrument skip"
     )]
     #[tracing::instrument(skip(self))]
+    #[must_use = "this returns a Result that may contain a credential storage error"]
     pub fn clear_credentials(&self) -> Result<()> {
         let path = Self::config_path()?;
         if path.exists() {
@@ -127,6 +128,7 @@ impl Config {
         reason = "consistent instance-method API; &self kept for tracing::instrument skip"
     )]
     #[tracing::instrument(skip(self, token))]
+    #[must_use = "this returns a Result that may contain a write error"]
     pub fn save_token(&self, token: &str) -> Result<()> {
         let path = Self::config_path()?;
         let mut file_config = Self::load_file().unwrap_or_default();

--- a/crates/theatron/tui/src/mapping.rs
+++ b/crates/theatron/tui/src/mapping.rs
@@ -10,6 +10,7 @@ use crate::msg::{MessageActionKind, Msg, OverlayKind};
 use crate::state::Overlay;
 
 impl App {
+    #[must_use = "this returns None when the event is not mapped"]
     pub fn map_event(&self, event: Event) -> Option<Msg> {
         match event {
             Event::Terminal(term_event) => self.map_terminal(term_event),

--- a/crates/theatron/tui/src/state/memory.rs
+++ b/crates/theatron/tui/src/state/memory.rs
@@ -260,6 +260,7 @@ impl MemoryInspectorState {
     }
 
     /// Returns the currently selected fact, if any.
+    #[must_use = "this returns None when nothing is selected"]
     pub fn selected_fact(&self) -> Option<&MemoryFact> {
         self.facts.get(self.selected)
     }

--- a/crates/theatron/tui/src/state/overlay.rs
+++ b/crates/theatron/tui/src/state/overlay.rs
@@ -67,6 +67,7 @@ pub struct ContextActionsOverlay {
 }
 
 impl ContextActionsOverlay {
+    #[must_use = "this returns None when nothing is selected"]
     pub fn selected_action(&self) -> Option<&ContextAction> {
         self.actions.get(self.cursor)
     }

--- a/crates/theatron/tui/src/state/settings.rs
+++ b/crates/theatron/tui/src/state/settings.rs
@@ -73,6 +73,7 @@ impl SettingsOverlay {
         self.sections.iter().map(|s| s.fields.len()).sum()
     }
 
+    #[must_use = "this returns None when no field is focused"]
     pub fn current_field(&self) -> Option<&SettingsField> {
         let mut idx = 0;
         for section in &self.sections {
@@ -86,6 +87,7 @@ impl SettingsOverlay {
         None
     }
 
+    #[must_use = "this returns None when no field is focused"]
     pub fn current_field_mut(&mut self) -> Option<&mut SettingsField> {
         let mut idx = 0;
         for section in &mut self.sections {

--- a/crates/theatron/tui/src/state/view_stack.rs
+++ b/crates/theatron/tui/src/state/view_stack.rs
@@ -58,6 +58,7 @@ impl ViewStack {
     }
 
     /// Pop the current view, returning it. Returns `None` if at Home (cannot pop).
+    #[must_use = "this returns None when the stack is empty"]
     pub fn pop(&mut self) -> Option<View> {
         if self.stack.len() > 1 {
             self.stack.pop()
@@ -161,9 +162,9 @@ mod tests {
     #[test]
     fn cannot_pop_below_home() {
         let mut stack = ViewStack::new();
-        stack.pop();
-        stack.pop();
-        stack.pop();
+        let _ = stack.pop();
+        let _ = stack.pop();
+        let _ = stack.pop();
         assert_eq!(stack.depth(), 1);
         assert_eq!(stack.current(), &View::Home);
     }
@@ -200,7 +201,7 @@ mod tests {
             agent_id: "syn".into(),
             session_id: "abc123".into(),
         });
-        stack.pop();
+        let _ = stack.pop();
         assert_eq!(stack.breadcrumbs(), vec!["Home", "Sessions"]);
     }
 
@@ -222,11 +223,11 @@ mod tests {
         );
 
         // Pop all the way back
-        stack.pop();
+        let _ = stack.pop();
         assert_eq!(stack.depth(), 3);
-        stack.pop();
+        let _ = stack.pop();
         assert_eq!(stack.depth(), 2);
-        stack.pop();
+        let _ = stack.pop();
         assert!(stack.is_home());
     }
 
@@ -284,7 +285,7 @@ mod tests {
         stack.push(View::MessageDetail { message_index: 42 });
         assert_eq!(stack.current(), &View::MessageDetail { message_index: 42 });
         assert_eq!(stack.breadcrumbs(), vec!["Home", "Message"]);
-        stack.pop();
+        let _ = stack.pop();
         assert!(stack.is_home());
     }
 }

--- a/crates/theatron/tui/src/update/memory.rs
+++ b/crates/theatron/tui/src/update/memory.rs
@@ -18,7 +18,7 @@ pub fn handle_close(app: &mut App) {
         app.view_stack.current(),
         View::MemoryInspector | View::FactDetail { .. }
     ) {
-        app.view_stack.pop();
+        let _ = app.view_stack.pop();
     }
 }
 
@@ -108,10 +108,10 @@ pub async fn handle_drill_in(app: &mut App) {
 
 pub fn handle_pop_back(app: &mut App) {
     if matches!(app.view_stack.current(), View::FactDetail { .. }) {
-        app.view_stack.pop();
+        let _ = app.view_stack.pop();
         app.memory.detail = None;
     } else {
-        app.view_stack.pop();
+        let _ = app.view_stack.pop();
     }
 }
 

--- a/crates/theatron/tui/src/update/view_nav.rs
+++ b/crates/theatron/tui/src/update/view_nav.rs
@@ -94,7 +94,7 @@ pub(crate) fn handle_pop_back(app: &mut App) {
         return;
     }
 
-    app.view_stack.pop();
+    let _ = app.view_stack.pop();
     restore_view_scroll(app);
 }
 

--- a/crates/thesauros/src/manifest.rs
+++ b/crates/thesauros/src/manifest.rs
@@ -128,6 +128,7 @@ pub struct PackPropertyDef {
 /// - [`error::Error::ManifestNotFound`] if `pack.toml` is missing
 /// - [`error::Error::ReadFile`] if the file cannot be read
 /// - [`error::Error::ParseManifest`] if TOML parsing fails
+#[must_use = "this returns a Result that may contain a read error"]
 pub fn load_manifest(pack_root: &Path) -> Result<PackManifest> {
     ensure!(
         pack_root.is_dir(),
@@ -191,6 +192,7 @@ fn is_valid_pack_name(name: &str) -> bool {
 ///
 /// Returns the canonical absolute path, or an error if the file does not
 /// exist or if the resolved path escapes the pack root directory.
+#[must_use = "this returns a Result that may contain a path resolution error"]
 pub fn resolve_context_path(pack_root: &Path, entry: &ContextEntry) -> Result<PathBuf> {
     let resolved = pack_root.join(&entry.path);
     ensure!(


### PR DESCRIPTION
## Summary

- Add `#[must_use]` with descriptive reasons to 101 public functions returning `Result` or `Option` across all workspace crates
- Fix 30 call sites that discarded return values by adding explicit `let _ = ...` where the discard is intentional
- Excluded: CLI entry points, HTTP handlers (framework-managed), engine internals, tool registration functions (side-effect functions)

Closes #1412

## Scope

Annotations added to functions in: agora, aletheia, daemon, dianoia, eval, hermeneus, koina, mneme, nous, organon, pylon, symbolon, taxis, theatron, thesauros.

Call site fixes in: `ViewStack::pop()` (theatron-tui), `LoopDetector::record()` (nous, integration-tests).

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes (zero warnings)
- [x] `cargo test --workspace` passes (one pre-existing failure in `integration_server` unrelated to this change)
- [x] No new clippy warnings from unused return values at call sites

## Observations

- **Debt**: `integration_server` test fails on main with "No provider set" (reqwest TLS provider issue, pre-existing)
- **Idea**: The `mneme/src/engine/` internals have ~30 additional `pub fn` returning `Result`/`Option` without `#[must_use]` that were excluded from this PR as engine-internal code

🤖 Generated with [Claude Code](https://claude.com/claude-code)