### PR TITLE
fix(theatron-tui): scroll, agent switching, tool rendering, session persistence

### DIFF
--- a/crates/theatron/tui/src/actions.rs
+++ b/crates/theatron/tui/src/actions.rs
@@ -5,6 +5,16 @@ use tracing::Instrument;
 /// Entries beyond this cap are pruned to agents currently in the active roster.
 const MAX_SCROLL_STATES: usize = 100;
 
+// WHY: These constants mirror view/mod.rs and view/ops.rs so that rebuild_virtual_scroll
+// can compute the same chat area width that the renderer uses.  Keeping them here avoids
+// a view → model dependency inversion while still producing a correct wrap_width for the
+// VirtualScroll cache.  If the view constants ever change, update these in lockstep.
+const LAYOUT_SIDEBAR_WIDTH: u16 = 22;
+const LAYOUT_MIN_SIDEBAR_TERMINAL_WIDTH: u16 = 60;
+const LAYOUT_MIN_OPS_TERMINAL_WIDTH: u16 = 80;
+const LAYOUT_MIN_CHAT_PANE_WIDTH: u16 = 40;
+const LAYOUT_MIN_OPS_PANE_WIDTH: u16 = 20;
+
 use crate::api::streaming;
 use crate::app::App;
 use crate::state::virtual_scroll::estimate_message_height;
@@ -52,7 +62,7 @@ impl App {
             .virtual_scroll
             .cached_width()
             .max(self.viewport.terminal_width.saturating_sub(2).max(1));
-        let h = estimate_message_height(msg.text.len(), !msg.tool_calls.is_empty(), width);
+        let h = estimate_message_height(msg.text.len(), width);
         self.dashboard.messages.push(msg);
         self.viewport.render.virtual_scroll.push_item(h);
         self.scroll_to_bottom();
@@ -179,15 +189,37 @@ impl App {
         }
     }
 
-    /// Rebuild the virtual scroll height cache from current messages and terminal width.
-    /// Called on session load, terminal resize, or when the cache becomes stale.
+    /// Rebuild the virtual scroll height cache from current messages and the actual chat
+    /// area width.  The width must match what the chat renderer uses (area.width - 2) so
+    /// that the cache is valid and `needs_fallback` stays false during normal rendering.
     pub(crate) fn rebuild_virtual_scroll(&mut self) {
-        let width = self.viewport.terminal_width.saturating_sub(2).max(1);
+        let tw = self.viewport.terminal_width;
+        // Mirror the layout logic from view/mod.rs to derive the chat column width.
+        let show_sidebar =
+            self.layout.sidebar_visible && tw >= LAYOUT_MIN_SIDEBAR_TERMINAL_WIDTH;
+        let rest = if show_sidebar {
+            tw.saturating_sub(LAYOUT_SIDEBAR_WIDTH)
+        } else {
+            tw
+        };
+        let show_ops = self.layout.ops.visible && tw >= LAYOUT_MIN_OPS_TERMINAL_WIDTH;
+        let chat_w = if show_ops {
+            let available = rest.saturating_sub(LAYOUT_MIN_CHAT_PANE_WIDTH);
+            let desired = (u32::from(rest) * u32::from(self.layout.ops.width_pct) / 100) as u16;
+            let ops_w = desired.clamp(
+                LAYOUT_MIN_OPS_PANE_WIDTH,
+                available.max(LAYOUT_MIN_OPS_PANE_WIDTH),
+            );
+            rest.saturating_sub(ops_w)
+        } else {
+            rest
+        };
+        let width = chat_w.saturating_sub(2).max(1);
         let heights: Vec<u16> = self
             .dashboard
             .messages
             .iter()
-            .map(|msg| estimate_message_height(msg.text.len(), !msg.tool_calls.is_empty(), width))
+            .map(|msg| estimate_message_height(msg.text.len(), width))
             .collect();
         self.viewport.render.virtual_scroll.rebuild(&heights, width);
     }

--- a/crates/theatron/tui/src/app/mod.rs
+++ b/crates/theatron/tui/src/app/mod.rs
@@ -55,6 +55,8 @@ pub struct DashboardState {
     pub daily_cost_cents: u32,
     pub session_cost_cents: u32,
     pub context_usage_pct: Option<u8>,
+    /// Last-active session per agent, loaded from disk on startup and saved on exit.
+    pub(crate) saved_sessions: HashMap<NousId, SessionId>,
 }
 
 /// SSE link, stream receiver, and reconnect bookkeeping.
