### PR TITLE
feat(pylon): add per-user rate limiting with endpoint-specific limits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -361,6 +361,7 @@ dependencies = [
  "aletheia-taxis",
  "axum 0.8.8",
  "axum-server",
+ "base64 0.22.1",
  "http-body-util",
  "jiff",
  "jsonwebtoken",

--- a/crates/pylon/Cargo.toml
+++ b/crates/pylon/Cargo.toml
@@ -44,6 +44,9 @@ prometheus = { workspace = true }
 # Types
 ulid = { workspace = true }
 
+# Base64 decoding for JWT payload extraction in rate limiting middleware
+base64 = { workspace = true }
+
 # Cryptographic random number generation (CSRF token generation)
 rand = { workspace = true }
 

--- a/crates/pylon/src/handlers/knowledge.rs
+++ b/crates/pylon/src/handlers/knowledge.rs
@@ -289,6 +289,7 @@ pub async fn get_fact(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
 ) -> Result<Json<FactDetailResponse>, ApiError> {
+    let _ = &state;
     // WHY: The previous implementation called get_all_facts which hardcoded
     // nous_id: None, causing get_stored_facts to always return an empty Vec
     // (it requires nous_id.is_some() to query the store). Bug #1252.
@@ -673,13 +674,6 @@ fn get_stored_entities(state: &AppState) -> Vec<aletheia_mneme::knowledge::Entit
     Vec::new()
 }
 
-fn get_fact_relationships(
-    _state: &AppState,
-    _fact: &aletheia_mneme::knowledge::Fact,
-) -> Vec<aletheia_mneme::knowledge::Relationship> {
-    Vec::new()
-}
-
 fn get_entity_relationships(
     _state: &AppState,
     _entity_id: &str,
@@ -687,6 +681,15 @@ fn get_entity_relationships(
     Vec::new()
 }
 
+#[cfg(feature = "knowledge-store")]
+fn get_fact_relationships(
+    _state: &AppState,
+    _fact: &aletheia_mneme::knowledge::Fact,
+) -> Vec<aletheia_mneme::knowledge::Relationship> {
+    Vec::new()
+}
+
+#[cfg(feature = "knowledge-store")]
 fn get_similar_facts(
     _state: &AppState,
     _fact: &aletheia_mneme::knowledge::Fact,

--- a/crates/pylon/src/middleware.rs
+++ b/crates/pylon/src/middleware.rs
@@ -9,7 +9,7 @@ use axum::extract::Request;
 use axum::http::{Method, StatusCode};
 use axum::middleware::Next;
 use axum::response::{IntoResponse, Response};
-use tracing::warn;
+use tracing::{Instrument, warn};
 
 use crate::error::{ErrorBody, ErrorResponse};
 
@@ -283,24 +283,429 @@ pub async fn rate_limit(request: Request, next: Next) -> Response {
 
     let client = extract_client_key(&request, limiter.trust_proxy);
     if let Some(retry_after_secs) = limiter.check(&client) {
-        let mut response = (
-            StatusCode::TOO_MANY_REQUESTS,
-            axum::Json(ErrorResponse {
-                error: ErrorBody {
-                    code: "rate_limited".to_owned(),
-                    message: format!("rate limited, retry after {retry_after_secs}s"),
-                    details: Some(serde_json::json!({ "retry_after_secs": retry_after_secs })),
-                },
-            }),
-        )
-            .into_response();
-        if let Ok(value) = axum::http::HeaderValue::from_str(&retry_after_secs.to_string()) {
-            response
-                .headers_mut()
-                .insert(axum::http::header::RETRY_AFTER, value);
-        }
-        return response;
+        return build_rate_limit_response(retry_after_secs);
     }
 
     next.run(request).await
+}
+
+// ---------------------------------------------------------------------------
+// Per-user token bucket rate limiter
+// ---------------------------------------------------------------------------
+
+/// Endpoint category for per-user rate limiting.
+///
+/// Different endpoint categories have different rate limits to reflect their
+/// cost: LLM calls are expensive, tool execution is moderate, and general
+/// API calls are cheapest.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) enum EndpointCategory {
+    General,
+    Llm,
+    Tool,
+}
+
+/// Token bucket state for a single user+category combination.
+struct TokenBucket {
+    tokens: f64,
+    last_refill: Instant,
+}
+
+/// Per-user rate limiter using the token bucket algorithm.
+///
+/// Each (user, endpoint category) combination gets an independent token
+/// bucket. Tokens refill at a steady rate (rpm / 60 tokens per second) up to
+/// a burst cap. Uses `std::sync::Mutex`: the critical section is a `HashMap`
+/// lookup with arithmetic, no `.await` points.
+pub struct UserRateLimiter {
+    /// WHY: lock held only during `HashMap` lookup + arithmetic, no await
+    state: Mutex<HashMap<(String, EndpointCategory), TokenBucket>>,
+    default_rpm: u32,
+    default_burst: u32,
+    llm_rpm: u32,
+    tool_rpm: u32,
+}
+
+impl UserRateLimiter {
+    pub(crate) fn new(default_rpm: u32, default_burst: u32, llm_rpm: u32, tool_rpm: u32) -> Self {
+        Self {
+            state: Mutex::new(HashMap::new()),
+            default_rpm,
+            default_burst,
+            llm_rpm,
+            tool_rpm,
+        }
+    }
+
+    /// Return (`refill_rate_per_sec`, `max_tokens`) for the given category.
+    fn limits(&self, category: EndpointCategory) -> (f64, f64) {
+        let rpm = match category {
+            EndpointCategory::General => self.default_rpm,
+            EndpointCategory::Llm => self.llm_rpm,
+            EndpointCategory::Tool => self.tool_rpm,
+        };
+        let refill_rate = f64::from(rpm) / 60.0;
+        // WHY: burst for LLM/tool is proportional to their rpm, scaled by
+        // the same ratio as default_burst / default_rpm, floored at 1.
+        let max_tokens = if self.default_rpm == 0 {
+            f64::from(self.default_burst).max(1.0)
+        } else {
+            (f64::from(rpm) * f64::from(self.default_burst) / f64::from(self.default_rpm)).max(1.0)
+        };
+        (refill_rate, max_tokens)
+    }
+
+    /// Check whether a request from `user` to an endpoint of `category` is allowed.
+    ///
+    /// Returns `None` if allowed, `Some(retry_after_secs)` if rate limited.
+    pub(crate) fn check(&self, user: &str, category: EndpointCategory) -> Option<u64> {
+        let now = Instant::now();
+        let (refill_rate, max_tokens) = self.limits(category);
+
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+
+        let key = (user.to_owned(), category);
+        let bucket = state.entry(key).or_insert_with(|| TokenBucket {
+            tokens: max_tokens,
+            last_refill: now,
+        });
+
+        // Refill tokens based on elapsed time.
+        let elapsed = now.duration_since(bucket.last_refill).as_secs_f64();
+        bucket.tokens = (bucket.tokens + elapsed * refill_rate).min(max_tokens);
+        bucket.last_refill = now;
+
+        if bucket.tokens >= 1.0 {
+            bucket.tokens -= 1.0;
+            None
+        } else {
+            // Calculate how long until one token is available.
+            let deficit = 1.0 - bucket.tokens;
+            let wait_secs = if refill_rate > 0.0 {
+                deficit / refill_rate
+            } else {
+                60.0
+            };
+            #[expect(
+                clippy::cast_possible_truncation,
+                clippy::cast_sign_loss,
+                reason = "wait_secs is a small positive f64 from ceil(), safe to convert"
+            )]
+            Some(wait_secs.ceil() as u64)
+        }
+    }
+
+    /// Remove entries for users who haven't made requests in the given duration.
+    ///
+    /// Call periodically to prevent unbounded memory growth from departed users.
+    pub(crate) fn cleanup_stale(&self, max_idle: Duration) {
+        let now = Instant::now();
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        state.retain(|_key, bucket| now.duration_since(bucket.last_refill) < max_idle);
+    }
+
+    /// Number of tracked user+category entries (for testing and metrics).
+    #[cfg(test)]
+    pub(crate) fn entry_count(&self) -> usize {
+        self.state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .len()
+    }
+}
+
+/// Classify a request path into an endpoint category for per-user rate limiting.
+pub(crate) fn classify_endpoint(path: &str, method: &Method) -> EndpointCategory {
+    // LLM endpoints: streaming chat turns (the expensive operation).
+    if path.starts_with("/api/v1/sessions") && path.ends_with("/stream") && *method == Method::POST
+    {
+        return EndpointCategory::Llm;
+    }
+
+    // Tool endpoints: sending messages (triggers tool execution pipeline).
+    if path.starts_with("/api/v1/sessions")
+        && path.ends_with("/messages")
+        && *method == Method::POST
+    {
+        return EndpointCategory::Tool;
+    }
+
+    EndpointCategory::General
+}
+
+/// Extract user identity from the JWT Bearer token for rate limiting.
+///
+/// Decodes the JWT payload to read the `sub` claim without full cryptographic
+/// validation. Full auth validation happens in the handler-level `Claims`
+/// extractor; this is only for rate limiting keying. Falls back to
+/// `extract_client_key` when no valid Bearer token is present.
+fn extract_user_key(request: &Request) -> Option<String> {
+    use base64::Engine;
+
+    let header = request.headers().get("authorization")?.to_str().ok()?;
+    let token = header.strip_prefix("Bearer ")?;
+
+    // JWT format: base64url(header).base64url(payload).signature
+    let payload = token.split('.').nth(1)?;
+
+    let decoded = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(payload)
+        .ok()?;
+    let json: serde_json::Value = serde_json::from_slice(&decoded).ok()?;
+    json.get("sub")?.as_str().map(str::to_owned)
+}
+
+/// Middleware that enforces per-user rate limiting with endpoint-specific limits.
+///
+/// Reads `Arc<UserRateLimiter>` from request extensions. Identifies the user
+/// from the JWT Bearer token and classifies the endpoint category from the
+/// request path. Returns 429 with `Retry-After` when the user's token bucket
+/// is exhausted.
+pub async fn user_rate_limit(request: Request, next: Next) -> Response {
+    let limiter = request.extensions().get::<Arc<UserRateLimiter>>().cloned();
+    let Some(limiter) = limiter else {
+        return next.run(request).await;
+    };
+
+    let user = extract_user_key(&request).unwrap_or_else(|| extract_client_key(&request, false));
+    let category = classify_endpoint(request.uri().path(), request.method());
+
+    if let Some(retry_after_secs) = limiter.check(&user, category) {
+        tracing::info!(
+            user = %user,
+            category = ?category,
+            retry_after_secs,
+            "per-user rate limit exceeded"
+        );
+        return build_rate_limit_response(retry_after_secs);
+    }
+
+    next.run(request).await
+}
+
+/// Build a 429 Too Many Requests response with `Retry-After` header.
+fn build_rate_limit_response(retry_after_secs: u64) -> Response {
+    let mut response = (
+        StatusCode::TOO_MANY_REQUESTS,
+        axum::Json(ErrorResponse {
+            error: ErrorBody {
+                code: "rate_limited".to_owned(),
+                message: format!("rate limited, retry after {retry_after_secs}s"),
+                details: Some(serde_json::json!({ "retry_after_secs": retry_after_secs })),
+            },
+        }),
+    )
+        .into_response();
+    if let Ok(value) = axum::http::HeaderValue::from_str(&retry_after_secs.to_string()) {
+        response
+            .headers_mut()
+            .insert(axum::http::header::RETRY_AFTER, value);
+    }
+    response
+}
+
+/// Spawn a background task that periodically removes stale rate limit entries.
+///
+/// Runs every `interval` and removes entries idle for longer than `max_idle`.
+/// Cancelled via the provided `CancellationToken`.
+pub fn spawn_rate_limit_cleanup(
+    limiter: Arc<UserRateLimiter>,
+    interval: Duration,
+    max_idle: Duration,
+    cancel: tokio_util::sync::CancellationToken,
+) {
+    let span = tracing::info_span!("rate_limit_cleanup");
+    tokio::spawn(
+        async move {
+            loop {
+                tokio::select! {
+                    biased;
+                    () = cancel.cancelled() => break,
+                    () = tokio::time::sleep(interval) => {
+                        limiter.cleanup_stale(max_idle);
+                    }
+                }
+            }
+            tracing::debug!("rate limit cleanup task stopped");
+        }
+        .instrument(span),
+    );
+}
+
+#[cfg(test)]
+#[expect(clippy::expect_used, reason = "test assertions")]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn token_bucket_allows_requests_under_limit() {
+        let limiter = UserRateLimiter::new(60, 10, 20, 30);
+        // First request should always succeed (bucket starts full).
+        assert!(
+            limiter.check("alice", EndpointCategory::General).is_none(),
+            "first request must be allowed"
+        );
+    }
+
+    #[test]
+    fn token_bucket_allows_burst() {
+        let limiter = UserRateLimiter::new(60, 10, 20, 30);
+        // Burst of 10 requests should all succeed.
+        for i in 0..10 {
+            assert!(
+                limiter.check("alice", EndpointCategory::General).is_none(),
+                "burst request {i} must be allowed"
+            );
+        }
+        // 11th request should be rate limited.
+        assert!(
+            limiter.check("alice", EndpointCategory::General).is_some(),
+            "request after burst exhaustion must be limited"
+        );
+    }
+
+    #[test]
+    fn token_bucket_returns_retry_after_on_limit() {
+        let limiter = UserRateLimiter::new(60, 1, 20, 30);
+        // Exhaust the single-token bucket.
+        assert!(limiter.check("bob", EndpointCategory::General).is_none());
+        let retry = limiter.check("bob", EndpointCategory::General);
+        assert!(retry.is_some(), "must return retry_after when limited");
+        assert!(
+            retry.expect("checked above") > 0,
+            "retry_after must be positive"
+        );
+    }
+
+    #[test]
+    fn per_user_isolation() {
+        let limiter = UserRateLimiter::new(60, 1, 20, 30);
+        // Exhaust alice's bucket.
+        assert!(limiter.check("alice", EndpointCategory::General).is_none());
+        assert!(limiter.check("alice", EndpointCategory::General).is_some());
+        // bob's bucket is independent.
+        assert!(
+            limiter.check("bob", EndpointCategory::General).is_none(),
+            "bob must not be affected by alice's usage"
+        );
+    }
+
+    #[test]
+    fn different_categories_have_different_limits() {
+        // LLM has lower limit (20 rpm) so burst = 10 * 20/60 ≈ 3.
+        let limiter = UserRateLimiter::new(60, 10, 20, 30);
+        let mut llm_allowed = 0;
+        for _ in 0..20 {
+            if limiter.check("alice", EndpointCategory::Llm).is_none() {
+                llm_allowed += 1;
+            }
+        }
+        let mut general_allowed = 0;
+        for _ in 0..20 {
+            if limiter.check("bob", EndpointCategory::General).is_none() {
+                general_allowed += 1;
+            }
+        }
+        assert!(
+            llm_allowed < general_allowed,
+            "LLM endpoints must have a stricter limit than general: llm={llm_allowed}, general={general_allowed}"
+        );
+    }
+
+    #[test]
+    fn cleanup_stale_removes_old_entries() {
+        let limiter = UserRateLimiter::new(60, 10, 20, 30);
+        let _ = limiter.check("alice", EndpointCategory::General);
+        let _ = limiter.check("bob", EndpointCategory::General);
+        assert_eq!(limiter.entry_count(), 2, "should have 2 entries");
+        // Cleanup with zero max_idle removes everything.
+        limiter.cleanup_stale(Duration::ZERO);
+        assert_eq!(
+            limiter.entry_count(),
+            0,
+            "stale entries must be removed after cleanup"
+        );
+    }
+
+    #[test]
+    fn cleanup_stale_preserves_recent_entries() {
+        let limiter = UserRateLimiter::new(60, 10, 20, 30);
+        let _ = limiter.check("alice", EndpointCategory::General);
+        // 10 minute max_idle should keep recent entries.
+        limiter.cleanup_stale(Duration::from_secs(600));
+        assert_eq!(limiter.entry_count(), 1, "recent entries must be preserved");
+    }
+
+    #[test]
+    fn classify_endpoint_llm() {
+        assert_eq!(
+            classify_endpoint("/api/v1/sessions/stream", &Method::POST),
+            EndpointCategory::Llm,
+        );
+    }
+
+    #[test]
+    fn classify_endpoint_tool() {
+        assert_eq!(
+            classify_endpoint("/api/v1/sessions/abc123/messages", &Method::POST),
+            EndpointCategory::Tool,
+        );
+    }
+
+    #[test]
+    fn classify_endpoint_general_get() {
+        assert_eq!(
+            classify_endpoint("/api/v1/sessions", &Method::GET),
+            EndpointCategory::General,
+        );
+    }
+
+    #[test]
+    fn classify_endpoint_general_other() {
+        assert_eq!(
+            classify_endpoint("/api/health", &Method::GET),
+            EndpointCategory::General,
+        );
+    }
+
+    #[test]
+    fn extract_user_key_from_valid_jwt() {
+        // Build a minimal JWT with sub claim.
+        use base64::Engine;
+        let header = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(br#"{"alg":"HS256"}"#);
+        let payload = base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .encode(br#"{"sub":"alice@example.com","role":"operator"}"#);
+        let token = format!("{header}.{payload}.fakesig");
+
+        let request = Request::builder()
+            .header("authorization", format!("Bearer {token}"))
+            .body(Body::empty())
+            .expect("test request");
+
+        let user = extract_user_key(&request);
+        assert_eq!(user.as_deref(), Some("alice@example.com"));
+    }
+
+    #[test]
+    fn extract_user_key_returns_none_without_auth() {
+        let request = Request::builder()
+            .body(Body::empty())
+            .expect("test request");
+        assert!(extract_user_key(&request).is_none());
+    }
+
+    #[test]
+    fn extract_user_key_returns_none_for_invalid_jwt() {
+        let request = Request::builder()
+            .header("authorization", "Bearer not-a-jwt")
+            .body(Body::empty())
+            .expect("test request");
+        assert!(extract_user_key(&request).is_none());
+    }
 }

--- a/crates/pylon/src/router.rs
+++ b/crates/pylon/src/router.rs
@@ -17,8 +17,9 @@ use tracing::info_span;
 use crate::error::ApiError;
 use crate::handlers::{config, health, knowledge, metrics, nous, sessions};
 use crate::middleware::{
-    CsrfState, RateLimiter, RequestId, enrich_error_response, inject_request_id, rate_limit,
-    record_http_metrics, require_csrf_header,
+    CsrfState, RateLimiter, RequestId, UserRateLimiter, enrich_error_response, inject_request_id,
+    rate_limit, record_http_metrics, require_csrf_header, spawn_rate_limit_cleanup,
+    user_rate_limit,
 };
 use crate::openapi;
 use crate::security::SecurityConfig;
@@ -88,6 +89,26 @@ pub fn build_router(state: Arc<AppState>, security: &SecurityConfig) -> Router {
 
     router = router.fallback(fallback_handler);
 
+    // Per-user rate limiting: token bucket keyed by authenticated identity,
+    // applied before the per-IP limiter so per-user limits are checked first.
+    if security.rate_limit_enabled {
+        let user_limiter = Arc::new(UserRateLimiter::new(
+            security.user_rate_limit_default_rpm,
+            security.user_rate_limit_default_burst,
+            security.user_rate_limit_llm_rpm,
+            security.user_rate_limit_tool_rpm,
+        ));
+        spawn_rate_limit_cleanup(
+            Arc::clone(&user_limiter),
+            Duration::from_secs(60),
+            Duration::from_secs(600),
+            state.shutdown.child_token(),
+        );
+        router = router
+            .layer(axum::middleware::from_fn(user_rate_limit))
+            .layer(axum::Extension(user_limiter));
+    }
+
     // Rate limiting: per-IP sliding window, applied before business logic
     if security.rate_limit_enabled {
         let limiter = Arc::new(
@@ -127,10 +148,10 @@ pub fn build_router(state: Arc<AppState>, security: &SecurityConfig) -> Router {
     router = router.layer(
         TraceLayer::new_for_http()
             .make_span_with(|request: &axum::http::Request<_>| {
-                let request_id = request
-                    .extensions()
-                    .get::<RequestId>()
-                    .map_or_else(|| ulid::Ulid::new().to_string(), std::string::ToString::to_string);
+                let request_id = request.extensions().get::<RequestId>().map_or_else(
+                    || ulid::Ulid::new().to_string(),
+                    std::string::ToString::to_string,
+                );
                 info_span!("http_request",
                     http.method = %request.method(),
                     http.path = %request.uri().path(),

--- a/crates/pylon/src/security.rs
+++ b/crates/pylon/src/security.rs
@@ -39,6 +39,14 @@ pub struct SecurityConfig {
     pub rate_limit_enabled: bool,
     /// Maximum requests per minute per client IP.
     pub rate_limit_requests_per_minute: u32,
+    /// Per-user requests per minute for general API endpoints.
+    pub user_rate_limit_default_rpm: u32,
+    /// Per-user burst allowance (max tokens in the bucket).
+    pub user_rate_limit_default_burst: u32,
+    /// Per-user requests per minute for LLM/chat endpoints.
+    pub user_rate_limit_llm_rpm: u32,
+    /// Per-user requests per minute for tool execution endpoints.
+    pub user_rate_limit_tool_rpm: u32,
     /// Trust X-Forwarded-For and X-Real-IP headers for client IP resolution.
     ///
     /// Enable only when pylon is behind a trusted reverse proxy that strips
@@ -89,6 +97,10 @@ impl SecurityConfig {
             tls_key_path: gateway.tls.key_path.as_ref().map(PathBuf::from),
             rate_limit_enabled: gateway.rate_limit.enabled,
             rate_limit_requests_per_minute: gateway.rate_limit.requests_per_minute,
+            user_rate_limit_default_rpm: gateway.rate_limit.default_rpm,
+            user_rate_limit_default_burst: gateway.rate_limit.default_burst,
+            user_rate_limit_llm_rpm: gateway.rate_limit.llm_rpm,
+            user_rate_limit_tool_rpm: gateway.rate_limit.tool_rpm,
             trust_proxy: false,
         }
     }
@@ -108,6 +120,10 @@ impl Default for SecurityConfig {
             tls_key_path: None,
             rate_limit_enabled: false,
             rate_limit_requests_per_minute: 60,
+            user_rate_limit_default_rpm: 60,
+            user_rate_limit_default_burst: 10,
+            user_rate_limit_llm_rpm: 20,
+            user_rate_limit_tool_rpm: 30,
             trust_proxy: false,
         }
     }

--- a/crates/taxis/src/config.rs
+++ b/crates/taxis/src/config.rs
@@ -498,8 +498,16 @@ impl Default for CsrfConfig {
 pub struct RateLimitConfig {
     /// Whether rate limiting is active.
     pub enabled: bool,
-    /// Maximum requests per minute per client IP.
+    /// Maximum requests per minute per client IP (global, pre-auth).
     pub requests_per_minute: u32,
+    /// Per-user requests per minute for general API endpoints.
+    pub default_rpm: u32,
+    /// Per-user burst allowance (max tokens in the bucket).
+    pub default_burst: u32,
+    /// Per-user requests per minute for LLM/chat endpoints.
+    pub llm_rpm: u32,
+    /// Per-user requests per minute for tool execution endpoints.
+    pub tool_rpm: u32,
 }
 
 impl Default for RateLimitConfig {
@@ -507,6 +515,10 @@ impl Default for RateLimitConfig {
         Self {
             enabled: false,
             requests_per_minute: 60,
+            default_rpm: 60,
+            default_burst: 10,
+            llm_rpm: 20,
+            tool_rpm: 30,
         }
     }
 }


### PR DESCRIPTION
## Summary

- Add per-user token bucket rate limiter to pylon HTTP middleware, keyed by authenticated user identity (JWT `sub` claim) with IP-based fallback
- Apply different rate limits per endpoint category: general API (60 rpm), LLM/chat (20 rpm), tool execution (30 rpm), each with proportional burst allowance
- Add configurable rate limit tiers via `gateway.rateLimit` TOML section (`defaultRpm`, `defaultBurst`, `llmRpm`, `toolRpm`)
- Background cleanup task removes stale entries (>10 min idle) to prevent unbounded memory growth

## Test plan

- [x] Verify requests under limit succeed (`token_bucket_allows_requests_under_limit`)
- [x] Verify burst allowance works (`token_bucket_allows_burst`)
- [x] Verify requests over limit return 429 with Retry-After (`token_bucket_returns_retry_after_on_limit`)
- [x] Verify per-user isolation: user A's usage doesn't affect user B (`per_user_isolation`)
- [x] Verify different endpoint categories have different limits (`different_categories_have_different_limits`)
- [x] Verify stale entry cleanup removes old entries (`cleanup_stale_removes_old_entries`)
- [x] Verify cleanup preserves recent entries (`cleanup_stale_preserves_recent_entries`)
- [x] Verify endpoint classification for LLM, tool, and general paths
- [x] Verify JWT sub claim extraction for user keying
- [x] All 256 pylon tests pass, all 129 taxis tests pass
- [x] `cargo clippy` clean, `cargo fmt` clean

## Observations

- **Debt**: `crates/pylon/src/handlers/knowledge.rs:677-696` — `get_fact_relationships` and `get_similar_facts` are stub functions only compiled under `knowledge-store` feature. `get_entity_relationships` is also a stub but called unconditionally.
- **Debt**: `crates/pylon/src/handlers/knowledge.rs:289` — `state` parameter unused without `knowledge-store` feature, required `let _ = &state` suppression.
- **Debt**: `crates/melete/src/distill.rs:382`, `crates/melete/src/prompt.rs:84,90` — non-exhaustive match arms on `Content` and `Role` enums from hermeneus (pre-existing on main).

Closes #1453

🤖 Generated with [Claude Code](https://claude.com/claude-code)