### PR TITLE
fix(aletheia): make init test env-independent via run_inner parameter

### DIFF
--- a/crates/aletheia/src/init/helpers.rs
+++ b/crates/aletheia/src/init/helpers.rs
@@ -51,7 +51,7 @@ mod tests {
 
     use super::super::scaffold::render_config;
     use super::super::scaffold::scaffold;
-    use super::super::{Answers, RunArgs, run};
+    use super::super::{Answers, RunArgs, run, run_inner};
     use super::*;
 
     #[test]
@@ -252,20 +252,21 @@ mod tests {
 
     #[test]
     fn non_interactive_without_instance_path_returns_error() {
-        // WHY: skip when ALETHEIA_ROOT is set -- the env fallback provides a root,
-        // masking the missing-flag error this test asserts on
-        if std::env::var("ALETHEIA_ROOT").is_ok() {
-            return;
-        }
-        let result = run(RunArgs {
-            root: None,
-            yes: false,
-            non_interactive: true,
-            api_key: None,
-            auth_mode: None,
-            api_provider: None,
-            model: None,
-        });
+        // WHY: call run_inner with env_root=None so ALETHEIA_ROOT in the ambient
+        // environment cannot mask the missing-flag error this test asserts on;
+        // avoids unsafe set_var (denied by crate policy) and temp_env dependency
+        let result = run_inner(
+            RunArgs {
+                root: None,
+                yes: false,
+                non_interactive: true,
+                api_key: None,
+                auth_mode: None,
+                api_provider: None,
+                model: None,
+            },
+            None,
+        );
         assert!(
             result.is_err(),
             "missing --instance-path should be an error"

--- a/crates/aletheia/src/init/mod.rs
+++ b/crates/aletheia/src/init/mod.rs
@@ -155,6 +155,12 @@ fn print_success_outro(root: &std::path::Path) -> Result<(), InitError> {
 }
 
 pub(crate) fn run(args: RunArgs) -> Result<(), InitError> {
+    // WHY: pass the env var through a parameter so tests can call run_inner
+    // directly with None and bypass ALETHEIA_ROOT without touching env state
+    run_inner(args, std::env::var("ALETHEIA_ROOT").ok().map(PathBuf::from))
+}
+
+fn run_inner(args: RunArgs, env_root: Option<PathBuf>) -> Result<(), InitError> {
     let RunArgs {
         root,
         yes,
@@ -167,7 +173,7 @@ pub(crate) fn run(args: RunArgs) -> Result<(), InitError> {
 
     // WHY: ALETHEIA_ROOT is the legacy env var used by deploy scripts; accept it
     // as a fallback when ALETHEIA_INSTANCE_PATH (the clap env) was not set.
-    let root = root.or_else(|| std::env::var("ALETHEIA_ROOT").ok().map(PathBuf::from));
+    let root = root.or(env_root);
 
     let is_non_interactive = non_interactive || yes;
 


### PR DESCRIPTION
## Summary
- Extract `ALETHEIA_ROOT` env var lookup from `run()` into private `run_inner(args, env_root)` with `env_root: Option<PathBuf>` parameter
- `run()` passes the real env var; tests call `run_inner(..., None)` to bypass ambient environment
- Remove the skip-when-set workaround from `non_interactive_without_instance_path_returns_error`

## Acceptance criteria
- [x] Test passes regardless of whether `ALETHEIA_ROOT` is set in environment
- [x] No `unsafe` code added (respects `#[deny(unsafe_code)]`)
- [x] Skip workaround removed from test
- [x] `ALETHEIA_ROOT=/tmp/fake cargo test -p aletheia -- init` passes (14/14 tests ok)
- [x] `unset ALETHEIA_ROOT && cargo test -p aletheia -- init` passes (14/14 tests ok)
- [x] Closes #2237

## Validation gate
- `cargo fmt --all -- --check` ✓
- `cargo clippy -p aletheia -- -D warnings` — pre-existing failures in `aletheia-koina` and `aletheia-krites` block compilation of dependents; these exist on main and are not introduced by this PR
- `cargo test -p aletheia -- init` with `ALETHEIA_ROOT=/tmp/fake` ✓ (14 passed, 0 failed)
- `cargo test -p aletheia -- init` without `ALETHEIA_ROOT` ✓ (14 passed, 0 failed)

## Observations
- **Pre-existing**: `aletheia-koina` has 3 clippy errors (`unused_imports` × 2, `ref_option`) and `aletheia-krites` has ~950 errors; these block `cargo clippy -p aletheia` workspace-wide on main. Not in scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)