### PR TITLE
docs: rewrite user-facing docs (README, quickstart, deployment)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,44 @@
 # Aletheia
 
-Self-hosted multi-agent AI system with persistent memory and Signal messaging.
+Self-hosted AI agents with persistent memory.
 
-Privacy-first. Runs on commodity hardware. No cloud dependencies beyond your LLM API key.
+Talk to an AI that remembers your previous conversations, learns your preferences, builds a knowledge graph over time, and gets better the more you use it. Give it a name, a personality, goals, and tools. Run it from a terminal dashboard, HTTP API, or Signal messenger.
 
-[Standards](standards/README.md) · [Quickstart](docs/QUICKSTART.md) · [Configuration](docs/CONFIGURATION.md) · [Architecture](docs/ARCHITECTURE.md) · [Architecture Guide](docs/ARCHITECTURE-GUIDE.md) · [Technology](docs/TECHNOLOGY.md) · [Data](docs/DATA.md) · [Network](docs/NETWORK.md) · [Packs](docs/PACKS.md) · [Releasing](docs/RELEASING.md)
+One binary. No containers. No external databases. No cloud dependencies beyond your LLM provider.
+
+[Quickstart](docs/QUICKSTART.md) · [Configuration](docs/CONFIGURATION.md) · [Deployment](docs/DEPLOYMENT.md) · [Architecture](docs/ARCHITECTURE.md)
 
 ---
 
-## What it is
+## Quick start
 
-Multiple AI agents working in concert with a human operator. Each agent has character, memory, and domain expertise. They persist understanding across sessions, coordinate through shared infrastructure, and evolve through use.
+```bash
+# Install (Linux x86_64)
+curl -L https://github.com/forkwright/aletheia/releases/latest/download/aletheia-linux-x86_64 -o aletheia
+chmod +x aletheia && sudo mv aletheia /usr/local/bin/
 
-Not a chatbot framework. A distributed cognition system.
+# Setup (interactive wizard handles config, credentials, first agent)
+aletheia init
+
+# Run
+aletheia                # start the server
+aletheia tui            # open the terminal dashboard
+```
+
+Build from source: `cargo build --release` (requires Rust 1.94+). See [QUICKSTART.md](docs/QUICKSTART.md) for the full guide.
+
+---
+
+## What you get
+
+- **Persistent memory.** Conversations carry forward. The agent builds a knowledge graph of facts, entities, and relationships that persists across sessions and grows over time.
+- **Multiple agents.** Each agent has its own character (SOUL.md), goals, memory, and workspace. They can coordinate, delegate, and specialize.
+- **Tools.** 33 built-in tools: file I/O, shell execution, web search, memory search, agent coordination. Extend with domain packs or custom tools.
+- **Terminal dashboard.** Rich TUI with markdown rendering, session management, and real-time streaming.
+- **Signal messaging.** Talk to your agents over Signal with 15 built-in commands.
+- **Privacy.** No telemetry, no analytics, no phone-home. Only outbound connections are to services you configure.
+
+---
 
 ## Architecture
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -11,59 +11,29 @@ Step-by-step guide from bare Linux or macOS to a running Aletheia instance. For 
 
 ## Getting started (first-time setup)
 
-Five steps from a fresh clone to a running instance:
-
-**Step 1: Install the binary**
+Three commands from zero to a running instance:
 
 ```bash
-cargo build --release
-cp target/release/aletheia ~/.local/bin/
+# 1. Install the binary (or build from source: cargo build --release)
+curl -L https://github.com/forkwright/aletheia/releases/latest/download/aletheia-linux-x86_64 -o aletheia
+chmod +x aletheia && sudo mv aletheia /usr/local/bin/
+
+# 2. Initialize (creates instance directory, config, credentials, first agent)
+aletheia init
+
+# 3. Start
+aletheia
 ```
 
-**Step 2: Copy the instance scaffold**
+The init wizard prompts for your API key, model, agent name, and bind address, then writes a complete instance. For non-interactive (CI/scripting) use:
 
 ```bash
-cp -r instance.example instance
+ANTHROPIC_API_KEY=sk-ant-... aletheia init --yes --instance-root /srv/aletheia/instance
 ```
 
-This creates the directory tree (`config/`, `data/`, `nous/`, etc.) with template files ready to edit.
+Verify with `aletheia health`. A `healthy` response means the server is running with a registered LLM provider. If the status is `degraded`, verify your API key is set and the config loaded it.
 
