### PR TITLE
docs: update hardcoded install version from v0.13.1 to v0.13.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ One binary. No containers. No external databases. No cloud dependencies beyond y
 Download the tarball from [releases](https://github.com/forkwright/aletheia/releases), extract, and run `init`:
 
 ```bash
-VERSION=v0.13.1
+VERSION=v0.13.11
 curl -L "https://github.com/forkwright/aletheia/releases/download/${VERSION}/aletheia-linux-x86_64-${VERSION}.tar.gz" \
   -o aletheia.tar.gz
 tar xzf aletheia.tar.gz

--- a/instance.example/nous/_default/MEMORY.md
+++ b/instance.example/nous/_default/MEMORY.md
@@ -6,7 +6,7 @@ Keep this file lean. If an entry is no longer relevant, delete it. If it belongs
 
 ## System
 
-- Runtime: Aletheia v0.13.1 (self-hosted, single binary, Rust)
+- Runtime: Aletheia v0.13.11 (self-hosted, single binary, Rust)
 - Source: https://github.com/forkwright/aletheia
 - Standing order: log bugs and improvements as issues on the repo
 - Config: instance/config/aletheia.toml (TOML, figment cascade)


### PR DESCRIPTION
## Summary
- Update hardcoded `VERSION=v0.13.1` in README.md install snippet to `v0.13.11`
- Update stale version reference in `instance.example/nous/_default/MEMORY.md`

Closes #2065

## Acceptance criteria
- [x] Issue #2065 requirements are satisfied (version updated from v0.13.1 to current v0.13.11)
- [x] Tests pass for affected code (`cargo test --workspace` clean)

## Observations
- **Debt**: The install snippet hardcodes a version that will go stale with each release. Consider a dynamic approach (e.g., linking to the releases page without a hardcoded version, or a `latest` redirect) to avoid recurring drift.
- **Debt**: `Cargo.lock` on main has crate versions at 0.13.10 despite the 0.13.11 release commit -- the release-please flow may not be regenerating the lockfile.

## Validation gate
- `cargo fmt --all -- --check` ✓
- `cargo clippy --workspace --all-targets -- -D warnings` ✓
- `cargo test --workspace` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)