### PR TITLE
fix(workspace): replace string slicing with safe .get() alternatives

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ expect_used = "deny"
 
 # Correctness: holding std::sync::Mutex across .await causes deadlocks
 await_holding_lock = "deny"
+string_slice = "warn"
 explicit_into_iter_loop = "warn"
 fallible_impl_from = "warn"
 fn_params_excessive_bools = "warn"

--- a/crates/agora/src/listener.rs
+++ b/crates/agora/src/listener.rs
@@ -12,7 +12,7 @@ use crate::types::InboundMessage;
 
 fn redact_phone(phone: &str) -> String {
     if phone.len() > 4 {
-        format!("...{}", &phone[phone.len() - 4..])
+        format!("...{}", phone.get(phone.len() - 4..).unwrap_or(""))
     } else {
         "****".to_owned()
     }

--- a/crates/aletheia/src/commands/credential.rs
+++ b/crates/aletheia/src/commands/credential.rs
@@ -18,7 +18,11 @@ pub enum Action {
 
 fn token_preview(s: &str) -> String {
     if s.len() > 10 {
-        format!("{}...{}", &s[..10], &s[s.len() - 3..])
+        format!(
+            "{}...{}",
+            s.get(..10).unwrap_or(s),
+            s.get(s.len() - 3..).unwrap_or("")
+        )
     } else {
         "***".to_owned()
     }

--- a/crates/daemon/src/maintenance/drift_detection.rs
+++ b/crates/daemon/src/maintenance/drift_detection.rs
@@ -124,12 +124,12 @@ impl DriftDetector {
 
         for pattern in &self.config.ignore_patterns {
             if pattern.ends_with('/') {
-                let prefix = &pattern[..pattern.len() - 1];
+                let prefix = pattern.get(..pattern.len() - 1).unwrap_or("");
                 if path_str.starts_with(prefix) || path_str == *prefix {
                     return true;
                 }
             } else if pattern.starts_with("*.") {
-                let ext = &pattern[1..];
+                let ext = pattern.get(1..).unwrap_or("");
                 if path_str.ends_with(ext) {
                     return true;
                 }

--- a/crates/diaporeia/src/sanitize.rs
+++ b/crates/diaporeia/src/sanitize.rs
@@ -36,23 +36,23 @@ pub(crate) fn strip_paths(message: &str) -> String {
         let is_abs_path_start =
             prev_byte.is_none() || prev_byte.is_some_and(|b| b.is_ascii_whitespace());
 
-        let after_slash = &remaining[slash_pos + 1..];
+        let after_slash = remaining.get(slash_pos + 1..).unwrap_or("");
         let next_is_path_char = after_slash
             .chars()
             .next()
             .is_some_and(|c| c.is_alphanumeric() || matches!(c, '_' | '-' | '.'));
 
         if is_abs_path_start && next_is_path_char {
-            result.push_str(&remaining[..slash_pos]);
+            result.push_str(remaining.get(..slash_pos).unwrap_or(""));
             result.push_str("[server path]");
             last_pushed_byte = Some(b']');
 
             let path_len = after_slash
                 .find(|c: char| !c.is_alphanumeric() && !matches!(c, '/' | '_' | '-' | '.'))
                 .unwrap_or(after_slash.len());
-            remaining = &after_slash[path_len..];
+            remaining = after_slash.get(path_len..).unwrap_or("");
         } else {
-            result.push_str(&remaining[..=slash_pos]);
+            result.push_str(remaining.get(..=slash_pos).unwrap_or(""));
             last_pushed_byte = Some(b'/');
             remaining = after_slash;
         }

--- a/crates/hermeneus/src/anthropic/client.rs
+++ b/crates/hermeneus/src/anthropic/client.rs
@@ -671,7 +671,9 @@ impl LlmProvider for AnthropicProvider {
 /// | `claude-haiku-4-5-20251001`  | `claude-haiku-4-5` |
 /// | `claude-haiku-4-5`           | `claude-haiku-4`   |
 fn model_family(model: &str) -> &str {
-    model.rfind('-').map_or(model, |pos| &model[..pos])
+    model
+        .rfind('-')
+        .map_or(model, |pos| model.get(..pos).unwrap_or(model))
 }
 
 /// Estimate cost using configured pricing.

--- a/crates/melete/src/prompt.rs
+++ b/crates/melete/src/prompt.rs
@@ -141,7 +141,7 @@ fn truncate_tool_result(content: &str) -> &str {
         while end > 0 && !content.is_char_boundary(end) {
             end -= 1;
         }
-        &content[..end]
+        content.get(..end).unwrap_or(content)
     }
 }
 

--- a/crates/mneme/src/consolidation/mod.rs
+++ b/crates/mneme/src/consolidation/mod.rs
@@ -270,13 +270,13 @@ pub struct LlmRelationshipEntry {
 fn extract_json_array(s: &str) -> Option<&str> {
     let start = s.find('[')?;
     let mut depth = 0i32;
-    for (i, ch) in s[start..].char_indices() {
+    for (i, ch) in s.get(start..).unwrap_or("").char_indices() {
         match ch {
             '[' => depth += 1,
             ']' => {
                 depth -= 1;
                 if depth == 0 {
-                    return Some(&s[start..=start + i]);
+                    return s.get(start..=start + i);
                 }
             }
             // NOTE: non-bracket character, no depth change

--- a/crates/mneme/src/engine/fts/tokenizer/ngram_tokenizer.rs
+++ b/crates/mneme/src/engine/fts/tokenizer/ngram_tokenizer.rs
@@ -144,7 +144,9 @@ impl<'a> TokenStream for NgramTokenStream<'a> {
             self.token.offset_from = offset_from;
             self.token.offset_to = offset_to;
             self.token.text.clear();
-            self.token.text.push_str(&self.text[offset_from..offset_to]);
+            self.token
+                .text
+                .push_str(self.text.get(offset_from..offset_to).unwrap_or(""));
             true
         } else {
             false
@@ -273,7 +275,7 @@ impl<'a> Iterator for CodepointFrontiers<'a> {
                 self.next_el = None;
             } else {
                 let first_codepoint_width = utf8_codepoint_width(self.s.as_bytes()[0]);
-                self.s = &self.s[first_codepoint_width..];
+                self.s = self.s.get(first_codepoint_width..).unwrap_or("");
                 self.next_el = Some(offset + first_codepoint_width);
             }
         })

--- a/crates/mneme/src/engine/fts/tokenizer/simple_tokenizer.rs
+++ b/crates/mneme/src/engine/fts/tokenizer/simple_tokenizer.rs
@@ -43,7 +43,9 @@ impl<'a> TokenStream for SimpleTokenStream<'a> {
                 let offset_to = self.search_token_end();
                 self.token.offset_from = offset_from;
                 self.token.offset_to = offset_to;
-                self.token.text.push_str(&self.text[offset_from..offset_to]);
+                self.token
+                    .text
+                    .push_str(self.text.get(offset_from..offset_to).unwrap_or(""));
                 return true;
             }
         }

--- a/crates/mneme/src/engine/fts/tokenizer/whitespace_tokenizer.rs
+++ b/crates/mneme/src/engine/fts/tokenizer/whitespace_tokenizer.rs
@@ -43,7 +43,9 @@ impl<'a> TokenStream for WhitespaceTokenStream<'a> {
                 let offset_to = self.search_token_end();
                 self.token.offset_from = offset_from;
                 self.token.offset_to = offset_to;
-                self.token.text.push_str(&self.text[offset_from..offset_to]);
+                self.token
+                    .text
+                    .push_str(self.text.get(offset_from..offset_to).unwrap_or(""));
                 return true;
             }
         }

--- a/crates/mneme/src/engine/parse/expr.rs
+++ b/crates/mneme/src/engine/parse/expr.rs
@@ -412,7 +412,7 @@ fn build_term(pair: Pair<'_>, param_pool: &BTreeMap<String, DataValue>) -> Resul
 }
 
 pub(crate) fn parse_int(s: &str, radix: u32) -> i64 {
-    i64::from_str_radix(&s[2..].replace('_', ""), radix)
+    i64::from_str_radix(&s.get(2..).unwrap_or("").replace('_', ""), radix)
         .expect("pest guarantees valid integer literal syntax")
 }
 

--- a/crates/mneme/src/engine/parse/query.rs
+++ b/crates/mneme/src/engine/parse/query.rs
@@ -814,7 +814,7 @@ fn parse_relation_apply_atom(
     };
     Ok(InputAtom::Relation {
         inner: InputRelationApplyAtom {
-            name: Symbol::new(&name.as_str()[1..], name.extract_span()),
+            name: Symbol::new(name.as_str().get(1..).unwrap_or(""), name.extract_span()),
             args,
             valid_at,
             span,
@@ -871,7 +871,10 @@ fn parse_relation_named_apply_atom(
     let name_p = src
         .next()
         .expect("pest guarantees relation_named_apply name");
-    let name = Symbol::new(&name_p.as_str()[1..], name_p.extract_span());
+    let name = Symbol::new(
+        name_p.as_str().get(1..).unwrap_or(""),
+        name_p.extract_span(),
+    );
     let args = src
         .next()
         .expect("pest guarantees relation_named_apply args")

--- a/crates/mneme/src/schema.rs
+++ b/crates/mneme/src/schema.rs
@@ -199,11 +199,15 @@ mod tests {
             .find(marker)
             .expect("CHECK constraint for category exists in DDL");
         let inner_start = start + marker.len();
-        let inner_end = DDL[inner_start..]
+        let inner_end = DDL
+            .get(inner_start..)
+            .expect("inner_start within DDL bounds")
             .find("))")
             .expect("closing parens for CHECK constraint")
             + inner_start;
-        let inner = &DDL[inner_start..inner_end];
+        let inner = DDL
+            .get(inner_start..inner_end)
+            .expect("inner_start..inner_end within DDL bounds");
 
         let ddl_cats: Vec<&str> = inner.split(", ").map(|s| s.trim_matches('\'')).collect();
 

--- a/crates/mneme/src/skill.rs
+++ b/crates/mneme/src/skill.rs
@@ -206,10 +206,10 @@ fn split_frontmatter(source: &str) -> (Option<&str>, &str) {
     if !trimmed.starts_with("---") {
         return (None, source);
     }
-    let after_open = &trimmed[3..];
+    let after_open = trimmed.get(3..).unwrap_or("");
     if let Some(close_pos) = after_open.find("\n---") {
-        let fm = &after_open[..close_pos];
-        let body = &after_open[close_pos + 4..];
+        let fm = after_open.get(..close_pos).unwrap_or("");
+        let body = after_open.get(close_pos + 4..).unwrap_or("");
         (Some(fm), body)
     } else {
         (None, source)
@@ -233,9 +233,9 @@ fn extract_steps(lines: &[String]) -> Vec<String> {
         .iter()
         .filter_map(|line| {
             let stripped = if let Some(pos) = line.find(". ") {
-                let prefix = &line[..pos];
+                let prefix = line.get(..pos).unwrap_or("");
                 if prefix.chars().all(|c| c.is_ascii_digit()) {
-                    line[pos + 2..].trim().to_owned()
+                    line.get(pos + 2..).unwrap_or("").trim().to_owned()
                 } else {
                     line.clone()
                 }
@@ -260,7 +260,7 @@ fn extract_tools(lines: &[String]) -> Vec<String> {
         .filter_map(|line| {
             let line = line.strip_prefix("- ").unwrap_or(line);
             let name = if let Some(colon_pos) = line.find(':') {
-                line[..colon_pos].trim()
+                line.get(..colon_pos).unwrap_or("").trim()
             } else {
                 line.trim()
             };

--- a/crates/mneme/src/skills/extract.rs
+++ b/crates/mneme/src/skills/extract.rs
@@ -363,7 +363,7 @@ fn parse_skill_response(response: &str) -> Result<ExtractedSkill, SkillExtractio
             .rfind("```")
             .filter(|&e| e > start)
             .unwrap_or(trimmed.len());
-        &trimmed[start..end]
+        trimmed.get(start..end).unwrap_or("")
     } else {
         trimmed
     };
@@ -371,7 +371,7 @@ fn parse_skill_response(response: &str) -> Result<ExtractedSkill, SkillExtractio
     let json_str = json_str.trim();
     let json_str = if let Some(start) = json_str.find('{') {
         let end = json_str.rfind('}').unwrap_or(json_str.len());
-        &json_str[start..=end]
+        json_str.get(start..=end).unwrap_or(json_str)
     } else {
         json_str
     };
@@ -380,7 +380,7 @@ fn parse_skill_response(response: &str) -> Result<ExtractedSkill, SkillExtractio
         ParseResponseSnafu {
             message: format!(
                 "invalid JSON in LLM response: {e}. Response was: {}",
-                &response[..response.len().min(200)]
+                response.get(..200).unwrap_or(response)
             ),
         }
         .build()

--- a/crates/nous/src/bootstrap/tools.rs
+++ b/crates/nous/src/bootstrap/tools.rs
@@ -101,14 +101,14 @@ fn extract_one_liner(description: &str) -> String {
 
     let end = first_line.find(". ").map_or(first_line.len(), |i| i + 1);
 
-    let sentence = &first_line[..end];
+    let sentence = first_line.get(..end).unwrap_or(first_line);
 
     if sentence.len() <= 80 {
         sentence.to_owned()
     } else {
-        let truncated = &sentence[..80];
+        let truncated = sentence.get(..80).unwrap_or(sentence);
         match truncated.rfind(' ') {
-            Some(i) if i > 40 => format!("{}...", &truncated[..i]),
+            Some(i) if i > 40 => format!("{}...", truncated.get(..i).unwrap_or(truncated)),
             _ => format!("{truncated}..."),
         }
     }

--- a/crates/nous/src/skills.rs
+++ b/crates/nous/src/skills.rs
@@ -34,8 +34,16 @@ pub(crate) fn extract_task_context(content: &str) -> String {
     }
 
     // WHY: prefer breaking at word boundary to avoid cutting mid-word
-    let word_end = trimmed[..end].rfind(' ').unwrap_or(end);
-    trimmed[..word_end].trim_end().to_owned()
+    let word_end = trimmed
+        .get(..end)
+        .unwrap_or(trimmed)
+        .rfind(' ')
+        .unwrap_or(end);
+    trimmed
+        .get(..word_end)
+        .unwrap_or(trimmed)
+        .trim_end()
+        .to_owned()
 }
 
 /// Strip characters that `CozoDB` FTS (tantivy) cannot parse.

--- a/crates/organon/src/builtins/research.rs
+++ b/crates/organon/src/builtins/research.rs
@@ -192,7 +192,7 @@ impl ToolExecutor for WebFetchExecutor {
                 }
                 format!(
                     "{}...\n\n[Truncated at {max_length} characters]",
-                    &text[..end]
+                    text.get(..end).unwrap_or(&text)
                 )
             } else {
                 text

--- a/crates/pylon/src/handlers/knowledge.rs
+++ b/crates/pylon/src/handlers/knowledge.rs
@@ -735,7 +735,7 @@ pub(crate) fn truncate_content(s: &str, max: usize) -> String {
         while end > 0 && !s.is_char_boundary(end) {
             end -= 1;
         }
-        format!("{}...", &s[..end])
+        format!("{}...", s.get(..end).unwrap_or(s))
     }
 }
 

--- a/crates/theatron/tui/src/actions.rs
+++ b/crates/theatron/tui/src/actions.rs
@@ -82,9 +82,9 @@ impl App {
     }
 
     pub(crate) fn handle_tab_completion(&mut self) {
-        let text_before_cursor = &self.input.text[..self.input.cursor];
+        let text_before_cursor = self.input.text.get(..self.input.cursor).unwrap_or("");
         if let Some(at_pos) = text_before_cursor.rfind('@') {
-            let prefix = &text_before_cursor[at_pos + 1..];
+            let prefix = text_before_cursor.get(at_pos + 1..).unwrap_or("");
 
             if let Some(ref mut tc) = self.tab_completion
                 && (tc.prefix == prefix || (!tc.candidates.is_empty() && tc.insert_start == at_pos))

--- a/crates/theatron/tui/src/diff.rs
+++ b/crates/theatron/tui/src/diff.rs
@@ -717,9 +717,14 @@ fn truncate_str(s: &str, max_chars: usize) -> String {
         while end > 0 && !s.is_char_boundary(end) {
             end -= 1;
         }
-        let truncated = &s[..end];
+        let truncated = s.get(..end).unwrap_or(s);
         if end >= 2 {
-            format!("{}…", &truncated[..truncated.len().saturating_sub(1)])
+            format!(
+                "{}…",
+                truncated
+                    .get(..truncated.len().saturating_sub(1))
+                    .unwrap_or(truncated)
+            )
         } else {
             truncated.to_string()
         }
@@ -728,7 +733,7 @@ fn truncate_str(s: &str, max_chars: usize) -> String {
 
 fn pad_to(s: String, width: usize) -> String {
     if s.len() >= width {
-        s[..width].to_string()
+        s.get(..width).unwrap_or(&s).to_string()
     } else {
         format!("{s:<width$}")
     }

--- a/crates/theatron/tui/src/hyperlink.rs
+++ b/crates/theatron/tui/src/hyperlink.rs
@@ -127,10 +127,10 @@ pub fn detect_urls(text: &str) -> Vec<(usize, usize, &str)> {
     let mut out = Vec::new();
     for m in URL_RE.find_iter(text) {
         let start = m.start();
-        let trimmed_len = trim_trailing_punct(&text[start..m.end()]);
+        let trimmed_len = trim_trailing_punct(text.get(start..m.end()).unwrap_or(""));
         let end = start + trimmed_len;
         if end > start {
-            out.push((start, end, &text[start..end]));
+            out.push((start, end, text.get(start..end).unwrap_or("")));
         }
     }
     out
@@ -147,7 +147,7 @@ fn trim_trailing_punct(url: &str) -> usize {
         match bytes[end - 1] {
             b'.' | b',' | b';' | b'!' | b'?' | b':' => end -= 1,
             b')' => {
-                let sub = &url[..end];
+                let sub = url.get(..end).unwrap_or("");
                 let opens = sub.bytes().filter(|&b| b == b'(').count();
                 let closes = sub.bytes().filter(|&b| b == b')').count();
                 if closes > opens {
@@ -289,7 +289,10 @@ mod tests {
         let urls = detect_urls(text);
         assert_eq!(urls.len(), 1);
         assert_eq!(urls[0].0, 6);
-        assert_eq!(&text[urls[0].0..urls[0].1], "https://foo.com");
+        assert_eq!(
+            text.get(urls[0].0..urls[0].1).unwrap_or(""),
+            "https://foo.com"
+        );
     }
 
     #[test]

--- a/crates/theatron/tui/src/markdown.rs
+++ b/crates/theatron/tui/src/markdown.rs
@@ -396,10 +396,10 @@ fn linkify_text(
     let mut last = 0usize;
     for &(start, end, url) in urls {
         if start > last {
-            let before = &text[last..start];
+            let before = text.get(last..start).unwrap_or("");
             push_span(spans, col, Span::styled(before.to_string(), base_style));
         }
-        let url_text = &text[start..end];
+        let url_text = text.get(start..end).unwrap_or("");
         let link_col = *col;
         push_span(spans, col, Span::styled(url_text.to_string(), link_style));
         md_links.push(MdLink {
@@ -414,7 +414,7 @@ fn linkify_text(
         push_span(
             spans,
             col,
-            Span::styled(text[last..].to_string(), base_style),
+            Span::styled(text.get(last..).unwrap_or("").to_string(), base_style),
         );
     }
 }

--- a/crates/theatron/tui/src/state/filter.rs
+++ b/crates/theatron/tui/src/state/filter.rs
@@ -68,7 +68,10 @@ impl FilterState {
 
     pub fn backspace(&mut self) {
         if self.cursor > 0 {
-            let prev = self.text[..self.cursor]
+            let prev = self
+                .text
+                .get(..self.cursor)
+                .unwrap_or("")
                 .char_indices()
                 .next_back()
                 .map(|(i, _)| i)

--- a/crates/theatron/tui/src/state/ops.rs
+++ b/crates/theatron/tui/src/state/ops.rs
@@ -321,7 +321,7 @@ fn parse_diff_from_output(output: &str, tool_name: &str) -> Option<OpsDiffEntry>
 
     for line in output.lines() {
         if line.starts_with("--- ") || line.starts_with("+++ ") {
-            let path = line[4..].trim().to_string();
+            let path = line.get(4..).unwrap_or("").trim().to_string();
             if !path.is_empty() && file_path.is_empty() {
                 file_path = path;
             }

--- a/crates/theatron/tui/src/update/command.rs
+++ b/crates/theatron/tui/src/update/command.rs
@@ -445,7 +445,7 @@ fn safe_truncate(s: &str, max_bytes: usize) -> &str {
     while end > 0 && !s.is_char_boundary(end) {
         end -= 1;
     }
-    &s[..end]
+    s.get(..end).unwrap_or(s)
 }
 
 pub(crate) fn execute_export_from_msg(app: &mut App) {

--- a/crates/theatron/tui/src/update/input.rs
+++ b/crates/theatron/tui/src/update/input.rs
@@ -50,9 +50,11 @@ pub(crate) fn handle_delete_word(app: &mut App) {
     let mut pos = app.input.cursor;
     while pos > 0 {
         let prev = app.prev_char_boundary(pos);
-        let is_ws = app.input.text[prev..pos]
-            .chars()
-            .next()
+        let is_ws = app
+            .input
+            .text
+            .get(prev..pos)
+            .and_then(|s| s.chars().next())
             .is_some_and(|c| c.is_whitespace());
         if is_ws {
             pos = prev;
@@ -62,9 +64,11 @@ pub(crate) fn handle_delete_word(app: &mut App) {
     }
     while pos > 0 {
         let prev = app.prev_char_boundary(pos);
-        let is_ws = app.input.text[prev..pos]
-            .chars()
-            .next()
+        let is_ws = app
+            .input
+            .text
+            .get(prev..pos)
+            .and_then(|s| s.chars().next())
             .is_some_and(|c| c.is_whitespace());
         if is_ws {
             break;

--- a/crates/theatron/tui/src/update/search.rs
+++ b/crates/theatron/tui/src/update/search.rs
@@ -25,9 +25,10 @@ pub(crate) fn handle_input(app: &mut App, c: char) {
 pub(crate) fn handle_backspace(app: &mut App) {
     let should_close = if let Some(Overlay::SessionSearch(ref mut search)) = app.overlay {
         if search.cursor > 0 {
-            let prev = search.query[..search.cursor]
-                .char_indices()
-                .next_back()
+            let prev = search
+                .query
+                .get(..search.cursor)
+                .and_then(|s| s.char_indices().next_back())
                 .map(|(i, _)| i)
                 .unwrap_or(0);
             search.query.drain(prev..search.cursor);
@@ -208,13 +209,18 @@ fn excerpt(text: &str, needle: &str, max_len: usize) -> String {
     let context = max_len / 2;
     let start = pos.saturating_sub(context);
     // Align to char boundary
-    let start = text[..start]
-        .char_indices()
-        .next_back()
+    let start = text
+        .get(..start)
+        .and_then(|s| s.char_indices().next_back())
         .map(|(i, _)| i)
         .unwrap_or(0);
 
-    let result: String = text[start..].chars().take(max_len).collect();
+    let result: String = text
+        .get(start..)
+        .unwrap_or("")
+        .chars()
+        .take(max_len)
+        .collect();
     if start > 0 {
         format!("...{result}")
     } else {

--- a/crates/theatron/tui/src/update/selection.rs
+++ b/crates/theatron/tui/src/update/selection.rs
@@ -245,7 +245,7 @@ fn extract_urls(text: &str) -> Vec<String> {
     for word in text.split_whitespace() {
         // NOTE: handle markdown link syntax [text](url) before falling through to plain URL detection
         if let Some(paren_start) = word.find("](") {
-            let url_part = &word[paren_start + 2..];
+            let url_part = word.get(paren_start + 2..).unwrap_or("");
             let candidate = url_part
                 .trim_end_matches(')')
                 .trim_end_matches(',')

--- a/crates/theatron/tui/src/view/chat.rs
+++ b/crates/theatron/tui/src/view/chat.rs
@@ -469,7 +469,7 @@ fn highlight_span(
 
     for (byte_start, _) in content_lower.match_indices(&pattern_lower) {
         // Convert byte offset in the original string to char index
-        let char_start = content[..byte_start].chars().count();
+        let char_start = content.get(..byte_start).unwrap_or("").chars().count();
         let pattern_chars = pattern.chars().count();
         let char_end = char_start + pattern_chars;
 

--- a/crates/theatron/tui/src/view/input.rs
+++ b/crates/theatron/tui/src/view/input.rs
@@ -44,7 +44,7 @@ pub fn render(app: &App, frame: &mut Frame, area: Rect, theme: &Theme) {
 
     let mut ratatui_lines: Vec<Line<'static>> = Vec::with_capacity(total_rows);
     for (i, &(start, end)) in line_ranges.iter().enumerate() {
-        let line_text = text[start..end].to_string();
+        let line_text = text.get(start..end).unwrap_or("").to_string();
         if i == 0 {
             ratatui_lines.push(Line::from(vec![
                 Span::styled(prompt_str.to_string(), Style::default().fg(prompt_color)),
@@ -111,7 +111,7 @@ pub(crate) fn word_wrap_lines(
         };
         is_first = false;
 
-        let remaining = &text[pos..];
+        let remaining = text.get(pos..).unwrap_or("");
 
         if remaining.is_empty() {
             break;
@@ -141,7 +141,10 @@ pub(crate) fn word_wrap_lines(
 
         if let Some(ws_b) = last_ws_byte {
             // NOTE: break at the last whitespace: exclude it from both lines
-            let ws_len = remaining[ws_b..].chars().next().map_or(1, |c| c.len_utf8());
+            let ws_len = remaining
+                .get(ws_b..)
+                .and_then(|s| s.chars().next())
+                .map_or(1, |c| c.len_utf8());
             lines.push((pos, pos + ws_b));
             pos += ws_b + ws_len; // skip over the whitespace
         } else {
@@ -171,7 +174,7 @@ pub(crate) fn cursor_visual_position(
         // Cursor on this line if it falls within [start, end] (inclusive at end
         // so cursor-at-end-of-line is on this line rather than the next).
         if cursor_byte >= start && cursor_byte <= end {
-            let col_display = UnicodeWidthStr::width(&text[start..cursor_byte]);
+            let col_display = UnicodeWidthStr::width(text.get(start..cursor_byte).unwrap_or(""));
             let col = if row == 0 {
                 prompt_width + col_display
             } else {
@@ -185,7 +188,8 @@ pub(crate) fn cursor_visual_position(
     // Place it at the start of the next line.
     let last_row = line_ranges.len().saturating_sub(1);
     if let Some(&(start, _)) = line_ranges.last() {
-        let col_display = UnicodeWidthStr::width(&text[start..cursor_byte.min(text.len())]);
+        let col_display =
+            UnicodeWidthStr::width(text.get(start..cursor_byte.min(text.len())).unwrap_or(""));
         let col = if last_row == 0 {
             prompt_width + col_display
         } else {
@@ -271,8 +275,8 @@ mod tests {
         // emoji 😀 (width 2) + "xyz" (width 3) = 5 cols; avail=4 → "😀xy" (4 cols) on line 0, "z" on line 1
         let ranges = word_wrap_lines("😀xyz", 4, 4);
         assert_eq!(ranges.len(), 2);
-        assert_eq!(&"😀xyz"[ranges[0].0..ranges[0].1], "😀xy");
-        assert_eq!(&"😀xyz"[ranges[1].0..ranges[1].1], "z");
+        assert_eq!("😀xyz".get(ranges[0].0..ranges[0].1).unwrap_or(""), "😀xy");
+        assert_eq!("😀xyz".get(ranges[1].0..ranges[1].1).unwrap_or(""), "z");
     }
 
     #[test]

--- a/crates/theatron/tui/src/view/memory.rs
+++ b/crates/theatron/tui/src/view/memory.rs
@@ -608,7 +608,7 @@ fn truncate(s: &str, max_len: usize) -> String {
     if s.len() <= max_len {
         s.to_string()
     } else {
-        format!("{}…", &s[..max_len.saturating_sub(1)])
+        format!("{}…", s.get(..max_len.saturating_sub(1)).unwrap_or(s))
     }
 }
 

--- a/crates/theatron/tui/src/view/ops.rs
+++ b/crates/theatron/tui/src/view/ops.rs
@@ -170,7 +170,7 @@ fn render_thinking_block(
 
         for line in display_lines {
             let display = if line.len() > inner_width.saturating_sub(3) {
-                &line[..inner_width.saturating_sub(6)]
+                line.get(..inner_width.saturating_sub(6)).unwrap_or(line)
             } else {
                 line
             };
@@ -291,13 +291,15 @@ fn render_tool_call(
                 Span::styled("input:", theme.style_muted()),
             ]));
             let truncated_input = if input.len() > JSON_TRUNCATE_BYTES {
-                format!("{}...", &input[..JSON_TRUNCATE_BYTES])
+                format!("{}...", input.get(..JSON_TRUNCATE_BYTES).unwrap_or(input))
             } else {
                 input.clone()
             };
             for json_line in truncated_input.lines() {
                 let display = if json_line.len() > inner_width.saturating_sub(4) {
-                    &json_line[..inner_width.saturating_sub(7)]
+                    json_line
+                        .get(..inner_width.saturating_sub(7))
+                        .unwrap_or(json_line)
                 } else {
                     json_line
                 };
@@ -323,7 +325,9 @@ fn render_tool_call(
 
             for out_line in display_lines {
                 let display = if out_line.len() > inner_width.saturating_sub(4) {
-                    &out_line[..inner_width.saturating_sub(7)]
+                    out_line
+                        .get(..inner_width.saturating_sub(7))
+                        .unwrap_or(out_line)
                 } else {
                     out_line
                 };

--- a/crates/theatron/tui/src/view/status_bar.rs
+++ b/crates/theatron/tui/src/view/status_bar.rs
@@ -204,14 +204,14 @@ fn truncate_str_to_cols(s: &str, max_cols: usize) -> &str {
     let mut w = 0usize;
     let mut end = 0usize;
     for (idx, ch) in s.char_indices() {
-        let char_w = s[idx..idx + ch.len_utf8()].width();
+        let char_w = s.get(idx..idx + ch.len_utf8()).unwrap_or("").width();
         if w + char_w > max_cols {
             break;
         }
         w += char_w;
         end = idx + ch.len_utf8();
     }
-    &s[..end]
+    s.get(..end).unwrap_or(s)
 }
 
 fn agent_identity_spans(app: &App, theme: &Theme) -> Vec<Span<'static>> {

--- a/crates/theatron/tui/src/view/tab_bar.rs
+++ b/crates/theatron/tui/src/view/tab_bar.rs
@@ -110,7 +110,7 @@ fn truncate_title(title: &str, max_width: usize) -> String {
     while end > 0 && !title.is_char_boundary(end) {
         end -= 1;
     }
-    format!("{}\u{2026}", &title[..end])
+    format!("{}\u{2026}", title.get(..end).unwrap_or(title))
 }
 
 /// Whether the tab bar should be shown (more than 1 tab or always-on).

--- a/crates/theatron/tui/src/view/views.rs
+++ b/crates/theatron/tui/src/view/views.rs
@@ -87,7 +87,8 @@ pub(crate) fn render_sessions(app: &App, frame: &mut Frame, area: Rect, theme: &
                                 .nth(8)
                                 .map(|(b, _)| b)
                                 .unwrap_or(nous_id_str.len());
-                            fallback_label = nous_id_str[..end].to_string();
+                            fallback_label =
+                                nous_id_str.get(..end).unwrap_or(nous_id_str).to_string();
                             &fallback_label
                         }
                     };


### PR DESCRIPTION
## Summary
- Replace direct string slicing with safe .get() alternatives to prevent panics on invalid UTF-8 boundaries

## Test plan
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes