### PR TITLE
feat(symbolon): add three-state circuit breaker for OAuth token refresh

### DIFF
--- a/crates/aletheia/src/server.rs
+++ b/crates/aletheia/src/server.rs
@@ -29,9 +29,10 @@ use aletheia_organon::registry::ToolRegistry;
 use aletheia_organon::types::ToolServices;
 use aletheia_pylon::router::build_router;
 use aletheia_pylon::state::AppState;
+use aletheia_symbolon::circuit_breaker::CircuitBreakerConfig;
 use aletheia_symbolon::credential::{
     CredentialChain, CredentialFile, EnvCredentialProvider, FileCredentialProvider,
-    RefreshingCredentialProvider, claude_code_default_path, claude_code_provider,
+    RefreshingCredentialProvider, claude_code_default_path, claude_code_provider_with_config,
 };
 use aletheia_symbolon::jwt::{JwtConfig, JwtManager};
 use aletheia_taxis::config::resolve_nous;
@@ -525,6 +526,14 @@ fn build_provider_registry(
     let cred_file = oikos.credentials().join("anthropic.json");
     let mut chain: Vec<Box<dyn CredentialProvider>> = Vec::new();
 
+    let cb_settings = &config.credential.circuit_breaker;
+    let cb_config = CircuitBreakerConfig {
+        failure_threshold: cb_settings.failure_threshold,
+        failure_window: std::time::Duration::from_secs(cb_settings.failure_window_secs),
+        cooldown: std::time::Duration::from_secs(cb_settings.cooldown_secs),
+        max_cooldown: std::time::Duration::from_secs(cb_settings.max_cooldown_secs),
+    };
+
     let claude_code_path = config
         .credential
         .claude_code_credentials
@@ -535,7 +544,7 @@ fn build_provider_registry(
     // When source is "claude-code", prioritize Claude Code credentials
     if cred_source == "claude-code" {
         if let Some(ref cc_path) = claude_code_path {
-            if let Some(provider) = claude_code_provider(cc_path) {
+            if let Some(provider) = claude_code_provider_with_config(cc_path, cb_config.clone()) {
                 chain.push(provider);
             }
         }
@@ -544,7 +553,9 @@ fn build_provider_registry(
     if cred_file.exists() {
         if let Some(cred) = CredentialFile::load(&cred_file) {
             if cred.has_refresh_token() {
-                if let Some(refreshing) = RefreshingCredentialProvider::new(cred_file.clone()) {
+                if let Some(refreshing) =
+                    RefreshingCredentialProvider::with_circuit_breaker(cred_file.clone(), cb_config.clone())
+                {
                     info!(path = %cred_file.display(), "credential file found (OAuth auto-refresh)");
                     chain.push(Box::new(refreshing));
                 } else {
@@ -569,7 +580,7 @@ fn build_provider_registry(
     // When source is "auto", add Claude Code credentials as lowest-priority fallback
     if cred_source == "auto" {
         if let Some(ref cc_path) = claude_code_path {
-            if let Some(provider) = claude_code_provider(cc_path) {
+            if let Some(provider) = claude_code_provider_with_config(cc_path, cb_config) {
                 chain.push(provider);
             }
         }

--- a/crates/symbolon/src/circuit_breaker.rs
+++ b/crates/symbolon/src/circuit_breaker.rs
@@ -1,0 +1,496 @@
+//! Three-state circuit breaker for OAuth token refresh.
+//!
+//! Protects the OAuth refresh endpoint from repeated failed requests by
+//! tracking failures within a sliding window and temporarily blocking
+//! requests when the failure threshold is exceeded.
+
+use std::collections::VecDeque;
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+/// Circuit breaker state.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum CircuitState {
+    /// Normal operation: requests flow through, failures counted.
+    Closed,
+    /// Tripped: requests fail immediately, cooldown timer running.
+    Open,
+    /// Probing: one request allowed through to test recovery.
+    HalfOpen,
+}
+
+impl std::fmt::Display for CircuitState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Closed => f.write_str("closed"),
+            Self::Open => f.write_str("open"),
+            Self::HalfOpen => f.write_str("half-open"),
+        }
+    }
+}
+
+/// Configuration for the circuit breaker.
+#[derive(Debug, Clone)]
+pub struct CircuitBreakerConfig {
+    /// Number of failures within the window to trip the circuit.
+    pub failure_threshold: u32,
+    /// Sliding window for failure counting.
+    pub failure_window: Duration,
+    /// Base cooldown before transitioning from Open to `HalfOpen`.
+    pub cooldown: Duration,
+    /// Maximum cooldown after exponential backoff.
+    pub max_cooldown: Duration,
+}
+
+impl Default for CircuitBreakerConfig {
+    fn default() -> Self {
+        Self {
+            failure_threshold: 5,
+            failure_window: Duration::from_secs(60),
+            cooldown: Duration::from_secs(30),
+            max_cooldown: Duration::from_secs(300),
+        }
+    }
+}
+
+struct Inner {
+    state: CircuitState,
+    /// Failure timestamps within the sliding window (Closed state).
+    failures: VecDeque<Instant>,
+    /// When the circuit entered the Open state.
+    opened_at: Option<Instant>,
+    /// Current cooldown duration (increases with exponential backoff).
+    current_cooldown: Duration,
+    /// Number of consecutive Open→HalfOpen→Open cycles (for backoff).
+    consecutive_trips: u32,
+}
+
+/// Three-state circuit breaker with exponential backoff.
+///
+/// Thread-safe via `std::sync::Mutex`: all operations are short
+/// (no `.await` while holding the lock).
+pub struct CircuitBreaker {
+    inner: Mutex<Inner>,
+    config: CircuitBreakerConfig,
+}
+
+impl CircuitBreaker {
+    /// Create a new circuit breaker starting in Closed state.
+    #[must_use]
+    pub fn new(config: CircuitBreakerConfig) -> Self {
+        let initial_cooldown = config.cooldown;
+        Self {
+            inner: Mutex::new(Inner {
+                state: CircuitState::Closed,
+                failures: VecDeque::new(),
+                opened_at: None,
+                current_cooldown: initial_cooldown,
+                consecutive_trips: 0,
+            }),
+            config,
+        }
+    }
+
+    /// Current circuit state.
+    #[must_use]
+    pub fn state(&self) -> CircuitState {
+        #[expect(
+            clippy::expect_used,
+            reason = "Mutex poisoning means a thread panicked; no Result return to propagate through"
+        )]
+        self.inner
+            .lock()
+            .expect("circuit breaker lock poisoned")
+            .state
+            .clone()
+    }
+
+    /// Check if a request is allowed through the circuit breaker.
+    ///
+    /// - Closed: always allowed
+    /// - Open: allowed only if cooldown has elapsed (transitions to `HalfOpen`)
+    /// - `HalfOpen`: blocked (one probe is already in flight)
+    #[must_use]
+    pub fn check_allowed(&self) -> bool {
+        #[expect(
+            clippy::expect_used,
+            reason = "Mutex poisoning means a thread panicked; no Result return to propagate through"
+        )]
+        let mut inner = self.inner.lock().expect("circuit breaker lock poisoned");
+        match inner.state {
+            CircuitState::Closed => true,
+            CircuitState::HalfOpen => false,
+            CircuitState::Open => {
+                let Some(opened_at) = inner.opened_at else {
+                    return false;
+                };
+                if opened_at.elapsed() >= inner.current_cooldown {
+                    let prev = inner.state.clone();
+                    inner.state = CircuitState::HalfOpen;
+                    tracing::info!(
+                        from = %prev,
+                        to = %inner.state,
+                        cooldown_secs = inner.current_cooldown.as_secs(),
+                        "circuit breaker state transition"
+                    );
+                    true
+                } else {
+                    false
+                }
+            }
+        }
+    }
+
+    /// Record a successful request.
+    ///
+    /// - Closed: clears failure history
+    /// - `HalfOpen`: closes the circuit (probe succeeded)
+    /// - Open: no-op (requests should not reach here)
+    pub fn record_success(&self) {
+        #[expect(
+            clippy::expect_used,
+            reason = "Mutex poisoning means a thread panicked; no Result return to propagate through"
+        )]
+        let mut inner = self.inner.lock().expect("circuit breaker lock poisoned");
+        match inner.state {
+            CircuitState::Closed => {
+                inner.failures.clear();
+                inner.consecutive_trips = 0;
+            }
+            CircuitState::HalfOpen => {
+                let prev = inner.state.clone();
+                inner.state = CircuitState::Closed;
+                inner.failures.clear();
+                inner.consecutive_trips = 0;
+                inner.current_cooldown = self.config.cooldown;
+                inner.opened_at = None;
+                tracing::info!(
+                    from = %prev,
+                    to = %inner.state,
+                    "circuit breaker state transition"
+                );
+            }
+            CircuitState::Open => {}
+        }
+    }
+
+    /// Record a failed request.
+    ///
+    /// - Closed: adds failure to sliding window; trips to Open if threshold exceeded
+    /// - `HalfOpen`: reopens circuit with exponentially increased cooldown
+    /// - Open: no-op (requests should not reach here)
+    pub fn record_failure(&self) {
+        #[expect(
+            clippy::expect_used,
+            reason = "Mutex poisoning means a thread panicked; no Result return to propagate through"
+        )]
+        let mut inner = self.inner.lock().expect("circuit breaker lock poisoned");
+        let now = Instant::now();
+
+        match inner.state {
+            CircuitState::Closed => {
+                inner.failures.push_back(now);
+                // SAFETY: failure_window is always less than elapsed time since
+                // process start, so underflow is not possible in practice.
+                let window_start = now.checked_sub(self.config.failure_window).unwrap_or(now);
+                while inner.failures.front().is_some_and(|&t| t < window_start) {
+                    inner.failures.pop_front();
+                }
+
+                #[expect(
+                    clippy::cast_possible_truncation,
+                    reason = "failure_threshold is u32, VecDeque::len fits"
+                )]
+                let count = inner.failures.len() as u32;
+                if count >= self.config.failure_threshold {
+                    let prev = inner.state.clone();
+                    inner.state = CircuitState::Open;
+                    inner.opened_at = Some(now);
+                    inner.current_cooldown =
+                        Self::compute_cooldown(&self.config, inner.consecutive_trips);
+                    inner.consecutive_trips = inner.consecutive_trips.saturating_add(1);
+                    inner.failures.clear();
+                    tracing::info!(
+                        from = %prev,
+                        to = %inner.state,
+                        failure_count = count,
+                        threshold = self.config.failure_threshold,
+                        cooldown_secs = inner.current_cooldown.as_secs(),
+                        "circuit breaker state transition"
+                    );
+                }
+            }
+            CircuitState::HalfOpen => {
+                let prev = inner.state.clone();
+                inner.current_cooldown =
+                    Self::compute_cooldown(&self.config, inner.consecutive_trips);
+                inner.consecutive_trips = inner.consecutive_trips.saturating_add(1);
+                inner.state = CircuitState::Open;
+                inner.opened_at = Some(now);
+                tracing::info!(
+                    from = %prev,
+                    to = %inner.state,
+                    consecutive_trips = inner.consecutive_trips,
+                    cooldown_secs = inner.current_cooldown.as_secs(),
+                    "circuit breaker state transition"
+                );
+            }
+            CircuitState::Open => {}
+        }
+    }
+
+    fn compute_cooldown(config: &CircuitBreakerConfig, consecutive_trips: u32) -> Duration {
+        let multiplier = 2u64.saturating_pow(consecutive_trips);
+        let cooldown_secs = config.cooldown.as_secs().saturating_mul(multiplier);
+        let capped = cooldown_secs.min(config.max_cooldown.as_secs());
+        Duration::from_secs(capped)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::thread;
+
+    use super::*;
+
+    fn breaker(
+        threshold: u32,
+        window_ms: u64,
+        cooldown_ms: u64,
+        max_cooldown_ms: u64,
+    ) -> CircuitBreaker {
+        CircuitBreaker::new(CircuitBreakerConfig {
+            failure_threshold: threshold,
+            failure_window: Duration::from_millis(window_ms),
+            cooldown: Duration::from_millis(cooldown_ms),
+            max_cooldown: Duration::from_millis(max_cooldown_ms),
+        })
+    }
+
+    #[test]
+    fn starts_closed() {
+        let cb = breaker(5, 60_000, 30_000, 300_000);
+        assert_eq!(cb.state(), CircuitState::Closed);
+        assert!(cb.check_allowed());
+    }
+
+    #[test]
+    fn trips_after_threshold_failures() {
+        let cb = breaker(3, 60_000, 30_000, 300_000);
+        for _ in 0..3 {
+            cb.record_failure();
+        }
+        assert_eq!(cb.state(), CircuitState::Open);
+        assert!(!cb.check_allowed());
+    }
+
+    #[test]
+    fn failures_below_threshold_stay_closed() {
+        let cb = breaker(3, 60_000, 30_000, 300_000);
+        cb.record_failure();
+        cb.record_failure();
+        assert_eq!(cb.state(), CircuitState::Closed);
+        assert!(cb.check_allowed());
+    }
+
+    #[test]
+    fn enters_half_open_after_cooldown() {
+        let cb = breaker(2, 60_000, 1, 300_000);
+        cb.record_failure();
+        cb.record_failure();
+        assert_eq!(cb.state(), CircuitState::Open);
+
+        thread::sleep(Duration::from_millis(5));
+        assert!(cb.check_allowed(), "should allow probe after cooldown");
+        assert_eq!(cb.state(), CircuitState::HalfOpen);
+    }
+
+    #[test]
+    fn half_open_blocks_additional_requests() {
+        let cb = breaker(2, 60_000, 1, 300_000);
+        cb.record_failure();
+        cb.record_failure();
+
+        thread::sleep(Duration::from_millis(5));
+        assert!(cb.check_allowed(), "first check transitions to half-open");
+        assert!(!cb.check_allowed(), "second check blocked in half-open");
+    }
+
+    #[test]
+    fn successful_probe_closes_circuit() {
+        let cb = breaker(2, 60_000, 1, 300_000);
+        cb.record_failure();
+        cb.record_failure();
+
+        thread::sleep(Duration::from_millis(5));
+        assert!(cb.check_allowed());
+        assert_eq!(cb.state(), CircuitState::HalfOpen);
+
+        cb.record_success();
+        assert_eq!(cb.state(), CircuitState::Closed);
+        assert!(cb.check_allowed());
+    }
+
+    #[test]
+    fn failed_probe_reopens_circuit() {
+        let cb = breaker(2, 60_000, 1, 300_000);
+        cb.record_failure();
+        cb.record_failure();
+        assert_eq!(cb.state(), CircuitState::Open);
+
+        thread::sleep(Duration::from_millis(5));
+        assert!(cb.check_allowed());
+        assert_eq!(cb.state(), CircuitState::HalfOpen);
+
+        cb.record_failure();
+        assert_eq!(
+            cb.state(),
+            CircuitState::Open,
+            "failed probe should reopen circuit"
+        );
+
+        // After the increased cooldown elapses, half-open should be reachable
+        thread::sleep(Duration::from_millis(10));
+        assert!(cb.check_allowed(), "should allow after increased cooldown");
+        assert_eq!(cb.state(), CircuitState::HalfOpen);
+    }
+
+    #[test]
+    fn exponential_backoff_computes_correct_cooldowns() {
+        let config = CircuitBreakerConfig {
+            failure_threshold: 5,
+            failure_window: Duration::from_secs(60),
+            cooldown: Duration::from_secs(30),
+            max_cooldown: Duration::from_secs(300),
+        };
+        assert_eq!(
+            CircuitBreaker::compute_cooldown(&config, 0),
+            Duration::from_secs(30),
+            "trip 0: base cooldown"
+        );
+        assert_eq!(
+            CircuitBreaker::compute_cooldown(&config, 1),
+            Duration::from_secs(60),
+            "trip 1: 2x base"
+        );
+        assert_eq!(
+            CircuitBreaker::compute_cooldown(&config, 2),
+            Duration::from_secs(120),
+            "trip 2: 4x base"
+        );
+        assert_eq!(
+            CircuitBreaker::compute_cooldown(&config, 3),
+            Duration::from_secs(240),
+            "trip 3: 8x base"
+        );
+        assert_eq!(
+            CircuitBreaker::compute_cooldown(&config, 4),
+            Duration::from_secs(300),
+            "trip 4: capped at max"
+        );
+        assert_eq!(
+            CircuitBreaker::compute_cooldown(&config, 10),
+            Duration::from_secs(300),
+            "trip 10: still capped"
+        );
+    }
+
+    #[test]
+    fn cooldown_caps_at_max() {
+        let config = CircuitBreakerConfig {
+            failure_threshold: 1,
+            failure_window: Duration::from_secs(60),
+            cooldown: Duration::from_secs(100),
+            max_cooldown: Duration::from_secs(300),
+        };
+        assert_eq!(
+            CircuitBreaker::compute_cooldown(&config, 0),
+            Duration::from_secs(100),
+            "trip 0"
+        );
+        assert_eq!(
+            CircuitBreaker::compute_cooldown(&config, 1),
+            Duration::from_secs(200),
+            "trip 1"
+        );
+        assert_eq!(
+            CircuitBreaker::compute_cooldown(&config, 2),
+            Duration::from_secs(300),
+            "trip 2: capped"
+        );
+        assert_eq!(
+            CircuitBreaker::compute_cooldown(&config, 3),
+            Duration::from_secs(300),
+            "trip 3: still capped"
+        );
+    }
+
+    #[test]
+    fn success_in_closed_resets_failure_count() {
+        let cb = breaker(3, 60_000, 30_000, 300_000);
+        cb.record_failure();
+        cb.record_failure();
+        assert_eq!(cb.state(), CircuitState::Closed);
+
+        cb.record_success();
+
+        // After success, two more failures should not trip (count was reset)
+        cb.record_failure();
+        cb.record_failure();
+        assert_eq!(cb.state(), CircuitState::Closed);
+    }
+
+    #[test]
+    fn failures_outside_window_are_pruned() {
+        let cb = breaker(3, 10, 30_000, 300_000);
+        cb.record_failure();
+        cb.record_failure();
+
+        // Wait for failures to leave the window
+        thread::sleep(Duration::from_millis(15));
+
+        cb.record_failure();
+        assert_eq!(
+            cb.state(),
+            CircuitState::Closed,
+            "old failures should be pruned from window"
+        );
+    }
+
+    #[test]
+    fn successful_close_resets_backoff() {
+        let cb = breaker(1, 60_000, 10, 300_000);
+
+        // Trip and recover
+        cb.record_failure();
+        thread::sleep(Duration::from_millis(15));
+        assert!(cb.check_allowed());
+        cb.record_success();
+        assert_eq!(cb.state(), CircuitState::Closed);
+
+        // Trip again: cooldown should be base (10ms), not escalated
+        cb.record_failure();
+        assert_eq!(cb.state(), CircuitState::Open);
+        thread::sleep(Duration::from_millis(15));
+        assert!(
+            cb.check_allowed(),
+            "cooldown should reset to base after successful close"
+        );
+    }
+
+    #[test]
+    fn open_before_cooldown_stays_blocked() {
+        let cb = breaker(2, 60_000, 60_000, 300_000);
+        cb.record_failure();
+        cb.record_failure();
+        assert_eq!(cb.state(), CircuitState::Open);
+        assert!(!cb.check_allowed(), "should block before cooldown elapses");
+    }
+
+    #[test]
+    fn breaker_is_send_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<CircuitBreaker>();
+    }
+}

