### PR TITLE
725: Add descriptive messages to bare assert calls (pass 2)

### DIFF
--- a/crates/aletheia/src/commands/add_nous.rs
+++ b/crates/aletheia/src/commands/add_nous.rs
@@ -309,46 +309,91 @@ mod tests {
 
     #[test]
     fn validate_name_accepts_alphanumeric() {
-        assert!(validate_name("chiron").is_ok());
-        assert!(validate_name("my-agent").is_ok());
-        assert!(validate_name("agent42").is_ok());
+        assert!(
+            validate_name("chiron").is_ok(),
+            "simple lowercase name should be valid"
+        );
+        assert!(
+            validate_name("my-agent").is_ok(),
+            "name with hyphen should be valid"
+        );
+        assert!(
+            validate_name("agent42").is_ok(),
+            "alphanumeric name should be valid"
+        );
     }
 
     #[test]
     fn validate_name_rejects_empty() {
-        assert!(validate_name("").is_err());
+        assert!(validate_name("").is_err(), "empty name should be rejected");
     }
 
     #[test]
     fn validate_name_rejects_special_chars() {
-        assert!(validate_name("my_agent").is_err());
-        assert!(validate_name("my agent").is_err());
-        assert!(validate_name("my.agent").is_err());
+        assert!(
+            validate_name("my_agent").is_err(),
+            "underscore in name should be rejected"
+        );
+        assert!(
+            validate_name("my agent").is_err(),
+            "space in name should be rejected"
+        );
+        assert!(
+            validate_name("my.agent").is_err(),
+            "dot in name should be rejected"
+        );
     }
 
     #[test]
     fn validate_name_rejects_leading_trailing_hyphen() {
-        assert!(validate_name("-agent").is_err());
-        assert!(validate_name("agent-").is_err());
+        assert!(
+            validate_name("-agent").is_err(),
+            "leading hyphen in name should be rejected"
+        );
+        assert!(
+            validate_name("agent-").is_err(),
+            "trailing hyphen in name should be rejected"
+        );
     }
 
     #[test]
     fn validate_provider_accepts_known() {
-        assert!(validate_provider("anthropic").is_ok());
-        assert!(validate_provider("openai").is_ok());
+        assert!(
+            validate_provider("anthropic").is_ok(),
+            "anthropic should be a valid provider"
+        );
+        assert!(
+            validate_provider("openai").is_ok(),
+            "openai should be a valid provider"
+        );
     }
 
     #[test]
     fn validate_provider_rejects_unknown() {
-        assert!(validate_provider("google").is_err());
+        assert!(
+            validate_provider("google").is_err(),
+            "unknown provider should be rejected"
+        );
     }
 
     #[test]
     fn capitalize_first_letter() {
-        assert_eq!(capitalize("chiron"), "Chiron");
-        assert_eq!(capitalize("my-agent"), "My-agent");
-        assert_eq!(capitalize(""), "");
-        assert_eq!(capitalize("A"), "A");
+        assert_eq!(
+            capitalize("chiron"),
+            "Chiron",
+            "first letter should be uppercased"
+        );
+        assert_eq!(
+            capitalize("my-agent"),
+            "My-agent",
+            "only first letter should be uppercased"
+        );
+        assert_eq!(capitalize(""), "", "empty string should remain empty");
+        assert_eq!(
+            capitalize("A"),
+            "A",
+            "already capitalized single letter should be unchanged"
+        );
     }
 
     #[test]
@@ -365,23 +410,68 @@ mod tests {
         scaffold_directory(&oikos, &args).unwrap();
 
         let nous_dir = dir.path().join("nous/test-agent");
-        assert!(nous_dir.join("SOUL.md").exists());
-        assert!(nous_dir.join("IDENTITY.md").exists());
-        assert!(nous_dir.join("AGENTS.md").exists());
-        assert!(nous_dir.join("CONTEXT.md").exists());
-        assert!(nous_dir.join("GOALS.md").exists());
-        assert!(nous_dir.join("MEMORY.md").exists());
-        assert!(nous_dir.join("PROSOCHE.md").exists());
-        assert!(nous_dir.join("TOOLS.md").exists());
-        assert!(nous_dir.join("USER.md").exists());
-        assert!(nous_dir.join("WORKFLOWS.md").exists());
-        assert!(nous_dir.join(".gitignore").exists());
-        assert!(nous_dir.join("memory").is_dir());
-        assert!(nous_dir.join("workspace/drafts").is_dir());
-        assert!(nous_dir.join("workspace/scripts").is_dir());
+        assert!(
+            nous_dir.join("SOUL.md").exists(),
+            "SOUL.md should be created by scaffold"
+        );
+        assert!(
+            nous_dir.join("IDENTITY.md").exists(),
+            "IDENTITY.md should be created by scaffold"
+        );
+        assert!(
+            nous_dir.join("AGENTS.md").exists(),
+            "AGENTS.md should be created by scaffold"
+        );
+        assert!(
+            nous_dir.join("CONTEXT.md").exists(),
+            "CONTEXT.md should be created by scaffold"
+        );
+        assert!(
+            nous_dir.join("GOALS.md").exists(),
+            "GOALS.md should be created by scaffold"
+        );
+        assert!(
+            nous_dir.join("MEMORY.md").exists(),
+            "MEMORY.md should be created by scaffold"
+        );
+        assert!(
+            nous_dir.join("PROSOCHE.md").exists(),
+            "PROSOCHE.md should be created by scaffold"
+        );
+        assert!(
+            nous_dir.join("TOOLS.md").exists(),
+            "TOOLS.md should be created by scaffold"
+        );
+        assert!(
+            nous_dir.join("USER.md").exists(),
+            "USER.md should be created by scaffold"
+        );
+        assert!(
+            nous_dir.join("WORKFLOWS.md").exists(),
+            "WORKFLOWS.md should be created by scaffold"
+        );
+        assert!(
+            nous_dir.join(".gitignore").exists(),
+            ".gitignore should be created by scaffold"
+        );
+        assert!(
+            nous_dir.join("memory").is_dir(),
+            "memory subdirectory should be created by scaffold"
+        );
+        assert!(
+            nous_dir.join("workspace/drafts").is_dir(),
+            "workspace/drafts subdirectory should be created by scaffold"
+        );
+        assert!(
+            nous_dir.join("workspace/scripts").is_dir(),
+            "workspace/scripts subdirectory should be created by scaffold"
+        );
 
         let soul = std::fs::read_to_string(nous_dir.join("SOUL.md")).unwrap();
-        assert!(soul.contains("Test-agent"));
+        assert!(
+            soul.contains("Test-agent"),
+            "SOUL.md should contain the capitalized agent name"
+        );
     }
 
     #[test]
@@ -461,7 +551,10 @@ mod tests {
         };
         update_config(&oikos, &args).unwrap();
         let result = update_config(&oikos, &args);
-        assert!(result.is_err());
+        assert!(
+            result.is_err(),
+            "adding a duplicate agent should return an error"
+        );
         let msg = result.unwrap_err().to_string();
         assert!(msg.contains("already exists"), "got: {msg}");
     }
@@ -481,7 +574,10 @@ mod tests {
         // NOTE: use a blocking executor since run() is async
         let rt = tokio::runtime::Runtime::new().unwrap();
         let result = rt.block_on(run(Some(&dir.path().to_path_buf()), &args));
-        assert!(result.is_err());
+        assert!(
+            result.is_err(),
+            "run should fail when the nous directory already exists"
+        );
         let msg = result.unwrap_err().to_string();
         assert!(
             msg.contains("already exists"),

--- a/crates/mneme/src/query/tests.rs
+++ b/crates/mneme/src/query/tests.rs
@@ -956,7 +956,7 @@ mod proptests {
                 !script.contains(&input),
                 "raw user input must not appear in script: {input}"
             );
-            prop_assert!(params.contains_key("user_input"));
+            prop_assert!(params.contains_key("user_input"), "param map should contain user_input binding");
         }
     }
 }

--- a/crates/mneme/src/skills/extract_tests.rs
+++ b/crates/mneme/src/skills/extract_tests.rs
@@ -114,10 +114,22 @@ fn build_prompt_includes_candidate_metadata() {
     let seqs = sample_sequences();
     let prompt = build_extraction_prompt(&candidate, &seqs);
 
-    assert!(prompt.contains("Recurrence count: 3"));
-    assert!(prompt.contains("Diagnostic"));
-    assert!(prompt.contains("0.72"));
-    assert!(prompt.contains("Grep → Read → Edit → Bash"));
+    assert!(
+        prompt.contains("Recurrence count: 3"),
+        "prompt should include recurrence count from candidate metadata"
+    );
+    assert!(
+        prompt.contains("Diagnostic"),
+        "prompt should include pattern type from candidate metadata"
+    );
+    assert!(
+        prompt.contains("0.72"),
+        "prompt should include heuristic score from candidate metadata"
+    );
+    assert!(
+        prompt.contains("Grep → Read → Edit → Bash"),
+        "prompt should include normalized tool sequence from candidate"
+    );
 }
 
 #[test]
@@ -126,9 +138,18 @@ fn build_prompt_includes_all_sessions() {
     let seqs = sample_sequences();
     let prompt = build_extraction_prompt(&candidate, &seqs);
 
-    assert!(prompt.contains("Session 1"));
-    assert!(prompt.contains("Session 2"));
-    assert!(prompt.contains("6 calls"));
+    assert!(
+        prompt.contains("Session 1"),
+        "prompt should include first session reference"
+    );
+    assert!(
+        prompt.contains("Session 2"),
+        "prompt should include second session reference"
+    );
+    assert!(
+        prompt.contains("6 calls"),
+        "prompt should include total call count for the session"
+    );
 }
 
 #[test]
@@ -140,8 +161,14 @@ fn build_prompt_includes_tool_call_details() {
     ]];
     let prompt = build_extraction_prompt(&candidate, &seqs);
 
-    assert!(prompt.contains("Read (50ms)"));
-    assert!(prompt.contains("Bash (300ms) [ERROR]"));
+    assert!(
+        prompt.contains("Read (50ms)"),
+        "prompt should include tool name with duration"
+    );
+    assert!(
+        prompt.contains("Bash (300ms) [ERROR]"),
+        "prompt should mark errored tool calls with [ERROR] suffix"
+    );
 }
 
 #[test]
@@ -149,8 +176,14 @@ fn build_prompt_handles_empty_sequences() {
     let candidate = sample_candidate();
     let prompt = build_extraction_prompt(&candidate, &[]);
 
-    assert!(prompt.contains("Candidate Pattern"));
-    assert!(prompt.contains("Observed Tool Call Sequences"));
+    assert!(
+        prompt.contains("Candidate Pattern"),
+        "prompt should include candidate pattern section even with no sequences"
+    );
+    assert!(
+        prompt.contains("Observed Tool Call Sequences"),
+        "prompt should include sequences section header even when empty"
+    );
 }
 
 #[test]
