### PR TITLE
feat(tui): tool approval dialog and category icons

### DIFF
--- a/crates/organon/src/types.rs
+++ b/crates/organon/src/types.rs
@@ -176,6 +176,50 @@ impl std::fmt::Display for ToolCategory {
     }
 }
 
+impl ToolCategory {
+    /// Unicode icon for TUI display.
+    #[must_use]
+    pub fn icon(self) -> &'static str {
+        match self {
+            Self::Workspace => "≡",
+            Self::Memory => "⊙",
+            Self::Communication => "↔",
+            Self::Planning => "◈",
+            Self::System => "⚙",
+            Self::Agent => "⊛",
+            Self::Research => "⊕",
+            Self::Domain => "○",
+        }
+    }
+
+    /// Human-readable display name.
+    #[must_use]
+    pub fn display_name(self) -> &'static str {
+        match self {
+            Self::Workspace => "Workspace",
+            Self::Memory => "Memory",
+            Self::Communication => "Communication",
+            Self::Planning => "Planning",
+            Self::System => "System",
+            Self::Agent => "Agent",
+            Self::Research => "Research",
+            Self::Domain => "Domain",
+        }
+    }
+
+    /// Whether this category is read-only (non-destructive).
+    #[must_use]
+    pub fn is_read_only(self) -> bool {
+        matches!(self, Self::Research | Self::Planning)
+    }
+
+    /// Whether this category performs destructive or irreversible operations.
+    #[must_use]
+    pub fn is_destructive(self) -> bool {
+        matches!(self, Self::System | Self::Agent | Self::Communication)
+    }
+}
+
 /// What the tool executor returns.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ToolResult {

--- a/crates/theatron/tui/src/app/mod.rs
+++ b/crates/theatron/tui/src/app/mod.rs
@@ -109,6 +109,8 @@ pub struct InteractionState {
     pub tool_expanded: HashSet<crate::id::ToolId>,
     pub filter: FilterState,
     pub(crate) keymap: KeyMap,
+    /// Tool names that bypass the approval dialog for the lifetime of this TUI session.
+    pub(crate) always_allowed_tools: HashSet<String>,
 }
 
 /// Sidebar, overlay, view stack, ops, tabs, and memory inspector.