--- a/crates/symbolon/src/credential.rs
+++ b/crates/symbolon/src/credential.rs
@@ -7,9 +7,11 @@ use std::sync::{Arc, RwLock};
 use std::time::{Duration, Instant, SystemTime};
 
 use serde::{Deserialize, Serialize};
-use tracing::{Instrument, info, warn};
+use tracing::{Instrument, debug, info, warn};
 
 use aletheia_koina::credential::{Credential, CredentialProvider, CredentialSource};
+
+use crate::circuit_breaker::{CircuitBreaker, CircuitBreakerConfig};
 
 /// Return current time as milliseconds since UNIX epoch, warning if the clock
 /// is before epoch rather than silently returning zero.
@@ -430,8 +432,16 @@ impl RefreshingCredentialProvider {
     /// Create a refreshing provider from a credential file path.
     ///
     /// Reads the credential file immediately and spawns a background refresh
-    /// task. Requires a tokio runtime to be active.
+    /// task with a default circuit breaker. Requires a tokio runtime to be active.
     pub fn new(path: PathBuf) -> Option<Self> {
+        Self::with_circuit_breaker(path, CircuitBreakerConfig::default())
+    }
+
+    /// Create a refreshing provider with a custom circuit breaker configuration.
+    ///
+    /// Reads the credential file immediately and spawns a background refresh
+    /// task. Requires a tokio runtime to be active.
+    pub fn with_circuit_breaker(path: PathBuf, cb_config: CircuitBreakerConfig) -> Option<Self> {
         let cred = CredentialFile::load(&path)?;
         let refresh_token = cred.refresh_token.clone().filter(|t| !t.is_empty())?;
 
@@ -448,14 +458,16 @@ impl RefreshingCredentialProvider {
         })));
 
         let shutdown = Arc::new(AtomicBool::new(false));
