### PR TITLE
feat(tui): context budget visualization and distillation indicators

### DIFF
--- a/crates/theatron/tui/src/app/mod.rs
+++ b/crates/theatron/tui/src/app/mod.rs
@@ -55,6 +55,10 @@ pub struct DashboardState {
     pub daily_cost_cents: u32,
     pub session_cost_cents: u32,
     pub context_usage_pct: Option<u8>,
+    /// Raw token count currently in the context window (input + cache-read).
+    pub context_tokens_used: Option<u32>,
+    /// Total context window capacity for the current model.
+    pub context_tokens_total: Option<u32>,
     /// Last-active session per agent, loaded from disk on startup and saved on exit.
     pub(crate) saved_sessions: HashMap<NousId, SessionId>,
 }
@@ -175,6 +179,8 @@ impl App {
                 daily_cost_cents: 0,
                 session_cost_cents: 0,
                 context_usage_pct: None,
+                context_tokens_used: None,
+                context_tokens_total: None,
                 saved_sessions,
             },
             connection: ConnectionState {
@@ -299,6 +305,7 @@ impl App {
                     sessions: Vec::new(),
                     model: a.model.map(|m| sanitize_for_display(&m).into_owned()),
                     compaction_stage: None,
+                    distill_completed_at: None,
                     unread_count: 0,
                     tools: Vec::new(),
                 }

--- a/crates/theatron/tui/src/app/test_helpers.rs
+++ b/crates/theatron/tui/src/app/test_helpers.rs
@@ -40,6 +40,8 @@ pub fn test_app() -> App {
             daily_cost_cents: 0,
             session_cost_cents: 0,
             context_usage_pct: None,
+            context_tokens_used: None,
+            context_tokens_total: None,
             saved_sessions: HashMap::new(),
         },
         connection: ConnectionState {
@@ -127,6 +129,7 @@ pub fn test_agent(id: &str, name: &str) -> AgentState {
         sessions: Vec::new(),
         model: Some("test-model".to_string()),
         compaction_stage: None,
+        distill_completed_at: None,
         unread_count: 0,
         tools: Vec::new(),
     }

--- a/crates/theatron/tui/src/command/mod.rs
+++ b/crates/theatron/tui/src/command/mod.rs
@@ -355,6 +355,7 @@ mod tests {
             sessions: Vec::new(),
             model: Some("claude-opus-4-6".into()),
             compaction_stage: None,
+            distill_completed_at: None,
             unread_count: 0,
             tools: Vec::new(),
         }];

--- a/crates/theatron/tui/src/keybindings/helpers.rs
+++ b/crates/theatron/tui/src/keybindings/helpers.rs
@@ -134,6 +134,7 @@ pub(crate) fn context_label(app: &App) -> &'static str {
         Some(Overlay::ToolApproval(_)) => "Tool Approval",
         Some(Overlay::PlanApproval(_)) => "Plan Approval",
         Some(Overlay::SystemStatus) => "System Status",
+        Some(Overlay::ContextBudget) => "Context Budget",
         Some(Overlay::Settings(_)) => "Settings",
         Some(Overlay::ContextActions(_)) => "Context Actions",
         Some(Overlay::DiffView(_)) => "Diff Viewer",

--- a/crates/theatron/tui/src/mapping/keyboard.rs
+++ b/crates/theatron/tui/src/mapping/keyboard.rs
@@ -123,6 +123,12 @@ impl crate::app::App {
             (_, KeyCode::Up) => Some(Msg::HistoryUp),
             (_, KeyCode::Down) => Some(Msg::HistoryDown),
 
+            (KeyModifiers::CONTROL, KeyCode::Char('b'))
+                if self.interaction.input.text.is_empty() =>
+            {
+                Some(Msg::OpenOverlay(OverlayKind::ContextBudget))
+            }
+
             (KeyModifiers::NONE, KeyCode::Char('?')) if self.interaction.input.text.is_empty() => {
                 Some(Msg::OpenOverlay(OverlayKind::Help))
             }

--- a/crates/theatron/tui/src/msg.rs
+++ b/crates/theatron/tui/src/msg.rs
@@ -358,6 +358,7 @@ pub enum OverlayKind {
     #[expect(dead_code, reason = "planned TUI feature")]
     SessionPickerAll,
     SystemStatus,
+    ContextBudget,
     #[expect(dead_code, reason = "planned TUI feature")]
     Settings,
 }

--- a/crates/theatron/tui/src/state/agent.rs
+++ b/crates/theatron/tui/src/state/agent.rs
@@ -40,6 +40,8 @@ pub struct AgentState {
     pub sessions: Vec<Session>,
     pub model: Option<String>,
     pub compaction_stage: Option<String>,
+    /// Set when distillation completes; cleared after 3-second auto-dismiss delay.
+    pub distill_completed_at: Option<std::time::Instant>,
     /// Number of unread messages since the user last focused this agent.
     /// Cleared when the user switches to this agent.
     pub unread_count: u32,

--- a/crates/theatron/tui/src/state/overlay.rs
+++ b/crates/theatron/tui/src/state/overlay.rs
@@ -12,6 +12,7 @@ pub enum Overlay {
     },
     SessionPicker(SessionPickerOverlay),
     SystemStatus,
+    ContextBudget,
     Settings(SettingsOverlay),
     ToolApproval(ToolApprovalOverlay),
     PlanApproval(PlanApprovalOverlay),

--- a/crates/theatron/tui/src/update/api.rs
+++ b/crates/theatron/tui/src/update/api.rs
@@ -23,6 +23,7 @@ pub(crate) fn handle_agents_loaded(app: &mut App, agents: Vec<Agent>) {
                 sessions: sanitize_sessions(Vec::new()),
                 model: a.model.map(|m| sanitize_for_display(&m).into_owned()),
                 compaction_stage: None,
+                distill_completed_at: None,
                 unread_count: 0,
                 tools: Vec::new(),
             }
@@ -178,6 +179,7 @@ pub(crate) fn handle_tick(app: &mut App) {
         app.viewport.success_toast = None;
     }
     super::sse::check_sse_reconnect_timeout(app);
+    super::sse::check_distill_auto_dismiss(app);
 }
 
 /// Sanitize session fields that may contain external data.

--- a/crates/theatron/tui/src/update/overlay.rs
+++ b/crates/theatron/tui/src/update/overlay.rs
@@ -22,6 +22,7 @@ pub(crate) async fn handle_open_overlay(app: &mut App, kind: OverlayKind) {
                     show_archived: true,
                 }),
                 OverlayKind::SystemStatus => Overlay::SystemStatus,
+                OverlayKind::ContextBudget => Overlay::ContextBudget,
                 OverlayKind::Settings => unreachable!(),
             });
         }

