### PR TITLE
fix(fuzz): repair broken fuzz targets and add weekly CI workflow

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,0 +1,56 @@
+# WHY: Weekly fuzz runs catch parsing/deserialization crashes that unit
+# tests miss. Targets exercise user-controlled JSON surfaces, config
+# parsing, and knowledge store round-trips.
+name: Fuzz
+
+on:
+  schedule:
+    # NOTE: Saturday 04:00 CST (10:00 UTC), avoids overlap with CodeQL (Wednesday)
+    - cron: "0 10 * * 6"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  fuzz:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - fuzz_config_parsing
+          - fuzz_tool_dispatch
+          - fuzz_knowledge_roundtrip
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # nightly
+        with:
+          toolchain: nightly
+
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          workspaces: fuzz
+
+      - name: Install cargo-fuzz
+        run: cargo install cargo-fuzz --locked
+
+      - name: Run ${{ matrix.target }}
+        working-directory: fuzz
+        run: cargo +nightly fuzz run ${{ matrix.target }} -- -max_total_time=300
+
+      - name: Upload crash artifacts
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: fuzz-crashes-${{ matrix.target }}
+          path: fuzz/artifacts/
+          retention-days: 30
+          if-no-files-found: ignore

--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -11,3 +11,8 @@ Cargo.lock
 /coverage/
 *.profraw
 *.profdata
+
+# WHY: libFuzzer generates hash-named corpus entries during runs.
+# Seed files (corpus/*/seed_*) are hand-crafted and tracked in git.
+# Generated entries match [0-9a-f]{40} — this pattern catches them.
+/corpus/*/[0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]*

--- a/fuzz/fuzz_targets/fuzz_knowledge_roundtrip.rs
+++ b/fuzz/fuzz_targets/fuzz_knowledge_roundtrip.rs
@@ -11,8 +11,10 @@ use std::sync::LazyLock;
 
 use libfuzzer_sys::fuzz_target;
 
+use aletheia_mneme::id::FactId;
 use aletheia_mneme::knowledge::{
-    EpistemicTier, Fact, FactType, ForgetReason, far_future, format_timestamp, parse_timestamp,
+    EpistemicTier, Fact, FactAccess, FactLifecycle, FactProvenance, FactTemporal, FactType,
+    ForgetReason, far_future, format_timestamp, parse_timestamp,
 };
 use aletheia_mneme::knowledge_store::KnowledgeStore;
 
@@ -106,24 +108,34 @@ fuzz_target!(|data: &[u8]| {
     };
 
     let now = jiff::Timestamp::now();
+    // WHY: FactId::new returns Result; skip iteration if ID is somehow invalid.
+    let Ok(id) = FactId::new(fact_id) else { return };
     let fact = Fact {
-        id: fact_id.as_str().into(),
+        id,
         nous_id: "fuzz-agent".to_owned(),
-        content: content.to_string(),
-        confidence,
-        tier,
-        valid_from: now,
-        valid_to: far_future(),
-        superseded_by: None,
-        source_session_id: None,
-        recorded_at: now,
-        access_count: 0,
-        last_accessed_at: None,
-        stability_hours: fact_type.base_stability_hours(),
         fact_type: fact_type.as_str().to_owned(),
-        is_forgotten: false,
-        forgotten_at: None,
-        forget_reason: None,
+        content: content.to_string(),
+        temporal: FactTemporal {
+            valid_from: now,
+            valid_to: far_future(),
+            recorded_at: now,
+        },
+        provenance: FactProvenance {
+            confidence,
+            tier,
+            source_session_id: None,
+            stability_hours: fact_type.base_stability_hours(),
+        },
+        lifecycle: FactLifecycle {
+            superseded_by: None,
+            is_forgotten: false,
+            forgotten_at: None,
+            forget_reason: None,
+        },
+        access: FactAccess {
+            access_count: 0,
+            last_accessed_at: None,
+        },
     };
 
     // Insert and read back.

--- a/fuzz/fuzz_targets/fuzz_tool_dispatch.rs
+++ b/fuzz/fuzz_targets/fuzz_tool_dispatch.rs
@@ -49,7 +49,9 @@ fuzz_target!(|data: &[u8]| {
                     let mid = part.floor_char_boundary((part.len() / 2).max(1));
                     if mid > 0 && mid < part.len() {
                         let (name, hash) = part.split_at(mid);
-                        let _ = detector.record(name, hash);
+                        // WHY: is_error derived from byte to exercise both paths.
+                        let is_error = mid % 2 == 0;
+                        let _ = detector.record(name, hash, is_error);
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- Fix two broken fuzz targets: `fuzz_knowledge_roundtrip` (Fact struct refactored to composition with FactTemporal/FactProvenance/FactLifecycle/FactAccess, FactId no longer From<&str>) and `fuzz_tool_dispatch` (LoopDetector::record gained third `is_error` parameter)
- Add `.github/workflows/fuzz.yml` — weekly Saturday schedule running all 3 targets for 300s each with crash artifact upload on failure
- Fix `fuzz/.gitignore` to exclude auto-generated corpus entries (hash-named files) while keeping hand-crafted seeds

## Acceptance criteria
- [x] Issue #2073 requirements are satisfied: nightly repaired, fuzz targets runnable, all 3 targets exercised, CI workflow added
- [x] Tests pass for affected code — all workspace tests pass, all 3 fuzz targets compile and run without crashes

## Verification
- `fuzz_config_parsing`: 79,919 runs in 61s — no crashes
- `fuzz_tool_dispatch`: 33,270 runs in 31s — no crashes
- `fuzz_knowledge_roundtrip`: 639 runs in 31s — no crashes

## Observations
- **Debt**: `fuzz/README.md` claims "Generated corpus entries are gitignored via the parent `.gitignore`" but this was false — only `fuzz/target/`, `fuzz/artifacts/`, and `fuzz/Cargo.lock` were ignored. Fixed in this PR via `fuzz/.gitignore`.
- **Debt**: The prompt blast radius listed `crates/general/` which does not exist. Actual changes are in `fuzz/` and `.github/workflows/`.
- **Flaky tests**: `theatron-tui` has 3 intermittently failing markdown link rendering tests (`link_appends_url_after_display_text`, `link_url_uses_dim_foreground_color`, `link_renders_with_url_visible`) that fail during `cargo test --workspace` but pass in isolation. Pre-existing, not introduced by this PR.

## Validation gate
- `cargo fmt --all -- --check` ✓
- `cargo clippy --workspace --all-targets -- -D warnings` ✓
- `cargo test --workspace` ✓

Closes #2073

🤖 Generated with [Claude Code](https://claude.com/claude-code)