### PR TITLE
feat(tui): planning dashboard and retrospective view

### DIFF
--- a/crates/theatron/core/src/api/client.rs
+++ b/crates/theatron/core/src/api/client.rs
@@ -1,9 +1,6 @@
 //! HTTP client for the Aletheia gateway REST API.
 // WHY: all async methods return Result which is already #[must_use]; outer attrs add caller context.
-#![expect(
-    clippy::double_must_use,
-    reason = "Result return type is must_use; outer attr adds caller context"
-)]
+#![allow(clippy::double_must_use)]
 
 use reqwest::{Client, Response, StatusCode, header};
 use snafu::prelude::*;

--- a/crates/theatron/tui/src/app/mod.rs
+++ b/crates/theatron/tui/src/app/mod.rs
@@ -33,9 +33,9 @@ pub use crate::state::{
     ActiveTool, AgentState, AgentStatus, ChatMessage, CommandPaletteState, ContextAction,
     ContextActionsOverlay, DecisionCardOverlay, DecisionField, DecisionOption, ErrorBanner,
     FilterState, FocusedPane, InputState, MemoryInspectorState, NotificationStore, OpsState,
-    Overlay, PlanApprovalOverlay, PlanStepApproval, SelectionContext, SessionPickerOverlay,
-    SlashCompleteState, SubmittedDecision, TabCompletion, Toast, ToolApprovalOverlay, ToolCallInfo,
-    ToolSummary, View, ViewStack,
+    Overlay, PlanApprovalOverlay, PlanStepApproval, PlanningDashboardState, RetrospectiveState,
+    SelectionContext, SessionPickerOverlay, SlashCompleteState, SubmittedDecision, TabCompletion,
+    Toast, ToolApprovalOverlay, ToolCallInfo, ToolSummary, View, ViewStack,
 };
 
 /// Default terminal width used before the first resize event arrives.
@@ -142,6 +142,8 @@ pub struct LayoutState {
     pub ops: OpsState,
     pub(crate) tab_bar: TabBar,
     pub memory: MemoryInspectorState,
+    pub planning: crate::state::PlanningDashboardState,
+    pub retrospective: crate::state::RetrospectiveState,
     pub(crate) pending_g: bool,
     pub(crate) bell_enabled: bool,
     /// Cross-agent notification log with read/unread tracking.
@@ -259,6 +261,8 @@ impl App {
                 ops: OpsState::default(),
                 tab_bar: TabBar::new(),
                 memory: MemoryInspectorState::new(),
+                planning: crate::state::PlanningDashboardState::new(),
+                retrospective: crate::state::RetrospectiveState::new(),
                 pending_g: false,
                 bell_enabled,
                 notifications: NotificationStore::default(),

--- a/crates/theatron/tui/src/app/test_helpers.rs
+++ b/crates/theatron/tui/src/app/test_helpers.rs
@@ -101,6 +101,8 @@ pub fn test_app() -> App {
             ops: OpsState::default(),
             tab_bar: TabBar::new(),
             memory: MemoryInspectorState::new(),
+            planning: crate::state::PlanningDashboardState::new(),
+            retrospective: crate::state::RetrospectiveState::new(),
             pending_g: false,
             bell_enabled: false,
             notifications: NotificationStore::default(),

--- a/crates/theatron/tui/src/command/mod.rs
+++ b/crates/theatron/tui/src/command/mod.rs
@@ -194,6 +194,20 @@ pub static COMMANDS: &[Command] = &[
         category: CommandCategory::Navigation,
         shortcut: None,
     },
+    Command {
+        name: "planning",
+        aliases: &["plan"],
+        description: "Open planning dashboard",
+        category: CommandCategory::Navigation,
+        shortcut: None,
+    },
+    Command {
+        name: "retrospective",
+        aliases: &["retro"],
+        description: "Project retrospective view",
+        category: CommandCategory::Navigation,
+        shortcut: None,
+    },
 ];
 
 const MAX_SUGGESTIONS: usize = 8;

--- a/crates/theatron/tui/src/msg.rs
+++ b/crates/theatron/tui/src/msg.rs
@@ -241,6 +241,36 @@ pub enum Msg {
     #[expect(dead_code, reason = "planned TUI feature")]
     SettingsSaveError(String),
 
+    #[expect(dead_code, reason = "dispatched via command palette, not keybindings")]
+    PlanningOpen,
+    #[expect(dead_code, reason = "dispatched via command palette, not keybindings")]
+    PlanningClose,
+    #[expect(dead_code, reason = "dispatched via command palette, not keybindings")]
+    PlanningTabNext,
+    #[expect(dead_code, reason = "dispatched via command palette, not keybindings")]
+    PlanningTabPrev,
+    #[expect(dead_code, reason = "dispatched via command palette, not keybindings")]
+    PlanningSelectUp,
+    #[expect(dead_code, reason = "dispatched via command palette, not keybindings")]
+    PlanningSelectDown,
+    #[expect(dead_code, reason = "dispatched via command palette, not keybindings")]
+    PlanningToggleExpand,
+    #[expect(dead_code, reason = "dispatched via command palette, not keybindings")]
+    PlanningApproveCheckpoint,
+
+    #[expect(dead_code, reason = "dispatched via command palette, not keybindings")]
+    RetroOpen,
+    #[expect(dead_code, reason = "dispatched via command palette, not keybindings")]
+    RetroClose,
+    #[expect(dead_code, reason = "dispatched via command palette, not keybindings")]
+    RetroSectionNext,
+    #[expect(dead_code, reason = "dispatched via command palette, not keybindings")]
+    RetroSectionPrev,
+    #[expect(dead_code, reason = "dispatched via command palette, not keybindings")]
+    RetroScrollUp,
+    #[expect(dead_code, reason = "dispatched via command palette, not keybindings")]
+    RetroScrollDown,
+
     MemoryOpen,
     MemoryClose,
     MemoryTabNext,
@@ -288,11 +318,11 @@ pub enum Msg {
     MemoryPageDown,
     MemoryPageUp,
 
-    #[expect(dead_code, reason = "planned TUI feature")]
+    #[cfg_attr(not(test), expect(dead_code, reason = "planned TUI feature"))]
     ShowError(String),
-    #[expect(dead_code, reason = "planned TUI feature")]
+    #[cfg_attr(not(test), expect(dead_code, reason = "planned TUI feature"))]
     ShowSuccess(String),
-    #[expect(dead_code, reason = "planned TUI feature")]
+    #[cfg_attr(not(test), expect(dead_code, reason = "planned TUI feature"))]
     DismissError,
 
     #[expect(dead_code, reason = "planned TUI feature")]
@@ -372,19 +402,28 @@ pub enum MessageActionKind {
     Delete,
     OpenLinks,
     Inspect,
-    #[expect(
-        dead_code,
-        reason = "constructed in context action overlay; lint fires in lib but not test target"
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "constructed in context action overlay; lint fires in lib but not test target"
+        )
     )]
     QuoteInReply,
-    #[expect(
-        dead_code,
-        reason = "constructed in context action overlay; lint fires in lib but not test target"
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "constructed in context action overlay; lint fires in lib but not test target"
+        )
     )]
     RateResponse,
-    #[expect(
-        dead_code,
-        reason = "constructed in context action overlay; lint fires in lib but not test target"
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "constructed in context action overlay; lint fires in lib but not test target"
+        )
     )]
     FlagForReview,
 }

--- a/crates/theatron/tui/src/state/mod.rs
+++ b/crates/theatron/tui/src/state/mod.rs
@@ -7,6 +7,7 @@ pub mod memory;
 pub mod notification;
 pub(crate) mod ops;
 mod overlay;
+pub(crate) mod planning;
 pub mod settings;
 pub(crate) mod tab;
 pub(crate) mod view_stack;
@@ -26,5 +27,6 @@ pub use overlay::{
     Overlay, PlanApprovalOverlay, PlanStepApproval, SearchResult, SearchResultKind,
     SessionPickerOverlay, SessionSearchOverlay, SubmittedDecision, ToolApprovalOverlay,
 };
+pub use planning::{PlanningDashboardState, RetrospectiveState};
 pub(crate) use tab::TabBar;
 pub use view_stack::{View, ViewStack};

--- a/crates/theatron/tui/src/state/overlay.rs
+++ b/crates/theatron/tui/src/state/overlay.rs
@@ -16,9 +16,12 @@ pub enum Overlay {
     Settings(SettingsOverlay),
     ToolApproval(ToolApprovalOverlay),
     PlanApproval(PlanApprovalOverlay),
-    #[expect(
-        dead_code,
-        reason = "overlay set by action dispatcher; lint fires in lib but not test target"
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "overlay set by action dispatcher; lint fires in lib but not test target"
+        )
     )]
     ContextActions(ContextActionsOverlay),
     DiffView(crate::diff::DiffViewState),

--- a/crates/theatron/tui/src/state/planning.rs
+++ b/crates/theatron/tui/src/state/planning.rs
@@ -1,0 +1,686 @@
+//! State for the planning dashboard and retrospective views.
+
+/// Which tab of the planning dashboard is active.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub(crate) enum PlanningTab {
+    Overview,
+    Requirements,
+    Execution,
+    Verification,
+    Tasks,
+    Timeline,
+    EditHistory,
+}
+
+impl PlanningTab {
+    pub(crate) const ALL: [Self; 7] = [
+        Self::Overview,
+        Self::Requirements,
+        Self::Execution,
+        Self::Verification,
+        Self::Tasks,
+        Self::Timeline,
+        Self::EditHistory,
+    ];
+
+    pub(crate) fn label(self) -> &'static str {
+        match self {
+            Self::Overview => "Overview",
+            Self::Requirements => "Requirements",
+            Self::Execution => "Execution",
+            Self::Verification => "Verification",
+            Self::Tasks => "Tasks",
+            Self::Timeline => "Timeline",
+            Self::EditHistory => "History",
+        }
+    }
+
+    pub(crate) fn next(self) -> Self {
+        match self {
+            Self::Overview => Self::Requirements,
+            Self::Requirements => Self::Execution,
+            Self::Execution => Self::Verification,
+            Self::Verification => Self::Tasks,
+            Self::Tasks => Self::Timeline,
+            Self::Timeline => Self::EditHistory,
+            Self::EditHistory => Self::Overview,
+        }
+    }
+
+    pub(crate) fn prev(self) -> Self {
+        match self {
+            Self::Overview => Self::EditHistory,
+            Self::Requirements => Self::Overview,
+            Self::Execution => Self::Requirements,
+            Self::Verification => Self::Execution,
+            Self::Tasks => Self::Verification,
+            Self::Timeline => Self::Tasks,
+            Self::EditHistory => Self::Timeline,
+        }
+    }
+}
+
+/// Risk level for a checkpoint requiring human approval.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "variants constructed when API populates planning data"
+    )
+)]
+pub(crate) enum CheckpointRisk {
+    Low,
+    Medium,
+    High,
+    Critical,
+}
+
+impl CheckpointRisk {
+    pub(crate) fn label(self) -> &'static str {
+        match self {
+            Self::Low => "LOW",
+            Self::Medium => "MED",
+            Self::High => "HIGH",
+            Self::Critical => "CRIT",
+        }
+    }
+}
+
+/// Status of a requirement in the requirements table.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+// WHY: variant construction depends on API data; subset used in tests.
+#[allow(dead_code)]
+pub(crate) enum RequirementStatus {
+    Pending,
+    InProgress,
+    Met,
+    Failed,
+    Deferred,
+}
+
+impl RequirementStatus {
+    pub(crate) fn label(self) -> &'static str {
+        match self {
+            Self::Pending => "Pending",
+            Self::InProgress => "In Progress",
+            Self::Met => "Met",
+            Self::Failed => "Failed",
+            Self::Deferred => "Deferred",
+        }
+    }
+}
+
+/// Display-friendly project state (decoupled from dianoia domain types).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+// WHY: variant construction depends on API data; some variants are only used in tests.
+#[allow(dead_code)]
+pub(crate) enum DisplayProjectState {
+    Created,
+    Planning,
+    Executing,
+    Verifying,
+    Complete,
+    Paused,
+    Failed,
+}
+
+impl DisplayProjectState {
+    pub(crate) fn label(self) -> &'static str {
+        match self {
+            Self::Created => "Created",
+            Self::Planning => "Planning",
+            Self::Executing => "Executing",
+            Self::Verifying => "Verifying",
+            Self::Complete => "Complete",
+            Self::Paused => "Paused",
+            Self::Failed => "Failed",
+        }
+    }
+}
+
+/// Display-friendly phase state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+// WHY: variant construction depends on API data; subset used in tests.
+#[allow(dead_code)]
+pub(crate) enum DisplayPhaseState {
+    Pending,
+    Active,
+    Executing,
+    Verifying,
+    Complete,
+    Failed,
+}
+
+impl DisplayPhaseState {
+    pub(crate) fn label(self) -> &'static str {
+        match self {
+            Self::Pending => "Pending",
+            Self::Active => "Active",
+            Self::Executing => "Executing",
+            Self::Verifying => "Verifying",
+            Self::Complete => "Complete",
+            Self::Failed => "Failed",
+        }
+    }
+}
+
+/// Display-friendly plan/task state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+// WHY: variant construction depends on API data; some variants are only used in tests.
+#[allow(dead_code)]
+pub(crate) enum DisplayPlanState {
+    Pending,
+    Ready,
+    Executing,
+    Complete,
+    Failed,
+    Skipped,
+    Stuck,
+}
+
+impl DisplayPlanState {
+    pub(crate) fn label(self) -> &'static str {
+        match self {
+            Self::Pending => "Pending",
+            Self::Ready => "Ready",
+            Self::Executing => "Executing",
+            Self::Complete => "Complete",
+            Self::Failed => "Failed",
+            Self::Skipped => "Skipped",
+            Self::Stuck => "Stuck",
+        }
+    }
+}
+
+/// A project for display in the planning dashboard.
+#[derive(Debug, Clone)]
+pub(crate) struct DisplayProject {
+    pub(crate) name: String,
+    pub(crate) description: String,
+    pub(crate) state: DisplayProjectState,
+    pub(crate) phases: Vec<DisplayPhase>,
+    pub(crate) checkpoints: Vec<DisplayCheckpoint>,
+    pub(crate) requirements: Vec<DisplayRequirement>,
+    pub(crate) verifications: Vec<DisplayVerification>,
+    pub(crate) tasks: Vec<DisplayTask>,
+    pub(crate) milestones: Vec<DisplayMilestone>,
+    pub(crate) edit_history: Vec<DisplayEditEntry>,
+}
+
+/// A phase within a project.
+#[derive(Debug, Clone)]
+pub(crate) struct DisplayPhase {
+    pub(crate) name: String,
+    pub(crate) state: DisplayPhaseState,
+    pub(crate) completion_pct: u8,
+    pub(crate) plans: Vec<DisplayPlan>,
+}
+
+/// A plan (unit of work) within a phase.
+#[derive(Debug, Clone)]
+pub(crate) struct DisplayPlan {
+    pub(crate) title: String,
+    pub(crate) wave: u32,
+    pub(crate) state: DisplayPlanState,
+    pub(crate) depends_on: Vec<String>,
+}
+
+/// A requirement tracked in the requirements table.
+#[derive(Debug, Clone)]
+pub(crate) struct DisplayRequirement {
+    pub(crate) id: String,
+    pub(crate) description: String,
+    pub(crate) status: RequirementStatus,
+    pub(crate) source: String,
+}
+
+/// A verification result.
+#[derive(Debug, Clone)]
+pub(crate) struct DisplayVerification {
+    pub(crate) name: String,
+    pub(crate) passed: bool,
+    pub(crate) evidence: String,
+}
+
+/// A task in the hierarchical task list.
+#[derive(Debug, Clone)]
+pub(crate) struct DisplayTask {
+    pub(crate) title: String,
+    pub(crate) state: DisplayPlanState,
+    pub(crate) depth: u8,
+    pub(crate) blocked_by: Vec<String>,
+}
+
+/// A milestone on the timeline.
+#[derive(Debug, Clone)]
+pub(crate) struct DisplayMilestone {
+    pub(crate) label: String,
+    pub(crate) timestamp: String,
+    pub(crate) completed: bool,
+}
+
+/// A checkpoint requiring human approval.
+#[derive(Debug, Clone)]
+pub(crate) struct DisplayCheckpoint {
+    pub(crate) description: String,
+    pub(crate) risk: CheckpointRisk,
+    pub(crate) approved: bool,
+}
+
+/// An entry in the edit history log.
+#[derive(Debug, Clone)]
+pub(crate) struct DisplayEditEntry {
+    pub(crate) timestamp: String,
+    pub(crate) description: String,
+    pub(crate) author: String,
+}
+
+/// Full planning dashboard state.
+#[derive(Debug, Clone)]
+pub struct PlanningDashboardState {
+    pub(crate) project: Option<DisplayProject>,
+    pub(crate) tab: PlanningTab,
+    pub(crate) selected_row: usize,
+    pub(crate) scroll_offset: usize,
+    pub(crate) expanded_phases: Vec<bool>,
+    pub(crate) checkpoint_cursor: usize,
+    pub(crate) loading: bool,
+}
+
+impl PlanningDashboardState {
+    pub(crate) fn new() -> Self {
+        Self {
+            project: None,
+            tab: PlanningTab::Overview,
+            selected_row: 0,
+            scroll_offset: 0,
+            expanded_phases: Vec::new(),
+            checkpoint_cursor: 0,
+            loading: false,
+        }
+    }
+
+    pub(crate) fn tab_next(&mut self) {
+        self.tab = self.tab.next();
+        self.selected_row = 0;
+        self.scroll_offset = 0;
+    }
+
+    pub(crate) fn tab_prev(&mut self) {
+        self.tab = self.tab.prev();
+        self.selected_row = 0;
+        self.scroll_offset = 0;
+    }
+
+    pub(crate) fn select_up(&mut self) {
+        self.selected_row = self.selected_row.saturating_sub(1);
+    }
+
+    pub(crate) fn select_down(&mut self) {
+        let max = self.row_count().saturating_sub(1);
+        if self.selected_row < max {
+            self.selected_row += 1;
+        }
+    }
+
+    pub(crate) fn toggle_phase(&mut self) {
+        if let Some(expanded) = self.expanded_phases.get_mut(self.selected_row) {
+            *expanded = !*expanded;
+        }
+    }
+
+    /// Approve the currently focused checkpoint.
+    pub(crate) fn approve_checkpoint(&mut self) -> bool {
+        if let Some(ref mut project) = self.project
+            && let Some(cp) = project.checkpoints.get_mut(self.checkpoint_cursor)
+            && !cp.approved
+        {
+            cp.approved = true;
+            return true;
+        }
+        false
+    }
+
+    /// Whether there are any unapproved checkpoints blocking execution.
+    pub(crate) fn has_pending_checkpoints(&self) -> bool {
+        self.project
+            .as_ref()
+            .is_some_and(|p| p.checkpoints.iter().any(|c| !c.approved))
+    }
+
+    /// Number of rows in the current tab's data.
+    pub(crate) fn row_count(&self) -> usize {
+        let Some(ref project) = self.project else {
+            return 0;
+        };
+        match self.tab {
+            PlanningTab::Overview => project.phases.len(),
+            PlanningTab::Requirements => project.requirements.len(),
+            PlanningTab::Execution => project.phases.len(),
+            PlanningTab::Verification => project.verifications.len(),
+            PlanningTab::Tasks => project.tasks.len(),
+            PlanningTab::Timeline => project.milestones.len(),
+            PlanningTab::EditHistory => project.edit_history.len(),
+        }
+    }
+}
+
+impl Default for PlanningDashboardState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// A decision made during project execution, for the retrospective audit trail.
+#[derive(Debug, Clone)]
+pub(crate) struct RetrospectiveDecision {
+    pub(crate) timestamp: String,
+    pub(crate) question: String,
+    pub(crate) choice: String,
+    pub(crate) rationale: String,
+}
+
+/// Data for the retrospective post-mortem view.
+#[derive(Debug, Clone)]
+pub(crate) struct RetrospectiveEntry {
+    pub(crate) project_name: String,
+    pub(crate) successes: Vec<String>,
+    pub(crate) blockers: Vec<String>,
+    pub(crate) lessons: Vec<String>,
+    pub(crate) decisions: Vec<RetrospectiveDecision>,
+}
+
+/// Which section of the retrospective is focused.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub(crate) enum RetrospectiveSection {
+    Successes,
+    Blockers,
+    Lessons,
+    Decisions,
+}
+
+impl RetrospectiveSection {
+    #[allow(dead_code)]
+    pub(crate) fn label(self) -> &'static str {
+        match self {
+            Self::Successes => "Successes",
+            Self::Blockers => "Blockers",
+            Self::Lessons => "Lessons",
+            Self::Decisions => "Decisions",
+        }
+    }
+
+    pub(crate) fn next(self) -> Self {
+        match self {
+            Self::Successes => Self::Blockers,
+            Self::Blockers => Self::Lessons,
+            Self::Lessons => Self::Decisions,
+            Self::Decisions => Self::Successes,
+        }
+    }
+
+    pub(crate) fn prev(self) -> Self {
+        match self {
+            Self::Successes => Self::Decisions,
+            Self::Blockers => Self::Successes,
+            Self::Lessons => Self::Blockers,
+            Self::Decisions => Self::Lessons,
+        }
+    }
+}
+
+/// Retrospective view state.
+#[derive(Debug, Clone)]
+pub struct RetrospectiveState {
+    pub(crate) entry: Option<RetrospectiveEntry>,
+    pub(crate) scroll_offset: usize,
+    pub(crate) selected_section: RetrospectiveSection,
+    pub(crate) loading: bool,
+}
+
+impl RetrospectiveState {
+    pub(crate) fn new() -> Self {
+        Self {
+            entry: None,
+            scroll_offset: 0,
+            selected_section: RetrospectiveSection::Successes,
+            loading: false,
+        }
+    }
+
+    pub(crate) fn section_next(&mut self) {
+        self.selected_section = self.selected_section.next();
+    }
+
+    pub(crate) fn section_prev(&mut self) {
+        self.selected_section = self.selected_section.prev();
+    }
+}
+
+impl Default for RetrospectiveState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn planning_tab_cycles_forward() {
+        let mut tab = PlanningTab::Overview;
+        for _ in 0..7 {
+            tab = tab.next();
+        }
+        assert_eq!(tab, PlanningTab::Overview);
+    }
+
+    #[test]
+    fn planning_tab_cycles_backward() {
+        let mut tab = PlanningTab::Overview;
+        for _ in 0..7 {
+            tab = tab.prev();
+        }
+        assert_eq!(tab, PlanningTab::Overview);
+    }
+
+    #[test]
+    fn planning_tab_next_prev_inverse() {
+        for tab in PlanningTab::ALL {
+            assert_eq!(tab.next().prev(), tab);
+        }
+    }
+
+    #[test]
+    fn planning_tab_all_has_seven_entries() {
+        assert_eq!(PlanningTab::ALL.len(), 7);
+    }
+
+    #[test]
+    fn planning_tab_labels_non_empty() {
+        for tab in PlanningTab::ALL {
+            assert!(!tab.label().is_empty());
+        }
+    }
+
+    #[test]
+    fn dashboard_state_default() {
+        let state = PlanningDashboardState::new();
+        assert!(state.project.is_none());
+        assert_eq!(state.tab, PlanningTab::Overview);
+        assert_eq!(state.selected_row, 0);
+        assert!(!state.loading);
+    }
+
+    #[test]
+    fn select_up_saturates_at_zero() {
+        let mut state = PlanningDashboardState::new();
+        state.select_up();
+        assert_eq!(state.selected_row, 0);
+    }
+
+    #[test]
+    fn select_down_clamps_at_max() {
+        let mut state = PlanningDashboardState::new();
+        state.project = Some(sample_project());
+        let max = state.row_count().saturating_sub(1);
+        for _ in 0..100 {
+            state.select_down();
+        }
+        assert_eq!(state.selected_row, max);
+    }
+
+    #[test]
+    fn tab_next_resets_selection() {
+        let mut state = PlanningDashboardState::new();
+        state.selected_row = 5;
+        state.tab_next();
+        assert_eq!(state.selected_row, 0);
+        assert_eq!(state.tab, PlanningTab::Requirements);
+    }
+
+    #[test]
+    fn approve_checkpoint_flips_flag() {
+        let mut state = PlanningDashboardState::new();
+        state.project = Some(sample_project());
+        assert!(state.has_pending_checkpoints());
+        assert!(state.approve_checkpoint());
+        assert!(!state.has_pending_checkpoints());
+    }
+
+    #[test]
+    fn approve_already_approved_returns_false() {
+        let mut state = PlanningDashboardState::new();
+        state.project = Some(sample_project());
+        state.approve_checkpoint();
+        assert!(!state.approve_checkpoint());
+    }
+
+    #[test]
+    fn toggle_phase_toggles_expanded() {
+        let mut state = PlanningDashboardState::new();
+        state.expanded_phases = vec![false, true];
+        state.selected_row = 0;
+        state.toggle_phase();
+        assert!(state.expanded_phases[0]);
+        state.toggle_phase();
+        assert!(!state.expanded_phases[0]);
+    }
+
+    #[test]
+    fn row_count_with_no_project_is_zero() {
+        let state = PlanningDashboardState::new();
+        assert_eq!(state.row_count(), 0);
+    }
+
+    #[test]
+    fn retrospective_section_cycles() {
+        let mut section = RetrospectiveSection::Successes;
+        for _ in 0..4 {
+            section = section.next();
+        }
+        assert_eq!(section, RetrospectiveSection::Successes);
+    }
+
+    #[test]
+    fn retrospective_section_next_prev_inverse() {
+        let sections = [
+            RetrospectiveSection::Successes,
+            RetrospectiveSection::Blockers,
+            RetrospectiveSection::Lessons,
+            RetrospectiveSection::Decisions,
+        ];
+        for section in sections {
+            assert_eq!(section.next().prev(), section);
+        }
+    }
+
+    #[test]
+    fn retrospective_state_default() {
+        let state = RetrospectiveState::new();
+        assert!(state.entry.is_none());
+        assert_eq!(state.selected_section, RetrospectiveSection::Successes);
+    }
+
+    #[test]
+    fn checkpoint_risk_labels() {
+        assert_eq!(CheckpointRisk::Low.label(), "LOW");
+        assert_eq!(CheckpointRisk::Medium.label(), "MED");
+        assert_eq!(CheckpointRisk::High.label(), "HIGH");
+        assert_eq!(CheckpointRisk::Critical.label(), "CRIT");
+    }
+
+    #[test]
+    fn requirement_status_labels() {
+        assert_eq!(RequirementStatus::Pending.label(), "Pending");
+        assert_eq!(RequirementStatus::Met.label(), "Met");
+        assert_eq!(RequirementStatus::Failed.label(), "Failed");
+    }
+
+    #[test]
+    fn display_project_state_labels() {
+        assert_eq!(DisplayProjectState::Created.label(), "Created");
+        assert_eq!(DisplayProjectState::Executing.label(), "Executing");
+        assert_eq!(DisplayProjectState::Complete.label(), "Complete");
+    }
+
+    fn sample_project() -> DisplayProject {
+        DisplayProject {
+            name: "Test Project".into(),
+            description: "A test project".into(),
+            state: DisplayProjectState::Executing,
+            phases: vec![DisplayPhase {
+                name: "Phase 1".into(),
+                state: DisplayPhaseState::Active,
+                completion_pct: 50,
+                plans: vec![DisplayPlan {
+                    title: "Task A".into(),
+                    wave: 1,
+                    state: DisplayPlanState::Executing,
+                    depends_on: vec![],
+                }],
+            }],
+            checkpoints: vec![DisplayCheckpoint {
+                description: "Approve deployment".into(),
+                risk: CheckpointRisk::High,
+                approved: false,
+            }],
+            requirements: vec![DisplayRequirement {
+                id: "REQ-001".into(),
+                description: "Must pass tests".into(),
+                status: RequirementStatus::Pending,
+                source: "spec".into(),
+            }],
+            verifications: vec![DisplayVerification {
+                name: "Unit tests".into(),
+                passed: true,
+                evidence: "All 42 tests passed".into(),
+            }],
+            tasks: vec![DisplayTask {
+                title: "Implement feature".into(),
+                state: DisplayPlanState::Executing,
+                depth: 0,
+                blocked_by: vec![],
+            }],
+            milestones: vec![DisplayMilestone {
+                label: "MVP".into(),
+                timestamp: "2026-03-20T10:00:00Z".into(),
+                completed: false,
+            }],
+            edit_history: vec![DisplayEditEntry {
+                timestamp: "2026-03-19T09:00:00Z".into(),
+                description: "Initial plan created".into(),
+                author: "agent".into(),
+            }],
+        }
+    }
+}

