### PR TITLE
fix(aletheia): set 0600 permissions on config and export writes

### DIFF
--- a/crates/aletheia/src/commands/add_nous.rs
+++ b/crates/aletheia/src/commands/add_nous.rs
@@ -255,6 +255,13 @@ fn update_config(oikos: &Oikos, args: &AddNousArgs) -> Result<()> {
     )]
     std::fs::write(&tmp, doc.to_string())
         .with_whatever_context(|_| format!("failed to write {}", tmp.display()))?;
+    // WHY: restrict config file to owner-only (0600) before atomic rename preserves permissions
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&tmp, std::fs::Permissions::from_mode(0o600))
+            .with_whatever_context(|_| format!("failed to set permissions on {}", tmp.display()))?;
+    }
     std::fs::rename(&tmp, &config_path)
         .with_whatever_context(|_| format!("failed to rename {}", tmp.display()))?;
 

--- a/crates/aletheia/src/commands/agent_io.rs
+++ b/crates/aletheia/src/commands/agent_io.rs
@@ -234,6 +234,15 @@ pub(crate) fn export_agent(instance_root: Option<&PathBuf>, args: &ExportArgs) -
     )]
     std::fs::write(&output_path, &json)
         .with_whatever_context(|_| format!("failed to write {}", output_path.display()))?;
+    // WHY: restrict agent export to owner-only (0600) — contains session history and workspace data
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&output_path, std::fs::Permissions::from_mode(0o600))
+            .with_whatever_context(|_| {
+                format!("failed to set permissions on {}", output_path.display())
+            })?;
+    }
 
     println!("Exported to: {}", output_path.display());
     println!("Size: {} bytes", json.len());

--- a/crates/aletheia/src/commands/session_export.rs
+++ b/crates/aletheia/src/commands/session_export.rs
@@ -207,8 +207,20 @@ fn write_output(content: &str, path: Option<&std::path::Path>) -> Result<()> {
             clippy::disallowed_methods,
             reason = "aletheia CLI commands use synchronous filesystem operations for config and certificate generation"
         )]
-        Some(p) => std::fs::write(p, content)
-            .with_whatever_context(|_| format!("failed to write to {}", p.display())),
+        Some(p) => {
+            std::fs::write(p, content)
+                .with_whatever_context(|_| format!("failed to write to {}", p.display()))?;
+            // WHY: restrict session export to owner-only (0600) — contains private conversation history
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                std::fs::set_permissions(p, std::fs::Permissions::from_mode(0o600))
+                    .with_whatever_context(|_| {
+                        format!("failed to set permissions on {}", p.display())
+                    })?;
+            }
+            Ok(())
+        }
         None => std::io::stdout()
             .write_all(content.as_bytes())
             .whatever_context("failed to write to stdout"),

--- a/crates/aletheia/src/commands/tls.rs
+++ b/crates/aletheia/src/commands/tls.rs
@@ -81,6 +81,15 @@ fn generate_certs(output_dir: &Path, days: u32, sans: &[String], force: bool) ->
     )]
     std::fs::write(&cert_path, cert.pem())
         .with_whatever_context(|_| format!("failed to write {}", cert_path.display()))?;
+    // WHY: restrict TLS certificate to owner-only (0600) — TLS files should not be world-readable
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&cert_path, std::fs::Permissions::from_mode(0o600))
+            .with_whatever_context(|_| {
+                format!("failed to set permissions on {}", cert_path.display())
+            })?;
+    }
     #[expect(
         clippy::disallowed_methods,
         reason = "aletheia CLI commands use synchronous filesystem operations for config and certificate generation"

--- a/crates/aletheia/src/init/scaffold.rs
+++ b/crates/aletheia/src/init/scaffold.rs
@@ -30,6 +30,8 @@ pub(super) fn scaffold(answers: &Answers) -> Result<(), InitError> {
     std::fs::write(&config_path, config_toml).context(WriteFileSnafu {
         path: config_path.clone(),
     })?;
+    // WHY: restrict config file to owner-only (0600) — contains credential sources and auth settings
+    set_permissions(&config_path, 0o600)?;
 
     if let Some(ref key) = answers.api_key {
         let cred_path = root.join(format!("config/credentials/{}.json", answers.api_provider));


### PR DESCRIPTION
## Summary

- `init/scaffold.rs`: `aletheia.toml` written on `aletheia init` now gets 0600 via the existing `helpers::set_permissions` helper
- `commands/tls.rs`: `cert.pem` joins `key.pem` with 0600 — both TLS files are now owner-only
- `commands/agent_io.rs`: agent export JSON (sessions, workspace, memory) gets 0600 immediately after write
- `commands/add_nous.rs`: `aletheia.toml.tmp` gets 0600 before the atomic rename so the final config inherits the permission
- `commands/session_export.rs`: session export file (conversation history) gets 0600; write arm restructured to propagate both errors

Closes #2067.

## Acceptance criteria

- [x] All `std::fs::write` calls to config/credential paths have adjacent `set_permissions` with 0600
- [x] `use std::os::unix::fs::PermissionsExt` is added where needed (inline `#[cfg(unix)]` blocks) or delegated to the existing `helpers::set_permissions` wrapper
- [x] No test-only writes are modified
- [x] Tests pass for affected crates

## Validation gate

- `cargo fmt --all -- --check` ✓
- `cargo clippy --workspace --all-targets -- -D warnings` ✓
- `cargo test --workspace` ✓ (all test suites pass, zero failures)

## Observations

- **Already fixed**: `crates/dianoia/src/workspace.rs`, `crates/dianoia/src/handoff.rs`, `crates/taxis/src/encrypt.rs`, `crates/graphe/src/retention.rs`, `crates/graphe/src/import.rs`, `crates/graphe/src/backup.rs`, and `crates/episteme/src/skill.rs` all already have `#[cfg(unix)] set_permissions(0o600)` in place — not touched.
- **Intentional skip — `init/mod.rs:412`**: `write_user_profile_from_wizard` has a `// codequality:ignore` comment explicitly exempting it; it writes `USER.md` with name/role/timezone (profile data, not credentials).
- **Intentional skip — `koina/src/system.rs:174`**: `RealSystem::write_file` is a generic `FileSystem` trait implementation used as a testability shim. Its production callers in `taxis` only perform read operations; adding 0600 unconditionally to a generic write method would restrict non-sensitive files incorrectly.
- **Intentional skip — template writes**: `scaffold.rs:157` and `add_nous.rs:302` write agent markdown templates (SOUL.md, IDENTITY.md, etc.) — not config/credential/secret paths.