### PR TITLE
feat(eidos): add memory scope model and path validation layer types

### DIFF
--- a/crates/eidos/src/knowledge.rs
+++ b/crates/eidos/src/knowledge.rs
@@ -4,6 +4,8 @@
 //! - **Facts**: extracted from conversations, bi-temporal (`valid_from`/`valid_to`)
 //! - **Entities**: people, projects, tools, concepts with typed relationships
 //! - **Vectors**: embedding-indexed for semantic recall
+//! - **Memory scopes**: team memory sharing model (`User`, `Feedback`, `Project`, `Reference`)
+//! - **Path validation layers**: defense-in-depth security for memory path operations
 
 use serde::{Deserialize, Serialize};
 
@@ -59,6 +61,13 @@ pub struct Fact {
     pub nous_id: String,
     pub fact_type: String,
     pub content: String,
+
+    /// Memory sharing scope for team memory.
+    ///
+    /// `None` for facts created before the team memory model was introduced.
+    /// New facts should always populate this field.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scope: Option<MemoryScope>,
 
     /// Bi-temporal validity and recording timestamps.
     #[serde(flatten)]
@@ -625,6 +634,273 @@ pub struct RecallResult {
     pub source_type: String,
     /// Source ID.
     pub source_id: String,
+}
+
+// ---------------------------------------------------------------------------
+// Team memory: scopes, access policies, and path validation layers
+// ---------------------------------------------------------------------------
+
+/// Memory sharing scope for multi-agent team memory.
+///
+/// Each scope maps to a subdirectory under the memory root and defines
+/// distinct access control semantics. Scopes form the authorization
+/// boundary that [`ScopeAccessPolicy`] enforces; path validation then
+/// confirms the resolved filesystem path falls within the correct scope
+/// directory.
+///
+/// Taxonomy mirrors the CC memory type model (`user`, `feedback`,
+/// `project`, `reference`) from `memoryTypes.ts`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum MemoryScope {
+    /// Private to the user, never shared with other agents.
+    ///
+    /// WHY: User memories contain personal context (role, preferences,
+    /// knowledge level) that should not leak across agent boundaries.
+    User,
+    /// Selectively shared corrections and preferences, write-gated to the user.
+    ///
+    /// WHY: Feedback memories encode behavioral guidance. Agents read them
+    /// to avoid repeating mistakes, but only the user can write because
+    /// agent-written feedback creates self-reinforcing loops.
+    Feedback,
+    /// Shared across all agents in a workspace, read-write.
+    ///
+    /// WHY: Project memories track ongoing work, deadlines, and decisions
+    /// that every agent in the workspace needs visibility into.
+    Project,
+    /// Hybrid: agents read, user curates write access.
+    ///
+    /// WHY: Reference memories point to external systems (Linear, Grafana,
+    /// Slack). Agents need to read them for context but the user controls
+    /// what gets indexed because stale pointers are worse than no pointers.
+    Reference,
+}
+
+impl MemoryScope {
+    /// All scope variants in definition order.
+    pub const ALL: [Self; 4] = [Self::User, Self::Feedback, Self::Project, Self::Reference];
+
+    /// Return the lowercase string representation of this scope.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::User => "user",
+            Self::Feedback => "feedback",
+            Self::Project => "project",
+            Self::Reference => "reference",
+        }
+    }
+
+    /// Directory name for this scope under the memory root.
+    ///
+    /// Each scope maps to a single subdirectory: `<memory_root>/<dir_name>/`.
+    /// The name is identical to `as_str()` by convention.
+    #[must_use]
+    pub fn as_dir_name(self) -> &'static str {
+        // WHY: Directory names match the enum's string representation to keep
+        // the mapping predictable and greppable.
+        self.as_str()
+    }
+
+    /// Access control policy for this scope.
+    ///
+    /// Returns the static [`ScopeAccessPolicy`] that describes who can
+    /// read and write within this scope boundary.
+    #[must_use]
+    #[expect(
+        clippy::match_same_arms,
+        reason = "Feedback and Reference share the same access policy values but are semantically distinct scopes with different sharing intent"
+    )]
+    pub fn access_policy(self) -> ScopeAccessPolicy {
+        match self {
+            Self::User => ScopeAccessPolicy {
+                agent_read: false,
+                agent_write: false,
+                user_write_only: true,
+            },
+            Self::Feedback => ScopeAccessPolicy {
+                agent_read: true,
+                agent_write: false,
+                user_write_only: true,
+            },
+            Self::Project => ScopeAccessPolicy {
+                agent_read: true,
+                agent_write: true,
+                user_write_only: false,
+            },
+            Self::Reference => ScopeAccessPolicy {
+                agent_read: true,
+                agent_write: false,
+                user_write_only: true,
+            },
+        }
+    }
+
+    /// Parse from a string, returning `None` for unknown values.
+    #[must_use]
+    pub fn from_str_opt(s: &str) -> Option<Self> {
+        match s {
+            "user" => Some(Self::User),
+            "feedback" => Some(Self::Feedback),
+            "project" => Some(Self::Project),
+            "reference" => Some(Self::Reference),
+            _ => None,
+        }
+    }
+}
+
+impl std::fmt::Display for MemoryScope {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl std::str::FromStr for MemoryScope {
+    type Err = String;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        Self::from_str_opt(s).ok_or_else(|| format!("unknown memory scope: {s}"))
+    }
+}
+
+/// Access control policy for a [`MemoryScope`].
+///
+/// Defines who can read and write within a scope boundary. The policy is
+/// static per scope variant -- it does not change at runtime.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ScopeAccessPolicy {
+    /// Whether agents can read memories in this scope.
+    pub agent_read: bool,
+    /// Whether agents can write memories in this scope.
+    pub agent_write: bool,
+    /// Whether only the user can write (agent writes are rejected).
+    pub user_write_only: bool,
+}
+
+impl ScopeAccessPolicy {
+    /// Whether an agent is allowed to perform a write operation in this scope.
+    #[must_use]
+    pub fn permits_agent_write(&self) -> bool {
+        self.agent_write && !self.user_write_only
+    }
+
+    /// Whether an agent is allowed to perform a read operation in this scope.
+    #[must_use]
+    pub fn permits_agent_read(&self) -> bool {
+        self.agent_read
+    }
+}
+
+/// Validation layer in the defense-in-depth path security model.
+///
+/// Each layer addresses a distinct class of path manipulation attack.
+/// Layers are applied in order during `validate_memory_path()` (in mneme);
+/// a path must pass all layers. The variant names map 1:1 to
+/// `PathValidationError` variants for error classification and logging.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum PathValidationLayer {
+    /// Null bytes truncate paths in C-based syscalls (libc, kernel).
+    NullByte,
+    /// Raw string checks miss `foo/../../../etc/passwd`; resolved via
+    /// `std::path::Path::components()`.
+    Canonicalization,
+    /// Symlinks can escape directory jails; resolved via
+    /// `std::fs::canonicalize()` with root containment check.
+    SymlinkResolution,
+    /// Dangling symlinks indicate filesystem manipulation; detected via
+    /// `std::fs::symlink_metadata()` when canonicalize returns ENOENT.
+    DanglingSymlink,
+    /// Symlink loops cause infinite recursion; capped at 40 hops matching
+    /// the Linux `ELOOP` limit.
+    LoopDetection,
+    /// URL-encoded traversals (`%2e%2e%2f` = `../`) bypass string-level
+    /// checks; detected by percent-decoding then re-checking for `..` or
+    /// separator characters.
+    UrlEncodedTraversal,
+    /// Fullwidth characters (U+FF0E `.`, U+FF0F `/`) normalize to ASCII
+    /// separators under NFKC; detected by normalizing and comparing to
+    /// the original.
+    UnicodeNormalization,
+    /// Resolved path falls outside the expected scope subdirectory.
+    ScopeContainment,
+}
+
+/// Total number of filesystem-level validation layers (excluding scope
+/// containment which is a logical check).
+pub const PATH_VALIDATION_FS_LAYERS: usize = 7;
+
+/// Maximum symlink hops before declaring a loop, matching the Linux
+/// `ELOOP` kernel limit.
+pub const SYMLINK_HOP_LIMIT: usize = 40;
+
+impl PathValidationLayer {
+    /// All layer variants in application order.
+    pub const ALL: [Self; 8] = [
+        Self::NullByte,
+        Self::Canonicalization,
+        Self::SymlinkResolution,
+        Self::DanglingSymlink,
+        Self::LoopDetection,
+        Self::UrlEncodedTraversal,
+        Self::UnicodeNormalization,
+        Self::ScopeContainment,
+    ];
+
+    /// Return the `snake_case` string representation of this layer.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::NullByte => "null_byte",
+            Self::Canonicalization => "canonicalization",
+            Self::SymlinkResolution => "symlink_resolution",
+            Self::DanglingSymlink => "dangling_symlink",
+            Self::LoopDetection => "loop_detection",
+            Self::UrlEncodedTraversal => "url_encoded_traversal",
+            Self::UnicodeNormalization => "unicode_normalization",
+            Self::ScopeContainment => "scope_containment",
+        }
+    }
+
+    /// Whether this layer requires filesystem I/O.
+    ///
+    /// Pure string-based layers (`NullByte`, `Canonicalization`,
+    /// `UrlEncodedTraversal`, `UnicodeNormalization`, `ScopeContainment`)
+    /// can run without touching the filesystem.
+    #[must_use]
+    pub fn requires_io(self) -> bool {
+        matches!(
+            self,
+            Self::SymlinkResolution | Self::DanglingSymlink | Self::LoopDetection
+        )
+    }
+}
+
+impl std::fmt::Display for PathValidationLayer {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl std::str::FromStr for PathValidationLayer {
+    type Err = String;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        match s {
+            "null_byte" => Ok(Self::NullByte),
+            "canonicalization" => Ok(Self::Canonicalization),
+            "symlink_resolution" => Ok(Self::SymlinkResolution),
+            "dangling_symlink" => Ok(Self::DanglingSymlink),
+            "loop_detection" => Ok(Self::LoopDetection),
+            "url_encoded_traversal" => Ok(Self::UrlEncodedTraversal),
+            "unicode_normalization" => Ok(Self::UnicodeNormalization),
+            "scope_containment" => Ok(Self::ScopeContainment),
+            other => Err(format!("unknown path validation layer: {other}")),
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/eidos/src/knowledge_test.rs
+++ b/crates/eidos/src/knowledge_test.rs
@@ -94,6 +94,7 @@ fn fact_serde_roundtrip() {
         nous_id: "syn".to_owned(),
         content: "The researcher published findings on memory consolidation".to_owned(),
         fact_type: String::new(),
+        scope: None,
         temporal: FactTemporal {
             valid_from: test_timestamp("2026-02-01"),
             valid_to: far_future(),
@@ -231,6 +232,7 @@ fn fact_with_empty_content() {
         nous_id: "syn".to_owned(),
         content: String::new(),
         fact_type: String::new(),
+        scope: None,
         temporal: FactTemporal {
             valid_from: test_timestamp("2026-01-01"),
             valid_to: far_future(),
@@ -270,6 +272,7 @@ fn fact_with_unicode_content() {
         nous_id: "syn".to_owned(),
         content: "The user writes \u{65E5}\u{672C}\u{8A9E} and emoji \u{1F980}".to_owned(),
         fact_type: String::new(),
+        scope: None,
         temporal: FactTemporal {
             valid_from: test_timestamp("2026-01-01"),
             valid_to: far_future(),
@@ -633,6 +636,7 @@ fn fact_with_supersession() {
         nous_id: "syn".to_owned(),
         content: "outdated claim".to_owned(),
         fact_type: String::new(),
+        scope: None,
         temporal: FactTemporal {
             valid_from: test_timestamp("2026-01-01"),
             valid_to: test_timestamp("2026-02-01"),
@@ -678,6 +682,7 @@ fn fact_with_session_source() {
         nous_id: "syn".to_owned(),
         content: "extracted from conversation".to_owned(),
         fact_type: "relationship".to_owned(),
+        scope: Some(MemoryScope::Project),
         temporal: FactTemporal {
             valid_from: test_timestamp("2026-03-01"),
             valid_to: far_future(),
@@ -774,5 +779,502 @@ fn far_future_is_year_9999() {
     assert!(
         is_far_future(&ts),
         "far_future() should be recognized by is_far_future"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// MemoryScope tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn memory_scope_serde_roundtrip() {
+    for scope in MemoryScope::ALL {
+        let json = serde_json::to_string(&scope).expect("MemoryScope serialization is infallible");
+        let back: MemoryScope =
+            serde_json::from_str(&json).expect("MemoryScope should deserialize from its own JSON");
+        assert_eq!(scope, back, "MemoryScope should survive serde roundtrip");
+    }
+}
+
+#[test]
+fn memory_scope_as_str_matches_serde() {
+    for scope in MemoryScope::ALL {
+        let json = serde_json::to_string(&scope).expect("MemoryScope serialization is infallible");
+        let expected = format!("\"{}\"", scope.as_str());
+        assert_eq!(
+            json, expected,
+            "MemoryScope json should match as_str representation"
+        );
+    }
+}
+
+#[test]
+fn memory_scope_from_str_roundtrip() {
+    for scope in MemoryScope::ALL {
+        let parsed: MemoryScope = scope
+            .as_str()
+            .parse()
+            .expect("MemoryScope as_str() should round-trip through FromStr");
+        assert_eq!(
+            scope, parsed,
+            "MemoryScope should survive as_str/parse roundtrip"
+        );
+    }
+}
+
+#[test]
+fn memory_scope_from_str_unknown() {
+    assert!(
+        "bogus".parse::<MemoryScope>().is_err(),
+        "unrecognized string should fail to parse as MemoryScope"
+    );
+}
+
+#[test]
+fn memory_scope_display() {
+    assert_eq!(
+        MemoryScope::User.to_string(),
+        "user",
+        "User should display as 'user'"
+    );
+    assert_eq!(
+        MemoryScope::Feedback.to_string(),
+        "feedback",
+        "Feedback should display as 'feedback'"
+    );
+    assert_eq!(
+        MemoryScope::Project.to_string(),
+        "project",
+        "Project should display as 'project'"
+    );
+    assert_eq!(
+        MemoryScope::Reference.to_string(),
+        "reference",
+        "Reference should display as 'reference'"
+    );
+}
+
+#[test]
+fn memory_scope_dir_names_match_as_str() {
+    for scope in MemoryScope::ALL {
+        assert_eq!(
+            scope.as_dir_name(),
+            scope.as_str(),
+            "dir name should match as_str for {scope:?}"
+        );
+    }
+}
+
+#[test]
+fn memory_scope_all_has_four_variants() {
+    assert_eq!(
+        MemoryScope::ALL.len(),
+        4,
+        "ALL should contain exactly 4 scope variants"
+    );
+}
+
+#[test]
+fn memory_scope_from_str_opt_returns_some_for_valid() {
+    assert_eq!(
+        MemoryScope::from_str_opt("user"),
+        Some(MemoryScope::User),
+        "from_str_opt should return Some(User) for 'user'"
+    );
+    assert_eq!(
+        MemoryScope::from_str_opt("feedback"),
+        Some(MemoryScope::Feedback),
+        "from_str_opt should return Some(Feedback) for 'feedback'"
+    );
+}
+
+#[test]
+fn memory_scope_from_str_opt_returns_none_for_invalid() {
+    assert_eq!(
+        MemoryScope::from_str_opt("invalid"),
+        None,
+        "from_str_opt should return None for unrecognized scope"
+    );
+    assert_eq!(
+        MemoryScope::from_str_opt(""),
+        None,
+        "from_str_opt should return None for empty string"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// ScopeAccessPolicy tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn user_scope_is_private() {
+    let policy = MemoryScope::User.access_policy();
+    assert!(
+        !policy.permits_agent_read(),
+        "agents must not read user scope"
+    );
+    assert!(
+        !policy.permits_agent_write(),
+        "agents must not write user scope"
+    );
+    assert!(
+        policy.user_write_only,
+        "user scope should be user-write-only"
+    );
+}
+
+#[test]
+fn feedback_scope_is_read_only_for_agents() {
+    let policy = MemoryScope::Feedback.access_policy();
+    assert!(
+        policy.permits_agent_read(),
+        "agents must read feedback scope"
+    );
+    assert!(
+        !policy.permits_agent_write(),
+        "agents must not write feedback scope"
+    );
+    assert!(
+        policy.user_write_only,
+        "feedback scope should be user-write-only"
+    );
+}
+
+#[test]
+fn project_scope_is_shared_read_write() {
+    let policy = MemoryScope::Project.access_policy();
+    assert!(
+        policy.permits_agent_read(),
+        "agents must read project scope"
+    );
+    assert!(
+        policy.permits_agent_write(),
+        "agents must write project scope"
+    );
+    assert!(
+        !policy.user_write_only,
+        "project scope should not be user-write-only"
+    );
+}
+
+#[test]
+fn reference_scope_is_hybrid() {
+    let policy = MemoryScope::Reference.access_policy();
+    assert!(
+        policy.permits_agent_read(),
+        "agents must read reference scope"
+    );
+    assert!(
+        !policy.permits_agent_write(),
+        "agents must not write reference scope"
+    );
+    assert!(
+        policy.user_write_only,
+        "reference scope should be user-write-only"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Fact with scope tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn fact_scope_none_omitted_in_json() {
+    let fact = Fact {
+        id: FactId::new("f-no-scope").expect("valid test id"),
+        nous_id: "syn".to_owned(),
+        content: "legacy fact without scope".to_owned(),
+        fact_type: String::new(),
+        scope: None,
+        temporal: FactTemporal {
+            valid_from: test_timestamp("2026-01-01"),
+            valid_to: far_future(),
+            recorded_at: test_timestamp("2026-01-01T00:00:00Z"),
+        },
+        provenance: FactProvenance {
+            confidence: 0.5,
+            tier: EpistemicTier::Assumed,
+            source_session_id: None,
+            stability_hours: 72.0,
+        },
+        lifecycle: FactLifecycle {
+            superseded_by: None,
+            is_forgotten: false,
+            forgotten_at: None,
+            forget_reason: None,
+        },
+        access: FactAccess {
+            access_count: 0,
+            last_accessed_at: None,
+        },
+    };
+    let json = serde_json::to_string(&fact).expect("Fact serialization is infallible");
+    assert!(
+        !json.contains("\"scope\""),
+        "scope: None should be omitted from serialized JSON"
+    );
+    let back: Fact =
+        serde_json::from_str(&json).expect("Fact should deserialize from its own JSON");
+    assert_eq!(
+        back.scope, None,
+        "deserialized scope should be None when omitted"
+    );
+}
+
+#[test]
+fn fact_scope_some_included_in_json() {
+    let fact = Fact {
+        id: FactId::new("f-scoped").expect("valid test id"),
+        nous_id: "syn".to_owned(),
+        content: "team project fact".to_owned(),
+        fact_type: "project".to_owned(),
+        scope: Some(MemoryScope::Project),
+        temporal: FactTemporal {
+            valid_from: test_timestamp("2026-03-01"),
+            valid_to: far_future(),
+            recorded_at: test_timestamp("2026-03-01T00:00:00Z"),
+        },
+        provenance: FactProvenance {
+            confidence: 0.9,
+            tier: EpistemicTier::Verified,
+            source_session_id: None,
+            stability_hours: 720.0,
+        },
+        lifecycle: FactLifecycle {
+            superseded_by: None,
+            is_forgotten: false,
+            forgotten_at: None,
+            forget_reason: None,
+        },
+        access: FactAccess {
+            access_count: 0,
+            last_accessed_at: None,
+        },
+    };
+    let json = serde_json::to_string(&fact).expect("Fact serialization is infallible");
+    assert!(
+        json.contains("\"scope\":\"project\""),
+        "scope: Some(Project) should appear in serialized JSON"
+    );
+    let back: Fact =
+        serde_json::from_str(&json).expect("Fact should deserialize from its own JSON");
+    assert_eq!(
+        back.scope,
+        Some(MemoryScope::Project),
+        "deserialized scope should be Some(Project)"
+    );
+}
+
+#[test]
+fn fact_backward_compat_no_scope_field() {
+    // WHY: Existing JSON without a `scope` field must deserialize to `scope: None`.
+    let json = r#"{
+        "id": "f-legacy",
+        "nous_id": "syn",
+        "fact_type": "observation",
+        "content": "old fact from before team memory",
+        "valid_from": "2026-01-01T00:00:00Z",
+        "valid_to": "9999-01-01T00:00:00Z",
+        "recorded_at": "2026-01-01T00:00:00Z",
+        "confidence": 0.5,
+        "tier": "assumed",
+        "source_session_id": null,
+        "stability_hours": 72.0,
+        "superseded_by": null,
+        "is_forgotten": false,
+        "forgotten_at": null,
+        "forget_reason": null,
+        "access_count": 0,
+        "last_accessed_at": null
+    }"#;
+    let fact: Fact =
+        serde_json::from_str(json).expect("legacy JSON without scope field should deserialize");
+    assert_eq!(
+        fact.scope, None,
+        "legacy fact without scope field should deserialize to scope: None"
+    );
+}
+
+#[test]
+fn fact_scope_all_variants_roundtrip() {
+    for scope in MemoryScope::ALL {
+        let fact = Fact {
+            id: FactId::new("f-scope-test").expect("valid test id"),
+            nous_id: "syn".to_owned(),
+            content: format!("fact in {scope} scope"),
+            fact_type: String::new(),
+            scope: Some(scope),
+            temporal: FactTemporal {
+                valid_from: test_timestamp("2026-01-01"),
+                valid_to: far_future(),
+                recorded_at: test_timestamp("2026-01-01T00:00:00Z"),
+            },
+            provenance: FactProvenance {
+                confidence: 0.5,
+                tier: EpistemicTier::Assumed,
+                source_session_id: None,
+                stability_hours: 72.0,
+            },
+            lifecycle: FactLifecycle {
+                superseded_by: None,
+                is_forgotten: false,
+                forgotten_at: None,
+                forget_reason: None,
+            },
+            access: FactAccess {
+                access_count: 0,
+                last_accessed_at: None,
+            },
+        };
+        let json = serde_json::to_string(&fact).expect("Fact serialization is infallible");
+        let back: Fact =
+            serde_json::from_str(&json).expect("Fact should deserialize from its own JSON");
+        assert_eq!(
+            back.scope,
+            Some(scope),
+            "scope {scope:?} should survive serde roundtrip"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// PathValidationLayer tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn path_validation_layer_serde_roundtrip() {
+    for layer in PathValidationLayer::ALL {
+        let json =
+            serde_json::to_string(&layer).expect("PathValidationLayer serialization is infallible");
+        let back: PathValidationLayer = serde_json::from_str(&json)
+            .expect("PathValidationLayer should deserialize from its own JSON");
+        assert_eq!(
+            layer, back,
+            "PathValidationLayer should survive serde roundtrip"
+        );
+    }
+}
+
+#[test]
+fn path_validation_layer_as_str_matches_serde() {
+    for layer in PathValidationLayer::ALL {
+        let json =
+            serde_json::to_string(&layer).expect("PathValidationLayer serialization is infallible");
+        let expected = format!("\"{}\"", layer.as_str());
+        assert_eq!(
+            json, expected,
+            "PathValidationLayer json should match as_str representation"
+        );
+    }
+}
+
+#[test]
+fn path_validation_layer_from_str_roundtrip() {
+    for layer in PathValidationLayer::ALL {
+        let parsed: PathValidationLayer = layer
+            .as_str()
+            .parse()
+            .expect("PathValidationLayer as_str() should round-trip through FromStr");
+        assert_eq!(
+            layer, parsed,
+            "PathValidationLayer should survive as_str/parse roundtrip"
+        );
+    }
+}
+
+#[test]
+fn path_validation_layer_from_str_unknown() {
+    assert!(
+        "bogus".parse::<PathValidationLayer>().is_err(),
+        "unrecognized string should fail to parse as PathValidationLayer"
+    );
+}
+
+#[test]
+fn path_validation_layer_display() {
+    assert_eq!(
+        PathValidationLayer::NullByte.to_string(),
+        "null_byte",
+        "NullByte should display as 'null_byte'"
+    );
+    assert_eq!(
+        PathValidationLayer::UnicodeNormalization.to_string(),
+        "unicode_normalization",
+        "UnicodeNormalization should display as 'unicode_normalization'"
+    );
+    assert_eq!(
+        PathValidationLayer::ScopeContainment.to_string(),
+        "scope_containment",
+        "ScopeContainment should display as 'scope_containment'"
+    );
+}
+
+#[test]
+fn path_validation_layer_all_has_eight_entries() {
+    assert_eq!(
+        PathValidationLayer::ALL.len(),
+        8,
+        "ALL should contain exactly 8 validation layers"
+    );
+}
+
+#[test]
+fn path_validation_layer_io_classification() {
+    // WHY: Only filesystem-interacting layers should require I/O.
+    let io_layers = PathValidationLayer::ALL
+        .iter()
+        .filter(|l| l.requires_io())
+        .count();
+    assert_eq!(
+        io_layers, 3,
+        "exactly 3 layers (symlink resolution, dangling symlink, loop detection) require I/O"
+    );
+    assert!(
+        PathValidationLayer::SymlinkResolution.requires_io(),
+        "symlink resolution requires I/O"
+    );
+    assert!(
+        PathValidationLayer::DanglingSymlink.requires_io(),
+        "dangling symlink detection requires I/O"
+    );
+    assert!(
+        PathValidationLayer::LoopDetection.requires_io(),
+        "loop detection requires I/O"
+    );
+    assert!(
+        !PathValidationLayer::NullByte.requires_io(),
+        "null byte check does not require I/O"
+    );
+    assert!(
+        !PathValidationLayer::Canonicalization.requires_io(),
+        "canonicalization does not require I/O"
+    );
+    assert!(
+        !PathValidationLayer::UrlEncodedTraversal.requires_io(),
+        "URL-encoded traversal check does not require I/O"
+    );
+    assert!(
+        !PathValidationLayer::UnicodeNormalization.requires_io(),
+        "unicode normalization check does not require I/O"
+    );
+    assert!(
+        !PathValidationLayer::ScopeContainment.requires_io(),
+        "scope containment check does not require I/O"
+    );
+}
+
+#[test]
+fn path_validation_fs_layers_constant() {
+    assert_eq!(
+        PATH_VALIDATION_FS_LAYERS, 7,
+        "PATH_VALIDATION_FS_LAYERS should be 7"
+    );
+}
+
+#[test]
+fn symlink_hop_limit_matches_linux_eloop() {
+    assert_eq!(
+        SYMLINK_HOP_LIMIT, 40,
+        "SYMLINK_HOP_LIMIT should match Linux ELOOP limit of 40"
     );
 }


### PR DESCRIPTION
## Summary
- Add `MemoryScope` enum (User, Feedback, Project, Reference) with per-scope `ScopeAccessPolicy` and directory name mapping
- Add `PathValidationLayer` enum classifying the 7-layer defense-in-depth path security model plus scope containment
- Add optional `scope: Option<MemoryScope>` field to `Fact` for team memory tracking (backward-compatible via `#[serde(default)]`)
- 26 new tests covering serde roundtrips, access policy semantics, scope I/O classification, and backward compatibility

## Acceptance criteria
- [x] Memory scope model: User (private), Feedback (selective), Project (shared), Reference (hybrid)
- [x] `MemoryScope::access_policy()` returns correct `ScopeAccessPolicy` per scope
- [x] `PathValidationLayer` enum with variant per validation layer (7 FS layers + scope containment)
- [x] `Fact` carries optional `scope` field, backward-compatible with existing JSON
- [x] `cargo test -p aletheia-eidos` passes (74 tests, 26 new)
- [x] `cargo clippy -p aletheia-eidos -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean

## Observations
- **Pre-existing**: unfulfilled `#[expect(dead_code)]` warning on `is_far_future` in knowledge.rs (present on main, not introduced by this PR)
- **Pre-existing**: `sha2` 0.11.0 bump (#2257) breaks `graphe/migration.rs:441` — `LowerHex` not implemented for new `Array` type. Blocks `cargo build --workspace` but not eidos-scoped validation
- **Scope**: `Fact` construction sites in episteme/nous (behind `#[cfg(feature = "mneme-engine")]`) will need `scope: None` when that feature is next compiled — deferred to the mneme worker or follow-up PR

## Validation gate
- `cargo fmt --all -- --check` ✓
- `cargo clippy -p aletheia-eidos -- -D warnings` ✓
- `cargo test -p aletheia-eidos` ✓ (74 passed)

Closes #2262

🤖 Generated with [Claude Code](https://claude.com/claude-code)