### PR TITLE
fix(theatron): resolve desktop compile errors (D2)

### DIFF
--- a/crates/theatron/core/src/sse.rs
+++ b/crates/theatron/core/src/sse.rs
@@ -24,7 +24,7 @@ pub struct SseEvent {
 /// Handles the full SSE wire protocol: `data:`, `event:`, `id:`, `retry:`,
 /// comment lines (`:` prefix), multi-line `data:` fields (concatenated with
 /// newlines), and blank-line event delimiters.
-pub(crate) struct SseStream<S> {
+pub struct SseStream<S> {
     stream: S,
     buf: String,
     done: bool,
@@ -42,7 +42,7 @@ where
     E: std::fmt::Display,
 {
     /// Create a new SSE stream parser wrapping the given byte stream.
-    pub(crate) fn new(stream: S) -> Self {
+    pub fn new(stream: S) -> Self {
         Self {
             stream,
             buf: String::new(),

--- a/crates/theatron/desktop/Cargo.lock
+++ b/crates/theatron/desktop/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-koina"
-version = "0.13.1"
+version = "0.13.23"
 dependencies = [
  "compact_str",
  "jiff",
@@ -4528,7 +4528,7 @@ dependencies = [
 
 [[package]]
 name = "theatron-core"
-version = "0.13.1"
+version = "0.13.23"
 dependencies = [
  "aletheia-koina",
  "bytes",

--- a/crates/theatron/desktop/src/components/chart.rs
+++ b/crates/theatron/desktop/src/components/chart.rs
@@ -394,6 +394,363 @@ pub(crate) fn GroupedBarChart(
     }
 }
 
+// -- Series colors ------------------------------------------------------------
+
+/// Palette for multi-series charts (8 visually distinct hues).
+pub(crate) const SERIES_COLORS: &[&str] = &[
+    "#5b6af0", "#22c55e", "#eab308", "#ef4444", "#a855f7", "#06b6d4", "#f97316", "#ec4899",
+];
+
+// -- Line chart types ---------------------------------------------------------
+
+/// A single data point in a line series.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct LinePoint {
+    pub label: String,
+    pub value: f64,
+}
+
+/// A named series of line points with a color.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct LineSeries {
+    pub name: String,
+    pub color: String,
+    pub points: Vec<LinePoint>,
+}
+
+/// Div-based multi-series line chart (approximated with vertical bars per point).
+///
+/// WHY: True SVG line rendering is not confirmed for Blitz. This component
+/// approximates a line chart using vertical bars sized proportionally to each
+/// point value, with a legend for series identification.
+#[component]
+pub(crate) fn LineChart(series: Vec<LineSeries>, height: u32) -> Element {
+    if series.is_empty() || series.iter().all(|s| s.points.is_empty()) {
+        return rsx! {
+            div {
+                style: "display: flex; align-items: center; justify-content: center; height: {height}px; color: #706c66; font-size: 13px;",
+                "No data"
+            }
+        };
+    }
+
+    let max_val = series
+        .iter()
+        .flat_map(|s| s.points.iter().map(|p| p.value))
+        .fold(0.0f64, f64::max)
+        .max(1.0);
+
+    let num_points = series
+        .iter()
+        .map(|s| s.points.len())
+        .max()
+        .unwrap_or(0);
+
+    rsx! {
+        div {
+            style: "display: flex; flex-direction: column; gap: 6px;",
+
+            // Legend
+            div {
+                style: "display: flex; flex-wrap: wrap; gap: 8px 12px; align-items: center;",
+                for s in &series {
+                    {
+                        let color = s.color.clone();
+                        let name = s.name.clone();
+                        rsx! {
+                            div {
+                                style: "display: flex; align-items: center; gap: 4px;",
+                                div { style: "width: 10px; height: 10px; border-radius: 2px; background: {color};" }
+                                span { style: "{CHART_LABEL_STYLE}", "{name}" }
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Chart area: one column per time point, stacked bars per series
+            div {
+                style: "display: flex; align-items: flex-end; gap: 1px; height: {height}px; padding: 0 4px;",
+                for idx in 0..num_points {
+                    div {
+                        style: "flex: 1; display: flex; gap: 1px; align-items: flex-end; min-width: 2px; height: 100%;",
+                        for s in &series {
+                            {
+                                let val = s.points.get(idx).map_or(0.0, |p| p.value);
+                                let pct = ((val / max_val) * 100.0) as u32;
+                                let color = s.color.clone();
+                                let label_text = s.points.get(idx).map(|p| p.label.clone()).unwrap_or_default();
+                                rsx! {
+                                    div {
+                                        style: "flex: 1; height: {pct}%; background: {color}; border-radius: 1px 1px 0 0; min-height: 1px;",
+                                        title: "{label_text}: {val:.1}",
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            // X-axis labels (first and last)
+            if num_points >= 2 {
+                {
+                    let first_label = series.iter()
+                        .find_map(|s| s.points.first().map(|p| p.label.clone()))
+                        .unwrap_or_default();
+                    let last_label = series.iter()
+                        .find_map(|s| s.points.last().map(|p| p.label.clone()))
+                        .unwrap_or_default();
+                    rsx! {
+                        div {
+                            style: "display: flex; justify-content: space-between; padding: 0 4px;",
+                            span { style: "{CHART_LABEL_STYLE}", "{first_label}" }
+                            span { style: "{CHART_LABEL_STYLE}", "{last_label}" }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+// -- Percentile bar chart -----------------------------------------------------
+
+/// Percentile distribution entry for a single tool.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct PercentileEntry {
+    pub label: String,
+    pub min_ms: u64,
+    pub p25_ms: u64,
+    pub p50_ms: u64,
+    pub p75_ms: u64,
+    pub p95_ms: u64,
+    pub max_ms: u64,
+}
+
+/// Horizontal bars showing percentile ranges (min..p25..p50..p75..p95..max).
+#[component]
+pub(crate) fn PercentileBarChart(entries: Vec<PercentileEntry>) -> Element {
+    if entries.is_empty() {
+        return rsx! {
+            div {
+                style: "color: #706c66; font-size: 13px; padding: 16px 0;",
+                "No data"
+            }
+        };
+    }
+
+    let global_max = entries
+        .iter()
+        .map(|e| e.max_ms)
+        .max()
+        .unwrap_or(1)
+        .max(1);
+
+    rsx! {
+        div {
+            style: "display: flex; flex-direction: column; gap: 6px;",
+
+            // Legend
+            div {
+                style: "display: flex; gap: 12px; font-size: 11px; color: #706c66;",
+                span { "min-p25" }
+                span { style: "color: #5b6af0;", "p25-p50" }
+                span { style: "color: #22c55e;", "p50-p75" }
+                span { style: "color: #eab308;", "p75-p95" }
+                span { style: "color: #ef4444;", "p95-max" }
+            }
+
+            for entry in &entries {
+                {
+                    let label = entry.label.clone();
+                    #[expect(clippy::cast_precision_loss, reason = "display-only percentage")]
+                    let pct = |v: u64| -> u32 {
+                        ((v as f64 / global_max as f64) * 100.0) as u32
+                    };
+                    let w_min_p25 = pct(entry.p25_ms.saturating_sub(entry.min_ms));
+                    let w_p25_p50 = pct(entry.p50_ms.saturating_sub(entry.p25_ms));
+                    let w_p50_p75 = pct(entry.p75_ms.saturating_sub(entry.p50_ms));
+                    let w_p75_p95 = pct(entry.p95_ms.saturating_sub(entry.p75_ms));
+                    let w_p95_max = pct(entry.max_ms.saturating_sub(entry.p95_ms));
+                    let tip = format!(
+                        "{label}: min={}ms p25={}ms p50={}ms p75={}ms p95={}ms max={}ms",
+                        entry.min_ms, entry.p25_ms, entry.p50_ms, entry.p75_ms, entry.p95_ms, entry.max_ms
+                    );
+                    rsx! {
+                        div {
+                            style: "display: flex; align-items: center; gap: 8px;",
+                            div {
+                                style: "width: 120px; font-size: 12px; color: #a8a49e; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; flex-shrink: 0;",
+                                title: "{label}",
+                                "{label}"
+                            }
+                            div {
+                                style: "flex: 1; height: 16px; display: flex; border-radius: 3px; overflow: hidden;",
+                                title: "{tip}",
+                                div { style: "width: {w_min_p25}%; background: #3a3530; min-width: 1px;" }
+                                div { style: "width: {w_p25_p50}%; background: #5b6af0; min-width: 1px;" }
+                                div { style: "width: {w_p50_p75}%; background: #22c55e; min-width: 1px;" }
+                                div { style: "width: {w_p75_p95}%; background: #eab308; min-width: 1px;" }
+                                div { style: "width: {w_p95_max}%; background: #ef4444; min-width: 1px;" }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+// -- BarEntry + HorizontalBarChart --------------------------------------------
+
+/// A bar entry with optional color (defaults assigned by the chart).
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct BarEntry {
+    pub label: String,
+    pub value: u64,
+    pub color: Option<String>,
+}
+
+/// Horizontal bar chart that accepts `BarEntry` (optional color).
+///
+/// Converts to `ChartEntry` and delegates to `HorizBarChart`.
+#[component]
+pub(crate) fn HorizontalBarChart(
+    entries: Vec<BarEntry>,
+    max_value: Option<f64>,
+    on_click: Option<EventHandler<String>>,
+) -> Element {
+    let chart_entries: Vec<ChartEntry> = entries
+        .iter()
+        .enumerate()
+        .map(|(i, e)| ChartEntry {
+            label: e.label.clone(),
+            #[expect(clippy::cast_precision_loss, reason = "display-only")]
+            value: e.value as f64,
+            color: e
+                .color
+                .clone()
+                .unwrap_or_else(|| SERIES_COLORS[i % SERIES_COLORS.len()].to_string()),
+            sub_label: None,
+        })
+        .collect();
+
+    let effective_max = max_value.unwrap_or(0.0);
+
+    rsx! {
+        HorizBarChart {
+            entries: chart_entries,
+            max_value: effective_max,
+            show_value: true,
+            on_click,
+        }
+    }
+}
+
+// -- Stacked bar chart --------------------------------------------------------
+
+/// A stacked bar entry with success/failure segments.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct StackedBarEntry {
+    pub label: String,
+    pub success: u64,
+    pub failure: u64,
+}
+
+/// Stacked horizontal bar chart showing success (green) and failure (red) segments.
+#[component]
+pub(crate) fn StackedBarChart(
+    entries: Vec<StackedBarEntry>,
+    sort_by_failure: bool,
+    on_click: Option<EventHandler<String>>,
+) -> Element {
+    if entries.is_empty() {
+        return rsx! {
+            div {
+                style: "color: #706c66; font-size: 13px; padding: 16px 0;",
+                "No data"
+            }
+        };
+    }
+
+    let mut sorted = entries.clone();
+    if sort_by_failure {
+        sorted.sort_by(|a, b| b.failure.cmp(&a.failure));
+    }
+
+    let max_total = sorted
+        .iter()
+        .map(|e| e.success + e.failure)
+        .max()
+        .unwrap_or(1)
+        .max(1);
+
+    rsx! {
+        div {
+            style: "display: flex; flex-direction: column; gap: 6px;",
+
+            // Legend
+            div {
+                style: "display: flex; gap: 12px; align-items: center;",
+                div {
+                    style: "display: flex; align-items: center; gap: 4px;",
+                    div { style: "width: 10px; height: 10px; border-radius: 2px; background: #22c55e;" }
+                    span { style: "{CHART_LABEL_STYLE}", "Success" }
+                }
+                div {
+                    style: "display: flex; align-items: center; gap: 4px;",
+                    div { style: "width: 10px; height: 10px; border-radius: 2px; background: #ef4444;" }
+                    span { style: "{CHART_LABEL_STYLE}", "Failure" }
+                }
+            }
+
+            for (idx, entry) in sorted.iter().enumerate() {
+                {
+                    let total = entry.success + entry.failure;
+                    #[expect(clippy::cast_precision_loss, reason = "display-only percentage")]
+                    let total_pct = ((total as f64 / max_total as f64) * 100.0) as u32;
+                    #[expect(clippy::cast_precision_loss, reason = "display-only percentage")]
+                    let success_pct = if total > 0 { ((entry.success as f64 / total as f64) * 100.0) as u32 } else { 50 };
+                    let failure_pct = 100u32.saturating_sub(success_pct);
+                    let label = entry.label.clone();
+                    let id = entry.label.clone();
+                    rsx! {
+                        div {
+                            key: "{idx}",
+                            style: "display: flex; align-items: center; gap: 8px; cursor: pointer;",
+                            onclick: move |_| {
+                                if let Some(handler) = &on_click {
+                                    handler.call(id.clone());
+                                }
+                            },
+                            div {
+                                style: "width: 120px; font-size: 12px; color: #a8a49e; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; flex-shrink: 0;",
+                                title: "{label}",
+                                "{label}"
+                            }
+                            div {
+                                style: "flex: 1; height: 20px; background: #1a1816; border-radius: 3px; overflow: hidden;",
+                                div {
+                                    style: "height: 100%; width: {total_pct}%; display: flex; border-radius: 3px; overflow: hidden;",
+                                    div { style: "width: {success_pct}%; background: #22c55e; min-width: 1px;" }
+                                    if failure_pct > 0 {
+                                        div { style: "width: {failure_pct}%; background: #ef4444; min-width: 1px;" }
+                                    }
+                                }
+                            }
+                            div {
+                                style: "width: 72px; text-align: right; font-size: 12px; color: #706c66; font-family: 'IBM Plex Mono', monospace; flex-shrink: 0;",
+                                "{total}"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
 // -- Format helpers -----------------------------------------------------------
 
 /// Format a float value for chart labels (K/M suffix).

--- a/crates/theatron/desktop/src/views/meta/charts.rs
+++ b/crates/theatron/desktop/src/views/meta/charts.rs
@@ -99,33 +99,49 @@ pub(crate) fn LineChart(
             }
 
             if show_labels {
-                // NOTE: Show first and last labels only to avoid clutter.
-                if let Some((first, &(x, _))) = data.first().zip(points.first()) {
-                    rsx! {
-                        text {
-                            x: "{x:.1}",
-                            y: "{height - 4.0:.1}",
-                            fill: "#666",
-                            font_size: "10",
-                            text_anchor: "start",
-                            "{first.label}"
-                        }
-                    }
-                }
-                if data.len() > 1 {
-                    if let Some((last, &(x, _))) = data.last().zip(points.last()) {
-                        rsx! {
-                            text {
-                                x: "{x:.1}",
-                                y: "{height - 4.0:.1}",
-                                fill: "#666",
-                                font_size: "10",
-                                text_anchor: "end",
-                                "{last.label}"
-                            }
-                        }
-                    }
-                }
+                {label_elements(&data, &points, height)}
+            }
+        }
+    }
+}
+
+/// Build SVG text label elements for the first and last data points.
+///
+/// WHY: Extracted because Dioxus 0.7 rsx! macro cannot parse SVG `text`
+/// elements inside `if let Some(...)` conditional blocks -- the `text`
+/// identifier conflicts with the text-node parser. A standalone function
+/// with its own top-level rsx! avoids the ambiguity.
+fn label_elements(
+    data: &[crate::state::meta::DataPoint],
+    points: &[(f64, f64)],
+    height: f64,
+) -> Element {
+    let first_label = data.first().map(|p| p.label.clone());
+    let first_x = points.first().map(|&(x, _)| x);
+    let last_label = if data.len() > 1 { data.last().map(|p| p.label.clone()) } else { None };
+    let last_x = if data.len() > 1 { points.last().map(|&(x, _)| x) } else { None };
+
+    let y_pos = format!("{:.1}", height - 4.0);
+
+    rsx! {
+        if let (Some(label), Some(x)) = (first_label, first_x) {
+            text {
+                x: "{x:.1}",
+                y: "{y_pos}",
+                fill: "#666",
+                font_size: "10",
+                text_anchor: "start",
+                "{label}"
+            }
+        }
+        if let (Some(label), Some(x)) = (last_label, last_x) {
+            text {
+                x: "{x:.1}",
+                y: "{y_pos}",
+                fill: "#666",
+                font_size: "10",
+                text_anchor: "end",
+                "{label}"
             }
         }
     }

--- a/crates/theatron/desktop/src/views/metrics/mod.rs
+++ b/crates/theatron/desktop/src/views/metrics/mod.rs
@@ -4,7 +4,7 @@ mod agent_breakdown;
 mod agent_costs;
 mod costs;
 mod model_breakdown;
-mod tool_detail;
+pub(crate) mod tool_detail;
 mod tool_duration;
 mod tool_frequency;
 mod tool_results;


### PR DESCRIPTION
## Summary

- Make `SseStream` and `SseStream::new` pub in theatron-core so desktop can construct SSE streams cross-crate
- Make `tool_detail` module `pub(crate)` so `app.rs` can import `ToolDetailView` for the `/metrics/tools/:tool_name` route
- Add 9 missing chart types/components to `desktop/src/components/chart.rs`: `SERIES_COLORS`, `LinePoint`, `LineSeries`, `LineChart`, `PercentileEntry`, `PercentileBarChart`, `BarEntry`/`HorizontalBarChart`, `StackedBarEntry`/`StackedBarChart`
- Fix Dioxus 0.7 rsx! parse error in `meta/charts.rs` by extracting SVG `text` labels into standalone function (avoids `text` identifier ambiguity inside `if let Some` blocks)
- All 7 cascading E0282 type inference errors resolve automatically once imports are satisfied

Resolves all 14 compile errors. `cargo build -p theatron-desktop` succeeds clean.

## Test plan

- [x] `cargo check --manifest-path crates/theatron/desktop/Cargo.toml` -- 0 errors
- [x] `cargo build --manifest-path crates/theatron/desktop/Cargo.toml` -- succeeds
- [ ] Launch desktop and connect to live server (REQ-D2-14 through REQ-D2-19, integration testing)