@@ -160,7 +193,10 @@ fn build_prompt_no_pattern_type() {
     let seqs = sample_sequences();
     let prompt = build_extraction_prompt(&candidate, &seqs);
 
-    assert!(!prompt.contains("pattern type"));
+    assert!(
+        !prompt.contains("pattern type"),
+        "prompt should omit pattern type section when candidate has no pattern type"
+    );
 }
 
 // -- Response parsing -----------------------------------------------------
@@ -170,25 +206,49 @@ fn parse_valid_json_response() {
     let response = valid_json_response();
     let skill = parse_skill_response(&response).expect("valid JSON response should parse");
 
-    assert_eq!(skill.name, "test-driven-bug-fix");
-    assert_eq!(skill.steps.len(), 4);
-    assert_eq!(skill.tools_used, vec!["Grep", "Read", "Edit", "Bash"]);
-    assert_eq!(skill.domain_tags, vec!["testing", "debugging"]);
-    assert!(!skill.when_to_use.is_empty());
+    assert_eq!(
+        skill.name, "test-driven-bug-fix",
+        "parsed skill should have the name from the JSON response"
+    );
+    assert_eq!(
+        skill.steps.len(),
+        4,
+        "parsed skill should have all 4 steps from the JSON response"
+    );
+    assert_eq!(
+        skill.tools_used,
+        vec!["Grep", "Read", "Edit", "Bash"],
+        "parsed skill should have tools in order from the JSON response"
+    );
+    assert_eq!(
+        skill.domain_tags,
+        vec!["testing", "debugging"],
+        "parsed skill should have domain tags from the JSON response"
+    );
+    assert!(
+        !skill.when_to_use.is_empty(),
+        "parsed skill should have a non-empty when_to_use field"
+    );
 }
 
 #[test]
 fn parse_json_in_markdown_fences() {
     let response = format!("```json\n{}\n```", valid_json_response());
     let skill = parse_skill_response(&response).expect("json in markdown fences should parse");
-    assert_eq!(skill.name, "test-driven-bug-fix");
+    assert_eq!(
+        skill.name, "test-driven-bug-fix",
+        "skill name should be extracted correctly from JSON in markdown fences"
+    );
 }
 
 #[test]
 fn parse_json_in_bare_fences() {
     let response = format!("```\n{}\n```", valid_json_response());
     let skill = parse_skill_response(&response).expect("json in bare fences should parse");
-    assert_eq!(skill.name, "test-driven-bug-fix");
+    assert_eq!(
+        skill.name, "test-driven-bug-fix",
+        "skill name should be extracted correctly from JSON in bare fences"
+    );
 }
 
 #[test]
@@ -198,16 +258,25 @@ fn parse_json_with_surrounding_text() {
         valid_json_response()
     );
     let skill = parse_skill_response(&response).expect("json with surrounding text should parse");
-    assert_eq!(skill.name, "test-driven-bug-fix");
+    assert_eq!(
+        skill.name, "test-driven-bug-fix",
+        "skill name should be extracted correctly when JSON has surrounding text"
+    );
 }
 
 #[test]
 fn parse_malformed_json_returns_error() {
     let response = "not json at all";
     let result = parse_skill_response(response);
-    assert!(result.is_err());
+    assert!(
+        result.is_err(),
+        "parsing non-JSON text should return an error"
+    );
     let err = result.unwrap_err();
-    assert!(err.to_string().contains("invalid JSON"));
+    assert!(
+        err.to_string().contains("invalid JSON"),
+        "error message should indicate the input was invalid JSON"
+    );
 }
 
 #[test]
@@ -215,13 +284,16 @@ fn parse_incomplete_json_returns_error() {
     let response = r#"{"name": "test", "description": "d"}"#;
     let result = parse_skill_response(response);
     // Missing required fields
-    assert!(result.is_err());
+    assert!(
+        result.is_err(),
+        "JSON missing required fields should return an error"
+    );
 }
 
 #[test]
 fn parse_empty_response_returns_error() {
     let result = parse_skill_response("");
-    assert!(result.is_err());
+    assert!(result.is_err(), "empty response should return an error");
 }
 
 #[test]
@@ -235,8 +307,14 @@ fn parse_empty_fields_succeeds() {
         "when_to_use": ""
     }"#;
     let skill = parse_skill_response(response).expect("minimal skill JSON should parse");
-    assert_eq!(skill.name, "minimal-skill");
-    assert!(skill.steps.is_empty());
+    assert_eq!(
+        skill.name, "minimal-skill",
+        "parsed skill should have the name from the minimal JSON"
+    );
+    assert!(
+        skill.steps.is_empty(),
+        "parsed skill should have empty steps when JSON steps array is empty"
+    );
 }
 
 // -- Extractor end-to-end -------------------------------------------------
@@ -252,7 +330,10 @@ async fn extractor_returns_skill_on_valid_response() {
         .extract_skill(&candidate, &seqs)
         .await
         .expect("mock provider returns valid response");
-    assert_eq!(skill.name, "test-driven-bug-fix");
+    assert_eq!(
+        skill.name, "test-driven-bug-fix",
+        "extractor should return skill with name parsed from provider response"
+    );
 }
 
 #[tokio::test]
@@ -263,7 +344,10 @@ async fn extractor_returns_error_on_provider_failure() {
     let seqs = sample_sequences();
 
     let result = extractor.extract_skill(&candidate, &seqs).await;
-    assert!(result.is_err());
+    assert!(
+        result.is_err(),
+        "extractor should return error when provider fails"
+    );
 }
 
 #[tokio::test]
@@ -274,7 +358,10 @@ async fn extractor_returns_error_on_malformed_response() {
     let seqs = sample_sequences();
 
     let result = extractor.extract_skill(&candidate, &seqs).await;
-    assert!(result.is_err());
+    assert!(
+        result.is_err(),
+        "extractor should return error when provider returns malformed JSON"
+    );
 }
 
 // -- ExtractedSkill → SkillContent ----------------------------------------
@@ -290,7 +377,10 @@ fn to_skill_content_sets_origin_extracted() {
         when_to_use: "When testing".to_owned(),
     };
     let content = extracted.to_skill_content();
-    assert_eq!(content.origin, "extracted");
+    assert_eq!(
+        content.origin, "extracted",
+        "skill content origin should be set to 'extracted' for LLM-extracted skills"
+    );
 }
 
 #[test]
@@ -304,8 +394,14 @@ fn to_skill_content_includes_when_to_use_in_description() {
         when_to_use: "When you need to test".to_owned(),
     };
     let content = extracted.to_skill_content();
-    assert!(content.description.contains("When to Use"));
-    assert!(content.description.contains("When you need to test"));
+    assert!(
+        content.description.contains("When to Use"),
+        "skill content description should include a 'When to Use' section header"
+    );
+    assert!(
+        content.description.contains("When you need to test"),
+        "skill content description should include the when_to_use text"
+    );
 }
 
 #[test]
@@ -319,7 +415,10 @@ fn to_skill_content_omits_when_to_use_if_empty() {
         when_to_use: String::new(),
     };
     let content = extracted.to_skill_content();
-    assert_eq!(content.description, "A test skill");
+    assert_eq!(
+        content.description, "A test skill",
+        "skill content description should be just the base description when when_to_use is empty"
+    );
 }
 
 // -- PendingSkill ---------------------------------------------------------
@@ -335,10 +434,22 @@ fn pending_skill_new_sets_status() {
         when_to_use: String::new(),
     };
     let pending = PendingSkill::new(&extracted, "cand-001");
-    assert!(pending.is_pending());
-    assert!(!pending.is_approved());
-    assert_eq!(pending.candidate_id, "cand-001");
-    assert_eq!(pending.status, "pending_review");
+    assert!(
+        pending.is_pending(),
+        "newly created pending skill should be in pending state"
+    );
+    assert!(
+        !pending.is_approved(),
+        "newly created pending skill should not be approved"
+    );
+    assert_eq!(
+        pending.candidate_id, "cand-001",
+        "pending skill should store the candidate id it was created with"
+    );
+    assert_eq!(
+        pending.status, "pending_review",
+        "newly created pending skill should have status 'pending_review'"
+    );
 }
 
 #[test]
@@ -354,9 +465,18 @@ fn pending_skill_serialization_roundtrip() {
     let pending = PendingSkill::new(&extracted, "cand-002");
     let json = pending.to_json().expect("pending skill serializes to JSON");
     let back = PendingSkill::from_json(&json).expect("pending skill deserializes from JSON");
-    assert_eq!(back.skill.name, "roundtrip-skill");
-    assert_eq!(back.candidate_id, "cand-002");
-    assert!(back.is_pending());
+    assert_eq!(
+        back.skill.name, "roundtrip-skill",
+        "deserialized skill should preserve the original skill name"
+    );
+    assert_eq!(
+        back.candidate_id, "cand-002",
+        "deserialized pending skill should preserve the candidate id"
+    );
+    assert!(
+        back.is_pending(),
+        "deserialized pending skill should still be in pending state"
+    );
 }
 
 #[test]
@@ -374,23 +494,50 @@ fn pending_skill_approved_status() {
         status: "approved".to_owned(),
         extracted_at: jiff::Timestamp::now(),
     };
-    assert!(pending.is_approved());
-    assert!(!pending.is_pending());
+    assert!(
+        pending.is_approved(),
+        "skill with status 'approved' should report as approved"
+    );
+    assert!(
+        !pending.is_pending(),
+        "skill with status 'approved' should not report as pending"
+    );
 
     pending.status = "rejected".to_owned();
-    assert!(!pending.is_approved());
-    assert!(!pending.is_pending());
+    assert!(
+        !pending.is_approved(),
+        "skill with status 'rejected' should not report as approved"
+    );
+    assert!(
+        !pending.is_pending(),
+        "skill with status 'rejected' should not report as pending"
+    );
 }
 
 // -- System prompt --------------------------------------------------------
 
 #[test]
 fn system_prompt_requests_json() {
-    assert!(EXTRACTION_SYSTEM_PROMPT.contains("JSON"));
-    assert!(EXTRACTION_SYSTEM_PROMPT.contains("name"));
-    assert!(EXTRACTION_SYSTEM_PROMPT.contains("steps"));
-    assert!(EXTRACTION_SYSTEM_PROMPT.contains("tools_used"));
-    assert!(EXTRACTION_SYSTEM_PROMPT.contains("domain_tags"));
+    assert!(
+        EXTRACTION_SYSTEM_PROMPT.contains("JSON"),
+        "system prompt should instruct the model to respond with JSON"
+    );
+    assert!(
+        EXTRACTION_SYSTEM_PROMPT.contains("name"),
+        "system prompt should reference the 'name' field in the expected schema"
+    );
+    assert!(
+        EXTRACTION_SYSTEM_PROMPT.contains("steps"),
+        "system prompt should reference the 'steps' field in the expected schema"
+    );
+    assert!(
+        EXTRACTION_SYSTEM_PROMPT.contains("tools_used"),
+        "system prompt should reference the 'tools_used' field in the expected schema"
+    );
+    assert!(
+        EXTRACTION_SYSTEM_PROMPT.contains("domain_tags"),
+        "system prompt should reference the 'domain_tags' field in the expected schema"
+    );
 }
 
 // -- Dedup ----------------------------------------------------------------
