### PR TITLE
fix(symbolon): harden OAuth refresh chain for standalone operation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,7 +33,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "aletheia-agora",
  "aletheia-dianoia",
@@ -83,7 +83,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-agora"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "aletheia-koina",
  "aletheia-taxis",
@@ -104,7 +104,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-dianoia"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "jiff",
  "prometheus",
@@ -118,7 +118,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-diaporeia"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "aletheia-koina",
  "aletheia-mneme",
@@ -141,7 +141,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-dokimion"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "aletheia-koina",
  "owo-colors",
@@ -160,7 +160,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-eidos"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "jiff",
  "serde",
@@ -169,7 +169,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-episteme"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "aletheia-eidos",
  "aletheia-graphe",
@@ -199,7 +199,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-graphe"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "aletheia-eidos",
  "aletheia-koina",
@@ -220,7 +220,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-hermeneus"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "aletheia-koina",
  "jiff",
@@ -242,7 +242,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-integration-tests"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "aletheia-dokimion",
  "aletheia-hermeneus",
@@ -268,7 +268,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-koina"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "compact_str",
  "jiff",
@@ -288,7 +288,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-krites"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "aho-corasick",
  "aletheia-eidos",
@@ -332,7 +332,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-melete"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "aletheia-hermeneus",
  "jiff",
@@ -347,7 +347,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-mneme"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "aletheia-eidos",
  "aletheia-episteme",
@@ -362,7 +362,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-nous"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "aletheia-dianoia",
  "aletheia-hermeneus",
@@ -390,7 +390,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-oikonomos"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "aletheia-koina",
  "chrono",
@@ -411,7 +411,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-organon"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "aletheia-hermeneus",
  "aletheia-koina",
@@ -438,7 +438,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-pylon"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "aletheia-hermeneus",
  "aletheia-koina",
@@ -472,7 +472,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-symbolon"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "aletheia-koina",
  "argon2",
@@ -483,6 +483,7 @@ dependencies = [
  "reqwest 0.13.2",
  "ring",
  "rusqlite",
+ "rustix 1.1.4",
  "serde",
  "serde_json",
  "snafu",
@@ -496,7 +497,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-taxis"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "aletheia-koina",
  "base64 0.22.1",
@@ -514,7 +515,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-thesauros"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "aletheia-koina",
  "aletheia-organon",
@@ -5924,7 +5925,7 @@ dependencies = [
 
 [[package]]
 name = "theatron-core"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "aletheia-koina",
  "bytes",
@@ -5943,7 +5944,7 @@ dependencies = [
 
 [[package]]
 name = "theatron-tui"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "aletheia-koina",
  "arboard",

--- a/crates/symbolon/Cargo.toml
+++ b/crates/symbolon/Cargo.toml
@@ -23,6 +23,7 @@ prometheus = { workspace = true }
 rand = { workspace = true }
 ring = { workspace = true }
 reqwest = { workspace = true }
+rustix = { workspace = true }
 rusqlite = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/symbolon/src/circuit_breaker.rs
+++ b/crates/symbolon/src/circuit_breaker.rs
@@ -234,6 +234,30 @@ impl CircuitBreaker {
         }
     }
 
+    /// Reset the circuit breaker to the Closed state.
+    ///
+    /// WHY: when an external process (e.g. Claude Code) writes fresh credentials,
+    /// the circuit should reset so the next refresh attempt proceeds immediately.
+    pub(crate) fn reset(&self) {
+        let mut inner = self
+            .inner
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let prev = inner.state.clone();
+        inner.state = CircuitState::Closed;
+        inner.failures.clear();
+        inner.consecutive_trips = 0;
+        inner.current_cooldown = self.config.cooldown;
+        inner.opened_at = None;
+        if prev != CircuitState::Closed {
+            tracing::info!(
+                from = %prev,
+                to = %inner.state,
+                "circuit breaker reset (external credential update)"
+            );
+        }
+    }
+
     fn compute_cooldown(config: &CircuitBreakerConfig, consecutive_trips: u32) -> Duration {
         let multiplier = 2u64.saturating_pow(consecutive_trips);
         let cooldown_secs = config.cooldown.as_secs().saturating_mul(multiplier);

--- a/crates/symbolon/src/credential.rs
+++ b/crates/symbolon/src/credential.rs
@@ -6,13 +6,16 @@ use std::time::{Duration, Instant, SystemTime};
 
 use serde::{Deserialize, Serialize};
 use tokio_util::sync::CancellationToken;
-use tracing::{Instrument, debug, info, warn};
+use tracing::{Instrument, debug, error, info, warn};
 
 use aletheia_koina::credential::{Credential, CredentialProvider, CredentialSource};
 use aletheia_koina::secret::SecretString;
 
 use crate::circuit_breaker::{CircuitBreaker, CircuitBreakerConfig};
-use crate::encrypt::{ENCRYPTED_SENTINEL, decrypt, encrypt, load_or_create_key};
+use crate::encrypt::{
+    ENCRYPTED_SENTINEL, commit_key_file, decrypt, encrypt, load_or_create_key,
+    load_or_generate_key, prepare_key_file,
+};
 use crate::util::decode_jwt_exp_secs;
 
 /// Return current time as milliseconds since UNIX epoch, warning if the clock
@@ -52,6 +55,12 @@ const REFRESH_CHECK_INTERVAL_SECS: u64 = 60;
 
 /// How often to check file mtime for external changes.
 const FILE_MTIME_CHECK_INTERVAL: Duration = Duration::from_secs(30);
+
+/// Minimum `expires_in` accepted from OAuth responses (seconds).
+const MIN_EXPIRES_IN_SECS: u64 = 60;
+
+/// Maximum `expires_in` accepted from OAuth responses (seconds).
+const MAX_EXPIRES_IN_SECS: u64 = 86400;
 
 /// On-disk credential file format.
 ///
@@ -93,6 +102,16 @@ impl CredentialFile {
     /// are invisible and the chain falls back to a stale env-var token.
     #[must_use]
     pub fn load(path: &Path) -> Option<Self> {
+        // WHY: orphaned .json.tmp files from crashed writes waste disk and confuse operators
+        let tmp = path.with_extension("json.tmp");
+        if tmp.exists() {
+            if let Err(e) = std::fs::remove_file(&tmp) {
+                warn!(error = %e, path = %tmp.display(), "failed to clean up orphaned temp file");
+            } else {
+                debug!(path = %tmp.display(), "cleaned up orphaned temp file");
+            }
+        }
+
         let contents = std::fs::read_to_string(path).ok()?;
 
         let json = if let Some(encoded) = contents.strip_prefix(ENCRYPTED_SENTINEL) {
@@ -118,10 +137,14 @@ impl CredentialFile {
         serde_json::from_value(outer.get("claudeAiOauth")?.clone()).ok()
     }
 
-    /// Write the credential file atomically (write to temp, rename).
+    /// Write the credential file atomically (write to temp, fsync, rename).
     ///
     /// The file is always encrypted with AES-256-GCM using a per-file key
     /// stored in a sidecar `.key` file (mode 0600).
+    ///
+    /// Both the key file and credential file are written to temp files, fsynced,
+    /// and renamed atomically as a pair. An advisory write lock (`flock`) is held
+    /// for the duration to prevent races with Claude Code.
     pub(crate) fn save(&self, path: &Path) -> std::io::Result<()> {
         use std::io::Write as _;
 
@@ -131,16 +154,41 @@ impl CredentialFile {
 
         let json = serde_json::to_string_pretty(self).map_err(std::io::Error::other)?;
 
-        let key = load_or_create_key(path)?;
+        // WHY: load_or_generate_key tells us whether the key needs persisting so we
+        // can write both temp files before committing either rename
+        let (key, key_needs_persist) = load_or_generate_key(path)?;
         let encoded = encrypt(&key, json.as_bytes())?;
 
-        let tmp = path.with_extension("json.tmp");
-        let mut file = std::fs::File::create(&tmp)?;
+        let _lock = CredentialFileLock::exclusive(path)?;
+
+        // Phase 1: write all temp files and fsync
+        let key_tmp = if key_needs_persist {
+            Some(prepare_key_file(path, &key)?)
+        } else {
+            None
+        };
+
+        let cred_tmp = path.with_extension("json.tmp");
+        let mut file = std::fs::File::create(&cred_tmp)?;
         file.write_all(ENCRYPTED_SENTINEL.as_bytes())?;
         file.write_all(encoded.as_bytes())?;
         file.flush()?;
         file.sync_all()?;
-        std::fs::rename(&tmp, path)?;
+
+        // Phase 2: rename both atomically. If either fails, clean up both.
+        if let Some(ref ktmp) = key_tmp
+            && let Err(e) = commit_key_file(path, ktmp)
+        {
+            let _ = std::fs::remove_file(ktmp);
+            let _ = std::fs::remove_file(&cred_tmp);
+            return Err(e);
+        }
+
+        if let Err(e) = std::fs::rename(&cred_tmp, path) {
+            let _ = std::fs::remove_file(&cred_tmp);
+            // NOTE: key file was already renamed; it's valid on its own
+            return Err(e);
+        }
 
         #[cfg(unix)]
         {
@@ -184,6 +232,66 @@ impl CredentialFile {
     }
 }
 
+/// Advisory file lock for credential read-modify-write cycles.
+///
+/// Uses `flock()` via `rustix` on a `.lock` sidecar file. The lock file is
+/// created alongside the credential file and never deleted (harmless).
+struct CredentialFileLock {
+    _file: std::fs::File,
+}
+
+impl CredentialFileLock {
+    /// Acquire a shared (read) lock on the credential file.
+    #[expect(
+        dead_code,
+        reason = "available for load() callers that need consistency"
+    )]
+    fn shared(credential_path: &Path) -> std::io::Result<Self> {
+        Self::lock(credential_path, rustix::fs::FlockOperation::LockShared)
+    }
+
+    /// Acquire an exclusive (write) lock on the credential file.
+    fn exclusive(credential_path: &Path) -> std::io::Result<Self> {
+        Self::lock(credential_path, rustix::fs::FlockOperation::LockExclusive)
+    }
+
+    #[cfg(unix)]
+    #[expect(
+        unsafe_code,
+        reason = "BorrowedFd::borrow_raw requires unsafe; fd is valid for File's lifetime"
+    )]
+    fn lock(credential_path: &Path, op: rustix::fs::FlockOperation) -> std::io::Result<Self> {
+        use std::os::unix::io::AsRawFd;
+
+        let lock_path = credential_path.with_extension("json.lock");
+        let file = std::fs::OpenOptions::new()
+            .create(true)
+            .truncate(false)
+            .write(true)
+            .open(&lock_path)?;
+        // WHY: flock is advisory but sufficient when all writers cooperate
+        rustix::fs::flock(
+            unsafe { rustix::fd::BorrowedFd::borrow_raw(file.as_raw_fd()) },
+            op,
+        )
+        .map_err(|e| std::io::Error::from_raw_os_error(e.raw_os_error()))?;
+        Ok(Self { _file: file })
+    }
+
+    #[cfg(not(unix))]
+    fn lock(credential_path: &Path, _op: rustix::fs::FlockOperation) -> std::io::Result<Self> {
+        let lock_path = credential_path.with_extension("json.lock");
+        let file = std::fs::OpenOptions::new()
+            .create(true)
+            .truncate(false)
+            .write(true)
+            .open(&lock_path)?;
+        Ok(Self { _file: file })
+    }
+}
+
+// NOTE: lock is released when _file is dropped (flock semantics)
+
 #[derive(Deserialize)]
 struct OAuthResponse {
     access_token: String,
@@ -206,6 +314,22 @@ impl std::fmt::Debug for OAuthResponse {
 
 fn default_expires_in() -> u64 {
     28800 // NOTE: 8 hours
+}
+
+/// Clamp `expires_in` to [`MIN_EXPIRES_IN_SECS`, `MAX_EXPIRES_IN_SECS`].
+///
+/// WHY: a zero or negative value from a buggy OAuth server causes infinite
+/// refresh loops; an absurdly large value delays legitimate re-auth.
+fn clamp_expires_in(raw: u64) -> u64 {
+    let clamped = raw.clamp(MIN_EXPIRES_IN_SECS, MAX_EXPIRES_IN_SECS);
+    if clamped != raw {
+        warn!(
+            raw_expires_in = raw,
+            clamped_expires_in = clamped,
+            "OAuth expires_in outside [{MIN_EXPIRES_IN_SECS}, {MAX_EXPIRES_IN_SECS}], clamped"
+        );
+    }
+    clamped
 }
 
 /// OAuth token prefix used by Claude Code for OAuth access tokens.
@@ -504,6 +628,90 @@ impl CredentialProvider for RefreshingCredentialProvider {
 // NOTE: No Drop impl — cleanup is registered at setup time via CleanupRegistry.
 // The registry fires its callbacks (cancel token + abort task) on drop.
 
+/// Track last-observed mtime for file change detection.
+struct FileMtimeTracker {
+    last_mtime: Option<SystemTime>,
+}
+
+impl FileMtimeTracker {
+    fn new(path: &Path) -> Self {
+        let mtime = std::fs::metadata(path).ok().and_then(|m| m.modified().ok());
+        Self { last_mtime: mtime }
+    }
+
+    /// Returns `true` if the file's mtime has changed since last check.
+    fn has_changed(&mut self, path: &Path) -> bool {
+        let current = std::fs::metadata(path).ok().and_then(|m| m.modified().ok());
+        if current == self.last_mtime {
+            return false;
+        }
+        self.last_mtime = current;
+        true
+    }
+}
+
+/// Reload credentials from file when circuit is open and file has changed.
+fn try_reload_from_file(
+    state: &RwLock<Option<RefreshState>>,
+    path: &Path,
+    circuit_breaker: &CircuitBreaker,
+) {
+    let Some(file_cred) = CredentialFile::load(path) else {
+        return;
+    };
+    info!("credential file changed externally while circuit open, reloading");
+    if let Ok(mut guard) = state.write() {
+        *guard = Some(RefreshState {
+            current_token: SecretString::from(file_cred.token),
+            refresh_token: file_cred.refresh_token.map_or_else(
+                || {
+                    guard
+                        .as_ref()
+                        .map_or_else(|| SecretString::from(""), |s| s.refresh_token.clone())
+                },
+                SecretString::from,
+            ),
+            expires_at_ms: file_cred.expires_at.unwrap_or(0),
+            subscription_type: file_cred.subscription_type,
+        });
+    }
+    circuit_breaker.reset();
+}
+
+/// Build the post-refresh state, adopting the on-disk credential if newer.
+fn resolve_post_refresh_state(
+    path: &Path,
+    resp: OAuthResponse,
+    new_expires_at_ms: u64,
+    subscription_type: Option<String>,
+) -> RefreshState {
+    if let Some(on_disk) = CredentialFile::load(path)
+        && on_disk.expires_at.unwrap_or(0) > new_expires_at_ms
+    {
+        info!(
+            our_expiry = new_expires_at_ms,
+            file_expiry = on_disk.expires_at.unwrap_or(0),
+            "file has newer credential than our refresh, adopting"
+        );
+        RefreshState {
+            current_token: SecretString::from(on_disk.token),
+            refresh_token: on_disk.refresh_token.map_or_else(
+                || SecretString::from(resp.refresh_token),
+                SecretString::from,
+            ),
+            expires_at_ms: on_disk.expires_at.unwrap_or(new_expires_at_ms),
+            subscription_type: on_disk.subscription_type,
+        }
+    } else {
+        RefreshState {
+            current_token: SecretString::from(resp.access_token),
+            refresh_token: SecretString::from(resp.refresh_token),
+            expires_at_ms: new_expires_at_ms,
+            subscription_type,
+        }
+    }
+}
+
 async fn refresh_loop(
     state: Arc<RwLock<Option<RefreshState>>>,
     shutdown: CancellationToken,
@@ -512,6 +720,7 @@ async fn refresh_loop(
 ) {
     let client = reqwest::Client::new();
     let check_interval = Duration::from_secs(REFRESH_CHECK_INTERVAL_SECS);
+    let mut mtime_tracker = FileMtimeTracker::new(&path);
 
     loop {
         tokio::select! {
@@ -523,6 +732,19 @@ async fn refresh_loop(
             () = tokio::time::sleep(check_interval) => {}
         }
 
+        // FIX 4: when circuit is open, poll file for external credential updates
+        if !circuit_breaker.check_allowed() {
+            if mtime_tracker.has_changed(&path) {
+                try_reload_from_file(&state, &path, &circuit_breaker);
+            } else {
+                debug!(
+                    state = %circuit_breaker.state(),
+                    "OAuth refresh circuit breaker is open, skipping refresh attempt"
+                );
+            }
+            continue;
+        }
+
         let (refresh_token_value, subscription_type, expires_at_ms, needs_refresh) = {
             let Ok(guard) = state.read() else {
                 continue;
@@ -531,18 +753,15 @@ async fn refresh_loop(
                 continue;
             };
             let now_ms = unix_epoch_ms();
-            // WHY: ms timestamps fit in i64 until year 292M; subtraction gives signed delta
             let expires_i64 = i64::try_from(s.expires_at_ms).unwrap_or(i64::MAX);
             let now_i64 = i64::try_from(now_ms).unwrap_or(i64::MAX);
             let remaining_secs = (expires_i64 - now_i64) / 1000;
-            // WHY: REFRESH_THRESHOLD_SECS is a small constant that fits in i64
             let threshold = i64::try_from(REFRESH_THRESHOLD_SECS).unwrap_or(i64::MAX);
-            let needs = remaining_secs < threshold;
             (
                 s.refresh_token.expose_secret().to_owned(),
                 s.subscription_type.clone(),
                 s.expires_at_ms,
-                needs,
+                remaining_secs < threshold,
             )
         };
 
@@ -550,51 +769,50 @@ async fn refresh_loop(
             continue;
         }
 
-        if !circuit_breaker.check_allowed() {
-            debug!(
-                state = %circuit_breaker.state(),
-                "OAuth refresh circuit breaker is open, skipping refresh attempt"
-            );
-            continue;
-        }
-
         info!(
             expires_at_ms,
             now_ms = unix_epoch_ms(),
-            "credential refresh needed, refreshing OAuth token"
+            "credential refresh needed"
         );
 
         if let Some(resp) = do_refresh(&client, &refresh_token_value).await {
             circuit_breaker.record_success();
-
-            let now_ms = unix_epoch_ms();
-            let expires_at_ms = now_ms + resp.expires_in * 1000;
-
-            if let Ok(mut guard) = state.write() {
-                *guard = Some(RefreshState {
-                    current_token: SecretString::from(resp.access_token.clone()),
-                    refresh_token: SecretString::from(resp.refresh_token.clone()),
-                    expires_at_ms,
-                    subscription_type: subscription_type.clone(),
-                });
-            }
+            let expires_in = clamp_expires_in(resp.expires_in);
+            let new_expires_at_ms = unix_epoch_ms() + expires_in * 1000;
 
             let scopes = resp
                 .scope
+                .as_deref()
                 .map(|s| s.split_whitespace().map(String::from).collect());
             let cred_file = CredentialFile {
-                token: resp.access_token,
-                refresh_token: Some(resp.refresh_token),
-                expires_at: Some(expires_at_ms),
+                token: resp.access_token.clone(),
+                refresh_token: Some(resp.refresh_token.clone()),
+                expires_at: Some(new_expires_at_ms),
                 scopes,
-                subscription_type,
+                subscription_type: subscription_type.clone(),
             };
-            if let Err(e) = cred_file.save(&path) {
-                warn!(error = %e, "failed to write refreshed credential file");
-            }
 
-            crate::metrics::record_token_refresh(true);
-            info!(expires_in_secs = resp.expires_in, "OAuth token refreshed");
+            match cred_file.save(&path) {
+                Ok(()) => {
+                    mtime_tracker.has_changed(&path);
+                    let final_state = resolve_post_refresh_state(
+                        &path,
+                        resp,
+                        new_expires_at_ms,
+                        subscription_type,
+                    );
+                    if let Ok(mut guard) = state.write() {
+                        *guard = Some(final_state);
+                    }
+                    crate::metrics::record_token_refresh(true);
+                    info!(expires_in_secs = expires_in, "OAuth token refreshed");
+                }
+                Err(e) => {
+                    error!(error = %e, "failed to write refreshed credential file, keeping previous in-memory token");
+                    crate::metrics::record_credential_write_failure();
+                    crate::metrics::record_token_refresh(true);
+                }
+            }
         } else {
             circuit_breaker.record_failure();
             crate::metrics::record_token_refresh(false);
@@ -664,8 +882,9 @@ pub async fn force_refresh(path: &Path) -> Result<CredentialFile, String> {
         .await
         .ok_or("OAuth refresh failed")?;
 
+    let expires_in = clamp_expires_in(resp.expires_in);
     let now_ms = unix_epoch_ms();
-    let expires_at_ms = now_ms + resp.expires_in * 1000;
+    let expires_at_ms = now_ms + expires_in * 1000;
 
     let scopes = resp
         .scope

--- a/crates/symbolon/src/encrypt.rs
+++ b/crates/symbolon/src/encrypt.rs
@@ -88,6 +88,70 @@ pub(crate) fn load_or_create_key(credential_path: &Path) -> std::io::Result<[u8;
     Ok(key)
 }
 
+/// Load an existing key or generate one without persisting.
+///
+/// Returns `(key, needs_persist)` — the caller must call [`write_key_file_atomic`]
+/// after both the key and credential temp files are ready.
+pub(crate) fn load_or_generate_key(
+    credential_path: &Path,
+) -> std::io::Result<([u8; KEY_LEN], bool)> {
+    let key_path = key_file_path(credential_path);
+    if key_path.exists() {
+        #[expect(
+            clippy::disallowed_methods,
+            reason = "symbolon credential storage writes configuration files; synchronous I/O is required in CLI/init contexts"
+        )]
+        let bytes = std::fs::read(&key_path)?;
+        let key: [u8; KEY_LEN] = bytes.try_into().map_err(|_ignored| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "encryption key file has wrong length (expected 32 bytes)",
+            )
+        })?;
+        Ok((key, false))
+    } else {
+        let key = generate_key()?;
+        Ok((key, true))
+    }
+}
+
+/// Write a key to a temp file, fsync, and return the temp path for later rename.
+///
+/// # Errors
+///
+/// Returns an `io::Error` if temp file creation or write fails.
+pub(crate) fn prepare_key_file(
+    credential_path: &Path,
+    key: &[u8; KEY_LEN],
+) -> std::io::Result<PathBuf> {
+    let key_path = key_file_path(credential_path);
+    let tmp = key_path.with_extension("key.tmp");
+    if let Some(parent) = key_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let mut f = std::fs::File::create(&tmp)?;
+    f.write_all(key)?;
+    f.flush()?;
+    f.sync_all()?;
+    Ok(tmp)
+}
+
+/// Rename a prepared key temp file to its final path with mode 0600.
+///
+/// # Errors
+///
+/// Returns an `io::Error` if the rename or permission set fails.
+pub(crate) fn commit_key_file(credential_path: &Path, tmp: &Path) -> std::io::Result<()> {
+    let key_path = key_file_path(credential_path);
+    std::fs::rename(tmp, &key_path)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&key_path, std::fs::Permissions::from_mode(0o600))?;
+    }
+    Ok(())
+}
+
 /// Encrypt `plaintext` using AES-256-GCM with a fresh random nonce.
 ///
 /// Returns base64-encoded `nonce || ciphertext_with_tag`.

--- a/crates/symbolon/src/metrics.rs
+++ b/crates/symbolon/src/metrics.rs
@@ -31,11 +31,20 @@ static TOKEN_REFRESHES_TOTAL: LazyLock<IntCounterVec> = LazyLock::new(|| {
     .expect("metric registration")
 });
 
+static CREDENTIAL_WRITE_FAILURES_TOTAL: LazyLock<prometheus::IntCounter> = LazyLock::new(|| {
+    prometheus::register_int_counter!(
+        "aletheia_credential_write_failures_total",
+        "Total credential file write failures"
+    )
+    .expect("metric registration")
+});
+
 /// Force-initialize all lazy metric statics.
 pub fn init() {
     // kanon:ignore RUST/pub-visibility
     LazyLock::force(&AUTH_ATTEMPTS_TOTAL);
     LazyLock::force(&TOKEN_REFRESHES_TOTAL);
+    LazyLock::force(&CREDENTIAL_WRITE_FAILURES_TOTAL);
 }
 
 /// Record an authentication attempt.
@@ -50,6 +59,11 @@ pub(crate) fn record_auth_attempt(method: &str, success: bool) {
 pub(crate) fn record_token_refresh(success: bool) {
     let status = if success { "ok" } else { "error" };
     TOKEN_REFRESHES_TOTAL.with_label_values(&[status]).inc();
+}
+
+/// Record a credential file write failure.
+pub(crate) fn record_credential_write_failure() {
+    CREDENTIAL_WRITE_FAILURES_TOTAL.inc();
 }
 
 #[cfg(test)]
@@ -71,5 +85,10 @@ mod tests {
     fn record_token_refresh_does_not_panic() {
         record_token_refresh(true);
         record_token_refresh(false);
+    }
+
+    #[test]
+    fn record_credential_write_failure_does_not_panic() {
+        record_credential_write_failure();
     }
 }


### PR DESCRIPTION
## Summary

- **Persist before memory**: disk write happens first; in-memory state only updates on success. Disk failure keeps previous valid token.
- **Atomic pair writes**: key+credential temp files are fsynced before either rename; cleanup on failure.
- **File locking**: `flock()` via `rustix` prevents CC/refresh race conditions during write cycles.
- **Circuit breaker file polling**: when circuit is open, polls credential file mtime for external changes (e.g. CC writing fresh creds) and resets circuit on detection.
- **Refresh token regression guard**: after saving, re-reads file and adopts on-disk credential if its expiry is newer than what was just written.
- **Expiry clamping**: `expires_in` clamped to `[60, 86400]` seconds with warning log.
- **Temp file cleanup**: `CredentialFile::load()` removes orphaned `.json.tmp` files on startup.
- **Write failure metrics**: `aletheia_credential_write_failures_total` counter + ERROR-level logging on disk write failure.

Closes #1972

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace --exclude theatron-desktop --all-targets -- -D warnings` passes
- [x] `cargo test --workspace --all-features` passes (all 135 symbolon tests pass)
- [ ] Manual: kill process mid-write, verify orphaned temp file cleaned on next load
- [ ] Manual: simulate CC writing newer credentials during refresh, verify adoption

🤖 Generated with [Claude Code](https://claude.com/claude-code)