### PR TITLE
fix(symbolon): fix SecretString type mismatch in auth and JWT tests

### DIFF
--- a/crates/symbolon/src/auth.rs
+++ b/crates/symbolon/src/auth.rs
@@ -219,7 +219,7 @@ mod tests {
     fn test_service() -> AuthService {
         AuthService::in_memory(AuthConfig {
             jwt: JwtConfig {
-                signing_key: SecretString::from("test-jwt-secret".to_owned()),
+                signing_key: secrecy::SecretString::from("test-jwt-secret"),
                 access_ttl: Duration::from_secs(3600),
                 refresh_ttl: Duration::from_secs(86400),
                 issuer: "aletheia-test".to_owned(),

--- a/crates/symbolon/src/jwt.rs
+++ b/crates/symbolon/src/jwt.rs
@@ -374,11 +374,11 @@ mod tests {
         let refresh = mgr.issue_refresh("user-1", Role::Operator).unwrap();
         let pair = mgr.refresh(&refresh).unwrap();
 
-        let access_claims = mgr.validate(&pair.access_token).unwrap();
+        let access_claims = mgr.validate(pair.access_token.expose_secret()).unwrap();
         assert_eq!(access_claims.sub, "user-1");
         assert_eq!(access_claims.kind, TokenKind::Access);
 
-        let refresh_claims = mgr.validate(&pair.refresh_token).unwrap();
+        let refresh_claims = mgr.validate(pair.refresh_token.expose_secret()).unwrap();
         assert_eq!(refresh_claims.kind, TokenKind::Refresh);
     }
 


### PR DESCRIPTION
## Summary

- Fix `JwtConfig.signing_key` in auth tests to use `secrecy::SecretString` instead of `aletheia_koina::secret::SecretString` (type mismatch after jwt.rs migrated to the `secrecy` crate)
- Fix jwt tests to call `.expose_secret()` on `TokenPair` fields before passing to `validate(&str)`

The three-state circuit breaker (closed/open/half-open) with exponential backoff was already implemented in #1546. These test fixes ensure the symbolon crate compiles and all 125 tests pass.

Closes #1445.

## Test plan

- [x] `cargo fmt --all` passes
- [x] `cargo clippy -p aletheia-symbolon --all-targets -- -D warnings` passes
- [x] `cargo test -p aletheia-symbolon` passes (125 tests)
- [x] `cargo clippy -p aletheia-taxis --all-targets -- -D warnings` passes
- [x] `cargo test -p aletheia-taxis` passes

## Observations

- **Debt**: `aletheia-mneme` has 114 pre-existing clippy errors (`expect_used` in test code, unfulfilled lint expectations). Not in scope.
- **Debt**: Two `SecretString` types coexist (`aletheia_koina::secret::SecretString` and `secrecy::SecretString`). The migration from one to the other appears incomplete across test code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)