--- a/crates/theatron/tui/src/update/sse.rs
+++ b/crates/theatron/tui/src/update/sse.rs
@@ -46,6 +46,7 @@ pub(crate) async fn handle_sse_connected(app: &mut App) {
                         sessions: Vec::new(),
                         model: a.model.map(|m| sanitize_for_display(&m).into_owned()),
                         compaction_stage: None,
+                        distill_completed_at: None,
                         unread_count: count,
                         tools: Vec::new(),
                     }
@@ -207,10 +208,25 @@ pub(crate) fn handle_sse_distill_stage(app: &mut App, nous_id: NousId, stage: St
 pub(crate) async fn handle_sse_distill_after(app: &mut App, nous_id: NousId) {
     if let Some(agent) = app.dashboard.agents.iter_mut().find(|a| a.id == nous_id) {
         agent.status = AgentStatus::Idle;
-        agent.compaction_stage = None;
+        agent.compaction_stage = Some("done".to_string());
+        agent.distill_completed_at = Some(std::time::Instant::now());
     }
     if app.dashboard.focused_agent.as_ref() == Some(&nous_id) {
         app.load_focused_session().await;
+    }
+}
+
+/// Auto-dismiss distillation stage indicator after 3 seconds.
+pub(crate) fn check_distill_auto_dismiss(app: &mut App) {
+    const DISMISS_DELAY: std::time::Duration = std::time::Duration::from_secs(3);
+    for agent in &mut app.dashboard.agents {
+        if agent
+            .distill_completed_at
+            .is_some_and(|t| t.elapsed() >= DISMISS_DELAY)
+        {
+            agent.compaction_stage = None;
+            agent.distill_completed_at = None;
+        }
     }
 }
 

--- a/crates/theatron/tui/src/update/streaming.rs
+++ b/crates/theatron/tui/src/update/streaming.rs
@@ -9,6 +9,12 @@ use crate::state::{
     ToolApprovalOverlay, ToolCallInfo,
 };
 
+/// Context window size in tokens for the given model.
+/// All current Claude models use 200K context.
+fn model_context_window(_model: &str) -> u32 {
+    200_000
+}
+
 #[tracing::instrument(skip_all, fields(%turn_id, %nous_id))]
 pub(crate) fn handle_stream_turn_start(app: &mut App, turn_id: TurnId, nous_id: NousId) {
     app.connection.active_turn_id = Some(turn_id);
@@ -228,6 +234,20 @@ pub(crate) async fn handle_stream_turn_complete(app: &mut App, outcome: TurnOutc
         agent.active_tool = None;
     }
     app.layout.ops.auto_hide_if_configured();
+    let ctx_used = outcome
+        .input_tokens
+        .saturating_add(outcome.cache_read_tokens);
+    if ctx_used > 0 {
+        let ctx_total = model_context_window(&outcome.model);
+        app.dashboard.context_tokens_used = Some(ctx_used);
+        app.dashboard.context_tokens_total = Some(ctx_total);
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "percentage is always 0–100, fits in u8"
+        )]
+        let pct = ((u64::from(ctx_used) * 100) / u64::from(ctx_total)).min(100) as u8;
+        app.dashboard.context_usage_pct = Some(pct);
+    }
     if let Ok(cents) = app.client.today_cost_cents().await {
         app.dashboard.daily_cost_cents = cents;
     }

