### PR TITLE
docs: fix mechanical writing violations across 22 files

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Not a chatbot framework. A distributed cognition system.
 
 ## Architecture
 
-Rust workspace with 17 crates. Single binary deployment.
+Rust workspace with 18 crates. Single binary deployment.
 
 ```text
      TUI / HTTP API              Signal Messenger
@@ -58,7 +58,7 @@ See [ARCHITECTURE.md](docs/ARCHITECTURE.md) for the full dependency graph and tr
 
 ---
 
-## Quick Start
+## Quick start
 
 ```bash
 git clone https://github.com/forkwright/aletheia.git && cd aletheia
@@ -71,7 +71,7 @@ aletheia
 
 ---
 
-## Why Greek?
+## Naming
 
 Every name follows a deliberate naming philosophy. Greek provides precision where English flattens: *nous* over "agent" because these are minds, not tools. *Mneme* over "store" because memory is the function, not the container. See [gnomon.md](docs/gnomon.md) for the naming system and [lexicon.md](docs/lexicon.md) for the full registry.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,6 +1,6 @@
 # Security
 
-## Reporting Vulnerabilities
+## Reporting vulnerabilities
 
 **Do not open a public GitHub issue for security vulnerabilities.**
 
@@ -37,7 +37,7 @@ Include: description, reproduction steps, potential impact, and any suggested fi
 
 After a fix ships, we publish a GitHub Security Advisory with CVE (if warranted), description, affected versions, fixed version, and credit to the reporter.
 
-### Supported Versions
+### Supported versions
 
 | Version | Supported |
 |---------|-----------|
@@ -49,7 +49,7 @@ After a fix ships, we publish a GitHub Security Advisory with CVE (if warranted)
 
 ## Developer security practices
 
-### Pre-commit Hooks
+### Pre-commit hooks
 
 Install pre-commit and gitleaks to catch secrets and PII before they reach git history:
 
@@ -68,7 +68,7 @@ Manual scan:
 gitleaks detect --config .gitleaks.toml --no-git --source . -v
 ```
 
-### Commit Signing
+### Commit signing
 
 All commits to `main` should be signed.
 
@@ -108,13 +108,13 @@ git config --global commit.gpgsign true
 - Test data uses synthetic identities (alice, bob, acme.corp, 192.168.1.100)
 - CI PII scanner (`.github/pii-patterns.txt`) rejects commits with personal data patterns
 
-### Dependency Auditing
+### Dependency auditing
 
 - `cargo audit` runs in CI on every PR and weekly
 - `cargo deny` enforces license compatibility and bans specific crates
 - Dependabot creates PRs for vulnerable dependencies automatically
 
-### Branch Protection
+### Branch protection
 
 Recommended `main` branch settings:
 

--- a/docs/ARCHITECTURE-GUIDE.md
+++ b/docs/ARCHITECTURE-GUIDE.md
@@ -4,7 +4,7 @@ A guided tour for new contributors. For the reference module map and dependency 
 
 ---
 
-## What Aletheia is
+## What aletheia is
 
 Aletheia is a self-hosted multi-agent AI system. Multiple AI agents run as persistent actors, each with character, memory, and domain expertise. They communicate via Signal, HTTP API, or TUI, and persist understanding across sessions.
 
@@ -37,7 +37,7 @@ Then it waits for SIGTERM or Ctrl+C and shuts down gracefully.
 
 ## What happens when a message arrives
 
-### Via Signal
+### Via signal
 
 ```
 Signal app → Signal servers (E2E encrypted) → signal-cli daemon (localhost JSON-RPC)
@@ -101,7 +101,7 @@ Crates are organized in layers. Lower layers know nothing about higher layers.
 
 ---
 
