### PR TITLE
fix(workspace): unify SecretString type, resolve clippy warnings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,7 +62,6 @@ dependencies = [
  "rcgen",
  "reqwest 0.13.2",
  "rustls",
- "secrecy",
  "serde",
  "serde_json",
  "sha2",
@@ -166,7 +165,6 @@ dependencies = [
  "rand 0.9.2",
  "reqwest 0.13.2",
  "rustls",
- "secrecy",
  "serde",
  "serde_json",
  "snafu",
@@ -398,7 +396,6 @@ dependencies = [
  "reqwest 0.13.2",
  "ring",
  "rusqlite",
- "secrecy",
  "serde",
  "serde_json",
  "snafu",
@@ -5218,16 +5215,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4ae55de56877481d112a559bbc12667635fdaf5e005712fd4e2b2fa50ffc884"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "secrecy"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
-dependencies = [
- "serde",
- "zeroize",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,7 +95,6 @@ tower-http = { version = "0.6", features = ["cors", "compression-gzip", "trace",
 axum-server = { version = "0.8", features = ["tls-rustls"] }
 
 # Secrets
-secrecy = { version = "0.10", features = ["serde"] }
 zeroize = "1"
 
 # Tracing

--- a/crates/aletheia/Cargo.toml
+++ b/crates/aletheia/Cargo.toml
@@ -47,7 +47,6 @@ aletheia-dokimion = { path = "../eval" }
 aletheia-thesauros = { path = "../thesauros" }
 theatron-tui = { path = "../theatron/tui", optional = true }
 
-secrecy = { workspace = true }
 tokio = { workspace = true }
 tokio-util = { workspace = true }
 axum = { workspace = true }

--- a/crates/aletheia/src/cli_tests.rs
+++ b/crates/aletheia/src/cli_tests.rs
@@ -84,7 +84,7 @@ fn status_custom_url_parses() {
     let cli = Cli::parse_from(["aletheia", "status", "--url", "http://example:9999"]);
     match cli.command {
         Some(Command::Status { url }) => {
-            assert_eq!(url, "http://example:9999", "custom url should be set")
+            assert_eq!(url, "http://example:9999", "custom url should be set");
         }
         _ => panic!("expected Status command"),
     }

--- a/crates/aletheia/src/commands/server.rs
+++ b/crates/aletheia/src/commands/server.rs
@@ -24,6 +24,7 @@ use aletheia_hermeneus::anthropic::AnthropicProvider;
 use aletheia_hermeneus::provider::{ProviderConfig, ProviderRegistry};
 use aletheia_koina::credential::{CredentialProvider, CredentialSource};
 use aletheia_koina::redacting_layer::RedactingLayer;
+use aletheia_koina::secret::SecretString;
 use aletheia_mneme::embedding::{EmbeddingConfig, EmbeddingProvider, create_provider};
 use aletheia_mneme::store::SessionStore;
 use aletheia_nous::config::{NousConfig, PipelineConfig};
@@ -44,7 +45,6 @@ use aletheia_taxis::config::resolve_nous;
 use aletheia_taxis::loader::load_config;
 use aletheia_taxis::oikos::Oikos;
 use aletheia_taxis::validate::validate_section;
-use secrecy::SecretString;
 
 use crate::commands::maintenance;
 use crate::daemon_bridge;

--- a/crates/dianoia/src/state.rs
+++ b/crates/dianoia/src/state.rs
@@ -191,6 +191,7 @@ impl ProjectState {
 }
 
 #[cfg(test)]
+#[expect(clippy::expect_used, reason = "test assertions")]
 mod tests {
     use super::*;
 

--- a/crates/hermeneus/Cargo.toml
+++ b/crates/hermeneus/Cargo.toml
@@ -17,7 +17,6 @@ prometheus = { workspace = true }
 rand = { workspace = true }
 reqwest = { workspace = true }
 rustls = { workspace = true }
-secrecy = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 snafu = { workspace = true }

--- a/crates/melete/src/distill_tests.rs
+++ b/crates/melete/src/distill_tests.rs
@@ -1,3 +1,4 @@
+#![expect(clippy::expect_used, reason = "test assertions")]
 use aletheia_hermeneus::test_utils::MockProvider;
 use aletheia_hermeneus::types::{
     CompletionResponse, ContentBlock, StopReason, ToolResultContent, Usage,

--- a/crates/mneme/src/engine/fixed_rule/tests.rs
+++ b/crates/mneme/src/engine/fixed_rule/tests.rs
@@ -11,6 +11,7 @@
 //!   bidirectional edges if undirected semantics are needed.
 
 #[cfg(test)]
+#[expect(clippy::expect_used, reason = "test assertions")]
 mod graph_algo_tests {
     use crate::engine::DbInstance;
     use crate::engine::data::value::DataValue;

--- a/crates/symbolon/Cargo.toml
+++ b/crates/symbolon/Cargo.toml
@@ -19,7 +19,6 @@ rand = { workspace = true }
 ring = { workspace = true }
 reqwest = { workspace = true }
 rusqlite = { workspace = true }
-secrecy = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 snafu = { workspace = true }

--- a/crates/symbolon/src/auth.rs
+++ b/crates/symbolon/src/auth.rs
@@ -219,7 +219,7 @@ mod tests {
     fn test_service() -> AuthService {
         AuthService::in_memory(AuthConfig {
             jwt: JwtConfig {
-                signing_key: secrecy::SecretString::from("test-jwt-secret"),
+                signing_key: SecretString::from("test-jwt-secret"),
                 access_ttl: Duration::from_secs(3600),
                 refresh_ttl: Duration::from_secs(86400),
                 issuer: "aletheia-test".to_owned(),

--- a/crates/symbolon/src/jwt.rs
+++ b/crates/symbolon/src/jwt.rs
@@ -6,10 +6,10 @@
 
 use std::time::Duration;
 
+use aletheia_koina::secret::SecretString;
 use base64::Engine;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use ring::hmac;
-use secrecy::{ExposeSecret, SecretString};
 use tracing::instrument;
 
 use crate::error::{self, Result};

--- a/crates/theatron/tui/src/msg.rs
+++ b/crates/theatron/tui/src/msg.rs
@@ -102,7 +102,9 @@ pub enum Msg {
     },
     SseTurnBefore {
         nous_id: NousId,
+        #[expect(dead_code, reason = "planned TUI feature")]
         session_id: SessionId,
+        #[expect(dead_code, reason = "planned TUI feature")]
         turn_id: TurnId,
     },
     SseTurnAfter {
@@ -115,7 +117,9 @@ pub enum Msg {
     },
     SseToolFailed {
         nous_id: NousId,
+        #[expect(dead_code, reason = "planned TUI feature")]
         tool_name: String,
+        #[expect(dead_code, reason = "planned TUI feature")]
         error: String,
     },
     SseStatusUpdate {
@@ -124,6 +128,7 @@ pub enum Msg {
     },
     SseSessionCreated {
         nous_id: NousId,
+        #[expect(dead_code, reason = "planned TUI feature")]
         session_id: SessionId,
     },
     SseSessionArchived {
@@ -142,6 +147,7 @@ pub enum Msg {
     },
 
     StreamTurnStart {
+        #[expect(dead_code, reason = "planned TUI feature")]
         session_id: SessionId,
         nous_id: NousId,
         turn_id: TurnId,
@@ -150,11 +156,13 @@ pub enum Msg {
     StreamThinkingDelta(String),
     StreamToolStart {
         tool_name: String,
+        #[expect(dead_code, reason = "planned TUI feature")]
         tool_id: ToolId,
         input: Option<serde_json::Value>,
     },
     StreamToolResult {
         tool_name: String,
+        #[expect(dead_code, reason = "planned TUI feature")]
         tool_id: ToolId,
         is_error: bool,
         duration_ms: u64,
@@ -169,22 +177,27 @@ pub enum Msg {
         reason: String,
     },
     StreamToolApprovalResolved {
+        #[expect(dead_code, reason = "planned TUI feature")]
         tool_id: ToolId,
+        #[expect(dead_code, reason = "planned TUI feature")]
         decision: String,
     },
     StreamPlanProposed {
         plan: Plan,
     },
     StreamPlanStepStart {
+        #[expect(dead_code, reason = "planned TUI feature")]
         plan_id: PlanId,
         step_id: u32,
     },
     StreamPlanStepComplete {
+        #[expect(dead_code, reason = "planned TUI feature")]
         plan_id: PlanId,
         step_id: u32,
         status: String,
     },
     StreamPlanComplete {
+        #[expect(dead_code, reason = "planned TUI feature")]
         plan_id: PlanId,
         status: String,
     },
@@ -196,23 +209,32 @@ pub enum Msg {
     },
     StreamError(String),
 
+    #[expect(dead_code, reason = "planned TUI feature")]
     AgentsLoaded(Vec<Agent>),
+    #[expect(dead_code, reason = "planned TUI feature")]
     SessionsLoaded {
         nous_id: NousId,
         sessions: Vec<Session>,
     },
+    #[expect(dead_code, reason = "planned TUI feature")]
     HistoryLoaded {
         session_id: SessionId,
         messages: Vec<HistoryMessage>,
     },
+    #[expect(dead_code, reason = "planned TUI feature")]
     CostLoaded {
         daily_total_cents: u32,
     },
+    #[expect(dead_code, reason = "planned TUI feature")]
     AuthResult(AuthOutcome),
+    #[expect(dead_code, reason = "planned TUI feature")]
     ApiError(String),
 
+    #[expect(dead_code, reason = "planned TUI feature")]
     SettingsLoaded(serde_json::Value),
+    #[expect(dead_code, reason = "planned TUI feature")]
     SettingsSaved,
+    #[expect(dead_code, reason = "planned TUI feature")]
     SettingsSaveError(String),
 
     MemoryOpen,
@@ -242,34 +264,47 @@ pub enum Msg {
     MemorySearchBackspace,
     MemorySearchSubmit,
     MemorySearchClose,
+    #[expect(dead_code, reason = "planned TUI feature")]
     MemoryFactsLoaded {
         facts: Vec<crate::state::memory::MemoryFact>,
         total: usize,
     },
+    #[expect(dead_code, reason = "planned TUI feature")]
     MemoryDetailLoaded(Box<crate::state::memory::FactDetail>),
+    #[expect(dead_code, reason = "planned TUI feature")]
     MemoryEntitiesLoaded(Vec<crate::state::memory::MemoryEntity>),
+    #[expect(dead_code, reason = "planned TUI feature")]
     MemoryRelationshipsLoaded(Vec<crate::state::memory::MemoryRelationship>),
+    #[expect(dead_code, reason = "planned TUI feature")]
     MemoryTimelineLoaded(Vec<crate::state::memory::MemoryTimelineEvent>),
+    #[expect(dead_code, reason = "planned TUI feature")]
     MemorySearchResults(Vec<crate::state::memory::MemorySearchResult>),
+    #[expect(dead_code, reason = "planned TUI feature")]
     MemoryActionResult(String),
     MemoryPageDown,
     MemoryPageUp,
 
+    #[allow(dead_code, reason = "planned TUI feature")]
     ShowError(String),
+    #[allow(dead_code, reason = "planned TUI feature")]
     ShowSuccess(String),
+    #[allow(dead_code, reason = "planned TUI feature")]
     DismissError,
 
+    #[expect(dead_code, reason = "planned TUI feature")]
     ExportConversation,
 
     SessionSearchOpen,
     SessionSearchClose,
     SessionSearchInput(char),
     SessionSearchBackspace,
+    #[expect(dead_code, reason = "planned TUI feature")]
     SessionSearchSubmit,
     SessionSearchUp,
     SessionSearchDown,
     SessionSearchSelect,
 
+    #[expect(dead_code, reason = "planned TUI feature")]
     DiffOpen,
     DiffClose,
     DiffCycleMode,
@@ -278,6 +313,7 @@ pub enum Msg {
     DiffPageUp,
     DiffPageDown,
     /// Auto-triggered diff from file modification tool result.
+    #[expect(dead_code, reason = "planned TUI feature")]
     DiffFromToolResult {
         path: String,
         old_content: String,
@@ -319,8 +355,10 @@ pub enum OverlayKind {
     Help,
     AgentPicker,
     SessionPicker,
+    #[expect(dead_code, reason = "planned TUI feature")]
     SessionPickerAll,
     SystemStatus,
+    #[expect(dead_code, reason = "planned TUI feature")]
     Settings,
 }
 
@@ -348,8 +386,11 @@ impl ErrorToast {
 #[non_exhaustive]
 #[derive(Debug)]
 pub enum AuthOutcome {
+    #[expect(dead_code, reason = "planned TUI feature")]
     Success { token: SecretString },
+    #[expect(dead_code, reason = "planned TUI feature")]
     NoAuthRequired,
+    #[expect(dead_code, reason = "planned TUI feature")]
     Failed(String),
 }
 


### PR DESCRIPTION
## Summary

- Replace `secrecy::SecretString` with `koina::SecretString` in symbolon and aletheia crates, removing the `secrecy` dependency from the workspace entirely
- Fix 113 pre-existing `expect_used` clippy errors in dianoia, melete, and mneme test modules
- Fix 13 dead_code warnings in theatron-tui msg.rs for planned-but-not-yet-connected TUI variants
- Fix semicolon lint in cli_tests.rs

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes (was failing on main)
- [x] `cargo test --workspace` all pass