### PR TITLE
refactor(hermeneus): expose model constants as public API

### DIFF
--- a/crates/hermeneus/src/anthropic/client.rs
+++ b/crates/hermeneus/src/anthropic/client.rs
@@ -31,12 +31,12 @@ const BACKOFF_FACTOR: u64 = 2;
 const BACKOFF_MAX_MS: u64 = 30_000;
 
 static SUPPORTED_MODELS: &[&str] = &[
-    "claude-opus-4-6",
-    "claude-opus-4-20250514",
-    "claude-sonnet-4-6",
-    "claude-sonnet-4-20250514",
-    "claude-haiku-4-5",
-    "claude-haiku-4-5-20251001",
+    crate::models::CLAUDE_OPUS_4,
+    crate::models::CLAUDE_OPUS_4_20250514,
+    crate::models::CLAUDE_SONNET_4,
+    crate::models::CLAUDE_SONNET_4_20250514,
+    crate::models::CLAUDE_HAIKU_4_5,
+    crate::models::CLAUDE_HAIKU_4_5_20251001,
 ];
 
 /// Anthropic Messages API provider.

--- a/crates/hermeneus/src/lib.rs
+++ b/crates/hermeneus/src/lib.rs
@@ -15,6 +15,8 @@ pub mod fallback;
 /// Provider health state machine (Up / Degraded / Down) with automatic recovery.
 pub mod health;
 pub mod metrics;
+/// Canonical model identifiers, context window sizes, and pricing rates.
+pub mod models;
 /// [`LlmProvider`](provider::LlmProvider), [`ProviderConfig`](provider::ProviderConfig), and [`ProviderRegistry`](provider::ProviderRegistry).
 pub mod provider;
 /// Shared mock provider for tests across the workspace.

--- a/crates/hermeneus/src/models.rs
+++ b/crates/hermeneus/src/models.rs
@@ -1,0 +1,45 @@
+//! Anthropic model identifiers and metadata.
+//!
+//! Canonical constants for model names, context window sizes, and pricing
+//! rates. Other crates should import from here instead of hardcoding model
+//! strings. Update these when Anthropic publishes new models or retires
+//! old ones.
+
+/// Claude Opus 4 (latest alias).
+pub const CLAUDE_OPUS_4: &str = "claude-opus-4-6";
+
+/// Claude Opus 4 (pinned 2025-05-14 snapshot).
+pub const CLAUDE_OPUS_4_20250514: &str = "claude-opus-4-20250514";
+
+/// Claude Sonnet 4 (latest alias).
+pub const CLAUDE_SONNET_4: &str = "claude-sonnet-4-6";
+
+/// Claude Sonnet 4 (pinned 2025-05-14 snapshot).
+pub const CLAUDE_SONNET_4_20250514: &str = "claude-sonnet-4-20250514";
+
+/// Claude Haiku 4.5 (latest alias).
+pub const CLAUDE_HAIKU_4_5: &str = "claude-haiku-4-5";
+
+/// Claude Haiku 4.5 (pinned 2025-10-01 snapshot).
+pub const CLAUDE_HAIKU_4_5_20251001: &str = "claude-haiku-4-5-20251001";
+
+/// Context window size shared by all current Claude models (tokens).
+pub const CONTEXT_WINDOW_TOKENS: u32 = 200_000;
+
+/// Cost per million input tokens (USD) for Opus models.
+pub const OPUS_INPUT_COST_PER_MTOK: f64 = 15.0;
+
+/// Cost per million output tokens (USD) for Opus models.
+pub const OPUS_OUTPUT_COST_PER_MTOK: f64 = 75.0;
+
+/// Cost per million input tokens (USD) for Sonnet models.
+pub const SONNET_INPUT_COST_PER_MTOK: f64 = 3.0;
+
+/// Cost per million output tokens (USD) for Sonnet models.
+pub const SONNET_OUTPUT_COST_PER_MTOK: f64 = 15.0;
+
+/// Cost per million input tokens (USD) for Haiku models.
+pub const HAIKU_INPUT_COST_PER_MTOK: f64 = 0.8;
+
+/// Cost per million output tokens (USD) for Haiku models.
+pub const HAIKU_OUTPUT_COST_PER_MTOK: f64 = 4.0;