@@ -216,6 +218,7 @@ impl App {
                 tool_expanded: HashSet::new(),
                 filter: FilterState::default(),
                 keymap,
+                always_allowed_tools: HashSet::new(),
             },
             layout: LayoutState {
                 sidebar_visible: true,

--- a/crates/theatron/tui/src/app/test_helpers.rs
+++ b/crates/theatron/tui/src/app/test_helpers.rs
@@ -81,6 +81,7 @@ pub fn test_app() -> App {
             tool_expanded: HashSet::new(),
             filter: FilterState::default(),
             keymap: KeyMap::build(&HashMap::new()),
+            always_allowed_tools: HashSet::new(),
         },
         layout: LayoutState {
             sidebar_visible: true,

--- a/crates/theatron/tui/src/mapping/keyboard.rs
+++ b/crates/theatron/tui/src/mapping/keyboard.rs
@@ -459,6 +459,9 @@ impl crate::app::App {
             (_, KeyCode::Char('d' | 'D')) if self.is_tool_approval_overlay() => {
                 Some(Msg::CloseOverlay)
             }
+            (_, KeyCode::Char('l' | 'L')) if self.is_tool_approval_overlay() => {
+                Some(Msg::ToolApprovalAlwaysAllow)
+            }
 
             (_, KeyCode::Char(' ')) if self.is_plan_approval_overlay() => Some(Msg::OverlaySelect),
             (_, KeyCode::Char('a' | 'A')) if self.is_plan_approval_overlay() => {

--- a/crates/theatron/tui/src/msg.rs
+++ b/crates/theatron/tui/src/msg.rs
@@ -94,6 +94,8 @@ pub enum Msg {
     OverlaySelect,
     OverlayFilter(char),
     OverlayFilterBackspace,
+    /// Approve a tool call and add it to the session-scoped always-allow list.
+    ToolApprovalAlwaysAllow,
 
     SseConnected,
     SseDisconnected,

--- a/crates/theatron/tui/src/state/ops/types.rs
+++ b/crates/theatron/tui/src/state/ops/types.rs
@@ -49,6 +49,46 @@ impl std::fmt::Display for ToolCategory {
     }
 }
 
+impl ToolCategory {
+    /// Unicode icon for TUI display.
+    #[must_use]
+    pub(crate) fn icon(self) -> &'static str {
+        match self {
+            Self::Read => "←",
+            Self::Write => "→",
+            Self::Search => "⊛",
+            Self::Exec => "▶",
+            Self::Http => "↗",
+            Self::Other => "·",
+        }
+    }
+
+    /// Human-readable display name.
+    #[must_use]
+    pub(crate) fn display_name(self) -> &'static str {
+        match self {
+            Self::Read => "read",
+            Self::Write => "write",
+            Self::Search => "search",
+            Self::Exec => "exec",
+            Self::Http => "http",
+            Self::Other => "other",
+        }
+    }
+
+    /// Whether this category is read-only (non-destructive).
+    #[must_use]
+    pub(crate) fn is_read_only(self) -> bool {
+        matches!(self, Self::Read | Self::Search)
+    }
+
+    /// Whether this category performs destructive or irreversible operations.
+    #[must_use]
+    pub(crate) fn is_destructive(self) -> bool {
+        matches!(self, Self::Exec | Self::Write)
+    }
+}
+
 /// Auto-show behavior configuration.
 ///
 /// Additional variants (`Always`, `Manual`) will be added when config wiring lands.

--- a/crates/theatron/tui/src/update/mod.rs
+++ b/crates/theatron/tui/src/update/mod.rs
@@ -108,6 +108,7 @@ pub(crate) async fn update(app: &mut App, msg: Msg) {
         Msg::OverlayUp => overlay::handle_overlay_up(app),
         Msg::OverlayDown => overlay::handle_overlay_down(app),
         Msg::OverlaySelect => overlay::handle_overlay_select(app).await,
+        Msg::ToolApprovalAlwaysAllow => overlay::handle_tool_approval_always_allow(app),
         Msg::OverlayFilter(c) => {
             if matches!(
                 &app.layout.overlay,

--- a/crates/theatron/tui/src/update/overlay.rs
+++ b/crates/theatron/tui/src/update/overlay.rs
@@ -28,6 +28,28 @@ pub(crate) async fn handle_open_overlay(app: &mut App, kind: OverlayKind) {
     }
 }
 
+pub(crate) fn handle_tool_approval_always_allow(app: &mut App) {
+    let Some(crate::state::Overlay::ToolApproval(ref approval)) = app.layout.overlay else {
+        return;
+    };
+    let turn_id = approval.turn_id.clone();
+    let tool_id = approval.tool_id.clone();
+    let tool_name = approval.tool_name.clone();
+    let client = app.client.clone();
+    let span = tracing::info_span!("approve_tool_always", %turn_id, %tool_id, %tool_name);
+    tokio::spawn(
+        // kanon:ignore RUST/spawn-no-instrument
+        async move {
+            if let Err(e) = client.approve_tool(&turn_id, &tool_id).await {
+                tracing::error!("failed to approve tool: {e}");
+            }
+        }
+        .instrument(span),
+    );
+    app.interaction.always_allowed_tools.insert(tool_name);
+    app.layout.overlay = None;
+}
+
 pub(crate) fn handle_close_overlay(app: &mut App) {
     // NOTE: Esc in settings edit mode cancels the edit, not the overlay itself
     if let Some(Overlay::Settings(ref s)) = app.layout.overlay

--- a/crates/theatron/tui/src/update/streaming.rs
+++ b/crates/theatron/tui/src/update/streaming.rs
@@ -1,3 +1,5 @@
+use tracing::Instrument;
+
 use crate::api::types::{Plan, TurnOutcome};
 use crate::app::App;
 use crate::id::{NousId, ToolId, TurnId};
@@ -111,6 +113,27 @@ pub(crate) fn handle_stream_tool_approval_required(
     risk: String,
     reason: String,
 ) {
+    // WHY: If the user previously chose "always allow" for this tool, auto-approve
+    // without presenting the dialog again.
+    if app
+        .interaction
+        .always_allowed_tools
+        .contains(tool_name.as_str())
+    {
+        let client = app.client.clone();
+        let span = tracing::info_span!("auto_approve_tool", %turn_id, %tool_id, %tool_name);
+        tokio::spawn(
+            // kanon:ignore RUST/spawn-no-instrument
+            async move {
+                if let Err(e) = client.approve_tool(&turn_id, &tool_id).await {
+                    tracing::error!("failed to auto-approve tool: {e}");
+                }
+            }
+            .instrument(span),
+        );
+        return;
+    }
+
     app.layout.overlay = Some(Overlay::ToolApproval(ToolApprovalOverlay {
         turn_id,
         tool_id,

--- a/crates/theatron/tui/src/view/ops.rs
+++ b/crates/theatron/tui/src/view/ops.rs
@@ -274,9 +274,19 @@ fn render_tool_call(
         }
     });
 
+    let icon = tc.category.icon();
+    let icon_style = if tc.category.is_destructive() {
+        theme.style_error()
+    } else if tc.category.is_read_only() {
+        theme.style_dim()
+    } else {
+        theme.style_muted()
+    };
+
     let mut header = vec![
         Span::styled(marker, marker_style),
         Span::styled(format!(" {status_icon}"), status_style),
+        Span::styled(format!(" {icon}"), icon_style),
         Span::styled(
             format!(" {}", tc.name),
             Style::default()
@@ -455,9 +465,17 @@ fn render_summary_row(
     // Per-category rows with tallies and percentiles.
     for cat in CATEGORY_ORDER {
         if let Some(stats) = summary.categories.get(cat) {
+            let icon_style = if cat.is_destructive() {
+                theme.style_error()
+            } else if cat.is_read_only() {
+                theme.style_dim()
+            } else {
+                theme.style_muted()
+            };
             let mut cat_spans = vec![
                 Span::styled("  ", Style::default()),
-                Span::styled(cat.to_string(), theme.style_muted()),
+                Span::styled(cat.icon(), icon_style),
+                Span::styled(format!(" {}", cat.display_name()), theme.style_muted()),
                 Span::styled(" ", Style::default()),
                 Span::styled(stats.success.to_string(), theme.style_success()),
                 Span::styled("/", theme.style_dim()),

--- a/crates/theatron/tui/src/view/overlay.rs
+++ b/crates/theatron/tui/src/view/overlay.rs
@@ -297,12 +297,42 @@ fn render_tool_approval(
     approval: &crate::app::ToolApprovalOverlay,
     theme: &Theme,
 ) {
+    let risk_lower = approval.risk.to_lowercase();
+    let risk_style = if risk_lower.contains("high") || risk_lower.contains("destructive") {
+        theme.style_error_bold()
+    } else if risk_lower.contains("medium") || risk_lower.contains("irreversible") {
+        Style::default()
+            .fg(theme.status.warning)
+            .add_modifier(Modifier::BOLD)
+    } else {
+        theme.style_error()
+    };
+    let risk_icon = if risk_lower.contains("destructive") || risk_lower.contains("high") {
+        "⚠ "
+    } else {
+        "! "
+    };
+
+    let humanized_name = approval
+        .tool_name
+        .replace('_', " ")
+        .split_whitespace()
+        .map(|w| {
+            let mut c = w.chars();
+            match c.next() {
+                None => String::new(),
+                Some(f) => f.to_uppercase().collect::<String>() + c.as_str(),
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ");
+
     let mut lines = vec![
         Line::raw(""),
         Line::from(vec![
             Span::styled("  Tool: ", theme.style_muted()),
             Span::styled(
-                &approval.tool_name,
+                humanized_name,
                 Style::default()
                     .fg(theme.status.warning)
                     .add_modifier(Modifier::BOLD),
@@ -310,7 +340,7 @@ fn render_tool_approval(
         ]),
         Line::from(vec![
             Span::styled("  Risk: ", theme.style_muted()),
-            Span::styled(&approval.risk, theme.style_error()),
+            Span::styled(format!("{risk_icon}{}", approval.risk), risk_style),
         ]),
         Line::from(vec![
             Span::styled("  Reason: ", theme.style_muted()),
@@ -343,6 +373,13 @@ fn render_tool_approval(
         Span::styled("pprove  ", theme.style_muted()),
         Span::styled("[D]", theme.style_error_bold()),
         Span::styled("eny  ", theme.style_muted()),
+        Span::styled(
+            "[L]",
+            Style::default()
+                .fg(theme.colors.accent)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(" Always allow  ", theme.style_muted()),
         Span::styled(
             "[Esc]",
             Style::default()


### PR DESCRIPTION
## Summary

- **#1855**: Enhanced tool approval overlay — humanized tool name (snake_case → Title Case), risk-level visual differentiation (high=error bold, medium=warning bold with icon prefix), `[L] Always allow` button with session-scoped `HashSet<String>` tracking, auto-approve bypass in streaming handler
- **#1868**: `icon()`, `display_name()`, `is_read_only()`, `is_destructive()` added to both `organon::ToolCategory` and TUI-local `ToolCategory`; category icons and color coding integrated into ops pane tool call rows and summary rows

## Changes

| File | Change |
|------|--------|
| `organon/src/types.rs` | Add 4 `#[must_use]` pub methods to `ToolCategory` |
| `theatron/tui/src/state/ops/types.rs` | Add 4 `pub(crate)` methods to TUI `ToolCategory` |
| `theatron/tui/src/app/mod.rs` | Add `always_allowed_tools: HashSet<String>` to `InteractionState` |
| `theatron/tui/src/msg.rs` | Add `ToolApprovalAlwaysAllow` variant |
| `theatron/tui/src/mapping/keyboard.rs` | Bind `l`/`L` → `ToolApprovalAlwaysAllow` in approval overlay |
| `theatron/tui/src/update/overlay.rs` | Add `handle_tool_approval_always_allow()` |
| `theatron/tui/src/update/streaming.rs` | Auto-approve bypass for always-allowed tools |
| `theatron/tui/src/view/overlay.rs` | Humanized name, risk styling, `[L] Always allow` button |
| `theatron/tui/src/view/ops.rs` | Category icons and color coding in tool call rows |

## Test plan

- [ ] `cargo test --workspace` passes (0 failures)
- [ ] `cargo build --workspace` succeeds
- [ ] `cargo fmt --all -- --check` no new formatting issues
- [ ] No new clippy errors introduced (pre-existing violations on main are unchanged)
- [ ] Approval overlay shows humanized tool name and risk label
- [ ] `[A]`pprove, `[D]`eny, `[L]` Always allow, `[Esc]` cancel all function correctly
- [ ] Second invocation of an always-allowed tool auto-approves without dialog
- [ ] Ops pane tool call rows show category icon with appropriate color