### PR TITLE
fix(tui): cursor style, paragraph breaks, SSE reconnect, stale docs

### DIFF
--- a/crates/theatron/tui/src/view/chat.rs
+++ b/crates/theatron/tui/src/view/chat.rs
@@ -875,6 +875,13 @@ fn render_streaming(
 
         // Render the partial line buffer (not yet flushed to streaming_text)
         if !app.connection.streaming_line_buffer.is_empty() {
+            // WHY: markdown strips trailing blank lines, so a \n\n paragraph break at
+            // the end of streaming_text is invisible in the rendered output.  Re-insert
+            // the blank line here so the gap is visible while the next paragraph is
+            // still being typed into the buffer.
+            if app.connection.streaming_text.ends_with("\n\n") {
+                lines.push(Line::raw(""));
+            }
             lines.push(Line::from(vec![
                 Span::raw(" "),
                 Span::styled(

--- a/crates/theatron/tui/src/view/status_bar.rs
+++ b/crates/theatron/tui/src/view/status_bar.rs
@@ -272,6 +272,15 @@ fn agent_identity_spans(app: &App, theme: &Theme) -> Vec<Span<'static>> {
     spans
 }
 
+/// How long the SSE connection must be down before "Reconnecting…" is shown.
+///
+/// WHY: Normal server-side SSE resets (keepalive gaps, load balancer timeouts)
+/// trigger a disconnect/reconnect cycle that typically completes in under 1s.
+/// Showing "Reconnecting…" immediately causes a brief flicker on every normal
+/// reconnect.  A 2s debounce hides transient blips while still surfacing genuine
+/// outages in a timely way.
+const RECONNECT_LABEL_DEBOUNCE: std::time::Duration = std::time::Duration::from_secs(2);
+
 fn connection_indicator_spans(app: &App, theme: &Theme) -> Vec<Span<'static>> {
     if app.connection.sse_connected {
         // WHY: The SSE layer triggers a reconnect after 30s of silence (READ_TIMEOUT).
@@ -290,7 +299,12 @@ fn connection_indicator_spans(app: &App, theme: &Theme) -> Vec<Span<'static>> {
         } else {
             vec![Span::styled("●", theme.style_success())]
         }
-    } else if app.connection.sse_disconnected_at.is_some() {
+    } else if app
+        .connection
+        .sse_disconnected_at
+        .is_some_and(|t| t.elapsed() >= RECONNECT_LABEL_DEBOUNCE)
+    {
+        // WHY: only label after the debounce window to avoid flicker on transient reconnects
         vec![
             Span::styled("○", theme.style_error()),
             Span::styled(" Reconnecting…", theme.style_dim()),

--- a/instance.example/nous/_default/MEMORY.md
+++ b/instance.example/nous/_default/MEMORY.md
@@ -6,7 +6,7 @@ Keep this file lean. If an entry is no longer relevant, delete it. If it belongs
 
 ## System
 
-- Runtime: Aletheia v0.12.0+ (self-hosted, single binary, Rust)
+- Runtime: Aletheia v0.13.1 (self-hosted, single binary, Rust)
 - Source: https://github.com/forkwright/aletheia
 - Standing order: log bugs and improvements as issues on the repo
 - Config: instance/config/aletheia.toml (TOML, figment cascade)


### PR DESCRIPTION
## Summary

- **#1978** Cursor: `SteadyBlock` on enter, `DefaultUserShape` on exit was already present in `lib.rs`; confirmed no change needed
- **#1979** Paragraph breaks: markdown renders drop trailing `\n\n`, so paragraph breaks between streaming sentences were invisible. Insert a blank line before the partial-line buffer when `streaming_text` ends with `\n\n` (`view/chat.rs`)
- **#1983** SSE reconnect flicker: debounce the "Reconnecting…" status-bar label by 2s so normal keepalive-gap reconnects don't flicker the indicator (`view/status_bar.rs`)
- **#1976** Stale agent docs: update `MEMORY.md` runtime version from `v0.12.0+` → `v0.13.1`

## Test plan

- [ ] `cargo test --workspace` passes (all existing tests green)
- [ ] `cargo clippy --workspace` zero warnings
- [ ] Streaming a multi-paragraph response shows blank lines between paragraphs while streaming
- [ ] Status bar shows "●" (not "○ Reconnecting…") during brief SSE keepalive reconnects
- [ ] Status bar shows "○ Reconnecting…" after sustained disconnect (>2s)
- [ ] TUI cursor is a non-blinking solid block

🤖 Generated with [Claude Code](https://claude.com/claude-code)