### PR TITLE
docs: add per-crate CLAUDE.md and agent navigation improvements

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,21 @@ cargo clippy --workspace               # Lint (zero warnings)
 - `instance.example/` shows the expected structure for fresh clones
 - CI PII scanner rejects commits with personal data patterns (`.github/pii-patterns.txt`)
 
+## Where to add things
+
+| Task | Location | Registration |
+|------|----------|-------------|
+| CLI subcommand | `crates/aletheia/src/commands/` | Add to clap derive in `main.rs` |
+| API endpoint | `crates/pylon/src/handlers/` | Add route in `crates/pylon/src/routes.rs` |
+| Built-in tool | `crates/organon/src/builtins/` | Register in `register_all()` |
+| Config section | `crates/taxis/src/config.rs` | Add field to `AletheiaConfig` struct |
+| Error variant | `crates/{crate}/src/error.rs` | snafu derive on the crate's Error enum |
+| Maintenance task | `crates/daemon/src/` | Register in runner |
+| Bootstrap file | `crates/nous/src/bootstrap/` | Add to section list in assembler |
+| Middleware | `crates/pylon/src/middleware/` | Add layer in `crates/pylon/src/server.rs` |
+
+Per-crate details in each crate's `CLAUDE.md`.
+
 ## Adding tools
 
 Tools live in `crates/organon/`. Each tool implements the `ToolExecutor` trait:

--- a/crates/hermeneus/CLAUDE.md
+++ b/crates/hermeneus/CLAUDE.md
@@ -1,0 +1,47 @@
+# hermeneus
+
+Anthropic LLM client with streaming, retries, fallback, health tracking, and cost estimation. 7K lines.
+
+## Read first
+
+1. `src/types.rs`: CompletionRequest, CompletionResponse, Message, ContentBlock (canonical type system)
+2. `src/provider.rs`: LlmProvider trait, ProviderRegistry, ModelPricing
+3. `src/anthropic/client.rs`: AnthropicProvider (HTTP client, retries, streaming)
+4. `src/error.rs`: Error variants and `is_retryable()` classification
+5. `src/health.rs`: ProviderHealth state machine (Up/Degraded/Down)
+
+## Key types
+
+| Type | Path | Purpose |
+|------|------|---------|
+| `LlmProvider` | `provider.rs` | Trait: `complete()`, `complete_streaming()`, `supported_models()` |
+| `ProviderRegistry` | `provider.rs` | Model -> provider routing with health tracking |
+| `AnthropicProvider` | `anthropic/client.rs` | Concrete Anthropic Messages API implementation |
+| `CompletionRequest` | `types.rs` | LLM request (model, messages, tools, thinking, cache config) |
+| `CompletionResponse` | `types.rs` | LLM response (content blocks, usage, stop reason) |
+| `StreamEvent` | `anthropic/mod.rs` | SSE events: TextDelta, ThinkingDelta, ToolUse, etc. |
+| `FallbackConfig` | `fallback.rs` | Model fallback chain on transient failures |
+
+## Patterns
+
+- **Retry + backoff**: exponential (1s base, 2x factor, 30s max), 3 retries default. Jitter ±25%.
+- **Health circuit breaker**: 5 consecutive errors -> Down. 60s cooldown. AuthFailure never auto-recovers.
+- **Streaming**: SSE parser emits StreamEvent. Retry-safe only before first event (mid-stream propagates).
+- **Prompt caching**: `cache_system`, `cache_tools`, `cache_turns` flags inject `cache_control: ephemeral`.
+- **OAuth auth**: `Bearer` + `anthropic-beta: oauth-2025-04-20`. API key auth: `x-api-key` header.
+- **Wire format**: `anthropic/wire/` handles Anthropic-specific JSON serialization.
+
+## Common tasks
+
+| Task | Where |
+|------|-------|
+| Add LLM provider | New module (e.g., `src/openai/`), implement `LlmProvider` trait |
+| Modify retry logic | `src/models.rs` (constants) + `src/anthropic/client.rs` (retry loop) |
+| Add streaming event | `anthropic/mod.rs` (StreamEvent enum) + `anthropic/stream.rs` (accumulator) |
+| Update model pricing | `src/models.rs` (PRICING constant) |
+| Add metric | `src/metrics.rs` (LazyLock static, record function) |
+
+## Dependencies
+
+Uses: koina, taxis, reqwest, serde_json, tokio, snafu, tracing
+Used by: nous, pylon, organon, melete

