### PR TITLE
fix(aletheia): set 0600 permissions on config and credential writes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,7 +33,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia"
-version = "0.13.19"
+version = "0.13.20"
 dependencies = [
  "aletheia-agora",
  "aletheia-dianoia",
@@ -83,7 +83,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-agora"
-version = "0.13.19"
+version = "0.13.20"
 dependencies = [
  "aletheia-koina",
  "aletheia-taxis",
@@ -104,7 +104,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-dianoia"
-version = "0.13.19"
+version = "0.13.20"
 dependencies = [
  "aletheia-koina",
  "jiff",
@@ -119,7 +119,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-diaporeia"
-version = "0.13.19"
+version = "0.13.20"
 dependencies = [
  "aletheia-koina",
  "aletheia-mneme",
@@ -142,7 +142,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-dokimion"
-version = "0.13.19"
+version = "0.13.20"
 dependencies = [
  "aletheia-koina",
  "owo-colors",
@@ -161,7 +161,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-eidos"
-version = "0.13.19"
+version = "0.13.20"
 dependencies = [
  "jiff",
  "serde",
@@ -171,7 +171,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-episteme"
-version = "0.13.19"
+version = "0.13.20"
 dependencies = [
  "aletheia-eidos",
  "aletheia-graphe",
@@ -201,7 +201,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-graphe"
-version = "0.13.19"
+version = "0.13.20"
 dependencies = [
  "aletheia-eidos",
  "aletheia-koina",
@@ -222,7 +222,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-hermeneus"
-version = "0.13.19"
+version = "0.13.20"
 dependencies = [
  "aletheia-koina",
  "jiff",
@@ -245,7 +245,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-integration-tests"
-version = "0.13.19"
+version = "0.13.20"
 dependencies = [
  "aletheia-dokimion",
  "aletheia-hermeneus",
@@ -271,7 +271,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-koina"
-version = "0.13.19"
+version = "0.13.20"
 dependencies = [
  "compact_str",
  "jiff",
@@ -291,7 +291,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-krites"
-version = "0.13.19"
+version = "0.13.20"
 dependencies = [
  "aho-corasick",
  "aletheia-eidos",
@@ -335,7 +335,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-melete"
-version = "0.13.19"
+version = "0.13.20"
 dependencies = [
  "aletheia-hermeneus",
  "fd-lock",
@@ -353,7 +353,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-mneme"
-version = "0.13.19"
+version = "0.13.20"
 dependencies = [
  "aletheia-eidos",
  "aletheia-episteme",
@@ -368,7 +368,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-nous"
-version = "0.13.19"
+version = "0.13.20"
 dependencies = [
  "aletheia-dianoia",
  "aletheia-hermeneus",
@@ -397,7 +397,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-oikonomos"
-version = "0.13.19"
+version = "0.13.20"
 dependencies = [
  "aletheia-koina",
  "axum 0.8.8",
@@ -422,7 +422,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-organon"
-version = "0.13.19"
+version = "0.13.20"
 dependencies = [
  "aletheia-hermeneus",
  "aletheia-koina",
@@ -449,7 +449,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-pylon"
-version = "0.13.19"
+version = "0.13.20"
 dependencies = [
  "aletheia-hermeneus",
  "aletheia-koina",
@@ -483,7 +483,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-symbolon"
-version = "0.13.19"
+version = "0.13.20"
 dependencies = [
  "aletheia-koina",
  "argon2",
@@ -510,7 +510,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-taxis"
-version = "0.13.19"
+version = "0.13.20"
 dependencies = [
  "aletheia-koina",
  "base64 0.22.1",
@@ -528,7 +528,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-thesauros"
-version = "0.13.19"
+version = "0.13.20"
 dependencies = [
  "aletheia-koina",
  "aletheia-organon",
@@ -6041,7 +6041,7 @@ dependencies = [
 
 [[package]]
 name = "theatron-core"
-version = "0.13.19"
+version = "0.13.20"
 dependencies = [
  "aletheia-koina",
  "bytes",
@@ -6060,7 +6060,7 @@ dependencies = [
 
 [[package]]
 name = "theatron-tui"
-version = "0.13.19"
+version = "0.13.20"
 dependencies = [
  "aletheia-koina",
  "arboard",

--- a/crates/aletheia/src/init/mod.rs
+++ b/crates/aletheia/src/init/mod.rs
@@ -371,7 +371,7 @@ fn collect_credential() -> Result<Option<SecretString>, InitError> {
 mod helpers;
 mod scaffold;
 
-use helpers::{capitalize, detect_timezone};
+use helpers::{capitalize, detect_timezone, set_permissions};
 use scaffold::scaffold;
 
 #[cfg(feature = "tui")]
@@ -431,5 +431,10 @@ fn write_user_profile_from_wizard(
             &format!("- **Timezone:** {}", wa.timezone),
         );
 
-    std::fs::write(&user_md_path, updated).context(WriteFileSnafu { path: user_md_path })
+    std::fs::write(&user_md_path, updated).context(WriteFileSnafu {
+        path: user_md_path.clone(),
+    })?;
+    // WHY: restrict USER.md to owner-only (0600) — contains personal user data (name, role, timezone)
+    set_permissions(&user_md_path, 0o600)?;
+    Ok(())
 }

--- a/crates/daemon/src/runner.rs
+++ b/crates/daemon/src/runner.rs
@@ -16,7 +16,6 @@ use crate::schedule::{
     BuiltinTask, Schedule, TaskAction, TaskDef, TaskStatus, apply_jitter, backoff_delay,
 };
 
-
 /// Output mode for daemon logging.
 ///
 /// WHY: daemon logs should be scannable; full model responses and tool results
@@ -37,7 +36,6 @@ const BRIEF_HEAD_LINES: usize = 5;
 const BRIEF_TAIL_LINES: usize = 3;
 /// Maximum character length for model response summaries in brief mode.
 const BRIEF_RESPONSE_MAX_CHARS: usize = 200;
-
 
 /// Truncate output for brief mode.
 ///
@@ -70,12 +68,9 @@ pub(crate) fn truncate_response(response: &str) -> String {
 
     let truncated = &response[..BRIEF_RESPONSE_MAX_CHARS];
     // NOTE: find the last space to avoid cutting mid-word
-    let end = truncated
-        .rfind(' ')
-        .unwrap_or(BRIEF_RESPONSE_MAX_CHARS);
+    let end = truncated.rfind(' ').unwrap_or(BRIEF_RESPONSE_MAX_CHARS);
     format!("{}...", &response[..end])
 }
-
 
 /// Per-nous background task runner.
 pub struct TaskRunner {
@@ -483,9 +478,8 @@ impl TaskRunner {
 
         // WHY: watchdog interval for systemd WatchdogSec integration.
         let watchdog_interval = sd_watchdog_interval();
-        let mut watchdog_tick = tokio::time::interval(
-            watchdog_interval.unwrap_or(Duration::from_secs(30)),
-        );
+        let mut watchdog_tick =
+            tokio::time::interval(watchdog_interval.unwrap_or(Duration::from_secs(30)));
 
         loop {
             tokio::select! {
@@ -885,7 +879,6 @@ impl TaskRunner {
     }
 }
 
-
 // -- systemd notify integration --
 
 /// Send `READY=1` to systemd via the `$NOTIFY_SOCKET`.
@@ -960,7 +953,6 @@ fn sd_notify(msg: &str) {
 fn sd_notify(_msg: &str) {
     // NOTE: systemd notify is Linux-only. No-op on other platforms.
 }
-
 
 #[cfg(test)]
 #[path = "runner_tests.rs"]

--- a/crates/daemon/src/schedule.rs
+++ b/crates/daemon/src/schedule.rs
@@ -238,7 +238,10 @@ impl Schedule {
     clippy::cast_precision_loss,
     reason = "u32 → f64 is lossless for all u32 values (f64 has 52-bit mantissa)"
 )]
-pub(crate) fn compute_jitter(task_id: &str, max_jitter: jiff::SignedDuration) -> jiff::SignedDuration {
+pub(crate) fn compute_jitter(
+    task_id: &str,
+    max_jitter: jiff::SignedDuration,
+) -> jiff::SignedDuration {
     let mut hasher = DefaultHasher::new();
     task_id.hash(&mut hasher);
     let hash = hasher.finish();
@@ -530,10 +533,7 @@ mod tests {
         let j1 = compute_jitter("task-alpha", max);
         let j2 = compute_jitter("task-beta", max);
         // NOTE: technically hash collisions are possible but astronomically unlikely
-        assert_ne!(
-            j1, j2,
-            "different task IDs should produce different jitter"
-        );
+        assert_ne!(j1, j2, "different task IDs should produce different jitter");
     }
 
     #[test]

--- a/crates/daemon/src/state.rs
+++ b/crates/daemon/src/state.rs
@@ -12,7 +12,6 @@ use snafu::ResultExt as _;
 
 use crate::error::Result;
 
-
 /// Persisted execution state for a single registered task.
 #[derive(Debug, Clone)]
 pub struct TaskState {
@@ -146,7 +145,6 @@ impl TaskStateStore {
     }
 }
 
-
 /// Per-workspace daemon configuration parsed from `.aletheia/daemon.toml`.
 ///
 /// WHY: the daemon only activates for workspaces that have explicitly opted in.
@@ -231,11 +229,10 @@ impl DaemonConfig {
             return Ok(Self::default());
         }
 
-        let contents = std::fs::read_to_string(&config_path).context(
-            crate::error::MaintenanceIoSnafu {
+        let contents =
+            std::fs::read_to_string(&config_path).context(crate::error::MaintenanceIoSnafu {
                 context: format!("reading daemon config: {}", config_path.display()),
-            },
-        )?;
+            })?;
 
         let config: Self = toml::from_str(&contents).map_err(|e| {
             crate::error::TaskFailedSnafu {
@@ -265,7 +262,6 @@ impl DaemonConfig {
     }
 }
 
-
 /// Single-instance lock guard for daemon process per workspace.
 ///
 /// WHY: only one daemon process should run per workspace. `fd-lock` provides
@@ -288,11 +284,9 @@ impl WorkspaceGuard {
     pub fn acquire(workspace_root: &Path) -> Result<Self> {
         let lock_dir = workspace_root.join(".aletheia");
         if !lock_dir.exists() {
-            std::fs::create_dir_all(&lock_dir).context(
-                crate::error::MaintenanceIoSnafu {
-                    context: format!("creating lock directory: {}", lock_dir.display()),
-                },
-            )?;
+            std::fs::create_dir_all(&lock_dir).context(crate::error::MaintenanceIoSnafu {
+                context: format!("creating lock directory: {}", lock_dir.display()),
+            })?;
         }
 
         let lock_path = lock_dir.join("daemon.lock");
@@ -351,7 +345,6 @@ impl Drop for WorkspaceGuard {
         let _ = std::fs::remove_file(&self.path);
     }
 }
-
 
 #[cfg(test)]
 #[expect(clippy::unwrap_used, reason = "test assertions")]


### PR DESCRIPTION
## Summary
- Add `set_permissions(0o600)` after `std::fs::write` in `write_user_profile_from_wizard` so `USER.md` containing personal user data (name, role, timezone) is restricted to owner-only access
- All other files listed in K-1712 were already fixed in prior work
- Also apply `cargo fmt` to pre-existing whitespace drift in `aletheia-oikonomos` that blocked format checks
- Closes forkwright/aletheia#2067

## Acceptance criteria
- [x] All `std::fs::write` calls to config/credential paths have adjacent `set_permissions` with 0600
- [x] `use std::os::unix::fs::PermissionsExt` added where needed (via `helpers::set_permissions` shim)
- [x] No test-only writes modified
- [x] Tests pass for affected crates (36 tests in `aletheia` crate)

## Observations
- Most files in the task's "remaining to fix" list were already fixed before this PR: `scaffold.rs`, `tls.rs`, `add_nous.rs`, `agent_io.rs`, `session_export.rs` all had `set_permissions` or `write_restricted` in place
- Only `init/mod.rs::write_user_profile_from_wizard` was missing the permission call
- `crates/daemon` had pre-existing `cargo fmt` drift (extra blank lines, line-length reflows) that caused `cargo fmt --check` to fail; fixed as part of validation gate
- Pre-existing clippy failures in `aletheia-oikonomos`, `aletheia-krites`, `aletheia-koina`, `aletheia-symbolon`, `aletheia-organon` are unrelated to this PR

## Validation gate
- `cargo fmt --all -- --check` ✓
- `cargo clippy -p aletheia -- -D warnings` ✓ (no errors in modified crate)
- `cargo test -p aletheia` ✓ (36/36 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)