### PR TITLE
refactor(symbolon): replace jsonwebtoken with owned HS256 JWT implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -190,7 +190,6 @@ dependencies = [
  "aletheia-thesauros",
  "axum 0.8.8",
  "jiff",
- "jsonwebtoken",
  "reqwest 0.13.2",
  "rustls",
  "secrecy",
@@ -363,7 +362,6 @@ dependencies = [
  "axum-server",
  "http-body-util",
  "jiff",
- "jsonwebtoken",
  "prometheus",
  "rand 0.9.2",
  "reqwest 0.13.2",
@@ -390,10 +388,11 @@ version = "0.12.0"
 dependencies = [
  "aletheia-koina",
  "argon2",
+ "base64 0.22.1",
  "blake3",
- "jsonwebtoken",
  "rand 0.9.2",
  "reqwest 0.13.2",
+ "ring",
  "rusqlite",
  "secrecy",
  "serde",
@@ -879,12 +878,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "base16ct"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
-
-[[package]]
 name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1322,12 +1315,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "const-oid"
-version = "0.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
-
-[[package]]
 name = "constant_time_eq"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1547,22 +1534,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
-name = "crypto-bigint"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
-dependencies = [
- "generic-array",
- "rand_core 0.6.4",
- "subtle",
- "zeroize",
-]
-
-[[package]]
 name = "crypto-common"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
@@ -1576,33 +1551,6 @@ checksum = "eb2a7d3066da2de787b7f032c736763eb7ae5d355f81a68bab2675a96008b0bf"
 dependencies = [
  "lab",
  "phf",
-]
-
-[[package]]
-name = "curve25519-dalek"
-version = "4.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.2.17",
- "curve25519-dalek-derive",
- "digest",
- "fiat-crypto",
- "rustc_version",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "curve25519-dalek-derive"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -1728,17 +1676,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5729f5117e208430e437df2f4843f5e5952997175992d1414f94c57d61e270b4"
 
 [[package]]
-name = "der"
-version = "0.7.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
-dependencies = [
- "const-oid",
- "pem-rfc7468",
- "zeroize",
-]
-
-[[package]]
 name = "der-parser"
 version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1827,7 +1764,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
- "const-oid",
  "crypto-common",
  "subtle",
 ]
@@ -1912,69 +1848,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d926b4d407d372f141f93bb444696142c29d32962ccbd3531117cf3aa0bfa9"
 
 [[package]]
-name = "ecdsa"
-version = "0.16.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
-dependencies = [
- "der",
- "digest",
- "elliptic-curve",
- "rfc6979",
- "signature",
- "spki",
-]
-
-[[package]]
-name = "ed25519"
-version = "2.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
-dependencies = [
- "pkcs8",
- "signature",
-]
-
-[[package]]
-name = "ed25519-dalek"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
-dependencies = [
- "curve25519-dalek",
- "ed25519",
- "serde",
- "sha2",
- "subtle",
- "zeroize",
-]
-
-[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
-
-[[package]]
-name = "elliptic-curve"
-version = "0.13.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
-dependencies = [
- "base16ct",
- "crypto-bigint",
- "digest",
- "ff",
- "generic-array",
- "group",
- "hkdf",
- "pem-rfc7468",
- "pkcs8",
- "rand_core 0.6.4",
- "sec1",
- "subtle",
- "zeroize",
-]
 
 [[package]]
 name = "encode_unicode"
@@ -2173,22 +2050,6 @@ checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
 dependencies = [
  "simd-adler32",
 ]
-
-[[package]]
-name = "ff"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
-dependencies = [
- "rand_core 0.6.4",
- "subtle",
-]
-
-[[package]]
-name = "fiat-crypto"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "figment"
@@ -2559,13 +2420,12 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.9"
+version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bb6743198531e02858aeaea5398fcc883e71851fcbcb5a2f773e2fb6cb1edf2"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
- "zeroize",
 ]
 
 [[package]]
@@ -2636,17 +2496,6 @@ checksum = "f5df2ba84018d80c213569363bdcd0c64e6933c67fe4c1d60ecf822971a3c35e"
 dependencies = [
  "color_quant",
  "weezl",
-]
-
-[[package]]
-name = "group"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
-dependencies = [
- "ff",
- "rand_core 0.6.4",
- "subtle",
 ]
 
 [[package]]
@@ -2767,24 +2616,6 @@ dependencies = [
  "tokio",
  "ureq",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "hkdf"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
-dependencies = [
- "hmac",
-]
-
-[[package]]
-name = "hmac"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
-dependencies = [
- "digest",
 ]
 
 [[package]]
@@ -3326,29 +3157,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "jsonwebtoken"
-version = "10.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0529410abe238729a60b108898784df8984c87f6054c9c4fcacc47e4803c1ce1"
-dependencies = [
- "base64 0.22.1",
- "ed25519-dalek",
- "getrandom 0.2.17",
- "hmac",
- "js-sys",
- "p256",
- "p384",
- "pem",
- "rand 0.8.5",
- "rsa",
- "serde",
- "serde_json",
- "sha2",
- "signature",
- "simple_asn1",
-]
-
-[[package]]
 name = "kasuari"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3381,9 +3189,6 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-dependencies = [
- "spin",
-]
 
 [[package]]
 name = "leb128fmt"
@@ -3790,22 +3595,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-bigint-dig"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
-dependencies = [
- "lazy_static",
- "libm",
- "num-integer",
- "num-iter",
- "num-traits",
- "rand 0.8.5",
- "smallvec",
- "zeroize",
-]
-
-[[package]]
 name = "num-complex"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3838,17 +3627,6 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "num-iter"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
-dependencies = [
- "autocfg",
- "num-integer",
  "num-traits",
 ]
 
@@ -4045,30 +3823,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
-name = "p256"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
-dependencies = [
- "ecdsa",
- "elliptic-curve",
- "primeorder",
- "sha2",
-]
-
-[[package]]
-name = "p384"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
-dependencies = [
- "ecdsa",
- "elliptic-curve",
- "primeorder",
- "sha2",
-]
-
-[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4151,15 +3905,6 @@ checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
  "base64 0.22.1",
  "serde_core",
-]
-
-[[package]]
-name = "pem-rfc7468"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
-dependencies = [
- "base64ct",
 ]
 
 [[package]]
@@ -4296,27 +4041,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
-name = "pkcs1"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
-dependencies = [
- "der",
- "pkcs8",
- "spki",
-]
-
-[[package]]
-name = "pkcs8"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
-dependencies = [
- "der",
- "spki",
-]
-
-[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4425,15 +4149,6 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "primeorder"
-version = "0.13.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
-dependencies = [
- "elliptic-curve",
 ]
 
 [[package]]
@@ -5191,16 +4906,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rfc6979"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
-dependencies = [
- "hmac",
- "subtle",
-]
-
-[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5275,26 +4980,6 @@ checksum = "72f81bee8c8ef9b577d1681a70ebbc962c232461e397b22c208c43c04b67a155"
 dependencies = [
  "rmp",
  "serde",
-]
-
-[[package]]
-name = "rsa"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
-dependencies = [
- "const-oid",
- "digest",
- "num-bigint-dig",
- "num-integer",
- "num-traits",
- "pkcs1",
- "pkcs8",
- "rand_core 0.6.4",
- "signature",
- "spki",
- "subtle",
- "zeroize",
 ]
 
 [[package]]
@@ -5554,20 +5239,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
-name = "sec1"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
-dependencies = [
- "base16ct",
- "der",
- "generic-array",
- "pkcs8",
- "subtle",
- "zeroize",
-]
-
-[[package]]
 name = "seccompiler"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5810,16 +5481,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "signature"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
-dependencies = [
- "digest",
- "rand_core 0.6.4",
-]
-
-[[package]]
 name = "simd-adler32"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5830,18 +5491,6 @@ name = "similar"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
-
-[[package]]
-name = "simple_asn1"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
-dependencies = [
- "num-bigint",
- "num-traits",
- "thiserror 2.0.18",
- "time",
-]
 
 [[package]]
 name = "siphasher"
@@ -5929,16 +5578,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 dependencies = [
  "lock_api",
-]
-
-[[package]]
-name = "spki"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
-dependencies = [
- "base64ct",
- "der",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,9 +136,6 @@ rustls = { version = "0.23", default-features = false, features = ["ring", "std"
 rcgen = "0.14"
 regex = "1"
 
-# Auth
-jsonwebtoken = { version = "10", features = ["rust_crypto"] }
-
 # Database
 rusqlite = { version = "0.38", features = ["bundled"] }
 

--- a/crates/hermeneus/src/fallback.rs
+++ b/crates/hermeneus/src/fallback.rs
@@ -172,7 +172,10 @@ mod tests {
         }
     }
 
-    #[expect(clippy::unnecessary_wraps, reason = "returns Result to match Vec<Result> in mock")]
+    #[expect(
+        clippy::unnecessary_wraps,
+        reason = "returns Result to match Vec<Result> in mock"
+    )]
     fn ok_response(model: &str) -> Result<CompletionResponse> {
         Ok(CompletionResponse {
             id: "resp-1".to_owned(),

--- a/crates/integration-tests/Cargo.toml
+++ b/crates/integration-tests/Cargo.toml
@@ -28,7 +28,6 @@ aletheia-thesauros = { path = "../thesauros" }
 aletheia-pylon = { path = "../pylon" }
 aletheia-symbolon = { path = "../symbolon" }
 jiff = { workspace = true }
-jsonwebtoken = { workspace = true }
 axum = { workspace = true }
 reqwest = { workspace = true }
 rustls = { workspace = true }

--- a/crates/integration-tests/tests/cross_crate_pipeline.rs
+++ b/crates/integration-tests/tests/cross_crate_pipeline.rs
@@ -777,7 +777,6 @@ async fn auth_invalid_token_returns_401() {
 
 #[tokio::test]
 async fn auth_expired_token_returns_401() {
-    // Craft a token with exp far in the past (beyond jsonwebtoken's 60s leeway)
     let claims = aletheia_symbolon::types::Claims {
         sub: "test-user".to_owned(),
         role: Role::Operator,
@@ -788,9 +787,8 @@ async fn auth_expired_token_returns_401() {
         jti: "expired-test".to_owned(),
         kind: aletheia_symbolon::types::TokenKind::Access,
     };
-    let key = jsonwebtoken::EncodingKey::from_secret(b"test-secret-key-for-jwt");
-    let token = jsonwebtoken::encode(&jsonwebtoken::Header::default(), &claims, &key)
-        .expect("encode expired token");
+    let key = aletheia_symbolon::jwt::hmac_key(b"test-secret-key-for-jwt");
+    let token = aletheia_symbolon::jwt::encode(&claims, &key).expect("encode expired token");
 
     let harness = TestHarness::build().await;
     let router = harness.router();

--- a/crates/koina/src/redacting_layer.rs
+++ b/crates/koina/src/redacting_layer.rs
@@ -267,7 +267,9 @@ mod tests {
     }
 
     fn output_string(buffer: &Arc<Mutex<Vec<u8>>>) -> String {
-        let guard = buffer.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        let guard = buffer
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         String::from_utf8_lossy(&guard).into_owned()
     }
 

--- a/crates/pylon/Cargo.toml
+++ b/crates/pylon/Cargo.toml
@@ -59,9 +59,6 @@ aletheia-symbolon = { path = "../symbolon" }
 aletheia-hermeneus = { path = "../hermeneus", features = ["test-utils"] }
 http-body-util = "0.1"
 jiff = { workspace = true }
-# jsonwebtoken 10.x pins rand 0.8; no released version uses rand 0.9.
-# This causes a duplicate rand in the binary. Track: https://github.com/Keats/jsonwebtoken/issues
-jsonwebtoken = { workspace = true }
 reqwest = { workspace = true }
 secrecy = { workspace = true }
 static_assertions = { workspace = true }

--- a/crates/pylon/src/router.rs
+++ b/crates/pylon/src/router.rs
@@ -127,10 +127,10 @@ pub fn build_router(state: Arc<AppState>, security: &SecurityConfig) -> Router {
     router = router.layer(
         TraceLayer::new_for_http()
             .make_span_with(|request: &axum::http::Request<_>| {
-                let request_id = request
-                    .extensions()
-                    .get::<RequestId>()
-                    .map_or_else(|| ulid::Ulid::new().to_string(), std::string::ToString::to_string);
+                let request_id = request.extensions().get::<RequestId>().map_or_else(
+                    || ulid::Ulid::new().to_string(),
+                    std::string::ToString::to_string,
+                );
                 info_span!("http_request",
                     http.method = %request.method(),
                     http.path = %request.uri().path(),

--- a/crates/pylon/src/tests.rs
+++ b/crates/pylon/src/tests.rs
@@ -250,8 +250,8 @@ async fn valid_token_passes() {
 
 #[tokio::test]
 async fn expired_token_rejected() {
+    use aletheia_symbolon::jwt::{encode, hmac_key};
     use aletheia_symbolon::types::{Claims, Role, TokenKind};
-    use jsonwebtoken::{Algorithm, EncodingKey, Header};
 
     let (app, _dir) = app().await;
 
@@ -265,12 +265,8 @@ async fn expired_token_rejected() {
         jti: "expired-jti".to_owned(),
         kind: TokenKind::Access,
     };
-    let token = jsonwebtoken::encode(
-        &Header::new(Algorithm::HS256),
-        &claims,
-        &EncodingKey::from_secret(b"test-secret-key-for-jwt"),
-    )
-    .unwrap();
+    let key = hmac_key(b"test-secret-key-for-jwt");
+    let token = encode(&claims, &key).unwrap();
 
     let req = Request::builder()
         .method("POST")

--- a/crates/symbolon/Cargo.toml
+++ b/crates/symbolon/Cargo.toml
@@ -13,12 +13,10 @@ workspace = true
 [dependencies]
 aletheia-koina = { path = "../koina" }
 argon2 = { version = "0.5", features = ["std"] }
+base64 = { workspace = true }
 blake3 = "1"
-# jsonwebtoken 10.x pins rand 0.8; no released version uses rand 0.9.
-# rand is declared explicitly to ensure the workspace 0.9 version is resolved
-# rather than the older 0.8 that jsonwebtoken transitively requires.
-jsonwebtoken = { workspace = true }
 rand = { workspace = true }
+ring = { workspace = true }
 reqwest = { workspace = true }
 rusqlite = { workspace = true }
 secrecy = { workspace = true }

--- a/crates/symbolon/src/error.rs
+++ b/crates/symbolon/src/error.rs
@@ -55,17 +55,17 @@ pub enum Error {
     },
 
     /// JWT encoding failed.
-    #[snafu(display("token encode error: {source}"))]
+    #[snafu(display("token encode error: {message}"))]
     TokenEncode {
-        source: jsonwebtoken::errors::Error,
+        message: String,
         #[snafu(implicit)]
         location: snafu::Location,
     },
 
     /// JWT decoding failed.
-    #[snafu(display("token decode error: {source}"))]
+    #[snafu(display("token decode error: {message}"))]
     TokenDecode {
-        source: jsonwebtoken::errors::Error,
+        message: String,
         #[snafu(implicit)]
         location: snafu::Location,
     },

--- a/crates/symbolon/src/jwt.rs
+++ b/crates/symbolon/src/jwt.rs
@@ -1,14 +1,22 @@
 //! JWT token issuance and validation.
+//!
+//! Implements HS256 (HMAC-SHA256) JWT encode/decode directly using `ring`,
+//! eliminating the `jsonwebtoken` crate and its CVE-flagged transitive deps.
 
 use std::time::Duration;
 
-use jsonwebtoken::{Algorithm, DecodingKey, EncodingKey, Header, Validation};
+use base64::Engine;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use ring::hmac;
 use secrecy::{ExposeSecret, SecretString};
-use snafu::IntoError;
+use snafu::ensure;
 use tracing::instrument;
 
 use crate::error::{self, Result};
 use crate::types::{Claims, Role, TokenKind, TokenPair};
+
+/// Fixed HS256 JWT header, pre-encoded as base64url.
+const HS256_HEADER_B64: &str = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9";
 
 /// Configuration for JWT token management.
 pub struct JwtConfig {
@@ -81,8 +89,7 @@ impl JwtConfig {
 
 /// Manages JWT issuance and validation.
 pub struct JwtManager {
-    encoding_key: EncodingKey,
-    decoding_key: DecodingKey,
+    hmac_key: hmac::Key,
     config: JwtConfig,
 }
 
@@ -90,13 +97,8 @@ impl JwtManager {
     /// Create a new JWT manager from the given config.
     pub fn new(config: JwtConfig) -> Self {
         let key_bytes = config.signing_key.expose_secret().as_bytes();
-        let encoding_key = EncodingKey::from_secret(key_bytes);
-        let decoding_key = DecodingKey::from_secret(key_bytes);
-        Self {
-            encoding_key,
-            decoding_key,
-            config,
-        }
+        let hmac_key = hmac::Key::new(hmac::HMAC_SHA256, key_bytes);
+        Self { hmac_key, config }
     }
 
     /// Issue an access token.
@@ -129,19 +131,24 @@ impl JwtManager {
     /// Returns [`crate::error::Error::TokenDecode`] if the token is malformed, has an invalid
     /// signature, or fails any other JWT validation check.
     pub fn validate(&self, token: &str) -> Result<Claims> {
-        let mut validation = Validation::new(Algorithm::HS256);
-        validation.set_issuer(&[&self.config.issuer]);
-        validation.set_required_spec_claims(&["exp", "iss", "sub", "iat"]);
+        let claims = decode(token, &self.hmac_key)?;
 
-        let token_data = jsonwebtoken::decode::<Claims>(token, &self.decoding_key, &validation)
-            .map_err(|e| match e.kind() {
-                jsonwebtoken::errors::ErrorKind::ExpiredSignature => {
-                    error::ExpiredTokenSnafu.build()
-                }
-                _ => error::TokenDecodeSnafu.into_error(e),
-            })?;
+        ensure!(
+            claims.iss == self.config.issuer,
+            error::TokenDecodeSnafu {
+                message: format!(
+                    "issuer mismatch: expected '{}', got '{}'",
+                    self.config.issuer, claims.iss
+                )
+            }
+        );
 
-        Ok(token_data.claims)
+        let now = now_unix();
+        if claims.exp <= now {
+            return Err(error::ExpiredTokenSnafu.build());
+        }
+
+        Ok(claims)
     }
 
     /// Refresh a token pair: validate the refresh token, issue a new access + refresh pair.
@@ -193,12 +200,99 @@ impl JwtManager {
             kind,
         };
 
-        jsonwebtoken::encode(&Header::new(Algorithm::HS256), &claims, &self.encoding_key)
-            .context(error::TokenEncodeSnafu)
+        encode(&claims, &self.hmac_key)
     }
 }
 
-use snafu::ResultExt;
+/// Encode claims as an HS256 JWT.
+///
+/// # Errors
+///
+/// Returns [`crate::error::Error::TokenEncode`] if the claims cannot be serialized to JSON.
+pub fn encode(claims: &Claims, key: &hmac::Key) -> Result<String> {
+    let payload_json = serde_json::to_vec(claims).map_err(|e| {
+        error::TokenEncodeSnafu {
+            message: e.to_string(),
+        }
+        .build()
+    })?;
+    let payload_b64 = URL_SAFE_NO_PAD.encode(&payload_json);
+
+    let signing_input = format!("{HS256_HEADER_B64}.{payload_b64}");
+    let signature = hmac::sign(key, signing_input.as_bytes());
+    let sig_b64 = URL_SAFE_NO_PAD.encode(signature.as_ref());
+
+    Ok(format!("{signing_input}.{sig_b64}"))
+}
+
+/// Decode and verify an HS256 JWT, returning the claims.
+///
+/// # Errors
+///
+/// Returns [`crate::error::Error::TokenDecode`] if the token is malformed or the signature
+/// is invalid.
+pub fn decode(token: &str, key: &hmac::Key) -> Result<Claims> {
+    let (header_payload, sig_b64) = token.rsplit_once('.').ok_or_else(|| {
+        error::TokenDecodeSnafu {
+            message: "missing signature segment".to_owned(),
+        }
+        .build()
+    })?;
+
+    // Verify there are exactly 3 segments
+    if header_payload.matches('.').count() != 1 {
+        return Err(error::TokenDecodeSnafu {
+            message: "token must have exactly 3 segments".to_owned(),
+        }
+        .build());
+    }
+
+    let sig_bytes = URL_SAFE_NO_PAD.decode(sig_b64).map_err(|_e| {
+        error::TokenDecodeSnafu {
+            message: "invalid base64url in signature".to_owned(),
+        }
+        .build()
+    })?;
+
+    hmac::verify(key, header_payload.as_bytes(), &sig_bytes).map_err(|_e| {
+        error::TokenDecodeSnafu {
+            message: "signature verification failed".to_owned(),
+        }
+        .build()
+    })?;
+
+    let payload_b64 = header_payload
+        .split_once('.')
+        .map(|(_, p)| p)
+        .ok_or_else(|| {
+            error::TokenDecodeSnafu {
+                message: "missing payload segment".to_owned(),
+            }
+            .build()
+        })?;
+
+    let payload_bytes = URL_SAFE_NO_PAD.decode(payload_b64).map_err(|_e| {
+        error::TokenDecodeSnafu {
+            message: "invalid base64url in payload".to_owned(),
+        }
+        .build()
+    })?;
+
+    let claims: Claims = serde_json::from_slice(&payload_bytes).map_err(|e| {
+        error::TokenDecodeSnafu {
+            message: format!("invalid claims JSON: {e}"),
+        }
+        .build()
+    })?;
+
+    Ok(claims)
+}
+
+/// Build an `hmac::Key` from raw secret bytes. Convenience for test helpers.
+#[must_use]
+pub fn hmac_key(secret: &[u8]) -> hmac::Key {
+    hmac::Key::new(hmac::HMAC_SHA256, secret)
+}
 
 fn now_unix() -> i64 {
     i64::try_from(
@@ -274,8 +368,8 @@ mod tests {
     #[test]
     fn expired_token_rejected() {
         let mgr = test_manager();
+        let key = hmac_key(b"test-secret-key-for-jwt");
 
-        // NOTE: manually encode a token with exp far in the past, beyond the 60s leeway
         let claims = Claims {
             sub: "user-1".to_owned(),
             role: Role::Operator,
@@ -286,12 +380,7 @@ mod tests {
             jti: "expired-jti".to_owned(),
             kind: TokenKind::Access,
         };
-        let token = jsonwebtoken::encode(
-            &Header::new(Algorithm::HS256),
-            &claims,
-            &EncodingKey::from_secret(b"test-secret-key-for-jwt"),
-        )
-        .unwrap();
+        let token = encode(&claims, &key).unwrap();
 
         let result = mgr.validate(&token);
         assert!(result.is_err());
@@ -385,5 +474,74 @@ mod tests {
         assert!(config.validate_for_auth_mode("jwt").is_ok());
         assert!(config.validate_for_auth_mode("token").is_ok());
         assert!(config.validate_for_auth_mode("none").is_ok());
+    }
+
+    #[test]
+    fn tampered_payload_rejected() {
+        let mgr = test_manager();
+        let token = mgr.issue_access("user-1", Role::Operator, None).unwrap();
+
+        // Tamper with the payload segment
+        let parts: Vec<&str> = token.splitn(3, '.').collect();
+        let tampered = format!("{}.dGFtcGVyZWQ.{}", parts[0], parts[2]);
+        assert!(mgr.validate(&tampered).is_err());
+    }
+
+    #[test]
+    fn tampered_signature_rejected() {
+        let mgr = test_manager();
+        let token = mgr.issue_access("user-1", Role::Operator, None).unwrap();
+
+        // Replace last character of signature
+        let mut tampered = token.clone();
+        let last = tampered.pop().unwrap();
+        tampered.push(if last == 'A' { 'B' } else { 'A' });
+        assert!(mgr.validate(&tampered).is_err());
+    }
+
+    #[test]
+    fn token_has_three_dot_separated_segments() {
+        let mgr = test_manager();
+        let token = mgr.issue_access("user-1", Role::Operator, None).unwrap();
+        assert_eq!(
+            token.matches('.').count(),
+            2,
+            "JWT must have exactly 3 segments"
+        );
+    }
+
+    #[test]
+    fn roundtrip_preserves_all_claims_fields() {
+        let mgr = test_manager();
+        let token = mgr
+            .issue_access("agent-syn", Role::Agent, Some("syn-nous"))
+            .unwrap();
+        let claims = mgr.validate(&token).unwrap();
+
+        assert_eq!(claims.sub, "agent-syn");
+        assert_eq!(claims.role, Role::Agent);
+        assert_eq!(claims.nous_id.as_deref(), Some("syn-nous"));
+        assert_eq!(claims.iss, "aletheia-test");
+        assert_eq!(claims.kind, TokenKind::Access);
+        assert!(claims.iat > 0, "iat must be positive");
+        assert!(claims.exp > claims.iat, "exp must be after iat");
+        assert!(!claims.jti.is_empty(), "jti must be non-empty");
+    }
+
+    #[test]
+    fn issuer_mismatch_rejected() {
+        let mgr1 = JwtManager::new(JwtConfig {
+            signing_key: SecretString::from("shared-key".to_owned()),
+            issuer: "issuer-a".to_owned(),
+            ..JwtConfig::default()
+        });
+        let mgr2 = JwtManager::new(JwtConfig {
+            signing_key: SecretString::from("shared-key".to_owned()),
+            issuer: "issuer-b".to_owned(),
+            ..JwtConfig::default()
+        });
+
+        let token = mgr1.issue_access("user-1", Role::Operator, None).unwrap();
+        assert!(mgr2.validate(&token).is_err());
     }
 }

--- a/deny.toml
+++ b/deny.toml
@@ -7,8 +7,7 @@ exclude = ["aletheia-integration-tests"]
 
 [advisories]
 ignore = [
-    { id = "RUSTSEC-2023-0071", reason = "rsa timing side-channel via jsonwebtoken — no safe upgrade, local-only use" },
-    { id = "RUSTSEC-2024-0320", reason = "yaml-rust unmaintained — transitive via syntect/aletheia-tui, no safe upgrade" },
+{ id = "RUSTSEC-2024-0320", reason = "yaml-rust unmaintained — transitive via syntect/aletheia-tui, no safe upgrade" },
     { id = "RUSTSEC-2025-0141", reason = "bincode unmaintained — transitive via syntect/aletheia-tui, no safe upgrade" },
     { id = "RUSTSEC-2024-0436", reason = "paste unmaintained, transitive via tokenizers; no safe upgrade" },
 ]

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -211,7 +211,7 @@ strip = "symbols"
 ## Structural properties
 
 - **koina is a true leaf node.** No workspace deps in Rust.
-- **symbolon depends only on koina** (plus external crates: reqwest, rusqlite, jsonwebtoken).
+- **symbolon depends only on koina** (plus external crates: reqwest, rusqlite, ring).
 - **Datalog+HNSW engine is embedded** inside `mneme/src/engine/`, gated behind the `mneme-engine` feature.
 - **Trait boundaries are extension points.** `EmbeddingProvider`, `ChannelProvider`, `LlmProvider` - implement the trait, swap the provider.
 - **daemon depends only on koina** - lightweight scheduling, not a high-layer crate. No other application crate imports it.

--- a/docs/TECHNOLOGY.md
+++ b/docs/TECHNOLOGY.md
@@ -87,7 +87,7 @@ Lean dependency count. See `Cargo.toml` workspace members and `[workspace.depend
 | **nous** | koina, taxis, mneme, hermeneus, organon, melete, tokio, ulid, compact_str |
 | **dianoia** | koina, taxis, mneme, hermeneus, nous, rusqlite |
 | **pylon** | koina, taxis, nous, axum, tower, tower-http, symbolon, serde_json, chacha20poly1305 |
-| **symbolon** | koina, taxis, rusqlite, jsonwebtoken, argon2 |
+| **symbolon** | koina, taxis, rusqlite, ring, argon2 |
 | **agora** | koina, taxis, nous, tokio (semeion: tokio::process, slack: tokio-tungstenite) |
 | **daemon** | koina, taxis, nous, mneme, cron, notify, arc-swap |
 | **melete** | koina, taxis, mneme, hermeneus, nous |


### PR DESCRIPTION
## Summary

- Replace `jsonwebtoken` crate with ~100 lines of owned HS256 JWT encode/decode using `ring::hmac` + `base64`
- Eliminates CVE-flagged transitive dependency (RUSTSEC-2023-0071 via `rsa`) and removes 18+ transitive crates
- Expose `encode`, `decode`, `hmac_key` public helpers from `symbolon::jwt` for test use across crates
- Error types changed from wrapping `jsonwebtoken::errors::Error` to carrying `message: String`

## Test plan

- [x] All 108 symbolon tests pass (including JWT roundtrip, expired, tampered, malformed, issuer mismatch)
- [x] All 242 pylon tests pass (including expired token rejection)
- [x] Integration tests pass (cross-crate expired token test)
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] No new `rand` version duplicates introduced
- [x] `jsonwebtoken` completely removed from Cargo.lock (0 occurrences)

## Observations

- **Debt**: `rand` still has 3 versions in the dep tree (0.8, 0.9, 0.10) from other transitive deps (tokenizers, argon2, etc.). Removing jsonwebtoken doesn't reduce this since `rand 0.8` is still pulled by other paths.
- **Debt**: Pre-existing test failure `server_starts_serves_health_and_shuts_down` in `aletheia` integration server test (reqwest TLS provider panic, unrelated to this change).

Closes #1430

🤖 Generated with [Claude Code](https://claude.com/claude-code)