--- a/crates/mneme/CLAUDE.md
+++ b/crates/mneme/CLAUDE.md
@@ -1,0 +1,47 @@
+# mneme
+
+Session store (SQLite) and knowledge engine (CozoDB Datalog + HNSW vectors). 110K lines. The memory layer.
+
+## Read first
+
+1. `src/types.rs`: Session, Message, UsageRecord (core domain)
+2. `src/knowledge.rs`: Fact, Entity, Relationship, EpistemicTier
+3. `src/store/mod.rs`: SessionStore (SQLite WAL)
+4. `src/knowledge_store/mod.rs`: KnowledgeStore (CozoDB, feature-gated)
+5. `src/recall.rs`: 6-factor recall scoring engine
+
+## Key types
+
+| Type | Path | Purpose |
+|------|------|---------|
+| `SessionStore` | `store/mod.rs` | SQLite session/message persistence |
+| `KnowledgeStore` | `knowledge_store/mod.rs` | CozoDB Datalog + HNSW (feature: `mneme-engine`) |
+| `Fact` | `knowledge.rs` | Bi-temporal memory with confidence, tier, decay |
+| `Entity` | `knowledge.rs` | Named entity with aliases and type |
+| `RecallEngine` | `recall.rs` | Weighted 6-factor scoring for memory retrieval |
+| `ExtractionEngine` | `extract/mod.rs` | LLM-driven fact/entity extraction from conversations |
+| `SkillExtractor` | `skills/mod.rs` | Auto-capture of recurring tool patterns as skills |
+
+## Patterns
+
+- **Bi-temporal facts**: `valid_from`/`valid_to` windows. Supersession chains via `superseded_by`.
+- **Epistemic tiers**: Verified > Inferred > Assumed. Tier affects decay rate and consolidation eligibility.
+- **FSRS decay**: `stability_hours` + `access_count` drive spaced-repetition-style recall scoring.
+- **Datalog queries**: typed builder in `query/builders.rs` or raw via `KnowledgeStore::run_query()`.
+- **SQLite recovery**: integrity check on open, auto-repair (backup + re-init), read-only fallback.
+- **Feature flags**: `mneme-engine` (knowledge store), `storage-fjall` (persistent), `embed-candle` (local embeddings).
+
+## Common tasks
+
+| Task | Where |
+|------|-------|
+| Add session field | `src/types.rs` (struct) + `src/schema.rs` (DDL) + `src/migration.rs` + `src/store/session.rs` |
+| Add knowledge query | `src/query/builders.rs` (typed) or `src/knowledge_store/mod.rs` (raw Datalog) |
+| Add recall signal | `src/recall.rs` (new field in FactorScores + weight in RecallWeights) |
+| Add extraction type | `src/extract/types.rs` + `src/extract/engine.rs` |
+| Add skill heuristic | `src/skills/heuristics.rs` (scoring function) |
+
+## Dependencies
+
+Uses: koina, serde, jiff, ulid, rusqlite, snafu, tracing, candle-*, fjall
+Used by: nous, pylon, melete, aletheia (binary)

