### PR TITLE
fix(test): add test-core/test-full feature tiers (#1895)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -49,6 +49,8 @@ jobs:
             args: "-p aletheia --features embed-candle"
           - name: migrate-qdrant
             args: "-p aletheia --features migrate-qdrant"
+          - name: test-core
+            args: "--workspace --features test-core"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable

--- a/.github/workflows/test-sharded.yml
+++ b/.github/workflows/test-sharded.yml
@@ -122,6 +122,7 @@ jobs:
         run: |
           cargo nextest run \
             --workspace \
+            --features test-core \
             --partition "hash:${SHARD}/4"
 
   # WHY: On pull requests, only test the crates that were changed plus their
@@ -155,7 +156,7 @@ jobs:
             exit 0
           fi
           pkg_flags=$(echo "$PACKAGES" | tr ' ' '\n' | grep -v '^$' | xargs -I{} printf -- '--package %s ' {})
-          cargo nextest run $pkg_flags
+          cargo nextest run --features test-core $pkg_flags
 
   # WHY: Gate merges on a single required status check regardless of whether
   # the full sharded suite or the filtered subset ran. Simpler to configure in

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,10 +22,14 @@ Shell: [standards/SHELL.md](standards/SHELL.md)
 ```bash
 cargo build                            # Debug build
 cargo build --release                  # Release (LTO, stripped)
-cargo test --workspace                 # All tests
+cargo test --workspace                 # Default tests (~4,800)
+cargo test --workspace --features test-core  # + storage/engine tests
+cargo test --workspace --features test-full  # + ML embedding tests
 cargo test -p aletheia-hermeneus       # Single crate
 cargo clippy --workspace               # Lint (zero warnings)
 ```
+
+Test tiers: [docs/test-tiers.md](docs/test-tiers.md)
 
 ## Key patterns
 

--- a/crates/agora/Cargo.toml
+++ b/crates/agora/Cargo.toml
@@ -10,6 +10,10 @@ rust-version.workspace = true
 [lints]
 workspace = true
 
+[features]
+test-core = []
+test-full = []
+
 [dependencies]
 aletheia-koina = { path = "../koina" }
 aletheia-taxis = { path = "../taxis" }

--- a/crates/aletheia/Cargo.toml
+++ b/crates/aletheia/Cargo.toml
@@ -29,6 +29,9 @@ embed-candle = ["aletheia-mneme/embed-candle"]
 migrate-qdrant = ["dep:qdrant-client", "aletheia-mneme/mneme-engine", "aletheia-mneme/storage-fjall"]
 tls = ["aletheia-pylon/tls"]
 tui = ["dep:theatron-tui"]
+# Test tiers (see docs/test-tiers.md)
+test-core = ["aletheia-mneme/test-core", "aletheia-nous/test-core"]
+test-full = ["test-core", "aletheia-mneme/test-full"]
 
 [dependencies]
 aletheia-diaporeia = { path = "../diaporeia", optional = true }

--- a/crates/aletheia/src/migrate_memory.rs
+++ b/crates/aletheia/src/migrate_memory.rs
@@ -288,7 +288,8 @@ fn import_fact(
 
     if let Ok(embedding) = embedder.embed(&record.content) {
         let chunk = EmbeddedChunk {
-            id: EmbeddingId::new(&format!("emb-{fact_id}")).expect("emb- prefix + ULID is always valid"),
+            id: EmbeddingId::new(&format!("emb-{fact_id}"))
+                .expect("emb- prefix + ULID is always valid"),
             content: record.content.clone(),
             source_type: "fact".to_owned(),
             source_id: fact_id,

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -10,6 +10,10 @@ rust-version.workspace = true
 [lints]
 workspace = true
 
+[features]
+test-core = []
+test-full = []
+
 [dependencies]
 aletheia-koina = { path = "../koina" }
 # Required by the `cron` crate API for schedule parsing

--- a/crates/dianoia/Cargo.toml
+++ b/crates/dianoia/Cargo.toml
@@ -10,6 +10,10 @@ rust-version.workspace = true
 [lints]
 workspace = true
 
+[features]
+test-core = []
+test-full = []
+
 [dependencies]
 jiff = { workspace = true, features = ["serde"] }
 serde = { workspace = true }

--- a/crates/diaporeia/Cargo.toml
+++ b/crates/diaporeia/Cargo.toml
@@ -10,6 +10,10 @@ rust-version.workspace = true
 [lints]
 workspace = true
 
+[features]
+test-core = []
+test-full = []
+
 [dependencies]
 # MCP SDK — pin exact per TECHNOLOGY.md policy
 rmcp = { version = "=1.2.0", features = ["server", "macros", "transport-io", "transport-streamable-http-server"] }

--- a/crates/eidos/Cargo.toml
+++ b/crates/eidos/Cargo.toml
@@ -10,6 +10,10 @@ rust-version.workspace = true
 [lints]
 workspace = true
 
+[features]
+test-core = []
+test-full = []
+
 [dependencies]
 jiff = { workspace = true, features = ["serde"] }
 serde = { workspace = true }

--- a/crates/episteme/Cargo.toml
+++ b/crates/episteme/Cargo.toml
@@ -14,10 +14,15 @@ workspace = true
 default = ["graph-algo"]
 graph-algo = []
 test-support = []
-mneme-engine = ["dep:aletheia-krites", "dep:tokio", "aletheia-graphe/mneme-engine"]
+# WHY: graphe/sqlite is required because knowledge_portability.rs (gated on
+# mneme-engine) references aletheia_graphe::portability which lives behind sqlite.
+mneme-engine = ["dep:aletheia-krites", "dep:tokio", "aletheia-graphe/mneme-engine", "aletheia-graphe/sqlite"]
 storage-fjall = ["mneme-engine", "aletheia-krites/storage-fjall"]
 embed-candle = ["dep:candle-core", "dep:candle-nn", "dep:candle-transformers", "dep:tokenizers", "dep:hf-hub"]
 hnsw_rs = ["dep:hnsw_rs", "aletheia-graphe/hnsw_rs"]
+# Test tiers (see docs/test-tiers.md)
+test-core = ["mneme-engine"]
+test-full = ["test-core", "embed-candle"]
 
 [dependencies]
 aletheia-eidos = { path = "../eidos" }

--- a/crates/eval/Cargo.toml
+++ b/crates/eval/Cargo.toml
@@ -11,6 +11,10 @@ publish = false
 [lints]
 workspace = true
 
+[features]
+test-core = []
+test-full = []
+
 [dependencies]
 aletheia-koina = { path = "../koina" }
 reqwest = { workspace = true }

--- a/crates/graphe/Cargo.toml
+++ b/crates/graphe/Cargo.toml
@@ -16,6 +16,8 @@ sqlite = ["dep:rusqlite", "dep:sha2"]
 # WHY: gates error variants that reference tokio::task::JoinError; no runtime dep.
 mneme-engine = ["dep:tokio"]
 hnsw_rs = []
+test-core = []
+test-full = []
 
 [dependencies]
 aletheia-eidos = { path = "../eidos" }

--- a/crates/hermeneus/Cargo.toml
+++ b/crates/hermeneus/Cargo.toml
@@ -31,6 +31,8 @@ local-llm = []
 # Use `test-support` (preferred); `test-utils` kept for compatibility.
 test-utils = []
 test-support = ["test-utils"]
+test-core = []
+test-full = []
 
 [dev-dependencies]
 proptest = { workspace = true }

--- a/crates/integration-tests/Cargo.toml
+++ b/crates/integration-tests/Cargo.toml
@@ -15,6 +15,9 @@ default = ["sqlite-tests", "knowledge-store"]
 sqlite-tests = ["aletheia-mneme/sqlite"]
 engine-tests = ["aletheia-mneme/mneme-engine"]
 knowledge-store = ["aletheia-nous/knowledge-store", "aletheia-pylon/knowledge-store"]
+# Test tiers (see docs/test-tiers.md)
+test-core = ["engine-tests"]
+test-full = ["test-core"]
 
 [dev-dependencies]
 aletheia-dokimion = { path = "../eval" }

--- a/crates/integration-tests/tests/access_tracking.rs
+++ b/crates/integration-tests/tests/access_tracking.rs
@@ -1,11 +1,30 @@
 //! Integration tests for access tracking and knowledge graph data audit.
 #![cfg(feature = "engine-tests")]
+#![expect(clippy::expect_used, reason = "test assertions")]
+#![expect(
+    clippy::indexing_slicing,
+    reason = "test: vec indices valid after length assertions"
+)]
 
 use std::sync::Arc;
 
 use aletheia_mneme::embedding::{EmbeddingProvider, MockEmbeddingProvider};
-use aletheia_mneme::knowledge::{EmbeddedChunk, EpistemicTier, Fact, default_stability_hours};
+use aletheia_mneme::id::{EmbeddingId, FactId};
+use aletheia_mneme::knowledge::{
+    EmbeddedChunk, EpistemicTier, Fact, FactAccess, FactLifecycle, FactProvenance, FactTemporal,
+    default_stability_hours,
+};
 use aletheia_mneme::knowledge_store::{KnowledgeConfig, KnowledgeStore};
+
+const TS_2026: &str = "2026-01-01T00:00:00Z";
+fn far_future() -> jiff::Timestamp {
+    aletheia_mneme::knowledge::far_future()
+}
+const TS_RECORDED: &str = "2026-03-01T00:00:00Z";
+
+fn ts(s: &str) -> jiff::Timestamp {
+    s.parse().expect("valid timestamp")
+}
 
 fn open_store(dim: usize) -> Arc<KnowledgeStore> {
     KnowledgeStore::open_mem_with_config(KnowledgeConfig { dim }).expect("open_mem")
@@ -13,23 +32,31 @@ fn open_store(dim: usize) -> Arc<KnowledgeStore> {
 
 fn make_fact(id: &str, nous_id: &str, content: &str) -> Fact {
     Fact {
-        id: id.to_owned(),
+        id: FactId::new(id).expect("valid test id"),
         nous_id: nous_id.to_owned(),
         content: content.to_owned(),
-        confidence: 0.9,
-        tier: EpistemicTier::Inferred,
-        valid_from: "2026-01-01T00:00:00Z".to_owned(),
-        valid_to: "9999-12-31".to_owned(),
-        superseded_by: None,
-        source_session_id: Some("ses-test".to_owned()),
-        recorded_at: "2026-03-01T00:00:00Z".to_owned(),
-        access_count: 0,
-        last_accessed_at: String::new(),
-        stability_hours: 720.0,
         fact_type: "inference".to_owned(),
-        is_forgotten: false,
-        forgotten_at: None,
-        forget_reason: None,
+        temporal: FactTemporal {
+            valid_from: ts(TS_2026),
+            valid_to: far_future(),
+            recorded_at: ts(TS_RECORDED),
+        },
+        provenance: FactProvenance {
+            confidence: 0.9,
+            tier: EpistemicTier::Inferred,
+            source_session_id: Some("ses-test".to_owned()),
+            stability_hours: 720.0,
+        },
+        lifecycle: FactLifecycle {
+            superseded_by: None,
+            is_forgotten: false,
+            forgotten_at: None,
+            forget_reason: None,
+        },
+        access: FactAccess {
+            access_count: 0,
+            last_accessed_at: None,
+        },
     }
 }
 
@@ -44,35 +71,34 @@ fn insert_fact_then_search_increments_access_count() {
 
     let embedding = provider.embed(&fact.content).expect("embed");
     let chunk = EmbeddedChunk {
-        id: "emb-track-1".to_owned(),
+        id: EmbeddingId::new("emb-track-1").expect("valid test id"),
         content: fact.content.clone(),
         source_type: "fact".to_owned(),
         source_id: "f-track-1".to_owned(),
         nous_id: "syn".to_owned(),
         embedding: embedding.clone(),
-        created_at: "2026-03-01T00:00:00Z".to_owned(),
+        created_at: ts(TS_RECORDED),
     };
     store.insert_embedding(&chunk).expect("insert embedding");
 
-    // Search with the same vector: should find our fact
+    // WHY: search_vectors triggers access tracking on matched source_ids
     let results = store.search_vectors(embedding, 5, 20).expect("search");
     assert!(!results.is_empty(), "search must return results");
     assert_eq!(results[0].source_id, "f-track-1");
 
-    // Verify access_count was incremented
     let facts = store
         .query_facts("syn", "2026-06-01T00:00:00Z", 10)
         .expect("query facts");
     let tracked = facts
         .iter()
-        .find(|f| f.id == "f-track-1")
+        .find(|f| f.id.as_str() == "f-track-1")
         .expect("find fact");
     assert_eq!(
-        tracked.access_count, 1,
+        tracked.access.access_count, 1,
         "access_count should be 1 after one search"
     );
     assert!(
-        !tracked.last_accessed_at.is_empty(),
+        tracked.access.last_accessed_at.is_some(),
         "last_accessed_at should be set"
     );
 }
@@ -88,17 +114,16 @@ fn triple_search_yields_access_count_3() {
 
     let embedding = provider.embed(&fact.content).expect("embed");
     let chunk = EmbeddedChunk {
-        id: "emb-triple".to_owned(),
+        id: EmbeddingId::new("emb-triple").expect("valid test id"),
         content: fact.content.clone(),
         source_type: "fact".to_owned(),
         source_id: "f-triple".to_owned(),
         nous_id: "syn".to_owned(),
         embedding: embedding.clone(),
-        created_at: "2026-03-01T00:00:00Z".to_owned(),
+        created_at: ts(TS_RECORDED),
     };
     store.insert_embedding(&chunk).expect("insert embedding");
 
-    // Search 3 times
     for _ in 0..3 {
         store
             .search_vectors(embedding.clone(), 5, 20)
@@ -110,10 +135,10 @@ fn triple_search_yields_access_count_3() {
         .expect("query facts");
     let tracked = facts
         .iter()
-        .find(|f| f.id == "f-triple")
+        .find(|f| f.id.as_str() == "f-triple")
         .expect("find fact");
     assert_eq!(
-        tracked.access_count, 3,
+        tracked.access.access_count, 3,
         "access_count should be 3 after three searches"
     );
 }
@@ -128,14 +153,15 @@ fn increment_access_empty_ids_is_noop() {
 
 #[test]
 fn default_stability_by_fact_type() {
-    assert!((default_stability_hours("identity") - 17520.0).abs() < f64::EPSILON);
-    assert!((default_stability_hours("preference") - 8760.0).abs() < f64::EPSILON);
-    assert!((default_stability_hours("relationship") - 4380.0).abs() < f64::EPSILON);
-    assert!((default_stability_hours("skill") - 2190.0).abs() < f64::EPSILON);
+    assert!((default_stability_hours("identity") - 17_520.0).abs() < f64::EPSILON);
+    assert!((default_stability_hours("preference") - 8_760.0).abs() < f64::EPSILON);
+    assert!((default_stability_hours("skill") - 4_380.0).abs() < f64::EPSILON);
+    assert!((default_stability_hours("relationship") - 2_190.0).abs() < f64::EPSILON);
     assert!((default_stability_hours("event") - 720.0).abs() < f64::EPSILON);
     assert!((default_stability_hours("task") - 168.0).abs() < f64::EPSILON);
-    assert!((default_stability_hours("inference") - 720.0).abs() < f64::EPSILON);
-    assert!((default_stability_hours("unknown_type") - 720.0).abs() < f64::EPSILON);
+    assert!((default_stability_hours("audit") - 720.0).abs() < f64::EPSILON);
+    // WHY: unknown types fall through to Observation (72 hours)
+    assert!((default_stability_hours("unknown_type") - 72.0).abs() < f64::EPSILON);
 }
 
 #[test]
@@ -143,7 +169,6 @@ fn default_stability_by_fact_type() {
 fn knowledge_graph_data_audit() {
     let store = open_store(4);
 
-    // Query facts, entities, relationships
     let facts = store
         .query_facts("", "9999-12-31", 1000)
         .unwrap_or_default();
@@ -169,38 +194,54 @@ fn knowledge_graph_data_audit() {
     println!("Entities:      {entity_rows}");
     println!("Relationships: {rel_rows}");
 
-    // Fact tier distribution
     let verified = facts
         .iter()
-        .filter(|f| f.tier == EpistemicTier::Verified)
+        .filter(|f| f.provenance.tier == EpistemicTier::Verified)
         .count();
     let inferred = facts
         .iter()
-        .filter(|f| f.tier == EpistemicTier::Inferred)
+        .filter(|f| f.provenance.tier == EpistemicTier::Inferred)
         .count();
     let assumed = facts
         .iter()
-        .filter(|f| f.tier == EpistemicTier::Assumed)
+        .filter(|f| f.provenance.tier == EpistemicTier::Assumed)
         .count();
     println!("\nFact tiers:");
     println!("  Verified:  {verified}");
     println!("  Inferred:  {inferred}");
     println!("  Assumed:   {assumed}");
 
-    // Access tracking stats
-    let accessed = facts.iter().filter(|f| f.access_count > 0).count();
-    let max_access = facts.iter().map(|f| f.access_count).max().unwrap_or(0);
+    let accessed = facts.iter().filter(|f| f.access.access_count > 0).count();
+    let max_access = facts
+        .iter()
+        .map(|f| f.access.access_count)
+        .max()
+        .unwrap_or(0);
     let avg_access = if facts.is_empty() {
         0.0
     } else {
-        facts.iter().map(|f| f64::from(f.access_count)).sum::<f64>() / facts.len() as f64
+        #[expect(
+            clippy::cast_precision_loss,
+            clippy::as_conversions,
+            reason = "test: small counts"
+        )]
+        let avg = facts
+            .iter()
+            .map(|f| f64::from(f.access.access_count))
+            .sum::<f64>()
+            / facts.len() as f64;
+        avg
     };
     println!("\nAccess tracking:");
     println!("  Facts accessed:    {accessed}/{}", facts.len());
     println!("  Max access count:  {max_access}");
     println!("  Avg access count:  {avg_access:.2}");
 
-    // Graph density
+    #[expect(
+        clippy::cast_precision_loss,
+        clippy::as_conversions,
+        reason = "test: small counts"
+    )]
     let density = if entity_rows > 1 {
         rel_rows as f64 / (entity_rows as f64 * (entity_rows as f64 - 1.0))
     } else {
@@ -208,15 +249,19 @@ fn knowledge_graph_data_audit() {
     };
     println!("\nGraph density: {density:.4}");
 
-    // Phase F viability
     println!("\n--- Phase F Viability ---");
     if facts.is_empty() {
         println!("No data yet. Phase F has nothing to calibrate against.");
     } else {
+        #[expect(
+            clippy::cast_precision_loss,
+            clippy::as_conversions,
+            reason = "test: small counts"
+        )]
+        let pct = accessed as f64 / facts.len() as f64 * 100.0;
         println!(
-            "Facts with access data: {accessed}/{} ({:.0}%)",
+            "Facts with access data: {accessed}/{} ({pct:.0}%)",
             facts.len(),
-            accessed as f64 / facts.len() as f64 * 100.0
         );
         if accessed > 10 {
             println!("Sufficient access data for initial FSRS calibration.");

--- a/crates/integration-tests/tests/knowledge_engine.rs
+++ b/crates/integration-tests/tests/knowledge_engine.rs
@@ -1,31 +1,99 @@
 //! Integration tests for `KnowledgeStore`: fact round-trip (TEST-02) and HNSW vector search (TEST-03).
 #![cfg(feature = "engine-tests")]
+#![expect(clippy::expect_used, reason = "test assertions")]
+#![expect(
+    clippy::indexing_slicing,
+    reason = "test: vec indices valid after length assertions"
+)]
 
 use std::collections::BTreeMap;
 
 use aletheia_mneme::embedding::{EmbeddingProvider, MockEmbeddingProvider};
-use aletheia_mneme::knowledge::{EmbeddedChunk, Entity, EpistemicTier, Fact, Relationship};
+use aletheia_mneme::id::{EmbeddingId, EntityId, FactId};
+use aletheia_mneme::knowledge::{
+    EmbeddedChunk, Entity, EpistemicTier, Fact, FactAccess, FactLifecycle, FactProvenance,
+    FactTemporal, Relationship,
+};
 use aletheia_mneme::knowledge_store::{HybridQuery, KnowledgeConfig, KnowledgeStore};
+
+const TS_2026: &str = "2026-01-01T00:00:00Z";
+// WHY: jiff::Timestamp cannot parse "9999-12-31" from a string; use the
+// programmatic constructor from eidos instead.
+fn far_future() -> jiff::Timestamp {
+    aletheia_mneme::knowledge::far_future()
+}
+const TS_RECORDED: &str = "2026-03-01T00:00:00Z";
+
+fn ts(s: &str) -> jiff::Timestamp {
+    s.parse().expect("valid timestamp")
+}
 
 fn make_fact(id: &str, nous_id: &str, content: &str, confidence: f64, tier: EpistemicTier) -> Fact {
     Fact {
-        id: id.to_owned(),
+        id: FactId::new(id).expect("valid test id"),
         nous_id: nous_id.to_owned(),
         content: content.to_owned(),
-        confidence,
-        tier,
-        valid_from: "2026-01-01".to_owned(),
-        valid_to: "9999-12-31".to_owned(),
-        superseded_by: None,
-        source_session_id: None,
-        recorded_at: "2026-03-01T00:00:00Z".to_owned(),
-        access_count: 0,
-        last_accessed_at: String::new(),
-        stability_hours: 720.0,
         fact_type: String::new(),
-        is_forgotten: false,
-        forgotten_at: None,
-        forget_reason: None,
+        temporal: FactTemporal {
+            valid_from: ts(TS_2026),
+            valid_to: far_future(),
+            recorded_at: ts(TS_RECORDED),
+        },
+        provenance: FactProvenance {
+            confidence,
+            tier,
+            source_session_id: None,
+            stability_hours: 720.0,
+        },
+        lifecycle: FactLifecycle {
+            superseded_by: None,
+            is_forgotten: false,
+            forgotten_at: None,
+            forget_reason: None,
+        },
+        access: FactAccess {
+            access_count: 0,
+            last_accessed_at: None,
+        },
+    }
+}
+
+fn make_entity(id: &str, name: &str, entity_type: &str) -> Entity {
+    Entity {
+        id: EntityId::new(id).expect("valid test id"),
+        name: name.to_owned(),
+        entity_type: entity_type.to_owned(),
+        aliases: vec![],
+        created_at: ts(TS_RECORDED),
+        updated_at: ts(TS_RECORDED),
+    }
+}
+
+fn make_relationship(src: &str, dst: &str, relation: &str, weight: f64) -> Relationship {
+    Relationship {
+        src: EntityId::new(src).expect("valid test id"),
+        dst: EntityId::new(dst).expect("valid test id"),
+        relation: relation.to_owned(),
+        weight,
+        created_at: ts(TS_RECORDED),
+    }
+}
+
+fn make_chunk(
+    id: &str,
+    content: &str,
+    source_id: &str,
+    nous_id: &str,
+    embedding: Vec<f32>,
+) -> EmbeddedChunk {
+    EmbeddedChunk {
+        id: EmbeddingId::new(id).expect("valid test id"),
+        content: content.to_owned(),
+        source_type: "test".to_owned(),
+        source_id: source_id.to_owned(),
+        nous_id: nous_id.to_owned(),
+        embedding,
+        created_at: ts(TS_RECORDED),
     }
 }
 
@@ -35,36 +103,44 @@ fn fact_round_trip() {
     let store = KnowledgeStore::open_mem_with_config(KnowledgeConfig { dim: 4 }).expect("open_mem");
 
     let fact = Fact {
-        id: "f-1".to_owned(),
+        id: FactId::new("f-1").expect("valid test id"),
         nous_id: "syn".to_owned(),
         content: "The researcher published findings on memory consolidation".to_owned(),
-        confidence: 0.95,
-        tier: EpistemicTier::Verified,
-        valid_from: "2026-01-01".to_owned(),
-        valid_to: "9999-12-31".to_owned(),
-        superseded_by: None,
-        source_session_id: Some("ses-abc".to_owned()),
-        recorded_at: "2026-03-01T00:00:00Z".to_owned(),
-        access_count: 0,
-        last_accessed_at: String::new(),
-        stability_hours: 720.0,
         fact_type: String::new(),
-        is_forgotten: false,
-        forgotten_at: None,
-        forget_reason: None,
+        temporal: FactTemporal {
+            valid_from: ts(TS_2026),
+            valid_to: far_future(),
+            recorded_at: ts(TS_RECORDED),
+        },
+        provenance: FactProvenance {
+            confidence: 0.95,
+            tier: EpistemicTier::Verified,
+            source_session_id: Some("ses-abc".to_owned()),
+            stability_hours: 720.0,
+        },
+        lifecycle: FactLifecycle {
+            superseded_by: None,
+            is_forgotten: false,
+            forgotten_at: None,
+            forget_reason: None,
+        },
+        access: FactAccess {
+            access_count: 0,
+            last_accessed_at: None,
+        },
     };
 
     store.insert_fact(&fact).expect("insert");
     let results = store.query_facts("syn", "2026-06-01", 10).expect("query");
 
     assert_eq!(results.len(), 1);
-    assert_eq!(results[0].id, "f-1");
+    assert_eq!(results[0].id.as_str(), "f-1");
     assert_eq!(
         results[0].content,
         "The researcher published findings on memory consolidation"
     );
-    assert!((results[0].confidence - 0.95).abs() < f64::EPSILON);
-    assert_eq!(results[0].tier, EpistemicTier::Verified);
+    assert!((results[0].provenance.confidence - 0.95).abs() < f64::EPSILON);
+    assert_eq!(results[0].provenance.tier, EpistemicTier::Verified);
 }
 
 // TEST-03: HNSW kNN returns the known-similar vector before dissimilar ones.
@@ -72,8 +148,6 @@ fn fact_round_trip() {
 fn hnsw_vector_search() {
     let dim = 16;
     let store = KnowledgeStore::open_mem_with_config(KnowledgeConfig { dim }).expect("open_mem");
-    // MockEmbeddingProvider is deterministic by text input: satisfies the
-    // "deterministic random vectors" constraint from CONTEXT.md.
     let provider = MockEmbeddingProvider::new(dim);
 
     let texts = [
@@ -81,19 +155,16 @@ fn hnsw_vector_search() {
     ];
     for (i, text) in texts.iter().enumerate() {
         let embedding = provider.embed(text).expect("embed");
-        let chunk = EmbeddedChunk {
-            id: format!("emb-{i}"),
-            content: text.to_string(),
-            source_type: "test".to_owned(),
-            source_id: format!("src-{i}"),
-            nous_id: "syn".to_owned(),
+        let chunk = make_chunk(
+            &format!("emb-{i}"),
+            text,
+            &format!("src-{i}"),
+            "syn",
             embedding,
-            created_at: "2026-03-01T00:00:00Z".to_owned(),
-        };
+        );
         store.insert_embedding(&chunk).expect("insert embedding");
     }
 
-    // Query with the "apple" vector: should find "apple" as nearest neighbor.
     let query_vec = provider.embed("apple").expect("embed query");
     let results = store.search_vectors(query_vec, 3, 20).expect("search");
 
@@ -103,7 +174,6 @@ fn hnsw_vector_search() {
         "nearest neighbor should be the exact match"
     );
     assert_eq!(results[0].source_type, "test");
-    // Cosine distance to identical vector should be ~0.
     assert!(
         results[0].distance < 0.01,
         "self-distance should be near zero, got {}",
@@ -116,7 +186,7 @@ fn hnsw_vector_search() {
 fn schema_version_queryable() {
     let store = KnowledgeStore::open_mem_with_config(KnowledgeConfig { dim: 4 }).expect("open_mem");
     let version = store.schema_version().expect("version");
-    assert_eq!(version, 3);
+    assert_eq!(version, 6);
 }
 
 // Verify ordering of multiple facts by confidence (descending).
@@ -137,10 +207,9 @@ fn multiple_facts_ordered_by_confidence() {
 
     let results = store.query_facts("syn", "2026-06-01", 10).expect("query");
     assert_eq!(results.len(), 3);
-    // FULL_CURRENT_FACTS orders by -confidence
-    assert!((results[0].confidence - 0.9).abs() < f64::EPSILON);
-    assert!((results[1].confidence - 0.7).abs() < f64::EPSILON);
-    assert!((results[2].confidence - 0.5).abs() < f64::EPSILON);
+    assert!((results[0].provenance.confidence - 0.9).abs() < f64::EPSILON);
+    assert!((results[1].provenance.confidence - 0.7).abs() < f64::EPSILON);
+    assert!((results[2].provenance.confidence - 0.5).abs() < f64::EPSILON);
 }
 
 // INTG-04: spawn_blocking async wrappers work from #[tokio::test] context.
@@ -148,25 +217,13 @@ fn multiple_facts_ordered_by_confidence() {
 async fn async_spawn_blocking_wrapper() {
     let store = KnowledgeStore::open_mem_with_config(KnowledgeConfig { dim: 4 }).expect("open_mem");
 
-    let fact = Fact {
-        id: "f-async".to_owned(),
-        nous_id: "syn".to_owned(),
-        content: "async test fact".to_owned(),
-        confidence: 0.8,
-        tier: EpistemicTier::Assumed,
-        valid_from: "2026-01-01".to_owned(),
-        valid_to: "9999-12-31".to_owned(),
-        superseded_by: None,
-        source_session_id: None,
-        recorded_at: "2026-03-01T00:00:00Z".to_owned(),
-        access_count: 0,
-        last_accessed_at: String::new(),
-        stability_hours: 720.0,
-        fact_type: String::new(),
-        is_forgotten: false,
-        forgotten_at: None,
-        forget_reason: None,
-    };
+    let fact = make_fact(
+        "f-async",
+        "syn",
+        "async test fact",
+        0.8,
+        EpistemicTier::Assumed,
+    );
 
     store.insert_fact_async(fact).await.expect("async insert");
     let results = store
@@ -186,7 +243,6 @@ fn raw_query_escape_hatch() {
     let rows = store
         .run_query("::relations", BTreeMap::new())
         .expect("relations");
-    // Should have at least: facts, entities, relationships, embeddings, _schema_version
     assert!(
         rows.rows.len() >= 5,
         "expected at least 5 relations, got {}",
@@ -200,7 +256,6 @@ fn hybrid_retrieval_end_to_end() {
     let dim = 8;
     let store = KnowledgeStore::open_mem_with_config(KnowledgeConfig { dim }).expect("open_mem");
 
-    // Insert 5 facts with distinct topics.
     let facts = [
         ("fact-1", "Rust is a systems programming language", 0.9f64),
         ("fact-2", "Python is used for machine learning", 0.8),
@@ -209,33 +264,13 @@ fn hybrid_retrieval_end_to_end() {
         ("fact-5", "Rust async runtime uses Tokio", 0.75),
     ];
     for (id, content, confidence) in &facts {
-        let fact = Fact {
-            id: id.to_string(),
-            nous_id: "test".to_string(),
-            content: content.to_string(),
-            confidence: *confidence,
-            tier: EpistemicTier::Inferred,
-            valid_from: "2026-01-01".to_owned(),
-            valid_to: "9999-12-31".to_owned(),
-            superseded_by: None,
-            source_session_id: None,
-            recorded_at: "2026-03-01T00:00:00Z".to_owned(),
-            access_count: 0,
-            last_accessed_at: String::new(),
-            stability_hours: 720.0,
-            fact_type: String::new(),
-            is_forgotten: false,
-            forgotten_at: None,
-            forget_reason: None,
-        };
+        let fact = make_fact(id, "test", content, *confidence, EpistemicTier::Inferred);
         store.insert_fact(&fact).expect("insert fact");
     }
 
-    // Insert 5 embeddings: Rust facts get a similar vector cluster.
-    // fact-1, fact-3, fact-5: Rust-related [0.9, 0.1, ...]; fact-2, fact-4: other [0.1, 0.9, ...]
     let rust_vec: Vec<f32> = vec![0.9, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1];
     let other_vec: Vec<f32> = vec![0.1, 0.9, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1];
-    let embeddings = [
+    let embeddings: Vec<(&str, Vec<f32>)> = vec![
         ("fact-1", rust_vec.clone()),
         ("fact-2", other_vec.clone()),
         ("fact-3", {
@@ -251,61 +286,32 @@ fn hybrid_retrieval_end_to_end() {
         }),
     ];
     for (id, vec) in &embeddings {
-        let chunk = EmbeddedChunk {
-            id: id.to_string(),
-            content: id.to_string(),
-            source_type: "fact".to_owned(),
-            source_id: id.to_string(),
-            nous_id: "test".to_owned(),
-            embedding: vec.clone(),
-            created_at: "2026-03-01T00:00:00Z".to_owned(),
-        };
+        let chunk = make_chunk(id, id, id, "test", vec.clone());
         store.insert_embedding(&chunk).expect("insert embedding");
     }
 
-    // Insert entities and relationships for graph signal.
     for (id, name) in [
         ("e-rust", "Rust"),
         ("e-python", "Python"),
         ("e-tokio", "Tokio"),
     ] {
-        let entity = Entity {
-            id: id.to_owned(),
-            name: name.to_owned(),
-            entity_type: "technology".to_owned(),
-            aliases: vec![],
-            created_at: "2026-03-01T00:00:00Z".to_owned(),
-            updated_at: "2026-03-01T00:00:00Z".to_owned(),
-        };
-        store.insert_entity(&entity).expect("insert entity");
+        store
+            .insert_entity(&make_entity(id, name, "technology"))
+            .expect("insert entity");
     }
-    // e-rust -> e-tokio (Rust uses Tokio async runtime)
+
     store
-        .insert_relationship(&Relationship {
-            src: "e-rust".to_owned(),
-            dst: "e-tokio".to_owned(),
-            relation: "uses".to_owned(),
-            weight: 0.8,
-            created_at: "2026-03-01T00:00:00Z".to_owned(),
-        })
+        .insert_relationship(&make_relationship("e-rust", "e-tokio", "uses", 0.8))
         .expect("insert relationship");
-    // e-rust -> fact-1 (Rust fact)
     store
-        .insert_relationship(&Relationship {
-            src: "e-rust".to_owned(),
-            dst: "fact-1".to_owned(),
-            relation: "described_by".to_owned(),
-            weight: 0.9,
-            created_at: "2026-03-01T00:00:00Z".to_owned(),
-        })
+        .insert_relationship(&make_relationship("e-rust", "fact-1", "described_by", 0.9))
         .expect("insert relationship");
 
-    // Run hybrid search with seed entity e-rust.
     let results = store
         .search_hybrid(&HybridQuery {
             text: "Rust programming".to_owned(),
             embedding: vec![0.9, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1],
-            seed_entities: vec!["e-rust".to_owned()],
+            seed_entities: vec![EntityId::new("e-rust").expect("valid test id")],
             limit: 5,
             ef: 20,
         })
@@ -318,7 +324,6 @@ fn hybrid_retrieval_end_to_end() {
         results[0].rrf_score
     );
 
-    // Results must be ordered by rrf_score descending.
     for window in results.windows(2) {
         assert!(
             window[0].rrf_score >= window[1].rrf_score,
@@ -328,13 +333,11 @@ fn hybrid_retrieval_end_to_end() {
         );
     }
 
-    // At least one result must have a nonzero bm25_rank (text signal contributed).
     assert!(
         results.iter().any(|r| r.bm25_rank > 0),
         "at least one result must have nonzero bm25_rank"
     );
 
-    // At least one result must have a nonzero vec_rank (vector signal contributed).
     assert!(
         results.iter().any(|r| r.vec_rank > 0),
         "at least one result must have nonzero vec_rank"
@@ -347,37 +350,38 @@ fn hnsw_connectivity_after_delete_reinsert_cycles() {
     let dim = 8;
     let store = KnowledgeStore::open_mem_with_config(KnowledgeConfig { dim }).expect("open_mem");
 
-    // Generate 50 deterministic pseudo-random 8-dim vectors using different primes per dimension.
     let primes: [u64; 8] = [7, 11, 13, 17, 19, 23, 29, 31];
     let make_vec = |i: u64| -> Vec<f32> {
         primes
             .iter()
             .enumerate()
             .map(|(d, &p)| {
+                #[expect(clippy::as_conversions, reason = "test: d fits in u64")]
                 let offset = (d as u64 + 1) * 37;
-                ((i * p + offset) % 256) as f32 / 255.0
+                #[expect(
+                    clippy::cast_possible_truncation,
+                    clippy::as_conversions,
+                    reason = "test: modular arithmetic result fits in f32"
+                )]
+                let val = ((i * p + offset) % 256) as f32 / 255.0;
+                val
             })
             .collect()
     };
 
-    // Insert 50 embeddings.
     for i in 0u64..50 {
-        let chunk = EmbeddedChunk {
-            id: format!("chunk-{i}"),
-            content: format!("chunk-{i}"),
-            source_type: "test".to_owned(),
-            source_id: format!("test-{i}"),
-            nous_id: "test".to_owned(),
-            embedding: make_vec(i),
-            created_at: "2026-03-01T00:00:00Z".to_owned(),
-        };
+        let chunk = make_chunk(
+            &format!("chunk-{i}"),
+            &format!("chunk-{i}"),
+            &format!("test-{i}"),
+            "test",
+            make_vec(i),
+        );
         store.insert_embedding(&chunk).expect("insert embedding");
     }
 
-    // Use chunk-25 as query vector.
     let query_vec = make_vec(25);
 
-    // Baseline recall@10.
     let baseline = store
         .search_vectors(query_vec.clone(), 10, 40)
         .expect("baseline search");
@@ -389,9 +393,7 @@ fn hnsw_connectivity_after_delete_reinsert_cycles() {
         "baseline search must return results"
     );
 
-    // 5 delete+reinsert cycles for chunk-0..chunk-9.
     for _cycle in 0..5 {
-        // Delete chunk-0..chunk-9 via :rm
         for i in 0u64..10 {
             let delete_script = format!("?[id] <- [[\"chunk-{i}\"]] :rm embeddings {{ id }}");
             store
@@ -399,22 +401,18 @@ fn hnsw_connectivity_after_delete_reinsert_cycles() {
                 .expect("delete embedding");
         }
 
-        // Reinsert chunk-0..chunk-9 with same IDs and vectors.
         for i in 0u64..10 {
-            let chunk = EmbeddedChunk {
-                id: format!("chunk-{i}"),
-                content: format!("chunk-{i}"),
-                source_type: "test".to_owned(),
-                source_id: format!("test-{i}"),
-                nous_id: "test".to_owned(),
-                embedding: make_vec(i),
-                created_at: "2026-03-01T00:00:00Z".to_owned(),
-            };
+            let chunk = make_chunk(
+                &format!("chunk-{i}"),
+                &format!("chunk-{i}"),
+                &format!("test-{i}"),
+                "test",
+                make_vec(i),
+            );
             store.insert_embedding(&chunk).expect("reinsert embedding");
         }
     }
 
-    // Post-cycle recall@10.
     let after = store
         .search_vectors(query_vec.clone(), 10, 40)
         .expect("post-cycle search");
@@ -422,13 +420,16 @@ fn hnsw_connectivity_after_delete_reinsert_cycles() {
         after.iter().map(|r| r.source_id.clone()).collect();
 
     let intersection = baseline_ids.intersection(&after_ids).count();
+    #[expect(
+        clippy::cast_precision_loss,
+        clippy::as_conversions,
+        reason = "test: small counts"
+    )]
     let recall = intersection as f64 / baseline_ids.len() as f64;
 
     assert!(
         recall >= 0.95,
-        "HNSW recall after 5 delete+reinsert cycles must be >= 0.95, got {:.3} ({}/{} results matched)",
-        recall,
-        intersection,
+        "HNSW recall after 5 delete+reinsert cycles must be >= 0.95, got {recall:.3} ({intersection}/{} results matched)",
         baseline_ids.len()
     );
 }

--- a/crates/integration-tests/tests/knowledge_lifecycle.rs
+++ b/crates/integration-tests/tests/knowledge_lifecycle.rs
@@ -1,5 +1,10 @@
 //! Integration tests for knowledge lifecycle: correct, retract, and audit operations.
 #![cfg(feature = "engine-tests")]
+#![expect(clippy::expect_used, reason = "test assertions")]
+#![expect(
+    clippy::indexing_slicing,
+    reason = "test: vec indices valid after length assertions"
+)]
 
 use std::collections::BTreeMap;
 use std::sync::Arc;
@@ -7,28 +12,49 @@ use std::sync::Arc;
 use serde_json::Value as JsonValue;
 
 use aletheia_mneme::engine::DataValue;
-use aletheia_mneme::knowledge::{EpistemicTier, Fact};
+use aletheia_mneme::id::FactId;
+use aletheia_mneme::knowledge::{
+    EpistemicTier, Fact, FactAccess, FactLifecycle, FactProvenance, FactTemporal,
+};
 use aletheia_mneme::knowledge_store::{KnowledgeConfig, KnowledgeStore};
+
+const TS_2026: &str = "2026-01-01T00:00:00Z";
+fn far_future() -> jiff::Timestamp {
+    aletheia_mneme::knowledge::far_future()
+}
+const TS_RECORDED: &str = "2026-03-01T00:00:00Z";
+
+fn ts(s: &str) -> jiff::Timestamp {
+    s.parse().expect("valid timestamp")
+}
 
 fn make_fact(id: &str, nous_id: &str, content: &str, confidence: f64, tier: EpistemicTier) -> Fact {
     Fact {
-        id: id.to_owned(),
+        id: FactId::new(id).expect("valid test id"),
         nous_id: nous_id.to_owned(),
         content: content.to_owned(),
-        confidence,
-        tier,
-        valid_from: "2026-01-01T00:00:00Z".to_owned(),
-        valid_to: "9999-12-31".to_owned(),
-        superseded_by: None,
-        source_session_id: Some("ses-test".to_owned()),
-        recorded_at: "2026-03-01T00:00:00Z".to_owned(),
-        access_count: 0,
-        last_accessed_at: String::new(),
-        stability_hours: 720.0,
         fact_type: String::new(),
-        is_forgotten: false,
-        forgotten_at: None,
-        forget_reason: None,
+        temporal: FactTemporal {
+            valid_from: ts(TS_2026),
+            valid_to: far_future(),
+            recorded_at: ts(TS_RECORDED),
+        },
+        provenance: FactProvenance {
+            confidence,
+            tier,
+            source_session_id: Some("ses-test".to_owned()),
+            stability_hours: 720.0,
+        },
+        lifecycle: FactLifecycle {
+            superseded_by: None,
+            is_forgotten: false,
+            forgotten_at: None,
+            forget_reason: None,
+        },
+        access: FactAccess {
+            access_count: 0,
+            last_accessed_at: None,
+        },
     }
 }
 
@@ -66,23 +92,31 @@ fn correct_fact(
         .expect("correct: supersede old fact");
 
     let new_fact = Fact {
-        id: new_id.to_owned(),
+        id: FactId::new(new_id).expect("valid test id"),
         nous_id: nous_id.to_owned(),
         content: new_content.to_owned(),
-        confidence: 1.0,
-        tier: EpistemicTier::Verified,
-        valid_from: correction_time.to_owned(),
-        valid_to: "9999-12-31".to_owned(),
-        superseded_by: None,
-        source_session_id: None,
-        recorded_at: correction_time.to_owned(),
-        access_count: 0,
-        last_accessed_at: String::new(),
-        stability_hours: 720.0,
         fact_type: String::new(),
-        is_forgotten: false,
-        forgotten_at: None,
-        forget_reason: None,
+        temporal: FactTemporal {
+            valid_from: ts(correction_time),
+            valid_to: far_future(),
+            recorded_at: ts(correction_time),
+        },
+        provenance: FactProvenance {
+            confidence: 1.0,
+            tier: EpistemicTier::Verified,
+            source_session_id: None,
+            stability_hours: 720.0,
+        },
+        lifecycle: FactLifecycle {
+            superseded_by: None,
+            is_forgotten: false,
+            forgotten_at: None,
+            forget_reason: None,
+        },
+        access: FactAccess {
+            access_count: 0,
+            last_accessed_at: None,
+        },
     };
     store
         .insert_fact(&new_fact)
@@ -112,7 +146,6 @@ fn retract_fact(store: &Arc<KnowledgeStore>, fact_id: &str, retraction_time: &st
 }
 
 /// Raw Datalog audit query: returns ALL facts for a `nous_id` without temporal filtering.
-/// This is what `audit_facts` SHOULD do (the adapter currently filters out historical facts).
 fn audit_all_facts(store: &Arc<KnowledgeStore>, nous_id: &str) -> Vec<AuditRow> {
     let script = r"
         ?[id, content, confidence, tier, valid_from, valid_to, superseded_by, recorded_at,
@@ -224,6 +257,7 @@ fn open_store() -> Arc<KnowledgeStore> {
     KnowledgeStore::open_mem_with_config(KnowledgeConfig { dim: 4 }).expect("open_mem")
 }
 
+#[path = "knowledge_lifecycle/forget.rs"]
 mod forget;
-#[test]
+#[path = "knowledge_lifecycle/lifecycle.rs"]
 mod lifecycle;

--- a/crates/integration-tests/tests/knowledge_lifecycle/forget.rs
+++ b/crates/integration-tests/tests/knowledge_lifecycle/forget.rs
@@ -40,7 +40,7 @@ fn supersession_chain() {
     // Only v3 visible in query
     let results = store.query_facts(nous, query_time, 10).expect("query");
     assert_eq!(results.len(), 1, "only latest fact should be visible");
-    assert_eq!(results[0].id, "v3");
+    assert_eq!(results[0].id.as_str(), "v3");
     assert_eq!(results[0].content, "Project migrated fully to Rust");
 
     // Audit shows full chain
@@ -76,7 +76,7 @@ fn supersession_chain() {
         a_v2.valid_to, "2026-07-01T00:00:00Z",
         "v2 expired at v3 creation"
     );
-    assert_eq!(a_v3.valid_to, "9999-12-31", "v3 still current");
+    assert_eq!(a_v3.valid_to, "9999-01-01T00:00:00Z", "v3 still current");
 }
 
 // --- Forget lifecycle tests ---
@@ -104,9 +104,9 @@ fn forget_excludes_from_recall() {
         .expect("query before forget");
     assert_eq!(results.len(), 1);
 
-    // Forget it
+    let fid = FactId::new("f-forget").expect("valid test id");
     store
-        .forget_fact("f-forget", ForgetReason::Privacy)
+        .forget_fact(&fid, ForgetReason::Privacy)
         .expect("forget");
 
     // Not visible after forget
@@ -135,8 +135,9 @@ fn forget_preserves_for_audit() {
     );
     store.insert_fact(&fact).expect("insert");
 
+    let fid = FactId::new("f-audit").expect("valid test id");
     store
-        .forget_fact("f-audit", ForgetReason::Privacy)
+        .forget_fact(&fid, ForgetReason::Privacy)
         .expect("forget");
 
     let audit = audit_all_facts(&store, nous);
@@ -172,8 +173,9 @@ fn unforget_restores_to_search() {
     );
     store.insert_fact(&fact).expect("insert");
 
+    let fid = FactId::new("f-unforget").expect("valid test id");
     store
-        .forget_fact("f-unforget", ForgetReason::Outdated)
+        .forget_fact(&fid, ForgetReason::Outdated)
         .expect("forget");
 
     let results = store
@@ -181,13 +183,13 @@ fn unforget_restores_to_search() {
         .expect("query after forget");
     assert!(results.is_empty(), "should be excluded after forget");
 
-    store.unforget_fact("f-unforget").expect("unforget");
+    store.unforget_fact(&fid).expect("unforget");
 
     let results = store
         .query_facts(nous, query_time, 10)
         .expect("query after unforget");
     assert_eq!(results.len(), 1, "should be restored after unforget");
-    assert_eq!(results[0].id, "f-unforget");
+    assert_eq!(results[0].id.as_str(), "f-unforget");
 
     // Audit should show cleared forget metadata
     let audit = audit_all_facts(&store, nous);
@@ -228,7 +230,8 @@ fn forget_with_each_reason() {
             EpistemicTier::Verified,
         );
         store.insert_fact(&fact).expect("insert");
-        store.forget_fact(&id, *reason).expect("forget");
+        let fid = FactId::new(&id).expect("valid test id");
+        store.forget_fact(&fid, *reason).expect("forget");
     }
 
     let audit = audit_all_facts(&store, nous);
@@ -269,8 +272,9 @@ fn full_forget_lifecycle() {
     assert_eq!(results.len(), 1);
 
     // 3. Forget: privacy
+    let fid = FactId::new("f-lifecycle").expect("valid test id");
     store
-        .forget_fact("f-lifecycle", ForgetReason::Privacy)
+        .forget_fact(&fid, ForgetReason::Privacy)
         .expect("forget");
 
     // 4. Search: not found
@@ -286,7 +290,7 @@ fn full_forget_lifecycle() {
     assert_eq!(audit[0].forget_reason.as_deref(), Some("privacy"));
 
     // 6. Unforget
-    store.unforget_fact("f-lifecycle").expect("unforget");
+    store.unforget_fact(&fid).expect("unforget");
 
     // 7. Search: found again
     let results = store

--- a/crates/integration-tests/tests/knowledge_lifecycle/lifecycle.rs
+++ b/crates/integration-tests/tests/knowledge_lifecycle/lifecycle.rs
@@ -38,7 +38,7 @@ fn full_knowledge_lifecycle() {
         .query_facts(nous, query_time, 10)
         .expect("query after correct");
     assert_eq!(results.len(), 1, "only corrected fact should be visible");
-    assert_eq!(results[0].id, "f-2");
+    assert_eq!(results[0].id.as_str(), "f-2");
     assert_eq!(
         results[0].content,
         "Cody's favorite languages are Rust and TypeScript"
@@ -70,7 +70,10 @@ fn full_knowledge_lifecycle() {
         .iter()
         .find(|r| r.id == "f-2")
         .expect("corrected in audit");
-    assert_eq!(new.valid_to, "9999-12-31", "new fact should be current");
+    assert_eq!(
+        new.valid_to, "9999-01-01T00:00:00Z",
+        "new fact should be current"
+    );
     assert!(
         new.superseded_by.is_none(),
         "new fact should not be superseded"

--- a/crates/koina/Cargo.toml
+++ b/crates/koina/Cargo.toml
@@ -10,6 +10,10 @@ rust-version.workspace = true
 [lints]
 workspace = true
 
+[features]
+test-core = []
+test-full = []
+
 [dependencies]
 compact_str = { workspace = true }
 jiff = { workspace = true }

--- a/crates/krites/Cargo.toml
+++ b/crates/krites/Cargo.toml
@@ -14,6 +14,8 @@ workspace = true
 default = ["graph-algo"]
 graph-algo = []
 storage-fjall = ["dep:fjall"]
+test-core = []
+test-full = []
 
 [dependencies]
 aletheia-eidos = { path = "../eidos" }

--- a/crates/melete/Cargo.toml
+++ b/crates/melete/Cargo.toml
@@ -10,6 +10,10 @@ rust-version.workspace = true
 [lints]
 workspace = true
 
+[features]
+test-core = []
+test-full = []
+
 [dependencies]
 aletheia-hermeneus = { path = "../hermeneus" }
 serde = { workspace = true }

--- a/crates/mneme/Cargo.toml
+++ b/crates/mneme/Cargo.toml
@@ -21,6 +21,9 @@ embed-candle = ["aletheia-episteme/embed-candle"]
 mneme-engine = ["dep:aletheia-krites", "aletheia-graphe/mneme-engine", "aletheia-episteme/mneme-engine"]
 storage-fjall = ["mneme-engine", "aletheia-episteme/storage-fjall"]
 hnsw_rs = ["aletheia-episteme/hnsw_rs"]
+# Test tiers (see docs/test-tiers.md)
+test-core = ["mneme-engine"]
+test-full = ["test-core", "embed-candle"]
 
 [dependencies]
 aletheia-eidos = { path = "../eidos" }

--- a/crates/nous/Cargo.toml
+++ b/crates/nous/Cargo.toml
@@ -14,6 +14,9 @@ workspace = true
 knowledge-store = ["aletheia-mneme/mneme-engine"]
 # Gates mock search implementations and other test helpers. No test code in release binaries.
 test-support = ["aletheia-hermeneus/test-utils", "aletheia-organon/test-support"]
+# Test tiers (see docs/test-tiers.md)
+test-core = ["knowledge-store"]
+test-full = ["test-core"]
 
 [dependencies]
 aletheia-hermeneus = { path = "../hermeneus" }

--- a/crates/nous/src/skills.rs
+++ b/crates/nous/src/skills.rs
@@ -101,14 +101,14 @@ use std::sync::Arc;
 #[cfg(feature = "knowledge-store")]
 use tracing::{Instrument, warn};
 
-#[cfg(feature = "knowledge-store")]
+#[cfg(any(feature = "knowledge-store", test))]
 use aletheia_mneme::knowledge::Fact;
 #[cfg(feature = "knowledge-store")]
 use aletheia_mneme::knowledge_store::KnowledgeStore;
 
-#[cfg(feature = "knowledge-store")]
+#[cfg(any(feature = "knowledge-store", test))]
 use crate::bootstrap::{BootstrapSection, SectionPriority};
-#[cfg(feature = "knowledge-store")]
+#[cfg(any(feature = "knowledge-store", test))]
 use crate::budget::{CharEstimator, TokenEstimator as _};
 
 /// Default number of skills to inject per session.
@@ -244,7 +244,7 @@ impl SkillLoader {
 ///
 /// Tries to parse `content` as JSON [`SkillContent`] and format it as markdown.
 /// Falls back to the raw content string if parsing fails (e.g. plain-text skills).
-#[cfg(feature = "knowledge-store")]
+#[cfg(any(feature = "knowledge-store", test))]
 pub(crate) fn fact_to_section(fact: &Fact) -> BootstrapSection {
     let content = if let Ok(skill) =
         serde_json::from_str::<aletheia_mneme::skill::SkillContent>(&fact.content)
@@ -273,7 +273,7 @@ pub(crate) fn fact_to_section(fact: &Fact) -> BootstrapSection {
 /// - **confidence**: fact confidence from mneme (0.0–1.0).
 /// - **access**: normalised `access_count`, capped at 20 accesses.
 /// - **recency**: exponential decay with 30-day half-life since last access (or `valid_from`).
-#[cfg(feature = "knowledge-store")]
+#[cfg(any(feature = "knowledge-store", test))]
 pub(crate) fn rank_skills(candidates: Vec<Fact>) -> Vec<Fact> {
     let total = candidates.len();
     if total <= 1 {
@@ -468,7 +468,6 @@ mod tests {
         assert!(!md.contains("**Tools:**"));
     }
 
-    #[cfg(feature = "knowledge-store")]
     fn make_fact(id: &str, content: &str, confidence: f64, access_count: u32) -> Fact {
         use aletheia_mneme::knowledge::{FactAccess, FactLifecycle, FactProvenance, FactTemporal};
         let now = jiff::Timestamp::now();
@@ -501,7 +500,6 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "knowledge-store")]
     #[test]
     fn fact_to_section_uses_flexible_priority() {
         let skill_json = serde_json::to_string(&sample_skill()).unwrap();
@@ -510,7 +508,6 @@ mod tests {
         assert_eq!(section.priority, SectionPriority::Flexible);
     }
 
-    #[cfg(feature = "knowledge-store")]
     #[test]
     fn fact_to_section_is_truncatable() {
         let skill_json = serde_json::to_string(&sample_skill()).unwrap();
@@ -519,7 +516,6 @@ mod tests {
         assert!(section.truncatable);
     }
 
-    #[cfg(feature = "knowledge-store")]
     #[test]
     fn fact_to_section_parses_json_skill_content() {
         let skill_json = serde_json::to_string(&sample_skill()).unwrap();
@@ -528,7 +524,6 @@ mod tests {
         assert!(section.content.contains("rust-error-handling"));
     }
 
-    #[cfg(feature = "knowledge-store")]
     #[test]
     fn fact_to_section_falls_back_to_plain_text() {
         let fact = make_fact("fact-2", "plain text skill description", 0.8, 0);
@@ -536,7 +531,6 @@ mod tests {
         assert_eq!(section.content, "plain text skill description");
     }
 
-    #[cfg(feature = "knowledge-store")]
     #[test]
     fn fact_to_section_name_includes_fact_id() {
         let fact = make_fact("my-skill-id", "content", 0.7, 0);
@@ -548,7 +542,6 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "knowledge-store")]
     #[test]
     fn fact_to_section_has_nonzero_token_estimate() {
         let skill_json = serde_json::to_string(&sample_skill()).unwrap();
@@ -557,14 +550,12 @@ mod tests {
         assert!(section.tokens > 0);
     }
 
-    #[cfg(feature = "knowledge-store")]
     #[test]
     fn rank_skills_empty_returns_empty() {
         let ranked = rank_skills(vec![]);
         assert!(ranked.is_empty());
     }
 
-    #[cfg(feature = "knowledge-store")]
     #[test]
     fn rank_skills_single_passes_through() {
         let fact = make_fact("f1", "content", 0.9, 0);
@@ -573,7 +564,6 @@ mod tests {
         assert_eq!(ranked[0].id.as_str(), "f1");
     }
 
-    #[cfg(feature = "knowledge-store")]
     #[test]
     fn rank_skills_preserves_all_facts() {
         let facts: Vec<Fact> = (0..10)
@@ -583,7 +573,6 @@ mod tests {
         assert_eq!(ranked.len(), 10);
     }
 
-    #[cfg(feature = "knowledge-store")]
     #[test]
     fn rank_skills_high_confidence_can_overcome_lower_position() {
         let low_conf = make_fact("low", "content", 0.0, 0);
@@ -592,7 +581,6 @@ mod tests {
         assert_eq!(ranked[0].id.as_str(), "high");
     }
 
-    #[cfg(feature = "knowledge-store")]
     #[test]
     fn rank_skills_returns_sorted_order() {
         let facts: Vec<Fact> = vec![

--- a/crates/organon/Cargo.toml
+++ b/crates/organon/Cargo.toml
@@ -16,6 +16,8 @@ workspace = true
 computer-use = []
 # Gates MockToolExecutor, ToolExecutorSpec, and other test helpers. No test code in release binaries.
 test-support = ["aletheia-hermeneus/test-support"]
+test-core = []
+test-full = []
 
 [dependencies]
 aletheia-hermeneus = { path = "../hermeneus" }

--- a/crates/pylon/Cargo.toml
+++ b/crates/pylon/Cargo.toml
@@ -14,6 +14,8 @@ workspace = true
 default = []
 tls = ["dep:axum-server"]
 knowledge-store = ["aletheia-nous/knowledge-store"]
+test-core = []
+test-full = []
 
 [dependencies]
 # HTTP framework

--- a/crates/symbolon/Cargo.toml
+++ b/crates/symbolon/Cargo.toml
@@ -10,6 +10,10 @@ rust-version.workspace = true
 [lints]
 workspace = true
 
+[features]
+test-core = []
+test-full = []
+
 [dependencies]
 aletheia-koina = { path = "../koina" }
 argon2 = { version = "0.5", features = ["std"] }

--- a/crates/taxis/Cargo.toml
+++ b/crates/taxis/Cargo.toml
@@ -10,6 +10,10 @@ rust-version.workspace = true
 [lints]
 workspace = true
 
+[features]
+test-core = []
+test-full = []
+
 [dependencies]
 aletheia-koina = { path = "../koina" }
 base64 = { workspace = true }

--- a/crates/theatron/core/Cargo.toml
+++ b/crates/theatron/core/Cargo.toml
@@ -7,6 +7,10 @@ rust-version.workspace = true
 description = "Shared API client, types, SSE, and streaming infrastructure for Aletheia UIs"
 publish = false
 
+[features]
+test-core = []
+test-full = []
+
 [dependencies]
 aletheia-koina = { path = "../../koina" }
 bytes = { workspace = true }

--- a/crates/theatron/tui/Cargo.toml
+++ b/crates/theatron/tui/Cargo.toml
@@ -11,6 +11,10 @@ publish = false
 name = "aletheia-tui"
 path = "src/main.rs"
 
+[features]
+test-core = []
+test-full = []
+
 [dependencies]
 aletheia-koina = { path = "../../koina" }
 theatron-core = { path = "../core" }

--- a/crates/thesauros/Cargo.toml
+++ b/crates/thesauros/Cargo.toml
@@ -10,6 +10,10 @@ rust-version.workspace = true
 [lints]
 workspace = true
 
+[features]
+test-core = []
+test-full = []
+
 [dependencies]
 aletheia-koina = { path = "../koina" }
 aletheia-organon = { path = "../organon" }

--- a/docs/test-tiers.md
+++ b/docs/test-tiers.md
@@ -1,0 +1,55 @@
+# Test Tiers
+
+Aletheia uses Cargo feature flags to organize tests into tiers that balance
+coverage against build time and resource requirements.
+
+## Tiers
+
+| Tier | Feature flag | What it enables | Approx. tests |
+|------|-------------|-----------------|---------------|
+| **default** | *(none)* | Pure-logic unit tests, config validation, type invariants | ~4,800 |
+| **test-core** | `--features test-core` | Storage engine tests (Datalog, HNSW, knowledge store CRUD) | ~4,825 |
+| **test-full** | `--features test-full` | ML embedding tests (candle model loading, vector generation) | all |
+
+Each tier is a strict superset of the previous: `test-full` implies `test-core`,
+which adds to the default set.
+
+## Usage
+
+```bash
+# Developer workflow: fast feedback loop
+cargo test --workspace
+
+# CI minimum: includes storage/engine integration tests
+cargo test --workspace --features test-core
+
+# Full suite: everything including ML tests (needs ~16 GB RAM)
+cargo test --workspace --features test-full
+```
+
+## How it works
+
+Every crate in the workspace defines `test-core = [...]` and `test-full = [...]`
+features. Crates with no gated tests leave these empty. Crates with storage-
+dependent tests wire `test-core` to their engine feature (e.g.,
+`test-core = ["mneme-engine"]`). The root `aletheia` crate propagates features
+down to dependencies.
+
+The `--features test-core` flag on `cargo test --workspace` activates the
+feature in every workspace member simultaneously, which is why every crate
+must declare the feature even if empty.
+
+## CI configuration
+
+The sharded test workflow (`.github/workflows/test-sharded.yml`) runs with
+`--features test-core` by default. The feature-isolation matrix in `rust.yml`
+verifies that `test-core` compiles cleanly.
+
+## Adding gated tests
+
+If a new test depends on the storage engine or Datalog:
+
+1. Gate the test module with `#![cfg(feature = "engine-tests")]` (or the
+   crate's equivalent gate)
+2. Ensure the crate's `test-core` feature enables the required dependency
+3. Verify: `cargo test -p <crate> --features test-core`


### PR DESCRIPTION
## Summary

- Add `test-core` and `test-full` feature flags to all 23 workspace crates, enabling tiered test execution via `cargo test --workspace --features test-core`
- Ungate 11 pure-logic tests in `nous/skills.rs` from the `knowledge-store` feature using `#[cfg(any(feature = "...", test))]`
- Fix pre-existing API rot in 5 integration test files (`knowledge_engine`, `knowledge_lifecycle`, `access_tracking`, `forget`, `lifecycle`) — rewritten to use current nested Fact API (`FactId`, `FactTemporal`, `FactProvenance`, `FactLifecycle`, `FactAccess`)
- Fix episteme `mneme-engine` feature missing `graphe/sqlite` dependency
- Update CI: `test-sharded.yml` runs `--features test-core`, `rust.yml` adds `test-core` to feature-isolation matrix
- Document test tiers in `docs/test-tiers.md` and `CLAUDE.md`

**Test counts:** default ~4,800 | test-core ~4,825 | test-full = all (needs ML deps)

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo test --workspace` passes (4,800 tests)
- [x] `cargo test --workspace --features test-core` passes (4,825 tests)
- [x] `cargo test -p aletheia-integration-tests --features engine-tests` passes (all integration tests)
- [ ] CI sharded test run passes with `--features test-core`

Closes #1895