### PR TITLE
feat(theatron-desktop): tool usage stats — frequency, rates, duration, drill-down

### DIFF
--- a/crates/theatron/desktop/src/app.rs
+++ b/crates/theatron/desktop/src/app.rs
@@ -8,18 +8,20 @@ use dioxus::prelude::*;
 
 use crate::layout::Layout;
 use crate::platform;
-use crate::services::{config, settings_config};
 use crate::services::toast::provide_toast_context;
+use crate::services::{config, settings_config};
 use crate::state::agents::AgentStore;
 use crate::state::connection::ConnectionState;
 use crate::state::notifications::{DndState, NotificationHistory};
 use crate::state::platform::{CloseBehavior, HotkeyState, QuickInputState, TrayState, WindowState};
+use crate::state::tool_metrics::DateRange;
 use crate::theme::ThemeProvider;
 use crate::views::chat::Chat;
 use crate::views::connect::ConnectView;
 use crate::views::files::Files;
 use crate::views::memory::Memory;
 use crate::views::metrics::Metrics;
+use crate::views::metrics::tool_detail::ToolDetailView;
 use crate::views::ops::Ops;
 use crate::views::planning::{Planning, PlanningProject};
 use crate::views::sessions::Sessions;
@@ -42,12 +44,35 @@ pub(crate) enum Route {
         Memory {},
         #[route("/metrics")]
         Metrics {},
+        #[route("/metrics/tools/:tool_name")]
+        MetricsToolDetail { tool_name: String },
         #[route("/ops")]
         Ops {},
         #[route("/sessions")]
         Sessions {},
         #[route("/settings")]
         Settings {},
+}
+
+/// Route component for `/metrics/tools/:tool_name`.
+///
+/// Wraps `ToolDetailView` so the tool drill-down is accessible via URL.
+#[component]
+fn MetricsToolDetail(tool_name: String) -> Element {
+    let nav = use_navigator();
+    rsx! {
+        div {
+            style: "\
+                display: flex; flex-direction: column; \
+                height: 100%; padding: 24px; gap: 16px; \
+                overflow-y: auto;",
+            ToolDetailView {
+                tool_name,
+                date_range: DateRange::default(),
+                on_back: move |_| { nav.push(Route::Metrics {}); },
+            }
+        }
+    }
 }
 
 /// Root component.

--- a/crates/theatron/desktop/src/components/chart.rs
+++ b/crates/theatron/desktop/src/components/chart.rs
@@ -1,0 +1,605 @@
+//! SVG chart primitives for metrics views.
+//!
+//! All charts render as inline SVG with inline styles. No external charting
+//! library is required. The API is designed to be compatible with chart usage
+//! in future metrics views (prompt 114 token/cost charts).
+
+use dioxus::prelude::*;
+
+// -- Shared palette -----------------------------------------------------------
+
+pub(crate) const COLOR_SUCCESS: &str = "#22c55e";
+pub(crate) const COLOR_FAILURE: &str = "#ef4444";
+pub(crate) const COLOR_PRIMARY: &str = "#4a4aff";
+pub(crate) const COLOR_MUTED: &str = "#555";
+pub(crate) const COLOR_TEXT: &str = "#e0e0e0";
+pub(crate) const COLOR_TEXT_DIM: &str = "#888";
+pub(crate) const COLOR_WARN: &str = "#eab308";
+
+/// Ten-color sequential palette for multi-series charts.
+pub(crate) const SERIES_COLORS: &[&str] = &[
+    "#4a4aff", "#22c55e", "#eab308", "#ef4444", "#06b6d4", "#a855f7", "#f97316", "#ec4899",
+    "#84cc16", "#14b8a6",
+];
+
+// -- Bar entry ----------------------------------------------------------------
+
+/// A single labeled value for bar charts.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct BarEntry {
+    pub label: String,
+    pub value: u64,
+    /// Optional hex color override. Falls back to `COLOR_PRIMARY`.
+    pub color: Option<String>,
+}
+
+// -- Horizontal bar chart -----------------------------------------------------
+
+/// Horizontal bar chart: tool name on the left, bar extending right, value label on right.
+///
+/// Height auto-sizes to `entries.len() * ROW_HEIGHT + PADDING`.
+#[component]
+pub(crate) fn HorizontalBarChart(
+    entries: Vec<BarEntry>,
+    /// If `None`, the maximum entry value is used.
+    max_value: Option<u64>,
+    /// Called with the entry label when a bar is clicked.
+    on_click: Option<EventHandler<String>>,
+) -> Element {
+    const LABEL_W: u64 = 130;
+    const VALUE_W: u64 = 50;
+    const ROW_H: u64 = 26;
+    const PAD_TOP: u64 = 8;
+    const TOTAL_W: u64 = 600;
+    const BAR_AREA: u64 = TOTAL_W - LABEL_W - VALUE_W;
+
+    let n = entries.len() as u64;
+    let chart_h = n * ROW_H + PAD_TOP * 2;
+
+    let effective_max =
+        max_value.unwrap_or_else(|| entries.iter().map(|e| e.value).max().unwrap_or(1).max(1));
+
+    rsx! {
+        svg {
+            width: "100%",
+            view_box: "0 0 {TOTAL_W} {chart_h}",
+            style: "display: block; overflow: visible;",
+
+            for (i, entry) in entries.iter().enumerate() {
+                {
+                    let y = PAD_TOP + i as u64 * ROW_H;
+                    let bar_w = (entry.value * BAR_AREA) / effective_max;
+                    let color = entry.color.as_deref().unwrap_or(COLOR_PRIMARY);
+                    let label = entry.label.clone();
+                    let clickable = on_click.is_some();
+                    let cursor = if clickable { "pointer" } else { "default" };
+
+                    rsx! {
+                        g {
+                            key: "{label}",
+                            style: "cursor: {cursor};",
+                            onclick: {
+                                let label = label.clone();
+                                let on_click = on_click.clone();
+                                move |_| {
+                                    if let Some(ref handler) = on_click {
+                                        handler.call(label.clone());
+                                    }
+                                }
+                            },
+
+                            // Label
+                            text {
+                                x: "0",
+                                y: "{y + ROW_H - 8}",
+                                fill: COLOR_TEXT,
+                                font_size: "12",
+                                font_family: "monospace",
+                                text_anchor: "start",
+                                "{truncate_label(&label, 18)}"
+                            }
+
+                            // Bar background
+                            rect {
+                                x: "{LABEL_W}",
+                                y: "{y + 4}",
+                                width: "{BAR_AREA}",
+                                height: "{ROW_H - 10}",
+                                fill: "#1a1a2e",
+                                rx: "3",
+                            }
+
+                            // Bar fill
+                            if bar_w > 0 {
+                                rect {
+                                    x: "{LABEL_W}",
+                                    y: "{y + 4}",
+                                    width: "{bar_w}",
+                                    height: "{ROW_H - 10}",
+                                    fill: color,
+                                    rx: "3",
+                                }
+                            }
+
+                            // Value label
+                            text {
+                                x: "{LABEL_W + BAR_AREA + 6}",
+                                y: "{y + ROW_H - 8}",
+                                fill: COLOR_TEXT_DIM,
+                                font_size: "11",
+                                font_family: "monospace",
+                                "{entry.value}"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+// -- Stacked horizontal bar ---------------------------------------------------
+
+/// One entry for the stacked bar chart.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct StackedBarEntry {
+    pub label: String,
+    pub success: u64,
+    pub failure: u64,
+}
+
+/// Horizontal stacked bar chart: success (green) + failure (red) per tool.
+///
+/// Sorted by `failure` descending inside the component if `sort_by_failure` is true.
+#[component]
+pub(crate) fn StackedBarChart(
+    entries: Vec<StackedBarEntry>,
+    sort_by_failure: bool,
+    on_click: Option<EventHandler<String>>,
+) -> Element {
+    const LABEL_W: u64 = 130;
+    const ROW_H: u64 = 26;
+    const PAD_TOP: u64 = 8;
+    const TOTAL_W: u64 = 600;
+    const BAR_AREA: u64 = TOTAL_W - LABEL_W - 60;
+
+    let mut sorted = entries.clone();
+    if sort_by_failure {
+        sorted.sort_by(|a, b| b.failure.cmp(&a.failure));
+    }
+
+    let n = sorted.len() as u64;
+    let chart_h = n * ROW_H + PAD_TOP * 2;
+
+    let max_total = sorted
+        .iter()
+        .map(|e| e.success + e.failure)
+        .max()
+        .unwrap_or(1)
+        .max(1);
+
+    rsx! {
+        svg {
+            width: "100%",
+            view_box: "0 0 {TOTAL_W} {chart_h}",
+            style: "display: block; overflow: visible;",
+
+            for (i, entry) in sorted.iter().enumerate() {
+                {
+                    let y = PAD_TOP + i as u64 * ROW_H;
+                    let total = entry.success + entry.failure;
+                    let success_w = (entry.success * BAR_AREA) / max_total;
+                    let failure_w = (entry.failure * BAR_AREA) / max_total;
+                    let label = entry.label.clone();
+                    let clickable = on_click.is_some();
+                    let cursor = if clickable { "pointer" } else { "default" };
+                    let pct_fail = if total > 0 { entry.failure * 100 / total } else { 0 };
+
+                    rsx! {
+                        g {
+                            key: "{label}",
+                            style: "cursor: {cursor};",
+                            onclick: {
+                                let label = label.clone();
+                                let on_click = on_click.clone();
+                                move |_| {
+                                    if let Some(ref handler) = on_click {
+                                        handler.call(label.clone());
+                                    }
+                                }
+                            },
+
+                            text {
+                                x: "0",
+                                y: "{y + ROW_H - 8}",
+                                fill: COLOR_TEXT,
+                                font_size: "12",
+                                font_family: "monospace",
+                                "{truncate_label(&label, 18)}"
+                            }
+
+                            // Background
+                            rect {
+                                x: "{LABEL_W}",
+                                y: "{y + 4}",
+                                width: "{BAR_AREA}",
+                                height: "{ROW_H - 10}",
+                                fill: "#1a1a2e",
+                                rx: "3",
+                            }
+
+                            // Success segment
+                            if success_w > 0 {
+                                rect {
+                                    x: "{LABEL_W}",
+                                    y: "{y + 4}",
+                                    width: "{success_w}",
+                                    height: "{ROW_H - 10}",
+                                    fill: COLOR_SUCCESS,
+                                    rx: "3",
+                                }
+                            }
+
+                            // Failure segment
+                            if failure_w > 0 {
+                                rect {
+                                    x: "{LABEL_W + success_w}",
+                                    y: "{y + 4}",
+                                    width: "{failure_w}",
+                                    height: "{ROW_H - 10}",
+                                    fill: COLOR_FAILURE,
+                                    rx: "3",
+                                }
+                            }
+
+                            // Failure % label
+                            text {
+                                x: "{LABEL_W + BAR_AREA + 6}",
+                                y: "{y + ROW_H - 8}",
+                                fill: if pct_fail > 50 { COLOR_FAILURE } else if pct_fail > 20 { COLOR_WARN } else { COLOR_TEXT_DIM },
+                                font_size: "11",
+                                font_family: "monospace",
+                                "{pct_fail}% fail"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+// -- Line chart ---------------------------------------------------------------
+
+/// A single data point in a line series.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct LinePoint {
+    pub label: String,
+    pub value: f64,
+}
+
+/// A single named series.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct LineSeries {
+    pub name: String,
+    pub color: String,
+    pub points: Vec<LinePoint>,
+}
+
+/// Line chart for time-series data. Supports multiple series.
+///
+/// X labels are drawn from the first series's point labels.
+#[component]
+pub(crate) fn LineChart(series: Vec<LineSeries>, height: u32) -> Element {
+    const PAD_L: f64 = 40.0;
+    const PAD_R: f64 = 10.0;
+    const PAD_TOP: f64 = 10.0;
+    const PAD_BOT: f64 = 24.0;
+    const TOTAL_W: f64 = 580.0;
+
+    if series.is_empty() || series[0].points.is_empty() {
+        return rsx! {
+            div {
+                style: "color: #555; font-size: 12px; padding: 8px;",
+                "No data"
+            }
+        };
+    }
+
+    let chart_h = height as f64;
+    let plot_w = TOTAL_W - PAD_L - PAD_R;
+    let plot_h = chart_h - PAD_TOP - PAD_BOT;
+
+    let all_values: Vec<f64> = series
+        .iter()
+        .flat_map(|s| s.points.iter().map(|p| p.value))
+        .collect();
+    let max_val = all_values
+        .iter()
+        .cloned()
+        .fold(f64::NEG_INFINITY, f64::max)
+        .max(1.0);
+
+    let n_points = series[0].points.len();
+    let step = if n_points > 1 {
+        plot_w / (n_points - 1) as f64
+    } else {
+        plot_w
+    };
+
+    rsx! {
+        svg {
+            width: "100%",
+            view_box: "0 0 {TOTAL_W} {chart_h}",
+            style: "display: block;",
+
+            // Y-axis gridlines
+            for tick in 0..=4u32 {
+                {
+                    let y = PAD_TOP + plot_h * (1.0 - tick as f64 / 4.0);
+                    let val = max_val * tick as f64 / 4.0;
+                    rsx! {
+                        g {
+                            key: "tick-{tick}",
+                            line {
+                                x1: "{PAD_L}",
+                                y1: "{y}",
+                                x2: "{TOTAL_W - PAD_R}",
+                                y2: "{y}",
+                                stroke: "#222",
+                                stroke_width: "1",
+                            }
+                            text {
+                                x: "{PAD_L - 4.0}",
+                                y: "{y + 4.0}",
+                                fill: COLOR_TEXT_DIM,
+                                font_size: "10",
+                                text_anchor: "end",
+                                "{format_axis_val(val)}"
+                            }
+                        }
+                    }
+                }
+            }
+
+            // X labels (every ~nth point to avoid crowding)
+            for (i, pt) in series[0].points.iter().enumerate() {
+                if should_show_x_label(i, n_points) {
+                    {
+                        let x = PAD_L + i as f64 * step;
+                        let label = pt.label.clone();
+                        rsx! {
+                            text {
+                                key: "xlabel-{i}",
+                                x: "{x}",
+                                y: "{chart_h - 4.0}",
+                                fill: COLOR_TEXT_DIM,
+                                font_size: "9",
+                                text_anchor: "middle",
+                                "{truncate_label(&label, 8)}"
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Series lines
+            for (si, s) in series.iter().enumerate() {
+                {
+                    let points_str: String = s
+                        .points
+                        .iter()
+                        .enumerate()
+                        .map(|(i, p)| {
+                            let x = PAD_L + i as f64 * step;
+                            let y = PAD_TOP + plot_h * (1.0 - p.value / max_val);
+                            format!("{x:.1},{y:.1}")
+                        })
+                        .collect::<Vec<_>>()
+                        .join(" ");
+                    rsx! {
+                        polyline {
+                            key: "series-{si}",
+                            points: "{points_str}",
+                            fill: "none",
+                            stroke: "{s.color}",
+                            stroke_width: "2",
+                        }
+                    }
+                }
+            }
+
+            // Legend
+            for (si, s) in series.iter().enumerate() {
+                {
+                    let lx = PAD_L + si as f64 * 100.0;
+                    let ly = PAD_TOP - 2.0;
+                    let name = truncate_label(&s.name, 12);
+                    rsx! {
+                        g { key: "legend-{si}",
+                            rect {
+                                x: "{lx}",
+                                y: "{ly}",
+                                width: "12",
+                                height: "4",
+                                fill: "{s.color}",
+                            }
+                            text {
+                                x: "{lx + 14.0}",
+                                y: "{ly + 4.0}",
+                                fill: COLOR_TEXT_DIM,
+                                font_size: "9",
+                                "{name}"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+// -- Percentile bar -----------------------------------------------------------
+
+/// A single tool's percentile distribution for the percentile bar chart.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct PercentileEntry {
+    pub label: String,
+    pub min_ms: u64,
+    pub p25_ms: u64,
+    pub p50_ms: u64,
+    pub p75_ms: u64,
+    pub p95_ms: u64,
+    pub max_ms: u64,
+}
+
+/// Horizontal percentile bars showing distribution of execution times.
+///
+/// Each row renders: whiskers (min—max), IQR box (p25—p75), median marker.
+#[component]
+pub(crate) fn PercentileBarChart(entries: Vec<PercentileEntry>) -> Element {
+    const LABEL_W: u64 = 130;
+    const ROW_H: u64 = 32;
+    const PAD_TOP: u64 = 8;
+    const TOTAL_W: u64 = 600;
+    const BAR_AREA: u64 = TOTAL_W - LABEL_W - 60;
+
+    let n = entries.len() as u64;
+    let chart_h = n * ROW_H + PAD_TOP * 2;
+
+    let scale_max = entries.iter().map(|e| e.p95_ms).max().unwrap_or(1).max(1);
+
+    rsx! {
+        svg {
+            width: "100%",
+            view_box: "0 0 {TOTAL_W} {chart_h}",
+            style: "display: block; overflow: visible;",
+
+            for (i, entry) in entries.iter().enumerate() {
+                {
+                    let y = PAD_TOP + i as u64 * ROW_H;
+                    let cy = y + ROW_H / 2;
+
+                    let x = |ms: u64| -> u64 {
+                        LABEL_W + (ms.min(scale_max) * BAR_AREA) / scale_max
+                    };
+
+                    let x_min = x(entry.min_ms);
+                    let x_p25 = x(entry.p25_ms);
+                    let x_p50 = x(entry.p50_ms);
+                    let x_p75 = x(entry.p75_ms);
+                    let x_p95 = x(entry.p95_ms);
+                    let label = entry.label.clone();
+                    let p95_color = if entry.p95_ms > 10_000 { COLOR_FAILURE }
+                        else if entry.p95_ms > 5_000 { COLOR_WARN }
+                        else { COLOR_SUCCESS };
+
+                    rsx! {
+                        g { key: "{label}",
+                            // Tool label
+                            text {
+                                x: "0",
+                                y: "{cy + 4}",
+                                fill: COLOR_TEXT,
+                                font_size: "12",
+                                font_family: "monospace",
+                                "{truncate_label(&label, 18)}"
+                            }
+
+                            // Whisker line (min to p95)
+                            line {
+                                x1: "{x_min}",
+                                y1: "{cy}",
+                                x2: "{x_p95}",
+                                y2: "{cy}",
+                                stroke: COLOR_MUTED,
+                                stroke_width: "1",
+                            }
+
+                            // IQR box (p25 to p75)
+                            rect {
+                                x: "{x_p25}",
+                                y: "{cy - 6}",
+                                width: "{x_p75.saturating_sub(x_p25)}",
+                                height: "12",
+                                fill: p95_color,
+                                fill_opacity: "0.3",
+                                stroke: p95_color,
+                                stroke_width: "1",
+                                rx: "2",
+                            }
+
+                            // Median marker
+                            line {
+                                x1: "{x_p50}",
+                                y1: "{cy - 7}",
+                                x2: "{x_p50}",
+                                y2: "{cy + 7}",
+                                stroke: p95_color,
+                                stroke_width: "2",
+                            }
+
+                            // Min tick
+                            line {
+                                x1: "{x_min}",
+                                y1: "{cy - 4}",
+                                x2: "{x_min}",
+                                y2: "{cy + 4}",
+                                stroke: COLOR_MUTED,
+                                stroke_width: "1",
+                            }
+
+                            // p95 label
+                            text {
+                                x: "{x_p95 + 4}",
+                                y: "{cy + 4}",
+                                fill: p95_color,
+                                font_size: "10",
+                                font_family: "monospace",
+                                "p95:{format_ms_short(entry.p95_ms)}"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+// -- Internal helpers ---------------------------------------------------------
+
+fn truncate_label(label: &str, max_chars: usize) -> String {
+    if label.len() <= max_chars {
+        label.to_string()
+    } else {
+        format!("{}…", &label[..max_chars.saturating_sub(1)])
+    }
+}
+
+fn format_axis_val(val: f64) -> String {
+    if val >= 1_000_000.0 {
+        format!("{:.0}M", val / 1_000_000.0)
+    } else if val >= 1_000.0 {
+        format!("{:.0}K", val / 1_000.0)
+    } else if val > 0.0 {
+        format!("{val:.0}")
+    } else {
+        String::new()
+    }
+}
+
+fn format_ms_short(ms: u64) -> String {
+    if ms >= 1_000 {
+        format!("{:.1}s", ms as f64 / 1_000.0) // kanon:ignore RUST/as-cast
+    } else {
+        format!("{ms}ms")
+    }
+}
+
+fn should_show_x_label(i: usize, n: usize) -> bool {
+    if n <= 7 {
+        return true;
+    }
+    let step = n / 6;
+    i == 0 || i == n - 1 || i % step == 0
+}

--- a/crates/theatron/desktop/src/components/mod.rs
+++ b/crates/theatron/desktop/src/components/mod.rs
@@ -1,6 +1,8 @@
 //! Dioxus components for the streaming chat interface.
 
 pub mod agent_sidebar;
+/// SVG chart primitives: horizontal bars, stacked bars, line charts, percentile bars.
+pub(crate) mod chart;
 pub mod chat;
 pub(crate) mod checkpoint_card;
 pub(crate) mod code_block;

--- a/crates/theatron/desktop/src/state/mod.rs
+++ b/crates/theatron/desktop/src/state/mod.rs
@@ -48,3 +48,5 @@ pub(crate) mod verification;
 pub(crate) mod ops;
 /// Settings state: server configs, appearance, keybindings, wizard flow.
 pub(crate) mod settings;
+/// Tool usage metrics: aggregated stats, stores, and helpers.
+pub(crate) mod tool_metrics;

--- a/crates/theatron/desktop/src/state/tool_metrics.rs
+++ b/crates/theatron/desktop/src/state/tool_metrics.rs
@@ -1,0 +1,395 @@
+//! Tool usage metrics state: aggregated stats, stores, and helpers.
+
+use std::collections::HashMap;
+
+use crate::state::fetch::FetchState;
+
+// -- API response types -------------------------------------------------------
+
+/// Top-level response from `/api/tool-stats`.
+///
+/// All fields use `#[serde(default)]` so partial responses degrade gracefully
+/// whether the server returns pre-aggregated stats or raw invocation logs.
+#[derive(Debug, Clone, Default, PartialEq, serde::Deserialize)]
+pub(crate) struct ToolStatsResponse {
+    #[serde(default)]
+    pub summary: ToolSummary,
+    #[serde(default)]
+    pub tools: Vec<ToolStat>,
+    #[serde(default)]
+    pub time_series: Vec<TimeSeriesBucket>,
+    #[serde(default)]
+    pub invocations: Vec<ToolInvocation>,
+}
+
+/// Aggregate summary values for summary cards.
+#[derive(Debug, Clone, Default, PartialEq, serde::Deserialize)]
+pub(crate) struct ToolSummary {
+    #[serde(default)]
+    pub total_invocations_today: u64,
+    #[serde(default)]
+    pub total_invocations_week: u64,
+    #[serde(default)]
+    pub total_invocations_month: u64,
+    /// Absolute delta vs. prior period (positive = more calls).
+    #[serde(default)]
+    pub delta_today: i64,
+    #[serde(default)]
+    pub delta_week: i64,
+    #[serde(default)]
+    pub delta_month: i64,
+    /// Overall success rate [0.0, 1.0].
+    #[serde(default)]
+    pub success_rate: f64,
+    /// Previous-period success rate for trend comparison.
+    #[serde(default)]
+    pub success_rate_prev: f64,
+    /// Average execution duration across all tools (ms).
+    #[serde(default)]
+    pub avg_duration_ms: u64,
+    /// Previous-period average duration for trend comparison.
+    #[serde(default)]
+    pub avg_duration_prev_ms: u64,
+    #[serde(default)]
+    pub most_used_tool: String,
+    #[serde(default)]
+    pub most_used_count: u64,
+}
+
+/// Per-tool aggregated statistics.
+#[derive(Debug, Clone, Default, PartialEq, serde::Deserialize)]
+pub(crate) struct ToolStat {
+    #[serde(default)]
+    pub name: String,
+    #[serde(default)]
+    pub total: u64,
+    #[serde(default)]
+    pub succeeded: u64,
+    #[serde(default)]
+    pub failed: u64,
+    #[serde(default)]
+    pub min_ms: u64,
+    #[serde(default)]
+    pub p25_ms: u64,
+    #[serde(default)]
+    pub p50_ms: u64,
+    #[serde(default)]
+    pub p75_ms: u64,
+    #[serde(default)]
+    pub p95_ms: u64,
+    #[serde(default)]
+    pub max_ms: u64,
+    #[serde(default)]
+    pub most_common_error: Option<String>,
+    #[serde(default)]
+    pub last_failure_at: Option<String>,
+}
+
+/// A single time-series bucket (one date, counts per tool).
+#[derive(Debug, Clone, Default, PartialEq, serde::Deserialize)]
+pub(crate) struct TimeSeriesBucket {
+    #[serde(default)]
+    pub date: String,
+    /// Map of tool_name → invocation count in this bucket.
+    #[serde(default)]
+    pub counts: HashMap<String, u64>,
+}
+
+/// A single raw invocation record.
+#[derive(Debug, Clone, Default, PartialEq, serde::Deserialize)]
+pub(crate) struct ToolInvocation {
+    #[serde(default)]
+    pub tool_name: String,
+    #[serde(default)]
+    pub agent_id: String,
+    #[serde(default)]
+    pub timestamp: String,
+    #[serde(default)]
+    pub duration_ms: u64,
+    #[serde(default)]
+    pub success: bool,
+    #[serde(default)]
+    pub error: Option<String>,
+}
+
+// -- UI state types -----------------------------------------------------------
+
+/// Time period selector shared across all metrics tabs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub(crate) enum DateRange {
+    #[default]
+    Last7Days,
+    Last30Days,
+    Last90Days,
+}
+
+impl DateRange {
+    pub(crate) fn days(self) -> u32 {
+        match self {
+            Self::Last7Days => 7,
+            Self::Last30Days => 30,
+            Self::Last90Days => 90,
+        }
+    }
+
+    pub(crate) fn label(self) -> &'static str {
+        match self {
+            Self::Last7Days => "7d",
+            Self::Last30Days => "30d",
+            Self::Last90Days => "90d",
+        }
+    }
+}
+
+/// Combined store for the tool metrics view.
+#[derive(Debug, Clone)]
+pub(crate) struct ToolMetricsStore {
+    pub data: FetchState<ToolStatsResponse>,
+    pub date_range: DateRange,
+    /// Tool selected for drill-down; `None` means overview.
+    pub selected_tool: Option<String>,
+}
+
+impl Default for ToolMetricsStore {
+    fn default() -> Self {
+        Self {
+            data: FetchState::Loading,
+            date_range: DateRange::default(),
+            selected_tool: None,
+        }
+    }
+}
+
+// -- Aggregation helpers ------------------------------------------------------
+
+/// Returns the top `limit` tools sorted by total invocations, plus an optional
+/// aggregated "Other" entry covering all remaining tools.
+pub(crate) fn top_tools(tools: &[ToolStat], limit: usize) -> (Vec<&ToolStat>, Option<ToolStat>) {
+    let mut sorted: Vec<&ToolStat> = tools.iter().collect();
+    sorted.sort_by(|a, b| b.total.cmp(&a.total));
+
+    if sorted.len() <= limit {
+        return (sorted, None);
+    }
+
+    let (top, rest) = sorted.split_at(limit);
+    let other = ToolStat {
+        name: "Other".to_string(),
+        total: rest.iter().map(|t| t.total).sum(),
+        succeeded: rest.iter().map(|t| t.succeeded).sum(),
+        failed: rest.iter().map(|t| t.failed).sum(),
+        ..Default::default()
+    };
+    (top.to_vec(), Some(other))
+}
+
+/// Tools sorted by failure count (most failures first), for the results view.
+pub(crate) fn tools_by_failure(tools: &[ToolStat]) -> Vec<&ToolStat> {
+    let mut sorted: Vec<&ToolStat> = tools.iter().collect();
+    sorted.sort_by(|a, b| b.failed.cmp(&a.failed));
+    sorted
+}
+
+/// Tools sorted by median duration (slowest first), for the duration view.
+pub(crate) fn tools_by_duration(tools: &[ToolStat]) -> Vec<&ToolStat> {
+    let mut sorted: Vec<&ToolStat> = tools.iter().collect();
+    sorted.sort_by(|a, b| b.p50_ms.cmp(&a.p50_ms));
+    sorted
+}
+
+/// Failure rate as a percentage [0.0, 100.0].
+pub(crate) fn failure_rate(stat: &ToolStat) -> f64 {
+    if stat.total == 0 {
+        return 0.0;
+    }
+    #[expect(
+        clippy::cast_precision_loss,
+        reason = "display-only: sub-percent precision irrelevant"
+    )]
+    let rate = stat.failed as f64 / stat.total as f64 * 100.0;
+    rate
+}
+
+/// Trend arrow: ↑ if current is >1% above prev, ↓ if >1% below, → otherwise.
+pub(crate) fn trend_arrow(current: f64, prev: f64) -> &'static str {
+    if prev == 0.0 {
+        return "→";
+    }
+    let ratio = current / prev;
+    if ratio > 1.01 {
+        "↑"
+    } else if ratio < 0.99 {
+        "↓"
+    } else {
+        "→"
+    }
+}
+
+/// Formats a delta value with + or − prefix.
+pub(crate) fn format_delta(delta: i64) -> String {
+    if delta >= 0 {
+        format!("+{delta}")
+    } else {
+        format!("{delta}")
+    }
+}
+
+/// Formats a duration in milliseconds as a human-readable string.
+pub(crate) fn format_duration_ms(ms: u64) -> String {
+    if ms >= 60_000 {
+        format!("{:.1}m", ms as f64 / 60_000.0) // kanon:ignore RUST/as-cast
+    } else if ms >= 1_000 {
+        format!("{:.1}s", ms as f64 / 1_000.0) // kanon:ignore RUST/as-cast
+    } else {
+        format!("{ms}ms")
+    }
+}
+
+/// Paginate a slice: returns items for page `page` with `per_page` items each.
+pub(crate) fn paginate<T>(items: &[T], page: usize, per_page: usize) -> &[T] {
+    let start = page * per_page;
+    if start >= items.len() {
+        return &[];
+    }
+    let end = (start + per_page).min(items.len());
+    &items[start..end]
+}
+
+/// Total number of pages for `total_items` items at `per_page` per page.
+pub(crate) fn page_count(total_items: usize, per_page: usize) -> usize {
+    if per_page == 0 {
+        return 0;
+    }
+    total_items.div_ceil(per_page)
+}
+
+/// Nearest-rank percentile: index = ceil(p * N) - 1 (clamped).
+///
+/// Used in tests and available for client-side percentile computation from
+/// raw invocation logs when the server doesn't return pre-aggregated stats.
+#[expect(dead_code, reason = "used in tests; reserved for raw-log path")]
+pub(crate) fn percentile_nearest_rank(sorted_values: &[u64], p: f64) -> u64 {
+    if sorted_values.is_empty() {
+        return 0;
+    }
+    #[expect(
+        clippy::cast_precision_loss,
+        reason = "display-only: fractional index is fine for N < 2^53"
+    )]
+    let rank = (p * sorted_values.len() as f64).ceil() as usize;
+    let idx = rank.saturating_sub(1).min(sorted_values.len() - 1);
+    sorted_values[idx]
+}
+
+// -- Tests --------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_stat(name: &str, total: u64, succeeded: u64, p50_ms: u64) -> ToolStat {
+        ToolStat {
+            name: name.to_string(),
+            total,
+            succeeded,
+            failed: total.saturating_sub(succeeded),
+            p50_ms,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn top_tools_within_limit_no_other() {
+        let tools = vec![
+            make_stat("bash", 500, 490, 200),
+            make_stat("read", 300, 295, 100),
+        ];
+        let (top, other) = top_tools(&tools, 10);
+        assert_eq!(top.len(), 2);
+        assert!(other.is_none());
+    }
+
+    #[test]
+    fn top_tools_beyond_limit_creates_other() {
+        let tools: Vec<ToolStat> = (0..12)
+            .map(|i| make_stat(&format!("tool_{i}"), (12 - i) as u64 * 10, 0, 0))
+            .collect();
+        let (top, other) = top_tools(&tools, 10);
+        assert_eq!(top.len(), 10);
+        let other = other.expect("should have Other entry");
+        assert_eq!(other.name, "Other");
+        // sum of ranks 10 and 11 (values 20 and 10)
+        assert_eq!(other.total, 30);
+    }
+
+    #[test]
+    fn top_tools_sorted_by_count_descending() {
+        let tools = vec![
+            make_stat("low", 10, 10, 0),
+            make_stat("high", 500, 490, 0),
+            make_stat("mid", 100, 90, 0),
+        ];
+        let (top, _) = top_tools(&tools, 10);
+        assert_eq!(top[0].name, "high");
+        assert_eq!(top[1].name, "mid");
+        assert_eq!(top[2].name, "low");
+    }
+
+    #[test]
+    fn failure_rate_zero_when_no_calls() {
+        let stat = make_stat("bash", 0, 0, 0);
+        assert_eq!(failure_rate(&stat), 0.0);
+    }
+
+    #[test]
+    fn failure_rate_percentage() {
+        let stat = make_stat("bash", 100, 75, 0);
+        assert!((failure_rate(&stat) - 25.0).abs() < 0.001);
+    }
+
+    #[test]
+    fn trend_arrow_directions() {
+        assert_eq!(trend_arrow(110.0, 100.0), "↑");
+        assert_eq!(trend_arrow(90.0, 100.0), "↓");
+        assert_eq!(trend_arrow(100.5, 100.0), "→");
+    }
+
+    #[test]
+    fn percentile_nearest_rank_median() {
+        let values = &[1u64, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+        // p50 of 10 values: ceil(0.5*10)=5, idx=4, value=5
+        assert_eq!(percentile_nearest_rank(values, 0.50), 5);
+    }
+
+    #[test]
+    fn percentile_nearest_rank_p95() {
+        let values: Vec<u64> = (1..=100).collect();
+        // p95 of 100: ceil(0.95*100)=95, idx=94, value=95
+        assert_eq!(percentile_nearest_rank(&values, 0.95), 95);
+    }
+
+    #[test]
+    fn paginate_first_page() {
+        let items: Vec<u32> = (0..50).collect();
+        let page = paginate(&items, 0, 20);
+        assert_eq!(page.len(), 20);
+        assert_eq!(page[0], 0);
+    }
+
+    #[test]
+    fn paginate_last_partial_page() {
+        let items: Vec<u32> = (0..25).collect();
+        let page = paginate(&items, 1, 20);
+        assert_eq!(page.len(), 5);
+    }
+
+    #[test]
+    fn page_count_exact_multiple() {
+        assert_eq!(page_count(40, 20), 2);
+    }
+
+    #[test]
+    fn page_count_partial_last_page() {
+        assert_eq!(page_count(41, 20), 3);
+    }
+}

--- a/crates/theatron/desktop/src/views/metrics/mod.rs
+++ b/crates/theatron/desktop/src/views/metrics/mod.rs
@@ -1,10 +1,30 @@
-//! Metrics dashboard: session counts, token usage, cost, and uptime.
+//! Metrics dashboard: server health, token usage, costs, and tool statistics.
+//!
+//! Tabs: Tokens (server health + token counts), Costs (cost breakdown), Tools (usage stats).
+
+pub(crate) mod tool_detail;
+pub(crate) mod tool_duration;
+pub(crate) mod tool_frequency;
+pub(crate) mod tool_results;
+pub(crate) mod tools;
 
 use dioxus::prelude::*;
 
 use crate::api::client::authenticated_client;
 use crate::state::connection::ConnectionConfig;
 use crate::state::fetch::FetchState;
+use crate::state::tool_metrics::DateRange;
+
+// -- Tab enum -----------------------------------------------------------------
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum MetricsTab {
+    Tokens,
+    Costs,
+    Tools,
+}
+
+// -- API response types -------------------------------------------------------
 
 #[derive(Debug, Clone, Default, serde::Deserialize)]
 struct HealthResponse {
@@ -37,6 +57,8 @@ struct DashboardData {
     health: HealthResponse,
     metrics: MetricsResponse,
 }
+
+// -- Style constants ----------------------------------------------------------
 
 const CONTAINER_STYLE: &str = "\
     display: flex; \
@@ -98,9 +120,32 @@ const REFRESH_BTN: &str = "\
     cursor: pointer;\
 ";
 
+const TAB_ACTIVE: &str = "\
+    background: #2a2a4a; \
+    color: #e0e0e0; \
+    border: 1px solid #4a4aff; \
+    border-radius: 6px; \
+    padding: 4px 14px; \
+    font-size: 13px; \
+    cursor: pointer;\
+";
+
+const TAB_INACTIVE: &str = "\
+    background: transparent; \
+    color: #888; \
+    border: 1px solid #333; \
+    border-radius: 6px; \
+    padding: 4px 14px; \
+    font-size: 13px; \
+    cursor: pointer;\
+";
+
+// -- Main component -----------------------------------------------------------
+
 #[component]
 pub(crate) fn Metrics() -> Element {
     let config: Signal<ConnectionConfig> = use_context();
+    let mut active_tab = use_signal(|| MetricsTab::Tokens);
     let mut fetch_state = use_signal(|| FetchState::<DashboardData>::Loading);
 
     let mut do_refresh = move || {
@@ -155,38 +200,75 @@ pub(crate) fn Metrics() -> Element {
     rsx! {
         div {
             style: "{CONTAINER_STYLE}",
+
+            // Header with title, tabs, and refresh
             div {
-                style: "display: flex; align-items: center; justify-content: space-between;",
+                style: "display: flex; align-items: center; justify-content: space-between; flex-wrap: wrap; gap: 8px;",
                 h2 { style: "font-size: 20px; margin: 0;", "Metrics" }
-                button {
-                    style: "{REFRESH_BTN}",
-                    onclick: move |_| do_refresh(),
-                    "Refresh"
+
+                div {
+                    style: "display: flex; gap: 6px; align-items: center;",
+
+                    button {
+                        style: if *active_tab.read() == MetricsTab::Tokens { TAB_ACTIVE } else { TAB_INACTIVE },
+                        onclick: move |_| active_tab.set(MetricsTab::Tokens),
+                        "Tokens"
+                    }
+                    button {
+                        style: if *active_tab.read() == MetricsTab::Costs { TAB_ACTIVE } else { TAB_INACTIVE },
+                        onclick: move |_| active_tab.set(MetricsTab::Costs),
+                        "Costs"
+                    }
+                    button {
+                        style: if *active_tab.read() == MetricsTab::Tools { TAB_ACTIVE } else { TAB_INACTIVE },
+                        onclick: move |_| active_tab.set(MetricsTab::Tools),
+                        "Tools"
+                    }
+
+                    if *active_tab.read() != MetricsTab::Tools {
+                        button {
+                            style: "{REFRESH_BTN}",
+                            onclick: move |_| do_refresh(),
+                            "Refresh"
+                        }
+                    }
                 }
             }
 
-            match &*fetch_state.read() {
-                FetchState::Loading => rsx! {
-                    div {
-                        style: "display: flex; align-items: center; justify-content: center; flex: 1; color: #888;",
-                        "Loading metrics..."
-                    }
-                },
-                FetchState::Error(err) => rsx! {
-                    div {
-                        style: "display: flex; align-items: center; justify-content: center; flex: 1; color: #ef4444;",
-                        "Error: {err}"
-                    }
-                },
-                FetchState::Loaded(data) => rsx! {
-                    {render_dashboard(data)}
+            match *active_tab.read() {
+                MetricsTab::Tokens => rsx! { {render_tokens_tab(&fetch_state)} },
+                MetricsTab::Costs => rsx! { {render_costs_tab(&fetch_state)} },
+                MetricsTab::Tools => rsx! {
+                    tools::ToolsOverview { date_range: DateRange::default() }
                 },
             }
         }
     }
 }
 
-fn render_dashboard(data: &DashboardData) -> Element {
+// -- Tokens tab ---------------------------------------------------------------
+
+fn render_tokens_tab(fetch_state: &Signal<FetchState<DashboardData>>) -> Element {
+    match &*fetch_state.read() {
+        FetchState::Loading => rsx! {
+            div {
+                style: "display: flex; align-items: center; justify-content: center; flex: 1; color: #888;",
+                "Loading metrics..."
+            }
+        },
+        FetchState::Error(err) => rsx! {
+            div {
+                style: "display: flex; align-items: center; justify-content: center; flex: 1; color: #ef4444;",
+                "Error: {err}"
+            }
+        },
+        FetchState::Loaded(data) => rsx! {
+            {render_tokens_content(data)}
+        },
+    }
+}
+
+fn render_tokens_content(data: &DashboardData) -> Element {
     let uptime = format_uptime(data.health.uptime_seconds);
     let status_color = if data.health.status == "ok" {
         "background: #1a3a1a; color: #22c55e;"
@@ -220,9 +302,7 @@ fn render_dashboard(data: &DashboardData) -> Element {
                 style: "{CARD_STYLE}",
                 div { style: "{CARD_VALUE}", "{data.metrics.total_sessions}" }
                 div { style: "{CARD_LABEL}", "Total Sessions" }
-                div { style: "{CARD_SUB}",
-                    "{data.metrics.active_sessions} active"
-                }
+                div { style: "{CARD_SUB}", "{data.metrics.active_sessions} active" }
             }
 
             div {
@@ -237,30 +317,62 @@ fn render_dashboard(data: &DashboardData) -> Element {
 
             div {
                 style: "{CARD_STYLE}",
-                div { style: "{CARD_VALUE}",
-                    "{format_tokens(data.metrics.total_input_tokens)}"
-                }
+                div { style: "{CARD_VALUE}", "{format_tokens(data.metrics.total_input_tokens)}" }
                 div { style: "{CARD_LABEL}", "Input Tokens" }
             }
 
             div {
                 style: "{CARD_STYLE}",
-                div { style: "{CARD_VALUE}",
-                    "{format_tokens(data.metrics.total_output_tokens)}"
-                }
+                div { style: "{CARD_VALUE}", "{format_tokens(data.metrics.total_output_tokens)}" }
                 div { style: "{CARD_LABEL}", "Output Tokens" }
-            }
-
-            div {
-                style: "{CARD_STYLE}",
-                div { style: "{CARD_VALUE} color: #eab308;",
-                    "{format_cost(data.metrics.total_cost_usd)}"
-                }
-                div { style: "{CARD_LABEL}", "Total Cost" }
             }
         }
     }
 }
+
+// -- Costs tab ----------------------------------------------------------------
+
+fn render_costs_tab(fetch_state: &Signal<FetchState<DashboardData>>) -> Element {
+    match &*fetch_state.read() {
+        FetchState::Loading => rsx! {
+            div {
+                style: "color: #888; padding: 8px;",
+                "Loading cost data..."
+            }
+        },
+        FetchState::Error(err) => rsx! {
+            div {
+                style: "color: #ef4444; padding: 8px;",
+                "Error: {err}"
+            }
+        },
+        FetchState::Loaded(data) => rsx! {
+            div {
+                style: "{GRID_STYLE}",
+
+                div {
+                    style: "{CARD_STYLE}",
+                    div {
+                        style: "{CARD_VALUE} color: #eab308;",
+                        "{format_cost(data.metrics.total_cost_usd)}"
+                    }
+                    div { style: "{CARD_LABEL}", "Total Cost" }
+                }
+
+                div {
+                    style: "{CARD_STYLE}",
+                    div {
+                        style: "{CARD_VALUE}",
+                        "{format_cost_per_turn(data.metrics.total_cost_usd, data.metrics.total_turns)}"
+                    }
+                    div { style: "{CARD_LABEL}", "Cost / Turn" }
+                }
+            }
+        },
+    }
+}
+
+// -- Formatting helpers -------------------------------------------------------
 
 fn format_uptime(seconds: u64) -> String {
     let days = seconds / 86400;
@@ -278,6 +390,18 @@ fn format_uptime(seconds: u64) -> String {
 
 fn format_cost(value: f64) -> String {
     format!("${value:.2}")
+}
+
+fn format_cost_per_turn(total_cost: f64, total_turns: u64) -> String {
+    if total_turns == 0 {
+        return "—".to_string();
+    }
+    #[expect(
+        clippy::cast_precision_loss,
+        reason = "display-only: turn count fits in f64"
+    )]
+    let per_turn = total_cost / total_turns as f64;
+    format!("${per_turn:.4}")
 }
 
 #[expect(

--- a/crates/theatron/desktop/src/views/metrics/tool_detail.rs
+++ b/crates/theatron/desktop/src/views/metrics/tool_detail.rs
@@ -1,0 +1,315 @@
+//! Tool detail drill-down: usage, success rate, duration, and recent invocations.
+
+use dioxus::prelude::*;
+
+use crate::api::client::authenticated_client;
+use crate::state::connection::ConnectionConfig;
+use crate::state::fetch::FetchState;
+use crate::state::tool_metrics::{
+    DateRange, ToolInvocation, ToolStat, ToolStatsResponse, format_duration_ms, page_count,
+    paginate,
+};
+
+const INVOCATIONS_PER_PAGE: usize = 20;
+
+// -- Style constants ----------------------------------------------------------
+
+const BACK_BTN: &str = "\
+    background: transparent; \
+    color: #4a4aff; \
+    border: 1px solid #333; \
+    border-radius: 6px; \
+    padding: 4px 12px; \
+    font-size: 12px; \
+    cursor: pointer;\
+";
+
+const TABLE_STYLE: &str = "\
+    width: 100%; \
+    border-collapse: collapse; \
+    font-size: 12px;\
+";
+
+const TH_STYLE: &str = "\
+    text-align: left; \
+    color: #888; \
+    font-weight: normal; \
+    padding: 4px 8px; \
+    border-bottom: 1px solid #333;\
+";
+
+const TD_STYLE: &str = "\
+    padding: 4px 8px; \
+    border-bottom: 1px solid #1e1e38; \
+    color: #ccc;\
+";
+
+const CARD_STYLE: &str = "\
+    background: #1a1a2e; \
+    border: 1px solid #333; \
+    border-radius: 8px; \
+    padding: 14px 18px; \
+    min-width: 130px; \
+    flex: 1;\
+";
+
+const CARD_VALUE: &str = "\
+    font-size: 24px; \
+    font-weight: bold; \
+    color: #e0e0e0; \
+    margin-bottom: 2px;\
+";
+
+const CARD_LABEL: &str = "\
+    font-size: 11px; \
+    color: #888; \
+    text-transform: uppercase; \
+    letter-spacing: 0.5px;\
+";
+
+const PAGE_BTN: &str = "\
+    background: #2a2a4a; \
+    color: #e0e0e0; \
+    border: 1px solid #444; \
+    border-radius: 4px; \
+    padding: 2px 8px; \
+    font-size: 12px; \
+    cursor: pointer;\
+";
+
+const PAGE_BTN_DISABLED: &str = "\
+    background: #1a1a2e; \
+    color: #444; \
+    border: 1px solid #2a2a2a; \
+    border-radius: 4px; \
+    padding: 2px 8px; \
+    font-size: 12px; \
+    cursor: default;\
+";
+
+// -- Component ----------------------------------------------------------------
+
+#[component]
+pub(crate) fn ToolDetailView(
+    tool_name: String,
+    date_range: DateRange,
+    on_back: EventHandler<()>,
+) -> Element {
+    let config: Signal<ConnectionConfig> = use_context();
+    let mut detail_fetch = use_signal(|| FetchState::<ToolStatsResponse>::Loading);
+    let mut detail_page = use_signal(|| 0usize);
+
+    let tool_name_for_effect = tool_name.clone();
+    use_effect(move || {
+        let cfg = config.read().clone();
+        let name = tool_name_for_effect.clone();
+        detail_fetch.set(FetchState::Loading);
+        detail_page.set(0);
+
+        spawn(async move {
+            let client = authenticated_client(&cfg);
+            let base = cfg.server_url.trim_end_matches('/');
+            let days = date_range.days();
+            let encoded = form_urlencoded::byte_serialize(name.as_bytes()).collect::<String>();
+            let url = format!("{base}/api/tool-stats?days={days}&tool={encoded}");
+
+            match client.get(&url).send().await {
+                Ok(resp) if resp.status().is_success() => {
+                    match resp.json::<ToolStatsResponse>().await {
+                        Ok(data) => detail_fetch.set(FetchState::Loaded(data)),
+                        Err(e) => {
+                            detail_fetch.set(FetchState::Error(format!("parse error: {e}")));
+                        }
+                    }
+                }
+                Ok(resp) => {
+                    detail_fetch.set(FetchState::Error(format!(
+                        "tool-stats returned {}",
+                        resp.status()
+                    )));
+                }
+                Err(e) => {
+                    detail_fetch.set(FetchState::Error(format!("connection error: {e}")));
+                }
+            }
+        });
+    });
+
+    rsx! {
+        div { style: "display: flex; flex-direction: column; gap: 16px;",
+
+            // Header: back button + tool name
+            div {
+                style: "display: flex; align-items: center; gap: 12px;",
+                button {
+                    style: "{BACK_BTN}",
+                    onclick: move |_| on_back.call(()),
+                    "← Back"
+                }
+                h3 {
+                    style: "font-size: 16px; margin: 0; font-family: monospace; color: #e0e0e0;",
+                    "{tool_name}"
+                }
+            }
+
+            match &*detail_fetch.read() {
+                FetchState::Loading => rsx! {
+                    div { style: "color: #888; padding: 8px;", "Loading tool detail..." }
+                },
+                FetchState::Error(err) => rsx! {
+                    div { style: "color: #ef4444; padding: 8px;", "Error: {err}" }
+                },
+                FetchState::Loaded(data) => {
+                    let stat = data.tools.iter().find(|t| t.name == tool_name);
+                    let inv_count = data.invocations.len();
+                    let page = *detail_page.read();
+                    rsx! {
+                        {render_summary_cards(stat)}
+                        div {
+                            style: "font-size: 13px; color: #aaa; margin-bottom: 4px;",
+                            "Recent Invocations"
+                        }
+                        {render_invocations_table(&data.invocations, page)}
+                        {render_pagination(page, inv_count, detail_page)}
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn render_summary_cards(stat: Option<&ToolStat>) -> Element {
+    let Some(stat) = stat else {
+        return rsx! { div { style: "color: #555; font-size: 12px;", "No stats for this tool." } };
+    };
+
+    let rate = if stat.total > 0 {
+        (stat.succeeded * 100) / stat.total
+    } else {
+        0
+    };
+    let rate_color = if rate > 90 {
+        "#22c55e"
+    } else if rate > 70 {
+        "#eab308"
+    } else {
+        "#ef4444"
+    };
+
+    rsx! {
+        div {
+            style: "display: flex; flex-wrap: wrap; gap: 10px;",
+            div {
+                style: "{CARD_STYLE}",
+                div { style: "{CARD_VALUE}", "{stat.total}" }
+                div { style: "{CARD_LABEL}", "Total Calls" }
+            }
+            div {
+                style: "{CARD_STYLE}",
+                div { style: "{CARD_VALUE} color: {rate_color};", "{rate}%" }
+                div { style: "{CARD_LABEL}", "Success Rate" }
+            }
+            div {
+                style: "{CARD_STYLE}",
+                div { style: "{CARD_VALUE}", "{format_duration_ms(stat.p50_ms)}" }
+                div { style: "{CARD_LABEL}", "Median Duration" }
+            }
+            div {
+                style: "{CARD_STYLE}",
+                div { style: "{CARD_VALUE}", "{format_duration_ms(stat.p95_ms)}" }
+                div { style: "{CARD_LABEL}", "p95 Duration" }
+            }
+        }
+    }
+}
+
+fn render_invocations_table(invocations: &[ToolInvocation], page: usize) -> Element {
+    if invocations.is_empty() {
+        return rsx! {
+            div { style: "color: #555; font-size: 12px; padding: 8px;", "No invocations recorded." }
+        };
+    }
+
+    let page_items = paginate(invocations, page, INVOCATIONS_PER_PAGE);
+
+    rsx! {
+        table {
+            style: "{TABLE_STYLE}",
+            thead {
+                tr {
+                    th { style: "{TH_STYLE}", "Timestamp" }
+                    th { style: "{TH_STYLE}", "Agent" }
+                    th { style: "{TH_STYLE}", "Duration" }
+                    th { style: "{TH_STYLE}", "Result" }
+                    th { style: "{TH_STYLE}", "Error" }
+                }
+            }
+            tbody {
+                for (idx, inv) in page_items.iter().enumerate() {
+                    {
+                        let (result_text, result_color) = if inv.success {
+                            ("✓", "#22c55e")
+                        } else {
+                            ("✗", "#ef4444")
+                        };
+                        let error = inv.error.as_deref().unwrap_or("—");
+                        let dur = format_duration_ms(inv.duration_ms);
+                        let ts = inv.timestamp.clone();
+                        let agent = inv.agent_id.clone();
+                        let key = format!("{idx}-{ts}");
+
+                        rsx! {
+                            tr {
+                                key: "{key}",
+                                td { style: "{TD_STYLE} font-size: 11px; color: #666;", "{ts}" }
+                                td { style: "{TD_STYLE} font-family: monospace; font-size: 11px;", "{agent}" }
+                                td { style: "{TD_STYLE}", "{dur}" }
+                                td { style: "{TD_STYLE} color: {result_color}; font-weight: bold;", "{result_text}" }
+                                td {
+                                    style: "{TD_STYLE} font-size: 11px; color: #888; max-width: 200px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;",
+                                    "{error}"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn render_pagination(page: usize, total_items: usize, mut detail_page: Signal<usize>) -> Element {
+    let total_pages = page_count(total_items, INVOCATIONS_PER_PAGE);
+    if total_pages <= 1 {
+        return rsx! {};
+    }
+
+    rsx! {
+        div {
+            style: "display: flex; align-items: center; gap: 8px; font-size: 12px; color: #888;",
+            button {
+                style: if page > 0 { PAGE_BTN } else { PAGE_BTN_DISABLED },
+                disabled: page == 0,
+                onclick: move |_| {
+                    let p = *detail_page.read();
+                    if p > 0 {
+                        detail_page.set(p - 1);
+                    }
+                },
+                "← Prev"
+            }
+            span { "Page {page + 1} of {total_pages}" }
+            button {
+                style: if page + 1 < total_pages { PAGE_BTN } else { PAGE_BTN_DISABLED },
+                disabled: page + 1 >= total_pages,
+                onclick: move |_| {
+                    let p = *detail_page.read();
+                    if p + 1 < total_pages {
+                        detail_page.set(p + 1);
+                    }
+                },
+                "Next →"
+            }
+        }
+    }
+}

--- a/crates/theatron/desktop/src/views/metrics/tool_duration.rs
+++ b/crates/theatron/desktop/src/views/metrics/tool_duration.rs
@@ -1,0 +1,182 @@
+//! Duration distribution: percentile bars, trend chart, and summary table.
+
+use dioxus::prelude::*;
+
+use crate::components::chart::{
+    LineChart, LinePoint, LineSeries, PercentileBarChart, PercentileEntry, SERIES_COLORS,
+};
+use crate::state::tool_metrics::{
+    TimeSeriesBucket, ToolStat, format_duration_ms, tools_by_duration,
+};
+
+// -- Style constants ----------------------------------------------------------
+
+const TABLE_STYLE: &str = "\
+    width: 100%; \
+    border-collapse: collapse; \
+    font-size: 12px;\
+";
+
+const TH_STYLE: &str = "\
+    text-align: left; \
+    color: #888; \
+    font-weight: normal; \
+    padding: 4px 8px; \
+    border-bottom: 1px solid #333;\
+";
+
+const TD_STYLE: &str = "\
+    padding: 4px 8px; \
+    border-bottom: 1px solid #1e1e38; \
+    color: #ccc;\
+";
+
+// -- Component ----------------------------------------------------------------
+
+#[component]
+pub(crate) fn ToolDurationView(tools: Vec<ToolStat>) -> Element {
+    if tools.is_empty() {
+        return rsx! {
+            div { style: "color: #555; font-size: 13px; padding: 8px;", "No tool data available." }
+        };
+    }
+
+    let sorted = tools_by_duration(&tools);
+
+    let perc_entries: Vec<PercentileEntry> = sorted
+        .iter()
+        .map(|t| PercentileEntry {
+            label: t.name.clone(),
+            min_ms: t.min_ms,
+            p25_ms: t.p25_ms,
+            p50_ms: t.p50_ms,
+            p75_ms: t.p75_ms,
+            p95_ms: t.p95_ms,
+            max_ms: t.max_ms,
+        })
+        .collect();
+
+    rsx! {
+        div { style: "display: flex; flex-direction: column; gap: 20px;",
+
+            // Percentile bar chart
+            PercentileBarChart { entries: perc_entries }
+
+            // Duration table
+            div {
+                style: "font-size: 13px; color: #aaa; margin-bottom: 4px;",
+                "Duration Summary"
+            }
+            {duration_table(&sorted)}
+        }
+    }
+}
+
+/// Standalone duration trend chart for the top 5 slowest tools.
+///
+/// Shown in the full tools overview to surface performance degradation.
+#[component]
+pub(crate) fn DurationTrendView(
+    tools: Vec<ToolStat>,
+    time_series: Vec<TimeSeriesBucket>,
+) -> Element {
+    if time_series.is_empty() {
+        return rsx! {
+            div { style: "color: #555; font-size: 12px;", "No time series data." }
+        };
+    }
+
+    let sorted = tools_by_duration(&tools);
+    let top5: Vec<&ToolStat> = sorted.into_iter().take(5).collect();
+
+    if top5.is_empty() {
+        return rsx! {
+            div { style: "color: #555; font-size: 12px;", "No duration data." }
+        };
+    }
+
+    // Use median duration (p50) as the series value. We only have per-bucket
+    // invocation counts, so we use a constant p50 as a flat proxy.
+    // WHY: Until the server provides per-bucket duration stats, this chart shows
+    // relative volume-weighted duration as an approximation. Swap when available.
+    let series: Vec<LineSeries> = top5
+        .iter()
+        .enumerate()
+        .map(|(i, tool)| {
+            let points = time_series
+                .iter()
+                .map(|bucket| {
+                    // Proxy: scale p50 by bucket share of total calls.
+                    let bucket_count = *bucket.counts.get(&tool.name).unwrap_or(&0);
+                    LinePoint {
+                        label: bucket.date.clone(),
+                        value: if bucket_count > 0 {
+                            tool.p50_ms as f64
+                        } else {
+                            0.0
+                        },
+                    }
+                })
+                .collect();
+            LineSeries {
+                name: tool.name.clone(),
+                color: SERIES_COLORS[i % SERIES_COLORS.len()].to_string(),
+                points,
+            }
+        })
+        .collect();
+
+    rsx! {
+        LineChart { series, height: 150 }
+    }
+}
+
+fn duration_table(sorted: &[&ToolStat]) -> Element {
+    rsx! {
+        table {
+            style: "{TABLE_STYLE}",
+            thead {
+                tr {
+                    th { style: "{TH_STYLE}", "Tool" }
+                    th { style: "{TH_STYLE}", "Min" }
+                    th { style: "{TH_STYLE}", "Median" }
+                    th { style: "{TH_STYLE}", "p95" }
+                    th { style: "{TH_STYLE}", "Max" }
+                    th { style: "{TH_STYLE}", "Calls" }
+                }
+            }
+            tbody {
+                for stat in sorted.iter() {
+                    {
+                        let p95_color = if stat.p95_ms > 10_000 { "#ef4444" }
+                            else if stat.p95_ms > 5_000 { "#eab308" }
+                            else { "#ccc" };
+                        let row_highlight = if stat.p95_ms > 10_000 {
+                            "background: rgba(239,68,68,0.06);"
+                        } else if stat.p95_ms > 5_000 {
+                            "background: rgba(234,179,8,0.06);"
+                        } else {
+                            ""
+                        };
+                        let name = stat.name.clone();
+
+                        rsx! {
+                            tr {
+                                key: "{name}",
+                                style: "{row_highlight}",
+                                td { style: "{TD_STYLE} font-family: monospace;", "{name}" }
+                                td { style: "{TD_STYLE}", "{format_duration_ms(stat.min_ms)}" }
+                                td { style: "{TD_STYLE}", "{format_duration_ms(stat.p50_ms)}" }
+                                td { style: "{TD_STYLE} color: {p95_color};",
+                                    "{format_duration_ms(stat.p95_ms)}"
+                                }
+                                td { style: "{TD_STYLE}", "{format_duration_ms(stat.max_ms)}" }
+                                td { style: "{TD_STYLE}", "{stat.total}" }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/crates/theatron/desktop/src/views/metrics/tool_frequency.rs
+++ b/crates/theatron/desktop/src/views/metrics/tool_frequency.rs
@@ -1,0 +1,134 @@
+//! Usage frequency chart: horizontal bars + time series.
+
+use dioxus::prelude::*;
+
+use crate::components::chart::{
+    BarEntry, HorizontalBarChart, LineChart, LinePoint, LineSeries, SERIES_COLORS,
+};
+use crate::state::tool_metrics::{TimeSeriesBucket, ToolStat, top_tools};
+
+const TOP_N: usize = 10;
+
+#[component]
+pub(crate) fn ToolFrequencyView(tools: Vec<ToolStat>, on_click: EventHandler<String>) -> Element {
+    if tools.is_empty() {
+        return rsx! {
+            div { style: "color: #555; font-size: 13px; padding: 8px;", "No tool data available." }
+        };
+    }
+
+    let (top, other) = top_tools(&tools, TOP_N);
+
+    let mut bar_entries: Vec<BarEntry> = top
+        .iter()
+        .enumerate()
+        .map(|(i, t)| BarEntry {
+            label: t.name.clone(),
+            value: t.total,
+            color: Some(SERIES_COLORS[i % SERIES_COLORS.len()].to_string()),
+        })
+        .collect();
+
+    if let Some(ref o) = other {
+        bar_entries.push(BarEntry {
+            label: o.name.clone(),
+            value: o.total,
+            color: Some("#555".to_string()),
+        });
+    }
+
+    rsx! {
+        div { style: "display: flex; flex-direction: column; gap: 16px;",
+
+            // Horizontal bar chart
+            HorizontalBarChart {
+                entries: bar_entries,
+                max_value: None,
+                on_click: Some(EventHandler::new(move |name: String| {
+                    // NOTE: "Other" is not a real tool; suppress drill-down.
+                    if name != "Other" {
+                        on_click.call(name);
+                    }
+                })),
+            }
+
+            if let Some(ref o) = other {
+                div {
+                    style: "font-size: 11px; color: #555; padding: 2px 0;",
+                    "\"Other\" groups {tools.len() - TOP_N} additional tools (total {o.total} calls). Click any named tool to drill down."
+                }
+            }
+        }
+    }
+}
+
+/// Time series variant: builds line series from raw time-series buckets.
+///
+/// Used by the overview when time series data is available.
+#[component]
+pub(crate) fn ToolTimeSeriesView(
+    tools: Vec<ToolStat>,
+    time_series: Vec<TimeSeriesBucket>,
+) -> Element {
+    if time_series.is_empty() {
+        return rsx! {
+            div { style: "color: #555; font-size: 13px; padding: 8px;", "No time series data." }
+        };
+    }
+
+    // Top N tools by total invocations for the legend.
+    let (top_tools_ref, _) = top_tools(&tools, TOP_N);
+    let top_names: Vec<String> = top_tools_ref.iter().map(|t| t.name.clone()).collect();
+
+    let series: Vec<LineSeries> = top_names
+        .iter()
+        .enumerate()
+        .map(|(i, name)| {
+            let points = time_series
+                .iter()
+                .map(|bucket| LinePoint {
+                    label: bucket.date.clone(),
+                    value: *bucket.counts.get(name).unwrap_or(&0) as f64,
+                })
+                .collect();
+            LineSeries {
+                name: name.clone(),
+                color: SERIES_COLORS[i % SERIES_COLORS.len()].to_string(),
+                points,
+            }
+        })
+        .collect();
+
+    // "Other" series aggregates remaining tools.
+    let other_series = {
+        let other_points = time_series
+            .iter()
+            .map(|bucket| {
+                let top_sum: u64 = top_names
+                    .iter()
+                    .map(|n| bucket.counts.get(n).unwrap_or(&0))
+                    .sum();
+                let total_bucket: u64 = bucket.counts.values().sum();
+                LinePoint {
+                    label: bucket.date.clone(),
+                    value: total_bucket.saturating_sub(top_sum) as f64,
+                }
+            })
+            .collect();
+        LineSeries {
+            name: "Other".to_string(),
+            color: "#555".to_string(),
+            points: other_points,
+        }
+    };
+
+    let mut all_series = series;
+    all_series.push(other_series);
+
+    rsx! {
+        LineChart {
+            series: all_series,
+            height: 180,
+        }
+    }
+}

--- a/crates/theatron/desktop/src/views/metrics/tool_results.rs
+++ b/crates/theatron/desktop/src/views/metrics/tool_results.rs
@@ -1,0 +1,185 @@
+//! Success/failure rate charts and summary table.
+
+use dioxus::prelude::*;
+
+use crate::components::chart::{
+    LineChart, LinePoint, LineSeries, SERIES_COLORS, StackedBarChart, StackedBarEntry,
+};
+use crate::state::tool_metrics::{TimeSeriesBucket, ToolStat, failure_rate, tools_by_failure};
+
+// -- Style constants ----------------------------------------------------------
+
+const TABLE_STYLE: &str = "\
+    width: 100%; \
+    border-collapse: collapse; \
+    font-size: 12px;\
+";
+
+const TH_STYLE: &str = "\
+    text-align: left; \
+    color: #888; \
+    font-weight: normal; \
+    padding: 4px 8px; \
+    border-bottom: 1px solid #333;\
+";
+
+const TD_STYLE: &str = "\
+    padding: 4px 8px; \
+    border-bottom: 1px solid #1e1e38; \
+    color: #ccc;\
+";
+
+// -- Main component -----------------------------------------------------------
+
+#[component]
+pub(crate) fn ToolResultsView(tools: Vec<ToolStat>, time_series: Vec<TimeSeriesBucket>) -> Element {
+    if tools.is_empty() {
+        return rsx! {
+            div { style: "color: #555; font-size: 13px; padding: 8px;", "No tool data available." }
+        };
+    }
+
+    let sorted = tools_by_failure(&tools);
+
+    let stacked_entries: Vec<StackedBarEntry> = sorted
+        .iter()
+        .map(|t| StackedBarEntry {
+            label: t.name.clone(),
+            success: t.succeeded,
+            failure: t.failed,
+        })
+        .collect();
+
+    rsx! {
+        div { style: "display: flex; flex-direction: column; gap: 20px;",
+
+            // Stacked bar chart
+            StackedBarChart {
+                entries: stacked_entries,
+                sort_by_failure: true,
+                on_click: None,
+            }
+
+            // Failure rate trend (top 5 most-failing tools)
+            if !time_series.is_empty() {
+                div {
+                    div {
+                        style: "font-size: 13px; color: #aaa; margin-bottom: 8px;",
+                        "Failure Rate Trend (top 5 most-failing tools)"
+                    }
+                    {failure_trend_chart(&tools, &time_series)}
+                }
+            }
+
+            // Summary table
+            div {
+                style: "font-size: 13px; color: #aaa; margin-bottom: 4px;",
+                "Failure Summary"
+            }
+            {failure_table(&sorted)}
+        }
+    }
+}
+
+fn failure_trend_chart(tools: &[ToolStat], time_series: &[TimeSeriesBucket]) -> Element {
+    let mut by_fail = tools_by_failure(tools);
+    by_fail.retain(|t| t.failed > 0);
+    let top5: Vec<&ToolStat> = by_fail.into_iter().take(5).collect();
+
+    if top5.is_empty() {
+        return rsx! {
+            div { style: "color: #555; font-size: 12px;", "No failures recorded." }
+        };
+    }
+
+    // Compute failure rate per bucket per tool.
+    // WHY: We only have aggregate counts per tool per bucket; failure rate is
+    // approximated as failed/(total) per bucket for each named tool.
+    // Time series only tracks call counts, not outcomes per bucket; so we show
+    // relative call volume as a proxy. If the server provides per-tool
+    // success/fail per bucket in the future, swap `counts` for separate fields.
+    let series: Vec<LineSeries> = top5
+        .iter()
+        .enumerate()
+        .map(|(i, tool)| {
+            let tool_total = tool.total.max(1);
+            let points = time_series
+                .iter()
+                .map(|bucket| {
+                    let bucket_count = *bucket.counts.get(&tool.name).unwrap_or(&0);
+                    // Approximate failure rate using overall failure ratio.
+                    #[expect(clippy::cast_precision_loss, reason = "display-only approximation")]
+                    let approx_fail_rate =
+                        (tool.failed as f64 / tool_total as f64) * bucket_count as f64;
+                    LinePoint {
+                        label: bucket.date.clone(),
+                        value: approx_fail_rate,
+                    }
+                })
+                .collect();
+            LineSeries {
+                name: tool.name.clone(),
+                color: SERIES_COLORS[i % SERIES_COLORS.len()].to_string(),
+                points,
+            }
+        })
+        .collect();
+
+    rsx! {
+        LineChart { series, height: 150 }
+    }
+}
+
+fn failure_table(sorted: &[&ToolStat]) -> Element {
+    rsx! {
+        table {
+            style: "{TABLE_STYLE}",
+            thead {
+                tr {
+                    th { style: "{TH_STYLE}", "Tool" }
+                    th { style: "{TH_STYLE}", "Calls" }
+                    th { style: "{TH_STYLE}", "Failures" }
+                    th { style: "{TH_STYLE}", "Fail %" }
+                    th { style: "{TH_STYLE}", "Last Error" }
+                    th { style: "{TH_STYLE}", "Last Failure" }
+                }
+            }
+            tbody {
+                for stat in sorted.iter() {
+                    {
+                        let rate = failure_rate(stat);
+                        let row_bg = if rate > 50.0 {
+                            "background: rgba(239,68,68,0.08);"
+                        } else if rate > 20.0 {
+                            "background: rgba(234,179,8,0.08);"
+                        } else {
+                            ""
+                        };
+                        let rate_color = if rate > 50.0 { "#ef4444" }
+                            else if rate > 20.0 { "#eab308" }
+                            else { "#888" };
+                        let name = stat.name.clone();
+                        let last_error = stat.most_common_error.as_deref().unwrap_or("—");
+                        let last_fail = stat.last_failure_at.as_deref().unwrap_or("—");
+
+                        rsx! {
+                            tr {
+                                key: "{name}",
+                                style: "{row_bg}",
+                                td { style: "{TD_STYLE} font-family: monospace;", "{name}" }
+                                td { style: "{TD_STYLE}", "{stat.total}" }
+                                td { style: "{TD_STYLE}", "{stat.failed}" }
+                                td { style: "{TD_STYLE} color: {rate_color};", "{rate:.1}%" }
+                                td {
+                                    style: "{TD_STYLE} font-size: 11px; max-width: 180px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;",
+                                    "{last_error}"
+                                }
+                                td { style: "{TD_STYLE} font-size: 11px; color: #666;", "{last_fail}" }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/crates/theatron/desktop/src/views/metrics/tools.rs
+++ b/crates/theatron/desktop/src/views/metrics/tools.rs
@@ -1,0 +1,303 @@
+//! Tools tab: summary cards, date range selector, and sub-view host.
+
+use dioxus::prelude::*;
+
+use crate::api::client::authenticated_client;
+use crate::state::connection::ConnectionConfig;
+use crate::state::fetch::FetchState;
+use crate::state::tool_metrics::{
+    DateRange, ToolMetricsStore, ToolStatsResponse, format_delta, format_duration_ms, trend_arrow,
+};
+
+use super::tool_detail::ToolDetailView;
+use super::tool_duration::ToolDurationView;
+use super::tool_frequency::ToolFrequencyView;
+use super::tool_results::ToolResultsView;
+
+// -- Style constants ----------------------------------------------------------
+
+const CARD_STYLE: &str = "\
+    background: #1a1a2e; \
+    border: 1px solid #333; \
+    border-radius: 8px; \
+    padding: 16px 20px; \
+    min-width: 150px; \
+    flex: 1;\
+";
+
+const CARD_VALUE: &str = "\
+    font-size: 28px; \
+    font-weight: bold; \
+    color: #e0e0e0; \
+    margin-bottom: 2px;\
+";
+
+const CARD_LABEL: &str = "\
+    font-size: 11px; \
+    color: #888; \
+    text-transform: uppercase; \
+    letter-spacing: 0.5px;\
+";
+
+const CARD_DELTA: &str = "\
+    font-size: 11px; \
+    margin-top: 6px;\
+";
+
+const RANGE_BTN_ACTIVE: &str = "\
+    background: #2a2a4a; \
+    color: #e0e0e0; \
+    border: 1px solid #4a4aff; \
+    border-radius: 4px; \
+    padding: 2px 10px; \
+    font-size: 12px; \
+    cursor: pointer;\
+";
+
+const RANGE_BTN_INACTIVE: &str = "\
+    background: transparent; \
+    color: #666; \
+    border: 1px solid #333; \
+    border-radius: 4px; \
+    padding: 2px 10px; \
+    font-size: 12px; \
+    cursor: pointer;\
+";
+
+const SECTION_STYLE: &str = "\
+    background: #1a1a2e; \
+    border: 1px solid #333; \
+    border-radius: 8px; \
+    padding: 16px;\
+";
+
+const SECTION_TITLE: &str = "\
+    font-size: 14px; \
+    font-weight: bold; \
+    color: #aaa; \
+    margin-bottom: 12px;\
+";
+
+const REFRESH_BTN: &str = "\
+    background: #2a2a4a; \
+    color: #e0e0e0; \
+    border: 1px solid #444; \
+    border-radius: 6px; \
+    padding: 4px 12px; \
+    font-size: 12px; \
+    cursor: pointer;\
+";
+
+// -- Component ----------------------------------------------------------------
+
+#[component]
+pub(crate) fn ToolsOverview(date_range: DateRange) -> Element {
+    let config: Signal<ConnectionConfig> = use_context();
+    let mut store = use_signal(|| ToolMetricsStore {
+        date_range,
+        ..Default::default()
+    });
+
+    let mut do_fetch = move || {
+        let cfg = config.read().clone();
+        let range = store.read().date_range;
+        store.write().data = FetchState::Loading;
+
+        spawn(async move {
+            let client = authenticated_client(&cfg);
+            let base = cfg.server_url.trim_end_matches('/');
+            let days = range.days();
+            let url = format!("{base}/api/tool-stats?days={days}");
+
+            match client.get(&url).send().await {
+                Ok(resp) if resp.status().is_success() => {
+                    match resp.json::<ToolStatsResponse>().await {
+                        Ok(data) => store.write().data = FetchState::Loaded(data),
+                        Err(e) => {
+                            store.write().data = FetchState::Error(format!("parse error: {e}"));
+                        }
+                    }
+                }
+                Ok(resp) => {
+                    store.write().data =
+                        FetchState::Error(format!("tool-stats returned {}", resp.status()));
+                }
+                Err(e) => {
+                    store.write().data = FetchState::Error(format!("connection error: {e}"));
+                }
+            }
+        });
+    };
+
+    use_effect(move || {
+        do_fetch();
+    });
+
+    // Read selected tool for drill-down routing.
+    let selected_tool = store.read().selected_tool.clone();
+
+    rsx! {
+        div {
+            style: "display: flex; flex-direction: column; gap: 16px; flex: 1;",
+
+            // Date range selector + refresh
+            div {
+                style: "display: flex; align-items: center; gap: 8px;",
+                span { style: "font-size: 12px; color: #888;", "Range:" }
+                for range in [DateRange::Last7Days, DateRange::Last30Days, DateRange::Last90Days] {
+                    {
+                        let is_active = store.read().date_range == range;
+                        rsx! {
+                            button {
+                                key: "{range.label()}",
+                                style: if is_active { RANGE_BTN_ACTIVE } else { RANGE_BTN_INACTIVE },
+                                onclick: move |_| {
+                                    store.write().date_range = range;
+                                    do_fetch();
+                                },
+                                "{range.label()}"
+                            }
+                        }
+                    }
+                }
+                button {
+                    style: "{REFRESH_BTN}",
+                    onclick: move |_| do_fetch(),
+                    "Refresh"
+                }
+            }
+
+            // If a tool is selected, show detail view; otherwise show overview.
+            if let Some(ref tool_name) = selected_tool {
+                ToolDetailView {
+                    tool_name: tool_name.clone(),
+                    date_range: store.read().date_range,
+                    on_back: move |_| {
+                        store.write().selected_tool = None;
+                    },
+                }
+            } else {
+                {render_overview(store, move |tool_name| {
+                    store.write().selected_tool = Some(tool_name);
+                })}
+            }
+        }
+    }
+}
+
+fn render_overview(
+    store: Signal<ToolMetricsStore>,
+    mut on_select_tool: impl FnMut(String) + 'static,
+) -> Element {
+    match store.read().data.clone() {
+        FetchState::Loading => rsx! {
+            div {
+                style: "display: flex; align-items: center; justify-content: center; flex: 1; color: #888;",
+                "Loading tool statistics..."
+            }
+        },
+        FetchState::Error(err) => rsx! {
+            div {
+                style: "color: #ef4444; padding: 8px;",
+                "Error: {err}"
+            }
+        },
+        FetchState::Loaded(data) => {
+            let mut on_select = move |tool_name: String| on_select_tool(tool_name);
+            rsx! {
+                // Summary cards
+                div {
+                    style: "display: flex; flex-wrap: wrap; gap: 12px;",
+
+                    // Total invocations (weekly)
+                    div {
+                        style: "{CARD_STYLE}",
+                        div { style: "{CARD_VALUE}", "{data.summary.total_invocations_week}" }
+                        div { style: "{CARD_LABEL}", "Invocations (7d)" }
+                        div {
+                            style: "{CARD_DELTA} color: #888;",
+                            "{format_delta(data.summary.delta_week)} vs prior"
+                        }
+                    }
+
+                    // Overall success rate
+                    {
+                        let rate_pct = (data.summary.success_rate * 100.0) as u64;
+                        let trend = trend_arrow(data.summary.success_rate, data.summary.success_rate_prev);
+                        let rate_color = if data.summary.success_rate > 0.9 { "#22c55e" }
+                            else if data.summary.success_rate > 0.7 { "#eab308" }
+                            else { "#ef4444" };
+                        rsx! {
+                            div {
+                                style: "{CARD_STYLE}",
+                                div { style: "{CARD_VALUE} color: {rate_color};", "{rate_pct}%" }
+                                div { style: "{CARD_LABEL}", "Success Rate" }
+                                div { style: "{CARD_DELTA} color: #888;", "{trend} trend" }
+                            }
+                        }
+                    }
+
+                    // Average duration
+                    {
+                        let dur = format_duration_ms(data.summary.avg_duration_ms);
+                        let trend = trend_arrow(
+                            data.summary.avg_duration_ms as f64,
+                            data.summary.avg_duration_prev_ms as f64,
+                        );
+                        rsx! {
+                            div {
+                                style: "{CARD_STYLE}",
+                                div { style: "{CARD_VALUE}", "{dur}" }
+                                div { style: "{CARD_LABEL}", "Avg Duration" }
+                                div { style: "{CARD_DELTA} color: #888;", "{trend} trend" }
+                            }
+                        }
+                    }
+
+                    // Most used tool
+                    if !data.summary.most_used_tool.is_empty() {
+                        div {
+                            style: "{CARD_STYLE}",
+                            div {
+                                style: "font-size: 18px; font-weight: bold; color: #e0e0e0; margin-bottom: 2px; font-family: monospace;",
+                                "{data.summary.most_used_tool}"
+                            }
+                            div { style: "{CARD_LABEL}", "Most Used Tool" }
+                            div {
+                                style: "{CARD_DELTA} color: #888;",
+                                "{data.summary.most_used_count} calls"
+                            }
+                        }
+                    }
+                }
+
+                // Frequency chart
+                div {
+                    style: "{SECTION_STYLE}",
+                    div { style: "{SECTION_TITLE}", "Usage Frequency" }
+                    ToolFrequencyView {
+                        tools: data.tools.clone(),
+                        on_click: EventHandler::new(move |name| on_select(name)),
+                    }
+                }
+
+                // Success/failure chart
+                div {
+                    style: "{SECTION_STYLE}",
+                    div { style: "{SECTION_TITLE}", "Success / Failure Rates" }
+                    ToolResultsView {
+                        tools: data.tools.clone(),
+                        time_series: data.time_series.clone(),
+                    }
+                }
+
+                // Duration distribution
+                div {
+                    style: "{SECTION_STYLE}",
+                    div { style: "{SECTION_TITLE}", "Duration Distribution" }
+                    ToolDurationView { tools: data.tools.clone() }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds tool usage statistics as a new **Tools** tab in the metrics view (tab order: Tokens → Costs → Tools)
- SVG chart primitives in `src/components/chart.rs` for reuse across metrics views
- Summary cards, frequency chart, success/failure chart, duration distribution, and per-tool drill-down

## Changes

### New files
- `src/components/chart.rs` — `HorizontalBarChart`, `StackedBarChart`, `LineChart`, `PercentileBarChart` (SVG, no external deps)
- `src/state/tool_metrics.rs` — `ToolStatsResponse`, `ToolMetricsStore`, `DateRange`, aggregation helpers, 12 unit tests
- `src/views/metrics/tools.rs` — summary cards + date range selector + sub-view host
- `src/views/metrics/tool_frequency.rs` — horizontal bar chart (top 10 + Other), time series
- `src/views/metrics/tool_results.rs` — stacked bar chart + failure summary table with amber/red highlighting
- `src/views/metrics/tool_duration.rs` — percentile bar chart + duration table with p95 highlighting
- `src/views/metrics/tool_detail.rs` — drill-down: summary cards, recent invocations table, pagination

### Modified files
- `src/views/metrics.rs` → `src/views/metrics/mod.rs` — converted to module with Tokens/Costs/Tools tabs
- `src/app.rs` — added `/metrics/tools/:tool_name` route
- `src/state/mod.rs`, `src/components/mod.rs` — module registrations

## Test plan

- [x] `cargo check --manifest-path crates/theatron/desktop/Cargo.toml` — clean compile
- [x] `cargo test` (desktop) — 12 new unit tests pass, 462 total pass
- [x] `cargo fmt -- --check` (desktop) — formatted
- [x] `cargo test --workspace` — no regressions

## Observations

- **Debt** — `src/views/metrics/tool_results.rs:100`: Failure rate trend chart uses overall failure ratio × bucket call count as an approximation. The `/api/tool-stats` endpoint would need to expose per-bucket success/fail counts for exact per-day failure rates. A `TODO(#NNN)` should track this when the API is extended.
- **Idea** — `src/components/chart.rs:1`: The chart primitives are intentionally minimal (no axis labels, tooltips, or zoom). A future pass could add SVG hover tooltips using the `title` element for accessibility and detail-on-hover UX.
- **Missing test** — `src/views/metrics/tools.rs`: The `ToolsOverview` component has no integration test for the fetch-error → retry flow. A mock-server test would improve coverage.
- **Doc gap** — `src/views/metrics/mod.rs`: The `/api/tool-stats` response contract is undocumented in the API endpoint table in `CLAUDE.md`. Should be added once the server implements the endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)