### PR TITLE
fix(lint): annotate remaining RUST/expect linter hits

### DIFF
--- a/crates/aletheia/src/server.rs
+++ b/crates/aletheia/src/server.rs
@@ -622,6 +622,10 @@ fn build_tool_registry() -> Result<ToolRegistry> {
     Ok(registry)
 }
 
+#[expect(
+    clippy::expect_used,
+    reason = "channel registration is infallible for unique providers"
+)]
 /// Build channel registry, start inbound listener, and spawn dispatch loop.
 fn start_inbound_dispatch(
     config: &aletheia_taxis::config::AletheiaConfig,
@@ -720,6 +724,10 @@ pub(crate) fn init_tracing(log_level: &str, json: bool) {
     }
 }
 
+#[expect(
+    clippy::expect_used,
+    reason = "signal handler installation is infallible on supported platforms"
+)]
 pub(crate) async fn shutdown_signal() {
     let ctrl_c = async {
         tokio::signal::ctrl_c()

--- a/crates/mneme/src/hnsw_index.rs
+++ b/crates/mneme/src/hnsw_index.rs
@@ -160,6 +160,10 @@ impl HnswIndex {
     ///
     /// The `data_id` is caller-assigned and returned in search results.
     #[instrument(skip(self, vector), fields(data_id))]
+    #[expect(
+        clippy::expect_used,
+        reason = "RwLock poisoning is unrecoverable; propagating would just defer the panic"
+    )]
     pub fn insert(&self, vector: &[f32], data_id: usize) {
         let guard = self.inner.read().expect("hnsw lock poisoned");
         if let Some(ref hnsw) = *guard {
@@ -169,6 +173,10 @@ impl HnswIndex {
 
     /// Insert multiple vectors in parallel.
     #[instrument(skip(self, vectors))]
+    #[expect(
+        clippy::expect_used,
+        reason = "RwLock poisoning is unrecoverable; propagating would just defer the panic"
+    )]
     pub fn insert_batch(&self, vectors: &[(&Vec<f32>, usize)]) {
         let guard = self.inner.read().expect("hnsw lock poisoned");
         if let Some(ref hnsw) = *guard {
@@ -182,6 +190,10 @@ impl HnswIndex {
     ///
     /// `ef` controls search width (must be >= `k`). Higher = better recall, slower.
     #[instrument(skip(self, query), fields(k, ef))]
+    #[expect(
+        clippy::expect_used,
+        reason = "RwLock poisoning is unrecoverable; propagating would just defer the panic"
+    )]
     pub fn search(&self, query: &[f32], k: usize, ef: usize) -> Vec<SearchResult> {
         let guard = self.inner.read().expect("hnsw lock poisoned");
         match *guard {
@@ -215,6 +227,10 @@ impl HnswIndex {
             .build()
         })?;
 
+        #[expect(
+            clippy::expect_used,
+            reason = "RwLock poisoning is unrecoverable; propagating would just defer the panic"
+        )]
         let guard = self.inner.read().expect("hnsw lock poisoned");
         if let Some(ref hnsw) = *guard {
             use hnsw_rs::api::AnnT;
@@ -230,6 +246,10 @@ impl HnswIndex {
     }
 
     /// Returns the number of points currently in the index.
+    #[expect(
+        clippy::expect_used,
+        reason = "RwLock poisoning is unrecoverable; propagating would just defer the panic"
+    )]
     pub fn len(&self) -> usize {
         let guard = self.inner.read().expect("hnsw lock poisoned");
         match *guard {

--- a/crates/nous/src/cross.rs
+++ b/crates/nous/src/cross.rs
@@ -962,7 +962,10 @@ mod tests {
 
         let err = router.ask(msg).await.unwrap_err();
         let err_msg = err.to_string();
-        assert!(err_msg.contains("timed out"), "expected timeout, got: {err_msg}");
+        assert!(
+            err_msg.contains("timed out"),
+            "expected timeout, got: {err_msg}"
+        );
 
         // Graph must be clean after timeout.
         assert_eq!(router_check.ask_graph.read().await.edge_count(), 0);


### PR DESCRIPTION
## Summary

- Audited all 464 reported `RUST/expect` linter hits from standards-check
- Found that the vast majority (459/464) were already suppressed via existing `#[expect(clippy::expect_used)]` annotations, test module exclusions, or linter heuristics (`LazyLock`, `// WHY:` comments, `main.rs` exclusion)
- Added `#[expect(clippy::expect_used, reason = "...")]` annotations to the 5 remaining hits in `mneme/hnsw_index.rs` (RwLock poisoning panics)
- Added missing annotations to 2 functions in `aletheia/server.rs` (`shutdown_signal` and `start_inbound_dispatch`)
- All 7 annotated calls are legitimate: RwLock poisoning is unrecoverable, signal handler installation is infallible on supported platforms, and channel registration for a unique provider cannot fail

## Audit findings

| Category | Count | Status |
|----------|-------|--------|
| Already annotated with `#[expect]` | ~200+ | No action needed |
| In `#[cfg(test)]` modules | ~492 | Excluded by linter |
| In `main.rs` / binary entrypoints | ~10 | Excluded by linter |
| In `LazyLock` / `static` initializers | ~20 | Excluded by linter |
| With `// WHY:` comments | ~5 | Excluded by linter |
| **Newly annotated (this PR)** | **7** | **Fixed** |

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [x] `standards-check --rust --summary` reports 0 `RUST/expect` violations

## Observations

- The `nous/src/cross.rs` change is a pre-existing `rustfmt` formatting fix (long `assert!` line) picked up by `cargo fmt --all`
- The codebase has ~3,476 total `.expect()` calls; ~492 are in test code, ~200+ in production code already have proper annotations
- Clippy's workspace-level `expect_used = "deny"` lint is fully satisfied — zero clippy violations

Closes #1396

🤖 Generated with [Claude Code](https://claude.com/claude-code)