### PR TITLE
feat(organon): tool reversibility tracking and custom slash commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -404,6 +404,7 @@ version = "0.13.0"
 dependencies = [
  "aletheia-hermeneus",
  "aletheia-koina",
+ "aletheia-taxis",
  "base64 0.22.1",
  "indexmap 2.13.0",
  "jiff",
@@ -416,6 +417,7 @@ dependencies = [
  "seccompiler",
  "serde",
  "serde_json",
+ "serde_yaml",
  "snafu",
  "static_assertions",
  "tempfile",
@@ -5446,6 +5448,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap 2.13.0",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "sfa"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6579,6 +6594,12 @@ name = "unit-prefix"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,6 +100,7 @@ snafu = "0.8"
 # Serialization
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+serde_yaml = "0.9"
 toml = "1.0"
 
 # HTTP

--- a/crates/aletheia/src/migrate_memory.rs
+++ b/crates/aletheia/src/migrate_memory.rs
@@ -288,7 +288,8 @@ fn import_fact(
 
     if let Ok(embedding) = embedder.embed(&record.content) {
         let chunk = EmbeddedChunk {
-            id: EmbeddingId::new(&format!("emb-{fact_id}")).expect("emb- prefix + ULID is always valid"),
+            id: EmbeddingId::new(&format!("emb-{fact_id}"))
+                .expect("emb- prefix + ULID is always valid"),
             content: record.content.clone(),
             source_type: "fact".to_owned(),
             source_id: fact_id,

--- a/crates/nous/src/execute/tests/mod.rs
+++ b/crates/nous/src/execute/tests/mod.rs
@@ -140,6 +140,7 @@ fn make_tool_def(name: &str) -> ToolDef {
             required: vec![],
         },
         category: ToolCategory::Workspace,
+        reversibility: aletheia_organon::types::Reversibility::Irreversible,
         auto_activate: false,
     }
 }

--- a/crates/organon/Cargo.toml
+++ b/crates/organon/Cargo.toml
@@ -20,6 +20,7 @@ test-support = ["aletheia-hermeneus/test-support"]
 [dependencies]
 aletheia-hermeneus = { path = "../hermeneus" }
 aletheia-koina = { path = "../koina" }
+aletheia-taxis = { path = "../taxis" }
 base64 = { workspace = true }
 indexmap = { workspace = true }
 jiff = { workspace = true }
@@ -27,6 +28,7 @@ prometheus = { workspace = true }
 reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+serde_yaml = { workspace = true }
 snafu = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }

--- a/crates/organon/src/builtins/agent.rs
+++ b/crates/organon/src/builtins/agent.rs
@@ -16,8 +16,8 @@ use super::workspace::{extract_opt_u64, extract_str};
 use crate::error::Result;
 use crate::registry::{ToolExecutor, ToolRegistry};
 use crate::types::{
-    InputSchema, PropertyDef, PropertyType, SpawnRequest, ToolCategory, ToolContext, ToolDef,
-    ToolInput, ToolResult,
+    InputSchema, PropertyDef, PropertyType, Reversibility, SpawnRequest, ToolCategory, ToolContext,
+    ToolDef, ToolInput, ToolResult,
 };
 
 const DEFAULT_TIMEOUT_SECS: u64 = 300;
@@ -240,6 +240,7 @@ fn sessions_spawn_def() -> ToolDef {
             required: vec!["role".to_owned(), "task".to_owned()],
         },
         category: ToolCategory::Agent,
+        reversibility: Reversibility::PartiallyReversible,
         auto_activate: false,
     }
 }
@@ -279,6 +280,7 @@ fn sessions_dispatch_def() -> ToolDef {
             required: vec!["tasks".to_owned()],
         },
         category: ToolCategory::Agent,
+        reversibility: Reversibility::Irreversible,
         auto_activate: false,
     }
 }

--- a/crates/organon/src/builtins/communication.rs
+++ b/crates/organon/src/builtins/communication.rs
@@ -15,8 +15,8 @@ use super::workspace::{extract_opt_u64, extract_str};
 use crate::error::Result;
 use crate::registry::{ToolExecutor, ToolRegistry};
 use crate::types::{
-    InputSchema, PropertyDef, PropertyType, ToolCategory, ToolContext, ToolDef, ToolInput,
-    ToolResult,
+    InputSchema, PropertyDef, PropertyType, Reversibility, ToolCategory, ToolContext, ToolDef,
+    ToolInput, ToolResult,
 };
 
 const MESSAGE_MAX_LEN: usize = 4000;
@@ -194,6 +194,7 @@ fn message_def() -> ToolDef {
             required: vec!["to".to_owned(), "text".to_owned()],
         },
         category: ToolCategory::Communication,
+        reversibility: Reversibility::Irreversible,
         auto_activate: true,
     }
 }
@@ -245,6 +246,7 @@ fn sessions_ask_def() -> ToolDef {
             required: vec!["agentId".to_owned(), "message".to_owned()],
         },
         category: ToolCategory::Communication,
+        reversibility: Reversibility::Reversible,
         auto_activate: true,
     }
 }
@@ -287,6 +289,7 @@ fn sessions_send_def() -> ToolDef {
             required: vec!["agentId".to_owned(), "message".to_owned()],
         },
         category: ToolCategory::Communication,
+        reversibility: Reversibility::Irreversible,
         auto_activate: true,
     }
 }

--- a/crates/organon/src/builtins/computer_use/executor.rs
+++ b/crates/organon/src/builtins/computer_use/executor.rs
@@ -11,8 +11,8 @@ use crate::error::{self, Result};
 use crate::registry::{ToolExecutor, ToolRegistry};
 use crate::sandbox::{SandboxConfig, SandboxEnforcement};
 use crate::types::{
-    InputSchema, PropertyDef, PropertyType, ToolCategory, ToolContext, ToolDef, ToolInput,
-    ToolResult,
+    InputSchema, PropertyDef, PropertyType, Reversibility, ToolCategory, ToolContext, ToolDef,
+    ToolInput, ToolResult,
 };
 
 use super::sandbox::{ComputerUseSessionConfig, execute_sandboxed_action};
@@ -236,6 +236,7 @@ fn computer_use_def() -> ToolDef {
             required: vec!["action".to_owned()],
         },
         category: ToolCategory::System,
+        reversibility: Reversibility::Irreversible,
         auto_activate: false,
     }
 }

--- a/crates/organon/src/builtins/enable_tool.rs
+++ b/crates/organon/src/builtins/enable_tool.rs
@@ -14,8 +14,8 @@ use aletheia_koina::id::ToolName;
 use crate::error::Result;
 use crate::registry::{ToolExecutor, ToolRegistry};
 use crate::types::{
-    InputSchema, PropertyDef, PropertyType, ToolCategory, ToolContext, ToolDef, ToolInput,
-    ToolResult,
+    InputSchema, PropertyDef, PropertyType, Reversibility, ToolCategory, ToolContext, ToolDef,
+    ToolInput, ToolResult,
 };
 
 use super::workspace::extract_str;
