### PR TITLE
feat(koina): add disk space monitoring with graceful degradation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -207,6 +207,7 @@ name = "aletheia-koina"
 version = "0.12.0"
 dependencies = [
  "compact_str",
+ "libc",
  "regex",
  "serde",
  "serde_json",
@@ -236,6 +237,7 @@ name = "aletheia-mneme"
 version = "0.12.0"
 dependencies = [
  "aho-corasick",
+ "aletheia-koina",
  "base64 0.22.1",
  "bytemuck",
  "candle-core",
@@ -311,6 +313,7 @@ dependencies = [
 name = "aletheia-oikonomos"
 version = "0.12.0"
 dependencies = [
+ "aletheia-koina",
  "chrono",
  "cron",
  "flate2",
@@ -410,6 +413,7 @@ dependencies = [
 name = "aletheia-taxis"
 version = "0.12.0"
 dependencies = [
+ "aletheia-koina",
  "base64 0.22.1",
  "figment",
  "proptest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -149,6 +149,9 @@ rusqlite = { version = "0.38", features = ["bundled"] }
 # String similarity
 strsim = "0.11"
 
+# FFI
+libc = "0.2"
+
 # Random number generation
 rand = "0.9"
 

--- a/crates/aletheia/src/commands/backup.rs
+++ b/crates/aletheia/src/commands/backup.rs
@@ -117,25 +117,30 @@ pub fn run(instance_root: Option<&PathBuf>, args: &BackupArgs) -> Result<()> {
 
     if export_json {
         let export_dir = oikos.archive().join("sessions");
-        let result = manager
+        match manager
             .export_sessions_json(&export_dir)
-            .context("failed to export sessions")?;
-        println!(
-            "Exported {} session(s) to {}",
-            result.sessions_exported,
-            result.output_dir.display()
-        );
+            .context("failed to export sessions")?
+        {
+            Some(result) => println!(
+                "Exported {} session(s) to {}",
+                result.sessions_exported,
+                result.output_dir.display()
+            ),
+            None => println!("Export skipped: disk space critical."),
+        }
         return Ok(());
     }
 
-    let result = manager.create_backup().context("failed to create backup")?;
-    println!(
-        "Backup created: {} ({} bytes, {} sessions, {} messages)",
-        result.path.display(),
-        result.size_bytes,
-        result.sessions_count,
-        result.messages_count,
-    );
+    match manager.create_backup().context("failed to create backup")? {
+        Some(result) => println!(
+            "Backup created: {} ({} bytes, {} sessions, {} messages)",
+            result.path.display(),
+            result.size_bytes,
+            result.sessions_count,
+            result.messages_count,
+        ),
+        None => println!("Backup skipped: disk space critical."),
+    }
 
     Ok(())
 }

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -11,6 +11,7 @@ rust-version.workspace = true
 workspace = true
 
 [dependencies]
+aletheia-koina = { path = "../koina" }
 # Required by the `cron` crate API for schedule parsing
 chrono = { workspace = true }
 cron = { workspace = true }

--- a/crates/daemon/src/maintenance/trace_rotation.rs
+++ b/crates/daemon/src/maintenance/trace_rotation.rs
@@ -5,6 +5,7 @@ use std::io::Write;
 use std::path::PathBuf;
 use std::time::SystemTime;
 
+use aletheia_koina::disk_space::DiskSpaceMonitor;
 use snafu::ResultExt;
 
 use crate::error;
@@ -56,21 +57,45 @@ pub struct RotationReport {
 /// Rotates old trace files to an archive directory with optional gzip compression.
 pub struct TraceRotator {
     config: TraceRotationConfig,
+    disk_monitor: Option<DiskSpaceMonitor>,
 }
 
 impl TraceRotator {
     /// Create a rotator with the given configuration.
     pub fn new(config: TraceRotationConfig) -> Self {
-        Self { config }
+        Self {
+            config,
+            disk_monitor: None,
+        }
+    }
+
+    /// Attach a disk space monitor. Rotation (a non-essential write) is
+    /// skipped when disk space reaches the critical threshold.
+    pub fn set_disk_monitor(&mut self, monitor: DiskSpaceMonitor) {
+        self.disk_monitor = Some(monitor);
     }
 
     /// Run trace rotation. Moves old files to archive, compresses if configured,
     /// prunes archives exceeding the limit.
+    ///
+    /// Trace rotation is a non-essential write. When disk space is critical,
+    /// rotation is skipped entirely (returns an empty report).
     #[expect(
         clippy::expect_used,
         reason = "file_name() is None only for paths ending in '..', which trace files never are"
     )]
     pub fn rotate(&self) -> error::Result<RotationReport> {
+        if let Some(ref monitor) = self.disk_monitor
+            && !monitor.allow_non_essential_write()
+        {
+            let mb = monitor.status().available_bytes() / (1024 * 1024);
+            tracing::warn!(
+                available_mb = mb,
+                "skipping trace rotation: disk space critical"
+            );
+            return Ok(RotationReport::default());
+        }
+
         if !self.config.trace_dir.exists() {
             return Ok(RotationReport::default());
         }

--- a/crates/koina/Cargo.toml
+++ b/crates/koina/Cargo.toml
@@ -12,6 +12,7 @@ workspace = true
 
 [dependencies]
 compact_str = { workspace = true }
+libc = { workspace = true }
 regex = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/koina/src/disk_space.rs
+++ b/crates/koina/src/disk_space.rs
@@ -1,0 +1,392 @@
+//! Disk space monitoring for proactive write protection.
+
+use std::fmt;
+use std::path::Path;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+const BYTES_PER_MB: u64 = 1024 * 1024;
+
+/// Default warning threshold: 1 GB.
+pub const DEFAULT_WARNING_BYTES: u64 = 1024 * BYTES_PER_MB;
+
+/// Default critical threshold: 100 MB.
+pub const DEFAULT_CRITICAL_BYTES: u64 = 100 * BYTES_PER_MB;
+
+/// Disk space status relative to configured thresholds.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum DiskStatus {
+    /// Available space is above the warning threshold.
+    Ok {
+        /// Bytes available on the filesystem.
+        available_bytes: u64,
+    },
+    /// Available space is below the warning threshold but above critical.
+    Warning {
+        /// Bytes available on the filesystem.
+        available_bytes: u64,
+    },
+    /// Available space is below the critical threshold.
+    Critical {
+        /// Bytes available on the filesystem.
+        available_bytes: u64,
+    },
+}
+
+impl DiskStatus {
+    /// Returns the available bytes regardless of status level.
+    #[must_use]
+    pub fn available_bytes(self) -> u64 {
+        match self {
+            Self::Ok { available_bytes }
+            | Self::Warning { available_bytes }
+            | Self::Critical { available_bytes } => available_bytes,
+        }
+    }
+
+    /// Returns `true` when space is at the critical level.
+    #[must_use]
+    pub fn is_critical(self) -> bool {
+        matches!(self, Self::Critical { .. })
+    }
+}
+
+impl fmt::Display for DiskStatus {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mb = self.available_bytes() / BYTES_PER_MB;
+        match self {
+            Self::Ok { .. } => write!(f, "ok ({mb} MB available)"),
+            Self::Warning { .. } => write!(f, "warning ({mb} MB available)"),
+            Self::Critical { .. } => write!(f, "critical ({mb} MB available)"),
+        }
+    }
+}
+
+/// Query available disk space for the filesystem containing `path`.
+///
+/// # Errors
+///
+/// Returns an I/O error if the `statvfs` syscall fails (e.g. path does not
+/// exist or is not accessible).
+#[expect(
+    unsafe_code,
+    reason = "single FFI call to libc::statvfs with zeroed struct"
+)]
+pub fn available_space(path: &Path) -> std::io::Result<u64> {
+    use std::ffi::CString;
+    use std::os::unix::ffi::OsStrExt;
+
+    let c_path = CString::new(path.as_os_str().as_bytes()).map_err(|e| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!("path contains interior null byte: {e}"),
+        )
+    })?;
+
+    // SAFETY: `stat` is zeroed before the call. `libc::statvfs` writes into
+    // the provided pointer and returns 0 on success, -1 on error. The CString
+    // is valid for the duration of the call.
+    let mut stat: libc::statvfs = unsafe { std::mem::zeroed() };
+    let ret = unsafe { libc::statvfs(c_path.as_ptr(), &raw mut stat) };
+    if ret != 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+
+    // WHY: f_bavail (blocks available to unprivileged users) * f_frsize
+    // (fragment size) gives the bytes available for non-root writes.
+    Ok(stat.f_bavail * stat.f_frsize)
+}
+
+/// Check disk space and classify against thresholds.
+///
+/// # Errors
+///
+/// Returns an I/O error if the underlying `statvfs` call fails.
+pub fn check_disk_space(
+    path: &Path,
+    warning_bytes: u64,
+    critical_bytes: u64,
+) -> std::io::Result<DiskStatus> {
+    let avail = available_space(path)?;
+    Ok(classify(avail, warning_bytes, critical_bytes))
+}
+
+/// Classify an available-bytes value against thresholds.
+fn classify(available_bytes: u64, warning_bytes: u64, critical_bytes: u64) -> DiskStatus {
+    if available_bytes < critical_bytes {
+        DiskStatus::Critical { available_bytes }
+    } else if available_bytes < warning_bytes {
+        DiskStatus::Warning { available_bytes }
+    } else {
+        DiskStatus::Ok { available_bytes }
+    }
+}
+
+/// Shared disk space monitor backed by an [`AtomicU64`].
+///
+/// The monitor caches the last-known available bytes so that write paths can
+/// check disk status without issuing a syscall on every operation. A
+/// background task should call [`DiskSpaceMonitor::refresh`] periodically.
+#[derive(Clone)]
+pub struct DiskSpaceMonitor {
+    cached_available: Arc<AtomicU64>,
+    warn_threshold: u64,
+    critical_threshold: u64,
+}
+
+impl DiskSpaceMonitor {
+    /// Create a new monitor with the given thresholds (in bytes).
+    ///
+    /// The initial cached value is `u64::MAX` (assumes space is available
+    /// until the first [`refresh`](Self::refresh) completes).
+    #[must_use]
+    pub fn new(warning_bytes: u64, critical_bytes: u64) -> Self {
+        Self {
+            cached_available: Arc::new(AtomicU64::new(u64::MAX)),
+            warn_threshold: warning_bytes,
+            critical_threshold: critical_bytes,
+        }
+    }
+
+    /// Refresh the cached value by querying the filesystem at `path`.
+    ///
+    /// Returns the new [`DiskStatus`] after updating the cache.
+    ///
+    /// # Errors
+    ///
+    /// Returns an I/O error if `statvfs` fails.
+    pub fn refresh(&self, path: &Path) -> std::io::Result<DiskStatus> {
+        let avail = available_space(path)?;
+        self.cached_available.store(avail, Ordering::Relaxed);
+        Ok(classify(
+            avail,
+            self.warn_threshold,
+            self.critical_threshold,
+        ))
+    }
+
+    /// Current disk status based on the last cached value.
+    #[must_use]
+    pub fn status(&self) -> DiskStatus {
+        let avail = self.cached_available.load(Ordering::Relaxed);
+        classify(avail, self.warn_threshold, self.critical_threshold)
+    }
+
+    /// Returns `true` if non-essential writes (logs, caches, backups) should
+    /// proceed. Returns `false` when disk space is at the critical level.
+    #[must_use]
+    pub fn allow_non_essential_write(&self) -> bool {
+        !self.status().is_critical()
+    }
+
+    /// Warning threshold in bytes.
+    #[must_use]
+    pub fn warning_bytes(&self) -> u64 {
+        self.warn_threshold
+    }
+
+    /// Critical threshold in bytes.
+    #[must_use]
+    pub fn critical_bytes(&self) -> u64 {
+        self.critical_threshold
+    }
+}
+
+impl fmt::Debug for DiskSpaceMonitor {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("DiskSpaceMonitor")
+            .field("status", &self.status())
+            .field("warn_threshold_mb", &(self.warn_threshold / BYTES_PER_MB))
+            .field(
+                "critical_threshold_mb",
+                &(self.critical_threshold / BYTES_PER_MB),
+            )
+            .finish_non_exhaustive()
+    }
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "test assertions")]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classify_returns_ok_above_warning() {
+        let status = classify(2_000_000_000, DEFAULT_WARNING_BYTES, DEFAULT_CRITICAL_BYTES);
+        assert!(
+            matches!(status, DiskStatus::Ok { .. }),
+            "2 GB should be Ok, got {status}"
+        );
+    }
+
+    #[test]
+    fn classify_returns_warning_between_thresholds() {
+        let status = classify(500_000_000, DEFAULT_WARNING_BYTES, DEFAULT_CRITICAL_BYTES);
+        assert!(
+            matches!(status, DiskStatus::Warning { .. }),
+            "500 MB should be Warning, got {status}"
+        );
+    }
+
+    #[test]
+    fn classify_returns_critical_below_critical() {
+        let status = classify(50_000_000, DEFAULT_WARNING_BYTES, DEFAULT_CRITICAL_BYTES);
+        assert!(
+            matches!(status, DiskStatus::Critical { .. }),
+            "50 MB should be Critical, got {status}"
+        );
+    }
+
+    #[test]
+    fn classify_at_exact_warning_boundary_is_ok() {
+        let status = classify(
+            DEFAULT_WARNING_BYTES,
+            DEFAULT_WARNING_BYTES,
+            DEFAULT_CRITICAL_BYTES,
+        );
+        assert!(
+            matches!(status, DiskStatus::Ok { .. }),
+            "exactly at warning threshold should be Ok, got {status}"
+        );
+    }
+
+    #[test]
+    fn classify_at_exact_critical_boundary_is_warning() {
+        let status = classify(
+            DEFAULT_CRITICAL_BYTES,
+            DEFAULT_WARNING_BYTES,
+            DEFAULT_CRITICAL_BYTES,
+        );
+        assert!(
+            matches!(status, DiskStatus::Warning { .. }),
+            "exactly at critical threshold should be Warning, got {status}"
+        );
+    }
+
+    #[test]
+    fn classify_zero_bytes_is_critical() {
+        let status = classify(0, DEFAULT_WARNING_BYTES, DEFAULT_CRITICAL_BYTES);
+        assert!(
+            matches!(status, DiskStatus::Critical { .. }),
+            "0 bytes should be Critical, got {status}"
+        );
+    }
+
+    #[test]
+    fn monitor_initial_status_is_ok() {
+        let monitor = DiskSpaceMonitor::new(DEFAULT_WARNING_BYTES, DEFAULT_CRITICAL_BYTES);
+        assert!(
+            matches!(monitor.status(), DiskStatus::Ok { .. }),
+            "initial status should be Ok (u64::MAX cached)"
+        );
+    }
+
+    #[test]
+    fn monitor_status_reflects_cached_value() {
+        let monitor = DiskSpaceMonitor::new(DEFAULT_WARNING_BYTES, DEFAULT_CRITICAL_BYTES);
+        monitor
+            .cached_available
+            .store(50_000_000, Ordering::Relaxed);
+        assert!(
+            monitor.status().is_critical(),
+            "50 MB cached should produce Critical status"
+        );
+    }
+
+    #[test]
+    fn monitor_allow_non_essential_write_at_ok() {
+        let monitor = DiskSpaceMonitor::new(DEFAULT_WARNING_BYTES, DEFAULT_CRITICAL_BYTES);
+        assert!(
+            monitor.allow_non_essential_write(),
+            "should allow non-essential writes when Ok"
+        );
+    }
+
+    #[test]
+    fn monitor_blocks_non_essential_write_at_critical() {
+        let monitor = DiskSpaceMonitor::new(DEFAULT_WARNING_BYTES, DEFAULT_CRITICAL_BYTES);
+        monitor
+            .cached_available
+            .store(50_000_000, Ordering::Relaxed);
+        assert!(
+            !monitor.allow_non_essential_write(),
+            "should block non-essential writes when Critical"
+        );
+    }
+
+    #[test]
+    fn monitor_allows_non_essential_write_at_warning() {
+        let monitor = DiskSpaceMonitor::new(DEFAULT_WARNING_BYTES, DEFAULT_CRITICAL_BYTES);
+        monitor
+            .cached_available
+            .store(500_000_000, Ordering::Relaxed);
+        assert!(
+            monitor.allow_non_essential_write(),
+            "should allow non-essential writes when Warning"
+        );
+    }
+
+    #[test]
+    fn available_bytes_accessor_returns_value() {
+        let status = DiskStatus::Warning {
+            available_bytes: 42,
+        };
+        assert_eq!(status.available_bytes(), 42);
+    }
+
+    #[test]
+    fn disk_status_display_includes_mb() {
+        let status = DiskStatus::Warning {
+            available_bytes: 500 * BYTES_PER_MB,
+        };
+        let display = status.to_string();
+        assert!(
+            display.contains("500"),
+            "display should contain MB value: {display}"
+        );
+        assert!(
+            display.contains("warning"),
+            "display should contain level: {display}"
+        );
+    }
+
+    #[test]
+    fn check_disk_space_returns_valid_status() {
+        let status = check_disk_space(
+            Path::new("/"),
+            DEFAULT_WARNING_BYTES,
+            DEFAULT_CRITICAL_BYTES,
+        )
+        .unwrap();
+        // NOTE: On any real filesystem "/" should have some space.
+        assert!(status.available_bytes() > 0, "root fs should have space");
+    }
+
+    #[test]
+    fn refresh_updates_cached_value() {
+        let monitor = DiskSpaceMonitor::new(DEFAULT_WARNING_BYTES, DEFAULT_CRITICAL_BYTES);
+        let status = monitor.refresh(Path::new("/")).unwrap();
+        assert!(
+            status.available_bytes() > 0,
+            "root fs should report available space"
+        );
+        assert_eq!(
+            monitor.status().available_bytes(),
+            status.available_bytes(),
+            "cached value should match refresh result"
+        );
+    }
+
+    #[test]
+    fn monitor_is_send_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<DiskSpaceMonitor>();
+    }
+
+    #[test]
+    fn disk_status_is_send_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<DiskStatus>();
+    }
+}