-**Step 3: Configure credentials**
-
-Set your Anthropic API key as an environment variable (or use the init wizard, see [Instance setup](#instance-setup)):
-
-```bash
-export ANTHROPIC_API_KEY="sk-ant-..."
-```
-
-Then edit `instance/config/aletheia.toml` (copy from `instance/config/aletheia.toml.example` if it does not exist) and set the bind address, port, and auth mode.
-
-**Step 4: Set up your first agent**
-
-```bash
-cp -r instance/nous/_template instance/nous/main
-```
-
-Edit `instance/nous/main/SOUL.md` with your agent's identity, then add the agent to `aletheia.toml`:
-
-```toml
-[agents]
-[[agents.list]]
-id = "main"
-default = true
-```
-
-**Step 5: Start and verify**
-
-```bash
-aletheia --instance-root ./instance
-# In another terminal:
-aletheia health
-```
-
-A `healthy` response means the server is running with a registered LLM provider. If the status is `degraded`, verify your `ANTHROPIC_API_KEY` is set and the config loaded it.
-
-> **Faster alternative:** Run `aletheia init` to let the interactive wizard perform steps 2–4 automatically.
+> **Manual setup:** If you prefer to configure everything by hand instead of using the wizard, see [Manual: copy the example scaffold](#manual-copy-the-example-scaffold) below.
 
 ---
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -1,27 +1,36 @@
 # Quickstart
 
-## Prerequisites
-
-- Rust toolchain (stable)
-- An Anthropic API key (or Claude Code installed - key is auto-detected)
-
 ## Install
 
+Download the prebuilt binary for your platform:
+
 ```bash
-git clone https://github.com/forkwright/aletheia.git
-cd aletheia
+# Linux x86_64
+curl -L https://github.com/forkwright/aletheia/releases/latest/download/aletheia-linux-x86_64 -o aletheia
+chmod +x aletheia && sudo mv aletheia /usr/local/bin/
+
+# macOS Apple Silicon
+curl -L https://github.com/forkwright/aletheia/releases/latest/download/aletheia-macos-aarch64 -o aletheia
+chmod +x aletheia && sudo mv aletheia /usr/local/bin/
+```
+
+Or build from source (requires Rust 1.94+):
+
+```bash
+git clone https://github.com/forkwright/aletheia.git && cd aletheia
 cargo build --release
 cp target/release/aletheia ~/.local/bin/
 ```
 
-## Initialize
+## Setup
+
+The init wizard creates an instance directory, writes config, sets up credentials, and scaffolds your first agent:
 
 ```bash
-export ANTHROPIC_API_KEY=sk-ant-...   # or enter it interactively
-aletheia init                          # creates instance/, prompts for settings
+aletheia init
 ```
 
-Accepts `--yes` for non-interactive setup (uses defaults + env var API key):
+It will prompt for your API key, model preference, and agent name. For non-interactive setup:
 
 ```bash
 ANTHROPIC_API_KEY=sk-ant-... aletheia init --yes
@@ -30,32 +39,36 @@ ANTHROPIC_API_KEY=sk-ant-... aletheia init --yes
 ## Run
 
 ```bash
-aletheia              # start the server (gateway, agents, daemon)
-aletheia health       # check connectivity (prints OK or FAILED)
-aletheia tui          # launch the terminal dashboard
+aletheia              # start the server
+aletheia tui          # open the terminal dashboard
+```
+
+In another terminal:
+
+```bash
+aletheia health       # verify the server is running
+aletheia status       # agent status, sessions, storage
 ```
 
 ## Daily use
 
 ```bash
-aletheia              # start the server (gateway, agents, daemon)
-aletheia health       # check config and connectivity
-aletheia status       # agent status, sessions, cron jobs
-aletheia backup       # create a point-in-time database backup
+aletheia              # start the server
+aletheia tui          # talk to your agent
+aletheia backup       # create a database backup
+aletheia --help       # full command reference
 ```
 
-Run `aletheia --help` for the full command reference.
+Everything runs locally. The embedded knowledge engine, session store, and embedding model are all inside the binary. No external databases, containers, or sidecars.
 
-Memory (embedded engine, candle) is embedded in the binary. No external databases, containers, or sidecars required.
+## Optional: Signal messaging
 
-## Optional: signal integration
-
-Requires [signal-cli](https://github.com/AsamK/signal-cli) and a registered phone number. See [CONFIGURATION.md](CONFIGURATION.md#channelssignal) for setup.
+Talk to your agents over Signal. Requires [signal-cli](https://github.com/AsamK/signal-cli) and a registered phone number. See [CONFIGURATION.md](CONFIGURATION.md#channelssignal) for setup.
 
 ## Next steps
 
-- [CONFIGURATION.md](CONFIGURATION.md) - config reference
-- [DEPLOYMENT.md](DEPLOYMENT.md) - production setup
-- [troubleshooting.md](troubleshooting.md) - common issues and fixes
-- [WORKSPACE_FILES.md](WORKSPACE_FILES.md) - agent workspace files
-- [ARCHITECTURE.md](ARCHITECTURE.md) - system architecture and extension points
+- [CONFIGURATION.md](CONFIGURATION.md): full config reference
+- [DEPLOYMENT.md](DEPLOYMENT.md): production setup, systemd, TLS
+- [troubleshooting.md](troubleshooting.md): common issues and fixes
+- [WORKSPACE_FILES.md](WORKSPACE_FILES.md): agent workspace files
+- [ARCHITECTURE.md](ARCHITECTURE.md): system architecture and extension points


### PR DESCRIPTION
## Summary

User-facing docs rewritten to lead with what aletheia does and the fastest path to running it.

**README:**
- New plain-language intro: "Talk to an AI that remembers..."
- Quick start leads with binary download (3 commands), not cargo build
- "What you get" section: persistent memory, multiple agents, tools, TUI, Signal, privacy
- Architecture section preserved below

**QUICKSTART:**
- Prebuilt binary download is primary install method
- `aletheia init` is THE setup path (not manual cp + edit)
- Build from source is secondary
- Three commands: install, init, run

**DEPLOYMENT:**
- "Getting started" replaced: 5 manual steps -> 3 commands with init wizard
- Manual scaffold setup demoted to reference section
- Non-interactive init example for CI/scripting

Closes #1644, #1645, #1646.

## Test plan

- [ ] All doc links resolve
- [ ] README reads well for someone who's never seen the project
- [ ] Binary download URLs point to real release assets