### PR TITLE
feat(dianoia): stuck detection and handoff protocol

### DIFF
--- a/crates/dianoia/src/error.rs
+++ b/crates/dianoia/src/error.rs
@@ -94,6 +94,38 @@ pub enum Error {
         /// Source location captured by snafu.
         location: snafu::Location,
     },
+
+    /// Filesystem error during handoff file operations.
+    #[snafu(display("handoff I/O error at {}", path.display()))]
+    HandoffIo {
+        /// The path at which the I/O error occurred.
+        path: PathBuf,
+        /// The underlying I/O error.
+        source: std::io::Error,
+        #[snafu(implicit)]
+        /// Source location captured by snafu.
+        location: snafu::Location,
+    },
+
+    /// Failed to deserialize a handoff file from JSON.
+    #[snafu(display("handoff deserialization error"))]
+    HandoffDeserialize {
+        /// The underlying deserialization error.
+        source: serde_json::Error,
+        #[snafu(implicit)]
+        /// Source location captured by snafu.
+        location: snafu::Location,
+    },
+
+    /// Failed to serialize handoff context to JSON.
+    #[snafu(display("handoff serialization error"))]
+    HandoffSerialize {
+        /// The underlying serialization error.
+        source: serde_json::Error,
+        #[snafu(implicit)]
+        /// Source location captured by snafu.
+        location: snafu::Location,
+    },
 }
 
 /// Convenience alias for `Result` with dianoia's [`Error`] type.