--- a/crates/theatron/tui/src/view/overlay.rs
+++ b/crates/theatron/tui/src/view/overlay.rs
@@ -55,6 +55,7 @@ pub(crate) fn render(app: &App, frame: &mut Frame, area: Rect, theme: &Theme) {
             render_context_actions(frame, compact_area, ctx, theme);
         }
         Overlay::SystemStatus => render_system_status(app, frame, popup_area, theme),
+        Overlay::ContextBudget => render_context_budget(app, frame, popup_area, theme),
         Overlay::Settings(settings) => super::settings::render(settings, frame, area, theme),
         Overlay::SessionSearch(search) => render_session_search(frame, popup_area, search, theme),
         Overlay::DiffView(diff_state) => {
@@ -690,6 +691,89 @@ fn render_session_search(
         .block(block)
         .wrap(Wrap { trim: false });
     frame.render_widget(paragraph, area);
+}
+
+fn render_context_budget(app: &App, frame: &mut Frame, area: Rect, theme: &Theme) {
+    const GAUGE_WIDTH: usize = 30;
+    const WARN_THRESHOLD: u8 = 70;
+    const CRITICAL_THRESHOLD: u8 = 90;
+
+    let block = overlay_block("Context Budget", theme);
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    let pct = app.dashboard.context_usage_pct.unwrap_or(0);
+    let used = app.dashboard.context_tokens_used;
+    let total = app.dashboard.context_tokens_total;
+
+    let color = if pct <= WARN_THRESHOLD {
+        theme.status.success
+    } else if pct <= CRITICAL_THRESHOLD {
+        theme.status.warning
+    } else {
+        theme.status.error
+    };
+
+    let filled = (usize::from(pct) * GAUGE_WIDTH) / 100;
+    let empty = GAUGE_WIDTH.saturating_sub(filled);
+    let bar = format!("[{}{}]", "=".repeat(filled), ".".repeat(empty));
+
+    let token_line = match (used, total) {
+        (Some(u), Some(t)) => format!(
+            "{pct}%  {bar}  ({} / {} tokens)",
+            format_tokens(u),
+            format_tokens(t)
+        ),
+        _ => format!("{pct}%  {bar}"),
+    };
+
+    let warn_badge = if pct > WARN_THRESHOLD {
+        if pct > CRITICAL_THRESHOLD {
+            "  ⚠ approaching limit"
+        } else {
+            "  ⚠ high usage"
+        }
+    } else {
+        ""
+    };
+
+    let lines = vec![
+        Line::from(vec![Span::styled(
+            "Context window usage",
+            theme.style_accent_bold(),
+        )]),
+        Line::raw(""),
+        Line::from(vec![
+            Span::styled(token_line, ratatui::style::Style::default().fg(color)),
+            Span::styled(warn_badge, theme.style_warning()),
+        ]),
+        Line::raw(""),
+        Line::from(vec![Span::styled(
+            "  Used tokens include input + cache reads.",
+            theme.style_muted(),
+        )]),
+        Line::from(vec![Span::styled(
+            "  Total capacity based on current model (200K).",
+            theme.style_muted(),
+        )]),
+        Line::raw(""),
+        Line::from(vec![Span::styled("  Esc  close", theme.style_dim())]),
+    ];
+
+    let para = Paragraph::new(lines)
+        .wrap(Wrap { trim: false })
+        .style(ratatui::style::Style::default());
+    frame.render_widget(para, inner);
+}
+
+fn format_tokens(n: u32) -> String {
+    if n >= 1_000_000 {
+        format!("{}M", n / 1_000_000)
+    } else if n >= 1_000 {
+        format!("{}K", n / 1_000)
+    } else {
+        format!("{n}")
+    }
 }
 
 /// Create a centered rect within the given area.

--- a/crates/theatron/tui/src/view/status_bar.rs
+++ b/crates/theatron/tui/src/view/status_bar.rs
@@ -58,7 +58,19 @@ fn render_info_bar(app: &App, width: u16, theme: &Theme) -> Line<'static> {
     right_spans.extend(scroll_position_spans(app, theme));
     right_spans.extend(cost_spans(app, theme));
     right_spans.push(Span::styled(" │ ", theme.style_dim()));
-    right_spans.extend(context_gauge_spans(app, theme));
+    let focused_agent = app
+        .dashboard
+        .focused_agent
+        .as_ref()
+        .and_then(|id| app.dashboard.agents.iter().find(|a| a.id == *id));
+    let is_distilling = focused_agent.is_some_and(|a| {
+        a.status == crate::state::AgentStatus::Compacting || a.distill_completed_at.is_some()
+    });
+    if is_distilling {
+        right_spans.extend(distillation_stage_spans(app, theme));
+    } else {
+        right_spans.extend(context_gauge_spans(app, theme));
+    }
     right_spans.push(Span::raw(" "));
     let right_width: usize = right_spans.iter().map(|s| s.content.width()).sum();
 
@@ -393,34 +405,104 @@ fn tool_indicator_spans(app: &App, theme: &Theme) -> Vec<Span<'static>> {
     ]
 }
 
