### PR TITLE
fix(taxis): resolve broken intra-doc links to cfg-gated TestSystem

### DIFF
--- a/crates/taxis/src/cascade.rs
+++ b/crates/taxis/src/cascade.rs
@@ -56,7 +56,7 @@ pub struct CascadeEntry {
 /// is returned (nous > shared > theke).
 ///
 /// Call [`discover_with`] to supply a custom [`FileSystem`] implementation
-/// (e.g. [`aletheia_koina::system::TestSystem`] in tests).
+/// (e.g. `aletheia_koina::system::TestSystem` in tests).
 ///
 /// # Arguments
 /// * `oikos`: The oikos instance for path resolution

--- a/crates/taxis/src/loader.rs
+++ b/crates/taxis/src/loader.rs
@@ -30,7 +30,7 @@ use crate::oikos::Oikos;
 /// encrypted values pass through unchanged with a warning.
 ///
 /// Call [`load_config_with`] to supply a custom [`FileSystem`] implementation
-/// (e.g. [`aletheia_koina::system::TestSystem`] in tests).
+/// (e.g. `aletheia_koina::system::TestSystem` in tests).
 ///
 /// # Errors
 ///

--- a/crates/taxis/src/oikos.rs
+++ b/crates/taxis/src/oikos.rs
@@ -43,7 +43,7 @@ impl Oikos {
     /// 2. `./instance` relative to current directory
     ///
     /// Call [`Oikos::discover_with`] to supply a custom [`Environment`]
-    /// implementation (e.g. [`aletheia_koina::system::TestSystem`] in tests).
+    /// implementation (e.g. `aletheia_koina::system::TestSystem` in tests).
     #[must_use]
     pub fn discover() -> Self {
         Self::discover_with(&RealSystem)


### PR DESCRIPTION
## Summary
- `TestSystem` in `aletheia-koina` is gated behind `#[cfg(any(test, feature = "test-support"))]`, making it invisible to rustdoc
- Three doc comments in `cascade.rs`, `loader.rs`, and `oikos.rs` used link syntax that produced `unresolved link` warnings
- Changed to backtick-only code spans — still readable, no resolution required

## Acceptance criteria
- [x] `cargo doc -p aletheia-taxis --no-deps` succeeds with zero warnings for `aletheia-taxis`
- [x] All intra-doc links resolve correctly (broken links removed)
- [x] No unnecessary visibility widening (doc text updated, not item visibility)
- [x] Closes forkwright/aletheia#2231

## Validation gate
- `cargo fmt --all -- --check` ✓
- `cargo doc -p aletheia-taxis --no-deps` ✓ (0 warnings for aletheia-taxis)
- `cargo test -p aletheia-taxis --lib` ✓ (174 passed)

## Observations
- **Issue description mismatch**: #2231 listed `env.rs`, `oikos.rs`, `preflight.rs`, and `workspace_schema.rs` as affected files. The actual broken links found by `cargo doc` were in `cascade.rs`, `loader.rs`, and `oikos.rs`. The `env.rs` file does not exist in `crates/taxis/src/`; the other three listed files had no broken links. The blast radius was expanded to cover the actual affected files.
- **Pre-existing doctest failures**: Two doctests in `aletheia-taxis` fail pre-branch — `interpolate.rs:41` (E0603: `pub(crate)` item used in doctest) and `lib.rs:41` (`workspace_schema` doctest). Neither is introduced by this PR.
- **Pre-existing koina warnings**: `aletheia-koina/src/system.rs` has two unused import warnings (`HashMap`, `HashSet`, `Arc`, `Mutex`) unrelated to this PR.