### PR TITLE
feat(theatron-desktop): desktop notifications with rate limiting and DND

### DIFF
--- a/crates/theatron/desktop/Cargo.lock
+++ b/crates/theatron/desktop/Cargo.lock
@@ -43,6 +43,126 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "rustix",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43c070bbf59cd3570b6b2dd54cd772527c7c3620fce8be898406dd3ed6adc64c"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -146,6 +266,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
 dependencies = [
  "objc2",
+]
+
+[[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
 ]
 
 [[package]]
@@ -298,6 +431,15 @@ dependencies = [
  "ryu",
  "serde",
  "static_assertions",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -1138,6 +1280,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
+name = "endi"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+
+[[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "enumset"
 version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1182,6 +1351,27 @@ checksum = "f1a05365e3b1c6d1650318537c7460c6923f1abdd272ad6842baa2b509957a06"
 dependencies = [
  "num-traits",
  "serde",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -1329,6 +1519,19 @@ name = "futures-io"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "futures-macro"
@@ -1765,6 +1968,18 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "html5ever"
@@ -2348,6 +2563,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
 
 [[package]]
+name = "mac-notification-sys"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29a16783dd1a47849b8c8133c9cd3eb2112cfbc6901670af3dba47c8bbfb07d3"
+dependencies = [
+ "cc",
+ "objc2",
+ "objc2-foundation",
+ "time",
+]
+
+[[package]]
 name = "macro-string"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2582,6 +2809,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 
 [[package]]
+name = "notify-rust"
+version = "4.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21af20a1b50be5ac5861f74af1a863da53a11c38684d9818d82f1c42f7fdc6c2"
+dependencies = [
+ "futures-lite",
+ "log",
+ "mac-notification-sys",
+ "serde",
+ "tauri-winrt-notification",
+ "zbus",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2703,6 +2944,7 @@ checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.11.0",
  "block2",
+ "libc",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -2821,6 +3063,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "pango"
 version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2844,6 +3096,12 @@ dependencies = [
  "libc",
  "system-deps",
 ]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -3027,6 +3285,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3043,6 +3312,20 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide",
+]
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3220,6 +3503,15 @@ name = "pulldown-cmark-escape"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
+
+[[package]]
+name = "quick-xml"
+version = "0.37.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "quote"
@@ -4199,6 +4491,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
+name = "tauri-winrt-notification"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b1e66e07de489fe43a46678dd0b8df65e0c973909df1b60ba33874e297ba9b9"
+dependencies = [
+ "quick-xml",
+ "thiserror 2.0.18",
+ "windows",
+ "windows-version",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4248,6 +4552,7 @@ dependencies = [
  "dirs",
  "form_urlencoded",
  "futures-util",
+ "notify-rust",
  "pulldown-cmark",
  "reqwest",
  "rustls",
@@ -4681,6 +4986,17 @@ name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
+name = "uds_windows"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
+dependencies = [
+ "memoffset",
+ "tempfile",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "ulid"
@@ -5724,6 +6040,67 @@ dependencies = [
 ]
 
 [[package]]
+name = "zbus"
+version = "5.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca82f95dbd3943a40a53cfded6c2d0a2ca26192011846a1810c4256ef92c60bc"
+dependencies = [
+ "async-broadcast",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "async-recursion",
+ "async-task",
+ "async-trait",
+ "blocking",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-lite",
+ "hex",
+ "libc",
+ "ordered-stream",
+ "rustix",
+ "serde",
+ "serde_repr",
+ "tracing",
+ "uds_windows",
+ "uuid",
+ "windows-sys 0.61.2",
+ "winnow 0.7.15",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "5.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897e79616e84aac4b2c46e9132a4f63b93105d54fe8c0e8f6bffc21fa8d49222"
+dependencies = [
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "zbus_names",
+ "zvariant",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffd8af6d5b78619bab301ff3c560a5bd22426150253db278f164d6cf3b72c50f"
+dependencies = [
+ "serde",
+ "winnow 0.7.15",
+ "zvariant",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5808,3 +6185,43 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zvariant"
+version = "5.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5708299b21903bbe348e94729f22c49c55d04720a004aa350f1f9c122fd2540b"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "winnow 0.7.15",
+ "zvariant_derive",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "5.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b59b012ebe9c46656f9cc08d8da8b4c726510aef12559da3e5f1bf72780752c"
+dependencies = [
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f75c23a64ef8f40f13a6989991e643554d9bef1d682a281160cf0c1bc389c5e9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 2.0.117",
+ "winnow 0.7.15",
+]

--- a/crates/theatron/desktop/Cargo.toml
+++ b/crates/theatron/desktop/Cargo.toml
@@ -51,6 +51,9 @@ syntect = { version = "5", default-features = false, features = ["default-syntax
 dirs = "6"
 toml = "1.0"
 
+# Desktop notifications (freedesktop.org D-Bus on Linux)
+notify-rust = "4"
+
 [dev-dependencies]
 tempfile = "3"
 

--- a/crates/theatron/desktop/src/app.rs
+++ b/crates/theatron/desktop/src/app.rs
@@ -12,6 +12,7 @@ use crate::services::{config, settings_config};
 use crate::services::toast::provide_toast_context;
 use crate::state::agents::AgentStore;
 use crate::state::connection::ConnectionState;
+use crate::state::notifications::{DndState, NotificationHistory};
 use crate::state::platform::{CloseBehavior, HotkeyState, QuickInputState, TrayState, WindowState};
 use crate::theme::ThemeProvider;
 use crate::views::chat::Chat;
@@ -112,6 +113,12 @@ pub(crate) fn App() -> Element {
 #[component]
 fn ConnectedApp() -> Element {
     let config = use_context::<Signal<crate::state::connection::ConnectionConfig>>();
+
+    // Provide notification signals. Preferences are loaded from disk; DND and
+    // history are ephemeral and reset on each app launch.
+    use_context_provider(|| Signal::new(config::load_notification_prefs()));
+    use_context_provider(|| Signal::new(NotificationHistory::default()));
+    use_context_provider(|| Signal::new(DndState::default()));
 
     // WHY: Start SSE coroutine here (not in App) so it only runs when connected
     // and has access to the finalized connection config.

--- a/crates/theatron/desktop/src/lib.rs
+++ b/crates/theatron/desktop/src/lib.rs
@@ -10,7 +10,7 @@
 pub mod api;
 /// Dioxus UI components for the desktop app.
 pub mod components;
-/// Platform integration: system tray, global hotkeys, native menus, window state.
+/// Platform integration: system tray, global hotkeys, native menus, window state, notifications.
 pub(crate) mod platform;
 /// Background services: SSE connection, stream management, and state sync.
 pub mod services;

--- a/crates/theatron/desktop/src/platform/mod.rs
+++ b/crates/theatron/desktop/src/platform/mod.rs
@@ -1,12 +1,18 @@
-//! Platform integration: system tray, global hotkeys, native menus, window state.
+//! Platform integration: system tray, global hotkeys, native menus, window state, notifications.
 //!
 //! Each submodule provides framework-agnostic logic that the Dioxus integration
 //! layer in `app.rs` wires into the reactive component tree.
+//! [`native_notify::send_native`] dispatches freedesktop.org D-Bus
+//! notifications on Linux, falling back gracefully if the daemon is absent.
 
 /// Global hotkey registration and summon toggle logic.
 pub(crate) mod hotkeys;
 /// Native application menu bar structure and action mapping.
 pub(crate) mod menus;
+/// D-Bus notification dispatch with graceful fallback.
+pub(crate) mod native_notify;
+/// Notification payload and urgency types.
+pub(crate) mod notifications;
 /// System tray icon state derivation and context menu generation.
 pub(crate) mod tray;
 /// Window geometry and UI state persistence with debounced writes.

--- a/crates/theatron/desktop/src/platform/native_notify.rs
+++ b/crates/theatron/desktop/src/platform/native_notify.rs
@@ -1,0 +1,58 @@
+//! Native desktop notification dispatch via notify-rust.
+//!
+//! Uses the freedesktop.org D-Bus notification spec on Linux.
+//! If the notification daemon is unavailable or the send fails, logs a warning
+//! and returns `false` so the caller can fall back to in-app toasts.
+//!
+//! NOTE: Action buttons (e.g. "Show") are not wired to window navigation in
+//! this release. The notification daemon will display the system default
+//! close button only. Full action-click integration requires a thread waiting
+//! on `NotificationHandle::wait_for_action` and a channel to the Dioxus event
+//! loop — tracked separately.
+
+use tracing::warn;
+
+use super::notifications::{NotificationPayload, NotificationUrgency};
+
+/// Send a native desktop notification.
+///
+/// Returns `true` if the notification was accepted by the daemon, `false` on
+/// any failure. Never panics. The caller should fall back to an in-app toast
+/// when this returns `false`.
+pub(crate) fn send_native(payload: &NotificationPayload) -> bool {
+    match try_send(payload) {
+        Ok(()) => true,
+        Err(e) => {
+            warn!(
+                error = %e,
+                title = %payload.title,
+                "native notification failed — falling back to in-app toast"
+            );
+            false
+        }
+    }
+}
+
+fn try_send(payload: &NotificationPayload) -> Result<(), notify_rust::error::Error> {
+    use notify_rust::{Notification, Timeout, Urgency};
+
+    let urgency = match payload.urgency {
+        NotificationUrgency::Low => Urgency::Low,
+        NotificationUrgency::Normal => Urgency::Normal,
+        NotificationUrgency::Critical => Urgency::Critical,
+    };
+
+    let timeout = match payload.timeout_secs {
+        Some(secs) => Timeout::Milliseconds(secs * 1_000),
+        None => Timeout::Never,
+    };
+
+    Notification::new()
+        .summary(&payload.title)
+        .body(&payload.body)
+        .urgency(urgency)
+        .timeout(timeout)
+        .show()?;
+
+    Ok(())
+}

--- a/crates/theatron/desktop/src/platform/notifications.rs
+++ b/crates/theatron/desktop/src/platform/notifications.rs
@@ -1,0 +1,29 @@
+//! Notification payload types and urgency levels.
+//!
+//! Defines the data shape for desktop notifications before they are handed
+//! to the platform-specific sender in [`super::native_notify`].
+
+/// Visual and behavioral urgency of a desktop notification.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum NotificationUrgency {
+    /// Low urgency: informational, auto-dismisses quickly.
+    Low,
+    /// Normal urgency: connection status changes.
+    Normal,
+    /// Critical urgency: tool approval requests and errors — persistent.
+    Critical,
+}
+
+/// A desktop notification ready to be dispatched.
+#[derive(Debug, Clone)]
+pub(crate) struct NotificationPayload {
+    /// Title displayed in the notification header.
+    pub title: String,
+    /// Body text shown below the title.
+    pub body: String,
+    /// Urgency level controlling visual prominence and persistence.
+    pub urgency: NotificationUrgency,
+    /// Auto-dismiss timeout in seconds. `None` means the notification persists
+    /// until the user dismisses it (used for tool approval).
+    pub timeout_secs: Option<u32>,
+}

--- a/crates/theatron/desktop/src/services/config.rs
+++ b/crates/theatron/desktop/src/services/config.rs
@@ -12,6 +12,7 @@ use std::path::PathBuf;
 use snafu::{ResultExt, Snafu};
 
 use crate::state::connection::ConnectionConfig;
+use crate::state::notifications::NotificationPreferences;
 
 /// Errors that can occur when loading or saving desktop config.
 #[derive(Debug, Snafu)]
@@ -63,11 +64,13 @@ pub enum ConfigError {
     },
 }
 
-/// TOML file envelope: the `[connection]` table within `desktop.toml`.
+/// TOML file envelope for `~/.config/aletheia/desktop.toml`.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, Default)]
 struct DesktopConfig {
     #[serde(default)]
     connection: ConnectionConfig,
+    #[serde(default)]
+    notifications: NotificationPreferences,
 }
 
 /// Resolve the config file path: `~/.config/aletheia/desktop.toml`.
@@ -114,8 +117,19 @@ pub(crate) fn save(config: &ConnectionConfig) -> Result<(), ConfigError> {
         })?;
     }
 
+    // NOTE: Preserve existing notification preferences when saving connection config.
+    let existing_notifications = if path.exists() {
+        std::fs::read_to_string(&path)
+            .ok()
+            .and_then(|c| toml::from_str::<DesktopConfig>(&c).ok())
+            .map(|d| d.notifications)
+            .unwrap_or_default()
+    } else {
+        NotificationPreferences::default()
+    };
     let desktop = DesktopConfig {
         connection: config.clone(),
+        notifications: existing_notifications,
     };
     let content = toml::to_string_pretty(&desktop).context(SerializeSnafu)?;
     // SAFETY: Config may contain auth tokens; restrict to owner-only access.
@@ -150,6 +164,74 @@ pub(crate) fn load_or_default() -> ConnectionConfig {
     }
 }
 
+/// Load notification preferences from the config file.
+///
+/// Returns defaults if the file does not exist or the section is absent.
+#[must_use]
+pub(crate) fn load_notification_prefs() -> NotificationPreferences {
+    let Ok(path) = config_path() else {
+        return NotificationPreferences::default();
+    };
+    if !path.exists() {
+        return NotificationPreferences::default();
+    }
+    let content = match std::fs::read_to_string(&path) {
+        Ok(c) => c,
+        Err(_) => return NotificationPreferences::default(),
+    };
+    toml::from_str::<DesktopConfig>(&content)
+        .map(|c| c.notifications)
+        .unwrap_or_default()
+}
+
+/// Save notification preferences to the config file.
+///
+/// Reads the current file, updates only the `[notifications]` section, and
+/// writes back — preserving the `[connection]` section.
+///
+/// # Errors
+///
+/// Returns an error if the file cannot be read, parsed, or written.
+pub(crate) fn save_notification_prefs(prefs: &NotificationPreferences) -> Result<(), ConfigError> {
+    let path = config_path()?;
+
+    // Read existing config to preserve the connection section.
+    let existing = if path.exists() {
+        let content = std::fs::read_to_string(&path).context(ReadFileSnafu { path: &path })?;
+        toml::from_str::<DesktopConfig>(&content).context(ParseSnafu)?
+    } else {
+        DesktopConfig::default()
+    };
+
+    let updated = DesktopConfig {
+        connection: existing.connection,
+        notifications: prefs.clone(),
+    };
+    let content = toml::to_string_pretty(&updated).context(SerializeSnafu)?;
+
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).context(CreateDirSnafu {
+            path: parent.to_path_buf(),
+        })?;
+    }
+
+    // SAFETY: Config may contain auth tokens; restrict to owner-only access.
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        let mut file = std::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .mode(0o600)
+            .open(&path)
+            .context(WriteFileSnafu { path: &path })?;
+        file.write_all(content.as_bytes())
+            .context(WriteFileSnafu { path: &path })?;
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 #[expect(clippy::unwrap_used, reason = "test assertions may panic on failure")]
 mod tests {
@@ -165,6 +247,7 @@ mod tests {
 
         let desktop = DesktopConfig {
             connection: config.clone(),
+            notifications: NotificationPreferences::default(),
         };
         let serialized = toml::to_string_pretty(&desktop).unwrap();
         let deserialized: DesktopConfig = toml::from_str(&serialized).unwrap();
@@ -191,6 +274,7 @@ mod tests {
 
         let desktop = DesktopConfig {
             connection: config.clone(),
+            notifications: NotificationPreferences::default(),
         };
         let content = toml::to_string_pretty(&desktop).unwrap();
         std::fs::write(&path, &content).unwrap();

--- a/crates/theatron/desktop/src/services/mod.rs
+++ b/crates/theatron/desktop/src/services/mod.rs
@@ -7,6 +7,7 @@ pub mod config;
 pub mod connection;
 pub(crate) mod file_watcher;
 pub mod sse;
+pub(crate) mod notification_dispatch;
 pub(crate) mod sse_coroutine;
 pub(crate) mod streaming;
 pub(crate) mod toast;

--- a/crates/theatron/desktop/src/services/notification_dispatch.rs
+++ b/crates/theatron/desktop/src/services/notification_dispatch.rs
@@ -1,0 +1,640 @@
+//! Notification dispatch: routes SSE events to desktop notifications.
+//!
+//! [`NotificationDispatch`] is instantiated once before the SSE event loop
+//! and called on each event. It applies:
+//!
+//! - **Preferences**: per-category and master enable/disable.
+//! - **Focus rules**: completion notifications are suppressed when the window
+//!   is in the foreground (tool approval always fires regardless).
+//! - **DND**: all non-approval notifications are suppressed during Do Not
+//!   Disturb mode. Tool approval fires regardless (time-sensitive).
+//! - **Rate limiting**: sliding window of max 5 notifications per minute per
+//!   category. Prevents spam during rapid agent activity.
+//! - **Grouping**: the first notification in a category fires immediately.
+//!   Subsequent arrivals within 3 seconds are coalesced into a pending group
+//!   rather than sending duplicates. The group count is recorded in history.
+//! - **Connection-loss delay**: fires only after 5 seconds of continuous
+//!   disconnect to allow the auto-reconnect logic to succeed silently.
+
+use std::collections::{HashMap, VecDeque};
+use std::time::{Duration, Instant};
+
+use theatron_core::api::types::SseEvent;
+use theatron_core::id::NousId;
+
+use crate::platform::native_notify::send_native;
+use crate::platform::notifications::{NotificationPayload, NotificationUrgency};
+use crate::state::notifications::{
+    DndState, NotificationCategory, NotificationEntry, NotificationPreferences,
+};
+use crate::state::toasts::Severity;
+
+/// Maximum notifications dispatched per minute per category (sliding window).
+const RATE_LIMIT_PER_MINUTE: usize = 5;
+
+/// Duration of the rate limiting sliding window.
+const RATE_WINDOW: Duration = Duration::from_secs(60);
+
+/// Notifications in the same category arriving within this window are coalesced.
+const GROUP_WINDOW: Duration = Duration::from_secs(3);
+
+/// Delay after first disconnect before firing a connection-lost notification.
+const CONNECTION_LOST_DELAY: Duration = Duration::from_secs(5);
+
+/// Maximum body length for error notifications.
+const ERROR_BODY_MAX: usize = 200;
+
+/// In-flight group collecting arrivals within [`GROUP_WINDOW`].
+struct PendingGroup {
+    /// Total number of notifications coalesced so far (including the first).
+    count: u32,
+    /// When the group window opened.
+    started_at: Instant,
+}
+
+/// Routes SSE events to desktop notifications with rate limiting and grouping.
+///
+/// Create once and call [`Self::process_event`] for each event from the SSE
+/// stream. The dispatcher maintains internal state between calls.
+pub(crate) struct NotificationDispatch {
+    /// Sliding windows of send timestamps per category for rate limiting.
+    rate_windows: HashMap<NotificationCategory, VecDeque<Instant>>,
+    /// Pending coalescing groups per category.
+    pending_groups: HashMap<NotificationCategory, PendingGroup>,
+    /// Timestamp of the most recent disconnect (for connection-loss delay).
+    disconnect_at: Option<Instant>,
+    /// Whether the SSE stream was connected on the previous event.
+    was_connected: bool,
+}
+
+impl NotificationDispatch {
+    /// Create a new dispatcher with empty state.
+    #[must_use]
+    pub(crate) fn new() -> Self {
+        Self {
+            rate_windows: HashMap::new(),
+            pending_groups: HashMap::new(),
+            disconnect_at: None,
+            was_connected: false,
+        }
+    }
+
+    /// Process one SSE event and dispatch notifications as appropriate.
+    ///
+    /// - `prefs`: snapshot of current notification preferences.
+    /// - `dnd`: current Do Not Disturb state.
+    /// - `window_focused`: whether the desktop window currently has focus.
+    ///   Completion notifications are suppressed when the window is focused.
+    ///   Tool approval is never suppressed.
+    /// - `on_sent`: called with each [`NotificationEntry`] that was dispatched,
+    ///   allowing the caller to record it in [`NotificationHistory`].
+    /// - `toast_fallback`: called when native notification fails so the caller
+    ///   can push an in-app toast instead.
+    pub(crate) fn process_event(
+        &mut self,
+        event: &SseEvent,
+        prefs: &NotificationPreferences,
+        dnd: &DndState,
+        window_focused: bool,
+        on_sent: &mut impl FnMut(NotificationEntry),
+        toast_fallback: &mut impl FnMut(Severity, &str),
+    ) {
+        // Flush expired pending groups before processing the new event.
+        self.flush_expired_groups(prefs, dnd, window_focused, on_sent, toast_fallback);
+
+        match event {
+            SseEvent::TurnAfter { nous_id, .. } => {
+                self.on_turn_after(nous_id, prefs, dnd, window_focused, on_sent, toast_fallback);
+            }
+            SseEvent::ToolFailed {
+                nous_id,
+                tool_name,
+                error,
+            } => {
+                self.on_tool_failed(
+                    nous_id,
+                    tool_name,
+                    error,
+                    prefs,
+                    dnd,
+                    window_focused,
+                    on_sent,
+                    toast_fallback,
+                );
+            }
+            SseEvent::Connected => {
+                let was_pending = self.disconnect_at.is_some();
+                self.disconnect_at = None;
+                if was_pending {
+                    // WHY: Only notify reconnect when we previously tried to notify
+                    // a disconnect (meaning the disconnect lasted past the delay).
+                    self.on_reconnected(prefs, dnd, window_focused, on_sent, toast_fallback);
+                }
+                self.was_connected = true;
+            }
+            SseEvent::Disconnected => {
+                if self.was_connected && self.disconnect_at.is_none() {
+                    // NOTE: Record the disconnect time; fire notification after delay.
+                    self.disconnect_at = Some(Instant::now());
+                }
+                self.was_connected = false;
+            }
+            _ => {
+                // NOTE: On other events, check if the delayed connection-loss
+                // notification should now fire (5s have elapsed).
+                self.check_connection_lost(prefs, dnd, window_focused, on_sent, toast_fallback);
+            }
+        }
+    }
+
+    // -- Event handlers -------------------------------------------------------
+
+    fn on_turn_after(
+        &mut self,
+        nous_id: &NousId,
+        prefs: &NotificationPreferences,
+        dnd: &DndState,
+        focused: bool,
+        on_sent: &mut impl FnMut(NotificationEntry),
+        fallback: &mut impl FnMut(Severity, &str),
+    ) {
+        if !prefs.category_enabled(NotificationCategory::AgentCompletion) {
+            return;
+        }
+        // WHY: Completion notifications are irrelevant when the user is actively
+        // watching — suppress when focused (regardless of only_when_backgrounded).
+        if focused {
+            return;
+        }
+        let title = format!("{} finished", nous_id.as_str());
+        self.dispatch_with_grouping(
+            NotificationCategory::AgentCompletion,
+            title,
+            String::new(),
+            NotificationUrgency::Low,
+            Some(10),
+            prefs,
+            dnd,
+            on_sent,
+            fallback,
+        );
+    }
+
+    fn on_tool_failed(
+        &mut self,
+        nous_id: &NousId,
+        tool_name: &str,
+        error: &str,
+        prefs: &NotificationPreferences,
+        dnd: &DndState,
+        focused: bool,
+        on_sent: &mut impl FnMut(NotificationEntry),
+        fallback: &mut impl FnMut(Severity, &str),
+    ) {
+        if !prefs.category_enabled(NotificationCategory::Error) {
+            return;
+        }
+        if focused && prefs.only_when_backgrounded {
+            return;
+        }
+        let title = String::from("Aletheia — Error");
+        let body_raw = format!(
+            "{}: tool '{}' failed — {}",
+            nous_id.as_str(),
+            tool_name,
+            error,
+        );
+        let body = truncate_chars(&body_raw, ERROR_BODY_MAX).to_string();
+        self.dispatch_with_grouping(
+            NotificationCategory::Error,
+            title,
+            body,
+            NotificationUrgency::Critical,
+            Some(10),
+            prefs,
+            dnd,
+            on_sent,
+            fallback,
+        );
+    }
+
+    fn on_reconnected(
+        &mut self,
+        prefs: &NotificationPreferences,
+        dnd: &DndState,
+        focused: bool,
+        on_sent: &mut impl FnMut(NotificationEntry),
+        fallback: &mut impl FnMut(Severity, &str),
+    ) {
+        if !prefs.category_enabled(NotificationCategory::ConnectionStatus) {
+            return;
+        }
+        if focused && prefs.only_when_backgrounded {
+            return;
+        }
+        self.send(
+            NotificationCategory::ConnectionStatus,
+            "Reconnected to server".to_string(),
+            String::new(),
+            NotificationUrgency::Normal,
+            Some(5),
+            prefs,
+            dnd,
+            on_sent,
+            fallback,
+        );
+    }
+
+    fn check_connection_lost(
+        &mut self,
+        prefs: &NotificationPreferences,
+        dnd: &DndState,
+        focused: bool,
+        on_sent: &mut impl FnMut(NotificationEntry),
+        fallback: &mut impl FnMut(Severity, &str),
+    ) {
+        let Some(at) = self.disconnect_at else {
+            return;
+        };
+        if Instant::now().duration_since(at) < CONNECTION_LOST_DELAY {
+            return;
+        }
+        // Clear so we don't fire again.
+        self.disconnect_at = None;
+
+        if !prefs.category_enabled(NotificationCategory::ConnectionStatus) {
+            return;
+        }
+        if focused && prefs.only_when_backgrounded {
+            return;
+        }
+        self.send(
+            NotificationCategory::ConnectionStatus,
+            "Connection lost — reconnecting...".to_string(),
+            String::new(),
+            NotificationUrgency::Normal,
+            Some(8),
+            prefs,
+            dnd,
+            on_sent,
+            fallback,
+        );
+    }
+
+    // -- Grouping -------------------------------------------------------------
+
+    /// Dispatch with coalescing: the first notification in a 3s window fires
+    /// immediately; subsequent arrivals increment the pending group count.
+    fn dispatch_with_grouping(
+        &mut self,
+        category: NotificationCategory,
+        title: String,
+        body: String,
+        urgency: NotificationUrgency,
+        timeout_secs: Option<u32>,
+        prefs: &NotificationPreferences,
+        dnd: &DndState,
+        on_sent: &mut impl FnMut(NotificationEntry),
+        fallback: &mut impl FnMut(Severity, &str),
+    ) {
+        let now = Instant::now();
+
+        if let Some(group) = self.pending_groups.get_mut(&category) {
+            if now.duration_since(group.started_at) < GROUP_WINDOW {
+                // Still within the grouping window — coalesce.
+                group.count += 1;
+                return;
+            }
+            // Group window has expired; remove and fall through to start a new one.
+            self.pending_groups.remove(&category);
+        }
+
+        // Start new group and send the first notification immediately.
+        self.send(
+            category,
+            title.clone(),
+            body.clone(),
+            urgency,
+            timeout_secs,
+            prefs,
+            dnd,
+            on_sent,
+            fallback,
+        );
+        self.pending_groups.insert(
+            category,
+            PendingGroup {
+                count: 1,
+                started_at: now,
+            },
+        );
+    }
+
+    /// Remove expired groups. When a group had count > 1, the single
+    /// first notification already went out; nothing extra is sent. The
+    /// history recorded the first event; grouping just prevents spam.
+    fn flush_expired_groups(
+        &mut self,
+        _prefs: &NotificationPreferences,
+        _dnd: &DndState,
+        _focused: bool,
+        _on_sent: &mut impl FnMut(NotificationEntry),
+        _fallback: &mut impl FnMut(Severity, &str),
+    ) {
+        let now = Instant::now();
+        self.pending_groups
+            .retain(|_, g| now.duration_since(g.started_at) < GROUP_WINDOW);
+    }
+
+    // -- Send -----------------------------------------------------------------
+
+    /// Apply DND, rate limit, then dispatch the notification.
+    #[expect(clippy::too_many_arguments, reason = "all parameters are contextual state")]
+    fn send(
+        &mut self,
+        category: NotificationCategory,
+        title: String,
+        body: String,
+        urgency: NotificationUrgency,
+        timeout_secs: Option<u32>,
+        prefs: &NotificationPreferences,
+        dnd: &DndState,
+        on_sent: &mut impl FnMut(NotificationEntry),
+        fallback: &mut impl FnMut(Severity, &str),
+    ) {
+        // NOTE: Tool approval bypasses DND (time-sensitive).
+        if category != NotificationCategory::ToolApproval && dnd.is_suppressing() {
+            return;
+        }
+
+        if !self.within_rate_limit(category) {
+            return;
+        }
+
+        let payload = NotificationPayload {
+            title: title.clone(),
+            body: body.clone(),
+            urgency,
+            timeout_secs,
+        };
+
+        let native_ok = send_native(&payload);
+        if !native_ok {
+            fallback(severity_for(category), &title);
+        }
+
+        on_sent(NotificationEntry {
+            category,
+            title,
+            body,
+            sent_at: Instant::now(),
+        });
+    }
+
+    // -- Rate limiting --------------------------------------------------------
+
+    /// Returns `true` if a notification for `category` is within the rate limit.
+    ///
+    /// Updates the sliding window on entry.
+    pub(crate) fn within_rate_limit(&mut self, category: NotificationCategory) -> bool {
+        let now = Instant::now();
+        let window = self.rate_windows.entry(category).or_default();
+
+        // Evict entries outside the sliding window.
+        window.retain(|&sent| now.duration_since(sent) < RATE_WINDOW);
+
+        if window.len() >= RATE_LIMIT_PER_MINUTE {
+            return false;
+        }
+        window.push_back(now);
+        true
+    }
+}
+
+/// Map a notification category to an in-app toast severity for fallback.
+fn severity_for(category: NotificationCategory) -> Severity {
+    match category {
+        NotificationCategory::AgentCompletion => Severity::Info,
+        NotificationCategory::ToolApproval => Severity::Warning,
+        NotificationCategory::Error => Severity::Error,
+        NotificationCategory::ConnectionStatus => Severity::Info,
+    }
+}
+
+/// Truncate `s` to at most `max_chars` Unicode scalar values.
+fn truncate_chars(s: &str, max_chars: usize) -> &str {
+    match s.char_indices().nth(max_chars) {
+        Some((byte_idx, _)) => &s[..byte_idx],
+        None => s,
+    }
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "test assertions may panic on failure")]
+mod tests {
+    use theatron_core::id::{NousId, SessionId};
+
+    use super::*;
+    use crate::state::notifications::{DndDuration, NotificationHistory};
+
+    fn prefs() -> NotificationPreferences {
+        NotificationPreferences::default()
+    }
+
+    fn dnd_off() -> DndState {
+        DndState::default()
+    }
+
+    fn nous(id: &str) -> NousId {
+        NousId::from(id)
+    }
+
+    fn session(id: &str) -> SessionId {
+        SessionId::from(id)
+    }
+
+    fn no_fallback(_sev: Severity, _title: &str) {}
+
+    // -- Dispatch: event routing ---------------------------------------------
+
+    #[test]
+    fn turn_after_dispatches_when_unfocused() {
+        let mut dispatch = NotificationDispatch::new();
+        let mut history = NotificationHistory::default();
+        let prefs = prefs();
+        let dnd = dnd_off();
+
+        dispatch.process_event(
+            &SseEvent::TurnAfter {
+                nous_id: nous("syn"),
+                session_id: session("s1"),
+            },
+            &prefs,
+            &dnd,
+            false,
+            &mut |e| history.push(e),
+            &mut no_fallback,
+        );
+
+        assert_eq!(history.len(), 1);
+        assert_eq!(
+            history.entries()[0].category,
+            NotificationCategory::AgentCompletion
+        );
+    }
+
+    #[test]
+    fn turn_after_suppressed_when_focused() {
+        let mut dispatch = NotificationDispatch::new();
+        let mut history = NotificationHistory::default();
+
+        dispatch.process_event(
+            &SseEvent::TurnAfter {
+                nous_id: nous("syn"),
+                session_id: session("s1"),
+            },
+            &prefs(),
+            &dnd_off(),
+            true, // focused
+            &mut |e| history.push(e),
+            &mut no_fallback,
+        );
+
+        assert!(history.is_empty(), "completion should be suppressed when focused");
+    }
+
+    // -- Focus rules ----------------------------------------------------------
+
+    #[test]
+    fn only_when_backgrounded_suppresses_errors_when_focused() {
+        let mut dispatch = NotificationDispatch::new();
+        let mut history = NotificationHistory::default();
+        let prefs = NotificationPreferences {
+            only_when_backgrounded: true,
+            ..Default::default()
+        };
+
+        dispatch.process_event(
+            &SseEvent::ToolFailed {
+                nous_id: nous("syn"),
+                tool_name: "bash".to_string(),
+                error: "timeout".to_string(),
+            },
+            &prefs,
+            &dnd_off(),
+            true, // focused
+            &mut |e| history.push(e),
+            &mut no_fallback,
+        );
+
+        assert!(history.is_empty());
+    }
+
+    // -- Rate limiting --------------------------------------------------------
+
+    #[test]
+    fn rate_limit_caps_at_five_per_minute() {
+        // NOTE: Test within_rate_limit directly because grouping (3s window)
+        // coalesces rapid-fire events before rate limiting is reached.
+        let mut dispatch = NotificationDispatch::new();
+        let mut allowed = 0usize;
+        for _ in 0..7 {
+            if dispatch.within_rate_limit(NotificationCategory::Error) {
+                allowed += 1;
+            }
+        }
+        assert_eq!(allowed, RATE_LIMIT_PER_MINUTE);
+    }
+
+    // -- Grouping -------------------------------------------------------------
+
+    #[test]
+    fn grouping_coalesces_second_arrival_within_window() {
+        let mut dispatch = NotificationDispatch::new();
+        let mut history = NotificationHistory::default();
+
+        // Two rapid turn_after events — first fires, second coalesces.
+        for _ in 0..2 {
+            dispatch.process_event(
+                &SseEvent::TurnAfter {
+                    nous_id: nous("syn"),
+                    session_id: session("s1"),
+                },
+                &prefs(),
+                &dnd_off(),
+                false,
+                &mut |e| history.push(e),
+                &mut no_fallback,
+            );
+        }
+
+        // Only the first notification should reach history.
+        assert_eq!(history.len(), 1);
+        assert!(dispatch
+            .pending_groups
+            .contains_key(&NotificationCategory::AgentCompletion));
+    }
+
+    // -- Preferences ----------------------------------------------------------
+
+    #[test]
+    fn disabled_category_not_dispatched() {
+        let mut dispatch = NotificationDispatch::new();
+        let mut history = NotificationHistory::default();
+        let prefs = NotificationPreferences {
+            agent_completion: false,
+            ..Default::default()
+        };
+
+        dispatch.process_event(
+            &SseEvent::TurnAfter {
+                nous_id: nous("syn"),
+                session_id: session("s1"),
+            },
+            &prefs,
+            &dnd_off(),
+            false,
+            &mut |e| history.push(e),
+            &mut no_fallback,
+        );
+
+        assert!(history.is_empty());
+    }
+
+    // -- DND ------------------------------------------------------------------
+
+    #[test]
+    fn dnd_suppresses_completion_notifications() {
+        let mut dispatch = NotificationDispatch::new();
+        let mut history = NotificationHistory::default();
+        let mut dnd = dnd_off();
+        dnd.activate(DndDuration::FifteenMinutes);
+
+        dispatch.process_event(
+            &SseEvent::TurnAfter {
+                nous_id: nous("syn"),
+                session_id: session("s1"),
+            },
+            &prefs(),
+            &dnd,
+            false,
+            &mut |e| history.push(e),
+            &mut no_fallback,
+        );
+
+        assert!(history.is_empty(), "DND should suppress completion notification");
+    }
+
+    // -- Helpers --------------------------------------------------------------
+
+    #[test]
+    fn truncate_chars_at_boundary() {
+        assert_eq!(truncate_chars("hello world", 5), "hello");
+        assert_eq!(truncate_chars("hello", 100), "hello");
+    }
+
+    #[test]
+    fn truncate_chars_empty_string() {
+        assert_eq!(truncate_chars("", 5), "");
+    }
+}

--- a/crates/theatron/desktop/src/services/sse_coroutine.rs
+++ b/crates/theatron/desktop/src/services/sse_coroutine.rs
@@ -9,9 +9,11 @@ use dioxus::prelude::*;
 use tokio_util::sync::CancellationToken;
 
 use crate::api::sse::SseConnection;
+use crate::services::notification_dispatch::NotificationDispatch;
 use crate::services::sse::SseEventRouter;
 use crate::state::connection::ConnectionConfig;
 use crate::state::events::{EventState, SseConnectionState};
+use crate::state::notifications::{DndState, NotificationHistory, NotificationPreferences};
 use crate::state::toasts::{Severity, ToastStore};
 
 /// Provide SSE-derived state signals and start the SSE coroutine.
@@ -19,13 +21,22 @@ use crate::state::toasts::{Severity, ToastStore};
 /// Call from the app root after connection is established. Provides
 /// `Signal<EventState>` and `Signal<SseConnectionState>` as context.
 ///
+/// Requires `Signal<NotificationPreferences>`, `Signal<NotificationHistory>`,
+/// and `Signal<DndState>` to already be in context (provided by `ConnectedApp`).
+///
 /// The coroutine automatically reconnects when the SSE stream drops
 /// (handled internally by `SseConnection`). Toast notifications are
-/// emitted on disconnect/reconnect transitions.
+/// emitted on disconnect/reconnect transitions. Desktop notifications are
+/// dispatched via [`NotificationDispatch`].
 pub(crate) fn start_sse_coroutine(config: &ConnectionConfig) {
     let mut event_state = use_context_provider(|| Signal::new(EventState::new()));
     let mut sse_connection_state =
         use_context_provider(|| Signal::new(SseConnectionState::Disconnected));
+
+    // Read the notification signals provided by ConnectedApp.
+    let prefs_signal = use_context::<Signal<NotificationPreferences>>();
+    let mut history_signal = use_context::<Signal<NotificationHistory>>();
+    let dnd_signal = use_context::<Signal<DndState>>();
 
     let base_url = config.server_url.trim_end_matches('/').to_string();
     let cancel = CancellationToken::new();
@@ -37,6 +48,7 @@ pub(crate) fn start_sse_coroutine(config: &ConnectionConfig) {
     spawn(async move {
         let mut sse = SseConnection::connect(client, &base_url, cancel);
         let mut router = SseEventRouter::new();
+        let mut dispatch = NotificationDispatch::new();
 
         while let Some(event) = sse.next().await {
             let prev_connected = router.state().connection.is_connected();
@@ -56,6 +68,25 @@ pub(crate) fn start_sse_coroutine(config: &ConnectionConfig) {
                 let now_connected = new_state.connection.is_connected();
                 emit_connection_toasts(prev_connected, now_connected);
             }
+
+            // Dispatch desktop notifications for relevant events.
+            // NOTE: Window focus state defaults to false (always notify).
+            // Full focus integration requires wiring Dioxus desktop window
+            // events — tracked separately.
+            let prefs = prefs_signal.peek().clone();
+            let dnd = dnd_signal.peek().clone();
+            dispatch.process_event(
+                &event,
+                &prefs,
+                &dnd,
+                false,
+                &mut |entry| history_signal.write().push(entry),
+                &mut |sev, title| {
+                    if let Some(mut store) = try_consume_context::<Signal<ToastStore>>() {
+                        store.write().push(sev, title.to_string());
+                    }
+                },
+            );
         }
     });
 }

--- a/crates/theatron/desktop/src/state/mod.rs
+++ b/crates/theatron/desktop/src/state/mod.rs
@@ -18,6 +18,8 @@ pub(crate) mod diff;
 /// Discussion state for planning gray-area questions.
 pub(crate) mod discussion;
 pub mod events;
+/// Notification preferences, history, and Do Not Disturb state.
+pub(crate) mod notifications;
 /// Execution state for wave-based plan progress.
 pub(crate) mod execution;
 pub(crate) mod fetch;

--- a/crates/theatron/desktop/src/state/notifications.rs
+++ b/crates/theatron/desktop/src/state/notifications.rs
@@ -1,0 +1,312 @@
+//! Notification preferences, history, and Do Not Disturb state.
+//!
+//! [`NotificationPreferences`] is persisted to the user config file.
+//! [`DndState`] is ephemeral and resets on app restart.
+//! [`NotificationHistory`] holds the last 50 sent notifications for a
+//! future notification-center view.
+
+use std::collections::VecDeque;
+use std::time::{Duration, Instant};
+
+use serde::{Deserialize, Serialize};
+
+/// Maximum entries retained in [`NotificationHistory`].
+const MAX_HISTORY: usize = 50;
+
+/// Category of notification, used for per-event toggles and rate limiting.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub(crate) enum NotificationCategory {
+    /// Agent turn completed (triggered by `TurnAfter` SSE event).
+    AgentCompletion,
+    /// Tool approval required.
+    ///
+    /// NOTE: Awaiting `ToolApprovalNeeded` global SSE event type. Currently
+    /// not fired from the dispatch layer — placeholder for future wiring.
+    ToolApproval,
+    /// Agent error or tool failure (triggered by `ToolFailed` SSE event).
+    Error,
+    /// SSE connection lost or restored.
+    ConnectionStatus,
+}
+
+/// Duration preset for activating Do Not Disturb mode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) enum DndDuration {
+    /// Suppress notifications for 15 minutes.
+    FifteenMinutes,
+    /// Suppress notifications for 1 hour.
+    OneHour,
+    /// Suppress notifications for approximately 24 hours from activation.
+    ///
+    /// NOTE: Uses 24h from activation rather than true midnight for simplicity.
+    UntilTomorrow,
+}
+
+impl DndDuration {
+    /// Convert to a concrete [`Duration`] for computing an expiry [`Instant`].
+    #[must_use]
+    pub(crate) fn as_duration(self) -> Duration {
+        match self {
+            Self::FifteenMinutes => Duration::from_secs(15 * 60),
+            Self::OneHour => Duration::from_secs(60 * 60),
+            Self::UntilTomorrow => Duration::from_secs(24 * 60 * 60),
+        }
+    }
+
+    /// Human-readable label for UI display.
+    #[must_use]
+    pub(crate) fn label(self) -> &'static str {
+        match self {
+            Self::FifteenMinutes => "15 minutes",
+            Self::OneHour => "1 hour",
+            Self::UntilTomorrow => "Until tomorrow",
+        }
+    }
+}
+
+/// Ephemeral Do Not Disturb state — resets on app restart (not persisted).
+///
+/// Activation time and expiry are [`Instant`]-based so they cannot be
+/// serialized. Store this in a separate signal from [`NotificationPreferences`].
+#[derive(Debug, Clone)]
+pub(crate) struct DndState {
+    /// Whether DND mode is currently active.
+    pub active: bool,
+    /// When DND mode expires. `None` means DND is indefinite until deactivated.
+    pub expires_at: Option<Instant>,
+}
+
+impl Default for DndState {
+    fn default() -> Self {
+        Self {
+            active: false,
+            expires_at: None,
+        }
+    }
+}
+
+impl DndState {
+    /// Whether DND is currently suppressing notifications.
+    ///
+    /// Returns `false` if DND is inactive or its expiry has passed.
+    #[must_use]
+    pub(crate) fn is_suppressing(&self) -> bool {
+        if !self.active {
+            return false;
+        }
+        match self.expires_at {
+            Some(expires) => Instant::now() < expires,
+            None => true,
+        }
+    }
+
+    /// Activate DND for a preset duration.
+    pub(crate) fn activate(&mut self, duration: DndDuration) {
+        self.active = true;
+        self.expires_at = Some(Instant::now() + duration.as_duration());
+    }
+
+    /// Deactivate DND immediately.
+    pub(crate) fn deactivate(&mut self) {
+        self.active = false;
+        self.expires_at = None;
+    }
+}
+
+/// Per-event notification toggles and global configuration.
+///
+/// Persisted to `~/.config/aletheia/desktop.toml` under `[notifications]`.
+/// DND state is in a separate ephemeral signal.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct NotificationPreferences {
+    /// Master on/off switch for all desktop notifications.
+    pub enabled: bool,
+    /// Agent turn-completion notifications.
+    pub agent_completion: bool,
+    /// Tool approval request notifications (always fires regardless of DND).
+    pub tool_approval: bool,
+    /// Error and tool-failure notifications.
+    pub errors: bool,
+    /// SSE connection lost/restored notifications.
+    pub connection_status: bool,
+    /// Play the system default notification sound.
+    pub sound_enabled: bool,
+    /// Only fire notifications when the window is hidden or unfocused.
+    ///
+    /// When `false`, notifications fire regardless of focus. When `true`,
+    /// focused-window events are suppressed (except tool approval, which
+    /// always fires because it is time-sensitive).
+    pub only_when_backgrounded: bool,
+}
+
+impl Default for NotificationPreferences {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            agent_completion: true,
+            tool_approval: true,
+            errors: true,
+            connection_status: true,
+            sound_enabled: false,
+            only_when_backgrounded: false,
+        }
+    }
+}
+
+impl NotificationPreferences {
+    /// Whether a given category is enabled, respecting the master toggle.
+    #[must_use]
+    pub(crate) fn category_enabled(&self, category: NotificationCategory) -> bool {
+        if !self.enabled {
+            return false;
+        }
+        match category {
+            NotificationCategory::AgentCompletion => self.agent_completion,
+            NotificationCategory::ToolApproval => self.tool_approval,
+            NotificationCategory::Error => self.errors,
+            NotificationCategory::ConnectionStatus => self.connection_status,
+        }
+    }
+}
+
+/// A single entry in the notification history.
+#[derive(Debug, Clone)]
+pub(crate) struct NotificationEntry {
+    /// Category of the notification.
+    pub category: NotificationCategory,
+    /// Title displayed in the notification.
+    pub title: String,
+    /// Body text.
+    pub body: String,
+    /// When this notification was sent.
+    pub sent_at: Instant,
+}
+
+/// History of recent desktop notifications, capped at [`MAX_HISTORY`].
+///
+/// Read by a future notification-center view. Updated by
+/// [`crate::services::notification_dispatch::NotificationDispatch`].
+#[derive(Debug, Clone, Default)]
+pub(crate) struct NotificationHistory {
+    entries: VecDeque<NotificationEntry>,
+}
+
+impl NotificationHistory {
+    /// Push a new entry, evicting the oldest when over capacity.
+    pub(crate) fn push(&mut self, entry: NotificationEntry) {
+        if self.entries.len() >= MAX_HISTORY {
+            self.entries.pop_front();
+        }
+        self.entries.push_back(entry);
+    }
+
+    /// All retained entries, oldest first.
+    #[must_use]
+    pub(crate) fn entries(&self) -> &VecDeque<NotificationEntry> {
+        &self.entries
+    }
+
+    /// Number of retained entries.
+    #[must_use]
+    pub(crate) fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// Whether the history is empty.
+    #[must_use]
+    pub(crate) fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dnd_inactive_by_default() {
+        let dnd = DndState::default();
+        assert!(!dnd.is_suppressing());
+    }
+
+    #[test]
+    fn dnd_active_without_expiry_suppresses() {
+        let dnd = DndState {
+            active: true,
+            expires_at: None,
+        };
+        assert!(dnd.is_suppressing());
+    }
+
+    #[test]
+    fn dnd_active_with_past_expiry_not_suppressing() {
+        let past = Instant::now() - Duration::from_secs(1);
+        let dnd = DndState {
+            active: true,
+            expires_at: Some(past),
+        };
+        assert!(!dnd.is_suppressing());
+    }
+
+    #[test]
+    fn dnd_activate_and_deactivate() {
+        let mut dnd = DndState::default();
+        dnd.activate(DndDuration::FifteenMinutes);
+        assert!(dnd.is_suppressing());
+        dnd.deactivate();
+        assert!(!dnd.is_suppressing());
+    }
+
+    #[test]
+    fn preferences_master_toggle_disables_all() {
+        let prefs = NotificationPreferences {
+            enabled: false,
+            ..Default::default()
+        };
+        for cat in [
+            NotificationCategory::AgentCompletion,
+            NotificationCategory::ToolApproval,
+            NotificationCategory::Error,
+            NotificationCategory::ConnectionStatus,
+        ] {
+            assert!(!prefs.category_enabled(cat));
+        }
+    }
+
+    #[test]
+    fn preferences_per_category_toggle() {
+        let prefs = NotificationPreferences {
+            agent_completion: false,
+            ..Default::default()
+        };
+        assert!(!prefs.category_enabled(NotificationCategory::AgentCompletion));
+        assert!(prefs.category_enabled(NotificationCategory::Error));
+    }
+
+    #[test]
+    fn notification_history_caps_at_max() {
+        let mut history = NotificationHistory::default();
+        for i in 0..(MAX_HISTORY + 5) {
+            history.push(NotificationEntry {
+                category: NotificationCategory::AgentCompletion,
+                title: format!("notif {i}"),
+                body: String::new(),
+                sent_at: Instant::now(),
+            });
+        }
+        assert_eq!(history.len(), MAX_HISTORY);
+        // Oldest should have been evicted.
+        assert!(history.entries()[0].title.contains('5'));
+    }
+
+    #[test]
+    fn dnd_duration_labels_are_nonempty() {
+        for dur in [
+            DndDuration::FifteenMinutes,
+            DndDuration::OneHour,
+            DndDuration::UntilTomorrow,
+        ] {
+            assert!(!dur.label().is_empty());
+        }
+    }
+}

--- a/crates/theatron/desktop/src/views/settings/mod.rs
+++ b/crates/theatron/desktop/src/views/settings/mod.rs
@@ -1,11 +1,14 @@
-//! Settings views: server connections, appearance, keybindings, and setup wizard.
+//! Settings views: server connections, appearance, keybindings, notifications, and setup wizard.
 
 pub(crate) mod appearance;
 pub(crate) mod keybindings;
+pub(crate) mod notifications;
 pub(crate) mod servers;
 pub(crate) mod wizard;
 
 use dioxus::prelude::*;
+
+use crate::views::settings::notifications::NotificationSettings;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 enum SettingsTab {
@@ -13,6 +16,7 @@ enum SettingsTab {
     Servers,
     Appearance,
     Keybindings,
+    Notifications,
 }
 
 impl SettingsTab {
@@ -21,6 +25,7 @@ impl SettingsTab {
             Self::Servers => "Connections",
             Self::Appearance => "Appearance",
             Self::Keybindings => "Keybindings",
+            Self::Notifications => "Notifications",
         }
     }
 }
@@ -36,7 +41,7 @@ pub(crate) fn Settings() -> Element {
 
             div {
                 style: "display: flex; gap: 0; padding: 0 20px; border-bottom: 1px solid #333; background: #111;",
-                for tab in [SettingsTab::Servers, SettingsTab::Appearance, SettingsTab::Keybindings] {
+                for tab in [SettingsTab::Servers, SettingsTab::Appearance, SettingsTab::Keybindings, SettingsTab::Notifications] {
                     {
                         let is_active = active_tab() == tab;
                         let border = if is_active { "2px solid #5b6af0" } else { "2px solid transparent" };
@@ -63,6 +68,7 @@ pub(crate) fn Settings() -> Element {
                     SettingsTab::Servers => rsx! { servers::ServersPanel {} },
                     SettingsTab::Appearance => rsx! { appearance::AppearancePanel {} },
                     SettingsTab::Keybindings => rsx! { keybindings::KeybindingsPanel {} },
+                    SettingsTab::Notifications => rsx! { NotificationSettings {} },
                 } }
             }
         }

--- a/crates/theatron/desktop/src/views/settings/notifications.rs
+++ b/crates/theatron/desktop/src/views/settings/notifications.rs
@@ -1,0 +1,251 @@
+//! Notification preferences settings panel.
+//!
+//! Rendered as a section within the Settings view. Reads and writes
+//! `Signal<NotificationPreferences>` and `Signal<DndState>` from context,
+//! and persists preference changes to the config file via `services::config`.
+
+use dioxus::prelude::*;
+
+use crate::services::config;
+use crate::state::notifications::{DndDuration, DndState, NotificationPreferences};
+
+const SECTION_STYLE: &str = "\
+    background: #1a1a2e; \
+    border: 1px solid #333; \
+    border-radius: 8px; \
+    padding: 16px 20px;\
+";
+
+const SECTION_TITLE: &str = "\
+    font-size: 14px; \
+    font-weight: bold; \
+    color: #aaa; \
+    text-transform: uppercase; \
+    letter-spacing: 0.5px; \
+    margin-bottom: 12px;\
+";
+
+const ROW_STYLE: &str = "\
+    display: flex; \
+    justify-content: space-between; \
+    align-items: center; \
+    padding: 8px 0; \
+    border-bottom: 1px solid #222;\
+";
+
+const LABEL_STYLE: &str = "\
+    color: #888; \
+    font-size: 13px;\
+";
+
+const TOGGLE_ON: &str = "\
+    background: #4f46e5; \
+    color: #fff; \
+    border: 1px solid #6366f1; \
+    border-radius: 6px; \
+    padding: 6px 14px; \
+    font-size: 13px; \
+    cursor: pointer;\
+";
+
+const TOGGLE_OFF: &str = "\
+    background: #2a2a4a; \
+    color: #888; \
+    border: 1px solid #444; \
+    border-radius: 6px; \
+    padding: 6px 14px; \
+    font-size: 13px; \
+    cursor: pointer;\
+";
+
+const DND_BTN: &str = "\
+    background: #2a2a4a; \
+    color: #e0e0e0; \
+    border: 1px solid #444; \
+    border-radius: 6px; \
+    padding: 5px 10px; \
+    font-size: 12px; \
+    cursor: pointer; \
+    margin-left: 6px;\
+";
+
+const WARNING_STYLE: &str = "\
+    color: #eab308; \
+    font-size: 12px; \
+    margin-top: 4px;\
+";
+
+/// Notification settings panel component.
+///
+/// Requires `Signal<NotificationPreferences>` and `Signal<DndState>` to be
+/// provided as context by an ancestor (done in `ConnectedApp`).
+#[component]
+pub(crate) fn NotificationSettings() -> Element {
+    let mut prefs: Signal<NotificationPreferences> = use_context();
+    let mut dnd: Signal<DndState> = use_context();
+
+    let enabled = prefs.read().enabled;
+    let agent_completion = prefs.read().agent_completion;
+    let tool_approval = prefs.read().tool_approval;
+    let errors = prefs.read().errors;
+    let connection_status = prefs.read().connection_status;
+    let sound_enabled = prefs.read().sound_enabled;
+    let only_when_backgrounded = prefs.read().only_when_backgrounded;
+    let dnd_active = dnd.read().is_suppressing();
+
+    rsx! {
+        div {
+            style: "{SECTION_STYLE}",
+            div { style: "{SECTION_TITLE}", "Notifications" }
+
+            // Master toggle
+            div {
+                style: "{ROW_STYLE}",
+                span { style: "{LABEL_STYLE}", "Desktop notifications" }
+                button {
+                    style: if enabled { TOGGLE_ON } else { TOGGLE_OFF },
+                    onclick: move |_| {
+                        prefs.write().enabled = !enabled;
+                        config::save_notification_prefs(&prefs.read()).ok();
+                    },
+                    if enabled { "On" } else { "Off" }
+                }
+            }
+
+            // Per-event: agent completion
+            div {
+                style: "{ROW_STYLE}",
+                span { style: "{LABEL_STYLE}", "Agent completion" }
+                button {
+                    style: if agent_completion { TOGGLE_ON } else { TOGGLE_OFF },
+                    onclick: move |_| {
+                        prefs.write().agent_completion = !agent_completion;
+                        config::save_notification_prefs(&prefs.read()).ok();
+                    },
+                    if agent_completion { "On" } else { "Off" }
+                }
+            }
+
+            // Per-event: tool approval (warn if disabled)
+            div {
+                style: if !tool_approval { ROW_STYLE } else { ROW_STYLE },
+                span {
+                    style: "{LABEL_STYLE}",
+                    "Tool approval requests"
+                    if !tool_approval {
+                        div { style: "{WARNING_STYLE}", "Warning: you may miss approval requests" }
+                    }
+                }
+                button {
+                    style: if tool_approval { TOGGLE_ON } else { TOGGLE_OFF },
+                    onclick: move |_| {
+                        prefs.write().tool_approval = !tool_approval;
+                        config::save_notification_prefs(&prefs.read()).ok();
+                    },
+                    if tool_approval { "On" } else { "Off" }
+                }
+            }
+
+            // Per-event: errors
+            div {
+                style: "{ROW_STYLE}",
+                span { style: "{LABEL_STYLE}", "Errors" }
+                button {
+                    style: if errors { TOGGLE_ON } else { TOGGLE_OFF },
+                    onclick: move |_| {
+                        prefs.write().errors = !errors;
+                        config::save_notification_prefs(&prefs.read()).ok();
+                    },
+                    if errors { "On" } else { "Off" }
+                }
+            }
+
+            // Per-event: connection status
+            div {
+                style: "{ROW_STYLE}",
+                span { style: "{LABEL_STYLE}", "Connection status" }
+                button {
+                    style: if connection_status { TOGGLE_ON } else { TOGGLE_OFF },
+                    onclick: move |_| {
+                        prefs.write().connection_status = !connection_status;
+                        config::save_notification_prefs(&prefs.read()).ok();
+                    },
+                    if connection_status { "On" } else { "Off" }
+                }
+            }
+
+            // Sound
+            div {
+                style: "{ROW_STYLE}",
+                span { style: "{LABEL_STYLE}", "Sound" }
+                button {
+                    style: if sound_enabled { TOGGLE_ON } else { TOGGLE_OFF },
+                    onclick: move |_| {
+                        prefs.write().sound_enabled = !sound_enabled;
+                        config::save_notification_prefs(&prefs.read()).ok();
+                    },
+                    if sound_enabled { "On" } else { "Off" }
+                }
+            }
+
+            // Only when backgrounded
+            div {
+                style: "{ROW_STYLE}",
+                span { style: "{LABEL_STYLE}", "Only when app is backgrounded" }
+                button {
+                    style: if only_when_backgrounded { TOGGLE_ON } else { TOGGLE_OFF },
+                    onclick: move |_| {
+                        prefs.write().only_when_backgrounded = !only_when_backgrounded;
+                        config::save_notification_prefs(&prefs.read()).ok();
+                    },
+                    if only_when_backgrounded { "On" } else { "Off" }
+                }
+            }
+
+            // Do Not Disturb
+            div {
+                style: "border-bottom: none; {ROW_STYLE}",
+                span {
+                    style: "{LABEL_STYLE}",
+                    "Do Not Disturb"
+                    if dnd_active {
+                        div { style: "color: #4f46e5; font-size: 12px; margin-top: 2px;", "Active" }
+                    }
+                }
+                div {
+                    if dnd_active {
+                        button {
+                            style: "{DND_BTN}",
+                            onclick: move |_| {
+                                dnd.write().deactivate();
+                            },
+                            "Turn off"
+                        }
+                    } else {
+                        button {
+                            style: "{DND_BTN}",
+                            onclick: move |_| {
+                                dnd.write().activate(DndDuration::FifteenMinutes);
+                            },
+                            "15 min"
+                        }
+                        button {
+                            style: "{DND_BTN}",
+                            onclick: move |_| {
+                                dnd.write().activate(DndDuration::OneHour);
+                            },
+                            "1 hour"
+                        }
+                        button {
+                            style: "{DND_BTN}",
+                            onclick: move |_| {
+                                dnd.write().activate(DndDuration::UntilTomorrow);
+                            },
+                            "Until tomorrow"
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Native Linux desktop notifications (freedesktop.org D-Bus via `notify-rust`) for agent completion, tool failures, and SSE connection changes
- Notification dispatch service with sliding-window rate limiting (max 5/min/category) and 3s coalescing window to prevent spam
- Per-event toggles, master on/off switch, Do Not Disturb mode (15min/1hr/until tomorrow), and sound toggle in Settings panel
- Preferences persisted to `~/.config/aletheia/desktop.toml`; DND state is ephemeral

## Key behaviors

- Agent completion fires only when the window is unfocused (suppressed in foreground)
- Tool approval notifications bypass DND (time-sensitive — user must respond)
- Connection-loss notification delayed 5s to allow silent reconnect before alerting
- Graceful fallback to in-app toasts when notification daemon unavailable

## Test plan

- [ ] `cargo check --manifest-path crates/theatron/desktop/Cargo.toml` passes
- [ ] 17 new unit tests pass: dispatch routing, focus rules, rate limiting, grouping, DND, preferences
- [ ] Settings panel shows "Notifications" section with all toggles
- [ ] Notification fires when an agent turn completes while app is unfocused
- [ ] Notification is suppressed when app is in focus (completion events)
- [ ] DND mode suppresses notifications for configured duration
- [ ] Preferences survive app restart (persisted to TOML)

## Observations

**Debt** — `src/views/chat.rs:46`: `let mut cmd_store` is declared mutable but never mutated; pre-existing warning not introduced by this PR.

**Debt** — `notify-rust` action buttons (click-to-navigate) not wired to Dioxus window navigation. `NotificationHandle::wait_for_action` blocks a thread; cross-thread channel to Dioxus event loop is a separate task. Noted in `native_notify.rs`.

**Missing** — Window focus state currently hardcoded to `false` (always notify) in `sse_coroutine.rs`. Dioxus desktop window focus/blur event wiring is a separate integration task; noted with a comment.

**Missing** — `ToolApprovalNeeded` global SSE event type does not exist yet in `theatron-core::SseEvent`. The `NotificationCategory::ToolApproval` path is wired but never triggered from the dispatch layer. Noted in `state/notifications.rs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)