### PR TITLE
docs(general): fix performative language in voice-interaction research doc

### DIFF
--- a/.kanon-lint-ignore
+++ b/.kanon-lint-ignore
@@ -212,3 +212,8 @@ RUST/indexing-slicing:crates/nous/src/recall.rs
 # logic — all cohesive recall functionality. Splitting would fragment the
 # abstraction.
 RUST/file-too-long:crates/nous/src/recall.rs
+
+# WHY: SOUL.md line 57 uses "great question" as a negative example of what the
+# agent should NOT say. The linter detects the phrase as performative language
+# but cannot distinguish mention from use.
+WRITING/performative-language:instance.example/nous/_default/SOUL.md

--- a/planning/research/voice-interaction.md
+++ b/planning/research/voice-interaction.md
@@ -181,7 +181,7 @@ No production-ready TTS model exists in candle today. SpeechT5 and VITS implemen
 
 #### TTS recommendation
 
-**Phase 1:** No TTS. Text responses only. Voice is input-only. This is the fastest path and delivers the core value (hands-free interaction).
+**Phase 1:** No TTS. Text responses only. Voice is input-only. Skipping TTS halves the integration surface and still delivers hands-free interaction.
 
 **Phase 2:** Cloud TTS (ElevenLabs or Google) behind `voice-tts-cloud` feature gate. Best quality, least integration work.
 


### PR DESCRIPTION
## Summary
- Suppress false-positive `WRITING/performative-language` lint on `SOUL.md:57` via `.kanon-lint-ignore` (line mentions "great question" as a negative example, not actual performative use)
- Replace superlative "the fastest path" with concrete "Skipping TTS halves the integration surface" in `planning/research/voice-interaction.md:184`

## Acceptance criteria
- [x] Issue #2076 requirements satisfied (both findings resolved)
- [x] Tests pass for affected code (`cargo test --workspace` passes)

## Validation gate
- `cargo fmt --all -- --check` ✓
- `cargo clippy --workspace --all-targets -- -D warnings` ✓
- `cargo test --workspace` ✓

## Observations
- **Debt**: `Cargo.lock` is stale (references 0.13.7 while `Cargo.toml` files specify 0.13.8). Running any cargo command regenerates it. Not in scope for this PR.

Closes #2076