@@ -155,6 +157,7 @@ impl App {
         tracing::info!(depth = ?theme.depth, mode = ?theme.mode, "theme initialized");
 
         let command_history = load_command_history(&config);
+        let saved_sessions = load_session_state(&config);
         let keymap = KeyMap::build(&config.keybindings);
         let bell_enabled = config.bell;
 
@@ -172,6 +175,7 @@ impl App {
                 daily_cost_cents: 0,
                 session_cost_cents: 0,
                 context_usage_pct: None,
+                saved_sessions,
             },
             connection: ConnectionState {
                 sse: None,
@@ -383,8 +387,15 @@ impl App {
             None => return,
         };
 
+        // WHY: Prefer the session the user last had open for this agent so that the TUI
+        // resumes exactly where they left off after a restart.  Fall back to the most
+        // recently updated session when no saved state exists, or when the saved session
+        // is no longer in the agent's session list (e.g. it was deleted server-side).
+        let saved_id = self.dashboard.saved_sessions.get(&agent_id).cloned();
         let session = if let Some(ref key) = self.config.default_session {
             agent.sessions.iter().find(|s| s.key == *key)
+        } else if let Some(ref sid) = saved_id {
+            agent.sessions.iter().find(|s| s.id == *sid)
         } else {
             agent
                 .sessions
@@ -410,6 +421,10 @@ impl App {
         if let Some(session) = session {
             let session_id = session.id.clone();
             self.dashboard.focused_session_id = Some(session_id.clone());
+            // Track the last-used session for this agent so we can restore it on relaunch.
+            self.dashboard
+                .saved_sessions
+                .insert(agent_id.clone(), session_id.clone());
 
             match self.client.history(&session_id).await {
                 Ok(history) => {
@@ -651,6 +666,54 @@ pub(crate) fn save_command_history(config: &Config, history: &[String]) {
         let _ = std::fs::create_dir_all(parent);
     }
     let content: String = history.iter().map(|s| format!("{s}\n")).collect();
+    let _ = std::fs::write(&path, content);
+}
+
+fn session_state_file_path(config: &Config) -> Option<std::path::PathBuf> {
+    config
+        .workspace_root
+        .as_ref()
+        .map(|root| root.join("state").join("tui_sessions"))
+}
+
+/// Load the per-agent last-active session map from disk.
+///
+/// Format: one entry per line, `<agent_id>:<session_id>`.
+/// Malformed or empty lines are silently skipped.
+fn load_session_state(config: &Config) -> HashMap<NousId, SessionId> {
+    let path = match session_state_file_path(config) {
+        Some(p) => p,
+        None => return HashMap::new(),
+    };
+    let contents = match std::fs::read_to_string(&path) {
+        Ok(c) => c,
+        Err(_) => return HashMap::new(),
+    };
+    contents
+        .lines()
+        .filter_map(|line| {
+            let (agent, session) = line.split_once(':')?;
+            if agent.is_empty() || session.is_empty() {
+                return None;
+            }
+            Some((NousId::from(agent), SessionId::from(session)))
+        })
+        .collect()
+}
+
+/// Persist the per-agent last-active session map to disk.
+pub(crate) fn save_session_state(config: &Config, sessions: &HashMap<NousId, SessionId>) {
+    let path = match session_state_file_path(config) {
+        Some(p) => p,
+        None => return,
+    };
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    let content: String = sessions
+        .iter()
+        .map(|(agent, session)| format!("{agent}:{session}\n"))
+        .collect();
     let _ = std::fs::write(&path, content);
 }
 

--- a/crates/theatron/tui/src/app/test_helpers.rs
+++ b/crates/theatron/tui/src/app/test_helpers.rs
@@ -39,6 +39,7 @@ pub fn test_app() -> App {
             daily_cost_cents: 0,
             session_cost_cents: 0,
             context_usage_pct: None,
+            saved_sessions: HashMap::new(),
         },
         connection: ConnectionState {
             sse: None,

--- a/crates/theatron/tui/src/lib.rs
+++ b/crates/theatron/tui/src/lib.rs
@@ -101,6 +101,8 @@ async fn run_tui_inner(
     let result = run_loop(terminal, &mut app).await;
     let _ = crossterm::execute!(std::io::stderr(), crossterm::event::DisableMouseCapture);
     ratatui::restore();
+    // Persist last-active sessions so the TUI resumes at the same place on relaunch.
+    crate::app::save_session_state(&app.config, &app.dashboard.saved_sessions);
 
     if let Err(ref e) = result {
         tracing::error!(error = %e, "tui exited with error");

--- a/crates/theatron/tui/src/state/virtual_scroll.rs
+++ b/crates/theatron/tui/src/state/virtual_scroll.rs
@@ -208,13 +208,14 @@ impl VirtualScroll {
 /// This is a cheap approximation used to avoid full markdown rendering
 /// for off-screen messages. It accounts for:
 /// - 1 header line
-/// - 1 tool summary line (if tools present)
 /// - text content wrapped at `width`
 /// - 1 trailing blank line
-pub(crate) fn estimate_message_height(text_len: usize, has_tools: bool, width: u16) -> u16 {
+///
+/// Tool calls are rendered exclusively in the ops pane and do not add
+/// lines to the chat view, so they are not counted here.
+pub(crate) fn estimate_message_height(text_len: usize, width: u16) -> u16 {
     let w = usize::from(width.max(1));
     let header = 1u16;
-    let tools = if has_tools { 1u16 } else { 0 };
     let content = if text_len == 0 {
         0u16
     } else {
@@ -222,7 +223,7 @@ pub(crate) fn estimate_message_height(text_len: usize, has_tools: bool, width: u
     };
     let blank = 1u16;
 
-    header + tools + content + blank
+    header + content + blank
 }
 
 #[cfg(test)]
@@ -411,24 +412,19 @@ mod tests {
 
     #[test]
     fn estimate_message_height_empty() {
-        assert_eq!(estimate_message_height(0, false, 80), 2); // header + blank
+        assert_eq!(estimate_message_height(0, 80), 2); // header + blank
     }
 
     #[test]
     fn estimate_message_height_short() {
         // "hello" (5 chars) at width 80 = 1 content line
-        assert_eq!(estimate_message_height(5, false, 80), 3); // header + 1 content + blank
-    }
-
-    #[test]
-    fn estimate_message_height_with_tools() {
-        assert_eq!(estimate_message_height(5, true, 80), 4); // header + tool + 1 content + blank
+        assert_eq!(estimate_message_height(5, 80), 3); // header + 1 content + blank
     }
 
     #[test]
     fn estimate_message_height_wrapping() {
         // 200 chars at width 80 = 3 content lines
-        assert_eq!(estimate_message_height(200, false, 80), 5); // header + 3 content + blank
+        assert_eq!(estimate_message_height(200, 80), 5); // header + 3 content + blank
     }
 
     #[test]

--- a/crates/theatron/tui/src/update/navigation.rs
+++ b/crates/theatron/tui/src/update/navigation.rs
@@ -69,6 +69,13 @@ pub(crate) async fn handle_focus_agent(app: &mut App, id: NousId) {
         agent.unread_count = 0;
     }
     app.dashboard.focused_agent = Some(id);
+    // WHY: Clear streaming state from the previous agent so it does not bleed into the
+    // newly focused agent's chat view.  The markdown cache must also be cleared so a
+    // stale rendered frame from the old agent is not reused.
+    app.connection.streaming_text.clear();
+    app.connection.streaming_thinking.clear();
+    app.connection.streaming_tool_calls.clear();
+    app.viewport.render.markdown_cache.clear();
     app.load_focused_session().await;
     app.restore_scroll_state();
 }
@@ -412,6 +419,39 @@ mod tests {
         handle_resize(&mut app, 120, 40);
         assert!(!app.viewport.render.auto_scroll);
         assert_eq!(app.viewport.render.scroll_offset, 5);
+    }
+
+    #[tokio::test]
+    async fn focus_agent_clears_streaming_state() {
+        let mut app = test_app();
+        app.dashboard.agents.push(test_agent("alpha", "Alpha"));
+        app.dashboard.agents.push(test_agent("beta", "Beta"));
+        app.dashboard.focused_agent = Some("alpha".into());
+        // Simulate streaming state left over from the previous agent.
+        app.connection.streaming_text = "old response".to_string();
+        app.connection.streaming_thinking = "old thinking".to_string();
+        app.connection
+            .streaming_tool_calls
+            .push(crate::state::ToolCallInfo {
+                name: "read_file".to_string(),
+                duration_ms: None,
+                is_error: false,
+            });
+
+        handle_focus_agent(&mut app, "beta".into()).await;
+
+        assert!(
+            app.connection.streaming_text.is_empty(),
+            "streaming_text must be cleared on agent switch"
+        );
+        assert!(
+            app.connection.streaming_thinking.is_empty(),
+            "streaming_thinking must be cleared on agent switch"
+        );
+        assert!(
+            app.connection.streaming_tool_calls.is_empty(),
+            "streaming_tool_calls must be cleared on agent switch"
+        );
     }
 
     #[tokio::test]

--- a/crates/theatron/tui/src/update/streaming.rs
+++ b/crates/theatron/tui/src/update/streaming.rs
@@ -174,18 +174,28 @@ pub(crate) fn handle_stream_plan_proposed(app: &mut App, plan: Plan) {
 // SAFETY: sanitized at ingestion: streaming_text already sanitized via handle_stream_text_delta,
 // model name from API is sanitized here.
 pub(crate) async fn handle_stream_turn_complete(app: &mut App, outcome: TurnOutcome) {
-    if !app.connection.streaming_text.is_empty() {
+    // WHY: Only commit the streamed message when the completing turn belongs to the
+    // currently focused agent.  If the user switched agents mid-stream the message
+    // belongs to the old agent's session; pushing it here would corrupt the new
+    // agent's in-memory message buffer.  The server has already persisted the
+    // message, so it will appear when the user navigates back via load_focused_session.
+    let belongs_to_focused = app
+        .dashboard
+        .focused_agent
+        .as_ref()
+        .is_some_and(|id| *id == outcome.nous_id);
+
+    if belongs_to_focused && !app.connection.streaming_text.is_empty() {
         let text = app.connection.streaming_text.clone();
         let text_lower = text.to_lowercase();
         let tool_calls = std::mem::take(&mut app.connection.streaming_tool_calls);
-        let has_tools = !tool_calls.is_empty();
         let width = app
             .viewport
             .render
             .virtual_scroll
             .cached_width()
             .max(app.viewport.terminal_width.saturating_sub(2).max(1));
-        let h = estimate_message_height(text.len(), has_tools, width);
+        let h = estimate_message_height(text.len(), width);
         app.dashboard.messages.push(ChatMessage {
             role: "assistant".to_string(),
             text,
@@ -574,6 +584,8 @@ mod tests {
     #[tokio::test]
     async fn turn_complete_auto_scroll_stays_at_bottom() {
         let mut app = test_app();
+        app.dashboard.agents.push(test_agent("syn", "Syn"));
+        app.dashboard.focused_agent = Some("syn".into());
         app.viewport.render.auto_scroll = true;
         app.viewport.render.scroll_offset = 0;
         app.connection.streaming_text = "hello world".to_string();
@@ -585,6 +597,8 @@ mod tests {
     #[tokio::test]
     async fn turn_complete_scroll_lock_preserves_offset() {
         let mut app = test_app();
+        app.dashboard.agents.push(test_agent("syn", "Syn"));
+        app.dashboard.focused_agent = Some("syn".into());
         app.viewport.render.auto_scroll = false;
         app.viewport.render.scroll_offset = 30;
         app.rebuild_virtual_scroll();
@@ -602,11 +616,39 @@ mod tests {
     #[tokio::test]
     async fn turn_complete_no_text_does_not_change_scroll() {
         let mut app = test_app();
+        app.dashboard.agents.push(test_agent("syn", "Syn"));
+        app.dashboard.focused_agent = Some("syn".into());
         app.viewport.render.auto_scroll = false;
         app.viewport.render.scroll_offset = 10;
         // streaming_text is empty: no message is committed, offset unchanged
         handle_stream_turn_complete(&mut app, make_outcome()).await;
         assert_eq!(app.viewport.render.scroll_offset, 10);
         assert!(!app.viewport.render.auto_scroll);
+    }
+
+    #[tokio::test]
+    async fn turn_complete_cross_agent_does_not_pollute_focused_agent() {
+        // WHY: If the user switches agents while a turn is streaming, the completing
+        // turn belongs to the old agent.  Its message must not be pushed to the new
+        // focused agent's message buffer.
+        let mut app = test_app();
+        app.dashboard.agents.push(test_agent("alpha", "Alpha"));
+        app.dashboard.agents.push(test_agent("beta", "Beta"));
+        // User has switched to "beta", but the completing outcome is for "alpha".
+        app.dashboard.focused_agent = Some("beta".into());
+        app.connection.streaming_text = "alpha's response".to_string();
+        let mut outcome = make_outcome();
+        outcome.nous_id = "alpha".into();
+
+        handle_stream_turn_complete(&mut app, outcome).await;
+
+        // Message must NOT appear in the (now-beta-focused) buffer.
+        assert!(
+            app.dashboard.messages.is_empty(),
+            "cross-agent turn completion must not push to focused agent's buffer"
+        );
+        // Streaming state must still be cleared.
+        assert!(app.connection.streaming_text.is_empty());
+        assert!(app.connection.active_turn_id.is_none());
     }
 }

--- a/crates/theatron/tui/src/view/chat.rs
+++ b/crates/theatron/tui/src/view/chat.rs
@@ -4,14 +4,12 @@ use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Paragraph, Wrap};
 
-use crate::app::{App, ToolCallInfo};
+use crate::app::App;
 use crate::hyperlink::{self, OscLink};
 use crate::markdown;
 use crate::state::FilterScope;
 use crate::theme::{self, Theme};
 use crate::view::image;
-
-const MS_PER_SECOND: u64 = 1000;
 
 struct MessageCtx<'a> {
     inner_width: usize,
@@ -150,11 +148,21 @@ pub fn render(app: &App, frame: &mut Frame, area: Rect, theme: &Theme) -> Vec<Os
         .sum();
     let vh = usize::from(visible_height);
 
+    // WHY: When the virtual scroll cache is stale (width mismatch or item count mismatch),
+    // render_virtual_messages falls back to rendering ALL messages.  In that case the
+    // virtual-scroll `line_offset` is meaningless — it was computed for a partial slice
+    // that was never rendered.  Detect the same stale condition here and use the same
+    // total-minus-offset formula that the filter path uses.
+    let needs_fallback = !filter_active
+        && (app.viewport.render.virtual_scroll.len() != app.dashboard.messages.len()
+            || (app.viewport.render.virtual_scroll.cached_width() != wrap_width
+                && !app.dashboard.messages.is_empty()));
+
     let scroll = if app.viewport.render.auto_scroll {
         // Pin to the very bottom of whatever was rendered (committed + streaming).
         total_visual.saturating_sub(vh)
-    } else if filter_active {
-        // Filtered path: all messages are in `lines`; use the pre-computed total.
+    } else if filter_active || needs_fallback {
+        // Filtered / fallback path: all messages are in `lines`; use the pre-computed total.
         total_visual
             .saturating_sub(vh)
             .saturating_sub(app.viewport.render.scroll_offset)
@@ -409,11 +417,6 @@ fn render_message(
 
     lines.push(Line::from(header_spans));
 
-    // Inline tool call summary (compact, between header and content)
-    if !msg.tool_calls.is_empty() {
-        render_tool_summary(&msg.tool_calls, lines, theme);
-    }
-
     // Message content: markdown parsed with syntax highlighting
     let (md_lines, md_links) = markdown::render(
         &msg.text,
@@ -523,44 +526,6 @@ fn highlight_span(
     }
 }
 
-/// Render a compact tool call summary line:
-///   ╰─ exec (0.3s) → read (0.1s) → grep (0.2s)
-fn render_tool_summary(tools: &[ToolCallInfo], lines: &mut Vec<Line<'static>>, theme: &Theme) {
-    let mut spans: Vec<Span> = vec![Span::raw("  "), Span::styled("╰─ ", theme.style_dim())];
-
-    for (i, tc) in tools.iter().enumerate() {
-        if i > 0 {
-            spans.push(Span::styled(" → ", theme.style_dim()));
-        }
-
-        let color = if tc.is_error {
-            theme.status.error
-        } else {
-            theme.text.fg_dim
-        };
-        let icon = if tc.is_error { "✗ " } else { "" };
-
-        let label = if let Some(ms) = tc.duration_ms {
-            if ms >= MS_PER_SECOND {
-                format!(
-                    "{}{} ({:.1}s)",
-                    icon,
-                    tc.name,
-                    ms as f64 / MS_PER_SECOND as f64
-                )
-            } else {
-                format!("{}{}  ({}ms)", icon, tc.name, ms)
-            }
-        } else {
-            format!("{}{}", icon, tc.name)
-        };
-
-        spans.push(Span::styled(label, Style::default().fg(color)));
-    }
-
-    lines.push(Line::from(spans));
-}
-
 fn render_streaming(
     app: &App,
     lines: &mut Vec<Line<'static>>,
@@ -591,52 +556,6 @@ fn render_streaming(
                 Style::default().fg(theme.thinking.border),
             ),
         ]));
-    }
-
-    // Active tool calls during streaming (show completed + current)
-    if !app.connection.streaming_tool_calls.is_empty() {
-        let mut tool_spans: Vec<Span> =
-            vec![Span::raw("  "), Span::styled("╰─ ", theme.style_dim())];
-
-        for (i, tc) in app.connection.streaming_tool_calls.iter().enumerate() {
-            if i > 0 {
-                tool_spans.push(Span::styled(" → ", theme.style_dim()));
-            }
-
-            if tc.duration_ms.is_some() {
-                // Completed tool
-                let color = if tc.is_error {
-                    theme.status.error
-                } else {
-                    theme.text.fg_dim
-                };
-                let icon = if tc.is_error { "✗ " } else { "" };
-                let label = if let Some(ms) = tc.duration_ms {
-                    if ms >= MS_PER_SECOND {
-                        format!(
-                            "{}{} ({:.1}s)",
-                            icon,
-                            tc.name,
-                            ms as f64 / MS_PER_SECOND as f64
-                        )
-                    } else {
-                        format!("{}{} ({}ms)", icon, tc.name, ms)
-                    }
-                } else {
-                    tc.name.clone()
-                };
-                tool_spans.push(Span::styled(label, Style::default().fg(color)));
-            } else {
-                // Currently running tool: animated
-                let ch = theme::spinner_frame(app.viewport.tick_count);
-                tool_spans.push(Span::styled(
-                    format!("{} {}", ch, tc.name),
-                    Style::default().fg(theme.status.spinner),
-                ));
-            }
-        }
-
-        lines.push(Line::from(tool_spans));
     }
 
     // Streaming text with cursor


### PR DESCRIPTION
## Summary

- **#1825 — Scroll**: Fixed `rebuild_virtual_scroll` to compute the actual chat area width (sidebar + ops pane subtracted), so the VirtualScroll cache stays valid and does not trigger a slow full-render fallback. Also fixed the fallback scroll formula: when the cache is stale and all messages are rendered, the position now uses `total_visual - vh - scroll_offset` instead of the invalid `slice.line_offset`.

- **#1826 — Agent switching**: `handle_focus_agent` clears `streaming_text`, `streaming_thinking`, and `streaming_tool_calls` on every focus change so previous-agent state doesn't bleed through. `handle_stream_turn_complete` guards the in-memory message push with a `nous_id` equality check — if the user switches agents mid-stream, the completing message is not pushed to the new agent's buffer (the server persisted it; `load_focused_session` will fetch it on switch-back).

- **#1827 — Tool call rendering**: Removed streaming tool call summary from `render_streaming` and committed tool summary from `render_message`; tool calls are now rendered exclusively in the ops pane. Removed the `has_tools` parameter from `estimate_message_height` accordingly.

- **#1828 — Session persistence**: Added `state/tui_sessions` (format: `agent_id:session_id` per line). Loaded on startup; written on shutdown. `load_focused_session` prefers the saved session for each agent when available.

## Test plan

- [x] `cargo test -p theatron-tui` — 903 tests pass, 0 failures
- [x] `cargo clippy -p theatron-tui --all-targets -- -D warnings` — zero warnings
- [x] New tests: `focus_agent_clears_streaming_state`, `turn_complete_cross_agent_does_not_pollute_focused_agent`
- [ ] Manual: scroll with mouse, trackpad, PgUp/PgDn on a populated chat
- [ ] Manual: switch agents and verify each shows its own session history
- [ ] Manual: tool calls visible only in ops pane, not inline in chat
- [ ] Manual: exit and relaunch — each agent resumes its last session

Closes #1825, #1826, #1827, #1828

🤖 Generated with [Claude Code](https://claude.com/claude-code)