@@ -102,6 +102,7 @@ fn enable_tool_def() -> ToolDef {
             required: vec!["name".to_owned()],
         },
         category: ToolCategory::System,
+        reversibility: Reversibility::FullyReversible,
         auto_activate: true,
     }
 }

--- a/crates/organon/src/builtins/filesystem.rs
+++ b/crates/organon/src/builtins/filesystem.rs
@@ -21,8 +21,8 @@ use crate::error::Result;
 use crate::process_guard::ProcessGuard;
 use crate::registry::{ToolExecutor, ToolRegistry};
 use crate::types::{
-    InputSchema, PropertyDef, PropertyType, ToolCategory, ToolContext, ToolDef, ToolInput,
-    ToolResult,
+    InputSchema, PropertyDef, PropertyType, Reversibility, ToolCategory, ToolContext, ToolDef,
+    ToolInput, ToolResult,
 };
 
 use super::workspace::{extract_opt_bool, extract_opt_u64, extract_str, validate_path};
@@ -429,6 +429,7 @@ fn grep_def() -> ToolDef {
             required: vec!["pattern".to_owned()],
         },
         category: ToolCategory::Workspace,
+        reversibility: Reversibility::FullyReversible,
         auto_activate: true,
     }
 }
@@ -489,6 +490,7 @@ fn find_def() -> ToolDef {
             required: vec!["pattern".to_owned()],
         },
         category: ToolCategory::Workspace,
+        reversibility: Reversibility::FullyReversible,
         auto_activate: true,
     }
 }
@@ -522,6 +524,7 @@ fn ls_def() -> ToolDef {
             required: vec![],
         },
         category: ToolCategory::Workspace,
+        reversibility: Reversibility::FullyReversible,
         auto_activate: true,
     }
 }

--- a/crates/organon/src/builtins/memory/blackboard.rs
+++ b/crates/organon/src/builtins/memory/blackboard.rs
@@ -14,8 +14,8 @@ use aletheia_koina::id::ToolName;
 use crate::error::Result;
 use crate::registry::{ToolExecutor, ToolRegistry};
 use crate::types::{
-    InputSchema, PropertyDef, PropertyType, ToolCategory, ToolContext, ToolDef, ToolInput,
-    ToolResult,
+    InputSchema, PropertyDef, PropertyType, Reversibility, ToolCategory, ToolContext, ToolDef,
+    ToolInput, ToolResult,
 };
 
 use crate::builtins::workspace::{extract_opt_u64, extract_str};
@@ -148,6 +148,7 @@ fn blackboard_def() -> ToolDef {
             required: vec!["action".to_owned()],
         },
         category: ToolCategory::Memory,
+        reversibility: Reversibility::Reversible,
         auto_activate: true,
     }
 }

--- a/crates/organon/src/builtins/memory/datalog.rs
+++ b/crates/organon/src/builtins/memory/datalog.rs
@@ -14,8 +14,8 @@ use aletheia_koina::id::ToolName;
 use crate::error::Result;
 use crate::registry::{ToolExecutor, ToolRegistry};
 use crate::types::{
-    InputSchema, PropertyDef, PropertyType, ToolCategory, ToolContext, ToolDef, ToolInput,
-    ToolResult,
+    InputSchema, PropertyDef, PropertyType, Reversibility, ToolCategory, ToolContext, ToolDef,
+    ToolInput, ToolResult,
 };
 
 use crate::builtins::workspace::extract_str;
@@ -187,6 +187,7 @@ fn datalog_query_def() -> ToolDef {
             required: vec!["query".to_owned()],
         },
         category: ToolCategory::Memory,
+        reversibility: Reversibility::FullyReversible,
         auto_activate: false,
     }
 }

--- a/crates/organon/src/builtins/memory/knowledge_ops.rs
+++ b/crates/organon/src/builtins/memory/knowledge_ops.rs
@@ -14,8 +14,8 @@ use aletheia_koina::id::ToolName;
 use crate::error::Result;
 use crate::registry::{ToolExecutor, ToolRegistry};
 use crate::types::{
-    InputSchema, PropertyDef, PropertyType, ToolCategory, ToolContext, ToolDef, ToolInput,
-    ToolResult,
+    InputSchema, PropertyDef, PropertyType, Reversibility, ToolCategory, ToolContext, ToolDef,
+    ToolInput, ToolResult,
 };
 
 use crate::builtins::workspace::{extract_opt_u64, extract_str};
@@ -247,6 +247,7 @@ fn memory_search_def() -> ToolDef {
             required: vec!["query".to_owned()],
         },
         category: ToolCategory::Memory,
+        reversibility: Reversibility::FullyReversible,
         auto_activate: true,
     }
 }
@@ -280,6 +281,7 @@ fn memory_correct_def() -> ToolDef {
             required: vec!["fact_id".to_owned(), "new_content".to_owned()],
         },
         category: ToolCategory::Memory,
+        reversibility: Reversibility::PartiallyReversible,
         auto_activate: false,
     }
 }
@@ -313,6 +315,7 @@ fn memory_retract_def() -> ToolDef {
             required: vec!["fact_id".to_owned()],
         },
         category: ToolCategory::Memory,
+        reversibility: Reversibility::PartiallyReversible,
         auto_activate: false,
     }
 }
@@ -352,6 +355,7 @@ fn memory_forget_def() -> ToolDef {
             required: vec!["fact_id".to_owned(), "reason".to_owned()],
         },
         category: ToolCategory::Memory,
+        reversibility: Reversibility::PartiallyReversible,
         auto_activate: false,
     }
 }
@@ -394,6 +398,7 @@ fn memory_audit_def() -> ToolDef {
             required: vec![],
         },
         category: ToolCategory::Memory,
+        reversibility: Reversibility::FullyReversible,
         auto_activate: false,
     }
 }

--- a/crates/organon/src/builtins/memory/note.rs
+++ b/crates/organon/src/builtins/memory/note.rs
@@ -14,8 +14,8 @@ use aletheia_koina::id::ToolName;
 use crate::error::Result;
 use crate::registry::{ToolExecutor, ToolRegistry};
 use crate::types::{
-    InputSchema, PropertyDef, PropertyType, ToolCategory, ToolContext, ToolDef, ToolInput,
-    ToolResult,
+    InputSchema, PropertyDef, PropertyType, Reversibility, ToolCategory, ToolContext, ToolDef,
+    ToolInput, ToolResult,
 };
 
 use crate::builtins::workspace::extract_str;
@@ -152,6 +152,7 @@ fn note_def() -> ToolDef {
             required: vec!["action".to_owned()],
         },
         category: ToolCategory::Memory,
+        reversibility: Reversibility::Reversible,
         auto_activate: true,
     }
 }

--- a/crates/organon/src/builtins/planning_defs.rs
+++ b/crates/organon/src/builtins/planning_defs.rs
@@ -8,7 +8,7 @@ use indexmap::IndexMap;
 
 use aletheia_koina::id::ToolName;
 
