### PR TITLE
docs(crates): fix 3 module path inaccuracies in per-crate CLAUDE.md

### DIFF
--- a/crates/episteme/CLAUDE.md
+++ b/crates/episteme/CLAUDE.md
@@ -41,7 +41,7 @@ Knowledge pipeline: extraction, recall, conflict detection, consolidation, embed
 - **6-factor recall**: recency, relevance, confidence, access frequency, knowledge tier, graph intelligence. Weighted sum produces final score.
 - **Conflict pipeline**: new facts checked against existing via embedding similarity. Classified as contradiction, supersession, elaboration, or independent.
 - **Extraction refinement**: turn classification, correction detection, quality filters, and fact type classification in `extract/refinement`.
-- **Serendipity engine**: cross-domain discovery and surprise scoring in `serendipity.rs`.
+- **Serendipity engine**: cross-domain discovery and surprise scoring in `serendipity/mod.rs`.
 - **Ecological succession**: domain volatility tracking and adaptive decay rates in `succession.rs`.
 
 ## Common tasks

--- a/crates/theatron/core/CLAUDE.md
+++ b/crates/theatron/core/CLAUDE.md
@@ -5,7 +5,7 @@ Shared API client, types, SSE parser, and streaming infrastructure for Aletheia 
 ## Read first
 
 1. `src/api/client.rs`: ApiClient (HTTP client for gateway REST API)
-2. `src/api/types.rs`: Agent, Session, HistoryMessage, SseEvent, TurnOutcome, CostSummary
+2. `src/api/types/mod.rs`: Agent, Session, HistoryMessage, SseEvent, TurnOutcome, CostSummary
 3. `src/events.rs`: StreamEvent enum (per-turn streaming: text deltas, tool calls, plan steps)
 4. `src/sse.rs`: SseEvent, SseStream (wire protocol parser for reqwest byte streams)
 5. `src/id.rs`: NousId, SessionId, TurnId, ToolId, PlanId (domain identifier newtypes)
@@ -21,9 +21,9 @@ Shared API client, types, SSE parser, and streaming infrastructure for Aletheia 
 | `NousId` | `id.rs` | Agent identifier newtype |
 | `SessionId` | `id.rs` | Session identifier newtype |
 | `TurnId` | `id.rs` | Turn identifier newtype |
-| `Agent` | `api/types.rs` | Agent info: id, name, model, status |
-| `Session` | `api/types.rs` | Session info: id, name, agent, message count, timestamps |
-| `SseEvent` (api) | `api/types.rs` | Deserialized dashboard SSE events (agent status, session updates, costs) |
+| `Agent` | `api/types/mod.rs` | Agent info: id, name, model, status |
+| `Session` | `api/types/mod.rs` | Session info: id, name, agent, message count, timestamps |
+| `SseEvent` (api) | `api/types/mod.rs` | Deserialized dashboard SSE events (agent status, session updates, costs) |
 | `ApiError` | `api/error.rs` | Error type for all API operations |
 
 ## Patterns
@@ -37,10 +37,10 @@ Shared API client, types, SSE parser, and streaming infrastructure for Aletheia 
 
 | Task | Where |
 |------|-------|
-| Add API endpoint | `src/api/client.rs` (method on ApiClient) + `src/api/types.rs` (request/response types) |
+| Add API endpoint | `src/api/client.rs` (method on ApiClient) + `src/api/types/mod.rs` (request/response types) |
 | Add stream event | `src/events.rs` (StreamEvent enum) + `src/api/streaming.rs` (parser) |
 | Add domain ID type | `src/id.rs` |
-| Add SSE dashboard event | `src/api/types.rs` (SseEvent enum) + `src/api/sse.rs` (parser) |
+| Add SSE dashboard event | `src/api/types/mod.rs` (SseEvent enum) + `src/api/sse.rs` (parser) |
 
 ## Dependencies
 

--- a/crates/theatron/tui/CLAUDE.md
+++ b/crates/theatron/tui/CLAUDE.md
@@ -7,7 +7,7 @@ Ratatui terminal dashboard for Aletheia: chat, planning, memory, metrics, ops vi
 1. `src/lib.rs`: Entry point, run_tui, event loop (tokio::select! over terminal, SSE, stream, tick)
 2. `src/app/mod.rs`: App struct, DashboardState, ConnectionState, sub-state groups
 3. `src/msg.rs`: Msg enum (all application messages), OverlayKind, NotificationKind
-4. `src/update.rs`: Message handler (Msg -> state mutations + side effects)
+4. `src/update/mod.rs`: Message handler (Msg -> state mutations + side effects)
 5. `src/state/mod.rs`: State modules (agent, chat, command, editor, filter, input, memory, metrics, ops, overlay)
 
 ## Key types


### PR DESCRIPTION
## Summary
- All 18 per-crate CLAUDE.md files were already added in PR #2040 — verified all exist with accurate content
- Audited all 18 files against actual crate source: file existence, key type locations, line counts
- Fixed 3 path inaccuracies where module directories were referenced as single files:
  - `crates/episteme/CLAUDE.md`: `serendipity.rs` → `serendipity/mod.rs`
  - `crates/theatron/core/CLAUDE.md`: `api/types.rs` → `api/types/mod.rs` (6 references)
  - `crates/theatron/tui/CLAUDE.md`: `update.rs` → `update/mod.rs`

Closes #2025

## Acceptance criteria
- [x] Issue #2025 requirements are satisfied (all 18 CLAUDE.md files present with correct structure)
- [x] Tests pass for affected code (docs-only change, `cargo test --workspace` passes)

## Observations
- **Already done**: PR #2040 added all 18 CLAUDE.md files but did not close #2025
- **Quality**: All 18 files follow the established pattern (purpose, line count, read-first, key types, patterns, common tasks, dependencies) and line counts are accurate within rounding

## Validation gate
- `cargo fmt --all -- --check` ✓
- `cargo clippy --workspace --all-targets -- -D warnings` ✓
- `cargo test --workspace` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)