### PR TITLE
chore(lint): fix mechanical kanon violations

### DIFF
--- a/crates/aletheia/src/commands/maintenance.rs
+++ b/crates/aletheia/src/commands/maintenance.rs
@@ -5,6 +5,8 @@ use std::path::PathBuf;
 use anyhow::{Context, Result};
 use clap::Subcommand;
 
+use tokio_util::sync::CancellationToken;
+
 use aletheia_oikonomos::maintenance::{
     DbMonitor, DbMonitoringConfig, DriftDetectionConfig, DriftDetector, MaintenanceConfig,
     TraceRotationConfig, TraceRotator,
@@ -12,7 +14,6 @@ use aletheia_oikonomos::maintenance::{
 use aletheia_oikonomos::runner::TaskRunner;
 use aletheia_taxis::loader::load_config;
 use aletheia_taxis::oikos::Oikos;
-use tokio_util::sync::CancellationToken;
 
 #[derive(Debug, Clone, Subcommand)]
 pub(crate) enum Action {

--- a/crates/aletheia/src/commands/server.rs
+++ b/crates/aletheia/src/commands/server.rs
@@ -3,6 +3,7 @@
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Instant;
+
 use tokio::sync::Mutex;
 
 use anyhow::{Context, Result};

--- a/crates/aletheia/src/init.rs
+++ b/crates/aletheia/src/init.rs
@@ -2,8 +2,9 @@
 
 use std::path::{Path, PathBuf};
 
-use aletheia_koina::secret::SecretString;
 use snafu::{ResultExt, Snafu};
+
+use aletheia_koina::secret::SecretString;
 
 #[derive(Debug, Snafu)]
 pub(crate) enum InitError {

--- a/crates/aletheia/src/knowledge_adapter.rs
+++ b/crates/aletheia/src/knowledge_adapter.rs
@@ -4,6 +4,8 @@ use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
 
+use snafu::ResultExt;
+
 use aletheia_mneme::embedding::EmbeddingProvider;
 use aletheia_mneme::knowledge::{EpistemicTier, Fact};
 use aletheia_mneme::knowledge_store::{HybridQuery, KnowledgeStore};
@@ -12,7 +14,6 @@ use aletheia_organon::error::{
     MutateStoreSnafu, SearchSnafu,
 };
 use aletheia_organon::types::{DatalogResult, FactSummary, KnowledgeSearchService, MemoryResult};
-use snafu::ResultExt;
 
 /// Boxes any error type for use with snafu context selectors that expect
 /// `Box<dyn Error + Send + Sync>` as source.

--- a/crates/aletheia/src/migrate_memory.rs
+++ b/crates/aletheia/src/migrate_memory.rs
@@ -8,14 +8,15 @@ use anyhow::{Context, Result};
 use sha2::{Digest, Sha256};
 use tracing::info;
 
-use aletheia_mneme::embedding::{EmbeddingConfig, EmbeddingProvider, create_provider};
-use aletheia_mneme::knowledge::{EmbeddedChunk, EpistemicTier, Fact, far_future, parse_timestamp};
-use aletheia_mneme::knowledge_store::{KnowledgeConfig, KnowledgeStore};
-use aletheia_taxis::oikos::Oikos;
 use qdrant_client::Qdrant;
 use qdrant_client::qdrant::{
     ScrollPointsBuilder, value, with_payload_selector, with_vectors_selector,
 };
+
+use aletheia_mneme::embedding::{EmbeddingConfig, EmbeddingProvider, create_provider};
+use aletheia_mneme::knowledge::{EmbeddedChunk, EpistemicTier, Fact, far_future, parse_timestamp};
+use aletheia_mneme::knowledge_store::{KnowledgeConfig, KnowledgeStore};
+use aletheia_taxis::oikos::Oikos;
 
 struct MemoryRecord {
     content: String,

--- a/crates/aletheia/src/planning_adapter.rs
+++ b/crates/aletheia/src/planning_adapter.rs
@@ -4,6 +4,8 @@ use std::future::Future;
 use std::path::{Path, PathBuf};
 use std::pin::Pin;
 
+use snafu::ResultExt;
+
 use aletheia_dianoia::phase::Phase;
 use aletheia_dianoia::plan::PlanState;
 use aletheia_dianoia::project::{Project, ProjectMode};
@@ -15,7 +17,6 @@ use aletheia_organon::error::{
     TransitionSnafu, WorkspaceSnafu,
 };
 use aletheia_organon::types::PlanningService;
-use snafu::ResultExt;
 
 /// Boxes any error type for use with snafu context selectors that expect
 /// `Box<dyn Error + Send + Sync>` as source.

--- a/crates/eval/src/client.rs
+++ b/crates/eval/src/client.rs
@@ -1,9 +1,10 @@
 //! HTTP client for interacting with a running Aletheia instance.
 
-use aletheia_koina::secret::SecretString;
 use serde::{Deserialize, Serialize};
 use snafu::ResultExt;
 use tracing::instrument;
+
+use aletheia_koina::secret::SecretString;
 
 use crate::error::{self, Result};
 use crate::sse::{self, ParsedSseEvent};

--- a/crates/eval/src/runner.rs
+++ b/crates/eval/src/runner.rs
@@ -2,8 +2,9 @@
 
 use std::time::{Duration, Instant};
 
-use aletheia_koina::secret::SecretString;
 use tracing::{info, warn};
+
+use aletheia_koina::secret::SecretString;
 
 use crate::client::EvalClient;
 use crate::scenario::{Scenario, ScenarioOutcome, ScenarioResult};

--- a/crates/hermeneus/src/anthropic/client.rs
+++ b/crates/hermeneus/src/anthropic/client.rs
@@ -6,13 +6,14 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use aletheia_koina::credential::{CredentialProvider, CredentialSource};
-use aletheia_koina::secret::SecretString;
 use rand::Rng as _;
 use reqwest::Client;
 use reqwest::header::{HeaderMap, HeaderValue};
 use snafu::ResultExt;
 use tracing::{Instrument as _, info, info_span, warn};
+
+use aletheia_koina::credential::{CredentialProvider, CredentialSource};
+use aletheia_koina::secret::SecretString;
 
 use crate::error::{self, Result};
 use crate::health::{HealthConfig, ProviderHealthTracker};

--- a/crates/hermeneus/src/anthropic/stream.rs
+++ b/crates/hermeneus/src/anthropic/stream.rs
@@ -196,8 +196,9 @@ impl StreamAccumulator {
                                 | BlockBuilder::ServerToolUse { input_json, .. } => {
                                     input_json.push_str(&partial_json);
                                 }
-                                // NOTE: InputJsonDelta for non-tool blocks is ignored
-                                _ => {}
+                                _ => {
+                                    // NOTE: InputJsonDelta for non-tool blocks is ignored
+                                }
                             }
                             on_event(StreamEvent::InputJsonDelta { partial_json });
                         }

--- a/crates/hermeneus/src/health.rs
+++ b/crates/hermeneus/src/health.rs
@@ -231,8 +231,9 @@ impl ProviderHealthTracker {
                     }
                 }
             }
-            // NOTE: non-availability errors (parse, unsupported model) do not affect health
-            _ => {}
+            _ => {
+                // NOTE: non-availability errors (parse, unsupported model) do not affect health
+            }
         }
     }
 }

--- a/crates/integration-tests/tests/access_tracking.rs
+++ b/crates/integration-tests/tests/access_tracking.rs
@@ -1,10 +1,11 @@
 //! Integration tests for access tracking and knowledge graph data audit.
 #![cfg(feature = "engine-tests")]
 
+use std::sync::Arc;
+
 use aletheia_mneme::embedding::{EmbeddingProvider, MockEmbeddingProvider};
 use aletheia_mneme::knowledge::{EmbeddedChunk, EpistemicTier, Fact, default_stability_hours};
 use aletheia_mneme::knowledge_store::{KnowledgeConfig, KnowledgeStore};
