### PR TITLE
feat(nous): sub-agent role prompts — coder, researcher, reviewer, explorer, runner

### DIFF
--- a/crates/aletheia/src/commands/server/mod.rs
+++ b/crates/aletheia/src/commands/server/mod.rs
@@ -365,6 +365,7 @@ pub(crate) async fn run(args: Args) -> Result<()> {
                 server_tools: Vec::new(),
                 cache_enabled: resolved.capabilities.cache_enabled,
                 recall: resolved.recall.into(),
+                tool_allowlist: None,
             };
             nous_manager
                 .spawn(

--- a/crates/nous/src/config.rs
+++ b/crates/nous/src/config.rs
@@ -108,6 +108,13 @@ pub struct NousConfig {
     /// Per-agent recall pipeline configuration.
     #[serde(default)]
     pub recall: RecallConfig,
+    /// Tool allowlist for sub-agent role enforcement.
+    ///
+    /// When `Some`, only the listed tool names are available during execution.
+    /// When `None`, all registered tools are available. Set by role templates
+    /// during ephemeral sub-agent spawning.
+    #[serde(default)]
+    pub tool_allowlist: Option<Vec<String>>,
 }
 
 fn default_cache_enabled() -> bool {
@@ -145,6 +152,7 @@ impl Default for NousConfig {
             server_tools: Vec::new(),
             cache_enabled: true,
             recall: RecallConfig::default(),
+            tool_allowlist: None,
         }
     }
 }
@@ -288,6 +296,7 @@ mod tests {
             server_tools: Vec::new(),
             cache_enabled: false,
             recall: RecallConfig::default(),
+            tool_allowlist: None,
         };
         assert_eq!(config.name.as_deref(), Some("Chiron"));
         assert!(config.generation.thinking_enabled);

--- a/crates/nous/src/execute/mod.rs
+++ b/crates/nous/src/execute/mod.rs
@@ -15,7 +15,7 @@ use aletheia_hermeneus::health::ProviderHealth;
 use aletheia_hermeneus::provider::{LlmProvider, ProviderRegistry};
 use aletheia_hermeneus::types::{
     CompletionRequest, Content, ContentBlock, Message, Role, ServerToolDefinition, StopReason,
-    ThinkingConfig,
+    ThinkingConfig, ToolResultContent,
 };
 use aletheia_koina::id::ToolName;
 use aletheia_organon::registry::ToolRegistry;
@@ -190,7 +190,11 @@ pub async fn execute(
         }
 
         let (active, server_tools) = resolve_active_server_tools(tool_ctx, config);
-        let tool_defs = tools.to_hermeneus_tools_filtered(&active);
+        let mut tool_defs = tools.to_hermeneus_tools_filtered(&active);
+
+        if let Some(allowlist) = &config.tool_allowlist {
+            tool_defs.retain(|td| allowlist.iter().any(|a| a == &td.name));
+        }
 
         let request = CompletionRequest {
             model: config.generation.model.clone(),
@@ -248,11 +252,37 @@ pub async fn execute(
             content: Content::Blocks(response_content),
         });
 
+        // WHY: belt-and-suspenders enforcement of role tool restrictions at execution time,
+        // in addition to the presentation-level filtering above
+        let mut denied_blocks: Vec<ContentBlock> = Vec::new();
+        let effective_tool_uses: Vec<_> = if let Some(allowlist) = &config.tool_allowlist {
+            let (allowed, denied): (Vec<_>, Vec<_>) = extracted
+                .tool_uses
+                .into_iter()
+                .partition(|(_, name, _)| allowlist.iter().any(|a| a == name));
+
+            for (id, name, _) in &denied {
+                warn!(tool = %name, tool_use_id = %id, "tool call denied by role policy");
+                denied_blocks.push(ContentBlock::ToolResult {
+                    tool_use_id: id.clone(),
+                    content: ToolResultContent::Text(format!(
+                        "Tool '{name}' is not available for this role. Available tools: {}",
+                        allowlist.join(", ")
+                    )),
+                    is_error: Some(true),
+                });
+            }
+
+            allowed
+        } else {
+            extracted.tool_uses
+        };
+
         let DispatchResult {
             mut blocks,
             loop_warning,
         } = dispatch_tools(
-            &extracted.tool_uses,
+            &effective_tool_uses,
             tools,
             tool_ctx,
             &mut loop_detector,
@@ -261,6 +291,8 @@ pub async fn execute(
             config.limits.max_tool_result_bytes,
         )
         .await?;
+
+        blocks.extend(denied_blocks);
 
         if let Some(ref warning) = loop_warning {
             debug!(warning = warning.as_str(), "loop warning injected");
@@ -348,7 +380,10 @@ pub async fn execute_streaming(
             budget_tokens: config.generation.thinking_budget,
         });
 
-    let tool_defs = tools.to_hermeneus_tools();
+    let mut tool_defs = tools.to_hermeneus_tools();
+    if let Some(allowlist) = &config.tool_allowlist {
+        tool_defs.retain(|td| allowlist.iter().any(|a| a == &td.name));
+    }
 
     loop {
         iterations += 1;
@@ -429,11 +464,35 @@ pub async fn execute_streaming(
             content: Content::Blocks(response_content),
         });
 
+        let mut denied_blocks: Vec<ContentBlock> = Vec::new();
+        let effective_tool_uses: Vec<_> = if let Some(allowlist) = &config.tool_allowlist {
+            let (allowed, denied): (Vec<_>, Vec<_>) = extracted
+                .tool_uses
+                .into_iter()
+                .partition(|(_, name, _)| allowlist.iter().any(|a| a == name));
+
+            for (id, name, _) in &denied {
+                warn!(tool = %name, tool_use_id = %id, "tool call denied by role policy");
+                denied_blocks.push(ContentBlock::ToolResult {
+                    tool_use_id: id.clone(),
+                    content: ToolResultContent::Text(format!(
+                        "Tool '{name}' is not available for this role. Available tools: {}",
+                        allowlist.join(", ")
+                    )),
+                    is_error: Some(true),
+                });
+            }
+
+            allowed
+        } else {
+            extracted.tool_uses
+        };
+
         let DispatchResult {
             mut blocks,
             loop_warning,
         } = dispatch_tools_streaming(
-            &extracted.tool_uses,
+            &effective_tool_uses,
             tools,
             tool_ctx,
             &mut loop_detector,
@@ -443,6 +502,8 @@ pub async fn execute_streaming(
             config.limits.max_tool_result_bytes,
         )
         .await?;
+
+        blocks.extend(denied_blocks);
 
         if let Some(ref warning) = loop_warning {
             debug!(warning = warning.as_str(), "loop warning injected");

--- a/crates/nous/src/lib.rs
+++ b/crates/nous/src/lib.rs
@@ -42,6 +42,8 @@ pub mod metrics;
 pub mod pipeline;
 /// Semantic recall stage: vector search over knowledge memories.
 pub mod recall;
+/// Specialized role templates for ephemeral sub-agents.
+pub mod roles;
 /// Session state tracking within a nous actor.
 pub mod session;
 /// Skill loading: queries mneme for task-relevant skills and injects them as bootstrap sections.

--- a/crates/nous/src/roles.rs
+++ b/crates/nous/src/roles.rs
@@ -1,0 +1,558 @@
+//! Specialized role templates for ephemeral sub-agents.
+
+use std::fmt;
+
+/// Sub-agent role determining system prompt, tool access, and model preference.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum Role {
+    /// Implementation, testing, debugging. Full workspace access.
+    Coder,
+    /// Investigation, comparison, documentation. Read-only plus web access.
+    Researcher,
+    /// Code review, standards compliance, risk assessment. Read-only, no writes.
+    Reviewer,
+    /// Codebase exploration, architecture understanding. Read-only, no execution.
+    Explorer,
+    /// Task execution, command running, deployment. Execute plus read, no edits.
+    Runner,
+}
+
+impl Role {
+    /// Parse a role string into a typed variant.
+    ///
+    /// Returns `None` for unrecognized role names.
+    #[must_use]
+    pub fn parse(s: &str) -> Option<Self> {
+        match s {
+            "coder" => Some(Self::Coder),
+            "researcher" => Some(Self::Researcher),
+            "reviewer" => Some(Self::Reviewer),
+            "explorer" => Some(Self::Explorer),
+            "runner" => Some(Self::Runner),
+            _ => None,
+        }
+    }
+
+    /// All defined roles.
+    #[must_use]
+    pub fn all() -> &'static [Role] {
+        &[
+            Self::Coder,
+            Self::Researcher,
+            Self::Reviewer,
+            Self::Explorer,
+            Self::Runner,
+        ]
+    }
+
+    /// Role name as a lowercase string.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Coder => "coder",
+            Self::Researcher => "researcher",
+            Self::Reviewer => "reviewer",
+            Self::Explorer => "explorer",
+            Self::Runner => "runner",
+        }
+    }
+
+    /// Structured template for this role.
+    #[must_use]
+    pub fn template(self) -> RoleTemplate {
+        match self {
+            Self::Coder => coder_template(),
+            Self::Researcher => researcher_template(),
+            Self::Reviewer => reviewer_template(),
+            Self::Explorer => explorer_template(),
+            Self::Runner => runner_template(),
+        }
+    }
+}
+
+impl fmt::Display for Role {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Tool access policy for a role.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ToolPolicy {
+    /// All registered tools available.
+    Unrestricted,
+    /// Only the listed tools are available. Everything else is denied.
+    AllowOnly(Vec<String>),
+}
+
+impl ToolPolicy {
+    /// Check whether a tool name is permitted under this policy.
+    #[must_use]
+    pub fn is_allowed(&self, tool_name: &str) -> bool {
+        match self {
+            Self::Unrestricted => true,
+            Self::AllowOnly(allowed) => allowed.iter().any(|a| a == tool_name),
+        }
+    }
+
+    /// Convert to an allowlist for `NousConfig.tool_allowlist`.
+    ///
+    /// Returns `None` for unrestricted (all tools allowed).
+    #[must_use]
+    pub fn to_allowlist(&self) -> Option<Vec<String>> {
+        match self {
+            Self::Unrestricted => None,
+            Self::AllowOnly(list) => Some(list.clone()),
+        }
+    }
+}
+
+/// Structured role template with system prompt, tool restrictions, and model preference.
+#[derive(Debug, Clone)]
+pub struct RoleTemplate {
+    /// Role identifier.
+    pub role: Role,
+    /// System prompt injected into the sub-agent's context.
+    pub system_prompt: &'static str,
+    /// Tool access restrictions.
+    pub tool_policy: ToolPolicy,
+    /// Preferred model identifier.
+    pub model: &'static str,
+}
+
+const OPUS_MODEL: &str = "claude-opus-4-20250514";
+const SONNET_MODEL: &str = "claude-sonnet-4-20250514";
+const HAIKU_MODEL: &str = "claude-haiku-4-5-20251001";
+
+fn coder_template() -> RoleTemplate {
+    RoleTemplate {
+        role: Role::Coder,
+        system_prompt: CODER_PROMPT,
+        tool_policy: ToolPolicy::AllowOnly(vec![
+            "read".into(),
+            "write".into(),
+            "edit".into(),
+            "exec".into(),
+            "grep".into(),
+            "find".into(),
+            "ls".into(),
+            "view_file".into(),
+            "memory_search".into(),
+            "note".into(),
+        ]),
+        model: SONNET_MODEL,
+    }
+}
+
+fn researcher_template() -> RoleTemplate {
+    RoleTemplate {
+        role: Role::Researcher,
+        system_prompt: RESEARCHER_PROMPT,
+        tool_policy: ToolPolicy::AllowOnly(vec![
+            "read".into(),
+            "grep".into(),
+            "find".into(),
+            "ls".into(),
+            "view_file".into(),
+            "web_fetch".into(),
+            "memory_search".into(),
+            "note".into(),
+        ]),
+        model: SONNET_MODEL,
+    }
+}
+
+fn reviewer_template() -> RoleTemplate {
+    RoleTemplate {
+        role: Role::Reviewer,
+        system_prompt: REVIEWER_PROMPT,
+        tool_policy: ToolPolicy::AllowOnly(vec![
+            "read".into(),
+            "grep".into(),
+            "find".into(),
+            "ls".into(),
+            "view_file".into(),
+            "memory_search".into(),
+        ]),
+        model: OPUS_MODEL,
+    }
+}
+
+fn explorer_template() -> RoleTemplate {
+    RoleTemplate {
+        role: Role::Explorer,
+        system_prompt: EXPLORER_PROMPT,
+        tool_policy: ToolPolicy::AllowOnly(vec![
+            "read".into(),
+            "grep".into(),
+            "find".into(),
+            "ls".into(),
+            "view_file".into(),
+        ]),
+        model: HAIKU_MODEL,
+    }
+}
+
+fn runner_template() -> RoleTemplate {
+    RoleTemplate {
+        role: Role::Runner,
+        system_prompt: RUNNER_PROMPT,
+        tool_policy: ToolPolicy::AllowOnly(vec![
+            "read".into(),
+            "exec".into(),
+            "grep".into(),
+            "find".into(),
+            "ls".into(),
+            "view_file".into(),
+        ]),
+        model: HAIKU_MODEL,
+    }
+}
+
+// --- System prompts ported from TS roles/prompts/*.ts ---
+
+const CODER_PROMPT: &str = "\
+You are a coder sub-agent. You write and modify code to complete a specific task.
+
+## Workflow
+
+1. Read the relevant files to understand the current code
+2. Make the specified changes
+3. Run the build to verify your changes compile
+4. Run relevant tests if they exist
+5. Report what you changed
+
+## Rules
+
+- Stay in scope. Do exactly what was asked. Do not refactor surrounding code or add features.
+- Match existing patterns. Follow the same style as the codebase.
+- Build must pass. If your changes break the build, fix them before reporting.
+- Ask nothing. Make the conservative choice on ambiguity and note it in your result.
+- No filler. Work and report.
+
+## Output
+
+End your response with a JSON block:
+
+```json
+{
+  \"role\": \"coder\",
+  \"status\": \"success | partial | failed\",
+  \"summary\": \"what you did\",
+  \"filesChanged\": [\"path/to/file\"],
+  \"confidence\": 0.95
+}
+```";
+
+const RESEARCHER_PROMPT: &str = "\
+You are a researcher sub-agent. You find and synthesize information.
+
+## Workflow
+
+1. Understand the question and scope constraints
+2. Search for information using available tools
+3. Read and evaluate sources for relevance
+4. Synthesize findings into a structured report
+5. Note confidence levels and caveats
+
+## Rules
+
+- Cite sources. Every claim traces to a specific URL or document.
+- Distinguish fact from inference. Say so when extrapolating.
+- Respect scope constraints. Stay within the specified sources.
+- Recency matters. Prefer the most recent documentation.
+- Admit gaps. \"Could not find authoritative information on X\" is a valid finding.
+- No filler. Findings, not feelings.
+
+## Output
+
+End your response with a JSON block:
+
+```json
+{
+  \"role\": \"researcher\",
+  \"status\": \"success | partial | failed\",
+  \"summary\": \"the answer or key finding\",
+  \"findings\": [{\"claim\": \"...\", \"source\": \"...\", \"confidence\": 0.9}],
+  \"gaps\": [\"things you could not verify\"],
+  \"confidence\": 0.85
+}
+```";
+
+const REVIEWER_PROMPT: &str = "\
+You are a code reviewer sub-agent. You read code and find problems. You do NOT fix code.
+
+## Workflow
+
+1. Read the diff or files provided
+2. Understand the intent from the task description
+3. Check for: correctness, edge cases, error handling, style, backward compatibility, security
+4. Report findings as structured issues
+
+## Rules
+
+- Be specific. \"Line 42: NULL check missing, destructure on line 43 will throw\" is useful. \"Error handling could be improved\" is not.
+- Severity matters. Unhandled null = error. Naming inconsistency = info.
+- Acknowledge clean code. Do not invent problems.
+- Check backward compatibility. Will existing data or clients break?
+- Check test coverage. Are new code paths tested?
+- No filler. Report findings directly.
+
+## Issue Categories
+
+- Error (must fix): unhandled null, missing error handling, type unsafety, injection, races, breaking changes
+- Warning (should fix): missing edge cases, inconsistent patterns, missing tests, performance issues
+- Info (consider): naming, alternative approaches, style preferences
+
+## Output
+
+End your response with a JSON block:
+
+```json
+{
+  \"role\": \"reviewer\",
+  \"status\": \"success\",
+  \"verdict\": \"approve | request-changes | needs-discussion\",
+  \"issues\": [{\"severity\": \"error\", \"file\": \"path\", \"line\": 42, \"message\": \"...\"}],
+  \"summary\": \"overall assessment\",
+  \"confidence\": 0.9
+}
+```";
+
+const EXPLORER_PROMPT: &str = "\
+You are an explorer sub-agent. You investigate codebases. You are read-only.
+
+## Workflow
+
+1. Start from the provided files or directories
+2. Use grep/find to locate relevant code
+3. Read files to understand structure and logic
+4. Trace call chains when asked
+5. Report findings with file paths and line numbers
+
+## Rules
+
+- Read-only. Never use write, edit, or exec. If modification is needed, report that and stop.
+- Be precise. Include file paths and line numbers for every finding.
+- Trace completely. Follow call chains from entry point to final execution.
+- Summarize, do not dump. Return the answer, not every file you read.
+- Stay efficient. Use grep before reading whole files.
+- No filler. Findings and paths, not narration.
+
+## Output
+
+End your response with a JSON block:
+
+```json
+{
+  \"role\": \"explorer\",
+  \"status\": \"success | partial | failed\",
+  \"summary\": \"the answer\",
+  \"relevantFiles\": [{\"path\": \"...\", \"role\": \"what this file does\"}],
+  \"callChain\": [\"entry() -> middleware() -> handler()\"],
+  \"confidence\": 0.9
+}
+```";
+
+const RUNNER_PROMPT: &str = "\
+You are a runner sub-agent. You execute commands and report results.
+
+## Workflow
+
+1. Run the specified commands
+2. Capture stdout, stderr, and exit codes
+3. For test suites: count total, passed, failed, extract failure details
+4. For health checks: report status of each endpoint
+5. Report everything structured
+
+## Rules
+
+- Run exactly what is asked. Do not add extra commands unless instructed.
+- Capture everything. Exit codes, stderr, stdout.
+- Report, do not diagnose. \"Test X failed with error Y\" is your job. Suggesting fixes is not.
+- Safe commands only. Never run destructive commands unless explicitly part of the task.
+- No filler. Exit codes and output, not commentary.
+- Timeout awareness. Report hangs. Do not retry unless instructed.
+
+## Output
+
+End your response with a JSON block:
+
+```json
+{
+  \"role\": \"runner\",
+  \"status\": \"success | partial | failed\",
+  \"summary\": \"overall result\",
+  \"commands\": [{\"command\": \"...\", \"exitCode\": 0, \"stdout\": \"...\"}],
+  \"confidence\": 0.95
+}
+```";
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn all_roles_have_templates() {
+        for role in Role::all() {
+            let template = role.template();
+            assert_eq!(template.role, *role, "template role mismatch for {role}");
+            assert!(
+                !template.system_prompt.is_empty(),
+                "empty system prompt for {role}"
+            );
+            assert!(!template.model.is_empty(), "empty model for {role}");
+        }
+    }
+
+    #[test]
+    fn role_from_str_roundtrip() {
+        for role in Role::all() {
+            let parsed = Role::parse(role.as_str());
+            assert_eq!(parsed, Some(*role), "from_str roundtrip failed for {role}");
+        }
+    }
+
+    #[test]
+    fn role_from_str_unknown_returns_none() {
+        assert_eq!(Role::parse("unknown"), None);
+        assert_eq!(Role::parse(""), None);
+        assert_eq!(Role::parse("planner"), None);
+    }
+
+    #[test]
+    fn role_display_matches_as_str() {
+        for role in Role::all() {
+            assert_eq!(role.to_string(), role.as_str());
+        }
+    }
+
+    #[test]
+    fn coder_has_write_access() {
+        let template = Role::Coder.template();
+        assert!(
+            template.tool_policy.is_allowed("write"),
+            "coder must have write access"
+        );
+        assert!(
+            template.tool_policy.is_allowed("edit"),
+            "coder must have edit access"
+        );
+        assert!(
+            template.tool_policy.is_allowed("exec"),
+            "coder must have exec access"
+        );
+    }
+
+    #[test]
+    fn reviewer_cannot_write_or_exec() {
+        let template = Role::Reviewer.template();
+        assert!(
+            !template.tool_policy.is_allowed("write"),
+            "reviewer must not write"
+        );
+        assert!(
+            !template.tool_policy.is_allowed("edit"),
+            "reviewer must not edit"
+        );
+        assert!(
+            !template.tool_policy.is_allowed("exec"),
+            "reviewer must not exec"
+        );
+    }
+
+    #[test]
+    fn explorer_is_read_only() {
+        let template = Role::Explorer.template();
+        assert!(
+            template.tool_policy.is_allowed("read"),
+            "explorer must read"
+        );
+        assert!(
+            template.tool_policy.is_allowed("grep"),
+            "explorer must grep"
+        );
+        assert!(
+            !template.tool_policy.is_allowed("write"),
+            "explorer must not write"
+        );
+        assert!(
+            !template.tool_policy.is_allowed("edit"),
+            "explorer must not edit"
+        );
+        assert!(
+            !template.tool_policy.is_allowed("exec"),
+            "explorer must not exec"
+        );
+    }
+
+    #[test]
+    fn runner_can_exec_but_not_edit() {
+        let template = Role::Runner.template();
+        assert!(template.tool_policy.is_allowed("exec"), "runner must exec");
+        assert!(template.tool_policy.is_allowed("read"), "runner must read");
+        assert!(
+            !template.tool_policy.is_allowed("write"),
+            "runner must not write"
+        );
+        assert!(
+            !template.tool_policy.is_allowed("edit"),
+            "runner must not edit"
+        );
+    }
+
+    #[test]
+    fn researcher_has_web_but_no_exec() {
+        let template = Role::Researcher.template();
+        assert!(
+            template.tool_policy.is_allowed("web_fetch"),
+            "researcher must have web access"
+        );
+        assert!(
+            template.tool_policy.is_allowed("read"),
+            "researcher must read"
+        );
+        assert!(
+            !template.tool_policy.is_allowed("exec"),
+            "researcher must not exec"
+        );
+        assert!(
+            !template.tool_policy.is_allowed("write"),
+            "researcher must not write"
+        );
+    }
+
+    #[test]
+    fn model_preferences() {
+        assert_eq!(Role::Coder.template().model, SONNET_MODEL);
+        assert_eq!(Role::Researcher.template().model, SONNET_MODEL);
+        assert_eq!(Role::Reviewer.template().model, OPUS_MODEL);
+        assert_eq!(Role::Explorer.template().model, HAIKU_MODEL);
+        assert_eq!(Role::Runner.template().model, HAIKU_MODEL);
+    }
+
+    #[test]
+    fn tool_policy_unrestricted_allows_all() {
+        let policy = ToolPolicy::Unrestricted;
+        assert!(policy.is_allowed("anything"));
+        assert!(policy.is_allowed("write"));
+        assert!(policy.to_allowlist().is_none());
+    }
+
+    #[test]
+    fn tool_policy_allow_only_restricts() {
+        let policy = ToolPolicy::AllowOnly(vec!["read".into(), "grep".into()]);
+        assert!(policy.is_allowed("read"));
+        assert!(policy.is_allowed("grep"));
+        assert!(!policy.is_allowed("write"));
+        assert!(!policy.is_allowed("exec"));
+        let list = policy.to_allowlist().expect("should produce allowlist");
+        assert_eq!(list.len(), 2);
+    }
+
+    #[test]
+    fn five_roles_defined() {
+        assert_eq!(Role::all().len(), 5, "must have exactly 5 roles");
+    }
+}

--- a/crates/nous/src/spawn_svc.rs
+++ b/crates/nous/src/spawn_svc.rs
@@ -15,15 +15,13 @@ use aletheia_taxis::oikos::Oikos;
 
 use crate::actor;
 use crate::config::{NousConfig, PipelineConfig, StageBudget};
+use crate::roles::Role;
 
 const SONNET_MODEL: &str = "claude-sonnet-4-20250514";
-const HAIKU_MODEL: &str = "claude-haiku-4-5-20251001";
 
-fn model_for_role(role: &str) -> &'static str {
-    match role {
-        "explorer" | "runner" => HAIKU_MODEL,
-        _ => SONNET_MODEL,
-    }
+/// Resolve role from string, returning typed role or falling back to model heuristic.
+fn resolve_role(role_str: &str) -> Option<Role> {
+    Role::parse(role_str)
 }
 
 /// Concrete [`SpawnService`] that bridges to `actor::spawn`.
@@ -63,10 +61,20 @@ impl SpawnService for SpawnServiceImpl {
             parent_nous_id,
             ulid::Ulid::new().to_string().to_lowercase()
         );
-        let model = request
-            .model
+        let role = resolve_role(&request.role);
+        let template = role.map(Role::template);
+
+        let model = request.model.clone().unwrap_or_else(|| {
+            template
+                .as_ref()
+                .map_or_else(|| SONNET_MODEL.to_owned(), |t| t.model.to_owned())
+        });
+
+        let tool_allowlist = request
+            .allowed_tools
             .clone()
-            .unwrap_or_else(|| model_for_role(&request.role).to_owned());
+            .or_else(|| template.as_ref().and_then(|t| t.tool_policy.to_allowlist()));
+
         let timeout = Duration::from_secs(request.timeout_secs);
         let task = request.task.clone();
         let session_key = format!("spawn:{}", ulid::Ulid::new().to_string().to_lowercase());
@@ -96,6 +104,7 @@ impl SpawnService for SpawnServiceImpl {
             server_tools: Vec::new(),
             cache_enabled: true,
             recall: crate::recall::RecallConfig::default(),
+            tool_allowlist,
         };
 
         let pipeline_config = PipelineConfig {
@@ -114,7 +123,13 @@ impl SpawnService for SpawnServiceImpl {
             spawn.role = %request.role,
         );
 
-        let role_desc = request.role.clone();
+        let soul_content = template.as_ref().map_or_else(
+            || {
+                let role_str = request.role.clone();
+                format!("You are an ephemeral {role_str} sub-agent. Complete the assigned task precisely and concisely.")
+            },
+            |t| t.system_prompt.to_owned(),
+        );
 
         Box::pin(
             async move {
@@ -123,12 +138,7 @@ impl SpawnService for SpawnServiceImpl {
                     return Err(format!("failed to create spawn workspace: {e}"));
                 }
                 let soul_path = nous_dir.join("SOUL.md");
-                if let Err(e) = tokio::fs::write(
-                    &soul_path,
-                    format!("You are an ephemeral {role_desc} sub-agent. Complete the assigned task precisely and concisely."),
-                )
-                .await
-                {
+                if let Err(e) = tokio::fs::write(&soul_path, &soul_content).await {
                     return Err(format!("failed to write SOUL.md: {e}"));
                 }
 
@@ -177,10 +187,7 @@ impl SpawnService for SpawnServiceImpl {
                     Err(_elapsed) => {
                         warn!(timeout_secs = timeout.as_secs(), "sub-agent timed out");
                         Ok(SpawnResult {
-                            content: format!(
-                                "Sub-agent timed out after {}s",
-                                timeout.as_secs()
-                            ),
+                            content: format!("Sub-agent timed out after {}s", timeout.as_secs()),
                             is_error: true,
                             input_tokens: 0,
                             output_tokens: 0,
@@ -266,14 +273,18 @@ mod tests {
         assert_eq!(result.output_tokens, 80);
     }
 
-    #[tokio::test]
-    async fn spawn_uses_role_default_model() {
-        assert_eq!(model_for_role("coder"), SONNET_MODEL);
-        assert_eq!(model_for_role("reviewer"), SONNET_MODEL);
-        assert_eq!(model_for_role("researcher"), SONNET_MODEL);
-        assert_eq!(model_for_role("explorer"), HAIKU_MODEL);
-        assert_eq!(model_for_role("runner"), HAIKU_MODEL);
-        assert_eq!(model_for_role("unknown"), SONNET_MODEL);
+    #[test]
+    fn spawn_uses_role_default_model() {
+        use crate::roles::Role;
+        assert_eq!(Role::Coder.template().model, "claude-sonnet-4-20250514");
+        assert_eq!(Role::Reviewer.template().model, "claude-opus-4-20250514");
+        assert_eq!(
+            Role::Researcher.template().model,
+            "claude-sonnet-4-20250514"
+        );
+        assert_eq!(Role::Explorer.template().model, "claude-haiku-4-5-20251001");
+        assert_eq!(Role::Runner.template().model, "claude-haiku-4-5-20251001");
+        assert!(resolve_role("unknown").is_none());
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -343,20 +354,19 @@ mod tests {
     }
 
     #[test]
-    fn model_for_role_defaults_to_sonnet() {
-        assert_eq!(model_for_role(""), SONNET_MODEL);
-        assert_eq!(model_for_role("analyst"), SONNET_MODEL);
-        assert_eq!(model_for_role("planner"), SONNET_MODEL);
+    fn resolve_role_known_roles() {
+        assert!(resolve_role("coder").is_some());
+        assert!(resolve_role("reviewer").is_some());
+        assert!(resolve_role("researcher").is_some());
+        assert!(resolve_role("explorer").is_some());
+        assert!(resolve_role("runner").is_some());
     }
 
     #[test]
-    fn model_for_role_explorer_uses_haiku() {
-        assert_eq!(model_for_role("explorer"), HAIKU_MODEL);
-    }
-
-    #[test]
-    fn model_for_role_runner_uses_haiku() {
-        assert_eq!(model_for_role("runner"), HAIKU_MODEL);
+    fn resolve_role_unknown_returns_none() {
+        assert!(resolve_role("").is_none());
+        assert!(resolve_role("analyst").is_none());
+        assert!(resolve_role("planner").is_none());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- Port TS `roles/prompts/*.ts` to Rust as structured `Role` enum with `RoleTemplate` data
- Define 5 specialized roles (coder, researcher, reviewer, explorer, runner), each with system prompt, tool policy (allowlist), and model preference
- Integrate role templates into `spawn_svc` so `spawn_sub_agent(role: "coder", task: "...")` uses the role's prompt, model, and tool restrictions
- Enforce tool restrictions at presentation level (filter `tool_defs` sent to LLM) and execution level (reject denied calls with error `ToolResult`)
- Add `tool_allowlist` field to `NousConfig` for role-based tool filtering

### Role Matrix

| Role | Model | Write | Edit | Exec | Web | Memory |
|------|-------|-------|------|------|-----|--------|
| Coder | sonnet | yes | yes | yes | no | yes |
| Researcher | sonnet | no | no | no | yes | yes |
| Reviewer | opus | no | no | no | no | yes |
| Explorer | haiku | no | no | no | no | no |
| Runner | haiku | no | no | yes | no | no |

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy -p aletheia-nous` clean (no new warnings)
- [x] `cargo test -p aletheia-nous` — 465 tests pass
- [x] `cargo test --workspace` — all tests pass, 0 failures
- [x] Unit tests: role template loading, from_str roundtrip, tool restriction enforcement per role
- [x] Unit tests: model preferences per role (opus/sonnet/haiku)
- [x] Unit tests: ToolPolicy allow/deny/unrestricted logic

Closes #1878

🤖 Generated with [Claude Code](https://claude.com/claude-code)