### PR TITLE
docs: fix stale architecture, counts, and per-crate CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,6 +111,8 @@ Register in `crates/organon/src/builtins/mod.rs` via `register_all()`.
 | `migrate-memory [--qdrant-url URL] [--collection NAME] [--knowledge-path PATH] [--review-file PATH] [--dry-run]` | Migrate memories from Qdrant into embedded knowledge store |
 | `add-nous <name> [--provider PROVIDER] [--model MODEL]` | Scaffold a new nous agent directory |
 | `init [--instance-root\|--instance-path PATH] [-y] [--non-interactive] [--auth-mode MODE] [--api-provider PROVIDER] [--model MODEL] [--api-key KEY]` | Initialize a new instance |
+| `config init-key` | Initialize encryption key for config secrets |
+| `config encrypt` | Encrypt a config value |
 | `check-config` | Validate configuration without starting services |
 | `completions <bash\|zsh\|fish>` | Generate shell completions |
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ See [QUICKSTART.md](docs/QUICKSTART.md) for install instructions, setup, and fir
 
 - **Persistent memory.** Conversations carry forward. The agent builds a knowledge graph of facts, entities, and relationships that persists across sessions and grows over time.
 - **Multiple agents.** Each agent has its own character (SOUL.md), goals, memory, and workspace. They can coordinate, delegate, and specialize.
-- **Tools.** 33 built-in tools: file I/O, shell execution, web search, memory search, agent coordination. Extend with domain packs or custom tools.
+- **Tools.** 36 built-in tools: file I/O, shell execution, web search, memory search, planning, agent coordination. Extend with domain packs or custom tools.
 - **Terminal dashboard.** Rich TUI with markdown rendering, session management, and real-time streaming.
 - **Signal messaging.** Talk to your agents over Signal with 15 built-in commands.
 - **Privacy.** No telemetry, no analytics, no phone-home. Only outbound connections are to services you configure.
@@ -29,7 +29,7 @@ See [QUICKSTART.md](docs/QUICKSTART.md) for install instructions, setup, and fir
 
 ## Architecture
 
-Rust workspace with 18 crates. Single binary deployment. See [ARCHITECTURE.md](docs/ARCHITECTURE.md) for the full dependency graph and trait boundaries.
+Rust workspace with 23 crates. Single binary deployment. See [ARCHITECTURE.md](docs/ARCHITECTURE.md) for the full dependency graph and trait boundaries.
 
 ---
 

--- a/crates/hermeneus/CLAUDE.md
+++ b/crates/hermeneus/CLAUDE.md
@@ -1,6 +1,6 @@
 # hermeneus
 
-Anthropic LLM client with streaming, retries, fallback, health tracking, and cost estimation. 7K lines.
+Anthropic LLM client with streaming, retries, fallback, health tracking, and cost estimation. 10.5K lines.
 
 ## Read first
 
@@ -19,7 +19,7 @@ Anthropic LLM client with streaming, retries, fallback, health tracking, and cos
 | `AnthropicProvider` | `anthropic/client.rs` | Concrete Anthropic Messages API implementation |
 | `CompletionRequest` | `types.rs` | LLM request (model, messages, tools, thinking, cache config) |
 | `CompletionResponse` | `types.rs` | LLM response (content blocks, usage, stop reason) |
-| `StreamEvent` | `anthropic/mod.rs` | SSE events: TextDelta, ThinkingDelta, ToolUse, etc. |
+| `StreamEvent` | `anthropic/stream/mod.rs` | SSE events: TextDelta, ThinkingDelta, ToolUse, etc. |
 | `FallbackConfig` | `fallback.rs` | Model fallback chain on transient failures |
 
 ## Patterns
@@ -37,7 +37,7 @@ Anthropic LLM client with streaming, retries, fallback, health tracking, and cos
 |------|-------|
 | Add LLM provider | New module (e.g., `src/openai/`), implement `LlmProvider` trait |
 | Modify retry logic | `src/models.rs` (constants) + `src/anthropic/client.rs` (retry loop) |
-| Add streaming event | `anthropic/mod.rs` (StreamEvent enum) + `anthropic/stream.rs` (accumulator) |
+| Add streaming event | `anthropic/stream/mod.rs` (StreamEvent enum) + `anthropic/stream/accumulator.rs` (accumulator) |
 | Update model pricing | `src/models.rs` (PRICING constant) |
 | Add metric | `src/metrics.rs` (LazyLock static, record function) |
 

