### PR TITLE
fix(theatron-desktop): resolve audit violations — target/ exclusion, TODO refs, allow→expect

### DIFF
--- a/crates/organon/src/testing.rs
+++ b/crates/organon/src/testing.rs
@@ -41,7 +41,6 @@ use crate::types::{ToolContext, ToolInput, ToolResult};
 /// assert!(!result.is_error, "result should not be an error");
 /// assert_eq!(ex.call_count(), 1, "call count should be 1 after one execution");
 /// ```
-#[allow(clippy::module_name_repetitions)] // kanon:ignore RUST/allow-not-expect
 pub struct MockToolExecutor {
     // kanon:ignore RUST/pub-visibility
     name: ToolName,

--- a/crates/theatron/desktop/src/views/planning/checkpoints.rs
+++ b/crates/theatron/desktop/src/views/planning/checkpoints.rs
@@ -64,7 +64,7 @@ const PLACEHOLDER_STYLE: &str = "\
 /// Fetches from `GET /api/planning/projects/{project_id}/checkpoints`.
 /// Pending gates appear at the top of the list.
 ///
-/// # TODO
+/// # TODO(#2033)
 /// Wire SSE checkpoint events (when added to `theatron_core::events::StreamEvent`)
 /// for real-time notification when new checkpoints arrive.
 #[component]

--- a/crates/theatron/desktop/src/views/planning/verification.rs
+++ b/crates/theatron/desktop/src/views/planning/verification.rs
@@ -114,7 +114,7 @@ const PLACEHOLDER_STYLE: &str = "\
 /// Displays overall and per-tier coverage bars, a requirement table,
 /// and the gap analysis panel.
 ///
-/// # TODO
+/// # TODO(#2034)
 /// `POST /api/planning/projects/{project_id}/verification/refresh` endpoint
 /// is assumed but may not exist yet; the Re-verify button is wired to it.
 #[component]

--- a/crates/theatron/tui/src/theme.rs
+++ b/crates/theatron/tui/src/theme.rs
@@ -22,7 +22,7 @@ pub enum ThemeMode {
 
 /// Background and accent colors.
 #[derive(Debug, Clone)]
-#[allow(
+#[expect(
     dead_code,
     reason = "complete semantic color set; not all fields used by every view"
 )]
@@ -61,10 +61,6 @@ pub struct Borders {
 
 /// Semantic feedback and animation-state colors.
 #[derive(Debug, Clone)]
-#[allow(
-    dead_code,
-    reason = "complete semantic color set; not all fields used by every view"
-)]
 pub struct StatusColors {
     pub success: Color,
     pub warning: Color,

--- a/crates/theatron/tui/src/update/streaming.rs
+++ b/crates/theatron/tui/src/update/streaming.rs
@@ -298,7 +298,6 @@ pub(crate) async fn handle_stream_turn_complete(app: &mut App, outcome: TurnOutc
         app.dashboard.context_tokens_used = Some(ctx_used);
         app.dashboard.context_tokens_total = Some(ctx_total);
         // WHY: clamped to [0, 100] by .min(100); u64 → u8 is safe here.
-        #[allow(clippy::cast_possible_truncation)]
         let pct = ((u64::from(ctx_used) * 100) / u64::from(ctx_total)).min(100) as u8;
         app.dashboard.context_usage_pct = Some(pct);
     }


### PR DESCRIPTION
## Summary

- **#2029** `crates/theatron/desktop/target/` git tracking: already excluded via root `.gitignore` (`crates/theatron/desktop/target/` entry present); no tracked files to remove — issue closed.
- **#2030** Bare TODO doc comments: created issues [#2033](https://github.com/forkwright/aletheia/issues/2033) and [#2034](https://github.com/forkwright/aletheia/issues/2034) for the two `/// # TODO` sections in `CheckpointsView` and `VerificationView`; updated both to `/// # TODO(#NNNN)` format.
- **#2018** `#[allow]` → `#[expect]`: converted all 4 instances. Three (`StatusColors` dead_code, `cast_possible_truncation`, `module_name_repetitions`) were stale — the lints no longer fired, so the attributes were removed entirely (that's the point of `#[expect]`). One (`Colors` dead_code) still fires and was kept as `#[expect]`.

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes (clean)
- [x] `cargo test --workspace` passes

Closes #2029, Closes #2030, Closes #2018