### PR TITLE
fix(ci): harden smoke test and split cargo-deny advisories

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -95,4 +95,7 @@ jobs:
           mkdir -p /tmp/test-instance/config /tmp/test-instance/data /tmp/test-instance/nous/_default
           echo '[gateway]' > /tmp/test-instance/config/aletheia.toml
           echo 'port = 19999' >> /tmp/test-instance/config/aletheia.toml
-          ./target/release/aletheia check-config -r /tmp/test-instance || true
+          # WHY: check-config exits 1 on incomplete config (expected in smoke test).
+          # Exits 101+ on panic/crash. Accept 0 or 1, fail on anything else.
+          rc=0; ./target/release/aletheia check-config -r /tmp/test-instance || rc=$?
+          if [ "$rc" -gt 1 ]; then echo "check-config crashed with exit code $rc"; exit 1; fi

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -25,11 +25,25 @@ jobs:
           IGNORES=$(grep -oP 'id = "\K[^"]+' deny.toml | sed 's/^/--ignore /' | tr '\n' ' ')
           cargo audit $IGNORES
 
+  # WHY: Split cargo-deny into two jobs. Advisories on transitive deps
+  # can block all PRs for days until upstream publishes a fix. Advisories
+  # warn; licenses/bans/sources block.
+  cargo-deny-advisories:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: EmbarkStudios/cargo-deny-action@3fd3802e88374d3fe9159b834c7714ec57d6c979 # v2
+        with:
+          command: check advisories
+
   cargo-deny:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: EmbarkStudios/cargo-deny-action@3fd3802e88374d3fe9159b834c7714ec57d6c979 # v2
+        with:
+          command: check licenses bans sources
 
   secret-scan:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Smoke test: replace `|| true` with exit-code check that accepts 0 or 1 (config validation error) but fails on 101+ (panic/crash). Closes #1554.
- Security: split cargo-deny into two jobs. Advisories run with `continue-on-error` so transitive unmaintained crates don't block PRs. Licenses/bans/sources remain strict blockers. Closes #1556.

## Test plan

- [ ] Smoke test still passes (check-config returns 1 on minimal config, not panic)
- [ ] cargo-deny advisories job runs but doesn't block merge
- [ ] cargo-deny licenses/bans/sources still blocks on violations