-use crate::types::{InputSchema, PropertyDef, PropertyType, ToolCategory, ToolDef};
+use crate::types::{InputSchema, PropertyDef, PropertyType, Reversibility, ToolCategory, ToolDef};
 
 pub(super) fn plan_create_def() -> ToolDef {
     ToolDef {
@@ -74,6 +74,7 @@ pub(super) fn plan_create_def() -> ToolDef {
             required: vec!["name".to_owned(), "description".to_owned()],
         },
         category: ToolCategory::Planning,
+        reversibility: Reversibility::Reversible,
         auto_activate: false,
     }
 }
@@ -107,6 +108,7 @@ pub(super) fn plan_research_def() -> ToolDef {
             required: vec!["project_id".to_owned()],
         },
         category: ToolCategory::Planning,
+        reversibility: Reversibility::Reversible,
         auto_activate: false,
     }
 }
@@ -140,6 +142,7 @@ pub(super) fn plan_requirements_def() -> ToolDef {
             required: vec!["project_id".to_owned(), "action".to_owned()],
         },
         category: ToolCategory::Planning,
+        reversibility: Reversibility::Reversible,
         auto_activate: false,
     }
 }
@@ -195,6 +198,7 @@ pub(super) fn plan_roadmap_def() -> ToolDef {
             required: vec!["project_id".to_owned(), "action".to_owned()],
         },
         category: ToolCategory::Planning,
+        reversibility: Reversibility::Reversible,
         auto_activate: false,
     }
 }
@@ -228,6 +232,7 @@ pub(super) fn plan_discuss_def() -> ToolDef {
             required: vec!["project_id".to_owned(), "action".to_owned()],
         },
         category: ToolCategory::Planning,
+        reversibility: Reversibility::Reversible,
         auto_activate: false,
     }
 }
@@ -267,6 +272,7 @@ pub(super) fn plan_execute_def() -> ToolDef {
             required: vec!["project_id".to_owned(), "action".to_owned()],
         },
         category: ToolCategory::Planning,
+        reversibility: Reversibility::PartiallyReversible,
         auto_activate: false,
     }
 }
@@ -314,6 +320,7 @@ pub(super) fn plan_verify_def() -> ToolDef {
             required: vec!["project_id".to_owned(), "action".to_owned()],
         },
         category: ToolCategory::Planning,
+        reversibility: Reversibility::PartiallyReversible,
         auto_activate: false,
     }
 }
@@ -336,6 +343,7 @@ pub(super) fn plan_status_def() -> ToolDef {
             required: vec!["project_id".to_owned()],
         },
         category: ToolCategory::Planning,
+        reversibility: Reversibility::FullyReversible,
         auto_activate: false,
     }
 }
@@ -391,6 +399,7 @@ pub(super) fn plan_step_complete_def() -> ToolDef {
             ],
         },
         category: ToolCategory::Planning,
+        reversibility: Reversibility::PartiallyReversible,
         auto_activate: false,
     }
 }
@@ -447,6 +456,7 @@ pub(super) fn plan_step_fail_def() -> ToolDef {
             ],
         },
         category: ToolCategory::Planning,
+        reversibility: Reversibility::PartiallyReversible,
         auto_activate: false,
     }
 }

--- a/crates/organon/src/builtins/research.rs
+++ b/crates/organon/src/builtins/research.rs
@@ -20,8 +20,8 @@ use aletheia_koina::id::ToolName;
 use crate::error::Result;
 use crate::registry::{ToolExecutor, ToolRegistry};
 use crate::types::{
-    InputSchema, PropertyDef, PropertyType, ToolCategory, ToolContext, ToolDef, ToolInput,
-    ToolResult,
+    InputSchema, PropertyDef, PropertyType, Reversibility, ToolCategory, ToolContext, ToolDef,
+    ToolInput, ToolResult,
 };
 
 use super::workspace::{extract_opt_u64, extract_str};
@@ -359,6 +359,7 @@ fn web_fetch_def() -> ToolDef {
             required: vec!["url".to_owned()],
         },
         category: ToolCategory::Research,
+        reversibility: Reversibility::Irreversible,
         auto_activate: false,
     }
 }

--- a/crates/organon/src/builtins/triage/mod.rs
+++ b/crates/organon/src/builtins/triage/mod.rs
@@ -29,8 +29,8 @@ use aletheia_koina::id::ToolName;
 use crate::error::Result;
 use crate::registry::{ToolExecutor, ToolRegistry};
 use crate::types::{
-    InputSchema, PropertyDef, PropertyType, ToolCategory, ToolContext, ToolDef, ToolInput,
-    ToolResult,
+    InputSchema, PropertyDef, PropertyType, Reversibility, ToolCategory, ToolContext, ToolDef,
+    ToolInput, ToolResult,
 };
 
 use prompt_gen::generate_prompt;
@@ -646,6 +646,7 @@ fn issue_scan_def() -> ToolDef {
             required: vec!["repo".to_owned()],
         },
         category: ToolCategory::Planning,
+        reversibility: Reversibility::FullyReversible,
         auto_activate: false,
     }
 }
@@ -708,6 +709,7 @@ fn issue_triage_def() -> ToolDef {
             required: vec!["repo".to_owned(), "staging_dir".to_owned()],
         },
         category: ToolCategory::Planning,
+        reversibility: Reversibility::PartiallyReversible,
         auto_activate: false,
     }
 }
@@ -763,6 +765,7 @@ fn issue_approve_def() -> ToolDef {
             ],
         },
         category: ToolCategory::Planning,
+        reversibility: Reversibility::PartiallyReversible,
         auto_activate: false,
     }
 }

--- a/crates/organon/src/builtins/view_file.rs
+++ b/crates/organon/src/builtins/view_file.rs
@@ -14,8 +14,8 @@ use indexmap::IndexMap;
 use crate::error::Result;
 use crate::registry::{ToolExecutor, ToolRegistry};
 use crate::types::{
-    DocumentSource, ImageSource, InputSchema, PropertyDef, PropertyType, ToolCategory, ToolContext,
-    ToolDef, ToolInput, ToolResult, ToolResultBlock,
+    DocumentSource, ImageSource, InputSchema, PropertyDef, PropertyType, Reversibility,
+    ToolCategory, ToolContext, ToolDef, ToolInput, ToolResult, ToolResultBlock,
 };
 
 use super::workspace::{extract_opt_u64, extract_str, validate_path};
@@ -225,6 +225,7 @@ fn view_file_def() -> crate::types::ToolDef {
             required: vec!["path".to_owned()],
         },
         category: ToolCategory::Workspace,
+        reversibility: Reversibility::FullyReversible,
         auto_activate: true,
     }
 }

--- a/crates/organon/src/builtins/workspace.rs
+++ b/crates/organon/src/builtins/workspace.rs
@@ -23,8 +23,8 @@ use crate::error::{self, Result};
 use crate::process_guard::ProcessGuard;
 use crate::registry::{ToolExecutor, ToolRegistry};
 use crate::types::{
-    InputSchema, PropertyDef, PropertyType, ToolCategory, ToolContext, ToolDef, ToolInput,
-    ToolResult,
+    InputSchema, PropertyDef, PropertyType, Reversibility, ToolCategory, ToolContext, ToolDef,
+    ToolInput, ToolResult,
 };
 
 /// Strip absolute path prefixes from an error message, showing only the filename.