--- a/crates/hermeneus/src/provider.rs
+++ b/crates/hermeneus/src/provider.rs
@@ -97,47 +97,48 @@ impl Default for ProviderConfig {
         // Built-in pricing for all first-party Anthropic models (USD per million tokens).
         // Operator configs are merged on top, so these act as sensible fallbacks.
         // Prices last verified against https://www.anthropic.com/pricing (2025-10-01).
+        use crate::models;
         let pricing = HashMap::from([
             (
-                "claude-opus-4-6".to_owned(),
+                models::CLAUDE_OPUS_4.to_owned(),
                 ModelPricing {
-                    input_cost_per_mtok: 15.0,
-                    output_cost_per_mtok: 75.0,
+                    input_cost_per_mtok: models::OPUS_INPUT_COST_PER_MTOK,
+                    output_cost_per_mtok: models::OPUS_OUTPUT_COST_PER_MTOK,
                 },
             ),
             (
-                "claude-opus-4-20250514".to_owned(),
+                models::CLAUDE_OPUS_4_20250514.to_owned(),
                 ModelPricing {
-                    input_cost_per_mtok: 15.0,
-                    output_cost_per_mtok: 75.0,
+                    input_cost_per_mtok: models::OPUS_INPUT_COST_PER_MTOK,
+                    output_cost_per_mtok: models::OPUS_OUTPUT_COST_PER_MTOK,
                 },
             ),
             (
-                "claude-sonnet-4-6".to_owned(),
+                models::CLAUDE_SONNET_4.to_owned(),
                 ModelPricing {
-                    input_cost_per_mtok: 3.0,
-                    output_cost_per_mtok: 15.0,
+                    input_cost_per_mtok: models::SONNET_INPUT_COST_PER_MTOK,
+                    output_cost_per_mtok: models::SONNET_OUTPUT_COST_PER_MTOK,
                 },
             ),
             (
-                "claude-sonnet-4-20250514".to_owned(),
+                models::CLAUDE_SONNET_4_20250514.to_owned(),
                 ModelPricing {
-                    input_cost_per_mtok: 3.0,
-                    output_cost_per_mtok: 15.0,
+                    input_cost_per_mtok: models::SONNET_INPUT_COST_PER_MTOK,
+                    output_cost_per_mtok: models::SONNET_OUTPUT_COST_PER_MTOK,
                 },
             ),
             (
-                "claude-haiku-4-5".to_owned(),
+                models::CLAUDE_HAIKU_4_5.to_owned(),
                 ModelPricing {
-                    input_cost_per_mtok: 0.8,
-                    output_cost_per_mtok: 4.0,
+                    input_cost_per_mtok: models::HAIKU_INPUT_COST_PER_MTOK,
+                    output_cost_per_mtok: models::HAIKU_OUTPUT_COST_PER_MTOK,
                 },
             ),
             (
-                "claude-haiku-4-5-20251001".to_owned(),
+                models::CLAUDE_HAIKU_4_5_20251001.to_owned(),
                 ModelPricing {
-                    input_cost_per_mtok: 0.8,
-                    output_cost_per_mtok: 4.0,
+                    input_cost_per_mtok: models::HAIKU_INPUT_COST_PER_MTOK,
+                    output_cost_per_mtok: models::HAIKU_OUTPUT_COST_PER_MTOK,
                 },
             ),
         ]);
@@ -145,7 +146,7 @@ impl Default for ProviderConfig {
             provider_type: "anthropic".to_owned(),
             api_key: None,
             base_url: None,
-            default_model: Some("claude-opus-4-20250514".to_owned()),
+            default_model: Some(models::CLAUDE_OPUS_4_20250514.to_owned()),
             max_retries: Some(3),
             pricing,
         }

--- a/crates/nous/src/config.rs
+++ b/crates/nous/src/config.rs
@@ -79,7 +79,7 @@ impl Default for NousConfig {
         Self {
             id: "default".to_owned(),
             name: None,
-            model: "claude-opus-4-20250514".to_owned(),
+            model: aletheia_hermeneus::models::CLAUDE_OPUS_4_20250514.to_owned(),
             context_window: 200_000,
             max_output_tokens: 16_384,
             bootstrap_max_tokens: 40_000,

--- a/crates/nous/src/distillation.rs
+++ b/crates/nous/src/distillation.rs
@@ -44,7 +44,7 @@ impl Default for DistillTriggerConfig {
     fn default() -> Self {
         Self {
             max_history_share: 0.7,
-            model: "claude-sonnet-4-20250514".to_owned(),
+            model: aletheia_hermeneus::models::CLAUDE_SONNET_4_20250514.to_owned(),
             verbatim_tail: 3,
         }
     }


### PR DESCRIPTION
## Summary

- Add `hermeneus::models` module with public constants for model identifiers (`CLAUDE_OPUS_4`, `CLAUDE_SONNET_4`, `CLAUDE_HAIKU_4_5`, and their pinned snapshots), context window size, and per-family pricing rates
- Replace hardcoded model string literals in `hermeneus::provider::ProviderConfig::default()` and `anthropic::client::SUPPORTED_MODELS`
- Replace hardcoded model strings in `nous::config::NousConfig::default()` and `nous::distillation::DistillTriggerConfig::default()`

Closes #1425

## Observations

- **Debt**: `crates/taxis/src/config.rs:301` hardcodes `"claude-sonnet-4-6"` in `ModelSpec::default()` but taxis has no dependency on hermeneus. Adding one just for a string constant would create inappropriate coupling (config crate depending on LLM provider crate). Consider extracting model constants to `aletheia-koina` if taxis needs them.
- **Debt**: `crates/melete/src/prompt.rs` has pre-existing clippy failures (non-exhaustive match on `Role` and `Content` types) unrelated to this change.
- **Debt**: Pre-existing `cargo fmt` violations in `crates/hermeneus/src/fallback.rs`, `crates/koina/src/redacting_layer.rs`, `crates/pylon/src/router.rs`.

## Test plan

- [x] `cargo check -p aletheia-hermeneus -p aletheia-nous` passes
- [x] `cargo clippy -p aletheia-hermeneus -p aletheia-nous --lib -- -D warnings` passes
- [x] `cargo test -p aletheia-hermeneus --lib` (166 tests pass)
- [x] `cargo test -p aletheia-nous --lib` (337 tests pass)
- [x] Existing tests verify constant values match expectations (e.g. `provider_config_defaults` checks pricing for haiku)

🤖 Generated with [Claude Code](https://claude.com/claude-code)