### PR TITLE
feat(mneme): temporal decay algorithms and serendipity engine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -179,6 +179,7 @@ dependencies = [
  "hnsw_rs",
  "jiff",
  "proptest",
+ "rand 0.9.2",
  "serde",
  "serde_json",
  "snafu",

--- a/crates/aletheia/src/migrate_memory.rs
+++ b/crates/aletheia/src/migrate_memory.rs
@@ -288,7 +288,8 @@ fn import_fact(
 
     if let Ok(embedding) = embedder.embed(&record.content) {
         let chunk = EmbeddedChunk {
-            id: EmbeddingId::new(&format!("emb-{fact_id}")).expect("emb- prefix + ULID is always valid"),
+            id: EmbeddingId::new(&format!("emb-{fact_id}"))
+                .expect("emb- prefix + ULID is always valid"),
             content: record.content.clone(),
             source_type: "fact".to_owned(),
             source_id: fact_id,

--- a/crates/eidos/src/knowledge.rs
+++ b/crates/eidos/src/knowledge.rs
@@ -166,6 +166,108 @@ impl std::fmt::Display for EpistemicTier {
     }
 }
 
+/// Knowledge lifecycle stage for graduated pruning.
+///
+/// Facts progress through stages as decay increases, rather than being
+/// deleted immediately. Each stage represents a different level of
+/// recall priority and pruning eligibility.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum KnowledgeStage {
+    /// Fully active, included in standard recall. Decay score >= 0.7.
+    Active,
+    /// Recall score declining. Still retrievable but deprioritized. Decay in [0.3, 0.7).
+    Fading,
+    /// Low recall probability. Excluded from default recall, available on explicit query. Decay in [0.1, 0.3).
+    Dormant,
+    /// Below retention threshold. Candidate for permanent removal. Decay < 0.1.
+    Archived,
+}
+
+/// Decay score threshold for transitioning from Active to Fading.
+const STAGE_ACTIVE_THRESHOLD: f64 = 0.7;
+/// Decay score threshold for transitioning from Fading to Dormant.
+const STAGE_FADING_THRESHOLD: f64 = 0.3;
+/// Decay score threshold for transitioning from Dormant to Archived.
+const STAGE_DORMANT_THRESHOLD: f64 = 0.1;
+
+impl KnowledgeStage {
+    /// Determine the lifecycle stage from a decay score in [0.0, 1.0].
+    #[must_use]
+    pub fn from_decay_score(decay_score: f64) -> Self {
+        if decay_score >= STAGE_ACTIVE_THRESHOLD {
+            Self::Active
+        } else if decay_score >= STAGE_FADING_THRESHOLD {
+            Self::Fading
+        } else if decay_score >= STAGE_DORMANT_THRESHOLD {
+            Self::Dormant
+        } else {
+            Self::Archived
+        }
+    }
+
+    /// Return the `snake_case` string representation.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Active => "active",
+            Self::Fading => "fading",
+            Self::Dormant => "dormant",
+            Self::Archived => "archived",
+        }
+    }
+
+    /// Whether this stage is eligible for graduated pruning.
+    ///
+    /// Only `Archived` facts may be permanently removed.
+    #[must_use]
+    pub fn is_prunable(self) -> bool {
+        matches!(self, Self::Archived)
+    }
+
+    /// Whether facts in this stage should appear in default recall results.
+    #[must_use]
+    pub fn in_default_recall(self) -> bool {
+        matches!(self, Self::Active | Self::Fading)
+    }
+}
+
+impl std::fmt::Display for KnowledgeStage {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl std::str::FromStr for KnowledgeStage {
+    type Err = String;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        match s {
+            "active" => Ok(Self::Active),
+            "fading" => Ok(Self::Fading),
+            "dormant" => Ok(Self::Dormant),
+            "archived" => Ok(Self::Archived),
+            other => Err(format!("unknown knowledge stage: {other}")),
+        }
+    }
+}
+
+/// Record of a stage transition for audit trail.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StageTransition {
+    /// The fact that transitioned.
+    pub fact_id: FactId,
+    /// Previous stage.
+    pub from: KnowledgeStage,
+    /// New stage.
+    pub to: KnowledgeStage,
+    /// Decay score that triggered the transition.
+    pub decay_score: f64,
+    /// When the transition occurred.
+    pub transitioned_at: jiff::Timestamp,
+}
+
 /// Reason for intentionally forgetting a fact.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]

--- a/crates/episteme/Cargo.toml
+++ b/crates/episteme/Cargo.toml
@@ -25,6 +25,7 @@ aletheia-graphe = { path = "../graphe", default-features = false }
 aletheia-koina = { path = "../koina" }
 aletheia-krites = { path = "../krites", optional = true }
 jiff = { workspace = true, features = ["serde"] }
+rand = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 snafu = { workspace = true }

