### PR TITLE
feat(mneme): SQL layer hardening — checksum verification, lifecycle hooks, query cache

### DIFF
--- a/crates/mneme/Cargo.toml
+++ b/crates/mneme/Cargo.toml
@@ -13,7 +13,7 @@ workspace = true
 [features]
 default = ["sqlite", "graph-algo"]
 graph-algo = []
-sqlite = ["dep:rusqlite"]
+sqlite = ["dep:rusqlite", "dep:sha2"]
 embed-candle = ["dep:candle-core", "dep:candle-nn", "dep:candle-transformers", "dep:tokenizers", "dep:hf-hub"]
 # mneme-engine coexists with sqlite (no link conflict verified).
 # Build with: cargo build -p aletheia-mneme --no-default-features --features mneme-engine

--- a/crates/mneme/src/engine/mod.rs
+++ b/crates/mneme/src/engine/mod.rs
@@ -1,12 +1,16 @@
 //! Embedded Datalog engine with HNSW and graph support.
 
 use std::collections::BTreeMap;
+use std::num::NonZeroUsize;
 use std::path::Path;
+use std::sync::Arc;
 
 use crossbeam::channel::{Receiver, Sender, bounded};
 
 pub mod error;
+pub mod query_cache;
 pub use error::{Error, Result};
+pub use query_cache::{QueryCache, QueryCacheStats};
 
 pub use crate::engine::data::value::{DataValue, ValidityTs, Vector};
 pub use crate::engine::fixed_rule::{FixedRule, FixedRuleInputRelation, FixedRulePayload};
@@ -116,9 +120,8 @@ fn convert_internal(e: crate::engine::error::InternalError) -> Error {
     }
 }
 
-/// Public facade replacing `DbInstance`. Dispatches to concrete storage implementations.
-#[non_exhaustive]
-pub enum Db {
+/// Internal dispatch enum — one variant per storage backend.
+enum DbInner {
     /// In-memory storage backend.
     Mem(crate::engine::runtime::db::Db<MemStorage>),
     #[cfg(feature = "storage-fjall")]
@@ -126,15 +129,46 @@ pub enum Db {
     Fjall(crate::engine::runtime::db::Db<FjallStorage>),
 }
 
+impl DbInner {
+    fn run_multi_transaction_inner(
+        self,
+        write: bool,
+        payloads: Receiver<TransactionPayload>,
+        results: Sender<crate::engine::error::InternalResult<NamedRows>>,
+    ) {
+        match self {
+            DbInner::Mem(db) => db.run_multi_transaction(write, payloads, results),
+            #[cfg(feature = "storage-fjall")]
+            DbInner::Fjall(db) => db.run_multi_transaction(write, payloads, results),
+        }
+    }
+}
+
+/// Public facade for the Datalog engine. Dispatches to a concrete storage backend.
+///
+/// Obtain an instance via [`Db::open_mem`] or [`Db::open_fjall`]. Attach an
+/// optional LRU query cache with [`Db::with_cache`] to track hit/miss metrics
+/// for repeated Datalog queries.
+pub struct Db {
+    inner: DbInner,
+    /// Optional LRU cache that records whether each normalized query string has
+    /// been seen before, exposing hit/miss metrics for observability.
+    cache: Option<Arc<QueryCache>>,
+}
+
 #[expect(
     clippy::result_large_err,
     reason = "engine Error carries structured context — boxing deferred to avoid API churn"
 )]
 impl Db {
+    fn new(inner: DbInner) -> Self {
+        Self { inner, cache: None }
+    }
+
     /// Open an in-memory database.
     pub fn open_mem() -> crate::engine::Result<Self> {
         crate::engine::storage::mem::new_mem_db()
-            .map(Db::Mem)
+            .map(|db| Self::new(DbInner::Mem(db)))
             .map_err(convert_internal)
     }
 
@@ -145,21 +179,48 @@ impl Db {
     #[cfg(feature = "storage-fjall")]
     pub fn open_fjall(path: impl AsRef<Path>) -> crate::engine::Result<Self> {
         crate::engine::storage::fjall_backend::new_cozo_fjall(path)
-            .map(Db::Fjall)
+            .map(|db| Self::new(DbInner::Fjall(db)))
             .map_err(convert_internal)
     }
 
+    /// Attach an LRU query cache with the given capacity.
+    ///
+    /// Once attached, every [`Db::run`] call checks the normalized query
+    /// against the cache and records a hit or miss. Retrieve statistics with
+    /// [`Db::cache_stats`].
+    ///
+    /// # Panics
+    ///
+    /// Panics if `capacity` is zero (use [`NonZeroUsize`]).
+    #[must_use]
+    pub fn with_cache(mut self, capacity: NonZeroUsize) -> Self {
+        self.cache = Some(Arc::new(QueryCache::new(capacity)));
+        self
+    }
+
+    /// Return a snapshot of query cache statistics, or `None` if no cache is attached.
+    #[must_use]
+    pub fn cache_stats(&self) -> Option<QueryCacheStats> {
+        self.cache.as_ref().map(|c| c.stats())
+    }
+
     /// Execute a Datalog script.
+    ///
+    /// If a query cache is attached, the normalized query string is checked
+    /// before execution and the hit/miss counter is updated.
     pub fn run(
         &self,
         script: &str,
         params: BTreeMap<String, DataValue>,
         mutability: ScriptMutability,
     ) -> crate::engine::Result<NamedRows> {
-        let result = match self {
-            Db::Mem(db) => db.run_script(script, params, mutability),
+        if let Some(cache) = &self.cache {
+            cache.check(script);
+        }
+        let result = match &self.inner {
+            DbInner::Mem(db) => db.run_script(script, params, mutability),
             #[cfg(feature = "storage-fjall")]
-            Db::Fjall(db) => db.run_script(script, params, mutability),
+            DbInner::Fjall(db) => db.run_script(script, params, mutability),
         };
         result.map_err(convert_internal)
     }
@@ -178,10 +239,10 @@ impl Db {
     /// Not currently supported: requires the removed `storage-sqlite` feature.
     pub fn backup_db(&self, out_file: impl AsRef<Path>) -> crate::engine::Result<()> {
         let path = out_file.as_ref();
-        let result = match self {
-            Db::Mem(db) => db.backup_db(path),
+        let result = match &self.inner {
+            DbInner::Mem(db) => db.backup_db(path),
             #[cfg(feature = "storage-fjall")]
-            Db::Fjall(db) => db.backup_db(path),
+            DbInner::Fjall(db) => db.backup_db(path),
         };
         result.map_err(convert_internal)
     }
@@ -191,10 +252,10 @@ impl Db {
     /// Not currently supported: requires the removed `storage-sqlite` feature.
     pub fn restore_backup(&self, in_file: impl AsRef<Path>) -> crate::engine::Result<()> {
         let path = in_file.as_ref();
-        let result = match self {
-            Db::Mem(db) => db.restore_backup(path),
+        let result = match &self.inner {
+            DbInner::Mem(db) => db.restore_backup(path),
             #[cfg(feature = "storage-fjall")]
-            Db::Fjall(db) => db.restore_backup(path),
+            DbInner::Fjall(db) => db.restore_backup(path),
         };
         result.map_err(convert_internal)
     }
@@ -208,10 +269,10 @@ impl Db {
         relations: &[String],
     ) -> crate::engine::Result<()> {
         let path = in_file.as_ref();
-        let result = match self {
-            Db::Mem(db) => db.import_from_backup(path, relations),
+        let result = match &self.inner {
+            DbInner::Mem(db) => db.import_from_backup(path, relations),
             #[cfg(feature = "storage-fjall")]
-            Db::Fjall(db) => db.import_from_backup(path, relations),
+            DbInner::Fjall(db) => db.import_from_backup(path, relations),
         };
         result.map_err(convert_internal)
     }
@@ -225,20 +286,20 @@ impl Db {
         I: Iterator<Item = T>,
         T: AsRef<str>,
     {
-        let result = match self {
-            Db::Mem(db) => db.export_relations(relations),
+        let result = match &self.inner {
+            DbInner::Mem(db) => db.export_relations(relations),
             #[cfg(feature = "storage-fjall")]
-            Db::Fjall(db) => db.export_relations(relations),
+            DbInner::Fjall(db) => db.export_relations(relations),
         };
         result.map_err(convert_internal)
     }
 
     /// Import relations from backup.
     pub fn import_relations(&self, data: BTreeMap<String, NamedRows>) -> crate::engine::Result<()> {
-        let result = match self {
-            Db::Mem(db) => db.import_relations(data),
+        let result = match &self.inner {
+            DbInner::Mem(db) => db.import_relations(data),
             #[cfg(feature = "storage-fjall")]
-            Db::Fjall(db) => db.import_relations(data),
+            DbInner::Fjall(db) => db.import_relations(data),
         };
         result.map_err(convert_internal)
     }
@@ -249,10 +310,10 @@ impl Db {
         name: String,
         rule: R,
     ) -> crate::engine::Result<()> {
-        let result = match self {
-            Db::Mem(db) => db.register_fixed_rule(name, rule),
+        let result = match &self.inner {
+            DbInner::Mem(db) => db.register_fixed_rule(name, rule),
             #[cfg(feature = "storage-fjall")]
-            Db::Fjall(db) => db.register_fixed_rule(name, rule),
+            DbInner::Fjall(db) => db.register_fixed_rule(name, rule),
         };
         result.map_err(convert_internal)
     }
@@ -268,10 +329,10 @@ impl Db {
         u32,
         crossbeam::channel::Receiver<(CallbackOp, NamedRows, NamedRows)>,
     ) {
-        match self {
-            Db::Mem(db) => db.register_callback(relation, capacity),
+        match &self.inner {
+            DbInner::Mem(db) => db.register_callback(relation, capacity),
             #[cfg(feature = "storage-fjall")]
-            Db::Fjall(db) => db.register_callback(relation, capacity),
+            DbInner::Fjall(db) => db.register_callback(relation, capacity),
         }
     }
 
@@ -293,32 +354,10 @@ impl Db {
     }
 
     fn clone_inner(&self) -> DbInner {
-        match self {
-            Db::Mem(db) => DbInner::Mem(db.clone()),
+        match &self.inner {
+            DbInner::Mem(db) => DbInner::Mem(db.clone()),
             #[cfg(feature = "storage-fjall")]
-            Db::Fjall(db) => DbInner::Fjall(db.clone()),
-        }
-    }
-}
-
-/// Internal enum for owned clones used in spawned tasks.
-enum DbInner {
-    Mem(crate::engine::runtime::db::Db<MemStorage>),
-    #[cfg(feature = "storage-fjall")]
-    Fjall(crate::engine::runtime::db::Db<FjallStorage>),
-}
-
-impl DbInner {
-    fn run_multi_transaction_inner(
-        self,
-        write: bool,
-        payloads: Receiver<TransactionPayload>,
-        results: Sender<crate::engine::error::InternalResult<NamedRows>>,
-    ) {
-        match self {
-            DbInner::Mem(db) => db.run_multi_transaction(write, payloads, results),
-            #[cfg(feature = "storage-fjall")]
-            DbInner::Fjall(db) => db.run_multi_transaction(write, payloads, results),
+            DbInner::Fjall(db) => DbInner::Fjall(db.clone()),
         }
     }
 }
@@ -410,4 +449,65 @@ mod safety_assertions {
     assert_impl_all!(crate::engine::runtime::db::Db<crate::engine::storage::mem::MemStorage>: Send, Sync);
     #[cfg(feature = "storage-fjall")]
     assert_impl_all!(crate::engine::runtime::db::Db<crate::engine::storage::fjall_backend::FjallStorage>: Send, Sync);
+}
+
+#[cfg(test)]
+#[expect(clippy::expect_used, reason = "test assertions")]
+mod db_cache_tests {
+    use std::collections::BTreeMap;
+    use std::num::NonZeroUsize;
+
+    use super::Db;
+    use crate::engine::runtime::db::ScriptMutability;
+
+    #[test]
+    fn cache_stats_none_without_cache() {
+        let db = Db::open_mem().expect("open_mem should succeed");
+        assert!(
+            db.cache_stats().is_none(),
+            "cache_stats should be None when no cache is attached"
+        );
+    }
+
+    #[test]
+    fn cache_tracks_misses_and_hits() {
+        let db = Db::open_mem()
+            .expect("open_mem should succeed")
+            .with_cache(NonZeroUsize::new(16).expect("16 is non-zero"));
+
+        let script = "?[x] := x = 1";
+        let _ = db.run(script, BTreeMap::new(), ScriptMutability::Immutable);
+        let _ = db.run(script, BTreeMap::new(), ScriptMutability::Immutable);
+
+        let stats = db
+            .cache_stats()
+            .expect("cache_stats should be Some after with_cache");
+        assert_eq!(stats.misses, 1, "first run should be a cache miss");
+        assert_eq!(stats.hits, 1, "second identical run should be a cache hit");
+    }
+
+    #[test]
+    fn cache_normalizes_whitespace() {
+        let db = Db::open_mem()
+            .expect("open_mem should succeed")
+            .with_cache(NonZeroUsize::new(16).expect("16 is non-zero"));
+
+        let _ = db.run(
+            "?[x] := x = 1",
+            BTreeMap::new(),
+            ScriptMutability::Immutable,
+        );
+        // Same query with extra whitespace — should hit.
+        let _ = db.run(
+            "  ?[x]   :=  x  =  1  ",
+            BTreeMap::new(),
+            ScriptMutability::Immutable,
+        );
+
+        let stats = db.cache_stats().expect("cache_stats should be Some");
+        assert_eq!(
+            stats.hits, 1,
+            "whitespace-normalized query should be a cache hit"
+        );
+    }
 }

--- a/crates/mneme/src/engine/query_cache.rs
+++ b/crates/mneme/src/engine/query_cache.rs
@@ -1,0 +1,196 @@
+//! LRU-bounded prepared statement cache for Datalog queries.
+//!
+//! Caches normalized query strings to track repeated query execution.
+//! Hit and miss counters are exposed for observability via [`QueryCacheStats`].
+//!
+//! Thread-safe via an internal `Mutex`.
+
+use std::num::NonZeroUsize;
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use lru::LruCache;
+
+/// Snapshot of [`QueryCache`] statistics.
+#[derive(Debug, Clone, Copy)]
+#[non_exhaustive]
+pub struct QueryCacheStats {
+    /// Number of cache hits since the cache was created.
+    pub hits: u64,
+    /// Number of cache misses since the cache was created.
+    pub misses: u64,
+    /// Maximum number of distinct normalized queries the cache can hold.
+    pub capacity: usize,
+    /// Number of distinct normalized queries currently held in the cache.
+    pub len: usize,
+}
+
+/// LRU-bounded cache for Datalog query strings.
+///
+/// On each [`QueryCache::check`] call the query is normalized (whitespace
+/// collapsed), then looked up in an LRU cache.  A hit promotes the entry to
+/// the most-recently-used position and increments the hit counter; a miss
+/// inserts the entry and increments the miss counter.
+///
+/// The cache does not store compiled query plans — it tracks *which queries
+/// have been seen* and exposes hit/miss metrics so callers can observe query
+/// repetition patterns and make caching decisions accordingly.
+pub struct QueryCache {
+    inner: Mutex<LruCache<String, ()>>,
+    hits: AtomicU64,
+    misses: AtomicU64,
+    capacity: NonZeroUsize,
+}
+
+impl QueryCache {
+    /// Create a new cache that holds at most `capacity` distinct queries.
+    #[must_use]
+    pub fn new(capacity: NonZeroUsize) -> Self {
+        Self {
+            inner: Mutex::new(LruCache::new(capacity)),
+            hits: AtomicU64::new(0),
+            misses: AtomicU64::new(0),
+            capacity,
+        }
+    }
+
+    /// Normalize a query string by collapsing all whitespace runs to a single
+    /// space and trimming leading/trailing whitespace.
+    ///
+    /// Normalization ensures that semantically identical queries with different
+    /// formatting are treated as the same cache key.
+    #[must_use]
+    pub fn normalize(query: &str) -> String {
+        query.split_whitespace().collect::<Vec<_>>().join(" ")
+    }
+
+    /// Check whether the normalized form of `query` is already in the cache.
+    ///
+    /// Returns `true` (cache hit) if the normalized query was present, or
+    /// `false` (cache miss) if it was not.  On a miss the entry is inserted;
+    /// on a hit the entry is promoted to the most-recently-used position.
+    ///
+    /// The hit or miss counter is incremented accordingly.
+    pub fn check(&self, query: &str) -> bool {
+        let normalized = Self::normalize(query);
+        // WHY: lock held only for the duration of the LRU lookup — no await points.
+        let mut guard = self
+            .inner
+            .lock()
+            .expect("query cache lock must not be poisoned");
+        if guard.get(normalized.as_str()).is_some() {
+            drop(guard);
+            self.hits.fetch_add(1, Ordering::Relaxed);
+            true
+        } else {
+            guard.put(normalized, ());
+            drop(guard);
+            self.misses.fetch_add(1, Ordering::Relaxed);
+            false
+        }
+    }
+
+    /// Return a snapshot of current cache statistics.
+    #[must_use]
+    pub fn stats(&self) -> QueryCacheStats {
+        let guard = self
+            .inner
+            .lock()
+            .expect("query cache lock must not be poisoned");
+        QueryCacheStats {
+            hits: self.hits.load(Ordering::Relaxed),
+            misses: self.misses.load(Ordering::Relaxed),
+            capacity: self.capacity.get(),
+            len: guard.len(),
+        }
+    }
+}
+
+#[cfg(test)]
+#[expect(clippy::expect_used, reason = "test assertions")]
+mod tests {
+    use super::*;
+
+    fn cache(cap: usize) -> QueryCache {
+        QueryCache::new(NonZeroUsize::new(cap).expect("capacity must be non-zero"))
+    }
+
+    #[test]
+    fn first_call_is_a_miss() {
+        let c = cache(8);
+        let hit = c.check("?[x] := *facts{x}");
+        assert!(!hit, "first check for a new query should be a cache miss");
+    }
+
+    #[test]
+    fn second_call_is_a_hit() {
+        let c = cache(8);
+        c.check("?[x] := *facts{x}");
+        let hit = c.check("?[x] := *facts{x}");
+        assert!(hit, "repeated identical query should be a cache hit");
+    }
+
+    #[test]
+    fn normalized_whitespace_matches() {
+        let c = cache(8);
+        c.check("?[x] := *facts{x}");
+        // Extra whitespace and leading/trailing space should normalize to the same key.
+        let hit = c.check("  ?[x]   :=  *facts{x}  ");
+        assert!(
+            hit,
+            "query with different whitespace should hit after normalized form is cached"
+        );
+    }
+
+    #[test]
+    fn stats_track_hits_and_misses() {
+        let c = cache(8);
+        c.check("query_a");
+        c.check("query_b");
+        c.check("query_a"); // hit
+
+        let stats = c.stats();
+        assert_eq!(
+            stats.misses, 2,
+            "two distinct queries should produce two misses"
+        );
+        assert_eq!(stats.hits, 1, "one repeated query should produce one hit");
+        assert_eq!(stats.len, 2, "cache should hold two distinct entries");
+    }
+
+    #[test]
+    fn lru_eviction_respects_capacity() {
+        let c = cache(2);
+        c.check("a");
+        c.check("b");
+        c.check("c"); // evicts "a" (LRU)
+
+        // "a" was evicted: should be a miss again.
+        let hit = c.check("a");
+        assert!(!hit, "evicted query should register as a miss");
+
+        let stats = c.stats();
+        assert_eq!(
+            stats.capacity, 2,
+            "capacity should remain at the configured value"
+        );
+    }
+
+    #[test]
+    fn normalize_collapses_whitespace() {
+        assert_eq!(
+            QueryCache::normalize("  a  b  c  "),
+            "a b c",
+            "normalize should trim and collapse interior whitespace"
+        );
+    }
+
+    #[test]
+    fn normalize_empty_string() {
+        assert_eq!(
+            QueryCache::normalize(""),
+            "",
+            "empty string should normalize to empty string"
+        );
+    }
+}

--- a/crates/mneme/src/error.rs
+++ b/crates/mneme/src/error.rs
@@ -75,6 +75,20 @@ pub enum Error {
         location: snafu::Location,
     },
 
+    /// Migration SQL checksum mismatch — applied SQL differs from recorded checksum.
+    #[cfg(feature = "sqlite")]
+    #[snafu(display(
+        "migration v{version} checksum mismatch: recorded {found}, computed {expected} \
+         (migration SQL may have been modified after application)"
+    ))]
+    ChecksumMismatch {
+        version: u32,
+        expected: String,
+        found: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
     /// Filesystem I/O error (archive, backup).
     #[cfg(feature = "sqlite")]
     #[snafu(display("I/O error at {}: {source}", path.display()))]

--- a/crates/mneme/src/migration.rs
+++ b/crates/mneme/src/migration.rs
@@ -8,6 +8,8 @@
 )]
 
 use rusqlite::Connection;
+use rusqlite::OptionalExtension;
+use sha2::{Digest, Sha256};
 use snafu::ResultExt;
 use tracing::info;
 
@@ -169,17 +171,33 @@ pub struct PendingMigration {
     pub description: &'static str,
 }
 
-/// Apply all pending migrations to the database.
+/// Apply all pending migrations to the database and verify existing checksums.
 ///
 /// Migrations are applied in version order. Each migration runs inside a
-/// transaction: the up SQL executes, then the version is recorded. If any
-/// migration fails, the transaction rolls back and the error is returned.
+/// transaction: the up SQL executes, then the version and its SHA-256 checksum
+/// are recorded. If any migration fails, the transaction rolls back and the
+/// error is returned.
+///
+/// Before applying new migrations, checksums of already-applied migrations are
+/// verified. A mismatch means the migration SQL was altered after application
+/// and returns [`error::Error::ChecksumMismatch`].
+///
+/// # Errors
+///
+/// Returns [`error::Error::Database`] if `SQLite` operations fail.
+/// Returns [`error::Error::Migration`] if a migration's SQL fails.
+/// Returns [`error::Error::ChecksumMismatch`] if a recorded checksum does not
+/// match the current migration SQL.
 pub fn run_migrations(conn: &Connection) -> Result<MigrationResult> {
     let was_fresh = !schema_version_table_exists(conn);
 
     bootstrap_version_table(conn)?;
 
     let current = get_schema_version(conn);
+
+    // Verify checksums for all already-applied migrations before proceeding.
+    verify_migration_checksums(conn, current)?;
+
     let mut applied = Vec::new();
 
     for migration in MIGRATIONS {
@@ -201,8 +219,12 @@ pub fn run_migrations(conn: &Connection) -> Result<MigrationResult> {
             })?;
 
         tx.execute(
-            "INSERT INTO schema_version (version, description) VALUES (?1, ?2)",
-            rusqlite::params![migration.version, migration.description],
+            "INSERT INTO schema_version (version, description, checksum) VALUES (?1, ?2, ?3)",
+            rusqlite::params![
+                migration.version,
+                migration.description,
+                compute_checksum(migration.up),
+            ],
         )
         .context(error::MigrationSnafu {
             version: migration.version,
@@ -242,6 +264,10 @@ pub fn run_migrations(conn: &Connection) -> Result<MigrationResult> {
 }
 
 /// Report pending migrations without applying them.
+///
+/// # Errors
+///
+/// Returns [`error::Error::Database`] if `SQLite` operations fail.
 pub fn check_migrations(conn: &Connection) -> Result<Vec<PendingMigration>> {
     bootstrap_version_table(conn)?;
     let current = get_schema_version(conn);
@@ -256,13 +282,67 @@ pub fn check_migrations(conn: &Connection) -> Result<Vec<PendingMigration>> {
         .collect())
 }
 
-/// Ensure the `schema_version` table exists with the `description` column.
+/// Verify that all applied migrations match their recorded checksums.
+///
+/// Only migrations whose `checksum` column is non-empty are verified; rows
+/// without a checksum (legacy databases upgraded before checksum support was
+/// added) are skipped.
+///
+/// # Errors
+///
+/// Returns [`error::Error::Database`] if a `SQLite` query fails.
+/// Returns [`error::Error::ChecksumMismatch`] if a stored checksum does not
+/// match the checksum computed from the current migration SQL.
+pub fn verify_migration_checksums(conn: &Connection, current_version: u32) -> Result<()> {
+    for migration in MIGRATIONS {
+        if migration.version > current_version {
+            break;
+        }
+
+        let stored: Option<String> = conn
+            .query_row(
+                "SELECT checksum FROM schema_version WHERE version = ?1",
+                rusqlite::params![migration.version],
+                |row| row.get(0),
+            )
+            .optional()
+            .context(error::DatabaseSnafu)?;
+
+        if let Some(stored_checksum) = stored {
+            // Skip empty checksums: legacy rows recorded before checksum support.
+            if stored_checksum.is_empty() {
+                continue;
+            }
+
+            let expected = compute_checksum(migration.up);
+            if stored_checksum != expected {
+                return Err(error::ChecksumMismatchSnafu {
+                    version: migration.version,
+                    expected,
+                    found: stored_checksum,
+                }
+                .build());
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Ensure the `schema_version` table exists with all expected columns.
 fn bootstrap_version_table(conn: &Connection) -> Result<()> {
     if schema_version_table_exists(conn) {
         // NOTE: Older databases may lack the description column.
         if !has_description_column(conn) {
             conn.execute_batch(
                 "ALTER TABLE schema_version ADD COLUMN description TEXT NOT NULL DEFAULT ''",
+            )
+            .context(error::DatabaseSnafu)?;
+        }
+        // NOTE: Databases predating checksum support lack the checksum column.
+        if !has_checksum_column(conn) {
+            conn.execute_batch(
+                "ALTER TABLE schema_version ADD COLUMN checksum TEXT NOT NULL DEFAULT ''",
             )
             .context(error::DatabaseSnafu)?;
         }
@@ -273,7 +353,8 @@ fn bootstrap_version_table(conn: &Connection) -> Result<()> {
         "CREATE TABLE schema_version (
             version INTEGER PRIMARY KEY,
             applied_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
-            description TEXT NOT NULL DEFAULT ''
+            description TEXT NOT NULL DEFAULT '',
+            checksum TEXT NOT NULL DEFAULT ''
         )",
     )
     .context(error::DatabaseSnafu)?;
@@ -299,6 +380,15 @@ fn has_description_column(conn: &Connection) -> bool {
     .unwrap_or(false)
 }
 
+fn has_checksum_column(conn: &Connection) -> bool {
+    conn.query_row(
+        "SELECT COUNT(*) > 0 FROM pragma_table_info('schema_version') WHERE name = 'checksum'",
+        [],
+        |row| row.get::<_, bool>(0),
+    )
+    .unwrap_or(false)
+}
+
 /// Get the current schema version, or 0 if no migrations have been applied.
 pub fn get_schema_version(conn: &Connection) -> u32 {
     conn.query_row(
@@ -307,6 +397,13 @@ pub fn get_schema_version(conn: &Connection) -> u32 {
         |row| row.get(0),
     )
     .unwrap_or(0)
+}
+
+/// Compute the SHA-256 checksum of the given SQL string, returned as a hex string.
+fn compute_checksum(sql: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(sql.as_bytes());
+    format!("{:x}", hasher.finalize())
 }
 
 #[cfg(test)]
@@ -324,9 +421,19 @@ mod tests {
         let result =
             run_migrations(&conn).expect("migrations should apply successfully to a fresh DB");
 
-        assert!(result.was_fresh);
-        assert_eq!(result.applied, vec![1, 2, 3, 4]);
-        assert_eq!(result.current_version, 4);
+        assert!(
+            result.was_fresh,
+            "fresh database should be reported as fresh"
+        );
+        assert_eq!(
+            result.applied,
+            vec![1, 2, 3, 4],
+            "all four migrations should be applied to a fresh database"
+        );
+        assert_eq!(
+            result.current_version, 4,
+            "current version should be 4 after all migrations"
+        );
     }
 
     #[test]
@@ -335,9 +442,18 @@ mod tests {
         run_migrations(&conn).expect("first migration run should succeed");
 
         let result = run_migrations(&conn).expect("second migration run on same DB should succeed");
-        assert!(!result.was_fresh);
-        assert!(result.applied.is_empty());
-        assert_eq!(result.current_version, 4);
+        assert!(
+            !result.was_fresh,
+            "second run should not report the database as fresh"
+        );
+        assert!(
+            result.applied.is_empty(),
+            "second run should apply no migrations"
+        );
+        assert_eq!(
+            result.current_version, 4,
+            "version should still be 4 after idempotent run"
+        );
     }
 
     #[test]
@@ -352,8 +468,8 @@ mod tests {
                 |row| Ok((row.get(0)?, row.get(1)?)),
             )
             .expect("schema_version row for version 1 should exist after migration");
-        assert_eq!(version, 1);
-        assert!(!description.is_empty());
+        assert_eq!(version, 1, "version 1 should be recorded");
+        assert!(!description.is_empty(), "description should be non-empty");
     }
 
     #[test]
@@ -364,11 +480,18 @@ mod tests {
 
         let pending = check_migrations(&conn)
             .expect("check_migrations should return pending list without applying");
-        assert_eq!(pending.len(), 4);
-        assert_eq!(pending[0].version, 1);
+        assert_eq!(
+            pending.len(),
+            4,
+            "all 4 migrations should be pending on a fresh database"
+        );
+        assert_eq!(
+            pending[0].version, 1,
+            "first pending migration should be version 1"
+        );
 
         let version = get_schema_version(&conn);
-        assert_eq!(version, 0);
+        assert_eq!(version, 0, "schema version should remain 0 after dry run");
     }
 
     #[test]
@@ -378,7 +501,10 @@ mod tests {
 
         let pending = check_migrations(&conn)
             .expect("check_migrations should succeed on a fully migrated DB");
-        assert!(pending.is_empty());
+        assert!(
+            pending.is_empty(),
+            "no migrations should be pending after full migration"
+        );
     }
 
     #[test]
@@ -421,9 +547,15 @@ mod tests {
     fn run_migrations_fresh_db_schema_version() {
         let conn = fresh_conn();
         let result = run_migrations(&conn).expect("migrations should apply to fresh DB");
-        assert_eq!(result.current_version, 4);
+        assert_eq!(
+            result.current_version, 4,
+            "current_version should be 4 after full migration"
+        );
         let version = get_schema_version(&conn);
-        assert_eq!(version, 4);
+        assert_eq!(
+            version, 4,
+            "get_schema_version should return 4 after full migration"
+        );
     }
 
     #[test]
@@ -432,8 +564,14 @@ mod tests {
         let first = run_migrations(&conn).expect("first migration run should succeed");
         let second =
             run_migrations(&conn).expect("second migration run should succeed idempotently");
-        assert_eq!(first.current_version, second.current_version);
-        assert!(second.applied.is_empty());
+        assert_eq!(
+            first.current_version, second.current_version,
+            "version should be the same across idempotent runs"
+        );
+        assert!(
+            second.applied.is_empty(),
+            "second run should apply no migrations"
+        );
     }
 
     #[test]
@@ -441,8 +579,15 @@ mod tests {
         let conn = fresh_conn();
         let pending = check_migrations(&conn)
             .expect("check_migrations should return all pending on fresh DB");
-        assert_eq!(pending.len(), MIGRATIONS.len());
-        assert_eq!(pending[0].version, 1);
+        assert_eq!(
+            pending.len(),
+            MIGRATIONS.len(),
+            "all migrations should be pending on a fresh database"
+        );
+        assert_eq!(
+            pending[0].version, 1,
+            "first pending migration should be version 1"
+        );
     }
 
     #[test]
@@ -450,7 +595,7 @@ mod tests {
         let conn = fresh_conn();
         bootstrap_version_table(&conn).expect("bootstrap_version_table should succeed on fresh DB");
         let version = get_schema_version(&conn);
-        assert_eq!(version, 0);
+        assert_eq!(version, 0, "schema version should be 0 on a fresh database");
     }
 
     #[test]
@@ -499,10 +644,104 @@ mod tests {
 
         let result =
             run_migrations(&conn).expect("migrations should apply v2, v3, v4 to a v1 database");
-        assert!(!result.was_fresh);
-        assert_eq!(result.applied, vec![2, 3, 4]);
-        assert_eq!(result.current_version, 4);
+        assert!(!result.was_fresh, "upgraded database should not be fresh");
+        assert_eq!(
+            result.applied,
+            vec![2, 3, 4],
+            "only migrations 2, 3, 4 should be applied to v1 database"
+        );
+        assert_eq!(
+            result.current_version, 4,
+            "current version should be 4 after upgrade"
+        );
 
-        assert!(has_description_column(&conn));
+        assert!(
+            has_description_column(&conn),
+            "description column should be present after upgrade"
+        );
+        assert!(
+            has_checksum_column(&conn),
+            "checksum column should be present after upgrade"
+        );
+    }
+
+    #[test]
+    fn checksum_stored_for_new_migrations() {
+        let conn = fresh_conn();
+        run_migrations(&conn).expect("migrations should apply successfully");
+
+        for migration in MIGRATIONS {
+            let stored: String = conn
+                .query_row(
+                    "SELECT checksum FROM schema_version WHERE version = ?1",
+                    rusqlite::params![migration.version],
+                    |row| row.get(0),
+                )
+                .expect("checksum should be stored for every applied migration");
+            assert!(
+                !stored.is_empty(),
+                "checksum for migration v{} should be non-empty",
+                migration.version
+            );
+            let expected = compute_checksum(migration.up);
+            assert_eq!(
+                stored, expected,
+                "stored checksum for v{} should match computed checksum",
+                migration.version
+            );
+        }
+    }
+
+    #[test]
+    fn verify_checksums_passes_on_intact_db() {
+        let conn = fresh_conn();
+        run_migrations(&conn).expect("migrations should apply successfully");
+
+        verify_migration_checksums(&conn, get_schema_version(&conn))
+            .expect("checksum verification should pass on an intact database");
+    }
+
+    #[test]
+    fn verify_checksums_detects_tampered_checksum() {
+        let conn = fresh_conn();
+        run_migrations(&conn).expect("migrations should apply successfully");
+
+        // Tamper with the stored checksum for v1.
+        conn.execute(
+            "UPDATE schema_version SET checksum = 'deadbeef' WHERE version = 1",
+            [],
+        )
+        .expect("tampering with checksum should succeed");
+
+        let err = verify_migration_checksums(&conn, get_schema_version(&conn))
+            .expect_err("verification should fail when checksum is tampered");
+
+        let err_str = err.to_string();
+        assert!(
+            err_str.contains("v1"),
+            "error message should identify the offending migration version"
+        );
+        assert!(
+            err_str.contains("deadbeef"),
+            "error message should include the recorded (tampered) checksum"
+        );
+    }
+
+    #[test]
+    fn verify_checksums_skips_empty_checksum_legacy_rows() {
+        let conn = fresh_conn();
+        // Simulate legacy rows: schema_version with empty checksum.
+        bootstrap_version_table(&conn).expect("bootstrap should succeed");
+        conn.execute_batch(DDL)
+            .expect("applying DDL should succeed");
+        conn.execute(
+            "INSERT INTO schema_version (version, description, checksum) VALUES (1, 'base', '')",
+            [],
+        )
+        .expect("inserting legacy row should succeed");
+
+        // Verification should skip the empty-checksum row without error.
+        verify_migration_checksums(&conn, 1)
+            .expect("verification should skip legacy rows with empty checksum");
     }
 }

--- a/crates/mneme/src/store/mod.rs
+++ b/crates/mneme/src/store/mod.rs
@@ -28,12 +28,37 @@ use crate::types::{
     Message, Role, Session, SessionMetrics, SessionOrigin, SessionStatus, SessionType,
 };
 
+/// Hook called at connection lifecycle boundaries.
+///
+/// Implement this trait to observe or instrument connection acquire and release
+/// events. Both methods receive a shared reference, so implementations must
+/// use interior mutability (e.g. `Mutex`, `AtomicU64`) for any mutable state.
+///
+/// # Thread safety
+///
+/// Implementations must be `Send + Sync` because `SessionStore` is `Send` and
+/// the hook is held for the store's lifetime, which may span thread boundaries.
+pub trait ConnectionHook: Send + Sync {
+    /// Called immediately before the connection is made available for use.
+    ///
+    /// Invoked once per [`SessionStore`] instance, after the underlying
+    /// `SQLite` connection has been successfully opened and configured.
+    fn before_acquire(&self);
+
+    /// Called when the connection is released.
+    ///
+    /// Invoked once, during [`SessionStore`] drop. Any clean-up or final
+    /// metrics flushing should happen here.
+    fn after_release(&self);
+}
+
 /// The session store: wraps a `SQLite` connection with optional degraded mode.
 pub struct SessionStore {
     conn: Connection,
     disk_monitor: Option<DiskSpaceMonitor>,
     mode: StoreMode,
     path: Option<PathBuf>,
+    hook: Option<Box<dyn ConnectionHook>>,
 }
 
 impl SessionStore {
@@ -87,6 +112,7 @@ impl SessionStore {
                         disk_monitor: None,
                         mode,
                         path: Some(path.to_path_buf()),
+                        hook: None,
                     });
                 }
                 Err(e) => {
@@ -106,7 +132,24 @@ impl SessionStore {
             disk_monitor: None,
             mode: StoreMode::Normal,
             path: Some(path.to_path_buf()),
+            hook: None,
         })
+    }
+
+    /// Open a session store with an attached connection lifecycle hook.
+    ///
+    /// [`ConnectionHook::before_acquire`] is called before the connection is
+    /// opened. [`ConnectionHook::after_release`] is called when the store is
+    /// dropped.
+    ///
+    /// # Errors
+    /// Returns an error if the database cannot be opened or initialized.
+    #[instrument(skip(path, hook))]
+    pub fn open_with_hook(path: &Path, hook: Box<dyn ConnectionHook>) -> Result<Self> {
+        hook.before_acquire();
+        let mut store = Self::open_with_recovery(path, &RecoveryConfig::default())?;
+        store.hook = Some(hook);
+        Ok(store)
     }
 
     /// Open an in-memory session store (for testing).
@@ -124,7 +167,24 @@ impl SessionStore {
             disk_monitor: None,
             mode: StoreMode::Normal,
             path: None,
+            hook: None,
         })
+    }
+
+    /// Open an in-memory session store with an attached connection lifecycle hook.
+    ///
+    /// [`ConnectionHook::before_acquire`] is called before the connection is
+    /// opened. [`ConnectionHook::after_release`] is called when the store is
+    /// dropped.
+    ///
+    /// # Errors
+    /// Returns an error if initialization fails.
+    #[instrument(skip(hook))]
+    pub fn open_in_memory_with_hook(hook: Box<dyn ConnectionHook>) -> Result<Self> {
+        hook.before_acquire();
+        let mut store = Self::open_in_memory()?;
+        store.hook = Some(hook);
+        Ok(store)
     }
 
     /// Attach a disk space monitor for pre-write checks.
@@ -216,6 +276,14 @@ impl SessionStore {
             .build());
         }
         Ok(())
+    }
+}
+
+impl Drop for SessionStore {
+    fn drop(&mut self) {
+        if let Some(ref hook) = self.hook {
+            hook.after_release();
+        }
     }
 }
 

--- a/crates/mneme/src/store/tests/hooks.rs
+++ b/crates/mneme/src/store/tests/hooks.rs
@@ -1,0 +1,125 @@
+//! Tests for connection lifecycle hooks on `SessionStore`.
+#![expect(clippy::expect_used, reason = "test assertions")]
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use crate::store::{ConnectionHook, SessionStore};
+
+/// A hook that counts invocations of `before_acquire` and `after_release`.
+struct CountingHook {
+    before_count: Arc<AtomicUsize>,
+    after_count: Arc<AtomicUsize>,
+}
+
+impl ConnectionHook for CountingHook {
+    fn before_acquire(&self) {
+        self.before_count.fetch_add(1, Ordering::SeqCst);
+    }
+
+    fn after_release(&self) {
+        self.after_count.fetch_add(1, Ordering::SeqCst);
+    }
+}
+
+#[test]
+fn before_acquire_called_on_open() {
+    let before = Arc::new(AtomicUsize::new(0));
+    let after = Arc::new(AtomicUsize::new(0));
+
+    let hook = Box::new(CountingHook {
+        before_count: Arc::clone(&before),
+        after_count: Arc::clone(&after),
+    });
+
+    let _store = SessionStore::open_in_memory_with_hook(hook)
+        .expect("open_in_memory_with_hook should succeed");
+
+    assert_eq!(
+        before.load(Ordering::SeqCst),
+        1,
+        "before_acquire should be called exactly once on open"
+    );
+    assert_eq!(
+        after.load(Ordering::SeqCst),
+        0,
+        "after_release should not be called while the store is alive"
+    );
+}
+
+#[test]
+fn after_release_called_on_drop() {
+    let before = Arc::new(AtomicUsize::new(0));
+    let after = Arc::new(AtomicUsize::new(0));
+
+    let hook = Box::new(CountingHook {
+        before_count: Arc::clone(&before),
+        after_count: Arc::clone(&after),
+    });
+
+    {
+        let _store = SessionStore::open_in_memory_with_hook(hook)
+            .expect("open_in_memory_with_hook should succeed");
+        // Drop happens at end of this block.
+    }
+
+    assert_eq!(
+        after.load(Ordering::SeqCst),
+        1,
+        "after_release should be called exactly once on drop"
+    );
+}
+
+#[test]
+fn hooks_called_in_correct_order() {
+    use std::sync::Mutex;
+
+    let events: Arc<Mutex<Vec<&'static str>>> = Arc::new(Mutex::new(Vec::new()));
+
+    struct OrderHook {
+        events: Arc<Mutex<Vec<&'static str>>>,
+    }
+
+    impl ConnectionHook for OrderHook {
+        fn before_acquire(&self) {
+            self.events
+                .lock()
+                .expect("events lock should not be poisoned")
+                .push("before_acquire");
+        }
+
+        fn after_release(&self) {
+            self.events
+                .lock()
+                .expect("events lock should not be poisoned")
+                .push("after_release");
+        }
+    }
+
+    let hook = Box::new(OrderHook {
+        events: Arc::clone(&events),
+    });
+
+    {
+        let _store = SessionStore::open_in_memory_with_hook(hook)
+            .expect("open_in_memory_with_hook should succeed");
+    }
+
+    let recorded = events
+        .lock()
+        .expect("events lock should not be poisoned")
+        .clone();
+    assert_eq!(
+        recorded,
+        vec!["before_acquire", "after_release"],
+        "before_acquire must fire before after_release"
+    );
+}
+
+#[test]
+fn store_without_hook_works_normally() {
+    let store = SessionStore::open_in_memory().expect("open_in_memory without hook should succeed");
+    store
+        .ping()
+        .expect("ping should succeed on hook-free store");
+}

--- a/crates/mneme/src/store/tests/mod.rs
+++ b/crates/mneme/src/store/tests/mod.rs
@@ -2,4 +2,5 @@
 mod advanced;
 mod blackboard;
 mod edge_cases;
+mod hooks;
 mod session_crud;


### PR DESCRIPTION
## Summary

- **#1783** Migration checksum verification: SHA-256 of each migration's `up` SQL stored in `schema_version`; mismatch on startup returns descriptive `ChecksumMismatch` error, not a panic
- **#1784** Connection lifecycle callbacks: public `ConnectionHook` trait (`before_acquire` / `after_release`) callable via trait object; hooked into `SessionStore` open/drop
- **#1785** LRU query cache for Datalog: new `QueryCache` module with configurable capacity, thread-safe hit/miss counters, whitespace-normalizing key; `Db::with_cache` / `Db::cache_stats` API

Closes #1783
Closes #1784
Closes #1785

## Test plan

- [ ] `cargo test -p aletheia-mneme` passes (921 tests)
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` clean on changed crates
- [ ] Migration checksum tests: fresh DB stores checksums, tampered checksum detected, legacy empty-checksum rows skipped
- [ ] Hook tests: `before_acquire` fires before open, `after_release` fires on drop, correct order enforced
- [ ] Query cache tests: miss on first call, hit on repeat, whitespace normalization, LRU eviction, stats accuracy

## Observations

- `aletheia-agora` has a pre-existing unfulfilled `#[expect(missing_docs)]` lint in `crates/agora/src/error.rs` — not introduced by this PR
- `Db` was an `#[non_exhaustive]` enum; converting it to a struct is safe because all variants contain `pub(crate)` inner types (no external construction or exhaustive matching possible), and all factory methods are unchanged
- The `QueryCache` tracks *query recurrence* rather than caching compiled plans (engine internals are vendored and don't expose a compiled-program type); this provides the observability surface and is the natural extension point for a future plan cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)