### PR TITLE
fix(init,cli): resolve 8 init and CLI issues

### DIFF
--- a/crates/aletheia/src/init/mod.rs
+++ b/crates/aletheia/src/init/mod.rs
@@ -82,6 +82,8 @@ pub(super) struct Answers {
     pub(super) bind: String,
     pub(super) auth_mode: String,
     pub(super) timezone: String,
+    /// Credential resolution source: `"auto"`, `"api-key"`, or `"claude-code"`.
+    pub(super) credential_source: String,
 }
 
 impl Default for Answers {
@@ -96,6 +98,7 @@ impl Default for Answers {
             bind: "localhost".to_owned(),
             auth_mode: "none".to_owned(),
             timezone: detect_timezone(),
+            credential_source: "auto".to_owned(),
         }
     }
 }
@@ -122,11 +125,17 @@ pub(crate) fn run(args: RunArgs) -> Result<(), InitError> {
             .build()
         })?;
 
-        if api_key.is_none() {
+        let credential_source = if api_key.is_some() {
+            // WHY: explicit API key was provided; pin source to "api-key" so the
+            // server loads the written credential file rather than falling through
+            // the "auto" chain which may pick up a different credential.
+            "api-key".to_owned()
+        } else {
             tracing::warn!(
                 "no API key provided — set --api-key or ANTHROPIC_API_KEY; server will start in degraded mode"
             );
-        }
+            "auto".to_owned()
+        };
 
         Answers {
             root,
@@ -134,17 +143,24 @@ pub(crate) fn run(args: RunArgs) -> Result<(), InitError> {
             api_provider: api_provider.unwrap_or_else(|| "anthropic".to_owned()),
             model: model.unwrap_or_else(|| "claude-sonnet-4-6".to_owned()),
             auth_mode: auth_mode.unwrap_or_else(|| "none".to_owned()),
+            credential_source,
             ..Answers::default()
         }
     } else if yes {
         // NOTE: lenient non-interactive: skip prompts, apply defaults for missing values
         let root = root.unwrap_or_else(|| PathBuf::from("./instance"));
 
-        if api_key.is_none() {
+        let credential_source = if api_key.is_some() {
+            // WHY: explicit API key was provided; pin source to "api-key" so the
+            // server loads the written credential file rather than falling through
+            // the "auto" chain which may pick up a different credential.
+            "api-key".to_owned()
+        } else {
             tracing::warn!(
                 "no API key provided — set --api-key or ANTHROPIC_API_KEY; server will start in degraded mode"
             );
-        }
+            "auto".to_owned()
+        };
 
         Answers {
             root,
@@ -152,6 +168,7 @@ pub(crate) fn run(args: RunArgs) -> Result<(), InitError> {
             api_provider: api_provider.unwrap_or_else(|| "anthropic".to_owned()),
             model: model.unwrap_or_else(|| "claude-sonnet-4-6".to_owned()),
             auth_mode: auth_mode.unwrap_or_else(|| "none".to_owned()),
+            credential_source,
             ..Answers::default()
         }
     } else {

--- a/crates/aletheia/src/init/scaffold.rs
+++ b/crates/aletheia/src/init/scaffold.rs
@@ -168,7 +168,10 @@ mod pronoea_template {
 }
 
 pub(super) fn render_config(a: &Answers) -> String {
-    let workspace = format!("{}/nous/{}", a.root.display(), a.agent_id);
+    // WHY: workspace is stored relative to the instance root so the config
+    // works regardless of where the instance directory is placed on disk.
+    // Oikos::validate_workspace_path resolves relative paths against the root.
+    let workspace = format!("nous/{}", a.agent_id);
     let mut config = format!(
         r#"# Aletheia Instance Configuration
 # Config cascade: compiled defaults -> this file -> ALETHEIA_* env vars
@@ -185,12 +188,12 @@ mode = "{auth_mode}"
 # tls:
 # [gateway.tls]
 # enabled = true
-# certPath = "config/tls/cert.pem"
-# keyPath = "config/tls/key.pem"
+# cert_path = "config/tls/cert.pem"
+# key_path = "config/tls/key.pem"
 
 # cors:
 # [gateway.cors]
-# allowedOrigins = ["https://my-dashboard.local"]
+# allowed_origins = ["https://my-dashboard.local"]
 
 # csrf:
 # [gateway.csrf]
@@ -198,14 +201,13 @@ mode = "{auth_mode}"
 
 # --- Agents ---
 [agents.defaults]
-contextTokens = 200000
-maxOutputTokens = 16384
-userTimezone = "{timezone}"
-timeoutSeconds = 300
-# thinkingEnabled = false
-# thinkingBudget = 10000
-# maxToolIterations = 50
-# toolTimeouts.defaultMs = 120000
+context_tokens = 200000
+max_output_tokens = 16384
+user_timezone = "{timezone}"
+timeout_seconds = 300
+# thinking_enabled = false
+# thinking_budget = 10000
+# max_tool_iterations = 50
 
 [agents.defaults.model]
 primary = "{model}"
@@ -219,14 +221,14 @@ workspace = "{workspace}"
 # --- Channels ---
 # [[channels.signal.accounts]]
 # account = "+1XXXXXXXXXX"
-# httpHost = "localhost"
-# httpPort = 8080
+# http_host = "localhost"
+# http_port = 8080
 
 # --- Bindings (route messages to agents) ---
 # [[bindings]]
 # channel = "signal"
 # source = "*"
-# nousId = "{agent_id}"
+# nous_id = "{agent_id}"
 
 # --- Embedding (for recall/knowledge search) ---
 # [embedding]
@@ -235,19 +237,23 @@ workspace = "{workspace}"
 
 # --- Data retention ---
 # [data.retention]
-# sessionMaxAgeDays = 90
-# archiveBeforeDelete = true
+# session_max_age_days = 90
+# archive_before_delete = true
 
 # --- Maintenance ---
-# [maintenance.traceRotation]
-# maxAgeDays = 14
-# [maintenance.dbMonitoring]
-# warnThresholdMb = 100
+# [maintenance.trace_rotation]
+# max_age_days = 14
+# [maintenance.db_monitoring]
+# warn_threshold_mb = 100
 
 # --- Cost tracking ---
 [pricing.{model}]
-inputCostPerMtok = 3.0
-outputCostPerMtok = 15.0
+input_cost_per_mtok = 3.0
+output_cost_per_mtok = 15.0
+
+# --- Credentials ---
+[credential]
+source = "{credential_source}"
 "#,
         bind = a.bind,
         auth_mode = a.auth_mode,
@@ -256,6 +262,7 @@ outputCostPerMtok = 15.0
         agent_id = a.agent_id,
         agent_name = a.agent_name,
         workspace = workspace,
+        credential_source = a.credential_source,
     );
     // WHY: single-agent init always produces a single-agent config.
     // Append permissive sandbox defaults so the agent is functional on kernels

--- a/crates/daemon/src/maintenance/drift_detection.rs
+++ b/crates/daemon/src/maintenance/drift_detection.rs
@@ -39,6 +39,10 @@ impl Default for DriftDetectionConfig {
                 ".gitkeep".to_owned(),
             ],
             optional_patterns: vec![
+                // WHY: _default/ and _template/ are scaffolding directories that
+                // live in the example but are not expected in a live instance
+                // (init writes agent files into nous/{id}/ instead).
+                "nous/_default/".to_owned(),
                 "nous/_template/".to_owned(),
                 "packs/".to_owned(),
                 "services/".to_owned(),

--- a/crates/integration-tests/tests/cross_crate_pipeline/lifecycle.rs
+++ b/crates/integration-tests/tests/cross_crate_pipeline/lifecycle.rs
@@ -327,5 +327,5 @@ async fn session_lifecycle_create_list_archive_unarchive_rename() {
         .iter()
         .find(|s| s["id"] == id)
         .expect("session should be in list");
-    assert_eq!(our_session["displayName"], "My Renamed Session");
+    assert_eq!(our_session["display_name"], "My Renamed Session");
 }

--- a/crates/pylon/src/handlers/nous.rs
+++ b/crates/pylon/src/handlers/nous.rs
@@ -106,6 +106,7 @@ pub async fn tools(
             name: d.name.as_str().to_owned(),
             description: d.description.clone(),
             category: format!("{:?}", d.category),
+            auto_activate: d.auto_activate,
         })
         .collect();
 
@@ -169,6 +170,11 @@ pub struct ToolSummary {
     pub description: String,
     /// Tool category (e.g. `"Builtin"`, `"Pack"`).
     pub category: String,
+    /// Whether the tool activates automatically without explicit configuration.
+    ///
+    /// When `false` the tool is lazy and must be activated via `enable_tool`
+    /// before the agent can use it.
+    pub auto_activate: bool,
 }
 
 #[cfg(test)]
@@ -242,11 +248,13 @@ mod tests {
                 name: "read_file".to_owned(),
                 description: "Read a file from disk".to_owned(),
                 category: "Builtin".to_owned(),
+                auto_activate: true,
             }],
         };
         let json = serde_json::to_value(&resp).unwrap();
         assert_eq!(json["tools"][0]["name"], "read_file");
         assert_eq!(json["tools"][0]["category"], "Builtin");
+        assert_eq!(json["tools"][0]["auto_activate"], true);
     }
 
     #[test]

--- a/crates/pylon/src/handlers/sessions/types.rs
+++ b/crates/pylon/src/handlers/sessions/types.rs
@@ -46,7 +46,6 @@ fn default_session_key() -> String {
 
 /// Query parameters for `GET /api/v1/sessions`.
 #[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
 pub struct ListSessionsParams {
     /// Filter sessions by agent ID.
     pub nous_id: Option<String>,
@@ -72,7 +71,6 @@ pub struct ListSessionsResponse {
 
 /// Session summary for list endpoints.
 #[derive(Debug, Serialize, ToSchema)]
-#[serde(rename_all = "camelCase")]
 pub struct SessionListItem {
     /// Session identifier.
     pub id: String,

--- a/crates/pylon/src/tests/middleware.rs
+++ b/crates/pylon/src/tests/middleware.rs
@@ -293,7 +293,9 @@ fn security_config_from_gateway() {
     let gw = GatewayConfig::default();
     let config = SecurityConfig::from_gateway(&gw);
     assert!(!config.tls_enabled);
-    assert!(config.csrf_enabled);
+    // WHY: CSRF defaults to disabled so the API works out-of-the-box;
+    // operators enable it explicitly when exposing to browsers (#1690).
+    assert!(!config.csrf_enabled);
     assert_eq!(config.cors_max_age_secs, 3600);
 }
 

--- a/crates/pylon/src/tests/session.rs
+++ b/crates/pylon/src/tests/session.rs
@@ -204,7 +204,7 @@ async fn list_sessions_includes_created_session() {
     let body = body_json(resp).await;
     let sessions = body["sessions"].as_array().unwrap();
     assert!(!sessions.is_empty());
-    assert_eq!(sessions[0]["nousId"], "syn");
+    assert_eq!(sessions[0]["nous_id"], "syn");
 }
 
 #[tokio::test]
@@ -216,7 +216,7 @@ async fn list_sessions_filter_by_nous_id() {
 
     let resp = router
         .clone()
-        .oneshot(authed_get("/api/v1/sessions?nousId=syn"))
+        .oneshot(authed_get("/api/v1/sessions?nous_id=syn"))
         .await
         .unwrap();
 
@@ -226,7 +226,7 @@ async fn list_sessions_filter_by_nous_id() {
 
     let resp2 = router
         .clone()
-        .oneshot(authed_get("/api/v1/sessions?nousId=nonexistent"))
+        .oneshot(authed_get("/api/v1/sessions?nous_id=nonexistent"))
         .await
         .unwrap();
 

--- a/crates/taxis/src/config/config_tests.rs
+++ b/crates/taxis/src/config/config_tests.rs
@@ -74,8 +74,8 @@ fn defaults_are_sensible() {
         "default body limit should be 1 MiB"
     );
     assert!(
-        config.gateway.csrf.enabled,
-        "csrf should be enabled by default"
+        !config.gateway.csrf.enabled,
+        "csrf should be disabled by default (#1690)"
     );
     assert_eq!(
         config.gateway.csrf.header_name, "x-requested-with",

--- a/crates/taxis/src/config/maintenance.rs
+++ b/crates/taxis/src/config/maintenance.rs
@@ -90,6 +90,10 @@ impl Default for DriftDetectionSettings {
                 ".gitkeep".to_owned(),
             ],
             optional_patterns: vec![
+                // WHY: _default/ and _template/ are scaffolding directories that
+                // live in the example but are not expected in a live instance
+                // (init writes agent files into nous/{id}/ instead).
+                "nous/_default/".to_owned(),
                 "nous/_template/".to_owned(),
                 "packs/".to_owned(),
                 "services/".to_owned(),

--- a/crates/taxis/src/config/mod.rs
+++ b/crates/taxis/src/config/mod.rs
@@ -524,8 +524,11 @@ pub struct CsrfConfig {
 
 impl Default for CsrfConfig {
     fn default() -> Self {
+        // WHY: CSRF is disabled by default so the API works out-of-the-box
+        // without any client configuration. Operators who expose the gateway
+        // to a browser should explicitly enable it.
         Self {
-            enabled: true,
+            enabled: false,
             header_name: "x-requested-with".to_owned(),
             header_value: "aletheia".to_owned(),
         }

--- a/crates/taxis/src/oikos.rs
+++ b/crates/taxis/src/oikos.rs
@@ -18,9 +18,20 @@ pub struct Oikos {
 
 impl Oikos {
     /// Create an oikos from an explicit root path.
+    ///
+    /// If the path exists on disk, it is canonicalized to an absolute path so
+    /// that all derived paths (data, logs, etc.) are absolute and work
+    /// regardless of the caller's current working directory. If the path does
+    /// not yet exist (e.g. during `init`), the path is stored as-is.
     #[must_use]
     pub fn from_root(root: impl Into<PathBuf>) -> Self {
-        Self { root: root.into() }
+        let root = root.into();
+        // WHY: canonicalize converts relative paths (./instance, instance) to
+        // absolute paths so that existence checks in print_storage and
+        // validate_workspace_path are cwd-independent. Fall back to the raw
+        // path when the directory does not yet exist (e.g. during init).
+        let root = std::fs::canonicalize(&root).unwrap_or(root);
+        Self { root }
     }
 
     /// Discover the oikos root.

--- a/crates/theatron/tui/src/api/client.rs
+++ b/crates/theatron/tui/src/api/client.rs
@@ -196,7 +196,7 @@ impl ApiClient {
         let resp = self
             .request(
                 reqwest::Method::GET,
-                &format!("/api/v1/sessions?nousId={encoded}"),
+                &format!("/api/v1/sessions?nous_id={encoded}"),
             )
             .send()
             .await
@@ -244,8 +244,8 @@ impl ApiClient {
         let resp = self
             .request(reqwest::Method::POST, "/api/v1/sessions")
             .json(&serde_json::json!({
-                "nousId": nous_id,
-                "sessionKey": session_key,
+                "nous_id": nous_id,
+                "session_key": session_key,
             }))
             .send()
             .await

--- a/crates/theatron/tui/src/api/types.rs
+++ b/crates/theatron/tui/src/api/types.rs
@@ -27,19 +27,18 @@ impl Agent {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Session {
     pub id: SessionId,
-    #[serde(rename = "nousId")]
     pub nous_id: NousId,
-    #[serde(rename = "sessionKey")]
+    #[serde(rename = "session_key")]
     pub key: String,
     #[serde(default)]
     pub status: Option<String>,
-    #[serde(rename = "messageCount", default)]
+    #[serde(default)]
     pub message_count: u32,
-    #[serde(rename = "sessionType", default)]
+    #[serde(default)]
     pub session_type: Option<String>,
-    #[serde(rename = "updatedAt", default)]
+    #[serde(default)]
     pub updated_at: Option<String>,
-    #[serde(rename = "displayName", default)]
+    #[serde(default)]
     pub display_name: Option<String>,
 }
 
@@ -70,11 +69,11 @@ pub struct HistoryMessage {
     pub role: String,
     #[serde(default)]
     pub content: Option<serde_json::Value>,
-    #[serde(rename = "createdAt", default)]
+    #[serde(default)]
     pub created_at: Option<String>,
     #[serde(default)]
     pub model: Option<String>,
-    #[serde(rename = "toolName", default)]
+    #[serde(default)]
     pub tool_name: Option<String>,
 }
 
@@ -333,9 +332,9 @@ mod tests {
     fn session_deserialization() {
         let json = r#"{
             "id": "sess-1",
-            "nousId": "syn",
-            "sessionKey": "main",
-            "messageCount": 5,
+            "nous_id": "syn",
+            "session_key": "main",
+            "message_count": 5,
             "status": "active"
         }"#;
         let session: Session = serde_json::from_str(json).unwrap();
@@ -348,7 +347,7 @@ mod tests {
 
     #[test]
     fn session_deserialization_defaults() {
-        let json = r#"{"id": "s1", "nousId": "n1", "sessionKey": "k1"}"#;
+        let json = r#"{"id": "s1", "nous_id": "n1", "session_key": "k1"}"#;
         let session: Session = serde_json::from_str(json).unwrap();
         assert_eq!(session.message_count, 0);
         assert!(session.status.is_none());
@@ -361,7 +360,7 @@ mod tests {
         let json = r#"{
             "role": "user",
             "content": "hello",
-            "createdAt": "2025-01-01T00:00:00Z"
+            "created_at": "2025-01-01T00:00:00Z"
         }"#;
         let msg: HistoryMessage = serde_json::from_str(json).unwrap();
         assert_eq!(msg.role, "user");
@@ -533,9 +532,9 @@ mod tests {
     fn session_deserialization_with_display_name() {
         let json = r#"{
             "id": "s1",
-            "nousId": "syn",
-            "sessionKey": "main",
-            "displayName": "My Chat"
+            "nous_id": "syn",
+            "session_key": "main",
+            "display_name": "My Chat"
         }"#;
         let session: Session = serde_json::from_str(json).unwrap();
         assert_eq!(session.display_name.as_deref(), Some("My Chat"));


### PR DESCRIPTION
## Summary
- fix workspace path redundancy in init (#1687)
- fix status command path resolution (#1689)
- default CSRF to disabled (#1690)
- unify API responses to snake_case (#1691)
- add credential source to non-interactive init (#1692)
- skip missing _default/ template in drift-detection (#1694)
- fix tool auto-activate status in tools endpoint (#1695)
- generate snake_case config in init (#1696)

Closes #1687, #1689, #1690, #1691, #1692, #1694, #1695, #1696

## Test plan
- [ ] cargo test --workspace passes
- [ ] cargo clippy --workspace -- -D warnings passes
- [ ] init produces clean workspace paths
- [ ] status works on valid instances
- [ ] CSRF disabled by default
- [ ] Consistent snake_case in API responses
- [ ] Non-interactive init sets credential source
- [ ] Drift detection skips missing _default/ templates
- [ ] Tool activation status correct
- [ ] Generated config uses snake_case

## Observations
- The TUI streaming protocol (SSE WebchatEvent) uses intentional camelCase field names (`sessionId`, `nousId`, `turnId`, etc.) as part of the webchat protocol contract — this is separate from the REST session list/create API and was left unchanged.
- The `ListSessionsParams` query parameter was changed from `nousId` to `nous_id` as part of the snake_case unification; this is a minor query-string API change.
- The `ChannelBinding` config type (TOML `nousId`, `sessionKey` fields) retains camelCase as it is a config-file concern with its own serialization contract, not part of the REST API surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)