### PR TITLE
chore: backup-cron script, standards-sync workflow, and TODO triage

### DIFF
--- a/.github/workflows/standards-sync.yml
+++ b/.github/workflows/standards-sync.yml
@@ -1,0 +1,66 @@
+name: Standards sync
+
+# Check that local standards/ files match the canonical versions in kanon.
+# Runs on PRs that touch standards/ and on a weekly schedule to catch upstream
+# changes that weren't manually synced.
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "standards/**"
+      - ".github/workflows/standards-sync.yml"
+  schedule:
+    # Every Monday at 08:00 UTC
+    - cron: "0 8 * * 1"
+  workflow_dispatch:
+
+concurrency:
+  group: standards-sync-${{ github.ref }}
+  cancel-in-progress: true
+
+# WHY: Principle of least privilege for CI workflows
+permissions:
+  contents: read
+
+jobs:
+  check-standards-drift:
+    name: Check standards drift against kanon
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Fetch canonical standards from kanon
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mkdir -p /tmp/kanon-standards
+          gh api repos/forkwright/kanon/contents/standards \
+            --jq '.[].name' | while IFS= read -r fname; do
+            gh api "repos/forkwright/kanon/contents/standards/${fname}" \
+              --jq '.content' \
+              | base64 -d > "/tmp/kanon-standards/${fname}"
+          done
+
+      - name: Diff standards against kanon canonical
+        run: |
+          failed=0
+          while IFS= read -r fname; do
+            local_file="standards/${fname}"
+            canonical="/tmp/kanon-standards/${fname}"
+            if [[ ! -f "$local_file" ]]; then
+              echo "::error file=${local_file}::Canonical file '${fname}' from kanon is missing locally"
+              failed=1
+            elif ! diff -q -- "$canonical" "$local_file" > /dev/null 2>&1; then
+              echo "::error file=${local_file}::Local '${fname}' diverges from kanon canonical"
+              diff -- "$canonical" "$local_file" || true
+              failed=1
+            fi
+          done < <(ls /tmp/kanon-standards/)
+          if [[ "$failed" -ne 0 ]]; then
+            echo ""
+            echo "Standards diverged from kanon. Update local standards/ to match, or sync kanon."
+            echo "Aletheia-specific additions (files only in standards/ but not in kanon) are allowed."
+            exit 1
+          fi
+          echo "standards/ is in sync with kanon"

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -96,6 +96,45 @@ systemctl --user enable --now aletheia-health.timer
 
 ---
 
+## Backup automation
+
+`scripts/backup-cron.sh` exports the session store to JSON and prunes old copies.
+
+```bash
+# One-off backup (keeps 7 copies, writes to $ALETHEIA_ROOT/backups/):
+scripts/backup-cron.sh
+
+# Keep 14 copies in a custom directory:
+scripts/backup-cron.sh --keep 14 --output-dir /mnt/backup/aletheia
+```
+
+### Cron setup (daily at 02:00)
+
+```cron
+0 2 * * * /path/to/scripts/backup-cron.sh >> /var/log/aletheia-backup.log 2>&1
+```
+
+### Environment overrides
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `ALETHEIA_ROOT` | `~/ergon/instance` | Instance root |
+| `ALETHEIA_BINARY` | `~/ergon/bin/aletheia` | Binary path |
+| `BACKUP_KEEP` | `7` | Number of backup files to retain |
+| `BACKUP_OUTPUT_DIR` | `$ALETHEIA_ROOT/backups` | Backup output directory |
+
+The script uses `flock` to prevent concurrent runs. Backup files are named `sessions-<timestamp>.json`.
+
+### Manual restore
+
+Backup files are plain JSON exported by `aletheia backup --export-json`. To inspect:
+
+```bash
+jq '.sessions | length' ~/ergon/instance/backups/sessions-*.json | tail -1
+```
+
+---
+
 ## Common issues
 
 ### EADDRINUSE on port 18789

--- a/scripts/backup-cron.sh
+++ b/scripts/backup-cron.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Automated database backup for aletheia. Designed for cron or systemd timer.
+#
+# Creates a timestamped JSON export of the session store and prunes old copies.
+#
+# Usage:
+#   scripts/backup-cron.sh [--keep N] [--output-dir DIR]
+#
+# Environment:
+#   ALETHEIA_ROOT       Instance root directory (default: ~/ergon/instance)
+#   ALETHEIA_BINARY     Path to the aletheia binary  (default: ~/ergon/bin/aletheia)
+#   BACKUP_KEEP         Number of backup files to retain (default: 7)
+#   BACKUP_OUTPUT_DIR   Directory for backup files (default: $ALETHEIA_ROOT/backups)
+#
+# Cron example (daily at 02:00):
+#   0 2 * * * /path/to/scripts/backup-cron.sh >> /var/log/aletheia-backup.log 2>&1
+#
+# Systemd timer: see instance.example/services/ for aletheia-backup.{service,timer}
+
+INSTANCE_ROOT="${ALETHEIA_ROOT:-$HOME/ergon/instance}"
+ALETHEIA="${ALETHEIA_BINARY:-$HOME/ergon/bin/aletheia}"
+KEEP="${BACKUP_KEEP:-7}"
+OUTPUT_DIR="${BACKUP_OUTPUT_DIR:-${INSTANCE_ROOT}/backups}"
+
+# Lock file — prevent concurrent runs
+LOCK_FILE="${INSTANCE_ROOT}/backup.lock"
+
+# --- Logging ---
+
+log() {
+    echo "[backup] $(date -u +"%Y-%m-%dT%H:%M:%SZ") $*"
+}
+
+die() {
+    log "ERROR: $*" >&2
+    exit 1
+}
+
+# --- Argument parsing ---
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --keep)
+            [[ $# -ge 2 && "$2" =~ ^[0-9]+$ ]] \
+                || die "--keep requires a positive integer argument"
+            KEEP="$2"
+            shift 2
+            ;;
+        --output-dir)
+            [[ $# -ge 2 && -n "$2" ]] \
+                || die "--output-dir requires a directory argument"
+            OUTPUT_DIR="$2"
+            shift 2
+            ;;
+        *)
+            die "Unknown argument: $1"
+            ;;
+    esac
+done
+
+# --- Prerequisite checks ---
+
+[[ -x "$ALETHEIA" ]] \
+    || die "aletheia binary not found or not executable: ${ALETHEIA}"
+
+[[ -d "$INSTANCE_ROOT" ]] \
+    || die "Instance root not found: ${INSTANCE_ROOT}. Run 'aletheia init' first."
+
+# --- Mutual exclusion ---
+
+exec 9>"${LOCK_FILE}"
+flock -n 9 || { log "Another backup is already running (lock: ${LOCK_FILE})"; exit 0; }
+
+# --- Output directory ---
+
+mkdir -p -- "$OUTPUT_DIR"
+
+# --- Run backup ---
+
+timestamp="$(date -u +"%Y%m%dT%H%M%SZ")"
+backup_file="${OUTPUT_DIR}/sessions-${timestamp}.json"
+
+log "Starting backup → ${backup_file}"
+
+"$ALETHEIA" -r "$INSTANCE_ROOT" backup --export-json --yes \
+    > "$backup_file" \
+    || die "aletheia backup command failed"
+
+bytes="$(wc -c < "$backup_file")"
+log "Backup complete: ${backup_file} (${bytes} bytes)"
+
+# --- Prune old backups ---
+
+log "Pruning to ${KEEP} most-recent backups in ${OUTPUT_DIR}"
+
+local_count=0
+while IFS= read -r old_file; do
+    local_count=$(( local_count + 1 ))
+    if (( local_count > KEEP )); then
+        log "Removing old backup: ${old_file}"
+        rm -f -- "$old_file"
+    fi
+done < <(find "$OUTPUT_DIR" -maxdepth 1 -name 'sessions-*.json' -type f \
+    | sort -r)
+
+log "Done. Kept ${KEEP} backups."


### PR DESCRIPTION
## Summary

- **#1726 Backup automation**: Add `scripts/backup-cron.sh` — a cron-compatible backup script that uses `aletheia backup --export-json`, `flock` for mutual exclusion, configurable retention (default 7 copies), and proper `set -euo pipefail` error handling per shell standards. Document cron setup and environment variables in `docs/RUNBOOK.md`.
- **#1650 Standards sync CI**: Add `.github/workflows/standards-sync.yml` — a dedicated standalone workflow that checks `standards/` for drift against the kanon canonical on PRs touching `standards/` and on a weekly Monday schedule. Extracted and promoted from the existing `standards-sync` job in `ci.yml`.
- **#1739 TODO triage**: Reviewed all `TODO.*#\d+` comments in `crates/*/src/`. Three found — `#1137` (RecallEngine wiring in diaporeia MCP tool), `#1140` (seccomp BPF pre-compilation in organon sandbox), `#1129` (RetentionConfig fields in taxis) — all confirmed still open with work genuinely incomplete. No comment changes needed.
- **#1606 Mechanical lint fixes**: `cargo clippy --fix --allow-dirty --allow-staged --workspace` and `cargo fmt --all` produced zero changes; workspace was already clean.

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes (zero warnings)
- [x] `cargo test --workspace` passes
- [x] `shellcheck scripts/backup-cron.sh` passes with zero warnings

Closes #1739
Closes #1726
Closes #1650
Closes #1606

🤖 Generated with [Claude Code](https://claude.com/claude-code)