### PR TITLE
727: Add messages to bare assert calls in mneme extract, skills, store

### DIFF
--- a/crates/mneme/src/skills/extract_tests.rs
+++ b/crates/mneme/src/skills/extract_tests.rs
@@ -594,7 +594,8 @@ fn dedup_similar_tools_discard_candidate() {
         result,
         DedupOutcome::DiscardCandidate {
             existing_id: "sk-1".to_owned()
-        }
+        },
+        "lower-confidence candidate with identical tools should be discarded in favor of existing"
     );
 }
 
@@ -617,7 +618,8 @@ fn dedup_candidate_better_supersedes() {
         result,
         DedupOutcome::SupersedeExisting {
             existing_id: "sk-1".to_owned()
-        }
+        },
+        "higher-confidence candidate with more usage should supersede existing skill"
     );
 }
 
@@ -642,7 +644,8 @@ fn dedup_embedding_similarity_above_threshold() {
         result,
         DedupOutcome::DiscardCandidate {
             existing_id: "sk-1".to_owned()
-        }
+        },
+        "high embedding similarity should discard candidate even with different tool sets"
     );
 }
 


### PR DESCRIPTION
## Summary

- Adds descriptive messages to 3 remaining bare `assert_eq!()` calls in `crates/mneme/src/skills/extract_tests.rs` (dedup tests)
- The other two target files (`extract/tests.rs` and `store/tests.rs`) already had messages on all assert calls — no changes needed

Partial progress on #1414.

## Observations

- The prompt expected 47 + 42 + 38 = 127 bare asserts across the 3 files, but only 3 were actually bare. The vast majority were already addressed in prior passes (#1581, #1582).
- `cargo clippy --workspace --all-targets -- -D warnings` has 113 pre-existing `expect_used`/`unwrap_used` lint errors in other files — none in the files touched by this PR.

## Test plan

- [x] Zero bare `assert!()` without messages in the 3 target files (verified with script)
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo test -p aletheia-mneme` — 912 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)