--- a/crates/mneme/CLAUDE.md
+++ b/crates/mneme/CLAUDE.md
@@ -1,47 +1,46 @@
 # mneme
 
-Session store (SQLite) and knowledge engine (CozoDB Datalog + HNSW vectors). 110K lines. The memory layer.
+Thin facade re-exporting from four decomposed sub-crates. 110 lines of glue code.
 
-## Read first
+## Architecture
 
-1. `src/types.rs`: Session, Message, UsageRecord (core domain)
-2. `src/knowledge.rs`: Fact, Entity, Relationship, EpistemicTier
-3. `src/store/mod.rs`: SessionStore (SQLite WAL)
-4. `src/knowledge_store/mod.rs`: KnowledgeStore (CozoDB, feature-gated)
-5. `src/recall.rs`: 6-factor recall scoring engine
+Mneme was decomposed into eidos, graphe, episteme, and krites. This crate re-exports their public APIs so downstream consumers (nous, pylon, melete) depend on `mneme` without knowing about the decomposition.
 
-## Key types
+## Re-exports
 
-| Type | Path | Purpose |
-|------|------|---------|
-| `SessionStore` | `store/mod.rs` | SQLite session/message persistence |
-| `KnowledgeStore` | `knowledge_store/mod.rs` | CozoDB Datalog + HNSW (feature: `mneme-engine`) |
-| `Fact` | `knowledge.rs` | Bi-temporal memory with confidence, tier, decay |
-| `Entity` | `knowledge.rs` | Named entity with aliases and type |
-| `RecallEngine` | `recall.rs` | Weighted 6-factor scoring for memory retrieval |
-| `ExtractionEngine` | `extract/mod.rs` | LLM-driven fact/entity extraction from conversations |
-| `SkillExtractor` | `skills/mod.rs` | Auto-capture of recurring tool patterns as skills |
+| Source crate | Re-exported modules | Feature gate |
+|--------------|---------------------|--------------|
+| `eidos` | `id`, `knowledge` | always |
+| `graphe` | `backup`, `error`, `export`, `import`, `migration`, `portability`, `recovery`, `retention`, `schema`, `store`, `types` | `sqlite` (default) for most |
+| `episteme` | `conflict`, `consolidation`, `embedding`, `extract`, `hnsw_index`, `instinct`, `knowledge_portability`, `knowledge_store`, `query`, `recall`, `skill`, `skills`, `vocab` | `hnsw_rs` for hnsw_index, `mneme-engine` for query |
+| `krites` | `engine` | `mneme-engine` |
 
-## Patterns
+## Feature flags
 
-- **Bi-temporal facts**: `valid_from`/`valid_to` windows. Supersession chains via `superseded_by`.
-- **Epistemic tiers**: Verified > Inferred > Assumed. Tier affects decay rate and consolidation eligibility.
-- **FSRS decay**: `stability_hours` + `access_count` drive spaced-repetition-style recall scoring.
-- **Datalog queries**: typed builder in `query/builders.rs` or raw via `KnowledgeStore::run_query()`.
-- **SQLite recovery**: integrity check on open, auto-repair (backup + re-init), read-only fallback.
-- **Feature flags**: `mneme-engine` (knowledge store), `storage-fjall` (persistent), `embed-candle` (local embeddings).
+| Feature | Default | Purpose |
+|---------|---------|---------|
+| `sqlite` | yes | SQLite session store (graphe backend) |
+| `graph-algo` | yes | Graph algorithms in episteme + krites |
+| `mneme-engine` | no | Datalog engine (krites) + typed query builder |
+| `storage-fjall` | no | Fjall LSM-tree backend (requires mneme-engine) |
+| `embed-candle` | no | Local ML embeddings via candle |
+| `hnsw_rs` | no | Alternative HNSW vector index backend |
+| `test-support` | no | MockEmbeddingProvider and test helpers |
 
-## Common tasks
+## Where to make changes
 
