### PR TITLE
fix(episteme): narrow detect_conflicts to pub(crate)

### DIFF
--- a/crates/episteme/src/conflict.rs
+++ b/crates/episteme/src/conflict.rs
@@ -493,7 +493,7 @@ pub(crate) fn resolve_action(
 /// Phase 3: LLM classification
 /// Phase 4: Action resolution
 #[cfg(feature = "mneme-engine")]
-pub fn detect_conflicts(
+pub(crate) fn detect_conflicts(
     facts: Vec<FactForConflictCheck>,
     store: &crate::knowledge_store::KnowledgeStore,
     nous_id: &str,


### PR DESCRIPTION
## Summary
- Narrows `detect_conflicts` in `crates/episteme/src/conflict.rs` from `pub fn` to `pub(crate) fn`
- The function's `classifier: &dyn ConflictClassifier` parameter exposed `ConflictClassifier` (a `pub(crate)` trait) through a `pub` function, triggering `private_interfaces`
- No cross-crate callers exist; narrowing the function visibility is the correct fix per the `pub(crate)` default convention

## Acceptance criteria
- [x] Zero "private type in public interface" clippy warnings
- [x] Visibility follows convention: `pub(crate)` default, `pub` only for cross-crate API
- [x] `cargo check --workspace` passes
- [x] `cargo test -p aletheia-episteme -p aletheia-dokimion` passes
- [x] Closes forkwright/aletheia#2234

## Observations
- **Investigation**: Issues 1–2 (`search_tiered_async` exposing `QueryRewriter`/`RewriteProvider`) do not trigger `private_interfaces` in practice — the types are `pub` inside a `pub(crate)` module, so the module-cap already restricts their effective visibility. No lint fires.
- **Investigation**: Issue 4 (`Scenario::run` exposing `EvalClient`) also does not fire — `scenario` is `pub(crate)` in `lib.rs`, capping `pub trait Scenario` at `pub(crate)` effective visibility. Clippy sees this correctly.
- **Single real warning**: Only `detect_conflicts` triggered `private_interfaces`, consistent with `ConflictClassifier` being `pub(crate)` in a `pub` function signature.

## Validation gate
- `cargo fmt --all -- --check` ✓
- `cargo clippy --workspace --exclude theatron-desktop -- -D warnings 2>&1 | grep 'private type'` (empty output) ✓
- `cargo test -p aletheia-episteme -p aletheia-dokimion` ✓