### PR TITLE
feat(dianoia): state reconciler and verification workflow

### DIFF
--- a/crates/aletheia/src/planning_adapter.rs
+++ b/crates/aletheia/src/planning_adapter.rs
@@ -295,6 +295,70 @@ impl PlanningService for FilesystemPlanningService {
                 .context(TaskJoinSnafu)?
         })
     }
+
+    fn verify_criteria(
+        &self,
+        project_id: &str,
+        phase_id: &str,
+        criteria_json: &str,
+    ) -> Pin<Box<dyn Future<Output = Result<String, PlanningAdapterError>> + Send + '_>> {
+        let root = self.projects_root.clone();
+        let project_id = project_id.to_owned();
+        let phase_id = phase_id.to_owned();
+        let criteria_json = criteria_json.to_owned();
+        Box::pin(async move {
+            tokio::task::spawn_blocking(move || {
+                let ws_path = root.join(&project_id);
+                let ws = ProjectWorkspace::open(&ws_path).map_err(|e| {
+                    WorkspaceSnafu {
+                        message: e.to_string(),
+                    }
+                    .build()
+                })?;
+                let project = ws.load_project().map_err(|e| {
+                    LoadProjectSnafu {
+                        message: e.to_string(),
+                    }
+                    .build()
+                })?;
+
+                let phase_ulid: ulid::Ulid = phase_id.parse().map_err(|e: ulid::DecodeError| {
+                    InvalidIdSnafu {
+                        kind: "phase_id".to_owned(),
+                        message: e.to_string(),
+                    }
+                    .build()
+                })?;
+
+                let phase = project
+                    .phases
+                    .iter()
+                    .find(|p| p.id == phase_ulid)
+                    .ok_or_else(|| {
+                        NotFoundSnafu {
+                            kind: "phase",
+                            id: &phase_id,
+                        }
+                        .build()
+                    })?;
+
+                let inputs: Vec<aletheia_dianoia::verify::CriterionInput> =
+                    serde_json::from_str(&criteria_json).context(SerializeSnafu)?;
+
+                let result = aletheia_dianoia::verify::verify_phase(phase, &inputs);
+                let traces = aletheia_dianoia::verify::trace_goals(phase, &result.criteria);
+
+                let output = serde_json::json!({
+                    "verification": result,
+                    "goal_traces": traces,
+                });
+
+                serde_json::to_string_pretty(&output).context(SerializeSnafu)
+            })
+            .await
+            .context(TaskJoinSnafu)?
+        })
+    }
 }
 
 fn parse_mode(

--- a/crates/dianoia/src/lib.rs
+++ b/crates/dianoia/src/lib.rs
@@ -18,10 +18,14 @@ pub mod phase;
 pub mod plan;
 /// Project types and lifecycle management: creation, phase tracking, and state transitions.
 pub mod project;
+/// State reconciler: keeps planning state consistent between database and filesystem.
+pub mod reconciler;
 /// Project lifecycle state machine: valid transitions, pause/resume, and terminal states.
 pub mod state;
 /// Pattern-based stuck detection: repeated errors, same-args loops, alternating failures, escalating retries.
 pub mod stuck;
+/// Verification workflow: goal-backward tracing against phase success criteria.
+pub mod verify;
 /// On-disk workspace persistence: project serialization, blocker files, and directory layout.
 pub mod workspace;
 
@@ -36,4 +40,7 @@ mod assertions {
     assert_impl_all!(crate::stuck::StuckDetector: Send, Sync);
     assert_impl_all!(crate::handoff::HandoffFile: Send, Sync);
     assert_impl_all!(crate::handoff::HandoffContext: Send, Sync);
+    assert_impl_all!(crate::verify::VerificationResult: Send, Sync);
+    assert_impl_all!(crate::reconciler::ReconciliationResult: Send, Sync);
+    assert_impl_all!(crate::reconciler::ReconciliationSummary: Send, Sync);
 }

--- a/crates/dianoia/src/reconciler.rs
+++ b/crates/dianoia/src/reconciler.rs
@@ -1,0 +1,588 @@
+//! State reconciler: keeps planning state consistent between two sources.
+//!
+//! Both database and filesystem are authoritative. On startup (or periodically),
+//! the reconciler compares two project snapshots and determines which direction
+//! to sync. Conflicts are logged for manual review.
+
+use serde::{Deserialize, Serialize};
+
+use crate::project::Project;
+
+/// A project snapshot from a single source, tagged with its origin and timestamp.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProjectSnapshot {
+    /// The project state from this source.
+    pub project: Project,
+    /// Which source this snapshot came from.
+    pub origin: SnapshotOrigin,
+}
+
+/// Where a project snapshot was loaded from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum SnapshotOrigin {
+    /// Loaded from the database.
+    Database,
+    /// Loaded from the filesystem (workspace JSON).
+    Filesystem,
+}
+
+impl std::fmt::Display for SnapshotOrigin {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Database => f.write_str("database"),
+            Self::Filesystem => f.write_str("filesystem"),
+        }
+    }
+}
+
+/// Direction of reconciliation for a single project.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum ReconciliationDirection {
+    /// Database is newer; regenerate filesystem from DB.
+    DbToFiles,
+    /// Filesystem is newer; import into DB.
+    FilesToDb,
+    /// Both sources are in sync (within tolerance).
+    InSync,
+    /// Project exists only in the database.
+    DbOnly,
+    /// Project exists only on the filesystem.
+    FilesOnly,
+}
+
+impl std::fmt::Display for ReconciliationDirection {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::DbToFiles => f.write_str("db-to-files"),
+            Self::FilesToDb => f.write_str("files-to-db"),
+            Self::InSync => f.write_str("in-sync"),
+            Self::DbOnly => f.write_str("db-only"),
+            Self::FilesOnly => f.write_str("files-only"),
+        }
+    }
+}
+
+/// A conflict detected during reconciliation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ConflictEntry {
+    /// Which field diverged between the two sources.
+    pub field: String,
+    /// Value from the database source.
+    pub db_value: String,
+    /// Value from the filesystem source.
+    pub fs_value: String,
+    /// Which source won (newest-wins).
+    pub resolution: SnapshotOrigin,
+}
+
+/// Result of reconciling a single project.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReconciliationResult {
+    /// The project ID that was reconciled.
+    pub project_id: String,
+    /// Which direction the sync went.
+    pub direction: ReconciliationDirection,
+    /// Conflicts detected between the two sources.
+    pub conflicts: Vec<ConflictEntry>,
+    /// The winning project state after reconciliation.
+    pub resolved: Option<Project>,
+    /// Errors encountered during reconciliation.
+    pub errors: Vec<String>,
+}
+
+/// Summary of reconciling all known projects.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReconciliationSummary {
+    /// Per-project results.
+    pub projects: Vec<ReconciliationResult>,
+    /// Total number of errors across all projects.
+    pub total_errors: usize,
+    /// Total number of conflicts detected.
+    pub total_conflicts: usize,
+}
+
+/// Tolerance in seconds for timestamp comparison. Differences within this
+/// window are treated as "in sync."
+const TIMESTAMP_TOLERANCE_SECS: i64 = 5;
+
+/// Reconcile two optional project snapshots into a single result.
+///
+/// Both database and filesystem snapshots are optional: a project may exist
+/// in only one source. When both exist, the newest-wins strategy applies
+/// and conflicts are logged.
+#[must_use]
+pub fn reconcile(
+    db_snapshot: Option<&ProjectSnapshot>,
+    fs_snapshot: Option<&ProjectSnapshot>,
+) -> ReconciliationResult {
+    match (db_snapshot, fs_snapshot) {
+        (Some(db), None) => ReconciliationResult {
+            project_id: db.project.id.to_string(),
+            direction: ReconciliationDirection::DbOnly,
+            conflicts: Vec::new(),
+            resolved: Some(db.project.clone()),
+            errors: Vec::new(),
+        },
+
+        (None, Some(fs)) => ReconciliationResult {
+            project_id: fs.project.id.to_string(),
+            direction: ReconciliationDirection::FilesOnly,
+            conflicts: Vec::new(),
+            resolved: Some(fs.project.clone()),
+            errors: Vec::new(),
+        },
+
+        (None, None) => ReconciliationResult {
+            project_id: String::new(),
+            direction: ReconciliationDirection::InSync,
+            conflicts: Vec::new(),
+            resolved: None,
+            errors: vec!["no snapshots provided".to_owned()],
+        },
+
+        (Some(db), Some(fs)) => reconcile_both(db, fs),
+    }
+}
+
+/// Reconcile when both sources have the project.
+fn reconcile_both(db: &ProjectSnapshot, fs: &ProjectSnapshot) -> ReconciliationResult {
+    let project_id = db.project.id.to_string();
+    let mut conflicts = Vec::new();
+
+    detect_conflicts(&db.project, &fs.project, &mut conflicts);
+
+    let diff_secs = db
+        .project
+        .updated_at
+        .as_second()
+        .saturating_sub(fs.project.updated_at.as_second());
+
+    let (direction, winner) = if diff_secs > TIMESTAMP_TOLERANCE_SECS {
+        (ReconciliationDirection::DbToFiles, SnapshotOrigin::Database)
+    } else if diff_secs < -TIMESTAMP_TOLERANCE_SECS {
+        (
+            ReconciliationDirection::FilesToDb,
+            SnapshotOrigin::Filesystem,
+        )
+    } else {
+        // WHY: within tolerance, prefer DB as canonical source
+        (ReconciliationDirection::InSync, SnapshotOrigin::Database)
+    };
+
+    for conflict in &mut conflicts {
+        conflict.resolution = winner;
+    }
+
+    let resolved = match winner {
+        SnapshotOrigin::Database => db.project.clone(),
+        SnapshotOrigin::Filesystem => fs.project.clone(),
+    };
+
+    ReconciliationResult {
+        project_id,
+        direction,
+        conflicts,
+        resolved: Some(resolved),
+        errors: Vec::new(),
+    }
+}
+
+/// Compare two projects and log field-level conflicts.
+fn detect_conflicts(db: &Project, fs: &Project, conflicts: &mut Vec<ConflictEntry>) {
+    if db.name != fs.name {
+        conflicts.push(ConflictEntry {
+            field: "name".to_owned(),
+            db_value: db.name.clone(),
+            fs_value: fs.name.clone(),
+            resolution: SnapshotOrigin::Database,
+        });
+    }
+
+    if db.description != fs.description {
+        conflicts.push(ConflictEntry {
+            field: "description".to_owned(),
+            db_value: db.description.clone(),
+            fs_value: fs.description.clone(),
+            resolution: SnapshotOrigin::Database,
+        });
+    }
+
+    if db.state != fs.state {
+        conflicts.push(ConflictEntry {
+            field: "state".to_owned(),
+            db_value: format!("{:?}", db.state),
+            fs_value: format!("{:?}", fs.state),
+            resolution: SnapshotOrigin::Database,
+        });
+    }
+
+    if db.phases.len() != fs.phases.len() {
+        conflicts.push(ConflictEntry {
+            field: "phases.len".to_owned(),
+            db_value: db.phases.len().to_string(),
+            fs_value: fs.phases.len().to_string(),
+            resolution: SnapshotOrigin::Database,
+        });
+    }
+}
+
+/// Reconcile multiple projects from two source sets.
+///
+/// Matches projects by ID across both sets and produces a summary.
+#[must_use]
+pub fn reconcile_all(
+    db_snapshots: &[ProjectSnapshot],
+    fs_snapshots: &[ProjectSnapshot],
+) -> ReconciliationSummary {
+    let mut seen = std::collections::HashSet::new();
+    let mut results = Vec::new();
+
+    let db_by_id: std::collections::HashMap<_, _> =
+        db_snapshots.iter().map(|s| (s.project.id, s)).collect();
+    let fs_by_id: std::collections::HashMap<_, _> =
+        fs_snapshots.iter().map(|s| (s.project.id, s)).collect();
+
+    for id in db_by_id.keys().chain(fs_by_id.keys()) {
+        if !seen.insert(*id) {
+            continue;
+        }
+        let db = db_by_id.get(id).copied();
+        let fs = fs_by_id.get(id).copied();
+        results.push(reconcile(db, fs));
+    }
+
+    let total_errors: usize = results.iter().map(|r| r.errors.len()).sum();
+    let total_conflicts: usize = results.iter().map(|r| r.conflicts.len()).sum();
+
+    ReconciliationSummary {
+        projects: results,
+        total_errors,
+        total_conflicts,
+    }
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "test assertions")]
+#[expect(
+    clippy::items_after_statements,
+    reason = "test-local imports near usage"
+)]
+mod tests {
+    use super::*;
+    use crate::project::ProjectMode;
+    use crate::state::ProjectState;
+
+    fn make_project(name: &str) -> Project {
+        Project::new(
+            name.to_owned(),
+            format!("{name} description"),
+            ProjectMode::Full,
+            "alice".to_owned(),
+        )
+    }
+
+    fn make_snapshot(project: Project, origin: SnapshotOrigin) -> ProjectSnapshot {
+        ProjectSnapshot { project, origin }
+    }
+
+    #[test]
+    fn db_only_project_resolves_to_db() {
+        let project = make_project("db-only");
+        let snap = make_snapshot(project.clone(), SnapshotOrigin::Database);
+
+        let result = reconcile(Some(&snap), None);
+
+        assert_eq!(result.direction, ReconciliationDirection::DbOnly);
+        assert!(result.conflicts.is_empty());
+        assert_eq!(result.resolved.as_ref().unwrap().id, project.id);
+    }
+
+    #[test]
+    fn fs_only_project_resolves_to_fs() {
+        let project = make_project("fs-only");
+        let snap = make_snapshot(project.clone(), SnapshotOrigin::Filesystem);
+
+        let result = reconcile(None, Some(&snap));
+
+        assert_eq!(result.direction, ReconciliationDirection::FilesOnly);
+        assert!(result.conflicts.is_empty());
+        assert_eq!(result.resolved.as_ref().unwrap().id, project.id);
+    }
+
+    #[test]
+    fn no_snapshots_returns_error() {
+        let result = reconcile(None, None);
+
+        assert_eq!(result.direction, ReconciliationDirection::InSync);
+        assert!(!result.errors.is_empty());
+        assert!(result.resolved.is_none());
+    }
+
+    #[test]
+    fn identical_projects_are_in_sync() {
+        let project = make_project("synced");
+        let db = make_snapshot(project.clone(), SnapshotOrigin::Database);
+        let fs = make_snapshot(project, SnapshotOrigin::Filesystem);
+
+        let result = reconcile(Some(&db), Some(&fs));
+
+        assert_eq!(result.direction, ReconciliationDirection::InSync);
+        assert!(result.conflicts.is_empty());
+    }
+
+    #[test]
+    fn db_newer_wins() {
+        let mut db_project = make_project("newer-db");
+        // WHY: advance timestamp beyond tolerance to trigger db-to-files
+        db_project.updated_at = db_project
+            .updated_at
+            .checked_add(jiff::SignedDuration::from_secs(10))
+            .unwrap();
+        let fs_project = make_project("newer-db");
+
+        let db = ProjectSnapshot {
+            project: db_project.clone(),
+            origin: SnapshotOrigin::Database,
+        };
+        let fs = ProjectSnapshot {
+            project: fs_project,
+            origin: SnapshotOrigin::Filesystem,
+        };
+
+        let result = reconcile(Some(&db), Some(&fs));
+
+        assert_eq!(result.direction, ReconciliationDirection::DbToFiles);
+        assert_eq!(
+            result.resolved.as_ref().unwrap().updated_at,
+            db_project.updated_at
+        );
+    }
+
+    #[test]
+    fn fs_newer_wins() {
+        let db_project = make_project("newer-fs");
+        let mut fs_project = make_project("newer-fs");
+        fs_project.updated_at = fs_project
+            .updated_at
+            .checked_add(jiff::SignedDuration::from_secs(10))
+            .unwrap();
+
+        let db = ProjectSnapshot {
+            project: db_project,
+            origin: SnapshotOrigin::Database,
+        };
+        let fs = ProjectSnapshot {
+            project: fs_project.clone(),
+            origin: SnapshotOrigin::Filesystem,
+        };
+
+        let result = reconcile(Some(&db), Some(&fs));
+
+        assert_eq!(result.direction, ReconciliationDirection::FilesToDb);
+        assert_eq!(
+            result.resolved.as_ref().unwrap().updated_at,
+            fs_project.updated_at
+        );
+    }
+
+    #[test]
+    fn detects_name_conflict() {
+        let mut db_project = make_project("db-name");
+        let mut fs_project = make_project("fs-name");
+
+        // WHY: set same ID so reconciler treats them as the same project
+        fs_project.id = db_project.id;
+        db_project.updated_at = db_project
+            .updated_at
+            .checked_add(jiff::SignedDuration::from_secs(10))
+            .unwrap();
+
+        let db = make_snapshot(db_project, SnapshotOrigin::Database);
+        let fs = make_snapshot(fs_project, SnapshotOrigin::Filesystem);
+
+        let result = reconcile(Some(&db), Some(&fs));
+
+        assert!(!result.conflicts.is_empty());
+        let name_conflict = result.conflicts.iter().find(|c| c.field == "name").unwrap();
+        assert_eq!(name_conflict.db_value, "db-name");
+        assert_eq!(name_conflict.fs_value, "fs-name");
+        assert_eq!(name_conflict.resolution, SnapshotOrigin::Database);
+    }
+
+    #[test]
+    fn detects_state_conflict() {
+        let mut db_project = make_project("state-conflict");
+        let mut fs_project = make_project("state-conflict");
+        fs_project.id = db_project.id;
+        db_project.state = ProjectState::Executing;
+        fs_project.state = ProjectState::Researching;
+        db_project.updated_at = db_project
+            .updated_at
+            .checked_add(jiff::SignedDuration::from_secs(10))
+            .unwrap();
+
+        let db = make_snapshot(db_project, SnapshotOrigin::Database);
+        let fs = make_snapshot(fs_project, SnapshotOrigin::Filesystem);
+
+        let result = reconcile(Some(&db), Some(&fs));
+
+        let state_conflict = result
+            .conflicts
+            .iter()
+            .find(|c| c.field == "state")
+            .unwrap();
+        assert!(state_conflict.db_value.contains("Executing"));
+        assert!(state_conflict.fs_value.contains("Researching"));
+    }
+
+    #[test]
+    fn detects_phase_count_conflict() {
+        let mut db_project = make_project("phase-count");
+        let mut fs_project = make_project("phase-count");
+        fs_project.id = db_project.id;
+
+        use crate::phase::Phase;
+        db_project.add_phase(Phase::new("P1".to_owned(), "g1".to_owned(), 1));
+        db_project.updated_at = db_project
+            .updated_at
+            .checked_add(jiff::SignedDuration::from_secs(10))
+            .unwrap();
+
+        let db = make_snapshot(db_project, SnapshotOrigin::Database);
+        let fs = make_snapshot(fs_project, SnapshotOrigin::Filesystem);
+
+        let result = reconcile(Some(&db), Some(&fs));
+
+        let phase_conflict = result
+            .conflicts
+            .iter()
+            .find(|c| c.field == "phases.len")
+            .unwrap();
+        assert_eq!(phase_conflict.db_value, "1");
+        assert_eq!(phase_conflict.fs_value, "0");
+    }
+
+    #[test]
+    fn reconcile_all_matches_by_id() {
+        let p1 = make_project("project-1");
+        let p2 = make_project("project-2");
+        let p3 = make_project("project-3");
+
+        let db_snaps = vec![
+            make_snapshot(p1.clone(), SnapshotOrigin::Database),
+            make_snapshot(p2.clone(), SnapshotOrigin::Database),
+        ];
+        let fs_snaps = vec![
+            make_snapshot(p2, SnapshotOrigin::Filesystem),
+            make_snapshot(p3, SnapshotOrigin::Filesystem),
+        ];
+
+        let summary = reconcile_all(&db_snaps, &fs_snaps);
+
+        assert_eq!(summary.projects.len(), 3);
+
+        let p1_result = summary
+            .projects
+            .iter()
+            .find(|r| r.project_id == p1.id.to_string())
+            .unwrap();
+        assert_eq!(p1_result.direction, ReconciliationDirection::DbOnly);
+    }
+
+    #[test]
+    fn within_tolerance_treated_as_in_sync() {
+        let mut db_project = make_project("tolerance");
+        let mut fs_project = make_project("tolerance");
+        fs_project.id = db_project.id;
+
+        // WHY: 3 seconds is within the 5-second tolerance window
+        db_project.updated_at = db_project
+            .updated_at
+            .checked_add(jiff::SignedDuration::from_secs(3))
+            .unwrap();
+
+        let db = make_snapshot(db_project, SnapshotOrigin::Database);
+        let fs = make_snapshot(fs_project, SnapshotOrigin::Filesystem);
+
+        let result = reconcile(Some(&db), Some(&fs));
+
+        assert_eq!(result.direction, ReconciliationDirection::InSync);
+    }
+
+    #[test]
+    fn fs_wins_conflict_resolution_when_newer() {
+        let mut db_project = make_project("fs-wins");
+        let mut fs_project = make_project("fs-wins-modified");
+        fs_project.id = db_project.id;
+        db_project.name = "fs-wins".to_owned();
+        fs_project.name = "fs-wins-modified".to_owned();
+
+        fs_project.updated_at = fs_project
+            .updated_at
+            .checked_add(jiff::SignedDuration::from_secs(10))
+            .unwrap();
+
+        let db = make_snapshot(db_project, SnapshotOrigin::Database);
+        let fs = make_snapshot(fs_project, SnapshotOrigin::Filesystem);
+
+        let result = reconcile(Some(&db), Some(&fs));
+
+        assert_eq!(result.direction, ReconciliationDirection::FilesToDb);
+        let name_conflict = result.conflicts.iter().find(|c| c.field == "name").unwrap();
+        assert_eq!(name_conflict.resolution, SnapshotOrigin::Filesystem);
+    }
+
+    #[test]
+    fn reconcile_all_empty_inputs() {
+        let summary = reconcile_all(&[], &[]);
+
+        assert!(summary.projects.is_empty());
+        assert_eq!(summary.total_errors, 0);
+        assert_eq!(summary.total_conflicts, 0);
+    }
+
+    #[test]
+    fn reconcile_all_counts_errors_and_conflicts() {
+        let mut db_project = make_project("counted");
+        let mut fs_project = make_project("counted-different");
+        fs_project.id = db_project.id;
+        db_project.updated_at = db_project
+            .updated_at
+            .checked_add(jiff::SignedDuration::from_secs(10))
+            .unwrap();
+
+        let db_snaps = vec![make_snapshot(db_project, SnapshotOrigin::Database)];
+        let fs_snaps = vec![make_snapshot(fs_project, SnapshotOrigin::Filesystem)];
+
+        let summary = reconcile_all(&db_snaps, &fs_snaps);
+
+        assert_eq!(summary.total_errors, 0);
+        assert!(
+            summary.total_conflicts > 0,
+            "expected conflicts from name/description divergence"
+        );
+    }
+
+    #[test]
+    fn snapshot_origin_display() {
+        assert_eq!(SnapshotOrigin::Database.to_string(), "database");
+        assert_eq!(SnapshotOrigin::Filesystem.to_string(), "filesystem");
+    }
+
+    #[test]
+    fn reconciliation_direction_display() {
+        assert_eq!(
+            ReconciliationDirection::DbToFiles.to_string(),
+            "db-to-files"
+        );
+        assert_eq!(
+            ReconciliationDirection::FilesToDb.to_string(),
+            "files-to-db"
+        );
+        assert_eq!(ReconciliationDirection::InSync.to_string(), "in-sync");
+        assert_eq!(ReconciliationDirection::DbOnly.to_string(), "db-only");
+        assert_eq!(ReconciliationDirection::FilesOnly.to_string(), "files-only");
+    }
+}

--- a/crates/dianoia/src/verify.rs
+++ b/crates/dianoia/src/verify.rs
@@ -1,0 +1,567 @@
+//! Verification workflow: goal-backward tracing against phase success criteria.
+//!
+//! Verifies that a phase's success criteria are met by checking each criterion
+//! against provided evidence. Works backward from goals: for each goal, trace
+//! which criteria are met and which have gaps.
+
+use serde::{Deserialize, Serialize};
+
+use crate::phase::Phase;
+
+/// Overall verification status for a phase.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum VerificationStatus {
+    /// All criteria are met.
+    Met,
+    /// Some criteria are met, some are not.
+    PartiallyMet,
+    /// No criteria are met (or critical criteria failed).
+    NotMet,
+}
+
+impl std::fmt::Display for VerificationStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Met => f.write_str("met"),
+            Self::PartiallyMet => f.write_str("partially-met"),
+            Self::NotMet => f.write_str("not-met"),
+        }
+    }
+}
+
+/// Status of an individual criterion.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum CriterionStatus {
+    /// Criterion is satisfied.
+    Met,
+    /// Criterion is partially satisfied.
+    PartiallyMet,
+    /// Criterion is not satisfied.
+    NotMet,
+}
+
+impl std::fmt::Display for CriterionStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Met => f.write_str("met"),
+            Self::PartiallyMet => f.write_str("partially-met"),
+            Self::NotMet => f.write_str("not-met"),
+        }
+    }
+}
+
+/// Evidence supporting a criterion evaluation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Evidence {
+    /// Type of evidence (e.g., "file", "test-result", "output").
+    pub kind: String,
+    /// The evidence content or reference (file path, test output, etc.).
+    pub content: String,
+}
+
+/// A gap found during verification: an unmet or partially-met criterion.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct VerificationGap {
+    /// The criterion text that was evaluated.
+    pub criterion: String,
+    /// Current status of this criterion.
+    pub status: CriterionStatus,
+    /// Detailed explanation of why the criterion is not fully met.
+    pub detail: String,
+    /// Concrete next step to close the gap.
+    pub proposed_fix: String,
+}
+
+/// Evaluation of a single criterion, with status and supporting evidence.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CriterionResult {
+    /// The criterion text being evaluated.
+    pub criterion: String,
+    /// Whether it passed, partially passed, or failed.
+    pub status: CriterionStatus,
+    /// Evidence supporting this evaluation.
+    pub evidence: Vec<Evidence>,
+    /// Explanation of the evaluation outcome.
+    pub detail: String,
+}
+
+/// Full verification result for a phase.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct VerificationResult {
+    /// Overall phase verification status.
+    pub status: VerificationStatus,
+    /// Human-readable summary of the verification outcome.
+    pub summary: String,
+    /// Per-criterion results.
+    pub criteria: Vec<CriterionResult>,
+    /// Gaps that need to be addressed.
+    pub gaps: Vec<VerificationGap>,
+    /// When the verification was performed.
+    pub verified_at: jiff::Timestamp,
+    /// Whether this result was manually overridden.
+    pub overridden: bool,
+    /// Override justification, if any.
+    pub override_note: Option<String>,
+}
+
+/// Input for verifying a single criterion.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CriterionInput {
+    /// The criterion text to evaluate.
+    pub criterion: String,
+    /// Whether the criterion is met.
+    pub status: CriterionStatus,
+    /// Evidence supporting the evaluation.
+    pub evidence: Vec<Evidence>,
+    /// Explanation of the evaluation.
+    pub detail: String,
+    /// If not met, a proposed fix.
+    pub proposed_fix: Option<String>,
+}
+
+/// A goal with its traced criteria mapping.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GoalTrace {
+    /// The goal being traced.
+    pub goal: String,
+    /// Criteria that map to this goal, with their statuses.
+    pub criteria: Vec<CriterionResult>,
+    /// Whether this goal is fully satisfied.
+    pub satisfied: bool,
+}
+
+/// Verify a phase's success criteria against provided evidence.
+///
+/// Takes a phase and a set of criterion evaluations, produces a structured
+/// verification result. The agent provides criterion evaluations, and this
+/// function aggregates them into an overall result.
+#[must_use]
+pub fn verify_phase(phase: &Phase, inputs: &[CriterionInput]) -> VerificationResult {
+    let mut criteria = Vec::with_capacity(inputs.len());
+    let mut gaps = Vec::new();
+
+    for input in inputs {
+        let result = CriterionResult {
+            criterion: input.criterion.clone(),
+            status: input.status,
+            evidence: input.evidence.clone(),
+            detail: input.detail.clone(),
+        };
+        criteria.push(result);
+
+        if input.status != CriterionStatus::Met {
+            gaps.push(VerificationGap {
+                criterion: input.criterion.clone(),
+                status: input.status,
+                detail: input.detail.clone(),
+                proposed_fix: input
+                    .proposed_fix
+                    .clone()
+                    .unwrap_or_else(|| "no fix proposed".to_owned()),
+            });
+        }
+    }
+
+    let status = compute_overall_status(&criteria);
+    let summary = build_summary(phase, &criteria, &gaps);
+
+    VerificationResult {
+        status,
+        summary,
+        criteria,
+        gaps,
+        verified_at: jiff::Timestamp::now(),
+        overridden: false,
+        override_note: None,
+    }
+}
+
+/// Trace goals backward: for each goal, find which criteria contribute to it
+/// and whether the goal is satisfied.
+///
+/// Goals are the phase goal plus any phase requirements. Each criterion is
+/// matched to the goal it most directly supports (by substring containment
+/// or shared significant words).
+#[must_use]
+pub fn trace_goals(phase: &Phase, criteria: &[CriterionResult]) -> Vec<GoalTrace> {
+    let mut goals: Vec<String> = vec![phase.goal.clone()];
+    goals.extend(phase.requirements.iter().cloned());
+
+    goals
+        .into_iter()
+        .map(|goal| {
+            let matching: Vec<CriterionResult> = criteria
+                .iter()
+                .filter(|c| {
+                    let goal_lower = goal.to_lowercase();
+                    let criterion_lower = c.criterion.to_lowercase();
+                    criterion_lower.contains(&goal_lower)
+                        || goal_lower.contains(&criterion_lower)
+                        || shares_significant_words(&goal_lower, &criterion_lower)
+                })
+                .cloned()
+                .collect();
+
+            let satisfied =
+                !matching.is_empty() && matching.iter().all(|c| c.status == CriterionStatus::Met);
+
+            GoalTrace {
+                goal,
+                criteria: matching,
+                satisfied,
+            }
+        })
+        .collect()
+}
+
+/// Override a verification result with a manual justification.
+#[must_use]
+pub fn override_result(mut result: VerificationResult, note: String) -> VerificationResult {
+    result.overridden = true;
+    result.override_note = Some(note);
+    result
+}
+
+/// Compute overall verification status from per-criterion results.
+fn compute_overall_status(criteria: &[CriterionResult]) -> VerificationStatus {
+    if criteria.is_empty() {
+        return VerificationStatus::NotMet;
+    }
+
+    let all_met = criteria.iter().all(|c| c.status == CriterionStatus::Met);
+    let any_met = criteria
+        .iter()
+        .any(|c| c.status == CriterionStatus::Met || c.status == CriterionStatus::PartiallyMet);
+
+    if all_met {
+        VerificationStatus::Met
+    } else if any_met {
+        VerificationStatus::PartiallyMet
+    } else {
+        VerificationStatus::NotMet
+    }
+}
+
+/// Build a human-readable summary of the verification.
+fn build_summary(phase: &Phase, criteria: &[CriterionResult], gaps: &[VerificationGap]) -> String {
+    let met_count = criteria
+        .iter()
+        .filter(|c| c.status == CriterionStatus::Met)
+        .count();
+
+    if gaps.is_empty() {
+        format!(
+            "Phase '{}': all {} criteria met.",
+            phase.name,
+            criteria.len()
+        )
+    } else {
+        format!(
+            "Phase '{}': {}/{} criteria met, {} gaps remaining.",
+            phase.name,
+            met_count,
+            criteria.len(),
+            gaps.len()
+        )
+    }
+}
+
+/// Check whether two strings share significant words (3+ chars).
+fn shares_significant_words(a: &str, b: &str) -> bool {
+    let a_words: Vec<&str> = a.split_whitespace().filter(|w| w.len() >= 3).collect();
+    let b_words: Vec<&str> = b.split_whitespace().filter(|w| w.len() >= 3).collect();
+
+    a_words.iter().any(|w| b_words.contains(w))
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "test assertions")]
+#[expect(
+    clippy::indexing_slicing,
+    reason = "test assertions on known-length collections"
+)]
+mod tests {
+    use super::*;
+
+    fn make_phase() -> Phase {
+        let mut phase = Phase::new(
+            "Foundation".to_owned(),
+            "Build the foundation layer".to_owned(),
+            1,
+        );
+        phase.requirements = vec![
+            "All tests pass".to_owned(),
+            "API endpoints documented".to_owned(),
+        ];
+        phase
+    }
+
+    fn met_input(criterion: &str) -> CriterionInput {
+        CriterionInput {
+            criterion: criterion.to_owned(),
+            status: CriterionStatus::Met,
+            evidence: vec![Evidence {
+                kind: "test_result".to_owned(),
+                content: "all tests passed".to_owned(),
+            }],
+            detail: "criterion satisfied".to_owned(),
+            proposed_fix: None,
+        }
+    }
+
+    fn failed_input(criterion: &str, fix: &str) -> CriterionInput {
+        CriterionInput {
+            criterion: criterion.to_owned(),
+            status: CriterionStatus::NotMet,
+            evidence: Vec::new(),
+            detail: "criterion not satisfied".to_owned(),
+            proposed_fix: Some(fix.to_owned()),
+        }
+    }
+
+    fn partial_input(criterion: &str) -> CriterionInput {
+        CriterionInput {
+            criterion: criterion.to_owned(),
+            status: CriterionStatus::PartiallyMet,
+            evidence: vec![Evidence {
+                kind: "file".to_owned(),
+                content: "src/lib.rs".to_owned(),
+            }],
+            detail: "partially done".to_owned(),
+            proposed_fix: Some("complete the remaining work".to_owned()),
+        }
+    }
+
+    #[test]
+    fn all_criteria_met_returns_met() {
+        let phase = make_phase();
+        let inputs = vec![met_input("tests pass"), met_input("docs complete")];
+
+        let result = verify_phase(&phase, &inputs);
+
+        assert_eq!(result.status, VerificationStatus::Met);
+        assert!(result.gaps.is_empty());
+        assert_eq!(result.criteria.len(), 2);
+        assert!(!result.overridden);
+    }
+
+    #[test]
+    fn no_criteria_returns_not_met() {
+        let phase = make_phase();
+        let result = verify_phase(&phase, &[]);
+
+        assert_eq!(result.status, VerificationStatus::NotMet);
+    }
+
+    #[test]
+    fn mixed_criteria_returns_partially_met() {
+        let phase = make_phase();
+        let inputs = vec![
+            met_input("tests pass"),
+            failed_input("docs complete", "write the docs"),
+        ];
+
+        let result = verify_phase(&phase, &inputs);
+
+        assert_eq!(result.status, VerificationStatus::PartiallyMet);
+        assert_eq!(result.gaps.len(), 1);
+        assert_eq!(result.gaps[0].criterion, "docs complete");
+        assert_eq!(result.gaps[0].proposed_fix, "write the docs");
+    }
+
+    #[test]
+    fn all_criteria_failed_returns_not_met() {
+        let phase = make_phase();
+        let inputs = vec![
+            failed_input("tests pass", "fix tests"),
+            failed_input("docs complete", "write docs"),
+        ];
+
+        let result = verify_phase(&phase, &inputs);
+
+        assert_eq!(result.status, VerificationStatus::NotMet);
+        assert_eq!(result.gaps.len(), 2);
+    }
+
+    #[test]
+    fn partially_met_criterion_creates_gap() {
+        let phase = make_phase();
+        let inputs = vec![partial_input("API coverage")];
+
+        let result = verify_phase(&phase, &inputs);
+
+        assert_eq!(result.status, VerificationStatus::PartiallyMet);
+        assert_eq!(result.gaps.len(), 1);
+        assert_eq!(result.gaps[0].status, CriterionStatus::PartiallyMet);
+    }
+
+    #[test]
+    fn failed_without_fix_gets_default_message() {
+        let phase = make_phase();
+        let inputs = vec![CriterionInput {
+            criterion: "no fix provided".to_owned(),
+            status: CriterionStatus::NotMet,
+            evidence: Vec::new(),
+            detail: "failed".to_owned(),
+            proposed_fix: None,
+        }];
+
+        let result = verify_phase(&phase, &inputs);
+
+        assert_eq!(result.gaps[0].proposed_fix, "no fix proposed");
+    }
+
+    #[test]
+    fn summary_includes_phase_name_and_counts() {
+        let phase = make_phase();
+        let inputs = vec![met_input("tests pass"), failed_input("docs", "write them")];
+
+        let result = verify_phase(&phase, &inputs);
+
+        assert!(
+            result.summary.contains("Foundation"),
+            "summary should contain phase name: {}",
+            result.summary
+        );
+        assert!(
+            result.summary.contains("1/2"),
+            "summary should contain met/total: {}",
+            result.summary
+        );
+    }
+
+    #[test]
+    fn all_met_summary_says_all() {
+        let phase = make_phase();
+        let inputs = vec![met_input("a"), met_input("b")];
+
+        let result = verify_phase(&phase, &inputs);
+
+        assert!(
+            result.summary.contains("all 2 criteria met"),
+            "summary: {}",
+            result.summary
+        );
+    }
+
+    #[test]
+    fn override_sets_flag_and_note() {
+        let phase = make_phase();
+        let inputs = vec![failed_input("criterion", "fix it")];
+        let result = verify_phase(&phase, &inputs);
+
+        let overridden = override_result(result, "accepted risk".to_owned());
+
+        assert!(overridden.overridden);
+        assert_eq!(overridden.override_note.as_deref(), Some("accepted risk"));
+        assert_eq!(overridden.status, VerificationStatus::NotMet);
+    }
+
+    #[test]
+    fn trace_goals_matches_criteria_to_goals() {
+        let phase = make_phase();
+        let criteria = vec![
+            CriterionResult {
+                criterion: "All tests pass in CI".to_owned(),
+                status: CriterionStatus::Met,
+                evidence: Vec::new(),
+                detail: "passed".to_owned(),
+            },
+            CriterionResult {
+                criterion: "API endpoints documented in OpenAPI".to_owned(),
+                status: CriterionStatus::NotMet,
+                evidence: Vec::new(),
+                detail: "missing".to_owned(),
+            },
+        ];
+
+        let traces = trace_goals(&phase, &criteria);
+
+        assert_eq!(traces.len(), 3, "phase goal + 2 requirements = 3 traces");
+
+        let tests_goal = traces.iter().find(|t| t.goal == "All tests pass").unwrap();
+        assert!(tests_goal.satisfied, "tests goal should be satisfied");
+
+        let docs_goal = traces
+            .iter()
+            .find(|t| t.goal == "API endpoints documented")
+            .unwrap();
+        assert!(!docs_goal.satisfied, "docs goal should not be satisfied");
+    }
+
+    #[test]
+    fn trace_goals_empty_criteria_unsatisfied() {
+        let phase = make_phase();
+        let traces = trace_goals(&phase, &[]);
+
+        for trace in &traces {
+            assert!(
+                !trace.satisfied,
+                "empty criteria means no goal is satisfied"
+            );
+        }
+    }
+
+    #[test]
+    fn evidence_preserved_in_result() {
+        let phase = make_phase();
+        let inputs = vec![CriterionInput {
+            criterion: "test".to_owned(),
+            status: CriterionStatus::Met,
+            evidence: vec![
+                Evidence {
+                    kind: "file".to_owned(),
+                    content: "src/main.rs".to_owned(),
+                },
+                Evidence {
+                    kind: "test_result".to_owned(),
+                    content: "42 tests passed".to_owned(),
+                },
+            ],
+            detail: "ok".to_owned(),
+            proposed_fix: None,
+        }];
+
+        let result = verify_phase(&phase, &inputs);
+
+        assert_eq!(result.criteria[0].evidence.len(), 2);
+        assert_eq!(result.criteria[0].evidence[0].kind, "file");
+        assert_eq!(result.criteria[0].evidence[1].content, "42 tests passed");
+    }
+
+    #[test]
+    fn verification_result_serde_roundtrip() {
+        let phase = make_phase();
+        let inputs = vec![
+            met_input("criterion-a"),
+            failed_input("criterion-b", "fix b"),
+        ];
+
+        let result = verify_phase(&phase, &inputs);
+        let json = serde_json::to_string(&result).unwrap();
+        let back: VerificationResult = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(back.status, result.status);
+        assert_eq!(back.criteria.len(), result.criteria.len());
+        assert_eq!(back.gaps.len(), result.gaps.len());
+    }
+
+    #[test]
+    fn verification_status_display() {
+        assert_eq!(VerificationStatus::Met.to_string(), "met");
+        assert_eq!(
+            VerificationStatus::PartiallyMet.to_string(),
+            "partially-met"
+        );
+        assert_eq!(VerificationStatus::NotMet.to_string(), "not-met");
+    }
+
+    #[test]
+    fn criterion_status_display() {
+        assert_eq!(CriterionStatus::Met.to_string(), "met");
+        assert_eq!(CriterionStatus::PartiallyMet.to_string(), "partially-met");
+        assert_eq!(CriterionStatus::NotMet.to_string(), "not-met");
+    }
+}

--- a/crates/organon/src/builtins/planning.rs
+++ b/crates/organon/src/builtins/planning.rs
@@ -13,7 +13,8 @@ use crate::types::{PlanningService, ToolContext, ToolInput, ToolResult};
 mod defs;
 use defs::{
     plan_create_def, plan_discuss_def, plan_execute_def, plan_requirements_def, plan_research_def,
-    plan_roadmap_def, plan_status_def, plan_step_complete_def, plan_step_fail_def, plan_verify_def,
+    plan_roadmap_def, plan_status_def, plan_step_complete_def, plan_step_fail_def,
+    plan_verify_criteria_def, plan_verify_def,
 };
 
 fn require_planning(
@@ -327,6 +328,34 @@ impl ToolExecutor for PlanStepCompleteExecutor {
     }
 }
 
+struct PlanVerifyCriteriaExecutor;
+
+impl ToolExecutor for PlanVerifyCriteriaExecutor {
+    fn execute<'a>(
+        &'a self,
+        input: &'a ToolInput,
+        ctx: &'a ToolContext,
+    ) -> Pin<Box<dyn Future<Output = Result<ToolResult>> + Send + 'a>> {
+        Box::pin(async {
+            let planning = match require_planning(ctx) {
+                Ok(p) => p,
+                Err(r) => return Ok(r),
+            };
+            let project_id = extract_str(&input.arguments, "project_id", &input.name)?;
+            let phase_id = extract_str(&input.arguments, "phase_id", &input.name)?;
+            let criteria = extract_str(&input.arguments, "criteria", &input.name)?;
+
+            match planning
+                .verify_criteria(project_id, phase_id, criteria)
+                .await
+            {
+                Ok(json) => Ok(ToolResult::text(json)),
+                Err(e) => Ok(ToolResult::error(e.to_string())),
+            }
+        })
+    }
+}
+
 struct PlanStepFailExecutor;
 
 impl ToolExecutor for PlanStepFailExecutor {
@@ -368,6 +397,10 @@ pub(crate) fn register(registry: &mut ToolRegistry) -> Result<()> {
     registry.register(plan_status_def(), Box::new(PlanStatusExecutor))?;
     registry.register(plan_step_complete_def(), Box::new(PlanStepCompleteExecutor))?;
     registry.register(plan_step_fail_def(), Box::new(PlanStepFailExecutor))?;
+    registry.register(
+        plan_verify_criteria_def(),
+        Box::new(PlanVerifyCriteriaExecutor),
+    )?;
     Ok(())
 }
 

--- a/crates/organon/src/builtins/planning_defs.rs
+++ b/crates/organon/src/builtins/planning_defs.rs
@@ -404,6 +404,64 @@ pub(super) fn plan_step_complete_def() -> ToolDef {
     }
 }
 
+pub(super) fn plan_verify_criteria_def() -> ToolDef {
+    ToolDef {
+        name: ToolName::new("plan_verify_criteria").expect("valid tool name"), // kanon:ignore RUST/expect
+        description: "Verify phase success criteria with evidence and goal-backward tracing"
+            .to_owned(),
+        extended_description: Some(
+            "Submit criterion evaluations for a phase. Each criterion includes status \
+             (met/partially-met/not-met), evidence (file paths, test results), and detail. \
+             Returns structured verification result with overall status, per-criterion \
+             results, gaps with proposed fixes, and goal-backward traces."
+                .to_owned(),
+        ),
+        input_schema: InputSchema {
+            properties: IndexMap::from([
+                (
+                    "project_id".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::String,
+                        description: "Project ID".to_owned(),
+                        enum_values: None,
+                        default: None,
+                    },
+                ),
+                (
+                    "phase_id".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::String,
+                        description: "Phase ID to verify".to_owned(),
+                        enum_values: None,
+                        default: None,
+                    },
+                ),
+                (
+                    "criteria".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::String,
+                        description: "JSON array of criterion evaluations. Each: \
+                            {criterion: string, status: 'met'|'partially-met'|'not-met', \
+                            evidence: [{kind: string, content: string}], detail: string, \
+                            proposed_fix?: string}"
+                            .to_owned(),
+                        enum_values: None,
+                        default: None,
+                    },
+                ),
+            ]),
+            required: vec![
+                "project_id".to_owned(),
+                "phase_id".to_owned(),
+                "criteria".to_owned(),
+            ],
+        },
+        category: ToolCategory::Planning,
+        reversibility: Reversibility::FullyReversible,
+        auto_activate: false,
+    }
+}
+
 pub(super) fn plan_step_fail_def() -> ToolDef {
     ToolDef {
         name: ToolName::new("plan_step_fail").expect("valid tool name"), // kanon:ignore RUST/expect

--- a/crates/organon/src/builtins/planning_tests.rs
+++ b/crates/organon/src/builtins/planning_tests.rs
@@ -200,6 +200,18 @@ impl PlanningService for MockPlanning {
     ) -> Pin<Box<dyn Future<Output = Result<String, PlanningAdapterError>> + Send + '_>> {
         Box::pin(async { Ok("[]".to_owned()) })
     }
+
+    fn verify_criteria(
+        &self,
+        _project_id: &str,
+        _phase_id: &str,
+        _criteria_json: &str,
+    ) -> Pin<Box<dyn Future<Output = Result<String, PlanningAdapterError>> + Send + '_>> {
+        Box::pin(async {
+            Ok(r#"{"verification":{"status":"Met","summary":"all criteria met"},"goal_traces":[]}"#
+                .to_owned())
+        })
+    }
 }
 
 #[tokio::test]
@@ -209,8 +221,8 @@ async fn register_planning_tools() {
     let planning_tools = reg.definitions_for_category(ToolCategory::Planning);
     assert_eq!(
         planning_tools.len(),
-        10,
-        "expected 10 planning tools to be registered"
+        11,
+        "expected 11 planning tools to be registered"
     );
 }
 
@@ -740,6 +752,7 @@ async fn plan_missing_service_returns_error_for_all_tools() {
         "plan_discuss",
         "plan_execute",
         "plan_verify",
+        "plan_verify_criteria",
         "plan_status",
         "plan_step_complete",
         "plan_step_fail",
@@ -760,4 +773,31 @@ async fn plan_missing_service_returns_error_for_all_tools() {
             "{tool_name}: expected 'not configured' in error"
         );
     }
+}
+
+#[tokio::test]
+async fn plan_verify_criteria_dispatches_to_service() {
+    let mock = Arc::new(MockPlanning::default());
+    let ctx = test_ctx_with_planning(mock);
+    let mut reg = ToolRegistry::new();
+    super::register(&mut reg).expect("register");
+    let criteria = r#"[{"criterion":"tests pass","status":"Met","evidence":[],"detail":"ok"}]"#;
+    let input = ToolInput {
+        name: ToolName::new("plan_verify_criteria").expect("valid"),
+        tool_use_id: "tu_1".to_owned(),
+        arguments: serde_json::json!({
+            "project_id": "proj1",
+            "phase_id": "phase1",
+            "criteria": criteria
+        }),
+    };
+    let result = reg.execute(&input, &ctx).await.expect("execute");
+    assert!(
+        !result.is_error,
+        "plan_verify_criteria should succeed when service is available"
+    );
+    assert!(
+        result.content.text_summary().contains("Met"),
+        "response should include verification status"
+    );
 }

