### PR TITLE
fix(mneme): remove remaining unwrap() calls in doc examples

### DIFF
--- a/crates/mneme/src/engine/fts/tokenizer/tokenizer_impl.rs
+++ b/crates/mneme/src/engine/fts/tokenizer/tokenizer_impl.rs
@@ -238,14 +238,14 @@ impl<T: TokenFilter> From<T> for BoxTokenFilter {
 ///        .filter(LowerCaser);
 /// let mut token_stream = tokenizer.token_stream("Hello, happy tax payer");
 /// {
-///     let token = token_stream.next().unwrap();
+///     let token = token_stream.next()?;
 ///     assert_eq!(&token.text, "hello");
 ///     assert_eq!(token.offset_from, 0);
 ///     assert_eq!(token.offset_to, 5);
 ///     assert_eq!(token.position, 0);
 /// }
 /// {
-///     let token = token_stream.next().unwrap();
+///     let token = token_stream.next()?;
 ///     assert_eq!(&token.text, "happy");
 ///     assert_eq!(token.offset_from, 7);
 ///     assert_eq!(token.offset_to, 12);

--- a/crates/mneme/src/engine/runtime/tests.rs
+++ b/crates/mneme/src/engine/runtime/tests.rs
@@ -1,5 +1,4 @@
 //! Integration tests for the engine runtime.
-#![expect(clippy::unwrap_used, reason = "test assertions")]
 #![expect(clippy::expect_used, reason = "test assertions")]
 use std::collections::BTreeMap;
 use std::time::Duration;


### PR DESCRIPTION
## Summary
- Replace 2 `.unwrap()` calls in `tokenizer_impl.rs` doc examples with `?` operator
- Remove unfulfilled `#![expect(clippy::unwrap_used)]` from `runtime/tests.rs` (no unwrap() calls remain)

The original 11 unwrap() calls flagged by standards-check were in doc comment examples across two FTS tokenizer files. 9 were fixed in PR #1538; these are the remaining 2 plus a lint cleanup.

Closes #1388

## Observations
- 189 pre-existing clippy errors on main (mostly `expect_used` in test code and dead code in `theatron-tui`), unrelated to this change
- PR #1538 fixed the same issue but did not link to #1388

## Test plan
- [x] `cargo fmt --all` passes
- [x] `cargo test -p aletheia-mneme` passes
- [x] `standards-check --rust` reports no `RUST/unwrap` violations
- [x] Change reduces clippy error count by 1 (unfulfilled lint expectation removed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)