### PR TITLE
feat(nous): conditional workspace file loading based on task context

### DIFF
--- a/crates/nous/src/bootstrap/bootstrap_tests.rs
+++ b/crates/nous/src/bootstrap/bootstrap_tests.rs
@@ -573,3 +573,377 @@ async fn assemble_with_extra_respects_priority_ordering() {
         "important-pack (Important) should appear before optional-pack (Optional)"
     );
 }
+
+// --- Task hint classification tests ---
+
+#[test]
+fn classify_coding_hint() {
+    assert_eq!(
+        classify_task_hint("Please implement a new function to fix this bug"),
+        TaskHint::Coding,
+        "message with coding keywords should classify as Coding"
+    );
+}
+
+#[test]
+fn classify_research_hint() {
+    assert_eq!(
+        classify_task_hint("Research and analyze the performance of our search pipeline"),
+        TaskHint::Research,
+        "message with research keywords should classify as Research"
+    );
+}
+
+#[test]
+fn classify_planning_hint() {
+    assert_eq!(
+        classify_task_hint("Let's design a roadmap and plan the next milestone"),
+        TaskHint::Planning,
+        "message with planning keywords should classify as Planning"
+    );
+}
+
+#[test]
+fn classify_conversation_hint() {
+    assert_eq!(
+        classify_task_hint("hello"),
+        TaskHint::Conversation,
+        "short greeting should classify as Conversation"
+    );
+    assert_eq!(
+        classify_task_hint("thanks"),
+        TaskHint::Conversation,
+        "short thanks should classify as Conversation"
+    );
+}
+
+#[test]
+fn classify_general_hint() {
+    assert_eq!(
+        classify_task_hint("What color is the sky?"),
+        TaskHint::General,
+        "ambiguous message with no task keywords should classify as General"
+    );
+}
+
+#[test]
+fn classify_empty_input() {
+    assert_eq!(
+        classify_task_hint(""),
+        TaskHint::General,
+        "empty input should classify as General"
+    );
+}
+
+#[test]
+fn task_hint_default_is_general() {
+    assert_eq!(
+        TaskHint::default(),
+        TaskHint::General,
+        "TaskHint default should be General for backward compatibility"
+    );
+}
+
+// --- Conditional assembly tests ---
+
+#[tokio::test]
+async fn assemble_conditional_coding_loads_tools_and_memory() {
+    let (_dir, oikos) = setup_oikos(
+        "test",
+        &[
+            ("SOUL.md", "identity"),
+            ("TOOLS.md", "tool list"),
+            ("MEMORY.md", "memory"),
+            ("AGENTS.md", "team topology"),
+            ("GOALS.md", "goals"),
+            ("CONTEXT.md", "runtime config"),
+        ],
+    );
+    let assembler = BootstrapAssembler::new(&oikos);
+    let mut budget = default_budget();
+
+    let result = assembler
+        .assemble_conditional("test", &mut budget, Vec::new(), TaskHint::Coding)
+        .await
+        .expect("assemble_conditional should succeed");
+
+    assert!(
+        result.sections_included.contains(&"SOUL.md".to_owned()),
+        "SOUL.md (identity tier) should always be included"
+    );
+    assert!(
+        result.sections_included.contains(&"TOOLS.md".to_owned()),
+        "TOOLS.md should be included for Coding hint"
+    );
+    assert!(
+        result.sections_included.contains(&"MEMORY.md".to_owned()),
+        "MEMORY.md should be included for Coding hint"
+    );
+    assert!(
+        !result.sections_included.contains(&"AGENTS.md".to_owned()),
+        "AGENTS.md should be filtered out for Coding hint"
+    );
+    assert!(
+        !result.sections_included.contains(&"GOALS.md".to_owned()),
+        "GOALS.md should be filtered out for Coding hint"
+    );
+    assert!(
+        result.sections_filtered.contains(&"AGENTS.md".to_owned()),
+        "AGENTS.md should appear in sections_filtered"
+    );
+    assert!(
+        result.sections_filtered.contains(&"GOALS.md".to_owned()),
+        "GOALS.md should appear in sections_filtered"
+    );
+    assert_eq!(
+        result.task_hint,
+        TaskHint::Coding,
+        "result should record the task hint used"
+    );
+}
+
+#[tokio::test]
+async fn assemble_conditional_research_loads_goals_and_context() {
+    let (_dir, oikos) = setup_oikos(
+        "test",
+        &[
+            ("SOUL.md", "identity"),
+            ("TOOLS.md", "tool list"),
+            ("MEMORY.md", "memory"),
+            ("GOALS.md", "goals"),
+            ("CONTEXT.md", "runtime config"),
+        ],
+    );
+    let assembler = BootstrapAssembler::new(&oikos);
+    let mut budget = default_budget();
+
+    let result = assembler
+        .assemble_conditional("test", &mut budget, Vec::new(), TaskHint::Research)
+        .await
+        .expect("assemble_conditional should succeed");
+
+    assert!(
+        result.sections_included.contains(&"GOALS.md".to_owned()),
+        "GOALS.md should be included for Research hint"
+    );
+    assert!(
+        result.sections_included.contains(&"CONTEXT.md".to_owned()),
+        "CONTEXT.md should be included for Research hint"
+    );
+    assert!(
+        result.sections_included.contains(&"MEMORY.md".to_owned()),
+        "MEMORY.md should be included for Research hint"
+    );
+    assert!(
+        !result.sections_included.contains(&"TOOLS.md".to_owned()),
+        "TOOLS.md should be filtered out for Research hint"
+    );
+    assert!(
+        result.sections_filtered.contains(&"TOOLS.md".to_owned()),
+        "TOOLS.md should appear in sections_filtered"
+    );
+}
+
+#[tokio::test]
+async fn assemble_conditional_planning_loads_goals_agents_context() {
+    let (_dir, oikos) = setup_oikos(
+        "test",
+        &[
+            ("SOUL.md", "identity"),
+            ("AGENTS.md", "team topology"),
+            ("GOALS.md", "goals"),
+            ("TOOLS.md", "tool list"),
+            ("CONTEXT.md", "runtime config"),
+            ("MEMORY.md", "memory"),
+        ],
+    );
+    let assembler = BootstrapAssembler::new(&oikos);
+    let mut budget = default_budget();
+
+    let result = assembler
+        .assemble_conditional("test", &mut budget, Vec::new(), TaskHint::Planning)
+        .await
+        .expect("assemble_conditional should succeed");
+
+    assert!(
+        result.sections_included.contains(&"GOALS.md".to_owned()),
+        "GOALS.md should be included for Planning hint"
+    );
+    assert!(
+        result.sections_included.contains(&"AGENTS.md".to_owned()),
+        "AGENTS.md should be included for Planning hint"
+    );
+    assert!(
+        result.sections_included.contains(&"CONTEXT.md".to_owned()),
+        "CONTEXT.md should be included for Planning hint"
+    );
+    assert!(
+        !result.sections_included.contains(&"TOOLS.md".to_owned()),
+        "TOOLS.md should be filtered out for Planning hint"
+    );
+    assert!(
+        !result.sections_included.contains(&"MEMORY.md".to_owned()),
+        "MEMORY.md should be filtered out for Planning hint"
+    );
+}
+
+#[tokio::test]
+async fn assemble_conditional_conversation_loads_identity_only() {
+    let (_dir, oikos) = setup_oikos(
+        "test",
+        &[
+            ("SOUL.md", "identity"),
+            ("USER.md", "user info"),
+            ("IDENTITY.md", "name and emoji"),
+            ("PROSOCHE.md", "checklist"),
+            ("AGENTS.md", "team topology"),
+            ("GOALS.md", "goals"),
+            ("TOOLS.md", "tool list"),
+            ("MEMORY.md", "memory"),
+            ("CONTEXT.md", "runtime config"),
+        ],
+    );
+    let assembler = BootstrapAssembler::new(&oikos);
+    let mut budget = default_budget();
+
+    let result = assembler
+        .assemble_conditional("test", &mut budget, Vec::new(), TaskHint::Conversation)
+        .await
+        .expect("assemble_conditional should succeed");
+
+    // WHY: only identity-tier files should be included
+    assert!(
+        result.sections_included.contains(&"SOUL.md".to_owned()),
+        "SOUL.md should be included for Conversation"
+    );
+    assert!(
+        result.sections_included.contains(&"USER.md".to_owned()),
+        "USER.md should be included for Conversation"
+    );
+    assert!(
+        result.sections_included.contains(&"IDENTITY.md".to_owned()),
+        "IDENTITY.md should be included for Conversation"
+    );
+    assert!(
+        result.sections_included.contains(&"PROSOCHE.md".to_owned()),
+        "PROSOCHE.md should be included for Conversation"
+    );
+    assert_eq!(
+        result.sections_included.len(),
+        4,
+        "only 4 identity-tier files should be included for Conversation"
+    );
+    // WHY: all operational files should be filtered
+    assert_eq!(
+        result.sections_filtered.len(),
+        6,
+        "all 6 conditional files should be filtered for Conversation"
+    );
+}
+
+#[tokio::test]
+async fn assemble_conditional_general_loads_all() {
+    let (_dir, oikos) = setup_oikos(
+        "test",
+        &[
+            ("SOUL.md", "identity"),
+            ("USER.md", "user info"),
+            ("AGENTS.md", "team topology"),
+            ("GOALS.md", "goals"),
+            ("TOOLS.md", "tool list"),
+            ("MEMORY.md", "memory"),
+            ("IDENTITY.md", "name and emoji"),
+            ("PROSOCHE.md", "checklist"),
+            ("CONTEXT.md", "runtime config"),
+        ],
+    );
+    let assembler = BootstrapAssembler::new(&oikos);
+    let mut budget = default_budget();
+
+    let result = assembler
+        .assemble_conditional("test", &mut budget, Vec::new(), TaskHint::General)
+        .await
+        .expect("assemble_conditional should succeed");
+
+    assert_eq!(
+        result.sections_included.len(),
+        9,
+        "General hint should load all 9 present workspace files"
+    );
+    assert!(
+        result.sections_filtered.is_empty(),
+        "General hint should not filter any files"
+    );
+    assert_eq!(
+        result.task_hint,
+        TaskHint::General,
+        "result should record General task hint"
+    );
+}
+
+#[tokio::test]
+async fn assemble_conditional_with_checklist() {
+    let (_dir, oikos) = setup_oikos(
+        "test",
+        &[
+            ("SOUL.md", "identity"),
+            ("TOOLS.md", "tool list"),
+            ("CHECKLIST.md", "work procedures"),
+        ],
+    );
+    let assembler = BootstrapAssembler::new(&oikos);
+    let mut budget = default_budget();
+
+    let result = assembler
+        .assemble_conditional("test", &mut budget, Vec::new(), TaskHint::Coding)
+        .await
+        .expect("assemble_conditional should succeed");
+
+    assert!(
+        result
+            .sections_included
+            .contains(&"CHECKLIST.md".to_owned()),
+        "CHECKLIST.md should be included for Coding hint"
+    );
+    assert!(
+        result.sections_included.contains(&"TOOLS.md".to_owned()),
+        "TOOLS.md should be included for Coding hint"
+    );
+}
+
+#[tokio::test]
+async fn assemble_backward_compat_loads_all() {
+    // WHY: assemble() without hint should behave identically to pre-change behavior
+    let (_dir, oikos) = setup_oikos(
+        "test",
+        &[
+            ("SOUL.md", "identity"),
+            ("AGENTS.md", "team topology"),
+            ("GOALS.md", "goals"),
+            ("TOOLS.md", "tool list"),
+            ("MEMORY.md", "memory"),
+        ],
+    );
+    let assembler = BootstrapAssembler::new(&oikos);
+    let mut budget = default_budget();
+
+    let result = assembler
+        .assemble("test", &mut budget)
+        .await
+        .expect("assemble should succeed with backward-compatible behavior");
+
+    assert_eq!(
+        result.sections_included.len(),
+        5,
+        "assemble() without hint should load all present files"
+    );
+    assert!(
+        result.sections_filtered.is_empty(),
+        "assemble() without hint should not filter any files"
+    );
+    assert_eq!(
+        result.task_hint,
+        TaskHint::General,
+        "assemble() should use General hint by default"
+    );
+}

