### PR TITLE
safety(workspace): audit and replace riskiest as-casts with safe numeric conversions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,9 @@ string_add = "warn"
 trait_duplication_in_bounds = "warn"
 unused_self = "warn"
 
+# Safety: numeric cast auditing (incremental)
+cast_possible_truncation = "warn"
+
 [workspace.dependencies]
 base64 = "0.22"
 rayon = "1"

--- a/crates/mneme/src/engine/data/functions/aggregate.rs
+++ b/crates/mneme/src/engine/data/functions/aggregate.rs
@@ -33,7 +33,7 @@ pub(crate) fn get_index(mut i: i64, total: usize, is_upper: bool) -> Result<usiz
         i += total as i64;
     }
     Ok(if i >= 0 {
-        let i = i as usize;
+        let i = usize::try_from(i).map_err(|_e| IndexOutOfBoundsSnafu { index: i }.build())?;
         if i > total || (!is_upper && i == total) {
             return IndexOutOfBoundsSnafu { index: i as i64 }.fail();
         } else {
@@ -87,7 +87,13 @@ fn get_json_path_immutable_local<'a>(
                         message: "json path must be a string or a number",
                     }
                     .build()
-                })? as usize;
+                })?;
+                let key = usize::try_from(key).map_err(|_e| {
+                    JsonPathSnafu {
+                        message: "json array index out of range",
+                    }
+                    .build()
+                })?;
 
                 let val = arr.get(key).ok_or_else(|| {
                     JsonPathSnafu {
@@ -141,7 +147,13 @@ pub(crate) fn get_impl(args: &[DataValue]) -> Result<DataValue> {
                         }
                         .build()
                     })?;
-                    json.get(i as usize)
+                    let idx = usize::try_from(i).map_err(|_e| {
+                        InvalidValueSnafu {
+                            message: format!("index '{i}' out of range for json array"),
+                        }
+                        .build()
+                    })?;
+                    json.get(idx)
                         .ok_or_else(|| {
                             InvalidValueSnafu {
                                 message: format!("index '{i}' not found in json"),
@@ -462,8 +474,14 @@ pub(crate) fn op_chunks(args: &[DataValue]) -> Result<DataValue> {
             message: "second argument to 'chunks' must be positive"
         }
     );
+    let n = usize::try_from(n).map_err(|_e| {
+        InvalidValueSnafu {
+            message: "second argument to 'chunks' out of range",
+        }
+        .build()
+    })?;
     let res = a
-        .chunks(n as usize)
+        .chunks(n)
         .map(|el| DataValue::List(el.to_vec()))
         .collect_vec();
     Ok(DataValue::List(res))
@@ -490,8 +508,14 @@ pub(crate) fn op_chunks_exact(args: &[DataValue]) -> Result<DataValue> {
             message: "second argument to 'chunks_exact' must be positive"
         }
     );
+    let n = usize::try_from(n).map_err(|_e| {
+        InvalidValueSnafu {
+            message: "second argument to 'chunks_exact' out of range",
+        }
+        .build()
+    })?;
     let res = a
-        .chunks_exact(n as usize)
+        .chunks_exact(n)
         .map(|el| DataValue::List(el.to_vec()))
         .collect_vec();
     Ok(DataValue::List(res))
@@ -518,8 +542,14 @@ pub(crate) fn op_windows(args: &[DataValue]) -> Result<DataValue> {
             message: "second argument to 'windows' must be positive"
         }
     );
+    let n = usize::try_from(n).map_err(|_e| {
+        InvalidValueSnafu {
+            message: "second argument to 'windows' out of range",
+        }
+        .build()
+    })?;
     let res = a
-        .windows(n as usize)
+        .windows(n)
         .map(|el| DataValue::List(el.to_vec()))
         .collect_vec();
     Ok(DataValue::List(res))

--- a/crates/mneme/src/engine/data/functions/math.rs
+++ b/crates/mneme/src/engine/data/functions/math.rs
@@ -50,11 +50,11 @@ pub(crate) fn add_vecs(args: &[DataValue]) -> Result<DataValue> {
                 (Vector::F32(a), Vector::F32(b)) => Ok(DataValue::Vec(Vector::F32(a + b))),
                 (Vector::F64(a), Vector::F64(b)) => Ok(DataValue::Vec(Vector::F64(a + b))),
                 (Vector::F32(a), Vector::F64(b)) => {
-                    let a = a.mapv(|x| x as f64);
+                    let a = a.mapv(f64::from);
                     Ok(DataValue::Vec(Vector::F64(a + b)))
                 }
                 (Vector::F64(a), Vector::F32(b)) => {
-                    let b = b.mapv(|x| x as f64);
+                    let b = b.mapv(f64::from);
                     Ok(DataValue::Vec(Vector::F64(a + b)))
                 }
             }
@@ -69,7 +69,12 @@ pub(crate) fn add_vecs(args: &[DataValue]) -> Result<DataValue> {
             })?;
             match a {
                 Vector::F32(mut v) => {
-                    v += f as f32;
+                    #[expect(
+                        clippy::cast_possible_truncation,
+                        reason = "intentional F64→F32 reduction for mixed-precision vector arithmetic"
+                    )]
+                    let f = f as f32;
+                    v += f;
                     Ok(DataValue::Vec(Vector::F32(v)))
                 }
                 Vector::F64(mut v) => {
@@ -87,7 +92,14 @@ pub(crate) fn add_vecs(args: &[DataValue]) -> Result<DataValue> {
                 .build()
             })?;
             match b {
-                Vector::F32(v) => Ok(DataValue::Vec(Vector::F32(v + f as f32))),
+                Vector::F32(v) => {
+                    #[expect(
+                        clippy::cast_possible_truncation,
+                        reason = "intentional F64→F32 reduction for mixed-precision vector arithmetic"
+                    )]
+                    let f = f as f32;
+                    Ok(DataValue::Vec(Vector::F32(v + f)))
+                }
                 Vector::F64(v) => Ok(DataValue::Vec(Vector::F64(v + f))),
             }
         }
@@ -116,11 +128,11 @@ pub(crate) fn mul_vecs(args: &[DataValue]) -> Result<DataValue> {
                 (Vector::F32(a), Vector::F32(b)) => Ok(DataValue::Vec(Vector::F32(a * b))),
                 (Vector::F64(a), Vector::F64(b)) => Ok(DataValue::Vec(Vector::F64(a * b))),
                 (Vector::F32(a), Vector::F64(b)) => {
-                    let a = a.mapv(|x| x as f64);
+                    let a = a.mapv(f64::from);
                     Ok(DataValue::Vec(Vector::F64(a * b)))
                 }
                 (Vector::F64(a), Vector::F32(b)) => {
-                    let b = b.mapv(|x| x as f64);
+                    let b = b.mapv(f64::from);
                     Ok(DataValue::Vec(Vector::F64(a * b)))
                 }
             }
@@ -135,7 +147,12 @@ pub(crate) fn mul_vecs(args: &[DataValue]) -> Result<DataValue> {
             })?;
             match a {
                 Vector::F32(mut v) => {
-                    v *= f as f32;
+                    #[expect(
+                        clippy::cast_possible_truncation,
+                        reason = "intentional F64→F32 reduction for mixed-precision vector arithmetic"
+                    )]
+                    let f = f as f32;
+                    v *= f;
                     Ok(DataValue::Vec(Vector::F32(v)))
                 }
                 Vector::F64(mut v) => {
@@ -153,7 +170,14 @@ pub(crate) fn mul_vecs(args: &[DataValue]) -> Result<DataValue> {
                 .build()
             })?;
             match b {
-                Vector::F32(v) => Ok(DataValue::Vec(Vector::F32(v * f as f32))),
+                Vector::F32(v) => {
+                    #[expect(
+                        clippy::cast_possible_truncation,
+                        reason = "intentional F64→F32 reduction for mixed-precision vector arithmetic"
+                    )]
+                    let f = f as f32;
+                    Ok(DataValue::Vec(Vector::F32(v * f)))
+                }
                 Vector::F64(v) => Ok(DataValue::Vec(Vector::F64(v * f))),
             }
         }
@@ -295,11 +319,11 @@ pub(crate) fn op_sub(args: &[DataValue]) -> Result<DataValue> {
             (Vector::F32(a), Vector::F32(b)) => DataValue::Vec(Vector::F32(a - b)),
             (Vector::F64(a), Vector::F64(b)) => DataValue::Vec(Vector::F64(a - b)),
             (Vector::F32(a), Vector::F64(b)) => {
-                let a = a.mapv(|x| x as f64);
+                let a = a.mapv(f64::from);
                 DataValue::Vec(Vector::F64(a - b))
             }
             (Vector::F64(a), Vector::F32(b)) => {
-                let b = b.mapv(|x| x as f64);
+                let b = b.mapv(f64::from);
                 DataValue::Vec(Vector::F64(a - b))
             }
         },
