### PR TITLE
fix(scripts): replace hardcoded /tmp path with XDG_STATE_HOME in health-monitor.sh

### DIFF
--- a/scripts/health-monitor.sh
+++ b/scripts/health-monitor.sh
@@ -8,7 +8,11 @@ set -euo pipefail
 #   scripts/health-monitor.sh --notify     # check, log, and send Signal on failure
 #
 # Cron example (every 5 minutes):
-#   */5 * * * * /path/to/scripts/health-monitor.sh --notify >> /tmp/aletheia-health.log 2>&1
+#   */5 * * * * /path/to/scripts/health-monitor.sh --notify >> "${XDG_STATE_HOME:-$HOME/.local/state}"/aletheia/health-monitor.log 2>&1
+
+# WARNING: Do not log to /tmp — world-writable paths are subject to symlink attacks.
+LOG_DIR="${ALETHEIA_LOG_DIR:-${XDG_STATE_HOME:-${HOME}/.local/state}/aletheia}"
+mkdir -p "$LOG_DIR"
 
 HEALTH_URL="${ALETHEIA_HEALTH_URL:-http://localhost:18789/api/health}"
 METRICS_URL="${ALETHEIA_METRICS_URL:-http://localhost:18789/metrics}"


### PR DESCRIPTION
## Summary
- Replace hardcoded `/tmp/aletheia-health.log` path in cron example comment with XDG_STATE_HOME-based path
- Add `LOG_DIR` variable using `ALETHEIA_LOG_DIR` env override or `${XDG_STATE_HOME:-$HOME/.local/state}/aletheia` default
- Add `mkdir -p` to ensure log directory exists at runtime
- Add WARNING comment documenting why /tmp must not be used

Closes #2069

## Acceptance criteria
- [x] Issue #2069 requirements satisfied — hardcoded /tmp path removed, replaced with user-specific XDG_STATE_HOME path
- [x] Tests pass for affected code — shell script syntax validates, workspace cargo test passes

## Observations
- **Debt**: The `LOG_DIR` variable is defined but not directly referenced by the script's own logging functions (which write to stdout). It exists for the cron redirect pattern and could be used by future structured logging.

## Validation gate
- `cargo fmt --all -- --check` ✓
- `cargo clippy --workspace --all-targets -- -D warnings` ✓
- `cargo test --workspace` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)