### PR TITLE
fix(theatron): instrument all tokio::spawn calls with tracing spans

### DIFF
--- a/crates/daemon/src/watchdog.rs
+++ b/crates/daemon/src/watchdog.rs
@@ -415,6 +415,8 @@ mod tests {
     use std::sync::Arc;
     use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 
+    use tracing::Instrument;
+
     use super::*;
 
     struct MockProcess {
@@ -650,9 +652,12 @@ mod tests {
         let token = CancellationToken::new();
         let mut wd = Watchdog::new(WatchdogConfig::default(), token.clone());
 
-        let handle = tokio::spawn(async move {
-            wd.run().await;
-        });
+        let handle = tokio::spawn(
+            async move {
+                wd.run().await;
+            }
+            .instrument(tracing::info_span!("test_watchdog_shutdown")),
+        );
 
         token.cancel();
 

--- a/crates/theatron/.kanon-lint-ignore
+++ b/crates/theatron/.kanon-lint-ignore
@@ -96,6 +96,7 @@ RUST/string-slice:tui/src/view/ops.rs
 # .instrument() calls chained on the async block.
 RUST/spawn-no-instrument:tui/src/actions.rs
 RUST/spawn-no-instrument:tui/src/update/overlay.rs
+RUST/spawn-no-instrument:tui/src/update/streaming/mod.rs
 
 # WHY: test helper functions (test_theme, test_agent_id, test_session, etc.)
 # use test_ prefix as constructor convention, not as test function naming.

--- a/crates/theatron/core/src/api/sse.rs
+++ b/crates/theatron/core/src/api/sse.rs
@@ -39,7 +39,6 @@ impl SseConnection {
 
         let span = tracing::info_span!("sse_connection", %url);
         let handle = tokio::spawn(
-            // kanon:ignore RUST/spawn-no-instrument
             async move {
                 let mut backoff_secs: u64 = 1;
 

--- a/crates/theatron/core/src/api/streaming.rs
+++ b/crates/theatron/core/src/api/streaming.rs
@@ -54,7 +54,6 @@ pub fn stream_message(
         session.key = session_key
     );
     tokio::spawn(
-        // kanon:ignore RUST/spawn-no-instrument
         async move {
             let resp = match builder.send().await {
                 Ok(resp) => resp,

--- a/crates/theatron/tui/src/actions.rs
+++ b/crates/theatron/tui/src/actions.rs
@@ -36,7 +36,6 @@ impl App {
                 let text = text.to_string();
                 let span = tracing::info_span!("queue_message", %session_id);
                 tokio::spawn(
-                    // kanon:ignore RUST/spawn-no-instrument
                     async move {
                         if let Err(e) = client.queue_message(&session_id, &text).await {
                             tracing::error!("failed to queue message: {e}");

--- a/crates/theatron/tui/src/update/overlay.rs
+++ b/crates/theatron/tui/src/update/overlay.rs
@@ -43,7 +43,6 @@ pub(crate) fn handle_tool_approval_always_allow(app: &mut App) {
     let client = app.client.clone();
     let span = tracing::info_span!("approve_tool_always", %turn_id, %tool_id, %tool_name);
     tokio::spawn(
-        // kanon:ignore RUST/spawn-no-instrument
         async move {
             if let Err(e) = client.approve_tool(&turn_id, &tool_id).await {
                 tracing::error!("failed to approve tool: {e}");
@@ -69,7 +68,6 @@ pub(crate) fn handle_close_overlay(app: &mut App) {
         let client = app.client.clone();
         let span = tracing::info_span!("deny_tool", %turn_id, %tool_id);
         tokio::spawn(
-            // kanon:ignore RUST/spawn-no-instrument
             async move {
                 if let Err(e) = client.deny_tool(&turn_id, &tool_id).await {
                     tracing::error!("failed to deny tool: {e}");
@@ -83,7 +81,6 @@ pub(crate) fn handle_close_overlay(app: &mut App) {
         let client = app.client.clone();
         let span = tracing::info_span!("cancel_plan", %plan_id);
         tokio::spawn(
-            // kanon:ignore RUST/spawn-no-instrument
             async move {
                 if let Err(e) = client.cancel_plan(&plan_id).await {
                     tracing::error!("failed to cancel plan: {e}");
@@ -227,7 +224,6 @@ pub(crate) async fn handle_overlay_select(app: &mut App) {
             let client = app.client.clone();
             let span = tracing::info_span!("approve_tool", %turn_id, %tool_id);
             tokio::spawn(
-                // kanon:ignore RUST/spawn-no-instrument
                 async move {
                     if let Err(e) = client.approve_tool(&turn_id, &tool_id).await {
                         tracing::error!("failed to approve tool: {e}");
@@ -242,7 +238,6 @@ pub(crate) async fn handle_overlay_select(app: &mut App) {
             let client = app.client.clone();
             let span = tracing::info_span!("approve_plan", %plan_id);
             tokio::spawn(
-                // kanon:ignore RUST/spawn-no-instrument
                 async move {
                     if let Err(e) = client.approve_plan(&plan_id).await {
                         tracing::error!("failed to approve plan: {e}");

--- a/crates/theatron/tui/src/update/streaming/mod.rs
+++ b/crates/theatron/tui/src/update/streaming/mod.rs
@@ -152,7 +152,6 @@ pub(crate) fn handle_stream_tool_approval_required(
         let client = app.client.clone();
         let span = tracing::info_span!("auto_approve_tool", %turn_id, %tool_id, %tool_name);
         tokio::spawn(
-            // kanon:ignore RUST/spawn-no-instrument
             async move {
                 if let Err(e) = client.approve_tool(&turn_id, &tool_id).await {
                     tracing::error!("failed to auto-approve tool: {e}");
@@ -376,11 +375,15 @@ pub(crate) async fn handle_cancel_turn(app: &mut App) {
     // stream receiver being dropped is sufficient to stop local processing.
     let client = app.client.clone();
     let id = turn_id.to_string();
-    tokio::spawn(async move {
-        if let Err(e) = client.abort_turn(&id).await {
-            tracing::warn!(error = %e, "abort_turn request failed");
+    let span = tracing::info_span!("abort_turn", turn_id = %id);
+    tokio::spawn(
+        async move {
+            if let Err(e) = client.abort_turn(&id).await {
+                tracing::warn!(error = %e, "abort_turn request failed");
+            }
         }
-    });
+        .instrument(span),
+    );
 
     app.connection.stream_phase = crate::state::StreamPhase::Idle;
     // Flush line buffer into streaming text before committing.


### PR DESCRIPTION
## Summary
- Add `.instrument()` to 2 uninstrumented `tokio::spawn` calls: watchdog test spawn (`daemon/watchdog.rs:653`) and `abort_turn` fire-and-forget (`theatron/tui/streaming/mod.rs:379`)
- Remove 9 stale inline `kanon:ignore RUST/spawn-no-instrument` comments from spawns that already had `.instrument()` — file-level suppression in `.kanon-lint-ignore` handles the linter false positive
- Add `tui/src/update/streaming/mod.rs` to `.kanon-lint-ignore` for `RUST/spawn-no-instrument` (multi-line `.instrument()` not detected by line-by-line linter)

Closes #2022

## Acceptance criteria
- [x] Issue #2022 requirements satisfied — all 7 listed spawn sites now have `.instrument()` with named tracing spans
- [x] Tests pass for affected crates (`aletheia-oikonomos`, `theatron-core`, `theatron-tui`)
- [x] `cargo fmt --all -- --check` ✓
- [x] `cargo clippy --workspace --all-targets -- -D warnings` ✓
- [x] `cargo test --workspace` ✓

## Observations
- **Linter limitation**: kanon `RUST/spawn-no-instrument` uses line-by-line detection and cannot see `.instrument()` chained on multi-line async blocks. This is documented in `crates/theatron/.kanon-lint-ignore` lines 9-10 and 94-96. File-level suppressions are the correct workaround; inline `kanon:ignore` comments within `.instrument()`-bearing spawns are redundant noise.
- **5 of 7 issue locations were already fixed**: Items 1-3 (`agora/listener.rs`), item 4 (`agora/semeion/mod.rs`), and item 6 (`daemon/runner.rs`) all had `.instrument()` already present, presumably from prior PRs. Item 4 was listed as `daemon/src/semeion/mod.rs` but the file actually lives at `agora/src/semeion/mod.rs`.

## Test plan
- [x] `cargo test -p aletheia-oikonomos --lib -- watchdog` — all 18 watchdog tests pass
- [x] `cargo test -p theatron-tui` — all 1005 tests pass
- [x] `cargo test -p theatron-core` — all 92 tests pass
- [x] `cargo test --workspace` — full workspace green

🤖 Generated with [Claude Code](https://claude.com/claude-code)