### PR TITLE
api: add #[non_exhaustive] to 44 remaining public enums

### DIFF
--- a/crates/dianoia/src/project.rs
+++ b/crates/dianoia/src/project.rs
@@ -34,6 +34,7 @@ pub struct Project {
 
 /// Operating modes for planning.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub enum ProjectMode {
     /// Full multi-phase project with research, scoping, planning, and verification.
     Full,

--- a/crates/hermeneus/src/anthropic/batch.rs
+++ b/crates/hermeneus/src/anthropic/batch.rs
@@ -49,6 +49,7 @@ pub struct BatchResult {
 /// Result type for a batch item.
 #[derive(Debug, Clone, Deserialize)]
 #[serde(tag = "type")]
+#[non_exhaustive]
 pub enum BatchResultType {
     #[serde(rename = "succeeded")]
     Succeeded { message: serde_json::Value },

--- a/crates/mneme/src/conflict.rs
+++ b/crates/mneme/src/conflict.rs
@@ -20,6 +20,7 @@ use crate::knowledge::EpistemicTier;
 /// Errors from the conflict detection pipeline.
 #[derive(Debug, Snafu)]
 #[snafu(visibility(pub(crate)))]
+#[non_exhaustive]
 pub enum ConflictError {
     /// The LLM classification call failed.
     #[snafu(display("conflict classification failed: {message}"))]

--- a/crates/mneme/src/extract/error.rs
+++ b/crates/mneme/src/extract/error.rs
@@ -3,6 +3,7 @@ use snafu::Snafu;
 /// Errors from the knowledge extraction pipeline.
 #[derive(Debug, Snafu)]
 #[snafu(visibility(pub))]
+#[non_exhaustive]
 pub enum ExtractionError {
     /// The LLM response could not be parsed as valid extraction JSON.
     #[snafu(display("failed to parse extraction response"))]

--- a/crates/mneme/src/skills/extract.rs
+++ b/crates/mneme/src/skills/extract.rs
@@ -19,6 +19,7 @@ use crate::skills::{SkillCandidate, ToolCallRecord};
 /// Errors from the skill extraction pipeline.
 #[derive(Debug, Snafu)]
 #[snafu(visibility(pub))]
+#[non_exhaustive]
 pub enum SkillExtractionError {
     /// The LLM provider returned an error.
     #[snafu(display("LLM extraction failed: {message}"))]

--- a/crates/nous/src/bootstrap/mod.rs
+++ b/crates/nous/src/bootstrap/mod.rs
@@ -23,6 +23,7 @@ use crate::error::{self, Result};
 /// Derives `Ord` so sections sort Required-first.
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[non_exhaustive]
 pub enum SectionPriority {
     /// Must be included. Missing = error.
     Required = 0,

--- a/crates/nous/src/message.rs
+++ b/crates/nous/src/message.rs
@@ -50,6 +50,7 @@ pub enum NousMessage {
 /// Lifecycle state machine for a nous actor.
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum NousLifecycle {
     /// Processing a turn or background task.
     Active,

--- a/crates/nous/src/pipeline.rs
+++ b/crates/nous/src/pipeline.rs
@@ -89,6 +89,7 @@ pub struct PipelineMessage {
 /// Guard stage result.
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum GuardResult {
     /// Request is allowed.
     Allow,

--- a/crates/theatron/desktop/src/api/types.rs
+++ b/crates/theatron/desktop/src/api/types.rs
@@ -196,6 +196,7 @@ impl std::ops::Deref for ToolId {
 /// lifecycle events, and memory distillation progress.
 #[non_exhaustive]
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub enum SseEvent {
     Connected,
     Disconnected,
@@ -251,6 +252,7 @@ pub enum SseEvent {
 /// invocations, plan execution, and completion/abort signals.
 #[non_exhaustive]
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub enum StreamEvent {
     TurnStart {
         session_id: SessionId,
@@ -326,6 +328,7 @@ pub struct TurnOutcome {
 /// Dioxus components read this to render connection indicators.
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum ConnectionState {
     /// Initial state, not yet attempted.
     Disconnected,

--- a/crates/theatron/desktop/src/components/chat.rs
+++ b/crates/theatron/desktop/src/components/chat.rs
@@ -59,6 +59,7 @@ pub struct ChatMessage {
 
 /// Who produced a chat message.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum MessageRole {
     User,
     Assistant,

--- a/crates/theatron/desktop/src/components/connection_indicator.rs
+++ b/crates/theatron/desktop/src/components/connection_indicator.rs
@@ -28,6 +28,7 @@ pub struct ConnectionIndicator {
 /// Semantic color for the connection indicator.
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum IndicatorColor {
     Green,
     Yellow,

--- a/crates/theatron/desktop/src/services/config.rs
+++ b/crates/theatron/desktop/src/services/config.rs
@@ -17,6 +17,7 @@ use crate::state::connection::ConnectionConfig;
 // ---------------------------------------------------------------------------
 
 #[derive(Debug, Snafu)]
+#[non_exhaustive]
 pub enum ConfigError {
     #[snafu(display("failed to determine config directory"))]
     NoConfigDir,

--- a/crates/theatron/desktop/src/services/connection.rs
+++ b/crates/theatron/desktop/src/services/connection.rs
@@ -44,6 +44,7 @@ use crate::state::connection::{
 // ---------------------------------------------------------------------------
 
 #[derive(Debug, Snafu)]
+#[non_exhaustive]
 pub enum ConnectionError {
     #[snafu(display("health check failed: {source}"))]
     HealthCheck { source: reqwest::Error },

--- a/crates/theatron/desktop/src/state/app.rs
+++ b/crates/theatron/desktop/src/state/app.rs
@@ -143,6 +143,7 @@ impl Default for TabBar {
 /// Modal overlays that block interaction with the main UI.
 #[non_exhaustive]
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub enum Overlay {
     Help,
     AgentPicker { cursor: usize },

--- a/crates/theatron/desktop/src/state/connection.rs
+++ b/crates/theatron/desktop/src/state/connection.rs
@@ -21,6 +21,7 @@ use serde::{Deserialize, Serialize};
 /// ```
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
+#[non_exhaustive]
 pub enum ConnectionState {
     /// No connection attempted yet, or explicitly disconnected by the user.
     #[default]

--- a/crates/theatron/desktop/src/state/events.rs
+++ b/crates/theatron/desktop/src/state/events.rs
@@ -59,6 +59,7 @@ impl Default for EventState {
 /// (P604). This tracks specifically whether we are receiving SSE events.
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum SseConnectionState {
     /// Not connected to the SSE stream.
     Disconnected,
@@ -90,6 +91,7 @@ impl SseConnectionState {
 /// Distillation (memory compaction) progress for a single agent.
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum DistillationProgress {
     /// Distillation is in progress but no stage reported yet.
     Started,

--- a/crates/theatron/desktop/src/theme.rs
+++ b/crates/theatron/desktop/src/theme.rs
@@ -8,6 +8,7 @@ use dioxus::prelude::*;
 /// User-selected theme preference.
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum ThemeMode {
     Dark,
     Light,

--- a/crates/theatron/tui/src/api/error.rs
+++ b/crates/theatron/tui/src/api/error.rs
@@ -9,6 +9,7 @@ use snafu::prelude::*;
 #[non_exhaustive]
 #[derive(Debug, Snafu)]
 #[snafu(visibility(pub(crate)))]
+#[non_exhaustive]
 pub enum ApiError {
     /// HTTP transport or connection error (no response received).
     #[snafu(display("{operation}: {source}"))]

--- a/crates/theatron/tui/src/api/types.rs
+++ b/crates/theatron/tui/src/api/types.rs
@@ -131,6 +131,7 @@ pub struct Plan {
 
 #[non_exhaustive]
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub enum SseEvent {
     Connected,
     Disconnected,

--- a/crates/theatron/tui/src/command/mod.rs
+++ b/crates/theatron/tui/src/command/mod.rs
@@ -6,6 +6,7 @@ use crate::state::AgentState;
 
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum CommandCategory {
     Navigation,
     Action,

--- a/crates/theatron/tui/src/error.rs
+++ b/crates/theatron/tui/src/error.rs
@@ -4,6 +4,7 @@ use snafu::prelude::*;
 #[non_exhaustive]
 #[derive(Debug, Snafu)]
 #[snafu(visibility(pub(crate)))]
+#[non_exhaustive]
 pub enum Error {
     /// API transport or authentication error from the HTTP client.
     #[snafu(context(false))]

--- a/crates/theatron/tui/src/events.rs
+++ b/crates/theatron/tui/src/events.rs
@@ -5,6 +5,7 @@ use crate::id::{NousId, PlanId, SessionId, ToolId, TurnId};
 /// Mapped to `Msg` by `App::map_event`.
 #[non_exhaustive]
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum Event {
     /// Terminal keypress, mouse, resize
     Terminal(crossterm::event::Event),
@@ -19,6 +20,7 @@ pub enum Event {
 /// Parsed events from a POST /api/sessions/stream response
 #[non_exhaustive]
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum StreamEvent {
     TurnStart {
         session_id: SessionId,

--- a/crates/theatron/tui/src/msg.rs
+++ b/crates/theatron/tui/src/msg.rs
@@ -7,6 +7,7 @@ use crate::id::{NousId, PlanId, SessionId, ToolId, TurnId};
 /// No I/O happens here: only data describing what happened.
 #[non_exhaustive]
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum Msg {
     CharInput(char),
     Backspace,
@@ -325,6 +326,7 @@ pub enum Msg {
 
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum MessageActionKind {
     Copy,
     YankCodeBlock,
@@ -351,6 +353,7 @@ pub enum MessageActionKind {
 
 #[non_exhaustive]
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub enum OverlayKind {
     Help,
     AgentPicker,
@@ -385,6 +388,7 @@ impl ErrorToast {
 
 #[non_exhaustive]
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum AuthOutcome {
     #[expect(dead_code, reason = "planned TUI feature")]
     Success { token: SecretString },

--- a/crates/theatron/tui/src/state/agent.rs
+++ b/crates/theatron/tui/src/state/agent.rs
@@ -3,6 +3,7 @@ use crate::id::NousId;
 
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum AgentStatus {
     Idle,
     Working,

--- a/crates/theatron/tui/src/state/command.rs
+++ b/crates/theatron/tui/src/state/command.rs
@@ -15,6 +15,7 @@ pub struct CommandPaletteState {
     dead_code,
     reason = "variants reserved for context-aware keybind hints"
 )]
+#[non_exhaustive]
 pub enum SelectionContext {
     #[default]
     None,

--- a/crates/theatron/tui/src/state/filter.rs
+++ b/crates/theatron/tui/src/state/filter.rs
@@ -2,6 +2,7 @@
 
 #[non_exhaustive]
 #[derive(Debug, Default, Clone, PartialEq)]
+#[non_exhaustive]
 pub enum FilterScope {
     #[default]
     Chat,

--- a/crates/theatron/tui/src/state/memory.rs
+++ b/crates/theatron/tui/src/state/memory.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 /// Sort options for the fact browser.
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum FactSort {
     Confidence,
     Recency,
@@ -48,6 +49,7 @@ impl FactSort {
 /// Which sub-view of the memory inspector is active.
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum MemoryTab {
     Facts,
     Graph,

--- a/crates/theatron/tui/src/state/ops.rs
+++ b/crates/theatron/tui/src/state/ops.rs
@@ -3,6 +3,7 @@
 /// Which pane currently has keyboard focus.
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[non_exhaustive]
 pub enum FocusedPane {
     #[default]
     Chat,
@@ -12,6 +13,7 @@ pub enum FocusedPane {
 /// Status of a tool call in the operations pane.
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum OpsToolStatus {
     Running,
     Complete,
@@ -53,6 +55,7 @@ pub struct OpsDiffEntry {
 /// Additional variants (`Always`, `Manual`) will be added when config wiring lands.
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[non_exhaustive]
 pub enum OpsAutoShow {
     /// Show automatically when streaming starts, collapse when idle
     #[default]

--- a/crates/theatron/tui/src/state/overlay.rs
+++ b/crates/theatron/tui/src/state/overlay.rs
@@ -5,6 +5,7 @@ use super::settings::SettingsOverlay;
 
 #[non_exhaustive]
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum Overlay {
     Help,
     AgentPicker {
@@ -55,6 +56,7 @@ pub struct SearchResult {
 
 #[non_exhaustive]
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub enum SearchResultKind {
     SessionName,
     MessageContent { role: String },

--- a/crates/theatron/tui/src/state/settings.rs
+++ b/crates/theatron/tui/src/state/settings.rs
@@ -29,6 +29,7 @@ pub struct SettingsField {
 
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum FieldType {
     Bool,
     Integer,
@@ -48,6 +49,7 @@ pub struct EditState {
 
 #[non_exhaustive]
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum SaveStatus {
     Idle,
     Saving,

--- a/crates/theatron/tui/src/theme.rs
+++ b/crates/theatron/tui/src/theme.rs
@@ -3,6 +3,7 @@ use ratatui::style::{Color, Modifier, Style};
 /// Terminal color depth, detected at startup.
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum ColorDepth {
     /// 24-bit RGB (COLORTERM=truecolor, iTerm2, Kitty, Alacritty, etc.)
     TrueColor,
@@ -15,6 +16,7 @@ pub enum ColorDepth {
 /// Background brightness: drives palette selection.
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum ThemeMode {
     Dark,
     Light,


### PR DESCRIPTION
## Summary

Adds `#[non_exhaustive]` to all 44 remaining public enums that were missing it (top 20 were done in #1579). This allows adding new variants without breaking downstream consumers.

31 files across hermeneus, mneme, nous, dianoia, theatron/tui, and theatron/desktop.

Closes #1630. Partial #735 (must_use deferred to separate PR).

## Test plan

- [ ] `cargo check --workspace` passes
- [ ] Zero RUST/non-exhaustive-enum violations from kanon linter