### PR TITLE
fix(organon,episteme,koina): resolve expect_used and as_conversions lint violations

### DIFF
--- a/crates/episteme/src/consolidation/engine.rs
+++ b/crates/episteme/src/consolidation/engine.rs
@@ -2,11 +2,6 @@
 //!
 //! Implements consolidation operations on `KnowledgeStore`: candidate
 //! identification, LLM-driven consolidation execution, and audit trail.
-#![expect(
-    clippy::as_conversions,
-    reason = "knowledge engine: ported codebase with numeric casts and direct indexing throughout"
-)]
-
 use std::collections::BTreeMap;
 use tracing::instrument;
 
@@ -515,6 +510,7 @@ impl KnowledgeStore {
             if let Ok(span) = now.since(last_ts) {
                 let total_minutes = i64::from(span.get_hours()) * 60 + span.get_minutes();
                 #[expect(
+                    clippy::as_conversions,
                     clippy::cast_precision_loss,
                     reason = "total_minutes is an elapsed time value; precision loss is acceptable for rate-limit comparison"
                 )]

--- a/crates/episteme/src/dedup.rs
+++ b/crates/episteme/src/dedup.rs
@@ -18,7 +18,6 @@
     any(feature = "mneme-engine", test),
     expect(
         clippy::as_conversions,
-        clippy::cast_precision_loss,
         clippy::indexing_slicing,
         reason = "knowledge engine: ported codebase with numeric casts and direct indexing throughout"
     )

--- a/crates/episteme/src/embedding.rs
+++ b/crates/episteme/src/embedding.rs
@@ -98,11 +98,6 @@ impl EmbeddingProvider for MockEmbeddingProvider {
         for &b in bytes {
             hash = hash.wrapping_mul(33).wrapping_add(u64::from(b));
         }
-        #[expect(
-            clippy::as_conversions,
-            clippy::cast_precision_loss,
-            reason = "mock embedding: usize→u64 and u64→f32 for deterministic hash; values bounded by dim and modulo"
-        )]
         for (i, v) in vec.iter_mut().enumerate() {
             #[expect(
                 clippy::as_conversions,

--- a/crates/episteme/src/graph_intelligence.rs
+++ b/crates/episteme/src/graph_intelligence.rs
@@ -6,13 +6,7 @@
 //! - Enhanced scoring functions that augment epistemic tier, relationship proximity, and access frequency
 //! - Background recomputation of `PageRank` + `Louvain` stored in `graph_scores`
 //! - Cache invalidation via [`GraphDirtyFlag`](crate::graph_intelligence::GraphDirtyFlag)
-#![cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "module internals; only exercised by crate-level tests"
-    )
-)]
+#![cfg_attr(not(test), allow(dead_code))]
 #![cfg_attr(
     feature = "mneme-engine",
     expect(
@@ -30,7 +24,7 @@ use snafu::ResultExt;
 ///
 /// Caches `PageRank` scores, community (cluster) assignments, and the `PageRank` max
 /// meta-entry. Updated by background recomputation.
-#[expect(dead_code, reason = "reserved for future graph intelligence queries")]
+#[allow(dead_code)]
 pub(crate) const GRAPH_SCORES_DDL: &str = r":create graph_scores {
     entity_id: String, score_type: String =>
     score: Float default 0.0, cluster_id: Int default -1, updated_at: String
@@ -135,7 +129,7 @@ pub(crate) fn score_access_with_evolution(base_access_score: f64, chain_length: 
 /// and stores results into `graph_scores`.
 ///
 /// Parameters: `$now` (ISO 8601 timestamp string).
-#[expect(dead_code, reason = "reserved for future graph intelligence queries")]
+#[allow(dead_code)]
 pub(crate) const RECOMPUTE_GRAPH_SCORES: &str = r"
 edges[src, dst] := *relationships{src, dst}
 edges_w[src, dst, weight] := *relationships{src, dst, weight}
@@ -162,7 +156,7 @@ comm[labels, entity_id] <~ CommunityDetectionLouvain(edges_w[])
 ";
 
 /// Datalog script to load all graph scores into memory.
-#[expect(dead_code, reason = "reserved for future graph intelligence queries")]
+#[allow(dead_code)]
 pub(crate) const LOAD_GRAPH_SCORES: &str = r"
 ?[entity_id, score_type, score, cluster_id] :=
     *graph_scores{entity_id, score_type, score, cluster_id}
@@ -174,7 +168,7 @@ pub(crate) const LOAD_GRAPH_SCORES: &str = r"
 /// Parameters: `$seeds` (list of entity IDs).
 ///
 /// Returns rows of `[entity_id, hops]`.
-#[expect(dead_code, reason = "reserved for future graph intelligence queries")]
+#[allow(dead_code)]
 pub(crate) const BFS_PROXIMITY_4HOP: &str = r"
 seed[id] := id in $seeds
 
@@ -194,7 +188,7 @@ hop4[dst, h] := hop3[src, _], *relationships{src, dst}, not hop0[dst, _], not ho
 /// Datalog script for computing supersession chain lengths.
 ///
 /// Counts how many predecessors each fact has in its supersession chain.
-#[expect(dead_code, reason = "reserved for future graph intelligence queries")]
+#[allow(dead_code)]
 pub(crate) const SUPERSESSION_CHAIN_LENGTHS: &str = r"
 chain[id, d] := *facts{id, superseded_by}, is_null(superseded_by), d = 0
 chain[id, n] := *facts{id, superseded_by}, superseded_by = next_id, not is_null(next_id),

--- a/crates/episteme/src/hnsw_index.rs
+++ b/crates/episteme/src/hnsw_index.rs
@@ -4,11 +4,6 @@
 //! Persistence is handled via `hnsw_rs` built-in `file_dump()` / `HnswIo::load_hnsw()`.
 //!
 //! This module is feature-gated behind `hnsw_rs`.
-#![expect(
-    clippy::expect_used,
-    reason = "RwLock::read panics only on poison — unrecoverable"
-)]
-
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::RwLock;

--- a/crates/episteme/src/knowledge_store/marshal.rs
+++ b/crates/episteme/src/knowledge_store/marshal.rs
@@ -1,10 +1,6 @@
 #![expect(
-    clippy::as_conversions,
-    clippy::cast_precision_loss,
-    clippy::cast_sign_loss,
-    clippy::cast_possible_truncation,
     clippy::indexing_slicing,
-    reason = "knowledge engine: ported codebase with numeric casts and direct indexing throughout"
+    reason = "knowledge engine: ported codebase with direct indexing throughout"
 )]
 use snafu::ResultExt;
 #[cfg(feature = "mneme-engine")]
@@ -187,6 +183,7 @@ pub(super) fn embedding_to_params(
 /// Returns 1.0 for identical sets, 0.0 for disjoint.
 #[cfg(feature = "mneme-engine")]
 #[expect(
+    clippy::as_conversions,
     clippy::cast_precision_loss,
     reason = "tool set sizes are small; precision loss is impossible in practice"
 )]
@@ -208,6 +205,11 @@ pub(super) fn compute_tool_overlap(a: &[String], b: &[String]) -> f64 {
 ///
 /// Returns 1.0 for identical names, 0.0 for completely different.
 #[cfg(feature = "mneme-engine")]
+#[expect(
+    clippy::as_conversions,
+    clippy::cast_precision_loss,
+    reason = "string lengths are small; precision loss is impossible in practice"
+)]
 pub(super) fn compute_name_similarity(a: &str, b: &str) -> f64 {
     if a == b {
         return 1.0;
@@ -318,7 +320,8 @@ pub(super) fn rows_to_facts(
 
         let tier = parse_epistemic_tier(&tier_str);
 
-        let access_count = row.get(10).and_then(|v| extract_int(v).ok()).unwrap_or(0) as u32; // SAFETY: access count fits u32
+        let access_count =
+            u32::try_from(row.get(10).and_then(|v| extract_int(v).ok()).unwrap_or(0)).unwrap_or(0);
         let last_accessed_at = row
             .get(11)
             .and_then(|v| extract_str(v).ok())
@@ -460,7 +463,8 @@ pub(super) fn rows_to_raw_facts(
             .build()
         })?)?;
         let tier = parse_epistemic_tier(&tier_str);
-        let access_count = row.get(10).and_then(|v| extract_int(v).ok()).unwrap_or(0) as u32; // SAFETY: access count fits u32
+        let access_count =
+            u32::try_from(row.get(10).and_then(|v| extract_int(v).ok()).unwrap_or(0)).unwrap_or(0);
         let last_accessed_at = row
             .get(11)
             .and_then(|v| extract_str(v).ok())

--- a/crates/episteme/src/knowledge_store/search.rs
+++ b/crates/episteme/src/knowledge_store/search.rs
@@ -1,7 +1,3 @@
-#![expect(
-    clippy::as_conversions,
-    reason = "knowledge engine: ported codebase with numeric casts and direct indexing throughout"
-)]
 use snafu::ResultExt;
 
 use super::marshal::{
@@ -279,6 +275,7 @@ impl KnowledgeStore {
     /// Takes the top entity IDs from existing results, queries their neighborhoods,
     /// and returns related facts as additional results.
     #[expect(
+        clippy::as_conversions,
         clippy::cast_precision_loss,
         reason = "rank indices fit in f64 mantissa"
     )]

--- a/crates/episteme/src/knowledge_store/skills.rs
+++ b/crates/episteme/src/knowledge_store/skills.rs
@@ -1,8 +1,3 @@
-#![expect(
-    clippy::as_conversions,
-    clippy::cast_precision_loss,
-    reason = "knowledge engine: numeric casts for elapsed-time and count calculations; values fit f64"
-)]
 use snafu::ResultExt;
 use tracing::instrument;
 
@@ -274,7 +269,12 @@ impl KnowledgeStore {
                 .last_accessed_at
                 .unwrap_or(fact.temporal.valid_from)
                 .as_second();
-            let days = ((now_secs - reference_secs).max(0) as f64) / 86_400.0; // SAFETY: seconds fit f64
+            #[expect(
+                clippy::as_conversions,
+                clippy::cast_precision_loss,
+                reason = "elapsed seconds fit f64"
+            )]
+            let days = ((now_secs - reference_secs).max(0) as f64) / 86_400.0;
 
             let score = crate::skill::skill_decay_score(
                 days,
@@ -322,7 +322,12 @@ impl KnowledgeStore {
                 .last_accessed_at
                 .unwrap_or(fact.temporal.valid_from)
                 .as_second();
-            let days = ((now_secs - ref_secs).max(0) as f64) / 86_400.0; // SAFETY: seconds fit f64
+            #[expect(
+                clippy::as_conversions,
+                clippy::cast_precision_loss,
+                reason = "elapsed seconds fit f64"
+            )]
+            let days = ((now_secs - ref_secs).max(0) as f64) / 86_400.0;
             days_since_use.push(days);
 
             let score = crate::skill::skill_decay_score(
@@ -342,7 +347,14 @@ impl KnowledgeStore {
         }
 
         let avg_usage_count = if total_active > 0 {
-            usage_counts.iter().map(|&c| f64::from(c)).sum::<f64>() / total_active as f64 // SAFETY: skill count fits f64
+            #[expect(
+                clippy::as_conversions,
+                clippy::cast_precision_loss,
+                reason = "skill count fits f64"
+            )]
+            {
+                usage_counts.iter().map(|&c| f64::from(c)).sum::<f64>() / total_active as f64
+            }
         } else {
             0.0
         };

--- a/crates/episteme/src/skills/candidate.rs
+++ b/crates/episteme/src/skills/candidate.rs
@@ -15,10 +15,6 @@
 //!
 //! Two signatures are considered the *same pattern* when
 //! [`crate::skills::signature_similarity`] ≥ 0.8.
-#![expect(
-    clippy::expect_used,
-    reason = "Mutex::lock() panics only on poisoning (another thread panicked while holding the lock), which is a fatal programming error"
-)]
 #![cfg_attr(
     test,
     expect(
@@ -109,6 +105,7 @@ pub struct CandidateTracker {
 }
 
 impl std::fmt::Debug for CandidateTracker {
+    #[expect(clippy::expect_used, reason = "mutex poisoning is unrecoverable")]
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let guard = self.candidates.lock().expect("lock not poisoned");
         f.debug_struct("CandidateTracker")
@@ -137,6 +134,7 @@ impl CandidateTracker {
     /// Returns [`TrackResult::Rejected`] when the heuristic gates fail.
     /// Returns [`TrackResult::Promoted`] when the candidate's recurrence
     /// count reaches [`PROMOTION_THRESHOLD`].
+    #[expect(clippy::expect_used, reason = "mutex poisoning is unrecoverable")]
     pub fn track_sequence(
         &self,
         tool_calls: &[ToolCallRecord],
@@ -188,6 +186,7 @@ impl CandidateTracker {
     }
 
     /// Return all current candidates for a given nous.
+    #[expect(clippy::expect_used, reason = "mutex poisoning is unrecoverable")]
     pub fn candidates_for(&self, nous_id: &str) -> Vec<SkillCandidate> {
         let guard = self.candidates.lock().expect("lock not poisoned");
         guard
@@ -198,6 +197,7 @@ impl CandidateTracker {
     }
 
     /// Return all promoted candidates (`recurrence_count` ≥ threshold) for a nous.
+    #[expect(clippy::expect_used, reason = "mutex poisoning is unrecoverable")]
     pub fn promoted_for(&self, nous_id: &str) -> Vec<SkillCandidate> {
         let guard = self.candidates.lock().expect("lock not poisoned");
         guard
@@ -208,6 +208,7 @@ impl CandidateTracker {
     }
 
     /// Total number of tracked candidates (all nous IDs).
+    #[expect(clippy::expect_used, reason = "mutex poisoning is unrecoverable")]
     pub fn len(&self) -> usize {
         self.candidates.lock().expect("lock not poisoned").len()
     }

--- a/crates/episteme/src/succession.rs
+++ b/crates/episteme/src/succession.rs
@@ -15,13 +15,7 @@
 //! - Stable domain (volatility ≈ 0) → 1.5× base stability
 //! - Neutral (volatility = 0.5) → 1.0× (unchanged)
 //! - Volatile domain (volatility ≈ 1) → 0.5× base stability
-#![cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "module internals; only exercised by crate-level tests"
-    )
-)]
+#![cfg_attr(not(test), allow(dead_code))]
 
 use serde::{Deserialize, Serialize};
 
@@ -125,7 +119,7 @@ pub(crate) fn adaptive_stability(
 /// `[entity_id, total_facts, superseded_facts, avg_chain_length]`
 ///
 /// Run after `SUPERSESSION_CHAIN_LENGTHS`: uses the same `chain[]` recursion inline.
-#[expect(dead_code, reason = "reserved for future graph intelligence queries")]
+#[allow(dead_code)]
 pub(crate) const ENTITY_VOLATILITY_METRICS: &str = r"
 chain[id, d] := *facts{id, superseded_by}, is_null(superseded_by), d = 0
 chain[id, n] := *facts{id, superseded_by}, superseded_by = next_id, not is_null(next_id),
@@ -173,7 +167,7 @@ avg_cl[eid, mean(cl)] := entity_facts[eid, _, cl]
 /// Datalog script to store volatility scores in `graph_scores`.
 ///
 /// Parameters: `$entity_id`, `$volatility`, `$now` (ISO 8601 string).
-#[expect(dead_code, reason = "reserved for future graph intelligence queries")]
+#[allow(dead_code)]
 pub(crate) const STORE_VOLATILITY_SCORE: &str = r"
 ?[entity_id, score_type, score, cluster_id, updated_at] :=
     entity_id = $entity_id,
@@ -191,7 +185,7 @@ pub(crate) const STORE_VOLATILITY_SCORE: &str = r"
 /// entities associated with a given nous.
 ///
 /// Parameters: `$nous_id`.
-#[expect(dead_code, reason = "reserved for future graph intelligence queries")]
+#[allow(dead_code)]
 pub(crate) const NOUS_KNOWLEDGE_PROFILE: &str = r"
 active_facts[fid, eid] :=
     *fact_entities{fact_id: fid, entity_id: eid},
@@ -216,7 +210,7 @@ entity_stats[eid, count(fid), mean(stab)] :=
 /// Datalog script for counting total active facts per nous.
 ///
 /// Parameters: `$nous_id`.
-#[expect(dead_code, reason = "reserved for future graph intelligence queries")]
+#[allow(dead_code)]
 pub(crate) const NOUS_ACTIVE_FACT_STATS: &str = r"
 active[fid, stab] :=
     *facts{id: fid, nous_id, is_forgotten, superseded_by, stability_hours: stab},
@@ -228,11 +222,7 @@ active[fid, stab] :=
 ";
 
 #[cfg(test)]
-#[expect(
-    clippy::expect_used,
-    clippy::indexing_slicing,
-    reason = "test assertions"
-)]
+#[expect(clippy::expect_used, reason = "test assertions")]
 mod tests {
     use super::*;
 
@@ -377,6 +367,7 @@ mod tests {
     }
 
     #[cfg(feature = "mneme-engine")]
+    #[expect(clippy::indexing_slicing, reason = "test assertions")]
     mod engine_tests {
         use super::*;
         use crate::knowledge::{

--- a/crates/koina/src/id.rs
+++ b/crates/koina/src/id.rs
@@ -273,6 +273,19 @@ impl fmt::Display for TurnId {
 pub struct ToolName(CompactString);
 
 impl ToolName {
+    /// Construct a `ToolName` from a string literal known to be valid at compile time.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the name fails validation. Only use with known-valid string literals.
+    #[must_use]
+    pub fn from_static(name: &'static str) -> Self {
+        match Self::new(name) {
+            Ok(t) => t,
+            Err(e) => panic!("invalid tool name literal: {e}"),
+        }
+    }
+
     /// Create a new tool name.
     ///
     /// # Errors

--- a/crates/organon/src/builtins/agent.rs
+++ b/crates/organon/src/builtins/agent.rs
@@ -1,8 +1,4 @@
 //! Agent coordination tool executors: sessions_spawn, sessions_dispatch.
-#![expect(
-    clippy::expect_used,
-    reason = "ToolName::new() with static string literals is infallible — name validation would only fail on invalid chars which these names don't contain"
-)]
 
 use std::future::Future;
 use std::pin::Pin;
@@ -183,7 +179,7 @@ pub(crate) fn register(registry: &mut ToolRegistry) -> Result<()> {
 
 fn sessions_spawn_def() -> ToolDef {
     ToolDef {
-        name: ToolName::new("sessions_spawn").expect("valid tool name"), // kanon:ignore RUST/expect
+        name: ToolName::from_static("sessions_spawn"), // kanon:ignore RUST/expect
         description: "Spawn an ephemeral sub-agent to execute a single task".to_owned(),
         extended_description: Some(
             "Creates a temporary agent with a role-appropriate model and tool set. \
@@ -247,7 +243,7 @@ fn sessions_spawn_def() -> ToolDef {
 
 fn sessions_dispatch_def() -> ToolDef {
     ToolDef {
-        name: ToolName::new("sessions_dispatch").expect("valid tool name"), // kanon:ignore RUST/expect
+        name: ToolName::from_static("sessions_dispatch"), // kanon:ignore RUST/expect
         description: "Spawn multiple sub-agents in parallel and collect their results".to_owned(),
         extended_description: Some(
             "Dispatches an array of tasks to ephemeral sub-agents running concurrently. \
@@ -379,7 +375,7 @@ mod tests {
     async fn spawn_def_requires_role_and_task() {
         let mut reg = ToolRegistry::new();
         super::register(&mut reg).expect("register");
-        let name = ToolName::new("sessions_spawn").expect("valid");
+        let name = ToolName::from_static("sessions_spawn");
         let def = reg.get_def(&name).expect("found");
         assert_eq!(
             def.input_schema.required,
@@ -397,7 +393,7 @@ mod tests {
     async fn dispatch_def_requires_tasks() {
         let mut reg = ToolRegistry::new();
         super::register(&mut reg).expect("register");
-        let name = ToolName::new("sessions_dispatch").expect("valid");
+        let name = ToolName::from_static("sessions_dispatch");
         let def = reg.get_def(&name).expect("found");
         assert_eq!(
             def.input_schema.required,
@@ -411,7 +407,7 @@ mod tests {
         let mut reg = ToolRegistry::new();
         super::register(&mut reg).expect("register");
         let input = ToolInput {
-            name: ToolName::new("sessions_spawn").expect("valid"),
+            name: ToolName::from_static("sessions_spawn"),
             tool_use_id: "tu_1".to_owned(),
             arguments: serde_json::json!({"role": "coder", "task": "write code"}),
         };
@@ -431,7 +427,7 @@ mod tests {
         super::register(&mut reg).expect("register");
 
         let input = ToolInput {
-            name: ToolName::new("sessions_spawn").expect("valid"),
+            name: ToolName::from_static("sessions_spawn"),
             tool_use_id: "tu_1".to_owned(),
             arguments: serde_json::json!({"role": "coder", "task": "write code"}),
         };
@@ -459,7 +455,7 @@ mod tests {
         let mut reg = ToolRegistry::new();
         super::register(&mut reg).expect("register");
         let input = ToolInput {
-            name: ToolName::new("sessions_dispatch").expect("valid"),
+            name: ToolName::from_static("sessions_dispatch"),
             tool_use_id: "tu_1".to_owned(),
             arguments: serde_json::json!({"tasks": [{"role": "coder", "task": "write code"}]}),
         };
@@ -478,7 +474,7 @@ mod tests {
             .map(|i| serde_json::json!({"role": "coder", "task": format!("task {i}")}))
             .collect();
         let input = ToolInput {
-            name: ToolName::new("sessions_dispatch").expect("valid"),
+            name: ToolName::from_static("sessions_dispatch"),
             tool_use_id: "tu_1".to_owned(),
             arguments: serde_json::json!({"tasks": tasks}),
         };
@@ -498,7 +494,7 @@ mod tests {
         super::register(&mut reg).expect("register");
 
         let input = ToolInput {
-            name: ToolName::new("sessions_dispatch").expect("valid"),
+            name: ToolName::from_static("sessions_dispatch"),
             tool_use_id: "tu_1".to_owned(),
             arguments: serde_json::json!({
                 "tasks": [

--- a/crates/organon/src/builtins/communication.rs
+++ b/crates/organon/src/builtins/communication.rs
@@ -1,8 +1,4 @@
 //! Communication tool executors: message, sessions_ask, sessions_send.
-#![expect(
-    clippy::expect_used,
-    reason = "ToolName::new() with static string literals is infallible — name validation would only fail on invalid chars which these names don't contain"
-)]
 
 use std::future::Future;
 use std::pin::Pin;
@@ -167,7 +163,7 @@ pub(crate) fn register(registry: &mut ToolRegistry) -> Result<()> {
 
 fn message_def() -> ToolDef {
     ToolDef {
-        name: ToolName::new("message").expect("valid tool name"), // kanon:ignore RUST/expect
+        name: ToolName::from_static("message"), // kanon:ignore RUST/expect
         description: "Send a message to a user or group via Signal".to_owned(),
         extended_description: None,
         input_schema: InputSchema {
@@ -201,7 +197,7 @@ fn message_def() -> ToolDef {
 
 fn sessions_ask_def() -> ToolDef {
     ToolDef {
-        name: ToolName::new("sessions_ask").expect("valid tool name"), // kanon:ignore RUST/expect
+        name: ToolName::from_static("sessions_ask"), // kanon:ignore RUST/expect
         description: "Ask another agent a question and wait for their response".to_owned(),
         extended_description: None,
         input_schema: InputSchema {
@@ -253,7 +249,7 @@ fn sessions_ask_def() -> ToolDef {
 
 fn sessions_send_def() -> ToolDef {
     ToolDef {
-        name: ToolName::new("sessions_send").expect("valid tool name"), // kanon:ignore RUST/expect
+        name: ToolName::from_static("sessions_send"), // kanon:ignore RUST/expect
         description: "Send a message to another agent without waiting for a response".to_owned(),
         extended_description: None,
         input_schema: InputSchema {
@@ -422,7 +418,7 @@ mod tests {
         install_crypto_provider();
         let mut reg = ToolRegistry::new();
         super::register(&mut reg).expect("register");
-        let name = ToolName::new("message").expect("valid");
+        let name = ToolName::from_static("message");
         let def = reg.get_def(&name).expect("found");
         assert_eq!(
             def.input_schema.required,
@@ -436,7 +432,7 @@ mod tests {
         install_crypto_provider();
         let mut reg = ToolRegistry::new();
         super::register(&mut reg).expect("register");
-        let name = ToolName::new("sessions_ask").expect("valid");
+        let name = ToolName::from_static("sessions_ask");
         let def = reg.get_def(&name).expect("found");
         assert_eq!(
             def.input_schema.required,
@@ -450,7 +446,7 @@ mod tests {
         install_crypto_provider();
         let mut reg = ToolRegistry::new();
         super::register(&mut reg).expect("register");
-        let name = ToolName::new("sessions_send").expect("valid");
+        let name = ToolName::from_static("sessions_send");
         let def = reg.get_def(&name).expect("found");
         assert_eq!(
             def.input_schema.required,
@@ -465,7 +461,7 @@ mod tests {
         let mut reg = ToolRegistry::new();
         super::register(&mut reg).expect("register");
         let input = ToolInput {
-            name: ToolName::new("message").expect("valid"),
+            name: ToolName::from_static("message"),
             tool_use_id: "tu_1".to_owned(),
             arguments: serde_json::json!({"to": "+1234567890", "text": "hello"}),
         };
@@ -483,7 +479,7 @@ mod tests {
         let mut reg = ToolRegistry::new();
         super::register(&mut reg).expect("register");
         let input = ToolInput {
-            name: ToolName::new("sessions_send").expect("valid"),
+            name: ToolName::from_static("sessions_send"),
             tool_use_id: "tu_1".to_owned(),
             arguments: serde_json::json!({"agentId": "syn", "message": "hello"}),
         };
@@ -501,7 +497,7 @@ mod tests {
         let mut reg = ToolRegistry::new();
         super::register(&mut reg).expect("register");
         let input = ToolInput {
-            name: ToolName::new("sessions_ask").expect("valid"),
+            name: ToolName::from_static("sessions_ask"),
             tool_use_id: "tu_1".to_owned(),
             arguments: serde_json::json!({"agentId": "syn", "message": "hello"}),
         };
@@ -532,7 +528,7 @@ mod tests {
         let mut reg = ToolRegistry::new();
         super::register(&mut reg).expect("register");
         let input = ToolInput {
-            name: ToolName::new("message").expect("valid"),
+            name: ToolName::from_static("message"),
             tool_use_id: "tu_1".to_owned(),
             arguments: serde_json::json!({"to": "+1234567890", "text": "x".repeat(4001)}),
         };
@@ -564,7 +560,7 @@ mod tests {
         let mut reg = ToolRegistry::new();
         super::register(&mut reg).expect("register");
         let input = ToolInput {
-            name: ToolName::new("message").expect("valid"),
+            name: ToolName::from_static("message"),
             tool_use_id: "tu_1".to_owned(),
             arguments: serde_json::json!({"to": "+1234567890", "text": "hello world"}),
         };
@@ -611,7 +607,7 @@ mod tests {
         let mut reg = ToolRegistry::new();
         super::register(&mut reg).expect("register");
         let input = ToolInput {
-            name: ToolName::new("sessions_send").expect("valid"),
+            name: ToolName::from_static("sessions_send"),
             tool_use_id: "tu_1".to_owned(),
             arguments: serde_json::json!({"agentId": "syn", "message": "do the thing"}),
         };
@@ -656,7 +652,7 @@ mod tests {
         let mut reg = ToolRegistry::new();
         super::register(&mut reg).expect("register");
         let input = ToolInput {
-            name: ToolName::new("sessions_send").expect("valid"),
+            name: ToolName::from_static("sessions_send"),
             tool_use_id: "tu_1".to_owned(),
             arguments: serde_json::json!({"agentId": "syn", "message": "hi", "sessionKey": "custom"}),
         };
@@ -690,7 +686,7 @@ mod tests {
         let mut reg = ToolRegistry::new();
         super::register(&mut reg).expect("register");
         let input = ToolInput {
-            name: ToolName::new("sessions_ask").expect("valid"),
+            name: ToolName::from_static("sessions_ask"),
             tool_use_id: "tu_1".to_owned(),
             arguments: serde_json::json!({"agentId": "syn", "message": "what is the answer?"}),
         };
@@ -723,7 +719,7 @@ mod tests {
         let mut reg = ToolRegistry::new();
         super::register(&mut reg).expect("register");
         let input = ToolInput {
-            name: ToolName::new("sessions_ask").expect("valid"),
+            name: ToolName::from_static("sessions_ask"),
             tool_use_id: "tu_1".to_owned(),
             arguments: serde_json::json!({"agentId": "syn", "message": "hello?"}),
         };

--- a/crates/organon/src/builtins/computer_use/executor.rs
+++ b/crates/organon/src/builtins/computer_use/executor.rs
@@ -143,7 +143,7 @@ impl ToolExecutor for ComputerUseExecutor {
 )]
 fn computer_use_def() -> ToolDef {
     ToolDef {
-        name: ToolName::new("computer_use").expect("valid tool name"), // kanon:ignore RUST/expect
+        name: ToolName::from_static("computer_use"), // kanon:ignore RUST/expect
         description: "Interact with the computer screen: capture screenshots, click, type text, \
                       press keys, and scroll. Actions run in a Landlock-sandboxed environment."
             .to_owned(),

--- a/crates/organon/src/builtins/enable_tool.rs
+++ b/crates/organon/src/builtins/enable_tool.rs
@@ -1,8 +1,4 @@
 //! Meta-tool for dynamically activating lazy tools per session.
-#![expect(
-    clippy::expect_used,
-    reason = "ToolName::new() with static string literals is infallible — name validation would only fail on invalid chars which these names don't contain"
-)]
 
 use std::future::Future;
 use std::pin::Pin;
@@ -84,7 +80,7 @@ impl ToolExecutor for EnableToolExecutor {
 
 fn enable_tool_def() -> ToolDef {
     ToolDef {
-        name: ToolName::new("enable_tool").expect("valid tool name"), // kanon:ignore RUST/expect
+        name: ToolName::from_static("enable_tool"), // kanon:ignore RUST/expect
         description: "Activate a tool for this session. Some tools are not loaded by default \
                       and must be enabled first. Call with the tool name to activate it."
             .to_owned(),
@@ -154,7 +150,7 @@ mod tests {
 
     fn make_input(tool_name: &str) -> ToolInput {
         ToolInput {
-            name: ToolName::new("enable_tool").expect("valid"),
+            name: ToolName::from_static("enable_tool"),
             tool_use_id: "toolu_1".to_owned(),
             arguments: serde_json::json!({"name": tool_name}),
         }
@@ -163,7 +159,7 @@ mod tests {
     #[tokio::test]
     async fn activate_known_tool() {
         let ctx = mock_ctx_with_catalog(vec![(
-            ToolName::new("web_search").expect("valid"),
+            ToolName::from_static("web_search"),
             "Search the web".to_owned(),
         )]);
 
@@ -187,8 +183,8 @@ mod tests {
         )]
         let active = ctx.active_tools.read().expect("lock poisoned");
         assert!(
-            active.contains(&ToolName::new("web_search").expect("valid")),
-            "expected active.contains(&ToolName::new(\"web_search\").expect(\"valid\")) to be true"
+            active.contains(&ToolName::from_static("web_search")),
+            "expected active.contains(&ToolName::from_static(\"web_search\")) to be true"
         );
     }
 
@@ -196,13 +192,10 @@ mod tests {
     async fn unknown_tool_lists_available() {
         let ctx = mock_ctx_with_catalog(vec![
             (
-                ToolName::new("web_search").expect("valid"),
+                ToolName::from_static("web_search"),
                 "Search the web".to_owned(),
             ),
-            (
-                ToolName::new("web_fetch").expect("valid"),
-                "Fetch a URL".to_owned(),
-            ),
+            (ToolName::from_static("web_fetch"), "Fetch a URL".to_owned()),
         ]);
 
         let executor = EnableToolExecutor;
@@ -226,7 +219,7 @@ mod tests {
     #[tokio::test]
     async fn double_activate_is_idempotent() {
         let ctx = mock_ctx_with_catalog(vec![(
-            ToolName::new("web_search").expect("valid"),
+            ToolName::from_static("web_search"),
             "Search the web".to_owned(),
         )]);
 
@@ -299,8 +292,8 @@ mod tests {
         )]
         let active = ctx.active_tools.read().expect("lock poisoned");
         assert!(
-            active.contains(&ToolName::new("web_search").expect("valid")),
-            "expected active.contains(&ToolName::new(\"web_search\").expect(\"valid\")) to be true"
+            active.contains(&ToolName::from_static("web_search")),
+            "expected active.contains(&ToolName::from_static(\"web_search\")) to be true"
         );
     }
 

--- a/crates/organon/src/builtins/filesystem.rs
+++ b/crates/organon/src/builtins/filesystem.rs
@@ -1,8 +1,4 @@
 //! Filesystem navigation tools: grep, find, ls.
-#![expect(
-    clippy::expect_used,
-    reason = "ToolName::new() with static string literals is infallible — name validation would only fail on invalid chars which these names don't contain"
-)]
 
 use std::fmt::Write as _;
 use std::future::Future;
@@ -374,7 +370,7 @@ pub(crate) fn register(registry: &mut ToolRegistry) -> Result<()> {
 
 fn grep_def() -> ToolDef {
     ToolDef {
-        name: ToolName::new("grep").expect("valid tool name"), // kanon:ignore RUST/expect
+        name: ToolName::from_static("grep"), // kanon:ignore RUST/expect
         description: "Search file contents for a pattern using ripgrep".to_owned(),
         extended_description: None,
         input_schema: InputSchema {
@@ -436,7 +432,7 @@ fn grep_def() -> ToolDef {
 
 fn find_def() -> ToolDef {
     ToolDef {
-        name: ToolName::new("find").expect("valid tool name"), // kanon:ignore RUST/expect
+        name: ToolName::from_static("find"), // kanon:ignore RUST/expect
         description: "Find files by name pattern using fd".to_owned(),
         extended_description: None,
         input_schema: InputSchema {
@@ -497,7 +493,7 @@ fn find_def() -> ToolDef {
 
 fn ls_def() -> ToolDef {
     ToolDef {
-        name: ToolName::new("ls").expect("valid tool name"), // kanon:ignore RUST/expect
+        name: ToolName::from_static("ls"), // kanon:ignore RUST/expect
         description: "List directory contents with file sizes and modification times".to_owned(),
         extended_description: None,
         input_schema: InputSchema {

--- a/crates/organon/src/builtins/memory/blackboard.rs
+++ b/crates/organon/src/builtins/memory/blackboard.rs
@@ -1,8 +1,4 @@
 //! Shared blackboard tool executor.
-#![expect(
-    clippy::expect_used,
-    reason = "ToolName::new() with static string literals is infallible — name validation would only fail on invalid chars which these names don't contain"
-)]
 
 use std::future::Future;
 use std::pin::Pin;
@@ -103,7 +99,7 @@ impl ToolExecutor for BlackboardExecutor {
 
 fn blackboard_def() -> ToolDef {
     ToolDef {
-        name: ToolName::new("blackboard").expect("valid tool name"), // kanon:ignore RUST/expect
+        name: ToolName::from_static("blackboard"), // kanon:ignore RUST/expect
         description: "Read and write shared state visible to all agents".to_owned(),
         extended_description: None,
         input_schema: InputSchema {

--- a/crates/organon/src/builtins/memory/datalog.rs
+++ b/crates/organon/src/builtins/memory/datalog.rs
@@ -1,8 +1,4 @@
 //! Datalog query tool executor for read-only knowledge graph queries.
-#![expect(
-    clippy::expect_used,
-    reason = "ToolName::new() with static string literals is infallible — name validation would only fail on invalid chars which these names don't contain"
-)]
 
 use std::future::Future;
 use std::pin::Pin;
@@ -135,7 +131,7 @@ pub(super) fn format_as_markdown_table(result: &crate::types::DatalogResult) -> 
 
 fn datalog_query_def() -> ToolDef {
     ToolDef {
-        name: ToolName::new("datalog_query").expect("valid tool name"), // kanon:ignore RUST/expect
+        name: ToolName::from_static("datalog_query"), // kanon:ignore RUST/expect
         description: "Execute a read-only Datalog query against the knowledge graph. \
             Returns tabular results. Use for advanced knowledge exploration, debugging \
             recall quality, or querying graph structure. Cannot modify data."

--- a/crates/organon/src/builtins/memory/knowledge_ops.rs
+++ b/crates/organon/src/builtins/memory/knowledge_ops.rs
@@ -1,8 +1,4 @@
 //! Knowledge graph memory operations: search, correct, retract, forget, audit.
-#![expect(
-    clippy::expect_used,
-    reason = "ToolName::new() with static string literals is infallible — name validation would only fail on invalid chars which these names don't contain"
-)]
 
 use std::future::Future;
 use std::pin::Pin;
@@ -220,7 +216,7 @@ impl ToolExecutor for MemoryAuditExecutor {
 
 fn memory_search_def() -> ToolDef {
     ToolDef {
-        name: ToolName::new("memory_search").expect("valid tool name"), // kanon:ignore RUST/expect
+        name: ToolName::from_static("memory_search"), // kanon:ignore RUST/expect
         description: "Search long-term memory for facts, preferences, and relationships".to_owned(),
         extended_description: None,
         input_schema: InputSchema {
@@ -254,7 +250,7 @@ fn memory_search_def() -> ToolDef {
 
 fn memory_correct_def() -> ToolDef {
     ToolDef {
-        name: ToolName::new("memory_correct").expect("valid tool name"), // kanon:ignore RUST/expect
+        name: ToolName::from_static("memory_correct"), // kanon:ignore RUST/expect
         description: "Correct a stored fact by superseding it with updated content".to_owned(),
         extended_description: None,
         input_schema: InputSchema {
@@ -288,7 +284,7 @@ fn memory_correct_def() -> ToolDef {
 
 fn memory_retract_def() -> ToolDef {
     ToolDef {
-        name: ToolName::new("memory_retract").expect("valid tool name"), // kanon:ignore RUST/expect
+        name: ToolName::from_static("memory_retract"), // kanon:ignore RUST/expect
         description: "Retract a stored fact (mark as no longer valid without deleting)".to_owned(),
         extended_description: None,
         input_schema: InputSchema {
@@ -322,7 +318,7 @@ fn memory_retract_def() -> ToolDef {
 
 fn memory_forget_def() -> ToolDef {
     ToolDef {
-        name: ToolName::new("memory_forget").expect("valid tool name"), // kanon:ignore RUST/expect
+        name: ToolName::from_static("memory_forget"), // kanon:ignore RUST/expect
         description: "Soft-delete a fact from memory (reversible, preserves audit trail)"
             .to_owned(),
         extended_description: None,
@@ -362,7 +358,7 @@ fn memory_forget_def() -> ToolDef {
 
 fn memory_audit_def() -> ToolDef {
     ToolDef {
-        name: ToolName::new("memory_audit").expect("valid tool name"), // kanon:ignore RUST/expect
+        name: ToolName::from_static("memory_audit"), // kanon:ignore RUST/expect
         description: "List recent fact extractions with confidence scores for review".to_owned(),
         extended_description: None,
         input_schema: InputSchema {
@@ -439,7 +435,7 @@ mod tests {
 
     fn tool_input(name: &str, args: serde_json::Value) -> ToolInput {
         ToolInput {
-            name: ToolName::new(name).expect("valid"),
+            name: ToolName::new(name).expect("valid test tool name"),
             tool_use_id: "toolu_test".to_owned(),
             arguments: args,
         }
@@ -487,7 +483,7 @@ mod tests {
     fn memory_search_def_requires_query_field() {
         let mut reg = crate::registry::ToolRegistry::new();
         super::register(&mut reg).expect("register");
-        let name = ToolName::new("memory_search").expect("valid");
+        let name = ToolName::from_static("memory_search");
         let def = reg.get_def(&name).expect("found");
         assert!(
             def.input_schema.required.contains(&"query".to_owned()),
@@ -499,7 +495,7 @@ mod tests {
     fn memory_search_def_is_auto_activate() {
         let mut reg = crate::registry::ToolRegistry::new();
         super::register(&mut reg).expect("register");
-        let name = ToolName::new("memory_search").expect("valid");
+        let name = ToolName::from_static("memory_search");
         let def = reg.get_def(&name).expect("found");
         assert!(def.auto_activate, "memory_search must be auto-activated");
     }

--- a/crates/organon/src/builtins/memory/note.rs
+++ b/crates/organon/src/builtins/memory/note.rs
@@ -1,8 +1,4 @@
 //! Session note tool executor.
-#![expect(
-    clippy::expect_used,
-    reason = "ToolName::new() with static string literals is infallible — name validation would only fail on invalid chars which these names don't contain"
-)]
 
 use std::future::Future;
 use std::pin::Pin;
@@ -104,7 +100,7 @@ impl ToolExecutor for NoteExecutor {
 
 fn note_def() -> ToolDef {
     ToolDef {
-        name: ToolName::new("note").expect("valid tool name"), // kanon:ignore RUST/expect
+        name: ToolName::from_static("note"), // kanon:ignore RUST/expect
         description: "Write a note to persistent session memory that survives distillation"
             .to_owned(),
         extended_description: None,

--- a/crates/organon/src/builtins/planning_defs.rs
+++ b/crates/organon/src/builtins/planning_defs.rs
@@ -1,8 +1,4 @@
 //! Tool definitions for planning tools.
-#![expect(
-    clippy::expect_used,
-    reason = "ToolName::new() with static string literals is infallible — name validation would only fail on invalid chars which these names don't contain"
-)]
 
 use indexmap::IndexMap;
 
@@ -12,7 +8,7 @@ use crate::types::{InputSchema, PropertyDef, PropertyType, Reversibility, ToolCa
 
 pub(super) fn plan_create_def() -> ToolDef {
     ToolDef {
-        name: ToolName::new("plan_create").expect("valid tool name"), // kanon:ignore RUST/expect
+        name: ToolName::from_static("plan_create"), // kanon:ignore RUST/expect
         description: "Create a new planning project with phases and plans".to_owned(),
         extended_description: Some(
             "Creates a multi-phase planning project. Modes: 'full' (research through verification), \
@@ -81,7 +77,7 @@ pub(super) fn plan_create_def() -> ToolDef {
 
 pub(super) fn plan_research_def() -> ToolDef {
     ToolDef {
-        name: ToolName::new("plan_research").expect("valid tool name"), // kanon:ignore RUST/expect
+        name: ToolName::from_static("plan_research"), // kanon:ignore RUST/expect
         description: "Advance project to research phase or skip research".to_owned(),
         extended_description: None,
         input_schema: InputSchema {
@@ -115,7 +111,7 @@ pub(super) fn plan_research_def() -> ToolDef {
 
 pub(super) fn plan_requirements_def() -> ToolDef {
     ToolDef {
-        name: ToolName::new("plan_requirements").expect("valid tool name"), // kanon:ignore RUST/expect
+        name: ToolName::from_static("plan_requirements"), // kanon:ignore RUST/expect
         description: "Manage requirements scoping phase".to_owned(),
         extended_description: None,
         input_schema: InputSchema {
@@ -149,7 +145,7 @@ pub(super) fn plan_requirements_def() -> ToolDef {
 
 pub(super) fn plan_roadmap_def() -> ToolDef {
     ToolDef {
-        name: ToolName::new("plan_roadmap").expect("valid tool name"), // kanon:ignore RUST/expect
+        name: ToolName::from_static("plan_roadmap"), // kanon:ignore RUST/expect
         description: "Manage project roadmap: add phases, start discussion or execution".to_owned(),
         extended_description: None,
         input_schema: InputSchema {
@@ -205,7 +201,7 @@ pub(super) fn plan_roadmap_def() -> ToolDef {
 
 pub(super) fn plan_discuss_def() -> ToolDef {
     ToolDef {
-        name: ToolName::new("plan_discuss").expect("valid tool name"), // kanon:ignore RUST/expect
+        name: ToolName::from_static("plan_discuss"), // kanon:ignore RUST/expect
         description: "Complete discussion phase and advance to execution".to_owned(),
         extended_description: None,
         input_schema: InputSchema {
@@ -239,7 +235,7 @@ pub(super) fn plan_discuss_def() -> ToolDef {
 
 pub(super) fn plan_execute_def() -> ToolDef {
     ToolDef {
-        name: ToolName::new("plan_execute").expect("valid tool name"), // kanon:ignore RUST/expect
+        name: ToolName::from_static("plan_execute"), // kanon:ignore RUST/expect
         description: "Manage plan execution: start, pause, resume, abandon, or verify".to_owned(),
         extended_description: None,
         input_schema: InputSchema {
@@ -279,7 +275,7 @@ pub(super) fn plan_execute_def() -> ToolDef {
 
 pub(super) fn plan_verify_def() -> ToolDef {
     ToolDef {
-        name: ToolName::new("plan_verify").expect("valid tool name"), // kanon:ignore RUST/expect
+        name: ToolName::from_static("plan_verify"), // kanon:ignore RUST/expect
         description: "Complete verification or revert to an earlier phase".to_owned(),
         extended_description: None,
         input_schema: InputSchema {
@@ -327,7 +323,7 @@ pub(super) fn plan_verify_def() -> ToolDef {
 
 pub(super) fn plan_status_def() -> ToolDef {
     ToolDef {
-        name: ToolName::new("plan_status").expect("valid tool name"), // kanon:ignore RUST/expect
+        name: ToolName::from_static("plan_status"), // kanon:ignore RUST/expect
         description: "Get current project status including phases and completion".to_owned(),
         extended_description: None,
         input_schema: InputSchema {
@@ -350,7 +346,7 @@ pub(super) fn plan_status_def() -> ToolDef {
 
 pub(super) fn plan_step_complete_def() -> ToolDef {
     ToolDef {
-        name: ToolName::new("plan_step_complete").expect("valid tool name"), // kanon:ignore RUST/expect
+        name: ToolName::from_static("plan_step_complete"), // kanon:ignore RUST/expect
         description: "Mark a plan step as successfully completed".to_owned(),
         extended_description: None,
         input_schema: InputSchema {
@@ -406,7 +402,7 @@ pub(super) fn plan_step_complete_def() -> ToolDef {
 
 pub(super) fn plan_verify_criteria_def() -> ToolDef {
     ToolDef {
-        name: ToolName::new("plan_verify_criteria").expect("valid tool name"), // kanon:ignore RUST/expect
+        name: ToolName::from_static("plan_verify_criteria"), // kanon:ignore RUST/expect
         description: "Verify phase success criteria with evidence and goal-backward tracing"
             .to_owned(),
         extended_description: Some(
@@ -464,7 +460,7 @@ pub(super) fn plan_verify_criteria_def() -> ToolDef {
 
 pub(super) fn plan_step_fail_def() -> ToolDef {
     ToolDef {
-        name: ToolName::new("plan_step_fail").expect("valid tool name"), // kanon:ignore RUST/expect
+        name: ToolName::from_static("plan_step_fail"), // kanon:ignore RUST/expect
         description: "Mark a plan step as failed with a reason".to_owned(),
         extended_description: None,
         input_schema: InputSchema {

--- a/crates/organon/src/builtins/research.rs
+++ b/crates/organon/src/builtins/research.rs
@@ -3,10 +3,6 @@
 //! Web search is now handled by Anthropic's server-side `web_search` tool,
 //! configured via `NousConfig.server_tools`. This module only provides
 //! `web_fetch` for direct URL retrieval.
-#![expect(
-    clippy::expect_used,
-    reason = "ToolName::new() with static string literals is infallible — name validation would only fail on invalid chars which these names don't contain"
-)]
 
 use std::future::Future;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
@@ -329,7 +325,7 @@ fn strip_html_tags(html: &str) -> String {
 
 fn web_fetch_def() -> ToolDef {
     ToolDef {
-        name: ToolName::new("web_fetch").expect("valid tool name"), // kanon:ignore RUST/expect
+        name: ToolName::from_static("web_fetch"), // kanon:ignore RUST/expect
         description:
             "Fetch a URL and return its content as text. HTML pages are converted to readable text."
                 .to_owned(),
@@ -465,7 +461,7 @@ mod tests {
         let ctx = mock_ctx();
         let executor = WebFetchExecutor;
         let input = ToolInput {
-            name: ToolName::new("web_fetch").expect("valid"),
+            name: ToolName::from_static("web_fetch"),
             tool_use_id: "toolu_1".to_owned(),
             arguments: serde_json::json!({"url": "not-a-url"}),
         };

--- a/crates/organon/src/builtins/triage/mod.rs
+++ b/crates/organon/src/builtins/triage/mod.rs
@@ -8,11 +8,6 @@
 //! - `issue_scan`: Fetch and filter open GitHub issues
 //! - `issue_triage`: Score issues, generate prompts, write to staging
 //! - `issue_approve`: Move staged prompts from staging to queue (human gate)
-#![expect(
-    clippy::expect_used,
-    reason = "ToolName::new() with static string literals is infallible"
-)]
-
 mod prompt_gen;
 mod scoring;
 
@@ -497,7 +492,8 @@ async fn find_staged_prompt(
 
     match candidates.len() {
         0 => Err(format!("no staged prompt found matching '{prompt_id}'")),
-        1 => Ok(candidates.into_iter().next().expect("length checked above")), // kanon:ignore RUST/expect
+        // SAFETY: len() == 1 guarantees next() returns Some
+        1 => Ok(candidates.into_iter().next().unwrap_or_default()),
         n => Err(format!(
             "ambiguous prompt_id '{prompt_id}': matched {n} files"
         )),
@@ -608,7 +604,7 @@ fn format_triage_summary(staged: &[StagedPrompt], scored: &[RelevanceResult]) ->
 
 fn issue_scan_def() -> ToolDef {
     ToolDef {
-        name: ToolName::new("issue_scan").expect("valid tool name"), // kanon:ignore RUST/expect
+        name: ToolName::from_static("issue_scan"), // kanon:ignore RUST/expect
         description: "Fetch open GitHub issues filtered by labels or milestone. Returns issue metadata for triage.".to_owned(),
         extended_description: Some(
             "Fetches open issues from a GitHub repository via the REST API. \
@@ -653,7 +649,7 @@ fn issue_scan_def() -> ToolDef {
 
 fn issue_triage_def() -> ToolDef {
     ToolDef {
-        name: ToolName::new("issue_triage").expect("valid tool name"), // kanon:ignore RUST/expect
+        name: ToolName::from_static("issue_triage"), // kanon:ignore RUST/expect
         description: "Score GitHub issues for relevance, generate kanon-format prompts, and stage them for human approval.".to_owned(),
         extended_description: Some(
             "Fetches open issues, scores each for relevance (0.0-1.0) against provided \
@@ -716,7 +712,7 @@ fn issue_triage_def() -> ToolDef {
 
 fn issue_approve_def() -> ToolDef {
     ToolDef {
-        name: ToolName::new("issue_approve").expect("valid tool name"), // kanon:ignore RUST/expect
+        name: ToolName::from_static("issue_approve"), // kanon:ignore RUST/expect
         description:
             "Move a staged prompt from staging to the dispatch queue. Human approval gate."
                 .to_owned(),

--- a/crates/organon/src/builtins/view_file.rs
+++ b/crates/organon/src/builtins/view_file.rs
@@ -1,8 +1,4 @@
 //! view_file tool: images, PDFs, and text with multimodal support.
-#![expect(
-    clippy::expect_used,
-    reason = "ToolName::new() with static string literals is infallible — name validation would only fail on invalid chars which these names don't contain"
-)]
 
 use std::future::Future;
 use std::path::Path;
@@ -198,7 +194,7 @@ pub(crate) fn register(registry: &mut ToolRegistry) -> Result<()> {
 fn view_file_def() -> crate::types::ToolDef {
     use aletheia_koina::id::ToolName;
     ToolDef {
-        name: ToolName::new("view_file").expect("valid tool name"), // kanon:ignore RUST/expect
+        name: ToolName::from_static("view_file"), // kanon:ignore RUST/expect
         description: "View a file — images, PDFs, and text. For images and PDFs, the content is sent directly to the model for visual analysis.".to_owned(),
         extended_description: None,
         input_schema: InputSchema {
@@ -258,7 +254,7 @@ mod tests {
 
     fn tool_input(args: serde_json::Value) -> ToolInput {
         ToolInput {
-            name: ToolName::new("view_file").expect("valid"),
+            name: ToolName::from_static("view_file"),
             tool_use_id: "toolu_test".to_owned(),
             arguments: args,
         }
@@ -401,7 +397,7 @@ mod tests {
     async fn view_file_registered() {
         let mut reg = crate::registry::ToolRegistry::new();
         register(&mut reg).expect("register");
-        let name = ToolName::new("view_file").expect("valid");
+        let name = ToolName::from_static("view_file");
         assert!(
             reg.get_def(&name).is_some(),
             "expected reg.get_def(&name).is_some() to be true"

--- a/crates/organon/src/builtins/workspace.rs
+++ b/crates/organon/src/builtins/workspace.rs
@@ -1,8 +1,4 @@
 //! Workspace tool executors: read, write, edit, exec.
-#![expect(
-    clippy::expect_used,
-    reason = "ToolName::new() with static string literals is infallible — name validation would only fail on invalid chars which these names don't contain"
-)]
 
 use std::future::Future;
 use std::io::Read as _;
@@ -609,7 +605,7 @@ pub(crate) fn register(
 
 fn read_def() -> ToolDef {
     ToolDef {
-        name: ToolName::new("read").expect("valid tool name"), // kanon:ignore RUST/expect
+        name: ToolName::from_static("read"), // kanon:ignore RUST/expect
         description: "Read a file's contents as text".to_owned(),
         extended_description: None,
         input_schema: InputSchema {
@@ -643,7 +639,7 @@ fn read_def() -> ToolDef {
 
 fn write_def() -> ToolDef {
     ToolDef {
-        name: ToolName::new("write").expect("valid tool name"), // kanon:ignore RUST/expect
+        name: ToolName::from_static("write"), // kanon:ignore RUST/expect
         description: "Write content to a file, creating parent directories as needed".to_owned(),
         extended_description: None,
         input_schema: InputSchema {
@@ -686,7 +682,7 @@ fn write_def() -> ToolDef {
 
 fn edit_def() -> ToolDef {
     ToolDef {
-        name: ToolName::new("edit").expect("valid tool name"), // kanon:ignore RUST/expect
+        name: ToolName::from_static("edit"), // kanon:ignore RUST/expect
         description: "Replace exact text in a file with new text".to_owned(),
         extended_description: None,
         input_schema: InputSchema {
@@ -733,7 +729,7 @@ fn edit_def() -> ToolDef {
 
 fn exec_def() -> ToolDef {
     ToolDef {
-        name: ToolName::new("exec").expect("valid tool name"), // kanon:ignore RUST/expect
+        name: ToolName::from_static("exec"), // kanon:ignore RUST/expect
         description: "Execute a shell command in your workspace and return stdout/stderr"
             .to_owned(),
         extended_description: None,

--- a/crates/organon/src/registry.rs
+++ b/crates/organon/src/registry.rs
@@ -279,7 +279,7 @@ mod tests {
 
     fn make_def(name: &str, category: ToolCategory) -> ToolDef {
         ToolDef {
-            name: ToolName::new(name).expect("valid"),
+            name: ToolName::new(name).expect("valid test tool name"),
             description: format!("Test tool: {name}"),
             extended_description: None,
             input_schema: InputSchema {
@@ -308,7 +308,7 @@ mod tests {
         reg.register(make_def("read", ToolCategory::Workspace), exec)
             .expect("register");
 
-        let name = ToolName::new("read").expect("valid");
+        let name = ToolName::from_static("read");
         let def = reg.get_def(&name).expect("found");
         assert_eq!(
             def.name.as_str(),
@@ -336,7 +336,7 @@ mod tests {
     #[test]
     fn lookup_missing() {
         let reg = ToolRegistry::new();
-        let name = ToolName::new("nonexistent").expect("valid");
+        let name = ToolName::from_static("nonexistent");
         assert!(
             reg.get_def(&name).is_none(),
             "expected reg.get_def(&name).is_none() to be true"
@@ -351,7 +351,7 @@ mod tests {
             .expect("register");
 
         let input = ToolInput {
-            name: ToolName::new("greet").expect("valid"),
+            name: ToolName::from_static("greet"),
             tool_use_id: "toolu_1".to_owned(),
             arguments: serde_json::json!({}),
         };
@@ -374,7 +374,7 @@ mod tests {
     async fn execute_not_found() {
         let reg = ToolRegistry::new();
         let input = ToolInput {
-            name: ToolName::new("missing").expect("valid"),
+            name: ToolName::from_static("missing"),
             tool_use_id: "toolu_1".to_owned(),
             arguments: serde_json::json!({}),
         };
@@ -427,7 +427,7 @@ mod tests {
         let mut reg = ToolRegistry::new();
         let (exec, _) = mock_executor("ok");
         let def = ToolDef {
-            name: ToolName::new("read").expect("valid"),
+            name: ToolName::from_static("read"),
             description: "Read a file".to_owned(),
             extended_description: None,
             input_schema: InputSchema {
@@ -504,7 +504,7 @@ mod tests {
             .expect("register");
 
         let input = ToolInput {
-            name: ToolName::new("ctx-test").expect("valid"),
+            name: ToolName::from_static("ctx-test"),
             tool_use_id: "toolu_1".to_owned(),
             arguments: serde_json::json!({}),
         };
@@ -524,7 +524,7 @@ mod tests {
 
     fn make_def_with_activate(name: &str, category: ToolCategory, auto_activate: bool) -> ToolDef {
         ToolDef {
-            name: ToolName::new(name).expect("valid"),
+            name: ToolName::new(name).expect("valid test tool name"),
             description: format!("Test tool: {name}"),
             extended_description: None,
             input_schema: InputSchema {
@@ -593,7 +593,7 @@ mod tests {
         .expect("register");
 
         let mut active = HashSet::new();
-        active.insert(ToolName::new("web_search").expect("valid"));
+        active.insert(ToolName::from_static("web_search"));
         let tools = reg.to_hermeneus_tools_filtered(&active);
         let names: Vec<&str> = tools.iter().map(|t| t.name.as_str()).collect();
         assert!(
@@ -671,7 +671,7 @@ mod tests {
         let mut reg = ToolRegistry::new();
         let (exec, _) = mock_executor("ok");
         let def = ToolDef {
-            name: ToolName::new("read").expect("valid"),
+            name: ToolName::from_static("read"),
             description: "Read a file".to_owned(),
             extended_description: None,
             input_schema: InputSchema {
@@ -704,7 +704,7 @@ mod tests {
         let mut reg = ToolRegistry::new();
         let (exec, _) = mock_executor("ok");
         let def = ToolDef {
-            name: ToolName::new("find").expect("valid"),
+            name: ToolName::from_static("find"),
             description: "Find files".to_owned(),
             extended_description: None,
             input_schema: InputSchema {
@@ -736,7 +736,7 @@ mod tests {
         let mut reg = ToolRegistry::new();
         let (exec, _) = mock_executor("ok");
         let def = ToolDef {
-            name: ToolName::new("grep").expect("valid"),
+            name: ToolName::from_static("grep"),
             description: "Grep".to_owned(),
             extended_description: None,
             input_schema: InputSchema {
@@ -770,7 +770,7 @@ mod tests {
         let (exec, _) = mock_executor("ok");
         reg.register(
             ToolDef {
-                name: ToolName::new("web_search").expect("valid"),
+                name: ToolName::from_static("web_search"),
                 description: "Search the web".to_owned(),
                 extended_description: None,
                 input_schema: InputSchema {
@@ -810,7 +810,7 @@ mod tests {
     async fn execute_returns_tool_not_found_for_unknown_name() {
         let reg = ToolRegistry::new();
         let input = ToolInput {
-            name: ToolName::new("ghost").expect("valid"),
+            name: ToolName::from_static("ghost"),
             tool_use_id: "toolu_x".to_owned(),
             arguments: serde_json::json!({}),
         };

--- a/crates/organon/src/testing.rs
+++ b/crates/organon/src/testing.rs
@@ -63,14 +63,10 @@ enum MockMode {
 impl MockToolExecutor {
     /// Create a mock that always returns the given text as a success result.
     #[must_use]
-    #[expect(
-        clippy::expect_used,
-        reason = "test-support: 'mock' is a known-valid tool name"
-    )]
     pub fn text(text: impl Into<String>) -> Self {
         // kanon:ignore RUST/pub-visibility
         Self {
-            name: ToolName::new("mock").expect("valid tool name"), // kanon:ignore RUST/expect
+            name: ToolName::from_static("mock"), // kanon:ignore RUST/expect
             inner: Mutex::new(MockInner {
                 mode: MockMode::Text(text.into()),
             }),
@@ -80,14 +76,10 @@ impl MockToolExecutor {
 
     /// Create a mock that returns an error result (not a Rust `Err`).
     #[must_use]
-    #[expect(
-        clippy::expect_used,
-        reason = "test-support: 'mock' is a known-valid tool name"
-    )]
     pub fn tool_error(message: impl Into<String>) -> Self {
         // kanon:ignore RUST/pub-visibility
         Self {
-            name: ToolName::new("mock").expect("valid tool name"), // kanon:ignore RUST/expect
+            name: ToolName::from_static("mock"), // kanon:ignore RUST/expect
             inner: Mutex::new(MockInner {
                 mode: MockMode::Error(message.into()),
             }),
@@ -97,14 +89,10 @@ impl MockToolExecutor {
 
     /// Create a mock that returns results from a sequence (repeats last when exhausted).
     #[must_use]
-    #[expect(
-        clippy::expect_used,
-        reason = "test-support: 'mock' is a known-valid tool name"
-    )]
     pub fn sequence(results: Vec<ToolResult>) -> Self {
         // kanon:ignore RUST/pub-visibility
         Self {
-            name: ToolName::new("mock").expect("valid tool name"), // kanon:ignore RUST/expect
+            name: ToolName::from_static("mock"), // kanon:ignore RUST/expect
             inner: Mutex::new(MockInner {
                 mode: MockMode::Sequence(results),
             }),
@@ -371,8 +359,7 @@ mod tests {
 
     #[test]
     fn make_tool_input_uses_given_name() {
-        #[expect(clippy::expect_used, reason = "test: known-valid tool name")]
-        let name = ToolName::new("my_tool").expect("valid name");
+        let name = ToolName::from_static("my_tool");
         let input = make_tool_input(&name);
         assert_eq!(
             input.name.as_str(),

--- a/crates/organon/src/types.rs
+++ b/crates/organon/src/types.rs
@@ -640,22 +640,18 @@ pub struct ServerToolConfig {
 impl ServerToolConfig {
     /// Generate catalog entries for server tools available via `enable_tool`.
     #[must_use]
-    #[expect(
-        clippy::expect_used,
-        reason = "ToolName::new() with known-valid static string literals is infallible"
-    )]
     pub fn catalog_entries(&self) -> Vec<(ToolName, String)> {
         // kanon:ignore RUST/pub-visibility
         let mut entries = Vec::new();
         if self.web_search {
             entries.push((
-                ToolName::new("web_search").expect("valid tool name"), // kanon:ignore RUST/expect
+                ToolName::from_static("web_search"), // kanon:ignore RUST/expect
                 "Search the web using Anthropic's server-side web search".to_owned(),
             ));
         }
         if self.code_execution {
             entries.push((
-                ToolName::new("code_execution").expect("valid tool name"), // kanon:ignore RUST/expect
+                ToolName::from_static("code_execution"), // kanon:ignore RUST/expect
                 "Execute Python code in a sandboxed server-side environment".to_owned(),
             ));
         }
@@ -664,18 +660,14 @@ impl ServerToolConfig {
 
     /// Produce server tool definitions for tools that are currently active.
     #[must_use]
-    #[expect(
-        clippy::expect_used,
-        reason = "ToolName::new() with known-valid static string literals is infallible"
-    )]
     pub fn active_definitions(
         // kanon:ignore RUST/pub-visibility
         &self,
         active: &HashSet<ToolName>,
     ) -> Vec<aletheia_hermeneus::types::ServerToolDefinition> {
         let mut defs = Vec::new();
-        let web_search_name = ToolName::new("web_search").expect("valid tool name"); // kanon:ignore RUST/expect
-        let code_exec_name = ToolName::new("code_execution").expect("valid tool name"); // kanon:ignore RUST/expect
+        let web_search_name = ToolName::from_static("web_search"); // kanon:ignore RUST/expect
+        let code_exec_name = ToolName::from_static("code_execution"); // kanon:ignore RUST/expect
 
         if self.web_search && active.contains(&web_search_name) {
             defs.push(aletheia_hermeneus::types::ServerToolDefinition {


### PR DESCRIPTION
## Summary

- Add `ToolName::from_static()` to koina, eliminating `.expect()` on known-valid string literals across 15 organon builtin files
- Narrow file-level `#![expect]` suppressions to inline `#[expect]` with structured reasons in episteme (6 files: consolidation/engine, hnsw_index, knowledge_store/marshal, knowledge_store/search, knowledge_store/skills, skills/candidate)
- Replace `as u32` casts with `u32::try_from().unwrap_or(0)` in episteme marshal.rs
- Fix pre-existing unfulfilled lint expectations in episteme (embedding.rs, dedup.rs, graph_intelligence.rs, succession.rs)
- Fix pre-existing `#[expect(dead_code)]` → `#[allow(dead_code)]` for conditionally-used items in graph_intelligence.rs and succession.rs

Partial #1915

## Test plan

- [x] `cargo clippy -p aletheia-organon -p aletheia-episteme -p aletheia-koina --all-targets -- -D warnings` — zero warnings
- [x] `cargo test -p aletheia-organon -p aletheia-episteme -p aletheia-koina` — 1,226 tests pass
- [x] `cargo fmt --all` — no formatting changes
- [x] No regressions: pre-existing workspace clippy failures (pylon, nous, diaporeia, binary crate) unchanged