@@ -421,7 +568,11 @@ fn dedup_unique_skills() {
         candidate_embedding: None,
         existing_embedding: None,
     });
-    assert_eq!(result, DedupOutcome::Unique);
+    assert_eq!(
+        result,
+        DedupOutcome::Unique,
+        "skills with different names and non-overlapping tools should be considered unique"
+    );
 }
 
 #[test]
@@ -512,7 +663,11 @@ fn dedup_embedding_below_threshold_is_unique() {
         candidate_embedding: Some(&cand_emb),
         existing_embedding: Some(&exist_emb),
     });
-    assert_eq!(result, DedupOutcome::Unique);
+    assert_eq!(
+        result,
+        DedupOutcome::Unique,
+        "orthogonal embeddings should result in a unique outcome despite similar tool overlap"
+    );
 }
 
 #[test]
@@ -540,7 +695,10 @@ fn cosine_similarity_orthogonal_vectors() {
 #[test]
 fn cosine_similarity_empty_vectors() {
     let sim = cosine_similarity(&[], &[]);
-    assert!(sim.abs() < f64::EPSILON);
+    assert!(
+        sim.abs() < f64::EPSILON,
+        "cosine similarity of two empty vectors should be zero"
+    );
 }
 
 #[test]
@@ -548,7 +706,10 @@ fn tool_overlap_identical_sets() {
     let a = vec!["Read".to_owned(), "Edit".to_owned()];
     let b = vec!["Read".to_owned(), "Edit".to_owned()];
     let overlap = compute_tool_overlap(&a, &b);
-    assert!((overlap - 1.0).abs() < f64::EPSILON);
+    assert!(
+        (overlap - 1.0).abs() < f64::EPSILON,
+        "identical tool sets should have overlap of 1.0"
+    );
 }
 
 #[test]
@@ -556,13 +717,19 @@ fn tool_overlap_disjoint_sets() {
     let a = vec!["Read".to_owned()];
     let b = vec!["Write".to_owned()];
     let overlap = compute_tool_overlap(&a, &b);
-    assert!(overlap.abs() < f64::EPSILON);
+    assert!(
+        overlap.abs() < f64::EPSILON,
+        "disjoint tool sets should have overlap of 0.0"
+    );
 }
 
 #[test]
 fn name_similarity_identical() {
     let sim = compute_name_similarity("rust-errors", "rust-errors");
-    assert!((sim - 1.0).abs() < f64::EPSILON);
+    assert!(
+        (sim - 1.0).abs() < f64::EPSILON,
+        "identical names should have similarity of 1.0"
+    );
 }
 
 #[test]

--- a/crates/nous/src/bootstrap/bootstrap_tests.rs
+++ b/crates/nous/src/bootstrap/bootstrap_tests.rs
@@ -40,9 +40,19 @@ async fn assemble_with_required_only() {
     let mut budget = default_budget();
 
     let result = assembler.assemble("test", &mut budget).await.unwrap();
-    assert!(result.system_prompt.contains("I am a test agent."));
-    assert_eq!(result.sections_included, vec!["SOUL.md"]);
-    assert!(result.sections_dropped.is_empty());
+    assert!(
+        result.system_prompt.contains("I am a test agent."),
+        "system prompt should include SOUL.md content"
+    );
+    assert_eq!(
+        result.sections_included,
+        vec!["SOUL.md"],
+        "only SOUL.md should be included when it is the only file"
+    );
+    assert!(
+        result.sections_dropped.is_empty(),
+        "no sections should be dropped when only required file is present"
+    );
 }
 
 #[tokio::test]
@@ -67,8 +77,15 @@ async fn assemble_missing_optional_skips() {
 
     let result = assembler.assemble("test", &mut budget).await.unwrap();
     // Only SOUL.md included, others silently skipped
-    assert_eq!(result.sections_included, vec!["SOUL.md"]);
-    assert!(result.sections_dropped.is_empty());
+    assert_eq!(
+        result.sections_included,
+        vec!["SOUL.md"],
+        "only SOUL.md should be included when optional files are absent"
+    );
+    assert!(
+        result.sections_dropped.is_empty(),
+        "missing optional files should be silently skipped, not dropped"
+    );
 }
 
 #[tokio::test]
@@ -101,8 +118,14 @@ async fn assemble_priority_ordering() {
         .iter()
         .position(|s| s == "MEMORY.md")
         .unwrap();
-    assert!(soul_pos < goals_pos);
-    assert!(goals_pos < memory_pos);
+    assert!(
+        soul_pos < goals_pos,
+        "SOUL.md (Required) should appear before GOALS.md (Important)"
+    );
+    assert!(
+        goals_pos < memory_pos,
+        "GOALS.md (Important) should appear before MEMORY.md (Flexible)"
+    );
 }
 
 #[tokio::test]
@@ -125,8 +148,15 @@ async fn assemble_all_files_present() {
     let mut budget = default_budget();
 
     let result = assembler.assemble("test", &mut budget).await.unwrap();
-    assert_eq!(result.sections_included.len(), 9);
-    assert!(result.total_tokens > 0);
+    assert_eq!(
+        result.sections_included.len(),
+        9,
+        "all 9 sections should be included when budget allows"
+    );
+    assert!(
+        result.total_tokens > 0,
+        "total token count should be greater than zero when sections are included"
+    );
 }
 
 #[tokio::test]
@@ -143,7 +173,11 @@ async fn assemble_empty_file_skipped() {
     let mut budget = default_budget();
 
     let result = assembler.assemble("test", &mut budget).await.unwrap();
-    assert_eq!(result.sections_included, vec!["SOUL.md"]);
+    assert_eq!(
+        result.sections_included,
+        vec!["SOUL.md"],
+        "empty and whitespace-only sections should be skipped"
+    );
 }
 
 #[tokio::test]
@@ -159,12 +193,19 @@ async fn assemble_memory_truncated() {
     let mut budget = TokenBudget::new(100_000, 0.0, 0, 500);
 
     let result = assembler.assemble("test", &mut budget).await.unwrap();
-    assert!(result.sections_included.contains(&"MEMORY.md".to_owned()));
-    assert!(result.sections_truncated.contains(&"MEMORY.md".to_owned()));
+    assert!(
+        result.sections_included.contains(&"MEMORY.md".to_owned()),
+        "MEMORY.md should be included even when truncated"
+    );
+    assert!(
+        result.sections_truncated.contains(&"MEMORY.md".to_owned()),
+        "MEMORY.md should be recorded as truncated when it exceeded the budget"
+    );
     assert!(
         result
             .system_prompt
-            .contains("[truncated for token budget]")
+            .contains("[truncated for token budget]"),
+        "truncated section should include a truncation marker in the system prompt"
     );
 }
 
@@ -180,8 +221,14 @@ async fn assemble_optional_dropped() {
     let mut budget = TokenBudget::new(100_000, 0.0, 0, 500);
 
     let result = assembler.assemble("test", &mut budget).await.unwrap();
-    assert!(result.sections_included.contains(&"SOUL.md".to_owned()));
-    assert!(result.sections_dropped.contains(&"MEMORY.md".to_owned()));
+    assert!(
+        result.sections_included.contains(&"SOUL.md".to_owned()),
+        "SOUL.md should always be included as a required section"
+    );
+    assert!(
+        result.sections_dropped.contains(&"MEMORY.md".to_owned()),
+        "MEMORY.md should be dropped when the budget is fully consumed by required sections"
+    );
 }
 
 #[tokio::test]
@@ -191,8 +238,15 @@ async fn assemble_budget_consumed_correctly() {
     let mut budget = default_budget();
 
     let result = assembler.assemble("test", &mut budget).await.unwrap();
-    assert_eq!(budget.consumed(), result.total_tokens);
-    assert!(result.total_tokens > 0);
+    assert_eq!(
+        budget.consumed(),
+        result.total_tokens,
+        "budget consumed should match the total tokens reported in the result"
+    );
+    assert!(
+        result.total_tokens > 0,
+        "total token count should be greater than zero when sections are included"
+    );
 }
 
 #[tokio::test]
@@ -203,7 +257,10 @@ async fn assemble_cascade_nous_tier() {
     let mut budget = default_budget();
 
     let result = assembler.assemble("syn", &mut budget).await.unwrap();
-    assert!(result.system_prompt.contains("I am Syn."));
+    assert!(
+        result.system_prompt.contains("I am Syn."),
+        "system prompt should include SOUL.md content from the nous tier"
+    );
 }
 
 #[tokio::test]
@@ -217,8 +274,14 @@ async fn assemble_cascade_theke_fallback() {
     let mut budget = default_budget();
 
     let result = assembler.assemble("syn", &mut budget).await.unwrap();
-    assert!(result.system_prompt.contains("Alice T."));
-    assert!(result.sections_included.contains(&"USER.md".to_owned()));
+    assert!(
+        result.system_prompt.contains("Alice T."),
+        "system prompt should include USER.md content found in the theke tier"
+    );
+    assert!(
+        result.sections_included.contains(&"USER.md".to_owned()),
+        "USER.md should be listed as included when resolved from the theke tier"
+    );
 }
 
 #[tokio::test]
@@ -237,8 +300,14 @@ async fn assemble_nous_overrides_theke() {
     let mut budget = default_budget();
 
     let result = assembler.assemble("syn", &mut budget).await.unwrap();
-    assert!(result.system_prompt.contains("nous-specific soul"));
-    assert!(!result.system_prompt.contains("theke soul"));
+    assert!(
+        result.system_prompt.contains("nous-specific soul"),
+        "nous-tier SOUL.md should override theke-tier SOUL.md in the system prompt"
+    );
+    assert!(
+        !result.system_prompt.contains("theke soul"),
+        "theke-tier SOUL.md should not appear when nous tier provides the same file"
+    );
 }
 
 // --- Truncation tests ---
@@ -259,9 +328,18 @@ fn truncate_section_aware() {
 
     // Budget enough for one section: newest (Section C) is kept, oldest dropped.
     let truncated = assembler.truncate_section(&section, 10);
-    assert!(truncated.content.contains("Section C"));
-    assert!(!truncated.content.contains("Section A"));
-    assert!(truncated.content.contains("[truncated for token budget]"));
+    assert!(
+        truncated.content.contains("Section C"),
+        "newest section should be preserved when truncating to fit budget"
+    );
+    assert!(
+        !truncated.content.contains("Section A"),
+        "oldest section should be removed when truncating to fit budget"
+    );
+    assert!(
+        truncated.content.contains("[truncated for token budget]"),
+        "truncated content should include a truncation marker"
+    );
 }
 
 #[test]
@@ -279,9 +357,18 @@ fn truncate_falls_back_to_lines() {
 
     // Budget enough for ~1 line: newest ("Line five") is kept, oldest dropped.
     let truncated = assembler.truncate_by_lines(&section, 5);
-    assert!(truncated.content.contains("Line five"));
-    assert!(!truncated.content.contains("Line one"));
-    assert!(truncated.content.contains("[truncated for token budget]"));
+    assert!(
+        truncated.content.contains("Line five"),
+        "last line should be preserved when truncating by lines"
+    );
+    assert!(
+        !truncated.content.contains("Line one"),
+        "first line should be removed when truncating by lines"
+    );
+    assert!(
+        truncated.content.contains("[truncated for token budget]"),
+        "line-truncated content should include a truncation marker"
+    );
 }
 
 // --- Pack conversion tests ---
@@ -310,22 +397,51 @@ fn pack_sections_to_bootstrap_converts_priorities() {
     let refs: Vec<&PackSection> = sections.iter().collect();
     let result = pack_sections_to_bootstrap(&refs, &CharEstimator::default());
 
-    assert_eq!(result.len(), 2);
-    assert_eq!(result[0].name, "[test-pack] LOGIC.md");
-    assert_eq!(result[0].priority, SectionPriority::Required);
-    assert!(!result[0].truncatable);
-    assert_eq!(result[0].content, "Business logic content");
-    assert!(result[0].tokens > 0);
+    assert_eq!(result.len(), 2, "both pack sections should be converted");
+    assert_eq!(
+        result[0].name, "[test-pack] LOGIC.md",
+        "converted section name should include the pack name prefix"
+    );
+    assert_eq!(
+        result[0].priority,
+        SectionPriority::Required,
+        "Required pack priority should map to Required bootstrap priority"
+    );
+    assert!(
+        !result[0].truncatable,
+        "non-truncatable pack section should remain non-truncatable after conversion"
+    );
+    assert_eq!(
+        result[0].content, "Business logic content",
+        "section content should be preserved unchanged after conversion"
+    );
+    assert!(
+        result[0].tokens > 0,
+        "token count should be estimated as greater than zero for non-empty content"
+    );
 
-    assert_eq!(result[1].name, "[test-pack] GLOSSARY.md");
-    assert_eq!(result[1].priority, SectionPriority::Flexible);
-    assert!(result[1].truncatable);
+    assert_eq!(
+        result[1].name, "[test-pack] GLOSSARY.md",
+        "converted section name should include the pack name prefix"
+    );
+    assert_eq!(
+        result[1].priority,
+        SectionPriority::Flexible,
+        "Flexible pack priority should map to Flexible bootstrap priority"
+    );
+    assert!(
+        result[1].truncatable,
+        "truncatable pack section should remain truncatable after conversion"
+    );
 }
 
 #[test]
 fn pack_sections_to_bootstrap_empty_input() {
     let result = pack_sections_to_bootstrap(&[], &CharEstimator::default());
-    assert!(result.is_empty());
+    assert!(
+        result.is_empty(),
+        "empty input should produce an empty list of bootstrap sections"
+    );
 }
 
 #[tokio::test]
@@ -346,13 +462,21 @@ async fn assemble_with_extra_includes_pack_sections() {
         .assemble_with_extra("test", &mut budget, extra)
         .await
         .unwrap();
-    assert!(result.system_prompt.contains("Domain logic from pack."));
+    assert!(
+        result.system_prompt.contains("Domain logic from pack."),
+        "system prompt should include content from extra pack sections"
+    );
     assert!(
         result
             .sections_included
-            .contains(&"[pack] LOGIC.md".to_owned())
+            .contains(&"[pack] LOGIC.md".to_owned()),
+        "extra pack section should be listed in sections_included"
     );
-    assert_eq!(result.sections_included.len(), 2);
+    assert_eq!(
+        result.sections_included.len(),
+        2,
+        "both SOUL.md and the extra pack section should be included"
+    );
 }
 
 #[tokio::test]
@@ -399,6 +523,12 @@ async fn assemble_with_extra_respects_priority_ordering() {
         .iter()
         .position(|s| s == "optional-pack")
         .unwrap();
-    assert!(soul_pos < important_pos);
-    assert!(important_pos < optional_pos);
+    assert!(
+        soul_pos < important_pos,
+        "SOUL.md (Required) should appear before important-pack (Important)"
+    );
+    assert!(
+        important_pos < optional_pos,
+        "important-pack (Important) should appear before optional-pack (Optional)"
+    );
 }

--- a/crates/nous/src/execute/tests.rs
+++ b/crates/nous/src/execute/tests.rs
@@ -173,13 +173,34 @@ async fn simple_text_response() {
     .await
     .expect("execute");
 
-    assert_eq!(result.content, "Hello there!");
-    assert!(result.tool_calls.is_empty());
-    assert_eq!(result.usage.llm_calls, 1);
-    assert_eq!(result.usage.input_tokens, 100);
-    assert_eq!(result.usage.output_tokens, 50);
-    assert_eq!(result.stop_reason, "end_turn");
-    assert!(result.signals.contains(&InteractionSignal::Conversation));
+    assert_eq!(
+        result.content, "Hello there!",
+        "response content should match mock text"
+    );
+    assert!(
+        result.tool_calls.is_empty(),
+        "text-only response should produce no tool calls"
+    );
+    assert_eq!(
+        result.usage.llm_calls, 1,
+        "single text response should use exactly one LLM call"
+    );
+    assert_eq!(
+        result.usage.input_tokens, 100,
+        "input token count should match mock response"
+    );
+    assert_eq!(
+        result.usage.output_tokens, 50,
+        "output token count should match mock response"
+    );
+    assert_eq!(
+        result.stop_reason, "end_turn",
+        "response should stop with end_turn reason"
+    );
+    assert!(
+        result.signals.contains(&InteractionSignal::Conversation),
+        "text-only response should produce Conversation signal"
+    );
 }
 
 #[tokio::test]
@@ -206,16 +227,36 @@ async fn single_tool_iteration() {
     .await
     .expect("execute");
 
-    assert_eq!(result.content, "Done!");
-    assert_eq!(result.tool_calls.len(), 1);
-    assert_eq!(result.tool_calls[0].name, "exec");
+    assert_eq!(
+        result.content, "Done!",
+        "final response content should match mock text"
+    );
+    assert_eq!(
+        result.tool_calls.len(),
+        1,
+        "should have recorded exactly one tool call"
+    );
+    assert_eq!(
+        result.tool_calls[0].name, "exec",
+        "tool call name should match registered tool"
+    );
     assert_eq!(
         result.tool_calls[0].result.as_deref(),
-        Some("executed: exec")
+        Some("executed: exec"),
+        "tool result should contain the echo executor output"
     );
-    assert!(!result.tool_calls[0].is_error);
-    assert_eq!(result.usage.llm_calls, 2);
-    assert_eq!(result.stop_reason, "end_turn");
+    assert!(
+        !result.tool_calls[0].is_error,
+        "tool call should not be marked as an error"
+    );
+    assert_eq!(
+        result.usage.llm_calls, 2,
+        "one tool iteration requires two LLM calls"
+    );
+    assert_eq!(
+        result.stop_reason, "end_turn",
+        "final response should stop with end_turn reason"
+    );
 }
 
 #[tokio::test]
@@ -243,9 +284,19 @@ async fn multi_tool_iteration() {
     .await
     .expect("execute");
 
-    assert_eq!(result.content, "All done!");
-    assert_eq!(result.tool_calls.len(), 2);
-    assert_eq!(result.usage.llm_calls, 3);
+    assert_eq!(
+        result.content, "All done!",
+        "final response content should match mock text"
+    );
+    assert_eq!(
+        result.tool_calls.len(),
+        2,
+        "should have recorded two tool calls across iterations"
+    );
+    assert_eq!(
+        result.usage.llm_calls, 3,
+        "two tool iterations require three LLM calls"
+    );
 }
 
 #[tokio::test]
@@ -272,7 +323,10 @@ async fn loop_detection_triggers() {
     .await
     .expect_err("should detect loop");
 
-    assert!(err.to_string().contains("loop detected"));
+    assert!(
+        err.to_string().contains("loop detected"),
+        "error message should indicate loop was detected"
+    );
 }
 
 #[tokio::test]
@@ -301,7 +355,10 @@ async fn max_iterations_respected() {
     .await
     .expect("should not error");
 
-    assert_eq!(result.usage.llm_calls, 3);
+    assert_eq!(
+        result.usage.llm_calls, 3,
+        "should stop after max_tool_iterations=3 LLM calls"
+    );
 }
 
 #[tokio::test]
@@ -328,16 +385,34 @@ async fn tool_error_captured() {
     .await
     .expect("execute should succeed despite tool error");
 
-    assert_eq!(result.tool_calls.len(), 1);
-    assert!(result.tool_calls[0].is_error);
-    assert_eq!(result.tool_calls[0].result.as_deref(), Some("tool failed"));
-    assert_eq!(result.content, "Recovered");
+    assert_eq!(
+        result.tool_calls.len(),
+        1,
+        "should have recorded one tool call even when it errored"
+    );
+    assert!(
+        result.tool_calls[0].is_error,
+        "tool call should be marked as an error"
+    );
+    assert_eq!(
+        result.tool_calls[0].result.as_deref(),
+        Some("tool failed"),
+        "tool error message should be captured in result"
+    );
+    assert_eq!(
+        result.content, "Recovered",
+        "final response content should reflect recovery after tool error"
+    );
 }
 
 #[test]
 fn signal_classification_conversation() {
     let signals = classify_signals(&[], "Hello", false, false);
-    assert_eq!(signals, vec![InteractionSignal::Conversation]);
+    assert_eq!(
+        signals,
+        vec![InteractionSignal::Conversation],
+        "no tool calls and plain text should produce only Conversation signal"
+    );
 }
 
 #[test]
@@ -351,8 +426,14 @@ fn signal_classification_code() {
         duration_ms: 10,
     }];
     let signals = classify_signals(&calls, "", false, false);