@@ -636,6 +636,7 @@ fn read_def() -> ToolDef {
             required: vec!["path".to_owned()],
         },
         category: ToolCategory::Workspace,
+        reversibility: Reversibility::FullyReversible,
         auto_activate: true,
     }
 }
@@ -678,6 +679,7 @@ fn write_def() -> ToolDef {
             required: vec!["path".to_owned(), "content".to_owned()],
         },
         category: ToolCategory::Workspace,
+        reversibility: Reversibility::Reversible,
         auto_activate: true,
     }
 }
@@ -724,6 +726,7 @@ fn edit_def() -> ToolDef {
             ],
         },
         category: ToolCategory::Workspace,
+        reversibility: Reversibility::Reversible,
         auto_activate: true,
     }
 }
@@ -758,6 +761,7 @@ fn exec_def() -> ToolDef {
             required: vec!["command".to_owned()],
         },
         category: ToolCategory::Workspace,
+        reversibility: Reversibility::Irreversible,
         auto_activate: true,
     }
 }

--- a/crates/organon/src/custom_commands.rs
+++ b/crates/organon/src/custom_commands.rs
@@ -1,0 +1,534 @@
+//! User-defined slash commands loaded from YAML files via oikos cascade.
+
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+use tracing::debug;
+
+use aletheia_koina::id::ToolName;
+use aletheia_taxis::cascade::{self, CascadeEntry};
+use aletheia_taxis::oikos::Oikos;
+
+use crate::types::Reversibility;
+
+/// A single step in a custom command's execution pipeline.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CommandStep {
+    /// Tool name to invoke.
+    pub tool: String,
+    /// Arguments to pass to the tool.
+    #[serde(default)]
+    pub args: serde_json::Value,
+}
+
+/// A user-defined slash command loaded from a YAML file.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CustomCommandDef {
+    /// Slash command name (without the leading `/`).
+    pub name: String,
+    /// Short description for autocomplete.
+    pub description: String,
+    /// Ordered list of tool invocations.
+    pub steps: Vec<CommandStep>,
+    /// Whether to prompt the user for confirmation before executing.
+    #[serde(default)]
+    pub confirm: bool,
+    /// Reversibility override for the command as a whole.
+    #[serde(default)]
+    pub reversibility: Option<Reversibility>,
+}
+
+impl CustomCommandDef {
+    /// Derive the effective reversibility for this command.
+    ///
+    /// If explicitly set, uses the override. Otherwise derives from the
+    /// most dangerous step: a command with any irreversible step is irreversible.
+    #[must_use]
+    pub fn effective_reversibility(
+        &self,
+        lookup: impl Fn(&str) -> Option<Reversibility>,
+    ) -> Reversibility {
+        if let Some(rev) = self.reversibility {
+            return rev;
+        }
+
+        // WHY: a chain is as reversible as its least reversible step
+        let mut worst = Reversibility::FullyReversible;
+        for step in &self.steps {
+            let step_rev = lookup(&step.tool).unwrap_or(Reversibility::Irreversible);
+            worst = max_reversibility(worst, step_rev);
+        }
+        worst
+    }
+}
+
+/// Return the more dangerous of two reversibility levels.
+fn max_reversibility(a: Reversibility, b: Reversibility) -> Reversibility {
+    let rank = |r: Reversibility| -> u8 {
+        match r {
+            Reversibility::FullyReversible => 0,
+            Reversibility::Reversible => 1,
+            Reversibility::PartiallyReversible => 2,
+            Reversibility::Irreversible => 3,
+        }
+    };
+    if rank(b) > rank(a) { b } else { a }
+}
+
+/// Parse a single YAML file into a command definition.
+///
+/// # Errors
+///
+/// Returns an error string if the file cannot be read or parsed.
+pub fn parse_command_file(path: &Path) -> Result<CustomCommandDef, String> {
+    let content = std::fs::read_to_string(path)
+        .map_err(|e| format!("failed to read {}: {e}", path.display()))?;
+    parse_command_yaml(&content)
+}
+
+/// Parse YAML content into a command definition.
+///
+/// # Errors
+///
+/// Returns an error string if the YAML is malformed or missing required fields.
+pub fn parse_command_yaml(content: &str) -> Result<CustomCommandDef, String> {
+    let def: CustomCommandDef =
+        serde_yaml::from_str(content).map_err(|e| format!("invalid command YAML: {e}"))?;
+
+    if def.name.is_empty() {
+        return Err("command name must not be empty".to_owned());
+    }
+    if def.steps.is_empty() {
+        return Err("command must have at least one step".to_owned());
+    }
+    for step in &def.steps {
+        if step.tool.is_empty() {
+            return Err("step tool name must not be empty".to_owned());
+        }
+    }
+
+    Ok(def)
+}
+
+/// Load all custom command definitions from a single directory.
+///
+/// Reads all `.yaml` and `.yml` files in the directory. Malformed files
+/// are logged and skipped.
+#[must_use]
+pub fn load_commands_from_dir(dir: &Path) -> Vec<CustomCommandDef> {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return Vec::new();
+    };
+
+    let mut commands = Vec::new();
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
+        if ext != "yaml" && ext != "yml" {
+            continue;
+        }
+        match parse_command_file(&path) {
+            Ok(cmd) => {
+                debug!(name = %cmd.name, path = %path.display(), "loaded custom command");
+                commands.push(cmd);
+            }
+            Err(e) => {
+                debug!(path = %path.display(), error = %e, "skipped malformed command file");
+            }
+        }
+    }
+    commands
+}
+
+/// Load custom commands via oikos cascade for a given agent.
+///
+/// Searches the three-tier hierarchy (nous → shared → theke) in the
+/// `commands/` subdirectory. Most-specific definition wins on name collision.
+#[must_use]
+pub fn load_commands_cascade(oikos: &Oikos, nous_id: &str) -> Vec<CustomCommandDef> {
+    let mut seen = std::collections::HashSet::new();
+    let mut commands = Vec::new();
+
+    let entries_long_ext = cascade::discover(oikos, nous_id, "commands", Some("yaml"));
+    let entries_short_ext = cascade::discover(oikos, nous_id, "commands", Some("yml"));
+
+    let all_entries: Vec<CascadeEntry> = entries_long_ext
+        .into_iter()
+        .chain(entries_short_ext)
+        .collect();
+
+    for entry in all_entries {
+        match parse_command_file(&entry.path) {
+            Ok(cmd) => {
+                if seen.insert(cmd.name.clone()) {
+                    debug!(
+                        name = %cmd.name,
+                        tier = %entry.tier,
+                        "loaded custom command via cascade"
+                    );
+                    commands.push(cmd);
+                }
+            }
+            Err(e) => {
+                debug!(
+                    path = %entry.path.display(),
+                    error = %e,
+                    "skipped malformed command in cascade"
+                );
+            }
+        }
+    }
+
+    commands
+}
+
+/// Validate that all tool names referenced in command steps are syntactically valid.
+///
+/// Returns a list of invalid tool references. An empty list means all are valid.
+#[must_use]
+pub fn validate_step_tools(def: &CustomCommandDef) -> Vec<String> {
+    let mut invalid = Vec::new();
+    for step in &def.steps {
+        if ToolName::new(&step.tool).is_err() {
+            invalid.push(step.tool.clone());
+        }
+    }
+    invalid
+}
+
+#[cfg(test)]
+#[expect(clippy::expect_used, reason = "test assertions")]
+#[expect(
+    clippy::indexing_slicing,
+    reason = "test assertions on known-length vecs"
+)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_valid_command_yaml() {
+        let yaml = r#"
+name: deploy
+description: Deploy to production
+steps:
+  - tool: exec
+    args:
+      command: "cargo build --release"
+  - tool: exec
+    args:
+      command: "./deploy.sh"
+confirm: true
+"#;
+        let cmd = parse_command_yaml(yaml).expect("valid yaml");
+        assert_eq!(cmd.name, "deploy", "command name should be 'deploy'");
+        assert_eq!(cmd.steps.len(), 2, "should have 2 steps");
+        assert!(cmd.confirm, "confirm should be true");
+        assert_eq!(
+            cmd.steps[0].tool, "exec",
+            "first step tool should be 'exec'"
+        );
+        assert_eq!(
+            cmd.steps[0].args["command"], "cargo build --release",
+            "first step args should contain command"
+        );
+    }
+
+    #[test]
+    fn parses_minimal_command() {
+        let yaml = r#"
+name: test
+description: Run tests
+steps:
+  - tool: exec
+    args:
+      command: "cargo test"
+"#;
+        let cmd = parse_command_yaml(yaml).expect("valid yaml");
+        assert_eq!(cmd.name, "test", "command name should be 'test'");
+        assert!(!cmd.confirm, "confirm should default to false");
+        assert!(
+            cmd.reversibility.is_none(),
+            "reversibility should default to None"
+        );
+    }
+
+    #[test]
+    fn rejects_empty_name() {
+        let yaml = r#"
+name: ""
+description: Bad command
+steps:
+  - tool: exec
+    args: {}
+"#;
+        let err = parse_command_yaml(yaml).expect_err("empty name");
+        assert!(
+            err.contains("name must not be empty"),
+            "error should mention empty name: {err}"
+        );
+    }
+
+    #[test]
+    fn rejects_no_steps() {
+        let yaml = r"
+name: empty
+description: No steps
+steps: []
+";
+        let err = parse_command_yaml(yaml).expect_err("no steps");
+        assert!(
+            err.contains("at least one step"),
+            "error should mention missing steps: {err}"
+        );
+    }
+
+    #[test]
+    fn rejects_empty_tool_name() {
+        let yaml = r#"
+name: bad
+description: Bad step
+steps:
+  - tool: ""
+    args: {}
+"#;
+        let err = parse_command_yaml(yaml).expect_err("empty tool");
+        assert!(
+            err.contains("tool name must not be empty"),
+            "error should mention empty tool name: {err}"
+        );
+    }
+
+    #[test]
+    fn rejects_malformed_yaml() {
+        let yaml = "not: valid: yaml: {{{{";
+        let err = parse_command_yaml(yaml).expect_err("malformed");
+        assert!(
+            err.contains("invalid command YAML"),
+            "error should mention invalid YAML: {err}"
+        );
+    }
+
+    #[test]
+    fn parses_reversibility_override() {
+        let yaml = r#"
+name: safe_deploy
+description: Safe deploy
+steps:
+  - tool: exec
+    args:
+      command: "echo hello"
+reversibility: reversible
+"#;
+        let cmd = parse_command_yaml(yaml).expect("valid yaml");
+        assert_eq!(
+            cmd.reversibility,
+            Some(Reversibility::Reversible),
+            "reversibility override should be Reversible"
+        );
+    }
+
+    #[test]
+    fn effective_reversibility_uses_override() {
+        let cmd = CustomCommandDef {
+            name: "test".to_owned(),
+            description: "test".to_owned(),
+            steps: vec![CommandStep {
+                tool: "exec".to_owned(),
+                args: serde_json::json!({}),
+            }],
+            confirm: false,
+            reversibility: Some(Reversibility::Reversible),
+        };
+
+        let rev = cmd.effective_reversibility(|_| Some(Reversibility::Irreversible));
+        assert_eq!(
+            rev,
+            Reversibility::Reversible,
+            "override should take precedence"
+        );
+    }
+
+    #[test]
+    fn effective_reversibility_derives_from_worst_step() {
+        let cmd = CustomCommandDef {
+            name: "test".to_owned(),
+            description: "test".to_owned(),
+            steps: vec![
+                CommandStep {
+                    tool: "read".to_owned(),
+                    args: serde_json::json!({}),
+                },
+                CommandStep {
+                    tool: "exec".to_owned(),
+                    args: serde_json::json!({}),
+                },
+            ],
+            confirm: false,
+            reversibility: None,
+        };
+
+        let rev = cmd.effective_reversibility(|tool| match tool {
+            "read" => Some(Reversibility::FullyReversible),
+            "exec" => Some(Reversibility::Irreversible),
+            _ => None,
+        });
+        assert_eq!(
+            rev,
+            Reversibility::Irreversible,
+            "chain should be as dangerous as worst step"
+        );
+    }
+
+    #[test]
+    fn effective_reversibility_defaults_unknown_to_irreversible() {
+        let cmd = CustomCommandDef {
+            name: "test".to_owned(),
+            description: "test".to_owned(),
+            steps: vec![CommandStep {
+                tool: "unknown_tool".to_owned(),
+                args: serde_json::json!({}),
+            }],
+            confirm: false,
+            reversibility: None,
+        };
+
+        let rev = cmd.effective_reversibility(|_| None);
+        assert_eq!(
+            rev,
+            Reversibility::Irreversible,
+            "unknown tools should default to irreversible"
+        );
+    }
+
+    #[test]
+    fn validate_step_tools_catches_invalid_names() {
+        let cmd = CustomCommandDef {
+            name: "test".to_owned(),
+            description: "test".to_owned(),
+            steps: vec![
+                CommandStep {
+                    tool: "valid_tool".to_owned(),
+                    args: serde_json::json!({}),
+                },
+                CommandStep {
+                    tool: "INVALID TOOL NAME!".to_owned(),
+                    args: serde_json::json!({}),
+                },
+            ],
+            confirm: false,
+            reversibility: None,
+        };
+
+        let invalid = validate_step_tools(&cmd);
+        assert_eq!(invalid.len(), 1, "should find one invalid tool name");
+        assert_eq!(
+            invalid[0], "INVALID TOOL NAME!",
+            "should report the invalid name"
+        );
+    }
+
+    #[test]
+    fn load_commands_from_dir_skips_non_yaml() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let yaml_path = dir.path().join("deploy.yaml");
+        let txt_path = dir.path().join("readme.txt");
+
+        #[expect(clippy::disallowed_methods, reason = "test: creating fixture files")]
+        {
+            std::fs::write(
+                &yaml_path,
+                "name: deploy\ndescription: Deploy\nsteps:\n  - tool: exec\n    args:\n      command: echo",
+            )
+            .expect("write yaml");
+            std::fs::write(&txt_path, "not a command").expect("write txt");
+        }
+
+        let cmds = load_commands_from_dir(dir.path());
+        assert_eq!(cmds.len(), 1, "should load only the yaml file");
+        assert_eq!(cmds[0].name, "deploy", "loaded command should be 'deploy'");
+    }
+
+    #[test]
+    fn load_commands_from_dir_handles_missing_dir() {
+        let cmds = load_commands_from_dir(Path::new("/nonexistent/path"));
+        assert!(
+            cmds.is_empty(),
+            "missing directory should return empty list"
+        );
+    }
+
+    #[test]
+    fn load_commands_from_dir_skips_malformed_yaml() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let bad_path = dir.path().join("bad.yaml");
+        let good_path = dir.path().join("good.yaml");
+
+        #[expect(clippy::disallowed_methods, reason = "test: creating fixture files")]
+        {
+            std::fs::write(&bad_path, "not: valid: yaml: {{{{").expect("write bad");
+            std::fs::write(
+                &good_path,
+                "name: good\ndescription: Good\nsteps:\n  - tool: exec\n    args:\n      command: echo",
+            )
+            .expect("write good");
+        }
+
+        let cmds = load_commands_from_dir(dir.path());
+        assert_eq!(cmds.len(), 1, "should skip malformed and load good one");
+        assert_eq!(cmds[0].name, "good", "loaded command should be 'good'");
+    }
+
+    #[test]
+    fn multi_step_command_preserves_order() {
+        let yaml = r#"
+name: build-and-test
+description: Build and run tests
+steps:
+  - tool: exec
+    args:
+      command: "cargo build"
+  - tool: exec
+    args:
+      command: "cargo test"
+  - tool: exec
+    args:
+      command: "cargo clippy"
+"#;
+        let cmd = parse_command_yaml(yaml).expect("valid yaml");
+        assert_eq!(cmd.steps.len(), 3, "should have 3 steps");
+        assert_eq!(
+            cmd.steps[0].args["command"], "cargo build",
+            "first step should be build"
+        );
+        assert_eq!(
+            cmd.steps[1].args["command"], "cargo test",
+            "second step should be test"
+        );
+        assert_eq!(
+            cmd.steps[2].args["command"], "cargo clippy",
+            "third step should be clippy"
+        );
+    }
+
+    #[test]
+    fn max_reversibility_returns_worse() {
+        assert_eq!(
+            max_reversibility(Reversibility::FullyReversible, Reversibility::Reversible),
+            Reversibility::Reversible,
+            "Reversible > FullyReversible"
+        );
+        assert_eq!(
+            max_reversibility(Reversibility::Irreversible, Reversibility::FullyReversible),
+            Reversibility::Irreversible,
+            "Irreversible > FullyReversible"
+        );
+        assert_eq!(
+            max_reversibility(
+                Reversibility::PartiallyReversible,
+                Reversibility::PartiallyReversible
+            ),
+            Reversibility::PartiallyReversible,
+            "same level returns same"
+        );
+    }
+}

