### PR TITLE
fix(agora): circuit breaker for Signal polling (#2344)

### DIFF
--- a/crates/agora/src/semeion/connection.rs
+++ b/crates/agora/src/semeion/connection.rs
@@ -16,6 +16,12 @@ pub enum ConnectionState {
         /// Number of reconnection attempts made so far.
         attempt: u32,
     },
+    /// Circuit breaker tripped after too many consecutive failures.
+    /// Polling has stopped; only periodic health checks run.
+    Halted {
+        /// Total consecutive failures when the circuit breaker tripped.
+        total_failures: u32,
+    },
 }
 
 /// Outbound message queued during disconnection.

--- a/crates/agora/src/semeion/mod.rs
+++ b/crates/agora/src/semeion/mod.rs
@@ -29,6 +29,12 @@ use connection::{AccountState, ConnectionHealthReport, ConnectionState, reconnec
 const DEFAULT_POLL_INTERVAL: Duration = Duration::from_secs(2);
 const DEFAULT_BUFFER_CAPACITY: usize = 100;
 
+/// Consecutive poll failures before the circuit breaker trips and polling halts.
+const CIRCUIT_BREAKER_THRESHOLD: u32 = 20;
+
+/// Interval between health checks while the circuit breaker is open.
+const HALTED_HEALTH_CHECK_INTERVAL: Duration = Duration::from_secs(60);
+
 /// Parsed Signal message target.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
@@ -255,12 +261,24 @@ impl ChannelProvider for SignalProvider {
             // the HTTP error handler below buffers the message.
             {
                 let mut s = state_mutex.lock().await;
-                if s.state != ConnectionState::Connected {
-                    s.enqueue(send_params);
-                    return SendResult {
-                        sent: false,
-                        error: Some("connection unavailable, message buffered".to_owned()),
-                    };
+                match s.state {
+                    ConnectionState::Connected => {}
+                    ConnectionState::Reconnecting { .. } => {
+                        s.enqueue(send_params);
+                        return SendResult {
+                            sent: false,
+                            error: Some("connection unavailable, message buffered".to_owned()),
+                        };
+                    }
+                    ConnectionState::Halted { .. } => {
+                        s.enqueue(send_params);
+                        return SendResult {
+                            sent: false,
+                            error: Some(
+                                "circuit breaker open, message buffered".to_owned(),
+                            ),
+                        };
+                    }
                 }
             }
 
@@ -356,6 +374,33 @@ async fn poll_loop(
 ) {
     tracing::info!("polling started");
     loop {
+        // WHY: check for halted state first so we don't poll when the circuit
+        // breaker is open -- only run periodic health checks to detect recovery.
+        {
+            let s = state.lock().await;
+            if let ConnectionState::Halted { total_failures } = s.state {
+                drop(s);
+                tokio::select! {
+                    biased;
+                    () = cancel.cancelled() => {
+                        tracing::info!("cancellation received, stopping poll");
+                        return;
+                    }
+                    () = tokio::time::sleep(HALTED_HEALTH_CHECK_INTERVAL) => {}
+                }
+
+                if signal_client.health().await {
+                    let mut s = state.lock().await;
+                    tracing::info!(
+                        previous_failures = total_failures,
+                        "health check passed, resuming polling"
+                    );
+                    s.state = ConnectionState::Connected;
+                }
+                continue;
+            }
+        }
+
         tokio::select! {
             biased;
             () = cancel.cancelled() => {
@@ -419,8 +464,27 @@ async fn poll_loop(
                                 }
                                 ConnectionState::Reconnecting { attempt } => {
                                     let next = attempt.saturating_add(1);
+                                    if next >= CIRCUIT_BREAKER_THRESHOLD {
+                                        tracing::error!(
+                                            consecutive_failures = next,
+                                            threshold = CIRCUIT_BREAKER_THRESHOLD,
+                                            "circuit breaker tripped, halting Signal polling \
+                                             (will health-check every {}s)",
+                                            HALTED_HEALTH_CHECK_INTERVAL.as_secs()
+                                        );
+                                        s.state = ConnectionState::Halted {
+                                            total_failures: next,
+                                        };
+                                        // NOTE: no sleep here -- the halted branch at the
+                                        // top of the loop handles the health-check interval.
+                                        continue;
+                                    }
                                     s.state = ConnectionState::Reconnecting { attempt: next };
                                     next
+                                }
+                                ConnectionState::Halted { .. } => {
+                                    // SAFETY: unreachable -- halted state is handled at loop top.
+                                    continue;
                                 }
                             }
                         };


### PR DESCRIPTION
## Summary

- Add `ConnectionState::Halted` variant that trips after 20 consecutive poll failures
- When halted, log a single ERROR and switch to 60s health-check-only mode
- Resume normal polling automatically when a health check succeeds
- Buffer outbound messages during halted state with a distinct error message

Closes #2344.

## Test plan

- [ ] Verify `cargo check -p aletheia-agora` passes (done)
- [ ] Verify existing tests pass (`cargo nextest run -p aletheia-agora`)
- [ ] Manual: stop signal-cli daemon, observe WARN logs escalate to single ERROR at attempt 20
- [ ] Manual: restart signal-cli daemon, observe health check recovery and polling resume