### PR TITLE
fix(taxis,organon): status false-negative, sandbox HOME default, init pricing camelCase

### DIFF
--- a/crates/aletheia/src/commands/server/setup.rs
+++ b/crates/aletheia/src/commands/server/setup.rs
@@ -147,6 +147,7 @@ pub(super) fn build_tool_registry(
             }
             _ => aletheia_organon::sandbox::SandboxEnforcement::Permissive,
         },
+        allowed_root: sandbox_settings.allowed_root.clone(),
         extra_read_paths: sandbox_settings.extra_read_paths.clone(),
         extra_write_paths: sandbox_settings.extra_write_paths.clone(),
         extra_exec_paths: sandbox_settings.extra_exec_paths.clone(),

--- a/crates/aletheia/src/init/scaffold.rs
+++ b/crates/aletheia/src/init/scaffold.rs
@@ -248,8 +248,8 @@ workspace = "{workspace}"
 
 # --- Cost tracking ---
 [pricing.{model}]
-input_cost_per_mtok = 3.0
-output_cost_per_mtok = 15.0
+inputCostPerMtok = 3.0
+outputCostPerMtok = 15.0
 
 # --- Credentials ---
 [credential]

--- a/crates/aletheia/src/status.rs
+++ b/crates/aletheia/src/status.rs
@@ -357,4 +357,28 @@ mod tests {
         let bytes = 1_610_612_736_u64; // 1.5 GB
         assert_eq!(format_bytes(bytes), "1.5 GB");
     }
+
+    /// Verify that `print_storage` shows file sizes (not the "not found" message)
+    /// when the instance `data/` directory exists.
+    ///
+    /// WHY: previously, `Oikos::discover()` did not canonicalize the discovered
+    /// path, so `oikos.data().exists()` returned false for a valid instance when
+    /// run from a different working directory: closes #1829.
+    #[test]
+    #[expect(clippy::expect_used, reason = "test assertions")]
+    fn print_storage_reports_files_for_valid_instance() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        std::fs::create_dir_all(dir.path().join("data")).expect("create data dir");
+
+        let oikos = aletheia_taxis::oikos::Oikos::from_root(dir.path());
+
+        // Capture stdout to verify the output does not contain the error message.
+        // We cannot easily capture println! output in unit tests, so we verify the
+        // underlying predicate used by print_storage directly.
+        assert!(
+            oikos.data().exists(),
+            "oikos.data() must exist for a valid instance; \
+             print_storage would otherwise show '(data directory not found)'"
+        );
+    }
 }

--- a/crates/organon/src/sandbox/config.rs
+++ b/crates/organon/src/sandbox/config.rs
@@ -59,6 +59,15 @@ pub struct SandboxConfig {
     pub enabled: bool,
     /// Enforcement level: `enforcing` blocks violations, `permissive` logs them.
     pub enforcement: SandboxEnforcement,
+    /// Default filesystem root granted read access.
+    ///
+    /// Defaults to `~` which expands to the HOME environment variable at
+    /// policy-build time. Operators can set this to a stricter path to
+    /// prevent agents from reading files outside a specific directory.
+    ///
+    /// WHY: without a home-directory default, agents cannot read user files
+    /// (dotfiles, project repos, etc.) even in permissive mode: closes #1823.
+    pub allowed_root: PathBuf,
     /// Additional filesystem paths granted read access.
     pub extra_read_paths: Vec<PathBuf>,
     /// Additional filesystem paths granted read+write access.
@@ -84,6 +93,7 @@ impl Default for SandboxConfig {
         Self {
             enabled: true,
             enforcement: SandboxEnforcement::Permissive,
+            allowed_root: PathBuf::from("~"),
             extra_read_paths: Vec::new(),
             extra_write_paths: Vec::new(),
             extra_exec_paths: Vec::new(),
@@ -190,6 +200,13 @@ impl SandboxConfig {
             if !exec_paths.contains(root) {
                 exec_paths.push(root.clone());
             }
+        }
+
+        // WHY: allowed_root is the operator-configured default read root (defaults
+        // to HOME). Expand tilde so config files can use `~` portably: closes #1823.
+        let expanded_allowed_root = expand_tilde(&self.allowed_root);
+        if !read_paths.contains(&expanded_allowed_root) {
+            read_paths.push(expanded_allowed_root);
         }
 
         read_paths.extend(self.extra_read_paths.iter().cloned());

--- a/crates/organon/src/sandbox/tests/mod.rs
+++ b/crates/organon/src/sandbox/tests/mod.rs
@@ -62,6 +62,7 @@ fn config_serde_roundtrip() {
     let config = SandboxConfig {
         enabled: true,
         enforcement: SandboxEnforcement::Permissive,
+        allowed_root: PathBuf::from("~"),
         extra_read_paths: vec![PathBuf::from("/opt/data")],
         extra_write_paths: vec![PathBuf::from("/var/cache")],
         extra_exec_paths: vec![PathBuf::from("/opt/scripts")],

--- a/crates/taxis/src/config/maintenance.rs
+++ b/crates/taxis/src/config/maintenance.rs
@@ -217,6 +217,14 @@ pub struct SandboxSettings {
     pub enabled: bool,
     /// Enforcement level: `enforcing` blocks violations, `permissive` logs them.
     pub enforcement: SandboxEnforcementMode,
+    /// Default filesystem root granted read access.
+    ///
+    /// Defaults to `~` (HOME). Operators can set this to a stricter path.
+    /// The `~` prefix is expanded to the HOME environment variable at runtime.
+    ///
+    /// WHY: without a home-directory default, agents cannot read user files:
+    /// closes #1823.
+    pub allowed_root: PathBuf,
     /// Additional filesystem paths granted read access.
     pub extra_read_paths: Vec<PathBuf>,
     /// Additional filesystem paths granted read+write access.
@@ -237,6 +245,7 @@ impl Default for SandboxSettings {
         Self {
             enabled: true,
             enforcement: SandboxEnforcementMode::Permissive,
+            allowed_root: PathBuf::from("~"),
             extra_read_paths: Vec::new(),
             extra_write_paths: Vec::new(),
             extra_exec_paths: Vec::new(),

--- a/crates/taxis/src/oikos.rs
+++ b/crates/taxis/src/oikos.rs
@@ -57,12 +57,17 @@ impl Oikos {
     ///
     /// This variant is the primary implementation; [`Oikos::discover`] is a
     /// convenience wrapper that passes [`RealSystem`].
+    ///
+    /// WHY: delegates to `from_root` so the discovered path is canonicalized
+    /// when it exists. This ensures existence checks (e.g. `print_storage` in
+    /// `aletheia status`) are cwd-independent and work with non-default paths
+    /// and symlinks: closes #1829.
     #[must_use]
     pub fn discover_with(env: &impl Environment) -> Self {
         let root = env
             .var("ALETHEIA_ROOT")
             .map_or_else(|| PathBuf::from("instance"), PathBuf::from);
-        Self { root }
+        Self::from_root(root)
     }
 
     /// The instance root directory.


### PR DESCRIPTION
## Summary

- **#1829**: `Oikos::discover_with` now delegates to `from_root`, canonicalizing the path when it exists. Previously the raw (possibly relative) path bypassed canonicalization, causing `oikos.data().exists()` to return `false` when `aletheia status` was run from a different working directory. Adds a unit test covering the valid-instance case in `status.rs`.
- **#1823**: Added `allowed_root: PathBuf` field to `SandboxConfig` (organon) and `SandboxSettings` (taxis) defaulting to `~` (expanded to `$HOME` at build-policy time). Without this, agents could not read user files even in permissive mode. Wired through `build_tool_registry` in `setup.rs`.
- **#1817**: `aletheia init` now generates pricing TOML keys in camelCase (`inputCostPerMtok`, `outputCostPerMtok`) to match the `#[serde(rename_all = "camelCase")]` derive on `ModelPricing`. The previous snake_case keys were silently ignored by the parser.

## Test plan

- [ ] `cargo test -p aletheia-taxis -p aletheia-organon -p aletheia` — all pass
- [ ] `cargo test --workspace` — no new failures (pre-existing failures in `aletheia-nous` proptest and chiron tests are unrelated to this PR)
- [ ] `Oikos::discover_with` test (`discover_with_falls_back_to_instance_when_unset`) still passes — canonicalize falls back to raw path when dir does not exist
- [ ] New test `print_storage_reports_files_for_valid_instance` verifies that `oikos.data().exists()` returns `true` for a temp dir instance

## Observations

- `crates/aletheia/src/commands/maintenance.rs`: `clippy::too_many_lines` (104/100) — pre-existing, not introduced by this PR, out of blast radius.
- `crates/nous/src/chiron/`: unfulfilled `expect_used` lint and `proptest_budget` unfulfilled lints — pre-existing, unrelated.

Closes #1829, #1823, #1817

🤖 Generated with [Claude Code](https://claude.com/claude-code)