-fn context_gauge_spans(app: &App, theme: &Theme) -> Vec<Span<'static>> {
-    const GAUGE_WIDTH: usize = 6;
-    const CONTEXT_WARN_THRESHOLD: u8 = 60;
-    const CONTEXT_CRITICAL_THRESHOLD: u8 = 80;
+const DISTILL_STAGES: &[&str] = &["sanitize", "extract", "summarize", "flush", "verify"];
 
-    match app.dashboard.context_usage_pct {
-        Some(pct) => {
-            let filled = (usize::from(pct) * GAUGE_WIDTH) / 100;
-            let empty = GAUGE_WIDTH.saturating_sub(filled);
+fn distillation_stage_spans(app: &App, theme: &Theme) -> Vec<Span<'static>> {
+    let agent = app
+        .dashboard
+        .focused_agent
+        .as_ref()
+        .and_then(|id| app.dashboard.agents.iter().find(|a| a.id == *id));
 
-            let color = if pct <= CONTEXT_WARN_THRESHOLD {
-                theme.status.success
-            } else if pct <= CONTEXT_CRITICAL_THRESHOLD {
-                theme.status.warning
-            } else {
-                theme.status.error
-            };
+    let stage = agent
+        .and_then(|a| a.compaction_stage.as_deref())
+        .unwrap_or("starting");
 
-            vec![
-                Span::styled("█".repeat(filled), Style::default().fg(color)),
-                Span::styled("░".repeat(empty), theme.style_dim()),
-                Span::styled(format!(" {pct}%"), Style::default().fg(color)),
-            ]
+    if stage == "done" {
+        return vec![
+            Span::styled("✓ ", theme.style_success()),
+            Span::styled("distilled", theme.style_muted()),
+        ];
+    }
+
+    let mut spans = vec![Span::styled("distilling: ", theme.style_muted())];
+    for (i, &s) in DISTILL_STAGES.iter().enumerate() {
+        if i > 0 {
+            spans.push(Span::styled(" ▸ ", theme.style_dim()));
         }
-        None => vec![
-            Span::styled("░".repeat(GAUGE_WIDTH), theme.style_dim()),
-            Span::styled(" —%", theme.style_dim()),
-        ],
+        if s == stage {
+            spans.push(Span::styled(s.to_owned(), theme.style_accent_bold()));
+        } else {
+            spans.push(Span::styled(s.to_owned(), theme.style_dim()));
+        }
+    }
+    spans
+}
+
+fn context_gauge_spans(app: &App, theme: &Theme) -> Vec<Span<'static>> {
+    const GAUGE_WIDTH: usize = 20;
+    const CONTEXT_WARN_THRESHOLD: u8 = 70;
+    const CONTEXT_CRITICAL_THRESHOLD: u8 = 90;
+
+    let pct = match app.dashboard.context_usage_pct {
+        Some(p) => p,
+        None => {
+            return vec![
+                Span::styled("ctx: ", theme.style_dim()),
+                Span::styled(
+                    "[".to_owned() + &".".repeat(GAUGE_WIDTH) + "]",
+                    theme.style_dim(),
+                ),
+                Span::styled(" —%", theme.style_dim()),
+            ];
+        }
+    };
+
+    let filled = (usize::from(pct) * GAUGE_WIDTH) / 100;
+    let empty = GAUGE_WIDTH.saturating_sub(filled);
+    let color = if pct <= CONTEXT_WARN_THRESHOLD {
+        theme.status.success
+    } else if pct <= CONTEXT_CRITICAL_THRESHOLD {
+        theme.status.warning
+    } else {
+        theme.status.error
+    };
+
+    let bar = format!("[{}{}]", "=".repeat(filled), ".".repeat(empty));
+    let mut spans = vec![
+        Span::styled("ctx: ", theme.style_muted()),
+        Span::styled(format!("{pct}% "), Style::default().fg(color)),
+        Span::styled(bar, Style::default().fg(color)),
+    ];
+
+    if let (Some(used), Some(total)) = (
+        app.dashboard.context_tokens_used,
+        app.dashboard.context_tokens_total,
+    ) {
+        spans.push(Span::styled(
+            format!(
+                "  ({} / {})",
+                format_token_count(used),
+                format_token_count(total)
+            ),
+            theme.style_muted(),
+        ));
+    }
+
+    if pct > CONTEXT_CRITICAL_THRESHOLD {
+        spans.push(Span::styled("  distilling soon", theme.style_warning()));
+    }
+
+    spans
+}
+
+fn format_token_count(n: u32) -> String {
+    if n >= 1_000_000 {
+        format!("{}M", n / 1_000_000)
+    } else if n >= 1_000 {
+        format!("{}K", n / 1_000)
+    } else {
+        format!("{n}")
     }
 }
 


