### PR TITLE
refactor: remaining refactors (datalog builders, deploy download, standards-sync CI)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,3 +58,45 @@ jobs:
             fi
           done < <(git log --format='%s' origin/main..HEAD)
           exit $failed
+
+  standards-sync:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Fetch canonical standards from kanon
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mkdir -p /tmp/kanon-standards
+          # List files in kanon standards/ and fetch each one
+          gh api repos/forkwright/kanon/contents/standards \
+            --jq '.[].name' | while IFS= read -r fname; do
+            gh api "repos/forkwright/kanon/contents/standards/${fname}" \
+              --jq '.content' \
+              | base64 -d > "/tmp/kanon-standards/${fname}"
+          done
+
+      - name: Diff standards against kanon canonical
+        run: |
+          failed=0
+          while IFS= read -r fname; do
+            local_file="standards/${fname}"
+            canonical="/tmp/kanon-standards/${fname}"
+            if [[ ! -f "$local_file" ]]; then
+              echo "::error file=${local_file}::Canonical file '${fname}' from kanon is missing locally"
+              failed=1
+            elif ! diff -q -- "$canonical" "$local_file" > /dev/null 2>&1; then
+              echo "::error file=${local_file}::Local '${fname}' diverges from kanon canonical"
+              diff -- "$canonical" "$local_file" || true
+              failed=1
+            fi
+          done < <(ls /tmp/kanon-standards/)
+          if [[ "$failed" -ne 0 ]]; then
+            echo ""
+            echo "Standards diverged from kanon. Update local standards/ to match, or sync kanon."
+            echo "Aletheia-specific additions (files only in standards/ but not in kanon) are allowed."
+            exit 1
+          fi
+          echo "standards/ is in sync with kanon"

--- a/crates/mneme/src/knowledge_store/entity.rs
+++ b/crates/mneme/src/knowledge_store/entity.rs
@@ -72,11 +72,7 @@ impl KnowledgeStore {
             DataValue::Str(entity_id.as_str().into()),
         );
         params.insert("created_at".to_owned(), DataValue::Str(now.into()));
-        self.run_mut(
-            r"?[fact_id, entity_id, created_at] <- [[$fact_id, $entity_id, $created_at]]
-            :put fact_entities {fact_id, entity_id => created_at}",
-            params,
-        )
+        self.run_mut(&queries::upsert_fact_entity(), params)
     }
 
     /// List all entities in the knowledge store.
@@ -184,13 +180,7 @@ impl KnowledgeStore {
             DataValue::from(i64::from(relationships_redirected)),
         );
         params.insert("merged_at".to_owned(), DataValue::Str(now_str.into()));
