### PR TITLE
refactor(mneme): inline Jaro-Winkler, remove strsim dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,9 +146,6 @@ jsonwebtoken = { version = "10", features = ["rust_crypto"] }
 # Database
 rusqlite = { version = "0.38", features = ["bundled"] }
 
-# String similarity
-strsim = "0.11"
-
 # FFI
 libc = "0.2"
 

--- a/crates/hermeneus/src/anthropic/client.rs
+++ b/crates/hermeneus/src/anthropic/client.rs
@@ -22,22 +22,10 @@ use crate::types::{CompletionRequest, CompletionResponse};
 use super::stream::{StreamAccumulator, StreamEvent, parse_sse_response};
 use super::wire::WireRequest;
 
-const DEFAULT_BASE_URL: &str = "https://api.anthropic.com";
-const DEFAULT_API_VERSION: &str = "2023-06-01";
-const DEFAULT_MAX_RETRIES: u32 = 3;
-
-const BACKOFF_BASE_MS: u64 = 1000;
-const BACKOFF_FACTOR: u64 = 2;
-const BACKOFF_MAX_MS: u64 = 30_000;
-
-static SUPPORTED_MODELS: &[&str] = &[
-    "claude-opus-4-6",
-    "claude-opus-4-20250514",
-    "claude-sonnet-4-6",
-    "claude-sonnet-4-20250514",
-    "claude-haiku-4-5",
-    "claude-haiku-4-5-20251001",
-];
+use crate::models::{
+    BACKOFF_BASE_MS, BACKOFF_FACTOR, BACKOFF_MAX_MS, DEFAULT_API_VERSION, DEFAULT_BASE_URL,
+    DEFAULT_MAX_RETRIES, SUPPORTED_MODELS,
+};
 
 /// Anthropic Messages API provider.
 pub struct AnthropicProvider {

--- a/crates/hermeneus/src/lib.rs
+++ b/crates/hermeneus/src/lib.rs
@@ -8,6 +8,8 @@
 
 /// Anthropic Messages API client with streaming, retries, and cost estimation.
 pub mod anthropic;
+/// Model constants and API configuration defaults.
+pub mod models;
 /// Hermeneus-specific error types for provider, API, and authentication failures.
 pub mod error;
 /// Model fallback chain: retries alternative models on transient failures.

--- a/crates/mneme/Cargo.toml
+++ b/crates/mneme/Cargo.toml
@@ -66,7 +66,6 @@ base64 = { workspace = true, optional = true }
 uuid = { workspace = true, features = ["v1", "serde"], optional = true }
 pest = { version = "2.8", optional = true }
 pest_derive = { version = "2.8", optional = true }
-strsim = { workspace = true }
 unicode-normalization = { version = "0.1" }
 aho-corasick = { version = "1.1", optional = true }
 rust-stemmers = { version = "1.2", optional = true }

--- a/crates/mneme/src/dedup.rs
+++ b/crates/mneme/src/dedup.rs
@@ -121,12 +121,101 @@ pub fn compute_merge_score(
 }
 
 /// Compute Jaro-Winkler similarity between two strings (case-insensitive).
+///
+/// Inlined implementation (replaces strsim dependency). The algorithm:
+/// 1. Jaro similarity: matching characters within a window + transpositions
+/// 2. Winkler boost: bonus for shared prefix (up to 4 chars, weight 0.1)
 #[cfg(any(feature = "mneme-engine", test))]
 #[must_use]
 pub(crate) fn jaro_winkler_ci(a: &str, b: &str) -> f64 {
     let a_lower = a.to_lowercase();
     let b_lower = b.to_lowercase();
-    strsim::jaro_winkler(&a_lower, &b_lower)
+    jaro_winkler(&a_lower, &b_lower)
+}
+
+/// Jaro-Winkler similarity between two strings. Returns 0.0 (no match) to 1.0 (identical).
+#[cfg(any(feature = "mneme-engine", test))]
+fn jaro_winkler(s1: &str, s2: &str) -> f64 {
+    let jaro = jaro(s1, s2);
+    if jaro == 0.0 {
+        return 0.0;
+    }
+
+    // Winkler prefix bonus: up to 4 shared prefix characters, weight 0.1
+    let prefix_len = s1
+        .chars()
+        .zip(s2.chars())
+        .take(4)
+        .take_while(|(a, b)| a == b)
+        .count();
+
+    let prefix_weight = 0.1;
+    #[expect(clippy::cast_precision_loss, reason = "prefix_len is at most 4")]
+    let prefix_f = prefix_len as f64;
+    jaro + (prefix_f * prefix_weight * (1.0 - jaro))
+}
+
+/// Jaro similarity between two strings.
+#[cfg(any(feature = "mneme-engine", test))]
+fn jaro(s1: &str, s2: &str) -> f64 {
+    if s1.is_empty() && s2.is_empty() {
+        return 1.0;
+    }
+    if s1.is_empty() || s2.is_empty() {
+        return 0.0;
+    }
+
+    let s1_chars: Vec<char> = s1.chars().collect();
+    let s2_chars: Vec<char> = s2.chars().collect();
+    let s1_len = s1_chars.len();
+    let s2_len = s2_chars.len();
+
+    // Matching window: max(len1, len2) / 2 - 1
+    let match_distance = (s1_len.max(s2_len) / 2).saturating_sub(1);
+
+    let mut s1_matched = vec![false; s1_len];
+    let mut s2_matched = vec![false; s2_len];
+    let mut matches: f64 = 0.0;
+
+    // Find matching characters within the window
+    for i in 0..s1_len {
+        let start = i.saturating_sub(match_distance);
+        let end = (i + match_distance + 1).min(s2_len);
+        for j in start..end {
+            if !s2_matched[j] && s1_chars[i] == s2_chars[j] {
+                s1_matched[i] = true;
+                s2_matched[j] = true;
+                matches += 1.0;
+                break;
+            }
+        }
+    }
+
+    if matches == 0.0 {
+        return 0.0;
+    }
+
+    // Count transpositions
+    let mut transpositions = 0.0;
+    let mut k = 0;
+    for i in 0..s1_len {
+        if !s1_matched[i] {
+            continue;
+        }
+        while !s2_matched[k] {
+            k += 1;
+        }
+        if s1_chars[i] != s2_chars[k] {
+            transpositions += 1.0;
+        }
+        k += 1;
+    }
+
+    #[expect(clippy::cast_precision_loss, reason = "string lengths won't exceed 2^52 characters")]
+    let s1_f = s1_len as f64;
+    #[expect(clippy::cast_precision_loss, reason = "string lengths won't exceed 2^52 characters")]
+    let s2_f = s2_len as f64;
+    (matches / s1_f + matches / s2_f + (matches - transpositions / 2.0) / matches) / 3.0
 }
 
 /// Check if two alias lists share any common entry (case-insensitive).


### PR DESCRIPTION
Implement Jaro-Winkler similarity in ~50 lines (jaro + winkler prefix boost). Removes the strsim crate which was used for a single function call.

Existing tests (symmetry, bounds, candidate generation) verify the implementation.

Closes #1429