### PR TITLE
fix(theatron-desktop): setup wizard UX + theme consistency (#2364, #2365)

### DIFF
--- a/crates/theatron/desktop/src/components/connection_indicator.rs
+++ b/crates/theatron/desktop/src/components/connection_indicator.rs
@@ -40,13 +40,13 @@ pub enum IndicatorColor {
 }
 
 impl IndicatorColor {
-    /// CSS-compatible color string for rendering.
+    /// CSS-compatible color string using theme tokens.
     #[must_use]
     pub(crate) fn css(self) -> &'static str {
         match self {
-            Self::Green => "#22c55e",
-            Self::Yellow => "#eab308",
-            Self::Red => "#ef4444",
+            Self::Green => "var(--status-success)",
+            Self::Yellow => "var(--status-warning)",
+            Self::Red => "var(--status-error)",
         }
     }
 }
@@ -134,8 +134,8 @@ mod tests {
 
     #[test]
     fn indicator_color_css() {
-        assert_eq!(IndicatorColor::Green.css(), "#22c55e");
-        assert_eq!(IndicatorColor::Yellow.css(), "#eab308");
-        assert_eq!(IndicatorColor::Red.css(), "#ef4444");
+        assert_eq!(IndicatorColor::Green.css(), "var(--status-success)");
+        assert_eq!(IndicatorColor::Yellow.css(), "var(--status-warning)");
+        assert_eq!(IndicatorColor::Red.css(), "var(--status-error)");
     }
 }

--- a/crates/theatron/desktop/src/components/diff_line.rs
+++ b/crates/theatron/desktop/src/components/diff_line.rs
@@ -25,7 +25,7 @@ const GUTTER_NUM_STYLE: &str = "\
     width: 4ch; \
     text-align: right; \
     padding: 0 4px; \
-    color: #555;\
+    color: var(--text-muted);\
 ";
 
 const INDICATOR_STYLE: &str = "\
@@ -72,9 +72,9 @@ fn indicator_char(change_type: ChangeType) -> &'static str {
 /// Indicator text color.
 fn indicator_color(change_type: ChangeType) -> &'static str {
     match change_type {
-        ChangeType::Context => "#555",
-        ChangeType::Add => "#22c55e",
-        ChangeType::Remove => "#ef4444",
+        ChangeType::Context => "var(--text-muted)",
+        ChangeType::Add => "var(--status-success)",
+        ChangeType::Remove => "var(--status-error)",
     }
 }
 

--- a/crates/theatron/desktop/src/components/distillation.rs
+++ b/crates/theatron/desktop/src/components/distillation.rs
@@ -14,20 +14,20 @@ const CONTAINER_STYLE: &str = "\
     align-items: center; \
     gap: 10px; \
     padding: 6px 16px; \
-    background: #1a1a2e; \
-    border-top: 1px solid #333;\
+    background: var(--bg-surface); \
+    border-top: 1px solid var(--border);\
 ";
 
 const LABEL_STYLE: &str = "\
     font-size: 12px; \
-    color: #888; \
+    color: var(--text-secondary); \
     min-width: 90px;\
 ";
 
 const TRACK_STYLE: &str = "\
     flex: 1; \
     height: 3px; \
-    background: #2a2a3a; \
+    background: var(--bg-surface-bright); \
     border-radius: 2px; \
     overflow: hidden;\
 ";
@@ -35,13 +35,13 @@ const TRACK_STYLE: &str = "\
 const BAR_STYLE: &str = "\
     height: 3px; \
     border-radius: 2px; \
-    background: #4a4aff;\
+    background: var(--accent);\
 ";
 
 const BAR_COMPLETE_STYLE: &str = "\
     height: 3px; \
     border-radius: 2px; \
-    background: #22c55e;\
+    background: var(--status-success);\
 ";
 
 /// Map a distillation stage name to a progress bar fill percentage.

--- a/crates/theatron/desktop/src/components/session_tabs.rs
+++ b/crates/theatron/desktop/src/components/session_tabs.rs
@@ -12,8 +12,8 @@ const TABS_BAR_STYLE: &str = "\
     align-items: center; \
     gap: 4px; \
     padding: 8px 16px 0; \
-    background: #0f0f1a; \
-    border-bottom: 1px solid #2a2a3a; \
+    background: var(--bg); \
+    border-bottom: 1px solid var(--border-separator); \
     overflow-x: auto;\
 ";
 
@@ -24,10 +24,10 @@ const TAB_STYLE: &str = "\
     padding: 6px 14px 7px; \
     border-radius: 6px 6px 0 0; \
     font-size: 13px; \
-    color: #888; \
+    color: var(--text-secondary); \
     cursor: pointer; \
-    background: #1a1a2e; \
-    border: 1px solid #333; \
+    background: var(--bg-surface); \
+    border: 1px solid var(--border); \
     border-bottom: none; \
     white-space: nowrap;\
 ";