--- a/crates/dianoia/src/handoff.rs
+++ b/crates/dianoia/src/handoff.rs
@@ -1,0 +1,470 @@
+//! Context handoff protocol for continuity across context breaks.
+
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+use snafu::ResultExt;
+
+use crate::error::{self, Result};
+
+const HANDOFF_JSON_FILENAME: &str = ".continue-here.json";
+const HANDOFF_MD_FILENAME: &str = ".continue-here.md";
+
+/// Why the handoff is being written.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum HandoffReason {
+    /// Context distillation is about to compress the conversation.
+    Distillation,
+    /// The process is shutting down in a controlled manner.
+    ControlledShutdown,
+    /// The context window is approaching its limit.
+    ContextLimitApproaching,
+}
+
+/// Full context preserved across a context break.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HandoffContext {
+    /// Description of the current task being worked on.
+    pub task: String,
+    /// Progress made so far (milestones, completed steps).
+    pub progress: Vec<String>,
+    /// What needs to happen next to continue the work.
+    pub next_steps: Vec<String>,
+    /// File paths relevant to the current work.
+    pub relevant_paths: Vec<PathBuf>,
+    /// Partial results or intermediate outputs worth preserving.
+    pub partial_results: Vec<String>,
+    /// Project identifier, if operating within a project context.
+    pub project_id: Option<String>,
+    /// Session identifier for the originating session.
+    pub session_id: Option<String>,
+    /// Why the handoff was triggered.
+    pub reason: HandoffReason,
+    /// When the handoff was created.
+    pub created_at: jiff::Timestamp,
+}
+
+impl HandoffContext {
+    /// Render the handoff context as a human-readable markdown string.
+    #[must_use]
+    pub fn to_markdown(&self) -> String {
+        let mut md = String::from("# Continue Here\n\n");
+
+        md.push_str("## Task\n\n");
+        md.push_str(&self.task);
+        md.push_str("\n\n");
+
+        if !self.progress.is_empty() {
+            md.push_str("## Progress\n\n");
+            for item in &self.progress {
+                md.push_str("- ");
+                md.push_str(item);
+                md.push('\n');
+            }
+            md.push('\n');
+        }
+
+        if !self.next_steps.is_empty() {
+            md.push_str("## Next steps\n\n");
+            for step in &self.next_steps {
+                md.push_str("- ");
+                md.push_str(step);
+                md.push('\n');
+            }
+            md.push('\n');
+        }
+
+        if !self.relevant_paths.is_empty() {
+            md.push_str("## Relevant files\n\n");
+            for path in &self.relevant_paths {
+                md.push_str("- `");
+                md.push_str(&path.display().to_string());
+                md.push_str("`\n");
+            }
+            md.push('\n');
+        }
+
+        if !self.partial_results.is_empty() {
+            md.push_str("## Partial results\n\n");
+            for result in &self.partial_results {
+                md.push_str("- ");
+                md.push_str(result);
+                md.push('\n');
+            }
+            md.push('\n');
+        }
+
+        md.push_str("## Metadata\n\n");
+        if let Some(project_id) = &self.project_id {
+            md.push_str("- Project: ");
+            md.push_str(project_id);
+            md.push('\n');
+        }
+        if let Some(session_id) = &self.session_id {
+            md.push_str("- Session: ");
+            md.push_str(session_id);
+            md.push('\n');
+        }
+        md.push_str("- Reason: ");
+        md.push_str(match self.reason {
+            HandoffReason::Distillation => "distillation",
+            HandoffReason::ControlledShutdown => "controlled shutdown",
+            HandoffReason::ContextLimitApproaching => "context limit approaching",
+        });
+        md.push('\n');
+        md.push_str("- Created: ");
+        md.push_str(&self.created_at.to_string());
+        md.push('\n');
+
+        md
+    }
+}
+
+/// Manages handoff file I/O for context continuity across breaks.
+///
+/// Writes both a machine-readable JSON file (`.continue-here.json`) and a
+/// human-readable markdown file (`.continue-here.md`) at the given directory.
+pub struct HandoffFile {
+    dir: PathBuf,
+}
+
+impl HandoffFile {
+    /// Create a handoff file manager for the given directory.
+    #[must_use]
+    pub fn new(dir: impl Into<PathBuf>) -> Self {
+        Self { dir: dir.into() }
+    }
+
+    /// Write a handoff file before distillation or controlled shutdown.
+    ///
+    /// Creates both `.continue-here.json` (machine-readable) and
+    /// `.continue-here.md` (human-readable) in the configured directory.
+    pub fn write(&self, context: &HandoffContext) -> Result<()> {
+        let json_path = self.json_path();
+        let md_path = self.md_path();
+
+        let json = serde_json::to_string_pretty(context).context(error::HandoffSerializeSnafu)?;
+        let markdown = context.to_markdown();
+
+        #[expect(
+            clippy::disallowed_methods,
+            reason = "handoff writes are pre-shutdown blocking operations; async context unavailable"
+        )]
+        {
+            std::fs::create_dir_all(&self.dir).context(error::HandoffIoSnafu {
+                path: self.dir.clone(),
+            })?;
+            std::fs::write(&json_path, json).context(error::HandoffIoSnafu { path: &json_path })?;
+            std::fs::write(&md_path, markdown).context(error::HandoffIoSnafu { path: &md_path })?;
+        }
+
+        Ok(())
+    }
+
+    /// Read a handoff file on resume, returning the preserved context.
+    ///
+    /// Returns `Ok(None)` if no handoff file exists.
+    pub fn read(&self) -> Result<Option<HandoffContext>> {
+        let json_path = self.json_path();
+        if !json_path.exists() {
+            return Ok(None);
+        }
+
+        let contents = std::fs::read_to_string(&json_path)
+            .context(error::HandoffIoSnafu { path: &json_path })?;
+        let context: HandoffContext =
+            serde_json::from_str(&contents).context(error::HandoffDeserializeSnafu)?;
+
+        Ok(Some(context))
+    }
+
+    /// Check whether an orphaned handoff file exists from a previous session.
+    ///
+    /// An existing handoff file at startup indicates either a planned handoff
+    /// or a crash recovery scenario. The caller decides based on session context.
+    #[must_use]
+    pub fn exists(&self) -> bool {
+        self.json_path().exists()
+    }
+
+    /// Remove handoff files after a successful resume.
+    pub fn clear(&self) -> Result<()> {
+        let json_path = self.json_path();
+        let md_path = self.md_path();
+
+        if json_path.exists() {
+            std::fs::remove_file(&json_path).context(error::HandoffIoSnafu { path: &json_path })?;
+        }
+        if md_path.exists() {
+            std::fs::remove_file(&md_path).context(error::HandoffIoSnafu { path: &md_path })?;
+        }
+
+        Ok(())
+    }
+
+    /// Path to the JSON handoff file.
+    #[must_use]
+    pub fn json_path(&self) -> PathBuf {
+        self.dir.join(HANDOFF_JSON_FILENAME)
+    }
+
+    /// Path to the markdown handoff file.
+    #[must_use]
+    pub fn md_path(&self) -> PathBuf {
+        self.dir.join(HANDOFF_MD_FILENAME)
+    }
+}
+
+impl std::fmt::Debug for HandoffFile {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("HandoffFile")
+            .field("dir", &self.dir)
+            .finish()
+    }
+}
+
+/// Detect an orphaned handoff file at a given path.
+///
+/// Returns `Ok(Some(context))` if a handoff file exists (indicating a crash or
+/// incomplete resume from a prior session). Returns `Ok(None)` if no handoff exists.
+pub fn detect_orphaned(dir: &Path) -> Result<Option<HandoffContext>> {
+    HandoffFile::new(dir).read()
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "test assertions")]
+mod tests {
+    use super::*;
+
+    fn sample_context() -> HandoffContext {
+        HandoffContext {
+            task: "Implement stuck detection for dianoia".into(),
+            progress: vec![
+                "Created StuckDetector struct".into(),
+                "Implemented repeated error detection".into(),
+            ],
+            next_steps: vec![
+                "Add alternating failure detection".into(),
+                "Write unit tests".into(),
+            ],
+            relevant_paths: vec![
+                PathBuf::from("crates/dianoia/src/stuck.rs"),
+                PathBuf::from("crates/dianoia/src/lib.rs"),
+            ],
+            partial_results: vec!["StuckDetector compiles and passes 3 tests".into()],
+            project_id: Some("01JTEST00000000000000000".into()),
+            session_id: Some("01JSESS00000000000000000".into()),
+            reason: HandoffReason::Distillation,
+            created_at: jiff::Timestamp::now(),
+        }
+    }
+
+    #[test]
+    fn write_and_read_roundtrip() {
+        let dir = tempfile::tempdir().unwrap();
+        let handoff = HandoffFile::new(dir.path());
+
+        let context = sample_context();
+        handoff.write(&context).unwrap();
+
+        assert!(handoff.exists());
+
+        let loaded = handoff.read().unwrap().unwrap();
+        assert_eq!(loaded.task, context.task);
+        assert_eq!(loaded.progress, context.progress);
+        assert_eq!(loaded.next_steps, context.next_steps);
+        assert_eq!(loaded.relevant_paths, context.relevant_paths);
+        assert_eq!(loaded.partial_results, context.partial_results);
+        assert_eq!(loaded.project_id, context.project_id);
+        assert_eq!(loaded.session_id, context.session_id);
+        assert_eq!(loaded.reason, context.reason);
+        assert_eq!(loaded.created_at, context.created_at);
+    }
+
+    #[test]
+    fn read_nonexistent_returns_none() {
+        let dir = tempfile::tempdir().unwrap();
+        let handoff = HandoffFile::new(dir.path());
+        let result = handoff.read().unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn exists_before_and_after_write() {
+        let dir = tempfile::tempdir().unwrap();
+        let handoff = HandoffFile::new(dir.path());
+
+        assert!(!handoff.exists());
+        handoff.write(&sample_context()).unwrap();
+        assert!(handoff.exists());
+    }
+
+    #[test]
+    fn clear_removes_both_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let handoff = HandoffFile::new(dir.path());
+
+        handoff.write(&sample_context()).unwrap();
+        assert!(handoff.json_path().exists());
+        assert!(handoff.md_path().exists());
+
+        handoff.clear().unwrap();
+        assert!(!handoff.json_path().exists());
+        assert!(!handoff.md_path().exists());
+    }
+
+    #[test]
+    fn clear_nonexistent_is_ok() {
+        let dir = tempfile::tempdir().unwrap();
+        let handoff = HandoffFile::new(dir.path());
+        handoff.clear().unwrap();
+    }
+
+    #[test]
+    fn detect_orphaned_finds_existing() {
+        let dir = tempfile::tempdir().unwrap();
+        let handoff = HandoffFile::new(dir.path());
+        handoff.write(&sample_context()).unwrap();
+
+        let orphaned = detect_orphaned(dir.path()).unwrap();
+        assert!(orphaned.is_some());
+        assert_eq!(
+            orphaned.unwrap().task,
+            "Implement stuck detection for dianoia"
+        );
+    }
+
+    #[test]
+    fn detect_orphaned_returns_none_when_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        let result = detect_orphaned(dir.path()).unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn markdown_contains_task() {
+        let context = sample_context();
+        let md = context.to_markdown();
+        assert!(md.contains("# Continue Here"));
+        assert!(md.contains("## Task"));
+        assert!(md.contains("Implement stuck detection for dianoia"));
+    }
+
+    #[test]
+    fn markdown_contains_progress() {
+        let context = sample_context();
+        let md = context.to_markdown();
+        assert!(md.contains("## Progress"));
+        assert!(md.contains("- Created StuckDetector struct"));
+        assert!(md.contains("- Implemented repeated error detection"));
+    }
+
+    #[test]
+    fn markdown_contains_next_steps() {
+        let context = sample_context();
+        let md = context.to_markdown();
+        assert!(md.contains("## Next steps"));
+        assert!(md.contains("- Add alternating failure detection"));
+    }
+
+    #[test]
+    fn markdown_contains_relevant_files() {
+        let context = sample_context();
+        let md = context.to_markdown();
+        assert!(md.contains("## Relevant files"));
+        assert!(md.contains("`crates/dianoia/src/stuck.rs`"));
+    }
+
+    #[test]
+    fn markdown_contains_metadata() {
+        let context = sample_context();
+        let md = context.to_markdown();
+        assert!(md.contains("## Metadata"));
+        assert!(md.contains("- Project: 01JTEST00000000000000000"));
+        assert!(md.contains("- Session: 01JSESS00000000000000000"));
+        assert!(md.contains("- Reason: distillation"));
+    }
+
+    #[test]
+    fn markdown_omits_empty_sections() {
+        let context = HandoffContext {
+            task: "minimal task".into(),
+            progress: Vec::new(),
+            next_steps: Vec::new(),
+            relevant_paths: Vec::new(),
+            partial_results: Vec::new(),
+            project_id: None,
+            session_id: None,
+            reason: HandoffReason::ControlledShutdown,
+            created_at: jiff::Timestamp::now(),
+        };
+        let md = context.to_markdown();
+        assert!(md.contains("## Task"));
+        assert!(!md.contains("## Progress"));
+        assert!(!md.contains("## Next steps"));
+        assert!(!md.contains("## Relevant files"));
+        assert!(!md.contains("## Partial results"));
+        assert!(md.contains("- Reason: controlled shutdown"));
+    }
+
+    #[test]
+    fn markdown_file_written_alongside_json() {
+        let dir = tempfile::tempdir().unwrap();
+        let handoff = HandoffFile::new(dir.path());
+        handoff.write(&sample_context()).unwrap();
+
+        assert!(handoff.md_path().exists());
+        let md_content = std::fs::read_to_string(handoff.md_path()).unwrap();
+        assert!(md_content.contains("# Continue Here"));
+    }
+
+    #[test]
+    fn write_creates_parent_directories() {
+        let dir = tempfile::tempdir().unwrap();
+        let nested = dir.path().join("deep").join("nested").join("dir");
+        let handoff = HandoffFile::new(&nested);
+
+        handoff.write(&sample_context()).unwrap();
+        assert!(handoff.exists());
+    }
+
+    #[test]
+    fn overwrite_replaces_previous_handoff() {
+        let dir = tempfile::tempdir().unwrap();
+        let handoff = HandoffFile::new(dir.path());
+
+        let first = sample_context();
+        handoff.write(&first).unwrap();
+
+        let mut second = sample_context();
+        second.task = "Updated task description".into();
+        handoff.write(&second).unwrap();
+
+        let loaded = handoff.read().unwrap().unwrap();
+        assert_eq!(loaded.task, "Updated task description");
+    }
+
+    #[test]
+    fn context_serde_roundtrip() {
+        let context = sample_context();
+        let json = serde_json::to_string(&context).unwrap();
+        let back: HandoffContext = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.task, context.task);
+        assert_eq!(back.reason, context.reason);
+    }
+
+    #[test]
+    fn handoff_reason_serde_roundtrip() {
+        let reasons = [
+            HandoffReason::Distillation,
+            HandoffReason::ControlledShutdown,
+            HandoffReason::ContextLimitApproaching,
+        ];
+        for reason in &reasons {
+            let json = serde_json::to_string(reason).unwrap();
+            let back: HandoffReason = serde_json::from_str(&json).unwrap();
+            assert_eq!(&back, reason, "roundtrip failed for {reason:?}");
+        }
+    }
+}

