### PR TITLE
fix: audit security — file permissions, instrument spans, transmute SAFETY

### DIFF
--- a/crates/aletheia/src/commands/add_nous.rs
+++ b/crates/aletheia/src/commands/add_nous.rs
@@ -253,6 +253,12 @@ fn update_config(oikos: &Oikos, args: &AddNousArgs) -> Result<()> {
     )]
     std::fs::write(&tmp, doc.to_string())
         .with_context(|| format!("failed to write {}", tmp.display()))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&tmp, std::fs::Permissions::from_mode(0o600))
+            .with_context(|| format!("failed to set permissions on {}", tmp.display()))?;
+    }
     std::fs::rename(&tmp, &config_path)
         .with_context(|| format!("failed to rename {}", tmp.display()))?;
 

--- a/crates/aletheia/src/commands/agent_io.rs
+++ b/crates/aletheia/src/commands/agent_io.rs
@@ -231,6 +231,12 @@ pub(crate) fn export_agent(instance_root: Option<&PathBuf>, args: &ExportArgs) -
     )]
     std::fs::write(&output_path, &json)
         .with_context(|| format!("failed to write {}", output_path.display()))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&output_path, std::fs::Permissions::from_mode(0o600))
+            .with_context(|| format!("failed to set permissions on {}", output_path.display()))?;
+    }
 
     println!("Exported to: {}", output_path.display());
     println!("Size: {} bytes", json.len());

--- a/crates/aletheia/src/commands/session_export.rs
+++ b/crates/aletheia/src/commands/session_export.rs
@@ -205,8 +205,17 @@ fn write_output(content: &str, path: Option<&std::path::Path>) -> Result<()> {
             clippy::disallowed_methods,
             reason = "aletheia CLI commands use synchronous filesystem operations for config and certificate generation"
         )]
-        Some(p) => std::fs::write(p, content)
-            .with_context(|| format!("failed to write to {}", p.display())),
+        Some(p) => {
+            std::fs::write(p, content)
+                .with_context(|| format!("failed to write to {}", p.display()))?;
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                std::fs::set_permissions(p, std::fs::Permissions::from_mode(0o600))
+                    .with_context(|| format!("failed to set permissions on {}", p.display()))?;
+            }
+            Ok(())
+        }
         None => std::io::stdout()
             .write_all(content.as_bytes())
             .context("failed to write to stdout"),

--- a/crates/aletheia/src/commands/tls.rs
+++ b/crates/aletheia/src/commands/tls.rs
@@ -86,11 +86,13 @@ fn generate_certs(output_dir: &Path, days: u32, sans: &[String], force: bool) ->
     std::fs::write(&key_path, key_pair.serialize_pem())
         .with_context(|| format!("failed to write {}", key_path.display()))?;
 
-    // WHY: restrict private key to owner-read-only (0600): security requirement
+    // WHY: restrict certificate and private key to owner-read-only (0600): security requirement
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
         let perms = std::fs::Permissions::from_mode(0o600);
+        std::fs::set_permissions(&cert_path, perms.clone())
+            .with_context(|| format!("failed to set permissions on {}", cert_path.display()))?;
         std::fs::set_permissions(&key_path, perms)
             .with_context(|| format!("failed to set permissions on {}", key_path.display()))?;
     }

--- a/crates/aletheia/src/init/mod.rs
+++ b/crates/aletheia/src/init/mod.rs
@@ -409,5 +409,9 @@ fn write_user_profile_from_wizard(
             &format!("- **Timezone:** {}", wa.timezone),
         );
 
-    std::fs::write(&user_md_path, updated).context(WriteFileSnafu { path: user_md_path })
+    std::fs::write(&user_md_path, &updated).context(WriteFileSnafu {
+        path: user_md_path.clone(),
+    })?;
+    helpers::set_permissions(&user_md_path, 0o600)?;
+    Ok(())
 }