@@ -39,16 +39,16 @@ const TAB_ACTIVE_STYLE: &str = "\
     padding: 6px 14px 7px; \
     border-radius: 6px 6px 0 0; \
     font-size: 13px; \
-    color: #ffffff; \
+    color: var(--text-primary); \
     cursor: pointer; \
-    background: #0f0f1a; \
-    border: 1px solid #4a4aff; \
-    border-bottom: 1px solid #0f0f1a; \
+    background: var(--bg); \
+    border: 1px solid var(--accent); \
+    border-bottom: 1px solid var(--bg); \
     white-space: nowrap;\
 ";
 
 const CLOSE_BTN_STYLE: &str = "\
-    color: #555; \
+    color: var(--text-muted); \
     font-size: 11px; \
     padding: 0 2px; \
     cursor: pointer; \
@@ -59,7 +59,7 @@ const UNREAD_BADGE_STYLE: &str = "\
     width: 7px; \
     height: 7px; \
     border-radius: 50%; \
-    background: #4a4aff; \
+    background: var(--accent); \
     flex-shrink: 0;\
 ";
 

--- a/crates/theatron/desktop/src/components/tool_approval.rs
+++ b/crates/theatron/desktop/src/components/tool_approval.rs
@@ -13,25 +13,25 @@ const APPROVAL_BASE_STYLE: &str = "\
 
 const TOOL_NAME_STYLE: &str = "\
     font-weight: 600; \
-    color: #c0c0e0; \
+    color: var(--text-primary); \
     font-size: 14px;\
 ";
 
 const REASON_STYLE: &str = "\
-    color: #aaa; \
+    color: var(--text-secondary); \
     margin-top: 4px; \
     font-size: 13px;\
 ";
 
 const INPUT_PREVIEW_STYLE: &str = "\
-    background: #0f0f1a; \
-    border: 1px solid #333; \
+    background: var(--code-bg); \
+    border: 1px solid var(--border); \
     border-radius: 4px; \
     padding: 6px 8px; \
     margin-top: 8px; \
-    font-family: 'JetBrains Mono', 'Fira Code', monospace; \
+    font-family: var(--font-mono); \
     font-size: 12px; \
-    color: #b0b0d0; \
+    color: var(--code-fg); \
     max-height: 120px; \
     overflow-y: auto; \
     white-space: pre-wrap;\
@@ -55,8 +55,8 @@ const BUTTON_ROW_STYLE: &str = "\
 ";
 
 const APPROVE_BTN_STYLE: &str = "\
-    background: #22c55e; \
-    color: #0f0f1a; \
+    background: var(--status-success); \
+    color: var(--code-bg); \
     border: none; \
     border-radius: 6px; \
     padding: 6px 16px; \
@@ -66,8 +66,8 @@ const APPROVE_BTN_STYLE: &str = "\
 ";
 
 const DENY_BTN_STYLE: &str = "\
-    background: #ef4444; \
-    color: white; \
+    background: var(--status-error); \
+    color: var(--text-inverse); \
     border: none; \
     border-radius: 6px; \
     padding: 6px 16px; \
@@ -77,7 +77,7 @@ const DENY_BTN_STYLE: &str = "\
 ";
 
 const RESOLVED_STYLE: &str = "\
-    color: #666; \
+    color: var(--text-muted); \
     font-style: italic; \
     padding: 8px; \
     font-size: 13px;\
@@ -139,10 +139,10 @@ pub(crate) fn ToolApproval(
 /// Build the container style with risk-level-appropriate border and background.
 fn approval_container_style(risk: RiskLevel) -> String {
     let (border_color, background) = match risk {
-        RiskLevel::Low => ("#2a4a2a", "#1a1a2e"),
-        RiskLevel::Medium => ("#8b6914", "#1e1a10"),
-        RiskLevel::High => ("#7a2020", "#1e0f0f"),
-        RiskLevel::Critical => ("#a02020", "#2a1010"),
+        RiskLevel::Low => ("var(--status-success)", "var(--status-success-bg)"),
+        RiskLevel::Medium => ("var(--status-warning)", "var(--status-warning-bg)"),
+        RiskLevel::High => ("var(--status-error)", "var(--status-error-bg)"),
+        RiskLevel::Critical => ("var(--aima)", "var(--aima-bg)"),
     };
     format!("{APPROVAL_BASE_STYLE} border: 2px solid {border_color}; background: {background};")
 }
@@ -150,10 +150,10 @@ fn approval_container_style(risk: RiskLevel) -> String {
 /// Build the risk badge style with risk-appropriate colors.
 fn risk_badge_style(risk: RiskLevel) -> String {
     let (bg, color) = match risk {
-        RiskLevel::Low => ("#1a3a1a", "#4ade80"),
-        RiskLevel::Medium => ("#3a2a0a", "#fbbf24"),
-        RiskLevel::High => ("#3a1010", "#f87171"),
-        RiskLevel::Critical => ("#5a1515", "#fca5a5"),
+        RiskLevel::Low => ("var(--status-success-bg)", "var(--status-success)"),
+        RiskLevel::Medium => ("var(--status-warning-bg)", "var(--status-warning)"),
+        RiskLevel::High => ("var(--status-error-bg)", "var(--status-error)"),
+        RiskLevel::Critical => ("var(--aima-bg)", "var(--aima)"),
     };
     format!("{RISK_BADGE_BASE} background: {bg}; color: {color};")
 }
@@ -183,8 +183,8 @@ mod tests {
         let critical = approval_container_style(RiskLevel::Critical);
         // WHY: critical risk gets a visibly red-tinted background.
         assert!(
-            critical.contains("#2a1010"),
-            "critical should have red-tinted background"
+            critical.contains("--aima-bg"),
+            "critical should use aima-bg token"
         );
     }
 }

