### PR TITLE
feat(tui): CC-aligned rendering engine, streaming, and tool cards

### DIFF
--- a/crates/theatron/tui/src/actions.rs
+++ b/crates/theatron/tui/src/actions.rs
@@ -19,7 +19,7 @@ use theatron_core::api::streaming;
 
 use crate::app::App;
 use crate::state::virtual_scroll::estimate_message_height;
-use crate::state::{ChatMessage, SavedScrollState, TabCompletion};
+use crate::state::{ChatMessage, MessageKind, SavedScrollState, TabCompletion};
 
 impl App {
     #[tracing::instrument(skip(self, text), fields(agent = ?self.dashboard.focused_agent))]
@@ -57,6 +57,7 @@ impl App {
             timestamp: None,
             model: None,
             tool_calls: Vec::new(),
+            kind: MessageKind::default(),
         };
         let width = self
             .viewport

--- a/crates/theatron/tui/src/app/app_tests.rs
+++ b/crates/theatron/tui/src/app/app_tests.rs
@@ -88,6 +88,7 @@ mod tests {
             timestamp: None,
             model: None,
             tool_calls: Vec::new(),
+            kind: crate::state::MessageKind::default(),
         }]
         .into();
         app.viewport.render.scroll_offset = 42;
@@ -109,6 +110,7 @@ mod tests {
             timestamp: None,
             model: None,
             tool_calls: Vec::new(),
+            kind: crate::state::MessageKind::default(),
         }]
         .into();
         app.viewport.render.scroll_offset = 10;
@@ -170,6 +172,7 @@ mod tests {
             timestamp: None,
             model: None,
             tool_calls: Vec::new(),
+            kind: crate::state::MessageKind::default(),
         });
 
         // App grew; tab snapshot is unchanged (COW semantics).

--- a/crates/theatron/tui/src/app/mod.rs
+++ b/crates/theatron/tui/src/app/mod.rs
@@ -33,16 +33,18 @@ use crate::state::virtual_scroll::VirtualScroll;
 pub use crate::state::{
     ActiveTool, AgentState, AgentStatus, ChatMessage, CommandPaletteState, ContextAction,
     ContextActionsOverlay, DecisionCardOverlay, DecisionField, DecisionOption, ErrorBanner,
-    FilterState, FocusedPane, InputState, MemoryInspectorState, NotificationStore, OpsState,
-    Overlay, PlanApprovalOverlay, PlanStepApproval, SelectionContext, SessionPickerOverlay,
-    SlashCompleteState, SubmittedDecision, TabCompletion, Toast, ToolApprovalOverlay, ToolCallInfo,
-    ToolSummary, View, ViewStack,
+    FilterState, FocusedPane, InputState, MemoryInspectorState, MessageKind, NotificationStore,
+    OpsState, Overlay, PlanApprovalOverlay, PlanStepApproval, SelectionContext,
+    SessionPickerOverlay, SlashCompleteState, StreamPhase, SubmittedDecision, TabCompletion, Toast,
+    ToolApprovalOverlay, ToolCallInfo, ToolSummary, View, ViewStack,
 };
 
 /// Default terminal width used before the first resize event arrives.
 const DEFAULT_TERMINAL_WIDTH: u16 = 120;
 /// Default terminal height used before the first resize event arrives.
 const DEFAULT_TERMINAL_HEIGHT: u16 = 40;
+/// Minimum interval between renders in milliseconds (30fps cap).
+const MIN_RENDER_INTERVAL_MS: u64 = 33;
 
 // ---------------------------------------------------------------------------
 // Sub-structs: group related fields so App stays under ~10 top-level fields.
@@ -82,6 +84,12 @@ pub struct ConnectionState {
     pub streaming_text: String,
     pub streaming_thinking: String,
     pub streaming_tool_calls: Vec<ToolCallInfo>,
+    /// Current stream lifecycle phase. Drives status indicator rendering.
+    pub stream_phase: crate::state::StreamPhase,
+    /// Partial line buffer for line-by-line streaming.
+    /// Complete lines (ending in `\n`) are flushed to `streaming_text`;
+    /// the incomplete tail stays here until the next delta.
+    pub(crate) streaming_line_buffer: String,
     /// Timestamp of the last stream event received during the current turn.
     /// Used for stall detection.
     pub(crate) stream_last_event_at: Option<std::time::Instant>,
@@ -98,6 +106,13 @@ pub struct RenderState {
     pub(crate) scroll_states: HashMap<NousId, SavedScrollState>,
     pub(crate) virtual_scroll: VirtualScroll,
     pub markdown_cache: MarkdownCache,
+    /// Pre-rendered lines for finalized (committed) messages.
+    /// PERF: Never re-rendered; only appended when a new message is committed.
+    pub(crate) static_lines: Vec<ratatui::text::Line<'static>>,
+    /// Number of committed messages covered by `static_lines`.
+    pub(crate) static_message_count: usize,
+    /// Width used to render `static_lines`. Cache invalidated on width change.
+    pub(crate) static_width: usize,
 }
 
 /// Terminal dimensions, tick counter, dirty flag, frame cache, and render state.
@@ -113,6 +128,8 @@ pub struct ViewportState {
     pub error_banner: Option<ErrorBanner>,
     pub(crate) dirty: bool,
     pub(crate) frame_cache: Option<Buffer>,
+    /// Timestamp of the last completed render. Used for 30fps throttling.
+    pub(crate) last_render_at: Option<std::time::Instant>,
     pub render: RenderState,
 }
 
@@ -219,6 +236,8 @@ impl App {
                 streaming_text: String::new(),
                 streaming_thinking: String::new(),
                 streaming_tool_calls: Vec::new(),
+                stream_phase: crate::state::StreamPhase::default(),
+                streaming_line_buffer: String::new(),
                 stream_last_event_at: None,
                 stall_warned: false,
                 stall_message: None,
@@ -233,12 +252,16 @@ impl App {
                 error_banner: None,
                 dirty: true,
                 frame_cache: None,
+                last_render_at: None,
                 render: RenderState {
                     scroll_offset: 0,
                     auto_scroll: true,
                     scroll_states: HashMap::new(),
                     virtual_scroll: VirtualScroll::new(),
                     markdown_cache: MarkdownCache::default(),
+                    static_lines: Vec::new(),
+                    static_message_count: 0,
+                    static_width: 0,
                 },
             },
             interaction: InteractionState {
@@ -490,12 +513,15 @@ impl App {
                                     .map(|t| sanitize_for_display(&t).into_owned()),
                                 model: m.model.map(|m| sanitize_for_display(&m).into_owned()),
                                 tool_calls: Vec::new(),
+                                kind: MessageKind::default(),
                             })
                         })
                         .collect();
                     // Stale streaming markdown from the previous session must not
                     // bleed through when the user switches agents.
                     self.viewport.render.markdown_cache.clear();