-| Task | Where |
-|------|-------|
-| Add session field | `src/types.rs` (struct) + `src/schema.rs` (DDL) + `src/migration.rs` + `src/store/session.rs` |
-| Add knowledge query | `src/query/builders.rs` (typed) or `src/knowledge_store/mod.rs` (raw Datalog) |
-| Add recall signal | `src/recall.rs` (new field in FactorScores + weight in RecallWeights) |
-| Add extraction type | `src/extract/types.rs` + `src/extract/engine.rs` |
-| Add skill heuristic | `src/skills/heuristics.rs` (scoring function) |
+Mneme itself has no logic. All changes go to the sub-crates:
+
+| Task | Sub-crate |
+|------|-----------|
+| Add session/message field | `graphe` (types, schema, migration, store) |
+| Add knowledge type | `eidos` (knowledge module) |
+| Add extraction/recall logic | `episteme` |
+| Add Datalog query builder | `episteme` (query module, requires mneme-engine) |
+| Modify Datalog engine | `krites` |
+| Add embedding provider | `episteme` (embedding module) |
 
 ## Dependencies
 
-Uses: koina, serde, jiff, ulid, rusqlite, snafu, tracing, candle-*, fjall
+Uses: eidos, graphe, episteme, krites
 Used by: nous, pylon, melete, aletheia (binary)

--- a/crates/nous/CLAUDE.md
+++ b/crates/nous/CLAUDE.md
@@ -1,11 +1,11 @@
 # nous
 
-Agent session pipeline: bootstrap, recall, execute, finalize. 15K lines. The agent runtime.
+Agent session pipeline: bootstrap, recall, execute, finalize. 17K lines. The agent runtime.
 
 ## Read first
 
 1. `src/actor/mod.rs`: NousActor run loop (tokio::select! inbox pattern)
-2. `src/pipeline.rs`: PipelineInput, PipelineContext, TurnResult, guard logic
+2. `src/pipeline/mod.rs`: PipelineInput, PipelineContext, TurnResult, guard logic
 3. `src/bootstrap/mod.rs`: System prompt assembly from workspace cascade
 4. `src/execute/mod.rs`: LLM call + tool dispatch loop
 5. `src/manager.rs`: NousManager lifecycle, health polling, restart
@@ -17,9 +17,9 @@ Agent session pipeline: bootstrap, recall, execute, finalize. 15K lines. The age
 | `NousActor` | `actor/mod.rs` | Tokio actor processing turns sequentially |
 | `NousHandle` | `handle.rs` | Cloneable sender for invoking turns |
 | `NousManager` | `manager.rs` | Spawns actors, monitors health, routes messages |
-| `PipelineContext` | `pipeline.rs` | Assembled context flowing through pipeline stages |
+| `PipelineContext` | `pipeline/mod.rs` | Assembled context flowing through pipeline stages |
 | `BootstrapAssembler` | `bootstrap/mod.rs` | Priority-based system prompt packer |
-| `CrossNousRouter` | `cross.rs` | Inter-agent message routing with delivery audit |
+| `CrossNousRouter` | `cross/router.rs` | Inter-agent message routing with delivery audit |
 | `SessionState` | `session.rs` | In-memory session tracking (turn count, token estimate) |
 
 ## Pipeline stages (in order)
@@ -48,7 +48,7 @@ Agent session pipeline: bootstrap, recall, execute, finalize. 15K lines. The age
 | Modify bootstrap | `src/bootstrap/mod.rs` (WorkspaceFileSpec list, priorities) |
 | Modify recall | `src/recall.rs` (weights, search strategy, reranking) |
 | Add session hook | `src/session.rs` (SessionManager or SessionState) |
-| Add cross-nous message type | `src/cross.rs` (CrossNousMessage enum) |
+| Add cross-nous message type | `src/cross/mod.rs` (CrossNousMessage enum) |
 
 ## Dependencies
 

--- a/crates/organon/CLAUDE.md
+++ b/crates/organon/CLAUDE.md
@@ -1,13 +1,13 @@
 # organon
 
-Tool registry, executors, and sandbox. 12K lines. 33 built-in tools.
+Tool registry, executors, and sandbox. 16K lines. 36 built-in tools.
 
 ## Read first
 
 1. `src/registry.rs`: ToolRegistry, ToolExecutor trait (the core abstraction)
 2. `src/types.rs`: ToolDef, ToolInput, ToolResult, ToolContext, service traits
 3. `src/builtins/mod.rs`: register_all() and module organization
