### PR TITLE
style: fix 90+ mechanical standards violations (structured comment tags)

### DIFF
--- a/crates/agora/src/semeion/mod.rs
+++ b/crates/agora/src/semeion/mod.rs
@@ -353,7 +353,7 @@ async fn poll_loop(
                         s.state = ConnectionState::Connected;
 
                         let buffered = s.drain_all();
-                        drop(s); // release lock before sending
+                        drop(s); // WHY: release lock before sending
 
                         if !buffered.is_empty() {
                             tracing::info!(count = buffered.len(), "draining buffered messages");

--- a/crates/aletheia/tests/integration_server.rs
+++ b/crates/aletheia/tests/integration_server.rs
@@ -58,7 +58,7 @@ enabled = false
     tmp
 }
 
-/// Send a raw HTTP GET request and return (status_code, body).
+/// Send a raw HTTP GET request and return (`status_code`, body).
 fn http_get(port: u16, path: &str) -> Option<(u16, String)> {
     let mut stream = TcpStream::connect(format!("127.0.0.1:{port}")).ok()?;
     stream.set_read_timeout(Some(Duration::from_secs(2))).ok()?;
@@ -119,11 +119,11 @@ fn server_starts_serves_health_and_shuts_down() {
     let mut ready = false;
     for _ in 0..30 {
         std::thread::sleep(Duration::from_millis(500));
-        if let Some((code, _)) = http_get(port, "/api/health") {
-            if code == 200 {
-                ready = true;
-                break;
-            }
+        if let Some((code, _)) = http_get(port, "/api/health")
+            && code == 200
+        {
+            ready = true;
+            break;
         }
     }
 

--- a/crates/daemon/src/maintenance/trace_rotation.rs
+++ b/crates/daemon/src/maintenance/trace_rotation.rs
@@ -90,7 +90,6 @@ impl TraceRotator {
         let total_size_bytes: u64 = entries.iter().map(|e| e.size).sum();
         let max_bytes = self.config.max_total_size_mb * 1024 * 1024;
 
-        // Determine which files to rotate: old files, or oldest when over size limit.
         let mut to_rotate = Vec::new();
         let mut cumulative_freed: u64 = 0;
 
@@ -117,7 +116,7 @@ impl TraceRotator {
                 context: format!("moving {} to archive", entry.path.display()),
             })?;
 
-            // Rename-and-reopen: create a new empty file at the original path so active
+            // WHY: Rename-and-reopen: create a new empty file at the original path so active
             // writers complete their current write to the renamed file (old inode) and
             // immediately get the new file on the next open by name.
             if let Err(e) = std::fs::File::create(&entry.path) {
@@ -285,8 +284,8 @@ mod tests {
     fn old_files_are_rotated_via_size_limit() {
         let tmp = tempfile::tempdir().expect("tempdir");
         let mut config = make_config(tmp.path());
-        config.max_age_days = 0; // treat all files as old
-        config.max_total_size_mb = 9999; // don't trigger size
+        config.max_age_days = 0; // NOTE: treat all files as old
+        config.max_total_size_mb = 9999; // NOTE: don't trigger size
         fs::create_dir_all(&config.trace_dir).unwrap();
 
         let file = config.trace_dir.join("old-trace.log");
@@ -315,8 +314,8 @@ mod tests {
     fn size_limit_triggers_rotation() {
         let tmp = tempfile::tempdir().expect("tempdir");
         let mut config = make_config(tmp.path());
-        config.max_total_size_mb = 0; // force everything to rotate
-        config.max_age_days = 9999; // don't rotate by age
+        config.max_total_size_mb = 0; // NOTE: force everything to rotate
+        config.max_age_days = 9999; // NOTE: don't rotate by age
         fs::create_dir_all(&config.trace_dir).unwrap();
 
         fs::write(config.trace_dir.join("a.log"), "data").unwrap();
@@ -357,7 +356,7 @@ mod tests {
         let tmp = tempfile::tempdir().expect("tempdir");
         let mut config = make_config(tmp.path());
         config.compress = true;
-        config.max_total_size_mb = 0; // rotate everything
+        config.max_total_size_mb = 0; // NOTE: force rotation of all files
         fs::create_dir_all(&config.trace_dir).unwrap();
 
         fs::write(config.trace_dir.join("trace.log"), "compressible data").unwrap();
@@ -428,7 +427,7 @@ mod tests {
     fn multiple_old_files_rotated() {
         let tmp = tempfile::tempdir().expect("tempdir");
         let mut config = make_config(tmp.path());
-        config.max_age_days = 0; // treat all files as old
+        config.max_age_days = 0; // NOTE: treat all files as old
         config.max_total_size_mb = 9999;
         fs::create_dir_all(&config.trace_dir).unwrap();
 

--- a/crates/daemon/src/schedule.rs
+++ b/crates/daemon/src/schedule.rs
@@ -314,7 +314,6 @@ mod tests {
 
     #[test]
     fn in_window_overnight_covers_late_or_early() {
-        // Overnight window 22-06: hour >= 22 OR hour < 6
         let now_hour = u8::try_from(jiff::Zoned::now().hour()).unwrap();
         let result = Schedule::in_window(Some((22, 6)));
         let expected = !(6..22).contains(&now_hour);
@@ -323,7 +322,6 @@ mod tests {
 
     #[test]
     fn in_window_daytime_range() {
-        // Daytime window 9-17: hour >= 9 AND hour < 17
         let now_hour = u8::try_from(jiff::Zoned::now().hour()).unwrap();
         let result = Schedule::in_window(Some((9, 17)));
         let expected = (9..17).contains(&now_hour);
@@ -337,7 +335,6 @@ mod tests {
             .next_run()
             .expect("no error")
             .expect("should have next");
-        // Should be very close to now (within a few seconds).
         let diff = next
             .since(jiff::Timestamp::now())
             .expect("since should work");
@@ -363,7 +360,7 @@ mod tests {
 
     #[test]
     fn in_window_same_start_end() {
-        // (10, 10): start <= end path, hour >= 10 && hour < 10 is always false.
+        // NOTE: (10, 10): start <= end path, hour >= 10 && hour < 10 is always false.
         assert!(
             !Schedule::in_window(Some((10, 10))),
             "same start and end should always be false"
@@ -421,7 +418,7 @@ mod tests {
 
     #[test]
     fn missed_since_stale_returns_false() {
-        // Last run more than 24h ago: too stale to catch up.
+        // NOTE: Last run more than 24h ago: too stale to catch up.
         let schedule = Schedule::Cron("0 0 * * * *".to_owned());
         let last_run = jiff::Timestamp::now()
             .checked_sub(jiff::SignedDuration::from_hours(25))
@@ -431,7 +428,7 @@ mod tests {
 
     #[test]
     fn missed_since_recent_cron_returns_true() {
-        // Hourly cron, last run 2 hours ago: should have missed at least one window.
+        // NOTE: Hourly cron, last run 2 hours ago: should have missed at least one window.
         let schedule = Schedule::Cron("0 0 * * * *".to_owned());
         let last_run = jiff::Timestamp::now()
             .checked_sub(jiff::SignedDuration::from_hours(2))

--- a/crates/hermeneus/src/provider.rs
+++ b/crates/hermeneus/src/provider.rs
@@ -94,7 +94,7 @@ pub struct ProviderConfig {
 
 impl Default for ProviderConfig {
     fn default() -> Self {
-        // Built-in pricing for all first-party Anthropic models (USD per million tokens).
+        // NOTE: Built-in pricing for all first-party Anthropic models (USD per million tokens).
         // Operator configs are merged on top, so these act as sensible fallbacks.
         // Prices last verified against https://www.anthropic.com/pricing (2025-10-01).
         let pricing = HashMap::from([
@@ -304,7 +304,7 @@ mod tests {
             config.default_model.as_deref(),
             Some("claude-opus-4-20250514")
         );
-        // Default pricing must cover the models used by background tasks.
+        // WHY: Default pricing must cover the models used by background tasks.
         assert!(
             config.pricing.contains_key("claude-haiku-4-5-20251001"),
             "missing default pricing for claude-haiku-4-5-20251001"
@@ -313,7 +313,6 @@ mod tests {
             config.pricing.contains_key("claude-sonnet-4-20250514"),
             "missing default pricing for claude-sonnet-4-20250514"
         );
-        // Spot-check values for haiku.
         let haiku = &config.pricing["claude-haiku-4-5-20251001"];
         assert!(
             (haiku.input_cost_per_mtok - 0.8).abs() < f64::EPSILON,
@@ -386,7 +385,6 @@ mod tests {
     fn registry_record_unknown_is_noop() {
         let mut registry = ProviderRegistry::new();
         registry.register(Box::new(MockProvider::new("mock response")));
-        // Should not panic
         registry.record_success("nonexistent");
         let err: crate::error::Error = crate::error::ApiRequestSnafu { message: "timeout" }.build();
         registry.record_error("nonexistent", &err);

--- a/crates/nous/src/distillation.rs
+++ b/crates/nous/src/distillation.rs
@@ -411,7 +411,7 @@ mod tests {
             max_history_share: 0.7,
             ..DistillTriggerConfig::default()
         };
-        // context_window=140_000 * 0.7 = 98_000, actual=100_000 >= 98_000
+        // NOTE: context_window=140_000 * 0.7 = 98_000, actual=100_000 >= 98_000
         let result = should_trigger_distillation(&session, 140_000, &config);
         assert!(result.is_some());
         assert!(result.unwrap().contains("legacy threshold"));
@@ -432,7 +432,6 @@ mod tests {
             .create_session("ses-1", "agent-1", "main", None, None)
             .expect("create session");
 
-        // Append 5 messages so we have a non-trivial history slice.
         for i in 0..5_i64 {
             store
                 .append_message(
@@ -449,7 +448,7 @@ mod tests {
         let history = store.get_history("ses-1", None).expect("history");
         assert_eq!(history.len(), 5);
 
-        // Distill all 5 messages: avoids the seq-shift conflict that occurs when
+        // WHY: Distill all 5 messages: avoids the seq-shift conflict that occurs when
         // undistilled messages have adjacent seq numbers after partial distillation.
         let result = DistillResult {
             summary: "Summary of previous turns.".to_owned(),
@@ -469,14 +468,12 @@ mod tests {
 
         apply_distillation(&store, "ses-1", &result, &history).expect("apply distillation");
 
-        // The distillation summary should now appear in history.
         let history_after = store.get_history("ses-1", None).expect("history after");
         let has_summary = history_after
             .iter()
             .any(|m| m.content.contains("[Distillation #1]"));
         assert!(has_summary, "distillation summary message must be present");
 
-        // The session's distillation metadata should be updated.
         let session = store
             .find_session_by_id("ses-1")
             .expect("find session")

--- a/crates/nous/src/finalize.rs
+++ b/crates/nous/src/finalize.rs
@@ -277,7 +277,7 @@ mod tests {
         finalize(&store, &session, "Read the file", &result, &config).expect("finalize");
 
         let history = store.get_history("ses-1", None).expect("history");
-        // user + tool_call(assistant) + tool_result + assistant = 4
+        // NOTE: user + tool_call(assistant) + tool_result + assistant = 4
         assert_eq!(history.len(), 4);
         assert_eq!(history[0].role, Role::User);
         assert_eq!(history[1].role, Role::Assistant);
@@ -322,7 +322,7 @@ mod tests {
     #[test]
     fn finalize_creates_session_if_missing() {
         let store = SessionStore::open_in_memory().expect("in-memory store");
-        // Do NOT call store.create_session: the actor wouldn't have done so.
+        // WHY: Do NOT call store.create_session: the actor wouldn't have done so.
         let config_nous = NousConfig {
             id: "test-nous".to_owned(),
             model: "test-model".to_owned(),
@@ -332,7 +332,7 @@ mod tests {
         let result = simple_result();
         let config = FinalizeConfig::default();
 
-        // This would previously fail with FOREIGN KEY constraint error
+        // NOTE: This would previously fail with FOREIGN KEY constraint error
         finalize(&store, &session, "Hi from orphan", &result, &config).expect("finalize");
 
         let history = store.get_history("ses-orphan", None).expect("history");
@@ -352,7 +352,6 @@ mod tests {
 
         let fr = finalize(&store, &session, "Hi", &result, &config).expect("finalize");
         assert!(!fr.usage_recorded);
-        // Messages should still be persisted
         assert_eq!(fr.messages_persisted, 2);
     }
 
@@ -362,17 +361,14 @@ mod tests {
         let result = simple_result();
         let config = FinalizeConfig::default();
 
-        // First call succeeds
         let fr = finalize(&store, &session, "Hi", &result, &config).expect("finalize");
         assert_eq!(fr.messages_persisted, 2);
         assert!(fr.usage_recorded);
 
-        // Second call with same session/turn is skipped
         let fr2 = finalize(&store, &session, "Hi again", &result, &config).expect("finalize");
         assert_eq!(fr2.messages_persisted, 0);
         assert!(!fr2.usage_recorded);
 
-        // Only the first set of messages should exist
         let history = store.get_history("ses-1", None).expect("history");
         assert_eq!(history.len(), 2);
     }
@@ -381,20 +377,19 @@ mod tests {
     fn finalize_returns_correct_counts() {
         let (store, session) = test_store_and_session();
 
-        // No tool calls: user + assistant = 2
+        // NOTE: No tool calls: user + assistant = 2
         let result = simple_result();
         let config = FinalizeConfig::default();
         let fr = finalize(&store, &session, "Hi", &result, &config).expect("finalize");
         assert_eq!(fr.messages_persisted, 2);
 
-        // New session for tool calls test
         store
             .create_session("ses-2", "test-nous", "main-2", None, Some("test-model"))
             .expect("create session");
         let mut session2 = session.clone();
         session2.id = "ses-2".to_owned();
 
-        // One tool call: user + tool_call + tool_result + assistant = 4
+        // NOTE: One tool call: user + tool_call + tool_result + assistant = 4
         let result = result_with_tools();
         let fr = finalize(&store, &session2, "Read it", &result, &config).expect("finalize");
         assert_eq!(fr.messages_persisted, 4);
@@ -414,12 +409,11 @@ mod tests {
         let store = SessionStore::open_in_memory().expect("in-memory store");
         let db_session_id = "db-ses-from-pylon";
 
-        // Simulate pylon creating the session in the store
         store
             .create_session(db_session_id, "test-nous", "main", None, Some("test-model"))
             .expect("create session");
 
-        // Actor's SessionState must use the SAME ID as the database.
+        // WHY: Actor's SessionState must use the SAME ID as the database.
         // Before the fix, the actor would generate a different ULID here.
         let config = NousConfig {
             id: "test-nous".to_owned(),
@@ -431,13 +425,12 @@ mod tests {
         let result = simple_result();
         let finalize_config = FinalizeConfig::default();
 
-        // This must succeed: no FK violation because IDs match.
+        // NOTE: This must succeed: no FK violation because IDs match.
         let fr = finalize(&store, &session, "Hello", &result, &finalize_config)
             .expect("finalize should not fail with matching session IDs");
         assert_eq!(fr.messages_persisted, 2);
         assert!(fr.usage_recorded);
 
-        // Verify messages are under the correct session ID.
         let history = store.get_history(db_session_id, None).expect("history");
         assert_eq!(history.len(), 2);
         assert_eq!(history[0].role, Role::User);
@@ -454,12 +447,11 @@ mod tests {
     fn divergent_session_id_causes_fk_violation() {
         let store = SessionStore::open_in_memory().expect("in-memory store");
 
-        // Pylon creates session with one ID
         store
             .create_session("pylon-id", "test-nous", "main", None, Some("test-model"))
             .expect("create session");
 
-        // Actor would have generated a DIFFERENT ID (before the fix)
+        // NOTE: Actor would have generated a DIFFERENT ID (before the fix)
         let config = NousConfig {
             id: "test-nous".to_owned(),
             model: "test-model".to_owned(),
@@ -471,7 +463,7 @@ mod tests {
         let result = simple_result();
         let finalize_config = FinalizeConfig::default();
 
-        // find_or_create_session finds "pylon-id" by (nous_id, session_key).
+        // WHY: find_or_create_session finds "pylon-id" by (nous_id, session_key).
         // But append_message uses "actor-generated-id" which has no DB row.
         // finalize internally calls find_or_create_session which ensures a
         // row exists matching the session_key, then tries append_message with
@@ -491,7 +483,7 @@ mod tests {
             &finalize_config,
         );
 
-        // This should fail with a database error due to FK constraint
+        // NOTE: This should fail with a database error due to FK constraint
         assert!(
             result.is_err(),
             "divergent session ID should cause FK violation"

--- a/crates/pylon/src/handlers/health.rs
+++ b/crates/pylon/src/handlers/health.rs
@@ -25,7 +25,6 @@ pub async fn check(State(state): State<Arc<AppState>>) -> impl IntoResponse {
 
     let mut checks = Vec::new();
 
-    // Check session store connectivity
     let store_ok = state.session_store.lock().await.ping().is_ok();
     checks.push(HealthCheck {
         name: "session_store",
@@ -37,7 +36,6 @@ pub async fn check(State(state): State<Arc<AppState>>) -> impl IntoResponse {
         },
     });
 
-    // Check provider registry has at least one provider
     let has_providers = !state.provider_registry.providers().is_empty();
     checks.push(HealthCheck {
         name: "providers",
@@ -49,7 +47,6 @@ pub async fn check(State(state): State<Arc<AppState>>) -> impl IntoResponse {
         },
     });
 
-    // Check nous actor health
     let actor_health = state.nous_manager.check_health().await;
     let any_dead = actor_health.values().any(|h| !h.alive);
     checks.push(HealthCheck {
@@ -156,7 +153,7 @@ mod tests {
         let json = serde_json::to_value(&check).unwrap();
         assert_eq!(json["name"], "session_store");
         assert_eq!(json["status"], "pass");
-        // message is None: serializes as null (no skip annotation)
+        // NOTE: message is None: serializes as null (no skip annotation).
         assert!(json["message"].is_null());
     }
 

--- a/crates/pylon/src/handlers/knowledge.rs
+++ b/crates/pylon/src/handlers/knowledge.rs
@@ -510,7 +510,6 @@ pub async fn search(
     State(state): State<Arc<AppState>>,
     Query(mut query): Query<SearchQuery>,
 ) -> Result<Json<SearchResponse>, ApiError> {
-    // Enforce pagination bound.
     query.limit = query.limit.min(MAX_SEARCH_LIMIT);
 
     // WHY: Pass the caller-supplied nous_id so get_stored_facts can query the store.
@@ -536,7 +535,7 @@ pub async fn search(
         .filter(|f| !f.is_forgotten)
         .filter_map(|f| {
             let content_lower = f.content.to_lowercase();
-            // Simple BM25-like scoring: term frequency
+            // NOTE: Simple BM25-like scoring: term frequency weighted by confidence.
             let mut score = 0.0_f64;
             for term in &query_terms {
                 if content_lower.contains(term) {
@@ -780,17 +779,15 @@ mod tests {
         let s = "a".repeat(100);
         let result = truncate_content(&s, 80);
         assert!(result.ends_with("..."));
-        // Content before ellipsis is 80 chars, total is 83
         assert_eq!(result.len(), 83);
     }
 
     #[test]
     fn truncate_content_handles_utf8_boundary() {
-        // "é" is 2 bytes; with max=1 we must not split mid-char
+        // NOTE: "é" is 2 bytes; with max=1 we must not split mid-char.
         let s = "éàü";
         let result = truncate_content(s, 1);
         assert!(result.ends_with("..."));
-        // Must be valid UTF-8 (no panic)
         assert!(std::str::from_utf8(result.as_bytes()).is_ok());
     }
 
@@ -850,7 +847,7 @@ mod tests {
 
     #[test]
     fn facts_query_default_values() {
-        // FactsQuery has individual serde defaults; test them via JSON
+        // NOTE: FactsQuery has individual serde defaults; test them via JSON.
         let q: FactsQuery = serde_json::from_str("{}").unwrap();
         assert_eq!(q.sort, "confidence");
         assert_eq!(q.order, "desc");
@@ -860,7 +857,7 @@ mod tests {
 
     #[test]
     fn limit_is_capped_at_max() {
-        // list_facts clamps query.limit to MAX_LIMIT (1000) before use.
+        // NOTE: list_facts clamps query.limit to MAX_LIMIT (1000) before use.
         const { assert!(MAX_LIMIT <= 1000) };
         assert_eq!(MAX_LIMIT, 1000);
     }
@@ -876,7 +873,7 @@ mod tests {
             score: 0.64,
         };
         let json = serde_json::to_value(&result).unwrap();
-        // fact_type → factType, not fact_type
+        // NOTE: serde(rename_all = "camelCase") maps fact_type to factType.
         assert!(json.get("factType").is_some());
         assert_eq!(json["factType"], "knowledge");
         assert_eq!(json["confidence"], 0.8);
@@ -937,7 +934,7 @@ mod tests {
     #[test]
     fn sort_facts_with_uppercase_order() {
         let mut facts = vec![make_fact("a", "low", 0.3), make_fact("b", "high", 0.9)];
-        // After validation, order is normalized to lowercase before reaching sort_facts
+        // NOTE: After validation, order is normalized to lowercase before reaching sort_facts.
         sort_facts(&mut facts, "confidence", "desc");
         assert_eq!(facts[0].id.as_str(), "b");
         assert_eq!(facts[1].id.as_str(), "a");

--- a/crates/pylon/src/handlers/metrics.rs
+++ b/crates/pylon/src/handlers/metrics.rs
@@ -67,15 +67,15 @@ mod tests {
         let families = prometheus::gather();
         let mut buf = Vec::new();
         encoder.encode(&families, &mut buf).unwrap();
-        // Must be valid UTF-8 (Prometheus text format is UTF-8)
+        // NOTE: Prometheus text format mandates UTF-8.
         assert!(std::str::from_utf8(&buf).is_ok());
     }
 
     #[test]
     fn text_encoder_content_type_is_text_plain() {
         let encoder = TextEncoder::new();
-        // prometheus TextEncoder declares "text/plain; version=0.0.4";
-        // we append charset=utf-8 to our served header
+        // NOTE: prometheus TextEncoder declares "text/plain; version=0.0.4";
+        // we append charset=utf-8 to our served header.
         assert!(encoder.format_type().starts_with("text/plain"));
         assert!(encoder.format_type().contains("version=0.0.4"));
     }

--- a/crates/pylon/src/handlers/sessions/mod.rs
+++ b/crates/pylon/src/handlers/sessions/mod.rs
@@ -357,7 +357,7 @@ pub async fn history(
 ) -> Result<Json<HistoryResponse>, ApiError> {
     let _ = find_session(&state, &id).await?;
 
-    // Cap limit at MAX_HISTORY_LIMIT and apply a sensible default so a single
+    // WHY: Cap limit at MAX_HISTORY_LIMIT and apply a sensible default so a single
     // request cannot fetch an unbounded number of messages.
     let limit = params
         .limit

--- a/crates/pylon/src/handlers/sessions/streaming.rs
+++ b/crates/pylon/src/handlers/sessions/streaming.rs
@@ -68,7 +68,7 @@ pub async fn send_message(
             LookupResult::Miss => { /* proceed normally */ }
             LookupResult::Hit { body, .. } => {
                 tracing::info!(idempotency_key = %key, "idempotency cache hit — returning cached completion");
-                // Decode the cached turn summary stored by the original request.
+                // NOTE: Decode the cached turn summary stored by the original request.
                 let cached: serde_json::Value = serde_json::from_str(&body).unwrap_or_default();
                 let stop_reason = cached["stop_reason"]
                     .as_str()
@@ -176,7 +176,7 @@ pub async fn send_message(
                 Ok(result) => {
                     emit_turn_result_events(&tx, &result).await;
 
-                    // Store the turn summary so cache-hit replays return real data.
+                    // NOTE: Store the turn summary so cache-hit replays return real data.
                     if let Some(ref key) = idem_key {
                         let body = serde_json::json!({
                             "stop_reason": result.stop_reason,
@@ -188,11 +188,11 @@ pub async fn send_message(
                     }
                 }
                 Err(err) => {
-                    // Log full error internally; the active span carries request_id and
-                    // session/nous context. Never forward internal details to the client. (#844)
+                    // WHY: Log full error internally; the active span carries request_id and
+                    // session/nous context. Never forward internal details to the client (#844).
                     tracing::error!(error = %err, "turn failed");
 
-                    // Remove idempotency entry on error so the client can retry.
+                    // WHY: Remove idempotency entry on error so the client can retry.
                     if let Some(ref key) = idem_key {
                         idem_cache.remove(key);
                     }
@@ -204,7 +204,7 @@ pub async fn send_message(
                             message: err_message.to_owned(),
                         })
                         .await;
-                    // Always send a completion marker so the client knows the
+                    // WHY: Always send a completion marker so the client knows the
                     // stream is finished, even on error paths.
                     let _ = tx
                         .send(SseEvent::MessageComplete {
@@ -317,8 +317,7 @@ pub async fn stream_turn(
         request_id = %request_id,
     );
 
-    // Bridge nous stream events to webchat events in real-time.
-    // Returns a JoinHandle so the turn task can wait for all deltas to drain
+    // WHY: Returns a JoinHandle so the turn task can wait for all deltas to drain
     // before emitting turn_complete (prevents the race where turn_complete
     // arrives at the TUI before the final text_delta events).
     let bridge_tx = webchat_tx.clone();
@@ -364,7 +363,6 @@ pub async fn stream_turn(
         .instrument(tracing::info_span!("sse_bridge")),
     );
 
-    // Run the turn, wait for bridge to drain, then emit completion event.
     tokio::spawn(
         async move {
             match handle
@@ -378,7 +376,7 @@ pub async fn stream_turn(
                 .await
             {
                 Ok(result) => {
-                    // Wait for the bridge to finish forwarding all buffered deltas
+                    // WHY: Wait for the bridge to finish forwarding all buffered deltas
                     // before sending turn_complete. This prevents the TUI from
                     // seeing turn_complete before the final text_delta events.
                     let _ = bridge_handle.await;
@@ -400,7 +398,7 @@ pub async fn stream_turn(
                         .await;
                 }
                 Err(err) => {
-                    // Log full error internally; span carries session/nous context. (#844)
+                    // WHY: Log full error internally; span carries session/nous context (#844).
                     tracing::error!(error = %err, "streaming turn failed");
                     let _ = bridge_handle.await;
                     let (_, err_message) = turn_error_info(&err);
@@ -409,7 +407,7 @@ pub async fn stream_turn(
                             message: err_message.to_owned(),
                         })
                         .await;
-                    // Always send a completion marker so the TUI knows the stream
+                    // WHY: Always send a completion marker so the TUI knows the stream
                     // is finished, even on error paths.
                     let _ = webchat_tx
                         .send(WebchatEvent::TurnComplete {

--- a/crates/pylon/src/router.rs
+++ b/crates/pylon/src/router.rs
@@ -59,7 +59,6 @@ pub fn build_router(state: Arc<AppState>, security: &SecurityConfig) -> Router {
             "/config/{section}",
             get(config::get_section).put(config::update_section),
         )
-        // Knowledge graph
         .route("/knowledge/facts", get(knowledge::list_facts))
         .route("/knowledge/facts/{id}", get(knowledge::get_fact))
         .route("/knowledge/facts/{id}/forget", post(knowledge::forget_fact))
@@ -81,14 +80,12 @@ pub fn build_router(state: Arc<AppState>, security: &SecurityConfig) -> Router {
 
     let mut router = Router::new()
         .nest("/api/v1", v1)
-        // Infrastructure
         .route("/api/health", get(health::check))
         .route("/api/docs/openapi.json", get(openapi::openapi_json))
         .route("/metrics", get(metrics::expose));
 
     router = router.fallback(fallback_handler);
 
-    // Rate limiting: per-IP sliding window, applied before business logic
     if security.rate_limit_enabled {
         let limiter = Arc::new(
             RateLimiter::new(security.rate_limit_requests_per_minute)
@@ -99,7 +96,6 @@ pub fn build_router(state: Arc<AppState>, security: &SecurityConfig) -> Router {
             .layer(axum::Extension(limiter));
     }
 
-    // CSRF protection: inject state and apply middleware
     if security.csrf_enabled {
         let csrf_state = CsrfState {
             header_name: security.csrf_header_name.clone(),
@@ -110,20 +106,16 @@ pub fn build_router(state: Arc<AppState>, security: &SecurityConfig) -> Router {
             .layer(axum::Extension(csrf_state));
     }
 
-    // Body size limit
     router = router.layer(DefaultBodyLimit::max(security.body_limit_bytes));
 
-    // Error response enrichment: inside compression (body uncompressed), outside
+    // WARNING: Must be inside compression (body uncompressed) but outside
     // rate_limit and CSRF so their error responses get request_id injected.
     router = router.layer(axum::middleware::from_fn(enrich_error_response));
 
-    // HTTP metrics recording
     router = router.layer(axum::middleware::from_fn(record_http_metrics));
 
-    // Compression
     router = router.layer(CompressionLayer::new());
 
-    // Request tracing: reads RequestId from extensions
     router = router.layer(
         TraceLayer::new_for_http()
             .make_span_with(|request: &axum::http::Request<_>| {
@@ -152,13 +144,12 @@ pub fn build_router(state: Arc<AppState>, security: &SecurityConfig) -> Router {
             ),
     );
 
-    // Request ID injection (before trace layer so span includes the ID)
+    // WARNING: Must be before trace layer so the span includes the ID.
     router = router.layer(axum::middleware::from_fn(inject_request_id));
 
-    // CORS
     router = router.layer(build_cors_layer(security));
 
-    // Security response headers (outermost: applied to every response)
+    // WARNING: Outermost layer: must wrap all other layers so headers apply to every response.
     router = apply_security_headers(router, security);
 
     router.with_state(state)
@@ -171,7 +162,6 @@ pub fn build_router(state: Arc<AppState>, security: &SecurityConfig) -> Router {
 async fn fallback_handler(uri: axum::http::Uri) -> Response {
     let path = uri.path();
 
-    // `/api/nous/*`: hint at v1
     if path.starts_with("/api/nous") {
         let suggestion = path.replacen("/api/", "/api/v1/", 1);
         return (

--- a/crates/pylon/src/security.rs
+++ b/crates/pylon/src/security.rs
@@ -53,7 +53,7 @@ fn generate_csrf_token() -> String {
     let bytes: [u8; 16] = rand::random();
     let mut s = String::with_capacity(32);
     for b in &bytes {
-        // String's fmt::Write implementation is infallible.
+        // NOTE: String's fmt::Write implementation is infallible.
         let _ = write!(s, "{b:02x}");
     }
     s
@@ -120,7 +120,6 @@ mod tests {
     #[test]
     fn from_gateway_replaces_insecure_default_token() {
         let gateway = GatewayConfig::default();
-        // Default config ships with the insecure "aletheia" value.
         assert_eq!(gateway.csrf.header_value, INSECURE_CSRF_DEFAULT);
         let sec = SecurityConfig::from_gateway(&gateway);
         assert_ne!(
@@ -157,7 +156,6 @@ mod tests {
 
     #[test]
     fn generate_csrf_token_is_not_static() {
-        // Two consecutive calls must not return the same token.
         let a = generate_csrf_token();
         let b = generate_csrf_token();
         assert_ne!(

--- a/crates/symbolon/src/api_key.rs
+++ b/crates/symbolon/src/api_key.rs
@@ -53,7 +53,7 @@ pub(crate) fn generate(
         key_hash,
         role,
         nous_id: nous_id.map(str::to_owned),
-        created_at: String::new(), // DB default handles this
+        created_at: String::new(), // NOTE: DB default handles this
         expires_at,
         last_used_at: None,
         revoked_at: None,
@@ -61,7 +61,6 @@ pub(crate) fn generate(
 
     store.store_api_key(&record)?;
 
-    // Re-read from DB to get populated timestamps
     let stored = store
         .find_api_key_by_hash(&record.key_hash)?
         .unwrap_or_else(|| {
@@ -84,12 +83,10 @@ pub(crate) fn validate(store: &AuthStore, raw_key: &str) -> Result<Claims> {
         .find_api_key_by_hash(&key_hash)?
         .ok_or_else(|| error::InvalidCredentialsSnafu.build())?;
 
-    // Check revocation
     if record.revoked_at.is_some() {
         return Err(error::InvalidCredentialsSnafu.build());
     }
 
-    // Check expiry
     if let Some(ref expires_at) = record.expires_at {
         let now = now_iso();
         if *expires_at < now {
@@ -97,7 +94,6 @@ pub(crate) fn validate(store: &AuthStore, raw_key: &str) -> Result<Claims> {
         }
     }
 
-    // Update last_used_at
     store.touch_api_key(&record.id)?;
 
     Ok(Claims {
@@ -146,19 +142,17 @@ fn now_iso() -> String {
 }
 
 fn time_from_unix(secs: u64) -> String {
-    // Simple ISO 8601 formatting without external dependency
+    // WHY: simple ISO 8601 formatting without external dependency
     let days = secs / 86400;
     let time_secs = secs % 86400;
     let hours = time_secs / 3600;
     let minutes = (time_secs % 3600) / 60;
     let seconds = time_secs % 60;
 
-    // Convert days since epoch to Y-M-D (simplified)
     let (year, month, day) = days_to_date(days);
     format!("{year:04}-{month:02}-{day:02}T{hours:02}:{minutes:02}:{seconds:02}.000Z")
 }
 
-// We need hex encoding for the secret bytes
 mod hex {
     const HEX_CHARS: &[u8; 16] = b"0123456789abcdef";
 
@@ -252,6 +246,6 @@ mod tests {
         let store = test_store();
         let (key, _) = generate(&store, "test", Role::Operator, None, None).unwrap();
         let parts: Vec<&str> = key.splitn(3, '_').collect();
-        assert_eq!(parts[2].len(), 64); // 32 bytes * 2 hex chars
+        assert_eq!(parts[2].len(), 64); // NOTE: 32 bytes * 2 hex chars
     }
 }

--- a/crates/symbolon/src/credential.rs
+++ b/crates/symbolon/src/credential.rs
@@ -87,12 +87,10 @@ impl CredentialFile {
     pub fn load(path: &Path) -> Option<Self> {
         let contents = std::fs::read_to_string(path).ok()?;
 
-        // Try flat format first (native "token" field or "accessToken" alias).
         if let Ok(cred) = serde_json::from_str::<Self>(&contents) {
             return Some(cred);
         }
 
-        // Try claudeAiOauth wrapper format written by current Claude Code releases.
         let outer: serde_json::Value = serde_json::from_str(&contents).ok()?;
         serde_json::from_value(outer.get("claudeAiOauth")?.clone()).ok()
     }
@@ -168,7 +166,7 @@ impl std::fmt::Debug for OAuthResponse {
 }
 
 fn default_expires_in() -> u64 {
-    28800 // 8 hours
+    28800 // NOTE: 8 hours
 }
 
 /// OAuth token prefix used by Claude Code for OAuth access tokens.
@@ -188,13 +186,12 @@ fn base64url_decode(s: &str) -> Option<Vec<u8>> {
             b'0'..=b'9' => Some(b - b'0' + 52),
             b'-' | b'+' => Some(62),
             b'_' | b'/' => Some(63),
-            b'=' => Some(0), // padding: treated as zero bits
+            b'=' => Some(0), // NOTE: padding treated as zero bits
             _ => None,
         }
     }
 
     let bytes = s.as_bytes();
-    // Strip trailing padding before computing output length.
     let end = bytes.iter().rposition(|&b| b != b'=').map_or(0, |i| i + 1);
     let bytes = &bytes[..end];
 
@@ -233,8 +230,8 @@ fn base64url_decode(s: &str) -> Option<Vec<u8>> {
 /// Returns `None` when the token has no recognisable payload segment or no `exp`
 /// field; the caller must treat `None` as "expiry unknown" (do not fall through).
 fn decode_jwt_exp_secs(token: &str) -> Option<u64> {
-    // Dot-segmented format: ignore the first segment (vendor prefix or JWT header)
-    // and decode the second segment as a JSON object containing the exp claim.
+    // NOTE: dot-segmented format — first segment is vendor prefix or JWT header,
+    // second segment is the JSON payload containing the exp claim.
     let mut segs = token.splitn(4, '.');
     let _first = segs.next()?;
     let payload_b64 = segs.next()?;
@@ -242,7 +239,7 @@ fn decode_jwt_exp_secs(token: &str) -> Option<u64> {
     let payload = base64url_decode(payload_b64)?;
     let value: serde_json::Value = serde_json::from_slice(&payload).ok()?;
 
-    // exp is stored as a u64 integer (seconds since epoch) per the JWT spec (RFC 7519).
+    // NOTE: exp is seconds since epoch per JWT spec (RFC 7519).
     value.get("exp").and_then(serde_json::Value::as_u64)
 }
 
@@ -282,10 +279,6 @@ impl CredentialProvider for EnvCredentialProvider {
                 return None;
             }
 
-            // When the env var holds an OAuth access token, check whether it has
-            // an embedded expiry claim. If the token appears expired, fall through
-            // to the next provider: typically a file-based provider with a live
-            // refresh token: rather than blocking the chain with a stale credential.
             // WHY: static env var tokens cannot be refreshed; a refreshable file
             // provider downstream must get a chance to supply a valid credential.
             if v.starts_with(OAUTH_TOKEN_PREFIX)

--- a/crates/theatron/tui/src/hyperlink.rs
+++ b/crates/theatron/tui/src/hyperlink.rs
@@ -176,7 +176,7 @@ fn detect_file_paths(text: &str) -> Vec<(usize, usize, &str, String)> {
         reason = "regex is a compile-time string literal and is always valid"
     )]
     static PATH_RE: LazyLock<Regex> = LazyLock::new(|| {
-        // crates/foo/src/bar.rs:142  or  src/foo.rs  or  ./src/foo.ts
+        // NOTE: crates/foo/src/bar.rs:142  or  src/foo.rs  or  ./src/foo.ts
         Regex::new(r"(?:\.{0,2}/)?(?:[a-zA-Z0-9_\-]+/)+[a-zA-Z0-9_\-]+\.[a-zA-Z]{1,6}(?::[0-9]+)?")
             .expect("file path regex is valid")
     });
@@ -189,7 +189,6 @@ fn detect_file_paths(text: &str) -> Vec<(usize, usize, &str, String)> {
     let mut out = Vec::new();
     for m in PATH_RE.find_iter(text) {
         let s = m.as_str();
-        // Only match paths with a recognised source extension
         let base = s.split(':').next().unwrap_or(s);
         let ext = base.rsplit('.').next().unwrap_or("");
         if !SOURCE_EXTS.contains(&ext) {
@@ -205,8 +204,6 @@ fn detect_file_paths(text: &str) -> Vec<(usize, usize, &str, String)> {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    // ── detect_urls ──
 
     #[test]
     fn detects_https_url() {
@@ -297,13 +294,10 @@ mod tests {
 
     #[test]
     fn strips_multiple_trailing_chars() {
-        // comma after dot
         let urls = detect_urls("See https://foo.com/bar.,");
         assert_eq!(urls.len(), 1);
         assert_eq!(urls[0].2, "https://foo.com/bar");
     }
-
-    // ── OSC 8 sequence format ──
 
     #[test]
     fn osc8_open_format() {
@@ -342,11 +336,9 @@ mod tests {
         assert_eq!(full, "\x1b]8;;https://example.com\x07click me\x1b]8;;\x07");
     }
 
-    // ── supports_hyperlinks ──
-
     #[test]
     fn supports_hyperlinks_returns_bool() {
-        // Smoke test: function must not panic regardless of environment
+        // NOTE: function must not panic regardless of environment
         let _ = supports_hyperlinks();
     }
 
@@ -356,7 +348,7 @@ mod tests {
         reason = "test-only env mutation in single-threaded test context"
     )]
     fn probe_detects_ghostty_resources_dir() {
-        // Use the raw probe (not cached) to test detection logic.
+        // WHY: Use the raw probe (not cached) to test detection logic.
         // SAFETY: test-only env mutation; env vars are not read concurrently here.
         unsafe { std::env::set_var("GHOSTTY_RESOURCES_DIR", "/usr/share/ghostty") };
         let result = probe_hyperlink_support();
@@ -403,8 +395,6 @@ mod tests {
         assert!(result, "should detect Windows Terminal via WT_SESSION");
     }
 
-    // ── file path detection ──
-
     #[test]
     fn detects_rust_file_path() {
         let paths = detect_file_paths("See crates/nous/src/actor.rs:142 for details");
@@ -415,7 +405,7 @@ mod tests {
 
     #[test]
     fn ignores_non_source_extension() {
-        // .bin files are not in SOURCE_EXTS
+        // NOTE: .bin files are not in SOURCE_EXTS
         let paths = detect_file_paths("target/debug/aletheia.bin");
         assert!(paths.is_empty());
     }

--- a/crates/theatron/tui/src/mapping.rs
+++ b/crates/theatron/tui/src/mapping.rs
@@ -105,13 +105,11 @@ impl App {
             return self.map_ops_pane_key(key);
         }
 
-        // Configurable keymap: covers global Ctrl+key shortcuts.
         if let Some(action) = self.keymap.lookup(key.modifiers, key.code) {
             return Some(action.to_msg());
         }
 
         match (key.modifiers, key.code) {
-            // Context-dependent Ctrl+W: TabClose when input is empty, DeleteWord otherwise.
             (KeyModifiers::CONTROL, KeyCode::Char('w')) if self.input.text.is_empty() => {
                 Some(Msg::TabClose)
             }
@@ -831,8 +829,6 @@ mod tests {
         assert!(matches!(msg, Some(Msg::Resize(80, 24))));
     }
 
-    // --- Selection mode tests ---
-
     #[test]
     fn selection_mode_j_moves_next() {
         let mut app = test_app_with_messages(vec![("user", "a"), ("assistant", "b")]);
@@ -872,8 +868,6 @@ mod tests {
         ));
     }
 
-    // --- Command palette mode tests ---
-
     #[test]
     fn palette_esc_closes() {
         let mut app = test_app();
@@ -900,8 +894,6 @@ mod tests {
         let msg = app.map_event(event);
         assert!(matches!(msg, Some(Msg::CommandPaletteInput('a'))));
     }
-
-    // --- Filter mode tests ---
 
     #[test]
     fn filter_editing_esc_closes() {
@@ -944,8 +936,6 @@ mod tests {
         assert!(matches!(msg, Some(Msg::FilterNextMatch)));
     }
 
-    // --- Overlay tests ---
-
     #[test]
     fn overlay_esc_closes() {
         let mut app = test_app();
@@ -964,8 +954,6 @@ mod tests {
         assert!(matches!(msg, Some(Msg::OverlayUp)));
     }
 
-    // --- SSE event mapping ---
-
     #[test]
     fn sse_connected_maps() {
         let app = test_app();
@@ -981,8 +969,6 @@ mod tests {
         let msg = app.map_event(event);
         assert!(matches!(msg, Some(Msg::Tick)));
     }
-
-    // --- Stream event mapping ---
 
     #[test]
     fn stream_text_delta_maps() {
@@ -1000,8 +986,6 @@ mod tests {
         assert!(matches!(msg, Some(Msg::StreamError(_))));
     }
 
-    // --- Scroll keys ---
-
     #[test]
     fn page_up_maps() {
         let app = test_app();
@@ -1017,8 +1001,6 @@ mod tests {
         let msg = app.map_event(event);
         assert!(matches!(msg, Some(Msg::ScrollLineUp)));
     }
-
-    // --- Settings overlay key mapping ---
 
     #[test]
     fn settings_overlay_up_down() {
@@ -1039,8 +1021,6 @@ mod tests {
         let msg = app.map_event(event);
         assert!(matches!(msg, Some(Msg::OverlayFilter('s'))));
     }
-
-    // --- v key enters selection ---
 
     #[test]
     fn v_on_empty_input_with_messages_enters_selection() {
@@ -1068,8 +1048,6 @@ mod tests {
         assert!(matches!(msg, Some(Msg::CharInput('v'))));
     }
 
-    // --- Enter in selection mode drills into detail view ---
-
     #[test]
     fn selection_mode_enter_drills_in() {
         let mut app = test_app_with_messages(vec![("user", "a")]);
@@ -1078,8 +1056,6 @@ mod tests {
         let msg = app.map_event(event);
         assert!(matches!(msg, Some(Msg::ViewDrillIn)));
     }
-
-    // --- Context actions overlay j/k navigation ---
 
     #[test]
     fn context_actions_overlay_j_moves_down() {
@@ -1115,8 +1091,6 @@ mod tests {
         assert!(matches!(msg, Some(Msg::OverlayUp)));
     }
 
-    // --- View stack navigation key tests ---
-
     #[test]
     fn esc_at_non_home_view_pops_back() {
         let mut app = test_app();
@@ -1132,7 +1106,6 @@ mod tests {
     fn esc_at_home_with_selection_deselects() {
         let mut app = test_app_with_messages(vec![("user", "a")]);
         app.selected_message = Some(0);
-        // view_stack is Home by default
         let event = Event::Terminal(key(KeyCode::Esc));
         let msg = app.map_event(event);
         assert!(matches!(msg, Some(Msg::DeselectMessage)));
@@ -1148,8 +1121,6 @@ mod tests {
         let msg = app.map_event(event);
         assert!(matches!(msg, Some(Msg::ViewPopBack)));
     }
-
-    // --- ScrollToBottom keybinding tests ---
 
     #[test]
     fn end_key_on_empty_input_scrolls_to_bottom() {
@@ -1168,8 +1139,6 @@ mod tests {
         let msg = app.map_event(event);
         assert!(matches!(msg, Some(Msg::CursorEnd)));
     }
-
-    // --- NextAgent/PrevAgent keybinding tests ---
 
     #[test]
     fn tab_on_empty_input_with_no_ops_cycles_next_agent() {


### PR DESCRIPTION
## Summary
- Fix 90+ mechanical standards violations: structured comment tags, code-restating comments
- Apply cargo fmt reformatting
- Fix collapsible if and doc comment lint in integration_server.rs

## Test plan
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes