### PR TITLE
ci: test sharding, workflow generation, expanded release matrix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,17 +77,25 @@ jobs:
 
       - name: Build (native)
         if: ${{ !matrix.cross }}
-        run: cargo build --release --target ${{ matrix.target }} --features recall,embed-candle
+        run: cargo build --release --target "$BUILD_TARGET" --features recall,embed-candle
+        env:
+          BUILD_TARGET: ${{ matrix.target }}
 
       - name: Build (cross)
         if: ${{ matrix.cross }}
-        run: cross build --release --target ${{ matrix.target }} --features recall,embed-candle
+        run: cross build --release --target "$BUILD_TARGET" --features recall,embed-candle
+        env:
+          BUILD_TARGET: ${{ matrix.target }}
 
       - name: Rename binary
         run: |
-          bin="${{ matrix.artifact }}-${{ steps.version.outputs.version }}"
-          cp "target/${{ matrix.target }}/release/aletheia" "$bin"
+          bin="${ARTIFACT}-${VERSION}"
+          cp "target/${BUILD_TARGET}/release/aletheia" "$bin"
           echo "BIN=$bin" >> "$GITHUB_ENV"
+        env:
+          ARTIFACT: ${{ matrix.artifact }}
+          VERSION: ${{ steps.version.outputs.version }}
+          BUILD_TARGET: ${{ matrix.target }}
 
       - name: Generate checksum (Linux)
         if: runner.os == 'Linux'

--- a/.github/workflows/test-sharded.yml
+++ b/.github/workflows/test-sharded.yml
@@ -59,13 +59,19 @@ jobs:
       - name: Install cargo-nextest
         uses: taiki-e/install-action@e24b8b7a939c6a537188f34a4163cb153dd85cf6 # v2
         with:
+<<<<<<< Updated upstream
           tool: cargo-nextest
+=======
+          tool: nextest
+>>>>>>> Stashed changes
 
       - name: "Test (shard ${{ matrix.shard }}/4)"
+        env:
+          SHARD: ${{ matrix.shard }}
         run: |
           cargo nextest run \
             --workspace \
-            --partition hash:${{ matrix.shard }}/4
+            --partition "hash:${SHARD}/4"
 
   # WHY: Gate merges on all shards passing. A single required status check
   # per "fan-in" job is simpler than listing N individual shard jobs in
@@ -77,9 +83,10 @@ jobs:
     if: always()
     steps:
       - name: Check all shards succeeded
+        env:
+          SHARD_RESULT: ${{ needs.test-shard.result }}
         run: |
-          result="${{ needs.test-shard.result }}"
-          if [[ "$result" != "success" ]]; then
-            printf 'One or more test shards failed (result: %s)\n' "$result" >&2
+          if [[ "$SHARD_RESULT" != "success" ]]; then
+            printf 'One or more test shards failed (result: %s)\n' "$SHARD_RESULT" >&2
             exit 1
           fi

--- a/scripts/generate-workflows.sh
+++ b/scripts/generate-workflows.sh
@@ -142,13 +142,19 @@ jobs:
       - name: Install cargo-nextest
         uses: taiki-e/install-action@e24b8b7a939c6a537188f34a4163cb153dd85cf6 # v2
         with:
+<<<<<<< Updated upstream
           tool: cargo-nextest
+=======
+          tool: nextest
+>>>>>>> Stashed changes
 
       - name: "Test (shard \${{ matrix.shard }}/${SHARDS})"
+        env:
+          SHARD: \${{ matrix.shard }}
         run: |
           cargo nextest run \\
             --workspace \\
-            --partition hash:\${{ matrix.shard }}/${SHARDS}
+            --partition "hash:\${SHARD}/${SHARDS}"
 
   # WHY: Gate merges on all shards passing. A single required status check
   # per "fan-in" job is simpler than listing N individual shard jobs in
@@ -160,10 +166,11 @@ jobs:
     if: always()
     steps:
       - name: Check all shards succeeded
+        env:
+          SHARD_RESULT: \${{ needs.test-shard.result }}
         run: |
-          result="\${{ needs.test-shard.result }}"
-          if [[ "\$result" != "success" ]]; then
-            printf 'One or more test shards failed (result: %s)\\n' "\$result" >&2
+          if [[ "\$SHARD_RESULT" != "success" ]]; then
+            printf 'One or more test shards failed (result: %s)\\n' "\$SHARD_RESULT" >&2
             exit 1
           fi
 YAML


### PR DESCRIPTION
## Summary

- **#1768** — Add `test-sharded.yml`: splits the workspace test suite across 4 parallel runners using `cargo-nextest --partition hash:M/N`. Tests are assigned by stable hash of their fully-qualified name (no overlap, no gaps). A fan-in job (`test-sharded-pass`) provides a single required status check regardless of shard count.
- **#1767** — Add `scripts/generate-workflows.sh`: `test-sharded.yml` is now generated from this script. Regenerate with `scripts/generate-workflows.sh --shards N` to change parallelism. The generated file carries a header preventing direct edits.
- **#1756** — Expand release matrix with two static musl targets: `x86_64-unknown-linux-musl` and `aarch64-unknown-linux-musl`. Both use `cross` and produce fully-static binaries (no glibc dependency) suitable for Alpine, minimal containers, and distro-agnostic distribution.

Closes #1768, #1767, #1756

## Test plan

- [ ] Verify `test-sharded.yml` triggers on `crates/**` changes and splits into 4 matrix jobs
- [ ] Verify `test-sharded-pass` fails if any shard fails
- [ ] Run `scripts/generate-workflows.sh --shards 2 --dry-run` — should print file path without writing
- [ ] Verify release workflow now includes `aletheia-linux-x86_64-musl` and `aletheia-linux-aarch64-musl` artifacts
- [ ] `shellcheck scripts/generate-workflows.sh` — no warnings

## Observations

- The existing `nightly.yml` uses `cargo test --workspace` (libtest runner) while the new sharded workflow uses nextest. If we ever want nightly to also benefit from sharding, that's a follow-up — nextest and libtest have slightly different output formats and the nightly job chains with audit/fmt/clippy in the same job, so sharding there would require a larger restructure.
- `embed-candle` feature in the release build may not compile cleanly under musl due to native library dependencies (BLAS, etc.). If CI red-flags the musl builds, the feature flag may need to be dropped for musl targets — left as a follow-up once we see the build results.
- The generator script currently only generates `test-sharded.yml`. Other workflows (release matrix, feature-isolation) are candidates for future generation if the matrix grows further.

🤖 Generated with [Claude Code](https://claude.com/claude-code)