### PR TITLE
fix(workspace): replace println! calls in library code with tracing macros

### DIFF
--- a/crates/aletheia/src/init.rs
+++ b/crates/aletheia/src/init.rs
@@ -121,8 +121,9 @@ pub(crate) fn run(args: RunArgs) -> Result<(), InitError> {
         })?;
 
         if api_key.is_none() {
-            eprintln!("Warning: no API key provided. Set --api-key or ANTHROPIC_API_KEY.");
-            eprintln!("         The server will start in degraded mode without credentials.");
+            tracing::warn!(
+                "no API key provided — set --api-key or ANTHROPIC_API_KEY; server will start in degraded mode"
+            );
         }
 
         Answers {
@@ -138,8 +139,9 @@ pub(crate) fn run(args: RunArgs) -> Result<(), InitError> {
         let root = root.unwrap_or_else(|| PathBuf::from("./instance"));
 
         if api_key.is_none() {
-            eprintln!("Warning: no API key provided. Set --api-key or ANTHROPIC_API_KEY.");
-            eprintln!("         The server will start in degraded mode without credentials.");
+            tracing::warn!(
+                "no API key provided — set --api-key or ANTHROPIC_API_KEY; server will start in degraded mode"
+            );
         }
 
         Answers {
@@ -162,9 +164,9 @@ pub(crate) fn run(args: RunArgs) -> Result<(), InitError> {
     let config_path = answers.root.join("config/aletheia.toml");
     if config_path.exists() {
         if is_non_interactive {
-            println!(
-                "Instance already exists at {}. Skipping (delete config/aletheia.toml to re-initialize).",
-                answers.root.display()
+            tracing::info!(
+                path = %answers.root.display(),
+                "instance already exists — skipping (delete config/aletheia.toml to re-initialize)"
             );
             return Ok(());
         }
@@ -181,7 +183,7 @@ pub(crate) fn run(args: RunArgs) -> Result<(), InitError> {
     scaffold(&answers)?;
 
     if is_non_interactive {
-        println!("Instance created at {}", answers.root.display());
+        tracing::info!(path = %answers.root.display(), "instance created");
     } else {
         cliclack::outro(format!(
             "Done! Start the server:\n\

--- a/crates/aletheia/src/migrate_memory.rs
+++ b/crates/aletheia/src/migrate_memory.rs
@@ -106,18 +106,18 @@ pub async fn run(
         total_deduped += deduped;
     }
 
-    println!(
-        "\nTotal: {} imported, {} deduplicated, {} flagged{}",
-        total_imported,
-        total_deduped,
-        flagged.len(),
-        if dry_run { " (DRY RUN)" } else { "" }
+    info!(
+        imported = total_imported,
+        deduplicated = total_deduped,
+        flagged = flagged.len(),
+        dry_run,
+        "migration complete"
     );
 
     if let Some(path) = review_file {
         if !flagged.is_empty() {
             write_review_file(path, &flagged)?;
-            println!("Review file written to {}", path.display());
+            info!(path = %path.display(), "review file written");
         }
     }
 
@@ -225,15 +225,16 @@ fn process_agent(
         }
     }
 
-    println!(
-        "agent: {agent_id} -- {} fetched, {} duplicates removed, {} imported, {} flagged",
-        records.len(),
-        agent_deduped,
-        unique.len(),
-        flagged
+    info!(
+        agent_id,
+        fetched = records.len(),
+        duplicates_removed = agent_deduped,
+        imported = unique.len(),
+        flagged = flagged
             .iter()
             .filter(|f| f.starts_with(&format!("[{agent_id}]")))
-            .count()
+            .count(),
+        "agent migration stats"
     );
 
     Ok((unique.len(), agent_deduped))

--- a/crates/eval/src/report.rs
+++ b/crates/eval/src/report.rs
@@ -2,6 +2,7 @@
 
 use owo_colors::OwoColorize;
 use serde::Serialize;
+use tracing::info;
 
 use crate::runner::RunReport;
 use crate::scenario::ScenarioOutcome;
@@ -12,12 +13,12 @@ pub fn print_report(report: &RunReport, base_url: &str) {
     let use_color = supports_color::on(supports_color::Stream::Stdout).is_some();
 
     if use_color {
-        println!("{} — {}", "Behavioral Eval".bold(), base_url.dimmed());
+        info!("{} — {}", "Behavioral Eval".bold(), base_url.dimmed());
     } else {
-        println!("Behavioral Eval — {base_url}");
+        info!("Behavioral Eval — {base_url}");
     }
-    println!("{}", "\u{2501}".repeat(39));
-    println!();
+    info!("{}", "\u{2501}".repeat(39));
+    info!("");
 
     let mut current_category = "";
 
@@ -25,9 +26,9 @@ pub fn print_report(report: &RunReport, base_url: &str) {
         if result.meta.category != current_category {
             current_category = result.meta.category;
             if use_color {
-                println!("  {}:", current_category.bold());
+                info!("  {}:", current_category.bold());
             } else {
-                println!("  {current_category}:");
+                info!("  {current_category}:");
             }
         }
 
@@ -35,45 +36,45 @@ pub fn print_report(report: &RunReport, base_url: &str) {
             ScenarioOutcome::Passed { duration } => {
                 let ms = duration.as_millis();
                 if use_color {
-                    println!(
+                    info!(
                         "    {}  {:<40} {}",
                         "PASS".green(),
                         result.meta.id,
                         format!("{ms}ms").dimmed()
                     );
                 } else {
-                    println!("    PASS  {:<40} {ms}ms", result.meta.id);
+                    info!("    PASS  {:<40} {ms}ms", result.meta.id);
                 }
             }
             ScenarioOutcome::Failed { duration, error } => {
                 let ms = duration.as_millis();
                 if use_color {
-                    println!(
+                    info!(
                         "    {}  {:<40} {}",
                         "FAIL".red(),
                         result.meta.id,
                         format!("{ms}ms").dimmed()
                     );
-                    println!("          {}", error.to_string().red());
+                    info!("          {}", error.to_string().red());
                 } else {
-                    println!("    FAIL  {:<40} {ms}ms", result.meta.id);
-                    println!("          {error}");
+                    info!("    FAIL  {:<40} {ms}ms", result.meta.id);
+                    info!("          {error}");
                 }
             }
             ScenarioOutcome::Skipped { reason } => {
                 if use_color {
-                    println!("    {}  {}", "SKIP".yellow(), result.meta.id,);
-                    println!("          {}", reason.dimmed());
+                    info!("    {}  {}", "SKIP".yellow(), result.meta.id,);
+                    info!("          {}", reason.dimmed());
                 } else {
-                    println!("    SKIP  {}", result.meta.id);
-                    println!("          {reason}");
+                    info!("    SKIP  {}", result.meta.id);
+                    info!("          {reason}");
                 }
             }
         }
     }
 
-    println!();
-    println!("{}", "\u{2501}".repeat(39));
+    info!("");
+    info!("{}", "\u{2501}".repeat(39));
 
     let total_secs = report.total_duration.as_secs_f64();
     let summary = format!(
@@ -83,12 +84,12 @@ pub fn print_report(report: &RunReport, base_url: &str) {
 
     if use_color {
         if report.failed > 0 {
-            println!("{}", summary.red().bold());
+            info!("{}", summary.red().bold());
         } else {
-            println!("{}", summary.green().bold());
+            info!("{}", summary.green().bold());
         }
     } else {
-        println!("{summary}");
+        info!("{summary}");
     }
 }
 
@@ -131,7 +132,7 @@ pub fn print_report_json(report: &RunReport) {
     };
 
     match serde_json::to_string_pretty(&json_report) {
-        Ok(json) => println!("{json}"),
+        Ok(json) => info!("{json}"),
         Err(e) => tracing::error!(error = %e, "failed to serialize eval report as JSON"),
     }
 }

--- a/crates/mneme/src/engine/runtime/imperative.rs
+++ b/crates/mneme/src/engine/runtime/imperative.rs
@@ -24,6 +24,8 @@ use crate::engine::runtime::db::{
 };
 use crate::engine::runtime::relation::InputRelationHandle;
 use crate::engine::runtime::transact::SessionTx;
+use tracing::debug;
+
 use crate::engine::{DataValue, DbCore as Db, NamedRows, Poison, Storage, ValidityTs};
 
 enum ControlCode {
@@ -278,7 +280,7 @@ impl<'s, S: Storage<'s>> Db<S> {
                 }
                 ImperativeStmt::TempDebug { temp, .. } => {
                     let relation = tx.get_relation(temp, false)?;
-                    println!("{}: {:?}", temp, relation.as_named_rows(tx)?);
+                    debug!(relation = %temp, rows = ?relation.as_named_rows(tx)?, "temp debug");
                     ret = NamedRows::default();
                 }
                 ImperativeStmt::SysOp { sysop, .. } => {

--- a/crates/mneme/src/engine/runtime/transact.rs
+++ b/crates/mneme/src/engine/runtime/transact.rs
@@ -17,6 +17,8 @@ use crate::engine::runtime::callback::CallbackCollector;
 use crate::engine::runtime::relation::RelationId;
 use crate::engine::storage::StoreTx;
 use crate::engine::storage::temp::TempTx;
+use tracing::error;
+
 use crate::engine::{CallbackOp, NamedRows};
 
 pub struct SessionTx<'a> {
@@ -230,7 +232,7 @@ impl<'s, S: Storage<'s>> Db<S> {
                 TransactionPayload::Commit => {
                     for (lower, upper) in cleanups {
                         if let Err(err) = tx.store_tx.del_range_from_persisted(&lower, &upper) {
-                            eprintln!("{err:?}")
+                            error!(error = ?err, "failed to clean up persisted range")
                         }
                     }
 

--- a/crates/theatron/tui/src/lib.rs
+++ b/crates/theatron/tui/src/lib.rs
@@ -84,7 +84,7 @@ async fn run_tui_inner(
 
     if logout {
         config.clear_credentials()?;
-        println!("Credentials cleared.");
+        tracing::info!("credentials cleared");
         return Ok(());
     }
 
@@ -101,7 +101,7 @@ async fn run_tui_inner(
     ratatui::restore();
 
     if let Err(ref e) = result {
-        eprintln!("Error: {e}");
+        tracing::error!(error = %e, "tui exited with error");
     }
 
     result


### PR DESCRIPTION
## Summary
- Replace println! calls in library code with appropriate tracing macros
- Mechanical CI fixes for integration test formatting

## Test plan
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes