### PR TITLE
feat(theatron): ops pane redesign, credential display, and spawn instrumentation

### DIFF
--- a/crates/aletheia/src/commands/server/tracing_setup.rs
+++ b/crates/aletheia/src/commands/server/tracing_setup.rs
@@ -26,6 +26,7 @@ use aletheia_taxis::oikos::Oikos;
 pub(super) fn spawn_log_retention(log_dir: PathBuf, retention_days: u32, token: CancellationToken) {
     use aletheia_oikonomos::maintenance::{TraceRotationConfig, TraceRotator};
 
+    let span = tracing::info_span!("log_retention", retention_days, dir = %log_dir.display());
     tokio::spawn(
         async move {
             loop {
@@ -71,7 +72,7 @@ pub(super) fn spawn_log_retention(log_dir: PathBuf, retention_days: u32, token: 
                 }
             }
         }
-        .instrument(tracing::info_span!("log_retention")),
+        .instrument(span),
     );
 }
 

--- a/crates/nous/src/cross/mod.rs
+++ b/crates/nous/src/cross/mod.rs
@@ -609,10 +609,13 @@ mod tests {
         let msg =
             CrossNousMessage::new("sender_c", "target", "hello").with_reply(Duration::from_secs(5));
 
-        let ask_handle = tokio::spawn({
-            let r = router.clone();
-            async move { r.ask(msg).await }
-        });
+        let ask_handle = tokio::spawn(
+            {
+                let r = router.clone();
+                async move { r.ask(msg).await }
+            }
+            .instrument(tracing::info_span!("test_ask_multi_receiver")),
+        );
 
         let envelope = rx.recv().await.unwrap();
         let reply = CrossNousReply {

--- a/crates/nous/src/manager.rs
+++ b/crates/nous/src/manager.rs
@@ -418,7 +418,10 @@ impl NousManager {
                     }
                 }
             }
-            .instrument(tracing::info_span!("health_poller")),
+            .instrument(tracing::info_span!(
+                "health_poller",
+                interval_secs = interval.as_secs()
+            )),
         )
     }
 

--- a/crates/pylon/src/handlers/sessions/streaming.rs
+++ b/crates/pylon/src/handlers/sessions/streaming.rs
@@ -144,7 +144,9 @@ pub async fn send_message(
                 drop(tx);
                 let stream = GuardedStream {
                     inner: ReceiverStream::new(rx).map(sse_event_to_axum),
-                    _guard: AbortOnDrop(tokio::spawn(async {})),
+                    _guard: AbortOnDrop(tokio::spawn(
+                        async {}.instrument(tracing::info_span!("idempotent_noop")),
+                    )),
                 };
                 return Ok(Sse::new(stream).keep_alive(
                     KeepAlive::new()

--- a/crates/theatron/tui/src/actions.rs
+++ b/crates/theatron/tui/src/actions.rs
@@ -23,7 +23,7 @@ impl App {
                 let client = self.client.clone();
                 let session_id = session_id.clone();
                 let text = text.to_string();
-                let span = tracing::info_span!("queue_message");
+                let span = tracing::info_span!("queue_message", %session_id);
                 tokio::spawn(
                     async move {
                         if let Err(e) = client.queue_message(&session_id, &text).await {

--- a/crates/theatron/tui/src/api/sse.rs
+++ b/crates/theatron/tui/src/api/sse.rs
@@ -29,7 +29,7 @@ impl SseConnection {
         let (tx, rx) = mpsc::channel(256);
         let url = format!("{}/api/v1/events", base_url.trim_end_matches('/'));
 
-        let span = tracing::info_span!("sse_connection");
+        let span = tracing::info_span!("sse_connection", %url);
         let handle = tokio::spawn(
             async move {
                 let mut backoff_secs: u64 = 1;

--- a/crates/theatron/tui/src/api/streaming.rs
+++ b/crates/theatron/tui/src/api/streaming.rs
@@ -37,7 +37,11 @@ pub fn stream_message(
         .json(&body)
         .header("Accept", CONTENT_TYPE_EVENT_STREAM);
 
-    let span = tracing::info_span!("stream_message");
+    let span = tracing::info_span!(
+        "stream_message",
+        nous.id = nous_id,
+        session.key = session_key
+    );
     tokio::spawn(
         async move {
             let resp = match builder.send().await {

--- a/crates/theatron/tui/src/app/test_helpers.rs
+++ b/crates/theatron/tui/src/app/test_helpers.rs
@@ -17,6 +17,7 @@ pub fn test_app() -> App {
         bell: false,
         keybindings: HashMap::new(),
         theme: None,
+        credential_label: crate::config::CredentialLabel::None,
     };
     let client = ApiClient::new(
         &config.url,

--- a/crates/theatron/tui/src/config.rs
+++ b/crates/theatron/tui/src/config.rs
@@ -11,6 +11,39 @@ use crate::theme::ThemeMode;
 
 const DEFAULT_URL: &str = "http://localhost:18789";
 
+/// Prefix for OAuth access tokens issued by the Anthropic identity provider.
+const OAUTH_TOKEN_PREFIX: &str = "sk-ant-oat";
+
+/// Display label for the credential type shown in the TUI status bar.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CredentialLabel {
+    /// OAuth token (auto-refreshable via Claude Code credential chain).
+    OAuthToken,
+    /// Static API key (no refresh capability).
+    StaticApiKey,
+    /// No credential configured.
+    None,
+}
+
+impl std::fmt::Display for CredentialLabel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::OAuthToken => write!(f, "OAuth token"),
+            Self::StaticApiKey => write!(f, "static API key"),
+            Self::None => write!(f, "no credential"),
+        }
+    }
+}
+
+/// Detect the credential type from a token string.
+pub fn detect_credential_label(token: Option<&str>) -> CredentialLabel {
+    match token {
+        Some(t) if t.starts_with(OAUTH_TOKEN_PREFIX) => CredentialLabel::OAuthToken,
+        Some(_) => CredentialLabel::StaticApiKey,
+        None => CredentialLabel::None,
+    }
+}
+
 #[derive(Clone, Default, Serialize, Deserialize)]
 pub struct ConfigFile {
     pub url: Option<String>,
@@ -51,6 +84,8 @@ pub struct Config {
     pub keybindings: HashMap<String, String>,
     /// Explicit theme override. `None` means auto-detect from terminal.
     pub theme: Option<ThemeMode>,
+    /// Detected credential type for status bar display.
+    pub credential_label: CredentialLabel,
 }
 
 impl std::fmt::Debug for Config {
@@ -92,17 +127,21 @@ impl Config {
             _ => None,
         });
 
+        let resolved_token = cli_token.or(file_config.token);
+        let credential_label = detect_credential_label(resolved_token.as_deref());
+
         Ok(Config {
             url: cli_url
                 .or(file_config.url)
                 .unwrap_or_else(|| DEFAULT_URL.to_string()),
-            token: cli_token.or(file_config.token).map(SecretString::from),
+            token: resolved_token.map(SecretString::from),
             default_agent: cli_agent.or(file_config.default_agent),
             default_session: cli_session.or(file_config.default_session),
             workspace_root,
             bell: file_config.bell.unwrap_or(false),
             keybindings: file_config.keybindings.unwrap_or_default(),
             theme,
+            credential_label,
         })
     }
 
@@ -231,5 +270,44 @@ mod tests {
         // workspace_root may be None (no file) or Some (if tui.toml has workspace_root).
         // The load succeeds either way.
         let _ = config.workspace_root;
+    }
+
+    #[test]
+    fn detect_oauth_token() {
+        assert_eq!(
+            detect_credential_label(Some("sk-ant-oat-abc123")),
+            CredentialLabel::OAuthToken
+        );
+    }
+
+    #[test]
+    fn detect_static_api_key() {
+        assert_eq!(
+            detect_credential_label(Some("sk-ant-api01-abc123")),
+            CredentialLabel::StaticApiKey
+        );
+    }
+
+    #[test]
+    fn detect_no_credential() {
+        assert_eq!(detect_credential_label(None), CredentialLabel::None);
+    }
+
+    #[test]
+    fn config_load_detects_oauth_credential() {
+        let config = Config::load(None, Some("sk-ant-oat-test123".into()), None, None).unwrap();
+        assert_eq!(config.credential_label, CredentialLabel::OAuthToken);
+    }
+
+    #[test]
+    fn config_load_detects_static_credential() {
+        let config = Config::load(None, Some("sk-ant-api01-test".into()), None, None).unwrap();
+        assert_eq!(config.credential_label, CredentialLabel::StaticApiKey);
+    }
+
+    #[test]
+    fn config_load_no_credential() {
+        let config = Config::load(None, None, None, None).unwrap();
+        assert_eq!(config.credential_label, CredentialLabel::None);
     }
 }

--- a/crates/theatron/tui/src/state/ops.rs
+++ b/crates/theatron/tui/src/state/ops.rs
@@ -16,6 +16,120 @@ pub enum OpsToolStatus {
     Failed,
 }
 
+/// Tool category for grouping calls by type in the ops pane KPI display.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ToolCategory {
+    /// File reads: read_file, glob, grep, etc.
+    Read,
+    /// File writes: write_file, edit_file, notebook_edit, etc.
+    Write,
+    /// Search operations: web_search, search, etc.
+    Search,
+    /// Shell execution: bash, exec, etc.
+    Exec,
+    /// HTTP operations: web_fetch, http, etc.
+    Http,
+    /// Uncategorized tools.
+    Other,
+}
+
+impl std::fmt::Display for ToolCategory {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
+            Self::Search => write!(f, "search"),
+            Self::Exec => write!(f, "exec"),
+            Self::Http => write!(f, "http"),
+            Self::Other => write!(f, "other"),
+        }
+    }
+}
+
+/// Categorize a tool name into a [`ToolCategory`].
+pub fn categorize_tool(name: &str) -> ToolCategory {
+    let lower = name.to_lowercase();
+    if lower.contains("read") || lower.contains("glob") || lower.contains("grep") {
+        ToolCategory::Read
+    } else if lower.contains("write")
+        || lower.contains("edit")
+        || lower.contains("patch")
+        || lower.contains("notebook")
+    {
+        ToolCategory::Write
+    } else if lower.contains("search") {
+        ToolCategory::Search
+    } else if lower.contains("bash") || lower.contains("exec") || lower.contains("shell") {
+        ToolCategory::Exec
+    } else if lower.contains("fetch") || lower.contains("http") || lower.contains("web_fetch") {
+        ToolCategory::Http
+    } else {
+        ToolCategory::Other
+    }
+}
+
+/// Per-category success/fail tallies and duration samples for percentile computation.
+#[derive(Debug, Clone, Default)]
+pub struct CategoryStats {
+    pub success: u32,
+    pub fail: u32,
+    /// Sorted durations in milliseconds for percentile computation.
+    durations: Vec<u64>,
+}
+
+impl CategoryStats {
+    /// Record a completed tool call.
+    pub fn record(&mut self, is_error: bool, duration_ms: u64) {
+        if is_error {
+            self.fail += 1;
+        } else {
+            self.success += 1;
+        }
+        // Insert in sorted order for percentile lookups.
+        let pos = self.durations.partition_point(|&d| d < duration_ms);
+        self.durations.insert(pos, duration_ms);
+    }
+
+    /// Total calls (success + fail).
+    #[cfg(test)]
+    pub fn total(&self) -> u32 {
+        self.success + self.fail
+    }
+
+    /// Compute a percentile (0–100) from the sorted durations.
+    /// Returns `None` if no durations have been recorded.
+    pub fn percentile(&self, p: u8) -> Option<u64> {
+        if self.durations.is_empty() {
+            return None;
+        }
+        let idx = ((p as usize) * self.durations.len() / 100).min(self.durations.len() - 1);
+        self.durations.get(idx).copied()
+    }
+}
+
+/// Summary KPIs for the ops pane header row.
+#[derive(Debug, Clone, Default)]
+pub struct OpsSummary {
+    pub total_calls: u32,
+    pub total_errors: u32,
+    /// Per-category statistics.
+    pub categories: std::collections::HashMap<ToolCategory, CategoryStats>,
+}
+
+impl OpsSummary {
+    /// Record a completed tool call into the summary.
+    pub fn record(&mut self, category: ToolCategory, is_error: bool, duration_ms: u64) {
+        self.total_calls += 1;
+        if is_error {
+            self.total_errors += 1;
+        }
+        self.categories
+            .entry(category)
+            .or_default()
+            .record(is_error, duration_ms);
+    }
+}
+
 /// A single tool call entry in the operations pane.
 #[derive(Debug, Clone)]
 pub struct OpsToolCall {
@@ -29,6 +143,8 @@ pub struct OpsToolCall {
     pub primary_arg: Option<String>,
     /// Error summary for failed tool calls, extracted from result text.
     pub error_message: Option<String>,
+    /// Tool category for KPI grouping.
+    pub category: ToolCategory,
 }
 
 /// A single thinking block in the operations pane.
@@ -78,6 +194,10 @@ pub struct OpsState {
     pub tool_calls: Vec<OpsToolCall>,
     /// File diffs parsed from tool results
     pub diffs: Vec<OpsDiffEntry>,
+    /// Aggregated KPI summary for the current turn.
+    pub summary: OpsSummary,
+    /// Wall-clock start time for the current turn (elapsed display).
+    pub turn_started_at: Option<std::time::Instant>,
 }
 
 impl Default for OpsState {
@@ -95,6 +215,8 @@ impl Default for OpsState {
             },
             tool_calls: Vec::new(),
             diffs: Vec::new(),
+            summary: OpsSummary::default(),
+            turn_started_at: None,
         }
     }
 }
@@ -131,6 +253,8 @@ impl OpsState {
         self.diffs.clear();
         self.scroll_offset = 0;
         self.selected_item = None;
+        self.summary = OpsSummary::default();
+        self.turn_started_at = Some(std::time::Instant::now());
     }
 
     /// Switch keyboard focus between panes.
@@ -216,6 +340,7 @@ impl OpsState {
         let primary_arg = input_json
             .as_deref()
             .and_then(|j| extract_primary_arg(j, &name));
+        let category = categorize_tool(&name);
         self.tool_calls.push(OpsToolCall {
             name,
             input_json,
@@ -225,6 +350,7 @@ impl OpsState {
             expanded: false,
             primary_arg,
             error_message: None,
+            category,
         });
     }
 
@@ -236,7 +362,7 @@ impl OpsState {
         duration_ms: u64,
         output: Option<String>,
     ) {
-        if let Some(tc) = self.tool_calls.iter_mut().rev().find(|t| t.name == name) {
+        let category = if let Some(tc) = self.tool_calls.iter_mut().rev().find(|t| t.name == name) {
             tc.status = if is_error {
                 OpsToolStatus::Failed
             } else {
@@ -252,7 +378,11 @@ impl OpsState {
                 }
             }
             tc.output = output;
-        }
+            tc.category
+        } else {
+            return;
+        };
+        self.summary.record(category, is_error, duration_ms);
     }
 }
 
@@ -414,6 +544,7 @@ mod tests {
             expanded: false,
             primary_arg: None,
             error_message: None,
+            category: ToolCategory::Other,
         });
         state.scroll_offset = 10;
         state.selected_item = Some(0);
@@ -424,6 +555,8 @@ mod tests {
         assert!(state.tool_calls.is_empty());
         assert_eq!(state.scroll_offset, 0);
         assert!(state.selected_item.is_none());
+        assert_eq!(state.summary.total_calls, 0);
+        assert!(state.turn_started_at.is_some());
     }
 
     #[test]
@@ -737,5 +870,92 @@ mod tests {
         let result = truncate_error(&long);
         assert!(result.chars().count() <= ERROR_MAX_LEN);
         assert!(result.ends_with('\u{2026}'));
+    }
+
+    #[test]
+    fn categorize_tool_read() {
+        assert_eq!(categorize_tool("read_file"), ToolCategory::Read);
+        assert_eq!(categorize_tool("Glob"), ToolCategory::Read);
+        assert_eq!(categorize_tool("Grep"), ToolCategory::Read);
+    }
+
+    #[test]
+    fn categorize_tool_write() {
+        assert_eq!(categorize_tool("write_file"), ToolCategory::Write);
+        assert_eq!(categorize_tool("Edit"), ToolCategory::Write);
+        assert_eq!(categorize_tool("NotebookEdit"), ToolCategory::Write);
+    }
+
+    #[test]
+    fn categorize_tool_exec() {
+        assert_eq!(categorize_tool("Bash"), ToolCategory::Exec);
+        assert_eq!(categorize_tool("exec_command"), ToolCategory::Exec);
+    }
+
+    #[test]
+    fn categorize_tool_search() {
+        assert_eq!(categorize_tool("web_search"), ToolCategory::Search);
+    }
+
+    #[test]
+    fn categorize_tool_http() {
+        assert_eq!(categorize_tool("web_fetch"), ToolCategory::Http);
+    }
+
+    #[test]
+    fn categorize_tool_other() {
+        assert_eq!(categorize_tool("agent"), ToolCategory::Other);
+    }
+
+    #[test]
+    fn category_stats_percentile() {
+        let mut stats = CategoryStats::default();
+        stats.record(false, 10);
+        stats.record(false, 20);
+        stats.record(false, 30);
+        stats.record(false, 40);
+        stats.record(true, 50);
+        assert_eq!(stats.success, 4);
+        assert_eq!(stats.fail, 1);
+        assert_eq!(stats.total(), 5);
+        // p50 = index 2 (of 5 elements) = 30
+        assert_eq!(stats.percentile(50), Some(30));
+        // p95 = index 4 = 50
+        assert_eq!(stats.percentile(95), Some(50));
+    }
+
+    #[test]
+    fn category_stats_empty_percentile() {
+        let stats = CategoryStats::default();
+        assert_eq!(stats.percentile(50), None);
+    }
+
+    #[test]
+    fn summary_records_across_categories() {
+        let mut summary = OpsSummary::default();
+        summary.record(ToolCategory::Read, false, 100);
+        summary.record(ToolCategory::Read, false, 200);
+        summary.record(ToolCategory::Write, true, 50);
+        assert_eq!(summary.total_calls, 3);
+        assert_eq!(summary.total_errors, 1);
+        assert_eq!(summary.categories[&ToolCategory::Read].success, 2);
+        assert_eq!(summary.categories[&ToolCategory::Write].fail, 1);
+    }
+
+    #[test]
+    fn complete_tool_updates_summary() {
+        let mut state = OpsState::default();
+        state.push_tool_start("read_file".to_string(), None);
+        state.complete_tool("read_file", false, 150, None);
+        assert_eq!(state.summary.total_calls, 1);
+        assert_eq!(state.summary.total_errors, 0);
+        assert!(state.summary.categories.contains_key(&ToolCategory::Read));
+    }
+
+    #[test]
+    fn push_tool_start_assigns_category() {
+        let mut state = OpsState::default();
+        state.push_tool_start("Bash".to_string(), None);
+        assert_eq!(state.tool_calls[0].category, ToolCategory::Exec);
     }
 }

--- a/crates/theatron/tui/src/update/overlay.rs
+++ b/crates/theatron/tui/src/update/overlay.rs
@@ -40,7 +40,7 @@ pub(crate) fn handle_close_overlay(app: &mut App) {
         let turn_id = approval.turn_id.clone();
         let tool_id = approval.tool_id.clone();
         let client = app.client.clone();
-        let span = tracing::info_span!("deny_tool");
+        let span = tracing::info_span!("deny_tool", %turn_id, %tool_id);
         tokio::spawn(
             async move {
                 if let Err(e) = client.deny_tool(&turn_id, &tool_id).await {
@@ -53,7 +53,7 @@ pub(crate) fn handle_close_overlay(app: &mut App) {
     if let Some(Overlay::PlanApproval(ref plan)) = app.layout.overlay {
         let plan_id = plan.plan_id.clone();
         let client = app.client.clone();
-        let span = tracing::info_span!("cancel_plan");
+        let span = tracing::info_span!("cancel_plan", %plan_id);
         tokio::spawn(
             async move {
                 if let Err(e) = client.cancel_plan(&plan_id).await {
@@ -177,7 +177,7 @@ pub(crate) async fn handle_overlay_select(app: &mut App) {
             let turn_id = approval.turn_id.clone();
             let tool_id = approval.tool_id.clone();
             let client = app.client.clone();
-            let span = tracing::info_span!("approve_tool");
+            let span = tracing::info_span!("approve_tool", %turn_id, %tool_id);
             tokio::spawn(
                 async move {
                     if let Err(e) = client.approve_tool(&turn_id, &tool_id).await {
@@ -191,7 +191,7 @@ pub(crate) async fn handle_overlay_select(app: &mut App) {
         Some(Overlay::PlanApproval(plan)) => {
             let plan_id = plan.plan_id.clone();
             let client = app.client.clone();
-            let span = tracing::info_span!("approve_plan");
+            let span = tracing::info_span!("approve_plan", %plan_id);
             tokio::spawn(
                 async move {
                     if let Err(e) = client.approve_plan(&plan_id).await {

--- a/crates/theatron/tui/src/view/ops.rs
+++ b/crates/theatron/tui/src/view/ops.rs
@@ -6,7 +6,7 @@ use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Paragraph, Wrap};
 
 use crate::app::App;
-use crate::state::ops::{FocusedPane, OpsToolStatus};
+use crate::state::ops::{FocusedPane, OpsToolStatus, ToolCategory};
 use crate::theme::{self, Theme};
 
 const THINKING_TRUNCATE_LINES: usize = 20;
@@ -50,6 +50,12 @@ pub fn render(app: &App, frame: &mut Frame, area: Rect, theme: &Theme) {
     let mut lines: Vec<Line> = Vec::new();
     let inner_width = inner.width.saturating_sub(1) as usize;
     let mut item_idx: usize = 0;
+
+    // Summary row: total calls, errors, elapsed time.
+    if ops.summary.total_calls > 0 || ops.turn_started_at.is_some() {
+        render_summary_row(ops, &mut lines, theme);
+        lines.push(Line::raw(""));
+    }
 
     if !ops.thinking.text.is_empty() {
         let is_selected = ops.selected_item == Some(item_idx);
@@ -389,6 +395,88 @@ fn render_diff(
                 Style::default().fg(theme.status.success),
             ),
         ]));
+    }
+}
+
+/// Category display order for consistent KPI rendering.
+const CATEGORY_ORDER: &[ToolCategory] = &[
+    ToolCategory::Read,
+    ToolCategory::Write,
+    ToolCategory::Search,
+    ToolCategory::Exec,
+    ToolCategory::Http,
+    ToolCategory::Other,
+];
+
+fn render_summary_row(
+    ops: &crate::state::ops::OpsState,
+    lines: &mut Vec<Line<'static>>,
+    theme: &Theme,
+) {
+    let elapsed = ops
+        .turn_started_at
+        .map(|t| {
+            let secs = t.elapsed().as_secs();
+            if secs < 60 {
+                format!("{secs}s")
+            } else {
+                format!("{}m{}s", secs / 60, secs % 60)
+            }
+        })
+        .unwrap_or_default();
+
+    let summary = &ops.summary;
+    let mut spans = vec![
+        Span::styled(" ", Style::default()),
+        Span::styled(
+            format!("{}", summary.total_calls),
+            theme.style_accent_bold(),
+        ),
+        Span::styled(" calls", theme.style_muted()),
+    ];
+
+    if summary.total_errors > 0 {
+        spans.push(Span::styled(" · ", theme.style_dim()));
+        spans.push(Span::styled(
+            format!("{}", summary.total_errors),
+            theme.style_error(),
+        ));
+        spans.push(Span::styled(" err", theme.style_error()));
+    }
+
+    if !elapsed.is_empty() {
+        spans.push(Span::styled(" · ", theme.style_dim()));
+        spans.push(Span::styled(elapsed, theme.style_dim()));
+    }
+
+    lines.push(Line::from(spans));
+
+    // Per-category rows with tallies and percentiles.
+    for cat in CATEGORY_ORDER {
+        if let Some(stats) = summary.categories.get(cat) {
+            let mut cat_spans = vec![
+                Span::styled("  ", Style::default()),
+                Span::styled(format!("{cat}"), theme.style_muted()),
+                Span::styled(" ", Style::default()),
+                Span::styled(format!("{}", stats.success), theme.style_success()),
+                Span::styled("/", theme.style_dim()),
+            ];
+
+            if stats.fail > 0 {
+                cat_spans.push(Span::styled(format!("{}", stats.fail), theme.style_error()));
+            } else {
+                cat_spans.push(Span::styled("0", theme.style_dim()));
+            }
+
+            if let Some(p50) = stats.percentile(50) {
+                cat_spans.push(Span::styled(format!("  p50={p50}ms"), theme.style_dim()));
+            }
+            if let Some(p95) = stats.percentile(95) {
+                cat_spans.push(Span::styled(format!(" p95={p95}ms"), theme.style_dim()));
+            }
+
+            lines.push(Line::from(cat_spans));
+        }
     }
 }
 

--- a/crates/theatron/tui/src/view/status_bar.rs
+++ b/crates/theatron/tui/src/view/status_bar.rs
@@ -104,6 +104,14 @@ fn render_info_bar(app: &App, width: u16, theme: &Theme) -> Line<'static> {
         }
     }
 
+    // Optional: credential type indicator.
+    let cred_spans = credential_indicator_spans(app, theme);
+    let cred_w: usize = cred_spans.iter().map(|s| s.content.width()).sum();
+    if cred_w > 0 && used + cred_w + 1 < total {
+        spans.extend(cred_spans);
+        used += cred_w;
+    }
+
     // Optional: tool indicator.
     let tool_spans = tool_indicator_spans(app, theme);
     let tool_w: usize = tool_spans.iter().map(|s| s.content.width()).sum();
@@ -328,6 +336,25 @@ fn scroll_position_spans(app: &App, theme: &Theme) -> Vec<Span<'static>> {
             ]
         }
         None => Vec::new(),
+    }
+}
+
+fn credential_indicator_spans(app: &App, theme: &Theme) -> Vec<Span<'static>> {
+    use crate::config::CredentialLabel;
+    match app.config.credential_label {
+        CredentialLabel::OAuthToken => {
+            vec![
+                Span::styled(" │ ", theme.style_dim()),
+                Span::styled("OAuth token", theme.style_muted()),
+            ]
+        }
+        CredentialLabel::StaticApiKey => {
+            vec![
+                Span::styled(" │ ", theme.style_dim()),
+                Span::styled("static API key", theme.style_muted()),
+            ]
+        }
+        CredentialLabel::None => Vec::new(),
     }
 }
 


### PR DESCRIPTION
## Summary

- **Ops pane redesign (#1824)**: Categorized tool calls (Read, Write, Search, Exec, Http, Other) with per-category success/fail tallies, p50/p95 duration percentiles, and a live summary row (total calls, total errors, wall-clock elapsed)
- **Credential display (#1830)**: Status bar now shows "OAuth token" or "static API key" based on `sk-ant-oat` prefix detection at config load
- **Spawn instrumentation (#1831)**: All `tokio::spawn` sites since PR #1670 now carry named `tracing` spans with contextual fields (agent ID, session ID, turn ID, etc.)

Closes #1824, #1831, #1830

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy -p theatron-tui -p aletheia-pylon --all-targets -- -D warnings` clean
- [x] `cargo test -p theatron-tui` — 919 tests pass
- [x] `cargo test -p aletheia-pylon` — 262 tests pass
- [x] `cargo test -p aletheia-nous` — all pass
- [ ] Manual: launch TUI, trigger tool calls, verify categorized summary row renders
- [ ] Manual: verify status bar shows credential type indicator

🤖 Generated with [Claude Code](https://claude.com/claude-code)