--- a/crates/organon/src/lib.rs
+++ b/crates/organon/src/lib.rs
@@ -9,6 +9,8 @@
 
 /// Built-in tool implementations that ship with the platform.
 pub mod builtins;
+/// User-defined slash commands loaded from YAML files via oikos cascade.
+pub mod custom_commands;
 /// Organon-specific error types and result alias.
 pub mod error;
 /// Prometheus metrics for tool execution counts, latency, and error rates.

--- a/crates/organon/src/registry.rs
+++ b/crates/organon/src/registry.rs
@@ -12,7 +12,10 @@ use tracing::info_span;
 use aletheia_koina::id::ToolName;
 
 use crate::error::{self, Result};
-use crate::types::{ToolCategory, ToolContext, ToolDef, ToolInput, ToolResult};
+use crate::types::{
+    ApprovalRequirement, Reversibility, ToolCallMetadata, ToolCategory, ToolContext, ToolDef,
+    ToolInput, ToolResult,
+};
 
 /// The trait tool implementations must satisfy.
 ///
@@ -99,6 +102,8 @@ impl ToolRegistry {
         })?;
         let span = info_span!("tool_execute",
             tool.name = %input.name,
+            tool.reversibility = %tool.def.reversibility,
+            tool.approval = %ApprovalRequirement::from(tool.def.reversibility),
             tool.duration_ms = tracing::field::Empty,
             tool.status = tracing::field::Empty,
         );