--- a/crates/nous/src/bootstrap/mod.rs
+++ b/crates/nous/src/bootstrap/mod.rs
@@ -2,6 +2,13 @@
 //!
 //! Reads workspace files through the taxis cascade, estimates tokens,
 //! and packs sections in priority order within the token budget.
+//!
+//! Workspace files are split into two load tiers (see issue #2041):
+//!
+//! - **Always-loaded (identity):** SOUL, USER, IDENTITY, PROSOCHE — define
+//!   who the agent is and load unconditionally.
+//! - **Conditionally-loaded (operational):** AGENTS, GOALS, TOOLS, CHECKLIST,
+//!   MEMORY, CONTEXT — loaded only when relevant to the [`TaskHint`].
 
 /// Tool summary generation for inclusion in the bootstrap system prompt.
 pub mod tools;
@@ -34,6 +41,36 @@ pub enum SectionPriority {
     Optional = 3,
 }
 
+/// Task hint for conditional workspace file loading.
+///
+/// Classifies the kind of work a turn involves so the bootstrap assembler
+/// loads only workspace files relevant to that work. Identity-tier files
+/// (SOUL, USER, IDENTITY, PROSOCHE) load regardless of the hint.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[non_exhaustive]
+pub enum TaskHint {
+    /// Load all workspace files. Default for backward compatibility.
+    #[default]
+    General,
+    /// Coding task: loads TOOLS, CHECKLIST, MEMORY.
+    Coding,
+    /// Research or information gathering: loads GOALS, CONTEXT, MEMORY.
+    Research,
+    /// Planning or architecture: loads GOALS, AGENTS, CONTEXT.
+    Planning,
+    /// Quick question or casual conversation: identity files only.
+    Conversation,
+}
+
+/// Load tier: whether a workspace file loads unconditionally or based on task hint.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LoadTier {
+    /// Identity files: always loaded regardless of task hint.
+    Always,
+    /// Operational files: loaded only when relevant to the current [`TaskHint`].
+    Conditional,
+}
+
 /// A section of the bootstrap system prompt.
 #[derive(Debug, Clone)]
 pub struct BootstrapSection {
@@ -60,8 +97,12 @@ pub struct BootstrapResult {
     pub sections_truncated: Vec<String>,
     /// Section names that were dropped entirely.
     pub sections_dropped: Vec<String>,
+    /// Workspace file names filtered out by the task hint (never loaded).
+    pub sections_filtered: Vec<String>,
     /// Total estimated tokens consumed by the system prompt.
     pub total_tokens: u64,
+    /// The task hint used for conditional loading.
+    pub task_hint: TaskHint,
 }
 
 /// Workspace file specification for cascade resolution.
@@ -69,65 +110,91 @@ struct WorkspaceFileSpec {
     filename: &'static str,
     priority: SectionPriority,
     truncatable: bool,
+    /// Whether this file loads unconditionally or based on task hint.
+    load_tier: LoadTier,
 }
 
 /// Ordered list of workspace files resolved through the oikos cascade.
 ///
-/// Priority ordering:
+/// Split into two tiers (issue #2041):
+///
+/// **Always-loaded (identity tier):**
 /// - SOUL.md: Required (core identity)
 /// - USER.md: Important (operator profile, typically in theke/)
-/// - AGENTS.md: Important (operating instructions, typically in theke/)
-/// - GOALS.md: Important + truncatable (active/completed/deferred goals)
-/// - TOOLS.md: Important + truncatable (available commands, SSH, paths)
-/// - MEMORY.md: Flexible + truncatable (operational memory, oldest entries dropped first)
 /// - IDENTITY.md: Flexible (name, emoji, avatar metadata)
 /// - PROSOCHE.md: Flexible (heartbeat checklist)
-/// - CONTEXT.md: Flexible + truncatable (runtime config, auto-generated)
+///
+/// **Conditionally-loaded (operational tier):**
+/// - AGENTS.md: Important (team topology) — Planning
+/// - GOALS.md: Important + truncatable (active/completed/deferred goals) — Research, Planning
+/// - TOOLS.md: Important + truncatable (available commands, SSH, paths) — Coding
+/// - CHECKLIST.md: Flexible + truncatable (work procedures) — Coding
+/// - MEMORY.md: Flexible + truncatable (operational memory) — Coding, Research
+/// - CONTEXT.md: Flexible + truncatable (runtime config, auto-generated) — Research, Planning
 const WORKSPACE_FILES: &[WorkspaceFileSpec] = &[
+    // --- Always-loaded (identity tier) ---
     WorkspaceFileSpec {
         filename: "SOUL.md",
         priority: SectionPriority::Required,
         truncatable: false,
+        load_tier: LoadTier::Always,
     },
     WorkspaceFileSpec {
         filename: "USER.md",
         priority: SectionPriority::Important,
         truncatable: false,
+        load_tier: LoadTier::Always,
     },
+    // --- Conditionally-loaded (operational tier) ---
     WorkspaceFileSpec {
         filename: "AGENTS.md",
         priority: SectionPriority::Important,
         truncatable: false,
+        load_tier: LoadTier::Conditional,
     },
     WorkspaceFileSpec {
         filename: "GOALS.md",
         priority: SectionPriority::Important,
         truncatable: true,
+        load_tier: LoadTier::Conditional,
     },
     WorkspaceFileSpec {
         filename: "TOOLS.md",
         priority: SectionPriority::Important,
         truncatable: true,
+        load_tier: LoadTier::Conditional,
+    },
+    WorkspaceFileSpec {
+        filename: "CHECKLIST.md",
+        priority: SectionPriority::Flexible,
+        truncatable: true,
+        load_tier: LoadTier::Conditional,
     },
     WorkspaceFileSpec {
         filename: "MEMORY.md",
         priority: SectionPriority::Flexible,
         truncatable: true,
+        load_tier: LoadTier::Conditional,
     },
+    // --- Always-loaded (identity tier, continued) ---
     WorkspaceFileSpec {
         filename: "IDENTITY.md",
         priority: SectionPriority::Flexible,
         truncatable: false,
+        load_tier: LoadTier::Always,
     },
     WorkspaceFileSpec {
         filename: "PROSOCHE.md",
         priority: SectionPriority::Flexible,
         truncatable: false,
+        load_tier: LoadTier::Always,
     },
+    // --- Conditionally-loaded (operational tier, continued) ---
     WorkspaceFileSpec {
         filename: "CONTEXT.md",
         priority: SectionPriority::Flexible,
         truncatable: true,
+        load_tier: LoadTier::Conditional,
     },
 ];
 
@@ -175,9 +242,8 @@ impl<'a, E: TokenEstimator> BootstrapAssembler<'a, E> {
 
     /// Assemble the bootstrap system prompt for the given nous.
     ///
-    /// Resolves workspace files through the cascade, packs them in priority order
-    /// within the token budget, truncates flexible sections, and drops optional
-    /// sections if budget is exhausted.
+    /// Loads all workspace files (identity + operational). Use
+    /// [`assemble_conditional`](Self::assemble_conditional) for task-aware loading.
     ///
     /// # Errors
     ///
@@ -193,6 +259,10 @@ impl<'a, E: TokenEstimator> BootstrapAssembler<'a, E> {
 
     /// Assemble the bootstrap system prompt with additional sections from domain packs.
     ///
+    /// Uses [`TaskHint::General`] which loads all workspace files, preserving
+    /// backward-compatible behavior. Use [`assemble_conditional`](Self::assemble_conditional)
+    /// for task-aware loading.
+    ///
     /// Extra sections participate in the same priority sorting and token budget
     /// as workspace files. They are appended after workspace files before sorting,
     /// so sections with the same priority level interleave naturally.
@@ -207,7 +277,30 @@ impl<'a, E: TokenEstimator> BootstrapAssembler<'a, E> {
         budget: &mut TokenBudget,
         extra_sections: Vec<BootstrapSection>,
     ) -> Result<BootstrapResult> {
-        let mut sections = self.resolve_workspace_files(nous_id).await?;
+        // WHY: General hint loads all files for backward compatibility
+        self.assemble_conditional(nous_id, budget, extra_sections, TaskHint::General)
+            .await
+    }
+
+    /// Assemble the bootstrap system prompt with conditional file loading.
+    ///
+    /// Only workspace files relevant to the given [`TaskHint`] are loaded.
+    /// Identity-tier files (SOUL, USER, IDENTITY, PROSOCHE) always load.
+    /// Operational files (AGENTS, GOALS, TOOLS, CHECKLIST, MEMORY, CONTEXT)
+    /// load only when relevant to the task hint.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`error::Error::ContextAssembly`] if a Required file (SOUL.md) is
+    /// missing or unreadable.
+    pub async fn assemble_conditional(
+        &self,
+        nous_id: &str,
+        budget: &mut TokenBudget,
+        extra_sections: Vec<BootstrapSection>,
+        hint: TaskHint,
+    ) -> Result<BootstrapResult> {
+        let (mut sections, filtered_names) = self.resolve_workspace_files(nous_id, hint).await?;
         sections.extend(extra_sections);
 
         // NOTE: stable sort preserves declaration order within same priority
@@ -259,10 +352,12 @@ impl<'a, E: TokenEstimator> BootstrapAssembler<'a, E> {
 
         info!(
             nous_id,
+            ?hint,
             sections = section_names.len(),
             total_tokens,
             truncated = truncated_names.len(),
             dropped = dropped_names.len(),
+            filtered = filtered_names.len(),
             "bootstrap assembled"
         );
 
@@ -271,7 +366,9 @@ impl<'a, E: TokenEstimator> BootstrapAssembler<'a, E> {
             sections_included: section_names,
             sections_truncated: truncated_names,
             sections_dropped: dropped_names,
+            sections_filtered: filtered_names,
             total_tokens,
+            task_hint: hint,
         })
     }
 
@@ -284,10 +381,25 @@ impl<'a, E: TokenEstimator> BootstrapAssembler<'a, E> {
     }
 
     /// Resolve workspace files through the cascade and read their contents.
-    async fn resolve_workspace_files(&self, nous_id: &str) -> Result<Vec<BootstrapSection>> {
+    ///
+    /// Returns `(sections, filtered_names)` where `filtered_names` lists
+    /// workspace files that were skipped by the task hint filter.
+    async fn resolve_workspace_files(
+        &self,
+        nous_id: &str,
+        hint: TaskHint,
+    ) -> Result<(Vec<BootstrapSection>, Vec<String>)> {
         let mut sections = Vec::new();
+        let mut filtered = Vec::new();
 
         for spec in WORKSPACE_FILES {
+            // NOTE: always-tier files load unconditionally; conditional files check relevance
+            if spec.load_tier == LoadTier::Conditional && !is_file_relevant(spec.filename, hint) {
+                debug!(file = spec.filename, ?hint, "skipped by task hint filter");
+                filtered.push(spec.filename.to_owned());
+                continue;
+            }
+
             let Some(p) = cascade::resolve(self.oikos, nous_id, spec.filename, None) else {
                 if spec.priority == SectionPriority::Required {
                     return Err(error::ContextAssemblySnafu {
@@ -332,7 +444,7 @@ impl<'a, E: TokenEstimator> BootstrapAssembler<'a, E> {
             }
         }
 
-        Ok(sections)
+        Ok((sections, filtered))
     }
 
     /// Truncate a section to fit within the given token limit.
@@ -457,6 +569,116 @@ impl<'a, E: TokenEstimator> BootstrapAssembler<'a, E> {
             truncatable: section.truncatable,
         }
     }
+}
+
+/// Whether a conditional workspace file should be loaded for the given task hint.
+///
+/// Only called for [`LoadTier::Conditional`] files. Always-tier files bypass
+/// this check entirely.
+fn is_file_relevant(filename: &str, hint: TaskHint) -> bool {
+    match hint {
+        // WHY: General loads everything for backward compatibility
+        TaskHint::General => true,
+        TaskHint::Coding => matches!(filename, "TOOLS.md" | "CHECKLIST.md" | "MEMORY.md"),
+        TaskHint::Research => matches!(filename, "GOALS.md" | "CONTEXT.md" | "MEMORY.md"),
+        TaskHint::Planning => matches!(filename, "GOALS.md" | "AGENTS.md" | "CONTEXT.md"),
+        // WHY: Conversation loads identity-tier files only; all conditional files skipped
+        TaskHint::Conversation => false,
+    }
+}
+
+/// Classify user message content into a task hint for conditional file loading.
+///
+/// Uses keyword scoring to detect task patterns. Returns [`TaskHint::General`]
+/// when the message is ambiguous or matches no specific pattern.
+#[must_use]
+pub fn classify_task_hint(content: &str) -> TaskHint {
+    let lower = content.to_lowercase();
+
+    // WHY: short messages with greetings are casual conversation, not work tasks
+    if content.split_whitespace().count() <= 5 && score_keywords(&lower, CONVERSATION_KEYWORDS) > 0
+    {
+        return TaskHint::Conversation;
+    }
+
+    let coding = score_keywords(&lower, CODING_KEYWORDS);
+    let research = score_keywords(&lower, RESEARCH_KEYWORDS);
+    let planning = score_keywords(&lower, PLANNING_KEYWORDS);
+
+    let max = coding.max(research).max(planning);
+    if max == 0 {
+        return TaskHint::General;
+    }
+
+    // WHY: ties broken coding > research > planning since coding is the most common task
+    if coding >= research && coding >= planning {
+        TaskHint::Coding
+    } else if research >= planning {
+        TaskHint::Research
+    } else {
+        TaskHint::Planning
+    }
+}
+
+const CODING_KEYWORDS: &[&str] = &[
+    "code",
+    "implement",
+    "fix",
+    "bug",
+    "compile",
+    "test",
+    "refactor",
+    "debug",
+    "build",
+    "error",
+    "function",
+    "struct",
+    "deploy",
+    "lint",
+];
+
+const RESEARCH_KEYWORDS: &[&str] = &[
+    "research",
+    "find",
+    "search",
+    "investigate",
+    "analyze",
+    "review",
+    "compare",
+    "evaluate",
+    "explain",
+    "understand",
+];
+
+const PLANNING_KEYWORDS: &[&str] = &[
+    "plan",
+    "design",
+    "architect",
+    "strategy",
+    "roadmap",
+    "organize",
+    "coordinate",
+    "priority",
+    "goal",
+    "milestone",
+];
+
+const CONVERSATION_KEYWORDS: &[&str] = &[
+    "hello",
+    "hi",
+    "hey",
+    "thanks",
+    "thank you",
+    "ok",
+    "okay",
+    "yes",
+    "no",
+    "sure",
+    "bye",
+];
+
+fn score_keywords(text: &str, keywords: &[&str]) -> usize {
+    keywords.iter().filter(|kw| text.contains(**kw)).count()
 }
 
 /// Convert domain pack sections into bootstrap sections.

--- a/crates/nous/src/pipeline/mod.rs
+++ b/crates/nous/src/pipeline/mod.rs
@@ -16,7 +16,7 @@ use aletheia_organon::registry::ToolRegistry;
 use aletheia_organon::types::ToolContext;
 use aletheia_taxis::oikos::Oikos;
 
-use crate::bootstrap::{BootstrapAssembler, BootstrapSection};
+use crate::bootstrap::{BootstrapAssembler, BootstrapSection, TaskHint, classify_task_hint};
 use crate::budget::TokenBudget;
 use crate::config::{NousConfig, PipelineConfig};
 use crate::error;
@@ -537,10 +537,21 @@ pub async fn assemble_context(
     pipeline_config: &PipelineConfig,
     ctx: &mut PipelineContext,
 ) -> crate::error::Result<()> {
-    assemble_context_with_extra(oikos, nous_config, pipeline_config, ctx, Vec::new()).await
+    assemble_context_conditional(
+        oikos,
+        nous_config,
+        pipeline_config,
+        ctx,
+        Vec::new(),
+        TaskHint::General,
+    )
+    .await
 }
 
 /// Assemble bootstrap context with extra sections from domain packs.
+///
+/// Uses [`TaskHint::General`] which loads all workspace files. Use
+/// [`assemble_context_conditional`] for task-aware loading.
 #[instrument(skip_all, fields(nous_id = %nous_config.id))]
 pub async fn assemble_context_with_extra(
     oikos: &Oikos,
@@ -548,6 +559,30 @@ pub async fn assemble_context_with_extra(
     pipeline_config: &PipelineConfig,
     ctx: &mut PipelineContext,
     extra_sections: Vec<BootstrapSection>,
+) -> crate::error::Result<()> {
+    assemble_context_conditional(
+        oikos,
+        nous_config,
+        pipeline_config,
+        ctx,
+        extra_sections,
+        TaskHint::General,
+    )
+    .await
+}
+
+/// Assemble bootstrap context with conditional file loading.
+///
+/// Only workspace files relevant to the given [`TaskHint`] are loaded.
+/// Identity-tier files always load; operational files load based on the hint.
+#[instrument(skip_all, fields(nous_id = %nous_config.id, ?task_hint))]
+pub async fn assemble_context_conditional(
+    oikos: &Oikos,
+    nous_config: &NousConfig,
+    pipeline_config: &PipelineConfig,
+    ctx: &mut PipelineContext,
+    extra_sections: Vec<BootstrapSection>,
+    task_hint: TaskHint,
 ) -> crate::error::Result<()> {
     let mut budget = TokenBudget::new(
         u64::from(nous_config.generation.context_window),
@@ -558,7 +593,7 @@ pub async fn assemble_context_with_extra(
 
     let assembler = BootstrapAssembler::new(oikos);
     let result = assembler
-        .assemble_with_extra(&nous_config.id, &mut budget, extra_sections)
+        .assemble_conditional(&nous_config.id, &mut budget, extra_sections, task_hint)
         .await?;
 
     ctx.system_prompt = Some(result.system_prompt);
@@ -648,6 +683,7 @@ pub(crate) async fn run_pipeline(
     let mut stages_completed: u32 = 0;
 
     let mut ctx = PipelineContext::default();
+    let task_hint = classify_task_hint(&input.content);
 
     run_context_stage(
         oikos,
@@ -655,6 +691,7 @@ pub(crate) async fn run_pipeline(
         pipeline_config,
         &mut ctx,
         extra_bootstrap,
+        task_hint,
         emitter,
     )
     .await?;

--- a/crates/nous/src/pipeline/stages.rs
+++ b/crates/nous/src/pipeline/stages.rs
@@ -14,7 +14,7 @@ use aletheia_organon::registry::ToolRegistry;
 use aletheia_organon::types::ToolContext;
 use aletheia_taxis::oikos::Oikos;
 
-use crate::bootstrap::BootstrapSection;
+use crate::bootstrap::{BootstrapSection, TaskHint};
 use crate::config::{NousConfig, PipelineConfig};
 use crate::error;
 use crate::history::{self, HistoryConfig};
@@ -24,7 +24,7 @@ use crate::stream::TurnStreamEvent;
 use super::events::{StageCompleted, StageError, StageSkipped, StageTimeout};
 use super::{
     GuardResult, PipelineContext, PipelineInput, PipelineMessage, TurnResult,
-    assemble_context_with_extra, check_guard,
+    assemble_context_conditional, check_guard,
 };
 
 pub(super) async fn run_context_stage(
@@ -33,6 +33,7 @@ pub(super) async fn run_context_stage(
     pipeline_config: &PipelineConfig,
     ctx: &mut PipelineContext,
     extra_bootstrap: Vec<BootstrapSection>,
+    task_hint: TaskHint,
     emitter: &EventEmitter,
 ) -> error::Result<()> {
     let span = info_span!(
@@ -43,16 +44,23 @@ pub(super) async fn run_context_stage(
     );
     let _guard = span.enter();
     let start = Instant::now();
-    assemble_context_with_extra(oikos, config, pipeline_config, ctx, extra_bootstrap)
-        .await
-        .inspect_err(|_| {
-            crate::metrics::record_error(&config.id, "context", "assembly_failed");
-            emitter.emit(&StageError {
-                nous_id: config.id.clone(),
-                stage: "context",
-                error_type: "assembly_failed".to_owned(),
-            });
-        })?;
+    assemble_context_conditional(
+        oikos,
+        config,
+        pipeline_config,
+        ctx,
+        extra_bootstrap,
+        task_hint,
+    )
+    .await
+    .inspect_err(|_| {
+        crate::metrics::record_error(&config.id, "context", "assembly_failed");
+        emitter.emit(&StageError {
+            nous_id: config.id.clone(),
+            stage: "context",
+            error_type: "assembly_failed".to_owned(),
+        });
+    })?;
     let duration_secs = start.elapsed().as_secs_f64();
     record_stage_duration(&span, &start);
     span.record("status", "ok");


### PR DESCRIPTION
## Summary
- Split workspace files into two load tiers: **always-loaded** (identity: SOUL, USER, IDENTITY, PROSOCHE) and **conditionally-loaded** (operational: AGENTS, GOALS, TOOLS, CHECKLIST, MEMORY, CONTEXT)
- Add keyword-based `classify_task_hint()` that determines which operational files to load based on user message content (Coding/Research/Planning/Conversation/General)
- Wire task hint classification through the pipeline context stage via new `assemble_conditional()` and `assemble_context_conditional()` methods
- Add `CHECKLIST.md` as a new workspace file spec for agents with work procedure checklists
- Preserve full backward compatibility: existing `assemble()` and `assemble_with_extra()` methods use `TaskHint::General` (loads all files)

Closes #2041

## Acceptance criteria
- [x] Issue #2041 requirements satisfied (two-tier workspace files, task-type-based loading, token budget integration)
- [x] Tests pass for affected code (42 bootstrap tests, 488 nous tests, full workspace passes)
- [x] `cargo fmt --all -- --check` ✓
- [x] `cargo clippy --workspace --all-targets -- -D warnings` ✓
- [x] `cargo test --workspace` ✓

## Test plan
- [x] Verify `classify_task_hint()` correctly classifies coding, research, planning, conversation, and general messages
- [x] Verify `assemble_conditional()` with Coding hint loads TOOLS, CHECKLIST, MEMORY but not AGENTS, GOALS
- [x] Verify `assemble_conditional()` with Research hint loads GOALS, CONTEXT, MEMORY but not TOOLS
- [x] Verify `assemble_conditional()` with Planning hint loads GOALS, AGENTS, CONTEXT but not TOOLS, MEMORY
- [x] Verify `assemble_conditional()` with Conversation hint loads only identity-tier files (4 files)
- [x] Verify `assemble_conditional()` with General hint loads all files (backward compat)
- [x] Verify `assemble()` without hint loads all files (backward compat)
- [x] Verify CHECKLIST.md is included for Coding hint when present
- [x] Verify all 28 pre-existing bootstrap tests still pass unchanged

## Observations
- **Future work**: Recency-based loading (MEMORY sections accessed in last N sessions get priority) mentioned in #2041 is not implemented — requires session access tracking which is out of scope for this change
- **Future work**: Access frequency tracking for token budget prioritization mentioned in #2041 — the existing priority/truncation system handles budget pressure, but frequency-based reordering would require persistence
- **Debt**: `classify_task_hint()` uses simple keyword matching. A more sophisticated classifier (e.g., using the LLM or embeddings) could improve accuracy but would add latency to the bootstrap stage

🤖 Generated with [Claude Code](https://claude.com/claude-code)