### PR TITLE
feat(nous): implement tool result truncation limit

### DIFF
--- a/crates/aletheia/src/commands/server.rs
+++ b/crates/aletheia/src/commands/server.rs
@@ -351,6 +351,7 @@ pub async fn run(args: Args) -> Result<()> {
                 recall: resolved.recall.into(),
                 chars_per_token: resolved.limits.chars_per_token,
                 prosoche_model: resolved.prosoche_model,
+                max_tool_result_bytes: resolved.limits.max_tool_result_bytes,
             };
             nous_manager
                 .spawn(

--- a/crates/aletheia/src/server.rs
+++ b/crates/aletheia/src/server.rs
@@ -291,6 +291,10 @@ pub(crate) async fn serve(cli: Cli) -> Result<()> {
                 server_tools: Vec::new(),
                 cache_enabled: resolved.capabilities.cache_enabled,
                 prosoche_model: resolved.prosoche_model,
+                session_token_cap: 500_000,
+                recall: resolved.recall.into(),
+                chars_per_token: resolved.limits.chars_per_token,
+                max_tool_result_bytes: resolved.limits.max_tool_result_bytes,
             };
             nous_manager
                 .spawn(

--- a/crates/nous/src/config.rs
+++ b/crates/nous/src/config.rs
@@ -63,6 +63,13 @@ pub struct NousConfig {
     /// advanced reasoning. Defaults to Haiku-tier to reduce cost.
     #[serde(default = "default_prosoche_model")]
     pub prosoche_model: String,
+    /// Maximum size in bytes for a single tool result before truncation.
+    ///
+    /// Results exceeding this limit are truncated with an indicator showing
+    /// the original and truncated sizes. Set to `0` to disable. Default:
+    /// 32 768 bytes (32 KB). Wired from `agents.defaults.maxToolResultBytes`.
+    #[serde(default = "default_max_tool_result_bytes")]
+    pub max_tool_result_bytes: u32,
 }
 
 fn default_cache_enabled() -> bool {
@@ -85,6 +92,11 @@ fn default_prosoche_model() -> String {
     "claude-haiku-4-5-20251001".to_owned()
 }
 
+fn default_max_tool_result_bytes() -> u32 {
+    // WHY: must match AgentDefaults::max_tool_result_bytes default in taxis.
+    32_768
+}
+
 impl Default for NousConfig {
     fn default() -> Self {
         Self {
@@ -105,6 +117,7 @@ impl Default for NousConfig {
             recall: RecallConfig::default(),
             chars_per_token: default_chars_per_token(),
             prosoche_model: default_prosoche_model(),
+            max_tool_result_bytes: default_max_tool_result_bytes(),
         }
     }
 }
@@ -237,6 +250,7 @@ mod tests {
             recall: RecallConfig::default(),
             chars_per_token: 4,
             prosoche_model: "claude-haiku-4-5-20251001".to_owned(),
+            max_tool_result_bytes: 32_768,
         };
         assert_eq!(config.name.as_deref(), Some("Chiron"));
         assert!(config.thinking_enabled);

--- a/crates/nous/src/execute/dispatch.rs
+++ b/crates/nous/src/execute/dispatch.rs
@@ -5,7 +5,7 @@ use std::hash::{Hash, Hasher};
 
 use tracing::debug;
 
-use aletheia_hermeneus::types::{ContentBlock, ToolResultContent};
+use aletheia_hermeneus::types::{ContentBlock, ToolResultBlock, ToolResultContent};
 use aletheia_koina::id::ToolName;
 use aletheia_organon::registry::ToolRegistry;
 use aletheia_organon::types::{ToolContext, ToolInput};
@@ -14,6 +14,105 @@ use tokio::sync::mpsc;
 use crate::error;
 use crate::pipeline::{InteractionSignal, LoopDetector, ToolCall};
 use crate::stream::TurnStreamEvent;
+
+/// Truncate a tool result if it exceeds `max_bytes`.
+///
+/// Only text content is truncated; image and document blocks are left
+/// intact because they are binary data that cannot be meaningfully
+/// split at arbitrary byte boundaries. When truncation occurs, the
+/// text is cut at the last char boundary within the limit and a
+/// `[truncated: {original} -> {truncated} bytes]` indicator is appended.
+///
+/// A `max_bytes` of `0` disables truncation entirely.
+pub(crate) fn truncate_tool_result(
+    content: ToolResultContent,
+    max_bytes: u32,
+) -> ToolResultContent {
+    if max_bytes == 0 {
+        return content;
+    }
+    let limit = max_bytes as usize;
+
+    match content {
+        ToolResultContent::Text(text) => {
+            if text.len() <= limit {
+                return ToolResultContent::Text(text);
+            }
+            let original_len = text.len();
+            // WHY: truncate at a char boundary to avoid producing invalid UTF-8.
+            let truncated = truncate_at_char_boundary(&text, limit);
+            let indicator = format!(
+                "\n[truncated: {} -> {} bytes]",
+                original_len,
+                truncated.len()
+            );
+            debug!(
+                original_bytes = original_len,
+                truncated_bytes = truncated.len(),
+                "tool result truncated"
+            );
+            ToolResultContent::Text(format!("{truncated}{indicator}"))
+        }
+        ToolResultContent::Blocks(blocks) => {
+            let total: usize = blocks
+                .iter()
+                .map(|b| match b {
+                    ToolResultBlock::Text { text } => text.len(),
+                    _ => 0,
+                })
+                .sum();
+
+            if total <= limit {
+                return ToolResultContent::Blocks(blocks);
+            }
+
+            debug!(
+                original_bytes = total,
+                limit_bytes = limit,
+                "tool result blocks truncated"
+            );
+
+            let mut remaining = limit;
+            let mut out = Vec::with_capacity(blocks.len());
+            for block in blocks {
+                match block {
+                    ToolResultBlock::Text { text } => {
+                        if remaining == 0 {
+                            continue;
+                        }
+                        if text.len() <= remaining {
+                            remaining -= text.len();
+                            out.push(ToolResultBlock::Text { text });
+                        } else {
+                            let truncated = truncate_at_char_boundary(&text, remaining);
+                            remaining = 0;
+                            out.push(ToolResultBlock::Text {
+                                text: truncated.to_owned(),
+                            });
+                        }
+                    }
+                    other => out.push(other),
+                }
+            }
+            let indicator = format!("\n[truncated: {total} -> {limit} bytes]");
+            out.push(ToolResultBlock::Text { text: indicator });
+            ToolResultContent::Blocks(out)
+        }
+        _ => content,
+    }
+}
+
+/// Find the largest prefix of `s` that is at most `max_bytes` bytes and
+/// ends on a UTF-8 char boundary.
+fn truncate_at_char_boundary(s: &str, max_bytes: usize) -> &str {
+    if s.len() <= max_bytes {
+        return s;
+    }
+    // WHY: floor_char_boundary rounds down to the nearest char boundary,
+    // avoiding a panic or invalid slice from splitting mid-codepoint.
+    let end = s.floor_char_boundary(max_bytes);
+    s.get(..end).unwrap_or(s)
+}
 
 /// Hash a JSON value for loop detection using the standard library hasher.
 pub(super) fn simple_hash(value: &serde_json::Value) -> String {
@@ -91,6 +190,7 @@ pub(super) async fn dispatch_tools(
     loop_detector: &mut LoopDetector,
     all_tool_calls: &mut Vec<ToolCall>,
     iterations: u32,
+    max_tool_result_bytes: u32,
 ) -> error::Result<Vec<ContentBlock>> {
     let mut tool_results: Vec<ContentBlock> = Vec::new();
 
@@ -135,6 +235,8 @@ pub(super) async fn dispatch_tools(
             Err(e) => (ToolResultContent::text(format!("Tool error: {e}")), true),
         };
 
+        let content = truncate_tool_result(content, max_tool_result_bytes);
+
         debug!(
             tool = tool_name.as_str(),
             duration_ms, is_error, "tool executed"
@@ -160,6 +262,10 @@ pub(super) async fn dispatch_tools(
 }
 
 /// Dispatch tool calls with streaming events emitted to the channel.
+#[expect(
+    clippy::too_many_arguments,
+    reason = "streaming dispatch inherently needs context, detector, channel, and limit"
+)]
 pub(super) async fn dispatch_tools_streaming(
     tool_uses: &[(String, String, serde_json::Value)],
     tools: &ToolRegistry,
@@ -168,6 +274,7 @@ pub(super) async fn dispatch_tools_streaming(
     all_tool_calls: &mut Vec<ToolCall>,
     iterations: u32,
     stream_tx: &mpsc::Sender<TurnStreamEvent>,
+    max_tool_result_bytes: u32,
 ) -> error::Result<Vec<ContentBlock>> {
     let mut tool_results: Vec<ContentBlock> = Vec::new();
 
@@ -218,6 +325,7 @@ pub(super) async fn dispatch_tools_streaming(
             Err(e) => (ToolResultContent::text(format!("Tool error: {e}")), true),
         };
 
+        let content = truncate_tool_result(content, max_tool_result_bytes);
         let result_summary = content.text_summary();
 
         debug!(
@@ -250,4 +358,147 @@ pub(super) async fn dispatch_tools_streaming(
     }
 
     Ok(tool_results)
+}
+
+#[cfg(test)]
+#[expect(clippy::expect_used, reason = "test assertions")]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn text_within_limit_passes_through() {
+        let content = ToolResultContent::text("hello world");
+        let result = truncate_tool_result(content, 100);
+        match result {
+            ToolResultContent::Text(s) => assert_eq!(s, "hello world"),
+            _ => panic!("expected Text variant"),
+        }
+    }
+
+    #[test]
+    fn text_at_exact_limit_passes_through() {
+        let text = "a".repeat(50);
+        let content = ToolResultContent::text(text.clone());
+        let result = truncate_tool_result(content, 50);
+        match result {
+            ToolResultContent::Text(s) => assert_eq!(s, text),
+            _ => panic!("expected Text variant"),
+        }
+    }
+
+    #[test]
+    fn text_over_limit_is_truncated_with_indicator() {
+        let text = "a".repeat(100);
+        let result = truncate_tool_result(ToolResultContent::text(text), 50);
+        match result {
+            ToolResultContent::Text(s) => {
+                assert!(
+                    s.contains("[truncated: 100 -> 50 bytes]"),
+                    "missing truncation indicator in: {s}"
+                );
+                assert!(
+                    s.starts_with("aaaa"),
+                    "truncated content should preserve prefix"
+                );
+            }
+            _ => panic!("expected Text variant"),
+        }
+    }
+
+    #[test]
+    fn zero_limit_disables_truncation() {
+        let text = "a".repeat(100_000);
+        let content = ToolResultContent::text(text.clone());
+        let result = truncate_tool_result(content, 0);
+        match result {
+            ToolResultContent::Text(s) => assert_eq!(s.len(), 100_000),
+            _ => panic!("expected Text variant"),
+        }
+    }
+
+    #[test]
+    fn multibyte_chars_truncated_at_char_boundary() {
+        // Each emoji is 4 bytes. 3 emojis = 12 bytes.
+        let text = "\u{1F600}\u{1F601}\u{1F602}";
+        assert_eq!(text.len(), 12, "test setup: 3 emojis = 12 bytes");
+
+        // Limit of 5 bytes: can fit 1 emoji (4 bytes), not 2 (8 bytes).
+        let result = truncate_tool_result(ToolResultContent::text(text), 5);
+        match result {
+            ToolResultContent::Text(s) => {
+                assert!(
+                    s.starts_with('\u{1F600}'),
+                    "should keep first complete emoji"
+                );
+                assert!(
+                    s.contains("[truncated: 12 -> 4 bytes]"),
+                    "indicator should show char-boundary size: {s}"
+                );
+            }
+            _ => panic!("expected Text variant"),
+        }
+    }
+
+    #[test]
+    fn blocks_within_limit_pass_through() {
+        let blocks = vec![
+            ToolResultBlock::Text {
+                text: "hello".to_owned(),
+            },
+            ToolResultBlock::Text {
+                text: "world".to_owned(),
+            },
+        ];
+        let content = ToolResultContent::Blocks(blocks);
+        let result = truncate_tool_result(content, 100);
+        match result {
+            ToolResultContent::Blocks(bs) => {
+                assert_eq!(bs.len(), 2, "both blocks should pass through");
+            }
+            _ => panic!("expected Blocks variant"),
+        }
+    }
+
+    #[test]
+    fn blocks_over_limit_truncates_text_preserves_images() {
+        let blocks = vec![
+            ToolResultBlock::Text {
+                text: "a".repeat(80),
+            },
+            ToolResultBlock::Image {
+                source: aletheia_hermeneus::types::ImageSource {
+                    source_type: "base64".to_owned(),
+                    media_type: "image/png".to_owned(),
+                    data: "base64data".to_owned(),
+                },
+            },
+            ToolResultBlock::Text {
+                text: "b".repeat(40),
+            },
+        ];
+        let content = ToolResultContent::Blocks(blocks);
+        let result = truncate_tool_result(content, 50);
+        match result {
+            ToolResultContent::Blocks(bs) => {
+                // First text block truncated to 50 bytes, image preserved,
+                // second text block skipped, indicator appended.
+                let has_image = bs
+                    .iter()
+                    .any(|b| matches!(b, ToolResultBlock::Image { .. }));
+                assert!(has_image, "image blocks should be preserved");
+
+                let indicator_block = bs.last().expect("should have indicator block");
+                match indicator_block {
+                    ToolResultBlock::Text { text } => {
+                        assert!(
+                            text.contains("[truncated: 120 -> 50 bytes]"),
+                            "indicator should show total text sizes: {text}"
+                        );
+                    }
+                    _ => panic!("last block should be text indicator"),
+                }
+            }
+            _ => panic!("expected Blocks variant"),
+        }
+    }
 }

--- a/crates/nous/src/execute/mod.rs
+++ b/crates/nous/src/execute/mod.rs
@@ -143,6 +143,10 @@ fn process_response_blocks(content: &[ContentBlock]) -> ResponseExtract {
 /// 3. Processes `tool_use` blocks by dispatching to the `ToolRegistry`
 /// 4. Feeds tool results back and re-calls the LLM
 /// 5. Repeats until `EndTurn`, `MaxTokens`, or iteration limit
+#[expect(
+    clippy::too_many_lines,
+    reason = "execution loop is inherently sequential, splitting would obscure control flow"
+)]
 #[instrument(skip_all, fields(nous_id = %session.nous_id, session_id = %session.id))]
 pub async fn execute(
     ctx: &PipelineContext,
@@ -236,6 +240,7 @@ pub async fn execute(
             &mut loop_detector,
             &mut all_tool_calls,
             iterations,
+            config.max_tool_result_bytes,
         )
         .await?;
 
@@ -384,6 +389,7 @@ pub async fn execute_streaming(
             &mut all_tool_calls,
             iterations,
             stream_tx,
+            config.max_tool_result_bytes,
         )
         .await?;
 

--- a/crates/nous/src/spawn_svc.rs
+++ b/crates/nous/src/spawn_svc.rs
@@ -87,6 +87,7 @@ impl SpawnService for SpawnServiceImpl {
             recall: crate::recall::RecallConfig::default(),
             chars_per_token: 4,
             prosoche_model: "claude-haiku-4-5-20251001".to_owned(),
+            max_tool_result_bytes: 32_768,
         };
 
         let pipeline_config = PipelineConfig {

--- a/crates/taxis/src/config.rs
+++ b/crates/taxis/src/config.rs
@@ -265,6 +265,12 @@ pub struct AgentDefaults {
     /// Prosoche checks are simple health/attention tasks that don't need
     /// advanced reasoning. Defaults to Haiku-tier to reduce cost.
     pub prosoche_model: String,
+    /// Maximum size in bytes for a single tool result before truncation.
+    ///
+    /// Tool results exceeding this limit are truncated to fit, with a
+    /// `[truncated: {original} -> {truncated} bytes]` indicator appended.
+    /// Set to `0` to disable truncation. Default: 32 768 (32 KB).
+    pub max_tool_result_bytes: u32,
 }
 
 impl Default for AgentDefaults {
@@ -284,6 +290,7 @@ impl Default for AgentDefaults {
             chars_per_token: 4,
             history_budget_ratio: 0.6,
             prosoche_model: "claude-haiku-4-5-20251001".to_owned(),
+            max_tool_result_bytes: 32_768,
         }
     }
 }
@@ -926,6 +933,8 @@ pub struct TokenLimits {
     pub chars_per_token: u32,
     /// Fraction of the context window reserved for conversation history.
     pub history_budget_ratio: f64,
+    /// Maximum tool result size in bytes before truncation (0 = disabled).
+    pub max_tool_result_bytes: u32,
 }
 
 /// Behavioral capabilities for an agent.
@@ -1039,6 +1048,7 @@ pub fn resolve_nous(config: &AletheiaConfig, nous_id: &str) -> ResolvedNousConfi
             thinking_budget: defaults.thinking_budget,
             chars_per_token: defaults.chars_per_token,
             history_budget_ratio: defaults.history_budget_ratio,
+            max_tool_result_bytes: defaults.max_tool_result_bytes,
         },
         capabilities: AgentCapabilities {
             thinking_enabled,

--- a/instance.example/config/aletheia.toml.example
+++ b/instance.example/config/aletheia.toml.example
@@ -43,6 +43,7 @@ contextTokens = 200000
 # thinkingBudget = 10000
 # maxToolIterations = 50
 # prosocheModel = "claude-haiku-4-5-20251001"  # model for prosoche heartbeat checks
+# maxToolResultBytes = 32768    # truncate tool results exceeding this size (0 = disabled)
 
 [[agents.list]]
 id = "main"


### PR DESCRIPTION
## Summary
- Add configurable max_tool_result_bytes limit (default 32KB) for tool results
- Truncate oversized tool results at char boundaries with indicator
- Wire through config cascade: taxis AgentDefaults -> TokenLimits -> NousConfig

## Test plan
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes