### PR TITLE
feat(hermeneus): OpenAI-compatible local LLM provider

### DIFF
--- a/crates/hermeneus/Cargo.toml
+++ b/crates/hermeneus/Cargo.toml
@@ -25,6 +25,8 @@ tower = { workspace = true }
 tracing = { workspace = true }
 
 [features]
+# OpenAI-compatible local LLM provider (vLLM, etc.).
+local-llm = []
 # Shared mock LLM provider for tests across the workspace.
 # Use `test-support` (preferred); `test-utils` kept for compatibility.
 test-utils = []

--- a/crates/hermeneus/src/lib.rs
+++ b/crates/hermeneus/src/lib.rs
@@ -19,6 +19,11 @@ pub mod error;
 pub mod fallback;
 /// Provider health state machine (Up / Degraded / Down) with automatic recovery.
 pub mod health;
+/// OpenAI-compatible local LLM provider for vLLM and similar servers.
+///
+/// Gated behind the `local-llm` feature flag.
+#[cfg(feature = "local-llm")]
+pub mod local;
 /// Prometheus metrics for LLM request counts, latency, and token usage.
 pub mod metrics;
 /// Model constants and API configuration defaults.

--- a/crates/hermeneus/src/local/mod.rs
+++ b/crates/hermeneus/src/local/mod.rs
@@ -1,0 +1,13 @@
+//! OpenAI-compatible local LLM provider for vLLM and similar servers.
+//!
+//! Routes requests with the `local/` model prefix to a configurable
+//! OpenAI-compatible endpoint. Supports both streaming and non-streaming
+//! completions, including function/tool calling.
+//!
+//! Gated behind the `local-llm` feature flag.
+
+mod provider;
+pub(crate) mod stream;
+pub(crate) mod types;
+
+pub use provider::{LocalProvider, LocalProviderConfig};

--- a/crates/hermeneus/src/local/provider.rs
+++ b/crates/hermeneus/src/local/provider.rs
@@ -1,0 +1,473 @@
+//! `LocalProvider`: routes LLM calls to a local vLLM endpoint via the
+//! OpenAI-compatible Chat Completions API.
+//!
+//! # Errors
+//!
+//! Connection failures (server not running) produce [`Error::ApiRequest`] with
+//! a descriptive message rather than panicking.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::time::Duration;
+
+use reqwest::Client;
+use tracing::{debug, warn};
+
+use super::stream::parse_openai_stream;
+use super::types::{
+    ChatCompletionRequest, ChatCompletionResponse, ChatFunction, ChatFunctionCall, ChatMessage,
+    ChatTool, ChatToolCall,
+};
+use crate::anthropic::StreamEvent;
+use crate::error::{self, Result};
+use crate::provider::LlmProvider;
+use crate::types::{
+    CompletionRequest, CompletionResponse, Content, ContentBlock, StopReason, ToolChoice, Usage,
+};
+
+/// Default base URL for local vLLM instances.
+const DEFAULT_BASE_URL: &str = "http://localhost:8000/v1";
+
+/// Model name prefix that routes requests to this provider.
+pub(crate) const LOCAL_MODEL_PREFIX: &str = "local/";
+
+/// Configuration for the local provider.
+#[derive(Debug, Clone)]
+pub struct LocalProviderConfig {
+    /// Base URL of the OpenAI-compatible endpoint (e.g. `http://localhost:8000/v1`).
+    pub base_url: String,
+    /// Default model to request when not specified.
+    pub default_model: String,
+    /// HTTP request timeout.
+    pub timeout: Duration,
+}
+
+impl Default for LocalProviderConfig {
+    fn default() -> Self {
+        Self {
+            base_url: DEFAULT_BASE_URL.to_owned(),
+            default_model: "qwen3.5-27b".to_owned(),
+            timeout: Duration::from_secs(120),
+        }
+    }
+}
+
+/// OpenAI-compatible LLM provider for local inference (vLLM, etc.).
+pub struct LocalProvider {
+    client: Client,
+    base_url: String,
+    default_model: String,
+}
+
+impl LocalProvider {
+    /// Create a new `LocalProvider` from configuration.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::ProviderInit`] if the HTTP client cannot be constructed.
+    pub fn new(config: &LocalProviderConfig) -> Result<Self> {
+        // WHY: reqwest 0.13 with rustls-no-provider requires an explicit crypto provider.
+        // install_default() is idempotent: subsequent calls return Err and are ignored.
+        let _ = rustls::crypto::ring::default_provider().install_default();
+
+        let client = Client::builder()
+            .timeout(config.timeout)
+            .build()
+            .map_err(|e| {
+                error::ProviderInitSnafu {
+                    message: format!("failed to build HTTP client: {e}"),
+                }
+                .build()
+            })?;
+
+        let base_url = config.base_url.trim_end_matches('/').to_owned();
+
+        debug!(
+            base_url = %base_url,
+            default_model = %config.default_model,
+            "local provider initialized"
+        );
+
+        Ok(Self {
+            client,
+            base_url,
+            default_model: config.default_model.clone(),
+        })
+    }
+
+    /// Resolve the model name: strip the `local/` prefix and fall back to default.
+    fn resolve_model<'a>(&'a self, model: &'a str) -> &'a str {
+        let stripped = model.strip_prefix(LOCAL_MODEL_PREFIX).unwrap_or(model);
+        if stripped.is_empty() {
+            &self.default_model
+        } else {
+            stripped
+        }
+    }
+
+    /// Map an Aletheia `CompletionRequest` to a `ChatCompletionRequest`.
+    fn build_request<'a>(
+        &'a self,
+        request: &'a CompletionRequest,
+        stream: bool,
+    ) -> ChatCompletionRequest<'a> {
+        let model = self.resolve_model(&request.model);
+        let messages = map_messages(request);
+
+        // Tool definitions.
+        let tools = if request.tools.is_empty() {
+            None
+        } else {
+            Some(
+                request
+                    .tools
+                    .iter()
+                    .map(|t| ChatTool {
+                        tool_type: "function",
+                        function: ChatFunction {
+                            name: &t.name,
+                            description: &t.description,
+                            parameters: &t.input_schema,
+                        },
+                    })
+                    .collect(),
+            )
+        };
+
+        let tool_choice = request.tool_choice.as_ref().map(|tc| match tc {
+            ToolChoice::Any => "required",
+            // NOTE: OpenAI's specific-tool format differs from Anthropic's; fall back to auto.
+            ToolChoice::Auto | ToolChoice::Tool { .. } => "auto",
+        });
+
+        let stop = if request.stop_sequences.is_empty() {
+            None
+        } else {
+            Some(request.stop_sequences.iter().map(String::as_str).collect())
+        };
+
+        ChatCompletionRequest {
+            model,
+            messages,
+            max_tokens: Some(request.max_tokens),
+            temperature: request.temperature,
+            stop,
+            tools,
+            tool_choice,
+            stream,
+        }
+    }
+
+    /// Execute a non-streaming completion.
+    async fn execute(&self, request: &CompletionRequest) -> Result<CompletionResponse> {
+        let chat_request = self.build_request(request, false);
+        let url = format!("{}/chat/completions", self.base_url);
+
+        let http_response = self
+            .client
+            .post(&url)
+            .json(&chat_request)
+            .send()
+            .await
+            .map_err(|e| {
+                error::ApiRequestSnafu {
+                    message: format!(
+                        "failed to connect to local provider at {url} \u{2014} \
+                         is the server running? ({e})"
+                    ),
+                }
+                .build()
+            })?;
+
+        let status = http_response.status();
+        if !status.is_success() {
+            return Err(map_http_error(status, http_response).await);
+        }
+
+        let chat_response: ChatCompletionResponse = http_response.json().await.map_err(|e| {
+            error::ApiRequestSnafu {
+                message: format!("failed to parse local provider response: {e}"),
+            }
+            .build()
+        })?;
+
+        Ok(map_response(chat_response))
+    }
+
+    /// Execute a streaming completion.
+    async fn execute_streaming(
+        &self,
+        request: &CompletionRequest,
+        on_event: &mut (dyn FnMut(StreamEvent) + Send),
+    ) -> Result<CompletionResponse> {
+        let chat_request = self.build_request(request, true);
+        let url = format!("{}/chat/completions", self.base_url);
+
+        let mut http_response = self
+            .client
+            .post(&url)
+            .json(&chat_request)
+            .send()
+            .await
+            .map_err(|e| {
+                error::ApiRequestSnafu {
+                    message: format!(
+                        "failed to connect to local provider at {url} \u{2014} \
+                         is the server running? ({e})"
+                    ),
+                }
+                .build()
+            })?;
+
+        let status = http_response.status();
+        if !status.is_success() {
+            return Err(map_http_error(status, http_response).await);
+        }
+
+        let (response, _has_content) = parse_openai_stream(&mut http_response, on_event).await?;
+        Ok(response)
+    }
+}
+
+/// Map Aletheia messages to chat messages.
+///
+/// Handles the translation from Anthropic's block-based content model to
+/// the flat message model:
+/// - System prompts become `role: "system"` messages
+/// - `Content::Text` maps directly
+/// - `Content::Blocks` are decomposed: text blocks are joined, tool results
+///   become `role: "tool"` messages, and tool use blocks become `tool_calls`
+fn map_messages(request: &CompletionRequest) -> Vec<ChatMessage> {
+    let mut messages = Vec::new();
+
+    // System prompt as a system message.
+    if let Some(system) = &request.system {
+        messages.push(ChatMessage {
+            role: "system".to_owned(),
+            content: Some(system.clone()),
+            tool_calls: None,
+            tool_call_id: None,
+        });
+    }
+
+    for msg in &request.messages {
+        match &msg.content {
+            Content::Text(text) => {
+                messages.push(ChatMessage {
+                    role: msg.role.as_str().to_owned(),
+                    content: Some(text.clone()),
+                    tool_calls: None,
+                    tool_call_id: None,
+                });
+            }
+            Content::Blocks(blocks) => {
+                map_block_message(&mut messages, msg.role.as_str(), blocks);
+            }
+        }
+    }
+
+    messages
+}
+
+/// Map a block-based message into one or more chat messages.
+fn map_block_message(messages: &mut Vec<ChatMessage>, role: &str, blocks: &[ContentBlock]) {
+    let mut text_parts: Vec<&str> = Vec::new();
+    let mut tool_calls: Vec<ChatToolCall> = Vec::new();
+
+    for block in blocks {
+        match block {
+            ContentBlock::Text { text, .. } => {
+                text_parts.push(text);
+            }
+            ContentBlock::ToolUse { id, name, input } => {
+                tool_calls.push(ChatToolCall {
+                    id: id.clone(),
+                    call_type: "function".to_owned(),
+                    function: ChatFunctionCall {
+                        name: name.clone(),
+                        arguments: input.to_string(),
+                    },
+                });
+            }
+            ContentBlock::ToolResult {
+                tool_use_id,
+                content,
+                ..
+            } => {
+                // Flush accumulated text before emitting tool result.
+                if !text_parts.is_empty() {
+                    messages.push(ChatMessage {
+                        role: role.to_owned(),
+                        content: Some(text_parts.join("\n")),
+                        tool_calls: None,
+                        tool_call_id: None,
+                    });
+                    text_parts.clear();
+                }
+                messages.push(ChatMessage {
+                    role: "tool".to_owned(),
+                    content: Some(content.text_summary()),
+                    tool_calls: None,
+                    tool_call_id: Some(tool_use_id.clone()),
+                });
+            }
+            // Thinking, server tool use, web search results, code execution
+            // are Anthropic-specific and have no equivalent in this wire format.
+            ContentBlock::Thinking { .. }
+            | ContentBlock::ServerToolUse { .. }
+            | ContentBlock::WebSearchToolResult { .. }
+            | ContentBlock::CodeExecutionResult { .. } => {}
+        }
+    }
+
+    // Flush remaining text and/or tool calls.
+    if !text_parts.is_empty() || !tool_calls.is_empty() {
+        messages.push(ChatMessage {
+            role: role.to_owned(),
+            content: if text_parts.is_empty() {
+                None
+            } else {
+                Some(text_parts.join("\n"))
+            },
+            tool_calls: if tool_calls.is_empty() {
+                None
+            } else {
+                Some(tool_calls)
+            },
+            tool_call_id: None,
+        });
+    }
+}
+
+/// Map an HTTP error response to a hermeneus error.
+async fn map_http_error(status: reqwest::StatusCode, response: reqwest::Response) -> error::Error {
+    let body = response.text().await.unwrap_or_default();
+    if status.as_u16() == 429 {
+        return error::RateLimitedSnafu {
+            retry_after_ms: 1000_u64,
+        }
+        .build();
+    }
+    error::ApiRequestSnafu {
+        message: format!("local provider returned {status}: {body}"),
+    }
+    .build()
+}
+
+/// Map a `finish_reason` string to a [`StopReason`].
+fn map_finish_reason(reason: Option<&str>) -> StopReason {
+    match reason {
+        Some("tool_calls") => StopReason::ToolUse,
+        Some("length") => StopReason::MaxTokens,
+        Some("stop" | _) | None => StopReason::EndTurn,
+    }
+}
+
+/// Map a chat completion response to Aletheia's canonical response type.
+fn map_response(response: ChatCompletionResponse) -> CompletionResponse {
+    let choice = response.choices.into_iter().next();
+    let (content, stop_reason) = match choice {
+        Some(c) => {
+            let mut blocks = Vec::new();
+
+            if let Some(text) = c.message.content
+                && !text.is_empty()
+            {
+                blocks.push(ContentBlock::Text {
+                    text,
+                    citations: None,
+                });
+            }
+
+            if let Some(tool_calls) = c.message.tool_calls {
+                for tc in tool_calls {
+                    let input = serde_json::from_str(&tc.function.arguments).unwrap_or_else(|e| {
+                        warn!(
+                            error = %e,
+                            arguments = %tc.function.arguments,
+                            "failed to parse tool call arguments, using empty object"
+                        );
+                        serde_json::Value::Object(serde_json::Map::new())
+                    });
+                    blocks.push(ContentBlock::ToolUse {
+                        id: tc.id,
+                        name: tc.function.name,
+                        input,
+                    });
+                }
+            }
+
+            let reason = map_finish_reason(c.finish_reason.as_deref());
+            (blocks, reason)
+        }
+        None => (Vec::new(), StopReason::EndTurn),
+    };
+
+    let usage = response.usage.map_or(Usage::default(), |u| Usage {
+        input_tokens: u.prompt_tokens,
+        output_tokens: u.completion_tokens,
+        ..Usage::default()
+    });
+
+    CompletionResponse {
+        id: response.id,
+        model: response.model,
+        stop_reason,
+        content,
+        usage,
+    }
+}
+
+impl std::fmt::Debug for LocalProvider {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("LocalProvider")
+            .field("base_url", &self.base_url)
+            .field("default_model", &self.default_model)
+            .finish_non_exhaustive()
+    }
+}
+
+impl LlmProvider for LocalProvider {
+    fn complete<'a>(
+        &'a self,
+        request: &'a CompletionRequest,
+    ) -> Pin<Box<dyn Future<Output = Result<CompletionResponse>> + Send + 'a>> {
+        Box::pin(self.execute(request))
+    }
+
+    fn supported_models(&self) -> &[&str] {
+        // WHY: LocalProvider matches any model with the "local/" prefix via
+        // `supports_model` override. Returning an empty slice here is correct
+        // because the set of local models is dynamic (whatever vLLM serves).
+        &[]
+    }
+
+    fn supports_model(&self, model: &str) -> bool {
+        model.starts_with(LOCAL_MODEL_PREFIX)
+    }
+
+    fn name(&self) -> &'static str {
+        "local"
+    }
+
+    fn supports_streaming(&self) -> bool {
+        true
+    }
+
+    fn complete_streaming<'a>(
+        &'a self,
+        request: &'a CompletionRequest,
+        on_event: &'a mut (dyn FnMut(StreamEvent) + Send),
+    ) -> Pin<Box<dyn Future<Output = Result<CompletionResponse>> + Send + 'a>> {
+        Box::pin(self.execute_streaming(request, on_event))
+    }
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "test assertions")]
+#[expect(
+    clippy::indexing_slicing,
+    reason = "test: index bounds verified by preceding assertions"
+)]
+#[path = "provider_tests.rs"]
+mod tests;