--- a/crates/theatron/desktop/src/components/tool_panel.rs
+++ b/crates/theatron/desktop/src/components/tool_panel.rs
@@ -11,19 +11,19 @@ const PANEL_COLLAPSED_STYLE: &str = "\
     align-items: center; \
     gap: 8px; \
     padding: 6px 10px; \
-    background: #1a1a30; \
-    border: 1px solid #2a2a4a; \
+    background: var(--bg-surface); \
+    border: 1px solid var(--border); \
     border-radius: 6px; \
     cursor: pointer; \
     margin-top: 4px; \
     font-size: 13px; \
-    color: #aaa;\
+    color: var(--text-secondary);\
 ";
 
 const PANEL_EXPANDED_STYLE: &str = "\
     padding: 8px 10px; \
-    background: #1a1a30; \
-    border: 1px solid #2a2a4a; \
+    background: var(--bg-surface); \
+    border: 1px solid var(--border); \
     border-radius: 6px; \
     margin-top: 4px; \
     font-size: 13px;\
@@ -34,51 +34,51 @@ const PANEL_HEADER_STYLE: &str = "\
     align-items: center; \
     gap: 8px; \
     cursor: pointer; \
-    color: #aaa; \
+    color: var(--text-secondary); \
     margin-bottom: 8px;\
 ";
 
 const TOOL_NAME_STYLE: &str = "\
     font-weight: 600; \
-    color: #c0c0e0;\
+    color: var(--text-primary);\
 ";
 
 const DURATION_BADGE_STYLE: &str = "\
     font-size: 11px; \
     padding: 1px 6px; \
-    background: #2a2a4a; \
+    background: var(--border); \
     border-radius: 10px; \
-    color: #888;\
+    color: var(--text-secondary);\
 ";
 
 const CODE_BLOCK_STYLE: &str = "\
-    background: #0f0f1a; \
-    border: 1px solid #333; \
+    background: var(--code-bg); \
+    border: 1px solid var(--border); \
     border-radius: 4px; \
     padding: 8px; \
     margin-top: 6px; \
     overflow-x: auto; \
     white-space: pre-wrap; \
     word-wrap: break-word; \
-    font-family: 'JetBrains Mono', 'Fira Code', monospace; \
+    font-family: var(--font-mono); \
     font-size: 12px; \
-    color: #b0b0d0; \
+    color: var(--code-fg); \
     max-height: 300px; \
     overflow-y: auto;\
 ";
 
 const SECTION_LABEL_STYLE: &str = "\
     font-size: 11px; \
-    color: #666; \
+    color: var(--text-muted); \
     text-transform: uppercase; \
     letter-spacing: 0.5px; \
     margin-top: 8px;\
 ";
 
 const ERROR_DETAIL_STYLE: &str = "\
-    color: #ef4444; \
-    background: #1a0f0f; \
-    border: 1px solid #4a2020; \
+    color: var(--status-error); \
+    background: var(--status-error-bg); \
+    border: 1px solid var(--status-error); \
     border-radius: 4px; \
     padding: 8px; \
     margin-top: 6px; \

--- a/crates/theatron/desktop/src/state/settings.rs
+++ b/crates/theatron/desktop/src/state/settings.rs
@@ -111,10 +111,10 @@ impl ServerHealth {
 
     pub(crate) fn color(self) -> &'static str {
         match self {
-            Self::Unchecked => "#666",
-            Self::Healthy => "#4ade80",
-            Self::Degraded => "#facc15",
-            Self::Unreachable => "#f87171",
+            Self::Unchecked => "var(--text-muted)",
+            Self::Healthy => "var(--status-success)",
+            Self::Degraded => "var(--status-warning)",
+            Self::Unreachable => "var(--status-error)",
         }
     }
 }