-    assert!(signals.contains(&InteractionSignal::ToolExecution));
-    assert!(signals.contains(&InteractionSignal::CodeGeneration));
+    assert!(
+        signals.contains(&InteractionSignal::ToolExecution),
+        "write tool call should produce ToolExecution signal"
+    );
+    assert!(
+        signals.contains(&InteractionSignal::CodeGeneration),
+        "write tool call should produce CodeGeneration signal"
+    );
 }
 
 #[test]
@@ -366,8 +447,14 @@ fn signal_classification_research() {
         duration_ms: 10,
     }];
     let signals = classify_signals(&calls, "", false, false);
-    assert!(signals.contains(&InteractionSignal::ToolExecution));
-    assert!(signals.contains(&InteractionSignal::Research));
+    assert!(
+        signals.contains(&InteractionSignal::ToolExecution),
+        "web_search tool call should produce ToolExecution signal"
+    );
+    assert!(
+        signals.contains(&InteractionSignal::Research),
+        "web_search tool call should produce Research signal"
+    );
 }
 
 #[test]
@@ -381,8 +468,14 @@ fn signal_classification_error_recovery() {
         duration_ms: 10,
     }];
     let signals = classify_signals(&calls, "", false, false);
-    assert!(signals.contains(&InteractionSignal::ToolExecution));
-    assert!(signals.contains(&InteractionSignal::ErrorRecovery));
+    assert!(
+        signals.contains(&InteractionSignal::ToolExecution),
+        "error tool call should produce ToolExecution signal"
+    );
+    assert!(
+        signals.contains(&InteractionSignal::ErrorRecovery),
+        "failed tool call should produce ErrorRecovery signal"
+    );
 }
 
 #[tokio::test]
