### PR TITLE
fix: resolve 17 lint violations via verda

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,3 +1,5 @@
+
+
 name: CodeQL
 
 on:
@@ -9,6 +11,10 @@ on:
 # PROJECT: explicit top-level default deny; job-level permissions grant only what's needed
 permissions:
   contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   analyze-actions:

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,3 +1,5 @@
+
+
 name: Dependabot Auto-Merge
 
 on:
@@ -6,6 +8,10 @@ on:
 permissions:
   contents: write
   pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   auto-merge:

--- a/.github/workflows/pr-hygiene.yml
+++ b/.github/workflows/pr-hygiene.yml
@@ -1,3 +1,5 @@
+
+
 name: PR Hygiene
 
 on:
@@ -7,6 +9,10 @@ on:
 
 permissions:
   pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   size-check:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,3 +1,5 @@
+
+
 name: Release Please
 
 on:
@@ -8,6 +10,10 @@ on:
 permissions:
   contents: write
   pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   release-please:

--- a/crates/agora/src/registry.rs
+++ b/crates/agora/src/registry.rs
@@ -1,3 +1,5 @@
+
+
 //! Channel registry: the single source of truth for available channels.
 
 use std::sync::Arc;
@@ -36,6 +38,7 @@ impl ChannelRegistry {
     /// # Errors
     ///
     /// Returns an error if a provider with the same ID is already registered.
+    #[must_use]
     pub fn register(&mut self, provider: Arc<dyn ChannelProvider>) -> Result<()> {
         let id = provider.id().to_owned();
         ensure!(
@@ -60,6 +63,7 @@ impl ChannelRegistry {
     /// # Errors
     ///
     /// Returns an error if the channel is not registered.
+    #[must_use]
     pub async fn send(&self, channel_id: &str, params: &SendParams) -> Result<SendResult> {
         let provider = self.providers.get(channel_id).ok_or_else(|| {
             error::UnknownChannelSnafu {

--- a/crates/agora/src/semeion/client.rs
+++ b/crates/agora/src/semeion/client.rs
@@ -1,3 +1,5 @@
+
+
 //! JSON-RPC client for the signal-cli HTTP daemon.
 
 use std::time::Duration;
@@ -56,6 +58,7 @@ impl SignalClient {
     /// # Errors
     ///
     /// Returns [`super::error::Error::Http`] if the HTTP client cannot be constructed.
+    #[must_use]
     pub fn new(base_url: &str) -> Result<Self> {
         let base = normalize_url(base_url);
 
@@ -120,6 +123,7 @@ impl SignalClient {
     /// Retries up to 2 times with 500ms, 1000ms backoff.
     /// Does NOT retry JSON-RPC application errors (only transport failures).
     #[instrument(skip(self, params))]
+    #[must_use]
     pub async fn send_message(&self, params: &SendParams) -> Result<Option<serde_json::Value>> {
         let rpc_params = params.to_rpc_value();
         let backoffs = [500u64, 1000];
@@ -174,6 +178,7 @@ impl SignalClient {
     /// that have accumulated since the last call. Uses a longer timeout than
     /// standard RPC calls since receive may block briefly.
     #[instrument(skip(self))]
+    #[must_use]
     pub async fn receive(&self, account: Option<&str>) -> Result<Vec<SignalEnvelope>> {
         let mut params = serde_json::Map::new();
         if let Some(acct) = account {

--- a/crates/daemon/src/state.rs
+++ b/crates/daemon/src/state.rs
@@ -1,3 +1,5 @@
+
+
 //! SQLite-backed persistence for daemon task execution state.
 //!
 //! Survives process restarts so tasks resume their schedules rather than
@@ -218,6 +220,7 @@ impl DaemonConfig {
     /// # Errors
     ///
     /// Returns `TaskFailed` if the file exists but cannot be parsed.
+    #[must_use]
     pub fn load(workspace_root: &Path) -> Result<Self> {
         let config_path = workspace_root.join(".aletheia").join("daemon.toml");
 
@@ -281,6 +284,7 @@ impl WorkspaceGuard {
     ///
     /// Returns `TaskFailed` if the lock file cannot be created or another
     /// daemon instance already holds the lock.
+    #[must_use]
     pub fn acquire(workspace_root: &Path) -> Result<Self> {
         let lock_dir = workspace_root.join(".aletheia");
         if !lock_dir.exists() {

--- a/crates/dianoia/src/project.rs
+++ b/crates/dianoia/src/project.rs
@@ -1,3 +1,5 @@
+
+
 //! Project types and lifecycle management.
 
 use serde::{Deserialize, Serialize};
@@ -67,6 +69,7 @@ impl Project {
     }
 
     /// Advance project state via a transition.
+    #[must_use]
     pub fn advance(&mut self, transition: Transition) -> Result<()> {
         let current = self.state.clone();
         self.state = current.transition(transition)?;

--- a/crates/dianoia/src/state.rs
+++ b/crates/dianoia/src/state.rs
@@ -1,3 +1,5 @@
+
+
 //! Project lifecycle state machine.
 
 use serde::{Deserialize, Serialize};
@@ -76,6 +78,7 @@ pub enum Transition {
 impl ProjectState {
     /// Attempt a state transition. Returns the new state or an error
     /// if the transition is invalid from the current state.
+    #[must_use]
     pub fn transition(self, t: Transition) -> Result<Self> {
         let from_label = state_label(&self);
         let result = match (&self, &t) {

--- a/crates/dianoia/src/workspace.rs
+++ b/crates/dianoia/src/workspace.rs
@@ -1,3 +1,5 @@
+
+
 //! On-disk workspace persistence for projects.
 
 use std::path::{Path, PathBuf};
@@ -37,6 +39,7 @@ impl ProjectWorkspace {
     /// # Errors
     ///
     /// Returns a workspace I/O error if the workspace directories cannot be created.
+    #[must_use]
     pub fn create(root: impl Into<PathBuf>) -> Result<Self> {
         let root = root.into();
         let layout = Self::build_layout(&root);
@@ -53,6 +56,7 @@ impl ProjectWorkspace {
     }
 
     /// Open an existing workspace.
+    #[must_use]
     pub fn open(root: impl Into<PathBuf>) -> Result<Self> {
         let root = root.into();
         if !root.exists() {
@@ -67,6 +71,7 @@ impl ProjectWorkspace {
     ///
     /// Returns a serialization error if the project cannot be serialized to JSON.
     /// Returns a workspace I/O error if the project file cannot be written.
+    #[must_use]
     pub fn save_project(&self, project: &Project) -> Result<()> {
         let layout = self.layout();
         let json = serde_json::to_string_pretty(project).context(error::WorkspaceSerializeSnafu)?;
@@ -79,6 +84,7 @@ impl ProjectWorkspace {
     }
 
     /// Load project state from disk.
+    #[must_use]
     pub fn load_project(&self) -> Result<Project> {
         let layout = self.layout();
         if !layout.project_file.exists() {


### PR DESCRIPTION
Mechanical lint fixes by Qwen/Qwen3.5-122B-A10B-FP8.

**Violations:** 17 | **Files:** 10
**Rules:** RUST/missing-must-use, YAML/missing-concurrency

Gate-Passed: kanon 0.1.0