### PR TITLE
refactor(aletheia): confine anyhow to main.rs, convert commands to snafu

### DIFF
--- a/crates/aletheia/src/commands/add_nous.rs
+++ b/crates/aletheia/src/commands/add_nous.rs
@@ -2,8 +2,10 @@
 
 use std::path::PathBuf;
 
-use anyhow::{Context, Result, bail};
 use clap::Args;
+use snafu::prelude::*;
+
+use crate::error::Result;
 
 use aletheia_taxis::oikos::Oikos;
 
@@ -32,7 +34,7 @@ pub(crate) async fn run(instance_root: Option<&PathBuf>, args: &AddNousArgs) -> 
 
     let nous_dir = oikos.nous_dir(&args.name);
     if nous_dir.exists() {
-        bail!(
+        whatever!(
             "nous directory already exists: {}\nRemove it first if you want to recreate this agent.",
             nous_dir.display()
         );
@@ -50,13 +52,13 @@ pub(crate) async fn run(instance_root: Option<&PathBuf>, args: &AddNousArgs) -> 
 
 fn validate_name(name: &str) -> Result<()> {
     if name.is_empty() {
-        bail!("agent name cannot be empty");
+        whatever!("agent name cannot be empty");
     }
     if !name.chars().all(|c| c.is_ascii_alphanumeric() || c == '-') {
-        bail!("agent name must contain only alphanumeric characters and hyphens");
+        whatever!("agent name must contain only alphanumeric characters and hyphens");
     }
     if name.starts_with('-') || name.ends_with('-') {
-        bail!("agent name cannot start or end with a hyphen");
+        whatever!("agent name cannot start or end with a hyphen");
     }
     Ok(())
 }
@@ -64,7 +66,7 @@ fn validate_name(name: &str) -> Result<()> {
 fn validate_provider(provider: &str) -> Result<()> {
     match provider {
         "anthropic" | "openai" => Ok(()),
-        other => bail!("unsupported provider: {other}\nSupported providers: anthropic, openai"),
+        other => whatever!("unsupported provider: {other}\nSupported providers: anthropic, openai"),
     }
 }
 
@@ -110,7 +112,7 @@ fn scaffold_directory(oikos: &Oikos, args: &AddNousArgs) -> Result<()> {
 
     for dir in &subdirs {
         std::fs::create_dir_all(dir)
-            .with_context(|| format!("failed to create directory: {}", dir.display()))?;
+            .with_whatever_context(|_| format!("failed to create directory: {}", dir.display()))?;
     }
 
     write_file(
@@ -171,14 +173,14 @@ fn update_config(oikos: &Oikos, args: &AddNousArgs) -> Result<()> {
 
     let existing = if config_path.exists() {
         std::fs::read_to_string(&config_path)
-            .with_context(|| format!("failed to read {}", config_path.display()))?
+            .with_whatever_context(|_| format!("failed to read {}", config_path.display()))?
     } else {
         String::new()
     };
 
     let mut doc: toml_edit::DocumentMut = existing
         .parse()
-        .with_context(|| format!("failed to parse {}", config_path.display()))?;
+        .with_whatever_context(|_| format!("failed to parse {}", config_path.display()))?;
 
     let already_listed = doc
         .get("agents")
@@ -191,7 +193,7 @@ fn update_config(oikos: &Oikos, args: &AddNousArgs) -> Result<()> {
         });
 
     if already_listed {
-        bail!(
+        whatever!(
             "agent '{}' already exists in the configuration file.\n\
              Remove the existing entry first, or choose a different name.",
             args.name
@@ -224,7 +226,7 @@ fn update_config(oikos: &Oikos, args: &AddNousArgs) -> Result<()> {
     )]
     let agents = doc["agents"]
         .as_table_mut()
-        .ok_or_else(|| anyhow::anyhow!("[agents] in config is not a table"))?;
+        .ok_or_else(|| crate::error::Error::msg("[agents] in config is not a table"))?;
 
     if agents
         .get("list")
@@ -237,24 +239,24 @@ fn update_config(oikos: &Oikos, args: &AddNousArgs) -> Result<()> {
         );
     }
 
-    let list = agents["list"]
-        .as_array_of_tables_mut()
-        .ok_or_else(|| anyhow::anyhow!("agents.list in config is not an array of tables"))?;
+    let list = agents["list"].as_array_of_tables_mut().ok_or_else(|| {
+        crate::error::Error::msg("agents.list in config is not an array of tables")
+    })?;
 
     list.push(entry);
 
     // WHY: atomic write: write to .tmp then rename, preserving existing comments in the file
     std::fs::create_dir_all(&config_dir)
-        .with_context(|| format!("failed to create {}", config_dir.display()))?;
+        .with_whatever_context(|_| format!("failed to create {}", config_dir.display()))?;
     let tmp = config_dir.join("aletheia.toml.tmp");
     #[expect(
         clippy::disallowed_methods,
         reason = "aletheia CLI commands use synchronous filesystem operations for config and certificate generation"
     )]
     std::fs::write(&tmp, doc.to_string())
-        .with_context(|| format!("failed to write {}", tmp.display()))?;
+        .with_whatever_context(|_| format!("failed to write {}", tmp.display()))?;
     std::fs::rename(&tmp, &config_path)
-        .with_context(|| format!("failed to rename {}", tmp.display()))?;
+        .with_whatever_context(|_| format!("failed to rename {}", tmp.display()))?;
 
     Ok(())
 }
@@ -299,7 +301,8 @@ fn write_file(path: &std::path::Path, content: &str) -> Result<()> {
         clippy::disallowed_methods,
         reason = "aletheia CLI commands use synchronous filesystem operations for config and certificate generation"
     )]
-    std::fs::write(path, content).with_context(|| format!("failed to write: {}", path.display()))
+    std::fs::write(path, content)
+        .with_whatever_context(|_| format!("failed to write: {}", path.display()))
 }
 
 fn capitalize(s: &str) -> String {

--- a/crates/aletheia/src/commands/agent_io.rs
+++ b/crates/aletheia/src/commands/agent_io.rs
@@ -2,8 +2,10 @@
 
 use std::path::PathBuf;
 
-use anyhow::{Context, Result};
 use clap::Args;
+use snafu::prelude::*;
+
+use crate::error::Result;
 
 #[derive(Debug, Clone, Args)]
 pub(crate) struct ExportArgs {
@@ -172,12 +174,13 @@ pub(crate) fn export_agent(instance_root: Option<&PathBuf>, args: &ExportArgs) -
         Some(root) => Oikos::from_root(root),
         None => Oikos::discover(),
     };
-    let config = load_config(&oikos).context("failed to load config")?;
+    let config = load_config(&oikos).whatever_context("failed to load config")?;
     let resolved = resolve_nous(&config, nous_id);
 
     let db_path = oikos.sessions_db();
-    let store = SessionStore::open(&db_path)
-        .with_context(|| format!("failed to open session store at {}", db_path.display()))?;
+    let store = SessionStore::open(&db_path).with_whatever_context(|_| {
+        format!("failed to open session store at {}", db_path.display())
+    })?;
 
     let workspace_path = oikos.nous_dir(nous_id);
 
@@ -206,7 +209,7 @@ pub(crate) fn export_agent(instance_root: Option<&PathBuf>, args: &ExportArgs) -
         &workspace_path,
         &opts,
     )
-    .context("export failed")?;
+    .whatever_context("export failed")?;
 
     let output_path = args.output.clone().unwrap_or_else(|| {
         let date = jiff::Timestamp::now().strftime("%Y-%m-%d").to_string();
@@ -214,23 +217,23 @@ pub(crate) fn export_agent(instance_root: Option<&PathBuf>, args: &ExportArgs) -
     });
 
     if output_path.exists() && !args.force {
-        anyhow::bail!(
+        whatever!(
             "output file already exists: {}\nUse --force to overwrite.",
             output_path.display()
         );
     }
 
     let json = if args.compact {
-        serde_json::to_string(&agent_file)?
+        serde_json::to_string(&agent_file).whatever_context("failed to serialize agent")?
     } else {
-        serde_json::to_string_pretty(&agent_file)?
+        serde_json::to_string_pretty(&agent_file).whatever_context("failed to serialize agent")?
     };
     #[expect(
         clippy::disallowed_methods,
         reason = "aletheia CLI commands use synchronous filesystem operations for config and certificate generation"
     )]
     std::fs::write(&output_path, &json)
-        .with_context(|| format!("failed to write {}", output_path.display()))?;
+        .with_whatever_context(|_| format!("failed to write {}", output_path.display()))?;
 
     println!("Exported to: {}", output_path.display());
     println!("Size: {} bytes", json.len());
@@ -246,9 +249,9 @@ pub(crate) fn export_agent(instance_root: Option<&PathBuf>, args: &ExportArgs) -
 
 pub(crate) fn import_agent(instance_root: Option<&PathBuf>, args: &ImportArgs) -> Result<()> {
     let json = std::fs::read_to_string(&args.file)
-        .with_context(|| format!("failed to read {}", args.file.display()))?;
+        .with_whatever_context(|_| format!("failed to read {}", args.file.display()))?;
     let agent_file: aletheia_mneme::portability::AgentFile =
-        serde_json::from_str(&json).context("failed to parse agent file")?;
+        serde_json::from_str(&json).whatever_context("failed to parse agent file")?;
 
     let nous_id = args.target_id.as_deref().unwrap_or(&agent_file.nous.id);
 
@@ -287,14 +290,16 @@ pub(crate) fn import_agent(instance_root: Option<&PathBuf>, args: &ImportArgs) -
     let db_path = oikos.sessions_db();
     if let Some(parent) = db_path.parent() {
         std::fs::create_dir_all(parent)
-            .with_context(|| format!("failed to create data dir {}", parent.display()))?;
+            .with_whatever_context(|_| format!("failed to create data dir {}", parent.display()))?;
     }
-    let store = SessionStore::open(&db_path)
-        .with_context(|| format!("failed to open session store at {}", db_path.display()))?;
+    let store = SessionStore::open(&db_path).with_whatever_context(|_| {
+        format!("failed to open session store at {}", db_path.display())
+    })?;
 
     let workspace_path = oikos.nous_dir(nous_id);
-    std::fs::create_dir_all(&workspace_path)
-        .with_context(|| format!("failed to create workspace {}", workspace_path.display()))?;
+    std::fs::create_dir_all(&workspace_path).with_whatever_context(|_| {
+        format!("failed to create workspace {}", workspace_path.display())
+    })?;
 
     let opts = aletheia_mneme::import::ImportOptions {
         skip_sessions: args.skip_sessions,
@@ -305,7 +310,7 @@ pub(crate) fn import_agent(instance_root: Option<&PathBuf>, args: &ImportArgs) -
     let id_gen = || ulid::Ulid::new().to_string();
     let result =
         aletheia_mneme::import::import_agent(&agent_file, &store, &workspace_path, &id_gen, &opts)
-            .context("import failed")?;
+            .whatever_context("import failed")?;
 
     println!("Imported agent: {}", result.nous_id);
     println!("Files restored: {}", result.files_restored);
@@ -326,7 +331,7 @@ pub(crate) fn seed_skills(args: &SeedSkillsArgs) -> Result<()> {
     let dir = &args.dir;
     let nous_id = &args.nous_id;
     let entries = scan_skill_dir(dir)
-        .with_context(|| format!("failed to scan skill directory: {}", dir.display()))?;
+        .with_whatever_context(|_| format!("failed to scan skill directory: {}", dir.display()))?;
 
     if entries.is_empty() {
         println!("No SKILL.md files found in {}", dir.display());
@@ -374,8 +379,8 @@ pub(crate) fn seed_skills(args: &SeedSkillsArgs) -> Result<()> {
         };
         use aletheia_mneme::knowledge_store::KnowledgeStore;
 
-        let store = KnowledgeStore::open_mem()
-            .map_err(|e| anyhow::anyhow!("failed to open knowledge store: {e}"))?;
+        let store =
+            KnowledgeStore::open_mem().whatever_context("failed to open knowledge store")?;
 
         let now = jiff::Timestamp::now();
         let mut seeded = 0u32;
@@ -385,12 +390,13 @@ pub(crate) fn seed_skills(args: &SeedSkillsArgs) -> Result<()> {
         for (slug, skill) in &parsed {
             let existing = store
                 .find_skill_by_name(nous_id, &skill.name)
-                .map_err(|e| anyhow::anyhow!("failed to query existing skills: {e}"))?;
+                .whatever_context("failed to query existing skills")?;
 
             if let Some(existing_id) = existing {
                 if args.force {
                     if let Err(e) = store.forget_fact(
-                        &aletheia_mneme::id::FactId::new(existing_id)?,
+                        &aletheia_mneme::id::FactId::new(existing_id)
+                            .whatever_context("invalid fact id")?,
                         aletheia_mneme::knowledge::ForgetReason::Outdated,
                     ) {
                         eprintln!("  WARN: failed to supersede {slug}: {e}");
@@ -404,11 +410,12 @@ pub(crate) fn seed_skills(args: &SeedSkillsArgs) -> Result<()> {
             }
 
             let content_json = serde_json::to_string(skill)
-                .with_context(|| format!("failed to serialize skill: {slug}"))?;
+                .with_whatever_context(|_| format!("failed to serialize skill: {slug}"))?;
 
             let fact_id = ulid::Ulid::new().to_string();
             let fact = Fact {
-                id: aletheia_mneme::id::FactId::new(fact_id.clone())?,
+                id: aletheia_mneme::id::FactId::new(fact_id.clone())
+                    .whatever_context("invalid fact id")?,
                 nous_id: nous_id.to_owned(),
                 content: content_json.clone(),
                 fact_type: "skill".to_owned(),
@@ -437,12 +444,13 @@ pub(crate) fn seed_skills(args: &SeedSkillsArgs) -> Result<()> {
 
             store
                 .insert_fact(&fact)
-                .map_err(|e| anyhow::anyhow!("failed to insert skill {slug}: {e}"))?;
+                .with_whatever_context(|_| format!("failed to insert skill {slug}"))?;
 
             let embedding_text = format!("{}: {}", skill.name, skill.description);
             let emb_id = ulid::Ulid::new().to_string();
             let chunk = aletheia_mneme::knowledge::EmbeddedChunk {
-                id: aletheia_mneme::id::EmbeddingId::new(emb_id)?,
+                id: aletheia_mneme::id::EmbeddingId::new(emb_id)
+                    .whatever_context("invalid embedding id")?,
                 content: embedding_text,
                 source_type: "fact".to_owned(),
                 source_id: fact_id,
@@ -468,7 +476,7 @@ pub(crate) fn seed_skills(args: &SeedSkillsArgs) -> Result<()> {
     #[cfg(not(feature = "recall"))]
     {
         let _ = (args, nous_id, parsed, parse_errors);
-        anyhow::bail!(
+        whatever!(
             "seed-skills requires the 'recall' feature (KnowledgeStore). \
              Build with: cargo build --features recall"
         );
@@ -495,17 +503,18 @@ pub(crate) fn export_skills(
         let knowledge_path = oikos.knowledge_db();
 
         let config = aletheia_mneme::knowledge_store::KnowledgeConfig::default();
-        let store = KnowledgeStore::open_fjall(&knowledge_path, config).map_err(|e| {
-            anyhow::anyhow!(
-                "failed to open knowledge store at {}: {e}",
-                knowledge_path.display()
-            )
-        })?;
+        let store =
+            KnowledgeStore::open_fjall(&knowledge_path, config).with_whatever_context(|_| {
+                format!(
+                    "failed to open knowledge store at {}",
+                    knowledge_path.display()
+                )
+            })?;
 
         let nous_id = &args.nous_id;
         let facts = store
             .find_skills_for_nous(nous_id, 500)
-            .map_err(|e| anyhow::anyhow!("failed to query skills: {e}"))?;
+            .whatever_context("failed to query skills")?;
 
         if facts.is_empty() {
             println!("No skills found for nous '{nous_id}'");
@@ -536,8 +545,10 @@ pub(crate) fn export_skills(
         };
 
         let output = &args.output;
-        let exported = export_skills_to_cc(&skills, output, filter)
-            .with_context(|| format!("failed to export skills to {}", output.display()))?;
+        let exported =
+            export_skills_to_cc(&skills, output, filter).with_whatever_context(|_| {
+                format!("failed to export skills to {}", output.display())
+            })?;
 
         println!(
             "Exported {} skill(s) to {}",
@@ -557,7 +568,7 @@ pub(crate) fn export_skills(
     #[cfg(not(feature = "recall"))]
     {
         let _ = (instance_root, args);
-        anyhow::bail!(
+        whatever!(
             "export-skills requires the 'recall' feature (KnowledgeStore). \
              Build with: cargo build --features recall"
         );
@@ -580,19 +591,20 @@ pub(crate) fn review_skills(
         let knowledge_path = oikos.knowledge_db();
 
         let config = aletheia_mneme::knowledge_store::KnowledgeConfig::default();
-        let store = KnowledgeStore::open_fjall(&knowledge_path, config).map_err(|e| {
-            anyhow::anyhow!(
-                "failed to open knowledge store at {}: {e}",
-                knowledge_path.display()
-            )
-        })?;
+        let store =
+            KnowledgeStore::open_fjall(&knowledge_path, config).with_whatever_context(|_| {
+                format!(
+                    "failed to open knowledge store at {}",
+                    knowledge_path.display()
+                )
+            })?;
 
         let nous_id = &args.nous_id;
         match args.action.as_str() {
             "list" => {
                 let pending = store
                     .find_pending_skills(nous_id)
-                    .map_err(|e| anyhow::anyhow!("failed to query pending skills: {e}"))?;
+                    .whatever_context("failed to query pending skills")?;
 
                 if pending.is_empty() {
                     println!("No pending skills for nous '{nous_id}'");
@@ -627,29 +639,29 @@ pub(crate) fn review_skills(
                 }
             }
             "approve" => {
-                let fid = args
-                    .fact_id
-                    .as_deref()
-                    .ok_or_else(|| anyhow::anyhow!("--fact-id required for approve action"))?;
-                let fact_id = aletheia_mneme::id::FactId::new(fid)?;
+                let fid = args.fact_id.as_deref().ok_or_else(|| {
+                    crate::error::Error::msg("--fact-id required for approve action")
+                })?;
+                let fact_id =
+                    aletheia_mneme::id::FactId::new(fid).whatever_context("invalid fact id")?;
                 let new_id = store
                     .approve_pending_skill(&fact_id, nous_id)
-                    .map_err(|e| anyhow::anyhow!("failed to approve skill: {e}"))?;
+                    .whatever_context("failed to approve skill")?;
                 println!("Approved: {fid} → new skill fact: {new_id}");
             }
             "reject" => {
-                let fid = args
-                    .fact_id
-                    .as_deref()
-                    .ok_or_else(|| anyhow::anyhow!("--fact-id required for reject action"))?;
-                let fact_id = aletheia_mneme::id::FactId::new(fid)?;
+                let fid = args.fact_id.as_deref().ok_or_else(|| {
+                    crate::error::Error::msg("--fact-id required for reject action")
+                })?;
+                let fact_id =
+                    aletheia_mneme::id::FactId::new(fid).whatever_context("invalid fact id")?;
                 store
                     .reject_pending_skill(&fact_id)
-                    .map_err(|e| anyhow::anyhow!("failed to reject skill: {e}"))?;
+                    .whatever_context("failed to reject skill")?;
                 println!("Rejected: {fid}");
             }
             other => {
-                anyhow::bail!("unknown action '{other}'. Use: list, approve, reject");
+                whatever!("unknown action '{other}'. Use: list, approve, reject");
             }
         }
 
@@ -659,7 +671,7 @@ pub(crate) fn review_skills(
     #[cfg(not(feature = "recall"))]
     {
         let _ = (instance_root, args);
-        anyhow::bail!(
+        whatever!(
             "review-skills requires the 'recall' feature (KnowledgeStore). \
              Build with: cargo build --features recall"
         );
@@ -689,7 +701,7 @@ pub(crate) async fn migrate_memory(
     #[cfg(not(feature = "migrate-qdrant"))]
     {
         let _ = (instance_root, args);
-        anyhow::bail!(
+        whatever!(
             "migrate-memory requires the `migrate-qdrant` feature.\n\
              Rebuild with: cargo build --features migrate-qdrant"
         );

--- a/crates/aletheia/src/commands/backup.rs
+++ b/crates/aletheia/src/commands/backup.rs
@@ -2,8 +2,10 @@
 
 use std::path::PathBuf;
 
-use anyhow::{Context, Result};
 use clap::Args;
+use snafu::prelude::*;
+
+use crate::error::Result;
 
 use aletheia_mneme::store::SessionStore;
 
@@ -45,77 +47,24 @@ pub(crate) fn run(instance_root: Option<&PathBuf>, args: &BackupArgs) -> Result<
     let oikos = super::resolve_oikos(instance_root)?;
 
     let db_path = oikos.sessions_db();
-    let store = SessionStore::open(&db_path)
-        .with_context(|| format!("failed to open session store at {}", db_path.display()))?;
+    let store = SessionStore::open(&db_path).with_whatever_context(|_| {
+        format!("failed to open session store at {}", db_path.display())
+    })?;
 
     let backup_dir = oikos.backups();
     let manager = aletheia_mneme::backup::BackupManager::new(store.conn(), &backup_dir);
 
     if list {
-        let backups = manager.list_backups().context("failed to list backups")?;
-        if json {
-            let items: Vec<serde_json::Value> = backups
-                .iter()
-                .map(|b| {
-                    serde_json::json!({
-                        "filename": b.filename,
-                        "size_bytes": b.size_bytes,
-                    })
-                })
-                .collect();
-            println!("{}", serde_json::to_string_pretty(&items)?);
-        } else if backups.is_empty() {
-            println!("No backups found.");
-        } else {
-            for b in &backups {
-                println!("{} ({} bytes)", b.filename, b.size_bytes);
-            }
-        }
-        return Ok(());
+        return run_list(&manager, json);
     }
-
     if prune {
-        let backups = manager.list_backups().context("failed to list backups")?;
-        let to_remove: Vec<_> = backups.iter().skip(keep).collect();
-
-        if to_remove.is_empty() {
-            println!(
-                "Nothing to prune: {} backup(s) found, keeping {keep}.",
-                backups.len()
-            );
-            return Ok(());
-        }
-
-        if !yes {
-            println!("The following backup(s) will be deleted:");
-            for b in &to_remove {
-                println!("  {} ({} bytes)", b.filename, b.size_bytes);
-            }
-            print!("Proceed? [y/N] ");
-            std::io::Write::flush(&mut std::io::stdout()).context("failed to flush stdout")?;
-
-            let mut input = String::new();
-            std::io::BufRead::read_line(&mut std::io::stdin().lock(), &mut input)
-                .context("failed to read confirmation")?;
-
-            if !input.trim().eq_ignore_ascii_case("y") {
-                println!("Aborted.");
-                return Ok(());
-            }
-        }
-
-        let removed = manager
-            .prune_backups(keep)
-            .context("failed to prune backups")?;
-        println!("Pruned {removed} backup(s), kept {keep}.");
-        return Ok(());
+        return run_prune(&manager, keep, yes);
     }
-
     if export_json {
         let export_dir = oikos.archive().join("sessions");
         match manager
             .export_sessions_json(&export_dir)
-            .context("failed to export sessions")?
+            .whatever_context("failed to export sessions")?
         {
             Some(result) => println!(
                 "Exported {} session(s) to {}",
@@ -127,7 +76,10 @@ pub(crate) fn run(instance_root: Option<&PathBuf>, args: &BackupArgs) -> Result<
         return Ok(());
     }
 
-    match manager.create_backup().context("failed to create backup")? {
+    match manager
+        .create_backup()
+        .whatever_context("failed to create backup")?
+    {
         Some(result) => println!(
             "Backup created: {} ({} bytes, {} sessions, {} messages)",
             result.path.display(),
@@ -138,5 +90,76 @@ pub(crate) fn run(instance_root: Option<&PathBuf>, args: &BackupArgs) -> Result<
         None => println!("Backup skipped: disk space critical."),
     }
 
+    Ok(())
+}
+
+fn run_list(manager: &aletheia_mneme::backup::BackupManager<'_>, json: bool) -> Result<()> {
+    let backups = manager
+        .list_backups()
+        .whatever_context("failed to list backups")?;
+    if json {
+        let items: Vec<serde_json::Value> = backups
+            .iter()
+            .map(|b| {
+                serde_json::json!({
+                    "filename": b.filename,
+                    "size_bytes": b.size_bytes,
+                })
+            })
+            .collect();
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&items).whatever_context("failed to serialize backups")?
+        );
+    } else if backups.is_empty() {
+        println!("No backups found.");
+    } else {
+        for b in &backups {
+            println!("{} ({} bytes)", b.filename, b.size_bytes);
+        }
+    }
+    Ok(())
+}
+
+fn run_prune(
+    manager: &aletheia_mneme::backup::BackupManager<'_>,
+    keep: usize,
+    yes: bool,
+) -> Result<()> {
+    let backups = manager
+        .list_backups()
+        .whatever_context("failed to list backups")?;
+    let to_remove: Vec<_> = backups.iter().skip(keep).collect();
+
+    if to_remove.is_empty() {
+        println!(
+            "Nothing to prune: {} backup(s) found, keeping {keep}.",
+            backups.len()
+        );
+        return Ok(());
+    }
+
+    if !yes {
+        println!("The following backup(s) will be deleted:");
+        for b in &to_remove {
+            println!("  {} ({} bytes)", b.filename, b.size_bytes);
+        }
+        print!("Proceed? [y/N] ");
+        std::io::Write::flush(&mut std::io::stdout()).whatever_context("failed to flush stdout")?;
+
+        let mut input = String::new();
+        std::io::BufRead::read_line(&mut std::io::stdin().lock(), &mut input)
+            .whatever_context("failed to read confirmation")?;
+
+        if !input.trim().eq_ignore_ascii_case("y") {
+            println!("Aborted.");
+            return Ok(());
+        }
+    }
+
+    let removed = manager
+        .prune_backups(keep)
+        .whatever_context("failed to prune backups")?;
+    println!("Pruned {removed} backup(s), kept {keep}.");
     Ok(())
 }

--- a/crates/aletheia/src/commands/check_config.rs
+++ b/crates/aletheia/src/commands/check_config.rs
@@ -2,7 +2,9 @@
 
 use std::path::PathBuf;
 
-use anyhow::Result;
+use snafu::prelude::*;
+
+use crate::error::Result;
 
 use aletheia_taxis::loader::load_config;
 use aletheia_taxis::oikos::Oikos;
@@ -29,7 +31,7 @@ pub(crate) fn run(instance_root: Option<&PathBuf>) -> Result<()> {
              help: set ALETHEIA_ROOT or run `aletheia init`",
             oikos.root().display()
         );
-        anyhow::bail!("Cannot validate: instance root does not exist");
+        whatever!("Cannot validate: instance root does not exist");
     }
 
     match oikos.validate() {
@@ -47,7 +49,7 @@ pub(crate) fn run(instance_root: Option<&PathBuf>) -> Result<()> {
         }
         Err(e) => {
             println!("  [FAIL] config load: {e}");
-            anyhow::bail!("config validation aborted: could not load config");
+            whatever!("config validation aborted: could not load config");
         }
     };
 
@@ -55,7 +57,7 @@ pub(crate) fn run(instance_root: Option<&PathBuf>) -> Result<()> {
         Ok(v) => v,
         Err(e) => {
             println!("  [FAIL] config serialization: {e}");
-            anyhow::bail!("config validation aborted: could not serialize config");
+            whatever!("config validation aborted: could not serialize config");
         }
     };
 
@@ -121,6 +123,6 @@ pub(crate) fn run(instance_root: Option<&PathBuf>) -> Result<()> {
         println!("Configuration OK");
         Ok(())
     } else {
-        anyhow::bail!("Configuration has errors — see above");
+        whatever!("Configuration has errors — see above");
     }
 }

--- a/crates/aletheia/src/commands/config.rs
+++ b/crates/aletheia/src/commands/config.rs
@@ -2,8 +2,10 @@
 
 use std::path::PathBuf;
 
-use anyhow::Result;
 use clap::Subcommand;
+use snafu::prelude::*;
+
+use crate::error::Result;
 
 use aletheia_taxis::encrypt;
 use aletheia_taxis::oikos::Oikos;
@@ -25,10 +27,10 @@ pub(crate) fn run(action: &Action, instance_root: Option<&PathBuf>) -> Result<()
 
 fn run_init_key() -> Result<()> {
     let key_path = encrypt::primary_key_path()
-        .ok_or_else(|| anyhow::anyhow!("cannot determine key path: HOME not set"))?;
+        .ok_or_else(|| crate::error::Error::msg("cannot determine key path: HOME not set"))?;
 
     println!("Generating primary key at {}", key_path.display());
-    encrypt::generate_primary_key(&key_path)?;
+    encrypt::generate_primary_key(&key_path).whatever_context("failed to generate primary key")?;
     println!("Primary key generated.");
     println!("  Permissions: 0600 (owner read/write only)");
     println!(
@@ -44,21 +46,24 @@ fn run_encrypt(instance_root: Option<&PathBuf>) -> Result<()> {
     };
 
     let key_path = encrypt::primary_key_path()
-        .ok_or_else(|| anyhow::anyhow!("cannot determine key path: HOME not set"))?;
+        .ok_or_else(|| crate::error::Error::msg("cannot determine key path: HOME not set"))?;
 
-    let primary_key = encrypt::load_primary_key(&key_path)?.ok_or_else(|| {
-        anyhow::anyhow!(
-            "no primary key found at {}\n  Run `aletheia config init-key` first.",
-            key_path.display()
-        )
-    })?;
+    let primary_key = encrypt::load_primary_key(&key_path)
+        .whatever_context("failed to load primary key")?
+        .ok_or_else(|| {
+            crate::error::Error::msg(format!(
+                "no primary key found at {}\n  Run `aletheia config init-key` first.",
+                key_path.display()
+            ))
+        })?;
 
     let toml_path = oikos.config().join("aletheia.toml");
     if !toml_path.exists() {
-        anyhow::bail!("config file not found: {}", toml_path.display());
+        whatever!("config file not found: {}", toml_path.display());
     }
 
-    let count = encrypt::encrypt_config_file(&toml_path, &primary_key)?;
+    let count = encrypt::encrypt_config_file(&toml_path, &primary_key)
+        .whatever_context("failed to encrypt config file")?;
 
     if count == 0 {
         println!("No plaintext sensitive values found to encrypt.");

--- a/crates/aletheia/src/commands/credential.rs
+++ b/crates/aletheia/src/commands/credential.rs
@@ -2,11 +2,14 @@
 
 use std::path::PathBuf;
 
-use anyhow::Result;
+use snafu::prelude::*;
+
 use clap::Subcommand;
 
 use aletheia_symbolon::credential::CredentialFile;
 use aletheia_taxis::oikos::Oikos;
+
+use crate::error::Result;
 
 #[derive(Debug, Clone, Subcommand)]
 pub(crate) enum Action {
@@ -112,7 +115,7 @@ pub(crate) async fn run(action: Action, instance_root: Option<&PathBuf>) -> Resu
                         println!("Token refreshed");
                     }
                 }
-                Err(e) => anyhow::bail!("refresh failed: {e}"),
+                Err(e) => whatever!("refresh failed: {e}"),
             }
         }
     }

--- a/crates/aletheia/src/commands/eval.rs
+++ b/crates/aletheia/src/commands/eval.rs
@@ -2,8 +2,10 @@
 
 use std::path::Path;
 
-use anyhow::Result;
 use clap::Args;
+use snafu::prelude::*;
+
+use crate::error::Result;
 
 #[derive(Debug, Clone, Args)]
 pub(crate) struct EvalArgs {
@@ -43,7 +45,8 @@ pub(crate) async fn run(args: EvalArgs) -> Result<()> {
 
     if show_triggers {
         let config = aletheia_dokimion::triggers::TriggerConfig::default_config();
-        let json = serde_json::to_string_pretty(&config)?;
+        let json = serde_json::to_string_pretty(&config)
+            .whatever_context("failed to serialize trigger config")?;
         println!("{json}");
         return Ok(());
     }
@@ -82,7 +85,8 @@ pub(crate) async fn run(args: EvalArgs) -> Result<()> {
 
     if let Some(ref path) = jsonl_output {
         let records = aletheia_dokimion::persistence::records_from_report(&report);
-        aletheia_dokimion::persistence::append_jsonl(Path::new(path), &records)?;
+        aletheia_dokimion::persistence::append_jsonl(Path::new(path), &records)
+            .whatever_context("failed to write JSONL output")?;
         tracing::info!(
             path = path,
             records = records.len(),
@@ -92,13 +96,13 @@ pub(crate) async fn run(args: EvalArgs) -> Result<()> {
 
     let total = report.passed + report.failed + report.skipped;
     if total == 0 || (report.passed == 0 && report.failed == 0) {
-        anyhow::bail!(
+        whatever!(
             "no scenarios passed — is the server running at {url}?\n  \
              Check with: aletheia health --url {url}"
         );
     }
     if report.failed > 0 {
-        anyhow::bail!("{} scenario(s) failed", report.failed);
+        whatever!("{} scenario(s) failed", report.failed);
     }
     Ok(())
 }

--- a/crates/aletheia/src/commands/health.rs
+++ b/crates/aletheia/src/commands/health.rs
@@ -1,9 +1,12 @@
 //! `aletheia health`: HTTP health check against a running instance.
 
-use anyhow::{Context, Result};
+use snafu::prelude::*;
+
 use clap::Args;
 
 use aletheia_koina::http::API_HEALTH;
+
+use crate::error::Result;
 
 #[derive(Debug, Clone, Args)]
 pub(crate) struct HealthArgs {
@@ -17,29 +20,29 @@ pub(crate) async fn run(args: &HealthArgs) -> Result<()> {
     let endpoint = format!("{url}{API_HEALTH}");
     let resp = reqwest::get(&endpoint).await.map_err(|e| {
         if e.is_connect() {
-            anyhow::anyhow!(
+            crate::error::Error::msg(format!(
                 "FAILED: cannot connect to {url}\n  \
                  Is the server running? Start it with: aletheia"
-            )
+            ))
         } else if e.is_builder() {
-            anyhow::anyhow!(
+            crate::error::Error::msg(format!(
                 "FAILED: invalid URL '{url}'\n  \
                  Expected format: http://host:port (e.g. http://127.0.0.1:18789)"
-            )
+            ))
         } else if e.is_timeout() {
-            anyhow::anyhow!(
+            crate::error::Error::msg(format!(
                 "FAILED: connection to {url} timed out\n  \
                  The server may be overloaded or unreachable."
-            )
+            ))
         } else {
-            anyhow::anyhow!("FAILED: could not reach {url}: {e}")
+            crate::error::Error::msg(format!("FAILED: could not reach {url}: {e}"))
         }
     })?;
     let status = resp.status();
     let body: serde_json::Value = resp
         .json()
         .await
-        .context("failed to parse health response")?;
+        .whatever_context("failed to parse health response")?;
     // NOTE: serde_json::Value indexing returns Value::Null for absent keys, not a panic
     let health_status = body
         .get("status")
@@ -56,8 +59,11 @@ pub(crate) async fn run(args: &HealthArgs) -> Result<()> {
     if status.is_success() {
         println!("OK — {health_status} | version {version} | uptime {uptime}s");
     } else {
-        println!("{}", serde_json::to_string_pretty(&body)?);
-        anyhow::bail!("FAILED: health check returned HTTP {status}");
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&body).whatever_context("failed to format JSON")?
+        );
+        whatever!("FAILED: health check returned HTTP {status}");
     }
     Ok(())
 }

--- a/crates/aletheia/src/commands/maintenance.rs
+++ b/crates/aletheia/src/commands/maintenance.rs
@@ -2,8 +2,10 @@
 
 use std::path::PathBuf;
 
-use anyhow::{Context, Result};
 use clap::Subcommand;
+use snafu::prelude::*;
+
+use crate::error::Result;
 
 use tokio_util::sync::CancellationToken;
 
@@ -38,7 +40,7 @@ pub(crate) fn run(action: Action, instance_root: Option<&PathBuf>) -> Result<()>
         Some(root) => Oikos::from_root(root),
         None => Oikos::discover(),
     };
-    let config = load_config(&oikos).context("failed to load config")?;
+    let config = load_config(&oikos).whatever_context("failed to load config")?;
     let maint = build_config(&oikos, &config.maintenance);
 
     match action {
@@ -48,7 +50,11 @@ pub(crate) fn run(action: Action, instance_root: Option<&PathBuf>) -> Result<()>
             runner.register_maintenance_tasks();
             let statuses = runner.status();
             if json {
-                println!("{}", serde_json::to_string_pretty(&statuses)?);
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&statuses)
+                        .whatever_context("failed to serialize status")?
+                );
             } else {
                 println!("{:<24} {:<8} {:<6} Last Run", "Task", "Enabled", "Runs");
                 println!("{}", "-".repeat(60));
@@ -79,7 +85,7 @@ fn run_task(name: &str, maint: &MaintenanceConfig, verbose: bool) -> Result<()> 
         "trace-rotation" => {
             let report = TraceRotator::new(maint.trace_rotation.clone())
                 .rotate()
-                .context("trace rotation failed")?;
+                .whatever_context("trace rotation failed")?;
             println!(
                 "trace-rotation: {} rotated, {} pruned, {} bytes freed",
                 report.files_rotated, report.files_pruned, report.bytes_freed
@@ -88,7 +94,7 @@ fn run_task(name: &str, maint: &MaintenanceConfig, verbose: bool) -> Result<()> 
         "drift-detection" => {
             let report = DriftDetector::new(maint.drift_detection.clone())
                 .check()
-                .context("drift detection failed")?;
+                .whatever_context("drift detection failed")?;
             let missing = report.missing_files.len();
             let extra = report.extra_files.len();
             if missing == 0 && extra == 0 {
@@ -111,7 +117,7 @@ fn run_task(name: &str, maint: &MaintenanceConfig, verbose: bool) -> Result<()> 
         "db-monitor" => {
             let report = DbMonitor::new(maint.db_monitoring.clone())
                 .check()
-                .context("db monitor failed")?;
+                .whatever_context("db monitor failed")?;
             for db in &report.databases {
                 println!(
                     "db-monitor: {} {}MB ({})",
@@ -140,7 +146,7 @@ fn run_task(name: &str, maint: &MaintenanceConfig, verbose: bool) -> Result<()> 
                 }
             }
         }
-        other => anyhow::bail!(
+        other => whatever!(
             "unknown task: {other}. Valid: trace-rotation, drift-detection, db-monitor, chiron-audit, all"
         ),
     }

--- a/crates/aletheia/src/commands/memory/mod.rs
+++ b/crates/aletheia/src/commands/memory/mod.rs
@@ -2,8 +2,10 @@
 
 use std::path::PathBuf;
 
-use anyhow::Result;
 use clap::Subcommand;
+use snafu::prelude::*;
+
+use crate::error::Result;
 
 #[derive(Debug, Clone, Subcommand)]
 pub(crate) enum Action {
@@ -59,7 +61,7 @@ pub(crate) async fn run(action: Action, url: &str, instance_root: Option<&PathBu
         match action {
             Action::Check { json } => return run_check_via_api(url, json).await,
             _ => {
-                anyhow::bail!(
+                whatever!(
                     "The server at {url} is running and holds an exclusive lock on the knowledge store.\n  \
                      Stop the server first to use this subcommand, or use the REST API:\n  \
                      GET {url}/api/v1/knowledge/facts\n  \
@@ -74,7 +76,7 @@ pub(crate) async fn run(action: Action, url: &str, instance_root: Option<&PathBu
         let oikos = super::resolve_oikos(instance_root)?;
         let knowledge_path = oikos.knowledge_db();
         if !knowledge_path.exists() {
-            anyhow::bail!(
+            whatever!(
                 "knowledge store not found at {}\n  \
                  Has this instance been initialized with recall enabled?",
                 knowledge_path.display()
@@ -84,7 +86,7 @@ pub(crate) async fn run(action: Action, url: &str, instance_root: Option<&PathBu
         let config = aletheia_mneme::knowledge_store::KnowledgeConfig::default();
         let store =
             aletheia_mneme::knowledge_store::KnowledgeStore::open_fjall(&knowledge_path, config)
-                .map_err(|e| anyhow::anyhow!("failed to open knowledge store: {e}"))?;
+                .whatever_context("failed to open knowledge store")?;
 
         match action {
             Action::Check { json } => run_check(&store, json),
@@ -98,7 +100,7 @@ pub(crate) async fn run(action: Action, url: &str, instance_root: Option<&PathBu
     #[cfg(not(feature = "recall"))]
     {
         let _ = (action, instance_root);
-        anyhow::bail!(
+        whatever!(
             "memory subcommands require the 'recall' feature.\n  \
              Build with: cargo build --features recall"
         );
@@ -119,19 +121,22 @@ async fn run_check_via_api(url: &str, json: bool) -> Result<()> {
     let endpoint = format!("{url}/api/v1/knowledge/check");
     let resp = reqwest::get(&endpoint)
         .await
-        .map_err(|e| anyhow::anyhow!("failed to connect to {endpoint}: {e}"))?;
+        .whatever_context("failed to connect to server")?;
 
     if resp.status() == reqwest::StatusCode::SERVICE_UNAVAILABLE {
-        anyhow::bail!("knowledge store is not enabled on the running server");
+        whatever!("knowledge store is not enabled on the running server");
     }
 
     let body: serde_json::Value = resp
         .json()
         .await
-        .map_err(|e| anyhow::anyhow!("failed to parse response: {e}"))?;
+        .whatever_context("failed to parse response")?;
 
     if json {
-        println!("{}", serde_json::to_string_pretty(&body)?);
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&body).whatever_context("failed to serialize JSON")?
+        );
     } else {
         println!("=== Memory Graph Health Check (via server API) ===\n");
         if let Some(fc) = body.get("fact_count").and_then(serde_json::Value::as_u64) {
@@ -184,7 +189,10 @@ fn run_check(
     let report = build_check_report(store)?;
 
     if json {
-        println!("{}", serde_json::to_string_pretty(&report)?);
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&report).whatever_context("failed to serialize report")?
+        );
     } else {
         println!("=== Memory Graph Sanity Check ===\n");
         println!("Facts:         {}", report.fact_count);
@@ -298,7 +306,7 @@ fn count_relation(
     let script = format!("row[{key_field}] := *{relation}{{{key_field}}} \n?[count(k)] := row[k]");
     let result = store
         .run_query(&script, BTreeMap::new())
-        .map_err(|e| anyhow::anyhow!("query failed: {e}"))?;
+        .whatever_context("query failed")?;
     let count = result
         .rows
         .first()
@@ -322,7 +330,7 @@ fn find_orphaned_entities(
     ";
     let result = store
         .run_query(script, BTreeMap::new())
-        .map_err(|e| anyhow::anyhow!("orphan query failed: {e}"))?;
+        .whatever_context("orphan query failed")?;
     Ok(result
         .rows
         .iter()
@@ -346,7 +354,7 @@ fn find_dangling_edges(
     ";
     let result = store
         .run_query(script, BTreeMap::new())
-        .map_err(|e| anyhow::anyhow!("dangling edge query failed: {e}"))?;
+        .whatever_context("dangling edge query failed")?;
     Ok(result
         .rows
         .iter()
@@ -372,7 +380,7 @@ fn find_orphaned_embeddings(
     ";
     let result = store
         .run_query(script, BTreeMap::new())
-        .map_err(|e| anyhow::anyhow!("orphaned embedding query failed: {e}"))?;
+        .whatever_context("orphaned embedding query failed")?;
     Ok(result
         .rows
         .iter()
@@ -396,10 +404,10 @@ fn run_consolidate(
 
     let entity_candidates = store
         .find_entity_overflow_candidates(nous_id, &config)
-        .map_err(|e| anyhow::anyhow!("entity overflow scan failed: {e}"))?;
+        .whatever_context("entity overflow scan failed")?;
     let community_candidates = store
         .find_community_overflow_candidates(nous_id, &config)
-        .map_err(|e| anyhow::anyhow!("community overflow scan failed: {e}"))?;
+        .whatever_context("community overflow scan failed")?;
 
     let total = entity_candidates.len() + community_candidates.len();
     if total == 0 {
@@ -442,11 +450,11 @@ fn run_sample(
             let now = aletheia_mneme::knowledge::format_timestamp(&jiff::Timestamp::now());
             store
                 .query_facts(id, &now, limit)
-                .map_err(|e| anyhow::anyhow!("query failed: {e}"))?
+                .whatever_context("query failed")?
         }
         None => store
             .list_all_facts(limit)
-            .map_err(|e| anyhow::anyhow!("query failed: {e}"))?,
+            .whatever_context("query failed")?,
     };
 
     if facts.is_empty() {
@@ -509,11 +517,11 @@ fn run_dedup(
 
     let candidates = store
         .find_duplicate_entities(nous_id)
-        .map_err(|e| anyhow::anyhow!("duplicate scan failed: {e}"))?;
+        .whatever_context("duplicate scan failed")?;
 
     let pending = store
         .get_pending_merges(nous_id)
-        .map_err(|e| anyhow::anyhow!("pending merge query failed: {e}"))?;
+        .whatever_context("pending merge query failed")?;
 
     let hash_dupes = find_content_hash_duplicates(store, nous_id)?;
 
@@ -558,7 +566,7 @@ fn run_dedup(
     } else {
         let records = store
             .run_entity_dedup(nous_id)
-            .map_err(|e| anyhow::anyhow!("dedup execution failed: {e}"))?;
+            .whatever_context("dedup execution failed")?;
         if records.is_empty() {
             println!("\nNo auto-merges met the threshold. Candidates stored for review.");
         } else {
@@ -591,7 +599,7 @@ fn find_content_hash_duplicates(
     let now = aletheia_mneme::knowledge::format_timestamp(&jiff::Timestamp::now());
     let facts = store
         .query_facts(nous_id, &now, 10_000)
-        .map_err(|e| anyhow::anyhow!("fact query failed: {e}"))?;
+        .whatever_context("fact query failed")?;
 
     let mut hash_map: HashMap<[u8; 32], Vec<(String, String)>> = HashMap::new();
     for fact in &facts {
@@ -694,7 +702,7 @@ fn find_entity_cooccurrence(
     );
     let result = store
         .run_query(&script, BTreeMap::new())
-        .map_err(|e| anyhow::anyhow!("co-occurrence query failed: {e}"))?;
+        .whatever_context("co-occurrence query failed")?;
     Ok(result
         .rows
         .iter()
@@ -726,7 +734,7 @@ fn find_relationship_chains(
     );
     let result = store
         .run_query(&script, BTreeMap::new())
-        .map_err(|e| anyhow::anyhow!("relationship chain query failed: {e}"))?;
+        .whatever_context("relationship chain query failed")?;
     Ok(result
         .rows
         .iter()
@@ -764,7 +772,7 @@ fn find_hub_entities(
     );
     let result = store
         .run_query(&script, BTreeMap::new())
-        .map_err(|e| anyhow::anyhow!("hub entity query failed: {e}"))?;
+        .whatever_context("hub entity query failed")?;
     Ok(result
         .rows
         .iter()

--- a/crates/aletheia/src/commands/mod.rs
+++ b/crates/aletheia/src/commands/mod.rs
@@ -22,13 +22,13 @@ use aletheia_taxis::oikos::Oikos;
 ///
 /// Returns a clear error message directing the user to `aletheia init` or `-r`
 /// instead of letting downstream code fail with opaque SQLite/config errors.
-pub(crate) fn resolve_oikos(instance_root: Option<&PathBuf>) -> anyhow::Result<Oikos> {
+pub(crate) fn resolve_oikos(instance_root: Option<&PathBuf>) -> crate::error::Result<Oikos> {
     let oikos = match instance_root {
         Some(root) => Oikos::from_root(root),
         None => Oikos::discover(),
     };
     if !oikos.root().exists() {
-        anyhow::bail!(
+        snafu::whatever!(
             "instance not found at {}\n  \
              Use -r /path/to/instance or set ALETHEIA_ROOT.\n  \
              To create a new instance: aletheia init",

--- a/crates/aletheia/src/commands/server/mod.rs
+++ b/crates/aletheia/src/commands/server/mod.rs
@@ -6,7 +6,7 @@ use std::time::Instant;
 
 use tokio::sync::Mutex;
 
-use anyhow::{Context, Result};
+use snafu::prelude::*;
 use tokio_util::sync::CancellationToken;
 use tracing::{Instrument, info, warn};
 
@@ -31,6 +31,7 @@ use aletheia_taxis::validate::validate_section;
 
 use crate::commands::maintenance;
 use crate::daemon_bridge;
+use crate::error::Result;
 use crate::planning_adapter;
 
 /// Arguments forwarded from the top-level CLI to the server startup.
@@ -54,12 +55,12 @@ pub(crate) async fn run(args: Args) -> Result<()> {
     };
 
     // Load config early to get [logging] settings before tracing is initialised.
-    // Errors here surface via anyhow to stderr before the subscriber is up.
-    let config = load_config(&oikos).context("failed to load config")?;
+    // Errors here surface to stderr before the subscriber is up.
+    let config = load_config(&oikos).whatever_context("failed to load config")?;
 
     // Resolve and create the log directory.
     let log_dir = resolve_log_dir(&oikos, config.logging.log_dir.as_deref());
-    std::fs::create_dir_all(&log_dir).context("failed to create log directory")?;
+    std::fs::create_dir_all(&log_dir).whatever_context("failed to create log directory")?;
 
     // Initialise tracing: console at the CLI-specified level, JSON file at
     // the configured level (default WARN+). The returned guard must live for
@@ -71,7 +72,7 @@ pub(crate) async fn run(args: Args) -> Result<()> {
         &config.logging.level,
         &config.logging.redaction,
     )
-    .context("failed to initialise file logging")?;
+    .whatever_context("failed to initialise file logging")?;
 
     info!("aletheia starting");
 
@@ -82,7 +83,9 @@ pub(crate) async fn run(args: Args) -> Result<()> {
     info!(root = %oikos.root().display(), "instance discovered");
 
     // Startup validation: fail fast before any actors or stores initialise
-    oikos.validate().context("instance layout invalid")?;
+    oikos
+        .validate()
+        .whatever_context("instance layout invalid")?;
 
     info!(
         port = config.gateway.port,
@@ -91,8 +94,8 @@ pub(crate) async fn run(args: Args) -> Result<()> {
     );
 
     // Validate all config sections: fail fast before any actors or stores initialise.
-    let config_value =
-        serde_json::to_value(&config).context("failed to serialize config for validation")?;
+    let config_value = serde_json::to_value(&config)
+        .whatever_context("failed to serialize config for validation")?;
     for section in &[
         "agents",
         "gateway",
@@ -105,7 +108,7 @@ pub(crate) async fn run(args: Args) -> Result<()> {
     ] {
         if let Some(section_value) = config_value.get(section) {
             validate_section(section, section_value)
-                .with_context(|| format!("invalid config section '{section}'"))?;
+                .with_whatever_context(|_| format!("invalid config section '{section}'"))?;
         }
     }
     info!("config validated");
@@ -125,11 +128,11 @@ pub(crate) async fn run(args: Args) -> Result<()> {
     };
     jwt_config
         .validate_for_auth_mode(config.gateway.auth.mode.as_str())
-        .context("JWT key security check failed")?;
+        .whatever_context("JWT key security check failed")?;
 
     // Validate per-agent workspace paths: fatal if any agent workspace is invalid.
     for agent in &config.agents.list {
-        oikos.validate_workspace_path(&agent.workspace).with_context(|| {
+        oikos.validate_workspace_path(&agent.workspace).with_whatever_context(|_| {
             format!(
                 "agent '{}' workspace path '{}' is invalid — create the directory or fix the config",
                 agent.id, agent.workspace
@@ -145,11 +148,12 @@ pub(crate) async fn run(args: Args) -> Result<()> {
     let db_path = oikos.sessions_db();
     if let Some(parent) = db_path.parent() {
         std::fs::create_dir_all(parent)
-            .with_context(|| format!("failed to create data dir {}", parent.display()))?;
+            .with_whatever_context(|_| format!("failed to create data dir {}", parent.display()))?;
     }
     let session_store = Arc::new(Mutex::new(
-        SessionStore::open(&db_path)
-            .with_context(|| format!("failed to open session store at {}", db_path.display()))?,
+        SessionStore::open(&db_path).with_whatever_context(|_| {
+            format!("failed to open session store at {}", db_path.display())
+        })?,
     ));
     info!(path = %db_path.display(), "session store opened");
 
@@ -251,13 +255,14 @@ pub(crate) async fn run(args: Args) -> Result<()> {
     let knowledge_store = {
         let kb_path = oikos_arc.knowledge_db();
         if let Some(parent) = kb_path.parent() {
-            std::fs::create_dir_all(parent)?;
+            std::fs::create_dir_all(parent)
+                .whatever_context("failed to create knowledge store directory")?;
         }
         let store = aletheia_mneme::knowledge_store::KnowledgeStore::open_fjall(
             &kb_path,
             aletheia_mneme::knowledge_store::KnowledgeConfig::default(),
         )
-        .context("failed to open knowledge store")?;
+        .whatever_context("failed to open knowledge store")?;
         info!(path = %kb_path.display(), dim = 384, "knowledge store opened (fjall)");
         Some(store)
     };
@@ -550,12 +555,12 @@ pub(crate) async fn run(args: Args) -> Result<()> {
         .await
         .map_err(|e| {
             if e.kind() == std::io::ErrorKind::AddrInUse {
-                anyhow::anyhow!(
+                crate::error::Error::msg(format!(
                     "Port {port} is already in use.\n  \
                      Use --port to choose another port, or stop the process using port {port}."
-                )
+                ))
             } else {
-                anyhow::anyhow!("failed to bind to {bind_addr}: {e}")
+                crate::error::Error::msg(format!("failed to bind to {bind_addr}: {e}"))
             }
         })?;
 
@@ -571,7 +576,7 @@ pub(crate) async fn run(args: Args) -> Result<()> {
             token_for_signal.cancel();
         })
         .await
-        .context("server error")?;
+        .whatever_context("server error")?;
 
     // ── Drain ordering ──────────────────────────────────────────────────────
     // 1. HTTP server has stopped accepting new requests (axum graceful_shutdown).

--- a/crates/aletheia/src/commands/server/setup.rs
+++ b/crates/aletheia/src/commands/server/setup.rs
@@ -3,7 +3,7 @@
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use anyhow::{Context, Result};
+use snafu::prelude::*;
 use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
 
@@ -26,6 +26,7 @@ use aletheia_symbolon::credential::{
 use aletheia_taxis::oikos::Oikos;
 
 use crate::dispatch;
+use crate::error::Result;
 
 /// Build a provider registry using the credential resolution chain.
 ///
@@ -165,7 +166,7 @@ pub(super) fn build_tool_registry(
         nproc_limit: sandbox_settings.nproc_limit,
     };
     builtins::register_all_with_sandbox(&mut registry, sandbox)
-        .context("failed to register builtin tools")?;
+        .whatever_context("failed to register builtin tools")?;
     info!(count = registry.definitions().len(), "tools registered");
     Ok(registry)
 }

--- a/crates/aletheia/src/commands/server/tracing_setup.rs
+++ b/crates/aletheia/src/commands/server/tracing_setup.rs
@@ -2,7 +2,7 @@
 
 use std::path::{Path, PathBuf};
 
-use anyhow::{Context, Result};
+use snafu::prelude::*;
 use tokio_util::sync::CancellationToken;
 use tracing::{Instrument, info};
 use tracing_appender::non_blocking::WorkerGuard;
@@ -13,6 +13,8 @@ use tracing_subscriber::{EnvFilter, fmt};
 
 use aletheia_koina::redacting_layer::RedactingLayer;
 use aletheia_taxis::oikos::Oikos;
+
+use crate::error::Result;
 
 /// Spawn a background task that prunes log files older than `retention_days`.
 ///
@@ -98,7 +100,7 @@ pub(super) fn init_tracing(
 
     // File filter: configured level, default "warn": captures WARN+ even
     // when the console is set to INFO.
-    let file_filter = EnvFilter::try_new(file_level).with_context(|| {
+    let file_filter = EnvFilter::try_new(file_level).with_whatever_context(|_| {
         format!("invalid logging.level '{file_level}' — use a tracing directive such as 'warn'")
     })?;
 
@@ -142,7 +144,7 @@ pub(super) fn init_tracing(
             .with(text_console)
             .with(redacting)
             .try_init()
-            .context("failed to set global tracing subscriber")?;
+            .whatever_context("failed to set global tracing subscriber")?;
     } else {
         let file_layer = fmt::layer()
             .json()
@@ -156,7 +158,7 @@ pub(super) fn init_tracing(
             .with(text_console)
             .with(file_layer)
             .try_init()
-            .context("failed to set global tracing subscriber")?;
+            .whatever_context("failed to set global tracing subscriber")?;
     }
 
     Ok(guard)

--- a/crates/aletheia/src/commands/session_export.rs
+++ b/crates/aletheia/src/commands/session_export.rs
@@ -4,9 +4,11 @@ use std::fmt::Write as _;
 use std::io::Write as _;
 use std::path::PathBuf;
 
-use anyhow::{Context, Result};
 use clap::Args;
 use serde::Deserialize;
+use snafu::prelude::*;
+
+use crate::error::Result;
 
 use aletheia_koina::http::{API_V1, BEARER_PREFIX};
 
@@ -76,13 +78,13 @@ fn build_client(token: Option<&str>) -> Result<reqwest::Client> {
     let mut headers = reqwest::header::HeaderMap::new();
     if let Some(tok) = token {
         let value = reqwest::header::HeaderValue::from_str(&format!("{BEARER_PREFIX}{tok}"))
-            .context("invalid token value")?;
+            .whatever_context("invalid token value")?;
         headers.insert(reqwest::header::AUTHORIZATION, value);
     }
     reqwest::Client::builder()
         .default_headers(headers)
         .build()
-        .context("failed to build HTTP client")
+        .whatever_context("failed to build HTTP client")
 }
 
 async fn fetch_session(
@@ -105,24 +107,24 @@ async fn fetch_session(
     // codequality:ignore -- non-HTTPS guard above warns on cleartext to non-localhost URLs
     let resp = client.get(&url).send().await.map_err(|e| {
         if e.is_connect() {
-            anyhow::anyhow!(
+            crate::error::Error::msg(format!(
                 "cannot connect to {base_url}\n  Is the server running? Start it with: aletheia"
-            )
+            ))
         } else {
-            anyhow::anyhow!("request failed: {e}")
+            crate::error::Error::msg(format!("request failed: {e}"))
         }
     })?;
 
     if resp.status() == reqwest::StatusCode::NOT_FOUND {
-        anyhow::bail!("session not found: {session_id}");
+        whatever!("session not found: {session_id}");
     }
     if !resp.status().is_success() {
-        anyhow::bail!("server returned HTTP {}", resp.status());
+        whatever!("server returned HTTP {}", resp.status());
     }
 
     resp.json::<SessionResponse>()
         .await
-        .context("failed to parse session response")
+        .whatever_context("failed to parse session response")
 }
 
 async fn fetch_history(
@@ -147,15 +149,15 @@ async fn fetch_history(
         .get(&url)
         .send()
         .await
-        .context("failed to fetch session history")?;
+        .whatever_context("failed to fetch session history")?;
 
     if !resp.status().is_success() {
-        anyhow::bail!("history endpoint returned HTTP {}", resp.status());
+        whatever!("history endpoint returned HTTP {}", resp.status());
     }
 
     resp.json::<HistoryResponse>()
         .await
-        .context("failed to parse history response")
+        .whatever_context("failed to parse history response")
 }
 
 fn render_markdown(session: &SessionResponse, history: &HistoryResponse) -> String {
@@ -196,7 +198,7 @@ fn render_json(session: &SessionResponse, history: &HistoryResponse) -> Result<S
             "created_at": m.created_at,
         })).collect::<Vec<_>>(),
     });
-    serde_json::to_string_pretty(&payload).context("failed to serialize session to JSON")
+    serde_json::to_string_pretty(&payload).whatever_context("failed to serialize session to JSON")
 }
 
 fn write_output(content: &str, path: Option<&std::path::Path>) -> Result<()> {
@@ -206,10 +208,10 @@ fn write_output(content: &str, path: Option<&std::path::Path>) -> Result<()> {
             reason = "aletheia CLI commands use synchronous filesystem operations for config and certificate generation"
         )]
         Some(p) => std::fs::write(p, content)
-            .with_context(|| format!("failed to write to {}", p.display())),
+            .with_whatever_context(|_| format!("failed to write to {}", p.display())),
         None => std::io::stdout()
             .write_all(content.as_bytes())
-            .context("failed to write to stdout"),
+            .whatever_context("failed to write to stdout"),
     }
 }
 

--- a/crates/aletheia/src/commands/tls.rs
+++ b/crates/aletheia/src/commands/tls.rs
@@ -2,8 +2,10 @@
 
 use std::path::{Path, PathBuf};
 
-use anyhow::{Context, Result};
 use clap::Subcommand;
+use snafu::prelude::*;
+
+use crate::error::Result;
 
 #[derive(Debug, Clone, Subcommand)]
 pub(crate) enum Action {
@@ -37,7 +39,7 @@ pub(crate) fn run(action: &Action) -> Result<()> {
 
 fn generate_certs(output_dir: &Path, days: u32, sans: &[String], force: bool) -> Result<()> {
     std::fs::create_dir_all(output_dir)
-        .with_context(|| format!("failed to create {}", output_dir.display()))?;
+        .with_whatever_context(|_| format!("failed to create {}", output_dir.display()))?;
 
     let cert_path = output_dir.join("cert.pem");
     let key_path = output_dir.join("key.pem");
@@ -45,7 +47,7 @@ fn generate_certs(output_dir: &Path, days: u32, sans: &[String], force: bool) ->
     if !force {
         for path in [&cert_path, &key_path] {
             if path.exists() {
-                anyhow::bail!(
+                whatever!(
                     "file already exists: {}\nUse --force to overwrite.",
                     path.display()
                 );
@@ -54,9 +56,9 @@ fn generate_certs(output_dir: &Path, days: u32, sans: &[String], force: bool) ->
     }
 
     let subject_alt_names: Vec<String> = sans.to_vec();
-    let key_pair = rcgen::KeyPair::generate().context("failed to generate key pair")?;
+    let key_pair = rcgen::KeyPair::generate().whatever_context("failed to generate key pair")?;
     let mut params = rcgen::CertificateParams::new(subject_alt_names)
-        .context("failed to build certificate params")?;
+        .whatever_context("failed to build certificate params")?;
     params
         .distinguished_name
         .push(rcgen::DnType::CommonName, "Aletheia Dev");
@@ -71,28 +73,29 @@ fn generate_certs(output_dir: &Path, days: u32, sans: &[String], force: bool) ->
 
     let cert = params
         .self_signed(&key_pair)
-        .context("failed to generate self-signed certificate")?;
+        .whatever_context("failed to generate self-signed certificate")?;
 
     #[expect(
         clippy::disallowed_methods,
         reason = "aletheia CLI commands use synchronous filesystem operations for config and certificate generation"
     )]
     std::fs::write(&cert_path, cert.pem())
-        .with_context(|| format!("failed to write {}", cert_path.display()))?;
+        .with_whatever_context(|_| format!("failed to write {}", cert_path.display()))?;
     #[expect(
         clippy::disallowed_methods,
         reason = "aletheia CLI commands use synchronous filesystem operations for config and certificate generation"
     )]
     std::fs::write(&key_path, key_pair.serialize_pem())
-        .with_context(|| format!("failed to write {}", key_path.display()))?;
+        .with_whatever_context(|_| format!("failed to write {}", key_path.display()))?;
 
     // WHY: restrict private key to owner-read-only (0600): security requirement
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
         let perms = std::fs::Permissions::from_mode(0o600);
-        std::fs::set_permissions(&key_path, perms)
-            .with_context(|| format!("failed to set permissions on {}", key_path.display()))?;
+        std::fs::set_permissions(&key_path, perms).with_whatever_context(|_| {
+            format!("failed to set permissions on {}", key_path.display())
+        })?;
     }
 
     // WHY: print absolute paths so the user knows where files were written,

--- a/crates/aletheia/src/error.rs
+++ b/crates/aletheia/src/error.rs
@@ -1,0 +1,30 @@
+//! Crate-level error type for the aletheia binary.
+//!
+//! WHY: The project standard restricts `anyhow` to `main.rs` only. Command
+//! handlers and internal modules use this snafu-based Whatever type, which
+//! provides ergonomic error wrapping via `whatever_context()` and `whatever!()`
+//! while keeping typed errors available for future extraction into library crates.
+
+use snafu::prelude::*;
+
+#[derive(Debug, Snafu)]
+#[snafu(whatever, display("{message}"))]
+pub(crate) struct Error {
+    message: String,
+    #[snafu(source(from(Box<dyn std::error::Error + Send + Sync>, Some)))]
+    source: Option<Box<dyn std::error::Error + Send + Sync>>,
+}
+
+impl Error {
+    /// Create an error with a message and no source.
+    ///
+    /// WHY: Avoids requiring `snafu::FromString` in scope at every call site.
+    pub(crate) fn msg(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+            source: None,
+        }
+    }
+}
+
+pub(crate) type Result<T, E = Error> = std::result::Result<T, E>;

--- a/crates/aletheia/src/main.rs
+++ b/crates/aletheia/src/main.rs
@@ -3,6 +3,7 @@
 mod commands;
 mod daemon_bridge;
 mod dispatch;
+mod error;
 mod init;
 #[cfg(feature = "recall")]
 mod knowledge_adapter;
@@ -153,75 +154,9 @@ async fn main() -> Result<()> {
         .expect("failed to install ring crypto provider");
 
     let cli = Cli::parse();
-    let instance_root = cli.instance_root.as_ref();
 
-    match cli.command {
-        Some(Command::Init(a)) => {
-            return init::run(init::RunArgs {
-                root: a.instance_root,
-                yes: a.yes,
-                non_interactive: a.non_interactive,
-                // codequality:ignore -- raw CLI string immediately wrapped in SecretString
-                api_key: a.api_key.map(aletheia_koina::secret::SecretString::from),
-                auth_mode: a.auth_mode,
-                api_provider: a.api_provider,
-                model: a.model,
-            })
-            .map_err(anyhow::Error::from);
-        }
-        Some(Command::Health(a)) => return commands::health::run(&a).await,
-        Some(Command::Backup(a)) => return commands::backup::run(instance_root, &a),
-        Some(Command::Maintenance { action }) => {
-            return commands::maintenance::run(action, instance_root);
-        }
-        Some(Command::Memory { url, action }) => {
-            return commands::memory::run(action, &url, instance_root).await;
-        }
-        Some(Command::Tls { action }) => return commands::tls::run(&action),
-        Some(Command::Status { url }) => {
-            return status::run(&url, instance_root)
-                .await
-                .map_err(anyhow::Error::from);
-        }
-        Some(Command::Credential { action }) => {
-            return commands::credential::run(action, instance_root).await;
-        }
-        #[cfg(feature = "tui")]
-        Some(Command::Tui(a)) => {
-            return theatron_tui::run_tui(a.url, a.token, a.agent, a.session, a.logout)
-                .await
-                .map_err(anyhow::Error::from);
-        }
-        #[cfg(not(feature = "tui"))]
-        Some(Command::Tui(_)) => anyhow::bail!("TUI not available - rebuild with `--features tui`"),
-        Some(Command::Eval(a)) => return commands::eval::run(a).await,
-        Some(Command::Export(a)) => return commands::agent_io::export_agent(instance_root, &a),
-        Some(Command::SessionExport(a)) => return commands::session_export::run(&a).await,
-        Some(Command::Import(a)) => return commands::agent_io::import_agent(instance_root, &a),
-        Some(Command::SeedSkills(a)) => return commands::agent_io::seed_skills(&a),
-        Some(Command::ExportSkills(a)) => {
-            return commands::agent_io::export_skills(instance_root, &a);
-        }
-        Some(Command::ReviewSkills(a)) => {
-            return commands::agent_io::review_skills(instance_root, &a);
-        }
-        Some(Command::Completions { shell }) => {
-            clap_complete::generate(
-                shell,
-                &mut Cli::command(),
-                "aletheia",
-                &mut std::io::stdout(),
-            );
-            return Ok(());
-        }
-        Some(Command::MigrateMemory(a)) => {
-            return commands::agent_io::migrate_memory(instance_root, a).await;
-        }
-        Some(Command::CheckConfig) => return commands::check_config::run(instance_root),
-        Some(Command::Config { action }) => return commands::config::run(&action, instance_root),
-        Some(Command::AddNous(a)) => return commands::add_nous::run(instance_root, &a).await,
-        // NOTE: no subcommand, fall through to default server startup
-        None => {}
+    if let Some(cmd) = cli.command {
+        return dispatch_command(cmd, cli.instance_root.as_ref()).await;
     }
 
     if cli.daemon && std::env::var("_ALETHEIA_DAEMON").is_err() {
@@ -236,6 +171,84 @@ async fn main() -> Result<()> {
         json_logs: cli.json_logs,
     })
     .await
+    .map_err(Into::into)
+}
+
+/// Route a CLI subcommand to its handler.
+///
+/// WHY: Extracted from `main` to stay under the `too_many_lines` lint threshold
+/// while keeping each command's dispatch as a single match arm.
+async fn dispatch_command(cmd: Command, instance_root: Option<&PathBuf>) -> Result<()> {
+    match cmd {
+        Command::Init(a) => {
+            init::run(init::RunArgs {
+                root: a.instance_root,
+                yes: a.yes,
+                non_interactive: a.non_interactive,
+                // codequality:ignore -- raw CLI string immediately wrapped in SecretString
+                api_key: a.api_key.map(aletheia_koina::secret::SecretString::from),
+                auth_mode: a.auth_mode,
+                api_provider: a.api_provider,
+                model: a.model,
+            })
+            .map_err(anyhow::Error::from)
+        }
+        Command::Health(a) => commands::health::run(&a).await.map_err(Into::into),
+        Command::Backup(a) => commands::backup::run(instance_root, &a).map_err(Into::into),
+        Command::Maintenance { action } => {
+            commands::maintenance::run(action, instance_root).map_err(Into::into)
+        }
+        Command::Memory { url, action } => commands::memory::run(action, &url, instance_root)
+            .await
+            .map_err(Into::into),
+        Command::Tls { action } => commands::tls::run(&action).map_err(Into::into),
+        Command::Status { url } => status::run(&url, instance_root)
+            .await
+            .map_err(anyhow::Error::from),
+        Command::Credential { action } => commands::credential::run(action, instance_root)
+            .await
+            .map_err(Into::into),
+        #[cfg(feature = "tui")]
+        Command::Tui(a) => theatron_tui::run_tui(a.url, a.token, a.agent, a.session, a.logout)
+            .await
+            .map_err(anyhow::Error::from),
+        #[cfg(not(feature = "tui"))]
+        Command::Tui(_) => anyhow::bail!("TUI not available - rebuild with `--features tui`"),
+        Command::Eval(a) => commands::eval::run(a).await.map_err(Into::into),
+        Command::Export(a) => {
+            commands::agent_io::export_agent(instance_root, &a).map_err(Into::into)
+        }
+        Command::SessionExport(a) => commands::session_export::run(&a).await.map_err(Into::into),
+        Command::Import(a) => {
+            commands::agent_io::import_agent(instance_root, &a).map_err(Into::into)
+        }
+        Command::SeedSkills(a) => commands::agent_io::seed_skills(&a).map_err(Into::into),
+        Command::ExportSkills(a) => {
+            commands::agent_io::export_skills(instance_root, &a).map_err(Into::into)
+        }
+        Command::ReviewSkills(a) => {
+            commands::agent_io::review_skills(instance_root, &a).map_err(Into::into)
+        }
+        Command::Completions { shell } => {
+            clap_complete::generate(
+                shell,
+                &mut Cli::command(),
+                "aletheia",
+                &mut std::io::stdout(),
+            );
+            Ok(())
+        }
+        Command::MigrateMemory(a) => commands::agent_io::migrate_memory(instance_root, a)
+            .await
+            .map_err(Into::into),
+        Command::CheckConfig => commands::check_config::run(instance_root).map_err(Into::into),
+        Command::Config { action } => {
+            commands::config::run(&action, instance_root).map_err(Into::into)
+        }
+        Command::AddNous(a) => commands::add_nous::run(instance_root, &a)
+            .await
+            .map_err(Into::into),
+    }
 }
 
 /// Fork the server to background by re-executing the binary without `--daemon`.

--- a/crates/aletheia/src/migrate_memory.rs
+++ b/crates/aletheia/src/migrate_memory.rs
@@ -4,8 +4,8 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use anyhow::{Context, Result};
 use sha2::{Digest, Sha256};
+use snafu::prelude::*;
 use tracing::info;
 
 use qdrant_client::Qdrant;
@@ -24,6 +24,8 @@ use aletheia_mneme::knowledge::{
 use aletheia_mneme::knowledge_store::{KnowledgeConfig, KnowledgeStore};
 use aletheia_taxis::loader::load_config;
 use aletheia_taxis::oikos::Oikos;
+
+use crate::error::Result;
 
 struct MemoryRecord {
     content: String,
@@ -67,9 +69,9 @@ pub(crate) async fn run(
         .timeout(std::time::Duration::from_secs(120))
         .keep_alive_while_idle()
         .build()
-        .context("failed to connect to Qdrant")?;
+        .whatever_context("failed to connect to Qdrant")?;
 
-    let config = load_config(&oikos).context("failed to load instance config")?;
+    let config = load_config(&oikos).whatever_context("failed to load instance config")?;
     let embedding_config = EmbeddingConfig {
         provider: config.embedding.provider.clone(),
         model: config.embedding.model.clone(),
@@ -98,18 +100,18 @@ pub(crate) async fn run(
     let knowledge_config = KnowledgeConfig::default();
     let knowledgedb = if dry_run {
         KnowledgeStore::open_mem_with_config(knowledge_config)
-            .context("failed to open in-memory knowledge store")?
+            .whatever_context("failed to open in-memory knowledge store")?
     } else {
         let path = knowledge_path
             .cloned()
             .unwrap_or_else(|| oikos.knowledge_db());
         if let Some(parent) = path.parent() {
             std::fs::create_dir_all(parent)
-                .context("failed to create knowledge store directory")?;
+                .whatever_context("failed to create knowledge store directory")?;
         }
         info!(path = %path.display(), "opening persistent knowledge store");
         KnowledgeStore::open_fjall(&path, knowledge_config)
-            .context("failed to open persistent knowledge store")?
+            .whatever_context("failed to open persistent knowledge store")?
     };
 
     let all_records = fetch_from_qdrant(&client, collection).await?;
@@ -174,7 +176,7 @@ async fn fetch_from_qdrant(client: &Qdrant, collection: &str) -> Result<Vec<Memo
         let response = client
             .scroll(builder)
             .await
-            .context("failed to scroll Qdrant points")?;
+            .whatever_context("failed to scroll Qdrant points")?;
 
         for point in &response.result {
             let payload = &point.payload;
@@ -313,7 +315,7 @@ fn import_fact(
     };
     knowledgedb
         .insert_fact(&fact)
-        .context("failed to insert fact")?;
+        .whatever_context("failed to insert fact")?;
 
     if let Ok(embedding) = embedder.embed(&record.content) {
         let chunk = EmbeddedChunk {
@@ -328,7 +330,7 @@ fn import_fact(
         };
         knowledgedb
             .insert_embedding(&chunk)
-            .context("failed to insert embedding")?;
+            .whatever_context("failed to insert embedding")?;
     }
 
     Ok(())
@@ -343,13 +345,14 @@ fn content_hash(content: &str) -> String {
 
 fn write_review_file(path: &Path, flagged: &[String]) -> Result<()> {
     use std::io::Write;
-    let mut f = std::fs::File::create(path).context("failed to create review file")?;
-    writeln!(f, "# Memory Migration Review")?;
-    writeln!(f)?;
-    writeln!(f, "The following facts were flagged during migration:")?;
-    writeln!(f)?;
+    let mut f = std::fs::File::create(path).whatever_context("failed to create review file")?;
+    writeln!(f, "# Memory Migration Review").whatever_context("failed to write review file")?;
+    writeln!(f).whatever_context("failed to write review file")?;
+    writeln!(f, "The following facts were flagged during migration:")
+        .whatever_context("failed to write review file")?;
+    writeln!(f).whatever_context("failed to write review file")?;
     for item in flagged {
-        writeln!(f, "- {item}")?;
+        writeln!(f, "- {item}").whatever_context("failed to write review file")?;
     }
     Ok(())
 }


### PR DESCRIPTION
## Summary
- Replace `anyhow` usage in 18 command/module files with a crate-level snafu `Whatever` error type (`crate::error::Error`)
- Only `main.rs` retains `anyhow` as the top-level error boundary, converting via `.map_err(Into::into)` at each subcommand dispatch point
- Extract `dispatch_command()` from `main` and `run_list`/`run_prune` from `backup::run` to satisfy `too_many_lines` clippy lint

## Changes
- **New**: `crates/aletheia/src/error.rs` — snafu Whatever error with `Error::msg()` convenience constructor
- **18 files converted**: all `use anyhow::{Context, Result}` → `use snafu::prelude::*` + `use crate::error::Result`
- Conversion patterns: `.context()` → `.whatever_context()`, `bail!()` → `whatever!()`, `anyhow::anyhow!()` → `Error::msg()`

## Acceptance criteria
- [x] `anyhow` confined to `main.rs` only (verified via grep — only `main.rs` imports anyhow)
- [x] All 18 command files converted to snafu Whatever pattern
- [x] All tests pass (`cargo test --workspace`)
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes

## Observations
- **Debt**: `status.rs`, `init/`, `dispatch.rs`, `daemon_bridge.rs`, `planning_adapter.rs`, `knowledge_adapter.rs`, `knowledge_maintenance.rs` already used snafu — no changes needed
- **Debt**: Several command handlers contain business logic (backup management, credential display, memory migration) that could be pushed into library crates. The snafu conversion makes this extraction easier since error types are already structured

## Validation gate
- `cargo fmt --all -- --check` ✓
- `cargo clippy --workspace --all-targets -- -D warnings` ✓
- `cargo test --workspace` ✓

Closes #2081

🤖 Generated with [Claude Code](https://claude.com/claude-code)