### PR TITLE
feat(episteme): add side-query memory relevance ranking

### DIFF
--- a/crates/episteme/src/lib.rs
+++ b/crates/episteme/src/lib.rs
@@ -42,6 +42,8 @@ pub mod instinct;
 pub mod knowledge_portability;
 /// `CozoDB`-backed knowledge store for graph traversal and vector search.
 pub mod knowledge_store;
+/// Memory manifest: lightweight headers for side-query pre-filtering.
+pub mod manifest;
 /// Prometheus metric definitions for the knowledge pipeline.
 pub mod metrics;
 /// Typed Datalog query builder for compile-time schema validation.
@@ -57,6 +59,8 @@ pub mod recall;
     expect(dead_code, reason = "pub(crate) items used only in tests")
 )]
 pub mod serendipity;
+/// Side-query memory relevance selector with LRU caching and already-surfaced tracking.
+pub mod side_query;
 /// Skill storage helpers and SKILL.md parser.
 pub mod skill;
 /// Skill auto-capture: heuristic filter, signature hashing, and candidate tracking.

--- a/crates/episteme/src/manifest.rs
+++ b/crates/episteme/src/manifest.rs
@@ -1,0 +1,300 @@
+//! Memory manifest: lightweight headers for side-query pre-filtering.
+//!
+//! Generates a compact index of available memory entries (name + description)
+//! without reading full content. Capped at [`MAX_MEMORY_ENTRIES`], sorted
+//! by modification time descending (newest first).
+//!
+//! Adapted from CC's `memoryScan.ts` pattern: single-pass header extraction
+//! followed by mtime sort, avoiding full content reads for irrelevant entries.
+
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+/// Maximum number of memory entries in a single manifest.
+///
+/// Limits the side-query prompt size and LLM processing cost.
+/// Matches CC's `MAX_MEMORY_FILES` constant.
+pub(crate) const MAX_MEMORY_ENTRIES: usize = 200;
+
+/// A lightweight header for a single memory entry.
+///
+/// Contains only identification and metadata fields — never the full content.
+/// Analogous to CC's `MemoryHeader` but adapted for knowledge-store facts
+/// rather than filesystem files.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MemoryHeader {
+    /// Source identifier (fact ID, document reference, or path).
+    pub source_id: String,
+    /// Short name or title for this memory entry.
+    pub name: String,
+    /// Brief description extracted from entry metadata.
+    pub description: Option<String>,
+    /// Modification time in milliseconds since epoch.
+    pub mtime_ms: i64,
+}
+
+impl MemoryHeader {
+    /// Create a new header with the required fields.
+    #[must_use]
+    pub fn new(source_id: impl Into<String>, name: impl Into<String>, mtime_ms: i64) -> Self {
+        Self {
+            source_id: source_id.into(),
+            name: name.into(),
+            description: None,
+            mtime_ms,
+        }
+    }
+
+    /// Set the description (builder pattern).
+    #[must_use]
+    pub fn with_description(mut self, description: impl Into<String>) -> Self {
+        self.description = Some(description.into());
+        self
+    }
+}
+
+impl fmt::Display for MemoryHeader {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}: {}", self.source_id, self.name)
+    }
+}
+
+/// A manifest of memory entry headers for side-query pre-filtering.
+///
+/// Provides a compact summary of available memories that can be sent to a
+/// lightweight model for relevance ranking without transferring full content.
+///
+/// # Invariants
+///
+/// - Entries are sorted by `mtime_ms` descending (newest first).
+/// - Length never exceeds [`MAX_MEMORY_ENTRIES`].
+#[derive(Debug, Clone)]
+pub struct MemoryManifest {
+    headers: Vec<MemoryHeader>,
+}
+
+impl MemoryManifest {
+    /// Build a manifest from raw headers.
+    ///
+    /// Sorts by modification time descending and enforces the
+    /// [`MAX_MEMORY_ENTRIES`] cap.
+    #[must_use]
+    pub fn from_headers(mut headers: Vec<MemoryHeader>) -> Self {
+        headers.sort_by(|a, b| b.mtime_ms.cmp(&a.mtime_ms));
+        headers.truncate(MAX_MEMORY_ENTRIES);
+        Self { headers }
+    }
+
+    /// Format the manifest as a text block suitable for the side-query prompt.
+    ///
+    /// Each entry occupies a single line:
+    /// `- <source_id> <name>: <description>` (with description)
+    /// `- <source_id> <name>` (without description)
+    #[must_use]
+    pub fn format(&self) -> String {
+        use std::fmt::Write;
+        let mut out = String::with_capacity(self.headers.len() * 80);
+        for h in &self.headers {
+            let _ = write!(out, "- {} {}", h.source_id, h.name);
+            if let Some(desc) = &h.description {
+                let _ = write!(out, ": {desc}");
+            }
+            out.push('\n');
+        }
+        out
+    }
+
+    /// The headers in this manifest, in mtime-descending order.
+    #[must_use]
+    pub fn headers(&self) -> &[MemoryHeader] {
+        &self.headers
+    }
+
+    /// Number of entries in this manifest.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.headers.len()
+    }
+
+    /// Whether this manifest contains no entries.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.headers.is_empty()
+    }
+}
+
+impl fmt::Display for MemoryManifest {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "MemoryManifest({} entries)", self.headers.len())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_header(id: &str, name: &str, mtime: i64) -> MemoryHeader {
+        MemoryHeader::new(id, name, mtime)
+    }
+
+    fn make_header_with_desc(id: &str, name: &str, desc: &str, mtime: i64) -> MemoryHeader {
+        MemoryHeader::new(id, name, mtime).with_description(desc)
+    }
+
+    #[test]
+    fn empty_headers_produces_empty_manifest() {
+        let manifest = MemoryManifest::from_headers(vec![]);
+        assert!(
+            manifest.is_empty(),
+            "manifest from empty headers should be empty"
+        );
+        assert_eq!(manifest.len(), 0, "manifest length should be 0");
+    }
+
+    #[test]
+    fn sorts_by_mtime_descending() {
+        let headers = vec![
+            make_header("old", "oldest", 100),
+            make_header("new", "newest", 300),
+            make_header("mid", "middle", 200),
+        ];
+        let manifest = MemoryManifest::from_headers(headers);
+        let ids: Vec<&str> = manifest
+            .headers()
+            .iter()
+            .map(|h| h.source_id.as_str())
+            .collect();
+        assert_eq!(
+            ids,
+            vec!["new", "mid", "old"],
+            "headers should be sorted newest first"
+        );
+    }
+
+    #[test]
+    fn caps_at_max_entries() {
+        let headers: Vec<MemoryHeader> = (0..250)
+            .map(|i| make_header(&format!("id-{i}"), &format!("entry-{i}"), i64::from(i)))
+            .collect();
+        let manifest = MemoryManifest::from_headers(headers);
+        assert_eq!(
+            manifest.len(),
+            MAX_MEMORY_ENTRIES,
+            "manifest should cap at {MAX_MEMORY_ENTRIES}"
+        );
+    }
+
+    #[test]
+    fn cap_retains_newest_entries() {
+        let headers: Vec<MemoryHeader> = (0..250)
+            .map(|i| make_header(&format!("id-{i}"), &format!("entry-{i}"), i64::from(i)))
+            .collect();
+        let manifest = MemoryManifest::from_headers(headers);
+        // WHY: after sorting desc and truncating, the first entry should be the newest.
+        let first = manifest.headers().first();
+        assert!(
+            first.is_some(),
+            "manifest should not be empty after capping"
+        );
+        assert_eq!(
+            first.map(|h| h.source_id.as_str()),
+            Some("id-249"),
+            "first entry should be the newest (id-249)"
+        );
+    }
+
+    #[test]
+    fn format_includes_source_id_and_name() {
+        let headers = vec![make_header("fact-001", "user preferences", 1000)];
+        let manifest = MemoryManifest::from_headers(headers);
+        let text = manifest.format();
+        assert!(
+            text.contains("fact-001"),
+            "formatted manifest should contain source_id"
+        );
+        assert!(
+            text.contains("user preferences"),
+            "formatted manifest should contain name"
+        );
+    }
+
+    #[test]
+    fn format_includes_description_when_present() {
+        let headers = vec![make_header_with_desc(
+            "fact-002",
+            "coding style",
+            "Prefers Rust with snafu errors",
+            2000,
+        )];
+        let manifest = MemoryManifest::from_headers(headers);
+        let text = manifest.format();
+        assert!(
+            text.contains("Prefers Rust with snafu errors"),
+            "formatted manifest should include description"
+        );
+    }
+
+    #[test]
+    fn format_omits_description_when_none() {
+        let headers = vec![make_header("fact-003", "meeting notes", 3000)];
+        let manifest = MemoryManifest::from_headers(headers);
+        let text = manifest.format();
+        // NOTE: without description, the line should end after the name.
+        assert!(
+            !text.contains(':'),
+            "formatted manifest should not contain colon separator without description"
+        );
+    }
+
+    #[test]
+    fn header_display_shows_id_and_name() {
+        let header = make_header("fact-010", "project setup", 5000);
+        let display = header.to_string();
+        assert!(
+            display.contains("fact-010"),
+            "display should include source_id"
+        );
+        assert!(
+            display.contains("project setup"),
+            "display should include name"
+        );
+    }
+
+    #[test]
+    fn manifest_display_shows_count() {
+        let headers = vec![make_header("a", "alpha", 1), make_header("b", "beta", 2)];
+        let manifest = MemoryManifest::from_headers(headers);
+        assert_eq!(manifest.to_string(), "MemoryManifest(2 entries)");
+    }
+
+    #[test]
+    fn header_builder_pattern() {
+        let header = MemoryHeader::new("id-1", "name-1", 100).with_description("a description");
+        assert_eq!(header.source_id, "id-1");
+        assert_eq!(header.name, "name-1");
+        assert_eq!(header.description.as_deref(), Some("a description"));
+        assert_eq!(header.mtime_ms, 100);
+    }
+
+    #[test]
+    fn from_headers_with_single_entry() {
+        let manifest = MemoryManifest::from_headers(vec![make_header("only", "the one", 42)]);
+        assert_eq!(manifest.len(), 1, "single entry manifest");
+        assert!(!manifest.is_empty(), "single entry is not empty");
+    }
+
+    #[test]
+    fn from_headers_preserves_all_within_cap() {
+        let count = MAX_MEMORY_ENTRIES - 1;
+        let headers: Vec<MemoryHeader> = (0..count)
+            .map(|i| make_header(&format!("id-{i}"), &format!("n-{i}"), i64::from(i as i32)))
+            .collect();
+        let manifest = MemoryManifest::from_headers(headers);
+        assert_eq!(
+            manifest.len(),
+            count,
+            "all entries within cap should be preserved"
+        );
+    }
+}

--- a/crates/episteme/src/recall.rs
+++ b/crates/episteme/src/recall.rs
@@ -12,6 +12,9 @@
 //! Each factor produces a score in [0.0, 1.0]. The final score is a weighted
 //! combination, configurable per-nous via oikos cascade.
 
+use std::collections::HashSet;
+use std::hash::BuildHasher;
+
 use serde::{Deserialize, Serialize};
 use tracing::instrument;
 
@@ -404,6 +407,34 @@ pub(crate) fn refresh_stability_hours(fact_type: &str, tier: &str, access_count:
         _ => EpistemicTier::Assumed,
     };
     compute_effective_stability(ft, et, access_count)
+}
+
+/// Pre-filter recall candidates using side-query selections.
+///
+/// Retains only candidates whose `source_id` appears in `selected_ids`.
+/// Designed to run between vector search retrieval and 6-factor scoring
+/// to reduce the candidate set before the more expensive scoring runs.
+///
+/// # Arguments
+///
+/// * `candidates` — Raw scored results from vector search.
+/// * `selected_ids` — Source IDs chosen by the side-query selector.
+///
+/// # Returns
+///
+/// Filtered candidates preserving original order.
+#[must_use]
+pub fn pre_filter_by_side_query<S: BuildHasher>(
+    candidates: Vec<ScoredResult>,
+    selected_ids: &HashSet<String, S>,
+) -> Vec<ScoredResult> {
+    if selected_ids.is_empty() {
+        return candidates;
+    }
+    candidates
+        .into_iter()
+        .filter(|c| selected_ids.contains(&c.source_id))
+        .collect()
 }
 
 #[cfg(test)]

--- a/crates/episteme/src/recall_tests/mod.rs
+++ b/crates/episteme/src/recall_tests/mod.rs
@@ -2,3 +2,4 @@ mod edge_cases;
 mod proptests;
 mod ranking;
 mod scoring;
+mod side_query;

--- a/crates/episteme/src/recall_tests/side_query.rs
+++ b/crates/episteme/src/recall_tests/side_query.rs
@@ -1,0 +1,481 @@
+//! Tests for side-query memory relevance selection, caching, and pre-filter
+//! integration with the recall pipeline.
+
+use std::collections::HashSet;
+
+use crate::manifest::{MAX_MEMORY_ENTRIES, MemoryHeader, MemoryManifest};
+use crate::recall::{FactorScores, ScoredResult, pre_filter_by_side_query};
+use crate::side_query::{
+    RankerFailedSnafu, SideQueryConfig, SideQueryError, SideQueryRanker, SideQuerySelector,
+};
+
+// ── Mock rankers ──────────────────────────────────────────────────────────
+
+/// Returns a fixed list of source IDs, respecting `max_results`.
+struct MockRanker {
+    response: Vec<String>,
+}
+
+impl MockRanker {
+    fn new(ids: Vec<&str>) -> Self {
+        Self {
+            response: ids.into_iter().map(String::from).collect(),
+        }
+    }
+}
+
+impl SideQueryRanker for MockRanker {
+    fn rank_memories(
+        &self,
+        _query: &str,
+        _manifest_text: &str,
+        max_results: usize,
+    ) -> Result<Vec<String>, SideQueryError> {
+        Ok(self.response.iter().take(max_results).cloned().collect())
+    }
+}
+
+/// Always returns an error.
+struct FailingRanker;
+
+impl SideQueryRanker for FailingRanker {
+    fn rank_memories(
+        &self,
+        _query: &str,
+        _manifest_text: &str,
+        _max_results: usize,
+    ) -> Result<Vec<String>, SideQueryError> {
+        RankerFailedSnafu {
+            message: "mock failure",
+        }
+        .fail()
+    }
+}
+
+/// Captures the manifest text that was sent to the ranker.
+struct CapturingRanker {
+    captured: std::sync::Mutex<Vec<String>>,
+    response: Vec<String>,
+}
+
+impl CapturingRanker {
+    fn new(response: Vec<&str>) -> Self {
+        Self {
+            captured: std::sync::Mutex::new(Vec::new()),
+            response: response.into_iter().map(String::from).collect(),
+        }
+    }
+
+    fn captured_manifests(&self) -> Vec<String> {
+        self.captured
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .clone()
+    }
+}
+
+impl SideQueryRanker for CapturingRanker {
+    fn rank_memories(
+        &self,
+        _query: &str,
+        manifest_text: &str,
+        max_results: usize,
+    ) -> Result<Vec<String>, SideQueryError> {
+        self.captured
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .push(manifest_text.to_owned());
+        Ok(self.response.iter().take(max_results).cloned().collect())
+    }
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────
+
+fn make_header(id: &str, name: &str, mtime: i64) -> MemoryHeader {
+    MemoryHeader::new(id, name, mtime)
+}
+
+fn make_manifest(entries: &[(&str, &str, i64)]) -> MemoryManifest {
+    let headers: Vec<MemoryHeader> = entries
+        .iter()
+        .map(|(id, name, mtime)| make_header(id, name, *mtime))
+        .collect();
+    MemoryManifest::from_headers(headers)
+}
+
+fn make_scored_result(source_id: &str, score: f64) -> ScoredResult {
+    ScoredResult {
+        content: format!("content for {source_id}"),
+        source_type: "fact".to_owned(),
+        source_id: source_id.to_owned(),
+        nous_id: String::new(),
+        factors: FactorScores::default(),
+        score,
+    }
+}
+
+fn default_selector() -> SideQuerySelector {
+    SideQuerySelector::new(SideQueryConfig::default())
+}
+
+fn selector_with_capacity(cap: usize) -> SideQuerySelector {
+    SideQuerySelector::new(SideQueryConfig {
+        cache_capacity: cap,
+        ..SideQueryConfig::default()
+    })
+}
+
+// ── Manifest tests ────────────────────────────────────────────────────────
+
+#[test]
+fn manifest_cap_is_200() {
+    assert_eq!(MAX_MEMORY_ENTRIES, 200, "cap constant should be 200");
+}
+
+// ── Selector: basic operation ─────────────────────────────────────────────
+
+#[test]
+fn select_returns_empty_when_disabled() {
+    let selector = SideQuerySelector::new(SideQueryConfig {
+        enabled: false,
+        ..SideQueryConfig::default()
+    });
+    let manifest = make_manifest(&[("a", "alpha", 1)]);
+    let ranker = MockRanker::new(vec!["a"]);
+
+    let result = selector.select("query", &manifest, &ranker);
+    assert!(result.is_ok(), "disabled selector should return Ok");
+    let result = result.unwrap_or_else(|_| unreachable!());
+    assert!(
+        result.selected_ids.is_empty(),
+        "disabled selector should return empty ids"
+    );
+    assert!(
+        !result.from_cache,
+        "disabled result should not be from cache"
+    );
+}
+
+#[test]
+fn select_returns_empty_when_manifest_empty() {
+    let selector = default_selector();
+    let manifest = MemoryManifest::from_headers(vec![]);
+    let ranker = MockRanker::new(vec!["a"]);
+
+    let result = selector.select("query", &manifest, &ranker);
+    assert!(result.is_ok(), "empty manifest should return Ok");
+    assert!(
+        result
+            .unwrap_or_else(|_| unreachable!())
+            .selected_ids
+            .is_empty(),
+        "empty manifest should yield empty selection"
+    );
+}
+
+#[test]
+fn select_calls_ranker_and_returns_results() {
+    let selector = default_selector();
+    let manifest = make_manifest(&[("a", "alpha", 3), ("b", "beta", 2), ("c", "gamma", 1)]);
+    let ranker = MockRanker::new(vec!["a", "c"]);
+
+    let result = selector
+        .select("what is alpha?", &manifest, &ranker)
+        .unwrap_or_else(|_| unreachable!());
+    assert_eq!(result.selected_ids, vec!["a", "c"]);
+    assert!(!result.from_cache, "first call should not be cached");
+}
+
+#[test]
+fn select_respects_max_results() {
+    let selector = SideQuerySelector::new(SideQueryConfig {
+        max_results: 2,
+        ..SideQueryConfig::default()
+    });
+    let manifest = make_manifest(&[("a", "a", 3), ("b", "b", 2), ("c", "c", 1)]);
+    let ranker = MockRanker::new(vec!["a", "b", "c"]);
+
+    let result = selector
+        .select("query", &manifest, &ranker)
+        .unwrap_or_else(|_| unreachable!());
+    assert_eq!(result.selected_ids.len(), 2, "should respect max_results=2");
+}
+
+#[test]
+fn select_returns_error_on_ranker_failure() {
+    let selector = default_selector();
+    let manifest = make_manifest(&[("a", "alpha", 1)]);
+    let ranker = FailingRanker;
+
+    let result = selector.select("query", &manifest, &ranker);
+    assert!(result.is_err(), "ranker failure should propagate");
+    let err = result.unwrap_err();
+    assert!(
+        err.to_string().contains("mock failure"),
+        "error should contain ranker's message"
+    );
+}
+
+// ── Selector: already_surfaced tracking ───────────────────────────────────
+
+#[test]
+fn mark_surfaced_prevents_reselection() {
+    let selector = default_selector();
+    let manifest = make_manifest(&[("a", "alpha", 3), ("b", "beta", 2), ("c", "gamma", 1)]);
+
+    // NOTE: mark "a" as surfaced before selection.
+    selector.mark_surfaced(&["a".to_owned()]);
+
+    let ranker = CapturingRanker::new(vec!["b"]);
+    let result = selector
+        .select("query", &manifest, &ranker)
+        .unwrap_or_else(|_| unreachable!());
+
+    // WHY: "a" was surfaced, so the manifest sent to the ranker should not contain it.
+    let manifests = ranker.captured_manifests();
+    assert_eq!(manifests.len(), 1, "ranker should be called once");
+    assert!(
+        !manifests.first().unwrap_or(&String::new()).contains(" a "),
+        "surfaced entry 'a' should not appear in manifest sent to ranker"
+    );
+
+    assert_eq!(result.selected_ids, vec!["b"]);
+}
+
+#[test]
+fn is_surfaced_reflects_state() {
+    let selector = default_selector();
+    assert!(
+        !selector.is_surfaced("x"),
+        "fresh selector should have nothing surfaced"
+    );
+    selector.mark_surfaced(&["x".to_owned()]);
+    assert!(selector.is_surfaced("x"), "marked ID should be surfaced");
+    assert!(
+        !selector.is_surfaced("y"),
+        "unmarked ID should not be surfaced"
+    );
+}
+
+#[test]
+fn all_surfaced_returns_empty_without_calling_ranker() {
+    let selector = default_selector();
+    let manifest = make_manifest(&[("a", "alpha", 1), ("b", "beta", 2)]);
+
+    selector.mark_surfaced(&["a".to_owned(), "b".to_owned()]);
+
+    let ranker = CapturingRanker::new(vec!["a"]);
+    let result = selector
+        .select("query", &manifest, &ranker)
+        .unwrap_or_else(|_| unreachable!());
+
+    assert!(
+        result.selected_ids.is_empty(),
+        "all-surfaced should return empty"
+    );
+    assert!(
+        ranker.captured_manifests().is_empty(),
+        "ranker should not be called when all entries surfaced"
+    );
+}
+
+// ── Selector: caching ─────────────────────────────────────────────────────
+
+#[test]
+fn second_identical_call_uses_cache() {
+    let selector = default_selector();
+    let manifest = make_manifest(&[("a", "alpha", 1)]);
+    let ranker = MockRanker::new(vec!["a"]);
+
+    // NOTE: first call — cache miss.
+    let r1 = selector
+        .select("query", &manifest, &ranker)
+        .unwrap_or_else(|_| unreachable!());
+    assert!(!r1.from_cache, "first call should not be cached");
+
+    // NOTE: second call — cache hit.
+    let r2 = selector
+        .select("query", &manifest, &ranker)
+        .unwrap_or_else(|_| unreachable!());
+    assert!(r2.from_cache, "second identical call should use cache");
+    assert_eq!(
+        r2.selected_ids, r1.selected_ids,
+        "cached result should match"
+    );
+}
+
+#[test]
+fn different_query_causes_cache_miss() {
+    let selector = default_selector();
+    let manifest = make_manifest(&[("a", "alpha", 1)]);
+    let ranker = MockRanker::new(vec!["a"]);
+
+    let _ = selector.select("query-1", &manifest, &ranker);
+    let r2 = selector
+        .select("query-2", &manifest, &ranker)
+        .unwrap_or_else(|_| unreachable!());
+    assert!(!r2.from_cache, "different query should cause cache miss");
+}
+
+#[test]
+fn cache_evicts_lru_at_capacity() {
+    let selector = selector_with_capacity(2);
+    let m1 = make_manifest(&[("a", "alpha", 1)]);
+    let m2 = make_manifest(&[("b", "beta", 2)]);
+    let m3 = make_manifest(&[("c", "gamma", 3)]);
+    let ranker = MockRanker::new(vec!["a", "b", "c"]);
+
+    // NOTE: fill the cache with 2 entries.
+    let _ = selector.select("q1", &m1, &ranker);
+    let _ = selector.select("q2", &m2, &ranker);
+    assert_eq!(selector.cache_len(), 2, "cache should have 2 entries");
+
+    // NOTE: third entry evicts the first.
+    let _ = selector.select("q3", &m3, &ranker);
+    assert_eq!(
+        selector.cache_len(),
+        2,
+        "cache should still have 2 entries after eviction"
+    );
+
+    // NOTE: q1 should be evicted (LRU), q2 and q3 remain.
+    let r1_retry = selector
+        .select("q1", &m1, &ranker)
+        .unwrap_or_else(|_| unreachable!());
+    assert!(
+        !r1_retry.from_cache,
+        "evicted entry q1 should cause cache miss"
+    );
+}
+
+#[test]
+fn cache_len_reflects_insertions() {
+    let selector = default_selector();
+    assert_eq!(selector.cache_len(), 0, "fresh selector has empty cache");
+
+    let manifest = make_manifest(&[("a", "alpha", 1)]);
+    let ranker = MockRanker::new(vec!["a"]);
+    let _ = selector.select("q", &manifest, &ranker);
+    assert_eq!(
+        selector.cache_len(),
+        1,
+        "cache should have 1 entry after first select"
+    );
+}
+
+// ── Pre-filter integration ────────────────────────────────────────────────
+
+#[test]
+fn pre_filter_retains_selected_candidates() {
+    let candidates = vec![
+        make_scored_result("a", 0.9),
+        make_scored_result("b", 0.8),
+        make_scored_result("c", 0.7),
+    ];
+    let selected: HashSet<String> = ["a", "c"].iter().map(|s| String::from(*s)).collect();
+
+    let filtered = pre_filter_by_side_query(candidates, &selected);
+    let ids: Vec<&str> = filtered.iter().map(|r| r.source_id.as_str()).collect();
+    assert_eq!(
+        ids,
+        vec!["a", "c"],
+        "only selected candidates should remain"
+    );
+}
+
+#[test]
+fn pre_filter_removes_unselected_candidates() {
+    let candidates = vec![make_scored_result("a", 0.9), make_scored_result("b", 0.8)];
+    let selected: HashSet<String> = ["a"].iter().map(|s| String::from(*s)).collect();
+
+    let filtered = pre_filter_by_side_query(candidates, &selected);
+    assert_eq!(filtered.len(), 1, "only 'a' should remain");
+    assert_eq!(filtered.first().map(|r| r.source_id.as_str()), Some("a"));
+}
+
+#[test]
+fn pre_filter_with_empty_selection_passes_all() {
+    let candidates = vec![make_scored_result("a", 0.9), make_scored_result("b", 0.8)];
+    let selected: HashSet<String> = HashSet::new();
+
+    let filtered = pre_filter_by_side_query(candidates, &selected);
+    assert_eq!(
+        filtered.len(),
+        2,
+        "empty selection should pass all candidates through"
+    );
+}
+
+#[test]
+fn pre_filter_preserves_order() {
+    let candidates = vec![
+        make_scored_result("c", 0.7),
+        make_scored_result("a", 0.9),
+        make_scored_result("b", 0.8),
+    ];
+    let selected: HashSet<String> = ["a", "b", "c"].iter().map(|s| String::from(*s)).collect();
+
+    let filtered = pre_filter_by_side_query(candidates, &selected);
+    let ids: Vec<&str> = filtered.iter().map(|r| r.source_id.as_str()).collect();
+    assert_eq!(
+        ids,
+        vec!["c", "a", "b"],
+        "pre-filter should preserve original order"
+    );
+}
+
+#[test]
+fn pre_filter_with_no_matching_ids_returns_empty() {
+    let candidates = vec![make_scored_result("a", 0.9), make_scored_result("b", 0.8)];
+    let selected: HashSet<String> = ["x", "y"].iter().map(|s| String::from(*s)).collect();
+
+    let filtered = pre_filter_by_side_query(candidates, &selected);
+    assert!(
+        filtered.is_empty(),
+        "no matches should produce empty result"
+    );
+}
+
+#[test]
+fn pre_filter_with_empty_candidates_returns_empty() {
+    let candidates: Vec<ScoredResult> = vec![];
+    let selected: HashSet<String> = ["a"].iter().map(|s| String::from(*s)).collect();
+
+    let filtered = pre_filter_by_side_query(candidates, &selected);
+    assert!(
+        filtered.is_empty(),
+        "empty candidates should produce empty result"
+    );
+}
+
+// ── SideQueryResult display ───────────────────────────────────────────────
+
+#[test]
+fn side_query_result_display() {
+    let result = crate::side_query::SideQueryResult {
+        selected_ids: vec!["a".to_owned(), "b".to_owned()],
+        from_cache: true,
+    };
+    let display = result.to_string();
+    assert!(display.contains("2 selected"), "display should show count");
+    assert!(
+        display.contains("cached=true"),
+        "display should show cache status"
+    );
+}
+
+// ── SideQuerySelector debug ───────────────────────────────────────────────
+
+#[test]
+fn selector_debug_shows_config() {
+    let selector = default_selector();
+    let debug = format!("{selector:?}");
+    assert!(
+        debug.contains("SideQuerySelector"),
+        "debug should identify the struct"
+    );
+    assert!(
+        debug.contains("surfaced_count"),
+        "debug should show surfaced count"
+    );
+}

--- a/crates/episteme/src/side_query.rs
+++ b/crates/episteme/src/side_query.rs
@@ -1,0 +1,359 @@
+//! Side-query memory relevance selector.
+//!
+//! Uses a lighter model to pre-filter memory entries from a manifest before
+//! the full 6-factor recall scoring runs. Implements `already_surfaced` tracking
+//! to avoid re-selecting previously injected memories, and an LRU cache to skip
+//! redundant side-queries for unchanged (query, manifest) pairs.
+//!
+//! Adapted from CC's `findRelevantMemories.ts` pattern: side-query to a cheaper
+//! model selects top-N from a name+description manifest. `alreadySurfaced` set
+//! prevents re-selecting files shown in prior turns.
+
+use std::collections::HashSet;
+use std::fmt;
+use std::hash::{DefaultHasher, Hash, Hasher};
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+use snafu::Snafu;
+use tracing::{debug, instrument};
+
+use crate::manifest::MemoryManifest;
+
+/// Default maximum entries returned by a single side-query.
+const DEFAULT_MAX_RESULTS: usize = 5;
+
+/// Default cache time-to-live in seconds.
+const DEFAULT_CACHE_TTL_SECS: u64 = 300;
+
+/// Default maximum cache entries.
+const DEFAULT_CACHE_CAPACITY: usize = 64;
+
+/// Errors from side-query operations.
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub))]
+#[non_exhaustive]
+#[expect(
+    missing_docs,
+    reason = "snafu error variant fields are self-documenting via display format"
+)]
+pub enum SideQueryError {
+    /// The ranking model call failed.
+    #[snafu(display("side-query ranker failed: {message}"))]
+    RankerFailed {
+        message: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+}
+
+/// Trait for ranking memory entries via a side-query to a lightweight model.
+///
+/// Implementations send the formatted manifest and query to an LLM and parse
+/// the response into a ranked list of source IDs. The trait is synchronous to
+/// match the existing recall pipeline's sync trait pattern
+/// ([`EmbeddingProvider`](crate::embedding::EmbeddingProvider),
+/// [`VectorSearch`]).
+pub trait SideQueryRanker: Send + Sync {
+    /// Rank memory entries by relevance to the query.
+    ///
+    /// # Arguments
+    ///
+    /// * `query` — The user's query or conversation context.
+    /// * `manifest_text` — Formatted manifest from [`MemoryManifest::format`].
+    /// * `max_results` — Maximum number of entries to return.
+    ///
+    /// # Returns
+    ///
+    /// Source IDs of the most relevant memory entries, in ranked order.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SideQueryError::RankerFailed`] if the model call or response
+    /// parsing fails.
+    fn rank_memories(
+        &self,
+        query: &str,
+        manifest_text: &str,
+        max_results: usize,
+    ) -> Result<Vec<String>, SideQueryError>;
+}
+
+/// Configuration for the side-query selector.
+#[derive(Debug, Clone)]
+pub struct SideQueryConfig {
+    /// Maximum number of results to return per query.
+    pub max_results: usize,
+    /// Cache entry time-to-live in seconds.
+    pub cache_ttl_secs: u64,
+    /// Maximum number of cached entries.
+    pub cache_capacity: usize,
+    /// Whether side-query pre-filtering is enabled.
+    pub enabled: bool,
+}
+
+impl Default for SideQueryConfig {
+    fn default() -> Self {
+        Self {
+            max_results: DEFAULT_MAX_RESULTS,
+            cache_ttl_secs: DEFAULT_CACHE_TTL_SECS,
+            cache_capacity: DEFAULT_CACHE_CAPACITY,
+            enabled: true,
+        }
+    }
+}
+
+/// Result from a side-query selection.
+#[derive(Debug, Clone)]
+pub struct SideQueryResult {
+    /// Source IDs selected by the side-query, in relevance order.
+    pub selected_ids: Vec<String>,
+    /// Whether this result was served from cache.
+    pub from_cache: bool,
+}
+
+impl fmt::Display for SideQueryResult {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "SideQueryResult({} selected, cached={})",
+            self.selected_ids.len(),
+            self.from_cache
+        )
+    }
+}
+
+/// A single entry in the relevance cache.
+struct CacheEntry {
+    selected_ids: Vec<String>,
+    created_at: Instant,
+}
+
+/// Bounded LRU relevance cache.
+///
+/// Keys are a combined hash of (query, `manifest_text`). Entries expire
+/// after a configurable TTL. Front = LRU, back = MRU.
+pub(crate) struct RelevanceCache {
+    // PERF: linear scan is acceptable for default capacity (64 entries).
+    entries: Vec<(u64, CacheEntry)>,
+    capacity: usize,
+    ttl: Duration,
+}
+
+impl RelevanceCache {
+    /// Create a new cache with the given capacity and TTL.
+    pub(crate) fn new(capacity: usize, ttl: Duration) -> Self {
+        Self {
+            entries: Vec::with_capacity(capacity),
+            capacity,
+            ttl,
+        }
+    }
+
+    /// Look up a cached result. Returns `None` on miss or expiry.
+    pub(crate) fn get(&mut self, key: u64) -> Option<Vec<String>> {
+        let now = Instant::now();
+        // PERF: linear scan is fine for small capacity (default 64).
+        let pos = self.entries.iter().position(|(k, _)| *k == key)?;
+
+        if now.duration_since(self.entries.get(pos)?.1.created_at) > self.ttl {
+            self.entries.remove(pos);
+            return None;
+        }
+
+        let ids = self.entries.get(pos)?.1.selected_ids.clone();
+        // NOTE: move to back (most recently used).
+        let pair = self.entries.remove(pos);
+        self.entries.push(pair);
+        Some(ids)
+    }
+
+    /// Insert a result, evicting the LRU entry if at capacity.
+    pub(crate) fn insert(&mut self, key: u64, selected_ids: Vec<String>) {
+        // NOTE: remove existing entry with same key before inserting.
+        self.entries.retain(|(k, _)| *k != key);
+        if self.entries.len() >= self.capacity {
+            self.entries.remove(0); // NOTE: evict LRU (front)
+        }
+        self.entries.push((
+            key,
+            CacheEntry {
+                selected_ids,
+                created_at: Instant::now(),
+            },
+        ));
+    }
+
+    /// Number of cached entries.
+    pub(crate) fn len(&self) -> usize {
+        self.entries.len()
+    }
+}
+
+/// Side-query selector: pre-filters memories using a lightweight model.
+///
+/// Wraps a [`SideQueryRanker`] with `already_surfaced` tracking and LRU
+/// caching. Designed to run as a pre-filter stage before the 6-factor
+/// recall scoring in [`RecallEngine`](crate::recall::RecallEngine).
+pub struct SideQuerySelector {
+    config: SideQueryConfig,
+    // WHY: std::sync::Mutex — lock never held across .await.
+    already_surfaced: Mutex<HashSet<String>>,
+    cache: Mutex<RelevanceCache>,
+}
+
+impl SideQuerySelector {
+    /// Create a new selector with the given configuration.
+    #[must_use]
+    pub fn new(config: SideQueryConfig) -> Self {
+        let cache = RelevanceCache::new(
+            config.cache_capacity,
+            Duration::from_secs(config.cache_ttl_secs),
+        );
+        Self {
+            config,
+            already_surfaced: Mutex::new(HashSet::new()),
+            cache: Mutex::new(cache),
+        }
+    }
+
+    /// Select relevant memory entries from the manifest.
+    ///
+    /// Filters out `already_surfaced` entries, checks the cache, and
+    /// falls back to the ranker on cache miss.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SideQueryError`] if the ranker call fails and no cached
+    /// result is available.
+    #[must_use = "selection result should be used for pre-filtering"]
+    #[instrument(skip_all, fields(manifest_len = manifest.len()))]
+    pub fn select(
+        &self,
+        query: &str,
+        manifest: &MemoryManifest,
+        ranker: &dyn SideQueryRanker,
+    ) -> Result<SideQueryResult, SideQueryError> {
+        if !self.config.enabled || manifest.is_empty() {
+            return Ok(SideQueryResult {
+                selected_ids: Vec::new(),
+                from_cache: false,
+            });
+        }
+
+        // NOTE: filter out already-surfaced entries before ranking.
+        let filtered = self.filter_surfaced(manifest);
+        if filtered.is_empty() {
+            debug!("all manifest entries already surfaced");
+            return Ok(SideQueryResult {
+                selected_ids: Vec::new(),
+                from_cache: false,
+            });
+        }
+
+        let manifest_text = filtered.format();
+        let cache_key = compute_cache_key(query, &manifest_text);
+
+        // NOTE: check cache first.
+        {
+            let mut cache = self
+                .cache
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            if let Some(ids) = cache.get(cache_key) {
+                debug!(count = ids.len(), "side-query cache hit");
+                return Ok(SideQueryResult {
+                    selected_ids: ids,
+                    from_cache: true,
+                });
+            }
+        }
+
+        // NOTE: cache miss — call the ranker.
+        let selected = ranker.rank_memories(query, &manifest_text, self.config.max_results)?;
+
+        debug!(count = selected.len(), "side-query selected memories");
+
+        // NOTE: store in cache.
+        {
+            let mut cache = self
+                .cache
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            cache.insert(cache_key, selected.clone());
+        }
+
+        Ok(SideQueryResult {
+            selected_ids: selected,
+            from_cache: false,
+        })
+    }
+
+    /// Mark source IDs as surfaced so they won't be re-selected.
+    pub fn mark_surfaced(&self, ids: &[String]) {
+        let mut surfaced = self
+            .already_surfaced
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        for id in ids {
+            surfaced.insert(id.clone());
+        }
+    }
+
+    /// Check whether a source ID has already been surfaced.
+    #[must_use]
+    pub fn is_surfaced(&self, id: &str) -> bool {
+        self.already_surfaced
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .contains(id)
+    }
+
+    /// Number of entries in the relevance cache.
+    #[must_use]
+    pub fn cache_len(&self) -> usize {
+        self.cache
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .len()
+    }
+
+    /// Build a filtered manifest excluding already-surfaced entries.
+    fn filter_surfaced(&self, manifest: &MemoryManifest) -> MemoryManifest {
+        let surfaced = self
+            .already_surfaced
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let filtered: Vec<_> = manifest
+            .headers()
+            .iter()
+            .filter(|h| !surfaced.contains(&h.source_id))
+            .cloned()
+            .collect();
+        MemoryManifest::from_headers(filtered)
+    }
+}
+
+impl fmt::Debug for SideQuerySelector {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SideQuerySelector")
+            .field("config", &self.config)
+            .field(
+                "surfaced_count",
+                &self.already_surfaced.lock().map(|s| s.len()).unwrap_or(0),
+            )
+            .field("cache_len", &self.cache_len())
+            .finish_non_exhaustive()
+    }
+}
+
+/// Compute a cache key from query and manifest text.
+///
+/// Uses [`DefaultHasher`] (`SipHash`) which is fast and collision-resistant
+/// for in-memory session-scoped caching.
+pub(crate) fn compute_cache_key(query: &str, manifest_text: &str) -> u64 {
+    let mut hasher = DefaultHasher::new();
+    query.hash(&mut hasher);
+    manifest_text.hash(&mut hasher);
+    hasher.finish()
+}


### PR DESCRIPTION
## Summary
- Add `MemoryManifest` for lightweight name+description headers without full content reads, capped at 200 entries, mtime-sorted
- Add `SideQuerySelector` with `SideQueryRanker` trait for pre-filtering memories via a lighter model before 6-factor scoring
- Implement `already_surfaced` tracking to prevent re-selecting memories shown in prior turns
- Add bounded LRU `RelevanceCache` keyed on (query_hash, manifest_hash) with configurable TTL
- Add `pre_filter_by_side_query()` integration point in `recall.rs` to narrow candidates before `RecallEngine::rank()`

## Acceptance criteria
- [x] `MemoryManifest` generates name+description headers without reading full file content
- [x] `SideQuerySelector` sends manifest to a lighter model and returns top-N ranked results
- [x] `already_surfaced` tracking prevents re-selecting files shown in prior turns
- [x] 200-file cap enforced on manifest generation
- [x] Relevance cache with bounded LRU stores results keyed on (query_hash, manifest_hash)
- [x] Side-query integrates as a pre-filter before the 6-factor recall scoring in episteme
- [x] Unit tests cover manifest generation, selection, caching, and integration (33 tests)
- [x] `cargo test -p aletheia-episteme` passes (721 tests)
- [x] `cargo clippy -p aletheia-episteme` clean (zero warnings)
- [ ] `cargo test -p aletheia-mneme -p aletheia-nous` — blocked by pre-existing graphe compile error (see Observations)

## Observations
- **Pre-existing blocker**: `aletheia-graphe/src/migration.rs:441` fails to compile after sha2 0.11.0 bump (commit 7d6f1c01) — `LowerHex` trait not implemented for `Array<u8, ...>`. Blocks `cargo test -p aletheia-mneme` and `cargo test -p aletheia-nous` on origin/main regardless of this PR's changes. No files in graphe were modified by this PR.
- **Architecture note**: `SideQueryRanker` trait is defined in episteme (knowledge layer) to avoid a circular dependency on hermeneus (agent layer). The concrete LLM-backed implementation should be provided by nous when wiring the pipeline.
- **Debt**: The `RelevanceCache` uses a `Vec`-based LRU with linear scan. Acceptable for default capacity (64) but should migrate to a proper LRU structure if capacity needs grow.

## Validation gate
- `cargo fmt --all -- --check` ✓
- `cargo clippy -p aletheia-episteme` ✓ (zero new warnings)
- `cargo test -p aletheia-episteme --lib` ✓ (721 passed)

Closes #2266

🤖 Generated with [Claude Code](https://claude.com/claude-code)