### PR TITLE
feat(eidos): add verification fact type for claim-source provenance

### DIFF
--- a/crates/eidos/src/knowledge.rs
+++ b/crates/eidos/src/knowledge.rs
@@ -363,6 +363,8 @@ pub enum FactType {
     Observation,
     /// Chiron self-audit result: short-lived (30 days).
     Audit,
+    /// Claim-source provenance check: ephemeral (7 days).
+    Verification,
 }
 
 impl FactType {
@@ -370,7 +372,7 @@ impl FactType {
     #[must_use]
     #[expect(
         clippy::match_same_arms,
-        reason = "Audit and Event share the same decay rate (30 days) but are semantically distinct fact types"
+        reason = "Audit/Event share 30-day decay, Task/Verification share 7-day decay, but are semantically distinct"
     )]
     pub fn base_stability_hours(self) -> f64 {
         match self {
@@ -382,6 +384,7 @@ impl FactType {
             Self::Task => 168.0,
             Self::Observation => 72.0,
             Self::Audit => 720.0,
+            Self::Verification => 168.0,
         }
     }
 
@@ -433,6 +436,7 @@ impl FactType {
             Self::Task => "task",
             Self::Observation => "observation",
             Self::Audit => "audit",
+            Self::Verification => "verification",
         }
     }
 
@@ -447,6 +451,7 @@ impl FactType {
             "event" => Self::Event,
             "task" => Self::Task,
             "audit" => Self::Audit,
+            "verification" => Self::Verification,
             // WHY: Unknown values fall back to Observation to keep the type system open.
             _ => Self::Observation,
         }
@@ -457,6 +462,117 @@ impl std::fmt::Display for FactType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str(self.as_str())
     }
+}
+
+/// How a verification claim was checked against ground truth.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum VerificationSource {
+    /// Shell command whose output is compared against the claim.
+    Command,
+    /// Database or API query returning structured data.
+    Query,
+    /// Arithmetic re-derivation (e.g. sum checks, percentage recalculation).
+    Arithmetic,
+    /// Cross-reference against an authoritative document or fact.
+    Reference,
+}
+
+impl VerificationSource {
+    /// Return the `snake_case` string representation.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Command => "command",
+            Self::Query => "query",
+            Self::Arithmetic => "arithmetic",
+            Self::Reference => "reference",
+        }
+    }
+
+    /// Parse from a string, returning `None` for unknown values.
+    #[must_use]
+    pub fn from_str_opt(s: &str) -> Option<Self> {
+        match s {
+            "command" => Some(Self::Command),
+            "query" => Some(Self::Query),
+            "arithmetic" => Some(Self::Arithmetic),
+            "reference" => Some(Self::Reference),
+            _ => None,
+        }
+    }
+}
+
+impl std::fmt::Display for VerificationSource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Outcome of a verification check.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum VerificationStatus {
+    /// Actual value matches expected within tolerance.
+    Pass,
+    /// Actual value diverges from expected beyond tolerance.
+    Fail,
+    /// Verification result is older than the staleness threshold.
+    Stale,
+}
+
+impl VerificationStatus {
+    /// Return the `snake_case` string representation.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Pass => "pass",
+            Self::Fail => "fail",
+            Self::Stale => "stale",
+        }
+    }
+
+    /// Parse from a string, returning `None` for unknown values.
+    #[must_use]
+    pub fn from_str_opt(s: &str) -> Option<Self> {
+        match s {
+            "pass" => Some(Self::Pass),
+            "fail" => Some(Self::Fail),
+            "stale" => Some(Self::Stale),
+            _ => None,
+        }
+    }
+}
+
+impl std::fmt::Display for VerificationStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Structured record of a claim-source provenance check.
+///
+/// Stored as JSON in the `content` field of a `Fact` with
+/// `fact_type = "verification"`. Captures what was claimed, how it was
+/// checked, and whether the check passed.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct VerificationRecord {
+    /// The assertion being verified (e.g. "build succeeded", "total is 383").
+    pub claim: String,
+    /// How the claim was checked against ground truth.
+    pub source: VerificationSource,
+    /// The value the claim asserts.
+    pub expected: serde_json::Value,
+    /// The value observed from the source.
+    pub actual: serde_json::Value,
+    /// Acceptable relative deviation before marking as `Fail` (0.0 = exact match).
+    pub tolerance: f64,
+    /// Outcome of the comparison.
+    pub status: VerificationStatus,
+    /// When the verification was performed.
+    pub verified_at: jiff::Timestamp,
 }
 
 /// Heuristic: content mentions a named relationship pattern (e.g. "works at", "reports to").

--- a/crates/eidos/src/knowledge_test.rs
+++ b/crates/eidos/src/knowledge_test.rs
@@ -378,6 +378,10 @@ fn default_stability_by_fact_type() {
         "observation stability should be 72 hours"
     );
     assert!(
+        (default_stability_hours("verification") - 168.0).abs() < f64::EPSILON,
+        "verification stability should be 168 hours"
+    );
+    assert!(
         (default_stability_hours("inference") - 72.0).abs() < f64::EPSILON,
         "inference should fall back to 72 hours"
     );
@@ -1947,4 +1951,186 @@ fn all_scopes_accept_valid_relative_path() {
             "validated scope should match input"
         );
     }
+}
+
+// ---------------------------------------------------------------------------
+// Verification types
+// ---------------------------------------------------------------------------
+
+#[test]
+fn verification_fact_type_roundtrip() {
+    let ft = FactType::Verification;
+    assert_eq!(ft.as_str(), "verification");
+    assert_eq!(FactType::from_str_lossy("verification"), ft);
+    assert_eq!(ft.to_string(), "verification");
+}
+
+#[test]
+fn verification_fact_type_serde_roundtrip() {
+    let ft = FactType::Verification;
+    let json = serde_json::to_string(&ft).expect("FactType serialization is infallible");
+    assert_eq!(
+        json, r#""verification""#,
+        "should serialize as snake_case string"
+    );
+    let back: FactType =
+        serde_json::from_str(&json).expect("FactType should deserialize from its own JSON");
+    assert_eq!(
+        ft, back,
+        "FactType::Verification should survive serde roundtrip"
+    );
+}
+
+#[test]
+fn verification_source_as_str_and_parse() {
+    for (variant, expected) in [
+        (VerificationSource::Command, "command"),
+        (VerificationSource::Query, "query"),
+        (VerificationSource::Arithmetic, "arithmetic"),
+        (VerificationSource::Reference, "reference"),
+    ] {
+        assert_eq!(variant.as_str(), expected, "{variant:?} as_str mismatch");
+        assert_eq!(
+            VerificationSource::from_str_opt(expected),
+            Some(variant),
+            "from_str_opt({expected}) should return {variant:?}"
+        );
+        assert_eq!(
+            variant.to_string(),
+            expected,
+            "{variant:?} Display mismatch"
+        );
+    }
+    assert_eq!(
+        VerificationSource::from_str_opt("bogus"),
+        None,
+        "unknown source should return None"
+    );
+}
+
+#[test]
+fn verification_source_serde_roundtrip() {
+    for src in [
+        VerificationSource::Command,
+        VerificationSource::Query,
+        VerificationSource::Arithmetic,
+        VerificationSource::Reference,
+    ] {
+        let json =
+            serde_json::to_string(&src).expect("VerificationSource serialization is infallible");
+        let back: VerificationSource = serde_json::from_str(&json)
+            .expect("VerificationSource should deserialize from its own JSON");
+        assert_eq!(
+            src, back,
+            "VerificationSource should survive serde roundtrip"
+        );
+    }
+}
+
+#[test]
+fn verification_status_as_str_and_parse() {
+    for (variant, expected) in [
+        (VerificationStatus::Pass, "pass"),
+        (VerificationStatus::Fail, "fail"),
+        (VerificationStatus::Stale, "stale"),
+    ] {
+        assert_eq!(variant.as_str(), expected, "{variant:?} as_str mismatch");
+        assert_eq!(
+            VerificationStatus::from_str_opt(expected),
+            Some(variant),
+            "from_str_opt({expected}) should return {variant:?}"
+        );
+        assert_eq!(
+            variant.to_string(),
+            expected,
+            "{variant:?} Display mismatch"
+        );
+    }
+    assert_eq!(
+        VerificationStatus::from_str_opt("unknown"),
+        None,
+        "unknown status should return None"
+    );
+}
+
+#[test]
+fn verification_status_serde_roundtrip() {
+    for status in [
+        VerificationStatus::Pass,
+        VerificationStatus::Fail,
+        VerificationStatus::Stale,
+    ] {
+        let json =
+            serde_json::to_string(&status).expect("VerificationStatus serialization is infallible");
+        let back: VerificationStatus = serde_json::from_str(&json)
+            .expect("VerificationStatus should deserialize from its own JSON");
+        assert_eq!(
+            status, back,
+            "VerificationStatus should survive serde roundtrip"
+        );
+    }
+}
+
+#[test]
+fn verification_record_serde_roundtrip() {
+    let record = VerificationRecord {
+        claim: "total line count is 383".to_owned(),
+        source: VerificationSource::Command,
+        expected: serde_json::json!(383),
+        actual: serde_json::json!(383),
+        tolerance: 0.0,
+        status: VerificationStatus::Pass,
+        verified_at: test_timestamp("2026-03-15T10:30:00Z"),
+    };
+    let json =
+        serde_json::to_string(&record).expect("VerificationRecord serialization is infallible");
+    let back: VerificationRecord = serde_json::from_str(&json)
+        .expect("VerificationRecord should deserialize from its own JSON");
+    assert_eq!(back.claim, record.claim, "claim should survive roundtrip");
+    assert_eq!(
+        back.source, record.source,
+        "source should survive roundtrip"
+    );
+    assert_eq!(
+        back.expected, record.expected,
+        "expected should survive roundtrip"
+    );
+    assert_eq!(
+        back.actual, record.actual,
+        "actual should survive roundtrip"
+    );
+    assert!(
+        (back.tolerance - record.tolerance).abs() < f64::EPSILON,
+        "tolerance should survive roundtrip"
+    );
+    assert_eq!(
+        back.status, record.status,
+        "status should survive roundtrip"
+    );
+    assert_eq!(
+        back.verified_at, record.verified_at,
+        "verified_at should survive roundtrip"
+    );
+}
+
+#[test]
+fn verification_record_fail_with_tolerance() {
+    let record = VerificationRecord {
+        claim: "build time is 120s".to_owned(),
+        source: VerificationSource::Arithmetic,
+        expected: serde_json::json!(120),
+        actual: serde_json::json!(135),
+        tolerance: 0.1,
+        status: VerificationStatus::Fail,
+        verified_at: test_timestamp("2026-03-15T11:00:00Z"),
+    };
+    let json = serde_json::to_string(&record).expect("serialization should succeed");
+    assert!(
+        json.contains(r#""status":"fail""#),
+        "JSON should contain fail status"
+    );
+    assert!(
+        json.contains(r#""tolerance":0.1"#),
+        "JSON should contain tolerance"
+    );
 }


### PR DESCRIPTION
## Summary

- Add `FactType::Verification` variant to the knowledge type system for standardized claim-source provenance checks
- Add supporting types: `VerificationSource` (command/query/arithmetic/reference), `VerificationStatus` (pass/fail/stale), `VerificationRecord` (structured JSON payload)
- 168-hour (7-day) base stability matching ephemeral verification lifecycle

Closes #2342

## Test plan

- [x] `VerificationSource` serde roundtrip and string conversion
- [x] `VerificationStatus` serde roundtrip and string conversion
- [x] `VerificationRecord` full serde roundtrip (pass case)
- [x] `VerificationRecord` fail-with-tolerance serialization
- [x] `FactType::Verification` roundtrip through `as_str`/`from_str_lossy`
- [x] `FactType::Verification` serde roundtrip
- [x] Stability hours for verification = 168.0

## Observations

- `aletheia-krites` has 34 unfulfilled `#[expect]` lint warnings (pre-existing on main) — likely needs a clippy cleanup pass
- `aletheia-pylon` has 2 flaky timing-sensitive tests (`idempotency_key_in_flight_returns_409`, `user_a_limit_does_not_affect_user_b`) that fail on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)