### PR TITLE
chore(deps): remove unused NCSA and OpenSSL license allowances

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -27,9 +27,7 @@ allow = [
     "0BSD",
     "MPL-2.0",              # option-ext, smartstring
     "LGPL-3.0-or-later",    # priority-queue
-    "NCSA",                 # libfuzzer-sys (transitive via rav1e)
     "CDLA-Permissive-2.0",  # webpki-roots, webpki-root-certs
-    "OpenSSL",              # ring (rustls crypto backend) includes OpenSSL-licensed code
 ]
 confidence-threshold = 0.8
 


### PR DESCRIPTION
## Summary
- Remove stale `NCSA` license allowance (was for libfuzzer-sys via rav1e, no longer in dependency tree)
- Remove stale `OpenSSL` license allowance (was for ring crypto backend, no longer encountered)

## Acceptance criteria
- [x] Issue #2077 requirements satisfied — both unused license allowances removed
- [x] `cargo deny check licenses` passes with zero warnings
- [x] Tests pass for affected code (`cargo test --workspace`)

## Validation gate
- `cargo fmt --all -- --check` ✓
- `cargo clippy --workspace --all-targets -- -D warnings` ✓
- `cargo test --workspace` ✓

Closes #2077

🤖 Generated with [Claude Code](https://claude.com/claude-code)