-        self.run_mut(
-            r"?[canonical_id, merged_id, merged_name, merge_score, facts_transferred, relationships_redirected, merged_at] <- [[
-                $canonical_id, $merged_id, $merged_name, $merge_score, $facts_transferred, $relationships_redirected, $merged_at
-            ]]
-            :put merge_audit {canonical_id, merged_id => merged_name, merge_score, facts_transferred, relationships_redirected, merged_at}",
-            params,
-        )?;
+        self.run_mut(&queries::put_merge_audit(), params)?;
 
         let mut rm_params = BTreeMap::new();
         rm_params.insert(
@@ -202,11 +192,7 @@ impl KnowledgeStore {
             DataValue::Str(merged_id.as_str().into()),
         );
         // WHY: Try both orderings; pending_merges may store (a,b) or (b,a).
-        if let Err(e) = self.run_mut(
-            r"?[entity_a, entity_b] <- [[$entity_a, $entity_b]]
-            :rm pending_merges {entity_a, entity_b}",
-            rm_params,
-        ) {
+        if let Err(e) = self.run_mut(&queries::rm_pending_merges(), rm_params) {
             tracing::warn!(
                 %canonical_id, %merged_id, error = %e,
                 "failed to remove pending_merges entry (a,b ordering)"
@@ -221,11 +207,7 @@ impl KnowledgeStore {
             "entity_b".to_owned(),
             DataValue::Str(canonical_id.as_str().into()),
         );
-        if let Err(e) = self.run_mut(
-            r"?[entity_a, entity_b] <- [[$entity_a, $entity_b]]
-            :rm pending_merges {entity_a, entity_b}",
-            rm_params2,
-        ) {
+        if let Err(e) = self.run_mut(&queries::rm_pending_merges(), rm_params2) {
             tracing::warn!(
                 %canonical_id, %merged_id, error = %e,
                 "failed to remove pending_merges entry (b,a ordering)"
@@ -530,10 +512,7 @@ impl KnowledgeStore {
                 let mut rm_params = BTreeMap::new();
                 rm_params.insert("src".to_owned(), DataValue::Str(from_id.as_str().into()));
                 rm_params.insert("dst".to_owned(), DataValue::Str(dst.into()));
-                let _ = self.run_mut(
-                    r"?[src, dst] <- [[$src, $dst]] :rm relationships {src, dst}",
-                    rm_params,
-                );
+                let _ = self.run_mut(&queries::rm_relationship(), rm_params);
                 continue;
             }
 
@@ -543,11 +522,7 @@ impl KnowledgeStore {
             put_params.insert("relation".to_owned(), DataValue::Str(relation.into()));
             put_params.insert("weight".to_owned(), DataValue::from(weight));
             put_params.insert("created_at".to_owned(), DataValue::Str(created_at.into()));
-            self.run_mut(
-                r"?[src, dst, relation, weight, created_at] <- [[$src, $dst, $relation, $weight, $created_at]]
-                :put relationships {src, dst => relation, weight, created_at}",
-                put_params,
-            )?;
+            self.run_mut(&queries::upsert_relationship(), put_params)?;
 
             let mut rm_params = BTreeMap::new();
             rm_params.insert("src".to_owned(), DataValue::Str(from_id.as_str().into()));
@@ -555,10 +530,7 @@ impl KnowledgeStore {
                 "dst".to_owned(),
                 DataValue::Str(extract_str(&row[1])?.into()),
             );
-            let _ = self.run_mut(
-                r"?[src, dst] <- [[$src, $dst]] :rm relationships {src, dst}",
-                rm_params,
-            );
+            let _ = self.run_mut(&queries::rm_relationship(), rm_params);
         }
 
         Ok(u32::try_from(count).unwrap_or(0))
@@ -597,10 +569,7 @@ impl KnowledgeStore {
                 let mut rm_params = BTreeMap::new();
                 rm_params.insert("src".to_owned(), DataValue::Str(src.into()));
                 rm_params.insert("dst".to_owned(), DataValue::Str(from_id.as_str().into()));
-                let _ = self.run_mut(
-                    r"?[src, dst] <- [[$src, $dst]] :rm relationships {src, dst}",
-                    rm_params,
-                );
+                let _ = self.run_mut(&queries::rm_relationship(), rm_params);
                 continue;
             }
 
@@ -610,11 +579,7 @@ impl KnowledgeStore {
             put_params.insert("relation".to_owned(), DataValue::Str(relation.into()));
             put_params.insert("weight".to_owned(), DataValue::from(weight));
             put_params.insert("created_at".to_owned(), DataValue::Str(created_at.into()));
-            self.run_mut(
-                r"?[src, dst, relation, weight, created_at] <- [[$src, $dst, $relation, $weight, $created_at]]
-                :put relationships {src, dst => relation, weight, created_at}",
-                put_params,
-            )?;
+            self.run_mut(&queries::upsert_relationship(), put_params)?;
 
             let mut rm_params = BTreeMap::new();
             rm_params.insert(
@@ -622,10 +587,7 @@ impl KnowledgeStore {
                 DataValue::Str(extract_str(&row[0])?.into()),
             );
             rm_params.insert("dst".to_owned(), DataValue::Str(from_id.as_str().into()));
-            let _ = self.run_mut(
-                r"?[src, dst] <- [[$src, $dst]] :rm relationships {src, dst}",
-                rm_params,
-            );
+            let _ = self.run_mut(&queries::rm_relationship(), rm_params);
         }
 
         Ok(u32::try_from(count).unwrap_or(0))
@@ -669,11 +631,7 @@ impl KnowledgeStore {
                 DataValue::Str(to_id.as_str().into()),
             );
             put_params.insert("created_at".to_owned(), DataValue::Str(created_at.into()));
-            self.run_mut(
-                r"?[fact_id, entity_id, created_at] <- [[$fact_id, $entity_id, $created_at]]
-                :put fact_entities {fact_id, entity_id => created_at}",
-                put_params,
-            )?;
+            self.run_mut(&queries::upsert_fact_entity(), put_params)?;
 
             // Remove old mapping
             let mut rm_params = BTreeMap::new();
@@ -682,11 +640,7 @@ impl KnowledgeStore {
                 "entity_id".to_owned(),
                 DataValue::Str(from_id.as_str().into()),
             );
-            let _ = self.run_mut(
-                r"?[fact_id, entity_id] <- [[$fact_id, $entity_id]]
-                :rm fact_entities {fact_id, entity_id}",
-                rm_params,
-            );
+            let _ = self.run_mut(&queries::rm_fact_entity(), rm_params);
         }
 
         Ok(u32::try_from(count).unwrap_or(0))
@@ -732,13 +686,7 @@ impl KnowledgeStore {
             "created_at".to_owned(),
             DataValue::Str(crate::knowledge::format_timestamp(&entity.created_at).into()),
         );
-        self.run_mut(
-            r"?[id, name, entity_type, aliases, created_at, updated_at] <- [[
-                $id, $name, $entity_type, $aliases, $created_at, $updated_at
-            ]]
-            :put entities {id => name, entity_type, aliases, created_at, updated_at}",
-            params,
-        )
+        self.run_mut(&queries::upsert_entity(), params)
     }
 
     /// Delete an entity from the entities relation.
@@ -748,7 +696,7 @@ impl KnowledgeStore {
 
         let mut params = BTreeMap::new();
         params.insert("id".to_owned(), DataValue::Str(entity_id.as_str().into()));
-        self.run_mut(r"?[id] <- [[$id]] :rm entities {id}", params)
+        self.run_mut(&queries::rm_entity(), params)
     }
 
     /// Store a pending merge candidate for review.
@@ -798,12 +746,6 @@ impl KnowledgeStore {
             DataValue::from(candidate.merge_score),
         );
         params.insert("created_at".to_owned(), DataValue::Str(now.into()));
-        self.run_mut(
-            r"?[entity_a, entity_b, name_a, name_b, name_similarity, embed_similarity, type_match, alias_overlap, merge_score, created_at] <- [[
-                $entity_a, $entity_b, $name_a, $name_b, $name_similarity, $embed_similarity, $type_match, $alias_overlap, $merge_score, $created_at
-            ]]
-            :put pending_merges {entity_a, entity_b => name_a, name_b, name_similarity, embed_similarity, type_match, alias_overlap, merge_score, created_at}",
-            params,
-        )
+        self.run_mut(&queries::put_pending_merge(), params)
     }
 }

