### PR TITLE
docs: consolidate and clean up documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,7 +61,7 @@ cargo clippy --workspace               # Lint (zero warnings)
 | Task | Location | Registration |
 |------|----------|-------------|
 | CLI subcommand | `crates/aletheia/src/commands/` | Add to clap derive in `main.rs` |
-| API endpoint | `crates/pylon/src/handlers/` | Add route in `crates/pylon/src/routes.rs` |
+| API endpoint | `crates/pylon/src/handlers/` | Add route in `crates/pylon/src/router.rs` |
 | Built-in tool | `crates/organon/src/builtins/` | Register in `register_all()` |
 | Config section | `crates/taxis/src/config.rs` | Add field to `AletheiaConfig` struct |
 | Error variant | `crates/{crate}/src/error.rs` | snafu derive on the crate's Error enum |

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Self-hosted AI agents with persistent memory.
 
-Talk to an AI that remembers your previous conversations, learns your preferences, builds a knowledge graph over time, and gets better the more you use it. Give it a name, a personality, goals, and tools. Run it from a terminal dashboard, HTTP API, or Signal messenger.
+Talk to an AI that remembers your previous conversations, learns your preferences, and builds a knowledge graph over time. Give it a name, a personality, and goals. Run it from a terminal dashboard, HTTP API, or Signal messenger.
 
 One binary. No containers. No external databases. No cloud dependencies beyond your LLM provider.
 
@@ -10,22 +10,9 @@ One binary. No containers. No external databases. No cloud dependencies beyond y
 
 ---
 
-## Quick start
+## Install
 
-```bash
-# Install (Linux x86_64)
-curl -L https://github.com/forkwright/aletheia/releases/latest/download/aletheia-linux-x86_64 -o aletheia
-chmod +x aletheia && sudo mv aletheia /usr/local/bin/
-
-# Setup (interactive wizard handles config, credentials, first agent)
-aletheia init
-
-# Run
-aletheia                # start the server
-aletheia tui            # open the terminal dashboard
-```
-
-Build from source: `cargo build --release` (requires Rust 1.94+). See [QUICKSTART.md](docs/QUICKSTART.md) for the full guide.
+See [QUICKSTART.md](docs/QUICKSTART.md) for install instructions, setup, and first run.
 
 ---
 
@@ -42,58 +29,7 @@ Build from source: `cargo build --release` (requires Rust 1.94+). See [QUICKSTAR
 
 ## Architecture
 
-Rust workspace with 18 crates. Single binary deployment.
-
-```text
-     TUI / HTTP API              Signal Messenger
-              |                          |
-         HTTP/SSE                   signal-cli (JSON-RPC)
-              |                          |
-              +----------+---------------+
-                         |
-                  +--------------+
-                  |   Gateway    |     Session management, tool execution,
-                  |   (:18789)   |     message routing, context assembly
-                  +--------------+
-                   /    |    |   \
-              Bindings (per-agent routing)
-                /       |    |      \
-         +------+  +------+ +------+ +------+
-         | nous |  | nous | | nous | | nous |   N agents, each with:
-         +------+  +------+ +------+ +------+   - SOUL.md (character)
-            |         |         |        |       - workspace files
-            v         v         v        v       - persistent memory
-         Claude     Claude    Claude   Claude
-```
-
-### Rust crates (target)
-
-See [ARCHITECTURE.md](docs/ARCHITECTURE.md) for the full dependency graph and trait boundaries.
-
-| Layer | Crates |
-|-------|--------|
-| Leaf | `koina` (errors, tracing), `symbolon` (auth) |
-| Low | `taxis` (config), `hermeneus` (LLM), `mneme` (memory + embedded DB engine), `organon` (tools), `agora` (channels), `melete` (distillation) |
-| Mid | `nous` (agent pipeline) |
-| High | `pylon` (HTTP gateway) |
-| Top | `aletheia` (binary entrypoint) |
-
-**Models:** Anthropic (OAuth or API key). Complexity-based routing.
-**Memory:** Embedded Datalog+HNSW engine for knowledge graph, long-term memory, and sessions.
-**Observability:** Structured tracing with tokio-tracing.
-
----
-
-## Quick start
-
-```bash
-git clone https://github.com/forkwright/aletheia.git && cd aletheia
-cargo build --release
-cp target/release/aletheia ~/.local/bin/
-aletheia
-```
-
-[Full setup guide](docs/QUICKSTART.md) · [Production deployment](docs/DEPLOYMENT.md)
+Rust workspace with 18 crates. Single binary deployment. See [ARCHITECTURE.md](docs/ARCHITECTURE.md) for the full dependency graph and trait boundaries.
 
 ---
 

--- a/docs/ARCHITECTURE-GUIDE.md
+++ b/docs/ARCHITECTURE-GUIDE.md
@@ -1,6 +1,6 @@
 # Architecture walkthrough
 
-A guided tour for new contributors. For the reference module map and dependency graph, see [ARCHITECTURE.md](ARCHITECTURE.md).
+For new contributors. For the reference module map and dependency graph, see [ARCHITECTURE.md](ARCHITECTURE.md).
 
 ---
 
@@ -8,7 +8,7 @@ A guided tour for new contributors. For the reference module map and dependency 
 
 Aletheia is a self-hosted multi-agent AI system. Multiple AI agents run as persistent actors, each with character, memory, and domain expertise. They communicate via Signal, HTTP API, or TUI, and persist understanding across sessions.
 
-It is not a chatbot framework. It is a distributed cognition system: agents have identity (SOUL.md), evolve through use (MEMORY.md), and coordinate through shared infrastructure.
+It is not a chatbot framework. It is a distributed cognition system: each agent has persistent identity (SOUL.md) and memory (MEMORY.md), and coordinates with other agents through shared infrastructure.
 
 The entire system compiles to a single Rust binary. No Node.js, no Python sidecar, no external databases required.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -119,7 +119,7 @@ Application crates in `crates/`, plus the `integration-tests` support crate.
 | `symbolon` | JWT tokens, password hashing, RBAC policies | koina |
 | `melete` | Context distillation, compression strategies, token budget management | koina, hermeneus |
 | `agora` | Channel registry, ChannelProvider trait, Signal JSON-RPC client | koina, taxis |
-| `daemon` | Background task scheduling, cron jobs, lifecycle events | koina |
+| `daemon` | Background task scheduling, cron jobs, lifecycle events (`oikonomos` internally) | koina |
 | `dianoia` | Multi-phase planning orchestrator, project context tracking | koina |
 | `thesauros` | Domain pack loader - external knowledge, tools, config overlays | koina, organon |
 | `nous` | Agent pipeline, NousActor (tokio), bootstrap, recall, execute, finalize | koina, taxis, mneme, hermeneus, organon, melete, thesauros |
@@ -127,6 +127,7 @@ Application crates in `crates/`, plus the `integration-tests` support crate.
 | `diaporeia` | MCP server interface for external AI agents (`crates/diaporeia`) | koina, taxis, nous, organon, mneme, symbolon |
 | `theatron-core` | Shared presentation types and traits for Aletheia UIs (`crates/theatron/core/`) | nothing (leaf) |
 | `theatron-tui` | Terminal dashboard (`crates/theatron/tui/`) | theatron-core, reqwest (standalone UI client) |
+| `theatron-desktop` | Dioxus desktop UI (`crates/theatron/desktop/`) - in progress | theatron-core |
 | `aletheia` | Binary entrypoint (Clap CLI) - wires all crates together | taxis, hermeneus, organon, mneme, nous, symbolon, pylon, agora, thesauros, daemon, dianoia, theatron-tui (optional) |
 
 **Support crates** (not part of the application dependency graph):
@@ -157,8 +158,8 @@ Application crates in `crates/`, plus the `integration-tests` support crate.
 - **Low** (koina only): `taxis`, `hermeneus`, `symbolon`, `mneme` (includes embedded Datalog+HNSW engine behind feature gate)
 - **Mid**: `melete` (koina + hermeneus), `organon` (koina + hermeneus), `agora` (koina + taxis), `daemon` (koina), `dianoia` (koina), `thesauros` (koina + organon)
 - **High**: `nous` (multiple mid+low deps), `pylon` (multiple deps including nous), `diaporeia` (MCP server, multiple deps including nous)
-- **Top**: `aletheia` binary, `tui` (terminal dashboard)
-- **Support**: `eval`, `integration-tests`
+- **Top**: `aletheia` binary, `theatron-tui` (terminal dashboard), `theatron-desktop` (Dioxus desktop, in progress)
+- **Support**: `eval` (behavioral scenario runner), `integration-tests`
 
 Imports flow downward only. Lower-layer crates must not depend on higher layers.
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,39 +1,8 @@
 # Deployment
 
-> This file covers the full production deployment reference. For focused sub-topics see:
-> - [QUICKSTART.md](QUICKSTART.md): minimal first-time setup
-> - [CONFIGURATION.md](CONFIGURATION.md): full configuration reference
-> - [TROUBLESHOOTING.md](TROUBLESHOOTING.md): common issues and solutions
+Production deployment reference. For configuration details, see [CONFIGURATION.md](CONFIGURATION.md). For upgrading an existing installation, see [UPGRADING.md](UPGRADING.md).
 
-Step-by-step guide from bare Linux or macOS to a running Aletheia instance. For configuration details, see [CONFIGURATION.md](CONFIGURATION.md). For upgrading an existing installation, see [UPGRADING.md](UPGRADING.md).
-
----
-
-## Getting started (first-time setup)
-
-Three commands from zero to a running instance:
-
-```bash
-# 1. Install the binary (or build from source: cargo build --release)
-curl -L https://github.com/forkwright/aletheia/releases/latest/download/aletheia-linux-x86_64 -o aletheia
-chmod +x aletheia && sudo mv aletheia /usr/local/bin/
-
-# 2. Initialize (creates instance directory, config, credentials, first agent)
-aletheia init
-
-# 3. Start
-aletheia
-```
-
-The init wizard prompts for your API key, model, agent name, and bind address, then writes a complete instance. For non-interactive (CI/scripting) use:
-
-```bash
-ANTHROPIC_API_KEY=sk-ant-... aletheia init --yes --instance-root /srv/aletheia/instance
-```
-
-Verify with `aletheia health`. A `healthy` response means the server is running with a registered LLM provider. If the status is `degraded`, verify your API key is set and the config loaded it.
-
-> **Manual setup:** If you prefer to configure everything by hand instead of using the wizard, see [Manual: copy the example scaffold](#manual-copy-the-example-scaffold) below.
+For first-time setup, see [QUICKSTART.md](QUICKSTART.md).
 
 ---
 
@@ -74,31 +43,7 @@ See [NETWORK.md](NETWORK.md) for the complete network call inventory.
 
 ## Installation
 
-### Prebuilt binary
-
-Download from [GitHub Releases](https://github.com/forkwright/aletheia/releases):
-
-```bash
-# Download binary and checksum (example for Linux x86_64)
-gh release download latest -p 'aletheia-linux-amd64*'
-
-# Verify
-sha256sum -c aletheia-linux-amd64.sha256
-
-# Install
-chmod +x aletheia-linux-amd64
-sudo mv aletheia-linux-amd64 /usr/local/bin/aletheia
-```
-
-### Build from source
-
-```bash
-git clone https://github.com/forkwright/aletheia.git
-cd aletheia
-cargo build --release
-```
-
-Binary: `target/release/aletheia`
+See [QUICKSTART.md](QUICKSTART.md) for standard install instructions (prebuilt binary and build from source).
 
 ### Headless build (no TUI)
 
@@ -141,7 +86,7 @@ Copy the example scaffold to create your instance directory:
 cp -r instance.example instance
 ```
 
-Then configure `instance/config/aletheia.toml` (see the Configuration section). The scaffold provides a template with all required directories and example configuration files.
+Then configure `instance/config/aletheia.toml` (see the Configuration section). The scaffold includes all required directories and example config files.
 
 This creates the full directory scaffold:
 
@@ -360,16 +305,7 @@ export ALETHEIA_ROOT=./instance
 aletheia
 ```
 
-The startup sequence:
-1. Discovers instance root (oikos)
-2. Loads config cascade (defaults + YAML + env vars)
-3. Opens session store (SQLite, auto-creates `data/sessions.db`)
-4. Registers LLM provider (Anthropic, if API key is set)
-5. Registers built-in tools
-6. Spawns nous actors (one per configured agent)
-7. Starts daemon (background maintenance tasks)
-8. Starts channel listeners (Signal, if configured)
-9. Starts HTTP gateway on configured bind:port
+For the full startup sequence (what the binary does at launch), see [ARCHITECTURE-GUIDE.md](ARCHITECTURE-GUIDE.md#the-binary).
 
 ### CLI flags
 

--- a/docs/PROJECT.md
+++ b/docs/PROJECT.md
@@ -44,7 +44,7 @@ See `Cargo.toml` workspace members for current crate inventory.
 | TUI | Active | Terminal dashboard, rich markdown, session management |
 | Signal | Active | 15 `!` commands, always-on ambient messaging |
 | HTTP API | Active | REST on port 18789, SSE streaming |
-| Desktop app | Planned | Dioxus 0.7 + Blitz native renderer |
+| Desktop app | In progress | Dioxus 0.7 desktop; scaffold with streaming architecture, not feature-complete |
 
 ## Related documents
 

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -37,7 +37,7 @@ fuser -k 18789/tcp
 aletheia
 ```
 
-The binary serves the HTTP gateway, spawns nous actors, starts the daemon, and (if configured) launches signal-cli. No subcommand needed.
+The binary starts the HTTP gateway, spawns nous actors, and runs the daemon. Signal is launched automatically if configured. No subcommand needed.
 
 Or via systemd:
 

--- a/docs/SHELL-COMPLETIONS.md
+++ b/docs/SHELL-COMPLETIONS.md
@@ -1,63 +1,18 @@
 # Shell completions
 
-Aletheia provides tab-completion for all subcommands, flags, and options via [clap_complete](https://docs.rs/clap_complete).
+Tab-completion for all subcommands, flags, and options via [clap_complete](https://docs.rs/clap_complete).
 
-## Generating completions
-
-```bash
-aletheia completions <SHELL>
-```
-
-Where `<SHELL>` is one of: `bash`, `zsh`, `fish`, `elvish`, `powershell`.
-
----
-
-## Bash
+Generate and install for your shell:
 
 ```bash
-# Generate and install
+# Bash
 aletheia completions bash > ~/.local/share/bash-completion/completions/aletheia
 
-# Or system-wide (requires root)
-aletheia completions bash | sudo tee /etc/bash_completion.d/aletheia > /dev/null
-```
-
-Reload your shell or source the file:
-
-```bash
-source ~/.local/share/bash-completion/completions/aletheia
-```
-
----
-
-## Zsh
-
-```bash
-# Generate to a directory in your $fpath
+# Zsh (add ~/.zfunc to $fpath before compinit)
 aletheia completions zsh > ~/.zfunc/_aletheia
-```
 
-Ensure `~/.zfunc` is in your `fpath` (add to `~/.zshrc` before `compinit`):
-
-```zsh
-fpath=(~/.zfunc $fpath)
-autoload -Uz compinit && compinit
-```
-
-Restart your shell or run `compinit` to pick up the new completions.
-
----
-
-## Fish
-
-```bash
+# Fish (picked up automatically)
 aletheia completions fish > ~/.config/fish/completions/aletheia.fish
 ```
 
-Fish picks up completions from this directory automatically; no restart needed.
-
----
-
-## Verifying
-
-After installation, type `aletheia <TAB>` to see available subcommands, or `aletheia health --<TAB>` to see flags.
+After install, type `aletheia <TAB>` to see subcommands or `aletheia health --<TAB>` for flags.

--- a/docs/WORKSPACE_FILES.md
+++ b/docs/WORKSPACE_FILES.md
@@ -1,6 +1,6 @@
 # Workspace files reference
 
-Each nous has a workspace directory (`instance/nous/<name>/`) containing up to 10 markdown files that form its identity, memory, and runtime context. The bootstrap system (`crates/nous/src/bootstrap/`) reads these files, applies token budgeting, and assembles them into the system prompt for each API call. For shared tools available to all agents, see [shared/TOOLS-INFRASTRUCTURE.md](../shared/TOOLS-INFRASTRUCTURE.md).
+Each nous has a workspace directory (`instance/nous/<name>/`) with up to 10 markdown files. These files define its identity, hold its memory, and supply runtime context. The bootstrap system (`crates/nous/src/bootstrap/`) reads these files, applies token budgeting, and assembles them into the system prompt for each API call. For shared tools available to all agents, see [shared/TOOLS-INFRASTRUCTURE.md](../shared/TOOLS-INFRASTRUCTURE.md).
 
 ---
 

--- a/instance.example/README.md
+++ b/instance.example/README.md
@@ -24,21 +24,20 @@ instance/
 ├── logs/                       # Runtime log output
 │
 ├── nous/                       # Agent identity + session memory ONLY
-│   ├── _template/              # Template for new agents (copied by `aletheia add-nous`)
+│   ├── _default/               # Pre-configured default agent (Pronoea/Noe)
+│   │                           # Used when aletheia init creates the first agent
+│   │                           # Copy to nous/{your-id}/ and update aletheia.toml
+│   ├── _template/              # Blank template for new agents (copied by `aletheia add-nous`)
 │   │   ├── SOUL.md             # Agent identity and character
 │   │   ├── IDENTITY.md         # Name, emoji, avatar
 │   │   ├── GOALS.md            # Goals and purpose
 │   │   ├── MEMORY.md           # Memory configuration
 │   │   └── memory/             # Session logs (memory/YYYY-MM-DD.md)
 │   └── {agent-id}/             # Per-agent workspace
-│       ├── SOUL.md             # Identity
+│       │                       # See docs/WORKSPACE_FILES.md for the full reference
+│       ├── SOUL.md             # Identity (required)
 │       ├── IDENTITY.md         # Name, emoji
-│       ├── AGENTS.md           # Operational rules
 │       ├── MEMORY.md           # Curated operational memory
-│       ├── GOALS.md            # Active/completed goals
-│       ├── TOOLS.md            # Tool inventory (auto-generated)
-│       ├── PROSOCHE.md         # Attention directives (auto-generated)
-│       ├── CONTEXT.md          # Session context (runtime-written)
 │       └── memory/             # Session logs (YYYY-MM-DD.md)
 │
 ├── shared/                     # Runtime infrastructure (agents only)

--- a/instance.example/config/aletheia.toml
+++ b/instance.example/config/aletheia.toml
@@ -101,3 +101,35 @@ workspace = "nous/main"
 # [pricing."claude-sonnet-4-6"]
 # inputCostPerMtok = 3.0
 # outputCostPerMtok = 15.0
+
+# --- Data retention ---
+# [data.retention]
+# sessionMaxAgeDays = 90
+# orphanMessageMaxAgeDays = 30
+# maxSessionsPerNous = 0          # 0 = unlimited
+# archiveBeforeDelete = true      # export sessions as JSON before deletion
+
+# --- Domain packs ---
+# Array of filesystem paths to external domain pack directories (containing pack.toml)
+# packs = [
+#     "/srv/aletheia/packs/engineering",
+# ]
+
+# --- Filesystem sandbox ---
+# Restricts tool execution to declared paths.
+# [sandbox]
+# enabled = true
+# enforcement = "enforcing"   # enforcing | permissive (log only)
+# extraReadPaths = []
+# extraWritePaths = []
+# extraExecPaths = ["~/.cargo/bin"]
+
+# --- Rate limiting ---
+# Per-IP request rate limiting for API endpoints.
+# [gateway.rateLimit]
+# enabled = false
+# requestsPerMinute = 60
+
+# --- Request body limit ---
+# [gateway.bodyLimit]
+# maxBytes = 1048576           # 1 MB default


### PR DESCRIPTION
## Summary

- Consolidate install instructions to QUICKSTART.md; README and DEPLOYMENT.md now link there
- Trim README from 133 lines to 68 by removing duplicate quick-start and architecture sections
- Remove throat-clearing opener in ARCHITECTURE-GUIDE.md
- Remove duplicated workspace file listing from instance.example/README.md, link to WORKSPACE_FILES.md
- Trim SHELL-COMPLETIONS.md from 64 lines to 18
- Replace startup sequence in DEPLOYMENT.md with link to ARCHITECTURE-GUIDE.md (canonical location)
- Fix five prose quality issues: nominalization ("provides a template"), tricolons, overcrowded lists
- Document `nous/_default/` in instance.example/README.md
- Fix CLAUDE.md file path: `crates/pylon/src/routes.rs` -> `crates/pylon/src/router.rs`
- Add `theatron-desktop` and `oikonomos` (daemon alias) to ARCHITECTURE.md crate table
- Fill in missing config sections in `aletheia.toml.example`: `data.retention`, `packs`, `sandbox`, `gateway.rateLimit`, `gateway.bodyLimit`
- Mark `theatron-desktop` as in-progress in PROJECT.md (was "Planned"; crate has ~4800 lines)

## Test plan

- [ ] Read QUICKSTART.md: confirms it is the single source for install instructions
- [ ] Read README.md: confirms it is under 200 lines with no duplicate sections
- [ ] Read SHELL-COMPLETIONS.md: confirms it is under 20 lines
- [ ] Read DEPLOYMENT.md: confirms no install duplication, startup sequence references ARCHITECTURE-GUIDE.md
- [ ] Read ARCHITECTURE-GUIDE.md: confirms no throat-clearing opener
- [ ] Read ARCHITECTURE.md: confirms `theatron-desktop` and `oikonomos` entries present
- [ ] Read CLAUDE.md: confirms `router.rs` (not `routes.rs`)
- [ ] Read instance.example/README.md: confirms `_default/` documented, file listing replaced with link
- [ ] Read instance.example/config/aletheia.toml: confirms data, packs, sandbox, rate limit sections present

## Closes

Closes #1702
Closes #1707
Closes #1708
Closes #1709
Closes #1731
Closes #1732
Closes #1733
Closes #1734
Closes #1735
Closes #1736
Closes #1737
Closes #1738

## Observations

- **#1730 (kanon roadmap stale)**: `kanon` is a separate workspace repo not in this codebase. The reference in `standards/README.md` describes where planning artifacts live. Updating the kanon roadmap requires access to that repo. Out of scope for this PR.
- `theatron-desktop` at `crates/theatron/desktop/` has ~4800 lines of Rust and a defined streaming architecture. It is more than a scaffold but not feature-complete. PROJECT.md updated to "In progress" accordingly.
- The `aletheia.toml.example` uses camelCase keys to match the existing style in that file (serde compat allows both).

🤖 Generated with [Claude Code](https://claude.com/claude-code)