### PR TITLE
docs(prostheke): replace minimizer word with precise language

### DIFF
--- a/docs/design/prostheke-wasm.md
+++ b/docs/design/prostheke-wasm.md
@@ -165,7 +165,8 @@ against the current host version. Version mismatch is a load error with a clear 
 
 The original design implies plugins reloaded on file change (common in JS plugin hosts).
 WASM components instantiate from compiled artifacts. A `watch` mode that recompiles and
-reloads during development is not trivial.
+reloads during development requires a file watcher, a recompilation step, and runtime
+re-instantiation of the component.
 
 Minimum viable answer: reload on config reload (`SIGHUP` or `aletheia reload`), not on
 file change. Document the compile-test cycle for plugin authors.


### PR DESCRIPTION
## Summary
- Replace "is not trivial" with precise description of what hot-reload requires (file watcher, recompilation, runtime re-instantiation) in `docs/design/prostheke-wasm.md:168`
- Fixes kanon lint minimizer violation per WRITING.md standards

Closes #2078

## Acceptance criteria
- [x] Issue #2078 requirements satisfied: minimizer word replaced with precise wording
- [x] Tests pass for affected code (docs-only change, `cargo test --workspace` passes)

## Validation gate
- `cargo fmt --all -- --check` ✓
- `cargo clippy --workspace --all-targets -- -D warnings` ✓
- `cargo test --workspace` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)