--- a/crates/dianoia/src/lib.rs
+++ b/crates/dianoia/src/lib.rs
@@ -10,6 +10,8 @@
 
 /// Errors from planning, state transitions, and workspace I/O.
 pub(crate) mod error;
+/// Context handoff protocol: continuity across distillation, shutdown, and crash recovery.
+pub mod handoff;
 /// Phase types within a project: groupings of related plans with lifecycle state.
 pub mod phase;
 /// Executable plans within a phase: dependency tracking, iteration limits, and blocker management.
@@ -18,6 +20,8 @@ pub mod plan;
 pub mod project;
 /// Project lifecycle state machine: valid transitions, pause/resume, and terminal states.
 pub mod state;
+/// Pattern-based stuck detection: repeated errors, same-args loops, alternating failures, escalating retries.
+pub mod stuck;
 /// On-disk workspace persistence: project serialization, blocker files, and directory layout.
 pub mod workspace;
 
@@ -29,4 +33,7 @@ mod assertions {
     assert_impl_all!(crate::phase::Phase: Send, Sync);
     assert_impl_all!(crate::plan::Plan: Send, Sync);
     assert_impl_all!(crate::workspace::ProjectWorkspace: Send, Sync);
+    assert_impl_all!(crate::stuck::StuckDetector: Send, Sync);
+    assert_impl_all!(crate::handoff::HandoffFile: Send, Sync);
+    assert_impl_all!(crate::handoff::HandoffContext: Send, Sync);
 }

