### PR TITLE
refactor(theatron): replace reqwest-eventsource git fork with owned SSE parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1979,17 +1979,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "eventsource-stream"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74fef4569247a5f429d9156b9d0a2599914385dd189c539334c625d8099d90ab"
-dependencies = [
- "futures-core",
- "nom",
- "pin-project-lite",
-]
-
-[[package]]
 name = "fallible-iterator"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2272,12 +2261,6 @@ name = "futures-task"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
-
-[[package]]
-name = "futures-timer"
-version = "3.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
 
 [[package]]
 name = "futures-util"
@@ -4897,21 +4880,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "reqwest-eventsource"
-version = "0.6.0"
-source = "git+https://github.com/romnn/reqwest-eventsource?branch=feat%2Freqwest-0.13#356e2f61827b193bd5ab389c38059bcc2eed90aa"
-dependencies = [
- "eventsource-stream",
- "futures-core",
- "futures-timer",
- "mime",
- "nom",
- "pin-project-lite",
- "reqwest 0.13.2",
- "thiserror 1.0.69",
-]
-
-[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5872,6 +5840,8 @@ dependencies = [
 name = "theatron-core"
 version = "0.12.0"
 dependencies = [
+ "bytes",
+ "futures-core",
  "pulldown-cmark",
  "serde",
 ]
@@ -5896,7 +5866,6 @@ dependencies = [
  "ratatui",
  "regex",
  "reqwest 0.13.2",
- "reqwest-eventsource",
  "rustls",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,6 +124,7 @@ cron = "0.15"
 jiff = "0.2"
 
 # Async utilities
+bytes = "1"
 futures = "0.3"
 
 # Async

--- a/crates/theatron/core/Cargo.toml
+++ b/crates/theatron/core/Cargo.toml
@@ -8,6 +8,8 @@ description = "Shared presentation types and traits for Aletheia UIs"
 publish = false
 
 [dependencies]
+bytes = { workspace = true }
+futures-core = "0.3"
 serde = { workspace = true }
 
 [dev-dependencies]

--- a/crates/theatron/core/src/lib.rs
+++ b/crates/theatron/core/src/lib.rs
@@ -1,1 +1,3 @@
 //! Shared presentation types and traits for Aletheia UIs.
+
+pub mod sse;

--- a/crates/theatron/core/src/sse.rs
+++ b/crates/theatron/core/src/sse.rs
@@ -1,0 +1,371 @@
+//! Owned SSE (Server-Sent Events) parser for reqwest response streams.
+
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use bytes::Bytes;
+use futures_core::Stream;
+
+/// A parsed SSE event from the wire protocol.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SseEvent {
+    /// The `event:` field. Defaults to `"message"` per the SSE spec.
+    pub event: String,
+    /// The `data:` field(s), concatenated with newlines for multi-line data.
+    pub data: String,
+    /// The `id:` field, if present.
+    pub id: Option<String>,
+    /// The `retry:` field in milliseconds, if present.
+    pub retry: Option<u64>,
+}
+
+/// Transforms a byte stream into a stream of parsed SSE events.
+///
+/// Handles the full SSE wire protocol: `data:`, `event:`, `id:`, `retry:`,
+/// comment lines (`:` prefix), multi-line `data:` fields (concatenated with
+/// newlines), and blank-line event delimiters.
+pub struct SseStream<S> {
+    stream: S,
+    buf: String,
+    done: bool,
+
+    current_event: Option<String>,
+    current_data: String,
+    current_id: Option<String>,
+    current_retry: Option<u64>,
+    has_data: bool,
+}
+
+impl<S, E> SseStream<S>
+where
+    S: Stream<Item = Result<Bytes, E>> + Unpin,
+    E: std::fmt::Display,
+{
+    pub fn new(stream: S) -> Self {
+        Self {
+            stream,
+            buf: String::new(),
+            done: false,
+            current_event: None,
+            current_data: String::new(),
+            current_id: None,
+            current_retry: None,
+            has_data: false,
+        }
+    }
+
+    /// Process a single SSE line. Returns `Some(SseEvent)` on blank-line
+    /// delimiter when accumulated data exists.
+    fn process_line(&mut self, line: &str) -> Option<SseEvent> {
+        if line.is_empty() {
+            if !self.has_data {
+                return None;
+            }
+
+            // WHY: trailing newline added by multi-line concatenation must be
+            // stripped; the SSE spec says "append data + LF" per data: line,
+            // but the final LF is not part of the event data.
+            if self.current_data.ends_with('\n') {
+                self.current_data.pop();
+            }
+
+            let event = SseEvent {
+                event: self
+                    .current_event
+                    .take()
+                    .unwrap_or_else(|| "message".to_string()),
+                data: std::mem::take(&mut self.current_data),
+                id: self.current_id.take(),
+                retry: self.current_retry.take(),
+            };
+            self.has_data = false;
+            return Some(event);
+        }
+
+        // Comment lines start with ':'
+        if line.starts_with(':') {
+            return None;
+        }
+
+        let (field, value) = if let Some((field, rest)) = line.split_once(':') {
+            // WHY: SSE spec says "if value starts with a space, remove it"
+            let value = rest.strip_prefix(' ').unwrap_or(rest);
+            (field, value)
+        } else {
+            (line, "")
+        };
+
+        match field {
+            "data" => {
+                self.current_data.push_str(value);
+                self.current_data.push('\n');
+                self.has_data = true;
+            }
+            "event" => {
+                self.current_event = Some(value.to_string());
+            }
+            "id" => {
+                self.current_id = Some(value.to_string());
+            }
+            "retry" => {
+                if let Ok(ms) = value.parse::<u64>() {
+                    self.current_retry = Some(ms);
+                }
+            }
+            _ => {
+                // NOTE: unknown fields are ignored per the SSE spec
+            }
+        }
+
+        None
+    }
+}
+
+impl<S, E> Stream for SseStream<S>
+where
+    S: Stream<Item = Result<Bytes, E>> + Unpin,
+    E: std::fmt::Display,
+{
+    type Item = SseEvent;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = self.get_mut();
+
+        loop {
+            // Process any complete lines already in the buffer.
+            while let Some(pos) = this.buf.find('\n') {
+                // SAFETY: `pos` is a valid byte index from `find('\n')`, and
+                // '\n' and '\r' are single-byte ASCII, so these slices are
+                // always on UTF-8 char boundaries.
+                #[expect(
+                    clippy::string_slice,
+                    reason = "indices from find() on ASCII delimiters"
+                )]
+                let line = if pos > 0 && this.buf.as_bytes()[pos - 1] == b'\r' {
+                    this.buf[..pos - 1].to_string()
+                } else {
+                    this.buf[..pos].to_string()
+                };
+                this.buf.drain(..=pos);
+
+                if let Some(event) = this.process_line(&line) {
+                    return Poll::Ready(Some(event));
+                }
+            }
+
+            if this.done {
+                // Flush any remaining partial event when the stream ends.
+                if this.has_data {
+                    if this.current_data.ends_with('\n') {
+                        this.current_data.pop();
+                    }
+                    let event = SseEvent {
+                        event: this
+                            .current_event
+                            .take()
+                            .unwrap_or_else(|| "message".to_string()),
+                        data: std::mem::take(&mut this.current_data),
+                        id: this.current_id.take(),
+                        retry: this.current_retry.take(),
+                    };
+                    this.has_data = false;
+                    return Poll::Ready(Some(event));
+                }
+                return Poll::Ready(None);
+            }
+
+            match Pin::new(&mut this.stream).poll_next(cx) {
+                Poll::Ready(Some(Ok(bytes))) => {
+                    // SAFETY: SSE is a text protocol; invalid UTF-8 is
+                    // replaced rather than causing a hard failure.
+                    this.buf.push_str(&String::from_utf8_lossy(&bytes));
+                }
+                Poll::Ready(Some(Err(_)) | None) => {
+                    this.done = true;
+                }
+                Poll::Pending => return Poll::Pending,
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Helper: creates a byte stream from a list of string chunks.
+    struct ChunkStream {
+        chunks: Vec<Bytes>,
+        index: usize,
+    }
+
+    impl ChunkStream {
+        fn new(chunks: Vec<&str>) -> Self {
+            Self {
+                chunks: chunks
+                    .into_iter()
+                    .map(|s| Bytes::from(s.to_string()))
+                    .collect(),
+                index: 0,
+            }
+        }
+    }
+
+    impl Stream for ChunkStream {
+        type Item = Result<Bytes, std::io::Error>;
+
+        fn poll_next(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+            let this = self.get_mut();
+            if this.index < this.chunks.len() {
+                let chunk = this.chunks[this.index].clone();
+                this.index += 1;
+                Poll::Ready(Some(Ok(chunk)))
+            } else {
+                Poll::Ready(None)
+            }
+        }
+    }
+
+    /// Collect all events from a chunk stream synchronously (all chunks are
+    /// immediately available so no actual async scheduling is needed).
+    fn collect_events(chunks: Vec<&str>) -> Vec<SseEvent> {
+        let stream = ChunkStream::new(chunks);
+        let mut sse = SseStream::new(stream);
+        let mut events = Vec::new();
+        let waker = std::task::Waker::noop();
+        let mut cx = Context::from_waker(waker);
+
+        loop {
+            match Pin::new(&mut sse).poll_next(&mut cx) {
+                Poll::Ready(Some(event)) => events.push(event),
+                Poll::Ready(None) => break,
+                Poll::Pending => panic!("unexpected Pending from synchronous stream"),
+            }
+        }
+        events
+    }
+
+    #[test]
+    fn single_data_event() {
+        let events = collect_events(vec!["data: hello\n\n"]);
+        assert_eq!(events.len(), 1, "expected exactly one event");
+        assert_eq!(events[0].event, "message");
+        assert_eq!(events[0].data, "hello");
+        assert!(events[0].id.is_none());
+    }
+
+    #[test]
+    fn multi_line_data_concatenated_with_newline() {
+        let events = collect_events(vec!["data: line1\ndata: line2\ndata: line3\n\n"]);
+        assert_eq!(events.len(), 1, "expected exactly one event");
+        assert_eq!(events[0].data, "line1\nline2\nline3");
+    }
+
+    #[test]
+    fn event_field_overrides_default() {
+        let events = collect_events(vec!["event: custom\ndata: payload\n\n"]);
+        assert_eq!(events.len(), 1, "expected exactly one event");
+        assert_eq!(events[0].event, "custom");
+        assert_eq!(events[0].data, "payload");
+    }
+
+    #[test]
+    fn comment_lines_skipped() {
+        let events = collect_events(vec![": this is a comment\ndata: real\n\n"]);
+        assert_eq!(events.len(), 1, "expected exactly one event");
+        assert_eq!(events[0].data, "real");
+    }
+
+    #[test]
+    fn empty_data_event() {
+        let events = collect_events(vec!["data:\n\n"]);
+        assert_eq!(events.len(), 1, "expected exactly one event");
+        assert_eq!(events[0].data, "");
+    }
+
+    #[test]
+    fn blank_lines_without_data_produce_no_event() {
+        let events = collect_events(vec!["\n\n\n"]);
+        assert!(
+            events.is_empty(),
+            "blank lines without data should not emit events"
+        );
+    }
+
+    #[test]
+    fn id_field_captured() {
+        let events = collect_events(vec!["id: 42\ndata: test\n\n"]);
+        assert_eq!(events.len(), 1, "expected exactly one event");
+        assert_eq!(events[0].id.as_deref(), Some("42"));
+    }
+
+    #[test]
+    fn retry_field_parsed() {
+        let events = collect_events(vec!["retry: 3000\ndata: test\n\n"]);
+        assert_eq!(events.len(), 1, "expected exactly one event");
+        assert_eq!(events[0].retry, Some(3000));
+    }
+
+    #[test]
+    fn retry_non_numeric_ignored() {
+        let events = collect_events(vec!["retry: abc\ndata: test\n\n"]);
+        assert_eq!(events.len(), 1, "expected exactly one event");
+        assert!(
+            events[0].retry.is_none(),
+            "non-numeric retry should be ignored"
+        );
+    }
+
+    #[test]
+    fn multiple_events_in_one_chunk() {
+        let events = collect_events(vec!["event: a\ndata: first\n\nevent: b\ndata: second\n\n"]);
+        assert_eq!(events.len(), 2, "expected two events");
+        assert_eq!(events[0].event, "a");
+        assert_eq!(events[0].data, "first");
+        assert_eq!(events[1].event, "b");
+        assert_eq!(events[1].data, "second");
+    }
+
+    #[test]
+    fn data_split_across_chunks() {
+        let events = collect_events(vec!["data: hel", "lo\n\n"]);
+        assert_eq!(events.len(), 1, "expected exactly one event");
+        assert_eq!(events[0].data, "hello");
+    }
+
+    #[test]
+    fn crlf_line_endings() {
+        let events = collect_events(vec!["data: hello\r\n\r\n"]);
+        assert_eq!(events.len(), 1, "expected exactly one event");
+        assert_eq!(events[0].data, "hello");
+    }
+
+    #[test]
+    fn event_and_data_combo() {
+        let events = collect_events(vec!["event: turn_start\ndata: {\"id\":1}\n\n"]);
+        assert_eq!(events.len(), 1, "expected exactly one event");
+        assert_eq!(events[0].event, "turn_start");
+        assert_eq!(events[0].data, r#"{"id":1}"#);
+    }
+
+    #[test]
+    fn data_with_no_space_after_colon() {
+        let events = collect_events(vec!["data:no-space\n\n"]);
+        assert_eq!(events.len(), 1, "expected exactly one event");
+        assert_eq!(events[0].data, "no-space");
+    }
+
+    #[test]
+    fn unknown_fields_ignored() {
+        let events = collect_events(vec!["foo: bar\ndata: ok\n\n"]);
+        assert_eq!(events.len(), 1, "expected exactly one event");
+        assert_eq!(events[0].data, "ok");
+    }
+
+    #[test]
+    fn flush_partial_event_on_stream_end() {
+        let events = collect_events(vec!["data: partial\n"]);
+        assert_eq!(events.len(), 1, "partial event should flush on stream end");
+        assert_eq!(events[0].data, "partial");
+    }
+}

--- a/crates/theatron/desktop/Cargo.toml
+++ b/crates/theatron/desktop/Cargo.toml
@@ -18,7 +18,6 @@ tokio = { workspace = true }
 
 # HTTP + SSE
 reqwest = { workspace = true, features = ["stream", "cookies"] }
-reqwest-eventsource = { git = "https://github.com/romnn/reqwest-eventsource", branch = "feat/reqwest-0.13" }
 rustls = { workspace = true }
 
 # Serialization

--- a/crates/theatron/desktop/src/api/sse.rs
+++ b/crates/theatron/desktop/src/api/sse.rs
@@ -25,7 +25,7 @@
 
 use futures_util::StreamExt;
 use reqwest::Client;
-use reqwest_eventsource::{Event as EsEvent, EventSource};
+use theatron_core::sse::SseStream;
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 use tracing::Instrument;
@@ -80,16 +80,21 @@ impl SseConnection {
                         return;
                     }
 
-                    let req = client.get(&url).header("Accept", "text/event-stream");
-                    let mut es = match EventSource::new(req) {
-                        Ok(es) => es,
+                    let resp = match tokio::select! {
+                        biased;
+                        _ = child.cancelled() => return,
+                        result = client
+                            .get(&url)
+                            .header("Accept", "text/event-stream")
+                            .send() => result,
+                    } {
+                        Ok(resp) => resp,
                         Err(e) => {
-                            tracing::error!("failed to create SSE EventSource: {e}");
+                            tracing::error!("SSE connection failed: {e}");
                             let _ = tx.send(SseEvent::Disconnected).await;
                             tokio::select! {
                                 biased;
                                 _ = child.cancelled() => return,
-                                // NOTE: backoff elapsed, retry connection
                                 _ = tokio::time::sleep(backoff) => {}
                             }
                             backoff = advance_backoff(backoff);
@@ -97,16 +102,31 @@ impl SseConnection {
                         }
                     };
 
+                    if !resp.status().is_success() {
+                        let status = resp.status();
+                        let reason = status.canonical_reason().unwrap_or("Unknown");
+                        let body = resp.text().await.unwrap_or_default();
+                        let message = extract_error_message(&body, status.as_u16(), reason);
+                        tracing::warn!("SSE error: {message}");
+                        let _ = tx.send(SseEvent::Disconnected).await;
+                        backoff = advance_backoff(backoff);
+                        tokio::select! {
+                            biased;
+                            _ = child.cancelled() => return,
+                            _ = tokio::time::sleep(backoff) => {}
+                        }
+                        continue;
+                    }
+
                     let _ = tx.send(SseEvent::Connected).await;
-                    let mut connected = false;
+                    tracing::info!("SSE connected");
+                    backoff = INITIAL_BACKOFF;
+                    let mut es = SseStream::new(resp.bytes_stream());
 
                     loop {
                         let maybe_event = tokio::select! {
                             biased;
-                            _ = child.cancelled() => {
-                                es.close();
-                                return;
-                            }
+                            _ = child.cancelled() => return,
                             result = tokio::time::timeout(HEARTBEAT_TIMEOUT, es.next()) => result,
                         };
 
@@ -114,52 +134,23 @@ impl SseConnection {
                             Ok(Some(event)) => event,
                             Ok(None) => break,
                             Err(_elapsed) => {
-                                // WHY: No event within HEARTBEAT_TIMEOUT. A healthy server
-                                // sends pings more frequently, so silence means the
-                                // connection is stale.
                                 tracing::warn!(
                                     timeout_secs = HEARTBEAT_TIMEOUT.as_secs(),
                                     "SSE heartbeat timeout — treating as disconnect"
                                 );
-                                es.close();
                                 break;
                             }
                         };
 
-                        match event {
-                            Ok(EsEvent::Open) => {
-                                tracing::info!("SSE connected");
-                                connected = true;
-                                backoff = INITIAL_BACKOFF;
-                            }
-                            Ok(EsEvent::Message(msg)) => {
-                                if let Some(parsed) = parse_sse_event(&msg.event, &msg.data)
-                                    && tx.send(parsed).await.is_err()
-                                {
-                                    // WHY: Receiver dropped: shut down.
-                                    return;
-                                }
-                            }
-                            Err(reqwest_eventsource::Error::InvalidStatusCode(status, resp)) => {
-                                let reason = status.canonical_reason().unwrap_or("Unknown");
-                                let body = resp.text().await.unwrap_or_default();
-                                let message = extract_error_message(&body, status.as_u16(), reason);
-                                tracing::warn!("SSE error: {message}");
-                                es.close();
-                                break;
-                            }
-                            Err(e) => {
-                                tracing::warn!("SSE error: {e}");
-                                es.close();
-                                break;
-                            }
+                        if let Some(parsed) = parse_sse_event(&event.event, &event.data)
+                            && tx.send(parsed).await.is_err()
+                        {
+                            // Receiver dropped: shut down.
+                            return;
                         }
                     }
 
                     let _ = tx.send(SseEvent::Disconnected).await;
-                    if !connected {
-                        backoff = advance_backoff(backoff);
-                    }
                     tracing::info!(backoff_secs = backoff.as_secs(), "SSE reconnecting");
                     tokio::select! {
                         biased;

--- a/crates/theatron/desktop/src/api/streaming.rs
+++ b/crates/theatron/desktop/src/api/streaming.rs
@@ -7,7 +7,7 @@
 //! # Abort support
 //!
 //! Pass a `CancellationToken` to `stream_turn`. When cancelled, the
-//! background task closes the `EventSource` immediately, freeing the
+//! background task drops the SSE stream immediately, freeing the
 //! HTTP connection. The Dioxus component triggers cancellation via a
 //! stop button bound to the token.
 //!
@@ -34,7 +34,7 @@
 
 use futures_util::StreamExt;
 use reqwest::Client;
-use reqwest_eventsource::{Event as EsEvent, EventSource};
+use theatron_core::sse::SseStream;
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 use tracing::Instrument;
@@ -75,8 +75,18 @@ pub fn stream_turn(
     let span = tracing::info_span!("stream_turn");
     tokio::spawn(
         async move {
-            let mut es = match EventSource::new(builder) {
-                Ok(es) => es,
+            let resp = match tokio::select! {
+                biased;
+                _ = cancel.cancelled() => {
+                    tracing::info!("stream cancelled before connect");
+                    let _ = tx.send(StreamEvent::TurnAbort {
+                        reason: "cancelled by user".to_string(),
+                    }).await;
+                    return;
+                }
+                result = builder.send() => result,
+            } {
+                Ok(resp) => resp,
                 Err(e) => {
                     let _ = tx
                         .send(StreamEvent::Error(format!("failed to connect: {e}")))
@@ -85,12 +95,22 @@ pub fn stream_turn(
                 }
             };
 
+            if !resp.status().is_success() {
+                let status = resp.status();
+                let reason = status.canonical_reason().unwrap_or("Unknown");
+                let body = resp.text().await.unwrap_or_default();
+                let message = extract_error_message(&body, status.as_u16(), reason);
+                let _ = tx.send(StreamEvent::Error(message)).await;
+                return;
+            }
+
+            let mut es = SseStream::new(resp.bytes_stream());
+
             loop {
                 let maybe_event = tokio::select! {
                     biased;
                     _ = cancel.cancelled() => {
                         tracing::info!("stream cancelled by user");
-                        es.close();
                         let _ = tx.send(StreamEvent::TurnAbort {
                             reason: "cancelled by user".to_string(),
                         }).await;
@@ -101,39 +121,17 @@ pub fn stream_turn(
 
                 let Some(event) = maybe_event else { break };
 
-                match event {
-                    // NOTE: SSE connection opened, no action needed
-                    Ok(EsEvent::Open) => {}
-                    Ok(EsEvent::Message(msg)) => {
-                        if let Some(parsed) = parse_stream_event(&msg.event, &msg.data) {
-                            let is_terminal = matches!(
-                                &parsed,
-                                StreamEvent::TurnComplete { .. }
-                                    | StreamEvent::TurnAbort { .. }
-                                    | StreamEvent::Error(_)
-                            );
-                            if tx.send(parsed).await.is_err() {
-                                break;
-                            }
-                            if is_terminal {
-                                es.close();
-                                break;
-                            }
-                        }
-                    }
-                    Err(reqwest_eventsource::Error::InvalidStatusCode(status, resp)) => {
-                        let reason = status.canonical_reason().unwrap_or("Unknown");
-                        let body = resp.text().await.unwrap_or_default();
-                        let message = extract_error_message(&body, status.as_u16(), reason);
-                        let _ = tx.send(StreamEvent::Error(message)).await;
-                        es.close();
+                if let Some(parsed) = parse_stream_event(&event.event, &event.data) {
+                    let is_terminal = matches!(
+                        &parsed,
+                        StreamEvent::TurnComplete { .. }
+                            | StreamEvent::TurnAbort { .. }
+                            | StreamEvent::Error(_)
+                    );
+                    if tx.send(parsed).await.is_err() {
                         break;
                     }
-                    Err(e) => {
-                        let _ = tx
-                            .send(StreamEvent::Error(format!("stream error: {e}")))
-                            .await;
-                        es.close();
+                    if is_terminal {
                         break;
                     }
                 }

--- a/crates/theatron/tui/Cargo.toml
+++ b/crates/theatron/tui/Cargo.toml
@@ -24,7 +24,6 @@ tokio = { workspace = true }
 
 # HTTP + SSE
 reqwest = { workspace = true, features = ["stream", "cookies"] }
-reqwest-eventsource = { git = "https://github.com/romnn/reqwest-eventsource", branch = "feat/reqwest-0.13" }
 rustls = { workspace = true }
 
 # Serialization

--- a/crates/theatron/tui/src/api/sse.rs
+++ b/crates/theatron/tui/src/api/sse.rs
@@ -1,10 +1,8 @@
 use futures_util::StreamExt;
 use reqwest::Client;
-use reqwest_eventsource::{Event as EsEvent, EventSource};
+use theatron_core::sse::SseStream;
 use tokio::sync::mpsc;
 use tracing::Instrument;
-
-use aletheia_koina::http::CONTENT_TYPE_EVENT_STREAM;
 
 use crate::id::{NousId, SessionId, TurnId};
 
@@ -37,11 +35,15 @@ impl SseConnection {
                 let mut backoff_secs: u64 = 1;
 
                 loop {
-                    let req = client.get(&url).header("Accept", CONTENT_TYPE_EVENT_STREAM);
-                    let mut es = match EventSource::new(req) {
-                        Ok(es) => es,
+                    let resp = match client
+                        .get(&url)
+                        .header("Accept", "text/event-stream")
+                        .send()
+                        .await
+                    {
+                        Ok(resp) => resp,
                         Err(e) => {
-                            tracing::error!("failed to create SSE EventSource: {e}");
+                            tracing::error!("SSE connection failed: {e}");
                             let _ = tx.send(SseEvent::Disconnected).await;
                             tokio::time::sleep(std::time::Duration::from_secs(backoff_secs)).await;
                             backoff_secs = (backoff_secs * 2).min(30);
@@ -49,8 +51,31 @@ impl SseConnection {
                         }
                     };
 
+                    if !resp.status().is_success() {
+                        let status = resp.status();
+                        let reason = status.canonical_reason().unwrap_or("Unknown");
+                        let body = resp.text().await.unwrap_or_default();
+                        let message =
+                            if let Ok(json) = serde_json::from_str::<serde_json::Value>(&body) {
+                                json.get("message")
+                                    .or_else(|| json.get("error"))
+                                    .and_then(|v| v.as_str())
+                                    .map(|s| s.to_string())
+                                    .unwrap_or_else(|| format!("{} {}", status.as_u16(), reason))
+                            } else {
+                                format!("{} {}", status.as_u16(), reason)
+                            };
+                        tracing::warn!("SSE error: {message}");
+                        let _ = tx.send(SseEvent::Disconnected).await;
+                        backoff_secs = (backoff_secs * 2).min(30);
+                        tokio::time::sleep(std::time::Duration::from_secs(backoff_secs)).await;
+                        continue;
+                    }
+
                     let _ = tx.send(SseEvent::Connected).await;
-                    let mut connected = false;
+                    tracing::info!("SSE connected");
+                    backoff_secs = 1;
+                    let mut es = SseStream::new(resp.bytes_stream());
 
                     loop {
                         let maybe_event = tokio::time::timeout(READ_TIMEOUT, es.next()).await;
@@ -65,57 +90,19 @@ impl SseConnection {
                                     timeout_secs = READ_TIMEOUT.as_secs(),
                                     "SSE read timeout — treating as disconnect"
                                 );
-                                es.close();
                                 break;
                             }
                         };
 
-                        match event {
-                            Ok(EsEvent::Open) => {
-                                tracing::info!("SSE connected");
-                                connected = true;
-                                backoff_secs = 1;
-                            }
-                            Ok(EsEvent::Message(msg)) => {
-                                if let Some(parsed) = parse_sse_event(&msg.event, &msg.data)
-                                    && tx.send(parsed).await.is_err()
-                                {
-                                    // WHY: receiver dropped: shut down the SSE loop
-                                    return;
-                                }
-                            }
-                            Err(reqwest_eventsource::Error::InvalidStatusCode(status, resp)) => {
-                                let reason = status.canonical_reason().unwrap_or("Unknown");
-                                let body = resp.text().await.unwrap_or_default();
-                                let message = if let Ok(json) =
-                                    serde_json::from_str::<serde_json::Value>(&body)
-                                {
-                                    json.get("message")
-                                        .or_else(|| json.get("error"))
-                                        .and_then(|v| v.as_str())
-                                        .map(|s| s.to_string())
-                                        .unwrap_or_else(|| {
-                                            format!("{} {}", status.as_u16(), reason)
-                                        })
-                                } else {
-                                    format!("{} {}", status.as_u16(), reason)
-                                };
-                                tracing::warn!("SSE error: {message}");
-                                es.close();
-                                break;
-                            }
-                            Err(e) => {
-                                tracing::warn!("SSE error: {e}");
-                                es.close();
-                                break;
-                            }
+                        if let Some(parsed) = parse_sse_event(&event.event, &event.data)
+                            && tx.send(parsed).await.is_err()
+                        {
+                            // WHY: receiver dropped: shut down the SSE loop
+                            return;
                         }
                     }
 
                     let _ = tx.send(SseEvent::Disconnected).await;
-                    if !connected {
-                        backoff_secs = (backoff_secs * 2).min(30);
-                    }
                     tracing::info!("SSE reconnecting in {backoff_secs}s");
                     tokio::time::sleep(std::time::Duration::from_secs(backoff_secs)).await;
                 }

--- a/crates/theatron/tui/src/api/streaming.rs
+++ b/crates/theatron/tui/src/api/streaming.rs
@@ -1,6 +1,6 @@
 use futures_util::StreamExt;
 use reqwest::Client;
-use reqwest_eventsource::{Event as EsEvent, EventSource};
+use theatron_core::sse::SseStream;
 use tokio::sync::mpsc;
 use tracing::Instrument;
 
@@ -40,8 +40,8 @@ pub fn stream_message(
     let span = tracing::info_span!("stream_message");
     tokio::spawn(
         async move {
-            let mut es = match EventSource::new(builder) {
-                Ok(es) => es,
+            let resp = match builder.send().await {
+                Ok(resp) => resp,
                 Err(e) => {
                     let _ = tx
                         .send(StreamEvent::Error(format!("failed to connect: {e}")))
@@ -50,49 +50,37 @@ pub fn stream_message(
                 }
             };
 
+            if !resp.status().is_success() {
+                let status = resp.status();
+                let reason = status.canonical_reason().unwrap_or("Unknown");
+                let body = resp.text().await.unwrap_or_default();
+                let message = if let Ok(json) = serde_json::from_str::<serde_json::Value>(&body) {
+                    json.get("message")
+                        .or_else(|| json.get("error"))
+                        .and_then(|v| v.as_str())
+                        .map(|s| s.to_string())
+                        .unwrap_or_else(|| format!("{} {}", status.as_u16(), reason))
+                } else {
+                    format!("{} {}", status.as_u16(), reason)
+                };
+                let _ = tx.send(StreamEvent::Error(message)).await;
+                return;
+            }
+
+            let mut es = SseStream::new(resp.bytes_stream());
+
             while let Some(event) = es.next().await {
-                match event {
-                    // NOTE: SSE connection opened, no action needed
-                    Ok(EsEvent::Open) => {}
-                    Ok(EsEvent::Message(msg)) => {
-                        if let Some(parsed) = parse_stream_event(&msg.event, &msg.data) {
-                            let is_terminal = matches!(
-                                &parsed,
-                                StreamEvent::TurnComplete { .. }
-                                    | StreamEvent::TurnAbort { .. }
-                                    | StreamEvent::Error(_)
-                            );
-                            if tx.send(parsed).await.is_err() {
-                                break;
-                            }
-                            if is_terminal {
-                                es.close();
-                                break;
-                            }
-                        }
-                    }
-                    Err(reqwest_eventsource::Error::InvalidStatusCode(status, resp)) => {
-                        let reason = status.canonical_reason().unwrap_or("Unknown");
-                        let body = resp.text().await.unwrap_or_default();
-                        let message =
-                            if let Ok(json) = serde_json::from_str::<serde_json::Value>(&body) {
-                                json.get("message")
-                                    .or_else(|| json.get("error"))
-                                    .and_then(|v| v.as_str())
-                                    .map(|s| s.to_string())
-                                    .unwrap_or_else(|| format!("{} {}", status.as_u16(), reason))
-                            } else {
-                                format!("{} {}", status.as_u16(), reason)
-                            };
-                        let _ = tx.send(StreamEvent::Error(message)).await;
-                        es.close();
+                if let Some(parsed) = parse_stream_event(&event.event, &event.data) {
+                    let is_terminal = matches!(
+                        &parsed,
+                        StreamEvent::TurnComplete { .. }
+                            | StreamEvent::TurnAbort { .. }
+                            | StreamEvent::Error(_)
+                    );
+                    if tx.send(parsed).await.is_err() {
                         break;
                     }
-                    Err(e) => {
-                        let _ = tx
-                            .send(StreamEvent::Error(format!("stream error: {e}")))
-                            .await;
-                        es.close();
+                    if is_terminal {
                         break;
                     }
                 }

--- a/deny.toml
+++ b/deny.toml
@@ -88,6 +88,3 @@ skip = [
 [sources]
 unknown-registry = "deny"
 unknown-git = "deny"
-allow-git = [
-    "https://github.com/romnn/reqwest-eventsource",  # pending upstream merge of reqwest 0.13 support (PR #35)
-]


### PR DESCRIPTION
## Summary

- Replace the `reqwest-eventsource` git fork dependency with an owned ~120-line SSE parser in `theatron-core`
- The SSE parser implements `Stream` over any generic byte stream, handling the full SSE wire protocol (data, event, id, retry, comments, multi-line data, blank-line delimiters)
- Both `theatron-tui` and `theatron-desktop` now use `SseStream::new(resp.bytes_stream())` instead of `EventSource::new(builder)`
- HTTP status error handling moved from stream iteration to explicit check before stream creation (cleaner separation of concerns)
- Removed git source allowlist from `deny.toml`

## Test plan

- [x] 16 unit tests in `theatron-core::sse`: single event, multi-line data, comments, empty data, CRLF, event+data combo, id, retry, split chunks, flush on stream end, unknown fields
- [x] All existing `theatron-tui` and `theatron-core` tests pass (867 + 16)
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy -p theatron-core -p theatron-tui --all-targets -- -D warnings` clean
- [x] No `reqwest-eventsource` references remain in any Cargo.toml or Cargo.lock
- [ ] Manual smoke test: verify streaming LLM responses work in TUI

## Observations

- **Debt**: `aletheia-nous` has pre-existing clippy failures with `--all-targets` due to non-exhaustive pattern matches on `Priority` and `Role` types (`crates/nous/src/bootstrap/mod.rs:466`, `crates/nous/src/distillation.rs:266`, `crates/nous/src/history.rs:115`). These exist on `main` and are unrelated to this PR.

Closes #1428

🤖 Generated with [Claude Code](https://claude.com/claude-code)