--- a/crates/nous/CLAUDE.md
+++ b/crates/nous/CLAUDE.md
@@ -1,0 +1,56 @@
+# nous
+
+Agent session pipeline: bootstrap, recall, execute, finalize. 15K lines. The agent runtime.
+
+## Read first
+
+1. `src/actor/mod.rs`: NousActor run loop (tokio::select! inbox pattern)
+2. `src/pipeline.rs`: PipelineInput, PipelineContext, TurnResult, guard logic
+3. `src/bootstrap/mod.rs`: System prompt assembly from workspace cascade
+4. `src/execute/mod.rs`: LLM call + tool dispatch loop
+5. `src/manager.rs`: NousManager lifecycle, health polling, restart
+
+## Key types
+
+| Type | Path | Purpose |
+|------|------|---------|
+| `NousActor` | `actor/mod.rs` | Tokio actor processing turns sequentially |
+| `NousHandle` | `handle.rs` | Cloneable sender for invoking turns |
+| `NousManager` | `manager.rs` | Spawns actors, monitors health, routes messages |
+| `PipelineContext` | `pipeline.rs` | Assembled context flowing through pipeline stages |
+| `BootstrapAssembler` | `bootstrap/mod.rs` | Priority-based system prompt packer |
+| `CrossNousRouter` | `cross.rs` | Inter-agent message routing with delivery audit |
+| `SessionState` | `session.rs` | In-memory session tracking (turn count, token estimate) |
+
+## Pipeline stages (in order)
+
+1. **Guard**: rate limits, session token cap, loop detection
+2. **Bootstrap**: assemble system prompt from workspace files (SOUL.md, etc.)
+3. **Skills**: inject task-relevant skills from knowledge store
+4. **Recall**: vector/BM25 search for related memories
+5. **History**: load recent messages within token budget
+6. **Execute**: LLM call, tool dispatch loop (max_tool_iterations)
+7. **Finalize**: persist messages, record usage, emit events
+
+## Patterns
+
+- **Actor model**: sequential message processing, panic boundary (degrades after 5 panics/10min)
+- **Bootstrap packing**: Required > Important > Flexible > Optional. Truncate flexible, drop optional.
+- **Token budget**: `CharEstimator` (chars_per_token=4). History gets 60% of remaining budget.
+- **Distillation triggers**: context >= 120K tokens, messages >= 150, 7+ day stale sessions.
+- **Session types**: primary (long-lived), ephemeral (`ask:`, `spawn:` prefix), background (`prosoche`).
+
+## Common tasks
+
+| Task | Where |
+|------|-------|
+| Add pipeline stage | New module in `src/`, wire into `src/actor/mod.rs::handle_turn()` |
+| Modify bootstrap | `src/bootstrap/mod.rs` (WorkspaceFileSpec list, priorities) |
+| Modify recall | `src/recall.rs` (weights, search strategy, reranking) |
+| Add session hook | `src/session.rs` (SessionManager or SessionState) |
+| Add cross-nous message type | `src/cross.rs` (CrossNousMessage enum) |
+
+## Dependencies
+
+Uses: koina, taxis, mneme, hermeneus, organon, melete, thesauros, tokio, snafu
+Used by: pylon, aletheia (binary)

--- a/crates/organon/CLAUDE.md
+++ b/crates/organon/CLAUDE.md
@@ -1,0 +1,56 @@
+# organon
+
+Tool registry, executors, and sandbox. 12K lines. 33 built-in tools.
+
+## Read first
+
+1. `src/registry.rs`: ToolRegistry, ToolExecutor trait (the core abstraction)
+2. `src/types.rs`: ToolDef, ToolInput, ToolResult, ToolContext, service traits
+3. `src/builtins/mod.rs`: register_all() and module organization
+4. `src/sandbox.rs`: Landlock + seccomp + network namespace config
+5. `src/process_guard.rs`: RAII subprocess lifecycle (kill-on-drop)
+
+## Key types
+
+| Type | Path | Purpose |
+|------|------|---------|
+| `ToolExecutor` | `registry.rs` | Trait: `async execute(input, ctx) -> Result<ToolResult>` |
+| `ToolRegistry` | `registry.rs` | Name-based dispatch with metrics and tracing |
+| `ToolDef` | `types.rs` | Tool metadata: name, description, schema, category |
+| `ToolContext` | `types.rs` | Per-execution context: nous_id, session_id, workspace, services |
+| `ToolServices` | `types.rs` | Service locator: messaging, planning, knowledge, spawn |
+| `SandboxConfig` | `sandbox.rs` | Landlock + seccomp + egress policy |
+| `ProcessGuard` | `process_guard.rs` | RAII child process wrapper (prevents orphans/zombies) |
+
+## Built-in tools (33)
+
+| Category | Tools |
+|----------|-------|
+| Workspace | read, write, edit, exec, view_file, grep, find, ls |
+| Memory | memory_search, memory_correct, memory_retract, memory_forget, memory_audit, note, blackboard, datalog_query |
+| Communication | message, sessions_send, sessions_ask |
+| Agent | sessions_spawn, sessions_dispatch, enable_tool |
+| Planning | plan_create, plan_research, plan_requirements, plan_roadmap, plan_discuss, plan_execute, plan_verify, plan_status, plan_step_complete, plan_step_fail |
+| Research | web_fetch |
+
+## Patterns
+
+- **Registration**: `ToolDef` + `impl ToolExecutor` -> `registry.register(def, Box::new(executor))`
+- **Activation**: `auto_activate: true` = always available. `false` = requires `enable_tool` to activate.
+- **Sandbox**: Linux only. Landlock (filesystem), seccomp (syscalls), network namespace. Permissive default.
+- **Path validation**: normalize -> check allowed_roots -> canonicalize -> re-check. Tilde expansion.
+- **ProcessGuard**: `kill()` + `wait()` on drop. Call `detach()` if process should outlive guard.
+
+## Common tasks
+
+| Task | Where |
+|------|-------|
+| Add built-in tool | New file in `src/builtins/`, implement ToolExecutor, register in `builtins/mod.rs` |
+| Modify sandbox | `src/sandbox.rs` (SandboxConfig) + `aletheia.toml` [sandbox] section |
+| Add service trait | `src/types.rs` (new trait) + binary crate provides implementation |
+| Add tool category | `src/types.rs` (ToolCategory enum) |
+
+## Dependencies
+
+Uses: koina, hermeneus, tokio, serde, snafu, tracing, landlock, seccompiler
+Used by: nous, pylon, thesauros, aletheia (binary)

