### PR TITLE
docs(theatron): add umbrella CLAUDE.md for presentation crate group

### DIFF
--- a/crates/theatron/CLAUDE.md
+++ b/crates/theatron/CLAUDE.md
@@ -1,0 +1,55 @@
+# theatron
+
+Presentation umbrella grouping the three UI crates: core (shared infrastructure), tui (terminal), desktop (Dioxus). 86K lines total.
+
+## Sub-crates
+
+| Crate | Path | Lines | Purpose |
+|-------|------|-------|---------|
+| `theatron-core` | `core/` | 3K | Shared API client, types, SSE parser, streaming infrastructure |
+| `theatron-tui` | `tui/` | 37K | Ratatui terminal dashboard (Elm architecture, feature-gated in workspace) |
+| `theatron-desktop` | `desktop/` | 45K | Dioxus desktop app (excluded from workspace, GTK deps) |
+
+## Dependency graph
+
+```
+theatron-core          (leaf: koina, reqwest, tokio)
+    ^           ^
+    |           |
+theatron-tui    theatron-desktop
+```
+
+Both UI crates depend on `theatron-core` for API client, domain types, and SSE infrastructure. They never depend on each other.
+
+## Shared infrastructure (core)
+
+- **ApiClient**: HTTP client for the pylon REST API (agents, sessions, history, auth, costs, streaming)
+- **Domain IDs**: NousId, SessionId, TurnId, ToolId, PlanId newtypes
+- **StreamEvent**: Per-turn streaming events (text deltas, tool calls, plan steps)
+- **SseEvent / SseStream**: Wire-level SSE parser for reqwest byte streams
+
+## Workspace status
+
+| Crate | In workspace | Reason |
+|-------|-------------|--------|
+| `theatron-core` | yes | Pure Rust deps |
+| `theatron-tui` | yes | Feature-gated (`tui` feature on aletheia binary) |
+| `theatron-desktop` | no | GTK/webkit2gtk system deps break CI |
+
+## Where to make changes
+
+| Task | Sub-crate |
+|------|-----------|
+| Add API endpoint binding | `core` (ApiClient method + request/response types) |
+| Add stream event type | `core` (StreamEvent enum + streaming parser) |
+| Add domain ID newtype | `core` (id.rs) |
+| Add TUI view | `tui` (view module + View enum + state + Msg handler) |
+| Add TUI keybinding | `tui` (keybindings.rs + mapping.rs) |
+| Add desktop view/route | `desktop` (Route enum + view module + sidebar nav) |
+| Add desktop component | `desktop` (components module) |
+| Add desktop state domain | `desktop` (state module) |
+
+## Dependencies
+
+Uses: koina, reqwest, tokio, snafu, ratatui, crossterm, dioxus
+Used by: aletheia (binary, tui feature-gated), theatron-desktop (standalone binary)


### PR DESCRIPTION
## Summary
- Add `crates/theatron/CLAUDE.md` documenting the umbrella directory structure
- Covers sub-crate relationships (core, tui, desktop), dependency graph, shared infrastructure, workspace status, and where-to-change guidance
- Follows the same format as other per-crate CLAUDE.md files (e.g., mneme, agora)

Closes #2070

## Acceptance criteria
- [x] Issue #2070 requirements satisfied: umbrella CLAUDE.md explains structure, sub-crates, relationships, shared API client/type infrastructure
- [x] Tests pass for affected code (docs-only change, no code affected)

## Observations
- **Debt** (`crates/theatron/desktop`): `AgentStore::load_agents` is defined but never called from production code — requires a fetch coroutine wiring
- **Debt** (`crates/theatron/desktop`): `PylonClient::raw_client` and `SseConnection.cancel` are dead code

## Validation gate
- `cargo fmt --all -- --check` ✓
- `cargo clippy --workspace --all-targets -- -D warnings` ✓
- `cargo test --workspace` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)