@@ -182,6 +187,33 @@ impl ToolRegistry {
             .collect()
     }
 
+    /// Look up the reversibility level for a tool by name.
+    #[must_use]
+    pub fn reversibility(&self, name: &ToolName) -> Option<Reversibility> {
+        // kanon:ignore RUST/pub-visibility
+        self.tools.get(name).map(|t| t.def.reversibility)
+    }
+
+    /// Determine what approval is required for a tool call.
+    #[must_use]
+    pub fn approval_requirement(&self, name: &ToolName) -> Option<ApprovalRequirement> {
+        // kanon:ignore RUST/pub-visibility
+        self.tools
+            .get(name)
+            .map(|t| ApprovalRequirement::from(t.def.reversibility))
+    }
+
+    /// Build session-log metadata for a tool call.
+    #[must_use]
+    pub fn call_metadata(&self, name: &ToolName, dry_run: bool) -> Option<ToolCallMetadata> {
+        // kanon:ignore RUST/pub-visibility
+        self.tools.get(name).map(|t| ToolCallMetadata {
+            reversibility: t.def.reversibility,
+            approval: ApprovalRequirement::from(t.def.reversibility),
+            dry_run,
+        })
+    }
+
     /// Catalog of lazy tools (`auto_activate=false`) for the `enable_tool` executor.
     #[must_use]
     pub fn lazy_tool_catalog(&self) -> Vec<(ToolName, String)> {
@@ -206,7 +238,7 @@ mod tests {
     use aletheia_koina::id::{NousId, SessionId};
 
     use super::*;
-    use crate::types::{InputSchema, PropertyDef, PropertyType};
+    use crate::types::{InputSchema, PropertyDef, PropertyType, Reversibility};
 
     /// Mock executor that captures calls for verification.
     struct MockExecutor {
@@ -255,6 +287,7 @@ mod tests {
                 required: vec![],
             },
             category,
+            reversibility: Reversibility::Irreversible,
             auto_activate: false,
         }
     }
@@ -410,6 +443,7 @@ mod tests {
                 required: vec!["path".to_owned()],
             },
             category: ToolCategory::Workspace,
+            reversibility: Reversibility::Irreversible,
             auto_activate: false,
         };
         reg.register(def, exec).expect("register");
@@ -498,6 +532,7 @@ mod tests {
                 required: vec![],
             },
             category,
+            reversibility: Reversibility::Irreversible,
             auto_activate,
         }
     }