-use std::sync::Arc;
 
 fn open_store(dim: usize) -> Arc<KnowledgeStore> {
     KnowledgeStore::open_mem_with_config(KnowledgeConfig { dim }).expect("open_mem")

--- a/crates/integration-tests/tests/cross_crate_pipeline.rs
+++ b/crates/integration-tests/tests/cross_crate_pipeline.rs
@@ -12,15 +12,16 @@
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
-use aletheia_koina::secret::SecretString;
 use axum::body::Body;
 use axum::http::{Request, StatusCode};
 use tokio::sync::Mutex as TokioMutex;
+use tokio_util::sync::CancellationToken;
 use tower::ServiceExt;
 
 use aletheia_hermeneus::provider::{LlmProvider, ProviderRegistry};
 use aletheia_hermeneus::test_utils::MockProvider;
 use aletheia_hermeneus::types::*;
+use aletheia_koina::secret::SecretString;
 use aletheia_mneme::store::SessionStore;
 use aletheia_nous::config::{NousConfig, PipelineConfig};
 use aletheia_nous::manager::NousManager;
@@ -31,7 +32,6 @@ use aletheia_pylon::state::AppState;
 use aletheia_symbolon::jwt::{JwtConfig, JwtManager};
 use aletheia_symbolon::types::Role;
 use aletheia_taxis::oikos::Oikos;
-use tokio_util::sync::CancellationToken;
 
 // ---------------------------------------------------------------------------
 // Mock providers

--- a/crates/integration-tests/tests/end_to_end.rs
+++ b/crates/integration-tests/tests/end_to_end.rs
@@ -5,16 +5,17 @@
 
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
-use tokio::sync::Mutex as TokioMutex;
 
-use aletheia_koina::secret::SecretString;
 use axum::body::Body;
 use axum::http::{Request, StatusCode};
+use tokio::sync::Mutex as TokioMutex;
+use tokio_util::sync::CancellationToken;
 use tower::ServiceExt;
 
 use aletheia_hermeneus::provider::{LlmProvider, ProviderRegistry};
 use aletheia_hermeneus::test_utils::MockProvider;
 use aletheia_hermeneus::types::*;
+use aletheia_koina::secret::SecretString;
 use aletheia_mneme::store::SessionStore;
 use aletheia_nous::config::{NousConfig, PipelineConfig};
 use aletheia_nous::manager::NousManager;
@@ -24,7 +25,6 @@ use aletheia_pylon::state::AppState;
 use aletheia_symbolon::jwt::{JwtConfig, JwtManager};
 use aletheia_symbolon::types::Role;
 use aletheia_taxis::oikos::Oikos;
-use tokio_util::sync::CancellationToken;
 
 // --- Mock Providers ---
 

--- a/crates/integration-tests/tests/eval_harness.rs
+++ b/crates/integration-tests/tests/eval_harness.rs
@@ -5,15 +5,16 @@
 
 use std::sync::Arc;
 use std::time::{Duration, Instant};
-use tokio::sync::Mutex as TokioMutex;
-use tracing::Instrument;
 
-use aletheia_koina::secret::SecretString;
 use tokio::net::TcpListener;
+use tokio::sync::Mutex as TokioMutex;
+use tokio_util::sync::CancellationToken;
+use tracing::Instrument;
 
 use aletheia_dokimion::runner::{RunConfig, ScenarioRunner};
 use aletheia_hermeneus::provider::ProviderRegistry;
 use aletheia_hermeneus::test_utils::MockProvider;
+use aletheia_koina::secret::SecretString;
 use aletheia_mneme::store::SessionStore;
 use aletheia_nous::config::{NousConfig, PipelineConfig};
 use aletheia_nous::manager::NousManager;
@@ -23,7 +24,6 @@ use aletheia_pylon::state::AppState;
 use aletheia_symbolon::jwt::{JwtConfig, JwtManager};
 use aletheia_symbolon::types::Role;
 use aletheia_taxis::oikos::Oikos;
-use tokio_util::sync::CancellationToken;
 
 fn install_crypto_provider() {
     let _ = rustls::crypto::ring::default_provider().install_default();

--- a/crates/integration-tests/tests/knowledge_engine.rs
+++ b/crates/integration-tests/tests/knowledge_engine.rs
@@ -1,10 +1,11 @@
 //! Integration tests for `KnowledgeStore`: fact round-trip (TEST-02) and HNSW vector search (TEST-03).
 #![cfg(feature = "engine-tests")]
 
+use std::collections::BTreeMap;
+
 use aletheia_mneme::embedding::{EmbeddingProvider, MockEmbeddingProvider};
 use aletheia_mneme::knowledge::{EmbeddedChunk, Entity, EpistemicTier, Fact, Relationship};
 use aletheia_mneme::knowledge_store::{HybridQuery, KnowledgeConfig, KnowledgeStore};
-use std::collections::BTreeMap;
 
 fn make_fact(id: &str, nous_id: &str, content: &str, confidence: f64, tier: EpistemicTier) -> Fact {
     Fact {

--- a/crates/integration-tests/tests/knowledge_lifecycle.rs
+++ b/crates/integration-tests/tests/knowledge_lifecycle.rs
@@ -1,12 +1,14 @@
 //! Integration tests for knowledge lifecycle: correct, retract, and audit operations.
 #![cfg(feature = "engine-tests")]
 
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use serde_json::Value as JsonValue;
+
 use aletheia_mneme::engine::DataValue;
 use aletheia_mneme::knowledge::{EpistemicTier, Fact};
 use aletheia_mneme::knowledge_store::{KnowledgeConfig, KnowledgeStore};
-use serde_json::Value as JsonValue;
-use std::collections::BTreeMap;
-use std::sync::Arc;
 
 fn make_fact(id: &str, nous_id: &str, content: &str, confidence: f64, tier: EpistemicTier) -> Fact {
     Fact {

--- a/crates/integration-tests/tests/organon_mneme_tools.rs
+++ b/crates/integration-tests/tests/organon_mneme_tools.rs
@@ -14,29 +14,29 @@
 #![expect(clippy::unwrap_used, reason = "test assertions")]
 #![expect(clippy::expect_used, reason = "test assertions")]
 
-use aletheia_organon::error::KnowledgeAdapterError;
 use std::collections::HashSet;
 use std::future::Future;
 use std::path::PathBuf;
 use std::pin::Pin;
-use std::sync::Arc;
-use tokio::sync::Mutex;
+use std::sync::{Arc, RwLock};
 
-fn install_crypto_provider() {
-    let _ = rustls::crypto::ring::default_provider().install_default();
-}
+use tokio::sync::Mutex;
 
 use aletheia_koina::id::ToolName;
 use aletheia_koina::id::{NousId, SessionId};
 use aletheia_mneme::store::SessionStore;
 use aletheia_nous::adapters::{SessionBlackboardAdapter, SessionNoteAdapter};
 use aletheia_organon::builtins;
+use aletheia_organon::error::KnowledgeAdapterError;
 use aletheia_organon::registry::ToolRegistry;
 use aletheia_organon::types::{
     FactSummary, KnowledgeSearchService, MemoryResult, ServerToolConfig, ToolContext, ToolInput,
     ToolServices,
 };
-use std::sync::RwLock;
+
+fn install_crypto_provider() {
+    let _ = rustls::crypto::ring::default_provider().install_default();
+}
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/crates/koina/src/id.rs
+++ b/crates/koina/src/id.rs
@@ -1,10 +1,10 @@
 //! Newtype wrappers for domain identifiers.
 
+use std::borrow::Borrow;
 use std::fmt;
 
 use compact_str::CompactString;
 use serde::{Deserialize, Serialize};
-use std::borrow::Borrow;
 
 /// Generate a newtype ID wrapper around a string-like inner type.
 ///

--- a/crates/melete/src/distill.rs
+++ b/crates/melete/src/distill.rs
@@ -1,9 +1,10 @@
 //! Context distillation engine.
 
-use aletheia_hermeneus::provider::LlmProvider;
-use aletheia_hermeneus::types::{CompletionRequest, Content, ContentBlock, Message, Role};
 use snafu::ResultExt;
 use tracing::instrument;
+
+use aletheia_hermeneus::provider::LlmProvider;
+use aletheia_hermeneus::types::{CompletionRequest, Content, ContentBlock, Message, Role};
 
 use crate::error::{EmptySummarySnafu, LlmCallSnafu, NoMessagesSnafu, Result};
 use crate::flush::{FlushItem, FlushSource, MemoryFlush};
@@ -555,8 +556,9 @@ fn collect_flush_section(
         "Task Context" => {
             *task_state = Some(content.join("\n"));
         }
-        // NOTE: unrecognized sections are not extracted
-        _ => {}
+        _ => {
+            // NOTE: unrecognized sections are not extracted
+        }
     }
 }
 

--- a/crates/melete/src/prompt.rs
+++ b/crates/melete/src/prompt.rs
@@ -118,16 +118,18 @@ pub fn format_messages(messages: &[Message], include_tool_calls: bool) -> String
                         ContentBlock::Thinking { thinking, .. } => {
                             let _ = writeln!(block_text, "[Thinking: {thinking}]");
                         }
-                        // NOTE: other content block types not rendered in prompt summary
-                        _ => {}
+                        _ => {
+                            // NOTE: other content block types not rendered in prompt summary
+                        }
                     }
                 }
                 if !block_text.is_empty() {
                     let _ = writeln!(output, "[{role_label}]\n{block_text}");
                 }
             }
-            // NOTE: future content variants rendered as empty
-            _ => {}
+            _ => {
+                // NOTE: future content variants rendered as empty
+            }
         }
     }
 