@@ -309,8 +309,6 @@ impl KeybindingStore {
 pub(crate) enum WizardStep {
     #[default]
     Server,
-    Auth,
-    Discovery,
     Appearance,
     Ready,
 }
@@ -319,22 +317,18 @@ impl WizardStep {
     pub(crate) fn index(self) -> usize {
         match self {
             Self::Server => 0,
-            Self::Auth => 1,
-            Self::Discovery => 2,
-            Self::Appearance => 3,
-            Self::Ready => 4,
+            Self::Appearance => 1,
+            Self::Ready => 2,
         }
     }
 
     pub(crate) fn total() -> usize {
-        5
+        3
     }
 
     pub(crate) fn next(self) -> Option<Self> {
         match self {
-            Self::Server => Some(Self::Auth),
-            Self::Auth => Some(Self::Discovery),
-            Self::Discovery => Some(Self::Appearance),
+            Self::Server => Some(Self::Appearance),
             Self::Appearance => Some(Self::Ready),
             Self::Ready => None,
         }
@@ -343,9 +337,7 @@ impl WizardStep {
     pub(crate) fn prev(self) -> Option<Self> {
         match self {
             Self::Server => None,
-            Self::Auth => Some(Self::Server),
-            Self::Discovery => Some(Self::Auth),
-            Self::Appearance => Some(Self::Discovery),
+            Self::Appearance => Some(Self::Server),
             Self::Ready => Some(Self::Appearance),
         }
     }
@@ -353,8 +345,6 @@ impl WizardStep {
     pub(crate) fn label(self) -> &'static str {
         match self {
             Self::Server => "Server",
-            Self::Auth => "Auth",
-            Self::Discovery => "Discovery",
             Self::Appearance => "Appearance",
             Self::Ready => "Ready",
         }
@@ -365,10 +355,7 @@ impl WizardStep {
 #[derive(Debug, Clone, Default)]
 pub(crate) struct WizardData {
     pub(crate) server_url: String,
-    pub(crate) server_name: String,
     pub(crate) auth_token: String,
-    pub(crate) skip_auth: bool,
-    pub(crate) discovered_agents: Vec<String>,
     pub(crate) selected_theme: String,
     pub(crate) selected_density: UiDensity,
 }
@@ -664,7 +651,7 @@ mod tests {
 
     #[test]
     fn wizard_step_progression() {
-        assert_eq!(WizardStep::Server.next(), Some(WizardStep::Auth));
+        assert_eq!(WizardStep::Server.next(), Some(WizardStep::Appearance));
         assert_eq!(WizardStep::Server.prev(), None);
         assert_eq!(WizardStep::Ready.next(), None);
         assert_eq!(WizardStep::Ready.prev(), Some(WizardStep::Appearance));

--- a/crates/theatron/desktop/src/views/connect.rs
+++ b/crates/theatron/desktop/src/views/connect.rs
@@ -19,13 +19,13 @@ const CONTAINER_STYLE: &str = "\
     align-items: center; \
     justify-content: center; \
     height: 100vh; \
-    background: #0f0f1a; \
-    color: #e0e0e0; \
-    font-family: system-ui, -apple-system, sans-serif;\
+    background: var(--bg); \
+    color: var(--text-primary); \
+    font-family: var(--font-body, system-ui, -apple-system, sans-serif);\
 ";
 
 const CARD_STYLE: &str = "\
-    background: #1a1a2e; \
+    background: var(--bg-surface); \
     border-radius: 12px; \
     padding: 40px; \
     width: 400px; \
@@ -43,24 +43,24 @@ const TITLE_STYLE: &str = "\
 
 const LABEL_STYLE: &str = "\
     font-size: 14px; \
-    color: #aaa; \
+    color: var(--text-secondary); \
     margin-bottom: 4px;\
 ";
 
 const INPUT_STYLE: &str = "\
-    background: #0f0f1a; \
-    border: 1px solid #333; \
+    background: var(--bg); \
+    border: 1px solid var(--border); \
     border-radius: 6px; \
     padding: 10px 12px; \
-    color: #e0e0e0; \
+    color: var(--text-primary); \
     font-size: 14px; \
     width: 100%; \
     box-sizing: border-box;\
 ";
 
 const BUTTON_STYLE: &str = "\
-    background: #4a4aff; \
-    color: white; \
+    background: var(--accent); \
+    color: var(--text-inverse); \
     border: none; \
     border-radius: 6px; \
     padding: 12px; \
@@ -70,8 +70,8 @@ const BUTTON_STYLE: &str = "\
 ";
 
 const BUTTON_DISABLED_STYLE: &str = "\
-    background: #333; \
-    color: #666; \
+    background: var(--bg-surface-bright); \
+    color: var(--text-muted); \
     border: none; \
     border-radius: 6px; \
     padding: 12px; \
@@ -120,10 +120,10 @@ pub(crate) fn ConnectView(
     };
 
     let status_color = match &*connection_state.read() {
-        ConnectionState::Connected => "#4caf50",
-        ConnectionState::Failed { .. } => "#f44336",
-        ConnectionState::Reconnecting { .. } | ConnectionState::Connecting => "#ff9800",
-        ConnectionState::Disconnected => "#888",
+        ConnectionState::Connected => "var(--status-success)",
+        ConnectionState::Failed { .. } => "var(--status-error)",
+        ConnectionState::Reconnecting { .. } | ConnectionState::Connecting => "var(--status-warning)",
+        ConnectionState::Disconnected => "var(--text-muted)",
     };
 
     let on_connect = move |_| {

--- a/crates/theatron/desktop/src/views/settings/wizard.rs
+++ b/crates/theatron/desktop/src/views/settings/wizard.rs
@@ -1,6 +1,6 @@
 //! First-run setup wizard.
 //!
-//! Five-step flow: Server → Auth → Discovery → Appearance → Ready.
+//! Three-step flow: Server -> Appearance -> Ready.
 //! Writes settings to disk and dismisses itself on completion.
 
 use dioxus::prelude::*;
@@ -29,17 +29,17 @@ pub(crate) fn SetupWizard() -> Element {
     rsx! {
         div {
             style: "min-height: 100vh; display: flex; align-items: center; justify-content: center; \
-                    background: #0a0a14; padding: 24px;",
+                    background: var(--bg-surface-dim); padding: 24px;",
 
             div {
-                style: "background: #111122; border: 1px solid #333; border-radius: 12px; \
+                style: "background: var(--bg-surface); border: 1px solid var(--border); border-radius: 12px; \
                         width: 100%; max-width: 520px; padding: 32px;",
 
                 // Title
                 div {
                     style: "margin-bottom: 24px;",
-                    h1 { style: "font-size: 22px; margin: 0 0 6px; color: #e0e0e0;", "Welcome to Aletheia" }
-                    p { style: "font-size: 14px; color: #666; margin: 0;", "Let's get you set up in a few steps." }
+                    h1 { style: "font-size: 22px; margin: 0 0 6px; color: var(--text-primary);", "Welcome to Aletheia" }
+                    p { style: "font-size: 14px; color: var(--text-muted); margin: 0;", "Let's get you set up in a few steps." }
                 }
 
                 // Progress bar
@@ -52,27 +52,13 @@ pub(crate) fn SetupWizard() -> Element {
                         WizardStep::Server => rsx! {
                             StepServer {
                                 wizard_data,
-                                on_next: move |_| { step.set(WizardStep::Auth); }
-                            }
-                        },
-                        WizardStep::Auth => rsx! {
-                            StepAuth {
-                                wizard_data,
-                                on_back: move |_| { step.set(WizardStep::Server); },
-                                on_next: move |_| { step.set(WizardStep::Discovery); }
-                            }
-                        },
-                        WizardStep::Discovery => rsx! {
-                            StepDiscovery {
-                                wizard_data,
-                                on_back: move |_| { step.set(WizardStep::Auth); },
                                 on_next: move |_| { step.set(WizardStep::Appearance); }
                             }
                         },
                         WizardStep::Appearance => rsx! {
                             StepAppearance {
                                 wizard_data,
-                                on_back: move |_| { step.set(WizardStep::Discovery); },
+                                on_back: move |_| { step.set(WizardStep::Server); },
                                 on_next: move |_| { step.set(WizardStep::Ready); }
                             }
                         },
@@ -87,7 +73,7 @@ pub(crate) fn SetupWizard() -> Element {
                                     let server_id = {
                                         let mut store = server_store.write();
                                         let id = store.add(
-                                            data.server_name.clone(),
+                                            "My Aletheia".to_string(),
                                             data.server_url.clone(),
                                             token.clone(),
                                         );
@@ -141,7 +127,7 @@ fn WizardProgress(current: usize, total: usize) -> Element {
             for i in 0..total {
                 {
                     let filled = i <= current;
-                    let bg = if filled { "#5b6af0" } else { "#2a2a3a" };
+                    let bg = if filled { "var(--accent)" } else { "var(--bg-surface-bright)" };
                     let style = format!(
                         "flex: 1; height: 3px; background: {bg}; border-radius: 2px; transition: background 0.2s;"
                     );
@@ -164,35 +150,20 @@ fn StepServer(wizard_data: Signal<WizardData>, on_next: EventHandler<()>) -> Ele
     rsx! {
         div {
             style: "display: flex; flex-direction: column; gap: 16px;",
-            h2 { style: "font-size: 16px; color: #e0e0e0; margin: 0;", "Server Connection" }
-            p { style: "font-size: 13px; color: #888; margin: 0;",
+            h2 { style: "font-size: 16px; color: var(--text-primary); margin: 0;", "Server Connection" }
+            p { style: "font-size: 13px; color: var(--text-secondary); margin: 0;",
                 "Enter the URL of your Aletheia server instance."
             }
 
             div {
                 style: "display: flex; flex-direction: column; gap: 4px;",
                 label {
-                    style: "font-size: 11px; color: #666; text-transform: uppercase; letter-spacing: 0.5px;",
-                    "Server Name"
-                }
-                input {
-                    style: "background: #0d0d1a; border: 1px solid #444; border-radius: 6px; \
-                            padding: 8px 12px; color: #e0e0e0; font-size: 13px; width: 100%; box-sizing: border-box;",
-                    placeholder: "My Aletheia",
-                    value: "{wizard_data.read().server_name}",
-                    oninput: move |e| { wizard_data.write().server_name = e.value(); },
-                }
-            }
-
-            div {
-                style: "display: flex; flex-direction: column; gap: 4px;",
-                label {
-                    style: "font-size: 11px; color: #666; text-transform: uppercase; letter-spacing: 0.5px;",
+                    style: "font-size: 11px; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.5px;",
                     "Server URL"
                 }
                 input {
-                    style: "background: #0d0d1a; border: 1px solid #444; border-radius: 6px; \
-                            padding: 8px 12px; color: #e0e0e0; font-size: 13px; width: 100%; box-sizing: border-box;",
+                    style: "background: var(--bg-surface-dim); border: 1px solid var(--border); border-radius: 6px; \
+                            padding: 8px 12px; color: var(--text-primary); font-size: 13px; width: 100%; box-sizing: border-box;",
                     placeholder: "http://localhost:3000",
                     value: "{wizard_data.read().server_url}",
                     oninput: move |e| { wizard_data.write().server_url = e.value(); },
@@ -204,153 +175,10 @@ fn StepServer(wizard_data: Signal<WizardData>, on_next: EventHandler<()>) -> Ele
                 on_back: move |_| {},
                 on_next: move |_| {
                     let url = wizard_data.read().server_url.clone();
-                    let name = wizard_data.read().server_name.clone();
                     if !url.is_empty() {
-                        if name.is_empty() {
-                            wizard_data.write().server_name = "My Aletheia".to_string();
-                        }
                         on_next.call(());
                     }
                 },
-                next_label: "Next",
-            }
-        }
-    }
-}
-
-// --- Step: Auth ---
-
-#[component]
-fn StepAuth(
-    wizard_data: Signal<WizardData>,
-    on_back: EventHandler<()>,
-    on_next: EventHandler<()>,
-) -> Element {
-    rsx! {
-        div {
-            style: "display: flex; flex-direction: column; gap: 16px;",
-            h2 { style: "font-size: 16px; color: #e0e0e0; margin: 0;", "Authentication" }
-            p { style: "font-size: 13px; color: #888; margin: 0;",
-                "If your server requires an API token, enter it here."
-            }
-
-            div {
-                style: "display: flex; flex-direction: column; gap: 4px;",
-                label {
-                    style: "font-size: 11px; color: #666; text-transform: uppercase; letter-spacing: 0.5px;",
-                    "Auth Token (optional)"
-                }
-                input {
-                    r#type: "password",
-                    style: "background: #0d0d1a; border: 1px solid #444; border-radius: 6px; \
-                            padding: 8px 12px; color: #e0e0e0; font-size: 13px; width: 100%; box-sizing: border-box;",
-                    placeholder: "Leave blank if not required",
-                    value: "{wizard_data.read().auth_token}",
-                    oninput: move |e| { wizard_data.write().auth_token = e.value(); },
-                }
-            }
-
-            div {
-                style: "display: flex; align-items: center; gap: 8px; padding: 10px; \
-                        background: #161626; border-radius: 6px; border: 1px solid #2a2a3a;",
-                input {
-                    r#type: "checkbox",
-                    id: "skip_auth",
-                    checked: wizard_data.read().skip_auth,
-                    onchange: move |e| { wizard_data.write().skip_auth = e.checked(); },
-                }
-                label {
-                    r#for: "skip_auth",
-                    style: "font-size: 13px; color: #aaa; cursor: pointer;",
-                    "My server does not require authentication"
-                }
-            }
-
-            WizardNav {
-                can_back: true,
-                on_back: move |_| on_back.call(()),
-                on_next: move |_| on_next.call(()),
-                next_label: "Next",
-            }
-        }
-    }
-}
-
-// --- Step: Discovery ---
-
-#[component]
-fn StepDiscovery(
-    wizard_data: Signal<WizardData>,
-    on_back: EventHandler<()>,
-    on_next: EventHandler<()>,
-) -> Element {
-    let mut discovering = use_signal(|| false);
-    let mut discover_error: Signal<Option<String>> = use_signal(|| None);
-
-    rsx! {
-        div {
-            style: "display: flex; flex-direction: column; gap: 16px;",
-            h2 { style: "font-size: 16px; color: #e0e0e0; margin: 0;", "Agent Discovery" }
-            p { style: "font-size: 13px; color: #888; margin: 0;",
-                "Connect to your server to discover available agents."
-            }
-
-            // Discovered agents list
-            if !wizard_data.read().discovered_agents.is_empty() {
-                div {
-                    style: "background: #0d1a0d; border: 1px solid #1a3a1a; border-radius: 6px; padding: 12px;",
-                    div {
-                        style: "font-size: 11px; color: #4ade80; margin-bottom: 8px;",
-                        "{wizard_data.read().discovered_agents.len()} agent(s) found"
-                    }
-                    for agent in wizard_data.read().discovered_agents.iter() {
-                        div {
-                            style: "font-size: 13px; color: #a0e0a0; padding: 2px 0;",
-                            "• {agent}"
-                        }
-                    }
-                }
-            }
-
-            if let Some(ref err) = discover_error.read().clone() {
-                div {
-                    style: "background: #1a0d0d; border: 1px solid #4a1a1a; border-radius: 6px; \
-                            padding: 10px 12px; font-size: 12px; color: #f87171;",
-                    "{err}"
-                }
-            }
-
-            div {
-                style: "display: flex; gap: 8px;",
-                button {
-                    style: "padding: 7px 16px; background: #1a2a3a; border: 1px solid #5b6af0; \
-                            border-radius: 6px; color: #8899ff; font-size: 13px; cursor: pointer;",
-                    disabled: discovering(),
-                    onclick: move |_| {
-                        let url = wizard_data.read().server_url.clone();
-                        let token = wizard_data.read().auth_token.clone();
-                        discovering.set(true);
-                        discover_error.set(None);
-                        spawn(async move {
-                            match fetch_agents(&url, &token).await {
-                                Ok(agents) => {
-                                    wizard_data.write().discovered_agents = agents;
-                                }
-                                Err(e) => {
-                                    discover_error.set(Some(e));
-                                }
-                            }
-                            discovering.set(false);
-                        });
-                    },
-                    if discovering() { "Connecting…" } else { "Discover agents" }
-                }
-            }
-
-            WizardNav {
-                can_back: true,
-                on_back: move |_| on_back.call(()),
-                on_next: move |_| on_next.call(()),
                 next_label: "Next",
             }
         }
@@ -368,8 +196,8 @@ fn StepAppearance(
     rsx! {
         div {
             style: "display: flex; flex-direction: column; gap: 20px;",
-            h2 { style: "font-size: 16px; color: #e0e0e0; margin: 0;", "Appearance" }
-            p { style: "font-size: 13px; color: #888; margin: 0;",
+            h2 { style: "font-size: 16px; color: var(--text-primary); margin: 0;", "Appearance" }
+            p { style: "font-size: 13px; color: var(--text-secondary); margin: 0;",
                 "Choose your preferred theme and layout density."
             }
 
@@ -377,7 +205,7 @@ fn StepAppearance(
             div {
                 style: "display: flex; flex-direction: column; gap: 8px;",
                 div {
-                    style: "font-size: 11px; color: #666; text-transform: uppercase; letter-spacing: 0.5px;",
+                    style: "font-size: 11px; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.5px;",
                     "Theme"
                 }
                 div {
@@ -385,9 +213,9 @@ fn StepAppearance(
                     for (mode, slug) in [("Dark", "dark"), ("Light", "light"), ("System", "system")] {
                         {
                             let is_active = wizard_data.read().selected_theme == slug;
-                            let bg = if is_active { "#5b6af0" } else { "#2a2a4a" };
-                            let border = if is_active { "1px solid #5b6af0" } else { "1px solid #444" };
-                            let color = if is_active { "#fff" } else { "#aaa" };
+                            let bg = if is_active { "var(--accent)" } else { "var(--bg-surface-bright)" };
+                            let border = if is_active { "1px solid var(--accent)" } else { "1px solid var(--border)" };
+                            let color = if is_active { "var(--text-inverse)" } else { "var(--text-secondary)" };
                             let style = format!(
                                 "flex: 1; padding: 8px; background: {bg}; border: {border}; \
                                  border-radius: 6px; color: {color}; font-size: 13px; cursor: pointer;"
@@ -409,7 +237,7 @@ fn StepAppearance(
             div {
                 style: "display: flex; flex-direction: column; gap: 8px;",
                 div {
-                    style: "font-size: 11px; color: #666; text-transform: uppercase; letter-spacing: 0.5px;",
+                    style: "font-size: 11px; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.5px;",
                     "Density"
                 }
                 div {
@@ -417,9 +245,9 @@ fn StepAppearance(
                     for density in [UiDensity::Compact, UiDensity::Comfortable, UiDensity::Spacious] {
                         {
                             let is_active = wizard_data.read().selected_density == density;
-                            let bg = if is_active { "#5b6af0" } else { "#2a2a4a" };
-                            let border = if is_active { "1px solid #5b6af0" } else { "1px solid #444" };
-                            let color = if is_active { "#fff" } else { "#aaa" };
+                            let bg = if is_active { "var(--accent)" } else { "var(--bg-surface-bright)" };
+                            let border = if is_active { "1px solid var(--accent)" } else { "1px solid var(--border)" };
+                            let color = if is_active { "var(--text-inverse)" } else { "var(--text-secondary)" };
                             let style = format!(
                                 "flex: 1; padding: 8px; background: {bg}; border: {border}; \
                                  border-radius: 6px; color: {color}; font-size: 13px; cursor: pointer; text-align: center;"
@@ -441,7 +269,7 @@ fn StepAppearance(
             div {
                 style: "display: flex; flex-direction: column; gap: 8px;",
                 div {
-                    style: "font-size: 11px; color: #666; text-transform: uppercase; letter-spacing: 0.5px;",
+                    style: "font-size: 11px; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.5px;",
                     "Accent Color (preview)"
                 }
                 div {
@@ -451,7 +279,7 @@ fn StepAppearance(
                             let hex_owned = hex.to_string();
                             let style = format!(
                                 "width: 28px; height: 28px; border-radius: 50%; background: {hex_owned}; \
-                                 border: 2px solid #333; cursor: pointer; outline: none;"
+                                 border: 2px solid var(--border); cursor: pointer; outline: none;"
                             );
                             rsx! {
                                 button {
@@ -485,34 +313,24 @@ fn StepReady(wizard_data: Signal<WizardData>, on_finish: EventHandler<()>) -> El
             style: "display: flex; flex-direction: column; gap: 20px; align-items: center; text-align: center;",
             div {
                 style: "font-size: 48px;",
-                "✓"
+                "\u{2713}"
             }
-            h2 { style: "font-size: 18px; color: #e0e0e0; margin: 0;", "You're all set!" }
-            p { style: "font-size: 13px; color: #888; margin: 0;",
+            h2 { style: "font-size: 18px; color: var(--text-primary); margin: 0;", "You're all set!" }
+            p { style: "font-size: 13px; color: var(--text-secondary); margin: 0;",
                 "Aletheia will connect to {data.server_url}"
             }
 
             div {
-                style: "background: #161626; border: 1px solid #333; border-radius: 8px; \
+                style: "background: var(--bg-surface-dim); border: 1px solid var(--border); border-radius: 8px; \
                         padding: 14px 20px; width: 100%; text-align: left;",
-                SummaryRow { label: "Server", value: data.server_name.clone() }
+                SummaryRow { label: "Server", value: data.server_url.clone() }
                 SummaryRow { label: "Theme", value: data.selected_theme.clone() }
                 SummaryRow { label: "Density", value: data.selected_density.label().to_string() }
-                SummaryRow {
-                    label: "Auth",
-                    value: if data.auth_token.is_empty() { "None".to_string() } else { "Configured".to_string() }
-                }
-                if !data.discovered_agents.is_empty() {
-                    SummaryRow {
-                        label: "Agents",
-                        value: format!("{} discovered", data.discovered_agents.len()),
-                    }
-                }
             }
 
             button {
-                style: "padding: 10px 32px; background: #5b6af0; border: none; border-radius: 8px; \
-                        color: #fff; font-size: 15px; cursor: pointer; width: 100%;",
+                style: "padding: 10px 32px; background: var(--accent); border: none; border-radius: 8px; \
+                        color: var(--text-inverse); font-size: 15px; cursor: pointer; width: 100%;",
                 onclick: move |_| on_finish.call(()),
                 "Launch Aletheia"
             }
@@ -532,22 +350,22 @@ fn WizardNav(
     rsx! {
         div {
             style: "display: flex; justify-content: space-between; align-items: center; \
-                    padding-top: 16px; border-top: 1px solid #222; margin-top: 8px;",
+                    padding-top: 16px; border-top: 1px solid var(--border-separator); margin-top: 8px;",
             if can_back {
                 button {
-                    style: "padding: 7px 18px; background: none; border: 1px solid #444; \
-                            border-radius: 6px; color: #888; font-size: 13px; cursor: pointer;",
+                    style: "padding: 7px 18px; background: none; border: 1px solid var(--border); \
+                            border-radius: 6px; color: var(--text-secondary); font-size: 13px; cursor: pointer;",
                     onclick: move |_| on_back.call(()),
-                    "← Back"
+                    "\u{2190} Back"
                 }
             } else {
                 div {}
             }
             button {
-                style: "padding: 7px 22px; background: #5b6af0; border: none; \
-                        border-radius: 6px; color: #fff; font-size: 13px; cursor: pointer;",
+                style: "padding: 7px 22px; background: var(--accent); border: none; \
+                        border-radius: 6px; color: var(--text-inverse); font-size: 13px; cursor: pointer;",
                 onclick: move |_| on_next.call(()),
-                "{next_label} →"
+                "{next_label} \u{2192}"
             }
         }
     }
@@ -558,49 +376,9 @@ fn SummaryRow(label: &'static str, value: String) -> Element {
     rsx! {
         div {
             style: "display: flex; justify-content: space-between; padding: 5px 0; \
-                    border-bottom: 1px solid #1a1a2e; font-size: 13px;",
-            span { style: "color: #666;", "{label}" }
-            span { style: "color: #e0e0e0;", "{value}" }
+                    border-bottom: 1px solid var(--border-separator); font-size: 13px;",
+            span { style: "color: var(--text-muted);", "{label}" }
+            span { style: "color: var(--text-primary);", "{value}" }
         }
     }
-}
-
-// --- Async discovery ---
-
-async fn fetch_agents(base_url: &str, token: &str) -> Result<Vec<String>, String> {
-    use crate::services::connection::PylonClient;
-    use crate::state::connection::ConnectionConfig;
-
-    let config = ConnectionConfig {
-        server_url: base_url.to_string(),
-        auth_token: if token.is_empty() { None } else { Some(token.to_string()) },
-        auto_reconnect: false,
-    };
-    let client = PylonClient::new(&config).map_err(|e| e.to_string())?;
-    let url = format!("{}/api/v1/nous", client.base_url());
-
-    let resp = client
-        .raw_client()
-        .get(&url)
-        .send()
-        .await
-        .map_err(|e| format!("request failed: {e}"))?;
-
-    if !resp.status().is_success() {
-        return Err(format!("server returned {}", resp.status()));
-    }
-
-    let body: serde_json::Value = resp
-        .json()
-        .await
-        .map_err(|e| format!("failed to parse response: {e}"))?;
-
-    let agents: Vec<String> = body
-        .as_array()
-        .unwrap_or(&vec![])
-        .iter()
-        .filter_map(|v| v.get("name").and_then(|n| n.as_str()).map(str::to_string))
-        .collect();
-
-    Ok(agents)
 }


### PR DESCRIPTION
## Summary
- Simplify setup wizard from 5 steps to 3 (Server, Appearance, Ready) by removing Auth, Discovery steps and Server Name field — optional config belongs in Settings, not first-run setup
- Replace hardcoded hex colors with CSS custom property tokens (`var(--*)`) across 9 component/view files so all UI elements respond to dark/light theme switching
- Affected components: connect view, wizard, session tabs, tool panel, tool approval, distillation indicator, diff lines, connection indicator

Closes #2364. Closes #2365.

## Test plan
- [ ] Launch desktop app in first-run mode — wizard should show 3 steps (Server, Appearance, Ready)
- [ ] Toggle theme between Dark/Light/System in Settings — all components should follow the active theme
- [ ] Verify connect view, session tabs, tool panels, and diff views render correctly in both themes
- [ ] Run `cargo check -p theatron-desktop` — no new warnings from these changes