### PR TITLE
refactor: tighten 79 pub items to pub(crate)

### DIFF
--- a/crates/aletheia/src/commands/add_nous.rs
+++ b/crates/aletheia/src/commands/add_nous.rs
@@ -8,7 +8,7 @@ use clap::Args;
 use aletheia_taxis::oikos::Oikos;
 
 #[derive(Debug, Clone, Args)]
-pub struct AddNousArgs {
+pub(crate) struct AddNousArgs {
     /// Agent identifier (alphanumeric and hyphens only).
     pub name: String,
 
@@ -21,7 +21,7 @@ pub struct AddNousArgs {
     pub model: String,
 }
 
-pub async fn run(instance_root: Option<&PathBuf>, args: &AddNousArgs) -> Result<()> {
+pub(crate) async fn run(instance_root: Option<&PathBuf>, args: &AddNousArgs) -> Result<()> {
     validate_name(&args.name)?;
     validate_provider(&args.provider)?;
 

--- a/crates/aletheia/src/commands/agent_io.rs
+++ b/crates/aletheia/src/commands/agent_io.rs
@@ -6,7 +6,7 @@ use anyhow::{Context, Result};
 use clap::Args;
 
 #[derive(Debug, Clone, Args)]
-pub struct ExportArgs {
+pub(crate) struct ExportArgs {
     /// Agent (nous) ID to export
     pub nous_id: String,
     /// Output file path (default: `{nous-id}-{date}.agent.json`)
@@ -31,7 +31,7 @@ pub struct ExportArgs {
     reason = "CLI flags — each bool is a distinct switch"
 )]
 #[derive(Debug, Clone, Args)]
-pub struct ImportArgs {
+pub(crate) struct ImportArgs {
     /// Path to .agent.json file
     pub file: PathBuf,
     /// Override the target agent ID
@@ -52,7 +52,7 @@ pub struct ImportArgs {
 }
 
 #[derive(Debug, Clone, Args)]
-pub struct SeedSkillsArgs {
+pub(crate) struct SeedSkillsArgs {
     /// Directory containing skill subdirectories (each with SKILL.md)
     #[arg(short, long)]
     pub dir: PathBuf,
@@ -68,7 +68,7 @@ pub struct SeedSkillsArgs {
 }
 
 #[derive(Debug, Clone, Args)]
-pub struct ExportSkillsArgs {
+pub(crate) struct ExportSkillsArgs {
     /// Agent (nous) ID whose skills to export
     #[arg(short, long)]
     pub nous_id: String,
@@ -81,7 +81,7 @@ pub struct ExportSkillsArgs {
 }
 
 #[derive(Debug, Clone, Args)]
-pub struct ReviewSkillsArgs {
+pub(crate) struct ReviewSkillsArgs {
     /// Agent (nous) ID whose pending skills to review
     #[arg(short, long)]
     pub nous_id: String,
@@ -94,7 +94,7 @@ pub struct ReviewSkillsArgs {
 }
 
 #[derive(Debug, Clone, Args)]
-pub struct MigrateMemoryArgs {
+pub(crate) struct MigrateMemoryArgs {
     /// Qdrant server URL
     #[arg(long, default_value = "http://localhost:6333", env = "QDRANT_URL")]
     pub qdrant_url: String,
@@ -113,7 +113,7 @@ pub struct MigrateMemoryArgs {
 }
 
 #[derive(Debug, Clone, Args)]
-pub struct TuiArgs {
+pub(crate) struct TuiArgs {
     /// Gateway URL
     #[arg(short, long, env = "ALETHEIA_URL")]
     pub url: Option<String>,
@@ -132,7 +132,7 @@ pub struct TuiArgs {
 }
 
 #[derive(Debug, Clone, Args)]
-pub struct InitArgs {
+pub(crate) struct InitArgs {
     /// Instance root directory (default in interactive/-y mode: ./instance)
     #[arg(
         short = 'r',
@@ -166,7 +166,7 @@ use aletheia_taxis::config::resolve_nous;
 use aletheia_taxis::loader::load_config;
 use aletheia_taxis::oikos::Oikos;
 
-pub fn export_agent(instance_root: Option<&PathBuf>, args: &ExportArgs) -> Result<()> {
+pub(crate) fn export_agent(instance_root: Option<&PathBuf>, args: &ExportArgs) -> Result<()> {
     let nous_id = &args.nous_id;
     let oikos = match instance_root {
         Some(root) => Oikos::from_root(root),
@@ -240,7 +240,7 @@ pub fn export_agent(instance_root: Option<&PathBuf>, args: &ExportArgs) -> Resul
     Ok(())
 }
 
-pub fn import_agent(instance_root: Option<&PathBuf>, args: &ImportArgs) -> Result<()> {
+pub(crate) fn import_agent(instance_root: Option<&PathBuf>, args: &ImportArgs) -> Result<()> {
     let json = std::fs::read_to_string(&args.file)
         .with_context(|| format!("failed to read {}", args.file.display()))?;
     let agent_file: aletheia_mneme::portability::AgentFile =
@@ -316,7 +316,7 @@ pub fn import_agent(instance_root: Option<&PathBuf>, args: &ImportArgs) -> Resul
     clippy::too_many_lines,
     reason = "CLI dispatch is inherently verbose — splitting would hurt readability"
 )]
-pub fn seed_skills(args: &SeedSkillsArgs) -> Result<()> {
+pub(crate) fn seed_skills(args: &SeedSkillsArgs) -> Result<()> {
     use aletheia_mneme::skill::{SkillContent, parse_skill_md, scan_skill_dir};
 
     let dir = &args.dir;
@@ -464,7 +464,10 @@ pub fn seed_skills(args: &SeedSkillsArgs) -> Result<()> {
 ///
 /// Reads skill facts from an in-process `KnowledgeStore`, converts them to
 /// `SkillContent`, and writes `.claude/skills/<slug>/SKILL.md` files.
-pub fn export_skills(instance_root: Option<&PathBuf>, args: &ExportSkillsArgs) -> Result<()> {
+pub(crate) fn export_skills(
+    instance_root: Option<&PathBuf>,
+    args: &ExportSkillsArgs,
+) -> Result<()> {
     #[cfg(feature = "recall")]
     {
         use aletheia_mneme::knowledge_store::KnowledgeStore;
@@ -546,7 +549,10 @@ pub fn export_skills(instance_root: Option<&PathBuf>, args: &ExportSkillsArgs) -
     }
 }
 
-pub fn review_skills(instance_root: Option<&PathBuf>, args: &ReviewSkillsArgs) -> Result<()> {
+pub(crate) fn review_skills(
+    instance_root: Option<&PathBuf>,
+    args: &ReviewSkillsArgs,
+) -> Result<()> {
     #[cfg(feature = "recall")]
     {
         use aletheia_mneme::knowledge_store::KnowledgeStore;
@@ -649,7 +655,7 @@ pub fn review_skills(instance_root: Option<&PathBuf>, args: &ReviewSkillsArgs) -
     clippy::unused_async,
     reason = "async required when migrate-qdrant feature is enabled"
 )]
-pub async fn migrate_memory(
+pub(crate) async fn migrate_memory(
     instance_root: Option<&PathBuf>,
     args: MigrateMemoryArgs,
 ) -> Result<()> {

--- a/crates/aletheia/src/commands/backup.rs
+++ b/crates/aletheia/src/commands/backup.rs
@@ -13,7 +13,7 @@ use aletheia_taxis::oikos::Oikos;
     reason = "CLI flags — each bool is a distinct switch"
 )]
 #[derive(Debug, Clone, Args)]
-pub struct BackupArgs {
+pub(crate) struct BackupArgs {
     /// List available backups
     #[arg(long)]
     pub list: bool,
@@ -34,7 +34,7 @@ pub struct BackupArgs {
     pub yes: bool,
 }
 
-pub fn run(instance_root: Option<&PathBuf>, args: &BackupArgs) -> Result<()> {
+pub(crate) fn run(instance_root: Option<&PathBuf>, args: &BackupArgs) -> Result<()> {
     let &BackupArgs {
         list,
         prune,

--- a/crates/aletheia/src/commands/check_config.rs
+++ b/crates/aletheia/src/commands/check_config.rs
@@ -11,7 +11,7 @@ use aletheia_taxis::validate::validate_section;
 /// Run `aletheia check-config`: load config, validate all sections, report and exit.
 ///
 /// Exits 0 on success, 1 if any check fails.
-pub fn run(instance_root: Option<&PathBuf>) -> Result<()> {
+pub(crate) fn run(instance_root: Option<&PathBuf>) -> Result<()> {
     let oikos = match instance_root {
         Some(root) => Oikos::from_root(root),
         None => Oikos::discover(),

--- a/crates/aletheia/src/commands/config.rs
+++ b/crates/aletheia/src/commands/config.rs
@@ -9,14 +9,14 @@ use aletheia_taxis::encrypt;
 use aletheia_taxis::oikos::Oikos;
 
 #[derive(Debug, Clone, Subcommand)]
-pub enum Action {
+pub(crate) enum Action {
     /// Generate a new master encryption key
     InitKey,
     /// Encrypt sensitive plaintext values in aletheia.toml
     Encrypt,
 }
 
-pub fn run(action: &Action, instance_root: Option<&PathBuf>) -> Result<()> {
+pub(crate) fn run(action: &Action, instance_root: Option<&PathBuf>) -> Result<()> {
     match action {
         Action::InitKey => run_init_key(),
         Action::Encrypt => run_encrypt(instance_root),

--- a/crates/aletheia/src/commands/credential.rs
+++ b/crates/aletheia/src/commands/credential.rs
@@ -9,7 +9,7 @@ use aletheia_symbolon::credential::CredentialFile;
 use aletheia_taxis::oikos::Oikos;
 
 #[derive(Debug, Clone, Subcommand)]
-pub enum Action {
+pub(crate) enum Action {
     /// Show current credential source, expiry, and token prefix
     Status,
     /// Force-refresh OAuth token now
@@ -28,7 +28,7 @@ fn token_preview(s: &str) -> String {
     }
 }
 
-pub async fn run(action: Action, instance_root: Option<&PathBuf>) -> Result<()> {
+pub(crate) async fn run(action: Action, instance_root: Option<&PathBuf>) -> Result<()> {
     let oikos = match instance_root {
         Some(root) => Oikos::from_root(root),
         None => Oikos::discover(),

--- a/crates/aletheia/src/commands/eval.rs
+++ b/crates/aletheia/src/commands/eval.rs
@@ -4,7 +4,7 @@ use anyhow::Result;
 use clap::Args;
 
 #[derive(Debug, Clone, Args)]
-pub struct EvalArgs {
+pub(crate) struct EvalArgs {
     /// Server URL to evaluate
     #[arg(long, default_value = "http://127.0.0.1:18789")]
     pub url: String,
@@ -22,7 +22,7 @@ pub struct EvalArgs {
     pub timeout: u64,
 }
 
-pub async fn run(args: EvalArgs) -> Result<()> {
+pub(crate) async fn run(args: EvalArgs) -> Result<()> {
     let EvalArgs {
         url,
         token,

--- a/crates/aletheia/src/commands/health.rs
+++ b/crates/aletheia/src/commands/health.rs
@@ -6,13 +6,13 @@ use clap::Args;
 use aletheia_koina::http::API_HEALTH;
 
 #[derive(Debug, Clone, Args)]
-pub struct HealthArgs {
+pub(crate) struct HealthArgs {
     /// Server URL to check
     #[arg(long, default_value = "http://127.0.0.1:18789")]
     pub url: String,
 }
 
-pub async fn run(args: &HealthArgs) -> Result<()> {
+pub(crate) async fn run(args: &HealthArgs) -> Result<()> {
     let url = &args.url;
     let endpoint = format!("{url}{API_HEALTH}");
     let resp = reqwest::get(&endpoint).await.map_err(|e| {

--- a/crates/aletheia/src/commands/maintenance.rs
+++ b/crates/aletheia/src/commands/maintenance.rs
@@ -15,7 +15,7 @@ use aletheia_taxis::oikos::Oikos;
 use tokio_util::sync::CancellationToken;
 
 #[derive(Debug, Clone, Subcommand)]
-pub enum Action {
+pub(crate) enum Action {
     /// Show status of all maintenance tasks
     Status {
         /// Output as JSON instead of human-readable table
@@ -32,7 +32,7 @@ pub enum Action {
     },
 }
 
-pub fn run(action: Action, instance_root: Option<&PathBuf>) -> Result<()> {
+pub(crate) fn run(action: Action, instance_root: Option<&PathBuf>) -> Result<()> {
     let oikos = match instance_root {
         Some(root) => Oikos::from_root(root),
         None => Oikos::discover(),
@@ -124,7 +124,7 @@ pub fn run(action: Action, instance_root: Option<&PathBuf>) -> Result<()> {
 /// Build a `MaintenanceConfig` from the oikos layout and config settings.
 ///
 /// Called from both the maintenance subcommand and the server startup path.
-pub fn build_config(
+pub(crate) fn build_config(
     oikos: &Oikos,
     settings: &aletheia_taxis::config::MaintenanceSettings,
 ) -> MaintenanceConfig {

--- a/crates/aletheia/src/commands/mod.rs
+++ b/crates/aletheia/src/commands/mod.rs
@@ -1,14 +1,14 @@
 //! CLI subcommand handlers: one module per subcommand.
 
-pub mod add_nous;
-pub mod agent_io;
-pub mod backup;
-pub mod check_config;
-pub mod config;
-pub mod credential;
-pub mod eval;
-pub mod health;
-pub mod maintenance;
-pub mod server;
-pub mod session_export;
-pub mod tls;
+pub(crate) mod add_nous;
+pub(crate) mod agent_io;
+pub(crate) mod backup;
+pub(crate) mod check_config;
+pub(crate) mod config;
+pub(crate) mod credential;
+pub(crate) mod eval;
+pub(crate) mod health;
+pub(crate) mod maintenance;
+pub(crate) mod server;
+pub(crate) mod session_export;
+pub(crate) mod tls;

--- a/crates/aletheia/src/commands/server.rs
+++ b/crates/aletheia/src/commands/server.rs
@@ -52,7 +52,7 @@ use crate::dispatch;
 use crate::planning_adapter;
 
 /// Arguments forwarded from the top-level CLI to the server startup.
-pub struct Args {
+pub(crate) struct Args {
     pub instance_root: Option<PathBuf>,
     pub bind: Option<String>,
     pub port: Option<u16>,
@@ -64,7 +64,7 @@ pub struct Args {
     clippy::too_many_lines,
     reason = "binary entrypoint — sequential init steps"
 )]
-pub async fn run(args: Args) -> Result<()> {
+pub(crate) async fn run(args: Args) -> Result<()> {
     // Oikos is pure path resolution: no IO, safe before tracing is set up.
     let oikos = match &args.instance_root {
         Some(root) => Oikos::from_root(root),
@@ -1015,7 +1015,7 @@ mod tool_adapters {
     use aletheia_nous::cross::{CrossNousMessage, CrossNousRouter};
     use aletheia_organon::types::{CrossNousService, MessageService};
 
-    pub struct CrossNousAdapter(pub Arc<CrossNousRouter>);
+    pub(crate) struct CrossNousAdapter(pub Arc<CrossNousRouter>);
 
     impl CrossNousService for CrossNousAdapter {
         fn send(
@@ -1058,7 +1058,7 @@ mod tool_adapters {
         }
     }
 
-    pub struct SignalAdapter(pub Arc<dyn ChannelProvider>);
+    pub(crate) struct SignalAdapter(pub Arc<dyn ChannelProvider>);
 
     impl MessageService for SignalAdapter {
         fn send_message(

--- a/crates/aletheia/src/commands/session_export.rs
+++ b/crates/aletheia/src/commands/session_export.rs
@@ -11,7 +11,7 @@ use serde::Deserialize;
 use aletheia_koina::http::{API_V1, BEARER_PREFIX};
 
 #[derive(Debug, Clone, Args)]
-pub struct SessionExportArgs {
+pub(crate) struct SessionExportArgs {
     /// Session ID to export
     pub session_id: String,
 
@@ -33,7 +33,7 @@ pub struct SessionExportArgs {
 }
 
 #[derive(Debug, Clone, clap::ValueEnum)]
-pub enum ExportFormat {
+pub(crate) enum ExportFormat {
     Md,
     Json,
 }
@@ -58,7 +58,7 @@ struct HistoryMessage {
     created_at: String,
 }
 
-pub async fn run(args: &SessionExportArgs) -> Result<()> {
+pub(crate) async fn run(args: &SessionExportArgs) -> Result<()> {
     let client = build_client(args.token.as_deref())?;
 
     let session = fetch_session(&client, &args.url, &args.session_id).await?;

--- a/crates/aletheia/src/commands/tls.rs
+++ b/crates/aletheia/src/commands/tls.rs
@@ -6,7 +6,7 @@ use anyhow::{Context, Result};
 use clap::Subcommand;
 
 #[derive(Debug, Clone, Subcommand)]
-pub enum Action {
+pub(crate) enum Action {
     /// Generate self-signed certificates for development/LAN use
     Generate {
         /// Output directory for cert and key files
@@ -24,7 +24,7 @@ pub enum Action {
     },
 }
 
-pub fn run(action: &Action) -> Result<()> {
+pub(crate) fn run(action: &Action) -> Result<()> {
     match action {
         Action::Generate {
             output_dir,

--- a/crates/aletheia/src/dispatch.rs
+++ b/crates/aletheia/src/dispatch.rs
@@ -14,7 +14,7 @@ use aletheia_nous::manager::NousManager;
 /// Spawn a background task that dispatches inbound messages to nous actors.
 ///
 /// Runs until the receiver channel closes (all senders dropped).
-pub fn spawn_dispatcher(
+pub(crate) fn spawn_dispatcher(
     mut rx: mpsc::Receiver<InboundMessage>,
     router: Arc<MessageRouter>,
     nous_manager: Arc<NousManager>,

--- a/crates/aletheia/src/knowledge_adapter.rs
+++ b/crates/aletheia/src/knowledge_adapter.rs
@@ -26,13 +26,13 @@ impl<T, E: std::error::Error + Send + Sync + 'static> BoxErr<T> for Result<T, E>
     }
 }
 
-pub struct KnowledgeSearchAdapter {
+pub(crate) struct KnowledgeSearchAdapter {
     store: Arc<KnowledgeStore>,
     embedder: Arc<dyn EmbeddingProvider>,
 }
 
 impl KnowledgeSearchAdapter {
-    pub fn new(store: Arc<KnowledgeStore>, embedder: Arc<dyn EmbeddingProvider>) -> Self {
+    pub(crate) fn new(store: Arc<KnowledgeStore>, embedder: Arc<dyn EmbeddingProvider>) -> Self {
         Self { store, embedder }
     }
 }

--- a/crates/aletheia/src/migrate_memory.rs
+++ b/crates/aletheia/src/migrate_memory.rs
@@ -38,7 +38,7 @@ fn extract_double(v: &qdrant_client::qdrant::Value) -> Option<f64> {
     }
 }
 
-pub async fn run(
+pub(crate) async fn run(
     instance_root: Option<&PathBuf>,
     qdrant_url: &str,
     collection: &str,

--- a/crates/aletheia/src/planning_adapter.rs
+++ b/crates/aletheia/src/planning_adapter.rs
@@ -29,12 +29,12 @@ impl<T, E: std::error::Error + Send + Sync + 'static> BoxErr<T> for Result<T, E>
     }
 }
 
-pub struct FilesystemPlanningService {
+pub(crate) struct FilesystemPlanningService {
     projects_root: PathBuf,
 }
 
 impl FilesystemPlanningService {
-    pub fn new(projects_root: PathBuf) -> Self {
+    pub(crate) fn new(projects_root: PathBuf) -> Self {
         Self { projects_root }
     }
 }

--- a/crates/aletheia/src/server.rs
+++ b/crates/aletheia/src/server.rs
@@ -756,7 +756,7 @@ pub(crate) mod tool_adapters {
     use aletheia_nous::cross::{CrossNousMessage, CrossNousRouter};
     use aletheia_organon::types::{CrossNousService, MessageService};
 
-    pub struct CrossNousAdapter(pub Arc<CrossNousRouter>);
+    pub(crate) struct CrossNousAdapter(pub Arc<CrossNousRouter>);
 
     impl CrossNousService for CrossNousAdapter {
         fn send(
@@ -799,7 +799,7 @@ pub(crate) mod tool_adapters {
         }
     }
 
-    pub struct SignalAdapter(pub Arc<dyn ChannelProvider>);
+    pub(crate) struct SignalAdapter(pub Arc<dyn ChannelProvider>);
 
     impl MessageService for SignalAdapter {
         fn send_message(

--- a/crates/aletheia/src/status.rs
+++ b/crates/aletheia/src/status.rs
@@ -26,7 +26,10 @@ pub(crate) enum StatusError {
 }
 
 /// Run the status command against a running (or stopped) instance.
-pub async fn run(url: &str, instance_root: Option<&std::path::PathBuf>) -> Result<(), StatusError> {
+pub(crate) async fn run(
+    url: &str,
+    instance_root: Option<&std::path::PathBuf>,
+) -> Result<(), StatusError> {
     let use_color = supports_color::on(supports_color::Stream::Stdout).is_some();
     let version = env!("CARGO_PKG_VERSION");
 
@@ -257,7 +260,7 @@ fn print_file_size(label: &str, path: &Path) {
 }
 
 /// Format seconds as human-readable duration.
-pub fn format_uptime(seconds: u64) -> String {
+pub(crate) fn format_uptime(seconds: u64) -> String {
     if seconds < 60 {
         return format!("{seconds}s");
     }
@@ -276,7 +279,7 @@ pub fn format_uptime(seconds: u64) -> String {
 }
 
 /// Format bytes as human-readable size.
-pub fn format_bytes(bytes: u64) -> String {
+pub(crate) fn format_bytes(bytes: u64) -> String {
     if bytes == 0 {
         return "0 B".to_owned();
     }

--- a/crates/daemon/src/maintenance/mod.rs
+++ b/crates/daemon/src/maintenance/mod.rs
@@ -1,15 +1,15 @@
 //! Instance maintenance services: trace rotation, drift detection, DB monitoring, retention.
 
 /// Database size monitoring with configurable warning and alert thresholds.
-pub mod db_monitor;
+pub(crate) mod db_monitor;
 /// Instance drift detection: compare a live instance against the example template.
-pub mod drift_detection;
+pub(crate) mod drift_detection;
 /// Knowledge graph maintenance bridge trait and report types.
-pub mod knowledge;
+pub(crate) mod knowledge;
 /// Data retention policy execution trait and summary types.
-pub mod retention;
+pub(crate) mod retention;
 /// Trace file rotation, gzip compression, and archive pruning.
-pub mod trace_rotation;
+pub(crate) mod trace_rotation;
 
 pub use db_monitor::{DbInfo, DbMonitor, DbMonitoringConfig, DbSizeReport, DbStatus};
 pub use drift_detection::{DriftDetectionConfig, DriftDetector, DriftReport};

--- a/crates/daemon/src/runner.rs
+++ b/crates/daemon/src/runner.rs
@@ -287,7 +287,7 @@ impl TaskRunner {
     /// Called once at startup. For each task with `catch_up: true` and a cron
     /// schedule, checks if a window was missed within the last 24 hours.
     /// If so, schedules the task for immediate execution.
-    pub fn check_missed_cron_catchup(&mut self) {
+    pub(crate) fn check_missed_cron_catchup(&mut self) {
         for task in &mut self.tasks {
             if !task.def.enabled || !task.def.catch_up {
                 continue;

--- a/crates/daemon/src/schedule.rs
+++ b/crates/daemon/src/schedule.rs
@@ -113,7 +113,7 @@ impl Schedule {
         clippy::expect_used,
         reason = "timestamp conversions are within valid ranges; interval durations fit in i64 nanos for any reasonable schedule"
     )]
-    pub fn next_run(&self) -> Result<Option<jiff::Timestamp>> {
+    pub(crate) fn next_run(&self) -> Result<Option<jiff::Timestamp>> {
         match self {
             Self::Cron(expr) => {
                 let schedule = cron::Schedule::from_str(expr).context(error::InvalidCronSnafu {
@@ -154,7 +154,7 @@ impl Schedule {
         clippy::expect_used,
         reason = "timestamp conversions within valid ranges; 24h subtraction from current time cannot overflow"
     )]
-    pub fn missed_since(&self, last_run: jiff::Timestamp) -> Result<bool> {
+    pub(crate) fn missed_since(&self, last_run: jiff::Timestamp) -> Result<bool> {
         let Self::Cron(expr) = self else {
             return Ok(false);
         };
@@ -193,7 +193,7 @@ impl Schedule {
         clippy::expect_used,
         reason = "hour() returns 0-23 which always fits in u8"
     )]
-    pub fn in_window(window: Option<(u8, u8)>) -> bool {
+    pub(crate) fn in_window(window: Option<(u8, u8)>) -> bool {
         let Some((start, end)) = window else {
             return true;
         };
@@ -215,7 +215,7 @@ impl Schedule {
 /// - 1st failure: 1 minute
 /// - 2nd failure: 5 minutes
 /// - 3rd+ failure: 15 minutes (but task will be auto-disabled at 3)
-pub fn backoff_delay(consecutive_failures: u32) -> Duration {
+pub(crate) fn backoff_delay(consecutive_failures: u32) -> Duration {
     match consecutive_failures {
         0 => Duration::ZERO,
         1 => Duration::from_secs(60),

--- a/crates/eval/src/report.rs
+++ b/crates/eval/src/report.rs
@@ -141,7 +141,7 @@ pub fn print_report_json(report: &RunReport) {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "lowercase")]
 #[non_exhaustive]
-pub enum OutcomeKind {
+pub(crate) enum OutcomeKind {
     Passed,
     Failed,
     Skipped,

--- a/crates/eval/src/scenarios/auth.rs
+++ b/crates/eval/src/scenarios/auth.rs
@@ -6,7 +6,7 @@ use crate::client::EvalClient;
 use crate::scenario::{Scenario, ScenarioFuture, ScenarioMeta, assert_eq_eval};
 
 #[tracing::instrument(skip_all)]
-pub fn scenarios() -> Vec<Box<dyn Scenario>> {
+pub(crate) fn scenarios() -> Vec<Box<dyn Scenario>> {
     vec![Box::new(AuthRejectsNoToken), Box::new(AuthRejectsBadToken)]
 }
 

--- a/crates/eval/src/scenarios/conversation.rs
+++ b/crates/eval/src/scenarios/conversation.rs
@@ -8,7 +8,7 @@ use crate::scenario::{Scenario, ScenarioFuture, ScenarioMeta, assert_eval, valid
 use crate::sse;
 
 #[tracing::instrument(skip_all)]
-pub fn scenarios() -> Vec<Box<dyn Scenario>> {
+pub(crate) fn scenarios() -> Vec<Box<dyn Scenario>> {
     vec![
         Box::new(ConversationSendSse),
         Box::new(ConversationHistoryReflects),

--- a/crates/eval/src/scenarios/health.rs
+++ b/crates/eval/src/scenarios/health.rs
@@ -6,7 +6,7 @@ use crate::client::{EvalClient, InstanceStatus};
 use crate::scenario::{Scenario, ScenarioFuture, ScenarioMeta, assert_eval};
 
 #[tracing::instrument(skip_all)]
-pub fn scenarios() -> Vec<Box<dyn Scenario>> {
+pub(crate) fn scenarios() -> Vec<Box<dyn Scenario>> {
     vec![
         Box::new(HealthReturnsOk),
         Box::new(HealthContainsVersion),

--- a/crates/eval/src/scenarios/mod.rs
+++ b/crates/eval/src/scenarios/mod.rs
@@ -10,7 +10,7 @@ use crate::scenario::Scenario;
 
 /// Return all built-in scenarios in execution order.
 #[tracing::instrument(skip_all)]
-pub fn all_scenarios() -> Vec<Box<dyn Scenario>> {
+pub(crate) fn all_scenarios() -> Vec<Box<dyn Scenario>> {
     let mut scenarios: Vec<Box<dyn Scenario>> = Vec::new();
     scenarios.extend(health::scenarios());
     scenarios.extend(auth::scenarios());

--- a/crates/eval/src/scenarios/nous.rs
+++ b/crates/eval/src/scenarios/nous.rs
@@ -6,7 +6,7 @@ use crate::client::EvalClient;
 use crate::scenario::{Scenario, ScenarioFuture, ScenarioMeta, assert_eq_eval, assert_eval};
 
 #[tracing::instrument(skip_all)]
-pub fn scenarios() -> Vec<Box<dyn Scenario>> {
+pub(crate) fn scenarios() -> Vec<Box<dyn Scenario>> {
     vec![
         Box::new(NousListReturnsArray),
         Box::new(NousUnknownReturns404),

--- a/crates/eval/src/scenarios/session.rs
+++ b/crates/eval/src/scenarios/session.rs
@@ -7,7 +7,7 @@ use crate::client::{EvalClient, SessionStatus};
 use crate::scenario::{Scenario, ScenarioFuture, ScenarioMeta, assert_eq_eval, assert_eval};
 
 #[tracing::instrument(skip_all)]
-pub fn scenarios() -> Vec<Box<dyn Scenario>> {
+pub(crate) fn scenarios() -> Vec<Box<dyn Scenario>> {
     vec![
         Box::new(SessionCreateAndGet),
         Box::new(SessionCloseArchives),

--- a/crates/nous/src/cross.rs
+++ b/crates/nous/src/cross.rs
@@ -962,7 +962,10 @@ mod tests {
 
         let err = router.ask(msg).await.unwrap_err();
         let err_msg = err.to_string();
-        assert!(err_msg.contains("timed out"), "expected timeout, got: {err_msg}");
+        assert!(
+            err_msg.contains("timed out"),
+            "expected timeout, got: {err_msg}"
+        );
 
         // Graph must be clean after timeout.
         assert_eq!(router_check.ask_graph.read().await.edge_count(), 0);


### PR DESCRIPTION
## Summary

- Changed 79 `pub` items to `pub(crate)` across 3 crates (aletheia, oikonomos, dokimion)
- **aletheia binary** (62 items): all internal by definition since nothing depends on the binary crate
- **oikonomos/daemon** (11 items): internal scheduler types, maintenance module items
- **dokimion/eval** (6 items): scenario definitions and report helper

## Approach

Compiler-driven: bulk-replaced `pub` to `pub(crate)` in non-lib.rs files, compiled, and reverted items that caused cross-crate errors. Skipped files where the change would expose dead_code warnings (dead code was already present but hidden by `pub` visibility).

## Observations

- **Debt**: ~900+ `pub` items remain that could be tightened. The daemon crate (`prosoche.rs`, `bridge.rs`, `state.rs`) and eval crate (`client.rs`, `scenario.rs`, `sse.rs`) have significant dead code hidden behind `pub` visibility.
- **Debt**: `crates/koina/src/id.rs` has types (`NousId`, `SessionId`, `ToolName`) that are used by nearly every crate -- these are correctly `pub`, but the module could benefit from a re-export audit.
- **Debt**: `crates/koina/src/disk_space.rs` and `crates/koina/src/credential.rs` contain items that appear unused within koina itself but are used cross-crate -- consider moving to consuming crates.

Closes #1395

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes (867 tests)
- [x] No cross-crate compilation errors
- [x] 79 items changed (exceeds 50 target)

🤖 Generated with [Claude Code](https://claude.com/claude-code)