@@ -313,7 +337,12 @@ pub(crate) fn op_sub(args: &[DataValue]) -> Result<DataValue> {
             })?;
             match a.clone() {
                 Vector::F32(mut v) => {
-                    v -= b as f32;
+                    #[expect(
+                        clippy::cast_possible_truncation,
+                        reason = "intentional F64→F32 reduction for mixed-precision vector arithmetic"
+                    )]
+                    let b = b as f32;
+                    v -= b;
                     DataValue::Vec(Vector::F32(v))
                 }
                 Vector::F64(mut v) => {
@@ -332,7 +361,12 @@ pub(crate) fn op_sub(args: &[DataValue]) -> Result<DataValue> {
             })?;
             match b.clone() {
                 Vector::F32(mut v) => {
-                    v -= a as f32;
+                    #[expect(
+                        clippy::cast_possible_truncation,
+                        reason = "intentional F64→F32 reduction for mixed-precision vector arithmetic"
+                    )]
+                    let a = a as f32;
+                    v -= a;
                     DataValue::Vec(Vector::F32(-v))
                 }
                 Vector::F64(mut v) => {
@@ -393,11 +427,11 @@ pub(crate) fn op_div(args: &[DataValue]) -> Result<DataValue> {
             (Vector::F32(a), Vector::F32(b)) => DataValue::Vec(Vector::F32(a / b)),
             (Vector::F64(a), Vector::F64(b)) => DataValue::Vec(Vector::F64(a / b)),
             (Vector::F32(a), Vector::F64(b)) => {
-                let a = a.mapv(|x| x as f64);
+                let a = a.mapv(f64::from);
                 DataValue::Vec(Vector::F64(a / b))
             }
             (Vector::F64(a), Vector::F32(b)) => {
-                let b = b.mapv(|x| x as f64);
+                let b = b.mapv(f64::from);
                 DataValue::Vec(Vector::F64(a / b))
             }
         },
@@ -411,7 +445,12 @@ pub(crate) fn op_div(args: &[DataValue]) -> Result<DataValue> {
             })?;
             match a.clone() {
                 Vector::F32(mut v) => {
-                    v /= b as f32;
+                    #[expect(
+                        clippy::cast_possible_truncation,
+                        reason = "intentional F64→F32 reduction for mixed-precision vector arithmetic"
+                    )]
+                    let b = b as f32;
+                    v /= b;
                     DataValue::Vec(Vector::F32(v))
                 }
                 Vector::F64(mut v) => {
@@ -429,7 +468,14 @@ pub(crate) fn op_div(args: &[DataValue]) -> Result<DataValue> {
                 .build()
             })?;
             match b {
-                Vector::F32(v) => DataValue::Vec(Vector::F32(a as f32 / v)),
+                Vector::F32(v) => {
+                    #[expect(
+                        clippy::cast_possible_truncation,
+                        reason = "intentional F64→F32 reduction for mixed-precision vector arithmetic"
+                    )]
+                    let a = a as f32;
+                    DataValue::Vec(Vector::F32(a / v))
+                }
                 Vector::F64(v) => DataValue::Vec(Vector::F64(a / v)),
             }
         }
@@ -679,7 +725,12 @@ pub(crate) fn op_pow(args: &[DataValue]) -> Result<DataValue> {
                 }
                 .build()
             })?;
-            return Ok(DataValue::Vec(Vector::F32(v.mapv(|x| x.powf(b as f32)))));
+            #[expect(
+                clippy::cast_possible_truncation,
+                reason = "intentional F64→F32 reduction for mixed-precision vector arithmetic"
+            )]
+            let b = b as f32;
+            return Ok(DataValue::Vec(Vector::F32(v.mapv(|x| x.powf(b)))));
         }
         DataValue::Vec(Vector::F64(v)) => {
             let b = arg(args, 1)?.get_float().ok_or_else(|| {

--- a/crates/mneme/src/engine/data/functions/vector.rs
+++ b/crates/mneme/src/engine/data/functions/vector.rs
@@ -11,7 +11,6 @@ type Result<T> = DataResult<T>;
 use crate::engine::data::relation::VecElementType;
 use crate::engine::data::value::{DataValue, Vector};
 
-#[expect(clippy::map_err_ignore, reason = "error context preserved in message")]
 pub(crate) fn op_vec(args: &[DataValue]) -> Result<DataValue> {
     let t = match args.get(1) {
         Some(DataValue::Str(s)) => match s as &str {
@@ -54,7 +53,12 @@ pub(crate) fn op_vec(args: &[DataValue]) -> Result<DataValue> {
                             }
                             .build()
                         })?;
-                        row.fill(f as f32);
+                        #[expect(
+                            clippy::cast_possible_truncation,
+                            reason = "intentional F64→F32 reduction for mixed-precision vector arithmetic"
+                        )]
+                        let f = f as f32;
+                        row.fill(f);
                     }
                     Ok(DataValue::Vec(Vector::F32(res_arr)))
                 }
@@ -85,7 +89,12 @@ pub(crate) fn op_vec(args: &[DataValue]) -> Result<DataValue> {
                         }
                         .build()
                     })?;
-                    row.fill(f as f32);
+                    #[expect(
+                        clippy::cast_possible_truncation,
+                        reason = "intentional F64→F32 reduction for mixed-precision vector arithmetic"
+                    )]
+                    let f = f as f32;
+                    row.fill(f);
                 }
                 Ok(DataValue::Vec(Vector::F32(res_arr)))
             }