### PR DESCRIPTION
## Summary

- **Context window gauge** (#1894): status bar now shows `ctx: N% [===...] (72K / 200K)` with color thresholds at 70% (yellow) and 90% (red); shows "distilling soon" hint when critical
- **Distillation progress** (#1858): staged pipeline `sanitize ▸ extract ▸ summarize ▸ flush ▸ verify` renders in status bar during active compaction; shows `✓ distilled` on completion; auto-dismisses after 3 seconds
- **Context budget overlay** (#1866): `Ctrl+B` opens an expandable panel showing the ASCII bar gauge, absolute token counts, and warning badges at >70%/>90%

## Implementation notes

- Token counts sourced from `TurnOutcome` (`input_tokens + cache_read_tokens`); context window total derived from model name (200K default, covers all current Claude models)
- Distillation auto-dismiss driven by `distill_completed_at` timestamp on `AgentState`, checked on every tick
- All new state is in `DashboardState` (`context_tokens_used`, `context_tokens_total`) and `AgentState` (`distill_completed_at`)

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo test -p theatron-tui` passes (858 tests)
- [ ] Visual: status bar shows `ctx:` gauge after a turn completes
- [ ] Visual: gauge turns yellow >70%, red >90%
- [ ] Visual: distillation pipeline appears when compaction starts
- [ ] Visual: `✓ distilled` shows briefly after distillation completes
- [ ] Visual: `Ctrl+B` opens context budget overlay

Closes #1894
Closes #1858
Closes #1866

🤖 Generated with [Claude Code](https://claude.com/claude-code)