--- a/crates/koina/src/lib.rs
+++ b/crates/koina/src/lib.rs
@@ -6,6 +6,8 @@
 
 /// Credential provider trait for dynamic API key resolution.
 pub mod credential;
+/// Disk space monitoring: threshold checks, cached monitor, write guards.
+pub mod disk_space;
 /// Error types shared across all Aletheia crates (file I/O, JSON, identifiers).
 pub mod error;
 /// Newtype wrappers for domain identifiers ([`id::NousId`], [`id::SessionId`], [`id::TurnId`], [`id::ToolName`]).

--- a/crates/mneme/Cargo.toml
+++ b/crates/mneme/Cargo.toml
@@ -35,6 +35,7 @@ storage-fjall = ["dep:fjall", "mneme-engine"]
 hnsw_rs = ["dep:hnsw_rs"]
 
 [dependencies]
+aletheia-koina = { path = "../koina" }
 jiff = { workspace = true, features = ["serde"] }
 ndarray = { version = "0.17", features = ["serde"], optional = true }
 rusqlite = { workspace = true, optional = true }

--- a/crates/mneme/src/backup.rs
+++ b/crates/mneme/src/backup.rs
@@ -2,9 +2,10 @@
 
 use std::path::{Path, PathBuf};
 
+use aletheia_koina::disk_space::DiskSpaceMonitor;
 use rusqlite::Connection;
 use snafu::ResultExt;