@@ -108,14 +117,19 @@ pub(crate) fn op_vec(args: &[DataValue]) -> Result<DataValue> {
             (VecElementType::F32, Vector::F32(v)) => Ok(DataValue::Vec(Vector::F32(v.clone()))),
             (VecElementType::F64, Vector::F64(v)) => Ok(DataValue::Vec(Vector::F64(v.clone()))),
             (VecElementType::F32, Vector::F64(v)) => {
-                Ok(DataValue::Vec(Vector::F32(v.mapv(|x| x as f32))))
+                #[expect(
+                    clippy::cast_possible_truncation,
+                    reason = "intentional F64→F32 reduction for mixed-precision vector arithmetic"
+                )]
+                let result = v.mapv(|x| x as f32);
+                Ok(DataValue::Vec(Vector::F32(result)))
             }
             (VecElementType::F64, Vector::F32(v)) => {
-                Ok(DataValue::Vec(Vector::F64(v.mapv(|x| x as f64))))
+                Ok(DataValue::Vec(Vector::F64(v.mapv(f64::from))))
             }
         },
         DataValue::Str(s) => {
-            let bytes = STANDARD.decode(s).map_err(|_| {
+            let bytes = STANDARD.decode(s).map_err(|_e| {
                 EncodingFailedSnafu {
                     message: "Data is not base64 encoded",
                 }
@@ -199,13 +213,19 @@ pub(crate) fn op_vec(args: &[DataValue]) -> Result<DataValue> {
 }
 
 pub(crate) fn op_rand_vec(args: &[DataValue]) -> Result<DataValue> {
-    let len = arg(args, 0)?.get_int().ok_or_else(|| {
+    let len_i64 = arg(args, 0)?.get_int().ok_or_else(|| {
         TypeMismatchSnafu {
             op: "rand_vec",
             expected: "an integer",
         }
         .build()
-    })? as usize;
+    })?;
+    let len = usize::try_from(len_i64).map_err(|_e| {
+        InvalidValueSnafu {
+            message: format!("rand_vec length must be non-negative, got {len_i64}"),
+        }
+        .build()
+    })?;
     let t = match args.get(1) {
         Some(DataValue::Str(s)) => match s as &str {
             "F32" | "Float" => VecElementType::F32,
@@ -232,7 +252,12 @@ pub(crate) fn op_rand_vec(args: &[DataValue]) -> Result<DataValue> {
         VecElementType::F32 => {
             let mut res_arr = ndarray::Array1::zeros(len);
             for mut row in res_arr.axis_iter_mut(ndarray::Axis(0)) {
-                row.fill(rng.random::<f64>() as f32);
+                #[expect(
+                    clippy::cast_possible_truncation,
+                    reason = "intentional F64→F32 reduction for mixed-precision vector arithmetic"
+                )]
+                let val = rng.random::<f64>() as f32;
+                row.fill(val);
             }
             Ok(DataValue::Vec(Vector::F32(res_arr)))
         }
@@ -278,7 +303,7 @@ pub(crate) fn op_l2_dist(args: &[DataValue]) -> Result<DataValue> {
                 .fail();
             }
             let diff = a - b;
-            Ok(DataValue::from(diff.dot(&diff) as f64))
+            Ok(DataValue::from(f64::from(diff.dot(&diff))))
         }
         (DataValue::Vec(Vector::F64(a)), DataValue::Vec(Vector::F64(b))) => {
             if a.len() != b.len() {
@@ -312,7 +337,7 @@ pub(crate) fn op_ip_dist(args: &[DataValue]) -> Result<DataValue> {
                 .fail();
             }
             let dot = a.dot(b);
-            Ok(DataValue::from(1. - dot as f64))
+            Ok(DataValue::from(1. - f64::from(dot)))
         }
         (DataValue::Vec(Vector::F64(a)), DataValue::Vec(Vector::F64(b))) => {
             if a.len() != b.len() {
@@ -345,9 +370,9 @@ pub(crate) fn op_cos_dist(args: &[DataValue]) -> Result<DataValue> {
                 }
                 .fail();
             }
-            let a_norm = a.dot(a) as f64;
-            let b_norm = b.dot(b) as f64;
-            let dot = a.dot(b) as f64;
+            let a_norm = f64::from(a.dot(a));
+            let b_norm = f64::from(b.dot(b));
+            let dot = f64::from(a.dot(b));
             Ok(DataValue::from(1. - dot / (a_norm * b_norm).sqrt()))
         }
         (DataValue::Vec(Vector::F64(a)), DataValue::Vec(Vector::F64(b))) => {

--- a/crates/mneme/src/engine/fixed_rule/algos/all_pairs_shortest_path.rs
+++ b/crates/mneme/src/engine/fixed_rule/algos/all_pairs_shortest_path.rs
@@ -48,6 +48,10 @@ impl FixedRule for BetweennessCentrality {
                 let grouped = res_for_start.into_iter().chunk_by(|(n, _, _)| *n);
                 for (_, grp) in grouped.into_iter() {
                     let grp = grp.collect_vec();
+                    #[expect(
+                        clippy::cast_precision_loss,
+                        reason = "path group count acceptable as approximate float"
+                    )]
                     let l = grp.len() as f32;
                     for (_, _, path) in grp {
                         if path.len() < 3 {
@@ -71,7 +75,7 @@ impl FixedRule for BetweennessCentrality {
 
         for (i, s) in centrality.into_iter().enumerate() {
             let node = indices[i].clone();
-            out.put(vec![node, (s as f64).into()]);
+            out.put(vec![node, f64::from(s).into()]);
         }
 
         Ok(())
@@ -111,14 +115,23 @@ impl FixedRule for ClosenessCentrality {
             .map(|start| -> Result<f32> {
                 let distances = dijkstra_cost_only(&graph, start, poison.clone())?;
                 let total_dist: f32 = distances.iter().filter(|d| d.is_finite()).cloned().sum();
+                #[expect(
+                    clippy::cast_precision_loss,
+                    reason = "reachable node count acceptable as approximate float"
+                )]
                 let nc: f32 = distances.iter().filter(|d| d.is_finite()).count() as f32;
-                Ok(nc * nc / total_dist / (n - 1) as f32)
+                #[expect(
+                    clippy::cast_precision_loss,
+                    reason = "node count minus one acceptable as approximate float"
+                )]
+                let denom = (n - 1) as f32;
+                Ok(nc * nc / total_dist / denom)
             })
             .collect::<Result<_>>()?;
         for (idx, centrality) in res.into_iter().enumerate() {
             out.put(vec![
                 indices[idx].clone(),
-                DataValue::from(centrality as f64),
+                DataValue::from(f64::from(centrality)),
             ]);
             poison.check()?;
         }

--- a/crates/mneme/src/engine/fixed_rule/algos/kcore.rs
+++ b/crates/mneme/src/engine/fixed_rule/algos/kcore.rs
@@ -41,7 +41,12 @@ impl FixedRule for KCore {
 
         // Build adjacency as plain degree counts; we need the full neighbour
         // set to recompute effective degrees after removals.
-        let adj: Vec<Vec<u32>> = (0..n as u32)
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "graph node count bounded by u32"
+        )]
+        let n_u32 = n as u32;
+        let adj: Vec<Vec<u32>> = (0..n_u32)
             .map(|node| {
                 let mut nb: Vec<u32> = graph.out_neighbors(node).collect();
                 // Deduplicate: edges may have been mirrored by as_directed_graph.
@@ -52,8 +57,17 @@ impl FixedRule for KCore {
             .collect_vec();
 
         // effective_degree[v] = number of neighbours that are still alive.
-        let mut effective_degree: Vec<u32> =
-            adj.iter().map(|nb: &Vec<u32>| nb.len() as u32).collect();
+        let mut effective_degree: Vec<u32> = adj
+            .iter()
+            .map(|nb: &Vec<u32>| {
+                #[expect(
+                    clippy::cast_possible_truncation,
+                    reason = "neighbour count bounded by u32 node count"
+                )]
+                let len = nb.len() as u32;
+                len
+            })
+            .collect();
         let mut alive: Vec<bool> = vec![true; n];
         // core[v] = k-core value; starts at 0 and is promoted as we peel.
         let mut core: Vec<u32> = vec![0; n];
@@ -63,7 +77,7 @@ impl FixedRule for KCore {
         let mut k: u32 = 1;
         while k <= max_degree {
             // Collect seeds: alive nodes whose degree has dropped below k.
-            let mut queue: Vec<u32> = (0..n as u32)
+            let mut queue: Vec<u32> = (0..n_u32)
                 .filter(|&v| alive[v as usize] && effective_degree[v as usize] < k)
                 .collect();
 
@@ -96,7 +110,7 @@ impl FixedRule for KCore {
         }
 
         for (v, k_val) in core.into_iter().enumerate() {
-            out.put(vec![indices[v].clone(), DataValue::from(k_val as i64)]);
+            out.put(vec![indices[v].clone(), DataValue::from(i64::from(k_val))]);
         }
 
         Ok(())

--- a/crates/mneme/src/engine/fixed_rule/algos/kruskal.rs
+++ b/crates/mneme/src/engine/fixed_rule/algos/kruskal.rs
@@ -36,7 +36,7 @@ impl FixedRule for MinimumSpanningForestKruskal {
             out.put(vec![
                 indices[src as usize].clone(),
                 indices[dst as usize].clone(),
-                DataValue::from(cost as f64),
+                DataValue::from(f64::from(cost)),
             ]);
         }
 

--- a/crates/mneme/src/engine/fixed_rule/algos/louvain.rs
+++ b/crates/mneme/src/engine/fixed_rule/algos/louvain.rs
@@ -27,6 +27,10 @@ impl FixedRule for CommunityDetectionLouvain {
         let edges = payload.get_input(0)?;
         let undirected = payload.bool_option("undirected", Some(false))?;
         let max_iter = payload.pos_integer_option("max_iter", Some(10))?;
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "delta is a unit interval [0,1], fits in f32"
+        )]
         let delta = payload.unit_interval_option("delta", Some(0.0001))? as f32;
         let keep_depth = payload.non_neg_integer_option("keep_depth", None).ok();
 
@@ -34,10 +38,14 @@ impl FixedRule for CommunityDetectionLouvain {
         let result = louvain(&graph, delta, max_iter, poison)?;
         for (idx, node) in indices.into_iter().enumerate() {
             let mut labels = vec![];
+            #[expect(
+                clippy::cast_possible_truncation,
+                reason = "graph node count bounded by u32"
+            )]
             let mut cur_idx = idx as u32;
             for hierarchy in &result {
                 let nxt_idx = hierarchy[cur_idx as usize];
-                labels.push(DataValue::from(nxt_idx as i64));
+                labels.push(DataValue::from(i64::from(nxt_idx)));
                 cur_idx = nxt_idx;
             }
             labels.reverse();
@@ -251,7 +259,12 @@ fn louvain_step(
         vec![BTreeMap::new(); new_comm_count as usize];
     for (node, comm) in node2comm.iter().enumerate() {
         let target = &mut new_graph_list[*comm as usize];
-        for t in graph.out_neighbors_with_values(node as u32) {
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "graph node count bounded by u32"
+        )]
+        let node_u32 = node as u32;
+        for t in graph.out_neighbors_with_values(node_u32) {
             let to_node = t.target;
             let weight = t.value;
             let to_comm = node2comm[to_node as usize];
@@ -266,8 +279,14 @@ fn louvain_step(
                 .into_iter()
                 .enumerate()
                 .flat_map(move |(fr, nds)| {
-                    nds.into_iter()
-                        .map(move |(to, weight)| (fr as u32, to, weight))
+                    nds.into_iter().map(move |(to, weight)| {
+                        #[expect(
+                            clippy::cast_possible_truncation,
+                            reason = "graph node count bounded by u32"
+                        )]
+                        let fr_u32 = fr as u32;
+                        (fr_u32, to, weight)
+                    })
                 }),
         )
         .build();
@@ -305,12 +324,16 @@ mod tests {
         ];
         let graph = CsrBuilder::new()
             .sorted()
-            .edges_with_values(
-                graph
-                    .into_iter()
-                    .enumerate()
-                    .flat_map(|(fr, tos)| tos.into_iter().map(move |to| (fr as u32, to, 1.))),
-            )
+            .edges_with_values(graph.into_iter().enumerate().flat_map(|(fr, tos)| {
+                tos.into_iter().map(move |to| {
+                    #[expect(
+                        clippy::cast_possible_truncation,
+                        reason = "test graph index fits in u32"
+                    )]
+                    let fr_u32 = fr as u32;
+                    (fr_u32, to, 1.)
+                })
+            }))
             .build();
         louvain(&graph, 0., 100, Poison::default()).unwrap();
     }

--- a/crates/mneme/src/engine/fixed_rule/algos/shortest_path_dijkstra.rs
+++ b/crates/mneme/src/engine/fixed_rule/algos/shortest_path_dijkstra.rs
@@ -86,7 +86,7 @@ impl FixedRule for ShortestPathDijkstra {
                     let t = vec![
                         indices[start as usize].clone(),
                         indices[target as usize].clone(),
-                        DataValue::from(cost as f64),
+                        DataValue::from(f64::from(cost)),
                         DataValue::List(
                             path.into_iter()
                                 .map(|u| indices[u as usize].clone())
@@ -135,7 +135,7 @@ impl FixedRule for ShortestPathDijkstra {
                     let t = vec![
                         indices[start as usize].clone(),
                         indices[target as usize].clone(),
-                        DataValue::from(cost as f64),
+                        DataValue::from(f64::from(cost)),
                         DataValue::List(
                             path.into_iter()
                                 .map(|u| indices[u as usize].clone())

--- a/crates/mneme/src/engine/fixed_rule/algos/strongly_connected_components.rs
+++ b/crates/mneme/src/engine/fixed_rule/algos/strongly_connected_components.rs
@@ -120,7 +120,12 @@ impl TarjanSccG {
 
         let mut low_map: BTreeMap<u32, Vec<u32>> = BTreeMap::new();
         for (idx, grp) in self.low.into_iter().enumerate() {
-            low_map.entry(grp).or_default().push(idx as u32);
+            #[expect(
+                clippy::cast_possible_truncation,
+                reason = "graph node count bounded by u32"
+            )]
+            let idx_u32 = idx as u32;
+            low_map.entry(grp).or_default().push(idx_u32);
         }
 
         Ok(low_map.into_values().collect_vec())

--- a/crates/mneme/src/engine/fixed_rule/csr/mod.rs
+++ b/crates/mneme/src/engine/fixed_rule/csr/mod.rs
@@ -44,7 +44,12 @@ struct Csr<EV> {
 
 impl<EV> Csr<EV> {
     fn node_count(&self) -> u32 {
-        (self.offsets.len() - 1) as u32
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "graph node count bounded by u32"
+        )]
+        let count = (self.offsets.len() - 1) as u32;
+        count
     }
 
     fn degree(&self, node: u32) -> u32 {
@@ -159,10 +164,20 @@ impl<EV: Copy> CsrBuilder<EV> {
         let mut offsets = Vec::with_capacity(n + 1);
         let mut targets = Vec::new();
         for list in adj {
-            offsets.push(targets.len() as u32);
+            #[expect(
+                clippy::cast_possible_truncation,
+                reason = "edge count bounded by u32 graph capacity"
+            )]
+            let offset = targets.len() as u32;
+            offsets.push(offset);
             targets.extend(list);
         }
-        offsets.push(targets.len() as u32);
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "edge count bounded by u32 graph capacity"
+        )]
+        let final_offset = targets.len() as u32;
+        offsets.push(final_offset);
 
         Csr {
             offsets: offsets.into_boxed_slice(),

--- a/crates/mneme/src/engine/fixed_rule/csr/page_rank.rs
+++ b/crates/mneme/src/engine/fixed_rule/csr/page_rank.rs
@@ -30,11 +30,28 @@ pub(crate) fn page_rank(
     } = config;
 
     let node_count = graph.node_count() as usize;
-    let init_score = 1_f32 / node_count as f32;
-    let base_score = (1.0_f32 - damping_factor) / node_count as f32;
+    #[expect(
+        clippy::cast_precision_loss,
+        reason = "node count acceptable as approximate float for scoring"
+    )]
+    let node_count_f32 = node_count as f32;
+    let init_score = 1_f32 / node_count_f32;
+    let base_score = (1.0_f32 - damping_factor) / node_count_f32;
 
     let mut out_scores: Vec<f32> = (0..node_count)
-        .map(|n| init_score / graph.out_degree(n as u32) as f32)
+        .map(|n| {
+            #[expect(
+                clippy::cast_possible_truncation,
+                reason = "graph node count bounded by u32"
+            )]
+            let n_u32 = n as u32;
+            #[expect(
+                clippy::cast_precision_loss,
+                reason = "out-degree acceptable as approximate float"
+            )]
+            let degree_f32 = graph.out_degree(n_u32) as f32;
+            init_score / degree_f32
+        })
         .collect();
 
     let mut scores = vec![init_score; node_count];
@@ -45,8 +62,13 @@ pub(crate) fn page_rank(
         let mut error = 0_f64;
 
         for u in 0..node_count {
+            #[expect(
+                clippy::cast_possible_truncation,
+                reason = "graph node count bounded by u32"
+            )]
+            let u_u32 = u as u32;
             let incoming_total: f32 = graph
-                .in_neighbors(u as u32)
+                .in_neighbors(u_u32)
                 .map(|v| out_scores[v as usize])
                 .sum();
 
@@ -56,7 +78,12 @@ pub(crate) fn page_rank(
             scores[u] = new_score;
             error += f64::from((new_score - old_score).abs());
 
-            out_scores[u] = new_score / graph.out_degree(u as u32) as f32;
+            #[expect(
+                clippy::cast_precision_loss,
+                reason = "out-degree acceptable as approximate float"
+            )]
+            let degree_f32 = graph.out_degree(u_u32) as f32;
+            out_scores[u] = new_score / degree_f32;
         }
 
         iteration += 1;

--- a/crates/mneme/src/engine/fts/indexing.rs
+++ b/crates/mneme/src/engine/fts/indexing.rs
@@ -12,6 +12,7 @@ use crate::engine::fts::ast::{FtsExpr, FtsLiteral, FtsNear};
 use crate::engine::fts::error::TokenizationFailedSnafu;
 use crate::engine::fts::tokenizer::TextAnalyzer;
 use crate::engine::parse::fts::parse_fts_query;
+use crate::engine::runtime::error::InvalidOperationSnafu;
 use crate::engine::runtime::relation::RelationHandle;
 use crate::engine::runtime::transact::SessionTx;
 use crate::engine::{DataValue, SourceSpan};
@@ -63,7 +64,16 @@ impl FtsCache {
                                 .build(),
                             )
                         })?;
