### PR TITLE
fix(security): add explicit 0600 permissions to config/credential writes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,7 +33,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "aletheia-agora",
  "aletheia-dianoia",
@@ -83,7 +83,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-agora"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "aletheia-koina",
  "aletheia-taxis",
@@ -104,7 +104,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-dianoia"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "jiff",
  "prometheus",
@@ -118,7 +118,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-diaporeia"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "aletheia-koina",
  "aletheia-mneme",
@@ -141,7 +141,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-dokimion"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "aletheia-koina",
  "owo-colors",
@@ -160,7 +160,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-eidos"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "jiff",
  "serde",
@@ -169,7 +169,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-episteme"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "aletheia-eidos",
  "aletheia-graphe",
@@ -199,7 +199,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-graphe"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "aletheia-eidos",
  "aletheia-koina",
@@ -220,7 +220,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-hermeneus"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "aletheia-koina",
  "jiff",
@@ -242,7 +242,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-integration-tests"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "aletheia-dokimion",
  "aletheia-hermeneus",
@@ -268,7 +268,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-koina"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "compact_str",
  "jiff",
@@ -288,7 +288,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-krites"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "aho-corasick",
  "aletheia-eidos",
@@ -332,7 +332,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-melete"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "aletheia-hermeneus",
  "jiff",
@@ -347,7 +347,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-mneme"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "aletheia-eidos",
  "aletheia-episteme",
@@ -362,7 +362,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-nous"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "aletheia-dianoia",
  "aletheia-hermeneus",
@@ -390,7 +390,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-oikonomos"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "aletheia-koina",
  "chrono",
@@ -411,7 +411,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-organon"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "aletheia-hermeneus",
  "aletheia-koina",
@@ -438,7 +438,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-pylon"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "aletheia-hermeneus",
  "aletheia-koina",
@@ -472,7 +472,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-symbolon"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "aletheia-koina",
  "argon2",
@@ -497,7 +497,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-taxis"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "aletheia-koina",
  "base64 0.22.1",
@@ -515,7 +515,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-thesauros"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "aletheia-koina",
  "aletheia-organon",
@@ -5875,7 +5875,7 @@ dependencies = [
 
 [[package]]
 name = "theatron-core"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "aletheia-koina",
  "bytes",
@@ -5894,7 +5894,7 @@ dependencies = [
 
 [[package]]
 name = "theatron-tui"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "aletheia-koina",
  "arboard",

--- a/crates/dianoia/src/handoff.rs
+++ b/crates/dianoia/src/handoff.rs
@@ -158,6 +158,15 @@ impl HandoffFile {
             std::fs::write(&json_path, json).context(error::HandoffIoSnafu { path: &json_path })?;
             std::fs::write(&md_path, markdown).context(error::HandoffIoSnafu { path: &md_path })?;
         }
+        // WHY: restrict handoff files to owner-only (0600) — contain session context
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&json_path, std::fs::Permissions::from_mode(0o600))
+                .context(error::HandoffIoSnafu { path: &json_path })?;
+            std::fs::set_permissions(&md_path, std::fs::Permissions::from_mode(0o600))
+                .context(error::HandoffIoSnafu { path: &md_path })?;
+        }
 
         Ok(())
     }

--- a/crates/dianoia/src/workspace.rs
+++ b/crates/dianoia/src/workspace.rs
@@ -73,6 +73,15 @@ impl ProjectWorkspace {
         std::fs::write(&layout.project_file, json).context(error::WorkspaceIoSnafu {
             path: &layout.project_file,
         })?;
+        // WHY: restrict project JSON to owner-only (0600) — may contain config secrets
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&layout.project_file, std::fs::Permissions::from_mode(0o600))
+                .context(error::WorkspaceIoSnafu {
+                    path: &layout.project_file,
+                })?;
+        }
         Ok(())
     }
 
@@ -112,7 +121,14 @@ impl ProjectWorkspace {
             clippy::disallowed_methods,
             reason = "dianoia workspace writes are CLI-invoked blocking operations; tokio::fs would require an async context not available here"
         )]
