### PR TITLE
perf(build): replace onig with fancy-regex, remove unused reqwest blocking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2000,6 +2000,28 @@ dependencies = [
 
 [[package]]
 name = "fancy-regex"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e24cb5a94bcae1e5408b0effca5cd7172ea3c5755049c5f3af4cd283a165298"
+dependencies = [
+ "bit-set 0.8.0",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "fancy-regex"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "998b056554fbe42e03ae0e152895cd1a7e1002aec800fdc6635d20270260c46f"
+dependencies = [
+ "bit-set 0.8.0",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "fancy-regex"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72cf461f865c862bb7dc573f643dd6a2b6842f7c30b07882b56bd148cc2761b8"
@@ -3741,28 +3763,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
-name = "onig"
-version = "6.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "336b9c63443aceef14bea841b899035ae3abe89b7c486aaf4c5bd8aafedac3f0"
-dependencies = [
- "bitflags 2.11.0",
- "libc",
- "once_cell",
- "onig_sys",
-]
-
-[[package]]
-name = "onig_sys"
-version = "69.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7f86c6eef3d6df15f23bcfb6af487cbd2fed4e5581d58d5bf1f5f8b7f6727dc"
-dependencies = [
- "cc",
- "pkg-config",
-]
-
-[[package]]
 name = "open"
 version = "5.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4843,7 +4843,6 @@ dependencies = [
  "bytes",
  "cookie",
  "cookie_store",
- "futures-channel",
  "futures-core",
  "futures-util",
  "h2",
@@ -5682,10 +5681,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "656b45c05d95a5704399aeef6bd0ddec7b2b3531b7c9e900abbf7c4d2190c925"
 dependencies = [
  "bincode",
+ "fancy-regex 0.16.2",
  "flate2",
  "fnv",
  "once_cell",
- "onig",
  "plist",
  "regex-syntax",
  "serde",
@@ -6002,12 +6001,12 @@ dependencies = [
  "dary_heap",
  "derive_builder",
  "esaxx-rs",
+ "fancy-regex 0.14.0",
  "getrandom 0.3.4",
  "itertools",
  "log",
  "macro_rules_attribute",
  "monostate",
- "onig",
  "paste",
  "rand 0.9.2",
  "rayon",

--- a/crates/aletheia/Cargo.toml
+++ b/crates/aletheia/Cargo.toml
@@ -55,7 +55,7 @@ tracing-subscriber = { workspace = true }
 tracing-appender = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-reqwest = { workspace = true, features = ["blocking"] }
+reqwest = { workspace = true }
 rustls = { workspace = true }
 
 jiff = { workspace = true }

--- a/crates/mneme/Cargo.toml
+++ b/crates/mneme/Cargo.toml
@@ -78,7 +78,7 @@ hnsw_rs = { version = "0.3", optional = true }
 candle-core = { version = "=0.9.2", optional = true }
 candle-nn = { version = "=0.9.2", optional = true }
 candle-transformers = { version = "=0.9.2", optional = true }
-tokenizers = { version = "0.22", optional = true, default-features = false, features = ["onig"] }
+tokenizers = { version = "0.22", optional = true, default-features = false, features = ["fancy-regex"] }
 hf-hub = { version = "0.5", optional = true, default-features = false, features = ["ureq", "rustls-tls", "tokio"] }
 
 [dev-dependencies]

--- a/crates/theatron/tui/Cargo.toml
+++ b/crates/theatron/tui/Cargo.toml
@@ -54,7 +54,7 @@ snafu = { workspace = true }
 
 # Futures
 futures-util = "0.3"
-syntect = "5"
+syntect = { version = "5", default-features = false, features = ["default-fancy", "default-syntaxes", "default-themes"] }
 arboard = "3"
 base64 = { workspace = true }
 regex = { workspace = true }

--- a/docs/build-performance.md
+++ b/docs/build-performance.md
@@ -1,0 +1,114 @@
+# build-performance
+
+Build timing analysis for `cargo build --release`. Profiled with `--timings` on 2026-03-19.
+Machine: x86_64 Linux, 180 logical CPUs (Verda). Toolchain: rustc 1.94.0.
+
+Baseline: 4m 33s (273.5s), 614 units, max concurrency 69.
+
+---
+
+## Bottleneck crates
+
+| Rank | Crate | Time | Notes |
+|------|-------|------|-------|
+| 1 | `aletheia` (bin) | 64.6s | Final link + codegen; serial with codegen-units=1 |
+| 2 | `aletheia-mneme` | 63.4s | Knowledge engine; largest crate by LOC (~110K) |
+| 3 | `candle-transformers` | 44.3s | Local ML inference — unavoidable; feature-gated |
+| 4 | `candle-core` | 33.6s | Tensor ops — unavoidable; feature-gated |
+| 5 | `onig_sys` (build script) | 32.4s | C regex library pulled in by tokenizers+syntect |
+| 6 | `ring` (build script) | 28.9s | C/asm cryptographic library |
+| 7 | `aletheia-pylon` | 18.5s | API server; heavy axum + utoipa codegen |
+| 8 | `tokenizers` | 14.5s | HuggingFace tokenizer library |
+| 9 | `theatron-tui` (bin) | 14.4s | TUI binary |
+| 10 | `aletheia-diaporeia` | 13.6s | MCP adapter |
+
+---
+
+## Quick wins implemented
+
+### 1. Replace `onig` with `fancy-regex` in tokenizers and syntect
+
+**Saves: ~32s** (eliminates `onig_sys` C build)
+
+`tokenizers` (HuggingFace) and `syntect` both default to the `onig` backend, which requires
+compiling `onig_sys` — a C foreign-function interface to the Oniguruma regex library. This C
+build takes 32.4s and cannot be parallelised with Rust compilation.
+
+Both crates support `fancy-regex` as a pure-Rust alternative. `fancy-regex` covers all
+lookahead/lookbehind patterns required by BERT tokenizers and syntax highlighting grammars used
+in this codebase.
+
+Changes:
+- `crates/mneme/Cargo.toml`: `tokenizers` feature `onig` → `fancy-regex`
+- `crates/theatron/tui/Cargo.toml`: `syntect` explicit `default-fancy` instead of implicit `default-onig`
+
+### 2. Remove unused `reqwest` `blocking` feature from `aletheia` binary
+
+**Saves: marginal link time** (eliminates dead code in final binary)
+
+`crates/aletheia/Cargo.toml` declared `reqwest = { features = ["blocking"] }` but no code in the
+crate uses `reqwest::blocking`. The blocking HTTP client spawns an internal thread pool and
+increases binary size. Removed.
+
+---
+
+## Remaining bottlenecks (no quick win)
+
+### candle-core + candle-transformers (78s combined)
+
+These are the local ML embedding crates. They compile large amounts of numeric kernel code.
+No trimming possible without dropping the `embed-candle` feature, which is intentionally on by
+default (see WARNING in `crates/aletheia/Cargo.toml` line 16). The feature guard exists because
+it was accidentally removed three times (#1263, #1326, #1378).
+
+Mitigation: CI caches these via `Swatinem/rust-cache`. Incremental local builds skip them
+after the first compile.
+
+### ring build script (28.9s)
+
+`ring` compiles C and assembly for cryptographic primitives used by `rustls`. Replacing `ring`
+with `aws-lc-rs` as the rustls backend is feasible (both are supported by rustls 0.23) but
+requires testing correctness on all target platforms. Left for a dedicated PR.
+
+### aletheia-mneme (63.4s)
+
+Largest workspace crate at ~110K lines. The storage-fjall and mneme-engine features pull in
+dozens of additional dependencies. No structural quick wins; this reflects real code mass.
+
+### aletheia (binary link, 64.6s)
+
+Final link with LTO=thin and codegen-units=1. These settings are correct for release: thin LTO
+provides meaningful size/speed improvements. Single codegen unit maximises inter-procedural
+optimisation. The link time is dominated by the candle and mneme objects.
+
+---
+
+## Profile settings (current)
+
+```toml
+[profile.dev]
+opt-level = 1
+codegen-units = 256        # fast incremental builds
+
+[profile.dev.package."*"]
+opt-level = 2              # optimise deps, keep local code fast
+
+[profile.release]
+lto = "thin"
+codegen-units = 1          # maximum optimisation
+strip = "symbols"
+```
+
+These settings match the standard in `standards/RUST.md`. No changes warranted.
+
+---
+
+## How to re-profile
+
+```bash
+cargo build --release --timings
+# Output: target/cargo-timings/cargo-timing.html
+```
+
+Open the HTML file in a browser. The waterfall chart shows the critical path.
+Sort the table by "Total" to find the longest-compiling units.


### PR DESCRIPTION
## Summary

- Switch `tokenizers` in `aletheia-mneme` from `onig` to `fancy-regex` backend
- Switch `syntect` in `theatron-tui` from implicit `default-onig` to `default-fancy`
- Remove unused `reqwest` `blocking` feature from the `aletheia` binary
- Add `docs/build-performance.md` with timing analysis and bottleneck findings

## Why

`onig_sys` is a C FFI wrapper around the Oniguruma regex library. It takes **32.4 seconds** to compile in release mode and cannot be parallelised with Rust compilation. Both `tokenizers` (HuggingFace) and `syntect` support `fancy-regex` as a pure-Rust drop-in replacement that covers all regex features used in this codebase.

`reqwest::blocking` was declared in `crates/aletheia/Cargo.toml` but never called (no `reqwest::blocking` import anywhere). Removing it trims dead code from the binary.

## Timing findings (profiled 2026-03-19)

| Crate | Time | Action |
|-------|------|--------|
| `aletheia` bin | 64.6s | No quick win (final link/LTO) |
| `aletheia-mneme` | 63.4s | No quick win (code mass) |
| `candle-transformers` | 44.3s | No quick win (intentional feature) |
| `candle-core` | 33.6s | No quick win (intentional feature) |
| **`onig_sys` build script** | **32.4s** | **Fixed: → fancy-regex** |
| `ring` build script | 28.9s | Out of scope (rustls backend swap) |

Expected savings: ~32s off the release build critical path.

## Test plan

- [x] `cargo check --workspace` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes (zero warnings)
- [x] `cargo test --workspace` passes
- [x] `cargo fmt --all` applied (no changes)

## Observations

- Issue #1650 (standards-sync CI job) is already implemented and merged in `origin/main` (commit `240920d4`). The job in `.github/workflows/ci.yml` fetches canonical files from `forkwright/kanon`, diffs them against local `standards/`, and correctly allows aletheia-specific additions. No work remained for that issue.
- `ring` (28.9s build script) could be replaced with `aws-lc-rs` as the rustls crypto backend to save another ~30s, but requires cross-platform testing. Documented in `docs/build-performance.md` for a follow-up PR.
- `aletheia-mneme` at 63.4s reflects genuine code mass (~110K lines with LSM-tree, Datalog, HNSW, and FSRS decay). No structural quick win without splitting the crate.

Closes #1596

🤖 Generated with [Claude Code](https://claude.com/claude-code)