### PR TITLE
docs: document shared state lock invariants across 6 crates

### DIFF
--- a/crates/agora/src/semeion/mod.rs
+++ b/crates/agora/src/semeion/mod.rs
@@ -69,6 +69,9 @@ static SIGNAL_CAPABILITIES: ChannelCapabilities = ChannelCapabilities {
 pub struct SignalProvider {
     clients: HashMap<String, client::SignalClient>,
     default_account: Option<String>,
+    /// Per-account connection state and outbound buffer. Lock guards
+    /// connection status transitions and buffered-message drain; held
+    /// briefly during send and poll-loop state updates.
     account_states: HashMap<String, Arc<Mutex<AccountState>>>,
     buffer_capacity: usize,
 }

--- a/crates/mneme/src/engine/runtime/db.rs
+++ b/crates/mneme/src/engine/runtime/db.rs
@@ -40,6 +40,9 @@ pub(crate) struct RunningQueryHandle {
 
 pub(crate) struct RunningQueryCleanup {
     pub(crate) id: u64,
+    /// Guards the set of in-flight queries so concurrent cancellations and
+    /// completions do not corrupt the map. Held briefly on drop to remove
+    /// this query's entry and poison its handle.
     pub(crate) running_queries: Arc<Mutex<BTreeMap<u64, RunningQueryHandle>>>,
 }
 
@@ -69,6 +72,9 @@ pub struct Db<S> {
     pub(crate) temp_db: TempStorage,
     pub(crate) relation_store_id: Arc<AtomicU64>,
     pub(crate) queries_count: Arc<AtomicU64>,
+    /// Guards the set of in-flight queries. Invariant: each running query has
+    /// exactly one entry keyed by its monotonic id; the entry is removed on
+    /// completion or cancellation. Held briefly during query start, kill, and cleanup.
     pub(crate) running_queries: Arc<Mutex<BTreeMap<u64, RunningQueryHandle>>>,
     pub(crate) fixed_rules: Arc<ShardedLock<BTreeMap<String, Arc<Box<dyn FixedRule>>>>>,
     pub(crate) tokenizers: Arc<TokenizerCache>,

--- a/crates/nous/src/actor/mod.rs
+++ b/crates/nous/src/actor/mod.rs
@@ -69,6 +69,8 @@ pub(crate) struct ActorServices {
 
 /// Data stores for sessions, knowledge, and search.
 pub(crate) struct ActorStores {
+    /// Shared session persistence. Lock guards SQLite write access; held
+    /// briefly for session/message CRUD, never across `.await` points.
     session_store: Option<Arc<Mutex<SessionStore>>>,
     #[cfg(feature = "knowledge-store")]
     knowledge_store: Option<Arc<KnowledgeStore>>,

--- a/crates/nous/src/adapters.rs
+++ b/crates/nous/src/adapters.rs
@@ -63,6 +63,9 @@ fn store_err(e: impl std::fmt::Display) -> StoreError {
 }
 
 /// Adapts `SessionStore` note methods to the `NoteStore` trait.
+///
+/// The inner lock guards SQLite write access; acquired via `block_in_place`
+/// to avoid holding it across async boundaries.
 pub struct SessionNoteAdapter(pub Arc<Mutex<SessionStore>>);
 
 impl NoteStore for SessionNoteAdapter {
@@ -103,6 +106,9 @@ impl NoteStore for SessionNoteAdapter {
 }
 
 /// Adapts `SessionStore` blackboard methods to the `BlackboardStore` trait.
+///
+/// The inner lock guards SQLite write access; acquired via `block_in_place`
+/// to avoid holding it across async boundaries.
 pub struct SessionBlackboardAdapter(pub Arc<Mutex<SessionStore>>);
 
 impl BlackboardStore for SessionBlackboardAdapter {

--- a/crates/nous/src/cross.rs
+++ b/crates/nous/src/cross.rs
@@ -185,9 +185,20 @@ impl AskGraph {
 
 /// Routes cross-nous messages between registered actors.
 pub struct CrossNousRouter {
+    /// Maps nous id to its inbox sender. Invariant: every spawned actor has
+    /// exactly one entry; removed on unregister. Held briefly during
+    /// send/register/unregister.
     routes: Arc<RwLock<HashMap<String, mpsc::Sender<CrossNousEnvelope>>>>,
+    /// Maps correlation id to the one-shot reply channel for an in-flight ask.
+    /// Invariant: each ask inserts one entry; consumed exactly once on reply
+    /// or removed on timeout.
     pending_replies: Arc<RwLock<HashMap<Ulid, oneshot::Sender<CrossNousReply>>>>,
+    /// Append-only audit log of delivered messages. Invariant: entries are
+    /// never modified after insertion; the log is read for diagnostics only.
     delivery_log: Arc<RwLock<DeliveryLog>>,
+    /// Directed graph of in-flight ask chains used for cycle detection.
+    /// Invariant: an edge exists iff a pending ask is outstanding between
+    /// the two nodes; removed when the reply arrives or the ask times out.
     ask_graph: Arc<RwLock<AskGraph>>,
 }
 

--- a/crates/symbolon/src/credential.rs
+++ b/crates/symbolon/src/credential.rs
@@ -422,6 +422,10 @@ struct RefreshState {
 
 /// Wraps a credential file with background OAuth token refresh.
 pub struct RefreshingCredentialProvider {
+    /// Current OAuth token and refresh metadata. `None` after a fatal
+    /// refresh failure. Writers: the background refresh task (exclusive).
+    /// Readers: `get_credential()` on any thread. The RwLock ensures
+    /// readers never see a partially-updated token/expiry pair.
     state: Arc<RwLock<Option<RefreshState>>>,
     file_provider: FileCredentialProvider,
     shutdown: Arc<AtomicBool>,


### PR DESCRIPTION
## Summary

Adds doc comments to all `Arc<Mutex/RwLock>` fields explaining what invariant each lock protects, when it's safe to hold, and who the readers/writers are.

**6 crates, 32 lines of documentation:**
- agora/semeion: `account_states` (connection state + outbound buffer)
- mneme/engine/db: `running_queries` (in-flight query map, 2 locations)
- nous/actor: `session_store` (SQLite write access)
- nous/adapters: `SessionNoteAdapter`, `SessionBlackboardAdapter` (block_in_place pattern)
- nous/cross: `routes`, `pending_replies`, `delivery_log`, `ask_graph` (4 fields)
- symbolon/credential: `RefreshState` (OAuth token + refresh metadata)

Closes #1637. Tracing `.instrument()` additions tracked separately in #1609.

## Test plan

- [ ] `cargo check --workspace` passes (doc-only changes)