### PR TITLE
docs(organon): fix inconsistent built-in tool count across docs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,7 +33,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia"
-version = "0.13.7"
+version = "0.13.10"
 dependencies = [
  "aletheia-agora",
  "aletheia-dianoia",
@@ -83,7 +83,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-agora"
-version = "0.13.7"
+version = "0.13.10"
 dependencies = [
  "aletheia-koina",
  "aletheia-taxis",
@@ -104,7 +104,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-dianoia"
-version = "0.13.7"
+version = "0.13.10"
 dependencies = [
  "jiff",
  "prometheus",
@@ -118,7 +118,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-diaporeia"
-version = "0.13.7"
+version = "0.13.10"
 dependencies = [
  "aletheia-koina",
  "aletheia-mneme",
@@ -141,7 +141,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-dokimion"
-version = "0.13.7"
+version = "0.13.10"
 dependencies = [
  "aletheia-koina",
  "owo-colors",
@@ -160,7 +160,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-eidos"
-version = "0.13.7"
+version = "0.13.10"
 dependencies = [
  "jiff",
  "serde",
@@ -169,7 +169,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-episteme"
-version = "0.13.7"
+version = "0.13.10"
 dependencies = [
  "aletheia-eidos",
  "aletheia-graphe",
@@ -199,7 +199,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-graphe"
-version = "0.13.7"
+version = "0.13.10"
 dependencies = [
  "aletheia-eidos",
  "aletheia-koina",
@@ -220,7 +220,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-hermeneus"
-version = "0.13.7"
+version = "0.13.10"
 dependencies = [
  "aletheia-koina",
  "jiff",
@@ -242,7 +242,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-integration-tests"
-version = "0.13.7"
+version = "0.13.10"
 dependencies = [
  "aletheia-dokimion",
  "aletheia-hermeneus",
@@ -268,7 +268,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-koina"
-version = "0.13.7"
+version = "0.13.10"
 dependencies = [
  "compact_str",
  "jiff",
@@ -288,7 +288,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-krites"
-version = "0.13.7"
+version = "0.13.10"
 dependencies = [
  "aho-corasick",
  "aletheia-eidos",
@@ -332,7 +332,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-melete"
-version = "0.13.7"
+version = "0.13.10"
 dependencies = [
  "aletheia-hermeneus",
  "jiff",
@@ -347,7 +347,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-mneme"
-version = "0.13.7"
+version = "0.13.10"
 dependencies = [
  "aletheia-eidos",
  "aletheia-episteme",
@@ -362,7 +362,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-nous"
-version = "0.13.7"
+version = "0.13.10"
 dependencies = [
  "aletheia-dianoia",
  "aletheia-hermeneus",
@@ -390,7 +390,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-oikonomos"
-version = "0.13.7"
+version = "0.13.10"
 dependencies = [
  "aletheia-koina",
  "chrono",
@@ -411,7 +411,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-organon"
-version = "0.13.7"
+version = "0.13.10"
 dependencies = [
  "aletheia-hermeneus",
  "aletheia-koina",
@@ -438,7 +438,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-pylon"
-version = "0.13.7"
+version = "0.13.10"
 dependencies = [
  "aletheia-hermeneus",
  "aletheia-koina",
@@ -472,7 +472,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-symbolon"
-version = "0.13.7"
+version = "0.13.10"
 dependencies = [
  "aletheia-koina",
  "argon2",
@@ -497,7 +497,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-taxis"
-version = "0.13.7"
+version = "0.13.10"
 dependencies = [
  "aletheia-koina",
  "base64 0.22.1",
@@ -515,7 +515,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-thesauros"
-version = "0.13.7"
+version = "0.13.10"
 dependencies = [
  "aletheia-koina",
  "aletheia-organon",
@@ -5875,7 +5875,7 @@ dependencies = [
 
 [[package]]
 name = "theatron-core"
-version = "0.13.7"
+version = "0.13.10"
 dependencies = [
  "aletheia-koina",
  "bytes",
@@ -5894,7 +5894,7 @@ dependencies = [
 
 [[package]]
 name = "theatron-tui"
-version = "0.13.7"
+version = "0.13.10"
 dependencies = [
  "aletheia-koina",
  "arboard",

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The tarball contains `instance.example/` with the reference config layout. See [
 
 - **Persistent memory.** Conversations carry forward. The agent builds a knowledge graph of facts, entities, and relationships that persists across sessions and grows over time.
 - **Multiple agents.** Each agent has its own character (SOUL.md), goals, memory, and workspace. They can coordinate, delegate, and specialize.
-- **Tools.** 39 built-in tools: file I/O, shell execution, web search, memory search, planning, agent coordination. Extend with domain packs or custom tools.
+- **Tools.** 38 built-in tools: file I/O, shell execution, web search, memory search, planning, agent coordination. Extend with domain packs or custom tools.
 - **Terminal dashboard.** Rich TUI with markdown rendering, session management, and real-time streaming.
 - **Signal messaging.** Talk to your agents over Signal with 15 built-in commands.
 - **Privacy.** No telemetry, no analytics, no phone-home. Only outbound connections are to services you configure.

--- a/crates/organon/CLAUDE.md
+++ b/crates/organon/CLAUDE.md
@@ -1,6 +1,6 @@
 # organon
 
-Tool registry, executors, and sandbox. 16K lines. 39 built-in tools.
+Tool registry, executors, and sandbox. 16K lines. 38 built-in tools.
 
 ## Read first
 
@@ -22,7 +22,7 @@ Tool registry, executors, and sandbox. 16K lines. 39 built-in tools.
 | `SandboxConfig` | `sandbox/mod.rs` | Landlock + seccomp + egress policy |
 | `ProcessGuard` | `process_guard.rs` | RAII child process wrapper, `pub(crate)` (prevents orphans/zombies) |
 
-## Built-in tools (39)
+## Built-in tools (38)
 
 | Category | Tools |
 |----------|-------|
@@ -33,9 +33,10 @@ Tool registry, executors, and sandbox. 16K lines. 39 built-in tools.
 | Communication | message, sessions_send, sessions_ask |
 | Agent | sessions_spawn, sessions_dispatch |
 | Enable Tool | enable_tool |
-| Planning | plan_create, plan_research, plan_requirements, plan_roadmap, plan_discuss, plan_execute, plan_verify, plan_status, plan_step_complete, plan_step_fail |
+| Planning | plan_create, plan_research, plan_requirements, plan_roadmap, plan_discuss, plan_execute, plan_verify, plan_status, plan_step_complete, plan_step_fail, plan_verify_criteria |
 | Research | web_fetch |
 | Triage | issue_scan, issue_triage, issue_approve |
+| Computer Use | computer_use (feature-gated: `computer-use`) |
 
 ## Patterns
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -26,7 +26,7 @@ aletheia
 │   ├── episteme   -  knowledge pipeline: extraction, recall, consolidation, embeddings
 │   └── krites     -  embedded Datalog engine + HNSW vectors (mneme-engine feature gate)
 ├── hermeneus      -  Anthropic client, model routing, credentials, provider trait
-├── organon        -  tool registry + 39 built-in tools
+├── organon        -  tool registry + 38 built-in tools
 ├── nous           -  agent pipeline, bootstrap, recall, finalize, actor model
 ├── dianoia        -  planning / project orchestration
 ├── pylon          -  Axum HTTP gateway, SSE streaming
@@ -119,7 +119,7 @@ The oikos hierarchy is described in [CONFIGURATION.md](CONFIGURATION.md).
 | `krites` | `crates/krites` | Embedded Datalog engine with HNSW and graph support | eidos |
 | `mneme` | `crates/mneme` | Thin facade re-exporting eidos, graphe, episteme, krites | eidos, graphe, episteme, krites |
 | `hermeneus` | `crates/hermeneus` | Anthropic client, model routing, credential management, provider trait | koina, taxis |
-| `organon` | `crates/organon` | Tool registry, tool definitions, 36 built-in tools, sandbox | koina, hermeneus |
+| `organon` | `crates/organon` | Tool registry, tool definitions, 38 built-in tools, sandbox | koina, hermeneus |
 | `symbolon` | `crates/symbolon` | JWT tokens, password hashing, RBAC policies | koina |
 | `melete` | `crates/melete` | Context distillation, compression strategies, token budget management | hermeneus |
 | `agora` | `crates/agora` | Channel registry, ChannelProvider trait, Signal JSON-RPC client | koina, taxis |


### PR DESCRIPTION
## Summary
- ARCHITECTURE.md table (line 122) said "36 built-in tools", tree diagram (line 29) said "39" -- both wrong
- Actual count from `registry.register()` calls: 37 unconditional + 1 feature-gated (`computer-use`) = **38 total**
- Updated all four doc locations (ARCHITECTURE.md x2, README.md, organon CLAUDE.md) to say 38
- Added missing `plan_verify_criteria` and `computer_use` to organon CLAUDE.md tool table

Closes #2066

## Acceptance criteria
- [x] Issue #2066 requirements are satisfied (ARCHITECTURE.md table and tree diagram now consistent and accurate)
- [x] Tests pass for affected code (docs-only change, `cargo test --workspace` passes)

## Observations
- **Drift risk**: tool counts in docs will drift again whenever tools are added/removed. No automated check exists to keep them in sync.

## Validation gate
- `cargo fmt --all -- --check` ✓
- `cargo clippy --workspace --all-targets -- -D warnings` ✓
- `cargo test --workspace` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)