### PR TITLE
feat(tui): knowledge graph visualization and 3D architecture doc

### DIFF
--- a/crates/theatron/core/src/api/client.rs
+++ b/crates/theatron/core/src/api/client.rs
@@ -641,6 +641,61 @@ impl ApiClient {
         Ok(())
     }
 
+    /// Fetch all knowledge entities.
+    #[tracing::instrument(skip(self))]
+    pub async fn knowledge_entities(&self) -> Result<serde_json::Value> {
+        let resp = self
+            .request(reqwest::Method::GET, "/api/v1/knowledge/entities")
+            .send()
+            .await
+            .context(HttpSnafu {
+                operation: "load entities",
+            })?;
+        let resp = Self::check_status(resp, "entities request").await?;
+        resp.json().await.context(HttpSnafu {
+            operation: "entities response",
+        })
+    }
+
+    /// Fetch relationships for a specific entity.
+    #[tracing::instrument(skip(self))]
+    pub async fn knowledge_entity_relationships(
+        &self,
+        entity_id: &str,
+    ) -> Result<serde_json::Value> {
+        let encoded = encode_path(entity_id);
+        let resp = self
+            .request(
+                reqwest::Method::GET,
+                &format!("/api/v1/knowledge/entities/{encoded}/relationships"),
+            )
+            .send()
+            .await
+            .context(HttpSnafu {
+                operation: "load entity relationships",
+            })?;
+        let resp = Self::check_status(resp, "entity relationships request").await?;
+        resp.json().await.context(HttpSnafu {
+            operation: "entity relationships response",
+        })
+    }
+
+    /// Fetch the knowledge activity timeline.
+    #[tracing::instrument(skip(self))]
+    pub async fn knowledge_timeline(&self) -> Result<serde_json::Value> {
+        let resp = self
+            .request(reqwest::Method::GET, "/api/v1/knowledge/timeline")
+            .send()
+            .await
+            .context(HttpSnafu {
+                operation: "load timeline",
+            })?;
+        let resp = Self::check_status(resp, "timeline request").await?;
+        resp.json().await.context(HttpSnafu {
+            operation: "timeline response",
+        })
+    }
+
     /// Update the confidence score for a knowledge fact.
     #[tracing::instrument(skip(self))]
     pub async fn knowledge_update_confidence(&self, fact_id: &str, confidence: f64) -> Result<()> {

--- a/crates/theatron/tui/src/mapping/keyboard.rs
+++ b/crates/theatron/tui/src/mapping/keyboard.rs
@@ -457,6 +457,7 @@ impl crate::app::App {
             self.layout.view_stack.current(),
             crate::state::view_stack::View::MemoryInspector
                 | crate::state::view_stack::View::FactDetail { .. }
+                | crate::state::view_stack::View::EntityDetail { .. }
         )
     }
 
@@ -517,6 +518,16 @@ impl crate::app::App {
             };
         }
 
+        if matches!(
+            self.layout.view_stack.current(),
+            crate::state::view_stack::View::EntityDetail { .. }
+        ) {
+            return match (key.modifiers, key.code) {
+                (_, KeyCode::Esc) => Some(Msg::MemoryPopBack),
+                _ => None,
+            };
+        }
+
         match (key.modifiers, key.code) {
             (_, KeyCode::Esc) => Some(Msg::MemoryClose),
             (_, KeyCode::Up) | (KeyModifiers::NONE, KeyCode::Char('k')) => {
@@ -538,6 +549,8 @@ impl crate::app::App {
             (KeyModifiers::NONE, KeyCode::Char('d')) => Some(Msg::MemoryForget),
             (KeyModifiers::NONE, KeyCode::Char('r')) => Some(Msg::MemoryRestore),
             (KeyModifiers::NONE, KeyCode::Char('e')) => Some(Msg::MemoryEditConfidence),
+            (KeyModifiers::NONE, KeyCode::Char(']')) => Some(Msg::MemoryDriftTabNext),
+            (KeyModifiers::NONE, KeyCode::Char('[')) => Some(Msg::MemoryDriftTabPrev),
             (_, KeyCode::Tab) => Some(Msg::MemoryTabNext),
             (KeyModifiers::SHIFT, KeyCode::BackTab) => Some(Msg::MemoryTabPrev),
             _ => None,

--- a/crates/theatron/tui/src/msg.rs
+++ b/crates/theatron/tui/src/msg.rs
@@ -299,6 +299,8 @@ pub enum Msg {
     MemoryActionResult(String),
     MemoryPageDown,
     MemoryPageUp,
+    MemoryDriftTabNext,
+    MemoryDriftTabPrev,
 
     #[expect(dead_code, reason = "opened via :editor command, not Msg pipeline")]
     EditorOpen,

--- a/crates/theatron/tui/src/state/memory.rs
+++ b/crates/theatron/tui/src/state/memory.rs
@@ -51,6 +51,7 @@ impl FactSort {
 pub(crate) enum MemoryTab {
     Facts,
     Graph,
+    Drift,
     Timeline,
 }
 
@@ -59,6 +60,7 @@ impl MemoryTab {
         match self {
             Self::Facts => "Facts",
             Self::Graph => "Graph",
+            Self::Drift => "Drift",
             Self::Timeline => "Timeline",
         }
     }
@@ -66,7 +68,8 @@ impl MemoryTab {
     pub(crate) fn next(self) -> Self {
         match self {
             Self::Facts => Self::Graph,
-            Self::Graph => Self::Timeline,
+            Self::Graph => Self::Drift,
+            Self::Drift => Self::Timeline,
             Self::Timeline => Self::Facts,
         }
     }
@@ -75,7 +78,47 @@ impl MemoryTab {
         match self {
             Self::Facts => Self::Timeline,
             Self::Graph => Self::Facts,
-            Self::Timeline => Self::Graph,
+            Self::Drift => Self::Graph,
+            Self::Timeline => Self::Drift,
+        }
+    }
+}
+
+/// Sub-tabs within the Drift panel.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub(crate) enum DriftTab {
+    Suggestions,
+    Orphans,
+    Stale,
+    Isolated,
+}
+
+impl DriftTab {
+    pub(crate) fn label(self) -> &'static str {
+        match self {
+            Self::Suggestions => "Suggestions",
+            Self::Orphans => "Orphans",
+            Self::Stale => "Stale",
+            Self::Isolated => "Isolated",
+        }
+    }
+
+    pub(crate) fn next(self) -> Self {
+        match self {
+            Self::Suggestions => Self::Orphans,
+            Self::Orphans => Self::Stale,
+            Self::Stale => Self::Isolated,
+            Self::Isolated => Self::Suggestions,
+        }
+    }
+
+    pub(crate) fn prev(self) -> Self {
+        match self {
+            Self::Suggestions => Self::Isolated,
+            Self::Orphans => Self::Suggestions,
+            Self::Stale => Self::Orphans,
+            Self::Isolated => Self::Stale,
         }
     }
 }
@@ -176,6 +219,74 @@ pub(crate) struct SimilarFact {
     pub(crate) id: String,
     pub(crate) content: String,
     pub(crate) similarity: f64,
+}
+
+/// An entity with computed graph statistics for the summary view.
+#[derive(Debug, Clone)]
+pub(crate) struct GraphEntityStat {
+    pub(crate) entity: MemoryEntity,
+    pub(crate) relationship_count: usize,
+    pub(crate) community_id: Option<u32>,
+    pub(crate) pagerank: f64,
+}
+
+/// A drift analysis suggestion (delete, review, or merge).
+#[derive(Debug, Clone)]
+pub(crate) struct DriftSuggestion {
+    pub(crate) action: String,
+    pub(crate) entity_name: String,
+    pub(crate) reason: String,
+}
+
+/// A cluster of entities identified as isolated (<3 members).
+#[derive(Debug, Clone)]
+pub(crate) struct IsolatedCluster {
+    pub(crate) entity_names: Vec<String>,
+    pub(crate) size: usize,
+}
+
+/// Aggregate health metrics for the knowledge graph.
+#[derive(Debug, Clone)]
+pub(crate) struct GraphHealthMetrics {
+    pub(crate) total_entities: usize,
+    pub(crate) total_relationships: usize,
+    pub(crate) orphan_count: usize,
+    pub(crate) stale_count: usize,
+    pub(crate) avg_cluster_size: f64,
+    pub(crate) community_count: usize,
+    pub(crate) isolated_cluster_count: usize,
+}
+
+impl Default for GraphHealthMetrics {
+    fn default() -> Self {
+        Self {
+            total_entities: 0,
+            total_relationships: 0,
+            orphan_count: 0,
+            stale_count: 0,
+            avg_cluster_size: 0.0,
+            community_count: 0,
+            isolated_cluster_count: 0,
+        }
+    }
+}
+
+/// A fact related to a graph entity (for the node card).
+#[derive(Debug, Clone)]
+pub(crate) struct NodeCardFact {
+    pub(crate) content: String,
+    pub(crate) confidence: f64,
+    pub(crate) tier: String,
+}
+
+/// Full detail for a selected entity (node card view).
+#[derive(Debug, Clone)]
+pub(crate) struct GraphNodeCard {
+    pub(crate) entity: MemoryEntity,
+    pub(crate) pagerank: f64,
+    pub(crate) community_id: Option<u32>,
+    pub(crate) relationships_grouped: Vec<(String, Vec<MemoryRelationship>)>,
+    pub(crate) related_facts: Vec<NodeCardFact>,
 }
 
 /// Search result from the knowledge API.
@@ -303,7 +414,7 @@ impl Default for MemorySearchState {
     }
 }
 
-/// State for the knowledge graph and timeline views.
+/// State for the knowledge graph, drift analysis, and timeline views.
 #[derive(Debug)]
 pub(crate) struct MemoryGraphState {
     /// Entities loaded for graph view.
@@ -312,6 +423,30 @@ pub(crate) struct MemoryGraphState {
     pub(crate) relationships: Vec<MemoryRelationship>,
     /// Timeline events.
     pub(crate) timeline_events: Vec<MemoryTimelineEvent>,
+    /// Entities with computed stats (PageRank, community, relationship count).
+    pub(crate) entity_stats: Vec<GraphEntityStat>,
+    /// Aggregate graph health metrics.
+    pub(crate) health: GraphHealthMetrics,
+    /// Selected entity index in the entity list.
+    pub(crate) selected_entity: usize,
+    /// Scroll offset for the entity list.
+    pub(crate) entity_scroll_offset: usize,
+    /// Current drift sub-tab.
+    pub(crate) drift_tab: DriftTab,
+    /// Drift suggestions (delete/review/merge).
+    pub(crate) drift_suggestions: Vec<DriftSuggestion>,
+    /// Names of orphaned entities (0 relationships).
+    pub(crate) orphaned_entities: Vec<String>,
+    /// Names of stale entities (>30d since update).
+    pub(crate) stale_entities: Vec<String>,
+    /// Clusters with fewer than 3 members.
+    pub(crate) isolated_clusters: Vec<IsolatedCluster>,
+    /// Selected item index in the current drift list.
+    pub(crate) drift_selected: usize,
+    /// Scroll offset for drift lists.
+    pub(crate) drift_scroll_offset: usize,
+    /// Loaded node card for entity detail view.
+    pub(crate) node_card: Option<GraphNodeCard>,
 }
 
 impl MemoryGraphState {
@@ -320,6 +455,18 @@ impl MemoryGraphState {
             entities: Vec::new(),
             relationships: Vec::new(),
             timeline_events: Vec::new(),
+            entity_stats: Vec::new(),
+            health: GraphHealthMetrics::default(),
+            selected_entity: 0,
+            entity_scroll_offset: 0,
+            drift_tab: DriftTab::Suggestions,
+            drift_suggestions: Vec::new(),
+            orphaned_entities: Vec::new(),
+            stale_entities: Vec::new(),
+            isolated_clusters: Vec::new(),
+            drift_selected: 0,
+            drift_scroll_offset: 0,
+            node_card: None,
         }
     }
 }
@@ -448,14 +595,16 @@ mod tests {
     #[test]
     fn memory_tab_cycle() {
         assert_eq!(MemoryTab::Facts.next(), MemoryTab::Graph);
-        assert_eq!(MemoryTab::Graph.next(), MemoryTab::Timeline);
+        assert_eq!(MemoryTab::Graph.next(), MemoryTab::Drift);
+        assert_eq!(MemoryTab::Drift.next(), MemoryTab::Timeline);
         assert_eq!(MemoryTab::Timeline.next(), MemoryTab::Facts);
     }
 
     #[test]
     fn memory_tab_cycle_prev() {
         assert_eq!(MemoryTab::Facts.prev(), MemoryTab::Timeline);
-        assert_eq!(MemoryTab::Timeline.prev(), MemoryTab::Graph);
+        assert_eq!(MemoryTab::Timeline.prev(), MemoryTab::Drift);
+        assert_eq!(MemoryTab::Drift.prev(), MemoryTab::Graph);
         assert_eq!(MemoryTab::Graph.prev(), MemoryTab::Facts);
     }
 
@@ -463,7 +612,40 @@ mod tests {
     fn memory_tab_labels() {
         assert_eq!(MemoryTab::Facts.label(), "Facts");
         assert_eq!(MemoryTab::Graph.label(), "Graph");
+        assert_eq!(MemoryTab::Drift.label(), "Drift");
         assert_eq!(MemoryTab::Timeline.label(), "Timeline");
+    }
+
+    #[test]
+    fn drift_tab_cycle() {
+        assert_eq!(DriftTab::Suggestions.next(), DriftTab::Orphans);
+        assert_eq!(DriftTab::Orphans.next(), DriftTab::Stale);
+        assert_eq!(DriftTab::Stale.next(), DriftTab::Isolated);
+        assert_eq!(DriftTab::Isolated.next(), DriftTab::Suggestions);
+    }
+
+    #[test]
+    fn drift_tab_cycle_prev() {
+        assert_eq!(DriftTab::Suggestions.prev(), DriftTab::Isolated);
+        assert_eq!(DriftTab::Isolated.prev(), DriftTab::Stale);
+        assert_eq!(DriftTab::Stale.prev(), DriftTab::Orphans);
+        assert_eq!(DriftTab::Orphans.prev(), DriftTab::Suggestions);
+    }
+
+    #[test]
+    fn drift_tab_labels() {
+        assert_eq!(DriftTab::Suggestions.label(), "Suggestions");
+        assert_eq!(DriftTab::Orphans.label(), "Orphans");
+        assert_eq!(DriftTab::Stale.label(), "Stale");
+        assert_eq!(DriftTab::Isolated.label(), "Isolated");
+    }
+
+    #[test]
+    fn graph_health_metrics_default() {
+        let health = GraphHealthMetrics::default();
+        assert_eq!(health.total_entities, 0);
+        assert_eq!(health.orphan_count, 0);
+        assert_eq!(health.avg_cluster_size, 0.0);
     }
 
     #[test]

--- a/crates/theatron/tui/src/state/view_stack.rs
+++ b/crates/theatron/tui/src/state/view_stack.rs
@@ -22,6 +22,8 @@ pub enum View {
     MemoryInspector,
     /// Fact detail within the memory inspector.
     FactDetail { fact_id: String },
+    /// Entity detail within the graph view (node card).
+    EntityDetail { entity_id: String },
     /// Metrics dashboard: token usage, cost, service health, per-agent stats.
     Metrics,
     /// Built-in file editor with syntax highlighting and tabs.
@@ -38,6 +40,7 @@ impl View {
             Self::MessageDetail { .. } => "Message",
             Self::MemoryInspector => "Memory",
             Self::FactDetail { .. } => "Fact",
+            Self::EntityDetail { .. } => "Entity",
             Self::Metrics => "Metrics",
             Self::FileEditor => "Editor",
         }

--- a/crates/theatron/tui/src/update/memory.rs
+++ b/crates/theatron/tui/src/update/memory.rs
@@ -1,8 +1,14 @@
 //! Update handlers for the memory inspector panel.
 
+use std::collections::{BTreeMap, HashMap};
+
 use crate::app::App;
 use crate::msg::ErrorToast;
-use crate::state::memory::{FactDetail, MemoryFact, MemorySearchResult, MemoryTab};
+use crate::state::memory::{
+    DriftSuggestion, DriftTab, FactDetail, GraphEntityStat, GraphHealthMetrics, GraphNodeCard,
+    IsolatedCluster, MemoryEntity, MemoryFact, MemoryRelationship, MemorySearchResult, MemoryTab,
+    NodeCardFact,
+};
 use crate::state::view_stack::View;
 
 /// Open the memory inspector, pushing it onto the view stack and loading data.
@@ -10,13 +16,14 @@ pub(crate) async fn handle_open(app: &mut App) {
     app.layout.view_stack.push(View::MemoryInspector);
     app.layout.memory.loading = true;
     load_facts(app).await;
+    load_graph_data(app).await;
 }
 
 /// Close memory inspector (pop back).
 pub(crate) fn handle_close(app: &mut App) {
     if matches!(
         app.layout.view_stack.current(),
-        View::MemoryInspector | View::FactDetail { .. }
+        View::MemoryInspector | View::FactDetail { .. } | View::EntityDetail { .. }
     ) {
         app.layout.view_stack.pop();
     }
@@ -104,6 +111,15 @@ pub(crate) async fn handle_drill_in(app: &mut App) {
             fact_id: fact_id.clone(),
         });
         load_fact_detail(app, &fact_id).await;
+    } else if app.layout.memory.tab == MemoryTab::Graph {
+        let selected = app.layout.memory.graph.selected_entity;
+        if let Some(stat) = app.layout.memory.graph.entity_stats.get(selected) {
+            let entity_id = stat.entity.id.clone();
+            build_node_card(app, &entity_id);
+            app.layout.view_stack.push(View::EntityDetail {
+                entity_id: entity_id.clone(),
+            });
+        }
     }
 }
 
@@ -111,9 +127,24 @@ pub(crate) fn handle_pop_back(app: &mut App) {
     if matches!(app.layout.view_stack.current(), View::FactDetail { .. }) {
         app.layout.view_stack.pop();
         app.layout.memory.fact_list.detail = None;
+    } else if matches!(app.layout.view_stack.current(), View::EntityDetail { .. }) {
+        app.layout.view_stack.pop();
+        app.layout.memory.graph.node_card = None;
     } else {
         app.layout.view_stack.pop();
     }
+}
+
+pub(crate) fn handle_drift_tab_next(app: &mut App) {
+    app.layout.memory.graph.drift_tab = app.layout.memory.graph.drift_tab.next();
+    app.layout.memory.graph.drift_selected = 0;
+    app.layout.memory.graph.drift_scroll_offset = 0;
+}
+
+pub(crate) fn handle_drift_tab_prev(app: &mut App) {
+    app.layout.memory.graph.drift_tab = app.layout.memory.graph.drift_tab.prev();
+    app.layout.memory.graph.drift_selected = 0;
+    app.layout.memory.graph.drift_scroll_offset = 0;
 }
 
 pub(crate) async fn handle_forget(app: &mut App) {
@@ -394,8 +425,18 @@ async fn load_fact_detail(app: &mut App, fact_id: &str) {
 fn item_count(app: &App) -> usize {
     match app.layout.memory.tab {
         MemoryTab::Facts => app.layout.memory.fact_list.facts.len(),
-        MemoryTab::Graph => app.layout.memory.graph.entities.len(),
+        MemoryTab::Graph => app.layout.memory.graph.entity_stats.len(),
+        MemoryTab::Drift => drift_item_count(app),
         MemoryTab::Timeline => app.layout.memory.graph.timeline_events.len(),
+    }
+}
+
+fn drift_item_count(app: &App) -> usize {
+    match app.layout.memory.graph.drift_tab {
+        DriftTab::Suggestions => app.layout.memory.graph.drift_suggestions.len(),
+        DriftTab::Orphans => app.layout.memory.graph.orphaned_entities.len(),
+        DriftTab::Stale => app.layout.memory.graph.stale_entities.len(),
+        DriftTab::Isolated => app.layout.memory.graph.isolated_clusters.len(),
     }
 }
 
@@ -419,6 +460,429 @@ fn adjust_scroll(app: &mut App) {
 struct FactsListResponse {
     facts: Vec<MemoryFact>,
     total: usize,
+}
+
+#[derive(serde::Deserialize)]
+struct EntitiesResponse {
+    #[serde(default)]
+    entities: Vec<MemoryEntity>,
+}
+
+#[derive(serde::Deserialize)]
+struct RelationshipsResponse {
+    #[serde(default)]
+    relationships: Vec<MemoryRelationship>,
+}
+
+#[derive(serde::Deserialize)]
+struct TimelineResponse {
+    #[serde(default)]
+    events: Vec<crate::state::memory::MemoryTimelineEvent>,
+}
+
+/// Stale threshold: entities not updated in this many days are flagged.
+const STALE_THRESHOLD_DAYS: u64 = 30;
+/// Clusters smaller than this are considered isolated.
+const ISOLATED_CLUSTER_THRESHOLD: usize = 3;
+/// Number of PageRank iterations for the TUI approximation.
+const PAGERANK_ITERATIONS: usize = 20;
+/// PageRank damping factor.
+const PAGERANK_DAMPING: f64 = 0.85;
+
+async fn load_graph_data(app: &mut App) {
+    let client = app.client.clone();
+
+    let mut entities: Vec<MemoryEntity> = Vec::new();
+    let mut relationships: Vec<MemoryRelationship> = Vec::new();
+
+    if let Ok(json) = client.knowledge_entities().await
+        && let Ok(resp) = serde_json::from_value::<EntitiesResponse>(json)
+    {
+        entities = resp.entities;
+    }
+
+    // WHY: fetch all relationships by iterating entities; the API exposes per-entity endpoints
+    let mut seen_rels = std::collections::HashSet::new();
+    for entity in &entities {
+        if let Ok(json) = client.knowledge_entity_relationships(&entity.id).await
+            && let Ok(resp) = serde_json::from_value::<RelationshipsResponse>(json)
+        {
+            for rel in resp.relationships {
+                let key = format!("{}:{}:{}", rel.src, rel.relation, rel.dst);
+                if seen_rels.insert(key) {
+                    relationships.push(rel);
+                }
+            }
+        }
+    }
+
+    if let Ok(json) = client.knowledge_timeline().await
+        && let Ok(resp) = serde_json::from_value::<TimelineResponse>(json)
+    {
+        app.layout.memory.graph.timeline_events = resp.events;
+    }
+
+    app.layout.memory.graph.entities = entities.clone();
+    app.layout.memory.graph.relationships = relationships.clone();
+
+    compute_graph_stats(app);
+    compute_drift_analysis(app);
+}
+
+fn compute_graph_stats(app: &mut App) {
+    let entities = &app.layout.memory.graph.entities;
+    let relationships = &app.layout.memory.graph.relationships;
+
+    let mut rel_counts: HashMap<String, usize> = HashMap::new();
+    for rel in relationships {
+        *rel_counts.entry(rel.src.clone()).or_default() += 1;
+        *rel_counts.entry(rel.dst.clone()).or_default() += 1;
+    }
+
+    let pageranks = compute_pagerank(entities, relationships);
+    let communities = compute_communities(entities, relationships);
+
+    let entity_stats: Vec<GraphEntityStat> = entities
+        .iter()
+        .map(|e| {
+            let rel_count = rel_counts.get(&e.id).copied().unwrap_or(0);
+            let pagerank = pageranks.get(&e.id).copied().unwrap_or(0.0);
+            let community_id = communities.get(&e.id).copied();
+            GraphEntityStat {
+                entity: e.clone(),
+                relationship_count: rel_count,
+                community_id,
+                pagerank,
+            }
+        })
+        .collect();
+
+    let community_sizes = compute_community_sizes(&communities);
+    let community_count = community_sizes.len();
+    let avg_cluster_size = if community_count > 0 {
+        let total: usize = community_sizes.values().sum();
+        total as f64 / community_count as f64
+    } else {
+        0.0
+    };
+
+    let orphan_count = entity_stats
+        .iter()
+        .filter(|s| s.relationship_count == 0)
+        .count();
+    let stale_count = count_stale_entities(entities);
+    let isolated_cluster_count = community_sizes
+        .values()
+        .filter(|&&size| size < ISOLATED_CLUSTER_THRESHOLD)
+        .count();
+
+    app.layout.memory.graph.entity_stats = entity_stats;
+    app.layout.memory.graph.health = GraphHealthMetrics {
+        total_entities: entities.len(),
+        total_relationships: relationships.len(),
+        orphan_count,
+        stale_count,
+        avg_cluster_size,
+        community_count,
+        isolated_cluster_count,
+    };
+}
+
+fn compute_drift_analysis(app: &mut App) {
+    let stats = &app.layout.memory.graph.entity_stats;
+    let relationships = &app.layout.memory.graph.relationships;
+
+    let mut suggestions = Vec::new();
+    let mut orphaned = Vec::new();
+    let mut stale = Vec::new();
+
+    for stat in stats {
+        if stat.relationship_count == 0 {
+            orphaned.push(stat.entity.name.clone());
+            suggestions.push(DriftSuggestion {
+                action: "review".into(),
+                entity_name: stat.entity.name.clone(),
+                reason: "orphaned: no relationships".into(),
+            });
+        }
+        if is_entity_stale(&stat.entity) {
+            stale.push(stat.entity.name.clone());
+            if stat.relationship_count == 0 {
+                suggestions.push(DriftSuggestion {
+                    action: "delete".into(),
+                    entity_name: stat.entity.name.clone(),
+                    reason: "stale and orphaned".into(),
+                });
+            }
+        }
+        if stat.pagerank < 0.01 && stat.relationship_count > 0 {
+            suggestions.push(DriftSuggestion {
+                action: "review".into(),
+                entity_name: stat.entity.name.clone(),
+                reason: "very low PageRank despite having relationships".into(),
+            });
+        }
+    }
+
+    // WHY: detect potential duplicates by checking for entities with similar names
+    let names: Vec<&str> = stats.iter().map(|s| s.entity.name.as_str()).collect();
+    for (i, a) in names.iter().enumerate() {
+        for b in names.iter().skip(i + 1) {
+            if a.to_lowercase() == b.to_lowercase() && a != b {
+                suggestions.push(DriftSuggestion {
+                    action: "merge".into(),
+                    entity_name: format!("{a} / {b}"),
+                    reason: "potential duplicate (case mismatch)".into(),
+                });
+            }
+        }
+    }
+
+    let communities = compute_communities(&app.layout.memory.graph.entities, relationships);
+    let community_members = invert_communities(&communities);
+    let mut isolated_clusters = Vec::new();
+    for members in community_members.values() {
+        if members.len() < ISOLATED_CLUSTER_THRESHOLD {
+            isolated_clusters.push(IsolatedCluster {
+                entity_names: members.clone(),
+                size: members.len(),
+            });
+        }
+    }
+
+    app.layout.memory.graph.drift_suggestions = suggestions;
+    app.layout.memory.graph.orphaned_entities = orphaned;
+    app.layout.memory.graph.stale_entities = stale;
+    app.layout.memory.graph.isolated_clusters = isolated_clusters;
+}
+
+/// Simple iterative PageRank on the entity graph.
+fn compute_pagerank(
+    entities: &[MemoryEntity],
+    relationships: &[MemoryRelationship],
+) -> HashMap<String, f64> {
+    if entities.is_empty() {
+        return HashMap::new();
+    }
+
+    let n = entities.len();
+    let initial = 1.0 / n as f64;
+    let mut scores: HashMap<String, f64> =
+        entities.iter().map(|e| (e.id.clone(), initial)).collect();
+
+    let mut outgoing: HashMap<String, Vec<String>> = HashMap::new();
+    for rel in relationships {
+        outgoing
+            .entry(rel.src.clone())
+            .or_default()
+            .push(rel.dst.clone());
+    }
+
+    for _ in 0..PAGERANK_ITERATIONS {
+        let mut new_scores: HashMap<String, f64> = entities
+            .iter()
+            .map(|e| (e.id.clone(), (1.0 - PAGERANK_DAMPING) / n as f64))
+            .collect();
+
+        for entity in entities {
+            let score = scores.get(&entity.id).copied().unwrap_or(0.0);
+            if let Some(targets) = outgoing.get(&entity.id)
+                && !targets.is_empty()
+            {
+                let share = score / targets.len() as f64;
+                for target in targets {
+                    if let Some(s) = new_scores.get_mut(target) {
+                        *s += PAGERANK_DAMPING * share;
+                    }
+                }
+            }
+        }
+
+        scores = new_scores;
+    }
+
+    scores
+}
+
+/// Union-Find community detection (connected components).
+fn compute_communities(
+    entities: &[MemoryEntity],
+    relationships: &[MemoryRelationship],
+) -> HashMap<String, u32> {
+    if entities.is_empty() {
+        return HashMap::new();
+    }
+
+    let mut id_to_idx: HashMap<&str, usize> = HashMap::new();
+    for (i, e) in entities.iter().enumerate() {
+        id_to_idx.insert(&e.id, i);
+    }
+
+    let mut parent: Vec<usize> = (0..entities.len()).collect();
+
+    for rel in relationships {
+        if let (Some(&a), Some(&b)) = (
+            id_to_idx.get(rel.src.as_str()),
+            id_to_idx.get(rel.dst.as_str()),
+        ) {
+            union(&mut parent, a, b);
+        }
+    }
+
+    let mut component_ids: HashMap<usize, u32> = HashMap::new();
+    let mut next_id = 0u32;
+    let mut result: HashMap<String, u32> = HashMap::new();
+    for (i, entity) in entities.iter().enumerate() {
+        let root = find(&mut parent, i);
+        let cid = *component_ids.entry(root).or_insert_with(|| {
+            let id = next_id;
+            next_id += 1;
+            id
+        });
+        result.insert(entity.id.clone(), cid);
+    }
+
+    result
+}
+
+fn find(parent: &mut Vec<usize>, i: usize) -> usize {
+    if parent[i] != i {
+        parent[i] = find(parent, parent[i]);
+    }
+    parent[i]
+}
+
+fn union(parent: &mut Vec<usize>, a: usize, b: usize) {
+    let ra = find(parent, a);
+    let rb = find(parent, b);
+    if ra != rb {
+        parent[ra] = rb;
+    }
+}
+
+fn compute_community_sizes(communities: &HashMap<String, u32>) -> HashMap<u32, usize> {
+    let mut sizes: HashMap<u32, usize> = HashMap::new();
+    for cid in communities.values() {
+        *sizes.entry(*cid).or_default() += 1;
+    }
+    sizes
+}
+
+fn invert_communities(communities: &HashMap<String, u32>) -> BTreeMap<u32, Vec<String>> {
+    let mut result: BTreeMap<u32, Vec<String>> = BTreeMap::new();
+    for (entity_id, cid) in communities {
+        result.entry(*cid).or_default().push(entity_id.clone());
+    }
+    result
+}
+
+fn is_entity_stale(entity: &MemoryEntity) -> bool {
+    if entity.updated_at.is_empty() {
+        return !entity.created_at.is_empty();
+    }
+    let date_str = entity
+        .updated_at
+        .split('T')
+        .next()
+        .unwrap_or(&entity.updated_at);
+    // WHY: simple date comparison; parse YYYY-MM-DD and check against threshold
+    if date_str.len() < 10 {
+        return false;
+    }
+    let now_approx = "2026-03-22";
+    date_str < &now_approx[..date_str.len().min(10)]
+        && days_between_approx(date_str, now_approx) > STALE_THRESHOLD_DAYS
+}
+
+fn days_between_approx(a: &str, b: &str) -> u64 {
+    // WHY: rough day estimate for staleness check; no jiff dependency in TUI
+    let parse = |s: &str| -> Option<u64> {
+        let parts: Vec<&str> = s.split('-').collect();
+        if parts.len() < 3 {
+            return None;
+        }
+        let y: u64 = parts[0].parse().ok()?;
+        let m: u64 = parts[1].parse().ok()?;
+        let d: u64 = parts[2].parse().ok()?;
+        Some(y * 365 + m * 30 + d)
+    };
+    match (parse(a), parse(b)) {
+        (Some(da), Some(db)) => db.saturating_sub(da),
+        _ => 0,
+    }
+}
+
+fn count_stale_entities(entities: &[MemoryEntity]) -> usize {
+    entities.iter().filter(|e| is_entity_stale(e)).count()
+}
+
+fn build_node_card(app: &mut App, entity_id: &str) {
+    let entity = app
+        .layout
+        .memory
+        .graph
+        .entities
+        .iter()
+        .find(|e| e.id == entity_id)
+        .cloned();
+
+    let entity = match entity {
+        Some(e) => e,
+        None => return,
+    };
+
+    let stat = app
+        .layout
+        .memory
+        .graph
+        .entity_stats
+        .iter()
+        .find(|s| s.entity.id == entity_id);
+
+    let pagerank = stat.map(|s| s.pagerank).unwrap_or(0.0);
+    let community_id = stat.and_then(|s| s.community_id);
+
+    // WHY: group relationships by type for the node card display
+    let mut grouped: BTreeMap<String, Vec<MemoryRelationship>> = BTreeMap::new();
+    for rel in &app.layout.memory.graph.relationships {
+        if rel.src == entity_id || rel.dst == entity_id {
+            grouped
+                .entry(rel.relation.clone())
+                .or_default()
+                .push(rel.clone());
+        }
+    }
+    let relationships_grouped: Vec<(String, Vec<MemoryRelationship>)> =
+        grouped.into_iter().collect();
+
+    // WHY: search facts for content mentioning this entity name
+    let related_facts: Vec<NodeCardFact> = app
+        .layout
+        .memory
+        .fact_list
+        .facts
+        .iter()
+        .filter(|f| {
+            !f.lifecycle.is_forgotten
+                && f.content
+                    .to_lowercase()
+                    .contains(&entity.name.to_lowercase())
+        })
+        .take(10)
+        .map(|f| NodeCardFact {
+            content: f.content.clone(),
+            confidence: f.confidence,
+            tier: f.tier.clone(),
+        })
+        .collect();
+
+    app.layout.memory.graph.node_card = Some(GraphNodeCard {
+        entity,
+        pagerank,
+        community_id,
+        relationships_grouped,
+        related_facts,
+    });
 }
 
 #[cfg(test)]
@@ -546,6 +1010,11 @@ mod tests {
         assert_eq!(
             app.layout.memory.tab,
             crate::state::memory::MemoryTab::Graph
+        );
+        handle_tab_next(&mut app);
+        assert_eq!(
+            app.layout.memory.tab,
+            crate::state::memory::MemoryTab::Drift
         );
         handle_tab_next(&mut app);
         assert_eq!(
@@ -718,7 +1187,100 @@ mod tests {
         app.layout.memory.tab = crate::state::memory::MemoryTab::Graph;
         assert_eq!(item_count(&app), 0);
 
+        app.layout.memory.tab = crate::state::memory::MemoryTab::Drift;
+        assert_eq!(item_count(&app), 0);
+
         app.layout.memory.tab = crate::state::memory::MemoryTab::Timeline;
         assert_eq!(item_count(&app), 0);
+    }
+
+    #[test]
+    fn handle_drift_tab_next_cycles() {
+        let mut app = test_app();
+        assert_eq!(
+            app.layout.memory.graph.drift_tab,
+            crate::state::memory::DriftTab::Suggestions
+        );
+        handle_drift_tab_next(&mut app);
+        assert_eq!(
+            app.layout.memory.graph.drift_tab,
+            crate::state::memory::DriftTab::Orphans
+        );
+    }
+
+    #[test]
+    fn handle_drift_tab_prev_cycles() {
+        let mut app = test_app();
+        handle_drift_tab_prev(&mut app);
+        assert_eq!(
+            app.layout.memory.graph.drift_tab,
+            crate::state::memory::DriftTab::Isolated
+        );
+    }
+
+    #[test]
+    fn compute_pagerank_empty() {
+        let scores = compute_pagerank(&[], &[]);
+        assert!(scores.is_empty());
+    }
+
+    #[test]
+    fn compute_pagerank_single_entity() {
+        let entities = vec![MemoryEntity {
+            id: "e1".into(),
+            name: "alice".into(),
+            entity_type: "person".into(),
+            aliases: Vec::new(),
+            created_at: String::new(),
+            updated_at: String::new(),
+        }];
+        let scores = compute_pagerank(&entities, &[]);
+        assert!(scores.contains_key("e1"));
+    }
+
+    #[test]
+    fn compute_communities_groups_connected_entities() {
+        let entities = vec![
+            MemoryEntity {
+                id: "e1".into(),
+                name: "alice".into(),
+                entity_type: "person".into(),
+                aliases: Vec::new(),
+                created_at: String::new(),
+                updated_at: String::new(),
+            },
+            MemoryEntity {
+                id: "e2".into(),
+                name: "bob".into(),
+                entity_type: "person".into(),
+                aliases: Vec::new(),
+                created_at: String::new(),
+                updated_at: String::new(),
+            },
+            MemoryEntity {
+                id: "e3".into(),
+                name: "charlie".into(),
+                entity_type: "person".into(),
+                aliases: Vec::new(),
+                created_at: String::new(),
+                updated_at: String::new(),
+            },
+        ];
+        let relationships = vec![MemoryRelationship {
+            src: "e1".into(),
+            dst: "e2".into(),
+            relation: "KNOWS".into(),
+            weight: 1.0,
+            created_at: String::new(),
+        }];
+        let communities = compute_communities(&entities, &relationships);
+        assert_eq!(communities.get("e1"), communities.get("e2"));
+        assert_ne!(communities.get("e1"), communities.get("e3"));
+    }
+
+    #[test]
+    fn days_between_approx_calculates() {
+        assert!(days_between_approx("2026-01-01", "2026-03-22") > 30);
+        assert_eq!(days_between_approx("invalid", "2026-03-22"), 0);
     }
 }

--- a/crates/theatron/tui/src/update/mod.rs
+++ b/crates/theatron/tui/src/update/mod.rs
@@ -309,6 +309,8 @@ pub(crate) async fn update(app: &mut App, msg: Msg) {
         Msg::MemorySearchClose => memory::handle_search_close(app),
         Msg::MemoryPageDown => memory::handle_page_down(app),
         Msg::MemoryPageUp => memory::handle_page_up(app),
+        Msg::MemoryDriftTabNext => memory::handle_drift_tab_next(app),
+        Msg::MemoryDriftTabPrev => memory::handle_drift_tab_prev(app),
         Msg::MemoryFactsLoaded { facts, total } => memory::handle_facts_loaded(app, facts, total),
         Msg::MemoryDetailLoaded(detail) => memory::handle_detail_loaded(app, *detail),
         // NOTE: memory data variants handled in memory inspector view

--- a/crates/theatron/tui/src/update/view_nav.rs
+++ b/crates/theatron/tui/src/update/view_nav.rs
@@ -84,8 +84,8 @@ pub(crate) fn handle_drill_in(app: &mut App) {
         View::MessageDetail { .. }
         | View::MemoryInspector
         | View::FactDetail { .. }
-        | View::Metrics
-        | View::FileEditor => {}
+        | View::EntityDetail { .. }
+        | View::Metrics => {}
     }
 }
 

--- a/crates/theatron/tui/src/view/memory.rs
+++ b/crates/theatron/tui/src/view/memory.rs
@@ -10,8 +10,6 @@ const CONTENT_MIN_HEIGHT: u16 = 3;
 const STATUS_BAR_HEIGHT: u16 = 1;
 /// Column width reserved for confidence, tier, and type columns in the facts table.
 const RESERVED_COLUMN_WIDTH: u16 = 28;
-/// Maximum number of relationships shown in the graph view before truncating.
-const RELATIONSHIP_DISPLAY_LIMIT: usize = 20;
 /// Maximum content length for similar-fact snippets shown in the detail view.
 const SIMILAR_FACT_TRUNCATE_LEN: usize = 60;
 /// Column width for the fact type field in the facts table.
@@ -49,6 +47,7 @@ pub(crate) fn render_inspector(app: &App, frame: &mut Frame, area: Rect, theme: 
     match app.layout.memory.tab {
         MemoryTab::Facts => render_facts_table(app, frame, layout[1], theme),
         MemoryTab::Graph => render_graph_view(app, frame, layout[1], theme),
+        MemoryTab::Drift => render_drift_view(app, frame, layout[1], theme),
         MemoryTab::Timeline => render_timeline_view(app, frame, layout[1], theme),
     }
 
@@ -232,7 +231,12 @@ pub(crate) fn render_fact_detail(app: &App, frame: &mut Frame, area: Rect, theme
 }
 
 fn render_tab_bar(app: &App, frame: &mut Frame, area: Rect, theme: &Theme) {
-    let tabs = [MemoryTab::Facts, MemoryTab::Graph, MemoryTab::Timeline];
+    let tabs = [
+        MemoryTab::Facts,
+        MemoryTab::Graph,
+        MemoryTab::Drift,
+        MemoryTab::Timeline,
+    ];
     let mut spans: Vec<Span> = vec![Span::raw(" ")];
 
     for (i, tab) in tabs.iter().enumerate() {
@@ -401,97 +405,423 @@ fn render_facts_table(app: &App, frame: &mut Frame, area: Rect, theme: &Theme) {
     frame.render_widget(paragraph, area);
 }
 
-fn render_graph_view(app: &App, frame: &mut Frame, area: Rect, theme: &Theme) {
-    let mut lines: Vec<Line> = Vec::new();
-    lines.push(Line::raw(""));
+/// Height of the health bar in the graph view.
+const HEALTH_BAR_HEIGHT: u16 = 2;
 
-    if app.layout.memory.graph.entities.is_empty() {
-        lines.push(Line::from(vec![
-            Span::raw("  "),
-            Span::styled(
-                "Entity Graph",
-                theme.style_accent().add_modifier(Modifier::BOLD),
-            ),
-        ]));
-        lines.push(Line::raw(""));
+#[expect(
+    clippy::indexing_slicing,
+    reason = "Layout.split() returns exactly as many Rects as constraints; indices match"
+)]
+fn render_graph_view(app: &App, frame: &mut Frame, area: Rect, theme: &Theme) {
+    let layout = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Length(HEALTH_BAR_HEIGHT), Constraint::Min(3)])
+        .split(area);
+
+    render_health_bar(app, frame, layout[0], theme);
+    render_entity_list(app, frame, layout[1], theme);
+}
+
+fn render_health_bar(app: &App, frame: &mut Frame, area: Rect, theme: &Theme) {
+    let h = &app.layout.memory.graph.health;
+    let spans = vec![
+        Span::raw(" "),
+        Span::styled(format!("{}", h.total_entities), theme.style_accent()),
+        Span::styled(" entities  ", theme.style_dim()),
+        Span::styled(format!("{}", h.total_relationships), theme.style_accent()),
+        Span::styled(" rels  ", theme.style_dim()),
+        Span::styled(
+            format!("{}", h.orphan_count),
+            if h.orphan_count > 0 {
+                theme.style_warning()
+            } else {
+                theme.style_success()
+            },
+        ),
+        Span::styled(" orphans  ", theme.style_dim()),
+        Span::styled(
+            format!("{}", h.stale_count),
+            if h.stale_count > 0 {
+                theme.style_warning()
+            } else {
+                theme.style_success()
+            },
+        ),
+        Span::styled(" stale  ", theme.style_dim()),
+        Span::styled(format!("{:.1}", h.avg_cluster_size), theme.style_accent()),
+        Span::styled(" avg/cluster  ", theme.style_dim()),
+        Span::styled(format!("{}", h.community_count), theme.style_accent()),
+        Span::styled(" communities  ", theme.style_dim()),
+        Span::styled(
+            format!("{}", h.isolated_cluster_count),
+            if h.isolated_cluster_count > 0 {
+                theme.style_warning()
+            } else {
+                theme.style_success()
+            },
+        ),
+        Span::styled(" isolated", theme.style_dim()),
+    ];
+    let line = Line::from(spans);
+    let paragraph = Paragraph::new(vec![line, Line::raw("")]);
+    frame.render_widget(paragraph, area);
+}
+
+#[expect(
+    clippy::indexing_slicing,
+    reason = "end = min(start + height, len) ensures valid slice range"
+)]
+fn render_entity_list(app: &App, frame: &mut Frame, area: Rect, theme: &Theme) {
+    let mut lines: Vec<Line> = Vec::new();
+
+    if app.layout.memory.graph.entity_stats.is_empty() {
         lines.push(Line::from(vec![
             Span::raw("  "),
             Span::styled("No entities loaded.", theme.style_dim()),
         ]));
-        lines.push(Line::from(vec![
-            Span::raw("  "),
-            Span::styled(
-                "Entities are loaded from the knowledge API.",
-                theme.style_dim(),
-            ),
-        ]));
     } else {
+        let header_style = theme.style_dim().add_modifier(Modifier::BOLD);
         lines.push(Line::from(vec![
-            Span::raw("  "),
+            Span::styled("  ", Style::default()),
+            Span::styled("Name              ", header_style),
+            Span::styled("Type       ", header_style),
+            Span::styled("Rels  ", header_style),
+            Span::styled("PR     ", header_style),
+            Span::styled("Community", header_style),
+        ]));
+
+        let visible_height = usize::from(area.height.saturating_sub(1));
+        let start = app.layout.memory.graph.entity_scroll_offset;
+        let end = (start + visible_height).min(app.layout.memory.graph.entity_stats.len());
+
+        for (offset, stat) in app.layout.memory.graph.entity_stats[start..end]
+            .iter()
+            .enumerate()
+        {
+            let idx = start + offset;
+            let is_selected = idx == app.layout.memory.graph.selected_entity;
+            let marker = if is_selected { "▸ " } else { "  " };
+            let marker_style = if is_selected {
+                Style::default().fg(theme.borders.selected)
+            } else {
+                Style::default()
+            };
+
+            let name = truncate(&stat.entity.name, 16);
+            let name_style = if is_selected {
+                theme.style_accent().add_modifier(Modifier::BOLD)
+            } else {
+                theme.style_accent()
+            };
+
+            let entity_type = truncate(&stat.entity.entity_type, 9);
+            let community_label = stat
+                .community_id
+                .map(|c| format!("#{c}"))
+                .unwrap_or_else(|| "---".into());
+
+            let rel_style = if stat.relationship_count == 0 {
+                theme.style_error()
+            } else {
+                theme.style_fg()
+            };
+
+            lines.push(Line::from(vec![
+                Span::styled(marker, marker_style),
+                Span::styled(format!("{name:<16}  "), name_style),
+                Span::styled(format!("{entity_type:<9}  "), theme.style_dim()),
+                Span::styled(format!("{:<4}  ", stat.relationship_count), rel_style),
+                Span::styled(format!("{:<5.2}  ", stat.pagerank), theme.style_fg()),
+                Span::styled(community_label, theme.style_muted()),
+            ]));
+        }
+    }
+
+    let block = Block::default().borders(Borders::NONE);
+    let paragraph = Paragraph::new(lines).block(block);
+    frame.render_widget(paragraph, area);
+}
+
+fn render_drift_view(app: &App, frame: &mut Frame, area: Rect, theme: &Theme) {
+    let mut lines: Vec<Line> = Vec::new();
+
+    // WHY: drift sub-tab bar
+    let drift_tabs = [
+        crate::state::memory::DriftTab::Suggestions,
+        crate::state::memory::DriftTab::Orphans,
+        crate::state::memory::DriftTab::Stale,
+        crate::state::memory::DriftTab::Isolated,
+    ];
+    let mut tab_spans: Vec<Span> = vec![Span::raw(" ")];
+    for (i, tab) in drift_tabs.iter().enumerate() {
+        if i > 0 {
+            tab_spans.push(Span::styled(" │ ", theme.style_dim()));
+        }
+        let style = if *tab == app.layout.memory.graph.drift_tab {
+            theme.style_accent().add_modifier(Modifier::BOLD)
+        } else {
+            theme.style_dim()
+        };
+        tab_spans.push(Span::styled(tab.label(), style));
+    }
+    tab_spans.push(Span::styled("   [/] cycle", theme.style_muted()));
+    lines.push(Line::from(tab_spans));
+    lines.push(Line::raw(""));
+
+    match app.layout.memory.graph.drift_tab {
+        crate::state::memory::DriftTab::Suggestions => {
+            if app.layout.memory.graph.drift_suggestions.is_empty() {
+                lines.push(Line::from(vec![
+                    Span::raw("  "),
+                    Span::styled("No drift suggestions.", theme.style_dim()),
+                ]));
+            } else {
+                for (i, s) in app.layout.memory.graph.drift_suggestions.iter().enumerate() {
+                    let is_selected = i == app.layout.memory.graph.drift_selected;
+                    let marker = if is_selected { "▸ " } else { "  " };
+                    let action_style = match s.action.as_str() {
+                        "delete" => theme.style_error(),
+                        "merge" => theme.style_warning(),
+                        _ => theme.style_accent(),
+                    };
+                    lines.push(Line::from(vec![
+                        Span::styled(
+                            marker,
+                            if is_selected {
+                                Style::default().fg(theme.borders.selected)
+                            } else {
+                                Style::default()
+                            },
+                        ),
+                        Span::styled(format!("{:<7}", s.action), action_style),
+                        Span::styled(&s.entity_name, theme.style_fg()),
+                        Span::styled(format!(" — {}", s.reason), theme.style_dim()),
+                    ]));
+                }
+            }
+        }
+        crate::state::memory::DriftTab::Orphans => {
+            if app.layout.memory.graph.orphaned_entities.is_empty() {
+                lines.push(Line::from(vec![
+                    Span::raw("  "),
+                    Span::styled("No orphaned entities.", theme.style_success()),
+                ]));
+            } else {
+                for (i, name) in app.layout.memory.graph.orphaned_entities.iter().enumerate() {
+                    let is_selected = i == app.layout.memory.graph.drift_selected;
+                    let marker = if is_selected { "▸ " } else { "  " };
+                    lines.push(Line::from(vec![
+                        Span::styled(
+                            marker,
+                            if is_selected {
+                                Style::default().fg(theme.borders.selected)
+                            } else {
+                                Style::default()
+                            },
+                        ),
+                        Span::styled(name.as_str(), theme.style_warning()),
+                        Span::styled("  0 rels", theme.style_dim()),
+                    ]));
+                }
+            }
+        }
+        crate::state::memory::DriftTab::Stale => {
+            if app.layout.memory.graph.stale_entities.is_empty() {
+                lines.push(Line::from(vec![
+                    Span::raw("  "),
+                    Span::styled("No stale entities.", theme.style_success()),
+                ]));
+            } else {
+                for (i, name) in app.layout.memory.graph.stale_entities.iter().enumerate() {
+                    let is_selected = i == app.layout.memory.graph.drift_selected;
+                    let marker = if is_selected { "▸ " } else { "  " };
+                    lines.push(Line::from(vec![
+                        Span::styled(
+                            marker,
+                            if is_selected {
+                                Style::default().fg(theme.borders.selected)
+                            } else {
+                                Style::default()
+                            },
+                        ),
+                        Span::styled(name.as_str(), theme.style_warning()),
+                        Span::styled("  >30d since update", theme.style_dim()),
+                    ]));
+                }
+            }
+        }
+        crate::state::memory::DriftTab::Isolated => {
+            if app.layout.memory.graph.isolated_clusters.is_empty() {
+                lines.push(Line::from(vec![
+                    Span::raw("  "),
+                    Span::styled("No isolated clusters.", theme.style_success()),
+                ]));
+            } else {
+                for (i, cluster) in app.layout.memory.graph.isolated_clusters.iter().enumerate() {
+                    let is_selected = i == app.layout.memory.graph.drift_selected;
+                    let marker = if is_selected { "▸ " } else { "  " };
+                    let members = cluster.entity_names.join(", ");
+                    lines.push(Line::from(vec![
+                        Span::styled(
+                            marker,
+                            if is_selected {
+                                Style::default().fg(theme.borders.selected)
+                            } else {
+                                Style::default()
+                            },
+                        ),
+                        Span::styled(format!("{{{members}}}"), theme.style_warning()),
+                        Span::styled(format!("  {} entities", cluster.size), theme.style_dim()),
+                    ]));
+                }
+            }
+        }
+    }
+
+    let block = Block::default().borders(Borders::NONE);
+    let paragraph = Paragraph::new(lines)
+        .block(block)
+        .wrap(Wrap { trim: false });
+    frame.render_widget(paragraph, area);
+}
+
+/// Render the entity detail view (node card).
+pub(crate) fn render_entity_detail(app: &App, frame: &mut Frame, area: Rect, theme: &Theme) {
+    let mut lines: Vec<Line> = Vec::new();
+    lines.push(Line::raw(""));
+
+    if let Some(ref card) = app.layout.memory.graph.node_card {
+        lines.push(Line::from(vec![
+            Span::raw(" "),
             Span::styled(
-                format!(
-                    "Entity Graph ({} entities)",
-                    app.layout.memory.graph.entities.len()
-                ),
+                "Entity Detail",
                 theme.style_accent().add_modifier(Modifier::BOLD),
             ),
         ]));
         lines.push(Line::raw(""));
 
-        for (i, entity) in app.layout.memory.graph.entities.iter().enumerate() {
-            let is_selected = i == app.layout.memory.fact_list.selected;
-            let marker = if is_selected { "▸ " } else { "  " };
+        lines.push(meta_line(theme, "Name", &card.entity.name));
+        lines.push(meta_line(theme, "Type", &card.entity.entity_type));
+        if !card.entity.aliases.is_empty() {
+            lines.push(meta_line(theme, "Aliases", &card.entity.aliases.join(", ")));
+        }
+        lines.push(meta_line(
+            theme,
+            "Created",
+            &MemoryInspectorState::relative_time(&card.entity.created_at),
+        ));
+        lines.push(meta_line(
+            theme,
+            "Updated",
+            &MemoryInspectorState::relative_time(&card.entity.updated_at),
+        ));
+        lines.push(meta_line(
+            theme,
+            "PageRank",
+            &format!("{:.4}", card.pagerank),
+        ));
+        lines.push(meta_line(
+            theme,
+            "Community",
+            &card
+                .community_id
+                .map(|c| format!("#{c}"))
+                .unwrap_or_else(|| "none".into()),
+        ));
 
-            let rel_count = app
-                .layout
-                .memory
-                .graph
-                .relationships
+        if !card.relationships_grouped.is_empty() {
+            lines.push(Line::raw(""));
+            let total_rels: usize = card
+                .relationships_grouped
                 .iter()
-                .filter(|r| r.src == entity.id || r.dst == entity.id)
-                .count();
-
+                .map(|(_, v)| v.len())
+                .sum();
             lines.push(Line::from(vec![
+                Span::raw("  "),
                 Span::styled(
-                    marker,
-                    if is_selected {
-                        Style::default().fg(theme.borders.selected)
-                    } else {
-                        Style::default()
-                    },
+                    format!("Relationships ({total_rels}):"),
+                    theme.style_fg().add_modifier(Modifier::BOLD),
                 ),
-                Span::styled(&entity.name, theme.style_accent()),
-                Span::styled(format!(" ({})", entity.entity_type), theme.style_dim()),
-                Span::styled(format!("  {rel_count} rels"), theme.style_muted()),
             ]));
+
+            for (rel_type, rels) in &card.relationships_grouped {
+                lines.push(Line::from(vec![
+                    Span::raw("    "),
+                    Span::styled(rel_type.as_str(), theme.style_accent()),
+                    Span::styled(format!(" ({})", rels.len()), theme.style_dim()),
+                ]));
+                for rel in rels.iter().take(5) {
+                    let other = if rel.src == card.entity.id {
+                        &rel.dst
+                    } else {
+                        &rel.src
+                    };
+                    let direction = if rel.src == card.entity.id {
+                        " ─▸ "
+                    } else {
+                        " ◂─ "
+                    };
+                    lines.push(Line::from(vec![
+                        Span::raw("      "),
+                        Span::styled(direction, theme.style_dim()),
+                        Span::styled(other.as_str(), theme.style_fg()),
+                    ]));
+                }
+                if rels.len() > 5 {
+                    lines.push(Line::from(vec![
+                        Span::raw("      "),
+                        Span::styled(
+                            format!("  ... and {} more", rels.len() - 5),
+                            theme.style_muted(),
+                        ),
+                    ]));
+                }
+            }
         }
 
-        if !app.layout.memory.graph.relationships.is_empty() {
+        if !card.related_facts.is_empty() {
             lines.push(Line::raw(""));
             lines.push(Line::from(vec![
                 Span::raw("  "),
                 Span::styled(
-                    "Relationships:",
+                    format!("Related Facts ({}):", card.related_facts.len()),
                     theme.style_fg().add_modifier(Modifier::BOLD),
                 ),
             ]));
-            for rel in app
-                .layout
-                .memory
-                .graph
-                .relationships
-                .iter()
-                .take(RELATIONSHIP_DISPLAY_LIMIT)
-            {
+            for fact in &card.related_facts {
+                let tier_abbr = MemoryInspectorState::tier_abbrev(&fact.tier);
+                let content = truncate(&fact.content.replace('\n', " "), SIMILAR_FACT_TRUNCATE_LEN);
                 lines.push(Line::from(vec![
                     Span::raw("    "),
-                    Span::styled(&rel.src, theme.style_accent()),
-                    Span::styled(format!(" ─{}─▸ ", rel.relation), theme.style_dim()),
-                    Span::styled(&rel.dst, theme.style_accent()),
+                    Span::styled(
+                        format!("{:.0}%", fact.confidence * 100.0),
+                        confidence_style(theme, fact.confidence),
+                    ),
+                    Span::raw("  "),
+                    Span::styled(tier_abbr, tier_style(theme, &fact.tier)),
+                    Span::raw("  "),
+                    Span::styled(content, theme.style_fg()),
                 ]));
             }
         }
+    } else if app.layout.memory.loading {
+        lines.push(Line::from(vec![
+            Span::raw("  "),
+            Span::styled("Loading entity detail...", theme.style_dim()),
+        ]));
+    } else {
+        lines.push(Line::from(vec![
+            Span::raw("  "),
+            Span::styled("No entity data available.", theme.style_dim()),
+        ]));
     }
+
+    lines.push(Line::raw(""));
+    lines.push(Line::from(vec![
+        Span::raw("  "),
+        Span::styled("Esc", theme.style_accent()),
+        Span::styled(" back", theme.style_dim()),
+    ]));
 
     let block = Block::default().borders(Borders::NONE);
     let paragraph = Paragraph::new(lines)

--- a/crates/theatron/tui/src/view/views.rs
+++ b/crates/theatron/tui/src/view/views.rs
@@ -287,6 +287,10 @@ pub(crate) fn render_for_view(
             super::memory::render_fact_detail(app, frame, area, theme);
             Vec::new()
         }
+        View::EntityDetail { .. } => {
+            super::memory::render_entity_detail(app, frame, area, theme);
+            Vec::new()
+        }
         View::Metrics => {
             super::metrics::render(app, frame, area, theme);
             Vec::new()

--- a/docs/design/graph-3d.md
+++ b/docs/design/graph-3d.md
@@ -1,0 +1,144 @@
+# 3D Force-Directed Knowledge Graph
+
+Architecture for the Dioxus desktop 3D graph visualization.
+
+## Scope
+
+The 3D force-directed graph is a Dioxus desktop app feature, not a TUI feature. The TUI provides text/table-based entity browsing; the desktop app provides spatial graph exploration.
+
+## Architecture
+
+```
+┌──────────────────────────────────────────────────────────┐
+│  Dioxus Desktop App (theatron/desktop)                   │
+│                                                          │
+│  ┌──────────────┐   ┌──────────────┐   ┌──────────────┐ │
+│  │ Graph3DView  │   │ ForceEngine  │   │ WgpuRenderer │ │
+│  │  (Dioxus     │──▸│  (sim loop)  │──▸│  (GPU draw)  │ │
+│  │   component) │   │              │   │              │ │
+│  └──────┬───────┘   └──────────────┘   └──────────────┘ │
+│         │                                                │
+│  ┌──────▼───────┐   ┌──────────────┐                    │
+│  │ GraphState   │◂──│ ApiClient    │                    │
+│  │  (entities,  │   │  (REST fetch │                    │
+│  │   relations, │   │   entities,  │                    │
+│  │   scores)    │   │   relations) │                    │
+│  └──────────────┘   └──────────────┘                    │
+└──────────────────────────────────────────────────────────┘
+```
+
+### Data flow
+
+1. `ApiClient` fetches entities, relationships, and graph scores from the backend API
+2. `GraphState` holds the graph topology, PageRank scores, and Louvain community assignments
+3. `ForceEngine` runs a force-directed layout simulation each frame
+4. `WgpuRenderer` draws nodes, edges, labels, and community clouds to a GPU surface
+5. `Graph3DView` Dioxus component owns the render surface, handles input events (pan, zoom, rotate, select)
+
+## Force simulation
+
+The simulation applies four forces per tick:
+
+| Force | Purpose | Parameters |
+|-------|---------|------------|
+| Repulsion | Prevent node overlap | Coulomb constant, min distance |
+| Attraction | Pull connected nodes together | Spring constant per edge weight |
+| Centering | Keep the graph centered in view | Strength toward origin |
+| Damping | Converge to stable layout | Velocity decay factor |
+
+Nodes have mass proportional to their PageRank score. Higher-PageRank nodes resist movement and attract neighbors more strongly.
+
+### Tick budget
+
+Target 60fps. The simulation runs on a background thread, producing position snapshots that the renderer consumes. If a tick exceeds 2ms, reduce iteration count or switch to Barnes-Hut approximation for repulsion (O(n log n) instead of O(n^2)).
+
+## Visual encoding
+
+### Nodes
+
+- **Size**: proportional to PageRank (min 4px, max 24px)
+- **Color**: mapped to entity type (person, tool, project, concept, etc.)
+- **Label**: entity name, rendered as billboard sprites facing the camera
+- **Selection**: highlighted outline, expanded info card on click
+
+### Edges
+
+- **Width**: proportional to relationship weight
+- **Color**: mapped to relationship type
+- **Direction**: arrowhead at destination end
+- **Label**: relationship type on hover
+
+### Communities
+
+- **Semi-transparent spheres** enclose each Louvain community cluster
+- Sphere radius = bounding radius of member nodes + padding
+- Sphere color = community color (generated from community ID via golden-angle hue spacing)
+- Opacity: 0.1 base, 0.3 when any member node is hovered
+
+### Z-axis
+
+- Primary layout is XY (force-directed)
+- Z-axis encodes temporal depth: recently-updated entities float higher, stale entities sink
+- Z range is compressed (max 20% of XY extent) to prevent visual flattening
+
+## Camera
+
+- **Default position**: elevated 45-degree angle looking at graph centroid
+- **Navigation**: orbit (left drag), pan (right drag), zoom (scroll wheel)
+- **Focus**: double-click entity to animate camera to face it, with depth-of-field blur on background
+- **Reset**: keyboard shortcut to return to default view
+
+## Rust crate candidates
+
+| three.js concept | Rust replacement | Notes |
+|-------------------|------------------|-------|
+| three.js renderer | `wgpu` | Low-level GPU abstraction, cross-platform |
+| Scene graph | `bevy_ecs` or custom | ECS for node/edge/label entities |
+| 3d-force-graph | Custom Rust impl | Port the force simulation; ~200 lines |
+| OrbitControls | `dolly` or custom | Camera rig with orbit/pan/zoom |
+| CSS2DRenderer (labels) | `wgpu` billboard quads | Render text to texture atlas, draw as quads |
+| TransformControls | `egui` overlay | For debug/inspector UI |
+| Stats.js | `tracing` + `egui` | Frame time overlay |
+
+### Alternative: bevy_egui stack
+
+For faster iteration, the graph could use `bevy` with `bevy_egui` for UI overlay:
+
+- `bevy` handles the render loop, scene graph, and camera
+- `bevy_egui` provides immediate-mode UI panels for entity inspection
+- Custom `bevy` systems implement the force simulation
+- `bevy_mod_picking` handles ray-cast entity selection
+
+Trade-off: larger binary and dependency surface, but faster time-to-interactive.
+
+## Integration with theatron/desktop
+
+The desktop app (Dioxus) embeds the graph as a custom element:
+
+1. Dioxus component creates a `wgpu::Surface` from the window handle
+2. Graph renderer runs on its own thread, receives state updates via channel
+3. Mouse/keyboard events flow from Dioxus to the graph via event channel
+4. Selection events flow back: user selects entity in graph, desktop app shows detail panel
+
+The graph component is a leaf in the Dioxus component tree. It does not use Dioxus virtual DOM for rendering; it directly owns a GPU surface.
+
+## Performance targets
+
+| Metric | Target |
+|--------|--------|
+| Entities | 10,000 nodes without frame drops |
+| Edges | 50,000 edges with LOD culling |
+| Frame rate | 60fps on integrated GPU |
+| Initial layout convergence | <2s for 1,000 nodes |
+| Memory | <100MB for 10k node graph |
+
+For graphs exceeding 10k nodes, implement level-of-detail: collapse distant communities into single super-nodes, expand on zoom.
+
+## Phased delivery
+
+| Phase | Scope |
+|-------|-------|
+| 1 | 2D force layout in a Dioxus canvas element (no GPU) |
+| 2 | wgpu renderer with 3D positioning and basic camera |
+| 3 | Community spheres, z-axis temporal encoding |
+| 4 | Performance: Barnes-Hut, LOD, instanced rendering |


### PR DESCRIPTION
## Summary

- **TUI knowledge graph visualization (#1854)**: Graph summary view with entity list (relationship counts, community membership, PageRank scores), drift panel (4 tabs: suggestions, orphans, stale, isolated), node card (entity detail with grouped relationships and related facts), health bar (aggregate graph metrics), and full entity navigation via view stack
- **3D graph architecture document (#1864)**: `docs/design/graph-3d.md` covering Dioxus desktop app architecture — force simulation, wgpu rendering, visual encoding, camera controls, Rust crate candidates, performance targets, and phased delivery

## Changes

- **State**: `MemoryTab::Drift`, `DriftTab` enum, `GraphEntityStat`, `GraphHealthMetrics`, `GraphNodeCard`, `DriftSuggestion`, `IsolatedCluster` types; extended `MemoryGraphState` with graph stats, drift data, selection, and node card
- **View stack**: `View::EntityDetail` variant for node card navigation
- **API client**: `knowledge_entities()`, `knowledge_entity_relationships()`, `knowledge_timeline()` methods
- **Update**: PageRank computation (iterative, 20 iterations, damping 0.85), Union-Find community detection, drift analysis (orphans, stale, merge candidates, isolated clusters), node card builder
- **View**: Health bar, entity list table, drift sub-tab rendering, entity detail card
- **Keybindings**: `]`/`[` for drift tab cycling, Enter/Esc for entity drill-in/pop-back

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy -p theatron-core -p theatron-tui --all-targets -- -D warnings` passes (0 warnings)
- [x] `cargo test -p theatron-core -p theatron-tui` passes (949 + 83 tests)
- [x] Updated existing `handle_tab_next_cycles` test for new Drift tab