### PR TITLE
fix(hermeneus): log full error body with model/token context

### DIFF
--- a/crates/hermeneus/src/anthropic/client.rs
+++ b/crates/hermeneus/src/anthropic/client.rs
@@ -219,6 +219,7 @@ impl AnthropicProvider {
                 tokio::time::sleep(backoff_delay(attempt, last_error.as_ref())).await;
             }
 
+            let (token_prefix, credential_source) = self.credential_log_info();
             let headers = self.build_headers()?;
 
             let mut response = match self
@@ -240,7 +241,13 @@ impl AnthropicProvider {
 
             if !response.status().is_success() {
                 let status = response.status().as_u16();
-                let err = super::error::map_error_response(response).await;
+                let err = super::error::map_error_response(
+                    response,
+                    &request.model,
+                    &token_prefix,
+                    &credential_source,
+                )
+                .await;
                 self.health.record_error(&err);
                 // Non-retryable HTTP status: 401, 400-level (except 429)
                 if status == 401 || ((400..500).contains(&status) && status != 429) {
@@ -400,6 +407,23 @@ impl AnthropicProvider {
         }))
     }
 
+    /// Return `(token_prefix, credential_source)` strings for diagnostic logging.
+    ///
+    /// The token prefix is the first 15 characters of the current secret value;
+    /// the credential source is the [`CredentialSource`] display string.
+    /// Returns empty strings when no credential is available.
+    fn credential_log_info(&self) -> (String, String) {
+        match self.credential_provider.get_credential() {
+            Some(cred) => {
+                let s = cred.secret.expose_secret();
+                let prefix = s.get(..15).unwrap_or(s).to_owned();
+                let source = cred.source.to_string();
+                (prefix, source)
+            }
+            None => (String::new(), String::new()),
+        }
+    }
+
     fn build_headers(&self) -> Result<HeaderMap> {
         let credential = self.credential_provider.get_credential().ok_or_else(|| {
             error::AuthFailedSnafu {
@@ -494,6 +518,7 @@ impl AnthropicProvider {
                 tokio::time::sleep(backoff_delay(attempt, last_error.as_ref())).await;
             }
 
+            let (token_prefix, credential_source) = self.credential_log_info();
             let headers = self.build_headers()?;
 
             let response = match self
@@ -574,7 +599,13 @@ impl AnthropicProvider {
                 return parsed;
             }
 
-            let err = super::error::map_error_response(response).await;
+            let err = super::error::map_error_response(
+                response,
+                &request.model,
+                &token_prefix,
+                &credential_source,
+            )
+            .await;
             self.health.record_error(&err);
 
             if status == 401 || ((400..500).contains(&status) && status != 429) {

--- a/crates/hermeneus/src/anthropic/error.rs
+++ b/crates/hermeneus/src/anthropic/error.rs
@@ -2,23 +2,46 @@
 
 use reqwest::Response;
 use snafu::ResultExt;
+use tracing::warn;
 
 use super::wire::WireErrorResponse;
-use crate::error::{self, Result};
+use crate::error::{self, ApiErrorContext, Result};
 
 /// Map an HTTP response with a non-success status to a hermeneus error.
 ///
 /// Consumes the response body to extract the Anthropic error detail.
-pub(crate) async fn map_error_response(response: Response) -> error::Error {
+/// Logs the full raw body, model, token prefix, credential source, and
+/// `x-request-id` at WARN level before parsing so operators can diagnose
+/// opaque errors (e.g. OAuth token with unknown model alias returning "Error").
+pub(crate) async fn map_error_response(
+    response: Response,
+    model: &str,
+    token_prefix: &str,
+    credential_source: &str,
+) -> error::Error {
     let status = response.status().as_u16();
     let retry_after_ms = extract_retry_after(&response);
+    let request_id = response
+        .headers()
+        .get("x-request-id")
+        .and_then(|v| v.to_str().ok())
+        .map(str::to_owned);
 
-    let detail = match response.text().await.ok() {
-        Some(body) => serde_json::from_str::<WireErrorResponse>(&body)
-            .ok()
-            .map(|e| e.error.message),
-        None => None,
-    };
+    let body = response.text().await.unwrap_or_default();
+
+    warn!(
+        status,
+        model,
+        token_prefix,
+        credential_source,
+        request_id = request_id.as_deref().unwrap_or(""),
+        body = %body,
+        "Anthropic API error response"
+    );
+
+    let detail = serde_json::from_str::<WireErrorResponse>(&body)
+        .ok()
+        .map(|e| e.error.message);
 
     let message = detail.unwrap_or_else(|| format!("HTTP {status}"));
 
@@ -28,7 +51,15 @@ pub(crate) async fn map_error_response(response: Response) -> error::Error {
             retry_after_ms: retry_after_ms.unwrap_or(1000),
         }
         .build(),
-        _ => error::ApiSnafu { status, message }.build(),
+        _ => error::ApiSnafu {
+            status,
+            message,
+            context: Box::new(ApiErrorContext {
+                model: model.to_owned(),
+                credential_source: credential_source.to_owned(),
+            }),
+        }
+        .build(),
     }
 }
 
@@ -73,6 +104,7 @@ pub(crate) fn map_sse_error(detail: super::wire::WireErrorDetail) -> crate::erro
         _ => crate::error::ApiSnafu {
             status: 0_u16,
             message: detail.message,
+            context: ApiErrorContext::empty(),
         }
         .build(),
     }

--- a/crates/hermeneus/src/error.rs
+++ b/crates/hermeneus/src/error.rs
@@ -6,6 +6,29 @@
 
 use snafu::Snafu;
 
+/// Diagnostic context carried by [`Error::ApiError`].
+///
+/// Grouped into a separate struct so it can be boxed in the enum variant,
+/// keeping the variant size below clippy's `result_large_err` threshold.
+#[derive(Debug)]
+pub struct ApiErrorContext {
+    /// Model requested when the error occurred.
+    pub model: String,
+    /// Credential source used (e.g. `"oauth"`, `"environment"`, `"file"`).
+    pub credential_source: String,
+}
+
+impl ApiErrorContext {
+    /// Empty context for error sites without model/credential information.
+    #[must_use]
+    pub fn empty() -> Box<Self> {
+        Box::new(Self {
+            model: String::new(),
+            credential_source: String::new(),
+        })
+    }
+}
+
 /// Errors from LLM provider operations.
 #[derive(Debug, Snafu)]
 #[snafu(visibility(pub))]
@@ -32,6 +55,13 @@ pub enum Error {
     ApiError {
         status: u16,
         message: String,
+        /// Diagnostic context (model + credential source).
+        ///
+        /// Boxed so that the variant stays within clippy's `result_large_err`
+        /// limit. `hermeneus::Error` is embedded as a `source` field inside
+        /// `nous::Error`, and two unboxed `String` fields would push the
+        /// `nous::Error` variant size over 128 bytes.
+        context: Box<ApiErrorContext>,
         #[snafu(implicit)]
         location: snafu::Location,
     },

--- a/crates/hermeneus/src/fallback.rs
+++ b/crates/hermeneus/src/fallback.rs
@@ -109,7 +109,7 @@ mod tests {
     use std::sync::atomic::{AtomicU32, Ordering};
 
     use super::*;
-    use crate::error;
+    use crate::error::{self, ApiErrorContext};
     use crate::types::*;
 
     struct MockFallbackProvider {
@@ -205,6 +205,7 @@ mod tests {
         Err(error::ApiSnafu {
             status: 503_u16,
             message: "service unavailable".to_owned(),
+            context: ApiErrorContext::empty(),
         }
         .build())
     }

--- a/crates/hermeneus/src/health.rs
+++ b/crates/hermeneus/src/health.rs
@@ -241,6 +241,7 @@ impl ProviderHealthTracker {
 #[expect(clippy::unwrap_used, reason = "test assertions")]
 mod tests {
     use super::*;
+    use crate::error::ApiErrorContext;
 
     fn tracker(threshold: u32, cooldown_ms: u64) -> ProviderHealthTracker {
         ProviderHealthTracker::new(HealthConfig {
@@ -261,6 +262,7 @@ mod tests {
         crate::error::ApiSnafu {
             status: 500_u16,
             message: "internal",
+            context: ApiErrorContext::empty(),
         }
         .build()
     }

--- a/crates/nous/src/user_error.rs
+++ b/crates/nous/src/user_error.rs
@@ -206,6 +206,7 @@ mod tests {
             source: aletheia_hermeneus::error::ApiSnafu {
                 status: 502_u16,
                 message: "bad gateway",
+                context: aletheia_hermeneus::error::ApiErrorContext::empty(),
             }
             .build(),
             location: snafu::Location::new("test", 1, 1),

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -162,7 +162,7 @@ and falls back to `127.0.0.1` for direct connections.
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `enabled` | bool | `false` | Whether rate limiting is active |
-| `requestsPerMinute` | u32 | `60` | Maximum requests per minute per client IP |
+| `requests_per_minute` | u32 | `60` | Maximum requests per minute per client IP |
 
 ```toml
 [gateway]


### PR DESCRIPTION
Closes #1599, closes #1600, closes #1602. Enriched API error logging with model name, credential source prefix, and full response body.

## Test plan
- [x] cargo clippy passes
- [x] cargo test passes