### PR TITLE
docs(symbolon): fix credential module path references in CLAUDE.md

### DIFF
--- a/crates/symbolon/CLAUDE.md
+++ b/crates/symbolon/CLAUDE.md
@@ -4,7 +4,7 @@ Authentication and authorization: JWT sessions, API keys, Argon2id passwords, OA
 
 ## Read first
 
-1. `src/credential.rs`: CredentialChain, RefreshingCredentialProvider, FileCredentialProvider (LLM API key resolution)
+1. `src/credential/mod.rs`: CredentialChain, RefreshingCredentialProvider, FileCredentialProvider (LLM API key resolution)
 2. `src/jwt.rs`: JwtManager, JwtConfig (HS256 JWT issuance and validation using ring::hmac)
 3. `src/types.rs`: Claims, Role, TokenKind, Action (shared auth types)
 4. `src/auth.rs`: AuthService facade composing JWT, API keys, passwords, RBAC
@@ -14,11 +14,11 @@ Authentication and authorization: JWT sessions, API keys, Argon2id passwords, OA
 
 | Type | Path | Purpose |
 |------|------|---------|
-| `CredentialChain` | `credential.rs` | Priority-ordered credential resolution: env -> file -> OAuth refresh |
-| `RefreshingCredentialProvider` | `credential.rs` | Background OAuth token refresh with circuit breaker |
-| `FileCredentialProvider` | `credential.rs` | Reads credentials from encrypted JSON files on disk |
-| `EnvCredentialProvider` | `credential.rs` | Reads API keys from environment variables |
-| `CredentialFile` | `credential.rs` | On-disk credential format (token, refresh_token, expires_at) |
+| `CredentialChain` | `credential/providers.rs` | Priority-ordered credential resolution: env -> file -> OAuth refresh |
+| `RefreshingCredentialProvider` | `credential/refresh.rs` | Background OAuth token refresh with circuit breaker |
+| `FileCredentialProvider` | `credential/providers.rs` | Reads credentials from encrypted JSON files on disk |
+| `EnvCredentialProvider` | `credential/providers.rs` | Reads API keys from environment variables |
+| `CredentialFile` | `credential/file_ops.rs` | On-disk credential format (token, refresh_token, expires_at) |
 | `JwtManager` | `jwt.rs` | HS256 JWT issuance, validation, and refresh (Send + Sync) |
 | `JwtConfig` | `jwt.rs` | Signing key, access/refresh TTL, issuer |
 | `Claims` | `types.rs` | JWT payload: sub, role, nous_id, iss, iat, exp, jti, kind |
@@ -39,7 +39,7 @@ Authentication and authorization: JWT sessions, API keys, Argon2id passwords, OA
 
 | Task | Where |
 |------|-------|
-| Add credential source | `src/credential.rs` (implement `CredentialProvider` trait from koina) |
+| Add credential source | `src/credential/` (implement `CredentialProvider` trait from koina) |
 | Add RBAC role | `src/types.rs` (Role enum) + `src/auth.rs` (permission checks) |
 | Modify JWT claims | `src/types.rs` (Claims struct) + `src/jwt.rs` (encode/decode) |
 | Add auth store table | `src/store.rs` (AuthStore, schema migrations) |


### PR DESCRIPTION
## Summary
- Fix 7 incorrect path references in `crates/symbolon/CLAUDE.md` where `credential.rs` (flat file) was referenced but the actual structure is `credential/` (module directory)
- Updated "Read first", "Key types", and "Common tasks" sections to point to correct submodule files (`credential/providers.rs`, `credential/refresh.rs`, `credential/file_ops.rs`)

## Acceptance criteria
- [x] Tests pass for affected code (docs-only change; all test failures are pre-existing on main: 7 integration-tests infrastructure failures, 10 pylon API test failures)
- [x] Issue #2025 requirements are satisfied (all 18 per-crate CLAUDE.md files present and verified; this PR fixes the last remaining path inaccuracy missed by PR #2104)

## Observations
- **Pre-existing**: 7 integration-test failures on main (cross_crate_pipeline tests require running backend)
- **Pre-existing**: 10 pylon test failures on main (API/streaming tests require mock infrastructure)
- **Pre-existing**: `cargo fmt` failures in `daemon/src/runner.rs` on main
- **Pre-existing**: 34 clippy errors in `krites` on main (unfulfilled lint expectations)
- **Context**: PR #2040 added all 18 CLAUDE.md files. PR #2104 fixed 3 path inaccuracies (episteme, theatron/core, theatron/tui). This PR fixes the 4th: symbolon's `credential.rs` → `credential/mod.rs` and submodule paths.

## Validation gate
- `cargo fmt --all -- --check` ✓ (no formatting issues in CLAUDE.md)
- `cargo clippy --workspace --all-targets -- -D warnings` — pre-existing failures in krites (not caused by this change)
- `cargo test --workspace` — pre-existing failures in integration-tests and pylon (not caused by this change)

Closes #2025

🤖 Generated with [Claude Code](https://claude.com/claude-code)