### PR TITLE
audit(theatron): document 50K budget compliance for umbrella sub-crates

### DIFF
--- a/crates/theatron/.kanon-lint-ignore
+++ b/crates/theatron/.kanon-lint-ignore
@@ -1,3 +1,10 @@
+# WHY: theatron umbrella totals 86K lines across three sub-crates, but no
+# individual sub-crate exceeds the 50K budget. core: 3K, tui: 37K,
+# desktop: 45K. The umbrella is already decomposed along clean boundaries
+# (shared infra / terminal / desktop). Desktop is closest at 45K — monitor
+# for further growth. See #2072.
+ARCH/crate-too-large:theatron
+
 # WHY: theatron-core is a library crate. These items are public API consumed
 # by theatron-tui and theatron-desktop.
 RUST/pub-visibility:core/src/api/client.rs

--- a/crates/theatron/CLAUDE.md
+++ b/crates/theatron/CLAUDE.md
@@ -1,14 +1,14 @@
 # theatron
 
-Presentation umbrella grouping the three UI crates: core (shared infrastructure), tui (terminal), desktop (Dioxus). 86K lines total.
+Presentation umbrella grouping the three UI crates: core (shared infrastructure), tui (terminal), desktop (Dioxus). 86K lines total across sub-crates; no individual sub-crate exceeds the 50K budget.
 
 ## Sub-crates
 
-| Crate | Path | Lines | Purpose |
-|-------|------|-------|---------|
-| `theatron-core` | `core/` | 3K | Shared API client, types, SSE parser, streaming infrastructure |
-| `theatron-tui` | `tui/` | 37K | Ratatui terminal dashboard (Elm architecture, feature-gated in workspace) |
-| `theatron-desktop` | `desktop/` | 45K | Dioxus desktop app (excluded from workspace, GTK deps) |
+| Crate | Path | Lines | Budget | Purpose |
+|-------|------|-------|--------|---------|
+| `theatron-core` | `core/` | 3K | ✓ | Shared API client, types, SSE parser, streaming infrastructure |
+| `theatron-tui` | `tui/` | 37K | ✓ | Ratatui terminal dashboard (Elm architecture, feature-gated in workspace) |
+| `theatron-desktop` | `desktop/` | 45K | ✓ | Dioxus desktop app (excluded from workspace, GTK deps) |
 
 ## Dependency graph
 


### PR DESCRIPTION
## Summary
- Resolve audit finding #2072: theatron umbrella (108K reported, 86K actual source) exceeds 50K line budget
- Verified all three sub-crates are individually under budget: core (3,222), tui (37,296), desktop (45,240)
- Added `ARCH/crate-too-large` suppression to `crates/theatron/.kanon-lint-ignore` with WHY comment
- Updated umbrella `CLAUDE.md` with budget compliance column in sub-crates table

## Acceptance criteria
- [x] Issue #2072 requirements satisfied: umbrella decomposition evaluated, no sub-crate exceeds 50K, desktop target/ confirmed gitignored
- [x] Tests pass for affected code (`cargo test --workspace` clean)

## Observations
- **Debt**: theatron-desktop at 45K lines is closest to the 50K threshold — should be monitored as new views/state domains are added
- **Note**: The 108K figure in #2072 likely included non-source files or used a different counting method; actual `*.rs` source totals 85,758 lines across all three sub-crates
- **Note**: Cargo.lock in worktree shows version bump from 0.13.11→0.13.12 (regenerated by cargo from release commit) — not staged as it's outside blast radius

## Validation gate
- `cargo fmt --all -- --check` ✓
- `cargo clippy --workspace --all-targets -- -D warnings` ✓
- `cargo test --workspace` ✓

Closes #2072

🤖 Generated with [Claude Code](https://claude.com/claude-code)