-        std::fs::write(&path, content).context(error::WorkspaceIoSnafu { path })?;
+        std::fs::write(&path, content).context(error::WorkspaceIoSnafu { path: &path })?;
+        // WHY: restrict blocker files to owner-only (0600) — project-internal data
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))
+                .context(error::WorkspaceIoSnafu { path })?;
+        }
         Ok(())
     }
 

--- a/crates/theatron/tui/src/state/editor/tab.rs
+++ b/crates/theatron/tui/src/state/editor/tab.rs
@@ -64,6 +64,13 @@ impl EditorTab {
             content.push('\n');
         }
         std::fs::write(&self.path, &content).map_err(|e| format!("Save failed: {e}"))?;
+        // WHY: restrict saved files to owner-only (0600) — may contain sensitive content
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&self.path, std::fs::Permissions::from_mode(0o600))
+                .map_err(|e| format!("Failed to set permissions: {e}"))?;
+        }
         self.dirty = false;
         self.last_saved_at = Some(std::time::Instant::now());
         Ok(())

--- a/crates/theatron/tui/src/update/command.rs
+++ b/crates/theatron/tui/src/update/command.rs
@@ -584,6 +584,18 @@ fn execute_export(app: &mut App) {
     )]
     match std::fs::write(&path, &md) {
         Ok(()) => {
+            // WHY: restrict export files to owner-only (0600) — contain conversation data
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                if let Err(e) =
+                    std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))
+                {
+                    app.viewport.error_toast =
+                        Some(ErrorToast::new(format!("Failed to set permissions: {e}")));
+                    return;
+                }
+            }
             app.viewport.success_toast =
                 Some(ErrorToast::new(format!("Exported to {}", path.display())));
         }

--- a/crates/theatron/tui/src/update/editor.rs
+++ b/crates/theatron/tui/src/update/editor.rs
@@ -376,6 +376,18 @@ fn execute_new_file(app: &mut App, name: &str) {
 
     match std::fs::write(&new_path, "") {
         Ok(()) => {
+            // WHY: restrict new files to owner-only (0600) — default secure permissions
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                if let Err(e) =
+                    std::fs::set_permissions(&new_path, std::fs::Permissions::from_mode(0o600))
+                {
+                    app.viewport.error_toast =
+                        Some(ErrorToast::new(format!("Failed to set permissions: {e}")));
+                    return;
+                }
+            }
             app.layout.editor.tree.refresh();
             app.layout.editor.open_file(&new_path);
             app.viewport.success_toast = Some(ErrorToast::new(format!("Created {name}")));


### PR DESCRIPTION
## Summary
- Add `#[cfg(unix)] set_permissions(0o600)` after 6 file writes that were missing explicit permission restrictions
- Locations: `dianoia/workspace.rs` (project JSON + blocker files), `dianoia/handoff.rs` (context handoff JSON + markdown), `theatron/tui` editor save, session export, and new file creation
- Follows existing patterns from `tls.rs` and `taxis/loader.rs`
- The 7th location (`episteme/skill.rs`) was already fixed on main

Closes #2021

## Acceptance criteria
- [x] Issue #2021 requirements satisfied — all 7 `SECURITY/config-write-no-perms` violations addressed (6 fixed here, 1 pre-existing fix in `episteme/skill.rs`)
- [x] Tests pass for affected code (`aletheia-dianoia`, `aletheia-episteme`, `theatron-tui`)

## Observations
- **Already fixed**: `crates/episteme/src/skill.rs:478` already has `#[cfg(unix)] set_permissions(0o600)` on main — the issue was likely filed before that fix landed
- **Pattern divergence**: `tls.rs` uses `anyhow::Context` while `workspace.rs`/`handoff.rs` use `snafu::ResultExt::context` — both are correct for their respective crate error strategies

## Validation gate
- `cargo fmt --all -- --check` ✓
- `cargo clippy -p aletheia-dianoia -p aletheia-episteme -p theatron-tui --all-targets -- -D warnings` ✓
- `cargo test --workspace` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)