@@ -652,6 +687,7 @@ mod tests {
                 required: vec!["path".to_owned()],
             },
             category: ToolCategory::Workspace,
+            reversibility: Reversibility::Irreversible,
             auto_activate: false,
         };
         reg.register(def, exec).expect("register");
@@ -684,6 +720,7 @@ mod tests {
                 required: vec![],
             },
             category: ToolCategory::Workspace,
+            reversibility: Reversibility::Irreversible,
             auto_activate: false,
         };
         reg.register(def, exec).expect("register");
@@ -715,6 +752,7 @@ mod tests {
                 required: vec![],
             },
             category: ToolCategory::Workspace,
+            reversibility: Reversibility::Irreversible,
             auto_activate: false,
         };
         reg.register(def, exec).expect("register");
@@ -740,6 +778,7 @@ mod tests {
                     required: vec![],
                 },
                 category: ToolCategory::Research,
+                reversibility: Reversibility::Irreversible,
                 auto_activate: false,
             },
             exec,

--- a/crates/organon/src/types.rs
+++ b/crates/organon/src/types.rs
@@ -31,6 +31,8 @@ pub struct ToolDef {
     pub input_schema: InputSchema,
     /// Semantic category.
     pub category: ToolCategory,
+    /// How reversible this tool's effects are.
+    pub reversibility: Reversibility,
     /// Whether the tool activates automatically by domain without explicit config.
     pub auto_activate: bool,
 }
@@ -133,6 +135,94 @@ impl std::fmt::Display for PropertyType {
             Self::Object => f.write_str("object"),
         }
     }
+}
+
+/// How reversible a tool's effects are.
+///
+/// Used by the approval system to determine which tool calls need confirmation
+/// and whether counterfactual dry-run simulation is meaningful.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum Reversibility {
+    /// Read-only operations with no side effects (ls, read, search).
+    FullyReversible,
+    /// Can be undone (write file with backup, git commit can revert).
+    Reversible,
+    /// Partial undo possible (delete file can restore from backup if exists).
+    PartiallyReversible,
+    /// Cannot be undone (exec with external side effects, API calls, messages).
+    #[default]
+    Irreversible,
+}
+
+impl std::fmt::Display for Reversibility {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::FullyReversible => f.write_str("fully_reversible"),
+            Self::Reversible => f.write_str("reversible"),
+            Self::PartiallyReversible => f.write_str("partially_reversible"),
+            Self::Irreversible => f.write_str("irreversible"),
+        }
+    }
+}
+
+impl Reversibility {
+    /// Whether this tool's effects can be simulated in a dry run.
+    #[must_use]
+    pub fn supports_dry_run(self) -> bool {
+        matches!(self, Self::FullyReversible | Self::Reversible)
+    }
+}
+
+/// What level of approval a tool call requires before execution.
+///
+/// Derived from [`Reversibility`] but can be overridden per-tool.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum ApprovalRequirement {
+    /// No approval needed (read-only, fully reversible).
+    None,
+    /// Approval recommended but not enforced.
+    Advisory,
+    /// Approval required before execution.
+    Required,
+    /// Approval required with explicit confirmation prompt.
+    Mandatory,
+}
+
+impl std::fmt::Display for ApprovalRequirement {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::None => f.write_str("none"),
+            Self::Advisory => f.write_str("advisory"),
+            Self::Required => f.write_str("required"),
+            Self::Mandatory => f.write_str("mandatory"),
+        }
+    }
+}
+
+impl From<Reversibility> for ApprovalRequirement {
+    fn from(rev: Reversibility) -> Self {
+        match rev {
+            Reversibility::FullyReversible => Self::None,
+            Reversibility::Reversible => Self::Advisory,
+            Reversibility::PartiallyReversible => Self::Required,
+            Reversibility::Irreversible => Self::Mandatory,
+        }
+    }
+}
+
+/// Metadata recorded per tool call for session audit trails.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ToolCallMetadata {
+    /// The tool's reversibility classification at call time.
+    pub reversibility: Reversibility,
+    /// The approval requirement that was applied.
+    pub approval: ApprovalRequirement,
+    /// Whether the call was a dry-run simulation.
+    pub dry_run: bool,
 }
 
 /// Semantic tool category: classifies tool purpose.

--- a/crates/organon/src/types_tests.rs
+++ b/crates/organon/src/types_tests.rs
@@ -24,6 +24,7 @@ fn tool_def_serde_roundtrip() {
             required: vec!["path".to_owned()],
         },
         category: ToolCategory::Workspace,
+        reversibility: Reversibility::Irreversible,
         auto_activate: false,
     };
     let json = serde_json::to_string(&def).expect("serialize");
@@ -390,6 +391,7 @@ fn test_tool_def_auto_activate_stored_correctly() {
             required: vec![],
         },
         category: ToolCategory::Workspace,
+        reversibility: Reversibility::Irreversible,
         auto_activate: true,
     };
     assert!(def.auto_activate, "expected def.auto_activate to be true");
