### PR TITLE
fix(test): wire test-core feature to enable engine tests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,9 +22,9 @@ Shell: [standards/SHELL.md](standards/SHELL.md)
 ```bash
 cargo build                            # Debug build
 cargo build --release                  # Release (LTO, stripped)
-cargo test --workspace                 # Default tests (~5,600)
-cargo test --workspace --features test-core  # + storage/engine tests
-cargo test --workspace --features test-full  # + ML embedding tests
+cargo test --workspace                 # Default tests (~5,400)
+cargo test --workspace --features test-core  # + storage/engine tests (~5,435)
+cargo test --workspace --features test-full  # + ML embedding tests (~5,435)
 cargo test -p aletheia-hermeneus       # Single crate
 cargo clippy --workspace               # Lint (zero warnings)
 ```

--- a/crates/aletheia/Cargo.toml
+++ b/crates/aletheia/Cargo.toml
@@ -30,7 +30,7 @@ migrate-qdrant = ["dep:qdrant-client", "aletheia-mneme/mneme-engine", "aletheia-
 tls = ["aletheia-pylon/tls"]
 tui = ["dep:theatron-tui"]
 # Test tiers (see docs/test-tiers.md)
-test-core = ["aletheia-mneme/test-core", "aletheia-nous/test-core"]
+test-core = ["aletheia-mneme/test-core", "aletheia-nous/test-core", "aletheia-pylon/test-core"]
 test-full = ["test-core", "aletheia-mneme/test-full"]
 
 [dependencies]

--- a/crates/episteme/Cargo.toml
+++ b/crates/episteme/Cargo.toml
@@ -21,7 +21,7 @@ storage-fjall = ["mneme-engine", "aletheia-krites/storage-fjall"]
 embed-candle = ["dep:candle-core", "dep:candle-nn", "dep:candle-transformers", "dep:tokenizers", "dep:hf-hub"]
 hnsw_rs = ["dep:hnsw_rs", "aletheia-graphe/hnsw_rs"]
 # Test tiers (see docs/test-tiers.md)
-test-core = ["mneme-engine"]
+test-core = ["mneme-engine", "hnsw_rs"]
 test-full = ["test-core", "embed-candle"]
 
 [dependencies]

--- a/crates/krites/Cargo.toml
+++ b/crates/krites/Cargo.toml
@@ -14,7 +14,7 @@ workspace = true
 default = ["graph-algo"]
 graph-algo = []
 storage-fjall = ["dep:fjall"]
-test-core = []
+test-core = ["storage-fjall"]
 test-full = []
 
 [dependencies]

--- a/crates/mneme/Cargo.toml
+++ b/crates/mneme/Cargo.toml
@@ -22,7 +22,7 @@ mneme-engine = ["dep:aletheia-krites", "aletheia-graphe/mneme-engine", "aletheia
 storage-fjall = ["mneme-engine", "aletheia-episteme/storage-fjall"]
 hnsw_rs = ["aletheia-episteme/hnsw_rs"]
 # Test tiers (see docs/test-tiers.md)
-test-core = ["mneme-engine"]
+test-core = ["mneme-engine", "hnsw_rs", "storage-fjall"]
 test-full = ["test-core", "embed-candle"]
 
 [dependencies]

--- a/crates/pylon/Cargo.toml
+++ b/crates/pylon/Cargo.toml
@@ -14,7 +14,7 @@ workspace = true
 default = []
 tls = ["dep:axum-server"]
 knowledge-store = ["aletheia-nous/knowledge-store"]
-test-core = []
+test-core = ["knowledge-store"]
 test-full = []
 
 [dependencies]

--- a/docs/test-tiers.md
+++ b/docs/test-tiers.md
@@ -7,9 +7,10 @@ coverage against build time and resource requirements.
 
 | Tier | Feature flag | What it enables | Approx. tests |
 |------|-------------|-----------------|---------------|
-| **default** | *(none)* | Pure-logic unit tests, config validation, type invariants | ~4,800 |
-| **test-core** | `--features test-core` | Storage engine tests (Datalog, HNSW, knowledge store CRUD) | ~4,825 |
-| **test-full** | `--features test-full` | ML embedding tests (candle model loading, vector generation) | all |
+| **default** | *(none)* | Pure-logic unit tests, config validation, type invariants | ~5,400 |
+| **test-core** | `--features test-core` | Storage engine tests (Datalog, HNSW, fjall, knowledge store CRUD) | ~5,435 |
+| **test-full** | `--features test-full` | ML embedding tests (candle model loading, vector generation) | ~5,435 |
+| **all** | `--all-features` | + local-llm, computer-use, other optional features | ~5,475 |
 
 Each tier is a strict superset of the previous: `test-full` implies `test-core`,
 which adds to the default set.
@@ -31,9 +32,15 @@ cargo test --workspace --features test-full
 
 Every crate in the workspace defines `test-core = [...]` and `test-full = [...]`
 features. Crates with no gated tests leave these empty. Crates with storage-
-dependent tests wire `test-core` to their engine feature (e.g.,
-`test-core = ["mneme-engine"]`). The root `aletheia` crate propagates features
-down to dependencies.
+dependent tests wire `test-core` to their engine features (e.g.,
+`test-core = ["mneme-engine", "hnsw_rs", "storage-fjall"]`). The root `aletheia`
+crate propagates features down to dependencies.
+
+NOTE: The `aletheia` binary's default features (`recall`, `embed-candle`,
+`storage-fjall`) enable mneme-engine and embed-candle for all workspace members
+via Cargo feature unification. This means `cargo test --workspace` (default
+tier) already runs engine and ML tests. The tier distinction matters most for
+per-crate testing (`cargo test -p <crate> --features test-core`).
 
 The `--features test-core` flag on `cargo test --workspace` activates the
 feature in every workspace member simultaneously, which is why every crate


### PR DESCRIPTION
## Summary

- Wire `test-core` feature to enable `hnsw_rs`, `storage-fjall`, and `knowledge-store` across the workspace, matching the documented scope in `docs/test-tiers.md`
- Previously `test-core` only enabled `mneme-engine` on mneme/nous — HNSW index tests, fjall storage tests, and knowledge-store CRUD were missing
- Update test-tiers doc with accurate counts and note on Cargo feature unification

## Changes

| Crate | test-core before | test-core after |
|-------|-----------------|-----------------|
| episteme | `["mneme-engine"]` | `["mneme-engine", "hnsw_rs"]` |
| mneme | `["mneme-engine"]` | `["mneme-engine", "hnsw_rs", "storage-fjall"]` |
| krites | `[]` | `["storage-fjall"]` |
| pylon | `[]` | `["knowledge-store"]` |
| aletheia | `[mneme/tc, nous/tc]` | `[mneme/tc, nous/tc, pylon/tc]` |

## Test counts

| Tier | Before | After |
|------|--------|-------|
| default | 5,404 | 5,404 |
| test-core | 5,429 | 5,435 |
| test-full | 5,429 | 5,435 |
| all-features | 5,475 | 5,475 |

Remaining 40-test gap between test-core and all-features is `local-llm` (15), `computer-use` (25) — optional/platform-specific features.

Closes #1961

## Test plan

- [x] `cargo test --workspace --features test-core` runs 5,435 tests (>5,000)
- [x] `cargo test --workspace` (default) runs 5,404 tests
- [x] `cargo clippy --workspace` clean


🤖 Generated with [Claude Code](https://claude.com/claude-code)