### PR TITLE
fix(pylon): graceful SIGHUP config reload (#2350)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,7 +33,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia"
-version = "0.13.20"
+version = "0.13.23"
 dependencies = [
  "aletheia-agora",
  "aletheia-dianoia",
@@ -83,7 +83,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-agora"
-version = "0.13.20"
+version = "0.13.23"
 dependencies = [
  "aletheia-koina",
  "aletheia-taxis",
@@ -104,7 +104,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-dianoia"
-version = "0.13.20"
+version = "0.13.23"
 dependencies = [
  "aletheia-koina",
  "jiff",
@@ -119,7 +119,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-diaporeia"
-version = "0.13.20"
+version = "0.13.23"
 dependencies = [
  "aletheia-koina",
  "aletheia-mneme",
@@ -142,7 +142,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-dokimion"
-version = "0.13.20"
+version = "0.13.23"
 dependencies = [
  "aletheia-koina",
  "owo-colors",
@@ -161,7 +161,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-eidos"
-version = "0.13.20"
+version = "0.13.23"
 dependencies = [
  "jiff",
  "serde",
@@ -171,7 +171,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-episteme"
-version = "0.13.20"
+version = "0.13.23"
 dependencies = [
  "aletheia-eidos",
  "aletheia-graphe",
@@ -201,7 +201,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-graphe"
-version = "0.13.20"
+version = "0.13.23"
 dependencies = [
  "aletheia-eidos",
  "aletheia-koina",
@@ -222,7 +222,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-hermeneus"
-version = "0.13.20"
+version = "0.13.23"
 dependencies = [
  "aletheia-koina",
  "jiff",
@@ -245,7 +245,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-integration-tests"
-version = "0.13.20"
+version = "0.13.23"
 dependencies = [
  "aletheia-dokimion",
  "aletheia-hermeneus",
@@ -271,7 +271,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-koina"
-version = "0.13.20"
+version = "0.13.23"
 dependencies = [
  "compact_str",
  "jiff",
@@ -291,7 +291,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-krites"
-version = "0.13.20"
+version = "0.13.23"
 dependencies = [
  "aho-corasick",
  "aletheia-eidos",
@@ -335,7 +335,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-melete"
-version = "0.13.20"
+version = "0.13.23"
 dependencies = [
  "aletheia-hermeneus",
  "fd-lock",
@@ -353,7 +353,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-mneme"
-version = "0.13.20"
+version = "0.13.23"
 dependencies = [
  "aletheia-eidos",
  "aletheia-episteme",
@@ -368,7 +368,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-nous"
-version = "0.13.20"
+version = "0.13.23"
 dependencies = [
  "aletheia-dianoia",
  "aletheia-hermeneus",
@@ -397,7 +397,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-oikonomos"
-version = "0.13.20"
+version = "0.13.23"
 dependencies = [
  "aletheia-koina",
  "axum 0.8.8",
@@ -422,7 +422,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-organon"
-version = "0.13.20"
+version = "0.13.23"
 dependencies = [
  "aletheia-hermeneus",
  "aletheia-koina",
@@ -449,7 +449,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-pylon"
-version = "0.13.20"
+version = "0.13.23"
 dependencies = [
  "aletheia-hermeneus",
  "aletheia-koina",
@@ -483,7 +483,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-symbolon"
-version = "0.13.20"
+version = "0.13.23"
 dependencies = [
  "aletheia-koina",
  "argon2",
@@ -510,7 +510,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-taxis"
-version = "0.13.20"
+version = "0.13.23"
 dependencies = [
  "aletheia-koina",
  "base64 0.22.1",
@@ -528,7 +528,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-thesauros"
-version = "0.13.20"
+version = "0.13.23"
 dependencies = [
  "aletheia-koina",
  "aletheia-organon",
@@ -6041,7 +6041,7 @@ dependencies = [
 
 [[package]]
 name = "theatron-core"
-version = "0.13.20"
+version = "0.13.23"
 dependencies = [
  "aletheia-koina",
  "bytes",
@@ -6060,7 +6060,7 @@ dependencies = [
 
 [[package]]
 name = "theatron-tui"
-version = "0.13.20"
+version = "0.13.23"
 dependencies = [
  "aletheia-koina",
  "arboard",

--- a/crates/aletheia/src/commands/server/mod.rs
+++ b/crates/aletheia/src/commands/server/mod.rs
@@ -134,6 +134,12 @@ pub(crate) async fn run(args: Args) -> Result<()> {
 
     info!(addr = %bind_addr, "pylon listening");
 
+    // WHY: Without a SIGHUP handler, the signal hits the default Unix
+    // disposition (terminate), crashing the server instead of reloading (#2350).
+    #[cfg(unix)]
+    let sighup_handle =
+        aletheia_pylon::server::spawn_sighup_handler(Arc::clone(&runtime.state));
+
     // Axum graceful shutdown: wait for OS signal, then cancel root token so
     // all subsystems observe shutdown simultaneously.
     let token_for_signal = runtime.shutdown_token.clone();
@@ -149,6 +155,7 @@ pub(crate) async fn run(args: Args) -> Result<()> {
     // Drain ordering:
     // 1. HTTP server has stopped accepting new requests (axum graceful_shutdown).
     // 2. Root token is cancelled: daemon tasks observe it and exit their loops.
+    // 2a. Drain SIGHUP handler (observes shutdown token).
     // 3. Wait for system daemon to finish in-flight maintenance work.
     // 4. Drain nous actors with a timeout, flushing fjall WAL and other state.
     // 5. Drop AppState (session store, registries).
@@ -161,6 +168,17 @@ pub(crate) async fn run(args: Args) -> Result<()> {
             .and_then(|v| v.parse::<u64>().ok())
             .unwrap_or(10),
     );
+
+    // Drain SIGHUP handler before other subsystems.
+    #[cfg(unix)]
+    {
+        if tokio::time::timeout(shutdown_timeout, sighup_handle)
+            .await
+            .is_err()
+        {
+            warn!("sighup handler did not exit within drain timeout");
+        }
+    }
 
     // Await system daemon handles
     for handle in runtime.daemon_handles.drain(..) {


### PR DESCRIPTION
## Summary

- Wire `pylon::server::spawn_sighup_handler` into the binary's server startup so SIGHUP triggers config hot-reload instead of crashing the process
- Drain the handler during graceful shutdown with the same timeout as other subsystems

## Root cause

The `spawn_sighup_handler` function existed in `crates/pylon/src/server.rs` (already `pub`) but was only called from `pylon::server::run()`, which the binary never uses. The binary builds its own startup sequence in `crates/aletheia/src/commands/server/mod.rs` and only handled SIGTERM/Ctrl+C via `shutdown_signal()`. SIGHUP hit the default Unix signal disposition: terminate.

## Test plan

- [ ] `cargo check -p aletheia-pylon -p aletheia` passes
- [ ] Start server, send `kill -HUP $PID`, verify server stays alive and logs `received SIGHUP, reloading config`
- [ ] Edit config, send SIGHUP, verify changed values are applied (e.g. `noneRole`)
- [ ] Edit config with invalid value, send SIGHUP, verify error log and server continues with old config
- [ ] SIGTERM / Ctrl+C still triggers graceful shutdown (SIGHUP handler drains within timeout)

Closes #2350.