### PR TITLE
fix(nous): align SessionId format between graphe and koina (#2349)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -137,7 +137,6 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
- "ulid",
 ]
 
 [[package]]

--- a/crates/diaporeia/Cargo.toml
+++ b/crates/diaporeia/Cargo.toml
@@ -26,9 +26,6 @@ axum = { workspace = true }
 tokio = { workspace = true }
 tokio-util = { workspace = true }
 
-# IDs
-ulid = { workspace = true }
-
 # Serialization
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/diaporeia/src/tools/mod.rs
+++ b/crates/diaporeia/src/tools/mod.rs
@@ -10,6 +10,8 @@ use rmcp::model::CallToolResult;
 use rmcp::{tool, tool_router};
 use snafu::{OptionExt as _, ResultExt as _};
 
+use aletheia_koina::id::SessionId;
+
 use crate::error::{NousNotFoundSnafu, PipelineSnafu, SerializationSnafu, SessionStoreSnafu};
 use crate::rate_limit::Tier;
 use crate::server::DiaporeiaServer;
@@ -28,7 +30,9 @@ impl DiaporeiaServer {
     ) -> Result<CallToolResult, rmcp::ErrorData> {
         self.rate_limiter.check(Tier::Expensive)?;
         let session_key = params.session_key.as_deref().unwrap_or("main");
-        let session_id = ulid::Ulid::new().to_string();
+        // WHY: SessionId (UUID v4) is the canonical format. ULID here caused
+        // 'invalid SessionId' when nous parsed the stored ID back (#2349).
+        let session_id = SessionId::new().to_string();
 
         let store = self.state.session_store.lock().await;
         let session = store

--- a/crates/graphe/src/types.rs
+++ b/crates/graphe/src/types.rs
@@ -149,7 +149,7 @@ pub struct SessionOrigin {
 /// A session record persisted in the store.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Session {
-    /// Unique session identifier (ULID).
+    /// Unique session identifier (UUID v4).
     pub id: String,
     /// Owning agent identifier.
     pub nous_id: String,


### PR DESCRIPTION
## Summary

- **Root cause**: `diaporeia::session_create` generated session IDs as ULIDs (26-char Crockford Base32), but `koina::SessionId::parse` expects UUID v4 hyphenated format (36-char `xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`). When `nous` read the stored session back from `graphe` and parsed it into a `SessionId`, the format mismatch caused `invalid SessionId` errors on every turn.
- **Fix**: Replace `ulid::Ulid::new()` with `SessionId::new()` in diaporeia, remove the now-unused `ulid` dependency, and fix a stale doc comment in `graphe::types::Session` that said "ULID" when UUID is the canonical format.

## Changed files

| File | Change |
|------|--------|
| `crates/diaporeia/src/tools/mod.rs` | Use `SessionId::new()` instead of `ulid::Ulid::new()` |
| `crates/diaporeia/Cargo.toml` | Remove `ulid` dependency |
| `crates/graphe/src/types.rs` | Fix doc comment: "ULID" -> "UUID v4" |

## Test plan

- [x] `cargo check --workspace` passes
- [ ] Run `cargo nextest run -p aletheia-diaporeia` for unit tests
- [ ] Run `cargo nextest run -p aletheia-nous` to verify turn execution parses session IDs correctly

Closes #2349.