--- a/crates/organon/src/types.rs
+++ b/crates/organon/src/types.rs
@@ -502,6 +502,22 @@ pub trait PlanningService: Send + Sync {
     fn list_projects(
         &self,
     ) -> Pin<Box<dyn Future<Output = Result<String, PlanningAdapterError>> + Send + '_>>;
+
+    /// Verify phase criteria against provided evidence.
+    ///
+    /// `criteria_json` is a JSON array of criterion evaluations, each with:
+    /// `criterion` (string), `status` ("met"/"partially-met"/"not-met"),
+    /// `evidence` (array of `{kind, content}`), `detail` (string),
+    /// and optional `proposed_fix` (string).
+    ///
+    /// Returns a JSON verification result with overall status, per-criterion
+    /// results, gaps, and goal-backward traces.
+    fn verify_criteria(
+        &self,
+        project_id: &str,
+        phase_id: &str,
+        criteria_json: &str,
+    ) -> Pin<Box<dyn Future<Output = Result<String, PlanningAdapterError>> + Send + '_>>;
 }
 
 /// A result from knowledge store search.


### PR DESCRIPTION
## Summary
- **State reconciler** (`reconciler.rs`): pure-domain module for DB/filesystem planning state consistency — compares `ProjectSnapshot` pairs by timestamp, resolves with newest-wins, logs field-level conflicts (name, state, phase count), 5-second tolerance window, batch reconciliation support
- **Verification workflow** (`verify.rs`): goal-backward tracing against phase success criteria — aggregates `CriterionInput` evaluations into structured `VerificationResult` with per-criterion pass/fail, evidence preservation, gap identification with proposed fixes, manual override support
- **Organon tool** (`plan_verify_criteria`): exposes verification via `PlanningService` trait, adapter in main binary deserializes criteria JSON, runs verification + goal tracing, returns combined result
- Fix pre-existing unfulfilled `clippy::double_must_use` lint expectation in `theatron-core`

Closes #1871, closes #1884

## Test plan
- [x] 14 unit tests for reconciler (db-only, fs-only, identical, newer-wins both directions, conflicts, tolerance, batch, Display)
- [x] 15 unit tests for verification (all-met, mixed, failed, partial, default fix, summary, override, goal tracing, evidence, serde roundtrip, Display)
- [x] Organon tool registration test + dispatch test
- [x] `cargo clippy` clean on all changed crates
- [x] `cargo fmt --check` clean
- [ ] Full `cargo test --workspace` (pre-existing failures in episteme/melete/theatron-tui unrelated to this PR)