--- a/crates/dianoia/src/stuck.rs
+++ b/crates/dianoia/src/stuck.rs
@@ -1,0 +1,734 @@
+//! Pattern-based stuck detection for tool execution loops.
+
+use std::collections::VecDeque;
+
+use serde::{Deserialize, Serialize};
+
+const DEFAULT_HISTORY_WINDOW: usize = 20;
+const DEFAULT_REPEATED_ERROR_THRESHOLD: u32 = 3;
+const DEFAULT_SAME_ARGS_THRESHOLD: u32 = 3;
+const DEFAULT_ALTERNATING_THRESHOLD: u32 = 3;
+const DEFAULT_ESCALATING_RETRY_THRESHOLD: u32 = 3;
+
+/// Configuration for stuck detection thresholds.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StuckConfig {
+    /// How many identical consecutive errors trigger detection.
+    pub repeated_error_threshold: u32,
+    /// How many identical consecutive tool+args calls trigger detection.
+    pub same_args_threshold: u32,
+    /// How many alternating failure cycles trigger detection.
+    pub alternating_threshold: u32,
+    /// How many scattered retries with the same error trigger detection.
+    pub escalating_retry_threshold: u32,
+    /// Maximum number of invocations retained in the sliding window.
+    pub history_window: usize,
+}
+
+impl Default for StuckConfig {
+    fn default() -> Self {
+        Self {
+            repeated_error_threshold: DEFAULT_REPEATED_ERROR_THRESHOLD,
+            same_args_threshold: DEFAULT_SAME_ARGS_THRESHOLD,
+            alternating_threshold: DEFAULT_ALTERNATING_THRESHOLD,
+            escalating_retry_threshold: DEFAULT_ESCALATING_RETRY_THRESHOLD,
+            history_window: DEFAULT_HISTORY_WINDOW,
+        }
+    }
+}
+
+/// The outcome of a tool invocation.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum InvocationOutcome {
+    /// Tool executed successfully.
+    Success,
+    /// Tool execution failed with an error message.
+    Error {
+        /// The error message from the failed invocation.
+        message: String,
+    },
+}
+
+/// A recorded tool invocation for pattern analysis.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ToolInvocation {
+    /// Name of the tool that was invoked.
+    pub tool_name: String,
+    /// Serialized arguments for identity comparison.
+    pub arguments: String,
+    /// Whether the invocation succeeded or failed.
+    pub outcome: InvocationOutcome,
+    /// When this invocation was recorded.
+    pub recorded_at: jiff::Timestamp,
+}
+
+/// The type of stuck pattern detected.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum StuckPattern {
+    /// The same error message appeared in the last N consecutive invocations.
+    RepeatedError {
+        /// The repeated error message.
+        message: String,
+        /// How many consecutive times the error appeared.
+        count: u32,
+    },
+    /// The same tool was called with identical arguments N consecutive times.
+    SameToolSameArgs {
+        /// The tool that was called repeatedly.
+        tool_name: String,
+        /// How many consecutive times it was called with the same args.
+        count: u32,
+    },
+    /// Two tools alternated back and forth, both failing.
+    AlternatingFailure {
+        /// First tool in the alternating pattern.
+        tool_a: String,
+        /// Second tool in the alternating pattern.
+        tool_b: String,
+        /// How many complete alternation cycles were detected.
+        cycles: u32,
+    },
+    /// The same tool+args+error combination appeared scattered across the history window.
+    EscalatingRetry {
+        /// The tool being retried.
+        tool_name: String,
+        /// How many times the same failure was observed in the window.
+        count: u32,
+    },
+}
+
+/// A signal that the agent appears to be stuck, with a suggestion for intervention.
+#[derive(Debug, Clone)]
+pub struct StuckSignal {
+    /// The pattern that triggered stuck detection.
+    pub pattern: StuckPattern,
+    /// A human-readable suggestion for how to intervene.
+    pub suggestion: String,
+}
+
+/// Detects stuck patterns in a sliding window of tool invocations.
+///
+/// Records each tool call and checks for repeated errors, same-argument loops,
+/// alternating failures, and escalating retry patterns.
+#[derive(Debug)]
+pub struct StuckDetector {
+    config: StuckConfig,
+    history: VecDeque<ToolInvocation>,
+}
+
+impl StuckDetector {
+    /// Create a new detector with the given configuration.
+    #[must_use]
+    pub fn new(config: StuckConfig) -> Self {
+        let capacity = config.history_window;
+        Self {
+            config,
+            history: VecDeque::with_capacity(capacity),
+        }
+    }
+
+    /// Record a tool invocation and check for stuck patterns.
+    ///
+    /// Returns `Some(StuckSignal)` if a stuck pattern is detected.
+    pub fn record(&mut self, invocation: ToolInvocation) -> Option<StuckSignal> {
+        self.history.push_back(invocation);
+        while self.history.len() > self.config.history_window {
+            self.history.pop_front();
+        }
+        self.check()
+    }
+
+    /// Check current history for stuck patterns without recording a new invocation.
+    #[must_use]
+    pub fn check(&self) -> Option<StuckSignal> {
+        self.check_same_tool_same_args()
+            .or_else(|| self.check_repeated_error())
+            .or_else(|| self.check_alternating_failure())
+            .or_else(|| self.check_escalating_retry())
+    }
+
+    /// Reset the detector, clearing all recorded history.
+    pub fn reset(&mut self) {
+        self.history.clear();
+    }
+
+    /// Number of invocations currently in the history window.
+    #[must_use]
+    pub fn history_len(&self) -> usize {
+        self.history.len()
+    }
+
+    /// The active configuration.
+    #[must_use]
+    pub fn config(&self) -> &StuckConfig {
+        &self.config
+    }
+
+    fn check_repeated_error(&self) -> Option<StuckSignal> {
+        #[expect(
+            clippy::as_conversions,
+            reason = "u32→usize: threshold values are small, no truncation possible"
+        )]
+        let threshold = self.config.repeated_error_threshold as usize;
+        if self.history.len() < threshold {
+            return None;
+        }
+
+        let tail: Vec<_> = self.history.iter().rev().take(threshold).collect();
+        let first_message = match &tail.first()?.outcome {
+            InvocationOutcome::Error { message } => message,
+            InvocationOutcome::Success => return None,
+        };
+
+        let all_same = tail.iter().all(|inv| {
+            matches!(
+                &inv.outcome,
+                InvocationOutcome::Error { message } if message == first_message
+            )
+        });
+
+        if all_same {
+            Some(StuckSignal {
+                pattern: StuckPattern::RepeatedError {
+                    message: first_message.clone(),
+                    #[expect(
+                        clippy::as_conversions,
+                        clippy::cast_possible_truncation,
+                        reason = "usize→u32: threshold originated as u32, roundtrip is lossless"
+                    )]
+                    count: threshold as u32,
+                },
+                suggestion: format!(
+                    "The same error has occurred {threshold} times consecutively. \
+                     Consider a different approach or ask for help."
+                ),
+            })
+        } else {
+            None
+        }
+    }
+
+    fn check_same_tool_same_args(&self) -> Option<StuckSignal> {
+        #[expect(
+            clippy::as_conversions,
+            reason = "u32→usize: threshold values are small, no truncation possible"
+        )]
+        let threshold = self.config.same_args_threshold as usize;
+        if self.history.len() < threshold {
+            return None;
+        }
+
+        let tail: Vec<_> = self.history.iter().rev().take(threshold).collect();
+        let first = tail.first()?;
+
+        let all_same = tail
+            .iter()
+            .all(|inv| inv.tool_name == first.tool_name && inv.arguments == first.arguments);
+
+        if all_same {
+            Some(StuckSignal {
+                pattern: StuckPattern::SameToolSameArgs {
+                    tool_name: first.tool_name.clone(),
+                    #[expect(
+                        clippy::as_conversions,
+                        clippy::cast_possible_truncation,
+                        reason = "usize→u32: threshold originated as u32, roundtrip is lossless"
+                    )]
+                    count: threshold as u32,
+                },
+                suggestion: format!(
+                    "Tool '{}' has been called with identical arguments {threshold} times. \
+                     The approach is not working.",
+                    first.tool_name
+                ),
+            })
+        } else {
+            None
+        }
+    }
+
+    fn check_alternating_failure(&self) -> Option<StuckSignal> {
+        #[expect(
+            clippy::as_conversions,
+            reason = "u32→usize: threshold values are small, no truncation possible"
+        )]
+        let threshold = self.config.alternating_threshold as usize;
+        let required = threshold.checked_mul(2)?;
+        if self.history.len() < required {
+            return None;
+        }
+
+        let tail: Vec<_> = self.history.iter().rev().take(required).collect();
+
+        // WHY: all invocations must be errors for an alternating failure pattern
+        if !tail
+            .iter()
+            .all(|inv| matches!(inv.outcome, InvocationOutcome::Error { .. }))
+        {
+            return None;
+        }
+
+        let a_inv = tail.first()?;
+        let b_inv = tail.get(1)?;
+
+        // The two pairs must be different tool+args combinations
+        if a_inv.tool_name == b_inv.tool_name && a_inv.arguments == b_inv.arguments {
+            return None;
+        }
+
+        let alternates = tail.iter().enumerate().all(|(i, inv)| {
+            let expected = if i % 2 == 0 { a_inv } else { b_inv };
+            inv.tool_name == expected.tool_name && inv.arguments == expected.arguments
+        });
+
+        if alternates {
+            Some(StuckSignal {
+                pattern: StuckPattern::AlternatingFailure {
+                    tool_a: a_inv.tool_name.clone(),
+                    tool_b: b_inv.tool_name.clone(),
+                    #[expect(
+                        clippy::as_conversions,
+                        clippy::cast_possible_truncation,
+                        reason = "usize→u32: threshold originated as u32, roundtrip is lossless"
+                    )]
+                    cycles: threshold as u32,
+                },
+                suggestion: format!(
+                    "Alternating between '{}' and '{}' without progress for {threshold} cycles. \
+                     Both approaches are failing.",
+                    a_inv.tool_name, b_inv.tool_name
+                ),
+            })
+        } else {
+            None
+        }
+    }
+
+    fn check_escalating_retry(&self) -> Option<StuckSignal> {
+        #[expect(
+            clippy::as_conversions,
+            reason = "u32→usize: threshold values are small, no truncation possible"
+        )]
+        let threshold = self.config.escalating_retry_threshold as usize;
+        if self.history.len() < threshold {
+            return None;
+        }
+
+        // WHY: count occurrences of each (tool, args, error) triple across the full window
+        // to find scattered retries that aren't necessarily consecutive
+        let mut counts: Vec<(&str, &str, &str, usize)> = Vec::new();
+
+        for inv in &self.history {
+            if let InvocationOutcome::Error { message } = &inv.outcome {
+                let found = counts.iter_mut().find(|(t, a, m, _)| {
+                    *t == inv.tool_name && *a == inv.arguments && *m == message.as_str()
+                });
+                if let Some(entry) = found {
+                    entry.3 += 1;
+                } else {
+                    counts.push((&inv.tool_name, &inv.arguments, message, 1));
+                }
+            }
+        }
+
+        let max_entry = counts.iter().max_by_key(|(_, _, _, count)| count)?;
+        if max_entry.3 < threshold {
+            return None;
+        }
+
+        // WHY: only trigger when retries are scattered (not consecutive), because consecutive
+        // patterns are already caught by check_repeated_error / check_same_tool_same_args
+        let matching_indices: Vec<usize> = self
+            .history
+            .iter()
+            .enumerate()
+            .filter(|(_, inv)| {
+                inv.tool_name == max_entry.0
+                    && inv.arguments == max_entry.1
+                    && matches!(
+                        &inv.outcome,
+                        InvocationOutcome::Error { message } if message == max_entry.2
+                    )
+            })
+            .map(|(i, _)| i)
+            .collect();
+
+        let first = matching_indices.first()?;
+        let last = matching_indices.last()?;
+        let span = last - first;
+        let has_gap = span > matching_indices.len() - 1;
+
+        if has_gap {
+            #[expect(
+                clippy::as_conversions,
+                clippy::cast_possible_truncation,
+                reason = "usize→u32: match count bounded by history_window which fits in u32"
+            )]
+            Some(StuckSignal {
+                pattern: StuckPattern::EscalatingRetry {
+                    tool_name: max_entry.0.to_string(),
+                    count: max_entry.3 as u32,
+                },
+                suggestion: format!(
+                    "Tool '{}' has been retried {} times across the history window with the same error. \
+                     Consider changing strategy.",
+                    max_entry.0, max_entry.3
+                ),
+            })
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "test assertions")]
+mod tests {
+    use super::*;
+
+    fn make_invocation(tool: &str, args: &str, outcome: InvocationOutcome) -> ToolInvocation {
+        ToolInvocation {
+            tool_name: tool.into(),
+            arguments: args.into(),
+            outcome,
+            recorded_at: jiff::Timestamp::now(),
+        }
+    }
+
+    fn error_outcome(msg: &str) -> InvocationOutcome {
+        InvocationOutcome::Error {
+            message: msg.into(),
+        }
+    }
+
+    #[test]
+    fn default_config_values() {
+        let config = StuckConfig::default();
+        assert_eq!(config.repeated_error_threshold, 3);
+        assert_eq!(config.same_args_threshold, 3);
+        assert_eq!(config.alternating_threshold, 3);
+        assert_eq!(config.escalating_retry_threshold, 3);
+        assert_eq!(config.history_window, 20);
+    }
+
+    #[test]
+    fn no_stuck_on_empty_history() {
+        let detector = StuckDetector::new(StuckConfig::default());
+        assert!(detector.check().is_none());
+    }
+
+    #[test]
+    fn no_stuck_on_varied_success_sequence() {
+        let mut detector = StuckDetector::new(StuckConfig::default());
+        for i in 0..5 {
+            let result = detector.record(make_invocation(
+                &format!("tool_{i}"),
+                &format!("/path/{i}"),
+                InvocationOutcome::Success,
+            ));
+            assert!(result.is_none());
+        }
+    }
+
+    #[test]
+    fn detects_repeated_error() {
+        let mut detector = StuckDetector::new(StuckConfig::default());
+        for i in 0..3 {
+            let result = detector.record(make_invocation(
+                &format!("tool_{i}"),
+                &format!("args_{i}"),
+                error_outcome("connection refused"),
+            ));
+            if i < 2 {
+                assert!(result.is_none());
+            } else {
+                let signal = result.unwrap();
+                assert_eq!(
+                    signal.pattern,
+                    StuckPattern::RepeatedError {
+                        message: "connection refused".into(),
+                        count: 3,
+                    }
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn detects_same_tool_same_args() {
+        let mut detector = StuckDetector::new(StuckConfig::default());
+        for i in 0..3 {
+            let result = detector.record(make_invocation(
+                "read_file",
+                "/etc/hosts",
+                InvocationOutcome::Success,
+            ));
+            if i < 2 {
+                assert!(result.is_none());
+            } else {
+                let signal = result.unwrap();
+                assert_eq!(
+                    signal.pattern,
+                    StuckPattern::SameToolSameArgs {
+                        tool_name: "read_file".into(),
+                        count: 3,
+                    }
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn same_tool_different_args_not_stuck() {
+        let mut detector = StuckDetector::new(StuckConfig::default());
+        for i in 0..5 {
+            let result = detector.record(make_invocation(
+                "read_file",
+                &format!("/path/{i}"),
+                InvocationOutcome::Success,
+            ));
+            assert!(result.is_none());
+        }
+    }
+
+    #[test]
+    fn detects_alternating_failure() {
+        let mut detector = StuckDetector::new(StuckConfig::default());
+        let mut last_result = None;
+        // WHY: each tool gets a distinct error message so repeated_error doesn't fire first
+        for i in 0..6 {
+            let tool = if i % 2 == 0 { "compile" } else { "lint" };
+            let args = if i % 2 == 0 {
+                "src/main.rs"
+            } else {
+                "src/lib.rs"
+            };
+            let err = if i % 2 == 0 {
+                "syntax error"
+            } else {
+                "lint violation"
+            };
+            last_result = detector.record(make_invocation(tool, args, error_outcome(err)));
+        }
+        let signal = last_result.unwrap();
+        assert!(matches!(
+            signal.pattern,
+            StuckPattern::AlternatingFailure { .. }
+        ));
+    }
+
+    #[test]
+    fn alternating_with_success_not_stuck() {
+        let mut detector = StuckDetector::new(StuckConfig::default());
+        for i in 0..6 {
+            let tool = if i % 2 == 0 { "compile" } else { "lint" };
+            let outcome = if i == 3 {
+                InvocationOutcome::Success
+            } else {
+                error_outcome("failed")
+            };
+            let result = detector.record(make_invocation(tool, "args", outcome));
+            // WHY: a success breaks the alternating failure pattern
+            if i >= 3 {
+                assert!(
+                    !matches!(
+                        result.as_ref().map(|s| &s.pattern),
+                        Some(StuckPattern::AlternatingFailure { .. })
+                    ),
+                    "should not detect alternating failure when success is present"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn detects_escalating_retry() {
+        let config = StuckConfig {
+            escalating_retry_threshold: 3,
+            // WHY: raise other thresholds so only escalating retry triggers
+            same_args_threshold: 100,
+            repeated_error_threshold: 100,
+            alternating_threshold: 100,
+            ..StuckConfig::default()
+        };
+        let mut detector = StuckDetector::new(config);
+
+        // Scattered retries with different tools in between
+        detector.record(make_invocation("deploy", "prod", error_outcome("timeout")));
+        detector.record(make_invocation(
+            "check_status",
+            "prod",
+            InvocationOutcome::Success,
+        ));
+        detector.record(make_invocation("deploy", "prod", error_outcome("timeout")));
+        detector.record(make_invocation(
+            "read_logs",
+            "prod",
+            InvocationOutcome::Success,
+        ));
+        let result = detector.record(make_invocation("deploy", "prod", error_outcome("timeout")));
+
+        let signal = result.unwrap();
+        assert!(matches!(
+            signal.pattern,
+            StuckPattern::EscalatingRetry { .. }
+        ));
+    }
+
+    #[test]
+    fn consecutive_errors_not_escalating() {
+        let config = StuckConfig {
+            escalating_retry_threshold: 3,
+            // WHY: raise same_args threshold so it doesn't fire first
+            same_args_threshold: 100,
+            repeated_error_threshold: 100,
+            ..StuckConfig::default()
+        };
+        let mut detector = StuckDetector::new(config);
+
+        // Three consecutive identical errors — no gap, so escalating retry should not trigger
+        detector.record(make_invocation("deploy", "prod", error_outcome("timeout")));
+        detector.record(make_invocation("deploy", "prod", error_outcome("timeout")));
+        let result = detector.record(make_invocation("deploy", "prod", error_outcome("timeout")));
+
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn custom_thresholds() {
+        let config = StuckConfig {
+            repeated_error_threshold: 5,
+            same_args_threshold: 5,
+            ..StuckConfig::default()
+        };
+        let mut detector = StuckDetector::new(config);
+
+        // 3 identical calls should not trigger with threshold of 5
+        for _ in 0..3 {
+            let result = detector.record(make_invocation(
+                "read_file",
+                "/same",
+                error_outcome("not found"),
+            ));
+            assert!(result.is_none());
+        }
+    }
+
+    #[test]
+    fn reset_clears_history() {
+        let mut detector = StuckDetector::new(StuckConfig::default());
+        detector.record(make_invocation("tool", "args", error_outcome("error")));
+        detector.record(make_invocation("tool", "args", error_outcome("error")));
+        assert_eq!(detector.history_len(), 2);
+
+        detector.reset();
+        assert_eq!(detector.history_len(), 0);
+        assert!(detector.check().is_none());
+    }
+
+    #[test]
+    fn history_window_eviction() {
+        let config = StuckConfig {
+            history_window: 3,
+            ..StuckConfig::default()
+        };
+        let mut detector = StuckDetector::new(config);
+
+        for i in 0..5 {
+            detector.record(make_invocation(
+                &format!("tool_{i}"),
+                "args",
+                InvocationOutcome::Success,
+            ));
+        }
+        assert_eq!(detector.history_len(), 3);
+    }
+
+    #[test]
+    fn same_tool_same_args_has_priority_over_repeated_error() {
+        let mut detector = StuckDetector::new(StuckConfig::default());
+        // WHY: same tool + same args + same error should trigger SameToolSameArgs first
+        // because it's checked before RepeatedError in the priority chain
+        for _ in 0..3 {
+            detector.record(make_invocation(
+                "compile",
+                "src/main.rs",
+                error_outcome("syntax error"),
+            ));
+        }
+        let signal = detector.check().unwrap();
+        assert!(matches!(
+            signal.pattern,
+            StuckPattern::SameToolSameArgs { .. }
+        ));
+    }
+
+    #[test]
+    fn below_threshold_no_signal() {
+        let mut detector = StuckDetector::new(StuckConfig::default());
+        detector.record(make_invocation("tool", "args", error_outcome("error")));
+        detector.record(make_invocation("tool", "args", error_outcome("error")));
+        // Only 2 of threshold 3
+        assert!(detector.check().is_none());
+    }
+
+    #[test]
+    fn mixed_errors_not_repeated() {
+        let mut detector = StuckDetector::new(StuckConfig::default());
+        detector.record(make_invocation("tool", "args", error_outcome("error A")));
+        detector.record(make_invocation("tool", "args", error_outcome("error B")));
+        detector.record(make_invocation("tool", "args", error_outcome("error A")));
+        // Different error messages break the repeated error pattern
+        // But same tool+args triggers SameToolSameArgs
+        let signal = detector.check().unwrap();
+        assert!(matches!(
+            signal.pattern,
+            StuckPattern::SameToolSameArgs { .. }
+        ));
+    }
+
+    #[test]
+    fn config_serde_roundtrip() {
+        let config = StuckConfig {
+            repeated_error_threshold: 5,
+            same_args_threshold: 4,
+            alternating_threshold: 6,
+            escalating_retry_threshold: 7,
+            history_window: 50,
+        };
+        let json = serde_json::to_string(&config).unwrap();
+        let back: StuckConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.repeated_error_threshold, 5);
+        assert_eq!(back.same_args_threshold, 4);
+        assert_eq!(back.alternating_threshold, 6);
+        assert_eq!(back.escalating_retry_threshold, 7);
+        assert_eq!(back.history_window, 50);
+    }
+
+    #[test]
+    fn invocation_serde_roundtrip() {
+        let inv = make_invocation("read_file", "/path/to/file", error_outcome("not found"));
+        let json = serde_json::to_string(&inv).unwrap();
+        let back: ToolInvocation = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.tool_name, "read_file");
+        assert_eq!(back.arguments, "/path/to/file");
+        assert_eq!(
+            back.outcome,
+            InvocationOutcome::Error {
+                message: "not found".into()
+            }
+        );
+    }
+
+    #[test]
+    fn signal_suggestion_is_nonempty() {
+        let mut detector = StuckDetector::new(StuckConfig::default());
+        for _ in 0..3 {
+            detector.record(make_invocation("tool", "args", error_outcome("error")));
+        }
+        let signal = detector.check().unwrap();
+        assert!(!signal.suggestion.is_empty());
+    }
+}


### PR DESCRIPTION
## Summary

- Add `StuckDetector` with pattern-based stuck detection: repeated errors, same tool+args loops, alternating failures between two tools, and escalating retry patterns scattered across the history window
- Add `HandoffFile` for context continuity across distillation, shutdown, and crash recovery, writing both `.continue-here.json` (machine-readable) and `.continue-here.md` (human-readable)
- All thresholds configurable via `StuckConfig` (defaults: 3 repetitions, 20-item sliding window)

## Test plan

- [x] `cargo clippy -p aletheia-dianoia --all-targets -- -D warnings` passes (zero warnings)
- [x] `cargo test -p aletheia-dianoia` passes (108 tests, 0 failures)
- [x] Stuck detection: repeated error, same-args, alternating failure, escalating retry patterns all tested
- [x] Handoff: write/read roundtrip, orphaned detection, clear, markdown rendering, nested dir creation
- [x] Send + Sync assertions for `StuckDetector`, `HandoffFile`, `HandoffContext`
- [x] Serde roundtrips for `StuckConfig`, `ToolInvocation`, `HandoffContext`, `HandoffReason`

Closes #1869
Closes #1870