### PR TITLE
feat(aletheia): add desktop subcommand (#2359)

### DIFF
--- a/crates/aletheia/src/commands/desktop.rs
+++ b/crates/aletheia/src/commands/desktop.rs
@@ -1,0 +1,69 @@
+//! `aletheia desktop` subcommand — PATH-based discovery and exec of the desktop app.
+
+use std::process::Command;
+
+use clap::Args;
+
+const BINARY_NAME: &str = "theatron-desktop";
+
+#[derive(Debug, Clone, Args)]
+pub(crate) struct DesktopArgs {
+    /// Gateway URL
+    #[arg(short, long, env = "ALETHEIA_URL")]
+    pub url: Option<String>,
+    /// Bearer token for authentication
+    #[arg(short, long, env = "ALETHEIA_TOKEN")]
+    pub token: Option<String>,
+    /// Agent to focus on startup
+    #[arg(short, long)]
+    pub agent: Option<String>,
+    /// Session to open
+    #[arg(short, long)]
+    pub session: Option<String>,
+}
+
+/// Search PATH for `theatron-desktop` and exec it with forwarded flags.
+pub(crate) fn run(args: &DesktopArgs) -> anyhow::Result<()> {
+    let binary = find_in_path().ok_or_else(|| {
+        anyhow::anyhow!(
+            "`{BINARY_NAME}` not found in PATH\n\n\
+             Build and install it from the workspace:\n  \
+             cd crates/theatron/desktop && cargo build --release\n  \
+             cp target/release/{BINARY_NAME} ~/.cargo/bin/\n\n\
+             Or add its build directory to PATH."
+        )
+    })?;
+
+    let mut cmd = Command::new(&binary);
+
+    if let Some(ref url) = args.url {
+        cmd.args(["--url", url]);
+    }
+    if let Some(ref token) = args.token {
+        cmd.args(["--token", token]);
+    }
+    if let Some(ref agent) = args.agent {
+        cmd.args(["--agent", agent]);
+    }
+    if let Some(ref session) = args.session {
+        cmd.args(["--session", session]);
+    }
+
+    let status = cmd.status().map_err(|e| {
+        anyhow::anyhow!("failed to exec `{}`: {e}", binary.display())
+    })?;
+
+    if !status.success() {
+        std::process::exit(status.code().unwrap_or(1));
+    }
+
+    Ok(())
+}
+
+/// Search `$PATH` for the desktop binary.
+fn find_in_path() -> Option<std::path::PathBuf> {
+    let path_var = std::env::var_os("PATH")?;
+    std::env::split_paths(&path_var)
+        .map(|dir| dir.join(BINARY_NAME))
+        .find(|candidate| candidate.is_file())
+}

--- a/crates/aletheia/src/commands/mod.rs
+++ b/crates/aletheia/src/commands/mod.rs
@@ -6,6 +6,7 @@ pub(crate) mod backup;
 pub(crate) mod check_config;
 pub(crate) mod config;
 pub(crate) mod credential;
+pub(crate) mod desktop;
 pub(crate) mod daemon;
 pub(crate) mod eval;
 pub(crate) mod health;

--- a/crates/aletheia/src/main.rs
+++ b/crates/aletheia/src/main.rs
@@ -28,6 +28,7 @@ use commands::agent_io::{
 use commands::backup::BackupArgs;
 use commands::config;
 use commands::credential;
+use commands::desktop::DesktopArgs;
 use commands::eval::EvalArgs;
 use commands::health::HealthArgs;
 use commands::maintenance;
@@ -109,6 +110,8 @@ enum Command {
     SessionExport(SessionExportArgs),
     /// Launch the terminal dashboard
     Tui(TuiArgs),
+    /// Launch the desktop app (discovers theatron-desktop in PATH)
+    Desktop(DesktopArgs),
     /// Migrate memories from Qdrant into embedded `KnowledgeStore`
     MigrateMemory(MigrateMemoryArgs),
     /// Initialize a new instance
@@ -211,6 +214,7 @@ async fn dispatch_command(cmd: Command, instance_root: Option<&PathBuf>) -> Resu
             .map_err(anyhow::Error::from),
         #[cfg(not(feature = "tui"))]
         Command::Tui(_) => anyhow::bail!("TUI not available - rebuild with `--features tui`"),
+        Command::Desktop(a) => commands::desktop::run(&a),
         Command::Eval(a) => commands::eval::run(a).await.map_err(Into::into),
         Command::Export(a) => {
             commands::agent_io::export_agent(instance_root, &a).map_err(Into::into)


### PR DESCRIPTION
## Summary

- Adds `aletheia desktop` subcommand that discovers `theatron-desktop` in `$PATH` and execs it
- Forwards `--url`, `--token`, `--agent`, `--session` flags (matching `aletheia tui` interface)
- Prints actionable build/install instructions when the binary is not found

Implements Option 3 (PATH discovery) from #2359. Closes #2359.

## Test plan

- [ ] `aletheia desktop --help` shows expected flags
- [ ] `aletheia desktop` without `theatron-desktop` in PATH prints install instructions
- [ ] `aletheia desktop --url http://localhost:18789` with binary installed launches the app
- [ ] `cargo check -p aletheia` passes (verified locally)