### PR TITLE
feat(theatron-desktop): checkpoint approval gates and verification

### DIFF
--- a/crates/theatron/desktop/src/components/checkpoint_card.rs
+++ b/crates/theatron/desktop/src/components/checkpoint_card.rs
@@ -1,0 +1,504 @@
+//! Checkpoint approval card with approve, skip, and override actions.
+
+use dioxus::prelude::*;
+
+use crate::api::client::authenticated_client;
+use crate::state::checkpoints::{
+    Checkpoint, CheckpointAction, CheckpointActionRequest, CheckpointStatus,
+};
+use crate::state::connection::ConnectionConfig;
+
+const CARD_BASE: &str = "\
+    border-radius: 8px; \
+    border: 1px solid; \
+    padding: 16px 20px; \
+    margin-bottom: 12px;\
+";
+
+const HEADER_ROW: &str = "\
+    display: flex; \
+    align-items: center; \
+    justify-content: space-between; \
+    margin-bottom: 8px;\
+";
+
+const TITLE_STYLE: &str = "\
+    font-size: 15px; \
+    font-weight: 600; \
+    color: #e0e0e0;\
+";
+
+const BADGE_BASE: &str = "\
+    display: inline-block; \
+    font-size: 11px; \
+    font-weight: 600; \
+    padding: 2px 8px; \
+    border-radius: 10px; \
+    text-transform: uppercase; \
+    letter-spacing: 0.4px;\
+";
+
+const DESCRIPTION_STYLE: &str = "\
+    color: #aaa; \
+    font-size: 13px; \
+    margin-bottom: 10px;\
+";
+
+const SECTION_LABEL: &str = "\
+    font-size: 11px; \
+    font-weight: 600; \
+    color: #666; \
+    text-transform: uppercase; \
+    letter-spacing: 0.5px; \
+    margin: 10px 0 4px;\
+";
+
+const CONTEXT_STYLE: &str = "\
+    font-size: 13px; \
+    color: #c0c0e0; \
+    background: #0f0f1a; \
+    border: 1px solid #2a2a3a; \
+    border-radius: 4px; \
+    padding: 8px 10px; \
+    margin-bottom: 4px;\
+";
+
+const REQ_ROW: &str = "\
+    display: flex; \
+    align-items: center; \
+    gap: 8px; \
+    padding: 3px 0; \
+    font-size: 13px;\
+";
+
+const ARTIFACT_ROW: &str = "\
+    display: flex; \
+    align-items: center; \
+    gap: 6px; \
+    padding: 2px 0; \
+    font-size: 12px;\
+";
+
+const DECISION_BOX: &str = "\
+    margin-top: 10px; \
+    padding: 8px 10px; \
+    background: #0f0f1a; \
+    border-radius: 4px; \
+    border: 1px solid #2a2a3a;\
+";
+
+const BTN_ROW: &str = "\
+    display: flex; \
+    gap: 8px; \
+    margin-top: 14px;\
+";
+
+const APPROVE_BTN: &str = "\
+    background: #166534; \
+    color: #dcfce7; \
+    border: 1px solid #22c55e; \
+    border-radius: 6px; \
+    padding: 6px 16px; \
+    font-size: 13px; \
+    font-weight: 600; \
+    cursor: pointer;\
+";
+
+const SKIP_BTN: &str = "\
+    background: #78350f; \
+    color: #fef3c7; \
+    border: 1px solid #f59e0b; \
+    border-radius: 6px; \
+    padding: 6px 16px; \
+    font-size: 13px; \
+    font-weight: 600; \
+    cursor: pointer;\
+";
+
+const OVERRIDE_BTN: &str = "\
+    background: #7f1d1d; \
+    color: #fee2e2; \
+    border: 1px solid #ef4444; \
+    border-radius: 6px; \
+    padding: 6px 16px; \
+    font-size: 13px; \
+    font-weight: 600; \
+    cursor: pointer;\
+";
+
+const SUBMIT_BTN_ACTIVE: &str = "\
+    background: #4a4aff; \
+    color: white; \
+    border: none; \
+    border-radius: 6px; \
+    padding: 6px 16px; \
+    font-size: 13px; \
+    font-weight: 600; \
+    cursor: pointer;\
+";
+
+const SUBMIT_BTN_DISABLED: &str = "\
+    background: #333; \
+    color: #666; \
+    border: none; \
+    border-radius: 6px; \
+    padding: 6px 16px; \
+    font-size: 13px; \
+    font-weight: 600; \
+    cursor: not-allowed;\
+";
+
+const CANCEL_BTN: &str = "\
+    background: transparent; \
+    color: #888; \
+    border: 1px solid #444; \
+    border-radius: 6px; \
+    padding: 6px 12px; \
+    font-size: 13px; \
+    cursor: pointer;\
+";
+
+const NOTES_TEXTAREA: &str = "\
+    width: 100%; \
+    background: #0f0f1a; \
+    border: 1px solid #333; \
+    border-radius: 4px; \
+    padding: 8px 10px; \
+    color: #e0e0e0; \
+    font-size: 13px; \
+    font-family: inherit; \
+    resize: vertical; \
+    min-height: 70px; \
+    box-sizing: border-box;\
+";
+
+const ERROR_STYLE: &str = "color: #ef4444; font-size: 12px; margin-top: 8px;";
+
+/// Checkpoint approval card with gate context, requirements, artifacts, and actions.
+///
+/// Approve, Skip, and Override are gated on the API response — no optimistic update.
+/// Skip and Override require a notes entry of at least 10 characters before submit.
+#[component]
+pub(crate) fn CheckpointCard(
+    checkpoint: Checkpoint,
+    project_id: String,
+    on_action_complete: EventHandler<()>,
+) -> Element {
+    let config: Signal<ConnectionConfig> = use_context();
+    let mut selected_action: Signal<Option<CheckpointAction>> = use_signal(|| None);
+    let mut notes = use_signal(String::new);
+    let mut submitting = use_signal(|| false);
+    let mut error_msg: Signal<Option<String>> = use_signal(|| None);
+
+    let is_pending = checkpoint.status == CheckpointStatus::Pending;
+    let notes_valid = notes.read().len() >= 10;
+
+    // Clones captured by the approve closure.
+    let checkpoint_id_approve = checkpoint.id.clone();
+    let project_id_approve = project_id.clone();
+
+    // Clones captured by the submit-with-notes closure.
+    let checkpoint_id_submit = checkpoint.id.clone();
+    let project_id_submit = project_id.clone();
+
+    let do_approve = move |_| {
+        let cfg = config.read().clone();
+        let cid = checkpoint_id_approve.clone();
+        let pid = project_id_approve.clone();
+        submitting.set(true);
+        error_msg.set(None);
+        spawn(async move {
+            let client = authenticated_client(&cfg);
+            let url = format!(
+                "{}/api/planning/projects/{pid}/checkpoints/{cid}/action",
+                cfg.server_url.trim_end_matches('/')
+            );
+            let req = CheckpointActionRequest {
+                action: CheckpointAction::Approve,
+                notes: None,
+            };
+            match client.post(&url).json(&req).send().await {
+                Ok(resp) if resp.status().is_success() => {
+                    on_action_complete.call(());
+                }
+                Ok(resp) => {
+                    let status = resp.status();
+                    error_msg.set(Some(format!("server error: {status}")));
+                    submitting.set(false);
+                }
+                Err(e) => {
+                    error_msg.set(Some(format!("connection error: {e}")));
+                    submitting.set(false);
+                }
+            }
+        });
+    };
+
+    let do_submit_notes = move |_| {
+        let Some(action) = *selected_action.read() else {
+            return;
+        };
+        if notes.read().len() < 10 {
+            return;
+        }
+        let cfg = config.read().clone();
+        let cid = checkpoint_id_submit.clone();
+        let pid = project_id_submit.clone();
+        let notes_val = notes.read().clone();
+        submitting.set(true);
+        error_msg.set(None);
+        spawn(async move {
+            let client = authenticated_client(&cfg);
+            let url = format!(
+                "{}/api/planning/projects/{pid}/checkpoints/{cid}/action",
+                cfg.server_url.trim_end_matches('/')
+            );
+            let req = CheckpointActionRequest {
+                action,
+                notes: Some(notes_val),
+            };
+            match client.post(&url).json(&req).send().await {
+                Ok(resp) if resp.status().is_success() => {
+                    on_action_complete.call(());
+                }
+                Ok(resp) => {
+                    let status = resp.status();
+                    error_msg.set(Some(format!("server error: {status}")));
+                    submitting.set(false);
+                }
+                Err(e) => {
+                    error_msg.set(Some(format!("connection error: {e}")));
+                    submitting.set(false);
+                }
+            }
+        });
+    };
+
+    let card_style = card_container_style(checkpoint.status);
+    let badge_style = status_badge_style(checkpoint.status);
+    let badge_label = status_label(checkpoint.status);
+
+    rsx! {
+        div {
+            style: "{card_style}",
+
+            // Header: title + status badge
+            div {
+                style: "{HEADER_ROW}",
+                span { style: "{TITLE_STYLE}", "{checkpoint.title}" }
+                span { style: "{badge_style}", "{badge_label}" }
+            }
+
+            // Description
+            if !checkpoint.description.is_empty() {
+                div { style: "{DESCRIPTION_STYLE}", "{checkpoint.description}" }
+            }
+
+            // Context
+            if !checkpoint.context.is_empty() {
+                div { style: "{SECTION_LABEL}", "Context" }
+                div { style: "{CONTEXT_STYLE}", "{checkpoint.context}" }
+            }
+
+            // Requirements
+            if !checkpoint.requirements.is_empty() {
+                div { style: "{SECTION_LABEL}", "Requirements" }
+                for req in &checkpoint.requirements {
+                    div {
+                        key: "{req.id}",
+                        style: "{REQ_ROW}",
+                        span {
+                            style: if req.met { "color: #22c55e; width: 18px;" } else { "color: #ef4444; width: 18px;" },
+                            if req.met { "[v]" } else { "[x]" }
+                        }
+                        span { style: "color: #c0c0e0;", "{req.title}" }
+                    }
+                }
+            }
+
+            // Artifacts
+            if !checkpoint.artifacts.is_empty() {
+                div { style: "{SECTION_LABEL}", "Artifacts" }
+                for (i, artifact) in checkpoint.artifacts.iter().enumerate() {
+                    div {
+                        key: "{i}",
+                        style: "{ARTIFACT_ROW}",
+                        span { style: "color: #666;", "{artifact.label}:" }
+                        span { style: "color: #c0c0e0; font-family: monospace;", "{artifact.value}" }
+                    }
+                }
+            }
+
+            // Decision record (resolved gates)
+            if let Some(ref decision) = checkpoint.decision {
+                div {
+                    style: "{DECISION_BOX}",
+                    div { style: "font-size: 12px; color: #888;",
+                        "{action_label(decision.action)} by {decision.actor} at {decision.timestamp}"
+                    }
+                    if !decision.notes.is_empty() {
+                        div { style: "font-size: 12px; color: #aaa; margin-top: 4px; font-style: italic;",
+                            "\"{decision.notes}\""
+                        }
+                    }
+                }
+            }
+
+            // Error feedback
+            if let Some(ref err) = *error_msg.read() {
+                div { style: "{ERROR_STYLE}", "{err}" }
+            }
+
+            // Action area (pending gates only)
+            if is_pending {
+                match *selected_action.read() {
+                    None => rsx! {
+                        div {
+                            style: "{BTN_ROW}",
+                            button {
+                                style: "{APPROVE_BTN}",
+                                disabled: *submitting.read(),
+                                onclick: do_approve,
+                                "Approve"
+                            }
+                            button {
+                                style: "{SKIP_BTN}",
+                                disabled: *submitting.read(),
+                                onclick: move |_| selected_action.set(Some(CheckpointAction::Skip)),
+                                "Skip"
+                            }
+                            button {
+                                style: "{OVERRIDE_BTN}",
+                                disabled: *submitting.read(),
+                                onclick: move |_| selected_action.set(Some(CheckpointAction::Override)),
+                                "Override"
+                            }
+                        }
+                    },
+                    Some(action) => rsx! {
+                        div {
+                            style: "margin-top: 12px;",
+                            div { style: "{SECTION_LABEL}", "{notes_action_label(action)} — reason required (min 10 chars):" }
+                            textarea {
+                                style: "{NOTES_TEXTAREA}",
+                                placeholder: "Explain your decision...",
+                                rows: "3",
+                                value: "{notes.read()}",
+                                oninput: move |evt: Event<FormData>| notes.set(evt.value().clone()),
+                            }
+                            div {
+                                style: "{BTN_ROW}",
+                                button {
+                                    style: if notes_valid { "{SUBMIT_BTN_ACTIVE}" } else { "{SUBMIT_BTN_DISABLED}" },
+                                    disabled: !notes_valid || *submitting.read(),
+                                    onclick: do_submit_notes,
+                                    if *submitting.read() { "Submitting..." } else { "Submit" }
+                                }
+                                button {
+                                    style: "{CANCEL_BTN}",
+                                    disabled: *submitting.read(),
+                                    onclick: move |_| {
+                                        selected_action.set(None);
+                                        notes.set(String::new());
+                                    },
+                                    "Back"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn card_container_style(status: CheckpointStatus) -> String {
+    let (bg, border) = match status {
+        CheckpointStatus::Pending => ("#1a1a2e", "#4a4aff"),
+        CheckpointStatus::Approved => ("#0f1f0f", "#22c55e"),
+        CheckpointStatus::Skipped => ("#1e1a10", "#f59e0b"),
+        CheckpointStatus::Overridden => ("#1e0f0f", "#ef4444"),
+    };
+    format!("{CARD_BASE} background: {bg}; border-color: {border};")
+}
+
+fn status_badge_style(status: CheckpointStatus) -> String {
+    let (bg, color) = match status {
+        CheckpointStatus::Pending => ("#1e1e5a", "#8080ff"),
+        CheckpointStatus::Approved => ("#0f2a0f", "#22c55e"),
+        CheckpointStatus::Skipped => ("#2a1f05", "#f59e0b"),
+        CheckpointStatus::Overridden => ("#2a0f0f", "#ef4444"),
+    };
+    format!("{BADGE_BASE} background: {bg}; color: {color};")
+}
+
+fn status_label(status: CheckpointStatus) -> &'static str {
+    match status {
+        CheckpointStatus::Pending => "Pending",
+        CheckpointStatus::Approved => "Approved",
+        CheckpointStatus::Skipped => "Skipped",
+        CheckpointStatus::Overridden => "Overridden",
+    }
+}
+
+fn action_label(action: CheckpointAction) -> &'static str {
+    match action {
+        CheckpointAction::Approve => "Approved",
+        CheckpointAction::Skip => "Skipped",
+        CheckpointAction::Override => "Overridden",
+    }
+}
+
+fn notes_action_label(action: CheckpointAction) -> &'static str {
+    match action {
+        CheckpointAction::Skip => "Skip",
+        CheckpointAction::Override => "Override",
+        CheckpointAction::Approve => "Approve",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn card_container_style_differs_by_status() {
+        let pending = card_container_style(CheckpointStatus::Pending);
+        let approved = card_container_style(CheckpointStatus::Approved);
+        let skipped = card_container_style(CheckpointStatus::Skipped);
+        let overridden = card_container_style(CheckpointStatus::Overridden);
+        assert_ne!(pending, approved);
+        assert_ne!(approved, skipped);
+        assert_ne!(skipped, overridden);
+    }
+
+    #[test]
+    fn status_badge_style_differs_by_status() {
+        let pending = status_badge_style(CheckpointStatus::Pending);
+        let approved = status_badge_style(CheckpointStatus::Approved);
+        assert_ne!(pending, approved);
+    }
+
+    #[test]
+    fn status_labels_are_distinct() {
+        let labels: Vec<_> = [
+            CheckpointStatus::Pending,
+            CheckpointStatus::Approved,
+            CheckpointStatus::Skipped,
+            CheckpointStatus::Overridden,
+        ]
+        .iter()
+        .map(|s| status_label(*s))
+        .collect();
+        let unique: std::collections::HashSet<_> = labels.iter().collect();
+        assert_eq!(unique.len(), labels.len(), "all labels must be distinct");
+    }
+
+    #[test]
+    fn notes_action_label_skip_and_override_distinct() {
+        assert_ne!(
+            notes_action_label(CheckpointAction::Skip),
+            notes_action_label(CheckpointAction::Override)
+        );
+    }
+}

--- a/crates/theatron/desktop/src/components/coverage_bar.rs
+++ b/crates/theatron/desktop/src/components/coverage_bar.rs
@@ -1,0 +1,111 @@
+//! Coverage bar component with color-coded threshold display.
+
+use dioxus::prelude::*;
+
+const BAR_OUTER_STYLE: &str = "\
+    width: 100%; \
+    height: 8px; \
+    background: #2a2a3a; \
+    border-radius: 4px; \
+    overflow: hidden;\
+";
+
+const LABEL_ROW_STYLE: &str = "\
+    display: flex; \
+    justify-content: space-between; \
+    align-items: center; \
+    margin-bottom: 4px; \
+    font-size: 12px; \
+    color: #aaa;\
+";
+
+const NO_REQS_STYLE: &str = "font-size: 12px; color: #555; font-style: italic;";
+
+/// Progress bar showing requirement coverage for a category.
+///
+/// `coverage` is `None` when no requirements exist for the category,
+/// which renders a "No requirements defined" placeholder instead of a 0% bar.
+#[component]
+pub(crate) fn CoverageBar(
+    /// Coverage percentage 0–100. `None` = no requirements defined.
+    coverage: Option<u8>,
+    /// Display label for this bar (e.g., `"Overall"`, `"v1"`, `"v2"`).
+    label: String,
+) -> Element {
+    let Some(pct) = coverage else {
+        return rsx! {
+            div {
+                style: "margin-bottom: 12px;",
+                div {
+                    style: "{LABEL_ROW_STYLE}",
+                    span { "{label}" }
+                }
+                span { style: "{NO_REQS_STYLE}", "No requirements defined" }
+            }
+        };
+    };
+
+    let color = coverage_color(pct);
+    let bar_inner_style = format!(
+        "height: 100%; width: {pct}%; background: {color}; border-radius: 4px; \
+         transition: width 0.3s ease;"
+    );
+
+    rsx! {
+        div {
+            style: "margin-bottom: 12px;",
+            div {
+                style: "{LABEL_ROW_STYLE}",
+                span { "{label}" }
+                span {
+                    style: "color: {color}; font-weight: 600;",
+                    "{pct}%"
+                }
+            }
+            div {
+                style: "{BAR_OUTER_STYLE}",
+                div { style: "{bar_inner_style}" }
+            }
+        }
+    }
+}
+
+/// Color for a coverage percentage.
+///
+/// - `>80%` → green
+/// - `50–80%` → amber
+/// - `<50%` → red
+#[must_use]
+pub(crate) fn coverage_color(pct: u8) -> &'static str {
+    if pct > 80 {
+        "#22c55e"
+    } else if pct >= 50 {
+        "#f59e0b"
+    } else {
+        "#ef4444"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn coverage_color_green_above_80() {
+        assert_eq!(coverage_color(81), "#22c55e");
+        assert_eq!(coverage_color(100), "#22c55e");
+    }
+
+    #[test]
+    fn coverage_color_amber_at_boundary() {
+        assert_eq!(coverage_color(80), "#f59e0b");
+        assert_eq!(coverage_color(50), "#f59e0b");
+        assert_eq!(coverage_color(65), "#f59e0b");
+    }
+
+    #[test]
+    fn coverage_color_red_below_50() {
+        assert_eq!(coverage_color(49), "#ef4444");
+        assert_eq!(coverage_color(0), "#ef4444");
+    }
+}

--- a/crates/theatron/desktop/src/components/mod.rs
+++ b/crates/theatron/desktop/src/components/mod.rs
@@ -1,6 +1,8 @@
 //! Dioxus components for the streaming chat interface.
 
 pub mod agent_sidebar;
+pub(crate) mod checkpoint_card;
+pub(crate) mod coverage_bar;
 pub mod chat;
 pub(crate) mod code_block;
 pub mod command_palette;

--- a/crates/theatron/desktop/src/state/checkpoints.rs
+++ b/crates/theatron/desktop/src/state/checkpoints.rs
@@ -1,0 +1,164 @@
+//! Checkpoint approval gate state for the planning project detail view.
+
+use serde::{Deserialize, Serialize};
+
+/// Action taken on a checkpoint gate.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub(crate) enum CheckpointAction {
+    /// Gate approved; execution continues.
+    Approve,
+    /// Gate skipped without approval; notes required.
+    Skip,
+    /// Failed gate overridden; notes required.
+    Override,
+}
+
+/// Current status of a checkpoint gate.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub(crate) enum CheckpointStatus {
+    /// Awaiting review.
+    Pending,
+    /// Approved by a reviewer.
+    Approved,
+    /// Skipped with a note.
+    Skipped,
+    /// Failed gate overridden with a note.
+    Overridden,
+}
+
+/// A single requirement validated by this checkpoint.
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+pub(crate) struct CheckpointRequirement {
+    pub(crate) id: String,
+    pub(crate) title: String,
+    pub(crate) met: bool,
+}
+
+/// An artifact produced or referenced by this checkpoint.
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+pub(crate) struct CheckpointArtifact {
+    pub(crate) label: String,
+    pub(crate) value: String,
+}
+
+/// Decision recorded after a checkpoint action is taken.
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+pub(crate) struct CheckpointDecision {
+    pub(crate) action: CheckpointAction,
+    pub(crate) actor: String,
+    pub(crate) timestamp: String,
+    pub(crate) notes: String,
+}
+
+/// A single checkpoint approval gate.
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+pub(crate) struct Checkpoint {
+    pub(crate) id: String,
+    pub(crate) project_id: String,
+    pub(crate) title: String,
+    pub(crate) description: String,
+    /// Summary of what was accomplished and what follows if approved.
+    pub(crate) context: String,
+    pub(crate) requirements: Vec<CheckpointRequirement>,
+    pub(crate) artifacts: Vec<CheckpointArtifact>,
+    pub(crate) status: CheckpointStatus,
+    /// Set once the gate is resolved.
+    #[serde(default)]
+    pub(crate) decision: Option<CheckpointDecision>,
+}
+
+/// Request body for `POST /api/planning/projects/{id}/checkpoints/{id}/action`.
+#[derive(Debug, Serialize)]
+pub(crate) struct CheckpointActionRequest {
+    pub(crate) action: CheckpointAction,
+    /// Required for Skip and Override actions.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) notes: Option<String>,
+}
+
+/// Store for checkpoints associated with the active project.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct CheckpointStore {
+    pub(crate) checkpoints: Vec<Checkpoint>,
+}
+
+impl CheckpointStore {
+    /// Count of checkpoints awaiting approval.
+    #[must_use]
+    pub(crate) fn pending_count(&self) -> usize {
+        self.checkpoints
+            .iter()
+            .filter(|c| c.status == CheckpointStatus::Pending)
+            .count()
+    }
+
+    /// Checkpoints with pending gates first, then ordered by id.
+    #[must_use]
+    pub(crate) fn sorted(&self) -> Vec<&Checkpoint> {
+        let mut refs: Vec<&Checkpoint> = self.checkpoints.iter().collect();
+        refs.sort_by(|a, b| {
+            let a_order = u8::from(a.status != CheckpointStatus::Pending);
+            let b_order = u8::from(b.status != CheckpointStatus::Pending);
+            a_order.cmp(&b_order).then_with(|| a.id.cmp(&b.id))
+        });
+        refs
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_checkpoint(id: &str, status: CheckpointStatus) -> Checkpoint {
+        Checkpoint {
+            id: id.to_string(),
+            project_id: "proj1".to_string(),
+            title: id.to_string(),
+            description: String::new(),
+            context: String::new(),
+            requirements: vec![],
+            artifacts: vec![],
+            status,
+            decision: None,
+        }
+    }
+
+    #[test]
+    fn pending_count_returns_only_pending() {
+        let store = CheckpointStore {
+            checkpoints: vec![
+                make_checkpoint("a", CheckpointStatus::Pending),
+                make_checkpoint("b", CheckpointStatus::Approved),
+                make_checkpoint("c", CheckpointStatus::Pending),
+                make_checkpoint("d", CheckpointStatus::Skipped),
+            ],
+        };
+        assert_eq!(store.pending_count(), 2);
+    }
+
+    #[test]
+    fn pending_count_zero_when_empty() {
+        assert_eq!(CheckpointStore::default().pending_count(), 0);
+    }
+
+    #[test]
+    fn sorted_places_pending_first() {
+        let store = CheckpointStore {
+            checkpoints: vec![
+                make_checkpoint("a", CheckpointStatus::Approved),
+                make_checkpoint("b", CheckpointStatus::Pending),
+                make_checkpoint("c", CheckpointStatus::Skipped),
+                make_checkpoint("d", CheckpointStatus::Pending),
+            ],
+        };
+        let sorted = store.sorted();
+        assert_eq!(sorted[0].status, CheckpointStatus::Pending);
+        assert_eq!(sorted[1].status, CheckpointStatus::Pending);
+        assert_ne!(sorted[2].status, CheckpointStatus::Pending);
+        assert_ne!(sorted[3].status, CheckpointStatus::Pending);
+    }
+}

--- a/crates/theatron/desktop/src/state/mod.rs
+++ b/crates/theatron/desktop/src/state/mod.rs
@@ -17,3 +17,7 @@ pub(crate) mod streaming;
 pub mod toasts;
 /// Enhanced tool call, approval, and planning state for desktop UI.
 pub mod tools;
+/// Checkpoint approval gate state for the planning project detail view.
+pub(crate) mod checkpoints;
+/// Goal-backward verification state for the planning project detail view.
+pub(crate) mod verification;

--- a/crates/theatron/desktop/src/state/verification.rs
+++ b/crates/theatron/desktop/src/state/verification.rs
@@ -1,0 +1,233 @@
+//! Goal-backward verification state for the planning project detail view.
+
+use serde::Deserialize;
+
+/// Verification status for a single requirement.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub(crate) enum VerificationStatus {
+    /// Requirement fully demonstrated.
+    Verified,
+    /// Some but not all criteria demonstrated.
+    PartiallyVerified,
+    /// No verification evidence found.
+    Unverified,
+    /// Verification attempted but explicitly failed.
+    Failed,
+}
+
+/// Priority tier for a requirement.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub(crate) enum RequirementPriority {
+    /// Blocking — must be verified before release.
+    P0,
+    /// High priority.
+    P1,
+    /// Medium priority.
+    P2,
+    /// Low or nice-to-have.
+    P3,
+}
+
+/// A piece of evidence demonstrating a requirement.
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+pub(crate) struct VerificationEvidence {
+    pub(crate) label: String,
+    pub(crate) artifact: String,
+}
+
+/// A criterion not yet satisfied.
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+pub(crate) struct VerificationGap {
+    pub(crate) missing_criteria: String,
+    pub(crate) suggested_action: String,
+}
+
+/// Verification result for a single requirement.
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+pub(crate) struct RequirementVerification {
+    pub(crate) id: String,
+    pub(crate) title: String,
+    /// Version tier (e.g., `"v1"`, `"v2"`).
+    pub(crate) tier: String,
+    pub(crate) priority: RequirementPriority,
+    pub(crate) status: VerificationStatus,
+    /// Coverage percentage 0–100.
+    pub(crate) coverage_pct: u8,
+    pub(crate) evidence: Vec<VerificationEvidence>,
+    pub(crate) gaps: Vec<VerificationGap>,
+}
+
+/// Full verification result for a project.
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+pub(crate) struct VerificationResult {
+    pub(crate) project_id: String,
+    pub(crate) requirements: Vec<RequirementVerification>,
+    pub(crate) last_verified_at: String,
+}
+
+/// Store for verification results of the active project.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct VerificationStore {
+    pub(crate) result: Option<VerificationResult>,
+}
+
+impl VerificationStore {
+    /// Overall coverage as `verified_count * 100 / total_count`.
+    ///
+    /// Returns `None` when no requirements are defined.
+    #[must_use]
+    pub(crate) fn overall_coverage(&self) -> Option<u8> {
+        let reqs = self.result.as_ref()?.requirements.as_slice();
+        if reqs.is_empty() {
+            return None;
+        }
+        let verified = reqs
+            .iter()
+            .filter(|r| r.status == VerificationStatus::Verified)
+            .count();
+        Some(((verified * 100) / reqs.len()).min(100) as u8)
+    }
+
+    /// Coverage percentage for a specific tier (e.g., `"v1"`, `"v2"`).
+    ///
+    /// Returns `None` when the tier has no requirements.
+    #[must_use]
+    pub(crate) fn tier_coverage(&self, tier: &str) -> Option<u8> {
+        let reqs = self.result.as_ref()?.requirements.as_slice();
+        let tier_reqs: Vec<_> = reqs.iter().filter(|r| r.tier == tier).collect();
+        if tier_reqs.is_empty() {
+            return None;
+        }
+        let verified = tier_reqs
+            .iter()
+            .filter(|r| r.status == VerificationStatus::Verified)
+            .count();
+        Some(((verified * 100) / tier_reqs.len()).min(100) as u8)
+    }
+
+    /// Requirements that have gaps (unverified, partially verified, or failed).
+    #[must_use]
+    pub(crate) fn gaps(&self) -> Vec<&RequirementVerification> {
+        match &self.result {
+            None => Vec::new(),
+            Some(r) => r
+                .requirements
+                .iter()
+                .filter(|req| {
+                    matches!(
+                        req.status,
+                        VerificationStatus::Unverified
+                            | VerificationStatus::PartiallyVerified
+                            | VerificationStatus::Failed
+                    )
+                })
+                .collect(),
+        }
+    }
+
+    /// Blocking (P0) requirements with gaps.
+    #[must_use]
+    pub(crate) fn blocking_gaps(&self) -> Vec<&RequirementVerification> {
+        self.gaps()
+            .into_iter()
+            .filter(|r| r.priority == RequirementPriority::P0)
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn req(
+        id: &str,
+        tier: &str,
+        priority: RequirementPriority,
+        status: VerificationStatus,
+    ) -> RequirementVerification {
+        RequirementVerification {
+            id: id.to_string(),
+            title: id.to_string(),
+            tier: tier.to_string(),
+            priority,
+            status,
+            coverage_pct: match status {
+                VerificationStatus::Verified => 100,
+                VerificationStatus::PartiallyVerified => 50,
+                _ => 0,
+            },
+            evidence: vec![],
+            gaps: vec![],
+        }
+    }
+
+    fn store_with(requirements: Vec<RequirementVerification>) -> VerificationStore {
+        VerificationStore {
+            result: Some(VerificationResult {
+                project_id: "p1".to_string(),
+                requirements,
+                last_verified_at: "2026-01-01T00:00:00Z".to_string(),
+            }),
+        }
+    }
+
+    #[test]
+    fn overall_coverage_none_when_no_result() {
+        assert_eq!(VerificationStore::default().overall_coverage(), None);
+    }
+
+    #[test]
+    fn overall_coverage_none_when_no_requirements() {
+        assert_eq!(store_with(vec![]).overall_coverage(), None);
+    }
+
+    #[test]
+    fn overall_coverage_calculates_verified_fraction() {
+        let store = store_with(vec![
+            req("r1", "v1", RequirementPriority::P0, VerificationStatus::Verified),
+            req("r2", "v1", RequirementPriority::P1, VerificationStatus::Unverified),
+            req("r3", "v1", RequirementPriority::P1, VerificationStatus::Verified),
+            req("r4", "v1", RequirementPriority::P2, VerificationStatus::Failed),
+        ]);
+        // 2 verified out of 4 = 50%
+        assert_eq!(store.overall_coverage(), Some(50));
+    }
+
+    #[test]
+    fn tier_coverage_none_for_missing_tier() {
+        let store = store_with(vec![
+            req("r1", "v1", RequirementPriority::P0, VerificationStatus::Verified),
+        ]);
+        assert_eq!(store.tier_coverage("v2"), None);
+    }
+
+    #[test]
+    fn gaps_excludes_verified() {
+        let store = store_with(vec![
+            req("r1", "v1", RequirementPriority::P0, VerificationStatus::Verified),
+            req("r2", "v1", RequirementPriority::P1, VerificationStatus::Unverified),
+            req("r3", "v2", RequirementPriority::P0, VerificationStatus::Failed),
+            req("r4", "v2", RequirementPriority::P2, VerificationStatus::PartiallyVerified),
+        ]);
+        let gaps = store.gaps();
+        assert_eq!(gaps.len(), 3, "unverified + failed + partially_verified");
+        assert!(gaps.iter().all(|r| r.status != VerificationStatus::Verified));
+    }
+
+    #[test]
+    fn blocking_gaps_returns_only_p0() {
+        let store = store_with(vec![
+            req("r1", "v1", RequirementPriority::P0, VerificationStatus::Unverified),
+            req("r2", "v1", RequirementPriority::P1, VerificationStatus::Unverified),
+            req("r3", "v1", RequirementPriority::P0, VerificationStatus::Failed),
+            req("r4", "v1", RequirementPriority::P0, VerificationStatus::Verified),
+        ]);
+        let blocking = store.blocking_gaps();
+        assert_eq!(blocking.len(), 2, "P0 unverified + P0 failed only");
+        assert!(blocking.iter().all(|r| r.priority == RequirementPriority::P0));
+    }
+}

--- a/crates/theatron/desktop/src/views/planning/checkpoints.rs
+++ b/crates/theatron/desktop/src/views/planning/checkpoints.rs
@@ -1,0 +1,211 @@
+//! Checkpoint list view: approval gates for a planning project.
+
+use dioxus::prelude::*;
+
+use crate::api::client::authenticated_client;
+use crate::components::checkpoint_card::CheckpointCard;
+use crate::state::checkpoints::{Checkpoint, CheckpointStore};
+use crate::state::connection::ConnectionConfig;
+
+#[derive(Debug, Clone)]
+enum FetchState {
+    Loading,
+    Loaded(CheckpointStore),
+    NotAvailable,
+    Error(String),
+}
+
+const CONTAINER_STYLE: &str = "\
+    display: flex; \
+    flex-direction: column; \
+    height: 100%; \
+    padding: 16px;\
+";
+
+const HEADER_ROW: &str = "\
+    display: flex; \
+    align-items: center; \
+    justify-content: space-between; \
+    margin-bottom: 16px;\
+";
+
+const PENDING_BANNER: &str = "\
+    background: #1e1e5a; \
+    border: 1px solid #4a4aff; \
+    border-radius: 6px; \
+    padding: 8px 12px; \
+    font-size: 13px; \
+    color: #8080ff; \
+    margin-bottom: 12px;\
+";
+
+const REFRESH_BTN: &str = "\
+    background: #2a2a4a; \
+    color: #e0e0e0; \
+    border: 1px solid #444; \
+    border-radius: 6px; \
+    padding: 4px 12px; \
+    font-size: 12px; \
+    cursor: pointer;\
+";
+
+const PLACEHOLDER_STYLE: &str = "\
+    display: flex; \
+    flex-direction: column; \
+    align-items: center; \
+    justify-content: center; \
+    flex: 1; \
+    gap: 10px; \
+    color: #555;\
+";
+
+/// Checkpoint approval list for a planning project.
+///
+/// Fetches from `GET /api/planning/projects/{project_id}/checkpoints`.
+/// Pending gates appear at the top of the list.
+///
+/// # TODO
+/// Wire SSE checkpoint events (when added to `theatron_core::events::StreamEvent`)
+/// for real-time notification when new checkpoints arrive.
+#[component]
+pub(crate) fn CheckpointsView(project_id: String) -> Element {
+    let config: Signal<ConnectionConfig> = use_context();
+    let mut fetch_state = use_signal(|| FetchState::Loading);
+    // WHY: incrementing this signal causes the fetch effect to re-run.
+    let mut fetch_trigger = use_signal(|| 0u32);
+
+    let project_id_effect = project_id.clone();
+
+    // Re-runs on mount and whenever fetch_trigger changes.
+    use_effect(move || {
+        let _ = *fetch_trigger.read();
+        let cfg = config.read().clone();
+        let pid = project_id_effect.clone();
+        fetch_state.set(FetchState::Loading);
+
+        spawn(async move {
+            let client = authenticated_client(&cfg);
+            let url = format!(
+                "{}/api/planning/projects/{pid}/checkpoints",
+                cfg.server_url.trim_end_matches('/')
+            );
+
+            match client.get(&url).send().await {
+                Ok(resp) if resp.status().is_success() => {
+                    match resp.json::<Vec<Checkpoint>>().await {
+                        Ok(checkpoints) => {
+                            fetch_state.set(FetchState::Loaded(CheckpointStore { checkpoints }));
+                        }
+                        Err(e) => {
+                            fetch_state.set(FetchState::Error(format!("parse error: {e}")));
+                        }
+                    }
+                }
+                // WHY: 404 means checkpoint endpoint not yet on this pylon version.
+                Ok(resp) if resp.status().as_u16() == 404 => {
+                    fetch_state.set(FetchState::NotAvailable);
+                }
+                Ok(resp) => {
+                    let status = resp.status();
+                    fetch_state.set(FetchState::Error(format!("server returned {status}")));
+                }
+                Err(e) => {
+                    fetch_state.set(FetchState::Error(format!("connection error: {e}")));
+                }
+            }
+        });
+    });
+
+    let project_id_card = project_id.clone();
+
+    rsx! {
+        div {
+            style: "{CONTAINER_STYLE}",
+            div {
+                style: "{HEADER_ROW}",
+                h3 { style: "margin: 0; font-size: 16px; color: #e0e0e0;", "Checkpoints" }
+                button {
+                    style: "{REFRESH_BTN}",
+                    onclick: move |_| {
+                        let next = *fetch_trigger.peek() + 1;
+                        fetch_trigger.set(next);
+                    },
+                    "Refresh"
+                }
+            }
+
+            match &*fetch_state.read() {
+                FetchState::Loading => rsx! {
+                    div {
+                        style: "display: flex; align-items: center; justify-content: center; flex: 1; color: #888;",
+                        "Loading checkpoints..."
+                    }
+                },
+                FetchState::Error(err) => rsx! {
+                    div {
+                        style: "display: flex; align-items: center; justify-content: center; flex: 1; color: #ef4444;",
+                        "Error: {err}"
+                    }
+                },
+                FetchState::NotAvailable => rsx! {
+                    div {
+                        style: "{PLACEHOLDER_STYLE}",
+                        div { style: "font-size: 16px;", "Checkpoints not available" }
+                        div { style: "font-size: 13px; max-width: 360px; text-align: center;",
+                            "The checkpoint API is not available on this pylon instance."
+                        }
+                    }
+                },
+                FetchState::Loaded(store) => {
+                    let pending = store.pending_count();
+                    let sorted_owned: Vec<Checkpoint> =
+                        store.sorted().into_iter().cloned().collect();
+                    let pid = project_id_card.clone();
+
+                    rsx! {
+                        div {
+                            style: "flex: 1; overflow-y: auto;",
+                            if pending > 0 {
+                                {
+                                    let noun = if pending == 1 { "checkpoint" } else { "checkpoints" };
+                                    rsx! {
+                                        div { style: "{PENDING_BANNER}",
+                                            "[!] {pending} {noun} awaiting approval"
+                                        }
+                                    }
+                                }
+                            }
+                            if sorted_owned.is_empty() {
+                                div {
+                                    style: "{PLACEHOLDER_STYLE}",
+                                    div { style: "font-size: 16px;", "No checkpoints" }
+                                    div { style: "font-size: 13px;",
+                                        "Checkpoints will appear as the project progresses."
+                                    }
+                                }
+                            } else {
+                                for checkpoint in sorted_owned {
+                                    {
+                                        let key = checkpoint.id.clone();
+                                        let project_id_inner = pid.clone();
+                                        rsx! {
+                                            CheckpointCard {
+                                                key: "{key}",
+                                                checkpoint,
+                                                project_id: project_id_inner,
+                                                on_action_complete: move |_| {
+                                                    let next = *fetch_trigger.peek() + 1;
+                                                    fetch_trigger.set(next);
+                                                },
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/crates/theatron/desktop/src/views/planning/gap_analysis.rs
+++ b/crates/theatron/desktop/src/views/planning/gap_analysis.rs
@@ -1,0 +1,222 @@
+//! Gap analysis panel: requirements not yet verified, filterable by priority.
+
+use dioxus::prelude::*;
+
+use crate::state::verification::{RequirementPriority, RequirementVerification, VerificationStatus};
+
+const PANEL_STYLE: &str = "\
+    display: flex; \
+    flex-direction: column; \
+    gap: 8px;\
+";
+
+const FILTER_ROW: &str = "\
+    display: flex; \
+    align-items: center; \
+    gap: 8px; \
+    margin-bottom: 8px;\
+";
+
+const FILTER_BTN_ACTIVE: &str = "\
+    background: #1e1e5a; \
+    color: #8080ff; \
+    border: 1px solid #4a4aff; \
+    border-radius: 6px; \
+    padding: 3px 10px; \
+    font-size: 12px; \
+    cursor: pointer;\
+";
+
+const FILTER_BTN_INACTIVE: &str = "\
+    background: transparent; \
+    color: #888; \
+    border: 1px solid #444; \
+    border-radius: 6px; \
+    padding: 3px 10px; \
+    font-size: 12px; \
+    cursor: pointer;\
+";
+
+const GAP_CARD: &str = "\
+    background: #1a1a2e; \
+    border: 1px solid #2a2a3a; \
+    border-radius: 6px; \
+    padding: 12px 14px;\
+";
+
+const GAP_TITLE_ROW: &str = "\
+    display: flex; \
+    align-items: center; \
+    gap: 8px; \
+    margin-bottom: 6px;\
+";
+
+const GAP_TITLE: &str = "\
+    font-size: 14px; \
+    font-weight: 600; \
+    color: #e0e0e0;\
+";
+
+const GAP_LABEL: &str = "\
+    font-size: 11px; \
+    font-weight: 600; \
+    padding: 1px 6px; \
+    border-radius: 4px; \
+    text-transform: uppercase;\
+";
+
+const CRITERIA_STYLE: &str = "\
+    font-size: 13px; \
+    color: #aaa; \
+    margin-bottom: 4px;\
+";
+
+const ACTION_STYLE: &str = "\
+    font-size: 12px; \
+    color: #4a9aff; \
+    background: #0f1a2a; \
+    border-radius: 3px; \
+    padding: 3px 6px; \
+    margin-top: 4px;\
+";
+
+const EMPTY_STYLE: &str = "\
+    color: #555; \
+    font-size: 13px; \
+    padding: 16px 0;\
+";
+
+/// Gap analysis panel listing requirements that are not yet fully verified.
+///
+/// Shows missing criteria and suggested actions. P0-only filter surfaces blocking gaps.
+#[component]
+pub(crate) fn GapAnalysisPanel(requirements: Vec<RequirementVerification>) -> Element {
+    let mut show_blocking_only = use_signal(|| false);
+
+    let gaps: Vec<&RequirementVerification> = requirements
+        .iter()
+        .filter(|r| {
+            matches!(
+                r.status,
+                VerificationStatus::Unverified
+                    | VerificationStatus::PartiallyVerified
+                    | VerificationStatus::Failed
+            )
+        })
+        .collect();
+
+    let displayed: Vec<&RequirementVerification> = if *show_blocking_only.read() {
+        gaps.iter()
+            .copied()
+            .filter(|r| r.priority == RequirementPriority::P0)
+            .collect()
+    } else {
+        gaps.clone()
+    };
+
+    let blocking_count = gaps
+        .iter()
+        .filter(|r| r.priority == RequirementPriority::P0)
+        .count();
+
+    rsx! {
+        div {
+            style: "{PANEL_STYLE}",
+            div {
+                style: "{FILTER_ROW}",
+                span { style: "font-size: 12px; color: #666;", "Filter:" }
+                button {
+                    style: if !*show_blocking_only.read() { "{FILTER_BTN_ACTIVE}" } else { "{FILTER_BTN_INACTIVE}" },
+                    onclick: move |_| show_blocking_only.set(false),
+                    "All ({gaps.len()})"
+                }
+                button {
+                    style: if *show_blocking_only.read() { "{FILTER_BTN_ACTIVE}" } else { "{FILTER_BTN_INACTIVE}" },
+                    onclick: move |_| show_blocking_only.set(true),
+                    "Blocking P0 ({blocking_count})"
+                }
+            }
+
+            if displayed.is_empty() {
+                div { style: "{EMPTY_STYLE}",
+                    if *show_blocking_only.read() {
+                        "No blocking (P0) gaps."
+                    } else {
+                        "No gaps found — all requirements verified."
+                    }
+                }
+            } else {
+                for req in displayed {
+                    {
+                        let priority_style = priority_badge_style(req.priority);
+                        let priority_label = priority_label(req.priority);
+                        let status_color = status_color(req.status);
+                        rsx! {
+                            div {
+                                key: "{req.id}",
+                                style: "{GAP_CARD}",
+                                div {
+                                    style: "{GAP_TITLE_ROW}",
+                                    span { style: "{GAP_TITLE}", "{req.title}" }
+                                    span { style: "{GAP_LABEL} {priority_style}", "{priority_label}" }
+                                    span {
+                                        style: "font-size: 11px; color: {status_color};",
+                                        "{status_label(req.status)}"
+                                    }
+                                }
+                                for (i, gap) in req.gaps.iter().enumerate() {
+                                    div {
+                                        key: "{i}",
+                                        div { style: "{CRITERIA_STYLE}", "Missing: {gap.missing_criteria}" }
+                                        div { style: "{ACTION_STYLE}", "Suggested: {gap.suggested_action}" }
+                                    }
+                                }
+                                if req.gaps.is_empty() {
+                                    div { style: "{CRITERIA_STYLE}",
+                                        "No detailed gap information available."
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn priority_badge_style(priority: RequirementPriority) -> &'static str {
+    match priority {
+        RequirementPriority::P0 => "background: #3a0f0f; color: #ef4444;",
+        RequirementPriority::P1 => "background: #2a1f05; color: #f59e0b;",
+        RequirementPriority::P2 => "background: #0f1f2a; color: #4a9aff;",
+        RequirementPriority::P3 => "background: #1a1a2e; color: #666;",
+    }
+}
+
+fn priority_label(priority: RequirementPriority) -> &'static str {
+    match priority {
+        RequirementPriority::P0 => "P0",
+        RequirementPriority::P1 => "P1",
+        RequirementPriority::P2 => "P2",
+        RequirementPriority::P3 => "P3",
+    }
+}
+
+fn status_label(status: VerificationStatus) -> &'static str {
+    match status {
+        VerificationStatus::Verified => "Verified",
+        VerificationStatus::PartiallyVerified => "Partial",
+        VerificationStatus::Unverified => "Unverified",
+        VerificationStatus::Failed => "Failed",
+    }
+}
+
+fn status_color(status: VerificationStatus) -> &'static str {
+    match status {
+        VerificationStatus::Verified => "#22c55e",
+        VerificationStatus::PartiallyVerified => "#f59e0b",
+        VerificationStatus::Unverified => "#888",
+        VerificationStatus::Failed => "#ef4444",
+    }
+}

--- a/crates/theatron/desktop/src/views/planning/mod.rs
+++ b/crates/theatron/desktop/src/views/planning/mod.rs
@@ -1,4 +1,9 @@
-//! Planning view: display active plans or a placeholder.
+//! Planning view: project list and project detail with checkpoints and verification.
+
+pub(crate) mod checkpoints;
+pub(crate) mod gap_analysis;
+pub(crate) mod project_detail;
+pub(crate) mod verification;
 
 use dioxus::prelude::*;
 

--- a/crates/theatron/desktop/src/views/planning/project_detail.rs
+++ b/crates/theatron/desktop/src/views/planning/project_detail.rs
@@ -1,0 +1,98 @@
+//! Project detail view: tab container with Checkpoints and Verification tabs.
+
+use dioxus::prelude::*;
+
+use crate::views::planning::checkpoints::CheckpointsView;
+use crate::views::planning::verification::VerificationView;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ActiveTab {
+    Checkpoints,
+    Verification,
+}
+
+const CONTAINER_STYLE: &str = "\
+    display: flex; \
+    flex-direction: column; \
+    height: 100%; \
+    overflow: hidden;\
+";
+
+const TAB_BAR_STYLE: &str = "\
+    display: flex; \
+    align-items: center; \
+    gap: 4px; \
+    padding: 8px 16px 0; \
+    border-bottom: 1px solid #2a2a3a; \
+    background: #0f0f1a;\
+";
+
+const TAB_ACTIVE: &str = "\
+    padding: 6px 16px; \
+    border: 1px solid #2a2a3a; \
+    border-bottom: 1px solid #0f0f1a; \
+    border-radius: 6px 6px 0 0; \
+    font-size: 13px; \
+    font-weight: 600; \
+    color: #e0e0e0; \
+    background: #0f0f1a; \
+    cursor: pointer;\
+";
+
+const TAB_INACTIVE: &str = "\
+    padding: 6px 16px; \
+    border: 1px solid transparent; \
+    border-radius: 6px 6px 0 0; \
+    font-size: 13px; \
+    color: #666; \
+    background: transparent; \
+    cursor: pointer;\
+";
+
+const TAB_CONTENT_STYLE: &str = "\
+    flex: 1; \
+    overflow: hidden;\
+";
+
+/// Project detail view with Checkpoints and Verification tabs.
+#[component]
+pub(crate) fn ProjectDetail(project_id: String) -> Element {
+    let mut active_tab = use_signal(|| ActiveTab::Checkpoints);
+
+    let project_id_ck = project_id.clone();
+    let project_id_vf = project_id.clone();
+
+    rsx! {
+        div {
+            style: "{CONTAINER_STYLE}",
+
+            // Tab bar
+            div {
+                style: "{TAB_BAR_STYLE}",
+                button {
+                    style: if *active_tab.read() == ActiveTab::Checkpoints { "{TAB_ACTIVE}" } else { "{TAB_INACTIVE}" },
+                    onclick: move |_| active_tab.set(ActiveTab::Checkpoints),
+                    "Checkpoints"
+                }
+                button {
+                    style: if *active_tab.read() == ActiveTab::Verification { "{TAB_ACTIVE}" } else { "{TAB_INACTIVE}" },
+                    onclick: move |_| active_tab.set(ActiveTab::Verification),
+                    "Verification"
+                }
+            }
+
+            // Tab content
+            div {
+                style: "{TAB_CONTENT_STYLE}",
+                match *active_tab.read() {
+                    ActiveTab::Checkpoints => rsx! {
+                        CheckpointsView { project_id: project_id_ck.clone() }
+                    },
+                    ActiveTab::Verification => rsx! {
+                        VerificationView { project_id: project_id_vf.clone() }
+                    },
+                }
+            }
+        }
+    }
+}

--- a/crates/theatron/desktop/src/views/planning/verification.rs
+++ b/crates/theatron/desktop/src/views/planning/verification.rs
@@ -1,0 +1,370 @@
+//! Verification view: goal-backward requirement verification results.
+
+use dioxus::prelude::*;
+
+use crate::api::client::authenticated_client;
+use crate::components::coverage_bar::{CoverageBar, coverage_color};
+use crate::state::connection::ConnectionConfig;
+use crate::state::verification::{RequirementVerification, VerificationResult, VerificationStore};
+use crate::views::planning::gap_analysis::GapAnalysisPanel;
+
+#[derive(Debug, Clone)]
+enum FetchState {
+    Loading,
+    Loaded(VerificationStore),
+    NotAvailable,
+    Error(String),
+}
+
+const CONTAINER_STYLE: &str = "\
+    display: flex; \
+    flex-direction: column; \
+    height: 100%; \
+    padding: 16px;\
+";
+
+const HEADER_ROW: &str = "\
+    display: flex; \
+    align-items: center; \
+    justify-content: space-between; \
+    margin-bottom: 16px;\
+";
+
+const SECTION_LABEL: &str = "\
+    font-size: 11px; \
+    font-weight: 600; \
+    color: #666; \
+    text-transform: uppercase; \
+    letter-spacing: 0.5px; \
+    margin: 16px 0 8px;\
+";
+
+const COVERAGE_SECTION: &str = "\
+    background: #1a1a2e; \
+    border: 1px solid #2a2a3a; \
+    border-radius: 8px; \
+    padding: 14px 16px; \
+    margin-bottom: 16px;\
+";
+
+const TABLE_STYLE: &str = "\
+    width: 100%; \
+    border-collapse: collapse; \
+    font-size: 13px;\
+";
+
+const TH_STYLE: &str = "\
+    text-align: left; \
+    padding: 6px 10px; \
+    font-size: 11px; \
+    font-weight: 600; \
+    color: #666; \
+    text-transform: uppercase; \
+    letter-spacing: 0.4px; \
+    border-bottom: 1px solid #2a2a3a;\
+";
+
+const TD_STYLE: &str = "\
+    padding: 8px 10px; \
+    border-bottom: 1px solid #1a1a2a; \
+    vertical-align: top;\
+";
+
+const GAP_SECTION: &str = "\
+    margin-top: 16px; \
+    background: #1a1a2e; \
+    border: 1px solid #2a2a3a; \
+    border-radius: 8px; \
+    padding: 14px 16px;\
+";
+
+const REFRESH_BTN: &str = "\
+    background: #2a2a4a; \
+    color: #e0e0e0; \
+    border: 1px solid #444; \
+    border-radius: 6px; \
+    padding: 4px 12px; \
+    font-size: 12px; \
+    cursor: pointer;\
+";
+
+const VERIFY_BTN: &str = "\
+    background: #1a2a4a; \
+    color: #4a9aff; \
+    border: 1px solid #4a9aff; \
+    border-radius: 6px; \
+    padding: 4px 12px; \
+    font-size: 12px; \
+    cursor: pointer;\
+";
+
+const PLACEHOLDER_STYLE: &str = "\
+    display: flex; \
+    flex-direction: column; \
+    align-items: center; \
+    justify-content: center; \
+    flex: 1; \
+    gap: 10px; \
+    color: #555;\
+";
+
+/// Goal-backward verification results view.
+///
+/// Fetches from `GET /api/planning/projects/{project_id}/verification`.
+/// Displays overall and per-tier coverage bars, a requirement table,
+/// and the gap analysis panel.
+///
+/// # TODO
+/// `POST /api/planning/projects/{project_id}/verification/refresh` endpoint
+/// is assumed but may not exist yet; the Re-verify button is wired to it.
+#[component]
+pub(crate) fn VerificationView(project_id: String) -> Element {
+    let config: Signal<ConnectionConfig> = use_context();
+    let mut fetch_state = use_signal(|| FetchState::Loading);
+    let mut reverifying = use_signal(|| false);
+    // WHY: incrementing this signal causes the fetch effect to re-run.
+    let mut fetch_trigger = use_signal(|| 0u32);
+
+    let project_id_effect = project_id.clone();
+    let project_id_reverify = project_id.clone();
+
+    // Re-runs on mount and whenever fetch_trigger changes.
+    use_effect(move || {
+        let _ = *fetch_trigger.read();
+        let cfg = config.read().clone();
+        let pid = project_id_effect.clone();
+        fetch_state.set(FetchState::Loading);
+
+        spawn(async move {
+            let client = authenticated_client(&cfg);
+            let url = format!(
+                "{}/api/planning/projects/{pid}/verification",
+                cfg.server_url.trim_end_matches('/')
+            );
+
+            match client.get(&url).send().await {
+                Ok(resp) if resp.status().is_success() => {
+                    match resp.json::<VerificationResult>().await {
+                        Ok(result) => {
+                            fetch_state.set(FetchState::Loaded(VerificationStore {
+                                result: Some(result),
+                            }));
+                        }
+                        Err(e) => {
+                            fetch_state.set(FetchState::Error(format!("parse error: {e}")));
+                        }
+                    }
+                }
+                // WHY: 404 means verification endpoint not yet on this pylon version.
+                Ok(resp) if resp.status().as_u16() == 404 => {
+                    fetch_state.set(FetchState::NotAvailable);
+                }
+                Ok(resp) => {
+                    let status = resp.status();
+                    fetch_state.set(FetchState::Error(format!("server returned {status}")));
+                }
+                Err(e) => {
+                    fetch_state.set(FetchState::Error(format!("connection error: {e}")));
+                }
+            }
+        });
+    });
+
+    // Re-verify: call the refresh endpoint then increment fetch_trigger to re-fetch.
+    let do_reverify = move |_| {
+        let cfg = config.read().clone();
+        let pid = project_id_reverify.clone();
+        reverifying.set(true);
+
+        spawn(async move {
+            let client = authenticated_client(&cfg);
+            let url = format!(
+                "{}/api/planning/projects/{pid}/verification/refresh",
+                cfg.server_url.trim_end_matches('/')
+            );
+
+            match client.post(&url).send().await {
+                Ok(resp) if resp.status().is_success() => {
+                    reverifying.set(false);
+                    let next = *fetch_trigger.peek() + 1;
+                    fetch_trigger.set(next);
+                }
+                Ok(resp) => {
+                    tracing::warn!("re-verify returned {}", resp.status());
+                    reverifying.set(false);
+                }
+                Err(e) => {
+                    tracing::warn!("re-verify error: {e}");
+                    reverifying.set(false);
+                }
+            }
+        });
+    };
+
+    rsx! {
+        div {
+            style: "{CONTAINER_STYLE}",
+            div {
+                style: "{HEADER_ROW}",
+                h3 { style: "margin: 0; font-size: 16px; color: #e0e0e0;", "Verification" }
+                div {
+                    style: "display: flex; gap: 8px; align-items: center;",
+                    button {
+                        style: "{VERIFY_BTN}",
+                        disabled: *reverifying.read(),
+                        onclick: do_reverify,
+                        if *reverifying.read() { "Verifying..." } else { "Re-verify" }
+                    }
+                    button {
+                        style: "{REFRESH_BTN}",
+                        onclick: move |_| {
+                            let next = *fetch_trigger.peek() + 1;
+                            fetch_trigger.set(next);
+                        },
+                        "Refresh"
+                    }
+                }
+            }
+
+            match &*fetch_state.read() {
+                FetchState::Loading => rsx! {
+                    div {
+                        style: "display: flex; align-items: center; justify-content: center; flex: 1; color: #888;",
+                        "Loading verification..."
+                    }
+                },
+                FetchState::Error(err) => rsx! {
+                    div {
+                        style: "display: flex; align-items: center; justify-content: center; flex: 1; color: #ef4444;",
+                        "Error: {err}"
+                    }
+                },
+                FetchState::NotAvailable => rsx! {
+                    div {
+                        style: "{PLACEHOLDER_STYLE}",
+                        div { style: "font-size: 16px;", "Verification not available" }
+                        div { style: "font-size: 13px; max-width: 360px; text-align: center;",
+                            "The verification API is not available on this pylon instance."
+                        }
+                    }
+                },
+                FetchState::Loaded(store) => {
+                    let overall = store.overall_coverage();
+                    let v1_cov = store.tier_coverage("v1");
+                    let v2_cov = store.tier_coverage("v2");
+                    let last_verified = store
+                        .result
+                        .as_ref()
+                        .map(|r| r.last_verified_at.as_str())
+                        .unwrap_or("unknown");
+                    let reqs: Vec<RequirementVerification> = store
+                        .result
+                        .as_ref()
+                        .map(|r| r.requirements.clone())
+                        .unwrap_or_default();
+
+                    rsx! {
+                        div {
+                            style: "flex: 1; overflow-y: auto;",
+                            // Timestamp
+                            div { style: "font-size: 11px; color: #555; margin-bottom: 12px;",
+                                "Last verified: {last_verified}"
+                            }
+
+                            // Coverage bars
+                            div {
+                                style: "{COVERAGE_SECTION}",
+                                div { style: "{SECTION_LABEL}", "Coverage" }
+                                CoverageBar { coverage: overall, label: "Overall".to_string() }
+                                CoverageBar { coverage: v1_cov, label: "v1".to_string() }
+                                CoverageBar { coverage: v2_cov, label: "v2".to_string() }
+                            }
+
+                            // Requirement table
+                            div { style: "{SECTION_LABEL}", "Requirements" }
+                            if reqs.is_empty() {
+                                div { style: "color: #555; font-size: 13px; padding: 8px 0;",
+                                    "No requirements defined."
+                                }
+                            } else {
+                                table {
+                                    style: "{TABLE_STYLE}",
+                                    thead {
+                                        tr {
+                                            th { style: "{TH_STYLE}", "Requirement" }
+                                            th { style: "{TH_STYLE}", "Status" }
+                                            th { style: "{TH_STYLE}", "Coverage" }
+                                            th { style: "{TH_STYLE}", "Tier" }
+                                            th { style: "{TH_STYLE}", "Evidence" }
+                                        }
+                                    }
+                                    tbody {
+                                        for req in &reqs {
+                                            {
+                                                let status_color = req_status_color(req.status);
+                                                let status_label = req_status_label(req.status);
+                                                let cov_color = coverage_color(req.coverage_pct);
+                                                let evidence_summary = if req.evidence.is_empty() {
+                                                    "—".to_string()
+                                                } else {
+                                                    req.evidence
+                                                        .iter()
+                                                        .map(|e| e.label.as_str())
+                                                        .collect::<Vec<_>>()
+                                                        .join(", ")
+                                                };
+                                                rsx! {
+                                                    tr {
+                                                        key: "{req.id}",
+                                                        td { style: "{TD_STYLE} color: #e0e0e0;", "{req.title}" }
+                                                        td {
+                                                            style: "{TD_STYLE} color: {status_color};",
+                                                            "{status_label}"
+                                                        }
+                                                        td {
+                                                            style: "{TD_STYLE} color: {cov_color}; font-weight: 600;",
+                                                            "{req.coverage_pct}%"
+                                                        }
+                                                        td { style: "{TD_STYLE} color: #888;", "{req.tier}" }
+                                                        td { style: "{TD_STYLE} color: #aaa;", "{evidence_summary}" }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+
+                            // Gap analysis panel
+                            div {
+                                style: "{GAP_SECTION}",
+                                div { style: "{SECTION_LABEL}", "Gap Analysis" }
+                                GapAnalysisPanel { requirements: reqs }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn req_status_color(status: crate::state::verification::VerificationStatus) -> &'static str {
+    use crate::state::verification::VerificationStatus;
+    match status {
+        VerificationStatus::Verified => "#22c55e",
+        VerificationStatus::PartiallyVerified => "#f59e0b",
+        VerificationStatus::Unverified => "#888",
+        VerificationStatus::Failed => "#ef4444",
+    }
+}
+
+fn req_status_label(status: crate::state::verification::VerificationStatus) -> &'static str {
+    use crate::state::verification::VerificationStatus;
+    match status {
+        VerificationStatus::Verified => "Verified",
+        VerificationStatus::PartiallyVerified => "Partial",
+        VerificationStatus::Unverified => "Unverified",
+        VerificationStatus::Failed => "Failed",
+    }
+}


### PR DESCRIPTION
## Summary

- Implements Phase 3.10–3.11 of the desktop planning view (checkpoint approval and goal-backward verification)
- `CheckpointCard`: approve/skip/override action flow with notes requirement (10-char min) for skip/override; waits for API response before updating UI (no optimistic update per design)
- `CheckpointsView`: fetches approval gates, sorts pending-first, shows pending count banner
- `CoverageBar`: color-coded progress bar (green >80%, amber 50–80%, red <50%)
- `VerificationView`: goal-backward results table with per-tier coverage breakdown (v1/v2), last-verified timestamp, Re-verify button
- `GapAnalysisPanel`: lists unverified requirements with missing criteria and suggested actions; P0-only filter toggle
- `ProjectDetail`: tab container (Checkpoints | Verification) for use within the planning view
- `state/checkpoints` and `state/verification`: typed stores with derived signals (pending_count, overall_coverage, gaps, blocking_gaps)
- 16 unit tests across state and component layers
- Converts `views/planning.rs` → `views/planning/` module directory

## Test plan

- [x] `cargo check --manifest-path crates/theatron/desktop/Cargo.toml` passes
- [x] `cargo test` (desktop): 240 tests pass including 16 new
- [x] `cargo test --workspace` passes
- [x] Pre-existing `cargo fmt` and `cargo clippy` failures confirmed pre-existing (not introduced by this branch)

## Observations

- **`layout.rs:78`** — The pending checkpoint count badge on the Planning nav item (acceptance criteria) requires modifying `NavItem` in `layout.rs`, which is outside the blast radius. `CheckpointStore::pending_count()` is implemented and ready; the nav integration is a follow-up.
- **`state/tools.rs:188`** — `PlanCardState::progress_fraction()` is never called from the `PlanningCard` component — the inline card uses direct arithmetic instead. Dead code candidate.
- **`views/planning/mod.rs`** — The `Planning` view fetches from `/api/v1/plans` but `ProjectDetail` fetches from `/api/planning/projects/{id}/checkpoints`. There's no navigation wiring between the plan list and the project detail view yet — clicking a plan doesn't open `ProjectDetail`. Routing/selection is a follow-up.
- **`state/verification.rs` / `views/planning/verification.rs`** — The `POST .../verification/refresh` endpoint is assumed but may not exist in pylon yet. Modeled with a graceful no-op on non-2xx.

🤖 Generated with [Claude Code](https://claude.com/claude-code)