--- a/crates/pylon/CLAUDE.md
+++ b/crates/pylon/CLAUDE.md
@@ -1,0 +1,61 @@
+# pylon
+
+HTTP gateway: Axum handlers, SSE streaming, auth middleware, rate limiting. 10K lines.
+
+## Read first
+
+1. `src/router.rs`: Route construction and middleware layer ordering (read the comments)
+2. `src/state.rs`: AppState (shared state everything references)
+3. `src/handlers/sessions/streaming.rs`: SSE streaming + idempotency
+4. `src/middleware.rs`: CSRF, request ID, rate limiting (per-IP + per-user)
+5. `src/error.rs`: ApiError enum and HTTP status mapping
+
+## Key types
+
+| Type | Path | Purpose |
+|------|------|---------|
+| `AppState` | `state.rs` | Shared state: stores, managers, JWT, config, shutdown token |
+| `ApiError` | `error.rs` | Error enum mapping to HTTP status codes |
+| `Claims` | `extract.rs` | JWT auth extractor |
+| `SecurityConfig` | `security.rs` | CORS, CSRF, TLS, rate limit config |
+| `SseEvent` | `stream.rs` | Message streaming events (TextDelta, ToolUse, etc.) |
+| `RateLimiter` | `middleware.rs` | Per-IP sliding window limiter |
+| `UserRateLimiter` | `middleware.rs` | Per-user token bucket with endpoint categories |
+| `IdempotencyCache` | `idempotency.rs` | TTL + LRU dedup for message sends |
+
+## Handler structure
+
+All handlers: `async fn(State(Arc<AppState>), Claims, ...) -> Result<impl IntoResponse, ApiError>`
+
+| Endpoint | Handler file |
+|----------|-------------|
+| `GET /api/health` | `handlers/health.rs` |
+| `GET /metrics` | `handlers/metrics.rs` |
+| `*/api/v1/sessions/*` | `handlers/sessions/` |
+| `*/api/v1/nous/*` | `handlers/nous.rs` |
+| `*/api/v1/config/*` | `handlers/config.rs` |
+| `*/api/v1/knowledge/*` | `handlers/knowledge.rs` |
+
+## Patterns
+
+- **Middleware order** (outermost first): security headers, CORS, request ID, trace, compression, metrics, error enrichment, body limit, CSRF, rate limiting, then routes.
+- **SSE streaming**: spawns tokio task subscribing to nous turn stream, converts to SseEvent, wraps in `Sse<Stream>` with KeepAlive.
+- **Idempotency**: `Idempotency-Key` header on POST /messages. Cache hit replays response. In-flight returns 409.
+- **CSRF**: custom header required on POST/PUT/DELETE/PATCH. Auto-generates per-instance token at startup.
+- **5xx errors**: generic message to clients, real detail logged internally only.
+- **OpenAPI**: utoipa derive on handlers, served at `GET /api/docs/openapi.json`.
+- **Config hot-reload**: SIGHUP handler re-reads config, validates, swaps via watch channel.
+
+## Common tasks
+
+| Task | Where |
+|------|-------|
+| Add API endpoint | `src/handlers/` (handler fn) + `src/router.rs` (route) + `src/openapi.rs` (spec) |
+| Add middleware | `src/middleware.rs` (fn) + `src/router.rs` (layer at correct position) |
+| Add error type | `src/error.rs` (ApiError variant + IntoResponse mapping) |
+| Add request type | `src/handlers/sessions/types.rs` or inline |
+
+## Dependencies
+
+Uses: koina, taxis, nous, hermeneus, mneme, organon, symbolon, axum, tower, tokio, snafu
+Used by: aletheia (binary)