--- a/crates/hermeneus/src/local/provider_tests.rs
+++ b/crates/hermeneus/src/local/provider_tests.rs
@@ -1,0 +1,343 @@
+//! Integration tests for `LocalProvider` using a wiremock mock server.
+
+use wiremock::matchers::{header, method, path};
+use wiremock::{Mock, MockServer, Request, ResponseTemplate};
+
+use crate::local::{LocalProvider, LocalProviderConfig};
+use crate::provider::LlmProvider;
+use crate::types::{
+    CompletionRequest, Content, ContentBlock, Message, Role, StopReason, ToolDefinition,
+};
+
+/// Helper to build a `LocalProvider` pointing at the mock server.
+fn provider_for(server: &MockServer) -> LocalProvider {
+    let config = LocalProviderConfig {
+        base_url: format!("{}/v1", server.uri()),
+        default_model: "test-model".to_owned(),
+        ..LocalProviderConfig::default()
+    };
+    LocalProvider::new(&config).unwrap()
+}
+
+/// Helper to build a simple user-message request.
+fn simple_request(model: &str) -> CompletionRequest {
+    CompletionRequest {
+        model: model.to_owned(),
+        system: Some("You are a test assistant.".to_owned()),
+        messages: vec![Message {
+            role: Role::User,
+            content: Content::Text("Hello".to_owned()),
+        }],
+        max_tokens: 100,
+        ..Default::default()
+    }
+}
+
+#[tokio::test]
+async fn simple_completion() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/v1/chat/completions"))
+        .and(header("content-type", "application/json"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "id": "chatcmpl-test-1",
+            "model": "test-model",
+            "choices": [{
+                "message": {
+                    "role": "assistant",
+                    "content": "Hello! How can I help?"
+                },
+                "finish_reason": "stop"
+            }],
+            "usage": {
+                "prompt_tokens": 15,
+                "completion_tokens": 8
+            }
+        })))
+        .mount(&server)
+        .await;
+
+    let provider = provider_for(&server);
+    let response = provider
+        .complete(&simple_request("local/test-model"))
+        .await
+        .unwrap();
+
+    assert_eq!(response.id, "chatcmpl-test-1");
+    assert_eq!(response.stop_reason, StopReason::EndTurn);
+    assert_eq!(response.usage.input_tokens, 15);
+    assert_eq!(response.usage.output_tokens, 8);
+    assert_eq!(response.content.len(), 1);
+    match &response.content[0] {
+        ContentBlock::Text { text, .. } => assert_eq!(text, "Hello! How can I help?"),
+        other => panic!("expected Text, got: {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn streaming_completion() {
+    let server = MockServer::start().await;
+
+    // WHY: wiremock serves the full body at once, which is fine for testing
+    // the SSE parser since it processes bytes incrementally.
+    let sse_body = "\
+data: {\"id\":\"chatcmpl-s1\",\"model\":\"test-model\",\"choices\":[{\"delta\":{\"content\":\"Hi\"},\"finish_reason\":null}]}\n\
+\n\
+data: {\"id\":\"chatcmpl-s1\",\"model\":\"test-model\",\"choices\":[{\"delta\":{\"content\":\" there\"},\"finish_reason\":null}]}\n\
+\n\
+data: {\"id\":\"chatcmpl-s1\",\"model\":\"test-model\",\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\"}]}\n\
+\n\
+data: [DONE]\n\
+\n";
+
+    Mock::given(method("POST"))
+        .and(path("/v1/chat/completions"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_string(sse_body)
+                .insert_header("content-type", "text/event-stream"),
+        )
+        .mount(&server)
+        .await;
+
+    let provider = provider_for(&server);
+    let request = simple_request("local/test-model");
+
+    let mut events = Vec::new();
+    let response = provider
+        .complete_streaming(&request, &mut |e| events.push(e))
+        .await
+        .unwrap();
+
+    assert_eq!(response.id, "chatcmpl-s1");
+    assert_eq!(response.stop_reason, StopReason::EndTurn);
+    match &response.content[0] {
+        ContentBlock::Text { text, .. } => assert_eq!(text, "Hi there"),
+        other => panic!("expected Text, got: {other:?}"),
+    }
+
+    // Verify streaming events were emitted.
+    assert!(
+        events.iter().any(
+            |e| matches!(e, crate::anthropic::StreamEvent::TextDelta { text } if text == "Hi")
+        )
+    );
+}
+
+#[tokio::test]
+async fn tool_call_completion() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/v1/chat/completions"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "id": "chatcmpl-tool-1",
+            "model": "test-model",
+            "choices": [{
+                "message": {
+                    "role": "assistant",
+                    "content": null,
+                    "tool_calls": [{
+                        "id": "call_abc123",
+                        "type": "function",
+                        "function": {
+                            "name": "get_weather",
+                            "arguments": "{\"location\":\"London\"}"
+                        }
+                    }]
+                },
+                "finish_reason": "tool_calls"
+            }],
+            "usage": {
+                "prompt_tokens": 20,
+                "completion_tokens": 10
+            }
+        })))
+        .mount(&server)
+        .await;
+
+    let provider = provider_for(&server);
+    let mut request = simple_request("local/test-model");
+    request.tools = vec![ToolDefinition {
+        name: "get_weather".to_owned(),
+        description: "Get weather for a location".to_owned(),
+        input_schema: serde_json::json!({
+            "type": "object",
+            "properties": {
+                "location": {"type": "string"}
+            }
+        }),
+        disable_passthrough: None,
+    }];
+
+    let response = provider.complete(&request).await.unwrap();
+
+    assert_eq!(response.stop_reason, StopReason::ToolUse);
+    assert_eq!(response.content.len(), 1);
+    match &response.content[0] {
+        ContentBlock::ToolUse { id, name, input } => {
+            assert_eq!(id, "call_abc123");
+            assert_eq!(name, "get_weather");
+            assert_eq!(input["location"], "London");
+        }
+        other => panic!("expected ToolUse, got: {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn connection_error_returns_api_request_error() {
+    // NOTE: No server started — connection will be refused.
+    let config = LocalProviderConfig {
+        base_url: "http://127.0.0.1:1/v1".to_owned(),
+        default_model: "test-model".to_owned(),
+        ..LocalProviderConfig::default()
+    };
+    let provider = LocalProvider::new(&config).unwrap();
+
+    let result = provider.complete(&simple_request("local/test-model")).await;
+
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("failed to connect"),
+        "expected connection error message, got: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn rate_limit_response_maps_to_rate_limited_error() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/v1/chat/completions"))
+        .respond_with(ResponseTemplate::new(429).set_body_string("rate limited"))
+        .mount(&server)
+        .await;
+
+    let provider = provider_for(&server);
+    let result = provider.complete(&simple_request("local/test-model")).await;
+
+    assert!(result.is_err());
+    assert!(
+        matches!(result.unwrap_err(), crate::error::Error::RateLimited { .. }),
+        "expected RateLimited error"
+    );
+}
+
+#[tokio::test]
+async fn server_error_maps_to_api_request_error() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/v1/chat/completions"))
+        .respond_with(ResponseTemplate::new(500).set_body_string("internal error"))
+        .mount(&server)
+        .await;
+
+    let provider = provider_for(&server);
+    let result = provider.complete(&simple_request("local/test-model")).await;
+
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("500"),
+        "expected status code in error, got: {msg}"
+    );
+}
+
+#[test]
+fn supports_model_with_local_prefix() {
+    let config = LocalProviderConfig::default();
+    let provider = LocalProvider::new(&config).unwrap();
+
+    assert!(provider.supports_model("local/qwen3.5-27b"));
+    assert!(provider.supports_model("local/anything"));
+    assert!(!provider.supports_model("claude-opus-4-20250514"));
+    assert!(!provider.supports_model("qwen3.5-27b"));
+}
+
+#[test]
+fn provider_name_is_local() {
+    let config = LocalProviderConfig::default();
+    let provider = LocalProvider::new(&config).unwrap();
+    assert_eq!(provider.name(), "local");
+}
+
+#[test]
+fn supports_streaming() {
+    let config = LocalProviderConfig::default();
+    let provider = LocalProvider::new(&config).unwrap();
+    assert!(provider.supports_streaming());
+}
+
+#[tokio::test]
+async fn request_sends_system_message_and_tools() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/v1/chat/completions"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "id": "chatcmpl-verify",
+            "model": "test-model",
+            "choices": [{
+                "message": {"content": "ok"},
+                "finish_reason": "stop"
+            }],
+            "usage": {"prompt_tokens": 10, "completion_tokens": 1}
+        })))
+        .mount(&server)
+        .await;
+
+    let provider = provider_for(&server);
+    let mut request = simple_request("local/test-model");
+    request.tools = vec![ToolDefinition {
+        name: "echo".to_owned(),
+        description: "Echo input".to_owned(),
+        input_schema: serde_json::json!({"type": "object"}),
+        disable_passthrough: None,
+    }];
+
+    let response = provider.complete(&request).await.unwrap();
+    assert_eq!(response.id, "chatcmpl-verify");
+}
+
+#[tokio::test]
+async fn model_prefix_stripped_in_request() {
+    let server = MockServer::start().await;
+
+    // Verify the model sent to vLLM has the "local/" prefix stripped.
+    // Use a wiremock expectation that captures the request body.
+    Mock::given(method("POST"))
+        .and(path("/v1/chat/completions"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "id": "chatcmpl-strip",
+            "model": "qwen3.5-27b",
+            "choices": [{
+                "message": {"content": "ok"},
+                "finish_reason": "stop"
+            }],
+            "usage": {"prompt_tokens": 5, "completion_tokens": 1}
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let provider = provider_for(&server);
+    let response = provider
+        .complete(&simple_request("local/qwen3.5-27b"))
+        .await
+        .unwrap();
+
+    assert_eq!(response.id, "chatcmpl-strip");
+
+    // Verify the "local/" prefix was stripped from the model in the request.
+    let requests: Vec<Request> = server.received_requests().await.unwrap();
+    let body: serde_json::Value = serde_json::from_slice(&requests[0].body).unwrap();
+    assert_eq!(
+        body["model"], "qwen3.5-27b",
+        "local/ prefix should be stripped"
+    );
+}

--- a/crates/hermeneus/src/local/stream.rs
+++ b/crates/hermeneus/src/local/stream.rs
@@ -1,0 +1,416 @@
+//! SSE stream parser for OpenAI-compatible streaming responses.
+//!
+//! Parses `data: {...}\n\n` server-sent events from an HTTP response body,
+//! accumulates tool call fragments, and emits [`StreamEvent`]s to a callback.
+//! The stream terminates on `data: [DONE]`.
+
+use reqwest::Response;
+
+use super::types::{ChatChunkToolCall, ChatCompletionChunk};
+use crate::anthropic::StreamEvent;
+use crate::error::{self, Result};
+use crate::types::{StopReason, Usage};
+
+/// Accumulated state for a tool call being streamed incrementally.
+#[derive(Debug, Default)]
+struct ToolCallAccumulator {
+    id: String,
+    name: String,
+    arguments: String,
+}
+
+/// Accumulator for the full streaming response.
+pub(crate) struct StreamAccumulator {
+    id: String,
+    model: String,
+    text: String,
+    tool_calls: Vec<ToolCallAccumulator>,
+    finish_reason: Option<String>,
+    usage: Option<(u64, u64)>,
+    /// Whether any content has been emitted (for retry safety).
+    has_content: bool,
+}
+
+impl StreamAccumulator {
+    pub(crate) fn new() -> Self {
+        Self {
+            id: String::new(),
+            model: String::new(),
+            text: String::new(),
+            tool_calls: Vec::new(),
+            finish_reason: None,
+            usage: None,
+            has_content: false,
+        }
+    }
+
+    /// Whether any content events have been emitted.
+    pub(crate) fn has_content(&self) -> bool {
+        self.has_content
+    }
+
+    /// Process a single chunk, emitting stream events to the callback.
+    pub(crate) fn process_chunk(
+        &mut self,
+        chunk: &ChatCompletionChunk,
+        on_event: &mut dyn FnMut(StreamEvent),
+    ) {
+        if self.id.is_empty() {
+            self.id.clone_from(&chunk.id);
+            self.model.clone_from(&chunk.model);
+            on_event(StreamEvent::MessageStart {
+                usage: Usage::default(),
+            });
+        }
+
+        if let Some(usage) = &chunk.usage {
+            self.usage = Some((usage.prompt_tokens, usage.completion_tokens));
+        }
+
+        for choice in &chunk.choices {
+            if let Some(text) = &choice.delta.content
+                && !text.is_empty()
+            {
+                if !self.has_content {
+                    on_event(StreamEvent::ContentBlockStart {
+                        index: 0,
+                        block_type: "text".to_owned(),
+                    });
+                    self.has_content = true;
+                }
+                self.text.push_str(text);
+                on_event(StreamEvent::TextDelta { text: text.clone() });
+            }
+
+            if let Some(tool_calls) = &choice.delta.tool_calls {
+                for tc in tool_calls {
+                    self.accumulate_tool_call(tc, on_event);
+                }
+            }
+
+            if let Some(reason) = &choice.finish_reason {
+                self.finish_reason = Some(reason.clone());
+            }
+        }
+    }
+
+    fn accumulate_tool_call(
+        &mut self,
+        tc: &ChatChunkToolCall,
+        on_event: &mut dyn FnMut(StreamEvent),
+    ) {
+        let idx = usize::try_from(tc.index).unwrap_or(0);
+
+        // Grow the accumulator vec if needed.
+        while self.tool_calls.len() <= idx {
+            self.tool_calls.push(ToolCallAccumulator::default());
+        }
+
+        // SAFETY: We just ensured self.tool_calls.len() > idx in the while loop above.
+        #[expect(
+            clippy::indexing_slicing,
+            reason = "idx is bounded: while loop above grows vec to len > idx"
+        )]
+        let acc = &mut self.tool_calls[idx];
+
+        if let Some(id) = &tc.id {
+            acc.id.clone_from(id);
+        }
+
+        if let Some(func) = &tc.function {
+            if let Some(name) = &func.name {
+                acc.name.clone_from(name);
+                // WHY: tool_use block index offset by 1 if text block exists.
+                let block_index = if self.text.is_empty() { idx } else { idx + 1 };
+                #[expect(
+                    clippy::cast_possible_truncation,
+                    reason = "block index is bounded by tool call count, always fits in u32"
+                )]
+                #[expect(
+                    clippy::as_conversions,
+                    reason = "block index is bounded by tool call count, safe truncation"
+                )]
+                let index = block_index as u32;
+                on_event(StreamEvent::ContentBlockStart {
+                    index,
+                    block_type: "tool_use".to_owned(),
+                });
+                self.has_content = true;
+            }
+            if let Some(args) = &func.arguments
+                && !args.is_empty()
+            {
+                acc.arguments.push_str(args);
+                on_event(StreamEvent::InputJsonDelta {
+                    partial_json: args.clone(),
+                });
+            }
+        }
+    }
+
+    /// Build the final stop reason from the accumulated `finish_reason`.
+    fn stop_reason(&self) -> StopReason {
+        map_finish_reason(self.finish_reason.as_deref())
+    }
+
+    /// Finalize and return the accumulated usage.
+    fn final_usage(&self) -> Usage {
+        match self.usage {
+            Some((input, output)) => Usage {
+                input_tokens: input,
+                output_tokens: output,
+                ..Usage::default()
+            },
+            None => Usage::default(),
+        }
+    }
+}
+
+/// Map a `finish_reason` string to a [`StopReason`].
+fn map_finish_reason(reason: Option<&str>) -> StopReason {
+    match reason {
+        Some("tool_calls") => StopReason::ToolUse,
+        Some("length") => StopReason::MaxTokens,
+        Some("stop" | _) | None => StopReason::EndTurn,
+    }
+}
+
+/// Parse OpenAI-format SSE events from a live HTTP response stream.
+///
+/// Reads the response body chunk-by-chunk, parses `data: {...}` lines,
+/// and emits [`StreamEvent`]s to the callback. The stream terminates
+/// on `data: [DONE]` or EOF.
+///
+/// # Errors
+///
+/// Returns an error on transport failure or malformed JSON in a chunk.
+pub(crate) async fn parse_openai_stream(
+    response: &mut Response,
+    on_event: &mut (dyn FnMut(StreamEvent) + Send),
+) -> Result<(crate::types::CompletionResponse, bool)> {
+    let mut acc = StreamAccumulator::new();
+    let mut line_buf: Vec<u8> = Vec::with_capacity(512);
+
+    loop {
+        let chunk = response.chunk().await.map_err(|e| {
+            error::ApiRequestSnafu {
+                message: format!("stream read error: {e}"),
+            }
+            .build()
+        })?;
+
+        let Some(bytes) = chunk else { break };
+
+        for &byte in &bytes {
+            if byte == b'\n' {
+                let line_cow = String::from_utf8_lossy(&line_buf);
+                let line = line_cow.trim_end_matches('\r');
+
+                if let Some(data) = line.strip_prefix("data: ") {
+                    if data == "[DONE]" {
+                        line_buf.clear();
+                        // Emit final stop events.
+                        let stop_reason = acc.stop_reason();
+                        let usage = acc.final_usage();
+                        on_event(StreamEvent::MessageStop { stop_reason, usage });
+                        return Ok((build_response(&acc), acc.has_content()));
+                    }
+
+                    let chunk: ChatCompletionChunk = serde_json::from_str(data).map_err(|e| {
+                        error::ApiRequestSnafu {
+                            message: format!("stream chunk parse error: {e}"),
+                        }
+                        .build()
+                    })?;
+                    acc.process_chunk(&chunk, on_event);
+                }
+                // NOTE: Ignore non-data lines (event:, id:, comments, blank).
+                line_buf.clear();
+            } else {
+                line_buf.push(byte);
+            }
+        }
+    }
+
+    // EOF without [DONE] — build response from what we have.
+    let stop_reason = acc.stop_reason();
+    let usage = acc.final_usage();
+    on_event(StreamEvent::MessageStop { stop_reason, usage });
+    Ok((build_response(&acc), acc.has_content()))
+}
+
+/// Parse OpenAI-format SSE events from a byte reader (for tests).
+#[cfg(test)]
+pub(crate) fn parse_openai_stream_sync(
+    mut reader: impl std::io::BufRead,
+    on_event: &mut impl FnMut(StreamEvent),
+) -> Result<crate::types::CompletionResponse> {
+    let mut acc = StreamAccumulator::new();
+    let mut raw_line: Vec<u8> = Vec::new();
+
+    loop {
+        raw_line.clear();
+        let n = reader.read_until(b'\n', &mut raw_line).map_err(|e| {
+            error::ApiRequestSnafu {
+                message: format!("stream read error: {e}"),
+            }
+            .build()
+        })?;
+
+        if n == 0 {
+            break;
+        }
+
+        let line_cow = String::from_utf8_lossy(&raw_line);
+        let line = line_cow.trim_end_matches(['\n', '\r']);
+
+        if let Some(data) = line.strip_prefix("data: ") {
+            if data == "[DONE]" {
+                let stop_reason = acc.stop_reason();
+                let usage = acc.final_usage();
+                on_event(StreamEvent::MessageStop { stop_reason, usage });
+                return Ok(build_response(&acc));
+            }
+
+            let chunk: ChatCompletionChunk = serde_json::from_str(data).map_err(|e| {
+                error::ApiRequestSnafu {
+                    message: format!("stream chunk parse error: {e}"),
+                }
+                .build()
+            })?;
+            acc.process_chunk(&chunk, on_event);
+        }
+    }
+
+    let stop_reason = acc.stop_reason();
+    let usage = acc.final_usage();
+    on_event(StreamEvent::MessageStop { stop_reason, usage });
+    Ok(build_response(&acc))
+}
+
+/// Build a [`CompletionResponse`] from accumulated stream state.
+fn build_response(acc: &StreamAccumulator) -> crate::types::CompletionResponse {
+    use crate::types::{CompletionResponse, ContentBlock};
+
+    let mut content = Vec::new();
+
+    if !acc.text.is_empty() {
+        content.push(ContentBlock::Text {
+            text: acc.text.clone(),
+            citations: None,
+        });
+    }
+
+    for tc in &acc.tool_calls {
+        // WHY: Parse arguments as JSON; fall back to empty object on parse failure
+        // (vLLM can send empty arguments for zero-parameter tools).
+        let input = serde_json::from_str(&tc.arguments)
+            .unwrap_or(serde_json::Value::Object(serde_json::Map::new()));
+        content.push(ContentBlock::ToolUse {
+            id: tc.id.clone(),
+            name: tc.name.clone(),
+            input,
+        });
+    }
+
+    CompletionResponse {
+        id: acc.id.clone(),
+        model: acc.model.clone(),
+        stop_reason: acc.stop_reason(),
+        content,
+        usage: acc.final_usage(),
+    }
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "test assertions")]
+#[expect(
+    clippy::indexing_slicing,
+    reason = "test: index 0 is valid after asserting content.len()"
+)]
+mod tests {
+    use super::*;
+    use crate::types::{ContentBlock, StopReason};
+
+    #[test]
+    fn parses_simple_text_stream() {
+        let sse = "\
+data: {\"id\":\"chatcmpl-1\",\"model\":\"local/qwen\",\"choices\":[{\"delta\":{\"content\":\"Hello\"},\"finish_reason\":null}]}\n\
+\n\
+data: {\"id\":\"chatcmpl-1\",\"model\":\"local/qwen\",\"choices\":[{\"delta\":{\"content\":\" world\"},\"finish_reason\":null}]}\n\
+\n\
+data: {\"id\":\"chatcmpl-1\",\"model\":\"local/qwen\",\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\"}]}\n\
+\n\
+data: [DONE]\n\
+\n";
+
+        let mut events = Vec::new();
+        let response =
+            parse_openai_stream_sync(std::io::Cursor::new(sse), &mut |e| events.push(e)).unwrap();
+
+        assert_eq!(response.id, "chatcmpl-1");
+        assert_eq!(response.stop_reason, StopReason::EndTurn);
+        assert_eq!(response.content.len(), 1);
+        match &response.content[0] {
+            ContentBlock::Text { text, .. } => assert_eq!(text, "Hello world"),
+            other => panic!("expected Text, got: {other:?}"),
+        }
+
+        assert!(
+            events
+                .iter()
+                .any(|e| matches!(e, StreamEvent::TextDelta { text } if text == "Hello"))
+        );
+        assert!(
+            events
+                .iter()
+                .any(|e| matches!(e, StreamEvent::TextDelta { text } if text == " world"))
+        );
+    }
+
+    #[test]
+    fn parses_tool_call_stream() {
+        let sse = "\
+data: {\"id\":\"chatcmpl-2\",\"model\":\"local/qwen\",\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_1\",\"function\":{\"name\":\"exec\",\"arguments\":\"\"}}]},\"finish_reason\":null}]}\n\
+\n\
+data: {\"id\":\"chatcmpl-2\",\"model\":\"local/qwen\",\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"function\":{\"arguments\":\"{\\\"cmd\\\"\"}}]},\"finish_reason\":null}]}\n\
+\n\
+data: {\"id\":\"chatcmpl-2\",\"model\":\"local/qwen\",\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"function\":{\"arguments\":\": \\\"ls\\\"}\"}}]},\"finish_reason\":null}]}\n\
+\n\
+data: {\"id\":\"chatcmpl-2\",\"model\":\"local/qwen\",\"choices\":[{\"delta\":{},\"finish_reason\":\"tool_calls\"}]}\n\
+\n\
+data: [DONE]\n\
+\n";
+
+        let mut events = Vec::new();
+        let response =
+            parse_openai_stream_sync(std::io::Cursor::new(sse), &mut |e| events.push(e)).unwrap();
+
+        assert_eq!(response.stop_reason, StopReason::ToolUse);
+        assert_eq!(response.content.len(), 1);
+        match &response.content[0] {
+            ContentBlock::ToolUse { id, name, input } => {
+                assert_eq!(id, "call_1");
+                assert_eq!(name, "exec");
+                assert_eq!(input["cmd"], "ls");
+            }
+            other => panic!("expected ToolUse, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn malformed_json_returns_error() {
+        let sse = "data: not valid json\n\n";
+        let result = parse_openai_stream_sync(std::io::Cursor::new(sse), &mut |_| {});
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn empty_stream_returns_defaults() {
+        let mut events = Vec::new();
+        let response =
+            parse_openai_stream_sync(std::io::Cursor::new(""), &mut |e| events.push(e)).unwrap();
+        assert_eq!(response.stop_reason, StopReason::EndTurn);
+        assert!(response.content.is_empty());
+    }
+}

--- a/crates/hermeneus/src/local/types.rs
+++ b/crates/hermeneus/src/local/types.rs
@@ -1,0 +1,187 @@
+//! OpenAI-compatible request and response types for local LLM inference.
+//!
+//! These types model the subset of the `OpenAI` Chat Completions API that
+//! vLLM and other compatible servers implement. They handle serialization
+//! for outbound requests and deserialization for inbound responses.
+
+use serde::{Deserialize, Serialize};
+
+/// Chat completion request in the OpenAI-compatible wire format.
+#[derive(Debug, Serialize)]
+pub(crate) struct ChatCompletionRequest<'a> {
+    /// Model identifier passed through to the vLLM endpoint.
+    pub model: &'a str,
+    /// Conversation messages.
+    pub messages: Vec<ChatMessage>,
+    /// Maximum tokens to generate.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_tokens: Option<u32>,
+    /// Sampling temperature.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub temperature: Option<f32>,
+    /// Stop sequences.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stop: Option<Vec<&'a str>>,
+    /// Tool (function) definitions for function calling.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tools: Option<Vec<ChatTool<'a>>>,
+    /// Tool choice constraint.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_choice: Option<&'a str>,
+    /// Whether to stream the response.
+    pub stream: bool,
+}
+
+/// A chat message in the OpenAI-compatible wire format.
+///
+/// Uses owned strings for `content` and `tool_call_id` because message
+/// mapping from Anthropic's block-based format requires constructing
+/// new strings (e.g., joining text blocks, extracting tool result summaries).
+#[derive(Debug, Serialize)]
+pub(crate) struct ChatMessage {
+    /// Message role: `"system"`, `"user"`, `"assistant"`, or `"tool"`.
+    pub role: String,
+    /// Text content of the message.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub content: Option<String>,
+    /// Tool calls made by the assistant.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_calls: Option<Vec<ChatToolCall>>,
+    /// Tool call ID this message responds to (for `role: "tool"`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_call_id: Option<String>,
+}
+
+/// A tool definition in the function-calling wire format.
+#[derive(Debug, Serialize)]
+pub(crate) struct ChatTool<'a> {
+    /// Always `"function"`.
+    #[serde(rename = "type")]
+    pub tool_type: &'a str,
+    /// Function definition.
+    pub function: ChatFunction<'a>,
+}
+
+/// Function definition within a tool.
+#[derive(Debug, Serialize)]
+pub(crate) struct ChatFunction<'a> {
+    /// Function name.
+    pub name: &'a str,
+    /// Human-readable description.
+    pub description: &'a str,
+    /// JSON Schema for the function parameters.
+    pub parameters: &'a serde_json::Value,
+}
+
+/// A tool call in the response wire format.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct ChatToolCall {
+    /// Unique tool call identifier.
+    pub id: String,
+    /// Always `"function"`.
+    #[serde(rename = "type")]
+    pub call_type: String,
+    /// Function call details.
+    pub function: ChatFunctionCall,
+}
+
+/// Function call details within a tool call.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct ChatFunctionCall {
+    /// Function name.
+    pub name: String,
+    /// JSON-encoded arguments string.
+    pub arguments: String,
+}
+
+/// Chat completion response (non-streaming).
+#[derive(Debug, Deserialize)]
+pub(crate) struct ChatCompletionResponse {
+    /// Response identifier.
+    pub id: String,
+    /// Model used for the completion.
+    pub model: String,
+    /// Response choices (typically one).
+    pub choices: Vec<ChatChoice>,
+    /// Token usage statistics.
+    pub usage: Option<ChatUsage>,
+}
+
+/// A single choice in the completion response.
+#[derive(Debug, Deserialize)]
+pub(crate) struct ChatChoice {
+    /// The assistant's response message.
+    pub message: ChatResponseMessage,
+    /// Why generation stopped.
+    pub finish_reason: Option<String>,
+}
+
+/// The assistant message in a completion response.
+#[derive(Debug, Deserialize)]
+pub(crate) struct ChatResponseMessage {
+    /// Text content.
+    pub content: Option<String>,
+    /// Tool calls requested by the model.
+    pub tool_calls: Option<Vec<ChatToolCall>>,
+}
+
+/// Token usage in the completion response.
+#[derive(Debug, Deserialize)]
+pub(crate) struct ChatUsage {
+    /// Tokens consumed by the prompt.
+    pub prompt_tokens: u64,
+    /// Tokens generated in the completion.
+    pub completion_tokens: u64,
+}
+
+/// A single streaming chunk in the SSE format.
+#[derive(Debug, Deserialize)]
+pub(crate) struct ChatCompletionChunk {
+    /// Chunk identifier (same across all chunks in a stream).
+    pub id: String,
+    /// Model used.
+    pub model: String,
+    /// Chunk choices (typically one).
+    pub choices: Vec<ChatChunkChoice>,
+    /// Usage statistics (only present in the final chunk when requested).
+    pub usage: Option<ChatUsage>,
+}
+
+/// A choice within a streaming chunk.
+#[derive(Debug, Deserialize)]
+pub(crate) struct ChatChunkChoice {
+    /// Incremental content delta.
+    pub delta: ChatChunkDelta,
+    /// Finish reason (present only in the final chunk).
+    pub finish_reason: Option<String>,
+}
+
+/// Delta content within a streaming chunk choice.
+#[derive(Debug, Deserialize)]
+pub(crate) struct ChatChunkDelta {
+    /// Incremental text content.
+    pub content: Option<String>,
+    /// Incremental tool call deltas.
+    pub tool_calls: Option<Vec<ChatChunkToolCall>>,
+}
+
+/// Tool call delta in a streaming chunk.
+#[derive(Debug, Deserialize)]
+pub(crate) struct ChatChunkToolCall {
+    /// Zero-based index of the tool call being built.
+    pub index: u32,
+    /// Tool call ID (present in the first chunk for this tool call).
+    #[serde(default)]
+    pub id: Option<String>,
+    /// Function call delta.
+    pub function: Option<ChatChunkFunction>,
+}
+
+/// Function call delta in a streaming chunk.
+#[derive(Debug, Deserialize)]
+pub(crate) struct ChatChunkFunction {
+    /// Function name (present in the first chunk for this tool call).
+    pub name: Option<String>,
+    /// Incremental JSON arguments fragment.
+    pub arguments: Option<String>,
+}

--- a/crates/taxis/src/config/mod.rs
+++ b/crates/taxis/src/config/mod.rs
@@ -51,6 +51,34 @@ pub struct AletheiaConfig {
     pub logging: LoggingSettings,
     /// MCP server configuration.
     pub mcp: McpConfig,
+    /// Local LLM provider configuration (vLLM / OpenAI-compatible endpoint).
+    pub local_provider: LocalProviderConfig,
+}
+
+/// Configuration for a local OpenAI-compatible LLM provider (vLLM, etc.).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[serde(default)]
+pub struct LocalProviderConfig {
+    /// Whether the local provider is enabled.
+    pub enabled: bool,
+    /// Base URL of the OpenAI-compatible endpoint.
+    pub base_url: String,
+    /// Default model served by the local endpoint.
+    pub model: String,
+    /// HTTP request timeout in seconds.
+    pub timeout_secs: u64,
+}
+
+impl Default for LocalProviderConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            base_url: "http://localhost:8000/v1".to_owned(),
+            model: "qwen3.5-27b".to_owned(),
+            timeout_secs: 120,
+        }
+    }
 }
 
 /// Sandbox enforcement level for tool execution.

--- a/crates/taxis/src/validate.rs
+++ b/crates/taxis/src/validate.rs
@@ -66,7 +66,7 @@ pub fn validate_section(section: &str, value: &Value) -> Result<(), ValidationEr
         "bindings" => validate_bindings(value, &mut errors),
         "credential" => validate_credential(value, &mut errors),
         // NOTE: these sections are pass-through with no validation rules
