### PR TITLE
fix(hermeneus): remove invalid OAuth beta header causing 400 errors

### DIFF
--- a/crates/hermeneus/src/anthropic/client.rs
+++ b/crates/hermeneus/src/anthropic/client.rs
@@ -453,10 +453,6 @@ impl AnthropicProvider {
                 .build()
             })?;
             headers.insert(reqwest::header::AUTHORIZATION, value);
-            headers.insert(
-                "anthropic-beta",
-                HeaderValue::from_static("oauth-2025-04-20"),
-            );
         } else {
             let value = HeaderValue::from_str(secret_value).map_err(|_e| {
                 error::AuthFailedSnafu {


### PR DESCRIPTION
## Summary

Remove `anthropic-beta: oauth-2025-04-20` header from OAuth token requests. This header is not part of the Anthropic SDK — it was a Claude Code internal header that the public Messages API rejects with 400.

The official Python SDK (`anthropic-sdk-python/_client.py`) sends only `Authorization: Bearer {token}` for OAuth, with no special beta headers. Our code was adding an extra header that caused every OAuth API call to fail.

Closes #1600

## Evidence

- [SDK source](https://github.com/anthropics/anthropic-sdk-python/blob/main/src/anthropic/_client.py): `_bearer_auth` returns only `{"Authorization": f"Bearer {auth_token}"}`
- [Known issue](https://github.com/anthropics/claude-code/issues/13770): `oauth-2025-04-20` beta header rejected by non-Anthropic backends
- Issue #1600: OAuth tokens return 400 for all model calls

## Test plan

- [x] cargo check passes
- [x] cargo clippy passes
- [ ] Manual test: deploy with OAuth token, verify 200 response from Messages API