--- a/crates/episteme/src/decay.rs
+++ b/crates/episteme/src/decay.rs
@@ -1,0 +1,646 @@
+//! Multi-factor temporal decay with lifecycle stages and graduated pruning.
+//!
+//! Extends the base FSRS decay in [`recall`](crate::recall) with:
+//! - **Reinforcement signals**: explicit reinforcement boosts slow decay
+//! - **Cross-agent access patterns**: facts accessed by multiple agents decay slower
+//! - **Knowledge lifecycle stages**: active → fading → dormant → archived
+//! - **Graduated pruning**: stage transitions instead of immediate deletion
+
+use serde::{Deserialize, Serialize};
+
+use crate::knowledge::{EpistemicTier, FactType, KnowledgeStage, StageTransition};
+
+/// Reinforcement boost per explicit reinforcement event.
+const REINFORCEMENT_BOOST: f64 = 0.02;
+
+/// Maximum cumulative reinforcement bonus (caps at 50 reinforcements).
+const MAX_REINFORCEMENT_BONUS: f64 = 1.0;
+
+/// Multiplier bonus per distinct agent that accessed a fact.
+const CROSS_AGENT_BONUS_PER_AGENT: f64 = 0.15;
+
+/// Maximum cross-agent multiplier (caps at 5 distinct agents → 1.75×).
+const MAX_CROSS_AGENT_MULTIPLIER: f64 = 1.75;
+
+/// Configuration for multi-factor decay computation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DecayConfig {
+    /// Weight for recency factor (hours since last access). Default: 0.35
+    pub recency_weight: f64,
+    /// Weight for access frequency factor. Default: 0.25
+    pub frequency_weight: f64,
+    /// Weight for confidence/tier factor. Default: 0.20
+    pub confidence_weight: f64,
+    /// Weight for reinforcement signal factor. Default: 0.20
+    pub reinforcement_weight: f64,
+}
+
+impl Default for DecayConfig {
+    fn default() -> Self {
+        Self {
+            recency_weight: 0.35,
+            frequency_weight: 0.25,
+            confidence_weight: 0.20,
+            reinforcement_weight: 0.20,
+        }
+    }
+}
+
+impl DecayConfig {
+    fn total_weight(&self) -> f64 {
+        self.recency_weight
+            + self.frequency_weight
+            + self.confidence_weight
+            + self.reinforcement_weight
+    }
+}
+
+/// Input factors for computing the multi-factor decay score of a single fact.
+#[derive(Debug, Clone)]
+pub struct DecayFactors {
+    /// Hours since the fact was last accessed (or created if never accessed).
+    pub age_hours: f64,
+    /// Classified fact type.
+    pub fact_type: FactType,
+    /// Epistemic confidence tier.
+    pub tier: EpistemicTier,
+    /// Total access count across all agents.
+    pub access_count: u32,
+    /// Number of explicit reinforcement events.
+    pub reinforcement_count: u32,
+    /// Number of distinct agents that accessed this fact.
+    pub distinct_agent_count: u32,
+    /// Domain volatility score in [0.0, 1.0] (from succession module).
+    pub volatility: f64,
+}
+
+/// Result of multi-factor decay computation.
+#[derive(Debug, Clone)]
+pub struct DecayResult {
+    /// Combined decay score in [0.0, 1.0]. Higher = better retained.
+    pub score: f64,
+    /// Individual factor scores for diagnostics.
+    pub factors: DecayFactorScores,
+    /// Computed lifecycle stage based on the decay score.
+    pub stage: KnowledgeStage,
+    /// Effective stability used in FSRS computation (hours).
+    pub effective_stability_hours: f64,
+}
+
+/// Individual factor contributions to the decay score.
+#[derive(Debug, Clone)]
+pub struct DecayFactorScores {
+    /// FSRS power-law recency score [0.0, 1.0].
+    pub recency: f64,
+    /// Logarithmic access frequency score [0.0, 1.0].
+    pub frequency: f64,
+    /// Confidence score from epistemic tier [0.0, 1.0].
+    pub confidence: f64,
+    /// Reinforcement signal score [0.0, 1.0].
+    pub reinforcement: f64,
+    /// Cross-agent multiplier applied to the final score.
+    pub cross_agent_multiplier: f64,
+}
+
+/// Compute the multi-factor decay score for a single fact.
+///
+/// Combines four weighted factors:
+/// 1. **Recency**: FSRS power-law decay from last access
+/// 2. **Frequency**: logarithmic access count normalization
+/// 3. **Confidence**: epistemic tier and base confidence
+/// 4. **Reinforcement**: explicit reinforcement events
+///
+/// The combined score is then multiplied by a cross-agent bonus
+/// for facts accessed by multiple distinct agents.
+#[must_use]
+pub fn compute_decay(config: &DecayConfig, factors: &DecayFactors) -> DecayResult {
+    let effective_stability = compute_effective_stability_with_reinforcement(
+        factors.fact_type,
+        factors.tier,
+        factors.access_count,
+        factors.reinforcement_count,
+        factors.volatility,
+    );
+
+    let recency = score_recency(factors.age_hours, effective_stability);
+    let frequency = score_frequency(factors.access_count);
+    let confidence = score_confidence(factors.tier);
+    let reinforcement = score_reinforcement(factors.reinforcement_count);
+
+    let total_weight = config.total_weight();
+    let weighted = if total_weight > 0.0 {
+        (recency * config.recency_weight
+            + frequency * config.frequency_weight
+            + confidence * config.confidence_weight
+            + reinforcement * config.reinforcement_weight)
+            / total_weight
+    } else {
+        recency
+    };
+
+    let cross_agent_mult = cross_agent_multiplier(factors.distinct_agent_count);
+    let score = (weighted * cross_agent_mult).clamp(0.0, 1.0);
+
+    DecayResult {
+        score,
+        factors: DecayFactorScores {
+            recency,
+            frequency,
+            confidence,
+            reinforcement,
+            cross_agent_multiplier: cross_agent_mult,
+        },
+        stage: KnowledgeStage::from_decay_score(score),
+        effective_stability_hours: effective_stability,
+    }
+}
+
+/// FSRS power-law recency score.
+///
+/// `R(t) = (1 + 19/81 × t/S)^(-0.5)`
+#[must_use]
+fn score_recency(age_hours: f64, effective_stability: f64) -> f64 {
+    if age_hours <= 0.0 {
+        return 1.0;
+    }
+    if effective_stability <= 0.0 {
+        return 0.0;
+    }
+    (1.0 + (19.0 / 81.0) * age_hours / effective_stability).powf(-0.5)
+}
+
+/// Logarithmic access frequency score.
+///
+/// `score = ln(1 + count) / ln(1 + 100)`
+///
+/// Uses a fixed normalization constant of 100 for consistency across
+/// different knowledge bases.
+#[must_use]
+fn score_frequency(access_count: u32) -> f64 {
+    let count = f64::from(access_count);
+    let max_norm = (1.0_f64 + 100.0).ln();
+    ((1.0 + count).ln() / max_norm).clamp(0.0, 1.0)
+}
+
+/// Confidence score from epistemic tier.
+#[must_use]
+fn score_confidence(tier: EpistemicTier) -> f64 {
+    match tier {
+        EpistemicTier::Verified => 1.0,
+        EpistemicTier::Inferred => 0.6,
+        // WHY: Assumed and any future unknown tiers get the lowest score.
+        _ => 0.3,
+    }
+}
+
+/// Reinforcement signal score.
+///
+/// Each reinforcement event adds a fixed boost, capped at `MAX_REINFORCEMENT_BONUS`.
+#[must_use]
+fn score_reinforcement(reinforcement_count: u32) -> f64 {
+    let bonus = f64::from(reinforcement_count) * REINFORCEMENT_BOOST;
+    bonus.min(MAX_REINFORCEMENT_BONUS)
+}
+
+/// Cross-agent access multiplier.
+///
+/// Facts accessed by multiple distinct agents are considered more universally
+/// relevant and decay slower. Each additional agent beyond the first adds
+/// a bonus multiplier.
+#[must_use]
+pub fn cross_agent_multiplier(distinct_agent_count: u32) -> f64 {
+    if distinct_agent_count <= 1 {
+        return 1.0;
+    }
+    let bonus = f64::from(distinct_agent_count - 1) * CROSS_AGENT_BONUS_PER_AGENT;
+    (1.0 + bonus).min(MAX_CROSS_AGENT_MULTIPLIER)
+}
+
+/// Compute effective stability incorporating reinforcement signals.
+///
+/// Extends [`crate::recall::compute_effective_stability`] with:
+/// - Reinforcement bonus: `1 + reinforcement_count × REINFORCEMENT_BOOST`
+/// - Volatility adjustment from succession module
+#[must_use]
+pub fn compute_effective_stability_with_reinforcement(
+    fact_type: FactType,
+    tier: EpistemicTier,
+    access_count: u32,
+    reinforcement_count: u32,
+    volatility: f64,
+) -> f64 {
+    let base = crate::recall::compute_effective_stability(fact_type, tier, access_count);
+    let reinforcement_mult =
+        1.0 + (f64::from(reinforcement_count) * REINFORCEMENT_BOOST).min(MAX_REINFORCEMENT_BONUS);
+    let volatility_mult = crate::succession::volatility_multiplier(volatility);
+    base * reinforcement_mult * volatility_mult
+}
+
+/// Evaluate lifecycle stage transitions for a batch of facts.
+///
+/// Compares each fact's current stage against its computed stage from
+/// the decay score. Returns transitions that represent stage changes
+/// (graduated pruning).
+#[must_use]
+pub fn evaluate_transitions(
+    facts: &[(crate::id::FactId, KnowledgeStage, f64)],
+) -> Vec<StageTransition> {
+    let now = jiff::Timestamp::now();
+    let mut transitions = Vec::new();
+
+    for (fact_id, current_stage, decay_score) in facts {
+        let new_stage = KnowledgeStage::from_decay_score(*decay_score);
+        if new_stage != *current_stage {
+            transitions.push(StageTransition {
+                fact_id: fact_id.clone(),
+                from: *current_stage,
+                to: new_stage,
+                decay_score: *decay_score,
+                transitioned_at: now,
+            });
+        }
+    }
+
+    transitions
+}
+
+/// Identify facts eligible for graduated pruning.
+///
+/// Returns fact IDs in the `Archived` stage that have remained there
+/// for at least `min_archived_hours` hours. Only archived facts
+/// may be permanently removed.
+#[must_use]
+pub fn pruning_candidates(
+    archived_facts: &[(crate::id::FactId, f64, f64)],
+    min_archived_hours: f64,
+) -> Vec<crate::id::FactId> {
+    archived_facts
+        .iter()
+        .filter(|(_, decay_score, hours_in_archived)| {
+            KnowledgeStage::from_decay_score(*decay_score).is_prunable()
+                && *hours_in_archived >= min_archived_hours
+        })
+        .map(|(id, _, _)| id.clone())
+        .collect()
+}
+
+#[cfg(test)]
+#[expect(clippy::expect_used, reason = "test assertions")]
+#[expect(
+    clippy::indexing_slicing,
+    reason = "test code with known-valid indices"
+)]
+mod tests {
+    use super::*;
+
+    fn default_factors() -> DecayFactors {
+        DecayFactors {
+            age_hours: 0.0,
+            fact_type: FactType::Observation,
+            tier: EpistemicTier::Inferred,
+            access_count: 0,
+            reinforcement_count: 0,
+            distinct_agent_count: 1,
+            volatility: 0.5,
+        }
+    }
+
+    #[test]
+    fn fresh_fact_has_high_decay_score() {
+        let result = compute_decay(&DecayConfig::default(), &default_factors());
+        // WHY: 0.47 — recency is perfect but frequency/reinforcement are zero
+        assert!(
+            result.score > 0.4,
+            "fresh fact should have moderate-high decay score, got {}",
+            result.score
+        );
+        assert_eq!(
+            result.stage,
+            KnowledgeStage::Fading,
+            "fresh unaccessed fact should be Fading"
+        );
+    }
+
+    #[test]
+    fn old_untouched_fact_decays_to_low_score() {
+        let factors = DecayFactors {
+            age_hours: 5000.0,
+            ..default_factors()
+        };
+        let result = compute_decay(&DecayConfig::default(), &factors);
+        assert!(
+            result.score < 0.5,
+            "old fact should have low decay score, got {}",
+            result.score
+        );
+    }
+
+    #[test]
+    fn reinforcement_slows_decay() {
+        let base = DecayFactors {
+            age_hours: 500.0,
+            ..default_factors()
+        };
+        let reinforced = DecayFactors {
+            reinforcement_count: 20,
+            ..base.clone()
+        };
+        let base_result = compute_decay(&DecayConfig::default(), &base);
+        let reinforced_result = compute_decay(&DecayConfig::default(), &reinforced);
+        assert!(
+            reinforced_result.score > base_result.score,
+            "reinforced fact should decay slower: {} vs {}",
+            reinforced_result.score,
+            base_result.score
+        );
+    }
+
+    #[test]
+    fn cross_agent_access_slows_decay() {
+        let single = DecayFactors {
+            age_hours: 500.0,
+            ..default_factors()
+        };
+        let multi = DecayFactors {
+            distinct_agent_count: 4,
+            ..single.clone()
+        };
+        let single_result = compute_decay(&DecayConfig::default(), &single);
+        let multi_result = compute_decay(&DecayConfig::default(), &multi);
+        assert!(
+            multi_result.score > single_result.score,
+            "multi-agent access should slow decay: {} vs {}",
+            multi_result.score,
+            single_result.score
+        );
+    }
+
+    #[test]
+    fn cross_agent_multiplier_bounds() {
+        assert!(
+            (cross_agent_multiplier(0) - 1.0).abs() < f64::EPSILON,
+            "zero agents should give 1.0 multiplier"
+        );
+        assert!(
+            (cross_agent_multiplier(1) - 1.0).abs() < f64::EPSILON,
+            "single agent should give 1.0 multiplier"
+        );
+        let two = cross_agent_multiplier(2);
+        assert!(
+            (two - 1.15).abs() < f64::EPSILON,
+            "two agents should give 1.15, got {two}"
+        );
+        let capped = cross_agent_multiplier(100);
+        assert!(
+            (capped - MAX_CROSS_AGENT_MULTIPLIER).abs() < f64::EPSILON,
+            "should cap at {MAX_CROSS_AGENT_MULTIPLIER}, got {capped}"
+        );
+    }
+
+    #[test]
+    fn lifecycle_stage_from_decay_score() {
+        assert_eq!(
+            KnowledgeStage::from_decay_score(1.0),
+            KnowledgeStage::Active
+        );
+        assert_eq!(
+            KnowledgeStage::from_decay_score(0.7),
+            KnowledgeStage::Active
+        );
+        assert_eq!(
+            KnowledgeStage::from_decay_score(0.69),
+            KnowledgeStage::Fading
+        );
+        assert_eq!(
+            KnowledgeStage::from_decay_score(0.3),
+            KnowledgeStage::Fading
+        );
+        assert_eq!(
+            KnowledgeStage::from_decay_score(0.29),
+            KnowledgeStage::Dormant
+        );
+        assert_eq!(
+            KnowledgeStage::from_decay_score(0.1),
+            KnowledgeStage::Dormant
+        );
+        assert_eq!(
+            KnowledgeStage::from_decay_score(0.09),
+            KnowledgeStage::Archived
+        );
+        assert_eq!(
+            KnowledgeStage::from_decay_score(0.0),
+            KnowledgeStage::Archived
+        );
+    }
+
+    #[test]
+    fn stage_pruning_eligibility() {
+        assert!(
+            !KnowledgeStage::Active.is_prunable(),
+            "Active should not be prunable"
+        );
+        assert!(
+            !KnowledgeStage::Fading.is_prunable(),
+            "Fading should not be prunable"
+        );
+        assert!(
+            !KnowledgeStage::Dormant.is_prunable(),
+            "Dormant should not be prunable"
+        );
+        assert!(
+            KnowledgeStage::Archived.is_prunable(),
+            "Archived should be prunable"
+        );
+    }
+
+    #[test]
+    fn stage_default_recall_inclusion() {
+        assert!(
+            KnowledgeStage::Active.in_default_recall(),
+            "Active should be in default recall"
+        );
+        assert!(
+            KnowledgeStage::Fading.in_default_recall(),
+            "Fading should be in default recall"
+        );
+        assert!(
+            !KnowledgeStage::Dormant.in_default_recall(),
+            "Dormant should not be in default recall"
+        );
+        assert!(
+            !KnowledgeStage::Archived.in_default_recall(),
+            "Archived should not be in default recall"
+        );
+    }
+
+    #[test]
+    fn evaluate_transitions_detects_stage_change() {
+        let fact_id = crate::id::FactId::new("f-1").expect("valid test id");
+        let facts = vec![(fact_id.clone(), KnowledgeStage::Active, 0.2)];
+        let transitions = evaluate_transitions(&facts);
+        assert_eq!(transitions.len(), 1, "should detect one transition");
+        assert_eq!(transitions[0].from, KnowledgeStage::Active);
+        assert_eq!(transitions[0].to, KnowledgeStage::Dormant);
+    }
+
+    #[test]
+    fn evaluate_transitions_no_change() {
+        let fact_id = crate::id::FactId::new("f-1").expect("valid test id");
+        let facts = vec![(fact_id, KnowledgeStage::Active, 0.9)];
+        let transitions = evaluate_transitions(&facts);
+        assert!(transitions.is_empty(), "should detect no transitions");
+    }
+
+    #[test]
+    fn graduated_pruning_respects_time() {
+        let fact_id = crate::id::FactId::new("f-1").expect("valid test id");
+        let archived = vec![(fact_id.clone(), 0.05, 100.0)];
+        let candidates = pruning_candidates(&archived, 720.0);
+        assert!(
+            candidates.is_empty(),
+            "should not prune fact archived for less than min hours"
+        );
+
+        let long_archived = vec![(fact_id, 0.05, 800.0)];
+        let candidates = pruning_candidates(&long_archived, 720.0);
+        assert_eq!(
+            candidates.len(),
+            1,
+            "should prune fact archived long enough"
+        );
+    }
+
+    #[test]
+    fn verified_fact_decays_slower_than_assumed() {
+        let verified = DecayFactors {
+            age_hours: 500.0,
+            tier: EpistemicTier::Verified,
+            ..default_factors()
+        };
+        let assumed = DecayFactors {
+            age_hours: 500.0,
+            tier: EpistemicTier::Assumed,
+            ..default_factors()
+        };
+        let v_result = compute_decay(&DecayConfig::default(), &verified);
+        let a_result = compute_decay(&DecayConfig::default(), &assumed);
+        assert!(
+            v_result.score > a_result.score,
+            "verified should decay slower: {} vs {}",
+            v_result.score,
+            a_result.score
+        );
+    }
+
+    #[test]
+    fn identity_fact_decays_slower_than_observation() {
+        let identity = DecayFactors {
+            age_hours: 2000.0,
+            fact_type: FactType::Identity,
+            ..default_factors()
+        };
+        let observation = DecayFactors {
+            age_hours: 2000.0,
+            fact_type: FactType::Observation,
+            ..default_factors()
+        };
+        let i_result = compute_decay(&DecayConfig::default(), &identity);
+        let o_result = compute_decay(&DecayConfig::default(), &observation);
+        assert!(
+            i_result.score > o_result.score,
+            "identity should decay slower: {} vs {}",
+            i_result.score,
+            o_result.score
+        );
+    }
+
+    #[test]
+    fn volatile_domain_decays_faster() {
+        let stable = DecayFactors {
+            age_hours: 500.0,
+            volatility: 0.0,
+            ..default_factors()
+        };
+        let volatile = DecayFactors {
+            age_hours: 500.0,
+            volatility: 1.0,
+            ..default_factors()
+        };
+        let s_result = compute_decay(&DecayConfig::default(), &stable);
+        let v_result = compute_decay(&DecayConfig::default(), &volatile);
+        assert!(
+            s_result.score > v_result.score,
+            "stable domain should decay slower: {} vs {}",
+            s_result.score,
+            v_result.score
+        );
+    }
+
+    #[test]
+    fn score_recency_at_zero_is_one() {
+        let s = score_recency(0.0, 720.0);
+        assert!(
+            (s - 1.0).abs() < f64::EPSILON,
+            "recency at t=0 should be 1.0, got {s}"
+        );
+    }
+
+    #[test]
+    fn score_recency_at_stability_is_about_090() {
+        let s = score_recency(720.0, 720.0);
+        assert!(
+            (s - 0.9).abs() < 0.01,
+            "recency at t=S should be ~0.9, got {s}"
+        );
+    }
+
+    #[test]
+    fn score_frequency_increases_with_access() {
+        let low = score_frequency(1);
+        let high = score_frequency(50);
+        assert!(
+            high > low,
+            "higher access should give higher frequency score: {high} vs {low}"
+        );
+    }
+
+    #[test]
+    fn score_reinforcement_caps() {
+        let capped = score_reinforcement(100);
+        assert!(
+            (capped - MAX_REINFORCEMENT_BONUS).abs() < f64::EPSILON,
+            "reinforcement should cap at {MAX_REINFORCEMENT_BONUS}, got {capped}"
+        );
+    }
+
+    #[test]
+    fn knowledge_stage_serde_roundtrip() {
+        for stage in [
+            KnowledgeStage::Active,
+            KnowledgeStage::Fading,
+            KnowledgeStage::Dormant,
+            KnowledgeStage::Archived,
+        ] {
+            let json = serde_json::to_string(&stage).expect("KnowledgeStage serialization");
+            let back: KnowledgeStage =
+                serde_json::from_str(&json).expect("KnowledgeStage deserialization");
+            assert_eq!(stage, back, "KnowledgeStage should survive roundtrip");
+        }
+    }
+
+    #[test]
+    fn knowledge_stage_from_str_roundtrip() {
+        for stage in [
+            KnowledgeStage::Active,
+            KnowledgeStage::Fading,
+            KnowledgeStage::Dormant,
+            KnowledgeStage::Archived,
+        ] {
+            let parsed: KnowledgeStage = stage
+                .as_str()
+                .parse::<KnowledgeStage>()
+                .expect("KnowledgeStage should parse from as_str");
+            assert_eq!(stage, parsed, "KnowledgeStage roundtrip failed for {stage}");
+        }
+    }
+}

