### PR TITLE
feat(theatron-desktop): credential management panel for ops view

### DIFF
--- a/crates/aletheia/src/commands/memory.rs
+++ b/crates/aletheia/src/commands/memory.rs
@@ -117,14 +117,17 @@ async fn is_server_running(url: &str) -> Result<bool> {
 /// Run the graph health check via the server's HTTP API.
 async fn run_check_via_api(url: &str, json: bool) -> Result<()> {
     let endpoint = format!("{url}/api/v1/knowledge/check");
-    let resp = reqwest::get(&endpoint).await
+    let resp = reqwest::get(&endpoint)
+        .await
         .map_err(|e| anyhow::anyhow!("failed to connect to {endpoint}: {e}"))?;
 
     if resp.status() == reqwest::StatusCode::SERVICE_UNAVAILABLE {
         anyhow::bail!("knowledge store is not enabled on the running server");
     }
 
-    let body: serde_json::Value = resp.json().await
+    let body: serde_json::Value = resp
+        .json()
+        .await
         .map_err(|e| anyhow::anyhow!("failed to parse response: {e}"))?;
 
     if json {
@@ -137,11 +140,20 @@ async fn run_check_via_api(url: &str, json: bool) -> Result<()> {
         if let Some(ec) = body.get("entity_count").and_then(serde_json::Value::as_u64) {
             println!("Entities:      {ec}");
         }
-        if let Some(rc) = body.get("relationship_count").and_then(serde_json::Value::as_u64) {
+        if let Some(rc) = body
+            .get("relationship_count")
+            .and_then(serde_json::Value::as_u64)
+        {
             println!("Relationships: {rc}");
         }
-        let orphaned = body.get("orphaned_entity_count").and_then(serde_json::Value::as_u64).unwrap_or(0);
-        let dangling = body.get("dangling_edge_count").and_then(serde_json::Value::as_u64).unwrap_or(0);
+        let orphaned = body
+            .get("orphaned_entity_count")
+            .and_then(serde_json::Value::as_u64)
+            .unwrap_or(0);
+        let dangling = body
+            .get("dangling_edge_count")
+            .and_then(serde_json::Value::as_u64)
+            .unwrap_or(0);
         if orphaned > 0 {
             println!("\nOrphaned entities: {orphaned}");
         } else {
@@ -152,7 +164,10 @@ async fn run_check_via_api(url: &str, json: bool) -> Result<()> {
         } else {
             println!("Dangling edges: 0");
         }
-        let status = body.get("status").and_then(|v| v.as_str()).unwrap_or("unknown");
+        let status = body
+            .get("status")
+            .and_then(|v| v.as_str())
+            .unwrap_or("unknown");
         println!("\nStatus: {status}");
     }
 

--- a/crates/aletheia/src/main.rs
+++ b/crates/aletheia/src/main.rs
@@ -272,7 +272,10 @@ async fn do_daemon() -> Result<()> {
         .await
         .with_context(|| format!("failed to write PID file at {}", pid_path.display()))?;
 
-    println!("aletheia started in background (PID: {pid}, PID file: {})", pid_path.display());
+    println!(
+        "aletheia started in background (PID: {pid}, PID file: {})",
+        pid_path.display()
+    );
     Ok(())
 }
 
@@ -288,8 +291,7 @@ fn daemon_instance_root() -> PathBuf {
             return PathBuf::from(path);
         }
     }
-    std::env::var("ALETHEIA_ROOT")
-        .map_or_else(|_| PathBuf::from("instance"), PathBuf::from)
+    std::env::var("ALETHEIA_ROOT").map_or_else(|_| PathBuf::from("instance"), PathBuf::from)
 }
 
 #[cfg(test)]

--- a/crates/aletheia/src/status.rs
+++ b/crates/aletheia/src/status.rs
@@ -234,11 +234,7 @@ fn print_nous(list: &[NousInfo], color: bool) {
     println!();
 }
 
-fn print_storage(
-    oikos: &aletheia_taxis::oikos::Oikos,
-    server_data_dir: Option<&str>,
-    color: bool,
-) {
+fn print_storage(oikos: &aletheia_taxis::oikos::Oikos, server_data_dir: Option<&str>, color: bool) {
     if color {
         println!("  {}:", "Storage".bold());
     } else {

--- a/crates/organon/src/sandbox/config.rs
+++ b/crates/organon/src/sandbox/config.rs
@@ -332,6 +332,7 @@ mod tests {
     }
 
     #[test]
+    #[expect(clippy::expect_used, reason = "test context — parse failure is a test bug")]
     fn nproc_limit_configurable_via_serde() {
         let json = r#"{"enabled":true,"nprocLimit":512}"#;
         let config: SandboxConfig = serde_json::from_str(json).expect("parse");

--- a/crates/pylon/src/handlers/knowledge/bulk_import.rs
+++ b/crates/pylon/src/handlers/knowledge/bulk_import.rs
@@ -122,7 +122,11 @@ pub async fn import_facts(
 }
 
 #[cfg(test)]
-#[expect(clippy::unwrap_used, reason = "test assertions")]
+#[expect(
+    clippy::unwrap_used,
+    clippy::indexing_slicing,
+    reason = "test assertions — panics are acceptable in test context"
+)]
 mod tests {
     use super::*;
 

--- a/crates/pylon/src/router.rs
+++ b/crates/pylon/src/router.rs
@@ -66,10 +66,7 @@ pub fn build_router(state: Arc<AppState>, security: &SecurityConfig) -> Router {
             get(config::get_section).put(config::update_section),
         )
         .route("/knowledge/facts", get(knowledge::list_facts))
-        .route(
-            "/knowledge/facts/import",
-            post(knowledge::import_facts),
-        )
+        .route("/knowledge/facts/import", post(knowledge::import_facts))
         .route("/knowledge/facts/{id}", get(knowledge::get_fact))
         .route("/knowledge/facts/{id}/forget", post(knowledge::forget_fact))
         .route(

--- a/crates/theatron/desktop/src/state/credentials.rs
+++ b/crates/theatron/desktop/src/state/credentials.rs
@@ -1,0 +1,240 @@
+//! Credential management state for the ops view.
+
+use std::collections::HashSet;
+
+/// Role of a credential relative to its provider.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub(crate) enum CredentialRole {
+    /// Active credential used for API calls.
+    Primary,
+    /// Standby credential used when primary is unavailable.
+    Backup,
+}
+
+impl CredentialRole {
+    pub(crate) fn label(self) -> &'static str {
+        match self {
+            Self::Primary => "Primary",
+            Self::Backup => "Backup",
+        }
+    }
+}
+
+/// Validation status of a credential.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub(crate) enum ValidationStatus {
+    /// Credential tested and accepted by provider.
+    Valid,
+    /// Credential tested and rejected by provider.
+    Expired,
+    /// Credential has not been tested.
+    Untested,
+}
+
+impl ValidationStatus {
+    pub(crate) fn label(self) -> &'static str {
+        match self {
+            Self::Valid => "Valid",
+            Self::Expired => "Expired",
+            Self::Untested => "Untested",
+        }
+    }
+
+    pub(crate) fn color(self) -> &'static str {
+        match self {
+            Self::Valid => "#22c55e",
+            Self::Expired => "#ef4444",
+            Self::Untested => "#888888",
+        }
+    }
+}
+
+/// A single credential entry.
+///
+/// NOTE: `masked_key` contains only the last 4 characters of the key prefixed
+/// with "..." (e.g., `"...ab12"`). Full key values must never be stored here.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct CredentialEntry {
+    pub(crate) id: String,
+    pub(crate) provider: String,
+    pub(crate) role: CredentialRole,
+    /// Display form of the key: last 4 chars prefixed with "...".
+    pub(crate) masked_key: String,
+    pub(crate) status: ValidationStatus,
+    pub(crate) last_validated: Option<String>,
+    pub(crate) requests_today: u64,
+    pub(crate) tokens_today: u64,
+}
+
+/// Store for credential entries.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct CredentialStore {
+    pub(crate) entries: Vec<CredentialEntry>,
+}
+
+impl CredentialStore {
+    /// Returns true if removing the credential with `id` would leave its
+    /// provider with no primary credential.
+    #[must_use]
+    pub(crate) fn is_last_primary(&self, id: &str) -> bool {
+        let Some(entry) = self.entries.iter().find(|e| e.id == id) else {
+            return false;
+        };
+        if entry.role != CredentialRole::Primary {
+            return false;
+        }
+        let provider = &entry.provider;
+        self.entries
+            .iter()
+            .filter(|e| &e.provider == provider && e.role == CredentialRole::Primary)
+            .count()
+            == 1
+    }
+
+    /// Returns true if the provider has both a primary and a backup credential.
+    #[must_use]
+    pub(crate) fn can_rotate(&self, provider: &str) -> bool {
+        let has_primary = self
+            .entries
+            .iter()
+            .any(|e| e.provider == provider && e.role == CredentialRole::Primary);
+        let has_backup = self
+            .entries
+            .iter()
+            .any(|e| e.provider == provider && e.role == CredentialRole::Backup);
+        has_primary && has_backup
+    }
+
+    /// Providers present in the store (deduplicated, stable insertion order).
+    #[must_use]
+    pub(crate) fn providers(&self) -> Vec<&str> {
+        let mut seen = HashSet::new();
+        self.entries
+            .iter()
+            .filter_map(|e| {
+                if seen.insert(e.provider.as_str()) {
+                    Some(e.provider.as_str())
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
+}
+
+/// Masks a credential key to show only the last 4 characters.
+///
+/// Returns `"...XXXX"` where XXXX is the last 4 chars of `key`.
+/// Returns `"...????"` if `key` is shorter than 4 characters.
+pub(crate) fn mask_key(key: &str) -> String {
+    let chars: Vec<char> = key.chars().collect();
+    if chars.len() >= 4 {
+        let tail: String = chars[chars.len() - 4..].iter().collect();
+        format!("...{tail}")
+    } else {
+        "...????".to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entry(id: &str, provider: &str, role: CredentialRole) -> CredentialEntry {
+        CredentialEntry {
+            id: id.to_string(),
+            provider: provider.to_string(),
+            role,
+            masked_key: "...ab12".to_string(),
+            status: ValidationStatus::Untested,
+            last_validated: None,
+            requests_today: 0,
+            tokens_today: 0,
+        }
+    }
+
+    fn store(entries: Vec<CredentialEntry>) -> CredentialStore {
+        CredentialStore { entries }
+    }
+
+    #[test]
+    fn is_last_primary_true_when_single_primary() {
+        let s = store(vec![entry("c1", "anthropic", CredentialRole::Primary)]);
+        assert!(s.is_last_primary("c1"));
+    }
+
+    #[test]
+    fn is_last_primary_false_when_backup() {
+        let s = store(vec![entry("c1", "anthropic", CredentialRole::Backup)]);
+        assert!(!s.is_last_primary("c1"));
+    }
+
+    #[test]
+    fn is_last_primary_false_when_two_primaries() {
+        let s = store(vec![
+            entry("c1", "anthropic", CredentialRole::Primary),
+            entry("c2", "anthropic", CredentialRole::Primary),
+        ]);
+        assert!(!s.is_last_primary("c1"));
+    }
+
+    #[test]
+    fn is_last_primary_false_for_unknown_id() {
+        let s = store(vec![entry("c1", "anthropic", CredentialRole::Primary)]);
+        assert!(!s.is_last_primary("missing"));
+    }
+
+    #[test]
+    fn can_rotate_true_with_primary_and_backup() {
+        let s = store(vec![
+            entry("c1", "anthropic", CredentialRole::Primary),
+            entry("c2", "anthropic", CredentialRole::Backup),
+        ]);
+        assert!(s.can_rotate("anthropic"));
+    }
+
+    #[test]
+    fn can_rotate_false_with_only_primary() {
+        let s = store(vec![entry("c1", "anthropic", CredentialRole::Primary)]);
+        assert!(!s.can_rotate("anthropic"));
+    }
+
+    #[test]
+    fn can_rotate_false_for_unknown_provider() {
+        let s = store(vec![entry("c1", "anthropic", CredentialRole::Primary)]);
+        assert!(!s.can_rotate("openai"));
+    }
+
+    #[test]
+    fn providers_deduplicates_stable_order() {
+        let s = store(vec![
+            entry("c1", "anthropic", CredentialRole::Primary),
+            entry("c2", "anthropic", CredentialRole::Backup),
+            entry("c3", "openai", CredentialRole::Primary),
+        ]);
+        let providers = s.providers();
+        assert_eq!(providers, vec!["anthropic", "openai"]);
+    }
+
+    #[test]
+    fn mask_key_last_four_chars() {
+        assert_eq!(mask_key("sk-abc123def456"), "...f456");
+    }
+
+    #[test]
+    fn mask_key_exactly_four_chars() {
+        assert_eq!(mask_key("ab12"), "...ab12");
+    }
+
+    #[test]
+    fn mask_key_too_short_returns_placeholder() {
+        assert_eq!(mask_key("abc"), "...????");
+    }
+
+    #[test]
+    fn mask_key_empty_returns_placeholder() {
+        assert_eq!(mask_key(""), "...????");
+    }
+}

--- a/crates/theatron/desktop/src/state/mod.rs
+++ b/crates/theatron/desktop/src/state/mod.rs
@@ -7,6 +7,8 @@
 pub mod agents;
 pub mod app;
 pub(crate) mod chat;
+/// Credential management state for the ops view.
+pub(crate) mod credentials;
 /// Checkpoint approval gate state for the planning project detail view.
 pub(crate) mod checkpoints;
 pub mod collections;

--- a/crates/theatron/desktop/src/views/ops/credentials.rs
+++ b/crates/theatron/desktop/src/views/ops/credentials.rs
@@ -1,0 +1,765 @@
+//! Credential management panel: display, validate, rotate, add, and remove credentials.
+//!
+//! TODO(#107): move CredentialApiEntry and related request types to theatron-core
+//! when /api/system/credentials is implemented in pylon.
+
+use dioxus::prelude::*;
+
+use crate::api::client::authenticated_client;
+use crate::state::connection::ConnectionConfig;
+use crate::state::credentials::{
+    CredentialEntry, CredentialRole, CredentialStore, ValidationStatus, mask_key,
+};
+use crate::state::fetch::FetchState;
+
+// --- API types (local until pylon implements the endpoint) ---
+
+#[derive(Debug, Clone, serde::Deserialize)]
+struct CredentialsListResponse {
+    #[serde(default)]
+    credentials: Vec<CredentialApiEntry>,
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
+struct CredentialApiEntry {
+    #[serde(default)]
+    id: String,
+    #[serde(default)]
+    provider: String,
+    #[serde(default)]
+    role: String,
+    /// Key value from API. Must be masked before use if it is not already masked.
+    #[serde(default)]
+    masked_key: String,
+    #[serde(default)]
+    status: String,
+    #[serde(default)]
+    last_validated: Option<String>,
+    #[serde(default)]
+    requests_today: u64,
+    #[serde(default)]
+    tokens_today: u64,
+}
+
+impl CredentialApiEntry {
+    fn into_entry(self) -> CredentialEntry {
+        let role = if self.role == "primary" {
+            CredentialRole::Primary
+        } else {
+            CredentialRole::Backup
+        };
+        let status = match self.status.as_str() {
+            "valid" => ValidationStatus::Valid,
+            "expired" => ValidationStatus::Expired,
+            _ => ValidationStatus::Untested,
+        };
+        // SAFETY: mask any full key value before it enters reactive state.
+        let masked = if self.masked_key.starts_with("...") {
+            self.masked_key
+        } else {
+            mask_key(&self.masked_key)
+        };
+        CredentialEntry {
+            id: self.id,
+            provider: self.provider,
+            role,
+            masked_key: masked,
+            status,
+            last_validated: self.last_validated,
+            requests_today: self.requests_today,
+            tokens_today: self.tokens_today,
+        }
+    }
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+struct AddCredentialRequest {
+    provider: String,
+    /// Raw key — cleared from reactive state immediately after spawn.
+    key: String,
+    role: String,
+}
+
+// --- Styles ---
+
+const PANEL_STYLE: &str = "\
+    display: flex; \
+    flex-direction: column; \
+    gap: 12px; \
+    flex: 1; \
+    overflow-y: auto;\
+";
+
+const CRED_CARD_STYLE: &str = "\
+    background: #1a1a2e; \
+    border: 1px solid #333; \
+    border-radius: 8px; \
+    padding: 16px 20px;\
+";
+
+const CARD_HEADER: &str = "\
+    display: flex; \
+    align-items: center; \
+    justify-content: space-between; \
+    margin-bottom: 10px;\
+";
+
+const PROVIDER_NAME: &str = "\
+    font-size: 15px; \
+    font-weight: bold; \
+    color: #e0e0e0;\
+";
+
+const META_ROW: &str = "\
+    display: flex; \
+    align-items: center; \
+    gap: 14px; \
+    margin-bottom: 6px; \
+    font-size: 13px;\
+";
+
+const STATS_ROW: &str = "\
+    display: flex; \
+    gap: 16px; \
+    font-size: 12px; \
+    color: #666; \
+    margin-bottom: 12px;\
+";
+
+const ACTIONS_ROW: &str = "\
+    display: flex; \
+    gap: 8px; \
+    align-items: center; \
+    flex-wrap: wrap;\
+";
+
+const BTN_STD: &str = "\
+    background: #2a2a4a; \
+    color: #e0e0e0; \
+    border: 1px solid #444; \
+    border-radius: 6px; \
+    padding: 4px 12px; \
+    font-size: 12px; \
+    cursor: pointer;\
+";
+
+const BTN_DANGER: &str = "\
+    background: #3a1a1a; \
+    color: #ef4444; \
+    border: 1px solid #5a2a2a; \
+    border-radius: 6px; \
+    padding: 4px 12px; \
+    font-size: 12px; \
+    cursor: pointer;\
+";
+
+const BTN_CONFIRM: &str = "\
+    background: #ef4444; \
+    color: #fff; \
+    border: none; \
+    border-radius: 6px; \
+    padding: 4px 12px; \
+    font-size: 12px; \
+    cursor: pointer;\
+";
+
+const BTN_CANCEL: &str = "\
+    background: #2a2a2a; \
+    color: #aaa; \
+    border: 1px solid #444; \
+    border-radius: 6px; \
+    padding: 4px 12px; \
+    font-size: 12px; \
+    cursor: pointer;\
+";
+
+const BTN_DISABLED: &str = "\
+    background: #1a1a2e; \
+    color: #555; \
+    border: 1px solid #2a2a3a; \
+    border-radius: 6px; \
+    padding: 4px 12px; \
+    font-size: 12px; \
+    cursor: not-allowed;\
+";
+
+const CONFIRM_BANNER: &str = "\
+    display: flex; \
+    gap: 8px; \
+    align-items: center; \
+    padding: 8px 0; \
+    border-top: 1px solid #333; \
+    margin-top: 10px;\
+";
+
+const WARN_TEXT: &str = "\
+    font-size: 12px; \
+    color: #f59e0b; \
+    flex: 1;\
+";
+
+const ADD_CARD_STYLE: &str = "\
+    background: #1a1a2e; \
+    border: 1px solid #2a2a4a; \
+    border-radius: 8px; \
+    padding: 16px 20px;\
+";
+
+const FORM_TITLE: &str = "\
+    font-size: 14px; \
+    font-weight: bold; \
+    color: #aaa; \
+    margin-bottom: 12px;\
+";
+
+const FORM_ROW: &str = "\
+    display: flex; \
+    gap: 10px; \
+    align-items: flex-end; \
+    flex-wrap: wrap; \
+    margin-bottom: 10px;\
+";
+
+const FORM_GROUP: &str = "\
+    display: flex; \
+    flex-direction: column; \
+    gap: 4px;\
+";
+
+const FORM_LABEL: &str = "\
+    font-size: 11px; \
+    color: #888; \
+    text-transform: uppercase; \
+    letter-spacing: 0.5px;\
+";
+
+const FORM_INPUT: &str = "\
+    background: #0f0f1a; \
+    color: #e0e0e0; \
+    border: 1px solid #444; \
+    border-radius: 6px; \
+    padding: 6px 10px; \
+    font-size: 13px; \
+    width: 160px;\
+";
+
+const FORM_SELECT: &str = "\
+    background: #0f0f1a; \
+    color: #e0e0e0; \
+    border: 1px solid #444; \
+    border-radius: 6px; \
+    padding: 6px 10px; \
+    font-size: 13px;\
+";
+
+const ERROR_TEXT: &str = "\
+    font-size: 12px; \
+    color: #ef4444; \
+    margin-top: 4px;\
+";
+
+// --- Components ---
+
+/// Credential management panel.
+#[component]
+pub(crate) fn CredentialsView() -> Element {
+    let mut fetch_trigger = use_signal(|| 0u32);
+    let mut fetch_state: Signal<FetchState<CredentialStore>> = use_signal(|| FetchState::Loading);
+    let config: Signal<ConnectionConfig> = use_context();
+
+    let mut show_add = use_signal(|| false);
+    let mut add_provider = use_signal(String::new);
+    let mut add_key = use_signal(String::new);
+    let mut add_role: Signal<CredentialRole> = use_signal(|| CredentialRole::Primary);
+    let mut add_error: Signal<Option<String>> = use_signal(|| None);
+
+    use_effect(move || {
+        let _trigger = *fetch_trigger.read();
+        let cfg = config.read().clone();
+        fetch_state.set(FetchState::Loading);
+
+        spawn(async move {
+            let client = authenticated_client(&cfg);
+            let url = format!(
+                "{}/api/system/credentials",
+                cfg.server_url.trim_end_matches('/')
+            );
+            match client.get(&url).send().await {
+                Ok(resp) if resp.status().is_success() => {
+                    match resp.json::<CredentialsListResponse>().await {
+                        Ok(data) => {
+                            let entries = data
+                                .credentials
+                                .into_iter()
+                                .map(CredentialApiEntry::into_entry)
+                                .collect();
+                            fetch_state.set(FetchState::Loaded(CredentialStore { entries }));
+                        }
+                        Err(e) => {
+                            fetch_state
+                                .set(FetchState::Error(format!("parse error: {e}")));
+                        }
+                    }
+                }
+                Ok(resp) => {
+                    let status = resp.status();
+                    fetch_state
+                        .set(FetchState::Error(format!("server returned {status}")));
+                }
+                Err(e) => {
+                    fetch_state
+                        .set(FetchState::Error(format!("connection error: {e}")));
+                }
+            }
+        });
+    });
+
+    let mut do_add = move || {
+        let provider = add_provider.read().trim().to_string();
+        let key = add_key.read().trim().to_string();
+        let role = *add_role.read();
+
+        if provider.is_empty() {
+            add_error.set(Some("Provider is required.".to_string()));
+            return;
+        }
+        if key.is_empty() {
+            add_error.set(Some("Key is required.".to_string()));
+            return;
+        }
+        add_error.set(None);
+
+        let role_str = match role {
+            CredentialRole::Primary => "primary".to_string(),
+            CredentialRole::Backup => "backup".to_string(),
+        };
+        let payload = AddCredentialRequest {
+            provider,
+            key,
+            role: role_str,
+        };
+        let cfg = config.read().clone();
+
+        // WHY: Clear key immediately before spawning so the raw value does not
+        // linger in reactive state after the async task begins.
+        add_key.set(String::new());
+
+        spawn(async move {
+            let client = authenticated_client(&cfg);
+            let url = format!(
+                "{}/api/system/credentials",
+                cfg.server_url.trim_end_matches('/')
+            );
+            match client.post(&url).json(&payload).send().await {
+                Ok(resp) if resp.status().is_success() => {
+                    add_provider.set(String::new());
+                    show_add.set(false);
+                    fetch_trigger.set(fetch_trigger() + 1);
+                }
+                Ok(resp) => {
+                    let status = resp.status();
+                    add_error.set(Some(format!("Add failed: {status}")));
+                }
+                Err(e) => {
+                    add_error.set(Some(format!("Connection error: {e}")));
+                }
+            }
+        });
+    };
+
+    // Collect card data from the loaded state (owned values for the RSX loop).
+    let (cards, fetch_loading, fetch_error_msg) = {
+        let state = fetch_state.read();
+        match &*state {
+            FetchState::Loading => (Vec::new(), true, None),
+            FetchState::Error(e) => (Vec::new(), false, Some(e.clone())),
+            FetchState::Loaded(store) => {
+                let cards: Vec<(CredentialEntry, bool, bool)> = store
+                    .entries
+                    .iter()
+                    .map(|e| {
+                        (
+                            e.clone(),
+                            store.can_rotate(&e.provider),
+                            store.is_last_primary(&e.id),
+                        )
+                    })
+                    .collect();
+                (cards, false, None)
+            }
+        }
+    };
+
+    rsx! {
+        div {
+            style: "{PANEL_STYLE}",
+
+            if fetch_loading {
+                div { style: "color: #888; font-size: 13px;", "Loading credentials..." }
+            }
+
+            if let Some(err) = &fetch_error_msg {
+                div { style: "color: #ef4444; font-size: 13px;", "Error: {err}" }
+            }
+
+            if !fetch_loading && fetch_error_msg.is_none() && cards.is_empty() {
+                div { style: "color: #555; font-size: 13px;", "No credentials configured." }
+            }
+
+            for (entry, can_rot, is_last_prim) in cards {
+                CredentialCard {
+                    key: "{entry.id}",
+                    entry,
+                    can_rotate: can_rot,
+                    is_last_primary: is_last_prim,
+                    on_change: move |_| fetch_trigger.set(fetch_trigger() + 1),
+                }
+            }
+
+            if *show_add.read() {
+                div {
+                    style: "{ADD_CARD_STYLE}",
+                    div { style: "{FORM_TITLE}", "Add Credential" }
+                    div {
+                        style: "{FORM_ROW}",
+                        div {
+                            style: "{FORM_GROUP}",
+                            span { style: "{FORM_LABEL}", "Provider" }
+                            input {
+                                style: "{FORM_INPUT}",
+                                r#type: "text",
+                                placeholder: "anthropic",
+                                value: "{add_provider}",
+                                oninput: move |evt: Event<FormData>| {
+                                    add_provider.set(evt.value().clone());
+                                    add_error.set(None);
+                                },
+                            }
+                        }
+                        div {
+                            style: "{FORM_GROUP}",
+                            span { style: "{FORM_LABEL}", "API Key" }
+                            input {
+                                style: "{FORM_INPUT}",
+                                r#type: "password",
+                                placeholder: "sk-...",
+                                value: "{add_key}",
+                                oninput: move |evt: Event<FormData>| {
+                                    add_key.set(evt.value().clone());
+                                    add_error.set(None);
+                                },
+                            }
+                        }
+                        div {
+                            style: "{FORM_GROUP}",
+                            span { style: "{FORM_LABEL}", "Role" }
+                            select {
+                                style: "{FORM_SELECT}",
+                                onchange: move |evt: Event<FormData>| {
+                                    let role = if evt.value() == "primary" {
+                                        CredentialRole::Primary
+                                    } else {
+                                        CredentialRole::Backup
+                                    };
+                                    add_role.set(role);
+                                },
+                                option { value: "primary", selected: true, "Primary" }
+                                option { value: "backup", "Backup" }
+                            }
+                        }
+                    }
+                    if let Some(err) = &*add_error.read() {
+                        div { style: "{ERROR_TEXT}", "{err}" }
+                    }
+                    div {
+                        style: "display: flex; gap: 8px; margin-top: 4px;",
+                        button {
+                            style: "{BTN_STD}",
+                            onclick: move |_| do_add(),
+                            "Add"
+                        }
+                        button {
+                            style: "{BTN_CANCEL}",
+                            onclick: move |_| {
+                                show_add.set(false);
+                                add_error.set(None);
+                                // WHY: Clear key field on cancel to avoid stale
+                                // credential values persisting in state.
+                                add_key.set(String::new());
+                            },
+                            "Cancel"
+                        }
+                    }
+                }
+            } else {
+                button {
+                    style: "{BTN_STD}",
+                    onclick: move |_| show_add.set(true),
+                    "+ Add Credential"
+                }
+            }
+        }
+    }
+}
+
+/// A single credential card with validation, rotation, and removal actions.
+#[component]
+fn CredentialCard(
+    entry: CredentialEntry,
+    can_rotate: bool,
+    is_last_primary: bool,
+    on_change: EventHandler<()>,
+) -> Element {
+    let config: Signal<ConnectionConfig> = use_context();
+    let mut is_validating = use_signal(|| false);
+    let mut confirm_rotate = use_signal(|| false);
+    let mut confirm_remove = use_signal(|| false);
+    let mut card_error: Signal<Option<String>> = use_signal(|| None);
+
+    let entry_id = entry.id.clone();
+    let entry_provider = entry.provider.clone();
+
+    let mut do_validate = {
+        let id = entry_id.clone();
+        move || {
+            let cfg = config.read().clone();
+            let id_v = id.clone();
+            is_validating.set(true);
+            card_error.set(None);
+
+            spawn(async move {
+                let client = authenticated_client(&cfg);
+                let url = format!(
+                    "{}/api/system/credentials/{}/validate",
+                    cfg.server_url.trim_end_matches('/'),
+                    id_v
+                );
+                match client.post(&url).send().await {
+                    Ok(resp) if resp.status().is_success() => {
+                        is_validating.set(false);
+                        on_change.call(());
+                    }
+                    Ok(resp) => {
+                        let status = resp.status();
+                        is_validating.set(false);
+                        card_error.set(Some(format!("Validate failed: {status}")));
+                    }
+                    Err(e) => {
+                        is_validating.set(false);
+                        card_error.set(Some(format!("Connection error: {e}")));
+                    }
+                }
+            });
+        }
+    };
+
+    let mut do_rotate = {
+        let provider = entry_provider.clone();
+        move || {
+            let cfg = config.read().clone();
+            let prov = provider.clone();
+            confirm_rotate.set(false);
+            card_error.set(None);
+
+            spawn(async move {
+                let client = authenticated_client(&cfg);
+                let encoded =
+                    form_urlencoded::byte_serialize(prov.as_bytes()).collect::<String>();
+                let url = format!(
+                    "{}/api/system/credentials/rotate?provider={}",
+                    cfg.server_url.trim_end_matches('/'),
+                    encoded
+                );
+                match client.post(&url).send().await {
+                    Ok(resp) if resp.status().is_success() => {
+                        on_change.call(());
+                    }
+                    Ok(resp) => {
+                        let status = resp.status();
+                        card_error.set(Some(format!("Rotate failed: {status}")));
+                    }
+                    Err(e) => {
+                        card_error.set(Some(format!("Connection error: {e}")));
+                    }
+                }
+            });
+        }
+    };
+
+    let mut do_remove = {
+        let id = entry_id.clone();
+        move || {
+            let cfg = config.read().clone();
+            let id_r = id.clone();
+            confirm_remove.set(false);
+            card_error.set(None);
+
+            spawn(async move {
+                let client = authenticated_client(&cfg);
+                let url = format!(
+                    "{}/api/system/credentials/{}",
+                    cfg.server_url.trim_end_matches('/'),
+                    id_r
+                );
+                match client.delete(&url).send().await {
+                    Ok(resp) if resp.status().is_success() => {
+                        on_change.call(());
+                    }
+                    Ok(resp) => {
+                        let status = resp.status();
+                        card_error.set(Some(format!("Remove failed: {status}")));
+                    }
+                    Err(e) => {
+                        card_error.set(Some(format!("Connection error: {e}")));
+                    }
+                }
+            });
+        }
+    };
+
+    let validating = *is_validating.read();
+    let show_rotate = *confirm_rotate.read();
+    let show_remove = *confirm_remove.read();
+
+    let role_bg = if entry.role == CredentialRole::Primary {
+        "background: #1a2a4a; color: #4a9aff;"
+    } else {
+        "background: #2a2a2a; color: #888;"
+    };
+
+    rsx! {
+        div {
+            style: "{CRED_CARD_STYLE}",
+
+            // Header: provider name + role badge
+            div {
+                style: "{CARD_HEADER}",
+                span { style: "{PROVIDER_NAME}", "{entry.provider}" }
+                span {
+                    style: "font-size: 11px; padding: 2px 8px; border-radius: 4px; \
+                            font-weight: bold; text-transform: uppercase; letter-spacing: 0.5px; \
+                            {role_bg}",
+                    "{entry.role.label()}"
+                }
+            }
+
+            // Masked key + validation status
+            div {
+                style: "{META_ROW}",
+                span {
+                    style: "font-family: monospace; color: #888; font-size: 13px;",
+                    "{entry.masked_key}"
+                }
+                span {
+                    style: "display: inline-flex; align-items: center; gap: 5px; font-size: 13px; \
+                            color: {entry.status.color()};",
+                    span {
+                        style: "width: 8px; height: 8px; border-radius: 50%; \
+                                background: {entry.status.color()}; display: inline-block;",
+                    }
+                    "{entry.status.label()}"
+                }
+            }
+
+            // Last validated + usage stats
+            div {
+                style: "{STATS_ROW}",
+                if let Some(ref ts) = entry.last_validated {
+                    span { "Validated: {ts}" }
+                } else {
+                    span { "Never validated" }
+                }
+                span { "{entry.requests_today} req today" }
+                span { "{entry.tokens_today} tok today" }
+            }
+
+            // Action buttons
+            div {
+                style: "{ACTIONS_ROW}",
+                if validating {
+                    button { style: "{BTN_DISABLED}", disabled: true, "Validating..." }
+                } else {
+                    button {
+                        style: "{BTN_STD}",
+                        onclick: move |_| do_validate(),
+                        "Validate"
+                    }
+                }
+
+                if can_rotate {
+                    button {
+                        style: "{BTN_STD}",
+                        onclick: move |_| {
+                            confirm_rotate.set(true);
+                            confirm_remove.set(false);
+                        },
+                        "Rotate"
+                    }
+                }
+
+                if is_last_primary {
+                    button {
+                        style: "{BTN_DISABLED}",
+                        disabled: true,
+                        title: "Cannot remove the last primary credential",
+                        "Remove"
+                    }
+                } else {
+                    button {
+                        style: "{BTN_DANGER}",
+                        onclick: move |_| {
+                            confirm_remove.set(true);
+                            confirm_rotate.set(false);
+                        },
+                        "Remove"
+                    }
+                }
+            }
+
+            // Rotate confirmation
+            if show_rotate {
+                div {
+                    style: "{CONFIRM_BANNER}",
+                    span {
+                        style: "{WARN_TEXT}",
+                        "Swap primary and backup for {entry_provider}? \
+                        If backup is untested or expired, API calls may fail."
+                    }
+                    button {
+                        style: "{BTN_CONFIRM}",
+                        onclick: move |_| do_rotate(),
+                        "Confirm"
+                    }
+                    button {
+                        style: "{BTN_CANCEL}",
+                        onclick: move |_| confirm_rotate.set(false),
+                        "Cancel"
+                    }
+                }
+            }
+
+            // Remove confirmation
+            if show_remove {
+                div {
+                    style: "{CONFIRM_BANNER}",
+                    span { style: "{WARN_TEXT}", "Permanently remove this credential?" }
+                    button {
+                        style: "{BTN_CONFIRM}",
+                        onclick: move |_| do_remove(),
+                        "Remove"
+                    }
+                    button {
+                        style: "{BTN_CANCEL}",
+                        onclick: move |_| confirm_remove.set(false),
+                        "Cancel"
+                    }
+                }
+            }
+
+            // Per-card error
+            if let Some(err) = &*card_error.read() {
+                div { style: "color: #ef4444; font-size: 12px; margin-top: 8px;", "{err}" }
+            }
+        }
+    }
+}

--- a/crates/theatron/desktop/src/views/ops/mod.rs
+++ b/crates/theatron/desktop/src/views/ops/mod.rs
@@ -1,10 +1,18 @@
-//! Operations view: tool call history and active tool monitoring.
+//! Operations view: tool call history, active tool monitoring, and credential management.
+
+pub(crate) mod credentials;
 
 use dioxus::prelude::*;
 
 use crate::api::client::authenticated_client;
 use crate::state::connection::ConnectionConfig;
 use crate::state::fetch::FetchState;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum OpsTab {
+    Tools,
+    Credentials,
+}
 
 #[derive(Debug, Clone, Default)]
 struct ToolStats {
@@ -134,9 +142,30 @@ const REFRESH_BTN: &str = "\
     cursor: pointer;\
 ";
 
+const TAB_ACTIVE: &str = "\
+    background: #2a2a4a; \
+    color: #e0e0e0; \
+    border: 1px solid #4a4aff; \
+    border-radius: 6px; \
+    padding: 4px 14px; \
+    font-size: 13px; \
+    cursor: pointer;\
+";
+
+const TAB_INACTIVE: &str = "\
+    background: transparent; \
+    color: #888; \
+    border: 1px solid #333; \
+    border-radius: 6px; \
+    padding: 4px 14px; \
+    font-size: 13px; \
+    cursor: pointer;\
+";
+
 #[component]
 pub(crate) fn Ops() -> Element {
     let config: Signal<ConnectionConfig> = use_context();
+    let mut active_tab = use_signal(|| OpsTab::Tools);
     let mut stats = use_signal(ToolStats::default);
     let mut fetch_state = use_signal(|| FetchState::<()>::Loading);
 
@@ -195,6 +224,7 @@ pub(crate) fn Ops() -> Element {
         do_refresh();
     });
 
+    let tab = *active_tab.read();
     let current_stats = stats.read();
 
     rsx! {
@@ -203,74 +233,93 @@ pub(crate) fn Ops() -> Element {
             div {
                 style: "display: flex; align-items: center; justify-content: space-between;",
                 h2 { style: "font-size: 20px; margin: 0;", "Operations" }
-                button {
-                    style: "{REFRESH_BTN}",
-                    onclick: move |_| do_refresh(),
-                    "Refresh"
-                }
-            }
-
-            if let FetchState::Error(err) = &*fetch_state.read() {
-                div { style: "color: #ef4444; font-size: 13px;", "Error: {err}" }
-            }
-
-            div {
-                style: "{CARDS_STYLE}",
                 div {
-                    style: "{CARD_STYLE}",
-                    div { style: "{CARD_VALUE}", "{current_stats.total}" }
-                    div { style: "{CARD_LABEL}", "Total Calls" }
-                }
-                div {
-                    style: "{CARD_STYLE}",
-                    div { style: "{CARD_VALUE} color: #22c55e;", "{current_stats.succeeded}" }
-                    div { style: "{CARD_LABEL}", "Succeeded" }
-                }
-                div {
-                    style: "{CARD_STYLE}",
-                    div { style: "{CARD_VALUE} color: #ef4444;", "{current_stats.failed}" }
-                    div { style: "{CARD_LABEL}", "Failed" }
-                }
-                div {
-                    style: "{CARD_STYLE}",
-                    div { style: "{CARD_VALUE} color: #4a4aff;",
-                        "{current_stats.active.len()}"
+                    style: "display: flex; align-items: center; gap: 8px;",
+                    button {
+                        style: if tab == OpsTab::Tools { TAB_ACTIVE } else { TAB_INACTIVE },
+                        onclick: move |_| active_tab.set(OpsTab::Tools),
+                        "Tools"
                     }
-                    div { style: "{CARD_LABEL}", "Active" }
+                    button {
+                        style: if tab == OpsTab::Credentials { TAB_ACTIVE } else { TAB_INACTIVE },
+                        onclick: move |_| active_tab.set(OpsTab::Credentials),
+                        "Credentials"
+                    }
+                    if tab == OpsTab::Tools {
+                        button {
+                            style: "{REFRESH_BTN}",
+                            onclick: move |_| do_refresh(),
+                            "Refresh"
+                        }
+                    }
                 }
             }
 
-            if !current_stats.active.is_empty() {
+            if tab == OpsTab::Credentials {
+                credentials::CredentialsView {}
+            } else {
+                if let FetchState::Error(err) = &*fetch_state.read() {
+                    div { style: "color: #ef4444; font-size: 13px;", "Error: {err}" }
+                }
+
+                div {
+                    style: "{CARDS_STYLE}",
+                    div {
+                        style: "{CARD_STYLE}",
+                        div { style: "{CARD_VALUE}", "{current_stats.total}" }
+                        div { style: "{CARD_LABEL}", "Total Calls" }
+                    }
+                    div {
+                        style: "{CARD_STYLE}",
+                        div { style: "{CARD_VALUE} color: #22c55e;", "{current_stats.succeeded}" }
+                        div { style: "{CARD_LABEL}", "Succeeded" }
+                    }
+                    div {
+                        style: "{CARD_STYLE}",
+                        div { style: "{CARD_VALUE} color: #ef4444;", "{current_stats.failed}" }
+                        div { style: "{CARD_LABEL}", "Failed" }
+                    }
+                    div {
+                        style: "{CARD_STYLE}",
+                        div { style: "{CARD_VALUE} color: #4a4aff;",
+                            "{current_stats.active.len()}"
+                        }
+                        div { style: "{CARD_LABEL}", "Active" }
+                    }
+                }
+
+                if !current_stats.active.is_empty() {
+                    div {
+                        style: "{SECTION_STYLE}",
+                        div { style: "{SECTION_TITLE}", "Active Tools" }
+                        for tool in &current_stats.active {
+                            div {
+                                style: "{ENTRY_STYLE}",
+                                span { style: "{ACTIVE_DOT}" }
+                                span { style: "color: #e0e0e0;", "{tool.name}" }
+                                span { style: "color: #555; font-size: 11px;", "{tool.id}" }
+                            }
+                        }
+                    }
+                }
+
                 div {
                     style: "{SECTION_STYLE}",
-                    div { style: "{SECTION_TITLE}", "Active Tools" }
-                    for tool in &current_stats.active {
-                        div {
-                            style: "{ENTRY_STYLE}",
-                            span { style: "{ACTIVE_DOT}" }
-                            span { style: "color: #e0e0e0;", "{tool.name}" }
-                            span { style: "color: #555; font-size: 11px;", "{tool.id}" }
-                        }
+                    div { style: "{SECTION_TITLE}", "Tool History" }
+                    if current_stats.history.is_empty() {
+                        div { style: "color: #555; font-size: 13px;", "No tool calls recorded" }
                     }
-                }
-            }
-
-            div {
-                style: "{SECTION_STYLE}",
-                div { style: "{SECTION_TITLE}", "Tool History" }
-                if current_stats.history.is_empty() {
-                    div { style: "color: #555; font-size: 13px;", "No tool calls recorded" }
-                }
-                for (i , entry) in current_stats.history.iter().enumerate() {
-                    div {
-                        key: "{i}",
-                        style: "{ENTRY_STYLE}",
-                        span { style: "color: {status_color(entry.is_error)};",
-                            if entry.is_error { "[x]" } else { "[v]" } // kanon:ignore RUST/indexing-slicing
-                        }
-                        span { style: "color: #e0e0e0; flex: 1;", "{entry.name}" }
-                        span { style: "color: #666; font-size: 11px;",
-                            "{entry.duration_ms}ms"
+                    for (i , entry) in current_stats.history.iter().enumerate() {
+                        div {
+                            key: "{i}",
+                            style: "{ENTRY_STYLE}",
+                            span { style: "color: {status_color(entry.is_error)};",
+                                if entry.is_error { "[x]" } else { "[v]" } // kanon:ignore RUST/indexing-slicing
+                            }
+                            span { style: "color: #e0e0e0; flex: 1;", "{entry.name}" }
+                            span { style: "color: #666; font-size: 11px;",
+                                "{entry.duration_ms}ms"
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
## Summary

- Adds a **Credentials** tab to the Operations view (alongside the existing Tools tab)
- `state/credentials.rs`: `CredentialStore` with `CredentialEntry`, `CredentialRole`, `ValidationStatus` types; `is_last_primary()`, `can_rotate()`, `providers()` helpers; `mask_key()` utility; 12 unit tests
- `views/ops/credentials.rs`: `CredentialsView` + `CredentialCard` sub-component — fetches `/api/system/credentials`, per-card validate/rotate/remove with inline confirmation dialogs, add-credential form
- `views/ops/mod.rs`: ops view converted to a module with tab bar; existing Tools content unchanged

## Security

- Key field uses `type: "password"` input masking
- Raw key cleared from reactive state immediately before async spawn
- API responses masked client-side via `mask_key()` before entering `CredentialStore`
- Remove blocked by UI when target is the last primary credential for a provider
- Rotate shows warning about backup credential validity risk before confirmation

## Test plan

- [ ] `cargo check --manifest-path crates/theatron/desktop/Cargo.toml` — compiles
- [ ] `cargo test --workspace` — all tests pass (12 new credential state tests)
- [ ] `cargo fmt --all -- --check` — clean
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [ ] Ops view shows Tools and Credentials tab buttons
- [ ] Credentials tab fetches and displays credential cards
- [ ] Validate button updates status; shows loading state while running
- [ ] Rotate shows inline confirm with backup validity warning; Confirm triggers API
- [ ] Remove shows inline confirm; blocked (disabled button) for last primary
- [ ] Add form accepts provider/key/role; key field cleared on success and cancel
- [ ] All credential keys masked as `...XXXX` in UI

## Observations

- **Debt** — `crates/pylon/src/handlers/knowledge/bulk_import.rs:147–151`: test uses `json[...]` indexing and `.unwrap()` without lint suppression; fixed missing `#[expect(clippy::indexing_slicing)]` as a gate fix.
- **Debt** — `crates/organon/src/sandbox/config.rs:337`: test used `.expect()` without `#[expect(clippy::expect_used)]`; fixed as gate fix.
- **Debt** — `crates/theatron/desktop/src/views/ops/credentials.rs`: `/api/system/credentials` endpoint does not yet exist in pylon; all credential API types are defined locally with a `TODO(#107)` comment to migrate to `theatron-core`.
- **Missing test** — `views/ops/credentials.rs`: no component-level tests for `CredentialCard` or `CredentialsView`; Dioxus component testing infrastructure not yet set up in this crate.
- **Doc gap** — `docs/ARCHITECTURE.md` does not mention the ops credential management panel or the tab-based ops view structure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)