--- a/crates/mneme/src/backup.rs
+++ b/crates/mneme/src/backup.rs
@@ -2,10 +2,11 @@
 
 use std::path::{Path, PathBuf};
 
-use aletheia_koina::disk_space::DiskSpaceMonitor;
 use rusqlite::Connection;
 use snafu::ResultExt;
 use tracing::{info, instrument, warn};
+
+use aletheia_koina::disk_space::DiskSpaceMonitor;
 
 use crate::error::{self, Result};
 

--- a/crates/mneme/src/consolidation/mod.rs
+++ b/crates/mneme/src/consolidation/mod.rs
@@ -279,8 +279,9 @@ fn extract_json_array(s: &str) -> Option<&str> {
                     return s.get(start..=start + i);
                 }
             }
-            // NOTE: non-bracket character, no depth change
-            _ => {}
+            _ => {
+                // NOTE: non-bracket character, no depth change
+            }
         }
     }
     None

--- a/crates/mneme/src/engine/data/program/magic.rs
+++ b/crates/mneme/src/engine/data/program/magic.rs
@@ -206,8 +206,9 @@ impl MagicInlineRule {
                         }
                     }
                 }
-                // NOTE: non-rule atoms don't contribute to rule containment
-                _ => {}
+                _ => {
+                    // NOTE: non-rule atoms don't contribute to rule containment
+                }
             }
         }
         coll

--- a/crates/mneme/src/engine/parse/mod.rs
+++ b/crates/mneme/src/engine/parse/mod.rs
@@ -190,8 +190,9 @@ impl ImperativeStmt {
                 SysOp::RemoveIndex(rel, idx) => {
                     collector.insert(CompactString::from(format!("{}:{}", rel.name, idx.name)));
                 }
-                // NOTE: other system operations don't require relation locks
-                _ => {}
+                _ => {
+                    // NOTE: other system operations don't require relation locks
+                }
             },
         }
     }

--- a/crates/mneme/src/engine/query/magic.rs
+++ b/crates/mneme/src/engine/query/magic.rs
@@ -279,8 +279,9 @@ impl NormalFormProgram {
                                         downstream_rules.insert(r_app.name.clone());
                                     }
                                 }
-                                // NOTE: non-rule atoms don't contribute downstream rules
-                                _ => {}
+                                _ => {
+                                    // NOTE: non-rule atoms don't contribute downstream rules
+                                }
                             }
                         }
                     }

--- a/crates/mneme/src/graph_intelligence.rs
+++ b/crates/mneme/src/graph_intelligence.rs
@@ -302,8 +302,9 @@ impl crate::knowledge_store::KnowledgeStore {
                 "cluster" => {
                     ctx.clusters.insert(entity_id.to_owned(), cluster_id);
                 }
-                // NOTE: pagerank_max meta entry, normalization already done in Datalog
-                _ => {}
+                _ => {
+                    // NOTE: pagerank_max meta entry, normalization already done in Datalog
+                }
             }
         }
 

--- a/crates/mneme/src/instinct.rs
+++ b/crates/mneme/src/instinct.rs
@@ -465,8 +465,9 @@ pub(crate) fn aggregate_observations(observations: &[ToolObservation]) -> Vec<Be
             None => {
                 accum.first_observed = Some(obs.observed_at);
             }
-            // NOTE: current observation is not earlier, no update needed
-            _ => {}
+            _ => {
+                // NOTE: current observation is not earlier, no update needed
+            }
         }
 
         match accum.last_observed {
@@ -476,8 +477,9 @@ pub(crate) fn aggregate_observations(observations: &[ToolObservation]) -> Vec<Be
             None => {
                 accum.last_observed = Some(obs.observed_at);
             }
-            // NOTE: current observation is not later, no update needed
-            _ => {}
+            _ => {
+                // NOTE: current observation is not later, no update needed
+            }
         }
     }
 

--- a/crates/mneme/src/store/mod.rs
+++ b/crates/mneme/src/store/mod.rs
@@ -15,10 +15,11 @@ mod tests;
 
 use std::path::{Path, PathBuf};
 
-use aletheia_koina::disk_space::{DiskSpaceMonitor, DiskStatus};
 use rusqlite::Connection;
 use snafu::ResultExt;
 use tracing::{error, info, instrument, warn};
+
+use aletheia_koina::disk_space::{DiskSpaceMonitor, DiskStatus};
 
 use crate::error::{self, Result};
 use crate::migration;

--- a/crates/nous/src/actor/mod.rs
+++ b/crates/nous/src/actor/mod.rs
@@ -6,26 +6,23 @@ use std::sync::atomic::AtomicBool;
 use std::time::Instant;
 
 use tokio::sync::Mutex;
-use tokio::task::JoinSet;
-
-#[cfg(feature = "knowledge-store")]
-use aletheia_mneme::knowledge_store::KnowledgeStore;
-use aletheia_mneme::store::SessionStore;
-
 use tokio::sync::mpsc;
+use tokio::task::JoinSet;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, instrument, warn};
 
-use crate::cross::CrossNousEnvelope;
-
 use aletheia_hermeneus::provider::ProviderRegistry;
 use aletheia_mneme::embedding::EmbeddingProvider;
+#[cfg(feature = "knowledge-store")]
+use aletheia_mneme::knowledge_store::KnowledgeStore;
+use aletheia_mneme::store::SessionStore;
 use aletheia_organon::registry::ToolRegistry;
 use aletheia_organon::types::ToolServices;
 use aletheia_taxis::oikos::Oikos;
 
 use crate::bootstrap::BootstrapSection;
 use crate::config::{NousConfig, PipelineConfig};
+use crate::cross::CrossNousEnvelope;
 use crate::message::{NousLifecycle, NousMessage, NousStatus};
 use crate::session::SessionState;
 

--- a/crates/nous/src/actor/tests.rs
+++ b/crates/nous/src/actor/tests.rs
@@ -1,9 +1,10 @@
 #![expect(clippy::unwrap_used, reason = "test assertions")]
 #![expect(clippy::expect_used, reason = "test assertions")]
+use tokio_util::sync::CancellationToken;
+
 use aletheia_hermeneus::provider::LlmProvider;
 use aletheia_hermeneus::test_utils::MockProvider;
 use aletheia_hermeneus::types::{CompletionRequest, CompletionResponse};
-use tokio_util::sync::CancellationToken;
 
 use super::*;
 

