### PR TITLE
audit(deps): document base64 and reqwest duplicate resolution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,7 +33,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia"
-version = "0.13.10"
+version = "0.13.11"
 dependencies = [
  "aletheia-agora",
  "aletheia-dianoia",
@@ -83,7 +83,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-agora"
-version = "0.13.10"
+version = "0.13.11"
 dependencies = [
  "aletheia-koina",
  "aletheia-taxis",
@@ -104,7 +104,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-dianoia"
-version = "0.13.10"
+version = "0.13.11"
 dependencies = [
  "jiff",
  "prometheus",
@@ -118,7 +118,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-diaporeia"
-version = "0.13.10"
+version = "0.13.11"
 dependencies = [
  "aletheia-koina",
  "aletheia-mneme",
@@ -141,7 +141,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-dokimion"
-version = "0.13.10"
+version = "0.13.11"
 dependencies = [
  "aletheia-koina",
  "owo-colors",
@@ -160,7 +160,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-eidos"
-version = "0.13.10"
+version = "0.13.11"
 dependencies = [
  "jiff",
  "serde",
@@ -169,7 +169,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-episteme"
-version = "0.13.10"
+version = "0.13.11"
 dependencies = [
  "aletheia-eidos",
  "aletheia-graphe",
@@ -199,7 +199,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-graphe"
-version = "0.13.10"
+version = "0.13.11"
 dependencies = [
  "aletheia-eidos",
  "aletheia-koina",
@@ -220,7 +220,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-hermeneus"
-version = "0.13.10"
+version = "0.13.11"
 dependencies = [
  "aletheia-koina",
  "jiff",
@@ -242,7 +242,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-integration-tests"
-version = "0.13.10"
+version = "0.13.11"
 dependencies = [
  "aletheia-dokimion",
  "aletheia-hermeneus",
@@ -268,7 +268,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-koina"
-version = "0.13.10"
+version = "0.13.11"
 dependencies = [
  "compact_str",
  "jiff",
@@ -288,7 +288,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-krites"
-version = "0.13.10"
+version = "0.13.11"
 dependencies = [
  "aho-corasick",
  "aletheia-eidos",
@@ -332,7 +332,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-melete"
-version = "0.13.10"
+version = "0.13.11"
 dependencies = [
  "aletheia-hermeneus",
  "jiff",
@@ -347,7 +347,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-mneme"
-version = "0.13.10"
+version = "0.13.11"
 dependencies = [
  "aletheia-eidos",
  "aletheia-episteme",
@@ -362,7 +362,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-nous"
-version = "0.13.10"
+version = "0.13.11"
 dependencies = [
  "aletheia-dianoia",
  "aletheia-hermeneus",
@@ -390,7 +390,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-oikonomos"
-version = "0.13.10"
+version = "0.13.11"
 dependencies = [
  "aletheia-koina",
  "chrono",
@@ -411,7 +411,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-organon"
-version = "0.13.10"
+version = "0.13.11"
 dependencies = [
  "aletheia-hermeneus",
  "aletheia-koina",
@@ -438,7 +438,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-pylon"
-version = "0.13.10"
+version = "0.13.11"
 dependencies = [
  "aletheia-hermeneus",
  "aletheia-koina",
@@ -472,7 +472,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-symbolon"
-version = "0.13.10"
+version = "0.13.11"
 dependencies = [
  "aletheia-koina",
  "argon2",
@@ -497,7 +497,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-taxis"
-version = "0.13.10"
+version = "0.13.11"
 dependencies = [
  "aletheia-koina",
  "base64 0.22.1",
@@ -515,7 +515,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-thesauros"
-version = "0.13.10"
+version = "0.13.11"
 dependencies = [
  "aletheia-koina",
  "aletheia-organon",
@@ -5875,7 +5875,7 @@ dependencies = [
 
 [[package]]
 name = "theatron-core"
-version = "0.13.10"
+version = "0.13.11"
 dependencies = [
  "aletheia-koina",
  "bytes",
@@ -5894,7 +5894,7 @@ dependencies = [
 
 [[package]]
 name = "theatron-tui"
-version = "0.13.10"
+version = "0.13.11"
 dependencies = [
  "aletheia-koina",
  "arboard",

--- a/crates/episteme/Cargo.toml
+++ b/crates/episteme/Cargo.toml
@@ -48,7 +48,8 @@ candle-transformers = { version = "=0.9.2", optional = true }
 tokenizers = { version = "0.22", optional = true, default-features = false, features = ["fancy-regex"] }
 # WHY: only "ureq" needed — code uses hf_hub::api::sync::Api (blocking).
 # The "tokio" feature pulled in reqwest 0.12 alongside workspace reqwest 0.13,
-# compiling two full HTTP client stacks. ureq handles TLS via its own rustls.
+# compiling two full HTTP client stacks. Switching to ureq resolved the reqwest
+# duplication (#2079). ureq handles TLS via its own rustls.
 hf-hub = { version = "0.5", optional = true, default-features = false, features = ["ureq"] }
 
 [dev-dependencies]

--- a/deny.toml
+++ b/deny.toml
@@ -34,6 +34,10 @@ confidence-threshold = 0.8
 [bans]
 multiple-versions = "warn"
 wildcards = "allow"
+# WHY: "pure Rust, no C++" — rustls replaces openssl across the workspace.
+deny = [
+    { crate = "openssl-sys", wrappers = [] },
+]
 
 # Skip entries for duplicates caused by upstream constraints we cannot resolve.
 # Each entry exempts the named version from the multiple-versions check.
@@ -81,8 +85,10 @@ skip = [
     { name = "windows_x86_64_msvc", version = "=0.42.2" },
     { name = "windows_x86_64_msvc", version = "=0.52.6" },
 
-    # WHY: spm_precompiled (via tokenizers/aletheia-episteme) pins base64 0.13.
-    # Blocked until tokenizers releases a version using base64 0.22+.
+    # WHY: spm_precompiled 0.1.4 (via tokenizers/aletheia-episteme) pins base64 0.13.
+    # spm_precompiled is unmaintained (last release 2022-05-30). Blocked until
+    # tokenizers replaces or forks spm_precompiled with a base64 0.22+ compatible
+    # version. Tracked in #2079.
     { name = "base64", version = "=0.13.1" },
 
     # WHY: older crypto crates (aes/sha family) pin cpufeatures 0.2.


### PR DESCRIPTION
## Summary
- Document base64 0.13 duplicate as blocked on unmaintained spm_precompiled (0.1.4, last release 2022-05-30) in deny.toml skip comment
- Cross-reference reqwest duplication resolution (hf-hub ureq backend) with #2079 in episteme Cargo.toml
- Add openssl-sys to deny.toml bans per RUST.md standard (pure Rust policy)
- Refresh stale Cargo.lock version entries (0.13.10 → 0.13.11)

## Acceptance criteria
- [x] Issue #2079 requirements are satisfied — base64 duplicate tracked with upstream blocker detail, reqwest duplicate documented as resolved
- [x] Tests pass for affected code — `cargo test --workspace` passes

## Audit findings

| Dependency | Status | Detail |
|-----------|--------|--------|
| reqwest | **Resolved** | hf-hub switched to ureq backend; only reqwest 0.13.2 in tree |
| base64 | **Blocked** | spm_precompiled 0.1.4 (unmaintained since 2022-05-30) pins base64 0.13 via tokenizers |

## Observations
- **Debt**: `Cargo.lock` on main was stale — version entries still showed 0.13.10 while workspace version is 0.13.11. Fixed incidentally by cargo resolution during this PR.
- **Debt**: deny.toml `[graph]` section lacks `targets = []` and `all-features = true` per RUST.md standard. Would catch target-conditional and feature-gated duplicates more thoroughly. Out of scope for this PR.

## Validation gate
- `cargo fmt --all -- --check` ✓
- `cargo clippy --workspace --all-targets -- -D warnings` ✓
- `cargo test --workspace` ✓
- `cargo deny check` ✓

Closes #2079

🤖 Generated with [Claude Code](https://claude.com/claude-code)