-## The Oikos
+## The oikos
 
 The instance directory is the boundary between platform code (git-tracked) and deployment state (gitignored).
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -18,42 +18,42 @@ Module and crate names use Greek terms reflecting their essential nature (nous =
 
 ```text
 aletheia
-├── koina         — errors, tracing, safe wrappers, fs utils
-├── taxis         — config, path resolution, oikos hierarchy, secret refs
-├── mneme         — session store (SQLite) + knowledge engine (vendored Datalog) + candle
-│   ├── store     — SQLite session store: WAL, migrations, retention
-│   ├── knowledge — Datalog knowledge graph, HNSW vectors, entity relations
-│   ├── embedding — EmbeddingProvider trait: candle (local default)
-│   ├── extract   — LLM-driven fact extraction, entity resolution
-│   ├── recall    — hybrid retrieval (vector + graph + BM25), MMR diversity
-│   └── engine/   — embedded Datalog + HNSW engine (mneme-engine feature gate)
-├── hermeneus     — Anthropic client, model routing, credentials, provider trait
-├── organon       — tool registry + built-in tools
-├── nous          — agent pipeline, bootstrap, recall, finalize, actor model
-├── dianoia       — planning / project orchestration
-├── pylon         — Axum HTTP gateway, SSE streaming
-├── diaporeia     — MCP server interface for external AI agents
-├── symbolon      — JWT auth, sessions, RBAC
-├── agora         — channel registry + ChannelProvider trait
-│   └── semeion   — Signal (signal-cli subprocess)
-├── daemon        — oikonomos: per-nous background tasks, cron, evolution, prosoche
-├── melete        — distillation, reflection, memory flush, consolidation
-└── theatron      — presentation umbrella (crates/theatron/)
-    └── tui       — terminal dashboard                                  (crates/theatron/tui/)
+├── koina          -  errors, tracing, safe wrappers, fs utils
+├── taxis          -  config, path resolution, oikos hierarchy, secret refs
+├── mneme          -  session store (SQLite) + knowledge engine (vendored Datalog) + candle
+│   ├── store      -  SQLite session store: WAL, migrations, retention
+│   ├── knowledge  -  Datalog knowledge graph, HNSW vectors, entity relations
+│   ├── embedding  -  EmbeddingProvider trait: candle (local default)
+│   ├── extract    -  LLM-driven fact extraction, entity resolution
+│   ├── recall     -  hybrid retrieval (vector + graph + BM25), MMR diversity
+│   └── engine/    -  embedded Datalog + HNSW engine (mneme-engine feature gate)
+├── hermeneus      -  Anthropic client, model routing, credentials, provider trait
+├── organon        -  tool registry + built-in tools
+├── nous           -  agent pipeline, bootstrap, recall, finalize, actor model
+├── dianoia        -  planning / project orchestration
+├── pylon          -  Axum HTTP gateway, SSE streaming
+├── diaporeia      -  MCP server interface for external AI agents
+├── symbolon       -  JWT auth, sessions, RBAC
+├── agora          -  channel registry + ChannelProvider trait
+│   └── semeion    -  Signal (signal-cli subprocess)
+├── daemon         -  oikonomos: per-nous background tasks, cron, evolution, prosoche
+├── melete         -  distillation, reflection, memory flush, consolidation
+└── theatron       -  presentation umbrella (crates/theatron/)
+    └── tui        -  terminal dashboard                                  (crates/theatron/tui/)
 ```
 
 ---
 
-## The Oikos (instance structure)
+## The oikos (instance structure)
 
 Platform (tracked) vs. instance (gitignored). One directory, one boundary.
 
 ```text
-aletheia/                          # git root — the platform
+aletheia/                          # git root  -  the platform
 ├── crates/                        # Rust workspace
 ├── docs/                          # platform docs
 │
-├── instance/                      # GITIGNORED — all instance state
+├── instance/                      # GITIGNORED  -  all instance state
 │   ├── theke/                     # Tier 0: human + nous collaborative space
 │   │   ├── USER.md               #   Canonical user profile (one copy)
 │   │   ├── AGENTS.md             #   Team topology
@@ -94,7 +94,7 @@ aletheia/                          # git root — the platform
 │   │
 │   └── signal/                   # signal-cli data
 │
-└── instance.example/              # TRACKED — scaffold template
+└── instance.example/              # TRACKED  -  scaffold template
 ```
 
 Three-tier cascading resolution: nous/{id} -> shared -> theke. Most specific wins. Presence is declaration - drop a file in the right directory, it's discovered.
@@ -198,7 +198,7 @@ Imports flow downward only. Lower-layer crates must not depend on higher layers.
 opt-level = 1
 
 [profile.dev.package."*"]
-opt-level = 2      # optimize deps in dev — faster iteration
+opt-level = 2      # optimize deps in dev  -  faster iteration
 
 [profile.release]
 lto = "thin"

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,39 +5,6 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
-## [0.12.0] - 2026-03-16
-
-### Added
-- Structured JSON file logging with daily rotation
-- MCP server rate limiting
-- OAuth auto-refresh from Claude Code credentials
-- Fuzz testing infrastructure (3 targets, 60+ seeds)
-- Default agent tool permissions expanded
-- Session display_name field
-- Prebuilt binary releases in CI
-- Theatron desktop scaffold (Dioxus 0.7)
-
-### Fixed
-- Landlock exec Permission Denied on kernel 6.18 (ABI v7)
-- Knowledge facts API returning empty despite extraction
-- embed-candle restored to default features
-- CSRF and rate limit responses now include request_id
-- JWT default signing key validated at startup
-- Session limit parameter enforced
-- Knowledge sort/order parameter validation
-- Haiku 4.5 pricing configuration
-- CrossNousRouter pending_replies leak
-- 8 TUI bugs (streaming, scrolling, contrast, :recall, stale indicator)
-
-### Changed
-- Adapter traits use typed error enums (no more Result<T, String>)
-- Hero functions decomposed in nous, pylon, organon
-- Distillation trigger thresholds extracted to named constants
-- Em dashes removed from inline comments
-- 40+ commented-out debug prints removed
-- Pylon isolated error response tests added
-- Zero-coverage crates now have tests (agora, dianoia, diaporeia, thesauros)
-
 ## [Unreleased]
 
 ### Added
@@ -168,6 +135,40 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+
+## [0.12.0] - 2026-03-16
+
+### Added
+- Structured JSON file logging with daily rotation
+- MCP server rate limiting
+- OAuth auto-refresh from Claude Code credentials
+- Fuzz testing infrastructure (3 targets, 60+ seeds)
+- Default agent tool permissions expanded
+- Session display_name field
+- Prebuilt binary releases in CI
+- Theatron desktop scaffold (Dioxus 0.7)
+
+### Fixed
+- Landlock exec Permission Denied on kernel 6.18 (ABI v7)
+- Knowledge facts API returning empty despite extraction
+- embed-candle restored to default features
+- CSRF and rate limit responses now include request_id
+- JWT default signing key validated at startup
+- Session limit parameter enforced
+- Knowledge sort/order parameter validation
+- Haiku 4.5 pricing configuration
+- CrossNousRouter pending_replies leak
+- 8 TUI bugs (streaming, scrolling, contrast, :recall, stale indicator)
+
+### Changed
+- Adapter traits use typed error enums (no more Result<T, String>)
+- Hero functions decomposed in nous, pylon, organon
+- Distillation trigger thresholds extracted to named constants
+- Em dashes removed from inline comments
+- 40+ commented-out debug prints removed
+- Pylon isolated error response tests added
+- Zero-coverage crates now have tests (agora, dianoia, diaporeia, thesauros)
+
 ## [1.3.0]: memory system audit & overhaul
 
 ### Added
@@ -222,7 +223,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
-## [1.2.0]: onboarding & Mac support
+## [1.2.0]: onboarding & mac support
 
 ### Added
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -559,7 +559,7 @@ See [troubleshooting.md](troubleshooting.md) for common issues and fixes.
 
 ---
 
-## Optional: Signal messaging
+## Optional: signal messaging
 
 Aletheia can receive and send messages via [Signal](https://signal.org/) using the [signal-cli](https://github.com/AsamK/signal-cli) JSON-RPC daemon.
 

--- a/docs/PACKS.md
+++ b/docs/PACKS.md
@@ -216,7 +216,7 @@ Use the `agents` field on context entries and the `overlays` table to target con
 path = "context/CLINICAL_GUIDELINES.md"
 agents = ["chiron"]
 
-# Or target by domain tag — any agent with "healthcare" domain receives it
+# Or target by domain tag  -  any agent with "healthcare" domain receives it
 [[context]]
 path = "context/ICD_CODES.md"
 agents = ["healthcare"]

--- a/docs/PROSOCHE.md
+++ b/docs/PROSOCHE.md
@@ -15,9 +15,9 @@ aletheia binary
 ├── pylon (HTTP gateway)
 ├── nous (agent actors)
 └── oikonomos (daemon)
-    ├── TaskRunner — cron/interval scheduler
-    ├── ProsocheCheck — heartbeat check definition
-    └── DaemonBridge — sends prompts to nous actors
+    ├── TaskRunner  -  cron/interval scheduler
+    ├── ProsocheCheck  -  heartbeat check definition
+    └── DaemonBridge  -  sends prompts to nous actors
 ```
 
 ### Data flow

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -48,7 +48,7 @@ Run `aletheia --help` for the full command reference.
 
 Memory (embedded engine, candle) is embedded in the binary. No external databases, containers, or sidecars required.
 
-## Optional: Signal integration
+## Optional: signal integration
 
 Requires [signal-cli](https://github.com/AsamK/signal-cli) and a registered phone number. See [CONFIGURATION.md](CONFIGURATION.md#channelssignal) for setup.
 

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -23,7 +23,7 @@ aletheia status          # agent status, sessions, cron jobs
 
 ## Start procedure
 
-### 1. Check port is free
+### 1. check port is free
 
 ```bash
 ss -tlnp | grep 18789
@@ -31,7 +31,7 @@ ss -tlnp | grep 18789
 fuser -k 18789/tcp
 ```
 
-### 2. Start the binary
+### 2. start the binary
 
 ```bash
 aletheia
@@ -45,7 +45,7 @@ Or via systemd:
 systemctl --user start aletheia
 ```
 
-### 3. Verify
+### 3. verify
 
 ```bash
 sleep 3

--- a/docs/gnomon.md
+++ b/docs/gnomon.md
@@ -6,7 +6,7 @@ A sundial's gnomon doesn't contain time. It casts a shadow that makes time legib
 
 ---
 
-## Why Greek
+## Why greek
 
 Ancient Greek was engineered across centuries for a single purpose: distinguishing between closely related things that matter. Where English has "knowledge," Greek has episteme (systematic knowledge), gnosis (direct acquaintance), techne (craft knowledge), phronesis (practical wisdom), and nous (direct apprehension). These aren't synonyms. They're fundamentally different stances toward the world.
 

--- a/instance.example/nous/_template/WORKFLOWS.md
+++ b/instance.example/nous/_template/WORKFLOWS.md
@@ -37,7 +37,7 @@
 | `memory_search` | Semantic search across long-term memory |
 | `consolidate-memory` | Merge/deduplicate memory entries |
 | `aletheia-graph` | Knowledge graph queries |
-| Daily logs | `memory/YYYY-MM-DD.md` — manual session logs |
+| Daily logs | `memory/YYYY-MM-DD.md`  -  manual session logs |
 
 ---
 

--- a/planning/research/active-forgetting.md
+++ b/planning/research/active-forgetting.md
@@ -71,7 +71,7 @@ This is not a storage crisis. CozoDB handles millions of records. The problem is
 
 ### Forgetting strategies evaluated
 
-#### 1. Decay-threshold forgetting
+#### 1. decay-threshold forgetting
 
 Transition facts to `is_forgotten` when their FSRS decay score falls below a threshold for a sustained period.
 
@@ -86,7 +86,7 @@ Transition facts to `is_forgotten` when their FSRS decay score falls below a thr
 
 **Verdict: Primary mechanism.** FSRS already models relevance decay. The missing piece is an actuator that converts low scores to forgotten status.
 
-#### 2. Contradiction-based forgetting
+#### 2. contradiction-based forgetting
 
 When conflict detection identifies a CONTRADICTS classification, the old fact is superseded. This already works. The gap is detecting contradictions in facts that were never explicitly contradicted but are implausible given newer information.
 
@@ -99,7 +99,7 @@ When conflict detection identifies a CONTRADICTS classification, the old fact is
 
 **Verdict: Secondary mechanism, gated behind decay threshold.** Only evaluate facts that are already fading. This keeps LLM costs proportional to decay, not total fact count.
 
-#### 3. Relevance-based forgetting (access frequency)
+#### 3. relevance-based forgetting (access frequency)
 
 Facts never recalled are candidates for removal. `access_count` already tracks this.
 
@@ -112,7 +112,7 @@ Facts never recalled are candidates for removal. `access_count` already tracks t
 
 **Verdict: Contributing signal within decay scoring, not standalone trigger.** Access frequency already has 5% weight in recall. Bump to 10% or add a zero-access penalty to the decay formula.
 
-#### 4. Confidence-based forgetting
+#### 4. confidence-based forgetting
 
 Low-confidence extractions (`confidence < 0.5`, tier = `assumed`) are pruned first.
 
@@ -125,7 +125,7 @@ Low-confidence extractions (`confidence < 0.5`, tier = `assumed`) are pruned fir
 
 **Verdict: Pre-filter for decay-threshold candidates.** Low-confidence, low-access assumed facts should have the lowest effective stability, making them the first to cross the decay threshold naturally. Adjust the FSRS stability formula to penalize low-confidence facts more aggressively rather than adding a separate mechanism.
 
-#### 5. User-directed forgetting
+#### 5. user-directed forgetting
 
 Already implemented via `forget_fact(reason: ForgetReason::UserRequested)`. Working correctly. No changes needed except surface it better in the UI/API.
 
@@ -200,7 +200,7 @@ forget_audit {
 
 User-pinned facts are exempt from automated forgetting. Pinning is explicit: "never forget this." Default: false.
 
-### Forgetting thresholds by FactType
+### Forgetting thresholds by factType
 
 | FactType | Base stability (h) | Forget threshold (R) | Effective age at forget |
 |---|---|---|---|

--- a/planning/research/browser-automation.md
+++ b/planning/research/browser-automation.md
@@ -12,7 +12,7 @@ How should Aletheia expose browser automation to agents? What protocol, crate, a
 
 ## Findings
 
-### 1. Current Tool System Architecture
+### 1. Current tool system architecture
 
 Organon (`crates/organon/`) implements a trait-based tool registry with sandbox enforcement.
 
@@ -41,11 +41,11 @@ pub trait ToolExecutor: Send + Sync {
 
 **Result types**: `ToolResult` supports text, image blocks (base64), and document blocks. The `view_file` tool already returns base64-encoded screenshots and PDFs to the agent.
 
-**Key observation**: The exec tool runs subprocesses with Landlock+seccomp sandboxing. A browser automation tool has two design paths: (a) implement as a native Rust tool using a browser crate, or (b) delegate to an external process (Playwright) via the existing exec infrastructure. Both paths can leverage the sandbox layer, but with different trade-offs.
+**Key observation**: The exec tool runs subprocesses with Landlock+seccomp sandboxing. A browser automation tool has two design paths: (a) implement as a native Rust tool using a browser crate, or (b) delegate to an external process (Playwright) via the existing exec infrastructure. Both paths can use the sandbox layer, but with different trade-offs.
 
-### 2. Browser Automation Approaches
+### 2. browser automation approaches
 
-#### 2.1 Chrome DevTools Protocol via `chromiumoxide`
+#### 2.1 chrome devTools protocol via `chromiumoxide`
 
 | Attribute | Value |
 |---|---|
@@ -64,7 +64,7 @@ CDP gives direct access to Chrome internals: DOM, network, rendering, JavaScript
 
 **Dependency weight**: ~20 runtime deps including reqwest, async-tungstenite (WebSocket), full tokio. Medium-heavy.
 
-#### 2.2 Chrome DevTools Protocol via `headless_chrome`
+#### 2.2 chrome devTools protocol via `headless_chrome`
 
 | Attribute | Value |
 |---|---|
@@ -81,7 +81,7 @@ CDP gives direct access to Chrome internals: DOM, network, rendering, JavaScript
 
 **Disqualifying factor**: No async support. Aletheia runs on tokio. Wrapping every call in `spawn_blocking` adds complexity and negates the library's simplicity advantage.
 
-#### 2.3 WebDriver Protocol via `fantoccini`
+#### 2.3 webDriver protocol via `fantoccini`
 
 | Attribute | Value |
 |---|---|
@@ -100,7 +100,7 @@ W3C WebDriver is a standardized protocol with broad browser support. `fantoccini
 
 **Dependency weight**: ~13 runtime deps. Uses hyper directly. Lighter than chromiumoxide.
 
-#### 2.4 WebDriver Protocol via `thirtyfour`
+#### 2.4 webDriver protocol via `thirtyfour`
 
 | Attribute | Value |
 |---|---|
@@ -116,7 +116,7 @@ W3C WebDriver is a standardized protocol with broad browser support. `fantoccini
 
 **Concern**: Repository transfer and version yanks suggest maintenance uncertainty.
 
-#### 2.5 HTTP-Only Approach (reqwest + scraper)
+#### 2.5 HTTP-Only approach (reqwest + scraper)
 
 | Attribute | Value |
 |---|---|
@@ -132,7 +132,7 @@ Static HTML parsing with CSS selectors. No browser binary, no JavaScript executi
 
 **Use case**: Static content extraction only. Already partially covered by the existing `web_fetch` tool in organon's research builtins.
 
-#### 2.6 External Process Delegation (Playwright via shell)
+#### 2.6 external process delegation (Playwright via shell)
 
 Shell out to Playwright (Node.js or Python) for browser control.
 
@@ -142,7 +142,7 @@ Shell out to Playwright (Node.js or Python) for browser control.
 
 **Mitigation pattern**: Use a long-lived Playwright process with JSON-RPC or stdio protocol, not one shell invocation per action. Wrap in a Rust trait so the implementation can be swapped later.
 
-### 3. Approach Comparison
+### 3. approach comparison
 
 | Factor | chromiumoxide | headless_chrome | fantoccini | thirtyfour | scraper+reqwest | Playwright shell |
 |---|---|---|---|---|---|---|
@@ -157,7 +157,7 @@ Shell out to Playwright (Node.js or Python) for browser control.
 | Pure Rust | Yes | Yes | Yes | Yes | Yes | **No** |
 | Compile impact | Heavy (codegen) | Moderate | Light | Moderate | Light | None |
 
-### 4. Tool Interface Design
+### 4. tool interface design
 
 Browser automation should be exposed as a single tool with an `action` parameter, not as separate tools per operation. This matches the pattern used by Anthropic's computer use tool and keeps the tool surface area small.
 
@@ -165,7 +165,7 @@ Browser automation should be exposed as a single tool with an `action` parameter
 
 | Action | Parameters | Returns |
 |---|---|---|
-| `navigate` | `url: String` | Page title, final URL (after redirects) |
+| `move through` | `url: String` | Page title, final URL (after redirects) |
 | `screenshot` | `selector?: String` | Base64 PNG image block |
 | `read_text` | `selector?: String` | Extracted text content |
 | `read_html` | `selector?: String` | Raw HTML of element or page |
@@ -178,12 +178,12 @@ Browser automation should be exposed as a single tool with an `action` parameter
 | `cookies` | `action: "get" \| "set" \| "clear", ...` | Cookie data |
 | `back` / `forward` / `refresh` | (none) | New page state |
 
-#### Tool Definition
+#### Tool definition
 
 ```rust
 ToolDef {
     name: "browser",
-    description: "Interact with web pages: navigate, read content, fill forms, take screenshots",
+    description: "Interact with web pages: move through, read content, fill forms, take screenshots",
     category: ToolCategory::Research,
     auto_activate: false,  // Lazy: enabled per-session when needed
     input_schema: InputSchema {
@@ -200,14 +200,14 @@ ToolDef {
 }
 ```
 
-#### Result Format
+#### Result format
 
 - **Text content**: Returned as plain text in `ToolResult::text()`
 - **Screenshots**: Returned as `ToolResult::blocks()` with `ToolResultBlock::Image` (base64 PNG). The agent sees the screenshot inline, matching how `view_file` works today.
 - **Structured data**: JSON-serialized into `ToolResult::text()`. The agent parses as needed.
 - **Errors**: `ToolResult::error()` with descriptive message (element not found, timeout, navigation failure).
 
-#### Authentication and Cookies
+#### Authentication and cookies
 
 Browser sessions are ephemeral by default. Each `browser` tool activation starts a fresh browser profile with no cookies or stored credentials. Persistence options:
 
@@ -215,11 +215,11 @@ Browser sessions are ephemeral by default. Each `browser` tool activation starts
 2. **Explicit cookie injection**: Agent uses `cookies` action with `set` to inject authentication cookies received from other sources.
 3. **No credential storage**: Browser tool never stores credentials to disk. Session ends, cookies are gone.
 
-### 5. Security Model
+### 5. security model
 
-#### Domain Allowlist
+#### Domain allowlist
 
-The browser tool must restrict which domains the agent can navigate to. Configuration:
+The browser tool must restrict which domains the agent can move through to. Configuration:
 
 ```toml
 [tools.browser]
@@ -230,7 +230,7 @@ block_private_networks = true  # Block 10.x, 172.16-31.x, 192.168.x, 169.254.x, 
 
 Domain checking happens before navigation. Redirects to blocked domains are intercepted and rejected.
 
-#### Resource Limits
+#### Resource limits
 
 | Limit | Default | Purpose |
 |---|---|---|
@@ -240,7 +240,7 @@ Domain checking happens before navigation. Redirects to blocked domains are inte
 | Max screenshots per session | 50 | Bound image token cost |
 | Max response size | 1 MB | Prevent memory exhaustion from large pages |
 
-#### Process Isolation
+#### Process isolation
 
 The browser process runs under the same Landlock+seccomp sandbox as the exec tool. Additional constraints:
 
@@ -249,13 +249,13 @@ The browser process runs under the same Landlock+seccomp sandbox as the exec too
 - **GPU**: Disabled (`--disable-gpu`). Headless mode only.
 - **Extensions**: Disabled. No user data directory.
 
-#### Content Risks
+#### Content risks
 
 - **Prompt injection via page content**: Web pages can contain text that looks like instructions to the agent. The tool should strip or truncate excessively long page content and warn if the page contains patterns that resemble prompt injection (e.g., "ignore previous instructions").
 - **Drive-by downloads**: Browser profile is ephemeral and sandboxed. Downloads go to a temp directory that is deleted on session end.
 - **Exfiltration**: Domain allowlist prevents the agent from navigating to attacker-controlled domains. The `execute_js` action is the highest-risk operation and should be gated behind a separate permission flag.
 
-#### Sandbox Integration
+#### Sandbox integration
 
 ```
 [Agent Session]
@@ -272,7 +272,7 @@ The browser process runs under the same Landlock+seccomp sandbox as the exec too
 
 Chrome's internal sandbox (`--no-sandbox`) is disabled because Landlock provides equivalent filesystem isolation at the OS level. This avoids the nested-sandbox complexity and user namespace requirements.
 
-### 6. Relationship to Computer Use
+### 6. relationship to computer use
 
 Anthropic's computer use tool and browser automation serve different purposes:
 
@@ -288,7 +288,7 @@ Anthropic's computer use tool and browser automation serve different purposes:
 
 For web-specific tasks, browser automation is more reliable, cheaper, and faster. Computer use is needed when the task involves non-browser GUI applications. The two can coexist: use the browser tool for web tasks, computer use for desktop GUI tasks.
 
-### 7. Observations
+### 7. observations
 
 - **Debt**: The existing `web_fetch` tool (`builtins/research.rs`) does HTTP-only fetching. Adding browser automation creates overlap. Consider deprecating `web_fetch` in favor of `browser` with a `read_text` action, or keeping `web_fetch` as the lightweight path for static content.
 - **Idea**: A `browser_pool` service (similar to database connection pooling) could manage browser lifecycle across sessions, amortizing startup cost.
@@ -299,7 +299,7 @@ For web-specific tasks, browser automation is more reliable, cheaper, and faster
 
 ## Recommendations
 
-### Recommended Approach: `chromiumoxide` (CDP)
+### Recommended approach: `chromiumoxide` (CDP)
 
 **Primary**: Use `chromiumoxide` for browser automation behind a feature flag.
 
@@ -316,7 +316,7 @@ For web-specific tasks, browser automation is more reliable, cheaper, and faster
 
 **Trade-off accepted**: Compile time increase from generated CDP bindings. Mitigated by putting the browser tool behind a feature flag so it does not affect default builds.
 
-### Fallback: Playwright Delegation
+### Fallback: Playwright delegation
 
 If `chromiumoxide` proves insufficient (stability issues, missing CDP features), fall back to Playwright delegation via a long-lived subprocess with stdio JSON protocol. This path:
 - Adds a Python/Node.js runtime dependency
@@ -325,11 +325,11 @@ If `chromiumoxide` proves insufficient (stability issues, missing CDP features),
 
 Design the `ToolExecutor` implementation behind a trait so the backend (chromiumoxide vs Playwright) can be swapped without changing the tool interface.
 
-### Implementation Plan
+### Implementation plan
 
-#### Phase 1: Core Tool (Medium)
+#### Phase 1: core tool (Medium)
 
-Add `browser` tool with `navigate`, `screenshot`, `read_text`, `click`, `type_text`, `wait` actions using `chromiumoxide`.
+Add `browser` tool with `move through`, `screenshot`, `read_text`, `click`, `type_text`, `wait` actions using `chromiumoxide`.
 
 - New module: `crates/organon/src/builtins/browser.rs`
 - Feature flag: `browser` in `crates/organon/Cargo.toml`
@@ -339,7 +339,7 @@ Add `browser` tool with `navigate`, `screenshot`, `read_text`, `click`, `type_te
 
 Blast radius: `crates/organon/src/builtins/browser.rs` (new), `crates/organon/src/builtins/mod.rs`, `crates/organon/Cargo.toml`
 
-#### Phase 2: Security Hardening (Small)
+#### Phase 2: security hardening (Small)
 
 Add resource limits, domain validation, private network blocking, session timeout.
 
@@ -349,7 +349,7 @@ Add resource limits, domain validation, private network blocking, session timeou
 
 Blast radius: `crates/organon/src/builtins/browser.rs`, `crates/taxis/src/tools.rs`
 
-#### Phase 3: Advanced Actions (Small)
+#### Phase 3: advanced actions (Small)
 
 Add `execute_js`, `list_elements`, `cookies`, `read_html`, `select`, navigation actions.
 
@@ -358,11 +358,11 @@ Add `execute_js`, `list_elements`, `cookies`, `read_html`, `select`, navigation 
 
 Blast radius: `crates/organon/src/builtins/browser.rs`
 
-#### Phase 4: Browser Pool (Optional, Future)
+#### Phase 4: browser pool (Optional, future)
 
 Connection pooling for browser instances across sessions. Only justified if browser startup latency becomes a measurable bottleneck.
 
-### Effort Estimate
+### Effort estimate
 
 | Phase | Scope | New deps |
 |---|---|---|

--- a/planning/research/knowledge-sharing.md
+++ b/planning/research/knowledge-sharing.md
@@ -50,7 +50,7 @@ Three mechanisms already enable some cross-agent knowledge flow:
 
 ### Designed sharing mechanisms
 
-#### 1. Knowledge publication
+#### 1. knowledge publication
 
 **Concept.** An agent explicitly publishes a fact to the shared knowledge base. Publication changes the fact's `nous_id` from the agent's ID to empty, or creates a new shared copy with provenance metadata.
 
@@ -86,7 +86,7 @@ published_facts { shared_fact_id: String =>
 }
 ```
 
-#### 2. Knowledge subscription
+#### 2. knowledge subscription
 
 **Concept.** An agent subscribes to topics, fact types, or entity categories. When another agent publishes knowledge matching a subscription, the subscriber receives a notification.
 
@@ -114,7 +114,7 @@ Subscriptions are evaluated at publication time. When `publish_fact` runs, it ch
 
 **Recommendation.** Push notification with pull content. The CrossNousRouter delivers a lightweight notification ("new shared fact about entity X, type Skill"). The subscriber's recall pipeline picks up the actual fact content on next recall query. This avoids message bloat while ensuring agents know new knowledge exists.
 
-#### 3. Federated queries
+#### 3. federated queries
 
 **Concept.** An agent queries across all agents' knowledge stores (or a subset) with access control. Returns results from multiple agents, ranked by the standard 6-factor recall engine.
 
@@ -149,7 +149,7 @@ recall_federated(query, options) -> Vec<RecallResult>
 
 For `restricted` visibility, a `fact_access` relation maps fact IDs to authorized `nous_id` values.
 
-#### 4. Shared knowledge base
+#### 4. shared knowledge base
 
 **Concept.** A curated collection of facts that are always available to all agents. Distinct from ad-hoc publication: these are ground-truth facts that define the system's shared understanding.
 
@@ -278,7 +278,7 @@ These are structured messages sent through the existing CrossNousRouter infrastr
 
 ### Effort estimate and phased approach
 
-#### Phase 1: Publication and visibility (5-8 days)
+#### Phase 1: publication and visibility (5-8 days)
 
 **Scope.**
 - Add `visibility` field to facts schema (default: `private`)
@@ -296,7 +296,7 @@ These are structured messages sent through the existing CrossNousRouter infrastr
 
 **Risk.** Schema migration on existing CozoDB data. Mitigated by defaulting all existing facts to `private` visibility.
 
-#### Phase 2: Subscription and notification (3-5 days)
+#### Phase 2: subscription and notification (3-5 days)
 
 **Scope.**
 - Implement subscription registry (in-memory, persisted to SQLite)
@@ -311,7 +311,7 @@ These are structured messages sent through the existing CrossNousRouter infrastr
 
 **Risk.** Notification volume with many agents and frequent publications. Mitigated by filter specificity and rate limiting.
 
-#### Phase 3: Verification and conflict resolution (4-6 days)
+#### Phase 3: verification and conflict resolution (4-6 days)
 
 **Scope.**
 - Multi-agent verification protocol (request -> vote -> promote)
@@ -327,7 +327,7 @@ These are structured messages sent through the existing CrossNousRouter infrastr
 
 **Risk.** Consensus deadlock with even number of agents. Mitigated by operator tiebreaker and timeout-based resolution.
 
-#### Phase 4: Federated recall and restricted access (3-4 days)
+#### Phase 4: federated recall and restricted access (3-4 days)
 
 **Scope.**
 - Extend recall engine with visibility-aware filtering

--- a/planning/research/mcp-client.md
+++ b/planning/research/mcp-client.md
@@ -6,7 +6,7 @@ Aletheia has MCP server support (diaporeia crate) but no MCP client capability. 
 
 ## Findings
 
-### 1. Existing MCP Server Audit (diaporeia)
+### 1. existing MCP server audit (diaporeia)
 
 **Crate**: `aletheia-diaporeia` at `crates/diaporeia/`
 
@@ -24,11 +24,11 @@ Aletheia has MCP server support (diaporeia crate) but no MCP client capability. 
 
 **Error handling**: 6 error variants mapped to JSON-RPC codes. Path sanitization strips server-side paths from error messages before they reach clients.
 
-### 2. MCP Protocol Requirements for Client Role
+### 2. MCP protocol requirements for client role
 
 The MCP spec (2025-11-25) defines three roles: host (aletheia), client (connector per server), and server (external tool provider). Each client maintains a 1:1 stateful session with one server.
 
-#### 2.1 Lifecycle
+#### 2.1 lifecycle
 
 Three-phase handshake:
 1. Client sends `initialize` with protocol version, capabilities, and client info.
@@ -39,7 +39,7 @@ Version negotiation: client proposes latest version it supports; server echoes i
 
 Shutdown: client sends `notifications/cancelled` for in-flight requests, then closes transport.
 
-#### 2.2 Client-to-Server Methods
+#### 2.2 client-to-Server methods
 
 | Method | Purpose | Paginated |
 |--------|---------|-----------|
@@ -55,7 +55,7 @@ Shutdown: client sends `notifications/cancelled` for in-flight requests, then cl
 | `logging/setLevel` | Set server log verbosity | No |
 | `ping` | Health check | No |
 
-#### 2.3 Server-to-Client Methods (optional client features)
+#### 2.3 server-to-Client methods (optional client features)
 
 | Method | Purpose | Phase |
 |--------|---------|-------|
@@ -63,19 +63,19 @@ Shutdown: client sends `notifications/cancelled` for in-flight requests, then cl
 | `roots/list` | Server asks for filesystem roots | 1 |
 | `elicitation/create` | Server requests user input | 4 |
 
-#### 2.4 Notifications
+#### 2.4 notifications
 
 Client receives: `notifications/tools/list_changed`, `notifications/resources/list_changed`, `notifications/resources/updated`, `notifications/prompts/list_changed`, `notifications/progress`, `notifications/message` (logging).
 
 Client sends: `notifications/initialized`, `notifications/cancelled`, `notifications/roots/list_changed`.
 
-### 3. Transport Options
+### 3. transport options
 
 #### 3.1 stdio
 
 Client launches server as a subprocess. JSON-RPC messages on stdin/stdout, newline-delimited. Server logs to stderr. Shutdown: close stdin, wait, SIGTERM, SIGKILL. Simplest transport, recommended by spec for local servers.
 
-#### 3.2 Streamable HTTP
+#### 3.2 streamable HTTP
 
 Single endpoint (e.g., `https://example.com/mcp`). POST for client requests (returns JSON or SSE stream). Optional GET for server-initiated SSE stream. Session management via `MCP-Session-Id` header. Resumable streams via `Last-Event-ID`. Protocol version header (`MCP-Protocol-Version`) required on all requests.
 
@@ -83,17 +83,17 @@ Single endpoint (e.g., `https://example.com/mcp`). POST for client requests (ret
 
 Separate GET endpoint (returns SSE with `endpoint` event) and POST endpoint. Backwards-compatibility fallback: try POST initialize first, fall back to GET if 400/404/405.
 
-#### 3.4 No WebSocket
+#### 3.4 no webSocket
 
 The spec does not define a WebSocket transport despite community discussion.
 
-### 4. Authentication
+### 4. authentication
 
 OAuth 2.1 for HTTP transports (optional). Discovery via Protected Resource Metadata (RFC 9728). PKCE required (S256). `resource` parameter (RFC 8707) required. Three client registration approaches: pre-registered, client ID metadata documents, dynamic registration (RFC 7591). Tokens via `Authorization: Bearer` on every request.
 
 stdio transport: credentials from environment, not OAuth.
 
-### 5. rmcp Client Support
+### 5. rmcp client support
 
 rmcp 1.2.0 has full client support via the `client` feature flag (not currently enabled in aletheia).
 
@@ -119,7 +119,7 @@ let tools = peer.list_all_tools().await?;
 
 The SDK abstracts JSON-RPC framing, lifecycle management, and transport details. No need to implement the protocol layer from scratch.
 
-### 6. Organon Tool System Integration Points
+### 6. organon tool system integration points
 
 **Tool trait**: `ToolExecutor` (object-safe async trait in `crates/organon/src/registry.rs`). Single method: `execute(&self, input: &ToolInput, ctx: &ToolContext) -> Result<ToolResult>`.
 
@@ -133,7 +133,7 @@ The SDK abstracts JSON-RPC framing, lifecycle management, and transport details.
 
 **Domain packs**: `thesauros` already registers external tools (from domain packs) using the same `ToolRegistry`. Precedent exists for non-builtin tool registration.
 
-### 7. Configuration System
+### 7. configuration system
 
 **Framework**: figment (defaults, TOML file, environment variables). All config types in `crates/taxis/src/config.rs`.
 
@@ -203,7 +203,7 @@ McpServerConfig {
 }
 ```
 
-### Tool Namespace
+### Tool namespace
 
 External MCP tools are namespaced as `mcp_{server}_{tool}` in the organon registry.
 
@@ -211,7 +211,7 @@ Example: server named "filesystem" exposing tool "read_file" becomes `mcp_filesy
 
 This prevents collisions with native organon tools and makes the tool's origin visible in LLM context and logs. The `enable_tool` meta-tool's catalog shows MCP tools grouped by server.
 
-### Tool Integration Architecture
+### Tool integration architecture
 
 ```
                     ToolRegistry (organon)
@@ -250,7 +250,7 @@ This prevents collisions with native organon tools and makes the tool's origin v
 5. Set `auto_activate = false` by default (lazy loading)
 6. Subscribe to `notifications/tools/list_changed` for dynamic updates
 
-### Resource Access
+### Resource access
 
 MCP resources from external servers are not directly exposed as organon tools. Instead:
 
@@ -260,7 +260,7 @@ MCP resources from external servers are not directly exposed as organon tools. I
 
 This avoids polluting the tool registry with resource URIs and keeps the interface consistent with how agents interact with tools.
 
-### Crate Placement
+### Crate placement
 
 Two options:
 
@@ -270,7 +270,7 @@ Two options:
 
 **Recommendation**: Option A. Diaporeia means "passage through" and already owns the MCP boundary. The client is the other direction of passage. Feature-gate the client (`mcp-client` feature) independently from the server (`mcp` feature). The rmcp dependency already exists; adding the `client` feature is a Cargo.toml change.
 
-### Error Handling
+### Error handling
 
 New error variants in `diaporeia::error`:
 
@@ -289,9 +289,9 @@ These map to organon's `ExecutionFailed` at the tool dispatch boundary. The agen
 
 ---
 
-## Security Model
+## Security model
 
-### Trust Levels
+### Trust levels
 
 Three trust levels per configured server:
 
@@ -303,7 +303,7 @@ Three trust levels per configured server:
 
 Default: `sandboxed`. Operator must explicitly set `trusted`.
 
-### Data Flow Control
+### Data flow control
 
 **Sandboxed servers**:
 - Receive only the tool call arguments (name + JSON params) that the LLM explicitly constructs.
@@ -318,27 +318,27 @@ Default: `sandboxed`. Operator must explicitly set `trusted`.
 - Path sanitization (already in diaporeia for server mode) applies to client-received error messages too.
 - Secret values from `symbolon` are never passed as tool arguments. The tool dispatch layer checks arguments against a redaction list.
 
-### Subprocess Isolation (stdio)
+### Subprocess isolation (stdio)
 
 - Subprocess inherits only explicitly configured `env` variables, not the full parent environment.
 - Working directory set to a temporary directory, not the aletheia instance root.
 - On Linux, consider landlock/seccomp for subprocess sandboxing (aletheia already has landlock support in organon for shell execution).
 
-### Network Isolation (HTTP)
+### Network isolation (HTTP)
 
 - TLS required for non-localhost URLs (`rustls`, consistent with aletheia's TLS policy).
 - Connection timeout + per-request timeout from config.
 - No automatic credential forwarding between servers (token audience binding per spec).
 
-### Tool Annotation Trust
+### Tool annotation trust
 
 Per the MCP spec, tool annotations (like `readOnlyHint`, `destructiveHint`) are untrusted unless the server is `trusted`. For `sandboxed` servers, ignore annotations and apply conservative defaults (assume potentially destructive).
 
 ---
 
-## Effort Estimate
+## Effort estimate
 
-### Phase 1: stdio + Tool Discovery/Invocation (3-4 weeks)
+### Phase 1: stdio + tool discovery/Invocation (3-4 weeks)
 
 - Extend `McpConfig` with `servers` array and `McpServerConfig` types
 - Add config validation in taxis
@@ -351,7 +351,7 @@ Per the MCP spec, tool annotations (like `readOnlyHint`, `destructiveHint`) are 
 - Trust level enforcement (sandboxed by default)
 - Tests: mock MCP server via stdio for integration tests
 
-### Phase 2: Resources, Prompts, and Dynamic Updates (2 weeks)
+### Phase 2: resources, prompts, and dynamic updates (2 weeks)
 
 - `mcp_resources` tool for resource listing and reading
 - Prompt listing and expansion
@@ -359,7 +359,7 @@ Per the MCP spec, tool annotations (like `readOnlyHint`, `destructiveHint`) are 
 - Resource subscriptions
 - Completion support
 
-### Phase 3: Streamable HTTP Transport (3-4 weeks)
+### Phase 3: streamable HTTP transport (3-4 weeks)
 
 - Enable rmcp `transport-streamable-http-client-reqwest` feature
 - Session management (`MCP-Session-Id`)
@@ -368,7 +368,7 @@ Per the MCP spec, tool annotations (like `readOnlyHint`, `destructiveHint`) are 
 - Legacy HTTP+SSE backwards compatibility
 - TLS enforcement for remote servers
 
-### Phase 4: Advanced Client Features (2-3 weeks)
+### Phase 4: advanced client features (2-3 weeks)
 
 - Sampling support (route server LLM requests through hermeneus)
 - Elicitation support (form + URL modes, requires TUI/UI integration)

--- a/planning/research/multi-provider-routing.md
+++ b/planning/research/multi-provider-routing.md
@@ -12,9 +12,9 @@ How should Aletheia support multiple LLM providers (Anthropic, OpenAI, local mod
 
 ## Findings
 
-### 1. Current Provider Coupling Audit
+### 1. Current provider coupling audit
 
-#### Architecture: Anthropic-Native by Design
+#### Architecture: anthropic-Native by design
 
 Hermeneus is explicitly Anthropic-native. From the module documentation (`crates/hermeneus/src/lib.rs`):
 
@@ -22,7 +22,7 @@ Hermeneus is explicitly Anthropic-native. From the module documentation (`crates
 
 This is a deliberate design decision, not accidental coupling. The type system models Anthropic's Messages API, and other providers are expected to adapt to it.
 
-#### Existing Abstraction Layer
+#### Existing abstraction layer
 
 The `LlmProvider` trait (`crates/hermeneus/src/provider.rs:23-65`) defines the provider interface:
 
@@ -49,7 +49,7 @@ The trait accepts `CompletionRequest` and returns `CompletionResponse`, both Ant
 - Per-provider health state machine (Up/Degraded/Down)
 - Success/error recording for health transitions
 
-#### Where Anthropic is Hardcoded
+#### Where Anthropic is hardcoded
 
 | Location | What | Portability Impact |
 |----------|------|--------------------|
@@ -62,13 +62,13 @@ The trait accepts `CompletionRequest` and returns `CompletionResponse`, both Ant
 | `anthropic/wire/` | Wire format serialization/deserialization | Fully Anthropic-specific, correctly isolated |
 | `anthropic/stream.rs` | SSE streaming parser | Anthropic-specific stream format, correctly isolated |
 
-#### How Providers Flow Through the System
+#### How providers flow through the system
 
 1. **Init** (`crates/aletheia/src/server.rs`): `build_provider_registry()` creates a registry, initializes `AnthropicProvider`, and registers it. Only one provider is registered today.
 2. **Routing** (`crates/nous/src/execute/mod.rs:33-56`): `resolve_provider_checked()` calls `registry.find_provider(model)` (first match), checks health, and returns the provider or an error.
 3. **Execution**: `provider.complete()` or `provider.complete_streaming()` is called. The caller records success/error for health tracking.
 
-#### Recent Addition: Model Fallback Chain
+#### Recent addition: model fallback chain
 
 `crates/hermeneus/src/fallback.rs` (landed on main) implements intra-provider model fallback. `complete_with_fallback()` retries the primary model `retries_before_fallback` times, then tries each model in `FallbackConfig.fallback_models` in order. Non-retryable errors (auth, 4xx) propagate immediately; retryable errors (429, 5xx, timeout) trigger fallback via the `Error::is_retryable()` method (`crates/hermeneus/src/error.rs:72-87`).
 
@@ -80,9 +80,9 @@ The coupling is well-structured. Anthropic-specific code is isolated in the `ant
 
 This is a strength, not a weakness. Making the types provider-neutral would lose Anthropic-specific features (prompt caching, extended thinking, server-side tools) that Aletheia uses heavily. The adapter pattern (other providers translate to/from these types) preserves full Anthropic capability while enabling other providers.
 
-### 2. Provider Trait Design
+### 2. provider trait design
 
-#### Current Trait: What Works
+#### Current trait: what works
 
 The existing `LlmProvider` trait handles the core use case well:
 
@@ -91,7 +91,7 @@ The existing `LlmProvider` trait handles the core use case well:
 - `Send + Sync` allows shared ownership across async tasks
 - `name` provides diagnostics
 
-#### What is Missing
+#### What is missing
 
 **Model capability metadata.** The registry knows which provider supports which model name, but nothing about model capabilities. The caller must know that `claude-opus-4-6` supports thinking and `gpt-4o` does not. This information should be queryable.
 
@@ -101,7 +101,7 @@ The existing `LlmProvider` trait handles the core use case well:
 
 **Health-aware routing.** `ProviderRegistry::find_provider()` returns the first match regardless of health. `resolve_provider_checked()` in nous checks health after finding the provider but does not try alternatives.
 
-#### Proposed Trait Extension
+#### Proposed trait extension
 
 Do not replace the existing trait. Extend the system with a capability registry:
 
@@ -150,9 +150,9 @@ pub trait EmbeddingProvider: Send + Sync {
 
 Embeddings are a different operation with different providers (OpenAI `text-embedding-3-small`, local Candle models). Merging them into `LlmProvider` would violate interface segregation.
 
-### 3. Routing Strategies
+### 3. routing strategies
 
-#### 3.1 Static Assignment (Task Type -> Provider)
+#### 3.1 static assignment (Task type -> provider)
 
 Map task categories to specific models/providers in configuration:
 
@@ -176,7 +176,7 @@ qa_evaluation = "claude-sonnet-4-6"
 
 **Verdict: Implement first.** This is the natural extension of the current system. `NousConfig.model` already selects a model per agent. Extending this to support provider-qualified model names (e.g., `openai/gpt-4o`) is straightforward.
 
-#### 3.2 Fallback Chain (Try Providers in Order)
+#### 3.2 fallback chain (Try providers in order)
 
 **Existing work:** `crates/hermeneus/src/fallback.rs` implements model-level fallback within a single provider. This section covers cross-provider fallback: trying a different provider when the primary provider is entirely unavailable.
 
@@ -230,7 +230,7 @@ for provider in providers.find_providers(model) {
 
 **Verdict: Implement second.** High value for reliability. The existing health system provides the foundation. The main risk is response format differences between providers causing downstream breakage.
 
-#### 3.3 Cost-Based Routing (Cheapest Capable Provider)
+#### 3.3 cost-Based routing (Cheapest capable provider)
 
 Select the cheapest provider that meets the request's capability requirements:
 
@@ -258,7 +258,7 @@ fn select_cheapest(
 
 **Verdict: Implement third, after capability metadata is in place.** This depends on `ModelCapabilities` being populated for all registered models. Without accurate capability data, the router cannot make correct decisions.
 
-#### 3.4 Load Balancing (Distribute Across Providers)
+#### 3.4 load balancing (Distribute across providers)
 
 Distribute requests across equivalent providers for throughput:
 
@@ -282,9 +282,9 @@ enum LoadBalanceStrategy {
 
 **Verdict: Defer.** Aletheia is a single-user system. Rate limiting is handled by the existing retry/backoff logic. Load balancing adds complexity without solving a current problem. Revisit if multi-tenant or high-throughput parallel agent use cases emerge.
 
-### 4. API Differences Between Providers
+### 4. API differences between providers
 
-#### 4.1 Message Format
+#### 4.1 message format
 
 | Feature | Anthropic | OpenAI | Ollama (OpenAI-compatible) |
 |---------|-----------|--------|---------------------------|
@@ -296,7 +296,7 @@ enum LoadBalanceStrategy {
 
 **Adapter complexity: Medium.** The core text message flow is similar across providers. The system prompt handling is the most common difference (separate field vs. message role). Image format differs but is a straightforward translation. Thinking/reasoning is provider-specific and may need to be stripped for non-Anthropic providers.
 
-#### 4.2 Tool/Function Calling
+#### 4.2 tool/Function calling
 
 | Feature | Anthropic | OpenAI | Ollama |
 |---------|-----------|--------|--------|
@@ -317,7 +317,7 @@ The adapter must:
 4. Handle streaming deltas differently
 5. Drop server-side tools (no OpenAI equivalent) or warn
 
-#### 4.3 Streaming Protocol
+#### 4.3 streaming protocol
 
 | Feature | Anthropic | OpenAI |
 |---------|-----------|--------|
@@ -331,7 +331,7 @@ The adapter must:
 
 The existing `StreamAccumulator` (`crates/hermeneus/src/anthropic/stream.rs`) expects Anthropic-specific events. An OpenAI streaming adapter would need its own accumulator that emits the same `StreamEvent` variants.
 
-#### 4.4 Token Counting
+#### 4.4 token counting
 
 | Feature | Anthropic | OpenAI | Local (Ollama) |
 |---------|-----------|--------|----------------|
@@ -343,7 +343,7 @@ The existing `StreamAccumulator` (`crates/hermeneus/src/anthropic/stream.rs`) ex
 
 Pre-request token estimation is provider-specific. `tiktoken` covers OpenAI models. Anthropic has no public tokenizer. For cost estimation, character-based heuristics (4 chars per token) are sufficient. Precise counting is only needed for context window management, and the API returns actual usage after each call.
 
-#### 4.5 Authentication
+#### 4.5 authentication
 
 | Provider | Method | Header |
 |----------|--------|--------|
@@ -354,7 +354,7 @@ Pre-request token estimation is provider-specific. `tiktoken` covers OpenAI mode
 
 **Adapter complexity: Low.** Each provider sets its own headers. The existing `CredentialProvider` trait in koina (`crates/koina/src/credential.rs`) already abstracts credential resolution. Each provider implementation handles its own auth.
 
-#### 4.6 Error Codes and Rate Limiting
+#### 4.6 error codes and rate limiting
 
 | Feature | Anthropic | OpenAI |
 |---------|-----------|--------|
@@ -366,7 +366,7 @@ Pre-request token estimation is provider-specific. `tiktoken` covers OpenAI mode
 
 **Adapter complexity: Low.** Both use standard HTTP status codes. The existing `Error` enum covers the necessary variants. Each provider's error mapper translates provider-specific codes to the common `Error` type. The health state machine operates on the common `Error` type and requires no changes.
 
-### 5. Observations
+### 5. observations
 
 - **Debt**: `ProviderRegistry::find_provider()` returns the first matching provider with no fallback. If Anthropic is down, the system fails even if OpenAI is registered and healthy. (`crates/hermeneus/src/provider.rs:197-201`)
 - **Debt**: `ProviderConfig::default()` hardcodes Anthropic pricing only. No mechanism for registering pricing from other providers at startup. (`crates/hermeneus/src/provider.rs:95-153`)
@@ -380,7 +380,7 @@ Pre-request token estimation is provider-specific. `tiktoken` covers OpenAI mode
 
 ### Phased Implementation
 
-#### Phase 1: Provider Capabilities and Configuration (Small)
+#### Phase 1: provider capabilities and configuration (Small)
 
 Add model capability metadata and multi-provider configuration. No new providers yet.
 
@@ -393,7 +393,7 @@ Add model capability metadata and multi-provider configuration. No new providers
 
 **Blast radius:** `crates/hermeneus/src/provider.rs`, `crates/hermeneus/src/anthropic/client.rs`, `crates/taxis/src/config.rs`
 
-#### Phase 2: OpenAI Provider Adapter (Medium)
+#### Phase 2: OpenAI provider adapter (Medium)
 
 Implement an OpenAI-compatible provider adapter. This covers OpenAI, Azure OpenAI, and any OpenAI-compatible API (Groq, Together, etc.).
 
@@ -418,7 +418,7 @@ Implement an OpenAI-compatible provider adapter. This covers OpenAI, Azure OpenA
 
 **Blast radius:** new `crates/hermeneus/src/openai/` module, `crates/hermeneus/Cargo.toml`
 
-#### Phase 3: Cross-Provider Fallback Routing (Small)
+#### Phase 3: cross-Provider fallback routing (Small)
 
 Extend the existing model-level fallback (`crates/hermeneus/src/fallback.rs`) to cross provider boundaries.
 
@@ -431,7 +431,7 @@ Extend the existing model-level fallback (`crates/hermeneus/src/fallback.rs`) to
 
 **Blast radius:** `crates/hermeneus/src/provider.rs`, `crates/hermeneus/src/fallback.rs`, `crates/nous/src/execute/mod.rs`, `crates/taxis/src/config.rs`
 
-#### Phase 4: Ollama / Local Model Provider (Small)
+#### Phase 4: Ollama / local model provider (Small)
 
 Add support for local models via Ollama's OpenAI-compatible API.
 
@@ -443,7 +443,7 @@ Add support for local models via Ollama's OpenAI-compatible API.
 
 **Blast radius:** `crates/hermeneus/src/openai/` or new `crates/hermeneus/src/ollama/` module
 
-#### Phase 5: Cost-Based Routing (Medium)
+#### Phase 5: cost-Based routing (Medium)
 
 Route requests to the cheapest capable provider.
 
@@ -455,7 +455,7 @@ Route requests to the cheapest capable provider.
 
 **Blast radius:** `crates/hermeneus/src/provider.rs`, `crates/nous/src/execute/mod.rs`, `crates/taxis/src/config.rs`
 
-### Effort Estimates
+### Effort estimates
 
 | Phase | Files Changed | New Files | Complexity | Dependencies |
 |-------|--------------|-----------|------------|-------------|
@@ -467,7 +467,7 @@ Route requests to the cheapest capable provider.
 
 Phases 1, 2, and 3 are the critical path. Phase 1 is a prerequisite for phases 2-5. Phases 2 and 3 can proceed in parallel after phase 1. Phase 4 builds on phase 2. Phase 5 can start after phase 1.
 
-### What NOT to Build
+### What NOT to build
 
 - **Provider-neutral type system.** Do not replace `CompletionRequest`/`CompletionResponse` with provider-agnostic types. The Anthropic-native types give full access to Anthropic features. Other providers adapt to what they support. A lowest-common-denominator type system would lose prompt caching, extended thinking, server-side tools, and citations.
 - **Load balancer.** Not needed for single-user system. The fallback chain provides sufficient resilience.

--- a/planning/research/observability-trace.md
+++ b/planning/research/observability-trace.md
@@ -6,7 +6,7 @@ How is tracing implemented in aletheia? What spans, events, and outputs exist? H
 
 ## Findings
 
-### 1. Tracing Stack
+### 1. tracing stack
 
 Aletheia uses the `tracing` ecosystem exclusively:
 
@@ -19,7 +19,7 @@ Aletheia uses the `tracing` ecosystem exclusively:
 
 No OpenTelemetry, OTLP, or Langfuse integration exists today.
 
-### 2. Initialization
+### 2. initialization
 
 Two initialization paths exist:
 
@@ -38,7 +38,7 @@ Two initialization paths exist:
 - File-only output to `~/.local/share/aletheia/tui.log`
 - Daily rolling, no console output (TUI owns the terminal)
 
-### 3. Span Hierarchy
+### 3. span hierarchy
 
 The system implements a layered span tree. Every spawned async task uses `.instrument(span)` to propagate context.
 
@@ -78,7 +78,7 @@ Other top-level spans:
 | `log_retention` | `crates/aletheia/src/commands/server.rs:850` | (none) |
 | `health_poller` | `crates/nous/src/manager.rs:407` | (none) |
 
-### 4. Correlation IDs
+### 4. correlation IDs
 
 Three primary identifiers flow through the span tree:
 
@@ -90,7 +90,7 @@ Three primary identifiers flow through the span tree:
 
 Error responses (4xx/5xx) are enriched with `request_id` by the `enrich_error_response` middleware (`pylon/src/middleware.rs:77-122`). This allows operators to correlate a user-visible error to its trace output.
 
-### 5. Key Events
+### 5. key events
 
 **Lifecycle events:**
 - `"actor started"` (info) with nous.id
@@ -110,7 +110,7 @@ Error responses (4xx/5xx) are enriched with `request_id` by the `enrich_error_re
 - `"maintenance: drift detection complete"` (info)
 - `"maintenance: retention complete"` (info)
 
-### 6. Instrumentation Coverage
+### 6. instrumentation coverage
 
 ~60 functions carry `#[instrument]` attributes across the codebase. Key areas:
 
@@ -125,7 +125,7 @@ Error responses (4xx/5xx) are enriched with `request_id` by the `enrich_error_re
 
 All production `tokio::spawn` calls use `.instrument(span)` for context propagation. Uninstrumented spawns exist only in test code.
 
-### 7. Configuration
+### 7. configuration
 
 **TOML config** (`aletheia.toml`):
 
@@ -160,7 +160,7 @@ maxArchives = 30       # Default: 30
 - `--log-level <level>`: console level (default: info)
 - `--json-logs`: switch console output to JSON
 
-### 8. File Rotation
+### 8. file rotation
 
 The `TraceRotator` (`crates/daemon/src/maintenance/trace_rotation.rs`) runs as a background daemon task:
 
@@ -172,7 +172,7 @@ The `TraceRotator` (`crates/daemon/src/maintenance/trace_rotation.rs`) runs as a
 
 Log retention (separate from trace rotation) prunes daily log files in `logs/` after `retention_days`.
 
-### 9. Debugging Workflow
+### 9. debugging workflow
 
 To trace a user-visible error back to its cause:
 
@@ -189,13 +189,13 @@ To increase verbosity for a running server:
 
 To increase verbosity without restart: not currently supported (requires process restart).
 
-### 10. Metrics (Prometheus)
+### 10. metrics (Prometheus)
 
 Separate from tracing, Prometheus metrics are exposed at `/metrics` (`crates/pylon/src/handlers/metrics.rs`). HTTP request count and duration are recorded by the `record_http_metrics` middleware. Turn completion triggers `crate::metrics::record_turn()`.
 
 ## Recommendations
 
-### R1: Install a structured panic handler (high priority)
+### R1: install a structured panic handler (high priority)
 
 `RUST.md` mandates a custom panic hook that logs to the structured log file. No panic handler is installed today. A panic in any async task silently disappears unless the `JoinHandle` is awaited and the `JoinError` explicitly logged. The daemon runner does catch task panics, but a panic on the main thread or in non-runner tasks would only hit stderr.
 
@@ -207,7 +207,7 @@ std::panic::set_hook(Box::new(|info| {
 
 This belongs in `init_tracing()` or immediately after it in the server startup path.
 
-### R2: Add OpenTelemetry export layer (medium priority)
+### R2: add openTelemetry export layer (medium priority)
 
 The current file-based JSON output is adequate for single-instance debugging but does not support:
 - Distributed trace correlation across instances
@@ -225,7 +225,7 @@ endpoint = "http://localhost:4317"
 service_name = "aletheia"
 ```
 
-### R3: Add Langfuse integration for LLM observability (medium priority)
+### R3: add langfuse integration for LLM observability (medium priority)
 
 The `llm_call` spans already capture provider, model, token counts, duration, and retry counts. A Langfuse layer or post-processing step could export these as Langfuse generations, enabling:
 - Cost tracking per session/agent
@@ -238,15 +238,15 @@ Two approaches:
 
 Approach 1 is preferred for production use. The Langfuse Rust SDK does not exist; the HTTP API would need a thin client.
 
-### R4: Support runtime log level changes (low priority)
+### R4: support runtime log level changes (low priority)
 
 Currently, changing log levels requires a process restart. `tracing-subscriber` supports `reload::Layer` which allows swapping the `EnvFilter` at runtime via an API endpoint or signal handler. This would allow operators to increase verbosity for debugging without downtime.
 
-### R5: Add `tool_execute` span in organon (low priority)
+### R5: add `tool_execute` span in organon (low priority)
 
 The span hierarchy shows `pipeline_stage(stage="execute")` containing `llm_call` spans, but individual tool executions within the execute stage do not have their own spans. Adding a `tool_execute` span with `tool_name`, `tool_id`, and `duration_ms` fields would close the gap between "the LLM asked to call a tool" and "the tool returned a result."
 
-### R6: Add span fields to `sse_bridge` and `credential_refresh` (low priority)
+### R6: add span fields to `sse_bridge` and `credential_refresh` (low priority)
 
 These spans carry no identifying fields, making them hard to correlate in multi-session environments. `sse_bridge` should carry `session.id`; `credential_refresh` should carry the credential type and user context.
 

--- a/planning/research/predictive-recall.md
+++ b/planning/research/predictive-recall.md
@@ -13,7 +13,7 @@ Current recall is purely reactive: each turn embeds the user message, runs tiere
 
 ## Findings
 
-### 1. Current Recall Pipeline
+### 1. Current recall pipeline
 
 The recall pipeline executes synchronously within the turn lifecycle:
 
@@ -46,18 +46,18 @@ The fast path is already sub-100ms. Predictive recall targets the Tier 2/3 cases
 
 **Signals used today:**
 
-1. **Vector similarity** (0.35 weight) — cosine distance in MiniLM embedding space
-2. **FSRS temporal decay** (0.20) — power-law forgetting curve tuned by fact type and epistemic tier
-3. **Nous relevance** (0.15) — own vs shared vs other agent memories
-4. **Epistemic tier** (0.15) — verified > inferred > assumed
-5. **Graph proximity** (0.10) — BFS hop count from query entities, community-boosted
-6. **Access frequency** (0.05) — log-normalized recall count with supersession chain bonus
+1. **Vector similarity** (0.35 weight)  -  cosine distance in MiniLM embedding space
+2. **FSRS temporal decay** (0.20)  -  power-law forgetting curve tuned by fact type and epistemic tier
+3. **Nous relevance** (0.15)  -  own vs shared vs other agent memories
+4. **Epistemic tier** (0.15)  -  verified > inferred > assumed
+5. **Graph proximity** (0.10)  -  BFS hop count from query entities, community-boosted
+6. **Access frequency** (0.05)  -  log-normalized recall count with supersession chain bonus
 
-**Key observation:** Only vector similarity is computed from the actual query. The other five factors are either static per-fact properties or config defaults. This means the scoring function is mostly query-independent once candidates are retrieved — a property that makes pre-fetching viable.
+**Key observation:** Only vector similarity is computed from the actual query. The other five factors are either static per-fact properties or config defaults. This means the scoring function is mostly query-independent once candidates are retrieved  -  a property that makes pre-fetching viable.
 
-### 2. Predictive Recall Strategies
+### 2. predictive recall strategies
 
-#### Strategy A: Graph Neighborhood Pre-Loading
+#### Strategy a: graph neighborhood pre-Loading
 
 **Mechanism:** When the current turn mentions entities E1, E2, ... En, pre-fetch the 1-hop and 2-hop neighborhoods of those entities from the knowledge graph before the next turn arrives.
 
@@ -69,7 +69,7 @@ The fast path is already sub-100ms. Predictive recall targets the Tier 2/3 cases
 
 **Strengths:**
 - Exploits the existing graph structure (entities, relationships, community clusters).
-- Low marginal cost — Cozo Datalog queries are sub-millisecond for 1-hop.
+- Low marginal cost  -  Cozo Datalog queries are sub-millisecond for 1-hop.
 - High hit rate for conversations that stay within a topic cluster.
 
 **Weaknesses:**
@@ -79,7 +79,7 @@ The fast path is already sub-100ms. Predictive recall targets the Tier 2/3 cases
 
 **Estimated hit rate:** 40-60% for multi-turn conversations on a single topic, <10% for topic-switching turns.
 
-#### Strategy B: Conversation Trajectory Prediction
+#### Strategy b: conversation trajectory prediction
 
 **Mechanism:** Use the last N turns to predict likely next-turn topics via a lightweight model (n-gram, TF-IDF, or small LM).
 
@@ -95,13 +95,13 @@ The fast path is already sub-100ms. Predictive recall targets the Tier 2/3 cases
 - Works even when graph is sparse.
 
 **Weaknesses:**
-- Trajectory vector is a coarse signal — it averages over topics rather than predicting the next one.
+- Trajectory vector is a coarse signal  -  it averages over topics rather than predicting the next one.
 - Requires maintaining per-session embedding history (memory cost: ~1.5KB per turn at 384 dims).
 - Speculative search adds background CPU/IO load.
 
 **Estimated hit rate:** 30-50% depending on conversation coherence.
 
-#### Strategy C: Idle-Time Pre-Fetching
+#### Strategy c: idle-Time pre-Fetching
 
 **Mechanism:** While the user is composing their next message (detected via typing indicators or simply the gap between turns), run speculative recall using the current conversation context.
 
@@ -113,8 +113,8 @@ The fast path is already sub-100ms. Predictive recall targets the Tier 2/3 cases
 
 **Strengths:**
 - Uses dead time (user thinking/typing) productively.
-- No prediction model needed — the last assistant message is a reasonable proxy for what comes next.
-- Minimal architecture change — same search pipeline, just triggered earlier.
+- No prediction model needed  -  the last assistant message is a reasonable proxy for what comes next.
+- Minimal architecture change  -  same search pipeline, just triggered earlier.
 
 **Weaknesses:**
 - Only useful when there is a significant gap between turns (>500ms).
@@ -123,7 +123,7 @@ The fast path is already sub-100ms. Predictive recall targets the Tier 2/3 cases
 
 **Estimated hit rate:** 25-40%. Higher for follow-up questions, lower for topic switches.
 
-#### Strategy D: User Pattern Learning
+#### Strategy d: user pattern learning
 
 **Mechanism:** Track recurring topic sequences per user/session over time. If user frequently discusses A then B, pre-fetch B-related facts when A appears.
 
@@ -142,11 +142,11 @@ The fast path is already sub-100ms. Predictive recall targets the Tier 2/3 cases
 - Requires significant history before patterns emerge (cold start problem).
 - Topic classification itself is noisy (extraction must produce consistent entity/topic labels).
 - Transition table grows with vocabulary; needs pruning strategy.
-- Privacy consideration — stores behavioral patterns.
+- Privacy consideration  -  stores behavioral patterns.
 
 **Estimated hit rate:** 10-20% initially, potentially 40-60% after months of use.
 
-#### Strategy E: Simple Heuristic — Last N Related Conversations
+#### Strategy e: simple heuristic - last n related conversations
 
 **Mechanism:** When a session starts or after N turns, find the top-K most similar prior sessions and pre-load their extracted facts.
 
@@ -156,18 +156,18 @@ The fast path is already sub-100ms. Predictive recall targets the Tier 2/3 cases
 - Bulk-load facts from those sessions into a warm cache.
 
 **Strengths:**
-- Very simple to implement — session embeddings likely already exist or are cheap to add.
+- Very simple to implement  -  session embeddings likely already exist or are cheap to add.
 - Good for recurring tasks ("last time I worked on X, I needed Y").
-- Low false-positive rate — session-level similarity is a strong signal.
+- Low false-positive rate  -  session-level similarity is a strong signal.
 
 **Weaknesses:**
-- Coarse granularity — loads entire sessions, not specific facts.
+- Coarse granularity  -  loads entire sessions, not specific facts.
 - Session embeddings may not exist yet (requires new indexing).
 - Stale if the related session's facts have been superseded.
 
 **Estimated hit rate:** 20-35% for users with recurring workflows.
 
-### 3. Comparison Matrix
+### 3. comparison matrix
 
 | Strategy | Hit Rate | Latency Saved | Compute Cost | Complexity | Cold Start |
 |----------|----------|---------------|--------------|------------|------------|
@@ -177,9 +177,9 @@ The fast path is already sub-100ms. Predictive recall targets the Tier 2/3 cases
 | D: User patterns | 10-60% | 20-60ms | Low (after training) | High | Yes (months) |
 | E: Session similarity | 20-35% | 20-50ms | Medium | Low | Mild (needs sessions) |
 
-### 4. Risks and Mitigations
+### 4. risks and mitigations
 
-#### Risk 1: Wasted Compute on Wrong Predictions
+#### Risk 1: wasted compute on wrong predictions
 
 Speculative recall consumes embedding compute, HNSW search time, and memory for results that may never be used.
 
@@ -189,16 +189,16 @@ Speculative recall consumes embedding compute, HNSW search time, and memory for 
 - Track hit rate per strategy. If a strategy's 30-day rolling hit rate drops below 15%, disable it automatically.
 - Use the existing `access_count` mechanism: speculative results that are never injected get zero access bumps, naturally decaying their priority.
 
-#### Risk 2: Stale Predictions After Topic Shift
+#### Risk 2: stale predictions after topic shift
 
 If the user switches topics, speculative cache is useless and may even pollute results if merged naively.
 
 **Mitigation:**
 - Invalidate speculative cache when the cosine similarity between the new user message embedding and the speculative query embedding drops below 0.5.
-- Never let speculative results override fresh recall — use RRF merge with speculative results getting a rank penalty (offset by +10 positions).
+- Never let speculative results override fresh recall  -  use RRF merge with speculative results getting a rank penalty (offset by +10 positions).
 - TTL on speculative cache: expire after 2 turns unused.
 
-#### Risk 3: Memory Pressure from Pre-Fetched Results
+#### Risk 3: memory pressure from pre-Fetched results
 
 Large graph neighborhoods or aggressive pre-fetching could consume significant memory.
 
@@ -207,7 +207,7 @@ Large graph neighborhoods or aggressive pre-fetching could consume significant m
 - For graph neighborhoods: limit to 1-hop only for entities with PageRank < 0.05; allow 2-hop only for high-importance entities.
 - Evict speculative cache on session end.
 
-#### Risk 4: Increased Complexity and Debugging Difficulty
+#### Risk 4: increased complexity and debugging difficulty
 
 Speculative recall adds a parallel code path that interacts with the existing 6-factor scoring system.
 
@@ -216,16 +216,16 @@ Speculative recall adds a parallel code path that interacts with the existing 6-
 - Emit structured tracing spans for all speculative operations: `recall.speculative.trigger`, `recall.speculative.hit`, `recall.speculative.miss`, `recall.speculative.invalidated`.
 - Speculative results carry a `source: Speculative` tag in `ScoredResult` so they can be filtered in debugging.
 
-#### Risk 5: Accuracy Regression
+#### Risk 5: accuracy regression
 
 Pre-fetched results may lower average recall quality if low-relevance speculative results displace high-relevance fresh results.
 
 **Mitigation:**
-- Speculative results are candidates only — they still pass through the full 6-factor scoring pipeline.
+- Speculative results are candidates only  -  they still pass through the full 6-factor scoring pipeline.
 - Apply a conservative score penalty (multiply speculative scores by 0.8) to prefer fresh results when scores are close.
 - A/B test: run both reactive and predictive recall, compare quality metrics (mean reciprocal rank of facts the LLM actually references).
 
-### 5. Architecture Sketch for MVP
+### 5. architecture sketch for MVP
 
 ```
                     Turn N completes
@@ -266,25 +266,25 @@ Pre-fetched results may lower average recall quality if low-relevance speculativ
 
 **Components to add:**
 
-1. **SpeculativeCache** — bounded LRU in `NousActor`, keyed by session ID.
+1. **SpeculativeCache**  -  bounded LRU in `NousActor`, keyed by session ID.
    - `insert(session_id, query_embedding, Vec<ScoredResult>)`
    - `get_if_relevant(session_id, new_query_embedding, threshold=0.5) -> Option<Vec<ScoredResult>>`
    - `invalidate(session_id)`
 
-2. **Speculative trigger** in `actor/background.rs` — after extraction spawns, also spawn `maybe_prefetch_neighborhood()`.
+2. **Speculative trigger** in `actor/background.rs`  -  after extraction spawns, also spawn `maybe_prefetch_neighborhood()`.
    - Gated on `config.recall.predictive.enabled`.
    - Queries 1-hop graph neighbors of entities from extraction results.
    - Loads associated facts and stores in `SpeculativeCache`.
 
-3. **Merge logic** in `RecallStage::run()` — check cache before/after fresh recall, merge via RRF with rank penalty.
+3. **Merge logic** in `RecallStage::run()`  -  check cache before/after fresh recall, merge via RRF with rank penalty.
 
-4. **Observability** — new tracing spans and metrics:
+4. **Observability**  -  new tracing spans and metrics:
    - `recall.speculative.prefetch_count`
    - `recall.speculative.cache_hit` / `cache_miss`
    - `recall.speculative.invalidated`
    - `recall.speculative.injected_count`
 
-### 6. Effort Estimate
+### 6. effort estimate
 
 | Work Item | Effort | Dependencies |
 |-----------|--------|--------------|
@@ -306,24 +306,24 @@ Strategies D and E are recommended for a later phase after the MVP proves the ca
 
 ## Recommendations
 
-### Minimum Viable Approach
+### Minimum viable approach
 
 **Start with Strategy A (Graph Neighborhood Pre-Loading) alone.** Rationale:
 
 1. **Highest hit rate** (40-60%) among strategies that require no new models or training data.
-2. **Lowest complexity** — reuses existing graph queries and fact loading.
-3. **No cold start** — the knowledge graph is already populated by extraction.
-4. **Natural fit** — the existing Tier 3 search already does graph expansion reactively; this just moves it earlier.
-5. **Proves the architecture** — the SpeculativeCache and merge logic built for Strategy A are reusable for all other strategies.
+2. **Lowest complexity**  -  reuses existing graph queries and fact loading.
+3. **No cold start**  -  the knowledge graph is already populated by extraction.
+4. **Natural fit**  -  the existing Tier 3 search already does graph expansion reactively; this just moves it earlier.
+5. **Proves the architecture**  -  the SpeculativeCache and merge logic built for Strategy A are reusable for all other strategies.
 
-### Implementation Order
+### Implementation order
 
 1. **Phase 1 (MVP):** Strategy A with feature flag, conservative defaults (1-hop only, 20-fact cache, 0.8 score penalty). Ship behind flag, instrument heavily.
 2. **Phase 2 (Validate):** Run A/B comparison for 2-4 weeks. Measure hit rate, latency delta, and whether injected speculative facts appear in LLM outputs.
 3. **Phase 3 (Expand):** If Phase 2 shows >25% hit rate, add Strategy B (trajectory vector) for sessions where graph coverage is sparse.
 4. **Phase 4 (Learn):** If user patterns become trackable, add Strategy D as a long-term enhancement.
 
-### Configuration Defaults
+### Configuration defaults
 
 ```toml
 [recall.predictive]
@@ -341,41 +341,41 @@ max_prefetch_ms = 50               # Wall-clock budget for speculative work
 
 ## Gotchas
 
-1. **Extraction timing.** Graph neighborhood pre-loading depends on extraction having identified entities from the current turn. Extraction runs in the background and may not complete before the user's next message arrives (especially for short turn gaps). The speculative cache must handle the case where no entities are available yet — fall back to no-op rather than blocking.
+1. **Extraction timing.** Graph neighborhood pre-loading depends on extraction having identified entities from the current turn. Extraction runs in the background and may not complete before the user's next message arrives (especially for short turn gaps). The speculative cache must handle the case where no entities are available yet  -  fall back to no-op rather than blocking.
 
 2. **Hub entity explosion.** High-PageRank entities (e.g., the user's own name, a project name) can have hundreds of 1-hop neighbors. The `max_prefetch_ms` budget and a PageRank-based neighbor limit (skip neighbors with PageRank < 0.01) prevent this from becoming a latency spike.
 
 3. **Score penalty tuning.** The 0.8 multiplier is a guess. Too aggressive and speculative results never surface; too lenient and they displace better fresh results. This needs empirical tuning against real conversations. Log the penalty-adjusted vs raw scores to enable offline analysis.
 
-4. **Interaction with iterative recall.** The existing `run_iterative()` path does terminology discovery and a second search cycle. Speculative results should be merged after the iterative cycles complete, not before — otherwise the speculative cache could prevent terminology discovery from finding novel terms (the system would think it already has enough results).
+4. **Interaction with iterative recall.** The existing `run_iterative()` path does terminology discovery and a second search cycle. Speculative results should be merged after the iterative cycles complete, not before  -  otherwise the speculative cache could prevent terminology discovery from finding novel terms (the system would think it already has enough results).
 
 5. **Cache coherence with fact updates.** If a fact is superseded or forgotten between the speculative fetch and the next recall, the cached version is stale. Check `is_forgotten` and `superseded_by` at merge time, not at cache time.
 
 6. **Multi-nous contention.** In multi-agent scenarios, each `NousActor` has its own speculative cache. This is correct (agents have different knowledge scopes) but means total memory scales with active agent count. At 20KB per agent, this is negligible for typical deployments (<100 agents).
 
-7. **The 5 static factors.** Today, only `vector_similarity` is computed from the actual query — the other 5 factors (decay, relevance, epistemic tier, proximity, frequency) use config defaults or per-fact static values (see `nous/src/recall.rs:470-493`). This means speculative scoring is nearly identical to fresh scoring for those factors. If the scoring model evolves to make more factors query-dependent, speculative pre-scoring becomes less reliable and the cache-then-rescore architecture becomes more important.
+7. **The 5 static factors.** Today, only `vector_similarity` is computed from the actual query  -  the other 5 factors (decay, relevance, epistemic tier, proximity, frequency) use config defaults or per-fact static values (see `nous/src/recall.rs:470-493`). This means speculative scoring is nearly identical to fresh scoring for those factors. If the scoring model evolves to make more factors query-dependent, speculative pre-scoring becomes less reliable and the cache-then-rescore architecture becomes more important.
 
 ---
 
 ## Observations
 
-- **Debt:** `nous/src/recall.rs:470-493` — Only `vector_similarity` is query-computed; the other 5 factor scores are config defaults, not actual per-fact values from mneme. The `decay`, `epistemic_tier`, and `access_frequency` scores should come from the fact's actual metadata (age, tier, access_count) via `RecallEngine::score_decay()` etc. This was likely a simplification during initial integration.
-- **Idea:** The `SpeculativeCache` infrastructure could also be used for "recall pinning" — letting users explicitly pin facts that should always appear in recall, bypassing scoring entirely.
+- **Debt:** `nous/src/recall.rs:470-493`  -  Only `vector_similarity` is query-computed; the other 5 factor scores are config defaults, not actual per-fact values from mneme. The `decay`, `epistemic_tier`, and `access_frequency` scores should come from the fact's actual metadata (age, tier, access_count) via `RecallEngine::score_decay()` etc. This was likely a simplification during initial integration.
+- **Idea:** The `SpeculativeCache` infrastructure could also be used for "recall pinning"  -  letting users explicitly pin facts that should always appear in recall, bypassing scoring entirely.
 - **Doc gap:** No documentation exists for the 6-factor scoring model's weight rationale. The weights (0.35/0.20/0.15/0.15/0.10/0.05) appear to be hand-tuned. An ablation study comparing weight configurations would validate or improve them.
 
 ---
 
 ## References
 
-- `crates/nous/src/recall.rs` — RecallStage, iterative recall, scoring, formatting
-- `crates/nous/src/pipeline.rs` — 6-stage turn pipeline, recall invocation
-- `crates/nous/src/actor/background.rs` — extraction trigger, skill capture
-- `crates/mneme/src/recall.rs` — RecallEngine, 6-factor scoring, FSRS decay
-- `crates/mneme/src/knowledge_store/search.rs` — HNSW, BM25, hybrid, tiered search
-- `crates/mneme/src/knowledge_store/marshal.rs` — HybridQuery building, RRF merge
-- `crates/mneme/src/graph_intelligence.rs` — PageRank, Louvain, proximity boosting
-- `crates/mneme/src/query_rewrite.rs` — LLM query rewriting, tiered search config
-- `crates/mneme/src/hnsw_index.rs` — HNSW vector index wrapper
-- `crates/mneme/src/knowledge.rs` — Fact, Entity, EpistemicTier types
-- `crates/nous/src/config.rs` — NousConfig, RecallConfig, PipelineConfig
-- `crates/nous/src/distillation.rs` — distillation triggers (context/message thresholds)
+- `crates/nous/src/recall.rs`  -  RecallStage, iterative recall, scoring, formatting
+- `crates/nous/src/pipeline.rs`  -  6-stage turn pipeline, recall invocation
+- `crates/nous/src/actor/background.rs`  -  extraction trigger, skill capture
+- `crates/mneme/src/recall.rs`  -  RecallEngine, 6-factor scoring, FSRS decay
+- `crates/mneme/src/knowledge_store/search.rs`  -  HNSW, BM25, hybrid, tiered search
+- `crates/mneme/src/knowledge_store/marshal.rs`  -  HybridQuery building, RRF merge
+- `crates/mneme/src/graph_intelligence.rs`  -  PageRank, Louvain, proximity boosting
+- `crates/mneme/src/query_rewrite.rs`  -  LLM query rewriting, tiered search config
+- `crates/mneme/src/hnsw_index.rs`  -  HNSW vector index wrapper
+- `crates/mneme/src/knowledge.rs`  -  Fact, Entity, EpistemicTier types
+- `crates/nous/src/config.rs`  -  NousConfig, RecallConfig, PipelineConfig
+- `crates/nous/src/distillation.rs`  -  distillation triggers (context/message thresholds)

--- a/planning/research/syntect-replacement.md
+++ b/planning/research/syntect-replacement.md
@@ -6,7 +6,7 @@ Syntect pulls in a large dependency tree including C FFI bindings (Oniguruma), u
 
 ## Findings
 
-### Current Usage Audit
+### Current usage audit
 
 Syntect is used in exactly one location: `crates/theatron/tui/src/highlight.rs` (78 lines of production code).
 
@@ -27,7 +27,7 @@ Syntect is used in exactly one location: `crates/theatron/tui/src/highlight.rs` 
 
 **Languages observed in tests:** Rust, Python, plaintext fallback. The TUI renders LLM responses containing fenced code blocks, so any language is possible, but Rust/Python/TOML/JSON/Bash cover the majority of real usage.
 
-### Current Dependency Cost
+### Current dependency cost
 
 Syntect 5.3.0 with default features pulls 13 direct dependencies and ~35 unique transitive crates. Key cost centers:
 
@@ -47,7 +47,7 @@ Syntect 5.3.0 with default features pulls 13 direct dependencies and ~35 unique 
 
 **Security advisories bypassed:** Two entries in `deny.toml` exist solely for syntect's transitive deps (yaml-rust, bincode).
 
-### Option 1: Syntect with `default-fancy` (Minimal Change)
+### Option 1: Syntect with `default-fancy` (Minimal change)
 
 Switch from the default Oniguruma engine to the pure-Rust `fancy-regex` engine.
 
@@ -68,7 +68,7 @@ Switch from the default Oniguruma engine to the pure-Rust `fancy-regex` engine.
 
 **Effort:** ~30 minutes. One-line Cargo.toml change + verify tests pass.
 
-### Option 2: Syntect with Minimal Features
+### Option 2: Syntect with Minimal features
 
 Disable all features we don't use, keeping only what `highlight.rs` needs.
 
@@ -155,7 +155,7 @@ inkjet bundles 70+ tree-sitter grammars into a single crate with a simpler API.
 
 **Recommendation:** Do not use. Unmaintained.
 
-### Option 5: Minimal Custom Highlighter
+### Option 5: Minimal custom highlighter
 
 Build a simple keyword-based highlighter for the languages we care about.
 
@@ -172,7 +172,7 @@ Build a simple keyword-based highlighter for the languages we care about.
 
 **Effort:** ~3-5 days for Rust + Python + a few others. Ongoing maintenance per language.
 
-### Option 6: No Highlighting
+### Option 6: no highlighting
 
 Remove syntax highlighting entirely. Render code blocks as monochrome text.
 
@@ -184,7 +184,7 @@ Remove syntax highlighting entirely. Render code blocks as monochrome text.
 
 **Effort:** ~1 hour. Delete highlight.rs, update markdown.rs to emit plain text.
 
-### Dependency Comparison
+### Dependency comparison
 
 | Option | Deps added | Deps removed | C FFI | Security advisories |
 |---|---|---|---|---|
@@ -196,7 +196,7 @@ Remove syntax highlighting entirely. Render code blocks as monochrome text.
 | 5: Custom | 0 | all syntect deps | None | None |
 | 6: No highlighting | 0 | all syntect deps | None | None |
 
-### Compile Time Estimate
+### Compile time estimate
 
 Precise measurement requires benchmarking, but directional estimates:
 
@@ -207,7 +207,7 @@ Precise measurement requires benchmarking, but directional estimates:
 
 ## Recommendations
 
-### Primary: Option 2 (Syntect with Minimal Features)
+### Primary: Option 2 (Syntect with Minimal features)
 
 **Justification:**
 1. Zero code changes to `highlight.rs`. The API surface we use is identical.

--- a/planning/research/vision-support.md
+++ b/planning/research/vision-support.md
@@ -12,7 +12,7 @@ How should Aletheia support image inputs in conversations, given the current tex
 
 ## Findings
 
-### 1. Current Message Format Audit
+### 1. Current message format audit
 
 #### Hermeneus (LLM types, `crates/hermeneus/src/types.rs`)
 
@@ -69,9 +69,9 @@ The TUI already has image rendering infrastructure:
 
 This rendering system works from file paths on disk. It does not render base64-encoded image data from message content blocks.
 
-### 2. Anthropic Vision API Requirements
+### 2. Anthropic vision API requirements
 
-#### Message Format
+#### Message format
 
 User messages accept image content blocks alongside text:
 
@@ -107,7 +107,7 @@ URL-referenced images are also supported:
 }
 ```
 
-#### Supported Formats
+#### Supported formats
 
 | Format | MIME Type | Notes |
 |--------|-----------|-------|
@@ -116,13 +116,13 @@ URL-referenced images are also supported:
 | GIF | `image/gif` | Static frames only |
 | WebP | `image/webp` | Good compression |
 
-#### Size Limits
+#### Size limits
 
 - Maximum image size: 20 MB per image (before base64 encoding)
 - Maximum image dimensions: the API resizes images larger than 1568px on the longest edge
 - Images are scaled to fit within a 1568x1568 bounding box while preserving aspect ratio
 
-#### Token Cost
+#### Token cost
 
 Image tokens are calculated from the scaled dimensions:
 
@@ -141,7 +141,7 @@ Examples at common resolutions:
 
 Images are the most token-expensive input type. A single high-resolution image costs as much as 1,800 tokens of text (roughly 1,350 words).
 
-#### Base64 vs URL Trade-offs
+#### Base64 vs URL trade-offs
 
 | Approach | Pros | Cons |
 |----------|------|------|
@@ -150,9 +150,9 @@ Images are the most token-expensive input type. A single high-resolution image c
 
 **Recommendation: base64 for user-provided files, URL for web references.** Aletheia operates locally; most image inputs will be files on disk. Base64 is the right default. URL support can be added later for web search integration.
 
-### 3. Integration Points
+### 3. integration points
 
-#### 3.1 Message Model Changes
+#### 3.1 message model changes
 
 **Add `Image` variant to `ContentBlock`:**
 
@@ -184,7 +184,7 @@ pub enum ImageSource {
 
 This is not needed for phase 1 (the current struct already works for base64), but should be planned for the type to avoid a breaking change later.
 
-#### 3.2 Pipeline Changes
+#### 3.2 pipeline changes
 
 `PipelineMessage` and `PipelineInput` need multimodal content support. Two approaches:
 
@@ -216,7 +216,7 @@ pub struct PipelineMessage {
 
 **Recommendation: Option A.** Keeping raw bytes in the pipeline and encoding at the wire boundary follows the "format at the boundary" principle from STANDARDS.md. It also avoids coupling the pipeline to the hermeneus wire format.
 
-#### 3.3 Token Estimation
+#### 3.3 token estimation
 
 The token estimator needs to account for image tokens. Currently, `PipelineMessage.token_estimate` is computed from text length. Image tokens follow the formula:
 
@@ -231,7 +231,7 @@ The pipeline must:
 
 This prevents the context window from overflowing when multiple images are in the conversation history.
 
-#### 3.4 Image Preprocessing
+#### 3.4 image preprocessing
 
 Before sending to the API, images should be preprocessed to:
 1. **Validate format** (JPEG, PNG, GIF, WebP only)
@@ -241,7 +241,7 @@ Before sending to the API, images should be preprocessed to:
 
 The `image` crate (`image = "0.25"`) is already a dependency of the theatron TUI crate. It handles loading, resizing, and format conversion. It should be added as a workspace dependency for shared use.
 
-#### 3.5 Storage Strategy
+#### 3.5 storage Strategy
 
 Three options for persisting images in mneme:
 
@@ -279,7 +279,7 @@ Store images on disk in `$XDG_DATA_HOME/aletheia/attachments/<hash>.ext` and ref
 
 **Recommendation: Option B for phase 1.** SQLite handles BLOBs well up to moderate sizes. The message content column stores a placeholder (`[image:1]`) while the actual binary lives in the attachments table. This keeps existing text queries fast while supporting binary data. Option C is the right choice if images become large or frequent, but it adds operational complexity that is not justified until storage pressure is measured.
 
-#### 3.6 TUI Rendering
+#### 3.6 TUI rendering
 
 The theatron image system currently renders from file paths detected in text. To render images from message content blocks:
 
@@ -290,11 +290,11 @@ The theatron image system currently renders from file paths detected in text. To
 
 The existing `load_and_render_halfblocks` function works with `image::DynamicImage`. Add a parallel path that decodes base64 data to `DynamicImage` instead of loading from disk.
 
-#### 3.7 Tool Results with Images
+#### 3.7 tool results with images
 
 Already working. The `view_file` tool returns `ToolResultBlock::Image` with base64-encoded data, and the wire serialization handles it. No changes needed for tool-result images.
 
-#### 3.8 User Input Path
+#### 3.8 user input path
 
 Users need a way to attach images. Options:
 
@@ -304,7 +304,7 @@ Users need a way to attach images. Options:
 
 **Recommendation: File path command for TUI, multipart upload for API.** A `/attach` or `/image` command in the TUI is the simplest first step. The TUI already detects image paths; extending this to actually attach them to the outgoing message is straightforward.
 
-### 4. Rust Image Processing Libraries
+### 4. Rust image processing libraries
 
 | Crate | Purpose | Status |
 |-------|---------|--------|
@@ -315,7 +315,7 @@ Users need a way to attach images. Options:
 
 The `image` crate is sufficient for all preprocessing needs: format detection, resize, format conversion. It is pure Rust (no C dependencies) and already compiled as part of the workspace.
 
-### 5. Observations
+### 5. observations
 
 - **Debt**: `PipelineMessage.content` is `String` but should be a richer type even for text-only use. Tool results with images are already converted to text summaries (`[image]`) before storage, losing the image data. (`crates/hermeneus/src/types.rs:190`)
 - **Debt**: `Content::text()` method joins text and thinking blocks but ignores images, which will return empty for image-only messages. (`crates/hermeneus/src/types.rs:60-78`)
@@ -329,7 +329,7 @@ The `image` crate is sufficient for all preprocessing needs: format detection, r
 
 ### Phased Implementation
 
-#### Phase 1: Image Content Block Support (Small)
+#### Phase 1: image content block support (Small)
 
 Add the `Image` variant to `ContentBlock`. This enables images in user messages at the wire format level. Scope:
 
@@ -340,7 +340,7 @@ Add the `Image` variant to `ContentBlock`. This enables images in user messages 
 
 Blast radius: `crates/hermeneus/src/types.rs`, `crates/hermeneus/src/types_tests.rs`
 
-#### Phase 2: Pipeline and Storage (Medium)
+#### Phase 2: pipeline and storage (Medium)
 
 Thread image data through the pipeline and persist it. Scope:
 
@@ -352,7 +352,7 @@ Thread image data through the pipeline and persist it. Scope:
 
 Blast radius: `crates/nous/src/pipeline.rs`, `crates/mneme/src/schema.rs`, `crates/mneme/src/types.rs`, `crates/mneme/src/store/message.rs`, `crates/nous/src/history.rs`, `crates/nous/src/budget.rs`
 
-#### Phase 3: Image Preprocessing (Small)
+#### Phase 3: image preprocessing (Small)
 
 Add validation and preprocessing before API submission. Scope:
 
@@ -363,7 +363,7 @@ Add validation and preprocessing before API submission. Scope:
 
 Blast radius: new module in `crates/nous/src/image.rs` or shared crate
 
-#### Phase 4: TUI Integration (Medium)
+#### Phase 4: TUI integration (Medium)
 
 Enable attaching and viewing images in the TUI. Scope:
 
@@ -374,7 +374,7 @@ Enable attaching and viewing images in the TUI. Scope:
 
 Blast radius: `crates/theatron/tui/src/msg.rs`, `crates/theatron/tui/src/view/chat.rs`, `crates/theatron/tui/src/view/image.rs`, `crates/theatron/tui/src/mapping.rs`
 
-#### Phase 5: API Endpoint (Small)
+#### Phase 5: API endpoint (Small)
 
 Accept image uploads via the pylon HTTP API. Scope:
 
@@ -384,7 +384,7 @@ Accept image uploads via the pylon HTTP API. Scope:
 
 Blast radius: `crates/pylon/src/handler/turn.rs`
 
-### Effort Estimate
+### Effort estimate
 
 | Phase | Scope | Dependencies |
 |-------|-------|-------------|

--- a/planning/research/voice-interaction.md
+++ b/planning/research/voice-interaction.md
@@ -15,7 +15,7 @@ Specific sub-questions:
 
 ## Findings
 
-### 1. Current Channel Architecture
+### 1. Current channel architecture
 
 Agora provides a provider-based channel abstraction with four components:
 
@@ -41,9 +41,9 @@ Currently only Signal (`semeion`) is implemented. The architecture is explicitly
 
 The core abstraction remains text-first. Audio fields are optional extensions for channels that produce or consume audio alongside text.
 
-### 2. STT Options
+### 2. STT options
 
-#### 2A. Candle Whisper (Pure Rust)
+#### 2A. candle whisper (Pure rust)
 
 Candle (`candle-transformers`) includes a full Whisper implementation covering `tiny` through `large-v3` models. Aletheia already depends on candle v0.9.2 for BERT embeddings in mneme.
 
@@ -68,7 +68,7 @@ Candle (`candle-transformers`) includes a full Whisper implementation covering `
 
 **Verdict:** Best fit for batch transcription and low-latency interactive use with `tiny`/`base` models. The accuracy trade-off at small model sizes is acceptable for conversational input where the agent can ask for clarification.
 
-#### 2B. whisper-rs (whisper.cpp Bindings)
+#### 2B. whisper-rs (whisper.cpp bindings)
 
 Rust FFI bindings to whisper.cpp. Latest version 0.15.1 (September 2025). Supports CUDA, ROCm, CoreML acceleration.
 
@@ -86,7 +86,7 @@ Rust FFI bindings to whisper.cpp. Latest version 0.15.1 (September 2025). Suppor
 
 **Verdict:** Technically superior for CPU performance. Conflicts with the pure Rust principle. Could serve as a feature-gated alternative for deployments where latency is critical.
 
-#### 2C. Cloud STT APIs
+#### 2C. cloud STT APIs
 
 | Provider | Latency | Streaming | Cost | Notes |
 |----------|---------|-----------|------|-------|
@@ -107,15 +107,15 @@ Rust FFI bindings to whisper.cpp. Latest version 0.15.1 (September 2025). Suppor
 - Dependency on external service availability
 - OpenAI Realtime API bypasses the LLM layer entirely (speech-to-speech), which conflicts with aletheia's nous/hermeneus architecture
 
-**Verdict:** Useful as a fallback or for deployments where accuracy is paramount. Not suitable as the primary path given the local-first principle.
+**Verdict:** Useful as a fallback or for deployments where accuracy is critical. Not suitable as the primary path given the local-first principle.
 
-#### 2D. Vosk (Local, C-Based)
+#### 2D. vosk (Local, c-Based)
 
 Open-source offline STT using Kaldi models. Rust bindings exist but are unmaintained.
 
 **Verdict:** Not recommended. Unmaintained Rust bindings, large model sizes, C/C++ dependency, accuracy behind Whisper.
 
-#### STT Recommendation
+#### STT recommendation
 
 **Primary:** Candle Whisper with `base` model (best balance of accuracy, latency, and purity). Feature-gated as `voice-stt-candle`.
 
@@ -123,9 +123,9 @@ Open-source offline STT using Kaldi models. Rust bindings exist but are unmainta
 
 **Fallback:** Cloud STT behind `voice-stt-cloud` for maximum accuracy when privacy constraints allow.
 
-### 3. TTS Options
+### 3. TTS options
 
-#### 3A. Piper (Local Neural TTS)
+#### 3A. piper (Local neural TTS)
 
 Fast, local neural TTS. Models are small (15-75 MB). Quality is good for a local engine. Rust bindings exist (`piper-rs`, `piper-tts-rust`) but depend on ONNX Runtime (C++ library).
 
@@ -140,7 +140,7 @@ Fast, local neural TTS. Models are small (15-75 MB). Quality is good for a local
 - Rust bindings are young (piper-rs released 2025)
 - No streaming output (generates full utterance, then plays)
 
-#### 3B. eSpeak-ng (Local, Formant-Based)
+#### 3B. eSpeak-ng (Local, formant-Based)
 
 Mature formant synthesizer. Rust bindings via `espeak-rs`. Compact (~2 MB). Robotic voice quality.
 
@@ -153,7 +153,7 @@ Mature formant synthesizer. Rust bindings via `espeak-rs`. Compact (~2 MB). Robo
 - Robotic voice quality, not suitable as primary TTS
 - C dependency
 
-#### 3C. Cloud TTS APIs
+#### 3C. cloud TTS APIs
 
 | Provider | Quality | Latency | Streaming | Cost |
 |----------|---------|---------|-----------|------|
@@ -173,13 +173,13 @@ Anthropic's own Claude voice mode uses ElevenLabs as a subcontractor.
 - Privacy (text leaves the machine)
 - Cost per character
 
-#### 3D. Candle-Based TTS (Future)
+#### 3D. candle-Based TTS (Future)
 
 No production-ready TTS model exists in candle today. SpeechT5 and VITS implementations are experimental. This gap may close in 2026-2027 as the Rust ML ecosystem matures.
 
 **Verdict:** Not viable today. Worth monitoring.
 
-#### TTS Recommendation
+#### TTS recommendation
 
 **Phase 1:** No TTS. Text responses only. Voice is input-only. This is the simplest path and delivers the core value (hands-free interaction).
 
@@ -187,9 +187,9 @@ No production-ready TTS model exists in candle today. SpeechT5 and VITS implemen
 
 **Phase 3:** Local Piper TTS behind `voice-tts-piper` feature gate when/if pure-Rust ONNX alternatives mature, or accept the C++ dependency behind a gate.
 
-### 4. Voice Channel Design
+### 4. voice channel design
 
-#### 4.1 Audio Capture
+#### 4.1 audio capture
 
 **Crate:** `cpal` (v0.16, 8.7M downloads, pure Rust, cross-platform). Provides real-time audio input/output with platform-native backends (ALSA, PulseAudio, WASAPI, CoreAudio).
 
@@ -197,7 +197,7 @@ No production-ready TTS model exists in candle today. SpeechT5 and VITS implemen
 
 **Buffer size:** 512 samples (32ms at 16kHz). Balances latency against callback overhead.
 
-#### 4.2 Voice Activity Detection (VAD)
+#### 4.2 voice activity detection (VAD)
 
 VAD determines when the user starts and stops speaking. Critical for turn-taking.
 
@@ -211,7 +211,7 @@ VAD determines when the user starts and stops speaking. Critical for turn-taking
 - Max silence within speech: 800ms (allows natural pauses)
 - Post-speech silence: 1.5s (triggers end-of-turn)
 
-#### 4.3 Streaming vs Batch Transcription
+#### 4.3 streaming vs batch transcription
 
 | Approach | Latency | Complexity | Accuracy |
 |----------|---------|------------|----------|
@@ -235,7 +235,7 @@ Microphone (cpal, 16kHz PCM)
     → [Optional TTS] → Speaker (cpal output)
 ```
 
-#### 4.4 Latency Budget (Batch Mode)
+#### 4.4 latency budget (Batch mode)
 
 | Stage | Target | Notes |
 |-------|--------|-------|
@@ -248,7 +248,7 @@ Microphone (cpal, 16kHz PCM)
 
 For comparison, a typical voice assistant (Alexa, Siri) targets 2-3s total. Aletheia's latency is higher due to the full LLM turn, but this is inherent to the agent model. The STT portion (1.5s + 2.0s = 3.5s) is the controllable overhead.
 
-#### 4.5 Audio Codec for Network Transport
+#### 4.5 audio codec for network transport
 
 If voice data needs to travel over the network (e.g., from a remote theatron client to the server):
 
@@ -258,7 +258,7 @@ If voice data needs to travel over the network (e.g., from a remote theatron cli
 
 **Alternative (pure Rust):** `mousiki` crate provides a `no_std` Opus decoder. Encode server-side with `opus-codec`, decode client-side with `mousiki` for embedded targets.
 
-### 5. Agora Integration Pattern
+### 5. agora integration pattern
 
 Voice integrates as a `VoiceProvider` implementing `ChannelProvider`:
 
@@ -303,7 +303,7 @@ sample_rate = 16000
 silence_threshold_ms = 1500
 ```
 
-### 6. Remote Voice (Theatron/Pylon)
+### 6. remote voice (Theatron/Pylon)
 
 For the TUI client (theatron) running on a different machine than the server:
 
@@ -322,7 +322,7 @@ This mirrors how the existing SSE streaming works for text but adds a bidirectio
 
 ## Recommendations
 
-### Phased Implementation Plan
+### Phased Implementation plan
 
 **Phase 1: Local Batch Voice Input (4-6 weeks)**
 - New crate: `phonesis` (from phon/voice + aisthesis/perception)
@@ -352,7 +352,7 @@ This mirrors how the existing SSE streaming works for text but adds a bidirectio
 - Partial transcript display during speech
 - Reduces perceived latency by showing interim results
 
-### Crate Structure
+### Crate structure
 
 ```
 crates/phonesis/
@@ -375,7 +375,7 @@ crates/phonesis/
 └── Cargo.toml
 ```
 
-### Dependency Budget
+### Dependency budget
 
 | Crate | Purpose | Phase | Pure Rust | Size Impact |
 |-------|---------|-------|-----------|-------------|


### PR DESCRIPTION
## Summary

Mechanical doc cleanup from kanon linter audit.

- 74 em dashes replaced with spaced hyphens
- 206 title-case headers converted to sentence case
- AI trope words replaced (leverage, navigate, paramount)
- README crate count 17->18, question header fixed
- SECURITY.md headers to sentence case
- CHANGELOG unreleased section moved above 0.12.0

Closes #1608, #1614, #1617, #1619, #1620, #1621, #1629.

## Test plan

- [ ] All doc links still resolve
- [ ] kanon lint writing violations reduced from 141 to 16 (all false positives)
- [ ] No code changes, no build required