-4. `src/sandbox.rs`: Landlock + seccomp + network namespace config
+4. `src/sandbox/mod.rs`: Landlock + seccomp + network namespace config
 5. `src/process_guard.rs`: RAII subprocess lifecycle (kill-on-drop)
 
 ## Key types
@@ -19,19 +19,23 @@ Tool registry, executors, and sandbox. 12K lines. 33 built-in tools.
 | `ToolDef` | `types.rs` | Tool metadata: name, description, schema, category |
 | `ToolContext` | `types.rs` | Per-execution context: nous_id, session_id, workspace, services |
 | `ToolServices` | `types.rs` | Service locator: messaging, planning, knowledge, spawn |
-| `SandboxConfig` | `sandbox.rs` | Landlock + seccomp + egress policy |
-| `ProcessGuard` | `process_guard.rs` | RAII child process wrapper (prevents orphans/zombies) |
+| `SandboxConfig` | `sandbox/mod.rs` | Landlock + seccomp + egress policy |
+| `ProcessGuard` | `process_guard.rs` | RAII child process wrapper, `pub(crate)` (prevents orphans/zombies) |
 
-## Built-in tools (33)
+## Built-in tools (36)
 
 | Category | Tools |
 |----------|-------|
-| Workspace | read, write, edit, exec, view_file, grep, find, ls |
+| Workspace | read, write, edit, exec |
+| Filesystem | grep, find, ls |
+| View File | view_file |
 | Memory | memory_search, memory_correct, memory_retract, memory_forget, memory_audit, note, blackboard, datalog_query |
 | Communication | message, sessions_send, sessions_ask |
-| Agent | sessions_spawn, sessions_dispatch, enable_tool |
+| Agent | sessions_spawn, sessions_dispatch |
+| Enable Tool | enable_tool |
 | Planning | plan_create, plan_research, plan_requirements, plan_roadmap, plan_discuss, plan_execute, plan_verify, plan_status, plan_step_complete, plan_step_fail |
 | Research | web_fetch |
+| Triage | issue_scan, issue_triage, issue_approve |
 
 ## Patterns
 
@@ -46,7 +50,7 @@ Tool registry, executors, and sandbox. 12K lines. 33 built-in tools.
 | Task | Where |
 |------|-------|
 | Add built-in tool | New file in `src/builtins/`, implement ToolExecutor, register in `builtins/mod.rs` |
-| Modify sandbox | `src/sandbox.rs` (SandboxConfig) + `aletheia.toml` [sandbox] section |
+| Modify sandbox | `src/sandbox/mod.rs` (SandboxConfig) + `aletheia.toml` [sandbox] section |
 | Add service trait | `src/types.rs` (new trait) + binary crate provides implementation |
 | Add tool category | `src/types.rs` (ToolCategory enum) |
 

--- a/crates/pylon/CLAUDE.md
+++ b/crates/pylon/CLAUDE.md
@@ -1,13 +1,13 @@
 # pylon
 
-HTTP gateway: Axum handlers, SSE streaming, auth middleware, rate limiting. 10K lines.
+HTTP gateway: Axum handlers, SSE streaming, auth middleware, rate limiting. 11K lines.
 
 ## Read first
 
 1. `src/router.rs`: Route construction and middleware layer ordering (read the comments)
 2. `src/state.rs`: AppState (shared state everything references)
 3. `src/handlers/sessions/streaming.rs`: SSE streaming + idempotency
-4. `src/middleware.rs`: CSRF, request ID, rate limiting (per-IP + per-user)
+4. `src/middleware/mod.rs`: CSRF, request ID, rate limiting (per-IP + per-user)
 5. `src/error.rs`: ApiError enum and HTTP status mapping
 
 ## Key types
@@ -19,8 +19,8 @@ HTTP gateway: Axum handlers, SSE streaming, auth middleware, rate limiting. 10K 
 | `Claims` | `extract.rs` | JWT auth extractor |
 | `SecurityConfig` | `security.rs` | CORS, CSRF, TLS, rate limit config |
 | `SseEvent` | `stream.rs` | Message streaming events (TextDelta, ToolUse, etc.) |