-        "packs" | "pricing" | "sandbox" | "logging" | "mcp" => {}
+        "packs" | "pricing" | "sandbox" | "logging" | "mcp" | "localProvider" => {}
         _ => errors.push(format!("unknown config section: {section}")),
     }
 

--- a/instance.example/config/aletheia.toml
+++ b/instance.example/config/aletheia.toml
@@ -133,3 +133,13 @@ workspace = "nous/main"
 # --- Request body limit ---
 # [gateway.bodyLimit]
 # maxBytes = 1048576           # 1 MB default
+
+# --- Local LLM provider ---
+# OpenAI-compatible endpoint for local model inference (vLLM, etc.).
+# Models are routed here when prefixed with "local/" (e.g. "local/qwen3.5-27b").
+# Requires the `local-llm` feature flag at compile time.
+# [localProvider]
+# enabled = false
+# baseUrl = "http://localhost:8000/v1"
+# model = "qwen3.5-27b"            # default model for "local/" requests
+# timeoutSecs = 120


### PR DESCRIPTION
## Summary

- Adds `LocalProvider` behind the `local-llm` feature flag, routing `local/`-prefixed models to a configurable vLLM endpoint via the OpenAI Chat Completions API
- Implements full streaming (SSE parser with incremental tool-call accumulation) and non-streaming paths
- Maps Aletheia's block-based content model to OpenAI's flat message format, including system prompts, tool definitions, and tool results
- Adds `LocalProviderConfig` to taxis with `enabled`, `base_url`, `model`, and `timeout_secs` fields

## New files

| File | Purpose |
|------|---------|
| `local/types.rs` | OpenAI-compatible wire-format types (request, response, streaming chunks) |
| `local/stream.rs` | SSE stream parser with `StreamAccumulator` state machine |
| `local/provider.rs` | `LocalProvider` implementing `LlmProvider` trait |
| `local/provider_tests.rs` | 11 wiremock integration tests |
| `local/mod.rs` | Module structure and re-exports |

## Test plan

- [x] 4 stream parser unit tests (text, tool calls, malformed JSON, empty stream)
- [x] 11 wiremock integration tests (simple completion, streaming, tool calls, connection error, rate limit, server error, model prefix stripping, provider metadata)
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes (0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)