### PR TITLE
fix(gitleaks): add target/ to allowlist for build artifact false positives

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -40,6 +40,10 @@ paths = [
   '''SECURITY\.md''',
   '''docs/DEPLOYMENT\.md''',
   '''docs/CONFIGURATION\.md''',
+  # WHY: build artifacts contain hash-like strings in LTO bytecode and compiled
+  # metadata (e.g. struct field names, OpenSSL constants) that trigger
+  # generic-api-key and private-key rules. Gitignored but visible to --no-git.
+  '''target/''',
   # WHY: redact.rs files contain intentional fake credentials for PII-scrubbing tests.
   '''crates/[^/]+/src/redact\.rs''',
   # WHY: runbook and checklist contain example CLI commands with synthetic values.


### PR DESCRIPTION
## Summary
- Add `target/` path to `.gitleaks.toml` allowlist to suppress 91 false positives from build artifacts (LTO bytecode hashes, OpenSSL constants in compiled rmeta)
- Existing allowlist already covered `crates/*/src/redact.rs` (test fixtures) and `docs/RUNBOOK.md` (synthetic 555-range phone number)

Closes #2024

## Acceptance criteria
- [x] Issue #2024 requirements are satisfied — `target/` build artifacts allowlisted, koina/redact.rs and RUNBOOK.md paths already present
- [x] Tests pass for affected code — `cargo test --workspace` clean
- [x] `gitleaks detect --no-git` reports zero findings

## Observations
- **Blast radius note**: prompt listed `crates/koina/src/` and `crates/theatron/src/` but the fix is solely in `.gitleaks.toml` — the source files already had correct test fixtures and the existing allowlist patterns covered them
- **Redundancy**: the `crates/theatron/desktop/target/` path from issue #2024's suggested fix is fully covered by the broader `target/` pattern, so only one entry was needed

## Validation gate
- `cargo fmt --all -- --check` ✓
- `cargo clippy --workspace --all-targets -- -D warnings` ✓
- `cargo test --workspace` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)