--- a/crates/nous/src/adapters.rs
+++ b/crates/nous/src/adapters.rs
@@ -167,8 +167,9 @@ impl BlackboardStore for SessionBlackboardAdapter {
 #[cfg(test)]
 #[expect(clippy::expect_used, reason = "test assertions")]
 mod tests {
-    use super::*;
     use aletheia_organon::types::NoteStore;
+
+    use super::*;
 
     fn test_store() -> Arc<Mutex<SessionStore>> {
         Arc::new(Mutex::new(

--- a/crates/nous/src/execute/dispatch.rs
+++ b/crates/nous/src/execute/dispatch.rs
@@ -5,11 +5,12 @@ use std::hash::{Hash, Hasher};
 
 use tracing::debug;
 
+use tokio::sync::mpsc;
+
 use aletheia_hermeneus::types::{ContentBlock, ToolResultBlock, ToolResultContent};
 use aletheia_koina::id::ToolName;
 use aletheia_organon::registry::ToolRegistry;
 use aletheia_organon::types::{ToolContext, ToolInput};
-use tokio::sync::mpsc;
 
 use crate::error;
 use crate::pipeline::{InteractionSignal, LoopDetector, ToolCall};

--- a/crates/nous/src/execute/mod.rs
+++ b/crates/nous/src/execute/mod.rs
@@ -8,6 +8,7 @@ mod tests;
 use std::collections::HashSet;
 
 use snafu::ResultExt;
+use tokio::sync::mpsc;
 use tracing::{debug, info, instrument, warn};
 
 use aletheia_hermeneus::health::ProviderHealth;
@@ -19,15 +20,13 @@ use aletheia_hermeneus::types::{
 use aletheia_koina::id::ToolName;
 use aletheia_organon::registry::ToolRegistry;
 use aletheia_organon::types::ToolContext;
-use tokio::sync::mpsc;
 
+use self::dispatch::{build_messages, classify_signals, dispatch_tools, dispatch_tools_streaming};
 use crate::config::NousConfig;
 use crate::error;
 use crate::pipeline::{LoopDetector, PipelineContext, ToolCall, TurnResult, TurnUsage};
 use crate::session::SessionState;
 use crate::stream::TurnStreamEvent;
-
-use dispatch::{build_messages, classify_signals, dispatch_tools, dispatch_tools_streaming};
 
 /// Resolve the LLM provider for `model` and verify it is not marked down.
 fn resolve_provider_checked<'a>(

--- a/crates/nous/src/execute/tests.rs
+++ b/crates/nous/src/execute/tests.rs
@@ -1,6 +1,5 @@
 #![expect(clippy::unwrap_used, reason = "test assertions")]
 #![expect(clippy::expect_used, reason = "test assertions")]
-use crate::execute::dispatch::simple_hash;
 use std::collections::HashSet;
 use std::future::Future;
 use std::path::PathBuf;
@@ -18,6 +17,7 @@ use aletheia_organon::types::{
 
 use super::*;
 use crate::config::NousConfig;
+use crate::execute::dispatch::simple_hash;
 use crate::pipeline::{InteractionSignal, PipelineContext, PipelineMessage};
 use crate::session::SessionState;
 

--- a/crates/nous/src/history.rs
+++ b/crates/nous/src/history.rs
@@ -104,8 +104,9 @@ pub fn load_history(
         match msg.role {
             Role::System => continue,
             Role::ToolResult if !config.include_tool_messages => continue,
-            // NOTE: User and Assistant roles pass through for inclusion
-            _ => {}
+            _ => {
+                // NOTE: User and Assistant roles pass through for inclusion
+            }
         }
 
         if tokens_consumed + msg.token_estimate > available {
@@ -158,8 +159,9 @@ pub fn load_history(
 #[expect(clippy::unwrap_used, reason = "test assertions may panic on failure")]
 #[expect(clippy::expect_used, reason = "test assertions may panic on failure")]
 mod tests {
-    use super::*;
     use aletheia_mneme::types::Role;
+
+    use super::*;
 
     fn setup_store() -> SessionStore {
         let store = SessionStore::open_in_memory().expect("open in-memory store");

--- a/crates/nous/src/manager.rs
+++ b/crates/nous/src/manager.rs
@@ -6,6 +6,12 @@ use std::sync::Mutex;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
+use tokio::sync::Mutex as TokioMutex;
+use tokio::sync::watch;
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
+use tracing::{Instrument, debug, error, info, warn};
+
 use aletheia_hermeneus::provider::ProviderRegistry;
 use aletheia_mneme::embedding::EmbeddingProvider;
 #[cfg(feature = "knowledge-store")]
@@ -15,11 +21,6 @@ use aletheia_organon::registry::ToolRegistry;
 use aletheia_organon::types::ToolServices;
 use aletheia_taxis::oikos::Oikos;
 use aletheia_thesauros::loader::LoadedPack;
-use tokio::sync::Mutex as TokioMutex;
-use tokio::sync::watch;
-use tokio::task::JoinHandle;
-use tokio_util::sync::CancellationToken;
-use tracing::{Instrument, debug, error, info, warn};
 
 use crate::actor;
 use crate::bootstrap::pack_sections_to_bootstrap;

--- a/crates/nous/src/pipeline.rs
+++ b/crates/nous/src/pipeline.rs
@@ -3,19 +3,17 @@
 use std::collections::VecDeque;
 use std::time::{Duration, Instant};
 
-use tokio::sync::Mutex;
-
 use serde::{Deserialize, Serialize};
+use tokio::sync::Mutex;
+use tokio::sync::mpsc;
 use tracing::{debug, error, info_span, instrument, warn};
 
+use aletheia_hermeneus::provider::ProviderRegistry;
 use aletheia_mneme::embedding::EmbeddingProvider;
 use aletheia_mneme::store::SessionStore;
-
-use aletheia_hermeneus::provider::ProviderRegistry;
 use aletheia_organon::registry::ToolRegistry;
 use aletheia_organon::types::ToolContext;
 use aletheia_taxis::oikos::Oikos;
-use tokio::sync::mpsc;
 
 use crate::bootstrap::{BootstrapAssembler, BootstrapSection};
 use crate::budget::TokenBudget;

--- a/crates/nous/src/pipeline_tests.rs
+++ b/crates/nous/src/pipeline_tests.rs
@@ -212,10 +212,13 @@ fn turn_usage_serde_roundtrip() {
 
 #[tokio::test]
 async fn assemble_context_populates_pipeline() {
-    use crate::config::{NousConfig, PipelineConfig};
-    use aletheia_taxis::oikos::Oikos;
     use std::fs;
+
     use tempfile::TempDir;
+
+    use aletheia_taxis::oikos::Oikos;
+
+    use crate::config::{NousConfig, PipelineConfig};
 
     let dir = TempDir::new().unwrap();
     let root = dir.path();
@@ -253,12 +256,13 @@ async fn run_pipeline_simple() {
     use std::path::PathBuf;
     use std::sync::{Arc, RwLock};
 
+    use tempfile::TempDir;
+
     use aletheia_hermeneus::provider::ProviderRegistry;
     use aletheia_hermeneus::test_utils::MockProvider;
     use aletheia_koina::id::{NousId, SessionId};
     use aletheia_organon::registry::ToolRegistry;
     use aletheia_organon::types::ToolContext;
-    use tempfile::TempDir;
 
     let dir = TempDir::new().unwrap();
     let root = dir.path();
@@ -474,8 +478,9 @@ fn check_guard_always_allows() {
 
 #[tokio::test]
 async fn assemble_context_missing_soul_returns_error() {
-    use aletheia_taxis::oikos::Oikos;
     use tempfile::TempDir;
+
+    use aletheia_taxis::oikos::Oikos;
 
     let dir = TempDir::new().unwrap();
     let root = dir.path();

--- a/crates/nous/src/recall.rs
+++ b/crates/nous/src/recall.rs
@@ -1,6 +1,8 @@
 //! Recall pipeline stage: retrieves relevant knowledge and injects into context.
 
 use std::collections::{HashMap, HashSet};
+#[cfg(feature = "knowledge-store")]
+use std::sync::Arc;
 use std::sync::LazyLock;
 
 use serde::{Deserialize, Serialize};
@@ -8,15 +10,11 @@ use tracing::{debug, instrument};
 
 use aletheia_mneme::embedding::EmbeddingProvider;
 use aletheia_mneme::knowledge::RecallResult as KnowledgeRecallResult;
-use aletheia_mneme::recall::{FactorScores, RecallEngine, ScoredResult};
-
-#[cfg(feature = "knowledge-store")]
-use std::sync::Arc;
-
-use crate::error;
-
 #[cfg(feature = "knowledge-store")]
 use aletheia_mneme::knowledge_store::KnowledgeStore;
+use aletheia_mneme::recall::{FactorScores, RecallEngine, ScoredResult};
+
+use crate::error;
 
 /// Abstracts BM25 text search for recall when no embedding provider is available.
 ///

--- a/crates/nous/src/skills.rs
+++ b/crates/nous/src/skills.rs
@@ -99,12 +99,12 @@ pub(crate) fn format_skill_as_markdown(skill: &aletheia_mneme::skill::SkillConte
 use std::sync::Arc;
 
 #[cfg(feature = "knowledge-store")]
+use tracing::{Instrument, warn};
+
+#[cfg(feature = "knowledge-store")]
 use aletheia_mneme::knowledge::Fact;
 #[cfg(feature = "knowledge-store")]
 use aletheia_mneme::knowledge_store::KnowledgeStore;
-
-#[cfg(feature = "knowledge-store")]
-use tracing::{Instrument, warn};
 
 #[cfg(feature = "knowledge-store")]
 use crate::bootstrap::{BootstrapSection, SectionPriority};

--- a/crates/nous/src/spawn_svc.rs
+++ b/crates/nous/src/spawn_svc.rs
@@ -5,12 +5,13 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::time::Duration;
 
+use tokio_util::sync::CancellationToken;
+use tracing::{Instrument, info, warn};
+
 use aletheia_hermeneus::provider::ProviderRegistry;
 use aletheia_organon::registry::ToolRegistry;
 use aletheia_organon::types::{SpawnRequest, SpawnResult, SpawnService};
 use aletheia_taxis::oikos::Oikos;
-use tokio_util::sync::CancellationToken;
-use tracing::{Instrument, info, warn};
 
 use crate::actor;
 use crate::config::{NousConfig, PipelineConfig, StageBudget};

--- a/crates/nous/src/user_error.rs
+++ b/crates/nous/src/user_error.rs
@@ -76,8 +76,9 @@ impl fmt::Display for UserFacingError {
 ///
 /// Returns `None` for internal errors that should not be shown to users.
 pub fn to_user_facing(error: &crate::error::Error) -> Option<UserFacingError> {
-    use crate::error::Error;
     use aletheia_hermeneus::error::Error as HError;
+
+    use crate::error::Error;
 
     match error {
         Error::Llm { source, .. } => match source {

--- a/crates/organon/src/builtins/agent.rs
+++ b/crates/organon/src/builtins/agent.rs
@@ -8,8 +8,9 @@ use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
 
-use aletheia_koina::id::ToolName;
 use indexmap::IndexMap;
+
+use aletheia_koina::id::ToolName;
 
 use super::workspace::{extract_opt_u64, extract_str};
 use crate::error::Result;

--- a/crates/organon/src/builtins/communication.rs
+++ b/crates/organon/src/builtins/communication.rs
@@ -7,8 +7,9 @@
 use std::future::Future;
 use std::pin::Pin;
 
-use aletheia_koina::id::ToolName;
 use indexmap::IndexMap;
+
+use aletheia_koina::id::ToolName;
 
 use super::workspace::{extract_opt_u64, extract_str};
 use crate::error::Result;

--- a/crates/organon/src/builtins/enable_tool.rs
+++ b/crates/organon/src/builtins/enable_tool.rs
@@ -7,8 +7,9 @@
 use std::future::Future;
 use std::pin::Pin;
 
-use aletheia_koina::id::ToolName;
 use indexmap::IndexMap;
+
+use aletheia_koina::id::ToolName;
 
 use crate::error::Result;
 use crate::registry::{ToolExecutor, ToolRegistry};

--- a/crates/organon/src/builtins/filesystem.rs
+++ b/crates/organon/src/builtins/filesystem.rs
@@ -12,8 +12,9 @@ use std::pin::Pin;
 use std::process::{Command, Stdio};
 use std::time::SystemTime;
 
-use aletheia_koina::id::ToolName;
 use indexmap::IndexMap;
+
+use aletheia_koina::id::ToolName;
 
 use crate::error::Result;
 use crate::process_guard::ProcessGuard;

--- a/crates/organon/src/builtins/memory/blackboard.rs
+++ b/crates/organon/src/builtins/memory/blackboard.rs
@@ -7,8 +7,9 @@
 use std::future::Future;
 use std::pin::Pin;
 
-use aletheia_koina::id::ToolName;
 use indexmap::IndexMap;
+
+use aletheia_koina::id::ToolName;
 
 use crate::error::Result;
 use crate::registry::{ToolExecutor, ToolRegistry};

--- a/crates/organon/src/builtins/memory/datalog.rs
+++ b/crates/organon/src/builtins/memory/datalog.rs
@@ -7,8 +7,9 @@
 use std::future::Future;
 use std::pin::Pin;
 
-use aletheia_koina::id::ToolName;
 use indexmap::IndexMap;
+
+use aletheia_koina::id::ToolName;
 
 use crate::error::Result;
 use crate::registry::{ToolExecutor, ToolRegistry};

--- a/crates/organon/src/builtins/memory/knowledge_ops.rs
+++ b/crates/organon/src/builtins/memory/knowledge_ops.rs
@@ -7,8 +7,9 @@
 use std::future::Future;
 use std::pin::Pin;
 
-use aletheia_koina::id::ToolName;
 use indexmap::IndexMap;
+
+use aletheia_koina::id::ToolName;
 
 use crate::error::Result;
 use crate::registry::{ToolExecutor, ToolRegistry};

--- a/crates/organon/src/builtins/memory/note.rs
+++ b/crates/organon/src/builtins/memory/note.rs
@@ -7,8 +7,9 @@
 use std::future::Future;
 use std::pin::Pin;
 
-use aletheia_koina::id::ToolName;
 use indexmap::IndexMap;
+
+use aletheia_koina::id::ToolName;
 
 use crate::error::Result;
 use crate::registry::{ToolExecutor, ToolRegistry};

--- a/crates/organon/src/builtins/planning_defs.rs
+++ b/crates/organon/src/builtins/planning_defs.rs
@@ -6,8 +6,9 @@
 
 use indexmap::IndexMap;
 
-use crate::types::{InputSchema, PropertyDef, PropertyType, ToolCategory, ToolDef};
 use aletheia_koina::id::ToolName;
+
+use crate::types::{InputSchema, PropertyDef, PropertyType, ToolCategory, ToolDef};
 
 pub(super) fn plan_create_def() -> ToolDef {
     ToolDef {

--- a/crates/organon/src/builtins/planning_tests.rs
+++ b/crates/organon/src/builtins/planning_tests.rs
@@ -6,9 +6,9 @@ use std::path::PathBuf;
 use std::pin::Pin;
 use std::sync::{Arc, Mutex, RwLock};
 
-use aletheia_koina::id::{NousId, SessionId, ToolName};
-
 use snafu::IntoError;
+
+use aletheia_koina::id::{NousId, SessionId, ToolName};
 
 use crate::error::{PlanningAdapterError, SaveProjectSnafu};
 use crate::registry::ToolRegistry;

--- a/crates/organon/src/builtins/research.rs
+++ b/crates/organon/src/builtins/research.rs
@@ -12,9 +12,10 @@ use std::future::Future;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::pin::Pin;
 
-use aletheia_koina::id::ToolName;
 use indexmap::IndexMap;
 use reqwest::redirect;
+
+use aletheia_koina::id::ToolName;
 
 use crate::error::Result;
 use crate::registry::{ToolExecutor, ToolRegistry};

--- a/crates/organon/src/builtins/workspace.rs
+++ b/crates/organon/src/builtins/workspace.rs
@@ -11,12 +11,12 @@ use std::pin::Pin;
 use std::process::{Command, Stdio};
 use std::time::{Duration, Instant};
 
-use crate::process_guard::ProcessGuard;
-
-use aletheia_koina::id::ToolName;
 use indexmap::IndexMap;
 
+use aletheia_koina::id::ToolName;
+
 use crate::error::{self, Result};
+use crate::process_guard::ProcessGuard;
 use crate::registry::{ToolExecutor, ToolRegistry};
 use crate::types::{
     InputSchema, PropertyDef, PropertyType, ToolCategory, ToolContext, ToolDef, ToolInput,

--- a/crates/organon/src/error.rs
+++ b/crates/organon/src/error.rs
@@ -1,7 +1,8 @@
 //! Error types for the organon crate.
 
-use aletheia_koina::id::ToolName;
 use snafu::Snafu;
+
+use aletheia_koina::id::ToolName;
 
 /// Errors from tool registry operations.
 #[derive(Debug, Snafu)]

--- a/crates/organon/src/registry.rs
+++ b/crates/organon/src/registry.rs
@@ -5,10 +5,11 @@ use std::future::Future;
 use std::pin::Pin;
 use std::time::Instant;
 
-use aletheia_koina::id::ToolName;
 use indexmap::IndexMap;
 use snafu::ensure;
 use tracing::info_span;
+
+use aletheia_koina::id::ToolName;
 
 use crate::error::{self, Result};
 use crate::types::{ToolCategory, ToolContext, ToolDef, ToolInput, ToolResult};

--- a/crates/organon/src/types.rs
+++ b/crates/organon/src/types.rs
@@ -6,13 +6,13 @@ use std::path::PathBuf;
 use std::pin::Pin;
 use std::sync::{Arc, RwLock};
 
-use aletheia_koina::id::{NousId, SessionId, ToolName};
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 
 pub use aletheia_hermeneus::types::{
     DocumentSource, ImageSource, ToolResultBlock, ToolResultContent,
 };
+use aletheia_koina::id::{NousId, SessionId, ToolName};
 
 /// Tool definition: the rich metadata that organon tracks internally.
 ///

--- a/crates/pylon/src/error.rs
+++ b/crates/pylon/src/error.rs
@@ -300,9 +300,10 @@ impl From<tokio::task::JoinError> for ApiError {
 #[expect(clippy::unwrap_used, reason = "test assertions")]
 #[expect(clippy::expect_used, reason = "test assertions")]
 mod tests {
-    use super::*;
     use axum::response::IntoResponse;
     use tracing::Instrument;
+
+    use super::*;
 
     #[test]
     fn rate_limited_includes_retry_after_header() {

--- a/crates/pylon/src/handlers/knowledge.rs
+++ b/crates/pylon/src/handlers/knowledge.rs
@@ -724,8 +724,9 @@ pub(crate) fn sort_facts(facts: &mut [aletheia_mneme::knowledge::Fact], sort: &s
                 .unwrap_or(std::cmp::Ordering::Equal);
             if desc { cmp.reverse() } else { cmp }
         }),
-        // NOTE: unrecognized sort field, facts retain original order
-        _ => {}
+        _ => {
+            // NOTE: unrecognized sort field, facts retain original order
+        }
     }
 }
 

--- a/crates/pylon/src/middleware.rs
+++ b/crates/pylon/src/middleware.rs
@@ -241,8 +241,9 @@ impl RateLimiter {
 /// arbitrary IP and bypass per-IP rate limits. Only trusted reverse proxies
 /// should supply these headers, controlled by the `trust_proxy` flag.
 fn extract_client_key(request: &Request, trust_proxy: bool) -> String {
-    use axum::extract::ConnectInfo;
     use std::net::SocketAddr;
+
+    use axum::extract::ConnectInfo;
 
     // NOTE: Prefer the actual peer address: not spoofable.
     if let Some(info) = request.extensions().get::<ConnectInfo<SocketAddr>>() {

--- a/crates/pylon/src/openapi.rs
+++ b/crates/pylon/src/openapi.rs
@@ -8,8 +8,9 @@
 use axum::http::header;
 use axum::response::IntoResponse;
 
-use aletheia_koina::http::CONTENT_TYPE_JSON;
 use utoipa::OpenApi;
+
+use aletheia_koina::http::CONTENT_TYPE_JSON;
 
 #[derive(OpenApi)]
 #[openapi(

--- a/crates/pylon/src/server.rs
+++ b/crates/pylon/src/server.rs
@@ -3,6 +3,7 @@
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Instant;
+
 use tokio::sync::Mutex;
 
 use snafu::{ResultExt, Snafu};

--- a/crates/pylon/src/state.rs
+++ b/crates/pylon/src/state.rs
@@ -2,7 +2,9 @@
 
 use std::sync::Arc;
 use std::time::Instant;
+
 use tokio::sync::Mutex;
+use tokio_util::sync::CancellationToken;
 
 use aletheia_hermeneus::provider::ProviderRegistry;
 #[cfg(feature = "knowledge-store")]
@@ -13,7 +15,6 @@ use aletheia_organon::registry::ToolRegistry;
 use aletheia_symbolon::jwt::JwtManager;
 use aletheia_taxis::config::AletheiaConfig;
 use aletheia_taxis::oikos::Oikos;
-use tokio_util::sync::CancellationToken;
 
 use crate::idempotency::IdempotencyCache;
 

--- a/crates/pylon/src/tests/helpers.rs
+++ b/crates/pylon/src/tests/helpers.rs
@@ -1,23 +1,22 @@
 use std::sync::Arc;
 use std::time::Instant;
 
-use aletheia_koina::secret::SecretString;
 use axum::body::Body;
 use axum::http::{Request, StatusCode};
 use tokio::sync::Mutex;
+use tokio_util::sync::CancellationToken;
 use tower::ServiceExt;
-
-use aletheia_koina::http::{BEARER_PREFIX, CONTENT_TYPE_JSON};
 
 use aletheia_hermeneus::provider::ProviderRegistry;
 use aletheia_hermeneus::test_utils::MockProvider;
+use aletheia_koina::http::{BEARER_PREFIX, CONTENT_TYPE_JSON};
+use aletheia_koina::secret::SecretString;
 use aletheia_mneme::store::SessionStore;
 use aletheia_nous::config::{NousConfig, PipelineConfig};
 use aletheia_nous::manager::NousManager;
 use aletheia_organon::registry::ToolRegistry;
 use aletheia_symbolon::jwt::{JwtConfig, JwtManager};
 use aletheia_taxis::oikos::Oikos;
-use tokio_util::sync::CancellationToken;
 
 pub(super) use crate::router::build_router;
 pub(super) use crate::security::SecurityConfig;

--- a/crates/symbolon/src/auth.rs
+++ b/crates/symbolon/src/auth.rs
@@ -7,8 +7,9 @@
 use std::path::Path;
 use std::time::Duration;
 
-use aletheia_koina::secret::SecretString;
 use tracing::instrument;
+
+use aletheia_koina::secret::SecretString;
 
 use crate::api_key;
 use crate::error::{self, Result};

--- a/crates/symbolon/src/jwt.rs
+++ b/crates/symbolon/src/jwt.rs
@@ -6,11 +6,12 @@
 
 use std::time::Duration;
 
-use aletheia_koina::secret::SecretString;
 use base64::Engine;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use ring::hmac;
 use tracing::instrument;
+
+use aletheia_koina::secret::SecretString;
 
 use crate::error::{self, Result};
 use crate::types::{Claims, Role, TokenKind, TokenPair};

--- a/crates/symbolon/src/password.rs
+++ b/crates/symbolon/src/password.rs
@@ -1,9 +1,10 @@
 //! Argon2id password hashing and verification.
 
-use aletheia_koina::secret::SecretString;
 use argon2::password_hash::SaltString;
 use argon2::password_hash::rand_core::OsRng;
 use argon2::{Argon2, PasswordHash, PasswordHasher, PasswordVerifier};
+
+use aletheia_koina::secret::SecretString;
 
 use crate::error::{self, Result};
 

--- a/crates/taxis/src/encrypt.rs
+++ b/crates/taxis/src/encrypt.rs
@@ -363,7 +363,10 @@ pub fn decrypt_toml_values(value: &mut toml::Value, master_key: Option<&[u8; KEY
                 decrypt_toml_values(item, master_key);
             }
         }
-        _ => {}
+        _ => {
+            // NOTE: leaf TOML values (bool, integer, float, datetime) cannot contain
+            // encrypted strings and require no decryption pass
+        }
     }
 }
 
@@ -416,7 +419,10 @@ fn encrypt_recursive(
                 encrypt_recursive(item, master_key, count)?;
             }
         }
-        _ => {}
+        _ => {
+            // NOTE: leaf TOML values (bool, integer, float, datetime) cannot hold
+            // plaintext secrets and are skipped during encryption traversal
+        }
     }
     Ok(())
 }

--- a/crates/taxis/src/loader.rs
+++ b/crates/taxis/src/loader.rs
@@ -1,10 +1,11 @@
 //! Figment-based configuration loading with TOML cascade.
 
-use aletheia_koina::disk_space::{DiskSpaceMonitor, DiskStatus};
 use figment::Figment;
 use figment::providers::{Env, Format, Serialized, Toml};
 use snafu::ResultExt;
 use tracing::{error, warn};
+
+use aletheia_koina::disk_space::{DiskSpaceMonitor, DiskStatus};
 
 use crate::config::AletheiaConfig;
 use crate::encrypt;
@@ -134,7 +135,9 @@ pub fn write_config_checked(
                     "disk space critical, config write proceeding (essential)"
                 );
             }
-            _ => {}
+            _ => {
+                // NOTE: DiskStatus::Ok requires no warning; write proceeds silently
+            }
         }
     }
 

--- a/crates/taxis/src/redact.rs
+++ b/crates/taxis/src/redact.rs
@@ -59,8 +59,9 @@ fn redact_sensitive_keys(value: &mut Value) {
                 redact_sensitive_keys(item);
             }
         }
-        // NOTE: leaf values (null, bool, number, string) have no keys to redact
-        _ => {}
+        _ => {
+            // NOTE: leaf values (null, bool, number, string) have no keys to redact
+        }
     }
 }
 

--- a/crates/taxis/src/validate.rs
+++ b/crates/taxis/src/validate.rs
@@ -255,8 +255,9 @@ fn validate_bindings(value: &Value, errors: &mut Vec<String>) {
                 None | Some("") => {
                     errors.push(format!("bindings[{i}].{field} must not be empty"));
                 }
-                // NOTE: non-empty field value passes validation
-                _ => {}
+                _ => {
+                    // NOTE: non-empty field value passes validation
+                }
             }
         }
     }

--- a/crates/theatron/tui/src/api/client.rs
+++ b/crates/theatron/tui/src/api/client.rs
@@ -1,6 +1,7 @@
-use aletheia_koina::secret::SecretString;
 use reqwest::{Client, Response, StatusCode, header};
 use snafu::prelude::*;
+
+use aletheia_koina::secret::SecretString;
 
 use super::error::{ApiError, AuthSnafu, HttpSnafu, Result, ServerSnafu};
 use super::types::*;

--- a/crates/theatron/tui/src/api/types.rs
+++ b/crates/theatron/tui/src/api/types.rs
@@ -1,5 +1,6 @@
-use aletheia_koina::secret::SecretString;
 use serde::{Deserialize, Serialize};
+
+use aletheia_koina::secret::SecretString;
 
 use crate::id::{NousId, PlanId, SessionId, TurnId};
 

--- a/crates/theatron/tui/src/config.rs
+++ b/crates/theatron/tui/src/config.rs
@@ -1,9 +1,10 @@
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
-use aletheia_koina::secret::SecretString;
 use serde::{Deserialize, Serialize};
 use snafu::prelude::*;
+
+use aletheia_koina::secret::SecretString;
 
 use crate::error::{ConfigDirSnafu, IoSnafu, Result, TomlSnafu};
 use crate::theme::ThemeMode;

--- a/crates/theatron/tui/src/hyperlink.rs
+++ b/crates/theatron/tui/src/hyperlink.rs
@@ -66,8 +66,9 @@ fn probe_hyperlink_support() -> bool {
     if let Ok(prog) = std::env::var("TERM_PROGRAM") {
         match prog.as_str() {
             "iTerm.app" | "WezTerm" | "ghostty" | "Ghostty" | "kitty" => return true,
-            // NOTE: unrecognized TERM_PROGRAM, continue probing other signals
-            _ => {}
+            _ => {
+                // NOTE: unrecognized TERM_PROGRAM, continue probing other signals
+            }
         }
     }
 

--- a/crates/theatron/tui/src/mapping.rs
+++ b/crates/theatron/tui/src/mapping.rs
@@ -361,8 +361,9 @@ impl App {
             (KeyModifiers::CONTROL, KeyCode::Char('c'))
             | (KeyModifiers::CONTROL, KeyCode::Char('q')) => return Some(Msg::Quit),
             (KeyModifiers::CONTROL, KeyCode::Char('f')) => return Some(Msg::ToggleSidebar),
-            // NOTE: unhandled key combinations produce no action
-            _ => {}
+            _ => {
+                // NOTE: unhandled key combinations produce no action
+            }
         }
 
         if self.layout.memory.fact_list.editing_confidence {

--- a/crates/theatron/tui/src/markdown.rs
+++ b/crates/theatron/tui/src/markdown.rs
@@ -163,8 +163,9 @@ pub fn render(
                 Tag::TableCell => {
                     current_cell.clear();
                 }
-                // NOTE: unhandled start tags (footnotes, metadata) are ignored
-                _ => {}
+                _ => {
+                    // NOTE: unhandled start tags (footnotes, metadata) are ignored
+                }
             },
             Event::End(tag_end) => match tag_end {
                 TagEnd::Heading(_) => {
@@ -277,8 +278,9 @@ pub fn render(
                 TagEnd::TableCell => {
                     current_row.push(current_cell.trim().to_string());
                 }
-                // NOTE: unhandled end tags are ignored
-                _ => {}
+                _ => {
+                    // NOTE: unhandled end tags are ignored
+                }
             },
             Event::Text(text) => {
                 if in_image {
@@ -348,8 +350,9 @@ pub fn render(
                 flush_line(&mut lines, &mut current_spans, &mut current_col);
                 lines.push(Line::from(Span::styled("─".repeat(40), theme.style_dim())));
             }
-            // NOTE: unhandled markdown events (footnotes, etc.) are ignored
-            _ => {}
+            _ => {
+                // NOTE: unhandled markdown events (footnotes, etc.) are ignored
+            }
         }
     }
 

--- a/crates/theatron/tui/src/sanitize.rs
+++ b/crates/theatron/tui/src/sanitize.rs
@@ -161,8 +161,9 @@ fn needs_sanitization(s: &str) -> bool {
         match b {
             // NOTE: replace C0 controls (except HT/LF/CR) and DEL with control pictures
             0x00..=0x08 | 0x0B..=0x0C | 0x0E..=0x1F | 0x7F => return true,
-            // NOTE: printable ASCII byte, no sanitization needed
-            _ => {}
+            _ => {
+                // NOTE: printable ASCII byte, no sanitization needed
+            }
         }
     }
     for ch in s.chars() {

--- a/crates/theatron/tui/src/update/mod.rs
+++ b/crates/theatron/tui/src/update/mod.rs
@@ -119,8 +119,9 @@ pub(crate) async fn update(app: &mut App, msg: Msg) {
                     match c {
                         's' | 'S' => settings::handle_save(app).await,
                         'r' | 'R' => settings::handle_reset(app),
-                        // NOTE: other keys ignored in settings non-edit mode
-                        _ => {}
+                        _ => {
+                            // NOTE: other keys ignored in settings non-edit mode
+                        }
                     }
                 }
             }

--- a/crates/theatron/tui/src/update/overlay.rs
+++ b/crates/theatron/tui/src/update/overlay.rs
@@ -83,8 +83,9 @@ pub(crate) fn handle_overlay_up(app: &mut App) {
         Some(Overlay::Settings(_)) => {
             super::settings::handle_up(app);
         }
-        // NOTE: no overlay or non-navigable overlay, nothing to do
-        _ => {}
+        _ => {
+            // NOTE: no overlay or non-navigable overlay, nothing to do
+        }
     }
 }
 
@@ -114,8 +115,9 @@ pub(crate) fn handle_overlay_down(app: &mut App) {
         Some(Overlay::Settings(_)) => {
             super::settings::handle_down(app);
         }
-        // NOTE: no overlay or non-navigable overlay, nothing to do
-        _ => {}
+        _ => {
+            // NOTE: no overlay or non-navigable overlay, nothing to do
+        }
     }
 }
 

--- a/crates/theatron/tui/src/update/settings.rs
+++ b/crates/theatron/tui/src/update/settings.rs
@@ -100,8 +100,9 @@ fn confirm_edit(s: &mut SettingsOverlay) {
             FieldType::Text => {
                 field.value = serde_json::Value::String(edit.buffer);
             }
-            // NOTE: ReadOnly and Boolean fields don't need text confirmation
-            _ => {}
+            _ => {
+                // NOTE: ReadOnly and Boolean fields don't need text confirmation
+            }
         }
     }
 }

--- a/crates/thesauros/src/tools.rs
+++ b/crates/thesauros/src/tools.rs
@@ -311,11 +311,13 @@ fn parse_property_type(type_name: &str, tool_name: &str) -> Result<PropertyType,
 #[cfg(test)]
 #[expect(clippy::unwrap_used, reason = "test assertions")]
 mod tests {
-    use super::*;
-    use crate::manifest::{PackInputSchema, PackManifest, PackPropertyDef, PackToolDef};
     use std::fs;
     use std::os::unix::fs::PermissionsExt;
+
     use tempfile::TempDir;
+
+    use super::*;
+    use crate::manifest::{PackInputSchema, PackManifest, PackPropertyDef, PackToolDef};
 
     fn setup_pack_dir(files: &[(&str, &str)]) -> TempDir {
         let dir = TempDir::new().unwrap();

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -65,7 +65,7 @@ done
 
 backup_binary() {
     if [[ ! -f "$BINARY_DST" ]]; then
-        log "No existing binary at $BINARY_DST, skipping backup"
+        log "No existing binary at ${BINARY_DST}, skipping backup"
         return 0
     fi
 
@@ -74,8 +74,8 @@ backup_binary() {
     local backup_path="${BACKUP_DIR}/aletheia.backup.${timestamp}"
 
     if [[ "$DRY_RUN" == true ]]; then
-        log "[dry-run] Would back up $BINARY_DST to $backup_path"
-        log "[dry-run] Would prune backups beyond $MAX_BACKUPS"
+        log "[dry-run] Would back up ${BINARY_DST} to $backup_path"
+        log "[dry-run] Would prune backups beyond ${MAX_BACKUPS}"
         return 0
     fi
 
@@ -155,12 +155,12 @@ do_rollback() {
     backup="$(get_latest_backup)"
 
     if [[ -z "$backup" ]]; then
-        die "No backups found in $BACKUP_DIR"
+        die "No backups found in ${BACKUP_DIR}"
     fi
 
     if [[ "$DRY_RUN" == true ]]; then
-        log "[dry-run] Would restore $backup to $BINARY_DST"
-        log "[dry-run] Would restart $SERVICE"
+        log "[dry-run] Would restore $backup to ${BINARY_DST}"
+        log "[dry-run] Would restart ${SERVICE}"
         log "[dry-run] Would run health check"
         return 0
     fi
@@ -169,7 +169,7 @@ do_rollback() {
 
     # Stop service
     if systemctl --user is-active "$SERVICE" &>/dev/null; then
-        log "Stopping $SERVICE..."
+        log "Stopping ${SERVICE}..."
         systemctl --user stop "$SERVICE"
     fi
 
@@ -206,7 +206,7 @@ refresh_token() {
                 echo "ANTHROPIC_AUTH_TOKEN=$token" >> "$env_file"
             fi
             chmod 600 "$env_file"
-            log "Token written to $env_file"
+            log "Token written to ${env_file}"
         fi
     fi
 }
@@ -241,7 +241,7 @@ fi
 
 # Verify binary exists
 if [[ "$DRY_RUN" == false && ! -f "$BINARY_SRC" ]]; then
-    die "Binary not found at $BINARY_SRC. Run with --build or build manually first."
+    die "Binary not found at ${BINARY_SRC}. Run with --build or build manually first."
 fi
 
 # Backup existing binary before deploy
@@ -250,20 +250,20 @@ backup_binary
 # Stop service if running
 if systemctl --user is-active "$SERVICE" &>/dev/null; then
     if [[ "$DRY_RUN" == true ]]; then
-        log "[dry-run] Would stop $SERVICE"
+        log "[dry-run] Would stop ${SERVICE}"
     else
-        log "Stopping $SERVICE..."
+        log "Stopping ${SERVICE}..."
         systemctl --user stop "$SERVICE"
     fi
 fi
 
 # Copy binary
 if [[ "$DRY_RUN" == true ]]; then
-    log "[dry-run] Would copy $BINARY_SRC to $BINARY_DST"
+    log "[dry-run] Would copy ${BINARY_SRC} to ${BINARY_DST}"
 else
     mkdir -p "$(dirname "$BINARY_DST")"
     cp -- "$BINARY_SRC" "$BINARY_DST"
-    log "Deployed: $BINARY_DST"
+    log "Deployed: ${BINARY_DST}"
 fi
 
 # Smoke test: validate config with the newly deployed binary
@@ -283,7 +283,7 @@ fi
 # Restart and health check
 if [[ "$RESTART" == true ]]; then
     if [[ "$DRY_RUN" == true ]]; then
-        log "[dry-run] Would restart $SERVICE"
+        log "[dry-run] Would restart ${SERVICE}"
         log "[dry-run] Would run health check (${HEALTH_TIMEOUT}s timeout)"
         log "[dry-run] Would auto-rollback on health check failure"
     else

--- a/scripts/pre-commit-instance-guard
+++ b/scripts/pre-commit-instance-guard
@@ -3,7 +3,7 @@ set -euo pipefail
 # Pre-commit hook: reject any staged files under instance/
 # Install: cp scripts/pre-commit-instance-guard .git/hooks/pre-commit
 
-INSTANCE_FILES=$(git diff --cached --name-only | grep "^instance/" || true)
+INSTANCE_FILES=$(git diff --cached --name-only | grep "^instance/" || true)  # NOTE: failure is non-fatal here
 
 if [[ -n "$INSTANCE_FILES" ]]; then
     echo "ERROR: Attempting to commit instance/ files:"

--- a/scripts/rollback.sh
+++ b/scripts/rollback.sh
@@ -28,20 +28,20 @@ fi
 
 [[ -f "$BACKUP" ]] || die "No backup found at ${BACKUP:-$BACKUP_DIR/}"
 
-log "Rolling back from $BACKUP..."
+log "Rolling back from ${BACKUP}..."
 
 # Stop service
 if systemctl --user is-active "$SERVICE" &>/dev/null; then
-    log "Stopping $SERVICE..."
+    log "Stopping ${SERVICE}..."
     systemctl --user stop "$SERVICE"
 fi
 
 # Restore binary
 cp -- "$BACKUP" "$BINARY_DST"
-log "Binary restored to $BINARY_DST"
+log "Binary restored to ${BINARY_DST}"
 
 # Restart
-log "Starting $SERVICE..."
+log "Starting ${SERVICE}..."
 systemctl --user daemon-reload
 systemctl --user start "$SERVICE"
 

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -188,11 +188,11 @@ trap 'rm -rf "$TMPDIR_INIT"' EXIT
 INIT_EXIT=0
 INIT_OUT=$("$BINARY" init --instance-root "$TMPDIR_INIT/instance" --yes 2>&1) || INIT_EXIT=$?
 if [[ "$INIT_EXIT" -le 1 ]]; then
-    pass "init --yes exits cleanly (exit $INIT_EXIT)"
+    pass "init --yes exits cleanly (exit ${INIT_EXIT})"
 elif echo "$INIT_OUT" | grep -qiE "api.?key|anthropic|credential|error"; then
     pass "init --yes fails with useful error message"
 else
-    fail "init --yes panicked or produced no useful output (exit $INIT_EXIT)"
+    fail "init --yes panicked or produced no useful output (exit ${INIT_EXIT})"
 fi
 
 section "Import (missing file — expect error)"
@@ -217,7 +217,7 @@ section "Unknown subcommand"
 UNKNOWN_EXIT=0
 "$BINARY" totally-unknown-subcommand 2>/dev/null || UNKNOWN_EXIT=$?
 if [[ "$UNKNOWN_EXIT" -ne 0 ]]; then
-    pass "unknown subcommand exits non-zero (exit $UNKNOWN_EXIT)"
+    pass "unknown subcommand exits non-zero (exit ${UNKNOWN_EXIT})"
 else
     fail "unknown subcommand should exit non-zero"
 fi

--- a/shared/bin/aletheia-backup
+++ b/shared/bin/aletheia-backup
@@ -64,7 +64,7 @@ trap 'rm -rf "$TEMP_DIR"' EXIT
 DB_FILE="$CONFIG_DIR/sessions.db"
 if [[ -f "$DB_FILE" ]]; then
   echo "→ Checkpointing SQLite WAL..."
-  sqlite3 "$DB_FILE" "PRAGMA wal_checkpoint(TRUNCATE);" 2>/dev/null || true
+  sqlite3 "$DB_FILE" "PRAGMA wal_checkpoint(TRUNCATE);" 2>/dev/null || true  # NOTE: failure is non-fatal here
   cp "$DB_FILE" "$TEMP_DIR/sessions.db"
   echo "  sessions.db: $(du -h "$TEMP_DIR/sessions.db" | cut -f1)"
 else

--- a/shared/bin/start.sh
+++ b/shared/bin/start.sh
@@ -28,7 +28,7 @@ if [[ -f "$CLAUDE_JSON" ]]; then
   api_key=$(python3 -c "
 import json, sys
 print(json.load(open(sys.argv[1])).get('primaryApiKey', ''))
-" "$CLAUDE_JSON" 2>/dev/null || true)
+" "$CLAUDE_JSON" 2>/dev/null || true)  # NOTE: failure is non-fatal here
   if [[ -n "$api_key" && "${api_key:0:11}" == "sk-ant-api0" ]]; then
     mkdir -p "$(dirname "$ALETHEIA_CREDS")"
     python3 -c "

--- a/shared/bin/transcribe
+++ b/shared/bin/transcribe
@@ -67,6 +67,6 @@ if $DO_SUMMARY; then
 EOF
   log "Summary stub created"
 fi
-chmod -R g+rw "$OUT_DIR" 2>/dev/null || true
+chmod -R g+rw "$OUT_DIR" 2>/dev/null || true  # NOTE: failure is non-fatal here
 log "Done."
 echo "$OUT_DIR"


### PR DESCRIPTION
Closes #1595. Mechanical style fixes: match arm formatting, import grouping, shell script cleanup.

## Test plan
- [x] cargo clippy passes
- [x] cargo test passes