### PR TITLE
fix(scripts): fix 8 deploy and operations issues

### DIFF
--- a/instance.example/services/aletheia-health.service
+++ b/instance.example/services/aletheia-health.service
@@ -4,6 +4,6 @@ After=aletheia.service
 
 [Service]
 Type=oneshot
-ExecStart=%h/ergon/scripts/health-monitor.sh
-StandardOutput=append:%h/ergon/instance/logs/health.log
-StandardError=append:%h/ergon/instance/logs/health.log
+ExecStart=%h/aletheia/scripts/health-monitor.sh
+StandardOutput=append:%h/aletheia/instance/logs/health.log
+StandardError=append:%h/aletheia/instance/logs/health.log

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -13,9 +13,9 @@ set -euo pipefail
 # Prerequisites: cargo, curl, jq, systemctl
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-INSTANCE_ROOT="${ALETHEIA_ROOT:-$HOME/ergon/instance}"
+INSTANCE_ROOT="${ALETHEIA_ROOT:-$HOME/aletheia/instance}"
 BINARY_SRC="$REPO_ROOT/target/release/aletheia"
-BINARY_DST="${ALETHEIA_BINARY:-$HOME/ergon/bin/aletheia}"
+BINARY_DST="${ALETHEIA_BINARY:-$HOME/.local/bin/aletheia}"
 SERVICE="aletheia.service"
 BACKUP_DIR="${INSTANCE_ROOT}/.deploy-backup"
 DEPLOY_LOG="${INSTANCE_ROOT}/deploy.log"