--- a/crates/aletheia/src/init/scaffold.rs
+++ b/crates/aletheia/src/init/scaffold.rs
@@ -30,6 +30,7 @@ pub(super) fn scaffold(answers: &Answers) -> Result<(), InitError> {
     std::fs::write(&config_path, config_toml).context(WriteFileSnafu {
         path: config_path.clone(),
     })?;
+    set_permissions(&config_path, 0o600)?;
 
     if let Some(ref key) = answers.api_key {
         let cred_path = root.join(format!("config/credentials/{}.json", answers.api_provider));

--- a/crates/aletheia/src/migrate_memory.rs
+++ b/crates/aletheia/src/migrate_memory.rs
@@ -351,5 +351,12 @@ fn write_review_file(path: &Path, flagged: &[String]) -> Result<()> {
     for item in flagged {
         writeln!(f, "- {item}")?;
     }
+    drop(f);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))
+            .context("failed to set permissions on review file")?;
+    }
     Ok(())
 }

--- a/crates/daemon/src/watchdog.rs
+++ b/crates/daemon/src/watchdog.rs
@@ -415,6 +415,8 @@ mod tests {
     use std::sync::Arc;
     use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 
+    use tracing::Instrument;
+
     use super::*;
 
     struct MockProcess {
@@ -650,9 +652,12 @@ mod tests {
         let token = CancellationToken::new();
         let mut wd = Watchdog::new(WatchdogConfig::default(), token.clone());
 
-        let handle = tokio::spawn(async move {
-            wd.run().await;
-        });
+        let handle = tokio::spawn(
+            async move {
+                wd.run().await;
+            }
+            .instrument(tracing::info_span!("test_watchdog")),
+        );
 
         token.cancel();
 

--- a/crates/episteme/src/hnsw_index.rs
+++ b/crates/episteme/src/hnsw_index.rs
@@ -132,11 +132,24 @@ impl HnswIndex {
                         }
                         .build()
                     })?;
-                // SAFETY: Extending the `Hnsw` lifetime to `'static` is sound
-                // because mmap is not used. `load_hnsw` copies all point data into
-                // heap-owned allocations inside `Hnsw`; the loader is not accessed
-                // after this call returns. The `_loader` Box is stored in the struct
-                // to satisfy the type system: see the safety invariant on `HnswIndex`.
+                // SAFETY: Transmuting `Hnsw<'_, f32, DistCosine>` to `Hnsw<'static, f32, DistCosine>`.
+                //
+                // Layout compatibility: Both types are identical structs differing only in a
+                // lifetime parameter. Lifetime erasure does not change size, alignment, or
+                // field layout — the compiler represents both identically at the machine level.
+                //
+                // Validity invariants preserved: `load_hnsw` with mmap disabled (our default)
+                // copies all point data into heap-owned `Vec`s inside `Hnsw`. The returned
+                // struct owns all its data outright — no references into the loader remain
+                // live. Extending the lifetime to `'static` cannot create a dangling reference
+                // because there are no borrowed references to dangle.
+                //
+                // Caller invariants: (1) mmap must NOT be enabled — mmap mode would create
+                // true borrows into the loader's mapped memory, making this transmute unsound.
+                // (2) The `_loader` Box must be retained in `HnswIndex` to satisfy the type
+                // system at construction time; it is never dereferenced after `load_hnsw`
+                // returns. (3) Drop order is pinned by `#[repr(C)]` and the compile-time
+                // assertion on field offsets (see `const _:` above).
                 #[expect(
                     unsafe_code,
                     reason = "lifetime extension: Hnsw owns its data after load (no mmap)"

--- a/crates/hermeneus/src/concurrency.rs
+++ b/crates/hermeneus/src/concurrency.rs
@@ -479,6 +479,8 @@ mod tests {
     use std::sync::Arc;
     use std::time::Duration;
 
+    use tracing::Instrument;
+
     use super::*;
 
     fn limiter(initial: u32, min: u32, max: u32) -> Arc<AdaptiveConcurrencyLimiter> {
@@ -581,7 +583,10 @@ mod tests {
         assert_eq!(l.in_flight(), 1);
 
         let l2 = Arc::clone(&l);
-        let waiter = tokio::spawn(async move { l2.acquire().await });
+        let waiter = tokio::spawn(
+            async move { l2.acquire().await }
+                .instrument(tracing::info_span!("test_acquire_blocked")),
+        );
 
         // WHY: tokio::time::sleep used because tokio test-util feature is not enabled for this crate. // kanon:ignore TESTING/sleep-in-test
         tokio::time::sleep(Duration::from_millis(10)).await; // kanon:ignore TESTING/sleep-in-test

--- a/crates/theatron/core/src/api/sse.rs
+++ b/crates/theatron/core/src/api/sse.rs
@@ -39,7 +39,6 @@ impl SseConnection {
 
         let span = tracing::info_span!("sse_connection", %url);
         let handle = tokio::spawn(
-            // kanon:ignore RUST/spawn-no-instrument
             async move {
                 let mut backoff_secs: u64 = 1;
 

--- a/crates/theatron/core/src/api/streaming.rs
+++ b/crates/theatron/core/src/api/streaming.rs
@@ -54,7 +54,6 @@ pub fn stream_message(
         session.key = session_key
     );
     tokio::spawn(
-        // kanon:ignore RUST/spawn-no-instrument
         async move {
             let resp = match builder.send().await {
                 Ok(resp) => resp,

--- a/crates/theatron/desktop/src/platform/window_state.rs
+++ b/crates/theatron/desktop/src/platform/window_state.rs
@@ -11,6 +11,7 @@ use std::time::Duration;
 
 use snafu::{ResultExt, Snafu};
 use tokio::sync::Notify;
+use tracing::Instrument;
 
 use crate::state::platform::WindowState;
 
@@ -163,27 +164,31 @@ impl DebouncedWriter {
 
         // WHY: Spawn a tokio task (not Dioxus coroutine) so it runs independently
         // of component lifecycle and can flush on app shutdown.
-        tokio::spawn({
-            let state = Arc::clone(&state);
-            let dirty = Arc::clone(&dirty);
-            let has_pending = Arc::clone(&has_pending);
-            async move {
-                loop {
-                    dirty.notified().await;
-                    tokio::time::sleep(DEBOUNCE_INTERVAL).await;
+        let span = tracing::info_span!("window_state_writer");
+        tokio::spawn(
+            {
+                let state = Arc::clone(&state);
+                let dirty = Arc::clone(&dirty);
+                let has_pending = Arc::clone(&has_pending);
+                async move {
+                    loop {
+                        dirty.notified().await;
+                        tokio::time::sleep(DEBOUNCE_INTERVAL).await;
 
-                    if has_pending.swap(false, std::sync::atomic::Ordering::SeqCst) {
-                        let snapshot = {
-                            let guard = state.lock().unwrap_or_else(|e| e.into_inner());
-                            guard.clone()
-                        };
-                        if let Err(e) = save_sync(&snapshot) {
-                            tracing::warn!("failed to save window state: {e}");
+                        if has_pending.swap(false, std::sync::atomic::Ordering::SeqCst) {
+                            let snapshot = {
+                                let guard = state.lock().unwrap_or_else(|e| e.into_inner());
+                                guard.clone()
+                            };
+                            if let Err(e) = save_sync(&snapshot) {
+                                tracing::warn!("failed to save window state: {e}");
+                            }
                         }
                     }
                 }
             }
-        });
+            .instrument(span),
+        );
 
         writer
     }

--- a/crates/theatron/tui/src/actions.rs
+++ b/crates/theatron/tui/src/actions.rs
@@ -36,7 +36,6 @@ impl App {
                 let text = text.to_string();
                 let span = tracing::info_span!("queue_message", %session_id);
                 tokio::spawn(
-                    // kanon:ignore RUST/spawn-no-instrument
                     async move {
                         if let Err(e) = client.queue_message(&session_id, &text).await {
                             tracing::error!("failed to queue message: {e}");

--- a/crates/theatron/tui/src/update/overlay.rs
+++ b/crates/theatron/tui/src/update/overlay.rs
@@ -43,7 +43,6 @@ pub(crate) fn handle_tool_approval_always_allow(app: &mut App) {
     let client = app.client.clone();
     let span = tracing::info_span!("approve_tool_always", %turn_id, %tool_id, %tool_name);
     tokio::spawn(
-        // kanon:ignore RUST/spawn-no-instrument
         async move {
             if let Err(e) = client.approve_tool(&turn_id, &tool_id).await {
                 tracing::error!("failed to approve tool: {e}");
@@ -69,7 +68,6 @@ pub(crate) fn handle_close_overlay(app: &mut App) {
         let client = app.client.clone();
         let span = tracing::info_span!("deny_tool", %turn_id, %tool_id);
         tokio::spawn(
-            // kanon:ignore RUST/spawn-no-instrument
             async move {
                 if let Err(e) = client.deny_tool(&turn_id, &tool_id).await {
                     tracing::error!("failed to deny tool: {e}");
@@ -83,7 +81,6 @@ pub(crate) fn handle_close_overlay(app: &mut App) {
         let client = app.client.clone();
         let span = tracing::info_span!("cancel_plan", %plan_id);
         tokio::spawn(
-            // kanon:ignore RUST/spawn-no-instrument
             async move {
                 if let Err(e) = client.cancel_plan(&plan_id).await {
                     tracing::error!("failed to cancel plan: {e}");
@@ -227,7 +224,6 @@ pub(crate) async fn handle_overlay_select(app: &mut App) {
             let client = app.client.clone();
             let span = tracing::info_span!("approve_tool", %turn_id, %tool_id);
             tokio::spawn(
-                // kanon:ignore RUST/spawn-no-instrument
                 async move {
                     if let Err(e) = client.approve_tool(&turn_id, &tool_id).await {
                         tracing::error!("failed to approve tool: {e}");
@@ -242,7 +238,6 @@ pub(crate) async fn handle_overlay_select(app: &mut App) {
             let client = app.client.clone();
             let span = tracing::info_span!("approve_plan", %plan_id);
             tokio::spawn(
-                // kanon:ignore RUST/spawn-no-instrument
                 async move {
                     if let Err(e) = client.approve_plan(&plan_id).await {
                         tracing::error!("failed to approve plan: {e}");

--- a/crates/theatron/tui/src/update/streaming.rs
+++ b/crates/theatron/tui/src/update/streaming.rs
@@ -152,7 +152,6 @@ pub(crate) fn handle_stream_tool_approval_required(
         let client = app.client.clone();
         let span = tracing::info_span!("auto_approve_tool", %turn_id, %tool_id, %tool_name);
         tokio::spawn(
-            // kanon:ignore RUST/spawn-no-instrument
             async move {
                 if let Err(e) = client.approve_tool(&turn_id, &tool_id).await {
                     tracing::error!("failed to auto-approve tool: {e}");
@@ -376,11 +375,15 @@ pub(crate) async fn handle_cancel_turn(app: &mut App) {
     // stream receiver being dropped is sufficient to stop local processing.
     let client = app.client.clone();
     let id = turn_id.to_string();
-    tokio::spawn(async move {
-        if let Err(e) = client.abort_turn(&id).await {
-            tracing::warn!(error = %e, "abort_turn request failed");
+    let span = tracing::info_span!("abort_turn", %turn_id);
+    tokio::spawn(
+        async move {
+            if let Err(e) = client.abort_turn(&id).await {
+                tracing::warn!(error = %e, "abort_turn request failed");
+            }
         }
-    });
+        .instrument(span),
+    );
 
     app.connection.stream_phase = crate::state::StreamPhase::Idle;
     // Flush line buffer into streaming text before committing.


### PR DESCRIPTION
## Summary

- **0600 permissions on config writes** — 7 locations where config/export/cert files were written without restricting permissions now call `set_permissions(path, 0o600)` under `#[cfg(unix)]`. Prevents secrets (API keys, tokens, session data) from being world-readable.
- **`.instrument()` on spawned tasks** — 4 `tokio::spawn` calls missing tracing span instrumentation now carry `info_span!` context (abort_turn, window_state_writer, test_watchdog, test_acquire_blocked). Removed 9 stale `kanon:ignore RUST/spawn-no-instrument` comments from spawns that already had proper `.instrument()`.
- **Transmute SAFETY comment** — Strengthened the `mem::transmute` lifetime extension in `hnsw_index.rs` to document layout compatibility (lifetime-only change), validity invariant preservation (heap-owned data, no dangling refs), and caller-upheld invariants (no mmap, loader retained, drop order pinned).

Closes #2021, Closes #2022, Closes #2026

## Test plan

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — zero warnings
- [x] `cargo test --workspace` — all passing
- [ ] Verify on macOS/non-Unix: `#[cfg(unix)]` blocks compile-gate cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)