### PR TITLE
fix(tui): cursor style and raw JSON tool call rendering on reload

### DIFF
--- a/crates/aletheia/src/migrate_memory.rs
+++ b/crates/aletheia/src/migrate_memory.rs
@@ -288,7 +288,8 @@ fn import_fact(
 
     if let Ok(embedding) = embedder.embed(&record.content) {
         let chunk = EmbeddedChunk {
-            id: EmbeddingId::new(&format!("emb-{fact_id}")).expect("emb- prefix + ULID is always valid"),
+            id: EmbeddingId::new(&format!("emb-{fact_id}"))
+                .expect("emb- prefix + ULID is always valid"),
             content: record.content.clone(),
             source_type: "fact".to_owned(),
             source_id: fact_id,

--- a/crates/theatron/core/src/api/client.rs
+++ b/crates/theatron/core/src/api/client.rs
@@ -95,7 +95,6 @@ impl ApiClient {
     ///
     /// Returns [`ApiError::InvalidToken`] if `token` contains characters invalid in HTTP headers.
     /// Returns [`ApiError::Http`] if the HTTP client cannot be constructed.
-    #[must_use]
     pub fn new(base_url: &str, token: Option<String>) -> Result<Self> {
         // kanon:ignore RUST/pub-visibility
         let client = build_http_client(token.as_deref())?;
@@ -139,7 +138,6 @@ impl ApiClient {
     /// Check server reachability (not health status).
     ///
     /// A 503 (unhealthy) means the server IS running but has degraded checks.
-    #[must_use]
     #[tracing::instrument(skip(self))]
     pub async fn health(&self) -> Result<bool> {
         let resp = self.client.get(self.url("/api/health")).send().await;
@@ -147,7 +145,6 @@ impl ApiClient {
     }
 
     /// Query the server's authentication mode.
-    #[must_use]
     #[tracing::instrument(skip(self))]
     pub async fn auth_mode(&self) -> Result<AuthMode> {
         let resp = self
@@ -163,7 +160,6 @@ impl ApiClient {
     }
 
     /// Authenticate with username and password.
-    #[must_use]
     #[tracing::instrument(skip(self, password))]
     pub async fn login(&self, username: &str, password: &str) -> Result<LoginResponse> {
         let resp = self
@@ -185,7 +181,6 @@ impl ApiClient {
     }
 
     /// Fetch all registered agents.
-    #[must_use]
     #[tracing::instrument(skip(self))]
     pub async fn agents(&self) -> Result<Vec<Agent>> {
         let resp = self
@@ -210,7 +205,6 @@ impl ApiClient {
     /// Returns [`ApiError::Http`] if the request fails or the response cannot be decoded.
     /// Returns [`ApiError::Auth`] if the server rejects the authentication token.
     /// Returns [`ApiError::Server`] if the server returns a non-success status.
-    #[must_use]
     #[tracing::instrument(skip(self))]
     pub async fn sessions(&self, nous_id: &str) -> Result<Vec<Session>> {
         let encoded = encode_path(nous_id);
@@ -239,7 +233,6 @@ impl ApiClient {
     /// Returns [`ApiError::Http`] if the request fails or the response cannot be decoded.
     /// Returns [`ApiError::Auth`] if the server rejects the authentication token.
     /// Returns [`ApiError::Server`] if the server returns a non-success status.
-    #[must_use]
     #[tracing::instrument(skip(self))]
     pub async fn history(&self, session_id: &str) -> Result<Vec<HistoryMessage>> {
         let encoded = encode_path(session_id);
@@ -262,7 +255,6 @@ impl ApiClient {
     }
 
     /// Create a new session for an agent.
-    #[must_use]
     #[tracing::instrument(skip(self))]
     pub async fn create_session(&self, nous_id: &str, session_key: &str) -> Result<Session> {
         let resp = self
@@ -284,7 +276,6 @@ impl ApiClient {
     }
 
     /// Archive a session.
-    #[must_use]
     #[tracing::instrument(skip(self))]
     pub async fn archive_session(&self, session_id: &str) -> Result<()> {
         let encoded = encode_path(session_id);
@@ -303,7 +294,6 @@ impl ApiClient {
     }
 
     /// Unarchive a previously archived session.
-    #[must_use]
     #[tracing::instrument(skip(self))]
     pub async fn unarchive_session(&self, session_id: &str) -> Result<()> {
         let encoded = encode_path(session_id);
@@ -322,7 +312,6 @@ impl ApiClient {
     }
 
     /// Rename a session.
-    #[must_use]
     #[tracing::instrument(skip(self))]
     pub async fn rename_session(&self, session_id: &str, name: &str) -> Result<()> {
         let encoded = encode_path(session_id);
@@ -342,7 +331,6 @@ impl ApiClient {
     }
 
     /// Abort a running turn.
-    #[must_use]
     #[tracing::instrument(skip(self))]
     pub async fn abort_turn(&self, turn_id: &str) -> Result<()> {
         let encoded = encode_path(turn_id);
@@ -361,7 +349,6 @@ impl ApiClient {
     }
 
     /// Approve a tool invocation awaiting user consent.
-    #[must_use]
     #[tracing::instrument(skip(self))]
     pub async fn approve_tool(&self, turn_id: &str, tool_id: &str) -> Result<()> {
         let t = encode_path(turn_id);
@@ -381,7 +368,6 @@ impl ApiClient {
     }
 
     /// Deny a tool invocation awaiting user consent.
-    #[must_use]
     #[tracing::instrument(skip(self))]
     pub async fn deny_tool(&self, turn_id: &str, tool_id: &str) -> Result<()> {
         let t = encode_path(turn_id);
@@ -401,7 +387,6 @@ impl ApiClient {
     }
 
     /// Approve a proposed execution plan.
-    #[must_use]
     #[tracing::instrument(skip(self))]
     pub async fn approve_plan(&self, plan_id: &str) -> Result<()> {
         let encoded = encode_path(plan_id);
@@ -420,7 +405,6 @@ impl ApiClient {
     }
 
     /// Cancel a proposed execution plan.
-    #[must_use]
     #[tracing::instrument(skip(self))]
     pub async fn cancel_plan(&self, plan_id: &str) -> Result<()> {
         let encoded = encode_path(plan_id);
@@ -439,7 +423,6 @@ impl ApiClient {
     }
 
     /// Fetch today's LLM cost in cents.
-    #[must_use]
     #[tracing::instrument(skip(self))]
     pub async fn today_cost_cents(&self) -> Result<u32> {
         let resp = self
@@ -459,6 +442,7 @@ impl ApiClient {
         #[expect(
             clippy::cast_possible_truncation,
             clippy::cast_sign_loss,
+            clippy::as_conversions,
             reason = "clamped to u32 range above"
         )]
         let cents = cents_f as u32; // kanon:ignore RUST/as-cast
@@ -466,7 +450,6 @@ impl ApiClient {
     }
 
     /// Trigger distillation (memory compaction) for a session.
-    #[must_use]
     #[tracing::instrument(skip(self))]
     pub async fn compact(&self, session_id: &str) -> Result<()> {
         let encoded = encode_path(session_id);
@@ -491,7 +474,6 @@ impl ApiClient {
     /// Returns [`ApiError::Http`] if the request fails or the response cannot be decoded.
     /// Returns [`ApiError::Auth`] if the server rejects the authentication token.
     /// Returns [`ApiError::Server`] if the server returns a non-success status.
-    #[must_use]
     #[tracing::instrument(skip(self))]
     pub async fn tools(&self, nous_id: &str) -> Result<Vec<NousTool>> {
         let encoded = encode_path(nous_id);
@@ -514,7 +496,6 @@ impl ApiClient {
     }
 
     /// Search agent memory by query.
-    #[must_use]
     #[tracing::instrument(skip(self))]
     pub async fn recall(&self, nous_id: &str, query: &str) -> Result<String> {
         let encoded = encode_path(nous_id);
@@ -542,7 +523,6 @@ impl ApiClient {
     /// Returns [`ApiError::Http`] if the request fails or the response cannot be decoded.
     /// Returns [`ApiError::Auth`] if the server rejects the authentication token.
     /// Returns [`ApiError::Server`] if the server returns a non-success status.
-    #[must_use]
     #[tracing::instrument(skip(self))]
     pub async fn config(&self) -> Result<serde_json::Value> {
         let resp = self
@@ -560,7 +540,6 @@ impl ApiClient {
     }
 
     /// Update a single configuration section.
-    #[must_use]
     #[tracing::instrument(skip(self, data))]
     pub async fn update_config_section(
         &self,
@@ -584,7 +563,6 @@ impl ApiClient {
     }
 
     /// Fetch knowledge facts with sorting and pagination.
-    #[must_use]
     #[tracing::instrument(skip(self))]
     pub async fn knowledge_facts(
         &self,
@@ -609,7 +587,6 @@ impl ApiClient {
     }
 
     /// Fetch detail for a single knowledge fact.
-    #[must_use]
     #[tracing::instrument(skip(self))]
     pub async fn knowledge_fact_detail(&self, fact_id: &str) -> Result<serde_json::Value> {
         let encoded = encode_path(fact_id);
@@ -630,7 +607,6 @@ impl ApiClient {
     }
 
     /// Mark a knowledge fact as forgotten.
-    #[must_use]
     #[tracing::instrument(skip(self))]
     pub async fn knowledge_forget(&self, fact_id: &str) -> Result<()> {
         let encoded = encode_path(fact_id);
@@ -649,7 +625,6 @@ impl ApiClient {
     }
 
     /// Restore a previously forgotten fact.
-    #[must_use]
     #[tracing::instrument(skip(self))]
     pub async fn knowledge_restore(&self, fact_id: &str) -> Result<()> {
         let encoded = encode_path(fact_id);
@@ -668,7 +643,6 @@ impl ApiClient {
     }
 
     /// Update the confidence score for a knowledge fact.
-    #[must_use]
     #[tracing::instrument(skip(self))]
     pub async fn knowledge_update_confidence(&self, fact_id: &str, confidence: f64) -> Result<()> {
         let encoded = encode_path(fact_id);
@@ -688,7 +662,6 @@ impl ApiClient {
     }
 
     /// Queue a message for asynchronous processing.
-    #[must_use]
     #[tracing::instrument(skip(self, text))]
     pub async fn queue_message(&self, session_id: &str, text: &str) -> Result<()> {
         let encoded = encode_path(session_id);

--- a/crates/theatron/tui/src/lib.rs
+++ b/crates/theatron/tui/src/lib.rs
@@ -98,8 +98,10 @@ async fn run_tui_inner(
             context: "enable mouse capture",
         },
     )?;
+    let _ = crossterm::execute!(std::io::stderr(), cursor::SetCursorStyle::SteadyBlock);
     let result = run_loop(terminal, &mut app).await;
     let _ = crossterm::execute!(std::io::stderr(), crossterm::event::DisableMouseCapture);
+    let _ = crossterm::execute!(std::io::stderr(), cursor::SetCursorStyle::DefaultUserShape);
     ratatui::restore();
     // Persist last-active sessions so the TUI resumes at the same place on relaunch.
     crate::app::save_session_state(&app.config, &app.dashboard.saved_sessions);

--- a/crates/theatron/tui/src/state/ops/mod.rs
+++ b/crates/theatron/tui/src/state/ops/mod.rs
@@ -5,14 +5,18 @@ mod state_impl;
 mod summary;
 mod types;
 
-pub(crate) use helpers::categorize_tool;
 pub use state_impl::OpsState;
-pub(crate) use summary::{CategoryStats, OpsSummary};
-pub use types::{FocusedPane, OpsAutoShow, OpsToolStatus};
+pub use types::{FocusedPane, OpsToolStatus};
 pub(crate) use types::{OpsDiffEntry, OpsThinkingBlock, OpsToolCall, ToolCategory};
 
 #[cfg(test)]
-pub(crate) use helpers::{extract_primary_arg, parse_diff_from_output, truncate_error};
+pub(crate) use helpers::{
+    categorize_tool, extract_primary_arg, parse_diff_from_output, truncate_error,
+};
+#[cfg(test)]
+pub(crate) use summary::{CategoryStats, OpsSummary};
+#[cfg(test)]
+pub(crate) use types::OpsAutoShow;
 
 #[cfg(test)]
 #[expect(clippy::unwrap_used, reason = "test assertions may panic on failure")]

--- a/crates/theatron/tui/src/state/ops/state_impl.rs
+++ b/crates/theatron/tui/src/state/ops/state_impl.rs
@@ -5,9 +5,7 @@ use super::helpers::{
     categorize_tool, extract_primary_arg, parse_diff_from_output, truncate_error,
 };
 use super::summary::OpsSummary;
-use super::types::{
-    FocusedPane, OpsAutoShow, OpsThinkingBlock, OpsToolCall, OpsToolStatus, ToolCategory,
-};
+use super::types::{FocusedPane, OpsAutoShow, OpsThinkingBlock, OpsToolCall, OpsToolStatus};
 
 /// Full state for the operations pane.
 #[derive(Debug, Clone)]

--- a/crates/theatron/tui/src/update/api.rs
+++ b/crates/theatron/tui/src/update/api.rs
@@ -222,6 +222,11 @@ pub(crate) fn extract_text_content(content: &Option<serde_json::Value>) -> Optio
         {
             return extract_texts_from_array(&parsed);
         }
+        // WHY: tool_use inputs are sometimes stored as JSON object strings;
+        // skip them rather than rendering raw JSON in the chat pane.
+        if s.starts_with('{') && serde_json::from_str::<serde_json::Value>(s).is_ok() {
+            return None;
+        }
         return Some(s.to_string());
     }
 
@@ -310,6 +315,25 @@ mod tests {
     fn extract_text_content_empty_array() {
         let content = Some(serde_json::json!([]));
         assert!(extract_text_content(&content).is_none());
+    }
+
+    #[test]
+    fn extract_text_content_json_object_string_skipped() {
+        // Tool use inputs stored as JSON object strings must not render as raw JSON.
+        let content = Some(serde_json::Value::String(
+            r#"{"command":"head -30 /path"}"#.to_string(),
+        ));
+        assert!(extract_text_content(&content).is_none());
+    }
+
+    #[test]
+    fn extract_text_content_non_json_brace_string_kept() {
+        // Plain text that happens to start with '{' but is not valid JSON is kept.
+        let content = Some(serde_json::Value::String("{not json}".to_string()));
+        assert_eq!(
+            extract_text_content(&content).as_deref(),
+            Some("{not json}")
+        );
     }
 
     #[test]

--- a/crates/theatron/tui/src/update/navigation.rs
+++ b/crates/theatron/tui/src/update/navigation.rs
@@ -152,10 +152,6 @@ fn clamp_scroll_offset(app: &mut App) {
         return;
     }
     let total = app.viewport.render.virtual_scroll.total_height();
-    #[expect(
-        clippy::cast_possible_truncation,
-        reason = "viewport height derived from u16, always fits in u64"
-    )]
     let vh = chat_viewport_height(app) as u64;
     #[expect(
         clippy::cast_possible_truncation,
@@ -379,10 +375,6 @@ mod tests {
         app.rebuild_virtual_scroll();
         app.viewport.render.auto_scroll = false;
         let total = app.viewport.render.virtual_scroll.total_height();
-        #[expect(
-            clippy::cast_possible_truncation,
-            reason = "viewport height derived from u16, always fits in u64"
-        )]
         let vh = chat_viewport_height(&app) as u64;
         // Offset within valid range: no clamping expected.
         if total > vh {

--- a/crates/theatron/tui/src/view/command_palette.rs
+++ b/crates/theatron/tui/src/view/command_palette.rs
@@ -1,6 +1,7 @@
 use ratatui::Frame;
 use ratatui::layout::Rect;
 use ratatui::style::{Modifier, Style};
+use unicode_width::UnicodeWidthStr;
 
 /// Fixed column width for command labels in the suggestion list.
 const COMMAND_LABEL_DISPLAY_WIDTH: usize = 12;
@@ -93,7 +94,12 @@ pub(crate) fn render(app: &App, frame: &mut Frame, area: Rect, theme: &Theme) {
     let paragraph = Paragraph::new(lines).block(block);
     frame.render_widget(paragraph, area);
 
-    let cursor_x = area.x + 1 + u16::try_from(palette.cursor).unwrap_or(u16::MAX);
+    let input_before_cursor = palette
+        .input
+        .get(..palette.cursor)
+        .unwrap_or(&palette.input);
+    let input_display_width = UnicodeWidthStr::width(input_before_cursor);
+    let cursor_x = area.x + 1 + u16::try_from(input_display_width).unwrap_or(u16::MAX);
     let cursor_y = area.y + 1;
     frame.set_cursor_position((cursor_x, cursor_y));
 }

--- a/crates/theatron/tui/src/view/image.rs
+++ b/crates/theatron/tui/src/view/image.rs
@@ -180,10 +180,6 @@ fn render_halfblock_cached(path: &Path, max_width: usize) -> Vec<Line<'static>> 
 /// Each text row represents two pixel rows, doubling effective vertical resolution.
 /// Images are scaled to fit within `max_width` columns and [`MAX_IMAGE_HEIGHT`] rows,
 /// maintaining aspect ratio. Never upscales.
-#[expect(
-    clippy::indexing_slicing,
-    reason = "Rgba<u8> is [u8; 4], indices 0..3 always valid"
-)]
 fn load_and_render_halfblocks(path: &Path, max_width: usize) -> Vec<Line<'static>> {
     let img = match image::open(path) {
         Ok(img) => img,

--- a/crates/theatron/tui/src/view/input.rs
+++ b/crates/theatron/tui/src/view/input.rs
@@ -18,8 +18,7 @@ pub(crate) fn render(app: &App, frame: &mut Frame, area: Rect, theme: &Theme) {
         theme.colors.accent
     };
 
-    // NOTE: ASCII-only prompt: bytes equal display columns
-    let prompt_width = prompt_str.len();
+    let prompt_width = UnicodeWidthStr::width(prompt_str);
     let content_width = usize::from(area.width.max(1));
     let visible_rows = usize::from(area.height.saturating_sub(1));
 


### PR DESCRIPTION
## Summary

- **#1890 (cursor style)**: Set `SteadyBlock` cursor on TUI init; restore `DefaultUserShape` on exit. Fix `cursor_x` miscalculation in `input.rs` and `command_palette.rs` where multi-byte chars (`›`, U+203A = 3 bytes, 1 display column) inflated the byte-counted offset — switch to `UnicodeWidthStr::width()`.
- **#1852 (raw JSON on reload)**: `extract_text_content()` was returning JSON object strings verbatim. Added guard in `update/api.rs`: strings starting with `{` that parse as valid JSON are skipped; only real text content reaches the chat pane.

## Collateral fixes (blocked clippy)

- `theatron-core/api/client.rs`: removed `#[must_use]` from 28 async functions whose return type is already `#[must_use]` (`double_must_use`); added `clippy::as_conversions` to existing `#[expect]` for a clamped cast.
- `theatron-tui/state/ops/mod.rs`: gated test-only re-exports under `#[cfg(test)]` to eliminate `unused_imports` in non-test builds.
- `theatron-tui/state/ops/state_impl.rs`: dropped unused `ToolCategory` import.
- `theatron-tui/update/navigation.rs`: removed stale `#[expect(cast_possible_truncation)]` — `usize as u64` is an upcast, lint never fires.
- `theatron-tui/view/image.rs`: removed stale `#[expect(indexing_slicing)]` — `Rgba<u8>` uses `Index` trait, not a slice.
- `aletheia/migrate_memory.rs`: split overlong `.expect()` chain to pass `cargo fmt`.

## Test plan

- [x] `cargo fmt --check` — passes
- [x] `cargo clippy -p theatron-tui -p theatron-core -- -D warnings` — passes (0 warnings)
- [x] `cargo test -p theatron-tui -p theatron-core` — 860 passed, 0 failed