@@ -225,7 +225,8 @@ refresh_token() {
 download_binary() {
     local version="$1"
     local repo="${GITHUB_REPO:-forkwright/aletheia}"
-    local asset_name="aletheia-$(uname -m)-unknown-linux-gnu"
+    local asset_name
+    asset_name="aletheia-$(uname -m)-unknown-linux-gnu"
     local tmp_bin
     tmp_bin="$(mktemp)" || return 1
     trap 'rm -f -- "$tmp_bin"' RETURN
@@ -234,7 +235,7 @@ download_binary() {
 
     # Try gh CLI first, fall back to curl
     if command -v gh &>/dev/null; then
-        if gh release download "$version" \
+        if timeout 120 gh release download "$version" \
             --repo "$repo" \
             --pattern "$asset_name" \
             --output "$tmp_bin" \
@@ -244,7 +245,7 @@ download_binary() {
             log "Downloaded binary via gh: ${BINARY_SRC}"
             return 0
         fi
-        log "gh release download failed, trying curl..."
+        log "WARNING: gh release download failed (timeout or error), trying curl..."
     fi
 
     local url="https://github.com/${repo}/releases/download/${version}/${asset_name}"
@@ -255,7 +256,7 @@ download_binary() {
         return 0
     fi
 
-    log "Download failed for ${version}, falling back to local build"
+    log "WARNING: curl download also failed for ${version}, falling back to local build"
     return 1
 }
 
@@ -270,7 +271,7 @@ fi
 
 # Download binary if requested
 if [[ -n "$DOWNLOAD_VERSION" ]]; then
-    [[ "$DOWNLOAD_VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9] ]] \
+    [[ "$DOWNLOAD_VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]] \
         || die "Version must match vX.Y.Z format, got: $DOWNLOAD_VERSION"
     if [[ "$DRY_RUN" == true ]]; then
         log "[dry-run] Would download ${DOWNLOAD_VERSION} from GitHub releases"

--- a/scripts/health-monitor.sh
+++ b/scripts/health-monitor.sh
@@ -47,9 +47,13 @@ health=$(curl -sf --max-time 5 "$HEALTH_URL" 2>/dev/null) || {
 status=$(echo "$health" | jq -r '.status // empty' 2>/dev/null)
 version=$(echo "$health" | jq -r '.version // empty' 2>/dev/null)
 
+if [[ -z "$status" ]]; then
+    log_warn "health response missing status field; raw: ${health:0:200}"
+fi
+
 if [[ "$status" != "healthy" ]]; then
-    log_err "unhealthy: $status (v$version)"
-    notify "unhealthy: $status (v$version)"
+    log_err "unhealthy: ${status:-<no status>} (v${version:-unknown})"
+    notify "unhealthy: ${status:-<no status>} (v${version:-unknown})"
     exit 1
 fi
 
@@ -58,6 +62,10 @@ log_ok "healthy v$version"
 # 3. Token expiry check
 if [[ -f "$CRED_FILE" ]]; then
     remaining=$(jq -r '(.claudeAiOauth.expiresAt // 0) / 1000 | (. - now) / 60 | floor' "$CRED_FILE" 2>/dev/null || echo "unknown")
+    if [[ -z "$remaining" ]]; then
+        remaining="unknown"
+        log_warn "jq returned empty output parsing credential file"
+    fi
 
     if [[ "$remaining" != "unknown" ]]; then
         if [[ "$remaining" -lt 30 ]]; then

--- a/scripts/rollback.sh
+++ b/scripts/rollback.sh
@@ -9,8 +9,8 @@
 
 set -euo pipefail
 
-INSTANCE_ROOT="${ALETHEIA_INSTANCE:-$HOME/ergon/instance}"
-BINARY_DST="${ALETHEIA_BINARY:-$HOME/ergon/bin/aletheia}"
+INSTANCE_ROOT="${ALETHEIA_ROOT:-$HOME/aletheia/instance}"
+BINARY_DST="${ALETHEIA_BINARY:-$HOME/.local/bin/aletheia}"
 BACKUP_DIR="${INSTANCE_ROOT}/.deploy-backup"
 SERVICE="aletheia.service"
 HEALTH_URL="${ALETHEIA_HEALTH_URL:-http://localhost:18789/api/health}"

--- a/shared/hooks/_templates/loop-guard.sh
+++ b/shared/hooks/_templates/loop-guard.sh
@@ -9,7 +9,8 @@ tool_calls=$(printf '%s' "$payload" | grep -o '"toolCalls":[0-9]*' | head -1 | c
 nous_id=$(printf '%s' "$payload" | grep -o '"nousId":"[^"]*"' | head -1 | cut -d'"' -f4)
 
 if [[ -z "${tool_calls:-}" ]] || [[ -z "${nous_id:-}" ]]; then
-  exit 0
+  echo "error: missing required fields (toolCalls or nousId) in payload" >&2
+  exit 1
 fi
 
 if [[ ! "$nous_id" =~ ^[a-zA-Z0-9._-]+$ ]]; then


### PR DESCRIPTION
## Summary

- Fix version regex to accept multi-digit patch versions (e.g. `v1.2.34`)
- Align `EnvironmentFile` path between `aletheia.service` and `deploy.sh` (both now use `~/aletheia/instance`)
- Add `timeout 120` wrapper around `gh release download` to prevent indefinite hangs
- Exit 1 (not 0) on missing `toolCalls` or `nousId` inputs in `loop-guard.sh`
- Add warning logging for silent download failures in `deploy.sh`
- Fix SC2155: split `local asset_name` declaration from its assignment in `deploy.sh`; add jq empty-output guards in `health-monitor.sh`
- Fix `aletheia-health.service` references from `~/ergon/` to `~/aletheia/`
- Align `INSTANCE_ROOT` default and env var name (`ALETHEIA_ROOT`) between `rollback.sh` and `deploy.sh`; align `BINARY_DST` default to `~/.local/bin/aletheia`

Closes #1698
Closes #1699
Closes #1700
Closes #1701
Closes #1703
Closes #1704
Closes #1705
Closes #1727

## Test plan

- [ ] `shellcheck scripts/deploy.sh scripts/health-monitor.sh scripts/rollback.sh shared/hooks/_templates/loop-guard.sh` — zero warnings
- [ ] `scripts/deploy.sh --download v1.2.34 --dry-run` accepts multi-digit patch version
- [ ] `scripts/deploy.sh --download v1.2.3 --dry-run` still accepted
- [ ] `scripts/deploy.sh --download v1.2 --dry-run` correctly rejected
- [ ] Confirm `aletheia.service` EnvironmentFile and `deploy.sh` both reference `~/aletheia/instance/config/env`
- [ ] Confirm `aletheia-health.service` ExecStart and log paths reference `~/aletheia/`
- [ ] Confirm `rollback.sh` and `deploy.sh` backup dir defaults are identical
- [ ] `echo '{}' | shared/hooks/_templates/loop-guard.sh` exits 1 with error message

## Observations

- `aletheia-health.service` uses `%h/aletheia/scripts/health-monitor.sh` which assumes a source-tree checkout at `~/aletheia/`. If operators install the binary only (without a checkout), this path will not exist. Documenting the expected install layout in `instance.example/` would help; out of scope for this PR.
- `rollback.sh` had its own 15-second health-check loop duplicating logic from `deploy.sh`. The duplication is not fixed here (out of scope) but worth a future consolidation.
- `loop-guard.sh` uses `/tmp/aletheia-loop-guard` as a sentinel dir — a predictable path that could be pre-created by another process. `mktemp -d` is not appropriate here (sentinel must persist across calls), but noting for future hardening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)