--- a/crates/mneme/src/query/builders.rs
+++ b/crates/mneme/src/query/builders.rs
@@ -31,6 +31,15 @@ impl QueryBuilder {
         }
     }
 
+    /// Start a `:rm` operation against a relation.
+    pub fn rm(self, relation: Relation) -> RmBuilder {
+        RmBuilder {
+            parent: self,
+            relation,
+            key_fields: Vec::new(),
+        }
+    }
+
     /// Start a `?[...] := *relation{...}` scan query.
     pub fn scan(self, relation: Relation) -> ScanBuilder {
         ScanBuilder {
@@ -229,6 +238,37 @@ impl ScanBuilder {
             let _ = write!(line, "\n:limit {lim}");
         }
 
+        self.parent.lines.push(line);
+        self.parent
+    }
+}
+
+/// Builds a `?[keys] <- [[params]]` `:rm relation {keys}` operation.
+#[must_use]
+pub struct RmBuilder {
+    parent: QueryBuilder,
+    relation: Relation,
+    key_fields: Vec<&'static str>,
+}
+
+impl RmBuilder {
+    /// Declare the key fields that identify the row to remove.
+    pub fn keys(mut self, fields: &[impl Field]) -> Self {
+        for f in fields {
+            self.key_fields.push(f.name());
+        }
+        self
+    }
+
+    /// Finish the `:rm`, returning the parent `QueryBuilder`.
+    pub fn done(mut self) -> QueryBuilder {
+        let field_list = self.key_fields.join(", ");
+        let params: Vec<String> = self.key_fields.iter().map(|f| format!("${f}")).collect();
+        let param_row = params.join(", ");
+        let line = format!(
+            "?[{field_list}] <- [[{param_row}]]\n:rm {} {{{field_list}}}",
+            self.relation.name()
+        );
         self.parent.lines.push(line);
         self.parent
     }

--- a/crates/mneme/src/query/queries.rs
+++ b/crates/mneme/src/query/queries.rs
@@ -523,3 +523,100 @@ pub fn audit_all_facts() -> String {
         .done()
         .build_script()
 }
+
+/// Remove a fact-entity mapping.
+/// Params: `$fact_id`, `$entity_id`.
+pub fn rm_fact_entity() -> String {
+    use FactEntitiesField::{EntityId, FactId};
+    QueryBuilder::new()
+        .rm(Relation::FactEntities)
+        .keys(&[FactId, EntityId])
+        .done()
+        .build_script()
+}
+
+/// Insert or update a fact-entity mapping.
+/// Params: `$fact_id`, `$entity_id`, `$created_at`.
+pub fn upsert_fact_entity() -> String {
+    use FactEntitiesField::*;
+    QueryBuilder::new()
+        .put(Relation::FactEntities)
+        .keys(&[FactId, EntityId])
+        .values(&[CreatedAt])
+        .done()
+        .build_script()
+}
+
+/// Remove an entity.
+/// Params: `$id`.
+pub fn rm_entity() -> String {
+    use EntitiesField::Id;
+    QueryBuilder::new()
+        .rm(Relation::Entities)
+        .keys(&[Id])
+        .done()
+        .build_script()
+}
+
+/// Remove a relationship edge.
+/// Params: `$src`, `$dst`.
+pub fn rm_relationship() -> String {
+    use RelationshipsField::{Dst, Src};
+    QueryBuilder::new()
+        .rm(Relation::Relationships)
+        .keys(&[Src, Dst])
+        .done()
+        .build_script()
+}
+
+/// Remove a pending-merge entry.
+/// Params: `$entity_a`, `$entity_b`.
+pub fn rm_pending_merges() -> String {
+    use PendingMergesField::{EntityA, EntityB};
+    QueryBuilder::new()
+        .rm(Relation::PendingMerges)
+        .keys(&[EntityA, EntityB])
+        .done()
+        .build_script()
+}
+
+/// Insert or update a merge-audit record.
+/// Params: `$canonical_id`, `$merged_id`, `$merged_name`, `$merge_score`,
+/// `$facts_transferred`, `$relationships_redirected`, `$merged_at`.
+pub fn put_merge_audit() -> String {
+    use MergeAuditField::*;
+    QueryBuilder::new()
+        .put(Relation::MergeAudit)
+        .keys(&[CanonicalId, MergedId])
+        .values(&[
+            MergedName,
+            MergeScore,
+            FactsTransferred,
+            RelationshipsRedirected,
+            MergedAt,
+        ])
+        .done()
+        .build_script()
+}
+
+/// Insert or update a pending-merge candidate.
+/// Params: `$entity_a`, `$entity_b`, `$name_a`, `$name_b`, `$name_similarity`,
+/// `$embed_similarity`, `$type_match`, `$alias_overlap`, `$merge_score`, `$created_at`.
+pub fn put_pending_merge() -> String {
+    use PendingMergesField::*;
+    QueryBuilder::new()
+        .put(Relation::PendingMerges)
+        .keys(&[EntityA, EntityB])
+        .values(&[
+            NameA,
+            NameB,
+            NameSimilarity,
+            EmbedSimilarity,
+            TypeMatch,
+            AliasOverlap,
+            MergeScore,
+            CreatedAt,
+        ])
+        .done()
+        .build_script()
+}

--- a/crates/mneme/src/query/schema.rs
+++ b/crates/mneme/src/query/schema.rs
@@ -15,6 +15,12 @@ pub enum Relation {
     Relationships,
     /// Vector embeddings for semantic search.
     Embeddings,
+    /// Fact-to-entity membership mapping.
+    FactEntities,
+    /// Audit log of completed entity merges.
+    MergeAudit,
+    /// Queue of candidate entity merges awaiting review.
+    PendingMerges,
 }
 
 impl Relation {
@@ -25,6 +31,9 @@ impl Relation {
             Self::Entities => "entities",
             Self::Relationships => "relationships",
             Self::Embeddings => "embeddings",
+            Self::FactEntities => "fact_entities",
+            Self::MergeAudit => "merge_audit",
+            Self::PendingMerges => "pending_merges",
         }
     }
 }
@@ -146,6 +155,85 @@ impl Field for EmbeddingsField {
             Self::SourceId => "source_id",
             Self::NousId => "nous_id",
             Self::Embedding => "embedding",
+            Self::CreatedAt => "created_at",
+        }
+    }
+}
+
+/// Fields in the `fact_entities` relation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum FactEntitiesField {
+    FactId,
+    EntityId,
+    CreatedAt,
+}
+
+impl Field for FactEntitiesField {
+    fn name(self) -> &'static str {
+        match self {
+            Self::FactId => "fact_id",
+            Self::EntityId => "entity_id",
+            Self::CreatedAt => "created_at",
+        }
+    }
+}
+
+/// Fields in the `merge_audit` relation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum MergeAuditField {
+    CanonicalId,
+    MergedId,
+    MergedName,
+    MergeScore,
+    FactsTransferred,
+    RelationshipsRedirected,
+    MergedAt,
+}
+
+impl Field for MergeAuditField {
+    fn name(self) -> &'static str {
+        match self {
+            Self::CanonicalId => "canonical_id",
+            Self::MergedId => "merged_id",
+            Self::MergedName => "merged_name",
+            Self::MergeScore => "merge_score",
+            Self::FactsTransferred => "facts_transferred",
+            Self::RelationshipsRedirected => "relationships_redirected",
+            Self::MergedAt => "merged_at",
+        }
+    }
+}
+
+/// Fields in the `pending_merges` relation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum PendingMergesField {
+    EntityA,
+    EntityB,
+    NameA,
+    NameB,
+    NameSimilarity,
+    EmbedSimilarity,
+    TypeMatch,
+    AliasOverlap,
+    MergeScore,
+    CreatedAt,
+}
+
+impl Field for PendingMergesField {
+    fn name(self) -> &'static str {
+        match self {
+            Self::EntityA => "entity_a",
+            Self::EntityB => "entity_b",
+            Self::NameA => "name_a",
+            Self::NameB => "name_b",
+            Self::NameSimilarity => "name_similarity",
+            Self::EmbedSimilarity => "embed_similarity",
+            Self::TypeMatch => "type_match",
+            Self::AliasOverlap => "alias_overlap",
+            Self::MergeScore => "merge_score",
             Self::CreatedAt => "created_at",
         }
     }

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 #   --restart    Restart systemd service after deploy (default: just copy)
 #   --rollback   Restore the most recent backup and restart
 #   --dry-run    Show what would happen without executing
+#   --download vX.Y.Z  Download prebuilt binary from GitHub releases (falls back to build)
 #   No flags:    build + copy + restart (full deploy)
 #
 # Prerequisites: cargo, curl, jq, systemctl
@@ -45,6 +46,7 @@ BUILD=false
 RESTART=false
 ROLLBACK=false
 DRY_RUN=false
+DOWNLOAD_VERSION=""
 
 if [[ $# -eq 0 ]]; then
     BUILD=true
@@ -57,6 +59,13 @@ while [[ $# -gt 0 ]]; do
         --restart) RESTART=true; shift ;;
         --rollback) ROLLBACK=true; shift ;;
         --dry-run) DRY_RUN=true; shift ;;
+        --download)
+            if [[ $# -lt 2 || "$2" == --* ]]; then
+                die "Missing version argument for --download (e.g. --download v0.12.0)"
+            fi
+            DOWNLOAD_VERSION="$2"
+            shift 2
+            ;;
         *) die "Unknown flag: $1" ;;
     esac
 done
@@ -211,6 +220,45 @@ refresh_token() {
     fi
 }
 
+# --- Download prebuilt binary ---
+
+download_binary() {
+    local version="$1"
+    local repo="${GITHUB_REPO:-forkwright/aletheia}"
+    local asset_name="aletheia-$(uname -m)-unknown-linux-gnu"
+    local tmp_bin
+    tmp_bin="$(mktemp)" || return 1
+    trap 'rm -f -- "$tmp_bin"' RETURN
+
+    log "Attempting to download ${version} from ${repo}..."
+
+    # Try gh CLI first, fall back to curl
+    if command -v gh &>/dev/null; then
+        if gh release download "$version" \
+            --repo "$repo" \
+            --pattern "$asset_name" \
+            --output "$tmp_bin" \
+            --clobber 2>/dev/null; then
+            chmod +x -- "$tmp_bin"
+            cp -- "$tmp_bin" "$BINARY_SRC"
+            log "Downloaded binary via gh: ${BINARY_SRC}"
+            return 0
+        fi
+        log "gh release download failed, trying curl..."
+    fi
+
+    local url="https://github.com/${repo}/releases/download/${version}/${asset_name}"
+    if curl -fsSL --max-time 120 --output "$tmp_bin" -- "$url" 2>/dev/null; then
+        chmod +x -- "$tmp_bin"
+        cp -- "$tmp_bin" "$BINARY_SRC"
+        log "Downloaded binary via curl: ${BINARY_SRC}"
+        return 0
+    fi
+
+    log "Download failed for ${version}, falling back to local build"
+    return 1
+}
+
 # --- Main ---
 
 # Handle rollback mode
@@ -218,6 +266,20 @@ if [[ "$ROLLBACK" == true ]]; then
     log "=== Rollback requested ==="
     do_rollback
     exit 0
+fi
+
+# Download binary if requested
+if [[ -n "$DOWNLOAD_VERSION" ]]; then
+    [[ "$DOWNLOAD_VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9] ]] \
+        || die "Version must match vX.Y.Z format, got: $DOWNLOAD_VERSION"
+    if [[ "$DRY_RUN" == true ]]; then
+        log "[dry-run] Would download ${DOWNLOAD_VERSION} from GitHub releases"
+    elif download_binary "$DOWNLOAD_VERSION"; then
+        BUILD=false
+    else
+        log "Download failed; proceeding with local build"
+        BUILD=true
+    fi
 fi
 
 # Prereq: instance directory must exist before any deploy step.


### PR DESCRIPTION
## Summary

- **#1628**: Replace 15 raw Datalog mutation strings in `entity.rs` with typed query builder calls. Added `RmBuilder` to `builders.rs`, three new `Relation` variants and field enums to `schema.rs`, and seven new query functions (`upsert_fact_entity`, `rm_fact_entity`, `rm_entity`, `rm_relationship`, `rm_pending_merges`, `put_merge_audit`, `put_pending_merge`) to `queries.rs`.
- **#1596**: Add `--download vX.Y.Z` flag to `scripts/deploy.sh` that fetches a prebuilt binary from GitHub releases via `gh` CLI (falls back to `curl`, then falls back to local build on failure).
- **#1650**: Add `standards-sync` CI job to `ci.yml` that diffs `standards/` against the canonical copy at `forkwright/kanon/standards/` via `gh api`, failing if any canonical file diverges. Aletheia-specific additions (files only present locally) are allowed.

Closes #1628, #1596, #1650.

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes (zero warnings)
- [x] `cargo test --workspace` passes
- [x] `cargo test --workspace --doc` passes
- [x] Zero `run_mut(r"..."` raw mutation calls remain in `entity.rs`
- [x] `deploy.sh --download v0.12.0` path exists and includes version format validation
- [x] `standards-sync` job added to `ci.yml`

## Observations

- `crates/mneme/src/knowledge_store/facts.rs` contains two additional raw Datalog `:put facts` mutations in `forget_fact` and `unforget_fact`. These use Datalog rule bodies (`:= *facts{...}`) to combine a read and write in a single script — a pattern the current builder does not support. They are out of scope for #1628 but could be addressed by extending `QueryBuilder` with a `scan_put` pattern.
- The `standards-sync` job requires `secrets.GITHUB_TOKEN` read access to the `forkwright/kanon` repository. If `kanon` is private, the token must have `contents: read` on that repo (may need a PAT).

🤖 Generated with [Claude Code](https://claude.com/claude-code)