@@ -410,10 +503,23 @@ async fn usage_accumulates_across_iterations() {
     .expect("execute");
 
     // First call: 80 input + 30 output, second call: 100 input + 50 output
-    assert_eq!(result.usage.input_tokens, 180);
-    assert_eq!(result.usage.output_tokens, 80);
-    assert_eq!(result.usage.llm_calls, 2);
-    assert_eq!(result.usage.total_tokens(), 260);
+    assert_eq!(
+        result.usage.input_tokens, 180,
+        "input tokens should be summed across both LLM calls (80 + 100)"
+    );
+    assert_eq!(
+        result.usage.output_tokens, 80,
+        "output tokens should be summed across both LLM calls (30 + 50)"
+    );
+    assert_eq!(
+        result.usage.llm_calls, 2,
+        "one tool iteration should produce exactly two LLM calls"
+    );
+    assert_eq!(
+        result.usage.total_tokens(),
+        260,
+        "total tokens should equal sum of all input and output tokens (180 + 80)"
+    );
 }
 
 #[tokio::test]
@@ -499,13 +605,20 @@ async fn text_response_no_tools() {
     .expect("execute");
 
     assert!(result.tool_calls.is_empty(), "no tool calls expected");
-    assert_eq!(result.content, "just text");
+    assert_eq!(
+        result.content, "just text",
+        "response content should match mock text"
+    );
 }
 
 #[test]
 fn classify_signals_conversation_when_no_tools() {
     let signals = classify_signals(&[], "some text", false, false);
-    assert_eq!(signals, vec![InteractionSignal::Conversation]);
+    assert_eq!(
+        signals,
+        vec![InteractionSignal::Conversation],
+        "no tool calls and plain text should produce only Conversation signal"
+    );
 }
 
 #[test]
@@ -562,10 +675,22 @@ fn classify_signals_server_code_execution() {
 #[test]
 fn classify_signals_both_server_tools() {
     let signals = classify_signals(&[], "", true, true);
-    assert!(signals.contains(&InteractionSignal::ToolExecution));
-    assert!(signals.contains(&InteractionSignal::Research));
-    assert!(signals.contains(&InteractionSignal::CodeGeneration));
-    assert!(!signals.contains(&InteractionSignal::Conversation));
+    assert!(
+        signals.contains(&InteractionSignal::ToolExecution),
+        "both server tools should produce ToolExecution signal"
+    );
+    assert!(
+        signals.contains(&InteractionSignal::Research),
+        "server web search should produce Research signal"
+    );
+    assert!(
+        signals.contains(&InteractionSignal::CodeGeneration),
+        "server code execution should produce CodeGeneration signal"
+    );
+    assert!(
+        !signals.contains(&InteractionSignal::Conversation),
+        "should not produce Conversation signal when server tools were used"
+    );
 }
 
 // --- Streaming Tests ---
@@ -593,8 +718,14 @@ async fn streaming_falls_back_to_non_streaming_for_mock() {
     .await
     .expect("execute_streaming");
 
-    assert_eq!(result.content, "Hello streaming!");
-    assert_eq!(result.usage.llm_calls, 1);
+    assert_eq!(
+        result.content, "Hello streaming!",
+        "streaming response content should match mock text"
+    );
+    assert_eq!(
+        result.usage.llm_calls, 1,
+        "single text response should use exactly one LLM call"
+    );
 
     // MockProvider doesn't support streaming, so no LlmDelta events
     drop(tx);
@@ -630,8 +761,15 @@ async fn streaming_tool_events_emitted() {
     .await
     .expect("execute_streaming");
 
-    assert_eq!(result.content, "Done!");
-    assert_eq!(result.tool_calls.len(), 1);
+    assert_eq!(
+        result.content, "Done!",
+        "streaming final response content should match mock text"
+    );
+    assert_eq!(
+        result.tool_calls.len(),
+        1,
+        "streaming execute should record one tool call"
+    );
 
     // Even with mock (non-streaming) provider, tool events should be emitted
     drop(tx);
@@ -648,8 +786,14 @@ async fn streaming_tool_events_emitted() {
     // Falls back to non-streaming execute(), no tool events via channel
     // (tool events only come from dispatch_tools_streaming, which requires
     //  a streaming provider to be found)
-    assert_eq!(tool_start_count, 0);
-    assert_eq!(tool_result_count, 0);
+    assert_eq!(
+        tool_start_count, 0,
+        "mock provider falls back to non-streaming so no ToolStart events should be emitted"
+    );
+    assert_eq!(
+        tool_result_count, 0,
+        "mock provider falls back to non-streaming so no ToolResult events should be emitted"
+    );
 }
 
 // --- Edge case tests ---
@@ -673,9 +817,18 @@ async fn empty_text_response() {
     .await
     .expect("execute");
 
-    assert_eq!(result.content, "");
-    assert_eq!(result.usage.llm_calls, 1);
-    assert!(result.signals.contains(&InteractionSignal::Conversation));
+    assert_eq!(
+        result.content, "",
+        "empty text response should produce empty content string"
+    );
+    assert_eq!(
+        result.usage.llm_calls, 1,
+        "empty text response should still use exactly one LLM call"
+    );
+    assert!(
+        result.signals.contains(&InteractionSignal::Conversation),
+        "empty text response should still produce Conversation signal"
+    );
 }
 
 #[tokio::test]
@@ -721,8 +874,14 @@ async fn thinking_only_response() {
     .await
     .expect("execute");
 
-    assert_eq!(result.content, "Here's the answer.");
-    assert_eq!(result.usage.llm_calls, 1);
+    assert_eq!(
+        result.content, "Here's the answer.",
+        "response should contain only the text block, not the thinking block"
+    );
+    assert_eq!(
+        result.usage.llm_calls, 1,
+        "thinking response should use exactly one LLM call"
+    );
 }
 
 #[tokio::test]
@@ -740,7 +899,10 @@ async fn no_provider_for_model_returns_error() {
     )
     .await;
 
-    assert!(err.is_err());
+    assert!(
+        err.is_err(),
+        "execute with no matching provider should return an error"
+    );
     let msg = err.unwrap_err().to_string();
     assert!(msg.contains("no provider"), "got: {msg}");
 }
@@ -750,14 +912,18 @@ fn simple_hash_deterministic() {
     let v = serde_json::json!({"key": "value"});
     let h1 = simple_hash(&v);
     let h2 = simple_hash(&v);
-    assert_eq!(h1, h2);
+    assert_eq!(h1, h2, "same input should always produce the same hash");
 }
 
 #[test]
 fn simple_hash_different_for_different_inputs() {
     let v1 = serde_json::json!({"key": "value1"});
     let v2 = serde_json::json!({"key": "value2"});
-    assert_ne!(simple_hash(&v1), simple_hash(&v2));
+    assert_ne!(
+        simple_hash(&v1),
+        simple_hash(&v2),
+        "different inputs should produce different hashes"
+    );
 }
 
 #[test]
@@ -771,7 +937,10 @@ fn classify_signals_edit_is_code_generation() {
         duration_ms: 10,
     }];
     let signals = classify_signals(&calls, "", false, false);
-    assert!(signals.contains(&InteractionSignal::CodeGeneration));
+    assert!(
+        signals.contains(&InteractionSignal::CodeGeneration),
+        "edit tool call should produce CodeGeneration signal"
+    );
 }
 
 #[test]
@@ -785,7 +954,10 @@ fn classify_signals_web_fetch_is_research() {
         duration_ms: 10,
     }];
     let signals = classify_signals(&calls, "", false, false);
-    assert!(signals.contains(&InteractionSignal::Research));
+    assert!(
+        signals.contains(&InteractionSignal::Research),
+        "web_fetch tool call should produce Research signal"
+    );
 }
 
 #[test]
@@ -809,10 +981,22 @@ fn classify_signals_multiple_flags() {
         },
     ];
     let signals = classify_signals(&calls, "", false, false);
-    assert!(signals.contains(&InteractionSignal::ToolExecution));
-    assert!(signals.contains(&InteractionSignal::CodeGeneration));
-    assert!(signals.contains(&InteractionSignal::Research));
-    assert!(signals.contains(&InteractionSignal::ErrorRecovery));
+    assert!(
+        signals.contains(&InteractionSignal::ToolExecution),
+        "mixed tool calls should produce ToolExecution signal"
+    );
+    assert!(
+        signals.contains(&InteractionSignal::CodeGeneration),
+        "write tool call should produce CodeGeneration signal"
+    );
+    assert!(
+        signals.contains(&InteractionSignal::Research),
+        "web_search tool call should produce Research signal"
+    );
+    assert!(
+        signals.contains(&InteractionSignal::ErrorRecovery),
+        "failed tool call should produce ErrorRecovery signal"
+    );
 }
 
 #[tokio::test]
@@ -843,7 +1027,10 @@ async fn max_iterations_one_exits_immediately() {
     .await
     .expect("should succeed");
 
-    assert_eq!(result.usage.llm_calls, 1);
+    assert_eq!(
+        result.usage.llm_calls, 1,
+        "with max_tool_iterations=1, should exit after the first LLM call"
+    );
 }
 
 #[test]
@@ -866,7 +1053,19 @@ fn build_messages_maps_roles_correctly() {
         },
     ];
     let built = build_messages(&msgs);
-    assert_eq!(built[0].role, Role::User);
-    assert_eq!(built[1].role, Role::Assistant);
-    assert_eq!(built[2].role, Role::User); // unknown maps to User
+    assert_eq!(
+        built[0].role,
+        Role::User,
+        "user role should map to Role::User"
+    );
+    assert_eq!(
+        built[1].role,
+        Role::Assistant,
+        "assistant role should map to Role::Assistant"
+    );
+    assert_eq!(
+        built[2].role,
+        Role::User,
+        "unknown role should fall back to Role::User"
+    ); // unknown maps to User
 }

--- a/crates/organon/src/builtins/filesystem_tests.rs
+++ b/crates/organon/src/builtins/filesystem_tests.rs
@@ -37,8 +37,11 @@ async fn grep_finds_pattern() {
     let ctx = test_ctx(dir.path());
     let input = tool_input("grep", serde_json::json!({ "pattern": "println" }));
     let result = GrepExecutor.execute(&input, &ctx).await.expect("exec");
-    assert!(!result.is_error);
-    assert!(result.content.text_summary().contains("println"));
+    assert!(!result.is_error, "grep should succeed without error");
+    assert!(
+        result.content.text_summary().contains("println"),
+        "grep output should contain the matched pattern"
+    );
 }
 
 #[tokio::test]
@@ -53,10 +56,19 @@ async fn grep_with_glob_filter() {
         serde_json::json!({ "pattern": "func", "glob": "*.rs" }),
     );
     let result = GrepExecutor.execute(&input, &ctx).await.expect("exec");