+                    self.viewport.render.static_lines.clear();
+                    self.viewport.render.static_message_count = 0;
                     self.rebuild_virtual_scroll();
                     self.scroll_to_bottom();
                 }
@@ -569,6 +595,7 @@ impl App {
             tab.state.streaming.streaming_thinking = self.connection.streaming_thinking.clone();
             tab.state.streaming.streaming_tool_calls = self.connection.streaming_tool_calls.clone();
             tab.state.streaming.active_turn_id = self.connection.active_turn_id.clone();
+            tab.state.streaming.stream_phase = self.connection.stream_phase;
             tab.state.markdown_cache = self.viewport.render.markdown_cache.clone();
             tab.state.ops = self.layout.ops.clone();
         }
@@ -591,6 +618,7 @@ impl App {
             self.connection.streaming_thinking = tab.state.streaming.streaming_thinking.clone();
             self.connection.streaming_tool_calls = tab.state.streaming.streaming_tool_calls.clone();
             self.connection.active_turn_id = tab.state.streaming.active_turn_id.clone();
+            self.connection.stream_phase = tab.state.streaming.stream_phase;
             self.viewport.render.markdown_cache = tab.state.markdown_cache.clone();
             self.layout.ops = tab.state.ops.clone();
         }
@@ -634,25 +662,33 @@ impl App {
 
     #[tracing::instrument(skip_all)]
     pub fn view(&mut self, frame: &mut Frame) -> Vec<OscLink> {
-        if !self.viewport.dirty {
-            // PERF: No state changed since last frame: replay the cached buffer.
-            // ratatui diffs against the previous frame, so identical content produces
-            // zero terminal output. This skips all layout and widget computation.
-            if let Some(ref cached) = self.viewport.frame_cache
-                && cached.area == frame.area()
-            {
-                *frame.buffer_mut() = cached.clone();
-                return Vec::new();
-            }
-            // Cache miss (terminal resized or first frame): fall through to full render.
+        // PERF: 30fps render throttle. Skip the frame if less than 33ms elapsed
+        // since the last render AND the state hasn't changed.
+        if !self.viewport.dirty
+            && let Some(ref cached) = self.viewport.frame_cache
+            && cached.area == frame.area()
+        {
+            *frame.buffer_mut() = cached.clone();
+            return Vec::new();
+        }
+        if let Some(last) = self.viewport.last_render_at
+            && last.elapsed() < std::time::Duration::from_millis(MIN_RENDER_INTERVAL_MS)
+            && !self.viewport.dirty
+            && let Some(ref cached) = self.viewport.frame_cache
+            && cached.area == frame.area()
+        {
+            *frame.buffer_mut() = cached.clone();
+            return Vec::new();
         }
         // PERF: Refresh the streaming markdown cache once per frame instead of on
         // every text delta. Multiple deltas arriving between frames are batched
         // into a single markdown::render call, reducing CPU from O(tokens) to O(frames).
         self.refresh_streaming_markdown_cache();
+        self.refresh_static_lines_cache();
         let links = view::render(self, frame);
         self.viewport.frame_cache = Some(frame.buffer_mut().clone());
         self.viewport.dirty = false;
+        self.viewport.last_render_at = Some(std::time::Instant::now());
         links
     }
 
@@ -677,6 +713,73 @@ impl App {
         .0;
         self.viewport.render.markdown_cache.text = self.connection.streaming_text.clone();
         self.viewport.render.markdown_cache.width = width;
+    }
+
+    /// Rebuild the static lines cache for finalized (committed) messages.
+    ///
+    /// PERF: This cache prevents re-parsing markdown for messages that haven't
+    /// changed. During streaming, only the streaming section re-renders.
+    /// The cache is invalidated when: message count changes, terminal width changes,
+    /// or a session switch clears it.
+    pub(crate) fn refresh_static_lines_cache(&mut self) {
+        let inner_width = usize::from(self.viewport.terminal_width.saturating_sub(2));
+        let msg_count = self.dashboard.messages.len();
+
+        if self.viewport.render.static_message_count == msg_count
+            && self.viewport.render.static_width == inner_width
+        {
+            return;
+        }
+
+        let agent_name: &str = self
+            .dashboard
+            .focused_agent
+            .as_ref()
+            .and_then(|id| self.dashboard.agents.iter().find(|a| a.id == *id))
+            .map(|a| a.name_lower.as_str())
+            .unwrap_or("assistant");
+
+        // PERF: Only render new messages appended since the last cache build,
+        // unless width changed (which requires full re-render).
+        let start = if self.viewport.render.static_width == inner_width {
+            self.viewport.render.static_message_count
+        } else {
+            self.viewport.render.static_lines.clear();
+            0
+        };
+
+        let render_width = inner_width.saturating_sub(2);
+        for idx in start..msg_count {
+            let msg = &self.dashboard.messages[idx];
+            let (role_label, role_style) = match msg.role.as_str() {
+                "user" => ("you", self.theme.style_user()),
+                "assistant" => (agent_name, self.theme.style_assistant()),
+                _ => ("system", self.theme.style_muted()),
+            };
+            self.viewport
+                .render
+                .static_lines
+                .push(ratatui::text::Line::from(vec![
+                    ratatui::text::Span::styled(format!(" {role_label}"), role_style),
+                ]));
+            let (md_lines, _) =
+                crate::markdown::render(&msg.text, render_width, &self.theme, &self.highlighter);
+            for line in md_lines {
+                let mut padded = vec![ratatui::text::Span::raw(" ")];
+                padded.extend(line.spans);
+                self.viewport
+                    .render
+                    .static_lines
+                    .push(ratatui::text::Line::from(padded));
+            }
+            self.viewport
+                .render
+                .static_lines
+                .push(ratatui::text::Line::raw(""));
+        }
+
+        self.viewport.render.static_message_count = msg_count;
+        self.viewport.render.static_width = inner_width;
     }
 }
 

--- a/crates/theatron/tui/src/app/test_helpers.rs
+++ b/crates/theatron/tui/src/app/test_helpers.rs
@@ -59,6 +59,8 @@ pub fn test_app() -> App {
             stream_last_event_at: None,
             stall_warned: false,
             stall_message: None,
+            stream_phase: crate::state::StreamPhase::Idle,
+            streaming_line_buffer: String::new(),
         },
         viewport: ViewportState {
             terminal_width: DEFAULT_TERMINAL_WIDTH,
@@ -70,12 +72,16 @@ pub fn test_app() -> App {
             error_banner: None,
             dirty: true,
             frame_cache: None,
+            last_render_at: None,
             render: RenderState {
                 scroll_offset: 0,
                 auto_scroll: true,
                 scroll_states: HashMap::new(),
                 virtual_scroll: VirtualScroll::new(),
                 markdown_cache: MarkdownCache::default(),
+                static_lines: Vec::new(),
+                static_message_count: 0,
+                static_width: 0,
             },
         },
         interaction: InteractionState {
@@ -123,6 +129,7 @@ pub fn test_app_with_messages(msgs: Vec<(&str, &str)>) -> App {
             timestamp: None,
             model: None,
             tool_calls: Vec::new(),
+            kind: MessageKind::default(),
         });
     }
     app

--- a/crates/theatron/tui/src/mapping/mod.rs
+++ b/crates/theatron/tui/src/mapping/mod.rs
@@ -112,6 +112,7 @@ mod tests {
             timestamp: None,
             model: None,
             tool_calls: Vec::new(),
+            kind: crate::state::MessageKind::default(),
         });
         let event = Event::Terminal(key(KeyCode::Up));
         let msg = app.map_event(event);

--- a/crates/theatron/tui/src/msg.rs
+++ b/crates/theatron/tui/src/msg.rs
@@ -174,13 +174,11 @@ pub enum Msg {
     StreamThinkingDelta(String),
     StreamToolStart {
         tool_name: String,
-        #[expect(dead_code, reason = "planned TUI feature")]
         tool_id: ToolId,
         input: Option<serde_json::Value>,
     },
     StreamToolResult {
         tool_name: String,
-        #[expect(dead_code, reason = "planned TUI feature")]
         tool_id: ToolId,
         is_error: bool,
         duration_ms: u64,

--- a/crates/theatron/tui/src/state/chat.rs
+++ b/crates/theatron/tui/src/state/chat.rs
@@ -1,6 +1,72 @@
 use std::ops::{Deref, DerefMut};
 use std::sync::Arc;
 
+use crate::id::ToolId;
+
+/// Stream lifecycle phase, modeled on Claude Code's state machine.
+///
+/// Drives the status indicator rendering: each phase has a distinct visual
+/// representation in the TUI status bar and streaming section.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[non_exhaustive]
+pub enum StreamPhase {
+    /// No active turn. Input is editable.
+    #[default]
+    Idle,
+    /// HTTP request sent, waiting for first SSE event.
+    Requesting,
+    /// Receiving text deltas from the model.
+    Streaming,
+    /// Model is in an extended thinking block.
+    Thinking,
+    /// Context window compaction in progress.
+    #[allow(dead_code)]
+    // WHY: constructed when server emits compaction SSE events; unfired in test target
+    Compacting,
+    /// Waiting for tool approval or external input.
+    Waiting,
+    /// Turn ended with an error.
+    Error,
+    /// Turn completed successfully. Transitions to Idle on next tick.
+    Done,
+}
+
+impl std::fmt::Display for StreamPhase {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Idle => write!(f, "idle"),
+            Self::Requesting => write!(f, "requesting"),
+            Self::Streaming => write!(f, "streaming"),
+            Self::Thinking => write!(f, "thinking"),
+            Self::Compacting => write!(f, "compacting"),
+            Self::Waiting => write!(f, "waiting"),
+            Self::Error => write!(f, "error"),
+            Self::Done => write!(f, "done"),
+        }
+    }
+}
+
+/// Semantic message category for rendering differentiation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[non_exhaustive]
+pub enum MessageKind {
+    /// Normal user or assistant message with full markdown rendering.
+    #[default]
+    Standard,
+    /// Compact one-line tool status summary (not full JSON).
+    #[allow(dead_code)] // WHY: constructed by SSE mapper; unfired in test target
+    ToolStatusLine,
+    /// Compact thinking indicator line.
+    #[allow(dead_code)] // WHY: constructed by SSE mapper; unfired in test target
+    ThinkingStatusLine,
+    /// Distillation summary boundary marker.
+    #[allow(dead_code)] // WHY: constructed by SSE mapper; unfired in test target
+    DistillationMarker,
+    /// Visual separator between conversation topics.
+    #[allow(dead_code)] // WHY: constructed by SSE mapper; unfired in test target
+    TopicBoundary,
+}
+
 /// Shared-ownership message history vector.
 ///
 /// `Clone` increments an `Arc` reference count: O(1) regardless of message count.
@@ -53,8 +119,11 @@ impl<T: Clone> From<Vec<T>> for ArcVec<T> {
 #[derive(Debug, Clone)]
 pub struct ToolCallInfo {
     pub name: String,
+    pub tool_id: Option<ToolId>,
     pub duration_ms: Option<u64>,
     pub is_error: bool,
+    /// Tool result text, stored for collapsible card rendering.
+    pub output: Option<String>,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -72,6 +141,8 @@ pub struct ChatMessage {
     pub timestamp: Option<String>,
     pub model: Option<String>,
     pub tool_calls: Vec<ToolCallInfo>,
+    /// Semantic category for rendering differentiation.
+    pub kind: MessageKind,
 }
 
 /// Paired streaming-markdown text and its pre-rendered line cache.
@@ -143,5 +214,27 @@ mod tests {
     fn arc_vec_default_is_empty() {
         let v: ArcVec<i32> = ArcVec::default();
         assert!(v.is_empty());
+    }
+
+    #[test]
+    fn stream_phase_default_is_idle() {
+        assert_eq!(StreamPhase::default(), StreamPhase::Idle);
+    }
+
+    #[test]
+    fn stream_phase_display_all_variants() {
+        assert_eq!(StreamPhase::Idle.to_string(), "idle");
+        assert_eq!(StreamPhase::Requesting.to_string(), "requesting");
+        assert_eq!(StreamPhase::Streaming.to_string(), "streaming");
+        assert_eq!(StreamPhase::Thinking.to_string(), "thinking");
+        assert_eq!(StreamPhase::Compacting.to_string(), "compacting");
+        assert_eq!(StreamPhase::Waiting.to_string(), "waiting");
+        assert_eq!(StreamPhase::Error.to_string(), "error");
+        assert_eq!(StreamPhase::Done.to_string(), "done");
+    }
+
+    #[test]
+    fn message_kind_default_is_standard() {
+        assert_eq!(MessageKind::default(), MessageKind::Standard);
     }
 }

--- a/crates/theatron/tui/src/state/mod.rs
+++ b/crates/theatron/tui/src/state/mod.rs
@@ -16,7 +16,7 @@ pub(crate) mod virtual_scroll;
 
 pub use agent::{ActiveTool, AgentState, AgentStatus, ToolSummary};
 pub(crate) use chat::{ArcVec, MarkdownCache, SavedScrollState};
-pub use chat::{ChatMessage, ToolCallInfo};
+pub use chat::{ChatMessage, MessageKind, StreamPhase, ToolCallInfo};
 pub use command::{CommandPaletteState, SelectionContext, SlashCompleteState, SlashSuggestion};
 pub use filter::{FilterScope, FilterState};
 pub use input::{

--- a/crates/theatron/tui/src/state/tab.rs
+++ b/crates/theatron/tui/src/state/tab.rs
@@ -19,6 +19,7 @@ pub(crate) struct TabStreamingState {
     pub(crate) streaming_thinking: String,
     pub(crate) streaming_tool_calls: Vec<ToolCallInfo>,
     pub(crate) active_turn_id: Option<TurnId>,
+    pub(crate) stream_phase: crate::state::chat::StreamPhase,
 }
 
 /// Per-tab snapshot of isolated session state.
@@ -452,6 +453,7 @@ mod tests {
             timestamp: None,
             model: None,
             tool_calls: Vec::new(),
+            kind: crate::state::MessageKind::default(),
         });
         bar.tabs[0].state.scroll.scroll_offset = 42;
         bar.tabs[0].state.input.text = "typing...".to_string();

--- a/crates/theatron/tui/src/update/api.rs
+++ b/crates/theatron/tui/src/update/api.rs
@@ -58,6 +58,7 @@ pub(crate) fn handle_history_loaded(app: &mut App, messages: Vec<HistoryMessage>
                 timestamp: m.created_at.map(|t| sanitize_for_display(&t).into_owned()),
                 model: m.model.map(|m| sanitize_for_display(&m).into_owned()),
                 tool_calls: Vec::new(),
+                kind: crate::state::MessageKind::default(),
             })
         })
         .collect();