--- a/instance.example/nous/_template/README.md
+++ b/instance.example/nous/_template/README.md
@@ -1,38 +1,44 @@
 # Nous agent template
 
-This directory is the reference template for new Aletheia agents. It shows the expected file and directory structure for a nous workspace.
+This directory is the reference template for new Aletheia agents. Copy it with `aletheia add-nous <name>` to create an additional agent.
 
-## Directory Structure
+## Directory structure
 
 ```text
 {agent-id}/
-├── workspace/
-│   ├── scripts/     # Agent-authored scripts and tools (git-tracked)
-│   ├── drafts/      # Work-in-progress output files (git-tracked)
-│   └── data/        # Datasets and ephemeral outputs (gitignored)
-├── AGENTS.md        # Operational defaults and tool grants
-├── CONTEXT.md       # Persistent context injected every session
-├── GOALS.md         # Active and completed goals
+├── SOUL.md          # Identity, voice, principles
 ├── IDENTITY.md      # Runtime-required: name and emoji
-├── MEMORY.md        # Agent knowledge base
-├── PROSOCHE.md      # Attention and focus directives
-├── SOUL.md          # Identity, voice, principles (written during onboarding)
-├── TOOLS.md         # Tool usage guidelines
+├── GOALS.md         # Active and completed goals
+├── MEMORY.md        # Curated operational memory
+├── AGENTS.md        # Operational rules, delegation, output quality
+├── CONTEXT.md       # Session-scoped state (runtime-written)
+├── PROSOCHE.md      # Attention and heartbeat directives
+├── TOOLS.md         # Tool inventory (auto-generated)
+├── USER.md          # Operator profile (learned from conversation)
+├── VOICE.md         # Operator writing style (learned from conversation)
 └── USER.md          # Operator profile and preferences
 ```
 
-## Gitignore Defaults
+## What goes where
 
-The parent `nous.dir/.gitignore` (written by `aletheia init`) contains:
+This directory holds **identity and session memory only**. All working files go in `theke/`:
 
-- `*/workspace/plans/` - planning artifacts (large, ephemeral)
-- `*/workspace/data/` - datasets and outputs (potentially large, private)
-- `memory/` - session memory logs
-- `.aletheia-index/` - workspace file index
-- `.env`, `*.key`, `*.pem`, `*.secret`, `secrets/`, `credentials/` - credentials
+| Content | Location |
+|---------|----------|
+| Identity files (SOUL, GOALS, etc.) | `nous/{id}/` |
+| Session logs | `nous/{id}/memory/YYYY-MM-DD.md` |
+| Project work, drafts, specs | `theke/projects/{name}/` |
+| Research | `theke/research/` |
+| Agent scratch space | `theke/nous/{id}/` |
 
-`workspace/scripts/` and `workspace/drafts/` are git-tracked by default.
+See `instance.example/README.md` for the full file organization guide.
+
+## Gitignore defaults
+
+- `memory/` session logs
+- `.aletheia-index/` workspace file index
+- `.env`, `*.key`, `*.pem`, `*.secret`, `secrets/`, `credentials/`
 
 ## Usage
 
-`aletheia init` creates a new agent directory with this structure. Files from `_example/` are NOT copied - the new agent starts with blank files generated from templates in the runtime. The `workspace/` subdirectories are created automatically.
+`aletheia add-nous <name>` copies this template to create a new agent. `aletheia init` uses `_default/` (Pronoea) for the first agent.


### PR DESCRIPTION
## Summary

AI agents working on specific crates now get immediate local context via per-crate CLAUDE.md files.

**5 per-crate CLAUDE.md files** (mneme, nous, hermeneus, pylon, organon):
- One-line purpose
- "Read first" ordered list (5 files max)
- Key types table with module paths
- Crate-specific patterns (condensed)
- Common tasks table (task -> file location)
- Dependencies (uses/used by)

**Root CLAUDE.md**: new "Where to add things" table mapping 8 common tasks to exact file locations.

**_template README**: removed `workspace/` directory tree that contradicted AGENTS.md. Aligned with "identity + memory only" rule.

Closes #1647, #1649, #1657.

## Test plan

- [ ] Each CLAUDE.md references real types (grep to verify)
- [ ] Root CLAUDE.md table paths are accurate
- [ ] _template README no longer mentions workspace/ subdirectories