### PR TITLE
fix(pylon): auth mode none grants full access (#2351)

### DIFF
--- a/crates/integration-tests/tests/cross_crate_pipeline.rs
+++ b/crates/integration-tests/tests/cross_crate_pipeline.rs
@@ -275,7 +275,7 @@ impl TestHarness {
             jwt_manager: Arc::clone(&jwt_manager),
             start_time: Instant::now(),
             auth_mode: "token".to_owned(),
-            none_role: "readonly".to_owned(),
+            none_role: "admin".to_owned(),
             config: Arc::new(tokio::sync::RwLock::new(default_config)),
             config_tx,
             idempotency_cache: Arc::new(aletheia_pylon::idempotency::IdempotencyCache::new()),

--- a/crates/integration-tests/tests/end_to_end.rs
+++ b/crates/integration-tests/tests/end_to_end.rs
@@ -189,7 +189,7 @@ impl TestHarness {
             jwt_manager: Arc::clone(&jwt_manager),
             start_time: Instant::now(),
             auth_mode: "token".to_owned(),
-            none_role: "readonly".to_owned(),
+            none_role: "admin".to_owned(),
             config: Arc::new(tokio::sync::RwLock::new(default_config)),
             config_tx,
             idempotency_cache: Arc::new(aletheia_pylon::idempotency::IdempotencyCache::new()),

--- a/crates/integration-tests/tests/eval_harness.rs
+++ b/crates/integration-tests/tests/eval_harness.rs
@@ -108,7 +108,7 @@ async fn start_test_server() -> (String, String, tempfile::TempDir) {
         jwt_manager,
         start_time: Instant::now(),
         auth_mode: "token".to_owned(),
-        none_role: "readonly".to_owned(),
+        none_role: "admin".to_owned(),
         config: Arc::new(tokio::sync::RwLock::new(default_config)),
         config_tx,
         idempotency_cache: Arc::new(aletheia_pylon::idempotency::IdempotencyCache::new()),

--- a/crates/pylon/src/tests/auth.rs
+++ b/crates/pylon/src/tests/auth.rs
@@ -131,7 +131,7 @@ async fn app_auth_disabled() -> (axum::Router, tempfile::TempDir) {
     let (config_tx, _config_rx) = tokio::sync::watch::channel(default_config);
     let state = Arc::new(AppState {
         auth_mode: "none".to_owned(),
-        none_role: "readonly".to_owned(),
+        none_role: "admin".to_owned(),
         session_store: Arc::clone(&state.session_store),
         nous_manager: Arc::clone(&state.nous_manager),
         provider_registry: Arc::clone(&state.provider_registry),

--- a/crates/pylon/src/tests/helpers.rs
+++ b/crates/pylon/src/tests/helpers.rs
@@ -123,7 +123,7 @@ pub(super) async fn test_state_with_provider(
         jwt_manager,
         start_time: Instant::now(),
         auth_mode: "token".to_owned(),
-        none_role: "readonly".to_owned(),
+        none_role: "admin".to_owned(),
         config: Arc::new(tokio::sync::RwLock::new(default_config)),
         config_tx,
         idempotency_cache: Arc::new(crate::idempotency::IdempotencyCache::new()),

--- a/crates/taxis/src/config/mod.rs
+++ b/crates/taxis/src/config/mod.rs
@@ -484,7 +484,7 @@ pub struct GatewayAuthConfig {
     /// Auth mode: `"token"` (bearer token), `"none"` (disabled), `"jwt"` (explicit JWT).
     pub mode: String,
     /// Role assigned to anonymous requests when auth mode is `"none"`.
-    /// Valid values: `"readonly"`, `"operator"`. Defaults to `"readonly"`.
+    /// Valid values: `"readonly"`, `"agent"`, `"operator"`, `"admin"`. Defaults to `"admin"`.
     pub none_role: String,
     /// JWT signing key. If `None`, falls back to `ALETHEIA_JWT_SECRET` env var.
     /// Startup fails when auth mode requires JWT and this is still the default placeholder.
@@ -497,7 +497,7 @@ impl Default for GatewayAuthConfig {
     fn default() -> Self {
         Self {
             mode: "token".to_owned(),
-            none_role: "readonly".to_owned(),
+            none_role: "admin".to_owned(),
             signing_key: None,
         }
     }


### PR DESCRIPTION
## Summary

- Changed `GatewayAuthConfig.none_role` default from `"readonly"` to `"admin"` so that `auth.mode = "none"` grants full API access instead of blocking all mutations
- Updated doc comment to list all valid role values
- Updated all test harnesses to match the new default

## Test plan

- [x] `cargo check -p aletheia-pylon` passes
- [x] All 15 auth tests pass (`cargo test -p aletheia-pylon -- tests::auth`)
- [ ] Manual: set `auth.mode = "none"`, verify chat/memory/config mutations succeed

Closes #2351.