-    assert!(!result.is_error);
+    assert!(
+        !result.is_error,
+        "grep with glob filter should succeed without error"
+    );
     let text = result.content.text_summary();
-    assert!(text.contains("rust_func"));
-    assert!(!text.contains("tsFunc"));
+    assert!(
+        text.contains("rust_func"),
+        "grep should find rust_func in .rs file"
+    );
+    assert!(
+        !text.contains("tsFunc"),
+        "grep should not find tsFunc when filtering to .rs files"
+    );
 }
 
 #[tokio::test]
@@ -70,10 +82,19 @@ async fn grep_case_insensitive() {
         serde_json::json!({ "pattern": "HELLO", "caseSensitive": false }),
     );
     let result = GrepExecutor.execute(&input, &ctx).await.expect("exec");
-    assert!(!result.is_error);
+    assert!(
+        !result.is_error,
+        "case-insensitive grep should succeed without error"
+    );
     let text = result.content.text_summary();
-    assert!(text.contains("Hello"));
-    assert!(text.contains("hello"));
+    assert!(
+        text.contains("Hello"),
+        "case-insensitive grep should match Hello"
+    );
+    assert!(
+        text.contains("hello"),
+        "case-insensitive grep should match hello"
+    );
 }
 
 #[tokio::test]
@@ -84,8 +105,15 @@ async fn grep_no_matches_not_error() {
     let ctx = test_ctx(dir.path());
     let input = tool_input("grep", serde_json::json!({ "pattern": "zzzznotfound" }));
     let result = GrepExecutor.execute(&input, &ctx).await.expect("exec");
-    assert!(!result.is_error);
-    assert_eq!(result.content.text_summary(), "No matches found.");
+    assert!(
+        !result.is_error,
+        "grep with no matches should not return an error"
+    );
+    assert_eq!(
+        result.content.text_summary(),
+        "No matches found.",
+        "grep with no matches should return the standard no-matches message"
+    );
 }
 
 #[tokio::test]
@@ -97,9 +125,12 @@ async fn find_locates_files() {
     let ctx = test_ctx(dir.path());
     let input = tool_input("find", serde_json::json!({ "pattern": "app" }));
     let result = FindExecutor.execute(&input, &ctx).await.expect("exec");
-    assert!(!result.is_error);
+    assert!(!result.is_error, "find should succeed without error");
     let text = result.content.text_summary();
-    assert!(text.contains("app"));
+    assert!(
+        text.contains("app"),
+        "find output should contain files matching the pattern"
+    );
 }
 
 #[tokio::test]
@@ -111,9 +142,15 @@ async fn find_type_filter() {
     let ctx = test_ctx(dir.path());
     let input = tool_input("find", serde_json::json!({ "pattern": ".", "type": "d" }));
     let result = FindExecutor.execute(&input, &ctx).await.expect("exec");
-    assert!(!result.is_error);
+    assert!(
+        !result.is_error,
+        "find with type filter should succeed without error"
+    );
     let text = result.content.text_summary();
-    assert!(text.contains("subdir"));
+    assert!(
+        text.contains("subdir"),
+        "find with directory type filter should include the subdirectory"
+    );
 }
 
 #[tokio::test]
@@ -130,10 +167,19 @@ async fn find_max_depth() {
         serde_json::json!({ "pattern": "txt", "maxDepth": 1 }),
     );
     let result = FindExecutor.execute(&input, &ctx).await.expect("exec");
-    assert!(!result.is_error);
+    assert!(
+        !result.is_error,
+        "find with max depth should succeed without error"
+    );
     let text = result.content.text_summary();
-    assert!(text.contains("shallow"));
-    assert!(!text.contains("deep"));
+    assert!(
+        text.contains("shallow"),
+        "find should include shallow file within max depth"
+    );
+    assert!(
+        !text.contains("deep"),
+        "find should not include deeply nested file beyond max depth"
+    );
 }
 
 #[tokio::test]
@@ -145,10 +191,16 @@ async fn ls_lists_directory() {
     let ctx = test_ctx(dir.path());
     let input = tool_input("ls", serde_json::json!({}));
     let result = LsExecutor.execute(&input, &ctx).await.expect("exec");
-    assert!(!result.is_error);
+    assert!(!result.is_error, "ls should succeed without error");
     let text = result.content.text_summary();
-    assert!(text.contains("subdir/"));
-    assert!(text.contains("file.txt"));
+    assert!(
+        text.contains("subdir/"),
+        "ls output should include the subdirectory"
+    );
+    assert!(
+        text.contains("file.txt"),
+        "ls output should include the file"
+    );
 }
 
 #[tokio::test]
@@ -160,10 +212,16 @@ async fn ls_hides_dotfiles() {
     let ctx = test_ctx(dir.path());
     let input = tool_input("ls", serde_json::json!({}));
     let result = LsExecutor.execute(&input, &ctx).await.expect("exec");
-    assert!(!result.is_error);
+    assert!(!result.is_error, "ls should succeed without error");
     let text = result.content.text_summary();
-    assert!(!text.contains(".hidden"));
-    assert!(text.contains("visible.txt"));
+    assert!(
+        !text.contains(".hidden"),
+        "ls should not show dotfiles by default"
+    );
+    assert!(
+        text.contains("visible.txt"),
+        "ls should show non-hidden files"
+    );
 }
 
 #[tokio::test]
@@ -175,10 +233,19 @@ async fn ls_shows_dotfiles_with_all() {
     let ctx = test_ctx(dir.path());
     let input = tool_input("ls", serde_json::json!({ "all": true }));
     let result = LsExecutor.execute(&input, &ctx).await.expect("exec");
-    assert!(!result.is_error);
+    assert!(
+        !result.is_error,
+        "ls with all flag should succeed without error"
+    );
     let text = result.content.text_summary();
-    assert!(text.contains(".hidden"));
-    assert!(text.contains("visible.txt"));
+    assert!(
+        text.contains(".hidden"),
+        "ls with all flag should show dotfiles"
+    );
+    assert!(
+        text.contains("visible.txt"),
+        "ls with all flag should still show non-hidden files"
+    );
 }
 
 #[tokio::test]
@@ -211,7 +278,10 @@ async fn path_validation_rejects_outside_roots() {
         .execute(&input, &ctx)
         .await
         .expect_err("should reject outside root");
-    assert!(err.to_string().contains("outside allowed roots"));
+    assert!(
+        err.to_string().contains("outside allowed roots"),
+        "error should indicate path is outside allowed roots"
+    );
 }
 
 #[tokio::test]
@@ -234,7 +304,10 @@ async fn test_grep_when_pattern_argument_missing_returns_error() {
         .execute(&input, &ctx)
         .await
         .expect_err("missing pattern should error");
-    assert!(err.to_string().contains("missing or invalid field"));
+    assert!(
+        err.to_string().contains("missing or invalid field"),
+        "error should indicate the pattern field is missing or invalid"
+    );
 }
 
 #[tokio::test]
@@ -246,7 +319,10 @@ async fn test_find_when_pattern_argument_missing_returns_error() {
         .execute(&input, &ctx)
         .await
         .expect_err("missing pattern should error");
-    assert!(err.to_string().contains("missing or invalid field"));
+    assert!(
+        err.to_string().contains("missing or invalid field"),
+        "error should indicate the pattern field is missing or invalid"
+    );
 }
 
 #[tokio::test]
@@ -264,7 +340,10 @@ async fn test_grep_max_results_limits_output_lines() {
         serde_json::json!({ "pattern": "match", "maxResults": 5 }),
     );
     let result = GrepExecutor.execute(&input, &ctx).await.expect("exec");
