### PR TITLE
fix(aletheia): correct #[expect] reason strings in export commands

### DIFF
--- a/crates/aletheia/src/commands/agent_io.rs
+++ b/crates/aletheia/src/commands/agent_io.rs
@@ -232,7 +232,7 @@ pub(crate) fn export_agent(instance_root: Option<&PathBuf>, args: &ExportArgs) -
     };
     #[expect(
         clippy::disallowed_methods,
-        reason = "aletheia CLI commands use synchronous filesystem operations for config and certificate generation"
+        reason = "aletheia CLI commands use synchronous filesystem operations for agent export writes"
     )]
     std::fs::write(&output_path, &json)
         .with_whatever_context(|_| format!("failed to write {}", output_path.display()))?;

--- a/crates/aletheia/src/commands/session_export.rs
+++ b/crates/aletheia/src/commands/session_export.rs
@@ -205,7 +205,7 @@ fn write_output(content: &str, path: Option<&std::path::Path>) -> Result<()> {
     match path {
         #[expect(
             clippy::disallowed_methods,
-            reason = "aletheia CLI commands use synchronous filesystem operations for config and certificate generation"
+            reason = "aletheia CLI commands use synchronous filesystem operations for session export writes"
         )]
         Some(p) => {
             std::fs::write(p, content)


### PR DESCRIPTION
## Summary

- Correct copy-pasted `#[expect(clippy::disallowed_methods)]` reason strings in `agent_io.rs` and `session_export.rs`
- Both files carried `"aletheia CLI commands use synchronous filesystem operations for config and certificate generation"` copied from `tls.rs`, but they perform agent and session exports respectively

Closes #2067

## Acceptance criteria

- [x] Closes forkwright/aletheia#2067

## Validation gate

- `cargo fmt --all -- --check` ✓
- `cargo clippy -p aletheia -- -D warnings` ✓ (pre-existing failures in unrelated crates: oikonomos, krites — not introduced by this PR)
- `cargo test -p aletheia` ✓ (36/36 passed)

## Observations

- Pre-existing clippy failures in `aletheia-oikonomos` (19 errors in `daemon/src/`) and `aletheia-krites` (1 error in `krites/src/`) block workspace-wide clippy. These are unrelated to this PR and were present before this branch.