-                    let total_length = vals[3].get_int().unwrap_or(0) as u32;
+                    let total_length =
+                        u32::try_from(vals[3].get_int().unwrap_or(0)).map_err(|_e| {
+                            crate::engine::error::InternalError::from(
+                                InvalidOperationSnafu {
+                                    op: "fts_avg_dl",
+                                    reason: "document length does not fit in u32",
+                                }
+                                .build(),
+                            )
+                        })?;
                     doc_lengths
                         .entry(doc_key)
                         .and_modify(|_| {})
@@ -73,7 +83,7 @@ impl FtsCache {
                     0.0
                 } else {
                     let sum: u32 = doc_lengths.values().sum();
-                    sum as f64 / doc_lengths.len() as f64
+                    f64::from(sum) / doc_lengths.len() as f64
                 };
                 v.insert(avg);
                 avg
@@ -113,7 +123,7 @@ pub(crate) fn bm25_compute_score(
     let tf = tf as f64;
     let df = df as f64;
     let n = n as f64;
-    let dl = dl as f64;
+    let dl = f64::from(dl);
     let idf = ((n - df + 0.5) / (df + 0.5) + 1.0).ln();
     let normalized_tf = (tf * (k1 + 1.0)) / (tf + k1 * (1.0 - b + b * dl / avgdl.max(1.0)));
     idf * normalized_tf * booster
@@ -165,15 +175,34 @@ impl<'a> SessionTx<'a> {
             let positions = vals[2]
                 .get_slice()
                 .expect("FTS index val[2] (positions) is always a list");
-            let total_length = vals[3].get_int().unwrap_or(0) as u32;
+            let total_length = u32::try_from(vals[3].get_int().unwrap_or(0)).map_err(|_e| {
+                crate::engine::error::InternalError::from(
+                    InvalidOperationSnafu {
+                        op: "fts_search",
+                        reason: "document length does not fit in u32",
+                    }
+                    .build(),
+                )
+            })?;
             let position_info = froms
                 .iter()
                 .zip(tos.iter())
                 .zip(positions.iter())
-                .map(|(_, p)| PositionInfo {
-                    position: p.get_int().expect("FTS position is always an integer") as u32,
+                .map(|(_, p)| {
+                    let position =
+                        u32::try_from(p.get_int().expect("FTS position is always an integer"))
+                            .map_err(|_e| {
+                                crate::engine::error::InternalError::from(
+                                    InvalidOperationSnafu {
+                                        op: "fts_search",
+                                        reason: "token position does not fit in u32",
+                                    }
+                                    .build(),
+                                )
+                            })?;
+                    Ok(PositionInfo { position })
                 })
-                .collect_vec();
+                .collect::<Result<Vec<_>>>()?;
             results.push(LiteralStats {
                 key: key_tuple[1..].to_vec(),
                 position_info,

--- a/crates/mneme/src/engine/runtime/hnsw.rs
+++ b/crates/mneme/src/engine/runtime/hnsw.rs
@@ -52,7 +52,13 @@ impl HnswIndexManifest {
         let uniform_num: f64 = rng.random_range(0.0..1.0);
         let r = -uniform_num.ln() * self.level_multiplier;
         // the level is the largest integer smaller than r
-        -(r.floor() as i64)
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "floor of bounded float fits in i64"
+        )]
+        {
+            -(r.floor() as i64)
+        }
     }
 }
 
@@ -79,12 +85,13 @@ impl VectorCache {
         use ndarray::Zip;
         match self.distance {
             HnswDistance::L2 => match (v1, v2) {
-                (Vector::F32(a), Vector::F32(b)) => {
-                    Ok(Zip::from(a).and(b).fold(0.0f32, |acc, &x, &y| {
+                (Vector::F32(a), Vector::F32(b)) => Ok(f64::from(Zip::from(a).and(b).fold(
+                    0.0f32,
+                    |acc, &x, &y| {
                         let d = x - y;
                         acc + d * d
-                    }) as f64)
-                }
+                    },
+                ))),
                 (Vector::F64(a), Vector::F64(b)) => {
                     Ok(Zip::from(a).and(b).fold(0.0f64, |acc, &x, &y| {
                         let d = x - y;
@@ -107,7 +114,7 @@ impl VectorCache {
                         .fold((0.0f32, 0.0f32, 0.0f32), |(an, bn, d), &x, &y| {
                             (an + x * x, bn + y * y, d + x * y)
                         });
-                    Ok(1.0 - dot as f64 / (a_norm as f64 * b_norm as f64).sqrt())
+                    Ok(1.0 - f64::from(dot) / (f64::from(a_norm) * f64::from(b_norm)).sqrt())
                 }
                 (Vector::F64(a), Vector::F64(b)) => {
                     let (a_norm, b_norm, dot) = Zip::from(a)
@@ -132,7 +139,7 @@ impl VectorCache {
             HnswDistance::InnerProduct => match (v1, v2) {
                 (Vector::F32(a), Vector::F32(b)) => {
                     let dot = a.dot(b);
-                    Ok(1. - dot as f64)
+                    Ok(1. - f64::from(dot))
                 }
                 (Vector::F64(a), Vector::F64(b)) => {
                     let dot = a.dot(b);
@@ -195,7 +202,9 @@ impl VectorCache {
                     if key.2 >= 0 {
                         match field {
                             DataValue::List(l) => {
-                                field = &l[key.2 as usize];
+                                #[expect(clippy::cast_sign_loss, reason = "guarded by >= 0 check")]
+                                let sub = key.2 as usize;
+                                field = &l[sub];
                             }
                             _ => {
                                 return Err(InvalidOperationSnafu {
@@ -258,7 +267,7 @@ impl<'a> SessionTx<'a> {
         for _ in 0..2 {
             canary_tuple.extend_from_slice(tuple_key);
             canary_tuple.push(DataValue::from(idx as i64));
-            canary_tuple.push(DataValue::from(subidx as i64));
+            canary_tuple.push(DataValue::from(i64::from(subidx)));
         }
         if let Some(v) = idx_table.get(self, &canary_tuple)? {
             if let DataValue::Bytes(b) = &v[tuple_key.len() * 2 + 6]
@@ -284,14 +293,30 @@ impl<'a> SessionTx<'a> {
                 .get_int()
                 .expect("HNSW index stores integers at this position");
             let ep_t_key = ep[1..orig_table.metadata.keys.len() + 1].to_vec();
-            let ep_idx = ep[orig_table.metadata.keys.len() + 1]
-                .get_int()
-                .expect("HNSW index stores integers at this position")
-                as usize;
-            let ep_subidx = ep[orig_table.metadata.keys.len() + 2]
-                .get_int()
-                .expect("HNSW index stores integers at this position")
-                as i32;
+            let ep_idx = usize::try_from(
+                ep[orig_table.metadata.keys.len() + 1]
+                    .get_int()
+                    .expect("HNSW index stores integers at this position"),
+            )
+            .map_err(|_e| {
+                InvalidOperationSnafu {
+                    op: "hnsw_read",
+                    reason: "stored index out of range",
+                }
+                .build()
+            })?;
+            let ep_subidx = i32::try_from(
+                ep[orig_table.metadata.keys.len() + 2]
+                    .get_int()
+                    .expect("HNSW index stores integers at this position"),
+            )
+            .map_err(|_e| {
+                InvalidOperationSnafu {
+                    op: "hnsw_read",
+                    reason: "stored subindex out of range",
+                }
+                .build()
+            })?;
             let ep_key = (ep_t_key, ep_idx, ep_subidx);
             vec_cache.ensure_key(&ep_key, orig_table, self)?;
             let ep_distance = vec_cache.v_dist(q, &ep_key)?;
@@ -328,7 +353,7 @@ impl<'a> SessionTx<'a> {
             for _ in 0..2 {
                 self_tuple_key.extend_from_slice(tuple_key);
                 self_tuple_key.push(DataValue::from(idx as i64));
-                self_tuple_key.push(DataValue::from(subidx as i64));
+                self_tuple_key.push(DataValue::from(i64::from(subidx)));
             }
             let mut self_tuple_val = vec![
                 DataValue::from(0.0),
@@ -383,10 +408,10 @@ impl<'a> SessionTx<'a> {
                     out_key.push(DataValue::from(current_level));
                     out_key.extend_from_slice(tuple_key);
                     out_key.push(DataValue::from(idx as i64));
-                    out_key.push(DataValue::from(subidx as i64));
+                    out_key.push(DataValue::from(i64::from(subidx)));
                     out_key.extend_from_slice(&neighbour.0);
                     out_key.push(DataValue::from(neighbour.1 as i64));
-                    out_key.push(DataValue::from(neighbour.2 as i64));
+                    out_key.push(DataValue::from(i64::from(neighbour.2)));
                     let out_key_bytes =
                         idx_table.encode_key_for_store(&out_key, Default::default())?;
                     let out_val_bytes =
@@ -402,10 +427,10 @@ impl<'a> SessionTx<'a> {
                     in_key.push(DataValue::from(current_level));
                     in_key.extend_from_slice(&neighbour.0);
                     in_key.push(DataValue::from(neighbour.1 as i64));
-                    in_key.push(DataValue::from(neighbour.2 as i64));
+                    in_key.push(DataValue::from(i64::from(neighbour.2)));
                     in_key.extend_from_slice(tuple_key);
                     in_key.push(DataValue::from(idx as i64));
-                    in_key.push(DataValue::from(subidx as i64));
+                    in_key.push(DataValue::from(i64::from(subidx)));
 
                     let in_key_bytes =
                         idx_table.encode_key_for_store(&in_key, Default::default())?;
@@ -420,7 +445,7 @@ impl<'a> SessionTx<'a> {
                     for _ in 0..2 {
                         target_self_key.extend_from_slice(&neighbour.0);
                         target_self_key.push(DataValue::from(neighbour.1 as i64));
-                        target_self_key.push(DataValue::from(neighbour.2 as i64));
+                        target_self_key.push(DataValue::from(i64::from(neighbour.2)));
                     }
                     let target_self_key_bytes =
                         idx_table.encode_key_for_store(&target_self_key, Default::default())?;
@@ -443,6 +468,11 @@ impl<'a> SessionTx<'a> {
                                 }
                                 .build(),
                             })?;
+                    #[expect(
+                        clippy::cast_possible_truncation,
+                        clippy::cast_sign_loss,
+                        reason = "degree is a small non-negative integer stored as f64"
+                    )]
                     let mut target_degree = target_self_val[0]
                         .get_float()
                         .expect("HNSW index stores floats at this position")
@@ -533,10 +563,10 @@ impl<'a> SessionTx<'a> {
                 new_key.push(DataValue::from(level));
                 new_key.extend_from_slice(&target_key.0);
                 new_key.push(DataValue::from(target_key.1 as i64));
-                new_key.push(DataValue::from(target_key.2 as i64));
+                new_key.push(DataValue::from(i64::from(target_key.2)));
                 new_key.extend_from_slice(&new.0);
                 new_key.push(DataValue::from(new.1 as i64));
-                new_key.push(DataValue::from(new.2 as i64));
+                new_key.push(DataValue::from(i64::from(new.2)));
                 let new_key_bytes = idx_table.encode_key_for_store(&new_key, Default::default())?;
                 let new_val_bytes =
                     idx_table.encode_val_only_for_store(&new_val, Default::default())?;
@@ -549,10 +579,10 @@ impl<'a> SessionTx<'a> {
                 old_key.push(DataValue::from(level));
                 old_key.extend_from_slice(&target_key.0);
                 old_key.push(DataValue::from(target_key.1 as i64));
-                old_key.push(DataValue::from(target_key.2 as i64));
+                old_key.push(DataValue::from(i64::from(target_key.2)));
                 old_key.extend_from_slice(&old.0);
                 old_key.push(DataValue::from(old.1 as i64));
-                old_key.push(DataValue::from(old.2 as i64));
+                old_key.push(DataValue::from(i64::from(old.2)));
                 let old_key_bytes = idx_table.encode_key_for_store(&old_key, Default::default())?;
                 let old_existing_val = match self.store_tx.get(&old_key_bytes, false)? {
                     Some(bytes) => bytes,
@@ -718,17 +748,22 @@ impl<'a> SessionTx<'a> {
         start_tuple.push(DataValue::from(level));
         start_tuple.extend_from_slice(&cand_key.0);
         start_tuple.push(DataValue::from(cand_key.1 as i64));
-        start_tuple.push(DataValue::from(cand_key.2 as i64));
+        start_tuple.push(DataValue::from(i64::from(cand_key.2)));
         let key_len = cand_key.0.len();
         Ok(idx_handle
             .scan_prefix(self, &start_tuple)
             .filter_map(move |res| {
                 let tuple = res.ok()?;
 
+                #[expect(clippy::cast_sign_loss, reason = "HNSW indices are non-negative")]
                 let key_idx = tuple[2 * key_len + 3]
                     .get_int()
                     .expect("HNSW index stores integers at this position")
                     as usize;
+                #[expect(
+                    clippy::cast_possible_truncation,
+                    reason = "HNSW subindex bounded by m_max (< i32::MAX)"
+                )]
                 let key_subidx = tuple[2 * key_len + 4]
                     .get_int()
                     .expect("HNSW index stores integers at this position")
@@ -780,7 +815,7 @@ impl<'a> SessionTx<'a> {
                 canary_key.push(DataValue::Null);
             }
             target_key.push(DataValue::from(idx as i64));
-            target_key.push(DataValue::from(subidx as i64));
+            target_key.push(DataValue::from(i64::from(subidx)));
             canary_key.push(DataValue::Null);
             canary_key.push(DataValue::Null);
         }
@@ -835,7 +870,12 @@ impl<'a> SessionTx<'a> {
             } else if let DataValue::List(l) = val {
                 for (sidx, v) in l.iter().enumerate() {
                     if let DataValue::Vec(v) = v {
-                        extracted_vectors.push((v, *idx, sidx as i32));
+                        #[expect(
+                            clippy::cast_possible_truncation,
+                            reason = "HNSW layer indices bounded by m_max (< i32::MAX)"
+                        )]
+                        let sidx_i32 = sidx as i32;
+                        extracted_vectors.push((v, *idx, sidx_i32));
                     }
                 }
             }
@@ -869,19 +909,26 @@ impl<'a> SessionTx<'a> {
         let candidates: FxHashSet<_> = idx_table
             .scan_prefix(self, &prefix)
             .filter_map(|t| match t {
-                Ok(t) => Some({
-                    (
+                Ok(t) => {
+                    #[expect(clippy::cast_sign_loss, reason = "HNSW indices are non-negative")]
+                    let idx = t[orig_table.metadata.keys.len() + 1]
+                        .get_int()
+                        .expect("HNSW index stores integers at this position")
+                        as usize;
+                    #[expect(
+                        clippy::cast_possible_truncation,
+                        reason = "HNSW subindex bounded by m_max (< i32::MAX)"
+                    )]
+                    let subidx = t[orig_table.metadata.keys.len() + 2]
+                        .get_int()
+                        .expect("HNSW index stores integers at this position")
+                        as i32;
+                    Some((
                         t[1..orig_table.metadata.keys.len() + 1].to_vec(),
-                        t[orig_table.metadata.keys.len() + 1]
-                            .get_int()
-                            .expect("HNSW index stores integers at this position")
-                            as usize,
-                        t[orig_table.metadata.keys.len() + 2]
-                            .get_int()
-                            .expect("HNSW index stores integers at this position")
-                            as i32,
-                    )
-                }),
+                        idx,
+                        subidx,
+                    ))
+                }
                 Err(_) => None,
             })
             .collect();
@@ -907,7 +954,7 @@ impl<'a> SessionTx<'a> {
             for _ in 0..2 {
                 self_key.extend_from_slice(tuple_key);
                 self_key.push(DataValue::from(idx as i64));
-                self_key.push(DataValue::from(subidx as i64));
+                self_key.push(DataValue::from(i64::from(subidx)));
             }
             let self_key_bytes = idx_table.encode_key_for_store(&self_key, Default::default())?;
             if self.store_tx.exists(&self_key_bytes, false)? {
@@ -926,26 +973,26 @@ impl<'a> SessionTx<'a> {
                 let mut out_key = vec![DataValue::from(layer)];
                 out_key.extend_from_slice(tuple_key);
                 out_key.push(DataValue::from(idx as i64));
-                out_key.push(DataValue::from(subidx as i64));
+                out_key.push(DataValue::from(i64::from(subidx)));
                 out_key.extend_from_slice(&neighbour_key.0);
                 out_key.push(DataValue::from(neighbour_key.1 as i64));
-                out_key.push(DataValue::from(neighbour_key.2 as i64));
+                out_key.push(DataValue::from(i64::from(neighbour_key.2)));
                 let out_key_bytes = idx_table.encode_key_for_store(&out_key, Default::default())?;
                 self.store_tx.del(&out_key_bytes)?;
                 let mut in_key = vec![DataValue::from(layer)];
                 in_key.extend_from_slice(&neighbour_key.0);
                 in_key.push(DataValue::from(neighbour_key.1 as i64));
-                in_key.push(DataValue::from(neighbour_key.2 as i64));
+                in_key.push(DataValue::from(i64::from(neighbour_key.2)));
                 in_key.extend_from_slice(tuple_key);
                 in_key.push(DataValue::from(idx as i64));
-                in_key.push(DataValue::from(subidx as i64));
+                in_key.push(DataValue::from(i64::from(subidx)));
                 let in_key_bytes = idx_table.encode_key_for_store(&in_key, Default::default())?;
                 self.store_tx.del(&in_key_bytes)?;
                 let mut neighbour_self_key = vec![DataValue::from(layer)];
                 for _ in 0..2 {
                     neighbour_self_key.extend_from_slice(&neighbour_key.0);
                     neighbour_self_key.push(DataValue::from(neighbour_key.1 as i64));
-                    neighbour_self_key.push(DataValue::from(neighbour_key.2 as i64));
+                    neighbour_self_key.push(DataValue::from(i64::from(neighbour_key.2)));
                 }
                 let neighbour_val_bytes = match self
                     .store_tx
@@ -1043,8 +1090,15 @@ impl<'a> SessionTx<'a> {
         let q = match (q, config.manifest.dtype) {
             (v @ Vector::F32(_), VecElementType::F32) => v,
             (v @ Vector::F64(_), VecElementType::F64) => v,
-            (Vector::F32(v), VecElementType::F64) => Vector::F64(v.mapv(|x| x as f64)),
-            (Vector::F64(v), VecElementType::F32) => Vector::F32(v.mapv(|x| x as f32)),
+            (Vector::F32(v), VecElementType::F64) => Vector::F64(v.mapv(f64::from)),
+            (Vector::F64(v), VecElementType::F32) => {
+                #[expect(
+                    clippy::cast_possible_truncation,
+                    reason = "intentional F64→F32 precision reduction for vector storage"
+                )]
+                let converted = v.mapv(|x| x as f32);
+                Vector::F32(converted)
+            }
         };
 
         let mut vec_cache =
@@ -1065,17 +1119,31 @@ impl<'a> SessionTx<'a> {
                 .get_int()
                 .expect("HNSW index stores integers at this position");
             let ep_idx = match ep[config.base_handle.metadata.keys.len() + 1].get_int() {
-                Some(x) => x as usize,
+                Some(x) => usize::try_from(x).map_err(|_e| {
+                    InvalidOperationSnafu {
+                        op: "hnsw_read",
+                        reason: "stored index out of range",
+                    }
+                    .build()
+                })?,
                 None => {
                     // this occurs if the index is empty
                     return Ok(vec![]);
                 }
             };
             let ep_t_key = ep[1..config.base_handle.metadata.keys.len() + 1].to_vec();
-            let ep_subidx = ep[config.base_handle.metadata.keys.len() + 2]
-                .get_int()
-                .expect("HNSW index stores integers at this position")
-                as i32;
+            let ep_subidx = i32::try_from(
+                ep[config.base_handle.metadata.keys.len() + 2]
+                    .get_int()
+                    .expect("HNSW index stores integers at this position"),
+            )
+            .map_err(|_e| {
+                InvalidOperationSnafu {
+                    op: "hnsw_read",
+                    reason: "stored subindex out of range",
+                }
+                .build()
+            })?;
             let ep_key = (ep_t_key, ep_idx, ep_subidx);
             vec_cache.ensure_key(&ep_key, &config.base_handle, self)?;
             let ep_distance = vec_cache.v_dist(&q, &ep_key)?;
@@ -1147,7 +1215,7 @@ impl<'a> SessionTx<'a> {
                     cand_tuple.push(if cand_key.2 < 0 {
                         DataValue::Null
                     } else {
-                        DataValue::from(cand_key.2 as i64)
+                        DataValue::from(i64::from(cand_key.2))
                     });
                 }
                 if config.bind_distance.is_some() {
@@ -1158,7 +1226,11 @@ impl<'a> SessionTx<'a> {
                         cand_tuple[cand_key.1].clone()
                     } else {
                         match &cand_tuple[cand_key.1] {
-                            DataValue::List(v) => v[cand_key.2 as usize].clone(),
+                            DataValue::List(v) => {
+                                #[expect(clippy::cast_sign_loss, reason = "guarded by >= 0 check")]
+                                let sub = cand_key.2 as usize;
+                                v[sub].clone()
+                            }
                             v => {
                                 return Err(InvalidOperationSnafu {
                                     op: "hnsw_index",
@@ -1191,7 +1263,12 @@ impl<'a> SessionTx<'a> {
 }
 
 #[cfg(test)]
-#[expect(clippy::unwrap_used, reason = "test assertions")]
+#[expect(
+    clippy::unwrap_used,
+    clippy::cast_possible_truncation,
+    clippy::cast_precision_loss,
+    reason = "test assertions and test-only numeric casts"
+)]
 mod tests {
     use rand::Rng;
     use std::collections::BTreeMap;

--- a/crates/mneme/src/engine/runtime/minhash_lsh.rs
+++ b/crates/mneme/src/engine/runtime/minhash_lsh.rs
@@ -141,7 +141,7 @@ impl<'a> SessionTx<'a> {
         let chunks = (0..manifest.n_bands)
             .map(|i| {
                 let mut byte_range = bytes[i * chunk_size..(i + 1) * chunk_size].to_vec();
-                byte_range.extend_from_slice(&(i as u16).to_le_bytes());
+                byte_range.extend_from_slice(&u16::try_from(i).unwrap_or(u16::MAX).to_le_bytes());
                 byte_range
             })
             .collect_vec();
@@ -206,7 +206,7 @@ impl<'a> SessionTx<'a> {
         for (i, chunk) in bytes.chunks_exact(chunk_size).enumerate() {
             key_prefix.clear();
             let mut chunk = chunk.to_vec();
-            chunk.extend_from_slice(&(i as u16).to_le_bytes());
+            chunk.extend_from_slice(&u16::try_from(i).unwrap_or(u16::MAX).to_le_bytes());
             key_prefix.push(DataValue::Bytes(chunk));
             for ks in config.idx_handle.scan_prefix(self, &key_prefix) {
                 let ks = ks?;
@@ -332,11 +332,19 @@ impl LshParams {
     }
 
     fn false_positive_probability(threshold: f64, b: usize, r: usize) -> f64 {
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "r is bounded by num_perm which fits in i32 for practical hash sizes"
+        )]
         let probability = |s| -> f64 { 1. - f64::powf(1. - f64::powi(s, r as i32), b as f64) };
         integrate_simpson(probability, 0.0, threshold, 100)
     }
 
     fn false_negative_probability(threshold: f64, b: usize, r: usize) -> f64 {
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "r is bounded by num_perm which fits in i32 for practical hash sizes"
+        )]
         let probability =
             |s| -> f64 { 1. - (1. - f64::powf(1. - f64::powi(s, r as i32), b as f64)) };
         integrate_simpson(probability, threshold, 1.0, 100)
@@ -388,6 +396,10 @@ impl HashValues {
             for (i, seed) in perms.0.iter().enumerate() {
                 let mut hasher = XxHash32::with_seed(*seed);
                 v.hash(&mut hasher);
+                #[expect(
+                    clippy::cast_possible_truncation,
+                    reason = "intentional hash truncation to u32"
+                )]
                 let hash = hasher.finish() as u32;
                 self.0[i] = min(self.0[i], hash);
             }
@@ -402,7 +414,13 @@ impl HashValues {
             .filter(|(left, right)| left == right)
             .count();
 
-        matches as f32 / self.0.len() as f32
+        #[expect(
+            clippy::cast_precision_loss,
+            reason = "minhash vector lengths are small; precision loss is negligible"
+        )]
+        {
+            matches as f32 / self.0.len() as f32
+        }
     }
     pub(crate) fn get_bytes(&self) -> &[u8] {
         bytemuck::cast_slice(&self.0)

--- a/crates/theatron/tui/src/state/virtual_scroll.rs
+++ b/crates/theatron/tui/src/state/virtual_scroll.rs
@@ -66,7 +66,7 @@ impl VirtualScroll {
     pub(crate) fn push_item(&mut self, height: u16) {
         let prev_sum = self.prefix_sums.last().copied().unwrap_or(0);
         self.item_heights.push(height);
-        self.prefix_sums.push(prev_sum + height as u64);
+        self.prefix_sums.push(prev_sum + u64::from(height));
     }
 
     /// Clear all cached heights (e.g. on session switch).
@@ -88,7 +88,7 @@ impl VirtualScroll {
         let mut running = 0u64;
         for &h in heights {
             self.item_heights.push(h);
-            running += h as u64;
+            running += u64::from(h);
             self.prefix_sums.push(running);
         }
     }
@@ -105,7 +105,7 @@ impl VirtualScroll {
         viewport_height: u16,
     ) -> ViewportSlice {
         let total = self.total_height();
-        let vh = viewport_height as u64;
+        let vh = u64::from(viewport_height);
 
         if total == 0 || self.item_heights.is_empty() {
             return ViewportSlice {
@@ -129,7 +129,8 @@ impl VirtualScroll {
         let last_item = self.item_at_line(bottom_line.min(total));
 
         let first_item_start = self.prefix_sums[first_item];
-        let line_offset = top_line.saturating_sub(first_item_start) as u16;
+        let line_offset =
+            u16::try_from(top_line.saturating_sub(first_item_start)).unwrap_or(u16::MAX);
 
         let start = first_item.saturating_sub(self.buffer);
         let end = (last_item + 1 + self.buffer).min(self.item_heights.len());
@@ -140,7 +141,9 @@ impl VirtualScroll {
                 // NOTE: Buffer items above are rendered; add their height so the
                 // line_offset is relative to the start of the rendered range, not first_item.
                 let buffer_height: u64 = self.prefix_sums[first_item] - self.prefix_sums[start];
-                (buffer_height as u16).saturating_add(line_offset)
+                u16::try_from(buffer_height)
+                    .unwrap_or(u16::MAX)
+                    .saturating_add(line_offset)
             } else {
                 line_offset
             },
@@ -175,7 +178,7 @@ impl VirtualScroll {
         viewport_height: u16,
     ) -> Option<(f64, f64)> {
         let total = self.total_height();
-        let vh = viewport_height as u64;
+        let vh = u64::from(viewport_height);
 
         if total <= vh {
             return None;
@@ -205,13 +208,13 @@ impl VirtualScroll {
 /// - text content wrapped at `width`
 /// - 1 trailing blank line
 pub(crate) fn estimate_message_height(text_len: usize, has_tools: bool, width: u16) -> u16 {
-    let w = width.max(1) as usize;
+    let w = usize::from(width.max(1));
     let header = 1u16;
     let tools = if has_tools { 1u16 } else { 0 };
     let content = if text_len == 0 {
         0u16
     } else {
-        (text_len / w + 1).min(u16::MAX as usize) as u16
+        u16::try_from(text_len / w + 1).unwrap_or(u16::MAX)
     };
     let blank = 1u16;
 

--- a/crates/theatron/tui/src/view/chat.rs
+++ b/crates/theatron/tui/src/view/chat.rs
@@ -22,7 +22,7 @@ struct MessageCtx<'a> {
 }
 
 pub fn render(app: &App, frame: &mut Frame, area: Rect, theme: &Theme) -> Vec<OscLink> {
-    let inner_width = area.width.saturating_sub(2) as usize;
+    let inner_width = usize::from(area.width.saturating_sub(2));
     let wrap_width = area.width.saturating_sub(2).max(1);
     // With Borders::NONE the paragraph has the full area height available.
     let visible_height = area.height;
@@ -109,7 +109,7 @@ pub fn render(app: &App, frame: &mut Frame, area: Rect, theme: &Theme) -> Vec<Os
     // the bottom by prepending empty lines.  Only applies when not scrolled
     // (content fits in the viewport).
     {
-        let w = wrap_width.max(1) as usize;
+        let w = usize::from(wrap_width.max(1));
         let total_visual: usize = lines
             .iter()
             .map(|line| {
@@ -117,7 +117,7 @@ pub fn render(app: &App, frame: &mut Frame, area: Rect, theme: &Theme) -> Vec<Os
                 if lw == 0 { 1 } else { lw.div_ceil(w) }
             })
             .sum();
-        let padding = (visible_height as usize).saturating_sub(total_visual);
+        let padding = usize::from(visible_height).saturating_sub(total_visual);
         if padding > 0 {
             let mut padded: Vec<Line<'static>> = vec![Line::raw(""); padding];
             padded.append(&mut lines);
@@ -138,12 +138,12 @@ pub fn render(app: &App, frame: &mut Frame, area: Rect, theme: &Theme) -> Vec<Os
     // Total visual rows of the final rendered lines vector (after padding + streaming).
     // Used for auto-scroll so that streaming content appended after virtual render is
     // always visible when the user is at the bottom.
-    let w = wrap_width.max(1) as usize;
+    let w = usize::from(wrap_width.max(1));
     let total_visual: usize = line_widths
         .iter()
         .map(|&lw| if lw == 0 { 1 } else { lw.div_ceil(w) })
         .sum();
-    let vh = visible_height as usize;
+    let vh = usize::from(visible_height);
 
     let scroll = if app.auto_scroll {
         // Pin to the very bottom of whatever was rendered (committed + streaming).
@@ -159,14 +159,14 @@ pub fn render(app: &App, frame: &mut Frame, area: Rect, theme: &Theme) -> Vec<Os
         let slice =
             app.virtual_scroll
                 .visible_slice(app.scroll_offset, app.auto_scroll, visible_height);
-        slice.line_offset as usize
+        usize::from(slice.line_offset)
     };
 
     let block = Block::default().borders(Borders::NONE);
     let paragraph = Paragraph::new(lines)
         .block(block)
         .wrap(Wrap { trim: false })
-        .scroll((scroll as u16, 0));
+        .scroll((u16::try_from(scroll).unwrap_or(u16::MAX), 0));
 
     frame.render_widget(paragraph, area);
 
@@ -175,8 +175,8 @@ pub fn render(app: &App, frame: &mut Frame, area: Rect, theme: &Theme) -> Vec<Os
         &para_links,
         &line_widths,
         area,
-        scroll as u16,
-        wrap_width as usize,
+        u16::try_from(scroll).unwrap_or(u16::MAX),
+        usize::from(wrap_width),
         theme,
     )
 }
@@ -209,11 +209,15 @@ fn resolve_osc_links(
     let mut cumulative: u32 = 0;
     for &w in line_widths {
         visual_row_start.push(cumulative);
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "terminal dimensions fit in u32"
+        )]
         let rows = if w == 0 { 1 } else { w.div_ceil(wrap_width) } as u32;
         cumulative += rows;
     }
 
-    let visible_height = area.height as i32;
+    let visible_height = i32::from(area.height);
     let mut osc_links = Vec::with_capacity(para_links.len());
 
     for (line_idx, col, text, url) in para_links {
@@ -222,20 +226,25 @@ fn resolve_osc_links(
         };
         // Adjust for which visual row within the wrapped line this col sits on.
         let col_row = if wrap_width > 0 {
-            (*col as usize) / wrap_width
+            usize::from(*col) / wrap_width
         } else {
             0
         };
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "visual row count fits in i32 for terminal"
+        )]
         let vrow = vrow_start as i32 + col_row as i32;
 
         // Apply scroll: positive scroll shifts content upward (scroll=0 means show from top).
-        let screen_row = vrow - scroll as i32;
+        let screen_row = vrow - i32::from(scroll);
         if screen_row < 0 || screen_row >= visible_height {
             continue; // link is outside the visible window
         }
 
-        let screen_x = area.x + (*col as usize % wrap_width.max(1)) as u16;
-        let screen_y = area.y + screen_row as u16;
+        let screen_x =
+            area.x + u16::try_from(usize::from(*col) % wrap_width.max(1)).unwrap_or(u16::MAX);
+        let screen_y = area.y + u16::try_from(screen_row).unwrap_or(0);
 
         osc_links.push(OscLink {
             screen_x,
@@ -399,7 +408,7 @@ fn render_message(
         &app.highlighter,
     );
     let content_prefix = if ctx.selected { "│" } else { " " };
-    let prefix_width: u16 = content_prefix.len() as u16; // always 1 byte for these strings
+    let prefix_width: u16 = u16::try_from(content_prefix.len()).unwrap_or(u16::MAX); // always 1 byte for these strings
     let prefix_style = if ctx.selected {
         Style::default().fg(theme.borders.selected)
     } else {

--- a/crates/theatron/tui/src/view/image.rs
+++ b/crates/theatron/tui/src/view/image.rs
@@ -10,7 +10,7 @@ const IMAGE_EXTENSIONS: &[&str] = &["png", "jpg", "jpeg", "gif", "webp", "bmp"];
 
 /// Maximum height for inline image previews (in terminal rows).
 /// Each row uses half-block characters representing two pixel rows.
-const MAX_IMAGE_HEIGHT: usize = 20;
+const MAX_IMAGE_HEIGHT: u32 = 20;
 
 /// Maximum number of cached image renders before eviction.
 const MAX_CACHE_ENTRIES: usize = 32;
@@ -194,15 +194,27 @@ fn load_and_render_halfblocks(path: &Path, max_width: usize) -> Vec<Line<'static
     }
 
     // Reserve 2 columns for left margin
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "terminal dimensions fit in u32"
+    )]
     let avail_width = max_width.saturating_sub(2).max(1) as u32;
-    let max_pixel_h = (MAX_IMAGE_HEIGHT as u32) * 2;
+    let max_pixel_h = MAX_IMAGE_HEIGHT * 2;
 
-    let scale_w = avail_width as f64 / orig_w as f64;
-    let scale_h = max_pixel_h as f64 / orig_h as f64;
+    let scale_w = f64::from(avail_width) / f64::from(orig_w);
+    let scale_h = f64::from(max_pixel_h) / f64::from(orig_h);
     let scale = scale_w.min(scale_h).min(1.0);
 
-    let new_w = ((orig_w as f64 * scale) as u32).max(1);
-    let new_h = ((orig_h as f64 * scale) as u32).max(1);
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "scaled dimension bounded by original u32 dimension"
+    )]
+    let new_w = ((f64::from(orig_w) * scale) as u32).max(1);
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "scaled dimension bounded by original u32 dimension"
+    )]
+    let new_h = ((f64::from(orig_h) * scale) as u32).max(1);
 
     let resized =
         image::imageops::resize(&img, new_w, new_h, image::imageops::FilterType::Triangle);
@@ -225,7 +237,7 @@ fn load_and_render_halfblocks(path: &Path, max_width: usize) -> Vec<Line<'static
     // Pixel rows → half-block text rows
     let mut y = 0u32;
     while y < new_h {
-        let mut spans: Vec<Span<'static>> = Vec::with_capacity(new_w as usize + 1);
+        let mut spans: Vec<Span<'static>> = Vec::with_capacity(new_w as usize + 1); // u32→usize: widening on 32/64-bit
         spans.push(Span::raw("  ")); // left margin
 
         for x in 0..new_w {

--- a/crates/theatron/tui/src/view/input.rs
+++ b/crates/theatron/tui/src/view/input.rs
@@ -20,8 +20,8 @@ pub fn render(app: &App, frame: &mut Frame, area: Rect, theme: &Theme) {
 
     // NOTE: ASCII-only prompt: bytes equal display columns
     let prompt_width = prompt_str.len();
-    let content_width = area.width.max(1) as usize;
-    let visible_rows = area.height.saturating_sub(1) as usize;
+    let content_width = usize::from(area.width.max(1));
+    let visible_rows = usize::from(area.height.saturating_sub(1));
 
     let text = app.input.text.as_str();
     let cursor_byte = app.input.cursor;
@@ -33,7 +33,7 @@ pub fn render(app: &App, frame: &mut Frame, area: Rect, theme: &Theme) {
         cursor_visual_position(&line_ranges, text, cursor_byte, prompt_width);
 
     let scroll = if visible_rows > 0 {
-        (cursor_row as usize).saturating_sub(visible_rows - 1)
+        usize::from(cursor_row).saturating_sub(visible_rows - 1)
     } else {
         0
     };
@@ -73,11 +73,11 @@ pub fn render(app: &App, frame: &mut Frame, area: Rect, theme: &Theme) {
 
     let paragraph = Paragraph::new(Text::from(ratatui_lines))
         .block(block)
-        .scroll((scroll as u16, 0));
+        .scroll((u16::try_from(scroll).unwrap_or(u16::MAX), 0));
     frame.render_widget(paragraph, area);
 
-    let visible_row = (cursor_row as usize).saturating_sub(scroll);
-    let cursor_y = area.y + 1 + visible_row as u16;
+    let visible_row = usize::from(cursor_row).saturating_sub(scroll);
+    let cursor_y = area.y + 1 + u16::try_from(visible_row).unwrap_or(u16::MAX);
     let cursor_x = area.x + cursor_col;
     frame.set_cursor_position((cursor_x, cursor_y));
 }
@@ -180,7 +180,10 @@ pub(crate) fn cursor_visual_position(
             } else {
                 col_display
             };
-            return (row as u16, col as u16);
+            return (
+                u16::try_from(row).unwrap_or(u16::MAX),
+                u16::try_from(col).unwrap_or(u16::MAX),
+            );
         }
     }
 
@@ -195,10 +198,13 @@ pub(crate) fn cursor_visual_position(
         } else {
             col_display
         };
-        return (last_row as u16, col as u16);
+        return (
+            u16::try_from(last_row).unwrap_or(u16::MAX),
+            u16::try_from(col).unwrap_or(u16::MAX),
+        );
     }
 
-    (0, prompt_width as u16)
+    (0, u16::try_from(prompt_width).unwrap_or(u16::MAX))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- Replace risky `as` casts with safe numeric conversions (try_into, saturating casts)

## Test plan
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes