### PR TITLE
fix(cli,pylon): resolve 5 CLI/server operational bugs

### DIFF
--- a/crates/aletheia/src/commands/memory.rs
+++ b/crates/aletheia/src/commands/memory.rs
@@ -51,7 +51,24 @@ pub(crate) enum Action {
     },
 }
 
-pub(crate) fn run(action: Action, instance_root: Option<&PathBuf>) -> Result<()> {
+pub(crate) async fn run(action: Action, url: &str, instance_root: Option<&PathBuf>) -> Result<()> {
+    // WHY: the knowledge store uses an exclusive fjall lock; opening it while the
+    // server holds the lock causes a confusing error. Detect a running server and
+    // route 'check' through the HTTP API instead of direct store access.
+    if let Ok(true) = is_server_running(url).await {
+        match action {
+            Action::Check { json } => return run_check_via_api(url, json).await,
+            _ => {
+                anyhow::bail!(
+                    "The server at {url} is running and holds an exclusive lock on the knowledge store.\n  \
+                     Stop the server first to use this subcommand, or use the REST API:\n  \
+                     GET {url}/api/v1/knowledge/facts\n  \
+                     GET {url}/api/v1/knowledge/entities"
+                );
+            }
+        }
+    }
+
     #[cfg(feature = "recall")]
     {
         let oikos = super::resolve_oikos(instance_root)?;
@@ -86,6 +103,60 @@ pub(crate) fn run(action: Action, instance_root: Option<&PathBuf>) -> Result<()>
              Build with: cargo build --features recall"
         );
     }
+}
+
+/// Check if a server is running at `url` by hitting the health endpoint.
+async fn is_server_running(url: &str) -> Result<bool> {
+    let endpoint = format!("{url}/api/health");
+    match reqwest::get(&endpoint).await {
+        Ok(resp) => Ok(resp.status().is_success() || resp.status().as_u16() == 503),
+        Err(_) => Ok(false),
+    }
+}
+
+/// Run the graph health check via the server's HTTP API.
+async fn run_check_via_api(url: &str, json: bool) -> Result<()> {
+    let endpoint = format!("{url}/api/v1/knowledge/check");
+    let resp = reqwest::get(&endpoint).await
+        .map_err(|e| anyhow::anyhow!("failed to connect to {endpoint}: {e}"))?;
+
+    if resp.status() == reqwest::StatusCode::SERVICE_UNAVAILABLE {
+        anyhow::bail!("knowledge store is not enabled on the running server");
+    }
+
+    let body: serde_json::Value = resp.json().await
+        .map_err(|e| anyhow::anyhow!("failed to parse response: {e}"))?;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&body)?);
+    } else {
+        println!("=== Memory Graph Health Check (via server API) ===\n");
+        if let Some(fc) = body.get("fact_count").and_then(serde_json::Value::as_u64) {
+            println!("Facts:         {fc}");
+        }
+        if let Some(ec) = body.get("entity_count").and_then(serde_json::Value::as_u64) {
+            println!("Entities:      {ec}");
+        }
+        if let Some(rc) = body.get("relationship_count").and_then(serde_json::Value::as_u64) {
+            println!("Relationships: {rc}");
+        }
+        let orphaned = body.get("orphaned_entity_count").and_then(serde_json::Value::as_u64).unwrap_or(0);
+        let dangling = body.get("dangling_edge_count").and_then(serde_json::Value::as_u64).unwrap_or(0);
+        if orphaned > 0 {
+            println!("\nOrphaned entities: {orphaned}");
+        } else {
+            println!("Orphaned entities: 0");
+        }
+        if dangling > 0 {
+            println!("Dangling edges: {dangling}");
+        } else {
+            println!("Dangling edges: 0");
+        }
+        let status = body.get("status").and_then(|v| v.as_str()).unwrap_or("unknown");
+        println!("\nStatus: {status}");
+    }
+
+    Ok(())
 }
 
 // --- check ---

--- a/crates/aletheia/src/main.rs
+++ b/crates/aletheia/src/main.rs
@@ -15,7 +15,7 @@ mod status;
 
 use std::path::PathBuf;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use clap::{CommandFactory, Parser, Subcommand};
 
 use commands::add_nous::AddNousArgs;
@@ -56,6 +56,10 @@ struct Cli {
     #[arg(long)]
     json_logs: bool,
 
+    /// Fork to background and write PID file at instance/aletheia.pid
+    #[arg(long)]
+    daemon: bool,
+
     #[command(subcommand)]
     command: Option<Command>,
 }
@@ -73,6 +77,9 @@ enum Command {
     },
     /// Knowledge graph inspection and maintenance
     Memory {
+        /// Server URL for API routing when server is running
+        #[arg(long, default_value = "http://127.0.0.1:18789")]
+        url: String,
         #[command(subcommand)]
         action: memory::Action,
     },
@@ -167,8 +174,8 @@ async fn main() -> Result<()> {
         Some(Command::Maintenance { action }) => {
             return commands::maintenance::run(action, instance_root);
         }
-        Some(Command::Memory { action }) => {
-            return commands::memory::run(action, instance_root);
+        Some(Command::Memory { url, action }) => {
+            return commands::memory::run(action, &url, instance_root).await;
         }
         Some(Command::Tls { action }) => return commands::tls::run(&action),
         Some(Command::Status { url }) => {
@@ -217,6 +224,10 @@ async fn main() -> Result<()> {
         None => {}
     }
 
+    if cli.daemon && std::env::var("_ALETHEIA_DAEMON").is_err() {
+        return do_daemon().await;
+    }
+
     commands::server::run(commands::server::Args {
         instance_root: cli.instance_root,
         bind: cli.bind,
@@ -225,6 +236,60 @@ async fn main() -> Result<()> {
         json_logs: cli.json_logs,
     })
     .await
+}
+
+/// Fork the server to background by re-executing the binary without `--daemon`.
+///
+/// WHY: `fork()` is unsafe inside a running tokio multi-thread runtime. Re-executing
+/// the binary avoids that hazard while still detaching from the terminal.
+async fn do_daemon() -> Result<()> {
+    let exe = std::env::current_exe().context("failed to locate executable")?;
+
+    // Strip --daemon from the child args
+    let child_args: Vec<String> = std::env::args()
+        .skip(1)
+        .filter(|a| a != "--daemon")
+        .collect();
+
+    let child = std::process::Command::new(&exe)
+        .args(&child_args)
+        .env("_ALETHEIA_DAEMON", "1")
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .context("failed to spawn background process")?;
+
+    let pid = child.id();
+
+    // Determine instance root to write PID file
+    let instance_root = daemon_instance_root();
+    tokio::fs::create_dir_all(&instance_root)
+        .await
+        .with_context(|| format!("failed to create {}", instance_root.display()))?;
+    let pid_path = instance_root.join("aletheia.pid");
+    tokio::fs::write(&pid_path, pid.to_string())
+        .await
+        .with_context(|| format!("failed to write PID file at {}", pid_path.display()))?;
+
+    println!("aletheia started in background (PID: {pid}, PID file: {})", pid_path.display());
+    Ok(())
+}
+
+/// Resolve the instance root from CLI args or environment for PID file placement.
+fn daemon_instance_root() -> PathBuf {
+    let args: Vec<String> = std::env::args().collect();
+    for (i, arg) in args.iter().enumerate() {
+        if arg == "-r" || arg == "--instance-root" {
+            if let Some(path) = args.get(i + 1) {
+                return PathBuf::from(path);
+            }
+        } else if let Some(path) = arg.strip_prefix("--instance-root=") {
+            return PathBuf::from(path);
+        }
+    }
+    std::env::var("ALETHEIA_ROOT")
+        .map_or_else(|_| PathBuf::from("instance"), PathBuf::from)
 }
 
 #[cfg(test)]

--- a/crates/aletheia/src/status.rs
+++ b/crates/aletheia/src/status.rs
@@ -67,7 +67,8 @@ pub(crate) async fn run(
         Some(root) => aletheia_taxis::oikos::Oikos::from_root(root),
         None => aletheia_taxis::oikos::Oikos::discover(),
     };
-    print_storage(&oikos, use_color);
+    let server_data_dir = health.as_ref().ok().and_then(|h| h.data_dir.as_deref());
+    print_storage(&oikos, server_data_dir, use_color);
 
     Ok(())
 }
@@ -78,6 +79,9 @@ struct HealthResponse {
     version: String,
     uptime_seconds: u64,
     checks: Vec<HealthCheck>,
+    /// Server's absolute data directory path (used when local discovery fails).
+    #[serde(default)]
+    data_dir: Option<String>,
 }
 
 #[derive(serde::Deserialize)]
@@ -230,7 +234,11 @@ fn print_nous(list: &[NousInfo], color: bool) {
     println!();
 }
 
-fn print_storage(oikos: &aletheia_taxis::oikos::Oikos, color: bool) {
+fn print_storage(
+    oikos: &aletheia_taxis::oikos::Oikos,
+    server_data_dir: Option<&str>,
+    color: bool,
+) {
     if color {
         println!("  {}:", "Storage".bold());
     } else {
@@ -242,8 +250,18 @@ fn print_storage(oikos: &aletheia_taxis::oikos::Oikos, color: bool) {
         print_file_size("sessions.db", &oikos.sessions_db());
         let plans_db = data_dir.join("plans.db");
         print_file_size("plans.db", &plans_db);
+    } else if let Some(dir_str) = server_data_dir {
+        // WHY: server reports its own data dir path; use it when local oikos
+        // discovery failed (e.g. aletheia status run from a different directory).
+        let server_data = std::path::Path::new(dir_str);
+        if server_data.exists() {
+            print_file_size("sessions.db", &server_data.join("sessions.db"));
+            print_file_size("plans.db", &server_data.join("plans.db"));
+        } else {
+            println!("    (data directory: {dir_str})");
+        }
     } else {
-        println!("    (data directory not found)");
+        println!("    (data directory not found — use -r /path/to/instance)");
     }
     println!();
 }

--- a/crates/koina/src/defaults.rs
+++ b/crates/koina/src/defaults.rs
@@ -11,6 +11,9 @@ pub const BOOTSTRAP_MAX_TOKENS: u32 = 40_000;
 /// Default context window budget (tokens).
 pub const CONTEXT_TOKENS: u32 = 200_000;
 
+/// Default context window budget for Opus models (1M token context window).
+pub const OPUS_CONTEXT_TOKENS: u32 = 1_000_000;
+
 /// Default maximum consecutive tool use iterations per turn.
 pub const MAX_TOOL_ITERATIONS: u32 = 200;
 

--- a/crates/pylon/src/handlers/health.rs
+++ b/crates/pylon/src/handlers/health.rs
@@ -89,6 +89,7 @@ pub async fn check(State(state): State<HealthState>) -> impl IntoResponse {
             version: env!("CARGO_PKG_VERSION"),
             uptime_seconds: uptime,
             checks,
+            data_dir: state.oikos.data().to_string_lossy().into_owned(),
         }),
     )
 }
@@ -106,6 +107,8 @@ pub struct HealthResponse {
     pub uptime_seconds: u64,
     /// Individual subsystem check results.
     pub checks: Vec<HealthCheck>,
+    /// Absolute path to the instance data directory.
+    pub data_dir: String,
 }
 
 /// Result of a single subsystem health check.
@@ -145,6 +148,7 @@ mod tests {
             version: "1.0.0",
             uptime_seconds: 300,
             checks: vec![],
+            data_dir: "/tmp/instance/data".to_owned(),
         };
         let json = serde_json::to_value(&resp).unwrap();
         assert_eq!(json["status"], "healthy");

--- a/crates/pylon/src/handlers/knowledge/mod.rs
+++ b/crates/pylon/src/handlers/knowledge/mod.rs
@@ -426,6 +426,139 @@ use search::{get_entity_relationships, get_stored_entities, get_stored_facts, so
 #[cfg(feature = "knowledge-store")]
 use search::{get_fact_relationships, get_similar_facts};
 
+/// Response type for graph health check.
+#[derive(Debug, serde::Serialize)]
+pub struct GraphCheckReport {
+    /// Total number of facts stored.
+    pub fact_count: usize,
+    /// Total number of entities stored.
+    pub entity_count: usize,
+    /// Total number of relationships stored.
+    pub relationship_count: usize,
+    /// Entities with no facts or relationships (potential orphans).
+    pub orphaned_entity_count: usize,
+    /// Edges that reference missing endpoint entities.
+    pub dangling_edge_count: usize,
+    /// Overall health: `"healthy"` or `"issues_found"`.
+    pub status: &'static str,
+}
+
+/// GET /api/v1/knowledge/check — run graph consistency checks.
+///
+/// Runs server-side; avoids the fjall exclusive-lock conflict that occurs when
+/// `aletheia memory check` tries to open the store while the server holds it.
+pub async fn check_graph_health(
+    State(state): State<KnowledgeState>,
+) -> impl axum::response::IntoResponse {
+    use axum::http::StatusCode;
+    use axum::response::IntoResponse as _;
+
+    #[cfg(feature = "knowledge-store")]
+    {
+        if let Some(ref store) = state.knowledge_store {
+            let report = build_graph_check_report(store);
+            return match report {
+                Ok(r) => (StatusCode::OK, Json(r)).into_response(),
+                Err(e) => (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(serde_json::json!({ "error": e })),
+                )
+                    .into_response(),
+            };
+        }
+    }
+
+    let _ = &state;
+    (
+        StatusCode::SERVICE_UNAVAILABLE,
+        Json(serde_json::json!({
+            "error": "knowledge store not enabled on this server"
+        })),
+    )
+        .into_response()
+}
+
+#[cfg(feature = "knowledge-store")]
+fn build_graph_check_report(
+    store: &std::sync::Arc<aletheia_mneme::knowledge_store::KnowledgeStore>,
+) -> Result<GraphCheckReport, String> {
+    use std::collections::BTreeMap;
+
+    fn count_relation(
+        store: &std::sync::Arc<aletheia_mneme::knowledge_store::KnowledgeStore>,
+        relation: &str,
+    ) -> Result<usize, String> {
+        let key_field = match relation {
+            "relationships" => "src",
+            "fact_entities" => "fact_id",
+            _ => "id",
+        };
+        let script =
+            format!("row[{key_field}] := *{relation}{{{key_field}}} \n?[count(k)] := row[k]");
+        let result = store
+            .run_query(&script, BTreeMap::new())
+            .map_err(|e| format!("query failed: {e}"))?;
+        let count = result
+            .rows
+            .first()
+            .and_then(|r| r.first())
+            .and_then(aletheia_mneme::engine::DataValue::get_int)
+            .unwrap_or(0);
+        Ok(usize::try_from(count).unwrap_or(0))
+    }
+
+    fn count_orphaned_entities(
+        store: &std::sync::Arc<aletheia_mneme::knowledge_store::KnowledgeStore>,
+    ) -> Result<usize, String> {
+        let script = r"
+            ?[id] :=
+                *entities{id},
+                not *relationships{src: id},
+                not *relationships{dst: id},
+                not *fact_entities{entity_id: id}
+        ";
+        let result = store
+            .run_query(script, BTreeMap::new())
+            .map_err(|e| format!("orphan query failed: {e}"))?;
+        Ok(result.rows.len())
+    }
+
+    fn count_dangling_edges(
+        store: &std::sync::Arc<aletheia_mneme::knowledge_store::KnowledgeStore>,
+    ) -> Result<usize, String> {
+        let script = r"
+            ?[src, dst, relation] :=
+                *relationships{src, dst, relation},
+                not *entities{id: src}
+
+            ?[src, dst, relation] :=
+                *relationships{src, dst, relation},
+                not *entities{id: dst}
+        ";
+        let result = store
+            .run_query(script, BTreeMap::new())
+            .map_err(|e| format!("dangling edge query failed: {e}"))?;
+        Ok(result.rows.len())
+    }
+
+    let fact_count = count_relation(store, "facts")?;
+    let entity_count = count_relation(store, "entities")?;
+    let relationship_count = count_relation(store, "relationships")?;
+    let orphaned_entity_count = count_orphaned_entities(store)?;
+    let dangling_edge_count = count_dangling_edges(store)?;
+
+    let healthy = orphaned_entity_count == 0 && dangling_edge_count == 0;
+
+    Ok(GraphCheckReport {
+        fact_count,
+        entity_count,
+        relationship_count,
+        orphaned_entity_count,
+        dangling_edge_count,
+        status: if healthy { "healthy" } else { "issues_found" },
+    })
+}
+
 #[cfg(test)]
 #[expect(clippy::unwrap_used, reason = "test assertions")]
 #[expect(

--- a/crates/pylon/src/router.rs
+++ b/crates/pylon/src/router.rs
@@ -82,11 +82,13 @@ pub fn build_router(state: Arc<AppState>, security: &SecurityConfig) -> Router {
             get(knowledge::entity_relationships),
         )
         .route("/knowledge/search", get(knowledge::search))
-        .route("/knowledge/timeline", get(knowledge::timeline));
+        .route("/knowledge/timeline", get(knowledge::timeline))
+        .route("/knowledge/check", get(knowledge::check_graph_health));
 
     let mut router = Router::new()
         .nest(API_V1, v1)
         .route(API_HEALTH, get(health::check))
+        .route("/health", get(health::check))
         .route("/api/docs/openapi.json", get(openapi::openapi_json))
         .route("/metrics", get(metrics::expose));
 

--- a/crates/pylon/src/state.rs
+++ b/crates/pylon/src/state.rs
@@ -79,6 +79,8 @@ pub struct HealthState {
     pub nous_manager: Arc<NousManager>,
     /// Server start instant for uptime calculation.
     pub start_time: std::time::Instant,
+    /// Instance directory layout for path reporting.
+    pub oikos: Arc<Oikos>,
 }
 
 impl FromRef<Arc<AppState>> for HealthState {
@@ -88,6 +90,7 @@ impl FromRef<Arc<AppState>> for HealthState {
             provider_registry: Arc::clone(&state.provider_registry),
             nous_manager: Arc::clone(&state.nous_manager),
             start_time: state.start_time,
+            oikos: Arc::clone(&state.oikos),
         }
     }
 }

--- a/crates/taxis/src/config/resolved.rs
+++ b/crates/taxis/src/config/resolved.rs
@@ -128,6 +128,18 @@ pub fn resolve_nous(config: &AletheiaConfig, nous_id: &str) -> ResolvedNousConfi
         .and_then(|a| a.recall.clone())
         .unwrap_or_else(|| defaults.recall.clone());
 
+    // WHY: Opus models have a 1M token context window; apply model-aware default
+    // when the config still holds the global default (200K). Computed before
+    // `model` is moved into `ResolvedModelConfig`.
+    let context_tokens = {
+        let configured = defaults.model_defaults.context_tokens;
+        if configured == aletheia_koina::defaults::CONTEXT_TOKENS && model.contains("opus") {
+            aletheia_koina::defaults::OPUS_CONTEXT_TOKENS
+        } else {
+            configured
+        }
+    };
+
     ResolvedNousConfig {
         id: nous_id.to_owned(),
         name,
@@ -137,7 +149,7 @@ pub fn resolve_nous(config: &AletheiaConfig, nous_id: &str) -> ResolvedNousConfi
             retries_before_fallback,
         },
         limits: TokenLimits {
-            context_tokens: defaults.model_defaults.context_tokens,
+            context_tokens,
             max_output_tokens: defaults.model_defaults.max_output_tokens,
             bootstrap_max_tokens: defaults.model_defaults.bootstrap_max_tokens,
             thinking_budget: defaults.model_defaults.thinking_budget,


### PR DESCRIPTION
## Summary

- **#1973 (status data dir)**: Health response now includes `data_dir`; `aletheia status` uses the server-reported path when local oikos discovery fails (e.g. run from a different directory than the instance root)
- **#1974 (memory fjall lock)**: `aletheia memory check` detects a running server via the health endpoint and routes through a new `GET /api/v1/knowledge/check` endpoint instead of trying to open the fjall store exclusively; other memory subcommands print a clear error directing to the REST API
- **#1975 (/health alias)**: Added `/health` route alias for load-balancer and ops-tooling compatibility
- **#1977 (daemon)**: Added `--daemon` flag; re-execs the binary detached from terminal (no `fork()` inside tokio), writes PID file at `instance/aletheia.pid`
- **#1982 (Opus context)**: `resolve_nous` now applies a 1M token context window when the model contains "opus" and `contextTokens` is still at the global default (200K); explicit config overrides are preserved

## Test plan

- [x] `cargo test --workspace --all-features` passes
- [x] `cargo clippy --workspace` zero warnings
- [ ] `aletheia status` shows correct data directory path (manual: run from non-instance dir while server is up)
- [ ] `aletheia memory check` works while server is running
- [ ] `curl localhost:18789/health` returns 200
- [ ] `aletheia --daemon` forks and writes PID file
- [ ] Opus agent gets 1M context tokens by default

🤖 Generated with [Claude Code](https://claude.com/claude-code)