### PR TITLE
feat(theatron-desktop): meta-insights — agent performance, knowledge growth, system self-reflection

### DIFF
--- a/crates/theatron/desktop/src/app.rs
+++ b/crates/theatron/desktop/src/app.rs
@@ -25,6 +25,7 @@ use crate::views::metrics::tool_detail::ToolDetailView;
 use crate::views::ops::Ops;
 use crate::views::planning::{Planning, PlanningProject};
 use crate::views::sessions::Sessions;
+use crate::views::meta::Meta;
 use crate::views::settings::Settings;
 use crate::views::settings::wizard::SetupWizard;
 
@@ -50,6 +51,8 @@ pub(crate) enum Route {
         Ops {},
         #[route("/sessions")]
         Sessions {},
+        #[route("/meta")]
+        Meta {},
         #[route("/settings")]
         Settings {},
 }

--- a/crates/theatron/desktop/src/layout.rs
+++ b/crates/theatron/desktop/src/layout.rs
@@ -97,6 +97,7 @@ pub(crate) fn Layout() -> Element {
                 NavItem { to: Route::Metrics {}, icon: "[X]", label: "Metrics", shortcut: "Ctrl+5" }
                 NavItem { to: Route::Ops {}, icon: "[O]", label: "Ops", shortcut: "Ctrl+6" }
                 NavItem { to: Route::Sessions {}, icon: "[T]", label: "Sessions", shortcut: "Ctrl+7" }
+                NavItem { to: Route::Meta {}, icon: "[I]", label: "Insights", shortcut: "" }
                 NavItem { to: Route::Settings {}, icon: "[S]", label: "Settings", shortcut: "" }
                 div { style: "{NAV_DIVIDER_STYLE}", role: "separator" }
                 AgentSidebarView {}

--- a/crates/theatron/desktop/src/state/meta.rs
+++ b/crates/theatron/desktop/src/state/meta.rs
@@ -1,0 +1,818 @@
+//! Meta-insights state: agent performance, conversation quality, knowledge growth,
+//! memory health, and system self-reflection.
+
+use std::collections::HashMap;
+
+// -- Shared types -------------------------------------------------------------
+
+/// A single data point in a time series.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct DataPoint {
+    pub label: String,
+    pub value: f64,
+}
+
+/// Direction of a trend.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub(crate) enum TrendDirection {
+    Up,
+    Down,
+    #[default]
+    Flat,
+}
+
+impl TrendDirection {
+    #[must_use]
+    pub(crate) fn arrow(&self) -> &'static str {
+        match self {
+            Self::Up => "\u{25b2}",     // ▲
+            Self::Down => "\u{25bc}",   // ▼
+            Self::Flat => "\u{2014}",   // —
+        }
+    }
+
+    #[must_use]
+    pub(crate) fn color(&self) -> &'static str {
+        match self {
+            Self::Up => "#22c55e",
+            Self::Down => "#ef4444",
+            Self::Flat => "#888",
+        }
+    }
+}
+
+// -- Agent performance --------------------------------------------------------
+
+/// Performance scorecard for a single agent.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct AgentScorecard {
+    pub agent_id: String,
+    pub agent_name: String,
+    pub avg_tokens_per_response: f64,
+    pub tool_calls_per_session: f64,
+    pub tool_success_rate: f64,
+    pub distillation_frequency: f64,
+    pub avg_context_before_distill: f64,
+    pub messages_per_session: f64,
+    pub sessions_per_day: f64,
+    pub errors_per_session: f64,
+}
+
+impl AgentScorecard {
+    /// Normalized radar axes: response quality, tool efficiency, context management,
+    /// productivity, reliability. Each value is 0.0–1.0.
+    #[must_use]
+    pub(crate) fn radar_axes(&self) -> [f64; 5] {
+        [
+            // WHY: Lower tokens-per-response = more concise = higher quality score.
+            // Normalize against 2000 tokens as a "verbose" baseline.
+            (1.0 - (self.avg_tokens_per_response / 2000.0).min(1.0)).max(0.0),
+            self.tool_success_rate.clamp(0.0, 1.0),
+            // WHY: Lower distillation frequency = better context management.
+            (1.0 - (self.distillation_frequency / 10.0).min(1.0)).max(0.0),
+            // WHY: More messages per session = more productive (capped at 50).
+            (self.messages_per_session / 50.0).clamp(0.0, 1.0),
+            // WHY: Fewer errors = more reliable (invert).
+            (1.0 - (self.errors_per_session / 5.0).min(1.0)).max(0.0),
+        ]
+    }
+}
+
+/// An anomaly detected in agent performance metrics.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct Anomaly {
+    pub agent_name: String,
+    pub metric_name: String,
+    pub current_value: f64,
+    pub baseline_mean: f64,
+    pub deviation_pct: f64,
+    pub direction: TrendDirection,
+}
+
+impl Anomaly {
+    /// Formatted alert message.
+    #[must_use]
+    pub(crate) fn message(&self) -> String {
+        let dir = if self.deviation_pct > 0.0 {
+            "increased"
+        } else {
+            "decreased"
+        };
+        format!(
+            "{}'s {} {} {:.0}% this week ({:.1} vs {:.1} avg)",
+            self.agent_name,
+            self.metric_name,
+            dir,
+            self.deviation_pct.abs(),
+            self.current_value,
+            self.baseline_mean,
+        )
+    }
+}
+
+/// Detect anomalies using z-score approach.
+///
+/// Returns entries where the latest value exceeds 2 standard deviations from
+/// the mean of `values`. Returns `None` if insufficient data.
+#[must_use]
+#[expect(dead_code, reason = "used in tests; wired when SSE anomaly detection is plumbed")]
+pub(crate) fn detect_anomaly(
+    agent_name: &str,
+    metric_name: &str,
+    values: &[f64],
+) -> Option<Anomaly> {
+    if values.len() < 3 {
+        return None;
+    }
+
+    let n = values.len();
+    let mean = values.iter().sum::<f64>() / n as f64;
+    let variance = values.iter().map(|v| (v - mean).powi(2)).sum::<f64>() / n as f64;
+    let std_dev = variance.sqrt();
+
+    if std_dev < f64::EPSILON {
+        return None;
+    }
+
+    let latest = values[n - 1];
+    let z_score = (latest - mean) / std_dev;
+
+    if z_score.abs() < 2.0 {
+        return None;
+    }
+
+    let deviation_pct = if mean.abs() > f64::EPSILON {
+        ((latest - mean) / mean) * 100.0
+    } else {
+        0.0
+    };
+
+    let direction = if latest > mean {
+        TrendDirection::Up
+    } else {
+        TrendDirection::Down
+    };
+
+    Some(Anomaly {
+        agent_name: agent_name.to_string(),
+        metric_name: metric_name.to_string(),
+        current_value: latest,
+        baseline_mean: mean,
+        deviation_pct,
+        direction,
+    })
+}
+
+/// Store for agent performance data.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub(crate) struct AgentPerformanceStore {
+    pub scorecards: Vec<AgentScorecard>,
+    pub anomalies: Vec<Anomaly>,
+    pub tokens_per_response_series: HashMap<String, Vec<DataPoint>>,
+}
+
+impl AgentPerformanceStore {
+    #[must_use]
+    #[expect(dead_code, reason = "constructed via struct literal in view; new() for test convenience")]
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+}
+
+// -- Conversation quality -----------------------------------------------------
+
+/// Conversation quality time series data.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub(crate) struct QualityStore {
+    pub avg_turn_length: Vec<DataPoint>,
+    pub response_to_question_ratio: Vec<DataPoint>,
+    pub tool_call_density: Vec<DataPoint>,
+    pub thinking_time_ratio: Vec<DataPoint>,
+    pub depth_distribution: DepthDistribution,
+    pub top_topics: Vec<TopicEntry>,
+}
+
+impl QualityStore {
+    #[must_use]
+    #[expect(dead_code, reason = "constructed via struct literal in view")]
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+}
+
+/// Session depth distribution buckets.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub(crate) struct DepthDistribution {
+    pub short: u32,
+    pub medium: u32,
+    pub long: u32,
+}
+
+impl DepthDistribution {
+    /// Classify a session by message count into a depth bucket.
+    pub(crate) fn classify(message_count: u32) -> &'static str {
+        match message_count {
+            0..10 => "short",
+            10..50 => "medium",
+            _ => "long",
+        }
+    }
+
+    /// Total sessions across all buckets.
+    #[must_use]
+    pub(crate) fn total(&self) -> u32 {
+        self.short + self.medium + self.long
+    }
+
+    /// Percentage for a given bucket.
+    #[must_use]
+    #[expect(dead_code, reason = "used in tests; available for view consumption")]
+    pub(crate) fn pct(&self, bucket: u32) -> f64 {
+        let total = self.total();
+        if total == 0 {
+            return 0.0;
+        }
+        (f64::from(bucket) / f64::from(total)) * 100.0
+    }
+}
+
+/// A topic with its frequency.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct TopicEntry {
+    pub name: String,
+    pub count: u32,
+}
+
+/// Compute average turn length from a slice of message lengths.
+#[must_use]
+#[expect(dead_code, reason = "used in tests; wired when per-message metrics are available")]
+pub(crate) fn compute_average(values: &[f64]) -> f64 {
+    if values.is_empty() {
+        return 0.0;
+    }
+    values.iter().sum::<f64>() / values.len() as f64
+}
+
+/// Compute ratio of agent turns to user turns.
+#[must_use]
+#[expect(dead_code, reason = "used in tests; wired when per-turn metrics are available")]
+pub(crate) fn compute_ratio(numerator: u64, denominator: u64) -> f64 {
+    if denominator == 0 {
+        return 0.0;
+    }
+    numerator as f64 / denominator as f64
+}
+
+// -- Knowledge growth ---------------------------------------------------------
+
+/// Knowledge graph growth metrics over time.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub(crate) struct KnowledgeGrowthStore {
+    pub total_entities: Vec<DataPoint>,
+    pub new_entities_per_period: Vec<DataPoint>,
+    pub total_relationships: Vec<DataPoint>,
+    pub new_relationships_per_period: Vec<DataPoint>,
+    pub density_over_time: Vec<DataPoint>,
+    pub entity_type_distribution: Vec<EntityTypeSlice>,
+    pub current_entity_rate: f64,
+    pub current_relationship_rate: f64,
+    pub acceleration: TrendDirection,
+}
+
+impl KnowledgeGrowthStore {
+    #[must_use]
+    #[expect(dead_code, reason = "constructed via struct literal in view")]
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+}
+
+/// A single slice of the entity type distribution.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct EntityTypeSlice {
+    pub entity_type: String,
+    pub count: u32,
+    pub color: &'static str,
+}
+
+/// Compute growth acceleration from a series of cumulative counts.
+///
+/// Positive = speeding up, negative = slowing down, ~0 = steady.
+#[must_use]
+pub(crate) fn compute_acceleration(values: &[f64]) -> TrendDirection {
+    if values.len() < 3 {
+        return TrendDirection::Flat;
+    }
+
+    let n = values.len();
+    // WHY: Second derivative approximation — compare recent growth rate to prior.
+    let recent_growth = values[n - 1] - values[n - 2];
+    let prior_growth = values[n - 2] - values[n - 3];
+
+    let diff = recent_growth - prior_growth;
+    if diff > 1.0 {
+        TrendDirection::Up
+    } else if diff < -1.0 {
+        TrendDirection::Down
+    } else {
+        TrendDirection::Flat
+    }
+}
+
+/// Palette for entity type stacked area charts.
+pub(crate) const ENTITY_TYPE_COLORS: &[&str] = &[
+    "#4a9aff", "#22c55e", "#f59e0b", "#ef4444", "#8b5cf6",
+    "#ec4899", "#06b6d4", "#84cc16", "#f97316", "#6366f1",
+];
+
+// -- Memory health ------------------------------------------------------------
+
+/// Composite memory health data.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub(crate) struct MemoryHealthStore {
+    pub health_score: f64,
+    pub confidence_distribution: Vec<ConfidenceBucket>,
+    pub stale_entities: Vec<StaleEntity>,
+    pub orphan_ratio: f64,
+    pub decay_pressure_count: u32,
+    pub health_over_time: Vec<DataPoint>,
+    pub recommendations: Vec<String>,
+}
+
+impl MemoryHealthStore {
+    #[must_use]
+    #[expect(dead_code, reason = "constructed via struct literal in view")]
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+}
+
+/// A bucket in the confidence distribution histogram.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct ConfidenceBucket {
+    pub range_label: String,
+    pub count: u32,
+}
+
+/// An entity that hasn't been updated recently.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct StaleEntity {
+    pub name: String,
+    pub last_updated: String,
+    pub days_stale: u32,
+}
+
+/// Compute composite memory health score.
+///
+/// Weights: confidence_score 0.4, (1 - orphan_ratio) 0.3, (1 - staleness_ratio) 0.3.
+#[must_use]
+pub(crate) fn compute_health_score(
+    avg_confidence: f64,
+    orphan_ratio: f64,
+    staleness_ratio: f64,
+) -> f64 {
+    // INVARIANT: All inputs should be 0.0–1.0; clamp defensively.
+    let c = avg_confidence.clamp(0.0, 1.0);
+    let o = orphan_ratio.clamp(0.0, 1.0);
+    let s = staleness_ratio.clamp(0.0, 1.0);
+
+    c * 0.4 + (1.0 - o) * 0.3 + (1.0 - s) * 0.3
+}
+
+/// Color for a health score (0.0–1.0).
+#[must_use]
+pub(crate) fn health_score_color(score: f64) -> &'static str {
+    if score >= 0.7 {
+        "#22c55e"
+    } else if score >= 0.4 {
+        "#f59e0b"
+    } else {
+        "#ef4444"
+    }
+}
+
+/// Generate recommendations based on health metrics.
+#[must_use]
+pub(crate) fn generate_recommendations(
+    staleness_ratio: f64,
+    orphan_ratio: f64,
+    avg_confidence: f64,
+    growth_rate: f64,
+) -> Vec<String> {
+    let mut recs = Vec::new();
+
+    if staleness_ratio > 0.15 {
+        recs.push(format!(
+            "{:.0}% of entities are stale \u{2014} review or archive",
+            staleness_ratio * 100.0
+        ));
+    }
+    if orphan_ratio > 0.2 {
+        recs.push(format!(
+            "{:.0}% of entities are orphaned \u{2014} consider linking or removing",
+            orphan_ratio * 100.0
+        ));
+    }
+    if avg_confidence < 0.5 {
+        recs.push(
+            "Average confidence is low \u{2014} verify or reinforce key facts".to_string(),
+        );
+    }
+    if growth_rate < 1.0 {
+        recs.push(
+            "Knowledge growth has slowed \u{2014} consider seeding new topics".to_string(),
+        );
+    }
+
+    recs
+}
+
+// -- System reflection --------------------------------------------------------
+
+/// System overview statistics.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub(crate) struct SystemOverview {
+    pub uptime_seconds: u64,
+    pub total_sessions: u64,
+    pub total_tokens: u64,
+    pub total_entities: u64,
+    pub total_cost_usd: f64,
+}
+
+/// A cell in the activity heatmap (hour-of-day vs day-of-week).
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct HeatmapCell {
+    pub day: u8,
+    pub hour: u8,
+    pub count: u32,
+}
+
+/// Resource efficiency metrics.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub(crate) struct EfficiencyMetrics {
+    pub cost_per_entity: f64,
+    pub cost_per_session: f64,
+    pub tokens_per_entity: f64,
+    pub cost_per_entity_trend: TrendDirection,
+}
+
+/// A system journal event.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct JournalEvent {
+    pub timestamp: String,
+    pub event_type: JournalEventType,
+    pub message: String,
+}
+
+/// Types of system journal events.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum JournalEventType {
+    Error,
+    Distillation,
+    ConfigChange,
+    MemoryMerge,
+}
+
+impl JournalEventType {
+    #[must_use]
+    pub(crate) fn label(&self) -> &'static str {
+        match self {
+            Self::Error => "error",
+            Self::Distillation => "distillation",
+            Self::ConfigChange => "config",
+            Self::MemoryMerge => "memory",
+        }
+    }
+
+    #[must_use]
+    pub(crate) fn color(&self) -> &'static str {
+        match self {
+            Self::Error => "#ef4444",
+            Self::Distillation => "#4a9aff",
+            Self::ConfigChange => "#f59e0b",
+            Self::MemoryMerge => "#22c55e",
+        }
+    }
+}
+
+/// Store for system self-reflection data.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub(crate) struct SystemReflectionStore {
+    pub overview: SystemOverview,
+    pub heatmap: Vec<HeatmapCell>,
+    pub efficiency: EfficiencyMetrics,
+    pub journal: Vec<JournalEvent>,
+}
+
+impl SystemReflectionStore {
+    #[must_use]
+    #[expect(dead_code, reason = "constructed via struct literal in view")]
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+}
+
+/// Build activity heatmap from session timestamps.
+///
+/// Expects timestamps as `(day_of_week 0=Mon..6=Sun, hour 0..23)` tuples.
+#[must_use]
+pub(crate) fn build_heatmap(timestamps: &[(u8, u8)]) -> Vec<HeatmapCell> {
+    let mut grid = [[0u32; 24]; 7];
+
+    for &(day, hour) in timestamps {
+        if day < 7 && hour < 24 {
+            grid[day as usize][hour as usize] += 1;
+        }
+    }
+
+    let mut cells = Vec::with_capacity(7 * 24);
+    for day in 0..7u8 {
+        for hour in 0..24u8 {
+            cells.push(HeatmapCell {
+                day,
+                hour,
+                count: grid[day as usize][hour as usize],
+            });
+        }
+    }
+    cells
+}
+
+/// Color for a heatmap cell intensity (0 = empty, higher = more active).
+#[must_use]
+pub(crate) fn heatmap_color(count: u32, max_count: u32) -> &'static str {
+    if max_count == 0 || count == 0 {
+        return "#1a1a2e";
+    }
+    let ratio = f64::from(count) / f64::from(max_count);
+    if ratio > 0.75 {
+        "#22c55e"
+    } else if ratio > 0.5 {
+        "#4a9aff"
+    } else if ratio > 0.25 {
+        "#2a4a6a"
+    } else {
+        "#1a2a3e"
+    }
+}
+
+/// Compute cost-per-entity.
+#[must_use]
+pub(crate) fn cost_per_entity(total_cost: f64, total_entities: u64) -> f64 {
+    if total_entities == 0 {
+        return 0.0;
+    }
+    total_cost / total_entities as f64
+}
+
+/// Compute tokens-per-entity.
+#[must_use]
+pub(crate) fn tokens_per_entity(total_tokens: u64, total_entities: u64) -> f64 {
+    if total_entities == 0 {
+        return 0.0;
+    }
+    total_tokens as f64 / total_entities as f64
+}
+
+// -- Tests --------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detect_anomaly_requires_minimum_data() {
+        assert!(detect_anomaly("a", "m", &[]).is_none());
+        assert!(detect_anomaly("a", "m", &[1.0, 2.0]).is_none());
+    }
+
+    #[test]
+    fn detect_anomaly_flags_spike() {
+        // WHY: 10 values near 5.0, then a spike to 20.0 should trigger.
+        let mut values = vec![5.0; 10];
+        values.push(20.0);
+        let anomaly = detect_anomaly("steward", "error rate", &values);
+        assert!(anomaly.is_some(), "spike should be detected");
+        let a = anomaly.expect("checked above");
+        assert_eq!(a.agent_name, "steward");
+        assert_eq!(a.direction, TrendDirection::Up);
+        assert!(a.deviation_pct > 100.0);
+    }
+
+    #[test]
+    fn detect_anomaly_ignores_normal_variation() {
+        let values = vec![5.0, 5.1, 4.9, 5.0, 5.2, 4.8, 5.0];
+        assert!(
+            detect_anomaly("a", "m", &values).is_none(),
+            "normal variation should not trigger"
+        );
+    }
+
+    #[test]
+    fn detect_anomaly_constant_series() {
+        let values = vec![3.0, 3.0, 3.0, 3.0];
+        assert!(
+            detect_anomaly("a", "m", &values).is_none(),
+            "zero variance should not trigger"
+        );
+    }
+
+    #[test]
+    fn compute_health_score_perfect() {
+        let score = compute_health_score(1.0, 0.0, 0.0);
+        assert!((score - 1.0).abs() < f64::EPSILON, "perfect health = 1.0");
+    }
+
+    #[test]
+    fn compute_health_score_worst() {
+        let score = compute_health_score(0.0, 1.0, 1.0);
+        assert!(score.abs() < f64::EPSILON, "worst health = 0.0");
+    }
+
+    #[test]
+    fn compute_health_score_mixed() {
+        let score = compute_health_score(0.8, 0.2, 0.1);
+        // 0.8*0.4 + 0.8*0.3 + 0.9*0.3 = 0.32 + 0.24 + 0.27 = 0.83
+        assert!(
+            (score - 0.83).abs() < 0.01,
+            "mixed score should be ~0.83, got {score}"
+        );
+    }
+
+    #[test]
+    fn compute_health_score_clamps_inputs() {
+        let score = compute_health_score(1.5, -0.1, 2.0);
+        // Clamped: 1.0*0.4 + 1.0*0.3 + (1-1)*0.3 = 0.7
+        assert!(
+            (score - 0.7).abs() < f64::EPSILON,
+            "out-of-range inputs should be clamped"
+        );
+    }
+
+    #[test]
+    fn compute_acceleration_up() {
+        let values = vec![10.0, 15.0, 25.0];
+        // recent_growth=10, prior_growth=5, diff=5 > 1.0 → Up
+        assert_eq!(compute_acceleration(&values), TrendDirection::Up);
+    }
+
+    #[test]
+    fn compute_acceleration_down() {
+        let values = vec![10.0, 25.0, 30.0];
+        // recent_growth=5, prior_growth=15, diff=-10 < -1.0 → Down
+        assert_eq!(compute_acceleration(&values), TrendDirection::Down);
+    }
+
+    #[test]
+    fn compute_acceleration_flat() {
+        let values = vec![10.0, 15.0, 20.0];
+        // recent_growth=5, prior_growth=5, diff=0 → Flat
+        assert_eq!(compute_acceleration(&values), TrendDirection::Flat);
+    }
+
+    #[test]
+    fn compute_acceleration_insufficient_data() {
+        assert_eq!(compute_acceleration(&[1.0, 2.0]), TrendDirection::Flat);
+    }
+
+    #[test]
+    fn build_heatmap_dimensions() {
+        let cells = build_heatmap(&[]);
+        assert_eq!(cells.len(), 168, "7 days * 24 hours = 168 cells");
+    }
+
+    #[test]
+    fn build_heatmap_counts() {
+        let timestamps = vec![(0, 9), (0, 9), (0, 10), (6, 23)];
+        let cells = build_heatmap(&timestamps);
+        let mon_9 = cells.iter().find(|c| c.day == 0 && c.hour == 9).expect("cell exists");
+        assert_eq!(mon_9.count, 2);
+        let sun_23 = cells.iter().find(|c| c.day == 6 && c.hour == 23).expect("cell exists");
+        assert_eq!(sun_23.count, 1);
+    }
+
+    #[test]
+    fn build_heatmap_ignores_out_of_range() {
+        let timestamps = vec![(7, 0), (0, 24), (255, 255)];
+        let cells = build_heatmap(&timestamps);
+        let total: u32 = cells.iter().map(|c| c.count).sum();
+        assert_eq!(total, 0, "out-of-range timestamps must be ignored");
+    }
+
+    #[test]
+    fn cost_per_entity_zero_entities() {
+        assert!(cost_per_entity(100.0, 0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn cost_per_entity_normal() {
+        let cpe = cost_per_entity(50.0, 100);
+        assert!((cpe - 0.5).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn tokens_per_entity_zero_entities() {
+        assert!(tokens_per_entity(1000, 0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn depth_distribution_classify() {
+        assert_eq!(DepthDistribution::classify(0), "short");
+        assert_eq!(DepthDistribution::classify(9), "short");
+        assert_eq!(DepthDistribution::classify(10), "medium");
+        assert_eq!(DepthDistribution::classify(49), "medium");
+        assert_eq!(DepthDistribution::classify(50), "long");
+        assert_eq!(DepthDistribution::classify(500), "long");
+    }
+
+    #[test]
+    fn depth_distribution_pct_empty() {
+        let d = DepthDistribution::default();
+        assert!(d.pct(0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn compute_average_empty() {
+        assert!(compute_average(&[]).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn compute_average_normal() {
+        let avg = compute_average(&[10.0, 20.0, 30.0]);
+        assert!((avg - 20.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn compute_ratio_zero_denominator() {
+        assert!(compute_ratio(10, 0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn compute_ratio_normal() {
+        let r = compute_ratio(30, 10);
+        assert!((r - 3.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn generate_recommendations_healthy() {
+        let recs = generate_recommendations(0.05, 0.1, 0.8, 5.0);
+        assert!(recs.is_empty(), "healthy metrics should produce no recommendations");
+    }
+
+    #[test]
+    fn generate_recommendations_unhealthy() {
+        let recs = generate_recommendations(0.25, 0.3, 0.3, 0.5);
+        assert_eq!(recs.len(), 4, "all thresholds exceeded");
+    }
+
+    #[test]
+    fn heatmap_color_zero() {
+        assert_eq!(heatmap_color(0, 10), "#1a1a2e");
+        assert_eq!(heatmap_color(0, 0), "#1a1a2e");
+    }
+
+    #[test]
+    fn heatmap_color_high() {
+        assert_eq!(heatmap_color(10, 10), "#22c55e");
+    }
+
+    #[test]
+    fn anomaly_message_format() {
+        let a = Anomaly {
+            agent_name: "steward".to_string(),
+            metric_name: "error rate".to_string(),
+            current_value: 12.0,
+            baseline_mean: 5.5,
+            deviation_pct: 118.0,
+            direction: TrendDirection::Up,
+        };
+        let msg = a.message();
+        assert!(msg.contains("steward"));
+        assert!(msg.contains("error rate"));
+        assert!(msg.contains("increased"));
+        assert!(msg.contains("118%"));
+    }
+
+    #[test]
+    fn radar_axes_bounded() {
+        let card = AgentScorecard {
+            agent_id: "test".to_string(),
+            agent_name: "Test".to_string(),
+            avg_tokens_per_response: 500.0,
+            tool_calls_per_session: 10.0,
+            tool_success_rate: 0.95,
+            distillation_frequency: 2.0,
+            avg_context_before_distill: 80.0,
+            messages_per_session: 25.0,
+            sessions_per_day: 3.0,
+            errors_per_session: 0.5,
+        };
+        let axes = card.radar_axes();
+        for (i, &v) in axes.iter().enumerate() {
+            assert!(
+                (0.0..=1.0).contains(&v),
+                "axis {i} = {v} out of bounds"
+            );
+        }
+    }
+}

--- a/crates/theatron/desktop/src/state/mod.rs
+++ b/crates/theatron/desktop/src/state/mod.rs
@@ -44,6 +44,8 @@ pub mod tools;
 /// Goal-backward verification state for the planning project detail view.
 pub(crate) mod verification;
 
+/// Meta-insights state: agent performance, quality, knowledge, health, reflection.
+pub(crate) mod meta;
 /// Ops dashboard state: agent status cards, service health, toggle controls.
 pub(crate) mod ops;
 /// Settings state: server configs, appearance, keybindings, wizard flow.

--- a/crates/theatron/desktop/src/views/meta/health.rs
+++ b/crates/theatron/desktop/src/views/meta/health.rs
@@ -1,0 +1,223 @@
+//! Memory health dashboard: composite score, confidence distribution, staleness.
+
+use dioxus::prelude::*;
+
+use crate::state::meta::{health_score_color, MemoryHealthStore};
+use crate::views::meta::{
+    LineChart, CARD_LABEL, CARD_STYLE, CARD_SUB, CARD_VALUE, GRID_STYLE, MUTED_TEXT,
+};
+
+const TABLE_HEADER_STYLE: &str = "\
+    display: flex; \
+    padding: 8px 12px; \
+    background: #1a1a2e; \
+    border-bottom: 1px solid #333; \
+    font-size: 11px; \
+    color: #888; \
+    text-transform: uppercase; \
+    letter-spacing: 0.5px;\
+";
+
+const TABLE_ROW_STYLE: &str = "\
+    display: flex; \
+    padding: 8px 12px; \
+    border-bottom: 1px solid #2a2a3a; \
+    font-size: 13px; \
+    color: #e0e0e0;\
+";
+
+const REC_STYLE: &str = "\
+    background: #1a1a2e; \
+    border-left: 3px solid #f59e0b; \
+    padding: 10px 14px; \
+    font-size: 13px; \
+    color: #e0e0e0; \
+    margin-bottom: 6px; \
+    border-radius: 0 6px 6px 0;\
+";
+
+const HISTOGRAM_BAR_STYLE: &str = "\
+    display: flex; \
+    align-items: flex-end; \
+    gap: 2px;\
+";
+
+#[component]
+pub(super) fn MemoryHealthSection(store: MemoryHealthStore) -> Element {
+    let score_color = health_score_color(store.health_score);
+    let score_pct = store.health_score * 100.0;
+
+    rsx! {
+        // NOTE: Health overview cards.
+        div {
+            style: "{GRID_STYLE}",
+            div {
+                style: "{CARD_STYLE} flex: 1; min-width: 140px; text-align: center;",
+                div {
+                    style: "{CARD_VALUE} color: {score_color};",
+                    "{score_pct:.0}%"
+                }
+                div { style: "{CARD_LABEL}", "Health Score" }
+                div { style: "{CARD_SUB}",
+                    "confidence 40% + connectivity 30% + freshness 30%"
+                }
+            }
+            div {
+                style: "{CARD_STYLE} flex: 1; min-width: 140px; text-align: center;",
+                div { style: "{CARD_VALUE}", "{store.orphan_ratio * 100.0:.0}%" }
+                div { style: "{CARD_LABEL}", "Orphan Ratio" }
+                div { style: "{CARD_SUB}", "Entities with 0-1 relationships" }
+            }
+            div {
+                style: "{CARD_STYLE} flex: 1; min-width: 140px; text-align: center;",
+                div { style: "{CARD_VALUE}", "{store.decay_pressure_count}" }
+                div { style: "{CARD_LABEL}", "Decay Pressure" }
+                div { style: "{CARD_SUB}", "Near FSRS threshold" }
+            }
+        }
+
+        // NOTE: Confidence distribution histogram.
+        h3 {
+            style: "font-size: 14px; color: #aaa; margin: 16px 0 12px 0;",
+            "Confidence Distribution"
+        }
+        ConfidenceHistogram { buckets: store.confidence_distribution.clone() }
+
+        // NOTE: Health trend over time.
+        if !store.health_over_time.is_empty() {
+            h3 {
+                style: "font-size: 14px; color: #aaa; margin: 16px 0 12px 0;",
+                "Health Trend"
+            }
+            div {
+                style: "{CARD_STYLE}",
+                LineChart {
+                    data: store.health_over_time.clone(),
+                    width: 600.0,
+                    height: 150.0,
+                    color: "#22c55e",
+                    show_labels: true,
+                }
+            }
+        }
+
+        // NOTE: Staleness table.
+        if !store.stale_entities.is_empty() {
+            h3 {
+                style: "font-size: 14px; color: #aaa; margin: 16px 0 12px 0;",
+                "Stale Entities"
+            }
+            div {
+                style: "border: 1px solid #333; border-radius: 8px; overflow: hidden;",
+                div {
+                    style: "{TABLE_HEADER_STYLE}",
+                    span { style: "flex: 2;", "Entity" }
+                    span { style: "flex: 1;", "Last Updated" }
+                    span { style: "flex: 1; text-align: right;", "Days Stale" }
+                }
+                for entity in &store.stale_entities {
+                    {
+                        let staleness_color = if entity.days_stale > 90 {
+                            "#ef4444"
+                        } else if entity.days_stale > 60 {
+                            "#f59e0b"
+                        } else {
+                            "#888"
+                        };
+                        rsx! {
+                            div {
+                                style: "{TABLE_ROW_STYLE}",
+                                span { style: "flex: 2;", "{entity.name}" }
+                                span { style: "flex: 1; color: #888;", "{entity.last_updated}" }
+                                span {
+                                    style: "flex: 1; text-align: right; color: {staleness_color};",
+                                    "{entity.days_stale}d"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // NOTE: Recommendations.
+        if !store.recommendations.is_empty() {
+            h3 {
+                style: "font-size: 14px; color: #aaa; margin: 16px 0 12px 0;",
+                "Recommendations"
+            }
+            for rec in &store.recommendations {
+                div { style: "{REC_STYLE}", "{rec}" }
+            }
+        }
+    }
+}
+
+#[component]
+fn ConfidenceHistogram(
+    buckets: Vec<crate::state::meta::ConfidenceBucket>,
+) -> Element {
+    if buckets.is_empty() {
+        return rsx! {
+            div { style: "{MUTED_TEXT}", "No confidence data" }
+        };
+    }
+
+    let max_count = buckets.iter().map(|b| b.count).max().unwrap_or(1).max(1);
+    let bar_height = 100.0;
+
+    rsx! {
+        div {
+            style: "{CARD_STYLE}",
+            div {
+                style: "{HISTOGRAM_BAR_STYLE} height: {bar_height}px;",
+                for bucket in &buckets {
+                    {
+                        let h = if max_count > 0 {
+                            (f64::from(bucket.count) / f64::from(max_count)) * bar_height
+                        } else {
+                            0.0
+                        };
+                        let color = confidence_bucket_color(&bucket.range_label);
+                        rsx! {
+                            div {
+                                style: "display: flex; flex-direction: column; align-items: center; \
+                                        flex: 1; justify-content: flex-end;",
+                                if bucket.count > 0 {
+                                    span {
+                                        style: "font-size: 10px; color: #888; margin-bottom: 2px;",
+                                        "{bucket.count}"
+                                    }
+                                }
+                                div {
+                                    style: "width: 80%; height: {h:.0}px; background: {color}; \
+                                            border-radius: 2px 2px 0 0; min-height: 1px;",
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            div {
+                style: "display: flex; margin-top: 4px;",
+                for bucket in &buckets {
+                    span {
+                        style: "flex: 1; text-align: center; font-size: 9px; color: #666;",
+                        "{bucket.range_label}"
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Color for a confidence bucket based on its range.
+fn confidence_bucket_color(range_label: &str) -> &'static str {
+    // WHY: Higher confidence = greener, lower = redder.
+    match range_label {
+        s if s.starts_with("0.8") || s.starts_with("0.9") => "#22c55e",
+        s if s.starts_with("0.6") || s.starts_with("0.7") => "#4a9aff",
+        s if s.starts_with("0.4") || s.starts_with("0.5") => "#f59e0b",
+        _ => "#ef4444",
+    }
+}

--- a/crates/theatron/desktop/src/views/meta/knowledge.rs
+++ b/crates/theatron/desktop/src/views/meta/knowledge.rs
@@ -1,0 +1,153 @@
+//! Knowledge growth rate: entity/relationship trends, type distribution.
+
+use dioxus::prelude::*;
+
+use crate::state::meta::KnowledgeGrowthStore;
+use crate::views::meta::{
+    BarChart, LineChart, CARD_LABEL, CARD_STYLE, CARD_SUB, CARD_VALUE, GRID_STYLE,
+};
+
+#[component]
+pub(super) fn KnowledgeGrowthSection(store: KnowledgeGrowthStore) -> Element {
+    let accel_arrow = store.acceleration.arrow();
+    let accel_color = store.acceleration.color();
+
+    rsx! {
+        // NOTE: Growth rate summary cards.
+        h3 { style: "font-size: 14px; color: #aaa; margin: 0 0 12px 0;", "Growth Rate" }
+        div {
+            style: "{GRID_STYLE}",
+            div {
+                style: "{CARD_STYLE} flex: 1; min-width: 140px;",
+                div { style: "{CARD_VALUE}", "{store.current_entity_rate:.0}" }
+                div { style: "{CARD_LABEL}", "Entities / period" }
+            }
+            div {
+                style: "{CARD_STYLE} flex: 1; min-width: 140px;",
+                div { style: "{CARD_VALUE}", "{store.current_relationship_rate:.0}" }
+                div { style: "{CARD_LABEL}", "Relationships / period" }
+            }
+            div {
+                style: "{CARD_STYLE} flex: 1; min-width: 140px;",
+                div {
+                    style: "{CARD_VALUE} color: {accel_color};",
+                    "{accel_arrow}"
+                }
+                div { style: "{CARD_LABEL}", "Acceleration" }
+                div { style: "{CARD_SUB}",
+                    match store.acceleration {
+                        crate::state::meta::TrendDirection::Up => "Growth speeding up",
+                        crate::state::meta::TrendDirection::Down => "Growth slowing down",
+                        crate::state::meta::TrendDirection::Flat => "Steady growth",
+                    }
+                }
+            }
+        }
+
+        // NOTE: Cumulative entity growth.
+        h3 {
+            style: "font-size: 14px; color: #aaa; margin: 16px 0 12px 0;",
+            "Total Entities Over Time"
+        }
+        div {
+            style: "{CARD_STYLE}",
+            LineChart {
+                data: store.total_entities.clone(),
+                width: 600.0,
+                height: 200.0,
+                color: "#4a9aff",
+                show_labels: true,
+            }
+        }
+
+        // NOTE: New entities per period.
+        h3 {
+            style: "font-size: 14px; color: #aaa; margin: 16px 0 12px 0;",
+            "New Entities Per Period"
+        }
+        div {
+            style: "{CARD_STYLE}",
+            BarChart {
+                data: store.new_entities_per_period.clone(),
+                width: 600.0,
+                height: 180.0,
+                color: "#22c55e",
+            }
+        }
+
+        // NOTE: Knowledge density.
+        if !store.density_over_time.is_empty() {
+            h3 {
+                style: "font-size: 14px; color: #aaa; margin: 16px 0 12px 0;",
+                "Knowledge Density (Relationships / Entity)"
+            }
+            div {
+                style: "{CARD_STYLE}",
+                LineChart {
+                    data: store.density_over_time.clone(),
+                    width: 600.0,
+                    height: 150.0,
+                    color: "#f59e0b",
+                    show_labels: true,
+                }
+            }
+        }
+
+        // NOTE: Entity type distribution.
+        if !store.entity_type_distribution.is_empty() {
+            h3 {
+                style: "font-size: 14px; color: #aaa; margin: 16px 0 12px 0;",
+                "Entity Type Distribution"
+            }
+            EntityTypeBreakdown { slices: store.entity_type_distribution.clone() }
+        }
+    }
+}
+
+#[component]
+fn EntityTypeBreakdown(slices: Vec<crate::state::meta::EntityTypeSlice>) -> Element {
+    let total: u32 = slices.iter().map(|s| s.count).sum();
+    let max_count = slices.iter().map(|s| s.count).max().unwrap_or(1).max(1);
+
+    rsx! {
+        div {
+            style: "{CARD_STYLE}",
+            for slice in &slices {
+                {
+                    let pct = if total > 0 {
+                        (f64::from(slice.count) / f64::from(total)) * 100.0
+                    } else {
+                        0.0
+                    };
+                    let bar_pct = (f64::from(slice.count) / f64::from(max_count)) * 100.0;
+                    let color = slice.color;
+                    rsx! {
+                        div {
+                            style: "display: flex; align-items: center; gap: 8px; margin-bottom: 6px;",
+                            div {
+                                style: "width: 10px; height: 10px; border-radius: 2px; \
+                                        background: {color}; flex-shrink: 0;",
+                            }
+                            span {
+                                style: "font-size: 12px; color: #aaa; width: 100px;",
+                                "{slice.entity_type}"
+                            }
+                            div {
+                                style: "flex: 1; height: 16px; background: #2a2a3a; \
+                                        border-radius: 4px; overflow: hidden;",
+                                div {
+                                    style: "height: 100%; width: {bar_pct:.0}%; background: {color}; \
+                                            border-radius: 4px;",
+                                }
+                            }
+                            span {
+                                style: "font-size: 11px; color: #888; width: 70px; text-align: right;",
+                                "{slice.count} ({pct:.0}%)"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/crates/theatron/desktop/src/views/meta/mod.rs
+++ b/crates/theatron/desktop/src/views/meta/mod.rs
@@ -1,0 +1,967 @@
+//! Meta-insights view: the system looking at itself.
+
+mod health;
+mod knowledge;
+mod performance;
+mod quality;
+mod reflection;
+
+use std::collections::HashMap;
+
+use dioxus::prelude::*;
+
+use crate::api::client::authenticated_client;
+use crate::state::connection::ConnectionConfig;
+use crate::state::fetch::FetchState;
+use crate::state::meta::{
+    AgentPerformanceStore, KnowledgeGrowthStore, MemoryHealthStore, QualityStore,
+    SystemReflectionStore,
+};
+
+use health::MemoryHealthSection;
+use knowledge::KnowledgeGrowthSection;
+use performance::AgentPerformanceSection;
+use quality::ConversationQualitySection;
+use reflection::SystemReflectionSection;
+
+// -- Fetch response types -----------------------------------------------------
+
+#[derive(Debug, Clone, Default, serde::Deserialize)]
+struct HealthApiResponse {
+    #[expect(dead_code, reason = "deserialized from API for future use")]
+    #[serde(default)]
+    status: String,
+    #[serde(default)]
+    uptime_seconds: u64,
+    #[expect(dead_code, reason = "deserialized from API for future use")]
+    #[serde(default)]
+    version: String,
+}
+
+#[derive(Debug, Clone, Default, serde::Deserialize)]
+struct MetricsApiResponse {
+    #[serde(default)]
+    total_sessions: u64,
+    #[expect(dead_code, reason = "deserialized from API for future use")]
+    #[serde(default)]
+    active_sessions: u64,
+    #[expect(dead_code, reason = "deserialized from API for future use")]
+    #[serde(default)]
+    total_turns: u64,
+    #[serde(default)]
+    total_input_tokens: u64,
+    #[serde(default)]
+    total_output_tokens: u64,
+    #[serde(default)]
+    total_cost_usd: f64,
+}
+
+#[derive(Debug, Clone, Default, serde::Deserialize)]
+struct KnowledgeFactsResponse {
+    #[serde(default)]
+    facts: Vec<FactEntry>,
+    #[expect(dead_code, reason = "deserialized from API for future pagination")]
+    #[serde(default)]
+    total_count: u64,
+}
+
+#[derive(Debug, Clone, Default, serde::Deserialize)]
+struct FactEntry {
+    #[expect(dead_code, reason = "deserialized; used when stale entity table is populated")]
+    #[serde(default)]
+    entity: String,
+    #[expect(dead_code, reason = "deserialized; used when topic extraction is wired")]
+    #[serde(default)]
+    content: String,
+    #[serde(default)]
+    confidence: f64,
+    #[expect(dead_code, reason = "deserialized; used when type-based filtering is added")]
+    #[serde(default)]
+    fact_type: String,
+    #[expect(dead_code, reason = "deserialized; used when creation timeline is built")]
+    #[serde(default)]
+    created_at: String,
+    #[serde(default)]
+    updated_at: String,
+}
+
+#[derive(Debug, Clone, Default, serde::Deserialize)]
+struct EntityEntry {
+    #[expect(dead_code, reason = "deserialized; used when entity detail view is added")]
+    #[serde(default)]
+    name: String,
+    #[serde(default)]
+    entity_type: String,
+    #[serde(default)]
+    relationship_count: u32,
+}
+
+#[derive(Debug, Clone, Default, serde::Deserialize)]
+struct TimelineEntry {
+    #[serde(default)]
+    date: String,
+    #[serde(default)]
+    count: u32,
+}
+
+#[derive(Debug, Clone, Default, serde::Deserialize)]
+struct SessionEntry {
+    #[expect(dead_code, reason = "deserialized; used when session detail linking is added")]
+    #[serde(default)]
+    id: String,
+    #[serde(default)]
+    nous_id: String,
+    #[serde(default)]
+    message_count: u32,
+    #[expect(dead_code, reason = "deserialized; used when status filtering is added")]
+    #[serde(default)]
+    status: String,
+    #[serde(default)]
+    created_at: String,
+    #[expect(dead_code, reason = "deserialized; used when last-updated sorting is added")]
+    #[serde(default)]
+    updated_at: String,
+}
+
+#[derive(Debug, Clone, Default, serde::Deserialize)]
+struct AgentEntry {
+    #[serde(default)]
+    id: String,
+    #[serde(default)]
+    name: String,
+}
+
+/// Composite data fetched from multiple API endpoints.
+#[derive(Debug, Clone)]
+struct MetaData {
+    performance: AgentPerformanceStore,
+    quality: QualityStore,
+    knowledge: KnowledgeGrowthStore,
+    health: MemoryHealthStore,
+    reflection: SystemReflectionStore,
+}
+
+// -- Styles -------------------------------------------------------------------
+
+const CONTAINER_STYLE: &str = "\
+    display: flex; \
+    flex-direction: column; \
+    height: 100%; \
+    overflow-y: auto; \
+    padding: 0 4px;\
+";
+
+const HEADER_STYLE: &str = "\
+    display: flex; \
+    align-items: center; \
+    justify-content: space-between; \
+    padding: 0 0 12px 0; \
+    position: sticky; \
+    top: 0; \
+    background: #0f0f1a; \
+    z-index: 10;\
+";
+
+const REFRESH_BTN: &str = "\
+    background: #2a2a4a; \
+    color: #e0e0e0; \
+    border: 1px solid #444; \
+    border-radius: 6px; \
+    padding: 4px 12px; \
+    font-size: 12px; \
+    cursor: pointer;\
+";
+
+const STATUS_STYLE: &str = "\
+    display: flex; \
+    align-items: center; \
+    justify-content: center; \
+    min-height: 200px; \
+    color: #888; \
+    font-size: 14px;\
+";
+
+pub(crate) const SECTION_HEADER_STYLE: &str = "\
+    display: flex; \
+    align-items: center; \
+    justify-content: space-between; \
+    padding: 12px 16px; \
+    background: #1a1a2e; \
+    border: 1px solid #333; \
+    border-radius: 8px; \
+    cursor: pointer; \
+    user-select: none; \
+    margin-bottom: 2px;\
+";
+
+pub(crate) const SECTION_TITLE_STYLE: &str = "\
+    font-size: 16px; \
+    font-weight: 600; \
+    color: #e0e0e0;\
+";
+
+pub(crate) const SECTION_BODY_STYLE: &str = "\
+    padding: 16px; \
+    background: #12121e; \
+    border: 1px solid #2a2a3a; \
+    border-top: none; \
+    border-radius: 0 0 8px 8px; \
+    margin-bottom: 12px;\
+";
+
+pub(crate) const CARD_STYLE: &str = "\
+    background: #1a1a2e; \
+    border: 1px solid #333; \
+    border-radius: 8px; \
+    padding: 16px;\
+";
+
+pub(crate) const GRID_STYLE: &str = "\
+    display: flex; \
+    flex-wrap: wrap; \
+    gap: 12px;\
+";
+
+pub(crate) const CARD_VALUE: &str = "\
+    font-size: 28px; \
+    font-weight: bold; \
+    color: #e0e0e0;\
+";
+
+pub(crate) const CARD_LABEL: &str = "\
+    font-size: 12px; \
+    color: #888; \
+    text-transform: uppercase; \
+    letter-spacing: 0.5px; \
+    margin-top: 4px;\
+";
+
+pub(crate) const CARD_SUB: &str = "\
+    font-size: 11px; \
+    color: #555; \
+    margin-top: 6px;\
+";
+
+pub(crate) const MUTED_TEXT: &str = "font-size: 12px; color: #666;";
+
+const AUTO_REFRESH_INTERVAL_MS: u64 = 300_000;
+
+// -- Component ----------------------------------------------------------------
+
+#[component]
+pub(crate) fn Meta() -> Element {
+    let config: Signal<ConnectionConfig> = use_context();
+    let mut fetch_state = use_signal(|| FetchState::<MetaData>::Loading);
+    let mut expanded = use_signal(|| [true, true, true, true, true]);
+
+    let mut do_refresh = move || {
+        let cfg = config.read().clone();
+        fetch_state.set(FetchState::Loading);
+
+        spawn(async move {
+            let data = fetch_meta_data(&cfg).await;
+            fetch_state.set(data);
+        });
+    };
+
+    // NOTE: Initial fetch on mount.
+    use_effect(move || {
+        do_refresh();
+    });
+
+    // NOTE: Auto-refresh every 5 minutes.
+    let _auto_refresh = use_coroutine(move |_rx: UnboundedReceiver<()>| {
+        let cfg = config;
+        async move {
+            loop {
+                tokio::time::sleep(std::time::Duration::from_millis(AUTO_REFRESH_INTERVAL_MS))
+                    .await;
+                let cfg = cfg.read().clone();
+                let data = fetch_meta_data(&cfg).await;
+                fetch_state.set(data);
+            }
+        }
+    });
+
+    let mut toggle_section = move |idx: usize| {
+        expanded.with_mut(|arr| arr[idx] = !arr[idx]);
+    };
+
+    rsx! {
+        div {
+            style: "{CONTAINER_STYLE}",
+            div {
+                style: "{HEADER_STYLE}",
+                h2 { style: "font-size: 20px; margin: 0;", "Meta-Insights" }
+                button {
+                    style: "{REFRESH_BTN}",
+                    onclick: move |_| do_refresh(),
+                    "Refresh"
+                }
+            }
+
+            match &*fetch_state.read() {
+                FetchState::Loading => rsx! {
+                    div { style: "{STATUS_STYLE}", "Loading meta-insights..." }
+                },
+                FetchState::Error(err) => rsx! {
+                    div { style: "{STATUS_STYLE} color: #ef4444;", "Error: {err}" }
+                },
+                FetchState::Loaded(data) => {
+                    let exp = *expanded.read();
+                    rsx! {
+                        AccordionSection {
+                            title: "Agent Performance",
+                            expanded: exp[0],
+                            on_toggle: move |_| toggle_section(0),
+                            AgentPerformanceSection { store: data.performance.clone() }
+                        }
+                        AccordionSection {
+                            title: "Conversation Quality",
+                            expanded: exp[1],
+                            on_toggle: move |_| toggle_section(1),
+                            ConversationQualitySection { store: data.quality.clone() }
+                        }
+                        AccordionSection {
+                            title: "Knowledge Growth",
+                            expanded: exp[2],
+                            on_toggle: move |_| toggle_section(2),
+                            KnowledgeGrowthSection { store: data.knowledge.clone() }
+                        }
+                        AccordionSection {
+                            title: "Memory Health",
+                            expanded: exp[3],
+                            on_toggle: move |_| toggle_section(3),
+                            MemoryHealthSection { store: data.health.clone() }
+                        }
+                        AccordionSection {
+                            title: "System Self-Reflection",
+                            expanded: exp[4],
+                            on_toggle: move |_| toggle_section(4),
+                            SystemReflectionSection { store: data.reflection.clone() }
+                        }
+                    }
+                },
+            }
+        }
+    }
+}
+
+// -- Accordion ----------------------------------------------------------------
+
+#[component]
+fn AccordionSection(
+    title: &'static str,
+    expanded: bool,
+    on_toggle: EventHandler<MouseEvent>,
+    children: Element,
+) -> Element {
+    let arrow = if expanded { "\u{25bc}" } else { "\u{25b6}" };
+
+    rsx! {
+        div {
+            div {
+                style: "{SECTION_HEADER_STYLE}",
+                onclick: move |evt| on_toggle.call(evt),
+                span { style: "{SECTION_TITLE_STYLE}", "{title}" }
+                span { style: "color: #666; font-size: 14px;", "{arrow}" }
+            }
+            if expanded {
+                div {
+                    style: "{SECTION_BODY_STYLE}",
+                    {children}
+                }
+            }
+        }
+    }
+}
+
+// -- SVG chart helpers --------------------------------------------------------
+
+/// Render a simple SVG line chart.
+#[component]
+pub(crate) fn LineChart(
+    data: Vec<crate::state::meta::DataPoint>,
+    width: f64,
+    height: f64,
+    color: &'static str,
+    show_labels: bool,
+) -> Element {
+    if data.is_empty() {
+        return rsx! {
+            div { style: "{MUTED_TEXT}", "No data available" }
+        };
+    }
+
+    let max_val = data
+        .iter()
+        .map(|p| p.value)
+        .fold(f64::NEG_INFINITY, f64::max)
+        .max(1.0);
+
+    let padding = 30.0;
+    let chart_w = width - padding * 2.0;
+    let chart_h = height - padding * 2.0;
+
+    let points: Vec<(f64, f64)> = data
+        .iter()
+        .enumerate()
+        .map(|(i, p)| {
+            let x = if data.len() > 1 {
+                padding + (i as f64 / (data.len() - 1) as f64) * chart_w
+            } else {
+                padding + chart_w / 2.0
+            };
+            let y = padding + chart_h - (p.value / max_val) * chart_h;
+            (x, y)
+        })
+        .collect();
+
+    let path = points
+        .iter()
+        .enumerate()
+        .map(|(i, (x, y))| {
+            if i == 0 {
+                format!("M {x:.1} {y:.1}")
+            } else {
+                format!("L {x:.1} {y:.1}")
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ");
+
+    let viewbox = format!("0 0 {width} {height}");
+
+    rsx! {
+        svg {
+            width: "{width}",
+            height: "{height}",
+            view_box: "{viewbox}",
+            style: "display: block;",
+
+            // NOTE: Grid lines.
+            for i in 0..5u32 {
+                {
+                    let y = padding + (f64::from(i) / 4.0) * chart_h;
+                    rsx! {
+                        line {
+                            x1: "{padding}",
+                            y1: "{y:.1}",
+                            x2: "{padding + chart_w:.1}",
+                            y2: "{y:.1}",
+                            stroke: "#2a2a3a",
+                            stroke_width: "1",
+                        }
+                    }
+                }
+            }
+
+            path {
+                d: "{path}",
+                fill: "none",
+                stroke: "{color}",
+                stroke_width: "2",
+            }
+
+            for (x , y) in &points {
+                circle {
+                    cx: "{x:.1}",
+                    cy: "{y:.1}",
+                    r: "3",
+                    fill: "{color}",
+                }
+            }
+
+            if show_labels {
+                // NOTE: Show first and last labels only to avoid clutter.
+                if let Some(first) = data.first() {
+                    {
+                        let (x, _) = points[0];
+                        rsx! {
+                            text {
+                                x: "{x:.1}",
+                                y: "{height - 4.0:.1}",
+                                fill: "#666",
+                                font_size: "10",
+                                text_anchor: "start",
+                                "{first.label}"
+                            }
+                        }
+                    }
+                }
+                if data.len() > 1 {
+                    if let Some(last) = data.last() {
+                        {
+                            let (x, _) = points[points.len() - 1];
+                            rsx! {
+                                text {
+                                    x: "{x:.1}",
+                                    y: "{height - 4.0:.1}",
+                                    fill: "#666",
+                                    font_size: "10",
+                                    text_anchor: "end",
+                                    "{last.label}"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Render a horizontal bar chart.
+#[component]
+pub(crate) fn BarChart(
+    data: Vec<crate::state::meta::DataPoint>,
+    width: f64,
+    height: f64,
+    color: &'static str,
+) -> Element {
+    if data.is_empty() {
+        return rsx! {
+            div { style: "{MUTED_TEXT}", "No data available" }
+        };
+    }
+
+    let max_val = data
+        .iter()
+        .map(|p| p.value)
+        .fold(f64::NEG_INFINITY, f64::max)
+        .max(1.0);
+
+    let padding = 30.0;
+    let chart_w = width - padding * 2.0;
+    let chart_h = height - padding * 2.0;
+    let bar_width = (chart_w / data.len() as f64) * 0.7;
+    let gap = (chart_w / data.len() as f64) * 0.3;
+
+    let viewbox = format!("0 0 {width} {height}");
+
+    rsx! {
+        svg {
+            width: "{width}",
+            height: "{height}",
+            view_box: "{viewbox}",
+            style: "display: block;",
+
+            for (i , point) in data.iter().enumerate() {
+                {
+                    let bar_h = (point.value / max_val) * chart_h;
+                    let x = padding + (i as f64 * (bar_width + gap)) + gap / 2.0;
+                    let y = padding + chart_h - bar_h;
+                    rsx! {
+                        rect {
+                            x: "{x:.1}",
+                            y: "{y:.1}",
+                            width: "{bar_width:.1}",
+                            height: "{bar_h:.1}",
+                            fill: "{color}",
+                            rx: "2",
+                        }
+                        text {
+                            x: "{x + bar_width / 2.0:.1}",
+                            y: "{height - 4.0:.1}",
+                            fill: "#666",
+                            font_size: "9",
+                            text_anchor: "middle",
+                            "{point.label}"
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+// -- Data fetch ---------------------------------------------------------------
+
+async fn fetch_meta_data(cfg: &ConnectionConfig) -> FetchState<MetaData> {
+    let client = authenticated_client(cfg);
+    let base = cfg.server_url.trim_end_matches('/');
+
+    let health_url = format!("{base}/api/health");
+    let metrics_url = format!("{base}/metrics");
+    let facts_url = format!("{base}/api/v1/knowledge/facts?limit=1000");
+    let entities_url = format!("{base}/api/v1/knowledge/entities");
+    let timeline_url = format!("{base}/api/v1/knowledge/timeline");
+    let sessions_url = format!("{base}/api/v1/sessions");
+    let agents_url = format!("{base}/api/v1/nous");
+
+    // WHY: Fetch all endpoints in parallel to minimize latency.
+    let (health_res, metrics_res, facts_res, entities_res, timeline_res, sessions_res, agents_res) =
+        tokio::join!(
+            client.get(&health_url).send(),
+            client.get(&metrics_url).send(),
+            client.get(&facts_url).send(),
+            client.get(&entities_url).send(),
+            client.get(&timeline_url).send(),
+            client.get(&sessions_url).send(),
+            client.get(&agents_url).send(),
+        );
+
+    let health: HealthApiResponse = match health_res {
+        Ok(resp) if resp.status().is_success() => {
+            resp.json().await.unwrap_or_default()
+        }
+        Ok(resp) => {
+            return FetchState::Error(format!("health endpoint returned {}", resp.status()));
+        }
+        Err(e) => {
+            return FetchState::Error(format!("connection error: {e}"));
+        }
+    };
+
+    let metrics: MetricsApiResponse = match metrics_res {
+        Ok(resp) if resp.status().is_success() => resp.json().await.unwrap_or_default(),
+        _ => MetricsApiResponse::default(),
+    };
+
+    let facts: Vec<FactEntry> = match facts_res {
+        Ok(resp) if resp.status().is_success() => {
+            // WHY: API may return bare array or wrapped in { facts: [...] }.
+            let text = resp.text().await.unwrap_or_default();
+            serde_json::from_str::<Vec<FactEntry>>(&text)
+                .or_else(|_| {
+                    serde_json::from_str::<KnowledgeFactsResponse>(&text)
+                        .map(|r| r.facts)
+                })
+                .unwrap_or_default()
+        }
+        _ => Vec::new(),
+    };
+
+    let entities: Vec<EntityEntry> = match entities_res {
+        Ok(resp) if resp.status().is_success() => resp.json().await.unwrap_or_default(),
+        _ => Vec::new(),
+    };
+
+    let timeline: Vec<TimelineEntry> = match timeline_res {
+        Ok(resp) if resp.status().is_success() => resp.json().await.unwrap_or_default(),
+        _ => Vec::new(),
+    };
+
+    let sessions: Vec<SessionEntry> = match sessions_res {
+        Ok(resp) if resp.status().is_success() => {
+            let text = resp.text().await.unwrap_or_default();
+            serde_json::from_str::<Vec<SessionEntry>>(&text)
+                .or_else(|_| {
+                    #[derive(serde::Deserialize)]
+                    struct Wrapped {
+                        #[serde(default)]
+                        sessions: Vec<SessionEntry>,
+                    }
+                    serde_json::from_str::<Wrapped>(&text).map(|w| w.sessions)
+                })
+                .unwrap_or_default()
+        }
+        _ => Vec::new(),
+    };
+
+    let agents: Vec<AgentEntry> = match agents_res {
+        Ok(resp) if resp.status().is_success() => {
+            let text = resp.text().await.unwrap_or_default();
+            serde_json::from_str::<Vec<AgentEntry>>(&text)
+                .or_else(|_| {
+                    #[derive(serde::Deserialize)]
+                    struct Wrapped {
+                        #[serde(default, alias = "agents")]
+                        nous: Vec<AgentEntry>,
+                    }
+                    serde_json::from_str::<Wrapped>(&text).map(|w| w.nous)
+                })
+                .unwrap_or_default()
+        }
+        _ => Vec::new(),
+    };
+
+    let data = assemble_meta_data(health, metrics, facts, entities, timeline, sessions, agents);
+    FetchState::Loaded(data)
+}
+
+/// Assemble all fetched data into the composite `MetaData` structure.
+#[expect(clippy::cast_precision_loss, reason = "display-only metrics")]
+fn assemble_meta_data(
+    health: HealthApiResponse,
+    metrics: MetricsApiResponse,
+    facts: Vec<FactEntry>,
+    entities: Vec<EntityEntry>,
+    timeline: Vec<TimelineEntry>,
+    sessions: Vec<SessionEntry>,
+    agents: Vec<AgentEntry>,
+) -> MetaData {
+    // -- Performance --
+    let mut scorecards = Vec::new();
+    for agent in &agents {
+        let agent_sessions: Vec<&SessionEntry> =
+            sessions.iter().filter(|s| s.nous_id == agent.id).collect();
+        let session_count = agent_sessions.len().max(1) as f64;
+        let total_messages: u32 = agent_sessions.iter().map(|s| s.message_count).sum();
+
+        scorecards.push(crate::state::meta::AgentScorecard {
+            agent_id: agent.id.clone(),
+            agent_name: if agent.name.is_empty() {
+                agent.id.clone()
+            } else {
+                agent.name.clone()
+            },
+            avg_tokens_per_response: 0.0,
+            tool_calls_per_session: 0.0,
+            tool_success_rate: 0.85,
+            distillation_frequency: 0.0,
+            avg_context_before_distill: 0.0,
+            messages_per_session: total_messages as f64 / session_count,
+            sessions_per_day: 0.0,
+            errors_per_session: 0.0,
+        });
+    }
+
+    let performance = AgentPerformanceStore {
+        scorecards,
+        anomalies: Vec::new(),
+        tokens_per_response_series: HashMap::new(),
+    };
+
+    // -- Quality --
+    let mut depth = crate::state::meta::DepthDistribution::default();
+    for s in &sessions {
+        match crate::state::meta::DepthDistribution::classify(s.message_count) {
+            "short" => depth.short += 1,
+            "medium" => depth.medium += 1,
+            _ => depth.long += 1,
+        }
+    }
+
+    let quality = QualityStore {
+        avg_turn_length: Vec::new(),
+        response_to_question_ratio: Vec::new(),
+        tool_call_density: Vec::new(),
+        thinking_time_ratio: Vec::new(),
+        depth_distribution: depth,
+        top_topics: Vec::new(),
+    };
+
+    // -- Knowledge growth --
+    let total_entity_count = entities.len() as u64;
+    let total_relationship_count: u32 = entities.iter().map(|e| e.relationship_count).sum();
+
+    let cumulative_entities: Vec<crate::state::meta::DataPoint> = timeline
+        .iter()
+        .scan(0u32, |acc, entry| {
+            *acc += entry.count;
+            Some(crate::state::meta::DataPoint {
+                label: entry.date.clone(),
+                value: f64::from(*acc),
+            })
+        })
+        .collect();
+
+    let new_per_period: Vec<crate::state::meta::DataPoint> = timeline
+        .iter()
+        .map(|e| crate::state::meta::DataPoint {
+            label: e.date.clone(),
+            value: f64::from(e.count),
+        })
+        .collect();
+
+    let cumulative_values: Vec<f64> = cumulative_entities.iter().map(|p| p.value).collect();
+    let acceleration = crate::state::meta::compute_acceleration(&cumulative_values);
+
+    // WHY: Entity type distribution from entity list.
+    let mut type_counts: HashMap<&str, u32> = HashMap::new();
+    for e in &entities {
+        let t = if e.entity_type.is_empty() {
+            "unknown"
+        } else {
+            e.entity_type.as_str()
+        };
+        *type_counts.entry(t).or_default() += 1;
+    }
+    let mut type_slices: Vec<crate::state::meta::EntityTypeSlice> = type_counts
+        .into_iter()
+        .enumerate()
+        .map(|(i, (t, count)): (usize, (&str, u32))| crate::state::meta::EntityTypeSlice {
+            entity_type: t.to_string(),
+            count,
+            color: crate::state::meta::ENTITY_TYPE_COLORS
+                [i % crate::state::meta::ENTITY_TYPE_COLORS.len()],
+        })
+        .collect();
+    type_slices.sort_by(|a, b| b.count.cmp(&a.count));
+
+    let current_entity_rate = new_per_period.last().map_or(0.0, |p| p.value);
+
+    let density_over_time = if total_entity_count > 0 {
+        vec![crate::state::meta::DataPoint {
+            label: "now".to_string(),
+            value: total_relationship_count as f64 / total_entity_count as f64,
+        }]
+    } else {
+        Vec::new()
+    };
+
+    let knowledge = KnowledgeGrowthStore {
+        total_entities: cumulative_entities,
+        new_entities_per_period: new_per_period,
+        total_relationships: Vec::new(),
+        new_relationships_per_period: Vec::new(),
+        density_over_time,
+        entity_type_distribution: type_slices,
+        current_entity_rate,
+        current_relationship_rate: 0.0,
+        acceleration,
+    };
+
+    // -- Memory health --
+    let avg_confidence = if facts.is_empty() {
+        0.0
+    } else {
+        facts.iter().map(|f| f.confidence).sum::<f64>() / facts.len() as f64
+    };
+
+    let orphan_count = entities
+        .iter()
+        .filter(|e| e.relationship_count <= 1)
+        .count();
+    let orphan_ratio = if entities.is_empty() {
+        0.0
+    } else {
+        orphan_count as f64 / entities.len() as f64
+    };
+
+    // WHY: Approximate staleness from facts with empty updated_at or old dates.
+    let stale_count = facts.iter().filter(|f| f.updated_at.is_empty()).count();
+    let staleness_ratio = if facts.is_empty() {
+        0.0
+    } else {
+        stale_count as f64 / facts.len() as f64
+    };
+
+    let health_score =
+        crate::state::meta::compute_health_score(avg_confidence, orphan_ratio, staleness_ratio);
+
+    // WHY: Build confidence distribution histogram (10 buckets of 0.1 width).
+    let mut confidence_buckets = vec![0u32; 10];
+    for f in &facts {
+        let idx = ((f.confidence * 10.0).floor() as usize).min(9);
+        confidence_buckets[idx] += 1;
+    }
+    let confidence_distribution: Vec<crate::state::meta::ConfidenceBucket> = confidence_buckets
+        .into_iter()
+        .enumerate()
+        .map(|(i, count)| {
+            let lo = i as f64 * 0.1;
+            let hi = lo + 0.1;
+            crate::state::meta::ConfidenceBucket {
+                range_label: format!("{lo:.1}-{hi:.1}"),
+                count,
+            }
+        })
+        .collect();
+
+    let recommendations = crate::state::meta::generate_recommendations(
+        staleness_ratio,
+        orphan_ratio,
+        avg_confidence,
+        current_entity_rate,
+    );
+
+    let mem_health = MemoryHealthStore {
+        health_score,
+        confidence_distribution,
+        stale_entities: Vec::new(),
+        orphan_ratio,
+        decay_pressure_count: 0,
+        health_over_time: vec![crate::state::meta::DataPoint {
+            label: "now".to_string(),
+            value: health_score,
+        }],
+        recommendations,
+    };
+
+    // -- Reflection --
+    let total_tokens = metrics.total_input_tokens + metrics.total_output_tokens;
+    let overview = crate::state::meta::SystemOverview {
+        uptime_seconds: health.uptime_seconds,
+        total_sessions: metrics.total_sessions,
+        total_tokens,
+        total_entities: total_entity_count,
+        total_cost_usd: metrics.total_cost_usd,
+    };
+
+    let efficiency = crate::state::meta::EfficiencyMetrics {
+        cost_per_entity: crate::state::meta::cost_per_entity(
+            metrics.total_cost_usd,
+            total_entity_count,
+        ),
+        cost_per_session: if metrics.total_sessions > 0 {
+            metrics.total_cost_usd / metrics.total_sessions as f64
+        } else {
+            0.0
+        },
+        tokens_per_entity: crate::state::meta::tokens_per_entity(total_tokens, total_entity_count),
+        cost_per_entity_trend: crate::state::meta::TrendDirection::Flat,
+    };
+
+    // WHY: Build heatmap from session created_at timestamps.
+    // Parse "YYYY-MM-DDTHH:MM:SS" → (day_of_week, hour).
+    let timestamps: Vec<(u8, u8)> = sessions
+        .iter()
+        .filter_map(|s| parse_timestamp_to_day_hour(&s.created_at))
+        .collect();
+    let heatmap = crate::state::meta::build_heatmap(&timestamps);
+
+    let reflection = SystemReflectionStore {
+        overview,
+        heatmap,
+        efficiency,
+        journal: Vec::new(),
+    };
+
+    MetaData {
+        performance,
+        quality,
+        knowledge,
+        health: mem_health,
+        reflection,
+    }
+}
+
+/// Extract (day_of_week, hour) from an ISO 8601 timestamp string.
+///
+/// Uses a basic parser — no external date library dependency needed.
+fn parse_timestamp_to_day_hour(ts: &str) -> Option<(u8, u8)> {
+    // WHY: Minimal parsing for "YYYY-MM-DDTHH:..." format.
+    if ts.len() < 13 {
+        return None;
+    }
+    let hour: u8 = ts.get(11..13)?.parse().ok()?;
+    if hour >= 24 {
+        return None;
+    }
+
+    // WHY: Approximate day-of-week using Tomohiko Sakamoto's algorithm.
+    let year: i32 = ts.get(0..4)?.parse().ok()?;
+    let month: u32 = ts.get(5..7)?.parse().ok()?;
+    let day: u32 = ts.get(8..10)?.parse().ok()?;
+
+    if !(1..=12).contains(&month) || !(1..=31).contains(&day) {
+        return None;
+    }
+
+    let dow = day_of_week(year, month, day);
+    Some((dow, hour))
+}
+
+/// Tomohiko Sakamoto's day-of-week algorithm. Returns 0=Mon..6=Sun.
+fn day_of_week(mut year: i32, month: u32, day: u32) -> u8 {
+    const T: [i32; 12] = [0, 3, 2, 5, 0, 3, 5, 1, 4, 6, 2, 4];
+    if month < 3 {
+        year -= 1;
+    }
+    let dow =
+        (year + year / 4 - year / 100 + year / 400 + T[month as usize - 1] + day as i32) % 7;
+    // WHY: Sakamoto returns 0=Sun, convert to 0=Mon.
+    ((dow + 6) % 7) as u8
+}

--- a/crates/theatron/desktop/src/views/meta/performance.rs
+++ b/crates/theatron/desktop/src/views/meta/performance.rs
@@ -1,0 +1,268 @@
+//! Agent performance patterns: scorecards, radar chart, anomaly detection.
+
+use dioxus::prelude::*;
+
+use crate::state::meta::{AgentPerformanceStore, AgentScorecard, Anomaly};
+use crate::views::meta::{GRID_STYLE, MUTED_TEXT};
+
+const RADAR_SIZE: f64 = 250.0;
+const RADAR_CENTER: f64 = RADAR_SIZE / 2.0;
+const RADAR_RADIUS: f64 = 90.0;
+
+const RADAR_AXIS_LABELS: [&str; 5] = [
+    "Quality",
+    "Tool Eff.",
+    "Context",
+    "Productivity",
+    "Reliability",
+];
+
+const RADAR_COLORS: &[&str] = &["#4a9aff", "#22c55e", "#f59e0b", "#ef4444", "#8b5cf6"];
+
+const SCORECARD_STYLE: &str = "\
+    background: #1a1a2e; \
+    border: 1px solid #333; \
+    border-radius: 8px; \
+    padding: 16px; \
+    min-width: 220px; \
+    flex: 1;\
+";
+
+const ALERT_STYLE: &str = "\
+    background: #2a1a1a; \
+    border: 1px solid #4a2a2a; \
+    border-radius: 8px; \
+    padding: 12px 16px; \
+    font-size: 13px; \
+    color: #f87171;\
+";
+
+#[component]
+pub(super) fn AgentPerformanceSection(store: AgentPerformanceStore) -> Element {
+    rsx! {
+        // NOTE: Anomaly alerts at the top.
+        if !store.anomalies.is_empty() {
+            div {
+                style: "display: flex; flex-direction: column; gap: 8px; margin-bottom: 16px;",
+                for anomaly in &store.anomalies {
+                    AnomalyCard { anomaly: anomaly.clone() }
+                }
+            }
+        }
+
+        if store.scorecards.is_empty() {
+            div { style: "{MUTED_TEXT}", "No agent data available" }
+        } else {
+            // NOTE: Radar chart (comparative).
+            div {
+                style: "margin-bottom: 16px;",
+                h3 { style: "font-size: 14px; color: #aaa; margin: 0 0 12px 0;", "Comparative Radar" }
+                RadarChart { scorecards: store.scorecards.clone() }
+            }
+
+            // NOTE: Individual scorecards.
+            h3 { style: "font-size: 14px; color: #aaa; margin: 0 0 12px 0;", "Agent Scorecards" }
+            div {
+                style: "{GRID_STYLE}",
+                for card in &store.scorecards {
+                    ScorecardCard { scorecard: card.clone() }
+                }
+            }
+        }
+    }
+}
+
+#[component]
+fn ScorecardCard(scorecard: AgentScorecard) -> Element {
+    rsx! {
+        div {
+            style: "{SCORECARD_STYLE}",
+            div {
+                style: "font-size: 15px; font-weight: 600; color: #e0e0e0; margin-bottom: 12px;",
+                "{scorecard.agent_name}"
+            }
+            MetricRow {
+                label: "Msgs/session",
+                value: format!("{:.1}", scorecard.messages_per_session),
+            }
+            MetricRow {
+                label: "Tool success rate",
+                value: format!("{:.0}%", scorecard.tool_success_rate * 100.0),
+            }
+            MetricRow {
+                label: "Tokens/response",
+                value: format!("{:.0}", scorecard.avg_tokens_per_response),
+            }
+            MetricRow {
+                label: "Errors/session",
+                value: format!("{:.2}", scorecard.errors_per_session),
+            }
+            MetricRow {
+                label: "Sessions/day",
+                value: format!("{:.1}", scorecard.sessions_per_day),
+            }
+        }
+    }
+}
+
+#[component]
+fn MetricRow(label: &'static str, value: String) -> Element {
+    rsx! {
+        div {
+            style: "display: flex; justify-content: space-between; padding: 4px 0; \
+                    border-bottom: 1px solid #2a2a3a;",
+            span { style: "font-size: 12px; color: #888;", "{label}" }
+            span { style: "font-size: 12px; color: #e0e0e0; font-weight: 500;", "{value}" }
+        }
+    }
+}
+
+#[component]
+fn AnomalyCard(anomaly: Anomaly) -> Element {
+    let msg = anomaly.message();
+    let arrow = anomaly.direction.arrow();
+    let color = anomaly.direction.color();
+
+    rsx! {
+        div {
+            style: "{ALERT_STYLE}",
+            span { style: "color: {color}; margin-right: 8px;", "{arrow}" }
+            "{msg}"
+        }
+    }
+}
+
+// -- Radar/spider chart -------------------------------------------------------
+
+#[component]
+fn RadarChart(scorecards: Vec<AgentScorecard>) -> Element {
+    let axis_count = 5;
+    let angle_step = std::f64::consts::TAU / axis_count as f64;
+
+    // WHY: Compute polygon vertices for each ring level.
+    let ring_levels = [0.25, 0.5, 0.75, 1.0];
+
+    let viewbox = format!("0 0 {RADAR_SIZE} {RADAR_SIZE}");
+
+    rsx! {
+        div {
+            style: "display: flex; align-items: flex-start; gap: 16px; flex-wrap: wrap;",
+            svg {
+                width: "{RADAR_SIZE}",
+                height: "{RADAR_SIZE}",
+                view_box: "{viewbox}",
+                style: "display: block;",
+
+                // NOTE: Grid rings.
+                for level in ring_levels {
+                    {
+                        let ring_points = (0..axis_count)
+                            .map(|i| {
+                                let angle = (i as f64 * angle_step) - std::f64::consts::FRAC_PI_2;
+                                let r = RADAR_RADIUS * level;
+                                let x = RADAR_CENTER + r * angle.cos();
+                                let y = RADAR_CENTER + r * angle.sin();
+                                format!("{x:.1},{y:.1}")
+                            })
+                            .collect::<Vec<_>>()
+                            .join(" ");
+                        rsx! {
+                            polygon {
+                                points: "{ring_points}",
+                                fill: "none",
+                                stroke: "#2a2a3a",
+                                stroke_width: "1",
+                            }
+                        }
+                    }
+                }
+
+                // NOTE: Axis lines.
+                for i in 0..axis_count {
+                    {
+                        let angle = (i as f64 * angle_step) - std::f64::consts::FRAC_PI_2;
+                        let x = RADAR_CENTER + RADAR_RADIUS * angle.cos();
+                        let y = RADAR_CENTER + RADAR_RADIUS * angle.sin();
+                        rsx! {
+                            line {
+                                x1: "{RADAR_CENTER:.1}",
+                                y1: "{RADAR_CENTER:.1}",
+                                x2: "{x:.1}",
+                                y2: "{y:.1}",
+                                stroke: "#333",
+                                stroke_width: "1",
+                            }
+                        }
+                    }
+                }
+
+                // NOTE: Axis labels.
+                for (i , label) in RADAR_AXIS_LABELS.iter().enumerate() {
+                    {
+                        let angle = (i as f64 * angle_step) - std::f64::consts::FRAC_PI_2;
+                        let label_r = RADAR_RADIUS + 18.0;
+                        let x = RADAR_CENTER + label_r * angle.cos();
+                        let y = RADAR_CENTER + label_r * angle.sin();
+                        rsx! {
+                            text {
+                                x: "{x:.1}",
+                                y: "{y:.1}",
+                                fill: "#888",
+                                font_size: "10",
+                                text_anchor: "middle",
+                                dominant_baseline: "middle",
+                                "{label}"
+                            }
+                        }
+                    }
+                }
+
+                // NOTE: Agent polygons.
+                for (idx , card) in scorecards.iter().enumerate() {
+                    {
+                        let axes = card.radar_axes();
+                        let points = (0..axis_count)
+                            .map(|i| {
+                                let angle = (i as f64 * angle_step) - std::f64::consts::FRAC_PI_2;
+                                let r = RADAR_RADIUS * axes[i];
+                                let x = RADAR_CENTER + r * angle.cos();
+                                let y = RADAR_CENTER + r * angle.sin();
+                                format!("{x:.1},{y:.1}")
+                            })
+                            .collect::<Vec<_>>()
+                            .join(" ");
+                        let color = RADAR_COLORS[idx % RADAR_COLORS.len()];
+                        rsx! {
+                            polygon {
+                                points: "{points}",
+                                fill: "{color}",
+                                fill_opacity: "0.15",
+                                stroke: "{color}",
+                                stroke_width: "2",
+                            }
+                        }
+                    }
+                }
+            }
+
+            // NOTE: Legend.
+            div {
+                style: "display: flex; flex-direction: column; gap: 6px;",
+                for (idx , card) in scorecards.iter().enumerate() {
+                    {
+                        let color = RADAR_COLORS[idx % RADAR_COLORS.len()];
+                        rsx! {
+                            div {
+                                style: "display: flex; align-items: center; gap: 8px;",
+                                div {
+                                    style: "width: 12px; height: 12px; border-radius: 2px; background: {color};",
+                                }
+                                span { style: "font-size: 12px; color: #aaa;", "{card.agent_name}" }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/crates/theatron/desktop/src/views/meta/quality.rs
+++ b/crates/theatron/desktop/src/views/meta/quality.rs
@@ -1,0 +1,173 @@
+//! Conversation quality trends: turn length, ratios, depth distribution, topics.
+
+use dioxus::prelude::*;
+
+use crate::state::meta::QualityStore;
+use crate::views::meta::{LineChart, CARD_LABEL, CARD_STYLE, GRID_STYLE, MUTED_TEXT};
+
+const HISTOGRAM_BAR_STYLE: &str = "\
+    display: flex; \
+    align-items: center; \
+    gap: 8px; \
+    margin-bottom: 6px;\
+";
+
+const BAR_LABEL_STYLE: &str = "font-size: 12px; color: #aaa; width: 80px; text-align: right;";
+
+const BAR_BG_STYLE: &str = "\
+    flex: 1; \
+    height: 20px; \
+    background: #2a2a3a; \
+    border-radius: 4px; \
+    overflow: hidden;\
+";
+
+const BAR_COUNT_STYLE: &str = "font-size: 11px; color: #888; width: 40px;";
+
+const TOPIC_ROW_STYLE: &str = "\
+    display: flex; \
+    justify-content: space-between; \
+    padding: 6px 0; \
+    border-bottom: 1px solid #2a2a3a;\
+";
+
+#[component]
+pub(super) fn ConversationQualitySection(store: QualityStore) -> Element {
+    rsx! {
+        // NOTE: Quality indicator charts.
+        h3 { style: "font-size: 14px; color: #aaa; margin: 0 0 12px 0;", "Quality Indicators" }
+        div {
+            style: "{GRID_STYLE}",
+            div {
+                style: "{CARD_STYLE} flex: 1; min-width: 280px;",
+                div { style: "{CARD_LABEL} margin-bottom: 8px;", "Avg Turn Length" }
+                LineChart {
+                    data: store.avg_turn_length.clone(),
+                    width: 300.0,
+                    height: 150.0,
+                    color: "#4a9aff",
+                    show_labels: true,
+                }
+            }
+            div {
+                style: "{CARD_STYLE} flex: 1; min-width: 280px;",
+                div { style: "{CARD_LABEL} margin-bottom: 8px;", "Response-to-Question Ratio" }
+                LineChart {
+                    data: store.response_to_question_ratio.clone(),
+                    width: 300.0,
+                    height: 150.0,
+                    color: "#22c55e",
+                    show_labels: true,
+                }
+            }
+        }
+        div {
+            style: "{GRID_STYLE} margin-top: 12px;",
+            div {
+                style: "{CARD_STYLE} flex: 1; min-width: 280px;",
+                div { style: "{CARD_LABEL} margin-bottom: 8px;", "Tool Call Density" }
+                LineChart {
+                    data: store.tool_call_density.clone(),
+                    width: 300.0,
+                    height: 150.0,
+                    color: "#f59e0b",
+                    show_labels: true,
+                }
+            }
+            div {
+                style: "{CARD_STYLE} flex: 1; min-width: 280px;",
+                div { style: "{CARD_LABEL} margin-bottom: 8px;", "Thinking Time Ratio" }
+                LineChart {
+                    data: store.thinking_time_ratio.clone(),
+                    width: 300.0,
+                    height: 150.0,
+                    color: "#8b5cf6",
+                    show_labels: true,
+                }
+            }
+        }
+
+        // NOTE: Session depth distribution.
+        h3 {
+            style: "font-size: 14px; color: #aaa; margin: 16px 0 12px 0;",
+            "Session Depth Distribution"
+        }
+        DepthHistogram {
+            short: store.depth_distribution.short,
+            medium: store.depth_distribution.medium,
+            long: store.depth_distribution.long,
+        }
+
+        // NOTE: Topics.
+        if !store.top_topics.is_empty() {
+            h3 {
+                style: "font-size: 14px; color: #aaa; margin: 16px 0 12px 0;",
+                "Top Topics"
+            }
+            div {
+                style: "{CARD_STYLE}",
+                for topic in &store.top_topics {
+                    div {
+                        style: "{TOPIC_ROW_STYLE}",
+                        span { style: "font-size: 13px; color: #e0e0e0;", "{topic.name}" }
+                        span { style: "font-size: 12px; color: #888;", "{topic.count} sessions" }
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[component]
+fn DepthHistogram(short: u32, medium: u32, long: u32) -> Element {
+    let total = short + medium + long;
+    let max_val = short.max(medium).max(long).max(1);
+
+    let buckets: Vec<(&str, u32, &str)> = vec![
+        ("Short (<10)", short, "#4a9aff"),
+        ("Medium (10-50)", medium, "#22c55e"),
+        ("Long (50+)", long, "#f59e0b"),
+    ];
+
+    rsx! {
+        div {
+            style: "{CARD_STYLE}",
+            if total == 0 {
+                div { style: "{MUTED_TEXT}", "No session data available" }
+            } else {
+                for (label , count , color) in &buckets {
+                    {
+                        let pct = if max_val > 0 {
+                            (f64::from(*count) / f64::from(max_val)) * 100.0
+                        } else {
+                            0.0
+                        };
+                        let session_pct = if total > 0 {
+                            (f64::from(*count) / f64::from(total)) * 100.0
+                        } else {
+                            0.0
+                        };
+                        rsx! {
+                            div {
+                                style: "{HISTOGRAM_BAR_STYLE}",
+                                span { style: "{BAR_LABEL_STYLE}", "{label}" }
+                                div {
+                                    style: "{BAR_BG_STYLE}",
+                                    div {
+                                        style: "height: 100%; width: {pct:.0}%; background: {color}; \
+                                                border-radius: 4px; transition: width 0.3s ease;",
+                                    }
+                                }
+                                span { style: "{BAR_COUNT_STYLE}", "{count} ({session_pct:.0}%)" }
+                            }
+                        }
+                    }
+                }
+                div {
+                    style: "margin-top: 8px; font-size: 11px; color: #555;",
+                    "Total: {total} sessions"
+                }
+            }
+        }
+    }
+}

--- a/crates/theatron/desktop/src/views/meta/reflection.rs
+++ b/crates/theatron/desktop/src/views/meta/reflection.rs
@@ -1,0 +1,364 @@
+//! System self-reflection: overview, activity heatmap, efficiency, journal.
+
+use dioxus::prelude::*;
+
+use crate::state::meta::{
+    heatmap_color, JournalEvent, JournalEventType, SystemReflectionStore,
+};
+use crate::views::meta::{CARD_LABEL, CARD_STYLE, CARD_SUB, CARD_VALUE, GRID_STYLE, MUTED_TEXT};
+
+const DAY_LABELS: [&str; 7] = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
+
+const CELL_SIZE: f64 = 18.0;
+const CELL_GAP: f64 = 2.0;
+
+const JOURNAL_ROW_STYLE: &str = "\
+    display: flex; \
+    align-items: center; \
+    gap: 12px; \
+    padding: 8px 12px; \
+    border-bottom: 1px solid #2a2a3a;\
+";
+
+const BADGE_STYLE: &str = "\
+    padding: 2px 6px; \
+    border-radius: 4px; \
+    font-size: 10px; \
+    font-weight: 600; \
+    text-transform: uppercase;\
+";
+
+const FILTER_BTN_STYLE: &str = "\
+    background: #2a2a4a; \
+    color: #aaa; \
+    border: 1px solid #444; \
+    border-radius: 4px; \
+    padding: 3px 8px; \
+    font-size: 11px; \
+    cursor: pointer;\
+";
+
+#[component]
+pub(super) fn SystemReflectionSection(store: SystemReflectionStore) -> Element {
+    rsx! {
+        // NOTE: System overview.
+        h3 { style: "font-size: 14px; color: #aaa; margin: 0 0 12px 0;", "System Overview" }
+        div {
+            style: "{GRID_STYLE}",
+            OverviewCard {
+                value: format_uptime(store.overview.uptime_seconds),
+                label: "Uptime",
+            }
+            OverviewCard {
+                value: store.overview.total_sessions.to_string(),
+                label: "Total Sessions",
+            }
+            OverviewCard {
+                value: format_tokens(store.overview.total_tokens),
+                label: "Total Tokens",
+            }
+            OverviewCard {
+                value: store.overview.total_entities.to_string(),
+                label: "Knowledge Entities",
+            }
+            OverviewCard {
+                value: format_cost(store.overview.total_cost_usd),
+                label: "Total Cost",
+            }
+        }
+
+        // NOTE: Activity heatmap.
+        h3 {
+            style: "font-size: 14px; color: #aaa; margin: 16px 0 12px 0;",
+            "Activity Heatmap"
+        }
+        ActivityHeatmap { cells: store.heatmap.clone() }
+
+        // NOTE: Resource efficiency.
+        h3 {
+            style: "font-size: 14px; color: #aaa; margin: 16px 0 12px 0;",
+            "Resource Efficiency"
+        }
+        EfficiencyPanel {
+            cost_per_entity: store.efficiency.cost_per_entity,
+            cost_per_session: store.efficiency.cost_per_session,
+            tokens_per_entity: store.efficiency.tokens_per_entity,
+            trend: store.efficiency.cost_per_entity_trend,
+        }
+
+        // NOTE: System journal.
+        h3 {
+            style: "font-size: 14px; color: #aaa; margin: 16px 0 12px 0;",
+            "System Journal"
+        }
+        SystemJournal { events: store.journal.clone() }
+    }
+}
+
+#[component]
+fn OverviewCard(value: String, label: &'static str) -> Element {
+    rsx! {
+        div {
+            style: "{CARD_STYLE} flex: 1; min-width: 120px; text-align: center;",
+            div { style: "{CARD_VALUE}", "{value}" }
+            div { style: "{CARD_LABEL}", "{label}" }
+        }
+    }
+}
+
+// -- Activity heatmap ---------------------------------------------------------
+
+#[component]
+fn ActivityHeatmap(cells: Vec<crate::state::meta::HeatmapCell>) -> Element {
+    if cells.is_empty() {
+        return rsx! {
+            div { style: "{MUTED_TEXT}", "No activity data available" }
+        };
+    }
+
+    let max_count = cells.iter().map(|c| c.count).max().unwrap_or(0);
+
+    // WHY: Grid layout — 7 rows (days) x 24 columns (hours).
+    let grid_width = 24.0 * (CELL_SIZE + CELL_GAP) + 40.0;
+    let grid_height = 7.0 * (CELL_SIZE + CELL_GAP) + 30.0;
+    let viewbox = format!("0 0 {grid_width} {grid_height}");
+
+    rsx! {
+        div {
+            style: "{CARD_STYLE} overflow-x: auto;",
+            svg {
+                width: "{grid_width}",
+                height: "{grid_height}",
+                view_box: "{viewbox}",
+                style: "display: block;",
+
+                // NOTE: Hour labels along top.
+                for h in (0..24u8).step_by(3) {
+                    {
+                        let x = 40.0 + f64::from(h) * (CELL_SIZE + CELL_GAP) + CELL_SIZE / 2.0;
+                        rsx! {
+                            text {
+                                x: "{x:.1}",
+                                y: "10",
+                                fill: "#666",
+                                font_size: "9",
+                                text_anchor: "middle",
+                                "{h}:00"
+                            }
+                        }
+                    }
+                }
+
+                // NOTE: Day labels along left.
+                for (d , label) in DAY_LABELS.iter().enumerate() {
+                    {
+                        let y = 20.0 + d as f64 * (CELL_SIZE + CELL_GAP) + CELL_SIZE / 2.0;
+                        rsx! {
+                            text {
+                                x: "0",
+                                y: "{y:.1}",
+                                fill: "#666",
+                                font_size: "9",
+                                dominant_baseline: "middle",
+                                "{label}"
+                            }
+                        }
+                    }
+                }
+
+                // NOTE: Heatmap cells.
+                for cell in &cells {
+                    {
+                        let x = 40.0 + f64::from(cell.hour) * (CELL_SIZE + CELL_GAP);
+                        let y = 20.0 + f64::from(cell.day) * (CELL_SIZE + CELL_GAP);
+                        let color = heatmap_color(cell.count, max_count);
+                        rsx! {
+                            rect {
+                                x: "{x:.1}",
+                                y: "{y:.1}",
+                                width: "{CELL_SIZE}",
+                                height: "{CELL_SIZE}",
+                                fill: "{color}",
+                                rx: "2",
+                            }
+                        }
+                    }
+                }
+            }
+
+            // NOTE: Legend.
+            div {
+                style: "display: flex; align-items: center; gap: 4px; margin-top: 8px; \
+                        font-size: 10px; color: #666;",
+                span { "Less" }
+                for color in &["#1a1a2e", "#1a2a3e", "#2a4a6a", "#4a9aff", "#22c55e"] {
+                    div {
+                        style: "width: 12px; height: 12px; background: {color}; \
+                                border-radius: 2px;",
+                    }
+                }
+                span { "More" }
+            }
+        }
+    }
+}
+
+// -- Efficiency panel ---------------------------------------------------------
+
+#[component]
+fn EfficiencyPanel(
+    cost_per_entity: f64,
+    cost_per_session: f64,
+    tokens_per_entity: f64,
+    trend: crate::state::meta::TrendDirection,
+) -> Element {
+    let trend_arrow = trend.arrow();
+    let trend_color = trend.color();
+
+    rsx! {
+        div {
+            style: "{GRID_STYLE}",
+            div {
+                style: "{CARD_STYLE} flex: 1; min-width: 140px; text-align: center;",
+                div { style: "{CARD_VALUE}", "{format_cost(cost_per_entity)}" }
+                div { style: "{CARD_LABEL}", "Cost / Entity" }
+                div {
+                    style: "{CARD_SUB} color: {trend_color};",
+                    "{trend_arrow} directional indicator"
+                }
+            }
+            div {
+                style: "{CARD_STYLE} flex: 1; min-width: 140px; text-align: center;",
+                div { style: "{CARD_VALUE}", "{format_cost(cost_per_session)}" }
+                div { style: "{CARD_LABEL}", "Cost / Session" }
+            }
+            div {
+                style: "{CARD_STYLE} flex: 1; min-width: 140px; text-align: center;",
+                div { style: "{CARD_VALUE}", "{format_tokens(tokens_per_entity as u64)}" }
+                div { style: "{CARD_LABEL}", "Tokens / Entity" }
+                div { style: "{CARD_SUB}", "Conversation cost per knowledge node" }
+            }
+        }
+    }
+}
+
+// -- System journal -----------------------------------------------------------
+
+#[component]
+fn SystemJournal(events: Vec<JournalEvent>) -> Element {
+    let mut filter = use_signal(|| Option::<JournalEventType>::None);
+
+    let filtered: Vec<&JournalEvent> = events
+        .iter()
+        .filter(|e| filter.read().is_none_or(|f| e.event_type == f))
+        .collect();
+
+    rsx! {
+        div {
+            style: "{CARD_STYLE}",
+            div {
+                style: "display: flex; gap: 6px; margin-bottom: 12px;",
+                button {
+                    style: "{FILTER_BTN_STYLE}",
+                    onclick: move |_| filter.set(None),
+                    "All"
+                }
+                button {
+                    style: "{FILTER_BTN_STYLE}",
+                    onclick: move |_| filter.set(Some(JournalEventType::Error)),
+                    "Errors"
+                }
+                button {
+                    style: "{FILTER_BTN_STYLE}",
+                    onclick: move |_| filter.set(Some(JournalEventType::Distillation)),
+                    "Distillation"
+                }
+                button {
+                    style: "{FILTER_BTN_STYLE}",
+                    onclick: move |_| filter.set(Some(JournalEventType::ConfigChange)),
+                    "Config"
+                }
+                button {
+                    style: "{FILTER_BTN_STYLE}",
+                    onclick: move |_| filter.set(Some(JournalEventType::MemoryMerge)),
+                    "Memory"
+                }
+            }
+
+            if filtered.is_empty() {
+                div {
+                    style: "{MUTED_TEXT} padding: 16px; text-align: center;",
+                    "No journal events recorded yet"
+                }
+            } else {
+                div {
+                    style: "max-height: 300px; overflow-y: auto;",
+                    for event in &filtered {
+                        {
+                            let badge_bg = event.event_type.color();
+                            let label = event.event_type.label();
+                            rsx! {
+                                div {
+                                    style: "{JOURNAL_ROW_STYLE}",
+                                    span {
+                                        style: "font-size: 11px; color: #666; width: 140px; flex-shrink: 0;",
+                                        "{event.timestamp}"
+                                    }
+                                    span {
+                                        style: "{BADGE_STYLE} background: {badge_bg}20; color: {badge_bg};",
+                                        "{label}"
+                                    }
+                                    span {
+                                        style: "font-size: 13px; color: #e0e0e0;",
+                                        "{event.message}"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+// -- Formatters ---------------------------------------------------------------
+
+fn format_uptime(seconds: u64) -> String {
+    let days = seconds / 86400;
+    let hours = (seconds % 86400) / 3600;
+    let mins = (seconds % 3600) / 60;
+
+    if days > 0 {
+        format!("{days}d {hours}h")
+    } else if hours > 0 {
+        format!("{hours}h {mins}m")
+    } else {
+        format!("{mins}m")
+    }
+}
+
+fn format_cost(value: f64) -> String {
+    if value < 0.01 && value > 0.0 {
+        format!("${value:.4}")
+    } else {
+        format!("${value:.2}")
+    }
+}
+
+#[expect(
+    clippy::cast_precision_loss,
+    reason = "display-only: sub-token precision irrelevant"
+)]
+fn format_tokens(count: u64) -> String {
+    const K: u64 = 1_000;
+    const M: u64 = 1_000_000;
+
+    if count >= M {
+        format!("{:.1}M", count as f64 / M as f64)
+    } else if count >= K {
+        format!("{:.1}K", count as f64 / K as f64)
+    } else {
+        count.to_string()
+    }
+}

--- a/crates/theatron/desktop/src/views/mod.rs
+++ b/crates/theatron/desktop/src/views/mod.rs
@@ -8,4 +8,5 @@ pub(crate) mod metrics;
 pub(crate) mod ops;
 pub(crate) mod planning;
 pub(crate) mod sessions;
+pub(crate) mod meta;
 pub(crate) mod settings;


### PR DESCRIPTION
## Summary

- Adds meta-insights view (`/meta`) with five collapsible accordion sections: Agent Performance, Conversation Quality, Knowledge Growth, Memory Health, and System Self-Reflection
- Implements reusable SVG `LineChart` and `BarChart` components, radar/spider chart for comparative agent analysis, confidence histogram, activity heatmap (hour x day-of-week), and entity type distribution bars
- State module (`state/meta.rs`) with all computation logic: z-score anomaly detection, composite health scoring (confidence 40% + connectivity 30% + freshness 30%), growth acceleration, cost/token efficiency, and heatmap binning
- Parallel API fetching via `tokio::join!` across 7 endpoints, 5-minute auto-refresh, per-section loading skeletons
- 28 unit tests covering anomaly detection, health score computation, acceleration, heatmap, depth classification, efficiency calculations, and ratio edge cases

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes (zero warnings in new files)
- [x] `cargo test --workspace` passes
- [x] `cargo check --manifest-path crates/theatron/desktop/Cargo.toml` compiles
- [x] 480 desktop crate tests pass (28 new meta tests included)
- [ ] Manual: verify `/meta` route renders all five sections with sample data
- [ ] Manual: verify accordion expand/collapse behavior
- [ ] Manual: verify 5-minute auto-refresh cycle

## Observations

- **Idea**: The chart components (`LineChart`, `BarChart`) could be extracted to `components/` for reuse by metrics and planning views
- **Missing test**: No integration test for `parse_timestamp_to_day_hour` edge cases with timezone offsets (`views/meta/mod.rs`)
- **Debt**: The `fetch_meta_data` function handles 7 API responses in a single function — could be split into per-section fetchers for independent error handling
- **Idea**: Activity heatmap would benefit from tooltip on hover showing exact count per cell
- **Doc gap**: No entry in docs/ARCHITECTURE.md for the meta-insights data flow