### PR TITLE
docs: replace em-dash characters with spaced hyphens

### DIFF
--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -25,8 +25,8 @@ sudo cp aletheia /usr/local/bin/
 ```
 
 The tarball extracts to `aletheia-${VERSION}/` and contains:
-- `aletheia` — the binary
-- `instance.example/` — reference config and directory layout for first-time setup
+- `aletheia` - the binary
+- `instance.example/` - reference config and directory layout for first-time setup
 
 Or build from source (requires Rust 1.94+):
 

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -524,12 +524,12 @@ journalctl --user -u aletheia --since "1 hour ago" | grep watchdog
 | Level | Message | Meaning |
 |-------|---------|---------|
 | INFO | `watchdog: registered process` | Process enrolled |
-| WARN | `watchdog: hung process detected — no heartbeat` | Timeout exceeded (includes `elapsed_secs`, `timeout_secs`) |
+| WARN | `watchdog: hung process detected - no heartbeat` | Timeout exceeded (includes `elapsed_secs`, `timeout_secs`) |
 | WARN | `watchdog: restarting process` | Restart initiated (includes `cause`, `attempt`) |
 | INFO | `watchdog: process restarted successfully` | Recovery succeeded |
-| INFO | `watchdog: process recovered — heartbeat received` | Process self-recovered before restart |
-| ERROR | `watchdog: restart failed — applying backoff` | Restart failed (includes `attempt`, `error`) |
-| ERROR | `watchdog: max restarts exceeded — abandoning process` | Process abandoned (includes `restart_count`, `max_restarts`) |
+| INFO | `watchdog: process recovered - heartbeat received` | Process self-recovered before restart |
+| ERROR | `watchdog: restart failed - applying backoff` | Restart failed (includes `attempt`, `error`) |
+| ERROR | `watchdog: max restarts exceeded - abandoning process` | Process abandoned (includes `restart_count`, `max_restarts`) |
 
 ### Restart backoff
 

--- a/docs/design/prostheke-wasm.md
+++ b/docs/design/prostheke-wasm.md
@@ -254,9 +254,9 @@ A reasonable initial limit: 50MB per WASM component. Configurable per plugin in
 
 ## See also
 
-- `crates/thesauros/` — current domain pack mechanism (`prostheke` extends this, not
+- `crates/thesauros/` - current domain pack mechanism (`prostheke` extends this, not
   replaces it)
-- `docs/PACKS.md` — domain pack reference
-- `docs/ARCHITECTURE.md` — M5 milestone context
-- `docs/PROJECT.md` — milestone map
+- `docs/PACKS.md` - domain pack reference
+- `docs/ARCHITECTURE.md` - M5 milestone context
+- `docs/PROJECT.md` - milestone map
 - Original design source: `git show 8ace85eb4^:docs/PLUGINS-DESIGN.md`


### PR DESCRIPTION
## Summary
- Replace 10 em-dash (—) characters with spaced hyphens (-) in three documentation files
- Fixes WRITING.md standard violation: "No em dashes"
- Files: `docs/QUICKSTART.md`, `docs/RUNBOOK.md`, `docs/design/prostheke-wasm.md`

Closes #2075

## Acceptance criteria
- [x] Issue #2075 requirements satisfied (all em-dash violations in listed files replaced)
- [x] Tests pass for affected code (`cargo test --workspace` passes)

## Observations
- **Count discrepancy**: Issue title says 12 violations but the listed locations contain 10 em-dash characters (2 + 4 + 4). All 10 found and fixed; no additional em-dashes exist in these files.
- **Debt**: `CHANGELOG.md` contains additional em-dashes in auto-generated release-please entries. These are outside the issue scope and modifying auto-generated changelog entries risks merge conflicts with release automation.

## Validation gate
- `cargo fmt --all -- --check` ✓
- `cargo clippy --workspace --all-targets -- -D warnings` ✓
- `cargo test --workspace` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)