### PR TITLE
feat(theatron-desktop): discussion panel and execution view

### DIFF
--- a/crates/theatron/desktop/src/components/mod.rs
+++ b/crates/theatron/desktop/src/components/mod.rs
@@ -1,16 +1,18 @@
 //! Dioxus components for the streaming chat interface.
 
 pub mod agent_sidebar;
-pub(crate) mod checkpoint_card;
-pub(crate) mod coverage_bar;
 pub mod chat;
+pub(crate) mod checkpoint_card;
 pub(crate) mod code_block;
 pub mod command_palette;
 pub mod connection_indicator;
+pub(crate) mod coverage_bar;
 pub mod distillation;
 pub(crate) mod input_bar;
 pub(crate) mod markdown;
 pub(crate) mod message;
+pub(crate) mod option_card;
+pub(crate) mod plan_card;
 pub(crate) mod planning_card;
 pub mod session_tabs;
 pub(crate) mod table;
@@ -21,3 +23,4 @@ pub(crate) mod toast_container;
 pub(crate) mod tool_approval;
 pub(crate) mod tool_panel;
 pub(crate) mod tool_status;
+pub(crate) mod wave_band;

--- a/crates/theatron/desktop/src/components/option_card.rs
+++ b/crates/theatron/desktop/src/components/option_card.rs
@@ -1,0 +1,205 @@
+//! Option card component for planning discussion choices.
+
+use dioxus::prelude::*;
+
+use crate::state::discussion::DiscussionOption;
+
+const CARD_STYLE: &str = "\
+    background: #1a1a2e; \
+    border: 1px solid #2a2a3a; \
+    border-radius: 8px; \
+    padding: 14px 16px; \
+    cursor: pointer; \
+    transition: border-color 0.15s;\
+";
+
+const CARD_RECOMMENDED: &str = "\
+    background: #1a1a2e; \
+    border: 2px solid #4a9aff; \
+    border-radius: 8px; \
+    padding: 14px 16px; \
+    cursor: pointer; \
+    transition: border-color 0.15s;\
+";
+
+const CARD_SELECTED: &str = "\
+    background: #1a2a3a; \
+    border: 2px solid #22c55e; \
+    border-radius: 8px; \
+    padding: 14px 16px; \
+    cursor: pointer; \
+    transition: border-color 0.15s;\
+";
+
+const HEADER_ROW: &str = "\
+    display: flex; \
+    align-items: center; \
+    gap: 8px; \
+    margin-bottom: 6px;\
+";
+
+const TITLE_STYLE: &str = "\
+    font-size: 14px; \
+    font-weight: 600; \
+    color: #e0e0e0;\
+";
+
+const BADGE_RECOMMENDED: &str = "\
+    display: inline-block; \
+    font-size: 10px; \
+    font-weight: 600; \
+    padding: 2px 6px; \
+    border-radius: 8px; \
+    background: #1a2a4a; \
+    color: #4a9aff; \
+    text-transform: uppercase; \
+    letter-spacing: 0.3px;\
+";
+
+const BADGE_SELECTED: &str = "\
+    display: inline-block; \
+    font-size: 10px; \
+    font-weight: 600; \
+    padding: 2px 6px; \
+    border-radius: 8px; \
+    background: #0f2a0f; \
+    color: #22c55e; \
+    text-transform: uppercase; \
+    letter-spacing: 0.3px;\
+";
+
+const DESCRIPTION_STYLE: &str = "\
+    font-size: 13px; \
+    color: #aaa; \
+    margin-bottom: 8px;\
+";
+
+const RATIONALE_STYLE: &str = "\
+    font-size: 12px; \
+    color: #999; \
+    font-style: italic; \
+    margin-bottom: 8px;\
+";
+
+const TRADE_OFF_SECTION: &str = "\
+    display: flex; \
+    gap: 16px; \
+    font-size: 12px;\
+";
+
+const PRO_ITEM: &str = "color: #22c55e; padding: 2px 0;";
+
+const CON_ITEM: &str = "color: #ef4444; padding: 2px 0;";
+
+/// Option card for a single discussion choice.
+///
+/// Displays title, description, rationale, trade-offs, and recommendation badge.
+/// Fires `on_select` when clicked.
+#[component]
+pub(crate) fn OptionCard(
+    option: DiscussionOption,
+    selected: bool,
+    on_select: EventHandler<String>,
+) -> Element {
+    let card_style = if selected {
+        CARD_SELECTED
+    } else if option.recommended {
+        CARD_RECOMMENDED
+    } else {
+        CARD_STYLE
+    };
+
+    let option_id = option.id.clone();
+
+    rsx! {
+        div {
+            style: "{card_style}",
+            onclick: move |_| on_select.call(option_id.clone()),
+
+            // Header: title + badges
+            div {
+                style: "{HEADER_ROW}",
+                span { style: "{TITLE_STYLE}", "{option.title}" }
+                if option.recommended {
+                    span { style: "{BADGE_RECOMMENDED}", "recommended" }
+                }
+                if selected {
+                    span { style: "{BADGE_SELECTED}", "selected" }
+                }
+            }
+
+            // Description
+            if !option.description.is_empty() {
+                div { style: "{DESCRIPTION_STYLE}", "{option.description}" }
+            }
+
+            // Rationale
+            if !option.rationale.is_empty() {
+                div { style: "{RATIONALE_STYLE}", "{option.rationale}" }
+            }
+
+            // Trade-offs
+            if !option.pros.is_empty() || !option.cons.is_empty() {
+                div {
+                    style: "{TRADE_OFF_SECTION}",
+
+                    if !option.pros.is_empty() {
+                        div {
+                            style: "flex: 1;",
+                            div { style: "color: #22c55e; font-weight: 600; margin-bottom: 4px;", "Pros" }
+                            for (i, pro) in option.pros.iter().enumerate() {
+                                div { key: "{i}", style: "{PRO_ITEM}", "+ {pro}" }
+                            }
+                        }
+                    }
+
+                    if !option.cons.is_empty() {
+                        div {
+                            style: "flex: 1;",
+                            div { style: "color: #ef4444; font-weight: 600; margin-bottom: 4px;", "Cons" }
+                            for (i, con) in option.cons.iter().enumerate() {
+                                div { key: "{i}", style: "{CON_ITEM}", "- {con}" }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Determine the card border style string based on state.
+#[must_use]
+pub(crate) fn card_style_for(recommended: bool, selected: bool) -> &'static str {
+    if selected {
+        CARD_SELECTED
+    } else if recommended {
+        CARD_RECOMMENDED
+    } else {
+        CARD_STYLE
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn card_style_selected_takes_priority() {
+        assert_eq!(
+            card_style_for(true, true),
+            CARD_SELECTED,
+            "selected overrides recommended"
+        );
+    }
+
+    #[test]
+    fn card_style_recommended_when_not_selected() {
+        assert_eq!(card_style_for(true, false), CARD_RECOMMENDED);
+    }
+
+    #[test]
+    fn card_style_default_when_neither() {
+        assert_eq!(card_style_for(false, false), CARD_STYLE);
+    }
+}

--- a/crates/theatron/desktop/src/components/plan_card.rs
+++ b/crates/theatron/desktop/src/components/plan_card.rs
@@ -1,0 +1,293 @@
+//! Plan card component for execution view.
+
+use dioxus::prelude::*;
+
+use crate::state::execution::{ExecutionPlan, StepStatus};
+
+const CARD_STYLE: &str = "\
+    flex: 1; \
+    min-width: 260px; \
+    max-width: 420px; \
+    background: #0f0f1a; \
+    border: 1px solid #2a2a3a; \
+    border-radius: 6px; \
+    padding: 12px 14px;\
+";
+
+const CARD_HEADER: &str = "\
+    display: flex; \
+    align-items: center; \
+    justify-content: space-between; \
+    margin-bottom: 8px;\
+";
+
+const PLAN_TITLE: &str = "\
+    font-size: 13px; \
+    font-weight: 600; \
+    color: #e0e0e0;\
+";
+
+const AGENT_BADGE: &str = "\
+    font-size: 11px; \
+    color: #888; \
+    display: flex; \
+    align-items: center; \
+    gap: 4px;\
+";
+
+const PROGRESS_TEXT: &str = "\
+    font-size: 11px; \
+    color: #888; \
+    margin-bottom: 6px;\
+";
+
+const STEP_ROW: &str = "\
+    display: flex; \
+    align-items: flex-start; \
+    gap: 6px; \
+    padding: 3px 0; \
+    font-size: 12px;\
+";
+
+const STEP_ICON_STYLE: &str = "\
+    flex-shrink: 0; \
+    width: 16px; \
+    text-align: center; \
+    font-size: 11px;\
+";
+
+const STEP_DESC: &str = "color: #c0c0e0;";
+
+const DETAIL_BOX: &str = "\
+    margin-top: 4px; \
+    padding: 6px 8px; \
+    background: #151525; \
+    border: 1px solid #2a2a3a; \
+    border-radius: 4px; \
+    font-size: 11px;\
+";
+
+const TIME_ROW: &str = "\
+    display: flex; \
+    align-items: center; \
+    gap: 12px; \
+    margin-top: 8px; \
+    font-size: 11px; \
+    color: #666;\
+";
+
+const EXPAND_BTN: &str = "\
+    background: transparent; \
+    border: none; \
+    color: #4a9aff; \
+    font-size: 11px; \
+    cursor: pointer; \
+    padding: 0;\
+";
+
+/// Plan card for an execution plan within a wave.
+///
+/// Shows title, agent, step list with status indicators, and an expandable detail view.
+#[component]
+pub(crate) fn PlanCard(plan: ExecutionPlan) -> Element {
+    let mut expanded = use_signal(|| false);
+    let progress = plan.progress_pct();
+    let completed = plan.completed_steps();
+    let total = plan.steps.len();
+    let has_failure = plan.has_failure();
+
+    let progress_label = if has_failure {
+        format!("Step {completed} of {total} (has failures)")
+    } else {
+        format!("Step {completed} of {total}")
+    };
+
+    rsx! {
+        div {
+            style: "{CARD_STYLE}",
+
+            // Header: title + agent
+            div {
+                style: "{CARD_HEADER}",
+                span { style: "{PLAN_TITLE}", "{plan.title}" }
+                if !plan.agent_name.is_empty() {
+                    span {
+                        style: "{AGENT_BADGE}",
+                        span {
+                            style: "width: 6px; height: 6px; border-radius: 50%; background: {agent_status_color(&plan.agent_status)};",
+                        }
+                        "{plan.agent_name}"
+                    }
+                }
+            }
+
+            // Progress
+            div {
+                style: "{PROGRESS_TEXT}",
+                "{progress_label} — {progress}%"
+            }
+
+            // Step list
+            for step in &plan.steps {
+                div {
+                    key: "{step.id}",
+                    style: "{STEP_ROW}",
+                    span {
+                        style: "{STEP_ICON_STYLE} color: {step_color(step.status)};",
+                        "{step_icon(step.status)}"
+                    }
+                    div {
+                        style: "flex: 1;",
+                        span { style: "{STEP_DESC}", "{step.description}" }
+
+                        // Expanded detail
+                        if *expanded.read() {
+                            if let Some(ref output) = step.output {
+                                div {
+                                    style: "{DETAIL_BOX} color: #aaa;",
+                                    "{output}"
+                                }
+                            }
+                            if let Some(ref error) = step.error {
+                                div {
+                                    style: "{DETAIL_BOX} color: #ef4444;",
+                                    "{error}"
+                                }
+                            }
+                            if let Some(dur) = step.duration_secs {
+                                span {
+                                    style: "font-size: 10px; color: #555; margin-left: 4px;",
+                                    "({dur:.1}s)"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Expand/collapse toggle
+            if !plan.steps.is_empty() {
+                button {
+                    style: "{EXPAND_BTN}",
+                    onclick: move |_| {
+                        let current = *expanded.read();
+                        expanded.set(!current);
+                    },
+                    if *expanded.read() { "Hide details" } else { "Show details" }
+                }
+            }
+
+            // Elapsed / remaining time
+            if plan.elapsed_secs.is_some() || plan.estimated_remaining_secs.is_some() {
+                div {
+                    style: "{TIME_ROW}",
+                    if let Some(elapsed) = plan.elapsed_secs {
+                        span { "{format_duration(elapsed)} elapsed" }
+                    }
+                    if let Some(remaining) = plan.estimated_remaining_secs {
+                        span { "~{format_duration(remaining)} remaining" }
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[must_use]
+pub(crate) fn step_icon(status: StepStatus) -> &'static str {
+    match status {
+        StepStatus::Pending => "( )",
+        StepStatus::Running => "(>)",
+        StepStatus::Complete => "(v)",
+        StepStatus::Failed => "(x)",
+        StepStatus::Skipped => "(-)",
+    }
+}
+
+#[must_use]
+pub(crate) fn step_color(status: StepStatus) -> &'static str {
+    match status {
+        StepStatus::Pending => "#666",
+        StepStatus::Running => "#4a9aff",
+        StepStatus::Complete => "#22c55e",
+        StepStatus::Failed => "#ef4444",
+        StepStatus::Skipped => "#888",
+    }
+}
+
+fn agent_status_color(status: &str) -> &'static str {
+    match status {
+        "active" | "running" => "#22c55e",
+        "idle" | "waiting" => "#f59e0b",
+        "error" | "failed" => "#ef4444",
+        _ => "#666",
+    }
+}
+
+fn format_duration(secs: f64) -> String {
+    if secs < 60.0 {
+        format!("{secs:.0}s")
+    } else if secs < 3600.0 {
+        let mins = secs / 60.0;
+        format!("{mins:.1}m")
+    } else {
+        let hours = secs / 3600.0;
+        format!("{hours:.1}h")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn step_icons_are_distinct() {
+        let icons: Vec<_> = [
+            StepStatus::Pending,
+            StepStatus::Running,
+            StepStatus::Complete,
+            StepStatus::Failed,
+            StepStatus::Skipped,
+        ]
+        .iter()
+        .map(|s| step_icon(*s))
+        .collect();
+        let unique: std::collections::HashSet<_> = icons.iter().collect();
+        assert_eq!(unique.len(), icons.len(), "all step icons must be distinct");
+    }
+
+    #[test]
+    fn step_colors_are_distinct() {
+        let colors: Vec<_> = [
+            StepStatus::Pending,
+            StepStatus::Running,
+            StepStatus::Complete,
+            StepStatus::Failed,
+            StepStatus::Skipped,
+        ]
+        .iter()
+        .map(|s| step_color(*s))
+        .collect();
+        let unique: std::collections::HashSet<_> = colors.iter().collect();
+        assert_eq!(
+            unique.len(),
+            colors.len(),
+            "all step colors must be distinct"
+        );
+    }
+
+    #[test]
+    fn format_duration_seconds() {
+        assert_eq!(format_duration(45.0), "45s");
+    }
+
+    #[test]
+    fn format_duration_minutes() {
+        assert_eq!(format_duration(150.0), "2.5m");
+    }
+
+    #[test]
+    fn format_duration_hours() {
+        assert_eq!(format_duration(7200.0), "2.0h");
+    }
+}

--- a/crates/theatron/desktop/src/components/wave_band.rs
+++ b/crates/theatron/desktop/src/components/wave_band.rs
@@ -1,0 +1,183 @@
+//! Wave band component for execution progress display.
+
+use dioxus::prelude::*;
+
+use crate::state::execution::{Wave, WaveStatus};
+
+const BAND_BASE: &str = "\
+    border-radius: 8px; \
+    border: 1px solid; \
+    padding: 12px 16px; \
+    margin-bottom: 8px;\
+";
+
+const BAND_HEADER: &str = "\
+    display: flex; \
+    align-items: center; \
+    justify-content: space-between; \
+    margin-bottom: 8px;\
+";
+
+const WAVE_LABEL: &str = "\
+    font-size: 14px; \
+    font-weight: 600; \
+    color: #e0e0e0;\
+";
+
+const BADGE_BASE: &str = "\
+    display: inline-block; \
+    font-size: 10px; \
+    font-weight: 600; \
+    padding: 2px 8px; \
+    border-radius: 10px; \
+    text-transform: uppercase; \
+    letter-spacing: 0.3px;\
+";
+
+const TIME_STYLE: &str = "\
+    font-size: 11px; \
+    color: #666;\
+";
+
+const PROGRESS_TRACK: &str = "\
+    height: 4px; \
+    background: #2a2a3a; \
+    border-radius: 2px; \
+    margin-bottom: 10px; \
+    overflow: hidden;\
+";
+
+const PLANS_ROW: &str = "\
+    display: flex; \
+    gap: 12px; \
+    flex-wrap: wrap;\
+";
+
+/// Wave band container showing wave header, progress bar, and child plan cards.
+#[component]
+pub(crate) fn WaveBand(wave: Wave, children: Element) -> Element {
+    let (bg, border_color) = band_colors(wave.status);
+    let band_style = format!("{BAND_BASE} background: {bg}; border-color: {border_color};");
+    let badge_style = status_badge_style(wave.status);
+    let label = status_label(wave.status);
+    let progress = wave.progress_pct();
+
+    rsx! {
+        div {
+            style: "{band_style}",
+
+            // Header
+            div {
+                style: "{BAND_HEADER}",
+                div {
+                    style: "display: flex; align-items: center; gap: 8px;",
+                    span { style: "{WAVE_LABEL}", "Wave {wave.wave_number}" }
+                    span { style: "{badge_style}", "{label}" }
+                }
+                div {
+                    style: "display: flex; align-items: center; gap: 12px;",
+                    if let Some(ref start) = wave.start_time {
+                        span { style: "{TIME_STYLE}", "Started: {start}" }
+                    }
+                    if let Some(ref end) = wave.end_time {
+                        span { style: "{TIME_STYLE}", "Ended: {end}" }
+                    }
+                    span { style: "font-size: 12px; color: #aaa;", "{progress}%" }
+                }
+            }
+
+            // Progress bar
+            div {
+                style: "{PROGRESS_TRACK}",
+                div {
+                    style: "height: 100%; background: {progress_color(wave.status)}; width: {progress}%; border-radius: 2px; transition: width 0.3s;",
+                }
+            }
+
+            // Plan cards row
+            div {
+                style: "{PLANS_ROW}",
+                {children}
+            }
+        }
+    }
+}
+
+fn band_colors(status: WaveStatus) -> (&'static str, &'static str) {
+    match status {
+        WaveStatus::Active => ("#1a1a2e", "#4a9aff"),
+        WaveStatus::Complete => ("#0f1a0f", "#2a4a2a"),
+        WaveStatus::Pending => ("#151520", "#2a2a3a"),
+    }
+}
+
+fn progress_color(status: WaveStatus) -> &'static str {
+    match status {
+        WaveStatus::Active => "#4a9aff",
+        WaveStatus::Complete => "#22c55e",
+        WaveStatus::Pending => "#444",
+    }
+}
+
+#[must_use]
+pub(crate) fn status_badge_style(status: WaveStatus) -> String {
+    let (bg, color) = match status {
+        WaveStatus::Active => ("#1e1e5a", "#4a9aff"),
+        WaveStatus::Complete => ("#0f2a0f", "#22c55e"),
+        WaveStatus::Pending => ("#2a2a3a", "#666"),
+    };
+    format!("{BADGE_BASE} background: {bg}; color: {color};")
+}
+
+#[must_use]
+pub(crate) fn status_label(status: WaveStatus) -> &'static str {
+    match status {
+        WaveStatus::Pending => "Pending",
+        WaveStatus::Active => "Active",
+        WaveStatus::Complete => "Complete",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn band_colors_differ_by_status() {
+        let active = band_colors(WaveStatus::Active);
+        let complete = band_colors(WaveStatus::Complete);
+        let pending = band_colors(WaveStatus::Pending);
+        assert_ne!(active, complete);
+        assert_ne!(complete, pending);
+    }
+
+    #[test]
+    fn status_labels_are_distinct() {
+        let labels: Vec<_> = [
+            WaveStatus::Pending,
+            WaveStatus::Active,
+            WaveStatus::Complete,
+        ]
+        .iter()
+        .map(|s| status_label(*s))
+        .collect();
+        let unique: std::collections::HashSet<_> = labels.iter().collect();
+        assert_eq!(
+            unique.len(),
+            labels.len(),
+            "all wave labels must be distinct"
+        );
+    }
+
+    #[test]
+    fn progress_color_differs_by_status() {
+        assert_ne!(
+            progress_color(WaveStatus::Active),
+            progress_color(WaveStatus::Complete)
+        );
+        assert_ne!(
+            progress_color(WaveStatus::Complete),
+            progress_color(WaveStatus::Pending)
+        );
+    }
+}

--- a/crates/theatron/desktop/src/state/discussion.rs
+++ b/crates/theatron/desktop/src/state/discussion.rs
@@ -1,0 +1,312 @@
+//! Discussion state for planning gray-area questions.
+
+use serde::{Deserialize, Serialize};
+
+/// Priority level for a discussion item.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub(crate) enum DiscussionPriority {
+    /// Blocking: cannot proceed without an answer.
+    Blocking,
+    /// Important but not blocking.
+    Important,
+    /// Nice-to-have clarification.
+    NiceToHave,
+}
+
+/// Resolution status of a discussion.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub(crate) enum DiscussionStatus {
+    /// Awaiting a human answer.
+    Open,
+    /// Answered — option selected or free-text provided.
+    Answered,
+    /// Deferred for later.
+    Deferred,
+}
+
+/// A single option the agent proposes for a discussion question.
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+pub(crate) struct DiscussionOption {
+    pub(crate) id: String,
+    pub(crate) title: String,
+    pub(crate) description: String,
+    /// Agent's analysis of pros and cons.
+    pub(crate) rationale: String,
+    pub(crate) pros: Vec<String>,
+    pub(crate) cons: Vec<String>,
+    /// Whether this is the agent's recommended choice.
+    #[serde(default)]
+    pub(crate) recommended: bool,
+}
+
+/// An entry in the discussion history (previous answers, reopens, follow-ups).
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+pub(crate) struct DiscussionHistoryEntry {
+    pub(crate) action: String,
+    pub(crate) actor: String,
+    pub(crate) timestamp: String,
+    #[serde(default)]
+    pub(crate) detail: String,
+}
+
+/// A single discussion item — a gray-area question needing human input.
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+pub(crate) struct Discussion {
+    pub(crate) id: String,
+    pub(crate) project_id: String,
+    pub(crate) question: String,
+    pub(crate) context: String,
+    pub(crate) status: DiscussionStatus,
+    pub(crate) priority: DiscussionPriority,
+    pub(crate) options: Vec<DiscussionOption>,
+    /// The selected option id, if answered via option selection.
+    #[serde(default)]
+    pub(crate) selected_option_id: Option<String>,
+    /// Free-text answer override, if provided.
+    #[serde(default)]
+    pub(crate) free_text_answer: Option<String>,
+    #[serde(default)]
+    pub(crate) history: Vec<DiscussionHistoryEntry>,
+}
+
+/// Request body for answering a discussion.
+#[derive(Debug, Serialize)]
+pub(crate) struct DiscussionAnswerRequest {
+    /// Selected option id, or None for free-text override.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) option_id: Option<String>,
+    /// Free-text answer override.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) free_text: Option<String>,
+}
+
+/// Store for discussions associated with the active project.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct DiscussionStore {
+    pub(crate) discussions: Vec<Discussion>,
+}
+
+impl DiscussionStore {
+    /// Count of discussions awaiting a human answer.
+    #[must_use]
+    pub(crate) fn open_count(&self) -> usize {
+        self.discussions
+            .iter()
+            .filter(|d| d.status == DiscussionStatus::Open)
+            .count()
+    }
+
+    /// Count of blocking discussions still open.
+    #[must_use]
+    pub(crate) fn blocking_count(&self) -> usize {
+        self.discussions
+            .iter()
+            .filter(|d| {
+                d.status == DiscussionStatus::Open && d.priority == DiscussionPriority::Blocking
+            })
+            .count()
+    }
+
+    /// Discussions sorted: open first, then blocking before important before nice-to-have.
+    #[must_use]
+    pub(crate) fn sorted(&self) -> Vec<&Discussion> {
+        let mut refs: Vec<&Discussion> = self.discussions.iter().collect();
+        refs.sort_by(|a, b| {
+            let a_status = status_order(a.status);
+            let b_status = status_order(b.status);
+            a_status
+                .cmp(&b_status)
+                .then_with(|| priority_order(a.priority).cmp(&priority_order(b.priority)))
+                .then_with(|| a.id.cmp(&b.id))
+        });
+        refs
+    }
+
+    /// Get the selected answer summary for a discussion.
+    #[must_use]
+    pub(crate) fn answer_summary(discussion: &Discussion) -> Option<String> {
+        if let Some(ref text) = discussion.free_text_answer {
+            return Some(text.clone());
+        }
+        if let Some(ref opt_id) = discussion.selected_option_id {
+            return discussion
+                .options
+                .iter()
+                .find(|o| &o.id == opt_id)
+                .map(|o| o.title.clone());
+        }
+        None
+    }
+}
+
+fn status_order(status: DiscussionStatus) -> u8 {
+    match status {
+        DiscussionStatus::Open => 0,
+        DiscussionStatus::Deferred => 1,
+        DiscussionStatus::Answered => 2,
+    }
+}
+
+fn priority_order(priority: DiscussionPriority) -> u8 {
+    match priority {
+        DiscussionPriority::Blocking => 0,
+        DiscussionPriority::Important => 1,
+        DiscussionPriority::NiceToHave => 2,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_discussion(
+        id: &str,
+        status: DiscussionStatus,
+        priority: DiscussionPriority,
+    ) -> Discussion {
+        Discussion {
+            id: id.to_string(),
+            project_id: "proj1".to_string(),
+            question: format!("Question {id}?"),
+            context: String::new(),
+            status,
+            priority,
+            options: vec![],
+            selected_option_id: None,
+            free_text_answer: None,
+            history: vec![],
+        }
+    }
+
+    #[test]
+    fn open_count_returns_only_open() {
+        let store = DiscussionStore {
+            discussions: vec![
+                make_discussion("a", DiscussionStatus::Open, DiscussionPriority::Blocking),
+                make_discussion(
+                    "b",
+                    DiscussionStatus::Answered,
+                    DiscussionPriority::Important,
+                ),
+                make_discussion("c", DiscussionStatus::Open, DiscussionPriority::NiceToHave),
+                make_discussion(
+                    "d",
+                    DiscussionStatus::Deferred,
+                    DiscussionPriority::Blocking,
+                ),
+            ],
+        };
+        assert_eq!(store.open_count(), 2, "only open discussions counted");
+    }
+
+    #[test]
+    fn blocking_count_returns_open_blocking_only() {
+        let store = DiscussionStore {
+            discussions: vec![
+                make_discussion("a", DiscussionStatus::Open, DiscussionPriority::Blocking),
+                make_discussion("b", DiscussionStatus::Open, DiscussionPriority::Important),
+                make_discussion(
+                    "c",
+                    DiscussionStatus::Answered,
+                    DiscussionPriority::Blocking,
+                ),
+                make_discussion("d", DiscussionStatus::Open, DiscussionPriority::Blocking),
+            ],
+        };
+        assert_eq!(
+            store.blocking_count(),
+            2,
+            "only open + blocking discussions counted"
+        );
+    }
+
+    #[test]
+    fn sorted_places_open_before_answered() {
+        let store = DiscussionStore {
+            discussions: vec![
+                make_discussion(
+                    "a",
+                    DiscussionStatus::Answered,
+                    DiscussionPriority::Blocking,
+                ),
+                make_discussion("b", DiscussionStatus::Open, DiscussionPriority::NiceToHave),
+            ],
+        };
+        let sorted = store.sorted();
+        assert_eq!(sorted[0].status, DiscussionStatus::Open);
+        assert_eq!(sorted[1].status, DiscussionStatus::Answered);
+    }
+
+    #[test]
+    fn sorted_places_blocking_before_nice_to_have() {
+        let store = DiscussionStore {
+            discussions: vec![
+                make_discussion("a", DiscussionStatus::Open, DiscussionPriority::NiceToHave),
+                make_discussion("b", DiscussionStatus::Open, DiscussionPriority::Blocking),
+                make_discussion("c", DiscussionStatus::Open, DiscussionPriority::Important),
+            ],
+        };
+        let sorted = store.sorted();
+        assert_eq!(sorted[0].priority, DiscussionPriority::Blocking);
+        assert_eq!(sorted[1].priority, DiscussionPriority::Important);
+        assert_eq!(sorted[2].priority, DiscussionPriority::NiceToHave);
+    }
+
+    #[test]
+    fn answer_summary_prefers_free_text() {
+        let mut disc = make_discussion(
+            "x",
+            DiscussionStatus::Answered,
+            DiscussionPriority::Important,
+        );
+        disc.free_text_answer = Some("custom answer".to_string());
+        disc.selected_option_id = Some("opt1".to_string());
+        disc.options.push(DiscussionOption {
+            id: "opt1".to_string(),
+            title: "Option One".to_string(),
+            description: String::new(),
+            rationale: String::new(),
+            pros: vec![],
+            cons: vec![],
+            recommended: false,
+        });
+        assert_eq!(
+            DiscussionStore::answer_summary(&disc),
+            Some("custom answer".to_string()),
+            "free text takes precedence over selected option"
+        );
+    }
+
+    #[test]
+    fn answer_summary_falls_back_to_option_title() {
+        let mut disc = make_discussion(
+            "x",
+            DiscussionStatus::Answered,
+            DiscussionPriority::Important,
+        );
+        disc.selected_option_id = Some("opt1".to_string());
+        disc.options.push(DiscussionOption {
+            id: "opt1".to_string(),
+            title: "Option One".to_string(),
+            description: String::new(),
+            rationale: String::new(),
+            pros: vec![],
+            cons: vec![],
+            recommended: false,
+        });
+        assert_eq!(
+            DiscussionStore::answer_summary(&disc),
+            Some("Option One".to_string()),
+        );
+    }
+
+    #[test]
+    fn answer_summary_none_when_unanswered() {
+        let disc = make_discussion("x", DiscussionStatus::Open, DiscussionPriority::Important);
+        assert_eq!(DiscussionStore::answer_summary(&disc), None);
+    }
+}

--- a/crates/theatron/desktop/src/state/execution.rs
+++ b/crates/theatron/desktop/src/state/execution.rs
@@ -1,0 +1,392 @@
+//! Execution state for wave-based plan progress.
+
+use serde::Deserialize;
+
+/// Status of a wave or individual plan step.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub(crate) enum StepStatus {
+    /// Not yet started.
+    Pending,
+    /// Currently executing.
+    Running,
+    /// Successfully completed.
+    Complete,
+    /// Execution failed.
+    Failed,
+    /// Intentionally skipped.
+    Skipped,
+}
+
+/// Status of a wave in the execution sequence.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub(crate) enum WaveStatus {
+    /// Not yet started.
+    Pending,
+    /// Currently executing.
+    Active,
+    /// All plans in wave completed.
+    Complete,
+}
+
+/// A single step within an execution plan.
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+pub(crate) struct PlanStep {
+    pub(crate) id: String,
+    pub(crate) description: String,
+    pub(crate) status: StepStatus,
+    /// Step output or result summary.
+    #[serde(default)]
+    pub(crate) output: Option<String>,
+    /// Duration in seconds, if completed.
+    #[serde(default)]
+    pub(crate) duration_secs: Option<f64>,
+    /// Error message, if failed.
+    #[serde(default)]
+    pub(crate) error: Option<String>,
+}
+
+/// An execution plan assigned to an agent within a wave.
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+pub(crate) struct ExecutionPlan {
+    pub(crate) id: String,
+    pub(crate) title: String,
+    #[serde(default)]
+    pub(crate) description: String,
+    /// Agent assigned to this plan.
+    #[serde(default)]
+    pub(crate) agent_name: String,
+    /// Agent status indicator.
+    #[serde(default)]
+    pub(crate) agent_status: String,
+    pub(crate) steps: Vec<PlanStep>,
+    /// Elapsed seconds since plan started.
+    #[serde(default)]
+    pub(crate) elapsed_secs: Option<f64>,
+    /// Estimated remaining seconds.
+    #[serde(default)]
+    pub(crate) estimated_remaining_secs: Option<f64>,
+}
+
+impl ExecutionPlan {
+    /// Number of steps completed (Complete, Failed, or Skipped).
+    #[must_use]
+    pub(crate) fn completed_steps(&self) -> usize {
+        self.steps
+            .iter()
+            .filter(|s| {
+                matches!(
+                    s.status,
+                    StepStatus::Complete | StepStatus::Failed | StepStatus::Skipped
+                )
+            })
+            .count()
+    }
+
+    /// Overall step progress as a percentage (0–100).
+    #[must_use]
+    pub(crate) fn progress_pct(&self) -> u8 {
+        if self.steps.is_empty() {
+            return 0;
+        }
+        let done = self.completed_steps();
+        ((done * 100) / self.steps.len()).min(100) as u8
+    }
+
+    /// Whether any step has failed.
+    #[must_use]
+    pub(crate) fn has_failure(&self) -> bool {
+        self.steps.iter().any(|s| s.status == StepStatus::Failed)
+    }
+}
+
+/// A wave: a sequential group of parallelizable plans.
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+pub(crate) struct Wave {
+    pub(crate) wave_number: u32,
+    pub(crate) status: WaveStatus,
+    pub(crate) plans: Vec<ExecutionPlan>,
+    #[serde(default)]
+    pub(crate) start_time: Option<String>,
+    #[serde(default)]
+    pub(crate) end_time: Option<String>,
+}
+
+impl Wave {
+    /// Wave progress as a percentage across all plans.
+    #[must_use]
+    pub(crate) fn progress_pct(&self) -> u8 {
+        let total_steps: usize = self.plans.iter().map(|p| p.steps.len()).sum();
+        if total_steps == 0 {
+            return if self.status == WaveStatus::Complete {
+                100
+            } else {
+                0
+            };
+        }
+        let done: usize = self.plans.iter().map(|p| p.completed_steps()).sum();
+        ((done * 100) / total_steps).min(100) as u8
+    }
+}
+
+/// Full execution state for a project.
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+pub(crate) struct ExecutionState {
+    pub(crate) project_id: String,
+    pub(crate) waves: Vec<Wave>,
+}
+
+/// Store for execution state of the active project.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct ExecutionStore {
+    pub(crate) state: Option<ExecutionState>,
+}
+
+impl ExecutionStore {
+    /// Total number of waves.
+    #[must_use]
+    pub(crate) fn wave_count(&self) -> usize {
+        self.state.as_ref().map_or(0, |s| s.waves.len())
+    }
+
+    /// The currently active wave number (1-indexed), or None if no wave is active.
+    #[must_use]
+    pub(crate) fn active_wave_number(&self) -> Option<u32> {
+        self.state.as_ref().and_then(|s| {
+            s.waves
+                .iter()
+                .find(|w| w.status == WaveStatus::Active)
+                .map(|w| w.wave_number)
+        })
+    }
+
+    /// Overall execution progress across all waves.
+    #[must_use]
+    pub(crate) fn overall_progress_pct(&self) -> u8 {
+        let Some(ref state) = self.state else {
+            return 0;
+        };
+        let total_steps: usize = state
+            .waves
+            .iter()
+            .flat_map(|w| &w.plans)
+            .map(|p| p.steps.len())
+            .sum();
+        if total_steps == 0 {
+            return 0;
+        }
+        let done: usize = state
+            .waves
+            .iter()
+            .flat_map(|w| &w.plans)
+            .map(|p| p.completed_steps())
+            .sum();
+        ((done * 100) / total_steps).min(100) as u8
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_step(id: &str, status: StepStatus) -> PlanStep {
+        PlanStep {
+            id: id.to_string(),
+            description: format!("Step {id}"),
+            status,
+            output: None,
+            duration_secs: None,
+            error: None,
+        }
+    }
+
+    fn make_plan(id: &str, steps: Vec<PlanStep>) -> ExecutionPlan {
+        ExecutionPlan {
+            id: id.to_string(),
+            title: format!("Plan {id}"),
+            description: String::new(),
+            agent_name: "agent-1".to_string(),
+            agent_status: "active".to_string(),
+            steps,
+            elapsed_secs: None,
+            estimated_remaining_secs: None,
+        }
+    }
+
+    fn make_wave(num: u32, status: WaveStatus, plans: Vec<ExecutionPlan>) -> Wave {
+        Wave {
+            wave_number: num,
+            status,
+            plans,
+            start_time: None,
+            end_time: None,
+        }
+    }
+
+    #[test]
+    fn plan_completed_steps_counts_done_states() {
+        let plan = make_plan(
+            "p1",
+            vec![
+                make_step("s1", StepStatus::Complete),
+                make_step("s2", StepStatus::Running),
+                make_step("s3", StepStatus::Failed),
+                make_step("s4", StepStatus::Skipped),
+                make_step("s5", StepStatus::Pending),
+            ],
+        );
+        assert_eq!(plan.completed_steps(), 3, "complete + failed + skipped = 3");
+    }
+
+    #[test]
+    fn plan_progress_pct_calculates_correctly() {
+        let plan = make_plan(
+            "p1",
+            vec![
+                make_step("s1", StepStatus::Complete),
+                make_step("s2", StepStatus::Complete),
+                make_step("s3", StepStatus::Pending),
+                make_step("s4", StepStatus::Pending),
+            ],
+        );
+        assert_eq!(plan.progress_pct(), 50);
+    }
+
+    #[test]
+    fn plan_progress_pct_zero_when_no_steps() {
+        let plan = make_plan("p1", vec![]);
+        assert_eq!(plan.progress_pct(), 0);
+    }
+
+    #[test]
+    fn plan_has_failure_detects_failed_step() {
+        let plan = make_plan(
+            "p1",
+            vec![
+                make_step("s1", StepStatus::Complete),
+                make_step("s2", StepStatus::Failed),
+            ],
+        );
+        assert!(plan.has_failure(), "should detect failed step");
+    }
+
+    #[test]
+    fn plan_has_failure_false_when_all_ok() {
+        let plan = make_plan(
+            "p1",
+            vec![
+                make_step("s1", StepStatus::Complete),
+                make_step("s2", StepStatus::Pending),
+            ],
+        );
+        assert!(!plan.has_failure(), "no failure when all ok or pending");
+    }
+
+    #[test]
+    fn wave_progress_pct_across_plans() {
+        let wave = make_wave(
+            1,
+            WaveStatus::Active,
+            vec![
+                make_plan(
+                    "p1",
+                    vec![
+                        make_step("s1", StepStatus::Complete),
+                        make_step("s2", StepStatus::Complete),
+                    ],
+                ),
+                make_plan(
+                    "p2",
+                    vec![
+                        make_step("s1", StepStatus::Pending),
+                        make_step("s2", StepStatus::Pending),
+                    ],
+                ),
+            ],
+        );
+        // 2 done out of 4 total = 50%
+        assert_eq!(wave.progress_pct(), 50);
+    }
+
+    #[test]
+    fn wave_progress_pct_complete_when_no_steps() {
+        let wave = make_wave(1, WaveStatus::Complete, vec![]);
+        assert_eq!(
+            wave.progress_pct(),
+            100,
+            "complete wave with no steps = 100%"
+        );
+    }
+
+    #[test]
+    fn store_active_wave_number_finds_active() {
+        let store = ExecutionStore {
+            state: Some(ExecutionState {
+                project_id: "p1".to_string(),
+                waves: vec![
+                    make_wave(1, WaveStatus::Complete, vec![]),
+                    make_wave(2, WaveStatus::Active, vec![]),
+                    make_wave(3, WaveStatus::Pending, vec![]),
+                ],
+            }),
+        };
+        assert_eq!(store.active_wave_number(), Some(2));
+    }
+
+    #[test]
+    fn store_active_wave_number_none_when_none_active() {
+        let store = ExecutionStore {
+            state: Some(ExecutionState {
+                project_id: "p1".to_string(),
+                waves: vec![
+                    make_wave(1, WaveStatus::Complete, vec![]),
+                    make_wave(2, WaveStatus::Complete, vec![]),
+                ],
+            }),
+        };
+        assert_eq!(store.active_wave_number(), None);
+    }
+
+    #[test]
+    fn store_overall_progress_across_all_waves() {
+        let store = ExecutionStore {
+            state: Some(ExecutionState {
+                project_id: "p1".to_string(),
+                waves: vec![
+                    make_wave(
+                        1,
+                        WaveStatus::Complete,
+                        vec![make_plan(
+                            "p1",
+                            vec![
+                                make_step("s1", StepStatus::Complete),
+                                make_step("s2", StepStatus::Complete),
+                            ],
+                        )],
+                    ),
+                    make_wave(
+                        2,
+                        WaveStatus::Active,
+                        vec![make_plan(
+                            "p2",
+                            vec![
+                                make_step("s1", StepStatus::Complete),
+                                make_step("s2", StepStatus::Pending),
+                            ],
+                        )],
+                    ),
+                ],
+            }),
+        };
+        // 3 done out of 4 total = 75%
+        assert_eq!(store.overall_progress_pct(), 75);
+    }
+
+    #[test]
+    fn store_overall_progress_zero_when_empty() {
+        assert_eq!(ExecutionStore::default().overall_progress_pct(), 0);
+    }
+}

--- a/crates/theatron/desktop/src/state/mod.rs
+++ b/crates/theatron/desktop/src/state/mod.rs
@@ -7,10 +7,16 @@
 pub mod agents;
 pub mod app;
 pub(crate) mod chat;
+/// Checkpoint approval gate state for the planning project detail view.
+pub(crate) mod checkpoints;
 pub mod collections;
 pub mod commands;
 pub mod connection;
+/// Discussion state for planning gray-area questions.
+pub(crate) mod discussion;
 pub mod events;
+/// Execution state for wave-based plan progress.
+pub(crate) mod execution;
 pub(crate) mod fetch;
 /// Workspace file tree explorer state.
 pub(crate) mod files;
@@ -19,7 +25,5 @@ pub(crate) mod streaming;
 pub mod toasts;
 /// Enhanced tool call, approval, and planning state for desktop UI.
 pub mod tools;
-/// Checkpoint approval gate state for the planning project detail view.
-pub(crate) mod checkpoints;
 /// Goal-backward verification state for the planning project detail view.
 pub(crate) mod verification;

--- a/crates/theatron/desktop/src/state/verification.rs
+++ b/crates/theatron/desktop/src/state/verification.rs
@@ -188,10 +188,30 @@ mod tests {
     #[test]
     fn overall_coverage_calculates_verified_fraction() {
         let store = store_with(vec![
-            req("r1", "v1", RequirementPriority::P0, VerificationStatus::Verified),
-            req("r2", "v1", RequirementPriority::P1, VerificationStatus::Unverified),
-            req("r3", "v1", RequirementPriority::P1, VerificationStatus::Verified),
-            req("r4", "v1", RequirementPriority::P2, VerificationStatus::Failed),
+            req(
+                "r1",
+                "v1",
+                RequirementPriority::P0,
+                VerificationStatus::Verified,
+            ),
+            req(
+                "r2",
+                "v1",
+                RequirementPriority::P1,
+                VerificationStatus::Unverified,
+            ),
+            req(
+                "r3",
+                "v1",
+                RequirementPriority::P1,
+                VerificationStatus::Verified,
+            ),
+            req(
+                "r4",
+                "v1",
+                RequirementPriority::P2,
+                VerificationStatus::Failed,
+            ),
         ]);
         // 2 verified out of 4 = 50%
         assert_eq!(store.overall_coverage(), Some(50));
@@ -199,35 +219,85 @@ mod tests {
 
     #[test]
     fn tier_coverage_none_for_missing_tier() {
-        let store = store_with(vec![
-            req("r1", "v1", RequirementPriority::P0, VerificationStatus::Verified),
-        ]);
+        let store = store_with(vec![req(
+            "r1",
+            "v1",
+            RequirementPriority::P0,
+            VerificationStatus::Verified,
+        )]);
         assert_eq!(store.tier_coverage("v2"), None);
     }
 
     #[test]
     fn gaps_excludes_verified() {
         let store = store_with(vec![
-            req("r1", "v1", RequirementPriority::P0, VerificationStatus::Verified),
-            req("r2", "v1", RequirementPriority::P1, VerificationStatus::Unverified),
-            req("r3", "v2", RequirementPriority::P0, VerificationStatus::Failed),
-            req("r4", "v2", RequirementPriority::P2, VerificationStatus::PartiallyVerified),
+            req(
+                "r1",
+                "v1",
+                RequirementPriority::P0,
+                VerificationStatus::Verified,
+            ),
+            req(
+                "r2",
+                "v1",
+                RequirementPriority::P1,
+                VerificationStatus::Unverified,
+            ),
+            req(
+                "r3",
+                "v2",
+                RequirementPriority::P0,
+                VerificationStatus::Failed,
+            ),
+            req(
+                "r4",
+                "v2",
+                RequirementPriority::P2,
+                VerificationStatus::PartiallyVerified,
+            ),
         ]);
         let gaps = store.gaps();
         assert_eq!(gaps.len(), 3, "unverified + failed + partially_verified");
-        assert!(gaps.iter().all(|r| r.status != VerificationStatus::Verified));
+        assert!(
+            gaps.iter()
+                .all(|r| r.status != VerificationStatus::Verified)
+        );
     }
 
     #[test]
     fn blocking_gaps_returns_only_p0() {
         let store = store_with(vec![
-            req("r1", "v1", RequirementPriority::P0, VerificationStatus::Unverified),
-            req("r2", "v1", RequirementPriority::P1, VerificationStatus::Unverified),
-            req("r3", "v1", RequirementPriority::P0, VerificationStatus::Failed),
-            req("r4", "v1", RequirementPriority::P0, VerificationStatus::Verified),
+            req(
+                "r1",
+                "v1",
+                RequirementPriority::P0,
+                VerificationStatus::Unverified,
+            ),
+            req(
+                "r2",
+                "v1",
+                RequirementPriority::P1,
+                VerificationStatus::Unverified,
+            ),
+            req(
+                "r3",
+                "v1",
+                RequirementPriority::P0,
+                VerificationStatus::Failed,
+            ),
+            req(
+                "r4",
+                "v1",
+                RequirementPriority::P0,
+                VerificationStatus::Verified,
+            ),
         ]);
         let blocking = store.blocking_gaps();
         assert_eq!(blocking.len(), 2, "P0 unverified + P0 failed only");
-        assert!(blocking.iter().all(|r| r.priority == RequirementPriority::P0));
+        assert!(
+            blocking
+                .iter()
+                .all(|r| r.priority == RequirementPriority::P0)
+        );
     }
 }

--- a/crates/theatron/desktop/src/views/planning/discussion.rs
+++ b/crates/theatron/desktop/src/views/planning/discussion.rs
@@ -1,0 +1,572 @@
+//! Discussion panel: gray-area questions, option cards, and answer flow.
+
+use dioxus::prelude::*;
+
+use crate::api::client::authenticated_client;
+use crate::components::option_card::OptionCard;
+use crate::state::connection::ConnectionConfig;
+use crate::state::discussion::{
+    Discussion, DiscussionAnswerRequest, DiscussionPriority, DiscussionStatus, DiscussionStore,
+};
+
+/// Fetch state for discussions, with a 404 variant for unavailable endpoints.
+#[derive(Debug, Clone)]
+enum DiscussionFetchState {
+    Loading,
+    Loaded(Vec<Discussion>),
+    NotAvailable,
+    Error(String),
+}
+
+const CONTAINER_STYLE: &str = "\
+    display: flex; \
+    flex-direction: column; \
+    height: 100%; \
+    padding: 16px; \
+    gap: 12px; \
+    overflow-y: auto;\
+";
+
+const HEADER_ROW: &str = "\
+    display: flex; \
+    align-items: center; \
+    justify-content: space-between;\
+";
+
+const REFRESH_BTN: &str = "\
+    background: #2a2a4a; \
+    color: #e0e0e0; \
+    border: 1px solid #444; \
+    border-radius: 6px; \
+    padding: 4px 12px; \
+    font-size: 12px; \
+    cursor: pointer;\
+";
+
+const CARD_BASE: &str = "\
+    border-radius: 8px; \
+    border: 1px solid; \
+    padding: 14px 18px;\
+";
+
+const QUESTION_STYLE: &str = "\
+    font-size: 15px; \
+    font-weight: 600; \
+    color: #e0e0e0; \
+    margin-bottom: 6px;\
+";
+
+const CONTEXT_STYLE: &str = "\
+    font-size: 13px; \
+    color: #999; \
+    margin-bottom: 10px;\
+";
+
+const BADGE_BASE: &str = "\
+    display: inline-block; \
+    font-size: 10px; \
+    font-weight: 600; \
+    padding: 2px 8px; \
+    border-radius: 10px; \
+    text-transform: uppercase; \
+    letter-spacing: 0.3px; \
+    margin-left: 8px;\
+";
+
+const OPTIONS_GRID: &str = "\
+    display: flex; \
+    flex-direction: column; \
+    gap: 8px; \
+    margin-top: 8px;\
+";
+
+const FREE_TEXT_INPUT: &str = "\
+    width: 100%; \
+    background: #0f0f1a; \
+    border: 1px solid #333; \
+    border-radius: 4px; \
+    padding: 8px 10px; \
+    color: #e0e0e0; \
+    font-size: 13px; \
+    font-family: inherit; \
+    resize: vertical; \
+    min-height: 50px; \
+    box-sizing: border-box;\
+";
+
+const SUBMIT_BTN: &str = "\
+    background: #4a4aff; \
+    color: white; \
+    border: none; \
+    border-radius: 6px; \
+    padding: 6px 16px; \
+    font-size: 13px; \
+    font-weight: 600; \
+    cursor: pointer;\
+";
+
+const SUBMIT_BTN_DISABLED: &str = "\
+    background: #333; \
+    color: #666; \
+    border: none; \
+    border-radius: 6px; \
+    padding: 6px 16px; \
+    font-size: 13px; \
+    font-weight: 600; \
+    cursor: not-allowed;\
+";
+
+const UNDO_BTN: &str = "\
+    background: transparent; \
+    color: #4a9aff; \
+    border: 1px solid #4a9aff; \
+    border-radius: 6px; \
+    padding: 4px 12px; \
+    font-size: 12px; \
+    cursor: pointer;\
+";
+
+const ANSWER_SUMMARY: &str = "\
+    font-size: 13px; \
+    color: #22c55e; \
+    padding: 6px 10px; \
+    background: #0f1a0f; \
+    border: 1px solid #1a3a1a; \
+    border-radius: 4px; \
+    margin-top: 8px;\
+";
+
+const PLACEHOLDER_STYLE: &str = "\
+    display: flex; \
+    flex-direction: column; \
+    align-items: center; \
+    justify-content: center; \
+    flex: 1; \
+    gap: 12px; \
+    color: #555;\
+";
+
+const ERROR_STYLE: &str = "color: #ef4444; font-size: 12px; margin-top: 6px;";
+
+/// Discussion panel listing all discussions for a project.
+#[component]
+pub(crate) fn DiscussionView(project_id: String) -> Element {
+    let config: Signal<ConnectionConfig> = use_context();
+    let mut fetch_state = use_signal(|| DiscussionFetchState::Loading);
+    let mut fetch_trigger = use_signal(|| 0u32);
+
+    let project_id_effect = project_id.clone();
+    use_effect(move || {
+        let _trigger = *fetch_trigger.read();
+        let cfg = config.read().clone();
+        let pid = project_id_effect.clone();
+        fetch_state.set(DiscussionFetchState::Loading);
+
+        spawn(async move {
+            let client = authenticated_client(&cfg);
+            let url = format!(
+                "{}/api/planning/projects/{pid}/discussions",
+                cfg.server_url.trim_end_matches('/')
+            );
+
+            match client.get(&url).send().await {
+                Ok(resp) if resp.status().is_success() => {
+                    match resp.json::<Vec<Discussion>>().await {
+                        Ok(discussions) => {
+                            fetch_state.set(DiscussionFetchState::Loaded(discussions));
+                        }
+                        Err(e) => {
+                            fetch_state
+                                .set(DiscussionFetchState::Error(format!("parse error: {e}")));
+                        }
+                    }
+                }
+                // WHY: 404 means discussions endpoint not available on this pylon version.
+                Ok(resp) if resp.status().as_u16() == 404 => {
+                    fetch_state.set(DiscussionFetchState::NotAvailable);
+                }
+                Ok(resp) => {
+                    let status = resp.status();
+                    fetch_state.set(DiscussionFetchState::Error(format!(
+                        "server returned {status}"
+                    )));
+                }
+                Err(e) => {
+                    fetch_state.set(DiscussionFetchState::Error(format!(
+                        "connection error: {e}"
+                    )));
+                }
+            }
+        });
+    });
+
+    rsx! {
+        div {
+            style: "{CONTAINER_STYLE}",
+            div {
+                style: "{HEADER_ROW}",
+                h3 { style: "font-size: 16px; margin: 0; color: #e0e0e0;", "Discussions" }
+                button {
+                    style: "{REFRESH_BTN}",
+                    onclick: move |_| fetch_trigger.set(fetch_trigger() + 1),
+                    "Refresh"
+                }
+            }
+
+            match &*fetch_state.read() {
+                DiscussionFetchState::Loading => rsx! {
+                    div {
+                        style: "display: flex; align-items: center; justify-content: center; flex: 1; color: #888;",
+                        "Loading discussions..."
+                    }
+                },
+                DiscussionFetchState::Error(err) => rsx! {
+                    div {
+                        style: "display: flex; align-items: center; justify-content: center; flex: 1; color: #ef4444;",
+                        "Error: {err}"
+                    }
+                },
+                DiscussionFetchState::NotAvailable => rsx! {
+                    div {
+                        style: "{PLACEHOLDER_STYLE}",
+                        div { style: "font-size: 48px;", "[?]" }
+                        div { style: "font-size: 16px;", "Discussions not available" }
+                        div { style: "font-size: 13px; max-width: 400px; text-align: center;",
+                            "The discussions API is not available on this pylon instance."
+                        }
+                    }
+                },
+                DiscussionFetchState::Loaded(discussions) => {
+                    if discussions.is_empty() {
+                        rsx! {
+                            div {
+                                style: "{PLACEHOLDER_STYLE}",
+                                div { style: "font-size: 16px;", "No discussions" }
+                                div { style: "font-size: 13px;",
+                                    "Gray-area questions will appear here when agents need human input."
+                                }
+                            }
+                        }
+                    } else {
+                        let store = DiscussionStore { discussions: discussions.clone() };
+                        let sorted = store.sorted();
+                        rsx! {
+                            for disc in sorted {
+                                DiscussionCard {
+                                    key: "{disc.id}",
+                                    discussion: disc.clone(),
+                                    project_id: project_id.clone(),
+                                    on_change: move |_| fetch_trigger.set(fetch_trigger() + 1),
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// A single discussion card with question, options, and answer flow.
+#[component]
+fn DiscussionCard(
+    discussion: Discussion,
+    project_id: String,
+    on_change: EventHandler<()>,
+) -> Element {
+    let config: Signal<ConnectionConfig> = use_context();
+    let mut selected_option_id: Signal<Option<String>> = use_signal(|| None);
+    let mut free_text = use_signal(String::new);
+    let mut show_free_text = use_signal(|| false);
+    let mut submitting = use_signal(|| false);
+    let mut error_msg: Signal<Option<String>> = use_signal(|| None);
+
+    let is_open = discussion.status == DiscussionStatus::Open;
+    let is_answered = discussion.status == DiscussionStatus::Answered;
+
+    let (card_bg, card_border) = discussion_card_colors(discussion.priority, discussion.status);
+    let card_style = format!("{CARD_BASE} background: {card_bg}; border-color: {card_border};");
+
+    let can_submit = *selected_option_id.read() != None || !free_text.read().is_empty();
+
+    // Clone ids for closures.
+    let disc_id_submit = discussion.id.clone();
+    let project_id_submit = project_id.clone();
+
+    let disc_id_undo = discussion.id.clone();
+    let project_id_undo = project_id.clone();
+
+    let do_submit = move |_| {
+        if !can_submit || *submitting.read() {
+            return;
+        }
+        let cfg = config.read().clone();
+        let did = disc_id_submit.clone();
+        let pid = project_id_submit.clone();
+        let opt_id = selected_option_id.read().clone();
+        let ft = if free_text.read().is_empty() {
+            None
+        } else {
+            Some(free_text.read().clone())
+        };
+
+        submitting.set(true);
+        error_msg.set(None);
+
+        spawn(async move {
+            let client = authenticated_client(&cfg);
+            let url = format!(
+                "{}/api/planning/projects/{pid}/discussions/{did}/answer",
+                cfg.server_url.trim_end_matches('/')
+            );
+            let req = DiscussionAnswerRequest {
+                option_id: opt_id,
+                free_text: ft,
+            };
+            match client.post(&url).json(&req).send().await {
+                Ok(resp) if resp.status().is_success() => {
+                    on_change.call(());
+                }
+                Ok(resp) => {
+                    let status = resp.status();
+                    error_msg.set(Some(format!("server error: {status}")));
+                    submitting.set(false);
+                }
+                Err(e) => {
+                    error_msg.set(Some(format!("connection error: {e}")));
+                    submitting.set(false);
+                }
+            }
+        });
+    };
+
+    let do_undo = move |_| {
+        let cfg = config.read().clone();
+        let did = disc_id_undo.clone();
+        let pid = project_id_undo.clone();
+
+        submitting.set(true);
+        error_msg.set(None);
+
+        spawn(async move {
+            let client = authenticated_client(&cfg);
+            // WHY: reopen is POST to the same answer endpoint with empty body.
+            let url = format!(
+                "{}/api/planning/projects/{pid}/discussions/{did}/reopen",
+                cfg.server_url.trim_end_matches('/')
+            );
+            match client.post(&url).send().await {
+                Ok(resp) if resp.status().is_success() => {
+                    on_change.call(());
+                }
+                Ok(resp) => {
+                    let status = resp.status();
+                    error_msg.set(Some(format!("server error: {status}")));
+                    submitting.set(false);
+                }
+                Err(e) => {
+                    error_msg.set(Some(format!("connection error: {e}")));
+                    submitting.set(false);
+                }
+            }
+        });
+    };
+
+    rsx! {
+        div {
+            style: "{card_style}",
+
+            // Header: question + status + priority
+            div {
+                style: "display: flex; align-items: flex-start; justify-content: space-between; margin-bottom: 6px;",
+                span { style: "{QUESTION_STYLE}", "{discussion.question}" }
+                div {
+                    style: "display: flex; align-items: center; flex-shrink: 0;",
+                    span { style: "{status_badge_style(discussion.status)}", "{status_label(discussion.status)}" }
+                    span { style: "{priority_badge_style(discussion.priority)}", "{priority_label(discussion.priority)}" }
+                }
+            }
+
+            // Context
+            if !discussion.context.is_empty() {
+                div { style: "{CONTEXT_STYLE}", "{discussion.context}" }
+            }
+
+            // Answered: show summary and undo button
+            if is_answered {
+                if let Some(summary) = DiscussionStore::answer_summary(&discussion) {
+                    div { style: "{ANSWER_SUMMARY}", "Answer: {summary}" }
+                }
+                button {
+                    style: "{UNDO_BTN}",
+                    disabled: *submitting.read(),
+                    onclick: do_undo,
+                    if *submitting.read() { "Reopening..." } else { "Reopen" }
+                }
+            }
+
+            // Open: show options and answer flow
+            if is_open {
+                div {
+                    style: "{OPTIONS_GRID}",
+                    for opt in &discussion.options {
+                        OptionCard {
+                            key: "{opt.id}",
+                            option: opt.clone(),
+                            selected: *selected_option_id.read() == Some(opt.id.clone()),
+                            on_select: move |id: String| {
+                                selected_option_id.set(Some(id));
+                                show_free_text.set(false);
+                                free_text.set(String::new());
+                            },
+                        }
+                    }
+                }
+
+                // Free-text override
+                div {
+                    style: "margin-top: 10px;",
+                    button {
+                        style: "background: transparent; border: none; color: #4a9aff; font-size: 12px; cursor: pointer; padding: 0;",
+                        onclick: move |_| {
+                            let current = *show_free_text.read();
+                            show_free_text.set(!current);
+                            if current {
+                                free_text.set(String::new());
+                            } else {
+                                selected_option_id.set(None);
+                            }
+                        },
+                        if *show_free_text.read() { "Cancel free-text" } else { "Provide custom answer" }
+                    }
+
+                    if *show_free_text.read() {
+                        textarea {
+                            style: "{FREE_TEXT_INPUT}",
+                            placeholder: "Type your custom answer...",
+                            rows: "3",
+                            value: "{free_text.read()}",
+                            oninput: move |evt: Event<FormData>| free_text.set(evt.value().clone()),
+                        }
+                    }
+                }
+
+                // Submit
+                div {
+                    style: "display: flex; gap: 8px; margin-top: 10px;",
+                    button {
+                        style: if can_submit { "{SUBMIT_BTN}" } else { "{SUBMIT_BTN_DISABLED}" },
+                        disabled: !can_submit || *submitting.read(),
+                        onclick: do_submit,
+                        if *submitting.read() { "Submitting..." } else { "Submit Answer" }
+                    }
+                }
+            }
+
+            // Error feedback
+            if let Some(ref err) = *error_msg.read() {
+                div { style: "{ERROR_STYLE}", "{err}" }
+            }
+        }
+    }
+}
+
+fn discussion_card_colors(
+    priority: DiscussionPriority,
+    status: DiscussionStatus,
+) -> (&'static str, &'static str) {
+    if status == DiscussionStatus::Answered {
+        return ("#0f1a0f", "#2a4a2a");
+    }
+    match priority {
+        DiscussionPriority::Blocking => ("#1e0f0f", "#ef4444"),
+        DiscussionPriority::Important => ("#1e1a10", "#f59e0b"),
+        DiscussionPriority::NiceToHave => ("#1a1a2e", "#2a2a3a"),
+    }
+}
+
+fn status_badge_style(status: DiscussionStatus) -> String {
+    let (bg, color) = match status {
+        DiscussionStatus::Open => ("#1e1e5a", "#4a9aff"),
+        DiscussionStatus::Answered => ("#0f2a0f", "#22c55e"),
+        DiscussionStatus::Deferred => ("#2a2a3a", "#888"),
+    };
+    format!("{BADGE_BASE} background: {bg}; color: {color};")
+}
+
+fn status_label(status: DiscussionStatus) -> &'static str {
+    match status {
+        DiscussionStatus::Open => "Open",
+        DiscussionStatus::Answered => "Answered",
+        DiscussionStatus::Deferred => "Deferred",
+    }
+}
+
+fn priority_badge_style(priority: DiscussionPriority) -> String {
+    let (bg, color) = match priority {
+        DiscussionPriority::Blocking => ("#3a0f0f", "#ef4444"),
+        DiscussionPriority::Important => ("#2a1f05", "#f59e0b"),
+        DiscussionPriority::NiceToHave => ("#2a2a3a", "#888"),
+    };
+    format!("{BADGE_BASE} background: {bg}; color: {color};")
+}
+
+fn priority_label(priority: DiscussionPriority) -> &'static str {
+    match priority {
+        DiscussionPriority::Blocking => "Blocking",
+        DiscussionPriority::Important => "Important",
+        DiscussionPriority::NiceToHave => "Nice to Have",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn discussion_card_colors_blocking_has_red_border() {
+        let (_, border) =
+            discussion_card_colors(DiscussionPriority::Blocking, DiscussionStatus::Open);
+        assert_eq!(border, "#ef4444", "blocking should have red border");
+    }
+
+    #[test]
+    fn discussion_card_colors_answered_overrides_priority() {
+        let (_, border) =
+            discussion_card_colors(DiscussionPriority::Blocking, DiscussionStatus::Answered);
+        assert_eq!(
+            border, "#2a4a2a",
+            "answered status should override blocking priority color"
+        );
+    }
+
+    #[test]
+    fn status_labels_are_distinct() {
+        let labels = [
+            status_label(DiscussionStatus::Open),
+            status_label(DiscussionStatus::Answered),
+            status_label(DiscussionStatus::Deferred),
+        ];
+        let unique: std::collections::HashSet<_> = labels.iter().collect();
+        assert_eq!(
+            unique.len(),
+            labels.len(),
+            "all status labels must be distinct"
+        );
+    }
+
+    #[test]
+    fn priority_labels_are_distinct() {
+        let labels = [
+            priority_label(DiscussionPriority::Blocking),
+            priority_label(DiscussionPriority::Important),
+            priority_label(DiscussionPriority::NiceToHave),
+        ];
+        let unique: std::collections::HashSet<_> = labels.iter().collect();
+        assert_eq!(
+            unique.len(),
+            labels.len(),
+            "all priority labels must be distinct"
+        );
+    }
+}

--- a/crates/theatron/desktop/src/views/planning/discussion_detail.rs
+++ b/crates/theatron/desktop/src/views/planning/discussion_detail.rs
@@ -1,0 +1,232 @@
+//! Expanded discussion detail view with full context, options, and history.
+
+use dioxus::prelude::*;
+
+use crate::api::client::authenticated_client;
+use crate::components::option_card::OptionCard;
+use crate::state::connection::ConnectionConfig;
+use crate::state::discussion::{Discussion, DiscussionStatus, DiscussionStore};
+
+/// Fetch state for a single discussion detail.
+#[derive(Debug, Clone)]
+enum DetailFetchState {
+    Loading,
+    Loaded(Discussion),
+    Error(String),
+}
+
+const CONTAINER_STYLE: &str = "\
+    display: flex; \
+    flex-direction: column; \
+    height: 100%; \
+    padding: 16px; \
+    gap: 12px; \
+    overflow-y: auto;\
+";
+
+const BACK_BTN: &str = "\
+    background: transparent; \
+    color: #4a9aff; \
+    border: none; \
+    font-size: 13px; \
+    cursor: pointer; \
+    padding: 0; \
+    margin-bottom: 8px;\
+";
+
+const QUESTION_STYLE: &str = "\
+    font-size: 18px; \
+    font-weight: 600; \
+    color: #e0e0e0; \
+    margin-bottom: 8px;\
+";
+
+const CONTEXT_STYLE: &str = "\
+    font-size: 14px; \
+    color: #aaa; \
+    padding: 10px 14px; \
+    background: #0f0f1a; \
+    border: 1px solid #2a2a3a; \
+    border-radius: 6px; \
+    margin-bottom: 12px;\
+";
+
+const SECTION_LABEL: &str = "\
+    font-size: 12px; \
+    font-weight: 600; \
+    color: #666; \
+    text-transform: uppercase; \
+    letter-spacing: 0.5px; \
+    margin: 12px 0 6px;\
+";
+
+const HISTORY_ENTRY: &str = "\
+    display: flex; \
+    align-items: flex-start; \
+    gap: 8px; \
+    padding: 6px 10px; \
+    border-left: 2px solid #2a2a3a; \
+    margin-bottom: 4px;\
+";
+
+const HISTORY_ACTION: &str = "\
+    font-size: 12px; \
+    font-weight: 600; \
+    color: #c0c0e0;\
+";
+
+const HISTORY_META: &str = "\
+    font-size: 11px; \
+    color: #666;\
+";
+
+const HISTORY_DETAIL: &str = "\
+    font-size: 12px; \
+    color: #999; \
+    font-style: italic;\
+";
+
+const OPTIONS_GRID: &str = "\
+    display: flex; \
+    flex-direction: column; \
+    gap: 8px;\
+";
+
+const ANSWER_SUMMARY: &str = "\
+    font-size: 14px; \
+    color: #22c55e; \
+    padding: 8px 12px; \
+    background: #0f1a0f; \
+    border: 1px solid #1a3a1a; \
+    border-radius: 6px;\
+";
+
+/// Expanded discussion detail view.
+///
+/// Shows the full context, all options, discussion history, and the current answer.
+#[component]
+pub(crate) fn DiscussionDetailView(
+    project_id: String,
+    discussion_id: String,
+    on_back: EventHandler<()>,
+) -> Element {
+    let config: Signal<ConnectionConfig> = use_context();
+    let mut fetch_state = use_signal(|| DetailFetchState::Loading);
+    let fetch_trigger = use_signal(|| 0u32);
+
+    let project_id_effect = project_id.clone();
+    let discussion_id_effect = discussion_id.clone();
+
+    use_effect(move || {
+        let _trigger = *fetch_trigger.read();
+        let cfg = config.read().clone();
+        let pid = project_id_effect.clone();
+        let did = discussion_id_effect.clone();
+        fetch_state.set(DetailFetchState::Loading);
+
+        spawn(async move {
+            let client = authenticated_client(&cfg);
+            let url = format!(
+                "{}/api/planning/projects/{pid}/discussions/{did}",
+                cfg.server_url.trim_end_matches('/')
+            );
+
+            match client.get(&url).send().await {
+                Ok(resp) if resp.status().is_success() => match resp.json::<Discussion>().await {
+                    Ok(disc) => fetch_state.set(DetailFetchState::Loaded(disc)),
+                    Err(e) => {
+                        fetch_state.set(DetailFetchState::Error(format!("parse error: {e}")));
+                    }
+                },
+                Ok(resp) => {
+                    let status = resp.status();
+                    fetch_state.set(DetailFetchState::Error(format!("server returned {status}")));
+                }
+                Err(e) => {
+                    fetch_state.set(DetailFetchState::Error(format!("connection error: {e}")));
+                }
+            }
+        });
+    });
+
+    rsx! {
+        div {
+            style: "{CONTAINER_STYLE}",
+
+            button {
+                style: "{BACK_BTN}",
+                onclick: move |_| on_back.call(()),
+                "<- Back to discussions"
+            }
+
+            match &*fetch_state.read() {
+                DetailFetchState::Loading => rsx! {
+                    div {
+                        style: "display: flex; align-items: center; justify-content: center; flex: 1; color: #888;",
+                        "Loading discussion..."
+                    }
+                },
+                DetailFetchState::Error(err) => rsx! {
+                    div {
+                        style: "display: flex; align-items: center; justify-content: center; flex: 1; color: #ef4444;",
+                        "Error: {err}"
+                    }
+                },
+                DetailFetchState::Loaded(disc) => rsx! {
+                    // Question
+                    div { style: "{QUESTION_STYLE}", "{disc.question}" }
+
+                    // Context
+                    if !disc.context.is_empty() {
+                        div { style: "{CONTEXT_STYLE}", "{disc.context}" }
+                    }
+
+                    // Current answer (if answered)
+                    if disc.status == DiscussionStatus::Answered {
+                        if let Some(summary) = DiscussionStore::answer_summary(disc) {
+                            div {
+                                style: "{SECTION_LABEL}",
+                                "Current Answer"
+                            }
+                            div { style: "{ANSWER_SUMMARY}", "{summary}" }
+                        }
+                    }
+
+                    // All options
+                    div { style: "{SECTION_LABEL}", "Options" }
+                    div {
+                        style: "{OPTIONS_GRID}",
+                        for opt in &disc.options {
+                            OptionCard {
+                                key: "{opt.id}",
+                                option: opt.clone(),
+                                selected: disc.selected_option_id.as_deref() == Some(opt.id.as_str()),
+                                on_select: move |_: String| {
+                                    // NOTE: read-only in detail view; selection happens in the list view card.
+                                },
+                            }
+                        }
+                    }
+
+                    // Discussion history
+                    if !disc.history.is_empty() {
+                        div { style: "{SECTION_LABEL}", "History" }
+                        for (i, entry) in disc.history.iter().enumerate() {
+                            div {
+                                key: "{i}",
+                                style: "{HISTORY_ENTRY}",
+                                div {
+                                    span { style: "{HISTORY_ACTION}", "{entry.action}" }
+                                    span { style: "{HISTORY_META}", " by {entry.actor} at {entry.timestamp}" }
+                                    if !entry.detail.is_empty() {
+                                        div { style: "{HISTORY_DETAIL}", "\"{entry.detail}\"" }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+            }
+        }
+    }
+}

--- a/crates/theatron/desktop/src/views/planning/execution.rs
+++ b/crates/theatron/desktop/src/views/planning/execution.rs
@@ -1,0 +1,223 @@
+//! Execution view: wave-based progress and parallel plan visualization.
+
+use dioxus::prelude::*;
+
+use crate::api::client::authenticated_client;
+use crate::components::plan_card::PlanCard;
+use crate::components::wave_band::WaveBand;
+use crate::state::connection::ConnectionConfig;
+use crate::state::execution::{ExecutionState, ExecutionStore};
+
+/// Fetch state for execution data.
+#[derive(Debug, Clone)]
+enum ExecutionFetchState {
+    Loading,
+    Loaded(ExecutionState),
+    NotAvailable,
+    Error(String),
+}
+
+const CONTAINER_STYLE: &str = "\
+    display: flex; \
+    flex-direction: column; \
+    height: 100%; \
+    padding: 16px; \
+    gap: 12px; \
+    overflow-y: auto;\
+";
+
+const HEADER_ROW: &str = "\
+    display: flex; \
+    align-items: center; \
+    justify-content: space-between;\
+";
+
+const REFRESH_BTN: &str = "\
+    background: #2a2a4a; \
+    color: #e0e0e0; \
+    border: 1px solid #444; \
+    border-radius: 6px; \
+    padding: 4px 12px; \
+    font-size: 12px; \
+    cursor: pointer;\
+";
+
+const PROGRESS_BAR_TRACK: &str = "\
+    height: 6px; \
+    background: #2a2a3a; \
+    border-radius: 3px; \
+    overflow: hidden;\
+";
+
+const PROGRESS_SUMMARY: &str = "\
+    display: flex; \
+    align-items: center; \
+    justify-content: space-between; \
+    font-size: 13px; \
+    color: #aaa; \
+    margin-bottom: 4px;\
+";
+
+const PLACEHOLDER_STYLE: &str = "\
+    display: flex; \
+    flex-direction: column; \
+    align-items: center; \
+    justify-content: center; \
+    flex: 1; \
+    gap: 12px; \
+    color: #555;\
+";
+
+/// Polling interval for execution state updates (10 seconds).
+const POLL_INTERVAL_MS: u64 = 10_000;
+
+/// Execution view with wave-based progress and plan visualization.
+#[component]
+pub(crate) fn ExecutionView(project_id: String) -> Element {
+    let config: Signal<ConnectionConfig> = use_context();
+    let mut fetch_state = use_signal(|| ExecutionFetchState::Loading);
+    let mut fetch_trigger = use_signal(|| 0u32);
+
+    // Fetch execution state on mount and when trigger changes.
+    let project_id_effect = project_id.clone();
+    use_effect(move || {
+        let _trigger = *fetch_trigger.read();
+        let cfg = config.read().clone();
+        let pid = project_id_effect.clone();
+        fetch_state.set(ExecutionFetchState::Loading);
+
+        spawn(async move {
+            let client = authenticated_client(&cfg);
+            let url = format!(
+                "{}/api/planning/projects/{pid}/execution",
+                cfg.server_url.trim_end_matches('/')
+            );
+
+            match client.get(&url).send().await {
+                Ok(resp) if resp.status().is_success() => {
+                    match resp.json::<ExecutionState>().await {
+                        Ok(state) => fetch_state.set(ExecutionFetchState::Loaded(state)),
+                        Err(e) => {
+                            fetch_state
+                                .set(ExecutionFetchState::Error(format!("parse error: {e}")));
+                        }
+                    }
+                }
+                // WHY: 404 means execution endpoint not available on this pylon version.
+                Ok(resp) if resp.status().as_u16() == 404 => {
+                    fetch_state.set(ExecutionFetchState::NotAvailable);
+                }
+                Ok(resp) => {
+                    let status = resp.status();
+                    fetch_state.set(ExecutionFetchState::Error(format!(
+                        "server returned {status}"
+                    )));
+                }
+                Err(e) => {
+                    fetch_state.set(ExecutionFetchState::Error(format!("connection error: {e}")));
+                }
+            }
+        });
+    });
+
+    // Polling fallback: re-fetch every 10 seconds.
+    use_effect(move || {
+        spawn(async move {
+            loop {
+                tokio::time::sleep(tokio::time::Duration::from_millis(POLL_INTERVAL_MS)).await;
+                fetch_trigger.set(fetch_trigger() + 1);
+            }
+        });
+    });
+
+    rsx! {
+        div {
+            style: "{CONTAINER_STYLE}",
+            div {
+                style: "{HEADER_ROW}",
+                h3 { style: "font-size: 16px; margin: 0; color: #e0e0e0;", "Execution" }
+                button {
+                    style: "{REFRESH_BTN}",
+                    onclick: move |_| fetch_trigger.set(fetch_trigger() + 1),
+                    "Refresh"
+                }
+            }
+
+            match &*fetch_state.read() {
+                ExecutionFetchState::Loading => rsx! {
+                    div {
+                        style: "display: flex; align-items: center; justify-content: center; flex: 1; color: #888;",
+                        "Loading execution state..."
+                    }
+                },
+                ExecutionFetchState::Error(err) => rsx! {
+                    div {
+                        style: "display: flex; align-items: center; justify-content: center; flex: 1; color: #ef4444;",
+                        "Error: {err}"
+                    }
+                },
+                ExecutionFetchState::NotAvailable => rsx! {
+                    div {
+                        style: "{PLACEHOLDER_STYLE}",
+                        div { style: "font-size: 48px;", "[E]" }
+                        div { style: "font-size: 16px;", "Execution view not available" }
+                        div { style: "font-size: 13px; max-width: 400px; text-align: center;",
+                            "The execution API is not available on this pylon instance."
+                        }
+                    }
+                },
+                ExecutionFetchState::Loaded(state) => {
+                    if state.waves.is_empty() {
+                        rsx! {
+                            div {
+                                style: "{PLACEHOLDER_STYLE}",
+                                div { style: "font-size: 16px;", "No execution in progress" }
+                                div { style: "font-size: 13px;",
+                                    "Waves will appear here when plan execution begins."
+                                }
+                            }
+                        }
+                    } else {
+                        let store = ExecutionStore { state: Some(state.clone()) };
+                        let overall_pct = store.overall_progress_pct();
+                        let active_wave = store.active_wave_number();
+                        let wave_count = store.wave_count();
+
+                        let progress_text = match active_wave {
+                            Some(n) => format!("Wave {n} of {wave_count} — {overall_pct}% complete"),
+                            None => format!("{wave_count} waves — {overall_pct}% complete"),
+                        };
+
+                        rsx! {
+                            // Overall progress
+                            div {
+                                style: "{PROGRESS_SUMMARY}",
+                                span { "{progress_text}" }
+                            }
+                            div {
+                                style: "{PROGRESS_BAR_TRACK}",
+                                div {
+                                    style: "height: 100%; background: #4a9aff; width: {overall_pct}%; border-radius: 3px; transition: width 0.3s;",
+                                }
+                            }
+
+                            // Wave bands
+                            for wave in &state.waves {
+                                WaveBand {
+                                    key: "{wave.wave_number}",
+                                    wave: wave.clone(),
+                                    for plan in &wave.plans {
+                                        PlanCard {
+                                            key: "{plan.id}",
+                                            plan: plan.clone(),
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/crates/theatron/desktop/src/views/planning/gap_analysis.rs
+++ b/crates/theatron/desktop/src/views/planning/gap_analysis.rs
@@ -2,7 +2,9 @@
 
 use dioxus::prelude::*;
 
-use crate::state::verification::{RequirementPriority, RequirementVerification, VerificationStatus};
+use crate::state::verification::{
+    RequirementPriority, RequirementVerification, VerificationStatus,
+};
 
 const PANEL_STYLE: &str = "\
     display: flex; \

--- a/crates/theatron/desktop/src/views/planning/mod.rs
+++ b/crates/theatron/desktop/src/views/planning/mod.rs
@@ -1,6 +1,9 @@
 //! Planning view: project list and project detail with checkpoints and verification.
 
 pub(crate) mod checkpoints;
+pub(crate) mod discussion;
+pub(crate) mod discussion_detail;
+pub(crate) mod execution;
 pub(crate) mod gap_analysis;
 pub(crate) mod project_detail;
 pub(crate) mod verification;

--- a/crates/theatron/desktop/src/views/planning/project_detail.rs
+++ b/crates/theatron/desktop/src/views/planning/project_detail.rs
@@ -1,14 +1,18 @@
-//! Project detail view: tab container with Checkpoints and Verification tabs.
+//! Project detail view: tab container for planning sub-views.
 
 use dioxus::prelude::*;
 
 use crate::views::planning::checkpoints::CheckpointsView;
+use crate::views::planning::discussion::DiscussionView;
+use crate::views::planning::execution::ExecutionView;
 use crate::views::planning::verification::VerificationView;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ActiveTab {
     Checkpoints,
     Verification,
+    Discussion,
+    Execution,
 }
 
 const CONTAINER_STYLE: &str = "\
@@ -54,13 +58,15 @@ const TAB_CONTENT_STYLE: &str = "\
     overflow: hidden;\
 ";
 
-/// Project detail view with Checkpoints and Verification tabs.
+/// Project detail view with Checkpoints, Verification, Discussion, and Execution tabs.
 #[component]
 pub(crate) fn ProjectDetail(project_id: String) -> Element {
     let mut active_tab = use_signal(|| ActiveTab::Checkpoints);
 
     let project_id_ck = project_id.clone();
     let project_id_vf = project_id.clone();
+    let project_id_dc = project_id.clone();
+    let project_id_ex = project_id.clone();
 
     rsx! {
         div {
@@ -79,6 +85,16 @@ pub(crate) fn ProjectDetail(project_id: String) -> Element {
                     onclick: move |_| active_tab.set(ActiveTab::Verification),
                     "Verification"
                 }
+                button {
+                    style: if *active_tab.read() == ActiveTab::Discussion { "{TAB_ACTIVE}" } else { "{TAB_INACTIVE}" },
+                    onclick: move |_| active_tab.set(ActiveTab::Discussion),
+                    "Discussion"
+                }
+                button {
+                    style: if *active_tab.read() == ActiveTab::Execution { "{TAB_ACTIVE}" } else { "{TAB_INACTIVE}" },
+                    onclick: move |_| active_tab.set(ActiveTab::Execution),
+                    "Execution"
+                }
             }
 
             // Tab content
@@ -90,6 +106,12 @@ pub(crate) fn ProjectDetail(project_id: String) -> Element {
                     },
                     ActiveTab::Verification => rsx! {
                         VerificationView { project_id: project_id_vf.clone() }
+                    },
+                    ActiveTab::Discussion => rsx! {
+                        DiscussionView { project_id: project_id_dc.clone() }
+                    },
+                    ActiveTab::Execution => rsx! {
+                        ExecutionView { project_id: project_id_ex.clone() }
                     },
                 }
             }


### PR DESCRIPTION
## Summary

- Add planning discussion panel (Phase 3.8) with gray-area questions, option cards, recommendation badges, answer flow with free-text override, and undo/reopen support
- Add execution view (Phase 3.9) with wave-based progress display, parallel plan visualization, step-level status indicators (pending/running/complete/failed/skipped), expandable plan detail, and 10s polling fallback
- Extend ProjectDetail tab bar with Discussion and Execution tabs
- 33 new unit tests across state modules and components

## New Files

| File | Purpose |
|------|---------|
| `state/discussion.rs` | Discussion, DiscussionOption, DiscussionStore with sorting and answer summary |
| `state/execution.rs` | Wave, ExecutionPlan, PlanStep, ExecutionStore with progress calculations |
| `components/option_card.rs` | Option card with trade-offs grid and recommendation badge |
| `components/wave_band.rs` | Wave horizontal band with progress bar and plan card container |
| `components/plan_card.rs` | Plan card with agent badge, step list, expandable detail |
| `views/planning/discussion.rs` | Discussion list with answer flow, optimistic UI, API integration |
| `views/planning/discussion_detail.rs` | Expanded discussion with full history |
| `views/planning/execution.rs` | Wave-based execution view with overall progress bar |

## Test plan

- [x] `cargo check --manifest-path crates/theatron/desktop/Cargo.toml` compiles
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo test --workspace` passes (0 failures)
- [x] 33 new unit tests: discussion state (8), execution state (12), option card (3), wave band (3), plan card (5), discussion view (4)
- [ ] Manual: Discussion panel lists open discussions sorted by priority
- [ ] Manual: Option cards show recommendation badge and trade-offs
- [ ] Manual: Answer flow submits via API, undo reopens
- [ ] Manual: Blocking discussions have red border
- [ ] Manual: Execution view shows wave bands with parallel plan columns
- [ ] Manual: Plan card expand shows step detail without re-fetch

## Observations

- **Pre-existing clippy failure**: `aletheia-organon/src/sandbox/config.rs:337` has `expect()` that triggers `-D clippy::expect-used`. Not introduced by this PR.
- **Dioxus const dead-code warnings**: rsx! macro string interpolation (`style: "{CONST}"`) doesn't register as a "use" for dead-code analysis. All component modules have these warnings, including pre-existing `checkpoint_card.rs`. May warrant a crate-level `#[expect]` or module-level suppression.
- **Pre-existing fmt drift**: `verification.rs` and `gap_analysis.rs` had formatting that didn't match `cargo fmt` output. Fixed as part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)