### PR TITLE
feat(tui): halt, stall detection, ops pane cleanup, session abstraction

### DIFF
--- a/crates/theatron/tui/src/app/mod.rs
+++ b/crates/theatron/tui/src/app/mod.rs
@@ -78,6 +78,13 @@ pub struct ConnectionState {
     pub streaming_text: String,
     pub streaming_thinking: String,
     pub streaming_tool_calls: Vec<ToolCallInfo>,
+    /// Timestamp of the last stream event received during the current turn.
+    /// Used for stall detection.
+    pub(crate) stream_last_event_at: Option<std::time::Instant>,
+    /// Set once the 30s stall warning has been shown for the current turn.
+    pub(crate) stall_warned: bool,
+    /// Non-dismissing status message shown during stall conditions.
+    pub(crate) stall_message: Option<String>,
 }
 
 /// Scroll position, virtual scroll index, and markdown render cache.
@@ -196,6 +203,9 @@ impl App {
                 streaming_text: String::new(),
                 streaming_thinking: String::new(),
                 streaming_tool_calls: Vec::new(),
+                stream_last_event_at: None,
+                stall_warned: false,
+                stall_message: None,
             },
             viewport: ViewportState {
                 terminal_width: DEFAULT_TERMINAL_WIDTH,
@@ -505,11 +515,13 @@ impl App {
         // tick-driven animation is actually visible: streaming spinner or toast dismissal.
         let had_animation = self.connection.active_turn_id.is_some()
             || self.viewport.error_toast.is_some()
-            || self.viewport.success_toast.is_some();
+            || self.viewport.success_toast.is_some()
+            || self.connection.stall_message.is_some();
         crate::update::update(self, msg).await;
         let has_animation = self.connection.active_turn_id.is_some()
             || self.viewport.error_toast.is_some()
-            || self.viewport.success_toast.is_some();
+            || self.viewport.success_toast.is_some()
+            || self.connection.stall_message.is_some();
         self.viewport.dirty = had_animation || has_animation;
     }
 

--- a/crates/theatron/tui/src/app/test_helpers.rs
+++ b/crates/theatron/tui/src/app/test_helpers.rs
@@ -55,6 +55,9 @@ pub fn test_app() -> App {
             streaming_text: String::new(),
             streaming_thinking: String::new(),
             streaming_tool_calls: Vec::new(),
+            stream_last_event_at: None,
+            stall_warned: false,
+            stall_message: None,
         },
         viewport: ViewportState {
             terminal_width: DEFAULT_TERMINAL_WIDTH,

--- a/crates/theatron/tui/src/keybindings/registry.rs
+++ b/crates/theatron/tui/src/keybindings/registry.rs
@@ -84,7 +84,7 @@ pub(crate) fn all_keybindings() -> &'static [Keybinding] {
         },
         Keybinding {
             keys: "/",
-            description: "Search sessions",
+            description: "Search history",
             contexts: &[KeyContext::Chat],
             show_in_status_bar: true,
         },

--- a/crates/theatron/tui/src/lib.rs
+++ b/crates/theatron/tui/src/lib.rs
@@ -172,6 +172,11 @@ async fn run_loop(mut terminal: DefaultTerminal, app: &mut App) -> error::Result
         if matches!(&event, Event::Sse(_)) {
             app.connection.sse_last_event_at = Some(std::time::Instant::now());
         }
+        // WHY: Every stream event resets the stall clock. Any data from the server
+        // (text deltas, tool starts, tool results) proves the agent is responsive.
+        if matches!(&event, Event::Stream(_)) {
+            app.connection.stream_last_event_at = Some(std::time::Instant::now());
+        }
 
         if let Some(msg) = app.map_event(event) {
             app.update(msg).await;

--- a/crates/theatron/tui/src/mapping/keyboard.rs
+++ b/crates/theatron/tui/src/mapping/keyboard.rs
@@ -7,6 +7,16 @@ use crate::state::Overlay;
 
 impl crate::app::App {
     pub(super) fn map_key(&self, key: KeyEvent) -> Option<Msg> {
+        // WHY: Ctrl+C during an active turn cancels it immediately rather than quitting.
+        // This is the highest-priority check so overlays and selection mode cannot
+        // intercept it — the user's intent is unambiguous when a turn is running.
+        if self.connection.active_turn_id.is_some()
+            && key.modifiers == KeyModifiers::CONTROL
+            && key.code == KeyCode::Char('c')
+        {
+            return Some(Msg::CancelTurn);
+        }
+
         if self.layout.overlay.is_some() {
             return self.map_overlay_key(key);
         }
@@ -58,6 +68,15 @@ impl crate::app::App {
             && self.layout.ops.focused_pane == crate::state::FocusedPane::Operations
         {
             return self.map_ops_pane_key(key);
+        }
+
+        // WHY: Esc during an active turn (no modal, home view, ops chat-focused) cancels it.
+        // Checked after filter/selection/ops so those modal contexts handle Esc first.
+        if self.connection.active_turn_id.is_some()
+            && matches!(key.code, KeyCode::Esc)
+            && self.layout.view_stack.is_home()
+        {
+            return Some(Msg::CancelTurn);
         }
 
         if let Some(action) = self.interaction.keymap.lookup(key.modifiers, key.code) {
@@ -178,6 +197,7 @@ impl crate::app::App {
             (_, KeyCode::Char('j')) | (_, KeyCode::Down) => Some(Msg::OpsSelectNext),
             (_, KeyCode::Char('k')) | (_, KeyCode::Up) => Some(Msg::OpsSelectPrev),
             (_, KeyCode::Enter) => Some(Msg::OpsToggleExpand),
+            (_, KeyCode::Char('s')) => Some(Msg::OpsToggleShowAll),
             _ => None,
         }
     }

--- a/crates/theatron/tui/src/msg.rs
+++ b/crates/theatron/tui/src/msg.rs
@@ -85,6 +85,8 @@ pub enum Msg {
     OpsSelectPrev,
     OpsSelectNext,
     OpsToggleExpand,
+    /// Toggle display of successful tool calls (collapse behind "show all").
+    OpsToggleShowAll,
     OpenOverlay(OverlayKind),
     CloseOverlay,
     Resize(u16, u16),
@@ -295,6 +297,9 @@ pub enum Msg {
 
     #[expect(dead_code, reason = "planned TUI feature")]
     ExportConversation,
+
+    /// Cancel the active LLM turn immediately (Esc / Ctrl+C during streaming).
+    CancelTurn,
 
     SessionSearchOpen,
     SessionSearchClose,

--- a/crates/theatron/tui/src/state/ops/mod.rs
+++ b/crates/theatron/tui/src/state/ops/mod.rs
@@ -89,6 +89,7 @@ mod tests {
             primary_arg: None,
             error_message: None,
             category: ToolCategory::Other,
+            started_at: std::time::Instant::now(),
         });
         state.scroll_offset = 10;
         state.selected_item = Some(0);

--- a/crates/theatron/tui/src/state/ops/state_impl.rs
+++ b/crates/theatron/tui/src/state/ops/state_impl.rs
@@ -34,6 +34,8 @@ pub struct OpsState {
     pub(crate) summary: OpsSummary,
     /// Wall-clock start time for the current turn (elapsed display).
     pub(crate) turn_started_at: Option<std::time::Instant>,
+    /// When true, show all tool calls including successful ones. Default: false (show only errors).
+    pub(crate) show_all_successful: bool,
 }
 
 impl Default for OpsState {
@@ -53,6 +55,7 @@ impl Default for OpsState {
             diffs: Vec::new(),
             summary: OpsSummary::default(),
             turn_started_at: None,
+            show_all_successful: false,
         }
     }
 }
@@ -91,6 +94,12 @@ impl OpsState {
         self.selected_item = None;
         self.summary = OpsSummary::default();
         self.turn_started_at = Some(std::time::Instant::now());
+        self.show_all_successful = false;
+    }
+
+    /// Toggle visibility of all successful tool calls.
+    pub(crate) fn toggle_show_all(&mut self) {
+        self.show_all_successful = !self.show_all_successful;
     }
 
     /// Switch keyboard focus between panes.
@@ -187,6 +196,7 @@ impl OpsState {
             primary_arg,
             error_message: None,
             category,
+            started_at: std::time::Instant::now(),
         });
     }
 

--- a/crates/theatron/tui/src/state/ops/types.rs
+++ b/crates/theatron/tui/src/state/ops/types.rs
@@ -115,6 +115,8 @@ pub(crate) struct OpsToolCall {
     pub(crate) error_message: Option<String>,
     /// Tool category for KPI grouping.
     pub(crate) category: ToolCategory,
+    /// Wall-clock start time for elapsed display in running tools.
+    pub(crate) started_at: std::time::Instant,
 }
 
 /// A single thinking block in the operations pane.

--- a/crates/theatron/tui/src/update/api.rs
+++ b/crates/theatron/tui/src/update/api.rs
@@ -159,6 +159,9 @@ pub(crate) fn handle_dismiss_error(app: &mut App) {
     app.viewport.error_toast = None;
 }
 
+const STALL_WARN_SECS: u64 = 30;
+const STALL_CANCEL_SECS: u64 = 60;
+
 #[tracing::instrument(skip_all)]
 pub(crate) fn handle_tick(app: &mut App) {
     app.viewport.tick_count = app.viewport.tick_count.wrapping_add(1);
@@ -180,6 +183,33 @@ pub(crate) fn handle_tick(app: &mut App) {
     }
     super::sse::check_sse_reconnect_timeout(app);
     super::sse::check_distill_auto_dismiss(app);
+    check_stream_stall(app);
+}
+
+fn check_stream_stall(app: &mut App) {
+    let Some(last_event) = app.connection.stream_last_event_at else {
+        // Clear any stall message if no active turn.
+        if app.connection.active_turn_id.is_none() {
+            app.connection.stall_message = None;
+        }
+        return;
+    };
+
+    if app.connection.active_turn_id.is_none() {
+        app.connection.stall_message = None;
+        return;
+    }
+
+    let elapsed = last_event.elapsed().as_secs();
+    if elapsed >= STALL_CANCEL_SECS {
+        app.connection.stall_message = Some(
+            format!("No response for {elapsed}s — Ctrl+C to cancel").to_string(),
+        );
+    } else if elapsed >= STALL_WARN_SECS && !app.connection.stall_warned {
+        app.connection.stall_warned = true;
+        app.connection.stall_message =
+            Some("No response for 30s — agent may be stalled".to_string());
+    }
 }
 
 /// Sanitize session fields that may contain external data.

--- a/crates/theatron/tui/src/update/mod.rs
+++ b/crates/theatron/tui/src/update/mod.rs
@@ -99,6 +99,7 @@ pub(crate) async fn update(app: &mut App, msg: Msg) {
         Msg::OpsSelectPrev => app.layout.ops.select_prev(),
         Msg::OpsSelectNext => app.layout.ops.select_next(),
         Msg::OpsToggleExpand => app.layout.ops.toggle_selected(),
+        Msg::OpsToggleShowAll => app.layout.ops.toggle_show_all(),
         Msg::Resize(w, h) => navigation::handle_resize(app, w, h),
         Msg::ViewDrillIn => view_nav::handle_drill_in(app),
         Msg::ViewPopBack => view_nav::handle_pop_back(app),
@@ -207,6 +208,7 @@ pub(crate) async fn update(app: &mut App, msg: Msg) {
         }
         Msg::StreamTurnAbort { reason } => streaming::handle_stream_turn_abort(app, reason),
         Msg::StreamError(msg) => streaming::handle_stream_error(app, msg),
+        Msg::CancelTurn => streaming::handle_cancel_turn(app).await,
 
         Msg::AgentsLoaded(agents) => api::handle_agents_loaded(app, agents),
         Msg::SessionsLoaded { nous_id, sessions } => {

--- a/crates/theatron/tui/src/update/sse.rs
+++ b/crates/theatron/tui/src/update/sse.rs
@@ -5,7 +5,7 @@ use crate::app::App;
 use crate::id::{NousId, SessionId};
 use crate::msg::ErrorToast;
 use crate::sanitize::sanitize_for_display;
-use crate::state::{ActiveTool, AgentState, AgentStatus};
+use crate::state::{ActiveTool, AgentState, AgentStatus, ChatMessage};
 
 const RECONNECT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(300);
 
@@ -213,6 +213,14 @@ pub(crate) async fn handle_sse_distill_after(app: &mut App, nous_id: NousId) {
     }
     if app.dashboard.focused_agent.as_ref() == Some(&nous_id) {
         app.load_focused_session().await;
+        app.dashboard.messages.push(ChatMessage {
+            role: "system".to_string(),
+            text: "— conversation summarized —".to_string(),
+            text_lower: "— conversation summarized —".to_string(),
+            timestamp: None,
+            model: None,
+            tool_calls: Vec::new(),
+        });
     }
 }
 

--- a/crates/theatron/tui/src/update/streaming.rs
+++ b/crates/theatron/tui/src/update/streaming.rs
@@ -23,6 +23,9 @@ pub(crate) fn handle_stream_turn_start(app: &mut App, turn_id: TurnId, nous_id: 
     app.connection.streaming_text.clear();
     app.connection.streaming_thinking.clear();
     app.connection.streaming_tool_calls.clear();
+    app.connection.stream_last_event_at = Some(std::time::Instant::now());
+    app.connection.stall_warned = false;
+    app.connection.stall_message = None;
     app.viewport.render.markdown_cache.clear();
     if let Some(agent) = app.dashboard.agents.iter_mut().find(|a| a.id == nous_id) {
         agent.status = AgentStatus::Streaming;
@@ -247,6 +250,9 @@ pub(crate) async fn handle_stream_turn_complete(app: &mut App, outcome: TurnOutc
     app.connection.streaming_text.clear();
     app.connection.streaming_thinking.clear();
     app.connection.streaming_tool_calls.clear();
+    app.connection.stream_last_event_at = None;
+    app.connection.stall_warned = false;
+    app.connection.stall_message = None;
     app.viewport.render.markdown_cache.clear();
     app.connection.active_turn_id = None;
     app.connection.stream_rx = None;
@@ -282,6 +288,9 @@ pub(crate) fn handle_stream_turn_abort(app: &mut App, reason: String) {
     app.connection.streaming_text.clear();
     app.connection.streaming_thinking.clear();
     app.connection.streaming_tool_calls.clear();
+    app.connection.stream_last_event_at = None;
+    app.connection.stall_warned = false;
+    app.connection.stall_message = None;
     app.connection.active_turn_id = None;
     app.connection.stream_rx = None;
     if let Some(ref agent_id) = app.dashboard.focused_agent
@@ -299,6 +308,9 @@ pub(crate) fn handle_stream_error(app: &mut App, msg: String) {
     app.viewport.error_toast = Some(ErrorToast::new(sanitize_for_display(&msg).into_owned()));
     app.connection.active_turn_id = None;
     app.connection.stream_rx = None;
+    app.connection.stream_last_event_at = None;
+    app.connection.stall_warned = false;
+    app.connection.stall_message = None;
     // WHY: Clear tool calls to remove stale spinners; preserve streaming_text
     // so the user can read any partial response received before the error.
     app.connection.streaming_tool_calls.clear();
@@ -308,6 +320,66 @@ pub(crate) fn handle_stream_error(app: &mut App, msg: String) {
         agent.status = AgentStatus::Idle;
         agent.active_tool = None;
     }
+}
+
+#[tracing::instrument(skip_all)]
+// SAFETY: sanitized at ingestion: streaming_text already sanitized via handle_stream_text_delta.
+pub(crate) async fn handle_cancel_turn(app: &mut App) {
+    let turn_id = match app.connection.active_turn_id.take() {
+        Some(id) => id,
+        None => return,
+    };
+
+    // Fire-and-forget: tell the server to abort. Errors are non-fatal; the
+    // stream receiver being dropped is sufficient to stop local processing.
+    let client = app.client.clone();
+    let id = turn_id.to_string();
+    tokio::spawn(async move {
+        if let Err(e) = client.abort_turn(&id).await {
+            tracing::warn!(error = %e, "abort_turn request failed");
+        }
+    });
+
+    // Commit partial streaming text as an incomplete turn marker.
+    let partial = std::mem::take(&mut app.connection.streaming_text);
+    let marker = if partial.is_empty() {
+        "[interrupted by user]".to_string()
+    } else {
+        format!("{partial}\n\n[interrupted by user]")
+    };
+    let marker_lower = marker.to_lowercase();
+    let tool_calls = std::mem::take(&mut app.connection.streaming_tool_calls);
+    let width = app
+        .viewport
+        .render
+        .virtual_scroll
+        .cached_width()
+        .max(app.viewport.terminal_width.saturating_sub(2).max(1));
+    let h = estimate_message_height(marker.len(), width);
+    app.dashboard.messages.push(ChatMessage {
+        role: "assistant".to_string(),
+        text: marker,
+        text_lower: marker_lower,
+        timestamp: None,
+        model: None,
+        tool_calls,
+    });
+    app.viewport.render.virtual_scroll.push_item(h);
+
+    app.connection.streaming_thinking.clear();
+    app.connection.stream_rx = None;
+    app.connection.stream_last_event_at = None;
+    app.connection.stall_warned = false;
+    app.connection.stall_message = None;
+    app.viewport.render.markdown_cache.clear();
+
+    if let Some(ref agent_id) = app.dashboard.focused_agent
+        && let Some(agent) = app.dashboard.agents.iter_mut().find(|a| a.id == *agent_id)
+    {
+        agent.status = AgentStatus::Idle;
+        agent.active_tool = None;
+    }
+    app.layout.ops.auto_hide_if_configured();
 }
 
 #[cfg(test)]

--- a/crates/theatron/tui/src/view/ops.rs
+++ b/crates/theatron/tui/src/view/ops.rs
@@ -32,7 +32,7 @@ pub(crate) fn render(app: &App, frame: &mut Frame, area: Rect, theme: &Theme) {
         .borders(Borders::LEFT)
         .border_style(border_style)
         .title(Span::styled(
-            " ops ",
+            " Activity ",
             if focused {
                 theme.style_accent_bold()
             } else {
@@ -70,17 +70,31 @@ pub(crate) fn render(app: &App, frame: &mut Frame, area: Rect, theme: &Theme) {
         item_idx += 1;
     }
 
+    let mut hidden_count = 0usize;
     for tc in &ops.tool_calls {
         let is_selected = ops.selected_item == Some(item_idx);
-        render_tool_call(
-            tc,
-            &mut lines,
-            inner_width,
-            theme,
-            is_selected,
-            app.viewport.tick_count,
-        );
+        if tc.status == OpsToolStatus::Complete && !ops.show_all_successful {
+            hidden_count += 1;
+        } else {
+            render_tool_call(
+                tc,
+                &mut lines,
+                inner_width,
+                theme,
+                is_selected,
+                app.viewport.tick_count,
+            );
+        }
         item_idx += 1;
+    }
+    if hidden_count > 0 {
+        lines.push(Line::from(vec![
+            Span::raw("  "),
+            Span::styled(
+                format!("▸ {hidden_count} successful  s=show all"),
+                theme.style_dim(),
+            ),
+        ]));
     }
 
     if !ops.diffs.is_empty() {
@@ -266,13 +280,18 @@ fn render_tool_call(
         ),
     };
 
-    let duration_str = tc.duration_ms.map(|ms| {
+    let duration_str = if let Some(ms) = tc.duration_ms {
         if ms >= MS_PER_SECOND {
-            format!(" ({:.1}s)", ms as f64 / MS_PER_SECOND as f64)
+            Some(format!(" ({:.1}s)", ms as f64 / MS_PER_SECOND as f64))
         } else {
-            format!(" ({}ms)", ms)
+            Some(format!(" ({}ms)", ms))
         }
-    });
+    } else if tc.status == OpsToolStatus::Running {
+        let secs = tc.started_at.elapsed().as_secs();
+        if secs > 0 { Some(format!(" ({secs}s)")) } else { None }
+    } else {
+        None
+    };
 
     let icon = tc.category.icon();
     let icon_style = if tc.category.is_destructive() {

--- a/crates/theatron/tui/src/view/sidebar.rs
+++ b/crates/theatron/tui/src/view/sidebar.rs
@@ -78,16 +78,38 @@ pub(crate) fn render(app: &App, frame: &mut Frame, area: Rect, theme: &Theme) {
 
         lines.push(Line::from(spans));
 
-        if let Some(ref tool) = agent.active_tool {
-            let elapsed = tool.started_at.elapsed().as_secs_f32();
-            let ch = theme::spinner_frame(app.viewport.tick_count);
-            lines.push(Line::from(vec![
-                Span::raw("     "),
-                Span::styled(
-                    format!("{} {} {:.1}s", ch, tool.name, elapsed),
-                    theme.style_muted(),
-                ),
-            ]));
+        match agent.status {
+            AgentStatus::Streaming => {
+                let elapsed_secs = if is_focused {
+                    app.layout.ops.turn_started_at.map(|t| t.elapsed().as_secs())
+                } else {
+                    None
+                };
+                let label = if let Some(secs) = elapsed_secs {
+                    format!("thinking… {:02}:{:02}", secs / 60, secs % 60)
+                } else {
+                    "thinking…".to_string()
+                };
+                lines.push(Line::from(vec![
+                    Span::raw("     "),
+                    Span::styled(label, theme.style_muted()),
+                ]));
+            }
+            AgentStatus::Working => {
+                if let Some(ref tool) = agent.active_tool {
+                    let secs = tool.started_at.elapsed().as_secs();
+                    let elapsed_str = format!("{:02}:{:02}", secs / 60, secs % 60);
+                    let label = tool_status_label(&tool.name);
+                    lines.push(Line::from(vec![
+                        Span::raw("     "),
+                        Span::styled(
+                            format!("{label} {elapsed_str}"),
+                            theme.style_muted(),
+                        ),
+                    ]));
+                }
+            }
+            AgentStatus::Idle | AgentStatus::Compacting => {}
         }
 
         if let Some(ref stage) = agent.compaction_stage {
@@ -108,4 +130,15 @@ pub(crate) fn render(app: &App, frame: &mut Frame, area: Rect, theme: &Theme) {
 
     let paragraph = Paragraph::new(lines).block(block);
     frame.render_widget(paragraph, area);
+}
+
+fn tool_status_label(name: &str) -> &'static str {
+    match name {
+        "Read" | "read_file" | "Glob" | "Grep" => "reading files…",
+        "Write" | "write_file" | "Edit" | "edit_file" | "NotebookEdit" => "writing…",
+        "Bash" | "bash" | "exec" => "running command…",
+        "WebSearch" | "web_search" => "searching…",
+        "WebFetch" | "web_fetch" => "fetching…",
+        _ => "working…",
+    }
 }

--- a/crates/theatron/tui/src/view/status_bar.rs
+++ b/crates/theatron/tui/src/view/status_bar.rs
@@ -167,6 +167,19 @@ fn render_info_bar(app: &App, width: u16, theme: &Theme) -> Line<'static> {
         }
     }
 
+    // Optional: stall warning message (visible during agent stall detection).
+    if let Some(ref msg) = app.connection.stall_message {
+        let stall = [
+            Span::styled(" │ ", theme.style_dim()),
+            Span::styled(msg.clone(), theme.style_warning()),
+        ];
+        let stall_w: usize = stall.iter().map(|s| s.content.width()).sum();
+        if used + stall_w + 1 < total {
+            spans.extend(stall);
+            used += stall_w;
+        }
+    }
+
     // Right side: show only when there is room for it with at least one space of padding.
     if used + right_width + 1 < total {
         let pad = total - used - right_width;
@@ -251,24 +264,11 @@ fn agent_identity_spans(app: &App, theme: &Theme) -> Vec<Span<'static>> {
         .map(|a| (a.emoji.clone().unwrap_or_default(), a.name.clone()))
         .unwrap_or_else(|| (String::new(), "no agent".to_string()));
 
-    let session_key = agent
-        .and_then(|a| {
-            app.dashboard.focused_session_id.as_ref().and_then(|sid| {
-                a.sessions
-                    .iter()
-                    .find(|s| s.id == *sid)
-                    .map(|s| s.key.clone())
-            })
-        })
-        .unwrap_or_else(|| "—".to_string());
-
     let mut spans = Vec::new();
     if !emoji.is_empty() {
         spans.push(Span::styled(format!("{emoji} "), theme.style_fg()));
     }
     spans.push(Span::styled(name, theme.style_accent()));
-    spans.push(Span::styled(" · ", theme.style_dim()));
-    spans.push(Span::styled(session_key, theme.style_muted()));
     spans
 }
 


### PR DESCRIPTION
## Summary

- **Halt (#1851):** Esc/Ctrl+C cancels active turn immediately — fires abort to server, marks message as `[interrupted by user]`. Stall detection warns at 30s, prompts cancel at 60s of no stream events, visible in status bar.
- **Ops pane cleanup (#1849 part 1):** Pane renamed "Activity". Successful tool calls hidden by default behind a `▸ N successful  s=show all` toggle. Running tools show elapsed seconds `(Ns)`.
- **Status indicator (#1849 part 2):** Sidebar replaces `spinner + tool_name + float_elapsed` with contextual labels (`thinking… MM:SS`, `reading files… MM:SS`, `running command… MM:SS`, etc.).
- **Session abstraction (#1849 part 3):** Status bar removes session key from agent identity line. `/` shortcut renamed "Search history". Distillation events append `— conversation summarized —` chat marker.

## Test plan

- [ ] `cargo test -p theatron-tui` → 858 tests pass
- [ ] `cargo clippy -p theatron-tui` → zero warnings
- [ ] Manual: stream a turn and press Esc — chat shows `[interrupted by user]`
- [ ] Manual: let a turn run for 30s with no events — stall warning appears in status bar
- [ ] Manual: ops pane shows only running/failed calls; press `s` to reveal successful
- [ ] Manual: sidebar shows "thinking… MM:SS" during LLM generation
- [ ] Manual: status bar no longer shows session key
- [ ] Manual: `/` hint reads "Search history"

Closes #1851, closes #1849

🤖 Generated with [Claude Code](https://claude.com/claude-code)