-    assert!(!result.is_error);
+    assert!(
+        !result.is_error,
+        "grep with maxResults should succeed without error"
+    );
     let text = result.content.text_summary();
     let match_count = text.lines().count();
     assert!(
@@ -284,7 +363,10 @@ async fn test_grep_case_sensitive_does_not_match_wrong_case() {
         serde_json::json!({ "pattern": "hello", "caseSensitive": true }),
     );
     let result = GrepExecutor.execute(&input, &ctx).await.expect("exec");
-    assert!(!result.is_error);
+    assert!(
+        !result.is_error,
+        "case-sensitive grep should succeed without error"
+    );
     assert_eq!(
         result.content.text_summary(),
         "No matches found.",
@@ -304,7 +386,10 @@ async fn test_grep_returns_error_result_for_invalid_path_outside_roots() {
         .execute(&input, &ctx)
         .await
         .expect_err("outside root should fail");
-    assert!(err.to_string().contains("outside allowed roots"));
+    assert!(
+        err.to_string().contains("outside allowed roots"),
+        "error should indicate path is outside allowed roots"
+    );
 }
 
 #[tokio::test]
@@ -313,8 +398,15 @@ async fn test_find_empty_results_returns_not_error_message() {
     let ctx = test_ctx(dir.path());
     let input = tool_input("find", serde_json::json!({ "pattern": "zzz_never_exists" }));
     let result = FindExecutor.execute(&input, &ctx).await.expect("exec");
-    assert!(!result.is_error);
-    assert_eq!(result.content.text_summary(), "No files found.");
+    assert!(
+        !result.is_error,
+        "find with no matches should not return an error"
+    );
+    assert_eq!(
+        result.content.text_summary(),
+        "No files found.",
+        "find with no matches should return the standard no-files message"
+    );
 }
 
 #[tokio::test]
@@ -327,7 +419,10 @@ async fn test_find_glob_extension_filter_matches_correctly() {
     let ctx = test_ctx(dir.path());
     let input = tool_input("find", serde_json::json!({ "pattern": "*.rs" }));
     let result = FindExecutor.execute(&input, &ctx).await.expect("exec");
-    assert!(!result.is_error);
+    assert!(
+        !result.is_error,
+        "find with glob extension filter should succeed without error"
+    );
     let text = result.content.text_summary();
     assert!(text.contains(".rs"), "should find .rs files");
 }
@@ -345,7 +440,10 @@ async fn test_find_max_results_limits_output() {
         serde_json::json!({ "pattern": "file", "maxResults": 3 }),
     );
     let result = FindExecutor.execute(&input, &ctx).await.expect("exec");
-    assert!(!result.is_error);
+    assert!(
+        !result.is_error,
+        "find with maxResults should succeed without error"
+    );
     let text = result.content.text_summary();
     let line_count = text.lines().count();
     assert!(
@@ -363,12 +461,16 @@ async fn test_ls_nonexistent_directory_returns_error_result() {
         serde_json::json!({ "path": dir.path().join("ghost").to_string_lossy().as_ref() }),
     );
     let result = LsExecutor.execute(&input, &ctx).await.expect("exec");
-    assert!(result.is_error);
+    assert!(
+        result.is_error,
+        "ls on nonexistent directory should return an error result"
+    );
     assert!(
         result
             .content
             .text_summary()
-            .contains("cannot read directory")
+            .contains("cannot read directory"),
+        "error message should indicate the directory cannot be read"
     );
 }
 
@@ -378,8 +480,15 @@ async fn test_ls_empty_directory_returns_descriptive_message() {
     let ctx = test_ctx(dir.path());
     let input = tool_input("ls", serde_json::json!({}));
     let result = LsExecutor.execute(&input, &ctx).await.expect("exec");
-    assert!(!result.is_error);
-    assert_eq!(result.content.text_summary(), "Directory is empty.");
+    assert!(
+        !result.is_error,
+        "ls on empty directory should succeed without error"
+    );
+    assert_eq!(
+        result.content.text_summary(),
+        "Directory is empty.",
+        "ls on empty directory should return the standard empty message"
+    );
 }
 
 #[tokio::test]
@@ -389,7 +498,7 @@ async fn test_ls_output_includes_file_size() {
     let ctx = test_ctx(dir.path());
     let input = tool_input("ls", serde_json::json!({}));
     let result = LsExecutor.execute(&input, &ctx).await.expect("exec");
-    assert!(!result.is_error);
+    assert!(!result.is_error, "ls should succeed without error");
     let text = result.content.text_summary();
     assert!(text.contains('5'), "should show file size 5");
 }
@@ -401,7 +510,7 @@ async fn test_ls_output_includes_date_column() {
     let ctx = test_ctx(dir.path());
     let input = tool_input("ls", serde_json::json!({}));
     let result = LsExecutor.execute(&input, &ctx).await.expect("exec");
-    assert!(!result.is_error);
+    assert!(!result.is_error, "ls should succeed without error");
     let text = result.content.text_summary();
     // Date format: YYYY-MM-DD HH:MM
     assert!(text.contains('-'), "should show date with hyphens");
@@ -415,61 +524,104 @@ async fn test_ls_uses_workspace_when_path_not_specified() {
     let ctx = test_ctx(dir.path());
     let input = tool_input("ls", serde_json::json!({}));
     let result = LsExecutor.execute(&input, &ctx).await.expect("exec");
-    assert!(!result.is_error);
-    assert!(result.content.text_summary().contains("sentinel.txt"));
+    assert!(
+        !result.is_error,
+        "ls without explicit path should succeed without error"
+    );
+    assert!(
+        result.content.text_summary().contains("sentinel.txt"),
+        "ls without explicit path should list workspace contents"
+    );
 }
 
 #[test]
 fn test_is_glob_pattern_detects_star() {
-    assert!(is_glob_pattern("*.rs"));
+    assert!(
+        is_glob_pattern("*.rs"),
+        "pattern with star should be detected as a glob"
+    );
 }
 
 #[test]
 fn test_is_glob_pattern_detects_question_mark() {
-    assert!(is_glob_pattern("file?.txt"));
+    assert!(
+        is_glob_pattern("file?.txt"),
+        "pattern with question mark should be detected as a glob"
+    );
 }
 
 #[test]
 fn test_is_glob_pattern_detects_brackets() {
-    assert!(is_glob_pattern("[abc]def"));
+    assert!(
+        is_glob_pattern("[abc]def"),
+        "pattern with brackets should be detected as a glob"
+    );
 }
 
 #[test]
 fn test_is_glob_pattern_detects_braces() {
-    assert!(is_glob_pattern("{foo,bar}"));
+    assert!(
+        is_glob_pattern("{foo,bar}"),
+        "pattern with braces should be detected as a glob"
+    );
 }
 
 #[test]
 fn test_is_glob_pattern_returns_false_for_plain_word() {
-    assert!(!is_glob_pattern("hello"));
-    assert!(!is_glob_pattern("file.txt"));
-    assert!(!is_glob_pattern("some_identifier"));
+    assert!(
+        !is_glob_pattern("hello"),
+        "plain word should not be detected as a glob"
+    );
+    assert!(
+        !is_glob_pattern("file.txt"),
+        "plain filename should not be detected as a glob"
+    );
+    assert!(
+        !is_glob_pattern("some_identifier"),
+        "plain identifier should not be detected as a glob"
+    );
 }
 
 #[test]
 fn test_days_to_ymd_known_epoch_gives_1970_01_01() {
     let (y, m, d) = days_to_ymd(0);
-    assert_eq!((y, m, d), (1970, 1, 1));
+    assert_eq!(
+        (y, m, d),
+        (1970, 1, 1),
+        "day 0 should correspond to the Unix epoch 1970-01-01"
+    );
 }
 
 #[test]
 fn test_days_to_ymd_365_days_gives_1971_01_01() {
     // 1970 was not a leap year, so day 365 = Jan 1, 1971
     let (y, m, d) = days_to_ymd(365);
-    assert_eq!((y, m, d), (1971, 1, 1));
+    assert_eq!(
+        (y, m, d),
+        (1971, 1, 1),
+        "day 365 after a non-leap year should be 1971-01-01"
+    );
 }
 
 #[test]
 fn test_days_to_ymd_known_date_2000_01_01() {
     // Days from 1970-01-01 to 2000-01-01 = 30 * 365 + 8 leap days = 10957
     let (y, m, d) = days_to_ymd(10957);
-    assert_eq!((y, m, d), (2000, 1, 1));
+    assert_eq!(
+        (y, m, d),
+        (2000, 1, 1),
+        "day 10957 from epoch should correspond to 2000-01-01"
+    );
 }
 
 #[test]
 fn test_truncate_output_short_string_returned_unchanged() {
     let short = "hello world".to_owned();
-    assert_eq!(truncate_output(short.clone()), short);
+    assert_eq!(
+        truncate_output(short.clone()),
+        short,
+        "short string should be returned unchanged by truncate_output"
+    );
 }
 
 #[test]
@@ -499,7 +651,10 @@ fn test_grep_def_has_pattern_as_required() {
     register(&mut reg).expect("register");
     let tn = ToolName::new("grep").expect("valid");
     let def = reg.get_def(&tn).expect("grep registered");
-    assert!(def.input_schema.required.contains(&"pattern".to_owned()));
+    assert!(
+        def.input_schema.required.contains(&"pattern".to_owned()),
+        "grep tool definition should require the pattern field"
+    );
 }
 
 #[test]
@@ -508,7 +663,10 @@ fn test_find_def_has_pattern_as_required() {
     register(&mut reg).expect("register");
     let tn = ToolName::new("find").expect("valid");
     let def = reg.get_def(&tn).expect("find registered");
-    assert!(def.input_schema.required.contains(&"pattern".to_owned()));
+    assert!(
+        def.input_schema.required.contains(&"pattern".to_owned()),
+        "find tool definition should require the pattern field"
+    );
 }
 
 #[test]
@@ -531,6 +689,12 @@ fn test_find_def_type_field_has_enum_values() {
     let def = reg.get_def(&tn).expect("find registered");
     let type_prop = def.input_schema.properties.get("type").expect("type prop");
     let enum_vals = type_prop.enum_values.as_ref().expect("enum values");
-    assert!(enum_vals.contains(&"f".to_owned()));
-    assert!(enum_vals.contains(&"d".to_owned()));
+    assert!(
+        enum_vals.contains(&"f".to_owned()),
+        "find type field should include 'f' for file"
+    );
+    assert!(
+        enum_vals.contains(&"d".to_owned()),
+        "find type field should include 'd' for directory"
+    );
 }

--- a/crates/organon/src/builtins/planning_tests.rs
+++ b/crates/organon/src/builtins/planning_tests.rs
@@ -181,7 +181,11 @@ async fn register_planning_tools() {
     let mut reg = ToolRegistry::new();
     super::register(&mut reg).expect("register");
     let planning_tools = reg.definitions_for_category(ToolCategory::Planning);
-    assert_eq!(planning_tools.len(), 10);
+    assert_eq!(
+        planning_tools.len(),
+        10,
+        "expected 10 planning tools to be registered"
+    );
 }
 
 #[tokio::test]
@@ -203,8 +207,14 @@ async fn plan_create_missing_service_returns_error() {
         arguments: serde_json::json!({"name": "test", "description": "test project"}),
     };
     let result = reg.execute(&input, &test_ctx()).await.expect("execute");
-    assert!(result.is_error);
-    assert!(result.content.text_summary().contains("not configured"));
+    assert!(
+        result.is_error,
+        "plan_create without a planning service should return an error"
+    );
+    assert!(
+        result.content.text_summary().contains("not configured"),
+        "error message should indicate service is not configured"
+    );
 }
 
 #[tokio::test]
@@ -219,8 +229,14 @@ async fn plan_create_success() {
         arguments: serde_json::json!({"name": "my project", "description": "build a thing"}),
     };
     let result = reg.execute(&input, &ctx).await.expect("execute");
-    assert!(!result.is_error);
-    assert!(result.content.text_summary().contains("Created"));
+    assert!(
+        !result.is_error,
+        "plan_create should succeed when service is available"
+    );
+    assert!(
+        result.content.text_summary().contains("Created"),
+        "response should include the Created state"
+    );
 }
 
 #[tokio::test]
@@ -239,8 +255,14 @@ async fn plan_create_error_propagates() {
         arguments: serde_json::json!({"name": "test", "description": "test"}),
     };
     let result = reg.execute(&input, &ctx).await.expect("execute");
-    assert!(result.is_error);
-    assert!(result.content.text_summary().contains("already exists"));
+    assert!(
+        result.is_error,
+        "plan_create should return an error when the service returns a failure"
+    );
+    assert!(
+        result.content.text_summary().contains("already exists"),
+        "error message should propagate the underlying cause"
+    );
 }
 
 #[tokio::test]
@@ -256,11 +278,17 @@ async fn plan_research_skip_dispatches_correctly() {
         arguments: serde_json::json!({"project_id": "01J0000000000000000000000", "skip": true}),
     };
     let result = reg.execute(&input, &ctx).await.expect("execute");
-    assert!(!result.is_error);
+    assert!(
+        !result.is_error,
+        "plan_research with skip=true should succeed"
+    );
 
     let calls = mock_ref.transition_calls.lock().unwrap();
-    assert_eq!(calls.len(), 1);
-    assert_eq!(calls[0].1, "skip_research");
+    assert_eq!(calls.len(), 1, "expected exactly one transition call");
+    assert_eq!(
+        calls[0].1, "skip_research",
+        "skip=true should dispatch the skip_research transition"
+    );
 }
 
 #[tokio::test]
@@ -276,10 +304,16 @@ async fn plan_research_no_skip_dispatches_start() {
         arguments: serde_json::json!({"project_id": "01J0000000000000000000000"}),
     };
     let result = reg.execute(&input, &ctx).await.expect("execute");
-    assert!(!result.is_error);
+    assert!(
+        !result.is_error,
+        "plan_research without skip should succeed"
+    );
 
     let calls = mock_ref.transition_calls.lock().unwrap();
-    assert_eq!(calls[0].1, "start_research");
+    assert_eq!(
+        calls[0].1, "start_research",
+        "omitting skip should dispatch the start_research transition"
+    );
 }
 
 #[tokio::test]
@@ -300,16 +334,25 @@ async fn plan_roadmap_add_phase_calls_add_phase() {
         }),
     };
     let result = reg.execute(&input, &ctx).await.expect("execute");