+        let circuit_breaker = Arc::new(CircuitBreaker::new(cb_config));
 
         let task_state = Arc::clone(&state);
         let task_shutdown = Arc::clone(&shutdown);
         let task_path = path.clone();
+        let task_cb = Arc::clone(&circuit_breaker);
 
         let task = tokio::spawn(
             async move {
-                refresh_loop(task_state, task_shutdown, task_path).await;
+                refresh_loop(task_state, task_shutdown, task_path, task_cb).await;
             }
             .instrument(tracing::info_span!("credential_refresh")),
         );
@@ -517,6 +529,7 @@ async fn refresh_loop(
     state: Arc<RwLock<Option<RefreshState>>>,
     shutdown: Arc<AtomicBool>,
     path: PathBuf,
+    circuit_breaker: Arc<CircuitBreaker>,
 ) {
     let client = reqwest::Client::new();
     let check_interval = Duration::from_secs(REFRESH_CHECK_INTERVAL_SECS);
@@ -556,45 +569,53 @@ async fn refresh_loop(
             continue;
         }
 
+        if !circuit_breaker.check_allowed() {
+            debug!(
+                state = %circuit_breaker.state(),
+                "OAuth refresh circuit breaker is open, skipping refresh attempt"
+            );
+            continue;
+        }
+
         info!(
             expires_at_ms,
             now_ms = unix_epoch_ms(),
             "credential refresh needed, refreshing OAuth token"
         );
 
-        match do_refresh(&client, &refresh_token).await {
-            Some(resp) => {
-                let now_ms = unix_epoch_ms();
-                let expires_at_ms = now_ms + resp.expires_in * 1000;
+        if let Some(resp) = do_refresh(&client, &refresh_token).await {
+            circuit_breaker.record_success();
 
-                if let Ok(mut guard) = state.write() {
-                    *guard = Some(RefreshState {
-                        current_token: resp.access_token.clone(),
-                        refresh_token: resp.refresh_token.clone(),
-                        expires_at_ms,
-                        subscription_type: subscription_type.clone(),
-                    });
-                }
+            let now_ms = unix_epoch_ms();
+            let expires_at_ms = now_ms + resp.expires_in * 1000;
 
-                let scopes = resp
-                    .scope
-                    .map(|s| s.split_whitespace().map(String::from).collect());
-                let cred_file = CredentialFile {
-                    token: resp.access_token,
-                    refresh_token: Some(resp.refresh_token),
-                    expires_at: Some(expires_at_ms),
-                    scopes,
-                    subscription_type,
-                };
-                if let Err(e) = cred_file.save(&path) {
-                    warn!(error = %e, "failed to write refreshed credential file");
-                }
-
-                info!(expires_in_secs = resp.expires_in, "OAuth token refreshed");
+            if let Ok(mut guard) = state.write() {
+                *guard = Some(RefreshState {
+                    current_token: resp.access_token.clone(),
+                    refresh_token: resp.refresh_token.clone(),
+                    expires_at_ms,
+                    subscription_type: subscription_type.clone(),
+                });
             }
-            None => {
-                warn!("OAuth token refresh failed — will retry next cycle");
+
+            let scopes = resp
+                .scope
+                .map(|s| s.split_whitespace().map(String::from).collect());
+            let cred_file = CredentialFile {
+                token: resp.access_token,
+                refresh_token: Some(resp.refresh_token),
+                expires_at: Some(expires_at_ms),
+                scopes,
+                subscription_type,
+            };
+            if let Err(e) = cred_file.save(&path) {
+                warn!(error = %e, "failed to write refreshed credential file");
             }
+
+            info!(expires_in_secs = resp.expires_in, "OAuth token refreshed");
+        } else {
+            circuit_breaker.record_failure();
+            warn!("OAuth token refresh failed — will retry next cycle");
         }
     }
 }
@@ -700,12 +721,23 @@ pub fn claude_code_default_path() -> Option<PathBuf> {
 ///
 /// Returns `None` if the file does not exist or cannot be parsed.
 pub fn claude_code_provider(path: &Path) -> Option<Box<dyn CredentialProvider>> {
+    claude_code_provider_with_config(path, CircuitBreakerConfig::default())
+}
+
+/// Build a credential provider with a custom circuit breaker configuration.
+///
+/// See [`claude_code_provider`] for behavior details.
+pub fn claude_code_provider_with_config(
+    path: &Path,
+    cb_config: CircuitBreakerConfig,
+) -> Option<Box<dyn CredentialProvider>> {
     if !path.exists() {
         return None;
     }
     let cred = CredentialFile::load(path)?;
     if cred.has_refresh_token()
-        && let Some(refreshing) = RefreshingCredentialProvider::new(path.to_path_buf())
+        && let Some(refreshing) =
+            RefreshingCredentialProvider::with_circuit_breaker(path.to_path_buf(), cb_config)
     {
         info!(
             path = %path.display(),

--- a/crates/symbolon/src/lib.rs
+++ b/crates/symbolon/src/lib.rs
@@ -7,6 +7,8 @@
 pub mod api_key;
 /// Unified auth facade composing JWT, API keys, passwords, and RBAC.
 pub(crate) mod auth;
+/// Three-state circuit breaker for OAuth token refresh.
+pub mod circuit_breaker;
 /// Credential provider implementations for LLM API key resolution.
 pub mod credential;
 /// Symbolon-specific error types and result alias.

--- a/crates/taxis/src/config.rs
+++ b/crates/taxis/src/config.rs
@@ -773,6 +773,8 @@ pub struct CredentialConfig {
     /// Override path to the Claude Code credentials file.
     /// Defaults to `~/.claude/.credentials.json`.
     pub claude_code_credentials: Option<String>,
+    /// Circuit breaker settings for OAuth token refresh.
+    pub circuit_breaker: CircuitBreakerSettings,
 }
 
 impl Default for CredentialConfig {
@@ -780,6 +782,36 @@ impl Default for CredentialConfig {
         Self {
             source: "auto".to_owned(),
             claude_code_credentials: None,
+            circuit_breaker: CircuitBreakerSettings::default(),
+        }
+    }
+}
+
+/// Circuit breaker settings for OAuth token refresh.
+///
+/// Controls the three-state circuit breaker (Closed → Open → `HalfOpen`)
+/// that protects the OAuth refresh endpoint from repeated failed requests.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[serde(default)]
+pub struct CircuitBreakerSettings {
+    /// Number of failures within the window to trip the circuit.
+    pub failure_threshold: u32,
+    /// Sliding window (seconds) for failure counting.
+    pub failure_window_secs: u64,
+    /// Base cooldown (seconds) before probing recovery.
+    pub cooldown_secs: u64,
+    /// Maximum cooldown (seconds) after exponential backoff.
+    pub max_cooldown_secs: u64,
+}
+
+impl Default for CircuitBreakerSettings {
+    fn default() -> Self {
+        Self {
+            failure_threshold: 5,
+            failure_window_secs: 60,
+            cooldown_secs: 30,
+            max_cooldown_secs: 300,
         }
     }
 }


### PR DESCRIPTION
## Summary
- Add three-state circuit breaker (Closed/HalfOpen/Open) for OAuth token refresh
- Prevents thundering herd on repeated auth failures

## Test plan
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes