### PR TITLE
feat(nous): add task registry with progress streaming and GC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -389,6 +389,7 @@ dependencies = [
  "tokio-util",
  "tracing",
  "ulid",
+ "uuid",
 ]
 
 [[package]]

--- a/crates/graphe/src/migration.rs
+++ b/crates/graphe/src/migration.rs
@@ -436,6 +436,8 @@ fn reconcile_user_version(conn: &Connection, table_version: u32) -> Result<()> {
 
 /// Compute the SHA-256 checksum of the given SQL string, returned as a hex string.
 fn compute_checksum(sql: &str) -> String {
+    use std::fmt::Write as _;
+
     let mut hasher = Sha256::new();
     hasher.update(sql.as_bytes());
     // WHY: sha2 0.11 output no longer implements LowerHex; format byte-by-byte

--- a/crates/nous/Cargo.toml
+++ b/crates/nous/Cargo.toml
@@ -35,8 +35,10 @@ serde_json = { workspace = true }
 snafu = { workspace = true }
 tokio = { workspace = true }
 tokio-util = { workspace = true }
+tempfile = { workspace = true }
 tracing = { workspace = true }
 ulid = { workspace = true }
+uuid = { workspace = true }
 
 [dev-dependencies]
 aletheia-hermeneus = { path = "../hermeneus", features = ["test-support"] }

--- a/crates/nous/src/lib.rs
+++ b/crates/nous/src/lib.rs
@@ -54,6 +54,8 @@ pub(crate) mod skills;
 pub mod spawn_svc;
 /// Real-time streaming events for the turn pipeline.
 pub mod stream;
+/// Task registry with progress streaming, cooperative cancellation, and GC.
+pub mod tasks;
 /// Uncertainty quantification: calibration tracking for agent confidence predictions.
 pub mod uncertainty;
 /// User-facing error formatting for display in chat responses.

--- a/crates/nous/src/tasks/gc.rs
+++ b/crates/nous/src/tasks/gc.rs
@@ -1,0 +1,237 @@
+//! Garbage collection for stale task entries.
+//!
+//! WHY: Completed and failed tasks waste memory and clutter listings if retained
+//! indefinitely. Periodic sweeps are simpler than per-task timers and avoid the
+//! coordination overhead of expiry-based eviction.
+
+use std::time::Duration;
+
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, warn};
+
+use super::output;
+use super::registry::TaskRegistry;
+
+/// Default interval between GC sweeps.
+const DEFAULT_GC_INTERVAL: Duration = Duration::from_secs(5 * 60);
+
+/// Spawn a background GC task that periodically evicts stale entries.
+///
+/// The task runs until the `shutdown` token is cancelled. Output files for
+/// evicted tasks are cleaned up from disk.
+///
+/// Returns a `JoinHandle` so the caller can await shutdown completion.
+pub fn spawn_gc_task(
+    registry: TaskRegistry,
+    shutdown: CancellationToken,
+) -> tokio::task::JoinHandle<()> {
+    spawn_gc_task_with_interval(registry, shutdown, DEFAULT_GC_INTERVAL)
+}
+
+/// Spawn a GC task with a custom sweep interval.
+///
+/// WHY: Exposed for testing with short intervals.
+pub(crate) fn spawn_gc_task_with_interval(
+    registry: TaskRegistry,
+    shutdown: CancellationToken,
+    interval: Duration,
+) -> tokio::task::JoinHandle<()> {
+    let span = tracing::info_span!("task_gc");
+    tokio::spawn(
+        async move {
+            let mut ticker = tokio::time::interval(interval);
+            // WHY: Skip the immediate first tick -- tasks just registered
+            // shouldn't be swept immediately.
+            ticker.tick().await;
+
+            loop {
+                tokio::select! {
+                    biased;
+                    () = shutdown.cancelled() => {
+                        debug!("GC task shutting down");
+                        break;
+                    }
+                    _ = ticker.tick() => {
+                        run_gc_sweep(&registry).await;
+                    }
+                }
+            }
+        }
+        .instrument(span),
+    )
+}
+
+/// Execute a single GC sweep: evict stale tasks and clean up output files.
+async fn run_gc_sweep(registry: &TaskRegistry) {
+    let evicted = match registry.gc_sweep() {
+        Ok(evicted) => evicted,
+        Err(e) => {
+            warn!(error = %e, "GC sweep failed");
+            return;
+        }
+    };
+
+    if evicted.is_empty() {
+        return;
+    }
+
+    debug!(count = evicted.len(), "GC evicted stale tasks");
+
+    for (task_id, output_path) in evicted {
+        if let Some(path) = output_path
+            && let Err(e) = output::remove_output_file(&path).await
+        {
+            // NOTE: Best-effort cleanup. File may already be gone.
+            warn!(%task_id, error = %e, "failed to remove output file during GC");
+        }
+    }
+}
+
+// WHY: `tracing::Instrument` must be in scope for `.instrument()` on futures.
+use tracing::Instrument as _;
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::*;
+    use crate::tasks::types::TaskType;
+
+    #[tokio::test]
+    async fn gc_evicts_completed_tasks_after_deadline() {
+        // WHY: Zero deadline + short interval = immediate eviction on first sweep.
+        let registry = TaskRegistry::new(Duration::from_secs(0));
+        let shutdown = CancellationToken::new();
+
+        let (id, _) = registry
+            .register(
+                TaskType::Shell {
+                    command: "done".into(),
+                },
+                "stale task".into(),
+            )
+            .expect("register");
+
+        registry
+            .update_status(id, crate::tasks::TaskStatus::Running)
+            .expect("to running");
+        registry
+            .update_status(id, crate::tasks::TaskStatus::Completed)
+            .expect("to completed");
+
+        let handle = spawn_gc_task_with_interval(
+            registry.clone(),
+            shutdown.clone(),
+            Duration::from_millis(50),
+        );
+
+        // WHY: Wait long enough for at least one sweep.
+        tokio::time::sleep(Duration::from_millis(200)).await;
+
+        shutdown.cancel();
+        handle.await.expect("gc task join");
+
+        assert!(registry.get(id).is_err(), "task should have been evicted");
+    }
+
+    #[tokio::test]
+    async fn gc_preserves_running_tasks() {
+        let registry = TaskRegistry::new(Duration::from_secs(0));
+        let shutdown = CancellationToken::new();
+
+        let (id, _) = registry
+            .register(
+                TaskType::Agent {
+                    agent_id: "alice".into(),
+                    prompt: "work".into(),
+                },
+                "active task".into(),
+            )
+            .expect("register");
+
+        registry
+            .update_status(id, crate::tasks::TaskStatus::Running)
+            .expect("to running");
+
+        let handle = spawn_gc_task_with_interval(
+            registry.clone(),
+            shutdown.clone(),
+            Duration::from_millis(50),
+        );
+
+        tokio::time::sleep(Duration::from_millis(200)).await;
+
+        shutdown.cancel();
+        handle.await.expect("gc task join");
+
+        assert!(registry.get(id).is_ok(), "running task should be preserved");
+    }
+
+    #[tokio::test]
+    async fn gc_cleans_up_output_files() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let registry = TaskRegistry::new(Duration::from_secs(0));
+        let shutdown = CancellationToken::new();
+
+        let (id, _) = registry
+            .register(
+                TaskType::Shell {
+                    command: "echo hi".into(),
+                },
+                "with output".into(),
+            )
+            .expect("register");
+
+        // Create an output file and register its path.
+        let mut writer = crate::tasks::OutputWriter::new(dir.path())
+            .await
+            .expect("create writer");
+        writer.write_chunk(b"output data").await.expect("write");
+        let output_path = writer.path().to_path_buf();
+
+        registry
+            .set_output_path(id, output_path.clone())
+            .expect("set output path");
+
+        registry
+            .update_status(id, crate::tasks::TaskStatus::Running)
+            .expect("to running");
+        registry
+            .update_status(id, crate::tasks::TaskStatus::Completed)
+            .expect("to completed");
+
+        assert!(output_path.exists(), "output file should exist before GC");
+
+        let handle = spawn_gc_task_with_interval(
+            registry.clone(),
+            shutdown.clone(),
+            Duration::from_millis(50),
+        );
+
+        tokio::time::sleep(Duration::from_millis(200)).await;
+
+        shutdown.cancel();
+        handle.await.expect("gc task join");
+
+        assert!(
+            !output_path.exists(),
+            "output file should be cleaned up after GC"
+        );
+    }
+
+    #[tokio::test]
+    async fn gc_shutdown_is_clean() {
+        let registry = TaskRegistry::with_default_deadline();
+        let shutdown = CancellationToken::new();
+
+        let handle =
+            spawn_gc_task_with_interval(registry, shutdown.clone(), Duration::from_millis(50));
+
+        shutdown.cancel();
+        // WHY: Should complete promptly without hanging.
+        tokio::time::timeout(Duration::from_secs(1), handle)
+            .await
+            .expect("gc task should shut down within 1s")
+            .expect("gc task join");
+    }
+}

--- a/crates/nous/src/tasks/mod.rs
+++ b/crates/nous/src/tasks/mod.rs
@@ -1,0 +1,16 @@
+//! Task registry with progress streaming and garbage collection.
+//!
+//! Provides a concurrent task registry for tracking background work across the
+//! nous actor system. Each task has a typed identity, status lifecycle, progress
+//! broadcast channel, disk-backed output, and cooperative cancellation via
+//! `CancellationToken`.
+
+mod gc;
+mod output;
+mod registry;
+mod types;
+
+pub use gc::spawn_gc_task;
+pub use output::{OutputError, OutputReader, OutputWriter};
+pub use registry::{RegistryError, TaskRegistry, TaskSnapshot};
+pub use types::{ProgressEvent, TaskEntry, TaskId, TaskStatus, TaskType, ToolCallSummary};

--- a/crates/nous/src/tasks/output.rs
+++ b/crates/nous/src/tasks/output.rs
@@ -1,0 +1,175 @@
+//! Disk-backed task output with streaming read-back.
+//!
+//! WHY: Large shell outputs should not live in memory. Writing to a temp file
+//! as output arrives lets callers page through results via `AsyncRead` without
+//! loading the full buffer.
+
+use std::io;
+use std::path::{Path, PathBuf};
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use snafu::{ResultExt as _, Snafu};
+use tokio::fs;
+use tokio::io::{AsyncRead, AsyncWriteExt as _, ReadBuf};
+
+/// Errors from task output I/O.
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub(crate)))]
+#[expect(
+    missing_docs,
+    reason = "snafu error variant fields (source, location, path) are self-documenting via display format"
+)]
+pub enum OutputError {
+    /// Failed to create the output temp file.
+    #[snafu(display("failed to create output file: {source}"))]
+    Create {
+        source: io::Error,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    /// Failed to write to the output file.
+    #[snafu(display("failed to write output: {source}"))]
+    Write {
+        source: io::Error,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    /// Failed to flush the output file.
+    #[snafu(display("failed to flush output: {source}"))]
+    Flush {
+        source: io::Error,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    /// Failed to open the output file for reading.
+    #[snafu(display("failed to open output for reading: {source}"))]
+    Open {
+        source: io::Error,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    /// Failed to remove the output file.
+    #[snafu(display("failed to remove output file at {}: {source}", path.display()))]
+    Remove {
+        path: PathBuf,
+        source: io::Error,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+}
+
+/// Writes task output to a temp file as it arrives.
+pub struct OutputWriter {
+    file: fs::File,
+    path: PathBuf,
+}
+
+impl OutputWriter {
+    /// Create a new output writer backed by a temp file in `dir`.
+    pub async fn new(dir: &Path) -> Result<Self, OutputError> {
+        // WHY: Create parent dir if missing so callers don't need to pre-create.
+        fs::create_dir_all(dir).await.context(CreateSnafu)?;
+
+        let path = dir.join(format!("task-output-{}.log", uuid::Uuid::new_v4()));
+        let file = fs::File::create(&path).await.context(CreateSnafu)?;
+
+        Ok(Self { file, path })
+    }
+
+    /// Append a chunk of output.
+    pub async fn write_chunk(&mut self, data: &[u8]) -> Result<(), OutputError> {
+        self.file.write_all(data).await.context(WriteSnafu)?;
+        self.file.flush().await.context(FlushSnafu)?;
+        Ok(())
+    }
+
+    /// The path to the backing file.
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+/// Streaming reader over a task's disk-backed output.
+///
+/// Implements `AsyncRead` so callers can page through output without loading
+/// the entire file into memory.
+pub struct OutputReader {
+    file: fs::File,
+}
+
+impl OutputReader {
+    /// Open the output file at `path` for streaming reads.
+    pub async fn open(path: &Path) -> Result<Self, OutputError> {
+        let file = fs::File::open(path).await.context(OpenSnafu)?;
+        Ok(Self { file })
+    }
+}
+
+impl AsyncRead for OutputReader {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.file).poll_read(cx, buf)
+    }
+}
+
+/// Remove a task's output file from disk.
+///
+/// WHY: Called during GC eviction to reclaim disk space from stale tasks.
+pub(crate) async fn remove_output_file(path: &Path) -> Result<(), OutputError> {
+    fs::remove_file(path).await.context(RemoveSnafu {
+        path: path.to_path_buf(),
+    })?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use tokio::io::AsyncReadExt as _;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn write_and_read_output() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut writer = OutputWriter::new(dir.path()).await.expect("create writer");
+
+        writer.write_chunk(b"hello ").await.expect("write 1");
+        writer.write_chunk(b"world").await.expect("write 2");
+
+        let path = writer.path().to_path_buf();
+        let mut reader = OutputReader::open(&path).await.expect("open reader");
+        let mut contents = String::new();
+        reader
+            .read_to_string(&mut contents)
+            .await
+            .expect("read output");
+
+        assert_eq!(contents, "hello world");
+    }
+
+    #[tokio::test]
+    async fn remove_output_cleans_up() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let writer = OutputWriter::new(dir.path()).await.expect("create writer");
+        let path = writer.path().to_path_buf();
+
+        assert!(path.exists());
+        remove_output_file(&path).await.expect("remove");
+        assert!(!path.exists());
+    }
+
+    #[tokio::test]
+    async fn open_missing_file_returns_error() {
+        let path = PathBuf::from("/tmp/aletheia-nonexistent-output.log");
+        let result = OutputReader::open(&path).await;
+        assert!(result.is_err());
+    }
+}

--- a/crates/nous/src/tasks/registry.rs
+++ b/crates/nous/src/tasks/registry.rs
@@ -1,0 +1,848 @@
+//! Concurrent task registry with progress streaming and cooperative cancellation.
+
+use std::collections::HashMap;
+use std::sync::{Arc, PoisonError, RwLock};
+use std::time::Duration;
+
+use snafu::Snafu;
+use tracing::debug;
+
+use super::output;
+use super::types::{ProgressEvent, TaskEntry, TaskId, TaskStatus, TaskType, ToolCallSummary};
+
+/// Errors from task registry operations.
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub(crate)))]
+#[expect(
+    missing_docs,
+    reason = "snafu error variant fields (task_id, from, to, source, location) are self-documenting via display format"
+)]
+pub enum RegistryError {
+    /// Task not found in the registry.
+    #[snafu(display("task {task_id} not found"))]
+    NotFound {
+        task_id: TaskId,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    /// Invalid status transition attempted.
+    #[snafu(display("invalid transition for task {task_id}: {from} -> {to}"))]
+    InvalidTransition {
+        task_id: TaskId,
+        from: TaskStatus,
+        to: TaskStatus,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    /// Registry lock poisoned.
+    #[snafu(display("registry lock poisoned"))]
+    LockPoisoned {
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    /// Output file operation failed.
+    #[snafu(display("output error: {source}"))]
+    Output {
+        source: output::OutputError,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+}
+
+/// WHY: `PoisonError` carries the guard type which we don't need in the error.
+/// Using a named binding satisfies `clippy::map_err_ignore`.
+fn lock_poisoned<T>(_poison: PoisonError<T>) -> RegistryError {
+    LockPoisonedSnafu.build()
+}
+
+/// Snapshot of a task for external consumption.
+///
+/// WHY: `TaskEntry` contains non-cloneable fields (`broadcast::Sender`,
+/// `CancellationToken`). This snapshot carries only the displayable state.
+#[derive(Debug, Clone)]
+pub struct TaskSnapshot {
+    /// Task identifier.
+    pub id: TaskId,
+    /// Task type with metadata.
+    pub task_type: TaskType,
+    /// Current lifecycle status.
+    pub status: TaskStatus,
+    /// Human-readable description.
+    pub description: String,
+    /// When the task was registered.
+    pub created_at: jiff::Timestamp,
+    /// When the task reached a terminal status.
+    pub completed_at: Option<jiff::Timestamp>,
+    /// Recent tool call summaries (up to 5).
+    pub recent_activity: Vec<ToolCallSummary>,
+    /// Last error message, if any.
+    pub error_snapshot: Option<String>,
+}
+
+impl From<&TaskEntry> for TaskSnapshot {
+    fn from(entry: &TaskEntry) -> Self {
+        Self {
+            id: entry.id,
+            task_type: entry.task_type.clone(),
+            status: entry.status,
+            description: entry.description.clone(),
+            created_at: entry.created_at,
+            completed_at: entry.completed_at,
+            recent_activity: entry.recent_activity.iter().cloned().collect(),
+            error_snapshot: entry.error_snapshot.clone(),
+        }
+    }
+}
+
+/// Concurrent task registry.
+///
+/// Thread-safe via `Arc<RwLock<...>>`. Uses `std::sync::RwLock` because no lock
+/// is held across `.await` boundaries — all mutations are synchronous under the
+/// lock, with async work (output file I/O, cancellation) happening after release.
+#[derive(Clone)]
+pub struct TaskRegistry {
+    tasks: Arc<RwLock<HashMap<TaskId, TaskEntry>>>,
+    /// How long after completion before GC evicts a task.
+    gc_deadline: Duration,
+}
+
+impl TaskRegistry {
+    /// Create a new task registry with the given GC deadline.
+    pub fn new(gc_deadline: Duration) -> Self {
+        Self {
+            tasks: Arc::new(RwLock::new(HashMap::new())),
+            gc_deadline,
+        }
+    }
+
+    /// Create a registry with the default 30-minute GC deadline.
+    pub fn with_default_deadline() -> Self {
+        Self::new(Duration::from_secs(30 * 60))
+    }
+
+    /// The configured GC deadline.
+    pub fn gc_deadline(&self) -> Duration {
+        self.gc_deadline
+    }
+
+    /// Register a new task and return its ID and cancellation token.
+    ///
+    /// The task starts in [`TaskStatus::Pending`].
+    pub fn register(
+        &self,
+        task_type: TaskType,
+        description: String,
+    ) -> Result<(TaskId, tokio_util::sync::CancellationToken), RegistryError> {
+        let entry = TaskEntry::new(task_type, description);
+        let id = entry.id;
+        let token = entry.cancellation_token.clone();
+
+        debug!(%id, "registering task");
+
+        let mut tasks = self.tasks.write().map_err(lock_poisoned)?;
+        tasks.insert(id, entry);
+
+        Ok((id, token))
+    }
+
+    /// Update a task's status.
+    ///
+    /// Returns an error if the transition is invalid (e.g. terminal -> running)
+    /// or the task doesn't exist.
+    pub fn update_status(
+        &self,
+        task_id: TaskId,
+        new_status: TaskStatus,
+    ) -> Result<(), RegistryError> {
+        let mut tasks = self.tasks.write().map_err(lock_poisoned)?;
+
+        let entry = tasks
+            .get_mut(&task_id)
+            .ok_or_else(|| NotFoundSnafu { task_id }.build())?;
+
+        let old_status = entry.status;
+
+        // WHY: Terminal states are final -- no further transitions allowed.
+        if old_status.is_terminal() {
+            return InvalidTransitionSnafu {
+                task_id,
+                from: old_status,
+                to: new_status,
+            }
+            .fail();
+        }
+
+        // WHY: Only valid forward transitions are allowed.
+        let valid = matches!(
+            (old_status, new_status),
+            (
+                TaskStatus::Pending,
+                TaskStatus::Running | TaskStatus::Failed | TaskStatus::Killed
+            ) | (
+                TaskStatus::Running,
+                TaskStatus::Completed | TaskStatus::Failed | TaskStatus::Killed
+            )
+        );
+
+        if !valid {
+            return InvalidTransitionSnafu {
+                task_id,
+                from: old_status,
+                to: new_status,
+            }
+            .fail();
+        }
+
+        entry.status = new_status;
+
+        if new_status.is_terminal() {
+            entry.completed_at = Some(jiff::Timestamp::now());
+        }
+
+        // NOTE: broadcast send failure is benign -- means no active subscribers.
+        let _ = entry.progress_tx.send(ProgressEvent::StatusChanged {
+            from: old_status,
+            to: new_status,
+        });
+
+        debug!(%task_id, %old_status, %new_status, "task status updated");
+
+        Ok(())
+    }
+
+    /// Record a tool call for a task's rolling activity window.
+    pub fn record_tool_call(
+        &self,
+        task_id: TaskId,
+        summary: ToolCallSummary,
+    ) -> Result<(), RegistryError> {
+        let mut tasks = self.tasks.write().map_err(lock_poisoned)?;
+
+        let entry = tasks
+            .get_mut(&task_id)
+            .ok_or_else(|| NotFoundSnafu { task_id }.build())?;
+
+        // NOTE: broadcast send failure is benign -- means no active subscribers.
+        let _ = entry
+            .progress_tx
+            .send(ProgressEvent::ToolActivity(summary.clone()));
+
+        entry.record_tool_call(summary);
+
+        Ok(())
+    }
+
+    /// Record an error snapshot for a task.
+    pub fn record_error(&self, task_id: TaskId, error: String) -> Result<(), RegistryError> {
+        let mut tasks = self.tasks.write().map_err(lock_poisoned)?;
+
+        let entry = tasks
+            .get_mut(&task_id)
+            .ok_or_else(|| NotFoundSnafu { task_id }.build())?;
+
+        let _ = entry.progress_tx.send(ProgressEvent::Error(error.clone()));
+
+        entry.error_snapshot = Some(error);
+
+        Ok(())
+    }
+
+    /// Set the output file path for a task.
+    pub fn set_output_path(
+        &self,
+        task_id: TaskId,
+        path: std::path::PathBuf,
+    ) -> Result<(), RegistryError> {
+        let mut tasks = self.tasks.write().map_err(lock_poisoned)?;
+
+        let entry = tasks
+            .get_mut(&task_id)
+            .ok_or_else(|| NotFoundSnafu { task_id }.build())?;
+
+        entry.output_path = Some(path);
+        Ok(())
+    }
+
+    /// Broadcast an output chunk for a task.
+    ///
+    /// WHY: This only sends the progress event. The actual disk write is done
+    /// by the `OutputWriter` that the task owns -- keeping I/O outside the lock.
+    pub fn broadcast_output_chunk(
+        &self,
+        task_id: TaskId,
+        data: Vec<u8>,
+    ) -> Result<(), RegistryError> {
+        let tasks = self.tasks.read().map_err(lock_poisoned)?;
+
+        let entry = tasks
+            .get(&task_id)
+            .ok_or_else(|| NotFoundSnafu { task_id }.build())?;
+
+        let _ = entry.progress_tx.send(ProgressEvent::OutputChunk(data));
+        Ok(())
+    }
+
+    /// Get a snapshot of a task.
+    pub fn get(&self, task_id: TaskId) -> Result<TaskSnapshot, RegistryError> {
+        let tasks = self.tasks.read().map_err(lock_poisoned)?;
+
+        let entry = tasks
+            .get(&task_id)
+            .ok_or_else(|| NotFoundSnafu { task_id }.build())?;
+
+        Ok(TaskSnapshot::from(entry))
+    }
+
+    /// List snapshots of all tasks, optionally filtered by status.
+    pub fn list(
+        &self,
+        status_filter: Option<TaskStatus>,
+    ) -> Result<Vec<TaskSnapshot>, RegistryError> {
+        let tasks = self.tasks.read().map_err(lock_poisoned)?;
+
+        let snapshots = tasks
+            .values()
+            .filter(|e| status_filter.is_none_or(|s| e.status == s))
+            .map(TaskSnapshot::from)
+            .collect();
+
+        Ok(snapshots)
+    }
+
+    /// Subscribe to progress events for a task.
+    ///
+    /// WHY: Returns a `broadcast::Receiver` so the subscriber sees all future
+    /// events. Past events are not replayed -- subscribers joining late only
+    /// see events from their subscription point forward.
+    pub fn subscribe(
+        &self,
+        task_id: TaskId,
+    ) -> Result<tokio::sync::broadcast::Receiver<ProgressEvent>, RegistryError> {
+        let tasks = self.tasks.read().map_err(lock_poisoned)?;
+
+        let entry = tasks
+            .get(&task_id)
+            .ok_or_else(|| NotFoundSnafu { task_id }.build())?;
+
+        Ok(entry.progress_tx.subscribe())
+    }
+
+    /// Kill a task by triggering its cancellation token.
+    ///
+    /// Sets the task status to `Killed` and cancels the token so the task's
+    /// execution loop can observe the cancellation at yield points.
+    pub fn kill(&self, task_id: TaskId) -> Result<(), RegistryError> {
+        let mut tasks = self.tasks.write().map_err(lock_poisoned)?;
+
+        let entry = tasks
+            .get_mut(&task_id)
+            .ok_or_else(|| NotFoundSnafu { task_id }.build())?;
+
+        if entry.status.is_terminal() {
+            debug!(%task_id, status = %entry.status, "kill called on terminal task, ignoring");
+            return Ok(());
+        }
+
+        let old_status = entry.status;
+        entry.status = TaskStatus::Killed;
+        entry.completed_at = Some(jiff::Timestamp::now());
+        entry.cancellation_token.cancel();
+
+        let _ = entry.progress_tx.send(ProgressEvent::StatusChanged {
+            from: old_status,
+            to: TaskStatus::Killed,
+        });
+
+        debug!(%task_id, "task killed");
+
+        Ok(())
+    }
+
+    /// Run a GC sweep, evicting terminal tasks past the deadline.
+    ///
+    /// Returns the IDs and output paths of evicted tasks so the caller can
+    /// clean up output files outside the lock.
+    pub(crate) fn gc_sweep(
+        &self,
+    ) -> Result<Vec<(TaskId, Option<std::path::PathBuf>)>, RegistryError> {
+        let now = jiff::Timestamp::now();
+        let deadline = jiff::SignedDuration::try_from(self.gc_deadline)
+            .unwrap_or_else(|_| jiff::SignedDuration::from_secs(30 * 60));
+
+        let mut tasks = self.tasks.write().map_err(lock_poisoned)?;
+
+        let mut evicted = Vec::new();
+
+        tasks.retain(|id, entry| {
+            if let Some(completed_at) = entry.completed_at {
+                let elapsed = now.duration_since(completed_at);
+                if elapsed >= deadline {
+                    debug!(%id, "GC evicting stale task");
+                    evicted.push((*id, entry.output_path.clone()));
+                    return false;
+                }
+            }
+            true
+        });
+
+        Ok(evicted)
+    }
+
+    /// Number of tasks currently in the registry.
+    pub fn len(&self) -> Result<usize, RegistryError> {
+        let tasks = self.tasks.read().map_err(lock_poisoned)?;
+        Ok(tasks.len())
+    }
+
+    /// Whether the registry is empty.
+    pub fn is_empty(&self) -> Result<bool, RegistryError> {
+        Ok(self.len()? == 0)
+    }
+}
+
+impl std::fmt::Debug for TaskRegistry {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let count = self.tasks.read().map(|t| t.len()).unwrap_or(0);
+        f.debug_struct("TaskRegistry")
+            .field("task_count", &count)
+            .field("gc_deadline", &self.gc_deadline)
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::*;
+
+    fn make_registry() -> TaskRegistry {
+        TaskRegistry::new(Duration::from_secs(1))
+    }
+
+    #[test]
+    fn register_and_get() {
+        let reg = make_registry();
+        let (id, _token) = reg
+            .register(
+                TaskType::Shell {
+                    command: "echo hello".into(),
+                },
+                "test shell".into(),
+            )
+            .expect("register");
+
+        let snap = reg.get(id).expect("get");
+        assert_eq!(snap.id, id);
+        assert_eq!(snap.status, TaskStatus::Pending);
+        assert_eq!(snap.description, "test shell");
+    }
+
+    #[test]
+    fn lifecycle_pending_to_running_to_completed() {
+        let reg = make_registry();
+        let (id, _token) = reg
+            .register(
+                TaskType::Agent {
+                    agent_id: "alice".into(),
+                    prompt: "research".into(),
+                },
+                "agent task".into(),
+            )
+            .expect("register");
+
+        reg.update_status(id, TaskStatus::Running)
+            .expect("to running");
+        assert_eq!(reg.get(id).expect("get").status, TaskStatus::Running);
+
+        reg.update_status(id, TaskStatus::Completed)
+            .expect("to completed");
+        let snap = reg.get(id).expect("get");
+        assert_eq!(snap.status, TaskStatus::Completed);
+        assert!(snap.completed_at.is_some());
+    }
+
+    #[test]
+    fn lifecycle_pending_to_running_to_failed() {
+        let reg = make_registry();
+        let (id, _token) = reg
+            .register(
+                TaskType::Shell {
+                    command: "false".into(),
+                },
+                "failing task".into(),
+            )
+            .expect("register");
+
+        reg.update_status(id, TaskStatus::Running)
+            .expect("to running");
+        reg.update_status(id, TaskStatus::Failed)
+            .expect("to failed");
+
+        let snap = reg.get(id).expect("get");
+        assert_eq!(snap.status, TaskStatus::Failed);
+        assert!(snap.completed_at.is_some());
+    }
+
+    #[test]
+    fn terminal_to_running_is_invalid() {
+        let reg = make_registry();
+        let (id, _token) = reg
+            .register(
+                TaskType::Monitor {
+                    target: "health".into(),
+                },
+                "monitor".into(),
+            )
+            .expect("register");
+
+        reg.update_status(id, TaskStatus::Running)
+            .expect("to running");
+        reg.update_status(id, TaskStatus::Completed)
+            .expect("to completed");
+
+        let result = reg.update_status(id, TaskStatus::Running);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn pending_to_completed_is_invalid() {
+        let reg = make_registry();
+        let (id, _token) = reg
+            .register(
+                TaskType::Workflow {
+                    name: "deploy".into(),
+                },
+                "workflow".into(),
+            )
+            .expect("register");
+
+        // WHY: Can't skip Running to reach Completed.
+        let result = reg.update_status(id, TaskStatus::Completed);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn pending_to_failed_is_valid() {
+        let reg = make_registry();
+        let (id, _token) = reg
+            .register(
+                TaskType::Shell {
+                    command: "bad-cmd".into(),
+                },
+                "fail fast".into(),
+            )
+            .expect("register");
+
+        // WHY: Tasks can fail before they start (e.g. validation failure).
+        reg.update_status(id, TaskStatus::Failed)
+            .expect("to failed");
+        assert_eq!(reg.get(id).expect("get").status, TaskStatus::Failed);
+    }
+
+    #[test]
+    fn kill_sets_status_and_cancels_token() {
+        let reg = make_registry();
+        let (id, token) = reg
+            .register(
+                TaskType::Agent {
+                    agent_id: "bob".into(),
+                    prompt: "long task".into(),
+                },
+                "killable".into(),
+            )
+            .expect("register");
+
+        reg.update_status(id, TaskStatus::Running)
+            .expect("to running");
+        assert!(!token.is_cancelled());
+
+        reg.kill(id).expect("kill");
+        assert!(token.is_cancelled());
+        assert_eq!(reg.get(id).expect("get").status, TaskStatus::Killed);
+    }
+
+    #[test]
+    fn kill_terminal_task_is_noop() {
+        let reg = make_registry();
+        let (id, _token) = reg
+            .register(
+                TaskType::Shell {
+                    command: "done".into(),
+                },
+                "done task".into(),
+            )
+            .expect("register");
+
+        reg.update_status(id, TaskStatus::Running)
+            .expect("to running");
+        reg.update_status(id, TaskStatus::Completed)
+            .expect("to completed");
+
+        // WHY: Killing an already-completed task should be silently ignored.
+        reg.kill(id).expect("kill noop");
+        assert_eq!(reg.get(id).expect("get").status, TaskStatus::Completed);
+    }
+
+    #[test]
+    fn get_nonexistent_returns_not_found() {
+        let reg = make_registry();
+        let fake_id = TaskId::new();
+        let result = reg.get(fake_id);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn list_all_tasks() {
+        let reg = make_registry();
+        reg.register(
+            TaskType::Shell {
+                command: "a".into(),
+            },
+            "task a".into(),
+        )
+        .expect("register a");
+        reg.register(
+            TaskType::Shell {
+                command: "b".into(),
+            },
+            "task b".into(),
+        )
+        .expect("register b");
+
+        let all = reg.list(None).expect("list");
+        assert_eq!(all.len(), 2);
+    }
+
+    #[test]
+    fn list_with_status_filter() {
+        let reg = make_registry();
+
+        let (id_a, _) = reg
+            .register(
+                TaskType::Shell {
+                    command: "a".into(),
+                },
+                "task a".into(),
+            )
+            .expect("register a");
+        let (_id_b, _) = reg
+            .register(
+                TaskType::Shell {
+                    command: "b".into(),
+                },
+                "task b".into(),
+            )
+            .expect("register b");
+
+        reg.update_status(id_a, TaskStatus::Running)
+            .expect("to running");
+
+        let running = reg.list(Some(TaskStatus::Running)).expect("list running");
+        assert_eq!(running.len(), 1);
+        assert_eq!(running[0].id, id_a);
+
+        let pending = reg.list(Some(TaskStatus::Pending)).expect("list pending");
+        assert_eq!(pending.len(), 1);
+    }
+
+    #[test]
+    fn record_tool_call_updates_activity() {
+        let reg = make_registry();
+        let (id, _) = reg
+            .register(
+                TaskType::Agent {
+                    agent_id: "alice".into(),
+                    prompt: "work".into(),
+                },
+                "agent".into(),
+            )
+            .expect("register");
+
+        reg.record_tool_call(
+            id,
+            ToolCallSummary {
+                tool_name: "read_file".into(),
+                elapsed: jiff::SignedDuration::from_millis(150),
+            },
+        )
+        .expect("record");
+
+        let snap = reg.get(id).expect("get");
+        assert_eq!(snap.recent_activity.len(), 1);
+        assert_eq!(snap.recent_activity[0].tool_name, "read_file");
+    }
+
+    #[test]
+    fn record_error_sets_snapshot() {
+        let reg = make_registry();
+        let (id, _) = reg
+            .register(
+                TaskType::Shell {
+                    command: "oops".into(),
+                },
+                "erroring".into(),
+            )
+            .expect("register");
+
+        reg.record_error(id, "something went wrong".into())
+            .expect("record error");
+
+        let snap = reg.get(id).expect("get");
+        assert_eq!(snap.error_snapshot.as_deref(), Some("something went wrong"));
+    }
+
+    #[tokio::test]
+    async fn progress_subscribe_receives_events() {
+        let reg = make_registry();
+        let (id, _) = reg
+            .register(
+                TaskType::Consolidation { sessions_count: 5 },
+                "consolidate".into(),
+            )
+            .expect("register");
+
+        let mut rx = reg.subscribe(id).expect("subscribe");
+
+        reg.update_status(id, TaskStatus::Running)
+            .expect("to running");
+
+        let event = rx.recv().await.expect("recv");
+        match event {
+            ProgressEvent::StatusChanged { from, to } => {
+                assert_eq!(from, TaskStatus::Pending);
+                assert_eq!(to, TaskStatus::Running);
+            }
+            other => panic!("unexpected event: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn progress_subscribe_receives_tool_activity() {
+        let reg = make_registry();
+        let (id, _) = reg
+            .register(
+                TaskType::Agent {
+                    agent_id: "alice".into(),
+                    prompt: "work".into(),
+                },
+                "agent".into(),
+            )
+            .expect("register");
+
+        let mut rx = reg.subscribe(id).expect("subscribe");
+
+        reg.record_tool_call(
+            id,
+            ToolCallSummary {
+                tool_name: "search".into(),
+                elapsed: jiff::SignedDuration::from_millis(200),
+            },
+        )
+        .expect("record");
+
+        let event = rx.recv().await.expect("recv");
+        match event {
+            ProgressEvent::ToolActivity(summary) => {
+                assert_eq!(summary.tool_name, "search");
+            }
+            other => panic!("unexpected event: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn concurrent_register_from_multiple_threads() {
+        let reg = make_registry();
+        let reg_clone = reg.clone();
+
+        let handles: Vec<_> = (0..10)
+            .map(|i| {
+                let r = reg_clone.clone();
+                std::thread::spawn(move || {
+                    r.register(
+                        TaskType::Shell {
+                            command: format!("cmd_{i}"),
+                        },
+                        format!("task {i}"),
+                    )
+                    .expect("register");
+                })
+            })
+            .collect();
+
+        for h in handles {
+            h.join().expect("thread join");
+        }
+
+        assert_eq!(reg.len().expect("len"), 10);
+    }
+
+    #[test]
+    fn gc_sweep_evicts_stale_tasks() {
+        // WHY: Use a zero deadline so tasks are immediately eligible.
+        let reg = TaskRegistry::new(Duration::from_secs(0));
+
+        let (id, _) = reg
+            .register(
+                TaskType::Shell {
+                    command: "done".into(),
+                },
+                "stale".into(),
+            )
+            .expect("register");
+
+        reg.update_status(id, TaskStatus::Running)
+            .expect("to running");
+        reg.update_status(id, TaskStatus::Completed)
+            .expect("to completed");
+
+        let evicted = reg.gc_sweep().expect("gc sweep");
+        assert_eq!(evicted.len(), 1);
+        assert_eq!(evicted[0].0, id);
+
+        // WHY: After GC, the task should no longer be in the registry.
+        assert!(reg.get(id).is_err());
+    }
+
+    #[test]
+    fn gc_sweep_retains_non_terminal_tasks() {
+        let reg = TaskRegistry::new(Duration::from_secs(0));
+
+        let (id, _) = reg
+            .register(
+                TaskType::Shell {
+                    command: "running".into(),
+                },
+                "active".into(),
+            )
+            .expect("register");
+
+        reg.update_status(id, TaskStatus::Running)
+            .expect("to running");
+
+        let evicted = reg.gc_sweep().expect("gc sweep");
+        assert!(evicted.is_empty());
+        assert!(reg.get(id).is_ok());
+    }
+
+    #[test]
+    fn len_and_is_empty() {
+        let reg = make_registry();
+        assert!(reg.is_empty().expect("is_empty"));
+        assert_eq!(reg.len().expect("len"), 0);
+
+        reg.register(
+            TaskType::Monitor {
+                target: "mcp".into(),
+            },
+            "monitor".into(),
+        )
+        .expect("register");
+
+        assert!(!reg.is_empty().expect("is_empty"));
+        assert_eq!(reg.len().expect("len"), 1);
+    }
+}

--- a/crates/nous/src/tasks/types.rs
+++ b/crates/nous/src/tasks/types.rs
@@ -1,0 +1,366 @@
+//! Task types, state, and progress events.
+
+use std::collections::VecDeque;
+use std::fmt;
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+use tokio::sync::broadcast;
+use tokio_util::sync::CancellationToken;
+
+/// Maximum number of recent tool call summaries kept per task.
+const ACTIVITY_WINDOW_SIZE: usize = 5;
+
+/// Capacity of the per-task progress broadcast channel.
+///
+/// WHY: Bounded to apply backpressure on slow subscribers rather than growing
+/// memory unboundedly. 64 events is enough for bursty tool execution without
+/// dropping under normal conditions.
+pub(crate) const PROGRESS_CHANNEL_CAPACITY: usize = 64;
+
+// ---------------------------------------------------------------------------
+// TaskId
+// ---------------------------------------------------------------------------
+
+/// Stable task identifier wrapping a UUID v4.
+///
+/// WHY: Tasks need identity that survives across progress updates, GC checks,
+/// and UI refreshes. UUID provides collision-free generation without coordination.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct TaskId(uuid::Uuid);
+
+impl TaskId {
+    /// Generate a new random task ID.
+    pub fn new() -> Self {
+        Self(uuid::Uuid::new_v4())
+    }
+}
+
+impl Default for TaskId {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl fmt::Display for TaskId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// TaskType
+// ---------------------------------------------------------------------------
+
+/// Task variant with type-specific metadata.
+///
+/// WHY: Task display and lifecycle differ by type. Shell tasks carry a command
+/// string, agent tasks carry an agent ID and prompt, etc. Discriminating at the
+/// type level lets callers match exhaustively.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum TaskType {
+    /// A shell command execution.
+    Shell {
+        /// The command being run.
+        command: String,
+    },
+    /// A sub-agent running an autonomous loop.
+    Agent {
+        /// Identity of the spawned agent.
+        agent_id: String,
+        /// The prompt given to the agent.
+        prompt: String,
+    },
+    /// A multi-step workflow execution.
+    Workflow {
+        /// Human-readable workflow name.
+        name: String,
+    },
+    /// Memory consolidation (dream) task.
+    Consolidation {
+        /// Number of sessions being consolidated.
+        sessions_count: usize,
+    },
+    /// Background monitoring task (e.g. MCP health).
+    Monitor {
+        /// What is being monitored.
+        target: String,
+    },
+}
+
+impl fmt::Display for TaskType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Shell { command } => write!(f, "shell: {command}"),
+            Self::Agent { agent_id, .. } => write!(f, "agent: {agent_id}"),
+            Self::Workflow { name } => write!(f, "workflow: {name}"),
+            Self::Consolidation { sessions_count } => {
+                write!(f, "consolidation: {sessions_count} sessions")
+            }
+            Self::Monitor { target } => write!(f, "monitor: {target}"),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// TaskStatus
+// ---------------------------------------------------------------------------
+
+/// Task status lifecycle.
+///
+/// ```text
+/// Pending -> Running -> Completed
+///                    -> Failed
+///                    -> Killed
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum TaskStatus {
+    /// Registered but not yet started.
+    Pending,
+    /// Actively executing.
+    Running,
+    /// Finished successfully.
+    Completed,
+    /// Terminated due to an error.
+    Failed,
+    /// Explicitly cancelled via `kill()`.
+    Killed,
+}
+
+impl TaskStatus {
+    /// Whether this status is terminal (no further transitions allowed).
+    pub fn is_terminal(self) -> bool {
+        matches!(self, Self::Completed | Self::Failed | Self::Killed)
+    }
+}
+
+impl fmt::Display for TaskStatus {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Pending => f.write_str("pending"),
+            Self::Running => f.write_str("running"),
+            Self::Completed => f.write_str("completed"),
+            Self::Failed => f.write_str("failed"),
+            Self::Killed => f.write_str("killed"),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ToolCallSummary
+// ---------------------------------------------------------------------------
+
+/// Summary of a single tool call for the rolling activity window.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ToolCallSummary {
+    /// Name of the tool that was called.
+    pub tool_name: String,
+    /// Wall-clock duration of the tool execution.
+    pub elapsed: jiff::SignedDuration,
+}
+
+// ---------------------------------------------------------------------------
+// ProgressEvent
+// ---------------------------------------------------------------------------
+
+/// Progress event emitted on a task's broadcast channel.
+///
+/// WHY: Subscribers (UI, logging, parent agents) need typed events to decide
+/// what to display. A single enum keeps the channel monomorphic.
+#[derive(Debug, Clone)]
+pub enum ProgressEvent {
+    /// Task transitioned between statuses.
+    StatusChanged {
+        /// Previous status.
+        from: TaskStatus,
+        /// New status.
+        to: TaskStatus,
+    },
+    /// A tool call completed.
+    ToolActivity(ToolCallSummary),
+    /// A chunk of output was produced.
+    OutputChunk(Vec<u8>),
+    /// An error snapshot for diagnostics.
+    Error(String),
+}
+
+// ---------------------------------------------------------------------------
+// TaskEntry
+// ---------------------------------------------------------------------------
+
+/// A task entry in the registry.
+///
+/// Contains all state needed for status queries, progress streaming,
+/// cancellation, and GC eligibility.
+pub struct TaskEntry {
+    /// Unique task identifier.
+    pub id: TaskId,
+    /// What kind of task this is.
+    pub task_type: TaskType,
+    /// Current lifecycle status.
+    pub status: TaskStatus,
+    /// Human-readable description.
+    pub description: String,
+    /// When the task was registered.
+    pub created_at: jiff::Timestamp,
+    /// When the task reached a terminal status.
+    pub completed_at: Option<jiff::Timestamp>,
+    /// Rolling window of recent tool call summaries (last 5).
+    pub recent_activity: VecDeque<ToolCallSummary>,
+    /// Token for cooperative cancellation.
+    pub cancellation_token: CancellationToken,
+    /// Broadcast sender for progress events.
+    ///
+    /// WHY: `broadcast::Sender` is kept alive as long as the entry exists so
+    /// late-joining subscribers can still receive future events. Capacity is
+    /// bounded at [`PROGRESS_CHANNEL_CAPACITY`].
+    pub progress_tx: broadcast::Sender<ProgressEvent>,
+    /// Path to the disk-backed output file, if created.
+    pub output_path: Option<PathBuf>,
+    /// Last error message, if any.
+    pub error_snapshot: Option<String>,
+}
+
+impl TaskEntry {
+    /// Create a new task entry with the given type and description.
+    pub(crate) fn new(task_type: TaskType, description: String) -> Self {
+        let (progress_tx, _) = broadcast::channel(PROGRESS_CHANNEL_CAPACITY);
+        Self {
+            id: TaskId::new(),
+            task_type,
+            status: TaskStatus::Pending,
+            description,
+            created_at: jiff::Timestamp::now(),
+            completed_at: None,
+            recent_activity: VecDeque::with_capacity(ACTIVITY_WINDOW_SIZE),
+            cancellation_token: CancellationToken::new(),
+            progress_tx,
+            output_path: None,
+            error_snapshot: None,
+        }
+    }
+
+    /// Record a tool call in the rolling activity window.
+    ///
+    /// Evicts the oldest entry when the window is full.
+    pub(crate) fn record_tool_call(&mut self, summary: ToolCallSummary) {
+        if self.recent_activity.len() >= ACTIVITY_WINDOW_SIZE {
+            self.recent_activity.pop_front();
+        }
+        self.recent_activity.push_back(summary);
+    }
+}
+
+impl fmt::Debug for TaskEntry {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TaskEntry")
+            .field("id", &self.id)
+            .field("task_type", &self.task_type)
+            .field("status", &self.status)
+            .field("description", &self.description)
+            .field("created_at", &self.created_at)
+            .field("completed_at", &self.completed_at)
+            .field("recent_activity", &self.recent_activity)
+            .field("output_path", &self.output_path)
+            .field("error_snapshot", &self.error_snapshot)
+            .finish_non_exhaustive()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn task_id_display_is_uuid_format() {
+        let id = TaskId::new();
+        let s = id.to_string();
+        // WHY: UUID v4 has a specific format with hyphens
+        assert_eq!(s.len(), 36);
+        assert_eq!(s.chars().filter(|c| *c == '-').count(), 4);
+    }
+
+    #[test]
+    fn task_id_uniqueness() {
+        let a = TaskId::new();
+        let b = TaskId::new();
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn task_status_terminal_states() {
+        assert!(!TaskStatus::Pending.is_terminal());
+        assert!(!TaskStatus::Running.is_terminal());
+        assert!(TaskStatus::Completed.is_terminal());
+        assert!(TaskStatus::Failed.is_terminal());
+        assert!(TaskStatus::Killed.is_terminal());
+    }
+
+    #[test]
+    fn task_entry_rolling_window_caps_at_five() {
+        let mut entry = TaskEntry::new(
+            TaskType::Shell {
+                command: "echo test".into(),
+            },
+            "test task".into(),
+        );
+
+        for i in 0..7 {
+            entry.record_tool_call(ToolCallSummary {
+                tool_name: format!("tool_{i}"),
+                elapsed: jiff::SignedDuration::from_secs(1),
+            });
+        }
+
+        assert_eq!(entry.recent_activity.len(), 5);
+        // WHY: First two should have been evicted
+        assert_eq!(
+            entry.recent_activity.front().map(|s| s.tool_name.as_str()),
+            Some("tool_2")
+        );
+        assert_eq!(
+            entry.recent_activity.back().map(|s| s.tool_name.as_str()),
+            Some("tool_6")
+        );
+    }
+
+    #[test]
+    fn task_entry_starts_pending() {
+        let entry = TaskEntry::new(
+            TaskType::Agent {
+                agent_id: "alice".into(),
+                prompt: "research topic".into(),
+            },
+            "agent task".into(),
+        );
+        assert_eq!(entry.status, TaskStatus::Pending);
+        assert!(entry.completed_at.is_none());
+        assert!(entry.error_snapshot.is_none());
+    }
+
+    #[test]
+    fn task_type_display() {
+        let shell = TaskType::Shell {
+            command: "ls -la".into(),
+        };
+        assert_eq!(shell.to_string(), "shell: ls -la");
+
+        let agent = TaskType::Agent {
+            agent_id: "bob".into(),
+            prompt: "search".into(),
+        };
+        assert_eq!(agent.to_string(), "agent: bob");
+
+        let consolidation = TaskType::Consolidation { sessions_count: 3 };
+        assert_eq!(consolidation.to_string(), "consolidation: 3 sessions");
+    }
+
+    #[test]
+    fn task_status_display() {
+        assert_eq!(TaskStatus::Pending.to_string(), "pending");
+        assert_eq!(TaskStatus::Running.to_string(), "running");
+        assert_eq!(TaskStatus::Completed.to_string(), "completed");
+        assert_eq!(TaskStatus::Failed.to_string(), "failed");
+        assert_eq!(TaskStatus::Killed.to_string(), "killed");
+    }
+}


### PR DESCRIPTION
## Summary
- Add concurrent `TaskRegistry` with `register`/`update_status`/`get`/`list`/`kill` operations backed by `Arc<RwLock<HashMap<TaskId, TaskEntry>>>`
- Task types: `Shell`, `Agent`, `Workflow`, `Consolidation`, `Monitor` with type-specific metadata
- Status lifecycle: `Pending -> Running -> Completed | Failed | Killed` with validated transitions
- Per-task `tokio::sync::broadcast` progress channel (capacity 64) for status changes, tool activity, output chunks, and errors
- Disk-backed output via `OutputWriter`/`OutputReader` with `AsyncRead` streaming read-back
- Cooperative cancellation via `CancellationToken` propagated through `kill()`
- Rolling activity window storing last 5 tool call summaries per task
- Background GC task evicts terminal entries after configurable deadline (default 30 min), cleans up output files
- 33 unit tests covering lifecycle transitions, concurrent access, progress streaming, cancellation propagation, and GC eviction

## Acceptance criteria
- [x] `TaskType` enum with Shell, Agent, Workflow, Consolidation, Monitor variants
- [x] `TaskState` with status lifecycle Pending -> Running -> Completed | Failed | Killed
- [x] `TaskRegistry` with register/update/get/list/kill operations, concurrent-safe
- [x] Progress streaming via `tokio::sync::broadcast` with bounded capacity
- [x] Disk-backed output using temp files with streaming read-back
- [x] Cooperative cancellation via `CancellationToken`, propagated through kill()
- [x] Rolling activity window storing last 5 tool call summaries per task
- [x] GC evicts stale tasks after configurable deadline, cleans up output files
- [x] Unit tests for lifecycle, concurrency, streaming, cancellation, GC
- [x] `cargo test -p nous` passes (33/33 task tests; 3 pre-existing failures in execute/actor unrelated)
- [x] `cargo clippy -p nous -- -D warnings` clean
- [x] Closes forkwright/aletheia#2263

## Observations
- **Pre-existing test failures**: 3 tests in `execute::tests` and `actor::tests` fail on main (`max_iterations_one_exits_immediately`, `max_iterations_respected`, `session_id_adoption_prevents_fk_divergence`) — unrelated to this PR
- **Pre-existing lint warnings**: 18 unfulfilled `#[expect(dead_code)]` warnings in `roles.rs`, `uncertainty.rs`, `working_state.rs` — pre-existing on main
- **sha2 0.11 breakage**: `graphe/migration.rs` `compute_checksum()` broke with sha2 0.11 (LowerHex removed from GenericArray) — fixed as collateral to unblock compilation. Introduced by #2257.
- **Debt**: `TaskEntry::new()` uses `unwrap_or_else` for `SignedDuration::try_from(Duration)` fallback — this conversion is infallible for reasonable durations but the type system doesn't guarantee it

## Validation gate
- `cargo fmt --all -- --check` ✓
- `cargo clippy -p aletheia-nous -- -D warnings` ✓
- `cargo test -p aletheia-nous --lib -- tasks` ✓ (33/33)

🤖 Generated with [Claude Code](https://claude.com/claude-code)