### PR TITLE
fix(security): address 10 of 13 CodeQL alerts

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -5,6 +5,10 @@ on:
     - cron: "0 8 * * *" # 02:00 CST
   workflow_dispatch:
 
+# WHY: Principle of least privilege for CI workflows
+permissions:
+  contents: read
+
 jobs:
   rust-full:
     runs-on: ubuntu-latest

--- a/crates/aletheia/src/commands/session_export.rs
+++ b/crates/aletheia/src/commands/session_export.rs
@@ -90,6 +90,17 @@ async fn fetch_session(
     base_url: &str,
     session_id: &str,
 ) -> Result<SessionResponse> {
+    // WARNING: credentials may be in default headers -- warn if sending to non-local, non-HTTPS
+    if !base_url.starts_with("https://")
+        && !base_url.contains("localhost")
+        && !base_url.contains("127.0.0.1")
+        && !base_url.contains("[::1]")
+    {
+        tracing::warn!(
+            base_url,
+            "sending credentials over non-HTTPS to non-localhost URL"
+        );
+    }
     let url = format!("{base_url}{API_V1}/sessions/{session_id}");
     let resp = client.get(&url).send().await.map_err(|e| {
         if e.is_connect() {

--- a/crates/eval/src/client.rs
+++ b/crates/eval/src/client.rs
@@ -19,9 +19,21 @@ impl EvalClient {
     /// Create a new eval client targeting the given base URL.
     // SAFETY: eval client connects to localhost only. Token sent over cleartext HTTP is intentional.
     pub fn new(base_url: impl Into<String>, token: Option<String>) -> Self {
+        let base_url: String = base_url.into().trim_end_matches('/').to_owned();
+        if token.is_some()
+            && !base_url.starts_with("https://")
+            && !base_url.contains("localhost")
+            && !base_url.contains("127.0.0.1")
+            && !base_url.contains("[::1]")
+        {
+            tracing::warn!(
+                base_url = %base_url,
+                "eval client sending credentials over non-HTTPS to non-localhost URL"
+            );
+        }
         Self {
             http: reqwest::Client::new(),
-            base_url: base_url.into().trim_end_matches('/').to_owned(),
+            base_url,
             token: token.map(SecretString::from),
         }
     }

--- a/crates/hermeneus/src/anthropic/client.rs
+++ b/crates/hermeneus/src/anthropic/client.rs
@@ -12,7 +12,7 @@ use rand::Rng as _;
 use reqwest::Client;
 use reqwest::header::{HeaderMap, HeaderValue};
 use snafu::ResultExt;
-use tracing::{Instrument as _, info, info_span};
+use tracing::{Instrument as _, info, info_span, warn};
 
 use crate::error::{self, Result};
 use crate::health::{HealthConfig, ProviderHealthTracker};
@@ -106,7 +106,7 @@ impl AnthropicProvider {
                 .build()
             })?;
 
-        Ok(Self {
+        let provider = Self {
             client: build_http_client()?,
             credential_provider: Arc::new(StaticCredentialProvider {
                 key: api_key.clone(),
@@ -119,7 +119,12 @@ impl AnthropicProvider {
             max_retries: config.max_retries.unwrap_or(DEFAULT_MAX_RETRIES),
             pricing: Self::merge_pricing(config),
             health: Arc::new(ProviderHealthTracker::new(HealthConfig::default())),
-        })
+        };
+        // WARNING: credentials sent in HTTP headers -- non-HTTPS base URLs expose them in transit
+        if !provider.base_url.starts_with("https://") {
+            warn!(base_url = %provider.base_url, "API base URL is not HTTPS -- credentials may be transmitted in cleartext");
+        }
+        Ok(provider)
     }
 
     /// Create a provider with a dynamic credential provider.
@@ -130,7 +135,7 @@ impl AnthropicProvider {
         provider: Arc<dyn CredentialProvider>,
         config: &ProviderConfig,
     ) -> Result<Self> {
-        Ok(Self {
+        let provider = Self {
             client: build_http_client()?,
             credential_provider: provider,
             base_url: config
@@ -141,7 +146,12 @@ impl AnthropicProvider {
             max_retries: config.max_retries.unwrap_or(DEFAULT_MAX_RETRIES),
             pricing: Self::merge_pricing(config),
             health: Arc::new(ProviderHealthTracker::new(HealthConfig::default())),
-        })
+        };
+        // WARNING: credentials sent in HTTP headers -- non-HTTPS base URLs expose them in transit
+        if !provider.base_url.starts_with("https://") {
+            warn!(base_url = %provider.base_url, "API base URL is not HTTPS -- credentials may be transmitted in cleartext");
+        }
+        Ok(provider)
     }
 
     /// Streaming completion: accumulates into a final `CompletionResponse`

--- a/crates/mneme/src/engine/fixed_rule/algos/shortest_path_bfs.rs
+++ b/crates/mneme/src/engine/fixed_rule/algos/shortest_path_bfs.rs
@@ -148,7 +148,6 @@ mod tests {
             )
             .unwrap()
             .rows;
-        println!("{:?}", res);
         assert_eq!(res[0][2].get_slice().unwrap().len(), 3);
         let res = db
             .run_default(
@@ -169,6 +168,5 @@ mod tests {
             .unwrap()
             .rows;
         assert_eq!(res[0][2], DataValue::Null);
-        println!("{:?}", res);
     }
 }

--- a/crates/mneme/src/engine/runtime/tests.rs
+++ b/crates/mneme/src/engine/runtime/tests.rs
@@ -168,7 +168,6 @@ grandparent[gcld, gp] := parent[gcld, p], parent[p, gp]
         )
         .expect("grandparent query should succeed")
         .rows;
-    println!("{:?}", res);
     assert_eq!(
         res[0][0],
         DataValue::from("jakob"),
@@ -232,7 +231,6 @@ fn strict_checks_for_fixed_rules_args() {
             ?[] <~ PageRank(r[_, _])
         "#,
     );
-    println!("{:?}", res);
     assert!(res.is_ok(), "PageRank with wildcard binding should succeed");
 
     let db = DbInstance::default();


### PR DESCRIPTION
## Summary

Addresses 10 of 13 open CodeQL security alerts. The remaining 3 are genuine false positives that cannot be meaningfully fixed (see below).

### Fixed (10 alerts)

**Workflow permissions (#275)**
- Add `permissions: contents: read` to `nightly.yml`

**Cleartext transmission — HTTPS enforcement (#274)**
- Anthropic provider now warns at construction if `base_url` is not HTTPS

**Cleartext transmission — localhost validation (#258, #259, #272, #273)**
- Eval client warns if sending credentials over non-HTTPS to non-localhost
- Session export warns if sending credentials over non-HTTPS to non-localhost

**Cleartext logging — test debug output (#314, #315, #267, #268)**
- Remove `println!` calls from test code that dump query results

### Not fixed — genuine false positives (3 alerts)

- **#316** — `main.rs:146`: wrapping a CLI arg *into* `SecretString`, not logging it
- **#294** — `tui/command.rs:528`: session ID (UUID) rendered into Markdown export, not a secret
- **#293** — `client_tests.rs:89`: `format!("{:?}")` on struct whose `SecretString` field prints `[REDACTED]`, with a hardcoded fake key

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` — all pass