### PR TITLE
feat(koina): unify retry/backoff into shared koina::retry module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,7 +33,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia"
-version = "0.13.20"
+version = "0.13.23"
 dependencies = [
  "aletheia-agora",
  "aletheia-dianoia",
@@ -83,7 +83,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-agora"
-version = "0.13.20"
+version = "0.13.23"
 dependencies = [
  "aletheia-koina",
  "aletheia-taxis",
@@ -104,7 +104,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-dianoia"
-version = "0.13.20"
+version = "0.13.23"
 dependencies = [
  "aletheia-koina",
  "jiff",
@@ -119,7 +119,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-diaporeia"
-version = "0.13.20"
+version = "0.13.23"
 dependencies = [
  "aletheia-koina",
  "aletheia-mneme",
@@ -142,7 +142,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-dokimion"
-version = "0.13.20"
+version = "0.13.23"
 dependencies = [
  "aletheia-koina",
  "owo-colors",
@@ -161,7 +161,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-eidos"
-version = "0.13.20"
+version = "0.13.23"
 dependencies = [
  "jiff",
  "serde",
@@ -171,7 +171,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-episteme"
-version = "0.13.20"
+version = "0.13.23"
 dependencies = [
  "aletheia-eidos",
  "aletheia-graphe",
@@ -201,7 +201,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-graphe"
-version = "0.13.20"
+version = "0.13.23"
 dependencies = [
  "aletheia-eidos",
  "aletheia-koina",
@@ -222,7 +222,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-hermeneus"
-version = "0.13.20"
+version = "0.13.23"
 dependencies = [
  "aletheia-koina",
  "jiff",
@@ -245,7 +245,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-integration-tests"
-version = "0.13.20"
+version = "0.13.23"
 dependencies = [
  "aletheia-dokimion",
  "aletheia-hermeneus",
@@ -271,10 +271,11 @@ dependencies = [
 
 [[package]]
 name = "aletheia-koina"
-version = "0.13.20"
+version = "0.13.23"
 dependencies = [
  "compact_str",
  "jiff",
+ "rand 0.9.2",
  "regex",
  "rustix 1.1.4",
  "serde",
@@ -291,7 +292,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-krites"
-version = "0.13.20"
+version = "0.13.23"
 dependencies = [
  "aho-corasick",
  "aletheia-eidos",
@@ -335,9 +336,10 @@ dependencies = [
 
 [[package]]
 name = "aletheia-melete"
-version = "0.13.20"
+version = "0.13.23"
 dependencies = [
  "aletheia-hermeneus",
+ "aletheia-koina",
  "fd-lock",
  "futures",
  "jiff",
@@ -353,7 +355,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-mneme"
-version = "0.13.20"
+version = "0.13.23"
 dependencies = [
  "aletheia-eidos",
  "aletheia-episteme",
@@ -368,7 +370,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-nous"
-version = "0.13.20"
+version = "0.13.23"
 dependencies = [
  "aletheia-dianoia",
  "aletheia-hermeneus",
@@ -397,7 +399,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-oikonomos"
-version = "0.13.20"
+version = "0.13.23"
 dependencies = [
  "aletheia-koina",
  "axum 0.8.8",
@@ -422,7 +424,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-organon"
-version = "0.13.20"
+version = "0.13.23"
 dependencies = [
  "aletheia-hermeneus",
  "aletheia-koina",
@@ -449,7 +451,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-pylon"
-version = "0.13.20"
+version = "0.13.23"
 dependencies = [
  "aletheia-hermeneus",
  "aletheia-koina",
@@ -483,7 +485,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-symbolon"
-version = "0.13.20"
+version = "0.13.23"
 dependencies = [
  "aletheia-koina",
  "argon2",
@@ -510,7 +512,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-taxis"
-version = "0.13.20"
+version = "0.13.23"
 dependencies = [
  "aletheia-koina",
  "base64 0.22.1",
@@ -528,7 +530,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-thesauros"
-version = "0.13.20"
+version = "0.13.23"
 dependencies = [
  "aletheia-koina",
  "aletheia-organon",
@@ -6041,7 +6043,7 @@ dependencies = [
 
 [[package]]
 name = "theatron-core"
-version = "0.13.20"
+version = "0.13.23"
 dependencies = [
  "aletheia-koina",
  "bytes",
@@ -6060,7 +6062,7 @@ dependencies = [
 
 [[package]]
 name = "theatron-tui"
-version = "0.13.20"
+version = "0.13.23"
 dependencies = [
  "aletheia-koina",
  "arboard",

--- a/crates/agora/src/registry.rs
+++ b/crates/agora/src/registry.rs
@@ -1,5 +1,3 @@
-
-
 //! Channel registry: the single source of truth for available channels.
 
 use std::sync::Arc;

--- a/crates/agora/src/semeion/client.rs
+++ b/crates/agora/src/semeion/client.rs
@@ -1,5 +1,3 @@
-
-
 //! JSON-RPC client for the signal-cli HTTP daemon.
 
 use std::time::Duration;
@@ -125,40 +123,21 @@ impl SignalClient {
     #[instrument(skip(self, params))]
     #[must_use]
     pub async fn send_message(&self, params: &SendParams) -> Result<Option<serde_json::Value>> {
+        use aletheia_koina::retry::{BackoffStrategy, RetryConfig};
+
         let rpc_params = params.to_rpc_value();
-        let backoffs = [500u64, 1000];
-        let mut last_err = None;
-
-        for attempt in 0..=backoffs.len() {
-            match self.rpc("send", &rpc_params).await {
-                Ok(result) => return Ok(result),
-                Err(e) => {
-                    if matches!(e, super::error::Error::Rpc { .. }) {
-                        return Err(e);
-                    }
-                    last_err = Some(e);
-                    if attempt < backoffs.len() {
-                        #[expect(
-                            clippy::indexing_slicing,
-                            reason = "attempt < backoffs.len() is checked by the if-guard"
-                        )]
-                        let delay = backoffs[attempt];
-                        tracing::warn!(
-                            attempt = attempt + 1,
-                            backoff_ms = delay,
-                            "signal send attempt failed, retrying"
-                        );
-                        tokio::time::sleep(Duration::from_millis(delay)).await;
-                    }
-                }
-            }
-        }
-
-        #[expect(
-            clippy::expect_used,
-            reason = "loop range 0..=backoffs.len() always executes at least one iteration, so last_err is always Some here"
-        )]
-        Err(last_err.expect("at least one attempt was made"))
+        let config = RetryConfig {
+            max_retries: 2,
+            strategy: BackoffStrategy::Fixed {
+                delays: vec![Duration::from_millis(500), Duration::from_millis(1000)],
+            },
+        };
+        config
+            .retry_async(
+                || self.rpc("send", &rpc_params),
+                |e| !matches!(e, super::error::Error::Rpc { .. }),
+            )
+            .await
     }
 
     /// Health check: hits the signal-cli check endpoint.

--- a/crates/daemon/src/state.rs
+++ b/crates/daemon/src/state.rs
@@ -1,5 +1,3 @@
-
-
 //! SQLite-backed persistence for daemon task execution state.
 //!
 //! Survives process restarts so tasks resume their schedules rather than

--- a/crates/daemon/src/watchdog.rs
+++ b/crates/daemon/src/watchdog.rs
@@ -406,17 +406,23 @@ impl Watchdog {
 
 /// Compute exponential backoff delay for watchdog restarts.
 ///
-/// Formula: `min(base * 2^(attempt-1), cap)`
+/// Delegates to [`aletheia_koina::retry::BackoffStrategy::Exponential`] with
+/// base=2s, factor=2, cap=300s.
+///
 /// - attempt 1: 2s
 /// - attempt 2: 4s
 /// - attempt 3: 8s
 /// - attempt 4: 16s
 /// - attempt 5+: capped at 300s (5 min)
 pub(crate) fn watchdog_backoff(attempt: u32) -> Duration {
-    let exponent = attempt.saturating_sub(1);
-    let multiplier = 1u64.checked_shl(exponent).unwrap_or(u64::MAX);
-    let delay = BACKOFF_BASE.saturating_mul(u32::try_from(multiplier).unwrap_or(u32::MAX));
-    std::cmp::min(delay, BACKOFF_CAP)
+    use aletheia_koina::retry::BackoffStrategy;
+    let strategy = BackoffStrategy::Exponential {
+        base: BACKOFF_BASE,
+        factor: 2,
+        max_delay: BACKOFF_CAP,
+    };
+    // WHY: call site passes 1-indexed attempt; delay_for_attempt is 0-indexed
+    strategy.delay_for_attempt(attempt.saturating_sub(1))
 }
 
 #[cfg(test)]

--- a/crates/dianoia/src/project.rs
+++ b/crates/dianoia/src/project.rs
@@ -1,5 +1,3 @@
-
-
 //! Project types and lifecycle management.
 
 use serde::{Deserialize, Serialize};

--- a/crates/dianoia/src/state.rs
+++ b/crates/dianoia/src/state.rs
@@ -1,5 +1,3 @@
-
-
 //! Project lifecycle state machine.
 
 use serde::{Deserialize, Serialize};

--- a/crates/dianoia/src/workspace.rs
+++ b/crates/dianoia/src/workspace.rs
@@ -1,5 +1,3 @@
-
-
 //! On-disk workspace persistence for projects.
 
 use std::path::{Path, PathBuf};

--- a/crates/graphe/src/store/mod.rs
+++ b/crates/graphe/src/store/mod.rs
@@ -261,8 +261,12 @@ impl SessionStore {
     /// # Errors
     /// Returns an error if the checkpoint fails for a reason other than `SQLITE_BUSY`.
     pub fn checkpoint_wal(&self) -> Result<()> {
+        use aletheia_koina::retry::BackoffStrategy;
+
         const MAX_RETRIES: u32 = 3;
-        const RETRY_DELAY: std::time::Duration = std::time::Duration::from_millis(100);
+        let backoff = BackoffStrategy::Constant {
+            delay: std::time::Duration::from_millis(100),
+        };
 
         for attempt in 1..=MAX_RETRIES {
             match self.conn.execute_batch("PRAGMA wal_checkpoint(TRUNCATE);") {
@@ -276,7 +280,7 @@ impl SessionStore {
                         max_retries = MAX_RETRIES,
                         "WAL checkpoint returned SQLITE_BUSY, retrying"
                     );
-                    std::thread::sleep(RETRY_DELAY);
+                    std::thread::sleep(backoff.delay_for_attempt(attempt.saturating_sub(1)));
                 }
                 Err(ref e) if is_busy_error(e) => {
                     warn!(

--- a/crates/hermeneus/src/anthropic/pricing.rs
+++ b/crates/hermeneus/src/anthropic/pricing.rs
@@ -3,10 +3,10 @@
 use std::collections::HashMap;
 use std::time::Duration;
 
-use rand::Rng as _;
+use aletheia_koina::retry::BackoffStrategy;
 
 use crate::error;
-use crate::models::{BACKOFF_BASE_MS, BACKOFF_FACTOR, BACKOFF_MAX_MS};
+use crate::models::{BACKOFF_BASE_MS, BACKOFF_MAX_MS};
 use crate::provider::ModelPricing;
 
 /// Derive the model family name by stripping the last dash-separated segment.
@@ -125,19 +125,12 @@ pub(crate) fn backoff_delay(attempt: u32, last_error: Option<&error::Error>) -> 
         return Duration::from_millis(*retry_after_ms);
     }
 
-    // WHY: cap exponent at 30 to prevent u64 overflow (2^31 * 1000 > u64::MAX)
-    let exponent = attempt.saturating_sub(1).min(30);
-    let base = BACKOFF_BASE_MS.saturating_mul(BACKOFF_FACTOR.saturating_pow(exponent));
-    let capped = base.min(BACKOFF_MAX_MS);
-
-    // WHY: ±25% random jitter: prevents thundering herd under concurrent load
-    let jitter_range = capped / 4;
-    let delay = if jitter_range > 0 {
-        let offset = rand::rng().random_range(0..jitter_range * 2);
-        capped - jitter_range + offset
-    } else {
-        capped
+    let strategy = BackoffStrategy::ExponentialJitter {
+        base: Duration::from_millis(BACKOFF_BASE_MS),
+        factor: 2,
+        max_delay: Duration::from_millis(BACKOFF_MAX_MS),
     };
-
-    Duration::from_millis(delay.max(100))
+    // WHY: call site passes 1-indexed attempt; delay_for_attempt is 0-indexed
+    let delay = strategy.delay_for_attempt(attempt.saturating_sub(1));
+    delay.max(Duration::from_millis(100))
 }

--- a/crates/koina/Cargo.toml
+++ b/crates/koina/Cargo.toml
@@ -26,9 +26,11 @@ snafu = { workspace = true }
 zeroize = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
-tokio = { workspace = true, features = ["sync"] }
+rand = { workspace = true }
+tokio = { workspace = true, features = ["sync", "time"] }
 ulid = { workspace = true }
 uuid = { workspace = true }
 
 [dev-dependencies]
 static_assertions = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt", "test-util"] }

--- a/crates/koina/src/lib.rs
+++ b/crates/koina/src/lib.rs
@@ -29,6 +29,8 @@ pub mod output_buffer;
 pub mod redact;
 /// Tracing layer that redacts sensitive field values before output.
 pub mod redacting_layer;
+/// Configurable retry strategies and backoff computation ([`retry::BackoffStrategy`], [`retry::RetryConfig`]).
+pub mod retry;
 /// Secret string newtype that prevents accidental leakage of sensitive values.
 pub mod secret;
 /// Trait abstractions for filesystem, clock, and environment operations.

--- a/crates/koina/src/retry.rs
+++ b/crates/koina/src/retry.rs
@@ -1,0 +1,565 @@
+//! Configurable retry and backoff strategies.
+//!
+//! Provides [`BackoffStrategy`] for computing delay durations between retry
+//! attempts and [`RetryConfig`] for executing async operations with automatic
+//! retries. Replaces per-crate retry implementations with a shared vocabulary.
+
+use std::fmt;
+use std::future::Future;
+use std::time::Duration;
+
+use rand::Rng;
+
+/// Backoff strategy for computing retry delays between attempts.
+///
+/// Attempts are 0-indexed: `delay_for_attempt(0)` returns the delay before
+/// the first retry, `delay_for_attempt(1)` before the second, and so on.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub enum BackoffStrategy {
+    /// Constant delay between every retry attempt.
+    Constant {
+        /// Delay applied before each retry.
+        delay: Duration,
+    },
+    /// Fixed sequence of delays, used in order per attempt.
+    ///
+    /// If the attempt index exceeds the sequence length, the last delay is
+    /// reused. An empty sequence yields zero delay.
+    Fixed {
+        /// Ordered delays for successive retry attempts.
+        delays: Vec<Duration>,
+    },
+    /// Exponential backoff: `base * factor^attempt`, capped at `max_delay`.
+    Exponential {
+        /// Initial delay for the first retry (attempt 0).
+        base: Duration,
+        /// Multiplier applied per attempt.
+        factor: u32,
+        /// Upper bound on the computed delay.
+        max_delay: Duration,
+    },
+    /// Exponential backoff with ±25% random jitter to prevent thundering herd.
+    ExponentialJitter {
+        /// Initial delay for the first retry (attempt 0).
+        base: Duration,
+        /// Multiplier applied per attempt.
+        factor: u32,
+        /// Upper bound on the computed delay (before jitter).
+        max_delay: Duration,
+    },
+}
+
+impl BackoffStrategy {
+    /// Compute the delay for a given 0-indexed retry attempt.
+    ///
+    /// # Errors
+    ///
+    /// This method is infallible. Overflow is handled via saturation and
+    /// capping against `max_delay`.
+    #[must_use]
+    pub fn delay_for_attempt(&self, attempt: u32) -> Duration {
+        match self {
+            Self::Constant { delay } => *delay,
+            Self::Fixed { delays } => {
+                let idx = usize::try_from(attempt).unwrap_or(usize::MAX);
+                let clamped = idx.min(delays.len().saturating_sub(1));
+                delays.get(clamped).copied().unwrap_or(Duration::ZERO)
+            }
+            Self::Exponential {
+                base,
+                factor,
+                max_delay,
+            } => compute_exponential(*base, *factor, *max_delay, attempt),
+            Self::ExponentialJitter {
+                base,
+                factor,
+                max_delay,
+            } => {
+                let base_delay = compute_exponential(*base, *factor, *max_delay, attempt);
+                apply_jitter(base_delay)
+            }
+        }
+    }
+}
+
+impl fmt::Display for BackoffStrategy {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Constant { delay } => write!(f, "constant({delay:?})"),
+            Self::Fixed { delays } => write!(f, "fixed({} steps)", delays.len()),
+            Self::Exponential {
+                base,
+                factor,
+                max_delay,
+            } => {
+                write!(f, "exponential({base:?}×{factor}, cap {max_delay:?})")
+            }
+            Self::ExponentialJitter {
+                base,
+                factor,
+                max_delay,
+            } => {
+                write!(
+                    f,
+                    "exponential+jitter({base:?}×{factor}, cap {max_delay:?})"
+                )
+            }
+        }
+    }
+}
+
+/// Configuration for retry behavior.
+///
+/// Pairs a [`BackoffStrategy`] with a maximum retry count. Use
+/// [`retry_async`][RetryConfig::retry_async] to execute an async operation
+/// with automatic retries.
+#[derive(Debug, Clone)]
+pub struct RetryConfig {
+    /// Maximum number of retry attempts (not counting the initial attempt).
+    pub max_retries: u32,
+    /// Strategy for computing delays between retries.
+    pub strategy: BackoffStrategy,
+}
+
+impl Default for RetryConfig {
+    fn default() -> Self {
+        Self {
+            max_retries: 3,
+            strategy: BackoffStrategy::Exponential {
+                base: Duration::from_secs(1),
+                factor: 2,
+                max_delay: Duration::from_secs(30),
+            },
+        }
+    }
+}
+
+impl fmt::Display for RetryConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "retry(max={}, {})", self.max_retries, self.strategy)
+    }
+}
+
+impl RetryConfig {
+    /// Run an async operation with retries according to this configuration.
+    ///
+    /// Calls `operation` up to `max_retries + 1` times (1 initial + retries).
+    /// After each failure, `should_retry` decides whether to continue. When it
+    /// returns `false` or all retries are exhausted, the last error is returned.
+    ///
+    /// Backoff delays are logged at `WARN` level with attempt metadata. Callers
+    /// should wrap calls in a tracing span for operation-specific context.
+    ///
+    /// # Errors
+    ///
+    /// Returns the last error from `operation` when retries are exhausted
+    /// or `should_retry` returns `false`.
+    pub async fn retry_async<F, Fut, T, E>(
+        &self,
+        mut operation: F,
+        should_retry: impl Fn(&E) -> bool,
+    ) -> Result<T, E>
+    where
+        F: FnMut() -> Fut,
+        Fut: Future<Output = Result<T, E>>,
+    {
+        let mut result = operation().await;
+
+        for attempt in 0..self.max_retries {
+            let err = match result {
+                Ok(val) => return Ok(val),
+                Err(e) => e,
+            };
+
+            if !should_retry(&err) {
+                return Err(err);
+            }
+
+            let delay = self.strategy.delay_for_attempt(attempt);
+            tracing::warn!(
+                attempt = attempt + 1,
+                max_retries = self.max_retries,
+                delay_ms = u64::try_from(delay.as_millis()).unwrap_or(u64::MAX),
+                "operation failed, retrying after backoff"
+            );
+            tokio::time::sleep(delay).await;
+
+            result = operation().await;
+        }
+
+        result
+    }
+}
+
+/// Compute exponential backoff steps for non-time-based backoff.
+///
+/// Returns `min(factor^attempt, cap)`. Useful when the backoff unit is not
+/// time (e.g., conversation turns to skip between retry attempts).
+///
+/// # Examples
+///
+/// ```
+/// use aletheia_koina::retry::exponential_steps;
+///
+/// assert_eq!(exponential_steps(0, 2, 8), 1); // 2^0 = 1
+/// assert_eq!(exponential_steps(1, 2, 8), 2); // 2^1 = 2
+/// assert_eq!(exponential_steps(2, 2, 8), 4); // 2^2 = 4
+/// assert_eq!(exponential_steps(3, 2, 8), 8); // 2^3 = 8
+/// assert_eq!(exponential_steps(4, 2, 8), 8); // capped
+/// ```
+#[must_use]
+pub fn exponential_steps(attempt: u32, factor: u32, cap: u32) -> u32 {
+    // WHY: cap exponent at 30 to prevent overflow in checked_pow
+    let exponent = attempt.min(30);
+    factor.checked_pow(exponent).unwrap_or(u32::MAX).min(cap)
+}
+
+// --- Internal helpers ---
+
+/// Compute exponential backoff delay: `base * factor^attempt`, capped at `max_delay`.
+fn compute_exponential(base: Duration, factor: u32, max_delay: Duration, attempt: u32) -> Duration {
+    // WHY: cap exponent at 30 to prevent u64 overflow (2^31 * base_ms > u64::MAX for large bases)
+    let exponent = attempt.min(30);
+    let multiplier = u64::from(factor).checked_pow(exponent).unwrap_or(u64::MAX);
+    let base_ms = u64::try_from(base.as_millis()).unwrap_or(u64::MAX);
+    let max_ms = u64::try_from(max_delay.as_millis()).unwrap_or(u64::MAX);
+    let delay_ms = base_ms.saturating_mul(multiplier);
+    Duration::from_millis(delay_ms.min(max_ms))
+}
+
+/// Apply ±25% random jitter to a delay duration.
+fn apply_jitter(delay: Duration) -> Duration {
+    let ms = u64::try_from(delay.as_millis()).unwrap_or(u64::MAX);
+    let jitter_range = ms / 4;
+    if jitter_range > 0 {
+        // WHY: ±25% jitter prevents thundering herd under concurrent load
+        let offset = rand::rng().random_range(0..jitter_range.saturating_mul(2));
+        Duration::from_millis(ms.saturating_sub(jitter_range).saturating_add(offset))
+    } else {
+        delay
+    }
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "test assertions")]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn constant_returns_same_delay_for_all_attempts() {
+        let strategy = BackoffStrategy::Constant {
+            delay: Duration::from_millis(100),
+        };
+        for attempt in 0..10 {
+            assert_eq!(
+                strategy.delay_for_attempt(attempt),
+                Duration::from_millis(100),
+                "constant strategy should return the same delay for attempt {attempt}"
+            );
+        }
+    }
+
+    #[test]
+    fn fixed_returns_delays_in_order() {
+        let strategy = BackoffStrategy::Fixed {
+            delays: vec![
+                Duration::from_millis(100),
+                Duration::from_millis(200),
+                Duration::from_millis(500),
+            ],
+        };
+        assert_eq!(
+            strategy.delay_for_attempt(0),
+            Duration::from_millis(100),
+            "attempt 0 should use first delay"
+        );
+        assert_eq!(
+            strategy.delay_for_attempt(1),
+            Duration::from_millis(200),
+            "attempt 1 should use second delay"
+        );
+        assert_eq!(
+            strategy.delay_for_attempt(2),
+            Duration::from_millis(500),
+            "attempt 2 should use third delay"
+        );
+    }
+
+    #[test]
+    fn fixed_repeats_last_delay_beyond_sequence() {
+        let strategy = BackoffStrategy::Fixed {
+            delays: vec![Duration::from_millis(100), Duration::from_millis(200)],
+        };
+        assert_eq!(
+            strategy.delay_for_attempt(5),
+            Duration::from_millis(200),
+            "attempts beyond sequence length should reuse last delay"
+        );
+    }
+
+    #[test]
+    fn fixed_empty_returns_zero() {
+        let strategy = BackoffStrategy::Fixed { delays: vec![] };
+        assert_eq!(
+            strategy.delay_for_attempt(0),
+            Duration::ZERO,
+            "empty Fixed sequence should return zero delay"
+        );
+    }
+
+    #[test]
+    fn exponential_computes_correct_delays() {
+        let strategy = BackoffStrategy::Exponential {
+            base: Duration::from_secs(2),
+            factor: 2,
+            max_delay: Duration::from_secs(300),
+        };
+        assert_eq!(
+            strategy.delay_for_attempt(0),
+            Duration::from_secs(2),
+            "attempt 0: 2s * 2^0 = 2s"
+        );
+        assert_eq!(
+            strategy.delay_for_attempt(1),
+            Duration::from_secs(4),
+            "attempt 1: 2s * 2^1 = 4s"
+        );
+        assert_eq!(
+            strategy.delay_for_attempt(2),
+            Duration::from_secs(8),
+            "attempt 2: 2s * 2^2 = 8s"
+        );
+        assert_eq!(
+            strategy.delay_for_attempt(3),
+            Duration::from_secs(16),
+            "attempt 3: 2s * 2^3 = 16s"
+        );
+    }
+
+    #[test]
+    fn exponential_caps_at_max_delay() {
+        let strategy = BackoffStrategy::Exponential {
+            base: Duration::from_secs(2),
+            factor: 2,
+            max_delay: Duration::from_secs(300),
+        };
+        assert_eq!(
+            strategy.delay_for_attempt(20),
+            Duration::from_secs(300),
+            "delay should be capped at max_delay"
+        );
+    }
+
+    #[test]
+    fn exponential_jitter_within_bounds() {
+        let strategy = BackoffStrategy::ExponentialJitter {
+            base: Duration::from_secs(1),
+            factor: 2,
+            max_delay: Duration::from_secs(30),
+        };
+        // NOTE: run multiple times to exercise jitter randomness
+        for _ in 0..20 {
+            let delay = strategy.delay_for_attempt(0);
+            // base=1s, ±25%: range is [750ms, 1250ms]
+            assert!(
+                delay >= Duration::from_millis(750) && delay <= Duration::from_millis(1250),
+                "jitter delay {delay:?} should be within ±25% of 1s"
+            );
+        }
+    }
+
+    #[test]
+    fn exponential_jitter_caps_before_jitter() {
+        let strategy = BackoffStrategy::ExponentialJitter {
+            base: Duration::from_secs(1),
+            factor: 2,
+            max_delay: Duration::from_secs(30),
+        };
+        for _ in 0..20 {
+            let delay = strategy.delay_for_attempt(10);
+            // base delay would be 1s * 2^10 = 1024s, capped at 30s
+            // jitter: ±25% of 30s = [22.5s, 37.5s]
+            assert!(
+                delay >= Duration::from_millis(22_500) && delay <= Duration::from_millis(37_500),
+                "jitter delay {delay:?} should be within ±25% of capped 30s"
+            );
+        }
+    }
+
+    #[test]
+    fn exponential_steps_basic() {
+        assert_eq!(exponential_steps(0, 2, 8), 1, "2^0 = 1");
+        assert_eq!(exponential_steps(1, 2, 8), 2, "2^1 = 2");
+        assert_eq!(exponential_steps(2, 2, 8), 4, "2^2 = 4");
+        assert_eq!(exponential_steps(3, 2, 8), 8, "2^3 = 8");
+    }
+
+    #[test]
+    fn exponential_steps_caps_at_max() {
+        assert_eq!(exponential_steps(4, 2, 8), 8, "2^4 = 16, capped at 8");
+        assert_eq!(exponential_steps(10, 2, 8), 8, "2^10 = 1024, capped at 8");
+    }
+
+    #[test]
+    fn exponential_steps_handles_large_attempt() {
+        assert_eq!(
+            exponential_steps(31, 2, 1000),
+            1000,
+            "attempt beyond exponent cap should still produce capped value"
+        );
+    }
+
+    #[test]
+    fn display_impls() {
+        let constant = BackoffStrategy::Constant {
+            delay: Duration::from_millis(100),
+        };
+        assert!(
+            constant.to_string().contains("constant"),
+            "Constant display should contain 'constant'"
+        );
+
+        let config = RetryConfig::default();
+        assert!(
+            config.to_string().contains("retry"),
+            "RetryConfig display should contain 'retry'"
+        );
+    }
+
+    #[test]
+    fn default_config_has_sensible_values() {
+        let config = RetryConfig::default();
+        assert_eq!(config.max_retries, 3, "default max_retries should be 3");
+        // NOTE: verify it's an Exponential variant
+        assert!(
+            matches!(config.strategy, BackoffStrategy::Exponential { .. }),
+            "default strategy should be Exponential"
+        );
+    }
+
+    #[tokio::test]
+    async fn retry_async_succeeds_on_first_attempt() {
+        let config = RetryConfig {
+            max_retries: 3,
+            strategy: BackoffStrategy::Constant {
+                delay: Duration::from_millis(1),
+            },
+        };
+        let result: Result<i32, &str> = config.retry_async(|| async { Ok(42) }, |_| true).await;
+        assert_eq!(result.unwrap(), 42, "should return success immediately");
+    }
+
+    #[tokio::test]
+    async fn retry_async_retries_on_transient_failure() {
+        tokio::time::pause();
+
+        let config = RetryConfig {
+            max_retries: 3,
+            strategy: BackoffStrategy::Constant {
+                delay: Duration::from_millis(10),
+            },
+        };
+        let attempt = std::sync::atomic::AtomicU32::new(0);
+        let result: Result<i32, &str> = config
+            .retry_async(
+                || {
+                    let n = attempt.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                    async move { if n < 2 { Err("transient") } else { Ok(42) } }
+                },
+                |_| true,
+            )
+            .await;
+        assert_eq!(result.unwrap(), 42, "should succeed after retries");
+        assert_eq!(
+            attempt.load(std::sync::atomic::Ordering::Relaxed),
+            3,
+            "should have attempted 3 times (1 initial + 2 retries)"
+        );
+    }
+
+    #[tokio::test]
+    async fn retry_async_stops_on_non_retryable_error() {
+        tokio::time::pause();
+
+        let config = RetryConfig {
+            max_retries: 5,
+            strategy: BackoffStrategy::Constant {
+                delay: Duration::from_millis(10),
+            },
+        };
+        let attempt = std::sync::atomic::AtomicU32::new(0);
+        let result: Result<i32, &str> = config
+            .retry_async(
+                || {
+                    attempt.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                    async { Err("fatal") }
+                },
+                |_e| false,
+            )
+            .await;
+        assert!(result.is_err(), "should return error");
+        assert_eq!(
+            attempt.load(std::sync::atomic::Ordering::Relaxed),
+            1,
+            "should not retry non-retryable errors"
+        );
+    }
+
+    #[tokio::test]
+    async fn retry_async_exhausts_retries() {
+        tokio::time::pause();
+
+        let config = RetryConfig {
+            max_retries: 2,
+            strategy: BackoffStrategy::Constant {
+                delay: Duration::from_millis(10),
+            },
+        };
+        let attempt = std::sync::atomic::AtomicU32::new(0);
+        let result: Result<i32, &str> = config
+            .retry_async(
+                || {
+                    attempt.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                    async { Err("always fails") }
+                },
+                |_| true,
+            )
+            .await;
+        assert!(
+            result.is_err(),
+            "should return error after exhausting retries"
+        );
+        assert_eq!(
+            attempt.load(std::sync::atomic::Ordering::Relaxed),
+            3,
+            "should attempt 1 + max_retries times"
+        );
+    }
+
+    #[tokio::test]
+    async fn retry_async_with_zero_retries() {
+        let config = RetryConfig {
+            max_retries: 0,
+            strategy: BackoffStrategy::Constant {
+                delay: Duration::from_millis(10),
+            },
+        };
+        let attempt = std::sync::atomic::AtomicU32::new(0);
+        let result: Result<i32, &str> = config
+            .retry_async(
+                || {
+                    attempt.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                    async { Err("fail") }
+                },
+                |_| true,
+            )
+            .await;
+        assert!(result.is_err(), "should fail with zero retries");
+        assert_eq!(
+            attempt.load(std::sync::atomic::Ordering::Relaxed),
+            1,
+            "should attempt exactly once with zero retries"
+        );
+    }
+}

--- a/crates/melete/Cargo.toml
+++ b/crates/melete/Cargo.toml
@@ -16,6 +16,7 @@ test-full = []
 
 [dependencies]
 aletheia-hermeneus = { path = "../hermeneus" }
+aletheia-koina = { path = "../koina" }
 fd-lock = { workspace = true }
 futures = { workspace = true }
 prometheus = { workspace = true }

--- a/crates/melete/src/distill.rs
+++ b/crates/melete/src/distill.rs
@@ -34,8 +34,11 @@ impl RetryState {
     fn record_failure(&mut self) {
         self.consecutive_failures = self.consecutive_failures.saturating_add(1);
         // NOTE: exponential backoff: 1, 2, 4, 8 turns; capped at MAX_BACKOFF_TURNS
-        let shift = self.consecutive_failures.saturating_sub(1).min(3);
-        self.turns_to_skip = (1u32 << shift).min(MAX_BACKOFF_TURNS);
+        self.turns_to_skip = aletheia_koina::retry::exponential_steps(
+            self.consecutive_failures.saturating_sub(1),
+            2,
+            MAX_BACKOFF_TURNS,
+        );
     }
 
     fn record_success(&mut self) {


### PR DESCRIPTION
## Summary

- Create `koina::retry` module with configurable `BackoffStrategy` enum (Constant, Fixed, Exponential, ExponentialJitter) and `RetryConfig` with `retry_async` helper
- Migrate all five incompatible retry/backoff implementations to use the shared module:
  - **agora**: Fixed array `[500ms, 1000ms]` → `RetryConfig::retry_async` with `BackoffStrategy::Fixed`
  - **graphe**: Flat 100ms retry → `BackoffStrategy::Constant` delay computation
  - **daemon**: Exponential 2s–300s → `BackoffStrategy::Exponential` delay computation
  - **melete**: Bit-shift turn backoff → `exponential_steps()` helper
  - **hermeneus**: Rate-limit-aware jitter → `BackoffStrategy::ExponentialJitter` (rate-limit handling stays in hermeneus)
- Add `exponential_steps()` for non-time-based backoff (conversation turn counting)

Closes #2329

## Test plan

- [x] All 178 koina tests pass including 19 new retry tests (strategy computation, retry_async behavior, edge cases)
- [x] All existing daemon watchdog_backoff tests pass unchanged (same delay values)
- [x] All existing hermeneus backoff_delay tests pass (rate-limit and exponential growth)
- [x] All existing melete distill retry/backoff tests pass (turn-based backoff schedule)
- [x] Doc-test for `exponential_steps` passes
- [x] `cargo check --workspace` clean
- [x] `cargo fmt --all -- --check` clean

## Observations

- Pre-existing unfulfilled `#[expect(dead_code)]` lint expectations in koina (25), graphe (5), and krites (34) cause `clippy --all-targets -D warnings` to fail on main. Not related to this change.
- Pre-existing `double_must_use` clippy warnings in agora (5 functions) exist on main.
- Pre-existing integration test failures in `cross_crate_pipeline` (7 tests) exist on main.
- `BACKOFF_FACTOR` constant in `hermeneus/models.rs` is now unused but left in place to avoid removing a `pub` API item in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)