-| `RateLimiter` | `middleware.rs` | Per-IP sliding window limiter |
-| `UserRateLimiter` | `middleware.rs` | Per-user token bucket with endpoint categories |
+| `RateLimiter` | `middleware/rate_limiter.rs` | Per-IP sliding window limiter |
+| `UserRateLimiter` | `middleware/user_rate_limiter.rs` | Per-user token bucket with endpoint categories |
 | `IdempotencyCache` | `idempotency.rs` | TTL + LRU dedup for message sends |
 
 ## Handler structure

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -20,15 +20,13 @@ Module and crate names use Greek terms reflecting their essential nature (nous =
 aletheia
 ├── koina          -  errors, tracing, safe wrappers, fs utils
 ├── taxis          -  config, path resolution, oikos hierarchy, secret refs
-├── mneme          -  session store (SQLite) + knowledge engine (vendored Datalog) + candle
-│   ├── store      -  SQLite session store: WAL, migrations, retention
-│   ├── knowledge  -  Datalog knowledge graph, HNSW vectors, entity relations
-│   ├── embedding  -  EmbeddingProvider trait: candle (local default)
-│   ├── extract    -  LLM-driven fact extraction, entity resolution
-│   ├── recall     -  hybrid retrieval (vector + graph + BM25), MMR diversity
-│   └── engine/    -  embedded Datalog + HNSW engine (mneme-engine feature gate)
+├── mneme          -  thin facade re-exporting eidos, graphe, episteme, krites
+│   ├── eidos      -  shared knowledge types (Fact, Entity, Relationship, EpistemicTier)
+│   ├── graphe     -  SQLite session store: WAL, migrations, retention, backup
+│   ├── episteme   -  knowledge pipeline: extraction, recall, consolidation, embeddings
+│   └── krites     -  embedded Datalog engine + HNSW vectors (mneme-engine feature gate)
 ├── hermeneus      -  Anthropic client, model routing, credentials, provider trait
-├── organon        -  tool registry + built-in tools
+├── organon        -  tool registry + 36 built-in tools
 ├── nous           -  agent pipeline, bootstrap, recall, finalize, actor model
 ├── dianoia        -  planning / project orchestration
 ├── pylon          -  Axum HTTP gateway, SSE streaming
@@ -36,10 +34,12 @@ aletheia
 ├── symbolon       -  JWT auth, sessions, RBAC
 ├── agora          -  channel registry + ChannelProvider trait
 │   └── semeion    -  Signal (signal-cli subprocess)
-├── daemon         -  oikonomos: per-nous background tasks, cron, evolution, prosoche
-├── melete         -  distillation, reflection, memory flush, consolidation
+├── daemon         -  oikonomos: per-nous background tasks, cron, prosoche
+├── melete         -  context distillation, compression, token budget management
+├── thesauros      -  domain pack loader (knowledge, tools, config overlays)
 └── theatron       -  presentation umbrella (crates/theatron/)
-    └── tui        -  terminal dashboard                                  (crates/theatron/tui/)
+    ├── core       -  shared API client, types, SSE infrastructure  (crates/theatron/core/)
+    └── tui        -  terminal dashboard                            (crates/theatron/tui/)
 ```
 
 ---
@@ -105,37 +105,54 @@ The oikos hierarchy is described in [CONFIGURATION.md](CONFIGURATION.md).
 
 ## Rust crate workspace
 
-Application crates in `crates/`, plus the `integration-tests` support crate.
+23 workspace members in `crates/`, plus `theatron-desktop` excluded from workspace (GTK3 CI deps).
 
 ### Crates
 
-| Crate | Domain | Depends On |
-|-------|--------|------------|
-| `koina` | Errors (snafu), tracing, fs utilities, safe wrappers | nothing (leaf) |
-| `taxis` | Config loading (figment TOML cascade), path resolution, oikos hierarchy | koina |
-| `mneme` | Unified memory store, embedding provider trait, knowledge retrieval. Includes embedded Datalog+HNSW engine behind `mneme-engine` feature gate. | koina |
-| `hermeneus` | Anthropic client, model routing, credential management, provider trait | koina |
-| `organon` | Tool registry, tool definitions, built-in tool set | koina, hermeneus |
-| `symbolon` | JWT tokens, password hashing, RBAC policies | koina |
-| `melete` | Context distillation, compression strategies, token budget management | koina, hermeneus |
-| `agora` | Channel registry, ChannelProvider trait, Signal JSON-RPC client | koina, taxis |
-| `daemon` | Background task scheduling, cron jobs, lifecycle events (`oikonomos` internally) | koina |
-| `dianoia` | Multi-phase planning orchestrator, project context tracking | koina |
-| `thesauros` | Domain pack loader - external knowledge, tools, config overlays | koina, organon |
-| `nous` | Agent pipeline, NousActor (tokio), bootstrap, recall, execute, finalize | koina, taxis, mneme, hermeneus, organon, melete, thesauros |
-| `pylon` | Axum HTTP gateway, SSE streaming, auth middleware | koina, taxis, hermeneus, organon, mneme, nous, symbolon |
-| `diaporeia` | MCP server interface for external AI agents (`crates/diaporeia`) | koina, taxis, nous, organon, mneme, symbolon |
-| `theatron-core` | Shared presentation types and traits for Aletheia UIs (`crates/theatron/core/`) | nothing (leaf) |
-| `theatron-tui` | Terminal dashboard (`crates/theatron/tui/`) | theatron-core, reqwest (standalone UI client) |
-| `theatron-desktop` | Dioxus desktop UI (`crates/theatron/desktop/`) - in progress | theatron-core |
-| `aletheia` | Binary entrypoint (Clap CLI) - wires all crates together | taxis, hermeneus, organon, mneme, nous, symbolon, pylon, agora, thesauros, daemon, dianoia, theatron-tui (optional) |
+| Crate | Directory | Domain | Depends On |
+|-------|-----------|--------|------------|
+| `koina` | `crates/koina` | Errors (snafu), tracing, fs utilities, safe wrappers | nothing (leaf) |
+| `taxis` | `crates/taxis` | Config loading (figment TOML cascade), path resolution, oikos hierarchy | koina |
+| `eidos` | `crates/eidos` | Shared knowledge types: Fact, Entity, Relationship, EpistemicTier | nothing (leaf) |
+| `graphe` | `crates/graphe` | SQLite session store: WAL, migrations, retention, backup, export/import | eidos, koina |
+| `episteme` | `crates/episteme` | Knowledge pipeline: extraction, recall, consolidation, embedding provider | eidos, koina, graphe, krites (opt) |
+| `krites` | `crates/krites` | Embedded Datalog engine with HNSW and graph support | eidos |
+| `mneme` | `crates/mneme` | Thin facade re-exporting eidos, graphe, episteme, krites | eidos, graphe, episteme, krites |
+| `hermeneus` | `crates/hermeneus` | Anthropic client, model routing, credential management, provider trait | koina, taxis |
+| `organon` | `crates/organon` | Tool registry, tool definitions, 36 built-in tools, sandbox | koina, hermeneus |
+| `symbolon` | `crates/symbolon` | JWT tokens, password hashing, RBAC policies | koina |
+| `melete` | `crates/melete` | Context distillation, compression strategies, token budget management | hermeneus |
+| `agora` | `crates/agora` | Channel registry, ChannelProvider trait, Signal JSON-RPC client | koina, taxis |
+| `daemon` (oikonomos) | `crates/daemon` | Per-nous background task scheduling, cron jobs, prosoche | koina |
+| `dianoia` | `crates/dianoia` | Multi-phase planning orchestrator, project context tracking | nothing (leaf) |
+| `thesauros` | `crates/thesauros` | Domain pack loader: external knowledge, tools, config overlays | koina, organon |
+| `nous` | `crates/nous` | Agent pipeline, NousActor (tokio), bootstrap, recall, execute, finalize | koina, taxis, mneme, hermeneus, organon, melete, thesauros |
+| `pylon` | `crates/pylon` | Axum HTTP gateway, SSE streaming, auth middleware | koina, taxis, hermeneus, organon, mneme, nous, symbolon |
+| `diaporeia` | `crates/diaporeia` | MCP server interface for external AI agents | koina, taxis, nous, organon, mneme, symbolon |
+| `theatron-core` | `crates/theatron/core` | Shared API client, types, SSE infrastructure for UIs | koina |
+| `theatron-tui` | `crates/theatron/tui` | Terminal dashboard | koina, theatron-core |
+| `theatron-desktop` | `crates/theatron/desktop` | Dioxus desktop UI (excluded from workspace, requires GTK3) | theatron-core |
+| `aletheia` | `crates/aletheia` | Binary entrypoint (Clap CLI), wires all crates together | koina, taxis, hermeneus, organon, mneme, nous, symbolon, pylon, agora, thesauros, daemon, dianoia, dokimion, diaporeia (opt), theatron-tui (opt) |
 
 **Support crates** (not part of the application dependency graph):
 
-| Crate | Domain | Depends On |
-|-------|--------|------------|
-| `eval` | Behavioral eval framework (HTTP scenario runner) | nothing (leaf) |
-| `integration-tests` | Cross-crate integration test suite | koina, taxis, mneme, hermeneus, nous, organon, pylon, symbolon, thesauros |
+| Crate | Directory | Domain | Depends On |
+|-------|-----------|--------|------------|
+| `dokimion` | `crates/eval` | Behavioral eval framework (HTTP scenario runner) | koina |
+| `integration-tests` | `crates/integration-tests` | Cross-crate integration test suite | dokimion, koina, taxis, mneme, hermeneus, nous, organon, pylon, symbolon, thesauros |
+
+### Mneme facade
+
+Mneme was decomposed into four sub-crates. The `mneme` crate is now a thin facade that re-exports their public APIs:
+
+| Sub-crate | Re-exports | Feature gate |
+|-----------|------------|--------------|
+| `eidos` | `id`, `knowledge` | always |
+| `graphe` | `backup`, `error`, `export`, `import`, `migration`, `portability`, `recovery`, `retention`, `schema`, `store`, `types` | `sqlite` (default) for most |
+| `episteme` | `conflict`, `consolidation`, `embedding`, `extract`, `hnsw_index`, `instinct`, `knowledge_portability`, `knowledge_store`, `query`, `recall`, `skill`, `skills`, `vocab` | some behind `mneme-engine` or `hnsw_rs` |
+| `krites` | `engine` | `mneme-engine` |
+
+Downstream crates depend on `mneme` and get the full API surface without knowing about the decomposition.
 
 ### Dependency graph
 
@@ -148,18 +165,18 @@ Application crates in `crates/`, plus the `integration-tests` support crate.
             / | \ \ | \ \ | \   |      | \    |
   symbolon  | organon |  taxis hermeneus  koina
             |  |  \   |    |
-            | hermeneus mneme
-            |    |       |
-            koina koina  koina
+            | hermeneus mneme (facade)
+            |    |      / | \ \
+            koina koina eidos graphe episteme krites
 ```
 
 **Layer rules:**
-- **Leaf** (no workspace deps): `koina`
-- **Low** (koina only): `taxis`, `hermeneus`, `symbolon`, `mneme` (includes embedded Datalog+HNSW engine behind feature gate)
-- **Mid**: `melete` (koina + hermeneus), `organon` (koina + hermeneus), `agora` (koina + taxis), `daemon` (koina), `dianoia` (koina), `thesauros` (koina + organon)
+- **Leaf** (no workspace deps): `koina`, `eidos`, `dianoia`
+- **Low** (one workspace dep): `taxis`, `hermeneus`, `symbolon`, `krites` (eidos only), `daemon` (koina), `melete` (hermeneus), `theatron-core` (koina), `dokimion` (koina)
+- **Mid**: `graphe` (eidos + koina), `episteme` (eidos + koina + graphe + krites), `mneme` (facade), `organon` (koina + hermeneus), `agora` (koina + taxis), `thesauros` (koina + organon)
 - **High**: `nous` (multiple mid+low deps), `pylon` (multiple deps including nous), `diaporeia` (MCP server, multiple deps including nous)
-- **Top**: `aletheia` binary, `theatron-tui` (terminal dashboard), `theatron-desktop` (Dioxus desktop, in progress)
-- **Support**: `eval` (behavioral scenario runner), `integration-tests`
+- **Top**: `aletheia` binary, `theatron-tui` (koina + theatron-core), `theatron-desktop` (Dioxus desktop, excluded from workspace)
+- **Support**: `integration-tests`
 
 Imports flow downward only. Lower-layer crates must not depend on higher layers.
 
@@ -167,7 +184,7 @@ Imports flow downward only. Lower-layer crates must not depend on higher layers.
 
 | Trait | Crate | Purpose |
 |-------|-------|---------|
-| `EmbeddingProvider` | mneme | Vector embeddings from text |
+| `EmbeddingProvider` | episteme | Vector embeddings from text |
 | `ChannelProvider` | agora | Send/receive on a messaging channel |
 | `LlmProvider` | hermeneus | LLM API calls |
 
@@ -211,11 +228,13 @@ strip = "symbols"
 
 ## Structural properties
 
-- **koina is a true leaf node.** No workspace deps in Rust.
+- **koina, eidos, and dianoia are true leaf nodes.** No workspace deps in Rust.
 - **symbolon depends only on koina** (plus external crates: reqwest, rusqlite, ring, argon2).
-- **Datalog+HNSW engine is embedded** inside `mneme/src/engine/`, gated behind the `mneme-engine` feature.
+- **mneme is a thin facade.** It re-exports from eidos (types), graphe (session store), episteme (knowledge pipeline), and krites (Datalog engine). No logic of its own.
+- **krites contains the Datalog+HNSW engine**, gated behind the `mneme-engine` feature.
+- **EmbeddingProvider lives in episteme**, not mneme.
 - **Trait boundaries are extension points.** `EmbeddingProvider`, `ChannelProvider`, `LlmProvider` - implement the trait, swap the provider.
 - **daemon depends only on koina** - lightweight scheduling, not a high-layer crate. No other application crate imports it.
-- **dianoia depends only on koina** - planning context decoupled from the agent pipeline. No other application crate imports it.
+- **dianoia has no workspace dependencies** - planning context fully decoupled from the agent pipeline. No other application crate imports it.
 - **thesauros loads domain packs** - knowledge, tools, config overlays bundled as portable extensions. Depends on koina + organon.
 - **nous requires a multi-thread Tokio runtime** (`rt-multi-thread`). The actor model and spawn-based timeout machinery depend on multiple OS threads. Single-thread runtime will deadlock.

--- a/llms.txt
+++ b/llms.txt
@@ -4,7 +4,7 @@
 
 Privacy-first distributed cognition. N agents + 1 human operator. Each agent has character, memory, and domain expertise. They persist understanding across sessions, coordinate through shared infrastructure, and evolve through use. Runs on commodity hardware with no cloud dependencies beyond your LLM API key.
 
-Rust workspace with 16 crates. TUI client.
+Rust workspace with 23 crates. TUI client.
 
 ## Getting Started
 
@@ -17,7 +17,7 @@ Rust workspace with 16 crates. TUI client.
 - [ARCHITECTURE](docs/ARCHITECTURE.md): Crate workspace, module map, dependency graph, trait boundaries
 - [PROJECT](docs/PROJECT.md): Project plan, milestones, dependency policy, crate-to-module mapping
 - [TECHNOLOGY](docs/TECHNOLOGY.md): Technology decisions, dependency rationale, pinning policy
-- [ALETHEIA](docs/ALETHEIA.md): System manifesto and naming philosophy
+- [gnomon](docs/gnomon.md): Naming philosophy and the gnomon system
 
 ## Standards
 
@@ -36,14 +36,10 @@ Rust workspace with 16 crates. TUI client.
 - [RELEASING](docs/RELEASING.md): Release process, versioning, changelog discipline
 - [SECURITY](SECURITY.md): Vulnerability reporting, developer security practices, pre-commit hooks
 
-## Reference
-
-- [VENDORING](docs/VENDORING.md): Vendored dependencies absorbed into mneme
-
 ## Key Directories
 
 - `crates/`: Rust workspace (koina, taxis, mneme, hermeneus, organon, nous, pylon, etc.)
-- `tui/`: Terminal UI client (workspace member)
+- `crates/theatron/tui/`: Terminal UI client (workspace member)
 - `instance.example/nous/_template/`: Template agent workspace (SOUL.md, USER.md, AGENTS.md)
 - `instance.example/config/`: Example gateway config
 - `standards/`: Coding standards for AI agents


### PR DESCRIPTION
## Summary
- Rewrite `docs/ARCHITECTURE.md` to fix 10 dependency inaccuracies (graphe, episteme, dianoia, melete, theatron-core, theatron-tui, dokimion, aletheia binary, integration-tests, leaf node list)
- Fix file paths in hermeneus, organon, and pylon CLAUDE.md files (stream/, sandbox/, middleware/ are directories not flat files)
- Update hermeneus line count (8K → 10.5K)

## Issues
Closes #1902, #1903, #1904

## Test plan
- [x] `cargo fmt --all -- --check` passes
- [x] All file paths in CLAUDE.md files verified against actual filesystem
- [x] All dependency claims verified against Cargo.toml files
- [x] Line counts within 10% of actual `wc -l`