-use tracing::{info, instrument};
+use tracing::{info, instrument, warn};
 
 use crate::error::{self, Result};
 
@@ -40,6 +41,7 @@ fn validate_backup_path(path: &Path) -> Result<()> {
 pub struct BackupManager<'a> {
     conn: &'a Connection,
     backup_dir: PathBuf,
+    disk_monitor: Option<DiskSpaceMonitor>,
 }
 
 /// Outcome of creating a backup.
@@ -74,10 +76,20 @@ impl<'a> BackupManager<'a> {
         Self {
             conn,
             backup_dir: backup_dir.into(),
+            disk_monitor: None,
         }
     }
 
+    /// Attach a disk space monitor. Backups are non-essential and will be
+    /// skipped when disk space reaches the critical threshold.
+    pub fn set_disk_monitor(&mut self, monitor: DiskSpaceMonitor) {
+        self.disk_monitor = Some(monitor);
+    }
+
     /// Create a `SQLite` backup using `VACUUM INTO`.
+    ///
+    /// Backups are non-essential writes. When disk space is critical, this
+    /// method returns `Ok(None)` instead of writing.
     ///
     /// # SQL injection defense
     ///
@@ -89,7 +101,15 @@ impl<'a> BackupManager<'a> {
     /// sequences. Any future changes to path construction MUST go through
     /// `validate_backup_path` (a private helper in this module).
     #[instrument(skip(self))]
-    pub fn create_backup(&self) -> Result<BackupResult> {
+    pub fn create_backup(&self) -> Result<Option<BackupResult>> {
+        if let Some(ref monitor) = self.disk_monitor
+            && !monitor.allow_non_essential_write()
+        {
+            let mb = monitor.status().available_bytes() / (1024 * 1024);
+            warn!(available_mb = mb, "skipping backup: disk space critical");
+            return Ok(None);
+        }
+
         std::fs::create_dir_all(&self.backup_dir).context(error::IoSnafu {
             path: self.backup_dir.clone(),
         })?;
@@ -125,17 +145,31 @@ impl<'a> BackupManager<'a> {
             "backup created"
         );
 
-        Ok(BackupResult {
+        Ok(Some(BackupResult {
             path: backup_path,
             size_bytes: metadata.len(),
             sessions_count,
             messages_count,
-        })
+        }))
     }
 
     /// Export all sessions as individual JSON files.
+    ///
+    /// Exports are non-essential writes. When disk space is critical, this
+    /// method returns `Ok(None)` instead of writing.
     #[instrument(skip(self))]
-    pub fn export_sessions_json(&self, output_dir: &Path) -> Result<ExportResult> {
+    pub fn export_sessions_json(&self, output_dir: &Path) -> Result<Option<ExportResult>> {
+        if let Some(ref monitor) = self.disk_monitor
+            && !monitor.allow_non_essential_write()
+        {
+            let mb = monitor.status().available_bytes() / (1024 * 1024);
+            warn!(
+                available_mb = mb,
+                "skipping JSON export: disk space critical"
+            );
+            return Ok(None);
+        }
+
         std::fs::create_dir_all(output_dir).context(error::IoSnafu {
             path: output_dir.to_path_buf(),
         })?;
@@ -162,11 +196,11 @@ impl<'a> BackupManager<'a> {
         let count = u32::try_from(session_ids.len()).unwrap_or(u32::MAX);
         info!(sessions = count, dir = %output_dir.display(), "JSON export complete");
 
-        Ok(ExportResult {
+        Ok(Some(ExportResult {
             output_dir: output_dir.to_path_buf(),
             sessions_exported: count,
             files_written,
-        })
+        }))
     }
 
     /// List available backup files.

--- a/crates/mneme/src/backup_tests.rs
+++ b/crates/mneme/src/backup_tests.rs
@@ -24,7 +24,8 @@ fn json_export_produces_valid_files() {
 
     let result = manager
         .export_sessions_json(&export_dir)
-        .expect("export sessions as JSON");
+        .expect("export sessions as JSON")
+        .expect("export should not be skipped without disk monitor");
     assert_eq!(result.sessions_exported, 1);
     assert_eq!(result.files_written, 1);
 
@@ -60,7 +61,10 @@ fn backup_creates_valid_sqlite_database() {
 
     let backup_dir = dir.path().join("backups");
     let manager = BackupManager::new(&conn, &backup_dir);
-    let result = manager.create_backup().expect("create backup");
+    let result = manager
+        .create_backup()
+        .expect("create backup")
+        .expect("backup should not be skipped without disk monitor");
 
     assert!(result.path.exists());
     assert!(result.size_bytes > 0);
@@ -204,7 +208,10 @@ fn restore_backup_preserves_data() {
 
     let backup_dir = dir.path().join("backups");
     let manager = BackupManager::new(&conn, &backup_dir);
-    let result = manager.create_backup().expect("create backup");
+    let result = manager
+        .create_backup()
+        .expect("create backup")
+        .expect("backup should not be skipped without disk monitor");
 
     let backup_conn = Connection::open(&result.path).expect("open backup SQLite database");
     let session_count: u32 = backup_conn
@@ -421,7 +428,8 @@ fn json_export_is_valid_json() {
     let manager = BackupManager::new(store.conn(), dir.path().join("backups"));
     let result = manager
         .export_sessions_json(&export_dir)
-        .expect("export sessions as JSON");
+        .expect("export sessions as JSON")
+        .expect("export should not be skipped without disk monitor");
 
     assert_eq!(result.sessions_exported, 1);
     assert_eq!(result.files_written, 1);
@@ -458,7 +466,8 @@ fn backup_empty_store() {
     let manager = BackupManager::new(&conn, &backup_dir);
     let result = manager
         .create_backup()
-        .expect("create backup of empty store");
+        .expect("create backup of empty store")
+        .expect("backup should not be skipped without disk monitor");
 
     assert!(result.path.exists());
     assert!(result.size_bytes > 0);
@@ -559,7 +568,8 @@ fn export_sessions_json_empty_store() {
 
     let result = manager
         .export_sessions_json(&export_dir)
-        .expect("export empty store as JSON");
+        .expect("export empty store as JSON")
+        .expect("export should not be skipped without disk monitor");
     assert_eq!(result.sessions_exported, 0);
     assert_eq!(result.files_written, 0);
     assert!(

--- a/crates/mneme/src/store/message.rs
+++ b/crates/mneme/src/store/message.rs
@@ -21,6 +21,7 @@ impl SessionStore {
         tool_name: Option<&str>,
         token_estimate: i64,
     ) -> Result<i64> {
+        self.check_disk("append_message");
         let tx = self
             .conn
             .unchecked_transaction()

--- a/crates/mneme/src/store/mod.rs
+++ b/crates/mneme/src/store/mod.rs
@@ -15,9 +15,10 @@ mod tests;
 
 use std::path::Path;
 
+use aletheia_koina::disk_space::{DiskSpaceMonitor, DiskStatus};
 use rusqlite::Connection;
 use snafu::ResultExt;
-use tracing::{info, instrument};
+use tracing::{error, info, instrument, warn};
 
 use crate::error::{self, Result};
 use crate::migration;
@@ -28,6 +29,7 @@ use crate::types::{
 /// The session store: wraps a `SQLite` connection.
 pub struct SessionStore {
     conn: Connection,
+    disk_monitor: Option<DiskSpaceMonitor>,
 }
 
 impl SessionStore {
@@ -50,7 +52,10 @@ impl SessionStore {
 
         migration::run_migrations(&conn)?;
 
-        Ok(Self { conn })
+        Ok(Self {
+            conn,
+            disk_monitor: None,
+        })
     }
 
     /// Open an in-memory session store (for testing).
@@ -63,7 +68,41 @@ impl SessionStore {
         conn.execute_batch("PRAGMA foreign_keys = ON;")
             .context(error::DatabaseSnafu)?;
         migration::run_migrations(&conn)?;
-        Ok(Self { conn })
+        Ok(Self {
+            conn,
+            disk_monitor: None,
+        })
+    }
+
+    /// Attach a disk space monitor for pre-write checks.
+    pub fn set_disk_monitor(&mut self, monitor: DiskSpaceMonitor) {
+        self.disk_monitor = Some(monitor);
+    }
+
+    /// Emit tracing diagnostics based on current disk status.
+    ///
+    /// Database writes are essential and always proceed, but warnings and
+    /// errors are emitted so operators can respond before the disk fills.
+    pub(crate) fn check_disk(&self, operation: &str) {
+        if let Some(ref monitor) = self.disk_monitor {
+            match monitor.status() {
+                DiskStatus::Warning { available_bytes } => {
+                    let mb = available_bytes / (1024 * 1024);
+                    warn!(
+                        available_mb = mb,
+                        operation, "disk space low, database write proceeding"
+                    );
+                }
+                DiskStatus::Critical { available_bytes } => {
+                    let mb = available_bytes / (1024 * 1024);
+                    error!(
+                        available_mb = mb,
+                        operation, "disk space critical, database write proceeding (essential)"
+                    );
+                }
+                _ => {}
+            }
+        }
     }
 
     /// Lightweight liveness check: executes `SELECT 1` against the connection.

--- a/crates/mneme/src/store/session.rs
+++ b/crates/mneme/src/store/session.rs
@@ -54,6 +54,7 @@ impl SessionStore {
         parent_session_id: Option<&str>,
         model: Option<&str>,
     ) -> Result<Session> {
+        self.check_disk("create_session");
         let session_type = SessionType::from_key(session_key);
 
         self.conn

--- a/crates/taxis/Cargo.toml
+++ b/crates/taxis/Cargo.toml
@@ -11,6 +11,7 @@ rust-version.workspace = true
 workspace = true
 
 [dependencies]
+aletheia-koina = { path = "../koina" }
 base64 = { workspace = true }
 figment = { workspace = true }
 rand = { workspace = true }

--- a/crates/taxis/src/config.rs
+++ b/crates/taxis/src/config.rs
@@ -627,6 +627,8 @@ pub struct MaintenanceSettings {
     pub drift_detection: DriftDetectionSettings,
     /// Database size monitoring and alerting.
     pub db_monitoring: DbMonitoringSettings,
+    /// Proactive disk space monitoring and write protection.
+    pub disk_space: DiskSpaceSettings,
     /// Automatic data retention enforcement.
     pub retention: RetentionSettings,
     /// Whether background knowledge graph maintenance tasks are enabled.
@@ -710,6 +712,36 @@ impl Default for DbMonitoringSettings {
             enabled: true,
             warn_threshold_mb: 100,
             alert_threshold_mb: 500,
+        }
+    }
+}
+
+/// Proactive disk space monitoring settings.
+///
+/// A background task periodically checks available disk space and updates a
+/// shared atomic counter. Write paths read the counter to decide whether to
+/// proceed, warn, or reject non-essential writes.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[serde(default)]
+pub struct DiskSpaceSettings {
+    /// Whether disk space monitoring is active.
+    pub enabled: bool,
+    /// Emit a warning when available space drops below this value (MB).
+    pub warning_threshold_mb: u64,
+    /// Reject non-essential writes when available space drops below this value (MB).
+    pub critical_threshold_mb: u64,
+    /// Seconds between background disk space checks.
+    pub check_interval_secs: u64,
+}
+
+impl Default for DiskSpaceSettings {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            warning_threshold_mb: 1024,
+            critical_threshold_mb: 100,
+            check_interval_secs: 60,
         }
     }
 }

--- a/crates/taxis/src/loader.rs
+++ b/crates/taxis/src/loader.rs
@@ -1,9 +1,10 @@
 //! Figment-based configuration loading with TOML cascade.
 
+use aletheia_koina::disk_space::{DiskSpaceMonitor, DiskStatus};
 use figment::Figment;
 use figment::providers::{Env, Format, Serialized, Toml};
 use snafu::ResultExt;
-use tracing::warn;
+use tracing::{error, warn};
 
 use crate::config::AletheiaConfig;
 use crate::encrypt;
@@ -101,6 +102,42 @@ fn decrypt_toml_content(content: &str) -> String {
     reason = "figment::Error is inherently large"
 )]
 pub fn write_config(oikos: &Oikos, config: &AletheiaConfig) -> Result<()> {
+    write_config_checked(oikos, config, None)
+}
+
+/// Write configuration with optional disk space monitoring.
+///
+/// Config writes are essential (state preservation), so they always proceed.
+/// Warning and critical disk states emit tracing diagnostics.
+#[expect(
+    clippy::result_large_err,
+    reason = "figment::Error is inherently large"
+)]
+pub fn write_config_checked(
+    oikos: &Oikos,
+    config: &AletheiaConfig,
+    disk_monitor: Option<&DiskSpaceMonitor>,
+) -> Result<()> {
+    if let Some(monitor) = disk_monitor {
+        match monitor.status() {
+            DiskStatus::Warning { available_bytes } => {
+                let mb = available_bytes / (1024 * 1024);
+                warn!(
+                    available_mb = mb,
+                    "disk space low, config write proceeding (essential)"
+                );
+            }
+            DiskStatus::Critical { available_bytes } => {
+                let mb = available_bytes / (1024 * 1024);
+                error!(
+                    available_mb = mb,
+                    "disk space critical, config write proceeding (essential)"
+                );
+            }
+            _ => {}
+        }
+    }
+
     let toml = toml::to_string(config).map_err(|e| {
         SerializeTomlSnafu {
             reason: e.to_string(),


### PR DESCRIPTION
## Summary
- Add disk space monitoring to maintenance daemon
- Graceful degradation when disk space is low (warn, then restrict writes)

## Test plan
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes