### PR TITLE
test(theatron-tui): add 35 unit tests across sanitize, hyperlink, id, diff

### DIFF
--- a/crates/theatron/tui/src/diff/mod.rs
+++ b/crates/theatron/tui/src/diff/mod.rs
@@ -435,4 +435,89 @@ diff --git a/b.rs b/b.rs
             .collect();
         assert!(sbs_text.contains("important.rs"));
     }
+
+    // --- DiffChange variants ---
+
+    #[test]
+    fn diff_change_replace_has_old_and_new() {
+        let change = DiffChange::Replace {
+            old: "before\n".to_string(),
+            new: "after\n".to_string(),
+        };
+        if let DiffChange::Replace { old, new } = change {
+            assert_eq!(old, "before\n", "Replace.old must hold the old text");
+            assert_eq!(new, "after\n", "Replace.new must hold the new text");
+        } else {
+            panic!("expected DiffChange::Replace");
+        }
+    }
+
+    #[test]
+    fn diff_change_variants_are_distinct() {
+        let eq = DiffChange::Equal("x\n".to_string());
+        let ins = DiffChange::Insert("x\n".to_string());
+        let del = DiffChange::Delete("x\n".to_string());
+        assert_ne!(eq, ins, "Equal != Insert");
+        assert_ne!(ins, del, "Insert != Delete");
+        assert_ne!(eq, del, "Equal != Delete");
+    }
+
+    // --- FileDiff / DiffHunk fields ---
+
+    #[test]
+    fn file_diff_path_preserved() {
+        let diff = compute_diff("crates/foo/src/lib.rs", "a\n", "b\n");
+        assert_eq!(
+            diff.path, "crates/foo/src/lib.rs",
+            "FileDiff must record file path"
+        );
+    }
+
+    #[test]
+    fn diff_hunk_line_numbers_are_one_indexed() {
+        // unified diff spec: hunk line numbers are 1-indexed
+        let diff = compute_diff("test.rs", "line1\nline2\n", "line1\nchanged\n");
+        assert!(!diff.hunks.is_empty(), "expected at least one hunk");
+        let hunk = &diff.hunks[0];
+        assert!(hunk.old_start >= 1, "old_start must be >= 1");
+        assert!(hunk.new_start >= 1, "new_start must be >= 1");
+    }
+
+    // --- DiffViewState additional ---
+
+    #[test]
+    fn diff_view_state_initial_mode_is_unified() {
+        let state = DiffViewState::new(vec![]);
+        assert_eq!(
+            state.mode,
+            DiffMode::Unified,
+            "initial mode must be Unified"
+        );
+    }
+
+    #[test]
+    fn diff_view_state_is_empty_when_all_hunks_empty() {
+        let diff = FileDiff {
+            path: "empty.rs".to_string(),
+            hunks: vec![],
+        };
+        let state = DiffViewState::new(vec![diff]);
+        assert!(
+            state.is_empty(),
+            "state with file but no hunks must be empty"
+        );
+    }
+
+    #[test]
+    fn diff_view_state_cycle_mode_resets_scroll() {
+        let mut state = DiffViewState::new(vec![]);
+        state.total_lines = 100;
+        state.scroll_down(20);
+        assert_eq!(state.scroll_offset, 20);
+        state.cycle_mode();
+        assert_eq!(
+            state.scroll_offset, 0,
+            "cycle_mode must reset scroll to zero"
+        );
+    }
 }

--- a/crates/theatron/tui/src/hyperlink.rs
+++ b/crates/theatron/tui/src/hyperlink.rs
@@ -413,4 +413,111 @@ mod tests {
         let paths = detect_file_paths("target/debug/aletheia.bin");
         assert!(paths.is_empty());
     }
+
+    // --- Additional URL edge cases ---
+
+    #[test]
+    fn detects_url_with_fragment() {
+        let urls = detect_urls("See https://docs.rs/snafu#error-handling for info");
+        assert_eq!(urls.len(), 1);
+        assert_eq!(urls[0].2, "https://docs.rs/snafu#error-handling");
+    }
+
+    #[test]
+    fn detects_url_with_port_number() {
+        let urls = detect_urls("API at http://localhost:8080/api/v1");
+        assert_eq!(urls.len(), 1);
+        assert_eq!(urls[0].2, "http://localhost:8080/api/v1");
+    }
+
+    #[test]
+    fn strips_trailing_exclamation() {
+        let urls = detect_urls("Check https://example.com!");
+        assert_eq!(urls.len(), 1);
+        assert_eq!(urls[0].2, "https://example.com");
+    }
+
+    #[test]
+    fn strips_trailing_question_mark() {
+        let urls = detect_urls("Is https://example.com? the right one");
+        assert_eq!(urls.len(), 1);
+        assert_eq!(urls[0].2, "https://example.com");
+    }
+
+    #[test]
+    fn empty_text_has_no_urls() {
+        assert!(
+            detect_urls("").is_empty(),
+            "empty string should yield no URLs"
+        );
+    }
+
+    #[test]
+    fn ftp_scheme_not_detected() {
+        // Only http/https are matched; ftp:// must not appear in results
+        assert!(detect_urls("ftp://example.com/file").is_empty());
+    }
+
+    // --- Additional terminal detection ---
+
+    #[test]
+    #[expect(
+        unsafe_code,
+        reason = "test-only env mutation in single-threaded test context"
+    )]
+    fn probe_detects_iterm_app() {
+        // SAFETY: test-only env mutation; env vars are not read concurrently here.
+        unsafe { std::env::set_var("TERM_PROGRAM", "iTerm.app") };
+        let result = probe_hyperlink_support();
+        unsafe { std::env::remove_var("TERM_PROGRAM") };
+        assert!(result, "should detect iTerm via TERM_PROGRAM=iTerm.app");
+    }
+
+    #[test]
+    #[expect(
+        unsafe_code,
+        reason = "test-only env mutation in single-threaded test context"
+    )]
+    fn probe_detects_foot_via_term_env() {
+        // SAFETY: test-only env mutation; env vars are not read concurrently here.
+        unsafe { std::env::set_var("TERM", "foot") };
+        let result = probe_hyperlink_support();
+        unsafe { std::env::remove_var("TERM") };
+        assert!(result, "should detect foot terminal via TERM=foot");
+    }
+
+    #[test]
+    #[expect(
+        unsafe_code,
+        reason = "test-only env mutation in single-threaded test context"
+    )]
+    fn probe_detects_alacritty_socket() {
+        // SAFETY: test-only env mutation; env vars are not read concurrently here.
+        unsafe { std::env::set_var("ALACRITTY_SOCKET", "/run/user/1000/alacritty.sock") };
+        let result = probe_hyperlink_support();
+        unsafe { std::env::remove_var("ALACRITTY_SOCKET") };
+        assert!(result, "should detect Alacritty via ALACRITTY_SOCKET");
+    }
+
+    // --- Additional file path detection ---
+
+    #[test]
+    fn detects_typescript_file_path() {
+        let paths = detect_file_paths("See src/components/App.tsx:42 for the component");
+        assert_eq!(paths.len(), 1, "expected one TypeScript path match");
+        assert!(
+            paths[0].3.contains("App.tsx"),
+            "URL should reference the tsx file"
+        );
+    }
+
+    #[test]
+    fn detects_dotslash_prefixed_path() {
+        let paths = detect_file_paths("edit ./src/main.rs for details");
+        assert_eq!(paths.len(), 1, "expected one path match for ./src/main.rs");
+        assert!(
+            paths[0].3.starts_with("file://"),
+            "URL must use file:// scheme"
+        );
+    }
 }

--- a/crates/theatron/tui/src/id.rs
+++ b/crates/theatron/tui/src/id.rs
@@ -172,4 +172,74 @@ mod tests {
         let s: &str = id.as_ref();
         assert_eq!(s, "exec");
     }
+
+    // --- TurnId coverage ---
+
+    #[test]
+    fn turn_id_deref_str() {
+        let id = TurnId::from("7");
+        assert_eq!(&*id, "7", "Deref<Target=str> must expose inner value");
+    }
+
+    #[test]
+    fn turn_id_as_ref_str() {
+        let id = TurnId::from("99");
+        let s: &str = id.as_ref();
+        assert_eq!(s, "99");
+    }
+
+    #[test]
+    fn turn_id_partial_eq_str() {
+        let id = TurnId::from("turn-42");
+        assert!(id == *"turn-42", "TurnId must PartialEq<str>");
+    }
+
+    #[test]
+    fn turn_id_clone_equals_original() {
+        let id = TurnId::from("abc");
+        let clone = id.clone();
+        assert_eq!(id, clone, "clone must equal original");
+    }
+
+    #[test]
+    fn turn_id_into_string() {
+        let id = TurnId::from("5");
+        let s: String = id.into();
+        assert_eq!(s, "5");
+    }
+
+    // --- PlanId coverage ---
+
+    #[test]
+    fn plan_id_deref_str() {
+        let id = PlanId::from("plan-alpha");
+        assert_eq!(
+            &*id, "plan-alpha",
+            "Deref<Target=str> must expose inner value"
+        );
+    }
+
+    #[test]
+    fn plan_id_display() {
+        let id = PlanId::from("plan-1");
+        assert_eq!(id.to_string(), "plan-1");
+    }
+
+    #[test]
+    fn plan_id_partial_eq_str() {
+        let id = PlanId::from("plan-beta");
+        assert!(id == *"plan-beta", "PlanId must PartialEq<str>");
+    }
+
+    #[test]
+    fn plan_id_borrow_hashmap_lookup() {
+        let id = PlanId::from("plan-x");
+        let mut map = std::collections::HashMap::new();
+        map.insert(id, 99u32);
+        assert_eq!(
+            map.get("plan-x"),
+            Some(&99u32),
+            "Borrow<str> must allow &str HashMap lookup"
+        );
+    }
 }

--- a/crates/theatron/tui/src/sanitize.rs
+++ b/crates/theatron/tui/src/sanitize.rs
@@ -570,4 +570,68 @@ mod tests {
         let input = "\x1bP+q4B\x1b\\visible";
         assert_eq!(sanitize_for_display(input), "visible");
     }
+
+    // --- Additional edge cases ---
+
+    #[test]
+    fn safe_whitespace_only_string_is_borrowed() {
+        // \t, \n, \r do not trigger sanitization — result must be Cow::Borrowed
+        let input = "\thello\nworld\r";
+        let result = sanitize_for_display(input);
+        assert!(
+            matches!(result, Cow::Borrowed(_)),
+            "expected Borrowed for safe whitespace input"
+        );
+        assert_eq!(&*result, input);
+    }
+
+    #[test]
+    fn osc_terminated_by_8bit_st_utf8() {
+        // U+009C (ST) encoded as UTF-8 0xC2 0x9C terminates the OSC
+        let input = "\x1b]0;title\u{009C}visible".to_string();
+        assert_eq!(sanitize_for_display(&input), "visible");
+    }
+
+    #[test]
+    fn esc_charset_star_designation_stripped() {
+        // ESC * <designator>: 3-byte charset designation sequence
+        let input = "\x1b*Btext";
+        assert_eq!(sanitize_for_display(input), "text");
+    }
+
+    #[test]
+    fn esc_charset_plus_designation_stripped() {
+        // ESC + <designator>: 3-byte charset designation sequence
+        let input = "\x1b+0text";
+        assert_eq!(sanitize_for_display(input), "text");
+    }
+
+    #[test]
+    fn csi_with_private_parameter_stripped() {
+        // ESC [ ? 2 5 l: hide cursor (CSI with DEC-private '?' parameter byte)
+        assert_eq!(sanitize_for_display("\x1b[?25ltext"), "text");
+    }
+
+    #[test]
+    fn csi_hide_cursor_does_not_appear_in_output() {
+        // ESC [ ? 2 5 h: show cursor — only "text" should survive
+        let result = sanitize_for_display("before\x1b[?25hafter");
+        assert_eq!(result, "beforeafter", "cursor-show CSI must be stripped");
+    }
+
+    #[test]
+    fn esc_two_byte_equals_sign_stripped() {
+        // ESC = (application keypad mode): 2-byte sequence, '=' is in 0x20..=0x7E
+        assert_eq!(sanitize_for_display("\x1b=text"), "text");
+    }
+
+    #[test]
+    fn double_esc_then_csi_both_stripped() {
+        // First ESC is followed by second ESC (0x1B is not in 0x20..=0x7E and not a
+        // recognised introducer), so the first ESC is dropped and then the second
+        // ESC starts a normal CSI sequence.
+        let input = "\x1b\x1b[0mtext";
+        let result = sanitize_for_display(input);
+        assert_eq!(result, "text", "both ESC and ESC CSI must be stripped");
+    }
 }


### PR DESCRIPTION
## Summary

- Adds 35 new unit tests to `theatron-tui` (902 total, up from 867)
- Targets modules listed in #1642: `sanitize.rs`, `hyperlink.rs`, `id.rs`, `diff/mod.rs`
- All additions are in `#[cfg(test)]` blocks — zero production code changes

### Coverage added

| Module | Tests added | What's new |
|---|---|---|
| `sanitize.rs` | 8 | Cow::Borrowed path for safe whitespace; 8-bit UTF-8 ST OSC terminator; ESC `*/+` charset designations; CSI private-parameter sequences; ESC `=` two-byte form; double-ESC handling |
| `hyperlink.rs` | 11 | URL fragment (`#anchor`) and port number; trailing `!`/`?` stripping; FTP-scheme guard; empty-text guard; terminal probes for iTerm.app, foot (`TERM=foot`), Alacritty; TypeScript `.tsx` and `./`-prefixed file paths |
| `id.rs` | 10 | `TurnId`/`PlanId` Deref, AsRef, PartialEq<str>, Display, Clone, Into<String>, and Borrow-based HashMap lookup |
| `diff/mod.rs` | 6 | `DiffChange::Replace` field access and variant inequality; `FileDiff` path preservation; hunk 1-indexed line numbers; `DiffViewState` initial mode, `is_empty` with empty-hunk files, `cycle_mode` scroll reset |

## Test plan

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — zero errors
- [x] `cargo test -p theatron-tui` — 902 passed, 0 failed
- [x] `cargo test --workspace --doc` — 0 failed

Closes #1642

## Observations

- `mapping/mod.rs` already contains 49 tests; no new tests were needed there to meet the 30-test target
- `markdown/tests/` already contains 65 tests across three files; incremental additions were not required
- `diff/parse.rs` and `diff/render.rs` exports are guarded by `#[cfg(test)]` — they are covered through the existing `diff/mod.rs` test harness
- `hyperlink::detect_file_paths` is itself `#[cfg(test)]`-only; new tests for it are colocated in the same test module