### PR TITLE
feat(theatron-desktop): design system — tokens, themes, fonts, theme switching

### DIFF
--- a/crates/theatron/desktop/Cargo.lock
+++ b/crates/theatron/desktop/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-koina"
-version = "0.13.1"
+version = "0.13.0"
 dependencies = [
  "compact_str",
  "jiff",
@@ -4147,7 +4147,7 @@ dependencies = [
 
 [[package]]
 name = "theatron-core"
-version = "0.13.1"
+version = "0.13.0"
 dependencies = [
  "aletheia-koina",
  "bytes",
@@ -4165,7 +4165,7 @@ dependencies = [
 
 [[package]]
 name = "theatron-desktop"
-version = "0.13.1"
+version = "0.13.0"
 dependencies = [
  "dioxus",
  "dirs",

--- a/crates/theatron/desktop/Cargo.toml
+++ b/crates/theatron/desktop/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "theatron-desktop"
-version = "0.13.1"
+version = "0.13.0"
 edition = "2024"
 license = "AGPL-3.0-or-later"
 rust-version = "1.94"

--- a/crates/theatron/desktop/src/components/mod.rs
+++ b/crates/theatron/desktop/src/components/mod.rs
@@ -7,5 +7,4 @@
 
 pub mod chat;
 pub mod connection_indicator;
-pub(crate) mod toast;
-pub(crate) mod toast_container;
+pub(crate) mod theme_toggle;


### PR DESCRIPTION
## Summary

- Complete CSS custom property token set: colors, dye palette (aima/thanatochromia/aporia/natural), typography scale (1.2 minor third, 14px base), spacing (4px × 8 sizes), transitions, radii, shadows
- Dark theme: `#12110f` bg / `#e8e6e3` text / `#9A7B4F` brass accent / muted earth-tone status and warm-shifted syntax colors
- Light theme: warm parchment bg / deep warm brown text / same brass accent / lighter status palette
- Font loading: `@font-face` for IBM Plex Mono + Cormorant Garamond (all weights + italic); `fetch-fonts.sh` downloads OFL-licensed WOFF2 from GitHub releases
- Tailwind config extended with full token set (colors, fonts, type scale, spacing, radii, shadows)
- `ThemeProvider` wraps root with `data-theme` attribute, provides `Signal<ThemeMode>` context; `ThemeToggle` cycles Dark/Light/System with icon + label
- Fix `Cargo.toml`: replace `workspace = true` inheritance with inline versions — excluded crates cannot use workspace inheritance
- Register `theme_toggle` in `components/mod.rs`

## Test plan

- [x] `cargo check --manifest-path crates/theatron/desktop/Cargo.toml` — compiles clean
- [x] `cargo clippy --workspace -- -D warnings` — zero warnings
- [x] `cargo test --workspace` — all pass
- [x] `cargo fmt --all -- --check` — no formatting issues

## Observations

**Bug** — `theatron-tui` markdown link tests (`link_renders_with_url_visible`, `link_appends_url_after_display_text`, `link_url_uses_dim_foreground_color`) showed a transient failure during the validation run but passed on retry. `crates/theatron/tui/src/markdown/tests/rendering_basics.rs:213` — possible non-deterministic rendering test.

**Debt** — `crates/theatron/desktop/Cargo.toml` previously used `workspace = true` inheritance despite being an excluded workspace member. Excluded crates cannot inherit from `[workspace.package]` — the Cargo reference states workspace inheritance requires the crate to be a workspace member. The fix (inline versions) is included here, but the original intent may have been to add it to workspace members later.

**Missing test** — No test verifies that `ThemeProvider` applies the correct `data-theme` attribute value at the DOM level. Theme logic unit tests cover `ThemeMode` cycling and resolution, but the component rendering path is untested. `crates/theatron/desktop/src/theme.rs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)