### PR TITLE
fix: confidence update, hard session delete, credential encryption

### DIFF
--- a/crates/mneme/src/knowledge_store/facts.rs
+++ b/crates/mneme/src/knowledge_store/facts.rs
@@ -631,6 +631,64 @@ impl KnowledgeStore {
             .context(crate::error::JoinSnafu)?
     }
 
+    /// Update the confidence of a fact in-place.
+    ///
+    /// Performs a read-modify-write cycle: reads all temporal records for the
+    /// fact, overwrites the `confidence` field on each, and re-perserts them.
+    ///
+    /// Returns the updated fact. Errors if no fact with the given ID exists or
+    /// if `confidence` is outside `[0.0, 1.0]`.
+    #[instrument(skip(self))]
+    pub fn update_confidence(
+        &self,
+        fact_id: &crate::id::FactId,
+        confidence: f64,
+    ) -> crate::error::Result<crate::knowledge::Fact> {
+        use snafu::ensure;
+
+        ensure!(
+            (0.0..=1.0).contains(&confidence),
+            crate::error::InvalidConfidenceSnafu { value: confidence }
+        );
+
+        let existing = self.read_facts_by_id(fact_id.as_str())?;
+        if existing.is_empty() {
+            return Err(crate::error::FactNotFoundSnafu {
+                id: fact_id.as_str(),
+            }
+            .build());
+        }
+
+        // WHY: CozoDB in-memory read-modify-write: read the record, change the
+        // field in Rust, then upsert it back. Same pattern as increment_access.
+        for mut fact in existing {
+            fact.confidence = confidence;
+            self.insert_fact(&fact)?;
+        }
+
+        let updated = self.read_facts_by_id(fact_id.as_str())?;
+        updated.into_iter().next().ok_or_else(|| {
+            crate::error::FactNotFoundSnafu {
+                id: fact_id.as_str(),
+            }
+            .build()
+        })
+    }
+
+    /// Async `update_confidence`: wraps sync call in `spawn_blocking`.
+    #[instrument(skip(self))]
+    pub async fn update_confidence_async(
+        self: &std::sync::Arc<Self>,
+        fact_id: crate::id::FactId,
+        confidence: f64,
+    ) -> crate::error::Result<crate::knowledge::Fact> {
+        use snafu::ResultExt;
+        let this = std::sync::Arc::clone(self);
+        tokio::task::spawn_blocking(move || this.update_confidence(&fact_id, confidence))
+            .await
+            .context(crate::error::JoinSnafu)?
+    }
+
     /// Async `insert_fact`: wraps sync call in `spawn_blocking`.
     #[instrument(skip(self, fact), fields(fact_id = %fact.id))]
     pub async fn insert_fact_async(

--- a/crates/mneme/src/store/session.rs
+++ b/crates/mneme/src/store/session.rs
@@ -202,4 +202,22 @@ impl SessionStore {
             .context(error::DatabaseSnafu)?;
         Ok(())
     }
+
+    /// Hard-delete a session and all its messages by ID.
+    ///
+    /// Unlike archiving, this permanently removes the session row and all
+    /// associated message rows. The caller must have verified the session
+    /// exists before calling this method.
+    #[instrument(skip(self))]
+    pub fn delete_session(&self, id: &str) -> Result<bool> {
+        self.require_writable()?;
+        // WHY: messages.session_id has ON DELETE CASCADE, so deleting the
+        // session row removes its messages in the same transaction without
+        // a separate DELETE statement.
+        let rows = self
+            .conn
+            .execute("DELETE FROM sessions WHERE id = ?1", [id])
+            .context(error::DatabaseSnafu)?;
+        Ok(rows > 0)
+    }
 }

--- a/crates/pylon/src/handlers/knowledge/mutation.rs
+++ b/crates/pylon/src/handlers/knowledge/mutation.rs
@@ -128,7 +128,7 @@ pub async fn restore_fact(
     security(("bearer_auth" = []))
 )]
 pub async fn update_confidence(
-    State(_state): State<Arc<AppState>>,
+    State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
     Json(body): Json<UpdateConfidenceRequest>,
 ) -> Result<Json<serde_json::Value>, ApiError> {
@@ -138,11 +138,37 @@ pub async fn update_confidence(
             location: snafu::location!(),
         });
     }
-    tracing::info!(fact_id = %id, confidence = body.confidence, "confidence update requested");
-    // WHY: KnowledgeStore exposes no direct confidence-update method; a full
-    // read-modify-write cycle is needed but not yet implemented (#1025).
-    Err(ApiError::NotImplemented {
-        message: "confidence update is not yet implemented in the knowledge store".to_owned(),
+    #[cfg(feature = "knowledge-store")]
+    if let Some(ref store) = state.knowledge_store {
+        let fact_id = aletheia_mneme::id::FactId::new(&id).map_err(|e| ApiError::BadRequest {
+            message: format!("invalid fact id: {e}"),
+            location: snafu::location!(),
+        })?;
+        return match store
+            .update_confidence_async(fact_id, body.confidence)
+            .await
+        {
+            Ok(_) => {
+                tracing::info!(fact_id = %id, confidence = body.confidence, "fact confidence updated");
+                Ok(Json(
+                    serde_json::json!({ "status": "updated", "id": id, "confidence": body.confidence }),
+                ))
+            }
+            Err(aletheia_mneme::error::Error::FactNotFound { .. }) => Err(ApiError::NotFound {
+                path: format!("fact/{id}"),
+                location: snafu::location!(),
+            }),
+            Err(e) => Err(ApiError::Internal {
+                message: e.to_string(),
+                location: snafu::location!(),
+            }),
+        };
+    }
+    #[cfg(not(feature = "knowledge-store"))]
+    let _ = (state, body);
+    tracing::info!(fact_id = %id, "confidence update requested but knowledge store not available");
+    Err(ApiError::ServiceUnavailable {
+        message: "knowledge store not available".to_owned(),
         location: snafu::location!(),
     })
 }

--- a/crates/pylon/src/handlers/sessions/mod.rs
+++ b/crates/pylon/src/handlers/sessions/mod.rs
@@ -207,6 +207,38 @@ pub async fn close(
     archive_session_by_id(&state, &id).await
 }
 
+/// DELETE /api/v1/sessions/{id}/purge: permanently delete a session and all its messages.
+#[utoipa::path(
+    delete,
+    path = "/api/v1/sessions/{id}/purge",
+    params(("id" = String, Path, description = "Session ID")),
+    responses(
+        (status = 204, description = "Session permanently deleted"),
+        (status = 401, description = "Unauthorized", body = ErrorResponse),
+        (status = 404, description = "Session not found", body = ErrorResponse),
+    ),
+    security(("bearer_auth" = []))
+)]
+#[instrument(skip(state, _claims))]
+pub async fn purge(
+    State(state): State<Arc<AppState>>,
+    _claims: Claims,
+    Path(id): Path<String>,
+) -> Result<StatusCode, ApiError> {
+    let _ = find_session(&state, &id).await?;
+
+    let state_clone = Arc::clone(&state);
+    let id_clone = id.clone();
+    tokio::task::spawn_blocking(move || {
+        let store = state_clone.session_store.blocking_lock();
+        store.delete_session(&id_clone).map_err(ApiError::from)
+    })
+    .await??;
+
+    info!(session_id = %id, "session permanently deleted");
+    Ok(StatusCode::NO_CONTENT)
+}
+
 /// POST /api/v1/sessions/{id}/archive: archive a session.
 ///
 /// Same behavior as DELETE but via POST, matching the TUI's API contract.

--- a/crates/pylon/src/router.rs
+++ b/crates/pylon/src/router.rs
@@ -48,6 +48,10 @@ pub fn build_router(state: Arc<AppState>, security: &SecurityConfig) -> Router {
         )
         .route("/sessions/{id}/archive", post(sessions::archive))
         .route("/sessions/{id}/unarchive", post(sessions::unarchive))
+        .route(
+            "/sessions/{id}/purge",
+            axum::routing::delete(sessions::purge),
+        )
         .route("/sessions/{id}/name", axum::routing::put(sessions::rename))
         .route("/sessions/{id}/messages", post(sessions::send_message))
         .route("/sessions/{id}/history", get(sessions::history))

--- a/crates/pylon/src/tests/error_envelope.rs
+++ b/crates/pylon/src/tests/error_envelope.rs
@@ -447,7 +447,11 @@ async fn update_confidence_negative_returns_400_with_envelope() {
 }
 
 #[tokio::test]
-async fn update_confidence_valid_range_returns_501_with_envelope() {
+async fn update_confidence_valid_range_without_store_returns_503() {
+    // WHY: the knowledge store is not available in the default test app (no
+    // mneme-engine feature), so a valid confidence update returns 503
+    // service_unavailable instead of 200. The 501 path is gone now that the
+    // handler is implemented.
     let (app, _dir) = app().await;
     let req = authed_request(
         "PUT",
@@ -460,11 +464,11 @@ async fn update_confidence_valid_range_returns_501_with_envelope() {
         .expect("request to PUT /knowledge/facts/.../confidence should succeed");
     assert_eq!(
         resp.status(),
-        StatusCode::NOT_IMPLEMENTED,
-        "valid confidence on unimplemented endpoint should return 501"
+        StatusCode::SERVICE_UNAVAILABLE,
+        "valid confidence update without knowledge store should return 503"
     );
     let body = body_json(resp).await;
-    assert_error_envelope(&body, "not_implemented");
+    assert_error_envelope(&body, "service_unavailable");
 }
 
 #[tokio::test]

--- a/crates/symbolon/src/credential.rs
+++ b/crates/symbolon/src/credential.rs
@@ -1,6 +1,5 @@
 //! Credential provider implementations for LLM API key resolution.
 
-use std::io::Write as _;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, RwLock};
 use std::time::{Duration, Instant, SystemTime};
@@ -13,6 +12,7 @@ use aletheia_koina::credential::{Credential, CredentialProvider, CredentialSourc
 use aletheia_koina::secret::SecretString;
 
 use crate::circuit_breaker::{CircuitBreaker, CircuitBreakerConfig};
+use crate::encrypt::{ENCRYPTED_SENTINEL, decrypt, encrypt, load_or_create_key};
 
 /// Return current time as milliseconds since UNIX epoch, warning if the clock
 /// is before epoch rather than silently returning zero.
@@ -81,8 +81,10 @@ pub struct CredentialFile {
 impl CredentialFile {
     /// Read and parse a credential file.
     ///
-    /// Accepts two on-disk layouts:
+    /// Accepts three on-disk layouts:
     ///
+    /// * **Encrypted**: prefixed with `ALETHEIA_ENC_V1:` — decrypted using the
+    ///   sidecar key file (`<path>.key`) before parsing.
     /// * **Flat**: `{"token": "...", "refreshToken": "..."}` (native) or with the
     ///   `"accessToken"` alias produced by older Claude Code versions.
     /// * **Wrapped**: `{"claudeAiOauth": {"accessToken": "...", ...}}`: the nested
@@ -95,22 +97,49 @@ impl CredentialFile {
     pub fn load(path: &Path) -> Option<Self> {
         let contents = std::fs::read_to_string(path).ok()?;
 
-        if let Ok(cred) = serde_json::from_str::<Self>(&contents) {
+        let json = if let Some(encoded) = contents.strip_prefix(ENCRYPTED_SENTINEL) {
+            // WHY: encrypted files must be decrypted before JSON parsing.
+            let key = load_or_create_key(path)
+                .map_err(|e| tracing::warn!(error = %e, path = %path.display(), "failed to load encryption key"))
+                .ok()?;
+            let plaintext = decrypt(&key, encoded.trim_end())
+                .map_err(|e| tracing::warn!(error = %e, path = %path.display(), "failed to decrypt credential file"))
+                .ok()?;
+            String::from_utf8(plaintext)
+                .map_err(|e| tracing::warn!(error = %e, "decrypted credential is not valid UTF-8"))
+                .ok()?
+        } else {
+            contents
+        };
+
+        if let Ok(cred) = serde_json::from_str::<Self>(&json) {
             return Some(cred);
         }
 
-        let outer: serde_json::Value = serde_json::from_str(&contents).ok()?;
+        let outer: serde_json::Value = serde_json::from_str(&json).ok()?;
         serde_json::from_value(outer.get("claudeAiOauth")?.clone()).ok()
     }
 
     /// Write the credential file atomically (write to temp, rename).
+    ///
+    /// The file is always encrypted with AES-256-GCM using a per-file key
+    /// stored in a sidecar `.key` file (mode 0600).
     pub(crate) fn save(&self, path: &Path) -> std::io::Result<()> {
+        use std::io::Write as _;
+
         if let Some(parent) = path.parent() {
             std::fs::create_dir_all(parent)?;
         }
+
+        let json = serde_json::to_string_pretty(self).map_err(std::io::Error::other)?;
+
+        let key = load_or_create_key(path)?;
+        let encoded = encrypt(&key, json.as_bytes())?;
+
         let tmp = path.with_extension("json.tmp");
         let mut file = std::fs::File::create(&tmp)?;
-        serde_json::to_writer_pretty(&mut file, self).map_err(std::io::Error::other)?;
+        file.write_all(ENCRYPTED_SENTINEL.as_bytes())?;
+        file.write_all(encoded.as_bytes())?;
         file.flush()?;
         file.sync_all()?;
         std::fs::rename(&tmp, path)?;

--- a/crates/symbolon/src/encrypt.rs
+++ b/crates/symbolon/src/encrypt.rs
@@ -1,0 +1,298 @@
+//! AES-256-GCM encryption for credential files at rest.
+//!
+//! Encrypted files are prefixed with [`ENCRYPTED_SENTINEL`] so that
+//! plaintext files (written by older versions) can still be read.
+//! All new writes are encrypted.
+//!
+//! Key management: a 32-byte random encryption key is stored in a sidecar
+//! file (`<credential-path>.key`, mode 0600). This means the key and the
+//! ciphertext live in separate files, so copying one without the other
+//! leaves the credential inaccessible.
+
+use std::io::Write as _;
+use std::path::{Path, PathBuf};
+
+use base64::Engine;
+use base64::engine::general_purpose::STANDARD as BASE64;
+use ring::aead::{
+    AES_256_GCM, Aad, BoundKey, NONCE_LEN as RING_NONCE_LEN, Nonce, NonceSequence, SealingKey,
+    UnboundKey,
+};
+
+/// Magic prefix that marks an encrypted credential file.
+pub(crate) const ENCRYPTED_SENTINEL: &str = "ALETHEIA_ENC_V1:";
+
+/// AES-256-GCM nonce length (96 bits / 12 bytes per NIST recommendation).
+const NONCE_LEN: usize = 12;
+// Compile-time assertion: our constant must match ring's.
+const _: () = assert!(NONCE_LEN == RING_NONCE_LEN, "NONCE_LEN must match ring");
+
+/// AES-256-GCM key length (256 bits / 32 bytes).
+const KEY_LEN: usize = 32;
+
+/// A [`NonceSequence`] that yields a single nonce and then errors.
+///
+/// AES-GCM with a random nonce is IND-CPA secure when the nonce is never
+/// reused. This type encodes "use once" at the type level: advancing it a
+/// second time returns `Unspecified`, which causes `SealingKey::seal` to fail.
+struct OnceThenError(Option<[u8; RING_NONCE_LEN]>);
+
+impl NonceSequence for OnceThenError {
+    fn advance(&mut self) -> Result<Nonce, ring::error::Unspecified> {
+        self.0
+            .take()
+            .map(Nonce::assume_unique_for_key)
+            .ok_or(ring::error::Unspecified)
+    }
+}
+
+/// Derive the key-file path from the credential file path.
+///
+/// The key file sits alongside the credential file with a `.key` extension
+/// appended: `/path/to/.credentials.json` → `/path/to/.credentials.json.key`.
+#[must_use]
+pub(crate) fn key_file_path(credential_path: &Path) -> PathBuf {
+    let mut key_path = credential_path.as_os_str().to_owned();
+    key_path.push(".key");
+    PathBuf::from(key_path)
+}
+
+/// Load or generate the encryption key for the given credential file.
+///
+/// If the key file does not yet exist, generates a new 32-byte random key,
+/// writes it (mode 0600 on Unix), and returns it.
+///
+/// # Errors
+///
+/// Returns an `io::Error` if the key file cannot be read or written.
+pub(crate) fn load_or_create_key(credential_path: &Path) -> std::io::Result<[u8; KEY_LEN]> {
+    let key_path = key_file_path(credential_path);
+
+    if key_path.exists() {
+        let bytes = std::fs::read(&key_path)?;
+        let key: [u8; KEY_LEN] = bytes.try_into().map_err(|_ignored| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "encryption key file has wrong length (expected 32 bytes)",
+            )
+        })?;
+        return Ok(key);
+    }
+
+    let key = generate_key()?;
+    write_key_file(&key_path, &key)?;
+    Ok(key)
+}
+
+/// Encrypt `plaintext` using AES-256-GCM with a fresh random nonce.
+///
+/// Returns base64-encoded `nonce || ciphertext_with_tag`.
+///
+/// # Errors
+///
+/// Returns an `io::Error` if the RNG or the AEAD primitive fails.
+pub(crate) fn encrypt(key: &[u8; KEY_LEN], plaintext: &[u8]) -> std::io::Result<String> {
+    let nonce_bytes: [u8; NONCE_LEN] = generate_nonce()?;
+
+    let unbound = UnboundKey::new(&AES_256_GCM, key)
+        .map_err(|_ignored| std::io::Error::other("AES-256-GCM: invalid key length"))?;
+
+    let mut sealing_key: SealingKey<OnceThenError> =
+        SealingKey::new(unbound, OnceThenError(Some(nonce_bytes)));
+
+    let mut in_out = plaintext.to_vec();
+    sealing_key
+        .seal_in_place_append_tag(Aad::empty(), &mut in_out)
+        .map_err(|_ignored| {
+            std::io::Error::other("AES-256-GCM: seal_in_place_append_tag failed")
+        })?;
+
+    // Prepend nonce so the decryptor can recover it.
+    let mut combined = Vec::with_capacity(NONCE_LEN + in_out.len());
+    combined.extend_from_slice(&nonce_bytes);
+    combined.extend_from_slice(&in_out);
+
+    Ok(BASE64.encode(&combined))
+}
+
+/// Decrypt a base64-encoded `nonce || ciphertext_with_tag` produced by [`encrypt`].
+///
+/// # Errors
+///
+/// Returns an `io::Error` if base64 decoding or AES-GCM authentication fails.
+pub(crate) fn decrypt(key: &[u8; KEY_LEN], encoded: &str) -> std::io::Result<Vec<u8>> {
+    use ring::aead::{LessSafeKey, Nonce as AeadNonce, UnboundKey as AeadUnbound};
+
+    let combined = BASE64.decode(encoded).map_err(|e| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("base64 decode failed: {e}"),
+        )
+    })?;
+
+    if combined.len() < NONCE_LEN {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "encrypted credential too short to contain nonce",
+        ));
+    }
+
+    let (nonce_bytes, ciphertext_with_tag) = combined.split_at(NONCE_LEN);
+    let nonce_arr: [u8; NONCE_LEN] = nonce_bytes.try_into().map_err(|_ignored| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "nonce slice has wrong length",
+        )
+    })?;
+
+    let unbound = AeadUnbound::new(&AES_256_GCM, key)
+        .map_err(|_ignored| std::io::Error::other("AES-256-GCM: invalid key length"))?;
+    let opening_key = LessSafeKey::new(unbound);
+    let nonce = AeadNonce::assume_unique_for_key(nonce_arr);
+
+    let mut buf = ciphertext_with_tag.to_vec();
+    let plaintext = opening_key
+        .open_in_place(nonce, Aad::empty(), &mut buf)
+        .map_err(|_ignored| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "AES-256-GCM authentication failed (wrong key or corrupted ciphertext)",
+            )
+        })?;
+
+    Ok(plaintext.to_vec())
+}
+
+/// Generate a fresh random 32-byte AES-256-GCM key using the system CSPRNG.
+///
+/// # Errors
+///
+/// Returns an `io::Error` if the system random source is unavailable.
+fn generate_key() -> std::io::Result<[u8; KEY_LEN]> {
+    let random = ring::rand::SystemRandom::new();
+    let mut key = [0u8; KEY_LEN];
+    ring::rand::SecureRandom::fill(&random, &mut key).map_err(|_ignored| {
+        std::io::Error::other("system RNG unavailable (cannot generate encryption key)")
+    })?;
+    Ok(key)
+}
+
+/// Generate a fresh 12-byte nonce using the system CSPRNG.
+///
+/// # Errors
+///
+/// Returns an `io::Error` if the system random source is unavailable.
+fn generate_nonce() -> std::io::Result<[u8; NONCE_LEN]> {
+    let random = ring::rand::SystemRandom::new();
+    let mut buf = [0u8; NONCE_LEN];
+    ring::rand::SecureRandom::fill(&random, &mut buf).map_err(|_ignored| {
+        std::io::Error::other("system RNG unavailable (cannot generate nonce)")
+    })?;
+    Ok(buf)
+}
+
+/// Write the encryption key to disk with restrictive permissions.
+fn write_key_file(path: &Path, key: &[u8; KEY_LEN]) -> std::io::Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+
+    let tmp = path.with_extension("key.tmp");
+    let mut f = std::fs::File::create(&tmp)?;
+    f.write_all(key)?;
+    f.flush()?;
+    f.sync_all()?;
+    std::fs::rename(&tmp, path)?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "test assertions")]
+mod tests {
+    use super::*;
+
+    fn test_key() -> [u8; KEY_LEN] {
+        let mut k = [0u8; KEY_LEN];
+        for (i, b) in k.iter_mut().enumerate() {
+            // NOTE: i is in 0..KEY_LEN (32), which fits in u8.
+            #[expect(
+                clippy::cast_possible_truncation,
+                clippy::as_conversions,
+                reason = "i < KEY_LEN = 32, fits in u8"
+            )]
+            {
+                *b = i as u8;
+            }
+        }
+        k
+    }
+
+    #[test]
+    fn encrypt_then_decrypt_roundtrip() {
+        let key = test_key();
+        let plaintext = b"hello, credential world";
+        let encoded = encrypt(&key, plaintext).unwrap();
+        let decoded = decrypt(&key, &encoded).unwrap();
+        assert_eq!(
+            decoded, plaintext,
+            "roundtrip must recover original plaintext"
+        );
+    }
+
+    #[test]
+    fn different_nonces_produce_different_ciphertexts() {
+        let key = test_key();
+        let plaintext = b"same plaintext";
+        let enc1 = encrypt(&key, plaintext).unwrap();
+        let enc2 = encrypt(&key, plaintext).unwrap();
+        assert_ne!(enc1, enc2, "each encrypt call must use a fresh nonce");
+    }
+
+    #[test]
+    fn wrong_key_fails_decryption() {
+        let key = test_key();
+        let mut bad_key = test_key();
+        bad_key[0] ^= 0xFF;
+        let encoded = encrypt(&key, b"secret").unwrap();
+        let result = decrypt(&bad_key, &encoded);
+        assert!(result.is_err(), "wrong key must not decrypt successfully");
+    }
+
+    #[test]
+    fn tampered_ciphertext_fails_decryption() {
+        let key = test_key();
+        let mut encoded = encrypt(&key, b"secret data").unwrap();
+        // NOTE: flip the last character to corrupt the GCM authentication tag.
+        if let Some(c) = encoded.pop() {
+            let flipped = if c == 'A' { 'B' } else { 'A' };
+            encoded.push(flipped);
+        }
+        let result = decrypt(&key, &encoded);
+        assert!(
+            result.is_err(),
+            "tampered ciphertext must fail authentication"
+        );
+    }
+
+    #[test]
+    fn key_file_path_appends_dot_key() {
+        let cred = Path::new("/home/alice/.claude/.credentials.json");
+        let key = key_file_path(cred);
+        assert_eq!(key, Path::new("/home/alice/.claude/.credentials.json.key"));
+    }
+
+    #[test]
+    fn load_or_create_key_is_stable_across_calls() {
+        let dir = tempfile::tempdir().unwrap();
+        let cred_path = dir.path().join("creds.json");
+        let key1 = load_or_create_key(&cred_path).unwrap();
+        let key2 = load_or_create_key(&cred_path).unwrap();
+        assert_eq!(key1, key2, "same key file must yield the same key twice");
+    }
+}

--- a/crates/symbolon/src/lib.rs
+++ b/crates/symbolon/src/lib.rs
@@ -11,6 +11,8 @@ pub(crate) mod auth;
 pub mod circuit_breaker;
 /// Credential provider implementations for LLM API key resolution.
 pub mod credential;
+/// AES-256-GCM encryption for credential files at rest.
+pub(crate) mod encrypt;
 /// Symbolon-specific error types and result alias.
 pub mod error;
 /// JWT token issuance, validation, and refresh.


### PR DESCRIPTION
## Summary

- **#1706** — `PUT /knowledge/facts/{id}/confidence`: replaced 501 stub with a real read-modify-write implementation against `KnowledgeStore`; returns 200 on success, 404 when the fact is not found, 503 when the knowledge store feature is disabled.
- **#1725** — `DELETE /api/v1/sessions/{id}/purge`: new hard-delete endpoint that permanently removes the session row and all cascade-linked rows (messages, usage, distillations, agent\_notes); distinct from the existing archive path which only sets a flag.
- **#1724** — Credential files are now encrypted at rest with AES-256-GCM (ring 0.17). A 32-byte random key is stored in a sidecar `<credential>.key` file (mode 0600). Existing plaintext files are still readable; all new writes use the `ALETHEIA_ENC_V1:` sentinel prefix.

## Test plan

- [ ] `cargo test -p aletheia-mneme` — `update_confidence` unit tests pass
- [ ] `cargo test -p aletheia-pylon` — `update_confidence_valid_range_without_store_returns_503` passes; no 501 regressions
- [ ] `cargo test -p aletheia-symbolon` — all 6 encrypt tests pass (roundtrip, nonce uniqueness, wrong-key failure, tampered-ciphertext failure, key-path derivation, key stability)
- [ ] `cargo clippy --workspace` — zero warnings
- [ ] Manual: create a credential file, restart, confirm it is reloaded correctly; confirm the `.key` sidecar is created with mode 0600
- [ ] Manual: `DELETE /api/v1/sessions/{id}/purge` returns 204 and the session no longer appears in `GET /api/v1/sessions`

Closes #1706, #1725, #1724

🤖 Generated with [Claude Code](https://claude.com/claude-code)