### PR TITLE
fix(pylon): convert sync-only planning tests from async to sync

### DIFF
--- a/crates/pylon/src/handlers/planning.rs
+++ b/crates/pylon/src/handlers/planning.rs
@@ -253,8 +253,8 @@ mod tests {
         assert_eq!(json["project_id"], "proj-456");
     }
 
-    #[tokio::test]
-    async fn verification_result_matches_desktop_shape() {
+    #[test]
+    fn verification_result_matches_desktop_shape() {
         // WHY: ensures the serialized JSON matches what the desktop
         // VerificationView component expects to deserialize.
         let result = VerificationResult {
@@ -283,8 +283,8 @@ mod tests {
         assert_eq!(json["requirements"][0]["evidence"][0]["label"], "CI run");
     }
 
-    #[tokio::test]
-    async fn all_status_variants_serialize_snake_case() {
+    #[test]
+    fn all_status_variants_serialize_snake_case() {
         let statuses = [
             (VerificationStatus::Verified, "verified"),
             (VerificationStatus::PartiallyVerified, "partially_verified"),
@@ -297,8 +297,8 @@ mod tests {
         }
     }
 
-    #[tokio::test]
-    async fn all_priority_variants_serialize_snake_case() {
+    #[test]
+    fn all_priority_variants_serialize_snake_case() {
         let priorities = [
             (RequirementPriority::P0, "p0"),
             (RequirementPriority::P1, "p1"),


### PR DESCRIPTION
## Summary
- Convert 3 planning verification tests from `#[tokio::test] async fn` to `#[test] fn` — they only perform synchronous serde operations and don't need a tokio runtime
- Corrective for PR #2048 (K-1673) where QA pre-screening failed due to a transient cargo file lock error preventing test completion

## Acceptance criteria
- [x] Tests pass for affected code (`aletheia-pylon`: 279 passed, `theatron-core`: 92 passed)

## Observations
- **Debt**: `Cargo.lock` on `main` has stale 0.13.4 versions for workspace crates despite `chore(main): release 0.13.5` having been merged. `cargo` auto-regenerates the lock file on build. A follow-up `chore: regenerate Cargo.lock` commit would fix this.
- **Types**: Pylon `planning.rs` still defines its own `Serialize`-only verification types that duplicate `theatron-core` canonical types. Consolidation blocked on pylon depending on `theatron-core` (existing observation from PR #2048).

## Validation gate
- `cargo fmt --all -- --check` ✓
- `cargo clippy --workspace --all-targets -- -D warnings` ✓
- `cargo test --workspace` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)