@@ -587,5 +589,167 @@ fn server_tool_config_deserializes_from_partial_json() {
     assert!(
         config.web_search_max_uses.is_none(),
         "expected config.web_search_max_uses.is_none() to be true"
+    );
+}
+
+// ── Reversibility tests ──────────────────────────────────────────────
+
+#[test]
+fn reversibility_display_all_variants() {
+    assert_eq!(
+        Reversibility::FullyReversible.to_string(),
+        "fully_reversible",
+        "FullyReversible display"
+    );
+    assert_eq!(
+        Reversibility::Reversible.to_string(),
+        "reversible",
+        "Reversible display"
+    );
+    assert_eq!(
+        Reversibility::PartiallyReversible.to_string(),
+        "partially_reversible",
+        "PartiallyReversible display"
+    );
+    assert_eq!(
+        Reversibility::Irreversible.to_string(),
+        "irreversible",
+        "Irreversible display"
+    );
+}
+
+#[test]
+fn reversibility_default_is_irreversible() {
+    assert_eq!(
+        Reversibility::default(),
+        Reversibility::Irreversible,
+        "default reversibility should be Irreversible"
+    );
+}
+
+#[test]
+fn reversibility_supports_dry_run() {
+    assert!(
+        Reversibility::FullyReversible.supports_dry_run(),
+        "FullyReversible should support dry run"
+    );
+    assert!(
+        Reversibility::Reversible.supports_dry_run(),
+        "Reversible should support dry run"
+    );
+    assert!(
+        !Reversibility::PartiallyReversible.supports_dry_run(),
+        "PartiallyReversible should not support dry run"
+    );
+    assert!(
+        !Reversibility::Irreversible.supports_dry_run(),
+        "Irreversible should not support dry run"
+    );
+}
+
+#[test]
+fn reversibility_serde_roundtrip() {
+    for rev in [
+        Reversibility::FullyReversible,
+        Reversibility::Reversible,
+        Reversibility::PartiallyReversible,
+        Reversibility::Irreversible,
+    ] {
+        let json = serde_json::to_string(&rev).expect("serialize");
+        let back: Reversibility = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(rev, back, "roundtrip for {rev}");
+    }
+}
+
+#[test]
+fn approval_requirement_from_reversibility() {
+    assert_eq!(
+        ApprovalRequirement::from(Reversibility::FullyReversible),
+        ApprovalRequirement::None,
+        "FullyReversible -> None"
+    );
+    assert_eq!(
+        ApprovalRequirement::from(Reversibility::Reversible),
+        ApprovalRequirement::Advisory,
+        "Reversible -> Advisory"
+    );
+    assert_eq!(
+        ApprovalRequirement::from(Reversibility::PartiallyReversible),
+        ApprovalRequirement::Required,
+        "PartiallyReversible -> Required"
+    );
+    assert_eq!(
+        ApprovalRequirement::from(Reversibility::Irreversible),
+        ApprovalRequirement::Mandatory,
+        "Irreversible -> Mandatory"
+    );
+}
+
+#[test]
+fn approval_requirement_display() {
+    assert_eq!(
+        ApprovalRequirement::None.to_string(),
+        "none",
+        "None display"
+    );
+    assert_eq!(
+        ApprovalRequirement::Advisory.to_string(),
+        "advisory",
+        "Advisory display"
+    );
+    assert_eq!(
+        ApprovalRequirement::Required.to_string(),
+        "required",
+        "Required display"
+    );
+    assert_eq!(
+        ApprovalRequirement::Mandatory.to_string(),
+        "mandatory",
+        "Mandatory display"
+    );
+}
+
+#[test]
+fn tool_call_metadata_serde_roundtrip() {
+    let meta = ToolCallMetadata {
+        reversibility: Reversibility::PartiallyReversible,
+        approval: ApprovalRequirement::Required,
+        dry_run: true,
+    };
+    let json = serde_json::to_string(&meta).expect("serialize");
+    let back: ToolCallMetadata = serde_json::from_str(&json).expect("deserialize");
+    assert_eq!(
+        back.reversibility,
+        Reversibility::PartiallyReversible,
+        "reversibility roundtrip"
+    );
+    assert_eq!(
+        back.approval,
+        ApprovalRequirement::Required,
+        "approval roundtrip"
+    );
+    assert!(back.dry_run, "dry_run roundtrip");
+}
+
+#[test]
+fn tool_def_includes_reversibility_in_serde() {
+    let def = ToolDef {
+        name: ToolName::new("test").expect("valid"),
+        description: "test".to_owned(),
+        extended_description: None,
+        input_schema: InputSchema {
+            properties: IndexMap::new(),
+            required: vec![],
+        },
+        category: ToolCategory::Workspace,
+        reversibility: Reversibility::Reversible,
+        auto_activate: false,
+    };
+    let json = serde_json::to_string(&def).expect("serialize");
+    let back: ToolDef = serde_json::from_str(&json).expect("deserialize");
+    assert_eq!(
+        back.reversibility,
+        Reversibility::Reversible,
+        "reversibility should survive serde roundtrip"
     );
 }

--- a/crates/organon/tests/proptest_registry.rs
+++ b/crates/organon/tests/proptest_registry.rs
@@ -17,7 +17,7 @@
 use aletheia_koina::id::ToolName;
 use aletheia_organon::registry::ToolRegistry;
 use aletheia_organon::testing::{MockToolExecutor, make_test_context, make_tool_input};
-use aletheia_organon::types::{InputSchema, ToolCategory, ToolDef};
+use aletheia_organon::types::{InputSchema, Reversibility, ToolCategory, ToolDef};
 use indexmap::IndexMap;
 use proptest::prelude::*;
 
@@ -36,6 +36,7 @@ fn make_def(name: &str) -> ToolDef {
             required: vec![],
         },
         category: ToolCategory::System,
+        reversibility: Reversibility::Irreversible,
         auto_activate: false,
     }
 }

--- a/crates/organon/tests/spec_validation.rs
+++ b/crates/organon/tests/spec_validation.rs
@@ -12,7 +12,9 @@
 
 use aletheia_koina::id::ToolName;
 use aletheia_organon::testing::{MockToolExecutor, ToolExecutorSpec, make_test_context};
-use aletheia_organon::types::{InputSchema, PropertyDef, PropertyType, ToolCategory, ToolDef};
+use aletheia_organon::types::{
+    InputSchema, PropertyDef, PropertyType, Reversibility, ToolCategory, ToolDef,
+};
 use indexmap::IndexMap;
 
 fn echo_def() -> ToolDef {
@@ -25,6 +27,7 @@ fn echo_def() -> ToolDef {
             required: vec![],
         },
         category: ToolCategory::System,
+        reversibility: Reversibility::Irreversible,
         auto_activate: false,
     }
 }
@@ -49,6 +52,7 @@ fn note_def() -> ToolDef {
             required: vec!["text".to_owned()],
         },
         category: ToolCategory::Memory,
+        reversibility: Reversibility::Irreversible,
         auto_activate: false,
     }
 }

--- a/crates/thesauros/src/tools/mod.rs
+++ b/crates/thesauros/src/tools/mod.rs
@@ -255,6 +255,7 @@ fn prepare_tool(
         extended_description: None,
         input_schema,
         category: ToolCategory::Domain,
+        reversibility: aletheia_organon::types::Reversibility::Irreversible,
         auto_activate: false,
     };
 


### PR DESCRIPTION
## Summary

- Add `Reversibility` enum (`FullyReversible`, `Reversible`, `PartiallyReversible`, `Irreversible`) to `ToolDef` and tag all 30+ built-in tools with appropriate levels
- Derive `ApprovalRequirement` from reversibility for the approval system; add `ToolCallMetadata` for session-log enrichment and dry-run support
- Implement custom slash commands loaded from YAML files via oikos cascade with multi-step tool chains, confirmation prompts, and reversibility overrides

Closes #1877, closes #1876

## Changes

### Reversibility tracking (`#1877`)
- `Reversibility` enum with `Display`, `Default` (Irreversible), serde roundtrip
- `ApprovalRequirement` enum derived via `From<Reversibility>` mapping
- `ToolCallMetadata` struct for session log enrichment
- `reversibility` field on `ToolDef`, all 30+ builtins tagged
- Registry methods: `reversibility()`, `approval_requirement()`, `call_metadata()`
- Reversibility + approval added to `tool_execute` tracing span

### Custom slash commands (`#1876`)
- `CustomCommandDef` with name, description, steps, confirm, reversibility override
- `effective_reversibility()` derives from worst step when no override set
- YAML parsing via `serde_yaml` with validation (non-empty name, steps, tool names)
- `load_commands_from_dir()` for directory scanning
- `load_commands_cascade()` for oikos three-tier hierarchy resolution
- `validate_step_tools()` for `ToolName` syntax checking

## Test plan

- [x] 12+ new unit tests for `Reversibility`, `ApprovalRequirement`, `ToolCallMetadata` serde/display
- [x] 15+ new unit tests for custom command YAML parsing, validation, cascade loading
- [x] All existing organon tests pass (361 total)
- [x] `cargo clippy -p aletheia-organon --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo test --workspace --tests` passes (all crates)