--- a/crates/theatron/tui/src/state/view_stack.rs
+++ b/crates/theatron/tui/src/state/view_stack.rs
@@ -22,6 +22,10 @@ pub enum View {
     MemoryInspector,
     /// Fact detail within the memory inspector.
     FactDetail { fact_id: String },
+    /// Planning dashboard: project phases, execution, checkpoints.
+    Planning,
+    /// Retrospective: post-mortem for completed projects.
+    Retrospective,
 }
 
 impl View {
@@ -34,6 +38,8 @@ impl View {
             Self::MessageDetail { .. } => "Message",
             Self::MemoryInspector => "Memory",
             Self::FactDetail { .. } => "Fact",
+            Self::Planning => "Planning",
+            Self::Retrospective => "Retrospective",
         }
     }
 }

--- a/crates/theatron/tui/src/update/command.rs
+++ b/crates/theatron/tui/src/update/command.rs
@@ -336,6 +336,12 @@ pub(crate) async fn execute_command(app: &mut App) {
             app.layout.notifications.mark_all_read();
             app.layout.overlay = Some(Overlay::NotificationHistory { scroll: 0 });
         }
+        "planning" | "plan" => {
+            super::planning::handle_open(app);
+        }
+        "retrospective" | "retro" => {
+            super::planning::handle_retro_open(app);
+        }
         _ => {
             app.viewport.error_toast =
                 Some(ErrorToast::new(format!("Unknown command: {cmd_name}")));

--- a/crates/theatron/tui/src/update/mod.rs
+++ b/crates/theatron/tui/src/update/mod.rs
@@ -6,6 +6,7 @@ mod input;
 pub(crate) mod memory;
 mod navigation;
 mod overlay;
+pub(crate) mod planning;
 mod search;
 pub(crate) mod selection;
 pub(crate) mod settings;
@@ -255,6 +256,22 @@ pub(crate) async fn update(app: &mut App, msg: Msg) {
         Msg::SettingsLoaded(config) => settings::handle_loaded(app, config),
         Msg::SettingsSaved => settings::handle_saved(app),
         Msg::SettingsSaveError(msg) => settings::handle_save_error(app, msg),
+        Msg::PlanningOpen => planning::handle_open(app),
+        Msg::PlanningClose => planning::handle_close(app),
+        Msg::PlanningTabNext => planning::handle_tab_next(app),
+        Msg::PlanningTabPrev => planning::handle_tab_prev(app),
+        Msg::PlanningSelectUp => planning::handle_select_up(app),
+        Msg::PlanningSelectDown => planning::handle_select_down(app),
+        Msg::PlanningToggleExpand => planning::handle_toggle_expand(app),
+        Msg::PlanningApproveCheckpoint => planning::handle_approve_checkpoint(app),
+
+        Msg::RetroOpen => planning::handle_retro_open(app),
+        Msg::RetroClose => planning::handle_retro_close(app),
+        Msg::RetroSectionNext => planning::handle_retro_section_next(app),
+        Msg::RetroSectionPrev => planning::handle_retro_section_prev(app),
+        Msg::RetroScrollUp => planning::handle_retro_scroll_up(app),
+        Msg::RetroScrollDown => planning::handle_retro_scroll_down(app),
+
         Msg::MemoryOpen => memory::handle_open(app).await,
         Msg::MemoryClose => memory::handle_close(app),
         Msg::MemoryTabNext => memory::handle_tab_next(app),

--- a/crates/theatron/tui/src/update/planning.rs
+++ b/crates/theatron/tui/src/update/planning.rs
@@ -1,0 +1,171 @@
+//! Update handlers for the planning dashboard and retrospective views.
+
+use crate::app::App;
+use crate::state::view_stack::View;
+
+/// Open the planning dashboard, pushing it onto the view stack.
+pub(crate) fn handle_open(app: &mut App) {
+    app.layout.view_stack.push(View::Planning);
+    app.layout.planning.loading = false;
+}
+
+/// Close the planning dashboard (pop back).
+pub(crate) fn handle_close(app: &mut App) {
+    if matches!(app.layout.view_stack.current(), View::Planning) {
+        app.layout.view_stack.pop();
+    }
+}
+
+pub(crate) fn handle_tab_next(app: &mut App) {
+    app.layout.planning.tab_next();
+}
+
+pub(crate) fn handle_tab_prev(app: &mut App) {
+    app.layout.planning.tab_prev();
+}
+
+pub(crate) fn handle_select_up(app: &mut App) {
+    app.layout.planning.select_up();
+}
+
+pub(crate) fn handle_select_down(app: &mut App) {
+    app.layout.planning.select_down();
+}
+
+pub(crate) fn handle_toggle_expand(app: &mut App) {
+    app.layout.planning.toggle_phase();
+}
+
+pub(crate) fn handle_approve_checkpoint(app: &mut App) {
+    app.layout.planning.approve_checkpoint();
+}
+
+/// Open the retrospective view.
+pub(crate) fn handle_retro_open(app: &mut App) {
+    app.layout.view_stack.push(View::Retrospective);
+    app.layout.retrospective.loading = false;
+}
+
+/// Close the retrospective view (pop back).
+pub(crate) fn handle_retro_close(app: &mut App) {
+    if matches!(app.layout.view_stack.current(), View::Retrospective) {
+        app.layout.view_stack.pop();
+    }
+}
+
+pub(crate) fn handle_retro_section_next(app: &mut App) {
+    app.layout.retrospective.section_next();
+}
+
+pub(crate) fn handle_retro_section_prev(app: &mut App) {
+    app.layout.retrospective.section_prev();
+}
+
+pub(crate) fn handle_retro_scroll_up(app: &mut App) {
+    app.layout.retrospective.scroll_offset =
+        app.layout.retrospective.scroll_offset.saturating_sub(1);
+}
+
+pub(crate) fn handle_retro_scroll_down(app: &mut App) {
+    app.layout.retrospective.scroll_offset += 1;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app::test_helpers::test_app;
+
+    #[test]
+    fn open_pushes_planning_view() {
+        let mut app = test_app();
+        handle_open(&mut app);
+        assert_eq!(app.layout.view_stack.current(), &View::Planning);
+    }
+
+    #[test]
+    fn close_pops_planning_view() {
+        let mut app = test_app();
+        handle_open(&mut app);
+        handle_close(&mut app);
+        assert!(app.layout.view_stack.is_home());
+    }
+
+    #[test]
+    fn close_does_nothing_if_not_on_planning() {
+        let mut app = test_app();
+        handle_close(&mut app);
+        assert!(app.layout.view_stack.is_home());
+    }
+
+    #[test]
+    fn tab_next_cycles_tab() {
+        let mut app = test_app();
+        handle_open(&mut app);
+        handle_tab_next(&mut app);
+        assert_eq!(
+            app.layout.planning.tab,
+            crate::state::planning::PlanningTab::Requirements
+        );
+    }
+
+    #[test]
+    fn tab_prev_cycles_tab() {
+        let mut app = test_app();
+        handle_open(&mut app);
+        handle_tab_prev(&mut app);
+        assert_eq!(
+            app.layout.planning.tab,
+            crate::state::planning::PlanningTab::EditHistory
+        );
+    }
+
+    #[test]
+    fn select_up_saturates() {
+        let mut app = test_app();
+        handle_open(&mut app);
+        handle_select_up(&mut app);
+        assert_eq!(app.layout.planning.selected_row, 0);
+    }
+
+    #[test]
+    fn retro_open_pushes_view() {
+        let mut app = test_app();
+        handle_retro_open(&mut app);
+        assert_eq!(app.layout.view_stack.current(), &View::Retrospective);
+    }
+
+    #[test]
+    fn retro_close_pops_view() {
+        let mut app = test_app();
+        handle_retro_open(&mut app);
+        handle_retro_close(&mut app);
+        assert!(app.layout.view_stack.is_home());
+    }
+
+    #[test]
+    fn retro_section_next_cycles() {
+        let mut app = test_app();
+        handle_retro_open(&mut app);
+        handle_retro_section_next(&mut app);
+        assert_eq!(
+            app.layout.retrospective.selected_section,
+            crate::state::planning::RetrospectiveSection::Blockers
+        );
+    }
+
+    #[test]
+    fn retro_scroll_up_saturates() {
+        let mut app = test_app();
+        handle_retro_open(&mut app);
+        handle_retro_scroll_up(&mut app);
+        assert_eq!(app.layout.retrospective.scroll_offset, 0);
+    }
+
+    #[test]
+    fn retro_scroll_down_increments() {
+        let mut app = test_app();
+        handle_retro_open(&mut app);
+        handle_retro_scroll_down(&mut app);
+        assert_eq!(app.layout.retrospective.scroll_offset, 1);
+    }
+}

--- a/crates/theatron/tui/src/update/streaming.rs
+++ b/crates/theatron/tui/src/update/streaming.rs
@@ -270,10 +270,7 @@ pub(crate) async fn handle_stream_turn_complete(app: &mut App, outcome: TurnOutc
         let ctx_total = model_context_window(&outcome.model);
         app.dashboard.context_tokens_used = Some(ctx_used);
         app.dashboard.context_tokens_total = Some(ctx_total);
-        #[expect(
-            clippy::cast_possible_truncation,
-            reason = "percentage is always 0–100, fits in u8"
-        )]
+        #[allow(clippy::cast_possible_truncation)]
         let pct = ((u64::from(ctx_used) * 100) / u64::from(ctx_total)).min(100) as u8;
         app.dashboard.context_usage_pct = Some(pct);
     }

--- a/crates/theatron/tui/src/update/view_nav.rs
+++ b/crates/theatron/tui/src/update/view_nav.rs
@@ -80,8 +80,12 @@ pub(crate) fn handle_drill_in(app: &mut App) {
                 app.viewport.render.auto_scroll = true;
             }
         }
-        // NOTE: already at detail level, no further drill-in
-        View::MessageDetail { .. } | View::MemoryInspector | View::FactDetail { .. } => {}
+        // NOTE: already at detail level or in a panel view, no further drill-in
+        View::MessageDetail { .. }
+        | View::MemoryInspector
+        | View::FactDetail { .. }
+        | View::Planning
+        | View::Retrospective => {}
     }
 }
 

--- a/crates/theatron/tui/src/view/mod.rs
+++ b/crates/theatron/tui/src/view/mod.rs
@@ -7,6 +7,7 @@ mod memory;
 pub(crate) mod notification;
 pub(crate) mod ops;
 mod overlay;
+pub(crate) mod planning;
 pub(crate) mod settings;
 mod sidebar;
 mod slash;

--- a/crates/theatron/tui/src/view/overlay.rs
+++ b/crates/theatron/tui/src/view/overlay.rs
@@ -326,7 +326,11 @@ fn render_tool_approval(
             let mut c = w.chars();
             match c.next() {
                 None => String::new(),
-                Some(f) => f.to_uppercase().collect::<String>() + c.as_str(),
+                Some(f) => {
+                    let mut s = f.to_uppercase().collect::<String>();
+                    s.push_str(c.as_str());
+                    s
+                }
             }
         })
         .collect::<Vec<_>>()

--- a/crates/theatron/tui/src/view/planning.rs
+++ b/crates/theatron/tui/src/view/planning.rs
@@ -1,0 +1,889 @@
+//! Rendering for the planning dashboard and retrospective views.
+
+use ratatui::Frame;
+use ratatui::layout::{Constraint, Direction, Layout, Rect};
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Paragraph, Wrap};
+
+use crate::app::App;
+use crate::state::planning::{
+    CheckpointRisk, DisplayPhaseState, DisplayPlanState, DisplayProjectState, PlanningTab,
+    RequirementStatus, RetrospectiveSection,
+};
+use crate::theme::Theme;
+
+/// Height of the tab bar row.
+const TAB_BAR_HEIGHT: u16 = 2;
+/// Minimum height for the content area.
+const CONTENT_MIN_HEIGHT: u16 = 3;
+/// Height of the status/help bar.
+const STATUS_BAR_HEIGHT: u16 = 1;
+
+/// Render the planning dashboard (tab bar + tab content + status bar).
+#[expect(
+    clippy::indexing_slicing,
+    reason = "Layout.split() returns exactly as many Rects as constraints; indices 0/1/2 match the three constraints"
+)]
+pub(crate) fn render_dashboard(app: &App, frame: &mut Frame, area: Rect, theme: &Theme) {
+    let layout = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(TAB_BAR_HEIGHT),
+            Constraint::Min(CONTENT_MIN_HEIGHT),
+            Constraint::Length(STATUS_BAR_HEIGHT),
+        ])
+        .split(area);
+
+    render_tab_bar(app, frame, layout[0], theme);
+
+    if app.layout.planning.loading {
+        let loading = Paragraph::new(Line::from(vec![
+            Span::raw("  "),
+            Span::styled("Loading planning data...", theme.style_dim()),
+        ]));
+        frame.render_widget(loading, layout[1]);
+    } else if app.layout.planning.project.is_none() {
+        let empty = Paragraph::new(Line::from(vec![
+            Span::raw("  "),
+            Span::styled(
+                "No active project. Use :planning to load project data.",
+                theme.style_dim(),
+            ),
+        ]));
+        frame.render_widget(empty, layout[1]);
+    } else {
+        match app.layout.planning.tab {
+            PlanningTab::Overview => render_overview(app, frame, layout[1], theme),
+            PlanningTab::Requirements => render_requirements(app, frame, layout[1], theme),
+            PlanningTab::Execution => render_execution(app, frame, layout[1], theme),
+            PlanningTab::Verification => render_verification(app, frame, layout[1], theme),
+            PlanningTab::Tasks => render_tasks(app, frame, layout[1], theme),
+            PlanningTab::Timeline => render_timeline(app, frame, layout[1], theme),
+            PlanningTab::EditHistory => render_edit_history(app, frame, layout[1], theme),
+        }
+    }
+
+    render_status_bar(app, frame, layout[2], theme);
+}
+
+fn render_tab_bar(app: &App, frame: &mut Frame, area: Rect, theme: &Theme) {
+    let mut spans: Vec<Span> = vec![Span::raw(" ")];
+    for tab in PlanningTab::ALL {
+        let is_active = tab == app.layout.planning.tab;
+        let style = if is_active {
+            theme.style_accent().add_modifier(Modifier::BOLD)
+        } else {
+            theme.style_dim()
+        };
+        let marker = if is_active { "▸ " } else { "  " };
+        spans.push(Span::styled(format!("{marker}{}", tab.label()), style));
+        spans.push(Span::raw("  "));
+    }
+    let line = Line::from(spans);
+    let paragraph = Paragraph::new(line);
+    frame.render_widget(paragraph, area);
+}
+
+fn render_status_bar(app: &App, frame: &mut Frame, area: Rect, theme: &Theme) {
+    let checkpoint_hint = if app.layout.planning.has_pending_checkpoints() {
+        Span::styled("  a", theme.style_accent())
+    } else {
+        Span::raw("")
+    };
+    let checkpoint_label = if app.layout.planning.has_pending_checkpoints() {
+        Span::styled(" approve  ", theme.style_dim())
+    } else {
+        Span::raw("")
+    };
+
+    let line = Line::from(vec![
+        Span::raw("  "),
+        Span::styled("Tab", theme.style_accent()),
+        Span::styled(" switch  ", theme.style_dim()),
+        Span::styled("j/k", theme.style_accent()),
+        Span::styled(" navigate  ", theme.style_dim()),
+        Span::styled("Enter", theme.style_accent()),
+        Span::styled(" expand  ", theme.style_dim()),
+        checkpoint_hint,
+        checkpoint_label,
+        Span::styled("Esc", theme.style_accent()),
+        Span::styled(" back", theme.style_dim()),
+    ]);
+    let paragraph = Paragraph::new(line);
+    frame.render_widget(paragraph, area);
+}
+
+fn render_overview(app: &App, frame: &mut Frame, area: Rect, theme: &Theme) {
+    let Some(ref project) = app.layout.planning.project else {
+        return;
+    };
+
+    let mut lines: Vec<Line> = Vec::new();
+    lines.push(Line::raw(""));
+    lines.push(Line::from(vec![
+        Span::raw("  "),
+        Span::styled(
+            &project.name,
+            theme.style_accent().add_modifier(Modifier::BOLD),
+        ),
+    ]));
+
+    if !project.description.is_empty() {
+        lines.push(Line::from(vec![
+            Span::raw("  "),
+            Span::styled(&project.description, theme.style_dim()),
+        ]));
+    }
+
+    lines.push(Line::from(vec![
+        Span::raw("  "),
+        Span::styled("State: ", theme.style_dim()),
+        Span::styled(project.state.label(), state_style(project.state, theme)),
+    ]));
+
+    // Checkpoints section
+    if !project.checkpoints.is_empty() {
+        lines.push(Line::raw(""));
+        lines.push(Line::from(vec![
+            Span::raw("  "),
+            Span::styled("Checkpoints", theme.style_fg().add_modifier(Modifier::BOLD)),
+        ]));
+        for (i, cp) in project.checkpoints.iter().enumerate() {
+            let icon = if cp.approved { "\u{2713}" } else { "\u{25cb}" };
+            let icon_style = if cp.approved {
+                theme.style_success()
+            } else {
+                risk_style(cp.risk, theme)
+            };
+            let cursor = if i == app.layout.planning.checkpoint_cursor && !cp.approved {
+                "▸ "
+            } else {
+                "  "
+            };
+            lines.push(Line::from(vec![
+                Span::raw("  "),
+                Span::styled(cursor, theme.style_accent()),
+                Span::styled(icon, icon_style),
+                Span::raw(" "),
+                Span::styled(
+                    format!("[{}] ", cp.risk.label()),
+                    risk_style(cp.risk, theme),
+                ),
+                Span::styled(&cp.description, theme.style_fg()),
+            ]));
+        }
+    }
+
+    // Phases summary
+    lines.push(Line::raw(""));
+    lines.push(Line::from(vec![
+        Span::raw("  "),
+        Span::styled("Phases", theme.style_fg().add_modifier(Modifier::BOLD)),
+    ]));
+    for (i, phase) in project.phases.iter().enumerate() {
+        let is_selected = i == app.layout.planning.selected_row;
+        let marker = if is_selected { "▸ " } else { "  " };
+        let name_style = if is_selected {
+            theme.style_fg().add_modifier(Modifier::BOLD)
+        } else {
+            theme.style_fg()
+        };
+        lines.push(Line::from(vec![
+            Span::raw("  "),
+            Span::styled(marker, theme.style_accent()),
+            Span::styled(&phase.name, name_style),
+            Span::raw("  "),
+            Span::styled(phase.state.label(), phase_state_style(phase.state, theme)),
+            Span::raw("  "),
+            Span::styled(progress_bar(phase.completion_pct, 20), theme.style_dim()),
+            Span::styled(format!(" {}%", phase.completion_pct), theme.style_dim()),
+        ]));
+
+        let expanded = app
+            .layout
+            .planning
+            .expanded_phases
+            .get(i)
+            .copied()
+            .unwrap_or(false);
+        if expanded {
+            for plan in &phase.plans {
+                lines.push(Line::from(vec![
+                    Span::raw("      "),
+                    Span::styled(format!("[w{}] ", plan.wave), theme.style_dim()),
+                    Span::styled(&plan.title, theme.style_fg()),
+                    Span::raw("  "),
+                    Span::styled(plan.state.label(), plan_state_style(plan.state, theme)),
+                ]));
+            }
+        }
+    }
+
+    let paragraph = Paragraph::new(lines)
+        .block(Block::default().borders(Borders::NONE))
+        .wrap(Wrap { trim: false });
+    frame.render_widget(paragraph, area);
+}
+
+fn render_requirements(app: &App, frame: &mut Frame, area: Rect, theme: &Theme) {
+    let Some(ref project) = app.layout.planning.project else {
+        return;
+    };
+
+    let mut lines: Vec<Line> = Vec::new();
+    lines.push(Line::raw(""));
+    lines.push(Line::from(vec![
+        Span::raw("  "),
+        Span::styled(
+            "Requirements",
+            theme.style_accent().add_modifier(Modifier::BOLD),
+        ),
+    ]));
+
+    // Header
+    lines.push(Line::from(vec![
+        Span::raw("  "),
+        Span::styled(
+            format!(
+                "{:<10} {:<40} {:<12} {}",
+                "ID", "Description", "Status", "Source"
+            ),
+            theme.style_dim().add_modifier(Modifier::UNDERLINED),
+        ),
+    ]));
+
+    for (i, req) in project.requirements.iter().enumerate() {
+        let is_selected = i == app.layout.planning.selected_row;
+        let marker = if is_selected { "▸" } else { " " };
+        let row_style = if is_selected {
+            theme.style_fg().add_modifier(Modifier::BOLD)
+        } else {
+            theme.style_fg()
+        };
+
+        let desc = truncate_str(&req.description, 40);
+        let status_style = requirement_status_style(req.status, theme);
+
+        lines.push(Line::from(vec![
+            Span::styled(format!(" {marker}"), theme.style_accent()),
+            Span::styled(format!("{:<10} ", req.id), row_style),
+            Span::styled(format!("{desc:<40} "), row_style),
+            Span::styled(format!("{:<12} ", req.status.label()), status_style),
+            Span::styled(&req.source, theme.style_dim()),
+        ]));
+    }
+
+    if project.requirements.is_empty() {
+        lines.push(Line::from(vec![
+            Span::raw("  "),
+            Span::styled("No requirements defined.", theme.style_dim()),
+        ]));
+    }
+
+    let paragraph = Paragraph::new(lines)
+        .block(Block::default().borders(Borders::NONE))
+        .wrap(Wrap { trim: false });
+    frame.render_widget(paragraph, area);
+}
+
+fn render_execution(app: &App, frame: &mut Frame, area: Rect, theme: &Theme) {
+    let Some(ref project) = app.layout.planning.project else {
+        return;
+    };
+
+    let mut lines: Vec<Line> = Vec::new();
+    lines.push(Line::raw(""));
+    lines.push(Line::from(vec![
+        Span::raw("  "),
+        Span::styled(
+            "Execution — Wave-Based Parallel Phases",
+            theme.style_accent().add_modifier(Modifier::BOLD),
+        ),
+    ]));
+
+    for (i, phase) in project.phases.iter().enumerate() {
+        let is_selected = i == app.layout.planning.selected_row;
+        let marker = if is_selected { "▸ " } else { "  " };
+        let name_style = if is_selected {
+            theme.style_fg().add_modifier(Modifier::BOLD)
+        } else {
+            theme.style_fg()
+        };
+
+        lines.push(Line::raw(""));
+        lines.push(Line::from(vec![
+            Span::raw("  "),
+            Span::styled(marker, theme.style_accent()),
+            Span::styled(&phase.name, name_style),
+            Span::raw("  "),
+            Span::styled(phase.state.label(), phase_state_style(phase.state, theme)),
+        ]));
+
+        // Group plans by wave
+        let max_wave = phase.plans.iter().map(|p| p.wave).max().unwrap_or(0);
+        for wave in 1..=max_wave {
+            let wave_plans: Vec<_> = phase.plans.iter().filter(|p| p.wave == wave).collect();
+            if wave_plans.is_empty() {
+                continue;
+            }
+
+            lines.push(Line::from(vec![
+                Span::raw("    "),
+                Span::styled(
+                    format!("Wave {wave}"),
+                    theme.style_dim().add_modifier(Modifier::UNDERLINED),
+                ),
+            ]));
+
+            for plan in wave_plans {
+                let deps = if plan.depends_on.is_empty() {
+                    String::new()
+                } else {
+                    format!(" (blocked by: {})", plan.depends_on.join(", "))
+                };
+                lines.push(Line::from(vec![
+                    Span::raw("      "),
+                    Span::styled(plan.state.label(), plan_state_style(plan.state, theme)),
+                    Span::raw("  "),
+                    Span::styled(&plan.title, theme.style_fg()),
+                    Span::styled(deps, theme.style_dim()),
+                ]));
+            }
+        }
+
+        // Progress bar
+        lines.push(Line::from(vec![
+            Span::raw("    "),
+            Span::styled(progress_bar(phase.completion_pct, 30), theme.style_dim()),
+            Span::styled(format!(" {}%", phase.completion_pct), theme.style_dim()),
+        ]));
+    }
+
+    let paragraph = Paragraph::new(lines)
+        .block(Block::default().borders(Borders::NONE))
+        .wrap(Wrap { trim: false });
+    frame.render_widget(paragraph, area);
+}
+
+fn render_verification(app: &App, frame: &mut Frame, area: Rect, theme: &Theme) {
+    let Some(ref project) = app.layout.planning.project else {
+        return;
+    };
+
+    let mut lines: Vec<Line> = Vec::new();
+    lines.push(Line::raw(""));
+    lines.push(Line::from(vec![
+        Span::raw("  "),
+        Span::styled(
+            "Verification",
+            theme.style_accent().add_modifier(Modifier::BOLD),
+        ),
+    ]));
+
+    for (i, v) in project.verifications.iter().enumerate() {
+        let is_selected = i == app.layout.planning.selected_row;
+        let marker = if is_selected { "▸" } else { " " };
+        let icon = if v.passed { "\u{2713}" } else { "\u{2717}" };
+        let icon_style = if v.passed {
+            theme.style_success()
+        } else {
+            theme.style_error()
+        };
+        let name_style = if is_selected {
+            theme.style_fg().add_modifier(Modifier::BOLD)
+        } else {
+            theme.style_fg()
+        };
+
+        lines.push(Line::from(vec![
+            Span::styled(format!(" {marker} "), theme.style_accent()),
+            Span::styled(icon, icon_style),
+            Span::raw("  "),
+            Span::styled(&v.name, name_style),
+        ]));
+        if !v.evidence.is_empty() {
+            lines.push(Line::from(vec![
+                Span::raw("      "),
+                Span::styled(&v.evidence, theme.style_dim()),
+            ]));
+        }
+    }
+
+    if project.verifications.is_empty() {
+        lines.push(Line::from(vec![
+            Span::raw("  "),
+            Span::styled("No verifications recorded.", theme.style_dim()),
+        ]));
+    }
+
+    let paragraph = Paragraph::new(lines)
+        .block(Block::default().borders(Borders::NONE))
+        .wrap(Wrap { trim: false });
+    frame.render_widget(paragraph, area);
+}
+
+fn render_tasks(app: &App, frame: &mut Frame, area: Rect, theme: &Theme) {
+    let Some(ref project) = app.layout.planning.project else {
+        return;
+    };
+
+    let mut lines: Vec<Line> = Vec::new();
+    lines.push(Line::raw(""));
+    lines.push(Line::from(vec![
+        Span::raw("  "),
+        Span::styled(
+            "Task List",
+            theme.style_accent().add_modifier(Modifier::BOLD),
+        ),
+    ]));
+
+    for (i, task) in project.tasks.iter().enumerate() {
+        let is_selected = i == app.layout.planning.selected_row;
+        let marker = if is_selected { "▸" } else { " " };
+        let indent = "  ".repeat(usize::from(task.depth) + 1);
+        let name_style = if is_selected {
+            theme.style_fg().add_modifier(Modifier::BOLD)
+        } else {
+            theme.style_fg()
+        };
+
+        let blocked_info = if task.blocked_by.is_empty() {
+            String::new()
+        } else {
+            format!("  [blocked by: {}]", task.blocked_by.join(", "))
+        };
+
+        lines.push(Line::from(vec![
+            Span::styled(format!(" {marker}"), theme.style_accent()),
+            Span::raw(indent),
+            Span::styled(task.state.label(), plan_state_style(task.state, theme)),
+            Span::raw("  "),
+            Span::styled(&task.title, name_style),
+            Span::styled(blocked_info, theme.style_error()),
+        ]));
+    }
+
+    if project.tasks.is_empty() {
+        lines.push(Line::from(vec![
+            Span::raw("  "),
+            Span::styled("No tasks defined.", theme.style_dim()),
+        ]));
+    }
+
+    let paragraph = Paragraph::new(lines)
+        .block(Block::default().borders(Borders::NONE))
+        .wrap(Wrap { trim: false });
+    frame.render_widget(paragraph, area);
+}
+
+fn render_timeline(app: &App, frame: &mut Frame, area: Rect, theme: &Theme) {
+    let Some(ref project) = app.layout.planning.project else {
+        return;
+    };
+
+    let mut lines: Vec<Line> = Vec::new();
+    lines.push(Line::raw(""));
+    lines.push(Line::from(vec![
+        Span::raw("  "),
+        Span::styled(
+            "Timeline",
+            theme.style_accent().add_modifier(Modifier::BOLD),
+        ),
+    ]));
+
+    for (i, milestone) in project.milestones.iter().enumerate() {
+        let is_selected = i == app.layout.planning.selected_row;
+        let marker = if is_selected { "▸" } else { " " };
+        let icon = if milestone.completed {
+            "\u{25c6}"
+        } else {
+            "\u{25c7}"
+        };
+        let icon_style = if milestone.completed {
+            theme.style_success()
+        } else {
+            theme.style_dim()
+        };
+        let name_style = if is_selected {
+            theme.style_fg().add_modifier(Modifier::BOLD)
+        } else {
+            theme.style_fg()
+        };
+
+        lines.push(Line::from(vec![
+            Span::styled(format!(" {marker} "), theme.style_accent()),
+            Span::styled(icon, icon_style),
+            Span::raw("  "),
+            Span::styled(&milestone.timestamp, theme.style_dim()),
+            Span::raw("  "),
+            Span::styled(&milestone.label, name_style),
+        ]));
+    }
+
+    if project.milestones.is_empty() {
+        lines.push(Line::from(vec![
+            Span::raw("  "),
+            Span::styled("No milestones recorded.", theme.style_dim()),
+        ]));
+    }
+
+    let paragraph = Paragraph::new(lines)
+        .block(Block::default().borders(Borders::NONE))
+        .wrap(Wrap { trim: false });
+    frame.render_widget(paragraph, area);
+}
+
+fn render_edit_history(app: &App, frame: &mut Frame, area: Rect, theme: &Theme) {
+    let Some(ref project) = app.layout.planning.project else {
+        return;
+    };
+
+    let mut lines: Vec<Line> = Vec::new();
+    lines.push(Line::raw(""));
+    lines.push(Line::from(vec![
+        Span::raw("  "),
+        Span::styled(
+            "Edit History",
+            theme.style_accent().add_modifier(Modifier::BOLD),
+        ),
+    ]));
+
+    for (i, entry) in project.edit_history.iter().enumerate() {
+        let is_selected = i == app.layout.planning.selected_row;
+        let marker = if is_selected { "▸" } else { " " };
+        let name_style = if is_selected {
+            theme.style_fg().add_modifier(Modifier::BOLD)
+        } else {
+            theme.style_fg()
+        };
+
+        lines.push(Line::from(vec![
+            Span::styled(format!(" {marker} "), theme.style_accent()),
+            Span::styled(&entry.timestamp, theme.style_dim()),
+            Span::raw("  "),
+            Span::styled(&entry.description, name_style),
+            Span::raw("  "),
+            Span::styled(format!("({})", entry.author), theme.style_dim()),
+        ]));
+    }
+
+    if project.edit_history.is_empty() {
+        lines.push(Line::from(vec![
+            Span::raw("  "),
+            Span::styled("No edit history.", theme.style_dim()),
+        ]));
+    }
+
+    let paragraph = Paragraph::new(lines)
+        .block(Block::default().borders(Borders::NONE))
+        .wrap(Wrap { trim: false });
+    frame.render_widget(paragraph, area);
+}
+
+/// Render the retrospective post-mortem view for completed projects.
+pub(crate) fn render_retrospective(app: &App, frame: &mut Frame, area: Rect, theme: &Theme) {
+    let state = &app.layout.retrospective;
+
+    if state.loading {
+        let loading = Paragraph::new(Line::from(vec![
+            Span::raw("  "),
+            Span::styled("Loading retrospective...", theme.style_dim()),
+        ]));
+        frame.render_widget(loading, area);
+        return;
+    }
+
+    let Some(ref entry) = state.entry else {
+        let empty = Paragraph::new(Line::from(vec![
+            Span::raw("  "),
+            Span::styled(
+                "No retrospective data. Only completed projects have retrospectives.",
+                theme.style_dim(),
+            ),
+        ]));
+        frame.render_widget(empty, area);
+        return;
+    };
+
+    let mut lines: Vec<Line> = Vec::new();
+    lines.push(Line::raw(""));
+    lines.push(Line::from(vec![
+        Span::raw("  "),
+        Span::styled(
+            format!("Retrospective — {}", entry.project_name),
+            theme.style_accent().add_modifier(Modifier::BOLD),
+        ),
+    ]));
+
+    // Section navigation
+    lines.push(Line::from(vec![
+        Span::raw("  "),
+        section_span(
+            "Successes",
+            RetrospectiveSection::Successes,
+            state.selected_section,
+            theme,
+        ),
+        Span::raw("  "),
+        section_span(
+            "Blockers",
+            RetrospectiveSection::Blockers,
+            state.selected_section,
+            theme,
+        ),
+        Span::raw("  "),
+        section_span(
+            "Lessons",
+            RetrospectiveSection::Lessons,
+            state.selected_section,
+            theme,
+        ),
+        Span::raw("  "),
+        section_span(
+            "Decisions",
+            RetrospectiveSection::Decisions,
+            state.selected_section,
+            theme,
+        ),
+    ]));
+    lines.push(Line::raw(""));
+
+    match state.selected_section {
+        RetrospectiveSection::Successes => {
+            for s in &entry.successes {
+                lines.push(Line::from(vec![
+                    Span::raw("  "),
+                    Span::styled("\u{2713} ", theme.style_success()),
+                    Span::styled(s.as_str(), theme.style_fg()),
+                ]));
+            }
+            if entry.successes.is_empty() {
+                lines.push(Line::from(vec![
+                    Span::raw("  "),
+                    Span::styled("No successes recorded.", theme.style_dim()),
+                ]));
+            }
+        }
+        RetrospectiveSection::Blockers => {
+            for b in &entry.blockers {
+                lines.push(Line::from(vec![
+                    Span::raw("  "),
+                    Span::styled("\u{2717} ", theme.style_error()),
+                    Span::styled(b.as_str(), theme.style_fg()),
+                ]));
+            }
+            if entry.blockers.is_empty() {
+                lines.push(Line::from(vec![
+                    Span::raw("  "),
+                    Span::styled("No blockers recorded.", theme.style_dim()),
+                ]));
+            }
+        }
+        RetrospectiveSection::Lessons => {
+            for l in &entry.lessons {
+                lines.push(Line::from(vec![
+                    Span::raw("  "),
+                    Span::styled("\u{25b8} ", theme.style_accent()),
+                    Span::styled(l.as_str(), theme.style_fg()),
+                ]));
+            }
+            if entry.lessons.is_empty() {
+                lines.push(Line::from(vec![
+                    Span::raw("  "),
+                    Span::styled("No lessons recorded.", theme.style_dim()),
+                ]));
+            }
+        }
+        RetrospectiveSection::Decisions => {
+            for d in &entry.decisions {
+                lines.push(Line::from(vec![
+                    Span::raw("  "),
+                    Span::styled(&d.timestamp, theme.style_dim()),
+                    Span::raw("  "),
+                    Span::styled(&d.question, theme.style_fg().add_modifier(Modifier::BOLD)),
+                ]));
+                lines.push(Line::from(vec![
+                    Span::raw("    Choice: "),
+                    Span::styled(&d.choice, theme.style_accent()),
+                ]));
+                if !d.rationale.is_empty() {
+                    lines.push(Line::from(vec![
+                        Span::raw("    Why: "),
+                        Span::styled(&d.rationale, theme.style_dim()),
+                    ]));
+                }
+                lines.push(Line::raw(""));
+            }
+            if entry.decisions.is_empty() {
+                lines.push(Line::from(vec![
+                    Span::raw("  "),
+                    Span::styled("No decisions recorded.", theme.style_dim()),
+                ]));
+            }
+        }
+    }
+
+    lines.push(Line::raw(""));
+    lines.push(Line::from(vec![
+        Span::raw("  "),
+        Span::styled("Tab", theme.style_accent()),
+        Span::styled(" section  ", theme.style_dim()),
+        Span::styled("Esc", theme.style_accent()),
+        Span::styled(" back", theme.style_dim()),
+    ]));
+
+    let scroll = u16::try_from(state.scroll_offset).unwrap_or(u16::MAX);
+    let paragraph = Paragraph::new(lines)
+        .block(Block::default().borders(Borders::NONE))
+        .wrap(Wrap { trim: false })
+        .scroll((scroll, 0));
+    frame.render_widget(paragraph, area);
+}
+
+// -- Style helpers --
+
+fn state_style(state: DisplayProjectState, theme: &Theme) -> Style {
+    match state {
+        DisplayProjectState::Complete => theme.style_success(),
+        DisplayProjectState::Failed => theme.style_error(),
+        DisplayProjectState::Executing => theme.style_accent(),
+        DisplayProjectState::Paused => Style::default().fg(theme.status.warning),
+        _ => theme.style_dim(),
+    }
+}
+
+fn phase_state_style(state: DisplayPhaseState, theme: &Theme) -> Style {
+    match state {
+        DisplayPhaseState::Complete => theme.style_success(),
+        DisplayPhaseState::Failed => theme.style_error(),
+        DisplayPhaseState::Active | DisplayPhaseState::Executing => theme.style_accent(),
+        DisplayPhaseState::Verifying => Style::default().fg(theme.status.warning),
+        DisplayPhaseState::Pending => theme.style_dim(),
+    }
+}
+
+fn plan_state_style(state: DisplayPlanState, theme: &Theme) -> Style {
+    match state {
+        DisplayPlanState::Complete => theme.style_success(),
+        DisplayPlanState::Failed | DisplayPlanState::Stuck => theme.style_error(),
+        DisplayPlanState::Executing => theme.style_accent(),
+        DisplayPlanState::Ready => Style::default().fg(theme.status.warning),
+        DisplayPlanState::Pending | DisplayPlanState::Skipped => theme.style_dim(),
+    }
+}
+
+fn risk_style(risk: CheckpointRisk, theme: &Theme) -> Style {
+    match risk {
+        CheckpointRisk::Low => theme.style_success(),
+        CheckpointRisk::Medium => Style::default().fg(theme.status.warning),
+        CheckpointRisk::High | CheckpointRisk::Critical => theme.style_error(),
+    }
+}
+
+fn requirement_status_style(status: RequirementStatus, theme: &Theme) -> Style {
+    match status {
+        RequirementStatus::Met => theme.style_success(),
+        RequirementStatus::Failed => theme.style_error(),
+        RequirementStatus::InProgress => theme.style_accent(),
+        RequirementStatus::Pending => theme.style_dim(),
+        RequirementStatus::Deferred => Style::default().fg(theme.status.warning),
+    }
+}
+
+fn section_span<'a>(
+    label: &'a str,
+    section: RetrospectiveSection,
+    current: RetrospectiveSection,
+    theme: &Theme,
+) -> Span<'a> {
+    if section == current {
+        Span::styled(
+            format!("[{label}]"),
+            theme.style_accent().add_modifier(Modifier::BOLD),
+        )
+    } else {
+        Span::styled(format!(" {label} "), theme.style_dim())
+    }
+}
+
+/// Render a text-based progress bar.
+pub(crate) fn progress_bar(pct: u8, width: usize) -> String {
+    let filled = (usize::from(pct) * width) / 100;
+    let empty = width.saturating_sub(filled);
+    format!(
+        "[{}{}]",
+        "\u{2588}".repeat(filled),
+        "\u{2591}".repeat(empty)
+    )
+}
+
+/// Truncate a string to a maximum length, appending "..." if truncated.
+pub(crate) fn truncate_str(s: &str, max: usize) -> String {
+    if s.len() <= max {
+        return s.to_string();
+    }
+    let end = max.saturating_sub(3);
+    let mut boundary = end;
+    while boundary > 0 && !s.is_char_boundary(boundary) {
+        boundary -= 1;
+    }
+    let prefix = s.get(..boundary).unwrap_or(s);
+    format!("{prefix}...")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn progress_bar_zero() {
+        let bar = progress_bar(0, 10);
+        assert_eq!(
+            bar,
+            "[\u{2591}\u{2591}\u{2591}\u{2591}\u{2591}\u{2591}\u{2591}\u{2591}\u{2591}\u{2591}]"
+        );
+    }
+
+    #[test]
+    fn progress_bar_full() {
+        let bar = progress_bar(100, 10);
+        assert_eq!(
+            bar,
+            "[\u{2588}\u{2588}\u{2588}\u{2588}\u{2588}\u{2588}\u{2588}\u{2588}\u{2588}\u{2588}]"
+        );
+    }
+
+    #[test]
+    fn progress_bar_half() {
+        let bar = progress_bar(50, 10);
+        assert_eq!(
+            bar,
+            "[\u{2588}\u{2588}\u{2588}\u{2588}\u{2588}\u{2591}\u{2591}\u{2591}\u{2591}\u{2591}]"
+        );
+    }
+
+    #[test]
+    fn truncate_str_short() {
+        assert_eq!(truncate_str("hello", 10), "hello");
+    }
+
+    #[test]
+    fn truncate_str_exact() {
+        assert_eq!(truncate_str("hello", 5), "hello");
+    }
+
+    #[test]
+    fn truncate_str_long() {
+        let result = truncate_str("hello world", 8);
+        assert_eq!(result, "hello...");
+    }
+
+    #[test]
+    fn truncate_str_multibyte() {
+        let s = "hello\u{00e9}world";
+        let result = truncate_str(s, 8);
+        assert!(result.is_char_boundary(result.len()));
+        assert!(result.ends_with("..."));
+    }
+}

--- a/crates/theatron/tui/src/view/status_bar.rs
+++ b/crates/theatron/tui/src/view/status_bar.rs
@@ -449,10 +449,7 @@ fn context_gauge_spans(app: &App, theme: &Theme) -> Vec<Span<'static>> {
         None => {
             return vec![
                 Span::styled("ctx: ", theme.style_dim()),
-                Span::styled(
-                    "[".to_owned() + &".".repeat(GAUGE_WIDTH) + "]",
-                    theme.style_dim(),
-                ),
+                Span::styled(format!("[{}]", ".".repeat(GAUGE_WIDTH)), theme.style_dim()),
                 Span::styled(" —%", theme.style_dim()),
             ];
         }

--- a/crates/theatron/tui/src/view/views.rs
+++ b/crates/theatron/tui/src/view/views.rs
@@ -287,5 +287,13 @@ pub(crate) fn render_for_view(
             super::memory::render_fact_detail(app, frame, area, theme);
             Vec::new()
         }
+        View::Planning => {
+            super::planning::render_dashboard(app, frame, area, theme);
+            Vec::new()
+        }
+        View::Retrospective => {
+            super::planning::render_retrospective(app, frame, area, theme);
+            Vec::new()
+        }
     }
 }

--- a/crates/theatron/tui/src/wizard/view.rs
+++ b/crates/theatron/tui/src/wizard/view.rs
@@ -377,7 +377,6 @@ fn split_vertical<const N: usize>(area: Rect, heights: &[u16; N]) -> [Rect; N] {
 }
 
 #[cfg(test)]
-#[expect(clippy::unwrap_used, reason = "test assertions")]
 mod tests {
     use super::*;
     use crate::wizard::state::WizardState;


### PR DESCRIPTION
## Summary

- Add planning dashboard (`:planning`) with 7 tabbed panels: overview, requirements, execution (wave-based parallel phases), verification (pass/fail with evidence), tasks (hierarchical with blocked-by), timeline, and edit history
- Add retrospective view (`:retro`) for completed projects showing successes, blockers, lessons learned, and decision audit trail
- Checkpoint approval system blocks execution progress until human approves (with risk labels: LOW/MED/HIGH/CRIT)
- Both views accessible via command palette with aliases (`:plan`, `:retro`)

### New files
| File | Purpose |
|------|---------|
| `state/planning.rs` | Display types, tab/section enums, dashboard + retrospective state (16 tests) |
| `view/planning.rs` | All rendering: 7 dashboard tabs + retrospective (8 tests) |
| `update/planning.rs` | Navigation handlers for both views (12 tests) |

### Wiring changes
- `View` enum: `Planning`, `Retrospective` variants
- `LayoutState`: `planning`, `retrospective` fields  
- `Msg` enum: 14 new variants for planning/retro navigation
- Command palette: `:planning`/`:plan`, `:retrospective`/`:retro`
- View dispatch, command execution, update routing

Also fixes pre-existing clippy issues (unfulfilled lint expectations, `string_add`) in overlay, status_bar, streaming, wizard/view, and msg modules.

Closes #1856
Closes #1867

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes (TUI + core)
- [x] `cargo test -p theatron-tui` passes (949 tests)
- [x] `cargo test --workspace` passes (all crates)
- [ ] Manual: `:planning` opens dashboard, Tab cycles tabs, j/k navigates rows
- [ ] Manual: `:retro` opens retrospective, Tab cycles sections, Esc returns
- [ ] Manual: checkpoint approval blocks execution in overview tab


🤖 Generated with [Claude Code](https://claude.com/claude-code)