### PR TITLE
api: add #[must_use] to all public Result-returning functions

### DIFF
--- a/crates/agora/src/registry.rs
+++ b/crates/agora/src/registry.rs
@@ -36,6 +36,7 @@ impl ChannelRegistry {
     /// # Errors
     ///
     /// Returns [`crate::error::Error::DuplicateChannel`] if a provider with the same ID is already registered.
+    #[must_use]
     pub fn register(&mut self, provider: Arc<dyn ChannelProvider>) -> Result<()> {
         let id = provider.id().to_owned();
         ensure!(
@@ -59,6 +60,7 @@ impl ChannelRegistry {
     /// # Errors
     ///
     /// Returns [`crate::error::Error::UnknownChannel`] if the channel is not registered.
+    #[must_use]
     pub async fn send(&self, channel_id: &str, params: &SendParams) -> Result<SendResult> {
         let provider = self.providers.get(channel_id).ok_or_else(|| {
             error::UnknownChannelSnafu {
@@ -70,6 +72,7 @@ impl ChannelRegistry {
     }
 
     /// Probe all registered channels for health status.
+    #[must_use]
     pub async fn probe_all(&self) -> IndexMap<String, ProbeResult> {
         let mut results = IndexMap::with_capacity(self.providers.len());
         for (id, provider) in &self.providers {

--- a/crates/agora/src/semeion/client.rs
+++ b/crates/agora/src/semeion/client.rs
@@ -54,6 +54,7 @@ impl SignalClient {
     /// # Errors
     ///
     /// Returns [`super::error::Error::Http`] if the HTTP client cannot be constructed.
+    #[must_use]
     pub fn new(base_url: &str) -> Result<Self> {
         let base = normalize_url(base_url);
 
@@ -118,6 +119,7 @@ impl SignalClient {
     /// Retries up to 2 times with 500ms, 1000ms backoff.
     /// Does NOT retry JSON-RPC application errors (only transport failures).
     #[instrument(skip(self, params))]
+    #[must_use]
     pub async fn send_message(&self, params: &SendParams) -> Result<Option<serde_json::Value>> {
         let rpc_params = params.to_rpc_value();
         let backoffs = [500u64, 1000];
@@ -167,6 +169,7 @@ impl SignalClient {
     /// that have accumulated since the last call. Uses a longer timeout than
     /// standard RPC calls since receive may block briefly.
     #[instrument(skip(self))]
+    #[must_use]
     pub async fn receive(&self, account: Option<&str>) -> Result<Vec<SignalEnvelope>> {
         let mut params = serde_json::Map::new();
         if let Some(acct) = account {

--- a/crates/aletheia/src/commands/add_nous.rs
+++ b/crates/aletheia/src/commands/add_nous.rs
@@ -21,6 +21,7 @@ pub struct AddNousArgs {
     pub model: String,
 }
 
+#[must_use]
 pub async fn run(instance_root: Option<&PathBuf>, args: &AddNousArgs) -> Result<()> {
     validate_name(&args.name)?;
     validate_provider(&args.provider)?;

--- a/crates/aletheia/src/commands/agent_io.rs
+++ b/crates/aletheia/src/commands/agent_io.rs
@@ -166,6 +166,7 @@ use aletheia_taxis::config::resolve_nous;
 use aletheia_taxis::loader::load_config;
 use aletheia_taxis::oikos::Oikos;
 
+#[must_use]
 pub fn export_agent(instance_root: Option<&PathBuf>, args: &ExportArgs) -> Result<()> {
     let nous_id = &args.nous_id;
     let oikos = match instance_root {
@@ -240,6 +241,7 @@ pub fn export_agent(instance_root: Option<&PathBuf>, args: &ExportArgs) -> Resul
     Ok(())
 }
 
+#[must_use]
 pub fn import_agent(instance_root: Option<&PathBuf>, args: &ImportArgs) -> Result<()> {
     let json = std::fs::read_to_string(&args.file)
         .with_context(|| format!("failed to read {}", args.file.display()))?;
@@ -316,6 +318,7 @@ pub fn import_agent(instance_root: Option<&PathBuf>, args: &ImportArgs) -> Resul
     clippy::too_many_lines,
     reason = "CLI dispatch is inherently verbose — splitting would hurt readability"
 )]
+#[must_use]
 pub fn seed_skills(args: &SeedSkillsArgs) -> Result<()> {
     use aletheia_mneme::skill::{SkillContent, parse_skill_md, scan_skill_dir};
 
@@ -464,6 +467,7 @@ pub fn seed_skills(args: &SeedSkillsArgs) -> Result<()> {
 ///
 /// Reads skill facts from an in-process `KnowledgeStore`, converts them to
 /// `SkillContent`, and writes `.claude/skills/<slug>/SKILL.md` files.
+#[must_use]
 pub fn export_skills(instance_root: Option<&PathBuf>, args: &ExportSkillsArgs) -> Result<()> {
     #[cfg(feature = "recall")]
     {
@@ -546,6 +550,7 @@ pub fn export_skills(instance_root: Option<&PathBuf>, args: &ExportSkillsArgs) -
     }
 }
 
+#[must_use]
 pub fn review_skills(instance_root: Option<&PathBuf>, args: &ReviewSkillsArgs) -> Result<()> {
     #[cfg(feature = "recall")]
     {

--- a/crates/aletheia/src/commands/backup.rs
+++ b/crates/aletheia/src/commands/backup.rs
@@ -34,6 +34,7 @@ pub struct BackupArgs {
     pub yes: bool,
 }
 
+#[must_use]
 pub fn run(instance_root: Option<&PathBuf>, args: &BackupArgs) -> Result<()> {
     let &BackupArgs {
         list,

--- a/crates/aletheia/src/commands/check_config.rs
+++ b/crates/aletheia/src/commands/check_config.rs
@@ -11,6 +11,7 @@ use aletheia_taxis::validate::validate_section;
 /// Run `aletheia check-config`: load config, validate all sections, report and exit.
 ///
 /// Exits 0 on success, 1 if any check fails.
+#[must_use]
 pub fn run(instance_root: Option<&PathBuf>) -> Result<()> {
     let oikos = match instance_root {
         Some(root) => Oikos::from_root(root),

--- a/crates/aletheia/src/commands/config.rs
+++ b/crates/aletheia/src/commands/config.rs
@@ -16,6 +16,7 @@ pub enum Action {
     Encrypt,
 }
 
+#[must_use]
 pub fn run(action: &Action, instance_root: Option<&PathBuf>) -> Result<()> {
     match action {
         Action::InitKey => run_init_key(),

--- a/crates/aletheia/src/commands/credential.rs
+++ b/crates/aletheia/src/commands/credential.rs
@@ -28,6 +28,7 @@ fn token_preview(s: &str) -> String {
     }
 }
 
+#[must_use]
 pub async fn run(action: Action, instance_root: Option<&PathBuf>) -> Result<()> {
     let oikos = match instance_root {
         Some(root) => Oikos::from_root(root),

--- a/crates/aletheia/src/commands/eval.rs
+++ b/crates/aletheia/src/commands/eval.rs
@@ -22,6 +22,7 @@ pub struct EvalArgs {
     pub timeout: u64,
 }
 
+#[must_use]
 pub async fn run(args: EvalArgs) -> Result<()> {
     let EvalArgs {
         url,

--- a/crates/aletheia/src/commands/health.rs
+++ b/crates/aletheia/src/commands/health.rs
@@ -10,6 +10,7 @@ pub struct HealthArgs {
     pub url: String,
 }
 
+#[must_use]
 pub async fn run(args: &HealthArgs) -> Result<()> {
     let url = &args.url;
     let endpoint = format!("{url}/api/health");

--- a/crates/aletheia/src/commands/maintenance.rs
+++ b/crates/aletheia/src/commands/maintenance.rs
@@ -32,6 +32,7 @@ pub enum Action {
     },
 }
 
+#[must_use]
 pub fn run(action: Action, instance_root: Option<&PathBuf>) -> Result<()> {
     let oikos = match instance_root {
         Some(root) => Oikos::from_root(root),

--- a/crates/aletheia/src/commands/server.rs
+++ b/crates/aletheia/src/commands/server.rs
@@ -64,6 +64,7 @@ pub struct Args {
     clippy::too_many_lines,
     reason = "binary entrypoint — sequential init steps"
 )]
+#[must_use]
 pub async fn run(args: Args) -> Result<()> {
     // Oikos is pure path resolution: no IO, safe before tracing is set up.
     let oikos = match &args.instance_root {

--- a/crates/aletheia/src/commands/session_export.rs
+++ b/crates/aletheia/src/commands/session_export.rs
@@ -56,6 +56,7 @@ struct HistoryMessage {
     created_at: String,
 }
 
+#[must_use]
 pub async fn run(args: &SessionExportArgs) -> Result<()> {
     let client = build_client(args.token.as_deref())?;
 

--- a/crates/aletheia/src/commands/tls.rs
+++ b/crates/aletheia/src/commands/tls.rs
@@ -24,6 +24,7 @@ pub enum Action {
     },
 }
 
+#[must_use]
 pub fn run(action: &Action) -> Result<()> {
     match action {
         Action::Generate {

--- a/crates/aletheia/src/status.rs
+++ b/crates/aletheia/src/status.rs
@@ -24,6 +24,7 @@ pub(crate) enum StatusError {
 }
 
 /// Run the status command against a running (or stopped) instance.
+#[must_use]
 pub async fn run(url: &str, instance_root: Option<&std::path::PathBuf>) -> Result<(), StatusError> {
     let use_color = supports_color::on(supports_color::Stream::Stdout).is_some();
     let version = env!("CARGO_PKG_VERSION");

--- a/crates/daemon/src/maintenance/db_monitor.rs
+++ b/crates/daemon/src/maintenance/db_monitor.rs
@@ -90,6 +90,7 @@ impl DbMonitor {
     }
 
     /// Check all database files and return a size report.
+    #[must_use]
     pub fn check(&self) -> error::Result<DbSizeReport> {
         let mut report = DbSizeReport::default();
 

--- a/crates/daemon/src/maintenance/drift_detection.rs
+++ b/crates/daemon/src/maintenance/drift_detection.rs
@@ -64,6 +64,7 @@ impl DriftDetector {
     }
 
     /// Run drift detection. Returns a report of discrepancies.
+    #[must_use]
     pub fn check(&self) -> error::Result<DriftReport> {
         if !self.config.example_root.exists() {
             return Ok(DriftReport {

--- a/crates/daemon/src/maintenance/trace_rotation.rs
+++ b/crates/daemon/src/maintenance/trace_rotation.rs
@@ -84,6 +84,7 @@ impl TraceRotator {
         clippy::expect_used,
         reason = "file_name() is None only for paths ending in '..', which trace files never are"
     )]
+    #[must_use]
     pub fn rotate(&self) -> error::Result<RotationReport> {
         if let Some(ref monitor) = self.disk_monitor
             && !monitor.allow_non_essential_write()

--- a/crates/daemon/src/prosoche.rs
+++ b/crates/daemon/src/prosoche.rs
@@ -105,6 +105,7 @@ impl ProsocheCheck {
     /// - Disk space on the data directory
     /// - Database file sizes
     /// - Process memory (RSS) via /proc/self/status
+    #[must_use]
     pub async fn run(&self) -> crate::error::Result<ProsocheResult> {
         let mut items = Vec::new();
 

--- a/crates/daemon/src/schedule.rs
+++ b/crates/daemon/src/schedule.rs
@@ -113,6 +113,7 @@ impl Schedule {
         clippy::expect_used,
         reason = "timestamp conversions are within valid ranges; interval durations fit in i64 nanos for any reasonable schedule"
     )]
+    #[must_use]
     pub fn next_run(&self) -> Result<Option<jiff::Timestamp>> {
         match self {
             Self::Cron(expr) => {
@@ -154,6 +155,7 @@ impl Schedule {
         clippy::expect_used,
         reason = "timestamp conversions within valid ranges; 24h subtraction from current time cannot overflow"
     )]
+    #[must_use]
     pub fn missed_since(&self, last_run: jiff::Timestamp) -> Result<bool> {
         let Self::Cron(expr) = self else {
             return Ok(false);

--- a/crates/daemon/src/state.rs
+++ b/crates/daemon/src/state.rs
@@ -30,6 +30,7 @@ pub struct TaskStateStore {
 
 impl TaskStateStore {
     /// Open (or create) the task state database at `path`.
+    #[must_use]
     pub fn open(path: &Path) -> Result<Self> {
         let conn = rusqlite::Connection::open(path).map_err(|e| {
             crate::error::TaskFailedSnafu {
@@ -62,6 +63,7 @@ impl TaskStateStore {
     }
 
     /// Load all persisted task states.
+    #[must_use]
     pub fn load_all(&self) -> Result<Vec<TaskState>> {
         let mut stmt = self
             .conn
@@ -108,6 +110,7 @@ impl TaskStateStore {
     }
 
     /// Persist (upsert) the state for a task.
+    #[must_use]
     pub fn save(&self, state: &TaskState) -> Result<()> {
         self.conn
             .execute(

--- a/crates/dianoia/src/plan.rs
+++ b/crates/dianoia/src/plan.rs
@@ -87,6 +87,7 @@ impl Plan {
     }
 
     /// Record an iteration. Returns `Err` if `max_iterations` exceeded.
+    #[must_use]
     pub fn record_iteration(&mut self) -> Result<()> {
         self.iterations += 1;
         if self.iterations > self.max_iterations {

--- a/crates/dianoia/src/project.rs
+++ b/crates/dianoia/src/project.rs
@@ -63,6 +63,7 @@ impl Project {
     }
 
     /// Advance project state via a transition.
+    #[must_use]
     pub fn advance(&mut self, transition: Transition) -> Result<()> {
         let current = self.state.clone();
         self.state = current.transition(transition)?;

--- a/crates/dianoia/src/state.rs
+++ b/crates/dianoia/src/state.rs
@@ -68,6 +68,7 @@ pub enum Transition {
 impl ProjectState {
     /// Attempt a state transition. Returns the new state or an error
     /// if the transition is invalid from the current state.
+    #[must_use]
     pub fn transition(self, t: Transition) -> Result<Self> {
         match (&self, &t) {
             (Self::Created, Transition::StartQuestioning) => Ok(Self::Questioning),

--- a/crates/dianoia/src/workspace.rs
+++ b/crates/dianoia/src/workspace.rs
@@ -33,6 +33,7 @@ impl ProjectWorkspace {
     /// # Errors
     ///
     /// Returns [`crate::error::Error::WorkspaceIo`] if the workspace directories cannot be created.
+    #[must_use]
     pub fn create(root: impl Into<PathBuf>) -> Result<Self> {
         let root = root.into();
         let layout = Self::build_layout(&root);
@@ -49,6 +50,7 @@ impl ProjectWorkspace {
     }
 
     /// Open an existing workspace.
+    #[must_use]
     pub fn open(root: impl Into<PathBuf>) -> Result<Self> {
         let root = root.into();
         if !root.exists() {
@@ -63,6 +65,7 @@ impl ProjectWorkspace {
     ///
     /// Returns [`crate::error::Error::WorkspaceSerialize`] if the project cannot be serialized to JSON.
     /// Returns [`crate::error::Error::WorkspaceIo`] if the project file cannot be written.
+    #[must_use]
     pub fn save_project(&self, project: &Project) -> Result<()> {
         let layout = self.layout();
         let json = serde_json::to_string_pretty(project).context(error::WorkspaceSerializeSnafu)?;
@@ -73,6 +76,7 @@ impl ProjectWorkspace {
     }
 
     /// Load project state from disk.
+    #[must_use]
     pub fn load_project(&self) -> Result<Project> {
         let layout = self.layout();
         if !layout.project_file.exists() {
@@ -91,6 +95,7 @@ impl ProjectWorkspace {
     }
 
     /// Write a blocker file for stuck detection integration.
+    #[must_use]
     pub fn write_blocker(&self, phase_id: &str, blocker: &Blocker) -> Result<()> {
         let layout = self.layout();
         let phase_blockers = layout.blockers_dir.join(phase_id);
@@ -109,6 +114,7 @@ impl ProjectWorkspace {
     }
 
     /// Read all blockers for a phase.
+    #[must_use]
     pub fn read_blockers(&self, phase_id: &str) -> Result<Vec<Blocker>> {
         let layout = self.layout();
         let phase_blockers = layout.blockers_dir.join(phase_id);

--- a/crates/eval/src/client.rs
+++ b/crates/eval/src/client.rs
@@ -36,6 +36,7 @@ impl EvalClient {
 
     /// Check instance health.
     #[instrument(skip(self))]
+    #[must_use]
     pub async fn health(&self) -> Result<HealthResponse> {
         let url = format!("{}/api/health", self.base_url);
         let resp = self.http.get(&url).send().await.context(error::HttpSnafu)?;
@@ -44,6 +45,7 @@ impl EvalClient {
 
     /// List all configured nous agents.
     #[instrument(skip(self))]
+    #[must_use]
     pub async fn list_nous(&self) -> Result<Vec<NousSummary>> {
         let url = format!("{}/api/v1/nous", self.base_url);
         let resp = self.authed_get(&url).await?;
@@ -53,6 +55,7 @@ impl EvalClient {
 
     /// Get status for a specific nous agent.
     #[instrument(skip(self))]
+    #[must_use]
     pub async fn get_nous(&self, id: &str) -> Result<NousStatus> {
         let url = format!("{}/api/v1/nous/{id}", self.base_url);
         let resp = self.authed_get(&url).await?;
@@ -77,6 +80,7 @@ impl EvalClient {
 
     /// Get session details by ID.
     #[instrument(skip(self))]
+    #[must_use]
     pub async fn get_session(&self, id: &str) -> Result<SessionResponse> {
         let url = format!("{}/api/v1/sessions/{id}", self.base_url);
         let resp = self.authed_get(&url).await?;
@@ -85,6 +89,7 @@ impl EvalClient {
 
     /// Close (archive) a session.
     #[instrument(skip(self))]
+    #[must_use]
     pub async fn close_session(&self, id: &str) -> Result<()> {
         let url = format!("{}/api/v1/sessions/{id}", self.base_url);
         let resp = self.authed_delete(&url).await?;
@@ -132,6 +137,7 @@ impl EvalClient {
 
     /// Get conversation history for a session.
     #[instrument(skip(self))]
+    #[must_use]
     pub async fn get_history(&self, session_id: &str) -> Result<HistoryResponse> {
         let url = format!("{}/api/v1/sessions/{session_id}/history", self.base_url);
         let resp = self.authed_get(&url).await?;
@@ -140,6 +146,7 @@ impl EvalClient {
 
     /// Send a GET request without any auth header.
     #[instrument(skip(self))]
+    #[must_use]
     pub async fn raw_get(&self, path: &str) -> Result<reqwest::Response> {
         let url = format!("{}{path}", self.base_url);
         self.http.get(&url).send().await.context(error::HttpSnafu)
@@ -165,6 +172,7 @@ impl EvalClient {
 
     /// Send a GET request with an arbitrary Bearer token.
     #[instrument(skip(self, token))]
+    #[must_use]
     pub async fn raw_get_with_token(&self, path: &str, token: &str) -> Result<reqwest::Response> {
         let url = format!("{}{path}", self.base_url);
         self.http

--- a/crates/eval/src/scenario.rs
+++ b/crates/eval/src/scenario.rs
@@ -68,6 +68,7 @@ pub trait Scenario: Send + Sync {
 
 /// Assert a condition, returning an assertion error if it fails.
 #[tracing::instrument(skip_all)]
+#[must_use]
 pub fn assert_eval(condition: bool, message: impl Into<String>) -> Result<()> {
     if condition {
         Ok(())
@@ -101,6 +102,7 @@ pub fn assert_eq_eval<T: PartialEq + std::fmt::Debug>(
 /// When neither `expected_contains` nor `expected_pattern` is set, accepts any
 /// non-empty response and logs a warning about missing validation criteria.
 #[tracing::instrument(skip(text), fields(scenario_id = meta.id, text_len = text.len()))]
+#[must_use]
 pub fn validate_response(meta: &ScenarioMeta, text: &str) -> Result<()> {
     if meta.expected_contains.is_none() && meta.expected_pattern.is_none() {
         tracing::warn!(

--- a/crates/eval/src/sse.rs
+++ b/crates/eval/src/sse.rs
@@ -14,6 +14,7 @@ pub struct ParsedSseEvent {
 
 /// Consume an entire SSE response body and parse it into discrete events.
 #[tracing::instrument(skip(response))]
+#[must_use]
 pub async fn parse_sse_stream(response: reqwest::Response) -> Result<Vec<ParsedSseEvent>> {
     let text = response.text().await.context(error::HttpSnafu)?;
     parse_sse_text(&text)
@@ -21,6 +22,7 @@ pub async fn parse_sse_stream(response: reqwest::Response) -> Result<Vec<ParsedS
 
 /// Parse raw SSE text into events. Exposed for testing.
 #[tracing::instrument(skip(text), fields(text_len = text.len()))]
+#[must_use]
 pub fn parse_sse_text(text: &str) -> Result<Vec<ParsedSseEvent>> {
     let mut events = Vec::new();
     let mut current_event_type = String::new();

--- a/crates/hermeneus/src/anthropic/client.rs
+++ b/crates/hermeneus/src/anthropic/client.rs
@@ -107,6 +107,7 @@ impl AnthropicProvider {
     ///
     /// # Errors
     /// Returns `ProviderInit` if `api_key` is missing.
+    #[must_use]
     pub fn from_config(config: &ProviderConfig) -> Result<Self> {
         let api_key = config
             .api_key

--- a/crates/hermeneus/src/health.rs
+++ b/crates/hermeneus/src/health.rs
@@ -116,6 +116,7 @@ impl ProviderHealthTracker {
     /// Returns `Ok(())` if Up or Degraded. Returns `Err(health)` if Down,
     /// unless the cooldown has elapsed (auto-transitions to Degraded).
     /// `Down(AuthFailure)` never auto-recovers.
+    #[must_use]
     pub fn check_available(&self) -> Result<(), ProviderHealth> {
         #[expect(
             clippy::expect_used,

--- a/crates/koina/src/disk_space.rs
+++ b/crates/koina/src/disk_space.rs
@@ -73,6 +73,7 @@ impl fmt::Display for DiskStatus {
     unsafe_code,
     reason = "single FFI call to libc::statvfs with zeroed struct"
 )]
+#[must_use]
 pub fn available_space(path: &Path) -> std::io::Result<u64> {
     use std::ffi::CString;
     use std::os::unix::ffi::OsStrExt;
@@ -156,6 +157,7 @@ impl DiskSpaceMonitor {
     /// # Errors
     ///
     /// Returns an I/O error if `statvfs` fails.
+    #[must_use]
     pub fn refresh(&self, path: &Path) -> std::io::Result<DiskStatus> {
         let avail = available_space(path)?;
         self.cached_available.store(avail, Ordering::Relaxed);

--- a/crates/koina/src/id.rs
+++ b/crates/koina/src/id.rs
@@ -17,6 +17,7 @@ impl NousId {
     /// # Errors
     /// Returns an error if the ID is empty, exceeds 64 characters,
     /// or contains characters other than lowercase alphanumeric and hyphens.
+    #[must_use]
     pub fn new(id: impl Into<CompactString>) -> Result<Self, IdError> {
         let id = id.into();
         validate_id(&id, "NousId")?;
@@ -82,6 +83,7 @@ impl SessionId {
     ///
     /// # Errors
     /// Returns an error if the string is not a valid ULID.
+    #[must_use]
     pub fn parse(s: &str) -> Result<Self, IdError> {
         let ulid = s
             .parse::<ulid::Ulid>()
@@ -177,6 +179,7 @@ impl ToolName {
     /// # Errors
     /// Returns an error if the name is empty, exceeds 128 characters,
     /// or contains characters other than alphanumeric, hyphens, and underscores.
+    #[must_use]
     pub fn new(name: impl Into<CompactString>) -> Result<Self, IdError> {
         let name = name.into();
         if name.is_empty() {

--- a/crates/mneme/src/backup.rs
+++ b/crates/mneme/src/backup.rs
@@ -101,6 +101,7 @@ impl<'a> BackupManager<'a> {
     /// sequences. Any future changes to path construction MUST go through
     /// `validate_backup_path` (a private helper in this module).
     #[instrument(skip(self))]
+    #[must_use]
     pub fn create_backup(&self) -> Result<Option<BackupResult>> {
         if let Some(ref monitor) = self.disk_monitor
             && !monitor.allow_non_essential_write()
@@ -158,6 +159,7 @@ impl<'a> BackupManager<'a> {
     /// Exports are non-essential writes. When disk space is critical, this
     /// method returns `Ok(None)` instead of writing.
     #[instrument(skip(self))]
+    #[must_use]
     pub fn export_sessions_json(&self, output_dir: &Path) -> Result<Option<ExportResult>> {
         if let Some(ref monitor) = self.disk_monitor
             && !monitor.allow_non_essential_write()
@@ -205,6 +207,7 @@ impl<'a> BackupManager<'a> {
 
     /// List available backup files.
     #[instrument(skip(self))]
+    #[must_use]
     pub fn list_backups(&self) -> Result<Vec<BackupInfo>> {
         if !self.backup_dir.exists() {
             return Ok(Vec::new());
@@ -242,6 +245,7 @@ impl<'a> BackupManager<'a> {
 
     /// Prune old backups, keeping the N most recent.
     #[instrument(skip(self))]
+    #[must_use]
     pub fn prune_backups(&self, keep: usize) -> Result<u32> {
         let backups = self.list_backups()?;
         let mut removed = 0u32;

--- a/crates/mneme/src/consolidation/engine.rs
+++ b/crates/mneme/src/consolidation/engine.rs
@@ -26,6 +26,7 @@ fn i64_as_usize(v: i64) -> usize {
 
 impl KnowledgeStore {
     /// Initialize the `consolidation_audit` relation. Called during schema setup.
+    #[must_use]
     pub fn init_consolidation_audit(&self) -> crate::error::Result<()> {
         self.run_mut_query(CONSOLIDATION_AUDIT_DDL, BTreeMap::new())?;
         Ok(())

--- a/crates/mneme/src/embedding.rs
+++ b/crates/mneme/src/embedding.rs
@@ -163,6 +163,7 @@ mod candle_provider {
         ///
         /// Returns `EmbeddingError::InitFailed` if model download or initialization fails.
         #[instrument]
+        #[must_use]
         pub fn new(model_repo: Option<&str>) -> EmbeddingResult<Self> {
             let repo_id = model_repo.unwrap_or(Self::DEFAULT_REPO);
             let device = Device::Cpu;
@@ -456,6 +457,7 @@ impl Default for EmbeddingConfig {
 /// # Errors
 /// Returns an error if the provider cannot be initialized.
 #[instrument(skip(config), fields(provider = %config.provider))]
+#[must_use]
 pub fn create_provider(config: &EmbeddingConfig) -> EmbeddingResult<Box<dyn EmbeddingProvider>> {
     match config.provider.as_str() {
         "mock" => {

--- a/crates/mneme/src/engine/data/expr.rs
+++ b/crates/mneme/src/engine/data/expr.rs
@@ -394,6 +394,7 @@ impl Expr {
         Ok(())
     }
     /// Evaluate the expression to a constant value if possible
+    #[must_use]
     pub fn eval_to_const(mut self) -> Result<DataValue> {
         self.partial_eval()?;
         match self {

--- a/crates/mneme/src/engine/fixed_rule/mod.rs
+++ b/crates/mneme/src/engine/fixed_rule/mod.rs
@@ -56,10 +56,12 @@ pub struct FixedRuleInputRelation<'a, 'b> {
 
 impl<'a, 'b> FixedRuleInputRelation<'a, 'b> {
     /// The arity of the input relation
+    #[must_use]
     pub fn arity(&self) -> Result<usize> {
         self.arg_manifest.arity(self.tx, self.stores)
     }
     /// Ensure the input relation contains tuples of the given minimal length.
+    #[must_use]
     pub fn ensure_min_len(self, len: usize) -> Result<Self> {
         let arity = self.arg_manifest.arity(self.tx, self.stores)?;
         if arity < len {
@@ -77,6 +79,7 @@ impl<'a, 'b> FixedRuleInputRelation<'a, 'b> {
         self.arg_manifest.get_binding_map(offset)
     }
     /// Iterate the input relation
+    #[must_use]
     pub fn iter(&self) -> Result<TupleIter<'a>> {
         Ok(match &self.arg_manifest {
             MagicFixedRuleRuleArg::InMem { name, .. } => {
@@ -100,6 +103,7 @@ impl<'a, 'b> FixedRuleInputRelation<'a, 'b> {
         })
     }
     /// Iterate the relation with the given single-value prefix
+    #[must_use]
     pub fn prefix_iter(&self, prefix: &DataValue) -> Result<TupleIter<'_>> {
         Ok(match self.arg_manifest {
             MagicFixedRuleRuleArg::InMem { name, .. } => {
@@ -361,6 +365,7 @@ impl<'a, 'b> FixedRulePayload<'a, 'b> {
         self.manifest.relations_count()
     }
     /// Get the input relation at `idx`.
+    #[must_use]
     pub fn get_input(&self, idx: usize) -> Result<FixedRuleInputRelation<'a, 'b>> {
         let arg_manifest = self.manifest.relation(idx)?;
         Ok(FixedRuleInputRelation {
@@ -378,6 +383,7 @@ impl<'a, 'b> FixedRulePayload<'a, 'b> {
         self.manifest.span
     }
     /// Extract an expression option
+    #[must_use]
     pub fn expr_option(&self, name: &str, default: Option<Expr>) -> Result<Expr> {
         match self.manifest.options.get(name) {
             Some(ex) => Ok(ex.clone()),
@@ -394,6 +400,7 @@ impl<'a, 'b> FixedRulePayload<'a, 'b> {
     }
 
     /// Extract a string option
+    #[must_use]
     pub fn string_option(&self, name: &str, default: Option<&str>) -> Result<CompactString> {
         match self.manifest.options.get(name) {
             Some(ex) => match ex.clone().eval_to_const()? {
@@ -419,6 +426,7 @@ impl<'a, 'b> FixedRulePayload<'a, 'b> {
     }
 
     /// Get the source span of the named option. Useful for generating informative error messages.
+    #[must_use]
     pub fn option_span(&self, name: &str) -> Result<SourceSpan> {
         match self.manifest.options.get(name) {
             None => Err(FixedRuleOptionNotFoundError {
@@ -431,6 +439,7 @@ impl<'a, 'b> FixedRulePayload<'a, 'b> {
         }
     }
     /// Extract an integer option
+    #[must_use]
     pub fn integer_option(&self, name: &str, default: Option<i64>) -> Result<i64> {
         match self.manifest.options.get(name) {
             Some(v) => match v.clone().eval_to_const() {
@@ -463,6 +472,7 @@ impl<'a, 'b> FixedRulePayload<'a, 'b> {
         }
     }
     /// Extract a positive integer option
+    #[must_use]
     pub fn pos_integer_option(&self, name: &str, default: Option<usize>) -> Result<usize> {
         let i = self.integer_option(name, default.map(|i| i as i64))?;
         if i <= 0 {
@@ -477,6 +487,7 @@ impl<'a, 'b> FixedRulePayload<'a, 'b> {
         Ok(i as usize)
     }
     /// Extract a non-negative integer option
+    #[must_use]
     pub fn non_neg_integer_option(&self, name: &str, default: Option<usize>) -> Result<usize> {
         let i = self.integer_option(name, default.map(|i| i as i64))?;
         if i < 0 {
@@ -491,6 +502,7 @@ impl<'a, 'b> FixedRulePayload<'a, 'b> {
         Ok(i as usize)
     }
     /// Extract a floating point option
+    #[must_use]
     pub fn float_option(&self, name: &str, default: Option<f64>) -> Result<f64> {
         match self.manifest.options.get(name) {
             Some(v) => match v.clone().eval_to_const() {
@@ -518,6 +530,7 @@ impl<'a, 'b> FixedRulePayload<'a, 'b> {
         }
     }
     /// Extract a floating point option between 0. and 1.
+    #[must_use]
     pub fn unit_interval_option(&self, name: &str, default: Option<f64>) -> Result<f64> {
         let f = self.float_option(name, default)?;
         if !(0. ..=1.).contains(&f) {
@@ -532,6 +545,7 @@ impl<'a, 'b> FixedRulePayload<'a, 'b> {
         Ok(f)
     }
     /// Extract a boolean option
+    #[must_use]
     pub fn bool_option(&self, name: &str, default: Option<bool>) -> Result<bool> {
         match self.manifest.options.get(name) {
             Some(v) => match v.clone().eval_to_const() {

--- a/crates/mneme/src/engine/mod.rs
+++ b/crates/mneme/src/engine/mod.rs
@@ -129,6 +129,7 @@ pub enum Db {
 )]
 impl Db {
     /// Open an in-memory database.
+    #[must_use]
     pub fn open_mem() -> crate::engine::Result<Self> {
         crate::engine::storage::mem::new_mem_db()
             .map(Db::Mem)
@@ -140,6 +141,7 @@ impl Db {
     /// Primary production backend: pure Rust, LSM-tree, LZ4 compression,
     /// native read-your-own-writes.
     #[cfg(feature = "storage-fjall")]
+    #[must_use]
     pub fn open_fjall(path: impl AsRef<Path>) -> crate::engine::Result<Self> {
         crate::engine::storage::fjall_backend::new_cozo_fjall(path)
             .map(Db::Fjall)
@@ -173,6 +175,7 @@ impl Db {
     /// Backup the running database into an `SQLite` file.
     ///
     /// Not currently supported: requires the removed `storage-sqlite` feature.
+    #[must_use]
     pub fn backup_db(&self, out_file: impl AsRef<Path>) -> crate::engine::Result<()> {
         let path = out_file.as_ref();
         let result = match self {
@@ -186,6 +189,7 @@ impl Db {
     /// Restore from an `SQLite` backup.
     ///
     /// Not currently supported: requires the removed `storage-sqlite` feature.
+    #[must_use]
     pub fn restore_backup(&self, in_file: impl AsRef<Path>) -> crate::engine::Result<()> {
         let path = in_file.as_ref();
         let result = match self {
@@ -231,6 +235,7 @@ impl Db {
     }
 
     /// Import relations from backup.
+    #[must_use]
     pub fn import_relations(&self, data: BTreeMap<String, NamedRows>) -> crate::engine::Result<()> {
         let result = match self {
             Db::Mem(db) => db.import_relations(data),

--- a/crates/mneme/src/engine/runtime/db.rs
+++ b/crates/mneme/src/engine/runtime/db.rs
@@ -153,6 +153,7 @@ impl NamedRows {
         })
     }
     /// Make named rows from JSON
+    #[must_use]
     pub fn from_json(value: &JsonValue) -> Result<Self> {
         let headers =
             value
@@ -265,6 +266,7 @@ impl<'s, S: Storage<'s>> Db<S> {
     /// # Errors
     ///
     /// Returns an error if the storage backend fails during initial setup.
+    #[must_use]
     pub fn new(storage: S) -> Result<Self> {
         let ret = Self {
             db: storage,
@@ -285,6 +287,7 @@ impl<'s, S: Storage<'s>> Db<S> {
     }
 
     /// Must be called after creation of the database to initialize the runtime state.
+    #[must_use]
     pub fn initialize(&'s self) -> Result<()> {
         self.load_last_ids()?;
         Ok(())
@@ -298,6 +301,7 @@ impl<'s, S: Storage<'s>> Db<S> {
     /// Backup the running database into an Sqlite file.
     ///
     /// Not currently supported: requires the removed `storage-sqlite` feature.
+    #[must_use]
     pub fn backup_db(&'s self, _out_file: impl AsRef<Path>) -> Result<()> {
         UnsupportedSnafu {
             operation: "backup",
@@ -308,6 +312,7 @@ impl<'s, S: Storage<'s>> Db<S> {
     /// Restore from an Sqlite backup.
     ///
     /// Not currently supported: requires the removed `storage-sqlite` feature.
+    #[must_use]
     pub fn restore_backup(&'s self, _in_file: impl AsRef<Path>) -> Result<()> {
         UnsupportedSnafu {
             operation: "restore",
@@ -330,6 +335,7 @@ impl<'s, S: Storage<'s>> Db<S> {
         .fail()?
     }
     /// Register a custom fixed rule implementation.
+    #[must_use]
     pub fn register_fixed_rule<R>(&self, name: String, rule_impl: R) -> Result<()>
     where
         R: FixedRule + 'static,
@@ -348,6 +354,7 @@ impl<'s, S: Storage<'s>> Db<S> {
     }
 
     /// Unregister a custom fixed rule implementation.
+    #[must_use]
     pub fn unregister_fixed_rule(&self, name: &str) -> Result<bool> {
         if DEFAULT_FIXED_RULES.contains_key(name) {
             InvalidOperationSnafu {
@@ -469,6 +476,7 @@ impl Poison {
     ///
     /// Returns a query-killed error if the user initiated termination.
     #[inline(always)]
+    #[must_use]
     pub fn check(&self) -> Result<()> {
         if self.0.load(Ordering::Relaxed) {
             QueryKilledSnafu.fail()?;

--- a/crates/mneme/src/engine/runtime/transact.rs
+++ b/crates/mneme/src/engine/runtime/transact.rs
@@ -137,6 +137,7 @@ impl<'a> SessionTx<'a> {
         Ok(ret)
     }
 
+    #[must_use]
     pub fn commit_tx(&mut self) -> Result<()> {
         self.store_tx.commit()?;
         Ok(())
@@ -308,6 +309,7 @@ impl<'s, S: Storage<'s>> Db<S> {
     /// Export relations to JSON data.
     ///
     /// `relations` contains names of the stored relations to export.
+    #[must_use]
     pub fn export_relations<I, T>(&'s self, relations: I) -> Result<BTreeMap<String, NamedRows>>
     where
         T: AsRef<str>,
@@ -362,6 +364,7 @@ impl<'s, S: Storage<'s>> Db<S> {
     ///
     /// Note that triggers and callbacks are _not_ run for the relations, if any exists.
     /// If you need to activate triggers or callbacks, use queries with parameters.
+    #[must_use]
     pub fn import_relations(&'s self, data: BTreeMap<String, NamedRows>) -> Result<()> {
         let rel_names = data.keys().map(CompactString::from).collect_vec();
         let locks = self.obtain_relation_locks(rel_names.iter());

--- a/crates/mneme/src/engine/storage/mem.rs
+++ b/crates/mneme/src/engine/storage/mem.rs
@@ -28,6 +28,7 @@ type Result<T> = StorageResult<T>;
 /// Create a database backed by memory.
 /// This is the fastest storage, but non-persistent.
 /// Supports concurrent readers but only a single writer.
+#[must_use]
 pub fn new_mem_db() -> crate::engine::error::InternalResult<crate::engine::DbCore<MemStorage>> {
     let ret = crate::engine::DbCore::new(MemStorage::default())?;
     ret.initialize()?;

--- a/crates/mneme/src/extract/engine.rs
+++ b/crates/mneme/src/extract/engine.rs
@@ -106,6 +106,7 @@ Rules:
     ///
     /// Strips markdown code fences if present.
     #[instrument(skip(self, response))]
+    #[must_use]
     pub fn parse_response(&self, response: &str) -> Result<Extraction, ExtractionError> {
         let trimmed = strip_code_fences(response);
         serde_json::from_str(trimmed).context(ParseResponseSnafu)

--- a/crates/mneme/src/extract/refinement.rs
+++ b/crates/mneme/src/extract/refinement.rs
@@ -546,6 +546,7 @@ pub struct BatchFilterResult {
 }
 
 /// Apply quality filters to a batch of extracted facts, including deduplication.
+#[must_use]
 pub fn filter_batch(facts: &[(String, f64)]) -> BatchFilterResult {
     let mut passed = Vec::new();
     let mut rejected = Vec::new();

--- a/crates/mneme/src/graph_intelligence.rs
+++ b/crates/mneme/src/graph_intelligence.rs
@@ -266,6 +266,7 @@ fn parse_hop_rows(
 #[cfg(feature = "mneme-engine")]
 impl crate::knowledge_store::KnowledgeStore {
     /// Initialize the `graph_scores` relation. Called during schema setup.
+    #[must_use]
     pub fn init_graph_scores(&self) -> crate::error::Result<()> {
         self.run_mut_query(GRAPH_SCORES_DDL, std::collections::BTreeMap::new())?;
         Ok(())
@@ -275,6 +276,7 @@ impl crate::knowledge_store::KnowledgeStore {
     ///
     /// Populates pageranks and cluster assignments. Caller should then fill
     /// `context_clusters`, `proximity`, and `chain_lengths` based on query context.
+    #[must_use]
     pub fn load_graph_context(&self) -> crate::error::Result<GraphContext> {
         let result = self.run_query(LOAD_GRAPH_SCORES, std::collections::BTreeMap::new())?;
 
@@ -370,6 +372,7 @@ impl crate::knowledge_store::KnowledgeStore {
     }
 
     /// Compute supersession chain lengths for all facts.
+    #[must_use]
     pub fn compute_chain_lengths(&self) -> crate::error::Result<HashMap<String, u32>> {
         let result = self.run_query(
             SUPERSESSION_CHAIN_LENGTHS,
@@ -379,6 +382,7 @@ impl crate::knowledge_store::KnowledgeStore {
     }
 
     /// Run the combined `PageRank` + `Louvain` recomputation and store to `graph_scores`.
+    #[must_use]
     pub fn recompute_graph_scores(&self) -> crate::error::Result<()> {
         let now = crate::knowledge::format_timestamp(&jiff::Timestamp::now());
         let mut params = std::collections::BTreeMap::new();
@@ -442,6 +446,7 @@ impl crate::knowledge_store::KnowledgeStore {
     /// Intended for background scheduling: runs the volatility Datalog,
     /// computes scores, and upserts them into `graph_scores` with
     /// `score_type = "volatility"`.
+    #[must_use]
     pub fn compute_and_store_volatility(&self) -> crate::error::Result<()> {
         let volatilities = self.compute_domain_volatility()?;
         let now = crate::knowledge::format_timestamp(&jiff::Timestamp::now());
@@ -470,6 +475,7 @@ impl crate::knowledge_store::KnowledgeStore {
     ///
     /// Returns a map of `entity_id → volatility_score` for all entities
     /// that have stored volatility data.
+    #[must_use]
     pub fn load_volatility_scores(&self) -> crate::error::Result<HashMap<String, f64>> {
         let result = self.run_query(
             r"?[entity_id, score] := *graph_scores{entity_id, score_type, score}, score_type = 'volatility'",

--- a/crates/mneme/src/hnsw_index.rs
+++ b/crates/mneme/src/hnsw_index.rs
@@ -120,6 +120,7 @@ impl HnswIndex {
 
     /// Try to load an existing index from disk, or create a new one.
     #[instrument(skip_all, fields(dir = ?config.persist_dir))]
+    #[must_use]
     pub fn open_or_create(config: HnswConfig) -> crate::error::Result<Arc<Self>> {
         if let Some(ref dir) = config.persist_dir {
             let graph_path = dir.join(format!("{}.hnsw.graph", &config.persist_basename));
@@ -182,6 +183,7 @@ impl HnswIndex {
     ///
     /// `ef` controls search width (must be >= `k`). Higher = better recall, slower.
     #[instrument(skip(self, query), fields(k, ef))]
+    #[must_use]
     pub fn search(&self, query: &[f32], k: usize, ef: usize) -> Vec<SearchResult> {
         let guard = self.inner.read().expect("hnsw lock poisoned");
         match *guard {
@@ -203,6 +205,7 @@ impl HnswIndex {
     ///
     /// Writes two files: `{basename}.hnsw.graph` and `{basename}.hnsw.data`.
     #[instrument(skip(self))]
+    #[must_use]
     pub fn dump(&self) -> crate::error::Result<()> {
         let dir = self.config.persist_dir.as_ref().context(HnswIndexSnafu {
             message: "no persist_dir configured for HNSW dump",

--- a/crates/mneme/src/id.rs
+++ b/crates/mneme/src/id.rs
@@ -23,6 +23,7 @@ macro_rules! define_id {
             /// # Errors
             /// Returns `IdValidationError` if the value is empty or exceeds
             /// the maximum length.
+            #[must_use]
             pub fn new(id: impl Into<String>) -> Result<Self, IdValidationError> {
                 let id = id.into();
                 if id.is_empty() {

--- a/crates/mneme/src/knowledge_store/entity.rs
+++ b/crates/mneme/src/knowledge_store/entity.rs
@@ -8,6 +8,7 @@ use tracing::instrument;
 impl KnowledgeStore {
     /// Insert or update an entity.
     #[instrument(skip(self, entity), fields(entity_id = %entity.id))]
+    #[must_use]
     pub fn insert_entity(&self, entity: &crate::knowledge::Entity) -> crate::error::Result<()> {
         use snafu::ensure;
         ensure!(!entity.name.is_empty(), crate::error::EmptyEntityNameSnafu);
@@ -81,6 +82,7 @@ impl KnowledgeStore {
 
     /// List all entities in the knowledge store.
     #[instrument(skip(self))]
+    #[must_use]
     pub fn list_entities(&self) -> crate::error::Result<Vec<crate::knowledge::Entity>> {
         use std::collections::BTreeMap;
 

--- a/crates/mneme/src/knowledge_store/facts.rs
+++ b/crates/mneme/src/knowledge_store/facts.rs
@@ -6,6 +6,7 @@ use tracing::instrument;
 impl KnowledgeStore {
     /// Insert or update a fact.
     #[instrument(skip(self, fact), fields(fact_id = %fact.id))]
+    #[must_use]
     pub fn insert_fact(&self, fact: &crate::knowledge::Fact) -> crate::error::Result<()> {
         use snafu::ensure;
         ensure!(!fact.content.is_empty(), crate::error::EmptyContentSnafu);
@@ -163,6 +164,7 @@ impl KnowledgeStore {
 
     /// Point-in-time fact query.
     #[instrument(skip(self))]
+    #[must_use]
     pub fn query_facts_at(&self, time: &str) -> crate::error::Result<Vec<crate::knowledge::Fact>> {
         use crate::engine::DataValue;
         use std::collections::BTreeMap;
@@ -176,6 +178,7 @@ impl KnowledgeStore {
 
     /// Increment access count and update last-accessed timestamp for the given fact IDs.
     #[instrument(skip(self), fields(count = fact_ids.len()))]
+    #[must_use]
     pub fn increment_access(&self, fact_ids: &[crate::id::FactId]) -> crate::error::Result<()> {
         if fact_ids.is_empty() {
             return Ok(());
@@ -540,6 +543,7 @@ impl KnowledgeStore {
     /// Unlike [`audit_all_facts`](Self::audit_all_facts), this does not require
     /// a `nous_id` filter and returns facts from every agent.
     #[instrument(skip(self))]
+    #[must_use]
     pub fn list_all_facts(&self, limit: i64) -> crate::error::Result<Vec<crate::knowledge::Fact>> {
         use crate::engine::DataValue;
         use std::collections::BTreeMap;

--- a/crates/mneme/src/knowledge_store/mod.rs
+++ b/crates/mneme/src/knowledge_store/mod.rs
@@ -281,6 +281,7 @@ impl KnowledgeStore {
 
     /// Open an in-memory knowledge store with default configuration.
     #[instrument]
+    #[must_use]
     pub fn open_mem() -> crate::error::Result<std::sync::Arc<Self>> {
         Self::open_mem_with_config(KnowledgeConfig::default())
     }
@@ -467,6 +468,7 @@ impl KnowledgeStore {
         Ok(())
     }
 
+    #[must_use]
     pub fn schema_version(&self) -> crate::error::Result<i64> {
         use crate::engine::DataValue;
         use std::collections::BTreeMap;
@@ -567,6 +569,7 @@ impl KnowledgeStore {
     /// Delegates to the inner engine's `backup_db`. Currently returns an error
     /// for in-memory and redb backends (`SQLite` storage support was removed).
     #[instrument(skip(self, out_file))]
+    #[must_use]
     pub fn backup_db(&self, out_file: impl AsRef<std::path::Path>) -> crate::error::Result<()> {
         self.db.backup_db(out_file).map_err(|e| {
             crate::error::EngineQuerySnafu {
@@ -581,6 +584,7 @@ impl KnowledgeStore {
     /// Delegates to the inner engine's `restore_backup`. Currently returns an error
     /// for in-memory and redb backends (`SQLite` storage support was removed).
     #[instrument(skip(self, in_file))]
+    #[must_use]
     pub fn restore_backup(&self, in_file: impl AsRef<std::path::Path>) -> crate::error::Result<()> {
         self.db.restore_backup(in_file).map_err(|e| {
             crate::error::EngineQuerySnafu {
@@ -626,6 +630,7 @@ impl KnowledgeStore {
 
     /// Read a single fact by its ID (all temporal records matching).
     /// Returns all fields; does not apply time/validity filters.
+    #[must_use]
     pub fn read_facts_by_id(&self, id: &str) -> crate::error::Result<Vec<crate::knowledge::Fact>> {
         use crate::engine::DataValue;
         use std::collections::BTreeMap;

--- a/crates/mneme/src/knowledge_store/search.rs
+++ b/crates/mneme/src/knowledge_store/search.rs
@@ -123,6 +123,7 @@ impl KnowledgeStore {
     /// Runs a single Datalog query combining all three signals in the engine.
     /// When `seed_entities` is empty, the graph signal contributes zero to RRF.
     #[instrument(skip(self, q), fields(limit = q.limit, ef = q.ef))]
+    #[must_use]
     pub fn search_hybrid(&self, q: &HybridQuery) -> crate::error::Result<Vec<HybridResult>> {
         use crate::engine::{Array1, DataValue, Vector};
         use std::collections::BTreeMap;

--- a/crates/mneme/src/knowledge_store/skills.rs
+++ b/crates/mneme/src/knowledge_store/skills.rs
@@ -255,6 +255,7 @@ impl KnowledgeStore {
     ///
     /// Returns `(active, needs_review, retired)` counts.
     #[instrument(skip(self))]
+    #[must_use]
     pub fn run_skill_decay(&self, nous_id: &str) -> crate::error::Result<(usize, usize, usize)> {
         let skills = self.find_skills_for_nous(nous_id, 10_000)?;
         let now_secs = jiff::Timestamp::now().as_second();

--- a/crates/mneme/src/migration.rs
+++ b/crates/mneme/src/migration.rs
@@ -167,6 +167,7 @@ pub struct PendingMigration {
 /// Migrations are applied in version order. Each migration runs inside a
 /// transaction: the up SQL executes, then the version is recorded. If any
 /// migration fails, the transaction rolls back and the error is returned.
+#[must_use]
 pub fn run_migrations(conn: &Connection) -> Result<MigrationResult> {
     let was_fresh = !schema_version_table_exists(conn);
 
@@ -235,6 +236,7 @@ pub fn run_migrations(conn: &Connection) -> Result<MigrationResult> {
 }
 
 /// Report pending migrations without applying them.
+#[must_use]
 pub fn check_migrations(conn: &Connection) -> Result<Vec<PendingMigration>> {
     bootstrap_version_table(conn)?;
     let current = get_schema_version(conn);

--- a/crates/mneme/src/recall.rs
+++ b/crates/mneme/src/recall.rs
@@ -264,6 +264,7 @@ impl RecallEngine {
     /// Score and rank a batch of candidates. Returns sorted by score descending.
     #[must_use]
     #[instrument(skip(self, candidates), fields(count = candidates.len()))]
+    #[must_use]
     pub fn rank(&self, mut candidates: Vec<ScoredResult>) -> Vec<ScoredResult> {
         for candidate in &mut candidates {
             candidate.score = self.compute_score(&candidate.factors);

--- a/crates/mneme/src/recovery.rs
+++ b/crates/mneme/src/recovery.rs
@@ -49,6 +49,7 @@ impl Default for RecoveryConfig {
 ///
 /// Returns `Ok(true)` if the database passes, `Ok(false)` if corruption
 /// is detected. Returns `Err` only for connection-level failures.
+#[must_use]
 pub fn check_integrity(conn: &Connection) -> Result<bool> {
     let result: String = conn
         .pragma_query_value(None, "integrity_check", |row| row.get(0))
@@ -75,6 +76,7 @@ pub fn is_corruption_error(err: &rusqlite::Error) -> bool {
 ///
 /// # Errors
 /// Returns an error if the read-only connection cannot be opened.
+#[must_use]
 pub fn open_read_only(path: &Path) -> Result<Connection> {
     let conn = Connection::open_with_flags(path, OpenFlags::SQLITE_OPEN_READ_ONLY)
         .context(error::DatabaseSnafu)?;
@@ -87,6 +89,7 @@ pub fn open_read_only(path: &Path) -> Result<Connection> {
 ///
 /// # Errors
 /// Returns an error if the copy fails.
+#[must_use]
 pub fn backup_corrupt_file(path: &Path) -> Result<PathBuf> {
     let timestamp = jiff::Zoned::now().strftime("%Y%m%dT%H%M%S");
     let backup_name = format!(
@@ -119,6 +122,7 @@ pub fn backup_corrupt_file(path: &Path) -> Result<PathBuf> {
 /// # Errors
 /// Returns an error only for fatal I/O failures. Partial read failures from
 /// the corrupt database are logged and skipped.
+#[must_use]
 pub fn attempt_recovery(corrupt_path: &Path, new_path: &Path) -> Result<bool> {
     // WHY: Open the corrupt database read-only so we don't modify it.
     let old_conn = match open_read_only(corrupt_path) {
@@ -295,6 +299,7 @@ fn copy_table(
 /// 4. Return a connection to the recovered (or read-only) database
 ///
 /// Returns `(Connection, StoreMode)`: the usable connection and its mode.
+#[must_use]
 pub fn recover_database(path: &Path, config: &RecoveryConfig) -> Result<(Connection, StoreMode)> {
     let path_display = path.display().to_string();
 

--- a/crates/mneme/src/retention.rs
+++ b/crates/mneme/src/retention.rs
@@ -63,6 +63,7 @@ impl RetentionPolicy {
         clippy::expect_used,
         reason = "timestamp arithmetic uses bounded durations well within i64 range"
     )]
+    #[must_use]
     pub fn apply(&self, conn: &Connection, archive_dir: &Path) -> Result<RetentionResult> {
         let page_size = get_page_size(conn);
         let free_before = get_free_pages(conn);

--- a/crates/mneme/src/skill.rs
+++ b/crates/mneme/src/skill.rs
@@ -104,6 +104,7 @@ impl std::fmt::Display for SkillParseError {
 ///
 /// Supports optional YAML frontmatter (delimited by `---`) with `tools` and
 /// `domains` fields. Falls back to extracting from markdown sections.
+#[must_use]
 pub fn parse_skill_md(source: &str, slug: &str) -> Result<SkillContent, SkillParseError> {
     let err = |reason: &str| SkillParseError {
         path: slug.to_owned(),
@@ -284,6 +285,7 @@ fn derive_domain_tags(slug: &str) -> Vec<String> {
 /// Scan a directory for subdirectories containing SKILL.md files.
 ///
 /// Returns `(slug, content_string)` pairs for each found skill.
+#[must_use]
 pub fn scan_skill_dir(dir: &std::path::Path) -> Result<Vec<(String, String)>, std::io::Error> {
     let mut skills = Vec::new();
 

--- a/crates/mneme/src/skills/candidate.rs
+++ b/crates/mneme/src/skills/candidate.rs
@@ -63,6 +63,7 @@ impl SkillCandidate {
     /// # Errors
     ///
     /// Returns a [`serde_json::Error`] if serialisation fails.
+    #[must_use]
     pub fn to_json(&self) -> Result<String, serde_json::Error> {
         serde_json::to_string(self)
     }
@@ -72,6 +73,7 @@ impl SkillCandidate {
     /// # Errors
     ///
     /// Returns a [`serde_json::Error`] if the JSON is malformed or the schema changed.
+    #[must_use]
     pub fn from_json(json: &str) -> Result<Self, serde_json::Error> {
         serde_json::from_str(json)
     }

--- a/crates/mneme/src/skills/extract.rs
+++ b/crates/mneme/src/skills/extract.rs
@@ -416,6 +416,7 @@ impl PendingSkill {
     /// # Errors
     ///
     /// Returns a [`serde_json::Error`] if serialization fails.
+    #[must_use]
     pub fn to_json(&self) -> Result<String, serde_json::Error> {
         serde_json::to_string(self)
     }
@@ -425,6 +426,7 @@ impl PendingSkill {
     /// # Errors
     ///
     /// Returns a [`serde_json::Error`] if the JSON is malformed.
+    #[must_use]
     pub fn from_json(json: &str) -> Result<Self, serde_json::Error> {
         serde_json::from_str(json)
     }

--- a/crates/mneme/src/store/message.rs
+++ b/crates/mneme/src/store/message.rs
@@ -150,6 +150,7 @@ impl SessionStore {
 
     /// Get message history for a session.
     #[instrument(skip(self))]
+    #[must_use]
     pub fn get_history(&self, session_id: &str, limit: Option<i64>) -> Result<Vec<Message>> {
         let mut messages = Vec::new();
 
@@ -231,6 +232,7 @@ impl SessionStore {
 
     /// Mark messages as distilled and recalculate session token count.
     #[instrument(skip(self, seqs), fields(count = seqs.len()))]
+    #[must_use]
     pub fn mark_messages_distilled(&self, session_id: &str, seqs: &[i64]) -> Result<()> {
         self.require_writable()?;
         if seqs.is_empty() {
@@ -295,6 +297,7 @@ impl SessionStore {
     /// unnecessary because the UNIQUE constraint is only violated if seq 0 already exists.
     /// Deleting the old summary first makes seq 0 available without any renumbering.
     #[instrument(skip(self, content))]
+    #[must_use]
     pub fn insert_distillation_summary(&self, session_id: &str, content: &str) -> Result<()> {
         self.require_writable()?;
         let tx = self
@@ -397,6 +400,7 @@ impl SessionStore {
 
     /// Check if usage has already been recorded for a given session + turn.
     #[instrument(skip(self), level = "debug")]
+    #[must_use]
     pub fn usage_exists_for_turn(&self, session_id: &str, turn_seq: i64) -> Result<bool> {
         let exists: bool = self
             .conn
@@ -411,6 +415,7 @@ impl SessionStore {
 
     /// Record token usage for a turn.
     #[instrument(skip(self, record), level = "debug")]
+    #[must_use]
     pub fn record_usage(&self, record: &UsageRecord) -> Result<()> {
         self.require_writable()?;
         self.conn

--- a/crates/mneme/src/store/mod.rs
+++ b/crates/mneme/src/store/mod.rs
@@ -44,6 +44,7 @@ impl SessionStore {
     /// # Errors
     /// Returns an error if the database cannot be opened or initialized.
     #[instrument(skip(path))]
+    #[must_use]
     pub fn open(path: &Path) -> Result<Self> {
         Self::open_with_recovery(path, &RecoveryConfig::default())
     }
@@ -53,6 +54,7 @@ impl SessionStore {
     /// # Errors
     /// Returns an error if the database cannot be opened or initialized.
     #[instrument(skip(path, recovery_config))]
+    #[must_use]
     pub fn open_with_recovery(path: &Path, recovery_config: &RecoveryConfig) -> Result<Self> {
         info!("Opening session store at {}", path.display());
         let conn = Connection::open(path).context(error::DatabaseSnafu)?;
@@ -113,6 +115,7 @@ impl SessionStore {
     /// # Errors
     /// Returns an error if initialization fails.
     #[instrument]
+    #[must_use]
     pub fn open_in_memory() -> Result<Self> {
         let conn = Connection::open_in_memory().context(error::DatabaseSnafu)?;
         conn.execute_batch("PRAGMA foreign_keys = ON;")
@@ -161,6 +164,7 @@ impl SessionStore {
     ///
     /// # Errors
     /// Returns an error if the database connection is broken.
+    #[must_use]
     pub fn ping(&self) -> Result<()> {
         self.conn
             .query_row("SELECT 1", [], |_| Ok(()))

--- a/crates/mneme/src/store/peripherals.rs
+++ b/crates/mneme/src/store/peripherals.rs
@@ -33,6 +33,7 @@ impl SessionStore {
 
     /// Get notes for a session.
     #[instrument(skip(self))]
+    #[must_use]
     pub fn get_notes(&self, session_id: &str) -> Result<Vec<AgentNote>> {
         let mut stmt = self
             .conn
@@ -63,6 +64,7 @@ impl SessionStore {
 
     /// Delete a note by ID.
     #[instrument(skip(self))]
+    #[must_use]
     pub fn delete_note(&self, note_id: i64) -> Result<bool> {
         self.require_writable()?;
         let rows = self
@@ -102,6 +104,7 @@ impl SessionStore {
 
     /// Read a blackboard entry by key, filtering expired entries.
     #[instrument(skip(self))]
+    #[must_use]
     pub fn blackboard_read(&self, key: &str) -> Result<Option<BlackboardRow>> {
         let result = self
             .conn
@@ -128,6 +131,7 @@ impl SessionStore {
 
     /// List all non-expired blackboard entries.
     #[instrument(skip(self))]
+    #[must_use]
     pub fn blackboard_list(&self) -> Result<Vec<BlackboardRow>> {
         let mut stmt = self
             .conn
@@ -161,6 +165,7 @@ impl SessionStore {
 
     /// Delete a blackboard entry. Only the original author can delete.
     #[instrument(skip(self))]
+    #[must_use]
     pub fn blackboard_delete(&self, key: &str, author: &str) -> Result<bool> {
         self.require_writable()?;
         let rows = self

--- a/crates/mneme/src/store/session.rs
+++ b/crates/mneme/src/store/session.rs
@@ -12,6 +12,7 @@ impl SessionStore {
 
     /// Find an active session by nous ID and session key.
     #[instrument(skip(self))]
+    #[must_use]
     pub fn find_session(&self, nous_id: &str, session_key: &str) -> Result<Option<Session>> {
         let mut stmt = self
             .conn
@@ -30,6 +31,7 @@ impl SessionStore {
 
     /// Find a session by ID (any status).
     #[instrument(skip(self))]
+    #[must_use]
     pub fn find_session_by_id(&self, id: &str) -> Result<Option<Session>> {
         let mut stmt = self
             .conn
@@ -146,6 +148,7 @@ impl SessionStore {
 
     /// List sessions, optionally filtered by nous ID.
     #[instrument(skip(self))]
+    #[must_use]
     pub fn list_sessions(&self, nous_id: Option<&str>) -> Result<Vec<Session>> {
         let mut sessions = Vec::new();
 
@@ -180,6 +183,7 @@ impl SessionStore {
 
     /// Update session status.
     #[instrument(skip(self))]
+    #[must_use]
     pub fn update_session_status(&self, id: &str, status: SessionStatus) -> Result<()> {
         self.require_writable()?;
         self.conn
@@ -193,6 +197,7 @@ impl SessionStore {
 
     /// Update session display name.
     #[instrument(skip(self))]
+    #[must_use]
     pub fn update_display_name(&self, id: &str, display_name: &str) -> Result<()> {
         self.require_writable()?;
         self.conn

--- a/crates/nous/src/cross.rs
+++ b/crates/nous/src/cross.rs
@@ -172,6 +172,7 @@ impl CrossNousRouter {
     /// Not cancel-safe. If cancelled after `mpsc::send` succeeds, the message
     /// is delivered but the caller never sees the `Delivered` result.
     #[instrument(skip(self, message), fields(msg_id = %message.id, from = %message.from, to = %message.to))]
+    #[must_use]
     pub async fn send(&self, message: CrossNousMessage) -> error::Result<DeliveryState> {
         let to = message.to.clone();
 
@@ -216,6 +217,7 @@ impl CrossNousRouter {
     /// Not cancel-safe. If cancelled after sending the message, a pending reply
     /// entry is leaked until timeout cleanup. Do not use in `select!` branches.
     #[instrument(skip(self, message), fields(msg_id = %message.id, from = %message.from, to = %message.to))]
+    #[must_use]
     pub async fn ask(&self, mut message: CrossNousMessage) -> error::Result<CrossNousReply> {
         let to = message.to.clone();
         let timeout_dur = message.reply_timeout.unwrap_or(DEFAULT_REPLY_TIMEOUT);
@@ -284,6 +286,7 @@ impl CrossNousRouter {
 
     /// Submit a reply for a pending ask.
     #[instrument(skip(self, reply), fields(in_reply_to = %reply.in_reply_to, from = %reply.from))]
+    #[must_use]
     pub async fn reply(&self, reply: CrossNousReply) -> error::Result<()> {
         let msg_id = reply.in_reply_to;
         let Some(tx) = self.pending_replies.write().await.remove(&msg_id) else {

--- a/crates/nous/src/handle.rs
+++ b/crates/nous/src/handle.rs
@@ -168,6 +168,7 @@ impl NousHandle {
     /// # Cancel safety
     ///
     /// Cancel-safe. Both sides are cancel-safe and a lost ping has no side effects.
+    #[must_use]
     pub async fn ping(&self, timeout: Duration) -> error::Result<()> {
         let (tx, rx) = oneshot::channel();
         self.send_with_timeout(NousMessage::Ping { reply: tx }, timeout)
@@ -207,6 +208,7 @@ impl NousHandle {
     ///
     /// Cancel-safe. Both `mpsc::send` and `oneshot::recv` are cancel-safe.
     /// A lost status query has no side effects.
+    #[must_use]
     pub async fn status(&self) -> error::Result<NousStatus> {
         let (tx, rx) = oneshot::channel();
         self.sender
@@ -231,6 +233,7 @@ impl NousHandle {
     /// # Cancel safety
     ///
     /// Cancel-safe. Uses a single `mpsc::send` with no follow-up await.
+    #[must_use]
     pub async fn sleep(&self) -> error::Result<()> {
         self.sender
             .send(NousMessage::Sleep)
@@ -248,6 +251,7 @@ impl NousHandle {
     /// # Cancel safety
     ///
     /// Cancel-safe. Uses a single `mpsc::send` with no follow-up await.
+    #[must_use]
     pub async fn wake(&self) -> error::Result<()> {
         self.sender
             .send(NousMessage::Wake)
@@ -265,6 +269,7 @@ impl NousHandle {
     /// # Cancel safety
     ///
     /// Cancel-safe. Uses a single `mpsc::send` with no follow-up await.
+    #[must_use]
     pub async fn shutdown(&self) -> error::Result<()> {
         self.sender
             .send(NousMessage::Shutdown)

--- a/crates/organon/src/builtins/agent.rs
+++ b/crates/organon/src/builtins/agent.rs
@@ -174,6 +174,7 @@ impl ToolExecutor for SessionsDispatchExecutor {
 }
 
 /// Register agent coordination tools.
+#[must_use]
 pub fn register(registry: &mut ToolRegistry) -> Result<()> {
     registry.register(sessions_spawn_def(), Box::new(SessionsSpawnExecutor))?;
     registry.register(sessions_dispatch_def(), Box::new(SessionsDispatchExecutor))?;

--- a/crates/organon/src/builtins/communication.rs
+++ b/crates/organon/src/builtins/communication.rs
@@ -157,6 +157,7 @@ impl ToolExecutor for SessionsSendExecutor {
 }
 
 /// Register communication tools.
+#[must_use]
 pub fn register(registry: &mut ToolRegistry) -> Result<()> {
     registry.register(message_def(), Box::new(MessageExecutor))?;
     registry.register(sessions_ask_def(), Box::new(SessionsAskExecutor))?;

--- a/crates/organon/src/builtins/enable_tool.rs
+++ b/crates/organon/src/builtins/enable_tool.rs
@@ -106,6 +106,7 @@ fn enable_tool_def() -> ToolDef {
     }
 }
 
+#[must_use]
 pub fn register(registry: &mut ToolRegistry) -> Result<()> {
     registry.register(enable_tool_def(), Box::new(EnableToolExecutor))?;
     Ok(())

--- a/crates/organon/src/builtins/filesystem.rs
+++ b/crates/organon/src/builtins/filesystem.rs
@@ -365,6 +365,7 @@ fn days_to_ymd(days: u64) -> (u64, u64, u64) {
     (y, m, d)
 }
 
+#[must_use]
 pub fn register(registry: &mut ToolRegistry) -> Result<()> {
     registry.register(grep_def(), Box::new(GrepExecutor))?;
     registry.register(find_def(), Box::new(FindExecutor))?;

--- a/crates/organon/src/builtins/memory/mod.rs
+++ b/crates/organon/src/builtins/memory/mod.rs
@@ -19,6 +19,7 @@ pub(super) fn require_services(
         .ok_or_else(|| ToolResult::error("memory services not configured"))
 }
 
+#[must_use]
 pub fn register(registry: &mut ToolRegistry) -> Result<()> {
     knowledge_ops::register(registry)?;
     note::register(registry)?;

--- a/crates/organon/src/builtins/mod.rs
+++ b/crates/organon/src/builtins/mod.rs
@@ -29,6 +29,7 @@ use crate::sandbox::SandboxConfig;
 ///
 /// Returns [`crate::error::Error::DuplicateTool`] if any built-in tool name collides with an
 /// already-registered tool.
+#[must_use]
 pub fn register_all(registry: &mut ToolRegistry) -> Result<()> {
     register_all_with_sandbox(registry, SandboxConfig::default())
 }

--- a/crates/organon/src/builtins/planning.rs
+++ b/crates/organon/src/builtins/planning.rs
@@ -360,6 +360,7 @@ impl ToolExecutor for PlanStepFailExecutor {
     }
 }
 
+#[must_use]
 pub fn register(registry: &mut ToolRegistry) -> Result<()> {
     registry.register(plan_create_def(), Box::new(PlanCreateExecutor))?;
     registry.register(plan_research_def(), Box::new(PlanResearchExecutor))?;

--- a/crates/organon/src/builtins/research.rs
+++ b/crates/organon/src/builtins/research.rs
@@ -344,6 +344,7 @@ fn web_fetch_def() -> ToolDef {
     }
 }
 
+#[must_use]
 pub fn register(registry: &mut ToolRegistry) -> Result<()> {
     registry.register(web_fetch_def(), Box::new(WebFetchExecutor))?;
     Ok(())

--- a/crates/organon/src/builtins/view_file.rs
+++ b/crates/organon/src/builtins/view_file.rs
@@ -182,6 +182,7 @@ fn execute_by_kind(
 }
 
 /// Register the `view_file` tool.
+#[must_use]
 pub fn register(registry: &mut ToolRegistry) -> Result<()> {
     registry.register(view_file_def(), Box::new(ViewFileExecutor))?;
     Ok(())

--- a/crates/organon/src/builtins/workspace.rs
+++ b/crates/organon/src/builtins/workspace.rs
@@ -519,6 +519,7 @@ impl ToolExecutor for ExecExecutor {
 }
 
 /// Register workspace tool executors.
+#[must_use]
 pub fn register(registry: &mut ToolRegistry, sandbox: crate::sandbox::SandboxConfig) -> Result<()> {
     registry.register(read_def(), Box::new(ReadExecutor))?;
     registry.register(write_def(), Box::new(WriteExecutor))?;

--- a/crates/organon/src/registry.rs
+++ b/crates/organon/src/registry.rs
@@ -58,6 +58,7 @@ impl ToolRegistry {
     /// # Errors
     ///
     /// Returns [`crate::error::Error::DuplicateTool`] if a tool with the same name is already registered.
+    #[must_use]
     pub fn register(&mut self, def: ToolDef, executor: Box<dyn ToolExecutor>) -> Result<()> {
         ensure!(
             !self.tools.contains_key(&def.name),
@@ -82,6 +83,7 @@ impl ToolRegistry {
     ///
     /// Returns [`crate::error::Error::ToolNotFound`] if no tool with the given name is registered.
     /// Returns the tool executor's error if execution fails.
+    #[must_use]
     pub async fn execute(&self, input: &ToolInput, ctx: &ToolContext) -> Result<ToolResult> {
         let tool = self.tools.get(&input.name).ok_or_else(|| {
             error::ToolNotFoundSnafu {

--- a/crates/organon/src/sandbox.rs
+++ b/crates/organon/src/sandbox.rs
@@ -174,6 +174,7 @@ impl SandboxPolicy {
     /// Designed to run in a child process via `pre_exec`. Returns `io::Error`
     /// on failure; on unsupported kernels, logs and continues based on
     /// enforcement mode.
+    #[must_use]
     pub fn apply(&self) -> std::io::Result<()> {
         self.apply_landlock()?;
         self.apply_seccomp()?;

--- a/crates/pylon/src/server.rs
+++ b/crates/pylon/src/server.rs
@@ -79,6 +79,7 @@ pub enum ServerError {
 /// Returns [`ServerError::Serve`] if the HTTP server encounters a fatal I/O error.
 /// Returns [`ServerError::TlsConfig`] if TLS is enabled but certs cannot be loaded.
 /// Returns [`ServerError::TlsNotCompiled`] if TLS is enabled but the feature is absent.
+#[must_use]
 pub async fn run(config: ServerConfig) -> Result<(), ServerError> {
     let oikos = Oikos::from_root(&config.instance_path);
     oikos.validate().context(ValidationSnafu)?;

--- a/crates/symbolon/src/credential.rs
+++ b/crates/symbolon/src/credential.rs
@@ -665,6 +665,7 @@ async fn do_refresh(client: &reqwest::Client, refresh_token: &str) -> Option<OAu
 /// Returns an error if the credential file cannot be read, contains no refresh
 /// token, the OAuth refresh request fails, or the updated credentials cannot
 /// be saved.
+#[must_use]
 pub async fn force_refresh(path: &Path) -> Result<CredentialFile, String> {
     let cred = CredentialFile::load(path)
         .ok_or_else(|| format!("cannot read credential file: {}", path.display()))?;

--- a/crates/symbolon/src/jwt.rs
+++ b/crates/symbolon/src/jwt.rs
@@ -64,6 +64,7 @@ impl JwtConfig {
     ///
     /// Returns [`crate::error::Error::InsecureKey`] if `auth_mode` is not `"none"` and the signing
     /// key is still the built-in insecure placeholder.
+    #[must_use]
     pub fn validate_for_auth_mode(&self, auth_mode: &str) -> Result<()> {
         if auth_mode != "none" && self.has_insecure_key() {
             tracing::error!(
@@ -105,6 +106,7 @@ impl JwtManager {
     ///
     /// Returns an error if the JWT claims cannot be encoded or signed.
     #[instrument(skip(self), fields(kind = "access"))]
+    #[must_use]
     pub fn issue_access(&self, sub: &str, role: Role, nous_id: Option<&str>) -> Result<String> {
         self.issue(
             sub,
@@ -128,6 +130,7 @@ impl JwtManager {
     /// Returns [`crate::error::Error::ExpiredToken`] if the token's expiration time has passed.
     /// Returns [`crate::error::Error::TokenDecode`] if the token is malformed, has an invalid
     /// signature, or fails any other JWT validation check.
+    #[must_use]
     pub fn validate(&self, token: &str) -> Result<Claims> {
         let mut validation = Validation::new(Algorithm::HS256);
         validation.set_issuer(&[&self.config.issuer]);

--- a/crates/taxis/src/encrypt.rs
+++ b/crates/taxis/src/encrypt.rs
@@ -56,6 +56,7 @@ pub fn master_key_path() -> Option<PathBuf> {
     clippy::result_large_err,
     reason = "taxis Error is inherently large due to PathBuf fields"
 )]
+#[must_use]
 pub fn load_master_key(path: &Path) -> Result<Option<[u8; KEY_LEN]>> {
     if !path.exists() {
         return Ok(None);
@@ -133,6 +134,7 @@ fn to_hex(bytes: &[u8]) -> String {
     clippy::result_large_err,
     reason = "taxis Error is inherently large due to PathBuf fields"
 )]
+#[must_use]
 pub fn generate_master_key(path: &Path) -> Result<()> {
     if path.exists() {
         return Err(error::MasterKeyExistsSnafu {
@@ -192,6 +194,7 @@ pub fn is_encrypted(value: &str) -> bool {
     clippy::result_large_err,
     reason = "taxis Error is inherently large due to PathBuf fields"
 )]
+#[must_use]
 pub fn encrypt_value(plaintext: &str, master_key: &[u8; KEY_LEN]) -> Result<String> {
     // WHY: ring::error::Unspecified has no useful fields to propagate
     let unbound = UnboundKey::new(&CHACHA20_POLY1305, master_key)
@@ -227,6 +230,7 @@ pub fn encrypt_value(plaintext: &str, master_key: &[u8; KEY_LEN]) -> Result<Stri
     clippy::result_large_err,
     reason = "taxis Error is inherently large due to PathBuf fields"
 )]
+#[must_use]
 pub fn decrypt_value(encrypted: &str, master_key: &[u8; KEY_LEN]) -> Result<String> {
     let encoded = encrypted
         .strip_prefix(ENCRYPTED_PREFIX)
@@ -288,6 +292,7 @@ fn build_decrypt_error(reason: &str) -> error::Error {
     clippy::result_large_err,
     reason = "taxis Error is inherently large due to PathBuf fields"
 )]
+#[must_use]
 pub fn encrypt_config_file(toml_path: &Path, master_key: &[u8; KEY_LEN]) -> Result<usize> {
     let content =
         std::fs::read_to_string(toml_path).context(error::ReadConfigSnafu { path: toml_path })?;

--- a/crates/taxis/src/loader.rs
+++ b/crates/taxis/src/loader.rs
@@ -30,6 +30,7 @@ use crate::oikos::Oikos;
     clippy::result_large_err,
     reason = "figment::Error is inherently large"
 )]
+#[must_use]
 pub fn load_config(oikos: &Oikos) -> Result<AletheiaConfig> {
     let toml_path = oikos.config().join("aletheia.toml");
     let yaml_path = oikos.config().join("aletheia.yaml");
@@ -101,6 +102,7 @@ fn decrypt_toml_content(content: &str) -> String {
     clippy::result_large_err,
     reason = "figment::Error is inherently large"
 )]
+#[must_use]
 pub fn write_config(oikos: &Oikos, config: &AletheiaConfig) -> Result<()> {
     write_config_checked(oikos, config, None)
 }

--- a/crates/taxis/src/oikos.rs
+++ b/crates/taxis/src/oikos.rs
@@ -237,6 +237,7 @@ impl Oikos {
         clippy::result_large_err,
         reason = "shared Error enum contains figment::Error; boxing would require a crate-wide change"
     )]
+    #[must_use]
     pub fn validate(&self) -> crate::error::Result<()> {
         use crate::error::{InstanceRootNotFoundSnafu, RequiredDirMissingSnafu};
 
@@ -278,6 +279,7 @@ impl Oikos {
         clippy::result_large_err,
         reason = "shared Error enum contains figment::Error; boxing would require a crate-wide change"
     )]
+    #[must_use]
     pub fn validate_workspace_path(&self, workspace: &str) -> crate::error::Result<()> {
         use crate::error::WorkspacePathInvalidSnafu;
 

--- a/crates/taxis/src/validate.rs
+++ b/crates/taxis/src/validate.rs
@@ -19,6 +19,7 @@ pub struct ValidationError {
 /// Serializes to JSON and validates each top-level section using
 /// [`validate_section`]. Returns all validation errors collected
 /// across all sections.
+#[must_use]
 pub fn validate_config(config: &AletheiaConfig) -> Result<(), ValidationError> {
     let value = serde_json::to_value(config).unwrap_or(Value::Null);
     let Value::Object(ref sections) = value else {
@@ -51,6 +52,7 @@ pub fn validate_config(config: &AletheiaConfig) -> Result<(), ValidationError> {
 /// Returns [`ValidationError`] if any field value is out of range, empty when
 /// required, or the section name is unrecognized. The error contains all
 /// collected validation messages.
+#[must_use]
 pub fn validate_section(section: &str, value: &Value) -> Result<(), ValidationError> {
     let mut errors = Vec::new();
 

--- a/crates/theatron/desktop/src/services/config.rs
+++ b/crates/theatron/desktop/src/services/config.rs
@@ -70,6 +70,7 @@ fn config_path() -> Result<PathBuf, ConfigError> {
 /// # Errors
 ///
 /// Returns an error if the file exists but cannot be read or parsed.
+#[must_use]
 pub fn load() -> Result<ConnectionConfig, ConfigError> {
     let path = config_path()?;
 
@@ -90,6 +91,7 @@ pub fn load() -> Result<ConnectionConfig, ConfigError> {
 ///
 /// Returns an error if the directory cannot be created or the file cannot
 /// be written.
+#[must_use]
 pub fn save(config: &ConnectionConfig) -> Result<(), ConfigError> {
     let path = config_path()?;
 

--- a/crates/theatron/desktop/src/services/connection.rs
+++ b/crates/theatron/desktop/src/services/connection.rs
@@ -80,6 +80,7 @@ impl PylonClient {
     ///
     /// Returns `InvalidToken` if the auth token contains non-ASCII characters.
     /// Returns `ClientBuild` if the reqwest client cannot be constructed.
+    #[must_use]
     pub fn new(config: &ConnectionConfig) -> Result<Self, ConnectionError> {
         let mut headers = HeaderMap::new();
         headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
@@ -112,6 +113,7 @@ impl PylonClient {
     /// Check server reachability via `GET /api/health`.
     ///
     /// Returns `Ok(())` if the server responds with a 2xx status.
+    #[must_use]
     pub async fn health(&self) -> Result<(), ConnectionError> {
         let url = format!("{}/api/health", self.base_url);
         let resp = self

--- a/crates/theatron/tui/src/api/client.rs
+++ b/crates/theatron/tui/src/api/client.rs
@@ -88,6 +88,7 @@ impl ApiClient {
     ///
     /// Returns [`ApiError::InvalidToken`] if `token` contains characters invalid in HTTP headers.
     /// Returns [`ApiError::Http`] if the HTTP client cannot be constructed.
+    #[must_use]
     pub fn new(base_url: &str, token: Option<String>) -> Result<Self> {
         let client = build_http_client(token.as_deref())?;
 
@@ -122,6 +123,7 @@ impl ApiClient {
     }
 
     #[tracing::instrument(skip(self))]
+    #[must_use]
     pub async fn health(&self) -> Result<bool> {
         // WHY: check reachability, not health status. A 503 (unhealthy)
         // means the server IS running but has degraded checks: still usable.
@@ -130,6 +132,7 @@ impl ApiClient {
     }
 
     #[tracing::instrument(skip(self))]
+    #[must_use]
     pub async fn auth_mode(&self) -> Result<AuthMode> {
         let resp = self
             .request(reqwest::Method::GET, "/api/auth/mode")
@@ -145,6 +148,7 @@ impl ApiClient {
 
     #[expect(dead_code, reason = "reserved for future interactive login flow")]
     #[tracing::instrument(skip(self, password))]
+    #[must_use]
     pub async fn login(&self, username: &str, password: &str) -> Result<LoginResponse> {
         let resp = self
             .client
@@ -165,6 +169,7 @@ impl ApiClient {
     }
 
     #[tracing::instrument(skip(self))]
+    #[must_use]
     pub async fn agents(&self) -> Result<Vec<Agent>> {
         let resp = self
             .request(reqwest::Method::GET, "/api/v1/nous")
@@ -189,6 +194,7 @@ impl ApiClient {
     /// Returns [`ApiError::Auth`] if the server rejects the authentication token.
     /// Returns [`ApiError::Server`] if the server returns a non-success status.
     #[tracing::instrument(skip(self))]
+    #[must_use]
     pub async fn sessions(&self, nous_id: &str) -> Result<Vec<Session>> {
         let encoded = encode_path(nous_id);
         let resp = self
@@ -217,6 +223,7 @@ impl ApiClient {
     /// Returns [`ApiError::Auth`] if the server rejects the authentication token.
     /// Returns [`ApiError::Server`] if the server returns a non-success status.
     #[tracing::instrument(skip(self))]
+    #[must_use]
     pub async fn history(&self, session_id: &str) -> Result<Vec<HistoryMessage>> {
         let encoded = encode_path(session_id);
         let resp = self
@@ -238,6 +245,7 @@ impl ApiClient {
     }
 
     #[tracing::instrument(skip(self))]
+    #[must_use]
     pub async fn create_session(&self, nous_id: &str, session_key: &str) -> Result<Session> {
         let resp = self
             .request(reqwest::Method::POST, "/api/v1/sessions")
@@ -258,6 +266,7 @@ impl ApiClient {
     }
 
     #[tracing::instrument(skip(self))]
+    #[must_use]
     pub async fn archive_session(&self, session_id: &str) -> Result<()> {
         let encoded = encode_path(session_id);
         let resp = self
@@ -275,6 +284,7 @@ impl ApiClient {
     }
 
     #[tracing::instrument(skip(self))]
+    #[must_use]
     pub async fn unarchive_session(&self, session_id: &str) -> Result<()> {
         let encoded = encode_path(session_id);
         let resp = self
@@ -292,6 +302,7 @@ impl ApiClient {
     }
 
     #[tracing::instrument(skip(self))]
+    #[must_use]
     pub async fn rename_session(&self, session_id: &str, name: &str) -> Result<()> {
         let encoded = encode_path(session_id);
         let resp = self
@@ -311,6 +322,7 @@ impl ApiClient {
 
     #[expect(dead_code, reason = "reserved for turn abort keybinding")]
     #[tracing::instrument(skip(self))]
+    #[must_use]
     pub async fn abort_turn(&self, turn_id: &str) -> Result<()> {
         let encoded = encode_path(turn_id);
         let resp = self
@@ -328,6 +340,7 @@ impl ApiClient {
     }
 
     #[tracing::instrument(skip(self))]
+    #[must_use]
     pub async fn approve_tool(&self, turn_id: &str, tool_id: &str) -> Result<()> {
         let t = encode_path(turn_id);
         let d = encode_path(tool_id);
@@ -346,6 +359,7 @@ impl ApiClient {
     }
 
     #[tracing::instrument(skip(self))]
+    #[must_use]
     pub async fn deny_tool(&self, turn_id: &str, tool_id: &str) -> Result<()> {
         let t = encode_path(turn_id);
         let d = encode_path(tool_id);
@@ -364,6 +378,7 @@ impl ApiClient {
     }
 
     #[tracing::instrument(skip(self))]
+    #[must_use]
     pub async fn approve_plan(&self, plan_id: &str) -> Result<()> {
         let encoded = encode_path(plan_id);
         let resp = self
@@ -381,6 +396,7 @@ impl ApiClient {
     }
 
     #[tracing::instrument(skip(self))]
+    #[must_use]
     pub async fn cancel_plan(&self, plan_id: &str) -> Result<()> {
         let encoded = encode_path(plan_id);
         let resp = self
@@ -398,6 +414,7 @@ impl ApiClient {
     }
 
     #[tracing::instrument(skip(self))]
+    #[must_use]
     pub async fn today_cost_cents(&self) -> Result<u32> {
         let resp = self
             .request(reqwest::Method::GET, "/api/v1/costs/daily")
@@ -415,6 +432,7 @@ impl ApiClient {
     }
 
     #[tracing::instrument(skip(self))]
+    #[must_use]
     pub async fn compact(&self, session_id: &str) -> Result<()> {
         let encoded = encode_path(session_id);
         let resp = self
@@ -439,6 +457,7 @@ impl ApiClient {
     /// Returns [`ApiError::Auth`] if the server rejects the authentication token.
     /// Returns [`ApiError::Server`] if the server returns a non-success status.
     #[tracing::instrument(skip(self))]
+    #[must_use]
     pub async fn tools(&self, nous_id: &str) -> Result<Vec<NousTool>> {
         let encoded = encode_path(nous_id);
         let resp = self
@@ -460,6 +479,7 @@ impl ApiClient {
     }
 
     #[tracing::instrument(skip(self))]
+    #[must_use]
     pub async fn recall(&self, nous_id: &str, query: &str) -> Result<String> {
         let encoded = encode_path(nous_id);
         let resp = self
@@ -487,6 +507,7 @@ impl ApiClient {
     /// Returns [`ApiError::Auth`] if the server rejects the authentication token.
     /// Returns [`ApiError::Server`] if the server returns a non-success status.
     #[tracing::instrument(skip(self))]
+    #[must_use]
     pub async fn config(&self) -> Result<serde_json::Value> {
         let resp = self
             .request(reqwest::Method::GET, "/api/v1/config")
@@ -548,6 +569,7 @@ impl ApiClient {
     }
 
     #[tracing::instrument(skip(self))]
+    #[must_use]
     pub async fn knowledge_fact_detail(&self, fact_id: &str) -> Result<serde_json::Value> {
         let encoded = encode_path(fact_id);
         let resp = self
@@ -567,6 +589,7 @@ impl ApiClient {
     }
 
     #[tracing::instrument(skip(self))]
+    #[must_use]
     pub async fn knowledge_forget(&self, fact_id: &str) -> Result<()> {
         let encoded = encode_path(fact_id);
         let resp = self
@@ -584,6 +607,7 @@ impl ApiClient {
     }
 
     #[tracing::instrument(skip(self))]
+    #[must_use]
     pub async fn knowledge_restore(&self, fact_id: &str) -> Result<()> {
         let encoded = encode_path(fact_id);
         let resp = self
@@ -601,6 +625,7 @@ impl ApiClient {
     }
 
     #[tracing::instrument(skip(self))]
+    #[must_use]
     pub async fn knowledge_update_confidence(&self, fact_id: &str, confidence: f64) -> Result<()> {
         let encoded = encode_path(fact_id);
         let resp = self
@@ -619,6 +644,7 @@ impl ApiClient {
     }
 
     #[tracing::instrument(skip(self, text))]
+    #[must_use]
     pub async fn queue_message(&self, session_id: &str, text: &str) -> Result<()> {
         let encoded = encode_path(session_id);
         let resp = self

--- a/crates/theatron/tui/src/app.rs
+++ b/crates/theatron/tui/src/app.rs
@@ -145,6 +145,7 @@ impl App {
     /// Returns an error if the API client cannot be constructed, the gateway is
     /// unreachable, or the server requires authentication and no token is configured.
     #[tracing::instrument(skip_all, fields(url = %config.url))]
+    #[must_use]
     pub async fn init(config: Config) -> Result<Self> {
         let client = ApiClient::new(&config.url, config.token.clone())?;
 

--- a/crates/theatron/tui/src/clipboard.rs
+++ b/crates/theatron/tui/src/clipboard.rs
@@ -1,5 +1,6 @@
 /// Copy text to the system clipboard.
 /// Tries arboard (native) first, falls back to OSC52 escape sequence.
+#[must_use]
 pub fn copy_to_clipboard(text: &str) -> Result<(), String> {
     match arboard::Clipboard::new() {
         Ok(mut clipboard) => match clipboard.set_text(text) {

--- a/crates/theatron/tui/src/config.rs
+++ b/crates/theatron/tui/src/config.rs
@@ -109,6 +109,7 @@ impl Config {
         reason = "consistent instance-method API; &self kept for tracing::instrument skip"
     )]
     #[tracing::instrument(skip(self))]
+    #[must_use]
     pub fn clear_credentials(&self) -> Result<()> {
         let path = Self::config_path()?;
         if path.exists() {
@@ -127,6 +128,7 @@ impl Config {
         reason = "consistent instance-method API; &self kept for tracing::instrument skip"
     )]
     #[tracing::instrument(skip(self, token))]
+    #[must_use]
     pub fn save_token(&self, token: &str) -> Result<()> {
         let path = Self::config_path()?;
         let mut file_config = Self::load_file().unwrap_or_default();

--- a/crates/thesauros/src/manifest.rs
+++ b/crates/thesauros/src/manifest.rs
@@ -128,6 +128,7 @@ pub struct PackPropertyDef {
 /// - [`error::Error::ManifestNotFound`] if `pack.toml` is missing
 /// - [`error::Error::ReadFile`] if the file cannot be read
 /// - [`error::Error::ParseManifest`] if TOML parsing fails
+#[must_use]
 pub fn load_manifest(pack_root: &Path) -> Result<PackManifest> {
     ensure!(
         pack_root.is_dir(),
@@ -191,6 +192,7 @@ fn is_valid_pack_name(name: &str) -> bool {
 ///
 /// Returns the canonical absolute path, or an error if the file does not
 /// exist or if the resolved path escapes the pack root directory.
+#[must_use]
 pub fn resolve_context_path(pack_root: &Path, entry: &ContextEntry) -> Result<PathBuf> {
     let resolved = pack_root.join(&entry.path);
     ensure!(


### PR DESCRIPTION
Every pub fn returning Result now has #[must_use]. 90 files, 231 insertions. Callers cannot silently discard errors.

Closes #1412