-    assert!(!result.is_error);
+    assert!(!result.is_error, "plan_roadmap add_phase should succeed");
 
     let calls = mock_ref.add_phase_calls.lock().unwrap();
-    assert_eq!(calls.len(), 1);
-    assert_eq!(calls[0].1, "Foundation");
-    assert_eq!(calls[0].2, "Set up core infrastructure");
+    assert_eq!(calls.len(), 1, "expected exactly one add_phase call");
+    assert_eq!(
+        calls[0].1, "Foundation",
+        "phase name should be passed through to the service"
+    );
+    assert_eq!(
+        calls[0].2, "Set up core infrastructure",
+        "phase goal should be passed through to the service"
+    );
 
     // transition_project should NOT have been called
     let t_calls = mock_ref.transition_calls.lock().unwrap();
-    assert!(t_calls.is_empty());
+    assert!(
+        t_calls.is_empty(),
+        "add_phase should not trigger any state transition"
+    );
 }
 
 #[tokio::test]
@@ -324,8 +367,14 @@ async fn plan_status_returns_project_json() {
         arguments: serde_json::json!({"project_id": "01J0000000000000000000000"}),
     };
     let result = reg.execute(&input, &ctx).await.expect("execute");
-    assert!(!result.is_error);
-    assert!(result.content.text_summary().contains("Created"));
+    assert!(
+        !result.is_error,
+        "plan_status should succeed and return project data"
+    );
+    assert!(
+        result.content.text_summary().contains("Created"),
+        "response should include the project state"
+    );
 }
 
 #[tokio::test]
@@ -346,13 +395,14 @@ async fn plan_step_complete_dispatches() {
         }),
     };
     let result = reg.execute(&input, &ctx).await.expect("execute");
-    assert!(!result.is_error);
+    assert!(!result.is_error, "plan_step_complete should succeed");
 
     let calls = mock_ref.complete_plan_calls.lock().unwrap();
-    assert_eq!(calls.len(), 1);
+    assert_eq!(calls.len(), 1, "expected exactly one complete_plan call");
     assert_eq!(
         calls[0],
-        ("proj1".to_owned(), "phase1".to_owned(), "plan1".to_owned())
+        ("proj1".to_owned(), "phase1".to_owned(), "plan1".to_owned()),
+        "project_id, phase_id, and plan_id should be forwarded correctly to the service"
     );
 }
 
@@ -374,11 +424,14 @@ async fn plan_step_fail_dispatches() {
         }),
     };
     let result = reg.execute(&input, &ctx).await.expect("execute");
-    assert!(!result.is_error);
+    assert!(!result.is_error, "plan_step_fail should succeed");
 
     let calls = mock_ref.fail_plan_calls.lock().unwrap();
-    assert_eq!(calls.len(), 1);
-    assert_eq!(calls[0].3, "compilation error");
+    assert_eq!(calls.len(), 1, "expected exactly one fail_plan call");
+    assert_eq!(
+        calls[0].3, "compilation error",
+        "failure reason should be forwarded to the service"
+    );
 }
 
 #[tokio::test]
@@ -398,10 +451,13 @@ async fn plan_verify_revert_dispatches_correctly() {
         }),
     };
     let result = reg.execute(&input, &ctx).await.expect("execute");
-    assert!(!result.is_error);
+    assert!(!result.is_error, "plan_verify revert action should succeed");
 
     let calls = mock_ref.transition_calls.lock().unwrap();
-    assert_eq!(calls[0].1, "revert_to_planning");
+    assert_eq!(
+        calls[0].1, "revert_to_planning",
+        "revert action should dispatch the revert_to_planning transition"
+    );
 }
 
 #[tokio::test]
@@ -453,8 +509,14 @@ async fn unknown_action_returns_error() {
         arguments: serde_json::json!({"project_id": "p1", "action": "invalid_action"}),
     };
     let result = reg.execute(&input, &ctx).await.expect("execute");
-    assert!(result.is_error);
-    assert!(result.content.text_summary().contains("unknown action"));
+    assert!(
+        result.is_error,
+        "plan_requirements with an invalid action should return an error"
+    );
+    assert!(
+        result.content.text_summary().contains("unknown action"),
+        "error message should indicate the action was not recognized"
+    );
 }
 
 #[tokio::test]
@@ -470,11 +532,17 @@ async fn plan_requirements_start_scoping_dispatches() {
         arguments: serde_json::json!({"project_id": "proj1", "action": "start_scoping"}),
     };
     let result = reg.execute(&input, &ctx).await.expect("execute");
-    assert!(!result.is_error);
+    assert!(
+        !result.is_error,
+        "plan_requirements start_scoping should succeed"
+    );
 
     let calls = mock_ref.transition_calls.lock().unwrap();
-    assert_eq!(calls.len(), 1);
-    assert_eq!(calls[0].1, "start_scoping");
+    assert_eq!(calls.len(), 1, "expected exactly one transition call");
+    assert_eq!(
+        calls[0].1, "start_scoping",
+        "start_scoping action should dispatch the start_scoping transition"
+    );
 }
 
 #[tokio::test]
@@ -490,11 +558,17 @@ async fn plan_requirements_complete_dispatches_start_planning() {
         arguments: serde_json::json!({"project_id": "proj1", "action": "complete"}),
     };
     let result = reg.execute(&input, &ctx).await.expect("execute");
-    assert!(!result.is_error);
+    assert!(
+        !result.is_error,
+        "plan_requirements complete action should succeed"
+    );
 
     let calls = mock_ref.transition_calls.lock().unwrap();
-    assert_eq!(calls.len(), 1);
-    assert_eq!(calls[0].1, "start_planning");
+    assert_eq!(calls.len(), 1, "expected exactly one transition call");
+    assert_eq!(
+        calls[0].1, "start_planning",
+        "complete action should advance to the start_planning transition"
+    );
 }
 
 #[tokio::test]
@@ -510,11 +584,17 @@ async fn plan_discuss_complete_dispatches_start_execution() {
         arguments: serde_json::json!({"project_id": "proj1", "action": "complete"}),
     };
     let result = reg.execute(&input, &ctx).await.expect("execute");
-    assert!(!result.is_error);
+    assert!(
+        !result.is_error,
+        "plan_discuss complete action should succeed"
+    );
 
     let calls = mock_ref.transition_calls.lock().unwrap();
-    assert_eq!(calls.len(), 1);
-    assert_eq!(calls[0].1, "start_execution");
+    assert_eq!(calls.len(), 1, "expected exactly one transition call");
+    assert_eq!(
+        calls[0].1, "start_execution",
+        "complete action on plan_discuss should dispatch the start_execution transition"
+    );
 }
 
 #[tokio::test]
@@ -529,8 +609,14 @@ async fn plan_discuss_unknown_action_returns_error() {
         arguments: serde_json::json!({"project_id": "proj1", "action": "invalid"}),
     };
     let result = reg.execute(&input, &ctx).await.expect("execute");
-    assert!(result.is_error);
-    assert!(result.content.text_summary().contains("unknown action"));
+    assert!(
+        result.is_error,
+        "plan_discuss with an invalid action should return an error"
+    );
+    assert!(
+        result.content.text_summary().contains("unknown action"),
+        "error message should indicate the action was not recognized"
+    );
 }
 
 #[tokio::test]
@@ -546,11 +632,17 @@ async fn plan_roadmap_start_discussion_dispatches() {
         arguments: serde_json::json!({"project_id": "proj1", "action": "start_discussion"}),
     };
     let result = reg.execute(&input, &ctx).await.expect("execute");
-    assert!(!result.is_error);
+    assert!(
+        !result.is_error,
+        "plan_roadmap start_discussion action should succeed"
+    );
 
     let calls = mock_ref.transition_calls.lock().unwrap();
-    assert_eq!(calls.len(), 1);
-    assert_eq!(calls[0].1, "start_discussion");
+    assert_eq!(calls.len(), 1, "expected exactly one transition call");
+    assert_eq!(
+        calls[0].1, "start_discussion",
+        "start_discussion action should dispatch the start_discussion transition"
+    );
 }
 
 #[tokio::test]
@@ -566,11 +658,17 @@ async fn plan_roadmap_start_execution_dispatches() {
         arguments: serde_json::json!({"project_id": "proj1", "action": "start_execution"}),
     };
     let result = reg.execute(&input, &ctx).await.expect("execute");
-    assert!(!result.is_error);
+    assert!(
+        !result.is_error,
+        "plan_roadmap start_execution action should succeed"
+    );
 
     let calls = mock_ref.transition_calls.lock().unwrap();
-    assert_eq!(calls.len(), 1);
-    assert_eq!(calls[0].1, "start_execution");
+    assert_eq!(calls.len(), 1, "expected exactly one transition call");
+    assert_eq!(
+        calls[0].1, "start_execution",
+        "start_execution action should dispatch the start_execution transition"
+    );
 }
 
 #[tokio::test]
@@ -586,11 +684,17 @@ async fn plan_verify_complete_dispatches() {
         arguments: serde_json::json!({"project_id": "proj1", "action": "complete"}),
     };
     let result = reg.execute(&input, &ctx).await.expect("execute");
-    assert!(!result.is_error);
+    assert!(
+        !result.is_error,
+        "plan_verify complete action should succeed"
+    );
 
     let calls = mock_ref.transition_calls.lock().unwrap();
-    assert_eq!(calls.len(), 1);
-    assert_eq!(calls[0].1, "complete");
+    assert_eq!(calls.len(), 1, "expected exactly one transition call");
+    assert_eq!(
+        calls[0].1, "complete",
+        "complete action on plan_verify should dispatch the complete transition"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- Added descriptive messages to ~170 bare `assert!()`, `assert_eq!()`, and `assert_ne!()` calls across 7 files (3 of the 10 target files already had messages)
- Messages describe what was expected rather than restating the condition
- No test logic changed; only message parameters added

## Files updated

| File | Asserts fixed |
|------|--------------|
| `crates/mneme/src/query/tests.rs` | 1 (prop_assert) |
| `crates/mneme/src/skills/extract_tests.rs` | 47 |
| `crates/aletheia/src/commands/add_nous.rs` | 31 |
| `crates/nous/src/execute/tests.rs` | 52 |
| `crates/nous/src/bootstrap/bootstrap_tests.rs` | 42 |
| `crates/organon/src/builtins/filesystem_tests.rs` | 42 |
| `crates/organon/src/builtins/planning_tests.rs` | 49 |

Files already compliant (no changes needed):
- `crates/organon/src/builtins/workspace_tests.rs`
- `crates/mneme/src/extract/tests.rs`
- `crates/mneme/src/store/tests.rs`

Partial progress on #1414.

## Observations

- Pre-existing clippy failures in workspace: 113 `expect_used` lint errors in `aletheia-mneme` test code, plus `SecretString`/`SecretBox` type mismatches in `integration-tests` and `pylon` crates. Not related to this PR.

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo test -p aletheia-mneme -p aletheia-organon -p aletheia -p aletheia-nous` all pass
- [x] Zero bare asserts remain in all 10 target files
- [x] No test logic changed (only message parameters added)

🤖 Generated with [Claude Code](https://claude.com/claude-code)