### PR TITLE
feat(nous): add turn-level hook system for behavior correction

### DIFF
--- a/crates/nous/src/actor/turn.rs
+++ b/crates/nous/src/actor/turn.rs
@@ -279,6 +279,10 @@ impl NousActor {
         let mut extra_bootstrap = self.extra_bootstrap.clone();
         extra_bootstrap.extend(self.resolve_skill_sections(content).await);
 
+        // WHY: create hook registry from config so hooks run inside the spawned pipeline task
+        let mut hook_registry = crate::hooks::registry::HookRegistry::new();
+        crate::hooks::builtins::register_builtin_hooks(&mut hook_registry, &self.config.hooks);
+
         let oikos = Arc::clone(&self.services.oikos);
         let config = self.config.clone();
         let pipeline_config = self.pipeline_config.clone();
@@ -314,6 +318,7 @@ impl NousActor {
                             extra_bootstrap,
                             Some(stx),
                             None,
+                            Some(&hook_registry),
                         )
                         .await
                     }
@@ -333,6 +338,7 @@ impl NousActor {
                             extra_bootstrap,
                             None,
                             None,
+                            Some(&hook_registry),
                         )
                         .await
                     }
@@ -477,6 +483,10 @@ impl NousActor {
         let mut extra_bootstrap = self.extra_bootstrap.clone();
         extra_bootstrap.extend(self.resolve_skill_sections(content).await);
 
+        // WHY: create hook registry for the direct (non-spawned) execute_turn path
+        let mut hook_registry = crate::hooks::registry::HookRegistry::new();
+        crate::hooks::builtins::register_builtin_hooks(&mut hook_registry, &self.config.hooks);
+
         #[cfg(feature = "knowledge-store")]
         let text_search_ref: Option<&dyn crate::recall::TextSearch> =
             self.stores.text_search.as_deref();
@@ -498,6 +508,7 @@ impl NousActor {
             extra_bootstrap,
             None,
             None,
+            Some(&hook_registry),
         )
         .await
     }

--- a/crates/nous/src/config.rs
+++ b/crates/nous/src/config.rs
@@ -125,6 +125,38 @@ pub struct NousConfig {
     /// during ephemeral sub-agent spawning.
     #[serde(default)]
     pub tool_allowlist: Option<Vec<String>>,
+    /// Turn-level hook configuration.
+    #[serde(default)]
+    pub hooks: HookConfig,
+}
+
+/// Configuration for turn-level behavior hooks.
+///
+/// Controls which built-in hooks are enabled and their parameters.
+/// All hooks are enabled by default.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct HookConfig {
+    /// Enable the cost control hook (priority 10).
+    pub cost_control_enabled: bool,
+    /// Maximum tokens allowed per turn before cost control aborts.
+    /// 0 = unlimited (default: 0).
+    pub turn_token_budget: u64,
+    /// Enable the scope enforcement hook (priority 20).
+    pub scope_enforcement_enabled: bool,
+    /// Enable the audit logging hook (priority 100).
+    pub audit_logging_enabled: bool,
+}
+
+impl Default for HookConfig {
+    fn default() -> Self {
+        Self {
+            cost_control_enabled: true,
+            turn_token_budget: 0,
+            scope_enforcement_enabled: true,
+            audit_logging_enabled: true,
+        }
+    }
 }
 
 fn default_cache_enabled() -> bool {
@@ -163,6 +195,7 @@ impl Default for NousConfig {
             cache_enabled: true,
             recall: RecallConfig::default(),
             tool_allowlist: None,
+            hooks: HookConfig::default(),
         }
     }
 }
@@ -312,6 +345,7 @@ mod tests {
             cache_enabled: false,
             recall: RecallConfig::default(),
             tool_allowlist: None,
+            hooks: HookConfig::default(),
         };
         assert_eq!(config.name.as_deref(), Some("Chiron"));
         assert!(config.generation.thinking_enabled);

--- a/crates/nous/src/execute/mod.rs
+++ b/crates/nous/src/execute/mod.rs
@@ -26,6 +26,8 @@ use self::dispatch::{
 };
 use crate::config::NousConfig;
 use crate::error;
+use crate::hooks::registry::HookRegistry;
+use crate::hooks::{ToolHookContext, ToolHookResult};
 use crate::pipeline::{LoopDetector, PipelineContext, ToolCall, TurnResult, TurnUsage};
 use crate::session::SessionState;
 use crate::stream::TurnStreamEvent;
@@ -156,6 +158,7 @@ pub async fn execute(
     providers: &ProviderRegistry,
     tools: &ToolRegistry,
     tool_ctx: &ToolContext,
+    hooks: Option<&HookRegistry>,
 ) -> error::Result<TurnResult> {
     let provider = resolve_provider_checked(providers, &config.generation.model)?;
 
@@ -292,6 +295,36 @@ pub async fn execute(
             extracted.tool_uses
         };
 
+        // WHY: before_tool hooks run after allowlist filtering but before dispatch,
+        // so hooks can deny individual tool calls based on budget/scope/policy.
+        let effective_tool_uses = if let Some(hook_registry) = hooks {
+            let hook_ctx = ToolHookContext {
+                nous_id: &session.nous_id,
+                turn_usage: &total_usage,
+                tool_allowlist: config.tool_allowlist.as_deref(),
+            };
+            let mut hook_allowed = Vec::with_capacity(effective_tool_uses.len());
+            for (id, name, input) in effective_tool_uses {
+                match hook_registry
+                    .run_before_tool(&name, &input, &hook_ctx)
+                    .await
+                {
+                    ToolHookResult::Allow => hook_allowed.push((id, name, input)),
+                    ToolHookResult::Deny { reason } => {
+                        warn!(tool = %name, tool_use_id = %id, reason = %reason, "tool call denied by hook");
+                        denied_blocks.push(ContentBlock::ToolResult {
+                            tool_use_id: id,
+                            content: ToolResultContent::Text(reason),
+                            is_error: Some(true),
+                        });
+                    }
+                }
+            }
+            hook_allowed
+        } else {
+            effective_tool_uses
+        };
+
         let DispatchResult {
             mut blocks,
             loop_warning,
@@ -371,6 +404,10 @@ pub async fn execute(
     clippy::too_many_lines,
     reason = "streaming agent loop parallels execute() with provider callback — one cohesive operation"
 )]
+#[expect(
+    clippy::too_many_arguments,
+    reason = "streaming execute requires provider, tools, context, stream channel, and hooks"
+)]
 #[instrument(skip_all, fields(nous_id = %session.nous_id, session_id = %session.id))]
 pub async fn execute_streaming(
     ctx: &PipelineContext,
@@ -380,11 +417,12 @@ pub async fn execute_streaming(
     tools: &ToolRegistry,
     tool_ctx: &ToolContext,
     stream_tx: &mpsc::Sender<TurnStreamEvent>,
+    hooks: Option<&HookRegistry>,
 ) -> error::Result<TurnResult> {
     let Some(streaming_provider) = providers.find_streaming_provider(&config.generation.model)
     else {
         // NOTE: fall back to non-streaming execute if no streaming provider is registered
-        return execute(ctx, session, config, providers, tools, tool_ctx).await;
+        return execute(ctx, session, config, providers, tools, tool_ctx, hooks).await;
     };
 
     let provider = resolve_provider_checked(providers, &config.generation.model)?;
@@ -528,6 +566,35 @@ pub async fn execute_streaming(
             allowed
         } else {
             extracted.tool_uses
+        };
+
+        // WHY: before_tool hooks filter tool calls before streaming dispatch
+        let effective_tool_uses = if let Some(hook_registry) = hooks {
+            let hook_ctx = ToolHookContext {
+                nous_id: &session.nous_id,
+                turn_usage: &total_usage,
+                tool_allowlist: config.tool_allowlist.as_deref(),
+            };
+            let mut hook_allowed = Vec::with_capacity(effective_tool_uses.len());
+            for (id, name, input) in effective_tool_uses {
+                match hook_registry
+                    .run_before_tool(&name, &input, &hook_ctx)
+                    .await
+                {
+                    ToolHookResult::Allow => hook_allowed.push((id, name, input)),
+                    ToolHookResult::Deny { reason } => {
+                        warn!(tool = %name, tool_use_id = %id, reason = %reason, "tool call denied by hook");
+                        denied_blocks.push(ContentBlock::ToolResult {
+                            tool_use_id: id,
+                            content: ToolResultContent::Text(reason),
+                            is_error: Some(true),
+                        });
+                    }
+                }
+            }
+            hook_allowed
+        } else {
+            effective_tool_uses
         };
 
         let DispatchResult {

--- a/crates/nous/src/execute/tests/core.rs
+++ b/crates/nous/src/execute/tests/core.rs
@@ -21,6 +21,7 @@ async fn simple_text_response() {
         &providers,
         &tools,
         &test_tool_ctx(),
+        None,
     )
     .await
     .expect("execute");
@@ -75,6 +76,7 @@ async fn single_tool_iteration() {
         &providers,
         &tools,
         &test_tool_ctx(),
+        None,
     )
     .await
     .expect("execute");
@@ -132,6 +134,7 @@ async fn multi_tool_iteration() {
         &providers,
         &tools,
         &test_tool_ctx(),
+        None,
     )
     .await
     .expect("execute");
@@ -171,6 +174,7 @@ async fn loop_detection_triggers() {
         &providers,
         &tools,
         &test_tool_ctx(),
+        None,
     )
     .await
     .expect_err("should detect loop");
@@ -203,6 +207,7 @@ async fn max_iterations_respected() {
         &providers,
         &tools,
         &test_tool_ctx(),
+        None,
     )
     .await
     .expect("should not error");
@@ -233,6 +238,7 @@ async fn tool_error_captured() {
         &providers,
         &tools,
         &test_tool_ctx(),
+        None,
     )
     .await
     .expect("execute should succeed despite tool error");
@@ -350,6 +356,7 @@ async fn usage_accumulates_across_iterations() {
         &providers,
         &tools,
         &test_tool_ctx(),
+        None,
     )
     .await
     .expect("execute");
@@ -392,6 +399,7 @@ async fn tool_error_captured_not_propagated() {
         &providers,
         &tools,
         &test_tool_ctx(),
+        None,
     )
     .await
     .expect("pipeline should complete despite tool error");
@@ -425,6 +433,7 @@ async fn max_iterations_stops_loop() {
         &providers,
         &tools,
         &test_tool_ctx(),
+        None,
     )
     .await
     .expect("should complete after hitting max iterations");
@@ -451,6 +460,7 @@ async fn text_response_no_tools() {
         &providers,
         &tools,
         &test_tool_ctx(),
+        None,
     )
     .await
     .expect("execute");

--- a/crates/nous/src/execute/tests/edge_cases.rs
+++ b/crates/nous/src/execute/tests/edge_cases.rs
@@ -20,6 +20,7 @@ async fn empty_text_response() {
         &providers,
         &tools,
         &test_tool_ctx(),
+        None,
     )
     .await
     .expect("execute");
@@ -77,6 +78,7 @@ async fn thinking_only_response() {
         &providers,
         &tools,
         &test_tool_ctx(),
+        None,
     )
     .await
     .expect("execute");
@@ -103,6 +105,7 @@ async fn no_provider_for_model_returns_error() {
         &providers,
         &tools,
         &test_tool_ctx(),
+        None,
     )
     .await;
 
@@ -232,6 +235,7 @@ async fn max_iterations_one_exits_immediately() {
         &providers,
         &tools,
         &test_tool_ctx(),
+        None,
     )
     .await
     .expect("should succeed");

--- a/crates/nous/src/execute/tests/streaming.rs
+++ b/crates/nous/src/execute/tests/streaming.rs
@@ -20,6 +20,7 @@ async fn streaming_falls_back_to_non_streaming_for_mock() {
         &tools,
         &test_tool_ctx(),
         &tx,
+        None,
     )
     .await
     .expect("execute_streaming");
@@ -62,6 +63,7 @@ async fn streaming_tool_events_emitted() {
         &tools,
         &test_tool_ctx(),
         &tx,
+        None,
     )
     .await
     .expect("execute_streaming");

--- a/crates/nous/src/hooks/builtins/audit_logging.rs
+++ b/crates/nous/src/hooks/builtins/audit_logging.rs
@@ -1,0 +1,58 @@
+//! Audit logging hook: records turn events for observability.
+
+use std::future::Future;
+use std::pin::Pin;
+
+use tracing::{debug, info};
+
+use crate::hooks::{HookResult, QueryContext, TurnContext, TurnHook};
+
+/// Hook that records turn events using existing nous metrics and tracing.
+///
+/// Fires on `before_query` (logs turn start) and `on_turn_complete`
+/// (logs turn summary with token usage and tool call count).
+pub(crate) struct AuditLoggingHook;
+
+impl TurnHook for AuditLoggingHook {
+    fn name(&self) -> &'static str {
+        "audit_logging"
+    }
+
+    fn before_query<'a>(
+        &'a self,
+        context: &'a mut QueryContext<'_>,
+    ) -> Pin<Box<dyn Future<Output = HookResult> + Send + 'a>> {
+        Box::pin(async move {
+            debug!(
+                nous_id = context.nous_id,
+                message_len = context.user_message.len(),
+                has_system_prompt = context.pipeline.system_prompt.is_some(),
+                tool_count = context.pipeline.tools.len(),
+                "audit: turn starting"
+            );
+            HookResult::Continue
+        })
+    }
+
+    fn on_turn_complete<'a>(
+        &'a self,
+        context: &'a TurnContext<'_>,
+    ) -> Pin<Box<dyn Future<Output = HookResult> + Send + 'a>> {
+        Box::pin(async move {
+            info!(
+                nous_id = context.nous_id,
+                input_tokens = context.result.usage.input_tokens,
+                output_tokens = context.result.usage.output_tokens,
+                tool_calls = context.result.tool_calls.len(),
+                session_tokens = context.session_tokens,
+                stop_reason = context.result.stop_reason.as_str(),
+                "audit: turn completed"
+            );
+
+            // WHY: record turn metrics through the existing metrics system
+            crate::metrics::record_turn(context.nous_id);
+
+            HookResult::Continue
+        })
+    }
+}

--- a/crates/nous/src/hooks/builtins/cost_control.rs
+++ b/crates/nous/src/hooks/builtins/cost_control.rs
@@ -1,0 +1,98 @@
+//! Cost control hook: tracks token usage and aborts turns exceeding budget.
+
+use std::future::Future;
+use std::pin::Pin;
+
+use tracing::debug;
+
+use crate::hooks::{HookResult, QueryContext, ToolHookContext, ToolHookResult, TurnHook};
+
+/// Hook that enforces per-turn token budgets.
+///
+/// Checks cumulative session token usage against a configured budget
+/// before each query. Aborts the turn if the budget is exceeded.
+pub(crate) struct CostControlHook {
+    /// Maximum tokens allowed per turn. 0 = unlimited.
+    turn_token_budget: u64,
+}
+
+impl CostControlHook {
+    /// Create a new cost control hook with the given per-turn token budget.
+    pub(crate) fn new(turn_token_budget: u64) -> Self {
+        Self { turn_token_budget }
+    }
+}
+
+impl TurnHook for CostControlHook {
+    fn name(&self) -> &'static str {
+        "cost_control"
+    }
+
+    fn before_query<'a>(
+        &'a self,
+        context: &'a mut QueryContext<'_>,
+    ) -> Pin<Box<dyn Future<Output = HookResult> + Send + 'a>> {
+        Box::pin(async move {
+            if self.turn_token_budget == 0 {
+                return HookResult::Continue;
+            }
+
+            // NOTE: check remaining token budget from the pipeline context
+            #[expect(
+                clippy::cast_sign_loss,
+                clippy::as_conversions,
+                reason = "i64→u64: remaining_tokens is clamped to non-negative in pipeline"
+            )]
+            let remaining = context.pipeline.remaining_tokens.max(0) as u64; // kanon:ignore RUST/as-cast
+
+            if remaining < self.turn_token_budget / 10 {
+                debug!(
+                    remaining,
+                    budget = self.turn_token_budget,
+                    "cost control: token budget nearly exhausted"
+                );
+                return HookResult::Abort {
+                    reason: format!(
+                        "token budget nearly exhausted: {remaining} tokens remaining \
+                         (budget: {})",
+                        self.turn_token_budget
+                    ),
+                };
+            }
+
+            HookResult::Continue
+        })
+    }
+
+    fn before_tool<'a>(
+        &'a self,
+        tool_name: &'a str,
+        _input: &'a serde_json::Value,
+        context: &'a ToolHookContext<'_>,
+    ) -> Pin<Box<dyn Future<Output = ToolHookResult> + Send + 'a>> {
+        Box::pin(async move {
+            if self.turn_token_budget == 0 {
+                return ToolHookResult::Allow;
+            }
+
+            let used = context.turn_usage.total_tokens();
+            if used > self.turn_token_budget {
+                debug!(
+                    used,
+                    budget = self.turn_token_budget,
+                    tool_name,
+                    "cost control: turn token budget exceeded, denying tool call"
+                );
+                return ToolHookResult::Deny {
+                    reason: format!(
+                        "turn token budget exceeded: {used} tokens used \
+                         (budget: {})",
+                        self.turn_token_budget
+                    ),
+                };
+            }
+
+            ToolHookResult::Allow
+        })
+    }
+}

--- a/crates/nous/src/hooks/builtins/mod.rs
+++ b/crates/nous/src/hooks/builtins/mod.rs
@@ -1,0 +1,40 @@
+//! Built-in turn hooks for behavior correction.
+
+mod audit_logging;
+mod cost_control;
+mod scope_enforcement;
+
+pub(crate) use audit_logging::AuditLoggingHook;
+pub(crate) use cost_control::CostControlHook;
+pub(crate) use scope_enforcement::ScopeEnforcementHook;
+
+use super::registry::HookRegistry;
+use crate::config::HookConfig;
+
+/// Priority constants for built-in hooks.
+///
+/// WHY: Cost control runs first (10) because budget exhaustion should
+/// prevent any further processing. Scope enforcement (20) runs next
+/// to block disallowed tools before execution. Audit logging (100)
+/// runs last to capture the final state of the turn.
+pub(crate) const COST_CONTROL_PRIORITY: i32 = 10;
+pub(crate) const SCOPE_ENFORCEMENT_PRIORITY: i32 = 20;
+pub(crate) const AUDIT_LOGGING_PRIORITY: i32 = 100;
+
+/// Register all enabled built-in hooks into the given registry.
+pub(crate) fn register_builtin_hooks(registry: &mut HookRegistry, config: &HookConfig) {
+    if config.cost_control_enabled {
+        registry.register(
+            COST_CONTROL_PRIORITY,
+            Box::new(CostControlHook::new(config.turn_token_budget)),
+        );
+    }
+
+    if config.scope_enforcement_enabled {
+        registry.register(SCOPE_ENFORCEMENT_PRIORITY, Box::new(ScopeEnforcementHook));
+    }
+
+    if config.audit_logging_enabled {
+        registry.register(AUDIT_LOGGING_PRIORITY, Box::new(AuditLoggingHook));
+    }
+}

--- a/crates/nous/src/hooks/builtins/scope_enforcement.rs
+++ b/crates/nous/src/hooks/builtins/scope_enforcement.rs
@@ -1,0 +1,50 @@
+//! Scope enforcement hook: validates tool calls against allowed-tool lists.
+
+use std::future::Future;
+use std::pin::Pin;
+
+use tracing::debug;
+
+use crate::hooks::{ToolHookContext, ToolHookResult, TurnHook};
+
+/// Hook that enforces tool allowlists from agent configuration.
+///
+/// When the agent has a `tool_allowlist` configured, this hook denies
+/// any tool call not in the list. When no allowlist is set, all tools
+/// are allowed.
+pub(crate) struct ScopeEnforcementHook;
+
+impl TurnHook for ScopeEnforcementHook {
+    fn name(&self) -> &'static str {
+        "scope_enforcement"
+    }
+
+    fn before_tool<'a>(
+        &'a self,
+        tool_name: &'a str,
+        _input: &'a serde_json::Value,
+        context: &'a ToolHookContext<'_>,
+    ) -> Pin<Box<dyn Future<Output = ToolHookResult> + Send + 'a>> {
+        Box::pin(async move {
+            let Some(allowlist) = context.tool_allowlist else {
+                return ToolHookResult::Allow;
+            };
+
+            if allowlist.iter().any(|allowed| allowed == tool_name) {
+                return ToolHookResult::Allow;
+            }
+
+            debug!(
+                tool_name,
+                nous_id = context.nous_id,
+                "scope enforcement: tool not in allowlist"
+            );
+
+            ToolHookResult::Deny {
+                reason: format!(
+                    "tool '{tool_name}' is not in the allowed tool list for this agent"
+                ),
+            }
+        })
+    }
+}

--- a/crates/nous/src/hooks/mod.rs
+++ b/crates/nous/src/hooks/mod.rs
@@ -1,0 +1,118 @@
+//! Turn-level hook system for behavior correction.
+//!
+//! Hooks intercept the agent pipeline at three points:
+//! - `before_query`: before the model call, can modify system prompt or inject messages
+//! - `on_turn_complete`: after the model responds, for audit/logging/metrics
+//! - `before_tool`: before tool execution, can approve/deny/modify
+//!
+//! Hooks run in priority order (lower number = higher priority = runs first).
+//! A denied tool call short-circuits: lower-priority hooks do not run.
+
+pub(crate) mod builtins;
+pub(crate) mod registry;
+
+#[cfg(test)]
+mod tests;
+
+use std::future::Future;
+use std::pin::Pin;
+
+use crate::pipeline::{PipelineContext, TurnResult, TurnUsage};
+
+/// Context passed to `before_query` hooks.
+///
+/// Hooks can modify the system prompt or inject messages before the model call.
+#[derive(Debug)]
+pub(crate) struct QueryContext<'a> {
+    /// Mutable reference to the pipeline context (system prompt, messages, tools).
+    pub pipeline: &'a mut PipelineContext,
+    /// Agent identifier.
+    pub nous_id: &'a str,
+    /// The user's message content for this turn.
+    pub user_message: &'a str,
+}
+
+/// Context passed to `on_turn_complete` hooks.
+#[derive(Debug)]
+pub(crate) struct TurnContext<'a> {
+    /// The completed turn result.
+    pub result: &'a TurnResult,
+    /// Agent identifier.
+    pub nous_id: &'a str,
+    /// Cumulative token usage for this session.
+    pub session_tokens: u64,
+}
+
+/// Context passed to `before_tool` hooks.
+#[derive(Debug)]
+pub(crate) struct ToolHookContext<'a> {
+    /// Agent identifier.
+    pub nous_id: &'a str,
+    /// Cumulative token usage for this turn so far.
+    pub turn_usage: &'a TurnUsage,
+    /// The allowed tool list from agent config, if any.
+    pub tool_allowlist: Option<&'a [String]>,
+}
+
+/// Result from `before_query` and `on_turn_complete` hooks.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum HookResult {
+    /// Continue processing.
+    Continue,
+    /// Abort the turn with a reason.
+    Abort {
+        /// Human-readable reason for the abort.
+        reason: String,
+    },
+}
+
+/// Result from `before_tool` hooks.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ToolHookResult {
+    /// Allow the tool call to proceed.
+    Allow,
+    /// Deny the tool call with a reason.
+    Deny {
+        /// Human-readable reason for the denial.
+        reason: String,
+    },
+}
+
+/// Async trait for turn-level behavior hooks.
+///
+/// Hooks intercept the agent pipeline at three points. Each method has a
+/// default no-op implementation so hooks only need to implement the points
+/// they care about.
+///
+/// WHY: Uses `Pin<Box<dyn Future>>` instead of `async fn` for object safety,
+/// matching the `ToolExecutor` pattern used throughout the crate.
+pub(crate) trait TurnHook: Send + Sync {
+    /// Hook name for logging and diagnostics.
+    fn name(&self) -> &'static str;
+
+    /// Fires before each model call. Can modify the system prompt or inject messages.
+    fn before_query<'a>(
+        &'a self,
+        _context: &'a mut QueryContext<'_>,
+    ) -> Pin<Box<dyn Future<Output = HookResult> + Send + 'a>> {
+        Box::pin(std::future::ready(HookResult::Continue))
+    }
+
+    /// Fires after the model responds. For audit, logging, and metrics.
+    fn on_turn_complete<'a>(
+        &'a self,
+        _context: &'a TurnContext<'_>,
+    ) -> Pin<Box<dyn Future<Output = HookResult> + Send + 'a>> {
+        Box::pin(std::future::ready(HookResult::Continue))
+    }
+
+    /// Fires before tool execution. Can approve or deny the tool call.
+    fn before_tool<'a>(
+        &'a self,
+        _tool_name: &'a str,
+        _input: &'a serde_json::Value,
+        _context: &'a ToolHookContext<'_>,
+    ) -> Pin<Box<dyn Future<Output = ToolHookResult> + Send + 'a>> {
+        Box::pin(std::future::ready(ToolHookResult::Allow))
+    }
+}

--- a/crates/nous/src/hooks/registry.rs
+++ b/crates/nous/src/hooks/registry.rs
@@ -1,0 +1,116 @@
+//! Hook registry: stores hooks with priority ordering.
+
+use tracing::{debug, warn};
+
+use super::{HookResult, QueryContext, ToolHookContext, ToolHookResult, TurnContext, TurnHook};
+
+/// Entry in the hook registry: a hook with its priority.
+struct HookEntry {
+    /// Lower number = higher priority = runs first.
+    priority: i32,
+    hook: Box<dyn TurnHook>,
+}
+
+/// Registry of turn-level hooks, ordered by priority.
+///
+/// Hooks run in priority order (lower number = higher priority).
+/// The expected hook count is small (under 20) and insertion is rare,
+/// so a sorted `Vec` is sufficient.
+pub(crate) struct HookRegistry {
+    hooks: Vec<HookEntry>,
+}
+
+impl Default for HookRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl HookRegistry {
+    /// Create an empty registry.
+    pub(crate) fn new() -> Self {
+        Self { hooks: Vec::new() }
+    }
+
+    /// Register a hook with the given priority.
+    ///
+    /// Lower priority numbers run first. Hooks with equal priority
+    /// run in insertion order.
+    pub(crate) fn register(&mut self, priority: i32, hook: Box<dyn TurnHook>) {
+        debug!(hook = hook.name(), priority, "registering turn hook");
+        let pos = self
+            .hooks
+            .partition_point(|entry| entry.priority <= priority);
+        self.hooks.insert(pos, HookEntry { priority, hook });
+    }
+
+    /// Number of registered hooks.
+    #[cfg(test)]
+    pub(crate) fn len(&self) -> usize {
+        self.hooks.len()
+    }
+
+    /// Run all `before_query` hooks in priority order.
+    ///
+    /// Short-circuits on `HookResult::Abort`.
+    pub(crate) async fn run_before_query(&self, context: &mut QueryContext<'_>) -> HookResult {
+        for entry in &self.hooks {
+            let result = entry.hook.before_query(context).await;
+            if let HookResult::Abort { ref reason } = result {
+                warn!(
+                    hook = entry.hook.name(),
+                    priority = entry.priority,
+                    reason = reason.as_str(),
+                    "before_query hook aborted turn"
+                );
+                return result;
+            }
+        }
+        HookResult::Continue
+    }
+
+    /// Run all `on_turn_complete` hooks in priority order.
+    ///
+    /// Does not short-circuit: all hooks run even if one returns Abort,
+    /// because the turn is already complete and audit hooks should always fire.
+    pub(crate) async fn run_on_turn_complete(&self, context: &TurnContext<'_>) {
+        for entry in &self.hooks {
+            let result = entry.hook.on_turn_complete(context).await;
+            if let HookResult::Abort { ref reason } = result {
+                // NOTE: log but do not short-circuit — turn is already complete
+                debug!(
+                    hook = entry.hook.name(),
+                    priority = entry.priority,
+                    reason = reason.as_str(),
+                    "on_turn_complete hook returned abort (ignored, turn already complete)"
+                );
+            }
+        }
+    }
+
+    /// Run all `before_tool` hooks in priority order.
+    ///
+    /// Short-circuits on `ToolHookResult::Deny`: a denied tool call
+    /// does not proceed through lower-priority hooks.
+    pub(crate) async fn run_before_tool(
+        &self,
+        tool_name: &str,
+        input: &serde_json::Value,
+        context: &ToolHookContext<'_>,
+    ) -> ToolHookResult {
+        for entry in &self.hooks {
+            let result = entry.hook.before_tool(tool_name, input, context).await;
+            if let ToolHookResult::Deny { ref reason } = result {
+                warn!(
+                    hook = entry.hook.name(),
+                    priority = entry.priority,
+                    tool_name,
+                    reason = reason.as_str(),
+                    "before_tool hook denied tool call"
+                );
+                return result;
+            }
+        }
+        ToolHookResult::Allow
+    }
+}

--- a/crates/nous/src/hooks/tests.rs
+++ b/crates/nous/src/hooks/tests.rs
@@ -1,0 +1,868 @@
+//! Tests for turn-level hook system.
+
+#![expect(clippy::expect_used, reason = "test assertions")]
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU32, Ordering};
+
+use super::builtins::{AuditLoggingHook, CostControlHook, ScopeEnforcementHook};
+use super::registry::HookRegistry;
+use super::{
+    HookResult, QueryContext, ToolHookContext, ToolHookResult, TurnContext, TurnHook, TurnUsage,
+};
+use crate::pipeline::{PipelineContext, TurnResult};
+
+// -- Test hook implementations --
+
+/// Hook that always allows everything. Tracks call counts.
+struct NoopHook {
+    name: &'static str,
+    before_query_count: AtomicU32,
+    on_turn_complete_count: AtomicU32,
+    before_tool_count: AtomicU32,
+}
+
+impl NoopHook {
+    fn new(name: &'static str) -> Self {
+        Self {
+            name,
+            before_query_count: AtomicU32::new(0),
+            on_turn_complete_count: AtomicU32::new(0),
+            before_tool_count: AtomicU32::new(0),
+        }
+    }
+}
+
+impl TurnHook for NoopHook {
+    fn name(&self) -> &'static str {
+        self.name
+    }
+
+    fn before_query<'a>(
+        &'a self,
+        _context: &'a mut QueryContext<'_>,
+    ) -> Pin<Box<dyn Future<Output = HookResult> + Send + 'a>> {
+        self.before_query_count.fetch_add(1, Ordering::Relaxed);
+        Box::pin(std::future::ready(HookResult::Continue))
+    }
+
+    fn on_turn_complete<'a>(
+        &'a self,
+        _context: &'a TurnContext<'_>,
+    ) -> Pin<Box<dyn Future<Output = HookResult> + Send + 'a>> {
+        self.on_turn_complete_count.fetch_add(1, Ordering::Relaxed);
+        Box::pin(std::future::ready(HookResult::Continue))
+    }
+
+    fn before_tool<'a>(
+        &'a self,
+        _tool_name: &'a str,
+        _input: &'a serde_json::Value,
+        _context: &'a ToolHookContext<'_>,
+    ) -> Pin<Box<dyn Future<Output = ToolHookResult> + Send + 'a>> {
+        self.before_tool_count.fetch_add(1, Ordering::Relaxed);
+        Box::pin(std::future::ready(ToolHookResult::Allow))
+    }
+}
+
+/// Hook that always aborts on before_query.
+struct AbortingHook;
+
+impl TurnHook for AbortingHook {
+    fn name(&self) -> &'static str {
+        "aborting"
+    }
+
+    fn before_query<'a>(
+        &'a self,
+        _context: &'a mut QueryContext<'_>,
+    ) -> Pin<Box<dyn Future<Output = HookResult> + Send + 'a>> {
+        Box::pin(std::future::ready(HookResult::Abort {
+            reason: "budget exceeded".to_owned(),
+        }))
+    }
+}
+
+/// Hook that always denies tool calls.
+struct DenyingToolHook;
+
+impl TurnHook for DenyingToolHook {
+    fn name(&self) -> &'static str {
+        "denying"
+    }
+
+    fn before_tool<'a>(
+        &'a self,
+        tool_name: &'a str,
+        _input: &'a serde_json::Value,
+        _context: &'a ToolHookContext<'_>,
+    ) -> Pin<Box<dyn Future<Output = ToolHookResult> + Send + 'a>> {
+        Box::pin(std::future::ready(ToolHookResult::Deny {
+            reason: format!("tool '{tool_name}' denied by test hook"),
+        }))
+    }
+}
+
+/// Hook that records the order it was called using a shared counter.
+struct OrderTrackingHook {
+    name: &'static str,
+    order: Arc<std::sync::Mutex<Vec<&'static str>>>,
+}
+
+impl TurnHook for OrderTrackingHook {
+    fn name(&self) -> &'static str {
+        self.name
+    }
+
+    fn before_query<'a>(
+        &'a self,
+        _context: &'a mut QueryContext<'_>,
+    ) -> Pin<Box<dyn Future<Output = HookResult> + Send + 'a>> {
+        Box::pin(async move {
+            self.order.lock().expect("lock").push(self.name);
+            HookResult::Continue
+        })
+    }
+
+    fn before_tool<'a>(
+        &'a self,
+        _tool_name: &'a str,
+        _input: &'a serde_json::Value,
+        _context: &'a ToolHookContext<'_>,
+    ) -> Pin<Box<dyn Future<Output = ToolHookResult> + Send + 'a>> {
+        Box::pin(async move {
+            self.order.lock().expect("lock").push(self.name);
+            ToolHookResult::Allow
+        })
+    }
+}
+
+fn test_turn_result() -> TurnResult {
+    TurnResult {
+        content: "test response".to_owned(),
+        tool_calls: Vec::new(),
+        usage: TurnUsage {
+            input_tokens: 100,
+            output_tokens: 50,
+            cache_read_tokens: 0,
+            cache_write_tokens: 0,
+            llm_calls: 1,
+        },
+        signals: Vec::new(),
+        stop_reason: "end_turn".to_owned(),
+    }
+}
+
+static DEFAULT_USAGE: TurnUsage = TurnUsage {
+    input_tokens: 0,
+    output_tokens: 0,
+    cache_read_tokens: 0,
+    cache_write_tokens: 0,
+    llm_calls: 0,
+};
+
+fn test_tool_hook_context() -> ToolHookContext<'static> {
+    ToolHookContext {
+        nous_id: "test-agent",
+        turn_usage: &DEFAULT_USAGE,
+        tool_allowlist: None,
+    }
+}
+
+// -- Trait tests --
+
+mod trait_tests {
+    use super::*;
+
+    #[test]
+    fn default_before_query_returns_continue() {
+        struct MinimalHook;
+        impl TurnHook for MinimalHook {
+            fn name(&self) -> &'static str {
+                "minimal"
+            }
+        }
+        let hook = MinimalHook;
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .expect("runtime");
+        let mut pipeline = PipelineContext::default();
+        let mut ctx = QueryContext {
+            pipeline: &mut pipeline,
+            nous_id: "test",
+            user_message: "hello",
+        };
+        let result = rt.block_on(hook.before_query(&mut ctx));
+        assert_eq!(
+            result,
+            HookResult::Continue,
+            "default before_query should return Continue"
+        );
+    }
+
+    #[test]
+    fn default_on_turn_complete_returns_continue() {
+        struct MinimalHook;
+        impl TurnHook for MinimalHook {
+            fn name(&self) -> &'static str {
+                "minimal"
+            }
+        }
+        let hook = MinimalHook;
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .expect("runtime");
+        let result = test_turn_result();
+        let ctx = TurnContext {
+            result: &result,
+            nous_id: "test",
+            session_tokens: 0,
+        };
+        let hook_result = rt.block_on(hook.on_turn_complete(&ctx));
+        assert_eq!(
+            hook_result,
+            HookResult::Continue,
+            "default on_turn_complete should return Continue"
+        );
+    }
+
+    #[test]
+    fn default_before_tool_returns_allow() {
+        struct MinimalHook;
+        impl TurnHook for MinimalHook {
+            fn name(&self) -> &'static str {
+                "minimal"
+            }
+        }
+        let hook = MinimalHook;
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .expect("runtime");
+        let ctx = test_tool_hook_context();
+        let result = rt.block_on(hook.before_tool("test_tool", &serde_json::json!({}), &ctx));
+        assert_eq!(
+            result,
+            ToolHookResult::Allow,
+            "default before_tool should return Allow"
+        );
+    }
+}
+
+// -- Registry tests --
+
+mod registry_tests {
+    use super::*;
+
+    #[test]
+    fn empty_registry_has_zero_hooks() {
+        let registry = HookRegistry::new();
+        assert_eq!(registry.len(), 0, "new registry should have zero hooks");
+    }
+
+    #[test]
+    fn register_adds_hooks() {
+        let mut registry = HookRegistry::new();
+        registry.register(10, Box::new(NoopHook::new("first")));
+        registry.register(20, Box::new(NoopHook::new("second")));
+        assert_eq!(registry.len(), 2, "should have two registered hooks");
+    }
+
+    #[tokio::test]
+    async fn before_query_runs_all_hooks_in_order() {
+        let order = Arc::new(std::sync::Mutex::new(Vec::<&'static str>::new()));
+        let mut registry = HookRegistry::new();
+        registry.register(
+            30,
+            Box::new(OrderTrackingHook {
+                name: "third",
+                order: Arc::clone(&order),
+            }),
+        );
+        registry.register(
+            10,
+            Box::new(OrderTrackingHook {
+                name: "first",
+                order: Arc::clone(&order),
+            }),
+        );
+        registry.register(
+            20,
+            Box::new(OrderTrackingHook {
+                name: "second",
+                order: Arc::clone(&order),
+            }),
+        );
+
+        let mut pipeline = PipelineContext::default();
+        let mut ctx = QueryContext {
+            pipeline: &mut pipeline,
+            nous_id: "test",
+            user_message: "hello",
+        };
+
+        let result = registry.run_before_query(&mut ctx).await;
+        assert_eq!(result, HookResult::Continue, "all hooks should allow");
+
+        let calls = order.lock().expect("lock");
+        assert_eq!(
+            *calls,
+            vec!["first", "second", "third"],
+            "hooks should run in priority order (lower number first)"
+        );
+    }
+
+    #[tokio::test]
+    async fn before_query_short_circuits_on_abort() {
+        let order = Arc::new(std::sync::Mutex::new(Vec::<&'static str>::new()));
+        let mut registry = HookRegistry::new();
+        registry.register(
+            10,
+            Box::new(OrderTrackingHook {
+                name: "first",
+                order: Arc::clone(&order),
+            }),
+        );
+        registry.register(20, Box::new(AbortingHook));
+        registry.register(
+            30,
+            Box::new(OrderTrackingHook {
+                name: "should_not_run",
+                order: Arc::clone(&order),
+            }),
+        );
+
+        let mut pipeline = PipelineContext::default();
+        let mut ctx = QueryContext {
+            pipeline: &mut pipeline,
+            nous_id: "test",
+            user_message: "hello",
+        };
+
+        let result = registry.run_before_query(&mut ctx).await;
+        assert!(
+            matches!(result, HookResult::Abort { .. }),
+            "should abort from aborting hook"
+        );
+
+        let calls = order.lock().expect("lock");
+        assert_eq!(
+            *calls,
+            vec!["first"],
+            "only first hook should have run before abort"
+        );
+    }
+
+    #[tokio::test]
+    async fn before_tool_short_circuits_on_deny() {
+        let order = Arc::new(std::sync::Mutex::new(Vec::<&'static str>::new()));
+        let mut registry = HookRegistry::new();
+        registry.register(
+            10,
+            Box::new(OrderTrackingHook {
+                name: "first",
+                order: Arc::clone(&order),
+            }),
+        );
+        registry.register(20, Box::new(DenyingToolHook));
+        registry.register(
+            30,
+            Box::new(OrderTrackingHook {
+                name: "should_not_run",
+                order: Arc::clone(&order),
+            }),
+        );
+
+        let ctx = test_tool_hook_context();
+        let result = registry
+            .run_before_tool("test_tool", &serde_json::json!({}), &ctx)
+            .await;
+
+        assert!(
+            matches!(result, ToolHookResult::Deny { .. }),
+            "should deny from denying hook"
+        );
+
+        let calls = order.lock().expect("lock");
+        assert_eq!(
+            *calls,
+            vec!["first"],
+            "only first hook should have run before deny"
+        );
+    }
+
+    #[tokio::test]
+    async fn on_turn_complete_runs_all_hooks_without_short_circuit() {
+        let hook1 = Arc::new(NoopHook::new("hook1"));
+        let hook2 = Arc::new(NoopHook::new("hook2"));
+
+        let mut registry = HookRegistry::new();
+        registry.register(10, Box::new(NoopHook::new("first")));
+        registry.register(20, Box::new(NoopHook::new("second")));
+
+        let result = test_turn_result();
+        let ctx = TurnContext {
+            result: &result,
+            nous_id: "test",
+            session_tokens: 100,
+        };
+
+        registry.run_on_turn_complete(&ctx).await;
+
+        // NOTE: we can't directly check call counts on the registered hooks
+        // because they're moved into boxes. The test verifies it runs without panic.
+        drop(hook1);
+        drop(hook2);
+    }
+
+    #[tokio::test]
+    async fn equal_priority_hooks_run_in_insertion_order() {
+        let order = Arc::new(std::sync::Mutex::new(Vec::<&'static str>::new()));
+        let mut registry = HookRegistry::new();
+        registry.register(
+            10,
+            Box::new(OrderTrackingHook {
+                name: "a",
+                order: Arc::clone(&order),
+            }),
+        );
+        registry.register(
+            10,
+            Box::new(OrderTrackingHook {
+                name: "b",
+                order: Arc::clone(&order),
+            }),
+        );
+        registry.register(
+            10,
+            Box::new(OrderTrackingHook {
+                name: "c",
+                order: Arc::clone(&order),
+            }),
+        );
+
+        let mut pipeline = PipelineContext::default();
+        let mut ctx = QueryContext {
+            pipeline: &mut pipeline,
+            nous_id: "test",
+            user_message: "hello",
+        };
+
+        registry.run_before_query(&mut ctx).await;
+
+        let calls = order.lock().expect("lock");
+        assert_eq!(
+            *calls,
+            vec!["a", "b", "c"],
+            "equal-priority hooks should run in insertion order"
+        );
+    }
+}
+
+// -- Built-in hook tests --
+
+mod cost_control_tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn allows_when_budget_is_zero() {
+        let hook = CostControlHook::new(0);
+        let mut pipeline = PipelineContext {
+            remaining_tokens: 100,
+            ..PipelineContext::default()
+        };
+        let mut ctx = QueryContext {
+            pipeline: &mut pipeline,
+            nous_id: "test",
+            user_message: "hello",
+        };
+
+        let result = hook.before_query(&mut ctx).await;
+        assert_eq!(
+            result,
+            HookResult::Continue,
+            "zero budget should mean unlimited"
+        );
+    }
+
+    #[tokio::test]
+    async fn allows_when_tokens_sufficient() {
+        let hook = CostControlHook::new(1000);
+        let mut pipeline = PipelineContext {
+            remaining_tokens: 500,
+            ..PipelineContext::default()
+        };
+        let mut ctx = QueryContext {
+            pipeline: &mut pipeline,
+            nous_id: "test",
+            user_message: "hello",
+        };
+
+        let result = hook.before_query(&mut ctx).await;
+        assert_eq!(
+            result,
+            HookResult::Continue,
+            "should allow when remaining > 10% of budget"
+        );
+    }
+
+    #[tokio::test]
+    async fn aborts_when_nearly_exhausted() {
+        let hook = CostControlHook::new(1000);
+        let mut pipeline = PipelineContext {
+            remaining_tokens: 50, // less than 1000/10 = 100
+            ..PipelineContext::default()
+        };
+        let mut ctx = QueryContext {
+            pipeline: &mut pipeline,
+            nous_id: "test",
+            user_message: "hello",
+        };
+
+        let result = hook.before_query(&mut ctx).await;
+        assert!(
+            matches!(result, HookResult::Abort { .. }),
+            "should abort when remaining < 10% of budget"
+        );
+    }
+
+    #[tokio::test]
+    async fn denies_tool_when_turn_budget_exceeded() {
+        let hook = CostControlHook::new(100);
+        let usage = TurnUsage {
+            input_tokens: 80,
+            output_tokens: 30, // total = 110 > 100
+            ..TurnUsage::default()
+        };
+        let ctx = ToolHookContext {
+            nous_id: "test",
+            turn_usage: &usage,
+            tool_allowlist: None,
+        };
+
+        let result = hook
+            .before_tool("test_tool", &serde_json::json!({}), &ctx)
+            .await;
+        assert!(
+            matches!(result, ToolHookResult::Deny { .. }),
+            "should deny when turn usage exceeds budget"
+        );
+    }
+
+    #[tokio::test]
+    async fn allows_tool_when_within_budget() {
+        let hook = CostControlHook::new(200);
+        let usage = TurnUsage {
+            input_tokens: 80,
+            output_tokens: 30, // total = 110 < 200
+            ..TurnUsage::default()
+        };
+        let ctx = ToolHookContext {
+            nous_id: "test",
+            turn_usage: &usage,
+            tool_allowlist: None,
+        };
+
+        let result = hook
+            .before_tool("test_tool", &serde_json::json!({}), &ctx)
+            .await;
+        assert_eq!(
+            result,
+            ToolHookResult::Allow,
+            "should allow when within budget"
+        );
+    }
+}
+
+mod scope_enforcement_tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn allows_when_no_allowlist() {
+        let hook = ScopeEnforcementHook;
+        let ctx = ToolHookContext {
+            nous_id: "test",
+            turn_usage: &TurnUsage::default(),
+            tool_allowlist: None,
+        };
+
+        let result = hook
+            .before_tool("any_tool", &serde_json::json!({}), &ctx)
+            .await;
+        assert_eq!(
+            result,
+            ToolHookResult::Allow,
+            "should allow any tool when no allowlist"
+        );
+    }
+
+    #[tokio::test]
+    async fn allows_tool_in_allowlist() {
+        let hook = ScopeEnforcementHook;
+        let allowlist = vec!["read".to_owned(), "write".to_owned()];
+        let ctx = ToolHookContext {
+            nous_id: "test",
+            turn_usage: &TurnUsage::default(),
+            tool_allowlist: Some(&allowlist),
+        };
+
+        let result = hook.before_tool("read", &serde_json::json!({}), &ctx).await;
+        assert_eq!(
+            result,
+            ToolHookResult::Allow,
+            "should allow tool in allowlist"
+        );
+    }
+
+    #[tokio::test]
+    async fn denies_tool_not_in_allowlist() {
+        let hook = ScopeEnforcementHook;
+        let allowlist = vec!["read".to_owned(), "write".to_owned()];
+        let ctx = ToolHookContext {
+            nous_id: "test",
+            turn_usage: &TurnUsage::default(),
+            tool_allowlist: Some(&allowlist),
+        };
+
+        let result = hook.before_tool("exec", &serde_json::json!({}), &ctx).await;
+        assert!(
+            matches!(result, ToolHookResult::Deny { reason } if reason.contains("exec")),
+            "should deny tool not in allowlist with tool name in reason"
+        );
+    }
+}
+
+mod audit_logging_tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn before_query_returns_continue() {
+        let hook = AuditLoggingHook;
+        let mut pipeline = PipelineContext::default();
+        let mut ctx = QueryContext {
+            pipeline: &mut pipeline,
+            nous_id: "test",
+            user_message: "hello",
+        };
+
+        let result = hook.before_query(&mut ctx).await;
+        assert_eq!(
+            result,
+            HookResult::Continue,
+            "audit hook should always continue on before_query"
+        );
+    }
+
+    #[tokio::test]
+    async fn on_turn_complete_returns_continue() {
+        let hook = AuditLoggingHook;
+        let turn_result = test_turn_result();
+        let ctx = TurnContext {
+            result: &turn_result,
+            nous_id: "test",
+            session_tokens: 150,
+        };
+
+        let result = hook.on_turn_complete(&ctx).await;
+        assert_eq!(
+            result,
+            HookResult::Continue,
+            "audit hook should always continue on turn_complete"
+        );
+    }
+}
+
+// -- Config tests --
+
+mod config_tests {
+    use crate::config::HookConfig;
+    use crate::hooks::builtins::register_builtin_hooks;
+    use crate::hooks::registry::HookRegistry;
+
+    #[test]
+    fn default_config_enables_all_hooks() {
+        let config = HookConfig::default();
+        assert!(
+            config.cost_control_enabled,
+            "cost control should be enabled by default"
+        );
+        assert!(
+            config.scope_enforcement_enabled,
+            "scope enforcement should be enabled by default"
+        );
+        assert!(
+            config.audit_logging_enabled,
+            "audit logging should be enabled by default"
+        );
+    }
+
+    #[test]
+    fn register_all_builtins_from_default_config() {
+        let mut registry = HookRegistry::new();
+        let config = HookConfig::default();
+        register_builtin_hooks(&mut registry, &config);
+        assert_eq!(
+            registry.len(),
+            3,
+            "default config should register 3 built-in hooks"
+        );
+    }
+
+    #[test]
+    fn disabling_hooks_reduces_count() {
+        let mut registry = HookRegistry::new();
+        let config = HookConfig {
+            cost_control_enabled: false,
+            scope_enforcement_enabled: false,
+            audit_logging_enabled: true,
+            turn_token_budget: 0,
+        };
+        register_builtin_hooks(&mut registry, &config);
+        assert_eq!(
+            registry.len(),
+            1,
+            "only audit logging hook should be registered"
+        );
+    }
+
+    #[test]
+    fn all_hooks_disabled_gives_empty_registry() {
+        let mut registry = HookRegistry::new();
+        let config = HookConfig {
+            cost_control_enabled: false,
+            scope_enforcement_enabled: false,
+            audit_logging_enabled: false,
+            turn_token_budget: 0,
+        };
+        register_builtin_hooks(&mut registry, &config);
+        assert_eq!(
+            registry.len(),
+            0,
+            "disabling all hooks should give empty registry"
+        );
+    }
+
+    #[test]
+    fn hook_config_serde_roundtrip() {
+        let config = HookConfig::default();
+        let json = serde_json::to_string(&config).expect("serialize HookConfig");
+        let back: HookConfig = serde_json::from_str(&json).expect("deserialize HookConfig");
+        assert_eq!(config.cost_control_enabled, back.cost_control_enabled);
+        assert_eq!(
+            config.scope_enforcement_enabled,
+            back.scope_enforcement_enabled
+        );
+        assert_eq!(config.audit_logging_enabled, back.audit_logging_enabled);
+        assert_eq!(config.turn_token_budget, back.turn_token_budget);
+    }
+}
+
+// -- Integration test --
+
+mod integration_tests {
+    use super::*;
+    use crate::config::HookConfig;
+    use crate::hooks::builtins::register_builtin_hooks;
+
+    #[tokio::test]
+    async fn full_hook_lifecycle_with_builtins() {
+        let mut registry = HookRegistry::new();
+        register_builtin_hooks(&mut registry, &HookConfig::default());
+
+        // before_query should succeed
+        let mut pipeline = PipelineContext {
+            remaining_tokens: 10_000,
+            ..PipelineContext::default()
+        };
+        let mut query_ctx = QueryContext {
+            pipeline: &mut pipeline,
+            nous_id: "test-agent",
+            user_message: "hello",
+        };
+        let result = registry.run_before_query(&mut query_ctx).await;
+        assert_eq!(
+            result,
+            HookResult::Continue,
+            "built-in hooks should allow normal query"
+        );
+
+        // before_tool with no allowlist should succeed
+        let usage = TurnUsage::default();
+        let tool_ctx = ToolHookContext {
+            nous_id: "test-agent",
+            turn_usage: &usage,
+            tool_allowlist: None,
+        };
+        let tool_result = registry
+            .run_before_tool("read", &serde_json::json!({}), &tool_ctx)
+            .await;
+        assert_eq!(
+            tool_result,
+            ToolHookResult::Allow,
+            "built-in hooks should allow tool with no allowlist"
+        );
+
+        // on_turn_complete should run without error
+        let turn_result = test_turn_result();
+        let turn_ctx = TurnContext {
+            result: &turn_result,
+            nous_id: "test-agent",
+            session_tokens: 150,
+        };
+        registry.run_on_turn_complete(&turn_ctx).await;
+    }
+
+    #[tokio::test]
+    async fn scope_enforcement_denies_through_registry() {
+        let allowlist = vec!["read".to_owned()];
+        let mut registry = HookRegistry::new();
+        register_builtin_hooks(&mut registry, &HookConfig::default());
+
+        let usage = TurnUsage::default();
+        let tool_ctx = ToolHookContext {
+            nous_id: "test-agent",
+            turn_usage: &usage,
+            tool_allowlist: Some(&allowlist),
+        };
+
+        let result = registry
+            .run_before_tool("write", &serde_json::json!({}), &tool_ctx)
+            .await;
+        assert!(
+            matches!(result, ToolHookResult::Deny { .. }),
+            "scope enforcement should deny 'write' when only 'read' is allowed"
+        );
+    }
+
+    #[tokio::test]
+    async fn cost_control_denies_through_registry() {
+        let config = HookConfig {
+            cost_control_enabled: true,
+            turn_token_budget: 100,
+            scope_enforcement_enabled: false,
+            audit_logging_enabled: false,
+        };
+        let mut registry = HookRegistry::new();
+        register_builtin_hooks(&mut registry, &config);
+
+        let usage = TurnUsage {
+            input_tokens: 80,
+            output_tokens: 30, // total = 110 > 100
+            ..TurnUsage::default()
+        };
+        let tool_ctx = ToolHookContext {
+            nous_id: "test-agent",
+            turn_usage: &usage,
+            tool_allowlist: None,
+        };
+
+        let result = registry
+            .run_before_tool("test_tool", &serde_json::json!({}), &tool_ctx)
+            .await;
+        assert!(
+            matches!(result, ToolHookResult::Deny { .. }),
+            "cost control should deny tool when turn budget exceeded"
+        );
+    }
+}

--- a/crates/nous/src/lib.rs
+++ b/crates/nous/src/lib.rs
@@ -32,6 +32,8 @@ pub(crate) mod finalize;
 pub mod handle;
 /// Conversation history retrieval and token-budgeted formatting.
 pub(crate) mod history;
+/// Turn-level hook system for behavior correction at query, tool, and turn boundaries.
+pub(crate) mod hooks;
 /// Instinct observation bridge: records tool usage for behavioral pattern learning.
 pub(crate) mod instinct;
 /// Lifecycle manager for spawning and addressing nous actors.

--- a/crates/nous/src/pipeline/mod.rs
+++ b/crates/nous/src/pipeline/mod.rs
@@ -21,6 +21,8 @@ use crate::budget::{CompactionMetrics, TokenBudget};
 use crate::config::{NousConfig, PipelineConfig};
 use crate::error;
 use crate::history::HistoryResult;
+use crate::hooks::registry::HookRegistry;
+use crate::hooks::{QueryContext, TurnContext};
 use crate::session::SessionState;
 use crate::stream::TurnStreamEvent;
 use crate::working_state::WorkingState;
@@ -665,6 +667,7 @@ pub(crate) async fn run_pipeline(
     extra_bootstrap: Vec<BootstrapSection>,
     stream_tx: Option<&mpsc::Sender<TurnStreamEvent>>,
     emitter: Option<&EventEmitter>,
+    hooks: Option<&HookRegistry>,
 ) -> error::Result<TurnResult> {
     let default_emitter = EventEmitter::new();
     let emitter = emitter.unwrap_or(&default_emitter);
@@ -728,6 +731,21 @@ pub(crate) async fn run_pipeline(
     run_guard_stage(&input.session, config, emitter)?;
     stages_completed += 1;
 
+    // WHY: before_query hooks run after guard (so rejected requests never reach hooks)
+    // but before execute (so hooks can modify context before the model call).
+    if let Some(hook_registry) = hooks {
+        let mut query_ctx = QueryContext {
+            pipeline: &mut ctx,
+            nous_id: &config.id,
+            user_message: &input.content,
+        };
+        if let crate::hooks::HookResult::Abort { reason } =
+            hook_registry.run_before_query(&mut query_ctx).await
+        {
+            return Err(error::GuardRejectedSnafu { reason }.build());
+        }
+    }
+
     let result = run_execute_stage(
         config,
         pipeline_config,
@@ -740,12 +758,24 @@ pub(crate) async fn run_pipeline(
         pipeline_start,
         total_timeout,
         emitter,
+        hooks,
     )
     .await?;
     stages_completed += 1;
 
     run_finalize_stage(config, &input, &result, session_store, emitter).await;
     stages_completed += 1;
+
+    // WHY: on_turn_complete hooks run after finalize so audit hooks see the
+    // fully persisted state. Does not short-circuit: all hooks fire.
+    if let Some(hook_registry) = hooks {
+        let turn_ctx = TurnContext {
+            result: &result,
+            nous_id: &config.id,
+            session_tokens: input.session.cumulative_tokens,
+        };
+        hook_registry.run_on_turn_complete(&turn_ctx).await;
+    }
 
     if !result.tool_calls.is_empty() {
         crate::instinct::record_observations(&result.tool_calls, &input.content, &config.id);

--- a/crates/nous/src/pipeline/pipeline_tests/pipeline_types.rs
+++ b/crates/nous/src/pipeline/pipeline_tests/pipeline_types.rs
@@ -287,6 +287,7 @@ async fn run_pipeline_simple() {
         Vec::new(),
         None,
         None,
+        None,
     )
     .await
     .expect("pipeline should succeed");

--- a/crates/nous/src/pipeline/stages.rs
+++ b/crates/nous/src/pipeline/stages.rs
@@ -19,6 +19,7 @@ use crate::compact::CompactConfig;
 use crate::config::{NousConfig, PipelineConfig};
 use crate::error;
 use crate::history::{self, HistoryConfig};
+use crate::hooks::registry::HookRegistry;
 use crate::session::SessionState;
 use crate::stream::TurnStreamEvent;
 
@@ -486,6 +487,7 @@ pub(super) async fn run_execute_stage(
     pipeline_start: Instant,
     total_timeout: Option<Duration>,
     emitter: &EventEmitter,
+    hooks: Option<&HookRegistry>,
 ) -> error::Result<TurnResult> {
     let span = info_span!(
         "pipeline_stage",
@@ -521,10 +523,20 @@ pub(super) async fn run_execute_stage(
                 tools,
                 tool_ctx,
                 tx,
+                hooks,
             )
             .await
         } else {
-            crate::execute::execute(ctx, &input.session, config, providers, tools, tool_ctx).await
+            crate::execute::execute(
+                ctx,
+                &input.session,
+                config,
+                providers,
+                tools,
+                tool_ctx,
+                hooks,
+            )
+            .await
         }
     };
 

--- a/crates/nous/src/pipeline_tests.rs
+++ b/crates/nous/src/pipeline_tests.rs
@@ -308,6 +308,7 @@ async fn run_pipeline_simple() {
         Vec::new(),
         None,
         None,
+        None,
     )
     .await
     .expect("pipeline should succeed");

--- a/crates/nous/src/spawn_svc.rs
+++ b/crates/nous/src/spawn_svc.rs
@@ -106,6 +106,7 @@ impl SpawnService for SpawnServiceImpl {
             cache_enabled: true,
             recall: crate::recall::RecallConfig::default(),
             tool_allowlist,
+            hooks: crate::config::HookConfig::default(),
         };
 
         let pipeline_config = PipelineConfig {


### PR DESCRIPTION
## Summary
- Add `TurnHook` async trait with three hook points: `before_query`, `on_turn_complete`, `before_tool`
- Add priority-ordered `HookRegistry` with short-circuit on denial for `before_query` and `before_tool`
- Add three built-in hooks: `CostControlHook` (token budget), `ScopeEnforcementHook` (tool allowlist), `AuditLoggingHook` (structured logging)
- Add `HookConfig` to `NousConfig` for toggling hooks and setting budgets
- Integrate hooks into pipeline at all three points (guard→execute→finalize)
- Fix pre-existing `graphe/migration.rs` build break from sha2 0.11 `LowerHex` removal

## Acceptance criteria
- [x] `TurnHook` trait with `before_query`, `on_turn_complete`, `before_tool` — default impls return Continue/Allow
- [x] `HookRegistry` stores hooks sorted by priority; `run_before_query` and `run_before_tool` short-circuit on Abort/Deny; `run_on_turn_complete` runs all hooks
- [x] `CostControlHook` aborts when remaining tokens < 10% of budget, denies tool calls when turn usage exceeds budget
- [x] `ScopeEnforcementHook` denies tools not in the agent's `tool_allowlist`
- [x] `AuditLoggingHook` logs turn start/completion via tracing and records metrics
- [x] `HookConfig` in `NousConfig` with `cost_control_enabled`, `turn_token_budget`, `scope_enforcement_enabled`, `audit_logging_enabled`
- [x] Pipeline integration: `before_query` fires between guard and execute, `on_turn_complete` after finalize, `before_tool` inside execute loop
- [x] 28 tests covering trait defaults, registry ordering, short-circuiting, all built-ins, config serde, and integration lifecycle

## Observations
- **Pre-existing test failures**: 3 tests fail on main (`max_iterations_respected`, `max_iterations_one_exits_immediately`, `session_id_adoption_prevents_fk_divergence`) — not introduced by this PR
- **Pre-existing build break**: `graphe/migration.rs` sha2 0.11 incompatibility fixed as a drive-by (sha2 removed `LowerHex` for `CtOutput`)
- **Debt**: `execute()` and `execute_streaming()` now have 7-8 parameters — consider a context struct in a future refactor

## Validation gate
- `cargo fmt --all -- --check` ✓
- `cargo clippy -p aletheia-nous -- -D warnings` ✓
- `cargo test -p aletheia-nous` ✓ (514 passed; 3 pre-existing failures on main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #1818