--- a/crates/episteme/src/lib.rs
+++ b/crates/episteme/src/lib.rs
@@ -19,6 +19,8 @@ pub use aletheia_graphe::error;
 pub mod conflict;
 /// LLM-driven fact consolidation for knowledge maintenance.
 pub mod consolidation;
+/// Multi-factor temporal decay with lifecycle stages and graduated pruning.
+pub mod decay;
 /// Entity deduplication pipeline for merging semantically identical entities.
 pub(crate) mod dedup;
 /// Embedding provider trait and implementations (candle, mock).
@@ -43,6 +45,8 @@ pub mod query;
 pub(crate) mod query_rewrite;
 /// 6-factor recall scoring engine for knowledge retrieval ranking.
 pub mod recall;
+/// Serendipity engine: cross-domain discovery, surprise scoring, and context injection.
+pub mod serendipity;
 /// Skill storage helpers and SKILL.md parser.
 pub mod skill;
 /// Skill auto-capture: heuristic filter, signature hashing, and candidate tracking.

--- a/crates/episteme/src/serendipity.rs
+++ b/crates/episteme/src/serendipity.rs
@@ -1,0 +1,961 @@
+//! Serendipity engine: cross-domain discovery and unexpected connection finding.
+//!
+//! Implements four core capabilities:
+//! - **Random walk exploration**: traverse the knowledge graph from a starting entity
+//! - **Surprise scoring**: identify facts the agent hasn't accessed recently
+//! - **Path exploration**: find paths between seemingly unrelated entities
+//! - **Serendipity injection**: select "did you know?" facts for context injection
+
+use std::collections::{HashMap, HashSet};
+
+use serde::{Deserialize, Serialize};
+
+use crate::id::EntityId;
+
+/// Configuration for the serendipity engine.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SerendipityConfig {
+    /// Maximum steps in a random walk. Default: 6
+    pub max_walk_length: u32,
+    /// Number of random walks per exploration. Default: 10
+    pub walk_count: u32,
+    /// Minimum surprise score to surface a discovery. Default: 0.3
+    pub surprise_threshold: f64,
+    /// Weight for novelty vs relevance in serendipity scoring. Default: 0.5
+    /// 0.0 = pure relevance, 1.0 = pure novelty.
+    pub novelty_weight: f64,
+    /// Maximum graph distance for path exploration. Default: 4
+    pub max_path_depth: u32,
+    /// Maximum number of discovery results to return. Default: 10
+    pub max_results: usize,
+}
+
+impl Default for SerendipityConfig {
+    fn default() -> Self {
+        Self {
+            max_walk_length: 6,
+            walk_count: 10,
+            surprise_threshold: 0.3,
+            novelty_weight: 0.5,
+            max_path_depth: 4,
+            max_results: 10,
+        }
+    }
+}
+
+/// A node in the knowledge graph for serendipity exploration.
+#[derive(Debug, Clone)]
+pub struct GraphNode {
+    /// Entity identifier.
+    pub entity_id: EntityId,
+    /// Display name.
+    pub name: String,
+    /// `PageRank` importance score [0.0, 1.0].
+    pub pagerank: f64,
+    /// Louvain community/cluster assignment.
+    pub community: i64,
+    /// Neighbor entity IDs.
+    pub neighbors: Vec<EntityId>,
+}
+
+/// A scored discovery from the serendipity engine.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Discovery {
+    /// The discovered entity.
+    pub entity_id: EntityId,
+    /// Display name.
+    pub name: String,
+    /// Combined serendipity score [0.0, 1.0].
+    pub serendipity_score: f64,
+    /// Relevance component [0.0, 1.0] (inverse graph distance).
+    pub relevance: f64,
+    /// Novelty component [0.0, 1.0] (cross-community + obscurity).
+    pub novelty: f64,
+    /// Surprise component [0.0, 1.0] (recency-weighted unexpectedness).
+    pub surprise: f64,
+    /// Graph distance from the query context.
+    pub graph_distance: Option<u32>,
+    /// Community/cluster ID.
+    pub community: i64,
+}
+
+/// A path between two entities in the knowledge graph.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExploredPath {
+    /// Ordered list of entity IDs along the path.
+    pub nodes: Vec<EntityId>,
+    /// Relationship labels along each edge.
+    pub edge_labels: Vec<String>,
+    /// Path length (number of edges).
+    pub length: u32,
+    /// Number of distinct communities traversed.
+    pub communities_traversed: u32,
+    /// Interest score combining distance and cross-community traversal.
+    pub interest_score: f64,
+}
+
+/// A fact selected for serendipity injection into context.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SerendipityInjection {
+    /// The fact content to inject.
+    pub content: String,
+    /// Source fact ID.
+    pub fact_id: String,
+    /// Surprise score that triggered the injection.
+    pub surprise_score: f64,
+    /// Brief explanation of why this is interesting.
+    pub connection_reason: String,
+}
+
+/// Snapshot of the knowledge graph for serendipity operations.
+///
+/// Loaded once per exploration session. All graph traversal operates
+/// on this in-memory snapshot rather than hitting the store repeatedly.
+#[derive(Debug, Clone, Default)]
+pub struct GraphSnapshot {
+    /// All nodes keyed by entity ID string.
+    pub nodes: HashMap<String, GraphNode>,
+    /// Adjacency list keyed by entity ID.
+    pub adjacency: HashMap<String, HashSet<String>>,
+    /// Edge labels: `(src, dst)` → relationship type.
+    pub edge_labels: HashMap<(String, String), String>,
+    /// Maximum `PageRank` score across all nodes (for normalization).
+    pub max_pagerank: f64,
+}
+
+impl GraphSnapshot {
+    /// Add a node to the snapshot.
+    pub fn add_node(&mut self, node: GraphNode) {
+        let id = node.entity_id.as_str().to_owned();
+        if node.pagerank > self.max_pagerank {
+            self.max_pagerank = node.pagerank;
+        }
+        self.adjacency.entry(id.clone()).or_default();
+        self.nodes.insert(id, node);
+    }
+
+    /// Add an edge to the snapshot.
+    pub fn add_edge(&mut self, src: &str, dst: &str, relation: &str) {
+        self.adjacency
+            .entry(src.to_owned())
+            .or_default()
+            .insert(dst.to_owned());
+        self.adjacency
+            .entry(dst.to_owned())
+            .or_default()
+            .insert(src.to_owned());
+        self.edge_labels
+            .insert((src.to_owned(), dst.to_owned()), relation.to_owned());
+        self.edge_labels
+            .insert((dst.to_owned(), src.to_owned()), relation.to_owned());
+    }
+
+    /// Get neighbors of an entity.
+    #[must_use]
+    pub fn neighbors(&self, entity_id: &str) -> Vec<&str> {
+        self.adjacency
+            .get(entity_id)
+            .map(|set| set.iter().map(String::as_str).collect())
+            .unwrap_or_default()
+    }
+
+    /// Total number of nodes.
+    #[must_use]
+    pub fn node_count(&self) -> usize {
+        self.nodes.len()
+    }
+
+    /// Normalized `PageRank` denominator (avoids division by zero).
+    // WHY: allow not expect — dead in lib target, live in test target
+    #[allow(dead_code)]
+    fn max_pagerank_or_one(&self) -> f64 {
+        if self.max_pagerank > 0.0 {
+            self.max_pagerank
+        } else {
+            1.0
+        }
+    }
+}
+
+/// Perform a random walk exploration from seed entities.
+///
+/// Executes multiple random walks from each seed, collecting visited nodes.
+/// Returns visit frequencies that indicate how "reachable" each entity is
+/// from the seeds through random traversal.
+#[must_use]
+pub fn random_walk(
+    graph: &GraphSnapshot,
+    seeds: &[String],
+    config: &SerendipityConfig,
+    rng_seed: u64,
+) -> HashMap<String, u32> {
+    use rand::SeedableRng;
+    use rand::prelude::IndexedRandom;
+    use rand::rngs::SmallRng;
+
+    let mut rng = SmallRng::seed_from_u64(rng_seed);
+    let mut visit_counts: HashMap<String, u32> = HashMap::new();
+
+    for seed in seeds {
+        if !graph.adjacency.contains_key(seed) {
+            continue;
+        }
+
+        for _ in 0..config.walk_count {
+            let mut current = seed.clone();
+            for _ in 0..config.max_walk_length {
+                let neighbors = graph.neighbors(&current);
+                if neighbors.is_empty() {
+                    break;
+                }
+                let next = match neighbors.choose(&mut rng) {
+                    Some(n) => (*n).to_owned(),
+                    None => break,
+                };
+                *visit_counts.entry(next.clone()).or_insert(0) += 1;
+                current = next;
+            }
+        }
+    }
+
+    // WHY: Remove seeds from results to focus on discoveries
+    for seed in seeds {
+        visit_counts.remove(seed);
+    }
+
+    visit_counts
+}
+
+/// Compute surprise scores for entities based on access recency.
+///
+/// Surprise is higher for entities that:
+/// 1. Haven't been accessed recently (high recency surprise)
+/// 2. Are connected to the current context (relevance floor)
+/// 3. Are in a different community from the query context (cross-community bonus)
+// WHY: allow not expect — dead in lib target, live in test target
+#[allow(dead_code)]
+#[must_use]
+pub(crate) fn surprise_scores(
+    graph: &GraphSnapshot,
+    walk_visits: &HashMap<String, u32>,
+    home_communities: &HashSet<i64>,
+    last_access_hours: &HashMap<String, f64>,
+) -> Vec<(String, f64)> {
+    let max_visits = walk_visits.values().copied().max().unwrap_or(1);
+    let max_pr = graph.max_pagerank_or_one();
+
+    let mut scores: Vec<(String, f64)> = walk_visits
+        .iter()
+        .filter_map(|(entity_id, &visits)| {
+            let node = graph.nodes.get(entity_id)?;
+
+            let reachability = f64::from(visits) / f64::from(max_visits);
+            let access_hours = last_access_hours.get(entity_id).copied().unwrap_or(10000.0);
+            let recency_surprise = 1.0 - (-0.01 * access_hours).exp();
+            let cross_community = community_novelty(node.community, home_communities);
+            let obscurity = 1.0 - (node.pagerank / max_pr);
+
+            let surprise = 0.3 * reachability
+                + 0.3 * recency_surprise
+                + 0.2 * cross_community
+                + 0.2 * obscurity;
+
+            Some((entity_id.clone(), surprise))
+        })
+        .collect();
+
+    scores.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+    scores
+}
+
+/// Score entities for serendipity: balance relevance vs novelty.
+///
+/// Serendipity = `(1 - novelty_weight) × relevance + novelty_weight × novelty`
+///
+/// Relevance: inverse graph distance from seed entities.
+/// Novelty: cross-community score + obscurity (low `PageRank`).
+// WHY: allow not expect — dead in lib target, live in test target
+#[allow(dead_code)]
+#[must_use]
+pub(crate) fn score_discoveries(
+    graph: &GraphSnapshot,
+    seeds: &[String],
+    distances: &HashMap<String, u32>,
+    config: &SerendipityConfig,
+) -> Vec<Discovery> {
+    let seed_set: HashSet<&str> = seeds.iter().map(String::as_str).collect();
+
+    let home_communities: HashSet<i64> = seeds
+        .iter()
+        .filter_map(|s| graph.nodes.get(s).map(|n| n.community))
+        .filter(|c| *c >= 0)
+        .collect();
+
+    let max_pr = graph.max_pagerank_or_one();
+
+    let mut discoveries: Vec<Discovery> = graph
+        .nodes
+        .iter()
+        .filter(|(id, _)| !seed_set.contains(id.as_str()))
+        .filter_map(|(id, node)| {
+            let dist = distances.get(id).copied();
+            let relevance = dist.map_or(0.0, |d| 1.0 / (1.0 + f64::from(d)));
+
+            if relevance <= 0.0 {
+                return None;
+            }
+
+            let cross_community = community_novelty(node.community, &home_communities);
+            let obscurity = 1.0 - (node.pagerank / max_pr);
+            let novelty = 0.6 * cross_community + 0.4 * obscurity;
+
+            let relevance_weight = 1.0 - config.novelty_weight;
+            let serendipity = relevance_weight * relevance + config.novelty_weight * novelty;
+
+            if serendipity <= 0.1 {
+                return None;
+            }
+
+            Some(Discovery {
+                entity_id: node.entity_id.clone(),
+                name: node.name.clone(),
+                serendipity_score: serendipity,
+                relevance,
+                novelty,
+                surprise: 0.0,
+                graph_distance: dist,
+                community: node.community,
+            })
+        })
+        .collect();
+
+    discoveries.sort_by(|a, b| {
+        b.serendipity_score
+            .partial_cmp(&a.serendipity_score)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+    discoveries.truncate(config.max_results);
+    discoveries
+}
+
+/// Find shortest path between two entities using BFS.
+///
+/// Returns `None` if no path exists within `max_depth` hops.
+#[must_use]
+pub fn find_path(
+    graph: &GraphSnapshot,
+    source: &str,
+    target: &str,
+    max_depth: u32,
+) -> Option<ExploredPath> {
+    if source == target {
+        return None;
+    }
+    if !graph.adjacency.contains_key(source) || !graph.adjacency.contains_key(target) {
+        return None;
+    }
+
+    let mut visited: HashSet<String> = HashSet::new();
+    let mut parent: HashMap<String, String> = HashMap::new();
+    let mut queue: std::collections::VecDeque<(String, u32)> = std::collections::VecDeque::new();
+
+    visited.insert(source.to_owned());
+    queue.push_back((source.to_owned(), 0));
+
+    while let Some((current, depth)) = queue.pop_front() {
+        if depth >= max_depth {
+            continue;
+        }
+        for neighbor in graph.neighbors(&current) {
+            if visited.contains(neighbor) {
+                continue;
+            }
+            visited.insert(neighbor.to_owned());
+            parent.insert(neighbor.to_owned(), current.clone());
+
+            if neighbor == target {
+                return Some(reconstruct_path(graph, source, target, &parent));
+            }
+            queue.push_back((neighbor.to_owned(), depth + 1));
+        }
+    }
+
+    None
+}
+
+/// Explore novel entities reachable from source within the configured depth.
+///
+/// Returns paths to the most "interesting" reachable entities, ranked
+/// by cross-community traversal and distance.
+#[must_use]
+pub fn explore_from(
+    graph: &GraphSnapshot,
+    source: &str,
+    config: &SerendipityConfig,
+) -> Vec<ExploredPath> {
+    if !graph.adjacency.contains_key(source) {
+        return Vec::new();
+    }
+
+    let source_community = graph.nodes.get(source).map_or(-1, |n| n.community);
+    let distances = bfs_distances(graph, source, config.max_path_depth);
+
+    let mut scored: Vec<(String, f64, u32)> = distances
+        .iter()
+        .filter(|(id, _)| id.as_str() != source)
+        .filter_map(|(id, &dist)| {
+            let node = graph.nodes.get(id)?;
+            let cross = if node.community != source_community
+                && node.community >= 0
+                && source_community >= 0
+            {
+                1.0
+            } else {
+                0.3
+            };
+            let interest = cross * f64::from(dist);
+            Some((id.clone(), interest, dist))
+        })
+        .collect();
+
+    scored.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+    scored.truncate(config.max_results);
+
+    scored
+        .into_iter()
+        .filter_map(|(target, interest, _)| {
+            let mut path = find_path(graph, source, &target, config.max_path_depth)?;
+            path.interest_score = interest;
+            Some(path)
+        })
+        .collect()
+}
+
+/// Select facts for serendipity injection into agent context.
+///
+/// Picks the most surprising fact from the scored discoveries that
+/// exceeds the surprise threshold.
+#[must_use]
+pub fn select_injection<S: ::std::hash::BuildHasher>(
+    discoveries: &[Discovery],
+    fact_contents: &HashMap<String, (String, String), S>,
+    config: &SerendipityConfig,
+) -> Option<SerendipityInjection> {
+    discoveries
+        .iter()
+        .filter(|d| d.surprise >= config.surprise_threshold || d.serendipity_score >= 0.5)
+        .find_map(|d| {
+            let entity_key = d.entity_id.as_str();
+            let (fact_id, content) = fact_contents.get(entity_key)?;
+            Some(SerendipityInjection {
+                content: content.clone(),
+                fact_id: fact_id.clone(),
+                surprise_score: d.surprise.max(d.serendipity_score),
+                connection_reason: format!(
+                    "connected to {} (distance: {}, community: {})",
+                    d.name,
+                    d.graph_distance
+                        .map_or_else(|| "unknown".to_owned(), |dist| dist.to_string()),
+                    d.community
+                ),
+            })
+        })
+}
+
+/// Community novelty score: 1.0 if in a different community, 0.3 if same.
+// WHY: allow not expect — dead in lib target, live in test target
+#[allow(dead_code)]
+fn community_novelty(community: i64, home_communities: &HashSet<i64>) -> f64 {
+    if community >= 0 && !home_communities.contains(&community) {
+        1.0
+    } else {
+        0.3
+    }
+}
+
+/// BFS distance computation from a source node.
+fn bfs_distances(graph: &GraphSnapshot, source: &str, max_depth: u32) -> HashMap<String, u32> {
+    let mut distances: HashMap<String, u32> = HashMap::new();
+    let mut queue: std::collections::VecDeque<(String, u32)> = std::collections::VecDeque::new();
+
+    distances.insert(source.to_owned(), 0);
+    queue.push_back((source.to_owned(), 0));
+
+    while let Some((current, depth)) = queue.pop_front() {
+        if depth >= max_depth {
+            continue;
+        }
+        for neighbor in graph.neighbors(&current) {
+            if distances.contains_key(neighbor) {
+                continue;
+            }
+            let next_depth = depth + 1;
+            distances.insert(neighbor.to_owned(), next_depth);
+            queue.push_back((neighbor.to_owned(), next_depth));
+        }
+    }
+
+    distances
+}
+
+/// Reconstruct a path from BFS parent map.
+fn reconstruct_path(
+    graph: &GraphSnapshot,
+    source: &str,
+    target: &str,
+    parent: &HashMap<String, String>,
+) -> ExploredPath {
+    let mut path_nodes = vec![target.to_owned()];
+    let mut current = target.to_owned();
+    while current != source {
+        let prev = match parent.get(&current) {
+            Some(p) => p.clone(),
+            None => break,
+        };
+        path_nodes.push(prev.clone());
+        current = prev;
+    }
+    path_nodes.reverse();
+
+    let edge_labels: Vec<String> = path_nodes
+        .windows(2)
+        .filter_map(|pair| {
+            let src = pair.first()?;
+            let dst = pair.get(1)?;
+            Some(
+                graph
+                    .edge_labels
+                    .get(&(src.clone(), dst.clone()))
+                    .cloned()
+                    .unwrap_or_else(|| "connected".to_owned()),
+            )
+        })
+        .collect();
+
+    let mut communities: HashSet<i64> = HashSet::new();
+    for node_id in &path_nodes {
+        if let Some(node) = graph.nodes.get(node_id)
+            && node.community >= 0
+        {
+            communities.insert(node.community);
+        }
+    }
+
+    let length = u32::try_from(path_nodes.len().saturating_sub(1)).unwrap_or(u32::MAX);
+    let communities_traversed = u32::try_from(communities.len()).unwrap_or(u32::MAX);
+
+    let node_ids: Vec<EntityId> = path_nodes
+        .into_iter()
+        .filter_map(|id| EntityId::new(id).ok())
+        .collect();
+
+    ExploredPath {
+        nodes: node_ids,
+        edge_labels,
+        length,
+        communities_traversed,
+        interest_score: 0.0,
+    }
+}
+
+#[cfg(test)]
+#[expect(clippy::expect_used, reason = "test assertions")]
+#[expect(
+    clippy::indexing_slicing,
+    reason = "test code with known-valid indices"
+)]
+mod tests {
+    use super::*;
+
+    fn build_test_graph() -> GraphSnapshot {
+        let mut graph = GraphSnapshot::default();
+
+        let entities = [
+            ("rust", "Rust", 0.8, 0),
+            ("python", "Python", 0.7, 0),
+            ("wasm", "WebAssembly", 0.3, 1),
+            ("llvm", "LLVM", 0.5, 1),
+            ("ml", "Machine Learning", 0.6, 2),
+            ("numpy", "NumPy", 0.4, 2),
+            ("gpu", "GPU Computing", 0.3, 2),
+            ("art", "Digital Art", 0.1, 3),
+            ("music", "Algorithmic Music", 0.1, 3),
+        ];
+
+        for (id, name, pagerank, community) in &entities {
+            graph.add_node(GraphNode {
+                entity_id: EntityId::new(*id).expect("valid test id"),
+                name: (*name).to_owned(),
+                pagerank: *pagerank,
+                community: *community,
+                neighbors: vec![],
+            });
+        }
+
+        let edges = [
+            ("rust", "wasm", "compiles_to"),
+            ("rust", "python", "interops_with"),
+            ("rust", "llvm", "uses"),
+            ("python", "ml", "used_for"),
+            ("python", "numpy", "depends_on"),
+            ("llvm", "wasm", "targets"),
+            ("ml", "numpy", "depends_on"),
+            ("ml", "gpu", "accelerated_by"),
+            ("art", "gpu", "uses"),
+            ("music", "ml", "uses"),
+        ];
+
+        for (src, dst, rel) in &edges {
+            graph.add_edge(src, dst, rel);
+        }
+
+        graph
+    }
+
+    #[test]
+    fn random_walk_visits_reachable_nodes() {
+        let graph = build_test_graph();
+        let visits = random_walk(
+            &graph,
+            &["rust".to_owned()],
+            &SerendipityConfig::default(),
+            42,
+        );
+
+        assert!(
+            !visits.is_empty(),
+            "random walk should visit at least one node"
+        );
+        assert!(
+            !visits.contains_key("rust"),
+            "seeds should be excluded from walk results"
+        );
+    }
+
+    #[test]
+    fn random_walk_deterministic_with_same_seed() {
+        let graph = build_test_graph();
+        let config = SerendipityConfig::default();
+
+        let visits1 = random_walk(&graph, &["rust".to_owned()], &config, 42);
+        let visits2 = random_walk(&graph, &["rust".to_owned()], &config, 42);
+
+        assert_eq!(
+            visits1, visits2,
+            "same RNG seed should produce identical walks"
+        );
+    }
+
+    #[test]
+    fn random_walk_different_seeds_differ() {
+        let graph = build_test_graph();
+        let config = SerendipityConfig::default();
+
+        let visits1 = random_walk(&graph, &["rust".to_owned()], &config, 42);
+        let visits2 = random_walk(&graph, &["rust".to_owned()], &config, 99);
+
+        assert_ne!(
+            visits1, visits2,
+            "different RNG seeds should produce different walks"
+        );
+    }
+
+    #[test]
+    fn surprise_scores_rank_unfamiliar_entities_higher() {
+        let graph = build_test_graph();
+        let mut walk_visits = HashMap::new();
+        walk_visits.insert("wasm".to_owned(), 5);
+        walk_visits.insert("ml".to_owned(), 3);
+        walk_visits.insert("art".to_owned(), 2);
+
+        let mut last_access = HashMap::new();
+        last_access.insert("wasm".to_owned(), 1.0);
+        last_access.insert("ml".to_owned(), 1000.0);
+        last_access.insert("art".to_owned(), 5000.0);
+
+        let home = HashSet::from([0_i64]);
+        let scores = surprise_scores(&graph, &walk_visits, &home, &last_access);
+
+        assert!(!scores.is_empty(), "should produce surprise scores");
+
+        let art_score = scores.iter().find(|(id, _)| id == "art").map(|(_, s)| *s);
+        let wasm_score = scores.iter().find(|(id, _)| id == "wasm").map(|(_, s)| *s);
+
+        assert!(
+            art_score > wasm_score,
+            "recently-unaccessed cross-community entity should have higher surprise"
+        );
+    }
+
+    #[test]
+    fn score_discoveries_balances_relevance_and_novelty() {
+        let graph = build_test_graph();
+        let seeds = vec!["rust".to_owned()];
+        let distances = bfs_distances(&graph, "rust", 4);
+        let config = SerendipityConfig {
+            novelty_weight: 0.5,
+            ..SerendipityConfig::default()
+        };
+
+        let discoveries = score_discoveries(&graph, &seeds, &distances, &config);
+
+        assert!(!discoveries.is_empty(), "should find discoveries from rust");
+
+        for d in &discoveries {
+            assert!(d.serendipity_score > 0.0, "score should be positive");
+            assert!(d.relevance > 0.0, "relevance should be positive");
+        }
+    }
+
+    #[test]
+    fn high_novelty_weight_favors_distant_communities() {
+        let graph = build_test_graph();
+        let seeds = vec!["rust".to_owned()];
+        let distances = bfs_distances(&graph, "rust", 6);
+
+        let high_novelty = SerendipityConfig {
+            novelty_weight: 0.9,
+            ..SerendipityConfig::default()
+        };
+
+        let high_results = score_discoveries(&graph, &seeds, &distances, &high_novelty);
+
+        assert!(!high_results.is_empty(), "high novelty should find results");
+
+        let high_top_community = high_results[0].community;
+        let rust_community = graph.nodes.get("rust").map_or(-1, |n| n.community);
+        assert_ne!(
+            high_top_community, rust_community,
+            "high novelty should prefer cross-community entities"
+        );
+    }
+
+    #[test]
+    fn find_path_between_connected_entities() {
+        let graph = build_test_graph();
+
+        let path = find_path(&graph, "rust", "ml", 6);
+        assert!(path.is_some(), "should find path from rust to ml");
+
+        let path = path.expect("path exists");
+        assert!(path.length >= 2, "rust→ml requires at least 2 hops");
+        assert!(!path.edge_labels.is_empty(), "path should have edge labels");
+    }
+
+    #[test]
+    fn find_path_returns_none_for_disconnected() {
+        let mut graph = build_test_graph();
+        graph.add_node(GraphNode {
+            entity_id: EntityId::new("isolated").expect("valid test id"),
+            name: "Isolated Node".to_owned(),
+            pagerank: 0.0,
+            community: 99,
+            neighbors: vec![],
+        });
+
+        let path = find_path(&graph, "rust", "isolated", 6);
+        assert!(path.is_none(), "should not find path to isolated node");
+    }
+
+    #[test]
+    fn find_path_respects_max_depth() {
+        let graph = build_test_graph();
+
+        let path = find_path(&graph, "rust", "art", 1);
+        assert!(path.is_none(), "should not find rust→art within 1 hop");
+
+        let path = find_path(&graph, "rust", "art", 6);
+        assert!(path.is_some(), "should find rust→art within 6 hops");
+    }
+
+    #[test]
+    fn explore_from_returns_interesting_entities() {
+        let graph = build_test_graph();
+        let config = SerendipityConfig::default();
+
+        let paths = explore_from(&graph, "rust", &config);
+
+        assert!(!paths.is_empty(), "should find exploration paths from rust");
+
+        for path in &paths {
+            assert!(path.length > 0, "path should have non-zero length");
+            assert!(!path.nodes.is_empty(), "path should have at least one node");
+        }
+    }
+
+    #[test]
+    fn explore_from_cross_community_paths_rank_higher() {
+        let graph = build_test_graph();
+        let config = SerendipityConfig::default();
+
+        let paths = explore_from(&graph, "rust", &config);
+
+        if paths.len() >= 2 {
+            assert!(
+                paths[0].interest_score >= paths[1].interest_score,
+                "paths should be ranked by interest score"
+            );
+        }
+    }
+
+    #[test]
+    fn select_injection_picks_surprising_fact() {
+        let discoveries = vec![
+            Discovery {
+                entity_id: EntityId::new("ml").expect("valid test id"),
+                name: "Machine Learning".to_owned(),
+                serendipity_score: 0.8,
+                relevance: 0.4,
+                novelty: 0.9,
+                surprise: 0.6,
+                graph_distance: Some(2),
+                community: 2,
+            },
+            Discovery {
+                entity_id: EntityId::new("wasm").expect("valid test id"),
+                name: "WebAssembly".to_owned(),
+                serendipity_score: 0.5,
+                relevance: 0.8,
+                novelty: 0.2,
+                surprise: 0.1,
+                graph_distance: Some(1),
+                community: 1,
+            },
+        ];
+
+        let mut fact_contents = HashMap::new();
+        fact_contents.insert(
+            "ml".to_owned(),
+            (
+                "fact-ml-1".to_owned(),
+                "Neural networks can compose music".to_owned(),
+            ),
+        );
+
+        let config = SerendipityConfig::default();
+        let injection = select_injection(&discoveries, &fact_contents, &config);
+
+        assert!(injection.is_some(), "should select an injection");
+        let injection = injection.expect("injection exists");
+        assert_eq!(injection.fact_id, "fact-ml-1");
+        assert!(injection.surprise_score > 0.0);
+    }
+
+    #[test]
+    fn select_injection_none_when_no_content() {
+        let discoveries = vec![Discovery {
+            entity_id: EntityId::new("ml").expect("valid test id"),
+            name: "Machine Learning".to_owned(),
+            serendipity_score: 0.8,
+            relevance: 0.4,
+            novelty: 0.9,
+            surprise: 0.6,
+            graph_distance: Some(2),
+            community: 2,
+        }];
+
+        let fact_contents = HashMap::new();
+        let config = SerendipityConfig::default();
+        let injection = select_injection(&discoveries, &fact_contents, &config);
+
+        assert!(injection.is_none(), "should return None when no content");
+    }
+
+    #[test]
+    fn graph_snapshot_add_and_query() {
+        let mut graph = GraphSnapshot::default();
+        graph.add_node(GraphNode {
+            entity_id: EntityId::new("a").expect("valid test id"),
+            name: "A".to_owned(),
+            pagerank: 0.5,
+            community: 0,
+            neighbors: vec![],
+        });
+        graph.add_node(GraphNode {
+            entity_id: EntityId::new("b").expect("valid test id"),
+            name: "B".to_owned(),
+            pagerank: 0.3,
+            community: 1,
+            neighbors: vec![],
+        });
+        graph.add_edge("a", "b", "knows");
+
+        assert_eq!(graph.node_count(), 2);
+        assert_eq!(graph.neighbors("a"), vec!["b"]);
+        assert_eq!(graph.neighbors("b"), vec!["a"]);
+        assert!((graph.max_pagerank - 0.5).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn bfs_distances_correct() {
+        let graph = build_test_graph();
+        let distances = bfs_distances(&graph, "rust", 4);
+
+        assert_eq!(
+            distances.get("rust").copied(),
+            Some(0),
+            "source should be 0"
+        );
+        assert_eq!(
+            distances.get("python").copied(),
+            Some(1),
+            "python is 1 hop from rust"
+        );
+        assert_eq!(
+            distances.get("wasm").copied(),
+            Some(1),
+            "wasm is 1 hop from rust"
+        );
+        assert_eq!(
+            distances.get("ml").copied(),
+            Some(2),
+            "ml is 2 hops from rust"
+        );
+    }
+
+    #[test]
+    fn explored_path_serde_roundtrip() {
+        let path = ExploredPath {
+            nodes: vec![
+                EntityId::new("a").expect("valid test id"),
+                EntityId::new("b").expect("valid test id"),
+            ],
+            edge_labels: vec!["knows".to_owned()],
+            length: 1,
+            communities_traversed: 2,
+            interest_score: 0.75,
+        };
+        let json = serde_json::to_string(&path).expect("ExploredPath serialization");
+        let back: ExploredPath = serde_json::from_str(&json).expect("ExploredPath deserialization");
+        assert_eq!(path.length, back.length, "length should survive roundtrip");
+        assert_eq!(
+            path.nodes.len(),
+            back.nodes.len(),
+            "nodes should survive roundtrip"
+        );
+    }
+
+    #[test]
+    fn discovery_serde_roundtrip() {
+        let discovery = Discovery {
+            entity_id: EntityId::new("test").expect("valid test id"),
+            name: "Test Entity".to_owned(),
+            serendipity_score: 0.75,
+            relevance: 0.5,
+            novelty: 0.8,
+            surprise: 0.6,
+            graph_distance: Some(3),
+            community: 2,
+        };
+        let json = serde_json::to_string(&discovery).expect("Discovery serialization");
+        let back: Discovery = serde_json::from_str(&json).expect("Discovery deserialization");
+        assert_eq!(
+            discovery.entity_id, back.entity_id,
+            "entity_id should survive roundtrip"
+        );
+        assert!(
+            (discovery.serendipity_score - back.serendipity_score).abs() < f64::EPSILON,
+            "serendipity_score should survive roundtrip"
+        );
+    }
+}

--- a/crates/mneme/src/lib.rs
+++ b/crates/mneme/src/lib.rs
@@ -58,6 +58,8 @@ pub use aletheia_graphe::types;
 pub use aletheia_episteme::conflict;
 /// LLM-driven fact consolidation for knowledge maintenance.
 pub use aletheia_episteme::consolidation;
+/// Multi-factor temporal decay with lifecycle stages and graduated pruning.
+pub use aletheia_episteme::decay;
 /// Embedding provider trait and implementations (candle, mock).
 pub use aletheia_episteme::embedding;
 /// LLM-driven knowledge extraction pipeline (entities, relationships, facts).
@@ -76,6 +78,8 @@ pub use aletheia_episteme::knowledge_store;
 pub use aletheia_episteme::query;
 /// 6-factor recall scoring engine for knowledge retrieval ranking.
 pub use aletheia_episteme::recall;
+/// Serendipity engine: cross-domain discovery, surprise scoring, and context injection.
+pub use aletheia_episteme::serendipity;
 /// Skill storage helpers and SKILL.md parser.
 pub use aletheia_episteme::skill;
 /// Skill auto-capture: heuristic filter, signature hashing, and candidate tracking.


### PR DESCRIPTION
## Summary

- **Temporal decay** (#1886): multi-factor decay combining FSRS recency, logarithmic frequency, epistemic tier confidence, reinforcement signals, and cross-agent access multiplier. Knowledge lifecycle stages (Active → Fading → Dormant → Archived) with graduated pruning and stage transition detection.
- **Serendipity engine** (#1887): random walk exploration with deterministic seeding, surprise scoring (reachability × recency × cross-community × obscurity), BFS path finding, novel entity exploration, and serendipity injection for context enrichment. Operates on pure `GraphSnapshot` without store access.

### Files changed

| File | Change |
|------|--------|
| `crates/eidos/src/knowledge.rs` | `KnowledgeStage` enum, `StageTransition` struct, threshold constants |
| `crates/episteme/src/decay.rs` | New: multi-factor decay engine (20 tests) |
| `crates/episteme/src/serendipity.rs` | New: serendipity engine (17 tests) |
| `crates/episteme/src/lib.rs` | Module declarations for decay, serendipity |
| `crates/episteme/Cargo.toml` | Added `rand` dependency |
| `crates/mneme/src/lib.rs` | Re-exports for decay, serendipity |
| `Cargo.lock` | Updated lockfile |

## Test plan

- [x] `cargo test -p aletheia-episteme decay::tests` — 20 tests pass
- [x] `cargo test -p aletheia-episteme serendipity::tests` — 17 tests pass
- [x] `cargo test --workspace` — all tests pass
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy -p aletheia-episteme --lib -- -D warnings` — clean (pre-existing warnings in other episteme modules unchanged)

Closes #1886, closes #1887