--- a/crates/theatron/tui/src/update/mod.rs
+++ b/crates/theatron/tui/src/update/mod.rs
@@ -218,15 +218,24 @@ pub(crate) async fn update(app: &mut App, msg: Msg) {
         Msg::StreamTextDelta(text) => streaming::handle_stream_text_delta(app, text),
         Msg::StreamThinkingDelta(text) => streaming::handle_stream_thinking_delta(app, text),
         Msg::StreamToolStart {
-            tool_name, input, ..
-        } => streaming::handle_stream_tool_start(app, tool_name, input),
+            tool_name,
+            tool_id,
+            input,
+        } => streaming::handle_stream_tool_start(app, tool_name, tool_id, input),
         Msg::StreamToolResult {
             tool_name,
+            tool_id,
             is_error,
             duration_ms,
             result,
-            ..
-        } => streaming::handle_stream_tool_result(app, tool_name, is_error, duration_ms, result),
+        } => streaming::handle_stream_tool_result(
+            app,
+            tool_name,
+            tool_id,
+            is_error,
+            duration_ms,
+            result,
+        ),
         Msg::StreamToolApprovalRequired {
             turn_id,
             tool_name,

--- a/crates/theatron/tui/src/update/navigation.rs
+++ b/crates/theatron/tui/src/update/navigation.rs
@@ -445,6 +445,8 @@ mod tests {
                 name: "read_file".to_string(),
                 duration_ms: None,
                 is_error: false,
+                tool_id: None,
+                output: None,
             });
 
         handle_focus_agent(&mut app, "beta".into()).await;

--- a/crates/theatron/tui/src/update/overlay.rs
+++ b/crates/theatron/tui/src/update/overlay.rs
@@ -207,6 +207,7 @@ pub(crate) async fn handle_overlay_select(app: &mut App) {
                                         .map(|t| sanitize_for_display(&t).into_owned()),
                                     model: m.model.map(|m| sanitize_for_display(&m).into_owned()),
                                     tool_calls: Vec::new(),
+                                    kind: crate::state::MessageKind::default(),
                                 })
                             })
                             .collect();

--- a/crates/theatron/tui/src/update/search.rs
+++ b/crates/theatron/tui/src/update/search.rs
@@ -115,6 +115,7 @@ pub(crate) async fn handle_select(app: &mut App) {
                         timestamp: m.created_at.map(|t| sanitize_for_display(&t).into_owned()),
                         model: m.model.map(|m| sanitize_for_display(&m).into_owned()),
                         tool_calls: Vec::new(),
+                        kind: crate::state::MessageKind::default(),
                     })
                 })
                 .collect();

--- a/crates/theatron/tui/src/update/selection.rs
+++ b/crates/theatron/tui/src/update/selection.rs
@@ -541,6 +541,8 @@ mod tests {
                 name: "test_tool".to_string(),
                 duration_ms: Some(100),
                 is_error: false,
+                tool_id: None,
+                output: None,
             });
         app.interaction.selected_message = Some(0);
         handle_message_action(&mut app, MessageActionKind::Inspect);

--- a/crates/theatron/tui/src/update/sse.rs
+++ b/crates/theatron/tui/src/update/sse.rs
@@ -220,6 +220,7 @@ pub(crate) async fn handle_sse_distill_after(app: &mut App, nous_id: NousId) {
             timestamp: None,
             model: None,
             tool_calls: Vec::new(),
+            kind: crate::state::MessageKind::default(),
         });
     }
 }
@@ -471,6 +472,7 @@ mod tests {
             timestamp: None,
             model: None,
             tool_calls: Vec::new(),
+            kind: crate::state::MessageKind::default(),
         });
 
         // Simulate the gap: stream started (stream_rx set) but StreamTurnStart
@@ -503,6 +505,7 @@ mod tests {
             timestamp: None,
             model: None,
             tool_calls: Vec::new(),
+            kind: crate::state::MessageKind::default(),
         });
 
         handle_sse_turn_after(&mut app, "syn".into(), "s1".into()).await;
@@ -530,6 +533,7 @@ mod tests {
             timestamp: None,
             model: None,
             tool_calls: Vec::new(),
+            kind: crate::state::MessageKind::default(),
         });
 
         let (_tx, rx) = tokio::sync::mpsc::channel(1);

--- a/crates/theatron/tui/src/update/streaming.rs
+++ b/crates/theatron/tui/src/update/streaming.rs
@@ -20,12 +20,14 @@ fn model_context_window(_model: &str) -> u32 {
 #[tracing::instrument(skip_all, fields(%turn_id, %nous_id))]
 pub(crate) fn handle_stream_turn_start(app: &mut App, turn_id: TurnId, nous_id: NousId) {
     app.connection.active_turn_id = Some(turn_id);
+    app.connection.stream_phase = crate::state::StreamPhase::Requesting;
     app.connection.streaming_text.clear();
     app.connection.streaming_thinking.clear();
     app.connection.streaming_tool_calls.clear();
     app.connection.stream_last_event_at = Some(std::time::Instant::now());
     app.connection.stall_warned = false;
     app.connection.stall_message = None;
+    app.connection.streaming_line_buffer.clear();
     app.viewport.render.markdown_cache.clear();
     if let Some(agent) = app.dashboard.agents.iter_mut().find(|a| a.id == nous_id) {
         agent.status = AgentStatus::Streaming;
@@ -37,12 +39,18 @@ pub(crate) fn handle_stream_turn_start(app: &mut App, turn_id: TurnId, nous_id: 
 #[tracing::instrument(skip_all, fields(len = text.len()))]
 // SAFETY: sanitized at ingestion: streaming text from LLM API.
 pub(crate) fn handle_stream_text_delta(app: &mut App, text: String) {
+    app.connection.stream_phase = crate::state::StreamPhase::Streaming;
     let clean = sanitize_for_display(&text);
-    app.connection.streaming_text.push_str(&clean);
-    // PERF: Markdown re-rendering is deferred to the frame boundary (app.view)
-    // so that multiple text deltas arriving between frames are batched into a
-    // single markdown::render call. At 100 tokens/sec with 60fps rendering,
-    // this reduces markdown parses from ~100/sec to at most 60/sec.
+    // PERF: Line-by-line streaming. Buffer partial lines and flush only complete
+    // lines (ending in `\n`) to streaming_text. The incomplete tail stays in the
+    // line buffer. This prevents markdown re-parses on every token within a line.
+    app.connection.streaming_line_buffer.push_str(&clean);
+    if let Some(last_newline) = app.connection.streaming_line_buffer.rfind('\n') {
+        let complete = app.connection.streaming_line_buffer[..=last_newline].to_string();
+        let remainder = app.connection.streaming_line_buffer[last_newline + 1..].to_string();
+        app.connection.streaming_text.push_str(&complete);
+        app.connection.streaming_line_buffer = remainder;
+    }
     if app.viewport.render.auto_scroll {
         app.viewport.render.scroll_offset = 0;
     }
@@ -51,6 +59,7 @@ pub(crate) fn handle_stream_text_delta(app: &mut App, text: String) {
 #[tracing::instrument(skip_all, fields(len = text.len()))]
 // SAFETY: sanitized at ingestion: thinking text from LLM API.
 pub(crate) fn handle_stream_thinking_delta(app: &mut App, text: String) {
+    app.connection.stream_phase = crate::state::StreamPhase::Thinking;
     let clean = sanitize_for_display(&text);
     app.connection.streaming_thinking.push_str(&clean);
     app.layout.ops.push_thinking(&clean);
@@ -61,13 +70,17 @@ pub(crate) fn handle_stream_thinking_delta(app: &mut App, text: String) {
 pub(crate) fn handle_stream_tool_start(
     app: &mut App,
     tool_name: String,
+    tool_id: ToolId,
     input: Option<serde_json::Value>,
 ) {
+    app.connection.stream_phase = crate::state::StreamPhase::Streaming;
     let clean_name = sanitize_for_display(&tool_name).into_owned();
     app.connection.streaming_tool_calls.push(ToolCallInfo {
         name: clean_name.clone(),
+        tool_id: Some(tool_id),
         duration_ms: None,
         is_error: false,
+        output: None,
     });
     let input_json = input.map(|v| v.to_string());
     app.layout
@@ -87,6 +100,7 @@ pub(crate) fn handle_stream_tool_start(
 pub(crate) fn handle_stream_tool_result(
     app: &mut App,
     tool_name: String,
+    tool_id: ToolId,
     is_error: bool,
     duration_ms: u64,
     result: Option<String>,
@@ -100,6 +114,11 @@ pub(crate) fn handle_stream_tool_result(
     {
         tc.duration_ms = Some(duration_ms);
         tc.is_error = is_error;
+        tc.output = result.clone();
+    }
+    // WHY: Auto-expand failed tool cards so errors are immediately visible.
+    if is_error {
+        app.interaction.tool_expanded.insert(tool_id);
     }
     app.layout
         .ops
@@ -122,6 +141,7 @@ pub(crate) fn handle_stream_tool_approval_required(
     risk: String,
     reason: String,
 ) {
+    app.connection.stream_phase = crate::state::StreamPhase::Waiting;
     // WHY: If the user previously chose "always allow" for this tool, auto-approve
     // without presenting the dialog again.
     if app
@@ -206,6 +226,12 @@ pub(crate) fn handle_stream_plan_proposed(app: &mut App, plan: Plan) {
 // SAFETY: sanitized at ingestion: streaming_text already sanitized via handle_stream_text_delta,
 // model name from API is sanitized here.
 pub(crate) async fn handle_stream_turn_complete(app: &mut App, outcome: TurnOutcome) {
+    app.connection.stream_phase = crate::state::StreamPhase::Done;
+    // Flush any remaining partial line from the line buffer.
+    if !app.connection.streaming_line_buffer.is_empty() {
+        let remaining = std::mem::take(&mut app.connection.streaming_line_buffer);
+        app.connection.streaming_text.push_str(&remaining);
+    }
     // WHY: Only commit the streamed message when the completing turn belongs to the
     // currently focused agent.  If the user switched agents mid-stream the message
     // belongs to the old agent's session; pushing it here would corrupt the new
@@ -235,6 +261,7 @@ pub(crate) async fn handle_stream_turn_complete(app: &mut App, outcome: TurnOutc
             timestamp: None,
             model: Some(sanitize_for_display(&outcome.model).into_owned()),
             tool_calls,
+            kind: crate::state::MessageKind::default(),
         });
         app.viewport.render.virtual_scroll.push_item(h);
         // WHY: Keep the viewport anchored when scrolled up by compensating the
@@ -291,12 +318,15 @@ pub(crate) async fn handle_stream_turn_complete(app: &mut App, outcome: TurnOutc
 
     // WHY: auto-send the next queued message now that the turn is complete
     crate::update::input::send_next_queued(app);
+    app.connection.stream_phase = crate::state::StreamPhase::Idle;
 }
 
 #[tracing::instrument(skip_all)]
 pub(crate) fn handle_stream_turn_abort(app: &mut App, reason: String) {
     tracing::info!("turn aborted: {reason}");
+    app.connection.stream_phase = crate::state::StreamPhase::Idle;
     app.connection.streaming_text.clear();
+    app.connection.streaming_line_buffer.clear();
     app.connection.streaming_thinking.clear();
     app.connection.streaming_tool_calls.clear();
     app.connection.stream_last_event_at = None;
@@ -316,6 +346,8 @@ pub(crate) fn handle_stream_turn_abort(app: &mut App, reason: String) {
 // SAFETY: sanitized at ingestion: error messages may contain external data.
 pub(crate) fn handle_stream_error(app: &mut App, msg: String) {
     tracing::error!("stream error: {msg}");
+    app.connection.stream_phase = crate::state::StreamPhase::Error;
+    app.connection.streaming_line_buffer.clear();
     app.viewport.error_toast = Some(ErrorToast::new(sanitize_for_display(&msg).into_owned()));
     app.connection.active_turn_id = None;
     app.connection.stream_rx = None;
@@ -351,6 +383,12 @@ pub(crate) async fn handle_cancel_turn(app: &mut App) {
         }
     });
 
+    app.connection.stream_phase = crate::state::StreamPhase::Idle;
+    // Flush line buffer into streaming text before committing.
+    if !app.connection.streaming_line_buffer.is_empty() {
+        let remaining = std::mem::take(&mut app.connection.streaming_line_buffer);
+        app.connection.streaming_text.push_str(&remaining);
+    }
     // Commit partial streaming text as an incomplete turn marker.
     let partial = std::mem::take(&mut app.connection.streaming_text);
     let marker = if partial.is_empty() {
@@ -374,6 +412,7 @@ pub(crate) async fn handle_cancel_turn(app: &mut App) {
         timestamp: None,
         model: None,
         tool_calls,
+        kind: crate::state::MessageKind::default(),
     });
     app.viewport.render.virtual_scroll.push_item(h);
 
@@ -423,9 +462,12 @@ mod tests {
     #[test]
     fn text_delta_appends() {
         let mut app = test_app();
+        // PERF: line buffering — partial lines stay in streaming_line_buffer
+        // until a newline flushes them to streaming_text.
         handle_stream_text_delta(&mut app, "hello ".to_string());
-        handle_stream_text_delta(&mut app, "world".to_string());
-        assert_eq!(app.connection.streaming_text, "hello world");
+        handle_stream_text_delta(&mut app, "world\n".to_string());
+        assert_eq!(app.connection.streaming_text, "hello world\n");
+        assert!(app.connection.streaming_line_buffer.is_empty());
     }
 
     #[test]
@@ -441,7 +483,12 @@ mod tests {
         app.dashboard.agents.push(test_agent("syn", "Syn"));
         app.dashboard.focused_agent = Some("syn".into());
 
-        handle_stream_tool_start(&mut app, "read_file".to_string(), None);
+        handle_stream_tool_start(
+            &mut app,
+            "read_file".to_string(),
+            ToolId::from("t1".to_string()),
+            None,
+        );
 
         assert_eq!(app.connection.streaming_tool_calls.len(), 1);
         assert_eq!(app.connection.streaming_tool_calls[0].name, "read_file");
@@ -461,8 +508,9 @@ mod tests {
         app.dashboard.agents.push(test_agent("syn", "Syn"));
         app.dashboard.focused_agent = Some("syn".into());
 
-        handle_stream_tool_start(&mut app, "read_file".to_string(), None);
-        handle_stream_tool_result(&mut app, "read_file".to_string(), false, 150, None);
+        let tid = ToolId::from("t1".to_string());
+        handle_stream_tool_start(&mut app, "read_file".to_string(), tid.clone(), None);
+        handle_stream_tool_result(&mut app, "read_file".to_string(), tid, false, 150, None);
 
         assert_eq!(
             app.connection.streaming_tool_calls[0].duration_ms,
@@ -478,8 +526,9 @@ mod tests {
         app.dashboard.agents.push(test_agent("syn", "Syn"));
         app.dashboard.focused_agent = Some("syn".into());
 
-        handle_stream_tool_start(&mut app, "write_file".to_string(), None);
-        handle_stream_tool_result(&mut app, "write_file".to_string(), true, 50, None);
+        let tid = ToolId::from("t2".to_string());
+        handle_stream_tool_start(&mut app, "write_file".to_string(), tid.clone(), None);
+        handle_stream_tool_result(&mut app, "write_file".to_string(), tid, true, 50, None);
 
         assert!(app.connection.streaming_tool_calls[0].is_error);
     }
@@ -616,6 +665,8 @@ mod tests {
             name: "read_file".to_string(),
             duration_ms: None,
             is_error: false,
+            tool_id: None,
+            output: None,
         });
         app.dashboard.agents[0].status = AgentStatus::Working;
 
@@ -654,6 +705,8 @@ mod tests {
             name: "grep".to_string(),
             duration_ms: None,
             is_error: false,
+            tool_id: None,
+            output: None,
         });
         app.dashboard.agents[0].status = AgentStatus::Working;
         app.dashboard.agents[0].active_tool = Some(ActiveTool {
@@ -677,23 +730,24 @@ mod tests {
     #[test]
     fn text_delta_defers_markdown_cache() {
         let mut app = test_app();
-        handle_stream_text_delta(&mut app, "hello".to_string());
+        handle_stream_text_delta(&mut app, "hello\n".to_string());
         // PERF: markdown cache is no longer updated per-delta; it is refreshed
         // once per frame in App::refresh_streaming_markdown_cache.
         assert!(
             app.viewport.render.markdown_cache.text.is_empty(),
             "cache must not update on delta (deferred to frame boundary)"
         );
-        assert_eq!(app.connection.streaming_text, "hello");
+        assert_eq!(app.connection.streaming_text, "hello\n");
     }
 
     #[test]
     fn refresh_markdown_cache_updates_after_delta() {
         let mut app = test_app();
         app.viewport.terminal_width = 80;
-        handle_stream_text_delta(&mut app, "hello\nworld".to_string());
+        // PERF: "hello\n" flushes to streaming_text; "world\n" completes the second line.
+        handle_stream_text_delta(&mut app, "hello\nworld\n".to_string());
         app.refresh_streaming_markdown_cache();
-        assert_eq!(app.viewport.render.markdown_cache.text, "hello\nworld");
+        assert_eq!(app.viewport.render.markdown_cache.text, "hello\nworld\n");
         assert!(!app.viewport.render.markdown_cache.lines.is_empty());
         // Width should be terminal_width - 4 (matching the view's inner_width - 2)
         assert_eq!(app.viewport.render.markdown_cache.width, 76);

--- a/crates/theatron/tui/src/view/chat.rs
+++ b/crates/theatron/tui/src/view/chat.rs
@@ -7,7 +7,7 @@ use ratatui::widgets::{Block, Borders, Paragraph, Wrap};
 use crate::app::App;
 use crate::hyperlink::{self, OscLink};
 use crate::markdown;
-use crate::state::FilterScope;
+use crate::state::{FilterScope, MessageKind, StreamPhase};
 use crate::theme::{self, Theme};
 use crate::view::image;
 
@@ -66,7 +66,18 @@ pub(crate) fn render(app: &App, frame: &mut Frame, area: Rect, theme: &Theme) ->
     let mut lines: Vec<Line> = Vec::new();
     lines.push(Line::raw("")); // top padding
 
-    if filter_active {
+    // PERF: Static buffer for finalized messages. When committed messages haven't
+    // changed and the width is the same, reuse the cached rendered lines instead
+    // of re-parsing markdown. This prevents redundant work during streaming frames
+    // where only the streaming section changes.
+    let static_cache_valid = !filter_active
+        && app.viewport.render.static_message_count == app.dashboard.messages.len()
+        && app.viewport.render.static_width == inner_width
+        && !app.dashboard.messages.is_empty();
+
+    if static_cache_valid {
+        lines.extend(app.viewport.render.static_lines.iter().cloned());
+    } else if filter_active {
         // Filtered path: iterate all messages, skip non-matching.
         // This is acceptable because filtering is interactive and users rarely
         // have 15K messages with a filter active.
@@ -405,6 +416,28 @@ fn render_message(
     para_links: &mut Vec<(usize, u16, String, String)>,
 ) {
     let theme = ctx.theme;
+
+    // Dispatch on message kind for distinct rendering per type.
+    match msg.kind {
+        MessageKind::ToolStatusLine => {
+            render_tool_status_line(msg, lines, theme);
+            return;
+        }
+        MessageKind::ThinkingStatusLine => {
+            render_thinking_status_line(msg, lines, theme);
+            return;
+        }
+        MessageKind::DistillationMarker => {
+            render_distillation_marker(msg, lines, ctx.inner_width, theme);
+            return;
+        }
+        MessageKind::TopicBoundary => {
+            render_topic_boundary(lines, ctx.inner_width, theme);
+            return;
+        }
+        MessageKind::Standard => {}
+    }
+
     let (role_label, role_style) = match msg.role.as_str() {
         "user" => ("you", theme.style_user()),
         "assistant" => (ctx.agent_name, theme.style_assistant()),
@@ -444,6 +477,11 @@ fn render_message(
 
     lines.push(Line::from(header_spans));
 
+    // Tool calls as collapsible cards
+    if !msg.tool_calls.is_empty() {
+        render_tool_cards(app, &msg.tool_calls, lines, ctx.inner_width, theme);
+    }
+
     // Message content: markdown parsed with syntax highlighting
     let (md_lines, md_links) = markdown::render(
         &msg.text,
@@ -462,7 +500,6 @@ fn render_message(
     let highlight_bg = Style::default().bg(theme.colors.accent_dim);
 
     // Offset: paragraph line index of the first markdown line for this message.
-    // +1 for the header line; +1 more if tool calls were rendered.
     let md_para_offset = lines.len();
 
     for line in md_lines {
@@ -500,6 +537,135 @@ fn render_message(
     }
 
     // Breathing room between messages
+    lines.push(Line::raw(""));
+}
+
+/// Render tool calls as collapsible cards with status icons.
+///
+/// Each card shows: status icon + tool name + duration on one line.
+/// Expanded cards show the tool output below. Errors are auto-expanded.
+fn render_tool_cards(
+    app: &App,
+    tool_calls: &[crate::state::ToolCallInfo],
+    lines: &mut Vec<Line<'static>>,
+    inner_width: usize,
+    theme: &Theme,
+) {
+    for tc in tool_calls {
+        let icon = if tc.is_error { "✗" } else { "✓" };
+        let icon_style = if tc.is_error {
+            Style::default().fg(theme.status.error)
+        } else {
+            Style::default().fg(theme.status.success)
+        };
+
+        let is_expanded = tc
+            .tool_id
+            .as_ref()
+            .is_some_and(|id| app.interaction.tool_expanded.contains(id));
+
+        let toggle = if is_expanded { "▾" } else { "▸" };
+
+        let mut card_spans = vec![
+            Span::styled(format!("  {toggle} "), theme.style_dim()),
+            Span::styled(icon, icon_style),
+            Span::raw(" "),
+            Span::styled(tc.name.clone(), theme.style_fg()),
+        ];
+
+        if let Some(ms) = tc.duration_ms {
+            card_spans.push(Span::styled(
+                format!(" · {}", format_duration_adaptive(ms)),
+                theme.style_dim(),
+            ));
+        }
+
+        lines.push(Line::from(card_spans));
+
+        // Expanded output
+        if is_expanded && let Some(ref output) = tc.output {
+            let max_width = inner_width.saturating_sub(6);
+            for output_line in output.lines().take(20) {
+                let truncated: String = output_line.chars().take(max_width).collect();
+                lines.push(Line::from(vec![
+                    Span::raw("      "),
+                    Span::styled(truncated, theme.style_dim()),
+                ]));
+            }
+            let line_count = output.lines().count();
+            if line_count > 20 {
+                lines.push(Line::from(vec![
+                    Span::raw("      "),
+                    Span::styled(
+                        format!("… ({} more lines)", line_count.saturating_sub(20)),
+                        theme.style_muted(),
+                    ),
+                ]));
+            }
+        }
+    }
+}
+
+/// Compact one-line tool status: `✓ tool_name · duration`.
+fn render_tool_status_line(
+    msg: &crate::app::ChatMessage,
+    lines: &mut Vec<Line<'static>>,
+    theme: &Theme,
+) {
+    lines.push(Line::from(vec![
+        Span::raw("  "),
+        Span::styled("·", theme.style_dim()),
+        Span::raw(" "),
+        Span::styled(msg.text.clone(), theme.style_muted()),
+    ]));
+}
+
+/// Compact thinking indicator line.
+fn render_thinking_status_line(
+    msg: &crate::app::ChatMessage,
+    lines: &mut Vec<Line<'static>>,
+    theme: &Theme,
+) {
+    lines.push(Line::from(vec![
+        Span::raw("  "),
+        Span::styled("◆", Style::default().fg(theme.thinking.border)),
+        Span::raw(" "),
+        Span::styled(msg.text.clone(), Style::default().fg(theme.thinking.fg)),
+    ]));
+}
+
+/// Distillation summary boundary marker.
+fn render_distillation_marker(
+    msg: &crate::app::ChatMessage,
+    lines: &mut Vec<Line<'static>>,
+    inner_width: usize,
+    theme: &Theme,
+) {
+    let border_len = inner_width.saturating_sub(18).min(30);
+    let border = "─".repeat(border_len);
+    lines.push(Line::from(vec![
+        Span::raw(" "),
+        Span::styled(
+            format!("─── distilled {border}"),
+            Style::default().fg(theme.colors.accent),
+        ),
+    ]));
+    if !msg.text.is_empty() {
+        lines.push(Line::from(vec![
+            Span::raw("  "),
+            Span::styled(msg.text.clone(), theme.style_dim()),
+        ]));
+    }
+    lines.push(Line::raw(""));
+}
+
+/// Visual separator between conversation topics.
+fn render_topic_boundary(lines: &mut Vec<Line<'static>>, inner_width: usize, theme: &Theme) {
+    let border = "─".repeat(inner_width.saturating_sub(4).min(40));
+    lines.push(Line::from(vec![
+        Span::raw("  "),
+        Span::styled(border, theme.style_dim()),
+    ]));
     lines.push(Line::raw(""));
 }
 
@@ -632,6 +798,11 @@ fn render_streaming(
     theme: &Theme,
     name: &str,
 ) {
+    let phase = app.connection.stream_phase;
+
+    // Phase-specific status indicator
+    render_phase_indicator(app, lines, theme, name, phase);
+
     // Thinking block (if visible)
     if app.layout.thinking_expanded && !app.connection.streaming_thinking.is_empty() {
         lines.push(Line::from(vec![
@@ -657,13 +828,8 @@ fn render_streaming(
         ]));
     }
 
-    // Streaming text with cursor
+    // Streaming text: render complete lines via markdown, partial line as plain text
     if !app.connection.streaming_text.is_empty() {
-        lines.push(Line::from(vec![Span::styled(
-            format!(" {}", name),
-            theme.style_assistant(),
-        )]));
-
         // Use cached markdown if text AND width match (streaming content, no OSC 8 links).
         let render_width = inner_width.saturating_sub(2);
         let rendered = if app.viewport.render.markdown_cache.text == app.connection.streaming_text
@@ -686,6 +852,17 @@ fn render_streaming(
             lines.push(Line::from(padded_spans));
         }
 
+        // Render the partial line buffer (not yet flushed to streaming_text)
+        if !app.connection.streaming_line_buffer.is_empty() {
+            lines.push(Line::from(vec![
+                Span::raw(" "),
+                Span::styled(
+                    app.connection.streaming_line_buffer.clone(),
+                    theme.style_fg(),
+                ),
+            ]));
+        }
+
         // Braille cursor
         let ch = theme::spinner_frame(app.viewport.tick_count);
         lines.push(Line::from(vec![
@@ -697,23 +874,43 @@ fn render_streaming(
                     .add_modifier(Modifier::BOLD),
             ),
         ]));
+    } else if !app.connection.streaming_line_buffer.is_empty() {
+        // Only partial line buffer (no complete lines yet)
+        lines.push(Line::from(vec![
+            Span::raw(" "),
+            Span::styled(
+                app.connection.streaming_line_buffer.clone(),
+                theme.style_fg(),
+            ),
+        ]));
+        let ch = theme::spinner_frame(app.viewport.tick_count);
+        lines.push(Line::from(vec![
+            Span::raw(" "),
+            Span::styled(
+                ch.to_string(),
+                Style::default()
+                    .fg(theme.status.streaming)
+                    .add_modifier(Modifier::BOLD),
+            ),
+        ]));
     } else if app.connection.active_turn_id.is_some() {
-        // No text yet: show agent name header then phase indicators or thinking fallback
-        lines.push(Line::from(vec![Span::styled(
-            format!(" {}", name),
-            theme.style_assistant(),
-        )]));
-
+        // No text yet: show tool call phase lines or thinking indicator
         let tool_calls = &app.layout.ops.tool_calls;
         if tool_calls.is_empty() {
-            // Nothing running yet: classic thinking indicator
             let ch = theme::spinner_frame(app.viewport.tick_count);
+            let label = match phase {
+                StreamPhase::Requesting => "connecting…",
+                StreamPhase::Thinking => "thinking…",
+                StreamPhase::Compacting => "compacting context…",
+                StreamPhase::Waiting => "waiting for approval…",
+                _ => "thinking…",
+            };
             lines.push(Line::from(vec![Span::styled(
-                format!("  {} thinking…", ch),
+                format!("  {} {label}", ch),
                 theme.style_muted(),
             )]));
         } else {
-            // Show last 5 tool calls as phase lines
+            // Show last 5 tool calls as collapsible card lines
             let start = tool_calls.len().saturating_sub(5);
             for call in &tool_calls[start..] {
                 let icon: String = match call.status {
@@ -744,13 +941,53 @@ fn render_streaming(
                 ) {
                     phase_text.push_str(&format!(" · {}", format_duration_adaptive(ms)));
                 }
+                // Pulsing border for running tools
+                let border_style =
+                    if matches!(call.status, crate::state::ops::OpsToolStatus::Running) {
+                        let pulse = (app.viewport.tick_count / 8).is_multiple_of(2);
+                        if pulse {
+                            Style::default().fg(theme.status.spinner)
+                        } else {
+                            theme.style_dim()
+                        }
+                    } else {
+                        theme.style_dim()
+                    };
                 lines.push(Line::from(vec![
-                    Span::raw("  "),
+                    Span::styled("  │", border_style),
+                    Span::raw(" "),
                     Span::styled(icon, icon_style),
                     Span::raw(" "),
                     Span::styled(phase_text, theme.style_muted()),
                 ]));
             }
         }
+    }
+}
+
+/// Render the stream phase indicator header.
+fn render_phase_indicator(
+    app: &App,
+    lines: &mut Vec<Line<'static>>,
+    theme: &Theme,
+    name: &str,
+    phase: StreamPhase,
+) {
+    let has_text = !app.connection.streaming_text.is_empty()
+        || !app.connection.streaming_line_buffer.is_empty();
+
+    // Show agent name header for streaming response
+    if has_text || app.connection.active_turn_id.is_some() {
+        let phase_suffix = match phase {
+            StreamPhase::Requesting => " · connecting",
+            StreamPhase::Compacting => " · compacting",
+            StreamPhase::Waiting => " · waiting",
+            StreamPhase::Error => " · error",
+            _ => "",
+        };
+        lines.push(Line::from(vec![
+            Span::styled(format!(" {name}"), theme.style_assistant()),
+            Span::styled(phase_suffix, theme.style_dim()),
+        ]));
     }
 }


### PR DESCRIPTION
## Summary

- **Static/dynamic rendering split**: finalized messages cached in a `static_lines` buffer (never re-rendered), only streaming response + input + status bar re-render each frame
- **30fps render throttle**: `MIN_RENDER_INTERVAL_MS = 33` gate in `App::view()` with `last_render_at` tracking, line-by-line streaming via `streaming_line_buffer` (partial lines buffered, complete lines flushed)
- **Stream state machine**: `StreamPhase` enum (`Idle → Requesting → Streaming → Done` with branches for `Thinking`, `Compacting`, `Waiting`, `Error`) driving phase transitions in all stream handlers
- **Tool cards as collapsible cards**: status icon (✓/✗), tool name + duration, expand/collapse toggle (▸/▾), errors auto-expanded, pulsing border while running
- **Message type awareness**: `MessageKind` enum with `ToolStatusLine`, `ThinkingStatusLine`, `DistillationMarker`, `TopicBoundary` variants dispatched to dedicated renderers
- **ToolCallInfo enrichment**: `tool_id` and `output` fields plumbed through from SSE events for card rendering and auto-expand on failure

Also fixes pre-existing unfulfilled lint expectations and `string_add` clippy warnings in theatron-tui and theatron-core.

Closes #1891, closes #1853.

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy -p theatron-tui --all-targets -- -D warnings` passes (0 warnings)
- [x] `cargo test -p theatron-tui` passes (915 tests)
- [x] `cargo test --workspace` passes
- [ ] Manual TUI smoke test: streaming response shows phase indicator, tool cards expand/collapse, static message buffer works on scroll