### PR TITLE
fix(nous,organon): tool spam, path validation, sandbox RLIMIT

### DIFF
--- a/crates/aletheia/src/commands/server/mod.rs
+++ b/crates/aletheia/src/commands/server/mod.rs
@@ -360,6 +360,7 @@ pub(crate) async fn run(args: Args) -> Result<()> {
                     loop_max_warnings: 2,
                     session_token_cap: 500_000,
                     max_tool_result_bytes: resolved.limits.max_tool_result_bytes,
+                    max_consecutive_tool_only_iterations: 3,
                 },
                 domains,
                 server_tools: Vec::new(),

--- a/crates/aletheia/src/commands/server/setup.rs
+++ b/crates/aletheia/src/commands/server/setup.rs
@@ -162,6 +162,7 @@ pub(super) fn build_tool_registry(
             _ => aletheia_organon::sandbox::EgressPolicy::Allow,
         },
         egress_allowlist: sandbox_settings.egress_allowlist.clone(),
+        nproc_limit: sandbox_settings.nproc_limit,
     };
     builtins::register_all_with_sandbox(&mut registry, sandbox)
         .context("failed to register builtin tools")?;

--- a/crates/nous/src/config.rs
+++ b/crates/nous/src/config.rs
@@ -66,6 +66,15 @@ pub struct NousLimits {
     /// the original and truncated sizes. Set to `0` to disable. Default:
     /// 32 768 bytes (32 KB).
     pub max_tool_result_bytes: u32,
+    /// Maximum consecutive LLM iterations that produce only tool calls
+    /// without any reasoning text before a think-first prompt is injected.
+    ///
+    /// WHY: Without this limit, agents can fire long bursts of tool calls
+    /// before producing any reasoning, wasting tokens and obscuring intent.
+    /// When the limit is hit, a system message is injected asking the agent
+    /// to explain its reasoning before making more tool calls. Set to `0` to
+    /// disable. Default: 3. Closes #1980.
+    pub max_consecutive_tool_only_iterations: u32,
 }
 
 impl Default for NousLimits {
@@ -78,6 +87,7 @@ impl Default for NousLimits {
             loop_max_warnings: 2,
             session_token_cap: default_session_token_cap(),
             max_tool_result_bytes: default_max_tool_result_bytes(),
+            max_consecutive_tool_only_iterations: 3,
         }
     }
 }
@@ -233,6 +243,10 @@ mod tests {
             "default should match koina::defaults"
         );
         assert!(!config.generation.thinking_enabled);
+        assert_eq!(
+            config.limits.max_consecutive_tool_only_iterations, 3,
+            "default tool-only iteration limit should be 3"
+        );
     }
 
     #[test]
@@ -291,6 +305,7 @@ mod tests {
                 loop_max_warnings: 2,
                 session_token_cap: 250_000,
                 max_tool_result_bytes: 32_768,
+                max_consecutive_tool_only_iterations: 3,
             },
             domains: vec!["medical".to_owned()],
             server_tools: Vec::new(),

--- a/crates/nous/src/execute/mod.rs
+++ b/crates/nous/src/execute/mod.rs
@@ -168,6 +168,7 @@ pub async fn execute(
         config.limits.loop_max_warnings,
     );
     let mut iterations: u32 = 0;
+    let mut consecutive_tool_only: u32 = 0;
     let mut final_content = String::new();
     let mut final_stop_reason = String::new();
     let mut used_server_web_search = false;
@@ -247,6 +248,19 @@ pub async fn execute(
             break;
         }
 
+        // WHY: Track consecutive iterations that produce tool calls without any
+        // reasoning text. When the limit is hit, inject a system message asking
+        // the agent to explain its reasoning before continuing. Closes #1980.
+        let has_reasoning = extracted
+            .text_parts
+            .iter()
+            .any(|t| t.chars().any(|c| !c.is_whitespace()));
+        if has_reasoning {
+            consecutive_tool_only = 0;
+        } else {
+            consecutive_tool_only += 1;
+        }
+
         messages.push(Message {
             role: Role::Assistant,
             content: Content::Blocks(response_content),
@@ -300,6 +314,23 @@ pub async fn execute(
                 text: format!("[System: {warning}]"),
                 citations: None,
             });
+        }
+
+        let tool_only_limit = config.limits.max_consecutive_tool_only_iterations;
+        if tool_only_limit > 0 && consecutive_tool_only >= tool_only_limit {
+            debug!(
+                consecutive_tool_only,
+                limit = tool_only_limit,
+                "tool-only iteration limit reached, injecting reasoning prompt"
+            );
+            blocks.push(ContentBlock::Text {
+                text: "[System: You have made several consecutive tool calls without explaining \
+                       your reasoning. Before making more tool calls, briefly explain what you \
+                       are trying to accomplish and why these tool calls are needed.]"
+                    .to_owned(),
+                citations: None,
+            });
+            consecutive_tool_only = 0;
         }
 
         messages.push(Message {
@@ -367,6 +398,7 @@ pub async fn execute_streaming(
         config.limits.loop_max_warnings,
     );
     let mut iterations: u32 = 0;
+    let mut consecutive_tool_only: u32 = 0;
     let mut final_content = String::new();
     let mut final_stop_reason = String::new();
     let mut used_server_web_search = false;
@@ -459,6 +491,16 @@ pub async fn execute_streaming(
             break;
         }
 
+        let has_reasoning = extracted
+            .text_parts
+            .iter()
+            .any(|t| t.chars().any(|c| !c.is_whitespace()));
+        if has_reasoning {
+            consecutive_tool_only = 0;
+        } else {
+            consecutive_tool_only += 1;
+        }
+
         messages.push(Message {
             role: Role::Assistant,
             content: Content::Blocks(response_content),
@@ -511,6 +553,23 @@ pub async fn execute_streaming(
                 text: format!("[System: {warning}]"),
                 citations: None,
             });
+        }
+
+        let tool_only_limit = config.limits.max_consecutive_tool_only_iterations;
+        if tool_only_limit > 0 && consecutive_tool_only >= tool_only_limit {
+            debug!(
+                consecutive_tool_only,
+                limit = tool_only_limit,
+                "tool-only iteration limit reached, injecting reasoning prompt"
+            );
+            blocks.push(ContentBlock::Text {
+                text: "[System: You have made several consecutive tool calls without explaining \
+                       your reasoning. Before making more tool calls, briefly explain what you \
+                       are trying to accomplish and why these tool calls are needed.]"
+                    .to_owned(),
+                citations: None,
+            });
+            consecutive_tool_only = 0;
         }
 
         messages.push(Message {

--- a/crates/nous/src/spawn_svc.rs
+++ b/crates/nous/src/spawn_svc.rs
@@ -99,6 +99,7 @@ impl SpawnService for SpawnServiceImpl {
                 loop_max_warnings: 2,
                 session_token_cap: 500_000,
                 max_tool_result_bytes: 32_768,
+                max_consecutive_tool_only_iterations: 3,
             },
             domains: Vec::new(),
             server_tools: Vec::new(),

--- a/crates/organon/src/builtins/workspace.rs
+++ b/crates/organon/src/builtins/workspace.rs
@@ -78,20 +78,6 @@ pub(crate) fn validate_path(raw: &str, ctx: &ToolContext, tool_name: &ToolName) 
 
     let normalized = normalize(&resolved);
 
-    // PERF: First check the normalized path (fast path, catches obvious traversals)
-    let allowed = ctx
-        .allowed_roots
-        .iter()
-        .any(|root| normalized.starts_with(root));
-
-    if !allowed {
-        return Err(error::InvalidInputSnafu {
-            name: tool_name.clone(),
-            reason: format!("path outside allowed roots: {raw}"),
-        }
-        .build());
-    }
-
     // NOTE: Resolve symlinks to prevent symlink-based escapes.
     // If the file exists, canonicalize it directly.
     // If not (e.g. write to new file), canonicalize the parent directory.
@@ -117,13 +103,17 @@ pub(crate) fn validate_path(raw: &str, ctx: &ToolContext, tool_name: &ToolName) 
 
     let canonical = canonical.unwrap_or_else(|_| normalized.clone());
 
-    // NOTE: Re-check canonical path against allowed roots
-    let canonical_allowed = ctx.allowed_roots.iter().any(|root| {
-        let canon_root = root.canonicalize().unwrap_or_else(|_| root.clone());
-        canonical.starts_with(&canon_root)
+    // WHY: Single-phase check using canonical paths for both the input and
+    // the allowed roots. The previous two-phase approach hard-rejected in the
+    // normalized check before reaching the canonical check, which broke when
+    // oikos canonicalized roots at startup (resolving symlinks) but the input
+    // path used the non-canonical form. Closes #1981.
+    let allowed = ctx.allowed_roots.iter().any(|root| {
+        let canon_root = root.canonicalize().unwrap_or_else(|_| normalize(root));
+        canonical.starts_with(&canon_root) || normalized.starts_with(&canon_root)
     });
 
-    if !canonical_allowed {
+    if !allowed {
         return Err(error::InvalidInputSnafu {
             name: tool_name.clone(),
             reason: format!("path outside allowed roots: {raw}"),
@@ -494,6 +484,8 @@ impl ToolExecutor for ExecExecutor {
             // RLIMIT_CPU caps CPU seconds. Closes #1717.
             #[cfg(target_os = "linux")]
             {
+                let nproc_cap = u64::from(self.sandbox.nproc_limit);
+
                 // SAFETY: setrlimit is async-signal-safe and only modifies the
                 // calling process's resource limits. Runs between fork and exec.
                 #[expect(
@@ -501,13 +493,16 @@ impl ToolExecutor for ExecExecutor {
                     reason = "pre_exec requires unsafe; setrlimit is async-signal-safe"
                 )]
                 unsafe {
-                    cmd.pre_exec(|| {
+                    cmd.pre_exec(move || {
                         use rustix::process::{Resource, Rlimit, setrlimit};
 
-                        // Cap subprocess count to prevent fork bombs
+                        // WHY: Cap subprocess count to prevent fork bombs.
+                        // RLIMIT_NPROC counts ALL user processes, not just sandbox
+                        // children, so the limit must be high enough to accommodate
+                        // existing background processes. Closes #1984.
                         let nproc_limit = Rlimit {
-                            current: Some(64),
-                            maximum: Some(64),
+                            current: Some(nproc_cap),
+                            maximum: Some(nproc_cap),
                         };
                         let _ = setrlimit(Resource::Nproc, nproc_limit);
 

--- a/crates/organon/src/builtins/workspace_tests/path_ops.rs
+++ b/crates/organon/src/builtins/workspace_tests/path_ops.rs
@@ -779,3 +779,92 @@ fn test_normalize_removes_current_dir_component() {
         "current directory components should be removed"
     );
 }
+
+#[test]
+fn test_validate_path_accepts_canonical_root_with_symlinked_input() {
+    // WHY: oikos canonicalizes roots at startup, so the allowed_roots contain
+    // the canonical (symlink-resolved) path. Input paths using the non-canonical
+    // form (through a symlink) must still be accepted. Closes #1981.
+    let dir = tempfile::tempdir().expect("create temp dir");
+    let real_dir = dir.path().join("real");
+    std::fs::create_dir(&real_dir).expect("create real dir");
+    std::fs::create_dir(real_dir.join("sub")).expect("create sub dir");
+
+    // NOTE: Create a symlink pointing to the real directory
+    #[cfg(unix)]
+    {
+        let link_dir = dir.path().join("link");
+        std::os::unix::fs::symlink(&real_dir, &link_dir).expect("create symlink");
+
+        // Set allowed_roots to the CANONICAL (real) path
+        let canonical_root = real_dir.canonicalize().expect("canonicalize real");
+        let ctx = ToolContext {
+            nous_id: NousId::new("test-agent").expect("valid"),
+            session_id: SessionId::new(),
+            workspace: canonical_root.clone(),
+            allowed_roots: vec![canonical_root],
+            services: None,
+            active_tools: Arc::new(RwLock::new(HashSet::new())),
+        };
+        let name = aletheia_koina::id::ToolName::new("ls").expect("valid");
+
+        // Validate a path using the SYMLINK form — should pass
+        let link_sub = link_dir.join("sub");
+        let result = validate_path(link_sub.to_str().expect("utf8"), &ctx, &name);
+        assert!(
+            result.is_ok(),
+            "path through symlink should be accepted when canonical root matches: {result:?}"
+        );
+    }
+}
+
+#[test]
+fn test_validate_path_trailing_slash_in_root() {
+    let dir = tempfile::tempdir().expect("create temp dir");
+    let name = aletheia_koina::id::ToolName::new("read").expect("valid");
+
+    // WHY: Trailing slashes in allowed roots must not break the prefix check.
+    let root_with_slash = PathBuf::from(format!("{}/", dir.path().display()));
+    let ctx = ToolContext {
+        nous_id: NousId::new("test-agent").expect("valid"),
+        session_id: SessionId::new(),
+        workspace: dir.path().to_path_buf(),
+        allowed_roots: vec![root_with_slash],
+        services: None,
+        active_tools: Arc::new(RwLock::new(HashSet::new())),
+    };
+
+    #[expect(
+        clippy::disallowed_methods,
+        reason = "organon workspace tools directly implement filesystem operations exposed to agents; synchronous access matches the tool executor contract"
+    )]
+    std::fs::write(dir.path().join("file.txt"), "data").expect("write");
+
+    let result = validate_path("file.txt", &ctx, &name);
+    assert!(
+        result.is_ok(),
+        "path within root with trailing slash should be accepted: {result:?}"
+    );
+}
+
+#[test]
+fn test_validate_path_root_exact_match() {
+    // WHY: `ls` on the root itself should be allowed.
+    let dir = tempfile::tempdir().expect("create temp dir");
+    let name = aletheia_koina::id::ToolName::new("ls").expect("valid");
+    let canonical = dir.path().canonicalize().expect("canonicalize");
+    let ctx = ToolContext {
+        nous_id: NousId::new("test-agent").expect("valid"),
+        session_id: SessionId::new(),
+        workspace: canonical.clone(),
+        allowed_roots: vec![canonical.clone()],
+        services: None,
+        active_tools: Arc::new(RwLock::new(HashSet::new())),
+    };
+
+    let result = validate_path(canonical.to_str().expect("utf8"), &ctx, &name);
+    assert!(
+        result.is_ok(),
+        "path that exactly matches an allowed root should be accepted: {result:?}"
+    );
+}

--- a/crates/organon/src/sandbox/config.rs
+++ b/crates/organon/src/sandbox/config.rs
@@ -86,6 +86,13 @@ pub struct SandboxConfig {
     /// destinations can be enforced without root privileges; non-loopback
     /// entries log a warning.
     pub egress_allowlist: Vec<String>,
+    /// Maximum number of processes (`RLIMIT_NPROC`) for exec child processes.
+    ///
+    /// WHY: `RLIMIT_NPROC` counts ALL processes for the user, not just sandbox
+    /// children. The previous default of 64 caused EAGAIN failures on systems
+    /// running dispatch agents or other background processes. Default: 256.
+    /// Closes #1984.
+    pub nproc_limit: u32,
 }
 
 impl Default for SandboxConfig {
@@ -99,6 +106,7 @@ impl Default for SandboxConfig {
             extra_exec_paths: Vec::new(),
             egress: EgressPolicy::default(),
             egress_allowlist: Vec::new(),
+            nproc_limit: 256,
         }
     }
 }
@@ -312,5 +320,21 @@ mod tests {
     #[test]
     fn egress_policy_default_is_allow() {
         assert_eq!(EgressPolicy::default(), EgressPolicy::Allow);
+    }
+
+    #[test]
+    fn nproc_limit_default_is_256() {
+        let config = SandboxConfig::default();
+        assert_eq!(
+            config.nproc_limit, 256,
+            "nproc_limit should default to 256 to accommodate background processes"
+        );
+    }
+
+    #[test]
+    fn nproc_limit_configurable_via_serde() {
+        let json = r#"{"enabled":true,"nprocLimit":512}"#;
+        let config: SandboxConfig = serde_json::from_str(json).expect("parse");
+        assert_eq!(config.nproc_limit, 512);
     }
 }

--- a/crates/organon/src/sandbox/tests/mod.rs
+++ b/crates/organon/src/sandbox/tests/mod.rs
@@ -68,6 +68,7 @@ fn config_serde_roundtrip() {
         extra_exec_paths: vec![PathBuf::from("/opt/scripts")],
         egress: EgressPolicy::Allow,
         egress_allowlist: Vec::new(),
+        nproc_limit: 256,
     };
     let json = serde_json::to_string(&config).expect("serialize");
     let back: SandboxConfig = serde_json::from_str(&json).expect("deserialize");

--- a/crates/taxis/src/config/maintenance.rs
+++ b/crates/taxis/src/config/maintenance.rs
@@ -241,6 +241,11 @@ pub struct SandboxSettings {
     pub egress: EgressPolicy,
     /// CIDR ranges or addresses permitted when `egress = "allowlist"`.
     pub egress_allowlist: Vec<String>,
+    /// Maximum number of processes (`RLIMIT_NPROC`) for exec child processes.
+    ///
+    /// WHY: `RLIMIT_NPROC` counts ALL processes for the user, not just sandbox
+    /// children. Default: 256. Closes #1984.
+    pub nproc_limit: u32,
 }
 
 impl Default for SandboxSettings {
@@ -254,6 +259,7 @@ impl Default for SandboxSettings {
             extra_exec_paths: Vec::new(),
             egress: EgressPolicy::default(),
             egress_allowlist: Vec::new(),
+            nproc_limit: 256,
         }
     }
 }


### PR DESCRIPTION
## Summary

- **Tool call spam (#1980):** Add `max_consecutive_tool_only_iterations` limit (default: 3) to `NousLimits`. When the agent fires consecutive tool calls without producing any reasoning text, a system message is injected asking it to explain its intent before continuing. Applied to both `execute()` and `execute_streaming()`.

- **Path validation (#1981):** Merge the two-phase `validate_path()` check into a single canonical-authority check. The previous approach hard-rejected in the normalized check before reaching the canonical check, which broke when oikos canonicalized roots at startup (resolving symlinks) but input paths used the non-canonical form.

- **Sandbox RLIMIT_NPROC (#1984):** Raise default from 64 to 256 and make configurable via `SandboxConfig.nproc_limit` and `SandboxSettings.nproc_limit`. `RLIMIT_NPROC` counts ALL user processes, not just sandbox children, so 64 was too restrictive on systems running dispatch agents.

Closes #1980, closes #1981, closes #1984.

## Test plan

- [x] New test: symlinked path accepted when canonical root matches
- [x] New test: trailing slash in allowed root
- [x] New test: root exact match
- [x] New test: `nproc_limit` default is 256
- [x] New test: `nproc_limit` configurable via serde
- [x] New test: `max_consecutive_tool_only_iterations` default is 3
- [x] `cargo clippy --workspace`: zero warnings
- [x] `cargo test --workspace --all-features`: all passing