### PR TITLE
feat(nous): use Haiku-tier model for prosoche heartbeat sessions

### DIFF
--- a/crates/aletheia/src/commands/server.rs
+++ b/crates/aletheia/src/commands/server.rs
@@ -350,6 +350,7 @@ pub async fn run(args: Args) -> Result<()> {
                 session_token_cap: 500_000,
                 recall: resolved.recall.into(),
                 chars_per_token: resolved.limits.chars_per_token,
+                prosoche_model: resolved.prosoche_model,
             };
             nous_manager
                 .spawn(

--- a/crates/aletheia/src/server.rs
+++ b/crates/aletheia/src/server.rs
@@ -290,6 +290,7 @@ pub(crate) async fn serve(cli: Cli) -> Result<()> {
                 domains,
                 server_tools: Vec::new(),
                 cache_enabled: resolved.capabilities.cache_enabled,
+                prosoche_model: resolved.prosoche_model,
             };
             nous_manager
                 .spawn(

--- a/crates/nous/src/actor/turn.rs
+++ b/crates/nous/src/actor/turn.rs
@@ -370,7 +370,13 @@ impl NousActor {
                 // WHY: cross-nous messages carry no database session ID: generate one so finalize can create the DB row
                 let id = SessionId::new().to_string();
                 debug!(session_key, session_id = %id, "creating new session");
-                SessionState::new(id, session_key.to_owned(), &self.config)
+                let mut state = SessionState::new(id, session_key.to_owned(), &self.config);
+                // WHY: prosoche heartbeat sessions use a cheap model to avoid
+                // wasting Opus-tier capacity on routine health checks.
+                if crate::session::SessionManager::is_background(session_key) {
+                    state.model.clone_from(&self.config.prosoche_model);
+                }
+                state
             });
 
         session.next_turn();

--- a/crates/nous/src/config.rs
+++ b/crates/nous/src/config.rs
@@ -57,6 +57,12 @@ pub struct NousConfig {
     /// heuristic. Wired from `agents.defaults.chars_per_token` at startup.
     #[serde(default = "default_chars_per_token")]
     pub chars_per_token: u32,
+    /// Model to use for prosoche heartbeat sessions instead of the primary model.
+    ///
+    /// Prosoche checks are simple health/attention tasks that don't need
+    /// advanced reasoning. Defaults to Haiku-tier to reduce cost.
+    #[serde(default = "default_prosoche_model")]
+    pub prosoche_model: String,
 }
 
 fn default_cache_enabled() -> bool {
@@ -72,6 +78,11 @@ fn default_chars_per_token() -> u32 {
     //      the serde default (used when deserialising NousConfig directly)
     //      is identical to the value wired at startup via ResolvedNousConfig.
     4
+}
+
+/// Default prosoche model: Haiku-tier for cheap heartbeat checks.
+fn default_prosoche_model() -> String {
+    "claude-haiku-4-5-20251001".to_owned()
 }
 
 impl Default for NousConfig {
@@ -93,6 +104,7 @@ impl Default for NousConfig {
             session_token_cap: default_session_token_cap(),
             recall: RecallConfig::default(),
             chars_per_token: default_chars_per_token(),
+            prosoche_model: default_prosoche_model(),
         }
     }
 }
@@ -224,10 +236,17 @@ mod tests {
             session_token_cap: 250_000,
             recall: RecallConfig::default(),
             chars_per_token: 4,
+            prosoche_model: "claude-haiku-4-5-20251001".to_owned(),
         };
         assert_eq!(config.name.as_deref(), Some("Chiron"));
         assert!(config.thinking_enabled);
         assert_eq!(config.domains.len(), 1);
         assert!(!config.cache_enabled);
+    }
+
+    #[test]
+    fn prosoche_model_defaults_to_haiku() {
+        let config = NousConfig::default();
+        assert_eq!(config.prosoche_model, "claude-haiku-4-5-20251001");
     }
 }

--- a/crates/nous/src/spawn_svc.rs
+++ b/crates/nous/src/spawn_svc.rs
@@ -86,6 +86,7 @@ impl SpawnService for SpawnServiceImpl {
             session_token_cap: 500_000,
             recall: crate::recall::RecallConfig::default(),
             chars_per_token: 4,
+            prosoche_model: "claude-haiku-4-5-20251001".to_owned(),
         };
 
         let pipeline_config = PipelineConfig {

--- a/crates/taxis/src/config.rs
+++ b/crates/taxis/src/config.rs
@@ -260,6 +260,11 @@ pub struct AgentDefaults {
     /// `bootstrap` (the remainder, capped at `bootstrap_max_tokens`).
     /// Default: 0.6 (60 % of the context window).
     pub history_budget_ratio: f64,
+    /// Model used for prosoche heartbeat sessions instead of the primary model.
+    ///
+    /// Prosoche checks are simple health/attention tasks that don't need
+    /// advanced reasoning. Defaults to Haiku-tier to reduce cost.
+    pub prosoche_model: String,
 }
 
 impl Default for AgentDefaults {
@@ -278,6 +283,7 @@ impl Default for AgentDefaults {
             recall: RecallSettings::default(),
             chars_per_token: 4,
             history_budget_ratio: 0.6,
+            prosoche_model: "claude-haiku-4-5-20251001".to_owned(),
         }
     }
 }
@@ -958,6 +964,8 @@ pub struct ResolvedNousConfig {
     pub domains: Vec<String>,
     /// Resolved recall pipeline settings.
     pub recall: RecallSettings,
+    /// Model used for prosoche heartbeat sessions.
+    pub prosoche_model: String,
 }
 
 /// Resolve effective configuration for a specific nous agent.
@@ -1042,6 +1050,7 @@ pub fn resolve_nous(config: &AletheiaConfig, nous_id: &str) -> ResolvedNousConfi
         allowed_roots,
         domains,
         recall,
+        prosoche_model: defaults.prosoche_model.clone(),
     }
 }
 

--- a/instance.example/config/aletheia.toml.example
+++ b/instance.example/config/aletheia.toml.example
@@ -42,6 +42,7 @@ contextTokens = 200000
 # thinkingEnabled = false
 # thinkingBudget = 10000
 # maxToolIterations = 50
+# prosocheModel = "claude-haiku-4-5-20251001"  # model for prosoche heartbeat checks
 
 [[agents.list]]
 id = "main"


### PR DESCRIPTION
## Summary
- Add configurable prosoche_model field to agent defaults (defaults to claude-haiku-4-5)
- Use cheaper Haiku-tier model for prosoche heartbeat sessions instead of the primary agent model

## Test plan
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes