### PR TITLE
feat(theatron-desktop): token usage and cost metrics views

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,3 +115,4 @@ __pycache__/
 !crates/*/dist/
 .claude/
 crates/aletheia/instance/
+crates/theatron/desktop/target/

--- a/crates/theatron/desktop/src/components/chart.rs
+++ b/crates/theatron/desktop/src/components/chart.rs
@@ -1,435 +1,234 @@
-//! SVG chart primitives for metrics views.
+//! Reusable div-based chart components for the metrics views.
 //!
-//! All charts render as inline SVG with inline styles. No external charting
-//! library is required. The API is designed to be compatible with chart usage
-//! in future metrics views (prompt 114 token/cost charts).
+// NOTE: Div-based rendering (CSS bars, conic-gradient donut) was chosen over
+// SVG because Blitz SVG support is not confirmed for this build target.
+// If SVG support is validated, these can be migrated to inline-SVG for
+// smoother path rendering.
 
 use dioxus::prelude::*;
 
-// -- Shared palette -----------------------------------------------------------
+// -- Shared data types --------------------------------------------------------
 
-pub(crate) const COLOR_SUCCESS: &str = "#22c55e";
-pub(crate) const COLOR_FAILURE: &str = "#ef4444";
-pub(crate) const COLOR_PRIMARY: &str = "#4a4aff";
-pub(crate) const COLOR_MUTED: &str = "#555";
-pub(crate) const COLOR_TEXT: &str = "#e0e0e0";
-pub(crate) const COLOR_TEXT_DIM: &str = "#888";
-pub(crate) const COLOR_WARN: &str = "#eab308";
-
-/// Ten-color sequential palette for multi-series charts.
-pub(crate) const SERIES_COLORS: &[&str] = &[
-    "#4a4aff", "#22c55e", "#eab308", "#ef4444", "#06b6d4", "#a855f7", "#f97316", "#ec4899",
-    "#84cc16", "#14b8a6",
-];
-
-// -- Bar entry ----------------------------------------------------------------
-
-/// A single labeled value for bar charts.
+/// A labeled numeric entry for bar and donut charts.
 #[derive(Debug, Clone, PartialEq)]
-pub(crate) struct BarEntry {
-    pub label: String,
-    pub value: u64,
-    /// Optional hex color override. Falls back to `COLOR_PRIMARY`.
-    pub color: Option<String>,
-}
-
-// -- Horizontal bar chart -----------------------------------------------------
-
-/// Horizontal bar chart: tool name on the left, bar extending right, value label on right.
-///
-/// Height auto-sizes to `entries.len() * ROW_HEIGHT + PADDING`.
-#[component]
-pub(crate) fn HorizontalBarChart(
-    entries: Vec<BarEntry>,
-    /// If `None`, the maximum entry value is used.
-    max_value: Option<u64>,
-    /// Called with the entry label when a bar is clicked.
-    on_click: Option<EventHandler<String>>,
-) -> Element {
-    const LABEL_W: u64 = 130;
-    const VALUE_W: u64 = 50;
-    const ROW_H: u64 = 26;
-    const PAD_TOP: u64 = 8;
-    const TOTAL_W: u64 = 600;
-    const BAR_AREA: u64 = TOTAL_W - LABEL_W - VALUE_W;
-
-    let n = entries.len() as u64;
-    let chart_h = n * ROW_H + PAD_TOP * 2;
-
-    let effective_max =
-        max_value.unwrap_or_else(|| entries.iter().map(|e| e.value).max().unwrap_or(1).max(1));
-
-    rsx! {
-        svg {
-            width: "100%",
-            view_box: "0 0 {TOTAL_W} {chart_h}",
-            style: "display: block; overflow: visible;",
-
-            for (i, entry) in entries.iter().enumerate() {
-                {
-                    let y = PAD_TOP + i as u64 * ROW_H;
-                    let bar_w = (entry.value * BAR_AREA) / effective_max;
-                    let color = entry.color.as_deref().unwrap_or(COLOR_PRIMARY);
-                    let label = entry.label.clone();
-                    let clickable = on_click.is_some();
-                    let cursor = if clickable { "pointer" } else { "default" };
-
-                    rsx! {
-                        g {
-                            key: "{label}",
-                            style: "cursor: {cursor};",
-                            onclick: {
-                                let label = label.clone();
-                                let on_click = on_click.clone();
-                                move |_| {
-                                    if let Some(ref handler) = on_click {
-                                        handler.call(label.clone());
-                                    }
-                                }
-                            },
-
-                            // Label
-                            text {
-                                x: "0",
-                                y: "{y + ROW_H - 8}",
-                                fill: COLOR_TEXT,
-                                font_size: "12",
-                                font_family: "monospace",
-                                text_anchor: "start",
-                                "{truncate_label(&label, 18)}"
-                            }
-
-                            // Bar background
-                            rect {
-                                x: "{LABEL_W}",
-                                y: "{y + 4}",
-                                width: "{BAR_AREA}",
-                                height: "{ROW_H - 10}",
-                                fill: "#1a1a2e",
-                                rx: "3",
-                            }
-
-                            // Bar fill
-                            if bar_w > 0 {
-                                rect {
-                                    x: "{LABEL_W}",
-                                    y: "{y + 4}",
-                                    width: "{bar_w}",
-                                    height: "{ROW_H - 10}",
-                                    fill: color,
-                                    rx: "3",
-                                }
-                            }
-
-                            // Value label
-                            text {
-                                x: "{LABEL_W + BAR_AREA + 6}",
-                                y: "{y + ROW_H - 8}",
-                                fill: COLOR_TEXT_DIM,
-                                font_size: "11",
-                                font_family: "monospace",
-                                "{entry.value}"
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
-}
-
-// -- Stacked horizontal bar ---------------------------------------------------
-
-/// One entry for the stacked bar chart.
-#[derive(Debug, Clone, PartialEq)]
-pub(crate) struct StackedBarEntry {
-    pub label: String,
-    pub success: u64,
-    pub failure: u64,
-}
-
-/// Horizontal stacked bar chart: success (green) + failure (red) per tool.
-///
-/// Sorted by `failure` descending inside the component if `sort_by_failure` is true.
-#[component]
-pub(crate) fn StackedBarChart(
-    entries: Vec<StackedBarEntry>,
-    sort_by_failure: bool,
-    on_click: Option<EventHandler<String>>,
-) -> Element {
-    const LABEL_W: u64 = 130;
-    const ROW_H: u64 = 26;
-    const PAD_TOP: u64 = 8;
-    const TOTAL_W: u64 = 600;
-    const BAR_AREA: u64 = TOTAL_W - LABEL_W - 60;
-
-    let mut sorted = entries.clone();
-    if sort_by_failure {
-        sorted.sort_by(|a, b| b.failure.cmp(&a.failure));
-    }
-
-    let n = sorted.len() as u64;
-    let chart_h = n * ROW_H + PAD_TOP * 2;
-
-    let max_total = sorted
-        .iter()
-        .map(|e| e.success + e.failure)
-        .max()
-        .unwrap_or(1)
-        .max(1);
-
-    rsx! {
-        svg {
-            width: "100%",
-            view_box: "0 0 {TOTAL_W} {chart_h}",
-            style: "display: block; overflow: visible;",
-
-            for (i, entry) in sorted.iter().enumerate() {
-                {
-                    let y = PAD_TOP + i as u64 * ROW_H;
-                    let total = entry.success + entry.failure;
-                    let success_w = (entry.success * BAR_AREA) / max_total;
-                    let failure_w = (entry.failure * BAR_AREA) / max_total;
-                    let label = entry.label.clone();
-                    let clickable = on_click.is_some();
-                    let cursor = if clickable { "pointer" } else { "default" };
-                    let pct_fail = if total > 0 { entry.failure * 100 / total } else { 0 };
-
-                    rsx! {
-                        g {
-                            key: "{label}",
-                            style: "cursor: {cursor};",
-                            onclick: {
-                                let label = label.clone();
-                                let on_click = on_click.clone();
-                                move |_| {
-                                    if let Some(ref handler) = on_click {
-                                        handler.call(label.clone());
-                                    }
-                                }
-                            },
-
-                            text {
-                                x: "0",
-                                y: "{y + ROW_H - 8}",
-                                fill: COLOR_TEXT,
-                                font_size: "12",
-                                font_family: "monospace",
-                                "{truncate_label(&label, 18)}"
-                            }
-
-                            // Background
-                            rect {
-                                x: "{LABEL_W}",
-                                y: "{y + 4}",
-                                width: "{BAR_AREA}",
-                                height: "{ROW_H - 10}",
-                                fill: "#1a1a2e",
-                                rx: "3",
-                            }
-
-                            // Success segment
-                            if success_w > 0 {
-                                rect {
-                                    x: "{LABEL_W}",
-                                    y: "{y + 4}",
-                                    width: "{success_w}",
-                                    height: "{ROW_H - 10}",
-                                    fill: COLOR_SUCCESS,
-                                    rx: "3",
-                                }
-                            }
-
-                            // Failure segment
-                            if failure_w > 0 {
-                                rect {
-                                    x: "{LABEL_W + success_w}",
-                                    y: "{y + 4}",
-                                    width: "{failure_w}",
-                                    height: "{ROW_H - 10}",
-                                    fill: COLOR_FAILURE,
-                                    rx: "3",
-                                }
-                            }
-
-                            // Failure % label
-                            text {
-                                x: "{LABEL_W + BAR_AREA + 6}",
-                                y: "{y + ROW_H - 8}",
-                                fill: if pct_fail > 50 { COLOR_FAILURE } else if pct_fail > 20 { COLOR_WARN } else { COLOR_TEXT_DIM },
-                                font_size: "11",
-                                font_family: "monospace",
-                                "{pct_fail}% fail"
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
-}
-
-// -- Line chart ---------------------------------------------------------------
-
-/// A single data point in a line series.
-#[derive(Debug, Clone, PartialEq)]
-pub(crate) struct LinePoint {
+pub(crate) struct ChartEntry {
     pub label: String,
     pub value: f64,
-}
-
-/// A single named series.
-#[derive(Debug, Clone, PartialEq)]
-pub(crate) struct LineSeries {
-    pub name: String,
     pub color: String,
-    pub points: Vec<LinePoint>,
+    /// Optional secondary label (e.g. percentage string).
+    pub sub_label: Option<String>,
 }
 
-/// Line chart for time-series data. Supports multiple series.
-///
-/// X labels are drawn from the first series's point labels.
-#[component]
-pub(crate) fn LineChart(series: Vec<LineSeries>, height: u32) -> Element {
-    const PAD_L: f64 = 40.0;
-    const PAD_R: f64 = 10.0;
-    const PAD_TOP: f64 = 10.0;
-    const PAD_BOT: f64 = 24.0;
-    const TOTAL_W: f64 = 580.0;
+/// A single column in a time series chart (stacked primary/secondary).
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct TimeSeriesColumn {
+    pub label: String,
+    pub primary: f64,
+    pub secondary: f64,
+    pub primary_color: String,
+    pub secondary_color: String,
+}
 
-    if series.is_empty() || series[0].points.is_empty() {
+impl TimeSeriesColumn {
+    pub(crate) fn total(&self) -> f64 {
+        self.primary + self.secondary
+    }
+}
+
+/// A grouped bar entry (current vs previous period).
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct GroupedBarEntry {
+    pub label: String,
+    pub current: f64,
+    pub previous: f64,
+    pub current_color: String,
+    pub previous_color: String,
+}
+
+// -- Style constants ----------------------------------------------------------
+
+const CHART_LABEL_STYLE: &str = "\
+    font-size: 11px; \
+    color: #706c66; \
+    font-family: 'IBM Plex Mono', monospace;\
+";
+
+#[expect(dead_code, reason = "tooltip style reserved for future hover implementation")]
+const TOOLTIP_STYLE: &str = "\
+    position: absolute; \
+    bottom: 110%; \
+    left: 50%; \
+    transform: translateX(-50%); \
+    background: #24211e; \
+    border: 1px solid #3a3530; \
+    border-radius: 6px; \
+    padding: 6px 10px; \
+    font-size: 11px; \
+    color: #e8e6e3; \
+    white-space: nowrap; \
+    pointer-events: none; \
+    z-index: 10;\
+";
+
+// -- TimeSeriesChart ----------------------------------------------------------
+
+/// Stacked column chart for time series token/cost data.
+#[component]
+pub(crate) fn TimeSeriesChart(
+    columns: Vec<TimeSeriesColumn>,
+    height_px: u32,
+    primary_label: String,
+    secondary_label: String,
+) -> Element {
+    if columns.is_empty() {
         return rsx! {
             div {
-                style: "color: #555; font-size: 12px; padding: 8px;",
+                style: "display: flex; align-items: center; justify-content: center; height: {height_px}px; color: #706c66; font-size: 13px;",
+                "No data for this range"
+            }
+        };
+    }
+
+    let max_total = columns
+        .iter()
+        .map(|c| c.total())
+        .fold(0.0f64, f64::max)
+        .max(1.0);
+
+    rsx! {
+        div {
+            style: "display: flex; flex-direction: column; gap: 6px;",
+
+            // Legend
+            div {
+                style: "display: flex; gap: 12px; align-items: center;",
+                div {
+                    style: "display: flex; align-items: center; gap: 4px;",
+                    div { style: "width: 10px; height: 10px; border-radius: 2px; background: {columns[0].primary_color};" }
+                    span { style: "{CHART_LABEL_STYLE}", "{primary_label}" }
+                }
+                if !secondary_label.is_empty() {
+                    div {
+                        style: "display: flex; align-items: center; gap: 4px;",
+                        div { style: "width: 10px; height: 10px; border-radius: 2px; background: {columns[0].secondary_color};" }
+                        span { style: "{CHART_LABEL_STYLE}", "{secondary_label}" }
+                    }
+                }
+            }
+
+            // Bars
+            div {
+                style: "display: flex; align-items: flex-end; gap: 2px; height: {height_px}px; padding: 0 4px;",
+                for col in &columns {
+                    {
+                        let total = col.total();
+                        let total_pct = (total / max_total * 100.0) as u32;
+                        let primary_pct = if total > 0.0 { (col.primary / total * 100.0) as u32 } else { 50 };
+                        let secondary_pct = 100u32.saturating_sub(primary_pct);
+                        let pcol = col.primary_color.clone();
+                        let scol = col.secondary_color.clone();
+                        let lbl = col.label.clone();
+                        let pv = format_chart_value(col.primary);
+                        let sv = format_chart_value(col.secondary);
+                        rsx! {
+                            div {
+                                style: "flex: 1; display: flex; flex-direction: column; align-items: stretch; cursor: pointer; position: relative; min-width: 4px;",
+                                title: "{lbl}\n{primary_label}: {pv}\n{secondary_label}: {sv}",
+                                div {
+                                    style: "height: {total_pct}%; display: flex; flex-direction: column; overflow: hidden; border-radius: 2px 2px 0 0;",
+                                    div {
+                                        style: "height: {primary_pct}%; background: {pcol}; min-height: 1px;",
+                                    }
+                                    div {
+                                        style: "height: {secondary_pct}%; background: {scol}; min-height: 1px;",
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            // X-axis labels
+            if columns.len() >= 2 {
+                div {
+                    style: "display: flex; justify-content: space-between; padding: 0 4px;",
+                    span { style: "{CHART_LABEL_STYLE}", "{columns.first().map(|c| c.label.as_str()).unwrap_or(\"\")}" }
+                    span { style: "{CHART_LABEL_STYLE}", "{columns.last().map(|c| c.label.as_str()).unwrap_or(\"\")}" }
+                }
+            }
+        }
+    }
+}
+
+// -- HorizBarChart ------------------------------------------------------------
+
+/// Horizontal bar chart with label, proportional bar, and value label.
+#[component]
+pub(crate) fn HorizBarChart(
+    entries: Vec<ChartEntry>,
+    max_value: f64,
+    show_value: bool,
+    on_click: Option<EventHandler<String>>,
+) -> Element {
+    if entries.is_empty() {
+        return rsx! {
+            div {
+                style: "color: #706c66; font-size: 13px; padding: 16px 0;",
                 "No data"
             }
         };
     }
 
-    let chart_h = height as f64;
-    let plot_w = TOTAL_W - PAD_L - PAD_R;
-    let plot_h = chart_h - PAD_TOP - PAD_BOT;
-
-    let all_values: Vec<f64> = series
-        .iter()
-        .flat_map(|s| s.points.iter().map(|p| p.value))
-        .collect();
-    let max_val = all_values
-        .iter()
-        .cloned()
-        .fold(f64::NEG_INFINITY, f64::max)
-        .max(1.0);
-
-    let n_points = series[0].points.len();
-    let step = if n_points > 1 {
-        plot_w / (n_points - 1) as f64
+    let effective_max = if max_value > 0.0 {
+        max_value
     } else {
-        plot_w
+        entries
+            .iter()
+            .map(|e| e.value)
+            .fold(0.0f64, f64::max)
+            .max(1.0)
     };
 
     rsx! {
-        svg {
-            width: "100%",
-            view_box: "0 0 {TOTAL_W} {chart_h}",
-            style: "display: block;",
-
-            // Y-axis gridlines
-            for tick in 0..=4u32 {
+        div {
+            style: "display: flex; flex-direction: column; gap: 8px;",
+            for (idx, entry) in entries.iter().enumerate() {
                 {
-                    let y = PAD_TOP + plot_h * (1.0 - tick as f64 / 4.0);
-                    let val = max_val * tick as f64 / 4.0;
+                    let pct = ((entry.value / effective_max) * 100.0).min(100.0) as u32;
+                    let color = entry.color.clone();
+                    let label = entry.label.clone();
+                    let value_str = if show_value {
+                        entry.sub_label.clone().unwrap_or_else(|| format_chart_value(entry.value))
+                    } else {
+                        String::new()
+                    };
+                    let id = entry.label.clone();
                     rsx! {
-                        g {
-                            key: "tick-{tick}",
-                            line {
-                                x1: "{PAD_L}",
-                                y1: "{y}",
-                                x2: "{TOTAL_W - PAD_R}",
-                                y2: "{y}",
-                                stroke: "#222",
-                                stroke_width: "1",
+                        div {
+                            key: "{idx}",
+                            style: "display: flex; align-items: center; gap: 8px; cursor: pointer;",
+                            onclick: move |_| {
+                                if let Some(handler) = &on_click {
+                                    handler.call(id.clone());
+                                }
+                            },
+                            div {
+                                style: "width: 120px; font-size: 12px; color: #a8a49e; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; flex-shrink: 0;",
+                                title: "{label}",
+                                "{label}"
                             }
-                            text {
-                                x: "{PAD_L - 4.0}",
-                                y: "{y + 4.0}",
-                                fill: COLOR_TEXT_DIM,
-                                font_size: "10",
-                                text_anchor: "end",
-                                "{format_axis_val(val)}"
+                            div {
+                                style: "flex: 1; height: 20px; background: #1a1816; border-radius: 3px; overflow: hidden;",
+                                div {
+                                    style: "height: 100%; width: {pct}%; background: {color}; border-radius: 3px; transition: width 0.3s ease;",
+                                }
                             }
-                        }
-                    }
-                }
-            }
-
-            // X labels (every ~nth point to avoid crowding)
-            for (i, pt) in series[0].points.iter().enumerate() {
-                if should_show_x_label(i, n_points) {
-                    {
-                        let x = PAD_L + i as f64 * step;
-                        let label = pt.label.clone();
-                        rsx! {
-                            text {
-                                key: "xlabel-{i}",
-                                x: "{x}",
-                                y: "{chart_h - 4.0}",
-                                fill: COLOR_TEXT_DIM,
-                                font_size: "9",
-                                text_anchor: "middle",
-                                "{truncate_label(&label, 8)}"
-                            }
-                        }
-                    }
-                }
-            }
-
-            // Series lines
-            for (si, s) in series.iter().enumerate() {
-                {
-                    let points_str: String = s
-                        .points
-                        .iter()
-                        .enumerate()
-                        .map(|(i, p)| {
-                            let x = PAD_L + i as f64 * step;
-                            let y = PAD_TOP + plot_h * (1.0 - p.value / max_val);
-                            format!("{x:.1},{y:.1}")
-                        })
-                        .collect::<Vec<_>>()
-                        .join(" ");
-                    rsx! {
-                        polyline {
-                            key: "series-{si}",
-                            points: "{points_str}",
-                            fill: "none",
-                            stroke: "{s.color}",
-                            stroke_width: "2",
-                        }
-                    }
-                }
-            }
-
-            // Legend
-            for (si, s) in series.iter().enumerate() {
-                {
-                    let lx = PAD_L + si as f64 * 100.0;
-                    let ly = PAD_TOP - 2.0;
-                    let name = truncate_label(&s.name, 12);
-                    rsx! {
-                        g { key: "legend-{si}",
-                            rect {
-                                x: "{lx}",
-                                y: "{ly}",
-                                width: "12",
-                                height: "4",
-                                fill: "{s.color}",
-                            }
-                            text {
-                                x: "{lx + 14.0}",
-                                y: "{ly + 4.0}",
-                                fill: COLOR_TEXT_DIM,
-                                font_size: "9",
-                                "{name}"
+                            if show_value {
+                                div {
+                                    style: "width: 72px; text-align: right; font-size: 12px; color: #706c66; font-family: 'IBM Plex Mono', monospace; flex-shrink: 0;",
+                                    "{value_str}"
+                                }
                             }
                         }
                     }
@@ -439,124 +238,70 @@ pub(crate) fn LineChart(series: Vec<LineSeries>, height: u32) -> Element {
     }
 }
 
-// -- Percentile bar -----------------------------------------------------------
+// -- DonutChart ---------------------------------------------------------------
 
-/// A single tool's percentile distribution for the percentile bar chart.
-#[derive(Debug, Clone, PartialEq)]
-pub(crate) struct PercentileEntry {
-    pub label: String,
-    pub min_ms: u64,
-    pub p25_ms: u64,
-    pub p50_ms: u64,
-    pub p75_ms: u64,
-    pub p95_ms: u64,
-    pub max_ms: u64,
-}
-
-/// Horizontal percentile bars showing distribution of execution times.
-///
-/// Each row renders: whiskers (min—max), IQR box (p25—p75), median marker.
+/// Donut chart using CSS conic-gradient with legend.
 #[component]
-pub(crate) fn PercentileBarChart(entries: Vec<PercentileEntry>) -> Element {
-    const LABEL_W: u64 = 130;
-    const ROW_H: u64 = 32;
-    const PAD_TOP: u64 = 8;
-    const TOTAL_W: u64 = 600;
-    const BAR_AREA: u64 = TOTAL_W - LABEL_W - 60;
+pub(crate) fn DonutChart(
+    segments: Vec<ChartEntry>,
+    size_px: u32,
+    center_label: String,
+) -> Element {
+    if segments.is_empty() {
+        return rsx! {
+            div {
+                style: "color: #706c66; font-size: 13px; padding: 16px 0;",
+                "No data"
+            }
+        };
+    }
 
-    let n = entries.len() as u64;
-    let chart_h = n * ROW_H + PAD_TOP * 2;
+    let total: f64 = segments.iter().map(|s| s.value).sum();
+    let effective_total = if total <= 0.0 { 1.0 } else { total };
 
-    let scale_max = entries.iter().map(|e| e.p95_ms).max().unwrap_or(1).max(1);
+    let mut accumulated = 0.0f64;
+    let gradient_stops: Vec<String> = segments
+        .iter()
+        .map(|s| {
+            let pct = s.value / effective_total * 100.0;
+            let start = accumulated;
+            accumulated += pct;
+            format!("{} {start:.1}% {accumulated:.1}%", s.color)
+        })
+        .collect();
+    let gradient = gradient_stops.join(", ");
+
+    let hole_size = size_px * 55 / 100;
+    let hole_offset = (size_px - hole_size) / 2;
 
     rsx! {
-        svg {
-            width: "100%",
-            view_box: "0 0 {TOTAL_W} {chart_h}",
-            style: "display: block; overflow: visible;",
+        div {
+            style: "display: flex; flex-direction: column; align-items: center; gap: 16px;",
 
-            for (i, entry) in entries.iter().enumerate() {
-                {
-                    let y = PAD_TOP + i as u64 * ROW_H;
-                    let cy = y + ROW_H / 2;
+            div {
+                style: "position: relative; width: {size_px}px; height: {size_px}px; border-radius: 50%; background: conic-gradient({gradient});",
+                div {
+                    style: "position: absolute; top: {hole_offset}px; left: {hole_offset}px; width: {hole_size}px; height: {hole_size}px; background: #12110f; border-radius: 50%; display: flex; flex-direction: column; align-items: center; justify-content: center;",
+                    div {
+                        style: "font-size: 11px; color: #706c66; text-align: center;",
+                        "{center_label}"
+                    }
+                }
+            }
 
-                    let x = |ms: u64| -> u64 {
-                        LABEL_W + (ms.min(scale_max) * BAR_AREA) / scale_max
-                    };
-
-                    let x_min = x(entry.min_ms);
-                    let x_p25 = x(entry.p25_ms);
-                    let x_p50 = x(entry.p50_ms);
-                    let x_p75 = x(entry.p75_ms);
-                    let x_p95 = x(entry.p95_ms);
-                    let label = entry.label.clone();
-                    let p95_color = if entry.p95_ms > 10_000 { COLOR_FAILURE }
-                        else if entry.p95_ms > 5_000 { COLOR_WARN }
-                        else { COLOR_SUCCESS };
-
-                    rsx! {
-                        g { key: "{label}",
-                            // Tool label
-                            text {
-                                x: "0",
-                                y: "{cy + 4}",
-                                fill: COLOR_TEXT,
-                                font_size: "12",
-                                font_family: "monospace",
-                                "{truncate_label(&label, 18)}"
-                            }
-
-                            // Whisker line (min to p95)
-                            line {
-                                x1: "{x_min}",
-                                y1: "{cy}",
-                                x2: "{x_p95}",
-                                y2: "{cy}",
-                                stroke: COLOR_MUTED,
-                                stroke_width: "1",
-                            }
-
-                            // IQR box (p25 to p75)
-                            rect {
-                                x: "{x_p25}",
-                                y: "{cy - 6}",
-                                width: "{x_p75.saturating_sub(x_p25)}",
-                                height: "12",
-                                fill: p95_color,
-                                fill_opacity: "0.3",
-                                stroke: p95_color,
-                                stroke_width: "1",
-                                rx: "2",
-                            }
-
-                            // Median marker
-                            line {
-                                x1: "{x_p50}",
-                                y1: "{cy - 7}",
-                                x2: "{x_p50}",
-                                y2: "{cy + 7}",
-                                stroke: p95_color,
-                                stroke_width: "2",
-                            }
-
-                            // Min tick
-                            line {
-                                x1: "{x_min}",
-                                y1: "{cy - 4}",
-                                x2: "{x_min}",
-                                y2: "{cy + 4}",
-                                stroke: COLOR_MUTED,
-                                stroke_width: "1",
-                            }
-
-                            // p95 label
-                            text {
-                                x: "{x_p95 + 4}",
-                                y: "{cy + 4}",
-                                fill: p95_color,
-                                font_size: "10",
-                                font_family: "monospace",
-                                "p95:{format_ms_short(entry.p95_ms)}"
+            div {
+                style: "display: flex; flex-wrap: wrap; gap: 8px 16px; justify-content: center;",
+                for seg in &segments {
+                    {
+                        let pct = seg.value / effective_total * 100.0;
+                        let color = seg.color.clone();
+                        let label = seg.label.clone();
+                        rsx! {
+                            div {
+                                style: "display: flex; align-items: center; gap: 4px;",
+                                div { style: "width: 10px; height: 10px; border-radius: 2px; background: {color}; flex-shrink: 0;" }
+                                span { style: "font-size: 12px; color: #a8a49e;", "{label}" }
+                                span { style: "font-size: 11px; color: #706c66;", "({pct:.1}%)" }
                             }
                         }
                     }
@@ -566,40 +311,100 @@ pub(crate) fn PercentileBarChart(entries: Vec<PercentileEntry>) -> Element {
     }
 }
 
-// -- Internal helpers ---------------------------------------------------------
+// -- GroupedBarChart ----------------------------------------------------------
 
-fn truncate_label(label: &str, max_chars: usize) -> String {
-    if label.len() <= max_chars {
-        label.to_string()
-    } else {
-        format!("{}…", &label[..max_chars.saturating_sub(1)])
+/// Grouped vertical bar chart: current vs previous period per entry.
+#[component]
+pub(crate) fn GroupedBarChart(
+    entries: Vec<GroupedBarEntry>,
+    height_px: u32,
+    current_label: String,
+    previous_label: String,
+) -> Element {
+    if entries.is_empty() {
+        return rsx! {
+            div {
+                style: "display: flex; align-items: center; justify-content: center; height: {height_px}px; color: #706c66; font-size: 13px;",
+                "No data for this range"
+            }
+        };
+    }
+
+    let max_val = entries
+        .iter()
+        .flat_map(|e| [e.current, e.previous])
+        .fold(0.0f64, f64::max)
+        .max(1.0);
+
+    rsx! {
+        div {
+            style: "display: flex; flex-direction: column; gap: 8px;",
+
+            div {
+                style: "display: flex; gap: 12px;",
+                if let Some(first) = entries.first() {
+                    div {
+                        style: "display: flex; align-items: center; gap: 4px;",
+                        div { style: "width: 10px; height: 10px; border-radius: 2px; background: {first.current_color};" }
+                        span { style: "{CHART_LABEL_STYLE}", "{current_label}" }
+                    }
+                    div {
+                        style: "display: flex; align-items: center; gap: 4px;",
+                        div { style: "width: 10px; height: 10px; border-radius: 2px; background: {first.previous_color};" }
+                        span { style: "{CHART_LABEL_STYLE}", "{previous_label}" }
+                    }
+                }
+            }
+
+            div {
+                style: "display: flex; align-items: flex-end; gap: 8px; height: {height_px}px; overflow-x: auto; padding-bottom: 4px;",
+                for entry in &entries {
+                    {
+                        let curr_pct = (entry.current / max_val * 100.0) as u32;
+                        let prev_pct = (entry.previous / max_val * 100.0) as u32;
+                        let ccol = entry.current_color.clone();
+                        let pcol = entry.previous_color.clone();
+                        let label = entry.label.clone();
+                        let cv = format_chart_value(entry.current);
+                        let pv = format_chart_value(entry.previous);
+                        rsx! {
+                            div {
+                                style: "display: flex; flex-direction: column; align-items: center; gap: 4px; min-width: 56px;",
+                                div {
+                                    style: "display: flex; align-items: flex-end; gap: 2px; height: {height_px}px;",
+                                    div {
+                                        style: "width: 24px; height: {curr_pct}%; background: {ccol}; border-radius: 2px 2px 0 0; min-height: 2px;",
+                                        title: "{current_label}: {cv}",
+                                    }
+                                    div {
+                                        style: "width: 24px; height: {prev_pct}%; background: {pcol}; border-radius: 2px 2px 0 0; min-height: 2px;",
+                                        title: "{previous_label}: {pv}",
+                                    }
+                                }
+                                div {
+                                    style: "width: 56px; text-align: center; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;",
+                                    span { style: "{CHART_LABEL_STYLE}", "{label}" }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
     }
 }
 
-fn format_axis_val(val: f64) -> String {
-    if val >= 1_000_000.0 {
-        format!("{:.0}M", val / 1_000_000.0)
-    } else if val >= 1_000.0 {
-        format!("{:.0}K", val / 1_000.0)
-    } else if val > 0.0 {
-        format!("{val:.0}")
-    } else {
-        String::new()
-    }
-}
+// -- Format helpers -----------------------------------------------------------
 
-fn format_ms_short(ms: u64) -> String {
-    if ms >= 1_000 {
-        format!("{:.1}s", ms as f64 / 1_000.0) // kanon:ignore RUST/as-cast
+/// Format a float value for chart labels (K/M suffix).
+pub(crate) fn format_chart_value(v: f64) -> String {
+    if v >= 1_000_000.0 {
+        format!("{:.1}M", v / 1_000_000.0)
+    } else if v >= 1_000.0 {
+        format!("{:.1}K", v / 1_000.0)
+    } else if v == v.trunc() {
+        format!("{}", v as u64)
     } else {
-        format!("{ms}ms")
+        format!("{v:.2}")
     }
-}
-
-fn should_show_x_label(i: usize, n: usize) -> bool {
-    if n <= 7 {
-        return true;
-    }
-    let step = n / 6;
-    i == 0 || i == n - 1 || i % step == 0
 }

--- a/crates/theatron/desktop/src/components/mod.rs
+++ b/crates/theatron/desktop/src/components/mod.rs
@@ -42,3 +42,5 @@ pub(crate) mod tool_status;
 /// Virtual scrolling utilities for large lists.
 pub(crate) mod virtual_list;
 pub(crate) mod wave_band;
+/// Reusable div-based chart components for the metrics views.
+pub(crate) mod chart;

--- a/crates/theatron/desktop/src/state/metrics.rs
+++ b/crates/theatron/desktop/src/state/metrics.rs
@@ -1,0 +1,744 @@
+//! Metrics state: token usage, cost tracking, and budget management.
+
+// -- Enums --------------------------------------------------------------------
+
+/// Time granularity for metric series.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[non_exhaustive]
+pub(crate) enum Granularity {
+    #[default]
+    Daily,
+    Weekly,
+    Monthly,
+}
+
+impl Granularity {
+    pub(crate) fn label(self) -> &'static str {
+        match self {
+            Self::Daily => "Daily",
+            Self::Weekly => "Weekly",
+            Self::Monthly => "Monthly",
+        }
+    }
+
+    pub(crate) fn url_param(self) -> &'static str {
+        match self {
+            Self::Daily => "daily",
+            Self::Weekly => "weekly",
+            Self::Monthly => "monthly",
+        }
+    }
+}
+
+/// Preset date range for metric queries.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+#[non_exhaustive]
+pub(crate) enum DateRange {
+    #[default]
+    Last7Days,
+    Last30Days,
+    Last90Days,
+    Custom { from: String, to: String },
+}
+
+impl DateRange {
+    pub(crate) fn label(&self) -> &'static str {
+        match self {
+            Self::Last7Days => "7 days",
+            Self::Last30Days => "30 days",
+            Self::Last90Days => "90 days",
+            Self::Custom { .. } => "Custom",
+        }
+    }
+
+    /// Compute (from, to) date strings for API query parameters.
+    pub(crate) fn to_query_dates(&self) -> (String, String) {
+        match self {
+            Self::Custom { from, to } => (from.clone(), to.clone()),
+            Self::Last7Days => (date_minus_days(7), today_date_str()),
+            Self::Last30Days => (date_minus_days(30), today_date_str()),
+            Self::Last90Days => (date_minus_days(90), today_date_str()),
+        }
+    }
+}
+
+/// Top-level tab selection for the metrics view.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub(crate) enum MetricsTab {
+    #[default]
+    Tokens,
+    Costs,
+}
+
+/// Sort direction for data tables.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub(crate) enum SortDir {
+    #[default]
+    Desc,
+    Asc,
+}
+
+impl SortDir {
+    pub(crate) fn flip(self) -> Self {
+        match self {
+            Self::Asc => Self::Desc,
+            Self::Desc => Self::Asc,
+        }
+    }
+}
+
+/// Sort column for the agent token table.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub(crate) enum AgentTokenSort {
+    #[default]
+    Total,
+    Name,
+    Input,
+    Output,
+    PctOfTotal,
+    AvgPerSession,
+}
+
+/// Sort column for the agent cost table.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub(crate) enum AgentCostSort {
+    #[default]
+    TotalCost,
+    Name,
+    CostPerSession,
+    CostPerMessage,
+    CostPer1k,
+}
+
+// -- API response types -------------------------------------------------------
+
+/// A single data point in a token usage time series.
+#[derive(Debug, Clone, PartialEq, Default, serde::Deserialize)]
+pub(crate) struct TokenSeriesPoint {
+    #[serde(default)]
+    pub date: String,
+    #[serde(default)]
+    pub input_tokens: u64,
+    #[serde(default)]
+    pub output_tokens: u64,
+}
+
+impl TokenSeriesPoint {
+    #[expect(dead_code, reason = "used when series filtering by agent/model is implemented")]
+    pub(crate) fn total(&self) -> u64 {
+        self.input_tokens.saturating_add(self.output_tokens)
+    }
+}
+
+/// Per-agent token usage row from the metrics API.
+#[derive(Debug, Clone, PartialEq, Default, serde::Deserialize)]
+pub(crate) struct AgentTokenRow {
+    #[serde(default)]
+    pub id: String,
+    #[serde(default)]
+    pub name: String,
+    #[serde(default)]
+    pub input_tokens: u64,
+    #[serde(default)]
+    pub output_tokens: u64,
+    #[serde(default)]
+    pub session_count: u64,
+}
+
+impl AgentTokenRow {
+    pub(crate) fn total(&self) -> u64 {
+        self.input_tokens.saturating_add(self.output_tokens)
+    }
+
+    pub(crate) fn avg_per_session(&self) -> u64 {
+        if self.session_count == 0 {
+            0
+        } else {
+            self.total() / self.session_count
+        }
+    }
+
+    #[expect(
+        clippy::cast_precision_loss,
+        reason = "display-only: percentage rounded for rendering"
+    )]
+    pub(crate) fn pct_of_total(&self, grand_total: u64) -> f64 {
+        if grand_total == 0 {
+            0.0
+        } else {
+            self.total() as f64 / grand_total as f64 * 100.0
+        }
+    }
+}
+
+/// Per-model token usage row from the metrics API.
+#[derive(Debug, Clone, PartialEq, Default, serde::Deserialize)]
+pub(crate) struct ModelTokenRow {
+    #[serde(default)]
+    pub model: String,
+    #[serde(default)]
+    pub input_tokens: u64,
+    #[serde(default)]
+    pub output_tokens: u64,
+    #[serde(default)]
+    pub session_count: u64,
+}
+
+impl ModelTokenRow {
+    pub(crate) fn total(&self) -> u64 {
+        self.input_tokens.saturating_add(self.output_tokens)
+    }
+
+    #[expect(
+        clippy::cast_precision_loss,
+        reason = "display-only: percentage rounded for rendering"
+    )]
+    pub(crate) fn pct_of_total(&self, grand_total: u64) -> f64 {
+        if grand_total == 0 {
+            0.0
+        } else {
+            self.total() as f64 / grand_total as f64 * 100.0
+        }
+    }
+}
+
+/// Full token metrics API response envelope.
+#[derive(Debug, Clone, PartialEq, Default, serde::Deserialize)]
+pub(crate) struct TokenMetricsResponse {
+    #[serde(default)]
+    pub series: Vec<TokenSeriesPoint>,
+    #[serde(default)]
+    pub agents: Vec<AgentTokenRow>,
+    #[serde(default)]
+    pub models: Vec<ModelTokenRow>,
+    #[serde(default)]
+    pub today_input: u64,
+    #[serde(default)]
+    pub today_output: u64,
+    #[serde(default)]
+    pub week_input: u64,
+    #[serde(default)]
+    pub week_output: u64,
+    #[serde(default)]
+    pub month_input: u64,
+    #[serde(default)]
+    pub month_output: u64,
+    #[serde(default)]
+    pub prev_today_input: u64,
+    #[serde(default)]
+    pub prev_today_output: u64,
+    #[serde(default)]
+    pub prev_week_input: u64,
+    #[serde(default)]
+    pub prev_week_output: u64,
+    #[serde(default)]
+    pub prev_month_input: u64,
+    #[serde(default)]
+    pub prev_month_output: u64,
+}
+
+impl TokenMetricsResponse {
+    pub(crate) fn today_total(&self) -> u64 {
+        self.today_input.saturating_add(self.today_output)
+    }
+
+    pub(crate) fn week_total(&self) -> u64 {
+        self.week_input.saturating_add(self.week_output)
+    }
+
+    pub(crate) fn month_total(&self) -> u64 {
+        self.month_input.saturating_add(self.month_output)
+    }
+
+    pub(crate) fn prev_today_total(&self) -> u64 {
+        self.prev_today_input.saturating_add(self.prev_today_output)
+    }
+
+    pub(crate) fn prev_week_total(&self) -> u64 {
+        self.prev_week_input.saturating_add(self.prev_week_output)
+    }
+
+    pub(crate) fn prev_month_total(&self) -> u64 {
+        self.prev_month_input.saturating_add(self.prev_month_output)
+    }
+
+    pub(crate) fn grand_total_tokens(&self) -> u64 {
+        self.agents.iter().map(|a| a.total()).sum()
+    }
+}
+
+/// A single data point in a cost time series.
+#[derive(Debug, Clone, PartialEq, Default, serde::Deserialize)]
+pub(crate) struct CostSeriesPoint {
+    #[serde(default)]
+    pub date: String,
+    #[serde(default)]
+    pub cost_usd: f64,
+}
+
+/// Per-agent cost row from the costs API.
+#[derive(Debug, Clone, PartialEq, Default, serde::Deserialize)]
+pub(crate) struct AgentCostRow {
+    #[serde(default)]
+    pub id: String,
+    #[serde(default)]
+    pub name: String,
+    #[serde(default)]
+    pub total_cost: f64,
+    #[serde(default)]
+    pub message_count: u64,
+    #[serde(default)]
+    pub session_count: u64,
+    #[serde(default)]
+    pub output_tokens: u64,
+    /// Cost from the previous equivalent period (for comparison chart).
+    #[serde(default)]
+    pub prev_period_cost: f64,
+}
+
+impl AgentCostRow {
+    pub(crate) fn cost_per_session(&self) -> f64 {
+        if self.session_count == 0 {
+            0.0
+        } else {
+            self.total_cost / self.session_count as f64
+        }
+    }
+
+    pub(crate) fn cost_per_message(&self) -> f64 {
+        if self.message_count == 0 {
+            0.0
+        } else {
+            self.total_cost / self.message_count as f64
+        }
+    }
+
+    pub(crate) fn cost_per_1k_output(&self) -> f64 {
+        if self.output_tokens == 0 {
+            0.0
+        } else {
+            self.total_cost / (self.output_tokens as f64 / 1000.0)
+        }
+    }
+}
+
+/// Full cost metrics API response envelope.
+#[derive(Debug, Clone, PartialEq, Default, serde::Deserialize)]
+pub(crate) struct CostMetricsResponse {
+    #[serde(default)]
+    pub series: Vec<CostSeriesPoint>,
+    #[serde(default)]
+    pub agents: Vec<AgentCostRow>,
+    #[serde(default)]
+    pub today_cost: f64,
+    #[serde(default)]
+    pub week_cost: f64,
+    #[serde(default)]
+    pub month_cost: f64,
+    #[serde(default)]
+    pub prev_today_cost: f64,
+    #[serde(default)]
+    pub prev_week_cost: f64,
+    #[serde(default)]
+    pub prev_month_cost: f64,
+}
+
+// -- Budget config (local-only) -----------------------------------------------
+
+/// Monthly spend budget configured locally.
+#[derive(Debug, Clone, PartialEq, Default)]
+pub(crate) struct BudgetConfig {
+    /// Monthly limit in USD. Zero means no budget set.
+    pub monthly_limit_usd: f64,
+}
+
+// -- Computed display types ---------------------------------------------------
+
+/// Summary card data: current value with delta vs previous period.
+#[derive(Debug, Clone, PartialEq, Default)]
+pub(crate) struct SummaryDelta {
+    pub value: f64,
+    pub delta_pct: f64,
+    pub is_up: bool,
+}
+
+// -- Helper functions ---------------------------------------------------------
+
+/// Compute a summary delta from current and previous u64 values.
+#[expect(
+    clippy::cast_precision_loss,
+    reason = "display-only: sub-unit precision irrelevant for delta"
+)]
+pub(crate) fn compute_delta_u64(current: u64, previous: u64) -> SummaryDelta {
+    compute_delta_f64(current as f64, previous as f64)
+}
+
+/// Compute a summary delta from current and previous float values.
+pub(crate) fn compute_delta_f64(current: f64, previous: f64) -> SummaryDelta {
+    let delta_pct = if previous == 0.0 {
+        0.0
+    } else {
+        ((current - previous) / previous) * 100.0
+    };
+    SummaryDelta {
+        value: current,
+        delta_pct: delta_pct.abs(),
+        is_up: current >= previous,
+    }
+}
+
+/// Budget progress as a clamped percentage (0–100).
+pub(crate) fn budget_progress_pct(spent: f64, limit: f64) -> f64 {
+    if limit <= 0.0 {
+        0.0
+    } else {
+        (spent / limit * 100.0).min(100.0)
+    }
+}
+
+/// Color for budget progress bar based on spend percentage.
+pub(crate) fn budget_bar_color(pct: f64) -> &'static str {
+    if pct >= 90.0 {
+        "#ef4444"
+    } else if pct >= 70.0 {
+        "#eab308"
+    } else {
+        "#22c55e"
+    }
+}
+
+/// Project month-end spend via linear extrapolation.
+///
+/// Returns 0.0 if `day_of_month` is 0 (guard against division by zero).
+pub(crate) fn project_month_end(
+    current_spend: f64,
+    day_of_month: u32,
+    days_in_month: u32,
+) -> f64 {
+    if day_of_month == 0 || days_in_month == 0 {
+        return 0.0;
+    }
+    let daily_rate = current_spend / f64::from(day_of_month);
+    daily_rate * f64::from(days_in_month)
+}
+
+// -- Display formatters -------------------------------------------------------
+
+/// Format a token count with K/M suffix.
+#[expect(
+    clippy::cast_precision_loss,
+    reason = "display-only: sub-token precision irrelevant"
+)]
+pub(crate) fn format_tokens(count: u64) -> String {
+    const K: u64 = 1_000;
+    const M: u64 = 1_000_000;
+    if count >= M {
+        format!("{:.1}M", count as f64 / M as f64)
+    } else if count >= K {
+        format!("{:.1}K", count as f64 / K as f64)
+    } else {
+        count.to_string()
+    }
+}
+
+/// Format a USD cost value.
+pub(crate) fn format_cost(value: f64) -> String {
+    format!("${value:.2}")
+}
+
+// -- Date helpers -------------------------------------------------------------
+
+/// Today's date as an ISO-8601 string (YYYY-MM-DD).
+pub(crate) fn today_date_str() -> String {
+    let (y, m, d) = epoch_secs_to_ymd(unix_seconds());
+    format!("{y:04}-{m:02}-{d:02}")
+}
+
+/// A date `offset` days before today as an ISO-8601 string.
+pub(crate) fn date_minus_days(offset: u32) -> String {
+    let secs = unix_seconds().saturating_sub(u64::from(offset) * 86400);
+    let (y, m, d) = epoch_secs_to_ymd(secs);
+    format!("{y:04}-{m:02}-{d:02}")
+}
+
+/// Current day of month (1-based).
+pub(crate) fn day_of_month_today() -> u32 {
+    let (_, _, d) = epoch_secs_to_ymd(unix_seconds());
+    d
+}
+
+/// Number of days in the current calendar month.
+pub(crate) fn days_in_current_month() -> u32 {
+    let (y, m, _) = epoch_secs_to_ymd(unix_seconds());
+    days_in_month(y, m)
+}
+
+fn unix_seconds() -> u64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+/// Convert Unix seconds to (year, month, day) using the civil calendar algorithm.
+///
+/// INVARIANT: Algorithm from Howard Hinnant's date library. Correct for all
+/// dates representable in a u64 Unix timestamp.
+fn epoch_secs_to_ymd(secs: u64) -> (u32, u32, u32) {
+    let days = (secs / 86400) as i64;
+    let z = days + 719468;
+    let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
+    let doe = z - era * 146_097;
+    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146_096) / 365;
+    let y = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = doy - (153 * mp + 2) / 5 + 1;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 };
+    let y = if m <= 2 { y + 1 } else { y };
+    (y as u32, m as u32, d as u32)
+}
+
+fn days_in_month(year: u32, month: u32) -> u32 {
+    match month {
+        1 | 3 | 5 | 7 | 8 | 10 | 12 => 31,
+        4 | 6 | 9 | 11 => 30,
+        2 => {
+            if year % 4 == 0 && (year % 100 != 0 || year % 400 == 0) {
+                29
+            } else {
+                28
+            }
+        }
+        _ => 30,
+    }
+}
+
+// -- Pricing table (client-side fallback) -------------------------------------
+
+/// Cost per 1K output tokens for a model (USD).
+///
+/// NOTE: Pricing as of 2026-03. Used only when the API does not return costs.
+pub(crate) fn cost_per_1k_output(model: &str) -> f64 {
+    if model.contains("opus-4") {
+        0.075
+    } else if model.contains("sonnet-4") {
+        0.015
+    } else if model.contains("haiku-4") {
+        0.00125
+    } else if model.contains("opus-3") {
+        0.060
+    } else if model.contains("sonnet-3-5") || model.contains("sonnet-3.5") {
+        0.015
+    } else if model.contains("sonnet-3") {
+        0.015
+    } else if model.contains("haiku-3") {
+        0.00125
+    } else {
+        0.015
+    }
+}
+
+// -- Color helpers ------------------------------------------------------------
+
+/// Consistent accent color for an agent by list position.
+pub(crate) fn agent_color(index: usize) -> &'static str {
+    const PALETTE: &[&str] = &[
+        "#5b6af0", "#10b981", "#f59e0b", "#f43f5e",
+        "#0ea5e9", "#8b5cf6", "#ec4899", "#14b8a6",
+    ];
+    PALETTE[index % PALETTE.len()]
+}
+
+/// Accent color for a model name.
+pub(crate) fn model_color(model: &str) -> &'static str {
+    if model.contains("opus") {
+        "#8b5cf6"
+    } else if model.contains("sonnet") {
+        "#5b6af0"
+    } else if model.contains("haiku") {
+        "#10b981"
+    } else {
+        "#9A7B4F"
+    }
+}
+
+// -- Sort helpers -------------------------------------------------------------
+
+/// Sort agent token rows in-place.
+pub(crate) fn sort_agent_token_rows(
+    rows: &mut Vec<AgentTokenRow>,
+    col: AgentTokenSort,
+    dir: SortDir,
+    grand_total: u64,
+) {
+    rows.sort_by(|a, b| {
+        let cmp = match col {
+            AgentTokenSort::Name => a.name.cmp(&b.name),
+            AgentTokenSort::Total => a.total().cmp(&b.total()),
+            AgentTokenSort::Input => a.input_tokens.cmp(&b.input_tokens),
+            AgentTokenSort::Output => a.output_tokens.cmp(&b.output_tokens),
+            AgentTokenSort::PctOfTotal => a
+                .pct_of_total(grand_total)
+                .partial_cmp(&b.pct_of_total(grand_total))
+                .unwrap_or(std::cmp::Ordering::Equal),
+            AgentTokenSort::AvgPerSession => a.avg_per_session().cmp(&b.avg_per_session()),
+        };
+        if dir == SortDir::Desc {
+            cmp.reverse()
+        } else {
+            cmp
+        }
+    });
+}
+
+/// Sort agent cost rows in-place.
+pub(crate) fn sort_agent_cost_rows(
+    rows: &mut Vec<AgentCostRow>,
+    col: AgentCostSort,
+    dir: SortDir,
+) {
+    rows.sort_by(|a, b| {
+        let cmp = match col {
+            AgentCostSort::Name => a.name.cmp(&b.name),
+            AgentCostSort::TotalCost => a
+                .total_cost
+                .partial_cmp(&b.total_cost)
+                .unwrap_or(std::cmp::Ordering::Equal),
+            AgentCostSort::CostPerSession => a
+                .cost_per_session()
+                .partial_cmp(&b.cost_per_session())
+                .unwrap_or(std::cmp::Ordering::Equal),
+            AgentCostSort::CostPerMessage => a
+                .cost_per_message()
+                .partial_cmp(&b.cost_per_message())
+                .unwrap_or(std::cmp::Ordering::Equal),
+            AgentCostSort::CostPer1k => a
+                .cost_per_1k_output()
+                .partial_cmp(&b.cost_per_1k_output())
+                .unwrap_or(std::cmp::Ordering::Equal),
+        };
+        if dir == SortDir::Desc {
+            cmp.reverse()
+        } else {
+            cmp
+        }
+    });
+}
+
+// -- Tests --------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn compute_delta_up_direction() {
+        let d = compute_delta_f64(120.0, 100.0);
+        assert!(d.is_up, "120 vs 100 should be up");
+        assert!((d.delta_pct - 20.0).abs() < 0.01, "delta must be 20%");
+    }
+
+    #[test]
+    fn compute_delta_down_direction() {
+        let d = compute_delta_f64(80.0, 100.0);
+        assert!(!d.is_up, "80 vs 100 should be down");
+        assert!((d.delta_pct - 20.0).abs() < 0.01, "delta magnitude must be 20%");
+    }
+
+    #[test]
+    fn compute_delta_zero_previous() {
+        let d = compute_delta_f64(50.0, 0.0);
+        assert_eq!(d.delta_pct, 0.0, "zero previous must return 0% delta");
+    }
+
+    #[test]
+    fn budget_progress_normal() {
+        let pct = budget_progress_pct(70.0, 100.0);
+        assert!((pct - 70.0).abs() < 0.01, "70/100 must be 70%");
+    }
+
+    #[test]
+    fn budget_progress_capped_at_100() {
+        let pct = budget_progress_pct(150.0, 100.0);
+        assert!((pct - 100.0).abs() < 0.01, "overshoot must cap at 100%");
+    }
+
+    #[test]
+    fn budget_progress_zero_limit() {
+        let pct = budget_progress_pct(50.0, 0.0);
+        assert_eq!(pct, 0.0, "zero limit must return 0%");
+    }
+
+    #[test]
+    fn budget_bar_color_green() {
+        assert_eq!(budget_bar_color(50.0), "#22c55e");
+    }
+
+    #[test]
+    fn budget_bar_color_amber() {
+        assert_eq!(budget_bar_color(75.0), "#eab308");
+    }
+
+    #[test]
+    fn budget_bar_color_red() {
+        assert_eq!(budget_bar_color(95.0), "#ef4444");
+    }
+
+    #[test]
+    fn project_month_end_linear() {
+        let projected = project_month_end(15.0, 15, 30);
+        assert!((projected - 30.0).abs() < 0.01, "half-month should project to double");
+    }
+
+    #[test]
+    fn project_month_end_zero_day() {
+        assert_eq!(project_month_end(10.0, 0, 30), 0.0);
+    }
+
+    #[test]
+    fn format_tokens_units() {
+        assert_eq!(format_tokens(500), "500");
+        assert_eq!(format_tokens(1500), "1.5K");
+        assert_eq!(format_tokens(2_500_000), "2.5M");
+    }
+
+    #[test]
+    fn format_cost_two_decimals() {
+        assert_eq!(format_cost(1.5), "$1.50");
+        assert_eq!(format_cost(0.001), "$0.00");
+    }
+
+    #[test]
+    fn sort_dir_flip() {
+        assert_eq!(SortDir::Asc.flip(), SortDir::Desc);
+        assert_eq!(SortDir::Desc.flip(), SortDir::Asc);
+    }
+
+    #[test]
+    fn agent_token_row_totals() {
+        let row = AgentTokenRow {
+            input_tokens: 1000,
+            output_tokens: 500,
+            session_count: 5,
+            ..Default::default()
+        };
+        assert_eq!(row.total(), 1500);
+        assert_eq!(row.avg_per_session(), 300);
+    }
+
+    #[test]
+    fn agent_cost_row_efficiency() {
+        let row = AgentCostRow {
+            total_cost: 1.0,
+            output_tokens: 10_000,
+            session_count: 2,
+            message_count: 10,
+            ..Default::default()
+        };
+        assert!((row.cost_per_1k_output() - 0.1).abs() < 0.001);
+        assert!((row.cost_per_session() - 0.5).abs() < 0.001);
+        assert!((row.cost_per_message() - 0.1).abs() < 0.001);
+    }
+}

--- a/crates/theatron/desktop/src/state/mod.rs
+++ b/crates/theatron/desktop/src/state/mod.rs
@@ -18,18 +18,12 @@ pub(crate) mod diff;
 /// Discussion state for planning gray-area questions.
 pub(crate) mod discussion;
 pub mod events;
-/// Notification preferences, history, and Do Not Disturb state.
-pub(crate) mod notifications;
 /// Execution state for wave-based plan progress.
 pub(crate) mod execution;
 pub(crate) mod fetch;
 /// Workspace file tree explorer state.
 pub(crate) mod files;
-/// Knowledge graph, force simulation, viewport, community filter, and drift state.
-pub(crate) mod graph;
 pub(crate) mod input;
-/// Entity list, detail, and navigation state for the memory explorer.
-pub(crate) mod memory;
 pub(crate) mod navigation;
 /// Planning project, requirements, and roadmap state.
 pub(crate) mod planning;
@@ -44,11 +38,9 @@ pub mod tools;
 /// Goal-backward verification state for the planning project detail view.
 pub(crate) mod verification;
 
-/// Meta-insights state: agent performance, quality, knowledge, health, reflection.
-pub(crate) mod meta;
 /// Ops dashboard state: agent status cards, service health, toggle controls.
 pub(crate) mod ops;
 /// Settings state: server configs, appearance, keybindings, wizard flow.
 pub(crate) mod settings;
-/// Tool usage metrics: aggregated stats, stores, and helpers.
-pub(crate) mod tool_metrics;
+/// Token usage, cost tracking, budget, and metrics display helpers.
+pub(crate) mod metrics;

--- a/crates/theatron/desktop/src/views/metrics/agent_breakdown.rs
+++ b/crates/theatron/desktop/src/views/metrics/agent_breakdown.rs
@@ -1,0 +1,133 @@
+//! Agent token usage breakdown: bar chart + sortable table.
+
+use dioxus::prelude::*;
+
+use crate::components::chart::{ChartEntry, HorizBarChart};
+use crate::state::metrics::{
+    agent_color, format_tokens, sort_agent_token_rows, AgentTokenRow, AgentTokenSort, SortDir,
+};
+
+/// Per-agent token breakdown with filter support.
+#[component]
+pub(crate) fn AgentBreakdown(
+    agents: Vec<AgentTokenRow>,
+    grand_total: u64,
+    active_filter: Option<String>,
+    on_filter: EventHandler<Option<String>>,
+) -> Element {
+    let sort_col = use_signal(|| AgentTokenSort::Total);
+    let sort_dir = use_signal(|| SortDir::Desc);
+
+    let mut sorted = agents.clone();
+    sort_agent_token_rows(&mut sorted, *sort_col.read(), *sort_dir.read(), grand_total);
+
+    let bar_entries: Vec<ChartEntry> = sorted
+        .iter()
+        .enumerate()
+        .map(|(i, a)| ChartEntry {
+            label: a.name.clone(),
+            value: a.total() as f64,
+            color: agent_color(i).to_string(),
+            sub_label: Some(format_tokens(a.total())),
+        })
+        .collect();
+
+    let filter_for_click = active_filter.clone();
+
+    rsx! {
+        div {
+            style: "display: flex; flex-direction: column; gap: 16px;",
+
+            HorizBarChart {
+                entries: bar_entries,
+                max_value: 0.0,
+                show_value: true,
+                on_click: move |name: String| {
+                    if filter_for_click.as_deref() == Some(&name) {
+                        on_filter.call(None);
+                    } else {
+                        on_filter.call(Some(name));
+                    }
+                },
+            }
+
+            // Sortable table
+            div {
+                style: "overflow-x: auto;",
+                table {
+                    style: "width: 100%; border-collapse: collapse; font-size: 12px; font-family: 'IBM Plex Mono', monospace;",
+                    thead {
+                        tr {
+                            style: "border-bottom: 1px solid #2a2724;",
+                            { sort_th("Agent", AgentTokenSort::Name, sort_col, sort_dir, grand_total) }
+                            { sort_th("Input", AgentTokenSort::Input, sort_col, sort_dir, grand_total) }
+                            { sort_th("Output", AgentTokenSort::Output, sort_col, sort_dir, grand_total) }
+                            { sort_th("Total", AgentTokenSort::Total, sort_col, sort_dir, grand_total) }
+                            { sort_th("% of Total", AgentTokenSort::PctOfTotal, sort_col, sort_dir, grand_total) }
+                            { sort_th("Avg/Session", AgentTokenSort::AvgPerSession, sort_col, sort_dir, grand_total) }
+                        }
+                    }
+                    tbody {
+                        for (idx, agent) in sorted.iter().enumerate() {
+                            {
+                                let is_active = active_filter.as_deref() == Some(&agent.name);
+                                let pct = agent.pct_of_total(grand_total);
+                                let color = agent_color(idx);
+                                rsx! {
+                                    tr {
+                                        key: "{agent.id}",
+                                        style: if is_active {
+                                            "border-bottom: 1px solid #2a2724; background: #1e1c1a;"
+                                        } else {
+                                            "border-bottom: 1px solid #2a2724;"
+                                        },
+                                        td {
+                                            style: "padding: 6px 8px; color: {color}; white-space: nowrap;",
+                                            "{agent.name}"
+                                        }
+                                        td { style: "padding: 6px 8px; color: #a8a49e; text-align: right;", "{format_tokens(agent.input_tokens)}" }
+                                        td { style: "padding: 6px 8px; color: #a8a49e; text-align: right;", "{format_tokens(agent.output_tokens)}" }
+                                        td { style: "padding: 6px 8px; color: #e8e6e3; text-align: right; font-weight: 600;", "{format_tokens(agent.total())}" }
+                                        td { style: "padding: 6px 8px; color: #706c66; text-align: right;", "{pct:.1}%" }
+                                        td { style: "padding: 6px 8px; color: #706c66; text-align: right;", "{format_tokens(agent.avg_per_session())}" }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn sort_th(
+    label: &str,
+    col: AgentTokenSort,
+    mut sort_col: Signal<AgentTokenSort>,
+    mut sort_dir: Signal<SortDir>,
+    _grand_total: u64,
+) -> Element {
+    let is_active = *sort_col.read() == col;
+    let indicator = if is_active {
+        if *sort_dir.read() == SortDir::Desc { " ↓" } else { " ↑" }
+    } else {
+        ""
+    };
+    let label = label.to_string();
+    rsx! {
+        th {
+            style: "padding: 6px 8px; text-align: right; color: #706c66; cursor: pointer; user-select: none; white-space: nowrap;",
+            onclick: move |_| {
+                if *sort_col.read() == col {
+                    let new_dir = sort_dir.read().flip();
+                    sort_dir.set(new_dir);
+                } else {
+                    sort_col.set(col);
+                    sort_dir.set(SortDir::Desc);
+                }
+            },
+            "{label}{indicator}"
+        }
+    }
+}

--- a/crates/theatron/desktop/src/views/metrics/agent_costs.rs
+++ b/crates/theatron/desktop/src/views/metrics/agent_costs.rs
@@ -1,0 +1,158 @@
+//! Agent cost breakdown: grouped bar chart (current vs previous) + efficiency table.
+
+use dioxus::prelude::*;
+
+use crate::components::chart::{GroupedBarChart, GroupedBarEntry};
+use crate::state::metrics::{
+    agent_color, format_cost, sort_agent_cost_rows, AgentCostRow, AgentCostSort, SortDir,
+};
+
+/// Per-agent cost comparison with grouped bar chart and efficiency metrics.
+#[component]
+pub(crate) fn AgentCosts(agents: Vec<AgentCostRow>) -> Element {
+    let sort_col = use_signal(|| AgentCostSort::TotalCost);
+    let sort_dir = use_signal(|| SortDir::Desc);
+
+    let mut sorted = agents.clone();
+    sort_agent_cost_rows(&mut sorted, *sort_col.read(), *sort_dir.read());
+
+    let max_cost = sorted
+        .iter()
+        .flat_map(|a| [a.total_cost, a.prev_period_cost])
+        .fold(0.0f64, f64::max);
+
+    // Most expensive = highest total_cost (first when sorted desc by TotalCost)
+    let most_expensive_id = sorted.first().map(|a| a.id.clone());
+    // Most efficient = lowest cost_per_1k_output among agents with output tokens
+    let most_efficient_id = sorted
+        .iter()
+        .filter(|a| a.output_tokens > 0 && a.total_cost > 0.0)
+        .min_by(|a, b| {
+            a.cost_per_1k_output()
+                .partial_cmp(&b.cost_per_1k_output())
+                .unwrap_or(std::cmp::Ordering::Equal)
+        })
+        .map(|a| a.id.clone());
+
+    let bar_entries: Vec<GroupedBarEntry> = sorted
+        .iter()
+        .enumerate()
+        .map(|(i, a)| GroupedBarEntry {
+            label: a.name.clone(),
+            current: a.total_cost,
+            previous: a.prev_period_cost,
+            current_color: agent_color(i).to_string(),
+            previous_color: muted_color(i),
+        })
+        .collect();
+
+    rsx! {
+        div {
+            style: "display: flex; flex-direction: column; gap: 16px;",
+
+            if max_cost > 0.0 {
+                GroupedBarChart {
+                    entries: bar_entries,
+                    height_px: 160,
+                    current_label: "Current".to_string(),
+                    previous_label: "Previous".to_string(),
+                }
+            }
+
+            // Efficiency table
+            div {
+                style: "overflow-x: auto;",
+                table {
+                    style: "width: 100%; border-collapse: collapse; font-size: 12px; font-family: 'IBM Plex Mono', monospace;",
+                    thead {
+                        tr {
+                            style: "border-bottom: 1px solid #2a2724;",
+                            { cost_th("Agent", AgentCostSort::Name, sort_col, sort_dir) }
+                            { cost_th("Total Cost", AgentCostSort::TotalCost, sort_col, sort_dir) }
+                            { cost_th("$/Session", AgentCostSort::CostPerSession, sort_col, sort_dir) }
+                            { cost_th("$/Message", AgentCostSort::CostPerMessage, sort_col, sort_dir) }
+                            { cost_th("$/1K out", AgentCostSort::CostPer1k, sort_col, sort_dir) }
+                        }
+                    }
+                    tbody {
+                        for (idx, agent) in sorted.iter().enumerate() {
+                            {
+                                let color = agent_color(idx);
+                                let is_expensive = most_expensive_id.as_deref() == Some(&agent.id);
+                                let is_efficient = most_efficient_id.as_deref() == Some(&agent.id);
+                                let per_1k = format!("{:.4}", agent.cost_per_1k_output());
+                                rsx! {
+                                    tr {
+                                        key: "{agent.id}",
+                                        style: "border-bottom: 1px solid #2a2724;",
+                                        td {
+                                            style: "padding: 6px 8px; color: {color}; white-space: nowrap;",
+                                            "{agent.name}"
+                                            if is_expensive {
+                                                span { style: "margin-left: 6px; font-size: 10px; background: #7f1d1d; color: #fca5a5; padding: 1px 4px; border-radius: 3px;", "highest" }
+                                            }
+                                            if is_efficient && !is_expensive {
+                                                span { style: "margin-left: 6px; font-size: 10px; background: #14532d; color: #86efac; padding: 1px 4px; border-radius: 3px;", "efficient" }
+                                            }
+                                        }
+                                        td { style: "padding: 6px 8px; color: #eab308; text-align: right; font-weight: 600;", "{format_cost(agent.total_cost)}" }
+                                        td { style: "padding: 6px 8px; color: #a8a49e; text-align: right;", "{format_cost(agent.cost_per_session())}" }
+                                        td { style: "padding: 6px 8px; color: #a8a49e; text-align: right;", "{format_cost(agent.cost_per_message())}" }
+                                        td { style: "padding: 6px 8px; color: #706c66; text-align: right;", "${per_1k}" }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn cost_th(
+    label: &str,
+    col: AgentCostSort,
+    mut sort_col: Signal<AgentCostSort>,
+    mut sort_dir: Signal<SortDir>,
+) -> Element {
+    let is_active = *sort_col.read() == col;
+    let indicator = if is_active {
+        if *sort_dir.read() == SortDir::Desc { " ↓" } else { " ↑" }
+    } else {
+        ""
+    };
+    let label = label.to_string();
+    rsx! {
+        th {
+            style: "padding: 6px 8px; text-align: right; color: #706c66; cursor: pointer; user-select: none; white-space: nowrap;",
+            onclick: move |_| {
+                if *sort_col.read() == col {
+                    let new_dir = sort_dir.read().flip();
+                    sort_dir.set(new_dir);
+                } else {
+                    sort_col.set(col);
+                    sort_dir.set(SortDir::Desc);
+                }
+            },
+            "{label}{indicator}"
+        }
+    }
+}
+
+/// Muted variant of an accent color for previous-period bars.
+///
+/// WHY: previous-period bars use 40% opacity to visually recede behind current-period bars.
+fn muted_color(index: usize) -> String {
+    const PALETTE: &[&str] = &[
+        "rgba(91,106,240,0.4)",
+        "rgba(16,185,129,0.4)",
+        "rgba(245,158,11,0.4)",
+        "rgba(244,63,94,0.4)",
+        "rgba(14,165,233,0.4)",
+        "rgba(139,92,246,0.4)",
+        "rgba(236,72,153,0.4)",
+        "rgba(20,184,166,0.4)",
+    ];
+    PALETTE[index % PALETTE.len()].to_string()
+}

--- a/crates/theatron/desktop/src/views/metrics/costs.rs
+++ b/crates/theatron/desktop/src/views/metrics/costs.rs
@@ -1,0 +1,372 @@
+//! Cost view: cost summary, trend chart, budget panel, and agent cost breakdown.
+
+use dioxus::prelude::*;
+
+use crate::api::client::authenticated_client;
+use crate::components::chart::{TimeSeriesChart, TimeSeriesColumn};
+use crate::state::connection::ConnectionConfig;
+use crate::state::fetch::FetchState;
+use crate::state::metrics::{
+    budget_bar_color, budget_progress_pct, compute_delta_f64, day_of_month_today,
+    days_in_current_month, format_cost, project_month_end, BudgetConfig, CostMetricsResponse,
+    DateRange, Granularity,
+};
+
+use super::agent_costs::AgentCosts;
+
+const SECTION_STYLE: &str = "\
+    background: #1a1816; \
+    border: 1px solid #2a2724; \
+    border-radius: 8px; \
+    padding: 16px;\
+";
+
+const SECTION_TITLE_STYLE: &str = "\
+    font-size: 12px; \
+    font-weight: 600; \
+    color: #a8a49e; \
+    text-transform: uppercase; \
+    letter-spacing: 0.05em; \
+    margin-bottom: 12px; \
+    font-family: 'IBM Plex Mono', monospace;\
+";
+
+const CARD_STYLE: &str = "\
+    background: #1a1816; \
+    border: 1px solid #2a2724; \
+    border-radius: 8px; \
+    padding: 12px 16px; \
+    flex: 1;\
+";
+
+const CARD_LABEL_STYLE: &str = "\
+    font-size: 11px; \
+    color: #706c66; \
+    margin-bottom: 4px; \
+    font-family: 'IBM Plex Mono', monospace;\
+";
+
+const CARD_VALUE_STYLE: &str = "\
+    font-size: 20px; \
+    font-weight: 600; \
+    color: #eab308; \
+    font-family: 'IBM Plex Mono', monospace;\
+";
+
+const CONTROL_BTN_ACTIVE: &str = "\
+    padding: 4px 10px; \
+    font-size: 12px; \
+    background: #2a2724; \
+    color: #e8e6e3; \
+    border: 1px solid #3a3530; \
+    border-radius: 4px; \
+    cursor: pointer; \
+    font-family: 'IBM Plex Mono', monospace;\
+";
+
+const CONTROL_BTN_INACTIVE: &str = "\
+    padding: 4px 10px; \
+    font-size: 12px; \
+    background: transparent; \
+    color: #706c66; \
+    border: 1px solid transparent; \
+    border-radius: 4px; \
+    cursor: pointer; \
+    font-family: 'IBM Plex Mono', monospace;\
+";
+
+const MAX_CHART_COLS: usize = 120;
+
+/// Cost tab: summary cards, trend chart, budget panel, agent comparison.
+#[component]
+pub(crate) fn Costs() -> Element {
+    let config = use_context::<Signal<ConnectionConfig>>();
+    let mut fetch_state = use_signal(|| FetchState::<CostMetricsResponse>::Loading);
+    let mut granularity = use_signal(|| Granularity::Daily);
+    let mut date_range = use_signal(|| DateRange::Last30Days);
+    let budget = use_signal(|| BudgetConfig::default());
+    let budget_input = use_signal(|| String::new());
+
+    use_effect(move || {
+        let cfg = config.read().clone();
+        let gran = *granularity.read();
+        let range = date_range.read().clone();
+
+        spawn(async move {
+            fetch_state.set(FetchState::Loading);
+            let client = authenticated_client(&cfg);
+            let (from, to) = range.to_query_dates();
+            let url = format!(
+                "{}/api/v1/metrics/costs?granularity={}&from={}&to={}",
+                cfg.server_url.trim_end_matches('/'),
+                gran.url_param(),
+                from,
+                to,
+            );
+            match client.get(&url).send().await {
+                Ok(resp) if resp.status().is_success() => {
+                    match resp.json::<CostMetricsResponse>().await {
+                        Ok(data) => fetch_state.set(FetchState::Loaded(data)),
+                        Err(e) => fetch_state.set(FetchState::Error(format!("parse error: {e}"))),
+                    }
+                }
+                Ok(resp) => {
+                    fetch_state.set(FetchState::Error(format!("server returned {}", resp.status())));
+                }
+                Err(e) => {
+                    fetch_state.set(FetchState::Error(format!("connection error: {e}")));
+                }
+            }
+        });
+    });
+
+    rsx! {
+        div {
+            style: "display: flex; flex-direction: column; gap: 16px;",
+
+            // Controls row
+            div {
+                style: "display: flex; gap: 8px; align-items: center; flex-wrap: wrap;",
+                div {
+                    style: "display: flex; gap: 4px;",
+                    for g in [Granularity::Daily, Granularity::Weekly, Granularity::Monthly] {
+                        {
+                            let active = *granularity.read() == g;
+                            rsx! {
+                                button {
+                                    style: if active { CONTROL_BTN_ACTIVE } else { CONTROL_BTN_INACTIVE },
+                                    onclick: move |_| granularity.set(g),
+                                    "{g.label()}"
+                                }
+                            }
+                        }
+                    }
+                }
+                div { style: "width: 1px; height: 20px; background: #2a2724;" }
+                div {
+                    style: "display: flex; gap: 4px;",
+                    for r in [DateRange::Last7Days, DateRange::Last30Days, DateRange::Last90Days] {
+                        {
+                            let is_active = matches!(
+                                *date_range.read(),
+                                ref dr if std::mem::discriminant(dr) == std::mem::discriminant(&r)
+                            );
+                            let r2 = r.clone();
+                            rsx! {
+                                button {
+                                    style: if is_active { CONTROL_BTN_ACTIVE } else { CONTROL_BTN_INACTIVE },
+                                    onclick: move |_| date_range.set(r2.clone()),
+                                    "{r.label()}"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            match fetch_state.read().clone() {
+                FetchState::Loading => rsx! {
+                    div {
+                        style: "display: flex; align-items: center; justify-content: center; height: 200px; color: #706c66; font-size: 13px;",
+                        "Loading…"
+                    }
+                },
+                FetchState::Error(msg) => rsx! {
+                    div {
+                        style: "padding: 16px; background: #2a1818; border: 1px solid #7f1d1d; border-radius: 8px; color: #fca5a5; font-size: 13px;",
+                        "Error: {msg}"
+                    }
+                },
+                FetchState::Loaded(data) => rsx! {
+                    { loaded_costs_view(data, budget, budget_input) }
+                },
+            }
+        }
+    }
+}
+
+fn loaded_costs_view(
+    data: CostMetricsResponse,
+    mut budget: Signal<BudgetConfig>,
+    mut budget_input: Signal<String>,
+) -> Element {
+    let today_d = compute_delta_f64(data.today_cost, data.prev_today_cost);
+    let week_d = compute_delta_f64(data.week_cost, data.prev_week_cost);
+    let month_d = compute_delta_f64(data.month_cost, data.prev_month_cost);
+
+    let projected = project_month_end(
+        data.month_cost,
+        day_of_month_today(),
+        days_in_current_month(),
+    );
+
+    let step = if data.series.len() > MAX_CHART_COLS {
+        data.series.len() / MAX_CHART_COLS
+    } else {
+        1
+    };
+    let columns: Vec<TimeSeriesColumn> = data
+        .series
+        .iter()
+        .step_by(step.max(1))
+        .map(|pt| TimeSeriesColumn {
+            label: pt.date.clone(),
+            primary: pt.cost_usd,
+            secondary: 0.0,
+            primary_color: "#eab308".to_string(),
+            secondary_color: "#eab308".to_string(),
+        })
+        .collect();
+
+    let budget_limit = budget.read().monthly_limit_usd;
+    let budget_pct = budget_progress_pct(data.month_cost, budget_limit);
+    let bar_color = budget_bar_color(budget_pct).to_string();
+
+    rsx! {
+        div {
+            style: "display: flex; flex-direction: column; gap: 16px;",
+
+            // Summary cards
+            div {
+                style: "display: flex; gap: 12px; flex-wrap: wrap;",
+                { cost_card("Today", &format_cost(today_d.value), today_d.delta_pct, today_d.is_up) }
+                { cost_card("This Week", &format_cost(week_d.value), week_d.delta_pct, week_d.is_up) }
+                { cost_card("This Month", &format_cost(month_d.value), month_d.delta_pct, month_d.is_up) }
+
+                // Projected month-end
+                div {
+                    style: "{CARD_STYLE}",
+                    div { style: "{CARD_LABEL_STYLE}", "Projected Month-End" }
+                    div { style: "{CARD_VALUE_STYLE}", "{format_cost(projected)}" }
+                    div { style: "font-size: 11px; color: #706c66; margin-top: 2px; font-family: 'IBM Plex Mono', monospace;", "linear projection" }
+                }
+            }
+
+            // Cost trend chart
+            div {
+                style: "{SECTION_STYLE}",
+                div { style: "{SECTION_TITLE_STYLE}", "Cost Over Time" }
+                TimeSeriesChart {
+                    columns,
+                    height_px: 160,
+                    primary_label: "Cost (USD)".to_string(),
+                    secondary_label: "".to_string(),
+                }
+            }
+
+            // Budget panel
+            div {
+                style: "{SECTION_STYLE}",
+                div { style: "{SECTION_TITLE_STYLE}", "Monthly Budget" }
+                { budget_panel(
+                    data.month_cost,
+                    budget_limit,
+                    budget_pct,
+                    &bar_color,
+                    budget_input.read().clone(),
+                    move |v: String| budget_input.set(v),
+                    move |limit: f64| budget.set(BudgetConfig { monthly_limit_usd: limit }),
+                ) }
+            }
+
+            // Agent cost comparison
+            if !data.agents.is_empty() {
+                div {
+                    style: "{SECTION_STYLE}",
+                    div { style: "{SECTION_TITLE_STYLE}", "By Agent" }
+                    AgentCosts { agents: data.agents }
+                }
+            }
+        }
+    }
+}
+
+fn budget_panel(
+    month_cost: f64,
+    budget_limit: f64,
+    budget_pct: f64,
+    bar_color: &str,
+    input_value: String,
+    mut on_input: impl FnMut(String) + 'static,
+    mut on_set: impl FnMut(f64) + 'static,
+) -> Element {
+    let bar_color = bar_color.to_string();
+    let input_for_set = input_value.clone();
+
+    if budget_limit > 0.0 {
+        rsx! {
+            div {
+                style: "display: flex; flex-direction: column; gap: 8px;",
+                div {
+                    style: "display: flex; justify-content: space-between; font-size: 12px; font-family: 'IBM Plex Mono', monospace;",
+                    span { style: "color: #a8a49e;", "{format_cost(month_cost)} spent" }
+                    span { style: "color: #706c66;", "of {format_cost(budget_limit)}" }
+                }
+                div {
+                    style: "height: 8px; background: #1a1816; border-radius: 4px; overflow: hidden; border: 1px solid #2a2724;",
+                    div {
+                        style: "height: 100%; width: {budget_pct:.0}%; background: {bar_color}; border-radius: 4px; transition: width 0.3s ease;",
+                    }
+                }
+                div {
+                    style: "display: flex; align-items: center; gap: 8px; margin-top: 4px;",
+                    input {
+                        style: "padding: 4px 8px; font-size: 12px; background: #12110f; border: 1px solid #3a3530; border-radius: 4px; color: #e8e6e3; width: 100px; font-family: 'IBM Plex Mono', monospace;",
+                        placeholder: "New limit $",
+                        value: "{input_value}",
+                        oninput: move |e| on_input(e.value()),
+                    }
+                    button {
+                        style: "padding: 4px 10px; font-size: 12px; background: #2a2724; color: #e8e6e3; border: 1px solid #3a3530; border-radius: 4px; cursor: pointer; font-family: 'IBM Plex Mono', monospace;",
+                        onclick: move |_| {
+                            if let Ok(v) = input_for_set.trim().parse::<f64>() {
+                                on_set(v);
+                            }
+                        },
+                        "Set"
+                    }
+                }
+            }
+        }
+    } else {
+        rsx! {
+            div {
+                style: "display: flex; align-items: center; gap: 8px;",
+                span { style: "font-size: 12px; color: #706c66; font-family: 'IBM Plex Mono', monospace;", "No budget set." }
+                input {
+                    style: "padding: 4px 8px; font-size: 12px; background: #12110f; border: 1px solid #3a3530; border-radius: 4px; color: #e8e6e3; width: 100px; font-family: 'IBM Plex Mono', monospace;",
+                    placeholder: "Monthly limit $",
+                    value: "{input_value}",
+                    oninput: move |e| on_input(e.value()),
+                }
+                button {
+                    style: "padding: 4px 10px; font-size: 12px; background: #2a2724; color: #e8e6e3; border: 1px solid #3a3530; border-radius: 4px; cursor: pointer; font-family: 'IBM Plex Mono', monospace;",
+                    onclick: move |_| {
+                        if let Ok(v) = input_for_set.trim().parse::<f64>() {
+                            on_set(v);
+                        }
+                    },
+                    "Set"
+                }
+            }
+        }
+    }
+}
+
+fn cost_card(label: &str, value: &str, delta_pct: f64, is_up: bool) -> Element {
+    let arrow = if is_up { "↑" } else { "↓" };
+    let delta_color = if is_up { "#ef4444" } else { "#22c55e" };
+    let delta_str = format!("{arrow} {delta_pct:.1}%");
+    let value = value.to_string();
+    let label = label.to_string();
+    rsx! {
+        div {
+            style: "{CARD_STYLE}",
+            div { style: "{CARD_LABEL_STYLE}", "{label}" }
+            div { style: "{CARD_VALUE_STYLE}", "{value}" }
+            if delta_pct > 0.0 {
+                div { style: "font-size: 11px; color: {delta_color}; margin-top: 2px; font-family: 'IBM Plex Mono', monospace;", "{delta_str} vs prev" }
+            }
+        }
+    }
+}

--- a/crates/theatron/desktop/src/views/metrics/mod.rs
+++ b/crates/theatron/desktop/src/views/metrics/mod.rs
@@ -1,422 +1,75 @@
-//! Metrics dashboard: server health, token usage, costs, and tool statistics.
-//!
-//! Tabs: Tokens (server health + token counts), Costs (cost breakdown), Tools (usage stats).
+//! Metrics dashboard: token usage and cost views with charts and breakdowns.
 
-pub(crate) mod tool_detail;
-pub(crate) mod tool_duration;
-pub(crate) mod tool_frequency;
-pub(crate) mod tool_results;
-pub(crate) mod tools;
+mod agent_breakdown;
+mod agent_costs;
+mod costs;
+mod model_breakdown;
+mod tokens;
 
 use dioxus::prelude::*;
 
-use crate::api::client::authenticated_client;
-use crate::state::connection::ConnectionConfig;
-use crate::state::fetch::FetchState;
-use crate::state::tool_metrics::DateRange;
+use crate::state::metrics::MetricsTab;
 
-// -- Tab enum -----------------------------------------------------------------
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum MetricsTab {
-    Tokens,
-    Costs,
-    Tools,
-}
-
-// -- API response types -------------------------------------------------------
-
-#[derive(Debug, Clone, Default, serde::Deserialize)]
-struct HealthResponse {
-    #[serde(default)]
-    status: String,
-    #[serde(default)]
-    uptime_seconds: u64,
-    #[serde(default)]
-    version: String,
-}
-
-#[derive(Debug, Clone, Default, serde::Deserialize)]
-struct MetricsResponse {
-    #[serde(default)]
-    total_sessions: u64,
-    #[serde(default)]
-    active_sessions: u64,
-    #[serde(default)]
-    total_turns: u64,
-    #[serde(default)]
-    total_input_tokens: u64,
-    #[serde(default)]
-    total_output_tokens: u64,
-    #[serde(default)]
-    total_cost_usd: f64,
-}
-
-#[derive(Debug, Clone)]
-struct DashboardData {
-    health: HealthResponse,
-    metrics: MetricsResponse,
-}
-
-// -- Style constants ----------------------------------------------------------
-
-const CONTAINER_STYLE: &str = "\
+const TAB_BAR_STYLE: &str = "\
     display: flex; \
-    flex-direction: column; \
-    height: 100%; \
-    gap: 16px;\
+    gap: 2px; \
+    border-bottom: 1px solid #2a2724; \
+    padding: 0 16px; \
+    margin-bottom: 16px;\
 ";
 
-const GRID_STYLE: &str = "\
-    display: flex; \
-    flex-wrap: wrap; \
-    gap: 12px;\
-";
-
-const CARD_STYLE: &str = "\
-    background: #1a1a2e; \
-    border: 1px solid #333; \
-    border-radius: 8px; \
-    padding: 20px; \
-    min-width: 160px; \
-    flex: 1;\
-";
-
-const CARD_VALUE: &str = "\
-    font-size: 32px; \
-    font-weight: bold; \
-    color: #e0e0e0; \
-    margin-bottom: 4px;\
-";
-
-const CARD_LABEL: &str = "\
-    font-size: 12px; \
-    color: #888; \
-    text-transform: uppercase; \
-    letter-spacing: 0.5px;\
-";
-
-const CARD_SUB: &str = "\
-    font-size: 11px; \
-    color: #555; \
-    margin-top: 8px;\
-";
-
-const STATUS_BADGE: &str = "\
-    display: inline-block; \
-    padding: 2px 8px; \
-    border-radius: 4px; \
-    font-size: 12px; \
-    font-weight: bold;\
-";
-
-const REFRESH_BTN: &str = "\
-    background: #2a2a4a; \
-    color: #e0e0e0; \
-    border: 1px solid #444; \
-    border-radius: 6px; \
-    padding: 4px 12px; \
-    font-size: 12px; \
-    cursor: pointer;\
-";
-
-const TAB_ACTIVE: &str = "\
-    background: #2a2a4a; \
-    color: #e0e0e0; \
-    border: 1px solid #4a4aff; \
-    border-radius: 6px; \
-    padding: 4px 14px; \
+const TAB_ACTIVE_STYLE: &str = "\
+    padding: 8px 16px; \
     font-size: 13px; \
-    cursor: pointer;\
-";
-
-const TAB_INACTIVE: &str = "\
+    color: #e8e6e3; \
     background: transparent; \
-    color: #888; \
-    border: 1px solid #333; \
-    border-radius: 6px; \
-    padding: 4px 14px; \
-    font-size: 13px; \
-    cursor: pointer;\
+    border: none; \
+    border-bottom: 2px solid #5b6af0; \
+    cursor: pointer; \
+    font-family: 'IBM Plex Mono', monospace;\
 ";
 
-// -- Main component -----------------------------------------------------------
+const TAB_INACTIVE_STYLE: &str = "\
+    padding: 8px 16px; \
+    font-size: 13px; \
+    color: #706c66; \
+    background: transparent; \
+    border: none; \
+    border-bottom: 2px solid transparent; \
+    cursor: pointer; \
+    font-family: 'IBM Plex Mono', monospace;\
+";
 
+/// Metrics dashboard root: tab bar + delegated tab view.
 #[component]
 pub(crate) fn Metrics() -> Element {
-    let config: Signal<ConnectionConfig> = use_context();
     let mut active_tab = use_signal(|| MetricsTab::Tokens);
-    let mut fetch_state = use_signal(|| FetchState::<DashboardData>::Loading);
-
-    let mut do_refresh = move || {
-        let cfg = config.read().clone();
-        fetch_state.set(FetchState::Loading);
-
-        spawn(async move {
-            let client = authenticated_client(&cfg);
-            let base = cfg.server_url.trim_end_matches('/');
-
-            let health_url = format!("{base}/api/health");
-            let metrics_url = format!("{base}/metrics");
-
-            let (health_result, metrics_result) = tokio::join!(
-                client.get(&health_url).send(),
-                client.get(&metrics_url).send()
-            );
-
-            let health = match health_result {
-                Ok(resp) if resp.status().is_success() => {
-                    resp.json::<HealthResponse>().await.unwrap_or_default()
-                }
-                Ok(resp) => {
-                    fetch_state.set(FetchState::Error(format!(
-                        "health endpoint returned {}",
-                        resp.status()
-                    )));
-                    return;
-                }
-                Err(e) => {
-                    fetch_state.set(FetchState::Error(format!("connection error: {e}")));
-                    return;
-                }
-            };
-
-            // WHY: /metrics may not exist on all pylon versions; use defaults.
-            let metrics = match metrics_result {
-                Ok(resp) if resp.status().is_success() => {
-                    resp.json::<MetricsResponse>().await.unwrap_or_default()
-                }
-                _ => MetricsResponse::default(),
-            };
-
-            fetch_state.set(FetchState::Loaded(DashboardData { health, metrics }));
-        });
-    };
-
-    use_effect(move || {
-        do_refresh();
-    });
 
     rsx! {
         div {
-            style: "{CONTAINER_STYLE}",
+            style: "display: flex; flex-direction: column; height: 100%; overflow: hidden;",
 
-            // Header with title, tabs, and refresh
             div {
-                style: "display: flex; align-items: center; justify-content: space-between; flex-wrap: wrap; gap: 8px;",
-                h2 { style: "font-size: 20px; margin: 0;", "Metrics" }
-
-                div {
-                    style: "display: flex; gap: 6px; align-items: center;",
-
-                    button {
-                        style: if *active_tab.read() == MetricsTab::Tokens { TAB_ACTIVE } else { TAB_INACTIVE },
-                        onclick: move |_| active_tab.set(MetricsTab::Tokens),
-                        "Tokens"
-                    }
-                    button {
-                        style: if *active_tab.read() == MetricsTab::Costs { TAB_ACTIVE } else { TAB_INACTIVE },
-                        onclick: move |_| active_tab.set(MetricsTab::Costs),
-                        "Costs"
-                    }
-                    button {
-                        style: if *active_tab.read() == MetricsTab::Tools { TAB_ACTIVE } else { TAB_INACTIVE },
-                        onclick: move |_| active_tab.set(MetricsTab::Tools),
-                        "Tools"
-                    }
-
-                    if *active_tab.read() != MetricsTab::Tools {
-                        button {
-                            style: "{REFRESH_BTN}",
-                            onclick: move |_| do_refresh(),
-                            "Refresh"
-                        }
-                    }
+                style: "{TAB_BAR_STYLE}",
+                button {
+                    style: if *active_tab.read() == MetricsTab::Tokens { TAB_ACTIVE_STYLE } else { TAB_INACTIVE_STYLE },
+                    onclick: move |_| active_tab.set(MetricsTab::Tokens),
+                    "Tokens"
+                }
+                button {
+                    style: if *active_tab.read() == MetricsTab::Costs { TAB_ACTIVE_STYLE } else { TAB_INACTIVE_STYLE },
+                    onclick: move |_| active_tab.set(MetricsTab::Costs),
+                    "Costs"
                 }
             }
 
-            match *active_tab.read() {
-                MetricsTab::Tokens => rsx! { {render_tokens_tab(&fetch_state)} },
-                MetricsTab::Costs => rsx! { {render_costs_tab(&fetch_state)} },
-                MetricsTab::Tools => rsx! {
-                    tools::ToolsOverview { date_range: DateRange::default() }
-                },
+            div {
+                style: "flex: 1; overflow-y: auto; padding: 0 16px 16px;",
+                match *active_tab.read() {
+                    MetricsTab::Tokens => rsx! { tokens::Tokens {} },
+                    MetricsTab::Costs => rsx! { costs::Costs {} },
+                }
             }
         }
-    }
-}
-
-// -- Tokens tab ---------------------------------------------------------------
-
-fn render_tokens_tab(fetch_state: &Signal<FetchState<DashboardData>>) -> Element {
-    match &*fetch_state.read() {
-        FetchState::Loading => rsx! {
-            div {
-                style: "display: flex; align-items: center; justify-content: center; flex: 1; color: #888;",
-                "Loading metrics..."
-            }
-        },
-        FetchState::Error(err) => rsx! {
-            div {
-                style: "display: flex; align-items: center; justify-content: center; flex: 1; color: #ef4444;",
-                "Error: {err}"
-            }
-        },
-        FetchState::Loaded(data) => rsx! {
-            {render_tokens_content(data)}
-        },
-    }
-}
-
-fn render_tokens_content(data: &DashboardData) -> Element {
-    let uptime = format_uptime(data.health.uptime_seconds);
-    let status_color = if data.health.status == "ok" {
-        "background: #1a3a1a; color: #22c55e;"
-    } else {
-        "background: #3a1a1a; color: #ef4444;"
-    };
-
-    rsx! {
-        div {
-            style: "{GRID_STYLE}",
-
-            div {
-                style: "{CARD_STYLE}",
-                div {
-                    style: "{STATUS_BADGE} {status_color}",
-                    "{data.health.status}"
-                }
-                div { style: "{CARD_LABEL} margin-top: 8px;", "Server Status" }
-                if !data.health.version.is_empty() {
-                    div { style: "{CARD_SUB}", "v{data.health.version}" }
-                }
-            }
-
-            div {
-                style: "{CARD_STYLE}",
-                div { style: "{CARD_VALUE}", "{uptime}" }
-                div { style: "{CARD_LABEL}", "Uptime" }
-            }
-
-            div {
-                style: "{CARD_STYLE}",
-                div { style: "{CARD_VALUE}", "{data.metrics.total_sessions}" }
-                div { style: "{CARD_LABEL}", "Total Sessions" }
-                div { style: "{CARD_SUB}", "{data.metrics.active_sessions} active" }
-            }
-
-            div {
-                style: "{CARD_STYLE}",
-                div { style: "{CARD_VALUE}", "{data.metrics.total_turns}" }
-                div { style: "{CARD_LABEL}", "Total Turns" }
-            }
-        }
-
-        div {
-            style: "{GRID_STYLE}",
-
-            div {
-                style: "{CARD_STYLE}",
-                div { style: "{CARD_VALUE}", "{format_tokens(data.metrics.total_input_tokens)}" }
-                div { style: "{CARD_LABEL}", "Input Tokens" }
-            }
-
-            div {
-                style: "{CARD_STYLE}",
-                div { style: "{CARD_VALUE}", "{format_tokens(data.metrics.total_output_tokens)}" }
-                div { style: "{CARD_LABEL}", "Output Tokens" }
-            }
-        }
-    }
-}
-
-// -- Costs tab ----------------------------------------------------------------
-
-fn render_costs_tab(fetch_state: &Signal<FetchState<DashboardData>>) -> Element {
-    match &*fetch_state.read() {
-        FetchState::Loading => rsx! {
-            div {
-                style: "color: #888; padding: 8px;",
-                "Loading cost data..."
-            }
-        },
-        FetchState::Error(err) => rsx! {
-            div {
-                style: "color: #ef4444; padding: 8px;",
-                "Error: {err}"
-            }
-        },
-        FetchState::Loaded(data) => rsx! {
-            div {
-                style: "{GRID_STYLE}",
-
-                div {
-                    style: "{CARD_STYLE}",
-                    div {
-                        style: "{CARD_VALUE} color: #eab308;",
-                        "{format_cost(data.metrics.total_cost_usd)}"
-                    }
-                    div { style: "{CARD_LABEL}", "Total Cost" }
-                }
-
-                div {
-                    style: "{CARD_STYLE}",
-                    div {
-                        style: "{CARD_VALUE}",
-                        "{format_cost_per_turn(data.metrics.total_cost_usd, data.metrics.total_turns)}"
-                    }
-                    div { style: "{CARD_LABEL}", "Cost / Turn" }
-                }
-            }
-        },
-    }
-}
-
-// -- Formatting helpers -------------------------------------------------------
-
-fn format_uptime(seconds: u64) -> String {
-    let days = seconds / 86400;
-    let hours = (seconds % 86400) / 3600;
-    let mins = (seconds % 3600) / 60;
-
-    if days > 0 {
-        format!("{days}d {hours}h")
-    } else if hours > 0 {
-        format!("{hours}h {mins}m")
-    } else {
-        format!("{mins}m")
-    }
-}
-
-fn format_cost(value: f64) -> String {
-    format!("${value:.2}")
-}
-
-fn format_cost_per_turn(total_cost: f64, total_turns: u64) -> String {
-    if total_turns == 0 {
-        return "—".to_string();
-    }
-    #[expect(
-        clippy::cast_precision_loss,
-        reason = "display-only: turn count fits in f64"
-    )]
-    let per_turn = total_cost / total_turns as f64;
-    format!("${per_turn:.4}")
-}
-
-#[expect(
-    clippy::cast_precision_loss,
-    reason = "display-only: sub-token precision irrelevant"
-)]
-fn format_tokens(count: u64) -> String {
-    const K: u64 = 1_000;
-    const M: u64 = 1_000_000;
-
-    if count >= M {
-        format!("{:.1}M", count as f64 / M as f64) // kanon:ignore RUST/as-cast
-    } else if count >= K {
-        format!("{:.1}K", count as f64 / K as f64) // kanon:ignore RUST/as-cast
-    } else {
-        count.to_string()
     }
 }

--- a/crates/theatron/desktop/src/views/metrics/model_breakdown.rs
+++ b/crates/theatron/desktop/src/views/metrics/model_breakdown.rs
@@ -1,0 +1,88 @@
+//! Model token usage breakdown: donut chart + table.
+
+use dioxus::prelude::*;
+
+use crate::components::chart::{ChartEntry, DonutChart};
+use crate::state::metrics::{cost_per_1k_output, format_tokens, model_color, ModelTokenRow};
+
+/// Per-model token breakdown with donut chart.
+#[component]
+pub(crate) fn ModelBreakdown(models: Vec<ModelTokenRow>, grand_total: u64) -> Element {
+    let segments: Vec<ChartEntry> = models
+        .iter()
+        .map(|m| ChartEntry {
+            label: short_model_name(&m.model),
+            value: m.total() as f64,
+            color: model_color(&m.model).to_string(),
+            sub_label: None,
+        })
+        .collect();
+
+    let total_display = format_tokens(grand_total);
+
+    rsx! {
+        div {
+            style: "display: flex; flex-direction: column; gap: 16px;",
+
+            DonutChart {
+                segments,
+                size_px: 160,
+                center_label: total_display,
+            }
+
+            // Detail table
+            div {
+                style: "overflow-x: auto;",
+                table {
+                    style: "width: 100%; border-collapse: collapse; font-size: 12px; font-family: 'IBM Plex Mono', monospace;",
+                    thead {
+                        tr {
+                            style: "border-bottom: 1px solid #2a2724;",
+                            th { style: "padding: 6px 8px; text-align: left; color: #706c66;", "Model" }
+                            th { style: "padding: 6px 8px; text-align: right; color: #706c66;", "Input" }
+                            th { style: "padding: 6px 8px; text-align: right; color: #706c66;", "Output" }
+                            th { style: "padding: 6px 8px; text-align: right; color: #706c66;", "Total" }
+                            th { style: "padding: 6px 8px; text-align: right; color: #706c66;", "%" }
+                            th { style: "padding: 6px 8px; text-align: right; color: #706c66;", "$/1K out" }
+                        }
+                    }
+                    tbody {
+                        for model in &models {
+                            {
+                                let pct = model.pct_of_total(grand_total);
+                                let price = cost_per_1k_output(&model.model);
+                                let color = model_color(&model.model);
+                                let short = short_model_name(&model.model);
+                                rsx! {
+                                    tr {
+                                        key: "{model.model}",
+                                        style: "border-bottom: 1px solid #2a2724;",
+                                        td {
+                                            style: "padding: 6px 8px; color: {color}; white-space: nowrap;",
+                                            title: "{model.model}",
+                                            "{short}"
+                                        }
+                                        td { style: "padding: 6px 8px; color: #a8a49e; text-align: right;", "{format_tokens(model.input_tokens)}" }
+                                        td { style: "padding: 6px 8px; color: #a8a49e; text-align: right;", "{format_tokens(model.output_tokens)}" }
+                                        td { style: "padding: 6px 8px; color: #e8e6e3; text-align: right; font-weight: 600;", "{format_tokens(model.total())}" }
+                                        td { style: "padding: 6px 8px; color: #706c66; text-align: right;", "{pct:.1}%" }
+                                        td { style: "padding: 6px 8px; color: #706c66; text-align: right;", "${price:.4}" }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Strip provider prefix from a model ID for compact display.
+fn short_model_name(model: &str) -> String {
+    model
+        .split('/')
+        .last()
+        .unwrap_or(model)
+        .to_string()
+}

--- a/crates/theatron/desktop/src/views/metrics/tokens.rs
+++ b/crates/theatron/desktop/src/views/metrics/tokens.rs
@@ -1,0 +1,341 @@
+//! Token usage view: time series chart, summary cards, agent/model breakdowns.
+
+use dioxus::prelude::*;
+
+use crate::api::client::authenticated_client;
+use crate::components::chart::{TimeSeriesChart, TimeSeriesColumn};
+use crate::state::connection::ConnectionConfig;
+use crate::state::fetch::FetchState;
+use crate::state::metrics::{
+    compute_delta_u64, format_tokens, DateRange, Granularity, TokenMetricsResponse,
+};
+
+use super::agent_breakdown::AgentBreakdown;
+use super::model_breakdown::ModelBreakdown;
+
+const SECTION_STYLE: &str = "\
+    background: #1a1816; \
+    border: 1px solid #2a2724; \
+    border-radius: 8px; \
+    padding: 16px;\
+";
+
+const SECTION_TITLE_STYLE: &str = "\
+    font-size: 12px; \
+    font-weight: 600; \
+    color: #a8a49e; \
+    text-transform: uppercase; \
+    letter-spacing: 0.05em; \
+    margin-bottom: 12px; \
+    font-family: 'IBM Plex Mono', monospace;\
+";
+
+const CARD_STYLE: &str = "\
+    background: #1a1816; \
+    border: 1px solid #2a2724; \
+    border-radius: 8px; \
+    padding: 12px 16px; \
+    flex: 1;\
+";
+
+const CARD_LABEL_STYLE: &str = "\
+    font-size: 11px; \
+    color: #706c66; \
+    margin-bottom: 4px; \
+    font-family: 'IBM Plex Mono', monospace;\
+";
+
+const CARD_VALUE_STYLE: &str = "\
+    font-size: 20px; \
+    font-weight: 600; \
+    color: #e8e6e3; \
+    font-family: 'IBM Plex Mono', monospace;\
+";
+
+const CONTROL_BTN_ACTIVE: &str = "\
+    padding: 4px 10px; \
+    font-size: 12px; \
+    background: #2a2724; \
+    color: #e8e6e3; \
+    border: 1px solid #3a3530; \
+    border-radius: 4px; \
+    cursor: pointer; \
+    font-family: 'IBM Plex Mono', monospace;\
+";
+
+const CONTROL_BTN_INACTIVE: &str = "\
+    padding: 4px 10px; \
+    font-size: 12px; \
+    background: transparent; \
+    color: #706c66; \
+    border: 1px solid transparent; \
+    border-radius: 4px; \
+    cursor: pointer; \
+    font-family: 'IBM Plex Mono', monospace;\
+";
+
+/// Max columns to render in the time series chart.
+const MAX_CHART_COLS: usize = 120;
+
+/// Token usage tab: summary + chart + breakdowns.
+#[component]
+pub(crate) fn Tokens() -> Element {
+    let config = use_context::<Signal<ConnectionConfig>>();
+    let mut fetch_state = use_signal(|| FetchState::<TokenMetricsResponse>::Loading);
+    let mut granularity = use_signal(|| Granularity::Daily);
+    let mut date_range = use_signal(|| DateRange::Last30Days);
+    let mut custom_from = use_signal(|| String::new());
+    let mut custom_to = use_signal(|| String::new());
+    let agent_filter = use_signal(|| Option::<String>::None);
+
+    use_effect(move || {
+        let cfg = config.read().clone();
+        let gran = *granularity.read();
+        let range = date_range.read().clone();
+
+        spawn(async move {
+            fetch_state.set(FetchState::Loading);
+            let client = authenticated_client(&cfg);
+            let (from, to) = range.to_query_dates();
+            let url = format!(
+                "{}/api/v1/metrics/tokens?granularity={}&from={}&to={}",
+                cfg.server_url.trim_end_matches('/'),
+                gran.url_param(),
+                from,
+                to,
+            );
+            match client.get(&url).send().await {
+                Ok(resp) if resp.status().is_success() => {
+                    match resp.json::<TokenMetricsResponse>().await {
+                        Ok(data) => fetch_state.set(FetchState::Loaded(data)),
+                        Err(e) => fetch_state.set(FetchState::Error(format!("parse error: {e}"))),
+                    }
+                }
+                Ok(resp) => {
+                    fetch_state.set(FetchState::Error(format!("server returned {}", resp.status())));
+                }
+                Err(e) => {
+                    fetch_state.set(FetchState::Error(format!("connection error: {e}")));
+                }
+            }
+        });
+    });
+
+    rsx! {
+        div {
+            style: "display: flex; flex-direction: column; gap: 16px;",
+
+            // Controls row
+            div {
+                style: "display: flex; gap: 8px; align-items: center; flex-wrap: wrap;",
+
+                // Granularity
+                div {
+                    style: "display: flex; gap: 4px;",
+                    for g in [Granularity::Daily, Granularity::Weekly, Granularity::Monthly] {
+                        {
+                            let active = *granularity.read() == g;
+                            rsx! {
+                                button {
+                                    style: if active { CONTROL_BTN_ACTIVE } else { CONTROL_BTN_INACTIVE },
+                                    onclick: move |_| granularity.set(g),
+                                    "{g.label()}"
+                                }
+                            }
+                        }
+                    }
+                }
+
+                div { style: "width: 1px; height: 20px; background: #2a2724;" }
+
+                // Date range presets
+                div {
+                    style: "display: flex; gap: 4px;",
+                    for r in [DateRange::Last7Days, DateRange::Last30Days, DateRange::Last90Days] {
+                        {
+                            let is_active = matches!(
+                                *date_range.read(),
+                                ref dr if std::mem::discriminant(dr) == std::mem::discriminant(&r)
+                            );
+                            let r2 = r.clone();
+                            rsx! {
+                                button {
+                                    style: if is_active { CONTROL_BTN_ACTIVE } else { CONTROL_BTN_INACTIVE },
+                                    onclick: move |_| date_range.set(r2.clone()),
+                                    "{r.label()}"
+                                }
+                            }
+                        }
+                    }
+                    button {
+                        style: if matches!(*date_range.read(), DateRange::Custom { .. }) { CONTROL_BTN_ACTIVE } else { CONTROL_BTN_INACTIVE },
+                        onclick: move |_| {
+                            let f = custom_from.read().clone();
+                            let t = custom_to.read().clone();
+                            date_range.set(DateRange::Custom { from: f, to: t });
+                        },
+                        "Custom"
+                    }
+                }
+
+                // Custom date inputs
+                if matches!(*date_range.read(), DateRange::Custom { .. }) {
+                    input {
+                        style: "padding: 4px 8px; font-size: 12px; background: #1a1816; border: 1px solid #3a3530; border-radius: 4px; color: #e8e6e3; width: 100px; font-family: 'IBM Plex Mono', monospace;",
+                        placeholder: "YYYY-MM-DD",
+                        value: "{custom_from}",
+                        oninput: move |e| {
+                            custom_from.set(e.value());
+                            let f = e.value();
+                            let t = custom_to.read().clone();
+                            date_range.set(DateRange::Custom { from: f, to: t });
+                        }
+                    }
+                    span { style: "color: #706c66; font-size: 12px;", "→" }
+                    input {
+                        style: "padding: 4px 8px; font-size: 12px; background: #1a1816; border: 1px solid #3a3530; border-radius: 4px; color: #e8e6e3; width: 100px; font-family: 'IBM Plex Mono', monospace;",
+                        placeholder: "YYYY-MM-DD",
+                        value: "{custom_to}",
+                        oninput: move |e| {
+                            custom_to.set(e.value());
+                            let f = custom_from.read().clone();
+                            let t = e.value();
+                            date_range.set(DateRange::Custom { from: f, to: t });
+                        }
+                    }
+                }
+            }
+
+            // Body: loading / error / loaded
+            match fetch_state.read().clone() {
+                FetchState::Loading => rsx! {
+                    div {
+                        style: "display: flex; align-items: center; justify-content: center; height: 200px; color: #706c66; font-size: 13px;",
+                        "Loading…"
+                    }
+                },
+                FetchState::Error(msg) => rsx! {
+                    div {
+                        style: "padding: 16px; background: #2a1818; border: 1px solid #7f1d1d; border-radius: 8px; color: #fca5a5; font-size: 13px;",
+                        "Error: {msg}"
+                    }
+                },
+                FetchState::Loaded(data) => rsx! {
+                    { loaded_tokens_view(data, agent_filter) }
+                },
+            }
+        }
+    }
+}
+
+fn loaded_tokens_view(
+    data: TokenMetricsResponse,
+    mut agent_filter: Signal<Option<String>>,
+) -> Element {
+    let today_d = compute_delta_u64(data.today_total(), data.prev_today_total());
+    let week_d = compute_delta_u64(data.week_total(), data.prev_week_total());
+    let month_d = compute_delta_u64(data.month_total(), data.prev_month_total());
+    let grand_total = data.grand_total_tokens();
+
+    // Build time series columns, downsampled to MAX_CHART_COLS
+    let series = &data.series;
+    let step = if series.len() > MAX_CHART_COLS {
+        series.len() / MAX_CHART_COLS
+    } else {
+        1
+    };
+    let columns: Vec<TimeSeriesColumn> = series
+        .iter()
+        .step_by(step.max(1))
+        .map(|pt| TimeSeriesColumn {
+            label: pt.date.clone(),
+            primary: pt.input_tokens as f64,
+            secondary: pt.output_tokens as f64,
+            primary_color: "#5b6af0".to_string(),
+            secondary_color: "#10b981".to_string(),
+        })
+        .collect();
+
+    let active_filter = agent_filter.read().clone();
+
+    rsx! {
+        div {
+            style: "display: flex; flex-direction: column; gap: 16px;",
+
+            // Summary cards
+            div {
+                style: "display: flex; gap: 12px; flex-wrap: wrap;",
+                { delta_card("Today", &format_tokens(today_d.value as u64), today_d.delta_pct, today_d.is_up) }
+                { delta_card("This Week", &format_tokens(week_d.value as u64), week_d.delta_pct, week_d.is_up) }
+                { delta_card("This Month", &format_tokens(month_d.value as u64), month_d.delta_pct, month_d.is_up) }
+            }
+
+            // Time series chart
+            div {
+                style: "{SECTION_STYLE}",
+                div { style: "{SECTION_TITLE_STYLE}",
+                    if let Some(ref name) = active_filter {
+                        "Usage Over Time — {name}"
+                    } else {
+                        "Usage Over Time"
+                    }
+                }
+                TimeSeriesChart {
+                    columns,
+                    height_px: 160,
+                    primary_label: "Input".to_string(),
+                    secondary_label: "Output".to_string(),
+                }
+            }
+
+            // Agent breakdown
+            if !data.agents.is_empty() {
+                div {
+                    style: "{SECTION_STYLE}",
+                    div { style: "{SECTION_TITLE_STYLE}", "By Agent" }
+                    AgentBreakdown {
+                        agents: data.agents.clone(),
+                        grand_total,
+                        active_filter: active_filter.clone(),
+                        on_filter: move |id: Option<String>| agent_filter.set(id),
+                    }
+                }
+            }
+
+            // Model breakdown
+            if !data.models.is_empty() {
+                div {
+                    style: "{SECTION_STYLE}",
+                    div { style: "{SECTION_TITLE_STYLE}", "By Model" }
+                    ModelBreakdown {
+                        models: data.models.clone(),
+                        grand_total,
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[expect(
+    clippy::cast_sign_loss,
+    clippy::cast_possible_truncation,
+    reason = "display-only: value already validated as non-negative f64 from u64 source"
+)]
+fn delta_card(label: &str, value: &str, delta_pct: f64, is_up: bool) -> Element {
+    let arrow = if is_up { "↑" } else { "↓" };
+    let delta_color = if is_up { "#22c55e" } else { "#ef4444" };
+    let delta_str = format!("{arrow} {delta_pct:.1}%");
+    let value = value.to_string();
+    let label = label.to_string();
+    rsx! {
+        div {
+            style: "{CARD_STYLE}",
+            div { style: "{CARD_LABEL_STYLE}", "{label}" }
+            div { style: "{CARD_VALUE_STYLE}", "{value}" }
+            if delta_pct > 0.0 {
+                div { style: "font-size: 11px; color: {delta_color}; margin-top: 2px; font-family: 'IBM Plex Mono', monospace;", "{delta_str} vs prev" }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Replaces the metrics stub with a full two-tab dashboard (Tokens | Costs)
- `state/metrics`: all data types, helpers, date arithmetic (no external deps), 16 unit tests
- `components/chart`: reusable div-based charts (bar, donut via conic-gradient, grouped bar) — SVG deferred pending Blitz validation
- `views/metrics/tokens`: period-over-period summary cards, stacked time series, agent filter, agent/model breakdowns
- `views/metrics/costs`: cost cards, trend chart, local budget panel with progress bar and month-end projection, agent cost comparison

## Test plan

- [ ] `cargo test --manifest-path crates/theatron/desktop/Cargo.toml` — 16 new state/metrics tests pass alongside existing 466
- [ ] `cargo check` clean (no new errors; pre-existing warnings unchanged)
- [ ] Token tab: granularity buttons switch Daily/Weekly/Monthly, date range buttons refetch, custom date inputs update range, agent bar click filters chart title
- [ ] Costs tab: summary cards show amber values, projected month-end card present, budget panel shows "No budget set" then renders progress bar after setting a limit
- [ ] Agent breakdowns: table columns sortable (click toggles asc/desc), sort indicator arrow updates
- [ ] Model breakdown: donut chart segments proportional, legend percentages sum to ~100%
- [ ] Agent costs: grouped bars render current vs muted previous, "highest"/"efficient" badges appear

Closes #114